### PR TITLE
feat(review): shadow-mode merge gate report

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -162,9 +162,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.102"
+version = "1.0.103"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
+checksum = "2a4385e2e34eb35d6b3efe798b9eb88096925d87726c0798709bf56d9ed84af3"
 
 [[package]]
 name = "arbitrary"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3193,6 +3193,7 @@ dependencies = [
  "kin-context",
  "kin-core",
  "kin-db",
+ "kin-git",
  "kin-model",
  "kin-parser",
  "kin-ranking",

--- a/crates/kin-cli/src/commands/review.rs
+++ b/crates/kin-cli/src/commands/review.rs
@@ -18,6 +18,15 @@ pub enum ReviewRequest {
         #[serde(default)]
         json: bool,
     },
+    Shadow {
+        base: String,
+        head: String,
+        title: Option<String>,
+        source_url: Option<String>,
+        author: Option<String>,
+        #[serde(default)]
+        json: bool,
+    },
     Create {
         title: String,
         base: String,
@@ -168,6 +177,19 @@ pub async fn execute_review_request(
             )?,
             mutated: false,
         }),
+        ReviewRequest::Shadow {
+            base,
+            head,
+            title,
+            source_url,
+            author,
+            json,
+        } => Ok(ReviewExecution {
+            response: build_shadow_run_response(
+                layout, graph, base, head, title, source_url, author, json,
+            )?,
+            mutated: false,
+        }),
         ReviewRequest::Create {
             title,
             base,
@@ -254,6 +276,56 @@ fn build_review_run_response(
     }
 
     Ok(ReviewResponse { text, json: None })
+}
+
+#[allow(clippy::too_many_arguments)]
+fn build_shadow_run_response(
+    layout: &kin_core::KinLayout,
+    graph: &kin_db::InMemoryGraph,
+    base: String,
+    head: String,
+    title: Option<String>,
+    source_url: Option<String>,
+    author: Option<String>,
+    json: bool,
+) -> Result<ReviewResponse> {
+    let resolved_base = crate::commands::ref_lookup::resolve_ref_importing_git_if_needed(
+        graph,
+        layout,
+        Some(base.as_str()),
+    )
+    .with_context(|| format!("resolve shadow base ref '{}'", base))?;
+    let resolved_head = crate::commands::ref_lookup::resolve_ref_importing_git_if_needed(
+        graph,
+        layout,
+        Some(head.as_str()),
+    )
+    .with_context(|| format!("resolve shadow head ref '{}'", head))?;
+
+    let request = kin_review::ShadowRequest {
+        base_ref: base,
+        head_ref: head,
+        resolved_base,
+        resolved_head,
+        title,
+        source_url,
+        author,
+        actor: crate::provenance::current_actor_label(),
+    };
+
+    let report = kin_review::build_shadow_report(graph, &request)?;
+
+    if json {
+        return Ok(ReviewResponse {
+            text: String::new(),
+            json: Some(serde_json::to_string_pretty(&report)?),
+        });
+    }
+
+    Ok(ReviewResponse {
+        text: kin_review::format_shadow_report(&report),
+        json: None,
+    })
 }
 
 fn compute_review(
@@ -485,6 +557,28 @@ fn parse_change_ids(change_csv: &str) -> Result<Vec<kin_model::SemanticChangeId>
 // ── Review mutation subcommands (Phase 11) ──
 // These depend on kin_model::review types being added by a teammate.
 // Structurally complete; will compile once kin-model review types land.
+
+pub async fn shadow_report(
+    base: String,
+    head: String,
+    title: Option<String>,
+    source_url: Option<String>,
+    author: Option<String>,
+    json: bool,
+) -> Result<()> {
+    print_review_response(
+        run_daemon_review(&ReviewRequest::Shadow {
+            base,
+            head,
+            title,
+            source_url,
+            author,
+            json,
+        })
+        .await?,
+    );
+    Ok(())
+}
 
 pub async fn create_review(
     title: String,

--- a/crates/kin-cli/src/main.rs
+++ b/crates/kin-cli/src/main.rs
@@ -1115,6 +1115,32 @@ enum IntentAction {
 
 #[derive(Subcommand)]
 enum ReviewAction {
+    /// Shadow-mode merge gate: evaluate a PR-shaped change and emit a
+    /// report-only verdict with blast radius, repair context, and audit
+    /// evidence. Never blocks and never mutates graph state.
+    Shadow {
+        /// Change range as <base>..<head>. Refs accept branch names,
+        /// semantic change IDs, and imported Git commit SHAs.
+        range: Option<String>,
+        /// Base ref (alternative to the positional range)
+        #[arg(long)]
+        base: Option<String>,
+        /// Head ref (alternative to the positional range)
+        #[arg(long)]
+        head: Option<String>,
+        /// Change title for the report (e.g. PR title)
+        #[arg(long)]
+        title: Option<String>,
+        /// Source URL for the report (e.g. PR URL)
+        #[arg(long = "source-url")]
+        source_url: Option<String>,
+        /// Change author identity for the report
+        #[arg(long)]
+        author: Option<String>,
+        /// Emit the report as machine-readable JSON
+        #[arg(long, default_value_t = false)]
+        json: bool,
+    },
     /// Create a new review
     Create {
         /// Review title
@@ -2072,6 +2098,37 @@ fn main() -> Result<()> {
                 } => {
                     if let Some(review_action) = action {
                         match review_action {
+                            ReviewAction::Shadow {
+                                range,
+                                base,
+                                head,
+                                title,
+                                source_url,
+                                author,
+                                json,
+                            } => {
+                                let (base, head) = match (range, base, head) {
+                                    (Some(range), None, None) => match range.split_once("..") {
+                                        Some((base, head))
+                                            if !base.is_empty() && !head.is_empty() =>
+                                        {
+                                            (base.to_string(), head.to_string())
+                                        }
+                                        _ => anyhow::bail!(
+                                            "invalid range '{}': expected <base>..<head>",
+                                            range
+                                        ),
+                                    },
+                                    (None, Some(base), Some(head)) => (base, head),
+                                    _ => anyhow::bail!(
+                                        "provide a <base>..<head> range or both --base and --head"
+                                    ),
+                                };
+                                commands::review::shadow_report(
+                                    base, head, title, source_url, author, json,
+                                )
+                                .await
+                            }
                             ReviewAction::Create {
                                 title,
                                 base,
@@ -2642,6 +2699,14 @@ mod tests {
 
     #[test]
     fn cli_definition_is_valid() {
-        Cli::command().debug_assert();
+        // clap's debug_assert recurses over the full command tree, which has
+        // outgrown the default 2 MiB test-thread stack; give it a dedicated
+        // thread with room to validate every subcommand.
+        std::thread::Builder::new()
+            .stack_size(16 * 1024 * 1024)
+            .spawn(|| Cli::command().debug_assert())
+            .expect("spawn cli validation thread")
+            .join()
+            .expect("cli definition validation must succeed");
     }
 }

--- a/crates/kin-cli/src/provenance.rs
+++ b/crates/kin-cli/src/provenance.rs
@@ -60,7 +60,7 @@ where
     Ok(event.event_id)
 }
 
-fn current_actor_label() -> String {
+pub(crate) fn current_actor_label() -> String {
     std::env::var("KIN_ACTOR")
         .ok()
         .filter(|value| !value.trim().is_empty())

--- a/crates/kin-cli/tests/review_shadow_json.rs
+++ b/crates/kin-cli/tests/review_shadow_json.rs
@@ -1,0 +1,269 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Firelock, LLC
+
+//! End-to-end proof of the shadow-mode merge gate: a PR-shaped change (two
+//! Git commits) goes in, one report comes out with a non-empty graph-proven
+//! blast radius, a report-only verdict, and audit evidence. Also proves the
+//! fail-loud contract: a change the graph cannot see must surface as an
+//! explicit evidence gap, never as a silent pass.
+
+use serde_json::Value;
+use std::path::Path;
+use std::process::Command;
+use tempfile::tempdir;
+
+mod common;
+
+fn kin_command() -> Command {
+    let mut cmd = Command::new(env!("CARGO_BIN_EXE_kin"));
+    cmd.env("KIN_DAEMON_BIN", common::fresh_daemon_bin());
+    cmd
+}
+
+fn run_git(repo: &Path, args: &[&str]) {
+    let output = Command::new("git")
+        .args(args)
+        .current_dir(repo)
+        .output()
+        .expect("run git");
+    assert!(
+        output.status.success(),
+        "git {:?} failed: stdout={} stderr={}",
+        args,
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+}
+
+fn git_head(repo: &Path) -> String {
+    let output = Command::new("git")
+        .args(["rev-parse", "HEAD"])
+        .current_dir(repo)
+        .output()
+        .expect("git rev-parse HEAD");
+    assert!(output.status.success(), "git rev-parse HEAD failed");
+    String::from_utf8(output.stdout)
+        .expect("utf8 git head")
+        .trim()
+        .to_string()
+}
+
+/// Fixture: base commit defines `compute_total` with a cross-file consumer
+/// `render_invoice`; head commit changes `compute_total`'s signature; a
+/// third commit touches only an unparsed artifact (YAML).
+fn setup_fixture_repo(repo: &Path) -> (String, String, String) {
+    std::fs::create_dir_all(repo.join("src")).expect("create src");
+    std::fs::write(
+        repo.join("src/billing.rs"),
+        "pub fn compute_total(amount: u64) -> u64 {\n    amount + fee()\n}\n\nfn fee() -> u64 {\n    3\n}\n",
+    )
+    .expect("write billing.rs");
+    std::fs::write(
+        repo.join("src/invoice.rs"),
+        "use crate::billing::compute_total;\n\npub fn render_invoice(amount: u64) -> String {\n    format!(\"total: {}\", compute_total(amount))\n}\n",
+    )
+    .expect("write invoice.rs");
+    std::fs::write(
+        repo.join("src/lib.rs"),
+        "pub mod billing;\npub mod invoice;\n",
+    )
+    .expect("write lib.rs");
+
+    run_git(repo, &["init"]);
+    run_git(repo, &["config", "user.email", "shadow-test@example.com"]);
+    run_git(repo, &["config", "user.name", "Shadow Test"]);
+    run_git(repo, &["add", "-A"]);
+    run_git(repo, &["commit", "-m", "base: billing and invoice"]);
+    let base = git_head(repo);
+
+    std::fs::write(
+        repo.join("src/billing.rs"),
+        "pub fn compute_total(amount: u64, currency: &str) -> u64 {\n    let _ = currency;\n    amount + fee()\n}\n\nfn fee() -> u64 {\n    3\n}\n",
+    )
+    .expect("rewrite billing.rs");
+    run_git(repo, &["add", "-A"]);
+    run_git(
+        repo,
+        &["commit", "-m", "head: change compute_total signature"],
+    );
+    let head = git_head(repo);
+
+    std::fs::write(repo.join("policy.yaml"), "gate:\n  mode: shadow\n").expect("write yaml");
+    run_git(repo, &["add", "-A"]);
+    run_git(repo, &["commit", "-m", "artifact: add policy config"]);
+    let artifact_head = git_head(repo);
+
+    (base, head, artifact_head)
+}
+
+fn kin_init(repo: &Path) {
+    let init = kin_command()
+        .arg("init")
+        .current_dir(repo)
+        .output()
+        .expect("run kin init");
+    assert!(
+        init.status.success(),
+        "kin init failed: stdout={} stderr={}",
+        String::from_utf8_lossy(&init.stdout),
+        String::from_utf8_lossy(&init.stderr)
+    );
+}
+
+fn run_shadow_json(repo: &Path, base: &str, head: &str) -> Value {
+    let output = kin_command()
+        .args(["review", "shadow", &format!("{base}..{head}"), "--json"])
+        .arg("--title")
+        .arg("Shadow gate smoke")
+        .current_dir(repo)
+        .output()
+        .expect("run kin review shadow");
+    assert!(
+        output.status.success(),
+        "kin review shadow failed: stdout={} stderr={}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+    serde_json::from_slice(&output.stdout).expect("shadow report must be valid JSON on stdout")
+}
+
+#[test]
+fn shadow_report_end_to_end_change_in_report_out() {
+    let dir = tempdir().expect("tempdir");
+    let repo = dir.path();
+    let (base, head, _artifact_head) = setup_fixture_repo(repo);
+    kin_init(repo);
+
+    let report = run_shadow_json(repo, &base, &head);
+
+    // Contract identity: report-only shadow payload, v1.
+    assert_eq!(report["schema_version"], 1);
+    assert_eq!(report["mode"], "shadow");
+    assert_eq!(report["policy"]["enforcement"], "report_only");
+
+    // Input echo resolves both refs to semantic changes.
+    assert_eq!(report["input"]["base_ref"], Value::String(base.clone()));
+    assert_eq!(report["input"]["head_ref"], Value::String(head.clone()));
+    assert!(!report["input"]["resolved_base"]
+        .as_str()
+        .unwrap()
+        .is_empty());
+    assert!(!report["input"]["resolved_head"]
+        .as_str()
+        .unwrap()
+        .is_empty());
+
+    // The changed entity is captured with its signature change.
+    let changed = report["changed_entities"].as_array().unwrap();
+    assert!(
+        changed
+            .iter()
+            .any(|entity| entity["name"] == "compute_total"
+                && entity["change"] == "modified"
+                && entity["signature_changed"] == true),
+        "compute_total signature change must be captured: {changed:?}"
+    );
+
+    // Non-empty, graph-proven blast radius including the cross-file consumer.
+    let radius = &report["blast_radius"];
+    assert!(radius["total_affected"].as_u64().unwrap() >= 1);
+    let dependents = radius["dependents"].as_array().unwrap();
+    assert!(
+        dependents
+            .iter()
+            .any(|dependent| dependent["name"] == "render_invoice"),
+        "cross-file consumer render_invoice must appear in the blast radius: {dependents:?}"
+    );
+
+    // The gate reports what it WOULD do; a contract-surface change with
+    // downstream entities must not pass silently.
+    let verdict = report["policy"]["verdict"].as_str().unwrap();
+    assert!(
+        verdict == "would_block" || verdict == "needs_attention",
+        "signature change with dependents must not pass: {verdict}"
+    );
+    assert!(!report["policy"]["findings"].as_array().unwrap().is_empty());
+
+    // Repair context exists for the findings.
+    assert!(!report["repair_context"].as_array().unwrap().is_empty());
+
+    // Audit evidence: who/what/when + graph state identity.
+    let audit = &report["audit"];
+    for key in [
+        "generated_at",
+        "actor",
+        "actor_kind",
+        "tool",
+        "tool_version",
+        "base_change",
+        "head_change",
+    ] {
+        assert!(
+            !audit[key]
+                .as_str()
+                .map(str::to_owned)
+                .unwrap_or_default()
+                .is_empty()
+                || audit[key].is_number(),
+            "audit.{key} must be present and non-empty: {audit:?}"
+        );
+    }
+    assert_eq!(audit["tool"], "kin-review");
+    assert!(audit["changes_in_range"].as_u64().unwrap() >= 1);
+
+    // Cross-repo scope is labeled explicitly, never silently implied.
+    assert_eq!(radius["cross_repo"]["status"], "not_evaluated");
+    let gaps = report["evidence_gaps"].as_array().unwrap();
+    assert!(gaps
+        .iter()
+        .any(|gap| gap["kind"] == "cross_repo_not_evaluated"));
+}
+
+#[test]
+fn shadow_report_fails_loud_on_unparsed_artifact_change() {
+    let dir = tempdir().expect("tempdir");
+    let repo = dir.path();
+    let (_base, head, artifact_head) = setup_fixture_repo(repo);
+    kin_init(repo);
+
+    let report = run_shadow_json(repo, &head, &artifact_head);
+
+    // The YAML-only change is invisible to the semantic graph: the report
+    // must say so explicitly instead of passing green.
+    let gaps = report["evidence_gaps"].as_array().unwrap();
+    assert!(
+        gaps.iter()
+            .any(|gap| gap["kind"] == "artifact_only_change" && gap["subject"] == "policy.yaml"),
+        "artifact-only change must surface as an explicit evidence gap: {gaps:?}"
+    );
+
+    let verdict = report["policy"]["verdict"].as_str().unwrap();
+    assert_ne!(
+        verdict, "pass",
+        "missing evidence must never certify a pass"
+    );
+}
+
+#[test]
+fn shadow_report_fails_loud_on_unknown_ref() {
+    let dir = tempdir().expect("tempdir");
+    let repo = dir.path();
+    let (_base, head, _artifact_head) = setup_fixture_repo(repo);
+    kin_init(repo);
+
+    let output = kin_command()
+        .args([
+            "review",
+            "shadow",
+            &format!("{}..{}", "0".repeat(40), head),
+            "--json",
+        ])
+        .current_dir(repo)
+        .output()
+        .expect("run kin review shadow with bogus base");
+    assert!(
+        !output.status.success(),
+        "unknown base ref must fail loud, got stdout={}",
+        String::from_utf8_lossy(&output.stdout)
+    );
+}

--- a/crates/kin-mcp/Cargo.toml
+++ b/crates/kin-mcp/Cargo.toml
@@ -10,6 +10,7 @@ description = "MCP server for Kin — assistant-neutral integration"
 
 [dependencies]
 kin-core = { workspace = true }
+kin-git = { workspace = true }
 kin-model = { workspace = true }
 kin-db = { workspace = true }
 kin-blobs = { workspace = true }

--- a/crates/kin-mcp/src/handlers/mod.rs
+++ b/crates/kin-mcp/src/handlers/mod.rs
@@ -53,6 +53,7 @@ pub async fn handle_tool_call<G: GraphStore>(
         "semantic_diff" => review::handle_semantic_diff(arguments, store),
         "impact_analysis" => review::handle_impact_analysis(arguments, store, sessions).await,
         "semantic_review" => review::handle_semantic_review(arguments, store, sessions),
+        "shadow_gate_report" => review::handle_shadow_gate_report(arguments, store),
         "entity_history" => review::handle_entity_history(arguments, store),
         // Sessions
         "register_session" => sessions::handle_register_session(arguments, sessions),

--- a/crates/kin-mcp/src/handlers/review.rs
+++ b/crates/kin-mcp/src/handlers/review.rs
@@ -4,6 +4,7 @@
 use std::collections::HashMap;
 
 use kin_model::graph::GraphStore;
+use kin_model::ids::SemanticChangeId;
 use kin_review::{format_review, SemanticReview};
 
 use crate::error::{McpError, Result};
@@ -200,6 +201,108 @@ fn collect_review_traffic_lines(
         }
     }
     traffic_lines
+}
+
+pub const SHADOW_GATE_REPORT_DESC: &str = "\
+Run the shadow-mode merge gate over a PR-shaped change (base ref .. head ref) and return \
+ONE report: changed entities, graph-proven blast radius, the policy verdict the gate \
+WOULD have issued (report-only — shadow mode never blocks), the repair context a reviewer \
+or agent needs to fix findings, explicit evidence gaps, and audit evidence for the \
+evaluation. Refs accept branch names and semantic change IDs; imported Git commit SHAs \
+resolve when their history has been imported into the graph. When the graph cannot prove \
+something — unparsed files, missing spans, an empty impact signal — the report says so in \
+`evidence_gaps` instead of passing silently. Reach for it to evaluate an AI-authored \
+change before merge, or to feed a merge-gate dashboard.";
+
+fn resolve_shadow_ref<G: GraphStore>(store: &G, reference: &str) -> Result<SemanticChangeId> {
+    if let Some(branch_name) = reference.strip_prefix("branch:") {
+        return resolve_shadow_branch(store, branch_name);
+    }
+
+    if let Some(change_ref) = reference
+        .strip_prefix("kin:")
+        .or_else(|| reference.strip_prefix("change:"))
+    {
+        return resolve_shadow_change(store, change_ref);
+    }
+
+    if let Some(git_oid) = reference.strip_prefix("git:") {
+        return resolve_shadow_git(store, git_oid);
+    }
+
+    if let Ok(Some(branch)) = store.get_branch(&kin_model::BranchName::new(reference)) {
+        return Ok(branch.head);
+    }
+
+    if reference.len() == 40 {
+        return resolve_shadow_git(store, reference);
+    }
+
+    resolve_shadow_change(store, reference)
+}
+
+fn resolve_shadow_branch<G: GraphStore>(store: &G, branch_name: &str) -> Result<SemanticChangeId> {
+    match store
+        .get_branch(&kin_model::BranchName::new(branch_name))
+        .map_err(McpError::graph)?
+    {
+        Some(branch) => Ok(branch.head),
+        None => Err(McpError::InvalidParams(format!(
+            "branch '{}' not found in the graph",
+            branch_name
+        ))),
+    }
+}
+
+fn resolve_shadow_change<G: GraphStore>(store: &G, change_ref: &str) -> Result<SemanticChangeId> {
+    let change_id = parse_change_id(change_ref)?;
+    match store.get_change(&change_id).map_err(McpError::graph)? {
+        Some(_) => Ok(change_id),
+        None => Err(McpError::InvalidParams(format!(
+            "change '{}' not found in the graph",
+            change_ref
+        ))),
+    }
+}
+
+fn resolve_shadow_git<G: GraphStore>(store: &G, git_oid: &str) -> Result<SemanticChangeId> {
+    let change_id = kin_git::semantic_change_id_from_git_oid_hex(git_oid)
+        .map_err(|e| McpError::InvalidParams(format!("invalid git commit '{}': {}", git_oid, e)))?;
+    match store.get_change(&change_id).map_err(McpError::graph)? {
+        Some(_) => Ok(change_id),
+        None => Err(McpError::InvalidParams(format!(
+            "imported Git commit '{}' is not in the graph; import its history first (e.g. run \
+             `kin review shadow` in the repo, which hydrates imported Git refs)",
+            git_oid
+        ))),
+    }
+}
+
+pub fn handle_shadow_gate_report<G: GraphStore>(
+    args: &HashMap<String, serde_json::Value>,
+    store: &G,
+) -> Result<ToolCallResult> {
+    let base_ref = get_string_param(args, "base")?;
+    let head_ref = get_string_param(args, "head")?;
+    let resolved_base = resolve_shadow_ref(store, &base_ref)?;
+    let resolved_head = resolve_shadow_ref(store, &head_ref)?;
+
+    let request = kin_review::ShadowRequest {
+        base_ref,
+        head_ref,
+        resolved_base,
+        resolved_head,
+        title: get_optional_string_param(args, "title"),
+        source_url: get_optional_string_param(args, "source_url"),
+        author: get_optional_string_param(args, "author"),
+        actor: get_optional_string_param(args, "actor").unwrap_or_else(|| "mcp-client".into()),
+    };
+
+    let report = kin_review::build_shadow_report(store, &request)
+        .map_err(|e| McpError::Review(e.to_string()))?;
+
+    let json = serde_json::to_string_pretty(&report).map_err(McpError::Json)?;
+    Ok(ToolCallResult::text(json))
 }
 
 pub const ENTITY_HISTORY_DESC: &str = "\
@@ -885,5 +988,39 @@ mod tests {
         let identity = parse_identity_arg(&args, "author", "author_kind", "mcp-client");
         assert_eq!(identity.name, "troy");
         assert!(matches!(identity.kind, kin_model::IdentityKind::Human));
+    }
+
+    #[test]
+    fn shadow_gate_report_fails_loud_on_unknown_base_ref() {
+        let store = kin_db::InMemoryGraph::new();
+        let mut args = HashMap::new();
+        args.insert("base".into(), serde_json::json!("branch:missing"));
+        args.insert("head".into(), serde_json::json!("branch:missing"));
+
+        let err = handle_shadow_gate_report(&args, &store).unwrap_err();
+        assert!(
+            err.to_string().contains("not found"),
+            "unknown branch must error, got: {err}"
+        );
+    }
+
+    #[test]
+    fn shadow_gate_report_fails_loud_on_unimported_git_sha() {
+        let store = kin_db::InMemoryGraph::new();
+        let mut args = HashMap::new();
+        args.insert(
+            "base".into(),
+            serde_json::json!("1111111111111111111111111111111111111111"),
+        );
+        args.insert(
+            "head".into(),
+            serde_json::json!("2222222222222222222222222222222222222222"),
+        );
+
+        let err = handle_shadow_gate_report(&args, &store).unwrap_err();
+        assert!(
+            err.to_string().contains("not in the graph"),
+            "unimported git sha must error, got: {err}"
+        );
     }
 }

--- a/crates/kin-mcp/src/tools.rs
+++ b/crates/kin-mcp/src/tools.rs
@@ -211,6 +211,22 @@ pub fn tool_definitions() -> ToolsListResult {
                 }),
             },
             ToolDefinition {
+                name: "shadow_gate_report".into(),
+                description: crate::handlers::review::SHADOW_GATE_REPORT_DESC.into(),
+                input_schema: serde_json::json!({
+                    "type": "object",
+                    "properties": {
+                        "base": { "type": "string", "description": "Base ref: branch name, semantic change ID (hex), or imported Git commit SHA" },
+                        "head": { "type": "string", "description": "Head ref: branch name, semantic change ID (hex), or imported Git commit SHA" },
+                        "title": { "type": "string", "description": "Change title for the report (e.g. PR title)" },
+                        "source_url": { "type": "string", "description": "Source URL for the report (e.g. PR URL)" },
+                        "author": { "type": "string", "description": "Change author identity for the report" },
+                        "actor": { "type": "string", "description": "Identity running the evaluation (defaults to mcp-client)" }
+                    },
+                    "required": ["base", "head"]
+                }),
+            },
+            ToolDefinition {
                 name: "dead_code".into(),
                 description: crate::handlers::entities::DEAD_CODE_DESC.into(),
                 input_schema: serde_json::json!({
@@ -959,8 +975,8 @@ mod tests {
     #[test]
     fn expected_tool_count() {
         let list = tool_definitions();
-        // 54 + 5 transaction tools + 1 semantic_locate = 60
-        assert_eq!(list.tools.len(), 60);
+        // 54 + 5 transaction tools + 1 semantic_locate + 1 shadow_gate_report = 61
+        assert_eq!(list.tools.len(), 61);
     }
 
     #[test]

--- a/crates/kin-review/src/lib.rs
+++ b/crates/kin-review/src/lib.rs
@@ -10,6 +10,7 @@ pub mod inline;
 pub mod release_gate;
 pub mod review;
 pub mod risk;
+pub mod shadow;
 
 pub use diff::{
     compute_diff, diff_from_change, diff_from_changes, diff_from_entity_ids, diff_from_files,
@@ -28,3 +29,7 @@ pub use release_gate::{
 };
 pub use review::{Review, SemanticReview};
 pub use risk::assess_risk;
+pub use shadow::{
+    build_shadow_report, format_shadow_report, ShadowGateReport, ShadowGateVerdict, ShadowRequest,
+    SHADOW_ENFORCEMENT_REPORT_ONLY, SHADOW_GATE_REPORT_SCHEMA_VERSION,
+};

--- a/crates/kin-review/src/shadow.rs
+++ b/crates/kin-review/src/shadow.rs
@@ -1,0 +1,1276 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Firelock, LLC
+
+//! Shadow-mode merge-gate report.
+//!
+//! Packages one PR-shaped change evaluation into a single payload: what
+//! changed at the entity level, the graph-proven blast radius, the policy
+//! verdict the gate would have issued, the context a reviewer or agent needs
+//! to repair findings, and the audit evidence for the evaluation itself.
+//!
+//! Shadow mode is report-only. It never blocks and never mutates graph
+//! state; a blocking verdict is reported as `would_block`.
+//!
+//! Every section is graph-derived. When the graph cannot prove something —
+//! files with no captured entities, entities without spans, an empty impact
+//! signal, cross-repo federation not evaluated — the report carries an
+//! explicit entry in `evidence_gaps` instead of passing silently.
+
+use std::collections::BTreeSet;
+
+use kin_model::entity::Entity;
+use kin_model::graph::GraphStore;
+use kin_model::ids::SemanticChangeId;
+use kin_model::timestamp::Timestamp;
+use serde::{Deserialize, Serialize};
+
+use crate::diff::EntityChangeKind;
+use crate::gate::{derive_decision, GateStatus, ReviewFinding, ReviewSignalKind};
+use crate::inline::InlineCommentKind;
+use crate::review::{Review, SemanticReview};
+use crate::ReviewError;
+
+/// Version of the shadow gate report payload schema. Mirrored by
+/// `packages/boundary-contracts/schemas/shadow-gate-report.schema.json`.
+pub const SHADOW_GATE_REPORT_SCHEMA_VERSION: u32 = 1;
+
+/// Enforcement label carried by every shadow report.
+pub const SHADOW_ENFORCEMENT_REPORT_ONLY: &str = "report_only";
+
+/// Inputs for one shadow gate evaluation.
+#[derive(Debug, Clone)]
+pub struct ShadowRequest {
+    /// Base ref exactly as supplied by the caller.
+    pub base_ref: String,
+    /// Head ref exactly as supplied by the caller.
+    pub head_ref: String,
+    /// Resolved base change.
+    pub resolved_base: SemanticChangeId,
+    /// Resolved head change.
+    pub resolved_head: SemanticChangeId,
+    /// Optional change title (e.g. PR title).
+    pub title: Option<String>,
+    /// Optional source URL (e.g. PR URL).
+    pub source_url: Option<String>,
+    /// Optional change author identity.
+    pub author: Option<String>,
+    /// Identity running the evaluation (for audit evidence).
+    pub actor: String,
+}
+
+/// Echo of the evaluated input, with resolution results.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ShadowInputEcho {
+    pub base_ref: String,
+    pub head_ref: String,
+    pub resolved_base: String,
+    pub resolved_head: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub title: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub source_url: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub author: Option<String>,
+}
+
+/// One directly changed entity.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ShadowChangedEntity {
+    pub entity_id: String,
+    pub name: String,
+    pub kind: String,
+    /// "added" | "modified" | "removed"
+    pub change: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub file: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub start_line: Option<u32>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub end_line: Option<u32>,
+    pub signature_changed: bool,
+    pub visibility_changed: bool,
+}
+
+/// One entity reached by blast-radius traversal, with the graph relationship
+/// bucket that proves why it is affected.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ShadowAffectedEntity {
+    pub entity_id: String,
+    pub name: String,
+    pub kind: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub file: Option<String>,
+    /// Relationship bucket: "calls" | "depends_on" | "consumes_contract" | "tests"
+    pub via: String,
+}
+
+/// Open work item scoped to a changed entity.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ShadowWorkItem {
+    pub work_id: String,
+    pub title: String,
+    pub status: String,
+}
+
+/// Cross-repo federation section. v1 reports single-repo blast radius only
+/// and labels the cross-repo section explicitly instead of implying coverage.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ShadowCrossRepo {
+    /// "not_evaluated" | "unavailable" | "available"
+    pub status: String,
+    pub detail: String,
+    pub nodes: Vec<ShadowCrossRepoNode>,
+}
+
+/// One cross-repo node (populated only when `status` is "available").
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ShadowCrossRepoNode {
+    pub repo_id: String,
+    pub entity_id: String,
+    pub name: String,
+}
+
+/// Graph-proven blast radius for the changed entities.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ShadowBlastRadius {
+    pub callers: Vec<ShadowAffectedEntity>,
+    pub dependents: Vec<ShadowAffectedEntity>,
+    pub contract_consumers: Vec<ShadowAffectedEntity>,
+    pub tests: Vec<ShadowAffectedEntity>,
+    pub open_work_items: Vec<ShadowWorkItem>,
+    pub total_affected: usize,
+    pub cross_repo: ShadowCrossRepo,
+}
+
+/// Gate status a shadow evaluation reports (never enforces).
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum ShadowGateVerdict {
+    Pass,
+    NeedsAttention,
+    WouldBlock,
+}
+
+/// One policy finding, anchored to source where the graph has a span.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ShadowPolicyFinding {
+    /// Machine-readable kind, e.g. "breaking", "coverage_gap".
+    pub kind: String,
+    /// "error" | "warning" | "info"
+    pub severity: String,
+    /// Whether this finding would block in enforcing mode.
+    pub blocking: bool,
+    pub message: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub file: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub line: Option<u32>,
+}
+
+/// The verdict the gate would have issued, plus its inputs.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ShadowPolicyResult {
+    /// Always "report_only" in shadow mode.
+    pub enforcement: String,
+    pub verdict: ShadowGateVerdict,
+    /// Overall risk from the risk assessment: "low" | "medium" | "high" | "critical".
+    pub risk_level: String,
+    pub blocking_count: usize,
+    pub attention_count: usize,
+    pub summary: String,
+    pub findings: Vec<ShadowPolicyFinding>,
+}
+
+/// What a reviewer or agent needs to address one finding.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ShadowRepairItem {
+    pub finding: String,
+    pub kind: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub file: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub line: Option<u32>,
+    /// Graph-known tests covering the changed entities ("name (file)").
+    pub covering_tests: Vec<String>,
+    /// Graph-known callers/consumers to check ("name (file)").
+    pub affected_consumers: Vec<String>,
+    pub guidance: String,
+}
+
+/// Explicit statement that the graph could not prove something.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ShadowEvidenceGap {
+    /// "artifact_only_change" | "missing_span" | "actor_attribution_unavailable"
+    /// | "impact_signal_absent" | "cross_repo_not_evaluated"
+    pub kind: String,
+    pub subject: String,
+    pub detail: String,
+}
+
+/// Actor attribution for one changed entity.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ShadowAttribution {
+    pub entity_id: String,
+    pub actor_kind: String,
+}
+
+/// One recorded approval on the head change.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ShadowApproval {
+    pub approver: String,
+    pub decision: String,
+    pub reason: String,
+}
+
+/// Who/what/when evidence for the evaluation itself.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ShadowAuditEvidence {
+    pub generated_at: Timestamp,
+    pub actor: String,
+    /// "human" | "assistant" | "service"
+    pub actor_kind: String,
+    pub tool: String,
+    pub tool_version: String,
+    pub base_change: String,
+    pub head_change: String,
+    pub changes_in_range: usize,
+    pub entity_attribution: Vec<ShadowAttribution>,
+    pub head_approvals: Vec<ShadowApproval>,
+}
+
+/// The complete shadow-mode merge-gate report.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ShadowGateReport {
+    pub schema_version: u32,
+    /// Always "shadow".
+    pub mode: String,
+    pub input: ShadowInputEcho,
+    pub changed_entities: Vec<ShadowChangedEntity>,
+    pub blast_radius: ShadowBlastRadius,
+    pub policy: ShadowPolicyResult,
+    pub repair_context: Vec<ShadowRepairItem>,
+    pub evidence_gaps: Vec<ShadowEvidenceGap>,
+    pub audit: ShadowAuditEvidence,
+}
+
+/// Build a shadow-mode merge-gate report for a resolved base..head range.
+///
+/// Read-only: consumes graph truth, produces a report, records nothing.
+pub fn build_shadow_report<G: GraphStore>(
+    store: &G,
+    request: &ShadowRequest,
+) -> Result<ShadowGateReport, ReviewError> {
+    let review =
+        SemanticReview::create_review(&request.resolved_base, &request.resolved_head, store)?;
+
+    let changes = store
+        .get_changes_since(&request.resolved_base, &request.resolved_head)
+        .map_err(ReviewError::graph)?;
+
+    let changed_entities = collect_changed_entities(&review);
+    let blast_radius = collect_blast_radius(&review);
+    let evidence_gaps = collect_evidence_gaps(&review, &changes, &changed_entities);
+    let policy = derive_policy(&review, &evidence_gaps);
+    let repair_context = collect_repair_context(&policy.findings, &review);
+    let audit = collect_audit_evidence(store, request, &review, changes.len())?;
+
+    Ok(ShadowGateReport {
+        schema_version: SHADOW_GATE_REPORT_SCHEMA_VERSION,
+        mode: "shadow".to_string(),
+        input: ShadowInputEcho {
+            base_ref: request.base_ref.clone(),
+            head_ref: request.head_ref.clone(),
+            resolved_base: request.resolved_base.to_string(),
+            resolved_head: request.resolved_head.to_string(),
+            title: request.title.clone(),
+            source_url: request.source_url.clone(),
+            author: request.author.clone(),
+        },
+        changed_entities,
+        blast_radius,
+        policy,
+        repair_context,
+        evidence_gaps,
+        audit,
+    })
+}
+
+fn entity_location(entity: &Entity) -> (Option<String>, Option<u32>, Option<u32>) {
+    match &entity.span {
+        Some(span) => (
+            Some(span.file.to_string()),
+            Some(span.start_line),
+            Some(span.end_line),
+        ),
+        None => (
+            entity.file_origin.as_ref().map(|file| file.to_string()),
+            None,
+            None,
+        ),
+    }
+}
+
+fn collect_changed_entities(review: &Review) -> Vec<ShadowChangedEntity> {
+    let mut changed = Vec::new();
+    for change in &review.diff.entity_changes {
+        match &change.kind {
+            EntityChangeKind::Added(entity) => {
+                let (file, start_line, end_line) = entity_location(entity);
+                changed.push(ShadowChangedEntity {
+                    entity_id: entity.id.to_string(),
+                    name: entity.name.clone(),
+                    kind: format!("{:?}", entity.kind),
+                    change: "added".to_string(),
+                    file,
+                    start_line,
+                    end_line,
+                    signature_changed: false,
+                    visibility_changed: false,
+                });
+            }
+            EntityChangeKind::Modified { old, new } => {
+                let (file, start_line, end_line) = entity_location(new);
+                changed.push(ShadowChangedEntity {
+                    entity_id: new.id.to_string(),
+                    name: new.name.clone(),
+                    kind: format!("{:?}", new.kind),
+                    change: "modified".to_string(),
+                    file,
+                    start_line,
+                    end_line,
+                    signature_changed: old.signature != new.signature,
+                    visibility_changed: old.visibility != new.visibility,
+                });
+            }
+            EntityChangeKind::Removed(id) => {
+                changed.push(ShadowChangedEntity {
+                    entity_id: id.to_string(),
+                    name: id.to_string(),
+                    kind: "unknown".to_string(),
+                    change: "removed".to_string(),
+                    file: None,
+                    start_line: None,
+                    end_line: None,
+                    signature_changed: false,
+                    visibility_changed: false,
+                });
+            }
+        }
+    }
+    changed.sort_by(|a, b| {
+        a.file
+            .cmp(&b.file)
+            .then_with(|| a.name.cmp(&b.name))
+            .then_with(|| a.entity_id.cmp(&b.entity_id))
+    });
+    changed
+}
+
+fn affected_from(entities: &[Entity], via: &str) -> Vec<ShadowAffectedEntity> {
+    let mut affected: Vec<ShadowAffectedEntity> = entities
+        .iter()
+        .map(|entity| {
+            let (file, _, _) = entity_location(entity);
+            ShadowAffectedEntity {
+                entity_id: entity.id.to_string(),
+                name: entity.name.clone(),
+                kind: format!("{:?}", entity.kind),
+                file,
+                via: via.to_string(),
+            }
+        })
+        .collect();
+    affected.sort_by(|a, b| {
+        a.file
+            .cmp(&b.file)
+            .then_with(|| a.name.cmp(&b.name))
+            .then_with(|| a.entity_id.cmp(&b.entity_id))
+    });
+    affected
+}
+
+fn collect_blast_radius(review: &Review) -> ShadowBlastRadius {
+    let impact = &review.impact;
+    let mut open_work_items: Vec<ShadowWorkItem> = impact
+        .affected_work_items
+        .iter()
+        .map(|item| ShadowWorkItem {
+            work_id: item.work_id.to_string(),
+            title: item.title.clone(),
+            status: format!("{:?}", item.status),
+        })
+        .collect();
+    open_work_items.sort_by(|a, b| a.work_id.cmp(&b.work_id));
+
+    ShadowBlastRadius {
+        callers: affected_from(&impact.affected_callers, "calls"),
+        dependents: affected_from(&impact.affected_dependents, "depends_on"),
+        contract_consumers: affected_from(&impact.affected_contract_consumers, "consumes_contract"),
+        tests: affected_from(&impact.affected_tests, "tests"),
+        open_work_items,
+        total_affected: impact.total_affected(),
+        cross_repo: ShadowCrossRepo {
+            status: "not_evaluated".to_string(),
+            detail: "cross-repo federation is not evaluated by shadow report v1; blast radius \
+                     covers this repository only"
+                .to_string(),
+            nodes: Vec::new(),
+        },
+    }
+}
+
+fn finding_kind_label(kind: InlineCommentKind) -> &'static str {
+    match kind {
+        InlineCommentKind::Breaking => "breaking",
+        InlineCommentKind::CoverageGap => "coverage_gap",
+        InlineCommentKind::ContractViolation => "contract_violation",
+        InlineCommentKind::SignatureChange => "signature_change",
+        InlineCommentKind::VisibilityChange => "visibility_change",
+        InlineCommentKind::Added => "entity_added",
+        InlineCommentKind::Removed => "entity_removed",
+        InlineCommentKind::Renamed => "entity_renamed",
+        InlineCommentKind::AgentUnreviewed => "agent_unreviewed",
+    }
+}
+
+fn finding_severity(kind: InlineCommentKind) -> &'static str {
+    match kind {
+        InlineCommentKind::Breaking | InlineCommentKind::ContractViolation => "error",
+        InlineCommentKind::CoverageGap
+        | InlineCommentKind::SignatureChange
+        | InlineCommentKind::VisibilityChange
+        | InlineCommentKind::Renamed
+        | InlineCommentKind::AgentUnreviewed => "warning",
+        InlineCommentKind::Added | InlineCommentKind::Removed => "info",
+    }
+}
+
+fn is_blocking(kind: InlineCommentKind) -> bool {
+    matches!(
+        kind,
+        InlineCommentKind::Breaking | InlineCommentKind::ContractViolation
+    )
+}
+
+/// Evidence-gap kinds that describe a deficit in what the graph could prove
+/// about THIS change. A gate cannot certify `pass` over them. Structural v1
+/// limits (cross-repo not evaluated, attribution unavailable) do not demote
+/// the verdict — they are constant framing, reported but not change-specific.
+fn gap_blocks_pass(kind: &str) -> bool {
+    matches!(
+        kind,
+        "artifact_only_change" | "missing_span" | "impact_signal_absent"
+    )
+}
+
+fn derive_policy(review: &Review, evidence_gaps: &[ShadowEvidenceGap]) -> ShadowPolicyResult {
+    let mut findings: Vec<ShadowPolicyFinding> = review
+        .inline_comments
+        .iter()
+        .map(|comment| ShadowPolicyFinding {
+            kind: finding_kind_label(comment.kind).to_string(),
+            severity: finding_severity(comment.kind).to_string(),
+            blocking: is_blocking(comment.kind),
+            message: comment.message.clone(),
+            file: Some(comment.file.clone()),
+            line: Some(comment.start_line),
+        })
+        .collect();
+
+    // Gate rule: a contract-surface change (signature/visibility/removal) with
+    // ANY graph-known downstream entity is a blocking downstream risk. The
+    // impact walker buckets incoming consumers under `dependents`, which the
+    // inline `Breaking` rule does not consult, so the gate consults the full
+    // affected set here.
+    let downstream_count = review.impact.affected_callers.len()
+        + review.impact.affected_dependents.len()
+        + review.impact.affected_contract_consumers.len();
+    if downstream_count > 0 {
+        for change in &review.diff.entity_changes {
+            let (name, location, surface_changed) = match &change.kind {
+                EntityChangeKind::Modified { old, new } => (
+                    new.name.clone(),
+                    new.span
+                        .as_ref()
+                        .map(|span| (span.file.to_string(), span.start_line)),
+                    old.signature != new.signature || old.visibility != new.visibility,
+                ),
+                EntityChangeKind::Removed(id) => (id.to_string(), None, true),
+                EntityChangeKind::Added(_) => continue,
+            };
+            if !surface_changed {
+                continue;
+            }
+            let already_blocking = findings.iter().any(|finding| {
+                finding.blocking
+                    && finding.file == location.as_ref().map(|(file, _)| file.clone())
+                    && finding.line == location.as_ref().map(|(_, line)| *line)
+            });
+            if already_blocking {
+                continue;
+            }
+            findings.push(ShadowPolicyFinding {
+                kind: "downstream_risk".to_string(),
+                severity: "error".to_string(),
+                blocking: true,
+                message: format!(
+                    "Contract surface of `{}` changed with {} graph-known downstream entity(ies)",
+                    name, downstream_count
+                ),
+                file: location.as_ref().map(|(file, _)| file.clone()),
+                line: location.as_ref().map(|(_, line)| *line),
+            });
+        }
+    }
+
+    // Informational findings (entity added/removed) describe the diff, not a
+    // gate signal; they are reported but do not feed the verdict.
+    let gate_findings: Vec<ReviewFinding> = findings
+        .iter()
+        .filter(|finding| finding.severity != "info")
+        .map(|finding| ReviewFinding {
+            kind: match finding.kind.as_str() {
+                "contract_violation" | "agent_unreviewed" => ReviewSignalKind::PolicyViolation,
+                "coverage_gap" => ReviewSignalKind::CoverageGap,
+                _ => ReviewSignalKind::DownstreamRisk,
+            },
+            title: finding.message.clone(),
+            blocking: finding.blocking,
+        })
+        .collect();
+
+    let decision = derive_decision(&gate_findings, 0);
+    let mut verdict = match decision.status {
+        GateStatus::Pass => ShadowGateVerdict::Pass,
+        GateStatus::NeedsAttention => ShadowGateVerdict::NeedsAttention,
+        GateStatus::Blocked => ShadowGateVerdict::WouldBlock,
+    };
+
+    // Missing evidence is never a pass: when the graph could not prove parts
+    // of this change, the gate reports needs_attention instead of certifying
+    // a clean result it did not actually verify.
+    let pass_blocking_gaps = evidence_gaps
+        .iter()
+        .filter(|gap| gap_blocks_pass(&gap.kind))
+        .count();
+    if verdict == ShadowGateVerdict::Pass && pass_blocking_gaps > 0 {
+        verdict = ShadowGateVerdict::NeedsAttention;
+    }
+
+    let risk_level = format!("{:?}", review.risk.overall_risk).to_lowercase();
+    let summary = match verdict {
+        ShadowGateVerdict::Pass => "no gate signals; would pass".to_string(),
+        ShadowGateVerdict::NeedsAttention if decision.attention_count == 0 => format!(
+            "{} evidence gap(s) prevent certifying a pass; evidence missing is not evidence of \
+             safety",
+            pass_blocking_gaps
+        ),
+        ShadowGateVerdict::NeedsAttention => format!(
+            "{} attention signal(s); would pass with attention",
+            decision.attention_count
+        ),
+        ShadowGateVerdict::WouldBlock => format!(
+            "{} blocking finding(s), {} attention signal(s); would block in enforcing mode",
+            decision.blocking_count, decision.attention_count
+        ),
+    };
+
+    ShadowPolicyResult {
+        enforcement: SHADOW_ENFORCEMENT_REPORT_ONLY.to_string(),
+        verdict,
+        risk_level,
+        blocking_count: decision.blocking_count,
+        attention_count: decision.attention_count,
+        summary,
+        findings,
+    }
+}
+
+fn repair_guidance(kind: &str) -> &'static str {
+    match kind {
+        "breaking" => {
+            "Update the listed consumers to the new contract or restore compatibility, then run \
+             the covering tests."
+        }
+        "contract_violation" => {
+            "The contract has graph-known consumers; version the contract or migrate every \
+             consumer in the same change."
+        }
+        "coverage_gap" => {
+            "No graph-known test covers this entity; add or link a test so the gate has proof."
+        }
+        "signature_change" => {
+            "Verify every listed caller against the new signature before merging."
+        }
+        "visibility_change" => {
+            "Confirm the visibility change is intentional; listed dependents may lose access."
+        }
+        "agent_unreviewed" => {
+            "Record a human review decision for the agent-authored change before enforcing."
+        }
+        "entity_renamed" => "Confirm references were updated for the rename.",
+        "downstream_risk" => {
+            "The contract surface changed with graph-known downstream entities; verify each \
+             listed dependent and consumer, then run the covering tests."
+        }
+        _ => "Review the change against the listed blast radius.",
+    }
+}
+
+fn collect_repair_context(
+    findings: &[ShadowPolicyFinding],
+    review: &Review,
+) -> Vec<ShadowRepairItem> {
+    let mut covering_tests: Vec<String> = review
+        .impact
+        .affected_tests
+        .iter()
+        .map(|test| {
+            let (file, _, _) = entity_location(test);
+            match file {
+                Some(file) => format!("{} ({})", test.name, file),
+                None => test.name.clone(),
+            }
+        })
+        .collect();
+    covering_tests.sort();
+    covering_tests.dedup();
+
+    let mut affected_consumers: Vec<String> = review
+        .impact
+        .affected_callers
+        .iter()
+        .chain(review.impact.affected_contract_consumers.iter())
+        .map(|consumer| {
+            let (file, _, _) = entity_location(consumer);
+            match file {
+                Some(file) => format!("{} ({})", consumer.name, file),
+                None => consumer.name.clone(),
+            }
+        })
+        .collect();
+    affected_consumers.sort();
+    affected_consumers.dedup();
+
+    findings
+        .iter()
+        .filter(|finding| finding.severity != "info")
+        .map(|finding| ShadowRepairItem {
+            finding: finding.message.clone(),
+            kind: finding.kind.clone(),
+            file: finding.file.clone(),
+            line: finding.line,
+            covering_tests: covering_tests.clone(),
+            affected_consumers: affected_consumers.clone(),
+            guidance: repair_guidance(&finding.kind).to_string(),
+        })
+        .collect()
+}
+
+fn collect_evidence_gaps(
+    review: &Review,
+    changes: &[kin_model::change::SemanticChange],
+    changed_entities: &[ShadowChangedEntity],
+) -> Vec<ShadowEvidenceGap> {
+    let mut gaps = Vec::new();
+
+    // Files whose changes were recorded only as raw artifacts: the graph has
+    // no entities for them, so they are invisible to blast radius and policy.
+    let entity_files: BTreeSet<String> = changed_entities
+        .iter()
+        .filter_map(|entity| entity.file.clone())
+        .collect();
+    let mut artifact_only: BTreeSet<String> = BTreeSet::new();
+    for change in changes {
+        for delta in &change.artifact_deltas {
+            let file = delta.file_id.to_string();
+            if !entity_files.contains(&file) {
+                artifact_only.insert(file);
+            }
+        }
+    }
+    for file in artifact_only {
+        gaps.push(ShadowEvidenceGap {
+            kind: "artifact_only_change".to_string(),
+            subject: file,
+            detail: "file changed but no semantic entities were captured for it (unsupported \
+                     language or unparsed artifact); its impact is NOT included in the blast \
+                     radius or policy result"
+                .to_string(),
+        });
+    }
+
+    // Changed entities without a source span cannot anchor line-level findings.
+    for entity in changed_entities {
+        if entity.change != "removed" && entity.start_line.is_none() {
+            gaps.push(ShadowEvidenceGap {
+                kind: "missing_span".to_string(),
+                subject: entity.name.clone(),
+                detail: "changed entity has no source span in the graph; line-anchored findings \
+                         and inline evidence are unavailable for it"
+                    .to_string(),
+            });
+        }
+    }
+
+    // An empty impact signal is only trustworthy when relation data exists.
+    // Distinguishing "genuinely isolated" from "relations never ingested"
+    // requires coverage state the report does not have, so say so.
+    if !changed_entities.is_empty() && review.impact.is_empty() {
+        gaps.push(ShadowEvidenceGap {
+            kind: "impact_signal_absent".to_string(),
+            subject: "blast_radius".to_string(),
+            detail: "no graph relations connect the changed entities to any caller, dependent, \
+                     contract consumer, or test; verify relation ingestion completed for this \
+                     repository before treating the empty blast radius as proof of isolation"
+                .to_string(),
+        });
+    }
+
+    // Actor attribution requires recorded audit events; absence is a gap, not
+    // a claim that no agent was involved.
+    if review.impact.actor_attribution.is_empty() && !changed_entities.is_empty() {
+        gaps.push(ShadowEvidenceGap {
+            kind: "actor_attribution_unavailable".to_string(),
+            subject: "audit.entity_attribution".to_string(),
+            detail: "no recorded audit events attribute the changed entities to an actor; \
+                     author identity comes from change metadata only"
+                .to_string(),
+        });
+    }
+
+    gaps.push(ShadowEvidenceGap {
+        kind: "cross_repo_not_evaluated".to_string(),
+        subject: "blast_radius.cross_repo".to_string(),
+        detail: "cross-repo federation is not evaluated by shadow report v1; consumers in other \
+                 repositories are not represented in this report"
+            .to_string(),
+    });
+
+    gaps
+}
+
+fn actor_kind_label(actor: &str) -> &'static str {
+    let lowered = actor.to_ascii_lowercase();
+    if lowered.contains("codex")
+        || lowered.contains("assistant")
+        || lowered.contains("claude")
+        || lowered.contains("gemini")
+        || lowered.contains("agent")
+    {
+        "assistant"
+    } else if lowered.contains("service") || lowered.contains("daemon") {
+        "service"
+    } else {
+        "human"
+    }
+}
+
+fn collect_audit_evidence<G: GraphStore>(
+    store: &G,
+    request: &ShadowRequest,
+    review: &Review,
+    changes_in_range: usize,
+) -> Result<ShadowAuditEvidence, ReviewError> {
+    let mut entity_attribution: Vec<ShadowAttribution> = review
+        .impact
+        .actor_attribution
+        .iter()
+        .map(|(entity_id, kind)| ShadowAttribution {
+            entity_id: entity_id.to_string(),
+            actor_kind: format!("{:?}", kind).to_lowercase(),
+        })
+        .collect();
+    entity_attribution.sort_by(|a, b| a.entity_id.cmp(&b.entity_id));
+
+    let mut head_approvals: Vec<ShadowApproval> = store
+        .get_approvals_for_change(&request.resolved_head)
+        .map_err(ReviewError::graph)?
+        .iter()
+        .map(|approval| ShadowApproval {
+            approver: approval.approver.to_string(),
+            decision: approval.decision.to_string(),
+            reason: approval.reason.clone(),
+        })
+        .collect();
+    head_approvals.sort_by(|a, b| a.approver.cmp(&b.approver));
+
+    Ok(ShadowAuditEvidence {
+        generated_at: Timestamp::now(),
+        actor: request.actor.clone(),
+        actor_kind: actor_kind_label(&request.actor).to_string(),
+        tool: "kin-review".to_string(),
+        tool_version: env!("CARGO_PKG_VERSION").to_string(),
+        base_change: request.resolved_base.to_string(),
+        head_change: request.resolved_head.to_string(),
+        changes_in_range,
+        entity_attribution,
+        head_approvals,
+    })
+}
+
+/// Render a shadow gate report for humans.
+pub fn format_shadow_report(report: &ShadowGateReport) -> String {
+    use std::fmt::Write as _;
+
+    let mut out = String::new();
+    let _ = writeln!(out, "Shadow Merge Gate Report (report-only; never blocks)");
+    let _ = writeln!(
+        out,
+        "  Range: {} .. {}",
+        report.input.base_ref, report.input.head_ref
+    );
+    if let Some(title) = &report.input.title {
+        let _ = writeln!(out, "  Title: {}", title);
+    }
+    if let Some(source_url) = &report.input.source_url {
+        let _ = writeln!(out, "  Source: {}", source_url);
+    }
+
+    let verdict = match report.policy.verdict {
+        ShadowGateVerdict::Pass => "PASS",
+        ShadowGateVerdict::NeedsAttention => "NEEDS ATTENTION",
+        ShadowGateVerdict::WouldBlock => "WOULD BLOCK",
+    };
+    let _ = writeln!(out);
+    let _ = writeln!(
+        out,
+        "Verdict: {} (risk: {}) — {}",
+        verdict, report.policy.risk_level, report.policy.summary
+    );
+
+    let _ = writeln!(out);
+    let _ = writeln!(out, "Changed entities ({}):", report.changed_entities.len());
+    for entity in &report.changed_entities {
+        let location = match (&entity.file, entity.start_line) {
+            (Some(file), Some(line)) => format!(" [{}:{}]", file, line),
+            (Some(file), None) => format!(" [{}]", file),
+            _ => String::new(),
+        };
+        let _ = writeln!(
+            out,
+            "  {} {} ({}){}",
+            match entity.change.as_str() {
+                "added" => "+",
+                "removed" => "-",
+                _ => "~",
+            },
+            entity.name,
+            entity.kind,
+            location
+        );
+    }
+
+    let radius = &report.blast_radius;
+    let _ = writeln!(out);
+    let _ = writeln!(
+        out,
+        "Blast radius ({} affected; this repository):",
+        radius.total_affected
+    );
+    for (label, entries) in [
+        ("callers", &radius.callers),
+        ("dependents", &radius.dependents),
+        ("contract consumers", &radius.contract_consumers),
+        ("tests", &radius.tests),
+    ] {
+        if !entries.is_empty() {
+            let _ = writeln!(out, "  {} ({}):", label, entries.len());
+            for entry in entries {
+                let location = entry
+                    .file
+                    .as_ref()
+                    .map(|file| format!(" [{}]", file))
+                    .unwrap_or_default();
+                let _ = writeln!(out, "    {}{}", entry.name, location);
+            }
+        }
+    }
+    if !radius.open_work_items.is_empty() {
+        let _ = writeln!(out, "  open work items ({}):", radius.open_work_items.len());
+        for item in &radius.open_work_items {
+            let _ = writeln!(out, "    {} [{}]", item.title, item.status);
+        }
+    }
+    let _ = writeln!(
+        out,
+        "  cross-repo: {} — {}",
+        radius.cross_repo.status, radius.cross_repo.detail
+    );
+
+    if !report.policy.findings.is_empty() {
+        let _ = writeln!(out);
+        let _ = writeln!(out, "Findings ({}):", report.policy.findings.len());
+        for finding in &report.policy.findings {
+            let location = match (&finding.file, finding.line) {
+                (Some(file), Some(line)) => format!(" [{}:{}]", file, line),
+                (Some(file), None) => format!(" [{}]", file),
+                _ => String::new(),
+            };
+            let _ = writeln!(
+                out,
+                "  [{}]{} {}{}",
+                finding.severity,
+                if finding.blocking { " [blocking]" } else { "" },
+                finding.message,
+                location
+            );
+        }
+    }
+
+    if !report.repair_context.is_empty() {
+        let _ = writeln!(out);
+        let _ = writeln!(out, "Repair context:");
+        for item in &report.repair_context {
+            let _ = writeln!(out, "  - {}", item.finding);
+            let _ = writeln!(out, "    {}", item.guidance);
+            if !item.covering_tests.is_empty() {
+                let _ = writeln!(out, "    tests: {}", item.covering_tests.join(", "));
+            }
+            if !item.affected_consumers.is_empty() {
+                let _ = writeln!(out, "    consumers: {}", item.affected_consumers.join(", "));
+            }
+        }
+    }
+
+    if !report.evidence_gaps.is_empty() {
+        let _ = writeln!(out);
+        let _ = writeln!(out, "Evidence gaps ({}):", report.evidence_gaps.len());
+        for gap in &report.evidence_gaps {
+            let _ = writeln!(out, "  [{}] {}: {}", gap.kind, gap.subject, gap.detail);
+        }
+    }
+
+    let _ = writeln!(out);
+    let _ = writeln!(
+        out,
+        "Audit: generated {} by {} ({}) via {} {} over {} change(s) [{} -> {}]",
+        report.audit.generated_at,
+        report.audit.actor,
+        report.audit.actor_kind,
+        report.audit.tool,
+        report.audit.tool_version,
+        report.audit.changes_in_range,
+        report.audit.base_change,
+        report.audit.head_change
+    );
+
+    out
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use kin_db::InMemoryGraph;
+    use kin_model::change::{ArtifactDelta, ArtifactDeltaKind, EntityDelta, SemanticChange};
+    use kin_model::entity::{
+        Entity, EntityKind, EntityMetadata, EntityRole, FingerprintAlgorithm, SemanticFingerprint,
+        SourceSpan, Visibility,
+    };
+    use kin_model::graph::{ChangeStore, EntityStore};
+    use kin_model::ids::*;
+    use kin_model::relation::{GraphNodeId, Relation, RelationKind, RelationOrigin};
+    use kin_model::timestamp::Timestamp;
+
+    fn entity_with_span(name: &str, file: &str, start_line: u32, role: EntityRole) -> Entity {
+        let file_id = FilePathId::new(file);
+        Entity {
+            id: EntityId::new(),
+            kind: EntityKind::Function,
+            name: name.to_string(),
+            language: LanguageId::Rust,
+            fingerprint: SemanticFingerprint {
+                algorithm: FingerprintAlgorithm::V1TreeSitter,
+                ast_hash: Hash256::from_bytes([0; 32]),
+                signature_hash: Hash256::from_bytes([0; 32]),
+                behavior_hash: Hash256::from_bytes([0; 32]),
+                stability_score: 1.0,
+            },
+            file_origin: Some(file_id.clone()),
+            span: Some(SourceSpan {
+                file: file_id,
+                start_byte: 0,
+                end_byte: 10,
+                start_line,
+                start_col: 0,
+                end_line: start_line + 2,
+                end_col: 1,
+            }),
+            signature: format!("fn {}()", name),
+            visibility: Visibility::Public,
+            role,
+            doc_summary: None,
+            metadata: EntityMetadata::default(),
+            lineage_parent: None,
+            created_in: None,
+            superseded_by: None,
+        }
+    }
+
+    fn change_id(byte: u8) -> SemanticChangeId {
+        SemanticChangeId::from_hash(Hash256::from_bytes([byte; 32]))
+    }
+
+    fn change_with_deltas(
+        id: SemanticChangeId,
+        parents: Vec<SemanticChangeId>,
+        entity_deltas: Vec<EntityDelta>,
+        artifact_deltas: Vec<ArtifactDelta>,
+    ) -> SemanticChange {
+        SemanticChange {
+            id,
+            parents,
+            timestamp: Timestamp::now(),
+            author: AuthorId::new("test-author"),
+            message: "test change".into(),
+            entity_deltas,
+            relation_deltas: vec![],
+            artifact_deltas,
+            projected_files: vec![],
+            spec_link: None,
+            evidence: vec![],
+            risk_summary: None,
+            authored_on: None,
+        }
+    }
+
+    fn relation(src: &Entity, dst: &Entity, kind: RelationKind) -> Relation {
+        Relation {
+            id: RelationId::new(),
+            kind,
+            src: GraphNodeId::Entity(src.id),
+            dst: GraphNodeId::Entity(dst.id),
+            confidence: 1.0,
+            origin: RelationOrigin::Parsed,
+            created_in: None,
+            import_source: None,
+            evidence: vec![],
+        }
+    }
+
+    fn request(base: SemanticChangeId, head: SemanticChangeId) -> ShadowRequest {
+        ShadowRequest {
+            base_ref: "main".into(),
+            head_ref: "feature/change".into(),
+            resolved_base: base,
+            resolved_head: head,
+            title: Some("test PR".into()),
+            source_url: None,
+            author: Some("agent-bot".into()),
+            actor: "test-runner".into(),
+        }
+    }
+
+    /// Graph with: base change adding `target` + `caller` + `test`, head
+    /// change modifying `target`'s signature. Caller and test are wired to
+    /// `target` via graph relations.
+    fn signature_change_graph() -> (InMemoryGraph, SemanticChangeId, SemanticChangeId) {
+        let graph = InMemoryGraph::new();
+
+        let target_v1 = entity_with_span("compute_total", "src/billing.rs", 10, EntityRole::Source);
+        let mut target_v2 = target_v1.clone();
+        target_v2.signature = "fn compute_total(currency: &str)".into();
+
+        let caller = entity_with_span("render_invoice", "src/invoice.rs", 5, EntityRole::Source);
+        let test = entity_with_span(
+            "test_compute_total",
+            "tests/billing.rs",
+            3,
+            EntityRole::Test,
+        );
+
+        graph.upsert_entity(&target_v2).unwrap();
+        graph.upsert_entity(&caller).unwrap();
+        graph.upsert_entity(&test).unwrap();
+        graph
+            .upsert_relation(&relation(&caller, &target_v2, RelationKind::Calls))
+            .unwrap();
+        graph
+            .upsert_relation(&relation(&test, &target_v2, RelationKind::Tests))
+            .unwrap();
+
+        let base_id = change_id(1);
+        let head_id = change_id(2);
+        let base = change_with_deltas(
+            base_id,
+            vec![],
+            vec![
+                EntityDelta::Added(target_v1.clone()),
+                EntityDelta::Added(caller),
+                EntityDelta::Added(test),
+            ],
+            vec![],
+        );
+        let head = change_with_deltas(
+            head_id,
+            vec![base_id],
+            vec![EntityDelta::Modified {
+                old: target_v1,
+                new: target_v2,
+            }],
+            vec![],
+        );
+        graph.create_change(&base).unwrap();
+        graph.create_change(&head).unwrap();
+
+        (graph, base_id, head_id)
+    }
+
+    #[test]
+    fn report_carries_blast_radius_verdict_and_audit() {
+        let (graph, base_id, head_id) = signature_change_graph();
+
+        let report = build_shadow_report(&graph, &request(base_id, head_id)).unwrap();
+
+        assert_eq!(report.schema_version, SHADOW_GATE_REPORT_SCHEMA_VERSION);
+        assert_eq!(report.mode, "shadow");
+        assert_eq!(report.policy.enforcement, SHADOW_ENFORCEMENT_REPORT_ONLY);
+
+        assert_eq!(report.changed_entities.len(), 1);
+        assert_eq!(report.changed_entities[0].name, "compute_total");
+        assert_eq!(report.changed_entities[0].change, "modified");
+        assert!(report.changed_entities[0].signature_changed);
+
+        // The impact walker reaches incoming consumers through the
+        // incoming-edge downstream traversal, bucketing them as dependents.
+        assert!(report
+            .blast_radius
+            .dependents
+            .iter()
+            .any(|dependent| dependent.name == "render_invoice"));
+        assert!(report
+            .blast_radius
+            .tests
+            .iter()
+            .any(|test| test.name == "test_compute_total"));
+        assert!(report.blast_radius.total_affected >= 2);
+
+        // Signature change with graph-known downstream entities -> would block.
+        assert_eq!(report.policy.verdict, ShadowGateVerdict::WouldBlock);
+        assert!(report.policy.blocking_count >= 1);
+        assert!(report
+            .policy
+            .findings
+            .iter()
+            .any(|finding| finding.blocking && finding.kind == "downstream_risk"));
+
+        // Repair context points at the covering test.
+        assert!(!report.repair_context.is_empty());
+        assert!(report.repair_context.iter().any(|item| item
+            .covering_tests
+            .iter()
+            .any(|test| test.contains("test_compute_total"))));
+
+        // Audit evidence identifies range, actor, and tool.
+        assert_eq!(report.audit.base_change, base_id.to_string());
+        assert_eq!(report.audit.head_change, head_id.to_string());
+        assert_eq!(report.audit.changes_in_range, 1);
+        assert_eq!(report.audit.actor, "test-runner");
+        assert_eq!(report.audit.tool, "kin-review");
+        assert!(!report.audit.tool_version.is_empty());
+
+        // Cross-repo is labeled, never silently green.
+        assert_eq!(report.blast_radius.cross_repo.status, "not_evaluated");
+        assert!(report
+            .evidence_gaps
+            .iter()
+            .any(|gap| gap.kind == "cross_repo_not_evaluated"));
+    }
+
+    #[test]
+    fn artifact_only_change_is_an_explicit_evidence_gap() {
+        let graph = InMemoryGraph::new();
+        let entity = entity_with_span("helper", "src/lib.rs", 1, EntityRole::Source);
+        graph.upsert_entity(&entity).unwrap();
+
+        let base_id = change_id(3);
+        let head_id = change_id(4);
+        let base = change_with_deltas(
+            base_id,
+            vec![],
+            vec![EntityDelta::Added(entity.clone())],
+            vec![],
+        );
+        let head = change_with_deltas(
+            head_id,
+            vec![base_id],
+            vec![EntityDelta::Modified {
+                old: entity.clone(),
+                new: entity,
+            }],
+            vec![ArtifactDelta {
+                file_id: FilePathId::new("config/policy.yaml"),
+                kind: ArtifactDeltaKind::Modified,
+                old_hash: Some(Hash256::from_bytes([7; 32])),
+                new_hash: Some(Hash256::from_bytes([8; 32])),
+            }],
+        );
+        graph.create_change(&base).unwrap();
+        graph.create_change(&head).unwrap();
+
+        let report = build_shadow_report(&graph, &request(base_id, head_id)).unwrap();
+
+        let artifact_gap = report
+            .evidence_gaps
+            .iter()
+            .find(|gap| gap.kind == "artifact_only_change")
+            .expect("artifact-only change must surface as an evidence gap");
+        assert_eq!(artifact_gap.subject, "config/policy.yaml");
+
+        // No relations exist -> empty impact must be flagged, not passed.
+        assert!(report
+            .evidence_gaps
+            .iter()
+            .any(|gap| gap.kind == "impact_signal_absent"));
+        assert!(report
+            .evidence_gaps
+            .iter()
+            .any(|gap| gap.kind == "actor_attribution_unavailable"));
+
+        // Missing evidence must never certify a pass.
+        assert_ne!(report.policy.verdict, ShadowGateVerdict::Pass);
+    }
+
+    #[test]
+    fn empty_range_fails_loud() {
+        let graph = InMemoryGraph::new();
+        let base_id = change_id(5);
+        let base = change_with_deltas(base_id, vec![], vec![], vec![]);
+        graph.create_change(&base).unwrap();
+
+        let result = build_shadow_report(&graph, &request(base_id, base_id));
+        assert!(
+            result.is_err(),
+            "empty base..head range must error, not report"
+        );
+    }
+
+    #[test]
+    fn report_json_is_deterministic_modulo_timestamp() {
+        let (graph, base_id, head_id) = signature_change_graph();
+
+        let strip = |report: ShadowGateReport| {
+            let mut value = serde_json::to_value(&report).unwrap();
+            value["audit"]["generated_at"] = serde_json::json!(null);
+            value
+        };
+
+        let first = strip(build_shadow_report(&graph, &request(base_id, head_id)).unwrap());
+        let second = strip(build_shadow_report(&graph, &request(base_id, head_id)).unwrap());
+        assert_eq!(first, second, "shadow report must be deterministic");
+    }
+
+    #[test]
+    fn human_rendering_carries_all_sections() {
+        let (graph, base_id, head_id) = signature_change_graph();
+        let report = build_shadow_report(&graph, &request(base_id, head_id)).unwrap();
+
+        let text = format_shadow_report(&report);
+        assert!(text.contains("Shadow Merge Gate Report"));
+        assert!(text.contains("report-only"));
+        assert!(text.contains("WOULD BLOCK"));
+        assert!(text.contains("Blast radius"));
+        assert!(text.contains("Evidence gaps"));
+        assert!(text.contains("Audit:"));
+    }
+}

--- a/packages/boundary-contracts/schemas/shadow-gate-report.schema.json
+++ b/packages/boundary-contracts/schemas/shadow-gate-report.schema.json
@@ -1,0 +1,281 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "kin://contracts/shadow-gate-report",
+  "type": "object",
+  "required": [
+    "schema_version",
+    "mode",
+    "input",
+    "changed_entities",
+    "blast_radius",
+    "policy",
+    "repair_context",
+    "evidence_gaps",
+    "audit"
+  ],
+  "properties": {
+    "schema_version": { "type": "integer", "enum": [1] },
+    "mode": { "type": "string", "enum": ["shadow"] },
+    "input": {
+      "type": "object",
+      "required": ["base_ref", "head_ref", "resolved_base", "resolved_head"],
+      "properties": {
+        "base_ref": { "type": "string" },
+        "head_ref": { "type": "string" },
+        "resolved_base": { "type": "string" },
+        "resolved_head": { "type": "string" },
+        "title": { "type": "string" },
+        "source_url": { "type": "string" },
+        "author": { "type": "string" }
+      }
+    },
+    "changed_entities": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "entity_id",
+          "name",
+          "kind",
+          "change",
+          "signature_changed",
+          "visibility_changed"
+        ],
+        "properties": {
+          "entity_id": { "type": "string" },
+          "name": { "type": "string" },
+          "kind": { "type": "string" },
+          "change": { "type": "string", "enum": ["added", "modified", "removed"] },
+          "file": { "type": "string" },
+          "start_line": { "type": "number" },
+          "end_line": { "type": "number" },
+          "signature_changed": { "type": "boolean" },
+          "visibility_changed": { "type": "boolean" }
+        }
+      }
+    },
+    "blast_radius": {
+      "type": "object",
+      "required": [
+        "callers",
+        "dependents",
+        "contract_consumers",
+        "tests",
+        "open_work_items",
+        "total_affected",
+        "cross_repo"
+      ],
+      "properties": {
+        "callers": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "required": ["entity_id", "name", "kind", "via"],
+            "properties": {
+              "entity_id": { "type": "string" },
+              "name": { "type": "string" },
+              "kind": { "type": "string" },
+              "file": { "type": "string" },
+              "via": { "type": "string" }
+            }
+          }
+        },
+        "dependents": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "required": ["entity_id", "name", "kind", "via"],
+            "properties": {
+              "entity_id": { "type": "string" },
+              "name": { "type": "string" },
+              "kind": { "type": "string" },
+              "file": { "type": "string" },
+              "via": { "type": "string" }
+            }
+          }
+        },
+        "contract_consumers": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "required": ["entity_id", "name", "kind", "via"],
+            "properties": {
+              "entity_id": { "type": "string" },
+              "name": { "type": "string" },
+              "kind": { "type": "string" },
+              "file": { "type": "string" },
+              "via": { "type": "string" }
+            }
+          }
+        },
+        "tests": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "required": ["entity_id", "name", "kind", "via"],
+            "properties": {
+              "entity_id": { "type": "string" },
+              "name": { "type": "string" },
+              "kind": { "type": "string" },
+              "file": { "type": "string" },
+              "via": { "type": "string" }
+            }
+          }
+        },
+        "open_work_items": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "required": ["work_id", "title", "status"],
+            "properties": {
+              "work_id": { "type": "string" },
+              "title": { "type": "string" },
+              "status": { "type": "string" }
+            }
+          }
+        },
+        "total_affected": { "type": "number" },
+        "cross_repo": {
+          "type": "object",
+          "required": ["status", "detail", "nodes"],
+          "properties": {
+            "status": {
+              "type": "string",
+              "enum": ["not_evaluated", "unavailable", "available"]
+            },
+            "detail": { "type": "string" },
+            "nodes": {
+              "type": "array",
+              "items": {
+                "type": "object",
+                "required": ["repo_id", "entity_id", "name"],
+                "properties": {
+                  "repo_id": { "type": "string" },
+                  "entity_id": { "type": "string" },
+                  "name": { "type": "string" }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "policy": {
+      "type": "object",
+      "required": [
+        "enforcement",
+        "verdict",
+        "risk_level",
+        "blocking_count",
+        "attention_count",
+        "summary",
+        "findings"
+      ],
+      "properties": {
+        "enforcement": { "type": "string", "enum": ["report_only"] },
+        "verdict": {
+          "type": "string",
+          "enum": ["pass", "needs_attention", "would_block"]
+        },
+        "risk_level": {
+          "type": "string",
+          "enum": ["low", "medium", "high", "critical"]
+        },
+        "blocking_count": { "type": "number" },
+        "attention_count": { "type": "number" },
+        "summary": { "type": "string" },
+        "findings": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "required": ["kind", "severity", "blocking", "message"],
+            "properties": {
+              "kind": { "type": "string" },
+              "severity": { "type": "string", "enum": ["error", "warning", "info"] },
+              "blocking": { "type": "boolean" },
+              "message": { "type": "string" },
+              "file": { "type": "string" },
+              "line": { "type": "number" }
+            }
+          }
+        }
+      }
+    },
+    "repair_context": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": ["finding", "kind", "covering_tests", "affected_consumers", "guidance"],
+        "properties": {
+          "finding": { "type": "string" },
+          "kind": { "type": "string" },
+          "file": { "type": "string" },
+          "line": { "type": "number" },
+          "covering_tests": { "type": "array", "items": { "type": "string" } },
+          "affected_consumers": { "type": "array", "items": { "type": "string" } },
+          "guidance": { "type": "string" }
+        }
+      }
+    },
+    "evidence_gaps": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": ["kind", "subject", "detail"],
+        "properties": {
+          "kind": { "type": "string" },
+          "subject": { "type": "string" },
+          "detail": { "type": "string" }
+        }
+      }
+    },
+    "audit": {
+      "type": "object",
+      "required": [
+        "generated_at",
+        "actor",
+        "actor_kind",
+        "tool",
+        "tool_version",
+        "base_change",
+        "head_change",
+        "changes_in_range",
+        "entity_attribution",
+        "head_approvals"
+      ],
+      "properties": {
+        "generated_at": {},
+        "actor": { "type": "string" },
+        "actor_kind": { "type": "string", "enum": ["human", "assistant", "service"] },
+        "tool": { "type": "string" },
+        "tool_version": { "type": "string" },
+        "base_change": { "type": "string" },
+        "head_change": { "type": "string" },
+        "changes_in_range": { "type": "number" },
+        "entity_attribution": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "required": ["entity_id", "actor_kind"],
+            "properties": {
+              "entity_id": { "type": "string" },
+              "actor_kind": { "type": "string" }
+            }
+          }
+        },
+        "head_approvals": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "required": ["approver", "decision", "reason"],
+            "properties": {
+              "approver": { "type": "string" },
+              "decision": { "type": "string" },
+              "reason": { "type": "string" }
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/packages/boundary-contracts/src/index.js
+++ b/packages/boundary-contracts/src/index.js
@@ -22,7 +22,8 @@ const schemaFiles = {
   scmResourceGroups: 'scm-resource-groups.schema.json',
   intent: 'intent.schema.json',
   intentConflict: 'intent-conflict.schema.json',
-  trafficReport: 'traffic-report.schema.json'
+  trafficReport: 'traffic-report.schema.json',
+  shadowGateReport: 'shadow-gate-report.schema.json'
 };
 
 const schemaIdMap = {

--- a/packages/boundary-contracts/test/contracts.test.js
+++ b/packages/boundary-contracts/test/contracts.test.js
@@ -9,7 +9,7 @@ import os from 'node:os';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
 
-import { assertContract, loadAllSchemas } from '../src/index.js';
+import { assertContract, loadAllSchemas, validateContract } from '../src/index.js';
 
 const root = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
 const gitHubRoot = path.resolve(root, '..', '..', '..');
@@ -24,6 +24,122 @@ test('all schemas load', async () => {
   assert.ok(schemas.kinCommandResult);
   assert.ok(schemas.scmSnapshot);
   assert.ok(schemas.scmResourceGroups);
+  assert.ok(schemas.shadowGateReport);
+});
+
+test('shadow gate report contract accepts the kin review shadow payload shape', async () => {
+  // Canonical shape emitted by `kin review shadow --json` (kin-review::shadow).
+  // The live payload is asserted against the same required fields by the
+  // review_shadow_json integration test in the kin workspace.
+  const report = {
+    schema_version: 1,
+    mode: 'shadow',
+    input: {
+      base_ref: 'main',
+      head_ref: 'feature/change',
+      resolved_base: 'a'.repeat(64),
+      resolved_head: 'b'.repeat(64),
+      title: 'Example PR'
+    },
+    changed_entities: [
+      {
+        entity_id: '3fa85f64-5717-4562-b3fc-2c963f66afa6',
+        name: 'compute_total',
+        kind: 'Function',
+        change: 'modified',
+        file: 'src/billing.rs',
+        start_line: 10,
+        end_line: 12,
+        signature_changed: true,
+        visibility_changed: false
+      }
+    ],
+    blast_radius: {
+      callers: [],
+      dependents: [
+        {
+          entity_id: '3fa85f64-5717-4562-b3fc-2c963f66afa7',
+          name: 'render_invoice',
+          kind: 'Function',
+          file: 'src/invoice.rs',
+          via: 'depends_on'
+        }
+      ],
+      contract_consumers: [],
+      tests: [
+        {
+          entity_id: '3fa85f64-5717-4562-b3fc-2c963f66afa8',
+          name: 'test_compute_total',
+          kind: 'Function',
+          file: 'tests/billing.rs',
+          via: 'tests'
+        }
+      ],
+      open_work_items: [],
+      total_affected: 2,
+      cross_repo: {
+        status: 'not_evaluated',
+        detail: 'cross-repo federation is not evaluated by shadow report v1',
+        nodes: []
+      }
+    },
+    policy: {
+      enforcement: 'report_only',
+      verdict: 'would_block',
+      risk_level: 'medium',
+      blocking_count: 1,
+      attention_count: 1,
+      summary: '1 blocking finding(s), 1 attention signal(s); would block in enforcing mode',
+      findings: [
+        {
+          kind: 'downstream_risk',
+          severity: 'error',
+          blocking: true,
+          message: 'Contract surface of `compute_total` changed with 1 graph-known downstream entity(ies)',
+          file: 'src/billing.rs',
+          line: 10
+        }
+      ]
+    },
+    repair_context: [
+      {
+        finding: 'Contract surface of `compute_total` changed with 1 graph-known downstream entity(ies)',
+        kind: 'downstream_risk',
+        file: 'src/billing.rs',
+        line: 10,
+        covering_tests: ['test_compute_total (tests/billing.rs)'],
+        affected_consumers: [],
+        guidance: 'Verify each listed dependent and consumer, then run the covering tests.'
+      }
+    ],
+    evidence_gaps: [
+      {
+        kind: 'cross_repo_not_evaluated',
+        subject: 'blast_radius.cross_repo',
+        detail: 'cross-repo federation is not evaluated by shadow report v1'
+      }
+    ],
+    audit: {
+      generated_at: '2026-07-01T00:00:00Z',
+      actor: 'ci-runner',
+      actor_kind: 'service',
+      tool: 'kin-review',
+      tool_version: '0.0.0',
+      base_change: 'a'.repeat(64),
+      head_change: 'b'.repeat(64),
+      changes_in_range: 1,
+      entity_attribution: [],
+      head_approvals: []
+    }
+  };
+
+  await assertContract('shadowGateReport', report);
+
+  // The contract must reject payloads that claim enforcement.
+  const enforcing = structuredClone(report);
+  enforcing.policy.enforcement = 'blocking';
+  const rejected = await validateContract('shadowGateReport', enforcing);
+  assert.equal(rejected.ok, false);
 });
 
 test('graph service and fs adapter outputs conform to shared workspace contracts', async () => {


### PR DESCRIPTION
## What

Productizes the shadow-mode AI merge gate as one coherent workflow: a PR-shaped change (base ref .. head ref) goes in, ONE report comes out. Phase-1 shadow semantics throughout: report-only, never blocking, no graph mutation.

New surfaces:
- **CLI**: `kin review shadow <base>..<head> [--base/--head] [--title] [--source-url] [--author] [--json]` — human rendering + machine JSON. Refs accept branch names, semantic change IDs, and Git commit SHAs (hydrated on demand through the existing imported-git path).
- **MCP**: `shadow_gate_report` tool (bundled kin-mcp), same payload, graph-resolved refs, fail-loud on unknown/unimported refs.
- **Contract**: `packages/boundary-contracts/schemas/shadow-gate-report.schema.json` (v1) + registration + contract tests, for control-plane consumers.

## Report payload (v1)

`schema_version / mode=shadow / input (refs + resolution echo) / changed_entities / blast_radius (callers, dependents, contract_consumers, tests, open_work_items, total_affected, cross_repo) / policy (enforcement=report_only, verdict pass|needs_attention|would_block, findings) / repair_context (covering tests + consumers + guidance per finding) / evidence_gaps / audit (who/what/when, tool version, base/head change ids, attribution, approvals)`.

Built entirely on existing graph primitives: `SemanticReview::create_review` (diff + impact + risk + inline comments), `gate::derive_decision`, ref resolution via `ref_lookup`. One shadow-layer gate rule added: a contract-surface change (signature/visibility/removal) with any graph-known downstream entity is a blocking `downstream_risk` finding — the impact walker buckets incoming consumers under `dependents`, which the inline Breaking rule alone does not consult.

## Fail-loud contract

- Files changed without semantic capture → `artifact_only_change` gap, and the verdict is demoted from pass to needs_attention: **missing evidence never certifies a pass**.
- Entities without spans, absent impact signal, unattributed actors → explicit gap entries.
- Cross-repo blast radius is **not** computed in v1 and is labeled `cross_repo.status=not_evaluated` (plus a gap entry) instead of implying coverage.
- Unknown refs / unimported git SHAs / empty ranges error; nothing degrades to silence.

## Testing

- kin-review unit suite (89 tests incl. shadow: verdicts, gaps, determinism-modulo-timestamp, rendering).
- kin-mcp handler tests incl. fail-loud ref resolution (169 tests).
- New e2e integration test `review_shadow_json`: real two-commit fixture repo → `kin init` → `kin review shadow --json` through the real daemon path; asserts non-empty blast radius (cross-file dependent), report-only verdict, audit evidence, artifact-only fail-loud, unknown-ref failure.
- boundary-contracts node tests validate the payload contract and reject an enforcing payload.
- Full gate: fmt, clippy (CI flags), zero-file-search + runtime-boundary + coupling scripts, `build --all-targets --locked`, `cargo test --locked` — all green locally.

Note: `cli_definition_is_valid` now runs on an explicit 16 MiB thread — clap's recursive debug_assert had outgrown the default test-thread stack as the command tree grew.
