### PR TITLE
deps: bump kin to kin-db 0.2.2 (embedding-worker layer_norm_eps fix)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1019,7 +1019,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users 0.5.2",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1118,7 +1118,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1788,7 +1788,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "19753d40da53d0ec41604750eeb969097a90fb2d7f7992730d904541c04e2c19"
 dependencies = [
  "bstr",
- "hashbrown 0.16.1",
+ "hashbrown 0.17.1",
 ]
 
 [[package]]
@@ -3057,9 +3057,9 @@ dependencies = [
 
 [[package]]
 name = "kin-db"
-version = "0.2.1"
+version = "0.2.2"
 source = "sparse+https://kinlab.ai/registry/cargo/"
-checksum = "03591add611183366774df136d6f28c9d9dabb636d71435e669b767dd58c9c5b"
+checksum = "e2b45a27678a8de06d1e13898068fdc871f3fe53694195a7d3ae39b9ca86184b"
 dependencies = [
  "bincode",
  "bytes",
@@ -3853,7 +3853,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4735,7 +4735,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -5354,7 +5354,7 @@ dependencies = [
  "getrandom 0.4.2",
  "once_cell",
  "rustix",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -6329,7 +6329,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.48.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -143,5 +143,5 @@ kin-lsp = { version = "0.2.0", registry = "kin" }
 # backend on every target (incl. Linux, where it cannot compile). Metal is re-enabled
 # additively on macOS via a `[target.'cfg(target_os = "macos")'.dependencies]` block in the
 # binary/runtime crates (kin-cli, kin-daemon). Feature unification makes that additive.
-kin-db = { version = "0.2.1", registry = "kin", default-features = false, features = ["vector", "embeddings"] }
+kin-db = { version = "0.2.2", registry = "kin", default-features = false, features = ["vector", "embeddings"] }
 kin-vfs-core = { version = "0.1.0", registry = "kin" }


### PR DESCRIPTION
Bumps kin's `kin-db` pin 0.2.1 → 0.2.2.

kin-db 0.2.2 (kin-db#25, merged 5406d30) fixes the daemon embedding-worker regression: the worker crashed on `duplicate field layer_norm_eps` in the nomic model config and reset the vector index to 0, silently breaking semantic search after a daemon restart. 0.2.2 tolerantly parses the duplicate alias.

- 0.2.2 is published to the Kin registry and checksum-verified: `/dl/kin-db/0.2.2` sha256 `e2b45a27…` == sparse-index cksum.
- Cargo.lock updated to 0.2.2 plus compatible transitive bumps from the index refresh (hashbrown 0.17.1, windows-sys 0.61.2 — windows-only, not compiled in the linux daemon image).

Gate before rebuilding + deploying the kin-daemon image, which then carries kin#34 (registry immutability) + kin#26 (native publish→serve) + this embedding fix together.