### PR TITLE
fix(ci): repair CLA gate config — allowlist real login, normalize cla.json, add CLA.md (FIR-995)

### DIFF
--- a/.github/workflows/cla.yml
+++ b/.github/workflows/cla.yml
@@ -22,7 +22,7 @@ jobs:
       - name: Check CLA author allowlist/signature
         env:
           PR_AUTHOR: ${{ github.event.pull_request.user.login }}
-          ALLOWLIST: "troyfortinjr,dependabot[bot],github-actions[bot]"
+          ALLOWLIST: "troyjr4103,troyfortinjr,dependabot[bot],github-actions[bot]"
         shell: bash
         run: |
           set -euo pipefail
@@ -48,7 +48,7 @@ jobs:
             if type == "array" then
               any(.[]; candidate == $user)
             elif type == "object" then
-              (.[$user]? != null) or (((.signatures? // .contributors? // []) | any(.[]; candidate == $user)))
+              (.[$user]? != null) or (((.signedContributors? // .signatures? // .contributors? // []) | any(.[]; candidate == $user)))
             else
               false
             end

--- a/CLA.md
+++ b/CLA.md
@@ -1,0 +1,9 @@
+# Contributor License Agreement
+
+By contributing to this repository, you certify that you have the right to
+submit the contribution under the repository license and that Firelock may use
+and distribute the contribution as part of Kin.
+
+For now, this repository uses a lightweight CLA gate: trusted automation and
+repository owner accounts may be allowlisted, and external contributors must be
+recorded in `signatures/cla.json` before their pull request is merged.

--- a/signatures/cla.json
+++ b/signatures/cla.json
@@ -1,1 +1,3 @@
-[]
+{
+  "signedContributors": []
+}


### PR DESCRIPTION
## Summary
Repairs the CLA gate so it stops failing on every kin PR (FIR-995): the PR author login (troyjr4103) was absent from the allowlist, signatures/cla.json was the wrong shape, and CLA.md 404'd.

- add the actual PR author login to the CLA allowlist
- normalize signatures/cla.json to the documented object shape (signedContributors)
- add a root CLA.md
- teach the gate to read signedContributors/contributors

## Why
kin#39 (M1 blend PR) and every kin PR show a red `cla` check purely from this config/login mismatch (advisory but always red).

## Verification
- parsed signatures/cla.json as JSON (object shape)
- ran the CLA allowlist shell check locally with PR_AUTHOR=troyjr4103 -> passes
- git diff --check clean

Authored by Codex; pushed + PR'd by Claude (Troy-authorized --no-verify). Linear: FIR-995.