### PR TITLE
fix(kin-cli): stop release_orch doc diagram compiling as a doctest

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2930,6 +2930,8 @@ dependencies = [
  "tar",
  "tempfile",
  "tokio",
+ "toml 0.8.23",
+ "toml_edit",
  "tracing",
  "tracing-subscriber",
  "url",

--- a/crates/kin-cli/src/commands/release_orch.rs
+++ b/crates/kin-cli/src/commands/release_orch.rs
@@ -12,7 +12,9 @@
 //! apply` / `kin release intent`). It reads registry truth plus the local
 //! sibling manifests and answers, in one bottom-up view
 //!
-//!     primitives -> kin-model -> kin-db -> kin -> kin-bench/kin-vfs/kin-lsp
+//! ```text
+//! primitives -> kin-model -> kin-db -> kin -> kin-bench/kin-vfs/kin-lsp
+//! ```
 //!
 //!   - which registry crates have a local version ahead of what is published
 //!     (a publish is pending),


### PR DESCRIPTION
## Summary

Two CI checks fail on `main` today (introduced by #125 / the `release_orch` orchestrator) and every PR branched off `main` inherits them. This fixes both.

### 1. `Check & Test` — broken doctest

`crates/kin-cli/src/commands/release_orch.rs` carried the bottom-up release ordering as a four-space-indented line inside the module doc comment:

```
//!     primitives -> kin-model -> kin-db -> kin -> kin-bench/kin-vfs/kin-lsp
```

Rustdoc treats an indented block in a doc comment as a Rust code block, so it was compiled as a doctest and failed (the line is not valid Rust):

```
error[E0425]: cannot find value `lsp` in this scope
error[E0423]: expected value, found attribute macro `bench`
... doctest failed, 1 failed
```

Fix: fence the diagram as a ```` ```text ```` block so it renders as prose and is no longer compiled. Scanned the whole file's doc comments — this was the only non-Rust block; the remaining indented line (`(a publish is pending),`) is markdown list-continuation, not a code block.

### 2. `Linux Daemon Smoke + MCP Headless` (`--locked`) — stale lock

The orchestrator added `toml` / `toml_edit` usage (and the matching `kin-cli/Cargo.toml` deps), but `Cargo.lock`'s `kin-cli` entry never recorded them, so `--locked` refused (`cannot update the lock file ... --locked was passed`).

Fix: add the two missing dependency edges to the `kin-cli` lock entry. Both packages (`toml 0.8.23`, `toml_edit 0.22.27`) already existed in the lock, so the change is exactly two lines. Generated from a registry-only checkout outside `$HOME`, so registry sources and checksums are preserved and no `[patch.kin]` path patch leaked in.

## Verification

Run in a registry-only checkout (clean `CARGO_HOME`, no `[patch.kin]`), mirroring CI:

- `cargo test -p kin-cli --doc` → ok (0 failed)
- `cargo metadata --locked` → exit 0 (lock consistent)
- `cargo build --locked -p kin-cli` → Finished, exit 0
- `cargo fmt --check -p kin-cli` → clean
- `cargo clippy --all-targets --all-features` with the ci.yml allow-list and `RUSTFLAGS=-D warnings` → clean

`git diff Cargo.lock` is the two-line edge addition only — no source/checksum churn.