### PR TITLE
deps: kin-lsp 0.2.0 (fix red main — last stale kin-model 0.1.0)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1019,7 +1019,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users 0.5.2",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -1118,7 +1118,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -1788,7 +1788,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "19753d40da53d0ec41604750eeb969097a90fb2d7f7992730d904541c04e2c19"
 dependencies = [
  "bstr",
- "hashbrown 0.17.1",
+ "hashbrown 0.16.1",
 ]
 
 [[package]]
@@ -2935,7 +2935,7 @@ dependencies = [
  "kin-lsp",
  "kin-mcp",
  "kin-migrate",
- "kin-model 0.2.0",
+ "kin-model",
  "kin-parser",
  "kin-projection",
  "kin-ranking",
@@ -2976,7 +2976,7 @@ version = "0.2.1"
 dependencies = [
  "kin-blobs",
  "kin-db",
- "kin-model 0.2.0",
+ "kin-model",
  "pretty_assertions",
  "serde",
  "serde_json",
@@ -2996,7 +2996,7 @@ dependencies = [
  "kin-blobs",
  "kin-db",
  "kin-index",
- "kin-model 0.2.0",
+ "kin-model",
  "kin-parser",
  "pretty_assertions",
  "serde",
@@ -3029,7 +3029,7 @@ dependencies = [
  "kin-index",
  "kin-lsp",
  "kin-mcp",
- "kin-model 0.2.0",
+ "kin-model",
  "kin-parser",
  "kin-projection",
  "kin-reconcile",
@@ -3071,7 +3071,7 @@ dependencies = [
  "hex",
  "hf-hub",
  "kin-infer",
- "kin-model 0.2.0",
+ "kin-model",
  "kin-search",
  "kin-vector",
  "memmap2",
@@ -3104,7 +3104,7 @@ dependencies = [
  "hex",
  "kin-blobs",
  "kin-db",
- "kin-model 0.2.0",
+ "kin-model",
  "pretty_assertions",
  "rayon",
  "sha2",
@@ -3120,7 +3120,7 @@ dependencies = [
  "hex",
  "kin-blobs",
  "kin-db",
- "kin-model 0.2.0",
+ "kin-model",
  "kin-parser",
  "kin-projection",
  "notify",
@@ -3169,7 +3169,7 @@ dependencies = [
  "kin-git",
  "kin-index",
  "kin-migrate",
- "kin-model 0.2.0",
+ "kin-model",
  "kin-parser",
  "kin-projection",
  "kin-reconcile",
@@ -3185,11 +3185,11 @@ dependencies = [
 
 [[package]]
 name = "kin-lsp"
-version = "0.1.0"
+version = "0.2.0"
 source = "sparse+https://kinlab.ai/registry/cargo/"
-checksum = "508c8fca105f311561412de969104cd29a153a1666dfe6cb48e41b6bb89280e4"
+checksum = "ce704b8a25f37b58311502fe0bcfb4ad275fdcfc50ab09eddb94bd9301f2c515"
 dependencies = [
- "kin-model 0.1.0",
+ "kin-model",
  "serde",
  "serde_json",
  "thiserror 2.0.18",
@@ -3206,7 +3206,7 @@ dependencies = [
  "kin-context",
  "kin-core",
  "kin-db",
- "kin-model 0.2.0",
+ "kin-model",
  "kin-parser",
  "kin-ranking",
  "kin-review",
@@ -3234,7 +3234,7 @@ dependencies = [
  "kin-db",
  "kin-git",
  "kin-index",
- "kin-model 0.2.0",
+ "kin-model",
  "kin-parser",
  "pretty_assertions",
  "reqwest",
@@ -3244,24 +3244,6 @@ dependencies = [
  "tempfile",
  "thiserror 2.0.18",
  "tracing",
-]
-
-[[package]]
-name = "kin-model"
-version = "0.1.0"
-source = "sparse+https://kinlab.ai/registry/cargo/"
-checksum = "6019f1ae1d53cc719e426724f347c669af1a967d35d12917bf8f27b87ae4cb4d"
-dependencies = [
- "chrono",
- "hex",
- "kin-blobs",
- "kin-vector",
- "schemars",
- "serde",
- "serde_json",
- "sha2",
- "thiserror 2.0.18",
- "uuid",
 ]
 
 [[package]]
@@ -3286,7 +3268,7 @@ dependencies = [
 name = "kin-parser"
 version = "0.2.1"
 dependencies = [
- "kin-model 0.2.0",
+ "kin-model",
  "pretty_assertions",
  "serde_json",
  "sha2",
@@ -3317,7 +3299,7 @@ version = "0.2.1"
 dependencies = [
  "kin-blobs",
  "kin-db",
- "kin-model 0.2.0",
+ "kin-model",
  "pretty_assertions",
  "proptest",
  "serde_json",
@@ -3330,7 +3312,7 @@ dependencies = [
 name = "kin-ranking"
 version = "0.2.1"
 dependencies = [
- "kin-model 0.2.0",
+ "kin-model",
  "serde",
  "serde_json",
 ]
@@ -3342,7 +3324,7 @@ dependencies = [
  "kin-blobs",
  "kin-db",
  "kin-index",
- "kin-model 0.2.0",
+ "kin-model",
  "kin-parser",
  "kin-projection",
  "notify",
@@ -3365,7 +3347,7 @@ dependencies = [
  "flate2",
  "hex",
  "kin-blobs",
- "kin-model 0.2.0",
+ "kin-model",
  "percent-encoding",
  "serde",
  "serde_json",
@@ -3385,7 +3367,7 @@ name = "kin-remote"
 version = "0.2.1"
 dependencies = [
  "chrono",
- "kin-model 0.2.0",
+ "kin-model",
  "pretty_assertions",
  "serde",
  "serde_json",
@@ -3402,7 +3384,7 @@ version = "0.2.1"
 dependencies = [
  "kin-blobs",
  "kin-db",
- "kin-model 0.2.0",
+ "kin-model",
  "pretty_assertions",
  "serde",
  "serde_json",
@@ -3418,7 +3400,7 @@ dependencies = [
  "chrono",
  "hex",
  "kin-blobs",
- "kin-model 0.2.0",
+ "kin-model",
  "pretty_assertions",
  "serde",
  "serde_json",
@@ -3447,7 +3429,7 @@ name = "kin-semantic-contracts"
 version = "0.2.1"
 dependencies = [
  "kin-db",
- "kin-model 0.2.0",
+ "kin-model",
  "pretty_assertions",
  "serde",
  "serde_json",
@@ -3463,7 +3445,7 @@ version = "0.2.1"
 dependencies = [
  "chrono",
  "hashbrown 0.15.5",
- "kin-model 0.2.0",
+ "kin-model",
  "parking_lot",
  "pretty_assertions",
  "reqwest",
@@ -3871,7 +3853,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -4753,7 +4735,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -5372,7 +5354,7 @@ dependencies = [
  "getrandom 0.4.2",
  "once_cell",
  "rustix",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -6347,7 +6329,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -137,7 +137,7 @@ kin-daemon = { path = "crates/kin-daemon" }
 kin-mcp = { path = "crates/kin-mcp" }
 kin-spine = { path = "crates/kin-spine" }
 kin-registry = { path = "crates/kin-registry" }
-kin-lsp = { version = "0.1.0", registry = "kin" }
+kin-lsp = { version = "0.2.0", registry = "kin" }
 # Cross-platform base: NO "metal" here. `[workspace.dependencies]` entries cannot be
 # `[target.'cfg(...)']`-gated, so listing "metal" here forces the macOS-only kin-infer/metal
 # backend on every target (incl. Linux, where it cannot compile). Metal is re-enabled


### PR DESCRIPTION
Tail of the forward-only registry repair. kin-lsp 0.1.0 was the last consumer dragging kin-model 0.1.0 into kin's --all-features build, breaking clippy on main after #31. kin-lsp 0.2.0 (kin-model 0.2.0) published; this pins it. Verified `cargo check --all-features` registry-only.