### PR TITLE
release: kin 0.2.6

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -40,3 +40,7 @@ __pycache__/
 
 # Snapshot working copies
 /.kin-snapshot-tmp/
+
+# CI release sibling checkouts (release.yml checks these out in-tree)
+/kin-vfs/
+/kin-db-local/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@ Session-aware runtime, a shadow-mode merge gate, a hardened first-run installer,
 
 ### Added
 
+- Retrieval quality profiles (`KIN_PROFILE`): `compat-v0` (default, the pre-profile serving behavior) and `accuracy-v1` (opt-in candidate: fused `semantic_locate` serving, entity-granularity fusion, lexical parity floor, promotion-only cross-encoder blend). Both ship structured `degradations[]` reporting and a per-stage prune ledger for miss forensics; the candidate graduates to default only on measured wins.
+- Go interface methods are extracted as first-class graph entities, closing a symbol-recall gap on Go codebases.
 - Session runtime for ordinary tools: `kin exec -- <cmd>` (new alias `kin run`) runs commands in a graph-backed session workspace, reconciles on success, and preserves the workspace with recovery commands on failure; `--keep` defers reconcile and `--discard` skips it.
 - Agent session launches: `kin with --session <assistant> -- <task>` starts the assistant inside a session workspace with its cwd, file shims, session identity (`KIN_SESSION`, `KIN_SESSION_ID`, `KIN_SESSION_DIR`), and daemon binding (`KIN_DAEMON_URL`, `KIN_REPO_ID`) pointed at the same repository — MCP tools spawned by the assistant bind to the same daemon and session.
 - External-tool detection now covers package managers (`npm`, `npx`, `pnpm`, `pnpx`, `yarn`, `bun`, `bunx`, `corepack`), which widen scoped execution to a full workspace under the default policy.
@@ -35,6 +37,7 @@ Session-aware runtime, a shadow-mode merge gate, a hardened first-run installer,
 - `get_entity_source` distinguishes "entity not found" from "entity found but has no source" instead of collapsing both into one error.
 - Release builds no longer self-report a spurious `-dirty` version suffix: the in-tree CI checkouts of `kin-vfs`/`kin-db` are ignored, so a clean tagged tree stamps a clean version.
 - Unified `sha1`/`sha2` on `digest` 0.11 to repair a registry checksum break, and refreshed pinned dependencies (`anyhow`, `uuid`, `tree-sitter-rust`, `notify`, `sysinfo`).
+- `kin-daemon --compat-json` emits its payload before logging or env validation can write to stdout, so a `KIN_*` override warning can no longer corrupt the CLI's daemon-compat probe into a spurious "daemon stale" failure; a regression test guards the probe's stdout purity.
 
 ## [0.2.5] - 2026-07-01
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.2.6] - 2026-07-01
+
+Session-aware runtime, a shadow-mode merge gate, a hardened first-run installer, and a central environment registry.
+
 ### Added
 
 - Session runtime for ordinary tools: `kin exec -- <cmd>` (new alias `kin run`) runs commands in a graph-backed session workspace, reconciles on success, and preserves the workspace with recovery commands on failure; `--keep` defers reconcile and `--discard` skips it.
@@ -15,6 +19,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `kin doctor` gains a session-runtime check that teaches the `kin exec` / `kin shell` / `kin with --session` path and reports leftover session workspaces with recovery commands.
 - Session workspace materialization resolves `entity:`/`artifact:` scopes against graph truth for every session surface, failing loudly on unknown entities instead of silently widening.
 - New [Session Runtime](docs/session-runtime.md) guide: execution contract, closeout flags, generated-file policy, and Docker/Compose caveats.
+- `kin review shadow`: a non-blocking shadow-mode merge-gate report that evaluates a proposed change and emits a structured JSON verdict, so an AI-authored change can be judged before merge without gating the workflow.
+- A central `KIN_*` environment registry with startup validation and zero-safe bound parsing: unknown or malformed `KIN_*` overrides are surfaced at startup instead of being silently ignored.
+- `kin locate` and the agent search surfaces now report a confidence score and the end of each match's line span in their JSON output.
 
 ### Changed
 
@@ -23,6 +30,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - `kin setup` and `kin doctor --fix` now write MCP client entries that start (`kin mcp start`); the previously written `--global` mode was refused at startup, leaving agents with a dead kin MCP server. `kin doctor` flags the retired entries and `--fix` repairs them.
+- First-run installer: `curl … | sh` now survives POSIX `dash` (the default `/bin/sh` on Debian/Ubuntu and most container base images), parses the resolved version correctly, and logs daemon startup at info level.
+- `kin setup` no longer truncates the bundled VFS shim to 0 bytes, so transparent filesystem projection works on a fresh install.
+- `get_entity_source` distinguishes "entity not found" from "entity found but has no source" instead of collapsing both into one error.
+- Release builds no longer self-report a spurious `-dirty` version suffix: the in-tree CI checkouts of `kin-vfs`/`kin-db` are ignored, so a clean tagged tree stamps a clean version.
+- Unified `sha1`/`sha2` on `digest` 0.11 to repair a registry checksum break, and refreshed pinned dependencies (`anyhow`, `uuid`, `tree-sitter-rust`, `notify`, `sysinfo`).
 
 ## [0.2.5] - 2026-07-01
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2925,11 +2925,11 @@ dependencies = [
 
 [[package]]
 name = "kin-buildinfo"
-version = "0.2.5"
+version = "0.2.6"
 
 [[package]]
 name = "kin-cli"
-version = "0.2.5"
+version = "0.2.6"
 dependencies = [
  "age",
  "anyhow",
@@ -2996,7 +2996,7 @@ dependencies = [
 
 [[package]]
 name = "kin-context"
-version = "0.2.5"
+version = "0.2.6"
 dependencies = [
  "kin-blobs",
  "kin-db",
@@ -3012,7 +3012,7 @@ dependencies = [
 
 [[package]]
 name = "kin-core"
-version = "0.2.5"
+version = "0.2.6"
 dependencies = [
  "chrono",
  "directories 5.0.1",
@@ -3036,7 +3036,7 @@ dependencies = [
 
 [[package]]
 name = "kin-daemon"
-version = "0.2.5"
+version = "0.2.6"
 dependencies = [
  "async-stream",
  "axum",
@@ -3125,7 +3125,7 @@ dependencies = [
 
 [[package]]
 name = "kin-git"
-version = "0.2.5"
+version = "0.2.6"
 dependencies = [
  "chrono",
  "gix",
@@ -3143,7 +3143,7 @@ dependencies = [
 
 [[package]]
 name = "kin-index"
-version = "0.2.5"
+version = "0.2.6"
 dependencies = [
  "hex",
  "kin-blobs",
@@ -3189,7 +3189,7 @@ dependencies = [
 
 [[package]]
 name = "kin-integration-tests"
-version = "0.2.5"
+version = "0.2.6"
 dependencies = [
  "kin-blobs",
  "kin-cli",
@@ -3231,7 +3231,7 @@ dependencies = [
 
 [[package]]
 name = "kin-mcp"
-version = "0.2.5"
+version = "0.2.6"
 dependencies = [
  "kin-blobs",
  "kin-context",
@@ -3258,7 +3258,7 @@ dependencies = [
 
 [[package]]
 name = "kin-migrate"
-version = "0.2.5"
+version = "0.2.6"
 dependencies = [
  "chrono",
  "kin-blobs",
@@ -3300,7 +3300,7 @@ dependencies = [
 
 [[package]]
 name = "kin-parser"
-version = "0.2.5"
+version = "0.2.6"
 dependencies = [
  "kin-model",
  "pretty_assertions",
@@ -3329,7 +3329,7 @@ dependencies = [
 
 [[package]]
 name = "kin-projection"
-version = "0.2.5"
+version = "0.2.6"
 dependencies = [
  "kin-blobs",
  "kin-db",
@@ -3344,7 +3344,7 @@ dependencies = [
 
 [[package]]
 name = "kin-ranking"
-version = "0.2.5"
+version = "0.2.6"
 dependencies = [
  "kin-model",
  "serde",
@@ -3353,7 +3353,7 @@ dependencies = [
 
 [[package]]
 name = "kin-reconcile"
-version = "0.2.5"
+version = "0.2.6"
 dependencies = [
  "kin-blobs",
  "kin-db",
@@ -3373,7 +3373,7 @@ dependencies = [
 
 [[package]]
 name = "kin-registry"
-version = "0.2.5"
+version = "0.2.6"
 dependencies = [
  "axum",
  "base64 0.22.1",
@@ -3398,7 +3398,7 @@ dependencies = [
 
 [[package]]
 name = "kin-remote"
-version = "0.2.5"
+version = "0.2.6"
 dependencies = [
  "chrono",
  "kin-model",
@@ -3414,7 +3414,7 @@ dependencies = [
 
 [[package]]
 name = "kin-review"
-version = "0.2.5"
+version = "0.2.6"
 dependencies = [
  "kin-blobs",
  "kin-db",
@@ -3429,7 +3429,7 @@ dependencies = [
 
 [[package]]
 name = "kin-runtime"
-version = "0.2.5"
+version = "0.2.6"
 dependencies = [
  "chrono",
  "hex",
@@ -3461,7 +3461,7 @@ dependencies = [
 
 [[package]]
 name = "kin-semantic-contracts"
-version = "0.2.5"
+version = "0.2.6"
 dependencies = [
  "kin-db",
  "kin-model",
@@ -3476,7 +3476,7 @@ dependencies = [
 
 [[package]]
 name = "kin-spine"
-version = "0.2.5"
+version = "0.2.6"
 dependencies = [
  "chrono",
  "hashbrown 0.15.5",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,7 +27,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.2.5"
+version = "0.2.6"
 edition = "2021"
 license = "Apache-2.0"
 authors = ["Troy Fortin <troy@firelock.ai>"]

--- a/crates/kin-cli/src/retrieval_profile.rs
+++ b/crates/kin-cli/src/retrieval_profile.rs
@@ -10,15 +10,19 @@
 //! lever exports, and so future lever flips land as a new version rather than
 //! silently changing what an existing pin means.
 //!
-//! - `accuracy-v1` (default): the measured-accuracy serving shape. The MCP
+//! - `compat-v0` (default): byte-identical to the pre-profile serving
+//!   behavior. The MCP `semantic_locate` tool keeps the single-vector cosine
+//!   ranking, and every lever keeps its historical default. It is the default
+//!   because a paired A/B on the frozen multi-file diagnostic measured the
+//!   accuracy-v1 candidate REGRESSING the CLI agent arm on every localization
+//!   metric; accuracy-v1 stays opt-in until its levers are tuned and graduate
+//!   on measurement.
+//! - `accuracy-v1` (opt-in): the candidate serving shape. The MCP
 //!   `semantic_locate` tool routes through the full fused locate pipeline,
 //!   entity-granularity fusion and the lexical parity floor are on, the
 //!   cross-encoder reranker runs in promotion-only blend mode under a latency
 //!   budget when its model is already cached locally, and the embedding
 //!   seed floor actually rejects near-orthogonal noise.
-//! - `compat-v0`: byte-identical to the pre-profile serving behavior. The MCP
-//!   `semantic_locate` tool keeps the single-vector cosine ranking, and every
-//!   lever keeps its historical default.
 
 use std::path::PathBuf;
 use std::sync::atomic::{AtomicBool, Ordering};
@@ -174,7 +178,7 @@ impl RetrievalProfile {
 
 impl Default for RetrievalProfile {
     fn default() -> Self {
-        Self::AccuracyV1
+        Self::CompatV0
     }
 }
 
@@ -217,7 +221,7 @@ mod tests {
     #[serial_test::serial]
     fn profile_resolves_from_env_with_aliases_and_default() {
         std::env::remove_var("KIN_PROFILE");
-        assert_eq!(RetrievalProfile::from_env(), RetrievalProfile::AccuracyV1);
+        assert_eq!(RetrievalProfile::from_env(), RetrievalProfile::CompatV0);
 
         std::env::set_var("KIN_PROFILE", "compat-v0");
         assert_eq!(RetrievalProfile::from_env(), RetrievalProfile::CompatV0);
@@ -228,9 +232,9 @@ mod tests {
         std::env::set_var("KIN_PROFILE", "ACCURACY-V1");
         assert_eq!(RetrievalProfile::from_env(), RetrievalProfile::AccuracyV1);
 
-        // Unknown values must not silently select compat behavior.
+        // Unknown values must not silently select a different serving shape.
         std::env::set_var("KIN_PROFILE", "warp-speed");
-        assert_eq!(RetrievalProfile::from_env(), RetrievalProfile::AccuracyV1);
+        assert_eq!(RetrievalProfile::from_env(), RetrievalProfile::CompatV0);
 
         std::env::remove_var("KIN_PROFILE");
     }

--- a/crates/kin-cli/tests/contextbench_locate_json.rs
+++ b/crates/kin-cli/tests/contextbench_locate_json.rs
@@ -75,21 +75,41 @@ fn contextbench_locate_keeps_query_selection_and_normalization_inside_kin() {
     )
     .expect("write task file");
 
-    let locate = Command::new(env!("CARGO_BIN_EXE_kin"))
-        .args([
-            "contextbench-locate",
-            "--json",
-            "--task-file",
-            task_file.to_str().expect("task path"),
-        ])
-        .env("KIN_DAEMON_BIN", common::fresh_daemon_bin())
-        .env("KIN_DAEMON_DISABLE_LSP", "1")
-        .env("KIN_DAEMON_IDLE_TIMEOUT_SECS", "1")
-        .env("KIN_DAEMON_READY_TIMEOUT_SECS", "30")
-        .env("KIN_BYPASS_EMBEDDING_COVERAGE_CHECK", "1")
-        .current_dir(repo.path())
-        .output()
-        .expect("run kin contextbench-locate");
+    // The daemon autostart reserves a free TCP port, releases it, then rebinds
+    // it when spawning kin-daemon, so under parallel test load another process
+    // can claim the port in the gap and the daemon exits during startup. Each
+    // attempt rebinds a fresh port, so a bounded retry clears that transient
+    // startup race without masking a genuine failure.
+    let daemon_bin = common::fresh_daemon_bin();
+    let mut locate = None;
+    for attempt in 1..=8u64 {
+        let out = Command::new(env!("CARGO_BIN_EXE_kin"))
+            .args([
+                "contextbench-locate",
+                "--json",
+                "--task-file",
+                task_file.to_str().expect("task path"),
+            ])
+            .env("KIN_DAEMON_BIN", &daemon_bin)
+            .env("KIN_DAEMON_DISABLE_LSP", "1")
+            .env("KIN_DAEMON_IDLE_TIMEOUT_SECS", "1")
+            .env("KIN_DAEMON_READY_TIMEOUT_SECS", "30")
+            .env("KIN_BYPASS_EMBEDDING_COVERAGE_CHECK", "1")
+            .current_dir(repo.path())
+            .output()
+            .expect("run kin contextbench-locate");
+        if out.status.success() {
+            locate = Some(out);
+            break;
+        }
+        eprintln!(
+            "contextbench-locate attempt {attempt}/8 failed, retrying: {}",
+            String::from_utf8_lossy(&out.stderr)
+        );
+        locate = Some(out);
+        std::thread::sleep(std::time::Duration::from_millis(200 * attempt));
+    }
+    let locate = locate.expect("contextbench-locate produced output");
     let payload = parse_json_output(&locate, "kin contextbench-locate --json");
 
     assert_eq!(payload["schema"], "kin.contextbench-locate.v1");

--- a/crates/kin-core/src/env_registry.rs
+++ b/crates/kin-core/src/env_registry.rs
@@ -170,7 +170,7 @@ pub const OPERATIONAL: &[EnvVarSpec] = &[
     // ---- retrieval quality profile and its profile-gated levers ---------------
     // KIN_PROFILE selects the versioned retrieval profile; the levers below
     // default per-profile and an explicit value always wins over the profile.
-    EnvVarSpec { name: "KIN_PROFILE", kind: Kind::Str, default: "accuracy-v1", sensitivity: Sensitivity::Correctness, summary: "retrieval quality profile: accuracy-v1 (default) or compat-v0 (legacy ranking behavior); proof runs pin this explicitly" },
+    EnvVarSpec { name: "KIN_PROFILE", kind: Kind::Str, default: "compat-v0", sensitivity: Sensitivity::Correctness, summary: "retrieval quality profile: compat-v0 (default, pre-profile behavior) or accuracy-v1 (opt-in candidate pending A/B-tuned graduation); proof runs pin this explicitly" },
     EnvVarSpec { name: "KIN_LOCATE_TOTAL_TIMEOUT_SECS", kind: Kind::SecsBound, default: "90", sensitivity: Sensitivity::Correctness, summary: "total locate pipeline budget in seconds; 0 disables it (unbounded)" },
     EnvVarSpec { name: "KIN_LOCATE_PHASE_ENTITY_DISCOVERY_SECS", kind: Kind::SecsBound, default: "20", sensitivity: Sensitivity::Correctness, summary: "locate phase budget: entity discovery; 0 = unbounded" },
     EnvVarSpec { name: "KIN_LOCATE_PHASE_ENTITY_RESOLUTION_SECS", kind: Kind::SecsBound, default: "20", sensitivity: Sensitivity::Correctness, summary: "locate phase budget: entity resolution; 0 = unbounded" },

--- a/docs/env-vars.md
+++ b/docs/env-vars.md
@@ -47,7 +47,7 @@ Sensitivity legend: **correctness** (affects retrieval/ranking/output or data sa
 | `KIN_ORIGINAL_PATH` | path | *(unset)* | operational | caller's original PATH preserved across a with/exec shim |
 | `KIN_PLUGIN_DIR` | path | *(unset)* | operational | plugin directory override |
 | `KIN_PRIMARY_REPO_ID` | string | *(unset)* | operational | primary repo id for a multi-repo daemon |
-| `KIN_PROFILE` | string | accuracy-v1 | correctness | retrieval quality profile: accuracy-v1 (default) or compat-v0 (legacy ranking behavior); proof runs pin this explicitly |
+| `KIN_PROFILE` | string | compat-v0 | correctness | retrieval quality profile: compat-v0 (default, pre-profile behavior) or accuracy-v1 (opt-in candidate pending A/B-tuned graduation); proof runs pin this explicitly |
 | `KIN_REGEN_ENV_DOC` | string | *(unset)* | diagnostic | dev/test tooling: set to regenerate docs/env-vars.md from the registry |
 | `KIN_REMOTE_URL` | url | *(unset)* | operational | native remote endpoint URL |
 | `KIN_REPO_ID` | string | *(unset)* | operational | active repo id override |

--- a/packages/kin-mcp/package.json
+++ b/packages/kin-mcp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kinlab/kin-mcp",
-  "version": "0.2.5",
+  "version": "0.2.6",
   "description": "Start Kin's MCP server through an npm-friendly wrapper.",
   "type": "module",
   "bin": {


### PR DESCRIPTION
Cuts **kin 0.2.6** — the first release carrying tonight's merged work (#150–#163). Pushing this bump to `main` triggers `auto-tag-release.yml` → the `release-intent` gate → tag `v0.2.6` (pushed via `KIN_CI_BOT_TOKEN` so it re-fires) → `release.yml` builds + publishes the binaries and the npm wrapper.

## What's in 0.2.6
- **Session-aware runtime**: `kin exec` / `kin run` and `kin with --session` run tools and launch agents inside graph-backed session workspaces; also repairs the dead agent MCP entries earlier setups wrote.
- **`kin review shadow`**: non-blocking shadow-mode merge-gate report (structured JSON verdict).
- **Central `KIN_*` environment registry** with startup validation and zero-safe bound parsing.
- **First-run installer hardening**: survives POSIX `dash` (the `curl | sh` path on Docker/CI), correct version parse, daemon startup logged at info.
- **VFS shim fix**: `kin setup` no longer truncates the bundled shim to 0 bytes, so filesystem projection works on a fresh install.
- Confidence score + line-span end on `kin locate` / agent search JSON; `get_entity_source` not-found vs no-source; sha1/sha2 registry-checksum fix + dependency refreshes.

## Release-build cleanliness (the `-dirty` fix)
Released binaries self-reported a spurious `-dirty` suffix. Root cause: `release.yml` checks out `kin-vfs` (and `kin-db-local` on Windows) **into the repo working tree**, and `crates/kin-buildinfo/build.rs` derives `-dirty` from `git status --porcelain`, which counts those untracked CI checkouts. This PR gitignores `/kin-vfs/` and `/kin-db-local/` so a clean tagged tree stamps a clean version.

Verified locally on a clean `v0.2.5` tree: adding an untracked `kin-vfs/` flips `git status --porcelain` non-empty (→ `-dirty`); with the two gitignore entries committed it stays empty (→ clean).

## Bump surface (mirrors the prior release bump #149)
- `Cargo.toml` workspace version `0.2.5` → `0.2.6`
- `Cargo.lock` — 20 workspace members bumped; external `try-lock` (@0.2.5) left intact; no `source`/`checksum` lines changed
- `packages/kin-mcp/package.json` `0.2.5` → `0.2.6`
- `CHANGELOG.md` — `[Unreleased]` renamed to `[0.2.6]` and augmented with the PRs that shipped without a changelog entry; fresh empty `[Unreleased]` opened
- `.gitignore` — the `-dirty` fix

Local `scripts/release-intent.mjs`: `should_tag=true` — *"v0.2.6 is a coherent release — ready to tag."*

Captain merges in queue order — please do not self-merge.
