### PR TITLE
fix: disable git gc.auto in tests to prevent parallel import race condition

### DIFF
--- a/crates/kin-git/src/import.rs
+++ b/crates/kin-git/src/import.rs
@@ -524,6 +524,10 @@ mod tests {
                     .args(["config", "user.name", "Test"])
                     .current_dir(dir)
                     .output();
+                let _ = Command::new("git")
+                    .args(["config", "gc.auto", "0"])
+                    .current_dir(dir)
+                    .output();
                 true
             }
             _ => false,


### PR DESCRIPTION
Closes FIR-1003 (PR #128 flaky test issue).
In `parallel_import_is_byte_identical_to_serial`, multiple commits generate loose objects. If an implicit `git gc --auto` starts in the background (or if high test concurrency triggers a race), git cleans up loose objects into packfiles while `gix` is iterating them via `thread_safe.to_thread_local()`. Disabling `gc.auto` exclusively in the test repo prevents the missing object error.