### PR TITLE
fix(spine): fail-loud cross-repo impact client + register-on-refresh test coverage

### DIFF
--- a/crates/kin-cli/src/backend.rs
+++ b/crates/kin-cli/src/backend.rs
@@ -442,15 +442,23 @@ pub async fn require_daemon_graph_mutations(
 // ── Spine Federation Helpers ──────────────────────────────────────────────
 
 /// Query the daemon for federated impact analysis across the spine.
+///
+/// Returns a [`kin_spine::SpineQuery`] so the caller can tell apart a spine
+/// that is not configured (no daemon endpoint), one that is configured but
+/// unreachable/non-2xx (e.g. `503` when the spine is disabled), and a healthy
+/// answer that is genuinely empty — instead of collapsing a transport/HTTP
+/// failure into a silent "no impact" result. Mirrors [`get_spine_xref`].
 pub async fn get_spine_impact(
     layout: &kin_core::KinLayout,
     repo_id: &str,
     entity_id: &kin_model::EntityId,
     depth: u32,
-) -> anyhow::Result<Option<::kin_spine::FederatedImpact>> {
-    let daemon_url = crate::daemon_client::resolve_daemon_url(layout)
-        .await?
-        .ok_or_else(|| anyhow::anyhow!("Kin daemon is required for spine impact queries"))?;
+) -> anyhow::Result<::kin_spine::SpineQuery<::kin_spine::FederatedImpact>> {
+    use ::kin_spine::{classify_spine_probe, SpineProbe, SpineQuery};
+
+    let Some(daemon_url) = crate::daemon_client::resolve_daemon_url(layout).await? else {
+        return Ok(SpineQuery::NotConfigured);
+    };
     let client = reqwest::Client::builder()
         .timeout(Duration::from_secs(10))
         .build()?;
@@ -466,14 +474,19 @@ pub async fn get_spine_impact(
             ("depth", &depth.to_string()),
         ])
         .send()
-        .await?;
+        .await;
+    let status = resp.as_ref().ok().map(|r| r.status().as_u16());
 
-    if !resp.status().is_success() {
-        return Ok(None);
+    match classify_spine_probe(true, status) {
+        SpineProbe::Healthy => {
+            let impact = resp?.json::<::kin_spine::FederatedImpact>().await?;
+            Ok(SpineQuery::Found(impact))
+        }
+        SpineProbe::Unavailable(reason) => Ok(SpineQuery::Unavailable(reason)),
+        SpineProbe::NotConfigured => Ok(SpineQuery::Unavailable(
+            "spine endpoint unexpectedly unconfigured".to_string(),
+        )),
     }
-
-    let impact = resp.json::<::kin_spine::FederatedImpact>().await?;
-    Ok(Some(impact))
 }
 
 /// Query the daemon for cross-repo edges (xrefs) for a specific entity.

--- a/crates/kin-daemon/src/api.rs
+++ b/crates/kin-daemon/src/api.rs
@@ -10295,10 +10295,13 @@ mod tests {
             "kin xref CLI must resolve consumer->provider: {cli_xref:?}"
         );
 
-        let cli_impact = get_spine_impact(&layout, "provider", &do_work_id, 5)
+        let cli_impact = match get_spine_impact(&layout, "provider", &do_work_id, 5)
             .await
             .expect("CLI get_spine_impact call")
-            .expect("CLI get_spine_impact returns impact");
+        {
+            kin_spine::SpineQuery::Found(impact) => impact,
+            other => panic!("CLI get_spine_impact expected Found, got {other:?}"),
+        };
         let cli_impact_hits_consumer = cli_impact.repos_involved.iter().any(|r| r == "consumer");
         assert!(
             cli_impact_hits_consumer,
@@ -10341,6 +10344,76 @@ mod tests {
             daemon_xref_to_provider && cli_xref_to_provider && mcp_xref_to_provider,
             "daemon, CLI, and MCP must all resolve the same consumer->provider xref"
         );
+
+        std::env::remove_var("KIN_DAEMON_URL");
+        server.abort();
+    }
+
+    /// Fail-loud contract: when a spine endpoint IS configured but the daemon
+    /// answers non-2xx (e.g. `503` because the spine is disabled), every client
+    /// surface must report the gap as `SpineQuery::Unavailable` — never collapse
+    /// it into a silent empty result (the old `Ok(None)` swallow) nor a quiet
+    /// `NotConfigured`. This is the cross-repo analogue of the graph-first
+    /// "fail loud or report the gap" rule, enforced across CLI and MCP.
+    #[tokio::test]
+    #[serial_test::serial]
+    async fn spine_clients_surface_unavailable_on_non_success_status() {
+        use kin_cli::backend::{get_spine_impact, get_spine_xref};
+        use kin_mcp::handlers::common::{fetch_spine_impact_typed, fetch_spine_xref};
+
+        // A stand-in daemon that answers every route 503. No real graph and no
+        // autostart — the clients reach it purely through KIN_DAEMON_URL.
+        async fn always_unavailable() -> StatusCode {
+            StatusCode::SERVICE_UNAVAILABLE
+        }
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let addr = listener.local_addr().unwrap();
+        let server = tokio::spawn(async move {
+            let _ = axum::serve(listener, Router::new().fallback(always_unavailable)).await;
+        });
+        std::env::set_var("KIN_DAEMON_URL", format!("http://{addr}"));
+
+        let layout = test_state().layout.clone();
+        let repo = "consumer";
+        let entity = EntityId::new();
+
+        // ── CLI xref: configured-but-failing must be Unavailable, naming 503. ──
+        match get_spine_xref(&layout, repo, &entity)
+            .await
+            .expect("CLI get_spine_xref call")
+        {
+            kin_spine::SpineQuery::Unavailable(reason) => {
+                assert!(
+                    reason.contains("503"),
+                    "reason must name the status: {reason}"
+                );
+            }
+            other => panic!("CLI xref must be Unavailable on 503, got {other:?}"),
+        }
+
+        // ── CLI impact: the surface migrated off the Ok(None) swallow. ──
+        match get_spine_impact(&layout, repo, &entity, 5)
+            .await
+            .expect("CLI get_spine_impact call")
+        {
+            kin_spine::SpineQuery::Unavailable(reason) => {
+                assert!(
+                    reason.contains("503"),
+                    "reason must name the status: {reason}"
+                );
+            }
+            other => panic!("CLI impact must be Unavailable on 503, got {other:?}"),
+        }
+
+        // ── MCP xref + impact: same fail-loud contract. ──
+        match fetch_spine_xref(repo, &entity).await {
+            kin_spine::SpineQuery::Unavailable(_) => {}
+            other => panic!("MCP xref must be Unavailable on 503, got {other:?}"),
+        }
+        match fetch_spine_impact_typed(repo, &entity, 5).await {
+            kin_spine::SpineQuery::Unavailable(_) => {}
+            other => panic!("MCP impact must be Unavailable on 503, got {other:?}"),
+        }
 
         std::env::remove_var("KIN_DAEMON_URL");
         server.abort();

--- a/crates/kin-mcp/src/handlers/common.rs
+++ b/crates/kin-mcp/src/handlers/common.rs
@@ -146,43 +146,6 @@ fn daemon_url_from_env() -> Result<String> {
         })
 }
 
-/// Query the daemon for federated impact analysis across the spine.
-pub async fn fetch_spine_impact(
-    repo_id: &str,
-    entity_id: &EntityId,
-    depth: u32,
-) -> Result<Option<serde_json::Value>> {
-    let daemon_url = daemon_url_from_env()?;
-    let client = reqwest::Client::builder()
-        .timeout(std::time::Duration::from_secs(10))
-        .build()
-        .map_err(|e| McpError::Other(format!("failed to build reqwest client: {}", e)))?;
-
-    let resp = client
-        .get(format!(
-            "{}/v1/spine/impact",
-            daemon_url.trim_end_matches('/')
-        ))
-        .query(&[
-            ("repo", repo_id),
-            ("entity", &entity_id.to_string()),
-            ("depth", &depth.to_string()),
-        ])
-        .send()
-        .await
-        .map_err(|e| McpError::Other(format!("failed to send spine request: {}", e)))?;
-
-    if !resp.status().is_success() {
-        return Ok(None);
-    }
-
-    let impact = resp
-        .json::<serde_json::Value>()
-        .await
-        .map_err(|e| McpError::Other(format!("failed to parse spine response: {}", e)))?;
-    Ok(Some(impact))
-}
-
 /// Query the daemon for federated impact analysis, returning the typed struct.
 ///
 /// Returns a [`SpineQuery`] so callers can distinguish a spine that is simply

--- a/crates/kin-spine/tests/integration.rs
+++ b/crates/kin-spine/tests/integration.rs
@@ -953,6 +953,104 @@ fn transitive_and_multi_consumer_edges_via_refresh_only() {
     );
 }
 
+// ── Test 18: refresh alone registers the repo as a resolution target ────────
+//
+// Regression guard for the register-on-refresh weld: refresh_cross_repo_edges
+// must register a repo's own entities, not just index its imports. Before it, a
+// repo indexed as an impact node but never became a name-resolution target, so
+// the registry the cross-repo traversal consults came up empty. This asserts the
+// weld directly — a repo that is ONLY ever passed to refresh_cross_repo_edges
+// (never an explicit register_repo) must afterward be both present in
+// registered_repo_ids() and resolvable by name.
+#[test]
+fn refresh_alone_registers_repo_as_resolution_target() {
+    let index = SpineIndex::new();
+    let leaf = source_entity(EntityId::new(), "open_graph", LanguageId::Rust);
+
+    index.refresh_cross_repo_edges("libgraph", std::slice::from_ref(&leaf), &[], &[]);
+
+    assert!(
+        index.registered_repo_ids().contains("libgraph"),
+        "refresh must register the repo in the registry the traversal consults"
+    );
+    let resolved = index.resolve("open_graph", Some(EntityKind::Function), None);
+    assert!(
+        resolved.iter().any(|e| e.repo_id == "libgraph"),
+        "the refreshed repo's own entities must become name-resolution targets"
+    );
+}
+
+// ── Test 19: a 2-hop chain resolves regardless of refresh order ─────────────
+//
+// The production daemon registers every sibling's metadata first, then refreshes
+// each repo's edges. This mirrors that shape: with all repos pre-registered, a
+// leaf ← mid ← top chain resolves even when edges are materialized in
+// dependent-first (adversarial) order — proving the fix does not depend on a
+// lucky dependency-ordered refresh, only on every repo being a resolution target
+// before edges are bound.
+#[test]
+fn two_hop_resolves_independent_of_refresh_order_when_prewired() {
+    let registry: Vec<String> = vec!["leaf".to_string(), "mid".to_string(), "top".to_string()];
+
+    let leaf_fn = source_entity(EntityId::new(), "leaf_fn", LanguageId::Rust);
+    let mid_fn = source_entity(EntityId::new(), "mid_fn", LanguageId::Rust);
+    let top_fn = source_entity(EntityId::new(), "top_fn", LanguageId::Rust);
+
+    // mid calls leaf::leaf_fn (2nd hop); top calls mid::mid_fn (1st hop).
+    let mid_rels = vec![cross_repo_call(
+        mid_fn.id,
+        "leaf",
+        "leaf::leaf_fn",
+        RelationKind::Calls,
+    )];
+    let top_rels = vec![cross_repo_call(
+        top_fn.id,
+        "mid",
+        "mid::mid_fn",
+        RelationKind::Calls,
+    )];
+
+    let index = SpineIndex::new();
+
+    // Pass 1 — register every repo's entities (edges deferred: empty relations),
+    // exactly as the daemon registers all siblings before resolving any edges.
+    index.refresh_cross_repo_edges("leaf", std::slice::from_ref(&leaf_fn), &[], &registry);
+    index.refresh_cross_repo_edges("mid", std::slice::from_ref(&mid_fn), &[], &registry);
+    index.refresh_cross_repo_edges("top", std::slice::from_ref(&top_fn), &[], &registry);
+
+    // Pass 2 — materialize edges in DEPENDENT-FIRST (adversarial) order.
+    index.refresh_cross_repo_edges("top", std::slice::from_ref(&top_fn), &top_rels, &registry);
+    index.refresh_cross_repo_edges("mid", std::slice::from_ref(&mid_fn), &mid_rels, &registry);
+
+    // 1st hop: top → mid, bound to mid's registered entity.
+    let top_out: Vec<_> = index
+        .cross_repo_edges_for("top", &top_fn.id)
+        .into_iter()
+        .filter(|e| e.src_repo == "top")
+        .collect();
+    assert_eq!(top_out.len(), 1, "top must resolve its edge into mid");
+    assert_eq!(top_out[0].dst_repo, "mid");
+    assert_eq!(top_out[0].dst_entity, mid_fn.id);
+
+    // 2nd hop: mid → leaf, bound to leaf's registered entity.
+    let mid_out: Vec<_> = index
+        .cross_repo_edges_for("mid", &mid_fn.id)
+        .into_iter()
+        .filter(|e| e.src_repo == "mid")
+        .collect();
+    assert_eq!(mid_out.len(), 1, "mid must resolve the 2nd hop into leaf");
+    assert_eq!(mid_out[0].dst_repo, "leaf");
+    assert_eq!(mid_out[0].dst_entity, leaf_fn.id);
+
+    // End to end: changing leaf_fn impacts top across both hops.
+    let impact = federated_impact(&index, "leaf", &leaf_fn.id, 5);
+    assert!(
+        impact.repos_involved.contains(&"top".to_string()),
+        "transitive blast radius from leaf must reach top, got {:?}",
+        impact.repos_involved
+    );
+}
+
 /// Register a repo's entity metadata through the store-backed backend,
 /// mirroring the metadata write the daemon performs when it indexes a repo.
 fn ingest_repo(


### PR DESCRIPTION
## What

Two cross-repo/xref hardening fixes plus the tests that pin them.

**1. Complete the fail-loud client migration.** The `SpineQuery<T>` taxonomy
(`NotConfigured` | `Unavailable` | `Found`) already backs the live `kin xref`
and MCP-review-impact paths, but two impact helpers were still on the old
`if !status.is_success() { Ok(None) }` swallow, which is indistinguishable from
a genuine empty result:

- `kin_cli::backend::get_spine_impact` now returns `SpineQuery<FederatedImpact>`,
  mirroring its sibling `get_spine_xref`: no daemon endpoint → `NotConfigured`
  (quiet); transport error / non-2xx → `Unavailable(reason)` naming the status;
  2xx → `Found`. Updated its sole caller (the cross-arm parity test).
- `kin_mcp::handlers::common::fetch_spine_impact` is removed — dead code
  superseded by `fetch_spine_impact_typed`, which already uses the taxonomy.

Net: zero `status → Ok(None)` swallows remain in the cross-repo / xref / impact
client paths; every surface (CLI + MCP) fails loud on a configured-but-failing
spine instead of reporting a silent "no references".

**2. Pin the register-on-refresh weld.** `SpineIndex::refresh_cross_repo_edges`
registers a repo's own entities as name-resolution targets, so a repo that is
only ever refreshed (the direct/store path) still becomes resolvable — the basis
for transitive 2-hop and multi-consumer cross-repo edges. This behavior is now
covered by direct regression tests (previously it was only implied by higher-level
tests).

## Why

A read-only cross-repo audit flagged a silent-empty swallow in the xref client
path and a missing register step in edge refresh. Re-verifying against current
`main` shows both root causes were already largely addressed in flight; this PR
closes the residual gaps (the two un-migrated impact helpers) and adds the
explicit registration + fail-loud tests the audit asked for, so the guarantees
are enforced rather than incidental.

## Evidence

- `cargo fmt -- --check`: clean.
- Clippy (CI allow-list, `-D warnings`) over the changed crates + full dependency
  graph: clean.
- `scripts/verify-zero-file-search.py`, `check_runtime_boundaries.sh`,
  `check_private_repo_coupling.sh`: pass.
- `kin-spine`: 40 unit + 19 integration tests green, including
  `refresh_alone_registers_repo_as_resolution_target` and
  `two_hop_resolves_independent_of_refresh_order_when_prewired`.
- `kin-daemon` spine tests: 12 green, including the new
  `spine_clients_surface_unavailable_on_non_success_status` (all four CLI/MCP
  client surfaces return `Unavailable` against an always-503 stand-in daemon) and
  the migrated cross-arm parity test.
- No dependency changes → `Cargo.lock` unaffected; the registry-clean `--locked`
  build/test is left to CI.

## Deferred follow-up: CrossRepoEdge provenance

`CrossRepoEdge` still carries only `{src_repo, src_entity, dst_repo, dst_entity,
confidence}` — no edge kind, evidence token, or resolution provenance (name-match
vs fingerprint-verified). Adding these is a model + wire-contract change that
cascades across the persisted store contract, the `/spine/xref` (+ `/spine/impact`)
HTTP response shape, and ~23 construction sites, plus new round-trip / surfacing
tests. It is intentionally left out of this correctness PR to keep the review
focused. Draft ticket:

> **Title:** CrossRepoEdge provenance: carry kind + evidence + resolution basis through materialize → persist → xref
>
> **Problem:** Cross-repo edges cannot answer "what kind of reference is this,
> what token produced it, and how was it resolved?" — the third of three
> cross-repo proof paths (edge existence ✓, bidirectional reachability ✓, edge
> provenance ✗).
>
> **Scope:** add optional `#[serde(default)]` fields to `CrossRepoEdge` (`kind`,
> `evidence`, `provenance`); populate at the single build site
> `xref::materialize_edges` from the unresolved import + resolution; surface them
> on the `/spine/xref` (+ impact) response contract; round-trip tests (Firestore
> persist→hydrate; xref JSON carries provenance). `serde(default)` keeps
> already-persisted edges backward-compatible (no hard store migration).
>
> **Why separate:** touches the persisted + wire contracts and ~23 construction
> sites; mixing it with the fail-loud / register fixes would bloat review.
