### PR TITLE
fix(setup): stop kin setup truncating the VFS shim to 0 bytes

### DIFF
--- a/crates/kin-cli/src/commands/health.rs
+++ b/crates/kin-cli/src/commands/health.rs
@@ -296,7 +296,8 @@ fn check_vfs_projection() -> HealthCheck {
                 lib_path.display()
             ),
         )
-        .with_manual_fix(format!("rm {} && kin setup", lib_path.display()))
+        .fixable()
+        .with_manual_fix("run `kin doctor --fix` to reinstall the shim (or reinstall kin if no local copy remains)")
     } else {
         HealthCheck::new(
             "vfs_projection",
@@ -304,7 +305,10 @@ fn check_vfs_projection() -> HealthCheck {
             HealthStatus::Missing,
             format!("shim not installed at {}", lib_path.display()),
         )
-        .with_manual_fix("run `kin setup` (builds/copies the VFS shim into ~/.kin/lib)")
+        .fixable()
+        .with_manual_fix(
+            "run `kin doctor --fix` (or `kin setup`) to install the VFS shim into ~/.kin/lib",
+        )
     }
 }
 

--- a/crates/kin-cli/src/commands/setup.rs
+++ b/crates/kin-cli/src/commands/setup.rs
@@ -7,7 +7,7 @@ use dialoguer::MultiSelect;
 use std::env;
 use std::fs;
 use std::io::{self, BufRead, IsTerminal, Write as _};
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 
 // ---------------------------------------------------------------------------
 // Embedded shell hooks (from kin-vfs/shell/)
@@ -539,17 +539,58 @@ pub(crate) fn shim_filename() -> &'static str {
     }
 }
 
+/// True when `path` is a shim we can actually inject: it exists and is
+/// non-empty. A 0-byte file — e.g. a shim an earlier self-copy truncated — is
+/// not a usable source; returning it would let a repair re-copy the corruption.
+fn is_usable_shim(path: &Path) -> bool {
+    fs::metadata(path)
+        .map(|meta| meta.is_file() && meta.len() > 0)
+        .unwrap_or(false)
+}
+
+/// Whether two paths resolve to the same file on disk (after following symlinks
+/// and normalizing `..`). Both must exist; a non-existent path is never "same".
+fn same_file(a: &Path, b: &Path) -> bool {
+    match (a.canonicalize(), b.canonicalize()) {
+        (Ok(x), Ok(y)) => x == y,
+        _ => false,
+    }
+}
+
+/// Outcome of a guarded shim copy.
+#[derive(Debug, PartialEq, Eq)]
+enum ShimCopy {
+    /// Source and destination are the same file — nothing copied.
+    Skipped,
+    /// Source was copied to the destination.
+    Copied,
+}
+
+/// Copy `src` to `dest`, skipping when they are the same file.
+///
+/// `fs::copy` truncates the destination before reading the source, so copying a
+/// file onto itself zeroes it out — the root cause of the "0-byte shim" that
+/// crashes every injected process. Both the setup flow and the doctor repair go
+/// through this guard so neither can truncate the shim.
+fn copy_shim(src: &Path, dest: &Path) -> Result<ShimCopy> {
+    if same_file(src, dest) {
+        return Ok(ShimCopy::Skipped);
+    }
+    fs::copy(src, dest).with_context(|| format!("failed to copy shim to {}", dest.display()))?;
+    Ok(ShimCopy::Copied)
+}
+
 fn find_shim() -> Option<PathBuf> {
     let name = shim_filename();
 
     if let Ok(exe) = env::current_exe() {
         if let Some(dir) = exe.parent() {
             let candidate = dir.join(name);
-            if candidate.exists() {
+            if is_usable_shim(&candidate) {
                 return Some(candidate);
             }
             let lib_candidate = dir.join("../lib").join(name);
-            if lib_candidate.exists() {
+            if is_usable_shim(&lib_candidate) {
                 return Some(lib_candidate);
             }
         }
@@ -557,18 +598,18 @@ fn find_shim() -> Option<PathBuf> {
 
     if let Ok(cargo_home) = env::var("CARGO_HOME") {
         let candidate = PathBuf::from(&cargo_home).join("lib").join(name);
-        if candidate.exists() {
+        if is_usable_shim(&candidate) {
             return Some(candidate);
         }
     }
 
     let cwd_candidate = PathBuf::from("target/release").join(name);
-    if cwd_candidate.exists() {
+    if is_usable_shim(&cwd_candidate) {
         return Some(cwd_candidate);
     }
 
     let cwd_debug = PathBuf::from("target/debug").join(name);
-    if cwd_debug.exists() {
+    if is_usable_shim(&cwd_debug) {
         return Some(cwd_debug);
     }
 
@@ -946,13 +987,22 @@ fn install_shell_hook(shell_name: &str) -> Result<(PathBuf, String)> {
 
     if let Some(shim_path) = find_shim() {
         let dest = lib_dir.join(shim_filename());
-        fs::copy(&shim_path, &dest)
-            .with_context(|| format!("failed to copy shim to {}", dest.display()))?;
-        println!(
-            "  Copied VFS shim: {} -> {}",
-            shim_path.display(),
-            dest.display()
-        );
+        // On the standard install layout the shim already lives at ~/.kin/lib
+        // and `find_shim` resolves the source via ~/.kin/bin/../lib — i.e. the
+        // source and destination are the SAME FILE. `copy_shim` no-ops that case
+        // so the shim is never truncated onto itself.
+        match copy_shim(&shim_path, &dest)? {
+            ShimCopy::Skipped => {
+                println!("  VFS shim already in place: {}", dest.display());
+            }
+            ShimCopy::Copied => {
+                println!(
+                    "  Copied VFS shim: {} -> {}",
+                    shim_path.display(),
+                    dest.display()
+                );
+            }
+        }
     } else {
         println!("  VFS shim not found. Build it with:");
         println!("    cargo build --release -p kin-vfs-shim");
@@ -1004,6 +1054,28 @@ pub(crate) fn reinstall_shell_hook() -> Result<PathBuf> {
     let shell_name = detect_shell();
     let (hook_file, _source_line) = install_shell_hook(shell_name)?;
     Ok(hook_file)
+}
+
+/// Re-source a usable VFS shim into `~/.kin/lib`.
+///
+/// Used by `kin doctor --fix` to repair the `vfs_projection` check when the
+/// installed shim is missing or was truncated to 0 bytes. Returns the
+/// destination path when a usable shim was installed, or `None` when no usable
+/// source shim exists anywhere — in that case the bytes cannot be reconstructed
+/// locally and the caller directs the user to reinstall.
+pub(crate) fn reinstall_vfs_shim() -> Result<Option<PathBuf>> {
+    let lib_dir = kin_dir()?.join("lib");
+    fs::create_dir_all(&lib_dir).context("failed to create ~/.kin/lib/")?;
+    let dest = lib_dir.join(shim_filename());
+
+    // `find_shim` only returns non-empty candidates, so a truncated shim is
+    // never re-selected as the source. `copy_shim` no-ops if the usable shim
+    // already is the destination.
+    let Some(shim_path) = find_shim() else {
+        return Ok(None);
+    };
+    copy_shim(&shim_path, &dest)?;
+    Ok(Some(dest))
 }
 
 /// Re-merge the kin MCP server entry (with the agent-default profile) into the
@@ -1596,6 +1668,24 @@ pub async fn doctor(fix: bool, json: bool) -> Result<()> {
         }
     }
 
+    // Re-source the VFS shim when it is missing or was truncated to 0 bytes.
+    let vfs_needs_fix = report.checks.iter().any(|c| {
+        c.id == "vfs_projection"
+            && c.fixable
+            && !matches!(c.status, crate::commands::health::HealthStatus::Healthy)
+    });
+    if vfs_needs_fix {
+        match reinstall_vfs_shim() {
+            Ok(Some(dest)) => applied.push(format!("reinstalled VFS shim ({})", dest.display())),
+            Ok(None) => println!(
+                "  {} no usable VFS shim found to reinstall — re-run the installer \
+                 (curl -fsSL https://get.kinlab.dev/install | sh)",
+                style("✗").red()
+            ),
+            Err(e) => println!("  {} VFS shim reinstall failed: {e}", style("✗").red()),
+        }
+    }
+
     // Start the repo daemon if we're inside a Kin repo and it isn't running.
     let daemon_needs_fix = report.checks.iter().any(|c| {
         c.id == "daemon_running"
@@ -1714,6 +1804,69 @@ mod tests {
             no_interactive: true,
             intent: None,
         }
+    }
+
+    #[test]
+    fn is_usable_shim_requires_a_nonempty_file() {
+        let tmp = tempfile::tempdir().unwrap();
+        let empty = tmp.path().join("empty.dylib");
+        fs::write(&empty, b"").unwrap();
+        let full = tmp.path().join("full.dylib");
+        fs::write(&full, b"real bytes").unwrap();
+        let missing = tmp.path().join("missing.dylib");
+
+        assert!(!is_usable_shim(&empty), "0-byte shim must not be usable");
+        assert!(is_usable_shim(&full));
+        assert!(!is_usable_shim(&missing));
+    }
+
+    #[test]
+    fn same_file_detects_the_bin_dotdot_lib_aliasing() {
+        let tmp = tempfile::tempdir().unwrap();
+        let lib = tmp.path().join("lib");
+        let bin = tmp.path().join("bin");
+        fs::create_dir_all(&lib).unwrap();
+        fs::create_dir_all(&bin).unwrap();
+        let dest = lib.join(shim_filename());
+        fs::write(&dest, b"shim").unwrap();
+
+        // The exact path find_shim produces on the standard install layout.
+        let aliased = bin.join("..").join("lib").join(shim_filename());
+        assert!(same_file(&aliased, &dest));
+
+        let other = lib.join("other.dylib");
+        fs::write(&other, b"x").unwrap();
+        assert!(!same_file(&other, &dest));
+    }
+
+    #[test]
+    fn copy_shim_skips_self_copy_and_preserves_bytes() {
+        // Regression: `kin setup` copied the shim onto itself (bin/../lib aliases
+        // lib) and fs::copy truncated it to 0 bytes. The guard must no-op and
+        // leave the bytes intact.
+        let tmp = tempfile::tempdir().unwrap();
+        let lib = tmp.path().join("lib");
+        let bin = tmp.path().join("bin");
+        fs::create_dir_all(&lib).unwrap();
+        fs::create_dir_all(&bin).unwrap();
+        let dest = lib.join(shim_filename());
+        fs::write(&dest, b"REAL_SHIM_BYTES").unwrap();
+        let aliased_src = bin.join("..").join("lib").join(shim_filename());
+
+        assert_eq!(copy_shim(&aliased_src, &dest).unwrap(), ShimCopy::Skipped);
+        assert_eq!(fs::read(&dest).unwrap(), b"REAL_SHIM_BYTES");
+    }
+
+    #[test]
+    fn copy_shim_copies_a_distinct_source() {
+        let tmp = tempfile::tempdir().unwrap();
+        let src = tmp.path().join("source.dylib");
+        fs::write(&src, b"SOURCE_BYTES").unwrap();
+        let dest = tmp.path().join("lib").join(shim_filename());
+        fs::create_dir_all(dest.parent().unwrap()).unwrap();
+
+        assert_eq!(copy_shim(&src, &dest).unwrap(), ShimCopy::Copied);
+        assert_eq!(fs::read(&dest).unwrap(), b"SOURCE_BYTES");
     }
 
     #[test]


### PR DESCRIPTION
## What

Fixes the fourth fresh-machine first-run breakage: `kin setup` truncated the VFS projection shim to 0 bytes, so every process the shell hook wrapped crashed (a 0-byte injected `DYLD_INSERT_LIBRARIES` / `LD_PRELOAD` library). Companion to #159 (the install.sh + daemon-logging first-run fixes); split out because it touches `setup.rs`/`health.rs` and sequences after the session-runtime PR that also edits them.

## Root cause

On the standard install layout the shim lives at `~/.kin/lib/<shim>`, and `find_shim()` resolves the source through the binary's sibling: `~/.kin/bin/../lib/<shim>` — the **same file** as the copy destination `~/.kin/lib/<shim>`. `fs::copy` opens the destination with truncation *before* reading the source, so copying the shim onto itself zeroed it out. Verified on both platforms: a valid ~825 KB dylib in the release tarball → 0 bytes after `kin setup`.

## Fixes (`crates/kin-cli/src/commands/setup.rs`, `health.rs`)

- **Copy guard**: route the shim copy through `copy_shim(src, dest)`, which no-ops when `src` and `dest` are the same file (`canonicalize` + compare). The shim is never truncated onto itself. Both `install_shell_hook` and the doctor repair use it.
- **Size-aware `find_shim`**: only return candidates that exist **and are non-empty**, so a previously-truncated shim is never re-selected as a copy source (which would just re-copy the corruption).
- **Doctor repair**: the `vfs_projection` health check is now `fixable`, and `kin doctor --fix` re-sources a usable shim into `~/.kin/lib` via `reinstall_vfs_shim()`. When no usable shim exists locally it reports honestly and points at a reinstall — the bytes can't be reconstructed offline, so it does not pretend to repair.

## Tests (`kin-cli`, unit)
- `copy_shim_skips_self_copy_and_preserves_bytes` — the regression: the `bin/../lib` self-alias is a no-op and the bytes survive.
- `same_file_detects_the_bin_dotdot_lib_aliasing` — the exact aliasing `find_shim` produces resolves to the same file.
- `is_usable_shim_requires_a_nonempty_file` — 0-byte / missing files are not usable sources.
- `copy_shim_copies_a_distinct_source` — a genuinely different source is still copied.

## Gate
`cargo fmt --all --check`, clippy (ci.yml allowlist, `RUSTFLAGS=-D warnings`), `cargo build --all-targets --locked`, `cargo test --workspace --locked` — all green (re-run after rebase onto main).
