### PR TITLE
deps: bump anyhow 1.0.102 -> 1.0.103

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -162,9 +162,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.102"
+version = "1.0.103"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
+checksum = "2a4385e2e34eb35d6b3efe798b9eb88096925d87726c0798709bf56d9ed84af3"
 
 [[package]]
 name = "arbitrary"


### PR DESCRIPTION
## What this is

A lockfile-only bump of `anyhow` to 1.0.103, within the workspace's existing `anyhow = "1"` requirement.

## Why now

The RustSec advisory **RUSTSEC-2026-0190** (unsound `Error::downcast_mut()`, patched in 1.0.103) is now in the advisory database, so the cargo-deny `advisories` gate fails on **every** branch in this repo — including all currently open PRs — regardless of their content. This unblocks the whole queue.

## Verification

- `cargo deny check advisories` → `advisories ok` locally after the bump (failed before)
- `cargo check` clean; no source changes, no requirement changes, registry source + checksum preserved in the lock entry

Recommend merging this ahead of the queue, then re-running cargo-deny on open PRs.
