### PR TITLE
guard(contextbench): fail closed on KIN_CONTEXTBENCH_TEST_HINTS gold-leak

### DIFF
--- a/crates/kin-cli/src/commands/contextbench_locate.rs
+++ b/crates/kin-cli/src/commands/contextbench_locate.rs
@@ -312,9 +312,22 @@ fn select_query(task: &Value) -> Result<(&'static str, String)> {
             let trimmed = text.trim();
             if !trimmed.is_empty() {
                 // test_patch hints leak ContextBench gold (the patch's own test files) and are
-                // forbidden for submission; default OFF, opt-in only via KIN_CONTEXTBENCH_TEST_HINTS=1
-                // for internal upper-bound experiments.
+                // forbidden for submission. Default OFF; enabling requires a double opt-in
+                // (KIN_CONTEXTBENCH_TEST_HINTS=1 + KIN_CONTEXTBENCH_ALLOW_NONCITABLE=1) so a
+                // citable/submission run can never silently contaminate the query, and it warns.
                 let query = if std::env::var("KIN_CONTEXTBENCH_TEST_HINTS").as_deref() == Ok("1") {
+                    if std::env::var("KIN_CONTEXTBENCH_ALLOW_NONCITABLE").as_deref() != Ok("1") {
+                        bail!(
+                            "KIN_CONTEXTBENCH_TEST_HINTS=1 leaks ContextBench gold (the task's own \
+                             test-patch file paths and test names) into the query and is forbidden \
+                             for submission/citable runs. To run a deliberately NON-CITABLE internal \
+                             upper-bound experiment, also set KIN_CONTEXTBENCH_ALLOW_NONCITABLE=1."
+                        );
+                    }
+                    eprintln!(
+                        "WARNING: KIN_CONTEXTBENCH_TEST_HINTS=1: query augmented with gold \
+                         test-patch hints; this run is NON-CITABLE (upper-bound experiment only)."
+                    );
                     augment_query_with_test_patch(trimmed, task)
                 } else {
                     trimmed.to_string()


### PR DESCRIPTION
## What

`contextbench locate`'s test-hints path (`KIN_CONTEXTBENCH_TEST_HINTS=1`) augments the locate query with the task's own gold `test_patch` file paths and test function names. That inflates recall/F1 and is only valid for internal upper-bound experiments — never for a citable/submission run.

## Problem

It was off by default but **unguarded**: a citable/submission run could enable it silently, and nothing marked the output as contaminated. A CI/harness accident or intentional use during a citable proof run would game the benchmark without being visible in the output JSON.

## Fix

Fail closed. `KIN_CONTEXTBENCH_TEST_HINTS=1` now **aborts** unless `KIN_CONTEXTBENCH_ALLOW_NONCITABLE=1` is also set (a deliberate double opt-in), and prints a loud `NON-CITABLE` warning when enabled. Default behavior and the direct `augment_query_with_test_patch` code path are unchanged — so a citable run can never silently contaminate the query.

## Test

15 `contextbench_locate` tests green, including `select_query_omits_test_patch_hints_by_default` and `augment_query_with_test_patch_appends_hints_when_opted_in`. The change touches only the env-gated branch in `select_query`.
