### PR TITLE
Emit cross-repo import-symbol evidence from the linker

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3151,6 +3151,7 @@ dependencies = [
  "kin-model",
  "kin-parser",
  "kin-projection",
+ "kin-spine",
  "notify",
  "pretty_assertions",
  "rayon",

--- a/crates/kin-index/Cargo.toml
+++ b/crates/kin-index/Cargo.toml
@@ -24,5 +24,6 @@ hex = { workspace = true }
 tokio = { workspace = true }
 
 [dev-dependencies]
+kin-spine = { workspace = true }
 tempfile = { workspace = true }
 pretty_assertions = { workspace = true }

--- a/crates/kin-index/src/linker.rs
+++ b/crates/kin-index/src/linker.rs
@@ -497,6 +497,21 @@ fn resolve_one_file(file: &FileParseData, ctx: &LinkContext<'_>) -> Vec<Relation
             continue;
         }
 
+        // (d) Cross-repo external reference: the target is not in this repo's
+        // parse universe, but the parser recorded the module it was imported
+        // from. Preserve it as an inferred edge carrying the imported symbol and
+        // source so the spine cross-repo resolver can match it against a sibling
+        // repo. Drops to the unresolved log below when no import source/symbol
+        // is available.
+        if let Some(external) = make_external_reference_relation(rel, src_id) {
+            if let GraphNodeId::Entity(dst_id) = external.dst {
+                if add_deduped(&mut seen, src_id, dst_id, rel.kind) {
+                    resolved.push(external);
+                }
+            }
+            continue;
+        }
+
         debug!(
             src = %rel.src_name,
             dst = %rel.dst_name,
@@ -811,6 +826,64 @@ fn make_relation(kind: RelationKind, src: EntityId, dst: EntityId, confidence: f
         import_source: None,
         evidence: Vec::new(),
     }
+}
+
+/// Confidence assigned to an unresolved cross-repo reference edge. The target
+/// entity lives in another repository and is absent from this repo's parse
+/// universe, so the edge is inferred until the spine cross-repo resolver matches
+/// it against a registered sibling repo.
+const EXTERNAL_REFERENCE_CONFIDENCE: f32 = 0.2;
+
+/// Synthetic tag used to derive a deterministic, repo-stable id for an external
+/// (cross-repo) reference target. It is never a real `EntityKind`, so the
+/// derived id can never collide with a locally indexed entity.
+const EXTERNAL_REFERENCE_KIND_TAG: &str = "ExternalReference";
+
+/// Emit a cross-repo reference edge for a Calls/References relation that could
+/// not be resolved to any local entity but carries a parser-provided import
+/// source.
+///
+/// The destination is a deterministic placeholder entity derived from the import
+/// source and the called/imported symbol. It is intentionally absent from this
+/// repo's entity set, which is exactly the signal the spine cross-repo resolver
+/// keys on. The relation carries the lexical symbol as `evidence.token` and the
+/// module hint as `import_source`, the two facts the resolver needs to match it
+/// against a sibling repo. When the parser supplied no import source or no
+/// symbol, no edge is emitted — the reference stays honestly unresolved rather
+/// than fabricated.
+fn make_external_reference_relation(rel: &ExtractedRelation, src: EntityId) -> Option<Relation> {
+    if rel.kind != RelationKind::Calls && rel.kind != RelationKind::References {
+        return None;
+    }
+    let import_source = rel
+        .import_source
+        .as_deref()
+        .map(str::trim)
+        .filter(|s| !s.is_empty())?;
+    let symbol = rel.dst_name.trim();
+    if symbol.is_empty() {
+        return None;
+    }
+
+    let dst = EntityId::from_content(import_source, symbol, EXTERNAL_REFERENCE_KIND_TAG, 0);
+    let id = stable_relation_id(&src, &dst, &rel.kind);
+
+    Some(Relation {
+        id,
+        kind: rel.kind,
+        src: GraphNodeId::Entity(src),
+        dst: GraphNodeId::Entity(dst),
+        confidence: EXTERNAL_REFERENCE_CONFIDENCE,
+        origin: RelationOrigin::Inferred,
+        created_in: None,
+        import_source: Some(import_source.to_string()),
+        evidence: vec![RelationEvidence {
+            token: Some(symbol.to_string()),
+            parser_rule: Some("external_import_reference".to_string()),
+            source_path: Some(import_source.to_string()),
+            ..RelationEvidence::default()
+        }],
+    })
 }
 
 // Graph-less caller: the cross-file linker pipeline builds these artifact
@@ -1650,7 +1723,21 @@ pub fn link_cross_file_incremental(
                     if add_deduped(&mut seen, src_id, *dst_id, rel.kind) {
                         resolved.push(make_relation(rel.kind, src_id, *dst_id, 0.7));
                     }
+                    continue;
                 }
+            }
+
+            // (d) Cross-repo external reference: preserve an unresolved
+            // import-bearing reference as an inferred edge carrying the imported
+            // symbol and source, so the spine cross-repo resolver can match it
+            // against a sibling repo. See `make_external_reference_relation`.
+            if let Some(external) = make_external_reference_relation(rel, src_id) {
+                if let GraphNodeId::Entity(dst_id) = external.dst {
+                    if add_deduped(&mut seen, src_id, dst_id, rel.kind) {
+                        resolved.push(external);
+                    }
+                }
+                continue;
             }
         }
     }
@@ -2879,5 +2966,110 @@ void f();
         assert_eq!(result[0].kind, RelationKind::Calls);
         assert_eq!(result[0].src, GraphNodeId::Entity(e1.id));
         assert_eq!(result[0].dst, GraphNodeId::Entity(e2.id));
+    }
+
+    #[test]
+    fn external_reference_carries_symbol_and_import_source() {
+        // A call to a symbol that lives in another repo: the target is absent
+        // from this repo's parse universe, but the parser recorded the module it
+        // was imported from. The linker must preserve it as a cross-repo edge
+        // carrying the lexical symbol (evidence.token) and the module hint
+        // (import_source) — exactly what the spine resolver keys on.
+        let caller = make_entity("run_task", "src/app.rs");
+
+        let files = vec![FileParseData {
+            file_path: "src/app.rs".to_string(),
+            entities: vec![caller.clone()],
+            relations: vec![ExtractedRelation {
+                kind: RelationKind::Calls,
+                src_name: "run_task".to_string(),
+                dst_name: "InMemoryGraph".to_string(),
+                import_source: Some("kin_db".to_string()),
+            }],
+            imports: vec![],
+        }];
+
+        let result = link_cross_file(&files);
+        assert_eq!(result.len(), 1, "one cross-repo reference edge expected");
+        let edge = &result[0];
+        assert_eq!(edge.kind, RelationKind::Calls);
+        assert_eq!(edge.src, GraphNodeId::Entity(caller.id));
+        // The destination is an external placeholder, never a local entity.
+        assert_ne!(edge.dst, GraphNodeId::Entity(caller.id));
+        assert_eq!(edge.import_source.as_deref(), Some("kin_db"));
+        assert_eq!(edge.origin, RelationOrigin::Inferred);
+        let token = edge
+            .evidence
+            .iter()
+            .find_map(|ev| ev.token.as_deref())
+            .expect("evidence token present");
+        assert_eq!(token, "InMemoryGraph");
+    }
+
+    #[test]
+    fn external_reference_not_emitted_without_import_source() {
+        // No import source from the parser means we cannot honestly attribute
+        // the reference to any repo — it must stay unresolved, not fabricated.
+        let caller = make_entity("run_task", "src/app.rs");
+
+        let files = vec![FileParseData {
+            file_path: "src/app.rs".to_string(),
+            entities: vec![caller.clone()],
+            relations: vec![ExtractedRelation {
+                kind: RelationKind::Calls,
+                src_name: "run_task".to_string(),
+                dst_name: "InMemoryGraph".to_string(),
+                import_source: None,
+            }],
+            imports: vec![],
+        }];
+
+        let result = link_cross_file(&files);
+        assert!(
+            result.is_empty(),
+            "no edge should be fabricated without an import source"
+        );
+    }
+
+    #[test]
+    fn external_reference_is_deterministic_and_deduped() {
+        // Two call sites to the same external symbol collapse to one stable edge,
+        // and the derived target id is identical across independent link runs.
+        let caller = make_entity("run_task", "src/app.rs");
+        let other = make_entity("run_again", "src/app.rs");
+
+        let build = |entities: Vec<Entity>| FileParseData {
+            file_path: "src/app.rs".to_string(),
+            entities,
+            relations: vec![
+                ExtractedRelation {
+                    kind: RelationKind::Calls,
+                    src_name: "run_task".to_string(),
+                    dst_name: "InMemoryGraph".to_string(),
+                    import_source: Some("kin_db".to_string()),
+                },
+                ExtractedRelation {
+                    kind: RelationKind::Calls,
+                    src_name: "run_again".to_string(),
+                    dst_name: "InMemoryGraph".to_string(),
+                    import_source: Some("kin_db".to_string()),
+                },
+            ],
+            imports: vec![],
+        };
+
+        let first = link_cross_file(&[build(vec![caller.clone(), other.clone()])]);
+        // Two distinct sources, same external target → two edges sharing one dst.
+        assert_eq!(first.len(), 2);
+        let dst_a = first[0].dst;
+        let dst_b = first[1].dst;
+        assert_eq!(dst_a, dst_b, "same symbol/source → same external target id");
+
+        let second = link_cross_file(&[build(vec![caller, other])]);
+        assert_eq!(second.len(), 2);
+        assert_eq!(
+            first[0].dst, second[0].dst,
+            "external target id is stable across link runs"
+        );
     }
 }

--- a/crates/kin-index/src/linker.rs
+++ b/crates/kin-index/src/linker.rs
@@ -498,12 +498,14 @@ fn resolve_one_file(file: &FileParseData, ctx: &LinkContext<'_>) -> Vec<Relation
         }
 
         // (d) Cross-repo external reference: the target is not in this repo's
-        // parse universe, but the parser recorded the module it was imported
-        // from. Preserve it as an inferred edge carrying the imported symbol and
-        // source so the spine cross-repo resolver can match it against a sibling
-        // repo. Drops to the unresolved log below when no import source/symbol
-        // is available.
-        if let Some(external) = make_external_reference_relation(rel, src_id) {
+        // parse universe, but the parser recorded an external module it was
+        // imported from. Preserve it as an inferred edge carrying the imported
+        // symbol and source so the spine cross-repo resolver can match it
+        // against a sibling repo. Drops to the unresolved log below when no
+        // external import source/symbol is available.
+        if let Some(external) =
+            make_external_reference_relation(rel, src_id, &file.file_path, &ctx.known_files)
+        {
             if let GraphNodeId::Entity(dst_id) = external.dst {
                 if add_deduped(&mut seen, src_id, dst_id, rel.kind) {
                     resolved.push(external);
@@ -841,7 +843,7 @@ const EXTERNAL_REFERENCE_KIND_TAG: &str = "ExternalReference";
 
 /// Emit a cross-repo reference edge for a Calls/References relation that could
 /// not be resolved to any local entity but carries a parser-provided import
-/// source.
+/// source from a module that lives outside this repo.
 ///
 /// The destination is a deterministic placeholder entity derived from the import
 /// source and the called/imported symbol. It is intentionally absent from this
@@ -851,7 +853,20 @@ const EXTERNAL_REFERENCE_KIND_TAG: &str = "ExternalReference";
 /// against a sibling repo. When the parser supplied no import source or no
 /// symbol, no edge is emitted — the reference stays honestly unresolved rather
 /// than fabricated.
-fn make_external_reference_relation(rel: &ExtractedRelation, src: EntityId) -> Option<Relation> {
+///
+/// An import whose module path resolves to a file in this repo is a local
+/// import, not a cross-repo reference: a symbol that fails local resolution
+/// there (e.g. a moved or deleted local definition) must not be mis-attributed
+/// as an external edge. Only module sources that do not resolve locally qualify.
+fn make_external_reference_relation<S>(
+    rel: &ExtractedRelation,
+    src: EntityId,
+    importer_file: &str,
+    known_files: &HashSet<S>,
+) -> Option<Relation>
+where
+    S: std::borrow::Borrow<str> + std::hash::Hash + Eq,
+{
     if rel.kind != RelationKind::Calls && rel.kind != RelationKind::References {
         return None;
     }
@@ -862,6 +877,9 @@ fn make_external_reference_relation(rel: &ExtractedRelation, src: EntityId) -> O
         .filter(|s| !s.is_empty())?;
     let symbol = rel.dst_name.trim();
     if symbol.is_empty() {
+        return None;
+    }
+    if resolve_module_path(importer_file, import_source, known_files).is_some() {
         return None;
     }
 
@@ -1728,10 +1746,13 @@ pub fn link_cross_file_incremental(
             }
 
             // (d) Cross-repo external reference: preserve an unresolved
-            // import-bearing reference as an inferred edge carrying the imported
-            // symbol and source, so the spine cross-repo resolver can match it
-            // against a sibling repo. See `make_external_reference_relation`.
-            if let Some(external) = make_external_reference_relation(rel, src_id) {
+            // reference to an external module as an inferred edge carrying the
+            // imported symbol and source, so the spine cross-repo resolver can
+            // match it against a sibling repo. See
+            // `make_external_reference_relation`.
+            if let Some(external) =
+                make_external_reference_relation(rel, src_id, &file.file_path, &linker.known_files)
+            {
                 if let GraphNodeId::Entity(dst_id) = external.dst {
                     if add_deduped(&mut seen, src_id, dst_id, rel.kind) {
                         resolved.push(external);
@@ -3070,6 +3091,50 @@ void f();
         assert_eq!(
             first[0].dst, second[0].dst,
             "external target id is stable across link runs"
+        );
+    }
+
+    #[test]
+    fn external_reference_skipped_for_local_module_import() {
+        // The import source resolves to a file in this repo, so a symbol that
+        // fails local resolution (e.g. a moved or deleted local definition) is a
+        // broken local import, not a cross-repo reference. No external edge may
+        // be fabricated for it.
+        let handler = make_entity("handler", "src/routes/api.ts");
+        // tools.ts still exists in the repo but no longer defines `executeTool`.
+        let surviving = make_entity("VERSION", "src/utils/tools.ts");
+
+        let files = vec![
+            FileParseData {
+                file_path: "src/routes/api.ts".to_string(),
+                entities: vec![handler.clone()],
+                relations: vec![ExtractedRelation {
+                    kind: RelationKind::Calls,
+                    src_name: "handler".to_string(),
+                    dst_name: "executeTool".to_string(),
+                    import_source: Some("../utils/tools".to_string()),
+                }],
+                imports: vec![FileImport {
+                    module_path: "../utils/tools".to_string(),
+                    specifiers: vec![kin_parser::ImportedName {
+                        local_name: "executeTool".to_string(),
+                        original_name: None,
+                        is_default: false,
+                    }],
+                }],
+            },
+            FileParseData {
+                file_path: "src/utils/tools.ts".to_string(),
+                entities: vec![surviving],
+                relations: vec![],
+                imports: vec![],
+            },
+        ];
+
+        let result = link_cross_file(&files);
+        assert!(
+            result.iter().all(|r| r.kind != RelationKind::Calls),
+            "a broken local import must not be emitted as a cross-repo edge"
         );
     }
 }

--- a/crates/kin-index/tests/cross_repo_xref_e2e.rs
+++ b/crates/kin-index/tests/cross_repo_xref_e2e.rs
@@ -1,0 +1,134 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Firelock, LLC
+
+//! End-to-end: real parser -> real linker -> real spine cross-repo resolver.
+//!
+//! A consumer repo calls a symbol imported from an external crate. The parser
+//! records the import source, the linker preserves the otherwise-unresolved
+//! reference as a cross-repo edge carrying the real symbol, and the spine
+//! resolver matches it to the providing repo by that real symbol name. This
+//! exercises the full production chain, not hand-injected evidence.
+
+use std::collections::HashSet;
+
+use kin_index::{link_cross_file, FileParseData};
+use kin_model::{
+    Entity, EntityId, EntityKind, EntityRole, FilePathId, FingerprintAlgorithm, Hash256,
+    SemanticFingerprint,
+};
+use kin_parser::AdapterRegistry;
+use kin_spine::{
+    collect_unresolved_imports, materialize_edges, resolve_imports, EntityEntry, SpineIndex,
+};
+
+fn parse_consumer(file_path: &str, source: &str) -> FileParseData {
+    let registry = AdapterRegistry::new();
+    let ext = std::path::Path::new(file_path)
+        .extension()
+        .and_then(|e| e.to_str())
+        .expect("file extension");
+    let adapter = registry
+        .get_by_extension(ext)
+        .expect("language adapter for extension");
+    let language = adapter.language_id();
+    let file_id = FilePathId::new(file_path);
+    let bytes = source.as_bytes();
+    let tree = adapter.parse(bytes).expect("parse");
+    let output = adapter.extract(&tree, bytes, &file_id).expect("extract");
+
+    let entities: Vec<Entity> = output
+        .entities
+        .into_iter()
+        .map(|e| e.into_entity_with_source(language, &file_id, Some(bytes)))
+        .collect();
+
+    FileParseData {
+        file_path: file_path.to_string(),
+        entities,
+        relations: output.relations,
+        imports: output.imports,
+    }
+}
+
+fn fingerprint() -> SemanticFingerprint {
+    let zero = Hash256::from_bytes([0u8; 32]);
+    SemanticFingerprint {
+        algorithm: FingerprintAlgorithm::V1TreeSitter,
+        ast_hash: zero,
+        signature_hash: zero,
+        behavior_hash: zero,
+        stability_score: 1.0,
+    }
+}
+
+#[test]
+fn parser_linker_spine_resolves_cross_repo_reference_with_real_symbol() {
+    // Consumer repo: a function that calls a free function imported from an
+    // external crate. `do_work` is defined in another repo, so the linker cannot
+    // resolve it locally.
+    let consumer = parse_consumer(
+        "src/app.rs",
+        "use external_dep::do_work;\n\npub fn run_task() {\n    do_work();\n}\n",
+    );
+    let consumer_entities = consumer.entities.clone();
+
+    let relations = link_cross_file(&[consumer]);
+
+    // The linker preserved the cross-repo reference: an edge whose destination is
+    // not a local entity.
+    let local_ids: HashSet<EntityId> = consumer_entities.iter().map(|e| e.id).collect();
+    let has_external_edge = relations.iter().any(|r| {
+        r.dst
+            .as_entity()
+            .map(|id| !local_ids.contains(&id))
+            .unwrap_or(false)
+    });
+    assert!(
+        has_external_edge,
+        "linker should emit a cross-repo reference edge for the external call"
+    );
+
+    // Drive the real spine collector over the linker's real output.
+    let unresolved = collect_unresolved_imports(&consumer_entities, &relations, "consumer", &[]);
+    assert!(
+        !unresolved.is_empty(),
+        "spine should collect the linker-emitted cross-repo reference"
+    );
+    let imp = &unresolved[0];
+    let dep = imp
+        .import_source
+        .clone()
+        .expect("import source from parser");
+    let symbol = imp.imported_name.clone();
+    assert_eq!(dep, "external_dep");
+    assert_eq!(
+        symbol, "do_work",
+        "the real symbol name flows parser -> linker -> spine"
+    );
+
+    // Provider repo named after the real import source, holding the real symbol.
+    let index = SpineIndex::new();
+    let target = EntityEntry {
+        repo_id: dep.clone(),
+        entity_id: EntityId::new(),
+        name: symbol.clone(),
+        kind: EntityKind::Function,
+        signature: format!("fn {symbol}()"),
+        fingerprint: fingerprint(),
+        file_path: Some("src/lib.rs".to_string()),
+        role: Some(EntityRole::Source),
+    };
+    index.register_repo(&dep, vec![target.clone()], "");
+
+    let resolutions = resolve_imports(&index, &unresolved);
+    let materialized = materialize_edges(&index, &unresolved, &resolutions);
+    assert!(materialized >= 1, "expected a materialized cross-repo edge");
+
+    let edges = index.cross_repo_edges_from("consumer");
+    assert!(
+        edges
+            .iter()
+            .any(|e| e.dst_repo == dep && e.dst_entity == target.entity_id),
+        "cross-repo edge should resolve to the providing repo's real symbol"
+    );
+}


### PR DESCRIPTION
## Problem

The cross-repo reference resolver is correct but starved of evidence on a real index. In `crates/kin-index/src/linker.rs`, the name→entity resolution step (`make_relation`) dropped each `ExtractedRelation`'s `dst_name` and `import_source`, and references that could not be resolved to a **local** entity were dropped entirely. As a result, entity-level Calls/References edges carried no `import_source` and no `evidence.token`, so the spine resolver's `derive_imported_symbol` (kin-spine `xref.rs`) correctly returned UNRESOLVED for them — real cross-repo edge volume stayed thin.

Verified current behavior before changing: `make_relation` (linker.rs) builds relations with `import_source: None` / `evidence: Vec::new()`, and both resolver loops (`resolve_one_file` and `link_cross_file_incremental`) fell through to a debug log + `continue` for unresolved references.

## Change

When a `Calls`/`References` reference cannot be resolved to any local entity **but the parser recorded the module it was imported from**, the linker now preserves it as an inferred cross-repo edge instead of dropping it:

- `evidence.token` = the lexical called/imported symbol (from `ExtractedRelation.dst_name`)
- `import_source` = the parser-provided module hint
- destination = a deterministic placeholder `EntityId` derived from `(import_source, symbol)` via `EntityId::from_content`, tagged so it can never collide with a locally indexed entity and is stable across re-index runs

These are exactly the two facts the spine resolver keys on. Wired into **both** resolver loops (`resolve_one_file` and the incremental linker).

**No fabrication:** where the parser supplies no import source or no symbol, no edge is emitted — the reference stays honestly unresolved (the resolver's own principle). Restricted to Calls/References (the only kinds the parser annotates with an import source and the only kinds the resolver consumes).

End-to-end persistence path verified against source: `upsert_relations_batch` accepts entity→entity edges with a non-local dst, indexes them outgoing-by-src, and `get_relations` returns them — so the daemon's spine relation collection sees them.

## Tests

- `external_reference_carries_symbol_and_import_source` — emitted edge carries `evidence.token` + `import_source` + an external (non-local) dst.
- `external_reference_not_emitted_without_import_source` — no source ⇒ no edge (no fabrication).
- `external_reference_is_deterministic_and_deduped` — same symbol/source ⇒ one stable target id, identical across runs.
- `cross_repo_xref_e2e.rs` — genuine **parser → linker → spine**: a real Rust source parsed, linked, and run through `collect_unresolved_imports` → `resolve_imports` → `materialize_edges`, asserting the reference resolves to the providing repo by its **real symbol name** (not hand-injected evidence). Adds `kin-spine` as a `kin-index` dev-dependency (no cycle; kin-spine depends only on kin-model).

## Gates (all green, full crates)

- `cargo fmt -- --check` — clean
- `cargo clippy --all-targets --all-features` (CI allow-list, `-D warnings`) — exit 0
- `cargo build --all-targets` — exit 0
- `cargo test -p kin-index -p kin-spine` — exit 0 (154 + 1 e2e + 32 + 14, 0 failed)

`Cargo.lock` kept registry-clean: only the legitimate `kin-spine` dependency edge added; every external `kin-*` entry keeps its `sparse+` source + checksum.

## Bounded out

- Locally-resolved (same-repo) edges are left unchanged — the resolver only consumes non-local-dst edges, so attaching evidence there adds no value and would churn existing behavior.