### PR TITLE
spine: distinguish unavailable from empty in client cross-repo queries (FIR-1149)

### DIFF
--- a/crates/kin-cli/src/backend.rs
+++ b/crates/kin-cli/src/backend.rs
@@ -477,14 +477,22 @@ pub async fn get_spine_impact(
 }
 
 /// Query the daemon for cross-repo edges (xrefs) for a specific entity.
+///
+/// Returns a [`kin_spine::SpineQuery`] so the caller can tell apart a spine
+/// that is not configured (no daemon endpoint), one that is configured but
+/// unreachable/non-2xx (e.g. `503` when the spine is disabled), and a healthy
+/// answer that is genuinely empty — instead of collapsing the failure into a
+/// silent "no references" result.
 pub async fn get_spine_xref(
     layout: &kin_core::KinLayout,
     repo_id: &str,
     entity_id: &kin_model::EntityId,
-) -> anyhow::Result<Option<Vec<::kin_spine::CrossRepoEdge>>> {
-    let daemon_url = crate::daemon_client::resolve_daemon_url(layout)
-        .await?
-        .ok_or_else(|| anyhow::anyhow!("Kin daemon is required for spine xref queries"))?;
+) -> anyhow::Result<::kin_spine::SpineQuery<Vec<::kin_spine::CrossRepoEdge>>> {
+    use ::kin_spine::{classify_spine_probe, SpineProbe, SpineQuery};
+
+    let Some(daemon_url) = crate::daemon_client::resolve_daemon_url(layout).await? else {
+        return Ok(SpineQuery::NotConfigured);
+    };
     let client = reqwest::Client::builder()
         .timeout(Duration::from_secs(10))
         .build()?;
@@ -496,15 +504,20 @@ pub async fn get_spine_xref(
         ))
         .query(&[("repo", repo_id), ("entity", &entity_id.to_string())])
         .send()
-        .await?;
+        .await;
+    let status = resp.as_ref().ok().map(|r| r.status().as_u16());
 
-    if !resp.status().is_success() {
-        return Ok(None);
+    match classify_spine_probe(true, status) {
+        SpineProbe::Healthy => {
+            let body: serde_json::Value = resp?.json().await?;
+            let edges = serde_json::from_value(body["edges"].clone())?;
+            Ok(SpineQuery::Found(edges))
+        }
+        SpineProbe::Unavailable(reason) => Ok(SpineQuery::Unavailable(reason)),
+        SpineProbe::NotConfigured => Ok(SpineQuery::Unavailable(
+            "spine endpoint unexpectedly unconfigured".to_string(),
+        )),
     }
-
-    let body: serde_json::Value = resp.json().await?;
-    let edges = serde_json::from_value(body["edges"].clone())?;
-    Ok(Some(edges))
 }
 
 #[cfg(test)]

--- a/crates/kin-cli/src/commands/xref.rs
+++ b/crates/kin-cli/src/commands/xref.rs
@@ -92,7 +92,9 @@ pub async fn build_xref_response(
         }
         // No daemon endpoint configured in this context.
         Ok(::kin_spine::SpineQuery::NotConfigured) => {
-            lines.push("  Cross-repo spine not configured (no daemon endpoint available).".to_string());
+            lines.push(
+                "  Cross-repo spine not configured (no daemon endpoint available).".to_string(),
+            );
         }
         Err(e) => {
             lines.push(format!("  Failed to query spine: {}", e));

--- a/crates/kin-cli/src/commands/xref.rs
+++ b/crates/kin-cli/src/commands/xref.rs
@@ -70,7 +70,7 @@ pub async fn build_xref_response(
     let repo_id = crate::commands::remote::resolve_repo_id(layout)?;
 
     match crate::backend::get_spine_xref(layout, &repo_id, &target.id).await {
-        Ok(Some(edges)) if !edges.is_empty() => {
+        Ok(::kin_spine::SpineQuery::Found(edges)) if !edges.is_empty() => {
             lines.push(format!("  Found {} cross-repo edges:", edges.len()));
             for edge in edges {
                 lines.push(format!(
@@ -79,8 +79,20 @@ pub async fn build_xref_response(
                 ));
             }
         }
-        Ok(_) => {
+        // Healthy spine, genuinely no edges — an explicit, trustworthy empty.
+        Ok(::kin_spine::SpineQuery::Found(_)) => {
             lines.push("  No cross-repo references found in the spine.".to_string());
+        }
+        // Spine configured but unreachable/disabled (e.g. HTTP 503) — say so
+        // instead of implying an empty result.
+        Ok(::kin_spine::SpineQuery::Unavailable(reason)) => {
+            lines.push(format!(
+                "  Cross-repo spine unavailable ({reason}) — this is not the same as 'no references found'."
+            ));
+        }
+        // No daemon endpoint configured in this context.
+        Ok(::kin_spine::SpineQuery::NotConfigured) => {
+            lines.push("  Cross-repo spine not configured (no daemon endpoint available).".to_string());
         }
         Err(e) => {
             lines.push(format!("  Failed to query spine: {}", e));

--- a/crates/kin-daemon/src/api.rs
+++ b/crates/kin-daemon/src/api.rs
@@ -9550,10 +9550,13 @@ mod tests {
         );
 
         // ── Surface 2: the `kin xref` / `kin impact` CLI client code. ──
-        let cli_xref = get_spine_xref(&layout, "consumer", &run_task_id)
+        let cli_xref = match get_spine_xref(&layout, "consumer", &run_task_id)
             .await
             .expect("CLI get_spine_xref call")
-            .expect("CLI get_spine_xref returns edges");
+        {
+            kin_spine::SpineQuery::Found(edges) => edges,
+            other => panic!("CLI get_spine_xref expected Found, got {other:?}"),
+        };
         let cli_xref_to_provider = cli_xref.iter().any(|e| e.dst_repo == "provider");
         assert!(
             cli_xref_to_provider,
@@ -9572,10 +9575,10 @@ mod tests {
         );
 
         // ── Surface 3: the MCP impact_analysis client code. ──
-        let mcp_xref = fetch_spine_xref("consumer", &run_task_id)
-            .await
-            .expect("MCP fetch_spine_xref call")
-            .expect("MCP fetch_spine_xref returns edges");
+        let mcp_xref = match fetch_spine_xref("consumer", &run_task_id).await {
+            kin_spine::SpineQuery::Found(body) => body,
+            other => panic!("MCP fetch_spine_xref expected Found, got {other:?}"),
+        };
         let mcp_xref_to_provider = mcp_xref["edges"]
             .as_array()
             .map(|edges| edges.iter().any(|e| e["dst_repo"] == "provider"))
@@ -9585,10 +9588,10 @@ mod tests {
             "MCP fetch_spine_xref must resolve consumer->provider: {mcp_xref}"
         );
 
-        let mcp_impact = fetch_spine_impact_typed("provider", &do_work_id, 5)
-            .await
-            .expect("MCP fetch_spine_impact_typed call")
-            .expect("MCP fetch_spine_impact_typed returns impact");
+        let mcp_impact = match fetch_spine_impact_typed("provider", &do_work_id, 5).await {
+            kin_spine::SpineQuery::Found(impact) => impact,
+            other => panic!("MCP fetch_spine_impact_typed expected Found, got {other:?}"),
+        };
         let mcp_impact_hits_consumer = mcp_impact.repos_involved.iter().any(|r| r == "consumer");
         assert!(
             mcp_impact_hits_consumer,

--- a/crates/kin-mcp/src/handlers/common.rs
+++ b/crates/kin-mcp/src/handlers/common.rs
@@ -20,6 +20,7 @@ thread_local! {
 }
 
 use crate::error::{McpError, Result};
+use kin_spine::{classify_spine_probe, SpineProbe, SpineQuery};
 
 // ── Parameter extraction helpers ──
 
@@ -183,18 +184,27 @@ pub async fn fetch_spine_impact(
 }
 
 /// Query the daemon for federated impact analysis, returning the typed struct.
+///
+/// Returns a [`SpineQuery`] so callers can distinguish a spine that is simply
+/// not configured (local-only — quiet) from one that is configured but
+/// unavailable (surface it) and a healthy, possibly-empty answer.
 pub async fn fetch_spine_impact_typed(
     repo_id: &str,
     entity_id: &EntityId,
     depth: u32,
-) -> Result<Option<kin_spine::FederatedImpact>> {
-    let daemon_url = daemon_url_from_env()?;
-    let client = reqwest::Client::builder()
+) -> SpineQuery<kin_spine::FederatedImpact> {
+    let Ok(daemon_url) = daemon_url_from_env() else {
+        return SpineQuery::NotConfigured;
+    };
+    let client = match reqwest::Client::builder()
         .timeout(std::time::Duration::from_secs(10))
         .build()
-        .map_err(|e| McpError::Other(format!("failed to build reqwest client: {}", e)))?;
+    {
+        Ok(client) => client,
+        Err(e) => return SpineQuery::Unavailable(format!("failed to build reqwest client: {e}")),
+    };
 
-    let resp = client
+    let resp = match client
         .get(format!(
             "{}/v1/spine/impact",
             daemon_url.trim_end_matches('/')
@@ -206,31 +216,42 @@ pub async fn fetch_spine_impact_typed(
         ])
         .send()
         .await
-        .map_err(|e| McpError::Other(format!("failed to send spine request: {}", e)))?;
+    {
+        Ok(resp) => resp,
+        Err(e) => return SpineQuery::Unavailable(format!("spine request failed: {e}")),
+    };
 
-    if !resp.status().is_success() {
-        return Ok(None);
+    match classify_spine_probe(true, Some(resp.status().as_u16())) {
+        SpineProbe::Healthy => match resp.json::<kin_spine::FederatedImpact>().await {
+            Ok(impact) => SpineQuery::Found(impact),
+            Err(e) => SpineQuery::Unavailable(format!("malformed spine impact response: {e}")),
+        },
+        SpineProbe::Unavailable(reason) => SpineQuery::Unavailable(reason),
+        SpineProbe::NotConfigured => {
+            SpineQuery::Unavailable("spine endpoint unexpectedly unconfigured".to_string())
+        }
     }
-
-    let impact = resp
-        .json::<kin_spine::FederatedImpact>()
-        .await
-        .map_err(|e| McpError::Other(format!("failed to parse spine impact response: {}", e)))?;
-    Ok(Some(impact))
 }
 
 /// Query the daemon for cross-repo edges (xrefs) for a specific entity.
+///
+/// See [`fetch_spine_impact_typed`] for the [`SpineQuery`] three-state contract.
 pub async fn fetch_spine_xref(
     repo_id: &str,
     entity_id: &EntityId,
-) -> Result<Option<serde_json::Value>> {
-    let daemon_url = daemon_url_from_env()?;
-    let client = reqwest::Client::builder()
+) -> SpineQuery<serde_json::Value> {
+    let Ok(daemon_url) = daemon_url_from_env() else {
+        return SpineQuery::NotConfigured;
+    };
+    let client = match reqwest::Client::builder()
         .timeout(std::time::Duration::from_secs(10))
         .build()
-        .map_err(|e| McpError::Other(format!("failed to build reqwest client: {}", e)))?;
+    {
+        Ok(client) => client,
+        Err(e) => return SpineQuery::Unavailable(format!("failed to build reqwest client: {e}")),
+    };
 
-    let resp = client
+    let resp = match client
         .get(format!(
             "{}/v1/spine/xref",
             daemon_url.trim_end_matches('/')
@@ -238,17 +259,21 @@ pub async fn fetch_spine_xref(
         .query(&[("repo", repo_id), ("entity", &entity_id.to_string())])
         .send()
         .await
-        .map_err(|e| McpError::Other(format!("failed to send spine request: {}", e)))?;
+    {
+        Ok(resp) => resp,
+        Err(e) => return SpineQuery::Unavailable(format!("spine request failed: {e}")),
+    };
 
-    if !resp.status().is_success() {
-        return Ok(None);
+    match classify_spine_probe(true, Some(resp.status().as_u16())) {
+        SpineProbe::Healthy => match resp.json::<serde_json::Value>().await {
+            Ok(body) => SpineQuery::Found(body),
+            Err(e) => SpineQuery::Unavailable(format!("malformed spine response: {e}")),
+        },
+        SpineProbe::Unavailable(reason) => SpineQuery::Unavailable(reason),
+        SpineProbe::NotConfigured => {
+            SpineQuery::Unavailable("spine endpoint unexpectedly unconfigured".to_string())
+        }
     }
-
-    let body = resp
-        .json::<serde_json::Value>()
-        .await
-        .map_err(|e| McpError::Other(format!("failed to parse spine response: {}", e)))?;
-    Ok(Some(body))
 }
 
 // ── Entity selection and ranking ──

--- a/crates/kin-mcp/src/handlers/entities.rs
+++ b/crates/kin-mcp/src/handlers/entities.rs
@@ -472,26 +472,35 @@ pub async fn handle_find_references<G: GraphStore>(
 
     // ── Federated Xrefs via Spine ─────────────────────────────────────
     let repo_id = std::env::var("KIN_REPO_ID").unwrap_or_else(|_| "unknown".into());
-    if let Ok(Some(body)) = fetch_spine_xref(&repo_id, &target.id).await {
-        if let Some(edges) = body.get("edges").and_then(|v| v.as_array()) {
-            for edge in edges {
-                if edge["to_repo_id"] == repo_id && edge["repo_id"] != repo_id {
-                    // This is an external caller pointing at us.
-                    rows.push(ReferenceRow {
-                        name: edge["from_name"].as_str().unwrap_or("unknown").to_string(),
-                        kind: edge["kind"].as_str().map(|s| s.to_string()),
-                        file_path: Some(format!(
-                            "[{}] {}",
-                            edge["repo_id"].as_str().unwrap_or("?"),
-                            edge["from_name"].as_str().unwrap_or("?")
-                        )),
-                        start_line: None,
-                        signature: None,
-                        relation_kinds: vec![RelationKind::References], // Spine edges are generic xrefs
-                    });
+    match fetch_spine_xref(&repo_id, &target.id).await {
+        kin_spine::SpineQuery::Found(body) => {
+            if let Some(edges) = body.get("edges").and_then(|v| v.as_array()) {
+                for edge in edges {
+                    if edge["to_repo_id"] == repo_id && edge["repo_id"] != repo_id {
+                        // This is an external caller pointing at us.
+                        rows.push(ReferenceRow {
+                            name: edge["from_name"].as_str().unwrap_or("unknown").to_string(),
+                            kind: edge["kind"].as_str().map(|s| s.to_string()),
+                            file_path: Some(format!(
+                                "[{}] {}",
+                                edge["repo_id"].as_str().unwrap_or("?"),
+                                edge["from_name"].as_str().unwrap_or("?")
+                            )),
+                            start_line: None,
+                            signature: None,
+                            relation_kinds: vec![RelationKind::References], // Spine edges are generic xrefs
+                        });
+                    }
                 }
             }
         }
+        // Spine configured but unreachable: surface as a warning rather than
+        // silently dropping cross-repo references (which would read as "none").
+        kin_spine::SpineQuery::Unavailable(reason) => {
+            tracing::warn!(reason = %reason, "cross-repo spine unavailable for references enrichment");
+        }
+        // Local-only (no spine configured): quiet — cross-repo refs don't apply.
+        kin_spine::SpineQuery::NotConfigured => {}
     }
 
     let references = rows

--- a/crates/kin-mcp/src/handlers/review.rs
+++ b/crates/kin-mcp/src/handlers/review.rs
@@ -79,20 +79,39 @@ pub async fn handle_impact_analysis<G: GraphStore>(
     let repo_id = std::env::var("KIN_REPO_ID").unwrap_or_else(|_| "unknown".into());
     let changed_ids = diff.changed_entity_ids();
     let mut cross_repo_nodes: Vec<kin_spine::FederatedNode> = Vec::new();
+    let mut spine_unavailable: Option<String> = None;
 
     for eid in &changed_ids {
-        if let Ok(Some(federated)) = fetch_spine_impact_typed(&repo_id, eid, depth).await {
-            for node in federated.nodes {
-                if node.repo_id != repo_id {
-                    cross_repo_nodes.push(node);
+        match fetch_spine_impact_typed(&repo_id, eid, depth).await {
+            kin_spine::SpineQuery::Found(federated) => {
+                for node in federated.nodes {
+                    if node.repo_id != repo_id {
+                        cross_repo_nodes.push(node);
+                    }
                 }
             }
+            // Configured but a query failed — record the first reason so the
+            // result reports the gap rather than silently omitting cross-repo
+            // impact (which would read as "analyzed, none").
+            kin_spine::SpineQuery::Unavailable(reason) => {
+                spine_unavailable.get_or_insert(reason);
+            }
+            // No spine in this context (local-only MCP server): a quiet absence
+            // of cross-repo impact is correct, so stay non-noisy.
+            kin_spine::SpineQuery::NotConfigured => {}
         }
     }
 
     if !cross_repo_nodes.is_empty() {
         result["cross_repo_impact"] =
             serde_json::to_value(&cross_repo_nodes).map_err(McpError::Json)?;
+    }
+    if let Some(reason) = spine_unavailable {
+        // Additive, failure-only field: present only when the spine was
+        // expected but unreachable, so an empty/absent cross_repo_impact is
+        // never mistaken for a healthy "no cross-repo impact" result.
+        result["cross_repo_impact_status"] =
+            serde_json::json!(format!("spine_unavailable: {reason}"));
     }
 
     let json = serde_json::to_string_pretty(&result).map_err(McpError::Json)?;

--- a/crates/kin-spine/src/lib.rs
+++ b/crates/kin-spine/src/lib.rs
@@ -15,6 +15,7 @@ pub mod backend;
 pub mod federation;
 pub mod firestore;
 pub mod index;
+pub mod query;
 pub mod routing;
 pub mod store;
 pub mod xref;
@@ -30,6 +31,7 @@ pub use firestore::FirestoreSpineBackend;
 #[cfg(feature = "firestore")]
 pub use firestore::FirestoreStore;
 pub use index::{CrossRepoEdge, EntityEntry, SpineIndex};
+pub use query::{classify_spine_probe, SpineProbe, SpineQuery};
 pub use routing::{RepoEndpoint, RoutingTable};
 pub use store::{LoadedRepo, SpineStore};
 pub use xref::{

--- a/crates/kin-spine/src/query.rs
+++ b/crates/kin-spine/src/query.rs
@@ -1,0 +1,118 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Firelock, LLC
+
+//! Client-side outcome of a cross-repo spine query.
+//!
+//! Every spine client (the CLI `kin xref`/impact path, the MCP handlers, and
+//! any future consumer) talks to the daemon's `/spine/*` endpoints over HTTP.
+//! Those calls have three meaningfully different outcomes that must NOT be
+//! collapsed into a single "empty" result:
+//!
+//! 1. **Not configured** — no daemon endpoint in this context (e.g. a
+//!    standalone, local-only MCP server with no `KIN_DAEMON_URL`). Cross-repo
+//!    federation simply does not apply here, so a quiet absence of cross-repo
+//!    data is correct and must stay non-noisy.
+//! 2. **Unavailable** — a daemon endpoint IS configured but the query failed:
+//!    the request errored, returned a non-success status (e.g. `503` when the
+//!    spine is disabled), or returned a malformed body. This is a real gap and
+//!    must be surfaced, never reported as "no cross-repo references".
+//! 3. **Found** — a healthy spine answered. The payload may be legitimately
+//!    empty (genuinely no cross-repo edges), which is an explicit, trustworthy
+//!    empty result distinct from case 2.
+//!
+//! Collapsing (2) into (3) is the silent-degradation bug this type removes: it
+//! is the cross-repo analogue of the graph-first rule "fail loud or report the
+//! gap; do not hide it behind a fallback".
+
+/// The outcome of a client spine query carrying a parsed body `T` on success.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum SpineQuery<T> {
+    /// No spine endpoint is configured in this context — local-only; quiet.
+    NotConfigured,
+    /// A spine endpoint is configured but the query failed (transport error,
+    /// non-success status, or malformed response). Carries a human reason.
+    Unavailable(String),
+    /// A healthy spine answered. `T` may be empty (an explicit empty result).
+    Found(T),
+}
+
+/// Body-agnostic classification of a spine HTTP probe, separated from response
+/// parsing so the local-only / unavailable / healthy distinction is identical
+/// across clients and unit-testable without a live daemon.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum SpineProbe {
+    /// No endpoint configured (`configured == false`).
+    NotConfigured,
+    /// Configured but the probe did not yield a success status.
+    Unavailable(String),
+    /// Configured and the endpoint returned a success (2xx) status.
+    Healthy,
+}
+
+/// Classify a spine probe from whether an endpoint is configured and the HTTP
+/// status it returned (`None` = the request never produced a response, e.g. a
+/// transport error). Pure: no I/O, no environment, no body type — the single
+/// place the three-state distinction is decided.
+pub fn classify_spine_probe(configured: bool, status: Option<u16>) -> SpineProbe {
+    if !configured {
+        return SpineProbe::NotConfigured;
+    }
+    match status {
+        Some(code) if (200..300).contains(&code) => SpineProbe::Healthy,
+        Some(code) => SpineProbe::Unavailable(format!("spine returned HTTP {code}")),
+        None => SpineProbe::Unavailable("spine request failed (no response)".to_string()),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn unconfigured_is_quiet_regardless_of_status() {
+        // State 1: no endpoint configured -> NotConfigured even if a status is
+        // somehow present. Local-only stays quiet.
+        assert_eq!(classify_spine_probe(false, None), SpineProbe::NotConfigured);
+        assert_eq!(
+            classify_spine_probe(false, Some(200)),
+            SpineProbe::NotConfigured
+        );
+    }
+
+    #[test]
+    fn configured_non_success_is_unavailable_not_empty() {
+        // State 2: configured but 503 (spine disabled) / 5xx / transport error
+        // -> Unavailable, never silently treated as "no references".
+        assert!(matches!(
+            classify_spine_probe(true, Some(503)),
+            SpineProbe::Unavailable(_)
+        ));
+        assert!(matches!(
+            classify_spine_probe(true, Some(500)),
+            SpineProbe::Unavailable(_)
+        ));
+        // No response at all (transport failure) is also Unavailable, not empty.
+        assert!(matches!(
+            classify_spine_probe(true, None),
+            SpineProbe::Unavailable(_)
+        ));
+    }
+
+    #[test]
+    fn configured_success_is_healthy() {
+        // State 3: a healthy spine answered (2xx). Whether the body is empty is
+        // then an explicit, trustworthy empty result decided by the caller.
+        assert_eq!(classify_spine_probe(true, Some(200)), SpineProbe::Healthy);
+        assert_eq!(classify_spine_probe(true, Some(204)), SpineProbe::Healthy);
+    }
+
+    #[test]
+    fn unavailable_reason_names_the_status() {
+        // The surfaced reason must identify the failure so it is actionable and
+        // distinguishable from a genuine empty result.
+        match classify_spine_probe(true, Some(503)) {
+            SpineProbe::Unavailable(reason) => assert!(reason.contains("503"), "reason: {reason}"),
+            other => panic!("expected Unavailable, got {other:?}"),
+        }
+    }
+}


### PR DESCRIPTION
Adds `kin_spine::SpineQuery<T>` (NotConfigured | Unavailable | Found) + pure `classify_spine_probe`, threaded through MCP impact_analysis/references and CLI xref. A spine that is configured-but-unreachable (non-2xx/transport/malformed) is now surfaced instead of collapsing into a silent empty; local-only stays quiet; healthy-empty is explicit. No daemon /spine response/version change.

Validation: cargo test -p kin-spine (40+16), kin-mcp (167), kin-cli (575+19), all pass; clippy clean on touched crates.