### PR TITLE
ci: automated kin-daemon image build+push (FIR-1020)

### DIFF
--- a/.github/workflows/daemon-image.yml
+++ b/.github/workflows/daemon-image.yml
@@ -1,0 +1,70 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2026 Firelock, LLC
+
+name: Daemon Image
+
+# Builds and pushes the kin-daemon container image to the Kin Artifact Registry.
+# On every push to main it keeps a fresh SHA-tagged (and :latest) image available
+# for the hosted rollout (kinlab deploy.yml consumes KINLAB_KIN_DAEMON_IMAGE);
+# workflow_dispatch builds the same image on demand. Auth is keyless via the
+# firelock-ai org Workload Identity Federation provider (no service-account keys).
+on:
+  push:
+    branches: [main]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  id-token: write
+
+concurrency:
+  group: daemon-image-${{ github.ref }}
+  cancel-in-progress: false
+
+env:
+  IMAGE: us-central1-docker.pkg.dev/kin-ecosystem/kin-ecosystem/kin-daemon
+
+jobs:
+  build-push:
+    name: Build + push kin-daemon image
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Authenticate to Google Cloud (keyless WIF)
+        uses: google-github-actions/auth@v3
+        with:
+          workload_identity_provider: ${{ secrets.WIF_PROVIDER }}
+          service_account: ${{ secrets.WIF_SERVICE_ACCOUNT }}
+
+      - name: Set up Cloud SDK
+        uses: google-github-actions/setup-gcloud@v3
+
+      - name: Configure Docker for Artifact Registry
+        run: gcloud auth configure-docker us-central1-docker.pkg.dev --quiet
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Build and push (linux/amd64)
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: ./Dockerfile
+          push: true
+          platforms: linux/amd64
+          # Single-arch manifest (no attestation index) for predictable GKE pulls.
+          provenance: false
+          tags: |
+            ${{ env.IMAGE }}:${{ github.sha }}
+            ${{ env.IMAGE }}:latest
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+
+      - name: Summary
+        run: |
+          {
+            echo "Pushed \`${IMAGE}:${GITHUB_SHA}\`"
+            echo "Pushed \`${IMAGE}:latest\`"
+          } >> "$GITHUB_STEP_SUMMARY"


### PR DESCRIPTION
Adds `.github/workflows/daemon-image.yml` — builds and pushes the linux/amd64 `kin-daemon` image to `us-central1-docker.pkg.dev/kin-ecosystem/kin-ecosystem/kin-daemon` (tags: commit SHA + `latest`) on every push to main, plus `workflow_dispatch`.

- Keyless auth via the firelock-ai org Workload Identity Federation provider (`WIF_PROVIDER` / `WIF_SERVICE_ACCOUNT`, now configured on this repo; impersonates `kin-deployer` which holds `artifactregistry.writer`). No service-account keys.
- Replaces the manual/stale image process (the AR currently holds only hand-pushed SHA images; nothing for the latest main). Gives the hosted rollout (kinlab `deploy.yml` → `KINLAB_KIN_DAEMON_IMAGE`) a fresh image automatically.
- Build+push only — prod promotion stays a deliberate `deploy.yml` dispatch (no auto-deploy).

Part of FIR-1020 / the FIR-1015 release-engineering automation.