### PR TITLE
[DRAFT/WIP] M0/M1 kin: MCP write-loop + embed completion + txn durability + beat-grep (FIR-984, 926, 795, 986)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -105,7 +105,7 @@ jobs:
           # platform; only kin-db needs the local vector-disabled override here.
           TOML
 
-      - name: Build kin-cli (native)
+      - name: Build kin-cli + kin-daemon (native)
         if: ${{ !matrix.cross }}
         shell: bash
         run: |
@@ -113,14 +113,17 @@ jobs:
           if [ "$SKIP_VECTOR" = "true" ]; then
             FLAGS="--no-default-features"
           fi
-          cargo build --release --target "$TARGET" -p kin-cli $FLAGS
+          # FIR-967: the daemon IS the runtime — `kin init` works without it but
+          # `kin status`/`kin search`/the MCP server all require kin-daemon on
+          # PATH, so a clean public install must ship it alongside `kin`.
+          cargo build --release --target "$TARGET" -p kin-cli -p kin-daemon $FLAGS
         env:
           TARGET: ${{ matrix.target }}
           SKIP_VECTOR: ${{ matrix.skip_vector }}
 
-      - name: Build kin-cli (cross)
+      - name: Build kin-cli + kin-daemon (cross)
         if: ${{ matrix.cross }}
-        run: cross build --release --target "$TARGET" -p kin-cli
+        run: cross build --release --target "$TARGET" -p kin-cli -p kin-daemon
         env:
           TARGET: ${{ matrix.target }}
 
@@ -167,6 +170,7 @@ jobs:
         run: |
           for f in \
             "target/${TARGET}/release/kin" \
+            "target/${TARGET}/release/kin-daemon" \
             "kin-vfs/target/${TARGET}/release/kin-vfs" \
             "kin-vfs/target/${TARGET}/release/${SHIM_NAME}"; do
             if [ -f "$f" ]; then
@@ -186,6 +190,7 @@ jobs:
           FILES=()
           for f in \
             "target/${TARGET}/release/kin" \
+            "target/${TARGET}/release/kin-daemon" \
             "kin-vfs/target/${TARGET}/release/kin-vfs" \
             "kin-vfs/target/${TARGET}/release/${SHIM_NAME}"; do
             [ -f "$f" ] && FILES+=("$f")
@@ -211,9 +216,19 @@ jobs:
         run: |
           mkdir "$ARTIFACT"
           cp "target/${TARGET}/release/kin" "$ARTIFACT/"
+          # FIR-967: kin-daemon is mandatory (no `|| true`) — a daemon-less
+          # archive lets `kin init` succeed but then `kin status`/`kin search`
+          # fail with no daemon on PATH, so a missing daemon must fail the build.
+          cp "target/${TARGET}/release/kin-daemon" "$ARTIFACT/"
           cp "kin-vfs/target/${TARGET}/release/kin-vfs" "$ARTIFACT/" 2>/dev/null || true
           cp "kin-vfs/target/${TARGET}/release/${SHIM_NAME}" "$ARTIFACT/" 2>/dev/null || true
           tar czf "${ARTIFACT}.tar.gz" "$ARTIFACT"
+          # FIR-967: assert the published archive actually contains kin-daemon so
+          # a daemon-less build can never be released green.
+          if ! tar tzf "${ARTIFACT}.tar.gz" | grep -q "/kin-daemon$"; then
+            echo "::error::kin-daemon missing from ${ARTIFACT}.tar.gz — refusing to publish a daemon-less archive"
+            exit 1
+          fi
           shasum -a 256 "${ARTIFACT}.tar.gz" > "${ARTIFACT}.tar.gz.sha256"
         env:
           TARGET: ${{ matrix.target }}
@@ -226,9 +241,18 @@ jobs:
         run: |
           New-Item -ItemType Directory -Path $env:ARTIFACT
           Copy-Item "target/$env:TARGET/release/kin.exe" "$env:ARTIFACT/"
+          # FIR-967: kin-daemon is mandatory — fail hard if it's missing rather
+          # than ship a daemon-less archive that can `kin init` but nothing else.
+          Copy-Item "target/$env:TARGET/release/kin-daemon.exe" "$env:ARTIFACT/" -ErrorAction Stop
           Copy-Item "kin-vfs/target/$env:TARGET/release/kin-vfs.exe" "$env:ARTIFACT/" -ErrorAction SilentlyContinue
           Copy-Item "kin-vfs/target/$env:TARGET/release/$env:SHIM_NAME" "$env:ARTIFACT/" -ErrorAction SilentlyContinue
           Compress-Archive -Path "$env:ARTIFACT/*" -DestinationPath "$env:ARTIFACT.zip"
+          # FIR-967: assert the produced zip actually contains kin-daemon.exe.
+          $entries = [System.IO.Compression.ZipFile]::OpenRead("$PWD/$env:ARTIFACT.zip").Entries.Name
+          if ($entries -notcontains "kin-daemon.exe") {
+            Write-Error "kin-daemon.exe missing from $env:ARTIFACT.zip — refusing to publish a daemon-less archive"
+            exit 1
+          }
           Get-FileHash -Algorithm SHA256 "$env:ARTIFACT.zip" | Format-List Hash | Out-File -Encoding utf8 "$env:ARTIFACT.zip.sha256"
         env:
           TARGET: ${{ matrix.target }}

--- a/crates/kin-cli/src/commands/embed.rs
+++ b/crates/kin-cli/src/commands/embed.rs
@@ -74,7 +74,55 @@ fn effective_batch_size(requested: usize, bounded: bool) -> usize {
     }
 }
 
+/// Default per-pass time budget (seconds) for the drive-to-completion loop used
+/// when `kin embed` runs with no explicit `--max-seconds`. Each pass returns
+/// well inside the CLI→daemon HTTP timeout, so a pass never has to be severed
+/// mid-flight (a severed pass orphans the server-side work behind the embedding
+/// lock and makes retries stack). Overridable via `KIN_EMBED_PASS_SECONDS`.
+pub const DEFAULT_PASS_SECONDS: u64 = 300;
+
+/// Safety ceiling on drive-to-completion passes so a pathological daemon cannot
+/// loop forever even if it keeps reporting a sliver of progress. At the default
+/// pass budget this is far above any real corpus. Overridable via
+/// `KIN_EMBED_MAX_PASSES`.
+pub const DEFAULT_MAX_PASSES: usize = 1000;
+
+fn pass_budget_seconds() -> u64 {
+    std::env::var("KIN_EMBED_PASS_SECONDS")
+        .ok()
+        .and_then(|v| v.parse::<u64>().ok())
+        .filter(|s| *s > 0)
+        .unwrap_or(DEFAULT_PASS_SECONDS)
+}
+
+fn max_passes() -> usize {
+    std::env::var("KIN_EMBED_MAX_PASSES")
+        .ok()
+        .and_then(|v| v.parse::<usize>().ok())
+        .filter(|n| *n > 0)
+        .unwrap_or(DEFAULT_MAX_PASSES)
+}
+
+/// Whether the drive-to-completion loop should issue another embed pass.
+///
+/// Continue only while retrievable work remains AND the last pass actually
+/// embedded something. A pass that persisted nothing while objects are still
+/// pending is stalled (e.g. objects that repeatedly fail inference); re-issuing
+/// would spin without converging, so stop and report the residual instead.
+pub fn embed_pass_should_continue(result: &EmbedResult, made_progress: bool) -> bool {
+    let pending = result.pending_entities + result.pending_artifacts;
+    pending > 0 && made_progress
+}
+
 /// Ask the repo daemon to build embeddings for the current repo's graph.
+///
+/// With an explicit `--max-seconds` this issues a single bounded pass and
+/// returns whatever coverage that timebox buys. With no `--max-seconds` the
+/// intent is full coverage, so the CLI transparently re-issues bounded passes
+/// until the daemon reports zero pending (FIR-926). Each pass persists its
+/// batches, so the next pass resumes where the last left off; coverage is
+/// therefore decoupled from any single request's HTTP timeout — a large corpus
+/// that cannot finish inside one request still completes across several.
 pub async fn run(
     batch_size: usize,
     json: bool,
@@ -91,22 +139,86 @@ pub async fn run(
     .entered();
     let layout = kin_core::KinLayout::discover(&std::env::current_dir()?)
         .ok_or_else(|| anyhow::anyhow!("not a Kin repository (no .kin/ found)"))?;
-    let response = run_daemon_embed(
-        &layout,
-        &EmbedRequest {
-            batch_size,
-            json,
-            max_seconds,
-            rebuild,
-        },
-    )
-    .await?;
-    if json {
-        println!("{}", serde_json::to_string_pretty(&response.result)?);
-    } else {
-        for line in response.lines {
-            println!("{line}");
+
+    if let Some(seconds) = max_seconds {
+        let response = run_daemon_embed(
+            &layout,
+            &EmbedRequest {
+                batch_size,
+                json,
+                max_seconds: Some(seconds),
+                rebuild,
+            },
+        )
+        .await?;
+        if json {
+            println!("{}", serde_json::to_string_pretty(&response.result)?);
+        } else {
+            for line in response.lines {
+                println!("{line}");
+            }
         }
+        return Ok(());
+    }
+
+    let pass_seconds = pass_budget_seconds();
+    let max_passes = max_passes();
+    let mut pass = 0usize;
+    let mut embedded_entities = 0usize;
+    let mut embedded_artifacts = 0usize;
+    let final_result = loop {
+        pass += 1;
+        let response = run_daemon_embed(
+            &layout,
+            &EmbedRequest {
+                batch_size,
+                json,
+                max_seconds: Some(pass_seconds),
+                // Only the first pass may rebuild — re-issuing `rebuild` would
+                // drop the index every pass and discard the vectors the prior
+                // passes just persisted, so the loop could never converge.
+                rebuild: rebuild && pass == 1,
+            },
+        )
+        .await?;
+        let result = response.result;
+        embedded_entities += result.embedded_entities;
+        embedded_artifacts += result.embedded_artifacts;
+        let made_progress = result.embedded_entities + result.embedded_artifacts > 0;
+
+        if !json {
+            println!(
+                "Pass {pass}: +{} entities, +{} artifacts ({} entities, {} artifacts still pending)",
+                result.embedded_entities,
+                result.embedded_artifacts,
+                result.pending_entities,
+                result.pending_artifacts
+            );
+        }
+
+        if !embed_pass_should_continue(&result, made_progress) || pass >= max_passes {
+            break result;
+        }
+    };
+    let pending = final_result.pending_entities + final_result.pending_artifacts;
+    if json {
+        let aggregate = EmbedResult {
+            embedded_entities,
+            embedded_artifacts,
+            time_limited: pending > 0,
+            ..final_result
+        };
+        println!("{}", serde_json::to_string_pretty(&aggregate)?);
+    } else if pending == 0 {
+        println!(
+            "Done. Full coverage: {} entities, {} artifacts embedded across {pass} pass(es), index saved to {}",
+            embedded_entities, embedded_artifacts, final_result.vector_index_path
+        );
+    } else {
+        println!(
+            "Stopped with {} entities + {} artifacts still pending after {pass} pass(es) — the daemon made no progress on the last pass. Re-run `kin embed` or inspect the daemon log.",
+            final_result.pending_entities, final_result.pending_artifacts
+        );
     }
     Ok(())
 }
@@ -286,7 +398,43 @@ pub fn build_embed_response(
 
 #[cfg(test)]
 mod tests {
-    use super::{effective_batch_size, should_queue_missing_embedding_pass, DEFAULT_BATCH_SIZE};
+    use super::{
+        effective_batch_size, embed_pass_should_continue, should_queue_missing_embedding_pass,
+        EmbedResult, DEFAULT_BATCH_SIZE,
+    };
+
+    fn result_with(pending_entities: usize, pending_artifacts: usize) -> EmbedResult {
+        EmbedResult {
+            total_entities: 100,
+            embedded_entities: 0,
+            pending_entities,
+            total_artifacts: 0,
+            embedded_artifacts: 0,
+            pending_artifacts,
+            time_limited: false,
+            vector_index_path: String::new(),
+        }
+    }
+
+    #[test]
+    fn drive_loop_continues_while_pending_and_progressing() {
+        assert!(embed_pass_should_continue(&result_with(40, 0), true));
+        assert!(embed_pass_should_continue(&result_with(0, 5), true));
+    }
+
+    #[test]
+    fn drive_loop_stops_on_full_coverage() {
+        // No pending work left → done regardless of whether the last pass moved.
+        assert!(!embed_pass_should_continue(&result_with(0, 0), true));
+        assert!(!embed_pass_should_continue(&result_with(0, 0), false));
+    }
+
+    #[test]
+    fn drive_loop_stops_when_stalled_to_avoid_spin() {
+        // Pending work remains but the pass embedded nothing — re-issuing would
+        // spin forever, so the loop must stop and surface the residual.
+        assert!(!embed_pass_should_continue(&result_with(40, 3), false));
+    }
 
     #[test]
     fn default_batch_size_is_progress_friendly() {

--- a/crates/kin-cli/src/commands/locate.rs
+++ b/crates/kin-cli/src/commands/locate.rs
@@ -2878,6 +2878,7 @@ fn priority_reason_allows_injection(kind: &str) -> bool {
             | "tracked_explicit_name"
             | "tracked_term_match"
             | "directory_name_match"
+            | "source_basename_match"
     )
 }
 
@@ -3747,6 +3748,87 @@ fn extract_priority_file_traces(
                 reason_kind,
                 term_lower.clone(),
             );
+        }
+    }
+
+    // (b3) FIR-986: source-file basename parity with grep.
+    //
+    // `query_backed_tracked_file_score` gives a tracked file a strong, injectable
+    // seat when a query term matches its basename — but the loop above only scans
+    // `tracked_non_entity` files (configs, docs, shallow artifacts). An
+    // entity-bearing source file whose basename IS the query term — term
+    // "manifest" → crates/.../manifest.rs — was never seeded at the file level,
+    // so it lost to an incidental `mod manifest` declaration in another file even
+    // though grep finds the file directly by its path. Seed those source files
+    // here on a strong basename hit (stem == term, or term is an exact basename
+    // segment) so Kin's lexical floor is at least grep's: the file the term names
+    // gets the same injectable seat a non-entity basename match would.
+    {
+        let mut entity_file_paths: HashSet<String> = HashSet::new();
+        if let Ok(all_entities) = graph.query_entities(&EntityFilter::default()) {
+            for entity in &all_entities {
+                if let Some(ref fo) = entity.file_origin {
+                    if !tracked_non_entity_paths.contains(&fo.0) {
+                        entity_file_paths.insert(fo.0.clone());
+                    }
+                }
+            }
+        }
+
+        let source_basename_limit = locate_env_usize("KIN_LOCATE_SOURCE_BASENAME_LIMIT", 4);
+        for term in tracked_term_candidates.iter().take(tracked_term_limit) {
+            let term_lower = term.to_ascii_lowercase();
+            if term_lower.len() < 4 || is_common_english_word(&term_lower) {
+                continue;
+            }
+
+            let mut matches: Vec<(String, f32)> = entity_file_paths
+                .iter()
+                .filter(|path| {
+                    if is_license_or_notice_path(path) {
+                        return false;
+                    }
+                    if is_test_path(path) && !allow_test_artifact_priority {
+                        return false;
+                    }
+                    if require_named_test_artifacts && !is_named_test_artifact_path(path) {
+                        return false;
+                    }
+                    true
+                })
+                .filter_map(|path| {
+                    // Only a strong basename hit (>= 75: stem-exact or exact
+                    // basename segment) earns a seat — incidental substring or
+                    // manifest-family matches are too loose to mirror grep here.
+                    query_backed_tracked_file_score(path, &term_lower)
+                        .filter(|score| *score >= 75.0)
+                        .map(|score| (path.clone(), score))
+                })
+                .collect();
+            if matches.is_empty() {
+                continue;
+            }
+            // A term that strongly names many basenames is too generic to seed
+            // like grep would; skip rather than blanket the tree.
+            if matches.len() > source_basename_limit {
+                continue;
+            }
+
+            matches.sort_by(|a, b| {
+                b.1.partial_cmp(&a.1)
+                    .unwrap_or(std::cmp::Ordering::Equal)
+                    .then_with(|| a.0.matches('/').count().cmp(&b.0.matches('/').count()))
+                    .then_with(|| a.0.cmp(&b.0))
+            });
+            for (path, score) in matches {
+                note_priority_reason(
+                    &mut file_scores,
+                    path,
+                    score,
+                    "source_basename_match",
+                    term_lower.clone(),
+                );
+            }
         }
     }
 
@@ -15941,6 +16023,38 @@ mod tests {
         assert!(terms
             .iter()
             .any(|term| term.eq_ignore_ascii_case("autocomplete")));
+    }
+
+    #[test]
+    fn source_basename_match_seeds_entity_bearing_file_like_grep() {
+        // FIR-986: a query term that names a source file's basename must seat
+        // THAT file at the file level, the way grep finds it — even though the
+        // file is entity-bearing (so it is absent from tracked_non_entity_files)
+        // and an incidental `mod manifest` declaration lives in another file.
+        let graph = kin_db::InMemoryGraph::new();
+
+        let mut manifest_file =
+            test_entity("ManifestStore", "crates/kin-core/src/manifest.rs", 1, 40);
+        manifest_file.metadata.extra.insert(
+            "file_surface_context".into(),
+            serde_json::Value::String("surface manifest ManifestStore manifest".into()),
+        );
+        // The incidental declaration that previously outscored the real file.
+        let mod_decl = test_entity("manifest", "crates/kin-core/src/lib.rs", 3, 3);
+
+        graph.upsert_entity(&manifest_file).unwrap();
+        graph.upsert_entity(&mod_decl).unwrap();
+
+        let scores = extract_priority_files("where does the manifest get loaded", &graph);
+        let manifest_score = scores
+            .iter()
+            .find(|(path, _)| path == "crates/kin-core/src/manifest.rs")
+            .map(|(_, score)| *score);
+
+        assert!(
+            manifest_score.is_some_and(|score| score >= 75.0),
+            "manifest.rs must get a strong basename seat (>=75) so it ranks like grep; got {manifest_score:?}"
+        );
     }
 
     #[test]

--- a/crates/kin-cli/src/commands/locate.rs
+++ b/crates/kin-cli/src/commands/locate.rs
@@ -16075,7 +16075,12 @@ mod tests {
             ),
         );
         graph.upsert_entity(&gold).unwrap();
-        for name in ["put_manifest", "get_manifest", "ManifestStore", "manifest_string"] {
+        for name in [
+            "put_manifest",
+            "get_manifest",
+            "ManifestStore",
+            "manifest_string",
+        ] {
             let mut e = test_entity(name, "crates/kin-daemon/src/api.rs", 1, 20);
             e.metadata.extra.insert(
                 "file_surface_context".into(),
@@ -16084,8 +16089,10 @@ mod tests {
             graph.upsert_entity(&e).unwrap();
         }
 
-        let scores =
-            extract_priority_files("Where is a repository's canonical id resolved from its manifest?", &graph);
+        let scores = extract_priority_files(
+            "Where is a repository's canonical id resolved from its manifest?",
+            &graph,
+        );
 
         let manifest_score = scores
             .iter()

--- a/crates/kin-cli/src/commands/locate.rs
+++ b/crates/kin-cli/src/commands/locate.rs
@@ -16058,6 +16058,54 @@ mod tests {
     }
 
     #[test]
+    fn source_basename_seed_beats_same_named_entities_in_other_files() {
+        // FIR-986, the real dogfood case: the gold file is
+        // crates/kin-core/src/manifest.rs (resolve_repo_id), but the repo also
+        // has many `manifest`-named entities in another file (the npm-registry
+        // put_manifest/get_manifest/ManifestStore in api.rs). Those win on
+        // lexical/graph signal, so the gold file lost. The basename seed must
+        // give the file the term NAMES the strong, injectable seat — and only
+        // that file, not the same-named entities' file.
+        let graph = kin_db::InMemoryGraph::new();
+        let mut gold = test_entity("resolve_repo_id", "crates/kin-core/src/manifest.rs", 71, 90);
+        gold.metadata.extra.insert(
+            "file_surface_context".into(),
+            serde_json::Value::String(
+                "surface manifest resolve_repo_id canonical repository id".into(),
+            ),
+        );
+        graph.upsert_entity(&gold).unwrap();
+        for name in ["put_manifest", "get_manifest", "ManifestStore", "manifest_string"] {
+            let mut e = test_entity(name, "crates/kin-daemon/src/api.rs", 1, 20);
+            e.metadata.extra.insert(
+                "file_surface_context".into(),
+                serde_json::Value::String(format!("surface manifest {name} npm registry")),
+            );
+            graph.upsert_entity(&e).unwrap();
+        }
+
+        let scores =
+            extract_priority_files("Where is a repository's canonical id resolved from its manifest?", &graph);
+
+        let manifest_score = scores
+            .iter()
+            .find(|(path, _)| path == "crates/kin-core/src/manifest.rs")
+            .map(|(_, score)| *score);
+        assert!(
+            manifest_score.is_some_and(|score| score >= 75.0),
+            "gold manifest.rs must get the strong basename seat (>=75); got {manifest_score:?}"
+        );
+        // The same-named entities' file must NOT be basename-seeded — only the
+        // file the term actually names earns the seat.
+        assert!(
+            !scores
+                .iter()
+                .any(|(path, _)| path == "crates/kin-daemon/src/api.rs"),
+            "api.rs (same-named entities, different basename) must not be basename-seeded; got {scores:?}"
+        );
+    }
+
+    #[test]
     fn curate_search_terms_keeps_source_artifact_backed_macro_terms() {
         let graph = kin_db::InMemoryGraph::new();
 

--- a/crates/kin-cli/src/commands/locate.rs
+++ b/crates/kin-cli/src/commands/locate.rs
@@ -13049,9 +13049,18 @@ fn entity_span_pair(entity: &kin_model::Entity) -> Vec<[u32; 2]> {
     // KIN_LOCATE_SPAN_FULL_EXTENT=1 emits the full node extent instead.
     let full_extent = locate_env_bool("KIN_LOCATE_SPAN_FULL_EXTENT", false);
     let head_threshold = locate_env_usize("KIN_LOCATE_SPAN_CLASS_HEAD_THRESHOLD", 60) as u32;
+    // FIR-990: only class-like nodes get head-truncated today, so a coarse
+    // non-class entity — above all a File-kind node whose span is the entire
+    // file (700-1600 lines) — is emitted at full extent and tanks symbol/line
+    // precision. KIN_LOCATE_SPAN_TRUNCATE_OVERLONG extends the same head-window
+    // truncation to ANY over-threshold entity (File-kind, oversized functions).
+    // Gated OFF so the default behavior is byte-identical; the precision↔recall
+    // trade is a line-F1 question decided by ContextBench before the default flips.
+    let head_truncate =
+        is_class_like || locate_env_bool("KIN_LOCATE_SPAN_TRUNCATE_OVERLONG", false);
     vec![entity_span_lines(
         s,
-        is_class_like,
+        head_truncate,
         full_extent,
         head_threshold,
     )]
@@ -13066,11 +13075,11 @@ fn entity_span_pair(entity: &kin_model::Entity) -> Vec<[u32; 2]> {
 /// 1-indexed traceback spans instead of landing one line short).
 fn entity_span_lines(
     s: &kin_model::SourceSpan,
-    is_class_like: bool,
+    head_truncate: bool,
     full_extent: bool,
     head_threshold: u32,
 ) -> [u32; 2] {
-    let (start, end, end_is_real) = if is_class_like && !full_extent {
+    let (start, end, end_is_real) = if head_truncate && !full_extent {
         let len = s.end_line.saturating_sub(s.start_line);
         if len > head_threshold {
             // Synthetic head window; `end` is start+4, not the node's real end
@@ -13738,6 +13747,37 @@ mod tests {
         assert_eq!(entity_span_lines(&span(0, 100), false, false, 30), [1, 101]);
         // Short class (len <= threshold) is not truncated even with OFF.
         assert_eq!(entity_span_lines(&span(0, 10), true, false, 30), [1, 11]);
+    }
+
+    #[test]
+    #[serial_test::serial]
+    fn span_truncate_overlong_lever_tightens_coarse_file_kind() {
+        // FIR-990: a File-kind entity spans the whole file (700-1600 lines) and
+        // is emitted at full extent by default — tanking symbol/line precision.
+        // The gated lever extends class-like head-truncation to any over-threshold
+        // entity. Default OFF keeps the span byte-identical (no regression risk);
+        // the precision↔recall trade is a ContextBench line-F1 call before flip.
+        std::env::remove_var("KIN_LOCATE_SPAN_FULL_EXTENT");
+        std::env::remove_var("KIN_LOCATE_SPAN_CLASS_HEAD_THRESHOLD");
+        std::env::remove_var("KIN_LOCATE_SPAN_TRUNCATE_OVERLONG");
+
+        let mut coarse = test_entity("whole_module", "src/big.rs", 0, 1500);
+        coarse.kind = EntityKind::File;
+
+        assert_eq!(
+            entity_span_pair(&coarse),
+            vec![[1, 1501]],
+            "default OFF: a coarse File-kind entity emits its full extent (unchanged)"
+        );
+
+        std::env::set_var("KIN_LOCATE_SPAN_TRUNCATE_OVERLONG", "1");
+        let tightened = entity_span_pair(&coarse);
+        std::env::remove_var("KIN_LOCATE_SPAN_TRUNCATE_OVERLONG");
+        assert_eq!(
+            tightened,
+            vec![[1, 5]],
+            "lever ON: the over-long File-kind span is head-truncated to a 5-line window"
+        );
     }
 
     #[test]

--- a/crates/kin-daemon/src/api.rs
+++ b/crates/kin-daemon/src/api.rs
@@ -3679,13 +3679,20 @@ fn persist_mcp_transactions(state: &DaemonState, registry: &kin_mcp::SessionRegi
     for transaction in registry.list_transactions() {
         store.insert(transaction.transaction_id.clone(), transaction);
     }
+    // FIR-795: mirror the in-flight set to disk so a restart does not silently
+    // drop staged-but-uncommitted transactions.
+    crate::state::write_persisted_mcp_transactions(&state.layout, &store);
 }
 
 /// Drop a transaction from the durable store once it reaches a terminal state
 /// (committed/aborted), so finished transactions do not accumulate. Called only
 /// after the terminal tool call succeeds.
 fn forget_mcp_transaction(state: &DaemonState, transaction_id: &str) {
-    lock_recover(&state.mcp_transactions).remove(transaction_id);
+    let mut store = lock_recover(&state.mcp_transactions);
+    store.remove(transaction_id);
+    // FIR-795: keep the durable mirror in step with the in-memory eviction so a
+    // committed/aborted transaction does not reappear after a restart.
+    crate::state::write_persisted_mcp_transactions(&state.layout, &store);
 }
 
 /// Collect the current graph state of all entities referenced in a commit
@@ -7134,6 +7141,63 @@ mod tests {
         assert!(
             !state.mcp_transactions.lock().unwrap().contains_key(&tx_id),
             "committed transaction must be evicted from the durable store"
+        );
+    }
+
+    #[test]
+    fn mcp_transaction_survives_daemon_restart() {
+        // FIR-795: staged-but-uncommitted transactions must survive a daemon
+        // restart, not just HTTP calls — otherwise a mid-transaction bounce
+        // silently drops the agent's staged work. Persist on one DaemonState,
+        // re-open on the SAME layout (a restart), and assert the staged op +
+        // body are restored intact.
+        install_test_registry_override();
+        let dir = std::env::temp_dir().join(format!("kin-daemon-tx-restart-{}", Uuid::new_v4()));
+        let kin_dir = dir.join(".kin");
+        std::fs::create_dir_all(kin_dir.join("objects")).unwrap();
+        std::fs::create_dir_all(kin_dir.join("working")).unwrap();
+        kin_core::manifest::KinManifest::new()
+            .save(&kin_core::KinLayout::new(kin_dir.clone()).manifest_path())
+            .unwrap();
+
+        let tx_id;
+        {
+            let state = Arc::new(DaemonState::open(kin_core::KinLayout::new(kin_dir.clone())).unwrap());
+            let registry = kin_mcp::SessionRegistry::new();
+            let tx = registry
+                .begin_transaction("sess-restart", "file:src/lib.rs")
+                .unwrap();
+            tx_id = tx.transaction_id.clone();
+            let op = kin_mcp::McpMutationOperation {
+                verb: "update".into(),
+                target: String::new(),
+                payload: None,
+                body: Some("pub fn greet() {}".into()),
+                description: "restart-durability".into(),
+            };
+            registry.stage_transaction(&tx_id, vec![op]).unwrap();
+            persist_mcp_transactions(&state, &registry);
+        } // state dropped — models daemon shutdown.
+
+        // Re-open on the SAME layout — models the restart.
+        let restarted =
+            Arc::new(DaemonState::open(kin_core::KinLayout::new(kin_dir)).unwrap());
+        let store = restarted
+            .mcp_transactions
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
+        let restored = store
+            .get(&tx_id)
+            .expect("staged transaction must survive a daemon restart (FIR-795)");
+        assert_eq!(
+            restored.staged_operations.len(),
+            1,
+            "staged operation must survive the restart"
+        );
+        assert_eq!(
+            restored.staged_operations[0].body.as_deref(),
+            Some("pub fn greet() {}"),
+            "the staged body must survive the restart intact"
         );
     }
 

--- a/crates/kin-daemon/src/api.rs
+++ b/crates/kin-daemon/src/api.rs
@@ -7162,7 +7162,8 @@ mod tests {
 
         let tx_id;
         {
-            let state = Arc::new(DaemonState::open(kin_core::KinLayout::new(kin_dir.clone())).unwrap());
+            let state =
+                Arc::new(DaemonState::open(kin_core::KinLayout::new(kin_dir.clone())).unwrap());
             let registry = kin_mcp::SessionRegistry::new();
             let tx = registry
                 .begin_transaction("sess-restart", "file:src/lib.rs")
@@ -7180,8 +7181,7 @@ mod tests {
         } // state dropped — models daemon shutdown.
 
         // Re-open on the SAME layout — models the restart.
-        let restarted =
-            Arc::new(DaemonState::open(kin_core::KinLayout::new(kin_dir)).unwrap());
+        let restarted = Arc::new(DaemonState::open(kin_core::KinLayout::new(kin_dir)).unwrap());
         let store = restarted
             .mcp_transactions
             .lock()

--- a/crates/kin-daemon/src/projection_wiring.rs
+++ b/crates/kin-daemon/src/projection_wiring.rs
@@ -843,7 +843,10 @@ mod tests {
             .find(|e| e.name == "foo")
             .cloned()
             .expect("foo must be present in the reconcile overlay");
-        let span = pre_commit_entity.span.clone().expect("foo must have a span");
+        let span = pre_commit_entity
+            .span
+            .clone()
+            .expect("foo must have a span");
         apply_overlay_to_graph(state.graph.as_ref(), &mut overlay)
             .expect("apply overlay must succeed");
 

--- a/crates/kin-daemon/src/projection_wiring.rs
+++ b/crates/kin-daemon/src/projection_wiring.rs
@@ -147,6 +147,55 @@ pub async fn project_after_mcp_commit(
     let mut reconciler = state.reconciler.write().await;
 
     // -----------------------------------------------------------------------
+    // FIR-984: Cold-projection priming.
+    //
+    // The reconciler's projection state (file layouts + content) is the map
+    // `project_overlay_to_files` uses to locate each entity's byte region and
+    // splice the new body in. On a freshly-started or restarted daemon that map
+    // is cold: `DaemonState::open` seeds the reconciler's LKG from the persisted
+    // graph but never registers any file layout (no reconcile tick has run yet).
+    // With no layout for the entity's file, `project_entity_mutations_with_policy`
+    // finds no region for the mutation and silently skips it — the graph commit
+    // lands (root hash advances, ops_applied > 0) but `modified_files` comes back
+    // empty and the working file is never touched. That is the FIR-984 silent
+    // no-op the MCP write loop hit on the first commit after daemon start.
+    //
+    // Prime the projection from graph + disk truth before projecting: reconcile
+    // each referenced file that is not yet registered, which parses the current
+    // source and registers its layout + content. The detected overlay is
+    // discarded — we only need the projection registration here, not a graph
+    // mutation (the agent's commit already landed, and the FIR-934 no-clobber
+    // resync below reconverges the graph onto the projected source afterwards).
+    // Files missing from disk are left to the existing structured-error path.
+    {
+        let mut primed: HashSet<FilePathId> = HashSet::new();
+        for entity in temp_overlay.entity_mods.values() {
+            let Some(span) = &entity.span else {
+                continue;
+            };
+            if reconciler.projection().get_content(&span.file).is_some() {
+                continue;
+            }
+            if !primed.insert(span.file.clone()) {
+                continue;
+            }
+            let path = state.layout.working_dir().join(span.file.0.as_str());
+            if !path.exists() {
+                continue;
+            }
+            let mut prime_overlay = GraphOverlay::default();
+            reconciler
+                .reconcile_file_change(
+                    &FileEvent::Changed(path),
+                    state.blobs.as_ref(),
+                    state.graph.as_ref(),
+                    &mut prime_overlay,
+                )
+                .map_err(|e| reconcile_err_to_projection_err(e, pre_commit_entities))?;
+        }
+    }
+
+    // -----------------------------------------------------------------------
     // FIR-904·3: Conflict detection — skip-conflicted semantics.
     //
     // For each entity in the overlay, compare the current on-disk file bytes at
@@ -745,6 +794,103 @@ mod tests {
         // changes. The body edit changed the bytes, but the FIR-934 resync drove
         // the reconciler LKG + graph onto the projected source, so the next
         // reconcile sees no delta — the agent's edit is NOT clobbered.
+        let mut reconciler2 = state.reconciler.write().await;
+        assert_no_clobber(&mut reconciler2, &state, &file_path);
+    }
+
+    // ------------------------------------------------------------------
+    // Test 1c (FIR-984): a body edit projected against a COLD reconciler
+    // projection (no prior reconcile tick — the daemon-restart state) still
+    // reaches disk. This is the silent-no-op regression: the graph commit
+    // landed but `modified_files` came back empty because the reconciler's
+    // projection had no layout for the entity's file. The fix primes the
+    // projection from graph + disk truth before projecting.
+    // ------------------------------------------------------------------
+
+    #[tokio::test]
+    async fn project_body_edit_primes_cold_projection_and_reaches_disk() {
+        let dir = tempfile::tempdir().unwrap();
+        let state = make_test_state(dir.path());
+        state
+            .is_initialized
+            .store(true, std::sync::atomic::Ordering::Relaxed);
+
+        let rel = "src/lib.rs";
+        let file_path = dir.path().join(rel);
+        std::fs::create_dir_all(file_path.parent().unwrap()).unwrap();
+        let original = b"pub fn foo() -> i32 { 1 }\npub fn bar() -> i32 { 2 }\n";
+        std::fs::write(&file_path, original).unwrap();
+
+        let blob_store = BlobStore::new(state.layout.objects_dir()).expect("blob store must open");
+
+        // Discover the entity (with its deterministic id + span) and seed the
+        // graph using a SEPARATE reconciler, so the daemon's own
+        // `state.reconciler` projection stays COLD — exactly the post-restart
+        // state where no reconcile tick has registered a file layout yet.
+        let mut discover = Reconciler::new(dir.path().to_path_buf());
+        let mut overlay = GraphOverlay::default();
+        discover
+            .reconcile_file_change(
+                &FileEvent::Changed(file_path.clone()),
+                &blob_store,
+                state.graph.as_ref(),
+                &mut overlay,
+            )
+            .expect("discovery reconcile must succeed");
+        let pre_commit_entity = overlay
+            .entity_adds
+            .values()
+            .find(|e| e.name == "foo")
+            .cloned()
+            .expect("foo must be present in the reconcile overlay");
+        let span = pre_commit_entity.span.clone().expect("foo must have a span");
+        apply_overlay_to_graph(state.graph.as_ref(), &mut overlay)
+            .expect("apply overlay must succeed");
+
+        // Sanity: the daemon's projection is cold — no layout/content for the file.
+        {
+            let reconciler = state.reconciler.read().await;
+            assert!(
+                reconciler.projection().get_content(&span.file).is_none(),
+                "precondition: daemon reconciler projection must be cold for this file"
+            );
+        }
+
+        let orig_region = &original[span.start_byte..span.end_byte];
+        let new_body = String::from_utf8_lossy(orig_region)
+            .replace("{ 1 }", "{ 42 }")
+            .into_bytes();
+
+        let mut bodies = HashMap::new();
+        bodies.insert(pre_commit_entity.id, new_body.clone());
+        let (modified_files, _warnings, conflicts) =
+            project_after_mcp_commit(&state, std::slice::from_ref(&pre_commit_entity), &bodies)
+                .await
+                .expect("projection must succeed");
+
+        assert_eq!(
+            modified_files.len(),
+            1,
+            "cold-projection body edit must still project exactly one file (FIR-984); \
+             empty here is the silent no-op"
+        );
+        assert!(conflicts.is_empty(), "no conflicts expected");
+
+        let on_disk = std::fs::read(&file_path).expect("projected file must exist");
+        let on_disk_str = String::from_utf8(on_disk).expect("projected file is utf-8");
+        assert!(
+            on_disk_str.contains("{ 42 }"),
+            "file must contain the new body literal; got: {on_disk_str}"
+        );
+        assert!(
+            !on_disk_str.contains("{ 1 }"),
+            "old body literal must be gone; got: {on_disk_str}"
+        );
+        assert!(
+            on_disk_str.contains("pub fn bar() -> i32 { 2 }"),
+            "sibling entity bar must be preserved; got: {on_disk_str}"
+        );
+
         let mut reconciler2 = state.reconciler.write().await;
         assert_no_clobber(&mut reconciler2, &state, &file_path);
     }

--- a/crates/kin-daemon/src/state.rs
+++ b/crates/kin-daemon/src/state.rs
@@ -22,6 +22,77 @@ use crate::session_registry::SessionCoordinator;
 pub const RECON_IDLE: u8 = 0;
 pub const RECON_PROCESSING: u8 = 1;
 
+/// FIR-795: on-disk home for in-flight MCP transactions.
+///
+/// Lives under `.kin/` (not the working tree), so it is never reconciled or
+/// committed. The in-memory `DaemonState::mcp_transactions` is the live copy;
+/// this file is its durable mirror so a daemon restart mid-transaction does not
+/// silently drop staged-but-uncommitted work — stdio-MCP and HTTP-MCP then
+/// behave identically across a restart, not just across HTTP calls.
+pub(crate) fn mcp_transactions_disk_path(layout: &KinLayout) -> std::path::PathBuf {
+    layout.root().join("mcp_transactions.json")
+}
+
+/// Load persisted in-flight MCP transactions on daemon startup. A missing file
+/// (clean start) or an unreadable/corrupt one yields an empty set — startup must
+/// never fail on transaction-state recovery — but corruption is surfaced loudly
+/// in the log so the loss is never silent.
+pub(crate) fn load_persisted_mcp_transactions(
+    layout: &KinLayout,
+) -> HashMap<String, kin_mcp::McpTransaction> {
+    let path = mcp_transactions_disk_path(layout);
+    let bytes = match std::fs::read(&path) {
+        Ok(bytes) => bytes,
+        Err(err) if err.kind() == std::io::ErrorKind::NotFound => return HashMap::new(),
+        Err(err) => {
+            warn!(path = %path.display(), error = %err, "failed to read persisted MCP transactions; starting with none");
+            return HashMap::new();
+        }
+    };
+    match serde_json::from_slice::<HashMap<String, kin_mcp::McpTransaction>>(&bytes) {
+        Ok(store) => {
+            if !store.is_empty() {
+                info!(
+                    count = store.len(),
+                    "restored in-flight MCP transactions from disk across daemon restart"
+                );
+            }
+            store
+        }
+        Err(err) => {
+            warn!(path = %path.display(), error = %err, "persisted MCP transactions are corrupt; starting with none");
+            HashMap::new()
+        }
+    }
+}
+
+/// Durably mirror the in-memory MCP transaction store to disk. Writes via a
+/// temp file + atomic rename so a crash mid-write can never leave a torn file.
+/// Best-effort: a write failure is logged, never propagated — the in-memory
+/// store remains authoritative for the running daemon.
+pub(crate) fn write_persisted_mcp_transactions(
+    layout: &KinLayout,
+    store: &HashMap<String, kin_mcp::McpTransaction>,
+) {
+    let path = mcp_transactions_disk_path(layout);
+    let bytes = match serde_json::to_vec(store) {
+        Ok(bytes) => bytes,
+        Err(err) => {
+            warn!(error = %err, "failed to serialize MCP transactions for durable persistence");
+            return;
+        }
+    };
+    let tmp = path.with_extension("json.tmp");
+    if let Err(err) = std::fs::write(&tmp, &bytes) {
+        warn!(path = %tmp.display(), error = %err, "failed to write MCP transactions temp file");
+        return;
+    }
+    if let Err(err) = std::fs::rename(&tmp, &path) {
+        warn!(path = %path.display(), error = %err, "failed to commit MCP transactions file");
+        let _ = std::fs::remove_file(&tmp);
+    }
+}
+
 /// SSE invalidation events pushed to subscribers (VFS daemon, spine, KinLab).
 #[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
 #[serde(tag = "type")]
@@ -496,6 +567,14 @@ impl DaemonState {
             embed_worker_failed: AtomicBool::new(false),
             mcp_transactions: Mutex::new(HashMap::new()),
         };
+        // FIR-795: restore in-flight MCP transactions persisted before a restart
+        // so staged-but-uncommitted work is not silently dropped across a daemon
+        // bounce — stdio-MCP and HTTP-MCP behave identically across a restart.
+        *state
+            .mcp_transactions
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner) =
+            load_persisted_mcp_transactions(&state.layout);
         Ok(state)
     }
 
@@ -619,6 +698,13 @@ impl DaemonState {
             embed_worker_failed: AtomicBool::new(false),
             mcp_transactions: Mutex::new(HashMap::new()),
         };
+
+        // FIR-795: restore in-flight MCP transactions persisted before a restart.
+        *state
+            .mcp_transactions
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner) =
+            load_persisted_mcp_transactions(&state.layout);
 
         // Pre-load repos into the map BEFORE any async context.
         // We use get_mut() since no one else has a reference yet.

--- a/crates/kin-daemon/src/state.rs
+++ b/crates/kin-daemon/src/state.rs
@@ -2330,4 +2330,51 @@ mod tests {
         state.persisted_entity_count.store(n * 2, Ordering::SeqCst);
         assert!(!state.shutdown_flush_would_wipe_graph());
     }
+
+    #[test]
+    fn persisted_mcp_transactions_missing_file_loads_empty() {
+        // FIR-795: a clean start (no mcp_transactions.json) yields an empty set,
+        // never an error — startup must not fail on transaction recovery.
+        let dir = tempfile::tempdir().unwrap();
+        let layout = KinLayout::new(dir.path().to_path_buf());
+        assert!(load_persisted_mcp_transactions(&layout).is_empty());
+    }
+
+    #[test]
+    fn persisted_mcp_transactions_round_trip_through_disk() {
+        // FIR-795: a staged transaction written to the durable mirror reloads
+        // intact — the mechanism that lets begin/stage survive a daemon restart.
+        let dir = tempfile::tempdir().unwrap();
+        let layout = KinLayout::new(dir.path().to_path_buf());
+        let mut store = HashMap::new();
+        store.insert(
+            "tx-1".to_string(),
+            kin_mcp::McpTransaction {
+                transaction_id: "tx-1".to_string(),
+                session_id: "sess".to_string(),
+                scope: "file:src/lib.rs".to_string(),
+                state: "active".to_string(),
+                staged_operations: Vec::new(),
+            },
+        );
+        write_persisted_mcp_transactions(&layout, &store);
+        assert!(mcp_transactions_disk_path(&layout).exists());
+
+        let restored = load_persisted_mcp_transactions(&layout);
+        assert_eq!(restored.len(), 1);
+        assert_eq!(
+            restored.get("tx-1").map(|t| t.scope.as_str()),
+            Some("file:src/lib.rs")
+        );
+    }
+
+    #[test]
+    fn persisted_mcp_transactions_corrupt_file_degrades_to_empty() {
+        // FIR-795: a torn/corrupt mirror degrades to empty (logged loud, never a
+        // startup crash) rather than poisoning daemon boot.
+        let dir = tempfile::tempdir().unwrap();
+        let layout = KinLayout::new(dir.path().to_path_buf());
+        std::fs::write(mcp_transactions_disk_path(&layout), b"{not valid json").unwrap();
+        assert!(load_persisted_mcp_transactions(&layout).is_empty());
+    }
 }


### PR DESCRIPTION
## DRAFT — active development (kin-impl lane). Do not merge yet.

- **FIR-984** (d66e97b) — prime cold reconciler projection so MCP body-edit commits reach disk (the moat write-loop; was a silent no-op). +regression test.
- **FIR-926** (989ce7b) — drive `kin embed` to full coverage across **bounded passes** (decouples coverage from the HTTP timeout; stall-guarded; no orphan-stacking). 12 embed tests green.
- **FIR-795** (15e637a) — **durably** persist in-flight MCP transactions across **daemon restart** (extends the prior in-memory 2aaaa5f to disk).
- **FIR-986** (a758afc, 1fba6b8) — beat-grep lexical parity: seat entity-bearing source files by basename so locate matches grep on keyword queries. +test.

### Still in progress on this branch
- FIR-986 needs a **daemon A/B verification** (KIN_LOCATE_* requires fresh-daemon restart; re-run locate-vs-grep). Not yet run.
- FIR-967 (release-archive packaging) is queued and will land here too.
- Do **not** close FIR-984/926/795/986 on commits alone — focused tests + skeptic-run evidence required (per review direction).