### PR TITLE
fix(mcp): graph-only find_references; honest semantic_locate scope (FIR-920)

### DIFF
--- a/crates/kin-mcp/src/handlers/common.rs
+++ b/crates/kin-mcp/src/handlers/common.rs
@@ -3,7 +3,7 @@
 
 use serde::Serialize;
 use std::collections::{HashMap, HashSet};
-use std::path::{Path, PathBuf};
+use std::path::PathBuf;
 
 use kin_model::entity::{Entity, EntityKind, SourceSpan};
 use kin_model::graph::{EntityFilter, GraphStore};
@@ -929,48 +929,6 @@ pub fn collect_graph_reference_rows<G: GraphStore>(
     Ok(rows)
 }
 
-pub fn merge_text_reference_rows(
-    rows: &mut Vec<ReferenceRow>,
-    text_refs: Vec<kin_core::TextReferenceMatch>,
-) {
-    let mut index_by_key = HashMap::new();
-    for (index, row) in rows.iter().enumerate() {
-        index_by_key.insert(
-            reference_row_key(row.file_path.as_deref(), &row.name),
-            index,
-        );
-        if let Some(path) = row.file_path.as_deref() {
-            index_by_key.insert(path.to_string(), index);
-        }
-    }
-
-    for text_ref in text_refs {
-        let key = text_ref.file_path.clone();
-        if let Some(existing) = index_by_key.get(&key).copied() {
-            let row = &mut rows[existing];
-            if row.start_line.is_none() {
-                row.start_line = text_ref.start_line;
-            }
-            for kind in text_ref.relation_kinds {
-                push_reference_kind(&mut row.relation_kinds, kind);
-            }
-            row.relation_kinds.sort_by_key(relation_kind_rank);
-            continue;
-        }
-
-        let index = rows.len();
-        rows.push(ReferenceRow {
-            name: label_from_path(&text_ref.file_path),
-            kind: None,
-            file_path: Some(text_ref.file_path.clone()),
-            start_line: text_ref.start_line,
-            signature: None,
-            relation_kinds: text_ref.relation_kinds,
-        });
-        index_by_key.insert(key, index);
-    }
-}
-
 pub fn reference_row_key(file_path: Option<&str>, name: &str) -> String {
     file_path
         .map(|path| path.to_string())
@@ -980,22 +938,10 @@ pub fn reference_row_key(file_path: Option<&str>, name: &str) -> String {
 pub const MCP_SOURCE_MAX_LINES: usize = 40;
 pub const MCP_SOURCE_MAX_CHARS: usize = 2400;
 
-pub fn label_from_path(rel_path: &str) -> String {
-    Path::new(rel_path)
-        .file_stem()
-        .and_then(|stem| stem.to_str())
-        .unwrap_or(rel_path)
-        .to_string()
-}
-
 pub fn push_reference_kind(kinds: &mut Vec<RelationKind>, kind: RelationKind) {
     if !kinds.contains(&kind) {
         kinds.push(kind);
     }
-}
-
-pub fn resolve_reference_source_root() -> Option<PathBuf> {
-    candidate_source_roots().into_iter().next()
 }
 
 pub fn candidate_source_roots() -> Vec<PathBuf> {

--- a/crates/kin-mcp/src/handlers/entities.rs
+++ b/crates/kin-mcp/src/handlers/entities.rs
@@ -77,21 +77,23 @@ pub fn handle_semantic_search<G: GraphStore>(
 }
 
 pub const SEMANTIC_LOCATE_DESC: &str = "\
-Rank the code most relevant to a natural-language query using Kin's real vector index — \
-the same embedding-backed retrieval that powers `kin locate`, not a name/metadata filter. \
+Rank the code most relevant to a natural-language query by embedding similarity against \
+Kin's real vector index — a graph-native semantic ranking, not a name/metadata filter. \
 This is the tool to reach for when you are looking for \"where is the code that does X\" \
 and you only have a description of the behavior, not an exact symbol name. Unlike \
 semantic_search (which matches declarations by name/kind/language and ignores the query \
-for ranking), semantic_locate embeds your query and scores entities by semantic \
-similarity against the graph's vector index, returning a ranked list with relevance \
-scores. Set granularity to \"entity\" (default) for ranked declarations or \"file\" to \
-roll results up to the most relevant files. The response also reports semantic_coverage \
-— the fraction of the graph that has embeddings indexed — so you can tell whether a thin \
-result set means \"not relevant\" or \"not yet embedded\". Requires the Kin daemon: vector \
-search runs against the daemon's live graph and HNSW index, so this tool returns an error \
-in offline/no-daemon mode. On an empty result the additive `negative` object's \
-`safe_to_conclude_absent` flag distinguishes an authoritative \"no match\" from \
-\"not yet embedded\".";
+for ranking), semantic_locate embeds your query and scores entities by cosine similarity \
+against the graph's HNSW index, returning a ranked list with relevance scores. It is a \
+single-vector ranking: it does NOT add the lexical and graph-structure fusion or the \
+cross-encoder reranking that the full `kin locate` CLI pipeline layers on top, so for the \
+product's best-ranked retrieval prefer `kin locate`. Set granularity to \"entity\" \
+(default) for ranked declarations or \"file\" to roll results up to the most relevant \
+files. The response also reports semantic_coverage — the fraction of the graph that has \
+embeddings indexed — so you can tell whether a thin result set means \"not relevant\" or \
+\"not yet embedded\". Requires the Kin daemon: vector search runs against the daemon's \
+live graph and HNSW index, so this tool returns an error in offline/no-daemon mode. On an \
+empty result the additive `negative` object's `safe_to_conclude_absent` flag distinguishes \
+an authoritative \"no match\" from \"not yet embedded\".";
 
 /// Offline/generic dispatch arm for `semantic_locate`.
 ///
@@ -465,10 +467,6 @@ pub async fn handle_find_references<G: GraphStore>(
     };
 
     let mut rows = collect_graph_reference_rows(store, &target.id, &relation_kinds)?;
-    if let Some(source_root) = resolve_reference_source_root() {
-        let text_refs = kin_core::find_text_references(&source_root, &target, &relation_kinds);
-        merge_text_reference_rows(&mut rows, text_refs);
-    }
     rows.sort_by(|left, right| {
         left.file_path
             .cmp(&right.file_path)
@@ -1853,6 +1851,53 @@ mod tests {
         assert_eq!(rows.len(), 2);
         assert_eq!(rows[0]["error"], "invalid entity_id (not a UUID)");
         assert_eq!(rows[1]["error"], "entity not found");
+    }
+
+    #[tokio::test]
+    async fn find_references_returns_only_graph_edges() {
+        let store = InMemoryGraph::new();
+        let caller = make_entity("caller", "src/a.rs");
+        let target = make_entity("target", "src/b.rs");
+        let caller_id = caller.id;
+        let target_id = target.id;
+
+        store.upsert_entity(&caller).unwrap();
+        store.upsert_entity(&target).unwrap();
+        store
+            .upsert_relation(&make_relation(caller_id, target_id, RelationKind::Calls))
+            .unwrap();
+
+        let mut args = HashMap::new();
+        args.insert(
+            "entity_id".to_string(),
+            serde_json::json!(target_id.to_string()),
+        );
+
+        let body = parsed_response(&handle_find_references(&args, &store).await.unwrap());
+        assert_eq!(body["total_upstream"], 1);
+        let refs = body["references"].as_array().unwrap();
+        assert_eq!(refs.len(), 1);
+        assert_eq!(refs[0]["name"], "caller");
+        assert_eq!(refs[0]["file_path"], "src/a.rs");
+        assert_eq!(refs[0]["kind"], "Function");
+    }
+
+    #[tokio::test]
+    async fn find_references_reports_empty_graph_gap_without_backfill() {
+        let store = InMemoryGraph::new();
+        let target = make_entity("orphan", "src/orphan.rs");
+        let target_id = target.id;
+        store.upsert_entity(&target).unwrap();
+
+        let mut args = HashMap::new();
+        args.insert(
+            "entity_id".to_string(),
+            serde_json::json!(target_id.to_string()),
+        );
+
+        let body = parsed_response(&handle_find_references(&args, &store).await.unwrap());
+        assert_eq!(body["total_upstream"], 0);
+        assert!(body["references"].as_array().unwrap().is_empty());
     }
 
     #[test]


### PR DESCRIPTION
## FIR-920 — kin-mcp thesis compliance (Zero File-Search Authority)

Two sub-fixes in `crates/kin-mcp/`.

### 1. find_references — remove raw-grep injection (thesis fix)
`handle_find_references` previously merged recursive-cwd text-grep rows
(`find_text_references` over a resolved source root) into the graph-derived
reference set on the **default authoritative path**, presenting filesystem
matches as if they were graph reference edges.

- The default path now returns **only graph-derived reference edges**
  (`collect_graph_reference_rows`) plus federated Spine xref edges (graph
  truth), sorted.
- When the graph has no incoming references, the result is an empty set
  already qualified by the additive `negative` object
  (`safe_to_conclude_absent`) — the graph gap is reported honestly instead
  of being backfilled by raw file search.
- Removed the now-dead helpers `merge_text_reference_rows`,
  `resolve_reference_source_root`, and `label_from_path`.

### 2. semantic_locate — honest scope (not full `kin locate` parity)
`semantic_locate` is a single-vector HNSW cosine ranking. Its description
previously claimed it was "the same embedding-backed retrieval that powers
`kin locate`", which overstates it: `kin locate` layers lexical +
graph-structure fusion and cross-encoder reranking on top. The description
now accurately states it is a single-vector ranking and points to `kin locate`
for the product's best-ranked retrieval.

**Not fully routed:** wiring `semantic_locate` through the full `kin locate`
fusion path (`run_with_graph_capture_*` in kin-cli) is dependency-feasible
(kin-daemon already depends on kin-cli) but requires a non-trivial
`LocateResult` → MCP contract mapping (fusion symbols don't carry `entity_id`)
and has telemetry / timeout / coverage-gating behaviors that cannot be
validated without running the daemon. Scoped honestly here; full routing left
as the clear seam at `build_semantic_locate_result`. Note: the raw HNSW path
is graph-native and does **not** violate the Zero File-Search rule.

### Tests
Added graph-only regression tests for find_references (graph edges only; empty
graph reports an honest empty gap with no text backfill). `cargo build` +
`cargo test -p kin-mcp` green (167 tests pass).
