### PR TITLE
sessions: run ordinary tools and launch agents inside graph-backed session workspaces

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,23 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Session runtime for ordinary tools: `kin exec -- <cmd>` (new alias `kin run`) runs commands in a graph-backed session workspace, reconciles on success, and preserves the workspace with recovery commands on failure; `--keep` defers reconcile and `--discard` skips it.
+- Agent session launches: `kin with --session <assistant> -- <task>` starts the assistant inside a session workspace with its cwd, file shims, session identity (`KIN_SESSION`, `KIN_SESSION_ID`, `KIN_SESSION_DIR`), and daemon binding (`KIN_DAEMON_URL`, `KIN_REPO_ID`) pointed at the same repository — MCP tools spawned by the assistant bind to the same daemon and session.
+- External-tool detection now covers package managers (`npm`, `npx`, `pnpm`, `pnpx`, `yarn`, `bun`, `bunx`, `corepack`), which widen scoped execution to a full workspace under the default policy.
+- `kin doctor` gains a session-runtime check that teaches the `kin exec` / `kin shell` / `kin with --session` path and reports leftover session workspaces with recovery commands.
+- Session workspace materialization resolves `entity:`/`artifact:` scopes against graph truth for every session surface, failing loudly on unknown entities instead of silently widening.
+- New [Session Runtime](docs/session-runtime.md) guide: execution contract, closeout flags, generated-file policy, and Docker/Compose caveats.
+
+### Changed
+
+- `kin exec` executes commands locally in the materialized session workspace instead of requiring the daemon's gated remote-exec capability; the daemon endpoint remains opt-in via `KIN_DAEMON_ALLOW_EXEC`.
+
+### Fixed
+
+- `kin setup` and `kin doctor --fix` now write MCP client entries that start (`kin mcp start`); the previously written `--global` mode was refused at startup, leaving agents with a dead kin MCP server. `kin doctor` flags the retired entries and `--fix` repairs them.
+
 ## [0.2.5] - 2026-07-01
 
 Cross-repo intelligence, more informative retrieval surfaces, and a guided first-run experience.

--- a/crates/kin-cli/src/commands/exec.rs
+++ b/crates/kin-cli/src/commands/exec.rs
@@ -1,6 +1,9 @@
 // SPDX-License-Identifier: Apache-2.0
 // Copyright 2026 Firelock, LLC
 
+use std::io::Write;
+use std::path::Path;
+
 use anyhow::Result;
 use kin_core::{ExternalToolExecutionPolicy, KinConfig};
 use kin_model::EntityStore;
@@ -32,48 +35,212 @@ pub struct ExecResponse {
     pub kept: bool,
 }
 
-/// Full version of `kin exec` with all options.
+/// `kin exec [flags] -- <command...>` (alias: `kin run`).
+///
+/// Runs an ordinary command through a graph-backed session workspace:
+/// the daemon materializes graph truth into `.kin/runs/session-<id>`, the
+/// command runs locally in that workspace with session env set, and on
+/// success the changes are reconciled back into the graph (generated
+/// directories like `node_modules/` are excluded by the reconcile skip
+/// policy). On failure the workspace is preserved with recovery commands.
+///
+/// The command itself always executes in this CLI process — never through
+/// the daemon's gated `/commands/exec` surface.
 pub async fn run_full(
-    command: String,
+    command_parts: Vec<String>,
     keep: bool,
+    discard: bool,
     strategy: Option<String>,
     scope: Option<String>,
 ) -> Result<()> {
-    let layout = kin_core::KinLayout::discover(&std::env::current_dir()?)
-        .ok_or_else(|| anyhow::anyhow!("not a Kin repository (no .kin/ found)"))?;
-    let base_url = match std::env::var("KIN_DAEMON_URL")
-        .ok()
-        .filter(|value| !value.trim().is_empty())
-    {
-        Some(base_url) => base_url,
-        None => crate::daemon_client::resolve_daemon_url(&layout)
-            .await?
-            .ok_or_else(|| anyhow::anyhow!("kin daemon is required"))?,
-    };
-    let client = crate::daemon_client::DaemonClient::from_base_url(base_url)?;
-
-    println!("Materializing workspace...");
-    let response = client
-        .exec(&ExecRequest {
-            command: command.clone(),
-            keep,
-            strategy,
-            scope,
-        })
-        .await?;
-
-    match &response.planned_scope {
-        Some(scope) => println!("  Scope: {scope}"),
-        None => println!("  Scope: full workspace"),
-    };
-
-    print_exec_response(&response);
-
-    if response.exit_code != 0 {
-        std::process::exit(response.exit_code);
+    let command = command_parts.join(" ").trim().to_string();
+    if command.is_empty() {
+        return Err(anyhow::anyhow!(
+            "no command provided. Usage: kin exec [--keep|--discard] [--scope <s>] -- <command...>"
+        ));
     }
 
+    let layout = kin_core::KinLayout::discover(&std::env::current_dir()?)
+        .ok_or_else(|| anyhow::anyhow!("not a Kin repository (no .kin/ found)"))?;
+
+    let config = KinConfig::load_or_default(&layout.config_path())?;
+    let planned_scope = plan_materialization_scope(&command, scope, &config)?;
+
+    let parsed_strategy = strategy
+        .as_deref()
+        .map(str::parse::<kin_runtime::MaterializeStrategy>)
+        .transpose()
+        .map_err(|e: String| anyhow::anyhow!(e))?;
+
+    let session_id = uuid::Uuid::new_v4();
+    let session_dir = layout
+        .root()
+        .join("runs")
+        .join(format!("session-{session_id}"));
+
+    eprintln!("Materializing session workspace...");
+    let ws = super::session_workspace::create_session_workspace(
+        &layout,
+        &session_dir,
+        parsed_strategy,
+        planned_scope.as_deref(),
+    )
+    .await?;
+    match &planned_scope {
+        Some(scope) => eprintln!("  Scope: {scope}"),
+        None => eprintln!("  Scope: full workspace"),
+    }
+    eprintln!("  Workspace: {}", ws.root.display());
+
+    let outcome = run_command_in_session(&ws.root, &command, &session_env(session_id, &ws.root))?;
+    eprintln!(
+        "\nCommand exited (code {}, {}ms).",
+        outcome.exit_code, outcome.duration_ms
+    );
+
+    {
+        let stderr = std::io::stderr();
+        let mut stderr = stderr.lock();
+        close_exec_session(
+            &layout,
+            &session_dir,
+            outcome.exit_code,
+            keep,
+            discard,
+            &mut stderr,
+        )
+        .await?;
+    }
+
+    if outcome.exit_code != 0 {
+        std::process::exit(outcome.exit_code);
+    }
     Ok(())
+}
+
+#[derive(Debug, Clone, Copy)]
+struct SessionExecOutcome {
+    exit_code: i32,
+    duration_ms: u64,
+}
+
+/// Session identity env for the executed command, matching the `kin shell`
+/// contract: `KIN_SESSION`/`KIN_SESSION_ID` carry the session UUID (the MCP
+/// daemon delegate reads `KIN_SESSION_ID` to scope forwarded tool calls) and
+/// `KIN_SESSION_DIR` carries the workspace root.
+fn session_env(session_id: uuid::Uuid, ws_root: &Path) -> Vec<(String, String)> {
+    vec![
+        ("KIN_SESSION".into(), session_id.to_string()),
+        ("KIN_SESSION_ID".into(), session_id.to_string()),
+        (
+            "KIN_SESSION_DIR".into(),
+            ws_root.to_string_lossy().into_owned(),
+        ),
+    ]
+}
+
+/// Run a shell command in the materialized session workspace, streaming
+/// stdio to the caller's terminal.
+fn run_command_in_session(
+    ws_root: &Path,
+    command: &str,
+    extra_env: &[(String, String)],
+) -> Result<SessionExecOutcome> {
+    let start = std::time::Instant::now();
+
+    let mut cmd = if cfg!(target_os = "windows") {
+        let mut cmd = std::process::Command::new("cmd");
+        cmd.args(["/C", command]);
+        cmd
+    } else {
+        let mut cmd = std::process::Command::new("sh");
+        cmd.args(["-c", command]);
+        cmd
+    };
+
+    let status = cmd
+        .current_dir(ws_root)
+        .envs(extra_env.iter().map(|(k, v)| (k.as_str(), v.as_str())))
+        .stdin(std::process::Stdio::inherit())
+        .stdout(std::process::Stdio::inherit())
+        .stderr(std::process::Stdio::inherit())
+        .status()
+        .map_err(|e| anyhow::anyhow!("failed to run command in session workspace: {e}"))?;
+
+    Ok(SessionExecOutcome {
+        exit_code: status.code().unwrap_or(1),
+        duration_ms: start.elapsed().as_millis() as u64,
+    })
+}
+
+/// Close out an exec session workspace.
+///
+/// - `discard`: remove the workspace without reconciling.
+/// - non-zero exit: preserve the workspace and print recovery commands —
+///   a failed run must never be silently reconciled or deleted.
+/// - `keep`: preserve the workspace and defer reconcile to the user.
+/// - otherwise: reconcile into the graph and clean up; reconcile failure
+///   preserves the workspace with recovery commands.
+async fn close_exec_session<W: Write>(
+    layout: &kin_core::KinLayout,
+    session_dir: &Path,
+    exit_code: i32,
+    keep: bool,
+    discard: bool,
+    writer: &mut W,
+) -> Result<()> {
+    let session_hint = session_id_hint(session_dir);
+
+    if discard {
+        match std::fs::remove_dir_all(session_dir) {
+            Ok(()) => writeln!(writer, "Discarded session workspace.")?,
+            Err(e) => writeln!(
+                writer,
+                "Warning: failed to discard session workspace {}: {}",
+                session_dir.display(),
+                e
+            )?,
+        }
+        return Ok(());
+    }
+
+    if exit_code != 0 {
+        writeln!(
+            writer,
+            "Command failed; session workspace kept at: {}",
+            session_dir.display()
+        )?;
+        writeln!(
+            writer,
+            "To reconcile its changes anyway: kin reconcile {session_hint} --cleanup"
+        )?;
+        writeln!(writer, "To discard it: rm -rf {}", session_dir.display())?;
+        return Ok(());
+    }
+
+    if keep {
+        writeln!(
+            writer,
+            "Session workspace kept at: {}",
+            session_dir.display()
+        )?;
+        writeln!(
+            writer,
+            "To reconcile and clean up: kin reconcile {session_hint} --cleanup"
+        )?;
+        return Ok(());
+    }
+
+    super::session_closeout::finalize_shell_session_with_writer(layout, session_dir, writer).await
+}
+
+fn session_id_hint(session_dir: &Path) -> String {
+    session_dir
+        .file_name()
+        .and_then(|name| name.to_str())
+        .and_then(|name| name.strip_prefix("session-"))
+        .map(ToOwned::to_owned)
+        .unwrap_or_else(|| session_dir.display().to_string())
 }
 
 pub fn execute_exec_request(
@@ -132,25 +299,7 @@ pub fn execute_exec_request(
     Ok(response)
 }
 
-fn print_exec_response(response: &ExecResponse) {
-    if !response.stdout.is_empty() {
-        print!("{}", response.stdout);
-    }
-    if !response.stderr.is_empty() {
-        eprint!("{}", response.stderr);
-    }
-
-    println!(
-        "\nExecution complete (exit code: {}, {}ms, strategy: {})",
-        response.exit_code, response.duration_ms, response.strategy_used
-    );
-
-    if response.kept {
-        println!("Workspace kept at: {}", response.workspace_path);
-    }
-}
-
-fn resolve_materialization_scope(
+pub(crate) fn resolve_materialization_scope(
     graph: &kin_db::InMemoryGraph,
     scope: Option<String>,
 ) -> Result<Option<String>> {
@@ -235,11 +384,19 @@ fn plan_materialization_scope(
     }
 }
 
+/// Package-manager front-ends that read manifests, lockfiles, and arbitrary
+/// project scripts. A partially materialized workspace surprises them, so
+/// scoped execution widens to a full workspace under the default policy.
+const PACKAGE_MANAGER_COMMANDS: &[&str] = &[
+    "npm", "npx", "pnpm", "pnpx", "yarn", "bun", "bunx", "corepack",
+];
+
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 enum ExternalToolKind {
     DockerCompose,
     DockerBuild,
     Make,
+    PackageManager(&'static str),
 }
 
 impl ExternalToolKind {
@@ -248,6 +405,7 @@ impl ExternalToolKind {
             Self::DockerCompose => "docker compose",
             Self::DockerBuild => "docker build",
             Self::Make => "make",
+            Self::PackageManager(name) => name,
         }
     }
 }
@@ -265,6 +423,10 @@ fn detect_external_tool(command: &str) -> Option<ExternalToolKind> {
         | ["docker", "buildx", "bake", ..]
         | ["podman", "bake", ..] => Some(ExternalToolKind::DockerBuild),
         ["make", ..] | ["gmake", ..] => Some(ExternalToolKind::Make),
+        [first, ..] => PACKAGE_MANAGER_COMMANDS
+            .iter()
+            .find(|name| *name == first)
+            .map(|name| ExternalToolKind::PackageManager(name)),
         _ => None,
     }
 }
@@ -272,14 +434,15 @@ fn detect_external_tool(command: &str) -> Option<ExternalToolKind> {
 #[cfg(test)]
 mod tests {
     use super::{
-        detect_external_tool, plan_materialization_scope, resolve_materialization_scope,
-        ExternalToolKind,
+        close_exec_session, detect_external_tool, plan_materialization_scope,
+        resolve_materialization_scope, run_command_in_session, session_env, ExternalToolKind,
     };
     use kin_core::{ExternalToolExecutionPolicy, KinConfig, WorldPreset};
     use kin_model::{
         Entity, EntityId, EntityKind, EntityMetadata, EntityRole, EntityStore, FilePathId,
         FingerprintAlgorithm, Hash256, LanguageId, SemanticFingerprint, SourceSpan, Visibility,
     };
+    use std::path::Path;
 
     fn test_entity(name: &str, file: &str) -> Entity {
         Entity {
@@ -313,6 +476,24 @@ mod tests {
             created_in: None,
             superseded_by: None,
         }
+    }
+
+    /// Write an executable stub script into `bin_dir` and return an env set
+    /// that resolves it first on PATH.
+    fn stub_tool(bin_dir: &Path, name: &str, script_body: &str) -> Vec<(String, String)> {
+        std::fs::create_dir_all(bin_dir).unwrap();
+        let path = bin_dir.join(name);
+        std::fs::write(&path, format!("#!/bin/sh\n{script_body}\n")).unwrap();
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt;
+            std::fs::set_permissions(&path, std::fs::Permissions::from_mode(0o755)).unwrap();
+        }
+        let original_path = std::env::var("PATH").unwrap_or_default();
+        vec![(
+            "PATH".to_string(),
+            format!("{}:{}", bin_dir.display(), original_path),
+        )]
     }
 
     #[test]
@@ -383,6 +564,34 @@ mod tests {
     }
 
     #[test]
+    fn detects_package_manager_variants() {
+        for command in [
+            "npm test",
+            "npm run build",
+            "npx vitest",
+            "pnpm install",
+            "pnpx create-app",
+            "yarn test",
+            "bun run dev",
+            "bunx tsc",
+            "corepack enable",
+        ] {
+            let detected = detect_external_tool(command);
+            assert!(
+                matches!(detected, Some(ExternalToolKind::PackageManager(_))),
+                "expected package-manager detection for `{command}`, got {detected:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn does_not_detect_ordinary_commands_as_external_tools() {
+        assert_eq!(detect_external_tool("cargo test"), None);
+        assert_eq!(detect_external_tool("python script.py"), None);
+        assert_eq!(detect_external_tool("ls -la"), None);
+    }
+
+    #[test]
     fn workspace_policy_widens_scoped_external_tools() {
         let mut config = KinConfig::default();
         config.apply_world_preset(WorldPreset::Native);
@@ -402,6 +611,18 @@ mod tests {
     }
 
     #[test]
+    fn workspace_policy_widens_scoped_package_managers() {
+        let mut config = KinConfig::default();
+        config.apply_world_preset(WorldPreset::Native);
+
+        let scope =
+            plan_materialization_scope("npm test", Some("file:package.json".to_string()), &config)
+                .unwrap();
+
+        assert_eq!(scope, None);
+    }
+
+    #[test]
     fn strict_policy_blocks_scoped_external_tools() {
         let mut config = KinConfig::default();
         config.apply_world_preset(WorldPreset::Native);
@@ -417,5 +638,253 @@ mod tests {
             config.execution.external_tools,
             ExternalToolExecutionPolicy::Strict
         );
+    }
+
+    #[test]
+    fn strict_policy_blocks_scoped_package_managers() {
+        let mut config = KinConfig::default();
+        config.apply_world_preset(WorldPreset::Native);
+        config.execution.external_tools = ExternalToolExecutionPolicy::Strict;
+
+        let err = plan_materialization_scope(
+            "pnpm install",
+            Some("file:package.json".to_string()),
+            &config,
+        )
+        .unwrap_err();
+
+        assert!(err.to_string().contains("pnpm"));
+    }
+
+    #[test]
+    fn session_env_carries_session_identity() {
+        let session_id = uuid::Uuid::new_v4();
+        let ws_root = Path::new("/tmp/repo/.kin/runs/session-x");
+
+        let env = session_env(session_id, ws_root);
+
+        for (key, expected) in [
+            ("KIN_SESSION", session_id.to_string()),
+            ("KIN_SESSION_ID", session_id.to_string()),
+            ("KIN_SESSION_DIR", ws_root.to_string_lossy().into_owned()),
+        ] {
+            assert_eq!(
+                env.iter().find(|(k, _)| k == key).map(|(_, v)| v.as_str()),
+                Some(expected.as_str()),
+                "missing or wrong {key}"
+            );
+        }
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn run_command_in_session_runs_in_workspace_with_session_env() {
+        let dir = tempfile::tempdir().unwrap();
+        let ws = dir.path().join("session-ws");
+        std::fs::create_dir_all(&ws).unwrap();
+        let session_id = uuid::Uuid::new_v4();
+
+        let outcome = run_command_in_session(
+            &ws,
+            "pwd > observed-cwd.txt && printf '%s' \"$KIN_SESSION_ID\" > observed-session.txt",
+            &session_env(session_id, &ws),
+        )
+        .unwrap();
+
+        assert_eq!(outcome.exit_code, 0);
+        let observed_cwd = std::fs::read_to_string(ws.join("observed-cwd.txt")).unwrap();
+        assert_eq!(
+            std::fs::canonicalize(observed_cwd.trim()).unwrap(),
+            std::fs::canonicalize(&ws).unwrap()
+        );
+        assert_eq!(
+            std::fs::read_to_string(ws.join("observed-session.txt")).unwrap(),
+            session_id.to_string()
+        );
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn run_command_in_session_propagates_exit_code() {
+        let dir = tempfile::tempdir().unwrap();
+        let ws = dir.path().join("session-ws");
+        std::fs::create_dir_all(&ws).unwrap();
+
+        let outcome =
+            run_command_in_session(&ws, "exit 3", &session_env(uuid::Uuid::new_v4(), &ws)).unwrap();
+
+        assert_eq!(outcome.exit_code, 3);
+    }
+
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn npm_smoke_reconciles_lockfile_and_ignores_node_modules() {
+        let repo = tempfile::tempdir().unwrap();
+        let init = kin_core::init(repo.path()).unwrap();
+        let layout = init.layout;
+        let session_dir = layout.root().join("runs/session-npm-smoke");
+
+        // Materialized state: the project manifest exists in both the source
+        // tree and the session workspace.
+        std::fs::write(repo.path().join("package.json"), "{\"name\":\"app\"}\n").unwrap();
+        std::fs::create_dir_all(&session_dir).unwrap();
+        std::fs::write(session_dir.join("package.json"), "{\"name\":\"app\"}\n").unwrap();
+
+        // Fake npm: emits a lockfile plus a node_modules tree, like a real install.
+        let mut env = stub_tool(
+            &repo.path().join("stub-bin"),
+            "npm",
+            "printf '{\"lockfileVersion\":3}' > package-lock.json\n\
+             mkdir -p node_modules/left-pad\n\
+             printf 'module.exports = 1' > node_modules/left-pad/index.js",
+        );
+        env.extend(session_env(uuid::Uuid::new_v4(), &session_dir));
+
+        let outcome = run_command_in_session(&session_dir, "npm install", &env).unwrap();
+        assert_eq!(outcome.exit_code, 0);
+        assert!(session_dir.join("package-lock.json").exists());
+        assert!(session_dir.join("node_modules/left-pad/index.js").exists());
+
+        let mut stderr = Vec::new();
+        close_exec_session(&layout, &session_dir, 0, false, false, &mut stderr)
+            .await
+            .unwrap();
+
+        assert!(
+            repo.path().join("package-lock.json").exists(),
+            "lockfile should reconcile back into the source tree"
+        );
+        assert!(
+            !repo.path().join("node_modules").exists(),
+            "generated node_modules must be excluded by the reconcile skip policy"
+        );
+        assert!(
+            !session_dir.exists(),
+            "successful closeout should remove the session workspace"
+        );
+    }
+
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn make_failure_preserves_workspace_with_recovery_commands() {
+        let repo = tempfile::tempdir().unwrap();
+        let init = kin_core::init(repo.path()).unwrap();
+        let layout = init.layout;
+        let session_dir = layout.root().join("runs/session-make-fail");
+        std::fs::create_dir_all(&session_dir).unwrap();
+        std::fs::write(session_dir.join("partial.log"), "half-written output\n").unwrap();
+
+        let mut env = stub_tool(&repo.path().join("stub-bin"), "make", "exit 2");
+        env.extend(session_env(uuid::Uuid::new_v4(), &session_dir));
+
+        let outcome = run_command_in_session(&session_dir, "make test", &env).unwrap();
+        assert_eq!(outcome.exit_code, 2);
+
+        let mut stderr = Vec::new();
+        close_exec_session(
+            &layout,
+            &session_dir,
+            outcome.exit_code,
+            false,
+            false,
+            &mut stderr,
+        )
+        .await
+        .unwrap();
+
+        let output = String::from_utf8(stderr).unwrap();
+        assert!(output.contains("session workspace kept"));
+        assert!(output.contains("kin reconcile make-fail --cleanup"));
+        assert!(output.contains("rm -rf"));
+        assert!(
+            session_dir.join("partial.log").exists(),
+            "failed run must preserve the session workspace"
+        );
+        assert!(
+            !repo.path().join("partial.log").exists(),
+            "failed run must not reconcile into the source tree"
+        );
+    }
+
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn docker_compose_config_smoke_runs_against_materialized_workspace() {
+        let repo = tempfile::tempdir().unwrap();
+        let init = kin_core::init(repo.path()).unwrap();
+        let layout = init.layout;
+        let session_dir = layout.root().join("runs/session-compose");
+        std::fs::create_dir_all(&session_dir).unwrap();
+        std::fs::write(
+            session_dir.join("docker-compose.yml"),
+            "services:\n  app:\n    image: alpine\n",
+        )
+        .unwrap();
+
+        // Fake docker: validates that the compose file is visible from the
+        // workspace cwd, like `docker compose config` would.
+        let mut env = stub_tool(
+            &repo.path().join("stub-bin"),
+            "docker",
+            "test -f docker-compose.yml || exit 64\nprintf '%s ' \"$@\" > docker-args.txt",
+        );
+        env.extend(session_env(uuid::Uuid::new_v4(), &session_dir));
+
+        let outcome = run_command_in_session(&session_dir, "docker compose config", &env).unwrap();
+        assert_eq!(outcome.exit_code, 0);
+        assert_eq!(
+            std::fs::read_to_string(session_dir.join("docker-args.txt"))
+                .unwrap()
+                .trim(),
+            "compose config"
+        );
+
+        let mut stderr = Vec::new();
+        close_exec_session(&layout, &session_dir, 0, false, false, &mut stderr)
+            .await
+            .unwrap();
+        assert!(!session_dir.exists());
+    }
+
+    #[tokio::test]
+    async fn keep_defers_reconcile_and_preserves_workspace() {
+        let repo = tempfile::tempdir().unwrap();
+        let init = kin_core::init(repo.path()).unwrap();
+        let layout = init.layout;
+        let session_dir = layout.root().join("runs/session-keep");
+        std::fs::create_dir_all(&session_dir).unwrap();
+        std::fs::write(session_dir.join("new-file.txt"), "kept\n").unwrap();
+
+        let mut stderr = Vec::new();
+        close_exec_session(&layout, &session_dir, 0, true, false, &mut stderr)
+            .await
+            .unwrap();
+
+        let output = String::from_utf8(stderr).unwrap();
+        assert!(output.contains("kin reconcile keep --cleanup"));
+        assert!(session_dir.join("new-file.txt").exists());
+        assert!(
+            !repo.path().join("new-file.txt").exists(),
+            "--keep must defer reconcile"
+        );
+    }
+
+    #[tokio::test]
+    async fn discard_removes_workspace_without_reconcile() {
+        let repo = tempfile::tempdir().unwrap();
+        let init = kin_core::init(repo.path()).unwrap();
+        let layout = init.layout;
+        let session_dir = layout.root().join("runs/session-discard");
+        std::fs::create_dir_all(&session_dir).unwrap();
+        std::fs::write(session_dir.join("scratch.txt"), "throwaway\n").unwrap();
+
+        let mut stderr = Vec::new();
+        close_exec_session(&layout, &session_dir, 0, false, true, &mut stderr)
+            .await
+            .unwrap();
+
+        assert!(!session_dir.exists());
+        assert!(!repo.path().join("scratch.txt").exists());
+        let output = String::from_utf8(stderr).unwrap();
+        assert!(output.contains("Discarded session workspace."));
     }
 }

--- a/crates/kin-cli/src/commands/health.rs
+++ b/crates/kin-cli/src/commands/health.rs
@@ -126,6 +126,7 @@ pub async fn run_health_checks() -> HealthReport {
         check_daemon_running().await,
         check_vfs_projection(),
         check_repo_init(),
+        check_session_runtime(),
         check_shell_path(),
     ];
     checks.extend(check_mcp_clients());
@@ -326,6 +327,62 @@ fn check_repo_init() -> HealthCheck {
     }
 }
 
+/// Teach the session runtime path and surface leftover session workspaces.
+///
+/// Ordinary project tools run through graph-backed session workspaces
+/// (`kin exec`, `kin shell`, `kin with --session`); a workspace left under
+/// `.kin/runs/` is either an active session or a failed run waiting for
+/// `kin reconcile`.
+fn check_session_runtime() -> HealthCheck {
+    let cwd = env::current_dir().unwrap_or_default();
+    session_runtime_check_for(kin_core::KinLayout::discover(&cwd).as_ref())
+}
+
+fn session_runtime_check_for(layout: Option<&kin_core::KinLayout>) -> HealthCheck {
+    let Some(layout) = layout else {
+        return HealthCheck::new(
+            "session_runtime",
+            "Session runtime",
+            HealthStatus::Unsupported,
+            "not inside a Kin repository — from a Kin repo, run project tools with `kin exec -- <cmd>`",
+        );
+    };
+
+    let runs_dir = layout.root().join("runs");
+    let pending: Vec<String> = std::fs::read_dir(&runs_dir)
+        .into_iter()
+        .flatten()
+        .filter_map(|entry| entry.ok())
+        .filter_map(|entry| entry.file_name().to_str().map(ToOwned::to_owned))
+        .filter(|name| name.starts_with("session-") || name.starts_with("exec-"))
+        .collect();
+
+    if pending.is_empty() {
+        HealthCheck::new(
+            "session_runtime",
+            "Session runtime",
+            HealthStatus::Healthy,
+            "run project tools with `kin exec -- <cmd>` (alias `kin run`), \
+             open an interactive env with `kin shell`, \
+             launch agents with `kin with --session <assistant>`",
+        )
+    } else {
+        HealthCheck::new(
+            "session_runtime",
+            "Session runtime",
+            HealthStatus::Stale,
+            format!(
+                "{} session workspace(s) under {} (active session, or a finished run waiting for reconcile)",
+                pending.len(),
+                runs_dir.display()
+            ),
+        )
+        .with_manual_fix(
+            "reconcile a finished session with `kin reconcile <session-id> --cleanup`, or remove it with `rm -rf <workspace>`",
+        )
+    }
+}
+
 fn check_shell_path() -> HealthCheck {
     let shell = detect_shell();
 
@@ -470,6 +527,21 @@ pub(crate) fn evaluate_mcp_client(path: &PathBuf) -> (HealthStatus, String) {
             format!("no mcpServers.kin entry in {}", path.display()),
         ),
         Some(entry) => {
+            // Entries written by older releases pass `--global`, which the MCP
+            // server refuses at startup — the agent sees a dead kin server.
+            let has_retired_global_flag = entry
+                .get("args")
+                .and_then(|args| args.as_array())
+                .is_some_and(|args| args.iter().any(|arg| arg.as_str() == Some("--global")));
+            if has_retired_global_flag {
+                return (
+                    HealthStatus::Misconfigured,
+                    format!(
+                        "mcpServers.kin uses the retired `--global` mode and cannot start in {}",
+                        path.display()
+                    ),
+                );
+            }
             let profile = entry
                 .get("env")
                 .and_then(|e| e.get("KIN_MCP_TOOL_PROFILE"))
@@ -764,7 +836,7 @@ mod tests {
                 "mcpServers": {
                     "kin": {
                         "command": "kin",
-                        "args": ["mcp", "start", "--global"],
+                        "args": ["mcp", "start"],
                         "env": {}
                     }
                 }
@@ -787,7 +859,7 @@ mod tests {
                 "mcpServers": {
                     "kin": {
                         "command": "kin",
-                        "args": ["mcp", "start", "--global"],
+                        "args": ["mcp", "start"],
                         "env": { "KIN_MCP_TOOL_PROFILE": "agent-default" }
                     }
                 }
@@ -801,10 +873,74 @@ mod tests {
     }
 
     #[test]
+    fn mcp_config_with_retired_global_flag_is_misconfigured() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("claude.json");
+        std::fs::write(
+            &path,
+            serde_json::to_string_pretty(&serde_json::json!({
+                "mcpServers": {
+                    "kin": {
+                        "command": "kin",
+                        "args": ["mcp", "start", "--global"],
+                        "env": { "KIN_MCP_TOOL_PROFILE": "agent-default" }
+                    }
+                }
+            }))
+            .unwrap(),
+        )
+        .unwrap();
+
+        let (status, detail) = evaluate_mcp_client(&path);
+        assert!(matches!(status, HealthStatus::Misconfigured));
+        assert!(detail.contains("--global"));
+    }
+
+    #[test]
     fn mcp_config_missing_file_is_missing() {
         let dir = tempfile::tempdir().unwrap();
         let path = dir.path().join("does-not-exist.json");
         let (status, _detail) = evaluate_mcp_client(&path);
         assert!(matches!(status, HealthStatus::Missing));
+    }
+
+    #[test]
+    fn session_runtime_outside_repo_is_skipped_with_hint() {
+        let check = session_runtime_check_for(None);
+        assert_eq!(check.id, "session_runtime");
+        assert!(matches!(check.status, HealthStatus::Unsupported));
+        assert!(check.detail.contains("kin exec"));
+    }
+
+    #[test]
+    fn session_runtime_in_clean_repo_teaches_the_commands() {
+        let dir = tempfile::tempdir().unwrap();
+        let kin_dir = dir.path().join(".kin");
+        std::fs::create_dir_all(&kin_dir).unwrap();
+        std::fs::write(kin_dir.join("HEAD"), "main").unwrap();
+        let layout = kin_core::KinLayout::discover(dir.path()).unwrap();
+
+        let check = session_runtime_check_for(Some(&layout));
+        assert!(matches!(check.status, HealthStatus::Healthy));
+        assert!(check.detail.contains("kin exec"));
+        assert!(check.detail.contains("kin shell"));
+        assert!(check.detail.contains("kin with --session"));
+    }
+
+    #[test]
+    fn session_runtime_reports_pending_session_workspaces() {
+        let dir = tempfile::tempdir().unwrap();
+        let kin_dir = dir.path().join(".kin");
+        std::fs::create_dir_all(kin_dir.join("runs/session-leftover")).unwrap();
+        std::fs::write(kin_dir.join("HEAD"), "main").unwrap();
+        let layout = kin_core::KinLayout::discover(dir.path()).unwrap();
+
+        let check = session_runtime_check_for(Some(&layout));
+        assert!(matches!(check.status, HealthStatus::Stale));
+        assert!(check.detail.contains("1 session workspace(s)"));
+        assert!(check
+            .manual_fix
+            .as_deref()
+            .is_some_and(|fix| fix.contains("kin reconcile")));
     }
 }

--- a/crates/kin-cli/src/commands/session_closeout.rs
+++ b/crates/kin-cli/src/commands/session_closeout.rs
@@ -42,7 +42,6 @@ pub async fn finalize_open_session_with_writer<W: Write>(
     finalize_session(layout, session_dir, writer, SessionCloseoutStyle::Open).await
 }
 
-#[cfg(test)]
 pub async fn finalize_shell_session_with_writer<W: Write>(
     layout: &kin_core::KinLayout,
     session_dir: &Path,

--- a/crates/kin-cli/src/commands/session_workspace.rs
+++ b/crates/kin-cli/src/commands/session_workspace.rs
@@ -116,12 +116,16 @@ pub fn materialize_session_workspace(
         .transpose()
         .map_err(|error| anyhow::anyhow!("{}", error))?;
     let session_dir = std::path::PathBuf::from(&request.session_dir);
+    // `entity:`/`artifact:` scopes resolve against graph truth here, so every
+    // session surface (shell, exec, open) shares one scope vocabulary and an
+    // unresolvable scope fails loud instead of silently widening.
+    let scope = super::exec::resolve_materialization_scope(graph, request.scope.clone())?;
     let workspace = create_session_workspace_from_graph(
         layout,
         graph,
         &session_dir,
         strategy,
-        request.scope.as_deref(),
+        scope.as_deref(),
     )?;
 
     Ok(SessionWorkspaceResponse {

--- a/crates/kin-cli/src/commands/setup.rs
+++ b/crates/kin-cli/src/commands/setup.rs
@@ -679,6 +679,11 @@ fn prompt_yn(prompt: &str, default_yes: bool, interactive: bool) -> bool {
 /// Prefers an absolute path to the `kin` binary (resolved from the current
 /// executable) so the entry works in agent processes that do not inherit the
 /// user's PATH.
+///
+/// The entry starts the MCP server in single-repo mode: `kin mcp start`
+/// resolves the repo from the agent's working directory (or from
+/// `KIN_DAEMON_URL` when a session launch pinned one), so each agent session
+/// binds to the daemon of the repository it is actually working in.
 fn kin_mcp_entry() -> serde_json::Value {
     // Try to resolve an absolute path from the running executable.  The
     // installed binary lives alongside the other kin-* binaries, so
@@ -692,7 +697,7 @@ fn kin_mcp_entry() -> serde_json::Value {
     };
     serde_json::json!({
         "command": command,
-        "args": ["mcp", "start", "--global"],
+        "args": ["mcp", "start"],
         "env": { "KIN_MCP_TOOL_PROFILE": "agent-default" }
     })
 }

--- a/crates/kin-cli/src/commands/with.rs
+++ b/crates/kin-cli/src/commands/with.rs
@@ -1,14 +1,27 @@
 // SPDX-License-Identifier: Apache-2.0
 // Copyright 2026 Firelock, LLC
 
+use std::io::Write;
+use std::path::Path;
+
 use anyhow::Result;
 
 use kin_core::{AssistantKind, PromptMode};
 
-/// `kin with <assistant> -- <task...>` — Launch an assistant with Kin guidance injected.
+/// `kin with [--session] <assistant> -- <task...>` — Launch an assistant with
+/// Kin guidance injected.
+///
+/// Without `--session` the assistant launches from the repo working directory
+/// with native-mode shims redirecting file commands to the source surface.
+/// With `--session` the assistant launches inside a graph-backed session
+/// workspace: its cwd and file operations target the materialized session,
+/// its environment pins the repo daemon and session identity (so MCP tools
+/// spawned by the assistant bind to the same repo and session), and a
+/// successful exit reconciles the session back into the graph.
 pub async fn run(
     assistant: String,
     task: Vec<String>,
+    session: bool,
     passive_guidance: bool,
     restrict_discovery: bool,
     restrict_filesystem: bool,
@@ -35,6 +48,19 @@ pub async fn run(
 
     let guidance =
         kin_core::generate_assistant_prompt(kind, PromptMode::Normal, &layout, summary.as_ref());
+
+    if session {
+        return run_in_session(
+            &layout,
+            kind,
+            &guidance,
+            &task_text,
+            passive_guidance,
+            restrict_discovery,
+            restrict_filesystem,
+        )
+        .await;
+    }
 
     let full_prompt = build_full_prompt(&guidance, &task_text, passive_guidance);
 
@@ -64,6 +90,181 @@ pub async fn run(
     }
 
     std::process::exit(code);
+}
+
+/// Launch the assistant inside a freshly materialized session workspace and
+/// close the session out when it exits.
+async fn run_in_session(
+    layout: &kin_core::KinLayout,
+    kind: AssistantKind,
+    guidance: &str,
+    task_text: &str,
+    passive_guidance: bool,
+    restrict_discovery: bool,
+    restrict_filesystem: bool,
+) -> Result<()> {
+    let session_id = uuid::Uuid::new_v4();
+    let session_dir = layout
+        .root()
+        .join("runs")
+        .join(format!("session-{session_id}"));
+
+    let ws = super::session_workspace::create_session_workspace(layout, &session_dir, None, None)
+        .await?;
+
+    // Pin the daemon endpoint for the assistant and everything it spawns.
+    // `kin mcp start` prefers KIN_DAEMON_URL over cwd discovery, so MCP tool
+    // calls from this assistant bind to the same repo daemon as this session.
+    let daemon_url = match std::env::var("KIN_DAEMON_URL")
+        .ok()
+        .filter(|value| !value.trim().is_empty())
+    {
+        Some(url) => url,
+        None => crate::daemon_client::resolve_daemon_url(layout)
+            .await?
+            .ok_or_else(|| anyhow::anyhow!("kin daemon is required for a session launch"))?,
+    };
+    let repo_id = super::remote::resolve_repo_id(layout).ok();
+
+    let session_guidance = format!("{guidance}\n\n{}", session_guidance_note(&ws.root));
+    let full_prompt = build_full_prompt(&session_guidance, task_text, passive_guidance);
+
+    let headless = std::env::var("KIN_BENCHMARK").ok().as_deref() == Some("1");
+    let (program, args) = build_assistant_command(kind, &full_prompt, headless)?;
+
+    // Shims target the live session workspace so shell-outs from the
+    // assistant resolve against the same files it is editing.
+    let shim_env = session_shim_env(layout, &ws.root, restrict_discovery, restrict_filesystem)?;
+    let mut env = session_launch_env(session_id, &ws.root, &daemon_url, repo_id.as_deref());
+    env.extend(shim_env);
+
+    eprintln!("Session workspace: {}", ws.root.display());
+    eprintln!("Launching {} in session workspace...", kind);
+
+    let code = spawn_assistant_in_session(&program, &args, &ws.root, &env)?;
+    eprintln!("\n{} exited (code {}).", kind, code);
+
+    {
+        let stderr = std::io::stderr();
+        let mut stderr = stderr.lock();
+        close_agent_session(layout, &session_dir, code, &mut stderr).await?;
+    }
+
+    std::process::exit(code);
+}
+
+/// Spawn the assistant process with cwd set to the session workspace root.
+fn spawn_assistant_in_session(
+    program: &str,
+    args: &[String],
+    ws_root: &Path,
+    env: &[(String, String)],
+) -> Result<i32> {
+    let status = std::process::Command::new(program)
+        .args(args)
+        .current_dir(ws_root)
+        .envs(env.iter().map(|(k, v)| (k.as_str(), v.as_str())))
+        .stdin(std::process::Stdio::inherit())
+        .stdout(std::process::Stdio::inherit())
+        .stderr(std::process::Stdio::inherit())
+        .status()
+        .map_err(|e| anyhow::anyhow!("failed to launch '{}': {}", program, e))?;
+    Ok(status.code().unwrap_or(1))
+}
+
+/// Session identity and daemon-binding env for an agent session launch.
+///
+/// - `KIN_SESSION` / `KIN_SESSION_DIR`: the `kin shell`/`kin open` contract.
+/// - `KIN_SESSION_ID`: read by the MCP daemon delegate, which forwards it as
+///   the `X-Kin-Session` header so the daemon can resolve session-scoped
+///   graph state for this agent's tool calls.
+/// - `KIN_DAEMON_URL`: pins `kin` CLI/MCP invocations inside the session to
+///   this repo's daemon instead of re-discovering from cwd.
+/// - `KIN_REPO_ID`: repo identity for provenance attribution.
+fn session_launch_env(
+    session_id: uuid::Uuid,
+    ws_root: &Path,
+    daemon_url: &str,
+    repo_id: Option<&str>,
+) -> Vec<(String, String)> {
+    let mut env = vec![
+        ("KIN_SESSION".into(), session_id.to_string()),
+        ("KIN_SESSION_ID".into(), session_id.to_string()),
+        (
+            "KIN_SESSION_DIR".into(),
+            ws_root.to_string_lossy().into_owned(),
+        ),
+        ("KIN_DAEMON_URL".into(), daemon_url.to_string()),
+    ];
+    if let Some(repo_id) = repo_id {
+        env.push(("KIN_REPO_ID".into(), repo_id.to_string()));
+    }
+    env
+}
+
+fn session_guidance_note(ws_root: &Path) -> String {
+    format!(
+        "You are working inside a Kin session workspace at {}. Ordinary shell \
+         commands and file edits apply to this workspace, and Kin reconciles \
+         your changes into the semantic graph when the session ends. Kin MCP \
+         tools are bound to this repository's daemon and this session.",
+        ws_root.display()
+    )
+}
+
+/// Close out an agent session: a clean exit reconciles the workspace into
+/// the graph; any failure preserves the workspace with recovery commands.
+async fn close_agent_session<W: Write>(
+    layout: &kin_core::KinLayout,
+    session_dir: &Path,
+    exit_code: i32,
+    writer: &mut W,
+) -> Result<()> {
+    if exit_code == 0 {
+        return super::session_closeout::finalize_shell_session_with_writer(
+            layout,
+            session_dir,
+            writer,
+        )
+        .await;
+    }
+
+    let session_hint = session_dir
+        .file_name()
+        .and_then(|name| name.to_str())
+        .and_then(|name| name.strip_prefix("session-"))
+        .map(ToOwned::to_owned)
+        .unwrap_or_else(|| session_dir.display().to_string());
+    writeln!(
+        writer,
+        "Assistant failed; session workspace kept at: {}",
+        session_dir.display()
+    )?;
+    writeln!(
+        writer,
+        "To reconcile its changes anyway: kin reconcile {session_hint} --cleanup"
+    )?;
+    writeln!(writer, "To discard it: rm -rf {}", session_dir.display())?;
+    Ok(())
+}
+
+fn session_shim_env(
+    layout: &kin_core::KinLayout,
+    workspace_root: &Path,
+    restrict_discovery: bool,
+    restrict_filesystem: bool,
+) -> Result<Vec<(String, String)>> {
+    let shim_dir = kin_core::shims::ensure_shim_dir(layout)?;
+    let mut env = kin_core::shims::shim_env_for_root(&shim_dir, workspace_root);
+    if restrict_filesystem {
+        eprintln!("Native mode: filesystem discovery and direct file reads are restricted");
+        env.push(("KIN_DISCOVERY_MODE".into(), "deny".into()));
+        env.push(("KIN_CONTENT_MODE".into(), "deny".into()));
+    } else if restrict_discovery {
+        eprintln!("Native mode: filesystem discovery commands are restricted");
+        env.push(("KIN_DISCOVERY_MODE".into(), "deny".into()));
+    }
+    Ok(env)
 }
 
 fn build_full_prompt(guidance: &str, task: &str, passive_guidance: bool) -> String {
@@ -401,5 +602,192 @@ mod tests {
         assert!(env
             .iter()
             .any(|(k, v)| k == "KIN_CONTENT_MODE" && v == "deny"));
+    }
+
+    #[test]
+    fn session_launch_env_pins_session_and_daemon() {
+        let session_id = uuid::Uuid::new_v4();
+        let ws_root = std::path::Path::new("/tmp/repo/.kin/runs/session-x");
+
+        let env = session_launch_env(
+            session_id,
+            ws_root,
+            "http://127.0.0.1:4242",
+            Some("repo-uuid"),
+        );
+
+        for (key, expected) in [
+            ("KIN_SESSION", session_id.to_string()),
+            ("KIN_SESSION_ID", session_id.to_string()),
+            ("KIN_SESSION_DIR", ws_root.to_string_lossy().into_owned()),
+            ("KIN_DAEMON_URL", "http://127.0.0.1:4242".to_string()),
+            ("KIN_REPO_ID", "repo-uuid".to_string()),
+        ] {
+            assert_eq!(
+                env.iter().find(|(k, _)| k == key).map(|(_, v)| v.as_str()),
+                Some(expected.as_str()),
+                "missing or wrong {key}"
+            );
+        }
+    }
+
+    #[test]
+    fn session_launch_env_omits_repo_id_when_unknown() {
+        let env = session_launch_env(
+            uuid::Uuid::new_v4(),
+            std::path::Path::new("/tmp/ws"),
+            "http://127.0.0.1:4242",
+            None,
+        );
+        assert!(!env.iter().any(|(k, _)| k == "KIN_REPO_ID"));
+    }
+
+    #[test]
+    fn session_shim_env_targets_session_workspace() {
+        let dir = tempfile::tempdir().unwrap();
+        let kin_dir = dir.path().join(".kin");
+        std::fs::create_dir_all(kin_dir.join("source-root")).unwrap();
+        std::fs::write(kin_dir.join("HEAD"), "main").unwrap();
+        let workspace_root = dir.path().join(".kin/runs/session-123");
+        std::fs::create_dir_all(&workspace_root).unwrap();
+        let layout = kin_core::KinLayout::discover(dir.path()).unwrap();
+
+        let env = session_shim_env(&layout, &workspace_root, false, false).unwrap();
+        assert!(
+            env.iter()
+                .any(|(k, v)| k == "KIN_SOURCE_ROOT"
+                    && v == workspace_root.to_string_lossy().as_ref())
+        );
+    }
+
+    #[test]
+    fn session_guidance_note_names_the_workspace() {
+        let note = session_guidance_note(std::path::Path::new("/tmp/ws/session-abc"));
+        assert!(note.contains("/tmp/ws/session-abc"));
+        assert!(note.contains("reconciles"));
+    }
+
+    /// Smoke: a fake `claude` binary launched via the session path must start
+    /// with cwd in the session workspace and see the session/daemon env.
+    #[cfg(unix)]
+    #[test]
+    #[serial]
+    fn claude_stub_launch_starts_in_session_workspace_with_session_env() {
+        let repo = tempfile::tempdir().unwrap();
+        let init = kin_core::init(repo.path()).unwrap();
+        let layout = init.layout;
+        let session_id = uuid::Uuid::new_v4();
+        let ws_root = layout.root().join(format!("runs/session-{session_id}"));
+        std::fs::create_dir_all(&ws_root).unwrap();
+
+        let stub_dir = repo.path().join("stub-bin");
+        std::fs::create_dir_all(&stub_dir).unwrap();
+        let record = repo.path().join("claude-record.txt");
+        std::fs::write(
+            stub_dir.join("claude"),
+            format!(
+                "#!/bin/sh\n\
+                 printf 'cwd=%s\\n' \"$PWD\" > {record}\n\
+                 printf 'session=%s\\n' \"$KIN_SESSION\" >> {record}\n\
+                 printf 'session_id=%s\\n' \"$KIN_SESSION_ID\" >> {record}\n\
+                 printf 'session_dir=%s\\n' \"$KIN_SESSION_DIR\" >> {record}\n\
+                 printf 'daemon=%s\\n' \"$KIN_DAEMON_URL\" >> {record}\n\
+                 printf 'source_root=%s\\n' \"$KIN_SOURCE_ROOT\" >> {record}\n\
+                 printf 'prompt=%s\\n' \"$2\" >> {record}\n",
+                record = record.display()
+            ),
+        )
+        .unwrap();
+        {
+            use std::os::unix::fs::PermissionsExt;
+            std::fs::set_permissions(
+                stub_dir.join("claude"),
+                std::fs::Permissions::from_mode(0o755),
+            )
+            .unwrap();
+        }
+
+        let original_path = std::env::var("PATH").unwrap_or_default();
+        std::env::set_var("PATH", format!("{}:{original_path}", stub_dir.display()));
+
+        let (program, args) =
+            build_assistant_command(AssistantKind::ClaudeCode, "session smoke task", false)
+                .unwrap();
+        let mut env = session_launch_env(session_id, &ws_root, "http://127.0.0.1:9/test", None);
+        env.extend(session_shim_env(&layout, &ws_root, false, false).unwrap());
+        let code = spawn_assistant_in_session(&program, &args, &ws_root, &env).unwrap();
+
+        std::env::set_var("PATH", original_path);
+
+        assert_eq!(code, 0);
+        let recorded = std::fs::read_to_string(&record).unwrap();
+        let ws_display = ws_root.display().to_string();
+        let cwd_line = recorded
+            .lines()
+            .find(|l| l.starts_with("cwd="))
+            .unwrap()
+            .trim_start_matches("cwd=");
+        assert_eq!(
+            std::fs::canonicalize(cwd_line).unwrap(),
+            std::fs::canonicalize(&ws_root).unwrap(),
+            "assistant must start inside the session workspace"
+        );
+        assert!(recorded.contains(&format!("session={session_id}")));
+        assert!(recorded.contains(&format!("session_id={session_id}")));
+        assert!(recorded.contains(&format!("session_dir={ws_display}")));
+        assert!(recorded.contains("daemon=http://127.0.0.1:9/test"));
+        assert!(recorded.contains(&format!("source_root={ws_display}")));
+        assert!(recorded.contains("prompt="));
+        assert!(recorded.contains("session smoke task"));
+    }
+
+    #[tokio::test]
+    async fn close_agent_session_reconciles_on_clean_exit() {
+        let repo = tempfile::tempdir().unwrap();
+        let init = kin_core::init(repo.path()).unwrap();
+        let layout = init.layout;
+        let session_dir = layout.root().join("runs/session-agent-clean");
+        let updated = "pub fn agent_edit() -> &'static str { \"ok\" }\n";
+        std::fs::create_dir_all(session_dir.join("src")).unwrap();
+        std::fs::write(session_dir.join("src/lib.rs"), updated).unwrap();
+
+        let mut stderr = Vec::new();
+        close_agent_session(&layout, &session_dir, 0, &mut stderr)
+            .await
+            .unwrap();
+
+        assert!(
+            !session_dir.exists(),
+            "clean agent exit should reconcile and remove the session workspace"
+        );
+        assert_eq!(
+            std::fs::read_to_string(repo.path().join("src/lib.rs")).unwrap(),
+            updated
+        );
+    }
+
+    #[tokio::test]
+    async fn close_agent_session_preserves_workspace_on_failure() {
+        let repo = tempfile::tempdir().unwrap();
+        let init = kin_core::init(repo.path()).unwrap();
+        let layout = init.layout;
+        let session_dir = layout.root().join("runs/session-agent-fail");
+        std::fs::create_dir_all(&session_dir).unwrap();
+        std::fs::write(session_dir.join("partial.txt"), "half-done\n").unwrap();
+
+        let mut stderr = Vec::new();
+        close_agent_session(&layout, &session_dir, 1, &mut stderr)
+            .await
+            .unwrap();
+
+        let output = String::from_utf8(stderr).unwrap();
+        assert!(output.contains("session workspace kept"));
+        assert!(output.contains("kin reconcile agent-fail --cleanup"));
+        assert!(output.contains("rm -rf"));
+        assert!(session_dir.join("partial.txt").exists());
+        assert!(
+            !repo.path().join("partial.txt").exists(),
+            "failed agent session must not auto-reconcile"
+        );
     }
 }

--- a/crates/kin-cli/src/main.rs
+++ b/crates/kin-cli/src/main.rs
@@ -549,13 +549,18 @@ enum Command {
         #[command(subcommand)]
         action: VerifyAction,
     },
-    /// Execute a command in a materialized workspace
+    /// Run a command in a graph-backed session workspace
+    #[command(visible_alias = "run")]
     Exec {
-        /// Command to execute
-        command: String,
-        /// Keep the workspace after execution
+        /// Command to run (put kin flags before it: `kin exec --keep -- npm test`)
+        #[arg(trailing_var_arg = true, allow_hyphen_values = true, required = true)]
+        command: Vec<String>,
+        /// Keep the session workspace after the run and defer reconcile
         #[arg(long)]
         keep: bool,
+        /// Discard all workspace changes after the run (no reconcile)
+        #[arg(long, conflicts_with = "keep")]
+        discard: bool,
         /// Materialization strategy
         #[arg(long)]
         strategy: Option<String>,
@@ -747,6 +752,11 @@ enum Command {
     With {
         /// Assistant to launch: claude, codex, gemini
         assistant: String,
+        /// Launch inside a graph-backed session workspace: the assistant starts
+        /// with its cwd in the session, receives session/daemon env, and its
+        /// changes reconcile into the graph on a successful exit
+        #[arg(long)]
+        session: bool,
         /// Pass the raw task only; keep AGENTS/bootstrap docs on disk but do not inject prompt guidance
         #[arg(long)]
         passive_guidance: bool,
@@ -2259,9 +2269,10 @@ fn main() -> Result<()> {
                 Command::Exec {
                     command,
                     keep,
+                    discard,
                     strategy,
                     scope,
-                } => commands::exec::run_full(command, keep, strategy, scope).await,
+                } => commands::exec::run_full(command, keep, discard, strategy, scope).await,
                 Command::Telemetry { action } => match action {
                     TelemetryAction::Status => commands::telemetry::run_status().await,
                     TelemetryAction::Consent => commands::telemetry::run_consent().await,
@@ -2493,6 +2504,7 @@ fn main() -> Result<()> {
                 }
                 Command::With {
                     assistant,
+                    session,
                     passive_guidance,
                     restrict_discovery,
                     restrict_filesystem,
@@ -2501,6 +2513,7 @@ fn main() -> Result<()> {
                     commands::with::run(
                         assistant,
                         task,
+                        session,
                         passive_guidance,
                         restrict_discovery,
                         restrict_filesystem,

--- a/docs/mcp-tools.md
+++ b/docs/mcp-tools.md
@@ -28,7 +28,7 @@ small curated surface below instead of the full internal one):
   "mcpServers": {
     "kin": {
       "command": "kin",
-      "args": ["mcp", "start", "--global"],
+      "args": ["mcp", "start"],
       "env": { "KIN_MCP_TOOL_PROFILE": "agent-default" }
     }
   }

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -170,6 +170,23 @@ Inspect changes at the level of entities rather than raw lines:
 kin diff
 ```
 
+### Run your normal tools
+
+Ordinary project commands run through a graph-backed **session workspace** — the
+venv-like execution contract, so you never need to know which files are
+materialized before running the repo:
+
+```sh
+kin exec -- npm test          # one-shot command (alias: kin run)
+kin shell                     # interactive shell in a session workspace
+kin with --session claude -- "fix the failing test"   # agent inside a session
+```
+
+On success the session reconciles back into the graph (generated dirs like
+`node_modules/` are skipped by policy); on failure the workspace is preserved
+with recovery commands. See [Session Runtime](session-runtime.md) for the full
+contract, closeout flags, and Docker/Compose caveats.
+
 ---
 
 ## 6. Semantic exploration and retrieval
@@ -230,7 +247,7 @@ The wizard writes this entry to each client:
   "mcpServers": {
     "kin": {
       "command": "kin",
-      "args": ["mcp", "start", "--global"],
+      "args": ["mcp", "start"],
       "env": { "KIN_MCP_TOOL_PROFILE": "agent-default" }
     }
   }
@@ -324,7 +341,7 @@ server to your client's config by hand. Match the wizard exactly — including t
   "mcpServers": {
     "kin": {
       "command": "kin",
-      "args": ["mcp", "start", "--global"],
+      "args": ["mcp", "start"],
       "env": { "KIN_MCP_TOOL_PROFILE": "agent-default" }
     }
   }
@@ -342,7 +359,11 @@ Config file locations the wizard targets (and `kin setup status` inspects):
 | Windsurf | `~/.codeium/windsurf/mcp_config.json` |
 
 `kin mcp start` launches the MCP **stdio** server. You normally do not run this by hand —
-your AI client launches it as a subprocess via the config above.
+your AI client launches it as a subprocess via the config above. The server binds
+per invocation: it uses `KIN_DAEMON_URL` when set (agent sessions launched with
+`kin with --session` pin it), and otherwise resolves the repository by walking up
+from the working directory — so each agent session talks to the daemon of the
+repository it is actually working in.
 
 ### npm wrapper (`@kinlab/kin-mcp`)
 

--- a/docs/session-runtime.md
+++ b/docs/session-runtime.md
@@ -1,0 +1,175 @@
+# Session Runtime: Running Ordinary Tools and Agents in a Kin Repository
+
+Kin's session runtime is the venv-like execution contract for a Kin repository:
+you (or an agent) run normal project commands — `npm test`, `make`,
+`docker compose config`, an editor, a coding assistant — without knowing which
+files are graph-owned, projected, or materialized. Kin materializes graph truth
+into a **session workspace**, the tool runs there like in any ordinary checkout,
+and Kin reconciles the results back into the semantic graph when the session
+ends.
+
+Three surfaces share this contract:
+
+| Surface | What it is | When to use it |
+| --- | --- | --- |
+| `kin exec -- <cmd>` (alias `kin run`) | One-shot command in a fresh session workspace | `kin exec -- npm test`, `kin run -- make build` |
+| `kin shell` | Interactive shell inside a session workspace | exploratory work, multiple commands in one session |
+| `kin with --session <assistant> -- <task>` | AI assistant launched inside a session workspace | agent work that should start Kin-native |
+| `kin open <editor>` | Editor launched into a session workspace | human editing sessions |
+
+`kin setup` is **not** part of this contract: it is one-time configuration that
+installs Kin's MCP server entry into your AI clients (Claude Code, Cursor,
+Codex, Gemini, Windsurf) and your shell hook. In short:
+
+- **`kin setup`** — configure clients once (MCP install, shell hook).
+- **`kin exec` / `kin shell`** — run ordinary commands through a session workspace.
+- **`kin with`** — launch an assistant; add `--session` to start it inside a
+  session workspace with session-coherent MCP.
+
+## The execution contract
+
+1. **Materialize.** The repo daemon materializes graph-owned truth into
+   `.kin/runs/session-<id>/`. This is a real directory containing real files —
+   any tool works unchanged. Scoped materialization (`--scope file:<path>`,
+   `--scope entity:<name>`) materializes a subset; `entity:` scopes are
+   resolved against the graph and fail loudly if the entity does not exist.
+2. **Run.** The command executes locally in that workspace (never through the
+   daemon), with `KIN_SESSION`, `KIN_SESSION_ID`, and `KIN_SESSION_DIR` set.
+3. **Reconcile.** On success, Kin diffs the workspace against the source
+   surface and reconciles changes into the graph, then removes the workspace.
+4. **Fail loud, lose nothing.** On a non-zero exit — or if reconcile itself
+   fails — the workspace is **preserved** and Kin prints the recovery
+   commands:
+
+   ```
+   Command failed; session workspace kept at: .kin/runs/session-<id>
+   To reconcile its changes anyway: kin reconcile <id> --cleanup
+   To discard it: rm -rf .kin/runs/session-<id>
+   ```
+
+`kin doctor` reports leftover session workspaces and the same recovery
+commands under its **Session runtime** check.
+
+### Closeout flags (`kin exec`)
+
+- default — reconcile on success, clean up; preserve on failure.
+- `--keep` — keep the workspace and defer reconcile (`kin reconcile <id>
+  --cleanup` when ready).
+- `--discard` — throw the workspace away without reconciling (pure scratch
+  run).
+
+Put kin flags **before** the command; everything after belongs to the command:
+`kin exec --keep -- npm run build`.
+
+### Generated files and tool output
+
+Reconcile skips generated and vendored directories by policy —
+`node_modules/`, `target/`, `__pycache__/`, `vendor/`, `.next/`, `dist/`,
+`build/`, `out/`, and hidden directories. So:
+
+- `kin exec -- npm install` reconciles `package-lock.json` but never imports
+  `node_modules/` into the graph.
+- `kin exec -- make build` reconciles source changes but not `build/` output.
+
+Anything outside the skip list that the tool writes **is** treated as a real
+change and reconciled on success. Use `--discard` for runs whose outputs you
+do not want, or `--keep` to inspect before reconciling.
+
+### External tools and scoped execution
+
+Some tools read far more than the files you name — package managers resolve
+manifests, lockfiles, and workspaces; `make` follows arbitrary prerequisites;
+Docker sends a whole build context to the daemon. Running these in a partially
+materialized workspace produces confusing failures, so Kin detects them and
+widens scoped execution to a **full** workspace under the default
+(`workspace`) execution policy:
+
+- Docker/Podman: `docker compose`, `docker build`, `docker buildx bake`,
+  `docker-compose`, `podman …`
+- Make: `make`, `gmake`
+- Package managers: `npm`, `npx`, `pnpm`, `pnpx`, `yarn`, `bun`, `bunx`,
+  `corepack`
+
+Under the `strict` policy Kin refuses instead of widening, and tells you to
+drop `--scope` or switch policy. Either way the decision is printed — scoped
+materialization never silently surprises you.
+
+## Docker and Compose caveats
+
+Container workflows cross a process boundary (the Docker daemon), so a few
+session-workspace realities matter:
+
+- **Build context.** `docker build` from a session workspace sends the
+  *materialized* workspace as the build context. That is graph truth — but it
+  is a copy. Absolute `COPY`/`ADD` assumptions about your repo's on-disk path
+  do not apply.
+- **Bind mounts.** `-v $(pwd):/app` style mounts point at
+  `.kin/runs/session-<id>/…`, which is **removed after successful closeout**.
+  Do not leave long-lived containers bind-mounted into a one-shot `kin exec`
+  workspace. For iterative container work, use `kin shell` (the workspace
+  lives as long as your shell) or `kin exec --keep`.
+- **Daemon-side writes.** Files written by containers into bind mounts land in
+  the session workspace and follow normal reconcile rules (generated dirs are
+  skipped; everything else reconciles on success).
+- **Safe validation.** `kin exec -- docker compose config` validates your
+  compose file against materialized graph truth without starting anything —
+  it's the recommended smoke check.
+- **Cleanup.** Kin removes the workspace, not your containers/volumes/images.
+  Stop containers that reference a session path before closeout.
+
+## Agent sessions and MCP session coherence
+
+`kin with --session <assistant> -- <task>` starts the assistant **inside** the
+session workspace:
+
+- cwd is the session workspace root, so the agent's shell commands and file
+  edits operate on materialized graph truth.
+- The environment carries the session identity and repo binding:
+  `KIN_SESSION` / `KIN_SESSION_ID` (session UUID), `KIN_SESSION_DIR`
+  (workspace root), `KIN_DAEMON_URL` (this repo's daemon), and `KIN_REPO_ID`
+  (repo identity).
+- Native-mode PATH shims target the session workspace, so `cat`/`rg`/`find`
+  from the agent resolve against the files it is editing.
+- On a clean exit the session reconciles into the graph and the workspace is
+  removed; on failure the workspace is preserved with recovery commands, same
+  as `kin exec`.
+
+**MCP session coherence.** The MCP server ships inside the `kin` binary
+(`kin mcp start`) and binds per invocation:
+
+1. If `KIN_DAEMON_URL` is set — which a session launch guarantees — the MCP
+   server forwards every graph tool call to exactly that daemon. No cwd
+   guessing, no stale global config.
+2. Otherwise it discovers the repository by walking up from the working
+   directory. Because agents launched with `--session` start inside
+   `.kin/runs/session-<id>`, the walk lands on the same repository's `.kin/`.
+3. Each forwarded tool call carries the session id (from `KIN_SESSION_ID`) as
+   the `X-Kin-Session` header, so the daemon can serve session-scoped graph
+   state where it applies and the live HEAD graph otherwise.
+
+Semantic answers stay graph-backed throughout: `semantic_locate`,
+`get_context_pack`, `trace_data_flow`, and the other MCP tools are answered by
+the daemon's graph authority, never by grepping the materialized workspace.
+The workspace is an execution surface, not a search authority.
+
+Agent-session launches do **not** require the daemon's remote command
+execution endpoint, which stays disabled unless an operator explicitly opts in
+with `KIN_DAEMON_ALLOW_EXEC=1`.
+
+## Recovery reference
+
+| Situation | What Kin does | Your move |
+| --- | --- | --- |
+| Command/agent succeeded | reconcile + clean up | nothing |
+| Command/agent failed | keep workspace, print recovery | fix and rerun, or `kin reconcile <id> --cleanup`, or `rm -rf` |
+| Reconcile failed | keep workspace, print recovery | `kin reconcile <id>` after resolving, then clean up |
+| Ran with `--keep` | keep workspace, defer reconcile | `kin reconcile <id> --cleanup` when ready |
+| Ran with `--discard` | delete workspace, no reconcile | nothing |
+| Not sure what's pending | — | `kin doctor` lists leftover session workspaces |
+
+One reconcile semantic to know: reconcile diffs the **entire workspace** against
+the current source surface — it is a state sync, not a change-set replay. A
+workspace kept around while the repo moves on will, when reconciled later,
+also revert whatever changed in the meantime (including deleting files created
+after the workspace was materialized). Reconcile kept workspaces promptly, or
+discard them.

--- a/llms.txt
+++ b/llms.txt
@@ -17,6 +17,7 @@ Kin coexists with Git and projects graph-owned truth back to a normal filesystem
 - `kin setup` — configure your shell and connect agents (Claude, Cursor, Codex, Gemini) to the MCP server.
 - `kin doctor` — verify the install and daemon health.
 - `kin init` turns a Git repo into a Kin workspace. `kin status` and `kin search` require the bundled `kin-daemon` runtime (installed by every channel above).
+- `kin exec -- <cmd>` (alias `kin run`) runs ordinary project tools (npm, make, docker) through a graph-backed session workspace; `kin shell` opens an interactive one; `kin with --session <assistant>` launches an agent inside one.
 
 ## For AI agents (MCP)
 


### PR DESCRIPTION
## What this is

Kin's session runtime is now a product-grade, venv-like execution contract: people and agents run **normal project commands** from a Kin repository without knowing which files are graph-owned, projected, or materialized — and agents launch **already inside** that contract, with their MCP tools bound to the same repository and session.

## The blessed command contract

| Surface | Role |
| --- | --- |
| `kin exec -- <cmd>` (new alias `kin run`) | one-shot command in a graph-backed session workspace |
| `kin shell` | interactive session workspace |
| `kin with --session <assistant> -- <task>` | agent launched inside a session workspace |
| `kin setup` | one-time MCP/client configuration (not an execution surface) |

`kin exec` previously routed through the daemon's remote-exec endpoint, which is (correctly) disabled by default — so the command dead-ended out of the box. It now materializes the workspace **through the daemon** (graph truth stays the authority) and runs the command **locally**:

- success → session reconciles into the graph, workspace cleaned up; generated dirs (`node_modules/`, `target/`, `dist/`, …) are excluded by the reconcile skip policy, so `kin exec -- npm install` reconciles `package-lock.json` but never imports `node_modules/`
- failure → exit code propagates, workspace preserved, recovery commands printed (`kin reconcile <id> --cleanup` / `rm -rf …`)
- `--keep` defers reconcile; `--discard` skips it (scratch runs)
- the daemon's remote-exec capability stays gated behind `KIN_DAEMON_ALLOW_EXEC` and is not needed for any of this

External-tool detection now covers package managers (`npm`, `npx`, `pnpm`, `pnpx`, `yarn`, `bun`, `bunx`, `corepack`) in addition to Docker/Compose/make, so scoped runs widen to a full workspace predictably (or refuse under `strict`) instead of surprising the tool with a partial checkout.

## Agent session launches + MCP session coherence

`kin with --session claude|codex|gemini -- <task>` launches the assistant with:

- **cwd = the session workspace** (materialized graph truth), PATH shims targeting the same workspace
- **session identity env**: `KIN_SESSION`, `KIN_SESSION_ID`, `KIN_SESSION_DIR`
- **repo binding env**: `KIN_DAEMON_URL` (pinned once at launch), `KIN_REPO_ID`
- clean exit → session reconciles into the graph; failure → workspace preserved with recovery commands

MCP coherence is mechanical, not aspirational: the MCP server ships in the `kin` binary; `kin mcp start` prefers `KIN_DAEMON_URL` (which the session launch pins) and otherwise resolves the repo by walking up from cwd — which for a session launch is inside the repo's own `.kin/runs/`. Every forwarded tool call carries the session id as the `X-Kin-Session` header, so the daemon can serve session-scoped graph state where applicable. Semantic answers stay graph-backed; the materialized workspace is an execution surface, never a search authority.

**Fixes a real breakage:** `kin setup` wrote MCP entries invoking `kin mcp start --global`, a mode the server refuses at startup — agents got a dead kin MCP server. Entries are now single-repo (`kin mcp start`), `kin doctor` flags legacy `--global` entries as misconfigured, and `kin doctor --fix` repairs them.

## Docs, doctor, and guardrails

- new `docs/session-runtime.md`: the execution contract, closeout flags, generated-file policy, Docker/Compose caveats (build context, bind mounts into ephemeral workspaces, daemon-side writes, cleanup), and the reconcile state-sync semantic
- `kin doctor` gains a **Session runtime** check that teaches the commands and reports leftover session workspaces with recovery steps
- session-workspace materialization now resolves `entity:`/`artifact:` scopes against graph truth for all session surfaces and fails loudly on unknown entities instead of silently widening
- quickstart + llms.txt updated; zero file-search invariant script passes

## Verification

- `cargo fmt --check`, clippy (CI allowlist, `-D warnings`), `cargo build --all-targets --locked`, `cargo test --workspace --locked` — all green locally
- new smoke tests: fake `npm` (lockfile reconciles, `node_modules` ignored, workspace cleaned), fake `make` failure (workspace preserved + recovery text), fake `docker compose config` (runs against materialized workspace), fake `claude` session launch (asserts cwd = session workspace and the full session/daemon env), closeout matrix for keep/discard/failure paths
- live validation on a scratch repo with a real daemon: `kin exec` materialize → run → reconcile → cleanup; failure path preserves the workspace and the printed `kin reconcile <id> --cleanup` recovery command works; exit codes propagate; `kin doctor` renders the new check
