### PR TITLE
docs: record canonical naming and add contributor history-hygiene policy

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -46,6 +46,22 @@ Common types are `feat`, `fix`, `docs`, `test`, `refactor`, `perf`, and
 `search`, `release`, and so on). Write the summary in the imperative mood and
 keep it focused on what changed and why.
 
+## Branch Naming and Commit Hygiene
+
+Public Git history is part of the product, so keep it clean and reviewable:
+
+- **Keep branch names topical, not tracker-coded.** Prefer short, descriptive
+  names like `fix/locate-tie-breaks` or `docs/contributing-hygiene`. Avoid
+  embedding internal issue or tracker IDs in a branch name — a squash merge
+  copies the branch name into the public commit subject, so anything in the
+  branch name lands in history verbatim.
+- **Write durable subjects and bodies.** Commit messages should describe the
+  technical change and why it was made. Keep internal tracker IDs, session
+  identifiers, and automated authorship trailers out of public commit
+  metadata; link that context from the pull request instead.
+- **Don't bypass the hooks.** Repository hooks normalize commit metadata for
+  consistency — don't skip them with `--no-verify`.
+
 ## Pull Requests
 
 - **Keep PRs scoped.** Stage only the files your change actually needs.

--- a/docs/ecosystem-manifest.json
+++ b/docs/ecosystem-manifest.json
@@ -3,6 +3,31 @@
   "organization": "firelock-ai",
   "status": "current",
   "description": "Current Kin ecosystem topology and repo ownership map.",
+  "naming": {
+    "summary": "Firelock (the company) builds Kin (the semantic repo and collaboration substrate). KinLab is the hosted collaboration product; @kinlab is the shared package and registry scope.",
+    "product": {
+      "name": "Kin",
+      "descriptor": "The semantic repo and collaboration substrate — the system of record for software work.",
+      "github": "https://github.com/firelock-ai/kin"
+    },
+    "company": {
+      "name": "Firelock",
+      "legalEntity": "Firelock, LLC",
+      "alsoKnownAs": ["Firelock AI"],
+      "githubOrg": "firelock-ai"
+    },
+    "hostedProduct": {
+      "name": "KinLab",
+      "descriptor": "The hosted collaboration and control-plane product.",
+      "domain": "kinlab.ai",
+      "install": "get.kinlab.dev"
+    },
+    "packageScope": {
+      "name": "@kinlab",
+      "npm": "@kinlab (for example, @kinlab/kin-mcp)",
+      "cargoRegistry": "sparse+https://kinlab.ai/registry/cargo/"
+    }
+  },
   "repos": [
     {
       "name": "kin-db",


### PR DESCRIPTION
## What

Two documentation-hygiene changes ahead of public launch:

1. **Ecosystem manifest — naming record.** Adds a `naming` block to
   `docs/ecosystem-manifest.json` recording the canonical names: the product
   **Kin** (the semantic repo and collaboration substrate), the company
   **Firelock** (Firelock, LLC; GitHub org `firelock-ai`), the hosted product
   **KinLab** (`kinlab.ai`, install `get.kinlab.dev`), and the shared
   package/registry scope **`@kinlab`** (npm scope plus the
   `sparse+https://kinlab.ai/registry/cargo/` registry). This puts the
   canonical naming in the umbrella source-of-truth so launch, landing, and
   public docs no longer reference an undefined naming surface.

2. **CONTRIBUTING — branch naming and commit hygiene.** Documents that branch
   names stay topical and avoid embedding internal tracker IDs (squash merges
   copy the branch name into the public commit subject), that internal
   references and automated trailers stay out of public commit metadata, and
   that the repository hooks normalizing commit metadata should not be
   bypassed.

## Why

Public Git history and the canonical manifest are investor- and user-facing
surfaces. Recording the naming and codifying the history-hygiene conventions
keeps both clean and reviewable.

## Scope

Docs only — no code or build changes. The manifest remains valid JSON
(`naming` is an additive, optional block; no consumer parses it strictly).
