### PR TITLE
[DRAFT] FIR-944/983 kin-daemon wiring (blocked on kin-db/kin-vfs registry republish)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1019,7 +1019,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users 0.5.2",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -1118,7 +1118,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -3057,9 +3057,9 @@ dependencies = [
 
 [[package]]
 name = "kin-db"
-version = "0.1.0"
+version = "0.2.0"
 source = "sparse+https://kinlab.ai/registry/cargo/"
-checksum = "1f6e20fde7e06d2c53e38a47c6c04291a0ff45a42c1f01287919b26de36f0388"
+checksum = "2ff9121965d0478b886f69994b4bb35ddb3510397189cc96a1b309521d0047a6"
 dependencies = [
  "bincode",
  "bytes",
@@ -3853,7 +3853,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -4378,7 +4378,7 @@ dependencies = [
  "once_cell",
  "socket2",
  "tracing",
- "windows-sys 0.60.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -4735,7 +4735,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -5354,7 +5354,7 @@ dependencies = [
  "getrandom 0.4.2",
  "once_cell",
  "rustix",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -6329,7 +6329,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -6479,15 +6479,6 @@ dependencies = [
 
 [[package]]
 name = "windows-sys"
-version = "0.60.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f2f500e4d28234f72040990ec9d39e3a6b950f9f22d3dba18416c35882612bcb"
-dependencies = [
- "windows-targets 0.53.5",
-]
-
-[[package]]
-name = "windows-sys"
 version = "0.61.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
@@ -6519,28 +6510,11 @@ dependencies = [
  "windows_aarch64_gnullvm 0.52.6",
  "windows_aarch64_msvc 0.52.6",
  "windows_i686_gnu 0.52.6",
- "windows_i686_gnullvm 0.52.6",
+ "windows_i686_gnullvm",
  "windows_i686_msvc 0.52.6",
  "windows_x86_64_gnu 0.52.6",
  "windows_x86_64_gnullvm 0.52.6",
  "windows_x86_64_msvc 0.52.6",
-]
-
-[[package]]
-name = "windows-targets"
-version = "0.53.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4945f9f551b88e0d65f3db0bc25c33b8acea4d9e41163edf90dcd0b19f9069f3"
-dependencies = [
- "windows-link",
- "windows_aarch64_gnullvm 0.53.1",
- "windows_aarch64_msvc 0.53.1",
- "windows_i686_gnu 0.53.1",
- "windows_i686_gnullvm 0.53.1",
- "windows_i686_msvc 0.53.1",
- "windows_x86_64_gnu 0.53.1",
- "windows_x86_64_gnullvm 0.53.1",
- "windows_x86_64_msvc 0.53.1",
 ]
 
 [[package]]
@@ -6565,12 +6539,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
 
 [[package]]
-name = "windows_aarch64_gnullvm"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a9d8416fa8b42f5c947f8482c43e7d89e73a173cead56d044f6a56104a6d1b53"
-
-[[package]]
 name = "windows_aarch64_msvc"
 version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6581,12 +6549,6 @@ name = "windows_aarch64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
-
-[[package]]
-name = "windows_aarch64_msvc"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b9d782e804c2f632e395708e99a94275910eb9100b2114651e04744e9b125006"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -6601,22 +6563,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8e9b5ad5ab802e97eb8e295ac6720e509ee4c243f69d781394014ebfe8bbfa0b"
 
 [[package]]
-name = "windows_i686_gnu"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "960e6da069d81e09becb0ca57a65220ddff016ff2d6af6a223cf372a506593a3"
-
-[[package]]
 name = "windows_i686_gnullvm"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
-
-[[package]]
-name = "windows_i686_gnullvm"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fa7359d10048f68ab8b09fa71c3daccfb0e9b559aed648a8f95469c27057180c"
 
 [[package]]
 name = "windows_i686_msvc"
@@ -6631,12 +6581,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
 
 [[package]]
-name = "windows_i686_msvc"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e7ac75179f18232fe9c285163565a57ef8d3c89254a30685b57d83a38d326c2"
-
-[[package]]
 name = "windows_x86_64_gnu"
 version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6647,12 +6591,6 @@ name = "windows_x86_64_gnu"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
-
-[[package]]
-name = "windows_x86_64_gnu"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c3842cdd74a865a8066ab39c8a7a473c0778a3f29370b5fd6b4b9aa7df4a499"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
@@ -6667,12 +6605,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
 
 [[package]]
-name = "windows_x86_64_gnullvm"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ffa179e2d07eee8ad8f57493436566c7cc30ac536a3379fdf008f47f6bb7ae1"
-
-[[package]]
 name = "windows_x86_64_msvc"
 version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6683,12 +6615,6 @@ name = "windows_x86_64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
-
-[[package]]
-name = "windows_x86_64_msvc"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d6bbff5f0aada427a1e5a6da5f1f98158182f26556f345ac9e04d36d0ebed650"
 
 [[package]]
 name = "winnow"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -143,5 +143,5 @@ kin-lsp = { version = "0.1.0", registry = "kin" }
 # backend on every target (incl. Linux, where it cannot compile). Metal is re-enabled
 # additively on macOS via a `[target.'cfg(target_os = "macos")'.dependencies]` block in the
 # binary/runtime crates (kin-cli, kin-daemon). Feature unification makes that additive.
-kin-db = { version = "0.1.0", registry = "kin", default-features = false, features = ["vector", "embeddings"] }
+kin-db = { version = "0.2.0", registry = "kin", default-features = false, features = ["vector", "embeddings"] }
 kin-vfs-core = { version = "0.1.0", registry = "kin" }

--- a/crates/kin-daemon/src/daemon.rs
+++ b/crates/kin-daemon/src/daemon.rs
@@ -779,6 +779,13 @@ pub async fn run(mut state: DaemonState, config: DaemonConfig) -> Result<()> {
             }
         }
         info!("embedding worker started");
+        // FIR-944: re-queue every object the persisted index still lacks a vector
+        // for, so the worker resumes after a restart drained the in-memory queue
+        // (the queue is not persisted; coverage is, via graph-vs-index truth).
+        // Idempotent (HashSet queues) — a fresh start that already enqueued via
+        // reconcile is unaffected.
+        embed_state.graph.queue_missing_for_embedding();
+        embed_state.graph.queue_missing_artifacts_for_embedding();
         let mut consecutive_panics: u32 = 0;
         const MAX_CONSECUTIVE_PANICS: u32 = 3;
         // Recovery + backoff state for vector-index errors (e.g. a stale on-disk
@@ -874,29 +881,23 @@ pub async fn run(mut state: DaemonState, config: DaemonConfig) -> Result<()> {
                         // Run inside spawn_blocking so the std persist Mutex is held
                         // only across the synchronous write, never across an await.
                         let state_for_persist = Arc::clone(&embed_state);
+                        // FIR-944: flush this batch incrementally — the vector
+                        // sidecar plus any concurrent LSP-enrichment graph delta —
+                        // instead of relying on the periodic full-graph save that
+                        // re-serializes the whole ~1 GB graph each tick. The method
+                        // holds the persist lock and advances the generation cursor
+                        // (mirrors save_snapshot), so the two paths never tear.
                         let persist_result = tokio::task::spawn_blocking(move || {
-                            let _persist_guard =
-                                state_for_persist.persist_lock.lock().map_err(|_| {
-                                    kin_db::KinDbError::ConcurrentAccessError(
-                                        "persist lock poisoned".to_string(),
-                                    )
-                                })?;
-                            let embedder_identity =
-                                kin_buildinfo::sha_with_dirty(kin_buildinfo::get());
-                            kin_db::SnapshotManager::save_vector_index_for_graph(
-                                state_for_persist.layout.kindb_snapshot_path(),
-                                state_for_persist.graph.as_ref(),
-                                Some(embedder_identity.as_str()),
-                            )
+                            state_for_persist.flush_embed_progress()
                         })
                         .await;
                         match persist_result {
-                            Ok(Ok(())) => {}
+                            Ok(Ok(_pending)) => {}
                             Ok(Err(e)) => {
-                                error!(error = %e, "failed to persist vector index");
+                                error!(error = %e, "failed to flush embed progress");
                             }
                             Err(e) => {
-                                error!(error = %e, "vector index persist task panicked");
+                                error!(error = %e, "embed progress flush task panicked");
                             }
                         }
                     }

--- a/crates/kin-daemon/src/state.rs
+++ b/crates/kin-daemon/src/state.rs
@@ -1176,6 +1176,47 @@ impl DaemonState {
         Ok(())
     }
 
+    /// FIR-944: incremental per-batch embed-progress flush for the background
+    /// embed worker.
+    ///
+    /// Persists this batch's vectors — plus any concurrent graph delta from LSP
+    /// enrichment that kept the graph dirty during embed — via
+    /// `SnapshotManager::flush_embed_progress`, which appends only the delta and
+    /// the vector sidecar and NEVER re-serializes the whole (~1 GB) graph. The
+    /// old worker leaned on the periodic full `save_snapshot` to land the graph
+    /// side, which is O(graph) per tick and is what wedged the daemon at scale.
+    ///
+    /// Mirrors `save_snapshot_impl`'s persist-lock + generation-cursor + marker
+    /// discipline so the two persistence paths compose safely (the shared
+    /// `persist_lock` serializes them and keeps `snapshot_generation` consistent).
+    /// Returns the persisted resume `pending` count — derived from graph-vs-index
+    /// truth, so it survives a crash/reopen and reaches zero only at full
+    /// coverage.
+    pub fn flush_embed_progress(&self) -> Result<usize> {
+        let _persist_guard = self
+            .persist_lock
+            .lock()
+            .map_err(|_| DaemonError::Io(std::io::Error::other("persist lock poisoned")))?;
+        let base_gen = self.snapshot_generation.load(Ordering::SeqCst);
+        let embedder_identity = kin_buildinfo::sha_with_dirty(kin_buildinfo::get());
+        let outcome = kin_db::SnapshotManager::flush_embed_progress(
+            self.layout.kindb_snapshot_path(),
+            self.graph.as_ref(),
+            base_gen,
+            Some(embedder_identity.as_str()),
+        )
+        .map_err(DaemonError::from)?;
+        // The graph moved (a delta was appended) only when `generation` is Some;
+        // advance the cursor + publish the marker so CLI/MCP reload, exactly as
+        // save_snapshot_impl does. A vectors-only batch leaves the graph at
+        // `base_gen`, so the cursor stays put.
+        if let Some(generation) = outcome.generation {
+            self.snapshot_generation.store(generation, Ordering::SeqCst);
+            self.write_generation_marker(generation);
+        }
+        Ok(outcome.status.pending)
+    }
+
     fn save_read_index(&self) -> Result<()> {
         let index =
             kin_db::ReadIndex::from_graph(self.graph.as_ref()).map_err(DaemonError::from)?;
@@ -2243,5 +2284,32 @@ mod tests {
         // A moderate drop (50%) is a legitimate edit, NOT a wipe.
         state.persisted_entity_count.store(n * 2, Ordering::SeqCst);
         assert!(!state.shutdown_flush_would_wipe_graph());
+    }
+
+    #[test]
+    fn flush_embed_progress_persists_snapshot_and_reports_pending() {
+        // FIR-944: the incremental flush persists the snapshot (full bundle on
+        // the first write) and returns the persisted resume count. With no
+        // embedder run the lone entity stays unembedded, so `pending` reflects it
+        // — proving the flush composes the graph-delta + sidecar write and reads
+        // coverage from persisted graph-vs-index truth.
+        let repo_dir = tempfile::tempdir().unwrap();
+        let init = kin_core::init(repo_dir.path()).unwrap();
+        let state = Arc::new(test_state(init.layout, repo_dir.path()));
+        state
+            .graph
+            .upsert_entity(&test_entity("embed_me", "src/lib.rs"))
+            .unwrap();
+        state.graph.queue_missing_for_embedding();
+
+        let pending = state.flush_embed_progress().expect("flush must succeed");
+        assert!(
+            state.layout.kindb_snapshot_path().exists(),
+            "flush must persist the snapshot bundle"
+        );
+        assert!(
+            pending >= 1,
+            "the unembedded entity must remain pending (no embedder ran); got {pending}"
+        );
     }
 }

--- a/crates/kin-daemon/src/state.rs
+++ b/crates/kin-daemon/src/state.rs
@@ -1939,6 +1939,105 @@ mod tests {
         );
     }
 
+    #[test]
+    fn first_publish_commit_persists_under_v2_repo_prefix_and_reloads_with_refs() {
+        // FIR-983 hosted publish->serve: a full-content commit into the served
+        // graph must persist through the StorageBackend at `<prefix>/<repo>/graph.kndb`
+        // (the GCS `v2/<repo>/` layout, reproduced here with a LocalFileBackend rooted
+        // at `v2/`) and survive a pod restart with its branch refs intact. A fresh
+        // served graph has no branch, so the branch is created before the head update
+        // (update_branch_head errors NotFound otherwise).
+        use kin_db::LocalFileBackend;
+        use kin_model::{
+            AuthorId, Branch, BranchName, ChangeStore, EntityDelta, SemanticChange,
+            SemanticChangeId, Timestamp,
+        };
+
+        let repo_dir = tempfile::tempdir().unwrap();
+        let init = kin_core::init(repo_dir.path()).unwrap();
+        let layout = init.layout;
+
+        let storage = tempfile::tempdir().unwrap();
+        let v2_root = storage.path().join("v2");
+        let repo_id = "kin";
+        let branch_name = BranchName::new("main");
+
+        let state = DaemonState::open_with_backend(
+            layout.clone(),
+            Box::new(LocalFileBackend::new(&v2_root)),
+            repo_id,
+            None,
+        )
+        .unwrap();
+        assert_eq!(
+            state.graph.entity_count(),
+            0,
+            "a fresh hosted repo starts with an empty served graph"
+        );
+
+        let entity = test_entity("served_fn", "src/lib.rs");
+        state.graph.upsert_entity(&entity).unwrap();
+
+        let change = SemanticChange {
+            id: SemanticChangeId::from_hash(Hash256::from_bytes([7; 32])),
+            parents: vec![],
+            author: AuthorId::new("tester"),
+            message: "first publish".to_string(),
+            timestamp: Timestamp::now(),
+            entity_deltas: vec![EntityDelta::Added(entity.clone())],
+            relation_deltas: vec![],
+            artifact_deltas: vec![],
+            projected_files: vec![],
+            spec_link: None,
+            evidence: vec![],
+            risk_summary: None,
+            authored_on: None,
+        };
+        let change_id = change.id;
+        state
+            .graph
+            .create_branch(&Branch {
+                name: branch_name.clone(),
+                head: change_id,
+            })
+            .unwrap();
+        state.graph.create_change(&change).unwrap();
+        state
+            .graph
+            .update_branch_head(&branch_name, &change_id)
+            .unwrap();
+        state.save_snapshot_full().unwrap();
+
+        let persisted = v2_root.join(repo_id).join("graph.kndb");
+        assert!(
+            persisted.exists(),
+            "served commit must persist under v2/<repo>/graph.kndb at {}",
+            persisted.display()
+        );
+
+        drop(state);
+
+        let reopened = DaemonState::open_with_backend(
+            layout,
+            Box::new(LocalFileBackend::new(&v2_root)),
+            repo_id,
+            None,
+        )
+        .unwrap();
+        assert_eq!(
+            reopened.graph.entity_count(),
+            1,
+            "published content must survive reload from the v2 backend"
+        );
+        let branches = reopened.graph.list_branches().unwrap();
+        assert!(
+            branches
+                .iter()
+                .any(|b| b.name == branch_name && b.head == change_id),
+            "published branch head must be visible after reload (refs non-empty)"
+        );
+    }
+
     fn make_scoped_graph_with_entity(name: &str, file_path: &str) -> Arc<kin_db::InMemoryGraph> {
         let graph = Arc::new(kin_db::InMemoryGraph::new());
         graph.upsert_entity(&test_entity(name, file_path)).unwrap();


### PR DESCRIPTION
## kin-daemon consumer wiring for the merged kin-db/kin-vfs primitives

- **FIR-944** (9fcf6bd): `DaemonState::flush_embed_progress` (mirrors the persist-lock + `snapshot_generation` cursor) + the embed worker now calls it per batch instead of `save_vector_index_for_graph` + `queue_missing_for_embedding` after worker start (restart-resumable). Unit test green; 249 kin-daemon tests.

### ⚠️ CI is expected RED until propagation
kin consumes `kin-db`/`kin-vfs-core` from the **`kin` registry** (`version="0.1.0"`), not git. The merged `flush_embed_progress` API isn't in the registry yet, so CI can't resolve it. This compiles + unit-tests locally via a `[patch.kin]` (kept local, NOT committed — only `daemon.rs`/`state.rs` are in the commit). **Unblock = republish kin-db (+kin-vfs) to the `kin` registry at the merged commits, then bump kin's dep versions.** Draft until then.

FIR-983-daemon (materialize published head into served kindb + GCS v2) will land on this branch next.