### PR TITLE
test(spine): prove store-backed backend serves non-empty cross-repo xref with no local siblings

### DIFF
--- a/crates/kin-spine/src/xref.rs
+++ b/crates/kin-spine/src/xref.rs
@@ -295,7 +295,7 @@ fn derive_imported_symbol(rel: &Relation) -> Option<String> {
 /// instead of producing a garbage name that could mis-resolve.
 fn symbol_leaf(token: &str) -> Option<String> {
     let leaf = token
-        .rsplit(|c| c == '.' || c == ':')
+        .rsplit(['.', ':'])
         .next()
         .unwrap_or(token)
         .trim();

--- a/crates/kin-spine/src/xref.rs
+++ b/crates/kin-spine/src/xref.rs
@@ -294,11 +294,7 @@ fn derive_imported_symbol(rel: &Relation) -> Option<String> {
 /// directives, macro text, punctuation), so non-symbol evidence is rejected
 /// instead of producing a garbage name that could mis-resolve.
 fn symbol_leaf(token: &str) -> Option<String> {
-    let leaf = token
-        .rsplit(['.', ':'])
-        .next()
-        .unwrap_or(token)
-        .trim();
+    let leaf = token.rsplit(['.', ':']).next().unwrap_or(token).trim();
     if !leaf.is_empty() && leaf.chars().all(|c| c.is_alphanumeric() || c == '_') {
         Some(leaf.to_string())
     } else {

--- a/crates/kin-spine/tests/integration.rs
+++ b/crates/kin-spine/tests/integration.rs
@@ -6,12 +6,21 @@
 //! These tests exercise the full spine stack: SpineIndex registration,
 //! cross-repo edge resolution, federated BFS traversal, and routing.
 
+use std::collections::HashMap;
 use std::collections::HashSet;
+use std::sync::Arc;
+use std::sync::Mutex;
 
-use kin_model::{EntityId, EntityKind, FingerprintAlgorithm, Hash256, SemanticFingerprint};
+use kin_model::{
+    Entity, EntityId, EntityKind, EntityMetadata, EntityRole, FingerprintAlgorithm, GraphNodeId,
+    Hash256, LanguageId, Relation, RelationEvidence, RelationId, RelationKind, RelationOrigin,
+    SemanticFingerprint, Visibility,
+};
+use kin_spine::backend::SpineBackend;
 use kin_spine::federation::federated_impact;
 use kin_spine::index::{CrossRepoEdge, EntityEntry, SpineIndex};
 use kin_spine::routing::{RepoEndpoint, RoutingTable};
+use kin_spine::{FirestoreSpineBackend, LoadedRepo, SpineError, SpineStore};
 
 // ── Helpers ─────────────────────────────────────────────────────────────
 
@@ -539,4 +548,288 @@ fn multiple_entities_per_repo_with_mixed_kinds() {
     // "parse" with no kind filter returns both Function and Method
     let parses = index.resolve("parse", None, None);
     assert_eq!(parses.len(), 2);
+}
+
+// ── Hosted-shaped multi-repo xref (no local disk, no network) ──────────
+//
+// The hosted daemon runs one repo per pod and owns no local sibling
+// checkouts: the cross-repo index has to come from the durable spine store,
+// not from on-disk sibling `.kndb` graphs. These tests stand up the exact
+// store-backed backend a cloud pod builds (`FirestoreSpineBackend` over a
+// `SpineStore`), hydrate it from a store seeded by a separate writer, drive
+// the cross-repo edge refresh over the primary repo's relations, and assert
+// the per-entity edge contract that backs `GET /spine/xref` returns
+// non-empty cross-repo edges. The store seam is in-memory here so the whole
+// pipeline runs with no Firestore and no filesystem siblings.
+
+/// In-memory [`SpineStore`] standing in for Firestore: same replace-by-repo
+/// semantics, no network, no disk. Shared between a writer backend (the
+/// ingestion side) and a reader backend (the freshly started pod) via `Arc`.
+#[derive(Default)]
+struct HostedFakeStore {
+    /// (root_hash, entries) keyed by repo_id.
+    repos: Mutex<HashMap<String, (String, Vec<EntityEntry>)>>,
+    edges: Mutex<Vec<CrossRepoEdge>>,
+}
+
+impl SpineStore for HostedFakeStore {
+    fn load_repos(&self) -> Result<Vec<LoadedRepo>, SpineError> {
+        Ok(self
+            .repos
+            .lock()
+            .unwrap()
+            .iter()
+            .map(|(repo_id, (root_hash, entries))| LoadedRepo {
+                repo_id: repo_id.clone(),
+                root_hash: root_hash.clone(),
+                entries: entries.clone(),
+            })
+            .collect())
+    }
+
+    fn load_edges(&self) -> Result<Vec<CrossRepoEdge>, SpineError> {
+        Ok(self.edges.lock().unwrap().clone())
+    }
+
+    fn write_entity(&self, entry: &EntityEntry, root_hash: &str) -> Result<(), SpineError> {
+        let mut repos = self.repos.lock().unwrap();
+        let bucket = repos
+            .entry(entry.repo_id.clone())
+            .or_insert_with(|| (root_hash.to_string(), Vec::new()));
+        bucket.0 = root_hash.to_string();
+        bucket.1.push(entry.clone());
+        Ok(())
+    }
+
+    fn delete_repo_entities(&self, repo_id: &str) -> Result<(), SpineError> {
+        self.repos.lock().unwrap().remove(repo_id);
+        Ok(())
+    }
+
+    fn write_edge(&self, edge: &CrossRepoEdge) -> Result<(), SpineError> {
+        self.edges.lock().unwrap().push(edge.clone());
+        Ok(())
+    }
+
+    fn delete_repo_edges(&self, repo_id: &str) -> Result<(), SpineError> {
+        self.edges.lock().unwrap().retain(|e| e.src_repo != repo_id);
+        Ok(())
+    }
+}
+
+/// A source-side function entity (the caller that references a sibling repo).
+fn source_entity(id: EntityId, name: &str, language: LanguageId) -> Entity {
+    Entity {
+        id,
+        kind: EntityKind::Function,
+        name: name.to_string(),
+        language,
+        fingerprint: make_fp(1),
+        file_origin: None,
+        span: None,
+        signature: format!("fn {name}()"),
+        visibility: Visibility::Public,
+        role: EntityRole::Source,
+        doc_summary: None,
+        metadata: EntityMetadata::default(),
+        lineage_parent: None,
+        created_in: None,
+        superseded_by: None,
+    }
+}
+
+/// A `Calls`/`References` relation from a local entity to an out-of-repo
+/// target, carrying the `import_source` module and the imported-symbol token
+/// the cross-repo resolver keys on. `dst` is a fresh id deliberately absent
+/// from the local entity set so the reference is treated as external.
+fn cross_repo_call(
+    src: EntityId,
+    import_source: &str,
+    symbol_token: &str,
+    kind: RelationKind,
+) -> Relation {
+    Relation {
+        id: RelationId::new(),
+        kind,
+        src: GraphNodeId::Entity(src),
+        dst: GraphNodeId::Entity(EntityId::new()),
+        confidence: 1.0,
+        origin: RelationOrigin::Parsed,
+        created_in: None,
+        import_source: Some(import_source.to_string()),
+        evidence: vec![RelationEvidence {
+            token: Some(symbol_token.to_string()),
+            ..RelationEvidence::default()
+        }],
+    }
+}
+
+// ── Test 15: hosted pod serves non-empty /spine/xref from the store ────
+//
+// This is the cross-repo demo blocker in miniature: a single-repo pod with
+// no on-disk siblings must still answer cross-repo xref. It proves the spine
+// pipeline (store hydrate → cross-repo edge refresh → per-entity edge read)
+// produces non-empty edges purely from store-resident sibling metadata.
+
+#[test]
+fn hosted_pod_serves_non_empty_xref_from_store_only() {
+    // Shared durable store standing in for Firestore — no disk, no network.
+    let store = Arc::new(HostedFakeStore::default());
+
+    // ── Ingestion side ────────────────────────────────────────────────
+    // Two repos land in the store the way cloud ingestion would: the sibling
+    // `kin-db` (which exports `InMemoryGraph`) and the primary `kin`. The
+    // sibling is registered through a *separate* backend instance to model a
+    // different ingestion actor; only its metadata reaches the store, never a
+    // local `.kndb`.
+    let graph_entity = entry("kin-db", "InMemoryGraph", EntityKind::Class, 7);
+    {
+        let ingest = FirestoreSpineBackend::with_store(store.clone());
+        ingest_repo(&ingest, "kin-db", vec![graph_entity.clone()], "db-hash");
+    }
+
+    // ── Pod startup side (the bug surface) ────────────────────────────
+    // A freshly started pod builds the same store-backed backend the cloud
+    // path constructs and hydrates its cache from the store — the cache is
+    // empty until then because the pod has no local siblings.
+    let pod = FirestoreSpineBackend::with_store(store.clone());
+    assert_eq!(
+        pod.entity_count(),
+        0,
+        "pod cache must be empty before hydrate (no local-disk siblings)"
+    );
+    pod.hydrate().expect("hydrate cache from store");
+    assert_eq!(
+        pod.repo_count(),
+        1,
+        "the sibling repo is visible purely from the store after hydrate"
+    );
+
+    // The pod registers its own primary repo and refreshes cross-repo edges,
+    // exactly as the daemon spine init does. The primary `kin` has a function
+    // that calls `kin_db::InMemoryGraph`; the relation carries the
+    // `import_source` and the imported symbol, so the resolver can bind it to
+    // the store-resident `kin-db` entity.
+    let caller = EntityId::new();
+    let primary_entities = vec![source_entity(caller, "open_graph", LanguageId::Rust)];
+    let primary_entries = vec![EntityEntry {
+        repo_id: "kin".to_string(),
+        entity_id: caller,
+        name: "open_graph".to_string(),
+        kind: EntityKind::Function,
+        signature: "fn open_graph()".to_string(),
+        fingerprint: make_fp(1),
+        file_path: Some("src/graph.rs".to_string()),
+        role: Some(EntityRole::Source),
+    }];
+    pod.register_repo("kin", primary_entries, "kin-hash");
+
+    let relations = vec![cross_repo_call(
+        caller,
+        "kin_db",
+        "kin_db::InMemoryGraph",
+        RelationKind::Calls,
+    )];
+    let registry: Vec<String> = pod.registered_repo_ids().into_iter().collect();
+    pod.refresh_cross_repo_edges("kin", &primary_entities, &relations, &registry);
+
+    // ── The contract the demo needs: non-empty cross-repo xref ────────
+    // This is exactly what `GET /spine/xref?repo=kin&entity=<caller>` reads.
+    assert!(
+        pod.edge_count() >= 1,
+        "spine must hold at least one cross-repo edge after refresh, got {}",
+        pod.edge_count()
+    );
+    let xref = pod.cross_repo_edges_for("kin", &caller);
+    assert!(
+        !xref.is_empty(),
+        "/spine/xref for the primary caller must be non-empty with store-only siblings"
+    );
+    let edge = &xref[0];
+    assert_eq!(edge.src_repo, "kin");
+    assert_eq!(edge.dst_repo, "kin-db", "edge must cross into the sibling repo");
+    assert_eq!(
+        edge.dst_entity, graph_entity.entity_id,
+        "edge must bind to the store-resident sibling entity, not a local guess"
+    );
+
+    // The same edge is reachable from the sibling side, and federated impact
+    // crosses the boundary — the cross-repo reachability the demo shows.
+    let from_db = pod.cross_repo_edges_for("kin-db", &graph_entity.entity_id);
+    assert_eq!(from_db.len(), 1, "edge is bidirectional from the dst side");
+    let impact = pod.federated_impact("kin-db", &graph_entity.entity_id, 5);
+    assert!(
+        impact.repos_involved.contains(&"kin".to_string()),
+        "changing the sibling entity must impact the primary repo across the boundary"
+    );
+}
+
+// ── Test 16: edges survive a cold pod restart (store is the source) ────
+//
+// A second pod that only ever hydrates from the store — never touching the
+// primary repo's relations — must still see the materialized cross-repo
+// edges, because `refresh_cross_repo_edges` write-through persisted them.
+// This proves the edge state is owned by the store, not by an ephemeral
+// in-pod refresh.
+
+#[test]
+fn cross_repo_edges_survive_cold_pod_restart_via_store() {
+    let store = Arc::new(HostedFakeStore::default());
+
+    let graph_entity = entry("kin-db", "InMemoryGraph", EntityKind::Class, 7);
+    let caller = EntityId::new();
+
+    // First pod: ingest sibling, register primary, refresh edges (all
+    // write-through to the store).
+    {
+        let pod = FirestoreSpineBackend::with_store(store.clone());
+        ingest_repo(&pod, "kin-db", vec![graph_entity.clone()], "db-hash");
+
+        let primary_entries = vec![EntityEntry {
+            repo_id: "kin".to_string(),
+            entity_id: caller,
+            name: "open_graph".to_string(),
+            kind: EntityKind::Function,
+            signature: "fn open_graph()".to_string(),
+            fingerprint: make_fp(1),
+            file_path: Some("src/graph.rs".to_string()),
+            role: Some(EntityRole::Source),
+        }];
+        let primary_entities = vec![source_entity(caller, "open_graph", LanguageId::Rust)];
+        pod.register_repo("kin", primary_entries, "kin-hash");
+
+        let relations = vec![cross_repo_call(
+            caller,
+            "kin_db",
+            "kin_db::InMemoryGraph",
+            RelationKind::Calls,
+        )];
+        let registry: Vec<String> = pod.registered_repo_ids().into_iter().collect();
+        pod.refresh_cross_repo_edges("kin", &primary_entities, &relations, &registry);
+        assert_eq!(pod.edge_count(), 1);
+    }
+
+    // Second (cold) pod: hydrate only — no access to the primary's relations.
+    let cold = FirestoreSpineBackend::with_store(store.clone());
+    cold.hydrate().expect("cold hydrate");
+
+    assert_eq!(
+        cold.edge_count(),
+        1,
+        "materialized cross-repo edge must rehydrate from the store on a cold pod"
+    );
+    let xref = cold.cross_repo_edges_for("kin", &caller);
+    assert_eq!(xref.len(), 1, "/spine/xref non-empty on a pod that only hydrated");
+    assert_eq!(xref[0].dst_repo, "kin-db");
+}
+
+/// Register a repo's entity metadata through the store-backed backend,
+/// mirroring the metadata write the daemon performs when it indexes a repo.
+fn ingest_repo(
+    backend: &FirestoreSpineBackend,
+    repo_id: &str,
+    entries: Vec<EntityEntry>,
+    root_hash: &str,
+) {
+    backend.register_repo(repo_id, entries, root_hash);
 }

--- a/crates/kin-spine/tests/integration.rs
+++ b/crates/kin-spine/tests/integration.rs
@@ -747,7 +747,10 @@ fn hosted_pod_serves_non_empty_xref_from_store_only() {
     );
     let edge = &xref[0];
     assert_eq!(edge.src_repo, "kin");
-    assert_eq!(edge.dst_repo, "kin-db", "edge must cross into the sibling repo");
+    assert_eq!(
+        edge.dst_repo, "kin-db",
+        "edge must cross into the sibling repo"
+    );
     assert_eq!(
         edge.dst_entity, graph_entity.entity_id,
         "edge must bind to the store-resident sibling entity, not a local guess"
@@ -819,7 +822,11 @@ fn cross_repo_edges_survive_cold_pod_restart_via_store() {
         "materialized cross-repo edge must rehydrate from the store on a cold pod"
     );
     let xref = cold.cross_repo_edges_for("kin", &caller);
-    assert_eq!(xref.len(), 1, "/spine/xref non-empty on a pod that only hydrated");
+    assert_eq!(
+        xref.len(),
+        1,
+        "/spine/xref non-empty on a pod that only hydrated"
+    );
     assert_eq!(xref[0].dst_repo, "kin-db");
 }
 


### PR DESCRIPTION
## What

Adds hosted-shaped integration coverage proving the spine can serve **non-empty cross-repo `/spine/xref`** in a no-local-disk context — the foundational blocker for the hosted cross-repo graph demo.

## Why this matters

The hosted daemon runs **one repo per pod** (`KIN_REPO_ID` is a single repo). Its spine init (`crates/kin-daemon/src/state.rs:773` `initialize_spine_lazy`) enumerates sibling repos **only** from the local `~/.kin/registry.toml` and requires each sibling's `.kin/kindb/graph.kndb` to exist on local disk (`state.rs:815-876`). A GKE pod has neither, so the refresh at `state.rs:880-883` runs over a single repo and `/spine/xref` (`api.rs:6111`, which is a pure `cross_repo_edges_for` read) returns empty in production.

The store-backed `FirestoreSpineBackend` (`crates/kin-spine/src/firestore.rs`) is already hosted-aware: `create_spine_backend` (`state.rs:894`) selects it under `GOOGLE_CLOUD_PROJECT` and `hydrate()`s before the refresh. So the backend layer is correct — the missing piece is purely **multi-repo cloud ingestion** (nothing writes >=2 repos' metadata to the store), not a missing call.

## What's proven (2 new tests, no daemon, no Firestore, no disk)

In `crates/kin-spine/tests/integration.rs`, using the public `FirestoreSpineBackend::with_store(Arc<dyn SpineStore>)` seam over an in-memory store:

- `hosted_pod_serves_non_empty_xref_from_store_only` — a pod with an empty cache and zero local-disk siblings hydrates sibling metadata from the store, refreshes cross-repo edges over the primary repo's relations, and serves a **non-empty** per-entity xref edge that binds to the **store-resident** sibling entity (not a local guess). Federated impact crosses the boundary.
- `cross_repo_edges_survive_cold_pod_restart_via_store` — a cold pod that only hydrates (never sees the primary's relations) still serves the materialized edge, proving edge state is owned by the store.

This isolates 100% of the remaining work to **cloud ingestion of >=2 repos into the spine store**.

## Exact remaining wiring (for the follow-on team)

The spine query/edge pipeline is de-risked. To light up the live demo, the remaining work is ingestion + a small daemon refinement:

1. **Multi-repo store ingestion (the real gap).** Something must write each repo's entity metadata (and the primary's resolvable relations) into the spine store (Firestore collections `spine_entities` / `spine_edges`) so `hydrate()` loads >=2 repos in a pod. Today only a single-repo pod writes its own entities via `register_repo` write-through (`firestore.rs:121`). Owner: import-orchestrator lane.
2. **Daemon refresh over hydrated siblings (small).** `initialize_spine_lazy` (`state.rs:773-891`) builds `repo_relations` only from the primary + local-disk siblings (`state.rs:779-876`) and refreshes those (`state.rs:881-883`). After `hydrate()` the cache holds sibling **metadata** (no relations), and `registry_ids` (`state.rs:880`) already includes them — so the **primary** repo already resolves against hydrated siblings. Confirm the primary's ingested relations carry `import_source` + an imported-symbol evidence token (required by `collect_unresolved_imports`, `xref.rs:320-386`), since without them every external reference is correctly left unresolved.
3. **Org-graph API/UI + access model.** Can build on the proven `/spine/xref`, `/spine/impact`, `/spine/resolve` contracts (already consumed in `kinlab/services/control-plane/src/real-kin.ts`).

## Also

Simplifies a manual char comparison in `symbol_leaf` (`xref.rs:298`) to the slice form (clippy-clean, behavior-preserving — covered by existing `symbol_leaf_*` tests).

## Verification

- `cargo test -p kin-spine` — 32 lib + 16 integration tests pass (14 pre-existing + 2 new).
- `cargo clippy -p kin-spine --tests` — clean.
- No `Cargo.lock` path-patch leak.
