### PR TITLE
fix(daemon): gate pre-0.2 repos with actionable error, not bare SIGTERM (FIR-978)

### DIFF
--- a/crates/kin-cli/src/commands/init.rs
+++ b/crates/kin-cli/src/commands/init.rs
@@ -267,9 +267,14 @@ fn snapshot_repo(dir: &Path, force: bool) -> Result<(PathBuf, serde_json::Value)
     let mut file_count: u64 = 0;
     let mut total_bytes: u64 = 0;
 
-    if let Err(err) =
-        walk_and_snapshot(dir, dir, snapshot_dir, &ignore, &mut file_count, &mut total_bytes)
-    {
+    if let Err(err) = walk_and_snapshot(
+        dir,
+        dir,
+        snapshot_dir,
+        &ignore,
+        &mut file_count,
+        &mut total_bytes,
+    ) {
         let _ = fs::remove_dir_all(&tmp_snapshot);
         return Err(err);
     }

--- a/crates/kin-core/src/manifest.rs
+++ b/crates/kin-core/src/manifest.rs
@@ -7,6 +7,14 @@ use std::path::Path;
 use crate::error::{KinError, Result};
 use crate::layout::KinLayout;
 
+/// Minimum `kin_version` (major, minor) this binary can open an existing repo
+/// with. A repo created by an older Kin (e.g. 0.1.x) carries an on-disk graph
+/// and vector index built before a breaking format change; the post-load embed
+/// and readiness path cannot serve it, so opening it must be refused up front
+/// with an actionable error instead of loading and then being SIGTERM-killed by
+/// the CLI supervisor when readiness never arrives.
+pub const MIN_COMPATIBLE_KIN_VERSION: (u64, u64) = (0, 2);
+
 /// Repo identity stored in `.kin/manifest.json`.
 ///
 /// This records the Kin version that created the repo, detected languages,
@@ -37,6 +45,76 @@ impl Default for KinManifest {
     }
 }
 
+/// Outcome of comparing a repo's recorded `kin_version` against this binary's
+/// minimum-compatible floor ([`MIN_COMPATIBLE_KIN_VERSION`]).
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum ManifestCompatibility {
+    /// The recorded version meets or exceeds the floor (or is unparseable and
+    /// therefore not provably old — see [`classify_kin_version`]).
+    Compatible,
+    /// The recorded version predates the floor and the repo must be rebuilt
+    /// before this binary can open it.
+    TooOld { found: String },
+}
+
+impl ManifestCompatibility {
+    /// Whether the repo can be opened by this binary.
+    pub fn is_compatible(&self) -> bool {
+        matches!(self, ManifestCompatibility::Compatible)
+    }
+
+    /// An actionable, user-facing message describing the version gap and how to
+    /// resolve it, or `None` when the repo is compatible. Names the recorded
+    /// version, the required floor, and the two rebuild paths (`kin migrate` /
+    /// `kin embed --rebuild`).
+    pub fn incompatibility_message(&self) -> Option<String> {
+        match self {
+            ManifestCompatibility::Compatible => None,
+            ManifestCompatibility::TooOld { found } => Some(format!(
+                "this repository was created by kin {found}, but this kin build \
+                 requires a repository created by kin {}.{}.x or newer. Its \
+                 on-disk graph and vector index predate a breaking format change \
+                 and cannot be served as-is. Run `kin migrate` to rebuild the \
+                 graph from source, or `kin embed --rebuild` to rebuild the \
+                 vector index at the current model dimension.",
+                MIN_COMPATIBLE_KIN_VERSION.0, MIN_COMPATIBLE_KIN_VERSION.1
+            )),
+        }
+    }
+}
+
+/// Parse the leading `MAJOR.MINOR` from a `kin_version` string, ignoring any
+/// patch / pre-release suffix. Returns `None` when major or minor are not
+/// numeric.
+fn parse_major_minor(version: &str) -> Option<(u64, u64)> {
+    let mut parts = version.trim().split('.');
+    let major = parts.next()?.trim().parse::<u64>().ok()?;
+    // A patch/pre-release suffix may ride on the minor segment (e.g. "2-rc1");
+    // take the leading run of digits so it still parses.
+    let minor_segment = parts.next()?.trim();
+    let minor_digits: String = minor_segment
+        .chars()
+        .take_while(|c| c.is_ascii_digit())
+        .collect();
+    let minor = minor_digits.parse::<u64>().ok()?;
+    Some((major, minor))
+}
+
+/// Classify a recorded `kin_version` against [`MIN_COMPATIBLE_KIN_VERSION`].
+///
+/// An unparseable version is treated as [`ManifestCompatibility::Compatible`]:
+/// the gate only blocks a version it can prove is older than the floor, never a
+/// version it merely fails to understand. (`KinManifest::new` always stamps a
+/// valid semver, so unparseable should not occur for repos this binary made.)
+pub fn classify_kin_version(version: &str) -> ManifestCompatibility {
+    match parse_major_minor(version) {
+        Some(found) if found < MIN_COMPATIBLE_KIN_VERSION => ManifestCompatibility::TooOld {
+            found: version.trim().to_string(),
+        },
+        _ => ManifestCompatibility::Compatible,
+    }
+}
+
 impl KinManifest {
     /// Create a new manifest for a freshly initialized repository.
     pub fn new() -> Self {
@@ -62,6 +140,43 @@ impl KinManifest {
         std::fs::write(path, contents).map_err(|e| KinError::io(path, e))?;
         Ok(())
     }
+
+    /// Classify this manifest's recorded `kin_version` against the
+    /// minimum-compatible floor ([`MIN_COMPATIBLE_KIN_VERSION`]).
+    pub fn compatibility(&self) -> ManifestCompatibility {
+        classify_kin_version(&self.kin_version)
+    }
+
+    /// Whether a repo with this manifest can be opened by this binary.
+    pub fn is_compatible(&self) -> bool {
+        self.compatibility().is_compatible()
+    }
+}
+
+/// Read ONLY the `kin_version` from a `.kin/manifest.json` and classify it
+/// against [`MIN_COMPATIBLE_KIN_VERSION`].
+///
+/// Deliberately resilient: it deserializes just the version field, so an older
+/// or partial manifest (one that predates fields this build expects) still
+/// gates correctly rather than failing with an opaque parse error. A missing
+/// file yields [`ManifestCompatibility::Compatible`] — callers decide how to
+/// treat an absent manifest — and a manifest with no `kin_version` is likewise
+/// treated as compatible rather than blocked.
+pub fn check_manifest_compatibility(path: &Path) -> Result<ManifestCompatibility> {
+    if !path.exists() {
+        return Ok(ManifestCompatibility::Compatible);
+    }
+    #[derive(Deserialize)]
+    struct VersionProbe {
+        #[serde(default)]
+        kin_version: Option<String>,
+    }
+    let contents = std::fs::read_to_string(path).map_err(|e| KinError::io(path, e))?;
+    let probe: VersionProbe = serde_json::from_str(&contents)?;
+    Ok(match probe.kin_version {
+        Some(version) => classify_kin_version(&version),
+        None => ManifestCompatibility::Compatible,
+    })
 }
 
 /// Resolve the canonical repo id for a discovered Kin layout.
@@ -136,5 +251,125 @@ mod tests {
 
         let resolved = resolve_repo_id(&layout, None).unwrap();
         assert_eq!(resolved, manifest.repo_id);
+    }
+
+    #[test]
+    fn classify_rejects_pre_floor_versions() {
+        assert_eq!(
+            classify_kin_version("0.1.0"),
+            ManifestCompatibility::TooOld {
+                found: "0.1.0".to_string()
+            }
+        );
+        assert_eq!(
+            classify_kin_version("0.0.9"),
+            ManifestCompatibility::TooOld {
+                found: "0.0.9".to_string()
+            }
+        );
+    }
+
+    #[test]
+    fn classify_accepts_floor_and_newer() {
+        assert_eq!(
+            classify_kin_version("0.2.0"),
+            ManifestCompatibility::Compatible
+        );
+        assert_eq!(
+            classify_kin_version("0.2.5"),
+            ManifestCompatibility::Compatible
+        );
+        assert_eq!(
+            classify_kin_version("0.3.0"),
+            ManifestCompatibility::Compatible
+        );
+        assert_eq!(
+            classify_kin_version("1.0.0"),
+            ManifestCompatibility::Compatible
+        );
+    }
+
+    #[test]
+    fn classify_is_lenient_on_unparseable_versions() {
+        // A version we cannot understand is never blocked — only provably-old
+        // versions are refused.
+        assert_eq!(classify_kin_version(""), ManifestCompatibility::Compatible);
+        assert_eq!(
+            classify_kin_version("garbage"),
+            ManifestCompatibility::Compatible
+        );
+        assert_eq!(classify_kin_version("0"), ManifestCompatibility::Compatible);
+    }
+
+    #[test]
+    fn classify_handles_prerelease_suffix_on_minor() {
+        assert_eq!(
+            classify_kin_version("0.1-rc1"),
+            ManifestCompatibility::TooOld {
+                found: "0.1-rc1".to_string()
+            }
+        );
+        assert_eq!(
+            classify_kin_version("0.2-rc1"),
+            ManifestCompatibility::Compatible
+        );
+    }
+
+    #[test]
+    fn current_build_version_is_compatible() {
+        // The version this binary stamps into fresh manifests must always pass
+        // its own floor — otherwise `kin init` would create unopenable repos.
+        assert!(KinManifest::new().is_compatible());
+    }
+
+    #[test]
+    fn incompatibility_message_names_gap_and_fix_commands() {
+        let message = classify_kin_version("0.1.0")
+            .incompatibility_message()
+            .expect("0.1.0 is below the floor");
+        assert!(message.contains("0.1.0"));
+        assert!(message.contains("0.2"));
+        assert!(message.contains("kin migrate"));
+        assert!(message.contains("kin embed --rebuild"));
+        // Compatible versions carry no message.
+        assert!(classify_kin_version("0.2.0")
+            .incompatibility_message()
+            .is_none());
+    }
+
+    #[test]
+    fn check_manifest_compatibility_gates_tiny_old_manifest() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("manifest.json");
+        // A minimal manifest with only the version field — the probe reads just
+        // `kin_version`, so it gates without the other fields being present.
+        std::fs::write(&path, r#"{"kin_version":"0.1.0"}"#).unwrap();
+        assert_eq!(
+            check_manifest_compatibility(&path).unwrap(),
+            ManifestCompatibility::TooOld {
+                found: "0.1.0".to_string()
+            }
+        );
+    }
+
+    #[test]
+    fn check_manifest_compatibility_missing_file_is_compatible() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("does-not-exist.json");
+        assert_eq!(
+            check_manifest_compatibility(&path).unwrap(),
+            ManifestCompatibility::Compatible
+        );
+    }
+
+    #[test]
+    fn check_manifest_compatibility_accepts_current_manifest() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("manifest.json");
+        KinManifest::new().save(&path).unwrap();
+        assert_eq!(
+            check_manifest_compatibility(&path).unwrap(),
+            ManifestCompatibility::Compatible
+        );
     }
 }

--- a/crates/kin-daemon/src/error.rs
+++ b/crates/kin-daemon/src/error.rs
@@ -26,6 +26,9 @@ pub enum DaemonError {
     #[error("Not initialized: no .kin/ directory found")]
     NotInitialized,
 
+    #[error("{0}")]
+    IncompatibleRepo(String),
+
     #[error("Already running")]
     AlreadyRunning,
 

--- a/crates/kin-daemon/src/state.rs
+++ b/crates/kin-daemon/src/state.rs
@@ -437,6 +437,24 @@ impl DaemonState {
 
     /// Open an existing .kin/ directory and create daemon state.
     pub fn open(layout: KinLayout) -> Result<Self> {
+        // Up-front compatibility gate. A repo created by a pre-0.2 kin carries
+        // an on-disk graph/index that this build's post-load embed/readiness
+        // path cannot serve. Without this gate the daemon loads the snapshot,
+        // then readiness never arrives and the CLI supervisor kills the process
+        // with a bare SIGTERM — opaque to the user. Refuse here, before opening
+        // kin-db or starting the embed worker, with an actionable error naming
+        // the version gap and the rebuild commands.
+        match kin_core::manifest::check_manifest_compatibility(&layout.manifest_path())
+            .map_err(DaemonError::from)?
+        {
+            kin_core::manifest::ManifestCompatibility::Compatible => {}
+            incompatible => {
+                if let Some(message) = incompatible.incompatibility_message() {
+                    return Err(DaemonError::IncompatibleRepo(message));
+                }
+            }
+        }
+
         let text_index_path = layout.text_index_dir();
         let locate_only = Self::locate_only_snapshot_mode();
         let (graph, loaded_snapshot) = if let Some(kndb_path) = Self::find_kndb_path(&layout) {
@@ -1981,6 +1999,51 @@ mod tests {
         let message = err.to_string();
         assert!(message.contains("failed to load persisted graph snapshot"));
         assert!(message.contains("graph.kndb"));
+    }
+
+    #[test]
+    fn open_rejects_pre_0_2_repo_with_actionable_error() {
+        // FIR-978: a repo created by a pre-0.2 kin must be refused UP FRONT with
+        // a clear, actionable error — never loaded into a daemon that then fails
+        // readiness and gets SIGTERM-killed by the supervisor. The gate fires
+        // before the graph snapshot is touched, so a tiny manifest fixture (just
+        // the version field) is enough to reproduce it.
+        let repo_dir = tempfile::tempdir().unwrap();
+        let kin_dir = repo_dir.path().join(".kin");
+        std::fs::create_dir_all(&kin_dir).unwrap();
+        std::fs::write(kin_dir.join("manifest.json"), r#"{"kin_version":"0.1.0"}"#).unwrap();
+        let layout = kin_core::KinLayout::new(kin_dir);
+
+        let err = match DaemonState::open(layout) {
+            Ok(_) => panic!("expected pre-0.2 repo open to be refused"),
+            Err(err) => err,
+        };
+        assert!(
+            matches!(err, DaemonError::IncompatibleRepo(_)),
+            "expected IncompatibleRepo, got {err:?}"
+        );
+        let message = err.to_string();
+        assert!(
+            message.contains("0.1.0"),
+            "message must name the found version: {message}"
+        );
+        assert!(
+            message.contains("0.2"),
+            "message must name the required floor: {message}"
+        );
+        assert!(
+            message.contains("kin migrate") && message.contains("kin embed --rebuild"),
+            "message must name the rebuild commands: {message}"
+        );
+    }
+
+    #[test]
+    fn open_accepts_current_version_repo() {
+        // The complement to the gate test: a repo stamped at the current build
+        // version opens cleanly (the gate must not false-positive on fresh repos).
+        let repo_dir = tempfile::tempdir().unwrap();
+        let init = kin_core::init(repo_dir.path()).unwrap();
+        DaemonState::open(init.layout).expect("current-version repo must open");
     }
 
     #[test]


### PR DESCRIPTION
## What

Closes the **kin half** of FIR-978. The kin-db half (PR #31) made a pre-0.2 graph snapshot load through all kin-db paths; this PR stops the daemon from accepting a pre-0.2 *repo* and then dying to a bare SIGTERM.

### The bug
A repo created by a pre-0.2 kin (e.g. `kin_version "0.1.0"`, real repro: `~/kin-dogfood/.kin`) loads its graph snapshot fine, but the daemon's post-load embed/readiness path never reaches ready (stale v1 kvec / pipeline-epoch mismatch). The CLI supervisor then kills the not-ready daemon with signal 15 — the user sees an opaque sub-second SIGTERM, not a cause.

### The fix — an up-front compatibility gate
- **kin-core** (`manifest.rs`): `MIN_COMPATIBLE_KIN_VERSION` floor (`0.2`), a `ManifestCompatibility` enum, `classify_kin_version`, `KinManifest::compatibility()/is_compatible()`, and a resilient `check_manifest_compatibility(path)` probe that deserializes **only** `kin_version` (so a partial/older manifest still gates instead of erroring opaquely). Lenient on unparseable versions — only a version we can *prove* is below the floor is refused.
- **kin-daemon** (`state.rs`): `DaemonState::open` runs the gate **before** opening kin-db / starting the embed worker / readiness, returning a new `DaemonError::IncompatibleRepo` whose message names the version gap and the rebuild commands (`kin migrate` / `kin embed --rebuild`). The CLI's `wait_for_daemon_ready` already surfaces the daemon's startup log tail when the child exits during startup, so the actionable message reaches the user.

Does not depend on the new kin-db `IncompatibleSnapshotVersion` variant (kin pins kin-db 0.2.4, which lacks it) — the error is constructed in kin with the same message shape.

## Tests
- `kin-daemon`: `open_rejects_pre_0_2_repo_with_actionable_error` (tiny `{"kin_version":"0.1.0"}` fixture → graceful actionable error naming the gap + fix commands, **not** a panic/SIGTERM) and `open_accepts_current_version_repo` (no false-positive on fresh repos).
- `kin-core`: classifier (reject pre-floor / accept floor+newer / lenient-on-unparseable / prerelease-suffix), probe (tiny old manifest, missing file, current manifest), message shape, and a guard that the current build's own stamped version always passes the floor.

`cargo build -p kin-core -p kin-daemon` clean; `kin-core manifest` (16) + `kin-daemon state::` (30) green.
