### PR TITLE
docs: collapse quickstart/install into one guided setup path (FIR-1011)

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,9 +65,41 @@ read from the daemon and auto-start it as needed — no configuration required f
 
 ## Quickstart
 
+There is **one recommended first-run path**, and it's the same on macOS, Linux, and
+Windows (via WSL2): install → run the guided `kin setup` wizard → build the graph → verify.
 See [docs/quickstart.md](docs/quickstart.md) for the full end-to-end walkthrough.
 
-### 1. Initialize a repository
+### 1. Run guided setup
+
+The installer above already launches `kin setup` for you (run it again any time). It opens
+with **"What do you want Kin for?"** and asks for your **intent**, then configures the
+matching pieces:
+
+```sh
+kin setup
+```
+
+- **AI agents** (default) — wires Kin's MCP server into every detected AI client
+  (Claude Code, Cursor, Codex, Gemini, Windsurf), plus shell integration and daemon
+  auto-start. The smallest path to value.
+- **Local-only** — shell integration + daemon auto-start; no AI client config.
+- **Editor** — local-only, plus how to install the `kin-editor` VS Code extension.
+- **Hosted / KinLab** — local setup, plus a note that hosted connect is coming soon (not
+  yet a first-run flow).
+- **Advanced / manual** — choose shell, per-client MCP, and daemon options yourself.
+
+*Flags* (global; `kin setup --intent agent --no-interactive` for scripts/CI):
+- `--intent <local|agent|editor|hosted|advanced>`: pick the first-run intent up front.
+- `--shell <zsh|bash|powershell>`: target shell for profile updates.
+- `--auto-daemon`: force daemon auto-start on (default on for every intent).
+- `--no-interactive`: run with defaults / provided flags (default intent: `agent`).
+
+*Subcommands:*
+- `kin setup status [--json]`: probe and show what's installed (the health checklist).
+- `kin setup doctor [--fix]` (or top-level `kin doctor [--fix]`): run health checks and
+  optionally apply safe repairs.
+
+### 2. Initialize a repository
 
 Build a semantic graph over your codebase:
 
@@ -81,7 +113,7 @@ kin init
 - `--git-history <off|recent|full>`: Git history import depth (default: `recent`).
 - `--no-lsp`: Skip LSP enrichment for a faster, tree-sitter-only init.
 
-### 2. Add embeddings (enables semantic search)
+### 3. Add embeddings (enables semantic search)
 
 `kin init` builds the graph instantly without embeddings. Run `kin embed` to add the
 vector index that powers semantic search and `kin locate`:
@@ -94,22 +126,23 @@ Embeddings are generated locally with `nomic-embed-text-v1.5` (768 dimensions; o
 via `KIN_EMBED_MODEL_ID`). `kin status --json` reports embedding coverage under its
 `enrichment` block (`embeddingsIndexed` / `embeddingsPending` / `embeddingsTotal`).
 
-### 3. Configure your system and shell
+### 4. Verify
 
-Run the setup wizard, or run health checks at any time:
+Run the health checklist any time — it probes real filesystem, daemon, and agent state:
 
 ```sh
-kin setup
+kin setup status
 ```
 
-*Options:*
-- `status`: Show what's installed.
-- `doctor`: Run a quick health check.
-- `--mode <native|compatibility>`: Repository operation mode.
-- `--shell <zsh|bash|powershell>`: Target shell for profile updates.
-- `--auto-daemon`: Auto-start `kin-daemon` when entering workspaces.
+Checks cover the `kin` and `kin-daemon` binaries, VFS projection (macOS/Linux; **n/a** on
+native Windows), shell integration, repository init, AI-client MCP config (the
+`agent-default` profile), editor extension, KinLab connect (**n/a** — coming soon), and
+semantic query readiness (**STALE** until you run `kin embed`). Failing checks print their
+own `fix:` line; `kin doctor --fix` applies the safe repairs. See
+[docs/quickstart.md](docs/quickstart.md#8-verify-your-setup-kin-setup-status) for the full
+check table and what to do for each state.
 
-### 4. Everyday commands
+### 5. Everyday commands
 
 - **Status of the working copy**:
   ```sh
@@ -145,14 +178,16 @@ kin setup
 ## MCP Server Integration
 
 Kin ships with a built-in MCP (Model Context Protocol) server that exposes semantic tools
-to AI assistants (Claude, Cursor, Gemini, Codex, etc.). It runs as a stdio server that the
-MCP client launches as a subprocess:
+to AI assistants (Claude, Cursor, Gemini, Codex, Windsurf, etc.). The **AI agents** intent
+in `kin setup` wires this up for every detected client automatically — there is nothing
+else to configure. The wizard writes a `kin` server entry running `kin mcp start --global`
+with `KIN_MCP_TOOL_PROFILE=agent-default` (the small curated tool surface).
 
-```sh
-kin mcp start
-```
-
-For the full tool surface, see [docs/mcp-tools.md](docs/mcp-tools.md).
+`kin mcp start` runs as a stdio server that the MCP client launches as a subprocess; you
+normally do not run it by hand. To wire up a client manually, use the npm wrapper
+(`@kinlab/kin-mcp`), or see the exact config and config-file locations, read the
+[Advanced configuration](docs/quickstart.md#9-advanced-configuration) section of the
+quickstart. For the full tool surface, see [docs/mcp-tools.md](docs/mcp-tools.md).
 
 ---
 

--- a/docs/mcp-tools.md
+++ b/docs/mcp-tools.md
@@ -12,6 +12,35 @@ daemon; `semantic_locate` returns an explicit error in offline/no-daemon mode.
 
 ---
 
+## Configuring the server
+
+The recommended way to expose these tools is the guided wizard: run `kin setup` and choose
+the **AI agents** intent. It writes Kin's MCP server entry into every detected client
+(Claude Code, Cursor, Codex CLI, Gemini CLI, Windsurf) with the curated tool profile, and
+adds a Kin-first discovery reminder to your agent instruction files. `kin setup status`
+then verifies each client config.
+
+The wizard writes this entry (and `KIN_MCP_TOOL_PROFILE=agent-default` is what selects the
+small curated surface below instead of the full internal one):
+
+```json
+{
+  "mcpServers": {
+    "kin": {
+      "command": "kin",
+      "args": ["mcp", "start", "--global"],
+      "env": { "KIN_MCP_TOOL_PROFILE": "agent-default" }
+    }
+  }
+}
+```
+
+To wire a client up by hand, or to use the npm wrapper (`@kinlab/kin-mcp`, which defaults
+to the same `agent-default` profile), see
+[Advanced configuration](quickstart.md#9-advanced-configuration) in the quickstart.
+
+---
+
 ## 1. Retrieval & Codebase Exploration
 *Tools:* `semantic_search`, `semantic_locate`, `get_entity`, `get_entity_source`, `get_entity_body`, `get_context_pack`, `explore_codebase`, `graph_neighborhood`
 

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -1,46 +1,98 @@
 # Kin Quickstart Guide
 
-This guide walks you through installing Kin, initializing a repository, and running the
-core semantic commands.
+This is the recommended first-run path for Kin. One flow works on macOS, Linux, and
+Windows (via WSL2):
+
+1. **Install** the binaries with the one-line installer.
+2. **`kin setup`** — answer a couple of questions; the guided wizard configures your
+   shell, daemon, and AI clients.
+3. **`kin init`** + **`kin embed`** — build the semantic graph and the vector index.
+4. **Verify** with `kin setup status` and read the health checklist.
+
+Manual / per-tool configuration is available in the
+[Advanced configuration](#9-advanced-configuration) section, but you do not need it for a
+normal first run.
 
 ---
 
 ## 1. Install
 
-Run the installer:
+### macOS and Linux
 
 ```sh
 curl -fsSL https://get.kinlab.dev/install | sh
 ```
 
-This downloads the latest release from GitHub, installs the `kin` and `kin-vfs` binaries
-into `~/.kin/bin`, and updates your shell profile (`.zshrc` / `.bashrc`). To skip the
-setup wizard during install, set `KIN_NO_SETUP=1`.
+The installer downloads the latest release from GitHub, **verifies its SHA-256 checksum**
+(and refuses to install an unverified or tampered download), installs the `kin` and
+`kin-daemon` binaries — plus the optional `kin-vfs` projection client and shim where the
+archive bundles them — into `~/.kin/bin` (and `~/.kin/lib`), updates your shell profile
+(`.zshrc` / `.bashrc`), and then runs the `kin setup` wizard. `kin-daemon` is mandatory;
+the installer aborts cleanly rather than leaving a daemon-less install. Re-running the
+installer upgrades an existing install in place and reports the version change.
 
-> **Windows:** run Kin inside WSL2. See [windows-wsl2.md](./windows-wsl2.md).
+### Windows
+
+On native Windows, use PowerShell:
+
+```powershell
+irm https://get.kinlab.dev/install.ps1 | iex
+```
+
+The native Windows build is a **limited, vector-free convenience binary with no filesystem
+projection** — the installer prints this up front. For the complete, vector-enabled Kin
+with working projection, install under **WSL2** and follow the Linux path inside it. See
+[windows-wsl2.md](./windows-wsl2.md).
+
+### Installer options
+
+Configure the installer with environment variables (supported by both `install.sh` and
+`install.ps1`):
+
+- `KIN_VERSION`: pin a specific version (e.g. `0.1.0`); otherwise the latest release is
+  resolved automatically.
+- `KIN_DIR`: custom install directory (defaults to `~/.kin`).
+- `KIN_NO_SETUP=1`: skip the `kin setup` wizard after the binaries are installed (run
+  `kin setup` yourself when ready).
+- `KIN_BASE_URL`: install from a mirror or local path instead of GitHub releases
+  (offline / airgapped installs and CI smoke tests).
 
 ---
 
-## 2. First-time setup
+## 2. Guided setup (`kin setup`)
 
-Run the interactive setup wizard to configure shell hooks, daemon auto-start, and health
-checks:
+`kin setup` is the guided wizard the installer launches for you (run it again any time).
+It opens with **"What do you want Kin for?"** and asks for your **intent** rather than a
+bag of independent toggles:
+
+| Intent | What it configures |
+| --- | --- |
+| **AI agents** (default) | Kin's MCP server for every detected AI client, plus shell integration and daemon auto-start. The smallest path to value. |
+| **Local-only** | Shell integration + daemon auto-start; no AI client config. |
+| **Editor** | Local-only, plus how to install the `kin-editor` VS Code extension. |
+| **Hosted / KinLab** | Local setup, plus a note that hosted connect is coming soon (see below). |
+| **Advanced / manual** | Choose shell, per-client MCP, and daemon options yourself. |
+
+You can pre-select non-interactively (handy in scripts / CI):
 
 ```sh
-kin setup
+kin setup --intent agent --no-interactive
 ```
 
-Run health checks at any time:
+Other flags (`global`, honored across every intent):
 
-```sh
-kin setup doctor
-```
+- `--intent <local|agent|editor|hosted|advanced>`: pick the first-run intent up front.
+- `--shell <zsh|bash|powershell>`: target a specific shell for the profile update.
+- `--auto-daemon`: force daemon auto-start on (enabled by default for every intent).
+- `--no-interactive`: run with defaults / provided flags (no prompts). The
+  non-interactive default intent is **agent**.
 
-Show what components are installed:
+When the wizard finishes, it prints the **health checklist** (the same engine as
+`kin setup status`, see step 8) and your next steps.
 
-```sh
-kin setup status
-```
+> **Hosted / KinLab is not yet a first-run flow.** There is no public `kin login` /
+> connect command shipped today. The wizard is honest about this; your local setup is
+> fully functional in the meantime.
 
 ---
 
@@ -57,16 +109,18 @@ kin init path/to/project
 ```
 
 *Flags:*
-- `--git-history <off|recent|full>`: How much Git history to import into the graph on init (default: `recent`).
-- `--force`: Initialize even if a `.git/` directory is already present.
-- `--no-lsp`: Skip LSP enrichment (faster, tree-sitter-only init).
+- `--git-history <off|recent|full>`: how much Git history to import into the graph on init
+  (default: `recent`).
+- `--force`: initialize even if a `.git/` directory is already present.
+- `--no-lsp`: skip LSP enrichment (faster, tree-sitter-only init).
 
 ---
 
 ## 4. Add embeddings for semantic search
 
 `kin init` builds the graph instantly **without** embeddings. To enable semantic
-(vector) search and `kin locate`, build the vector index:
+(vector) search, `kin locate`, and the MCP `semantic_locate` tool, build the vector
+index:
 
 ```sh
 kin embed
@@ -81,7 +135,8 @@ kin status --json   # see the "enrichment" block: embeddingsIndexed / embeddings
 
 > Until embedding is complete, `kin search --semantic` and `kin locate` degrade
 > gracefully (vector hits over whatever is already embedded, plus a text fallback) and
-> report their coverage honestly rather than erroring.
+> report their coverage honestly rather than erroring. In the health checklist, semantic
+> query readiness shows **yellow / STALE** until the vector index exists.
 
 ---
 
@@ -155,39 +210,183 @@ kin locate "users can't reset their password" --explain
 
 ---
 
-## 7. Model Context Protocol (MCP) setup
+## 7. Using Kin from an AI agent (MCP)
 
-Kin exposes its semantic tools to AI agents over MCP.
+If you chose the **AI agents** intent in step 2, `kin setup` already wrote Kin's MCP
+server entry into every detected AI client (Claude Code, Cursor, Codex CLI, Gemini CLI,
+Windsurf) and added a Kin-first discovery reminder to your agent instruction files. There
+is **nothing else to configure** — open your agent in a Kin repository and ask it to use
+the semantic tools:
 
-### Start the MCP server
-
-`kin mcp start` launches the MCP **stdio** server. You normally do not run this by hand —
-your AI client launches it as a subprocess (see the config below):
-
-```sh
-kin mcp start
+```
+Use Kin to explore this codebase: run semantic_locate to find the
+main entry point, then get_context_pack on that file.
 ```
 
-### Configure your AI client
-
-Add the Kin MCP server to your client's configuration (e.g.
-`claude_desktop_config.json`):
+The wizard writes this entry to each client:
 
 ```json
 {
   "mcpServers": {
     "kin": {
       "command": "kin",
-      "args": ["mcp", "start"]
+      "args": ["mcp", "start", "--global"],
+      "env": { "KIN_MCP_TOOL_PROFILE": "agent-default" }
     }
   }
 }
 ```
 
-> Vector-backed MCP retrieval (`semantic_locate`) and the stateful session/transaction/
-> review/work tools operate against the repo's running Kin daemon. Enable
-> `kin setup --auto-daemon` (or start the daemon yourself) so these tools have a live
-> graph to query — `semantic_locate` returns an explicit error in offline/no-daemon mode.
+`KIN_MCP_TOOL_PROFILE=agent-default` exposes the small curated tool surface instead of the
+full internal one. (The wizard writes an absolute path to the installed `kin` binary as
+the `command`, so the entry works in agent processes that do not inherit your `PATH`.)
 
-Once configured, your assistant can use the semantic tools listed in the
-[MCP Tools Reference](mcp-tools.md).
+> Vector-backed MCP retrieval (`semantic_locate`) and the stateful session / transaction /
+> work / review tools operate against the repo's running Kin daemon. Daemon auto-start is
+> on by default, so these tools have a live graph to query — `semantic_locate` returns an
+> explicit error in offline / no-daemon mode.
+
+For the full tool surface, see the [MCP Tools Reference](mcp-tools.md). To wire up a
+client by hand (or use the npm wrapper), see
+[Advanced configuration](#9-advanced-configuration).
+
+---
+
+## 8. Verify your setup (`kin setup status`)
+
+Run the health checklist at any time. It probes real filesystem, daemon, and agent state —
+nothing is assumed healthy:
+
+```sh
+kin setup status          # human-readable table
+kin setup status --json   # machine-readable report
+```
+
+Each line shows a status mark:
+
+- `✓` **ok** — healthy.
+- `✗` **MISSING** / **MISCONFIGURED** — failing; these are the only states that make the
+  overall report unhealthy.
+- `!` **STALE** — present but not fully ready (e.g. embeddings pending).
+- `→` **n/a** — unsupported / not applicable on this platform or context.
+
+The checks (IDs as emitted in `--json`):
+
+| Check (id) | What "ok" means |
+| --- | --- |
+| `kin_binary` | The `kin` binary resolved (reports version + path). |
+| `kin_daemon_binary` | `kin-daemon` found beside `kin` or on `PATH`. |
+| `vfs_projection` | The VFS shim is installed and non-zero in `~/.kin/lib` (macOS/Linux). On Windows this is **n/a** — projection uses ProjFS (planned), not the shell-injected shim. |
+| `repo_init` | The current directory is inside a Kin repository. |
+| `shell_path` | The `kin-vfs` shell hook is installed and sourced from your rc. |
+| `mcp_client_*` (e.g. `mcp_client_claude`) | A detected AI client has the `kin` MCP server with the `agent-default` profile. With no client configs present, a single `mcp_clients` check reports ok ("nothing to configure"). |
+| `editor` | The `kin-editor` VS Code extension is detected in `~/.vscode/extensions`. **n/a** if not found / non-VS Code. |
+| `kinlab_connect` | A stored KinLab credential is present. **n/a** today — hosted connect is not yet a first-run flow. |
+| `semantic_query_readiness` | The daemon is reachable and the vector index exists. **yellow/STALE** until you run `kin embed`; **MISSING** if the daemon isn't running. |
+
+### When a check is yellow or red
+
+Each failing/incomplete check prints its own `fix:` line. The most common ones:
+
+- **`shell_path` / `mcp_client_*` red** → run `kin doctor --fix` (or `kin setup`) to
+  reinstall the shell hook and re-merge the MCP entries.
+- **`semantic_query_readiness` STALE** → run `kin embed` to build the vector index.
+- **`semantic_query_readiness` MISSING** → run any `kin` command in the repo to auto-start
+  the daemon.
+- **`repo_init` MISSING** → run `kin init .` to initialize a repository here.
+- **`vfs_projection` MISSING** → run `kin setup` to (re)install the shim into `~/.kin/lib`.
+- **`kin_daemon_binary` MISSING** → reinstall Kin so `kin-daemon` lands beside `kin`.
+
+`kin doctor` (or `kin setup doctor`) runs the same checklist; add `--fix` to apply the
+safe repairs (shell hook, MCP configs, config dirs, stale-daemon cleanup) and then re-run
+the checks to show the post-fix state:
+
+```sh
+kin doctor          # report only
+kin doctor --fix    # apply safe repairs, then re-check
+```
+
+---
+
+## 9. Advanced configuration
+
+You do not need anything here for a normal first run — the guided wizard covers it. This
+section is for manual wiring, troubleshooting, and non-standard environments.
+
+### Manual MCP client configuration
+
+If you skipped the wizard's agent step, or your client wasn't auto-detected, add Kin's MCP
+server to your client's config by hand. Match the wizard exactly — including the
+`agent-default` profile:
+
+```json
+{
+  "mcpServers": {
+    "kin": {
+      "command": "kin",
+      "args": ["mcp", "start", "--global"],
+      "env": { "KIN_MCP_TOOL_PROFILE": "agent-default" }
+    }
+  }
+}
+```
+
+Config file locations the wizard targets (and `kin setup status` inspects):
+
+| Client | Config path |
+| --- | --- |
+| Claude Code | `~/.claude.json` (falls back to `~/.claude/config.json`) |
+| Cursor | `~/.cursor/mcp.json` |
+| Codex CLI | `~/.codex/mcp.json` |
+| Gemini CLI | `~/.gemini/settings.json` |
+| Windsurf | `~/.codeium/windsurf/mcp_config.json` |
+
+`kin mcp start` launches the MCP **stdio** server. You normally do not run this by hand —
+your AI client launches it as a subprocess via the config above.
+
+### npm wrapper (`@kinlab/kin-mcp`)
+
+If you'd rather not install the binaries first, the published `@kinlab/kin-mcp` package
+downloads, checksum-verifies, and runs Kin's MCP server for you. Point your client at it:
+
+```json
+{
+  "mcpServers": {
+    "kin": {
+      "command": "npx",
+      "args": ["-y", "@kinlab/kin-mcp"]
+    }
+  }
+}
+```
+
+On first run it provisions `kin-daemon` next to `kin`, defaults
+`KIN_MCP_TOOL_PROFILE=agent-default`, starts (or reuses) the repo daemon, and **requires an
+explicit `kin init`** (no silent init) unless you set `KIN_MCP_AUTO_INIT=1`. Requires
+Node.js 20+ on macOS or Linux (Windows users go through WSL2). See the
+[`@kinlab/kin-mcp` README](../packages/kin-mcp/README.md) for cache locations and the full
+environment-variable surface.
+
+### Runtime / daemon configuration
+
+The Kin daemon is the canonical authority for graph truth and auto-starts as needed for
+normal use. The escape hatches:
+
+- `KIN_NO_DAEMON=1`: disable daemon auto-start (use only an already-running daemon or
+  `KIN_DAEMON_URL`).
+- `KIN_DAEMON_URL`: point the CLI at an explicit daemon endpoint.
+- `KIN_ALLOW_DAEMON_BOOTSTRAP_ADMIN=1`: offline/admin escape hatch that lets the read-only
+  in-process commands fall back to reading the local `.kin` snapshot directly. Never used
+  for writes — all graph mutations still route through the daemon.
+
+---
+
+## 10. Removing Kin
+
+Kin is ejectable — there is no data lock-in:
+
+```sh
+kin eject [--force]
+```
+
+This removes Kin and restores files to their pre-init state.

--- a/docs/windows-wsl2.md
+++ b/docs/windows-wsl2.md
@@ -33,17 +33,25 @@ against.
    Reboot if prompted, then open the **Ubuntu** shell to finish first-time
    user setup.
 
-2. Inside the WSL2 Linux shell, install Kin the same way you would on Linux:
+2. Inside the WSL2 Linux shell, install Kin the same way you would on Linux —
+   this is the **same one-path flow** documented in the
+   [quickstart](./quickstart.md):
 
    ```sh
    curl -fsSL https://get.kinlab.dev/install | sh
    ```
 
+   The installer launches the `kin setup` guided wizard for you. Answer its
+   "What do you want Kin for?" prompt (the **AI agents** intent is the default),
+   then verify with `kin setup status` — inside WSL2 the VFS projection check is
+   supported, unlike native Windows.
+
 3. Work on your repositories from inside the WSL2 filesystem (e.g.
-   `~/projects/...`). Initialize and use Kin as usual:
+   `~/projects/...`). Initialize, embed, and use Kin as usual:
 
    ```sh
    kin init
+   kin embed     # build the vector index for semantic search / kin locate
    kin status
    ```
 
@@ -53,7 +61,19 @@ against.
 
 ## Native Windows binary (limited)
 
-If you only need the core CLI and cannot use WSL2, the release page publishes a
-native `kin-windows-x86_64.zip`. It is **vector-free** and does not provide the
-transparent filesystem projection. Treat it as experimental; WSL2 remains the
-recommended path.
+If you only need the core CLI and cannot use WSL2, install with PowerShell:
+
+```powershell
+irm https://get.kinlab.dev/install.ps1 | iex
+```
+
+The installer prints the limitation up front, verifies the download's SHA-256
+checksum, and still requires `kin-daemon` (it aborts on a daemon-less archive).
+The native `kin-windows-x86_64.zip` it installs is **vector-free** (semantic
+search disabled) and does **not** provide the transparent filesystem projection:
+projection relies on Unix library injection (`LD_PRELOAD` /
+`DYLD_INSERT_LIBRARIES`), which native Windows does not offer. Windows projection
+is planned via ProjFS — an optional feature started by an explicit daemon init,
+not injected by the shell hook — so on native Windows the `vfs_projection` health
+check reports **n/a** rather than ok. Treat the native binary as experimental;
+WSL2 remains the recommended path.


### PR DESCRIPTION
## Summary

Collapses the public quickstart/install docs into **one recommended first-run path** that is identical on macOS, Windows (via WSL2), and Linux:

```
install  ->  kin setup (guided wizard)  ->  kin init / kin embed  ->  verify with kin setup status
```

Manual MCP JSON / per-client config is kept reachable but **secondary**, in an advanced/troubleshooting section, and now matches the merged behavior. Docs-only — no code or test changes.

## Docs changed + one-path structure

- **`docs/quickstart.md`** — rewritten as the canonical one-path guide. Opens with the four-step flow, then: Install (macOS/Linux + Windows/WSL2 + installer env vars) -> Guided setup (`kin setup` intent menu) -> Initialize -> Embed -> workflow/exploration -> Using Kin from an AI agent -> **Verify (`kin setup status`)** with the full health-check table and per-state fixes -> **Advanced configuration** (manual MCP JSON, npm wrapper, daemon env vars) -> Removing Kin.
- **`README.md`** — Quickstart now leads with `kin setup` + the intent menu and adds a **Verify** step. MCP section points at the wizard and the advanced docs for manual wiring. The FIR-1006 installer block (checksums, daemon guard, `KIN_BASE_URL`, upgrade messaging, Windows limitation) is preserved untouched.
- **`docs/mcp-tools.md`** — adds a "Configuring the server" section that leads with the wizard + `agent-default` profile; manual/npm config pointed to the advanced quickstart section. Tool reference unchanged.
- **`docs/windows-wsl2.md`** — WSL2 path now uses the same guided flow and adds `kin embed`; native-Windows section is explicit that projection is unavailable (ProjFS planned) and that `vfs_projection` reports n/a there.

`docs/thesis.md` and `docs/write-authority-model.md` are untouched.

## Acceptance criteria -> doc section

1. **One primary first-run path (macOS/Windows/Linux)** -> quickstart top "recommended first-run path" + sections 1-2-3-4-8; README Quickstart steps 1-4.
2. **Manual MCP JSON moved to advanced + matches behavior** -> quickstart section 9 (Advanced configuration): exact `command`/`args: ["mcp","start","--global"]`/`env.KIN_MCP_TOOL_PROFILE=agent-default`, the per-client config paths, and the `@kinlab/kin-mcp` npm wrapper.
3. **Every required first-run component, accurately** -> health-check table in quickstart section 8 (`kin`, `kin-daemon`, VFS projection with the honest native-Windows ProjFS limitation + WSL2 path, MCP client config, editor, KinLab connect marked coming soon / not yet a first-run flow).
4. **Windows + Linux differences explicit** -> quickstart Install (Windows subsection + WSL2 link), `docs/windows-wsl2.md`, and the projection n/a note — not hidden behind macOS-only assumptions.
5. **Expected success output / health checklist + yellow/red guidance** -> quickstart section 8 mirrors the real `kin setup status` check IDs and green/yellow/red marks, plus a "When a check is yellow or red" subsection and `kin doctor --fix`.

## Verified against merged source

- Wizard intents, flags, MCP entry: `crates/kin-cli/src/commands/setup.rs` (intent menu/defaults `run_wizard`/`resolve_intent` L1033-1106; `kin_mcp_entry` `agent-default` L682-698; client config paths L1374-1396) and CLI flags `crates/kin-cli/src/main.rs` L778-797, `SetupAction` L1456-1469, top-level `Doctor` L772-777.
- Health checks (IDs/statuses/marks): `crates/kin-cli/src/commands/health.rs` L89-109 (check list), `vfs_projection` Windows-unsupported L172-188, `kinlab_connect` not-a-first-run-flow L493-512, `semantic_query_readiness` L514-564; marks in `setup.rs` `print_human_report` L1491-1523.
- Installers: `scripts/install.sh` (checksum verify L126-158, mandatory daemon L174-205, `KIN_BASE_URL` L24-26, upgrade L252-256, runs `kin setup` L262-281) and `scripts/install.ps1` (Windows limitation L57-65, checksum L113-154, mandatory daemon L165-199).
- npm wrapper: `packages/kin-mcp/README.md` + `package.json` (`@kinlab/kin-mcp`, `agent-default` default, explicit `kin init`).

## Notes

- The push triggered a server-side `REMOTE_AUDIT_FAIL` referencing two pre-existing commits from earlier today (67c0ebb, 7fb5f1f) by other contributors — unrelated to this docs-only branch.
- If CI `Check & Test` flakes on the known parallel-suite lock-contention test (`...graph.lock... Resource temporarily unavailable`), that is a pre-existing flake unrelated to these docs.