### PR TITLE
docs: add privacy policy, contribution governance, and daemon/VFS threat model

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -83,12 +83,79 @@ using the provided templates:
 For security vulnerabilities, do **not** open a public issue. Follow the
 private reporting process in [SECURITY.md](SECURITY.md).
 
+## Issue Triage and Response
+
+Kin is actively developed and pre-1.0, so issue triage is best-effort. The
+target is to **acknowledge new issues within three business days** —
+acknowledgement means an initial response (a label, a clarifying question, or a
+triage decision), not a fix or a committed delivery date. Bug reports that
+include a minimal reproduction and the `kin --version` output are usually
+triaged fastest.
+
+Security reports are handled separately and more urgently. Do not use the public
+issue tracker for them; follow [SECURITY.md](SECURITY.md).
+
 ## Repository Boundaries
 
 Kin is one repository within a larger ecosystem (`kin-db`, `kin-vfs`,
 `kinlab`, and others). Graph storage and retrieval internals live in `kin-db`;
 the filesystem projection lives in `kin-vfs`. If your change targets one of
 those concerns, open it against the repository that owns the code.
+
+## Releases and Security Disclosures
+
+Kin follows [Semantic Versioning](https://semver.org/). The project is currently
+pre-1.0, so it ships as `0.x` releases, and a minor version may include breaking
+changes to APIs and on-disk formats while the system stabilizes.
+
+Every release is documented in [CHANGELOG.md](CHANGELOG.md), which follows the
+[Keep a Changelog](https://keepachangelog.com/) format. Land user-facing changes
+with an entry under `[Unreleased]` (see [Pull Requests](#pull-requests)); cutting
+a release promotes those entries under a versioned, dated heading.
+
+Security vulnerabilities are not reported through the public issue tracker.
+Report them privately as described in [SECURITY.md](SECURITY.md), which also
+defines which versions receive fixes. Fixes ship in a new `0.x` release rather
+than as backports to older tags.
+
+## Contribution Sign-Off, IP, and AI Assistance
+
+### Sign-off (DCO)
+
+Every commit must carry a `Signed-off-by` trailer, added with `git commit -s`.
+The repository hooks add it when it is missing — don't bypass them with
+`--no-verify`. The sign-off is your Developer Certificate of Origin: by adding it
+you certify that you wrote the contribution, or otherwise have the right to
+submit it under the repository's license, and that you understand it becomes a
+public, permanent part of the project.
+
+### Contributor License Agreement
+
+External contributions also pass a lightweight CLA gate before merge. The check
+matches the pull request author against an allowlist of trusted accounts and the
+recorded signatures in [`signatures/cla.json`](signatures/cla.json); see
+[CLA.md](CLA.md). If you are a first-time external contributor, a maintainer will
+help you get recorded there.
+
+### IP ownership and AI assistance
+
+Contributions may be AI-assisted — Kin does not prohibit AI coding tools. But the
+human contributor remains the author of record and is fully responsible for the
+contribution:
+
+- **You assert ownership.** By signing off, you assert that you own or have the
+  right to submit the contribution under the [Apache License 2.0](LICENSE),
+  regardless of which tools helped produce it. Do not submit code that a tool
+  reproduced from license-incompatible sources.
+- **AI-generated code must be human-reviewed and owned.** Review, understand, and
+  test anything a tool generated before you submit it. You are accountable for it
+  exactly as if you had written every line yourself; "a tool wrote it" excuses
+  neither a bug, a license violation, nor a security flaw.
+- **Keep tool provenance out of commit metadata.** As noted under
+  [Branch Naming and Commit Hygiene](#branch-naming-and-commit-hygiene), commit
+  messages should describe the durable technical change. Leave AI-authorship
+  trailers, tool banners, and session identifiers out of public commit metadata;
+  if attribution matters for a change, record it in the pull request instead.
 
 ## License
 

--- a/PRIVACY.md
+++ b/PRIVACY.md
@@ -1,0 +1,122 @@
+# Privacy
+
+Kin is local-first. The semantic graph that Kin builds from your repository —
+entities, relations, snapshots, search and vector indexes — is stored on your
+own machine under the repository's `.kin/` directory. Running Kin does not send
+your code, your queries, or usage analytics to Firelock or any third party.
+
+This document describes the data Kin handles and the one optional, local-only
+telemetry feature that exists today. It covers the `kin` repository (the CLI,
+daemon, and MCP server). Hosted services such as KinLab are separate products
+with their own privacy terms.
+
+## What Kin Collects By Default
+
+By default, **nothing leaves your machine.**
+
+- There is no usage analytics, crash reporting, or "phone-home" behavior. Kin
+  does not contain a Segment, Sentry, PostHog, Amplitude, or similar client,
+  and it does not POST events to a Firelock-operated endpoint.
+- The daemon binds to loopback (`127.0.0.1`) by default and serves only local
+  clients. See [Daemon and Network Behavior](#daemon-and-network-behavior).
+- Operations you explicitly invoke may use the network because that is their
+  purpose — for example, fetching dependencies or publishing to a remote. Those
+  are user-initiated actions, not background collection.
+
+## Locate Telemetry (Opt-In, Local-Only)
+
+Kin includes one optional telemetry feature, scoped to the `kin locate`
+command, to help you understand and tune retrieval quality. It is **disabled by
+default** and, when disabled, is a complete no-op: no telemetry directory is
+created and `kin locate` behaves byte-for-byte as if the feature did not exist.
+
+When enabled, each `kin locate` query appends a single JSON line to a local
+spool file. **Nothing is ever uploaded.** No network connection and no daemon
+are involved in writing telemetry — it is a plain local file append.
+
+### Enabling It
+
+Telemetry turns on through either of two opt-in signals:
+
+- **Environment variable** — set `KIN_LOCATE_TELEMETRY` to a truthy value
+  (`1`, `true`, `yes`, or `on`).
+- **Consent marker file** — create the file `.kin/telemetry/consent` inside the
+  repository.
+
+The environment variable takes precedence when it is decisive: setting
+`KIN_LOCATE_TELEMETRY=0` (or `false`/`no`/`off`) forces telemetry **off** even
+if the consent marker file is present. When the environment variable is unset or
+not decisive, the presence of the consent marker governs. With neither signal,
+telemetry is off.
+
+The first time telemetry actually records an event in a process, Kin prints a
+one-time notice to stderr stating that telemetry is on, what it records, where
+it is stored, and how to disable and purge it.
+
+### What Is Recorded
+
+Each event is a `locate_query` record containing:
+
+- a schema version and the event timestamp (Unix milliseconds, UTC);
+- the **query text** you passed to `kin locate`;
+- the requested result limit (`max_files`);
+- the **ranked results** — for each: file path, rank, score, the scoring
+  signals that fired, and the top entity attributed to that file;
+- when you run `kin locate --explain`, the scoring track and the **funnel** of
+  pruned candidates (path, score, and the reason each was pruned).
+
+Because the query text and the matched file paths and entity names are recorded,
+treat the spool as you would your source: it can contain identifiers from your
+codebase. It stays local, but it is readable by anything that can read your
+repository.
+
+### Where It Is Stored
+
+Events are written as append-only [JSON Lines](https://jsonlines.org/) to
+day-bucketed files under the repository's `.kin/telemetry/` directory, named
+`locate-YYYY-MM-DD.jsonl` (UTC date). Writing telemetry is best-effort: if a
+write fails, Kin logs it at debug level and the `kin locate` result is
+unaffected.
+
+### Disabling It
+
+- Delete the consent marker: `rm .kin/telemetry/consent`, and/or
+- Set `KIN_LOCATE_TELEMETRY=0` in your environment.
+
+### Purging Collected Data
+
+Telemetry lives entirely in one directory, so you can purge it by deleting that
+directory:
+
+```sh
+rm -rf .kin/telemetry/
+```
+
+This removes both the recorded events and the consent marker. A dedicated
+`kin telemetry purge` subcommand is planned to make this a first-class
+operation; until it ships, deleting the directory is the supported way to purge.
+
+## Daemon and Network Behavior
+
+The Kin daemon is a local process. By default it binds to loopback
+(`127.0.0.1`) and is reachable only from your own machine; it does not transmit
+your repository contents or queries anywhere. Binding the daemon to a
+non-loopback address is refused unless an authentication token is configured, so
+the daemon is not exposed off-host by accident. See
+[docs/security/threat-model.md](docs/security/threat-model.md) for the full
+daemon trust boundary.
+
+## Hosted Services
+
+KinLab and any other hosted Kin services are separate products. When you choose
+to use a hosted service — for example to publish or collaborate — data you send
+to it is governed by that service's own terms, not by this document. The `kin`
+CLI, daemon, and MCP server described here do not enroll you in any hosted
+service on their own.
+
+## Questions
+
+If something about Kin's data handling is unclear or appears to contradict this
+document, please open an issue. For anything you believe is a security or
+privacy vulnerability, follow the private process in [SECURITY.md](SECURITY.md)
+instead of filing a public issue.

--- a/docs/security/threat-model.md
+++ b/docs/security/threat-model.md
@@ -149,7 +149,7 @@ process** and runs with that process's privileges. Two consequences follow:
   more-privileged process.
 
 The daemon-side counterpart of projection — materializing graph-owned files into
-a workspace for a session or an exec request — runs within the same same-user
+a workspace for a session or an exec request — runs within the same-user
 daemon trust boundary described above.
 
 ## Blob-Store Integrity

--- a/docs/security/threat-model.md
+++ b/docs/security/threat-model.md
@@ -1,0 +1,195 @@
+# Threat Model: Daemon and Filesystem Projection
+
+This document describes the security model of the parts of Kin that run as
+long-lived local processes or interpose on the operating system: the **Kin
+daemon** (its control API and the command-execution endpoint) and the
+**filesystem projection** that serves graph-backed content to ordinary tools. It
+describes behavior as it exists today, including the cases where a protection is
+provisioned but not enforced by default. Where a boundary is owned by another
+repository in the ecosystem, that is called out so the authority for the
+implementation is unambiguous.
+
+For how to report a suspected vulnerability, see [SECURITY.md](../../SECURITY.md).
+
+## Scope and Trust Model
+
+Kin's baseline trust boundary is the **local operating-system user account**. Kin
+trusts the user it runs as, the integrity of that user's filesystem, and the
+OS-level isolation between users and between a user's processes and other users'
+processes. A repository's graph, indexes, blobs, and configuration live under the
+repository's `.kin/` directory and are protected by ordinary filesystem
+permissions.
+
+The following are therefore **in scope** for this document:
+
+- the daemon's network exposure, request authentication, and cross-origin
+  defenses;
+- the daemon's command-execution capability and the conditions under which it
+  can run a shell;
+- the trust boundary of the filesystem projection (library interposition);
+- the integrity properties of the content-addressed blob store.
+
+The following are **out of scope** here:
+
+- hosted services such as KinLab, which run under their own operational security
+  model;
+- an attacker who already has code execution as the same OS user (that is inside
+  the trust boundary — see [Residual Risks](#residual-risks-and-hardening) for
+  the partial defenses that still apply);
+- physical access and full-disk compromise.
+
+## The Kin Daemon
+
+The daemon exposes an HTTP control API used by the CLI, the MCP server, and
+editor integrations. Three layers defend it: where it binds, a cross-origin
+guard, and an optional bearer token.
+
+### Network binding
+
+By default the daemon binds to loopback (`127.0.0.1`) and is reachable only from
+the local host. Binding to a non-loopback address is **refused** unless an
+authentication token is configured: the listener setup returns an error
+(`KIN_DAEMON_AUTH_TOKEN is required when binding to a non-loopback host`) when
+the resolved bind address is not a loopback address and no token is present. This
+prevents accidentally exposing an unauthenticated daemon off-host.
+
+### Cross-origin and DNS-rebinding guard
+
+A Host/Origin validation layer runs on **every** request, including the public
+package-registry routes. It enforces an allowlist of Host values
+(`localhost`, `127.0.0.1`, `::1`, and the configured bind host) and rejects
+anything else. A request that omits the `Host` header is rejected on sensitive
+routes; only the public liveness routes (`/health`, `/ready`, `/readiness`,
+`/spine/health`) remain reachable without a Host so that health-probe tooling is
+unaffected.
+
+This is the primary defense against a browser-driven DNS-rebinding attack: a web
+page cannot rebind a name to `127.0.0.1` and drive the loopback daemon, because
+the rebound request still carries the attacker's Host value and is rejected by
+the allowlist. This guard is always active, independent of whether bearer
+authentication is enabled.
+
+### Request authentication (bearer token)
+
+The daemon supports a per-install bearer token. On first run it auto-provisions a
+random token at `.kin/daemon.token` with owner-only permissions (`0600` on
+Unix); local clients read the same file and present it as
+`Authorization: Bearer <token>`. The authentication middleware is scoped to the
+daemon's own control routes — the package-registry routes (cargo/npm/oci/go) stay
+public so that build tooling, which does not send credentials on reads, can fetch
+from a token-protected daemon.
+
+Enforcement of the per-install token is **opt-in** and **off by default**:
+
+- With no configuration, the token file is provisioned (so clients can adopt it)
+  but the daemon does **not** require it. In this default state the daemon relies
+  on the loopback bind, the Host/Origin guard, and OS-level filesystem and
+  process isolation rather than on bearer authentication.
+- Setting `KIN_DAEMON_REQUIRE_TOKEN` to a truthy value makes the daemon enforce
+  the per-install token, returning `401` to requests that do not present it.
+- Setting `KIN_DAEMON_AUTH_TOKEN` to an explicit value always takes precedence
+  and is always enforced; this is also the token required to bind a non-loopback
+  address.
+
+### Resulting trust boundary
+
+In its default configuration the daemon's effective trust boundary is **any
+process running as the same OS user**: such a process can reach the loopback
+daemon and can read the `0600` token file. Cross-user access is blocked by file
+permissions, and remote/browser access is blocked by the loopback bind and the
+Host/Origin guard. Operators on shared or multi-tenant hosts should raise this
+boundary explicitly (see [Residual Risks](#residual-risks-and-hardening)).
+
+## Command Execution (`POST /commands/exec`)
+
+The daemon can run a shell command inside a graph-materialized workspace via the
+`POST /commands/exec` endpoint. This is the highest-risk capability the daemon
+exposes: if an unauthorized caller can reach the loopback daemon, an enabled exec
+endpoint is local remote-code-execution. It is therefore **disabled by default**
+and gated behind an explicit opt-in.
+
+The handler applies two checks before doing any work:
+
+1. If the daemon is not fully initialized, it returns `503 Service Unavailable`.
+2. If the exec capability is not enabled, it returns `403 Forbidden` with a
+   message instructing the operator to set `KIN_DAEMON_ALLOW_EXEC=1` to opt in.
+
+The capability is enabled only when `KIN_DAEMON_ALLOW_EXEC` is set to a truthy
+value (`1`, `true`, `yes`, or `on`); it is disabled in every other case,
+including when the variable is unset. When enabled, the request runs the supplied
+command through the system shell (`sh -c` on Unix) inside a per-request workspace
+materialized from the graph.
+
+**Operator guidance.** Leave exec disabled unless a specific workflow requires
+it. When it must be enabled, pair it with `KIN_DAEMON_REQUIRE_TOKEN` so the
+endpoint is also behind bearer authentication, and never enable exec on a daemon
+bound to a non-loopback address that local-network peers can reach.
+
+## Filesystem Projection (Library Interposition)
+
+Kin's transparent filesystem projection (the `kin-vfs` repository) serves
+graph-backed content to unmodified tools by interposing on libc file calls using
+the dynamic loader's preload mechanism (`LD_PRELOAD` on Linux,
+`DYLD_INSERT_LIBRARIES` on macOS). The projection's implementation and its
+detailed security properties are owned by `kin-vfs`; this section states the
+trust boundary as it pertains to running Kin.
+
+The interposition library is loaded **into the address space of the target
+process** and runs with that process's privileges. Two consequences follow:
+
+- **The shim is as trusted as the program it is injected into.** Because it
+  intercepts that process's file I/O, a user enabling projection for a tool is
+  extending that tool's trust to the projection library. Install the shim only
+  from a trusted build, exactly as you would any other code you run.
+- **Projection is per-user and per-process.** It is configured through the
+  environment of the processes a user launches; it does not grant cross-user
+  access and does not run with elevated privilege of its own. Consistent with the
+  platform loaders, preload-based interposition is ignored by the OS for
+  privileged (for example setuid) binaries, so it cannot be used to inject into a
+  more-privileged process.
+
+The daemon-side counterpart of projection — materializing graph-owned files into
+a workspace for a session or an exec request — runs within the same same-user
+daemon trust boundary described above.
+
+## Blob-Store Integrity
+
+Kin stores file and artifact content in a content-addressed blob store (the
+`kin-blobs` substrate). A blob's identity **is** the SHA-256 hash of its
+contents: blobs are keyed and read by that hash, and workspace snapshots derive a
+content hash over their materialized contents. Package artifacts served by the
+bundled registries (cargo/npm/oci) likewise carry SHA-256 digests.
+
+Content-addressing gives integrity by construction: changing a single byte of a
+blob changes its address, so stored content cannot be silently substituted under
+an existing key without producing a hash collision. Where a consumer re-derives
+or verifies the address on read, tampering is detectable rather than transparent.
+The storage substrate that performs reads and any read-time verification is
+`kin-blobs`; this repository consumes it and relies on those integrity
+properties.
+
+An attacker with write access to a repository's `.kin/` directory could modify
+stored blobs or graph state — but such an attacker already holds same-user
+filesystem access, which is inside the trust boundary. Content-addressing limits
+that actor to detectable substitution rather than silent tampering wherever
+addresses are re-verified.
+
+## Residual Risks and Hardening
+
+- **Shared and multi-tenant hosts.** The default same-user trust boundary means
+  any process running as your user can reach the loopback daemon. On hosts where
+  that is not an acceptable assumption, enable `KIN_DAEMON_REQUIRE_TOKEN` (or set
+  an explicit `KIN_DAEMON_AUTH_TOKEN`) and keep `KIN_DAEMON_ALLOW_EXEC` unset.
+- **Provisioned-but-unenforced token.** Because the per-install token is
+  provisioned but not enforced by default, do not assume bearer authentication is
+  active unless one of the enforcement variables above is set.
+- **Off-host exposure.** Binding the daemon to a non-loopback address requires a
+  token, but exposing it to a network still widens the attack surface
+  considerably; treat it as a deliberate, audited deployment choice and never
+  combine it with command execution.
+
+## Reporting
+
+Report suspected vulnerabilities privately through the process described in
+[SECURITY.md](../../SECURITY.md). Do not open a public issue for a suspected
+vulnerability.


### PR DESCRIPTION
## Summary

Adds public-facing privacy, governance, and security documentation ahead of the
public launch. All three documents describe current, source-verified behavior
rather than aspirations.

## Changes

- **PRIVACY.md** (new) — Documents Kin's local-first data handling: no usage
  analytics or phone-home by default, and the one optional, local-only telemetry
  feature, scoped to `kin locate`. Covers how it is opted into
  (`KIN_LOCATE_TELEMETRY` env or a `.kin/telemetry/consent` marker), exactly what
  each JSONL event records, where it is stored, and how to disable and purge it.
  Notes that purge is currently manual (delete `.kin/telemetry/`) with a
  `kin telemetry purge` subcommand planned.

- **CONTRIBUTING.md** (extended) — Three new sections in the existing tone:
  - *Issue Triage and Response* — best-effort target to acknowledge new issues
    within three business days.
  - *Releases and Security Disclosures* — Semantic Versioning, release notes via
    CHANGELOG.md (Keep a Changelog), and private security reporting via
    SECURITY.md.
  - *Contribution Sign-Off, IP, and AI Assistance* — the `Signed-off-by` (DCO)
    requirement and the CLA gate already wired in CI, plus an IP/AI clause:
    contributions may be AI-assisted, but the human contributor asserts
    ownership, signs off, and must human-review and own any AI-generated code.

- **docs/security/threat-model.md** (new) — A durable technical threat model of
  the daemon and filesystem-projection attack surface: the daemon's loopback bind
  and non-loopback token requirement, the always-on Host/Origin (DNS-rebinding)
  guard, the per-install bearer token and its opt-in enforcement, the
  `POST /commands/exec` capability (disabled by default; `403` unless
  `KIN_DAEMON_ALLOW_EXEC=1`; runs through `sh -c`), the library-interposition
  trust boundary of the projection (owned by `kin-vfs`), and the content-addressed
  blob store's integrity properties.

## Verification

Behavior in PRIVACY.md and the threat model was confirmed against the source, not
inferred from comments:

- Locate telemetry — `crates/kin-cli/src/commands/locate_telemetry.rs` and its
  wiring in `locate.rs`: default-off, opt-in, append-only local JSONL, no network.
- Exec gating — `crates/kin-daemon/src/api.rs` (`exec_capability_enabled`,
  `command_exec` returning `503`/`403`) and `crates/kin-runtime/src/exec.rs`
  (`sh -c`).
- Daemon trust boundary — `api.rs` (`daemon_auth`, `validate_host_and_origin`,
  `bind_listener`, loopback token at `.kin/daemon.token`, mode `0600`).
- No external analytics/phone-home client exists in the daemon or CLI paths.

Documentation only; no code changes. Relative links verified to resolve.
