### PR TITLE
fix(bench-meta): bind prepared-state cache key to kin commit, not binary sha

### DIFF
--- a/crates/kin-cli/src/commands/bench_meta.rs
+++ b/crates/kin-cli/src/commands/bench_meta.rs
@@ -20,7 +20,8 @@ pub(crate) struct BenchMeta {
     vector_index_metadata_version: Option<u32>,
     feature_flags: Vec<&'static str>,
     embeddings: EmbeddingMeta,
-    kin_binary_sha256: String,
+    kin_commit: &'static str,
+    kin_dirty: bool,
 }
 
 #[derive(Debug, Clone, Serialize)]
@@ -54,7 +55,8 @@ pub(crate) struct PreparedManifest {
     embeddings_enabled: bool,
     vector_enabled: bool,
     metal_enabled: bool,
-    kin_binary_sha256: String,
+    kin_commit: &'static str,
+    kin_dirty: bool,
     kin_version: &'static str,
 }
 
@@ -76,7 +78,8 @@ pub(crate) struct RepoBaseManifest {
     embeddings_enabled: bool,
     vector_enabled: bool,
     metal_enabled: bool,
-    kin_binary_sha256: String,
+    kin_commit: &'static str,
+    kin_dirty: bool,
     kin_version: &'static str,
     source_git_head: String,
     source_git_tree: String,
@@ -128,7 +131,8 @@ pub async fn run(json: bool, prepared_state: bool) -> Result<()> {
             println!("vector_index_metadata_version: disabled");
         }
         println!("feature_flags: {}", meta.feature_flags.join(","));
-        println!("kin_binary_sha256: {}", meta.kin_binary_sha256);
+        println!("kin_commit: {}", meta.kin_commit);
+        println!("kin_dirty: {}", meta.kin_dirty);
         if let Some(model_id) = meta.embeddings.model_id.as_deref() {
             println!("embedding_model_id: {}", model_id);
         }
@@ -144,6 +148,7 @@ pub async fn run(json: bool, prepared_state: bool) -> Result<()> {
 }
 
 pub(crate) fn build_meta() -> Result<BenchMeta> {
+    let build = kin_buildinfo::get();
     Ok(BenchMeta {
         schema: "kin.bench-meta.v1",
         kin_version: env!("CARGO_PKG_VERSION"),
@@ -155,14 +160,9 @@ pub(crate) fn build_meta() -> Result<BenchMeta> {
         vector_index_metadata_version: vector_index_metadata_version(),
         feature_flags: feature_flags(),
         embeddings: embedding_meta(),
-        kin_binary_sha256: current_binary_sha256()?,
+        kin_commit: build.sha,
+        kin_dirty: build.dirty,
     })
-}
-
-fn current_binary_sha256() -> Result<String> {
-    let exe = std::env::current_exe()?;
-    let bytes = std::fs::read(exe)?;
-    Ok(hex::encode(Sha256::digest(bytes)))
 }
 
 /// Whether the Metal embedding backend is *actually* compiled into this binary.
@@ -258,10 +258,8 @@ pub(crate) fn build_prepared_manifests(
         "embeddings_enabled": meta.embeddings.embeddings_enabled,
         "vector_enabled": meta.embeddings.vector_enabled,
         "metal_enabled": meta.embeddings.metal_enabled,
-        // Prepared graph truth is parser/linker/runtime output, not only a
-        // storage-format artifact. Bind cache entries to the exact Kin binary
-        // so parser or linker changes cannot silently reuse stale graph state.
-        "kin_binary_sha256": &meta.kin_binary_sha256,
+        "kin_commit": meta.kin_commit,
+        "kin_dirty": meta.kin_dirty,
     }));
     let repo_base_key = hash_json(&serde_json::json!({
         "repo_identity": &repo_identity,
@@ -278,7 +276,8 @@ pub(crate) fn build_prepared_manifests(
         "embeddings_enabled": meta.embeddings.embeddings_enabled,
         "vector_enabled": meta.embeddings.vector_enabled,
         "metal_enabled": meta.embeddings.metal_enabled,
-        "kin_binary_sha256": &meta.kin_binary_sha256,
+        "kin_commit": meta.kin_commit,
+        "kin_dirty": meta.kin_dirty,
     }));
 
     let prepared = PreparedManifest {
@@ -300,7 +299,8 @@ pub(crate) fn build_prepared_manifests(
         embeddings_enabled: meta.embeddings.embeddings_enabled,
         vector_enabled: meta.embeddings.vector_enabled,
         metal_enabled: meta.embeddings.metal_enabled,
-        kin_binary_sha256: meta.kin_binary_sha256.clone(),
+        kin_commit: meta.kin_commit,
+        kin_dirty: meta.kin_dirty,
         kin_version: meta.kin_version,
         repo_base_key: repo_base_key.clone(),
     };
@@ -321,7 +321,8 @@ pub(crate) fn build_prepared_manifests(
         embeddings_enabled: meta.embeddings.embeddings_enabled,
         vector_enabled: meta.embeddings.vector_enabled,
         metal_enabled: meta.embeddings.metal_enabled,
-        kin_binary_sha256: meta.kin_binary_sha256.clone(),
+        kin_commit: meta.kin_commit,
+        kin_dirty: meta.kin_dirty,
         kin_version: meta.kin_version,
         source_git_head: prepared.git_head.clone(),
         source_git_tree: prepared.git_tree.clone(),
@@ -476,7 +477,7 @@ mod tests {
     }
 
     #[test]
-    fn prepared_manifest_cache_keys_track_kin_binary_hash() {
+    fn prepared_manifest_cache_keys_track_kin_commit_and_dirty() {
         let repo = tempdir().unwrap();
         fs::write(repo.path().join("README.md"), "hello\n").unwrap();
         Command::new("git")
@@ -507,17 +508,39 @@ mod tests {
 
         let meta = build_meta().unwrap();
         let (prepared_a, repo_base_a) = build_prepared_manifests(&meta, repo.path()).unwrap();
-        let mut meta_b = meta.clone();
-        meta_b.kin_binary_sha256 = format!("{}-changed", meta.kin_binary_sha256);
-        let (prepared_b, repo_base_b) = build_prepared_manifests(&meta_b, repo.path()).unwrap();
 
+        let (prepared_a2, repo_base_a2) = build_prepared_manifests(&meta, repo.path()).unwrap();
+        assert_eq!(
+            prepared_a.cache_key, prepared_a2.cache_key,
+            "prepared-state cache key must be STABLE across rebuilds of the same commit"
+        );
+        assert_eq!(
+            repo_base_a.repo_base_key, repo_base_a2.repo_base_key,
+            "warm init cache key must be STABLE across rebuilds of the same commit"
+        );
+
+        let mut meta_commit = meta.clone();
+        meta_commit.kin_commit = "ffffffffffff";
+        let (prepared_b, repo_base_b) = build_prepared_manifests(&meta_commit, repo.path()).unwrap();
         assert_ne!(
             prepared_a.cache_key, prepared_b.cache_key,
-            "prepared-state cache must miss when the Kin binary changes"
+            "prepared-state cache must miss when the Kin commit changes"
         );
         assert_ne!(
             repo_base_a.repo_base_key, repo_base_b.repo_base_key,
-            "warm init cache must miss when the Kin binary changes"
+            "warm init cache must miss when the Kin commit changes"
+        );
+
+        let mut meta_dirty = meta.clone();
+        meta_dirty.kin_dirty = !meta.kin_dirty;
+        let (prepared_c, repo_base_c) = build_prepared_manifests(&meta_dirty, repo.path()).unwrap();
+        assert_ne!(
+            prepared_a.cache_key, prepared_c.cache_key,
+            "prepared-state cache must miss when the dirty flag changes"
+        );
+        assert_ne!(
+            repo_base_a.repo_base_key, repo_base_c.repo_base_key,
+            "warm init cache must miss when the dirty flag changes"
         );
     }
 }

--- a/crates/kin-cli/src/commands/bench_meta.rs
+++ b/crates/kin-cli/src/commands/bench_meta.rs
@@ -521,7 +521,8 @@ mod tests {
 
         let mut meta_commit = meta.clone();
         meta_commit.kin_commit = "ffffffffffff";
-        let (prepared_b, repo_base_b) = build_prepared_manifests(&meta_commit, repo.path()).unwrap();
+        let (prepared_b, repo_base_b) =
+            build_prepared_manifests(&meta_commit, repo.path()).unwrap();
         assert_ne!(
             prepared_a.cache_key, prepared_b.cache_key,
             "prepared-state cache must miss when the Kin commit changes"

--- a/crates/kin-cli/src/commands/prepared_state.rs
+++ b/crates/kin-cli/src/commands/prepared_state.rs
@@ -31,7 +31,8 @@ const VALIDATION_KEYS: &[&str] = &[
     "embeddings_enabled",
     "vector_enabled",
     "metal_enabled",
-    "kin_binary_sha256",
+    "kin_commit",
+    "kin_dirty",
 ];
 
 #[derive(Debug, Serialize)]

--- a/crates/kin-cli/tests/bench_meta_json.rs
+++ b/crates/kin-cli/tests/bench_meta_json.rs
@@ -29,7 +29,8 @@ fn bench_meta_json_reports_cache_key_dimensions() {
     assert!(payload["layout_schema_version"].is_u64());
     assert!(payload["graph_snapshot_version"].is_u64());
     assert!(payload["text_index_format_version"].is_u64());
-    assert!(payload["kin_binary_sha256"].is_string());
+    assert!(payload["kin_commit"].is_string());
+    assert!(payload["kin_dirty"].is_boolean());
 
     let embeddings = payload["embeddings"]
         .as_object()


### PR DESCRIPTION
## Problem (FIR-947 / FIR-1052)

`kin bench-meta` derived the prepared-state `cache_key` and `repo_base_key` by folding in `kin_binary_sha256` — a SHA-256 of the running `kin` executable's bytes. But `kin-buildinfo`'s `build.rs` embeds a build **timestamp** (`KIN_BUILD_TIME`) into every binary, so **rebuilding the same commit produces different bytes → a different hash → a different cache key**.

The downstream effect (FIR-1052): `freeze-prep-base.sh` publishes a snapshot under `prepared/<cache_key>`. When `reproduce.sh` rebuilds the `kin` binary before eval, `kin bench-meta` computes a *new* key, the published snapshot is orphaned, and the scoped-session + backfill-OFF eval paths fail-loud (`none was found for base ...`). This forced full reprep on every rebuild and made prepared-state reuse untrustworthy.

## Fix

Bind the cache key to **commit identity**, which is what the original code comment actually described ("parser or linker changes cannot silently reuse stale graph state") — a code change is a new commit (or a dirty tree), not merely new binary bytes.

Source from the already-linked `kin_buildinfo::get()`:
- `kin_commit` — 12-hex short SHA (`build.sha`)
- `kin_dirty` — bool (`build.dirty`, true when `git status --porcelain` was non-empty at build)

The key is now **stable across rebuilds of the same clean commit**, and still **misses on a different commit or a dirty build** (a dirty tree must not reuse a clean snapshot).

## Changes (kin-cli only)

- `crates/kin-cli/src/commands/bench_meta.rs`
  - `kin_binary_sha256: String` → `kin_commit: &'static str` + `kin_dirty: bool` on `BenchMeta`, `PreparedManifest`, `RepoBaseManifest`.
  - `build_meta()` populates from `kin_buildinfo::get()`; deleted the now-unused `current_binary_sha256()` (sha2/hex remain — still used by `hash_json`).
  - Both `cache_key` / `repo_base_key` hash compositions, both struct literals, and the human-readable print updated.
  - Renamed `prepared_manifest_cache_keys_track_kin_binary_hash` → `..._track_kin_commit_and_dirty`; now asserts same-commit **stability** plus a miss on commit change and on dirty-flag flip.
- `crates/kin-cli/src/commands/prepared_state.rs` — mirrored the rename in `VALIDATION_KEYS` so the field-level manifest validator keeps guarding (now on commit + dirty rather than the byte hash).
- `crates/kin-cli/tests/bench_meta_json.rs` — assert `kin_commit` (string) + `kin_dirty` (bool).

No `Cargo.toml`, shell-script, daemon, or MCP changes. `kin-buildinfo` was already a `kin-cli` dependency.

## Validation

- `cargo build --release --bin kin --bin kin-daemon` — succeeds.
- `cargo test -p kin-cli bench_meta` — 5 lib + 2 integration pass.
- `cargo test -p kin-cli --lib commands::prepared_state` + `--test prepared_state_json` — 5 lib + 2 integration pass.
- Behavioral sanity (`kin bench-meta --json --prepared-state`): emits `kin_commit` + `kin_dirty` at top level and in both manifests; `kin_binary_sha256` is gone; `kin --version` shows the same 12-hex short SHA.

## Follow-up (out of scope here, kin-bench)

`kin-bench`'s `kin-bench-eval.rs` `PREPARED_STATE_VALIDATION_KEYS` still lists `kin_binary_sha256`. The `cache_key` *string* auto-follows (consumers read it from `kin bench-meta`), so correctness is preserved (the cache_key itself now encodes commit+dirty); the standalone field check silently becomes a no-op until that list is mirrored. Per the task boundary this PR touches **kin only**; the kin-bench list + its test should be mirrored in a follow-up once the bench is idle, and all pre-fix `prepared/<oldkey>` snapshots must be rebuilt (they were computed from the old binary-hash algorithm and will not match the new key regardless).
