### PR TITLE
Extend zero-file-search guard to daemon query handlers and context pack

### DIFF
--- a/crates/kin-daemon/src/api.rs
+++ b/crates/kin-daemon/src/api.rs
@@ -2988,12 +2988,6 @@ async fn locate(
         state.graph.embedding_status().indexed,
         state.graph.compute_root_hash()
     );
-    let kvec_meta_path = state.layout.kindb_dir().join("graph.kvec.meta.json");
-    if let Ok(content) = std::fs::read_to_string(kvec_meta_path) {
-        if let Ok(json) = serde_json::from_str::<serde_json::Value>(&content) {
-            tracing::info!(">>> LOCATE: kvec hash={:?}", json.get("graph_root_hash"));
-        }
-    }
 
     let result = if let Some(reference) = req.reference.as_deref() {
         // Explicit --ref always takes precedence over session scope.

--- a/scripts/verify-zero-file-search.py
+++ b/scripts/verify-zero-file-search.py
@@ -3,20 +3,67 @@ import os
 import sys
 import json
 import re
+from datetime import date
 
 # Resolve paths relative to kin repo root
 SCRIPT_DIR = os.path.dirname(os.path.abspath(__file__))
 KIN_ROOT = os.path.dirname(SCRIPT_DIR)
 ALLOWLIST_PATH = os.path.join(SCRIPT_DIR, "zero-file-search-allowlist.json")
 
+# Every allowlist entry must carry these so each exemption has an accountable
+# owner and a date by which it is re-justified or removed.
+REQUIRED_FIELDS = ("file", "reason", "owner", "expiration")
+
+
 def load_allowlist():
+    """Load and validate the allowlist, returning the set of exempt files.
+
+    Each entry must declare file, reason, owner, and an ISO `expiration` date.
+    Missing fields, malformed dates, and past-due exemptions fail the guard so
+    exemptions cannot silently accumulate or outlive their justification.
+    """
     try:
         with open(ALLOWLIST_PATH, "r", encoding="utf-8") as f:
             data = json.load(f)
-            return {item["file"] for item in data.get("allowlist", [])}
     except Exception as e:
         print(f"Error loading allowlist from {ALLOWLIST_PATH}: {e}")
         sys.exit(1)
+
+    entries = data.get("allowlist", [])
+    errors = []
+    files = set()
+    today = date.today()
+
+    for i, item in enumerate(entries):
+        missing = [k for k in REQUIRED_FIELDS if not item.get(k)]
+        if missing:
+            errors.append(
+                f"  entry #{i} ({item.get('file', '?')}) missing required "
+                f"field(s): {', '.join(missing)}"
+            )
+            continue
+        files.add(item["file"])
+        try:
+            exp_date = date.fromisoformat(item["expiration"])
+        except ValueError:
+            errors.append(
+                f"  entry {item['file']} has invalid expiration "
+                f"'{item['expiration']}' (want YYYY-MM-DD)"
+            )
+            continue
+        if exp_date < today:
+            errors.append(
+                f"  entry {item['file']} exemption expired {item['expiration']} "
+                f"(owner: {item['owner']}) — re-justify or remove"
+            )
+
+    if errors:
+        print("Allowlist validation FAILED:")
+        print("\n".join(errors))
+        sys.exit(1)
+
+    return files
+
 
 BOUNDARY_DIRS = [
     "crates/kin-daemon/",
@@ -43,8 +90,31 @@ QUERY_COMMANDS = {
     "trace_data_flow.rs",
     "xref.rs",
     "review.rs",
-    "ref_lookup.rs"
+    "ref_lookup.rs",
+    # Context-pack assembly is an answer authority, not an IO boundary.
+    "context.rs"
 }
+
+# Query/answer authority handlers that live inside an otherwise IO-boundary
+# crate (the daemon serves package registries, persists snapshots, and writes
+# auth tokens — all legitimate boundary IO). These files are scanned
+# function-scoped: only the named handler bodies are checked, so the boundary
+# IO elsewhere in the same file is not falsely flagged, while a raw filesystem
+# read sneaking into a query answer path still fails the guard.
+DAEMON_QUERY_HANDLERS = {
+    "crates/kin-daemon/src/api.rs": {
+        "locate",
+        "search",
+        "context",
+        "trace",
+        "impact",
+        "review",
+    },
+}
+
+# Matches a (possibly `pub`/`async`) free or method function declaration.
+FN_DECL = re.compile(r"^\s*(?:pub\s+)?(?:async\s+)?fn\s+([A-Za-z0-9_]+)\s*[(<]")
+
 
 def is_test_file(rel_path):
     # Skip standalone test directories
@@ -54,14 +124,15 @@ def is_test_file(rel_path):
     for bdir in BOUNDARY_DIRS:
         if rel_path.startswith(bdir) or rel_path == bdir:
             return True
-            
+
     # For CLI commands, only scan query commands
     if "crates/kin-cli/src/commands/" in rel_path:
         filename = os.path.basename(rel_path)
         if filename not in QUERY_COMMANDS:
             return True
-            
+
     return False
+
 
 # Patterns to scan
 PATTERNS = [
@@ -71,20 +142,57 @@ PATTERNS = [
     (re.compile(r'Command::new\("git"\).*?"grep"'), "git grep subprocess usage")
 ]
 
-def scan_file(filepath, rel_path):
+
+def find_fn_body_ranges(lines, fn_names):
+    """Return inclusive 0-based line ranges for the bodies of the named
+    functions. Body bounds are tracked by brace depth from the function's
+    opening brace to its matching close."""
+    ranges = []
+    n = len(lines)
+    i = 0
+    while i < n:
+        m = FN_DECL.match(lines[i])
+        if m and m.group(1) in fn_names:
+            depth = 0
+            started = False
+            j = i
+            while j < n:
+                opens = lines[j].count("{")
+                closes = lines[j].count("}")
+                if opens > 0:
+                    started = True
+                if started:
+                    depth += opens - closes
+                    if depth <= 0:
+                        break
+                j += 1
+            ranges.append((i, j))
+            i = j + 1
+        else:
+            i += 1
+    return ranges
+
+
+def scan_file(filepath, rel_path, query_fn_names=None):
     violations = []
-    
+
     with open(filepath, "r", encoding="utf-8") as f:
         lines = f.readlines()
-        
+
+    # When scanning a mixed boundary file, restrict violations to the bodies of
+    # the designated query handlers.
+    allowed_ranges = (
+        find_fn_body_ranges(lines, query_fn_names) if query_fn_names else None
+    )
+
     in_block_comment = False
     in_test_module = False
     brace_depth = 0
     test_module_brace_depth = -1
-    
+
     for idx, line in enumerate(lines, 1):
         stripped = line.strip()
-        
+
         # Track block comments
         if "/*" in stripped:
             in_block_comment = True
@@ -92,79 +200,91 @@ def scan_file(filepath, rel_path):
             if "*/" in stripped:
                 in_block_comment = False
             continue
-            
+
         # Ignore single line comments
         if stripped.startswith("//"):
             continue
-            
+
         # Remove trailing comments
         if "//" in line:
             line = line.split("//")[0]
             stripped = line.strip()
-            
+
         # Track test module to ignore test code inside source files
         if "mod tests" in stripped or "#[cfg(test)]" in stripped:
             in_test_module = True
             test_module_brace_depth = brace_depth
-            
+
         # Track brace depth
         brace_depth += stripped.count("{") - stripped.count("}")
-        
+
         if in_test_module and brace_depth <= test_module_brace_depth:
             in_test_module = False
             test_module_brace_depth = -1
-            
+
         if in_test_module:
             continue
-            
+
         # Skip attributes like #[test]
         if stripped.startswith("#[test]"):
             continue
-            
+
+        # When function-scoped, only flag lines inside a designated handler body.
+        if allowed_ranges is not None and not any(
+            lo <= (idx - 1) <= hi for lo, hi in allowed_ranges
+        ):
+            continue
+
         # Scan for patterns
         for pattern, desc in PATTERNS:
             if pattern.search(line):
                 violations.append((idx, line.strip(), desc))
-                
+
     return violations
+
 
 def main():
     allowlist = load_allowlist()
     total_violations = 0
-    
+
     # Walk crates directory
     crates_dir = os.path.join(KIN_ROOT, "crates")
     if not os.path.exists(crates_dir):
         print(f"Error: crates directory not found at {crates_dir}")
         sys.exit(1)
-        
+
     for root, _, files in os.walk(crates_dir):
         for file in files:
             if not file.endswith(".rs"):
                 continue
-                
+
             filepath = os.path.join(root, file)
             rel_path = os.path.relpath(filepath, KIN_ROOT)
-            
-            # Skip test files and allowed files
-            if is_test_file(rel_path):
-                continue
+
+            # Allowed files are exempt regardless of where they live.
             if rel_path in allowlist:
                 continue
-                
-            violations = scan_file(filepath, rel_path)
+
+            # Query handlers inside boundary crates are scanned function-scoped;
+            # they bypass the boundary skip so their answer paths are covered.
+            query_fns = DAEMON_QUERY_HANDLERS.get(rel_path)
+            if query_fns is None and is_test_file(rel_path):
+                continue
+
+            violations = scan_file(filepath, rel_path, query_fns)
             if violations:
                 print(f"\n[VIOLATION] {rel_path} contains forbidden filesystem access:")
                 for line_num, content, desc in violations:
                     print(f"  Line {line_num:4d}: {content} ({desc})")
                 total_violations += len(violations)
-                
+
     if total_violations > 0:
         print(f"\nVerification FAILED: Found {total_violations} zero-file-search violations.")
         sys.exit(1)
-        
+
     print("Verification PASSED: Zero File-Search Invariant holds.")
     sys.exit(0)
+
 
 if __name__ == "__main__":
     main()

--- a/scripts/zero-file-search-allowlist.json
+++ b/scripts/zero-file-search-allowlist.json
@@ -2,64 +2,95 @@
   "allowlist": [
     {
       "file": "crates/kin-cli/src/commands/checkout.rs",
-      "reason": "IO Boundary: materializes file state during checkout and reads files for status/reconcile bounds"
+      "reason": "IO Boundary: materializes file state during checkout and reads files for status/reconcile bounds",
+      "owner": "kin-cli",
+      "expiration": "2026-12-31"
     },
     {
       "file": "crates/kin-cli/src/commands/commit.rs",
-      "reason": "IO Boundary: reads local workspace files to build gitignore, hashes, and commit metadata"
+      "reason": "IO Boundary: reads local workspace files to build gitignore, hashes, and commit metadata",
+      "owner": "kin-cli",
+      "expiration": "2026-12-31"
     },
     {
       "file": "crates/kin-cli/src/commands/init.rs",
-      "reason": "IO Ingestion: imports files from disk to build the initial semantic graph"
+      "reason": "IO Ingestion: imports files from disk to build the initial semantic graph",
+      "owner": "kin-cli",
+      "expiration": "2026-12-31"
     },
     {
       "file": "crates/kin-cli/src/commands/reconcile.rs",
-      "reason": "IO Boundary: writes/projects graph modifications back to filesystem"
+      "reason": "IO Boundary: writes/projects graph modifications back to filesystem",
+      "owner": "kin-cli",
+      "expiration": "2026-12-31"
     },
     {
       "file": "crates/kin-cli/src/commands/stash.rs",
-      "reason": "IO Boundary: stashes and restores uncommitted file changes"
+      "reason": "IO Boundary: stashes and restores uncommitted file changes",
+      "owner": "kin-cli",
+      "expiration": "2026-12-31"
     },
     {
       "file": "crates/kin-cli/src/commands/session_workspace.rs",
-      "reason": "IO Boundary: syncs workspace by reading and writing files"
+      "reason": "IO Boundary: syncs workspace by reading and writing files",
+      "owner": "kin-cli",
+      "expiration": "2026-12-31"
     },
     {
       "file": "crates/kin-cli/src/commands/native_sync.rs",
-      "reason": "IO Boundary: reads/writes sync files between local and remote state"
+      "reason": "IO Boundary: reads/writes sync files between local and remote state",
+      "owner": "kin-cli",
+      "expiration": "2026-12-31"
     },
     {
       "file": "crates/kin-cli/src/commands/open.rs",
-      "reason": "IO Boundary: materializes session folder and reads/writes files"
+      "reason": "IO Boundary: materializes session folder and reads/writes files",
+      "owner": "kin-cli",
+      "expiration": "2026-12-31"
     },
     {
       "file": "crates/kin-cli/src/commands/shell.rs",
-      "reason": "IO Boundary: bootstraps session shell workspace files"
+      "reason": "IO Boundary: bootstraps session shell workspace files",
+      "owner": "kin-cli",
+      "expiration": "2026-12-31"
     },
     {
       "file": "crates/kin-cli/src/commands/secret.rs",
-      "reason": "IO Boundary: reads authentication/tokens from stdin or config file"
+      "reason": "IO Boundary: reads authentication/tokens from stdin or config file",
+      "owner": "kin-cli",
+      "expiration": "2026-12-31"
     },
     {
       "file": "crates/kin-cli/src/commands/locate_debug.rs",
-      "reason": "Debug Command: reads benchmark/test inputs from disk"
+      "reason": "Debug Command: reads benchmark/test inputs from disk",
+      "owner": "kin-cli",
+      "expiration": "2026-12-31"
     },
     {
       "file": "crates/kin-cli/src/backend.rs",
-      "reason": "Direct Snapshot direct-reads (offline bootstrap fallback)"
+      "reason": "Direct Snapshot direct-reads (offline bootstrap fallback)",
+      "owner": "kin-cli",
+      "expiration": "2026-12-31"
     },
     {
       "file": "crates/kin-cli/src/capability.rs",
-      "reason": "Hardware check: reads /proc/meminfo for system stats"
+      "reason": "Hardware check: reads /proc/meminfo for system stats",
+      "owner": "kin-cli",
+      "expiration": "2026-12-31"
     },
     {
       "file": "crates/kin-mcp/src/daemon_delegate.rs",
-      "reason": "Auth: reads token from local daemon token file"
+      "reason": "Auth: reads token from local daemon token file",
+      "owner": "kin-mcp",
+      "expiration": "2026-12-31"
     },
     {
       "file": "crates/kin-core/src/text_refs.rs",
       "reason": "TRANSITIONAL: Direct filesystem read for text references. Needs migration to graph-derived source.",
-      "status": "transitional"
+      "owner": "kin-core",
+      "status": "transitional",
+      "removal_target": "Replace direct text-reference reads with graph-derived source projection.",
+      "expiration": "2026-09-30"
     }
   ]
 }


### PR DESCRIPTION
## Summary

The zero-file-search guard skipped the entire `kin-daemon` crate (a `BOUNDARY_DIR`) and the context-pack command, so the daemon's query answer paths and context-pack assembly were never checked against the Zero File-Search Authority Rule.

## Changes

**`scripts/verify-zero-file-search.py`**
- Function-scoped scanning for the daemon query handlers (`locate`, `search`, `context`, `trace`, `impact`, `review` in `api.rs`). Only those handler bodies are checked, so the daemon's legitimate boundary IO (package-registry serving, auth-token persistence, snapshot persistence) elsewhere in the same file is not falsely flagged, while a raw filesystem read in a query answer path still fails the guard.
- Added the context-pack CLI command (`context.rs`) to the query-command scan. (`kin-context/src/builder.rs`, the context-pack assembly authority, is already scanned and clean.)
- Allowlist validation: every entry must declare `file`, `reason`, `owner`, and an ISO `expiration`. Missing fields, malformed dates, and past-due exemptions now fail the guard so exemptions can't silently accumulate or outlive their justification.

**`scripts/zero-file-search-allowlist.json`**
- Added `owner` + `expiration` to every entry.
- The transitional `kin-core/src/text_refs.rs` read now carries an explicit `removal_target`, a `status: transitional`, and a nearer `expiration` (2026-09-30).

**`crates/kin-daemon/src/api.rs`**
- Removed a diagnostic raw-file read (`graph.kvec.meta.json`) from the `locate` handler that the widened scan surfaced. It only fed a `tracing::info!` debug line; the locate answer path is now free of raw filesystem reads.

## Testing

- `python3 scripts/verify-zero-file-search.py` → `Verification PASSED`.
- Pre-fix, the widened scan flagged exactly `api.rs:2992` (the kvec-meta read) and nothing else in `api.rs` — confirming function-scoping covers the query handlers without flagging boundary IO.
- Negative check: deleting `owner` from an entry → guard exits 1 with `Allowlist validation FAILED`.
- `cargo build -p kin-daemon` → clean; `cargo test -p kin-daemon --lib -- api::tests::` → 92 passed (incl. locate/search/context/trace/review endpoint tests).