### PR TITLE
fix(ci): eliminate two load-induced test flakes (kin-git import race, chaos_recovery poll)

### DIFF
--- a/crates/kin-daemon/tests/chaos_recovery.rs
+++ b/crates/kin-daemon/tests/chaos_recovery.rs
@@ -18,6 +18,29 @@ fn free_port() -> u16 {
         .port()
 }
 
+/// Readiness budget for a daemon to come up. Generous enough that two CI runs
+/// sharing a runner (a push build and a pull_request build on the same commit)
+/// can both bring a daemon up under load without a false timeout. A daemon that
+/// dies during startup is detected eagerly via its child handle, so this budget
+/// only ever bounds a slow-but-live startup, never a dead one.
+const READINESS_TIMEOUT: Duration = Duration::from_secs(180);
+
+/// Capped exponential backoff for readiness polling: responsive at first, then
+/// it stops hammering a saturated runner once the wait stretches out.
+fn backoff_after(current: Duration) -> Duration {
+    (current * 2).min(Duration::from_millis(1000))
+}
+
+/// Fail loudly the instant a daemon child exits before it is ready instead of
+/// polling a dead process until the readiness deadline. This turns a bind
+/// collision or a startup crash into an immediate, legible failure rather than
+/// a multi-minute "never became healthy" hang.
+fn assert_child_alive(child: &mut Child, port: u16, what: &str) {
+    if let Ok(Some(status)) = child.try_wait() {
+        panic!("daemon on port {port} exited before it became {what}: {status}");
+    }
+}
+
 fn init_repo(root: &Path) {
     kin_core::init(root).unwrap();
 }
@@ -41,10 +64,11 @@ fn spawn_daemon_with_env(repo_root: &Path, port: u16, envs: &[(&str, &str)]) -> 
     cmd.spawn().expect("failed to spawn kin-daemon")
 }
 
-async fn wait_for_health(port: u16) -> HealthResponse {
+async fn wait_for_health(child: &mut Child, port: u16) -> HealthResponse {
     let client = reqwest::Client::new();
     let url = format!("http://127.0.0.1:{port}/health");
-    let deadline = Instant::now() + Duration::from_secs(60);
+    let deadline = Instant::now() + READINESS_TIMEOUT;
+    let mut backoff = Duration::from_millis(50);
 
     loop {
         if let Ok(response) = client.get(&url).send().await {
@@ -56,17 +80,20 @@ async fn wait_for_health(port: u16) -> HealthResponse {
             }
         }
 
+        assert_child_alive(child, port, "healthy");
         if Instant::now() >= deadline {
             panic!("daemon on port {port} never became healthy");
         }
 
-        tokio::time::sleep(Duration::from_millis(100)).await;
+        tokio::time::sleep(backoff).await;
+        backoff = backoff_after(backoff);
     }
 }
 
-async fn wait_for_serving(port: u16) {
+async fn wait_for_serving(child: &mut Child, port: u16) {
     let addr = format!("127.0.0.1:{port}");
-    let deadline = Instant::now() + Duration::from_secs(60);
+    let deadline = Instant::now() + READINESS_TIMEOUT;
+    let mut backoff = Duration::from_millis(50);
     let mut observations = Vec::new();
 
     loop {
@@ -77,6 +104,7 @@ async fn wait_for_serving(port: u16) {
             }
         }
 
+        assert_child_alive(child, port, "reachable");
         if Instant::now() >= deadline {
             let last_observation = observations
                 .last()
@@ -85,7 +113,8 @@ async fn wait_for_serving(port: u16) {
             panic!("daemon on port {port} never served health: {last_observation}");
         }
 
-        tokio::time::sleep(Duration::from_millis(100)).await;
+        tokio::time::sleep(backoff).await;
+        backoff = backoff_after(backoff);
     }
 }
 
@@ -118,7 +147,8 @@ async fn wait_for_path_removed(path: &Path, what: &str, timeout: Duration) {
 async fn create_branch(port: u16, name: &str) {
     let client = reqwest::Client::new();
     let url = format!("http://127.0.0.1:{port}/graph/branches");
-    let deadline = Instant::now() + Duration::from_secs(10);
+    let deadline = Instant::now() + Duration::from_secs(30);
+    let mut backoff = Duration::from_millis(50);
 
     loop {
         let result = client
@@ -136,7 +166,8 @@ async fn create_branch(port: u16, name: &str) {
         if Instant::now() >= deadline {
             result.expect("create branch request failed");
         }
-        tokio::time::sleep(Duration::from_millis(100)).await;
+        tokio::time::sleep(backoff).await;
+        backoff = backoff_after(backoff);
     }
 }
 
@@ -148,7 +179,7 @@ async fn daemon_recovers_after_process_kill_and_restart() {
     let port = free_port();
     let mut child = spawn_daemon(repo.path(), port);
 
-    let first = wait_for_health(port).await;
+    let first = wait_for_health(&mut child, port).await;
     assert_eq!(first.status, "ok");
     assert!(first.uptime_seconds < 20);
 
@@ -163,7 +194,7 @@ async fn daemon_recovers_after_process_kill_and_restart() {
     );
 
     let mut restarted = spawn_daemon(repo.path(), port);
-    let second = wait_for_health(port).await;
+    let second = wait_for_health(&mut restarted, port).await;
     assert_eq!(second.status, "ok");
     assert!(second.uptime_seconds < 20);
 
@@ -194,7 +225,7 @@ async fn daemon_exits_after_idle_timeout_and_removes_endpoint_files() {
         ],
     );
 
-    wait_for_serving(port).await;
+    wait_for_serving(&mut child, port).await;
 
     let daemon_port = repo.path().join(".kin/daemon.port");
     let daemon_pid = repo.path().join(".kin/daemon.pid");
@@ -257,7 +288,7 @@ async fn daemon_exits_after_dirty_repo_control_dir_is_removed() {
         ],
     );
 
-    wait_for_serving(port).await;
+    wait_for_serving(&mut child, port).await;
     create_branch(port, "dirty-before-delete").await;
 
     std::fs::remove_dir_all(repo.path().join(".kin")).unwrap();

--- a/crates/kin-git/src/import.rs
+++ b/crates/kin-git/src/import.rs
@@ -232,6 +232,22 @@ fn import_full(
         let _span =
             tracing::info_span!("kin.git.import_full.map_commits", commits = oids.len()).entered();
         let thread_safe = repo.clone().into_sync();
+
+        // Force every pack index to load once here, on the walking thread,
+        // before the workers fan out. gitoxide loads pack indices lazily on
+        // first access; when many rayon workers take that first look
+        // concurrently through their own thread-local handles, a worker can
+        // transiently observe a present object as missing while another worker
+        // is still initializing the shared index slot. Loading all indices up
+        // front on a single thread closes that window for the commit lookup
+        // and every nested tree/blob lookup below. A genuinely absent object
+        // still fails loud in the worker.
+        thread_safe
+            .to_thread_local()
+            .objects
+            .packed_object_count()
+            .map_err(|e| GitError::Git(e.to_string()))?;
+
         oids.par_iter()
             .map(|oid| {
                 let local = thread_safe.to_thread_local();


### PR DESCRIPTION
Two well-diagnosed CI flakes were taxing every PR under load. Both are timing/contention artifacts, not product defects; this lands a root-cause fix for each.

### 1. kin-git parallel-import ODB visibility race

`import_full` walks commit OIDs sequentially, then maps them to `SemanticChange`s in parallel with rayon. Each worker takes a thread-local gitoxide handle and looks up its commit — and transitively the parent commit, both trees, and changed blobs. gitoxide loads pack indices lazily on first access; when many workers take that first look at once through their own handles, a worker can transiently observe a **present** object as missing while another worker is still initializing the shared index slot. Symptom: `parallel_import_is_byte_identical_to_serial` panics with `Git("object <oid> could not be found")` at ~50% per run under saturated CI (hit both ubuntu and macOS runs). The earlier `gc.auto=off` mitigation did not close it — the race is process-internal.

**Fix:** force every pack index to load once, on the walking thread, before the workers fan out (`packed_object_count()` drives `Store::load_all_indices`, populating the shared object store's slot map). Every thread-local handle created afterward inherits the fully-loaded index set, so no worker performs a concurrent first-load — for the commit lookup or any nested tree/blob lookup. Nothing is masked: a genuinely missing object still returns NotFound and fails loud in the worker.

**Stability:** `parallel_import_is_byte_identical_to_serial` × 24 under 8-way concurrent oversubscription → 24/24 green (plus the full kin-git suite, twice).

### 2. chaos_recovery daemon readiness-poll timeout

`daemon_recovers_after_process_kill_and_restart` and its two sibling lifecycle tests polled a fixed 60s readiness deadline. With two CI runs sharing a runner (push + pull_request on the same SHA), a loaded runner's daemon didn't reach `/health` within 60s and the test panicked "never became healthy" while the twin passed. (Ports were already ephemeral via `free_port()`.)

**Fix**, applied consistently to `wait_for_health`, `wait_for_serving`, and `create_branch`:
- Load-tolerant readiness budget (180s) for a slow-but-live startup under 2× load.
- Capped exponential backoff (50ms → 1s) so a saturated runner isn't hammered.
- Eager child-liveness check: if the daemon exits before becoming ready (e.g. a bind collision), fail immediately with its exit status instead of polling a dead process to the deadline.

**Stability:** the three tests × 8 as 2-way concurrent "twin CI" pairs under load → 8/8 green.

### Gate (local, toolchain 1.96.0, registry-clean `--locked`)

`cargo fmt --check` · clippy (ci.yml allowlist, `-D warnings`) · `check_runtime_boundaries.sh` · `check_private_repo_coupling.sh` · `cargo build --all-targets --locked` · `cargo test --workspace --locked` (2475 passed / 0 failed, 56 binaries) — all green.
