### PR TITLE
perf(daemon): embed-pipeline overlap + lock GPU-saturation deps (kin-db 0.2.9 / kin-vector 0.1.3)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1019,7 +1019,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users 0.5.2",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -1118,7 +1118,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -1788,7 +1788,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "19753d40da53d0ec41604750eeb969097a90fb2d7f7992730d904541c04e2c19"
 dependencies = [
  "bstr",
- "hashbrown 0.16.1",
+ "hashbrown 0.17.1",
 ]
 
 [[package]]
@@ -3140,14 +3140,15 @@ dependencies = [
 
 [[package]]
 name = "kin-infer"
-version = "0.2.3"
+version = "0.2.7"
 source = "sparse+https://kinlab.ai/registry/cargo/"
-checksum = "f4dd1a8f2e9853919eb15eb4442c2d2a91c380735cbfa43ff8236884a5cfd99b"
+checksum = "8aae4e0fbcd059033706d983bf1e82b71d2b2410a00163d619aa4ab5b8b06d6d"
 dependencies = [
  "block",
  "half",
  "hashbrown 0.15.5",
  "libc",
+ "memmap2",
  "metal",
  "ndarray",
  "objc2",
@@ -3880,7 +3881,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -4762,7 +4763,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -5381,7 +5382,7 @@ dependencies = [
  "getrandom 0.3.4",
  "once_cell",
  "rustix",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -6356,7 +6357,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2948,6 +2948,7 @@ dependencies = [
  "kin-spine",
  "kin-vfs-core",
  "libc",
+ "mimalloc",
  "open",
  "pretty_assertions",
  "rayon",
@@ -3038,6 +3039,7 @@ dependencies = [
  "kin-registry",
  "kin-spine",
  "libc",
+ "mimalloc",
  "pretty_assertions",
  "reqwest",
  "serde",
@@ -3059,9 +3061,9 @@ dependencies = [
 
 [[package]]
 name = "kin-db"
-version = "0.2.8"
+version = "0.2.9"
 source = "sparse+https://kinlab.ai/registry/cargo/"
-checksum = "2b4d7107f77f05d4a2f15863c861f9286785023dc300585e12d63c746e93eb00"
+checksum = "192e625e97c63f2fe560853e36065d5b10f6803b944065e0a9f64b041a003722"
 dependencies = [
  "bincode",
  "bytes",
@@ -3418,12 +3420,13 @@ dependencies = [
 
 [[package]]
 name = "kin-search"
-version = "0.1.0"
+version = "0.1.1"
 source = "sparse+https://kinlab.ai/registry/cargo/"
-checksum = "7b22b97ae1e3891601574147d39c51e4bb2063041ee6c97c8051623f9943332d"
+checksum = "160bf55ac9c6851277c67b9132bc07fe5b88d1f3514aca3a42f3553881900738"
 dependencies = [
  "bincode",
  "parking_lot",
+ "rayon",
  "serde",
  "thiserror 2.0.18",
  "tracing",
@@ -3465,13 +3468,14 @@ dependencies = [
 
 [[package]]
 name = "kin-vector"
-version = "0.1.0"
+version = "0.1.3"
 source = "sparse+https://kinlab.ai/registry/cargo/"
-checksum = "2191212c42d82b8b594c1a7768ee67665b4ada7ce2ef449757ce563ee6519881"
+checksum = "c0194335bc27f7fd154e4b47e660bd5410947a23d988c0a256cdd0d0d8f65801"
 dependencies = [
  "fs2",
  "hashbrown 0.15.5",
  "parking_lot",
+ "rayon",
  "rmp-serde",
  "serde",
  "serde_json",
@@ -3541,6 +3545,15 @@ name = "libc"
 version = "0.2.186"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "68ab91017fe16c622486840e4c83c9a37afeff978bd239b5293d61ece587de66"
+
+[[package]]
+name = "libmimalloc-sys"
+version = "0.1.49"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6a45a52f43e1c16f667ccfe4dd8c85b7f7c204fd5e3bf46c5b0db9a5c3c0b8e9"
+dependencies = [
+ "cc",
+]
 
 [[package]]
 name = "libredox"
@@ -3709,6 +3722,15 @@ dependencies = [
  "log",
  "objc",
  "paste",
+]
+
+[[package]]
+name = "mimalloc"
+version = "0.1.52"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2d4139bb28d14ad1facf21d5eb8825051b326e172d216b39f6d31df53cc97862"
+dependencies = [
+ "libmimalloc-sys",
 ]
 
 [[package]]
@@ -5356,7 +5378,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
 dependencies = [
  "fastrand",
- "getrandom 0.4.2",
+ "getrandom 0.3.4",
  "once_cell",
  "rustix",
  "windows-sys 0.61.2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -150,3 +150,4 @@ kin-vfs-core = { version = "0.1.0", registry = "kin" }
 opt-level = 3
 lto = "fat"
 codegen-units = 1
+

--- a/crates/kin-cli/Cargo.toml
+++ b/crates/kin-cli/Cargo.toml
@@ -25,6 +25,7 @@ name = "kin"
 path = "src/main.rs"
 
 [dependencies]
+mimalloc = { version = "0.1", default-features = false }
 kin-model = { workspace = true }
 kin-core = { workspace = true }
 kin-blobs = { workspace = true }

--- a/crates/kin-cli/src/commands/resources.rs
+++ b/crates/kin-cli/src/commands/resources.rs
@@ -164,6 +164,14 @@ pub fn throughput_embed_batch_size() -> usize {
         .max_entities_per_graph_chunk
 }
 
+/// Whether the background embed worker should overlap a batch's persist with the
+/// next batch's prep + GPU forward. Enabled only under the throughput profile;
+/// the proof and default paths stay serial so the persisted vector order is
+/// fully deterministic.
+pub fn embed_pipeline_overlap_default(resource_profile: Option<&str>) -> bool {
+    resource_profile.map(str::trim) == Some("throughput")
+}
+
 pub async fn run(json: bool, profile: Option<String>) -> Result<()> {
     let response = run_daemon_resources(&CommandResourcesRequest { json, profile }).await?;
     if json {
@@ -323,5 +331,15 @@ mod tests {
             resolve_embed_batch_size(Some(7), Some("throughput"), 512, never),
             7
         );
+    }
+
+    #[test]
+    fn embed_pipeline_overlap_only_under_throughput() {
+        assert!(embed_pipeline_overlap_default(Some("throughput")));
+        assert!(embed_pipeline_overlap_default(Some(" throughput ")));
+        assert!(!embed_pipeline_overlap_default(None));
+        assert!(!embed_pipeline_overlap_default(Some("proof")));
+        assert!(!embed_pipeline_overlap_default(Some("interactive")));
+        assert!(!embed_pipeline_overlap_default(Some("ci")));
     }
 }

--- a/crates/kin-cli/src/main.rs
+++ b/crates/kin-cli/src/main.rs
@@ -1,6 +1,9 @@
 // SPDX-License-Identifier: Apache-2.0
 // Copyright 2026 Firelock, LLC
 
+#[global_allocator]
+static GLOBAL: mimalloc::MiMalloc = mimalloc::MiMalloc;
+
 use anyhow::Result;
 use clap::{CommandFactory, Parser, Subcommand};
 use clap_complete::{self, Shell};

--- a/crates/kin-daemon/Cargo.toml
+++ b/crates/kin-daemon/Cargo.toml
@@ -23,6 +23,7 @@ gcs = ["kin-db/gcs"]
 firestore = ["kin-spine/firestore"]
 
 [dependencies]
+mimalloc = { version = "0.1", default-features = false }
 kin-model = { workspace = true }
 kin-core = { workspace = true }
 kin-db = { workspace = true }

--- a/crates/kin-daemon/src/bin/kin-daemon.rs
+++ b/crates/kin-daemon/src/bin/kin-daemon.rs
@@ -371,6 +371,10 @@ async fn async_main() -> i32 {
         }
     };
 
+    let embed_pipeline_overlap = kin_cli::commands::resources::embed_pipeline_overlap_default(
+        env::var("KIN_RESOURCE_PROFILE").ok().as_deref(),
+    );
+
     let config = DaemonConfig {
         api_port: args.port,
         lsp_enabled: !env_flag("KIN_DAEMON_DISABLE_LSP"),
@@ -382,6 +386,7 @@ async fn async_main() -> i32 {
             }
         },
         embed_batch_size,
+        embed_pipeline_overlap,
         ..DaemonConfig::default()
     };
 

--- a/crates/kin-daemon/src/bin/kin-daemon.rs
+++ b/crates/kin-daemon/src/bin/kin-daemon.rs
@@ -3,6 +3,9 @@
 
 #[cfg(feature = "gcs")]
 use std::collections::HashSet;
+
+#[global_allocator]
+static GLOBAL: mimalloc::MiMalloc = mimalloc::MiMalloc;
 use std::env;
 use std::path::{Path, PathBuf};
 use std::process;

--- a/crates/kin-daemon/src/daemon.rs
+++ b/crates/kin-daemon/src/daemon.rs
@@ -30,6 +30,11 @@ pub struct DaemonConfig {
     /// bursts can reuse warm state without leaving background processes alive
     /// indefinitely.
     pub idle_timeout: Option<Duration>,
+    /// Overlap the background embed worker's per-batch persist with the next
+    /// batch's prep + GPU forward, so the accelerator is never idle during a
+    /// flush. Off by default: the serial path is deterministic and is what the
+    /// proof profile relies on. Enabled only under the throughput profile.
+    pub embed_pipeline_overlap: bool,
 }
 
 impl Default for DaemonConfig {
@@ -42,6 +47,7 @@ impl Default for DaemonConfig {
             embed_batch_size: 512,
             lsp_enabled: true,
             idle_timeout: None,
+            embed_pipeline_overlap: false,
         }
     }
 }
@@ -56,6 +62,26 @@ fn idle_check_interval(idle_timeout: Duration) -> Duration {
 /// pure so the no-tight-spin guarantee is unit-testable.
 fn next_embed_error_backoff(current: Option<Duration>, base: Duration, max: Duration) -> Duration {
     current.unwrap_or(base).saturating_mul(2).min(max)
+}
+
+/// Await an in-flight embed-progress flush, logging any persistence or task
+/// failure. Awaiting before the next flush is scheduled is what serializes
+/// successive flushes: at most one persist runs at a time, so two flushes can
+/// never interleave and the persisted generation cursor advances monotonically.
+/// Returns once the handle is cleared so callers can use this both to overlap a
+/// flush with the next batch's prep and to drain the tail at every loop exit.
+async fn drain_pending_flush(pending: &mut Option<tokio::task::JoinHandle<Result<usize>>>) {
+    if let Some(handle) = pending.take() {
+        match handle.await {
+            Ok(Ok(_pending)) => {}
+            Ok(Err(e)) => {
+                error!(error = %e, "failed to flush embed progress");
+            }
+            Err(e) => {
+                error!(error = %e, "embed progress flush task panicked");
+            }
+        }
+    }
 }
 
 /// Default grace the shutdown-escalation watchdog grants — once graceful
@@ -797,6 +823,7 @@ pub async fn run(mut state: DaemonState, config: DaemonConfig) -> Result<()> {
     let embed_state = Arc::clone(&state);
     let embed_interval = config.embed_interval;
     let embed_batch_size = config.embed_batch_size;
+    let embed_pipeline_overlap = config.embed_pipeline_overlap;
     let mut embed_cancel = cancel_rx.clone();
     let embed_handle = tokio::spawn(async move {
         // Wait for the daemon to finish its first reconciliation cycle
@@ -852,8 +879,16 @@ pub async fn run(mut state: DaemonState, config: DaemonConfig) -> Result<()> {
             // persistence, and cancellation stay responsive, then fall back to the
             // idle sleep once the queue is empty. Incremental trickle (a handful of
             // newly-reconciled entities) drains in a single pass and is unchanged.
+            // At most one batch's flush is in flight at a time. Under the
+            // throughput profile its flush stays here while the next batch's
+            // prep + GPU forward runs, so the accelerator is never idle during a
+            // persist; it is drained before the next flush is scheduled and at
+            // every loop exit so two flushes never interleave and the tail is
+            // always awaited.
+            let mut pending_flush: Option<tokio::task::JoinHandle<Result<usize>>> = None;
             loop {
                 if *embed_cancel.borrow() {
+                    drain_pending_flush(&mut pending_flush).await;
                     break 'wake;
                 }
                 if embed_state.background_embed_paused() {
@@ -907,6 +942,14 @@ pub async fn run(mut state: DaemonState, config: DaemonConfig) -> Result<()> {
                         index_reset_triggered = false;
                         error_backoff = None;
                         info!(count, remaining = remaining.saturating_sub(count), label);
+                        // Serialize successive flushes: the previous batch's
+                        // flush — which may still be running concurrently with
+                        // this batch's prep + GPU forward under the throughput
+                        // profile — must finish before this batch's flush starts.
+                        // This guarantees at most one persist runs at a time, so
+                        // two flushes never interleave and the persisted
+                        // generation cursor advances monotonically.
+                        drain_pending_flush(&mut pending_flush).await;
                         // Persist the vector index under the shared persist lock so
                         // this kvec write can never interleave with a snapshot save
                         // running in the persistence loop or idle-shutdown flush.
@@ -919,18 +962,16 @@ pub async fn run(mut state: DaemonState, config: DaemonConfig) -> Result<()> {
                         // re-serializes the whole ~1 GB graph each tick. The method
                         // holds the persist lock and advances the generation cursor
                         // (mirrors save_snapshot), so the two paths never tear.
-                        let persist_result = tokio::task::spawn_blocking(move || {
+                        let flush = tokio::task::spawn_blocking(move || {
                             state_for_persist.flush_embed_progress()
-                        })
-                        .await;
-                        match persist_result {
-                            Ok(Ok(_pending)) => {}
-                            Ok(Err(e)) => {
-                                error!(error = %e, "failed to flush embed progress");
-                            }
-                            Err(e) => {
-                                error!(error = %e, "embed progress flush task panicked");
-                            }
+                        });
+                        pending_flush = Some(flush);
+                        // Throughput leaves the flush in flight and loops straight
+                        // to the next batch so the GPU is fed while the persist
+                        // runs; proof/serial blocks on it now so the persisted
+                        // order is fully deterministic.
+                        if !embed_pipeline_overlap {
+                            drain_pending_flush(&mut pending_flush).await;
                         }
                     }
                     Ok(Ok(_)) => {
@@ -1005,6 +1046,7 @@ pub async fn run(mut state: DaemonState, config: DaemonConfig) -> Result<()> {
                                 consecutive_panics,
                                 "embedding worker permanently failed — vector index will not update until daemon restart; daemon continues in embed-degraded mode (see /health embed_worker_failed)"
                             );
+                            drain_pending_flush(&mut pending_flush).await;
                             break 'wake;
                         }
                         error!(
@@ -1024,6 +1066,7 @@ pub async fn run(mut state: DaemonState, config: DaemonConfig) -> Result<()> {
                 // signal) is left for the bounded teardown to handle.
                 if *embed_cancel.borrow() {
                     info!("embedding worker stopping mid-drain on shutdown");
+                    drain_pending_flush(&mut pending_flush).await;
                     break 'wake;
                 }
 
@@ -1034,6 +1077,11 @@ pub async fn run(mut state: DaemonState, config: DaemonConfig) -> Result<()> {
                 tokio::task::yield_now().await;
                 tokio::time::sleep(Duration::from_millis(25)).await;
             }
+            // Drain the tail flush at every drain-loop exit (pause, queue empty,
+            // transient error, or panic respawn) so a persist started under the
+            // throughput profile is always awaited before the worker idles or
+            // re-enters the next wake — no flush outlives the loop unobserved.
+            drain_pending_flush(&mut pending_flush).await;
         }
     });
 
@@ -1856,9 +1904,12 @@ async fn select_with_signals(
 #[cfg(all(test, unix))]
 mod tests {
     use super::{
-        next_embed_error_backoff, parse_duration_secs, should_flush_now, watched_process_is_alive,
-        DaemonConfig, DEFAULT_RUNTIME_SHUTDOWN_GRACE, DEFAULT_SHUTDOWN_ESCALATION_GRACE,
+        drain_pending_flush, next_embed_error_backoff, parse_duration_secs, should_flush_now,
+        watched_process_is_alive, DaemonConfig, DEFAULT_RUNTIME_SHUTDOWN_GRACE,
+        DEFAULT_SHUTDOWN_ESCALATION_GRACE,
     };
+    use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
+    use std::sync::Arc;
     use std::time::Duration;
 
     #[test]
@@ -1999,5 +2050,93 @@ mod tests {
         let pid = child.id() as i32;
         child.wait().expect("reap child");
         assert!(!watched_process_is_alive(pid));
+    }
+
+    #[test]
+    fn pipeline_overlap_off_by_default() {
+        // The deterministic serial persist path is the default; only the
+        // throughput profile opts into overlap (wired in the daemon binary).
+        assert!(!DaemonConfig::default().embed_pipeline_overlap);
+    }
+
+    // The embed worker keeps at most one flush in flight and always awaits it
+    // before scheduling the next. Modeling that bookkeeping with the real
+    // `drain_pending_flush` helper proves two flushes can never run at once,
+    // regardless of how long any single persist takes — the stable persisted
+    // vector order depends on flushes never interleaving.
+    #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+    async fn pipelined_flushes_never_interleave() {
+        let concurrent = Arc::new(AtomicUsize::new(0));
+        let peak = Arc::new(AtomicUsize::new(0));
+        let completed = Arc::new(AtomicUsize::new(0));
+
+        let mut pending: Option<tokio::task::JoinHandle<super::Result<usize>>> = None;
+        const BATCHES: usize = 8;
+        for _ in 0..BATCHES {
+            // Serialize the previous flush before scheduling the next, exactly as
+            // the drain loop does between successful batches.
+            drain_pending_flush(&mut pending).await;
+            let concurrent = Arc::clone(&concurrent);
+            let peak = Arc::clone(&peak);
+            let completed = Arc::clone(&completed);
+            pending = Some(tokio::task::spawn_blocking(move || {
+                let now = concurrent.fetch_add(1, Ordering::SeqCst) + 1;
+                peak.fetch_max(now, Ordering::SeqCst);
+                std::thread::sleep(Duration::from_millis(5));
+                concurrent.fetch_sub(1, Ordering::SeqCst);
+                completed.fetch_add(1, Ordering::SeqCst);
+                Ok(0)
+            }));
+        }
+        // The tail flush must always be drained at loop exit.
+        drain_pending_flush(&mut pending).await;
+
+        assert!(pending.is_none(), "tail flush must be cleared on drain");
+        assert_eq!(completed.load(Ordering::SeqCst), BATCHES, "every flush ran");
+        assert_eq!(
+            peak.load(Ordering::SeqCst),
+            1,
+            "at most one flush may run at a time"
+        );
+    }
+
+    // The point of the lever: when a flush is left in flight (throughput
+    // profile), the next batch's prep + GPU forward proceeds concurrently
+    // instead of blocking on the persist. The flush parks until the "next
+    // batch" signals it has started; if the loop had instead drained the flush
+    // before running the next batch, this would deadlock — the timeout guards
+    // against that regression.
+    #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+    async fn in_flight_flush_overlaps_next_batch() {
+        let flush_started = Arc::new(AtomicBool::new(false));
+        let next_batch_started = Arc::new(AtomicBool::new(false));
+
+        let flush_started_w = Arc::clone(&flush_started);
+        let next_batch_started_r = Arc::clone(&next_batch_started);
+        let mut pending: Option<tokio::task::JoinHandle<super::Result<usize>>> =
+            Some(tokio::task::spawn_blocking(move || {
+                flush_started_w.store(true, Ordering::SeqCst);
+                // Hold the "persist" open until the next batch is underway.
+                while !next_batch_started_r.load(Ordering::SeqCst) {
+                    std::thread::sleep(Duration::from_millis(1));
+                }
+                Ok(0)
+            }));
+
+        // The next batch runs WITHOUT first draining the in-flight flush.
+        let overlap = tokio::time::timeout(Duration::from_secs(5), async {
+            while !flush_started.load(Ordering::SeqCst) {
+                tokio::time::sleep(Duration::from_millis(1)).await;
+            }
+            next_batch_started.store(true, Ordering::SeqCst);
+        })
+        .await;
+        assert!(
+            overlap.is_ok(),
+            "next batch must make progress while a flush is in flight"
+        );
+
+        drain_pending_flush(&mut pending).await;
+        assert!(pending.is_none());
     }
 }


### PR DESCRIPTION
Lands the daemon embed-pipeline overlap and picks up the published GPU-saturation release deps.

- **Overlap** each embed batch's persist with the next batch's GPU forward (daemon embed throughput).
- **Lock** kin-db 0.2.9 (adaptive GPU/CPU-twin embed split + batched upsert + deferred canon), kin-vector 0.1.3 (parallel HNSW insert), kin-search 0.1.1. Registry-clean lock.

The default embed now rides to GPU-heavy with no manual tuning (~2x the old fixed-ratio default on the bench corpus; GPU 73-89% utilized during embed, CPU does fast parallel HNSW insert).