### PR TITLE
feat(locate): entity-centric output + paging — return semantic entities, not files

### DIFF
--- a/crates/kin-cli/src/commands/contextbench_locate.rs
+++ b/crates/kin-cli/src/commands/contextbench_locate.rs
@@ -154,6 +154,7 @@ pub async fn run(task_file: PathBuf, json: bool, debug: bool) -> Result<()> {
         max_files_explicit,
         None,
         false,
+        crate::commands::locate::LocatePaging::default(),
     )
     .await?;
 

--- a/crates/kin-cli/src/commands/locate.rs
+++ b/crates/kin-cli/src/commands/locate.rs
@@ -30,8 +30,30 @@ type ResolveEntitiesOutput = (
 // JSON output types
 // ---------------------------------------------------------------------------
 
-#[derive(Serialize, Deserialize)]
+#[derive(Serialize, Deserialize, Default)]
 pub struct LocateResult {
+    /// Graph-native PRIMARY result: the top-confidence semantic ENTITIES
+    /// (function/method/type …) the query is about — each with its kind, name,
+    /// signature, bounded body, and the file demoted to mere provenance. This is
+    /// the entity-centric surface an agent reasons over; `files` below is kept for
+    /// back-compat and file-level provenance. Populated on the agent/JSON surface
+    /// (when snippet projection is requested); empty on the human/in-process path,
+    /// where it is omitted from output. Capped to one page (see `next_cursor`).
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub entities: Vec<LocateEntity>,
+    /// Opaque cursor for the NEXT page of ranked entities. Present iff the full
+    /// ranking holds more entities than this page. Re-issue the query with this
+    /// cursor (`kin locate --next`, or the `cursor` arg) to fetch the next page
+    /// from the daemon's cached ranking — no retrieval re-run. `None` on the last
+    /// page or when paging is not active.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub next_cursor: Option<String>,
+    /// 0-based index of the entity page in `entities`.
+    #[serde(default, skip_serializing_if = "is_zero_usize")]
+    pub page: usize,
+    /// Total entities in the full ranking behind this paged view.
+    #[serde(default, skip_serializing_if = "is_zero_usize")]
+    pub total_ranked: usize,
     pub files: Vec<LocateFileEntry>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub debug: Option<LocateDebugInfo>,
@@ -158,6 +180,79 @@ pub struct LocateSymbol {
     /// otherwise or on a graph gap. Never read from the working tree.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub snippet: Option<String>,
+}
+
+/// `serde` skip predicate: omit a `usize` field when it is `0`.
+fn is_zero_usize(value: &usize) -> bool {
+    *value == 0
+}
+
+/// A single ranked graph ENTITY surfaced by `kin locate` — the graph-native unit
+/// of the result. Unlike [`LocateSymbol`] (a file-attributed symbol), a
+/// `LocateEntity` is self-describing and act-on-able: it carries the entity's
+/// stable graph id, declared signature, and bounded body, with the file demoted
+/// to [`LocateProvenance`]. An agent can declare it, read its body, or drill its
+/// references straight from this record — no path typing, no follow-up file read.
+#[derive(Serialize, Deserialize, Clone, Debug)]
+pub struct LocateEntity {
+    /// Stable graph entity id. The handle for every follow-up graph query
+    /// (`get_entity_source`, `get_context_pack`, `find_references`, `declare`).
+    pub entity_id: String,
+    /// Entity kind (function, method, class, …), lowercased.
+    pub kind: String,
+    /// Entity name (the symbol identifier).
+    pub name: String,
+    /// Declared signature (params/return contract) from graph truth. Empty when
+    /// the graph carries none.
+    #[serde(default, skip_serializing_if = "String::is_empty")]
+    pub signature: String,
+    /// Composite resolution score; higher means more confident.
+    pub score: f32,
+    /// True when Kin resolved this entity as a definition (has a body) rather than
+    /// a bare reference/re-export.
+    pub definition: bool,
+    /// 1-based inclusive line span of the entity, when known.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub span: Option<[u32; 2]>,
+    /// The entity's BOUNDED body — the answer itself — projected from the same
+    /// content-addressed, hash-verified graph body that backs `get_entity_source`
+    /// (never a working-tree read). Capped for density; when the full body
+    /// exceeds the cap a trailing note points at `get_entity_source <entity_id>`
+    /// for the remainder. `None` on a graph/blob miss (coordinates only).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub body: Option<String>,
+    /// Where this entity lives. The file is provenance, not the result.
+    pub provenance: LocateProvenance,
+}
+
+/// Provenance for a [`LocateEntity`]: the file (and resolution origin) the entity
+/// was materialized from. The file is metadata about the entity, never the unit
+/// the agent acts on.
+#[derive(Serialize, Deserialize, Clone, Debug)]
+pub struct LocateProvenance {
+    /// File the entity is defined in (graph `file_origin`).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub file: Option<String>,
+    /// Resolution origin ("text", "vector", or empty) — which seed pool surfaced
+    /// the entity. Populated under --explain.
+    #[serde(default, skip_serializing_if = "String::is_empty")]
+    pub origin: String,
+    /// Raw embedding cosine of the seed that surfaced this entity, when from the
+    /// vector pool. Recorded under --explain only; never affects rank.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub cosine: Option<f32>,
+}
+
+/// Default count of top ranked entities returned per `kin locate` page. Kept
+/// small (top-few high-confidence) so the agent sees the answer, not a file
+/// listing; the rest of the ranking is reachable via `next_cursor`. Tunable via
+/// `KIN_LOCATE_ENTITY_CAP`.
+pub const DEFAULT_ENTITY_PAGE_SIZE: usize = 6;
+
+/// Effective entities-per-page from `KIN_LOCATE_ENTITY_CAP`
+/// (default [`DEFAULT_ENTITY_PAGE_SIZE`]; clamped to at least 1).
+pub fn entity_page_size() -> usize {
+    locate_env_usize("KIN_LOCATE_ENTITY_CAP", DEFAULT_ENTITY_PAGE_SIZE).max(1)
 }
 
 /// Controls the bounded inline snippet attached to located symbols. Disabled by
@@ -965,6 +1060,15 @@ fn source_file_paths(graph: &kin_db::InMemoryGraph) -> HashSet<String> {
 // Entry point
 // ---------------------------------------------------------------------------
 
+/// Paging inputs for a locate request: an opaque `cursor` from a prior result's
+/// `next_cursor`, and an optional `page_size` override for the entity surface.
+/// Defaults to no paging (first page, env-default page size).
+#[derive(Debug, Clone, Default)]
+pub struct LocatePaging {
+    pub cursor: Option<String>,
+    pub page_size: Option<usize>,
+}
+
 pub async fn run(
     text: &str,
     json: bool,
@@ -973,6 +1077,7 @@ pub async fn run(
     max_files_explicit: bool,
     reference: Option<String>,
     snippets: bool,
+    paging: LocatePaging,
 ) -> Result<()> {
     let _span = tracing::info_span!(
         "kin.locate",
@@ -989,8 +1094,12 @@ pub async fn run(
         max_files_explicit,
         reference,
         snippets,
+        paging,
     )
     .await?;
+    // Persist the paging cursor so `kin locate --next` can fetch the next page
+    // without the caller re-supplying the query. Best-effort; never fatal.
+    super::locate_cursor::persist_locate_cursor(result.next_cursor.as_deref());
     output_result(&result, json);
     Ok(())
 }
@@ -1002,6 +1111,7 @@ pub async fn capture(
     max_files_explicit: bool,
     reference: Option<String>,
     snippets: bool,
+    paging: LocatePaging,
 ) -> Result<LocateResult> {
     let layout = kin_core::KinLayout::discover(&std::env::current_dir()?)
         .ok_or_else(|| anyhow::anyhow!("not a Kin repository (no .kin/ found)"))?;
@@ -1019,6 +1129,7 @@ pub async fn capture(
         max_files_explicit,
         reference,
         snippets,
+        paging,
     )
     .await?;
     record_locate_telemetry(&layout, text, max_files, &result);
@@ -1102,6 +1213,7 @@ async fn try_locate_via_daemon(
     max_files_explicit: bool,
     reference: Option<String>,
     snippets: bool,
+    paging: LocatePaging,
 ) -> Result<LocateResult> {
     let daemon_url = std::env::var("KIN_DAEMON_URL")
         .ok()
@@ -1120,6 +1232,8 @@ async fn try_locate_via_daemon(
         reference,
         snippets,
         snippet_lines: None,
+        cursor: paging.cursor,
+        page_size: paging.page_size,
     };
     client
         .locate(&request)
@@ -3099,6 +3213,11 @@ pub fn run_with_graph_capture_with_priority_files_and_vector_source(
     // the working tree). No-op unless requested; the early budget-exhausted
     // return above carries no symbols, so it needs no snippets.
     attach_snippets(&mut result, graph, &snippet_opts);
+    // Re-project the ranked symbols into the graph-native PRIMARY surface: a
+    // single globally-ranked entity list (file demoted to provenance). Reuses the
+    // snippet projection's bounds; the daemon caches the full ranking and windows
+    // one page. No-op unless the agent/JSON surface requested snippets.
+    build_entity_view(&mut result, graph, &snippet_opts);
     Ok(result)
 }
 
@@ -14319,6 +14438,212 @@ fn match_symbol_entity<'a>(
         .or_else(|| entities.iter().find(|e| e.name == sym.name))
 }
 
+/// Project an entity's BOUNDED body from graph-owned content, appending a
+/// truncation note (pointing at `get_entity_source <id>` for the remainder) when
+/// the entity spans more source lines than the cap surfaced. Same
+/// content-addressed, hash-verified projection
+/// ([`kin_mcp::handlers::common::read_entity_source_excerpt_detailed`]) every
+/// agent surface uses — never a working-tree read; a graph/blob miss yields
+/// `None` (coordinates only).
+fn bounded_entity_body_with_note(
+    graph: &kin_db::InMemoryGraph,
+    entity: &kin_model::Entity,
+    max_lines: usize,
+    max_chars: usize,
+) -> Option<String> {
+    let body = kin_mcp::handlers::common::read_entity_source_excerpt_detailed(
+        graph, entity, max_lines, max_chars,
+    )?;
+    if let Some(span) = entity.span.as_ref() {
+        let total_lines =
+            (span.end_line.saturating_sub(span.start_line) as usize).saturating_add(1);
+        let shown = body.lines().count();
+        if total_lines > shown {
+            let remaining = total_lines - shown;
+            return Some(format!(
+                "{body}\n… (+{remaining} more line{} — get_entity_source {} for the full body)",
+                if remaining == 1 { "" } else { "s" },
+                entity.id
+            ));
+        }
+    }
+    Some(body)
+}
+
+/// Re-project the file-attributed ranked symbols already built into `result`
+/// (`build_result` + `attach_snippets`) into the graph-native PRIMARY surface:
+/// a single GLOBALLY-ranked list of [`LocateEntity`] (kind + name + signature +
+/// bounded body, file demoted to provenance), stored on `result.entities`.
+///
+/// This is a thin RE-PROJECTION, not new retrieval: it reuses the tuned file/
+/// symbol ranking and the graph-owned body projection. For each ranked file it
+/// resolves every emitted symbol to its graph entity ([`match_symbol_entity`]),
+/// fills the stable `entity_id` + declared `signature` + bounded `body`, then
+/// global-ranks (definition-before-reference, score desc, file-rank, name) and
+/// de-duplicates by `entity_id`. The FULL ranking is written to `result.entities`
+/// (and `total_ranked`); the daemon then caches it and windows a single page via
+/// [`apply_entity_page`]. No filesystem read. A no-op unless `opts.enabled`
+/// (the agent/JSON surface), so the human/in-process path is unchanged.
+pub fn build_entity_view(
+    result: &mut LocateResult,
+    graph: &kin_db::InMemoryGraph,
+    opts: &SnippetOptions,
+) {
+    if !opts.enabled {
+        return;
+    }
+    // (file_rank, LocateEntity) so global ranking can tie-break on file order.
+    let mut ranked: Vec<(usize, LocateEntity)> = Vec::new();
+    let mut seen: HashSet<String> = HashSet::new();
+    for (file_rank, file) in result.files.iter().enumerate() {
+        if file.symbols.is_empty() {
+            continue;
+        }
+        let filter = EntityFilter {
+            file_path: Some(kin_model::FilePathId::new(&file.path)),
+            ..Default::default()
+        };
+        let Ok(entities) = graph.query_entities(&filter) else {
+            continue;
+        };
+        if entities.is_empty() {
+            continue;
+        }
+        for sym in &file.symbols {
+            let Some(entity) = match_symbol_entity(&entities, sym) else {
+                continue;
+            };
+            let entity_id = entity.id.to_string();
+            if !seen.insert(entity_id.clone()) {
+                continue;
+            }
+            // Bodies belong to definitions; references/re-exports stay
+            // coordinates-only (the symbol already reused its snippet, if any).
+            let body = if sym.definition {
+                bounded_entity_body_with_note(graph, entity, opts.max_lines, opts.max_chars)
+                    .or_else(|| sym.snippet.clone())
+            } else {
+                None
+            };
+            let file_origin = entity
+                .file_origin
+                .as_ref()
+                .map(|origin| origin.0.clone())
+                .or_else(|| Some(file.path.clone()));
+            ranked.push((
+                file_rank,
+                LocateEntity {
+                    entity_id,
+                    kind: format!("{:?}", entity.kind).to_lowercase(),
+                    name: entity.name.clone(),
+                    signature: entity.signature.clone(),
+                    score: sym.score,
+                    definition: sym.definition,
+                    span: sym.span,
+                    body,
+                    provenance: LocateProvenance {
+                        file: file_origin,
+                        origin: sym.origin.clone(),
+                        cosine: sym.cosine,
+                    },
+                },
+            ));
+        }
+    }
+
+    // Global rank: definitions first, then composite score desc, then the file's
+    // own rank, then name/id for a total deterministic order.
+    ranked.sort_by(|(a_rank, a), (b_rank, b)| {
+        b.definition
+            .cmp(&a.definition)
+            .then_with(|| {
+                b.score
+                    .partial_cmp(&a.score)
+                    .unwrap_or(std::cmp::Ordering::Equal)
+            })
+            .then_with(|| a_rank.cmp(b_rank))
+            .then_with(|| a.name.cmp(&b.name))
+            .then_with(|| a.entity_id.cmp(&b.entity_id))
+    });
+
+    result.entities = ranked.into_iter().map(|(_, entity)| entity).collect();
+    result.total_ranked = result.entities.len();
+}
+
+/// Stable, opaque key for a locate ranking, scoped to the query, the ref/scope it
+/// ran against, and the graph version. Embedding the graph version means any
+/// edit (a `vfs_version` bump) yields a different key, so a stale cursor can
+/// never page a ranking built against different graph truth.
+pub fn locate_cursor_key(text: &str, reference: Option<&str>, graph_version: u64) -> String {
+    use std::hash::{Hash, Hasher};
+    let mut hasher = FxHasher::default();
+    text.hash(&mut hasher);
+    0xff_u8.hash(&mut hasher); // field separator
+    reference.unwrap_or("").hash(&mut hasher);
+    0xff_u8.hash(&mut hasher);
+    graph_version.hash(&mut hasher);
+    format!("{:016x}", hasher.finish())
+}
+
+/// A locate paging cursor: the ranking key plus the page to fetch. Serialized as
+/// `<key>.<page>` (the key is hex, so the last `.` cleanly separates the page).
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct LocateCursor {
+    pub key: String,
+    pub page: usize,
+}
+
+impl LocateCursor {
+    pub fn encode(&self) -> String {
+        format!("{}.{}", self.key, self.page)
+    }
+
+    pub fn decode(token: &str) -> Option<LocateCursor> {
+        let (key, page) = token.trim().rsplit_once('.')?;
+        if key.is_empty() {
+            return None;
+        }
+        let page = page.parse::<usize>().ok()?;
+        Some(LocateCursor {
+            key: key.to_string(),
+            page,
+        })
+    }
+}
+
+/// Window the full ranked `result.entities` down to a single page and set the
+/// paging fields. Pure: the daemon caches the full ranking under `cursor_key`,
+/// then calls this to emit page `page` of `page_size` and a `next_cursor` when
+/// more entities remain — so `--next` pages from cache without re-running
+/// retrieval.
+pub fn apply_entity_page(
+    result: &mut LocateResult,
+    cursor_key: &str,
+    page: usize,
+    page_size: usize,
+) {
+    let page_size = page_size.max(1);
+    let total = result.entities.len();
+    result.total_ranked = total;
+    let start = page.saturating_mul(page_size);
+    let end = start.saturating_add(page_size).min(total);
+    let window = if start < total {
+        result.entities[start..end].to_vec()
+    } else {
+        Vec::new()
+    };
+    let has_more = end < total;
+    result.entities = window;
+    result.page = page;
+    result.next_cursor = has_more.then(|| {
+        LocateCursor {
+            key: cursor_key.to_string(),
+            page: page + 1,
+        }
+        .encode()
+    });
+}
+
 fn build_result(
     results: &[(String, f32)],
     all_hits: &[HashMap<String, Vec<FileHit>>],
@@ -14401,7 +14726,7 @@ fn build_result(
         files,
         debug,
         semantic_coverage: None,
-        degradations: Vec::new(),
+        ..Default::default()
     }
 }
 
@@ -14501,6 +14826,186 @@ mod tests {
             score,
             spans: vec![],
         }]
+    }
+
+    // ── Graph-native entity surface + cursor paging (static shape) ──
+
+    fn mk_locate_entity(name: &str, score: f32, definition: bool) -> LocateEntity {
+        LocateEntity {
+            entity_id: format!("id-{name}"),
+            kind: "function".to_string(),
+            name: name.to_string(),
+            signature: format!("fn {name}()"),
+            score,
+            definition,
+            span: Some([10, 20]),
+            body: Some(format!("fn {name}() {{ /* … */ }}")),
+            provenance: LocateProvenance {
+                file: Some(format!("src/{name}.rs")),
+                origin: "vector".to_string(),
+                cosine: Some(0.5),
+            },
+        }
+    }
+
+    fn ranking(n: usize) -> Vec<LocateEntity> {
+        (0..n)
+            .map(|i| mk_locate_entity(&format!("e{i}"), 1.0 - i as f32 * 0.01, true))
+            .collect()
+    }
+
+    #[test]
+    fn locate_entity_serializes_entity_centric_with_file_as_provenance() {
+        let result = LocateResult {
+            entities: vec![mk_locate_entity("parse_config", 0.9, true)],
+            total_ranked: 1,
+            page: 0,
+            files: Vec::new(),
+            ..Default::default()
+        };
+        let v: serde_json::Value =
+            serde_json::from_str(&serde_json::to_string(&result).unwrap()).unwrap();
+        let e = &v["entities"][0];
+        assert_eq!(e["entity_id"], "id-parse_config");
+        assert_eq!(e["kind"], "function");
+        assert_eq!(e["name"], "parse_config");
+        assert_eq!(e["signature"], "fn parse_config()");
+        assert!(e["body"].as_str().unwrap().contains("parse_config"));
+        // File is provenance, never a top-level field on the entity.
+        assert_eq!(e["provenance"]["file"], "src/parse_config.rs");
+        assert!(e.get("file").is_none());
+        assert_eq!(v["total_ranked"], 1);
+        // Empty file list + zero/None paging fields are omitted from the wire.
+        assert!(v.get("files").is_some()); // files is always serialized
+        assert!(v.get("next_cursor").is_none());
+        assert!(v.get("page").is_none()); // page == 0 is skipped
+    }
+
+    #[test]
+    fn empty_entities_are_omitted_from_serialized_output() {
+        let result = LocateResult {
+            files: Vec::new(),
+            ..Default::default()
+        };
+        let v: serde_json::Value =
+            serde_json::from_str(&serde_json::to_string(&result).unwrap()).unwrap();
+        // Human/in-process path: no entity surface leaks into the JSON.
+        assert!(v.get("entities").is_none());
+        assert!(v.get("total_ranked").is_none());
+    }
+
+    #[test]
+    fn apply_entity_page_windows_first_page_and_emits_next_cursor() {
+        let mut result = LocateResult {
+            entities: ranking(20),
+            ..Default::default()
+        };
+        apply_entity_page(&mut result, "abc123", 0, 6);
+        assert_eq!(result.entities.len(), 6);
+        assert_eq!(result.page, 0);
+        assert_eq!(result.total_ranked, 20);
+        // First page holds the top-ranked entity; more remain → next_cursor set.
+        assert_eq!(result.entities[0].name, "e0");
+        assert_eq!(result.next_cursor.as_deref(), Some("abc123.1"));
+    }
+
+    #[test]
+    fn apply_entity_page_last_page_has_no_next_cursor() {
+        let mut result = LocateResult {
+            entities: ranking(10),
+            ..Default::default()
+        };
+        // page 1 of size 6 over 10 entities → 4 remaining, then done.
+        apply_entity_page(&mut result, "k", 1, 6);
+        assert_eq!(result.entities.len(), 4);
+        assert_eq!(result.page, 1);
+        assert_eq!(result.total_ranked, 10);
+        assert_eq!(result.entities[0].name, "e6");
+        assert!(result.next_cursor.is_none());
+    }
+
+    #[test]
+    fn apply_entity_page_past_end_is_empty_window() {
+        let mut result = LocateResult {
+            entities: ranking(5),
+            ..Default::default()
+        };
+        apply_entity_page(&mut result, "k", 9, 6);
+        assert!(result.entities.is_empty());
+        assert_eq!(result.total_ranked, 5);
+        assert!(result.next_cursor.is_none());
+    }
+
+    #[test]
+    fn apply_entity_page_clamps_zero_page_size() {
+        let mut result = LocateResult {
+            entities: ranking(3),
+            ..Default::default()
+        };
+        // page_size 0 must clamp to 1, not divide-by-zero or return everything.
+        apply_entity_page(&mut result, "k", 0, 0);
+        assert_eq!(result.entities.len(), 1);
+        assert_eq!(result.next_cursor.as_deref(), Some("k.1"));
+    }
+
+    #[test]
+    fn locate_cursor_round_trips_and_rejects_garbage() {
+        let cursor = LocateCursor {
+            key: "deadbeefcafef00d".to_string(),
+            page: 7,
+        };
+        let token = cursor.encode();
+        assert_eq!(token, "deadbeefcafef00d.7");
+        assert_eq!(LocateCursor::decode(&token), Some(cursor));
+        // Garbage / non-numeric page / empty key → None (never a silent page 0).
+        assert!(LocateCursor::decode("nodelimiter").is_none());
+        assert!(LocateCursor::decode("key.notanumber").is_none());
+        assert!(LocateCursor::decode(".5").is_none());
+    }
+
+    #[test]
+    fn locate_cursor_key_is_deterministic_and_version_scoped() {
+        let a = locate_cursor_key("find the parser", Some("HEAD"), 42);
+        let b = locate_cursor_key("find the parser", Some("HEAD"), 42);
+        assert_eq!(a, b, "same inputs must yield the same key");
+        // A graph edit bumps the version → a different key, so a stale cursor can
+        // never page a ranking built against different graph truth.
+        let c = locate_cursor_key("find the parser", Some("HEAD"), 43);
+        assert_ne!(a, c);
+        // Query and ref are part of the identity.
+        assert_ne!(a, locate_cursor_key("other query", Some("HEAD"), 42));
+        assert_ne!(a, locate_cursor_key("find the parser", Some("main"), 42));
+    }
+
+    #[test]
+    fn build_entity_view_is_noop_when_snippets_disabled() {
+        let graph = kin_db::InMemoryGraph::new();
+        let mut result = LocateResult {
+            files: vec![LocateFileEntry {
+                path: "src/a.rs".to_string(),
+                score: 1.0,
+                signals: vec![],
+                spans: vec![],
+                symbols: vec![],
+                explain: vec![],
+                provenance: None,
+                signal_scores: None,
+                score_breakdown: None,
+            }],
+            ..Default::default()
+        };
+        build_entity_view(&mut result, &graph, &SnippetOptions::default());
+        assert!(
+            result.entities.is_empty(),
+            "disabled snippet opts must leave the entity surface untouched"
+        );
+    }
+
+    #[test]
+    fn entity_page_size_honors_env_override() {
+        // Default when unset; floor of 1 when set to 0.
+        std::env::remove_var("KIN_LOCATE_ENTITY_CAP");
+        assert_eq!(entity_page_size(), DEFAULT_ENTITY_PAGE_SIZE);
     }
 
     #[test]
@@ -20617,7 +21122,7 @@ mod tests {
             }],
             debug: None,
             semantic_coverage: None,
-            degradations: Vec::new(),
+            ..Default::default()
         }
     }
 

--- a/crates/kin-cli/src/commands/locate_cursor.rs
+++ b/crates/kin-cli/src/commands/locate_cursor.rs
@@ -1,0 +1,58 @@
+//! Per-repo paging cursor state for `kin locate --next`.
+//!
+//! `kin locate` returns page 0 plus an opaque next-page cursor; a follow-up `kin
+//! locate --next` resumes from it. The cursor token is carried between the two
+//! invocations through a small local state file (`.kin/locate-cursor`). This is
+//! CLI paging state, not a semantic answer authority: the token is opaque and the
+//! ranking it indexes lives in the daemon's page cache, so this module never reads
+//! repo content or answers a query from the filesystem.
+
+use anyhow::Result;
+
+/// Path of the per-repo locate cursor file (`.kin/locate-cursor`), used to carry
+/// the next-page cursor between a `kin locate` and a follow-up `kin locate
+/// --next`.
+pub fn locate_cursor_path(layout: &kin_core::KinLayout) -> std::path::PathBuf {
+    layout.root().join("locate-cursor")
+}
+
+/// Persist (or clear) the next-page cursor for `--next`. Best-effort: any IO
+/// error is ignored so paging never breaks the result.
+pub fn persist_locate_cursor(next_cursor: Option<&str>) {
+    let Ok(cwd) = std::env::current_dir() else {
+        return;
+    };
+    let Some(layout) = kin_core::KinLayout::discover(&cwd) else {
+        return;
+    };
+    let path = locate_cursor_path(&layout);
+    match next_cursor {
+        Some(cursor) => {
+            let _ = std::fs::write(&path, cursor);
+        }
+        // No further pages: clear any stale cursor so a later bare `--next`
+        // fails loud instead of paging a dead ranking.
+        None => {
+            let _ = std::fs::remove_file(&path);
+        }
+    }
+}
+
+/// Read the persisted next-page cursor for `kin locate --next`. Errors loud when
+/// absent: a `--next` with no prior page is a user error, not a silent empty.
+pub fn read_persisted_locate_cursor() -> Result<String> {
+    let cwd = std::env::current_dir()?;
+    let layout = kin_core::KinLayout::discover(&cwd)
+        .ok_or_else(|| anyhow::anyhow!("not a Kin repository (no .kin/ found)"))?;
+    let path = locate_cursor_path(&layout);
+    let cursor = std::fs::read_to_string(&path).map_err(|_| {
+        anyhow::anyhow!(
+            "no locate page to advance: run `kin locate <query>` first, then `kin locate --next`"
+        )
+    })?;
+    let cursor = cursor.trim().to_string();
+    if cursor.is_empty() {
+        anyhow::bail!("no further locate pages (the previous page was the last)");
+    }
+    Ok(cursor)
+}

--- a/crates/kin-cli/src/commands/locate_debug.rs
+++ b/crates/kin-cli/src/commands/locate_debug.rs
@@ -496,8 +496,16 @@ pub async fn run(
     }
 
     // 2. Run locate with explain=true and wider max_files
-    let result =
-        crate::commands::locate::capture(&query_text, true, max_files, true, None, false).await?;
+    let result = crate::commands::locate::capture(
+        &query_text,
+        true,
+        max_files,
+        true,
+        None,
+        false,
+        crate::commands::locate::LocatePaging::default(),
+    )
+    .await?;
 
     // 3. Build the report
     let mut report = build_report(&query_text, &gold_files, &result);

--- a/crates/kin-cli/src/commands/mcp.rs
+++ b/crates/kin-cli/src/commands/mcp.rs
@@ -41,6 +41,10 @@ pub async fn start(global: bool) -> Result<()> {
         match std::env::var("KIN_MCP_TOOL_PROFILE").ok().as_deref() {
             Some("agent-default") => Some(kin_mcp::agent_default_tool_names()),
             Some("benchmark") => Some(kin_mcp::benchmark_tool_names()),
+            // Read-only graph-native ContextBench belt: no write-side session/
+            // transaction tools and no filesystem tools (none exist) — the
+            // purely graph-native arm.
+            Some("context-bench") => Some(kin_mcp::context_bench_tool_names()),
             _ => None,
         };
     if let Some(names) = profile_tools {

--- a/crates/kin-cli/src/commands/mod.rs
+++ b/crates/kin-cli/src/commands/mod.rs
@@ -36,6 +36,7 @@ pub mod import;
 pub mod init;
 pub mod intent;
 pub mod locate;
+pub mod locate_cursor;
 pub mod locate_debug;
 pub mod locate_telemetry;
 pub mod log;

--- a/crates/kin-cli/src/daemon_client.rs
+++ b/crates/kin-cli/src/daemon_client.rs
@@ -135,6 +135,17 @@ pub struct LocateRequest {
     /// otherwise). Only meaningful when `snippets` is true.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub snippet_lines: Option<usize>,
+    /// Opaque paging cursor (`<key>.<page>`) from a prior locate's `next_cursor`.
+    /// When set and the daemon still holds the matching ranking, the next page of
+    /// ENTITIES is sliced from cache with NO retrieval re-run; on a cache miss or
+    /// a graph-version change the daemon transparently re-runs retrieval and
+    /// returns page 0. Absent for a first/fresh query.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub cursor: Option<String>,
+    /// Entities per page for the graph-native `entities` surface
+    /// (`KIN_LOCATE_ENTITY_CAP` otherwise). Only affects entity paging.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub page_size: Option<usize>,
 }
 
 /// Resolve the bearer token the daemon expects on non-public routes.

--- a/crates/kin-cli/src/main.rs
+++ b/crates/kin-cli/src/main.rs
@@ -256,6 +256,19 @@ enum Command {
         /// Suppress inline snippets even on the `--json` surface.
         #[arg(long = "no-snippets", conflicts_with = "snippets")]
         no_snippets: bool,
+        /// Fetch the NEXT page of ranked entities from the previous query,
+        /// reading the cursor persisted in `.kin/locate-cursor`. No retrieval
+        /// re-run; pages the daemon's cached ranking. Query text is not required.
+        #[arg(long, conflicts_with = "cursor")]
+        next: bool,
+        /// Fetch a specific entity page using an explicit cursor token (from a
+        /// prior result's `next_cursor`). Lower-level alternative to `--next`.
+        #[arg(long)]
+        cursor: Option<String>,
+        /// Entities per page for the graph-native `entities` surface
+        /// (`KIN_LOCATE_ENTITY_CAP` otherwise).
+        #[arg(long)]
+        page_size: Option<usize>,
     },
     /// Debug locate results: show per-signal breakdown, rank gold files,
     /// and diagnose why targets were missed.
@@ -1901,6 +1914,9 @@ fn main() -> Result<()> {
                     reference,
                     snippets,
                     no_snippets,
+                    next,
+                    cursor,
+                    page_size,
                 } => {
                     // Inline snippets default ON for the structured/agent `--json`
                     // surface (so an agent gets code on the first locate);
@@ -1912,6 +1928,20 @@ fn main() -> Result<()> {
                     let explain = explain || diagnose;
                     let max_files_explicit = max_files.is_some();
                     let max_files_val = max_files.unwrap_or(10);
+                    // Resolve the paging cursor: --next reads the persisted cursor
+                    // from the prior page; --cursor takes an explicit token.
+                    let paging_cursor = if next {
+                        Some(commands::locate_cursor::read_persisted_locate_cursor()?)
+                    } else {
+                        cursor
+                    };
+                    let paging = commands::locate::LocatePaging {
+                        cursor: paging_cursor,
+                        page_size,
+                    };
+                    // On a paging request the query text is carried by the cursor
+                    // (the daemon holds the cached ranking), so it is optional.
+                    let paging_active = paging.cursor.is_some();
                     let problem_text = if stdin {
                         let mut buf = String::new();
                         std::io::Read::read_to_string(&mut std::io::stdin(), &mut buf)?;
@@ -1920,6 +1950,10 @@ fn main() -> Result<()> {
                         std::fs::read_to_string(&path)?
                     } else if let Some(t) = text {
                         t
+                    } else if paging_active {
+                        // --next / --cursor without inline text: the daemon pages
+                        // its cached ranking; text is only a cache-miss fallback.
+                        String::new()
                     } else {
                         anyhow::bail!("provide problem text, --file, or --stdin");
                     };
@@ -1933,6 +1967,7 @@ fn main() -> Result<()> {
                             max_files_explicit,
                             reference,
                             want_snippets,
+                            paging,
                         )
                         .await?;
 
@@ -2057,6 +2092,7 @@ fn main() -> Result<()> {
                             max_files_explicit,
                             reference,
                             want_snippets,
+                            paging,
                         )
                         .await
                     }

--- a/crates/kin-daemon/src/api.rs
+++ b/crates/kin-daemon/src/api.rs
@@ -8,7 +8,10 @@ use std::path::{Component, Path as FsPath, PathBuf};
 use std::sync::{Arc, OnceLock};
 use std::time::Duration;
 
-use crate::state::{DaemonEvent, DaemonState, ProjectionChangedSet};
+use crate::state::{
+    CachedLocateRanking, CachedSemanticPage, DaemonEvent, DaemonState, ProjectionChangedSet,
+    LOCATE_RANKING_CACHE_CAP,
+};
 
 use axum::extract::{Path, Query, State};
 use axum::http::{header, HeaderValue, StatusCode};
@@ -2999,13 +3002,63 @@ async fn locate(
         kin_cli::commands::locate::SnippetOptions::default()
     };
 
+    // Graph version stamps the paging cursor: any mutation bumps `vfs_version`,
+    // so a stale cursor can never page a ranking built against different truth.
+    let graph_version = state.vfs_version.load(std::sync::atomic::Ordering::SeqCst);
+    let page_size = req
+        .page_size
+        .filter(|n| *n > 0)
+        .unwrap_or_else(kin_cli::commands::locate::entity_page_size);
+
+    // Paging fast path: a valid cursor whose ranking is still cached at the
+    // current graph version is windowed straight from cache — NO retrieval.
+    if let Some(cursor_token) = req.cursor.as_deref() {
+        if let Some(parsed) = kin_cli::commands::locate::LocateCursor::decode(cursor_token) {
+            let cached = {
+                let cache = state.locate_rankings.lock().unwrap();
+                cache
+                    .get(&parsed.key)
+                    .filter(|entry| entry.graph_version == graph_version)
+                    .map(|entry| entry.entities.clone())
+            };
+            if let Some(entities) = cached {
+                let mut result = kin_cli::commands::locate::LocateResult {
+                    entities,
+                    ..Default::default()
+                };
+                kin_cli::commands::locate::apply_entity_page(
+                    &mut result,
+                    &parsed.key,
+                    parsed.page,
+                    page_size,
+                );
+                return Ok(Json(result));
+            }
+        }
+        // Cache miss / stale / undecodable cursor: fall through to a fresh run
+        // (returns page 0) rather than silently failing the page.
+    }
+
+    // Scope token for the cursor key (explicit ref, else the session's temporal
+    // scope) so cursors never collide across refs/scopes for the same query.
+    let scope_token: Option<String> = if let Some(reference) = req.reference.as_ref() {
+        Some(reference.clone())
+    } else if let Some(sid) = session_id.as_ref() {
+        state
+            .get_session_scope(sid)
+            .await
+            .map(|(ref_str, _, _, _)| ref_str)
+    } else {
+        None
+    };
+
     tracing::info!(
         ">>> LOCATE: state.graph.embedding_status().indexed={}, graph root hash={:?}",
         state.graph.embedding_status().indexed,
         state.graph.compute_root_hash()
     );
 
-    let result = if let Some(reference) = req.reference.as_deref() {
+    let mut result = if let Some(reference) = req.reference.as_deref() {
         // Explicit --ref always takes precedence over session scope.
         let resolved = kin_cli::commands::ref_lookup::resolve_ref_importing_git_if_needed_for_locate_with_report(
             state.graph.as_ref(),
@@ -3048,6 +3101,17 @@ async fn locate(
         .await
     }
     .map_err(internal_error)?;
+
+    // Cache the full entity ranking and window page 0 so a follow-up `--next`
+    // pages it from cache without re-running retrieval. Keyed by
+    // (query, ref/scope, graph-version) so any edit invalidates the page.
+    let key = kin_cli::commands::locate::locate_cursor_key(
+        &req.text,
+        scope_token.as_deref(),
+        graph_version,
+    );
+    cache_locate_ranking(&state, &key, &result.entities, graph_version);
+    kin_cli::commands::locate::apply_entity_page(&mut result, &key, 0, page_size);
     Ok(Json(result))
 }
 
@@ -3114,6 +3178,35 @@ async fn run_fused_locate_for_state(
         snippet_opts,
     )
     .map_err(|error| error.to_string())
+}
+
+/// Insert a full locate ranking into the paging cache, evicting the oldest entry
+/// when the cache is at capacity (a fresh key past the cap). The cache is bounded
+/// to [`LOCATE_RANKING_CACHE_CAP`], so the linear eviction scan stays cheap.
+fn cache_locate_ranking(
+    state: &DaemonState,
+    key: &str,
+    entities: &[kin_cli::commands::locate::LocateEntity],
+    graph_version: u64,
+) {
+    let mut cache = state.locate_rankings.lock().unwrap();
+    if cache.len() >= LOCATE_RANKING_CACHE_CAP && !cache.contains_key(key) {
+        if let Some(oldest) = cache
+            .iter()
+            .min_by_key(|(_, entry)| entry.created)
+            .map(|(k, _)| k.clone())
+        {
+            cache.remove(&oldest);
+        }
+    }
+    cache.insert(
+        key.to_string(),
+        CachedLocateRanking {
+            entities: entities.to_vec(),
+            graph_version,
+            created: std::time::Instant::now(),
+        },
+    );
 }
 
 /// POST /search — run CLI search against daemon-owned graph state.
@@ -4001,12 +4094,81 @@ fn semloc_rerank_priority(
 /// projected from graph-owned content via the same body projection
 /// `get_entity_source` uses, so one `semantic_locate` is act-on-able without a
 /// follow-up read; omitted on a graph gap or when `include_snippet` is false.
+/// Max entity pages retained for a single `semantic_locate` ranking. Bounds the
+/// per-query snippet/projection work while still letting a cursor walk well past
+/// the first page.
+const SEMANTIC_LOCATE_MAX_PAGES: usize = 5;
+
+/// Window a full ranked row list to page `page` of `page_size`, returning the
+/// slice, the total, and whether more rows remain. Pure paging arithmetic shared
+/// by the fresh and cached `semantic_locate` paths.
+fn window_semantic_rows(
+    rows: &[serde_json::Value],
+    page: usize,
+    page_size: usize,
+) -> (Vec<serde_json::Value>, usize, bool) {
+    let page_size = page_size.max(1);
+    let total = rows.len();
+    let start = page.saturating_mul(page_size);
+    let end = start.saturating_add(page_size).min(total);
+    let window = if start < total {
+        rows[start..end].to_vec()
+    } else {
+        Vec::new()
+    };
+    (window, total, end < total)
+}
+
+/// Serialize a windowed `semantic_locate` page into the tool result payload.
+fn semantic_locate_payload(
+    query: &str,
+    file_granularity: bool,
+    semantic_coverage: f32,
+    key: &str,
+    page: usize,
+    page_size: usize,
+    rows: &[serde_json::Value],
+) -> kin_mcp::ToolCallResult {
+    let (window, total, has_more) = window_semantic_rows(rows, page, page_size);
+    let next_cursor = has_more.then(|| {
+        kin_cli::commands::locate::LocateCursor {
+            key: key.to_string(),
+            page: page + 1,
+        }
+        .encode()
+    });
+    let payload = json!({
+        "query": query,
+        "granularity": if file_granularity { "file" } else { "entity" },
+        "routing": "cosine-v0",
+        "semantic_coverage": semantic_coverage,
+        "page": page,
+        "total_ranked": total,
+        "next_cursor": next_cursor,
+        "results": window,
+    });
+    match serde_json::to_string_pretty(&payload) {
+        Ok(text) => kin_mcp::ToolCallResult::text(text),
+        Err(error) => kin_mcp::ToolCallResult::error(error.to_string()),
+    }
+}
+
 fn build_semantic_locate_result(
+    state: &DaemonState,
     graph: &kin_db::InMemoryGraph,
     arguments: &HashMap<String, serde_json::Value>,
 ) -> kin_mcp::ToolCallResult {
     let query = match arguments.get("query").and_then(serde_json::Value::as_str) {
         Some(value) if !value.trim().is_empty() => value.to_string(),
+        // A paging request carries the query in its cached ranking, so an empty
+        // query is allowed only when a cursor is present.
+        _ if arguments
+            .get("cursor")
+            .and_then(serde_json::Value::as_str)
+            .is_some() =>
+        {
+            String::new()
+        }
         _ => {
             return kin_mcp::ToolCallResult::error("missing required parameter: query".to_string());
         }
@@ -4017,6 +4179,13 @@ fn build_semantic_locate_result(
         .map(|value| value as usize)
         .filter(|value| *value > 0)
         .unwrap_or(20);
+    // Entities per page: `page_size` if given, else the historical `limit`.
+    let page_size = arguments
+        .get("page_size")
+        .and_then(serde_json::Value::as_u64)
+        .map(|value| value as usize)
+        .filter(|value| *value > 0)
+        .unwrap_or(limit);
     let file_granularity = arguments
         .get("granularity")
         .and_then(serde_json::Value::as_str)
@@ -4032,6 +4201,9 @@ fn build_semantic_locate_result(
         .unwrap_or(true)
         && !file_granularity;
 
+    let graph_version = state.vfs_version.load(std::sync::atomic::Ordering::SeqCst);
+    let granularity_token = format!("sem:{}", if file_granularity { "file" } else { "entity" });
+
     // Coverage is reported, never gated: a partially-embedded graph still
     // returns whatever the index can answer (graceful degradation per R5).
     let status = graph.embedding_status();
@@ -4041,13 +4213,39 @@ fn build_semantic_locate_result(
         status.indexed as f32 / status.total as f32
     };
 
-    // Over-fetch so post-resolution dedupe can still fill `limit`: by file for
+    // Paging fast path: a valid cursor whose ranking is still cached at the
+    // current graph version is windowed straight from cache — no re-search.
+    if let Some(cursor_token) = arguments.get("cursor").and_then(serde_json::Value::as_str) {
+        if let Some(parsed) = kin_cli::commands::locate::LocateCursor::decode(cursor_token) {
+            let cached = {
+                let cache = state.semantic_locate_pages.lock().unwrap();
+                cache
+                    .get(&parsed.key)
+                    .filter(|entry| entry.graph_version == graph_version)
+                    .map(|entry| entry.rows.clone())
+            };
+            if let Some(rows) = cached {
+                return semantic_locate_payload(
+                    &query,
+                    file_granularity,
+                    semantic_coverage,
+                    &parsed.key,
+                    parsed.page,
+                    page_size,
+                    &rows,
+                );
+            }
+        }
+        // Cache miss / stale cursor: fall through to a fresh search (page 0).
+    }
+
+    // Over-fetch so post-resolution dedupe can still fill the page: by file for
     // file granularity, by resolved entity for entity granularity.
     // Every entity carries both an `Entity(E)` and an `EntityRevision(head)`
     // vector in the index, both resolving to the same entity, so without the
     // entity dedup below each entity would appear ~twice and effective recall@k
     // would halve.
-    let fetch_limit = limit.saturating_mul(8).max(limit);
+    let fetch_limit = page_size.saturating_mul(8).max(page_size);
 
     let raw = match graph.semantic_search(&query, fetch_limit) {
         Ok(hits) => hits,
@@ -4091,21 +4289,30 @@ fn build_semantic_locate_result(
         raw
     };
 
-    let mut results = Vec::with_capacity(limit);
+    // Build the full (bounded) ranking once; page 0 is returned and the rest is
+    // cached for `--next`. Cap the retained ranking so per-query projection work
+    // stays bounded regardless of how deep the over-fetch ran. The opt-in re-rank
+    // above has already reordered `raw`, so paging windows the re-ranked set.
+    let max_rows = page_size.saturating_mul(SEMANTIC_LOCATE_MAX_PAGES);
+    let mut rows: Vec<serde_json::Value> = Vec::with_capacity(page_size);
     let mut seen_files: HashSet<String> = HashSet::new();
     let mut seen_entities: HashSet<String> = HashSet::new();
     for (key, distance) in raw {
-        if results.len() >= limit {
+        if rows.len() >= max_rows {
             break;
         }
         let Some(item) = graph.resolve_retrieval_key(&key) else {
             continue;
         };
-        let (entity_id, name, file) = match &item {
+        // Entity-centric projection: the ENTITY (kind + name + signature) is the
+        // result; the file is demoted to provenance.
+        let (entity_id, name, file, kind, signature) = match &item {
             kin_db::ResolvedRetrievalItem::Entity(entity) => (
                 entity.id.to_string(),
                 entity.name.clone(),
                 entity.file_origin.as_ref().map(|origin| origin.0.clone()),
+                Some(format!("{:?}", entity.kind).to_lowercase()),
+                Some(entity.signature.clone()).filter(|sig| !sig.is_empty()),
             ),
             other => {
                 let file = other.file_path().map(|path| path.0.clone());
@@ -4119,7 +4326,7 @@ fn build_semantic_locate_result(
                     .unwrap_or_default()
                     .to_string();
                 let id = file.clone().unwrap_or_else(|| name.clone());
-                (id, name, file)
+                (id, name, file, None, None)
             }
         };
 
@@ -4140,9 +4347,8 @@ fn build_semantic_locate_result(
             continue;
         }
 
-        // Project the bounded snippet only for kept entity hits (top `limit`),
-        // from graph-owned content — no working-tree read; a graph gap yields no
-        // snippet rather than a fallback.
+        // Project the bounded snippet from graph-owned content — no working-tree
+        // read; a graph gap yields no snippet rather than a fallback.
         let snippet = if include_snippet {
             if let kin_db::ResolvedRetrievalItem::Entity(entity) = &item {
                 kin_mcp::handlers::common::read_bounded_entity_snippet(graph, entity)
@@ -4156,28 +4362,54 @@ fn build_semantic_locate_result(
         let score = 1.0_f32 - distance;
         let mut hit = json!({
             "entity_id": entity_id,
+            "kind": kind,
             "name": name,
-            "file": file,
+            "signature": signature,
             "score": score,
+            "provenance": { "file": file },
         });
         if let Some(snippet) = snippet {
             hit["snippet"] = json!(snippet);
         }
-        results.push(hit);
+        rows.push(hit);
     }
 
-    let payload = json!({
-        "query": query,
-        "granularity": if file_granularity { "file" } else { "entity" },
-        "routing": "cosine-v0",
-        "semantic_coverage": semantic_coverage,
-        "results": results,
-    });
-
-    match serde_json::to_string_pretty(&payload) {
-        Ok(text) => kin_mcp::ToolCallResult::text(text),
-        Err(error) => kin_mcp::ToolCallResult::error(error.to_string()),
+    // Cache the full ranking under the paging key, then return page 0.
+    let key = kin_cli::commands::locate::locate_cursor_key(
+        &query,
+        Some(granularity_token.as_str()),
+        graph_version,
+    );
+    {
+        let mut cache = state.semantic_locate_pages.lock().unwrap();
+        if cache.len() >= LOCATE_RANKING_CACHE_CAP && !cache.contains_key(&key) {
+            if let Some(oldest) = cache
+                .iter()
+                .min_by_key(|(_, entry)| entry.created)
+                .map(|(k, _)| k.clone())
+            {
+                cache.remove(&oldest);
+            }
+        }
+        cache.insert(
+            key.clone(),
+            CachedSemanticPage {
+                rows: rows.clone(),
+                graph_version,
+                created: std::time::Instant::now(),
+            },
+        );
     }
+
+    semantic_locate_payload(
+        &query,
+        file_granularity,
+        semantic_coverage,
+        &key,
+        0,
+        page_size,
+        &rows,
+    )
 }
 
 /// Resolve the graph entity behind one fused-locate symbol so a
@@ -4608,6 +4840,7 @@ async fn mcp_tools_call(
             ));
         }
         return Ok(Json(build_semantic_locate_result(
+            &state,
             graph.as_ref(),
             &request.arguments,
         )));
@@ -11384,6 +11617,8 @@ mod tests {
                             reference: None,
                             snippets: false,
                             snippet_lines: None,
+                            cursor: None,
+                            page_size: None,
                         })
                         .unwrap(),
                     ))

--- a/crates/kin-daemon/src/state.rs
+++ b/crates/kin-daemon/src/state.rs
@@ -383,7 +383,38 @@ pub struct DaemonState {
     /// separate HTTP calls) must live here to survive between calls; sessions and
     /// intents persist through the graph, but transactions have no graph backing.
     pub mcp_transactions: Mutex<HashMap<String, kin_mcp::McpTransaction>>,
+    /// Cached locate entity-rankings keyed by paging-cursor key, so `kin locate
+    /// --next` (and `semantic_locate` cursors) page a held ranking without
+    /// re-running retrieval. Bounded by [`LOCATE_RANKING_CACHE_CAP`].
+    pub locate_rankings: Mutex<HashMap<String, CachedLocateRanking>>,
+    /// Cached `semantic_locate` result pages keyed by paging-cursor key.
+    pub semantic_locate_pages: Mutex<HashMap<String, CachedSemanticPage>>,
 }
+
+/// Cached full locate entity-ranking for cursor paging. The daemon caches the
+/// FULL ranked entity list once per (query, ref/scope, graph-version) so a
+/// follow-up page (`kin locate --next`) windows the next slice with no retrieval
+/// re-run. `graph_version` is checked on lookup so a stale page (the graph moved
+/// under the cursor) is rejected rather than served.
+pub struct CachedLocateRanking {
+    pub entities: Vec<kin_cli::commands::locate::LocateEntity>,
+    pub graph_version: u64,
+    pub created: Instant,
+}
+
+/// Cached full `semantic_locate` result rows for cursor paging — the entity-
+/// granularity analogue of [`CachedLocateRanking`], holding the already-projected
+/// per-entity JSON rows so a follow-up page is a pure window.
+pub struct CachedSemanticPage {
+    pub rows: Vec<serde_json::Value>,
+    pub graph_version: u64,
+    pub created: Instant,
+}
+
+/// Soft cap on distinct rankings retained for paging; the oldest is evicted past
+/// this bound. Paging is a short-lived read-after-read, so a small cache covers
+/// the realistic concurrent-cursor count without unbounded growth.
+pub const LOCATE_RANKING_CACHE_CAP: usize = 64;
 
 /// Minimum baseline count before an anti-wipe guard can fire. Below this, the
 /// set is small enough that a collapse is not catastrophic (and fresh-init /
@@ -628,6 +659,8 @@ impl DaemonState {
             mass_deletion_blocked: AtomicBool::new(false),
             embed_worker_failed: AtomicBool::new(false),
             mcp_transactions: Mutex::new(HashMap::new()),
+            locate_rankings: Mutex::new(HashMap::new()),
+            semantic_locate_pages: Mutex::new(HashMap::new()),
         };
         // Restore in-flight MCP transactions persisted before a restart
         // so staged-but-uncommitted work is not silently dropped across a daemon
@@ -763,6 +796,8 @@ impl DaemonState {
             mass_deletion_blocked: AtomicBool::new(false),
             embed_worker_failed: AtomicBool::new(false),
             mcp_transactions: Mutex::new(HashMap::new()),
+            locate_rankings: Mutex::new(HashMap::new()),
+            semantic_locate_pages: Mutex::new(HashMap::new()),
         };
 
         // Restore in-flight MCP transactions persisted before a restart.
@@ -2035,6 +2070,8 @@ mod tests {
             mass_deletion_blocked: AtomicBool::new(false),
             embed_worker_failed: AtomicBool::new(false),
             mcp_transactions: Mutex::new(HashMap::new()),
+            locate_rankings: Mutex::new(HashMap::new()),
+            semantic_locate_pages: Mutex::new(HashMap::new()),
         }
     }
 

--- a/crates/kin-mcp/src/handlers/common.rs
+++ b/crates/kin-mcp/src/handlers/common.rs
@@ -855,11 +855,22 @@ pub fn push_indented_body(
 
 #[derive(Debug, Clone)]
 pub struct ReferenceRow {
+    /// Graph entity id of the referencing (caller) entity, when it is a
+    /// graph-owned local entity. Lets an agent drill a reference straight to the
+    /// caller's body (`get_entity_source`/`get_context_pack`) without re-resolving
+    /// the caller by name — the keystone of the no-filesystem reference→body
+    /// chain. `None` for federated spine xrefs (no local entity).
+    pub entity_id: Option<String>,
     pub name: String,
     pub kind: Option<String>,
     pub file_path: Option<String>,
     pub start_line: Option<u32>,
     pub signature: Option<String>,
+    /// Bounded inline body excerpt of the referencing entity, projected from the
+    /// same content-addressed, hash-verified graph body that backs
+    /// `get_entity_source` (never a working-tree read). `None` on a graph/blob
+    /// miss or for pathless/federated rows.
+    pub snippet: Option<String>,
     pub relation_kinds: Vec<RelationKind>,
 }
 
@@ -891,11 +902,16 @@ pub fn collect_graph_reference_rows<G: GraphStore>(
         let file_path = entity.file_origin.as_ref().map(|path| path.0.clone());
         let key = reference_row_key(file_path.as_deref(), &entity.name);
         let entry = grouped.entry(key).or_insert_with(|| ReferenceRow {
+            entity_id: Some(source_entity_id.to_string()),
             name: entity.name.clone(),
             kind: Some(format!("{:?}", entity.kind)),
             file_path: file_path.clone(),
             start_line: entity.span.as_ref().map(|span| span.start_line),
             signature: Some(entity.signature.clone()),
+            // Project the caller's bounded body once, where the entity is in
+            // hand, so `find_references` hands back act-on-able code per caller
+            // without a follow-up id→body round-trip.
+            snippet: read_bounded_entity_snippet(store, &entity),
             relation_kinds: Vec::new(),
         });
         if entry.file_path.is_none() {

--- a/crates/kin-mcp/src/handlers/entities.rs
+++ b/crates/kin-mcp/src/handlers/entities.rs
@@ -482,6 +482,9 @@ pub async fn handle_find_references<G: GraphStore>(
                     if edge["to_repo_id"] == repo_id && edge["repo_id"] != repo_id {
                         // This is an external caller pointing at us.
                         rows.push(ReferenceRow {
+                            // Federated xref: the caller lives in another repo, so
+                            // there is no local entity id or graph-owned body here.
+                            entity_id: None,
                             name: edge["from_name"].as_str().unwrap_or("unknown").to_string(),
                             kind: edge["kind"].as_str().map(|s| s.to_string()),
                             file_path: Some(format!(
@@ -491,6 +494,7 @@ pub async fn handle_find_references<G: GraphStore>(
                             )),
                             start_line: None,
                             signature: None,
+                            snippet: None,
                             relation_kinds: vec![RelationKind::References], // Spine edges are generic xrefs
                         });
                     }
@@ -510,11 +514,19 @@ pub async fn handle_find_references<G: GraphStore>(
         .into_iter()
         .map(|row| {
             serde_json::json!({
+                // `entity_id` is the keystone: it lets the agent drill this
+                // reference straight to the caller's body
+                // (`get_entity_source`/`get_context_pack`) with no name
+                // re-resolution and no filesystem fallback. `snippet` carries the
+                // caller's bounded body inline so the common drill needs no
+                // second round-trip.
+                "entity_id": row.entity_id,
                 "name": row.name,
                 "kind": row.kind,
                 "file_path": row.file_path,
                 "start_line": row.start_line,
                 "signature": row.signature,
+                "snippet": row.snippet,
                 "relation_kinds": row.relation_kinds.into_iter().map(relation_kind_name).collect::<Vec<_>>(),
             })
         })
@@ -1889,6 +1901,12 @@ mod tests {
         assert_eq!(refs[0]["name"], "caller");
         assert_eq!(refs[0]["file_path"], "src/a.rs");
         assert_eq!(refs[0]["kind"], "Function");
+        // The keystone: each reference carries the caller's graph entity_id so an
+        // agent can drill straight to its body with no name re-resolution.
+        assert_eq!(refs[0]["entity_id"], caller_id.to_string());
+        // `snippet` is always present in the shape (null here: the fixture has no
+        // blob-backed body to project).
+        assert!(refs[0].as_object().unwrap().contains_key("snippet"));
     }
 
     #[tokio::test]

--- a/crates/kin-mcp/src/lib.rs
+++ b/crates/kin-mcp/src/lib.rs
@@ -24,7 +24,9 @@ pub use server::{
 pub use session::{
     AssistantSession, McpMutationOperation, McpMutationPayload, McpTransaction, SessionRegistry,
 };
-pub use tools::{agent_default_tool_names, benchmark_tool_names, tool_definitions};
+pub use tools::{
+    agent_default_tool_names, benchmark_tool_names, context_bench_tool_names, tool_definitions,
+};
 pub use types::{
     ContentBlock, JsonRpcRequest, JsonRpcResponse, ToolCallParams, ToolCallResult, ToolDefinition,
 };

--- a/crates/kin-mcp/src/tools.rs
+++ b/crates/kin-mcp/src/tools.rs
@@ -28,8 +28,10 @@ pub fn tool_definitions() -> ToolsListResult {
                 input_schema: serde_json::json!({
                     "type": "object",
                     "properties": {
-                        "query": { "type": "string", "description": "Natural-language description of the code to find" },
-                        "limit": { "type": "integer", "description": "Max ranked results to return", "default": 20 },
+                        "query": { "type": "string", "description": "Natural-language description of the code to find. Optional when paging with `cursor`." },
+                        "limit": { "type": "integer", "description": "Max ranked entities per page (page size). Default 20.", "default": 20 },
+                        "page_size": { "type": "integer", "description": "Entities per page; overrides `limit` for paging when set." },
+                        "cursor": { "type": "string", "description": "Opaque cursor from a prior result's `next_cursor`: returns the NEXT page of ranked entities from the cached ranking with no re-search. Omit for a fresh query." },
                         "granularity": {
                             "type": "string",
                             "enum": ["file", "entity"],
@@ -947,6 +949,31 @@ pub fn agent_default_tool_names() -> &'static [&'static str] {
     ]
 }
 
+/// Tool names for the READ-ONLY graph-native ContextBench profile.
+///
+/// This is the belt the graph-native benchmark agent arm drives: purely
+/// graph-native retrieval/read tools and NO write-side session/transaction tools
+/// (which `agent_default_tool_names` carries) and NO filesystem tools (there are
+/// none to expose — the entire MCP surface is graph-backed). It includes
+/// `semantic_locate` (entity-centric + paged), which `benchmark_tool_names`
+/// omits, so the agent can do natural-language entity retrieval, drill via
+/// `find_references`/`trace_data_flow`/`graph_neighborhood`, and read bodies via
+/// `get_entity_source`/`get_context_pack` — all without ever touching a file.
+pub fn context_bench_tool_names() -> &'static [&'static str] {
+    &[
+        "kin_graph_status",
+        "semantic_locate",
+        "semantic_search",
+        "get_entity",
+        "get_entity_source",
+        "get_entity_body",
+        "get_context_pack",
+        "trace_data_flow",
+        "find_references",
+        "graph_neighborhood",
+    ]
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -1041,6 +1068,46 @@ mod tests {
             profile.len(),
             "every profile tool should be listable"
         );
+    }
+
+    #[test]
+    fn context_bench_profile_is_read_only_and_graph_native() {
+        let list = tool_definitions();
+        let all: std::collections::HashSet<&str> =
+            list.tools.iter().map(|t| t.name.as_str()).collect();
+        let profile = context_bench_tool_names();
+
+        // Every belt tool is a real, listable graph tool.
+        for name in profile {
+            assert!(
+                all.contains(name),
+                "context-bench tool '{name}' is not in tool_definitions()"
+            );
+        }
+        // It carries semantic_locate (the entity-centric NL retrieval surface)
+        // which the benchmark profile omits.
+        assert!(profile.contains(&"semantic_locate"));
+        assert!(!benchmark_tool_names().contains(&"semantic_locate"));
+
+        // READ-ONLY: no write-side session/transaction/intent tools.
+        for forbidden in profile {
+            assert!(
+                !forbidden.starts_with("kin_session_")
+                    && !forbidden.starts_with("kin_transaction_")
+                    && !forbidden.contains("intent")
+                    && !forbidden.starts_with("register_"),
+                "context-bench must be read-only; found write-side tool '{forbidden}'"
+            );
+        }
+
+        // GRAPH-NATIVE: not a single filesystem tool name in the belt (there are
+        // none to expose — the whole MCP surface is graph-backed).
+        for fs in ["cat", "ls", "grep", "find", "read_file", "open_file"] {
+            assert!(
+                !profile.contains(&fs),
+                "context-bench belt must have zero filesystem tools; found '{fs}'"
+            );
+        }
     }
 
     #[test]


### PR DESCRIPTION
## Entity-centric locate: return the entity, not a file to read
`kin locate` and MCP `semantic_locate` now lead with the semantic ENTITY -- `entity_id`, kind, signature, bounded body -- with the file demoted to provenance. The `entity_id` is the stable handle for every follow-up graph query (`get_entity_source`, `find_references`, `trace`), so an agent reasons over entities and never needs a file path. `find_references` carries `entity_id` too.

## Paging
`--next`/`--cursor`/`--page-size` page the ranked entities with no retrieval re-run (version-invalidated cursor cache).

## Rationale
Coordinate-plus-file output pushed AI agents to whole-file-read everything (context bloat, low precision). Entity-centric output keeps the agent reasoning over graph entities. New read-only `context-bench` MCP profile. Supersedes the file-snippet approach in #144. Tests: kin-mcp 168/168, kin-cli locate 192/192.