### PR TITLE
test(eject): prove plain-git round-trip fidelity and guard partial snapshots

### DIFF
--- a/crates/kin-cli/src/commands/eject.rs
+++ b/crates/kin-cli/src/commands/eject.rs
@@ -16,6 +16,16 @@ use std::path::Path;
 /// file with the pre-init snapshot copy.  Requires typing "revert" to confirm
 /// (or --yes for non-interactive use).  A backup of current files is written
 /// to `.kin-backup-eject-<timestamp>/` in the project root before any mutation.
+///
+/// Scope guarantee — what eject does NOT touch:
+/// - `.git/` and Git history are never read, rewritten, or restored by Kin.
+///   Kin snapshots the *working tree* at init (excluding `.git`, `.kin*`, and
+///   ignored paths); eject restores those files only.  Commit history is and
+///   always was owned by Git, so after eject the repository is a plain Git repo
+///   with its history intact.
+/// - --revert-files refuses to run against a truncated/partial snapshot: it
+///   verifies the snapshot file count against the manifest first and bails
+///   before any mutation, so a corrupt snapshot never silently strands files.
 pub async fn run(revert_files: bool, yes: bool) -> Result<()> {
     let cwd = std::env::current_dir()?;
     let layout =
@@ -52,6 +62,20 @@ fn run_with_layout(layout: &KinLayout, revert_files: bool, yes: bool) -> Result<
     };
 
     let file_count = manifest["file_count"].as_u64().unwrap_or(0);
+
+    // Verify the snapshot is complete BEFORE touching any working file. A
+    // truncated or partially-deleted snapshot must fail loudly here — never
+    // half-restore and then delete .kin/, which would silently strand files at
+    // their post-init content with no path back to pre-init state.
+    let snapshot_file_count = count_snapshot_files(&snapshot_dir, &snapshot_dir)?;
+    if snapshot_file_count != file_count {
+        bail!(
+            "Snapshot is incomplete: manifest records {file_count} file(s) but the snapshot \
+             directory contains {snapshot_file_count}. Refusing to revert from a partial \
+             snapshot — your working files have NOT been touched. Run without --revert-files \
+             to remove Kin while leaving every working file exactly as it is."
+        );
+    }
 
     // Require typed confirmation unless --yes.
     if !yes {
@@ -200,6 +224,35 @@ fn restore_files(
         }
     }
     Ok(())
+}
+
+/// Count the user files present in the snapshot, mirroring `restore_files`'
+/// walk (the top-level `manifest.json` is metadata and is not counted). Used to
+/// detect a truncated or partially-deleted snapshot before any destructive
+/// restore begins.
+fn count_snapshot_files(snapshot_root: &Path, current: &Path) -> Result<u64> {
+    let mut count = 0u64;
+    for entry in fs::read_dir(current)? {
+        let entry = entry?;
+        let path = entry.path();
+
+        if path
+            .file_name()
+            .map(|f| f == "manifest.json")
+            .unwrap_or(false)
+            && path.parent() == Some(snapshot_root)
+        {
+            continue;
+        }
+
+        let ft = entry.file_type()?;
+        if ft.is_dir() {
+            count += count_snapshot_files(snapshot_root, &path)?;
+        } else if ft.is_file() {
+            count += 1;
+        }
+    }
+    Ok(count)
 }
 
 // ── Daemon helpers ────────────────────────────────────────────────────────────
@@ -393,6 +446,55 @@ mod tests {
             fs::read_to_string(backup_dir.join("src/main.rs")).unwrap(),
             "fn current() {}",
             "backup must contain the pre-mutation src/main.rs"
+        );
+    }
+
+    /// A truncated snapshot (manifest count > files present) must fail loudly
+    /// BEFORE any mutation: .kin/ stays, working files are untouched, and no
+    /// backup is created.
+    #[test]
+    fn revert_files_fails_loud_on_partial_snapshot() {
+        let dir = tempfile::tempdir().unwrap();
+        let root = dir.path();
+        setup_fake_repo(root);
+
+        // Post-init working content the user would lose if we half-reverted.
+        fs::write(root.join("README.md"), "current content").unwrap();
+        fs::create_dir_all(root.join("src")).unwrap();
+        fs::write(root.join("src/main.rs"), "fn current() {}").unwrap();
+
+        // Truncate the snapshot: manifest still claims 2 files but one is gone.
+        fs::remove_file(root.join(".kin/snapshot/src/main.rs")).unwrap();
+
+        let layout = KinLayout::discover(root).unwrap();
+        let result = run_with_layout(&layout, true, true);
+
+        assert!(result.is_err(), "partial snapshot must fail loudly");
+        assert!(
+            root.join(".kin").exists(),
+            ".kin/ must remain after a refused revert"
+        );
+        assert_eq!(
+            fs::read_to_string(root.join("README.md")).unwrap(),
+            "current content",
+            "working files must be untouched after a refused revert"
+        );
+        assert_eq!(
+            fs::read_to_string(root.join("src/main.rs")).unwrap(),
+            "fn current() {}"
+        );
+        let backups = fs::read_dir(root)
+            .unwrap()
+            .filter_map(|e| e.ok())
+            .filter(|e| {
+                e.file_name()
+                    .to_string_lossy()
+                    .starts_with(".kin-backup-eject-")
+            })
+            .count();
+        assert_eq!(
+            backups, 0,
+            "no backup should be created when revert is refused pre-mutation"
         );
     }
 

--- a/crates/kin-cli/src/main.rs
+++ b/crates/kin-cli/src/main.rs
@@ -95,6 +95,10 @@ enum Command {
     /// file with the pre-init snapshot copy, destroying any uncommitted changes.
     /// Requires typing "revert" to confirm unless --yes is also given.
     /// A backup of current files is created before any mutation.
+    ///
+    /// Eject never touches .git: Kin only restores files it snapshotted at init,
+    /// and Git history is left intact. After eject the directory is a plain Git
+    /// repository again.
     Eject {
         /// DESTRUCTIVE: overwrite working files with the pre-init snapshot and
         /// delete the Kin graph. Requires typing "revert" to confirm (or --yes).

--- a/crates/kin-cli/tests/eject_round_trip.rs
+++ b/crates/kin-cli/tests/eject_round_trip.rs
@@ -1,0 +1,363 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Firelock, LLC
+
+//! Eject conviction suite: "you can always leave".
+//!
+//! These tests drive the real `kin` binary end-to-end over a real Git repo to
+//! prove the load-bearing adoption promise — a team can remove Kin any day and
+//! be left with a plain, intact Git repository.
+//!
+//! What is proven here:
+//! - `kin eject` (default) removes Kin and leaves every working file and the
+//!   entire `.git` directory byte-for-byte intact.
+//! - `kin eject --revert-files` restores the working tree to its exact pre-init
+//!   bytes (a faithful round-trip), backs up the pre-eject files first, and
+//!   leaves `.git` intact.
+//! - A corrupt or partial snapshot fails loudly and mutates nothing — Kin never
+//!   silently strands files.
+//!
+//! Honest scope: Kin never reads, rewrites, or restores Git history. It
+//! snapshots the working tree at init (excluding `.git`, `.kin*`, and ignored
+//! paths) and restores those files only. Commit history is owned by Git the
+//! whole time, which is exactly why these tests assert `.git` is untouched
+//! rather than re-imported.
+
+use std::collections::BTreeMap;
+use std::fs;
+use std::path::Path;
+use std::process::{Command, Output};
+use tempfile::tempdir;
+
+/// Run a git command in `dir` and assert it succeeds.
+fn git(dir: &Path, args: &[&str]) -> Output {
+    let output = Command::new("git")
+        .args(args)
+        .current_dir(dir)
+        .output()
+        .expect("run git command");
+    assert!(
+        output.status.success(),
+        "git {args:?} failed: stdout={} stderr={}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+    output
+}
+
+/// Run a git command in `dir` and return its exit status without asserting.
+fn git_status_code(dir: &Path, args: &[&str]) -> i32 {
+    Command::new("git")
+        .args(args)
+        .current_dir(dir)
+        .output()
+        .expect("run git command")
+        .status
+        .code()
+        .unwrap_or(-1)
+}
+
+/// Run the real `kin` binary in `dir` with a fully hermetic environment:
+/// an isolated registry file and the warm-init cache disabled, so the test
+/// never touches `~/.kin` or any other global state.
+fn run_kin(dir: &Path, registry: &Path, args: &[&str]) -> Output {
+    Command::new(env!("CARGO_BIN_EXE_kin"))
+        .args(args)
+        .current_dir(dir)
+        .env("KIN_REGISTRY_PATH", registry)
+        .env("KIN_INIT_WARM_CACHE", "0")
+        .output()
+        .expect("run kin binary")
+}
+
+fn run_kin_ok(dir: &Path, registry: &Path, args: &[&str]) -> Output {
+    let output = run_kin(dir, registry, args);
+    assert!(
+        output.status.success(),
+        "kin {args:?} failed: stdout={} stderr={}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+    output
+}
+
+/// `git rev-parse HEAD`.
+fn head_sha(repo: &Path) -> String {
+    String::from_utf8_lossy(&git(repo, &["rev-parse", "HEAD"]).stdout)
+        .trim()
+        .to_string()
+}
+
+/// The set of Git-tracked files mapped to their exact on-disk bytes. This is
+/// the "original git checkout" baseline we round-trip against.
+fn tracked_file_bytes(repo: &Path) -> BTreeMap<String, Vec<u8>> {
+    let listing = git(repo, &["ls-files"]).stdout;
+    let listing = String::from_utf8(listing).expect("git ls-files is utf-8 paths");
+    let mut map = BTreeMap::new();
+    for rel in listing.lines().filter(|line| !line.trim().is_empty()) {
+        let bytes = fs::read(repo.join(rel)).unwrap_or_else(|e| panic!("read tracked {rel}: {e}"));
+        map.insert(rel.to_string(), bytes);
+    }
+    assert!(!map.is_empty(), "seed repo should have tracked files");
+    map
+}
+
+/// Build a small, real Git repo with text and binary content, all committed.
+fn seed_repo(repo: &Path) {
+    fs::create_dir_all(repo).expect("create repo dir");
+    git(repo, &["init", "-q"]);
+    git(repo, &["config", "user.email", "kin@example.com"]);
+    git(repo, &["config", "user.name", "Kin Test"]);
+    git(repo, &["config", "commit.gpgsign", "false"]);
+
+    fs::write(repo.join("README.md"), "# Demo\n\nHello, Kin.\n").unwrap();
+    fs::create_dir_all(repo.join("src")).unwrap();
+    fs::write(
+        repo.join("src/lib.rs"),
+        "pub fn greet(name: &str) -> String {\n    format!(\"hi {name}\")\n}\n",
+    )
+    .unwrap();
+    fs::write(
+        repo.join("src/main.rs"),
+        "fn main() {\n    println!(\"{}\", demo::greet(\"world\"));\n}\n",
+    )
+    .unwrap();
+    fs::create_dir_all(repo.join("docs")).unwrap();
+    fs::write(repo.join("docs/guide.md"), "Guide.\n\n- one\n- two\n").unwrap();
+
+    // A binary file with non-UTF-8 bytes proves byte-fidelity beyond text.
+    fs::create_dir_all(repo.join("assets")).unwrap();
+    let mut blob: Vec<u8> = (0u8..=255).collect();
+    blob.extend_from_slice(&[0xDE, 0xAD, 0xBE, 0xEF, 0x00, 0x10]);
+    fs::write(repo.join("assets/blob.bin"), &blob).unwrap();
+
+    git(repo, &["add", "-A"]);
+    git(repo, &["commit", "-q", "-m", "seed repo"]);
+    git(repo, &["branch", "-M", "main"]);
+}
+
+/// Assert `.git` is structurally intact and on the same commit as `before`.
+fn assert_git_intact(repo: &Path, before_head: &str) {
+    assert_eq!(
+        head_sha(repo),
+        before_head,
+        "HEAD must be unchanged — Kin never rewrites Git history"
+    );
+    assert_eq!(
+        git_status_code(repo, &["fsck", "--full", "--strict"]),
+        0,
+        "git fsck must pass — .git must be untouched and intact"
+    );
+    // The commit and its log are still readable as a plain Git repo.
+    let log = git(repo, &["log", "--oneline"]).stdout;
+    assert!(
+        String::from_utf8_lossy(&log).contains("seed repo"),
+        "commit history must survive eject"
+    );
+}
+
+/// Default `kin eject` removes Kin and leaves the working tree and `.git`
+/// byte-for-byte intact.
+#[test]
+fn default_eject_preserves_git_history_and_working_tree() {
+    let root = tempdir().expect("temp root");
+    let repo = root.path().join("repo");
+    let registry = root.path().join("registry.toml");
+    seed_repo(&repo);
+
+    let head_before = head_sha(&repo);
+    let bytes_before = tracked_file_bytes(&repo);
+
+    run_kin_ok(&repo, &registry, &["init", "--no-lsp", "."]);
+    assert!(repo.join(".kin").is_dir(), "init must create .kin/");
+    assert!(
+        repo.join(".kin/snapshot/manifest.json").is_file(),
+        "init must write the pre-init snapshot manifest"
+    );
+
+    run_kin_ok(&repo, &registry, &["eject"]);
+
+    assert!(
+        !repo.join(".kin").exists(),
+        ".kin/ must be removed by eject"
+    );
+    assert!(
+        no_kin_residue(&repo),
+        "no .kin* residue may remain after eject"
+    );
+    assert_eq!(
+        tracked_file_bytes(&repo),
+        bytes_before,
+        "every working file must be byte-identical after default eject"
+    );
+    assert_git_intact(&repo, &head_before);
+    // A clean working tree: default eject creates no backup and no stray files.
+    assert!(
+        git(&repo, &["status", "--porcelain"]).stdout.is_empty(),
+        "working tree must be clean after default eject"
+    );
+}
+
+/// `kin eject --revert-files` restores the working tree to its exact pre-init
+/// bytes even after edits, backs up the pre-eject files, and leaves `.git`
+/// intact.
+#[test]
+fn revert_files_round_trips_to_pre_init_bytes() {
+    let root = tempdir().expect("temp root");
+    let repo = root.path().join("repo");
+    let registry = root.path().join("registry.toml");
+    seed_repo(&repo);
+
+    let head_before = head_sha(&repo);
+    let bytes_before = tracked_file_bytes(&repo);
+
+    run_kin_ok(&repo, &registry, &["init", "--no-lsp", "."]);
+
+    // Simulate real work done while living in Kin: edit tracked files on disk.
+    let edited_lib = "pub fn greet(name: &str) -> String {\n    format!(\"HELLO {name}!!!\")\n}\n";
+    fs::write(repo.join("src/lib.rs"), edited_lib).unwrap();
+    fs::write(repo.join("README.md"), "# Demo (edited under Kin)\n").unwrap();
+    assert_ne!(
+        fs::read(repo.join("src/lib.rs")).unwrap(),
+        bytes_before["src/lib.rs"],
+        "precondition: file was actually edited"
+    );
+
+    run_kin_ok(&repo, &registry, &["eject", "--revert-files", "--yes"]);
+
+    assert!(
+        !repo.join(".kin").exists(),
+        ".kin/ must be removed by eject"
+    );
+    assert_eq!(
+        tracked_file_bytes(&repo),
+        bytes_before,
+        "every working file must round-trip to its exact pre-init bytes"
+    );
+    assert_git_intact(&repo, &head_before);
+
+    // The pre-eject (edited) content is preserved in a backup, never lost.
+    let backup = find_backup_dir(&repo).expect("a backup dir must be created");
+    assert_eq!(
+        fs::read_to_string(backup.join("src/lib.rs")).unwrap(),
+        edited_lib,
+        "backup must hold the pre-eject edited content"
+    );
+}
+
+/// A missing snapshot directory fails loudly and mutates nothing.
+#[test]
+fn revert_files_fails_loud_on_missing_snapshot() {
+    let (root, repo, registry) = init_repo();
+    fs::remove_dir_all(repo.join(".kin/snapshot")).unwrap();
+    let head_before = head_sha(&repo);
+    let bytes_before = tracked_file_bytes(&repo);
+
+    let out = run_kin(&repo, &registry, &["eject", "--revert-files", "--yes"]);
+    assert_refused(&out, "No snapshot found");
+    assert!(
+        repo.join(".kin").exists(),
+        ".kin/ must remain after refusal"
+    );
+    assert_eq!(tracked_file_bytes(&repo), bytes_before, "files untouched");
+    assert_git_intact(&repo, &head_before);
+    drop(root);
+}
+
+/// A missing manifest fails loudly and mutates nothing.
+#[test]
+fn revert_files_fails_loud_on_missing_manifest() {
+    let (root, repo, registry) = init_repo();
+    fs::remove_file(repo.join(".kin/snapshot/manifest.json")).unwrap();
+    let head_before = head_sha(&repo);
+    let bytes_before = tracked_file_bytes(&repo);
+
+    let out = run_kin(&repo, &registry, &["eject", "--revert-files", "--yes"]);
+    assert_refused(&out, "manifest missing");
+    assert!(
+        repo.join(".kin").exists(),
+        ".kin/ must remain after refusal"
+    );
+    assert_eq!(tracked_file_bytes(&repo), bytes_before, "files untouched");
+    assert_git_intact(&repo, &head_before);
+    drop(root);
+}
+
+/// A truncated/partial snapshot (fewer files than the manifest records) fails
+/// loudly before any mutation: nothing restored, nothing deleted, no backup.
+#[test]
+fn revert_files_fails_loud_on_partial_snapshot() {
+    let (root, repo, registry) = init_repo();
+    // Delete one file's snapshot copy so the manifest count no longer matches.
+    fs::remove_file(repo.join(".kin/snapshot/src/lib.rs")).unwrap();
+    let head_before = head_sha(&repo);
+    let bytes_before = tracked_file_bytes(&repo);
+
+    let out = run_kin(&repo, &registry, &["eject", "--revert-files", "--yes"]);
+    assert_refused(&out, "incomplete");
+    assert!(
+        repo.join(".kin").exists(),
+        ".kin/ must remain after refusal"
+    );
+    assert_eq!(tracked_file_bytes(&repo), bytes_before, "files untouched");
+    assert!(
+        find_backup_dir(&repo).is_none(),
+        "no backup may be created when revert is refused pre-mutation"
+    );
+    assert_git_intact(&repo, &head_before);
+    drop(root);
+}
+
+// ── shared helpers ──────────────────────────────────────────────────────────
+
+/// Seed a repo and run `kin init`, returning (tempdir, repo, registry).
+/// The tempdir is returned so it outlives the test body.
+fn init_repo() -> (tempfile::TempDir, std::path::PathBuf, std::path::PathBuf) {
+    let root = tempdir().expect("temp root");
+    let repo = root.path().join("repo");
+    let registry = root.path().join("registry.toml");
+    seed_repo(&repo);
+    run_kin_ok(&repo, &registry, &["init", "--no-lsp", "."]);
+    (root, repo, registry)
+}
+
+/// Assert an eject invocation was refused (non-zero exit) with a clear message.
+fn assert_refused(out: &Output, expect_substr: &str) {
+    assert!(
+        !out.status.success(),
+        "eject should have failed but succeeded: stdout={} stderr={}",
+        String::from_utf8_lossy(&out.stdout),
+        String::from_utf8_lossy(&out.stderr)
+    );
+    let combined = format!(
+        "{}{}",
+        String::from_utf8_lossy(&out.stdout),
+        String::from_utf8_lossy(&out.stderr)
+    );
+    assert!(
+        combined
+            .to_lowercase()
+            .contains(&expect_substr.to_lowercase()),
+        "error message should mention {expect_substr:?}; got: {combined}"
+    );
+}
+
+/// True when no `.kin*` entry remains in the repo root.
+fn no_kin_residue(repo: &Path) -> bool {
+    fs::read_dir(repo)
+        .expect("read repo dir")
+        .filter_map(|e| e.ok())
+        .all(|e| !e.file_name().to_string_lossy().starts_with(".kin"))
+}
+
+/// Find the single `.kin-backup-eject-*` directory, if any.
+fn find_backup_dir(repo: &Path) -> Option<std::path::PathBuf> {
+    fs::read_dir(repo)
+        .ok()?
+        .filter_map(|e| e.ok())
+        .map(|e| e.path())
+        .find(|p| {
+            p.file_name()
+                .map(|n| n.to_string_lossy().starts_with(".kin-backup-eject-"))
+                .unwrap_or(false)
+        })
+}

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -383,10 +383,31 @@ normal use. The escape hatches:
 
 ## 10. Removing Kin
 
-Kin is ejectable — there is no data lock-in:
+Kin is ejectable — there is no data lock-in. There are two modes, and they
+do different things:
 
 ```sh
-kin eject [--force]
+kin eject                 # safe default
 ```
 
-This removes Kin and restores files to their pre-init state.
+Stops the Kin daemon and removes the `.kin/` directory (the graph and all Kin
+metadata). **Your working files are left exactly as they are** — whatever is on
+disk right now stays on disk. This is the everyday "walk away with my files"
+path.
+
+```sh
+kin eject --revert-files  # destructive: restore the pre-init snapshot
+```
+
+Additionally overwrites every working file with the copy Kin snapshotted at
+`kin init`, discarding changes made since. It asks you to type `revert` to
+confirm (use `--yes` to skip the prompt in scripts), and it writes a timestamped
+backup of your current files to `.kin-backup-eject-<timestamp>/` first, so
+nothing is lost. If the snapshot is missing or incomplete, eject refuses and
+touches nothing rather than half-restoring.
+
+**What eject never touches: `.git`.** Kin snapshots your *working tree* at init
+(excluding `.git`, `.kin*`, and ignored paths) and restores those files only. It
+never reads, rewrites, or restores Git history — your commit history is owned by
+Git the entire time. After eject, the directory is a plain Git repository with
+its history intact; `git log`, `git status`, and `git fsck` all work unchanged.


### PR DESCRIPTION
## Why

Eject is the load-bearing trust promise of the adoption story — "you can always leave with your files any day" (FIR-892, and objection #10 on the Red Team page). The existing eject tests were all unit-level over a hand-built `.kin/snapshot`; nothing asserted `.git` integrity or proved a real `kin init` → `kin eject` round-trip. The public claim was broader than the test.

## What

**Conviction suite** (`crates/kin-cli/tests/eject_round_trip.rs`) — drives the real `kin` binary end-to-end over a real Git repo (text + binary files), fully hermetic (isolated registry, warm cache off, `--no-lsp`, no daemon, no GPU):

- `default_eject_preserves_git_history_and_working_tree` — `kin eject` removes Kin and leaves every working file **and the entire `.git`** byte-for-byte intact (`git fsck` passes, HEAD unchanged, working tree clean).
- `revert_files_round_trips_to_pre_init_bytes` — after edits made "while living in Kin", `kin eject --revert-files` restores the working tree to its **exact pre-init bytes**, backing up the pre-eject content first (nothing lost), `.git` intact.
- `revert_files_fails_loud_on_{missing_snapshot,missing_manifest,partial_snapshot}` — corrupt/partial snapshots fail loudly and mutate nothing.

**Hardening** (`eject.rs`) — eject now verifies snapshot completeness against the manifest **before any mutation**, so a truncated snapshot can never half-restore and strand files. Added a matching unit test.

**Honest scope docs** — corrected `docs/quickstart.md` §10 (it wrongly said the default eject "restores files to their pre-init state") and the `kin eject` help to state the precise guarantee: eject restores only the files Kin snapshotted at init and **never reads, rewrites, or restores Git history** — `kin git import` is intentionally disabled, and history was always Git's to own.

## Tests

- `cargo test -p kin-cli --lib commands::eject` → 8 passed
- `cargo test -p kin-cli --test eject_round_trip` → 5 passed

Closes FIR-892.