### PR TITLE
ci(sast): install the pinned toolchain inside the cargo-deny container

### DIFF
--- a/.github/workflows/sast.yml
+++ b/.github/workflows/sast.yml
@@ -28,7 +28,11 @@ jobs:
           grep -q '^\[registries\.kin\]' .cargo/config.toml
           if grep -q '^\[patch\.kin\]' .cargo/config.toml; then echo "::error::[patch.kin] git pins must be removed — kin-* resolve from the Kin registry"; exit 1; fi
 
+      - name: Read pinned toolchain channel
+        id: toolchain
+        run: echo "channel=$(sed -n 's/^channel = "\(.*\)"/\1/p' rust-toolchain.toml)" >> "$GITHUB_OUTPUT"
+
       - name: Run cargo-deny
         uses: EmbarkStudios/cargo-deny-action@v2
         with:
-          rust-version: stable
+          rust-version: ${{ steps.toolchain.outputs.channel }}


### PR DESCRIPTION
The SAST job has been red on every recent main push: cargo-deny-action@v2 runs in a musl container, where the repo toolchain pin resolves to 1.96.0-x86_64-unknown-linux-musl — a toolchain the container never installs (its rust-version input said stable). This reads the pinned channel out of rust-toolchain.toml and installs exactly that inside the container, restoring the SAST signal and making the pin impossible to drift from.

Validation: this branch push itself triggers the SAST workflow with the fix applied.
