### PR TITLE
ci: add parser fuzz targets and bounded fuzz workflow

### DIFF
--- a/.github/workflows/fuzz.yml
+++ b/.github/workflows/fuzz.yml
@@ -1,0 +1,105 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2026 Firelock, LLC
+
+# Bounded fuzzing of the tree-sitter parsing and language-adapter surface.
+#
+# The fuzz targets live in `fuzz/` and feed arbitrary bytes into kin-parser's
+# source-ingesting entry points:
+#   - parse_adapter: every built-in LanguageAdapter's parse + extract path.
+#   - parse_shallow: the C2 shallow parse path (parse_shallow_file).
+# The invariant under test is that the parser is total on arbitrary input -- it
+# returns a value or a handled error and never panics, crashes, or hits UB.
+#
+# Triggers:
+#   - pull_request touching the parser crate or the harness: a short smoke per
+#     target keeps regressions out of `main` without slowing every PR.
+#   - schedule (weekly): a longer bounded campaign for drift detection.
+#   - workflow_dispatch: on-demand runs.
+#
+# Every run has a hard `-max_total_time` wall-clock cap plus a per-input
+# `-timeout`, so neither a single pathological input nor the campaign as a whole
+# can hang the runner.
+
+name: Fuzz
+
+on:
+  pull_request:
+    branches: [main]
+    paths:
+      - "crates/kin-parser/**"
+      - "fuzz/**"
+      - ".github/workflows/fuzz.yml"
+  schedule:
+    # Mondays 06:00 UTC.
+    - cron: "0 6 * * 1"
+  workflow_dispatch:
+
+env:
+  CARGO_TERM_COLOR: always
+
+jobs:
+  fuzz:
+    name: cargo-fuzz (${{ matrix.target }})
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    strategy:
+      fail-fast: false
+      matrix:
+        target:
+          - parse_adapter
+          - parse_shallow
+    steps:
+      - uses: actions/checkout@v6
+
+      # kin-model resolves from the Kin sparse registry ([registries.kin]). The
+      # fuzz crate is detached from the kin workspace, but Cargo still discovers
+      # the tracked .cargo/config.toml by walking up from fuzz/, so the registry
+      # is configured exactly as for a normal kin build.
+      - name: Verify kin cargo registry config
+        run: |
+          test -f .cargo/config.toml
+          grep -q '^\[registries\.kin\]' .cargo/config.toml
+
+      # cargo-fuzz requires nightly (libFuzzer + -Zsanitizer).
+      - name: Install nightly toolchain
+        uses: dtolnay/rust-toolchain@nightly
+
+      - name: Cache cargo registry and fuzz build
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            fuzz/target
+          key: ${{ runner.os }}-parser-fuzz-${{ hashFiles('fuzz/Cargo.toml', 'crates/kin-parser/**') }}
+          restore-keys: |
+            ${{ runner.os }}-parser-fuzz-
+
+      - name: Install cargo-fuzz
+        run: cargo install cargo-fuzz --locked
+
+      - name: Build fuzz target
+        run: cargo +nightly fuzz build ${{ matrix.target }}
+
+      # Bounded campaign: 300s/target on the weekly schedule, 60s on PRs/dispatch.
+      # `-timeout` caps any single input; `-rss_limit_mb` guards against a runaway
+      # allocation aborting the runner. EVENT_NAME / TARGET are mapped through env
+      # (not interpolated into the shell) per GitHub Actions injection-hardening
+      # guidance.
+      - name: Run bounded fuzz campaign
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          TARGET: ${{ matrix.target }}
+        run: |
+          DURATION=60
+          if [ "$EVENT_NAME" = "schedule" ]; then DURATION=300; fi
+          cargo +nightly fuzz run "$TARGET" -- \
+            -max_total_time="$DURATION" -timeout=25 -rss_limit_mb=2048
+
+      - name: Upload crash artifacts on failure
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: fuzz-artifacts-${{ matrix.target }}
+          path: fuzz/artifacts/${{ matrix.target }}/
+          if-no-files-found: ignore

--- a/fuzz/.gitignore
+++ b/fuzz/.gitignore
@@ -1,0 +1,5 @@
+target
+corpus
+artifacts
+coverage
+Cargo.lock

--- a/fuzz/Cargo.toml
+++ b/fuzz/Cargo.toml
@@ -1,0 +1,52 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2026 Firelock, LLC
+
+# Fuzz harness for the tree-sitter parsing and language-adapter surface.
+#
+# These targets feed arbitrary bytes into kin-parser's two source-ingesting
+# entry points -- the full LanguageAdapter parse + extract path (every built-in
+# grammar) and the C2 shallow parse path -- asserting the parser is total on
+# arbitrary input: it returns a value or a handled error and never panics,
+# crashes, or hits undefined behavior.
+#
+# This package declares its own (empty) [workspace] table so it is detached from
+# the parent kin workspace and is built only by the Fuzz CI workflow, never by
+# the standard `cargo build --workspace` / clippy gate. kin-parser is pulled in
+# by path; its `workspace = true` dependency inheritance still resolves from the
+# kin workspace root, so kin-model resolves from the Kin registry exactly as in a
+# normal kin build (Cargo discovers the tracked .cargo/config.toml by walking up
+# from this directory).
+
+[package]
+name = "kin-parser-fuzz"
+version = "0.0.0"
+edition = "2021"
+license = "Apache-2.0"
+publish = false
+
+[package.metadata]
+cargo-fuzz = true
+
+[dependencies]
+libfuzzer-sys = "0.4"
+kin-parser = { path = "../crates/kin-parser" }
+kin-model = { version = "0.2.1", registry = "kin" }
+
+[workspace]
+
+[profile.release]
+debug = 1
+
+[[bin]]
+name = "parse_adapter"
+path = "fuzz_targets/parse_adapter.rs"
+test = false
+doc = false
+bench = false
+
+[[bin]]
+name = "parse_shallow"
+path = "fuzz_targets/parse_shallow.rs"
+test = false
+doc = false
+bench = false

--- a/fuzz/fuzz_targets/parse_adapter.rs
+++ b/fuzz/fuzz_targets/parse_adapter.rs
@@ -1,0 +1,33 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Firelock, LLC
+
+//! Fuzz the full language-adapter parse + extract path.
+//!
+//! Every built-in `LanguageAdapter` is handed the same arbitrary byte slice:
+//! `parse` turns it into a tree-sitter `Tree`, then `extract` walks that tree
+//! into entities and relations. Arbitrary input lands almost entirely on the
+//! error / partial-tree branches -- exactly where `utf8_text`, byte-range
+//! slicing, and name/identifier extraction are most likely to panic.
+//!
+//! Invariant: the adapter is total on arbitrary bytes. `parse` / `extract` may
+//! return an error, but must never panic, crash, or trigger undefined behavior.
+
+#![no_main]
+
+use kin_model::FilePathId;
+use kin_parser::AdapterRegistry;
+use libfuzzer_sys::fuzz_target;
+
+fuzz_target!(|data: &[u8]| {
+    let registry = AdapterRegistry::new();
+    let file_id = FilePathId::new("fuzz_input");
+
+    for lang in registry.supported_languages() {
+        let Some(adapter) = registry.get_by_language(lang) else {
+            continue;
+        };
+        if let Ok(tree) = adapter.parse(data) {
+            let _ = adapter.extract(&tree, data, &file_id);
+        }
+    }
+});

--- a/fuzz/fuzz_targets/parse_shallow.rs
+++ b/fuzz/fuzz_targets/parse_shallow.rs
@@ -1,0 +1,29 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Firelock, LLC
+
+//! Fuzz the C2 shallow parse path.
+//!
+//! `parse_shallow_file` looks up a tree-sitter grammar by language hint, parses
+//! arbitrary bytes, and runs the generic shallow extractor (top-level
+//! declaration / import classification plus file-level fingerprinting). It is
+//! the ingestion tier for languages that have a grammar but no full semantic
+//! adapter.
+//!
+//! Invariant: shallow parsing is total on arbitrary bytes for every supported
+//! hint -- it returns `Some(ShallowFile)` or `None`, never panicking or crashing.
+
+#![no_main]
+
+use kin_model::FilePathId;
+use kin_parser::parse_shallow_file;
+use libfuzzer_sys::fuzz_target;
+
+// Language hints accepted by `get_shallow_grammar`.
+const SHALLOW_HINTS: &[&str] = &["c", "cpp", "csharp", "ruby", "php", "swift"];
+
+fuzz_target!(|data: &[u8]| {
+    let file_id = FilePathId::new("fuzz_input");
+    for hint in SHALLOW_HINTS {
+        let _ = parse_shallow_file(data, &file_id, hint);
+    }
+});


### PR DESCRIPTION
## What

Adds a cargo-fuzz harness for the tree-sitter parsing and language-adapter surface in `kin-parser`, plus a bounded `Fuzz` CI workflow that runs it.

Two targets feed arbitrary bytes into the crate's source-ingesting entry points and assert the parser is **total** on arbitrary input — it returns a value or a handled error, and never panics, crashes, or hits undefined behavior:

- **`parse_adapter`** — every built-in `LanguageAdapter`'s `parse` + `extract` path. For each input, all grammars (TypeScript, JavaScript, Python, Go, Java, Rust, C, C++, C#, Ruby, PHP, Swift, Kotlin, HCL) parse the bytes and walk the resulting tree into entities/relations.
- **`parse_shallow`** — the C2 shallow parse path (`parse_shallow_file`) across every grammar exposed by `get_shallow_grammar` (c, cpp, csharp, ruby, php, swift).

## Structure

The harness mirrors the existing `kin-vfs` fuzz setup so tooling and CI match across the ecosystem:

- `fuzz/` is its own **detached** cargo workspace (empty `[workspace]` table), so it stays off the standard `cargo build --workspace` / clippy / test gate and is built only by the Fuzz workflow.
- `fuzz/Cargo.toml` depends on `kin-parser` by path; `kin-model` resolves from the Kin registry exactly as in a normal kin build (Cargo discovers the tracked `.cargo/config.toml` by walking up from `fuzz/`).

## CI

`.github/workflows/fuzz.yml` builds and runs each target under **hard caps** — `-max_total_time` (60s/target on pull requests, 300s on the weekly schedule), a per-input `-timeout`, and an RSS limit — so a run can never hang the runner. It triggers on pull requests touching `crates/kin-parser/**` or the harness, a weekly schedule, and `workflow_dispatch`. Never an unbounded run.

## Local verification

Built and ran both targets on nightly + cargo-fuzz 0.13.1:

- `cargo +nightly fuzz build` — both targets compile clean.
- `parse_adapter` — 43,790 runs over a 30s campaign, crash-free.
- `parse_shallow` — 53,983 runs over a 30s campaign, crash-free.

No crashes, panics, AddressSanitizer errors, or leaks. The bounded fuzz tier runs on this PR.
