### PR TITLE
chore: release v0.2.3 (signed + notarized macOS binaries)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.2.3] - 2026-06-24
+
+Signed release. The macOS binaries are now code-signed with a Developer ID certificate and notarized by Apple.
+
+### Changed
+
+- The `kin-macos-x86_64` and `kin-macos-aarch64` archives are now code-signed (Developer ID Application) and notarized, so they launch without a Gatekeeper warning on first run.
+
 ## [0.2.2] - 2026-06-24
 
 Corrective release adding Intel Mac (`x86_64`) to the public install matrix.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2928,11 +2928,11 @@ dependencies = [
 
 [[package]]
 name = "kin-buildinfo"
-version = "0.2.2"
+version = "0.2.3"
 
 [[package]]
 name = "kin-cli"
-version = "0.2.2"
+version = "0.2.3"
 dependencies = [
  "age",
  "anyhow",
@@ -2997,7 +2997,7 @@ dependencies = [
 
 [[package]]
 name = "kin-context"
-version = "0.2.2"
+version = "0.2.3"
 dependencies = [
  "kin-blobs",
  "kin-db",
@@ -3013,7 +3013,7 @@ dependencies = [
 
 [[package]]
 name = "kin-core"
-version = "0.2.2"
+version = "0.2.3"
 dependencies = [
  "chrono",
  "directories 5.0.1",
@@ -3037,7 +3037,7 @@ dependencies = [
 
 [[package]]
 name = "kin-daemon"
-version = "0.2.2"
+version = "0.2.3"
 dependencies = [
  "async-stream",
  "axum",
@@ -3126,7 +3126,7 @@ dependencies = [
 
 [[package]]
 name = "kin-git"
-version = "0.2.2"
+version = "0.2.3"
 dependencies = [
  "chrono",
  "gix",
@@ -3144,7 +3144,7 @@ dependencies = [
 
 [[package]]
 name = "kin-index"
-version = "0.2.2"
+version = "0.2.3"
 dependencies = [
  "hex",
  "kin-blobs",
@@ -3190,7 +3190,7 @@ dependencies = [
 
 [[package]]
 name = "kin-integration-tests"
-version = "0.2.2"
+version = "0.2.3"
 dependencies = [
  "kin-blobs",
  "kin-cli",
@@ -3232,7 +3232,7 @@ dependencies = [
 
 [[package]]
 name = "kin-mcp"
-version = "0.2.2"
+version = "0.2.3"
 dependencies = [
  "kin-blobs",
  "kin-context",
@@ -3258,7 +3258,7 @@ dependencies = [
 
 [[package]]
 name = "kin-migrate"
-version = "0.2.2"
+version = "0.2.3"
 dependencies = [
  "chrono",
  "kin-blobs",
@@ -3300,7 +3300,7 @@ dependencies = [
 
 [[package]]
 name = "kin-parser"
-version = "0.2.2"
+version = "0.2.3"
 dependencies = [
  "kin-model",
  "pretty_assertions",
@@ -3329,7 +3329,7 @@ dependencies = [
 
 [[package]]
 name = "kin-projection"
-version = "0.2.2"
+version = "0.2.3"
 dependencies = [
  "kin-blobs",
  "kin-db",
@@ -3344,7 +3344,7 @@ dependencies = [
 
 [[package]]
 name = "kin-ranking"
-version = "0.2.2"
+version = "0.2.3"
 dependencies = [
  "kin-model",
  "serde",
@@ -3353,7 +3353,7 @@ dependencies = [
 
 [[package]]
 name = "kin-reconcile"
-version = "0.2.2"
+version = "0.2.3"
 dependencies = [
  "kin-blobs",
  "kin-db",
@@ -3373,7 +3373,7 @@ dependencies = [
 
 [[package]]
 name = "kin-registry"
-version = "0.2.2"
+version = "0.2.3"
 dependencies = [
  "axum",
  "base64 0.22.1",
@@ -3398,7 +3398,7 @@ dependencies = [
 
 [[package]]
 name = "kin-remote"
-version = "0.2.2"
+version = "0.2.3"
 dependencies = [
  "chrono",
  "kin-model",
@@ -3414,7 +3414,7 @@ dependencies = [
 
 [[package]]
 name = "kin-review"
-version = "0.2.2"
+version = "0.2.3"
 dependencies = [
  "kin-blobs",
  "kin-db",
@@ -3429,7 +3429,7 @@ dependencies = [
 
 [[package]]
 name = "kin-runtime"
-version = "0.2.2"
+version = "0.2.3"
 dependencies = [
  "chrono",
  "hex",
@@ -3461,7 +3461,7 @@ dependencies = [
 
 [[package]]
 name = "kin-semantic-contracts"
-version = "0.2.2"
+version = "0.2.3"
 dependencies = [
  "kin-db",
  "kin-model",
@@ -3476,7 +3476,7 @@ dependencies = [
 
 [[package]]
 name = "kin-spine"
-version = "0.2.2"
+version = "0.2.3"
 dependencies = [
  "chrono",
  "hashbrown 0.15.5",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,7 +27,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.2.2"
+version = "0.2.3"
 edition = "2021"
 license = "Apache-2.0"
 authors = ["Troy Fortin <troy@firelock.ai>"]

--- a/packages/kin-mcp/package.json
+++ b/packages/kin-mcp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kinlab/kin-mcp",
-  "version": "0.2.2",
+  "version": "0.2.3",
   "description": "Start Kin's MCP server through an npm-friendly wrapper.",
   "type": "module",
   "bin": {


### PR DESCRIPTION
Release v0.2.3.

The macOS release binaries (`x86_64` and `aarch64`) are now code-signed with a Developer ID Application certificate and notarized by Apple, so they launch without a Gatekeeper warning on first run.

Bumps the workspace version, the kin-mcp npm wrapper, and the CHANGELOG coherently (release-intent gate green). Merging to main cuts the `v0.2.3` tag via auto-tag-release, which triggers the signed + notarized release build and publish.

No code changes — release-surface bump only.