### PR TITLE
release: kin 0.2.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,32 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.2.5] - 2026-07-01
+
+Cross-repo intelligence, more informative retrieval surfaces, and a guided first-run experience.
+
+### Added
+
+- Guided first-run setup: `kin` detects whether the daemon is running and walks through initial configuration, with a scriptable `kin doctor` for health checks.
+- `kin locate` and the agent retrieval surfaces now return inline, bounded source snippets alongside each result, so callers see the relevant code without a second fetch.
+- Cross-repo spine now resolves transitive (2-hop) and multi-consumer blast radius: a repository's entities are registered as resolution targets on every refresh, so impact and cross-references span the full dependency chain rather than stopping at direct neighbours.
+- The daemon can ingest multi-repo graphs into the spine directly from durable storage.
+- `kin release`: a cross-repo release orchestrator (`plan`, `apply`, `intent`, `snapshot`) for bottom-up version and dependency-pin management.
+- `@kin/boundary-contracts` gains intent-scope, intent-summary, and lock-type schemas.
+- Opt-in `semantic_locate` re-ranking (role demotion + exact-name boost), off by default.
+
+### Changed
+
+- Cross-repo spine queries now distinguish "spine configured but unavailable" from "genuinely no cross-repo impact" instead of silently collapsing both into an empty result; the gap is observable across the CLI, MCP, and hosted gateways.
+- Locate ranking constants are environment-overridable for tuning.
+
+### Fixed
+
+- Locate priority injectors no longer surface fixture or VCS-internal paths.
+- Cross-repo imports bind by normalized crate root and refresh across every repository.
+- The cross-encoder re-rank gates on graph presence rather than workspace-root presence.
+- The daemon honours `KIN_PRIMARY_REPO_ID` when selecting the primary repository.
+
 ## [0.2.4] - 2026-06-25
 
 Portable Linux release. The Linux binaries are now statically linked against musl with rustls, removing the OpenSSL and glibc-version runtime dependencies, so `kin` and `kin-daemon` run on any Linux distribution including Alpine/musl and older glibc systems.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2871,11 +2871,11 @@ dependencies = [
 
 [[package]]
 name = "kin-buildinfo"
-version = "0.2.4"
+version = "0.2.5"
 
 [[package]]
 name = "kin-cli"
-version = "0.2.4"
+version = "0.2.5"
 dependencies = [
  "age",
  "anyhow",
@@ -2942,7 +2942,7 @@ dependencies = [
 
 [[package]]
 name = "kin-context"
-version = "0.2.4"
+version = "0.2.5"
 dependencies = [
  "kin-blobs",
  "kin-db",
@@ -2958,7 +2958,7 @@ dependencies = [
 
 [[package]]
 name = "kin-core"
-version = "0.2.4"
+version = "0.2.5"
 dependencies = [
  "chrono",
  "directories 5.0.1",
@@ -2982,7 +2982,7 @@ dependencies = [
 
 [[package]]
 name = "kin-daemon"
-version = "0.2.4"
+version = "0.2.5"
 dependencies = [
  "async-stream",
  "axum",
@@ -3071,7 +3071,7 @@ dependencies = [
 
 [[package]]
 name = "kin-git"
-version = "0.2.4"
+version = "0.2.5"
 dependencies = [
  "chrono",
  "gix",
@@ -3089,7 +3089,7 @@ dependencies = [
 
 [[package]]
 name = "kin-index"
-version = "0.2.4"
+version = "0.2.5"
 dependencies = [
  "hex",
  "kin-blobs",
@@ -3135,7 +3135,7 @@ dependencies = [
 
 [[package]]
 name = "kin-integration-tests"
-version = "0.2.4"
+version = "0.2.5"
 dependencies = [
  "kin-blobs",
  "kin-cli",
@@ -3177,7 +3177,7 @@ dependencies = [
 
 [[package]]
 name = "kin-mcp"
-version = "0.2.4"
+version = "0.2.5"
 dependencies = [
  "kin-blobs",
  "kin-context",
@@ -3203,7 +3203,7 @@ dependencies = [
 
 [[package]]
 name = "kin-migrate"
-version = "0.2.4"
+version = "0.2.5"
 dependencies = [
  "chrono",
  "kin-blobs",
@@ -3245,7 +3245,7 @@ dependencies = [
 
 [[package]]
 name = "kin-parser"
-version = "0.2.4"
+version = "0.2.5"
 dependencies = [
  "kin-model",
  "pretty_assertions",
@@ -3274,7 +3274,7 @@ dependencies = [
 
 [[package]]
 name = "kin-projection"
-version = "0.2.4"
+version = "0.2.5"
 dependencies = [
  "kin-blobs",
  "kin-db",
@@ -3289,7 +3289,7 @@ dependencies = [
 
 [[package]]
 name = "kin-ranking"
-version = "0.2.4"
+version = "0.2.5"
 dependencies = [
  "kin-model",
  "serde",
@@ -3298,7 +3298,7 @@ dependencies = [
 
 [[package]]
 name = "kin-reconcile"
-version = "0.2.4"
+version = "0.2.5"
 dependencies = [
  "kin-blobs",
  "kin-db",
@@ -3318,7 +3318,7 @@ dependencies = [
 
 [[package]]
 name = "kin-registry"
-version = "0.2.4"
+version = "0.2.5"
 dependencies = [
  "axum",
  "base64 0.22.1",
@@ -3343,7 +3343,7 @@ dependencies = [
 
 [[package]]
 name = "kin-remote"
-version = "0.2.4"
+version = "0.2.5"
 dependencies = [
  "chrono",
  "kin-model",
@@ -3359,7 +3359,7 @@ dependencies = [
 
 [[package]]
 name = "kin-review"
-version = "0.2.4"
+version = "0.2.5"
 dependencies = [
  "kin-blobs",
  "kin-db",
@@ -3374,7 +3374,7 @@ dependencies = [
 
 [[package]]
 name = "kin-runtime"
-version = "0.2.4"
+version = "0.2.5"
 dependencies = [
  "chrono",
  "hex",
@@ -3406,7 +3406,7 @@ dependencies = [
 
 [[package]]
 name = "kin-semantic-contracts"
-version = "0.2.4"
+version = "0.2.5"
 dependencies = [
  "kin-db",
  "kin-model",
@@ -3421,7 +3421,7 @@ dependencies = [
 
 [[package]]
 name = "kin-spine"
-version = "0.2.4"
+version = "0.2.5"
 dependencies = [
  "chrono",
  "hashbrown 0.15.5",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,7 +27,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.2.4"
+version = "0.2.5"
 edition = "2021"
 license = "Apache-2.0"
 authors = ["Troy Fortin <troy@firelock.ai>"]

--- a/packages/kin-mcp/package.json
+++ b/packages/kin-mcp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kinlab/kin-mcp",
-  "version": "0.2.4",
+  "version": "0.2.5",
   "description": "Start Kin's MCP server through an npm-friendly wrapper.",
   "type": "module",
   "bin": {


### PR DESCRIPTION
Cuts the kin 0.2.5 release. Bumps the workspace version and npm wrapper (`@kinlab/kin-mcp`) to 0.2.5 and adds the CHANGELOG section.

Merging to main triggers auto-tag-release (v0.2.5) which drives the multi-platform build, signing/notarization, GitHub release, and npm publish.

Highlights: cross-repo spine transitive (2-hop) + multi-consumer resolution, fail-loud distinction between an unavailable and a genuinely-empty cross-repo query, inline bounded source snippets on retrieval surfaces, guided first-run setup with a scriptable doctor, and the `kin release` orchestrator. Verified: registry-clean (release-check), release-intent should_tag=true, no lockfile path patches.