### PR TITLE
fix(release): static musl Linux binaries via rustls (drop OpenSSL)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -38,12 +38,19 @@ jobs:
       fail-fast: false
       matrix:
         include:
+          # Linux core binaries (kin, kin-daemon) target musl and link static by
+          # default, so a single artifact runs on any Linux distro: musl (Alpine)
+          # and glibc (Ubuntu/Debian/RHEL) alike, with no OpenSSL or glibc version
+          # coupling. The VFS leg builds against gnu (vfs_target) because an
+          # LD_PRELOAD shim is intrinsically libc-specific (see the VFS steps).
           - os: ubuntu-latest
-            target: x86_64-unknown-linux-gnu
+            target: x86_64-unknown-linux-musl
+            vfs_target: x86_64-unknown-linux-gnu
             artifact: kin-linux-x86_64
             shim_name: libkin_vfs_shim.so
           - os: ubuntu-24.04-arm
-            target: aarch64-unknown-linux-gnu
+            target: aarch64-unknown-linux-musl
+            vfs_target: aarch64-unknown-linux-gnu
             artifact: kin-linux-aarch64
             shim_name: libkin_vfs_shim.so
           - os: macos-latest
@@ -68,7 +75,16 @@ jobs:
       - name: Install Rust stable
         uses: dtolnay/rust-toolchain@1.96.0
         with:
-          targets: ${{ matrix.target }}
+          # On the Linux legs the core (kin, kin-daemon) targets musl and the VFS
+          # leg targets gnu (vfs_target), so both targets must be installed.
+          targets: ${{ matrix.target }}${{ matrix.vfs_target && format(' {0}', matrix.vfs_target) || '' }}
+
+      # musl-static C dependencies (ring, oniguruma, sqlite, tree-sitter) need a
+      # musl-targeting C compiler; musl-tools provides musl-gcc. Only the Linux
+      # musl legs require it.
+      - name: Install musl C toolchain (Linux musl)
+        if: ${{ contains(matrix.target, '-linux-musl') }}
+        run: sudo apt-get update && sudo apt-get install -y musl-tools
 
       - name: Install cross (ARM64)
         if: matrix.cross
@@ -144,10 +160,14 @@ jobs:
         working-directory: kin-vfs
         shell: bash
         run: |
-          cargo build --release --target "$TARGET" -p kin-vfs-cli
-          cargo build --release --target "$TARGET" -p kin-vfs-shim
+          # The VFS shim is an LD_PRELOAD libc interceptor and is therefore
+          # libc-specific: on Linux it builds against gnu (VFS_TARGET) so it can
+          # preload into the host distro's glibc programs. macOS/Windows have no
+          # vfs_target, so VFS_TARGET falls back to the core target there.
+          cargo build --release --target "$VFS_TARGET" -p kin-vfs-cli
+          cargo build --release --target "$VFS_TARGET" -p kin-vfs-shim
         env:
-          TARGET: ${{ matrix.target }}
+          VFS_TARGET: ${{ matrix.vfs_target || matrix.target }}
 
       - name: Build kin-vfs (cross)
         if: ${{ matrix.cross }}
@@ -232,8 +252,10 @@ jobs:
           # archive lets `kin init` succeed but then `kin status`/`kin search`
           # fail with no daemon on PATH, so a missing daemon must fail the build.
           cp "target/${TARGET}/release/kin-daemon" "$ARTIFACT/"
-          cp "kin-vfs/target/${TARGET}/release/kin-vfs" "$ARTIFACT/" 2>/dev/null || true
-          cp "kin-vfs/target/${TARGET}/release/${SHIM_NAME}" "$ARTIFACT/" 2>/dev/null || true
+          # kin-vfs (cli + shim) is built under VFS_TARGET, which on Linux is the
+          # gnu triple (the shim is libc-specific) and elsewhere equals TARGET.
+          cp "kin-vfs/target/${VFS_TARGET}/release/kin-vfs" "$ARTIFACT/" 2>/dev/null || true
+          cp "kin-vfs/target/${VFS_TARGET}/release/${SHIM_NAME}" "$ARTIFACT/" 2>/dev/null || true
           tar czf "${ARTIFACT}.tar.gz" "$ARTIFACT"
           # Assert the published archive actually contains kin-daemon so
           # a daemon-less build can never be released green.
@@ -244,6 +266,7 @@ jobs:
           shasum -a 256 "${ARTIFACT}.tar.gz" > "${ARTIFACT}.tar.gz.sha256"
         env:
           TARGET: ${{ matrix.target }}
+          VFS_TARGET: ${{ matrix.vfs_target || matrix.target }}
           ARTIFACT: ${{ matrix.artifact }}
           SHIM_NAME: ${{ matrix.shim_name }}
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -915,16 +915,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "der"
-version = "0.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "71fd89660b2dc699704064e59e9dba0147b903e85319429e131620d022be411b"
-dependencies = [
- "pem-rfc7468",
- "zeroize",
-]
-
-[[package]]
 name = "deranged"
 version = "0.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1158,9 +1148,6 @@ name = "esaxx-rs"
 version = "0.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d817e038c30374a4bcb22f94d0a8a0e216958d4c3dcde369b1439fec4bdda6e6"
-dependencies = [
- "cc",
-]
 
 [[package]]
 name = "faster-hex"
@@ -1283,21 +1270,12 @@ checksum = "77ce24cb58228fbb8aa041425bb1050850ac19177686ea6e0f41a70416f56fdb"
 
 [[package]]
 name = "foreign-types"
-version = "0.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f6f339eb8adc052cd2ca78910fda869aefa38d22d5cb648e6485e4d3fc06f3b1"
-dependencies = [
- "foreign-types-shared 0.1.1",
-]
-
-[[package]]
-name = "foreign-types"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d737d9aa519fb7b749cbc3b962edcf310a8dd1f4b67c91c4f83975dbdd17d965"
 dependencies = [
  "foreign-types-macros",
- "foreign-types-shared 0.3.1",
+ "foreign-types-shared",
 ]
 
 [[package]]
@@ -1310,12 +1288,6 @@ dependencies = [
  "quote",
  "syn",
 ]
-
-[[package]]
-name = "foreign-types-shared"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "00b0228411908ca8685dba7fc2cdd70ec9990a6e753e89b6ac91a84c40fbaf4b"
 
 [[package]]
 name = "foreign-types-shared"
@@ -2313,12 +2285,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
-name = "hermit-abi"
-version = "0.5.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fc0fef456e4baa96da950455cd02c081ca953b141298e41db3fc7e36b1da849c"
-
-[[package]]
 name = "hex"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2331,19 +2297,14 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "aef3982638978efa195ff11b305f51f1f22f4f0a6cabee7af79b383ebee6a213"
 dependencies = [
  "dirs",
- "futures",
  "http",
  "indicatif",
  "libc",
  "log",
- "native-tls",
- "num_cpus",
  "rand 0.9.4",
- "reqwest",
  "serde",
  "serde_json",
  "thiserror 2.0.18",
- "tokio",
  "ureq",
  "windows-sys 0.61.2",
 ]
@@ -2457,22 +2418,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "hyper-tls"
-version = "0.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "70206fc6890eaca9fde8a0bf71caa2ddfc9fe045ac9e5c70df101a7dbde866e0"
-dependencies = [
- "bytes",
- "http-body-util",
- "hyper",
- "hyper-util",
- "native-tls",
- "tokio",
- "tokio-native-tls",
- "tower-service",
-]
-
-[[package]]
 name = "hyper-util"
 version = "0.1.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2490,11 +2435,9 @@ dependencies = [
  "percent-encoding",
  "pin-project-lite",
  "socket2",
- "system-configuration",
  "tokio",
  "tower-service",
  "tracing",
- "windows-registry",
 ]
 
 [[package]]
@@ -3086,9 +3029,9 @@ dependencies = [
 
 [[package]]
 name = "kin-db"
-version = "0.2.23"
+version = "0.2.24"
 source = "sparse+https://kinlab.ai/registry/cargo/"
-checksum = "5033d96edbb46cf837d000d30134823aad7229a1e8316016d12e830f7479f844"
+checksum = "e8221413c719d47483ff17ec49c020a293dd6f46b691f68c1f1ddeda04299bc5"
 dependencies = [
  "bincode",
  "bytes",
@@ -3166,9 +3109,9 @@ dependencies = [
 
 [[package]]
 name = "kin-infer"
-version = "0.2.34"
+version = "0.2.35"
 source = "sparse+https://kinlab.ai/registry/cargo/"
-checksum = "482db439d0cc953970287f50b2fa8a7b54e00796d6382550bb81695e327e3925"
+checksum = "30798cf132286f15a01c45e7ecc19df29c96264686bd0121bf97a28e0aeee7ec"
 dependencies = [
  "block",
  "half",
@@ -3739,7 +3682,7 @@ dependencies = [
  "bitflags 2.13.0",
  "block",
  "core-graphics-types",
- "foreign-types 0.5.0",
+ "foreign-types",
  "log",
  "objc",
  "paste",
@@ -3808,23 +3751,6 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
-]
-
-[[package]]
-name = "native-tls"
-version = "0.2.18"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "465500e14ea162429d264d44189adc38b199b62b1c21eea9f69e4b73cb03bbf2"
-dependencies = [
- "libc",
- "log",
- "openssl",
- "openssl-probe",
- "openssl-sys",
- "schannel",
- "security-framework 3.7.0",
- "security-framework-sys",
- "tempfile",
 ]
 
 [[package]]
@@ -3935,16 +3861,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
 dependencies = [
  "autocfg",
-]
-
-[[package]]
-name = "num_cpus"
-version = "1.17.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "91df4bbde75afed763b708b7eee1e8e7651e02d97f6d5dd763e89367e957b23b"
-dependencies = [
- "hermit-abi",
- "libc",
 ]
 
 [[package]]
@@ -4079,47 +3995,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "openssl"
-version = "0.10.81"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "77823a27f0babb03091cb9ed9ef80af3b39dbc82f97e8fa530374b7dafd87a45"
-dependencies = [
- "bitflags 2.13.0",
- "cfg-if",
- "foreign-types 0.3.2",
- "libc",
- "openssl-macros",
- "openssl-sys",
-]
-
-[[package]]
-name = "openssl-macros"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a948666b637a0f465e8564c73e89d4dde00d72d4d473cc972f390fc3dcee7d9c"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
-]
-
-[[package]]
 name = "openssl-probe"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7c87def4c32ab89d880effc9e097653c8da5d6ef28e6b539d313baaacfbafcbe"
-
-[[package]]
-name = "openssl-sys"
-version = "0.9.117"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b47e7e6bb2c38cd930d25a23b40fa52e068c10e85f3e03a7f5ba5aaca5713695"
-dependencies = [
- "cc",
- "libc",
- "pkg-config",
- "vcpkg",
-]
 
 [[package]]
 name = "option-ext"
@@ -4173,15 +4052,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "pem-rfc7468"
-version = "1.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a6305423e0e7738146434843d1694d621cce767262b2a86910beab705e4493d9"
-dependencies = [
- "base64ct",
-]
-
-[[package]]
 name = "percent-encoding"
 version = "2.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4219,7 +4089,7 @@ version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f950b2377845cebe5cf8b5165cb3cc1a5e0fa5cfa3e1f7f55707d8fd82e0a7b7"
 dependencies = [
- "der 0.7.10",
+ "der",
  "spki",
 ]
 
@@ -4613,7 +4483,6 @@ checksum = "eddd3ca559203180a307f12d114c268abf583f59b03cb906fd0b3ff8646c1147"
 dependencies = [
  "base64 0.22.1",
  "bytes",
- "encoding_rs",
  "futures-channel",
  "futures-core",
  "futures-util",
@@ -4623,12 +4492,9 @@ dependencies = [
  "http-body-util",
  "hyper",
  "hyper-rustls",
- "hyper-tls",
  "hyper-util",
  "js-sys",
  "log",
- "mime",
- "native-tls",
  "percent-encoding",
  "pin-project-lite",
  "quinn",
@@ -4640,7 +4506,6 @@ dependencies = [
  "serde_urlencoded",
  "sync_wrapper",
  "tokio",
- "tokio-native-tls",
  "tokio-rustls",
  "tokio-util",
  "tower",
@@ -5260,7 +5125,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d91ed6c858b01f942cd56b37a94b3e0a1798290327d1236e4d9cf4eaca44d29d"
 dependencies = [
  "base64ct",
- "der 0.7.10",
+ "der",
 ]
 
 [[package]]
@@ -5348,27 +5213,6 @@ dependencies = [
  "objc2-core-foundation",
  "objc2-io-kit",
  "windows",
-]
-
-[[package]]
-name = "system-configuration"
-version = "0.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a13f3d0daba03132c0aa9767f98351b3488edc2c100cda2d2ec2b04f3d8d3c8b"
-dependencies = [
- "bitflags 2.13.0",
- "core-foundation 0.9.4",
- "system-configuration-sys",
-]
-
-[[package]]
-name = "system-configuration-sys"
-version = "0.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e1d1b10ced5ca923a1fcb8d03e96b8d3268065d724548c0211415ff6ac6bac4"
-dependencies = [
- "core-foundation-sys",
- "libc",
 ]
 
 [[package]]
@@ -5560,16 +5404,6 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
-]
-
-[[package]]
-name = "tokio-native-tls"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bbae76ab933c85776efabc971569dd6119c580d8f5d448769dec1764bf796ef2"
-dependencies = [
- "native-tls",
- "tokio",
 ]
 
 [[package]]
@@ -6046,10 +5880,8 @@ checksum = "dea7109cdcd5864d4eeb1b58a1648dc9bf520360d7af16ec26d0a9354bafcfc0"
 dependencies = [
  "base64 0.22.1",
  "cookie_store",
- "der 0.8.0",
  "flate2",
  "log",
- "native-tls",
  "percent-encoding",
  "rustls",
  "rustls-pki-types",
@@ -6058,7 +5890,6 @@ dependencies = [
  "socks",
  "ureq-proto",
  "utf8-zero",
- "webpki-root-certs",
  "webpki-roots",
 ]
 
@@ -6122,12 +5953,6 @@ name = "valuable"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ba73ea9cf16a25df0c8caa16c51acb937d5712a8429db78a3ee29d5dcacd3a65"
-
-[[package]]
-name = "vcpkg"
-version = "0.2.15"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
 
 [[package]]
 name = "version_check"
@@ -6267,15 +6092,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "webpki-root-certs"
-version = "1.0.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0d46a5a140e6f7afeccd8eae97eff335163939eac8b929834875168b29b3d267"
-dependencies = [
- "rustls-pki-types",
-]
-
-[[package]]
 name = "webpki-roots"
 version = "1.0.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6318,7 +6134,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.48.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -6408,17 +6224,6 @@ checksum = "6e2e40844ac143cdb44aead537bbf727de9b044e107a0f1220392177d15b0f26"
 dependencies = [
  "windows-core",
  "windows-link",
-]
-
-[[package]]
-name = "windows-registry"
-version = "0.6.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "02752bf7fbdcce7f2a27a742f798510f3e5ad88dbe84871e5168e2120c3d5720"
-dependencies = [
- "windows-link",
- "windows-result",
- "windows-strings",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -143,7 +143,7 @@ kin-lsp = { version = "0.2.1", registry = "kin" }
 # backend on every target (incl. Linux, where it cannot compile). Metal is re-enabled
 # additively on macOS via a `[target.'cfg(target_os = "macos")'.dependencies]` block in the
 # binary/runtime crates (kin-cli, kin-daemon). Feature unification makes that additive.
-kin-db = { version = "0.2.23", registry = "kin", default-features = false, features = ["vector", "embeddings"] }
+kin-db = { version = "0.2.24", registry = "kin", default-features = false, features = ["vector", "embeddings"] }
 kin-vfs-core = { version = "0.1.0", registry = "kin" }
 
 [profile.release]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -92,7 +92,7 @@ gix = { version = "0.84", default-features = false, features = ["max-performance
 axum = "0.8"
 tower = "0.5"
 tower-http = { version = "0.6", features = ["cors", "fs"] }
-reqwest = { version = "0.12", features = ["json"] }
+reqwest = { version = "0.12", default-features = false, features = ["json", "rustls-tls"] }
 socket2 = "0.6"
 
 # Interactive CLI


### PR DESCRIPTION
## What

Make the Linux release binaries (`kin`, `kin-daemon`) fully static and portable
across any Linux distro, not just modern glibc + OpenSSL 3.

- **`reqwest`** → `default-features = false, features = ["json", "rustls-tls"]`.
  kin's HTTP path uses rustls (ring) instead of OpenSSL / native-tls.
- **`release.yml`** → the two Linux legs build the core (`kin`, `kin-daemon`)
  for `*-unknown-linux-musl` (static by default) instead of `*-unknown-linux-gnu`,
  and install `musl-tools` for the C deps (ring, oniguruma, sqlite, tree-sitter).
  The VFS leg stays on gnu (`vfs_target`); see below.

## Why

The published Linux binary was dynamically linked against glibc + OpenSSL 3
(`NEEDED libssl.so.3` / `libcrypto.so.3`, interpreter `ld-linux-aarch64.so.1`).
It ran on Ubuntu 24.04 but failed on Alpine/musl and would fail on older
OpenSSL-1.1 distros. A static musl build removes both the glibc and OpenSSL
coupling: one binary runs everywhere.

## VFS shim

`libkin_vfs_shim.so` is an LD_PRELOAD libc interceptor, so it is intrinsically
libc-specific: one shim cannot serve both musl and glibc hosts. The core
`kin`/`kin-daemon` are the portability priority and are now static-musl. The VFS
leg (cli + shim) builds against gnu (`vfs_target`) so the shim can preload into
the host distro's glibc programs (the majority of Linux installs). The
macOS/Windows legs are unchanged (`VFS_TARGET` falls back to the core target).

## Verification (aarch64 musl, built natively on arm64)

`file kin` → `ELF 64-bit LSB executable, ARM aarch64, statically linked`
`readelf -d kin` → no dynamic `NEEDED` entries (no libssl/libcrypto); no PT_INTERP

```
# alpine:3 (MUSL)
$ docker run --rm --platform linux/arm64 -v out:/k:ro alpine:3 /k/kin --version
kin 0.2.3 ...
$ ... /k/kin-daemon --version
kin-daemon 0.2.3 ...

# ubuntu:24.04 (GLIBC)
$ docker run --rm --platform linux/arm64 -v out:/k:ro ubuntu:24.04 /k/kin --version
kin 0.2.3 ...
$ ... /k/kin-daemon --version
kin-daemon 0.2.3 ...
```

With the kin-db change below in place, `cargo tree -i openssl-sys` is empty and
the TLS backend is `ring` (no `aws-lc-rs`).

## ⚠️ Merge / release order (required)

The OpenSSL pull on the embeddings path comes from **`kin-db`** (`hf-hub`'s
default `native-tls`), not just reqwest. This PR removes kin's *own* OpenSSL use,
but the musl Linux legs build OpenSSL-free only once `kin-db` ships the matching
fix:

1. Merge + publish **firelock-ai/kin-db#64** (hf-hub → rustls, drop `esaxx_fast`).
2. Bump kin's `kin-db` dependency to that version and re-lock.
3. The musl Linux release is then OpenSSL-free and green.

Until step 2, registry `kin-db 0.2.23` still pulls OpenSSL + a C++ dep, which the
musl legs cannot build. **Do not tag a release off this branch before the kin-db
bump.** (PR-time CI is unaffected: the musl matrix only runs on release tags.)
