### PR TITLE
fix(install): harden cross-platform public installer path (FIR-1006)

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,9 +21,21 @@ Install Kin with a single command:
 curl -fsSL https://get.kinlab.dev/install | sh
 ```
 
-The installer downloads the latest release from GitHub, places the `kin` and `kin-vfs`
-binaries into `~/.kin/bin`, updates your shell profile (`.zshrc` / `.bashrc`), and then
-runs the interactive setup wizard.
+The installer downloads the latest release from GitHub, verifies its SHA-256 checksum
+(and refuses to install an unverified or tampered download), places the `kin` and
+`kin-daemon` binaries — plus the optional `kin-vfs` projection client where bundled —
+into `~/.kin/bin`, updates your shell profile (`.zshrc` / `.bashrc`), and then runs the
+interactive setup wizard. Re-running the installer upgrades an existing install in place.
+
+On **Windows**, use PowerShell:
+
+```powershell
+irm https://get.kinlab.dev/install.ps1 | iex
+```
+
+The native Windows build is a limited, vector-free convenience binary with no filesystem
+projection. For the complete, vector-enabled Kin with working projection, install under
+WSL2 — see [docs/windows-wsl2.md](docs/windows-wsl2.md).
 
 ### Installer configuration
 
@@ -32,6 +44,7 @@ Configure the installer with environment variables:
 - `KIN_VERSION`: Pin a specific version to download (e.g. `0.1.0`). If omitted, the latest release is resolved automatically.
 - `KIN_DIR`: Custom installation directory (defaults to `~/.kin`).
 - `KIN_NO_SETUP`: Set to `1` to skip the interactive setup wizard after the binaries are downloaded.
+- `KIN_BASE_URL`: Install from a mirror or local path instead of GitHub releases (offline/airgapped installs and CI smoke tests). Supported by both the `sh` and PowerShell installers.
 
 ### Runtime configuration
 

--- a/scripts/install.ps1
+++ b/scripts/install.ps1
@@ -10,6 +10,11 @@
 #   $env:KIN_VERSION = "0.1.0"   Pin a specific version (default: latest)
 #   $env:KIN_DIR = "$HOME\.kin"  Install directory (default: ~/.kin)
 #   $env:KIN_NO_SETUP = "1"     Skip interactive setup after install
+#   $env:KIN_BASE_URL = "..."   Install from a mirror (CI smoke tests / offline)
+#
+# Note: the native Windows build is a limited, vector-free convenience binary
+# with no filesystem projection. For the full experience, install under WSL2
+# (see docs/windows-wsl2.md).
 
 $ErrorActionPreference = "Stop"
 
@@ -20,7 +25,9 @@ $KinBin = Join-Path $KinDir "bin"
 $KinLib = Join-Path $KinDir "lib"
 $GitHubOrg = "firelock-ai"
 $GitHubRepo = "kin"
-$BaseUrl = "https://github.com/$GitHubOrg/$GitHubRepo/releases"
+# Override KIN_BASE_URL to install from a mirror or a local path (offline /
+# airgapped installs and CI smoke tests). Mirrors the install.sh override.
+$BaseUrl = if ($env:KIN_BASE_URL) { $env:KIN_BASE_URL } else { "https://github.com/$GitHubOrg/$GitHubRepo/releases" }
 
 # ── Helpers ─────────────────────────────────────────────────────────────
 
@@ -46,6 +53,29 @@ Write-Host "  Semantic development environment"
 Write-Host ""
 
 Write-Info "Platform: windows ($Arch)"
+
+# The native Windows binary is a limited convenience build: it is vector-free
+# (semantic search disabled) and does NOT provide the transparent filesystem
+# projection. Projection relies on Unix library-injection (LD_PRELOAD /
+# DYLD_INSERT_LIBRARIES), which native Windows does not offer. For the complete,
+# vector-enabled Kin with working projection, install under WSL2 instead — see
+# docs/windows-wsl2.md.
+Write-Host "  ! Native Windows build is vector-free and has no filesystem projection." -ForegroundColor Yellow
+Write-Host "    For the full experience, install under WSL2 (see docs/windows-wsl2.md)." -ForegroundColor DarkGray
+Write-Host ""
+
+# ── Detect an existing install (reinstall / upgrade) ──────────────────
+
+$PreviousVersion = $null
+$ExistingKinExe = Join-Path $KinBin "kin.exe"
+if (Test-Path $ExistingKinExe) {
+    $PreviousVersion = (& $ExistingKinExe --version 2>$null | Select-Object -First 1)
+    if ($PreviousVersion) {
+        Write-Info "Existing install found: kin $PreviousVersion (will be replaced)"
+    } else {
+        Write-Info "Existing install found in $KinDir (will be replaced)"
+    }
+}
 
 # ── Resolve version ─────────────────────────────────────────────────────
 
@@ -132,29 +162,41 @@ New-Item -ItemType Directory -Path $KinLib -Force | Out-Null
 
 Expand-Archive -Path (Join-Path $TmpDir $Archive) -DestinationPath $TmpDir -Force
 
-# FIR-967: kin-daemon is mandatory — kin status/search and the MCP server all
-# require it. Assert it is present BEFORE moving anything so a daemon-less
-# archive aborts cleanly instead of leaving a half-installed environment.
+# kin-daemon is mandatory — kin status/search and the MCP server all require it.
+# Assert it is present BEFORE moving anything so a daemon-less archive aborts
+# cleanly instead of leaving a half-installed environment.
 if (-not (Test-Path (Join-Path $TmpDir "kin-daemon.exe"))) {
     Write-Err "kin-daemon.exe missing from the downloaded archive. Refusing a daemon-less install."
     exit 1
 }
 
-# Move binaries. kin-daemon.exe is mandatory (asserted above); kin-vfs.exe is optional.
+# Move binaries. kin-daemon.exe is mandatory (asserted above); kin-vfs.exe ships
+# only when the archive includes the (Unix-only) projection client.
+$HaveVfs = $false
 foreach ($bin in @("kin.exe", "kin-daemon.exe", "kin-vfs.exe")) {
     $src = Join-Path $TmpDir $bin
     if (Test-Path $src) {
         Move-Item -Path $src -Destination (Join-Path $KinBin $bin) -Force
+        if ($bin -eq "kin-vfs.exe") { $HaveVfs = $true }
     }
 }
 
-# Move shim library
+# Move the projection shim if the archive bundled it. The native Windows release
+# is vector-free and ships no shim, so this is normally absent.
+$HaveShim = $false
 $shimSrc = Join-Path $TmpDir "kin_vfs_shim.dll"
 if (Test-Path $shimSrc) {
     Move-Item -Path $shimSrc -Destination (Join-Path $KinLib "kin_vfs_shim.dll") -Force
+    $HaveShim = $true
 }
 
-Write-Ok "Binaries installed"
+Write-Ok "Binaries installed (kin, kin-daemon)"
+
+if ($HaveVfs -and $HaveShim) {
+    Write-Ok "Filesystem projection installed (kin-vfs + shim)"
+} else {
+    Write-Info "Filesystem projection is not available on native Windows. Use WSL2 for projection (see docs/windows-wsl2.md)."
+}
 
 # ── PATH setup ──────────────────────────────────────────────────────────
 
@@ -171,8 +213,12 @@ if ($CurrentPath -notlike "*$KinBin*") {
 
 $KinExe = Join-Path $KinBin "kin.exe"
 if (Test-Path $KinExe) {
-    $ver = & $KinExe --version 2>$null
-    Write-Ok "kin $ver"
+    $InstalledVersion = (& $KinExe --version 2>$null | Select-Object -First 1)
+    if ($PreviousVersion -and $InstalledVersion -and ($PreviousVersion -ne $InstalledVersion)) {
+        Write-Ok "kin upgraded: $PreviousVersion -> $InstalledVersion"
+    } else {
+        Write-Ok "kin $InstalledVersion"
+    }
 } else {
     Write-Err "Installation failed — kin.exe not found"
     exit 1

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -64,6 +64,18 @@ printf '\n'
 
 info "Platform: $OS ($ARCH)"
 
+# ── Detect an existing install (reinstall / upgrade) ──────────────────
+
+PREVIOUS_VERSION=""
+if [ -x "$KIN_BIN/kin" ]; then
+    PREVIOUS_VERSION=$("$KIN_BIN/kin" --version 2>/dev/null | awk '{print $NF}')
+    if [ -n "$PREVIOUS_VERSION" ]; then
+        info "Existing install found: kin $PREVIOUS_VERSION (will be replaced)"
+    else
+        info "Existing install found in $KIN_DIR (will be replaced)"
+    fi
+fi
+
 # ── Resolve version ────────────────────────────────────────────────────
 
 if [ -n "${KIN_VERSION:-}" ]; then
@@ -159,32 +171,44 @@ if [ -z "$EXTRACT_DIR" ]; then
     EXTRACT_DIR="$TMPDIR"
 fi
 
-# FIR-967: kin-daemon is mandatory — `kin status`/`kin search` and the MCP
-# server all require it. Assert it is present in the extracted archive BEFORE
-# moving anything, so a daemon-less archive (e.g. a stale build) aborts cleanly
-# instead of leaving a half-installed, daemon-less environment.
+# kin-daemon is mandatory — `kin status`/`kin search` and the MCP server all
+# require it. Assert it is present in the extracted archive BEFORE moving
+# anything, so a daemon-less archive (e.g. a stale build) aborts cleanly instead
+# of leaving a half-installed, daemon-less environment.
 if [ ! -f "$EXTRACT_DIR/kin-daemon" ]; then
     err "kin-daemon missing from the downloaded archive."
     err "kin status/search and the MCP server require it. Refusing a daemon-less install. Aborting."
     exit 1
 fi
 
-# Move binaries. kin-daemon is mandatory (asserted above); kin-vfs is optional.
+# Move binaries. kin-daemon is mandatory (asserted above); kin-vfs is the
+# optional filesystem-projection client.
+HAVE_VFS=0
 for bin in kin kin-daemon kin-vfs; do
     if [ -f "$EXTRACT_DIR/$bin" ]; then
         mv "$EXTRACT_DIR/$bin" "$KIN_BIN/$bin"
         chmod +x "$KIN_BIN/$bin"
+        [ "$bin" = "kin-vfs" ] && HAVE_VFS=1
     fi
 done
 
-# Move shim library
+# Move the projection shim library if the archive bundled it (Linux .so /
+# macOS .dylib). It is consumed by the shell hooks via $KIN_DIR/lib.
+HAVE_SHIM=0
 for lib in libkin_vfs_shim.so libkin_vfs_shim.dylib; do
     if [ -f "$EXTRACT_DIR/$lib" ]; then
         mv "$EXTRACT_DIR/$lib" "$KIN_LIB/$lib"
+        HAVE_SHIM=1
     fi
 done
 
-ok "Binaries installed"
+ok "Binaries installed (kin, kin-daemon)"
+
+if [ "$HAVE_VFS" = "1" ] && [ "$HAVE_SHIM" = "1" ]; then
+    ok "Filesystem projection installed (kin-vfs + shim)"
+else
+    info "Filesystem projection (kin-vfs) not bundled in this archive — core CLI and daemon are fully functional without it."
+fi
 
 # ── PATH setup ──────────────────────────────────────────────────────────
 
@@ -224,7 +248,12 @@ esac
 export PATH="$KIN_BIN:$PATH"
 
 if has_cmd "$KIN_BIN/kin"; then
-    ok "kin $(\"$KIN_BIN/kin\" --version 2>/dev/null || echo 'installed')"
+    INSTALLED_VERSION=$("$KIN_BIN/kin" --version 2>/dev/null | awk '{print $NF}')
+    if [ -n "$PREVIOUS_VERSION" ] && [ -n "$INSTALLED_VERSION" ] && [ "$PREVIOUS_VERSION" != "$INSTALLED_VERSION" ]; then
+        ok "kin upgraded: $PREVIOUS_VERSION → $INSTALLED_VERSION"
+    else
+        ok "kin ${INSTALLED_VERSION:-installed}"
+    fi
 else
     err "Installation failed — kin binary not found"
     exit 1


### PR DESCRIPTION
## FIR-1006 — Cross-platform public installer path (macOS, Windows, Linux)

Audit + harden `scripts/install.sh` and `scripts/install.ps1` against the public-install acceptance criteria. Scope is **installer scripts + install docs only** — deliberately does **not** touch `crates/kin-cli/src/commands/setup.rs` or `main.rs` (owned by #27).

### Per-criterion audit result

| # | Criterion | State before | Action |
|---|-----------|--------------|--------|
| 1 | macOS+Linux install all first-run binaries (`kin`, `kin-daemon`, projection) | PASS — daemon guard + move loop correct (`install.sh:166-185`); shim dest `~/.kin/lib` matches setup's `find_shim` `../lib` lookup | Added honest projection-install status reporting |
| 2 | Windows PowerShell-first path, honest VFS/projection limitation | PARTIAL — installed kin+daemon but silently moved a shim that the vector-free Windows release never ships, and never told the user projection is unavailable | Added up-front limitation banner + WSL2 pointer; report projection status after move |
| 3 | Checksums for every artifact path | PASS — both scripts download per-artifact `.sha256`, fail loudly on missing/malformed/mismatch (`install.sh:116-146`, `install.ps1:88-124`); matches `release.yml` per-artifact `.sha256` | Left as correct |
| 4 | Never silently succeed when daemon/component missing | PASS — guard-before-move present in BOTH scripts | Left as correct; **verified it fires** (smoke test, rc=1) |
| 5 | Version pinning + upgrade/reinstall explicit & testable | PARTIAL — `KIN_VERSION` pinning worked; upgrade/reinstall was silent overwrite | Added existing-install detection + explicit `old → new` upgrade messaging in both scripts |
| 6 | Fresh install independent of dev PATH / cargo / daemon | PASS for behavior; install.ps1 was **not** smoke-testable (hardcoded base URL) | Added `KIN_BASE_URL` override to install.ps1 for parity with install.sh |

### Validation performed locally
- `bash -n`, `sh -n`, and `dash -n` (POSIX) all pass on `install.sh`.
- End-to-end `install.sh` smoke test via `KIN_BASE_URL=file://` mirror with a fake release: happy path, daemon-less archive (guard fires, rc=1), checksum mismatch (refuses, rc=1), and fresh→upgrade transition all verified.
- `install.ps1`: **could not execute** — no PowerShell interpreter (`pwsh`/`powershell`) on this machine. Reviewed structurally (balanced braces/parens, logic mirrors install.sh). A real `pwsh` parse on a Windows/PowerShell runner is the one item that needs a real environment.

### Needs a real fresh machine (acceptance matrix, tracked separately)
- Native Windows PowerShell run end-to-end against a real release.
- Real `curl | sh` fresh-user run on clean macOS + Linux.

### Notes
- No `FIR-xxx` refs remain in the scripts (stripped from the comments I touched; ticket ref is in the commit message only).
- Repo does **not** implement Windows ProjFS projection today; docs/scripts state the truth (no projection on native Windows; use WSL2) rather than overclaiming.