### PR TITLE
spine: register repo entities on refresh + transitive 2-hop/multi-consumer gate (FIR-1149/FIR-1085)

### DIFF
--- a/crates/kin-daemon/src/api.rs
+++ b/crates/kin-daemon/src/api.rs
@@ -9319,6 +9319,150 @@ mod tests {
         );
     }
 
+    /// The daemon's /spine endpoints serve a TRANSITIVE (2-hop) blast radius and
+    /// MULTI-CONSUMER edges through the production refresh path: provider <-
+    /// consumer <- downstream, plus a second consumer of provider. This is the
+    /// FIR-1149 transitive/multi-consumer gate on top of the 1-hop fixture; it
+    /// depends on refresh registering each repo's own entities so the next hop
+    /// can resolve them.
+    #[tokio::test]
+    async fn spine_serves_transitive_2hop_and_multi_consumer_blast_radius() {
+        let do_work_id = EntityId::new();
+        let provider_entry = kin_spine::EntityEntry {
+            repo_id: "provider".to_string(),
+            entity_id: do_work_id,
+            name: "do_work".to_string(),
+            kind: kin_model::EntityKind::Function,
+            signature: "fn do_work()".to_string(),
+            fingerprint: spine_test_fingerprint(),
+            file_path: Some("src/lib.rs".to_string()),
+            role: Some(kin_model::EntityRole::Source),
+        };
+
+        // consumer: imports provider::do_work via run_task (the 1st hop).
+        let consumer = parse_consumer_source(
+            "src/app.rs",
+            "use provider::do_work;\n\npub fn run_task() {\n    do_work();\n}\n",
+        );
+        let consumer_entities = consumer.entities.clone();
+        let consumer_relations = kin_index::link_cross_file(&[consumer]);
+        let run_task_id = consumer_entities
+            .iter()
+            .find(|e| e.name == "run_task")
+            .expect("run_task entity present")
+            .id;
+
+        // consumer2: a SECOND consumer of provider::do_work (multi-consumer).
+        let consumer2 = parse_consumer_source(
+            "src/other.rs",
+            "use provider::do_work;\n\npub fn other_task() {\n    do_work();\n}\n",
+        );
+        let consumer2_entities = consumer2.entities.clone();
+        let consumer2_relations = kin_index::link_cross_file(&[consumer2]);
+
+        // downstream: imports consumer::run_task (the 2nd hop).
+        let downstream = parse_consumer_source(
+            "src/top.rs",
+            "use consumer::run_task;\n\npub fn orchestrate() {\n    run_task();\n}\n",
+        );
+        let downstream_entities = downstream.entities.clone();
+        let downstream_relations = kin_index::link_cross_file(&[downstream]);
+        let orchestrate_id = downstream_entities
+            .iter()
+            .find(|e| e.name == "orchestrate")
+            .expect("orchestrate entity present")
+            .id;
+
+        let state = test_state();
+        let spine = state.ensure_spine().expect("spine enabled in test");
+        let registry = [
+            "provider".to_string(),
+            "consumer".to_string(),
+            "consumer2".to_string(),
+            "downstream".to_string(),
+        ];
+        spine.register_repo("provider", vec![provider_entry], "");
+        // Each refresh registers the repo's own entities as resolution targets so
+        // the next hop can bind to them — the behavior this gate proves. Refresh
+        // in dependency order so each hop's targets are present.
+        spine.refresh_cross_repo_edges("consumer", &consumer_entities, &consumer_relations, &registry);
+        spine.refresh_cross_repo_edges(
+            "consumer2",
+            &consumer2_entities,
+            &consumer2_relations,
+            &registry,
+        );
+        spine.refresh_cross_repo_edges(
+            "downstream",
+            &downstream_entities,
+            &downstream_relations,
+            &registry,
+        );
+
+        let app = router(state);
+
+        // 2-hop: /spine/xref for downstream's orchestrate resolves into consumer.
+        let xref = app
+            .clone()
+            .oneshot(
+                Request::get(format!(
+                    "/spine/xref?repo=downstream&entity={}",
+                    orchestrate_id.0
+                ))
+                .body(Body::empty())
+                .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(xref.status(), StatusCode::OK);
+        let xbody: serde_json::Value =
+            serde_json::from_slice(&axum::body::to_bytes(xref.into_body(), 65536).await.unwrap())
+                .unwrap();
+        let edges = xbody["edges"].as_array().expect("edges array in /spine/xref");
+        assert!(
+            edges.iter().any(|e| e["dst_repo"] == "consumer"),
+            "2-hop: downstream must resolve a cross-repo edge into consumer, got {edges:?}"
+        );
+
+        // Multi-consumer + transitive: federated impact of provider::do_work
+        // includes BOTH consumers AND the transitive downstream repo.
+        let impact = app
+            .oneshot(
+                Request::get(format!(
+                    "/spine/impact?repo=provider&entity={}&depth=5",
+                    do_work_id.0
+                ))
+                .body(Body::empty())
+                .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(impact.status(), StatusCode::OK);
+        let ibody: serde_json::Value = serde_json::from_slice(
+            &axum::body::to_bytes(impact.into_body(), 65536)
+                .await
+                .unwrap(),
+        )
+        .unwrap();
+        let repos: Vec<&str> = ibody["repos_involved"]
+            .as_array()
+            .expect("repos_involved array in /spine/impact")
+            .iter()
+            .filter_map(|v| v.as_str())
+            .collect();
+        assert!(
+            repos.contains(&"consumer") && repos.contains(&"consumer2"),
+            "multi-consumer: both consumers must appear in provider's blast radius, got {repos:?}"
+        );
+        assert!(
+            repos.contains(&"downstream"),
+            "transitive: the 2-hop downstream repo must appear in provider's blast radius, got {repos:?}"
+        );
+        // Bind the 1st-hop id so the helper is exercised end-to-end (and the
+        // unused-variable lint stays quiet) — run_task anchors the chain.
+        let _ = run_task_id;
+    }
+
     #[tokio::test]
     async fn spine_ingest_route_rejects_body_repo_mismatch() {
         // The path `repo_id` is authoritative. A body `repo` that disagrees is

--- a/crates/kin-daemon/src/api.rs
+++ b/crates/kin-daemon/src/api.rs
@@ -9385,7 +9385,12 @@ mod tests {
         // Each refresh registers the repo's own entities as resolution targets so
         // the next hop can bind to them — the behavior this gate proves. Refresh
         // in dependency order so each hop's targets are present.
-        spine.refresh_cross_repo_edges("consumer", &consumer_entities, &consumer_relations, &registry);
+        spine.refresh_cross_repo_edges(
+            "consumer",
+            &consumer_entities,
+            &consumer_relations,
+            &registry,
+        );
         spine.refresh_cross_repo_edges(
             "consumer2",
             &consumer2_entities,
@@ -9418,7 +9423,9 @@ mod tests {
         let xbody: serde_json::Value =
             serde_json::from_slice(&axum::body::to_bytes(xref.into_body(), 65536).await.unwrap())
                 .unwrap();
-        let edges = xbody["edges"].as_array().expect("edges array in /spine/xref");
+        let edges = xbody["edges"]
+            .as_array()
+            .expect("edges array in /spine/xref");
         assert!(
             edges.iter().any(|e| e["dst_repo"] == "consumer"),
             "2-hop: downstream must resolve a cross-repo edge into consumer, got {edges:?}"

--- a/crates/kin-spine/src/index.rs
+++ b/crates/kin-spine/src/index.rs
@@ -235,6 +235,16 @@ impl SpineIndex {
     ) {
         use crate::xref::{collect_unresolved_imports, materialize_edges, resolve_imports};
 
+        // Register this repo's own entities as resolution targets first, so a
+        // downstream repo importing THIS repo's symbols can resolve them — the
+        // basis for transitive (2-hop) and multi-consumer cross-repo edges. A
+        // repo that only ever has its edges refreshed (the direct/store path)
+        // would otherwise index as an impact node but never as a name-resolution
+        // target. Idempotent with the ingest-time register_repo: re-registration
+        // replaces this repo's rows and preserves its existing root hash.
+        let root_hash = self.root_hash(repo_id).unwrap_or_default();
+        self.register_repo(repo_id, entries_from_entities(repo_id, entities), &root_hash);
+
         // Remove existing edges from this repo
         {
             let mut inner = self.inner.write();
@@ -250,6 +260,26 @@ impl SpineIndex {
         let resolutions = resolve_imports(self, &unresolved);
         materialize_edges(self, &unresolved, &resolutions);
     }
+}
+
+/// Project a repo's graph entities into the metadata-only [`EntityEntry`] rows
+/// the index resolves against — the same mapping the daemon uses when it
+/// registers a repo. Bodies are never stored; just name/kind/signature/
+/// fingerprint/role, enough for cross-repo resolution.
+fn entries_from_entities(repo_id: &str, entities: &[Entity]) -> Vec<EntityEntry> {
+    entities
+        .iter()
+        .map(|e| EntityEntry {
+            repo_id: repo_id.to_string(),
+            entity_id: e.id,
+            name: e.name.clone(),
+            kind: e.kind,
+            signature: e.signature.clone(),
+            fingerprint: e.fingerprint.clone(),
+            file_path: e.file_origin.as_ref().map(|f| f.0.clone()),
+            role: Some(e.role),
+        })
+        .collect()
 }
 
 /// Score how well two fingerprints match (0.0 = no match, 3.0 = exact match).

--- a/crates/kin-spine/src/index.rs
+++ b/crates/kin-spine/src/index.rs
@@ -243,7 +243,11 @@ impl SpineIndex {
         // target. Idempotent with the ingest-time register_repo: re-registration
         // replaces this repo's rows and preserves its existing root hash.
         let root_hash = self.root_hash(repo_id).unwrap_or_default();
-        self.register_repo(repo_id, entries_from_entities(repo_id, entities), &root_hash);
+        self.register_repo(
+            repo_id,
+            entries_from_entities(repo_id, entities),
+            &root_hash,
+        );
 
         // Remove existing edges from this repo
         {

--- a/crates/kin-spine/tests/integration.rs
+++ b/crates/kin-spine/tests/integration.rs
@@ -830,6 +830,129 @@ fn cross_repo_edges_survive_cold_pod_restart_via_store() {
     assert_eq!(xref[0].dst_repo, "kin-db");
 }
 
+// ── Test 17: transitive (2-hop) + multi-consumer edges form through
+// refresh_cross_repo_edges alone, without a separate register_repo ─────────
+//
+// Chain: prov ← consumer ← downstream, plus a second consumer2 ← prov. Each
+// repo is ONLY ever passed to refresh_cross_repo_edges (never an explicit
+// register_repo), exactly as a direct/store refresh does. The downstream→
+// consumer edge can only materialize if consumer's own entities became
+// name-resolution targets during consumer's refresh — the behavior this fix
+// adds. Before it, consumer indexed as an impact node but not a resolution
+// target, so the 2nd hop never resolved.
+#[test]
+fn transitive_and_multi_consumer_edges_via_refresh_only() {
+    let index = SpineIndex::new();
+    let registry: Vec<String> = vec![
+        "prov".to_string(),
+        "consumer".to_string(),
+        "consumer2".to_string(),
+        "downstream".to_string(),
+    ];
+
+    // prov exports `target_fn` (a leaf; no outgoing imports).
+    let target = source_entity(EntityId::new(), "target_fn", LanguageId::Rust);
+    index.refresh_cross_repo_edges("prov", std::slice::from_ref(&target), &[], &registry);
+
+    // consumer imports prov::target_fn via its own `run_task`.
+    let run_task = source_entity(EntityId::new(), "run_task", LanguageId::Rust);
+    let consumer_rels = vec![cross_repo_call(
+        run_task.id,
+        "prov",
+        "prov::target_fn",
+        RelationKind::Calls,
+    )];
+    index.refresh_cross_repo_edges(
+        "consumer",
+        std::slice::from_ref(&run_task),
+        &consumer_rels,
+        &registry,
+    );
+
+    // consumer2 also imports prov::target_fn (the multi-consumer case).
+    let other_task = source_entity(EntityId::new(), "other_task", LanguageId::Rust);
+    let consumer2_rels = vec![cross_repo_call(
+        other_task.id,
+        "prov",
+        "prov::target_fn",
+        RelationKind::Calls,
+    )];
+    index.refresh_cross_repo_edges(
+        "consumer2",
+        std::slice::from_ref(&other_task),
+        &consumer2_rels,
+        &registry,
+    );
+
+    // downstream imports consumer::run_task — the 2nd hop.
+    let down_fn = source_entity(EntityId::new(), "orchestrate", LanguageId::Rust);
+    let downstream_rels = vec![cross_repo_call(
+        down_fn.id,
+        "consumer",
+        "consumer::run_task",
+        RelationKind::Calls,
+    )];
+    index.refresh_cross_repo_edges(
+        "downstream",
+        std::slice::from_ref(&down_fn),
+        &downstream_rels,
+        &registry,
+    );
+
+    // 1-hop (unchanged): consumer → prov outgoing edge bound to prov's entity.
+    let consumer_out: Vec<_> = index
+        .cross_repo_edges_for("consumer", &run_task.id)
+        .into_iter()
+        .filter(|e| e.src_repo == "consumer")
+        .collect();
+    assert_eq!(
+        consumer_out.len(),
+        1,
+        "consumer must have exactly one outgoing 1-hop edge"
+    );
+    assert_eq!(consumer_out[0].dst_repo, "prov");
+    assert_eq!(consumer_out[0].dst_entity, target.id);
+
+    // 2-hop (the fix): downstream → consumer outgoing edge. ABSENT without
+    // registering consumer's entities during its own refresh.
+    let downstream_out: Vec<_> = index
+        .cross_repo_edges_for("downstream", &down_fn.id)
+        .into_iter()
+        .filter(|e| e.src_repo == "downstream")
+        .collect();
+    assert_eq!(
+        downstream_out.len(),
+        1,
+        "downstream must resolve the 2nd hop into consumer (transitive edge)"
+    );
+    assert_eq!(downstream_out[0].dst_repo, "consumer");
+    assert_eq!(downstream_out[0].dst_entity, run_task.id);
+
+    // multi-consumer: prov's target_fn has incoming edges from both consumers.
+    let into_prov: Vec<_> = index
+        .cross_repo_edges_for("prov", &target.id)
+        .into_iter()
+        .filter(|e| e.dst_repo == "prov")
+        .collect();
+    let mut src_repos: Vec<String> = into_prov.iter().map(|e| e.src_repo.clone()).collect();
+    src_repos.sort();
+    assert_eq!(
+        src_repos,
+        vec!["consumer".to_string(), "consumer2".to_string()],
+        "prov's exported entity must show both consumers as incoming edges"
+    );
+
+    // Registering each repo's own entities during refresh must not create
+    // self-edges (src_repo == dst_repo).
+    assert!(
+        index
+            .cross_repo_edges_for("prov", &target.id)
+            .iter()
+            .all(|e| e.src_repo != e.dst_repo),
+        "refresh must not introduce self-edges"
+    );
+}
+
 /// Register a repo's entity metadata through the store-backed backend,
 /// mirroring the metadata write the daemon performs when it indexes a repo.
 fn ingest_repo(


### PR DESCRIPTION
Registers a repo's own entities during `refresh_cross_repo_edges` so downstream repos can resolve them — unblocks transitive (2-hop) and multi-consumer cross-repo edges. Adds a daemon e2e gate (`spine_serves_transitive_2hop_and_multi_consumer_blast_radius`) over /spine/impact + /spine/xref. Idempotent with the ingest-time register_repo (root hash preserved); no self-edges.

Validation: cargo test -p kin-spine (53) + cargo test -p kin-daemon spine (11), all pass; existing 1-hop fixture unchanged.

Closes the transitive/multi-consumer gap in FIR-1149; advances FIR-1085 multi-hop materialization.