### PR TITLE
feat(kin-mcp): npm/MCP first-run works without local dev state (FIR-1007)

### DIFF
--- a/packages/kin-mcp/README.md
+++ b/packages/kin-mcp/README.md
@@ -4,11 +4,26 @@
 command is still `kin-mcp`).
 
 It downloads the matching Kin release archive from GitHub, verifies the published
-SHA-256 checksum, extracts the `kin` binary into a local cache, and runs:
+SHA-256 checksum, extracts both the `kin` CLI and the `kin-daemon` it depends on
+into a local cache, and runs:
 
 ```sh
 kin mcp start
 ```
+
+On first run it:
+
+- provisions `kin-daemon` next to `kin` and points the CLI at it with
+  `KIN_DAEMON_BIN`, so the MCP path never depends on a locally-built `kin`, a
+  stale daemon on `PATH`, or a pre-existing daemon;
+- defaults `KIN_MCP_TOOL_PROFILE=agent-default`, so agents see the small curated
+  tool surface instead of the full internal one;
+- starts (or reuses) the repo daemon automatically, and only then serves tools;
+- requires an explicit `kin init` (no silent init) unless you opt in with
+  `KIN_MCP_AUTO_INIT=1`.
+
+If a runnable Kin cannot be provisioned (unsupported target, release download
+blocked), the wrapper exits with a precise guided fix instead of a stack trace.
 
 ## Usage
 
@@ -48,7 +63,7 @@ Windows users should run Kin through WSL2 during the alpha.
 
 ## Cache
 
-The wrapper caches the downloaded `kin` binary under:
+The wrapper caches the downloaded `kin` and `kin-daemon` binaries under:
 
 - macOS: `~/Library/Caches/kin-mcp`
 - Linux: `~/.cache/kin-mcp`
@@ -57,16 +72,33 @@ Set `KIN_MCP_CACHE_DIR` to override the cache location.
 
 ## Environment
 
-- `KIN_MCP_KIN_BINARY`: run a specific local `kin` binary instead of downloading one
+- `KIN_MCP_KIN_BINARY`: run a specific local `kin` binary instead of downloading
+  one (you are then responsible for its `kin-daemon`)
 - `KIN_BINARY_PATH`: alias for `KIN_MCP_KIN_BINARY`
 - `KIN_MCP_CACHE_DIR`: override the cache directory
 - `KIN_MCP_AUTO_INIT=1`: allow the wrapper to run `kin init .` when `.kin/` is missing
+- `KIN_MCP_TOOL_PROFILE`: override the default `agent-default` tool profile
 - `KIN_MCP_RELEASE_BASE_URL`: override the GitHub release download base URL
 
 ## Local Check
 
 ```sh
-npx -y @kinlab/kin-mcp --print-bin
+npx -y @kinlab/kin-mcp --print-bin         # provisioned kin path
+npx -y @kinlab/kin-mcp --print-daemon-bin  # provisioned kin-daemon path
 ```
 
 Then initialize a repository and let the MCP client launch `kin-mcp`.
+
+## First-run smoke proof
+
+`test/smoke-first-run.mjs` exercises the whole first-run path against built Kin
+binaries: it stages `kin` + `kin-daemon` into a throwaway cache (no pre-existing
+daemon, no dev `PATH` state), runs the wrapper, and drives the MCP stdio protocol
+through one safe semantic tool (`kin_graph_status`). Run it with:
+
+```sh
+cargo build --release -p kin-cli -p kin-daemon
+KIN_BIN=target/release/kin \
+KIN_DAEMON_BIN=target/release/kin-daemon \
+npm run smoke
+```

--- a/packages/kin-mcp/package.json
+++ b/packages/kin-mcp/package.json
@@ -14,7 +14,8 @@
   ],
   "scripts": {
     "test": "node --test",
-    "lint": "node --check ./bin/kin-mcp.js && node --check ./src/index.js && node --check ./test/index.test.js"
+    "lint": "node --check ./bin/kin-mcp.js && node --check ./src/index.js && node --check ./test/index.test.js && node --check ./test/smoke-first-run.mjs",
+    "smoke": "node ./test/smoke-first-run.mjs"
   },
   "engines": {
     "node": ">=20"

--- a/packages/kin-mcp/src/index.js
+++ b/packages/kin-mcp/src/index.js
@@ -20,33 +20,40 @@ export function resolveReleaseTag(version = PACKAGE_VERSION) {
   return version.startsWith('v') ? version : `v${version}`;
 }
 
+export const PRIMARY_BINARY_NAME = 'kin';
+export const DAEMON_BINARY_NAME = 'kin-daemon';
+
 export function resolveReleaseAsset(platform = process.platform, arch = process.arch) {
   if (platform === 'darwin' && arch === 'arm64') {
     return {
       assetName: 'kin-macos-aarch64',
       archiveName: 'kin-macos-aarch64.tar.gz',
-      binaryName: 'kin'
+      binaryName: PRIMARY_BINARY_NAME,
+      daemonBinaryName: DAEMON_BINARY_NAME
     };
   }
   if (platform === 'darwin' && arch === 'x64') {
     return {
       assetName: 'kin-macos-x86_64',
       archiveName: 'kin-macos-x86_64.tar.gz',
-      binaryName: 'kin'
+      binaryName: PRIMARY_BINARY_NAME,
+      daemonBinaryName: DAEMON_BINARY_NAME
     };
   }
   if (platform === 'linux' && arch === 'x64') {
     return {
       assetName: 'kin-linux-x86_64',
       archiveName: 'kin-linux-x86_64.tar.gz',
-      binaryName: 'kin'
+      binaryName: PRIMARY_BINARY_NAME,
+      daemonBinaryName: DAEMON_BINARY_NAME
     };
   }
   if (platform === 'linux' && arch === 'arm64') {
     return {
       assetName: 'kin-linux-aarch64',
       archiveName: 'kin-linux-aarch64.tar.gz',
-      binaryName: 'kin'
+      binaryName: PRIMARY_BINARY_NAME,
+      daemonBinaryName: DAEMON_BINARY_NAME
     };
   }
 
@@ -115,11 +122,16 @@ export async function ensureKinBinary({
     cacheRoot
   });
 
-  if (await isRunnable(binaryPath, platform)) {
+  const daemonPath = path.join(path.dirname(binaryPath), DAEMON_BINARY_NAME);
+  if (
+    (await isRunnable(binaryPath, platform)) &&
+    (await isRunnable(daemonPath, platform))
+  ) {
     return binaryPath;
   }
 
   await installKinBinary({ binaryPath, env, platform, arch, version });
+  await assertDaemonProvisioned(binaryPath, platform);
   return binaryPath;
 }
 
@@ -127,6 +139,7 @@ export async function runKinMcp(argv = [], options = {}) {
   const stdout = options.stdout || process.stdout;
   const stderr = options.stderr || process.stderr;
   const env = options.env || process.env;
+  const platform = options.platform || process.platform;
 
   if (argv.includes('--help') || argv.includes('-h')) {
     stdout.write(renderHelp());
@@ -138,9 +151,18 @@ export async function runKinMcp(argv = [], options = {}) {
     return 0;
   }
 
-  if (argv.includes('--print-bin')) {
-    const binaryPath = await ensureKinBinary(options);
-    stdout.write(`${binaryPath}\n`);
+  if (argv.includes('--print-bin') || argv.includes('--print-daemon-bin')) {
+    let binaryPath;
+    try {
+      binaryPath = await ensureKinBinary(options);
+    } catch (error) {
+      stderr.write(`${guidedProvisioningFailure(error)}\n`);
+      return 1;
+    }
+    const target = argv.includes('--print-daemon-bin')
+      ? resolveDaemonBinaryPath(binaryPath)
+      : binaryPath;
+    stdout.write(`${target}\n`);
     return 0;
   }
 
@@ -151,7 +173,18 @@ export async function runKinMcp(argv = [], options = {}) {
     return 2;
   }
 
-  const binaryPath = await ensureKinBinary(options);
+  let binaryPath;
+  try {
+    binaryPath = await ensureKinBinary(options);
+  } catch (error) {
+    stderr.write(`${guidedProvisioningFailure(error)}\n`);
+    return 1;
+  }
+
+  const spawnOptions = {
+    ...options,
+    env: childEnv(env, binaryPath, platform)
+  };
 
   const cwd = options.cwd || process.cwd();
   if (!await kinRepoExists(cwd)) {
@@ -162,14 +195,45 @@ export async function runKinMcp(argv = [], options = {}) {
       return 2;
     }
     stderr.write('No .kin/ found; KIN_MCP_AUTO_INIT=1, running kin init...\n');
-    const initCode = await spawnKin(binaryPath, ['init', '.'], { ...options, cwd });
+    const initCode = await spawnKin(binaryPath, ['init', '.'], { ...spawnOptions, cwd });
     if (initCode !== 0) {
       stderr.write('kin init failed. Cannot start MCP server.\n');
       return initCode;
     }
   }
 
-  return spawnKin(binaryPath, ['mcp', 'start'], options);
+  return spawnKin(binaryPath, ['mcp', 'start'], spawnOptions);
+}
+
+export function resolveDaemonBinaryPath(kinBinaryPath) {
+  return path.join(path.dirname(kinBinaryPath), DAEMON_BINARY_NAME);
+}
+
+export function childEnv(env, kinBinaryPath, platform = process.platform) {
+  const next = { ...env };
+
+  if (!next.KIN_MCP_TOOL_PROFILE) {
+    next.KIN_MCP_TOOL_PROFILE = 'agent-default';
+  }
+
+  const usesManagedBinary = !(env.KIN_MCP_KIN_BINARY || env.KIN_BINARY_PATH);
+  if (usesManagedBinary && !next.KIN_DAEMON_BIN) {
+    next.KIN_DAEMON_BIN = resolveDaemonBinaryPath(kinBinaryPath);
+  }
+
+  return next;
+}
+
+function guidedProvisioningFailure(error) {
+  const detail = error && error.message ? error.message : String(error);
+  return [
+    `kin-mcp could not provision a runnable Kin: ${detail}`,
+    'Fixes:',
+    '  - Install Kin directly and run `kin setup` to configure your agent, then point',
+    '    this wrapper at it with KIN_MCP_KIN_BINARY=/path/to/kin.',
+    '  - Or retry on a supported target (macOS/Linux). On Windows use WSL2 for this alpha.',
+    '  - Or override the release source with KIN_MCP_RELEASE_BASE_URL if you mirror releases.'
+  ].join('\n');
 }
 
 function isTruthyEnv(value) {
@@ -182,25 +246,34 @@ function renderHelp() {
 Usage:
   kin-mcp
   kin-mcp --print-bin
+  kin-mcp --print-daemon-bin
   kin-mcp --version
 
-This wrapper downloads a matching Kin release binary on demand, caches it
-locally, and then runs:
+This wrapper downloads a matching Kin release archive on demand, extracts both
+the kin CLI and the kin-daemon it depends on into a local cache, and then runs:
 
   kin mcp start
 
+It defaults KIN_MCP_TOOL_PROFILE=agent-default so first-run agents see the small
+curated tool surface, and points the kin CLI at the cached kin-daemon via
+KIN_DAEMON_BIN so it never depends on a stale daemon on PATH.
+
 Environment:
-  KIN_MCP_KIN_BINARY   Use a specific kin binary
+  KIN_MCP_KIN_BINARY   Use a specific kin binary (you manage its kin-daemon)
   KIN_BINARY_PATH      Alias for KIN_MCP_KIN_BINARY
   KIN_MCP_CACHE_DIR    Override the cache directory
   KIN_MCP_AUTO_INIT    Set to 1 to allow wrapper-initiated kin init
+  KIN_MCP_TOOL_PROFILE Override the default agent-default tool profile
   KIN_MCP_RELEASE_BASE_URL
                        Override the release download base URL
 `;
 }
 
 async function installKinBinary({ binaryPath, env, platform, arch, version }) {
-  const { assetName, archiveName, binaryName } = resolveReleaseAsset(platform, arch);
+  const { assetName, archiveName, binaryName, daemonBinaryName } = resolveReleaseAsset(
+    platform,
+    arch
+  );
   const tag = resolveReleaseTag(version);
   const baseUrl = (env.KIN_MCP_RELEASE_BASE_URL || DEFAULT_RELEASE_BASE_URL).replace(
     /\/$/,
@@ -227,6 +300,7 @@ async function installKinBinary({ binaryPath, env, platform, arch, version }) {
     archiveName,
     assetName,
     binaryName,
+    daemonBinaryName,
     binaryPath,
     platform
   });
@@ -237,30 +311,80 @@ async function installFromArchive({
   archiveName,
   assetName,
   binaryName,
+  daemonBinaryName,
   binaryPath,
   platform
 }) {
   const tmpRoot = await fsp.mkdtemp(path.join(os.tmpdir(), 'kin-mcp-install-'));
   const archivePath = path.join(tmpRoot, archiveName);
-  const tmpPath = `${binaryPath}.download`;
+  const installDir = path.dirname(binaryPath);
+  const daemonPath = path.join(installDir, daemonBinaryName);
+  const staged = [];
 
   try {
     await fsp.writeFile(archivePath, archiveBytes);
     await execFile('tar', ['-xzf', archivePath, '-C', tmpRoot]);
 
-    const extractedBinary = path.join(tmpRoot, assetName, binaryName);
-    await fsp.access(extractedBinary, fs.constants.R_OK);
-    await fsp.copyFile(extractedBinary, tmpPath);
-    if (platform !== 'win32') {
-      await fsp.chmod(tmpPath, 0o755);
+    const kinStaged = await stageBinary({
+      tmpRoot,
+      assetName,
+      sourceName: binaryName,
+      destination: binaryPath,
+      platform,
+      required: true
+    });
+    staged.push(kinStaged);
+
+    const daemonStaged = await stageBinary({
+      tmpRoot,
+      assetName,
+      sourceName: daemonBinaryName,
+      destination: daemonPath,
+      platform,
+      required: true,
+      missingHint:
+        'the published release archive is missing kin-daemon; the daemon is required for MCP'
+    });
+    staged.push(daemonStaged);
+
+    for (const item of staged) {
+      await fsp.rename(item.tmpPath, item.destination);
     }
-    await fsp.rename(tmpPath, binaryPath);
   } catch (error) {
-    await fsp.unlink(tmpPath).catch(() => {});
-    throw new Error(`failed to install ${binaryName} from ${archiveName}: ${error.message}`);
+    await Promise.all(staged.map(item => fsp.unlink(item.tmpPath).catch(() => {})));
+    throw new Error(
+      `failed to install ${binaryName} from ${archiveName}: ${error.message}`
+    );
   } finally {
     await fsp.rm(tmpRoot, { recursive: true, force: true });
   }
+}
+
+async function stageBinary({
+  tmpRoot,
+  assetName,
+  sourceName,
+  destination,
+  platform,
+  required,
+  missingHint
+}) {
+  const extracted = path.join(tmpRoot, assetName, sourceName);
+  try {
+    await fsp.access(extracted, fs.constants.R_OK);
+  } catch {
+    if (required) {
+      throw new Error(missingHint || `archive is missing ${sourceName}`);
+    }
+    return null;
+  }
+
+  const tmpPath = `${destination}.download`;
+  await fsp.copyFile(extracted, tmpPath);
+  if (platform !== 'win32') {
+    await fsp.chmod(tmpPath, 0o755);
+  }
+  return { destination, tmpPath };
 }
 
 function execFile(file, args, options = {}) {
@@ -328,6 +452,15 @@ async function kinRepoExists(cwd) {
 async function assertRunnable(filePath, platform) {
   if (!(await isRunnable(filePath, platform))) {
     throw new Error(`kin binary not found or not executable: ${filePath}`);
+  }
+}
+
+async function assertDaemonProvisioned(kinBinaryPath, platform) {
+  const daemonPath = resolveDaemonBinaryPath(kinBinaryPath);
+  if (!(await isRunnable(daemonPath, platform))) {
+    throw new Error(
+      `kin-daemon was not provisioned next to ${kinBinaryPath}; the MCP server cannot start without it`
+    );
   }
 }
 

--- a/packages/kin-mcp/test/index.test.js
+++ b/packages/kin-mcp/test/index.test.js
@@ -8,8 +8,10 @@ import path from 'node:path';
 import test from 'node:test';
 
 import {
+  childEnv,
   ensureKinBinary,
   resolveCachedBinaryPath,
+  resolveDaemonBinaryPath,
   resolveReleaseAsset,
   resolveReleaseTag,
   runKinMcp
@@ -28,22 +30,26 @@ test('resolveReleaseAsset maps supported targets', () => {
   assert.deepEqual(resolveReleaseAsset('darwin', 'arm64'), {
     assetName: 'kin-macos-aarch64',
     archiveName: 'kin-macos-aarch64.tar.gz',
-    binaryName: 'kin'
+    binaryName: 'kin',
+    daemonBinaryName: 'kin-daemon'
   });
   assert.deepEqual(resolveReleaseAsset('darwin', 'x64'), {
     assetName: 'kin-macos-x86_64',
     archiveName: 'kin-macos-x86_64.tar.gz',
-    binaryName: 'kin'
+    binaryName: 'kin',
+    daemonBinaryName: 'kin-daemon'
   });
   assert.deepEqual(resolveReleaseAsset('linux', 'x64'), {
     assetName: 'kin-linux-x86_64',
     archiveName: 'kin-linux-x86_64.tar.gz',
-    binaryName: 'kin'
+    binaryName: 'kin',
+    daemonBinaryName: 'kin-daemon'
   });
   assert.deepEqual(resolveReleaseAsset('linux', 'arm64'), {
     assetName: 'kin-linux-aarch64',
     archiveName: 'kin-linux-aarch64.tar.gz',
-    binaryName: 'kin'
+    binaryName: 'kin',
+    daemonBinaryName: 'kin-daemon'
   });
 });
 
@@ -59,37 +65,53 @@ test('resolveReleaseTag prefixes versions with v', () => {
   assert.equal(resolveReleaseTag('v0.1.0-alpha.1'), 'v0.1.0-alpha.1');
 });
 
-test('ensureKinBinary downloads and verifies a release asset', async () => {
-  const tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), 'kin-mcp-download-'));
-  const assetName = 'kin-linux-x86_64';
-  const assetBytes = Buffer.from('#!/bin/sh\necho kin\n', 'utf8');
+async function buildReleaseArchive(tmpDir, assetName, { includeDaemon = true } = {}) {
+  const kinBytes = Buffer.from('#!/bin/sh\necho kin\n', 'utf8');
+  const daemonBytes = Buffer.from('#!/bin/sh\necho kin-daemon\n', 'utf8');
   const packageDir = path.join(tmpDir, assetName);
   const archivePath = path.join(tmpDir, `${assetName}.tar.gz`);
-  const version = '9.9.9-test';
 
   await fs.mkdir(packageDir);
-  await fs.writeFile(path.join(packageDir, 'kin'), assetBytes, { mode: 0o755 });
+  await fs.writeFile(path.join(packageDir, 'kin'), kinBytes, { mode: 0o755 });
+  if (includeDaemon) {
+    await fs.writeFile(path.join(packageDir, 'kin-daemon'), daemonBytes, { mode: 0o755 });
+  }
   cp.execFileSync('tar', ['-czf', archivePath, '-C', tmpDir, assetName]);
+  await fs.rm(packageDir, { recursive: true, force: true });
 
   const archiveBytes = await fs.readFile(archivePath);
+  await fs.rm(archivePath, { force: true });
   const checksum = crypto.createHash('sha256').update(archiveBytes).digest('hex');
+  return { archiveBytes, checksum, kinBytes, daemonBytes };
+}
 
+function startReleaseServer(version, assetName, archiveBytes, checksum) {
   const server = http.createServer((req, res) => {
     if (req.url === `/v${version}/${assetName}.tar.gz`) {
       res.writeHead(200, { 'content-type': 'application/octet-stream' });
       res.end(archiveBytes);
       return;
     }
-
     if (req.url === `/v${version}/${assetName}.tar.gz.sha256`) {
       res.writeHead(200, { 'content-type': 'text/plain; charset=utf-8' });
       res.end(`${checksum}  ${assetName}.tar.gz\n`);
       return;
     }
-
     res.writeHead(404);
     res.end('not found');
   });
+  return server;
+}
+
+test('ensureKinBinary downloads kin and its daemon from a release asset', async () => {
+  const tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), 'kin-mcp-download-'));
+  const assetName = 'kin-linux-x86_64';
+  const version = '9.9.9-test';
+  const { archiveBytes, checksum, kinBytes, daemonBytes } = await buildReleaseArchive(
+    tmpDir,
+    assetName
+  );
+  const server = startReleaseServer(version, assetName, archiveBytes, checksum);
 
   await new Promise(resolve => server.listen(0, '127.0.0.1', resolve));
   const address = server.address();
@@ -116,7 +138,39 @@ test('ensureKinBinary downloads and verifies a release asset', async () => {
         version
       })
     );
-    assert.equal(await fs.readFile(binaryPath, 'utf8'), assetBytes.toString('utf8'));
+    assert.equal(await fs.readFile(binaryPath, 'utf8'), kinBytes.toString('utf8'));
+
+    const daemonPath = resolveDaemonBinaryPath(binaryPath);
+    assert.equal(await exists(daemonPath), true);
+    assert.equal(await fs.readFile(daemonPath, 'utf8'), daemonBytes.toString('utf8'));
+  } finally {
+    await new Promise(resolve => server.close(resolve));
+    await fs.rm(tmpDir, { recursive: true, force: true });
+  }
+});
+
+test('ensureKinBinary fails with a precise message when the archive omits kin-daemon', async () => {
+  const tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), 'kin-mcp-nodaemon-'));
+  const assetName = 'kin-linux-x86_64';
+  const version = '9.9.9-test';
+  const { archiveBytes, checksum } = await buildReleaseArchive(tmpDir, assetName, {
+    includeDaemon: false
+  });
+  const server = startReleaseServer(version, assetName, archiveBytes, checksum);
+
+  await new Promise(resolve => server.listen(0, '127.0.0.1', resolve));
+  const address = server.address();
+  const baseUrl = `http://127.0.0.1:${address.port}`;
+  const env = {
+    KIN_MCP_CACHE_DIR: tmpDir,
+    KIN_MCP_RELEASE_BASE_URL: baseUrl
+  };
+
+  try {
+    await assert.rejects(
+      ensureKinBinary({ env, platform: 'linux', arch: 'x64', version }),
+      /kin-daemon/
+    );
   } finally {
     await new Promise(resolve => server.close(resolve));
     await fs.rm(tmpDir, { recursive: true, force: true });
@@ -169,6 +223,86 @@ test('runKinMcp refuses implicit init when .kin/ is missing', async () => {
     assert.equal(exitCode, 2);
     assert.match(stderr, /Run `kin init \.` first/);
     assert.equal(await exists(path.join(tmpDir, '.kin')), false);
+  } finally {
+    await fs.rm(tmpDir, { recursive: true, force: true });
+  }
+});
+
+test('childEnv defaults the agent-default tool profile and daemon binary', () => {
+  const kinBinary = '/cache/v1/kin-linux-x86_64/kin';
+  const next = childEnv({}, kinBinary, 'linux');
+  assert.equal(next.KIN_MCP_TOOL_PROFILE, 'agent-default');
+  assert.equal(next.KIN_DAEMON_BIN, '/cache/v1/kin-linux-x86_64/kin-daemon');
+});
+
+test('childEnv respects an explicit tool profile and daemon override', () => {
+  const kinBinary = '/cache/v1/kin-linux-x86_64/kin';
+  const next = childEnv(
+    { KIN_MCP_TOOL_PROFILE: 'benchmark', KIN_DAEMON_BIN: '/opt/kin-daemon' },
+    kinBinary,
+    'linux'
+  );
+  assert.equal(next.KIN_MCP_TOOL_PROFILE, 'benchmark');
+  assert.equal(next.KIN_DAEMON_BIN, '/opt/kin-daemon');
+});
+
+test('childEnv does not pin the daemon when a user supplies their own kin binary', () => {
+  const next = childEnv(
+    { KIN_MCP_KIN_BINARY: '/usr/local/bin/kin' },
+    '/usr/local/bin/kin',
+    'linux'
+  );
+  assert.equal(next.KIN_MCP_TOOL_PROFILE, 'agent-default');
+  assert.equal(next.KIN_DAEMON_BIN, undefined);
+});
+
+test('runKinMcp forwards the agent-default profile to kin mcp start', async () => {
+  const tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), 'kin-mcp-profile-'));
+  const binaryPath = path.join(tmpDir, 'kin');
+  const profilePath = path.join(tmpDir, 'profile.txt');
+  const script = `#!/bin/sh
+printf '%s' "$KIN_MCP_TOOL_PROFILE" > "${profilePath}"
+`;
+  await fs.writeFile(binaryPath, script, { mode: 0o755 });
+  await fs.mkdir(path.join(tmpDir, '.kin'));
+
+  try {
+    const discard = { write() {} };
+    const exitCode = await runKinMcp([], {
+      env: { KIN_MCP_KIN_BINARY: binaryPath },
+      cwd: tmpDir,
+      stdout: discard,
+      stderr: discard,
+      stdio: 'ignore'
+    });
+
+    assert.equal(exitCode, 0);
+    assert.equal(await fs.readFile(profilePath, 'utf8'), 'agent-default');
+  } finally {
+    await fs.rm(tmpDir, { recursive: true, force: true });
+  }
+});
+
+test('runKinMcp emits a guided fix when no binary can be provisioned', async () => {
+  const tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), 'kin-mcp-guided-'));
+  let stderr = '';
+  try {
+    const exitCode = await runKinMcp([], {
+      env: {
+        KIN_MCP_CACHE_DIR: tmpDir,
+        KIN_MCP_RELEASE_BASE_URL: 'http://127.0.0.1:1'
+      },
+      platform: 'linux',
+      arch: 'x64',
+      version: '9.9.9-test',
+      cwd: tmpDir,
+      stderr: { write(chunk) { stderr += chunk; } },
+      stdio: 'ignore'
+    });
+
+    assert.equal(exitCode, 1);
+    assert.match(stderr, /could not provision a runnable Kin/);
+    assert.match(stderr, /kin setup/);
   } finally {
     await fs.rm(tmpDir, { recursive: true, force: true });
   }

--- a/packages/kin-mcp/test/smoke-first-run.mjs
+++ b/packages/kin-mcp/test/smoke-first-run.mjs
@@ -1,0 +1,280 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Firelock, LLC
+
+// End-to-end first-run proof for the @kinlab/kin-mcp wrapper.
+//
+// Stages release `kin` + `kin-daemon` binaries into a wrapper-style cache (no
+// pre-existing daemon, no dev PATH state), initializes a throwaway repo, runs
+// the wrapper, and drives the MCP stdio protocol far enough to call one safe
+// Kin semantic tool (`kin_graph_status`). Exits non-zero on any failure.
+//
+// Usage:
+//   node test/smoke-first-run.mjs                 # auto-locate target/release
+//   KIN_BIN=/path/kin KIN_DAEMON_BIN=/path/kin-daemon node test/smoke-first-run.mjs
+//
+// The script is intentionally not part of `npm test`: it requires built Kin
+// binaries and spawns a real daemon, so it runs on demand / in release CI.
+
+import cp from 'node:child_process';
+import fs from 'node:fs/promises';
+import os from 'node:os';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+import { resolveCachedBinaryPath, resolveReleaseAsset } from '../src/index.js';
+
+const here = path.dirname(fileURLToPath(import.meta.url));
+const packageDir = path.dirname(here);
+const repoRoot = path.resolve(packageDir, '..', '..');
+
+function log(message) {
+  process.stderr.write(`[smoke] ${message}\n`);
+}
+
+async function isFile(candidate) {
+  try {
+    const stat = await fs.stat(candidate);
+    return stat.isFile();
+  } catch {
+    return false;
+  }
+}
+
+async function locateBinary(envKey, name) {
+  const explicit = process.env[envKey];
+  if (explicit) {
+    if (!(await isFile(explicit))) {
+      throw new Error(`${envKey}=${explicit} is not a file`);
+    }
+    return explicit;
+  }
+  for (const profile of ['release', 'debug']) {
+    const candidate = path.join(repoRoot, 'target', profile, name);
+    if (await isFile(candidate)) {
+      return candidate;
+    }
+  }
+  throw new Error(
+    `could not find ${name}; build it (cargo build --release -p kin-cli -p kin-daemon) ` +
+      `or set ${envKey}`
+  );
+}
+
+async function stageCache(cacheRoot, kinBin, daemonBin) {
+  const { assetName } = resolveReleaseAsset();
+  const cachedKin = resolveCachedBinaryPath({
+    env: { KIN_MCP_CACHE_DIR: cacheRoot }
+  });
+  const assetDir = path.dirname(cachedKin);
+  await fs.mkdir(assetDir, { recursive: true });
+  await fs.copyFile(kinBin, cachedKin);
+  await fs.chmod(cachedKin, 0o755);
+  const cachedDaemon = path.join(assetDir, 'kin-daemon');
+  await fs.copyFile(daemonBin, cachedDaemon);
+  await fs.chmod(cachedDaemon, 0o755);
+  log(`staged cache: ${assetName}/{kin,kin-daemon}`);
+  return cachedKin;
+}
+
+function framedRequest(id, method, params) {
+  return `${JSON.stringify({ jsonrpc: '2.0', id, method, params })}\n`;
+}
+
+class JsonRpcReader {
+  constructor() {
+    this.buffer = '';
+    this.waiters = new Map();
+  }
+
+  feed(chunk) {
+    this.buffer += chunk;
+    let newline;
+    while ((newline = this.buffer.indexOf('\n')) >= 0) {
+      const line = this.buffer.slice(0, newline).trim();
+      this.buffer = this.buffer.slice(newline + 1);
+      if (!line) {
+        continue;
+      }
+      let message;
+      try {
+        message = JSON.parse(line);
+      } catch {
+        continue;
+      }
+      if (message.id != null && this.waiters.has(message.id)) {
+        const { resolve } = this.waiters.get(message.id);
+        this.waiters.delete(message.id);
+        resolve(message);
+      }
+    }
+  }
+
+  await(id, timeoutMs) {
+    return new Promise((resolve, reject) => {
+      const timer = setTimeout(() => {
+        this.waiters.delete(id);
+        reject(new Error(`timed out waiting for response id=${id}`));
+      }, timeoutMs);
+      this.waiters.set(id, {
+        resolve: message => {
+          clearTimeout(timer);
+          resolve(message);
+        }
+      });
+    });
+  }
+}
+
+function killPid(pid) {
+  if (Number.isInteger(pid) && pid > 0) {
+    try {
+      process.kill(pid, 'SIGTERM');
+    } catch {
+      // already gone
+    }
+  }
+}
+
+async function killTree(child, kinRoot, cacheRoot) {
+  try {
+    const pidText = await fs.readFile(path.join(kinRoot, 'daemon.pid'), 'utf8');
+    killPid(Number.parseInt(pidText.trim(), 10));
+  } catch {
+    // no daemon.pid; nothing to clean
+  }
+
+  // Tear down the supervisor (and any other daemon) this run spawned from the
+  // throwaway cache so the smoke leaves no background processes behind.
+  try {
+    const listing = cp.execFileSync('ps', ['-Ao', 'pid=,command='], {
+      encoding: 'utf8'
+    });
+    for (const line of listing.split('\n')) {
+      const match = line.trim().match(/^(\d+)\s+(.*)$/);
+      if (match && match[2].includes(cacheRoot)) {
+        killPid(Number.parseInt(match[1], 10));
+      }
+    }
+  } catch {
+    // ps unavailable; idle timeout will reap the supervisor
+  }
+
+  if (!child.killed) {
+    child.kill('SIGTERM');
+  }
+}
+
+async function main() {
+  const kinBin = await locateBinary('KIN_BIN', 'kin');
+  const daemonBin = await locateBinary('KIN_DAEMON_BIN', 'kin-daemon');
+  log(`kin: ${kinBin}`);
+  log(`kin-daemon: ${daemonBin}`);
+
+  const workRoot = await fs.mkdtemp(path.join(os.tmpdir(), 'kin-mcp-smoke-'));
+  const cacheRoot = path.join(workRoot, 'cache');
+  const repoDir = path.join(workRoot, 'repo');
+  await fs.mkdir(repoDir, { recursive: true });
+  await fs.writeFile(
+    path.join(repoDir, 'main.rs'),
+    'fn greet() -> &\'static str {\n    "hello kin"\n}\n'
+  );
+
+  await stageCache(cacheRoot, kinBin, daemonBin);
+
+  // Explicit first-run init (no silent init): use the cached kin directly.
+  const cachedKin = resolveCachedBinaryPath({
+    env: { KIN_MCP_CACHE_DIR: cacheRoot }
+  });
+  log('kin init . (explicit first-run)');
+  cp.execFileSync(cachedKin, ['init', '.'], { cwd: repoDir, stdio: 'inherit' });
+
+  const wrapperBin = path.join(packageDir, 'bin', 'kin-mcp.js');
+  const env = {
+    ...process.env,
+    KIN_MCP_CACHE_DIR: cacheRoot,
+    KIN_DAEMON_IDLE_TIMEOUT_SECS: '30',
+    KIN_SUPERVISOR_IDLE_TIMEOUT_SECS: '30'
+  };
+  // Prove no reliance on a stale PATH binary or pre-existing daemon: scrub
+  // any daemon discovery hints the wrapper would otherwise inherit.
+  delete env.KIN_DAEMON_BIN;
+  delete env.KIN_DAEMON_URL;
+  delete env.KIN_SUPERVISOR_URL;
+  delete env.KIN_MCP_KIN_BINARY;
+  delete env.KIN_BINARY_PATH;
+
+  log('starting wrapper (kin-mcp -> kin mcp start), auto-spawning daemon...');
+  const child = cp.spawn(process.execPath, [wrapperBin], {
+    cwd: repoDir,
+    env,
+    stdio: ['pipe', 'pipe', 'inherit']
+  });
+
+  const reader = new JsonRpcReader();
+  child.stdout.setEncoding('utf8');
+  child.stdout.on('data', chunk => reader.feed(chunk));
+
+  let exitInfo = null;
+  child.on('exit', (code, signal) => {
+    exitInfo = { code, signal };
+  });
+
+  const timeoutMs = 180_000;
+  try {
+    child.stdin.write(
+      framedRequest(1, 'initialize', {
+        protocolVersion: '2024-11-05',
+        capabilities: {},
+        clientInfo: { name: 'kin-mcp-smoke', version: '0.0.0' }
+      })
+    );
+    const initResponse = await reader.await(1, timeoutMs);
+    if (initResponse.error) {
+      throw new Error(`initialize failed: ${JSON.stringify(initResponse.error)}`);
+    }
+    log('initialize ok');
+
+    child.stdin.write(framedRequest(2, 'tools/list', {}));
+    const listResponse = await reader.await(2, timeoutMs);
+    const tools = listResponse.result?.tools ?? [];
+    const toolNames = tools.map(tool => tool.name).sort();
+    log(`tools/list returned ${toolNames.length} tools (agent-default profile expected)`);
+    if (!toolNames.includes('kin_graph_status')) {
+      throw new Error(`kin_graph_status missing from tools/list: ${toolNames.join(', ')}`);
+    }
+    if (toolNames.length > 20) {
+      throw new Error(
+        `expected the small agent-default surface, got ${toolNames.length} tools`
+      );
+    }
+
+    child.stdin.write(
+      framedRequest(3, 'tools/call', { name: 'kin_graph_status', arguments: {} })
+    );
+    const callResponse = await reader.await(3, timeoutMs);
+    if (callResponse.error) {
+      throw new Error(`kin_graph_status failed: ${JSON.stringify(callResponse.error)}`);
+    }
+    const content = callResponse.result?.content ?? [];
+    const text = content.map(part => part.text ?? '').join('\n');
+    if (callResponse.result?.isError) {
+      throw new Error(`kin_graph_status returned an error result: ${text}`);
+    }
+    log('tools/call kin_graph_status ok');
+    log(`status payload (first 400 chars): ${text.slice(0, 400)}`);
+
+    process.stdout.write('SMOKE PASS: kin-mcp first-run reached a safe semantic tool\n');
+    process.stdout.write(
+      `SMOKE DETAIL: tools=${toolNames.length} sample=${toolNames.slice(0, 5).join(',')}\n`
+    );
+  } finally {
+    await killTree(child, path.join(repoDir, '.kin'), cacheRoot);
+    await fs.rm(workRoot, { recursive: true, force: true }).catch(() => {});
+    void exitInfo;
+  }
+}
+
+main().catch(error => {
+  process.stderr.write(`SMOKE FAIL: ${error.message}\n`);
+  process.exit(1);
+});


### PR DESCRIPTION
## FIR-1007: MCP/npm first-run agent path works without local developer state

Makes the `@kinlab/kin-mcp` npm wrapper + MCP server first-run path work from a clean machine, without relying on a locally-built `kin`, a stale PATH binary, or a pre-existing daemon.

### Root cause
The wrapper downloaded only the `kin` binary into its cache. When `kin mcp start` then auto-spawned the daemon, `find_daemon_binary()` looked for a sibling `kin-daemon` (which wasn't extracted) and fell back to `which::which("kin-daemon")` — failing on a clean machine with a cryptic `kin-daemon binary not found`. The wrapper also never set the FIR-963 `agent-default` profile, so npx-launched agents saw the full 60-tool surface.

### Changes (npm wrapper only — `packages/kin-mcp/`)
- **Provision the daemon.** Extract `kin-daemon` from the same release archive as a sibling of `kin` (the release ships both per FIR-967) and pin the CLI to it via `KIN_DAEMON_BIN`, so the path never depends on a local build, a stale PATH binary, or a pre-existing daemon. A daemon-less archive fails the install with a precise message.
- **Small default profile.** Default `KIN_MCP_TOOL_PROFILE=agent-default` (overridable) so first-run agents see the 13-tool curated surface.
- **Guided fix, not a stack trace.** When a runnable Kin can't be provisioned, emit a precise guided message that points into `kin setup`, exit 1.
- **Explicit first-run init preserved** (no silent init); added `--print-daemon-bin`.
- **Smoke proof.** `test/smoke-first-run.mjs` stages the binaries into a throwaway cache (no pre-existing daemon, no dev PATH state), runs the wrapper, and calls one safe semantic tool (`kin_graph_status`) end-to-end over MCP stdio.

### Verification
- `npm run lint` + `node --test`: 14/14 pass.
- `cargo fmt --check`: clean (no Rust touched).
- Smoke proof against freshly-built release binaries:
  ```
  tools/list returned 13 tools (agent-default profile expected)
  tools/call kin_graph_status ok
  SMOKE PASS: kin-mcp first-run reached a safe semantic tool
  SMOKE DETAIL: tools=13 sample=find_references,get_context_pack,graph_neighborhood,kin_graph_status,kin_provenance_query
  ```

### Notes for the acceptance matrix
- The smoke ran on macOS/arm64 against built release binaries. A truly clean fresh machine (real network download from GitHub releases, Linux/Windows-WSL2) still needs a CI/manual pass to fully prove the download + cross-OS extraction path.
- Surfaced (and confirmed fixed-on-`main`-source) that the Jun-15 release binary predated FIR-963: stale binaries return 60 tools. The fresh build returns 13. This argues for a release-binary refresh before publishing the wrapper.