### PR TITLE
test(kin-daemon): fix all-features clippy regression in spine xref test

### DIFF
--- a/crates/kin-daemon/src/api.rs
+++ b/crates/kin-daemon/src/api.rs
@@ -9309,7 +9309,7 @@ mod tests {
             .expect("CLI get_spine_xref returns edges");
         let cli_xref_to_provider = cli_xref
             .iter()
-            .any(|e| e.dst_repo.to_string() == "provider");
+            .any(|e| e.dst_repo == "provider");
         assert!(
             cli_xref_to_provider,
             "kin xref CLI must resolve consumer->provider: {cli_xref:?}"


### PR DESCRIPTION
## Problem

The all-features clippy gate (`cargo clippy --all-targets --all-features -- -D warnings`) is currently red on `main`:

```
error: this creates an owned instance just for comparison
  --> crates/kin-daemon/src/api.rs  (spine_blast_radius_is_consistent_across_daemon_cli_and_mcp)
     .any(|e| e.dst_repo.to_string() == "provider");
  = note: `-D clippy::cmp-owned` implied by `-D warnings`
```

The cross-repo xref assertion converts an already-owned `RepoId` (a `String` alias) into a fresh `String` purely to compare it against a string literal. `cmp_owned` is not in the gate's allowlist, so it fails as a hard error. This surfaces in the merge-build of every PR (default features don't compile this assertion, so it slipped through).

## Fix

Compare directly — `e.dst_repo == "provider"` — dropping the needless allocation. One line, behavior identical.

## Verification

`cargo clippy --all-targets --all-features --workspace -- -D warnings <ci allowlist>` now passes with **zero errors** (previously failed with exactly this one).

This is a pre-existing regression introduced with the spine cross-repo test surface, unrelated to (but discovered during) the macOS daemon-lifecycle flake fix.