### PR TITLE
chore: bump kin-db pin to 0.2.4 (FIR-1051)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3057,9 +3057,9 @@ dependencies = [
 
 [[package]]
 name = "kin-db"
-version = "0.2.3"
+version = "0.2.4"
 source = "sparse+https://kinlab.ai/registry/cargo/"
-checksum = "ab5ca4f070ca83e772e8aaa289cbb72d4732166a0df22bab746dd873706266b1"
+checksum = "7cb64edf189c1e7f076e9779ef1724c151c7ef5af3766c9e09260a6d48d592ec"
 dependencies = [
  "bincode",
  "bytes",
@@ -6329,7 +6329,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.48.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -143,5 +143,5 @@ kin-lsp = { version = "0.2.0", registry = "kin" }
 # backend on every target (incl. Linux, where it cannot compile). Metal is re-enabled
 # additively on macOS via a `[target.'cfg(target_os = "macos")'.dependencies]` block in the
 # binary/runtime crates (kin-cli, kin-daemon). Feature unification makes that additive.
-kin-db = { version = "0.2.3", registry = "kin", default-features = false, features = ["vector", "embeddings"] }
+kin-db = { version = "0.2.4", registry = "kin", default-features = false, features = ["vector", "embeddings"] }
 kin-vfs-core = { version = "0.1.0", registry = "kin" }


### PR DESCRIPTION
Bumps kin-db to 0.2.4, which carries the FIR-1051 kvec reopen-gate fix (validate vector sidecar against the stable persisted root). kin-db 0.2.4 is published to the registry.