### PR TITLE
perf(index,migrate): parallelize cross-file linker and batch migrate upserts

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1788,7 +1788,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "19753d40da53d0ec41604750eeb969097a90fb2d7f7992730d904541c04e2c19"
 dependencies = [
  "bstr",
- "hashbrown 0.17.1",
+ "hashbrown 0.16.1",
 ]
 
 [[package]]
@@ -2892,8 +2892,6 @@ dependencies = [
 [[package]]
 name = "kin-blobs"
 version = "0.1.0"
-source = "sparse+https://kinlab.ai/registry/cargo/"
-checksum = "44903add90c5bdc9cd68dabe4babc846729caa795b4d50c9c3a138d560646216"
 dependencies = [
  "hex",
  "schemars",
@@ -3059,9 +3057,7 @@ dependencies = [
 
 [[package]]
 name = "kin-db"
-version = "0.2.7"
-source = "sparse+https://kinlab.ai/registry/cargo/"
-checksum = "42f0bb9b81de21d2bb50d4eb8e234115c35f5769b8465e1699dd4bd395ac7830"
+version = "0.2.8"
 dependencies = [
  "bincode",
  "bytes",
@@ -3138,9 +3134,7 @@ dependencies = [
 
 [[package]]
 name = "kin-infer"
-version = "0.2.2"
-source = "sparse+https://kinlab.ai/registry/cargo/"
-checksum = "d1388f2de69b783d6cddf92842c5914bc1855aa23770decf81c05823a57756db"
+version = "0.2.3"
 dependencies = [
  "block",
  "half",
@@ -3254,8 +3248,6 @@ dependencies = [
 [[package]]
 name = "kin-model"
 version = "0.2.0"
-source = "sparse+https://kinlab.ai/registry/cargo/"
-checksum = "e941e72effaa65527d22cc60b391a936629d01215ff4fecdc3838e8378457c1d"
 dependencies = [
  "chrono",
  "hex",
@@ -3419,8 +3411,6 @@ dependencies = [
 [[package]]
 name = "kin-search"
 version = "0.1.0"
-source = "sparse+https://kinlab.ai/registry/cargo/"
-checksum = "7b22b97ae1e3891601574147d39c51e4bb2063041ee6c97c8051623f9943332d"
 dependencies = [
  "bincode",
  "parking_lot",
@@ -3466,8 +3456,6 @@ dependencies = [
 [[package]]
 name = "kin-vector"
 version = "0.1.0"
-source = "sparse+https://kinlab.ai/registry/cargo/"
-checksum = "2191212c42d82b8b594c1a7768ee67665b4ada7ce2ef449757ce563ee6519881"
 dependencies = [
  "fs2",
  "hashbrown 0.15.5",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2892,6 +2892,8 @@ dependencies = [
 [[package]]
 name = "kin-blobs"
 version = "0.1.0"
+source = "sparse+https://kinlab.ai/registry/cargo/"
+checksum = "44903add90c5bdc9cd68dabe4babc846729caa795b4d50c9c3a138d560646216"
 dependencies = [
  "hex",
  "schemars",
@@ -3058,6 +3060,8 @@ dependencies = [
 [[package]]
 name = "kin-db"
 version = "0.2.8"
+source = "sparse+https://kinlab.ai/registry/cargo/"
+checksum = "2b4d7107f77f05d4a2f15863c861f9286785023dc300585e12d63c746e93eb00"
 dependencies = [
  "bincode",
  "bytes",
@@ -3135,6 +3139,8 @@ dependencies = [
 [[package]]
 name = "kin-infer"
 version = "0.2.3"
+source = "sparse+https://kinlab.ai/registry/cargo/"
+checksum = "f4dd1a8f2e9853919eb15eb4442c2d2a91c380735cbfa43ff8236884a5cfd99b"
 dependencies = [
  "block",
  "half",
@@ -3248,6 +3254,8 @@ dependencies = [
 [[package]]
 name = "kin-model"
 version = "0.2.0"
+source = "sparse+https://kinlab.ai/registry/cargo/"
+checksum = "e941e72effaa65527d22cc60b391a936629d01215ff4fecdc3838e8378457c1d"
 dependencies = [
  "chrono",
  "hex",
@@ -3411,6 +3419,8 @@ dependencies = [
 [[package]]
 name = "kin-search"
 version = "0.1.0"
+source = "sparse+https://kinlab.ai/registry/cargo/"
+checksum = "7b22b97ae1e3891601574147d39c51e4bb2063041ee6c97c8051623f9943332d"
 dependencies = [
  "bincode",
  "parking_lot",
@@ -3456,6 +3466,8 @@ dependencies = [
 [[package]]
 name = "kin-vector"
 version = "0.1.0"
+source = "sparse+https://kinlab.ai/registry/cargo/"
+checksum = "2191212c42d82b8b594c1a7768ee67665b4ada7ce2ef449757ce563ee6519881"
 dependencies = [
  "fs2",
  "hashbrown 0.15.5",
@@ -6322,7 +6334,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.48.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3127,6 +3127,7 @@ dependencies = [
  "kin-projection",
  "notify",
  "pretty_assertions",
+ "rayon",
  "sha2",
  "tempfile",
  "thiserror 2.0.18",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -143,5 +143,10 @@ kin-lsp = { version = "0.2.0", registry = "kin" }
 # backend on every target (incl. Linux, where it cannot compile). Metal is re-enabled
 # additively on macOS via a `[target.'cfg(target_os = "macos")'.dependencies]` block in the
 # binary/runtime crates (kin-cli, kin-daemon). Feature unification makes that additive.
-kin-db = { version = "0.2.7", registry = "kin", default-features = false, features = ["vector", "embeddings"] }
+kin-db = { version = "0.2.8", registry = "kin", default-features = false, features = ["vector", "embeddings"] }
 kin-vfs-core = { version = "0.1.0", registry = "kin" }
+
+[profile.release]
+opt-level = 3
+lto = "fat"
+codegen-units = 1

--- a/crates/kin-index/Cargo.toml
+++ b/crates/kin-index/Cargo.toml
@@ -16,6 +16,7 @@ kin-projection = { workspace = true }
 tree-sitter = { workspace = true }
 kin-db = { workspace = true }
 notify = { workspace = true }
+rayon = { workspace = true }
 thiserror = { workspace = true }
 tracing = { workspace = true }
 sha2 = { workspace = true }

--- a/crates/kin-index/src/linker.rs
+++ b/crates/kin-index/src/linker.rs
@@ -564,8 +564,10 @@ fn link_cross_file_against_entities_serial(
     universe_entities: &[Entity],
 ) -> Vec<Relation> {
     let ctx = build_link_context(files, universe_entities);
-    let per_file_relations: Vec<Vec<Relation>> =
-        files.iter().map(|file| resolve_one_file(file, &ctx)).collect();
+    let per_file_relations: Vec<Vec<Relation>> = files
+        .iter()
+        .map(|file| resolve_one_file(file, &ctx))
+        .collect();
     merge_resolved(per_file_relations, files, &ctx)
 }
 
@@ -1841,7 +1843,10 @@ mod tests {
             // Same-file resolution.
             FileParseData {
                 file_path: "src/a.ts".to_string(),
-                entities: vec![make_entity("funcA", "src/a.ts"), make_entity("helperA", "src/a.ts")],
+                entities: vec![
+                    make_entity("funcA", "src/a.ts"),
+                    make_entity("helperA", "src/a.ts"),
+                ],
                 relations: vec![calls("funcA", "helperA")],
                 imports: vec![],
             },

--- a/crates/kin-index/src/linker.rs
+++ b/crates/kin-index/src/linker.rs
@@ -3,7 +3,9 @@
 
 use std::collections::{HashMap, HashSet};
 use std::path::{Path, PathBuf};
+use std::sync::atomic::{AtomicUsize, Ordering};
 
+use rayon::prelude::*;
 use tracing::debug;
 
 use sha2::{Digest, Sha256};
@@ -153,6 +155,76 @@ pub fn link_cross_file_against_entities(
         universe_entities = universe_entities.len()
     )
     .entered();
+
+    let ctx = build_link_context(files, universe_entities);
+
+    let total_files = files.len();
+    let progress_interval = std::cmp::max(total_files / 50, 1);
+    let link_start = std::time::Instant::now();
+
+    // Resolve each file independently: every relation's source entity is owned
+    // by its own file, so the (src, dst, kind) triples produced by different
+    // files never collide. Per-file resolution carries its own dedup state and
+    // is therefore order-independent; results are collected in input-file order
+    // (`par_iter().collect()` preserves order) and merged serially below so the
+    // materialized relation set and ordering are identical to a serial pass.
+    let per_file_relations: Vec<Vec<Relation>> = {
+        let _span = tracing::info_span!(
+            "kin.index.link_cross_file.resolve_relations",
+            files = files.len()
+        )
+        .entered();
+        let completed = AtomicUsize::new(0);
+        let found = AtomicUsize::new(0);
+        files
+            .par_iter()
+            .map(|file| {
+                let relations = resolve_one_file(file, &ctx);
+                if total_files > 50 {
+                    let done = completed.fetch_add(1, Ordering::Relaxed) + 1;
+                    let total =
+                        found.fetch_add(relations.len(), Ordering::Relaxed) + relations.len();
+                    if done % progress_interval == 0 || done == total_files {
+                        eprint!(
+                            "\r  Linking: [{}/{}] {}% | {} relations | {:.1}s",
+                            done,
+                            total_files,
+                            (done * 100) / total_files,
+                            total,
+                            link_start.elapsed().as_secs_f64()
+                        );
+                    }
+                }
+                relations
+            })
+            .collect()
+    };
+
+    let resolved = merge_resolved(per_file_relations, files, &ctx);
+
+    if total_files > 0 {
+        eprintln!(); // newline after \r progress
+    }
+    debug!(resolved = resolved.len(), "cross-file linking complete");
+    resolved
+}
+
+/// Read-only indices shared across per-file relation resolution.
+struct LinkContext<'a> {
+    sorted_universe: Vec<&'a Entity>,
+    entity_by_file_name: HashMap<(&'a str, &'a str), EntityId>,
+    entity_by_name: HashMap<&'a str, Vec<(&'a str, EntityId)>>,
+    entity_by_bare_name: HashMap<&'a str, Vec<(&'a str, EntityId)>>,
+    entity_kind_by_id: HashMap<EntityId, EntityKind>,
+    known_files: HashSet<&'a str>,
+    import_map: HashMap<&'a str, HashMap<&'a str, (&'a str, &'a str)>>,
+    include_graph: HashMap<String, Vec<String>>,
+}
+
+fn build_link_context<'a>(
+    files: &'a [FileParseData],
+    universe_entities: &'a [Entity],
+) -> LinkContext<'a> {
     // Sort for deterministic relation materialization.
     let sorted_universe: Vec<&Entity> = {
         let mut sorted: Vec<&Entity> = universe_entities.iter().collect();
@@ -237,207 +309,220 @@ pub fn link_cross_file_against_entities(
         import_map
     };
 
-    let mut resolved = Vec::new();
-    let mut seen: HashSet<(EntityId, EntityId, RelationKind)> = HashSet::new();
-    let mut seen_artifact: HashSet<(GraphNodeId, GraphNodeId, RelationKind)> = HashSet::new();
     let include_graph = build_include_graph(files, &known_files);
 
-    let total_files = files.len();
-    let progress_interval = std::cmp::max(total_files / 50, 1);
-    let link_start = std::time::Instant::now();
+    LinkContext {
+        sorted_universe,
+        entity_by_file_name,
+        entity_by_name,
+        entity_by_bare_name,
+        entity_kind_by_id,
+        known_files,
+        import_map,
+        include_graph,
+    }
+}
 
-    {
-        let _span = tracing::info_span!(
-            "kin.index.link_cross_file.resolve_relations",
-            files = files.len()
-        )
-        .entered();
-        for (file_idx, file) in files.iter().enumerate() {
-            if total_files > 50
-                && (file_idx % progress_interval == 0 || file_idx + 1 == total_files)
-            {
-                eprint!(
-                    "\r  Linking: [{}/{}] {}% | {} relations | {:.1}s",
-                    file_idx + 1,
-                    total_files,
-                    ((file_idx + 1) * 100) / total_files,
-                    resolved.len(),
-                    link_start.elapsed().as_secs_f64()
+/// Resolve the name-based relations of a single file into entity-ID relations.
+///
+/// All reads are against the shared read-only [`LinkContext`]; the only mutable
+/// state is a file-local dedup set, so this is pure with respect to other files.
+fn resolve_one_file(file: &FileParseData, ctx: &LinkContext<'_>) -> Vec<Relation> {
+    let mut resolved = Vec::new();
+    let mut seen: HashSet<(EntityId, EntityId, RelationKind)> = HashSet::new();
+
+    for rel in &file.relations {
+        let src_id = ctx
+            .entity_by_file_name
+            .get(&(file.file_path.as_str(), rel.src_name.as_str()));
+        let dst_same_file = ctx
+            .entity_by_file_name
+            .get(&(file.file_path.as_str(), rel.dst_name.as_str()));
+
+        let src_id = match src_id {
+            Some(id) => *id,
+            None => {
+                debug!(
+                    src = %rel.src_name,
+                    dst = %rel.dst_name,
+                    file = %file.file_path,
+                    "linker: src entity not found, skipping"
                 );
+                continue;
             }
-            for rel in &file.relations {
-                let src_id =
-                    entity_by_file_name.get(&(file.file_path.as_str(), rel.src_name.as_str()));
-                let dst_same_file =
-                    entity_by_file_name.get(&(file.file_path.as_str(), rel.dst_name.as_str()));
+        };
 
-                let src_id = match src_id {
-                    Some(id) => *id,
-                    None => {
-                        debug!(
-                            src = %rel.src_name,
-                            dst = %rel.dst_name,
-                            file = %file.file_path,
-                            "linker: src entity not found, skipping"
-                        );
-                        continue;
-                    }
-                };
-
-                if rel.kind == RelationKind::UsesMacro {
-                    if let Some(&dst_id) = dst_same_file {
-                        if entity_kind_by_id.get(&dst_id) == Some(&EntityKind::Macro) {
-                            if add_deduped(&mut seen, src_id, dst_id, rel.kind) {
-                                resolved.push(make_relation(rel.kind, src_id, dst_id, 1.0));
-                            }
-                            continue;
-                        }
-                    }
-
-                    if let Some(dst_id) = resolve_reachable_macro_target(
-                        &file.file_path,
-                        &rel.dst_name,
-                        &include_graph,
-                        &entity_by_file_name,
-                        &entity_kind_by_id,
-                    ) {
-                        if add_deduped(&mut seen, src_id, dst_id, rel.kind) {
-                            resolved.push(make_relation(rel.kind, src_id, dst_id, 0.95));
-                        }
-                        continue;
-                    }
-
-                    debug!(
-                        src = %rel.src_name,
-                        dst = %rel.dst_name,
-                        file = %file.file_path,
-                        "linker: macro use unresolved through same-file/include closure"
-                    );
-                    continue;
-                }
-
-                // (a) Same-file resolution
-                if let Some(&dst_id) = dst_same_file {
+        if rel.kind == RelationKind::UsesMacro {
+            if let Some(&dst_id) = dst_same_file {
+                if ctx.entity_kind_by_id.get(&dst_id) == Some(&EntityKind::Macro) {
                     if add_deduped(&mut seen, src_id, dst_id, rel.kind) {
                         resolved.push(make_relation(rel.kind, src_id, dst_id, 1.0));
                     }
                     continue;
                 }
+            }
 
-                // (b) Import-based cross-file resolution
-                if let Some(file_imports) = import_map.get(file.file_path.as_str()) {
-                    if let Some(&(module_path, original_name)) =
-                        file_imports.get(rel.dst_name.as_str())
-                    {
-                        if let Some(target_file) =
-                            resolve_module_path(&file.file_path, module_path, &known_files)
-                        {
-                            let direct = entity_by_file_name
-                                .get(&(target_file.as_str(), original_name))
-                                .copied();
-                            let dst_id = if direct.is_some() {
-                                direct
-                            } else if original_name == "default" {
-                                // Default import: fall back to first entity in target file
-                                resolve_default_export(&target_file, &sorted_universe)
-                            } else {
-                                None
-                            };
-                            if let Some(dst_id) = dst_id {
-                                if add_deduped(&mut seen, src_id, dst_id, rel.kind) {
-                                    resolved.push(make_relation(rel.kind, src_id, dst_id, 0.95));
-                                }
-                                continue;
-                            }
-                        }
-                    }
-
-                    // (b2) Namespace/package import member resolution:
-                    //   JS/TS: `util.finalizeIssue` via `import * as util from "./util"`
-                    //   Go:    `create.NewCmdCreate` via `import "github.com/.../create"`
-                    if let Some((import_name, member_name)) =
-                        split_member_access(rel.dst_name.as_str())
-                    {
-                        if let Some(&(module_path, _original_name)) = file_imports.get(import_name)
-                        {
-                            // Try resolving module path and looking up the member
-                            if let Some(target_file) =
-                                resolve_module_path(&file.file_path, module_path, &known_files)
-                            {
-                                if let Some(&dst_id) =
-                                    entity_by_file_name.get(&(target_file.as_str(), member_name))
-                                {
-                                    if add_deduped(&mut seen, src_id, dst_id, rel.kind) {
-                                        resolved.push(make_relation(rel.kind, src_id, dst_id, 0.9));
-                                    }
-                                    continue;
-                                }
-                            }
-                        }
-                    }
+            if let Some(dst_id) = resolve_reachable_macro_target(
+                &file.file_path,
+                &rel.dst_name,
+                &ctx.include_graph,
+                &ctx.entity_by_file_name,
+                &ctx.entity_kind_by_id,
+            ) {
+                if add_deduped(&mut seen, src_id, dst_id, rel.kind) {
+                    resolved.push(make_relation(rel.kind, src_id, dst_id, 0.95));
                 }
+                continue;
+            }
 
-                // (c) Global name-match fallback
-                let exact_candidates = entity_by_name
-                    .get(rel.dst_name.as_str())
-                    .map(|v| v.as_slice())
-                    .unwrap_or(&[]);
+            debug!(
+                src = %rel.src_name,
+                dst = %rel.dst_name,
+                file = %file.file_path,
+                "linker: macro use unresolved through same-file/include closure"
+            );
+            continue;
+        }
 
-                let bare_candidates = if rel.kind == RelationKind::Calls {
-                    entity_by_bare_name
-                        .get(rel.dst_name.as_str())
-                        .map(|v| v.as_slice())
-                        .unwrap_or(&[])
-                } else {
-                    &[]
-                };
+        // (a) Same-file resolution
+        if let Some(&dst_id) = dst_same_file {
+            if add_deduped(&mut seen, src_id, dst_id, rel.kind) {
+                resolved.push(make_relation(rel.kind, src_id, dst_id, 1.0));
+            }
+            continue;
+        }
 
-                let mut linked = false;
-
-                // Pick the first exact candidate from a different file
-                if let Some(&(_, dst_id)) = exact_candidates
-                    .iter()
-                    .find(|(fp, _)| *fp != file.file_path.as_str())
+        // (b) Import-based cross-file resolution
+        if let Some(file_imports) = ctx.import_map.get(file.file_path.as_str()) {
+            if let Some(&(module_path, original_name)) = file_imports.get(rel.dst_name.as_str()) {
+                if let Some(target_file) =
+                    resolve_module_path(&file.file_path, module_path, &ctx.known_files)
                 {
-                    if add_deduped(&mut seen, src_id, dst_id, rel.kind) {
-                        resolved.push(make_relation(rel.kind, src_id, dst_id, 0.7));
-                        linked = true;
-                    }
-                }
-
-                // (c2) Receiver-method calls (`x.method()`) arrive as the bare method
-                // name and never match (b)'s `Type::method` key. Resolve them through
-                // the bare-name index only when unambiguous — exactly one method of
-                // that name in another file. Ambiguous names (`new`, `run`, `get`) have
-                // an unknowable receiver type, so linking every candidate would mint
-                // spurious callers; leave those to the inconclusive-absence gate.
-                if !linked && !bare_candidates.is_empty() {
-                    let mut distinct_targets: HashSet<EntityId> = HashSet::new();
-                    for &(fp, dst_id) in bare_candidates {
-                        if fp != file.file_path.as_str() {
-                            distinct_targets.insert(dst_id);
-                        }
-                    }
-                    if distinct_targets.len() == 1 {
-                        let dst_id = *distinct_targets.iter().next().expect("len checked == 1");
+                    let direct = ctx
+                        .entity_by_file_name
+                        .get(&(target_file.as_str(), original_name))
+                        .copied();
+                    let dst_id = if direct.is_some() {
+                        direct
+                    } else if original_name == "default" {
+                        // Default import: fall back to first entity in target file
+                        resolve_default_export(&target_file, &ctx.sorted_universe)
+                    } else {
+                        None
+                    };
+                    if let Some(dst_id) = dst_id {
                         if add_deduped(&mut seen, src_id, dst_id, rel.kind) {
-                            resolved.push(make_relation(rel.kind, src_id, dst_id, 0.3));
-                            linked = true;
+                            resolved.push(make_relation(rel.kind, src_id, dst_id, 0.95));
+                        }
+                        continue;
+                    }
+                }
+            }
+
+            // (b2) Namespace/package import member resolution:
+            //   JS/TS: `util.finalizeIssue` via `import * as util from "./util"`
+            //   Go:    `create.NewCmdCreate` via `import "github.com/.../create"`
+            if let Some((import_name, member_name)) = split_member_access(rel.dst_name.as_str()) {
+                if let Some(&(module_path, _original_name)) = file_imports.get(import_name) {
+                    // Try resolving module path and looking up the member
+                    if let Some(target_file) =
+                        resolve_module_path(&file.file_path, module_path, &ctx.known_files)
+                    {
+                        if let Some(&dst_id) = ctx
+                            .entity_by_file_name
+                            .get(&(target_file.as_str(), member_name))
+                        {
+                            if add_deduped(&mut seen, src_id, dst_id, rel.kind) {
+                                resolved.push(make_relation(rel.kind, src_id, dst_id, 0.9));
+                            }
+                            continue;
                         }
                     }
                 }
+            }
+        }
 
-                if linked {
-                    continue;
+        // (c) Global name-match fallback
+        let exact_candidates = ctx
+            .entity_by_name
+            .get(rel.dst_name.as_str())
+            .map(|v| v.as_slice())
+            .unwrap_or(&[]);
+
+        let bare_candidates = if rel.kind == RelationKind::Calls {
+            ctx.entity_by_bare_name
+                .get(rel.dst_name.as_str())
+                .map(|v| v.as_slice())
+                .unwrap_or(&[])
+        } else {
+            &[]
+        };
+
+        let mut linked = false;
+
+        // Pick the first exact candidate from a different file
+        if let Some(&(_, dst_id)) = exact_candidates
+            .iter()
+            .find(|(fp, _)| *fp != file.file_path.as_str())
+        {
+            if add_deduped(&mut seen, src_id, dst_id, rel.kind) {
+                resolved.push(make_relation(rel.kind, src_id, dst_id, 0.7));
+                linked = true;
+            }
+        }
+
+        // (c2) Receiver-method calls (`x.method()`) arrive as the bare method
+        // name and never match (b)'s `Type::method` key. Resolve them through
+        // the bare-name index only when unambiguous — exactly one method of
+        // that name in another file. Ambiguous names (`new`, `run`, `get`) have
+        // an unknowable receiver type, so linking every candidate would mint
+        // spurious callers; leave those to the inconclusive-absence gate.
+        if !linked && !bare_candidates.is_empty() {
+            let mut distinct_targets: HashSet<EntityId> = HashSet::new();
+            for &(fp, dst_id) in bare_candidates {
+                if fp != file.file_path.as_str() {
+                    distinct_targets.insert(dst_id);
                 }
+            }
+            if distinct_targets.len() == 1 {
+                let dst_id = *distinct_targets.iter().next().expect("len checked == 1");
+                if add_deduped(&mut seen, src_id, dst_id, rel.kind) {
+                    resolved.push(make_relation(rel.kind, src_id, dst_id, 0.3));
+                    linked = true;
+                }
+            }
+        }
 
-                debug!(
-                    src = %rel.src_name,
-                    dst = %rel.dst_name,
-                    file = %file.file_path,
-                    kind = ?rel.kind,
-                    "linker: cross-file relation unresolved"
-                );
+        if linked {
+            continue;
+        }
+
+        debug!(
+            src = %rel.src_name,
+            dst = %rel.dst_name,
+            file = %file.file_path,
+            kind = ?rel.kind,
+            "linker: cross-file relation unresolved"
+        );
+    }
+
+    resolved
+}
+
+/// Merge per-file resolved relations in input-file order, deduplicating across
+/// files (a no-op when sources are disjoint, but kept so output is identical to
+/// a single serial pass), then append artifact-level import/include edges.
+fn merge_resolved(
+    per_file_relations: Vec<Vec<Relation>>,
+    files: &[FileParseData],
+    ctx: &LinkContext<'_>,
+) -> Vec<Relation> {
+    let mut resolved = Vec::new();
+    let mut seen: HashSet<(GraphNodeId, GraphNodeId, RelationKind)> = HashSet::new();
+    for file_relations in per_file_relations {
+        for rel in file_relations {
+            if seen.insert((rel.src, rel.dst, rel.kind)) {
+                resolved.push(rel);
             }
         }
     }
@@ -447,6 +532,7 @@ pub fn link_cross_file_against_entities(
     // Import/include syntax belongs to the file/module surface. Do not anchor it
     // to an arbitrary "first entity" in the file; that makes the graph lie about
     // which symbol owns the dependency and drops files with no parsed entities.
+    let mut seen_artifact: HashSet<(GraphNodeId, GraphNodeId, RelationKind)> = HashSet::new();
     {
         let _span = tracing::info_span!(
             "kin.index.link_cross_file.build_import_edges",
@@ -455,7 +541,8 @@ pub fn link_cross_file_against_entities(
         .entered();
         for file in files {
             for imp in &file.imports {
-                if let Some(rel) = make_artifact_import_relation(&file.file_path, imp, &known_files)
+                if let Some(rel) =
+                    make_artifact_import_relation(&file.file_path, imp, &ctx.known_files)
                 {
                     let key = (rel.src, rel.dst, rel.kind);
                     if seen_artifact.insert(key) {
@@ -466,11 +553,20 @@ pub fn link_cross_file_against_entities(
         }
     }
 
-    if total_files > 0 {
-        eprintln!(); // newline after \r progress
-    }
-    debug!(resolved = resolved.len(), "cross-file linking complete");
     resolved
+}
+
+/// Serial counterpart of [`link_cross_file_against_entities`], retained as the
+/// byte-identical reference for the parallel resolution path.
+#[cfg(test)]
+fn link_cross_file_against_entities_serial(
+    files: &[FileParseData],
+    universe_entities: &[Entity],
+) -> Vec<Relation> {
+    let ctx = build_link_context(files, universe_entities);
+    let per_file_relations: Vec<Vec<Relation>> =
+        files.iter().map(|file| resolve_one_file(file, &ctx)).collect();
+    merge_resolved(per_file_relations, files, &ctx)
 }
 
 fn build_include_graph<S>(
@@ -1722,6 +1818,95 @@ mod tests {
             .expect("ambiguous global fallback should still pick one stable target");
         assert_eq!(calls.src, GraphNodeId::Entity(caller.id));
         assert_eq!(calls.dst, GraphNodeId::Entity(earlier_target.id));
+    }
+
+    #[test]
+    fn parallel_resolution_is_byte_identical_to_serial() {
+        let calls = |src: &str, dst: &str| ExtractedRelation {
+            kind: RelationKind::Calls,
+            src_name: src.to_string(),
+            dst_name: dst.to_string(),
+            import_source: None,
+        };
+        let import = |module: &str, name: &str| FileImport {
+            module_path: module.to_string(),
+            specifiers: vec![kin_parser::ImportedName {
+                local_name: name.to_string(),
+                original_name: None,
+                is_default: false,
+            }],
+        };
+
+        let mut files = vec![
+            // Same-file resolution.
+            FileParseData {
+                file_path: "src/a.ts".to_string(),
+                entities: vec![make_entity("funcA", "src/a.ts"), make_entity("helperA", "src/a.ts")],
+                relations: vec![calls("funcA", "helperA")],
+                imports: vec![],
+            },
+            // Import-based cross-file resolution + artifact import edge.
+            FileParseData {
+                file_path: "src/b.ts".to_string(),
+                entities: vec![make_entity("handler", "src/b.ts")],
+                relations: vec![calls("handler", "executeTool")],
+                imports: vec![import("./utils/tools", "executeTool")],
+            },
+            FileParseData {
+                file_path: "src/utils/tools.ts".to_string(),
+                entities: vec![make_entity("executeTool", "src/utils/tools.ts")],
+                relations: vec![],
+                imports: vec![],
+            },
+            // Ambiguous global name fallback across two files.
+            FileParseData {
+                file_path: "src/c.ts".to_string(),
+                entities: vec![make_entity("runner", "src/c.ts")],
+                relations: vec![calls("runner", "shared")],
+                imports: vec![],
+            },
+            FileParseData {
+                file_path: "src/d/shared.ts".to_string(),
+                entities: vec![make_entity("shared", "src/d/shared.ts")],
+                relations: vec![],
+                imports: vec![],
+            },
+            FileParseData {
+                file_path: "src/z/shared.ts".to_string(),
+                entities: vec![make_entity("shared", "src/z/shared.ts")],
+                relations: vec![],
+                imports: vec![],
+            },
+        ];
+
+        // Pad with self-contained files so the parallel pass spreads real work
+        // and any ordering hazard would surface.
+        for i in 0..32 {
+            let path = format!("src/pad/m{i}.ts");
+            files.push(FileParseData {
+                file_path: path.clone(),
+                entities: vec![make_entity("a", &path), make_entity("b", &path)],
+                relations: vec![calls("a", "b"), calls("b", "missing")],
+                imports: vec![],
+            });
+        }
+
+        let universe: Vec<Entity> = files
+            .iter()
+            .flat_map(|file| file.entities.iter().cloned())
+            .collect();
+
+        let parallel = link_cross_file_against_entities(&files, &universe);
+        let serial = link_cross_file_against_entities_serial(&files, &universe);
+
+        assert_eq!(
+            format!("{parallel:?}"),
+            format!("{serial:?}"),
+            "parallel linking must produce byte-identical relations to the serial path"
+        );
+        // Re-running the parallel path must also be byte-stable.
+        let parallel_again = link_cross_file_against_entities(&files, &universe);
+        assert_eq!(format!("{parallel:?}"), format!("{parallel_again:?}"));
     }
 
     #[test]

--- a/crates/kin-migrate/src/executor.rs
+++ b/crates/kin-migrate/src/executor.rs
@@ -509,30 +509,33 @@ fn persist_semantic_index<G: GraphStore>(
         index_planned_files_parallel(plan, blob_store, &workspace_root)?
     };
 
+    let mut all_entities: Vec<kin_model::Entity> = Vec::new();
+    let mut all_relations: Vec<kin_model::Relation> = Vec::new();
     for indexed in indexed_files {
-        for entity in &indexed.indexed_file.entities {
-            graph
-                .upsert_entity(entity)
-                .map_err(|e| MigrateError::Graph(e.to_string()))?;
-        }
-        for relation in &indexed.indexed_file.relations {
-            graph
-                .upsert_relation(relation)
-                .map_err(|e| MigrateError::Graph(e.to_string()))?;
-        }
+        let entity_count = indexed.indexed_file.entities.len();
+        let relation_count = indexed.indexed_file.relations.len();
+        all_entities.extend(indexed.indexed_file.entities.iter().cloned());
+        all_relations.extend(indexed.indexed_file.relations);
 
         file_parse_data.push(kin_index::linker::FileParseDataWithTests {
             file_path: indexed.indexed_file.file_id.0.clone(),
-            entities: indexed.indexed_file.entities.clone(),
+            entities: indexed.indexed_file.entities,
             relations: indexed.indexed_file.extracted_relations,
             imports: indexed.indexed_file.imports,
             tests: indexed.tests,
         });
 
         files_indexed += 1;
-        entities_extracted += indexed.indexed_file.entities.len();
-        relations_extracted += indexed.indexed_file.relations.len();
+        entities_extracted += entity_count;
+        relations_extracted += relation_count;
     }
+
+    graph
+        .upsert_entities_batch(&all_entities)
+        .map_err(|e| MigrateError::Graph(e.to_string()))?;
+    graph
+        .upsert_relations_batch(&all_relations)
+        .map_err(|e| MigrateError::Graph(e.to_string()))?;
 
     // Cross-file relation linking
     let cross_file_relations = {
@@ -541,11 +544,9 @@ fn persist_semantic_index<G: GraphStore>(
                 .entered();
         kin_index::linker::link_cross_file_with_tests(&file_parse_data)
     };
-    for rel in &cross_file_relations {
-        graph
-            .upsert_relation(rel)
-            .map_err(|e| MigrateError::Graph(e.to_string()))?;
-    }
+    graph
+        .upsert_relations_batch(&cross_file_relations)
+        .map_err(|e| MigrateError::Graph(e.to_string()))?;
     relations_extracted += cross_file_relations.len();
 
     Ok((files_indexed, entities_extracted, relations_extracted))


### PR DESCRIPTION
## What

Two deterministic CPU-saturation wins in the `kin init` / `kin migrate` conversion path, where tree-sitter parse is already parallel but downstream stages pinned a single core.

### 1. Parallelize the cross-file linker (`crates/kin-index/src/linker.rs`)
`link_cross_file_against_entities` resolved relations in a serial `for` over files. It now:
- builds the read-only lookup indices once into a shared `LinkContext`,
- resolves each file independently with `rayon` `par_iter` into a per-file `Vec<Relation>` (collected in input-file order),
- merges serially with the existing dedup so the materialized relation set **and ordering are byte-identical** to the prior serial pass.

This is safe because every relation's source entity is owned by its own file, so the `(src, dst, kind)` triples produced by different files never collide; per-file dedup state keeps each file's resolution order-independent. A new unit test (`parallel_resolution_is_byte_identical_to_serial`) asserts the parallel path matches a retained serial reference byte for byte, and the existing `cross_file_resolution_is_independent_of_universe_entity_order` guard still passes.

Runs on **both** init and migrate (the #1 conversion offender).

### 2. Batch migrate upserts (`crates/kin-migrate/src/executor.rs`)
`persist_semantic_index` upserted entities/relations one at a time (each call re-refreshing merkle/text). It now collects per-file entities/relations in the same deterministic order and calls `upsert_entities_batch` / `upsert_relations_batch` — the same batch APIs `kin init` already uses — collapsing per-call merkle/text refreshes into one. Upsert order is unchanged, so the resulting graph and merkle root are identical (batching changes lock granularity, not content).

## Determinism
- Linker output is proven byte-identical to serial (new test + existing order-independence guard).
- Migrate batching is content-preserving; persisted-migration end-to-end tests (`persisted_migration_writes_kidx`, `_creates_eject_snapshot`, `_preserves_source_default_branch`, `_materializes_distinct_target_workspace`) pass unchanged.

## Not done (noted)
The migrate convert/persist **double-parse** (`converter.rs` parses every source file to populate blobs + counts, then `persist_semantic_index` re-parses to populate the graph) was left as-is: the two passes have distinct side-effects (blob population vs graph population) and `convert()`'s `ConversionResult` count fields are a public contract, so "parse once and reuse" is a non-trivial cross-module refactor rather than a small safe change.

## Tests
- `kin-index` lib: 148 passed (incl. new byte-identical linker test)
- `kin-migrate` lib: 58 passed (incl. persisted-migration e2e)
- `kin-cli` builds clean (downstream consumer of `link_cross_file`)