### PR TITLE
feat(resources): resource inspect surface + throughput-aware embed batch

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2932,6 +2932,7 @@ dependencies = [
  "kin-db",
  "kin-git",
  "kin-index",
+ "kin-infer",
  "kin-lsp",
  "kin-mcp",
  "kin-migrate",
@@ -3027,6 +3028,7 @@ dependencies = [
  "kin-db",
  "kin-git",
  "kin-index",
+ "kin-infer",
  "kin-lsp",
  "kin-mcp",
  "kin-model",
@@ -3057,9 +3059,9 @@ dependencies = [
 
 [[package]]
 name = "kin-db"
-version = "0.2.6"
+version = "0.2.7"
 source = "sparse+https://kinlab.ai/registry/cargo/"
-checksum = "3e7a5367844e9688a9b86254f878b86e8ca16f1a640669e14d226634318dca11"
+checksum = "42f0bb9b81de21d2bb50d4eb8e234115c35f5769b8465e1699dd4bd395ac7830"
 dependencies = [
  "bincode",
  "bytes",
@@ -3135,9 +3137,9 @@ dependencies = [
 
 [[package]]
 name = "kin-infer"
-version = "0.2.0"
+version = "0.2.2"
 source = "sparse+https://kinlab.ai/registry/cargo/"
-checksum = "55723a3b66a0c8c530129dbfaa6a0d45c5c1247d539d37447fc767c1feb5f72f"
+checksum = "d1388f2de69b783d6cddf92842c5914bc1855aa23770decf81c05823a57756db"
 dependencies = [
  "block",
  "half",
@@ -6329,7 +6331,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -143,5 +143,5 @@ kin-lsp = { version = "0.2.0", registry = "kin" }
 # backend on every target (incl. Linux, where it cannot compile). Metal is re-enabled
 # additively on macOS via a `[target.'cfg(target_os = "macos")'.dependencies]` block in the
 # binary/runtime crates (kin-cli, kin-daemon). Feature unification makes that additive.
-kin-db = { version = "0.2.6", registry = "kin", default-features = false, features = ["vector", "embeddings"] }
+kin-db = { version = "0.2.7", registry = "kin", default-features = false, features = ["vector", "embeddings"] }
 kin-vfs-core = { version = "0.1.0", registry = "kin" }

--- a/crates/kin-cli/Cargo.toml
+++ b/crates/kin-cli/Cargo.toml
@@ -41,6 +41,7 @@ kin-runtime = { workspace = true }
 kin-buildinfo = { workspace = true }
 kin-mcp = { workspace = true }
 kin-db = { workspace = true }
+kin-infer = { version = ">=0.2.1", registry = "kin", default-features = false }
 kin-ranking = { workspace = true }
 kin-lsp = { workspace = true }
 kin-remote = { workspace = true }
@@ -92,3 +93,4 @@ libc = "0.2"
 # block is absent and metal is never requested, keeping the Linux build green.
 [target.'cfg(target_os = "macos")'.dependencies]
 kin-db = { workspace = true, features = ["metal"] }
+kin-infer = { version = ">=0.2.1", registry = "kin", features = ["metal"] }

--- a/crates/kin-cli/src/commands/embed.rs
+++ b/crates/kin-cli/src/commands/embed.rs
@@ -124,11 +124,17 @@ pub fn embed_pass_should_continue(result: &EmbedResult, made_progress: bool) -> 
 /// therefore decoupled from any single request's HTTP timeout — a large corpus
 /// that cannot finish inside one request still completes across several.
 pub async fn run(
-    batch_size: usize,
+    batch_size: Option<usize>,
     json: bool,
     max_seconds: Option<u64>,
     rebuild: bool,
 ) -> Result<()> {
+    let batch_size = crate::commands::resources::resolve_embed_batch_size(
+        batch_size,
+        std::env::var("KIN_RESOURCE_PROFILE").ok().as_deref(),
+        DEFAULT_BATCH_SIZE,
+        crate::commands::resources::throughput_embed_batch_size,
+    );
     let _span = tracing::info_span!(
         "kin.embed",
         batch_size = batch_size,

--- a/crates/kin-cli/src/commands/mod.rs
+++ b/crates/kin-cli/src/commands/mod.rs
@@ -60,6 +60,7 @@ pub mod release_cmd;
 pub mod remote;
 pub mod rename;
 pub mod resolve;
+pub mod resources;
 pub mod review;
 pub mod scope;
 pub mod search;

--- a/crates/kin-cli/src/commands/resources.rs
+++ b/crates/kin-cli/src/commands/resources.rs
@@ -1,0 +1,322 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Firelock, LLC
+
+use anyhow::{Context, Result};
+use kin_infer::resource::{Profile, ResourcePlan};
+use serde::{Deserialize, Serialize};
+
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+pub struct CommandResourcesRequest {
+    #[serde(default)]
+    pub json: bool,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub profile: Option<String>,
+}
+
+/// Live daemon embedding state attached to the resource plan so an inspector
+/// sees both the recommended budgets and what the running daemon is actually
+/// doing. Sourced entirely from daemon-owned state — never recomputed here.
+#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
+pub struct EmbedRuntimeState {
+    /// The background embedding worker has permanently stopped (embed-degraded).
+    pub embed_worker_failed: bool,
+    /// The embedding work mutex is currently held — an embed pass is in flight.
+    pub embedding_work_busy: bool,
+    pub embeddings_indexed: usize,
+    pub embeddings_pending: usize,
+    pub embeddings_total: usize,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct CommandResourcesResponse {
+    pub plan: ResourcePlan,
+    pub embed_runtime: EmbedRuntimeState,
+    #[serde(default)]
+    pub text: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub json: Option<String>,
+}
+
+/// The `--json` surface: the stable `kin.resource_plan.v1` plan flattened to the
+/// top level (so `schema_version` stays where every consumer expects it) with
+/// the live daemon embedding state attached alongside.
+#[derive(Serialize)]
+struct ResourcesJson<'a> {
+    #[serde(flatten)]
+    plan: &'a ResourcePlan,
+    embed_runtime: &'a EmbedRuntimeState,
+}
+
+/// Parse a CLI/request profile name. Absent input defaults to `Interactive`;
+/// an unknown name is rejected rather than silently coerced.
+pub fn parse_profile(raw: Option<&str>) -> Result<Profile, String> {
+    match raw.map(str::trim) {
+        None | Some("") => Ok(Profile::Interactive),
+        Some(name) => match name.to_ascii_lowercase().as_str() {
+            "proof" => Ok(Profile::Proof),
+            "interactive" => Ok(Profile::Interactive),
+            "throughput" => Ok(Profile::Throughput),
+            "ci" => Ok(Profile::Ci),
+            other => Err(format!(
+                "unknown resource profile `{other}` (expected proof, interactive, throughput, or ci)"
+            )),
+        },
+    }
+}
+
+fn profile_label(profile: Profile) -> &'static str {
+    match profile {
+        Profile::Proof => "proof",
+        Profile::Interactive => "interactive",
+        Profile::Throughput => "throughput",
+        Profile::Ci => "ci",
+    }
+}
+
+fn render_lines(plan: &ResourcePlan, embed: &EmbedRuntimeState) -> Vec<String> {
+    let accel = format!("{:?}", plan.accelerator.backend).to_ascii_lowercase();
+    vec![
+        format!("Profile: {}", profile_label(plan.profile)),
+        format!(
+            "Host: {} ({} logical cores, {} rayon threads, {} reserved)",
+            plan.host.arch,
+            plan.host.logical_cores,
+            plan.host.rayon_threads,
+            plan.host.reserve_logical_cores
+        ),
+        format!(
+            "Accelerator: {accel} (unified memory: {})",
+            plan.accelerator.unified_memory
+        ),
+        format!(
+            "Embedding: max_seq_len {}, max_batch_tokens {}, entities/chunk {}",
+            plan.embedding.max_seq_len,
+            plan.embedding.max_batch_tokens,
+            plan.embedding.max_entities_per_graph_chunk
+        ),
+        format!(
+            "Embed coverage: {}/{} indexed, {} pending",
+            embed.embeddings_indexed, embed.embeddings_total, embed.embeddings_pending
+        ),
+        format!(
+            "Embed worker: {}",
+            if embed.embed_worker_failed {
+                "failed (embed-degraded)"
+            } else if embed.embedding_work_busy {
+                "busy (pass in flight)"
+            } else {
+                "idle"
+            }
+        ),
+    ]
+}
+
+/// Build the inspect response from a detected plan plus live daemon embedding
+/// state. Kept free of daemon types so it is unit-testable on its own.
+pub fn build_command_resources_response(
+    plan: ResourcePlan,
+    embed_runtime: EmbedRuntimeState,
+    json: bool,
+) -> Result<CommandResourcesResponse> {
+    let text = render_lines(&plan, &embed_runtime)
+        .into_iter()
+        .map(|line| format!("{line}\n"))
+        .collect::<String>();
+    let json = if json {
+        Some(serde_json::to_string(&ResourcesJson {
+            plan: &plan,
+            embed_runtime: &embed_runtime,
+        })?)
+    } else {
+        None
+    };
+    Ok(CommandResourcesResponse {
+        plan,
+        embed_runtime,
+        text,
+        json,
+    })
+}
+
+/// Resolve an embedding batch size. An explicit override always wins; absent
+/// one, the batch is `default_batch` unless `KIN_RESOURCE_PROFILE=throughput`,
+/// in which case it follows the throughput resource plan (`throughput_batch`).
+/// `throughput_batch` is only evaluated when that profile is active, so the
+/// default and proof paths never touch resource detection.
+pub fn resolve_embed_batch_size(
+    explicit: Option<usize>,
+    resource_profile: Option<&str>,
+    default_batch: usize,
+    throughput_batch: impl FnOnce() -> usize,
+) -> usize {
+    match explicit {
+        Some(size) => size,
+        None if resource_profile.map(str::trim) == Some("throughput") => throughput_batch(),
+        None => default_batch,
+    }
+}
+
+/// The throughput-profile embedding batch (entities per graph chunk), derived
+/// from a freshly detected resource plan.
+pub fn throughput_embed_batch_size() -> usize {
+    ResourcePlan::detect(Profile::Throughput)
+        .embedding
+        .max_entities_per_graph_chunk
+}
+
+pub async fn run(json: bool, profile: Option<String>) -> Result<()> {
+    let response = run_daemon_resources(&CommandResourcesRequest { json, profile }).await?;
+    if json {
+        if let Some(json) = response.json {
+            println!("{json}");
+        }
+    } else {
+        print!("{}", response.text);
+    }
+    Ok(())
+}
+
+async fn run_daemon_resources(
+    request: &CommandResourcesRequest,
+) -> Result<CommandResourcesResponse> {
+    let layout = kin_core::KinLayout::discover(&std::env::current_dir()?).ok_or_else(|| {
+        anyhow::anyhow!(
+            "not a Kin repository (no .kin/ found)\nhint: run `kin init .` to initialize a Kin repository here"
+        )
+    })?;
+    let daemon_url = std::env::var("KIN_DAEMON_URL")
+        .ok()
+        .filter(|value| !value.trim().is_empty())
+        .map(Some)
+        .unwrap_or(crate::daemon_client::resolve_daemon_url(&layout).await?);
+    let base_url = daemon_url.ok_or_else(|| {
+        anyhow::anyhow!("Kin daemon is required for resource inspection but no daemon endpoint is available")
+    })?;
+    let client = crate::daemon_client::DaemonClient::from_base_url(base_url)?;
+    client
+        .command_resources(request)
+        .await
+        .context("daemon resources failed")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use kin_infer::resource::{AcceleratorBackend, AcceleratorInfo, HostInfo, MemoryInfo};
+
+    fn sample_plan(profile: Profile) -> ResourcePlan {
+        let host = HostInfo {
+            arch: "aarch64".to_string(),
+            logical_cores: 8,
+            physical_cores: Some(8),
+            performance_cores: None,
+            efficiency_cores: None,
+            rayon_threads: 8,
+            reserve_logical_cores: 0,
+            blas_threads: 1,
+        };
+        let accel = AcceleratorInfo {
+            backend: AcceleratorBackend::Metal,
+            device_index: 0,
+            unified_memory: true,
+            device_total_bytes: None,
+            device_available_bytes: None,
+            recommended_working_set_bytes: None,
+            max_single_buffer_bytes: None,
+            max_inflight_command_buffers: 1,
+            reserve_device_bytes: None,
+            allow_cpu_fallback: true,
+        };
+        let mem = MemoryInfo {
+            system_total_bytes: None,
+            system_available_bytes: None,
+            max_process_rss_bytes: None,
+            hot_graph_budget_bytes: None,
+        };
+        ResourcePlan::for_profile(profile, &host, &accel, &mem)
+    }
+
+    #[test]
+    fn json_response_carries_schema_version_and_embed_state() {
+        let embed = EmbedRuntimeState {
+            embed_worker_failed: true,
+            embedding_work_busy: true,
+            embeddings_indexed: 3,
+            embeddings_pending: 7,
+            embeddings_total: 10,
+        };
+        let response =
+            build_command_resources_response(sample_plan(Profile::Interactive), embed, true)
+                .unwrap();
+
+        let value: serde_json::Value =
+            serde_json::from_str(&response.json.expect("json requested")).unwrap();
+        assert_eq!(value["schema_version"], "kin.resource_plan.v1");
+        assert_eq!(value["profile"], "interactive");
+        assert_eq!(value["embed_runtime"]["embed_worker_failed"], true);
+        assert_eq!(value["embed_runtime"]["embedding_work_busy"], true);
+        assert_eq!(value["embed_runtime"]["embeddings_indexed"], 3);
+        assert_eq!(value["embed_runtime"]["embeddings_pending"], 7);
+        assert_eq!(value["embed_runtime"]["embeddings_total"], 10);
+    }
+
+    #[test]
+    fn human_text_omitted_json_when_not_requested() {
+        let response = build_command_resources_response(
+            sample_plan(Profile::Proof),
+            EmbedRuntimeState::default(),
+            false,
+        )
+        .unwrap();
+        assert!(response.json.is_none());
+        assert!(response.text.contains("Profile: proof"));
+        assert!(response.text.contains("Embed coverage:"));
+    }
+
+    #[test]
+    fn parse_profile_defaults_to_interactive() {
+        assert_eq!(parse_profile(None), Ok(Profile::Interactive));
+        assert_eq!(parse_profile(Some("")), Ok(Profile::Interactive));
+        assert_eq!(parse_profile(Some(" Throughput ")), Ok(Profile::Throughput));
+        assert_eq!(parse_profile(Some("PROOF")), Ok(Profile::Proof));
+        assert_eq!(parse_profile(Some("ci")), Ok(Profile::Ci));
+        assert!(parse_profile(Some("nonsense")).is_err());
+    }
+
+    #[test]
+    fn embed_batch_default_path_is_byte_identical() {
+        // Daemon worker default (512) and CLI default (64) are unchanged when no
+        // profile is set or the profile is anything other than throughput. The
+        // throughput closure must never run on these paths.
+        let never = || panic!("throughput batch evaluated off the throughput path");
+        assert_eq!(resolve_embed_batch_size(None, None, 512, never), 512);
+        assert_eq!(resolve_embed_batch_size(None, None, 64, never), 64);
+        assert_eq!(resolve_embed_batch_size(None, Some("proof"), 512, never), 512);
+        assert_eq!(
+            resolve_embed_batch_size(None, Some("interactive"), 64, never),
+            64
+        );
+    }
+
+    #[test]
+    fn embed_batch_throughput_uses_plan_value() {
+        assert_eq!(
+            resolve_embed_batch_size(None, Some("throughput"), 512, || 999),
+            999
+        );
+        assert_eq!(
+            resolve_embed_batch_size(None, Some(" throughput "), 64, || 256),
+            256
+        );
+    }
+
+    #[test]
+    fn embed_batch_explicit_override_always_wins() {
+        let never = || panic!("explicit override must not consult the plan");
+        assert_eq!(resolve_embed_batch_size(Some(7), None, 512, never), 7);
+        assert_eq!(
+            resolve_embed_batch_size(Some(7), Some("throughput"), 512, never),
+            7
+        );
+    }
+}

--- a/crates/kin-cli/src/commands/resources.rs
+++ b/crates/kin-cli/src/commands/resources.rs
@@ -190,7 +190,9 @@ async fn run_daemon_resources(
         .map(Some)
         .unwrap_or(crate::daemon_client::resolve_daemon_url(&layout).await?);
     let base_url = daemon_url.ok_or_else(|| {
-        anyhow::anyhow!("Kin daemon is required for resource inspection but no daemon endpoint is available")
+        anyhow::anyhow!(
+            "Kin daemon is required for resource inspection but no daemon endpoint is available"
+        )
     })?;
     let client = crate::daemon_client::DaemonClient::from_base_url(base_url)?;
     client
@@ -291,7 +293,10 @@ mod tests {
         let never = || panic!("throughput batch evaluated off the throughput path");
         assert_eq!(resolve_embed_batch_size(None, None, 512, never), 512);
         assert_eq!(resolve_embed_batch_size(None, None, 64, never), 64);
-        assert_eq!(resolve_embed_batch_size(None, Some("proof"), 512, never), 512);
+        assert_eq!(
+            resolve_embed_batch_size(None, Some("proof"), 512, never),
+            512
+        );
         assert_eq!(
             resolve_embed_batch_size(None, Some("interactive"), 64, never),
             64

--- a/crates/kin-cli/src/daemon_client.rs
+++ b/crates/kin-cli/src/daemon_client.rs
@@ -594,6 +594,29 @@ impl DaemonClient {
             .context("parse daemon command status response")?)
     }
 
+    pub async fn command_resources(
+        &self,
+        request: &crate::commands::resources::CommandResourcesRequest,
+    ) -> Result<crate::commands::resources::CommandResourcesResponse> {
+        let resp = self
+            .send(
+                self.client
+                    .post(format!("{}/commands/resources", self.base_url))
+                    .json(request),
+                "send daemon command resources request",
+            )
+            .await?;
+        if !resp.status().is_success() {
+            let status = resp.status().as_u16();
+            let body = resp.text().await.unwrap_or_default();
+            bail!("daemon command resources error (HTTP {}): {}", status, body);
+        }
+        Ok(resp
+            .json()
+            .await
+            .context("parse daemon command resources response")?)
+    }
+
     pub async fn graph_command(
         &self,
         request: &crate::commands::graph::GraphCommandRequest,

--- a/crates/kin-cli/src/main.rs
+++ b/crates/kin-cli/src/main.rs
@@ -275,9 +275,11 @@ enum Command {
     /// `--rebuild` to drop the stale index and re-embed every entity at the
     /// current model's dimension.
     Embed {
-        /// Embedding batch size (entities per inference pass).
-        #[arg(long, default_value_t = crate::commands::embed::DEFAULT_BATCH_SIZE)]
-        batch_size: usize,
+        /// Embedding batch size (entities per inference pass). Defaults to 64, or
+        /// the throughput resource plan's per-chunk budget when
+        /// KIN_RESOURCE_PROFILE=throughput is set.
+        #[arg(long)]
+        batch_size: Option<usize>,
         /// Stop after this many seconds, persist completed vectors, and leave the rest pending.
         #[arg(long, value_name = "SECONDS")]
         max_seconds: Option<u64>,
@@ -820,6 +822,24 @@ enum Command {
     HostedRelease {
         #[command(subcommand)]
         action: HostedReleaseAction,
+    },
+    /// Inspect host/accelerator/memory resources and per-profile budgets
+    Resources {
+        #[command(subcommand)]
+        action: ResourcesAction,
+    },
+}
+
+#[derive(Subcommand)]
+enum ResourcesAction {
+    /// Report the detected resource plan and live daemon embedding state
+    Inspect {
+        /// Output the stable JSON resource plan instead of a human summary
+        #[arg(long)]
+        json: bool,
+        /// Resource profile to plan for: proof, interactive, throughput, or ci
+        #[arg(long)]
+        profile: Option<String>,
     },
 }
 
@@ -1610,6 +1630,11 @@ fn main() -> Result<()> {
                         commands::status::run().await
                     }
                 }
+                Command::Resources { action } => match action {
+                    ResourcesAction::Inspect { json, profile } => {
+                        commands::resources::run(json, profile).await
+                    }
+                },
                 Command::Commit {
                     message,
                     quiet,

--- a/crates/kin-daemon/Cargo.toml
+++ b/crates/kin-daemon/Cargo.toml
@@ -26,6 +26,7 @@ firestore = ["kin-spine/firestore"]
 kin-model = { workspace = true }
 kin-core = { workspace = true }
 kin-db = { workspace = true }
+kin-infer = { version = ">=0.2.1", registry = "kin", default-features = false }
 kin-blobs = { workspace = true }
 kin-index = { workspace = true }
 kin-projection = { workspace = true }
@@ -66,6 +67,7 @@ libc = "0.2"
 # Additive via feature unification; absent on Linux so the Linux build stays green.
 [target.'cfg(target_os = "macos")'.dependencies]
 kin-db = { workspace = true, features = ["metal"] }
+kin-infer = { version = ">=0.2.1", registry = "kin", features = ["metal"] }
 
 [dev-dependencies]
 kin-git = { workspace = true }

--- a/crates/kin-daemon/src/api.rs
+++ b/crates/kin-daemon/src/api.rs
@@ -749,6 +749,7 @@ fn api_routes() -> Router<Arc<DaemonState>> {
         .route("/graph/commit", post(graph_commit))
         .route("/graph/mutations", post(graph_mutations))
         .route("/commands/status", post(command_status))
+        .route("/commands/resources", post(command_resources))
         .route("/commands/graph", post(command_graph))
         .route("/commands/overview", post(command_overview))
         .route("/commands/dead-code", post(command_dead_code))
@@ -1795,6 +1796,49 @@ async fn command_status(
         summary,
         request.json,
         Some(build),
+    )
+    .map_err(internal_error)?;
+    Ok(Json(response))
+}
+
+/// POST /commands/resources — detect the resource plan for a profile and attach
+/// live daemon embedding state. Inspect-only: never loads a model or embeds.
+async fn command_resources(
+    headers: axum::http::HeaderMap,
+    State(state): State<Arc<DaemonState>>,
+    Json(request): Json<kin_cli::commands::resources::CommandResourcesRequest>,
+) -> Result<impl IntoResponse, (StatusCode, String)> {
+    if !state
+        .is_initialized
+        .load(std::sync::atomic::Ordering::Relaxed)
+    {
+        return Err((
+            StatusCode::SERVICE_UNAVAILABLE,
+            "daemon not fully initialized".to_string(),
+        ));
+    }
+
+    let profile = kin_cli::commands::resources::parse_profile(request.profile.as_deref())
+        .map_err(|message| (StatusCode::BAD_REQUEST, message))?;
+    let plan = kin_infer::resource::ResourcePlan::detect(profile);
+
+    let session_id = extract_session_id_from_headers(&headers)?;
+    let graph = resolve_session_graph(&state, session_id.as_ref()).await;
+    let embed_status = graph.embedding_status();
+    let embed_runtime = kin_cli::commands::resources::EmbedRuntimeState {
+        embed_worker_failed: state
+            .embed_worker_failed
+            .load(std::sync::atomic::Ordering::Relaxed),
+        embedding_work_busy: state.embedding_work.try_lock().is_err(),
+        embeddings_indexed: embed_status.indexed,
+        embeddings_pending: embed_status.pending,
+        embeddings_total: embed_status.total,
+    };
+
+    let response = kin_cli::commands::resources::build_command_resources_response(
+        plan,
+        embed_runtime,
+        request.json,
     )
     .map_err(internal_error)?;
     Ok(Json(response))

--- a/crates/kin-daemon/src/bin/kin-daemon.rs
+++ b/crates/kin-daemon/src/bin/kin-daemon.rs
@@ -353,7 +353,15 @@ async fn async_main() -> i32 {
     };
 
     let embed_batch_size = match embed_batch_size_from_env() {
-        Ok(size) => size.unwrap_or_else(|| DaemonConfig::default().embed_batch_size),
+        Ok(explicit) => {
+            let resource_profile = env::var("KIN_RESOURCE_PROFILE").ok();
+            kin_cli::commands::resources::resolve_embed_batch_size(
+                explicit,
+                resource_profile.as_deref(),
+                DaemonConfig::default().embed_batch_size,
+                kin_cli::commands::resources::throughput_embed_batch_size,
+            )
+        }
         Err(error) => {
             eprintln!("kin-daemon: {error}");
             process::exit(1);


### PR DESCRIPTION
## Summary

Adds a graph-daemon-backed resource inspection surface and wires the
throughput resource profile into embedding batch sizing.

### CLI — `kin resources inspect [--json] [--profile <p>]`
Mirrors the `status` command wiring: request/response types and the
response builder live in `kin-cli`, the daemon client POSTs to the new
route, and the command prints a human summary by default or the stable
`kin.resource_plan.v1` JSON with `--json`.

### Daemon — `POST /commands/resources`
Detects the `ResourcePlan` for the requested profile (default
`interactive`) and attaches live daemon embedding state:
- `embed_worker_failed` (background worker permanently stopped),
- `embedding_work_busy` (an embed pass is holding the work lock),
- embed coverage (`indexed` / `pending` / `total`) from the resolved graph.

Inspect-only: it never loads a model or embeds.

### Embedding batch sizing (throughput profile)
Both the daemon background worker (default 512) and `kin embed` CLI
(default 64) derive their default batch from the throughput plan's
`max_entities_per_graph_chunk` **only** when `KIN_RESOURCE_PROFILE=throughput`
and no explicit override is set. The default and proof paths are
byte-identical to today; an explicit `KIN_DAEMON_EMBED_BATCH_SIZE` or
`--batch-size` always wins. Locate/search and the proof path are untouched.

## Tests
`cargo build -p kin-cli -p kin-daemon` (macOS metal features) passes.
New unit tests in `kin-cli` cover the response builder (asserts
`schema_version == "kin.resource_plan.v1"` plus the attached embed-state
fields), profile parsing, and the batch selector (512/64 default,
plan value under throughput, explicit override wins). Existing `embed`
tests still pass.

## Dependency note
`kin-cli` and `kin-daemon` now depend on `kin-infer` (registry `kin`,
`>=0.2.1`) for `kin_infer::resource::ResourcePlan`. The `resource`
module ships in `kin-infer` 0.2.2; that version must be published to the
`kin` registry before CI can resolve and build this branch, and
`Cargo.lock` should be regenerated against it (intentionally not touched
here to avoid pinning a local path).