### PR TITLE
fix(deps): patch 3 rustls-webpki CVEs (RUSTSEC-2026-0098/0099/0104)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4912,9 +4912,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-webpki"
-version = "0.103.10"
+version = "0.103.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df33b2b81ac578cabaf06b89b0631153a3f416b0a886e8a7a1707fb51abbd1ef"
+checksum = "61c429a8649f110dddef65e2a5ad240f747e85f7758a6bccc7e5777bd33f756e"
 dependencies = [
  "ring",
  "rustls-pki-types",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,6 +33,9 @@ license = "Apache-2.0"
 authors = ["Troy Fortin <troy@firelock.ai>"]
 repository = "https://github.com/firelock-ai/kin"
 
+[patch.crates-io]
+rustls-webpki = "0.103.13"
+
 [workspace.dependencies]
 # Serialization
 serde = { version = "1", features = ["derive"] }


### PR DESCRIPTION
## Summary
- Bump \`rustls-webpki\` to \`0.103.13\` via \`[patch.crates-io]\` in root \`Cargo.toml\`
- Resolves:
  - RUSTSEC-2026-0098
  - RUSTSEC-2026-0099
  - RUSTSEC-2026-0104
- TLS validation paths (OAuth, HuggingFace download) previously vulnerable
- Identified in red-team audit 2026-04-24 (hydra-project PR #146 Phase 2)

## Why \`[patch.crates-io]\` (Option B) over \`cargo update\`
\`cargo update -p kin-db\` failed in this environment (private \"kin\" registry unconfigured). The patch block achieves the same CVE resolution and composes cleanly with the workspace lockfile.

## Verification
- \`cargo audit\`: 3 rustls-webpki advisories → 0 (only 8 pre-existing unmaintained warnings remain)
- \`rustls-webpki\` 0.103.10 → 0.103.13 (checksum verified from crates.io)
- Full \`cargo build --workspace\` could not run in my environment (private registry); please verify locally before merge

## Files changed
- \`Cargo.toml\` — add \`[patch.crates-io]\` block
- \`Cargo.lock\` — version + checksum update
