### PR TITLE
test(init): bounded-retry SnapshotManager::open to fix flock fork-leak flake

### DIFF
--- a/crates/kin-cli/src/commands/init.rs
+++ b/crates/kin-cli/src/commands/init.rs
@@ -3310,9 +3310,7 @@ mod tests {
     use tokio::io::{AsyncReadExt, AsyncWriteExt};
     use tokio::net::TcpListener;
 
-    fn open_snapshot_with_retry(
-        path: impl Into<std::path::PathBuf>,
-    ) -> kin_db::SnapshotManager {
+    fn open_snapshot_with_retry(path: impl Into<std::path::PathBuf>) -> kin_db::SnapshotManager {
         let path = path.into();
         for attempt in 0..10u32 {
             match kin_db::SnapshotManager::open(path.clone()) {
@@ -4318,8 +4316,7 @@ mod tests {
         let _warm_cache_guard = EnvVarGuard::set("KIN_INIT_WARM_CACHE", "1");
 
         let init_result = kin_core::init(repo_dir.path()).unwrap();
-        let local_snap =
-            open_snapshot_with_retry(init_result.layout.kindb_snapshot_path());
+        let local_snap = open_snapshot_with_retry(init_result.layout.kindb_snapshot_path());
         let blob_store = kin_blobs::BlobStore::new(init_result.layout.objects_dir()).unwrap();
 
         let all_files = collect_source_files(repo_dir.path()).unwrap();
@@ -4415,8 +4412,7 @@ mod tests {
     fn warm_embedding_state_restores_cached_vectors_and_requeues_delta() {
         let dir = tempfile::tempdir().unwrap();
         let result = kin_core::init(dir.path()).unwrap();
-        let local_snap =
-            open_snapshot_with_retry(result.layout.kindb_snapshot_path());
+        let local_snap = open_snapshot_with_retry(result.layout.kindb_snapshot_path());
 
         let source_graph = kin_db::InMemoryGraph::new();
         let entity_a = test_entity("alpha", "src/lib.rs");
@@ -4453,8 +4449,7 @@ mod tests {
     fn warm_text_index_sidecar_reopens_with_queryable_docs() {
         let dir = tempfile::tempdir().unwrap();
         let result = kin_core::init(dir.path()).unwrap();
-        let local_snap =
-            open_snapshot_with_retry(result.layout.kindb_snapshot_path());
+        let local_snap = open_snapshot_with_retry(result.layout.kindb_snapshot_path());
 
         let cache_graph_path = dir.path().join("warm-cache/graph.kndb");
         let cache_snap = kin_db::SnapshotManager::new(&cache_graph_path);
@@ -4482,8 +4477,7 @@ mod tests {
     fn warm_graft_preserves_tracked_non_entity_files() {
         let dir = tempfile::tempdir().unwrap();
         let result = kin_core::init(dir.path()).unwrap();
-        let local_snap =
-            open_snapshot_with_retry(result.layout.kindb_snapshot_path());
+        let local_snap = open_snapshot_with_retry(result.layout.kindb_snapshot_path());
 
         let source_graph = kin_db::InMemoryGraph::new();
         let shallow = kin_model::ShallowTrackedFile {
@@ -4535,8 +4529,7 @@ mod tests {
     fn warm_graft_preserves_change_dag_and_branches() {
         let dir = tempfile::tempdir().unwrap();
         let result = kin_core::init(dir.path()).unwrap();
-        let local_snap =
-            open_snapshot_with_retry(result.layout.kindb_snapshot_path());
+        let local_snap = open_snapshot_with_retry(result.layout.kindb_snapshot_path());
 
         let source_graph = kin_db::InMemoryGraph::new();
         let genesis_id = SemanticChangeId::from_hash(Hash256::from_bytes([0x11; 32]));
@@ -4949,8 +4942,7 @@ mod tests {
         // Re-open snapshot to verify persistence.
         drop(graph);
         drop(snap);
-        let snap2 =
-            open_snapshot_with_retry(init_result.layout.kindb_snapshot_path());
+        let snap2 = open_snapshot_with_retry(init_result.layout.kindb_snapshot_path());
         let graph2 = snap2.graph();
         let entities = graph2.list_all_entities().unwrap();
 
@@ -5143,8 +5135,7 @@ pub struct Config {
         // Reload from snapshot to verify persistence
         drop(graph);
         drop(snap);
-        let snap2 =
-            open_snapshot_with_retry(init_result.layout.kindb_snapshot_path());
+        let snap2 = open_snapshot_with_retry(init_result.layout.kindb_snapshot_path());
         let graph2 = snap2.graph();
         let entities = graph2.list_all_entities().unwrap();
 

--- a/crates/kin-cli/src/commands/init.rs
+++ b/crates/kin-cli/src/commands/init.rs
@@ -3310,6 +3310,26 @@ mod tests {
     use tokio::io::{AsyncReadExt, AsyncWriteExt};
     use tokio::net::TcpListener;
 
+    fn open_snapshot_with_retry(
+        path: impl Into<std::path::PathBuf>,
+    ) -> kin_db::SnapshotManager {
+        let path = path.into();
+        for attempt in 0..10u32 {
+            match kin_db::SnapshotManager::open(path.clone()) {
+                Ok(s) => return s,
+                Err(e) => {
+                    if attempt == 9 {
+                        panic!("SnapshotManager::open({path:?}) failed after 10 attempts: {e}");
+                    }
+                    std::thread::sleep(std::time::Duration::from_millis(
+                        50 * u64::from(attempt + 1),
+                    ));
+                }
+            }
+        }
+        unreachable!()
+    }
+
     #[test]
     fn git_history_import_options_supports_recent_full_and_off() {
         assert!(git_history_import_options("off").is_none());
@@ -4229,7 +4249,7 @@ mod tests {
         .unwrap();
 
         let layout = kin_core::KinLayout::new(repo_dir.path().join(".kin"));
-        let snap = kin_db::SnapshotManager::open(layout.kindb_snapshot_path()).unwrap();
+        let snap = open_snapshot_with_retry(layout.kindb_snapshot_path());
         let graph = snap.graph();
 
         assert!(repo_dir.path().join(".kin/snapshot/manifest.json").exists());
@@ -4279,7 +4299,7 @@ mod tests {
         assert_eq!(daemon_hits.load(Ordering::SeqCst), 0);
 
         let layout = kin_core::KinLayout::new(repo_dir.path().join(".kin"));
-        let snap = kin_db::SnapshotManager::open(layout.kindb_snapshot_path()).unwrap();
+        let snap = open_snapshot_with_retry(layout.kindb_snapshot_path());
         let graph = snap.graph();
         assert_repo_owned_graph_truth(graph.as_ref(), &expected_paths);
         assert_makefile_is_text_searchable(graph.as_ref());
@@ -4299,7 +4319,7 @@ mod tests {
 
         let init_result = kin_core::init(repo_dir.path()).unwrap();
         let local_snap =
-            kin_db::SnapshotManager::open(init_result.layout.kindb_snapshot_path()).unwrap();
+            open_snapshot_with_retry(init_result.layout.kindb_snapshot_path());
         let blob_store = kin_blobs::BlobStore::new(init_result.layout.objects_dir()).unwrap();
 
         let all_files = collect_source_files(repo_dir.path()).unwrap();
@@ -4396,7 +4416,7 @@ mod tests {
         let dir = tempfile::tempdir().unwrap();
         let result = kin_core::init(dir.path()).unwrap();
         let local_snap =
-            kin_db::SnapshotManager::open(result.layout.kindb_snapshot_path()).unwrap();
+            open_snapshot_with_retry(result.layout.kindb_snapshot_path());
 
         let source_graph = kin_db::InMemoryGraph::new();
         let entity_a = test_entity("alpha", "src/lib.rs");
@@ -4434,7 +4454,7 @@ mod tests {
         let dir = tempfile::tempdir().unwrap();
         let result = kin_core::init(dir.path()).unwrap();
         let local_snap =
-            kin_db::SnapshotManager::open(result.layout.kindb_snapshot_path()).unwrap();
+            open_snapshot_with_retry(result.layout.kindb_snapshot_path());
 
         let cache_graph_path = dir.path().join("warm-cache/graph.kndb");
         let cache_snap = kin_db::SnapshotManager::new(&cache_graph_path);
@@ -4463,7 +4483,7 @@ mod tests {
         let dir = tempfile::tempdir().unwrap();
         let result = kin_core::init(dir.path()).unwrap();
         let local_snap =
-            kin_db::SnapshotManager::open(result.layout.kindb_snapshot_path()).unwrap();
+            open_snapshot_with_retry(result.layout.kindb_snapshot_path());
 
         let source_graph = kin_db::InMemoryGraph::new();
         let shallow = kin_model::ShallowTrackedFile {
@@ -4516,7 +4536,7 @@ mod tests {
         let dir = tempfile::tempdir().unwrap();
         let result = kin_core::init(dir.path()).unwrap();
         let local_snap =
-            kin_db::SnapshotManager::open(result.layout.kindb_snapshot_path()).unwrap();
+            open_snapshot_with_retry(result.layout.kindb_snapshot_path());
 
         let source_graph = kin_db::InMemoryGraph::new();
         let genesis_id = SemanticChangeId::from_hash(Hash256::from_bytes([0x11; 32]));
@@ -4917,7 +4937,7 @@ mod tests {
 
         // Initialize kin so we get a valid graph.
         let init_result = kin_core::init(root).unwrap();
-        let snap = kin_db::SnapshotManager::open(init_result.layout.kindb_snapshot_path()).unwrap();
+        let snap = open_snapshot_with_retry(init_result.layout.kindb_snapshot_path());
         let graph = snap.graph();
         let blob_store = kin_blobs::BlobStore::new(init_result.layout.objects_dir()).unwrap();
 
@@ -4930,7 +4950,7 @@ mod tests {
         drop(graph);
         drop(snap);
         let snap2 =
-            kin_db::SnapshotManager::open(init_result.layout.kindb_snapshot_path()).unwrap();
+            open_snapshot_with_retry(init_result.layout.kindb_snapshot_path());
         let graph2 = snap2.graph();
         let entities = graph2.list_all_entities().unwrap();
 
@@ -5023,7 +5043,7 @@ fn test_parse_json() {
         .unwrap();
 
         let init_result = kin_core::init(root).unwrap();
-        let snap = kin_db::SnapshotManager::open(init_result.layout.kindb_snapshot_path()).unwrap();
+        let snap = open_snapshot_with_retry(init_result.layout.kindb_snapshot_path());
         let graph = snap.graph();
         let blob_store = kin_blobs::BlobStore::new(init_result.layout.objects_dir()).unwrap();
 
@@ -5112,7 +5132,7 @@ pub struct Config {
 
         // Init and index
         let init_result = kin_core::init(root).unwrap();
-        let snap = kin_db::SnapshotManager::open(init_result.layout.kindb_snapshot_path()).unwrap();
+        let snap = open_snapshot_with_retry(init_result.layout.kindb_snapshot_path());
         let graph = snap.graph();
         let blob_store = kin_blobs::BlobStore::new(init_result.layout.objects_dir()).unwrap();
         let all_files = collect_source_files(root).unwrap();
@@ -5124,7 +5144,7 @@ pub struct Config {
         drop(graph);
         drop(snap);
         let snap2 =
-            kin_db::SnapshotManager::open(init_result.layout.kindb_snapshot_path()).unwrap();
+            open_snapshot_with_retry(init_result.layout.kindb_snapshot_path());
         let graph2 = snap2.graph();
         let entities = graph2.list_all_entities().unwrap();
 


### PR DESCRIPTION
`commands::init::tests` reopen a snapshot right after dropping it. In parallel test runs an advisory `flock` fd can leak through `fork()` to a sibling test process, so the reopen transiently fails with `LockError` (EAGAIN / os error 35) — the flake that forced a re-run on #58.

Fix: a comment-free `open_snapshot_with_retry` helper (10 attempts, linear backoff) wrapping the 12 reopen sites. The lock frees in ms, so bounded retry clears the flake without masking real errors (still panics after 10 attempts with the underlying error).

Validated: init test module 6× consecutive green (31 passed, 0 failed each).
