### PR TITLE
feat(locate): inline code snippets in locate + semantic_locate (agent-native output)

### DIFF
--- a/crates/kin-cli/src/commands/contextbench_locate.rs
+++ b/crates/kin-cli/src/commands/contextbench_locate.rs
@@ -147,9 +147,15 @@ pub async fn run(task_file: PathBuf, json: bool, debug: bool) -> Result<()> {
     let max_files = contextbench_max_files(&bounded_query);
 
     let max_files_explicit = std::env::var("KIN_CONTEXTBENCH_MAX_FILES").is_ok();
-    let locate_result =
-        crate::commands::locate::capture(&bounded_query, true, max_files, max_files_explicit, None)
-            .await?;
+    let locate_result = crate::commands::locate::capture(
+        &bounded_query,
+        true,
+        max_files,
+        max_files_explicit,
+        None,
+        false,
+    )
+    .await?;
 
     let mut pred_files = Vec::new();
     let mut pred_symbols = std::collections::HashMap::new();

--- a/crates/kin-cli/src/commands/locate.rs
+++ b/crates/kin-cli/src/commands/locate.rs
@@ -123,6 +123,71 @@ pub struct LocateSymbol {
     /// from the vector pool. Recorded under --explain only; never affects rank.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub cosine: Option<f32>,
+    /// Bounded inline source snippet: the symbol's signature plus the first
+    /// several body lines, projected from graph-owned content (the same
+    /// content-addressed, hash-verified body `get_entity_source` and
+    /// `semantic_locate` serve), capped for density. Lets an agent act on the
+    /// first `locate` without a follow-up file read. Populated only on the
+    /// structured/agent JSON surface when snippets are requested; `None`
+    /// otherwise or on a graph gap. Never read from the working tree.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub snippet: Option<String>,
+}
+
+/// Controls the bounded inline snippet attached to located symbols. Disabled by
+/// default so non-agent and in-process callers (and human CLI output) are
+/// byte-identical; the structured/agent JSON path (`kin locate --json`, the
+/// daemon `/locate` result) turns it on. Caps default to the shared
+/// retrieval-snippet bound used by every agent surface (locate symbols and
+/// `semantic_locate` hits alike) and are env-overridable.
+#[derive(Clone, Copy, Debug)]
+pub struct SnippetOptions {
+    /// Whether to project snippets at all.
+    pub enabled: bool,
+    /// Max snippet lines per symbol (signature + first body lines).
+    pub max_lines: usize,
+    /// Hard char cap per snippet.
+    pub max_chars: usize,
+    /// Max definition symbols per file that receive a snippet (top-ranked
+    /// first); the rest keep coordinates only, so the payload stays dense.
+    pub max_symbols_per_file: usize,
+}
+
+/// Default count of top definition symbols per file that receive a snippet.
+const DEFAULT_SNIPPET_SYMBOLS: usize = 4;
+
+impl Default for SnippetOptions {
+    fn default() -> Self {
+        Self {
+            enabled: false,
+            max_lines: kin_mcp::handlers::common::RETRIEVAL_SNIPPET_MAX_LINES,
+            max_chars: kin_mcp::handlers::common::RETRIEVAL_SNIPPET_MAX_CHARS,
+            max_symbols_per_file: DEFAULT_SNIPPET_SYMBOLS,
+        }
+    }
+}
+
+impl SnippetOptions {
+    /// Enabled options. `max_lines` honors an explicit per-request override,
+    /// else `KIN_LOCATE_SNIPPET_LINES`, else the shared default; the char and
+    /// per-file-symbol caps honor `KIN_LOCATE_SNIPPET_CHARS` /
+    /// `KIN_LOCATE_SNIPPET_SYMBOLS`.
+    pub fn enabled(max_lines: Option<usize>) -> Self {
+        let base = Self::default();
+        let lines = max_lines
+            .unwrap_or_else(|| locate_env_usize("KIN_LOCATE_SNIPPET_LINES", base.max_lines))
+            .clamp(1, 200);
+        Self {
+            enabled: true,
+            max_lines: lines,
+            max_chars: locate_env_usize("KIN_LOCATE_SNIPPET_CHARS", base.max_chars).clamp(1, 8000),
+            max_symbols_per_file: locate_env_usize(
+                "KIN_LOCATE_SNIPPET_SYMBOLS",
+                base.max_symbols_per_file,
+            )
+            .clamp(1, 50),
+        }
+    }
 }
 
 #[derive(Serialize, Deserialize, Clone, Default)]
@@ -778,6 +843,7 @@ pub async fn run(
     max_files: usize,
     max_files_explicit: bool,
     reference: Option<String>,
+    snippets: bool,
 ) -> Result<()> {
     let _span = tracing::info_span!(
         "kin.locate",
@@ -787,7 +853,15 @@ pub async fn run(
         max_files = max_files
     )
     .entered();
-    let result = capture(text, explain, max_files, max_files_explicit, reference).await?;
+    let result = capture(
+        text,
+        explain,
+        max_files,
+        max_files_explicit,
+        reference,
+        snippets,
+    )
+    .await?;
     output_result(&result, json);
     Ok(())
 }
@@ -798,6 +872,7 @@ pub async fn capture(
     max_files: usize,
     max_files_explicit: bool,
     reference: Option<String>,
+    snippets: bool,
 ) -> Result<LocateResult> {
     let layout = kin_core::KinLayout::discover(&std::env::current_dir()?)
         .ok_or_else(|| anyhow::anyhow!("not a Kin repository (no .kin/ found)"))?;
@@ -814,6 +889,7 @@ pub async fn capture(
         max_files,
         max_files_explicit,
         reference,
+        snippets,
     )
     .await?;
     record_locate_telemetry(&layout, text, max_files, &result);
@@ -896,6 +972,7 @@ async fn try_locate_via_daemon(
     max_files: usize,
     max_files_explicit: bool,
     reference: Option<String>,
+    snippets: bool,
 ) -> Result<LocateResult> {
     let daemon_url = std::env::var("KIN_DAEMON_URL")
         .ok()
@@ -912,6 +989,8 @@ async fn try_locate_via_daemon(
         max_files,
         max_files_explicit,
         reference,
+        snippets,
+        snippet_lines: None,
     };
     client
         .locate(&request)
@@ -994,6 +1073,7 @@ pub fn run_with_graph_capture_with_priority_files(
         max_files_explicit,
         extra_priority_files,
         None,
+        SnippetOptions::default(),
     )
 }
 
@@ -1006,6 +1086,7 @@ pub fn run_with_graph_capture_with_priority_files_and_vector_source(
     max_files_explicit: bool,
     extra_priority_files: Vec<(String, f32)>,
     vector_source: Option<&kin_db::InMemoryGraph>,
+    snippet_opts: SnippetOptions,
 ) -> Result<LocateResult> {
     let _span = tracing::info_span!(
         "kin.locate.run_with_graph",
@@ -2652,7 +2733,7 @@ pub fn run_with_graph_capture_with_priority_files_and_vector_source(
         );
     }
 
-    Ok(build_result(
+    let mut result = build_result(
         &results,
         &all_hits,
         &projection_explain,
@@ -2663,7 +2744,12 @@ pub fn run_with_graph_capture_with_priority_files_and_vector_source(
         debug_info,
         explain,
     )
-    .with_semantic_coverage(semantic_coverage))
+    .with_semantic_coverage(semantic_coverage);
+    // Project bounded inline snippets from graph-owned content (no extra IO on
+    // the working tree). No-op unless requested; the early budget-exhausted
+    // return above carries no symbols, so it needs no snippets.
+    attach_snippets(&mut result, graph, &snippet_opts);
+    Ok(result)
 }
 
 pub fn run_with_graph_capture_at_ref(
@@ -2676,6 +2762,7 @@ pub fn run_with_graph_capture_at_ref(
     explain: bool,
     max_files: usize,
     max_files_explicit: bool,
+    snippet_opts: SnippetOptions,
 ) -> Result<LocateResult> {
     let changes = kin_core::collect_changes_at_ref(graph, head)
         .map_err(|err| anyhow::anyhow!(err.to_string()))?;
@@ -2710,6 +2797,7 @@ pub fn run_with_graph_capture_at_ref(
         max_files_explicit,
         extra_priority_files,
         Some(graph),
+        snippet_opts,
     )
 }
 
@@ -8917,6 +9005,7 @@ fn resolve_entities_to_files(
                     } else {
                         None
                     },
+                    snippet: None,
                 };
                 file_symbols.entry(path.clone()).or_default().push(symbol);
                 if explain {
@@ -12956,6 +13045,7 @@ fn rank_enriched_symbols(
                 definition: true,
                 origin: String::new(),
                 cosine: None,
+                snippet: None,
             }
         })
         .collect();
@@ -13073,6 +13163,7 @@ fn apply_query_relevance(
             definition: true,
             origin: String::new(),
             cosine: None,
+            snippet: None,
         });
     }
     existing
@@ -13287,6 +13378,7 @@ fn rank_body_relevant_symbols(
             definition: true,
             origin: String::new(),
             cosine: None,
+            snippet: None,
         })
         .collect()
 }
@@ -13619,6 +13711,83 @@ fn collect_explain_for_file(
     } else {
         vec![format!("matched signals: {}", signals.join(", "))]
     }
+}
+
+/// Attach a bounded inline snippet to the top definition symbols of every
+/// located file. The body is projected from graph-owned content through the
+/// shared [`kin_mcp::handlers::common::read_entity_source_excerpt_detailed`]
+/// projection (content-addressed, hash-verified — the same bytes
+/// `get_entity_source` and `semantic_locate` serve), so there is no working-tree
+/// read: a graph/blob miss simply leaves the symbol as coordinates-only.
+///
+/// Additive: symbol set, ordering, and scores are untouched (the ContextBench
+/// scorer derives its predicted symbol set from `symbols[].name`, which is
+/// unchanged), so retrieval scoring and proof are unaffected. A no-op unless
+/// `opts.enabled`.
+pub fn attach_snippets(
+    result: &mut LocateResult,
+    graph: &kin_db::InMemoryGraph,
+    opts: &SnippetOptions,
+) {
+    if !opts.enabled {
+        return;
+    }
+    for file in result.files.iter_mut() {
+        if file.symbols.is_empty() {
+            continue;
+        }
+        let filter = EntityFilter {
+            file_path: Some(kin_model::FilePathId::new(&file.path)),
+            ..Default::default()
+        };
+        let Ok(entities) = graph.query_entities(&filter) else {
+            continue;
+        };
+        if entities.is_empty() {
+            continue;
+        }
+        let mut filled = 0usize;
+        for sym in file.symbols.iter_mut() {
+            if filled >= opts.max_symbols_per_file {
+                break;
+            }
+            // References/re-exports have no body to surface; only definitions.
+            if !sym.definition {
+                continue;
+            }
+            let Some(entity) = match_symbol_entity(&entities, sym) else {
+                continue;
+            };
+            if let Some(snippet) = kin_mcp::handlers::common::read_entity_source_excerpt_detailed(
+                graph,
+                entity,
+                opts.max_lines,
+                opts.max_chars,
+            ) {
+                sym.snippet = Some(snippet);
+                filled += 1;
+            }
+        }
+    }
+}
+
+/// Resolve a located symbol to its graph entity by name, disambiguating by start
+/// line when the symbol carries a span (so same-name overloads map to the right
+/// definition). Falls back to a name-only match when spans are absent.
+fn match_symbol_entity<'a>(
+    entities: &'a [kin_model::Entity],
+    sym: &LocateSymbol,
+) -> Option<&'a kin_model::Entity> {
+    let start_line = sym.span.map(|s| s[0]);
+    entities
+        .iter()
+        .find(|e| {
+            e.name == sym.name
+                && start_line
+                    .zip(e.span.as_ref())
+                    .is_some_and(|(sl, es)| es.start_line == sl)
+        })
+        .or_else(|| entities.iter().find(|e| e.name == sym.name))
 }
 
 fn build_result(
@@ -14567,6 +14736,7 @@ mod tests {
             definition: true,
             origin: String::new(),
             cosine: None,
+            snippet: None,
         };
         let json = serde_json::to_string(&symbol).unwrap();
         assert!(
@@ -14597,6 +14767,7 @@ mod tests {
             definition,
             origin: String::new(),
             cosine: None,
+            snippet: None,
         }
     }
 
@@ -19401,6 +19572,7 @@ mod tests {
             false,
             10,
             true,
+            SnippetOptions::default(),
         )
         .unwrap();
         assert_eq!(
@@ -19423,6 +19595,7 @@ mod tests {
             false,
             10,
             true,
+            SnippetOptions::default(),
         )
         .unwrap();
         assert!(

--- a/crates/kin-cli/src/commands/locate_debug.rs
+++ b/crates/kin-cli/src/commands/locate_debug.rs
@@ -496,7 +496,8 @@ pub async fn run(
     }
 
     // 2. Run locate with explain=true and wider max_files
-    let result = crate::commands::locate::capture(&query_text, true, max_files, true, None).await?;
+    let result =
+        crate::commands::locate::capture(&query_text, true, max_files, true, None, false).await?;
 
     // 3. Build the report
     let mut report = build_report(&query_text, &gold_files, &result);

--- a/crates/kin-cli/src/daemon_client.rs
+++ b/crates/kin-cli/src/daemon_client.rs
@@ -125,6 +125,16 @@ pub struct LocateRequest {
     pub max_files_explicit: bool,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub reference: Option<String>,
+    /// When true, the daemon attaches a bounded inline source snippet to each
+    /// top definition symbol of every located file (the structured/agent JSON
+    /// surface). Defaults to false so existing clients and human output are
+    /// unchanged.
+    #[serde(default)]
+    pub snippets: bool,
+    /// Optional override for the snippet line budget (`KIN_LOCATE_SNIPPET_LINES`
+    /// otherwise). Only meaningful when `snippets` is true.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub snippet_lines: Option<usize>,
 }
 
 /// Resolve the bearer token the daemon expects on non-public routes.

--- a/crates/kin-cli/src/main.rs
+++ b/crates/kin-cli/src/main.rs
@@ -247,6 +247,15 @@ enum Command {
         /// and semantic changes as `kin:<id>`, `change:<id>`, or bare change IDs.
         #[arg(long = "ref", value_name = "REF")]
         reference: Option<String>,
+        /// Attach a bounded inline source snippet (signature + first body lines)
+        /// to each top definition symbol. Default ON for `--json` (the agent
+        /// surface), so an agent can act on the first locate without a follow-up
+        /// read; force it on for any output with this flag.
+        #[arg(long)]
+        snippets: bool,
+        /// Suppress inline snippets even on the `--json` surface.
+        #[arg(long = "no-snippets", conflicts_with = "snippets")]
+        no_snippets: bool,
     },
     /// Debug locate results: show per-signal breakdown, rank gold files,
     /// and diagnose why targets were missed.
@@ -1845,7 +1854,14 @@ fn main() -> Result<()> {
                     gold,
                     max_files,
                     reference,
+                    snippets,
+                    no_snippets,
                 } => {
+                    // Inline snippets default ON for the structured/agent `--json`
+                    // surface (so an agent gets code on the first locate);
+                    // --diagnose stays lean unless --snippets is explicit;
+                    // --no-snippets always wins.
+                    let want_snippets = !no_snippets && (snippets || (json && !diagnose));
                     // --diagnose implies --json --explain
                     let json = json || diagnose;
                     let explain = explain || diagnose;
@@ -1871,6 +1887,7 @@ fn main() -> Result<()> {
                             max_files_val,
                             max_files_explicit,
                             reference,
+                            want_snippets,
                         )
                         .await?;
 
@@ -1994,6 +2011,7 @@ fn main() -> Result<()> {
                             max_files_val,
                             max_files_explicit,
                             reference,
+                            want_snippets,
                         )
                         .await
                     }

--- a/crates/kin-daemon/src/api.rs
+++ b/crates/kin-daemon/src/api.rs
@@ -2990,6 +2990,15 @@ async fn locate(
 ) -> Result<impl IntoResponse, (StatusCode, String)> {
     let session_id = extract_session_id_from_headers(&headers)?;
 
+    // Resolve the bounded-snippet projection for this request. Off by default
+    // (CLI human path, legacy clients); the agent JSON surface sets it so each
+    // located definition symbol carries inline code from graph-owned content.
+    let snippet_opts = if req.snippets {
+        kin_cli::commands::locate::SnippetOptions::enabled(req.snippet_lines)
+    } else {
+        kin_cli::commands::locate::SnippetOptions::default()
+    };
+
     tracing::info!(
         ">>> LOCATE: state.graph.embedding_status().indexed={}, graph root hash={:?}",
         state.graph.embedding_status().indexed,
@@ -3020,6 +3029,7 @@ async fn locate(
             req.explain,
             req.max_files,
             req.max_files_explicit,
+            snippet_opts,
         )
     } else {
         // Use scoped graph if session has a temporal scope, otherwise HEAD.
@@ -3068,6 +3078,7 @@ async fn locate(
             req.max_files_explicit,
             extra_priority_files,
             vector_source,
+            snippet_opts,
         )
     }
     .map_err(internal_error)?;
@@ -3875,10 +3886,15 @@ fn terminal_transaction_id(
 /// Build the `semantic_locate` response from the daemon's real vector index.
 ///
 /// Contract (shared verbatim with the MCP server): args
-/// `{query, limit?=20, granularity?="entity"|"file"}`; response object with a
-/// ranked `results: [{entity_id, name, file, score}]` array plus a
+/// `{query, limit?=20, granularity?="entity"|"file", include_snippet?=true}`;
+/// response object with a ranked
+/// `results: [{entity_id, name, file, score, snippet?}]` array plus a
 /// `semantic_coverage` float (`indexed / total`). `score` is cosine similarity
 /// (`1.0 - distance`), higher is better; results are already rank-ordered.
+/// `snippet` is a bounded inline body excerpt (entity granularity only),
+/// projected from graph-owned content via the same body projection
+/// `get_entity_source` uses, so one `semantic_locate` is act-on-able without a
+/// follow-up read; omitted on a graph gap or when `include_snippet` is false.
 fn build_semantic_locate_result(
     graph: &kin_db::InMemoryGraph,
     arguments: &HashMap<String, serde_json::Value>,
@@ -3900,6 +3916,15 @@ fn build_semantic_locate_result(
         .and_then(serde_json::Value::as_str)
         .map(|value| value.eq_ignore_ascii_case("file"))
         .unwrap_or(false);
+    // Inline a bounded code snippet on each entity hit by default, so a single
+    // `semantic_locate` is act-on-able without a follow-up `get_entity_source`.
+    // Suppressible via `include_snippet: false`; never applies to file
+    // granularity (a file hit has no single entity body).
+    let include_snippet = arguments
+        .get("include_snippet")
+        .and_then(serde_json::Value::as_bool)
+        .unwrap_or(true)
+        && !file_granularity;
 
     // Coverage is reported, never gated: a partially-embedded graph still
     // returns whatever the index can answer (graceful degradation per R5).
@@ -3974,13 +3999,30 @@ fn build_semantic_locate_result(
             continue;
         }
 
+        // Project the bounded snippet only for kept entity hits (top `limit`),
+        // from graph-owned content — no working-tree read; a graph gap yields no
+        // snippet rather than a fallback.
+        let snippet = if include_snippet {
+            if let kin_db::ResolvedRetrievalItem::Entity(entity) = &item {
+                kin_mcp::handlers::common::read_bounded_entity_snippet(graph, entity)
+            } else {
+                None
+            }
+        } else {
+            None
+        };
+
         let score = 1.0_f32 - distance;
-        results.push(json!({
+        let mut hit = json!({
             "entity_id": entity_id,
             "name": name,
             "file": file,
             "score": score,
-        }));
+        });
+        if let Some(snippet) = snippet {
+            hit["snippet"] = json!(snippet);
+        }
+        results.push(hit);
     }
 
     let payload = json!({

--- a/crates/kin-mcp/src/handlers/common.rs
+++ b/crates/kin-mcp/src/handlers/common.rs
@@ -1037,6 +1037,32 @@ pub fn read_entity_source_excerpt_detailed<G: GraphStore>(
     None
 }
 
+/// Caps for the inline snippet surfaced on a retrieval hit (`kin locate --json`
+/// symbols, `semantic_locate` entity results): a signature plus the first
+/// several body lines — dense enough for an agent to act on without a follow-up
+/// read, but far tighter than the full-body excerpt
+/// ([`MCP_SOURCE_MAX_LINES`]/[`MCP_SOURCE_MAX_CHARS`]) `get_entity_source` and
+/// `get_context_pack` serve. One bound shared by every agent surface so the
+/// snippet is identical wherever it appears.
+pub const RETRIEVAL_SNIPPET_MAX_LINES: usize = 12;
+pub const RETRIEVAL_SNIPPET_MAX_CHARS: usize = 800;
+
+/// Graph-native bounded snippet for an entity. Delegates to the same
+/// content-addressed, hash-verified body projection
+/// ([`read_entity_source_excerpt_detailed`]) that backs `get_entity_source` and
+/// `get_context_pack`, capped to
+/// [`RETRIEVAL_SNIPPET_MAX_LINES`]/[`RETRIEVAL_SNIPPET_MAX_CHARS`] for inline use
+/// on retrieval hits. Returns `None` on a graph/blob miss so callers surface the
+/// coordinates without a snippet rather than reading the working tree.
+pub fn read_bounded_entity_snippet<G: GraphStore>(store: &G, entity: &Entity) -> Option<String> {
+    read_entity_source_excerpt_detailed(
+        store,
+        entity,
+        RETRIEVAL_SNIPPET_MAX_LINES,
+        RETRIEVAL_SNIPPET_MAX_CHARS,
+    )
+}
+
 pub fn excerpt_from_span_bytes(
     bytes: &[u8],
     span: &SourceSpan,


### PR DESCRIPTION
## Agent-native output: code on the first call
`kin locate` and the MCP `semantic_locate` tool now return a bounded inline `snippet` (signature + first body lines, capped 12 lines / 800 chars) per result, via one shared graph-native projection (the same body path backing `get_entity_source`/`get_context_pack`). An AI agent gets the code it needs on the first call instead of a follow-up file read.

## Graph-native, no working-tree read
The snippet is sourced from the content-addressed blob store (graph-recorded file hash -> digest-verified blob), not the working tree. A blob miss yields coordinates-only (no fallback). Default-on for `--json`/MCP; `--no-snippets` suppresses; human CLI output unchanged.

## Scope
3 crates (kin-daemon `/locate`, kin-cli `LocateSymbol`, kin-mcp `semantic_locate`) + a shared `read_bounded_entity_snippet`. 10 locate unit tests added; build + tests green. Closes the agent-context gap where coordinate-only output forced a follow-up `cat`.