### PR TITLE
feat(locate): gated lexical-parity floor to subsume grep on keyword queries (FIR-986)

### DIFF
--- a/crates/kin-cli/src/commands/locate.rs
+++ b/crates/kin-cli/src/commands/locate.rs
@@ -2452,6 +2452,18 @@ pub fn run_with_graph_capture_with_priority_files_and_vector_source(
         );
     }
 
+    if locate_env_bool("KIN_LOCATE_LEXICAL_FLOOR_READMIT", false) {
+        apply_lexical_parity_floor(&mut fused, graph, text);
+        if explain {
+            record_debug_stage(
+                &mut score_breakdown,
+                &mut debug_info,
+                &fused,
+                "after_lexical_parity_floor",
+            );
+        }
+    }
+
     if explain {
         record_full_debug_stage(&mut debug_info, &fused, "pre_cap_full");
     }
@@ -4088,6 +4100,221 @@ fn signal_support_count_refs(path: &str, signal_sets: &[&HashMap<String, Vec<Fil
         .iter()
         .filter(|signal_set| signal_set.contains_key(path))
         .count()
+}
+
+#[derive(Default)]
+struct LexicalFileMatch {
+    best_quality: f32,
+    name_terms: HashSet<String>,
+    text_terms: HashSet<String>,
+    context_terms: HashSet<String>,
+    weighted_strength: f32,
+    exact_hit: bool,
+}
+
+fn lexical_term_rarity(graph: &kin_db::InMemoryGraph, term: &str) -> f32 {
+    let df = graph.text_doc_frequency(term);
+    let n = graph.text_document_count();
+    if df == 0 || n == 0 {
+        return 1.0;
+    }
+    let common_frac = locate_env_f32("KIN_LOCATE_LEXICAL_FLOOR_COMMON_FRAC", 0.02);
+    let common = (common_frac * n as f32).max(1.0);
+    (common / df as f32).clamp(0.05, 1.0)
+}
+
+fn lexical_parity_matches(
+    graph: &kin_db::InMemoryGraph,
+    terms: &[String],
+) -> HashMap<String, LexicalFileMatch> {
+    let mut matches: HashMap<String, LexicalFileMatch> = HashMap::new();
+    let quality_floor = locate_env_f32("KIN_LOCATE_LEXICAL_FLOOR_QUALITY", 3.0);
+
+    let scored_terms: Vec<(String, f32)> = terms
+        .iter()
+        .map(|term| term.to_ascii_lowercase())
+        .filter(|term| term.len() >= 4 && !is_english_stopword(term))
+        .map(|term| {
+            let rarity = lexical_term_rarity(graph, &term);
+            (term, rarity)
+        })
+        .collect();
+    if scored_terms.is_empty() {
+        return matches;
+    }
+
+    let Ok(entities) = graph.query_entities(&EntityFilter {
+        kinds: Some(vec![
+            EntityKind::Function,
+            EntityKind::Method,
+            EntityKind::Class,
+            EntityKind::TraitDef,
+            EntityKind::Interface,
+            EntityKind::EnumDef,
+            EntityKind::Module,
+        ]),
+        ..Default::default()
+    }) else {
+        return matches;
+    };
+
+    let mut per_term_files: HashMap<String, HashSet<String>> = HashMap::new();
+    for entity in &entities {
+        let Some(file_origin) = entity.file_origin.as_ref() else {
+            continue;
+        };
+        if entity.role == EntityRole::Docs || is_test_path(&file_origin.0) {
+            continue;
+        }
+        for (term, rarity) in &scored_terms {
+            let quality = score_name_match(term, &entity.name);
+            if quality < quality_floor {
+                continue;
+            }
+            let record = matches.entry(file_origin.0.clone()).or_default();
+            record.best_quality = record.best_quality.max(quality);
+            record.name_terms.insert(term.clone());
+            if per_term_files
+                .entry(term.clone())
+                .or_default()
+                .insert(file_origin.0.clone())
+            {
+                record.weighted_strength += (quality / 5.0) * rarity;
+            }
+            if quality >= 5.0 {
+                record.exact_hit = true;
+            }
+        }
+
+        let mut context = String::new();
+        context.push_str(&entity.signature.to_ascii_lowercase());
+        if let Some(doc) = entity.doc_summary.as_ref() {
+            context.push(' ');
+            context.push_str(&doc.to_ascii_lowercase());
+        }
+        if context.is_empty() {
+            continue;
+        }
+        for (term, rarity) in &scored_terms {
+            if context.contains(term.as_str()) {
+                let record = matches.entry(file_origin.0.clone()).or_default();
+                if record.context_terms.insert(term.clone())
+                    && !record.name_terms.contains(term)
+                    && !record.text_terms.contains(term)
+                {
+                    record.weighted_strength += 0.25 * rarity;
+                }
+            }
+        }
+    }
+
+    let text_hit_limit = locate_env_usize("KIN_LOCATE_LEXICAL_FLOOR_TEXT_HITS", 40);
+    for (term, rarity) in &scored_terms {
+        let Ok(hits) = graph.text_search(term, text_hit_limit) else {
+            continue;
+        };
+        let mut term_files: HashSet<String> = HashSet::new();
+        for (key, _score) in hits {
+            let Some(path) = file_path_from_retrieval_key(graph, &key) else {
+                continue;
+            };
+            if is_test_path(&path) || is_license_or_notice_path(&path) {
+                continue;
+            }
+            term_files.insert(path);
+        }
+        for path in term_files {
+            let record = matches.entry(path).or_default();
+            if record.text_terms.insert(term.clone()) && !record.name_terms.contains(term) {
+                record.weighted_strength += 0.5 * rarity;
+            }
+        }
+    }
+
+    matches
+}
+
+fn apply_lexical_parity_floor(
+    fused: &mut Vec<(String, f32)>,
+    graph: &kin_db::InMemoryGraph,
+    text: &str,
+) {
+    let mut terms: Vec<String> = extract_loose_query_terms(text)
+        .into_iter()
+        .filter(|term| {
+            let lower = term.to_ascii_lowercase();
+            lower.len() >= 4 && !is_english_stopword(&lower) && !is_common_english_word(&lower)
+        })
+        .collect();
+    terms.sort();
+    terms.dedup_by(|left, right| left.eq_ignore_ascii_case(right));
+    if terms.is_empty() {
+        return;
+    }
+
+    let matches = lexical_parity_matches(graph, &terms);
+    if matches.is_empty() {
+        return;
+    }
+
+    let name_anchored: HashSet<&String> = matches
+        .iter()
+        .filter(|(_, record)| !record.name_terms.is_empty())
+        .map(|(path, _)| path)
+        .collect();
+    let in_fused: HashSet<String> = fused.iter().map(|(path, _)| path.clone()).collect();
+    let nonlexical_top = fused
+        .iter()
+        .filter(|(path, _)| !name_anchored.contains(path))
+        .map(|(_, score)| *score)
+        .fold(0.0_f32, f32::max);
+    let top_score = fused
+        .iter()
+        .map(|(_, score)| *score)
+        .fold(0.0_f32, f32::max);
+    let lift_gain = locate_env_f32("KIN_LOCATE_LEXICAL_FLOOR_LIFT", 1.05);
+    let admit_min_strength = locate_env_f32("KIN_LOCATE_LEXICAL_FLOOR_ADMIT_STRENGTH", 0.6);
+    let strong_strength = locate_env_f32("KIN_LOCATE_LEXICAL_FLOOR_STRONG_STRENGTH", 1.0);
+    let lift_present = locate_env_bool("KIN_LOCATE_LEXICAL_FLOOR_LIFT_PRESENT", true);
+    let mut existing: HashMap<String, usize> = HashMap::new();
+    for (idx, (path, _)) in fused.iter().enumerate() {
+        existing.insert(path.clone(), idx);
+    }
+
+    let mut admitted: Vec<(String, f32)> = Vec::new();
+    for (path, record) in &matches {
+        if record.name_terms.is_empty() {
+            continue;
+        }
+        let present = in_fused.contains(path);
+        let admit_ok = record.exact_hit || record.weighted_strength >= admit_min_strength;
+        let quality_scale = (record.best_quality / 5.0).clamp(0.0, 1.0);
+        let strength_scale = (record.weighted_strength / strong_strength).clamp(0.0, 1.0);
+        let lexical_strength = quality_scale.max(strength_scale).clamp(0.0, 1.0);
+        let ceiling = nonlexical_top + (top_score - nonlexical_top) * strength_scale;
+        let parity = ceiling.max(nonlexical_top) * lift_gain * lexical_strength;
+        if present {
+            if !lift_present {
+                continue;
+            }
+            if let Some(&idx) = existing.get(path) {
+                let original = fused[idx].1;
+                if parity > original {
+                    let tiebreak = locate_env_f32("KIN_LOCATE_LEXICAL_FLOOR_TIEBREAK", 0.05);
+                    fused[idx].1 = parity + tiebreak * original;
+                }
+            }
+        } else if admit_ok {
+            admitted.push((path.clone(), parity));
+        }
+    }
+    fused.extend(admitted);
+
+    fused.sort_by(|a, b| {
+        b.1.partial_cmp(&a.1)
+            .unwrap_or(std::cmp::Ordering::Equal)
+            .then_with(|| a.0.cmp(&b.0))
+    });
 }
 
 fn companion_query_match_count(
@@ -13459,6 +13686,34 @@ mod tests {
             score,
             spans: vec![],
         }]
+    }
+
+    #[test]
+    fn lexical_parity_floor_is_noop_when_no_entities_match() {
+        let graph = kin_db::InMemoryGraph::new();
+        let mut fused = vec![
+            ("crates/a.rs".to_string(), 1.0_f32),
+            ("crates/b.rs".to_string(), 0.5_f32),
+        ];
+        let before = fused.clone();
+        apply_lexical_parity_floor(&mut fused, &graph, "resolve repository identifier manifest");
+        assert_eq!(
+            fused, before,
+            "empty graph yields no lexical matches, so the floor must not change fusion"
+        );
+    }
+
+    #[test]
+    fn lexical_file_match_records_part_named_entity() {
+        let record = LexicalFileMatch {
+            best_quality: 3.0,
+            name_terms: HashSet::from(["commit".to_string()]),
+            ..Default::default()
+        };
+        assert!(!record.name_terms.is_empty());
+        assert_eq!(record.best_quality, 3.0);
+        assert!(!record.exact_hit);
+        assert!(record.text_terms.is_empty());
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Adds a **lexical-parity floor** over the post-fusion file list in `kin locate`, applied just before `adaptive_cap` (after `demote_zero_signal_files`). Entirely gated behind **`KIN_LOCATE_LEXICAL_FLOOR_READMIT` (default FALSE)** — flag OFF is a true no-op. The flag stays OFF in this PR.

Goal (FIR-986): make kin subsume grep on rung-1 keyword queries — find what grep finds, at rank >= grep.

## Where / how the boost is injected

- **Injection point:** `crates/kin-cli/src/commands/locate.rs`, in `run_with_graph`, right after `demote_zero_signal_files` and before the `semantic_retention_paths` / `adaptive_cap` block. Single gated call: `apply_lexical_parity_floor(&mut fused, graph, text)`.
- **Entity names in scope:** the floor does ONE `graph.query_entities(EntityFilter { kinds: [Function, Method, Class, Trait, Interface, Enum, Module] })` scan (same primitive `companion_query_match_count` already uses) and reads `entity.name`, `entity.signature`, `entity.doc_summary`, `entity.file_origin` — no new graph round-trip beyond this scan plus bounded per-term `text_search`. Reuses the existing `score_name_match` (0..5 part matcher) and `file_path_from_retrieval_key`.
- **Scoring:** per file, IDF-weighted (`text_doc_frequency`) strength from entity-name matches + signature/doc coverage + bounded BM25 text coverage. Name-anchored files are lifted toward a parity ceiling (between strongest non-lexical fused score and global top), scaled by rarity-weighted strength; strongly-covered missing files can be re-admitted. An original-score tiebreak preserves fusion order among ceiling-saturated files.

## Flag-OFF no-op proof

The gated `if` block is the only new code on the execution path; when the flag is false it is never entered. Final-binary harness run with the flag OFF reproduces the documented baseline exactly: **kin 5/6 gold-hit, avg-rank 3.4**, per-gold ranks `#2 / #2 / MISS / #5 / #2 / #6` — identical to main. (Raw-kin locate is nondeterministic run-to-run, so the proof is the gate's code structure + gold-rank stability, not a byte diff.)

## Dogfood before/after (6 rung-1 queries)

| query | grep | kin OFF | kin ON |
|---|---|---|---|
| resolve-repo-id | #1 | #2 | **#1** |
| rebuild-projection | #3 | #2 | #2 |
| project-after-commit | #1 | **MISS** | **#7** (rescued) |
| flush-during-embed | #1 | #5 | **#4** |
| mcp-tools | #2 | #2 | #5 (regressed) |
| supervisor-repoid | MISS | #6 | MISS (regressed) |
| **aggregate** | 5/6, 3.4 | 5/6, 3.4 | 5/6, 3.8 |

Flag ON **rescues the target coverage miss** (`project_after_mcp_commit`, MISS->found) and reaches grep parity on two queries, but trades off mcp-tools/supervisor on some runs. Across repeated runs, daemon ranking nondeterminism dominates at n=6 (baseline itself flips 4/6<->5/6; the q3 rescue and q6 flip both vary run-to-run).

**Honest verdict: this is NOT a clean net win on the noisy n=6 dogfood set.** The mechanism demonstrably works (rescues the miss, improves grep parity on multiple queries) but cannot be declared a win here. **It must clear the 27-task aggregate-F1 guardrail before any default-ON flip.** No default-ON flip in this PR.

## Build / fmt / clippy / tests

- `cargo build --release -p kin-cli -p kin-daemon` — clean
- `cargo fmt -- --check` — clean
- `cargo clippy -p kin-cli --all-targets --all-features` — no findings in new code (only pre-existing warnings in unrelated files)
- `cargo test -p kin-cli --lib commands::locate` — **184 passed** (182 existing + 2 new floor tests)

## Tuning knobs (all `KIN_LOCATE_LEXICAL_FLOOR_*`, read by the daemon)

`READMIT` (master gate, OFF), `QUALITY`, `COMMON_FRAC`, `TEXT_HITS`, `ADMIT_STRENGTH`, `STRONG_STRENGTH`, `LIFT`, `TIEBREAK`, `LIFT_PRESENT`. Defaults baked for the dogfood probe; the 27-task sweep will set the production values.