### PR TITLE
fix(trace,mcp): graph-first source authority — remove raw file-search fallbacks (FIR-863)

### DIFF
--- a/crates/kin-cli/src/commands/trace.rs
+++ b/crates/kin-cli/src/commands/trace.rs
@@ -523,7 +523,11 @@ fn render_file_path_trace_lines(
 
     let mut lines = vec![format!("--- entities declared in {} ---", read_path)];
     for entity in entities.iter().take(40) {
-        let line = entity.span.as_ref().map(|span| span.start_line).unwrap_or(0);
+        let line = entity
+            .span
+            .as_ref()
+            .map(|span| span.start_line)
+            .unwrap_or(0);
         lines.push(format!(
             "  {} ({:?}) @ {}:{}",
             entity.name, entity.kind, read_path, line
@@ -566,7 +570,11 @@ fn graph_entities_for_file(graph: &impl GraphStore, path: &str) -> Vec<Entity> {
 fn sort_entities_by_line(mut entities: Vec<Entity>) -> Vec<Entity> {
     entities.sort_by_key(|entity| {
         (
-            entity.span.as_ref().map(|span| span.start_line).unwrap_or(0),
+            entity
+                .span
+                .as_ref()
+                .map(|span| span.start_line)
+                .unwrap_or(0),
             entity.name.clone(),
         )
     });
@@ -1023,7 +1031,10 @@ issues.map((iss) => util.finalizeItem(iss, ctx, core.config()));
         )
         .unwrap();
         let joined = response.lines.join("\n");
-        assert!(joined.contains("not found"), "graph-miss guidance: {joined}");
+        assert!(
+            joined.contains("not found"),
+            "graph-miss guidance: {joined}"
+        );
         assert!(
             joined.contains("kin search definitelyMissingEntity"),
             "offers search instead of disk fallback: {joined}"

--- a/crates/kin-cli/src/commands/trace.rs
+++ b/crates/kin-cli/src/commands/trace.rs
@@ -4,7 +4,6 @@
 use anyhow::{Context, Result};
 use kin_model::{Entity, GraphStore, TokenBudget};
 use serde::{Deserialize, Serialize};
-use std::path::PathBuf;
 
 /// Resolve session id from KIN_SESSION_ID env var.
 ///
@@ -171,7 +170,7 @@ pub fn build_trace_json_response(
         matches
     };
 
-    if let Some(best_id) = select_best_match_with_layout(layout, entity, &matches).map(|e| e.id) {
+    if let Some(best_id) = select_best_match_with_layout(entity, &matches).map(|e| e.id) {
         matches.sort_by_key(|candidate| (candidate.id != best_id, candidate.name.len()));
     }
 
@@ -212,11 +211,10 @@ fn build_trace_lines(
     nearby_limit: usize,
     transitive_limit: usize,
 ) -> Result<Vec<String>> {
-    // Detect file path arguments inside the daemon-owned renderer. Agents sometimes
-    // pass file paths instead of entity names; the daemon returns the rendered file
-    // content without giving the CLI a local source read path.
+    // Agents sometimes pass file paths instead of entity names; resolve those to
+    // the graph-owned entities declared in that file rather than a raw file read.
     if looks_like_file_path(entity) {
-        return Ok(render_file_path_trace_lines(layout, entity));
+        return Ok(render_file_path_trace_lines(layout, graph, entity));
     }
 
     build_trace_lines_with_graph(
@@ -301,34 +299,12 @@ fn build_trace_lines_with_graph(
     };
 
     if matches.is_empty() {
-        if let Some(fallback) =
-            source_symbol_fallback(layout, entity, focal_max_lines, snippet_max_chars)?
-        {
-            return Ok(render_source_fallback_lines(
-                layout,
-                entity,
-                &fallback,
-                followup_limit,
-            ));
-        }
         return Ok(trace_not_found_guidance(entity));
     }
 
-    let target = match select_best_match_with_layout(layout, entity, &matches) {
+    let target = match select_best_match_with_layout(entity, &matches) {
         Some(target) => target,
-        None => {
-            if let Some(fallback) =
-                source_symbol_fallback(layout, entity, focal_max_lines, snippet_max_chars)?
-            {
-                return Ok(render_source_fallback_lines(
-                    layout,
-                    entity,
-                    &fallback,
-                    followup_limit,
-                ));
-            }
-            return Ok(trace_not_found_guidance(entity));
-        }
+        None => return Ok(trace_not_found_guidance(entity)),
     };
 
     let opts = kin_context::ContextOptions {
@@ -364,7 +340,8 @@ fn build_trace_lines_with_graph(
         ));
     }
 
-    if let Some(content) = render_entity_source(layout, target, focal_max_lines, snippet_max_chars)
+    if let Some(content) =
+        render_entity_source(layout, graph, target, focal_max_lines, snippet_max_chars)
     {
         if !compact {
             lines.push("\n--- Focal ---".to_string());
@@ -436,9 +413,13 @@ fn build_trace_lines_with_graph(
                 if let Some(dep) = graph.get_entity(&entry.entity_id)? {
                     let same_file = dep.file_origin == target.file_origin;
                     if same_file && expanded_same_file < 4 {
-                        if let Some(content) =
-                            render_neighbor_source(layout, &dep, focal_max_lines, snippet_max_chars)
-                        {
+                        if let Some(content) = render_neighbor_source(
+                            layout,
+                            graph,
+                            &dep,
+                            focal_max_lines,
+                            snippet_max_chars,
+                        ) {
                             lines.push(content);
                             expanded_same_file += 1;
                             continue;
@@ -517,298 +498,79 @@ fn select_best_match<'a>(query: &str, matches: &'a [Entity]) -> Option<&'a Entit
     })
 }
 
-fn select_best_match_with_layout<'a>(
-    layout: &kin_core::KinLayout,
-    query: &str,
-    matches: &'a [Entity],
-) -> Option<&'a Entity> {
+fn select_best_match_with_layout<'a>(query: &str, matches: &'a [Entity]) -> Option<&'a Entity> {
     kin_core::select_best_match(query, matches, |entity, hint| {
-        entity_or_file_mentions_qualifier(layout, entity, hint)
+        entity_mentions_qualifier(entity, hint)
     })
 }
 
-struct SourceSymbolFallback {
-    path: PathBuf,
-    snippet: String,
-}
-
-fn source_symbol_fallback(
+fn render_file_path_trace_lines(
     layout: &kin_core::KinLayout,
-    query: &str,
-    max_lines: usize,
-    max_chars: usize,
-) -> Result<Option<SourceSymbolFallback>> {
-    let source_root = kin_core::source_dir(layout);
-    if !source_root.exists() {
-        return Ok(None);
-    }
-
-    let search_patterns = textual_patterns_for_query(query);
-    if search_patterns.is_empty() {
-        return Ok(None);
-    }
-
-    let mut stack = vec![source_root.clone()];
-    let mut best: Option<(i32, PathBuf, String)> = None;
-
-    while let Some(path) = stack.pop() {
-        let entries = match std::fs::read_dir(&path) {
-            Ok(entries) => entries,
-            Err(_) => continue,
-        };
-
-        for entry in entries.flatten() {
-            let path = entry.path();
-            let file_type = match entry.file_type() {
-                Ok(file_type) => file_type,
-                Err(_) => continue,
-            };
-
-            if file_type.is_dir() {
-                stack.push(path);
-                continue;
-            }
-
-            let ext = path.extension().and_then(|e| e.to_str()).unwrap_or("");
-            if !matches!(
-                ext,
-                "ts" | "tsx" | "js" | "jsx" | "rs" | "py" | "go" | "java"
-            ) {
-                continue;
-            }
-
-            let content = match std::fs::read_to_string(&path) {
-                Ok(content) => content,
-                Err(_) => continue,
-            };
-
-            if let Some((score, snippet)) = best_source_snippet_for_patterns(
-                &path,
-                &content,
-                &search_patterns,
-                max_lines,
-                max_chars,
-            ) {
-                match &best {
-                    Some((best_score, _, _)) if *best_score >= score => {}
-                    _ => best = Some((score, path.clone(), snippet)),
-                }
-            }
-        }
-    }
-
-    Ok(best.map(|(_, path, snippet)| SourceSymbolFallback { path, snippet }))
-}
-
-fn textual_patterns_for_query(query: &str) -> Vec<String> {
-    let query = query.trim();
-    let mut patterns = Vec::new();
-
-    if !query.is_empty() {
-        patterns.push(query.to_string());
-    }
-
-    let dotted = query.replace("::", ".");
-    if dotted != query {
-        patterns.push(dotted.clone());
-    }
-
-    let qualifier = kin_core::qualifier_hint_from_query(query)
-        .map(|q| q.replace('$', ""))
-        .unwrap_or_default();
-    let leaf = query
-        .rfind("::")
-        .map(|idx| &query[idx + 2..])
-        .or_else(|| query.rfind('.').map(|idx| &query[idx + 1..]))
-        .unwrap_or(query)
-        .trim();
-
-    if !qualifier.is_empty() && !leaf.is_empty() {
-        patterns.push(leaf.to_string());
-        patterns.push(format!("{}.{}", qualifier, leaf));
-        patterns.push(format!("{}::{}", qualifier, leaf));
-        patterns.push(format!(".{}", leaf));
-    } else if !leaf.is_empty() {
-        patterns.push(leaf.to_string());
-        patterns.push(format!(".{}", leaf));
-    }
-
-    patterns.sort();
-    patterns.dedup();
-    patterns
-}
-
-fn best_source_snippet_for_patterns(
-    path: &std::path::Path,
-    content: &str,
-    patterns: &[String],
-    max_lines: usize,
-    max_chars: usize,
-) -> Option<(i32, String)> {
-    let mut best: Option<(i32, usize)> = None;
-    let path_str = path.to_string_lossy();
-
-    for pattern in patterns {
-        if pattern.is_empty() {
-            continue;
-        }
-        for (idx, _) in content.match_indices(pattern) {
-            let mut score = match pattern.as_str() {
-                p if p == patterns[0] => 300,
-                p if p.starts_with('.') => 120,
-                _ => 180,
-            };
-
-            if path_str.contains("/tests/")
-                || path_str.contains("/test/")
-                || path_str.contains(".test.")
-                || path_str.contains(".spec.")
-                || path_str.contains("/fixtures/")
-                || path_str.contains("/fixture/")
-                || path_str.contains("/examples/")
-                || path_str.contains("/example/")
-            {
-                score -= 220;
-            }
-            if path_str.contains("/bench/") {
-                score -= 120;
-            }
-            score += local_symbol_context_bonus(content, idx, pattern);
-
-            match best {
-                Some((best_score, _)) if best_score >= score => {}
-                _ => best = Some((score, idx)),
-            }
-        }
-    }
-
-    let (score, idx) = best?;
-    let snippet = snippet_around_index(content, idx, max_lines, max_chars);
-    Some((
-        score,
-        format!("// source fallback ({})\n{}", path.display(), snippet),
-    ))
-}
-
-fn local_symbol_context_bonus(content: &str, idx: usize, pattern: &str) -> i32 {
-    let window = safe_char_window_around_byte(content, idx, 160, 240);
-    let leaf = pattern
-        .trim_start_matches('.')
-        .rsplit("::")
-        .next()
-        .and_then(|s| s.rsplit('.').next())
-        .unwrap_or(pattern)
-        .trim();
-    if leaf.is_empty() {
-        return 0;
-    }
-
-    let mut score = 0;
-    for needle in [
-        format!("function {}", leaf),
-        format!("const {} =", leaf),
-        format!("let {} =", leaf),
-        format!("var {} =", leaf),
-        format!("class {}", leaf),
-        format!("{} =", leaf),
-        format!("{}(", leaf),
-        format!("{}:", leaf),
-    ] {
-        if window.contains(&needle) {
-            score += 35;
-        }
-    }
-
-    if window.contains("describe(") || window.contains("it(") || window.contains("test(") {
-        score -= 80;
-    }
-
-    score
-}
-
-fn safe_char_window_around_byte(content: &str, idx: usize, before: usize, after: usize) -> &str {
-    let mut start = idx.saturating_sub(before).min(content.len());
-    while start > 0 && !content.is_char_boundary(start) {
-        start -= 1;
-    }
-
-    let mut end = (idx + after).min(content.len());
-    while end < content.len() && !content.is_char_boundary(end) {
-        end += 1;
-    }
-
-    &content[start..end]
-}
-
-fn snippet_around_index(content: &str, index: usize, max_lines: usize, max_chars: usize) -> String {
-    let mut current = 0usize;
-    let mut target_line = 0usize;
-    for (line_no, line) in content.lines().enumerate() {
-        let next = current + line.len() + 1;
-        if index < next {
-            target_line = line_no;
-            break;
-        }
-        current = next;
-    }
-
-    let start_line = target_line.saturating_sub(max_lines / 2);
-    let end_line = start_line + max_lines;
-    let snippet = content
-        .lines()
-        .enumerate()
-        .filter(|(i, _)| *i >= start_line && *i < end_line)
-        .map(|(_, line)| line)
-        .collect::<Vec<_>>()
-        .join("\n");
-
-    clip_rendered_text_with_cap(&snippet, max_lines, max_chars)
-}
-
-fn render_file_path_trace_lines(layout: &kin_core::KinLayout, entity: &str) -> Vec<String> {
-    let source_root = kin_core::source_dir(layout);
-    let file_path = source_root.join(entity);
-    let read_path = display_read_path(layout, entity);
-    if file_path.is_file() {
-        let mut lines = vec![format!("--- {} ---", read_path)];
-        if let Ok(content) = std::fs::read_to_string(&file_path) {
-            // Use generous limits for file auto-reads; these are usually small
-            // files and truncation causes agents to re-read redundantly.
-            lines.push(clip_rendered_text_with_cap(&content, 40, 2400));
-        }
-        return lines;
-    }
-
-    vec![format!(
-        "`kin trace` expects an entity name, not a file path.\n\
-         To read this file: Read {}\n\
-         To find entities: kin search <EntityName> --show-body",
-        read_path
-    )]
-}
-
-fn render_source_fallback_lines(
-    layout: &kin_core::KinLayout,
-    query: &str,
-    fallback: &SourceSymbolFallback,
-    followup_limit: usize,
+    graph: &impl GraphStore,
+    entity: &str,
 ) -> Vec<String> {
-    let display_path = display_source_path(layout, &fallback.path);
-    let mut lines = vec![
-        format!("Trace for '{}' -> source match ({})", query, display_path),
-        "\n--- Focal ---".to_string(),
-        fallback.snippet.clone(),
-    ];
-    let followups = extract_textual_followups(&fallback.snippet);
-    if !followups.is_empty() {
-        lines.push("\n--- Follow-ups ---".to_string());
-        for item in followups.iter().take(followup_limit) {
-            lines.push(format!("- {}", item));
-        }
+    let read_path = display_read_path(layout, entity);
+    let entities = graph_entities_for_file(graph, entity);
+
+    if entities.is_empty() {
+        return vec![format!(
+            "`kin trace` expects an entity name, not a file path.\n\
+             To read this file: Read {}\n\
+             To find entities: kin search <EntityName> --show-body",
+            read_path
+        )];
     }
-    lines.push("\nCounts: contracts=0 tests=0 work_items=0 annotations=0".to_string());
-    lines.push(fallback_trace_tip(&display_path));
+
+    let mut lines = vec![format!("--- entities declared in {} ---", read_path)];
+    for entity in entities.iter().take(40) {
+        let line = entity.span.as_ref().map(|span| span.start_line).unwrap_or(0);
+        lines.push(format!(
+            "  {} ({:?}) @ {}:{}",
+            entity.name, entity.kind, read_path, line
+        ));
+    }
+    lines.push(
+        "\nTip: `kin trace <EntityName>` to follow data flow from one of these declarations."
+            .to_string(),
+    );
     lines
+}
+
+fn graph_entities_for_file(graph: &impl GraphStore, path: &str) -> Vec<Entity> {
+    let direct = graph
+        .query_entities(&kin_model::EntityFilter {
+            file_path: Some(kin_model::FilePathId::new(path)),
+            ..Default::default()
+        })
+        .unwrap_or_default();
+    if !direct.is_empty() {
+        return sort_entities_by_line(direct);
+    }
+
+    let suffix = path.trim_start_matches("./");
+    let matched = graph
+        .query_entities(&kin_model::EntityFilter::default())
+        .unwrap_or_default()
+        .into_iter()
+        .filter(|entity| {
+            entity
+                .file_origin
+                .as_ref()
+                .map(|origin| origin.0 == path || origin.0.ends_with(suffix))
+                .unwrap_or(false)
+        })
+        .collect::<Vec<_>>();
+    sort_entities_by_line(matched)
+}
+
+fn sort_entities_by_line(mut entities: Vec<Entity>) -> Vec<Entity> {
+    entities.sort_by_key(|entity| {
+        (
+            entity.span.as_ref().map(|span| span.start_line).unwrap_or(0),
+            entity.name.clone(),
+        )
+    });
+    entities
 }
 
 fn focused_trace_tip(_read_path: &str, target_name: &str) -> String {
@@ -822,14 +584,6 @@ fn focused_trace_tip(_read_path: &str, target_name: &str) -> String {
             "Tip: after 2-3 traces you likely have enough to answer. Use `kin context {}` only if you need a broader view.",
             target_name
         )
-    }
-}
-
-fn fallback_trace_tip(_display_path: &str) -> String {
-    if native_content_restricted() {
-        "Tip: you have enough context to summarize the flow. Stop tracing and answer.".to_string()
-    } else {
-        "Tip: after 2-3 traces you likely have enough to answer. Stop and summarize.".to_string()
     }
 }
 
@@ -856,37 +610,32 @@ fn looks_like_file_path(s: &str) -> bool {
     extensions.iter().any(|ext| s.ends_with(ext))
 }
 
-fn entity_or_file_mentions_qualifier(
-    layout: &kin_core::KinLayout,
-    entity: &Entity,
-    qualifier_hint: &str,
-) -> bool {
+fn entity_mentions_qualifier(entity: &Entity, qualifier_hint: &str) -> bool {
     if kin_core::normalize_symbol_hint(&entity.name).contains(qualifier_hint) {
         return true;
     }
 
-    let Some(file_origin) = entity.file_origin.as_ref() else {
-        return false;
-    };
+    if kin_core::normalize_symbol_hint(&entity.signature).contains(qualifier_hint) {
+        return true;
+    }
 
-    let path = kin_core::source_dir(layout).join(&file_origin.0);
-    let Ok(content) = std::fs::read_to_string(&path) else {
-        return false;
-    };
-    let normalized = kin_core::normalize_symbol_hint(&content);
-    normalized.contains(qualifier_hint)
+    entity
+        .doc_summary
+        .as_ref()
+        .map(|summary| kin_core::normalize_symbol_hint(summary).contains(qualifier_hint))
+        .unwrap_or(false)
 }
 
 fn render_entity_source(
     layout: &kin_core::KinLayout,
+    graph: &impl GraphStore,
     entity: &Entity,
     max_lines: usize,
     max_chars: usize,
 ) -> Option<String> {
     let span = entity.span.as_ref()?;
     let file_origin = entity.file_origin.as_ref()?;
-    let path = kin_core::source_dir(layout).join(&file_origin.0);
-    let bytes = std::fs::read(&path).ok()?;
+    let bytes = graph_owned_source_bytes(layout, graph, file_origin)?;
     let start = span.start_byte.min(bytes.len());
     let end = span.end_byte.min(bytes.len());
     if start >= end {
@@ -908,12 +657,17 @@ fn render_entity_source(
     ))
 }
 
-fn display_source_path(layout: &kin_core::KinLayout, path: &std::path::Path) -> String {
-    let source_root = kin_core::source_dir(layout);
-    if let Ok(rel) = path.strip_prefix(&source_root) {
-        return display_read_path(layout, &rel.to_string_lossy());
+fn graph_owned_source_bytes(
+    layout: &kin_core::KinLayout,
+    graph: &impl GraphStore,
+    file_origin: &kin_model::FilePathId,
+) -> Option<Vec<u8>> {
+    let hash = graph.get_file_hash(file_origin).ok().flatten()?;
+    let bytes = kin_core::read_blob_from_layout(layout, &hash)?;
+    if kin_blobs::digest(&bytes) != hash {
+        return None;
     }
-    path.display().to_string()
+    Some(bytes)
 }
 
 fn display_read_path(_layout: &kin_core::KinLayout, rel_path: &str) -> String {
@@ -922,11 +676,12 @@ fn display_read_path(_layout: &kin_core::KinLayout, rel_path: &str) -> String {
 
 fn render_neighbor_source(
     layout: &kin_core::KinLayout,
+    graph: &impl GraphStore,
     entity: &Entity,
     max_lines: usize,
     max_chars: usize,
 ) -> Option<String> {
-    let content = render_entity_source(layout, entity, max_lines, max_chars)?;
+    let content = render_entity_source(layout, graph, entity, max_lines, max_chars)?;
     Some(format!("// same-file neighbor\n{}", content))
 }
 
@@ -1037,7 +792,7 @@ fn trace_not_found_guidance(entity: &str) -> Vec<String> {
 #[cfg(test)]
 mod tests {
     use super::{
-        best_source_snippet_for_patterns, fallback_leaf_trace_matches, query_trace_matches,
+        entity_mentions_qualifier, fallback_leaf_trace_matches, query_trace_matches,
         select_best_match, trace_not_found_guidance,
     };
     use kin_core::normalize_trace_name;
@@ -1226,61 +981,52 @@ issues.map((iss) => util.finalizeItem(iss, ctx, core.config()));
     }
 
     #[test]
-    fn source_fallback_prefers_implementation_over_test_file() {
-        let impl_content = r#"
-export const parseStrict = <T>(schema: $MyType<T>, value: unknown) => {
-  const result = schema.engine.run({ value, issues: [] }, { async: false });
-  return result;
-};
-"#;
-        let test_content = r#"
-test("parseStrict works", () => {
-  expect(schema.parseStrict("x").success).toBe(true);
-});
-"#;
+    fn entity_mentions_qualifier_uses_graph_signature_not_disk() {
+        let mut entity = make_entity("parse");
+        entity.signature = "fn parse(input: &Config) -> Result<()>".to_string();
+        assert!(entity_mentions_qualifier(&entity, "config"));
 
-        let impl_score = best_source_snippet_for_patterns(
-            std::path::Path::new("/repo/packages/app/src/core/parse.ts"),
-            impl_content,
-            &["parseStrict".to_string(), ".parseStrict".to_string()],
-            20,
-            2400,
-        )
-        .unwrap()
-        .0;
-
-        let test_score = best_source_snippet_for_patterns(
-            std::path::Path::new("/repo/packages/app/src/core/tests/index.test.ts"),
-            test_content,
-            &["parseStrict".to_string(), ".parseStrict".to_string()],
-            20,
-            2400,
-        )
-        .unwrap()
-        .0;
-
-        assert!(
-            impl_score > test_score,
-            "{impl_score} should outrank {test_score}"
-        );
+        let unrelated = make_entity("parse");
+        assert!(!entity_mentions_qualifier(&unrelated, "config"));
     }
 
     #[test]
-    fn source_fallback_handles_unicode_without_panicking() {
-        let content = r#"
-test("Georgian locale uses 'ველი' instead of 'სტრინგი'", () => {
-  expect(schema.parseStrict("x").success).toBe(true);
-});
-"#;
+    fn entity_mentions_qualifier_uses_graph_doc_summary() {
+        let mut entity = make_entity("run");
+        entity.signature = "fn run()".to_string();
+        entity.doc_summary = Some("Drives the Scheduler loop".to_string());
+        assert!(entity_mentions_qualifier(&entity, "scheduler"));
+    }
 
-        let found = best_source_snippet_for_patterns(
-            std::path::Path::new("/repo/src/tests/index.test.ts"),
-            content,
-            &["parseStrict".to_string()],
-            20,
-            2400,
+    #[test]
+    fn trace_graph_miss_returns_guidance_without_disk_fallback() {
+        let graph = InMemoryGraph::new();
+        let layout = kin_core::KinLayout::discover(&std::env::current_dir().unwrap())
+            .or_else(|| kin_core::KinLayout::discover(std::path::Path::new(".")));
+        let layout = match layout {
+            Some(layout) => layout,
+            None => return,
+        };
+        let response = super::build_trace_response(
+            &layout,
+            &graph,
+            &super::TraceRequest {
+                entity: "definitelyMissingEntity".to_string(),
+                json: false,
+                compact: false,
+                budget: "8k".to_string(),
+                assistant: None,
+                max_lines: 20,
+                nearby_limit: 3,
+                transitive_limit: 0,
+            },
+        )
+        .unwrap();
+        let joined = response.lines.join("\n");
+        assert!(joined.contains("not found"), "graph-miss guidance: {joined}");
+        assert!(
+            joined.contains("kin search definitelyMissingEntity"),
+            "offers search instead of disk fallback: {joined}"
         );
-
-        assert!(found.is_some());
     }
 }

--- a/crates/kin-daemon/src/api.rs
+++ b/crates/kin-daemon/src/api.rs
@@ -7811,7 +7811,52 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn trace_endpoint_renders_file_paths_in_daemon() {
+    async fn trace_endpoint_resolves_file_paths_to_graph_entities() {
+        let state = test_state();
+        state
+            .graph
+            .upsert_entity(&test_entity("handler", "src/lib.py"))
+            .unwrap();
+        state
+            .is_initialized
+            .store(true, std::sync::atomic::Ordering::Relaxed);
+        let app = router(state);
+        let response = app
+            .oneshot(
+                Request::post("/trace")
+                    .header("content-type", "application/json")
+                    .body(Body::from(
+                        serde_json::json!({
+                            "entity": "src/lib.py",
+                            "json": false,
+                            "compact": false,
+                            "budget": "8k",
+                            "max_lines": 20,
+                            "nearby_limit": 2,
+                            "transitive_limit": 1,
+                        })
+                        .to_string(),
+                    ))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(response.status(), StatusCode::OK);
+        let body = axum::body::to_bytes(response.into_body(), 16 * 1024)
+            .await
+            .unwrap();
+        let result: kin_cli::commands::trace::TraceResponse =
+            serde_json::from_slice(&body).unwrap();
+        assert!(result
+            .lines
+            .iter()
+            .any(|line| line == "--- entities declared in src/lib.py ---"));
+        assert!(result.lines.iter().any(|line| line.contains("handler")));
+    }
+
+    #[tokio::test]
+    async fn trace_endpoint_file_path_without_graph_entities_returns_guidance() {
         let state = test_state();
         std::fs::create_dir_all(state.layout.working_dir().join("src")).unwrap();
         std::fs::write(
@@ -7850,8 +7895,15 @@ mod tests {
             .unwrap();
         let result: kin_cli::commands::trace::TraceResponse =
             serde_json::from_slice(&body).unwrap();
-        assert!(result.lines.iter().any(|line| line == "--- src/lib.py ---"));
-        assert!(result.lines.iter().any(|line| line.contains("def handler")));
+        let joined = result.lines.join("\n");
+        assert!(
+            joined.contains("expects an entity name, not a file path"),
+            "untracked file path must return guidance, not a raw disk dump: {joined}"
+        );
+        assert!(
+            !joined.contains("def handler"),
+            "file body must not be served from disk: {joined}"
+        );
     }
 
     #[tokio::test]

--- a/crates/kin-mcp/src/handlers/common.rs
+++ b/crates/kin-mcp/src/handlers/common.rs
@@ -978,19 +978,6 @@ pub fn entity_read_path(entity: &Entity) -> Option<String> {
         .map(|path| display_read_path(path.0.as_str()))
 }
 
-pub fn resolve_entity_source_path(entity: &Entity) -> Option<PathBuf> {
-    let rel_path = entity.file_origin.as_ref()?.0.as_str();
-
-    for root in candidate_source_roots() {
-        let candidate = root.join(rel_path);
-        if candidate.is_file() {
-            return Some(candidate);
-        }
-    }
-
-    None
-}
-
 pub fn read_entity_source_excerpt_detailed<G: GraphStore>(
     store: &G,
     entity: &Entity,
@@ -1045,49 +1032,9 @@ pub fn read_entity_source_excerpt_detailed<G: GraphStore>(
             .or(excerpt);
     }
 
-    // Fall back to disk
     GRAPH_MISS_COUNT.fetch_add(1, Ordering::SeqCst);
-    LAST_READ_SOURCE.with(|f| f.set("disk"));
-
-    let path = resolve_entity_source_path(entity)?;
-    let disk_bytes = std::fs::read(&path).ok()?;
-
-    // Verify span bounds sanity
-    if span.start_byte > disk_bytes.len() || span.end_byte > disk_bytes.len() {
-        tracing::warn!(
-            "Span bounds sanity check failed for entity {} on file {:?}: start_byte={}, end_byte={}, file size={}",
-            entity.id,
-            path,
-            span.start_byte,
-            span.end_byte,
-            disk_bytes.len()
-        );
-        return None;
-    }
-
-    // Detect if disk content is stale
-    if let Some(ref gh) = graph_hash {
-        let disk_hash = kin_blobs::digest(&disk_bytes);
-        if disk_hash != *gh {
-            LAST_READ_STALE.with(|f| f.set(true));
-            tracing::warn!(
-                "Disk content stale for {:?}: disk hash {} != graph hash {}",
-                path,
-                disk_hash,
-                gh
-            );
-        }
-    }
-
-    let excerpt = excerpt_from_span_bytes(&disk_bytes, span, max_lines, max_chars);
-    if let Some(ref excerpt) = excerpt {
-        if !should_expand_excerpt(entity, excerpt) {
-            return Some(excerpt.clone());
-        }
-    }
-
-    let text = String::from_utf8_lossy(&disk_bytes);
-    expand_entity_source_excerpt(entity, &text, span.start_byte, max_lines, max_chars).or(excerpt)
+    LAST_READ_SOURCE.with(|f| f.set("graph-miss"));
+    None
 }
 
 pub fn excerpt_from_span_bytes(

--- a/crates/kin-mcp/src/handlers/mod.rs
+++ b/crates/kin-mcp/src/handlers/mod.rs
@@ -1455,7 +1455,8 @@ mod tests {
         signature: &str,
         content: &str,
     ) -> Entity {
-        let blob_store = kin_blobs::BlobStore::new(dir.path().join(".kin").join("objects")).unwrap();
+        let blob_store =
+            kin_blobs::BlobStore::new(dir.path().join(".kin").join("objects")).unwrap();
         let hash = blob_store.write(content.as_bytes()).unwrap();
 
         let file_id = kin_model::ids::FilePathId::new(rel_path);
@@ -2206,7 +2207,10 @@ mod tests {
         let entity = &source.entity;
         let store = InMemoryGraph::default();
         store.upsert_entity(entity).unwrap();
-        store.set_file_hash(&entity.file_origin.as_ref().unwrap().0, *source.hash.as_bytes());
+        store.set_file_hash(
+            &entity.file_origin.as_ref().unwrap().0,
+            *source.hash.as_bytes(),
+        );
 
         // Deposit via the real add handler against the entity scope.
         let mut add_args = HashMap::new();
@@ -2259,7 +2263,10 @@ mod tests {
         let entity = &source.entity;
         let store = InMemoryGraph::default();
         store.upsert_entity(entity).unwrap();
-        store.set_file_hash(&entity.file_origin.as_ref().unwrap().0, *source.hash.as_bytes());
+        store.set_file_hash(
+            &entity.file_origin.as_ref().unwrap().0,
+            *source.hash.as_bytes(),
+        );
 
         let sessions = SessionRegistry::new();
         let mut args = HashMap::new();
@@ -2297,7 +2304,10 @@ mod tests {
         let entity = &source.entity;
         let store = InMemoryGraph::default();
         store.upsert_entity(entity).unwrap();
-        store.set_file_hash(&entity.file_origin.as_ref().unwrap().0, *source.hash.as_bytes());
+        store.set_file_hash(
+            &entity.file_origin.as_ref().unwrap().0,
+            *source.hash.as_bytes(),
+        );
 
         let sessions = SessionRegistry::new();
         let mut args = HashMap::new();
@@ -2617,7 +2627,10 @@ mod tests {
             object.get("source_excerpt").is_none(),
             "graph blob-miss must not serve a disk excerpt"
         );
-        assert_eq!(object.get("source").unwrap().as_str().unwrap(), "graph-miss");
+        assert_eq!(
+            object.get("source").unwrap().as_str().unwrap(),
+            "graph-miss"
+        );
 
         let after_misses = GRAPH_MISS_COUNT.load(std::sync::atomic::Ordering::SeqCst);
         assert!(after_misses >= before_misses + 1);
@@ -2700,7 +2713,10 @@ mod tests {
             object.get("source_excerpt").is_none(),
             "corrupt blob must not fall back to disk"
         );
-        assert_eq!(object.get("source").unwrap().as_str().unwrap(), "graph-miss");
+        assert_eq!(
+            object.get("source").unwrap().as_str().unwrap(),
+            "graph-miss"
+        );
 
         let after_misses = GRAPH_MISS_COUNT.load(std::sync::atomic::Ordering::SeqCst);
         assert!(after_misses >= before_misses + 1);

--- a/crates/kin-mcp/src/handlers/mod.rs
+++ b/crates/kin-mcp/src/handlers/mod.rs
@@ -161,6 +161,21 @@ mod tests {
         approvals_by_change: HashMap<SemanticChangeId, Vec<kin_model::provenance::Approval>>,
     }
 
+    thread_local! {
+        static TEST_FILE_HASHES: std::cell::RefCell<HashMap<FilePathId, Hash256>> =
+            std::cell::RefCell::new(HashMap::new());
+    }
+
+    fn reset_trace_source_registry() {
+        TEST_FILE_HASHES.with(|map| map.borrow_mut().clear());
+    }
+
+    fn register_trace_source(file_id: &FilePathId, hash: Hash256) {
+        TEST_FILE_HASHES.with(|map| {
+            map.borrow_mut().insert(file_id.clone(), hash);
+        });
+    }
+
     impl kin_model::graph::EntityStore for EmptyStore {
         type Error = KinDbError;
 
@@ -350,7 +365,10 @@ mod tests {
             &self,
             file_id: &FilePathId,
         ) -> std::result::Result<Option<kin_model::Hash256>, Self::Error> {
-            Ok(self.file_hashes.get(file_id).copied())
+            if let Some(hash) = self.file_hashes.get(file_id).copied() {
+                return Ok(Some(hash));
+            }
+            Ok(TEST_FILE_HASHES.with(|map| map.borrow().get(file_id).copied()))
         }
     }
 
@@ -1269,11 +1287,28 @@ mod tests {
         assert!(kinds.contains(&EntityKind::Method));
     }
 
-    fn make_source_backed_entity(content: &str) -> (tempfile::TempDir, Entity) {
+    struct GraphBackedSource {
+        _dir: tempfile::TempDir,
+        _env: EnvVarGuard,
+        entity: Entity,
+        hash: Hash256,
+    }
+
+    /// Build an entity whose body is materialized only in a graph-owned blob
+    /// store (no source file on disk), discoverable via `KIN_SOURCE_ROOT`. The
+    /// caller registers `hash` against the entity's file path in its store so
+    /// the graph-first read path can resolve the body. Callers must hold
+    /// `ENV_MUTEX` for the lifetime of the returned guard.
+    fn make_source_backed_entity(content: &str) -> GraphBackedSource {
         let dir = tempdir().unwrap();
-        let path = dir.path().join("validate.ts");
-        fs::write(&path, content).unwrap();
-        let file_id = kin_model::ids::FilePathId::new(path.to_string_lossy());
+        let kin_dir = dir.path().join(".kin");
+        fs::create_dir_all(&kin_dir).unwrap();
+        let env = EnvVarGuard::set("KIN_SOURCE_ROOT", dir.path());
+
+        let blob_store = kin_blobs::BlobStore::new(kin_dir.join("objects")).unwrap();
+        let hash = blob_store.write(content.as_bytes()).unwrap();
+
+        let file_id = kin_model::ids::FilePathId::new("validate.ts");
 
         let entity = Entity {
             id: EntityId::new(),
@@ -1307,14 +1342,24 @@ mod tests {
             superseded_by: None,
         };
 
-        (dir, entity)
+        GraphBackedSource {
+            _dir: dir,
+            _env: env,
+            entity,
+            hash,
+        }
     }
 
-    fn make_signature_only_python_entity(content: &str) -> (tempfile::TempDir, Entity) {
+    fn make_signature_only_python_entity(content: &str) -> GraphBackedSource {
         let dir = tempdir().unwrap();
-        let path = dir.path().join("validate.py");
-        fs::write(&path, content).unwrap();
-        let file_id = kin_model::ids::FilePathId::new(path.to_string_lossy());
+        let kin_dir = dir.path().join(".kin");
+        fs::create_dir_all(&kin_dir).unwrap();
+        let env = EnvVarGuard::set("KIN_SOURCE_ROOT", dir.path());
+
+        let blob_store = kin_blobs::BlobStore::new(kin_dir.join("objects")).unwrap();
+        let hash = blob_store.write(content.as_bytes()).unwrap();
+
+        let file_id = kin_model::ids::FilePathId::new("validate.py");
         let signature = content
             .lines()
             .next()
@@ -1355,7 +1400,12 @@ mod tests {
             superseded_by: None,
         };
 
-        (dir, entity)
+        GraphBackedSource {
+            _dir: dir,
+            _env: env,
+            entity,
+            hash,
+        }
     }
 
     fn make_dead_code_entity(file_path: &str, name: &str, start_line: u32) -> Entity {
@@ -1393,6 +1443,10 @@ mod tests {
         }
     }
 
+    /// Build a trace entity whose body is materialized in the graph-owned blob
+    /// store under `dir/.kin` and registered against the entity's relative file
+    /// path. Callers must set `KIN_SOURCE_ROOT` to `dir` (so the layout is
+    /// discoverable) and `reset_trace_source_registry()` at test entry.
     fn make_trace_entity(
         dir: &tempfile::TempDir,
         rel_path: &str,
@@ -1401,12 +1455,11 @@ mod tests {
         signature: &str,
         content: &str,
     ) -> Entity {
-        let path = dir.path().join(rel_path);
-        if let Some(parent) = path.parent() {
-            fs::create_dir_all(parent).unwrap();
-        }
-        fs::write(&path, content).unwrap();
-        let file_id = kin_model::ids::FilePathId::new(path.to_string_lossy());
+        let blob_store = kin_blobs::BlobStore::new(dir.path().join(".kin").join("objects")).unwrap();
+        let hash = blob_store.write(content.as_bytes()).unwrap();
+
+        let file_id = kin_model::ids::FilePathId::new(rel_path);
+        register_trace_source(&file_id, hash);
 
         Entity {
             id: EntityId::new(),
@@ -1472,16 +1525,20 @@ mod tests {
 
     #[test]
     fn entity_response_json_includes_real_source_excerpt() {
-        // read_path is only the raw file_origin while KIN_SOURCE_ROOT is unset;
-        // hold ENV_MUTEX so the EnvVarGuard tests can't set it mid-assertion.
         let _lock = ENV_MUTEX
             .get_or_init(|| Mutex::new(()))
             .lock()
             .unwrap_or_else(|e| e.into_inner());
         let content = "export function validate_probe_range_1d8f8275(value: number, minVal: number, maxVal: number): boolean {\n  if (value < minVal) {\n    return false;\n  }\n  return value <= maxVal;\n}\n";
-        let (_dir, entity) = make_source_backed_entity(content);
+        let source = make_source_backed_entity(content);
+        let entity = &source.entity;
 
-        let value = entity_response_json(&EmptyStore::default(), &entity).unwrap();
+        let mut store = EmptyStore::default();
+        store
+            .file_hashes
+            .insert(entity.file_origin.clone().unwrap(), source.hash);
+
+        let value = entity_response_json(&store, entity).unwrap();
         let object = value.as_object().unwrap();
         let excerpt = object
             .get("source_excerpt")
@@ -1489,55 +1546,69 @@ mod tests {
             .unwrap();
 
         assert!(excerpt.contains("return value <= maxVal;"));
+        assert_eq!(object.get("source").unwrap().as_str().unwrap(), "graph");
         assert_eq!(object.get("start_line").unwrap(), 1);
-        assert_eq!(
-            object
-                .get("read_path")
-                .and_then(|value| value.as_str())
-                .unwrap(),
-            entity.file_origin.as_ref().unwrap().0
-        );
     }
 
     #[test]
     fn focal_context_json_prefers_real_source_excerpt() {
+        let _lock = ENV_MUTEX
+            .get_or_init(|| Mutex::new(()))
+            .lock()
+            .unwrap_or_else(|e| e.into_inner());
         let content = "export function validate_probe_range_1d8f8275(value: number, minVal: number, maxVal: number): boolean {\n  if (value < minVal) {\n    return false;\n  }\n  return value <= maxVal;\n}\n";
-        let (_dir, entity) = make_source_backed_entity(content);
+        let source = make_source_backed_entity(content);
+        let entity = &source.entity;
         let entry = kin_model::ContextEntry {
             entity_id: entity.id,
             projection_level: kin_model::ProjectionLevel::FullBody,
             content: entity.signature.clone(),
         };
 
-        let value = focal_context_json(&EmptyStore::default(), &entry, &entity, false);
+        let mut store = EmptyStore::default();
+        store
+            .file_hashes
+            .insert(entity.file_origin.clone().unwrap(), source.hash);
+
+        let value = focal_context_json(&store, &entry, entity, false);
         let object = value.as_object().unwrap();
         let body = object.get("body").and_then(|value| value.as_str()).unwrap();
 
         assert!(body.contains("return value <= maxVal;"));
         assert_ne!(body, entity.signature);
+        assert_eq!(object.get("source").unwrap().as_str().unwrap(), "graph");
         assert_eq!(object.get("start_line").unwrap(), 1);
     }
 
     #[test]
     fn focal_context_json_surfaces_source_and_stale_markers() {
-        // W1-B contract: get_context_pack's focal entity must carry the
-        // graph/disk source marker and staleness flag in the response payload,
-        // matching get_entity_source.
+        // get_context_pack's focal entity must carry the graph source marker and
+        // staleness flag in the response payload, matching get_entity_source.
+        let _lock = ENV_MUTEX
+            .get_or_init(|| Mutex::new(()))
+            .lock()
+            .unwrap_or_else(|e| e.into_inner());
         let content = "export function validate_probe_range_1d8f8275(value: number, minVal: number, maxVal: number): boolean {\n  return value <= maxVal;\n}\n";
-        let (_dir, entity) = make_source_backed_entity(content);
+        let source = make_source_backed_entity(content);
+        let entity = &source.entity;
         let entry = kin_model::ContextEntry {
             entity_id: entity.id,
             projection_level: kin_model::ProjectionLevel::FullBody,
             content: entity.signature.clone(),
         };
 
-        let value = focal_context_json(&EmptyStore::default(), &entry, &entity, false);
+        let mut store = EmptyStore::default();
+        store
+            .file_hashes
+            .insert(entity.file_origin.clone().unwrap(), source.hash);
+
+        let value = focal_context_json(&store, &entry, entity, false);
         let object = value.as_object().unwrap();
 
-        let source = object.get("source").and_then(|v| v.as_str()).unwrap();
-        assert!(
-            source == "graph" || source == "disk",
-            "focal source marker must reflect the read path, got: {source}"
+        let marker = object.get("source").and_then(|v| v.as_str()).unwrap();
+        assert_eq!(
+            marker, "graph",
+            "focal source marker must reflect the graph read path, got: {marker}"
         );
         assert!(
             object.get("stale").map(|v| v.is_boolean()).unwrap_or(false),
@@ -1547,15 +1618,25 @@ mod tests {
 
     #[test]
     fn focal_context_json_expands_signature_only_python_span() {
+        let _lock = ENV_MUTEX
+            .get_or_init(|| Mutex::new(()))
+            .lock()
+            .unwrap_or_else(|e| e.into_inner());
         let content = "def validate_probe_range_f0cc1f1d(value: float, min_val: float, max_val: float) -> bool:\n    return min_val <= value and value <= max_val\n";
-        let (_dir, entity) = make_signature_only_python_entity(content);
+        let source = make_signature_only_python_entity(content);
+        let entity = &source.entity;
         let entry = kin_model::ContextEntry {
             entity_id: entity.id,
             projection_level: kin_model::ProjectionLevel::FullBody,
             content: entity.signature.clone(),
         };
 
-        let value = focal_context_json(&EmptyStore::default(), &entry, &entity, false);
+        let mut store = EmptyStore::default();
+        store
+            .file_hashes
+            .insert(entity.file_origin.clone().unwrap(), source.hash);
+
+        let value = focal_context_json(&store, &entry, entity, false);
         let object = value.as_object().unwrap();
         let body = object.get("body").and_then(|value| value.as_str()).unwrap();
 
@@ -1565,7 +1646,13 @@ mod tests {
 
     #[test]
     fn handle_explore_codebase_trace_returns_ordered_bodies_and_constants() {
+        let _lock = ENV_MUTEX
+            .get_or_init(|| Mutex::new(()))
+            .lock()
+            .unwrap_or_else(|e| e.into_inner());
+        reset_trace_source_registry();
         let dir = tempdir().unwrap();
+        let _env = EnvVarGuard::set("KIN_SOURCE_ROOT", dir.path());
         let tag = "trace9f31";
 
         let entry = make_trace_entity(
@@ -1694,7 +1781,13 @@ mod tests {
 
     #[test]
     fn handle_explore_codebase_trace_infers_constants_without_graph_edges() {
+        let _lock = ENV_MUTEX
+            .get_or_init(|| Mutex::new(()))
+            .lock()
+            .unwrap_or_else(|e| e.into_inner());
+        reset_trace_source_registry();
         let dir = tempdir().unwrap();
+        let _env = EnvVarGuard::set("KIN_SOURCE_ROOT", dir.path());
         let tag = "traceconst";
 
         let step = make_trace_entity(
@@ -1739,7 +1832,13 @@ mod tests {
 
     #[test]
     fn handle_explore_codebase_trace_evaluates_rust_call_query() {
+        let _lock = ENV_MUTEX
+            .get_or_init(|| Mutex::new(()))
+            .lock()
+            .unwrap_or_else(|e| e.into_inner());
+        reset_trace_source_registry();
         let dir = tempdir().unwrap();
+        let _env = EnvVarGuard::set("KIN_SOURCE_ROOT", dir.path());
         let tag = "traceeval";
 
         let entry = make_trace_entity(
@@ -2098,10 +2197,16 @@ mod tests {
         // get_context_pack response, through the real graph surfaces — no fake
         // or demo data, the same create/query path the product uses.
         use kin_model::graph::EntityStore;
+        let _lock = ENV_MUTEX
+            .get_or_init(|| Mutex::new(()))
+            .lock()
+            .unwrap_or_else(|e| e.into_inner());
         let content = "export function validate_probe_range_1d8f8275(value: number, minVal: number, maxVal: number): boolean {\n  return value <= maxVal;\n}\n";
-        let (_dir, entity) = make_source_backed_entity(content);
+        let source = make_source_backed_entity(content);
+        let entity = &source.entity;
         let store = InMemoryGraph::default();
-        store.upsert_entity(&entity).unwrap();
+        store.upsert_entity(entity).unwrap();
+        store.set_file_hash(&entity.file_origin.as_ref().unwrap().0, *source.hash.as_bytes());
 
         // Deposit via the real add handler against the entity scope.
         let mut add_args = HashMap::new();
@@ -2145,10 +2250,16 @@ mod tests {
     #[test]
     fn handle_trace_computation_returns_focal_body_for_entity_id() {
         use kin_model::graph::EntityStore;
+        let _lock = ENV_MUTEX
+            .get_or_init(|| Mutex::new(()))
+            .lock()
+            .unwrap_or_else(|e| e.into_inner());
         let content = "export function validate_probe_range_1d8f8275(value: number, minVal: number, maxVal: number): boolean {\n  if (value < minVal) {\n    return false;\n  }\n  return value <= maxVal;\n}\n";
-        let (_dir, entity) = make_source_backed_entity(content);
+        let source = make_source_backed_entity(content);
+        let entity = &source.entity;
         let store = InMemoryGraph::default();
-        store.upsert_entity(&entity).unwrap();
+        store.upsert_entity(entity).unwrap();
+        store.set_file_hash(&entity.file_origin.as_ref().unwrap().0, *source.hash.as_bytes());
 
         let sessions = SessionRegistry::new();
         let mut args = HashMap::new();
@@ -2177,10 +2288,16 @@ mod tests {
     #[test]
     fn handle_trace_computation_resolves_query_to_entity() {
         use kin_model::graph::EntityStore;
+        let _lock = ENV_MUTEX
+            .get_or_init(|| Mutex::new(()))
+            .lock()
+            .unwrap_or_else(|e| e.into_inner());
         let content = "export function validate_probe_range_1d8f8275(value: number, minVal: number, maxVal: number): boolean {\n  if (value < minVal) {\n    return false;\n  }\n  return value <= maxVal;\n}\n";
-        let (_dir, entity) = make_source_backed_entity(content);
+        let source = make_source_backed_entity(content);
+        let entity = &source.entity;
         let store = InMemoryGraph::default();
-        store.upsert_entity(&entity).unwrap();
+        store.upsert_entity(entity).unwrap();
+        store.set_file_hash(&entity.file_origin.as_ref().unwrap().0, *source.hash.as_bytes());
 
         let sessions = SessionRegistry::new();
         let mut args = HashMap::new();
@@ -2437,7 +2554,7 @@ mod tests {
     }
 
     #[test]
-    fn test_disk_fallback_stale_flag() {
+    fn test_graph_blob_miss_reports_gap_without_disk_fallback() {
         let _lock = ENV_MUTEX
             .get_or_init(|| Mutex::new(()))
             .lock()
@@ -2495,21 +2612,19 @@ mod tests {
 
         let value = entity_response_json(&store, &entity).unwrap();
         let object = value.as_object().unwrap();
-        let excerpt = object
-            .get("source_excerpt")
-            .and_then(|v| v.as_str())
-            .unwrap();
 
-        assert_eq!(excerpt, disk_content);
-        assert_eq!(object.get("stale").unwrap().as_bool().unwrap(), true);
-        assert_eq!(object.get("source").unwrap().as_str().unwrap(), "disk");
+        assert!(
+            object.get("source_excerpt").is_none(),
+            "graph blob-miss must not serve a disk excerpt"
+        );
+        assert_eq!(object.get("source").unwrap().as_str().unwrap(), "graph-miss");
 
         let after_misses = GRAPH_MISS_COUNT.load(std::sync::atomic::Ordering::SeqCst);
         assert!(after_misses >= before_misses + 1);
     }
 
     #[test]
-    fn test_hash_mismatch_falls_back_to_disk() {
+    fn test_hash_mismatch_reports_gap_without_disk_fallback() {
         let _lock = ENV_MUTEX
             .get_or_init(|| Mutex::new(()))
             .lock()
@@ -2522,11 +2637,10 @@ mod tests {
         let objects_dir = kin_dir.join("objects");
         let blob_store = kin_blobs::BlobStore::new(objects_dir).unwrap();
 
-        // correct content
         let content = "export function test_mismatch() { return 42; }";
         let correct_hash = kin_blobs::digest(content.as_bytes());
 
-        // Write incorrect bytes to the correct hash path to simulate corrupt/mismatched blob
+        // Write incorrect bytes to the correct hash path to simulate a corrupt blob
         let bad_content = "corrupt content";
         let hex = correct_hash.to_string();
         let shard_dir = blob_store.root().join(&hex[..2]);
@@ -2534,7 +2648,7 @@ mod tests {
         let blob_file = shard_dir.join(&hex[2..]);
         fs::write(&blob_file, bad_content.as_bytes()).unwrap();
 
-        // Write the correct file on disk
+        // The correct content exists on disk, but the graph blob is corrupt
         let file_path = "src/lib.rs";
         let full_path = dir.path().join(file_path);
         fs::create_dir_all(full_path.parent().unwrap()).unwrap();
@@ -2580,16 +2694,13 @@ mod tests {
 
         let value = entity_response_json(&store, &entity).unwrap();
         let object = value.as_object().unwrap();
-        let excerpt = object
-            .get("source_excerpt")
-            .and_then(|v| v.as_str())
-            .unwrap();
 
-        // It should verify incorrect blob, discard it, fall back to disk, which has the correct content
-        assert_eq!(excerpt, content);
-        // Since disk matches correct_hash, it should NOT be stale
-        assert_eq!(object.get("stale").unwrap().as_bool().unwrap(), false);
-        assert_eq!(object.get("source").unwrap().as_str().unwrap(), "disk");
+        // The corrupt blob is discarded and the graph gap is reported — no disk read.
+        assert!(
+            object.get("source_excerpt").is_none(),
+            "corrupt blob must not fall back to disk"
+        );
+        assert_eq!(object.get("source").unwrap().as_str().unwrap(), "graph-miss");
 
         let after_misses = GRAPH_MISS_COUNT.load(std::sync::atomic::Ordering::SeqCst);
         assert!(after_misses >= before_misses + 1);


### PR DESCRIPTION
## What

Implements the FIR-863 graph-first fixes for the **zero file-search authority** rule in `kin trace` and the MCP entity-source path. After graph truth exists, these runtime query paths must answer from graph-owned truth — never raw filesystem reads, grep, or source-tree walks. On a graph miss they now fail loud or return the existing guidance instead of silently repairing from disk.

This is a **core-path behavior change** — opening for Troy's review, not merging.

## Fixes (all in `kin`)

**`crates/kin-cli/src/commands/trace.rs`**
1. `render_entity_source` (was `fs::read` PRIMARY) — now serves the focal/neighbor body from the **graph blob store** (`get_file_hash` + `read_blob_from_layout`, digest-verified). The raw `fs::read` is gone; the graph signature projection from `build_context_pack` remains the fallback.
2. `source_symbol_fallback` (recursive `read_dir` + grep of the source tree) — **deleted**, along with `best_source_snippet_for_patterns` / `render_source_fallback_lines` / `SourceSymbolFallback` and the now-dead snippet helpers. Entity graph-miss now returns the existing `trace_not_found_guidance`.
3. `entity_or_file_mentions_qualifier` (disk `content.contains()`) — replaced by `entity_mentions_qualifier`, which disambiguates from the graph-owned name, signature, and doc summary.
4. `render_file_path_trace_lines` (raw disk dump for a file-path arg) — now resolves the path to the **graph-owned entities** declared in that file (`query_entities`), or returns guidance if the file isn't in the graph.

**`crates/kin-mcp/src/handlers/common.rs`**
5. `read_entity_source_excerpt_detailed` — drops the disk leg; on graph blob-miss it increments `GRAPH_MISS_COUNT`, sets the source marker to `graph-miss`, and returns `None` so the caller's `ok_or_else("entity source body unavailable")` fail-loud fires. `resolve_entity_source_path` (filesystem probing) removed.

Out of scope: `locate.rs` ref/scope `git grep` (FIR-908) is left as-is.

## Tests

- Added trace tests: graph-owned signature/doc-summary disambiguation, and graph-miss returns guidance with no disk fallback.
- Rewrote the two MCP disk-fallback tests to assert the graph-gap / fail-loud behavior (no disk excerpt, `source == "graph-miss"`).
- Converted the MCP source fixtures (`make_source_backed_entity`, `make_signature_only_python_entity`, `make_trace_entity`) to be **graph-blob backed** rather than disk backed, so the positive body-serving tests now prove the graph-first path end to end.

## Validation (actual)

- `cargo build --release --bin kin --bin kin-daemon` — clean.
- `cargo test -p kin-cli trace` — 28 passed, 0 failed.
- `cargo test -p kin-mcp` — 167 passed, 0 failed.
- No new clippy/unused warnings in the changed files.
