### PR TITLE
docs(security): release signing and update-trust auditor doc

### DIFF
--- a/docs/security/signing-and-update-trust.md
+++ b/docs/security/signing-and-update-trust.md
@@ -1,0 +1,186 @@
+# Release Signing and Update Trust
+
+This document describes the trust chain a downloaded Kin release carries and how
+that trust is verified on install, for a reviewer auditing the supply chain. It
+describes the release pipeline as it exists in
+[`.github/workflows/release.yml`](../../.github/workflows/release.yml) and the
+installer in [`scripts/install.sh`](../../scripts/install.sh); where a property
+is conditional or not yet enforced, that is called out.
+
+For the daemon/projection runtime trust model see
+[threat-model.md](./threat-model.md); for vulnerability reporting see
+[SECURITY.md](../../SECURITY.md).
+
+## What a Release Contains
+
+A tagged release (`v*.*.*`) builds one archive per platform. Each archive bundles
+the `kin` CLI, the mandatory `kin-daemon`, and — when built — the `kin-vfs`
+projection CLI and its interposition shim. Every archive is published alongside a
+per-artifact SHA-256 file:
+
+| Platform | Archive | Checksum |
+| --- | --- | --- |
+| Linux x86_64 | `kin-linux-x86_64.tar.gz` | `.tar.gz.sha256` |
+| Linux aarch64 | `kin-linux-aarch64.tar.gz` | `.tar.gz.sha256` |
+| macOS x86_64 | `kin-macos-x86_64.tar.gz` | `.tar.gz.sha256` |
+| macOS aarch64 | `kin-macos-aarch64.tar.gz` | `.tar.gz.sha256` |
+| Windows x86_64 | `kin-windows-x86_64.zip` | `.zip.sha256` |
+
+A convenience `checksums-sha256.txt` aggregating every per-artifact file is also
+attached to the release, but the installer verifies against the per-artifact
+`.sha256` file, not the aggregate.
+
+The Windows leg is marked experimental (`continue-on-error`) while its
+vector-free dependency path is hardened, so it must not be treated as a fully
+supported, signed target.
+
+## Two Independent Integrity Layers
+
+Kin's release trust rests on two layers that are verified independently:
+
+1. **A SHA-256 checksum** published next to every archive. This is the
+   cross-platform integrity check the installer enforces on every platform.
+2. **Apple code-signing and notarization** of the macOS binaries. This is an
+   OS-level authenticity and integrity check enforced by macOS Gatekeeper, and
+   it applies only to the macOS artifacts.
+
+Linux and Windows artifacts rely on the SHA-256 layer (plus the integrity of the
+GitHub release asset host); they are not OS-code-signed by this pipeline today.
+
+## macOS Trust Chain
+
+The macOS legs sign and notarize **before** packaging, so the published tarball
+and its SHA-256 cover the already-signed binaries. The chain has three links.
+
+### 1. Developer ID Application signature (hardened runtime)
+
+The signing certificate is imported into a throwaway keychain on the runner from
+the `MACOS_CERTIFICATE` / `MACOS_CERTIFICATE_PWD` secrets, then each binary
+(`kin`, `kin-daemon`, `kin-vfs`, and the `libkin_vfs_shim.dylib` shim) is signed:
+
+```
+codesign --force --options runtime --timestamp --sign "$MACOS_DEVELOPER_ID" "$f"
+codesign --verify --strict --verbose=2 "$f"
+```
+
+- `--sign "$MACOS_DEVELOPER_ID"` signs with the project's **Developer ID
+  Application** identity. This is the identity Gatekeeper checks to attribute the
+  binary to a known Apple Developer account.
+- `--options runtime` opts the binary into the **hardened runtime**, which
+  Apple requires for notarization.
+- `--timestamp` embeds a **secure (trusted) timestamp** from Apple's timestamp
+  authority, so the signature remains valid after the signing certificate later
+  expires.
+- The immediate `codesign --verify --strict` re-checks each binary in the same
+  job, so a signing failure fails the build rather than shipping an unsigned
+  binary under a signed-looking name.
+
+The signing secrets are surfaced as job-level environment so steps can guard on
+`env.MACOS_CERTIFICATE != ''`. When those secrets are **absent**, every signing
+and notarization step is skipped and the pipeline still builds, packages, and
+publishes the (then-unsigned) binaries. A reviewer therefore cannot infer from
+the presence of a release alone that a given build was signed; signing is gated
+on the secrets being configured for that run.
+
+### 2. Apple notarization
+
+After signing, the macOS binaries are zipped and submitted to Apple's
+notarization service:
+
+```
+xcrun notarytool submit "$NOTARIZE_ZIP" \
+  --apple-id "$APPLE_ID" \
+  --password "$APPLE_APP_SPECIFIC_PASSWORD" \
+  --team-id "$APPLE_TEAM_ID" \
+  --wait --timeout 30m
+```
+
+Notarization uploads the signed binaries to Apple, which scans them and, on
+success, issues a notarization ticket bound to the binaries' code-signing
+identity. The `--wait` makes the job block on the result (capped at 30 minutes so
+a stalled Apple queue fails fast rather than burning the runner), and a
+notarization rejection fails the job. This step runs only when both the signing
+certificate and `APPLE_ID` secrets are present.
+
+### 3. Online ticket validation (no stapling)
+
+The released artifacts are bare CLI binaries inside a `.tar.gz`. Apple's
+`xcrun stapler` can only staple `.app` bundles, `.dmg`, `.pkg`, and `.xip`, so
+the notarization ticket is **not stapled to the artifact**. Instead the ticket
+lives on Apple's servers and is validated **online by Gatekeeper on first run**.
+
+Audit consequence: an end user verifying notarization offline (e.g.
+`stapler validate`) will not find a stapled ticket on the tarball or the bare
+binary — that is expected for this artifact shape, not a signing gap. If a
+`.dmg`/`.pkg` installer is added later, the pipeline has a documented place to
+add `xcrun stapler staple`.
+
+## Linux Release Posture (static musl)
+
+The Linux core binaries (`kin`, `kin-daemon`) target
+`*-unknown-linux-musl` and link **static by default**. A single Linux artifact
+per architecture therefore runs across distros — musl (Alpine) and glibc
+(Ubuntu/Debian/RHEL) alike — with no OpenSSL or glibc-version coupling. From a
+supply-chain standpoint this means the Linux binary does not dynamically pull a
+host TLS/crypto library at runtime for its own operation; the musl C toolchain
+(`musl-tools`) is installed only to build the static C dependencies (ring,
+oniguruma, sqlite, tree-sitter).
+
+The `kin-vfs` shim is the deliberate exception: an `LD_PRELOAD` interposer is
+intrinsically libc-specific, so the VFS leg is built against the `gnu` target
+(`vfs_target`) so it can preload into the host distro's glibc programs. The
+core CLI/daemon remain static-musl regardless.
+
+## Install-Time Verification
+
+The installer (`scripts/install.sh`) refuses to install an unverified download.
+Its checksum gate is mandatory and fail-closed:
+
+1. It downloads the archive and its per-artifact `.sha256`. If the checksum file
+   cannot be fetched or is empty/malformed, the installer **aborts** ("Refusing
+   to install an unverified download").
+2. It recomputes the archive's SHA-256 with `shasum -a 256` (or `sha256sum`). If
+   neither tool is present it **aborts** rather than skipping verification.
+3. It compares the computed hash against the published one and **aborts on
+   mismatch** ("The download may be corrupted or tampered with").
+
+Only after the checksum matches does it extract and install. The installer also
+asserts `kin-daemon` is present in the archive before moving any files, so a
+daemon-less archive aborts cleanly instead of leaving a half-installed
+environment.
+
+On macOS, the second, independent layer is enforced by the OS at run time:
+because the binaries are signed with a Developer ID and notarized, Gatekeeper
+validates the signature and (online) the notarization ticket the first time each
+binary runs. A tampered macOS binary fails Gatekeeper even if it somehow passed
+the checksum step.
+
+### Verifying a download manually
+
+```sh
+# Compare the recomputed checksum against the published per-artifact file.
+shasum -a 256 -c kin-macos-aarch64.tar.gz.sha256
+
+# macOS: confirm the binary is signed with a Developer ID and accepted.
+codesign --verify --strict --verbose=2 ./kin
+spctl --assess --type execute --verbose ./kin
+```
+
+## Trust Boundaries and Residual Risk
+
+- **CI is in the trusted computing base.** The signing identity and Apple
+  credentials are GitHub Actions secrets available to the release workflow. A
+  compromise of the release pipeline or its secrets could produce a validly
+  signed malicious build. This is the standard trust assumption for
+  CI-signed releases.
+- **Unsigned-but-published builds are possible.** Because every signing step is
+  guarded on the secrets being present, a run without those secrets publishes
+  unsigned binaries. Verify the macOS signature/notarization (above) rather than
+  assuming a release is signed.
+- **Linux/Windows have one integrity layer.** They are protected by the SHA-256
+  checksum and the release host, not by an OS code signature from this pipeline.
+  The checksum protects integrity (tamper-evidence) but not authorship
+  attribution the way a code signature does.
+- **npm and Homebrew distribution** are downstream of the GitHub release. The
+  npm wrapper publishes via OIDC Trusted Publishing (no long-lived `NPM_TOKEN`),
+  and the Homebrew tap consumes the published archives and their checksums.

--- a/docs/security/threat-model.md
+++ b/docs/security/threat-model.md
@@ -10,6 +10,8 @@ repository in the ecosystem, that is called out so the authority for the
 implementation is unambiguous.
 
 For how to report a suspected vulnerability, see [SECURITY.md](../../SECURITY.md).
+For the trust chain a downloaded release carries and how it is verified on
+install, see [signing-and-update-trust.md](./signing-and-update-trust.md).
 
 ## Scope and Trust Model
 
@@ -132,7 +134,9 @@ graph-backed content to unmodified tools by interposing on libc file calls using
 the dynamic loader's preload mechanism (`LD_PRELOAD` on Linux,
 `DYLD_INSERT_LIBRARIES` on macOS). The projection's implementation and its
 detailed security properties are owned by `kin-vfs`; this section states the
-trust boundary as it pertains to running Kin.
+trust boundary as it pertains to running Kin. For the shim's re-entrancy and
+signal-safety handling specifically, see the `kin-vfs` note
+`docs/security/shim-reentrancy-and-signal-safety.md`.
 
 The interposition library is loaded **into the address space of the target
 process** and runs with that process's privileges. Two consequences follow:


### PR DESCRIPTION
Adds an auditor-facing doc, `docs/security/signing-and-update-trust.md`, completing the security-audit prep alongside the existing threat model and `SECURITY.md`.

## What it documents
- **macOS trust chain** (grounded in `.github/workflows/release.yml`): Developer ID Application signing with `--options runtime` (hardened runtime) and `--timestamp` (trusted timestamp), the in-job `codesign --verify --strict`, Apple notarization via `xcrun notarytool submit --wait`, and the fact that the notarization ticket is validated online by Gatekeeper on first run rather than stapled (bare CLI binaries in a `.tar.gz` cannot be stapled).
- **Two independent integrity layers**: the cross-platform SHA-256 checksum and, on macOS only, OS-level signing/notarization.
- **Linux static-musl posture**: core `kin`/`kin-daemon` link static against musl with no OpenSSL/glibc coupling; the VFS shim is the deliberate libc-specific (gnu) exception.
- **Install-time verification** (grounded in `scripts/install.sh`): the fail-closed SHA-256 gate that aborts on a missing/empty/mismatched checksum or a missing hash tool, plus manual `shasum -c` / `codesign` / `spctl` commands.
- **Trust boundaries / residual risk**: CI is in the TCB; signing is gated on secrets being present (an unsigned-but-published build is possible); Linux/Windows have a single integrity layer.

## Notes
- Also adds two cross-reference lines in `threat-model.md` pointing to this doc and to the kin-vfs shim re-entrancy note.
- Every claim is grounded in the actual workflow/installer source; conditional or not-yet-enforced behavior is called out explicitly.
- Docs only — no code changes.