### PR TITLE
Hydrate spine cache from durable store and persist edge writes

### DIFF
--- a/crates/kin-spine/src/firestore.rs
+++ b/crates/kin-spine/src/firestore.rs
@@ -1,327 +1,139 @@
 // SPDX-License-Identifier: Apache-2.0
 // Copyright 2026 Firelock, LLC
 
-//! Firestore-backed spine backend using the REST API.
+//! Store-backed spine backend.
 //!
-//! Uses `reqwest` to talk to the Firestore v1 REST API. Authentication
-//! is via the GCE metadata server (Workload Identity on GKE).
+//! [`FirestoreSpineBackend`] keeps every read on a fast in-memory cache and
+//! mirrors writes through to a durable [`SpineStore`]. On startup it hydrates
+//! the cache from the store so a freshly started (stateless) daemon pod rebuilds
+//! the full cross-repo index. The store seam is the only component that talks to
+//! an external system, which keeps the backend's hydrate and write-through logic
+//! testable against an in-memory fake.
+//!
+//! The production store is [`FirestoreStore`] (behind the `firestore` feature),
+//! which talks to the Firestore v1 REST API authenticated via the GCE metadata
+//! server (Workload Identity on GKE).
 //!
 //! Firestore collections:
 //! ```text
 //! spine_entities/{repo_id}_{entity_id}
-//!   repo_id, entity_id, name, kind, signature, fingerprint_ast,
-//!   fingerprint_sig, fingerprint_beh, file_path, root_hash, updated_at
+//!   repo_id, name, kind, signature, file_path, root_hash, payload
 //!
 //! spine_edges/{auto_id}
-//!   src_repo, src_entity, dst_repo, dst_entity, confidence
+//!   src_repo, dst_repo, confidence, payload
 //! ```
+//!
+//! `payload` carries the JSON-serialized `EntityEntry` / `CrossRepoEdge` and is
+//! the authoritative copy used to rebuild the cache; the sibling fields stay
+//! human-readable for the Firestore console and back the by-repo delete queries.
 
 use std::collections::HashSet;
 use std::sync::atomic::{AtomicBool, Ordering};
-use std::time::{Duration, Instant};
+use std::sync::Arc;
 
 use kin_model::{Entity, EntityId, EntityKind, Relation, SemanticFingerprint};
-use parking_lot::RwLock;
 use tracing::{debug, error, info, warn};
 
 use crate::backend::{InMemorySpineBackend, SpineBackend, SpineError};
 use crate::federation::FederatedImpact;
 use crate::index::{CrossRepoEdge, EntityEntry};
+use crate::store::SpineStore;
 
-/// Firestore-backed spine backend.
+/// Spine backend that reads from an in-memory cache and writes through to a
+/// durable [`SpineStore`].
 ///
-/// Strategy: write-through to Firestore, read from local in-memory cache.
-/// On startup, hydrates the local cache from Firestore. Periodic polling
-/// detects changes from other daemon pods.
-///
-/// This ensures the hot path (resolve, lookup) is always fast (in-memory),
-/// while writes propagate to Firestore for cross-pod visibility.
+/// Strategy: write-through to the store, read from the local cache. On startup,
+/// [`hydrate`](FirestoreSpineBackend::hydrate) repopulates the cache from the
+/// store. This keeps the hot path (resolve, lookup, federated impact) in memory
+/// while writes propagate to durable storage for cross-pod visibility.
 pub struct FirestoreSpineBackend {
-    /// GCP project ID (from GOOGLE_CLOUD_PROJECT env var).
-    project_id: String,
-    /// Firestore database ID (default: "(default)").
-    database_id: String,
-    /// HTTP client for Firestore REST API calls.
-    client: reqwest::Client,
     /// Local in-memory cache — all reads go here.
     cache: InMemorySpineBackend,
-    /// Whether the initial hydration from Firestore has completed.
+    /// Whether the initial hydration from the store has completed.
     hydrated: AtomicBool,
-    /// Cached access token + expiry.
-    token: RwLock<Option<(String, Instant)>>,
+    /// Durable backing store; the only seam that touches an external system.
+    store: Arc<dyn SpineStore>,
 }
 
 impl FirestoreSpineBackend {
-    /// Create a new Firestore spine backend.
+    /// Create a Firestore-backed spine backend.
     ///
-    /// `project_id`: GCP project ID
-    /// `database_id`: Firestore database (typically "(default)")
+    /// `project_id`: GCP project ID.
+    /// `database_id`: Firestore database (typically "(default)").
+    #[cfg(feature = "firestore")]
     pub fn new(project_id: String, database_id: Option<String>) -> Self {
-        let client = reqwest::Client::builder()
-            .timeout(Duration::from_secs(10))
-            .build()
-            .expect("failed to create HTTP client");
+        Self::with_store(Arc::new(FirestoreStore::new(project_id, database_id)))
+    }
 
+    /// Create a backend over an arbitrary durable store.
+    ///
+    /// This is the seam used both by the Firestore constructor and by tests that
+    /// inject an in-memory store.
+    pub fn with_store(store: Arc<dyn SpineStore>) -> Self {
         Self {
-            project_id,
-            database_id: database_id.unwrap_or_else(|| "(default)".to_string()),
-            client,
             cache: InMemorySpineBackend::new(),
             hydrated: AtomicBool::new(false),
-            token: RwLock::new(None),
+            store,
         }
     }
 
-    /// Base URL for Firestore REST API.
-    fn base_url(&self) -> String {
-        format!(
-            "https://firestore.googleapis.com/v1/projects/{}/databases/{}/documents",
-            self.project_id, self.database_id
-        )
-    }
-
-    /// Get an access token from the GCE metadata server.
-    /// Caches the token for its lifetime minus a 60-second buffer.
-    fn get_access_token(&self) -> Result<String, SpineError> {
-        // Check cached token.
-        {
-            let cached = self.token.read();
-            if let Some((ref token, ref expiry)) = *cached {
-                if Instant::now() < *expiry {
-                    return Ok(token.clone());
-                }
-            }
-        }
-
-        // Fetch new token from metadata server.
-        let rt = tokio::runtime::Handle::try_current()
-            .map_err(|e| SpineError::Auth(format!("no tokio runtime available: {e}")))?;
-
-        let client = self.client.clone();
-        let token_result = rt.block_on(async {
-            let resp = client
-                .get("http://metadata.google.internal/computeMetadata/v1/instance/service-accounts/default/token")
-                .header("Metadata-Flavor", "Google")
-                .send()
-                .await
-                .map_err(|e| SpineError::Auth(format!("metadata server request failed: {e}")))?;
-
-            if !resp.status().is_success() {
-                return Err(SpineError::Auth(format!(
-                    "metadata server returned {}",
-                    resp.status()
-                )));
-            }
-
-            let body: serde_json::Value = resp.json().await.map_err(|e| {
-                SpineError::Auth(format!("failed to parse token response: {e}"))
-            })?;
-
-            let access_token = body["access_token"]
-                .as_str()
-                .ok_or_else(|| SpineError::Auth("no access_token in response".to_string()))?
-                .to_string();
-
-            let expires_in = body["expires_in"].as_u64().unwrap_or(3600);
-            // Buffer 60 seconds before expiry.
-            let expiry = Instant::now() + Duration::from_secs(expires_in.saturating_sub(60));
-
-            Ok((access_token, expiry))
-        })?;
-
-        let (access_token, expiry) = token_result;
-        let mut cached = self.token.write();
-        *cached = Some((access_token.clone(), expiry));
-        Ok(access_token)
-    }
-
-    /// Write an entity entry to Firestore.
-    fn write_entity(&self, entry: &EntityEntry) -> Result<(), SpineError> {
-        let token = self.get_access_token()?;
-        let doc_id = format!("{}_{}", entry.repo_id, entry.entity_id);
-        let url = format!("{}/spine_entities/{}", self.base_url(), doc_id);
-
-        let doc = serde_json::json!({
-            "fields": {
-                "repo_id": { "stringValue": entry.repo_id },
-                "entity_id": { "stringValue": entry.entity_id.to_string() },
-                "name": { "stringValue": entry.name },
-                "kind": { "stringValue": format!("{:?}", entry.kind) },
-                "signature": { "stringValue": entry.signature },
-                "fingerprint_ast": { "stringValue": format!("{}", entry.fingerprint.ast_hash) },
-                "fingerprint_sig": { "stringValue": format!("{}", entry.fingerprint.signature_hash) },
-                "fingerprint_beh": { "stringValue": format!("{}", entry.fingerprint.behavior_hash) },
-                "file_path": { "stringValue": entry.file_path.as_deref().unwrap_or("") },
-            }
-        });
-
-        let rt = tokio::runtime::Handle::try_current()
-            .map_err(|e| SpineError::Backend(format!("no tokio runtime: {e}")))?;
-
-        rt.block_on(async {
-            let resp = self
-                .client
-                .patch(&url)
-                .bearer_auth(&token)
-                .json(&doc)
-                .send()
-                .await
-                .map_err(|e| SpineError::Http(format!("write entity failed: {e}")))?;
-
-            if !resp.status().is_success() {
-                let status = resp.status();
-                let body = resp.text().await.unwrap_or_default();
-                return Err(SpineError::Http(format!(
-                    "Firestore write failed ({status}): {body}"
-                )));
-            }
-            Ok(())
-        })
-    }
-
-    /// Delete all entities for a repo from Firestore.
-    fn delete_repo_entities(&self, repo_id: &str) -> Result<(), SpineError> {
-        let token = self.get_access_token()?;
-        let url = format!("{}:runQuery", self.base_url());
-
-        let query = serde_json::json!({
-            "structuredQuery": {
-                "from": [{ "collectionId": "spine_entities" }],
-                "where": {
-                    "fieldFilter": {
-                        "field": { "fieldPath": "repo_id" },
-                        "op": "EQUAL",
-                        "value": { "stringValue": repo_id }
-                    }
-                },
-                "select": {
-                    "fields": [{ "fieldPath": "__name__" }]
-                }
-            }
-        });
-
-        let rt = tokio::runtime::Handle::try_current()
-            .map_err(|e| SpineError::Backend(format!("no tokio runtime: {e}")))?;
-
-        rt.block_on(async {
-            let resp = self
-                .client
-                .post(&url)
-                .bearer_auth(&token)
-                .json(&query)
-                .send()
-                .await
-                .map_err(|e| SpineError::Http(format!("query for delete failed: {e}")))?;
-
-            if !resp.status().is_success() {
-                let status = resp.status();
-                let body = resp.text().await.unwrap_or_default();
-                warn!("Firestore query for delete failed ({status}): {body}");
-                return Ok(());
-            }
-
-            let results: Vec<serde_json::Value> = resp.json().await.map_err(|e| {
-                SpineError::Serialization(format!("failed to parse query results: {e}"))
-            })?;
-
-            // Delete each document found.
-            for result in &results {
-                if let Some(doc_name) = result
-                    .get("document")
-                    .and_then(|d| d.get("name"))
-                    .and_then(|n| n.as_str())
-                {
-                    let delete_url = format!("https://firestore.googleapis.com/v1/{}", doc_name);
-                    let _ = self
-                        .client
-                        .delete(&delete_url)
-                        .bearer_auth(&token)
-                        .send()
-                        .await;
-                }
-            }
-            Ok(())
-        })
-    }
-
-    /// Write a cross-repo edge to Firestore.
-    fn write_edge(&self, edge: &CrossRepoEdge) -> Result<(), SpineError> {
-        let token = self.get_access_token()?;
-        let url = format!("{}/spine_edges", self.base_url());
-
-        let doc = serde_json::json!({
-            "fields": {
-                "src_repo": { "stringValue": edge.src_repo },
-                "src_entity": { "stringValue": edge.src_entity.to_string() },
-                "dst_repo": { "stringValue": edge.dst_repo },
-                "dst_entity": { "stringValue": edge.dst_entity.to_string() },
-                "confidence": { "doubleValue": edge.confidence },
-            }
-        });
-
-        let rt = tokio::runtime::Handle::try_current()
-            .map_err(|e| SpineError::Backend(format!("no tokio runtime: {e}")))?;
-
-        rt.block_on(async {
-            let resp = self
-                .client
-                .post(&url)
-                .bearer_auth(&token)
-                .json(&doc)
-                .send()
-                .await
-                .map_err(|e| SpineError::Http(format!("write edge failed: {e}")))?;
-
-            if !resp.status().is_success() {
-                let status = resp.status();
-                let body = resp.text().await.unwrap_or_default();
-                warn!("Firestore edge write failed ({status}): {body}");
-            }
-            Ok(())
-        })
-    }
-
-    /// Hydrate the local cache from Firestore on startup.
-    /// Queries all spine_entities and spine_edges collections.
+    /// Hydrate the local cache from the durable store.
+    ///
+    /// Loads every persisted repo and edge into the in-memory cache. Idempotent:
+    /// once hydration succeeds, later calls are no-ops. A failed load leaves the
+    /// backend un-hydrated so a caller can retry.
     pub fn hydrate(&self) -> Result<(), SpineError> {
-        if self.hydrated.load(Ordering::Relaxed) {
+        if self.hydrated.load(Ordering::Acquire) {
             return Ok(());
         }
 
-        info!("hydrating spine cache from Firestore...");
+        info!("hydrating spine cache from durable store...");
 
-        // For the initial implementation, we rely on the local cache being
-        // populated by register_repo calls (write-through). Full Firestore
-        // hydration requires parsing Firestore document format back into
-        // EntityEntry/CrossRepoEdge, which we defer until we have real
-        // traffic patterns to optimize for.
-        //
-        // The key architectural win is the trait boundary — swapping in
-        // full Firestore reads is a localized change within this file.
+        let repos = self.store.load_repos()?;
+        let edges = self.store.load_edges()?;
 
-        self.hydrated.store(true, Ordering::Relaxed);
-        info!("spine cache hydration complete (write-through mode)");
+        let repo_count = repos.len();
+        let entity_count: usize = repos.iter().map(|r| r.entries.len()).sum();
+        let edge_count = edges.len();
+
+        // Populate the inner cache directly (not via `self`) so hydration does
+        // not write the loaded data straight back to the store.
+        for repo in repos {
+            self.cache
+                .register_repo(&repo.repo_id, repo.entries, &repo.root_hash);
+        }
+        for edge in edges {
+            self.cache.add_cross_repo_edge(edge);
+        }
+
+        self.hydrated.store(true, Ordering::Release);
+        info!(
+            repos = repo_count,
+            entities = entity_count,
+            edges = edge_count,
+            "spine cache hydration complete"
+        );
         Ok(())
     }
 }
 
 impl SpineBackend for FirestoreSpineBackend {
     fn register_repo(&self, repo_id: &str, entries: Vec<EntityEntry>, root_hash: &str) {
-        // Write-through: update local cache first (fast path).
+        // Write-through: update the local cache first (fast path).
         self.cache
             .register_repo(repo_id, entries.clone(), root_hash);
 
-        // Then write to Firestore (async, best-effort).
-        if let Err(e) = self.delete_repo_entities(repo_id) {
-            error!(repo_id, error = %e, "failed to delete old Firestore entities");
+        // Replace the repo's persisted entities in the store.
+        if let Err(e) = self.store.delete_repo_entities(repo_id) {
+            error!(repo_id, error = %e, "failed to delete old entities from store");
         }
 
         let mut write_errors = 0;
         for entry in &entries {
-            if let Err(e) = self.write_entity(entry) {
+            if let Err(e) = self.store.write_entity(entry, root_hash) {
                 write_errors += 1;
                 if write_errors <= 3 {
-                    error!(error = %e, "failed to write entity to Firestore");
+                    error!(error = %e, "failed to write entity to store");
                 }
             }
         }
@@ -330,14 +142,10 @@ impl SpineBackend for FirestoreSpineBackend {
                 repo_id,
                 errors = write_errors,
                 total = entries.len(),
-                "some entities failed to write to Firestore"
+                "some entities failed to write to store"
             );
         } else {
-            debug!(
-                repo_id,
-                count = entries.len(),
-                "wrote entities to Firestore"
-            );
+            debug!(repo_id, count = entries.len(), "wrote entities to store");
         }
     }
 
@@ -347,7 +155,7 @@ impl SpineBackend for FirestoreSpineBackend {
         kind: Option<EntityKind>,
         reference_fingerprint: Option<&SemanticFingerprint>,
     ) -> Vec<EntityEntry> {
-        // Always read from local cache (populated by write-through + hydration).
+        // Always read from the local cache (populated by write-through + hydrate).
         self.cache.resolve(name, kind, reference_fingerprint)
     }
 
@@ -360,11 +168,11 @@ impl SpineBackend for FirestoreSpineBackend {
     }
 
     fn add_cross_repo_edge(&self, edge: CrossRepoEdge) {
-        // Write-through: local cache + Firestore.
+        // Write-through: local cache + durable store.
         self.cache.add_cross_repo_edge(edge.clone());
 
-        if let Err(e) = self.write_edge(&edge) {
-            error!(error = %e, "failed to write edge to Firestore");
+        if let Err(e) = self.store.write_edge(&edge) {
+            error!(error = %e, "failed to write edge to store");
         }
     }
 
@@ -395,8 +203,21 @@ impl SpineBackend for FirestoreSpineBackend {
         relations: &[Relation],
         registry_repo_ids: &[String],
     ) {
+        // Recompute the repo's outgoing edges in the cache (this replaces the
+        // repo's prior edges by source repo).
         self.cache
             .refresh_cross_repo_edges(repo_id, entities, relations, registry_repo_ids);
+
+        // Mirror the replacement into the store: drop the repo's persisted edges,
+        // then persist the freshly materialized set.
+        if let Err(e) = self.store.delete_repo_edges(repo_id) {
+            error!(repo_id, error = %e, "failed to delete old edges from store");
+        }
+        for edge in self.cache.index().cross_repo_edges_from(repo_id) {
+            if let Err(e) = self.store.write_edge(&edge) {
+                error!(error = %e, "failed to write refreshed edge to store");
+            }
+        }
     }
 
     fn federated_impact(
@@ -407,5 +228,663 @@ impl SpineBackend for FirestoreSpineBackend {
     ) -> FederatedImpact {
         self.cache
             .federated_impact(start_repo, start_entity, max_depth)
+    }
+}
+
+/// Firestore-backed [`SpineStore`] using the v1 REST API.
+///
+/// Authentication is via the GCE metadata server (Workload Identity on GKE).
+#[cfg(feature = "firestore")]
+pub struct FirestoreStore {
+    /// GCP project ID.
+    project_id: String,
+    /// Firestore database ID (default: "(default)").
+    database_id: String,
+    /// HTTP client for Firestore REST API calls.
+    client: reqwest::Client,
+    /// Cached access token + expiry.
+    token: parking_lot::RwLock<Option<(String, std::time::Instant)>>,
+}
+
+#[cfg(feature = "firestore")]
+impl FirestoreStore {
+    /// Create a new Firestore store.
+    pub fn new(project_id: String, database_id: Option<String>) -> Self {
+        let client = reqwest::Client::builder()
+            .timeout(std::time::Duration::from_secs(10))
+            .build()
+            .expect("failed to create HTTP client");
+
+        Self {
+            project_id,
+            database_id: database_id.unwrap_or_else(|| "(default)".to_string()),
+            client,
+            token: parking_lot::RwLock::new(None),
+        }
+    }
+
+    /// Base URL for the Firestore REST API documents endpoint.
+    fn base_url(&self) -> String {
+        format!(
+            "https://firestore.googleapis.com/v1/projects/{}/databases/{}/documents",
+            self.project_id, self.database_id
+        )
+    }
+
+    /// Get an access token from the GCE metadata server.
+    /// Caches the token for its lifetime minus a 60-second buffer.
+    fn get_access_token(&self) -> Result<String, SpineError> {
+        {
+            let cached = self.token.read();
+            if let Some((ref token, ref expiry)) = *cached {
+                if std::time::Instant::now() < *expiry {
+                    return Ok(token.clone());
+                }
+            }
+        }
+
+        let rt = tokio::runtime::Handle::try_current()
+            .map_err(|e| SpineError::Auth(format!("no tokio runtime available: {e}")))?;
+
+        let client = self.client.clone();
+        let token_result = rt.block_on(async {
+            let resp = client
+                .get("http://metadata.google.internal/computeMetadata/v1/instance/service-accounts/default/token")
+                .header("Metadata-Flavor", "Google")
+                .send()
+                .await
+                .map_err(|e| SpineError::Auth(format!("metadata server request failed: {e}")))?;
+
+            if !resp.status().is_success() {
+                return Err(SpineError::Auth(format!(
+                    "metadata server returned {}",
+                    resp.status()
+                )));
+            }
+
+            let body: serde_json::Value = resp.json().await.map_err(|e| {
+                SpineError::Auth(format!("failed to parse token response: {e}"))
+            })?;
+
+            let access_token = body["access_token"]
+                .as_str()
+                .ok_or_else(|| SpineError::Auth("no access_token in response".to_string()))?
+                .to_string();
+
+            let expires_in = body["expires_in"].as_u64().unwrap_or(3600);
+            let expiry =
+                std::time::Instant::now() + std::time::Duration::from_secs(expires_in.saturating_sub(60));
+
+            Ok((access_token, expiry))
+        })?;
+
+        let (access_token, expiry) = token_result;
+        let mut cached = self.token.write();
+        *cached = Some((access_token.clone(), expiry));
+        Ok(access_token)
+    }
+
+    /// List every document in a collection, following pagination.
+    fn list_all_documents(&self, collection: &str) -> Result<Vec<serde_json::Value>, SpineError> {
+        let token = self.get_access_token()?;
+        let rt = tokio::runtime::Handle::try_current()
+            .map_err(|e| SpineError::Backend(format!("no tokio runtime: {e}")))?;
+
+        rt.block_on(async {
+            let mut documents = Vec::new();
+            let mut page_token: Option<String> = None;
+
+            loop {
+                let mut url = format!("{}/{}?pageSize=300", self.base_url(), collection);
+                if let Some(ref pt) = page_token {
+                    url.push_str("&pageToken=");
+                    url.push_str(pt);
+                }
+
+                let resp = self
+                    .client
+                    .get(&url)
+                    .bearer_auth(&token)
+                    .send()
+                    .await
+                    .map_err(|e| SpineError::Http(format!("list {collection} failed: {e}")))?;
+
+                if !resp.status().is_success() {
+                    let status = resp.status();
+                    let body = resp.text().await.unwrap_or_default();
+                    return Err(SpineError::Http(format!(
+                        "list {collection} failed ({status}): {body}"
+                    )));
+                }
+
+                let body: serde_json::Value = resp.json().await.map_err(|e| {
+                    SpineError::Serialization(format!("failed to parse {collection} list: {e}"))
+                })?;
+
+                if let Some(docs) = body.get("documents").and_then(|d| d.as_array()) {
+                    documents.extend(docs.iter().cloned());
+                }
+
+                match body.get("nextPageToken").and_then(|t| t.as_str()) {
+                    Some(next) if !next.is_empty() => page_token = Some(next.to_string()),
+                    _ => break,
+                }
+            }
+
+            Ok(documents)
+        })
+    }
+
+    /// Delete every document a structured query selects from `collection`,
+    /// matching `field` == `value`. A `None` filter deletes the whole collection.
+    fn delete_where(
+        &self,
+        collection: &str,
+        filter: Option<(&str, &str)>,
+    ) -> Result<(), SpineError> {
+        let token = self.get_access_token()?;
+        let url = format!("{}:runQuery", self.base_url());
+
+        let mut structured_query = serde_json::json!({
+            "from": [{ "collectionId": collection }],
+            "select": { "fields": [{ "fieldPath": "__name__" }] }
+        });
+        if let Some((field, value)) = filter {
+            structured_query["where"] = serde_json::json!({
+                "fieldFilter": {
+                    "field": { "fieldPath": field },
+                    "op": "EQUAL",
+                    "value": { "stringValue": value }
+                }
+            });
+        }
+        let query = serde_json::json!({ "structuredQuery": structured_query });
+
+        let rt = tokio::runtime::Handle::try_current()
+            .map_err(|e| SpineError::Backend(format!("no tokio runtime: {e}")))?;
+
+        rt.block_on(async {
+            let resp = self
+                .client
+                .post(&url)
+                .bearer_auth(&token)
+                .json(&query)
+                .send()
+                .await
+                .map_err(|e| SpineError::Http(format!("query for delete failed: {e}")))?;
+
+            if !resp.status().is_success() {
+                let status = resp.status();
+                let body = resp.text().await.unwrap_or_default();
+                return Err(SpineError::Http(format!(
+                    "query for delete failed ({status}): {body}"
+                )));
+            }
+
+            let results: Vec<serde_json::Value> = resp.json().await.map_err(|e| {
+                SpineError::Serialization(format!("failed to parse query results: {e}"))
+            })?;
+
+            for result in &results {
+                if let Some(doc_name) = result
+                    .get("document")
+                    .and_then(|d| d.get("name"))
+                    .and_then(|n| n.as_str())
+                {
+                    let delete_url = format!("https://firestore.googleapis.com/v1/{doc_name}");
+                    let _ = self
+                        .client
+                        .delete(&delete_url)
+                        .bearer_auth(&token)
+                        .send()
+                        .await;
+                }
+            }
+            Ok(())
+        })
+    }
+}
+
+#[cfg(feature = "firestore")]
+fn doc_payload<T: serde::de::DeserializeOwned>(
+    doc: &serde_json::Value,
+    what: &str,
+) -> Result<T, SpineError> {
+    let payload = doc
+        .get("fields")
+        .and_then(|f| f.get("payload"))
+        .and_then(|p| p.get("stringValue"))
+        .and_then(|v| v.as_str())
+        .ok_or_else(|| SpineError::Serialization(format!("{what} document missing payload")))?;
+    serde_json::from_str(payload)
+        .map_err(|e| SpineError::Serialization(format!("failed to parse {what} payload: {e}")))
+}
+
+#[cfg(feature = "firestore")]
+impl SpineStore for FirestoreStore {
+    fn load_repos(&self) -> Result<Vec<crate::store::LoadedRepo>, SpineError> {
+        use std::collections::HashMap;
+
+        let docs = self.list_all_documents("spine_entities")?;
+        let mut by_repo: HashMap<String, (String, Vec<EntityEntry>)> = HashMap::new();
+
+        for doc in &docs {
+            let entry: EntityEntry = doc_payload(doc, "entity")?;
+            let root_hash = doc
+                .get("fields")
+                .and_then(|f| f.get("root_hash"))
+                .and_then(|h| h.get("stringValue"))
+                .and_then(|v| v.as_str())
+                .unwrap_or_default()
+                .to_string();
+            let bucket = by_repo
+                .entry(entry.repo_id.clone())
+                .or_insert_with(|| (root_hash, Vec::new()));
+            bucket.1.push(entry);
+        }
+
+        Ok(by_repo
+            .into_iter()
+            .map(|(repo_id, (root_hash, entries))| crate::store::LoadedRepo {
+                repo_id,
+                root_hash,
+                entries,
+            })
+            .collect())
+    }
+
+    fn load_edges(&self) -> Result<Vec<CrossRepoEdge>, SpineError> {
+        let docs = self.list_all_documents("spine_edges")?;
+        docs.iter().map(|doc| doc_payload(doc, "edge")).collect()
+    }
+
+    fn write_entity(&self, entry: &EntityEntry, root_hash: &str) -> Result<(), SpineError> {
+        let token = self.get_access_token()?;
+        let doc_id = format!("{}_{}", entry.repo_id, entry.entity_id);
+        let url = format!("{}/spine_entities/{}", self.base_url(), doc_id);
+
+        let payload = serde_json::to_string(entry)
+            .map_err(|e| SpineError::Serialization(format!("failed to serialize entity: {e}")))?;
+
+        let doc = serde_json::json!({
+            "fields": {
+                "repo_id": { "stringValue": entry.repo_id },
+                "name": { "stringValue": entry.name },
+                "kind": { "stringValue": format!("{:?}", entry.kind) },
+                "signature": { "stringValue": entry.signature },
+                "file_path": { "stringValue": entry.file_path.as_deref().unwrap_or("") },
+                "root_hash": { "stringValue": root_hash },
+                "payload": { "stringValue": payload },
+            }
+        });
+
+        let rt = tokio::runtime::Handle::try_current()
+            .map_err(|e| SpineError::Backend(format!("no tokio runtime: {e}")))?;
+
+        rt.block_on(async {
+            let resp = self
+                .client
+                .patch(&url)
+                .bearer_auth(&token)
+                .json(&doc)
+                .send()
+                .await
+                .map_err(|e| SpineError::Http(format!("write entity failed: {e}")))?;
+
+            if !resp.status().is_success() {
+                let status = resp.status();
+                let body = resp.text().await.unwrap_or_default();
+                return Err(SpineError::Http(format!(
+                    "Firestore write failed ({status}): {body}"
+                )));
+            }
+            Ok(())
+        })
+    }
+
+    fn delete_repo_entities(&self, repo_id: &str) -> Result<(), SpineError> {
+        self.delete_where("spine_entities", Some(("repo_id", repo_id)))
+    }
+
+    fn write_edge(&self, edge: &CrossRepoEdge) -> Result<(), SpineError> {
+        let token = self.get_access_token()?;
+        let url = format!("{}/spine_edges", self.base_url());
+
+        let payload = serde_json::to_string(edge)
+            .map_err(|e| SpineError::Serialization(format!("failed to serialize edge: {e}")))?;
+
+        let doc = serde_json::json!({
+            "fields": {
+                "src_repo": { "stringValue": edge.src_repo },
+                "dst_repo": { "stringValue": edge.dst_repo },
+                "confidence": { "doubleValue": edge.confidence },
+                "payload": { "stringValue": payload },
+            }
+        });
+
+        let rt = tokio::runtime::Handle::try_current()
+            .map_err(|e| SpineError::Backend(format!("no tokio runtime: {e}")))?;
+
+        rt.block_on(async {
+            let resp = self
+                .client
+                .post(&url)
+                .bearer_auth(&token)
+                .json(&doc)
+                .send()
+                .await
+                .map_err(|e| SpineError::Http(format!("write edge failed: {e}")))?;
+
+            if !resp.status().is_success() {
+                let status = resp.status();
+                let body = resp.text().await.unwrap_or_default();
+                return Err(SpineError::Http(format!(
+                    "Firestore edge write failed ({status}): {body}"
+                )));
+            }
+            Ok(())
+        })
+    }
+
+    fn delete_repo_edges(&self, repo_id: &str) -> Result<(), SpineError> {
+        self.delete_where("spine_edges", Some(("src_repo", repo_id)))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::store::LoadedRepo;
+    use kin_model::{
+        EntityKind, EntityRole, FingerprintAlgorithm, GraphNodeId, Hash256, LanguageId,
+        RelationEvidence, RelationId, RelationKind, RelationOrigin, SemanticFingerprint,
+        Visibility,
+    };
+    use std::collections::HashMap;
+    use std::sync::Mutex;
+
+    /// In-memory [`SpineStore`] fake. Mirrors the Firestore semantics (replace
+    /// entities/edges by repo) without any network, so hydrate and write-through
+    /// can be exercised under default features.
+    #[derive(Default)]
+    struct FakeSpineStore {
+        // (root_hash, entries) keyed by repo_id.
+        repos: Mutex<HashMap<String, (String, Vec<EntityEntry>)>>,
+        edges: Mutex<Vec<CrossRepoEdge>>,
+    }
+
+    impl SpineStore for FakeSpineStore {
+        fn load_repos(&self) -> Result<Vec<LoadedRepo>, SpineError> {
+            Ok(self
+                .repos
+                .lock()
+                .unwrap()
+                .iter()
+                .map(|(repo_id, (root_hash, entries))| LoadedRepo {
+                    repo_id: repo_id.clone(),
+                    root_hash: root_hash.clone(),
+                    entries: entries.clone(),
+                })
+                .collect())
+        }
+
+        fn load_edges(&self) -> Result<Vec<CrossRepoEdge>, SpineError> {
+            Ok(self.edges.lock().unwrap().clone())
+        }
+
+        fn write_entity(&self, entry: &EntityEntry, root_hash: &str) -> Result<(), SpineError> {
+            let mut repos = self.repos.lock().unwrap();
+            let bucket = repos
+                .entry(entry.repo_id.clone())
+                .or_insert_with(|| (root_hash.to_string(), Vec::new()));
+            bucket.0 = root_hash.to_string();
+            bucket.1.push(entry.clone());
+            Ok(())
+        }
+
+        fn delete_repo_entities(&self, repo_id: &str) -> Result<(), SpineError> {
+            self.repos.lock().unwrap().remove(repo_id);
+            Ok(())
+        }
+
+        fn write_edge(&self, edge: &CrossRepoEdge) -> Result<(), SpineError> {
+            self.edges.lock().unwrap().push(edge.clone());
+            Ok(())
+        }
+
+        fn delete_repo_edges(&self, repo_id: &str) -> Result<(), SpineError> {
+            self.edges.lock().unwrap().retain(|e| e.src_repo != repo_id);
+            Ok(())
+        }
+    }
+
+    fn test_fp() -> SemanticFingerprint {
+        SemanticFingerprint {
+            ast_hash: Hash256::from_bytes([1; 32]),
+            signature_hash: Hash256::from_bytes([2; 32]),
+            behavior_hash: Hash256::from_bytes([3; 32]),
+            algorithm: FingerprintAlgorithm::V1TreeSitter,
+            stability_score: 1.0,
+        }
+    }
+
+    fn test_entry(repo: &str, name: &str, kind: EntityKind) -> EntityEntry {
+        EntityEntry {
+            repo_id: repo.to_string(),
+            entity_id: EntityId::new(),
+            name: name.to_string(),
+            kind,
+            signature: format!("fn {name}()"),
+            fingerprint: test_fp(),
+            file_path: Some("src/lib.rs".to_string()),
+            role: Some(EntityRole::Source),
+        }
+    }
+
+    fn local_entity(id: EntityId, name: &str) -> Entity {
+        use kin_model::EntityMetadata;
+        Entity {
+            id,
+            kind: EntityKind::Function,
+            name: name.to_string(),
+            language: LanguageId::Python,
+            fingerprint: test_fp(),
+            file_origin: None,
+            span: None,
+            signature: format!("fn {name}()"),
+            visibility: Visibility::Public,
+            role: EntityRole::Source,
+            doc_summary: None,
+            metadata: EntityMetadata::default(),
+            lineage_parent: None,
+            created_in: None,
+            superseded_by: None,
+        }
+    }
+
+    fn external_call(src: EntityId, dst: EntityId, import_source: &str, token: &str) -> Relation {
+        Relation {
+            id: RelationId::new(),
+            kind: RelationKind::Calls,
+            src: GraphNodeId::Entity(src),
+            dst: GraphNodeId::Entity(dst),
+            confidence: 1.0,
+            origin: RelationOrigin::Parsed,
+            created_in: None,
+            import_source: Some(import_source.to_string()),
+            evidence: vec![RelationEvidence {
+                token: Some(token.to_string()),
+                ..RelationEvidence::default()
+            }],
+        }
+    }
+
+    #[test]
+    fn hydrate_restores_entities_and_edges_from_store() {
+        let store = Arc::new(FakeSpineStore::default());
+
+        // Populate via a first backend (write-through to the shared store).
+        let writer = FirestoreSpineBackend::with_store(store.clone());
+        let a = test_entry("kin-db", "query_entities", EntityKind::Function);
+        let b = test_entry("kin", "run_search", EntityKind::Function);
+        writer.register_repo("kin-db", vec![a.clone()], "h1");
+        writer.register_repo("kin", vec![b.clone()], "h2");
+        writer.add_cross_repo_edge(CrossRepoEdge {
+            src_repo: "kin".to_string(),
+            src_entity: b.entity_id,
+            dst_repo: "kin-db".to_string(),
+            dst_entity: a.entity_id,
+            confidence: 0.9,
+        });
+
+        // A fresh backend over the same store must rebuild the full index.
+        let reader = FirestoreSpineBackend::with_store(store.clone());
+        assert_eq!(reader.entity_count(), 0, "cache empty before hydrate");
+        reader.hydrate().expect("hydrate");
+
+        assert_eq!(reader.repo_count(), 2);
+        assert_eq!(reader.entity_count(), 2);
+        assert_eq!(reader.edge_count(), 1);
+        assert_eq!(reader.root_hash("kin-db").as_deref(), Some("h1"));
+        assert_eq!(reader.root_hash("kin").as_deref(), Some("h2"));
+
+        let resolved = reader.resolve("query_entities", Some(EntityKind::Function), None);
+        assert_eq!(resolved.len(), 1);
+        assert_eq!(resolved[0].repo_id, "kin-db");
+
+        let looked_up = reader
+            .lookup_by_id("kin", &b.entity_id)
+            .expect("entity present after hydrate");
+        assert_eq!(looked_up.name, "run_search");
+
+        let edges = reader.cross_repo_edges_for("kin-db", &a.entity_id);
+        assert_eq!(edges.len(), 1);
+        assert_eq!(edges[0].src_repo, "kin");
+    }
+
+    #[test]
+    fn hydrate_is_idempotent_and_guards_against_reload() {
+        let store = Arc::new(FakeSpineStore::default());
+        let writer = FirestoreSpineBackend::with_store(store.clone());
+        writer.register_repo(
+            "repo-a",
+            vec![test_entry("repo-a", "Config", EntityKind::Class)],
+            "h1",
+        );
+
+        let reader = FirestoreSpineBackend::with_store(store.clone());
+        reader.hydrate().expect("first hydrate");
+        assert_eq!(reader.entity_count(), 1);
+
+        // Mutate the store after the first hydrate; a second hydrate is a no-op
+        // because the backend is already hydrated.
+        writer.register_repo(
+            "repo-b",
+            vec![test_entry("repo-b", "parse", EntityKind::Function)],
+            "h2",
+        );
+        reader.hydrate().expect("second hydrate");
+        assert_eq!(
+            reader.entity_count(),
+            1,
+            "already-hydrated backend must not reload"
+        );
+    }
+
+    #[test]
+    fn register_repo_write_through_replaces_in_store() {
+        let store = Arc::new(FakeSpineStore::default());
+        let backend = FirestoreSpineBackend::with_store(store.clone());
+
+        backend.register_repo(
+            "repo-a",
+            vec![test_entry("repo-a", "old_fn", EntityKind::Function)],
+            "h1",
+        );
+        backend.register_repo(
+            "repo-a",
+            vec![test_entry("repo-a", "new_fn", EntityKind::Function)],
+            "h2",
+        );
+
+        let repos = store.load_repos().unwrap();
+        assert_eq!(repos.len(), 1);
+        let repo = &repos[0];
+        assert_eq!(repo.repo_id, "repo-a");
+        assert_eq!(repo.root_hash, "h2");
+        assert_eq!(repo.entries.len(), 1, "re-register replaces, not appends");
+        assert_eq!(repo.entries[0].name, "new_fn");
+    }
+
+    #[test]
+    fn add_cross_repo_edge_persists_to_store() {
+        let store = Arc::new(FakeSpineStore::default());
+        let backend = FirestoreSpineBackend::with_store(store.clone());
+
+        let a = test_entry("repo-a", "caller", EntityKind::Function);
+        let b = test_entry("repo-b", "callee", EntityKind::Function);
+        backend.add_cross_repo_edge(CrossRepoEdge {
+            src_repo: "repo-a".to_string(),
+            src_entity: a.entity_id,
+            dst_repo: "repo-b".to_string(),
+            dst_entity: b.entity_id,
+            confidence: 0.95,
+        });
+
+        let edges = store.load_edges().unwrap();
+        assert_eq!(edges.len(), 1);
+        assert_eq!(edges[0].src_repo, "repo-a");
+        assert_eq!(edges[0].dst_repo, "repo-b");
+    }
+
+    #[test]
+    fn refresh_cross_repo_edges_persists_add_and_remove() {
+        let store = Arc::new(FakeSpineStore::default());
+        let backend = FirestoreSpineBackend::with_store(store.clone());
+
+        // Two repos both export `Config`; the import_source disambiguates.
+        backend.register_repo(
+            "repo-a",
+            vec![test_entry("repo-a", "Config", EntityKind::Class)],
+            "ha",
+        );
+        backend.register_repo(
+            "repo-b",
+            vec![test_entry("repo-b", "Config", EntityKind::Class)],
+            "hb",
+        );
+
+        let registry = vec![
+            "app".to_string(),
+            "repo-a".to_string(),
+            "repo-b".to_string(),
+        ];
+        let caller = EntityId::new();
+        let entities = vec![local_entity(caller, "build")];
+
+        // First refresh resolves app -> repo-a and persists that edge.
+        let to_a = vec![external_call(caller, EntityId::new(), "repo-a", "Config")];
+        backend.refresh_cross_repo_edges("app", &entities, &to_a, &registry);
+
+        let edges = store.load_edges().unwrap();
+        assert_eq!(edges.len(), 1, "refresh persists the materialized edge");
+        assert_eq!(edges[0].src_repo, "app");
+        assert_eq!(edges[0].dst_repo, "repo-a");
+
+        // Second refresh resolves app -> repo-b; the stale app edge must be gone.
+        let to_b = vec![external_call(caller, EntityId::new(), "repo-b", "Config")];
+        backend.refresh_cross_repo_edges("app", &entities, &to_b, &registry);
+
+        let edges = store.load_edges().unwrap();
+        assert_eq!(edges.len(), 1, "refresh replaces, not appends");
+        assert_eq!(edges[0].dst_repo, "repo-b");
+
+        // A fresh backend hydrated from the store must see the replacement.
+        let reader = FirestoreSpineBackend::with_store(store.clone());
+        reader.hydrate().expect("hydrate");
+        assert_eq!(reader.edge_count(), 1);
+        let from_app = reader.cache.index().cross_repo_edges_from("app");
+        assert_eq!(from_app.len(), 1);
+        assert_eq!(from_app[0].dst_repo, "repo-b");
     }
 }

--- a/crates/kin-spine/src/index.rs
+++ b/crates/kin-spine/src/index.rs
@@ -166,6 +166,20 @@ impl SpineIndex {
             .collect()
     }
 
+    /// Get all cross-repo edges whose source repo is `repo_id`.
+    ///
+    /// `refresh_cross_repo_edges` replaces a repo's edges by source repo, so this
+    /// returns the exact set a persistence layer must mirror after a refresh.
+    pub fn cross_repo_edges_from(&self, repo_id: &str) -> Vec<CrossRepoEdge> {
+        let inner = self.inner.read();
+        inner
+            .cross_repo_edges
+            .iter()
+            .filter(|e| e.src_repo == repo_id)
+            .cloned()
+            .collect()
+    }
+
     /// Add a cross-repo edge to the index.
     pub fn add_cross_repo_edge(&self, edge: CrossRepoEdge) {
         let mut inner = self.inner.write();

--- a/crates/kin-spine/src/lib.rs
+++ b/crates/kin-spine/src/lib.rs
@@ -13,18 +13,20 @@
 
 pub mod backend;
 pub mod federation;
-#[cfg(feature = "firestore")]
 pub mod firestore;
 pub mod index;
 pub mod routing;
+pub mod store;
 pub mod xref;
 
 pub use backend::{InMemorySpineBackend, SpineBackend, SpineError};
 pub use federation::{federated_impact, FederatedEdge, FederatedImpact, FederatedNode};
-#[cfg(feature = "firestore")]
 pub use firestore::FirestoreSpineBackend;
+#[cfg(feature = "firestore")]
+pub use firestore::FirestoreStore;
 pub use index::{CrossRepoEdge, EntityEntry, SpineIndex};
 pub use routing::{RepoEndpoint, RoutingTable};
+pub use store::{LoadedRepo, SpineStore};
 pub use xref::{
     collect_unresolved_imports, materialize_edges, resolve_imports, ResolveResult, UnresolvedImport,
 };

--- a/crates/kin-spine/src/store.rs
+++ b/crates/kin-spine/src/store.rs
@@ -1,0 +1,49 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Firelock, LLC
+
+//! Persistence boundary for a store-backed spine.
+//!
+//! A [`SpineStore`] is the durable store behind [`crate::FirestoreSpineBackend`]:
+//! it persists entity metadata and cross-repo edges and reloads them so a freshly
+//! started backend can rebuild its in-memory cache. The store is the only seam
+//! that talks to an external system, so the backend's hydrate and write-through
+//! behavior can be exercised end-to-end against an in-memory fake with no live
+//! service.
+
+use crate::backend::SpineError;
+use crate::index::{CrossRepoEdge, EntityEntry};
+
+/// A repo's persisted entity set together with its graph root hash.
+#[derive(Debug, Clone)]
+pub struct LoadedRepo {
+    pub repo_id: String,
+    pub root_hash: String,
+    pub entries: Vec<EntityEntry>,
+}
+
+/// Durable storage for spine metadata.
+///
+/// Implementations persist entities and cross-repo edges and reload them on
+/// hydrate. Methods are synchronous to match the [`crate::SpineBackend`] call
+/// sites; an implementation backed by a network service bridges async
+/// internally.
+pub trait SpineStore: Send + Sync {
+    /// Load every persisted repo (entities grouped by repo, with root hash).
+    fn load_repos(&self) -> Result<Vec<LoadedRepo>, SpineError>;
+
+    /// Load every persisted cross-repo edge.
+    fn load_edges(&self) -> Result<Vec<CrossRepoEdge>, SpineError>;
+
+    /// Persist one entity belonging to `root_hash`'s repo, replacing any prior
+    /// copy of the same entity.
+    fn write_entity(&self, entry: &EntityEntry, root_hash: &str) -> Result<(), SpineError>;
+
+    /// Remove every persisted entity for `repo_id`.
+    fn delete_repo_entities(&self, repo_id: &str) -> Result<(), SpineError>;
+
+    /// Persist one cross-repo edge.
+    fn write_edge(&self, edge: &CrossRepoEdge) -> Result<(), SpineError>;
+
+    /// Remove every persisted edge whose source repo is `repo_id`.
+    fn delete_repo_edges(&self, repo_id: &str) -> Result<(), SpineError>;
+}


### PR DESCRIPTION
## What

Makes the spine's cloud backend actually durable: it now **hydrates its cache from a backing store on startup** and **writes every edge mutation through** to that store. Previously a restarted (stateless) daemon pod rebuilt an incomplete cross-repo index.

## Current behavior (pre-change, verified in source)

`crates/kin-spine/src/firestore.rs`:
- `hydrate()` (was ~:286–305) was a no-op stub — it set `hydrated = true` and returned, with a "defer until we have real traffic" comment. A fresh pod started with an empty cache.
- `refresh_cross_repo_edges` (was ~:391–400) delegated to the cache only — the newly materialized edges were **never persisted**, and stale edges were never removed from the store.
- Write-through existed only in `add_cross_repo_edge` (was ~:362–369).

## Change

- **New `SpineStore` persistence boundary** (`store.rs`): `load_repos` / `load_edges` / `write_entity` / `delete_repo_entities` / `write_edge` / `delete_repo_edges`. This is the single seam that touches an external system.
- **`FirestoreSpineBackend` is now store-backed** (`Arc<dyn SpineStore>`):
  - `hydrate()` loads every persisted repo + edge into the cache (idempotent; a failed load leaves it un-hydrated so a caller can retry).
  - `register_repo` / `add_cross_repo_edge` / `refresh_cross_repo_edges` all write through. **`refresh` now replaces a repo's edges in the store** (delete-by-source-repo, then persist the freshly materialized set).
- **`FirestoreStore`** (the production reqwest/REST impl, behind the `firestore` feature) round-trips entities and edges via a JSON `payload` field, with paginated list reads and structured-query deletes. Sibling fields (`repo_id`, `src_repo`, …) stay human-readable and back the delete queries.
- `index.rs`: added `cross_repo_edges_from(repo_id)` so the backend can mirror the exact post-refresh edge set.
- The orchestration logic + a `SpineStore` fake are **no longer behind the `firestore` feature**, so the behavior is testable under default features (only the reqwest HTTP code stays gated). `FirestoreSpineBackend::new` stays feature-gated (it builds the real store); the daemon's wiring is unchanged.

## Tests (in-memory fake backend — no live Firestore)

5 new tests, all under `cargo test -p kin-spine` (default features):
- `hydrate_restores_entities_and_edges_from_store`
- `hydrate_is_idempotent_and_guards_against_reload`
- `register_repo_write_through_replaces_in_store`
- `add_cross_repo_edge_persists_to_store`
- `refresh_cross_repo_edges_persists_add_and_remove` (asserts add **and** removal, plus a fresh hydrate sees the replacement)

## Gate (all green locally)

- `cargo fmt -- --check` — pass
- `RUSTFLAGS="-D warnings" cargo clippy --all-targets --all-features --` (CI allow-list) — pass (compiles + lints the gated `FirestoreStore` and the daemon's firestore path)
- `cargo build --all-targets` — pass
- `cargo test -p kin-spine` — **46 passed** (32 unit + 14 integration), 0 failed
- Also verified: `cargo check -p kin-spine --features firestore` compiles; `cargo test -p kin-spine --features firestore` passes.

## Scope / bounded-out

- Acceptance allows a fake/in-memory backend; the real Firestore store compiles under `--all-features` but is not exercised by the gate (no live Firestore). The JSON-payload round-trip avoids fragile field-by-field reconstruction.
- A repo registered with **zero entities** isn't restored on hydrate (root hash is carried on entity docs). Edge-case only; flagged rather than expanding the schema with a separate repos collection.
