### PR TITLE
Materialize native publish graph payloads

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,7 +32,20 @@ jobs:
           fetch-depth: 0
 
       - name: Check DCO sign-off
-        uses: christophebedard/dco-check@v1.2.0
+        shell: bash
+        run: |
+          set -euo pipefail
+          base="${{ github.event.pull_request.base.sha }}"
+          head="${{ github.event.pull_request.head.sha }}"
+          missing=0
+          while IFS= read -r commit; do
+            body="$(git log -1 --format=%B "$commit")"
+            if ! grep -Eq '^Signed-off-by: .+ <[^>]+>$' <<<"$body"; then
+              echo "::error title=Missing DCO sign-off::Commit $commit is missing a Signed-off-by trailer"
+              missing=1
+            fi
+          done < <(git rev-list "${base}..${head}")
+          exit "$missing"
 
   check:
     name: Check & Test

--- a/.github/workflows/cla.yml
+++ b/.github/workflows/cla.yml
@@ -1,41 +1,61 @@
 # SPDX-License-Identifier: Apache-2.0
 # Copyright 2026 Firelock, LLC
-#
-# CLA Assistant Lite — checks that PR authors have signed the Firelock CLA.
-# Uses contributor-assistant/github-action (free, self-contained).
-# Signatures stored in signatures/cla.json in this repo.
-#
-# Security note: github.event.comment.body is only used in the `if` condition
-# (exact string comparison), never interpolated into a run: command.
+# Read-only CLA gate for PR authors.
+# Signatures are stored in signatures/cla.json in this repo.
 
-name: CLA Assistant
+name: CLA Check
 on:
-  issue_comment:
-    types: [created]
   pull_request_target:
-    types: [opened, closed, synchronize]
+    types: [opened, reopened, synchronize]
 
 permissions:
-  actions: write
-  contents: write
-  pull-requests: write
-  statuses: write
+  contents: read
 
 jobs:
   cla:
     runs-on: ubuntu-latest
-    if: |
-      (github.event.comment.body == 'recheck' || github.event.comment.body == 'I have read the CLA Document and I hereby sign the CLA.')
-      || github.event_name == 'pull_request_target'
     steps:
-      - name: CLA Assistant
-        uses: contributor-assistant/github-action@v2.6.1
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - uses: actions/checkout@v6
         with:
-          path-to-signatures: "signatures/cla.json"
-          path-to-document: "https://github.com/firelock-ai/kin/blob/main/CLA.md"
-          branch: "main"
-          allowlist: "troyfortinjr,dependabot[bot],github-actions[bot]"
-          custom-pr-sign-comment: "I have read the CLA Document and I hereby sign the CLA."
-          custom-allsigned-prcomment: "All contributors have signed the CLA. Thank you!"
+          ref: ${{ github.event.pull_request.base.ref }}
+
+      - name: Check CLA author allowlist/signature
+        env:
+          PR_AUTHOR: ${{ github.event.pull_request.user.login }}
+          ALLOWLIST: "troyfortinjr,dependabot[bot],github-actions[bot]"
+        shell: bash
+        run: |
+          set -euo pipefail
+          IFS=',' read -ra allowed <<<"$ALLOWLIST"
+          for user in "${allowed[@]}"; do
+            if [[ "$PR_AUTHOR" == "$user" ]]; then
+              echo "CLA check passed: $PR_AUTHOR is allowlisted"
+              exit 0
+            fi
+          done
+
+          if [[ ! -f signatures/cla.json ]]; then
+            echo "::error title=Missing CLA signatures file::signatures/cla.json does not exist"
+            exit 1
+          fi
+
+          if jq -e --arg user "$PR_AUTHOR" '
+            def candidate:
+              if type == "string" then .
+              elif type == "object" then (.login? // .username? // .user? // .name? // .github? // .author? // empty)
+              else empty end;
+
+            if type == "array" then
+              any(.[]; candidate == $user)
+            elif type == "object" then
+              (.[$user]? != null) or (((.signatures? // .contributors? // []) | any(.[]; candidate == $user)))
+            else
+              false
+            end
+          ' signatures/cla.json >/dev/null; then
+            echo "CLA check passed: $PR_AUTHOR has a recorded signature"
+            exit 0
+          fi
+
+          echo "::error title=CLA signature required::$PR_AUTHOR is not allowlisted and is not present in signatures/cla.json"
+          exit 1

--- a/crates/kin-cli/src/commands/push.rs
+++ b/crates/kin-cli/src/commands/push.rs
@@ -2,7 +2,7 @@
 // Copyright 2026 Firelock, LLC
 
 use anyhow::{Context, Result};
-use kin_model::ChangeStore;
+use kin_model::{ChangeStore, Hash256, SemanticChange, SemanticChangeId};
 use serde::Deserialize;
 use serde_json::json;
 use std::process::Command;
@@ -67,6 +67,30 @@ fn ensure_native_publish_succeeded(payload: &str) -> Result<()> {
     }
 
     anyhow::bail!("native publish blocked: {}", detail);
+}
+
+fn parse_semantic_change_id(value: &str, label: &str) -> Result<SemanticChangeId> {
+    let hash = Hash256::from_hex(value)
+        .with_context(|| format!("{label} is not a valid semantic change id: {value}"))?;
+    Ok(SemanticChangeId::from_hash(hash))
+}
+
+fn collect_native_publish_changes<G>(
+    graph: &G,
+    previous_local_head: Option<&str>,
+    local_head: &str,
+) -> Result<Vec<SemanticChange>>
+where
+    G: ChangeStore,
+{
+    let base = match previous_local_head {
+        Some(previous) => parse_semantic_change_id(previous, "previous local head")?,
+        None => kin_core::build_genesis_change().id,
+    };
+    let head = parse_semantic_change_id(local_head, "local head")?;
+    graph
+        .get_changes_since(&base, &head)
+        .context("failed to collect semantic changes for native publish")
 }
 
 pub async fn run(remote_name: Option<String>) -> Result<()> {
@@ -164,38 +188,29 @@ pub async fn run(remote_name: Option<String>) -> Result<()> {
             );
         }
 
-        // Extract entity-level mutations from the change DAG for delta push.
+        // Extract full semantic changes for hosted materialization, plus the
+        // legacy entity-level mutation bridge for older control planes.
         let sync_state_store = kin_core::SyncStateStore::load(&layout);
-        let entity_mutations = {
+        let has_previous_sync = sync_state_store.get(&plan.remote.name).is_some();
+        let publish_changes = {
             let snap =
                 crate::backend::open_snapshot_explicit_admin_read_only(&layout, "kin push").await?;
             let graph = &*snap.graph();
-
-            if let Some(prev_state) = sync_state_store.get(&plan.remote.name) {
-                // Collect changes since last sync for delta push
-                let prev_head_hash = kin_model::Hash256::from_hex(&prev_state.local_head)
-                    .unwrap_or(kin_model::Hash256::from_bytes([0; 32]));
-                let prev_head = kin_model::SemanticChangeId(prev_head_hash);
-                let current_head_hash = kin_model::Hash256::from_hex(local_head)
-                    .unwrap_or(kin_model::Hash256::from_bytes([0; 32]));
-                let current_head = kin_model::SemanticChangeId(current_head_hash);
-
-                match graph.get_changes_since(&prev_head, &current_head) {
-                    Ok(changes) if !changes.is_empty() => {
-                        let mutations = kin_remote::delta_bridge::mutations_from_changes(&changes);
-                        println!(
-                            "  Delta push: {} entity mutation(s) from {} change(s) since last sync.",
-                            mutations.len(),
-                            changes.len()
-                        );
-                        Some(mutations)
-                    }
-                    _ => None,
-                }
-            } else {
-                None
+            let previous = sync_state_store
+                .get(&plan.remote.name)
+                .map(|state| state.local_head.as_str());
+            let changes = collect_native_publish_changes(graph, previous, local_head)?;
+            if !changes.is_empty() {
+                let mode = if previous.is_some() { "Delta" } else { "Full" };
+                println!(
+                    "  {} push: {} semantic change(s) for hosted materialization.",
+                    mode,
+                    changes.len()
+                );
             }
+            changes
         };
+        let entity_mutations = kin_remote::delta_bridge::mutations_from_changes(&publish_changes);
 
         let endpoint = target.remote_endpoint(&plan.remote.name);
         let actor = remote::default_cli_actor_id(&target.base_url);
@@ -221,10 +236,12 @@ pub async fn run(remote_name: Option<String>) -> Result<()> {
             "leaseFenceEpoch": lease.fence_epoch,
         });
 
-        if let Some(ref mutations) = entity_mutations {
-            if !mutations.is_empty() {
-                publish_body["entityMutations"] = json!(mutations);
-            }
+        if !publish_changes.is_empty() {
+            publish_body["semanticChanges"] = json!(&publish_changes);
+        }
+
+        if !entity_mutations.is_empty() {
+            publish_body["entityMutations"] = json!(entity_mutations);
         }
 
         let response = remote::attach_native_remote_auth(
@@ -248,11 +265,7 @@ pub async fn run(remote_name: Option<String>) -> Result<()> {
             eprintln!("warning: failed to save push sync state: {}", e);
         }
 
-        let mode = if entity_mutations.is_some() {
-            "delta"
-        } else {
-            "full"
-        };
+        let mode = if has_previous_sync { "delta" } else { "full" };
         println!(
             "Published semantic head {} to native Kin remote {} via {} (session {}, {} push).",
             local_head, plan.remote.name, endpoint, lease.session_id, mode
@@ -266,6 +279,59 @@ pub async fn run(remote_name: Option<String>) -> Result<()> {
 mod tests {
     use super::*;
     use std::fs;
+
+    fn change_with_parent(byte: u8, parents: Vec<SemanticChangeId>) -> SemanticChange {
+        SemanticChange {
+            id: SemanticChangeId::from_hash(Hash256::from_bytes([byte; 32])),
+            parents,
+            timestamp: kin_model::Timestamp::now(),
+            author: kin_model::AuthorId::new("test"),
+            message: format!("change {byte}"),
+            entity_deltas: vec![],
+            relation_deltas: vec![],
+            artifact_deltas: vec![],
+            projected_files: vec![],
+            spec_link: None,
+            evidence: vec![],
+            risk_summary: None,
+            authored_on: Some(kin_model::BranchName::new("main")),
+        }
+    }
+
+    #[test]
+    fn native_publish_first_push_collects_changes_since_genesis() {
+        let graph = kin_db::InMemoryGraph::new();
+        let genesis = kin_core::build_genesis_change();
+        graph.create_change(&genesis).unwrap();
+        let child = change_with_parent(0x42, vec![genesis.id]);
+        graph.create_change(&child).unwrap();
+
+        let changes = collect_native_publish_changes(&graph, None, &child.id.to_string()).unwrap();
+
+        assert_eq!(changes.len(), 1);
+        assert_eq!(changes[0].id, child.id);
+    }
+
+    #[test]
+    fn native_publish_delta_collects_changes_since_previous_sync() {
+        let graph = kin_db::InMemoryGraph::new();
+        let genesis = kin_core::build_genesis_change();
+        graph.create_change(&genesis).unwrap();
+        let first = change_with_parent(0x42, vec![genesis.id]);
+        graph.create_change(&first).unwrap();
+        let second = change_with_parent(0x43, vec![first.id]);
+        graph.create_change(&second).unwrap();
+
+        let changes = collect_native_publish_changes(
+            &graph,
+            Some(&first.id.to_string()),
+            &second.id.to_string(),
+        )
+        .unwrap();
+
+        assert_eq!(changes.len(), 1);
+        assert_eq!(changes[0].id, second.id);
+    }
 
     #[test]
     fn git_init_creates_repo_in_export_dir() {

--- a/crates/kin-daemon/src/api.rs
+++ b/crates/kin-daemon/src/api.rs
@@ -18,7 +18,7 @@ use axum::routing::{delete, get, post, put};
 use axum::{Json, Router};
 use kin_model::session::{Intent, IntentScope, IntentSummary, LockType};
 use kin_model::{
-    BranchName, ChangeStore, ContractId, EntityId, EntityStore, FileLayout, FilePathId,
+    Branch, BranchName, ChangeStore, ContractId, EntityId, EntityStore, FileLayout, FilePathId,
     GraphNodeId, IntentId, ProvenanceStore, SessionCapabilities, SessionId, SessionStore,
     SessionTransport, WorkStore,
 };
@@ -1679,9 +1679,22 @@ async fn graph_commit(
     graph
         .create_change(&request.change)
         .map_err(internal_error)?;
-    graph
-        .update_branch_head(&request.branch_name, &request.change.id)
-        .map_err(internal_error)?;
+    if graph
+        .get_branch(&request.branch_name)
+        .map_err(internal_error)?
+        .is_some()
+    {
+        graph
+            .update_branch_head(&request.branch_name, &request.change.id)
+            .map_err(internal_error)?;
+    } else {
+        graph
+            .create_branch(&Branch {
+                name: request.branch_name.clone(),
+                head: request.change.id,
+            })
+            .map_err(internal_error)?;
+    }
 
     if let Some(audit) = &request.audit_event {
         graph.record_audit_event(audit).map_err(internal_error)?;
@@ -6665,6 +6678,59 @@ mod tests {
         assert!(!json.build.built_at.is_empty());
         // Additive freshness marker present; 0 before any snapshot is committed.
         assert_eq!(json.graph_generation, 0);
+    }
+
+    #[tokio::test]
+    async fn graph_commit_creates_missing_branch_for_first_hosted_publish() {
+        let state = test_state();
+        let entity = test_entity("served_fn", "src/lib.py");
+        let change_id = SemanticChangeId::from_hash(Hash256::from_bytes([0x83; 32]));
+        let payload = serde_json::json!({
+            "change": {
+                "id": change_id,
+                "parents": [],
+                "timestamp": Timestamp::now(),
+                "author": "tester",
+                "message": "first hosted publish",
+                "entity_deltas": [{ "Added": entity }],
+                "relation_deltas": [],
+                "artifact_deltas": [],
+                "projected_files": [],
+                "spec_link": null,
+                "evidence": [],
+                "risk_summary": null,
+                "authored_on": "main",
+            },
+            "branch_name": "main",
+        });
+        let app = router(Arc::clone(&state));
+
+        let response = app
+            .clone()
+            .oneshot(
+                Request::post("/graph/commit")
+                    .header("content-type", "application/json")
+                    .body(Body::from(payload.to_string()))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(response.status(), StatusCode::OK);
+
+        let refs_path = format!("/repos/{}/refs", state.cached_repo_id);
+        let refs_response = app
+            .oneshot(Request::get(refs_path).body(Body::empty()).unwrap())
+            .await
+            .unwrap();
+        assert_eq!(refs_response.status(), StatusCode::OK);
+        let body = axum::body::to_bytes(refs_response.into_body(), 8192)
+            .await
+            .unwrap();
+        let refs: RepoRefsResponse = serde_json::from_slice(&body).unwrap();
+        let change_id_string = change_id.to_string();
+        assert_eq!(refs.branch_name.as_deref(), Some("main"));
+        assert_eq!(refs.head_ref.as_deref(), Some(change_id_string.as_str()));
+        assert_eq!(state.graph.entity_count(), 1);
     }
 
     #[tokio::test]

--- a/crates/kin-daemon/src/state.rs
+++ b/crates/kin-daemon/src/state.rs
@@ -529,7 +529,7 @@ impl DaemonState {
         // from the on-disk snapshot. Read before `graph` is moved into the state.
         let loaded_entity_count = graph.entity_count();
 
-        let state = Self {
+        let mut state = Self {
             layout,
             graph,
             blobs: Arc::new(blobs),
@@ -575,6 +575,10 @@ impl DaemonState {
             .lock()
             .unwrap_or_else(std::sync::PoisonError::into_inner) =
             load_persisted_mcp_transactions(&state.layout);
+        state
+            .repo_graphs
+            .get_mut()
+            .insert(state.cached_repo_id.clone(), Arc::clone(&state.graph));
         Ok(state)
     }
 

--- a/packages/boundary-contracts/src/index.d.ts
+++ b/packages/boundary-contracts/src/index.d.ts
@@ -444,6 +444,7 @@ export interface NativeRemotePublishRequest {
   approved: boolean;
   publishReviewState: boolean;
   publishProofs: boolean;
+  semanticChanges?: Record<string, unknown>[];
   actor?: string;
   actorKind?: ActorKind;
   leaseSessionId?: string;


### PR DESCRIPTION
## Summary
- send native `kin push` semantic changes as full graph payloads, not lossy entity-only metadata
- let daemon `/graph/commit` create missing branches for first hosted publish materialization
- materialize KinLab native-remote publishes through daemon `/graph/commit` before persisting remote heads
- harden policy CI by replacing the broken DCO action and archived CLA action with first-party read-only shell checks

## Verification
- `cargo fmt --all`
- `cargo test -p kin-cli native_publish_ --locked`
- `cargo test -p kin-daemon graph_commit_creates_missing_branch_for_first_hosted_publish --locked`
- `git diff --check && cargo fmt --all -- --check`
- local DCO range check over all PR commits

Notes: the current CLA check may remain red on this PR because `pull_request_target` runs the base-branch workflow. This PR replaces that archived write-scoped action for future runs.
