### PR TITLE
fix(mcp): distinguish not-found from no-source in get_entity_source

### DIFF
--- a/crates/kin-cli/src/commands/graph.rs
+++ b/crates/kin-cli/src/commands/graph.rs
@@ -45,6 +45,28 @@ pub struct GraphSourceRecord {
     pub body: String,
 }
 
+/// The three distinguishable results of resolving an entity's source for
+/// `get_entity_source` / `get_entity_body`.
+///
+/// Callers (agents especially) must be able to tell these apart: a source they
+/// can act on, an ID that does not exist (retrying it is pointless), and a real
+/// entity that simply has no source body attached to graph truth. Collapsing
+/// the latter two into one opaque "missing source" message makes agents retry
+/// invented or stale IDs and probe adjacent ones, which burns their tool-call
+/// budget for no gain.
+#[derive(Debug, Clone)]
+pub enum EntitySourceOutcome {
+    /// The entity resolved and its source body was read from graph-owned truth.
+    Found(GraphSourceRecord),
+    /// The query resolved to no entity. Non-retryable: the ID is invalid or
+    /// stale. The string is an agent-facing explanation.
+    NotFound(String),
+    /// The entity resolved but has no source body in graph truth (no file
+    /// origin or no source span). Distinct from [`EntitySourceOutcome::NotFound`]
+    /// — the ID is valid, there is simply nothing to return.
+    NoSource(String),
+}
+
 /// `kin graph status` — quick health check of the semantic graph.
 pub async fn status() -> Result<()> {
     let layout = kin_core::KinLayout::discover(&std::env::current_dir()?)
@@ -563,43 +585,118 @@ fn graph_entity_not_found_lines(name: &str) -> Vec<String> {
     ]
 }
 
+/// Resolve an entity's source into a typed [`EntitySourceOutcome`].
+///
+/// This is the taxonomy authority for `get_entity_source` / `get_entity_body`:
+/// it separates a non-existent/stale ID (`NotFound`, non-retryable) from a real
+/// entity that has no source body (`NoSource`) from a genuine read/extraction
+/// failure (`Err`, e.g. an out-of-bounds span or an unavailable blob). The
+/// daemon MCP path consumes this directly so those cases surface distinctly to
+/// agents instead of collapsing into one opaque message.
+pub fn build_entity_source_outcome(
+    layout: &kin_core::KinLayout,
+    graph: &kin_db::InMemoryGraph,
+    entity_query: &str,
+) -> Result<EntitySourceOutcome> {
+    let entity = match resolve_source_entity(graph, entity_query)? {
+        Some(e) => e,
+        None => {
+            return Ok(EntitySourceOutcome::NotFound(
+                entity_source_not_found_message(entity_query),
+            ));
+        }
+    };
+
+    // A structurally sourceless entity (no file origin or no span) is a valid ID
+    // with nothing to return — reported as `NoSource`, not as the genuine
+    // extraction error below (which signals corrupt spans or unavailable blobs).
+    if entity.file_origin.is_none() {
+        return Ok(EntitySourceOutcome::NoSource(entity_no_source_message(
+            &entity,
+            "the entity has no file origin",
+        )));
+    }
+    if entity.span.is_none() {
+        return Ok(EntitySourceOutcome::NoSource(entity_no_source_message(
+            &entity,
+            "the entity has no source span",
+        )));
+    }
+
+    let record = graph_source_record(layout, graph, &entity)?;
+    Ok(EntitySourceOutcome::Found(record))
+}
+
 pub fn build_graph_source_response(
     layout: &kin_core::KinLayout,
     graph: &kin_db::InMemoryGraph,
     entity_query: &str,
 ) -> Result<GraphCommandResponse> {
-    let entity = match resolve_source_entity(graph, entity_query)? {
-        Some(e) => e,
-        None => {
-            return Ok(GraphCommandResponse {
-                lines: graph_entity_not_found_lines(entity_query),
-                error: Some(format!("no entity found matching '{}'", entity_query)),
-                source: None,
-            });
+    match build_entity_source_outcome(layout, graph, entity_query)? {
+        EntitySourceOutcome::Found(record) => {
+            let mut lines = vec![
+                format!(
+                    "Entity source for '{}' -> {} ({})",
+                    entity_query, record.name, record.kind
+                ),
+                format!("ID: {}", record.id),
+                format!("File: {}", record.file_path),
+                format!("Lines: {}-{}", record.start_line, record.end_line),
+            ];
+            if !record.signature.is_empty() {
+                lines.push(format!("Signature: {}", record.signature));
+            }
+            lines.push("--- Source ---".to_string());
+            lines.push(record.body.clone());
+
+            Ok(GraphCommandResponse {
+                lines,
+                error: None,
+                source: Some(record),
+            })
         }
-    };
-    let record = graph_source_record(layout, graph, &entity)?;
-
-    let mut lines = vec![
-        format!(
-            "Entity source for '{}' -> {} ({})",
-            entity_query, record.name, record.kind
-        ),
-        format!("ID: {}", record.id),
-        format!("File: {}", record.file_path),
-        format!("Lines: {}-{}", record.start_line, record.end_line),
-    ];
-    if !record.signature.is_empty() {
-        lines.push(format!("Signature: {}", record.signature));
+        EntitySourceOutcome::NotFound(message) => Ok(GraphCommandResponse {
+            lines: graph_entity_not_found_lines(entity_query),
+            error: Some(message),
+            source: None,
+        }),
+        // A valid entity with no retrievable source is an error for the text/`?`
+        // command paths (the CLI `kin graph source` and `trace_data_flow`, which
+        // drops the step). The MCP path keeps the two apart via the typed outcome.
+        EntitySourceOutcome::NoSource(message) => Err(anyhow::anyhow!(message)),
     }
-    lines.push("--- Source ---".to_string());
-    lines.push(record.body.clone());
+}
 
-    Ok(GraphCommandResponse {
-        lines,
-        error: None,
-        source: Some(record),
-    })
+/// Agent-facing message for a `get_entity_source` query that resolved to no
+/// entity. When the query is a UUID — the shape MCP agents pass — the wording
+/// states plainly that the ID does not exist so the agent stops retrying it and
+/// probing adjacent IDs; for a name query it points at the discovery tools.
+fn entity_source_not_found_message(entity_query: &str) -> String {
+    let trimmed = entity_query.trim();
+    if uuid::Uuid::parse_str(trimmed).is_ok() {
+        format!(
+            "no entity exists with ID '{trimmed}'. This entity ID is invalid or stale — it is \
+             not present in the graph, so retrying the same ID will not succeed. Use \
+             semantic_locate or semantic_search to obtain a current entity ID."
+        )
+    } else {
+        format!(
+            "no entity found matching '{trimmed}'. Use semantic_search or semantic_locate to \
+             find the entity, then call get_entity_source with the ID it returns."
+        )
+    }
+}
+
+/// Agent-facing message for a real entity that has no source body to return.
+/// Explicitly affirms the ID is valid so the agent does not treat it as a
+/// missing/stale ID and retry or probe around it.
+fn entity_no_source_message(entity: &Entity, reason: &str) -> String {
+    format!(
+        "entity '{}' ({}) exists in the graph but has no retrievable source: {reason}. The \
+         entity ID is valid — this is not a missing or stale ID — there is simply no source \
+         body attached to return.",
+        entity.name, entity.id
+    )
 }
 
 fn resolve_source_entity(
@@ -957,5 +1054,103 @@ mod tests {
             err.contains("source body cannot be read from daemon-backed graph"),
             "{err}"
         );
+    }
+
+    #[test]
+    fn entity_source_outcome_found_returns_record() {
+        let source = "fn before() {}\nfn target() {\n    2 + 2\n}\nfn after() {}\n";
+        let body = "fn target() {\n    2 + 2\n}";
+        let start = source.find(body).unwrap();
+        let end = start + body.len();
+        let fixture = graph_source_fixture(Some(source.as_bytes()));
+
+        let entity = source_entity("target", fixture.file_id.clone(), start, end);
+        let id = entity.id;
+        fixture.graph.upsert_entity(&entity).unwrap();
+
+        match build_entity_source_outcome(&fixture.layout, &fixture.graph, &id.to_string()).unwrap()
+        {
+            EntitySourceOutcome::Found(record) => assert_eq!(record.body, body),
+            other => panic!("expected Found, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn entity_source_outcome_not_found_for_invented_uuid() {
+        let fixture = graph_source_fixture(Some(b"fn x() {}\n"));
+        let invented = uuid::Uuid::new_v4();
+
+        match build_entity_source_outcome(&fixture.layout, &fixture.graph, &invented.to_string())
+            .unwrap()
+        {
+            EntitySourceOutcome::NotFound(message) => {
+                assert!(message.contains(&invented.to_string()), "{message}");
+                // Non-retryable signal for the agent.
+                assert!(message.contains("invalid or stale"), "{message}");
+                assert!(message.contains("will not succeed"), "{message}");
+            }
+            other => panic!("expected NotFound, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn entity_source_outcome_no_source_for_spanless_entity() {
+        let fixture = graph_source_fixture(Some(b"fn x() {}\n"));
+        let mut entity = source_entity("target", fixture.file_id.clone(), 0, 8);
+        // A valid, resolvable entity that simply carries no source span.
+        entity.span = None;
+        let id = entity.id;
+        fixture.graph.upsert_entity(&entity).unwrap();
+
+        match build_entity_source_outcome(&fixture.layout, &fixture.graph, &id.to_string()).unwrap()
+        {
+            EntitySourceOutcome::NoSource(message) => {
+                assert!(message.contains("target"), "{message}");
+                assert!(message.contains("no source span"), "{message}");
+                assert!(message.contains("ID is valid"), "{message}");
+            }
+            other => panic!("expected NoSource, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn not_found_and_no_source_messages_are_distinguishable() {
+        let fixture = graph_source_fixture(Some(b"fn x() {}\n"));
+
+        let invented = uuid::Uuid::new_v4();
+        let not_found =
+            build_entity_source_outcome(&fixture.layout, &fixture.graph, &invented.to_string())
+                .unwrap();
+
+        let mut spanless = source_entity("target", fixture.file_id.clone(), 0, 8);
+        spanless.span = None;
+        let spanless_id = spanless.id;
+        fixture.graph.upsert_entity(&spanless).unwrap();
+        let no_source =
+            build_entity_source_outcome(&fixture.layout, &fixture.graph, &spanless_id.to_string())
+                .unwrap();
+
+        let (nf, ns) = match (not_found, no_source) {
+            (EntitySourceOutcome::NotFound(nf), EntitySourceOutcome::NoSource(ns)) => (nf, ns),
+            other => panic!("unexpected taxonomy: {other:?}"),
+        };
+        assert_ne!(nf, ns);
+    }
+
+    #[test]
+    fn graph_source_response_not_found_sets_error_and_leaves_source_none() {
+        // Regression guard for the precedence bug: a not-found query must set the
+        // structured `error` field (surfaced ahead of any missing-source text)
+        // and leave `source` empty.
+        let fixture = graph_source_fixture(Some(b"fn x() {}\n"));
+        let invented = uuid::Uuid::new_v4();
+
+        let response =
+            build_graph_source_response(&fixture.layout, &fixture.graph, &invented.to_string())
+                .unwrap();
+
+        assert!(response.source.is_none());
+        let error = response.error.expect("not-found must populate error");
+        assert!(error.contains(&invented.to_string()), "{error}");
     }
 }

--- a/crates/kin-daemon/src/api.rs
+++ b/crates/kin-daemon/src/api.rs
@@ -4148,6 +4148,34 @@ fn build_semantic_locate_result(
     }
 }
 
+/// Map a resolved [`kin_cli::commands::graph::EntitySourceOutcome`] to an MCP
+/// tool result.
+///
+/// The three application outcomes are surfaced distinctly so an agent can act on
+/// each: a not-found ID and a sourceless-but-valid entity each carry their own
+/// explanatory error — reported ahead of any generic missing-source text — while
+/// a found entity serializes to its source record. Genuine read failures (`Err`)
+/// surface their message verbatim. Generic over the error type so the daemon
+/// need not name the caller's error crate.
+fn entity_source_tool_result<E: std::fmt::Display>(
+    outcome: Result<kin_cli::commands::graph::EntitySourceOutcome, E>,
+) -> kin_mcp::ToolCallResult {
+    use kin_cli::commands::graph::EntitySourceOutcome;
+    match outcome {
+        Ok(EntitySourceOutcome::Found(source)) => match serde_json::to_string_pretty(&source) {
+            Ok(json) => kin_mcp::ToolCallResult::text(json),
+            Err(error) => kin_mcp::ToolCallResult::error(error.to_string()),
+        },
+        // The ID does not resolve — non-retryable. Surfaced verbatim so the agent
+        // stops retrying and probing the ID (this case previously masqueraded as
+        // "graph source response missing source").
+        Ok(EntitySourceOutcome::NotFound(message)) => kin_mcp::ToolCallResult::error(message),
+        // A real entity with no attached source body — distinct from not-found.
+        Ok(EntitySourceOutcome::NoSource(message)) => kin_mcp::ToolCallResult::error(message),
+        Err(error) => kin_mcp::ToolCallResult::error(error.to_string()),
+    }
+}
+
 async fn mcp_tools_call(
     headers: axum::http::HeaderMap,
     State(state): State<Arc<DaemonState>>,
@@ -4191,22 +4219,12 @@ async fn mcp_tools_call(
                 "missing required parameter: entity_id".to_string(),
             )));
         };
-        let result = match kin_cli::commands::graph::build_graph_source_response(
-            &state.layout,
-            graph.as_ref(),
-            entity_id,
-        ) {
-            Ok(response) => match response.source {
-                Some(source) => match serde_json::to_string_pretty(&source) {
-                    Ok(json) => kin_mcp::ToolCallResult::text(json),
-                    Err(error) => kin_mcp::ToolCallResult::error(error.to_string()),
-                },
-                None => kin_mcp::ToolCallResult::error(
-                    "graph source response missing source".to_string(),
-                ),
-            },
-            Err(error) => kin_mcp::ToolCallResult::error(error.to_string()),
-        };
+        let result =
+            entity_source_tool_result(kin_cli::commands::graph::build_entity_source_outcome(
+                &state.layout,
+                graph.as_ref(),
+                entity_id,
+            ));
         return Ok(Json(result));
     }
 
@@ -6890,6 +6908,86 @@ mod tests {
                 < 1e-6
         );
         assert!((semloc_rerank_priority(None, "X", q, false, 0.30) - 0.30).abs() < 1e-6);
+    }
+
+    fn tool_result_json(result: &kin_mcp::ToolCallResult) -> serde_json::Value {
+        serde_json::to_value(result).unwrap()
+    }
+
+    #[test]
+    fn entity_source_tool_result_not_found_surfaces_error_not_missing_source() {
+        use kin_cli::commands::graph::EntitySourceOutcome;
+        // The case that previously rendered as "graph source response missing
+        // source": a not-found ID must surface its own error verbatim.
+        let message = "no entity exists with ID 'abc'. This entity ID is invalid or stale.";
+        let result = entity_source_tool_result(Ok::<_, String>(EntitySourceOutcome::NotFound(
+            message.into(),
+        )));
+
+        let json = tool_result_json(&result);
+        assert_eq!(json["isError"], serde_json::json!(true));
+        let text = json["content"][0]["text"].as_str().unwrap();
+        assert_eq!(text, message);
+        assert!(!text.contains("missing source"), "{text}");
+    }
+
+    #[test]
+    fn entity_source_tool_result_no_source_is_distinct_from_not_found() {
+        use kin_cli::commands::graph::EntitySourceOutcome;
+        let not_found =
+            entity_source_tool_result(Ok::<_, String>(EntitySourceOutcome::NotFound("NF".into())));
+        let no_source =
+            entity_source_tool_result(Ok::<_, String>(EntitySourceOutcome::NoSource("NS".into())));
+
+        let nf = tool_result_json(&not_found);
+        let ns = tool_result_json(&no_source);
+        assert_eq!(nf["isError"], serde_json::json!(true));
+        assert_eq!(ns["isError"], serde_json::json!(true));
+        let nf_text = nf["content"][0]["text"].as_str().unwrap();
+        let ns_text = ns["content"][0]["text"].as_str().unwrap();
+        assert_eq!(nf_text, "NF");
+        assert_eq!(ns_text, "NS");
+        assert_ne!(nf_text, ns_text);
+    }
+
+    #[test]
+    fn entity_source_tool_result_found_serializes_record_without_error_flag() {
+        use kin_cli::commands::graph::{EntitySourceOutcome, GraphSourceRecord};
+        let record = GraphSourceRecord {
+            id: "id-1".into(),
+            name: "target".into(),
+            kind: "Function".into(),
+            language: "rust".into(),
+            file_path: "src/lib.rs".into(),
+            start_line: 1,
+            end_line: 3,
+            start_byte: 0,
+            end_byte: 14,
+            signature: "fn target()".into(),
+            body: "fn target() {}".into(),
+        };
+        let result = entity_source_tool_result(Ok::<_, String>(EntitySourceOutcome::Found(record)));
+
+        let json = tool_result_json(&result);
+        // A success result omits the isError flag entirely.
+        assert!(json.get("isError").is_none());
+        let text = json["content"][0]["text"].as_str().unwrap();
+        assert!(text.contains("\"body\": \"fn target() {}\""), "{text}");
+    }
+
+    #[test]
+    fn entity_source_tool_result_genuine_error_surfaces_message() {
+        use kin_cli::commands::graph::EntitySourceOutcome;
+        let result = entity_source_tool_result(Err::<EntitySourceOutcome, _>(
+            "graph blob for file 'src/lib.rs' is unavailable".to_string(),
+        ));
+        let json = tool_result_json(&result);
+        assert_eq!(json["isError"], serde_json::json!(true));
+        let text = json["content"][0]["text"].as_str().unwrap();
+        assert!(
+            text.contains("graph blob for file 'src/lib.rs' is unavailable"),
+            "{text}"
+        );
     }
 
     #[test]

--- a/crates/kin-mcp/src/daemon_delegate.rs
+++ b/crates/kin-mcp/src/daemon_delegate.rs
@@ -16,7 +16,7 @@ use std::time::Duration;
 use kin_model::session::SessionCapabilities;
 use tracing::debug;
 
-use crate::types::ToolCallResult;
+use crate::types::{ContentBlock, ToolCallResult};
 
 /// Cached daemon HTTP client. We only cache positive connectivity so that a
 /// daemon that comes online after MCP startup can still take authority.
@@ -166,6 +166,158 @@ fn optional_u32(args: &HashMap<String, serde_json::Value>, key: &str) -> Option<
     args.get(key)
         .and_then(|value| value.as_u64())
         .map(|value| value as u32)
+}
+
+// ── get_entity_source failure memo ──────────────────────────────────────
+//
+// `get_entity_source` / `get_entity_body` are pure functions of (entity_id,
+// graph generation): for a given graph, an ID either resolves to a body or it
+// does not. The observed agent-loop failure mode is calling the tool on a
+// hallucinated, invented, or stale ID, getting a failure, and then retrying the
+// same ID (or probing adjacent ones), which burns tool-call budget. Memoizing
+// the failure lets an identical repeated call short-circuit locally instead of
+// paying another daemon round-trip.
+//
+// The memo is bounded and keyed by (session, entity_id), and is dropped whenever
+// the graph generation marker advances — a re-index can resurrect a previously
+// absent ID, so a stale negative must not outlive the graph it described.
+
+/// Maximum number of remembered failures across all sessions. Bounds memory for
+/// long-lived agent sessions; eviction is oldest-first.
+const ENTITY_SOURCE_MEMO_CAP: usize = 512;
+
+/// Bounded per-session memo of `get_entity_source` failures, valid for a single
+/// graph generation.
+struct EntitySourceFailureMemo {
+    generation: u64,
+    entries: HashMap<(String, String), String>,
+    order: std::collections::VecDeque<(String, String)>,
+}
+
+impl EntitySourceFailureMemo {
+    fn new(generation: u64) -> Self {
+        Self {
+            generation,
+            entries: HashMap::new(),
+            order: std::collections::VecDeque::new(),
+        }
+    }
+
+    /// Drop every entry and rebind to `generation`.
+    fn reset(&mut self, generation: u64) {
+        self.generation = generation;
+        self.entries.clear();
+        self.order.clear();
+    }
+
+    /// Cached failure message for `key` at `generation`, if any. A generation
+    /// change invalidates the whole memo before the lookup.
+    fn get(&mut self, generation: u64, key: &(String, String)) -> Option<String> {
+        if generation != self.generation {
+            self.reset(generation);
+            return None;
+        }
+        self.entries.get(key).cloned()
+    }
+
+    /// Remember `message` as the failure for `key` at `generation`. First write
+    /// for a key wins; the oldest entry is evicted once the cap is reached.
+    fn insert(&mut self, generation: u64, key: (String, String), message: String) {
+        if generation != self.generation {
+            self.reset(generation);
+        }
+        if self.entries.contains_key(&key) {
+            return;
+        }
+        if self.entries.len() >= ENTITY_SOURCE_MEMO_CAP {
+            if let Some(evicted) = self.order.pop_front() {
+                self.entries.remove(&evicted);
+            }
+        }
+        self.order.push_back(key.clone());
+        self.entries.insert(key, message);
+    }
+}
+
+static ENTITY_SOURCE_MEMO: OnceLock<std::sync::Mutex<EntitySourceFailureMemo>> = OnceLock::new();
+
+fn entity_source_memo() -> &'static std::sync::Mutex<EntitySourceFailureMemo> {
+    ENTITY_SOURCE_MEMO.get_or_init(|| std::sync::Mutex::new(EntitySourceFailureMemo::new(0)))
+}
+
+/// Session identity for the memo key. Mirrors [`with_session_header`]: an
+/// explicit `session_id` argument wins, else `KIN_SESSION_ID`, else a shared
+/// process-global bucket (the common single-session MCP process case).
+fn session_key(arguments: &HashMap<String, serde_json::Value>) -> String {
+    if let Some(session_id) = optional_string(arguments, "session_id") {
+        return session_id.to_string();
+    }
+    if let Ok(session_id) = std::env::var("KIN_SESSION_ID") {
+        let trimmed = session_id.trim();
+        if !trimmed.is_empty() {
+            return trimmed.to_string();
+        }
+    }
+    String::new()
+}
+
+/// Current graph generation from the local marker the daemon maintains at
+/// `<kin_dir>/kindb/generation`. Read directly off disk (no daemon round-trip);
+/// a missing or unreadable marker reads as generation 0, which still gives a
+/// stable within-session memo, just without cross-generation invalidation.
+fn current_graph_generation() -> u64 {
+    let Some(kin_dir) = discover_kin_dir() else {
+        return 0;
+    };
+    std::fs::read_to_string(kin_dir.join("kindb").join("generation"))
+        .ok()
+        .and_then(|contents| contents.trim().parse::<u64>().ok())
+        .unwrap_or(0)
+}
+
+/// Extract a cacheable failure message from a forwarded tool result. Only
+/// error results are cacheable — a success or a non-result is never memoized.
+fn cacheable_failure_message(result: Option<&ToolCallResult>) -> Option<String> {
+    let result = result?;
+    if result.is_error != Some(true) {
+        return None;
+    }
+    result.content.first().map(|block| match block {
+        ContentBlock::Text { text } => text.clone(),
+    })
+}
+
+/// Forward `get_entity_source` / `get_entity_body` through the failure memo.
+///
+/// On a cache hit the remembered failure is returned without contacting the
+/// daemon; otherwise the call is forwarded and a resulting failure is recorded
+/// for the current graph generation. Calls without a concrete `entity_id` are
+/// forwarded unmemoized (there is nothing stable to key on).
+async fn forward_entity_source_memoized(
+    name: &str,
+    arguments: &HashMap<String, serde_json::Value>,
+) -> Result<Option<ToolCallResult>, String> {
+    let Some(entity_id) = optional_string(arguments, "entity_id").map(str::to_string) else {
+        return forward_mcp_tool_call(name, arguments).await;
+    };
+    let key = (session_key(arguments), entity_id);
+    let generation = current_graph_generation();
+
+    if let Ok(mut memo) = entity_source_memo().lock() {
+        if let Some(cached) = memo.get(generation, &key) {
+            debug!(tool = name, "get_entity_source failure served from memo");
+            return Ok(Some(ToolCallResult::error(cached)));
+        }
+    }
+
+    let result = forward_mcp_tool_call(name, arguments).await?;
+
+    if let Some(message) = cacheable_failure_message(result.as_ref()) {
+        if let Ok(mut memo) = entity_source_memo().lock() {
+            memo.insert(generation, key, message);
+        }
+    }
+    Ok(result)
 }
 
 fn parse_capabilities(args: &HashMap<String, serde_json::Value>) -> SessionCapabilities {
@@ -604,6 +756,12 @@ pub async fn forward_tool_call(
             Ok(()) => forward_mcp_tool_call(name, arguments).await,
             Err(message) => Ok(Some(ToolCallResult::error(message))),
         },
+        // Short-circuit repeated failures for an identical entity ID within a
+        // session so a hallucinated/stale ID does not burn a daemon round-trip
+        // on every retry.
+        "get_entity_source" | "get_entity_body" => {
+            forward_entity_source_memoized(name, arguments).await
+        }
         _ => forward_mcp_tool_call(name, arguments).await,
     }
 }
@@ -1291,5 +1449,85 @@ mod tests {
         let mut args = HashMap::new();
         args.insert("transaction_id".into(), serde_json::json!("tx-1"));
         assert!(validate_stage_arguments(&args).is_ok());
+    }
+
+    #[test]
+    fn entity_source_failure_memo_hit_then_generation_invalidates() {
+        let mut memo = EntitySourceFailureMemo::new(1);
+        let key = ("session-a".to_string(), "entity-1".to_string());
+
+        // Cold: nothing remembered yet.
+        assert!(memo.get(1, &key).is_none());
+
+        // Record a failure, then the identical (session, id) lookup is a HIT.
+        memo.insert(
+            1,
+            key.clone(),
+            "no entity exists with ID 'entity-1'".to_string(),
+        );
+        assert_eq!(
+            memo.get(1, &key).as_deref(),
+            Some("no entity exists with ID 'entity-1'"),
+        );
+
+        // A different id in the same session is unaffected.
+        let other = ("session-a".to_string(), "entity-2".to_string());
+        assert!(memo.get(1, &other).is_none());
+
+        // A graph-generation bump drops the negative — a re-index may resurrect
+        // the id, so the stale failure must not be served.
+        assert!(memo.get(2, &key).is_none());
+    }
+
+    #[test]
+    fn entity_source_memo_first_write_wins() {
+        let mut memo = EntitySourceFailureMemo::new(0);
+        let key = ("s".to_string(), "id".to_string());
+        memo.insert(0, key.clone(), "first".to_string());
+        memo.insert(0, key.clone(), "second".to_string());
+        assert_eq!(memo.get(0, &key).as_deref(), Some("first"));
+    }
+
+    #[test]
+    fn entity_source_memo_is_bounded_with_oldest_first_eviction() {
+        let mut memo = EntitySourceFailureMemo::new(0);
+        for i in 0..(ENTITY_SOURCE_MEMO_CAP + 5) {
+            memo.insert(0, ("s".to_string(), format!("id-{i}")), format!("fail-{i}"));
+        }
+        assert_eq!(memo.entries.len(), ENTITY_SOURCE_MEMO_CAP);
+        // The five oldest were evicted; the newest survive.
+        for i in 0..5 {
+            assert!(memo.get(0, &("s".to_string(), format!("id-{i}"))).is_none());
+        }
+        let newest = ENTITY_SOURCE_MEMO_CAP + 4;
+        assert_eq!(
+            memo.get(0, &("s".to_string(), format!("id-{newest}")))
+                .as_deref(),
+            Some(format!("fail-{newest}").as_str()),
+        );
+    }
+
+    #[test]
+    fn only_error_results_are_cacheable() {
+        let err = ToolCallResult::error("boom".to_string());
+        assert_eq!(
+            cacheable_failure_message(Some(&err)).as_deref(),
+            Some("boom")
+        );
+
+        let ok = ToolCallResult::text("{}".to_string());
+        assert!(cacheable_failure_message(Some(&ok)).is_none());
+
+        assert!(cacheable_failure_message(None).is_none());
+    }
+
+    #[test]
+    fn session_key_prefers_explicit_argument() {
+        let mut args = HashMap::new();
+        args.insert(
+            "session_id".to_string(),
+            serde_json::json!("explicit-session"),
+        );
+        assert_eq!(session_key(&args), "explicit-session");
     }
 }


### PR DESCRIPTION
## What

`get_entity_source` / `get_entity_body` now return a precise error taxonomy instead of one ambiguous "missing source" message, and repeated failures are memoized at the MCP transport shim.

## Why

When entity resolution failed, the daemon MCP handler checked the response's `source` field before its `error` field and returned `graph source response missing source` for every miss. Agents interpreted that as "the entity exists but source retrieval flaked", so they retried the same (often hallucinated or stale) ID and probed adjacent IDs — burning tool-call budget for no gain (observed live in benchmark runs).

## Changes

- **Typed outcome** (`kin-cli` graph command): entity-source resolution returns `Found` / `NotFound` / `NoSource`. Not-found messages are ID-aware and explicitly non-retryable; no-source messages affirm the ID is valid but carries no source body — distinct from not-found. `build_graph_source_response` now delegates to this so the CLI path keeps its contract.
- **Daemon MCP handler** (`kin-daemon`): maps the typed outcome to the tool result, surfacing the error ahead of any missing-source fallback. The `graph source response missing source` text is gone.
- **MCP transport shim** (`kin-mcp` daemon delegate): a bounded, per-session memo of not-found/no-source failures keyed by `(session, entity_id)`, dropped when the local graph generation marker advances, so an identical repeated call short-circuits without a daemon round-trip. Bounded at 512 entries with oldest-first eviction.

## Error taxonomy an agent now sees

- **Invalid / invented / stale ID** → `no entity exists with ID '<id>'. This entity ID is invalid or stale — it is not present in the graph, so retrying the same ID will not succeed. Use semantic_locate or semantic_search to obtain a current entity ID.`
- **Valid entity, no source** → `entity '<name>' (<id>) exists in the graph but has no retrievable source: <reason>. The entity ID is valid — this is not a missing or stale ID — there is simply no source body attached to return.`
- **Genuine read failure** → the specific extraction error (out-of-bounds span, unavailable blob, non-UTF-8, …), unchanged.

## Tests (unit / in-process only — no daemon-boot integration)

- `kin-cli` graph command: found record, not-found for an invented UUID (non-retryable wording), no-source for a spanless entity, not-found vs no-source distinguishability, and not-found sets the structured `error` with empty `source`.
- `kin-daemon` mapping: not-found surfaces its error (never "missing source"), no-source distinct from not-found, found serializes without the error flag, and a genuine error surfaces verbatim.
- `kin-mcp` memo: hit path + graph-generation invalidation, first-write-wins, bounded oldest-first eviction, only-error-results-are-cacheable, session-key precedence.

## Local gate

`cargo fmt --all --check`, `cargo clippy --all-targets --all-features` (ci.yml allowlist, `RUSTFLAGS=-D warnings`), `cargo build --all-targets --locked`, `cargo test --workspace --locked` — all green.

Addresses FIR-1190 and FIR-1187.
