### PR TITLE
ci(release): cap macOS notarization wait at 30m

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -232,7 +232,7 @@ jobs:
             --apple-id "$APPLE_ID" \
             --password "$APPLE_APP_SPECIFIC_PASSWORD" \
             --team-id "$APPLE_TEAM_ID" \
-            --wait
+            --wait --timeout 30m
           # NOTE: a bare CLI binary (and a .tar.gz) cannot be stapled — `xcrun
           # stapler` only supports .app bundles, .dmg, .pkg, and .xip. The
           # notarization ticket is stored on Apple's servers and validated


### PR DESCRIPTION
Bounds notarytool --wait so a stalled Apple Notary queue fails the job fast instead of holding a 10x-billed macOS runner for hours (the new-account first notarization sat ~7.5h before timing out the job). --timeout only stops local polling; the Notary service keeps processing, so a re-run picks up the completed notarization. Interim safety ahead of moving the notarize step to a 1x Linux runner via rcodesign.