### PR TITLE
fix(install): don't fail non-interactive installs when /dev/tty is unopenable (FIR-1012)

### DIFF
--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -271,11 +271,16 @@ else
     if [ -t 0 ]; then
         # Already in a TTY — run directly
         "$KIN_BIN/kin" setup
-    elif [ -e /dev/tty ]; then
-        # Piped but TTY available — redirect stdin from /dev/tty
+    elif [ -e /dev/tty ] && { : < /dev/tty; } 2>/dev/null; then
+        # Piped but a usable controlling TTY is available — read keyboard input
+        # from it. The `: < /dev/tty` probe confirms the device can actually be
+        # OPENED — on CI/Docker /dev/tty often exists but has no controlling
+        # terminal, so opening it errors ("cannot open /dev/tty") and the bare
+        # `[ -e /dev/tty ]` check is not enough.
         "$KIN_BIN/kin" setup < /dev/tty
     else
-        # No TTY at all (CI, Docker, etc.) — run non-interactive
+        # No usable TTY (CI, Docker, piped without a controlling terminal) —
+        # run non-interactive so the install never exits non-zero here.
         "$KIN_BIN/kin" setup --no-interactive
     fi
 fi


### PR DESCRIPTION
Installer exited code 2 on CI/Docker/piped installs — `[ -e /dev/tty ]` is true on a runner but the device can't be opened (no controlling terminal), so `kin setup < /dev/tty` errors. Probe openability and fall through to `kin setup --no-interactive`. Surfaced by the new install-proof matrix. The served copy at `gs://kinlab-dev-install/install` (get.kinlab.dev) is already updated.