### PR TITLE
fix(runtime): public-hardening trio — fresh daemon log tail (FIR-979), home-dir daemon loop (FIR-980), review audit events (FIR-969)

### DIFF
--- a/crates/kin-cli/src/commands/review.rs
+++ b/crates/kin-cli/src/commands/review.rs
@@ -542,6 +542,15 @@ fn create_review_with_graph(
         };
         graph.add_review_note(&note)?;
     }
+    crate::provenance::record_cli_audit_event(
+        graph,
+        "review.create",
+        None,
+        Some(format!(
+            "review_id={}; title={}; base={}; head={}",
+            review.review_id, title, base, head
+        )),
+    )?;
     Ok(ReviewExecution {
         response: ReviewResponse {
             text: format!(
@@ -598,6 +607,12 @@ fn decide_review_with_graph(
     };
 
     graph.add_review_decision(&rid, &decision)?;
+    crate::provenance::record_cli_audit_event(
+        graph,
+        "review.decide",
+        None,
+        Some(format!("review_id={}; decision={}", review_id, state)),
+    )?;
     Ok(ReviewExecution {
         response: ReviewResponse {
             text: format!("Recorded decision '{}' on review {}\n", state, review_id),
@@ -972,5 +987,68 @@ fn inline_comment_severity(kind: kin_review::InlineCommentKind) -> &'static str 
         | InlineCommentKind::Renamed
         | InlineCommentKind::AgentUnreviewed => "warning",
         InlineCommentKind::Added | InlineCommentKind::Removed => "info",
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use kin_model::ProvenanceStore;
+
+    #[test]
+    fn create_review_records_audit_event() {
+        let graph = kin_db::InMemoryGraph::new();
+
+        create_review_with_graph(
+            &graph,
+            "Fix login".into(),
+            "main".into(),
+            "feature/login".into(),
+            Some("body edit".into()),
+        )
+        .unwrap();
+
+        let events = graph.query_audit_events(None, 10).unwrap();
+        assert_eq!(events.len(), 1, "review create must record one audit event");
+        assert_eq!(events[0].action, "review.create");
+        let details = events[0].details.as_deref().unwrap_or_default();
+        assert!(
+            details.contains("base=main") && details.contains("head=feature/login"),
+            "audit details should carry review refs: {details}"
+        );
+    }
+
+    #[test]
+    fn decide_review_records_audit_event() {
+        let graph = kin_db::InMemoryGraph::new();
+
+        let execution = create_review_with_graph(
+            &graph,
+            "Fix login".into(),
+            "main".into(),
+            "feature/login".into(),
+            None,
+        )
+        .unwrap();
+        // Recover the review id from the create response text.
+        let review_id = execution
+            .response
+            .text
+            .lines()
+            .find_map(|line| line.strip_prefix("Created review "))
+            .map(|s| s.trim().to_string())
+            .expect("review id in create response");
+
+        decide_review_with_graph(&graph, review_id, "approved".into(), None).unwrap();
+
+        let events = graph.query_audit_events(None, 10).unwrap();
+        assert_eq!(
+            events.len(),
+            2,
+            "create + decide must each record an audit event"
+        );
+        // query_audit_events returns most-recent first.
+        assert_eq!(events[0].action, "review.decide");
+        assert_eq!(events[1].action, "review.create");
     }
 }

--- a/crates/kin-cli/src/daemon_client.rs
+++ b/crates/kin-cli/src/daemon_client.rs
@@ -1468,15 +1468,36 @@ fn open_daemon_log(kin_root: &Path) -> Result<File> {
         .with_context(|| format!("open daemon log at {}", daemon_log_path(kin_root).display()))
 }
 
-fn daemon_log_tail(kin_root: &Path) -> String {
+/// Byte length of the daemon log at the moment a new start attempt begins.
+/// Anything written at or after this offset belongs to the current attempt;
+/// anything before it is the stale tail of a prior run.
+fn daemon_log_len(kin_root: &Path) -> u64 {
+    std::fs::metadata(daemon_log_path(kin_root))
+        .map(|metadata| metadata.len())
+        .unwrap_or(0)
+}
+
+/// Render the daemon log output produced by the current start attempt only —
+/// the bytes written at or after `since_offset` (the log length captured just
+/// before the daemon was spawned). This avoids surfacing the stale tail of a
+/// prior run's log as if it were the cause of this failure. When the failing
+/// process wrote nothing, we say so explicitly rather than echoing old lines.
+fn daemon_log_tail_since(kin_root: &Path, since_offset: u64) -> String {
     let path = daemon_log_path(kin_root);
     let Ok(content) = std::fs::read_to_string(&path) else {
         return format!("daemon log unavailable at {}", path.display());
     };
-    let lines: Vec<&str> = content.lines().rev().take(20).collect();
-    if lines.is_empty() {
-        return format!("daemon log is empty at {}", path.display());
+    let fresh = content
+        .get(since_offset as usize..)
+        .unwrap_or(&content)
+        .trim();
+    if fresh.is_empty() {
+        return format!(
+            "no fresh daemon output captured for this start attempt at {}",
+            path.display()
+        );
     }
+    let lines: Vec<&str> = fresh.lines().rev().take(20).collect();
     lines.into_iter().rev().collect::<Vec<_>>().join("\n")
 }
 
@@ -1680,6 +1701,7 @@ async fn wait_for_daemon_ready(
     child: &mut Child,
     port: u16,
     deadline: Instant,
+    log_offset: u64,
 ) -> Result<String> {
     let timeout = deadline.saturating_duration_since(Instant::now());
     let client = daemon_health_client();
@@ -1690,7 +1712,7 @@ async fn wait_for_daemon_ready(
         if let Some(status) = child.try_wait().context("check daemon child status")? {
             bail!(
                 "daemon exited during startup with status {status}; recent log:\n{}",
-                daemon_log_tail(kin_root)
+                daemon_log_tail_since(kin_root, log_offset)
             );
         }
 
@@ -1737,7 +1759,7 @@ async fn wait_for_daemon_ready(
         "daemon failed to become ready within {:.1}s: {}; recent log:\n{}",
         timeout.as_secs_f64(),
         last_error,
-        daemon_log_tail(kin_root)
+        daemon_log_tail_since(kin_root, log_offset)
     )
 }
 
@@ -2191,6 +2213,7 @@ pub async fn ensure_daemon_running_with_idle_timeout(
         "--port",
         &port.to_string(),
     ]);
+    let log_offset = daemon_log_len(kin_root);
     let log = open_daemon_log(kin_root)?;
     let stderr = log
         .try_clone()
@@ -2220,7 +2243,7 @@ pub async fn ensure_daemon_running_with_idle_timeout(
 
     let timeout_secs = daemon_ready_timeout_secs();
     let deadline = Instant::now() + Duration::from_secs(timeout_secs);
-    let base_url = wait_for_daemon_ready(kin_root, &mut child, port, deadline).await?;
+    let base_url = wait_for_daemon_ready(kin_root, &mut child, port, deadline, log_offset).await?;
     register_repo_daemon_with_supervisor(kin_root, &base_url, &supervisor_url).await?;
     info!(port, "daemon is up and ready");
     Ok(base_url)
@@ -2308,6 +2331,43 @@ mod urlencoding {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn daemon_log_tail_since_omits_stale_prior_run_lines() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = daemon_log_path(dir.path());
+        let stale = "ERROR 2026-06-09 embedding dimension mismatch: expected 384, got 768\n";
+        std::fs::write(&path, stale).unwrap();
+        let offset = daemon_log_len(dir.path());
+
+        // No fresh output written by the failing attempt -> explicit message,
+        // never the stale tail.
+        let tail = daemon_log_tail_since(dir.path(), offset);
+        assert!(
+            tail.contains("no fresh daemon output captured"),
+            "expected fresh-output notice, got: {tail}"
+        );
+        assert!(
+            !tail.contains("384, got 768"),
+            "stale prior-run line must not be surfaced: {tail}"
+        );
+
+        // Fresh output appended after the offset is the only thing surfaced.
+        std::fs::write(
+            &path,
+            format!("{stale}ERROR 2026-06-16 incompatible graph schema version\n"),
+        )
+        .unwrap();
+        let tail = daemon_log_tail_since(dir.path(), offset);
+        assert!(
+            tail.contains("incompatible graph schema version"),
+            "fresh line must be surfaced: {tail}"
+        );
+        assert!(
+            !tail.contains("384, got 768"),
+            "stale prior-run line must not be surfaced even when fresh output exists: {tail}"
+        );
+    }
 
     #[test]
     fn live_daemon_endpoint_returns_alive_pid_even_before_port_binds() {

--- a/crates/kin-core/src/layout.rs
+++ b/crates/kin-core/src/layout.rs
@@ -26,7 +26,11 @@ impl KinLayout {
 
     /// Discover the `.kin/` directory by walking up from `start`.
     ///
-    /// Returns `None` if no `.kin/` directory is found.
+    /// Returns `None` if no `.kin/` directory is found. The global home
+    /// `~/.kin` is the cross-repo registry/cache root, not a servable repo: it
+    /// holds `registry.toml` but never a `manifest.json`. Discovery skips it so
+    /// running outside any repo does not resolve to the home directory and spawn
+    /// a daemon that fails `resolve_repo_id` against a non-existent manifest.
     pub fn discover(start: &Path) -> Option<Self> {
         if std::env::var("KIN_DAEMON_URL").is_ok() {
             return Some(Self::new(start.join(".kin")));
@@ -34,7 +38,7 @@ impl KinLayout {
         let mut current = start.to_path_buf();
         loop {
             let candidate = current.join(".kin");
-            if candidate.is_dir() {
+            if candidate.is_dir() && !is_global_home_kin_dir(&candidate) {
                 return Some(Self::new(candidate));
             }
             if !current.pop() {
@@ -281,6 +285,33 @@ impl KinLayout {
     }
 }
 
+/// The global home Kin directory `~/.kin` — the cross-repo registry/cache root,
+/// not a servable repo. Returns `None` when no home directory is resolvable.
+pub fn global_home_kin_dir() -> Option<PathBuf> {
+    directories::BaseDirs::new().map(|dirs| dirs.home_dir().join(".kin"))
+}
+
+/// Whether `candidate` is the global home `~/.kin` registry/cache root rather
+/// than a real repository. The home root holds `registry.toml` but never a
+/// `manifest.json`; a candidate that carries a manifest is a real repo even if
+/// it happens to live at `~/.kin`, so it is not treated as the home root.
+fn is_global_home_kin_dir(candidate: &Path) -> bool {
+    let Some(home_kin) = global_home_kin_dir() else {
+        return false;
+    };
+    if candidate != home_kin {
+        // Compare canonical forms too, so symlinked or non-normalized paths
+        // (e.g. a `/var` vs `/private/var` HOME on macOS) still match.
+        let canonical_candidate = candidate.canonicalize().ok();
+        let canonical_home = home_kin.canonicalize().ok();
+        match (canonical_candidate, canonical_home) {
+            (Some(a), Some(b)) if a == b => {}
+            _ => return false,
+        }
+    }
+    !candidate.join("manifest.json").exists()
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -338,6 +369,29 @@ mod tests {
     fn discover_returns_none_when_missing() {
         let dir = tempfile::tempdir().unwrap();
         assert!(KinLayout::discover(dir.path()).is_none());
+    }
+
+    #[test]
+    fn is_global_home_kin_dir_rejects_unrelated_and_repo_paths() {
+        // A normal repo `.kin` (carrying a manifest) is never the home root.
+        let dir = tempfile::tempdir().unwrap();
+        let kin_dir = dir.path().join(".kin");
+        std::fs::create_dir(&kin_dir).unwrap();
+        std::fs::write(kin_dir.join("manifest.json"), "{}").unwrap();
+        assert!(!is_global_home_kin_dir(&kin_dir));
+
+        // An unrelated `.kin` path that is not the home root is never the home
+        // root either, regardless of manifest presence.
+        let bare = dir.path().join("sub").join(".kin");
+        std::fs::create_dir_all(&bare).unwrap();
+        assert!(!is_global_home_kin_dir(&bare));
+    }
+
+    #[test]
+    fn global_home_kin_dir_targets_home_dot_kin() {
+        if let Some(home_kin) = global_home_kin_dir() {
+            assert_eq!(home_kin.file_name().and_then(|n| n.to_str()), Some(".kin"));
+        }
     }
 
     fn empty_kin_layout() -> (tempfile::TempDir, KinLayout) {


### PR DESCRIPTION
Public-scrutiny hardening: three pure-code defects a reviewer hits in the first hour. Each verified to still reproduce in current `main`, fixed on one branch, with targeted unit tests. Validated with `cargo check -p kin-cli` / `cargo check -p kin-core` and per-fix `cargo test` (no daemon started, no full-workspace build).

## FIR-979 — daemon-startup error surfaced STALE `daemon.log` lines as "recent log"
`wait_for_daemon_ready` printed the last 20 lines of `.kin/daemon.log` regardless of age, so a failed start replayed days-old ERROR lines (e.g. a long-resolved 384/768 dimension mismatch) that had nothing to do with the current failure.

Fix (`crates/kin-cli/src/daemon_client.rs`): capture the log byte-length immediately before spawning the child (`daemon_log_len`), thread it into `wait_for_daemon_ready`, and render only bytes written at/after that offset (`daemon_log_tail_since`). When the failing process wrote nothing fresh, emit `no fresh daemon output captured for this start attempt` instead of the stale tail. Satisfies the acceptance criterion without needing a boot-id line.

## FIR-980 — supervisor/CLI hot-loop: "failed to resolve repo id: ~/.kin/manifest.json: No such file"
Running `kin` outside any repo made `KinLayout::discover` walk up and select the global home `~/.kin` (which has `registry.toml` but never a `manifest.json`). The CLI then spawned `kin-daemon --repo $HOME`; the daemon discovered `~/.kin`, failed `resolve_repo_id` on the missing manifest, and exited — repeated on every command, filling `daemon.log` with identical errors.

Fix (`crates/kin-core/src/layout.rs`): `KinLayout::discover` now skips a `.kin` candidate that is the global home root (`global_home_kin_dir()` / `is_global_home_kin_dir`, identified by being `~/.kin` and lacking a `manifest.json`). Running outside any repo now resolves to no repo instead of the home directory, so no `kin-daemon --repo ~` is ever spawned. Existing repo discovery is unchanged (a real `.kin` always carries its manifest birth-certificate).

## FIR-969 — `kin audit` empty after commits + reviews
Commits already record `commit.create` audit events, but `kin review create` / `kin review decide` recorded none — so the governance-relevant review actions never appeared in `kin audit`. (kin-db storage + the daemon read path were verified correct; this was a pure CLI wiring gap.)

Fix (`crates/kin-cli/src/commands/review.rs`): `create_review_with_graph` / `decide_review_with_graph` now record `review.create` / `review.decide` via the same `record_cli_audit_event` path used by `commit`/`note`/`verify`/`work`.

## Tests
- `daemon_client::tests::daemon_log_tail_since_omits_stale_prior_run_lines`
- `layout::tests::is_global_home_kin_dir_rejects_unrelated_and_repo_paths`, `global_home_kin_dir_targets_home_dot_kin` (+ existing discover tests still green)
- `commands::review::tests::create_review_records_audit_event`, `decide_review_records_audit_event`

All passing. `cargo check -p kin-cli` and `cargo check -p kin-core` clean.