### PR TITLE
ci(docker): ride out transient registry 502 in Docker Image Build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,6 +14,10 @@ WORKDIR /build/kin
 # registry that kin-* crates resolve from (the Git [patch.kin] pins were dropped
 # at the registry cutover — kin no longer depends on GitHub for crate deps).
 RUN test -f .cargo/config.toml && grep -q '^\[registries\.kin\]' .cargo/config.toml
+# The kin sparse registry can return a brief 502 during a deploy/cold start.
+# Cargo's default of 3 retries can be exhausted inside such a window and fail
+# the whole build; raise the retry budget so a transient blip is ridden out.
+ENV CARGO_NET_RETRY=10
 # kin-daemon needs --features gcs for GCS StorageBackend in cloud deployment.
 RUN cargo build --release --features gcs --bin kin-daemon --bin kin
 


### PR DESCRIPTION
The "Docker Image Build (no push)" check intermittently fails on PRs and main with cargo unable to reach the kin sparse registry:

```
warning: spurious network error (1 try remaining): failed to get successful HTTP
response from `https://kinlab.ai/registry/cargo/config.json` (34.120.192.24), got 502
```
(e.g. run 28186597773). The builder stage resolves kin-* crates from `https://kinlab.ai/registry/cargo/`. During a registry deploy / cold start the index returns a brief 502; cargo's default of 3 retries is exhausted inside that short window and the entire image build fails red, even though nothing in the PR is broken.

## Fix
Set `ENV CARGO_NET_RETRY=10` in the builder stage before `cargo build`. Cargo applies exponential backoff between retries, so 10 attempts span a meaningfully longer window and ride out a transient blip. Placed in the Dockerfile (not just the workflow) so every build path — this CI gate, Cloud Build, and local `docker build` — benefits.

Validated with `docker buildx build --check`: no warnings. YAML/Dockerfile-only.

Note: this is a transient-availability flake, not the FIR-1151 billing block — the job starts and runs; it just loses a registry race. Companion PRs address the same registry-502 root cause in kin-bench cargo-deny.