### PR TITLE
feat(locate): additive promotion-only cross-encoder blend (M1, FIR-987)

### DIFF
--- a/crates/kin-cli/src/commands/locate.rs
+++ b/crates/kin-cli/src/commands/locate.rs
@@ -2373,8 +2373,33 @@ pub fn run_with_graph_capture_with_priority_files_and_vector_source(
                             let budget_ms =
                                 locate_env_usize("KIN_LOCATE_RERANK_LATENCY_BUDGET_MS", 0) as u128;
                             if rerank_within_budget(elapsed_ms, budget_ms) {
-                                for (i, score) in scores.into_iter().enumerate() {
-                                    candidates[i].1 = score;
+                                // M1 (FIR-986/987): additive, promotion-only blend.
+                                // Legacy (default) OVERWRITES the fused score with the raw
+                                // cross-encoder logit and re-sorts purely by it — substitutive,
+                                // so it evicts multi-signal-corroborated golds whenever the
+                                // encoder prefers a single-signal filler. The blend squashes
+                                // each logit to (0,1), spread-normalizes, and ADDS a bounded
+                                // term so scores are monotonically non-decreasing (a gold can
+                                // only move up, never below its fused floor); confidence-gated
+                                // to skip flat distributions where the encoder isn't separating.
+                                if locate_env_bool("KIN_LOCATE_RERANK_BLEND", false) {
+                                    let sig: Vec<f32> =
+                                        scores.iter().map(|&l| 1.0 / (1.0 + (-l).exp())).collect();
+                                    let mn = sig.iter().copied().fold(f32::INFINITY, f32::min);
+                                    let mx = sig.iter().copied().fold(f32::NEG_INFINITY, f32::max);
+                                    let spread = mx - mn;
+                                    let w = locate_env_f32("KIN_LOCATE_RERANK_BLEND_WEIGHT", 0.04);
+                                    let min_spread =
+                                        locate_env_f32("KIN_LOCATE_RERANK_MIN_SPREAD", 0.10);
+                                    if spread >= min_spread {
+                                        for (i, s) in sig.iter().enumerate() {
+                                            candidates[i].1 += w * (s - mn) / spread.max(1e-6);
+                                        }
+                                    }
+                                } else {
+                                    for (i, s) in scores.iter().enumerate() {
+                                        candidates[i].1 = *s;
+                                    }
                                 }
                                 candidates.sort_by(|a, b| {
                                     b.1.partial_cmp(&a.1)


### PR DESCRIPTION
## Why every prior reranker regressed (code-verified)

`locate.rs:2376-2389` does `candidates[i].1 = score` — it **overwrites** the fused RRF score with the raw, unbounded cross-encoder logit (no sigmoid; `kin-infer` emits `logits[[b,0]]` verbatim) and re-sorts the top-K window purely by it. This annihilates the fusion corroboration inside the window and operates on an incommensurable scale. With a 5/6-hit, avg-rank-~3.4 starting order, a substitutive re-sort can only shuffle slots — it evicts a multi-signal-corroborated gold whenever the encoder prefers a single-signal filler. **The gap is rank, not recall, so the lever must promote without evicting.**

## The fix — additive, promotion-only, confidence-gated

New `KIN_LOCATE_RERANK_BLEND` (default **OFF**):
- `sigmoid(logit)` → bounded (0,1) (kills the unbounded/negative-logit incoherence)
- spread-normalize over the window (worst→0, best→1)
- confidence gate: skip if `spread < KIN_LOCATE_RERANK_MIN_SPREAD` (default 0.10)
- **`candidates[i].1 += w * norm`** (`KIN_LOCATE_RERANK_BLEND_WEIGHT` default 0.04 — RRF-commensurate with `cross_bonus`/one rank-step), never overwrite

Because the term is bounded and **non-negative**, every score is monotonically non-decreasing: a corroborated gold can only move *up*, never below its fused floor. The induced reorder is a *bounded perturbation* of the fusion order (a candidate can only overtake a neighbor whose fused lead is `< w`), so strong wins are immovable and only near-ties get rescued. Legacy overwrite preserved as the `else` branch = the A/B comparison arm.

## Gate (do not merge-flip until cleared)

Default-OFF and inert until flagged. Must clear the **27-task aggregate F1** gate, n≥3 over the 3 suites (cli/sympy/nlohmann), **raw F1 up AND strict/line/symbol not regressed** — strict-F1 is the canary for over-promotion (how the de-cliff arm was rejected). Sweep `KIN_LOCATE_RERANK_BLEND_WEIGHT ∈ {0.02,0.04,0.08}`, accept the largest W that improves raw without regressing strict. Compiles clean (kin-cli + kin-daemon).