### PR TITLE
ci(release): make Homebrew tap dispatch non-fatal

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -478,9 +478,17 @@ jobs:
             echo "KIN_CI_BOT_TOKEN not configured; the tap self-updates on its 6h schedule"
             exit 0
           fi
-          curl -fsS -X POST \
+          # Convenience dispatch: the tap also self-updates on its 6h schedule, so a
+          # failure here (e.g. a token without homebrew-kin access) warns rather than
+          # failing an already-published release.
+          code=$(curl -sS -o /tmp/tap-dispatch.out -w '%{http_code}' -X POST \
             -H "Authorization: Bearer ${TAP_DISPATCH_TOKEN}" \
             -H "Accept: application/vnd.github+json" \
             https://api.github.com/repos/firelock-ai/homebrew-kin/dispatches \
-            -d '{"event_type":"kin-release"}'
-          echo "Dispatched kin-release to firelock-ai/homebrew-kin"
+            -d '{"event_type":"kin-release"}' || echo "000")
+          if [ "$code" = "204" ]; then
+            echo "Dispatched kin-release to firelock-ai/homebrew-kin"
+          else
+            echo "::warning::Homebrew tap dispatch returned HTTP ${code}; the tap self-updates on its 6h schedule, not failing the release."
+            cat /tmp/tap-dispatch.out 2>/dev/null || true
+          fi


### PR DESCRIPTION
## What

The release `bump_homebrew` job dispatched a `repository_dispatch` to the `homebrew-kin` tap with `curl -fsS`. The `-f` flag makes curl exit non-zero on any HTTP error, so a non-2xx response (e.g. the dispatch token lacking write access to `homebrew-kin` → 403) hard-fails the job — and thus the whole release run — even though every publish job already succeeded.

## Fix

Capture the HTTP status code and branch on it: succeed on `204` (GitHub's `repository_dispatch` success code), otherwise emit a `::warning::` and continue. This mirrors the step's existing empty-token graceful-skip and matches the designed fallback — the tap also self-updates on its 6h schedule, so the formula is never more than 6h stale regardless.

## Impact

- Releases no longer show red on a non-critical post-publish convenience step.
- A genuine dispatch failure is now visible as a warning (with HTTP code + response body) instead of an opaque `curl: (22)` exit.
- No behavior change on the happy path (`204` → same success log).
