### PR TITLE
fix(daemon): own port selection via bind-:0 handshake

### DIFF
--- a/crates/kin-cli/src/daemon_client.rs
+++ b/crates/kin-cli/src/daemon_client.rs
@@ -1280,13 +1280,6 @@ pub fn daemon_is_up(kin_root: &Path) -> Option<u16> {
     }
 }
 
-fn find_free_port() -> Option<u16> {
-    std::net::TcpListener::bind("127.0.0.1:0")
-        .ok()
-        .and_then(|l| l.local_addr().ok())
-        .map(|a| a.port())
-}
-
 fn daemon_binary_supports_supervisor(path: &Path) -> bool {
     let output = match Command::new(path).arg("--help").output() {
         Ok(output) => output,
@@ -1732,14 +1725,12 @@ async fn validate_daemon_endpoint(
 async fn wait_for_daemon_ready(
     kin_root: &Path,
     child: &mut Child,
-    port: u16,
     deadline: Instant,
     log_offset: u64,
 ) -> Result<String> {
     let timeout = deadline.saturating_duration_since(Instant::now());
     let client = daemon_health_client();
-    let base_url = format!("http://127.0.0.1:{port}");
-    let mut last_error = String::from("daemon did not bind");
+    let mut last_error = String::from("daemon did not report its port");
 
     while Instant::now() < deadline {
         if let Some(status) = child.try_wait().context("check daemon child status")? {
@@ -1748,6 +1739,16 @@ async fn wait_for_daemon_ready(
                 daemon_log_tail_since(kin_root, log_offset)
             );
         }
+
+        // The daemon binds :0 and writes its actual bound port to the port file
+        // once it is listening. Read it each poll until it appears — the port
+        // file is the daemon→CLI handshake that lets the daemon own port
+        // selection, eliminating the reserve-release-rebind race.
+        let Some(port) = read_port_file(kin_root) else {
+            tokio::time::sleep(Duration::from_millis(200)).await;
+            continue;
+        };
+        let base_url = format!("http://127.0.0.1:{port}");
 
         if is_port_open(port) {
             match client.get(format!("{base_url}/readiness")).send().await {
@@ -1879,20 +1880,27 @@ fn open_supervisor_log() -> Result<File> {
         .with_context(|| format!("open supervisor log at {}", log_path.display()))
 }
 
-async fn wait_for_supervisor_ready(
-    child: &mut Child,
-    port: u16,
-    deadline: Instant,
-) -> Result<String> {
+async fn wait_for_supervisor_ready(child: &mut Child, deadline: Instant) -> Result<String> {
     let timeout = deadline.saturating_duration_since(Instant::now());
     let client = daemon_health_client();
-    let base_url = format!("http://127.0.0.1:{port}");
-    let mut last_error = String::from("supervisor did not bind");
+    let mut last_error = String::from("supervisor did not report its port");
 
     while Instant::now() < deadline {
         if let Some(status) = child.try_wait().context("check supervisor child status")? {
             bail!("supervisor exited during startup with status {status}");
         }
+
+        // The supervisor binds :0 and writes its real bound port to its port
+        // file once listening. Read it each poll until it appears — the port
+        // file is the supervisor→CLI handshake.
+        let Some(port) = std::fs::read_to_string(supervisor_port_path())
+            .ok()
+            .and_then(|value| value.trim().parse::<u16>().ok())
+        else {
+            tokio::time::sleep(Duration::from_millis(100)).await;
+            continue;
+        };
+        let base_url = format!("http://127.0.0.1:{port}");
 
         if is_port_open(port) {
             match client.get(format!("{base_url}/health")).send().await {
@@ -1938,11 +1946,15 @@ pub async fn ensure_supervisor_running() -> Result<String> {
     }
 
     let daemon_bin = find_daemon_binary()?;
-    let port = find_free_port().unwrap_or(4218);
-    info!(binary = %daemon_bin.display(), port, "starting supervisor");
+    // The supervisor binds :0 and reports its real bound port via its endpoint
+    // files; passing 0 (rather than a reserved port) removes the same
+    // reserve-release-rebind race the repo-daemon path had. Clear stale endpoint
+    // files so wait_for_supervisor_ready reads only this spawn's port.
+    remove_stale_supervisor_files();
+    info!(binary = %daemon_bin.display(), "starting supervisor (OS-assigned port)");
 
     let mut cmd = std::process::Command::new(&daemon_bin);
-    cmd.args(["--supervisor", "--port", &port.to_string()]);
+    cmd.args(["--supervisor", "--port", "0"]);
     let log = open_supervisor_log()?;
     let stderr = log
         .try_clone()
@@ -1969,8 +1981,8 @@ pub async fn ensure_supervisor_running() -> Result<String> {
 
     let mut child = cmd.spawn().context("spawn kin supervisor")?;
     let deadline = Instant::now() + Duration::from_secs(daemon_ready_timeout_secs());
-    let base_url = wait_for_supervisor_ready(&mut child, port, deadline).await?;
-    info!(port, "supervisor is up and ready");
+    let base_url = wait_for_supervisor_ready(&mut child, deadline).await?;
+    info!(supervisor = %base_url, "supervisor is up and ready");
     Ok(base_url)
 }
 
@@ -2235,16 +2247,22 @@ pub async fn ensure_daemon_running_with_idle_timeout(
     let working_dir = kin_root
         .parent()
         .ok_or_else(|| anyhow!("invalid .kin layout: no parent"))?;
-    let port = find_free_port().unwrap_or(4219);
 
-    info!(binary = %daemon_bin.display(), repo = %working_dir.display(), port, "starting daemon");
+    // The daemon owns port selection: it binds :0 and reports the real bound
+    // port via the port file. Passing 0 (rather than a port we reserve here)
+    // eliminates the reserve-release-rebind race where a sibling process steals
+    // the port between our probe and the daemon's bind. Clear any stale port
+    // file first so wait_for_daemon_ready only reads the port this spawn writes.
+    let _ = std::fs::remove_file(kin_root.join("daemon.port"));
+
+    info!(binary = %daemon_bin.display(), repo = %working_dir.display(), "starting daemon (OS-assigned port)");
 
     let mut cmd = std::process::Command::new(&daemon_bin);
     cmd.args([
         "--repo",
         &working_dir.display().to_string(),
         "--port",
-        &port.to_string(),
+        "0",
     ]);
     let log_offset = daemon_log_len(kin_root);
     let log = open_daemon_log(kin_root)?;
@@ -2276,9 +2294,9 @@ pub async fn ensure_daemon_running_with_idle_timeout(
 
     let timeout_secs = daemon_ready_timeout_secs();
     let deadline = Instant::now() + Duration::from_secs(timeout_secs);
-    let base_url = wait_for_daemon_ready(kin_root, &mut child, port, deadline, log_offset).await?;
+    let base_url = wait_for_daemon_ready(kin_root, &mut child, deadline, log_offset).await?;
     register_repo_daemon_with_supervisor(kin_root, &base_url, &supervisor_url).await?;
-    info!(port, "daemon is up and ready");
+    info!(daemon = %base_url, "daemon is up and ready");
     Ok(base_url)
 }
 

--- a/crates/kin-cli/src/daemon_client.rs
+++ b/crates/kin-cli/src/daemon_client.rs
@@ -2258,12 +2258,7 @@ pub async fn ensure_daemon_running_with_idle_timeout(
     info!(binary = %daemon_bin.display(), repo = %working_dir.display(), "starting daemon (OS-assigned port)");
 
     let mut cmd = std::process::Command::new(&daemon_bin);
-    cmd.args([
-        "--repo",
-        &working_dir.display().to_string(),
-        "--port",
-        "0",
-    ]);
+    cmd.args(["--repo", &working_dir.display().to_string(), "--port", "0"]);
     let log_offset = daemon_log_len(kin_root);
     let log = open_daemon_log(kin_root)?;
     let stderr = log

--- a/crates/kin-daemon/src/api.rs
+++ b/crates/kin-daemon/src/api.rs
@@ -7419,6 +7419,33 @@ mod tests {
         Arc::new(DaemonState::open(layout).unwrap())
     }
 
+    #[tokio::test]
+    async fn bind_api_listener_reports_real_ephemeral_port() {
+        // Runs under a Tokio runtime because binding a tokio TcpListener needs
+        // the reactor — exactly how the daemon calls this at startup.
+        // The daemon-owned port handshake: binding :0 must yield a concrete,
+        // live ephemeral port (never 0), and two independent :0 binds must land
+        // on different ports — proving the OS assigns the port and nothing is
+        // reserved ahead of the bind. This is what lets the daemon pick its own
+        // port and report it, instead of a launcher reserving-and-releasing a
+        // port a peer can steal before the daemon binds.
+        let state = test_state();
+
+        let (listener_a, port_a) = bind_api_listener(&state, 0).expect("bind :0");
+        assert_ne!(port_a, 0, "bind_api_listener must report a real bound port");
+        assert_eq!(
+            port_a,
+            listener_a.local_addr().unwrap().port(),
+            "reported port must equal the listener's actual bound port"
+        );
+
+        let (_listener_b, port_b) = bind_api_listener(&state, 0).expect("second bind :0");
+        assert_ne!(
+            port_a, port_b,
+            "two :0 binds must get distinct ports (no fixed-port reservation)"
+        );
+    }
+
     #[test]
     fn scope_build_timeout_defaults_and_rejects_invalid_values() {
         assert_eq!(resolve_scope_build_timeout(None), Duration::from_secs(870));

--- a/crates/kin-daemon/src/api.rs
+++ b/crates/kin-daemon/src/api.rs
@@ -6985,16 +6985,40 @@ pub async fn serve(state: Arc<DaemonState>, port: u16) -> std::io::Result<()> {
     serve_with_shutdown(state, port, shutdown_rx).await
 }
 
-/// Start the API server on the given port and stop when shutdown is signaled.
-pub async fn serve_with_shutdown(
-    state: Arc<DaemonState>,
+/// Bind the daemon API listener and report the concrete port it is bound to.
+///
+/// Passing `port == 0` binds an OS-assigned ephemeral port; the returned value
+/// is the real port the daemon must advertise. This is the primitive behind the
+/// daemon-owned port handshake: the daemon binds (optionally `:0`) and then
+/// publishes the actual bound port via `.kin/daemon.port`, instead of a launcher
+/// reserving a port and releasing it before the daemon re-binds — a window a
+/// racing process can steal (the `find_free_port` TOCTOU).
+pub fn bind_api_listener(
+    state: &DaemonState,
     port: u16,
+) -> std::io::Result<(tokio::net::TcpListener, u16)> {
+    let bind_host = bind_host_from_env();
+    let auth_present = resolve_serve_auth_token(&state.layout).is_some();
+    let listener = bind_listener(&bind_host, port, auth_present)?;
+    let bound_port = listener.local_addr()?.port();
+    Ok((listener, bound_port))
+}
+
+/// Serve the daemon API on an already-bound listener until shutdown is signaled.
+///
+/// Pairs with [`bind_api_listener`]: the daemon binds first — so it can publish
+/// the real bound port before the slower graph/LSP startup — then serves here.
+pub async fn serve_bound_with_shutdown(
+    state: Arc<DaemonState>,
+    listener: tokio::net::TcpListener,
     mut shutdown_rx: tokio::sync::watch::Receiver<bool>,
 ) -> std::io::Result<()> {
-    let bind_host = bind_host_from_env();
     let auth_token = resolve_serve_auth_token(&state.layout);
-    let app = router_with_auth(state, auth_token.clone());
-    let listener = bind_listener(&bind_host, port, auth_token.is_some())?;
+    let app = router_with_auth(state, auth_token);
+    let port = listener
+        .local_addr()
+        .map(|addr| addr.port())
+        .unwrap_or_default();
 
     info!(port, "daemon API server listening");
 
@@ -7007,6 +7031,16 @@ pub async fn serve_with_shutdown(
             }
         })
         .await
+}
+
+/// Start the API server on the given port and stop when shutdown is signaled.
+pub async fn serve_with_shutdown(
+    state: Arc<DaemonState>,
+    port: u16,
+    shutdown_rx: tokio::sync::watch::Receiver<bool>,
+) -> std::io::Result<()> {
+    let (listener, _bound_port) = bind_api_listener(&state, port)?;
+    serve_bound_with_shutdown(state, listener, shutdown_rx).await
 }
 
 fn resolve_bind_host(bind_host: Option<String>) -> String {

--- a/crates/kin-daemon/src/daemon.rs
+++ b/crates/kin-daemon/src/daemon.rs
@@ -512,16 +512,32 @@ pub async fn run(mut state: DaemonState, config: DaemonConfig) -> Result<()> {
 
     let state = Arc::new(state);
 
-    // Write the port file so CLI processes can discover and auto-connect. Each
-    // repo gets its own daemon on its own port — the port file enables per-repo
-    // isolation (critical for benchmark worktrees). The PID file was written
-    // earlier, immediately after acquiring the singleton lock.
-    crate::lifecycle::write_port_file(state.layout.root(), config.api_port);
+    // Bind the API listener up front so the daemon owns port selection. With
+    // config.api_port == 0 the OS assigns a free ephemeral port; we then publish
+    // the *actual* bound port via the port file. Binding here — before the port
+    // file is written and before the slower graph/LSP startup — closes the
+    // reserve-release-rebind race (find_free_port TOCTOU) where a launcher picked
+    // a port, dropped it, and a sibling process stole it before the daemon bound.
+    let (api_listener, bound_port) = match api::bind_api_listener(&state, config.api_port) {
+        Ok(bound) => bound,
+        Err(error) => {
+            // We hold the singleton lock and already wrote daemon.pid; drop the
+            // pid file so a failed bind never strands a stale endpoint record.
+            crate::lifecycle::remove_pid_file(state.layout.root());
+            return Err(DaemonError::Io(error));
+        }
+    };
+
+    // Publish the actual bound port so CLI processes can discover and auto-connect.
+    // Each repo gets its own daemon on its own port — the port file enables
+    // per-repo isolation (critical for benchmark worktrees). The PID file was
+    // written earlier, immediately after acquiring the singleton lock.
+    crate::lifecycle::write_port_file(state.layout.root(), bound_port);
 
     // Shutdown signal: when set to true, all loops exit.
     let (cancel_tx, cancel_rx) = tokio::sync::watch::channel(false);
 
-    info!(port = config.api_port, "starting kin daemon");
+    info!(port = bound_port, "starting kin daemon");
 
     let idle_state = Arc::clone(&state);
     let idle_timeout = config.idle_timeout;
@@ -576,20 +592,18 @@ pub async fn run(mut state: DaemonState, config: DaemonConfig) -> Result<()> {
             async move { loop_runner::run_loop(loop_state, loop_config, loop_cancel).await },
         );
 
-    // Spawn the API server.
+    // Spawn the API server on the pre-bound listener.
     let api_state = Arc::clone(&state);
-    let api_port = config.api_port;
     let api_cancel = cancel_rx.clone();
-    let api_handle =
-        tokio::spawn(
-            async move { api::serve_with_shutdown(api_state, api_port, api_cancel).await },
-        );
+    let api_handle = tokio::spawn(async move {
+        api::serve_bound_with_shutdown(api_state, api_listener, api_cancel).await
+    });
 
     // Register this repo-scoped graph daemon with the lightweight central
     // supervisor when one is available. The supervisor owns process/routing
     // metadata only; this daemon remains graph-authoritative for its repo.
     let supervisor_state = Arc::clone(&state);
-    let supervisor_port = config.api_port;
+    let supervisor_port = bound_port;
     let supervisor_cancel = cancel_rx.clone();
     let supervisor_handle = tokio::spawn(async move {
         crate::supervisor::repo_daemon_registration_loop(

--- a/crates/kin-daemon/src/lifecycle.rs
+++ b/crates/kin-daemon/src/lifecycle.rs
@@ -556,6 +556,34 @@ pub enum AutoStartError {
 mod tests {
     use super::*;
 
+    // ── Port-file handshake ────────────────────────────────────────────────
+    //
+    // The daemon publishes its real bound port here for the CLI handshake, so
+    // read_port_file must recover exactly what write_port_file wrote, overwrite
+    // must replace cleanly, and the atomic temp artifact must never linger for a
+    // polling reader to trip over.
+
+    #[test]
+    fn port_file_round_trips_atomically() {
+        let dir = tempfile::TempDir::new().expect("tempdir");
+        let root = dir.path();
+
+        assert_eq!(read_port_file(root), None, "no port file before first write");
+
+        write_port_file(root, 51234);
+        assert_eq!(read_port_file(root), Some(51234));
+
+        // Overwrite (temp + rename) must replace the previous value cleanly.
+        write_port_file(root, 6001);
+        assert_eq!(read_port_file(root), Some(6001));
+
+        // The atomic-write temp file must not be left behind.
+        assert!(
+            !root.join("daemon.port.tmp").exists(),
+            "atomic write must not leave a .tmp artifact"
+        );
+    }
+
     // ── Idle-timeout env resolution ────────────────────────────────────────
     //
     // These lock the scoped-timeout contract: user env wins over everything,

--- a/crates/kin-daemon/src/lifecycle.rs
+++ b/crates/kin-daemon/src/lifecycle.rs
@@ -568,7 +568,11 @@ mod tests {
         let dir = tempfile::TempDir::new().expect("tempdir");
         let root = dir.path();
 
-        assert_eq!(read_port_file(root), None, "no port file before first write");
+        assert_eq!(
+            read_port_file(root),
+            None,
+            "no port file before first write"
+        );
 
         write_port_file(root, 51234);
         assert_eq!(read_port_file(root), Some(51234));

--- a/crates/kin-daemon/src/lifecycle.rs
+++ b/crates/kin-daemon/src/lifecycle.rs
@@ -160,9 +160,16 @@ pub fn write_pid_file(kin_root: &Path) {
     }
 }
 
-/// Write port file so the CLI knows where to connect.
+/// Write the port file so the CLI knows where to connect.
+///
+/// Written atomically (temp + rename) so a CLI polling the port file during the
+/// daemon→CLI port handshake never parses a torn or partial value.
 pub fn write_port_file(kin_root: &Path, port: u16) {
-    let _ = std::fs::write(kin_root.join("daemon.port"), port.to_string());
+    let tmp = kin_root.join("daemon.port.tmp");
+    let dst = kin_root.join("daemon.port");
+    if std::fs::write(&tmp, port.to_string()).is_ok() {
+        let _ = std::fs::rename(&tmp, &dst);
+    }
 }
 
 /// Read port from `.kin/daemon.port`.

--- a/crates/kin-daemon/src/supervisor.rs
+++ b/crates/kin-daemon/src/supervisor.rs
@@ -176,7 +176,12 @@ fn write_supervisor_endpoint_files(port: u16) {
     if std::fs::write(&pid_tmp, std::process::id().to_string()).is_ok() {
         let _ = std::fs::rename(pid_tmp, supervisor_pid_path());
     }
-    let _ = std::fs::write(supervisor_port_path(), port.to_string());
+    // Written atomically (temp + rename) so a CLI polling the port file during
+    // the supervisor→CLI port handshake never parses a torn or partial value.
+    let port_tmp = dir.join(format!("{SUPERVISOR_PORT_FILE}.tmp"));
+    if std::fs::write(&port_tmp, port.to_string()).is_ok() {
+        let _ = std::fs::rename(port_tmp, supervisor_port_path());
+    }
 }
 
 fn remove_supervisor_endpoint_files_if_current_process() {

--- a/crates/kin-daemon/tests/port_handshake.rs
+++ b/crates/kin-daemon/tests/port_handshake.rs
@@ -1,0 +1,106 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Firelock, LLC
+
+//! End-to-end proof of the daemon-owned port handshake.
+//!
+//! The daemon binds an OS-assigned ephemeral port (`--port 0`) and publishes the
+//! *actual* bound port to `.kin/daemon.port`. The CLI reads the port from that
+//! file instead of reserving a port and releasing it before the daemon re-binds
+//! — the reserve-release-rebind window a sibling process could steal, killing
+//! the daemon during startup under parallel load.
+//!
+//! Because the daemon owns port selection, this test needs no `#[serial]` and no
+//! reserved port to collide on: it spins up its own daemon against a scratch
+//! tempdir store on an ephemeral port and never touches the shared runtime or
+//! `~/.kin`.
+
+use std::path::Path;
+use std::process::Stdio;
+use std::time::{Duration, Instant};
+
+use tokio::process::{Child, Command};
+
+/// Readiness budget for the daemon to bind and serve. Generous so two CI runs
+/// sharing a runner can both come up under load without a false timeout; a
+/// daemon that dies during startup is detected eagerly via its child handle, so
+/// this only ever bounds a slow-but-live startup, never a dead one.
+const READINESS_TIMEOUT: Duration = Duration::from_secs(180);
+
+fn spawn_daemon_ephemeral(repo_root: &Path) -> Child {
+    Command::new(env!("CARGO_BIN_EXE_kin-daemon"))
+        .arg("--repo")
+        .arg(repo_root)
+        // The feature under test: the daemon, not the launcher, picks the port.
+        .arg("--port")
+        .arg("0")
+        // Keep the test hermetic and light: no LSP discovery on the host.
+        .env("KIN_DAEMON_DISABLE_LSP", "1")
+        .stdout(Stdio::inherit())
+        .stderr(Stdio::inherit())
+        .spawn()
+        .expect("failed to spawn kin-daemon")
+}
+
+fn read_port_file(kin_root: &Path) -> Option<u16> {
+    std::fs::read_to_string(kin_root.join("daemon.port"))
+        .ok()
+        .and_then(|value| value.trim().parse().ok())
+}
+
+/// Fail loudly the instant the daemon child exits before it is ready, instead of
+/// polling a dead process until the deadline.
+fn assert_child_alive(child: &mut Child, what: &str) {
+    if let Ok(Some(status)) = child.try_wait() {
+        panic!("daemon exited before it became {what}: {status}");
+    }
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn daemon_binds_ephemeral_port_and_publishes_it() {
+    let repo = tempfile::TempDir::new().expect("tempdir");
+    kin_core::init(repo.path()).expect("init scratch repo");
+    let kin_root = repo.path().join(".kin");
+
+    let mut child = spawn_daemon_ephemeral(repo.path());
+    let deadline = Instant::now() + READINESS_TIMEOUT;
+
+    // Handshake half 1: the daemon must publish a real, non-zero bound port —
+    // never the sentinel 0 we passed on the command line.
+    let port = loop {
+        assert_child_alive(&mut child, "bound");
+        if let Some(port) = read_port_file(&kin_root) {
+            assert_ne!(port, 0, "daemon must publish its real bound port, not 0");
+            break port;
+        }
+        if Instant::now() >= deadline {
+            let _ = child.kill().await;
+            panic!("daemon never wrote its bound port to daemon.port");
+        }
+        tokio::time::sleep(Duration::from_millis(50)).await;
+    };
+
+    // Handshake half 2: the published port must actually serve — /health
+    // responds on exactly the port the daemon reported.
+    let client = reqwest::Client::new();
+    let url = format!("http://127.0.0.1:{port}/health");
+    let mut healthy = false;
+    while Instant::now() < deadline {
+        assert_child_alive(&mut child, "healthy");
+        if let Ok(resp) = client.get(&url).send().await {
+            if resp.status().is_success() {
+                healthy = true;
+                break;
+            }
+        }
+        tokio::time::sleep(Duration::from_millis(100)).await;
+    }
+
+    // Shut the daemon down before asserting so a failure never leaks a process.
+    let _ = child.kill().await;
+    let _ = child.wait().await;
+
+    assert!(
+        healthy,
+        "daemon did not serve /health on its published port {port}"
+    );
+}


### PR DESCRIPTION
## Problem (FIR-1220)

The CLI daemon/supervisor autostart reserved `127.0.0.1:0`, read the assigned port, dropped the listener, then spawned `kin-daemon --port <that port>` to re-bind it. Under parallel `cargo test` a sibling process could grab the port inside that reserve→release→rebind window, so the child failed to bind and exited during startup ("daemon exited during startup" → "kin daemon is required"). That is the `find_free_port()` TOCTOU FIR-1220 describes.

## Fix

Remove the window: the one process that will actually hold the socket selects the port.

- The daemon and supervisor accept `--port 0`, bind an OS-assigned ephemeral port, and publish the **actual bound port** through their endpoint file (`.kin/daemon.port` / the supervisor port file).
- The CLI spawns with `--port 0` and reads the real port from the endpoint file as the readiness handshake, instead of pre-reserving a port.

### Changes
- `api`: split bind from serve — `bind_api_listener` returns `(listener, bound_port)`; `serve_bound_with_shutdown` serves a pre-bound listener. `serve_with_shutdown` keeps its signature (binds then delegates), so existing callers are unaffected.
- `daemon`: bind before announcing, so the port file always carries the real bound port (never the `0` sentinel); the bound port flows to the port file, the startup log, and supervisor registration. On bind failure the pid file is cleared so a failed start leaves no stale endpoint record.
- `lifecycle` / `supervisor`: write the port file atomically (temp + rename) so a polling reader never parses a torn value.
- `daemon_client`: spawn `--port 0` and read the bound port from the endpoint file for both the repo daemon and the supervisor; clear any stale port file before spawn so only this spawn's port is read.

Backward compatible: an explicit `--port <n>` still binds that exact port, so fixed-port callers and existing tests are unaffected.

## Tests
- `port_handshake` integration test: spawns a daemon with `--port 0` against a scratch tempdir store, asserts it publishes a real non-zero bound port and serves `/health` on it. Hermetic and parallel-safe with no `#[serial]` and no reserved port to collide on — the property the handshake provides.
- `bind_api_listener` unit test: `:0` yields a concrete bound port; two binds land on distinct ports (no fixed-port reservation).
- `write_port_file` unit test: atomic round-trip, no leftover temp artifact.

Local verification: `cargo test -p kin-daemon` (290 lib + chaos_recovery + port_handshake, all green), `cargo test -p kin-cli --lib` (612 green), clippy clean on the changed lines.

## Scope notes
- `kin_daemon::lifecycle::ensure_daemon_running` is an unreferenced duplicate autostart (no workspace callers; `kin-cli`'s `daemon_client` is the live path FIR-1220 cites) and is left unchanged.
- The "serial-path ODB pre-warm" companion item is intentionally not in this PR yet: no cold-start race was found at store construction (the graph snapshot and text index both load eagerly/synchronously; blob shard dirs are created idempotently on write). Awaiting a concrete target before adding it to this branch.