### PR TITLE
chore(deps): relock to kin-db 0.2.18 / kin-vector 0.1.4 / kin-infer 0.2.28

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1051,7 +1051,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users 0.5.2",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1150,7 +1150,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3085,9 +3085,9 @@ dependencies = [
 
 [[package]]
 name = "kin-db"
-version = "0.2.17"
+version = "0.2.18"
 source = "sparse+https://kinlab.ai/registry/cargo/"
-checksum = "a2242b653a56cd98b0afd78c76dfe054b54beb432e2ccbab9639e3e475f55487"
+checksum = "b1bf6c94f7e094434af39316c1318f9ece0c7c9b3b902e100049000d4f01e094"
 dependencies = [
  "bincode",
  "bytes",
@@ -3165,9 +3165,9 @@ dependencies = [
 
 [[package]]
 name = "kin-infer"
-version = "0.2.26"
+version = "0.2.28"
 source = "sparse+https://kinlab.ai/registry/cargo/"
-checksum = "9145b934d71e4f490a13fd190eba60c5c5a8995b2a239abe8960ba95750fe752"
+checksum = "c213998bc39eea9f74d53e1f6a87a002dc35d684994caf251bca21bacecaff37"
 dependencies = [
  "block",
  "half",
@@ -3494,9 +3494,9 @@ dependencies = [
 
 [[package]]
 name = "kin-vector"
-version = "0.1.3"
+version = "0.1.4"
 source = "sparse+https://kinlab.ai/registry/cargo/"
-checksum = "c0194335bc27f7fd154e4b47e660bd5410947a23d988c0a256cdd0d0d8f65801"
+checksum = "66280d81b3a20f465351aa9cab72e63d4eff8643bb30314e1beca369b564b732"
 dependencies = [
  "fs2",
  "hashbrown 0.15.5",
@@ -3900,7 +3900,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4772,7 +4772,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -5388,10 +5388,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
 dependencies = [
  "fastrand",
- "getrandom 0.4.3",
+ "getrandom 0.3.4",
  "once_cell",
  "rustix",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -6317,7 +6317,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.48.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]


### PR DESCRIPTION
## What
Registry-clean lockfile relock (patch-off) on the frozen proof candidate, bumping the three published deps the two-tier-parity re-proof needs:
- **kin-db** 0.2.17 → **0.2.18** (deterministic traversal ordering)
- **kin-vector** 0.1.3 → **0.1.4**
- **kin-infer** 0.2.26 → **0.2.28** (no-lever-kvec byte-determinism — serialized fused add-norm stages)

Lock-only change (the Cargo.toml ranges already permit these).

## Registry-clean (patch-off)
Regenerated from a /tmp worktree with an isolated registry-only `CARGO_HOME` — **zero `[patch.kin]` leak**:
- 8/8 external kin-* lock entries carry a `sparse+` registry source + checksum.
- **0 path-sources** in the lock.
- `cargo fetch --locked` rc=0 (resolves registry-only).
- Full kin CI (`--locked` build + test) runs on this PR.

## Why
The relocked candidate for the FIR-1117 two-tier-parity re-proof; kin-infer 0.2.28 carries the no-lever-kvec byte-determinism fix that the Tier-1 (strict-byte) `parity-noise-floor` gate requires.