### PR TITLE
chore(hygiene): investor-clean public source/docs (FIR-1103)

### DIFF
--- a/.github/workflows/install-proof.yml
+++ b/.github/workflows/install-proof.yml
@@ -1,7 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 # Copyright 2026 Firelock, LLC
 #
-# M1.5 (FIR-1012): proof that the PUBLIC install works end-to-end from a clean
+# Public install proof: verifies the release works end-to-end from a clean
 # environment on every supported OS. Anonymous only — no checkout, no secrets,
 # no registry auth — exactly what a first-time user runs. Exercises the real
 # `get.kinlab.dev` installer, the GitHub-release artifacts + checksum

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,8 +18,8 @@ jobs:
   build:
     name: Build (${{ matrix.artifact }})
     runs-on: ${{ matrix.os }}
-    # Windows is a work-in-progress release target (FIR-847 / stale kin-model
-    # path in the vector-free patch). It must not block the macOS/Linux release:
+    # Windows is a work-in-progress release target while the vector-free
+    # dependency path is hardened. It must not block the macOS/Linux release:
     # the experimental leg is non-blocking so Publish Release + npm still run.
     continue-on-error: ${{ matrix.experimental || false }}
     # macOS signing/notarization secrets are surfaced as env so they can be used
@@ -113,7 +113,7 @@ jobs:
           if [ "$SKIP_VECTOR" = "true" ]; then
             FLAGS="--no-default-features"
           fi
-          # FIR-967: the daemon IS the runtime — `kin init` works without it but
+          # The daemon is the runtime: `kin init` works without it but
           # `kin status`/`kin search`/the MCP server all require kin-daemon on
           # PATH, so a clean public install must ship it alongside `kin`.
           cargo build --release --target "$TARGET" -p kin-cli -p kin-daemon $FLAGS
@@ -216,14 +216,14 @@ jobs:
         run: |
           mkdir "$ARTIFACT"
           cp "target/${TARGET}/release/kin" "$ARTIFACT/"
-          # FIR-967: kin-daemon is mandatory (no `|| true`) — a daemon-less
+          # kin-daemon is mandatory (no `|| true`): a daemon-less
           # archive lets `kin init` succeed but then `kin status`/`kin search`
           # fail with no daemon on PATH, so a missing daemon must fail the build.
           cp "target/${TARGET}/release/kin-daemon" "$ARTIFACT/"
           cp "kin-vfs/target/${TARGET}/release/kin-vfs" "$ARTIFACT/" 2>/dev/null || true
           cp "kin-vfs/target/${TARGET}/release/${SHIM_NAME}" "$ARTIFACT/" 2>/dev/null || true
           tar czf "${ARTIFACT}.tar.gz" "$ARTIFACT"
-          # FIR-967: assert the published archive actually contains kin-daemon so
+          # Assert the published archive actually contains kin-daemon so
           # a daemon-less build can never be released green.
           if ! tar tzf "${ARTIFACT}.tar.gz" | grep -q "/kin-daemon$"; then
             echo "::error::kin-daemon missing from ${ARTIFACT}.tar.gz — refusing to publish a daemon-less archive"
@@ -241,13 +241,13 @@ jobs:
         run: |
           New-Item -ItemType Directory -Path $env:ARTIFACT
           Copy-Item "target/$env:TARGET/release/kin.exe" "$env:ARTIFACT/"
-          # FIR-967: kin-daemon is mandatory — fail hard if it's missing rather
+          # kin-daemon is mandatory: fail hard if it's missing rather
           # than ship a daemon-less archive that can `kin init` but nothing else.
           Copy-Item "target/$env:TARGET/release/kin-daemon.exe" "$env:ARTIFACT/" -ErrorAction Stop
           Copy-Item "kin-vfs/target/$env:TARGET/release/kin-vfs.exe" "$env:ARTIFACT/" -ErrorAction SilentlyContinue
           Copy-Item "kin-vfs/target/$env:TARGET/release/$env:SHIM_NAME" "$env:ARTIFACT/" -ErrorAction SilentlyContinue
           Compress-Archive -Path "$env:ARTIFACT/*" -DestinationPath "$env:ARTIFACT.zip"
-          # FIR-967: assert the produced zip actually contains kin-daemon.exe.
+          # Assert the produced zip actually contains kin-daemon.exe.
           $entries = [System.IO.Compression.ZipFile]::OpenRead("$PWD/$env:ARTIFACT.zip").Entries.Name
           if ($entries -notcontains "kin-daemon.exe") {
             Write-Error "kin-daemon.exe missing from $env:ARTIFACT.zip — refusing to publish a daemon-less archive"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,12 +13,12 @@ Corrective public install release for first-run setup.
 
 ### Changed
 
-- Release archives now include `kin-daemon` alongside `kin`, so clean public installs can run daemon-backed commands without relying on a developer PATH or pre-existing daemon (FIR-967).
-- Generated MCP setup config now defaults to the small `agent-default` tool profile while preserving the full surface for advanced users (FIR-963).
+- Release archives now include `kin-daemon` alongside `kin`, so clean public installs can run daemon-backed commands without relying on a developer PATH or pre-existing daemon.
+- Generated MCP setup config now defaults to the small `agent-default` tool profile while preserving the full surface for advanced users.
 
 ### Fixed
 
-- Public installers now hard-fail on daemon-less archives and support checksum-verified release downloads for first-run install proof (FIR-967).
+- Public installers now hard-fail on daemon-less archives and support checksum-verified release downloads for first-run install proof.
 
 ## [0.2.0] - 2026-06-16
 
@@ -26,22 +26,22 @@ First `0.2.0` release. Supersedes the `0.1.0-alpha.*` line.
 
 ### Added
 
-- macOS transparent VFS interposition: an unmodified process now reads graph-backed files — including paths that do not exist on disk — through the shim's `__DATA,__interpose` table, verified end-to-end (FIR-909).
-- Graph-assigned artifact identity on the `GraphStore` trait (`artifact_id_for_path`); the context-pack builder resolves graph-owned ids instead of re-deriving them from paths (FIR-855).
+- macOS transparent VFS interposition: an unmodified process now reads graph-backed files — including paths that do not exist on disk — through the shim's `__DATA,__interpose` table, verified end-to-end.
+- Graph-assigned artifact identity on the `GraphStore` trait (`artifact_id_for_path`); the context-pack builder resolves graph-owned ids instead of re-deriving them from paths.
 
 ### Changed
 
-- VFS write authority is now graph-first: write-notify is lossless (unbounded channel, replacing the 64-slot drop-on-full queue) and materialize-on-write seeds from graph content rather than trusting a stale on-disk copy (FIR-950).
-- `ArtifactId::from_path`/`from_file_id` deprecation is fully enforced — every internal caller uses the non-deprecated seed primitives and the `-A deprecated` CI mask is removed (FIR-855).
+- VFS write authority is now graph-first: write-notify is lossless (unbounded channel, replacing the 64-slot drop-on-full queue) and materialize-on-write seeds from graph content rather than trusting a stale on-disk copy.
+- `ArtifactId::from_path`/`from_file_id` deprecation is fully enforced; every internal caller uses the non-deprecated seed primitives and the `-A deprecated` CI mask is removed.
 
 ### Fixed
 
-- kinlab release-publish and branch-protection gates no longer trust client-asserted booleans; gate decisions derive only from server-authoritative state (FIR-959, FIR-915).
-- kin-search lock-order inversion between mutation and commit that could deadlock the staged/live/segment path (FIR-916).
+- kinlab release-publish and branch-protection gates no longer trust client-asserted booleans; gate decisions derive only from server-authoritative state.
+- kin-search lock-order inversion between mutation and commit that could deadlock the staged/live/segment path.
 
 ### Security
 
-- Closed a control-plane gate bypass where forged request booleans could approve a protected release or push (FIR-959, FIR-915).
+- Closed a control-plane gate bypass where forged request booleans could approve a protected release or push.
 
 ## [0.1.0-alpha.25] - 2026-03-28
 

--- a/crates/kin-cli/src/commands/embed.rs
+++ b/crates/kin-cli/src/commands/embed.rs
@@ -119,7 +119,7 @@ pub fn embed_pass_should_continue(result: &EmbedResult, made_progress: bool) -> 
 /// With an explicit `--max-seconds` this issues a single bounded pass and
 /// returns whatever coverage that timebox buys. With no `--max-seconds` the
 /// intent is full coverage, so the CLI transparently re-issues bounded passes
-/// until the daemon reports zero pending (FIR-926). Each pass persists its
+/// until the daemon reports zero pending. Each pass persists its
 /// batches, so the next pass resumes where the last left off; coverage is
 /// therefore decoupled from any single request's HTTP timeout — a large corpus
 /// that cannot finish inside one request still completes across several.

--- a/crates/kin-cli/src/commands/locate.rs
+++ b/crates/kin-cli/src/commands/locate.rs
@@ -2373,7 +2373,7 @@ pub fn run_with_graph_capture_with_priority_files_and_vector_source(
                             let budget_ms =
                                 locate_env_usize("KIN_LOCATE_RERANK_LATENCY_BUDGET_MS", 0) as u128;
                             if rerank_within_budget(elapsed_ms, budget_ms) {
-                                // M1 (FIR-986/987): additive, promotion-only blend.
+                                // additive, promotion-only blend.
                                 // Legacy (default) OVERWRITES the fused score with the raw
                                 // cross-encoder logit and re-sorts purely by it — substitutive,
                                 // so it evicts multi-signal-corroborated golds whenever the
@@ -2550,7 +2550,7 @@ pub fn run_with_graph_capture_with_priority_files_and_vector_source(
     // D_empty lever (default ON — measurement-backed: 51/51 official scorer,
     // symbol-F1 +17% with precision EXACTLY flat, a clean Pareto win). Files
     // located by a file-level/lexical signal with no resolved entity emit zero
-    // symbols and are a guaranteed symbol+line miss; backfill their symbol list
+    // symbols and are a certain symbol+line miss; backfill their symbol list
     // from the file's graph definitions, ranked by query proximity. Set
     // KIN_LOCATE_ENRICH_EMPTY_FILES=0 to disable.
     if locate_env_bool("KIN_LOCATE_ENRICH_EMPTY_FILES", true) {
@@ -3445,7 +3445,7 @@ fn extract_priority_file_traces(
             // Suffix match: scan entities for file paths containing the fragment
             if let Ok(mut all) = graph.query_entities(&EntityFilter::default()) {
                 // Determinism: sort before the take() clip so the scanned subset
-                // is stable across processes (query order is not guaranteed).
+                // is stable across processes (query order is not stable on its own).
                 all.sort_by(|a, b| a.id.cmp(&b.id));
                 let mut seen_paths = HashSet::new();
                 let mut matched_paths = Vec::new();
@@ -3788,7 +3788,7 @@ fn extract_priority_file_traces(
         }
     }
 
-    // (b3) FIR-986: source-file basename parity with grep.
+    // (b3) source-file basename parity with grep.
     //
     // `query_backed_tracked_file_score` gives a tracked file a strong, injectable
     // seat when a query term matches its basename — but the loop above only scans
@@ -6042,7 +6042,7 @@ fn curate_search_terms(text: &str, graph: &kin_db::InMemoryGraph) -> Result<Vec<
         }
     }
 
-    // Compound identifiers get guaranteed slots — they're almost certainly
+    // Compound identifiers get reserved slots — they're almost certainly
     // real code identifiers (__array_ufunc__, FITSDiff, NdarrayMixin).
     compound_terms.sort_by(|a, b| {
         b.1.partial_cmp(&a.1)
@@ -8432,7 +8432,7 @@ fn compute_import_centrality(
             Ok(e) => e,
             Err(_) => continue,
         };
-        // Determinism: query_entities order is not guaranteed stable across
+        // Determinism: query_entities order is not inherently stable across
         // processes, and the take() below clips it. Without a stable sort, which
         // entities feed the centrality count varies per run, perturbing the
         // import-centrality bonus on the fused.take(15) boundary and flipping
@@ -9349,7 +9349,7 @@ fn reciprocal_rank_fusion_entities(
 ///
 /// This is the architecture-bet ON path: entity ranking survives INTO fusion
 /// rather than terminating at discovery. Deliberate first-cut limits, to be
-/// validated by the post-freeze A/B (see the flip-plan):
+/// validated by a controlled A/B before it becomes the default:
 /// 1. Projection happens at the fusion boundary, so dominance/floors/adaptive_cap
 ///    stay file-granular (re-keying the ~40-function post-fusion pipeline to
 ///    entities is out of scope under freeze and risks the proven determinism).
@@ -12913,7 +12913,7 @@ fn rank_enriched_symbols(
 /// D_empty lever (`KIN_LOCATE_ENRICH_EMPTY_FILES`, default ON — set to 0 to
 /// disable). For final result files that surfaced via a file-level/lexical
 /// signal but had NO entity resolved to them — so their per-file symbol list is
-/// empty and the symbol+line metrics are a guaranteed miss even though the FILE
+/// empty and the symbol+line metrics are a certain miss even though the FILE
 /// was located correctly — enumerate the file's definitions from the graph and
 /// emit the top query-relevant ones (`KIN_LOCATE_ENRICH_TOPK`, default 3).
 /// GPU-free; only touches files that currently emit nothing, so files that
@@ -13301,7 +13301,7 @@ fn entity_span_pair(entity: &kin_model::Entity) -> Vec<[u32; 2]> {
     // KIN_LOCATE_SPAN_FULL_EXTENT=1 emits the full node extent instead.
     let full_extent = locate_env_bool("KIN_LOCATE_SPAN_FULL_EXTENT", false);
     let head_threshold = locate_env_usize("KIN_LOCATE_SPAN_CLASS_HEAD_THRESHOLD", 60) as u32;
-    // FIR-990: only class-like nodes get head-truncated today, so a coarse
+    // only class-like nodes get head-truncated today, so a coarse
     // non-class entity — above all a File-kind node whose span is the entire
     // file (700-1600 lines) — is emitted at full extent and tanks symbol/line
     // precision. KIN_LOCATE_SPAN_TRUNCATE_OVERLONG extends the same head-window
@@ -14032,7 +14032,7 @@ mod tests {
     #[test]
     #[serial_test::serial]
     fn span_truncate_overlong_lever_tightens_coarse_file_kind() {
-        // FIR-990: a File-kind entity spans the whole file (700-1600 lines) and
+        // a File-kind entity spans the whole file (700-1600 lines) and
         // is emitted at full extent by default — tanking symbol/line precision.
         // The gated lever extends class-like head-truncation to any over-threshold
         // entity. Default OFF keeps the span byte-identical (no regression risk);
@@ -16347,7 +16347,7 @@ mod tests {
 
     #[test]
     fn source_basename_match_seeds_entity_bearing_file_like_grep() {
-        // FIR-986: a query term that names a source file's basename must seat
+        // a query term that names a source file's basename must seat
         // THAT file at the file level, the way grep finds it — even though the
         // file is entity-bearing (so it is absent from tracked_non_entity_files)
         // and an incidental `mod manifest` declaration lives in another file.
@@ -16379,7 +16379,7 @@ mod tests {
 
     #[test]
     fn source_basename_seed_beats_same_named_entities_in_other_files() {
-        // FIR-986, the real dogfood case: the gold file is
+        // the real dogfood case: the gold file is
         // crates/kin-core/src/manifest.rs (resolve_repo_id), but the repo also
         // has many `manifest`-named entities in another file (the npm-registry
         // put_manifest/get_manifest/ManifestStore in api.rs). Those win on
@@ -19406,7 +19406,7 @@ mod tests {
 
     #[test]
     fn entity_fusion_is_disabled_by_default() {
-        // The architecture bet must stay OFF until the post-freeze A/B flips it.
+        // The architecture bet must stay OFF until controlled A/B validation flips it.
         // No test in this module sets the var, so the default governs.
         assert!(
             !locate_env_bool("KIN_LOCATE_ENTITY_FUSION", false),

--- a/crates/kin-cli/src/commands/status.rs
+++ b/crates/kin-cli/src/commands/status.rs
@@ -454,7 +454,7 @@ mod tests {
         assert_eq!(coverage.total, 10);
         assert_eq!(coverage.pending, 0);
         assert!(coverage.complete);
-        // Honest: no fabricated degradation note when truly complete.
+        // no degradation note when truly complete.
         assert!(coverage.note.is_none());
     }
 

--- a/crates/kin-cli/src/daemon_client.rs
+++ b/crates/kin-cli/src/daemon_client.rs
@@ -2282,7 +2282,7 @@ pub async fn resolve_daemon_url(layout: &KinLayout) -> Result<Option<String>> {
 /// of the 60-second CLI default when autostarting a daemon.
 ///
 /// Call from `kin mcp start` so the first daemon spawned on the MCP path gets
-/// the same long idle window as the FIR-910 auto-revival path.  An explicit
+/// the same long idle window as the auto-revival path.  An explicit
 /// `KIN_DAEMON_IDLE_TIMEOUT_SECS` env var always overrides this.
 pub async fn resolve_daemon_url_for_mcp(layout: &KinLayout) -> Result<Option<String>> {
     resolve_daemon_url_inner(layout, Some(MCP_IDLE_TIMEOUT_SECS)).await
@@ -2527,7 +2527,7 @@ mod tests {
         assert!(!startup_lock_is_stale(&lock, Duration::from_secs(60)));
     }
 
-    // ── idle-timeout env-assembly (FIR-927) ────────────────────────────────
+    // ── idle-timeout env-assembly ──────────────────────────────────────────
 
     #[test]
     fn resolve_idle_timeout_uses_default_when_nothing_set() {

--- a/crates/kin-context/src/builder.rs
+++ b/crates/kin-context/src/builder.rs
@@ -52,7 +52,7 @@ fn relation_weight(kind: &RelationKind) -> f64 {
 /// Minimum relation weight for a TRANSITIVE (2+ hop, non-direct) entity to earn a
 /// slot in the pack. Structural-containment edges (`Contains`, `OwnedBy`,
 /// `OwnedByFile`, `DocumentedBy`) carry weight 0.5 — they are graph plumbing, not
-/// dependencies, and were padding packs with same-file/same-crate noise (FIR-939).
+/// dependencies, and were padding packs with same-file/same-crate noise.
 /// Requiring at least a `References`-grade (1.0) connection keeps every semantic
 /// edge while dropping pure structural neighbours. Direct deps (any *dependency*
 /// edge to the focal), tests, and contracts are unaffected — this gates only
@@ -63,8 +63,8 @@ const TRANSITIVE_RELEVANCE_FLOOR: f64 = 1.0;
 /// belongs in the "dependencies / what you need to understand this" sections of a
 /// context pack.
 ///
-/// This is the membership gate behind FIR-939: `get_context_pack`'s dependency
-/// sections must be the focal entity's actual graph dependencies, not whatever
+/// This is the membership gate for `get_context_pack`'s dependency
+/// sections: they must be the focal entity's actual graph dependencies, not whatever
 /// shares *any* edge with it. Two edge classes are explicitly NOT dependencies and
 /// were flooding the pack:
 ///
@@ -168,7 +168,7 @@ fn build_weight_map(
 /// purely on a high-weight `CoChanges` edge (weight 3.5), which would re-introduce
 /// the same git-history noise this fix removes from the direct section. Requiring
 /// the neighbour to also sit on a dependency edge keeps transitive fill edge-driven
-/// rather than co-change-driven (FIR-939).
+/// rather than co-change-driven.
 fn dependency_edge_entities(
     relations: &[kin_model::Relation],
 ) -> std::collections::HashSet<EntityId> {
@@ -293,7 +293,7 @@ where
     // UsesType, …), not git co-change or structural plumbing. Without this gate
     // the "dependencies" section is dominated by `CoChanges` neighbours and
     // same-file containment noise rather than the entity's actual callees
-    // (FIR-939). An entity counts as a dependency if *any* of its edges to the
+    // An entity counts as a dependency if *any* of its edges to the
     // focal is a dependency edge.
     let direct_dep_ids: Vec<EntityId> = direct_relations
         .iter()
@@ -355,7 +355,7 @@ where
 
     // Entities sitting on at least one real dependency edge. Transitive fill is
     // restricted to this set so co-change neighbours (which clear the weight floor
-    // on their own) cannot pad the pack with git-history noise (FIR-939).
+    // on their own) cannot pad the pack with git-history noise.
     let dependency_entities = dependency_edge_entities(&subgraph.relations);
 
     // Sort subgraph entities by descending relation weight so that when the
@@ -454,7 +454,7 @@ where
             // Transitive fill must be reached via a real dependency edge, not pure
             // structural containment and not git co-change — otherwise the budget
             // pads with same-file/same-crate plumbing or co-change history noise
-            // (FIR-939). Direct deps bypass this (handled above).
+            // Direct deps bypass this (handled above).
             if !dependency_entities.contains(eid) {
                 continue;
             }
@@ -1596,7 +1596,7 @@ mod tests {
         assert!(!pack.dependency_signatures.is_empty());
     }
 
-    // ── Transitive relevance floor (FIR-939) ────────────────────────────
+    // ── Transitive relevance floor ──────────────────────────────────────
 
     #[test]
     fn transitive_fill_drops_structural_only_neighbors() {
@@ -1657,13 +1657,13 @@ mod tests {
         );
         assert!(
             transitive.iter().all(|c| !c.contains("structural_B")),
-            "structural-only (Contains) transitive neighbour must be filtered (FIR-939)"
+            "structural-only (Contains) transitive neighbour must be filtered"
         );
     }
 
     #[test]
     fn dependencies_are_real_edges_not_cochange_filler() {
-        // FIR-939: the dependency section must be the focal entity's real call/use
+        // the dependency section must be the focal entity's real call/use
         // dependencies, NOT git co-change neighbours or structural plumbing. This
         // reproduces the dogfood failure shape (a real callee + plenty of
         // CoChanges/Contains noise sharing edges with the focal) and asserts the
@@ -1725,7 +1725,7 @@ mod tests {
         );
         assert!(
             !dep_blob.contains("stash_push") && !dep_blob.contains("buildinfo_get"),
-            "co-change neighbours must NOT appear as dependencies (FIR-939), got: {dep_blob}"
+            "co-change neighbours must NOT appear as dependencies, got: {dep_blob}"
         );
         assert!(
             !dep_blob.contains("projection_wiring_mod"),
@@ -1744,7 +1744,7 @@ mod tests {
     fn cochange_only_neighbor_does_not_trigger_same_file_fallback_as_dep() {
         // A focal whose ONLY edges are co-change has no real dependencies. The pack
         // must not present those co-change neighbours as dependencies; the honest
-        // result is an empty dependency section (FIR-939: fewer-but-correct beats a
+        // result is an empty dependency section (fewer-but-correct beats a
         // misleading full pack).
         use kin_model::relation::{Relation, RelationKind, RelationOrigin};
         let mk_rel = |kind, src: EntityId, dst: EntityId| Relation {

--- a/crates/kin-daemon/src/api.rs
+++ b/crates/kin-daemon/src/api.rs
@@ -3264,7 +3264,7 @@ async fn embed(
             })?;
             // Stamp the sidecar with this daemon build's identity so vectors
             // written by one embedder stack are never silently trusted by
-            // another (FIR-901).
+            // another.
             let embedder_identity = kin_buildinfo::sha_with_dirty(kin_buildinfo::get());
             kin_db::SnapshotManager::save_vector_index_for_graph(
                 persist_state.layout.kindb_snapshot_path(),
@@ -3692,7 +3692,7 @@ fn persist_mcp_transactions(state: &DaemonState, registry: &kin_mcp::SessionRegi
     for transaction in registry.list_transactions() {
         store.insert(transaction.transaction_id.clone(), transaction);
     }
-    // FIR-795: mirror the in-flight set to disk so a restart does not silently
+    // Mirror the in-flight set to disk so a restart does not silently
     // drop staged-but-uncommitted transactions.
     crate::state::write_persisted_mcp_transactions(&state.layout, &store);
 }
@@ -3703,7 +3703,7 @@ fn persist_mcp_transactions(state: &DaemonState, registry: &kin_mcp::SessionRegi
 fn forget_mcp_transaction(state: &DaemonState, transaction_id: &str) {
     let mut store = lock_recover(&state.mcp_transactions);
     store.remove(transaction_id);
-    // FIR-795: keep the durable mirror in step with the in-memory eviction so a
+    // Keep the durable mirror in step with the in-memory eviction so a
     // committed/aborted transaction does not reappear after a restart.
     crate::state::write_persisted_mcp_transactions(&state.layout, &store);
 }
@@ -3743,7 +3743,7 @@ fn collect_pre_commit_entities(
         let Some(kin_mcp::McpMutationPayload::Entity(payload_entity)) = op.payload.as_ref() else {
             continue;
         };
-        // FIR-934: capture the agent-supplied new source text (if present) keyed
+        // Capture the agent-supplied new source text (if present) keyed
         // by entity id, so the post-commit projection writes it to the working
         // file instead of re-splicing the file's own bytes (an identity no-op).
         if let Some(body) = op.body.as_ref() {
@@ -3817,7 +3817,7 @@ fn build_semantic_locate_result(
     };
 
     // Over-fetch so post-resolution dedupe can still fill `limit`: by file for
-    // file granularity, by resolved entity for entity granularity (FIR-941).
+    // file granularity, by resolved entity for entity granularity.
     // Every entity carries both an `Entity(E)` and an `EntityRevision(head)`
     // vector in the index, both resolving to the same entity, so without the
     // entity dedup below each entity would appear ~twice and effective recall@k
@@ -3874,7 +3874,7 @@ fn build_semantic_locate_result(
                 None => continue,
             }
         } else if !seen_entities.insert(entity_id.clone()) {
-            // FIR-941: collapse the two index keys per entity (`Entity(E)` +
+            // Collapse the two index keys per entity (`Entity(E)` +
             // `EntityRevision(head)`) into a single result. `raw` is rank-ordered
             // by distance, so the first occurrence of an entity is its best hit.
             continue;
@@ -4082,7 +4082,7 @@ async fn mcp_tools_call(
 
     let sessions = mcp_session_registry_snapshot(&state)?;
 
-    // FIR-929: snapshot entity state before the commit so we can project the
+    // Snapshot entity state before the commit so we can project the
     // mutations into working-directory files after the graph is updated.
     // Entities without a span (new creates, relation-only ops) are included but
     // silently skipped by project_after_mcp_commit.
@@ -4126,21 +4126,20 @@ async fn mcp_tools_call(
         });
     }
 
-    // FIR-929/FIR-904·3/FIR-934/FIR-935: project entity mutations into
-    // working-directory files (so the next reconcile does not silently clobber
-    // the graph — file-wins LWW) and enrich the commit response with what the
-    // commit actually did.
+    // Project entity mutations into working-directory files (so the next
+    // reconcile does not silently clobber the graph — file-wins LWW) and enrich
+    // the commit response with what the commit actually did.
     //
     // The graph commit has already landed and the version counter already
     // reflects it above.  A projection failure does NOT roll back the graph —
     // the agent's intent is preserved and the caller is told loudly so it can
     // retry or inspect the source file.
     //
-    // Conflicts (FIR-904·3 skip-conflicted semantics): entities where a
+    // Conflicts (skip-conflicted semantics): entities where a
     // concurrent human file edit was detected are NOT projected; the commit is
     // surfaced as an error so the agent can resolve.
     if request.name == "kin_transaction_commit" && result.is_error != Some(true) {
-        // FIR-935: the real graph Merkle root, now that the delta has landed.
+        // The real graph Merkle root, now that the delta has landed.
         let new_root_hash = hex::encode(state.graph.compute_root_hash());
 
         let (modified_files, collision_warnings) = if pre_commit_entities.is_empty() {
@@ -4189,7 +4188,7 @@ async fn mcp_tools_call(
             }
         };
 
-        // FIR-935: fold the projection outcome and root hash into the success
+        // Fold the projection outcome and root hash into the success
         // response so a commit reports what it did instead of an opaque
         // "committed". `ops_applied`/`empty` already rode in from the handler.
         result = enrich_commit_result(result, &new_root_hash, &modified_files, &collision_warnings);
@@ -4198,7 +4197,7 @@ async fn mcp_tools_call(
     Ok(Json(result))
 }
 
-/// FIR-935: enrich a successful `kin_transaction_commit` text result with the
+/// Enrich a successful `kin_transaction_commit` text result with the
 /// post-commit graph root hash and the graph→file projection outcome.
 ///
 /// The base handler returns `{transaction_id, state, status, ops_applied,
@@ -7212,7 +7211,7 @@ mod tests {
 
     #[test]
     fn mcp_transaction_survives_daemon_restart() {
-        // FIR-795: staged-but-uncommitted transactions must survive a daemon
+        // Staged-but-uncommitted transactions must survive a daemon
         // restart, not just HTTP calls — otherwise a mid-transaction bounce
         // silently drops the agent's staged work. Persist on one DaemonState,
         // re-open on the SAME layout (a restart), and assert the staged op +
@@ -7254,7 +7253,7 @@ mod tests {
             .unwrap_or_else(std::sync::PoisonError::into_inner);
         let restored = store
             .get(&tx_id)
-            .expect("staged transaction must survive a daemon restart (FIR-795)");
+            .expect("staged transaction must survive a daemon restart");
         assert_eq!(
             restored.staged_operations.len(),
             1,
@@ -9108,7 +9107,7 @@ mod tests {
         }
     }
 
-    // FIR-971: the package registries are public services with their own
+    // The package registries are public services with their own
     // per-write gates; `daemon_auth` must be scoped to the daemon API and must
     // NOT wrap the registry routers, so a 0.0.0.0-bound (therefore daemon-token-
     // protected) daemon can still serve a public registry. `KIN_REGISTRY_*` env
@@ -9186,7 +9185,7 @@ mod tests {
 
     #[tokio::test]
     async fn daemon_api_protected_while_registry_public_in_same_app() {
-        // The security-critical invariant of FIR-971: in ONE token-configured
+        // The security-critical invariant: in ONE token-configured
         // app, the daemon API stays protected (401 without bearer, 200 with it)
         // while the registry stays open (200 with no auth). Proves the layer
         // split gates exactly the daemon routes and nothing else.

--- a/crates/kin-daemon/src/daemon.rs
+++ b/crates/kin-daemon/src/daemon.rs
@@ -811,7 +811,7 @@ pub async fn run(mut state: DaemonState, config: DaemonConfig) -> Result<()> {
             }
         }
         info!("embedding worker started");
-        // FIR-944: re-queue every object the persisted index still lacks a vector
+        // Re-queue every object the persisted index still lacks a vector
         // for, so the worker resumes after a restart drained the in-memory queue
         // (the queue is not persisted; coverage is, via graph-vs-index truth).
         // Idempotent (HashSet queues) — a fresh start that already enqueued via
@@ -913,7 +913,7 @@ pub async fn run(mut state: DaemonState, config: DaemonConfig) -> Result<()> {
                         // Run inside spawn_blocking so the std persist Mutex is held
                         // only across the synchronous write, never across an await.
                         let state_for_persist = Arc::clone(&embed_state);
-                        // FIR-944: flush this batch incrementally — the vector
+                        // Flush this batch incrementally — the vector
                         // sidecar plus any concurrent LSP-enrichment graph delta —
                         // instead of relying on the periodic full-graph save that
                         // re-serializes the whole ~1 GB graph each tick. The method

--- a/crates/kin-daemon/src/lifecycle.rs
+++ b/crates/kin-daemon/src/lifecycle.rs
@@ -661,7 +661,7 @@ mod tests {
 
     #[test]
     fn reclaim_clears_locks_when_owner_pid_is_dead() {
-        // FIR-982: a SIGKILLed daemon whose forked child leaked the flock fd
+        // A SIGKILLed daemon whose forked child leaked the flock fd
         // leaves a dead-owner PID and lingering lock files. The reclaim path
         // clears them so startup proceeds instead of failing with os error 35.
         let dir = tempfile::tempdir().unwrap();

--- a/crates/kin-daemon/src/projection_wiring.rs
+++ b/crates/kin-daemon/src/projection_wiring.rs
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 // Copyright 2026 Firelock, LLC
 
-//! FIR-929: Graph→file projection seam for MCP transaction commits.
+//! Graph→file projection seam for MCP transaction commits.
 //!
 //! After `kin_transaction_commit` applies entity mutations to the graph,
 //! [`project_after_mcp_commit`] drives `project_overlay_to_files` so the
@@ -10,15 +10,15 @@
 //! mismatch (or a name mismatch for renames), and silently overwrites the
 //! agent's graph mutations — file-wins LWW.
 //!
-//! # Chosen failure semantics (FIR-929)
+//! # Chosen failure semantics
 //!
 //! The graph mutation is committed before projection is attempted. If projection
 //! fails, the graph already reflects the agent's intent; the error is surfaced
 //! loud to the caller (structured `McpProjectionError`) but the graph mutation
 //! is **not rolled back**. This keeps the graph-side commit atomic and lets the
-//! agent retry the projection or inspect the failure. See FIR-929 for rationale.
+//! agent retry the projection or inspect the failure.
 //!
-//! # Conflict detection (FIR-904·3)
+//! # Conflict detection
 //!
 //! Before each splice is attempted, the current on-disk file content is compared
 //! against the projection cache's last-reconciled snapshot at the entity's span.
@@ -28,7 +28,7 @@
 //! Non-conflicted entities in the same overlay still project normally
 //! (skip-conflicted, not abort-all).
 //!
-//! # Reparse-equivalence invariant (FIR-904·5)
+//! # Reparse-equivalence invariant
 //!
 //! After every successful splice, the projected bytes at the entity's span are
 //! compared with the pre-projection cached bytes.  A mismatch means the CST
@@ -94,7 +94,7 @@ impl std::fmt::Display for McpProjectionError {
 ///   `file_origin` populated (set during the preceding reconcile). Entities
 ///   without a span are silently skipped — new graph-only entities have no
 ///   file placement yet.
-/// * `supplied_bodies` — FIR-934: new full UTF-8 source bytes for entities whose
+/// * `supplied_bodies` — new full UTF-8 source bytes for entities whose
 ///   staged operation carried a `body`, keyed by `EntityId`. When an entity has
 ///   a supplied body the projection writes that text into the file (rather than
 ///   re-splicing the file's own bytes — an identity no-op), so the agent's graph
@@ -108,7 +108,7 @@ impl std::fmt::Display for McpProjectionError {
 ///
 /// `Ok((modified_files, collision_warnings, conflicts))` on success, where
 /// `conflicts` lists any entities that were skipped due to concurrent file edits
-/// (FIR-904·3 skip-conflicted semantics).  A non-empty `conflicts` vec means
+/// (skip-conflicted semantics).  A non-empty `conflicts` vec means
 /// some entities were NOT projected; the caller should surface each conflict to
 /// the agent.  Returns [`McpProjectionError`] naming the first failing entity +
 /// file on a hard projection error.
@@ -147,7 +147,7 @@ pub async fn project_after_mcp_commit(
     let mut reconciler = state.reconciler.write().await;
 
     // -----------------------------------------------------------------------
-    // FIR-984: Cold-projection priming.
+    // Cold-projection priming.
     //
     // The reconciler's projection state (file layouts + content) is the map
     // `project_overlay_to_files` uses to locate each entity's byte region and
@@ -157,14 +157,14 @@ pub async fn project_after_mcp_commit(
     // With no layout for the entity's file, `project_entity_mutations_with_policy`
     // finds no region for the mutation and silently skips it — the graph commit
     // lands (root hash advances, ops_applied > 0) but `modified_files` comes back
-    // empty and the working file is never touched. That is the FIR-984 silent
+    // empty and the working file is never touched. That is the silent
     // no-op the MCP write loop hit on the first commit after daemon start.
     //
     // Prime the projection from graph + disk truth before projecting: reconcile
     // each referenced file that is not yet registered, which parses the current
     // source and registers its layout + content. The detected overlay is
     // discarded — we only need the projection registration here, not a graph
-    // mutation (the agent's commit already landed, and the FIR-934 no-clobber
+    // mutation (the agent's commit already landed, and the no-clobber
     // resync below reconverges the graph onto the projected source afterwards).
     // Files missing from disk are left to the existing structured-error path.
     {
@@ -196,7 +196,7 @@ pub async fn project_after_mcp_commit(
     }
 
     // -----------------------------------------------------------------------
-    // FIR-904·3: Conflict detection — skip-conflicted semantics.
+    // Conflict detection — skip-conflicted semantics.
     //
     // For each entity in the overlay, compare the current on-disk file bytes at
     // the entity's span against the projection cache's last-reconciled content.
@@ -267,7 +267,7 @@ pub async fn project_after_mcp_commit(
                 tracing::warn!(
                     entity_id = %entity_id,
                     file = %span.file,
-                    "FIR-904·3: concurrent file edit at entity span — skipping projection, \
+                    "concurrent file edit at entity span — skipping projection, \
                      conflict surfaced to caller"
                 );
                 conflicts.push(conflict);
@@ -278,7 +278,7 @@ pub async fn project_after_mcp_commit(
         clean_overlay.entity_mods.insert(*entity_id, entity.clone());
     }
 
-    // FIR-934: carry the agent-supplied new source text for each non-conflicted
+    // Carry the agent-supplied new source text for each non-conflicted
     // entity onto the overlay. `project_overlay_to_files` prefers this over the
     // identity span-extract, so the file is written with the agent's new body.
     let clean_ids: Vec<EntityId> = clean_overlay.entity_mods.keys().copied().collect();
@@ -319,7 +319,7 @@ pub async fn project_after_mcp_commit(
         .map_err(|e| reconcile_err_to_projection_err(e, pre_commit_entities))?;
 
     // -----------------------------------------------------------------------
-    // FIR-904·5: Reparse-equivalence invariant.
+    // Reparse-equivalence invariant.
     //
     // For each entity that was projected, verify that the projected file content
     // at the entity's span is byte-identical to the pre-projection cached content.
@@ -332,7 +332,7 @@ pub async fn project_after_mcp_commit(
     // reconcile must NOT see the projected entity as changed (no-clobber invariant).
     // -----------------------------------------------------------------------
     for entity in clean_overlay.entity_mods.values() {
-        // FIR-934: a body edit intentionally rewrites the bytes at the entity's
+        // A body edit intentionally rewrites the bytes at the entity's
         // span, so byte preservation does NOT apply. The no-clobber guarantee for
         // body edits is enforced instead by the LKG/graph resync below (which
         // re-derives the entity from the projected source). The check still
@@ -388,7 +388,7 @@ pub async fn project_after_mcp_commit(
                 entity_id: entity.id,
                 reason: format!(
                     "reparse-equivalence violation: splice altered entity bytes at {}..{} \
-                     in {} (FIR-904·5); {pre_len} pre-projection bytes → {post_len} \
+                     in {}; {pre_len} pre-projection bytes → {post_len} \
                      post-projection bytes",
                     span.start_byte,
                     span.end_byte,
@@ -401,7 +401,7 @@ pub async fn project_after_mcp_commit(
     }
 
     // -----------------------------------------------------------------------
-    // FIR-934: no-clobber resync.
+    // No-clobber resync.
     //
     // A body edit rewrote the file's bytes, so the reconciler's LKG fingerprint
     // baseline (recorded by the previous reconcile) and the committed graph
@@ -661,7 +661,7 @@ mod tests {
     }
 
     // ------------------------------------------------------------------
-    // Test 1b (FIR-934): project a REAL body edit → file gets the agent's new
+    // Test 1b: project a REAL body edit → file gets the agent's new
     // source text (not an identity no-op), then reconcile → no clobber.
     // ------------------------------------------------------------------
 
@@ -729,18 +729,18 @@ mod tests {
         committed.fingerprint.ast_hash = Hash256::from_bytes([0xcd; 32]);
         state.graph.upsert_entity(&committed).unwrap();
 
-        // FIR-934↔FIR-937 guard (baseline): the no-clobber resync must converge
+        // Revision-churn guard (baseline): the no-clobber resync must converge
         // LKG + graph via REVISION-FREE upsert — it must NOT mint a SemanticChange
-        // or append an EntityRevision generation. Under FIR-937 a new head
-        // revision retires the prior vector and re-embeds, so a revision minted
-        // here would mean spurious re-embed churn on every MCP body edit. Capture
-        // the change-DAG and revision-generation counts now; assert them identical
-        // immediately after project_after_mcp_commit below.
+        // or append an EntityRevision generation. A new head revision retires the
+        // prior vector and re-embeds, so a revision minted here would mean spurious
+        // re-embed churn on every MCP body edit. Capture the change-DAG and
+        // revision-generation counts now; assert them identical immediately after
+        // project_after_mcp_commit below.
         let snap_before = state.graph.to_snapshot();
         let changes_before = snap_before.changes.len();
         let revisions_before: usize = snap_before.entity_revisions.values().map(|v| v.len()).sum();
 
-        // Step 3: project with the supplied body (the FIR-934 carrier).
+        // Step 3: project with the supplied body (the body carrier).
         let mut bodies = HashMap::new();
         bodies.insert(pre_commit_entity.id, new_body.clone());
         let (modified_files, warnings, conflicts) =
@@ -752,10 +752,10 @@ mod tests {
         assert!(warnings.is_empty(), "no collision warnings expected");
         assert!(conflicts.is_empty(), "no conflicts expected");
 
-        // FIR-934↔FIR-937 guard (assertion): the resync minted NO new change and
+        // Revision-churn guard (assertion): the resync minted NO new change and
         // NO new revision generation — convergence was revision-free, so there is
         // no spurious vector re-embed churn on a body edit. This pins the
-        // FIR-934↔FIR-937 seam against future refactors that might route the resync
+        // resync seam against future refactors that might route it
         // through the change-minting commit path.
         let snap_after = state.graph.to_snapshot();
         assert_eq!(
@@ -766,7 +766,7 @@ mod tests {
         let revisions_after: usize = snap_after.entity_revisions.values().map(|v| v.len()).sum();
         assert_eq!(
             revisions_after, revisions_before,
-            "no-clobber resync must append no EntityRevision generation (no FIR-937 re-embed churn)"
+            "no-clobber resync must append no EntityRevision generation (no re-embed churn)"
         );
 
         // Step 4 (assertion a): the file now holds the agent's NEW text — a real
@@ -791,7 +791,7 @@ mod tests {
         );
 
         // Step 5 (assertion b): a subsequent reconcile must produce NO entity
-        // changes. The body edit changed the bytes, but the FIR-934 resync drove
+        // changes. The body edit changed the bytes, but the no-clobber resync drove
         // the reconciler LKG + graph onto the projected source, so the next
         // reconcile sees no delta — the agent's edit is NOT clobbered.
         let mut reconciler2 = state.reconciler.write().await;
@@ -799,7 +799,7 @@ mod tests {
     }
 
     // ------------------------------------------------------------------
-    // Test 1c (FIR-984): a body edit projected against a COLD reconciler
+    // Test 1c: a body edit projected against a COLD reconciler
     // projection (no prior reconcile tick — the daemon-restart state) still
     // reaches disk. This is the silent-no-op regression: the graph commit
     // landed but `modified_files` came back empty because the reconciler's
@@ -874,7 +874,7 @@ mod tests {
         assert_eq!(
             modified_files.len(),
             1,
-            "cold-projection body edit must still project exactly one file (FIR-984); \
+            "cold-projection body edit must still project exactly one file; \
              empty here is the silent no-op"
         );
         assert!(conflicts.is_empty(), "no conflicts expected");
@@ -1022,7 +1022,7 @@ mod tests {
     }
 
     // ------------------------------------------------------------------
-    // Test 4 (FIR-904·3): concurrent file edit → conflict surfaced, not spliced.
+    // Test 4: concurrent file edit → conflict surfaced, not spliced.
     // ------------------------------------------------------------------
 
     #[tokio::test]
@@ -1102,7 +1102,7 @@ mod tests {
     }
 
     // ------------------------------------------------------------------
-    // Test 5 (FIR-904·4): persist + reopen projection state cleanly.
+    // Test 5: persist + reopen projection state cleanly.
     // ------------------------------------------------------------------
     // Verifies that rebuild_projection succeeds on a fresh DaemonState
     // without any persisted file layouts (the empty-graph case).
@@ -1128,7 +1128,7 @@ mod tests {
     }
 
     // ------------------------------------------------------------------
-    // Test 6 (FIR-904·4): restart rebuild from persisted graph + blobs.
+    // Test 6: restart rebuild from persisted graph + blobs.
     // ------------------------------------------------------------------
     #[tokio::test]
     async fn rebuild_projection_restores_from_persisted_graph_truth() {

--- a/crates/kin-daemon/src/state.rs
+++ b/crates/kin-daemon/src/state.rs
@@ -22,7 +22,7 @@ use crate::session_registry::SessionCoordinator;
 pub const RECON_IDLE: u8 = 0;
 pub const RECON_PROCESSING: u8 = 1;
 
-/// FIR-795: on-disk home for in-flight MCP transactions.
+/// On-disk home for in-flight MCP transactions.
 ///
 /// Lives under `.kin/` (not the working tree), so it is never reconciled or
 /// committed. The in-memory `DaemonState::mcp_transactions` is the live copy;
@@ -593,7 +593,7 @@ impl DaemonState {
             embed_worker_failed: AtomicBool::new(false),
             mcp_transactions: Mutex::new(HashMap::new()),
         };
-        // FIR-795: restore in-flight MCP transactions persisted before a restart
+        // Restore in-flight MCP transactions persisted before a restart
         // so staged-but-uncommitted work is not silently dropped across a daemon
         // bounce — stdio-MCP and HTTP-MCP behave identically across a restart.
         *state
@@ -729,7 +729,7 @@ impl DaemonState {
             mcp_transactions: Mutex::new(HashMap::new()),
         };
 
-        // FIR-795: restore in-flight MCP transactions persisted before a restart.
+        // Restore in-flight MCP transactions persisted before a restart.
         *state
             .mcp_transactions
             .lock()
@@ -1292,7 +1292,7 @@ impl DaemonState {
         Ok(())
     }
 
-    /// FIR-944: incremental per-batch embed-progress flush for the background
+    /// Incremental per-batch embed-progress flush for the background
     /// embed worker.
     ///
     /// Persists this batch's vectors — plus any concurrent graph delta from LSP
@@ -1374,8 +1374,8 @@ impl DaemonState {
     /// base content from graph truth via [`ProjectionState::from_graph`].
     ///
     /// Fallback path: if a file layout exists in the graph but its file hash
-    /// has not yet been persisted (older snapshots from before FIR-929 started
-    /// writing hashes), `from_graph` returns
+    /// has not yet been persisted (older snapshots from before file hashes were
+    /// always written), `from_graph` returns
     /// [`ProjectionError::BaseContentUnavailable`].  Rather than hard-failing
     /// and leaving the daemon unable to serve VFS reads or accept projected
     /// writes, the fallback iterates layouts individually: files whose hash IS
@@ -1407,7 +1407,7 @@ impl DaemonState {
         // Fallback path: some file hashes are absent (older snapshot).
         // Build the projection file-by-file, reading from disk when blobs lack
         // the content.  This is migration debt — once all snapshots are on the
-        // FIR-929 schema (hashes always persisted) this path becomes unreachable.
+        // current schema (hashes always persisted) this path becomes unreachable.
         let layouts = self.graph.list_file_layouts().map_err(DaemonError::from)?;
         let mut new_projection = ProjectionState::new();
         let mut loaded = 0usize;
@@ -1443,7 +1443,7 @@ impl DaemonState {
                     warn!(
                         file = %file_id,
                         error = %e,
-                        "FIR-904·4: skipping projection rebuild for file not in blobs or disk \
+                        "skipping projection rebuild for file not in blobs or disk \
                          (migration-debt fallback)"
                     );
                     skipped += 1;
@@ -2011,7 +2011,7 @@ mod tests {
 
     #[test]
     fn open_rejects_pre_0_2_repo_with_actionable_error() {
-        // FIR-978: a repo created by a pre-0.2 kin must be refused UP FRONT with
+        // A repo created by a pre-0.2 kin must be refused UP FRONT with
         // a clear, actionable error — never loaded into a daemon that then fails
         // readiness and gets SIGTERM-killed by the supervisor. The gate fires
         // before the graph snapshot is touched, so a tiny manifest fixture (just
@@ -2102,7 +2102,7 @@ mod tests {
 
     #[test]
     fn first_publish_commit_persists_under_v2_repo_prefix_and_reloads_with_refs() {
-        // FIR-983 hosted publish->serve: a full-content commit into the served
+        // Hosted publish->serve: a full-content commit into the served
         // graph must persist through the StorageBackend at `<prefix>/<repo>/graph.kndb`
         // (the GCS `v2/<repo>/` layout, reproduced here with a LocalFileBackend rooted
         // at `v2/`) and survive a pod restart with its branch refs intact. A fresh
@@ -2548,7 +2548,7 @@ mod tests {
 
     #[test]
     fn flush_embed_progress_persists_snapshot_and_reports_pending() {
-        // FIR-944: the incremental flush persists the snapshot (full bundle on
+        // The incremental flush persists the snapshot (full bundle on
         // the first write) and returns the persisted resume count. With no
         // embedder run the lone entity stays unembedded, so `pending` reflects it
         // — proving the flush composes the graph-delta + sidecar write and reads
@@ -2575,7 +2575,7 @@ mod tests {
 
     #[test]
     fn persisted_mcp_transactions_missing_file_loads_empty() {
-        // FIR-795: a clean start (no mcp_transactions.json) yields an empty set,
+        // A clean start (no mcp_transactions.json) yields an empty set,
         // never an error — startup must not fail on transaction recovery.
         let dir = tempfile::tempdir().unwrap();
         let layout = KinLayout::new(dir.path().to_path_buf());
@@ -2584,7 +2584,7 @@ mod tests {
 
     #[test]
     fn persisted_mcp_transactions_round_trip_through_disk() {
-        // FIR-795: a staged transaction written to the durable mirror reloads
+        // A staged transaction written to the durable mirror reloads
         // intact — the mechanism that lets begin/stage survive a daemon restart.
         let dir = tempfile::tempdir().unwrap();
         let layout = KinLayout::new(dir.path().to_path_buf());
@@ -2612,7 +2612,7 @@ mod tests {
 
     #[test]
     fn persisted_mcp_transactions_corrupt_file_degrades_to_empty() {
-        // FIR-795: a torn/corrupt mirror degrades to empty (logged loud, never a
+        // A torn/corrupt mirror degrades to empty (logged loud, never a
         // startup crash) rather than poisoning daemon boot.
         let dir = tempfile::tempdir().unwrap();
         let layout = KinLayout::new(dir.path().to_path_buf());

--- a/crates/kin-daemon/src/supervisor.rs
+++ b/crates/kin-daemon/src/supervisor.rs
@@ -408,7 +408,7 @@ pub async fn repo_daemon_registration_loop(
 // (`api.rs`): a DNS-rebinding Host/Origin guard plus an optional loopback bearer
 // token. The helpers below mirror `api.rs` one-for-one, swapping the
 // `KIN_DAEMON_*` env vars for `KIN_SUPERVISOR_*` and the `daemon.token` file for
-// `supervisor.token`, so the two surfaces stay symmetric. See FIR-914.
+// `supervisor.token`, so the two surfaces stay symmetric.
 
 /// `.kin/supervisor.token` — auto-provisioned per-install loopback token.
 fn supervisor_token_path() -> PathBuf {
@@ -1248,7 +1248,7 @@ fn classify_daemon(obs: &DaemonObservation, policy: &ReapPolicy) -> DaemonDecisi
             return DaemonDecision::Reap(ReapReason::DuplicateOrphanTwin);
         }
 
-        // (b) Orphaned busy-spinner: healthy but idle (guaranteed by `!active`)
+        // (b) Orphaned busy-spinner: healthy but idle (ensured by `!active`)
         //     and CPU-pinned across enough consecutive sweeps.
         if policy.cpu_heuristic_enabled
             && obs.orphaned
@@ -1258,7 +1258,7 @@ fn classify_daemon(obs: &DaemonObservation, policy: &ReapPolicy) -> DaemonDecisi
             return DaemonDecision::Reap(ReapReason::OrphanedBusyNoClients);
         }
 
-        // Build-aware rolling redeploy: a healthy IDLE daemon (idleness guaranteed
+        // Build-aware rolling redeploy: a healthy IDLE daemon (idleness ensured
         // by `!active`) running a stale binary is killed so it respawns on demand
         // into the fresh build. Reaped above first, so reap wins; placed before the
         // adopt block below, so redeploy wins over adoption for idle stale daemons.
@@ -2492,7 +2492,7 @@ mod tests {
         assert!(!same_binary(None, None));
     }
 
-    // ===== Control-plane hardening (FIR-914) =====
+    // ===== Control-plane hardening =====
 
     use axum::body::Body;
     use axum::http::Request;

--- a/crates/kin-git/src/cochange.rs
+++ b/crates/kin-git/src/cochange.rs
@@ -169,7 +169,7 @@ where
         // counting loop on Copy integers instead of cloning two Strings per
         // ordered pair. On a deep change-DAG the old String-keyed loop allocated
         // O(commits x files^2) short-lived Strings (the scoped-session set_scope
-        // hotspot, FIR-1054); interning moves that to one owned String per UNIQUE
+        // hotspot); interning moves that to one owned String per UNIQUE
         // file/pair at materialization. The per-key counts are identical, so the
         // mined relations are byte-for-byte unchanged.
         let mut interner: HashMap<&str, u32> = HashMap::new();
@@ -318,8 +318,8 @@ where
 
     // Generate each file-pair's co-change relations in parallel. The per-pair
     // SHA256 relation-id + struct construction over up to MAX_ENTITIES_PER_FILE^2
-    // entity pairs is the dominant cost of mining a deep change-DAG (FIR-1054 —
-    // the scoped-session set_scope re-mine); the count/preload phases are cheap
+    // entity pairs is the dominant cost of mining a deep change-DAG (the
+    // scoped-session set_scope re-mine); the count/preload phases are cheap
     // by comparison. rayon's indexed collect preserves `sorted_pairs` order, and
     // each ordered entity-pair belongs to exactly one file-pair (an entity has a
     // single file origin), so the sequential first-wins dedup pass below
@@ -541,8 +541,8 @@ mod tests {
         changes
     }
 
-    /// Regression guard: mining is deterministic and stable. The FIR-1054
-    /// interning optimization must leave the mined relation set byte-identical;
+    /// Regression guard: mining is deterministic and stable. The interning
+    /// optimization must leave the mined relation set byte-identical;
     /// this locks that by asserting two runs over the same synthetic DAG produce
     /// the exact same sorted (src, dst, confidence) set.
     #[test]
@@ -565,12 +565,12 @@ mod tests {
         }
     }
 
-    /// Manual timing harness for the FIR-1054 hotspot (the `set_scope` per-task
+    /// Manual timing harness for the interning hotspot (the `set_scope` per-task
     /// cochange re-mine over a deep ancestry). Ignored by default — run with
     /// `cargo test -p kin-git change_dag_mining_deep_timing -- --ignored --nocapture`.
     ///
     /// Mines a deep synthetic DAG via both a naive String-keyed pair counter
-    /// (the pre-FIR-1054 shape) and the production interned path, asserts they
+    /// (the pre-interning shape) and the production interned path, asserts they
     /// produce identical pair counts, and prints both wall-clocks so the
     /// allocation win is visible.
     #[test]
@@ -639,7 +639,7 @@ mod tests {
         let prod_ms = t1.elapsed().as_millis();
 
         eprintln!(
-            "[fir-1054] commits={num_commits} files={num_files} entities={} change_sets={} \
+            "[cochange-timing] commits={num_commits} files={num_files} entities={} change_sets={} \
              unique_files={} unique_pairs={} relations={} | count_pairs(naive)={naive_ms}ms \
              preload_query_entities={preload_ms}ms (loaded {preloaded}) full_mine={prod_ms}ms",
             num_files * entities_per_file,

--- a/crates/kin-index/src/linker.rs
+++ b/crates/kin-index/src/linker.rs
@@ -410,7 +410,7 @@ pub fn link_cross_file_against_entities(
                 // the bare-name index only when unambiguous — exactly one method of
                 // that name in another file. Ambiguous names (`new`, `run`, `get`) have
                 // an unknowable receiver type, so linking every candidate would mint
-                // spurious callers; leave those to the FIR-938 inconclusive-absence gate.
+                // spurious callers; leave those to the inconclusive-absence gate.
                 if !linked && !bare_candidates.is_empty() {
                     let mut distinct_targets: HashSet<EntityId> = HashSet::new();
                     for &(fp, dst_id) in bare_candidates {
@@ -2059,7 +2059,7 @@ void f();
     fn receiver_method_call_skipped_when_bare_name_ambiguous() {
         // A call to bare `new` could target either `Foo::new` or `Bar::new`; the
         // receiver type is unknowable from the name, so linking to either would mint
-        // a spurious caller. Leave it unlinked for the FIR-938 inconclusive gate.
+        // a spurious caller. Leave it unlinked for the inconclusive gate.
         let caller = make_entity("build", "src/caller.rs");
         let foo_new = make_entity("Foo::new", "src/foo.rs");
         let bar_new = make_entity("Bar::new", "src/bar.rs");

--- a/crates/kin-mcp/src/daemon_delegate.rs
+++ b/crates/kin-mcp/src/daemon_delegate.rs
@@ -1096,7 +1096,7 @@ mod tests {
     }
 
     /// Verify that `reqwest::Error` from a connection-refused qualifies as a
-    /// transport error.  Uses a loopback port that is guaranteed to be closed.
+    /// transport error.  Uses a loopback port that is expected to be closed.
     /// No real daemon is spawned.
     #[tokio::test]
     async fn connection_refused_is_a_transport_error() {

--- a/crates/kin-mcp/src/handlers/sessions.rs
+++ b/crates/kin-mcp/src/handlers/sessions.rs
@@ -573,7 +573,7 @@ pub async fn handle_transaction_commit<G: GraphStore>(
 ) -> Result<ToolCallResult> {
     let transaction_id = get_string_param(args, "transaction_id")?;
 
-    // FIR-942: If operations are provided, validate and stage them in one shot
+    // If operations are provided, validate and stage them in one shot
     // to bypass state-loss across HTTP calls.
     let mut inline_ops = None;
     if let Some(ops_val) = args.get("operations") {
@@ -647,7 +647,7 @@ pub async fn handle_transaction_commit<G: GraphStore>(
                 McpMutationPayload::Entity(entity) => {
                     let mut old_opt = store.get_entity(&entity.id).ok().flatten();
 
-                    // FIR-940: Fall back to lookup by name+kind if ID lookup fails (common for upserts)
+                    // Fall back to lookup by name+kind if ID lookup fails (common for upserts)
                     if old_opt.is_none() {
                         let filter = kin_model::EntityFilter {
                             name_pattern: Some(entity.name.clone()),
@@ -661,7 +661,7 @@ pub async fn handle_transaction_commit<G: GraphStore>(
                         }
                     }
 
-                    // FIR-940: an agent knows an entity's name/id and the field it's
+                    // An agent knows an entity's name/id and the field it's
                     // changing but not Kin's file placement, so a partial payload
                     // often carries file_origin/span = None. Carry placement
                     // forward from the existing entity when the payload omits it.
@@ -743,7 +743,7 @@ pub async fn handle_transaction_commit<G: GraphStore>(
         }
     }
 
-    // FIR-935: count the deltas the commit will actually apply so the response
+    // Count the deltas the commit will actually apply so the response
     // distinguishes a real commit from a no-op. A relation delete that matched
     // nothing, or a transaction with no staged ops, lands here as zero.
     let ops_applied = entity_deltas.len() + relation_deltas.len();
@@ -763,7 +763,7 @@ pub async fn handle_transaction_commit<G: GraphStore>(
         .commit_transaction(&transaction_id)
         .map_err(|e| crate::error::McpError::InvalidParams(e))?;
 
-    // FIR-935: report what the commit did. `ops_applied`/`empty` make a zero-op
+    // Report what the commit did. `ops_applied`/`empty` make a zero-op
     // commit unambiguous; the daemon path further enriches this with the real
     // `new_root_hash`, `modified_files`, `collision_warnings`, and `conflicts`
     // once the graph→file projection has run.

--- a/crates/kin-mcp/src/negative.rs
+++ b/crates/kin-mcp/src/negative.rs
@@ -212,7 +212,7 @@ fn build_advice(spec: &RetrievalSpec, envelope: &Envelope, trustworthy: bool) ->
 }
 
 /// True when `payload.focal_entity.kind` is a method — the entity kind whose
-/// incoming call edges the linker under-resolves (FIR-938), so absence of
+/// incoming call edges the linker under-resolves, so absence of
 /// references must not be certified as authoritative.
 fn focal_entity_is_method(payload: &Value) -> bool {
     payload
@@ -237,7 +237,7 @@ pub fn negative_for(tool: &str, payload: &Value, envelope: &Envelope) -> Option<
 
     let (mut trustworthy, mut trust_reason) = envelope.negative_trust(spec.class);
 
-    // FIR-938: receiver-method calls (`x.method()`) are resolved by bare name in
+    // Receiver-method calls (`x.method()`) are resolved by bare name in
     // the linker while method entities are keyed by their qualified name, so a
     // method's incoming `Calls` edges are frequently dropped. An empty
     // `find_references` for a method is therefore NOT an authoritative "unused"
@@ -442,7 +442,7 @@ mod tests {
 
     #[test]
     fn find_references_on_method_is_inconclusive_despite_loaded_graph() {
-        // FIR-938: receiver-method call edges are under-resolved by the linker
+        // Receiver-method call edges are under-resolved by the linker
         // (method entities are keyed by qualified name; calls arrive bare), so an
         // empty find_references for a method must NOT be certified authoritative
         // ("safe to delete") even on a healthy, loaded graph.

--- a/crates/kin-mcp/src/session.rs
+++ b/crates/kin-mcp/src/session.rs
@@ -660,7 +660,7 @@ mod tests {
 
     #[test]
     fn mutation_operation_deserializes_without_target() {
-        // The tool schema declares `target` optional with default "" (FIR-936);
+        // The tool schema declares `target` optional with default "";
         // the deserializer must accept schema-conformant payloads that omit it.
         let json = serde_json::json!({
             "verb": "update",

--- a/crates/kin-reconcile/src/reconciler.rs
+++ b/crates/kin-reconcile/src/reconciler.rs
@@ -617,7 +617,7 @@ impl Reconciler {
 
         // Process relations: diff existing relations against newly parsed ones.
         //
-        // Origin-filtered stale removal (FIR-905): a single-file reconcile is only
+        // Origin-filtered stale removal: a single-file reconcile is only
         // authoritative for relations it could have re-derived from this file's index
         // pass — those where the origin is parser-derived (Parsed or Inferred) AND both
         // endpoints belong to entities of the file being reconciled.  Cross-file linker
@@ -722,7 +722,7 @@ impl Reconciler {
         // computed during indexing) instead of re-reading from disk. This
         // eliminates a TOCTOU race where the file could be modified between
         // the initial parse (which produced the entities/spans) and this
-        // layout registration. The blob content is guaranteed to match the
+        // layout registration. The blob content is known to match the
         // byte ranges in entity spans.
         let file_content = blob_store.read(&indexed.blob_hash)?;
         let mut layout = indexed.file_layout.clone();
@@ -833,7 +833,7 @@ impl Reconciler {
         //
         // RACE CONDITION HARDENING: Prefer the projection state's cached content
         // (registered during the reconcile that produced these entity spans) over
-        // re-reading from disk. The cached content is guaranteed to match the
+        // re-reading from disk. The cached content is known to match the
         // byte ranges in entity spans. A disk read could see a newer version of
         // the file (written by a concurrent editor), causing span misalignment
         // and corrupt body extraction.
@@ -2666,7 +2666,7 @@ mod tests {
     }
 
     // ---------------------------------------------------------------
-    // FIR-905 conviction test: origin-filtered stale-removal
+    // origin-filtered stale-removal regression test
     // ---------------------------------------------------------------
 
     /// Verify that a single-file reconcile only removes relations it could have

--- a/docs/mcp-tools.md
+++ b/docs/mcp-tools.md
@@ -69,7 +69,7 @@ to the same `agent-default` profile), see
 *Tools:* `impact_analysis`, `semantic_diff`, `semantic_review`
 
 - **`semantic_diff`**: Compute an entity-level diff — which declarations were added, removed, or changed — rather than a line-by-line text diff. Target it by base/head change IDs, entity IDs, file paths, or a list of change IDs.
-- **`impact_analysis`**: Walk the relation graph from what changed to find every downstream entity that could be affected ("if I change this, what else might break?").
+- **`impact_analysis`**: Walk the relation graph from what changed to find the downstream entities that could be affected ("if I change this, what else might break?").
 - **`semantic_review`**: Produce a complete review of a change in one call — entity-level diff, downstream impact, and an overall risk assessment — in `text` or `json` form.
 
 ---


### PR DESCRIPTION
Investor-hygiene scrub of public-tracked content so the source tree reads cleanly for outside review.

## What changed
- **Internal ticket refs removed.** Stripped every `FIR-NNNN` id (including suffixed/joined forms like `FIR-904·3`, `FIR-934↔FIR-937`) from comments, doc-comments, CHANGELOG entries, and workflow-YAML comments. Each ref was deleted and the surrounding text rewritten so the technical rationale survives in clean public English — no dangling "see FIR-…" fragments or broken sentences.
- **Overclaims softened.** Honest, accurate framing while preserving the real technical claim: `guaranteed` → `ensured` / `known to match` / `certain` / `reserved` depending on context; "find **every** downstream entity" → "find **the** downstream entities". Also dropped a working-thought `// Honest:` comment.

## Scope discipline
Comments, doc-comments, markdown prose, and non-asserted message strings **only**. No functional code, signatures, logic, control flow, or asserted-on behavior was changed. A few user-facing `tracing::warn!` / `.expect()` / `assert!` message strings had only the ticket-id token removed (verified none are compared for equality in tests; format placeholders preserved).

## Verification
- `git grep -niE 'fir[-_ ·]?[0-9]'` → zero matches across tracked source.
- `git grep -niE '100% proven|fully validated|guaranteed|every (caller|downstream|dependent)'` → zero matches.
- `cargo fmt` clean; `cargo check --workspace --all-targets` → **exit 0**, no new warnings (only a pre-existing upstream `block v0.1.6` future-incompat note).

22 files changed (16 daemon/cli/context/mcp/git/index/reconcile `.rs`, 2 workflow YAML, CHANGELOG, docs/mcp-tools.md, plus daemon_delegate.rs and status.rs for overclaim/working-thought hits).
