### PR TITLE
Make hardcoded locate ranking constants env-overridable

### DIFF
--- a/crates/kin-cli/src/commands/locate.rs
+++ b/crates/kin-cli/src/commands/locate.rs
@@ -515,6 +515,27 @@ fn locate_env_bool(name: &str, default: bool) -> bool {
         .unwrap_or(default)
 }
 
+/// Parse a comma-separated list of signal-list indices from the environment into a
+/// set, falling back to `default` when the variable is unset or yields no valid
+/// entries. Whitespace and empty fields are ignored; non-numeric fields make the
+/// whole override fall back so a typo cannot silently drop graph signals.
+fn locate_env_usize_set(name: &str, default: &[usize]) -> HashSet<usize> {
+    if let Ok(value) = std::env::var(name) {
+        let parsed: Option<HashSet<usize>> = value
+            .split(',')
+            .map(str::trim)
+            .filter(|field| !field.is_empty())
+            .map(|field| field.parse::<usize>().ok())
+            .collect();
+        if let Some(set) = parsed {
+            if !set.is_empty() {
+                return set;
+            }
+        }
+    }
+    default.iter().copied().collect()
+}
+
 /// Single source for the entity-resolve strength floor (read by both the
 /// strong-resolve support cap and resolve-boundary compression).
 fn resolve_strength_floor() -> f32 {
@@ -1441,6 +1462,11 @@ pub fn run_with_graph_capture_with_priority_files_and_vector_source(
         ScoringTrack::BroadBlend
     };
 
+    // RRF rank-saturation constant `k` in `w / (k + rank + 1)`. Default 60.0 (classic
+    // RRF); larger compresses rank differences, smaller sharpens top ranks. Shared by
+    // every track's fusion below so a sweep moves them together.
+    let rrf_k = locate_env_f32("KIN_LOCATE_RRF_K", 60.0);
+
     // Entity-granular fusion experiment (default OFF; byte-identical when unset).
     // When KIN_LOCATE_ENTITY_FUSION=1, fuse at ENTITY granularity (entity-derived
     // signals keyed by entity id, the rest by path) and PROJECT to files at the
@@ -1473,7 +1499,7 @@ pub fn run_with_graph_capture_with_priority_files_and_vector_source(
                 }
                 reciprocal_rank_fusion_weighted(
                     &ranked_lists,
-                    60.0,
+                    rrf_k,
                     &rrf_rank_lift_weights(ranked_lists.len()),
                     &[],
                 )
@@ -1508,7 +1534,7 @@ pub fn run_with_graph_capture_with_priority_files_and_vector_source(
                     }
                     reciprocal_rank_fusion_weighted(
                         &ranked_lists,
-                        60.0,
+                        rrf_k,
                         &rrf_rank_lift_weights(ranked_lists.len()),
                         &entity_dom_weights,
                     )
@@ -1548,7 +1574,7 @@ pub fn run_with_graph_capture_with_priority_files_and_vector_source(
                         .filter(|(idx, _)| *idx != 7)
                         .map(|(_, list)| list.clone())
                         .collect::<Vec<_>>();
-                    let other_fused = reciprocal_rank_fusion(&other_ranked_lists, 60.0);
+                    let other_fused = reciprocal_rank_fusion(&other_ranked_lists, rrf_k);
                     let other_max = other_fused
                         .first()
                         .map(|(_, s)| *s)
@@ -1568,7 +1594,7 @@ pub fn run_with_graph_capture_with_priority_files_and_vector_source(
                 // Boost multihop and imports, suppress test/snippet noise.
                 reciprocal_rank_fusion_weighted(
                     &ranked_lists,
-                    60.0,
+                    rrf_k,
                     &rrf_rank_lift_weights(ranked_lists.len()),
                     &[],
                 )
@@ -1589,7 +1615,7 @@ pub fn run_with_graph_capture_with_priority_files_and_vector_source(
                 }
                 reciprocal_rank_fusion_weighted(
                     &ranked_lists,
-                    60.0,
+                    rrf_k,
                     &rrf_rank_lift_weights(ranked_lists.len()),
                     &[],
                 )
@@ -9409,7 +9435,8 @@ fn entity_granular_fused_files(
         };
         keyed_lists.push(keyed);
     }
-    let fused_entities = reciprocal_rank_fusion_entities(&keyed_lists, 60.0);
+    let rrf_k = locate_env_f32("KIN_LOCATE_RRF_K", 60.0);
+    let fused_entities = reciprocal_rank_fusion_entities(&keyed_lists, rrf_k);
     // Project entity ranking → files: each file takes its best entity's score.
     let mut best_per_file: HashMap<String, f32> = HashMap::new();
     for (_, path, score) in &fused_entities {
@@ -9786,8 +9813,10 @@ fn reciprocal_rank_fusion_weighted(
     let mut signal_counts: FxHashMap<String, usize> = FxHashMap::default();
 
     // Track which graph-structural signal indices each file appears in.
-    // multihop=1, tests=2, imports=4, cochange=6.
-    let graph_signal_indices: HashSet<usize> = [1, 2, 4, 6].iter().copied().collect();
+    // multihop=1, tests=2, imports=4, cochange=6 (override:
+    // KIN_LOCATE_GRAPH_SIGNAL_INDICES as a comma-separated list).
+    let graph_signal_indices: HashSet<usize> =
+        locate_env_usize_set("KIN_LOCATE_GRAPH_SIGNAL_INDICES", &[1, 2, 4, 6]);
     let mut graph_signal_counts: FxHashMap<String, usize> = FxHashMap::default();
 
     for (list_idx, list) in ranked_lists.iter().enumerate() {

--- a/crates/kin-ranking/src/lib.rs
+++ b/crates/kin-ranking/src/lib.rs
@@ -22,15 +22,27 @@ pub struct WeightConfig {
     pub proof_bias: f32,
 }
 
+/// Read a non-negative finite `f32` override from the environment, falling back to
+/// `default` when the variable is unset or unparseable. Keeps the unset path
+/// byte-identical to the hardcoded defaults so ranking is unchanged unless an
+/// operator opts in.
+fn rank_env_f32(name: &str, default: f32) -> f32 {
+    std::env::var(name)
+        .ok()
+        .and_then(|value| value.parse::<f32>().ok())
+        .filter(|value| value.is_finite() && *value >= 0.0)
+        .unwrap_or(default)
+}
+
 impl Default for WeightConfig {
     fn default() -> Self {
         Self {
-            lexical: 0.30,
-            semantic: 0.28,
-            graph: 0.18,
-            proof: 0.16,
-            provenance: 0.08,
-            proof_bias: 1.35,
+            lexical: rank_env_f32("KIN_RANK_LEXICAL", 0.30),
+            semantic: rank_env_f32("KIN_RANK_SEMANTIC", 0.28),
+            graph: rank_env_f32("KIN_RANK_GRAPH", 0.18),
+            proof: rank_env_f32("KIN_RANK_PROOF", 0.16),
+            provenance: rank_env_f32("KIN_RANK_PROVENANCE", 0.08),
+            proof_bias: rank_env_f32("KIN_RANK_PROOF_BIAS", 1.35),
         }
     }
 }


### PR DESCRIPTION
## Summary

Wires the previously-hardcoded `locate` ranking constants behind environment
variables so they can be swept empirically. Each variable defaults to the
existing hardcoded value, so ranking is **byte-identical when nothing is set** —
this is purely additive plumbing, no default behavior change.

## What changed

**RRF rank-saturation constant** (`k` in `w / (k + rank + 1)`, default `60.0`)
- `KIN_LOCATE_RRF_K`, read once per fusion scope and applied at every
  track-regime fusion call site (Traceback / EntityDominant / GraphStructural /
  BroadBlend) and the entity-granular fusion path.

**WeightConfig ranking weights** (`kin-ranking`)
- `KIN_RANK_LEXICAL` (0.30), `KIN_RANK_SEMANTIC` (0.28), `KIN_RANK_GRAPH` (0.18),
  `KIN_RANK_PROOF` (0.16), `KIN_RANK_PROVENANCE` (0.08), `KIN_RANK_PROOF_BIAS` (1.35).

**Graph-structural signal-index set**
- `KIN_LOCATE_GRAPH_SIGNAL_INDICES`, comma-separated (default `1,2,4,6`).
  A non-numeric field makes the whole override fall back so a typo cannot
  silently drop graph signals.

## Notes

- Env helpers follow the existing `locate_env_f32/usize/bool` pattern; a new
  `locate_env_usize_set` parses the index-set var, and a crate-local
  `rank_env_f32` covers the `WeightConfig` defaults.
- The `60.0` literals left untouched are unrelated path/priority scores, not RRF
  `k`; test-module literals are likewise unchanged.
- `Cargo.lock` is unchanged (registry sources intact).

## Verification

- `cargo build -p kin-ranking -p kin-cli` — clean.
- `cargo test -p kin-ranking` — 104 passed.
- `cargo test -p kin-cli --lib` — 563 passed (incl. RRF determinism/parity tests).
- No new clippy warnings from the added code.