### PR TITLE
release: v0.2.4 (portable static-musl Linux + signed macOS)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.2.4] - 2026-06-25
+
+Portable Linux release. The Linux binaries are now statically linked against musl with rustls, removing the OpenSSL and glibc-version runtime dependencies, so `kin` and `kin-daemon` run on any Linux distribution including Alpine/musl and older glibc systems.
+
+### Changed
+- Linux release binaries switched from glibc dynamic linking to static musl, and from native-tls/OpenSSL to rustls. The binaries no longer require libssl/libcrypto at runtime or a minimum glibc version.
+
 ## [0.2.3] - 2026-06-24
 
 Signed release. The macOS binaries are now code-signed with a Developer ID certificate and notarized by Apple.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2871,11 +2871,11 @@ dependencies = [
 
 [[package]]
 name = "kin-buildinfo"
-version = "0.2.3"
+version = "0.2.4"
 
 [[package]]
 name = "kin-cli"
-version = "0.2.3"
+version = "0.2.4"
 dependencies = [
  "age",
  "anyhow",
@@ -2940,7 +2940,7 @@ dependencies = [
 
 [[package]]
 name = "kin-context"
-version = "0.2.3"
+version = "0.2.4"
 dependencies = [
  "kin-blobs",
  "kin-db",
@@ -2956,7 +2956,7 @@ dependencies = [
 
 [[package]]
 name = "kin-core"
-version = "0.2.3"
+version = "0.2.4"
 dependencies = [
  "chrono",
  "directories 5.0.1",
@@ -2980,7 +2980,7 @@ dependencies = [
 
 [[package]]
 name = "kin-daemon"
-version = "0.2.3"
+version = "0.2.4"
 dependencies = [
  "async-stream",
  "axum",
@@ -3069,7 +3069,7 @@ dependencies = [
 
 [[package]]
 name = "kin-git"
-version = "0.2.3"
+version = "0.2.4"
 dependencies = [
  "chrono",
  "gix",
@@ -3087,7 +3087,7 @@ dependencies = [
 
 [[package]]
 name = "kin-index"
-version = "0.2.3"
+version = "0.2.4"
 dependencies = [
  "hex",
  "kin-blobs",
@@ -3133,7 +3133,7 @@ dependencies = [
 
 [[package]]
 name = "kin-integration-tests"
-version = "0.2.3"
+version = "0.2.4"
 dependencies = [
  "kin-blobs",
  "kin-cli",
@@ -3175,7 +3175,7 @@ dependencies = [
 
 [[package]]
 name = "kin-mcp"
-version = "0.2.3"
+version = "0.2.4"
 dependencies = [
  "kin-blobs",
  "kin-context",
@@ -3201,7 +3201,7 @@ dependencies = [
 
 [[package]]
 name = "kin-migrate"
-version = "0.2.3"
+version = "0.2.4"
 dependencies = [
  "chrono",
  "kin-blobs",
@@ -3243,7 +3243,7 @@ dependencies = [
 
 [[package]]
 name = "kin-parser"
-version = "0.2.3"
+version = "0.2.4"
 dependencies = [
  "kin-model",
  "pretty_assertions",
@@ -3272,7 +3272,7 @@ dependencies = [
 
 [[package]]
 name = "kin-projection"
-version = "0.2.3"
+version = "0.2.4"
 dependencies = [
  "kin-blobs",
  "kin-db",
@@ -3287,7 +3287,7 @@ dependencies = [
 
 [[package]]
 name = "kin-ranking"
-version = "0.2.3"
+version = "0.2.4"
 dependencies = [
  "kin-model",
  "serde",
@@ -3296,7 +3296,7 @@ dependencies = [
 
 [[package]]
 name = "kin-reconcile"
-version = "0.2.3"
+version = "0.2.4"
 dependencies = [
  "kin-blobs",
  "kin-db",
@@ -3316,7 +3316,7 @@ dependencies = [
 
 [[package]]
 name = "kin-registry"
-version = "0.2.3"
+version = "0.2.4"
 dependencies = [
  "axum",
  "base64 0.22.1",
@@ -3341,7 +3341,7 @@ dependencies = [
 
 [[package]]
 name = "kin-remote"
-version = "0.2.3"
+version = "0.2.4"
 dependencies = [
  "chrono",
  "kin-model",
@@ -3357,7 +3357,7 @@ dependencies = [
 
 [[package]]
 name = "kin-review"
-version = "0.2.3"
+version = "0.2.4"
 dependencies = [
  "kin-blobs",
  "kin-db",
@@ -3372,7 +3372,7 @@ dependencies = [
 
 [[package]]
 name = "kin-runtime"
-version = "0.2.3"
+version = "0.2.4"
 dependencies = [
  "chrono",
  "hex",
@@ -3404,7 +3404,7 @@ dependencies = [
 
 [[package]]
 name = "kin-semantic-contracts"
-version = "0.2.3"
+version = "0.2.4"
 dependencies = [
  "kin-db",
  "kin-model",
@@ -3419,7 +3419,7 @@ dependencies = [
 
 [[package]]
 name = "kin-spine"
-version = "0.2.3"
+version = "0.2.4"
 dependencies = [
  "chrono",
  "hashbrown 0.15.5",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,7 +27,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.2.3"
+version = "0.2.4"
 edition = "2021"
 license = "Apache-2.0"
 authors = ["Troy Fortin <troy@firelock.ai>"]

--- a/packages/kin-mcp/package.json
+++ b/packages/kin-mcp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kinlab/kin-mcp",
-  "version": "0.2.3",
+  "version": "0.2.4",
   "description": "Start Kin's MCP server through an npm-friendly wrapper.",
   "type": "module",
   "bin": {


### PR DESCRIPTION
Cuts v0.2.4: bumps the workspace + npm wrapper to 0.2.4 and adds the CHANGELOG section. This release carries the static-musl Linux binaries (rustls, no OpenSSL or glibc-version coupling, from #116) together with the Developer ID signed + notarized macOS binaries. On merge, the auto-tag workflow tags v0.2.4 and release.yml builds, signs, notarizes, and publishes.