### PR TITLE
chore: update Homebrew formula to v0.2.2

### DIFF
--- a/Formula/kin.rb
+++ b/Formula/kin.rb
@@ -1,31 +1,9 @@
 # SPDX-License-Identifier: Apache-2.0
 # Copyright 2026 Firelock, LLC
-#
-# =============================================================================
-#  DRAFT FORMULA — NOT YET INSTALLABLE
-# -----------------------------------------------------------------------------
-#  The `sha256` values below are PLACEHOLDERS, not real checksums. This formula
-#  is committed so the packaging shape is reviewable, but it will NOT install
-#  until a real tagged release exists and these are filled in.
-#
-#  Before publishing this to a Homebrew tap you MUST:
-#    1. Tag and publish a release (see .github/workflows/release.yml). Each
-#       release uploads `<asset>.tar.gz` and a matching `<asset>.tar.gz.sha256`.
-#    2. Set `version` below to that release tag, WITHOUT the leading "v"
-#       (e.g. tag v0.1.0-alpha.1  ->  version "0.1.0-alpha.1").
-#    3. Replace each placeholder `sha256` with the real hash, e.g.:
-#         curl -fsSL \
-#           https://github.com/firelock-ai/kin/releases/download/v0.1.0-alpha.1/kin-macos-aarch64.tar.gz.sha256
-#
-#  Do NOT paste a zero/dummy 64-hex hash to make `brew` proceed — that would
-#  silently install an unverified binary. A real release is the only fix; until
-#  then the obviously-non-hex placeholders below make `brew` fail fast on
-#  purpose.
-# =============================================================================
 class Kin < Formula
   desc "Semantic system of record for software work"
   homepage "https://github.com/firelock-ai/kin"
-  version "0.1.0-alpha.1" # TODO: set to the real released tag (no leading "v")
+  version "0.2.2"
   license "Apache-2.0"
 
   # macOS-only for now. The release also publishes Linux tarballs
@@ -35,13 +13,11 @@ class Kin < Formula
   on_macos do
     on_arm do
       url "https://github.com/firelock-ai/kin/releases/download/v#{version}/kin-macos-aarch64.tar.gz"
-      # TODO: real hash from kin-macos-aarch64.tar.gz.sha256
-      sha256 "REPLACE_WITH_RELEASE_SHA256_kin_macos_aarch64"
+      sha256 "7a222f929ce0984e5a4478cf4db9a4b53726b6fc62c25ae01f16adf5b40ccfe2"
     end
     on_intel do
       url "https://github.com/firelock-ai/kin/releases/download/v#{version}/kin-macos-x86_64.tar.gz"
-      # TODO: real hash from kin-macos-x86_64.tar.gz.sha256
-      sha256 "REPLACE_WITH_RELEASE_SHA256_kin_macos_x86_64"
+      sha256 "621230294d298b17f482daabe3f0b7fce4fc92f28b3b0e41ebebff9e2c77acff"
     end
   end
 


### PR DESCRIPTION
## Summary

Updates the kin Homebrew formula from the non-installable draft to the published
v0.2.2 release so the tap is installable on macOS.

- Bump `version` to `0.2.2`. The macOS asset URLs resolve through the existing
  `v#{version}` interpolation, so they now point at the v0.2.2 assets.
- Fill in the real per-platform `sha256` checksums for the macOS arm64 and
  x86_64 tarballs, taken from the v0.2.2 release.
- Remove the draft "not yet installable" placeholder header and TODO markers now
  that the formula installs from a tagged release.

## Verification

- `sha256` values cross-checked three ways and all agree: the release
  `checksums-sha256.txt`, the per-asset `.tar.gz.sha256` files, and a fresh
  `shasum -a 256` of the downloaded tarballs.
- macOS asset URLs return HTTP 200 from the public release with no auth.
- `brew style` and `brew audit --strict` both pass with no offenses (run with the
  formula in a local tap so the formula-aware cops apply).

## Scope

macOS only, matching the existing formula structure. Linux users continue to use
the curl|sh installer and Windows users WSL2; the release still publishes those
assets.
