### PR TITLE
chore: relock kin to kin-db 0.2.19 / kin-infer 0.2.28 / kin-vector 0.1.4 for FIR-1141 re-proof

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3085,9 +3085,9 @@ dependencies = [
 
 [[package]]
 name = "kin-db"
-version = "0.2.18"
+version = "0.2.19"
 source = "sparse+https://kinlab.ai/registry/cargo/"
-checksum = "b1bf6c94f7e094434af39316c1318f9ece0c7c9b3b902e100049000d4f01e094"
+checksum = "396a33e30e495d89f51833bb58b8a1dbdb2163d34df25f33bd5f8e26db368913"
 dependencies = [
  "bincode",
  "bytes",
@@ -6317,7 +6317,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -143,7 +143,7 @@ kin-lsp = { version = "0.2.1", registry = "kin" }
 # backend on every target (incl. Linux, where it cannot compile). Metal is re-enabled
 # additively on macOS via a `[target.'cfg(target_os = "macos")'.dependencies]` block in the
 # binary/runtime crates (kin-cli, kin-daemon). Feature unification makes that additive.
-kin-db = { version = "0.2.18", registry = "kin", default-features = false, features = ["vector", "embeddings"] }
+kin-db = { version = "0.2.19", registry = "kin", default-features = false, features = ["vector", "embeddings"] }
 kin-vfs-core = { version = "0.1.0", registry = "kin" }
 
 [profile.release]


### PR DESCRIPTION
Relock the kin workspace onto the newly published private-registry dependency versions for the FIR-1141 citable re-proof.

## Changes
- Bump kin-db workspace dependency requirement `0.2.18` -> `0.2.19` (Cargo.toml).
- Cargo.lock relocked patch-OFF against the kin registry:
  - kin-db `0.2.18` -> `0.2.19`
  - kin-infer `0.2.28` (already at target; #29/#30 were test-only, no version bump; 0.2.28 carries the #26 fused-norm determinism fix)
  - kin-vector `0.1.4` (already at target)
- One incidental transitive `windows-sys` reselection (Windows-only; not built on macOS).

## Verification (release-clean discipline)
- Branched fresh off `origin/main` @ `8fbc6c36` (single-commit append; no rebase of public history).
- Regenerated the lock from a `/tmp` checkout outside $HOME with an isolated CARGO_HOME carrying only `[registries.kin]` and zero `[patch]` blocks.
- Every external kin-* lock entry keeps a `sparse+` source + checksum; zero `path+` contamination.
- `cargo check --locked --workspace --all-targets` resolves registry-only and builds (exit 0).

Registry-clean lock lines:
```
kin-db    0.2.19  sparse+https://kinlab.ai/registry/cargo/  checksum 396a33e30e495d89f51833bb58b8a1dbdb2163d34df25f33bd5f8e26db368913
kin-infer 0.2.28  sparse+https://kinlab.ai/registry/cargo/  checksum c213998bc39eea9f74d53e1f6a87a002dc35d684994caf251bca21bacecaff37
kin-vector 0.1.4  sparse+https://kinlab.ai/registry/cargo/  checksum 66280d81b3a20f465351aa9cab72e63d4eff8643bb30314e1beca369b564b732
```