### PR TITLE
fix(spine): bind cross-repo imports by normalized crate root + refresh every repo

### DIFF
--- a/crates/kin-daemon/src/api.rs
+++ b/crates/kin-daemon/src/api.rs
@@ -817,6 +817,10 @@ fn api_routes() -> Router<Arc<DaemonState>> {
         .route("/spine/impact", get(spine_impact))
         .route("/spine/xref", get(spine_xref))
         .route("/spine/repos/{repo_id}/ingest", post(spine_ingest_repo))
+        .route(
+            "/spine/refresh-cross-repo-edges",
+            post(spine_refresh_cross_repo_edges),
+        )
         // LSP enrichment — trigger a full cold sweep
         .route("/lsp/sweep", post(lsp_sweep))
 }
@@ -6192,6 +6196,28 @@ async fn spine_ingest_repo(
     })))
 }
 
+/// `POST /spine/refresh-cross-repo-edges` — re-resolve cross-repo edges for
+/// every registered repo.
+///
+/// The control-plane import orchestrator calls this once, after all repos are
+/// ingested, so cross-repo edges emanate from every repo (mirroring the local
+/// daemon's multi-anchor pass) rather than only the anchor. Loads each repo's
+/// graph from durable storage and re-materializes its outgoing edges; the
+/// operation is idempotent. Field names are camelCase to match the orchestrator.
+async fn spine_refresh_cross_repo_edges(
+    State(state): State<Arc<DaemonState>>,
+) -> Result<impl IntoResponse, (StatusCode, String)> {
+    let outcome = state
+        .refresh_all_cross_repo_edges()
+        .await
+        .map_err(internal_error)?;
+
+    Ok(Json(json!({
+        "reposRefreshed": outcome.repos_refreshed,
+        "crossRepoEdges": outcome.cross_repo_edges,
+    })))
+}
+
 /// POST /lsp/sweep — trigger a full LSP cold sweep of all entities.
 async fn lsp_sweep(State(state): State<Arc<DaemonState>>) -> impl IntoResponse {
     state.queue_lsp_sweep();
@@ -9319,6 +9345,50 @@ mod tests {
             StatusCode::INTERNAL_SERVER_ERROR,
             "ingest without a storage backend must surface an error, not a 200"
         );
+    }
+
+    #[tokio::test]
+    async fn spine_refresh_cross_repo_edges_route_is_wired_and_degrades_gracefully() {
+        // The hosted orchestrator calls this final pass after every repo is
+        // ingested so edges emanate from every repo, not just the anchor. Without
+        // a storage backend (the local single-repo daemon) no repo graph can be
+        // loaded, so the pass refreshes nothing — but it must still answer 200
+        // with the camelCase contract the orchestrator reads, never a 500/panic.
+        let state = test_state();
+        let spine = state.ensure_spine().expect("spine enabled in test");
+        // Register two repos' metadata so the pass has a non-empty repo set to
+        // iterate over (their graphs are unavailable without a backend).
+        spine.register_repo("kin", vec![], "");
+        spine.register_repo("kin-db", vec![], "");
+        let app = router(state);
+
+        let response = app
+            .oneshot(
+                Request::post("/spine/refresh-cross-repo-edges")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(response.status(), StatusCode::OK);
+        let body: serde_json::Value = serde_json::from_slice(
+            &axum::body::to_bytes(response.into_body(), 4096)
+                .await
+                .unwrap(),
+        )
+        .unwrap();
+        assert!(
+            body.get("reposRefreshed").is_some(),
+            "response must carry reposRefreshed, got {body}"
+        );
+        assert!(
+            body.get("crossRepoEdges").is_some(),
+            "response must carry crossRepoEdges, got {body}"
+        );
+        // No backend → no repo graph loadable → nothing refreshed, but a clean
+        // 200 rather than a hard failure.
+        assert_eq!(body["reposRefreshed"], serde_json::json!(0));
     }
 
     /// One gate proving the cross-repo blast radius is consistent across every

--- a/crates/kin-daemon/src/state.rs
+++ b/crates/kin-daemon/src/state.rs
@@ -236,6 +236,21 @@ pub struct SpineIngestOutcome {
     pub resolvable_relations: usize,
 }
 
+/// Outcome of refreshing cross-repo edges across every registered repo.
+///
+/// Returned by [`DaemonState::refresh_all_cross_repo_edges`] and surfaced by the
+/// `POST /spine/refresh-cross-repo-edges` route. The hosted import orchestrator
+/// runs this final pass once every repo is registered so cross-repo edges
+/// emanate from every repo (kin-db→kin-search, kin-model→kin-vector, …), not
+/// only the anchor.
+#[derive(Debug, Clone)]
+pub struct SpineRefreshOutcome {
+    /// Repos whose outgoing cross-repo edges were re-resolved.
+    pub repos_refreshed: usize,
+    /// Total cross-repo edges in the spine after the refresh pass.
+    pub cross_repo_edges: usize,
+}
+
 /// Shared daemon state. All mutable state is behind RwLock for
 /// concurrent access from the reconciliation loop and API handlers.
 pub struct DaemonState {
@@ -1040,6 +1055,64 @@ impl DaemonState {
             entity_count,
             relation_count,
             resolvable_relations,
+        })
+    }
+
+    /// Refresh cross-repo edges for EVERY registered repo, mirroring the local
+    /// [`Self::initialize_spine_lazy`] "register all, then resolve all" pass.
+    ///
+    /// The per-repo ingest path only materializes the anchor repo's edges, so a
+    /// repo ingested before its dependency was registered never forms its
+    /// outgoing edges. This final pass — run by the hosted orchestrator once
+    /// every repo is registered — loads each registered repo's graph from
+    /// durable storage (the blob store, never on-disk siblings) and re-resolves
+    /// its imports against the now-complete spine. It is idempotent: each repo's
+    /// existing edges are removed and re-materialized.
+    pub async fn refresh_all_cross_repo_edges(&self) -> Result<SpineRefreshOutcome> {
+        let Some(spine) = self.ensure_spine() else {
+            return Err(DaemonError::Graph(kin_db::KinDbError::StorageError(
+                "spine disabled via KIN_DISABLE_SPINE".to_string(),
+            )));
+        };
+
+        // Resolve against the full registered-repo set, sorted for a
+        // deterministic pass order.
+        let mut registry_ids: Vec<String> = spine.registered_repo_ids().into_iter().collect();
+        registry_ids.sort();
+
+        let mut repos_refreshed = 0usize;
+        for repo_id in &registry_ids {
+            // Load this repo's graph from durable storage (cached after the first
+            // load). Skip a repo this pod cannot load rather than aborting the
+            // whole pass — the others still refresh.
+            let graph = match self.get_repo_graph(repo_id).await {
+                Ok(graph) => graph,
+                Err(e) => {
+                    warn!(repo_id, error = %e, "skipping cross-repo refresh: graph load failed");
+                    continue;
+                }
+            };
+            let entities = match graph.list_all_entities() {
+                Ok(entities) => entities,
+                Err(e) => {
+                    warn!(repo_id, error = %e, "skipping cross-repo refresh: entity listing failed");
+                    continue;
+                }
+            };
+            let relations = Self::collect_spine_relations(graph.as_ref(), &entities);
+            spine.refresh_cross_repo_edges(repo_id, &entities, &relations, &registry_ids);
+            repos_refreshed += 1;
+        }
+
+        info!(
+            repos_refreshed,
+            cross_repo_edges = spine.edge_count(),
+            "refreshed cross-repo edges across all registered repos"
+        );
+
+        Ok(SpineRefreshOutcome {
+            repos_refreshed,
+            cross_repo_edges: spine.edge_count(),
         })
     }
 

--- a/crates/kin-spine/src/xref.rs
+++ b/crates/kin-spine/src/xref.rs
@@ -80,57 +80,85 @@ pub fn resolve_imports(
     results
 }
 
+/// Normalize a crate name or repo id for cross-repo matching: trim, lowercase,
+/// and fold underscores to hyphens. Rust crate names are written with `_`
+/// (`kin_db`) while repo ids are hyphenated (`kin-db`), so the two compare equal
+/// only after folding.
+fn normalize_repo_token(token: &str) -> String {
+    token.trim().to_lowercase().replace('_', "-")
+}
+
+/// Extract the leading crate/package segment from an import source path. Rust
+/// paths separate with `::` (`kin_db::graph` → `kin_db`) and dotted-module
+/// languages with `.` (`os.path` → `os`); that leading segment is the crate or
+/// top-level package identifying the owning repo.
+fn import_source_root(source: &str) -> &str {
+    let trimmed = source.trim();
+    let crate_seg = trimmed.split("::").next().unwrap_or(trimmed);
+    crate_seg.split('.').next().unwrap_or(crate_seg).trim()
+}
+
 /// Resolve a single import using the 3-tier strategy.
 fn resolve_single(
     index: &SpineIndex,
     import: &UnresolvedImport,
     registered_repos: &HashSet<String>,
 ) -> ResolveResult {
-    // Tier 1: import_source directly matches a registry repo name
+    // The import_source names the crate/package the referenced symbol came
+    // from. Match its root segment against registered repo ids, folding the Rust
+    // crate-name / repo-id spelling gap (`kin_db` ↔ `kin-db`) so real cross-repo
+    // imports bind at Tier 1 instead of collapsing into name-only Tier 3
+    // collisions.
     if let Some(ref source) = import.import_source {
-        if registered_repos.contains(source.as_str()) {
+        let normalized_source = normalize_repo_token(import_source_root(source));
+
+        // Tier 1: the import's crate/package root names a registered repo.
+        if let Some(matched_repo) = registered_repos
+            .iter()
+            .find(|r| normalize_repo_token(r.as_str()) == normalized_source)
+        {
             let matches = index.resolve(
                 &import.imported_name,
                 import.imported_kind,
                 import.reference_fingerprint.as_ref(),
             );
-            let in_source: Vec<&EntityEntry> =
-                matches.iter().filter(|e| e.repo_id == *source).collect();
+            let in_source: Vec<&EntityEntry> = matches
+                .iter()
+                .filter(|e| e.repo_id == *matched_repo)
+                .collect();
 
-            match in_source.len() {
-                0 => {} // Fall through to tier 2/3
-                1 => {
-                    return ResolveResult::Resolved {
-                        target_repo: in_source[0].repo_id.clone(),
-                        target_entity: in_source[0].entity_id,
-                        confidence: 0.95,
-                    };
-                }
-                _ => {
-                    // Multiple in that repo — still high confidence, return best match
-                    let candidates: Vec<(String, EntityId, f32)> = in_source
+            // The import names one specific repo, so resolve only there. A
+            // symbol absent from that repo is a graph gap, not grounds to bind an
+            // unrelated repo by name collision.
+            return match in_source.len() {
+                0 => ResolveResult::NotFound,
+                1 => ResolveResult::Resolved {
+                    target_repo: in_source[0].repo_id.clone(),
+                    target_entity: in_source[0].entity_id,
+                    confidence: 0.95,
+                },
+                _ => ResolveResult::Ambiguous {
+                    candidates: in_source
                         .iter()
                         .map(|e| (e.repo_id.clone(), e.entity_id, 0.95))
-                        .collect();
-                    return ResolveResult::Ambiguous { candidates };
-                }
-            }
+                        .collect(),
+                },
+            };
         }
 
-        // Tier 2: import_source set but doesn't match a repo directly —
-        // use it to filter candidate_repos (repos whose name contains the source)
-        let source_lower = source.to_lowercase();
+        // Tier 2: import_source set but names no registered repo directly —
+        // use its normalized root to narrow candidate_repos by containment.
         let filtered_candidates: Vec<String> = if import.candidate_repos.is_empty() {
             registered_repos
                 .iter()
-                .filter(|r| r.to_lowercase().contains(&source_lower))
+                .filter(|r| normalize_repo_token(r.as_str()).contains(&normalized_source))
                 .cloned()
                 .collect()
         } else {
             import
                 .candidate_repos
                 .iter()
-                .filter(|r| r.to_lowercase().contains(&source_lower))
+                .filter(|r| normalize_repo_token(r.as_str()).contains(&normalized_source))
                 .cloned()
                 .collect()
         };
@@ -997,5 +1025,126 @@ mod tests {
             }
             other => panic!("expected deterministic Ambiguous over both repos, got {other:?}"),
         }
+    }
+
+    #[test]
+    fn normalize_and_root_fold_crate_spelling() {
+        assert_eq!(normalize_repo_token("kin_db"), "kin-db");
+        assert_eq!(normalize_repo_token("Kin_DB"), "kin-db");
+        assert_eq!(normalize_repo_token("kin-db"), "kin-db");
+        assert_eq!(import_source_root("kin_db"), "kin_db");
+        assert_eq!(import_source_root("kin_db::graph::Inner"), "kin_db");
+        assert_eq!(import_source_root("os.path"), "os");
+        assert_eq!(import_source_root("requests"), "requests");
+    }
+
+    #[test]
+    fn rust_crate_underscore_binds_to_hyphenated_repo() {
+        // The Rust parser emits import_source as the crate's module path with an
+        // underscore (`kin_db`), while the repo is registered hyphenated
+        // (`kin-db`). Tier 1 must fold the spelling and bind at 0.95 instead of
+        // dropping to a name-only collision match.
+        let index = SpineIndex::new();
+        index.register_repo(
+            "kin-db",
+            vec![test_entry("kin-db", "InMemoryGraph", EntityKind::Class)],
+            "hash-db",
+        );
+
+        let imports = vec![UnresolvedImport {
+            source_repo: "kin".to_string(),
+            source_entity: EntityId::new(),
+            imported_name: "InMemoryGraph".to_string(),
+            imported_kind: Some(EntityKind::Class),
+            candidate_repos: vec!["kin-db".to_string()],
+            language: Some("rust".to_string()),
+            reference_fingerprint: None,
+            import_source: Some("kin_db".to_string()),
+        }];
+
+        let results = resolve_imports(&index, &imports);
+        match &results[0].1 {
+            ResolveResult::Resolved {
+                target_repo,
+                confidence,
+                ..
+            } => {
+                assert_eq!(target_repo, "kin-db");
+                assert!(
+                    *confidence >= 0.95,
+                    "underscore→hyphen crate match must bind at Tier 1 (0.95), got {confidence}"
+                );
+            }
+            other => panic!("expected Tier-1 Resolved to kin-db, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn multi_segment_module_path_binds_to_crate_repo() {
+        // `use kin_db::graph::InMemoryGraph` yields import_source `kin_db::graph`.
+        // Only the crate root (`kin_db`) identifies the repo, so the resolver
+        // must bind it to `kin-db` rather than miss on the full module path.
+        let index = SpineIndex::new();
+        index.register_repo(
+            "kin-db",
+            vec![test_entry("kin-db", "InMemoryGraph", EntityKind::Class)],
+            "hash-db",
+        );
+
+        let imports = vec![UnresolvedImport {
+            source_repo: "kin".to_string(),
+            source_entity: EntityId::new(),
+            imported_name: "InMemoryGraph".to_string(),
+            imported_kind: Some(EntityKind::Class),
+            candidate_repos: vec!["kin-db".to_string()],
+            language: Some("rust".to_string()),
+            reference_fingerprint: None,
+            import_source: Some("kin_db::graph".to_string()),
+        }];
+
+        let results = resolve_imports(&index, &imports);
+        match &results[0].1 {
+            ResolveResult::Resolved { target_repo, .. } => {
+                assert_eq!(target_repo, "kin-db");
+            }
+            other => panic!("expected Resolved to kin-db from crate root, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn named_repo_miss_does_not_bind_collision_repo() {
+        // `use kin_db::SomeType` where SomeType is NOT in kin-db but a same-named
+        // entity exists in an unrelated repo (kin-vfs). The import names kin-db,
+        // so a miss there must report NotFound — never bind the bogus kin→kin-vfs
+        // collision edge the hosted org graph was showing.
+        let index = SpineIndex::new();
+        index.register_repo(
+            "kin-db",
+            vec![test_entry("kin-db", "InMemoryGraph", EntityKind::Class)],
+            "hash-db",
+        );
+        index.register_repo(
+            "kin-vfs",
+            vec![test_entry("kin-vfs", "SomeType", EntityKind::Class)],
+            "hash-vfs",
+        );
+
+        let imports = vec![UnresolvedImport {
+            source_repo: "kin".to_string(),
+            source_entity: EntityId::new(),
+            imported_name: "SomeType".to_string(),
+            imported_kind: Some(EntityKind::Class),
+            candidate_repos: vec!["kin-db".to_string(), "kin-vfs".to_string()],
+            language: Some("rust".to_string()),
+            reference_fingerprint: None,
+            import_source: Some("kin_db".to_string()),
+        }];
+
+        let results = resolve_imports(&index, &imports);
+        assert!(
+            matches!(results[0].1, ResolveResult::NotFound),
+            "import naming kin_db must not bind a kin-vfs name collision, got {:?}",
+            results[0].1
+        );
     }
 }


### PR DESCRIPTION
## Why

The hosted org-graph showed exactly two cross-repo edges (kin->kinlab, kin->kin-vfs @ 0.90) and both were **bogus** — Tier-3 name-collision matches, not real imports (`kin_vfs` appears 0x in kin's graph). Root cause is an import_source <-> repo-id spelling mismatch in cross-repo resolution.

## Bug 1 — crate-name vs repo-id mismatch (correctness)

The Rust parser sets `import_source` to the crate's module path with an underscore (`kin_db`), but repos are registered hyphenated (`kin-db`). In `resolve_single` (kin-spine/src/xref.rs) Tier-1 required exact string equality and Tier-2 substring containment — both fail on `kin_db` vs `kin-db`, so **every** Rust cross-repo import fell through to Tier-3 `resolve_fallback`, which matches by name only and produced the collision edges.

Fix:
- Add `normalize_repo_token` (trim + lowercase + fold `_`->`-`) and `import_source_root` (take the crate/package root: `kin_db::graph` -> `kin_db`, `os.path` -> `os`).
- Tier-1 now matches the import's normalized crate root against registered repo ids and, when it names a registered repo, resolves **only** there. A symbol absent from the named repo returns `NotFound` (a graph gap) instead of binding an unrelated repo by name collision — this is what makes the bogus kin->kin-vfs edge disappear.
- Tier-2 narrows candidate repos by the same normalized root.

New kin-spine unit tests:
- `rust_crate_underscore_binds_to_hyphenated_repo` — `kin_db` -> `kin-db` at Tier-1 (0.95).
- `multi_segment_module_path_binds_to_crate_repo` — `kin_db::graph` -> `kin-db`.
- `named_repo_miss_does_not_bind_collision_repo` — `use kin_db::SomeType` where `SomeType` only exists in kin-vfs returns `NotFound` (the bogus-edge case).
- `normalize_and_root_fold_crate_spelling` — helper coverage.

## Bug 2 — only the anchor formed edges

The hosted ingest path materialized edges only when `refresh_cross_repo_edges == true`, which the orchestrator set for the primary (`kin`) only, so edges emanated from kin alone (kin-db->kin-search, kin-model->kin-vector, ... never formed). The local `initialize_spine_lazy` registers all repos then refreshes **every** repo.

Fix (daemon):
- Add `DaemonState::refresh_all_cross_repo_edges` — loops every registered repo, loads its graph from durable storage (blob store, never on-disk siblings), and re-resolves its imports against the now-complete spine. Idempotent (refresh removes+re-adds per repo).
- Expose `POST /spine/refresh-cross-repo-edges`. (The kinlab orchestrator calls it after all repos are ingested — see firelock-ai/kinlab PR.)

New kin-daemon test: `spine_refresh_cross_repo_edges_route_is_wired_and_degrades_gracefully`.

## Verification

- fmt clean; clippy (CI allowlist, `--all-targets --all-features`, `-D warnings`) clean on kin-spine + kin-daemon.
- kin-spine: 36 tests pass (4 new). kin-daemon: new route test passes.
- All registry-clean (built from /tmp outside $HOME, isolated CARGO_HOME, no path patches; no Cargo.lock change).

Deferred (needs the daemon/GPU, owned by another lane): a hosted re-ingest. It should show kin binding real edges to kin-db / kin-model / kin-blobs at Tier-1 (0.95), the bogus kin->kin-vfs edge gone, and edges emanating from non-anchor repos.

Do not merge yet — paired with the kinlab orchestrator PR.
