### PR TITLE
feat(daemon): stale-lock reclaim + kin gc for the ~/.kin cache (FIR-982)

### DIFF
--- a/crates/kin-cli/src/commands/gc.rs
+++ b/crates/kin-cli/src/commands/gc.rs
@@ -1,0 +1,474 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Firelock, LLC
+
+//! `kin gc` — reclaim space from the global `~/.kin` content cache.
+//!
+//! The init warm-start cache (`~/.kin/cache/init/<namespace>/<repo>/bundles/`)
+//! keeps one graph bundle per git HEAD it has ever warmed, and never evicts
+//! them, so a repo that is re-initialized often accumulates hundreds of
+//! multi-GB bundles. `kin gc` prunes that cache toward a healthy size by
+//! removing:
+//!
+//! - **orphaned bundles** — bundle dirs on disk that the repo's `manifest.json`
+//!   no longer references at all; and
+//! - **aged bundles** — referenced bundles older than `--max-age-days`, except
+//!   the repo's `current_bundle_id`, which is always preserved.
+//!
+//! A reclaimed-but-still-referenced bundle is safe to remove: the next
+//! `kin init` at that HEAD re-checks the bundle path, misses, and rebuilds it —
+//! a cache miss, never corruption.
+//!
+//! `--dry-run` reports what would be reclaimed (and the total size) without
+//! deleting anything.
+
+use std::collections::BTreeSet;
+use std::path::{Path, PathBuf};
+use std::time::{Duration, SystemTime};
+
+use anyhow::Result;
+use serde::Deserialize;
+
+/// Default age threshold: bundles older than this (and not the current bundle)
+/// are reclaimed. Conservative enough that an actively re-initialized repo keeps
+/// its recent warm bundles.
+const DEFAULT_MAX_AGE_DAYS: u64 = 14;
+
+/// Why a cache entry is being reclaimed — surfaced in the report so the action
+/// is never silent.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum ReclaimReason {
+    /// On disk but not referenced by the repo's manifest.
+    Orphaned,
+    /// Referenced but older than the age threshold (not the current bundle).
+    Aged,
+}
+
+impl ReclaimReason {
+    fn label(self) -> &'static str {
+        match self {
+            ReclaimReason::Orphaned => "orphaned",
+            ReclaimReason::Aged => "aged",
+        }
+    }
+}
+
+/// A single reclaimable cache entry (a bundle directory).
+#[derive(Debug, Clone)]
+struct ReclaimEntry {
+    path: PathBuf,
+    bytes: u64,
+    reason: ReclaimReason,
+}
+
+/// The set of entries a gc pass would reclaim, with the total size.
+#[derive(Debug, Default)]
+struct GcPlan {
+    entries: Vec<ReclaimEntry>,
+    total_bytes: u64,
+}
+
+impl GcPlan {
+    fn push(&mut self, entry: ReclaimEntry) {
+        self.total_bytes = self.total_bytes.saturating_add(entry.bytes);
+        self.entries.push(entry);
+    }
+}
+
+/// Minimal view of a warm-cache `manifest.json` — only the fields gc needs.
+/// Resilient by design: unrelated fields are ignored and missing ones default,
+/// so a manifest written by a newer or older build still parses.
+#[derive(Debug, Deserialize, Default)]
+struct CacheManifest {
+    #[serde(default)]
+    current_bundle_id: Option<String>,
+    /// git HEAD → bundle id. Every value here is a referenced bundle.
+    #[serde(default)]
+    heads: std::collections::BTreeMap<String, String>,
+}
+
+impl CacheManifest {
+    /// All bundle ids this manifest references (current + every head target).
+    fn referenced_ids(&self) -> BTreeSet<String> {
+        let mut ids: BTreeSet<String> = self.heads.values().cloned().collect();
+        if let Some(current) = &self.current_bundle_id {
+            ids.insert(current.clone());
+        }
+        ids
+    }
+}
+
+/// Resolve the base directory that holds the init warm-cache namespaces.
+///
+/// Mirrors `kin init`'s resolution: an explicit `KIN_INIT_CACHE_DIR` wins,
+/// otherwise `~/.kin/cache/init`. Returns `None` only when neither the env var
+/// nor a home directory can be resolved.
+fn init_cache_base() -> Option<PathBuf> {
+    if let Ok(dir) = std::env::var("KIN_INIT_CACHE_DIR") {
+        if !dir.trim().is_empty() {
+            return Some(PathBuf::from(dir));
+        }
+    }
+    directories::BaseDirs::new().map(|dirs| dirs.home_dir().join(".kin/cache/init"))
+}
+
+/// Total size in bytes of a directory tree. Best-effort: unreadable entries are
+/// skipped (counted as zero) rather than failing the whole pass.
+fn dir_size(path: &Path) -> u64 {
+    let mut total = 0u64;
+    let Ok(entries) = std::fs::read_dir(path) else {
+        return std::fs::metadata(path).map(|m| m.len()).unwrap_or(0);
+    };
+    for entry in entries.flatten() {
+        let entry_path = entry.path();
+        match entry.file_type() {
+            Ok(ft) if ft.is_dir() => total = total.saturating_add(dir_size(&entry_path)),
+            Ok(_) => {
+                total = total.saturating_add(entry.metadata().map(|m| m.len()).unwrap_or(0));
+            }
+            Err(_) => {}
+        }
+    }
+    total
+}
+
+/// Whether `path`'s last-modified time is older than `max_age` relative to
+/// `now`. A path whose mtime cannot be read is treated as NOT old (kept), so an
+/// unreadable timestamp never causes deletion.
+fn is_older_than(path: &Path, max_age: Duration, now: SystemTime) -> bool {
+    let Ok(meta) = std::fs::metadata(path) else {
+        return false;
+    };
+    let Ok(modified) = meta.modified() else {
+        return false;
+    };
+    now.duration_since(modified)
+        .map(|age| age > max_age)
+        .unwrap_or(false)
+}
+
+/// Recursively locate warm-cache repo directories under `base`. A repo dir is
+/// any directory that has both a `manifest.json` and a `bundles/` subdir; the
+/// walk stops descending once it finds one. Depth-bounded so it cannot wander
+/// arbitrarily deep, and works for both the namespaced home layout
+/// (`<base>/<namespace>/<repo>`) and the flat `KIN_INIT_CACHE_DIR` layout.
+fn find_repo_cache_dirs(base: &Path) -> Vec<PathBuf> {
+    fn walk(dir: &Path, depth: usize, out: &mut Vec<PathBuf>) {
+        if depth > 4 {
+            return;
+        }
+        if dir.join("manifest.json").is_file() && dir.join("bundles").is_dir() {
+            out.push(dir.to_path_buf());
+            return;
+        }
+        let Ok(entries) = std::fs::read_dir(dir) else {
+            return;
+        };
+        for entry in entries.flatten() {
+            if entry.file_type().map(|ft| ft.is_dir()).unwrap_or(false) {
+                walk(&entry.path(), depth + 1, out);
+            }
+        }
+    }
+    let mut out = Vec::new();
+    if base.is_dir() {
+        walk(base, 0, &mut out);
+    }
+    out
+}
+
+/// Build the reclaim plan for a single repo cache dir.
+fn plan_repo_cache(repo_dir: &Path, max_age: Duration, now: SystemTime, plan: &mut GcPlan) {
+    // Only act on a parseable manifest: it tells us which bundle is current and
+    // which are still referenced. Without it we cannot reclaim safely, so skip.
+    let manifest_path = repo_dir.join("manifest.json");
+    let Ok(contents) = std::fs::read_to_string(&manifest_path) else {
+        return;
+    };
+    let Ok(manifest) = serde_json::from_str::<CacheManifest>(&contents) else {
+        return;
+    };
+    let referenced = manifest.referenced_ids();
+
+    let bundles_dir = repo_dir.join("bundles");
+    let Ok(entries) = std::fs::read_dir(&bundles_dir) else {
+        return;
+    };
+    for entry in entries.flatten() {
+        if !entry.file_type().map(|ft| ft.is_dir()).unwrap_or(false) {
+            continue;
+        }
+        let bundle_path = entry.path();
+        let Some(id) = bundle_path
+            .file_name()
+            .and_then(|n| n.to_str())
+            .map(str::to_string)
+        else {
+            continue;
+        };
+
+        // Never reclaim the active bundle.
+        if manifest.current_bundle_id.as_deref() == Some(id.as_str()) {
+            continue;
+        }
+
+        let reason = if !referenced.contains(&id) {
+            Some(ReclaimReason::Orphaned)
+        } else if is_older_than(&bundle_path, max_age, now) {
+            Some(ReclaimReason::Aged)
+        } else {
+            None
+        };
+
+        if let Some(reason) = reason {
+            let bytes = dir_size(&bundle_path);
+            plan.push(ReclaimEntry {
+                path: bundle_path,
+                bytes,
+                reason,
+            });
+        }
+    }
+}
+
+/// Compute the full reclaim plan for the init warm-cache rooted at `base`.
+/// Pure (no deletion) so it is unit-testable; `now` is injected for the same
+/// reason.
+fn plan_init_cache_gc(base: &Path, max_age: Duration, now: SystemTime) -> GcPlan {
+    let mut plan = GcPlan::default();
+    for repo_dir in find_repo_cache_dirs(base) {
+        plan_repo_cache(&repo_dir, max_age, now, &mut plan);
+    }
+    plan
+}
+
+/// Render a byte count as a short human-readable string.
+fn human_bytes(bytes: u64) -> String {
+    const UNITS: [&str; 6] = ["B", "KB", "MB", "GB", "TB", "PB"];
+    let mut value = bytes as f64;
+    let mut unit = 0;
+    while value >= 1024.0 && unit < UNITS.len() - 1 {
+        value /= 1024.0;
+        unit += 1;
+    }
+    if unit == 0 {
+        format!("{bytes} {}", UNITS[unit])
+    } else {
+        format!("{value:.1} {}", UNITS[unit])
+    }
+}
+
+/// `kin gc [--dry-run] [--max-age-days N]` — reclaim space from the init
+/// warm-cache.
+pub async fn run(dry_run: bool, max_age_days: Option<u64>) -> Result<()> {
+    let max_age = Duration::from_secs(max_age_days.unwrap_or(DEFAULT_MAX_AGE_DAYS) * 24 * 60 * 60);
+    let now = SystemTime::now();
+
+    let Some(base) = init_cache_base() else {
+        println!("kin gc: no init cache directory to scan (no home directory resolved)");
+        return Ok(());
+    };
+
+    if !base.is_dir() {
+        println!(
+            "kin gc: init cache is empty (nothing at {})",
+            base.display()
+        );
+        return Ok(());
+    }
+
+    let plan = plan_init_cache_gc(&base, max_age, now);
+
+    if plan.entries.is_empty() {
+        println!(
+            "kin gc: nothing to reclaim under {} (max-age {} days)",
+            base.display(),
+            max_age_days.unwrap_or(DEFAULT_MAX_AGE_DAYS)
+        );
+        return Ok(());
+    }
+
+    let verb = if dry_run {
+        "would reclaim"
+    } else {
+        "reclaiming"
+    };
+    println!(
+        "kin gc: {verb} {} cache bundle(s), {} under {}",
+        plan.entries.len(),
+        human_bytes(plan.total_bytes),
+        base.display()
+    );
+
+    let mut reclaimed_bytes = 0u64;
+    let mut reclaimed_count = 0usize;
+    for entry in &plan.entries {
+        if dry_run {
+            println!(
+                "  [{}] {} ({})",
+                entry.reason.label(),
+                entry.path.display(),
+                human_bytes(entry.bytes)
+            );
+            continue;
+        }
+        match std::fs::remove_dir_all(&entry.path) {
+            Ok(()) => {
+                reclaimed_bytes = reclaimed_bytes.saturating_add(entry.bytes);
+                reclaimed_count += 1;
+            }
+            Err(err) => {
+                eprintln!(
+                    "kin gc: failed to remove {} ({}): {err}",
+                    entry.path.display(),
+                    entry.reason.label()
+                );
+            }
+        }
+    }
+
+    if dry_run {
+        println!(
+            "kin gc: dry run — {} reclaimable across {} bundle(s). Re-run without --dry-run to delete.",
+            human_bytes(plan.total_bytes),
+            plan.entries.len()
+        );
+    } else {
+        println!(
+            "kin gc: reclaimed {} across {} bundle(s)",
+            human_bytes(reclaimed_bytes),
+            reclaimed_count
+        );
+    }
+
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::fs;
+
+    /// Build a repo cache dir with the given bundles and manifest references.
+    /// `bundle_files` maps bundle id → file bytes to write into it.
+    fn make_repo_cache(
+        repo: &Path,
+        current: Option<&str>,
+        head_targets: &[&str],
+        bundles: &[(&str, usize)],
+    ) {
+        fs::create_dir_all(repo.join("bundles")).unwrap();
+        for (id, size) in bundles {
+            let bundle = repo.join("bundles").join(id);
+            fs::create_dir_all(&bundle).unwrap();
+            fs::write(bundle.join("graph.kndb"), vec![0u8; *size]).unwrap();
+            fs::write(bundle.join(".ready"), b"1").unwrap();
+        }
+        let heads: std::collections::BTreeMap<String, String> = head_targets
+            .iter()
+            .enumerate()
+            .map(|(i, b)| (format!("head{i}"), b.to_string()))
+            .collect();
+        let manifest = serde_json::json!({
+            "schema": "v1",
+            "current_bundle_id": current,
+            "heads": heads,
+        });
+        fs::write(
+            repo.join("manifest.json"),
+            serde_json::to_vec(&manifest).unwrap(),
+        )
+        .unwrap();
+    }
+
+    #[test]
+    fn reclaims_orphaned_bundles_not_referenced_by_manifest() {
+        let dir = tempfile::tempdir().unwrap();
+        let repo = dir.path().join("ns").join("repo");
+        // "cur" is current+referenced; "orphan" is on disk but unreferenced.
+        make_repo_cache(&repo, Some("cur"), &["cur"], &[("cur", 10), ("orphan", 20)]);
+
+        // max_age huge so age never triggers — isolate the orphaned rule.
+        let plan = plan_init_cache_gc(
+            dir.path(),
+            Duration::from_secs(u64::MAX / 2),
+            SystemTime::now(),
+        );
+        assert_eq!(plan.entries.len(), 1, "only the orphan should be reclaimed");
+        assert_eq!(plan.entries[0].reason, ReclaimReason::Orphaned);
+        assert!(plan.entries[0].path.ends_with("bundles/orphan"));
+    }
+
+    #[test]
+    fn reclaims_aged_referenced_bundles_but_preserves_current() {
+        let dir = tempfile::tempdir().unwrap();
+        let repo = dir.path().join("ns").join("repo");
+        // Both referenced via heads; "cur" is current. With max_age 0 every
+        // non-current bundle is "aged", but current must be preserved.
+        make_repo_cache(
+            &repo,
+            Some("cur"),
+            &["cur", "old"],
+            &[("cur", 10), ("old", 30)],
+        );
+
+        let plan = plan_init_cache_gc(dir.path(), Duration::ZERO, SystemTime::now());
+        assert_eq!(plan.entries.len(), 1, "current bundle must be preserved");
+        assert_eq!(plan.entries[0].reason, ReclaimReason::Aged);
+        assert!(plan.entries[0].path.ends_with("bundles/old"));
+        // Whole bundle dir: graph.kndb (30) + .ready (1).
+        assert_eq!(plan.total_bytes, 31);
+    }
+
+    #[test]
+    fn keeps_recent_referenced_bundles() {
+        let dir = tempfile::tempdir().unwrap();
+        let repo = dir.path().join("ns").join("repo");
+        make_repo_cache(
+            &repo,
+            Some("cur"),
+            &["cur", "recent"],
+            &[("cur", 10), ("recent", 30)],
+        );
+
+        // Large max_age: "recent" is referenced and not old → kept. Nothing to do.
+        let plan = plan_init_cache_gc(dir.path(), Duration::from_secs(3600), SystemTime::now());
+        assert!(
+            plan.entries.is_empty(),
+            "recent referenced bundles must be kept"
+        );
+    }
+
+    #[test]
+    fn skips_repo_dirs_without_parseable_manifest() {
+        let dir = tempfile::tempdir().unwrap();
+        let repo = dir.path().join("ns").join("repo");
+        fs::create_dir_all(repo.join("bundles").join("b1")).unwrap();
+        fs::write(
+            repo.join("bundles").join("b1").join("graph.kndb"),
+            vec![0u8; 40],
+        )
+        .unwrap();
+        // No manifest.json → not a recognized repo cache dir → skipped entirely.
+        let plan = plan_init_cache_gc(dir.path(), Duration::ZERO, SystemTime::now());
+        assert!(plan.entries.is_empty());
+    }
+
+    #[test]
+    fn finds_repo_in_flat_layout() {
+        // KIN_INIT_CACHE_DIR layout has repo dirs directly under the base.
+        let dir = tempfile::tempdir().unwrap();
+        let repo = dir.path().join("repo");
+        make_repo_cache(&repo, Some("cur"), &["cur"], &[("cur", 10), ("orphan", 20)]);
+
+        let plan = plan_init_cache_gc(dir.path(), Duration::from_secs(3600), SystemTime::now());
+        assert_eq!(plan.entries.len(), 1);
+        assert!(plan.entries[0].path.ends_with("bundles/orphan"));
+    }
+
+    #[test]
+    fn human_bytes_formats_units() {
+        assert_eq!(human_bytes(512), "512 B");
+        assert_eq!(human_bytes(1536), "1.5 KB");
+        assert_eq!(human_bytes(1024 * 1024 * 1024), "1.0 GB");
+    }
+}

--- a/crates/kin-cli/src/commands/mod.rs
+++ b/crates/kin-cli/src/commands/mod.rs
@@ -24,6 +24,7 @@ pub mod diff;
 pub mod eject;
 pub mod embed;
 pub mod exec;
+pub mod gc;
 pub mod git;
 pub mod graph;
 pub mod graph_health;

--- a/crates/kin-cli/src/main.rs
+++ b/crates/kin-cli/src/main.rs
@@ -644,6 +644,16 @@ enum Command {
         #[arg(long)]
         resume: bool,
     },
+    /// Reclaim space from the global ~/.kin warm-start cache
+    Gc {
+        /// Report what would be reclaimed without deleting anything
+        #[arg(long)]
+        dry_run: bool,
+        /// Reclaim cache bundles older than this many days (default 14).
+        /// The active (current) bundle of each repo is always preserved.
+        #[arg(long, value_name = "DAYS")]
+        max_age_days: Option<u64>,
+    },
     /// Inspect and validate the semantic graph
     Graph {
         #[command(subcommand)]
@@ -2193,6 +2203,10 @@ fn main() -> Result<()> {
                     depth,
                     resume,
                 } => commands::migrate::run(source, depth, resume).await,
+                Command::Gc {
+                    dry_run,
+                    max_age_days,
+                } => commands::gc::run(dry_run, max_age_days).await,
                 Command::Graph { action } => match action {
                     GraphAction::Status => commands::graph::status().await,
                     GraphAction::Validate => commands::graph::validate().await,

--- a/crates/kin-daemon/src/daemon.rs
+++ b/crates/kin-daemon/src/daemon.rs
@@ -379,14 +379,46 @@ pub async fn run(mut state: DaemonState, config: DaemonConfig) -> Result<()> {
     let _daemon_lock = match crate::lifecycle::acquire_singleton_lock(state.layout.root()) {
         Ok(Some(lock)) => lock,
         Ok(None) => {
+            // Contended. Either a live daemon already owns this repo, or a
+            // forked child leaked the flock fd past its dead parent (os error 35
+            // with no live owner). Reclaim clears only the latter — it is a
+            // no-op unless the recorded owner PID is present and dead — so a
+            // genuine second daemon still refuses to start.
+            let cleared = crate::lifecycle::reclaim_stale_locks(state.layout.root());
+            if cleared.is_empty() {
+                warn!(
+                    repo = %state.layout.root().display(),
+                    "another kin daemon already owns this repo — refusing to start a second daemon"
+                );
+                return Ok(());
+            }
             warn!(
                 repo = %state.layout.root().display(),
-                "another kin daemon already owns this repo — refusing to start a second daemon"
+                cleared = cleared.len(),
+                "reclaimed stale repo locks left by a dead daemon; retrying singleton acquire"
             );
-            return Ok(());
+            match crate::lifecycle::acquire_singleton_lock(state.layout.root()) {
+                Ok(Some(lock)) => lock,
+                Ok(None) => {
+                    warn!(
+                        repo = %state.layout.root().display(),
+                        "singleton lock still contended after stale-lock reclaim — refusing to start"
+                    );
+                    return Ok(());
+                }
+                Err(error) => return Err(DaemonError::Io(error)),
+            }
         }
         Err(error) => return Err(DaemonError::Io(error)),
     };
+
+    // Stamp ownership immediately, before the slower migrate / LSP-discovery
+    // steps below. A contending starter consults `daemon.pid` to decide whether
+    // a contended lock is a live owner (refuse) or a dead-owner stale lock
+    // (reclaim); recording our live PID now closes the window where a lingering
+    // dead-owner PID could be mistaken for reclaimable while we already hold the
+    // lock. The port file is still written later, once the port is bound.
+    crate::lifecycle::write_pid_file(state.layout.root());
 
     // Refuse to serve an incompatible `.kin/` layout. We now hold the singleton
     // lock (sole writer for this repo) but have not bound a port, written
@@ -425,10 +457,10 @@ pub async fn run(mut state: DaemonState, config: DaemonConfig) -> Result<()> {
 
     let state = Arc::new(state);
 
-    // Write PID and port files so CLI processes can discover and auto-connect.
-    // Each repo gets its own daemon on its own port — the port file enables
-    // per-repo isolation (critical for benchmark worktrees).
-    crate::lifecycle::write_pid_file(state.layout.root());
+    // Write the port file so CLI processes can discover and auto-connect. Each
+    // repo gets its own daemon on its own port — the port file enables per-repo
+    // isolation (critical for benchmark worktrees). The PID file was written
+    // earlier, immediately after acquiring the singleton lock.
     crate::lifecycle::write_port_file(state.layout.root(), config.api_port);
 
     // Shutdown signal: when set to true, all loops exit.

--- a/crates/kin-daemon/src/lifecycle.rs
+++ b/crates/kin-daemon/src/lifecycle.rs
@@ -62,6 +62,92 @@ pub fn acquire_singleton_lock(kin_root: &Path) -> std::io::Result<Option<DaemonL
     }
 }
 
+// ── Stale-Lock Reclaim ────────────────────────────────────────────────────
+
+/// Recorded owner PID for this repo, from `.kin/daemon.pid`, if present and
+/// parseable.
+fn recorded_daemon_pid(kin_root: &Path) -> Option<u32> {
+    std::fs::read_to_string(kin_root.join("daemon.pid"))
+        .ok()
+        .and_then(|content| content.trim().parse::<u32>().ok())
+}
+
+/// All on-disk lock files for a repo: the daemon singleton lock under the `.kin`
+/// root, plus every `*.lock` under `.kin/kindb/` (kin-db's snapshot `graph.lock`
+/// and any future sibling such as a kvec write lock). Enumerated by extension so
+/// the set tracks kin-db across versions without hard-coding paths that may not
+/// exist in every build.
+fn lock_files(kin_root: &Path) -> Vec<PathBuf> {
+    let mut locks = vec![kin_root.join("daemon.lock")];
+    if let Ok(entries) = std::fs::read_dir(kin_root.join("kindb")) {
+        for entry in entries.flatten() {
+            let path = entry.path();
+            if path.extension().is_some_and(|ext| ext == "lock") {
+                locks.push(path);
+            }
+        }
+    }
+    locks
+}
+
+/// Reclaim stale lock files left behind when a daemon died while a forked child
+/// still held an inherited `flock(2)` fd.
+///
+/// All of Kin's repo locks are advisory flocks, so the kernel releases them when
+/// the owning process dies — *except* when a child inherited the open fd before
+/// the parent died (or wedged) without `exec`-ing it away. The kernel keeps the
+/// advisory lock alive on the open file description until every inheriting fd
+/// closes, so a fresh acquire then spuriously fails with `EWOULDBLOCK`
+/// (os error 35) even though no live daemon owns the repo.
+///
+/// SAFETY: reclaim ONLY when the recorded owner PID is present **and dead**.
+///
+/// - A *live* owner means a real daemon holds the lock; unlinking would let a
+///   second daemon lock a fresh inode and run concurrently — the very
+///   singleton-multiplicity hazard `daemon.lock` exists to prevent.
+/// - An *absent* PID is ambiguous (a daemon mid-startup may hold the flock
+///   before stamping its PID), so it is treated conservatively as "do not
+///   reclaim" — refusing to start is always safe; reclaiming a live lock is not.
+///
+/// Unlinking a genuinely leaked-fd lock is safe: the next acquire creates a new
+/// inode, while the zombie child's flock stays on the now-orphaned old one.
+///
+/// Returns the lock files actually cleared (each logged loudly); empty when no
+/// reclaim was warranted.
+pub fn reclaim_stale_locks(kin_root: &Path) -> Vec<PathBuf> {
+    match recorded_daemon_pid(kin_root) {
+        // Present and dead → the unambiguous stale-owner record a SIGKILLed
+        // daemon leaves behind. Safe to reclaim.
+        Some(pid) if !is_process_alive(pid) => {}
+        // Present and alive, or absent → do not touch the locks.
+        _ => return Vec::new(),
+    }
+
+    let mut cleared = Vec::new();
+    for lock in lock_files(kin_root) {
+        if !lock.exists() {
+            continue;
+        }
+        match std::fs::remove_file(&lock) {
+            Ok(()) => {
+                tracing::warn!(
+                    lock = %lock.display(),
+                    "reclaimed stale repo lock left by a dead daemon owner"
+                );
+                cleared.push(lock);
+            }
+            Err(err) => {
+                tracing::warn!(
+                    lock = %lock.display(),
+                    error = %err,
+                    "failed to reclaim stale repo lock"
+                );
+            }
+        }
+    }
+    cleared
+}
+
 // ── Daemon State Files ──────────────────────────────────────────────────
 
 /// Write PID file atomically (write tmp + rename).
@@ -571,6 +657,68 @@ mod tests {
             }
         }
         None
+    }
+
+    #[test]
+    fn reclaim_clears_locks_when_owner_pid_is_dead() {
+        // FIR-982: a SIGKILLed daemon whose forked child leaked the flock fd
+        // leaves a dead-owner PID and lingering lock files. The reclaim path
+        // clears them so startup proceeds instead of failing with os error 35.
+        let dir = tempfile::tempdir().unwrap();
+        let root = dir.path();
+        std::fs::create_dir_all(root.join("kindb")).unwrap();
+        std::fs::write(root.join("daemon.pid"), "999999999").unwrap();
+        std::fs::write(root.join("daemon.lock"), b"").unwrap();
+        std::fs::write(root.join("kindb").join("graph.lock"), b"").unwrap();
+
+        let cleared = reclaim_stale_locks(root);
+        assert_eq!(cleared.len(), 2, "both stale locks should be reclaimed");
+        assert!(!root.join("daemon.lock").exists());
+        assert!(!root.join("kindb").join("graph.lock").exists());
+
+        // Startup proceeds: the singleton lock acquires cleanly afterward.
+        assert!(
+            acquire_singleton_lock(root)
+                .expect("lock IO should succeed")
+                .is_some(),
+            "singleton lock should acquire after stale-lock reclaim"
+        );
+    }
+
+    #[test]
+    fn reclaim_preserves_locks_when_owner_is_live() {
+        // A LIVE owner (this test process) means a real daemon holds the lock;
+        // reclaiming would let a second daemon lock a fresh inode and run
+        // concurrently — the singleton-multiplicity hazard. Must be a no-op.
+        let dir = tempfile::tempdir().unwrap();
+        let root = dir.path();
+        std::fs::create_dir_all(root.join("kindb")).unwrap();
+        std::fs::write(root.join("daemon.pid"), std::process::id().to_string()).unwrap();
+        std::fs::write(root.join("daemon.lock"), b"").unwrap();
+        std::fs::write(root.join("kindb").join("graph.lock"), b"").unwrap();
+
+        assert!(
+            reclaim_stale_locks(root).is_empty(),
+            "live-owner locks must be preserved"
+        );
+        assert!(root.join("daemon.lock").exists());
+        assert!(root.join("kindb").join("graph.lock").exists());
+    }
+
+    #[test]
+    fn reclaim_is_noop_without_recorded_owner() {
+        // No daemon.pid is ambiguous (a daemon may hold the flock before
+        // stamping its PID), so the conservative choice is to NOT reclaim:
+        // refusing to start is always safe; reclaiming a live lock is not.
+        let dir = tempfile::tempdir().unwrap();
+        let root = dir.path();
+        std::fs::create_dir_all(root.join("kindb")).unwrap();
+        std::fs::write(root.join("daemon.lock"), b"").unwrap();
+        std::fs::write(root.join("kindb").join("graph.lock"), b"").unwrap();
+
+        assert!(reclaim_stale_locks(root).is_empty());
+        assert!(root.join("daemon.lock").exists());
+        assert!(root.join("kindb").join("graph.lock").exists());
     }
 
     #[test]

--- a/crates/kin-daemon/src/state.rs
+++ b/crates/kin-daemon/src/state.rs
@@ -455,6 +455,14 @@ impl DaemonState {
             }
         }
 
+        // Reclaim stale repo locks (daemon.lock + kin-db's graph.lock) left by a
+        // dead daemon whose forked child leaked the flock fd — otherwise the
+        // SnapshotManager::open below fails with a spurious lock error (os error
+        // 35) even though no live daemon owns the repo. A no-op unless the
+        // recorded owner PID is present and dead, so a live daemon's locks are
+        // never touched.
+        let _ = crate::lifecycle::reclaim_stale_locks(layout.root());
+
         let text_index_path = layout.text_index_dir();
         let locate_only = Self::locate_only_snapshot_mode();
         let (graph, loaded_snapshot) = if let Some(kndb_path) = Self::find_kndb_path(&layout) {


### PR DESCRIPTION
## What

Daemon hygiene for the `~/.kin` global home (FIR-982), two parts.

### 1. Stale-lock reclaim
All of Kin's repo locks (`daemon.lock`, kin-db's `kindb/graph.lock`) are advisory `flock(2)` locks, so the kernel releases them on process death — **except** the flock-leaks-through-fork case: a forked child inherits the open fd past a dead/wedged parent without `exec`-ing it away, keeping the advisory lock alive on the open file description. A fresh acquire then fails spuriously with `EWOULDBLOCK` (os error 35) though no live daemon owns the repo.

- **kin-daemon `lifecycle`**: new `reclaim_stale_locks(kin_root)` clears `daemon.lock` + every `*.lock` under `.kin/kindb/`, but **only when the recorded owner PID is present and dead**. A live owner is never touched (unlinking would let a second daemon lock a fresh inode and run concurrently — the singleton-multiplicity hazard `daemon.lock` exists to prevent); an absent PID is ambiguous (a daemon mid-startup may hold the flock before stamping its PID) and is also left alone — refusing to start is always safe, reclaiming a live lock is not.
- **`DaemonState::open`** calls it before `SnapshotManager::open` (which takes `graph.lock`), so a leaked `graph.lock` no longer fails open.
- **`daemon.rs` `run()`**: on a contended singleton acquire, reclaim and retry once; and stamp `daemon.pid` **immediately** after acquiring the lock (before the slower migrate/LSP-discovery steps) so a contender reads a live owner rather than a lingering stale PID.

### 2. `kin gc`
The init warm-start cache (`~/.kin/cache/init/<ns>/<repo>/bundles/`) keeps one graph bundle per git HEAD **forever with no eviction**, so a frequently re-initialized repo piles up hundreds of multi-GB bundles. Observed locally: **770 GB in one repo, 1.4 TB total**.

- New **`kin gc [--dry-run] [--max-age-days N]`** reclaims:
  - **orphaned** bundles (on disk, unreferenced by the repo's `manifest.json`), and
  - **aged** bundles (older than the threshold, default 14d),
  - always preserving each repo's `current_bundle_id`.
- Reclaiming a still-referenced bundle is safe: the next `kin init` re-checks the bundle path, misses, and rebuilds — a cache miss, never corruption.
- Namespace- and depth-agnostic (handles the home layout and the `KIN_INIT_CACHE_DIR` flat layout); only acts on a parseable manifest. `--dry-run` reports the reclaimable set + total size and deletes nothing.

Scope note: focused on the init warm-cache (the dominant consumer). No LRU / size-cap eviction (deliberately out of scope for this pass).

## Tests
- **lifecycle**: `reclaim_clears_locks_when_owner_pid_is_dead` (cleared + startup proceeds), `reclaim_preserves_locks_when_owner_is_live`, `reclaim_is_noop_without_recorded_owner`.
- **gc**: orphaned reclaim, aged reclaim with current preserved, recent referenced kept, manifest-less dirs skipped, flat-layout discovery, human-bytes formatting.
- Smoke-tested the CLI end-to-end against a temp cache: `--dry-run` lists aged+orphaned and deletes nothing; real run removes both and preserves the current bundle.

`cargo build -p kin-cli -p kin-daemon` clean; clippy/fmt clean on changed files; `kin-cli commands::gc::` (6) + `kin-daemon lifecycle::`/`open_` (19) green.
