### PR TITLE
style: apply rustfmt to mcp.rs and daemon.rs

### DIFF
--- a/crates/kin-cli/src/commands/mcp.rs
+++ b/crates/kin-cli/src/commands/mcp.rs
@@ -95,7 +95,10 @@ mod tests {
     async fn global_flag_returns_clear_error() {
         let err = start(true).await.unwrap_err();
         let msg = err.to_string();
-        assert!(msg.contains("not yet implemented"), "unexpected message: {msg}");
+        assert!(
+            msg.contains("not yet implemented"),
+            "unexpected message: {msg}"
+        );
         assert!(msg.contains("--global"), "missing flag hint: {msg}");
     }
 }

--- a/crates/kin-daemon/src/daemon.rs
+++ b/crates/kin-daemon/src/daemon.rs
@@ -81,10 +81,7 @@ async fn wait_for_lsp_index(server: &kin_lsp::lifecycle::LspServer, max: Duratio
     loop {
         let probe = server
             .client
-            .request(
-                "workspace/symbol",
-                serde_json::json!({ "query": "" }),
-            )
+            .request("workspace/symbol", serde_json::json!({ "query": "" }))
             .await;
         if probe.is_ok() {
             return;
@@ -1505,7 +1502,8 @@ pub async fn run(mut state: DaemonState, config: DaemonConfig) -> Result<()> {
                                     {
                                         Ok(server) => {
                                             info!(language = %lang, "LSP server started for sweep, polling for readiness...");
-                                            wait_for_lsp_index(&server, Duration::from_secs(60)).await;
+                                            wait_for_lsp_index(&server, Duration::from_secs(60))
+                                                .await;
                                             info!(language = %lang, "LSP server ready");
                                             servers.insert(lang, server);
                                         }


### PR DESCRIPTION
Admin-merged PR #108 bypassed CI (private repo billing gate). Two files landed with minor formatting differences from what rustfmt produces. Run `cargo fmt` without code change to normalize.