### PR TITLE
fix(locate): gate cross-encoder rerank on graph presence not workspace root

### DIFF
--- a/crates/kin-cli/src/commands/locate.rs
+++ b/crates/kin-cli/src/commands/locate.rs
@@ -2372,7 +2372,14 @@ pub fn run_with_graph_capture_with_priority_files_and_vector_source(
     if locate_env_bool("KIN_LOCATE_CROSS_ENCODER_ENABLED", false) {
         let ltr_window = locate_env_usize("KIN_LOCATE_LTR_WINDOW", 20).min(fused.len());
         if ltr_window > 0 {
-            if workspace_root.is_some() {
+            // Gate the cross-encoder rerank on graph presence, not a live
+            // workspace root. The candidate text is built entirely from
+            // `graph_derived_candidate_text` (graph-owned artifact bodies), so the
+            // reranker only needs the graph's retrievable artifacts to score
+            // against. Scoped sessions run with `workspace_root = None` while
+            // keeping a populated graph, so the gate must key on the graph to stay
+            // effective in that mode.
+            if cross_encoder_has_graph_candidates(graph) {
                 let model_id = std::env::var("KIN_LOCATE_CROSS_ENCODER_MODEL")
                     .unwrap_or_else(|_| "BAAI/bge-reranker-base".to_string());
                 let revision = std::env::var("KIN_LOCATE_CROSS_ENCODER_REVISION")
@@ -2474,7 +2481,8 @@ pub fn run_with_graph_capture_with_priority_files_and_vector_source(
                 }
             } else {
                 tracing::warn!(
-                    "skipping cross-encoder rerank because no live workspace root is available"
+                    "skipping cross-encoder rerank because the graph has no entities \
+                     to derive candidate text from"
                 );
             }
         }
@@ -7953,6 +7961,19 @@ fn graph_derived_candidate_text(graph: &kin_db::InMemoryGraph, path: &str) -> St
             String::new()
         }
     }
+}
+
+/// Whether the cross-encoder rerank stage has graph truth to rerank against.
+///
+/// The reranker scores `graph_derived_candidate_text`, whose bodies are resolved
+/// from graph-owned artifacts (`get_opaque_artifact`), so its only data
+/// precondition is that the graph holds those retrievable artifacts. It is
+/// deliberately independent of any live `workspace_root`: scoped sessions run
+/// with `workspace_root = None` while keeping a populated graph, and the
+/// candidate text is graph-owned, so keying the gate on the graph keeps the
+/// reranker effective in scoped mode.
+fn cross_encoder_has_graph_candidates(graph: &kin_db::InMemoryGraph) -> bool {
+    graph.artifact_count() > 0
 }
 
 fn workspace_source_path_exists(path: &str, workspace_root: Option<&std::path::Path>) -> bool {
@@ -13781,6 +13802,38 @@ mod tests {
             graph_derived_candidate_text(&graph, "src/foo.rs"),
             "GRAPH_BODY_MARKER",
             "graph-owned body is the only authority for candidate text"
+        );
+    }
+
+    #[test]
+    fn cross_encoder_gate_keys_on_graph_presence_not_workspace_root() {
+        // In scoped eval the daemon runs with `workspace_root = None` while still
+        // passing a populated scoped graph. The cross-encoder scores
+        // graph-derived candidate text, so the rerank gate must fire on graph
+        // presence alone — an absent workspace root must not disable it.
+        let scoped_graph = kin_db::InMemoryGraph::new();
+        scoped_graph
+            .upsert_opaque_artifact(&OpaqueArtifact {
+                file_id: FilePathId::new("src/scoped.rs"),
+                content_hash: Hash256::from_bytes([13; 32]),
+                mime_type: Some("text/x-rust".into()),
+                text_preview: Some("SCOPED_GRAPH_BODY".into()),
+            })
+            .unwrap();
+        assert!(scoped_graph.artifact_count() > 0);
+        assert!(
+            cross_encoder_has_graph_candidates(&scoped_graph),
+            "a populated scoped graph must enable the cross-encoder even when \
+             workspace_root is None"
+        );
+
+        // An empty graph offers no candidate text to rerank, so the gate stays
+        // closed and the stage is skipped — never a raw-disk fallback.
+        let empty_graph = kin_db::InMemoryGraph::new();
+        assert_eq!(empty_graph.artifact_count(), 0);
+        assert!(
+            !cross_encoder_has_graph_candidates(&empty_graph),
+            "an empty graph has no candidate text, so the rerank gate stays closed"
         );
     }
 


### PR DESCRIPTION
## Summary

In scoped-eval mode the cross-encoder rerank stage in `locate` could never fire,
even when explicitly enabled. The daemon nulls `workspace_root` whenever a
session scope is active (`kin-daemon/src/api.rs`:
`let workspace_root = if scope_ref_string.is_some() { None } else { ... }`), and
the rerank stage was gated on `workspace_root.is_some()`. So with a scoped
session the gate was always false and the reranker was silently skipped.

That gate was gratuitous and non-graph-native: the rerank candidate text is
**already** built entirely from graph-owned bodies via
`graph_derived_candidate_text` → `graph_source_text` → `get_opaque_artifact`
(which fails loud / records a graph gap on a miss and never reads raw disk). The
reranker needs the graph's retrievable artifacts, not a filesystem root.

## Change

Gate the cross-encoder rerank on **graph presence** instead of a live workspace
root, via a small extracted predicate.

Before (`crates/kin-cli/src/commands/locate.rs`):

```rust
if ltr_window > 0 {
    if workspace_root.is_some() {
        // ... build candidates from graph_derived_candidate_text(graph, path)
        //     and run kin_db::embed::rerank::CrossEncoder
```

After:

```rust
if ltr_window > 0 {
    // Gate on graph presence, not a live workspace root: the candidate text is
    // graph-owned artifact bodies, so the reranker only needs the graph's
    // retrievable artifacts.
    if cross_encoder_has_graph_candidates(graph) {   // graph.artifact_count() > 0
```

`cross_encoder_has_graph_candidates` is co-located with
`graph_derived_candidate_text` and keys on `artifact_count()` — the exact graph
content (`opaque_artifacts`) that supplies the CE's candidate text. Extracting it
makes the gate unit-testable and makes any future revert to a filesystem gate
visible in review.

This is strictly **more** graph-native: the rerank path runs on graph-derived
text through the pure-Rust `kin_db::embed::rerank::CrossEncoder` (kin-infer
`BertModel` — no ONNX), with no raw-filesystem authority.

## Scope / behavior

- Default behavior is unchanged. The stage stays **off by default**, opt-in via
  `KIN_LOCATE_CROSS_ENCODER_ENABLED`. This PR only makes that flag *effective* in
  scoped mode.
- Non-scoped mode is unaffected (the graph holds artifacts there too, so the gate
  is equivalent to before in practice).
- The `else` branch now reports a graph gap ("graph has no entities to derive
  candidate text from") instead of a missing workspace root.

## Fairness / honesty

This removes a **self-handicap on the kin arm**; it does not advantage kin. The
competitor `BM25 + CE` baseline arm already runs a cross-encoder. With the old
gate, the kin arm in scoped eval could not run one at all. This change
**equalizes** the two arms so both can apply a cross-encoder over their
candidates — it adds no kin-only retrieval advantage.

## Recommended re-run configuration

Per the retrieval audit, the cross-encoder should be used in **blend /
promotion-only** mode, not the default substitutive mode (which overwrites the
fused score with the raw logit and can evict multi-signal-corroborated golds).
The blend path is reachable and is the intended configuration:

```
KIN_LOCATE_CROSS_ENCODER_ENABLED=true \
KIN_LOCATE_RERANK_BLEND=true \
KIN_LOCATE_RERANK_BLEND_WEIGHT=0.04
```

## Validation (code-only; no daemon / no GPU)

Run from a registry-clean checkout outside `$HOME` with an isolated, patch-free
`CARGO_HOME` (no `[patch.kin]` leak; `kin-db 0.2.24` / `kin-infer 0.2.35`
resolved from the kin registry):

- `cargo build -p kin-cli -p kin-daemon --locked` — clean.
- New unit test `cross_encoder_gate_keys_on_graph_presence_not_workspace_root`
  passes: the gate fires on a populated graph with **no** workspace root (the
  scoped-mode case) and stays closed on an empty graph.
- `cargo fmt` clean.
- `cargo clippy --all-targets --all-features` with the repo CI allowlist and
  `RUSTFLAGS=-D warnings` — exit 0, clean.
