### PR TITLE
test(kin-daemon): make macOS daemon-lifecycle tests deterministic

### DIFF
--- a/crates/kin-daemon/src/api.rs
+++ b/crates/kin-daemon/src/api.rs
@@ -7660,8 +7660,7 @@ mod tests {
     /// `KIN_DAEMON_AUTH_TOKEN`, `KIN_DAEMON_REQUIRE_TOKEN`) so their
     /// opposite expectations never race under the parallel test runner.
     fn env_test_lock() -> std::sync::MutexGuard<'static, ()> {
-        static LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
-        LOCK.lock().unwrap_or_else(|poisoned| poisoned.into_inner())
+        crate::test_env_lock()
     }
 
     #[tokio::test]

--- a/crates/kin-daemon/src/lib.rs
+++ b/crates/kin-daemon/src/lib.rs
@@ -111,3 +111,18 @@ pub use state::{ChangeType, DaemonEvent, DaemonState, LspEnrichmentMessage, LspE
 
 /// Re-export kin_spine so consumers (MCP server, API) can use it via kin_daemon.
 pub use kin_spine;
+
+/// Process-global serialization for tests that mutate shared `KIN_*` environment
+/// variables.
+///
+/// `std::env::set_var`/`remove_var` mutate one process-wide table that is not
+/// synchronized against concurrent reads on other test threads, and several
+/// `KIN_*` variables (notably `KIN_REGISTRY_PATH`) are read by code under test in
+/// more than one module. A single shared lock keeps every env-mutating test in
+/// this binary inside one serialization domain so their opposite expectations
+/// can never race the parallel test runner.
+#[cfg(test)]
+pub(crate) fn test_env_lock() -> std::sync::MutexGuard<'static, ()> {
+    static LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
+    LOCK.lock().unwrap_or_else(|poisoned| poisoned.into_inner())
+}

--- a/crates/kin-daemon/src/supervisor.rs
+++ b/crates/kin-daemon/src/supervisor.rs
@@ -410,9 +410,10 @@ pub async fn repo_daemon_registration_loop(
 // `KIN_DAEMON_*` env vars for `KIN_SUPERVISOR_*` and the `daemon.token` file for
 // `supervisor.token`, so the two surfaces stay symmetric.
 
-/// `.kin/supervisor.token` — auto-provisioned per-install loopback token.
-fn supervisor_token_path() -> PathBuf {
-    supervisor_dir().join(SUPERVISOR_TOKEN_FILE)
+/// `.kin/supervisor.token` — auto-provisioned per-install loopback token, under
+/// the given supervisor directory.
+fn supervisor_token_path(dir: &Path) -> PathBuf {
+    dir.join(SUPERVISOR_TOKEN_FILE)
 }
 
 /// Strip an optional `:port` suffix from a Host/authority value, correctly
@@ -600,8 +601,8 @@ fn auth_token_from_env() -> Option<String> {
 
 /// Load the per-install supervisor loopback token, generating and persisting one
 /// (mode 0600 on unix) on first run. Mirrors `api::ensure_loopback_token`.
-fn ensure_loopback_token() -> std::io::Result<String> {
-    let path = supervisor_token_path();
+fn ensure_loopback_token(dir: &Path) -> std::io::Result<String> {
+    let path = supervisor_token_path(dir);
     if let Ok(existing) = std::fs::read_to_string(&path) {
         let trimmed = existing.trim().to_string();
         if !trimmed.is_empty() {
@@ -640,11 +641,11 @@ fn loopback_token_enforced() -> bool {
 /// loopback token is auto-provisioned under `.kin/` (so local clients can adopt
 /// it) but only returned for enforcement when `KIN_SUPERVISOR_REQUIRE_TOKEN`
 /// is set. Mirrors `api::resolve_serve_auth_token`.
-fn resolve_serve_auth_token() -> Option<String> {
+fn resolve_serve_auth_token(dir: &Path) -> Option<String> {
     if let Some(env_token) = auth_token_from_env() {
         return Some(env_token);
     }
-    match ensure_loopback_token() {
+    match ensure_loopback_token(dir) {
         Ok(token) => loopback_token_enforced().then_some(token),
         Err(error) => {
             warn!(
@@ -888,7 +889,7 @@ pub async fn run_supervisor(port: u16, idle_timeout: Option<Duration>) -> std::i
     // which rejects a non-loopback daemon bind that has no auth token. The
     // Host/Origin guard is always active; the token is the second layer for
     // non-browser local/LAN callers.
-    let auth_token = resolve_serve_auth_token();
+    let auth_token = resolve_serve_auth_token(&supervisor_dir());
     if !addr.ip().is_loopback() && auth_token.is_none() {
         return Err(std::io::Error::new(
             std::io::ErrorKind::PermissionDenied,
@@ -2498,21 +2499,11 @@ mod tests {
     use axum::http::Request;
     use tower::ServiceExt;
 
-    /// Serialize tests that mutate process-global `KIN_SUPERVISOR_*` /
-    /// `KIN_REGISTRY_PATH` env so they cannot race. Mirrors `api::env_test_lock`.
+    /// Serialize tests that mutate process-global `KIN_SUPERVISOR_*` env so they
+    /// cannot race. Shares one lock with every other env-mutating test in this
+    /// binary (see `crate::test_env_lock`).
     fn env_test_lock() -> std::sync::MutexGuard<'static, ()> {
-        static LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
-        LOCK.lock().unwrap_or_else(|poisoned| poisoned.into_inner())
-    }
-
-    /// Point `supervisor_dir()` (via `KIN_REGISTRY_PATH`) at a unique temp dir so
-    /// `supervisor.token` provisioning is hermetic. Returns the `.kin` dir.
-    fn isolate_supervisor_dir() -> PathBuf {
-        let root = std::env::temp_dir().join(format!("kin-supervisor-test-{}", Uuid::new_v4()));
-        let kin_dir = root.join(".kin");
-        std::fs::create_dir_all(&kin_dir).unwrap();
-        std::env::set_var("KIN_REGISTRY_PATH", kin_dir.join("registry.toml"));
-        kin_dir
+        crate::test_env_lock()
     }
 
     #[tokio::test]
@@ -2726,19 +2717,25 @@ mod tests {
         let _env = env_test_lock();
         std::env::remove_var("KIN_SUPERVISOR_AUTH_TOKEN");
         std::env::remove_var("KIN_SUPERVISOR_REQUIRE_TOKEN");
-        let _kin_dir = isolate_supervisor_dir();
+
+        // Hermetic per-test supervisor directory, passed explicitly to the token
+        // helpers so the assertions never depend on the process-global
+        // `KIN_REGISTRY_PATH` (which other tests in this binary mutate
+        // concurrently). Mirrors `api::resolve_serve_auth_token_gates_enforcement`.
+        let dir = std::env::temp_dir().join(format!("kin-supervisor-token-{}", Uuid::new_v4()));
+        std::fs::create_dir_all(&dir).unwrap();
 
         // First provisioning persists a token; re-provisioning returns the SAME
         // token (mode 0600 on unix).
-        let token = ensure_loopback_token().unwrap();
+        let token = ensure_loopback_token(&dir).unwrap();
         assert!(!token.is_empty());
-        assert_eq!(ensure_loopback_token().unwrap(), token);
-        let on_disk = std::fs::read_to_string(supervisor_token_path()).unwrap();
+        assert_eq!(ensure_loopback_token(&dir).unwrap(), token);
+        let on_disk = std::fs::read_to_string(supervisor_token_path(&dir)).unwrap();
         assert_eq!(on_disk.trim(), token);
         #[cfg(unix)]
         {
             use std::os::unix::fs::PermissionsExt;
-            let mode = std::fs::metadata(supervisor_token_path())
+            let mode = std::fs::metadata(supervisor_token_path(&dir))
                 .unwrap()
                 .permissions()
                 .mode();
@@ -2747,21 +2744,23 @@ mod tests {
 
         // Default: enforcement OFF — the file is provisioned but not required, so
         // existing unauthenticated local clients keep working.
-        assert!(resolve_serve_auth_token().is_none());
+        assert!(resolve_serve_auth_token(&dir).is_none());
 
         // Opt-in via KIN_SUPERVISOR_REQUIRE_TOKEN returns the provisioned token.
         std::env::set_var("KIN_SUPERVISOR_REQUIRE_TOKEN", "1");
-        assert_eq!(resolve_serve_auth_token().as_deref(), Some(token.as_str()));
+        assert_eq!(
+            resolve_serve_auth_token(&dir).as_deref(),
+            Some(token.as_str())
+        );
 
         // An explicit KIN_SUPERVISOR_AUTH_TOKEN override always wins.
         std::env::set_var("KIN_SUPERVISOR_AUTH_TOKEN", "explicit-override");
         assert_eq!(
-            resolve_serve_auth_token().as_deref(),
+            resolve_serve_auth_token(&dir).as_deref(),
             Some("explicit-override")
         );
 
         std::env::remove_var("KIN_SUPERVISOR_AUTH_TOKEN");
         std::env::remove_var("KIN_SUPERVISOR_REQUIRE_TOKEN");
-        std::env::remove_var("KIN_REGISTRY_PATH");
     }
 }

--- a/crates/kin-daemon/tests/chaos_recovery.rs
+++ b/crates/kin-daemon/tests/chaos_recovery.rs
@@ -89,6 +89,32 @@ async fn wait_for_serving(port: u16) {
     }
 }
 
+async fn wait_for_path(path: &Path, what: &str, timeout: Duration) {
+    let deadline = Instant::now() + timeout;
+    loop {
+        if path.exists() {
+            return;
+        }
+        if Instant::now() >= deadline {
+            panic!("{what}: {} never appeared", path.display());
+        }
+        tokio::time::sleep(Duration::from_millis(50)).await;
+    }
+}
+
+async fn wait_for_path_removed(path: &Path, what: &str, timeout: Duration) {
+    let deadline = Instant::now() + timeout;
+    loop {
+        if !path.exists() {
+            return;
+        }
+        if Instant::now() >= deadline {
+            panic!("{what}: {} was never removed", path.display());
+        }
+        tokio::time::sleep(Duration::from_millis(50)).await;
+    }
+}
+
 async fn create_branch(port: u16, name: &str) {
     let client = reqwest::Client::new();
     let url = format!("http://127.0.0.1:{port}/graph/branches");
@@ -152,13 +178,19 @@ async fn daemon_exits_after_idle_timeout_and_removes_endpoint_files() {
     let repo = tempfile::tempdir().unwrap();
     init_repo(repo.path());
 
+    // A generous idle window (rather than a few seconds) keeps the daemon alive
+    // long enough to deterministically observe the endpoint files on a loaded CI
+    // runner before the idle timer fires and removes them.
+    let idle_timeout = Duration::from_secs(15);
+    let idle_secs = idle_timeout.as_secs().to_string();
+
     let port = free_port();
     let mut child = spawn_daemon_with_env(
         repo.path(),
         port,
         &[
             ("KIN_DAEMON_DISABLE_LSP", "1"),
-            ("KIN_DAEMON_IDLE_TIMEOUT_SECS", "5"),
+            ("KIN_DAEMON_IDLE_TIMEOUT_SECS", idle_secs.as_str()),
         ],
     );
 
@@ -166,10 +198,26 @@ async fn daemon_exits_after_idle_timeout_and_removes_endpoint_files() {
 
     let daemon_port = repo.path().join(".kin/daemon.port");
     let daemon_pid = repo.path().join(".kin/daemon.pid");
-    assert!(daemon_port.exists(), "daemon did not write port file");
-    assert!(daemon_pid.exists(), "daemon did not write pid file");
+    // Poll for the endpoint files instead of asserting they are present the
+    // instant the socket accepts: observing them can lag the socket becoming
+    // connectable on a loaded runner, and they must still be there before the
+    // idle timer removes them.
+    wait_for_path(
+        &daemon_port,
+        "daemon did not write port file",
+        Duration::from_secs(10),
+    )
+    .await;
+    wait_for_path(
+        &daemon_pid,
+        "daemon did not write pid file",
+        Duration::from_secs(10),
+    )
+    .await;
 
-    let exit = match tokio::time::timeout(Duration::from_secs(15), child.wait()).await {
+    // Wait for the idle timer to fire and the process to exit. The budget is far
+    // larger than the idle window so a slow runner's shutdown still fits.
+    let exit = match tokio::time::timeout(Duration::from_secs(90), child.wait()).await {
         Ok(result) => result.expect("kin-daemon wait failed"),
         Err(_) => {
             let _ = child.start_kill();
@@ -177,8 +225,21 @@ async fn daemon_exits_after_idle_timeout_and_removes_endpoint_files() {
         }
     };
     assert!(exit.success(), "idle shutdown should be graceful: {exit}");
-    assert!(!daemon_port.exists(), "idle daemon left daemon.port behind");
-    assert!(!daemon_pid.exists(), "idle daemon left daemon.pid behind");
+
+    // Graceful shutdown removes the endpoint files before the process exits; poll
+    // for their removal to tolerate any cleanup-vs-exit ordering gap.
+    wait_for_path_removed(
+        &daemon_port,
+        "idle daemon left daemon.port behind",
+        Duration::from_secs(10),
+    )
+    .await;
+    wait_for_path_removed(
+        &daemon_pid,
+        "idle daemon left daemon.pid behind",
+        Duration::from_secs(10),
+    )
+    .await;
 }
 
 #[tokio::test(flavor = "multi_thread")]


### PR DESCRIPTION
## Problem

Two `kin-daemon` daemon-lifecycle tests fail intermittently on loaded macOS CI runners while passing on Linux and on rerun — timing/teardown flakiness unrelated to product code, which taxes the merge queue.

- `supervisor::tests::supervisor_loopback_token_provisioned_persisted_and_enforced`
- `daemon_exits_after_idle_timeout_and_removes_endpoint_files` (`tests/chaos_recovery.rs`)

## Root causes & fixes

**Supervisor token test — shared-global path clobber.** The test derived its token path from the process-global `KIN_REGISTRY_PATH`, which other tests in the same unit-test binary (`api::tests`, via `install_test_registry_override`) rewrite concurrently and without a shared lock. Mid-test the token path could be swapped to another test's temp dir, corrupting the persistence/0600/enforcement assertions. The daemon-side twin (`resolve_serve_auth_token_gates_enforcement`) is stable precisely because it already passes an explicit path.

- Parameterize `supervisor_token_path` / `ensure_loopback_token` / `resolve_serve_auth_token` on an explicit directory (mirroring the daemon side); production `run_supervisor` passes `&supervisor_dir()`, so runtime behavior is unchanged.
- The test now uses a hermetic per-test directory and never reads `KIN_REGISTRY_PATH`.
- Collapse the two per-module `env_test_lock` mutexes into one process-wide `crate::test_env_lock`, so every env-mutating test in the binary serializes its `setenv` calls (the modules were already documented as mirrors).

**Idle-timeout test — tight window racing the idle timer.** The test used a 5s idle timeout and asserted the endpoint files were present the instant the socket accepted, racing the idle timer that removes them on a slow runner.

- Widen the idle window and size the exit-wait generously for a slow runner.
- Replace the immediate presence/absence asserts with bounded poll-for-condition loops (`wait_for_path` / `wait_for_path_removed`) — robust *when* we check, same *what* we check.

All original assertions (token provisioned/persisted/enforced; graceful idle exit; endpoint files cleaned up) are preserved; only the timing is made deterministic. No per-test sharing of temp dirs, sockets, or ports.

## Verification (local, macOS)

- Full `kin-daemon` lib suite (270 tests, supervisor token test running concurrently with the `KIN_REGISTRY_PATH`-churning api tests — the real flake scenario): **20/20** at default parallelism, **15/15** at `--test-threads=24`, plus **30/30** isolated runs of the supervisor test. Zero failures.
- Idle-timeout test: **12/12** sequential, **3/3** via the full chaos file, and **4/4** run in parallel (4 daemons + 4 test threads contending = loaded-runner simulation). Zero failures.
- `cargo fmt --check` clean; `cargo clippy` introduces no new warnings on the changed files.

A macOS-only flake can't be *proven* gone from local runs, but each race is removed structurally: the supervisor test no longer reads a concurrently-mutated global, and the idle test no longer assumes a duration where it should wait for a condition.