### PR TITLE
Add Kin registry release automation

### DIFF
--- a/.github/workflows/kin-dependency-wave.yml
+++ b/.github/workflows/kin-dependency-wave.yml
@@ -1,0 +1,17 @@
+name: Kin Dependency Wave
+
+on:
+  repository_dispatch:
+    types: [kin-registry-release]
+  workflow_dispatch:
+  schedule:
+    - cron: "17 * * * *"
+
+jobs:
+  dependency-wave:
+    uses: firelock-ai/kin-actions/.github/workflows/cargo-dependency-wave.yml@v0.1.1
+    with:
+      manifests: Cargo.toml
+      test-command: cargo check -p kin-core -p kin-cli -p kin-daemon -p kin-mcp
+    secrets:
+      KIN_CI_BOT_TOKEN: ${{ secrets.KIN_CI_BOT_TOKEN }}


### PR DESCRIPTION
## Summary
- Add Kin registry release/dependency-wave automation using `firelock-ai/kin-actions@v0.1.1`
- Require release-relevant Cargo source changes to move the package version before merge/publish
- Publish registry packages idempotently, verify checksum/fresh consumer install, then dispatch downstream dependency-wave PRs
- Use scoped workflow secrets instead of `secrets: inherit`

## Verification
- Parsed all changed workflow YAML with Ruby `YAML.load_file`
- Ran `bash -n` for shared shell scripts and `python3 -m py_compile` for shared Python scripts
- Ran `git diff --check` for each repo branch
- Verified commits include DCO `Signed-off-by`
- Fixed and tagged `kin-actions@v0.1.1` after the first PR run exposed empty `registry-build-command` bash handling
