### PR TITLE
chore: bump kin-actions ref-pins to v0.1.7

### DIFF
--- a/.github/workflows/kin-dependency-wave.yml
+++ b/.github/workflows/kin-dependency-wave.yml
@@ -9,7 +9,7 @@ on:
 
 jobs:
   dependency-wave:
-    uses: firelock-ai/kin-actions/.github/workflows/cargo-dependency-wave.yml@v0.1.5
+    uses: firelock-ai/kin-actions/.github/workflows/cargo-dependency-wave.yml@v0.1.7
     with:
       manifests: Cargo.toml
       test-command: cargo check -p kin-core -p kin-cli -p kin-daemon -p kin-mcp


### PR DESCRIPTION
## Summary

Advance kin-actions ref-pins to v0.1.7, which includes the version-movement gate fix that scopes the bump requirement to release-affecting changes only. Prior to this, the gate failed non-releasing PRs (docs, tests, CI, chore changes) and required manual `--admin` overrides.

- `cargo-dependency-wave.yml` callers: v0.1.5 → v0.1.7

## Test plan

- [ ] CI uses the updated kin-actions ref on the next workflow run