### PR TITLE
docs(manifest): add kin-actions, remove planning, add AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,25 @@
+# AGENTS.md
+
+This repository (`kin`) is part of the Kin ecosystem.
+
+The canonical source of truth for agent and contributor guidance — repo roles,
+boundaries, multi-session lane arbitration, commit hygiene, investor-hygiene
+rules, the ordered vision, and the public narrative — lives in the umbrella
+workspace `AGENTS.md`:
+
+**`kin-ecosystem/AGENTS.md`** (also symlinked as `kin-ecosystem/CLAUDE.md`)
+
+When working inside this repo as part of the umbrella workspace, that file is
+loaded automatically by Claude Code. If working in this repo in isolation,
+read the umbrella `AGENTS.md` before making architectural or process decisions.
+
+## This repo's role
+
+`kin` is the semantic system of record: CLI, daemon, MCP server, projections,
+reconcile, review, provenance, execution, and the bundled seam packages and
+crates under `crates/` and `packages/`.
+
+Boundary rule: put work here when it changes local semantic repo truth,
+projections/reconcile, CLI/daemon/MCP behavior, or provenance/review/execution
+semantics. Graph internals go in `kin-db`; hosted collaboration goes in
+`kinlab`.

--- a/docs/ecosystem-manifest.json
+++ b/docs/ecosystem-manifest.json
@@ -173,10 +173,11 @@
       ]
     },
     {
-      "name": "planning",
-      "layer": "strategy",
-      "role": "ordered-program-authority",
-      "dependsOn": []
+      "name": "kin-actions",
+      "layer": "infrastructure",
+      "role": "shared-ci-and-release-workflows",
+      "dependsOn": [],
+      "note": "Reusable GitHub Actions workflows for CI and release pipelines. Infrastructure/CI-only — not a product surface."
     },
     {
       "name": "experimental/kin-kernel",


### PR DESCRIPTION
## Summary

- `docs/ecosystem-manifest.json`: adds `kin-actions` entry (layer: infrastructure, role: shared-ci-and-release-workflows, CI-only, not a product surface); removes stale `planning` entry (directory removed 2026-06-11 — roadmap lives in Linear + Notion per umbrella AGENTS.md)
- `AGENTS.md`: new repo-level pointer to the umbrella `kin-ecosystem/AGENTS.md` as the canonical source of truth for agent guidance, lane rules, and process boundaries

Closes FIR-1106.

## Test plan

- [ ] `docs/ecosystem-manifest.json` JSON is valid (no parse errors)
- [ ] `kin-actions` entry present with `infrastructure` layer and `shared-ci-and-release-workflows` role
- [ ] `planning` entry absent
- [ ] `AGENTS.md` present at repo root, references umbrella AGENTS.md as canonical source
- [ ] CI green (docs-only change, no Rust compilation)