### PR TITLE
chore(deps): bump kin-db 0.2.2 -> 0.2.3 (FIR-983 GCS conditional-update fix)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3057,9 +3057,9 @@ dependencies = [
 
 [[package]]
 name = "kin-db"
-version = "0.2.2"
+version = "0.2.3"
 source = "sparse+https://kinlab.ai/registry/cargo/"
-checksum = "e2b45a27678a8de06d1e13898068fdc871f3fe53694195a7d3ae39b9ca86184b"
+checksum = "ab5ca4f070ca83e772e8aaa289cbb72d4732166a0df22bab746dd873706266b1"
 dependencies = [
  "bincode",
  "bytes",
@@ -6329,7 +6329,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -143,5 +143,5 @@ kin-lsp = { version = "0.2.0", registry = "kin" }
 # backend on every target (incl. Linux, where it cannot compile). Metal is re-enabled
 # additively on macOS via a `[target.'cfg(target_os = "macos")'.dependencies]` block in the
 # binary/runtime crates (kin-cli, kin-daemon). Feature unification makes that additive.
-kin-db = { version = "0.2.2", registry = "kin", default-features = false, features = ["vector", "embeddings"] }
+kin-db = { version = "0.2.3", registry = "kin", default-features = false, features = ["vector", "embeddings"] }
 kin-vfs-core = { version = "0.1.0", registry = "kin" }


### PR DESCRIPTION
Picks up kin-db#26 — GCS `save_snapshot` threads the object generation into conditional updates, fixing "Version required for conditional update" (every hosted snapshot save after the first failed → the publish→serve gap). Validated against the real bucket via ADC. Merging rebuilds the daemon image against the fixed backend.