### PR TITLE
Assert locate answers from graph bodies with zero source-text gaps

### DIFF
--- a/crates/kin-cli/src/commands/locate.rs
+++ b/crates/kin-cli/src/commands/locate.rs
@@ -13837,16 +13837,66 @@ mod tests {
         );
     }
 
-    // Full end-to-end assertion that a complete graph drives locate with zero
-    // recorded source-text graph gaps. Requires a live daemon/graph fixture, so
-    // it is excluded from the default suite and run in the serial daemon window.
+    // Full end-to-end assertion that a graph with complete source-body coverage
+    // drives locate with zero recorded source-text graph gaps. Every entity
+    // carries its graph-owned body (an opaque artifact with non-empty text), the
+    // shape a daemon holds for a fully indexed repo, so locate's authority path
+    // resolves all source text from graph truth and never falls back to a raw
+    // workspace disk read. `LOCATE_GRAPH_SOURCE_GAPS` is the source-body coverage
+    // signal — a nonzero value would mean the authority path hit a graph gap and
+    // would otherwise have needed disk.
     #[test]
-    #[ignore = "requires live daemon/graph fixture; run in the serial daemon window"]
+    #[serial_test::serial]
     fn locate_over_complete_graph_records_zero_source_text_gaps() {
+        let graph = kin_db::InMemoryGraph::new();
+        let entities = [
+            test_entity("parse_config", "src/config.rs", 1, 40),
+            test_entity("load_settings", "src/settings.rs", 1, 30),
+        ];
+        for entity in &entities {
+            graph.upsert_entity(entity).unwrap();
+        }
+        graph
+            .upsert_opaque_artifact(&OpaqueArtifact {
+                file_id: FilePathId::new("src/config.rs"),
+                content_hash: Hash256::from_bytes([21; 32]),
+                mime_type: Some("text/x-rust".into()),
+                text_preview: Some(
+                    "fn parse_config() reads and parses the configuration settings".into(),
+                ),
+            })
+            .unwrap();
+        graph
+            .upsert_opaque_artifact(&OpaqueArtifact {
+                file_id: FilePathId::new("src/settings.rs"),
+                content_hash: Hash256::from_bytes([22; 32]),
+                mime_type: Some("text/x-rust".into()),
+                text_preview: Some(
+                    "fn load_settings() loads settings from the parsed configuration".into(),
+                ),
+            })
+            .unwrap();
+        graph.flush_text_index().unwrap();
+
         let before = locate_graph_source_gap_count();
-        // A daemon-backed locate over a fully materialized graph must answer
-        // entirely from graph-owned bodies. Wire the live fixture here, run a
-        // representative locate, then assert no authority path fell into a gap.
+
+        // `workspace_root = None` is a scoped-session daemon locate: the
+        // workspace is off-limits, so every source-text resolution must be
+        // satisfied from graph-owned bodies or reported as a gap.
+        let result = run_with_graph_capture_in_workspace(
+            &graph,
+            None,
+            "where is parse_config defined",
+            true,
+            10,
+            true,
+        )
+        .unwrap();
+
+        assert!(
+            !result.files.is_empty(),
+            "complete-graph locate should return graph-derived results"
+        );
         assert_eq!(
             locate_graph_source_gap_count(),
             before,


### PR DESCRIPTION
## Summary

The previously deferred end-to-end assertion for the locate graph-source-gap invariant existed only as an `#[ignore]`d stub with no body. This implements it.

`locate.rs` instruments `LOCATE_GRAPH_SOURCE_GAPS`: every time the locate authority path needs source text for a path but the graph holds no body, it records a gap and reports it (instead of reading raw workspace disk). On a fully materialized graph this stays zero.

## Changes

`crates/kin-cli/src/commands/locate.rs` — `locate_over_complete_graph_records_zero_source_text_gaps`:
- Un-ignored; now builds a real fixture: two entities, each with its source body stored as a graph-owned opaque artifact (the shape a daemon holds for an indexed repo).
- Runs the daemon's locate authority entry point (`run_with_graph_capture_in_workspace`) with `workspace_root = None` (a scoped-session locate — the workspace is off-limits), using a **symbolic** query identifier so the source-text resolution loop is genuinely exercised against graph-owned bodies rather than skipped.
- Asserts the run returns graph-derived results **and** records **zero** new source-text gaps — i.e. locate's authority path performed zero disk source reads on a complete graph.

## Testing

- `cargo test -p kin-cli --lib -- commands::locate::tests::` → 181 passed, 0 failed, **0 ignored** (the stub is now live).
- Non-vacuity verified out-of-band: a throwaway probe (same path, same symbolic query, but with one body absent) recorded a gap and failed the zero assertion — confirming the harness reaches the gap site and the zero result is meaningful. The probe was removed; it is not part of this change.

## Notes

- The fixture is "complete" along the axis the gap counter measures — graph-owned **source-body** coverage. Vector/embedding completeness is a separate axis (`load_complete_test_vectors` only covers entity vectors, not the artifact docs, so it would conflict with the bodies the gap path needs); it is not required for this invariant and is omitted.
- The test lives in `kin-cli` (not a daemon integration test) because the gap counter and `locate_graph_source_gap_count()` are `#[cfg(test)]`-private to this module; `run_with_graph_capture_in_workspace` is exactly the function the daemon `/locate` handler calls, so the in-process run exercises the daemon's authority path.