### PR TITLE
style: collapse iterator chain onto one line in api.rs test

### DIFF
--- a/crates/kin-daemon/src/api.rs
+++ b/crates/kin-daemon/src/api.rs
@@ -9307,9 +9307,7 @@ mod tests {
             .await
             .expect("CLI get_spine_xref call")
             .expect("CLI get_spine_xref returns edges");
-        let cli_xref_to_provider = cli_xref
-            .iter()
-            .any(|e| e.dst_repo == "provider");
+        let cli_xref_to_provider = cli_xref.iter().any(|e| e.dst_repo == "provider");
         assert!(
             cli_xref_to_provider,
             "kin xref CLI must resolve consumer->provider: {cli_xref:?}"


### PR DESCRIPTION
Restores `cargo fmt -- --check` to a clean state on main.

A prior clippy cleanup removed a `.to_string()` in the `spine` cross-surface test, shortening the `cli_xref_to_provider` binding so rustfmt now wants it on a single line. It was left in the multi-line form, which made the "Check formatting" step fail and cancel the Check & Test job.

This collapses the binding to:

```rust
let cli_xref_to_provider = cli_xref.iter().any(|e| e.dst_repo == "provider");
```

Formatting only; no behavior change. `cargo fmt -- --check` now exits 0.