### PR TITLE
fix(install): survive POSIX dash on curl|sh, correct version parse, log daemon startup at info

### DIFF
--- a/crates/kin-daemon/src/bin/kin-daemon.rs
+++ b/crates/kin-daemon/src/bin/kin-daemon.rs
@@ -13,6 +13,7 @@ use std::time::Duration;
 
 use kin_core::KinLayout;
 use kin_daemon::{run, DaemonConfig, DaemonState};
+use tracing_subscriber::EnvFilter;
 
 /// Storage mode for graph snapshots.
 #[derive(Debug, Clone, PartialEq)]
@@ -285,8 +286,32 @@ fn main() {
     process::exit(exit_code);
 }
 
+/// Default tracing directive when `RUST_LOG` is unset.
+///
+/// `info` so first-run daemon and supervisor lifecycle logs actually land in the
+/// daemon/supervisor log files. A bare `tracing_subscriber::fmt::init()` derives
+/// its default from `RUST_LOG` and admits no info-level events when it is unset,
+/// which left the log files empty and first-run failures undiagnosable.
+const DEFAULT_LOG_DIRECTIVE: &str = "info";
+
+/// Tracing filter for the daemon/supervisor process: honor `RUST_LOG` when set,
+/// otherwise fall back to [`DEFAULT_LOG_DIRECTIVE`].
+fn daemon_env_filter() -> EnvFilter {
+    if env::var_os("RUST_LOG").is_some() {
+        EnvFilter::from_default_env()
+    } else {
+        EnvFilter::new(DEFAULT_LOG_DIRECTIVE)
+    }
+}
+
+fn init_tracing() {
+    tracing_subscriber::fmt()
+        .with_env_filter(daemon_env_filter())
+        .init();
+}
+
 async fn async_main() -> i32 {
-    tracing_subscriber::fmt::init();
+    init_tracing();
 
     let program = env::args()
         .next()
@@ -395,4 +420,70 @@ async fn async_main() -> i32 {
         return 1;
     }
     0
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::io::Write;
+    use std::sync::{Arc, Mutex};
+    use tracing::level_filters::LevelFilter;
+    use tracing_subscriber::fmt::MakeWriter;
+
+    /// A `MakeWriter` that appends everything the subscriber emits into a shared
+    /// buffer — stands in for the daemon/supervisor log file the spawn code wires
+    /// the process's stdout/stderr to.
+    #[derive(Clone)]
+    struct SharedBuf(Arc<Mutex<Vec<u8>>>);
+
+    impl Write for SharedBuf {
+        fn write(&mut self, buf: &[u8]) -> std::io::Result<usize> {
+            self.0
+                .lock()
+                .expect("log buffer poisoned")
+                .extend_from_slice(buf);
+            Ok(buf.len())
+        }
+        fn flush(&mut self) -> std::io::Result<()> {
+            Ok(())
+        }
+    }
+
+    impl<'a> MakeWriter<'a> for SharedBuf {
+        type Writer = SharedBuf;
+        fn make_writer(&'a self) -> Self::Writer {
+            self.clone()
+        }
+    }
+
+    #[test]
+    fn default_directive_admits_info() {
+        // The regression: a bare `fmt::init()` starves info-level logs when
+        // RUST_LOG is unset. The daemon default must admit info.
+        let filter = EnvFilter::new(DEFAULT_LOG_DIRECTIVE);
+        assert_eq!(filter.max_level_hint(), Some(LevelFilter::INFO));
+    }
+
+    #[test]
+    fn info_events_reach_the_log_writer_under_default_filter() {
+        // Build the subscriber exactly as the daemon does for the RUST_LOG-unset
+        // case and confirm a lifecycle info event actually lands in the writer —
+        // i.e. the log file receives content on startup.
+        let buf = Arc::new(Mutex::new(Vec::new()));
+        let subscriber = tracing_subscriber::fmt()
+            .with_env_filter(EnvFilter::new(DEFAULT_LOG_DIRECTIVE))
+            .with_writer(SharedBuf(Arc::clone(&buf)))
+            .finish();
+
+        tracing::subscriber::with_default(subscriber, || {
+            tracing::info!(port = 4219, "daemon is up and ready");
+        });
+
+        let logged = String::from_utf8(buf.lock().expect("log buffer poisoned").clone())
+            .expect("log output is valid UTF-8");
+        assert!(
+            logged.contains("daemon is up and ready"),
+            "expected info lifecycle log in the writer, got: {logged:?}"
+        );
+    }
 }

--- a/crates/kin-daemon/src/bin/kin-daemon.rs
+++ b/crates/kin-daemon/src/bin/kin-daemon.rs
@@ -465,6 +465,25 @@ mod tests {
     }
 
     #[test]
+    fn bare_fmt_init_default_drops_info() {
+        // Root-cause proof. `tracing_subscriber::fmt::init()` filters through
+        // `EnvFilter::from_default_env()`, whose builder default directive is
+        // ERROR; with RUST_LOG unset it admits only ERROR, so every info-level
+        // lifecycle log is dropped — the reason supervisor.log / daemon.log
+        // stayed empty on a fresh install. Reproduce that filter deterministically
+        // (explicit empty RUST_LOG) and confirm it excludes info, unlike the
+        // daemon's explicit `info` default.
+        let bare = EnvFilter::builder()
+            .with_default_directive(LevelFilter::ERROR.into())
+            .parse_lossy("");
+        assert_eq!(bare.max_level_hint(), Some(LevelFilter::ERROR));
+        assert_eq!(
+            EnvFilter::new(DEFAULT_LOG_DIRECTIVE).max_level_hint(),
+            Some(LevelFilter::INFO)
+        );
+    }
+
+    #[test]
     fn info_events_reach_the_log_writer_under_default_filter() {
         // Build the subscriber exactly as the daemon does for the RUST_LOG-unset
         // case and confirm a lifecycle info event actually lands in the writer —

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -68,7 +68,7 @@ info "Platform: $OS ($ARCH)"
 
 PREVIOUS_VERSION=""
 if [ -x "$KIN_BIN/kin" ]; then
-    PREVIOUS_VERSION=$("$KIN_BIN/kin" --version 2>/dev/null | awk '{print $NF}')
+    PREVIOUS_VERSION=$("$KIN_BIN/kin" --version 2>/dev/null | awk '{print $2}')
     if [ -n "$PREVIOUS_VERSION" ]; then
         info "Existing install found: kin $PREVIOUS_VERSION (will be replaced)"
     else
@@ -254,7 +254,7 @@ esac
 export PATH="$KIN_BIN:$PATH"
 
 if has_cmd "$KIN_BIN/kin"; then
-    INSTALLED_VERSION=$("$KIN_BIN/kin" --version 2>/dev/null | awk '{print $NF}')
+    INSTALLED_VERSION=$("$KIN_BIN/kin" --version 2>/dev/null | awk '{print $2}')
     if [ -n "$PREVIOUS_VERSION" ] && [ -n "$INSTALLED_VERSION" ] && [ "$PREVIOUS_VERSION" != "$INSTALLED_VERSION" ]; then
         ok "kin upgraded: $PREVIOUS_VERSION → $INSTALLED_VERSION"
     else
@@ -282,12 +282,15 @@ else
     if [ -t 0 ]; then
         # Already in a TTY — run directly
         "$KIN_BIN/kin" setup
-    elif [ -e /dev/tty ] && { : < /dev/tty; } 2>/dev/null; then
+    elif [ -e /dev/tty ] && ( : < /dev/tty ) 2>/dev/null; then
         # Piped but a usable controlling TTY is available — read keyboard input
-        # from it. The `: < /dev/tty` probe confirms the device can actually be
-        # OPENED — on CI/Docker /dev/tty often exists but has no controlling
+        # from it. The `( : < /dev/tty )` probe confirms the device can actually
+        # be OPENED — on CI/Docker /dev/tty often exists but has no controlling
         # terminal, so opening it errors ("cannot open /dev/tty") and the bare
-        # `[ -e /dev/tty ]` check is not enough.
+        # `[ -e /dev/tty ]` check is not enough. The probe runs in a SUBSHELL:
+        # a redirection failure on the `:` special built-in exits its shell, so
+        # in a bare brace group it would terminate the whole non-interactive
+        # installer (POSIX dash) before the fallback below can run.
         "$KIN_BIN/kin" setup < /dev/tty
     else
         # No usable TTY (CI, Docker, piped without a controlling terminal) —


### PR DESCRIPTION
## What

Fixes three fresh-machine launch-path breakages found testing kin 0.2.5 on a clean host. (A fourth first-run fix — the `kin setup` VFS-shim 0-byte truncation in `setup.rs`/`health.rs` — lands in a separate follow-up PR to avoid colliding with the in-flight session-runtime PR that also edits those files.)

## Fixes

### P0 — `curl | sh` dies on Ubuntu/dash (`scripts/install.sh`)
The piped-install TTY probe wrapped the `:` **special built-in** in a brace group: `{ : < /dev/tty; }`. Per POSIX, *a redirection error on a special built-in terminates a non-interactive shell* — and it does so even under `set +e`. On any host where `/dev/tty` can't be opened (CI, Docker, `curl \| sh`), Ubuntu's `/bin/sh` (dash) executed the redirection, failed to open the device, and **exited the whole installer** before the non-interactive `kin setup --no-interactive` fallback or the auto-setup tail could run.

Fix: run the probe in a **subshell** — `( : < /dev/tty ) 2>/dev/null` — so the redirection failure is confined to a child process the installer survives.

Repro (dash), old vs new pattern against an unopenable path:
```
$ /bin/dash -c 'set +e; if { : < /nonexistent; } 2>/dev/null; then echo TTY; else echo FALLBACK; fi; echo END'
$ echo $?
2                      # ← nothing printed: dash exited at the redirect
$ /bin/dash -c 'set +e; if ( : < /nonexistent ) 2>/dev/null; then echo TTY; else echo FALLBACK; fi; echo END'
FALLBACK
END                    # ← fallback taken, script continues
```

### P2 — version parse grabs a timestamp fragment (`scripts/install.sh`)
`kin --version` prints `kin <version> (<hash> <branch> <built_at>)`, so `awk '{print $NF}'` returned e.g. `2026-06-30T12:00:00Z)` instead of `0.2.5`. Parse field 2.

### P1 — daemon/supervisor logs empty on fresh install (`kin-daemon`)
`crates/kin-daemon/src/bin/kin-daemon.rs` initialised tracing with a bare `tracing_subscriber::fmt::init()`, whose `RUST_LOG`-derived default admits no info-level events when `RUST_LOG` is unset. The CLI spawn code wires the daemon/supervisor stdout+stderr to `supervisor.log`/`daemon.log` correctly, but with the info logs filtered out those files stayed empty (0 bytes) even while the daemon ran and served — so a first-run daemon failure was undiagnosable.

Fix: default the filter to `info` when `RUST_LOG` is unset, still honoring `RUST_LOG` when set (mirrors the existing kin-cli `default_env_filter` pattern).

## Tests
- **install.sh**: `sh -n` syntax check; dash repro above proving old pattern kills a non-interactive shell (exit 2) and the subshell fix survives; `awk` field-2 parse verified against a representative version line.
- **kin-daemon** (unit, in-process): `default_directive_admits_info` (filter permits info) and `info_events_reach_the_log_writer_under_default_filter` (an info lifecycle event actually lands in the writer that stands in for the log file).

## Gate
`cargo fmt --all --check`, clippy (ci.yml allowlist, `RUSTFLAGS=-D warnings`), `cargo build --all-targets --locked`, `cargo test --workspace --locked` — all green.
