### PR TITLE
ci(release): add Cargo cache and promote macos-x86_64 to non-experimental

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -50,7 +50,6 @@ jobs:
             target: x86_64-apple-darwin
             artifact: kin-macos-x86_64
             shim_name: libkin_vfs_shim.dylib
-            experimental: true
           - os: macos-latest
             target: aarch64-apple-darwin
             artifact: kin-macos-aarch64
@@ -80,6 +79,18 @@ jobs:
         with:
           repository: firelock-ai/kin-vfs
           path: kin-vfs
+
+      - name: Cache Cargo registry and build artifacts
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            target
+            kin-vfs/target
+          key: ${{ runner.os }}-${{ matrix.target }}-cargo-${{ hashFiles('**/Cargo.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-${{ matrix.target }}-cargo-
 
       - name: Checkout kin-db (for Windows vector-free build)
         if: ${{ matrix.skip_vector }}


### PR DESCRIPTION
## Summary

- Add `actions/cache@v4` before build steps to cache `~/.cargo/registry`, `~/.cargo/git`, `target/`, and `kin-vfs/target/`
- Cache key: `<OS>-<target>-cargo-<Cargo.lock hash>`; restore key falls back to same OS+target
- Remove `experimental: true` from `kin-macos-x86_64` matrix entry — the root cause (stat64/lstat64/fstat64 conflicting-type declarations in `macos_interpose.c`) is fixed in `firelock-ai/kin-vfs`

## Expected impact

Cold release builds currently take ~3-4 h per matrix leg. On a cache hit the Cargo registry and incremental build artifacts are restored, reducing time to ~20-30 min.

## Test plan

- [ ] Release workflow runs all five matrix legs with cache step visible in logs
- [ ] `kin-macos-x86_64` Build kin-vfs (native) step passes (after kin-vfs fix merges)
- [ ] Cache hit shows restored bytes in subsequent runs
- [ ] Package and upload steps still produce correct artifacts