### PR TITLE
feat(daemon): write-veto warn-by-default with envelope annotation (FIR-790 phase 1)

### DIFF
--- a/crates/kin-core/src/env_registry.rs
+++ b/crates/kin-core/src/env_registry.rs
@@ -155,7 +155,7 @@ pub const OPERATIONAL: &[EnvVarSpec] = &[
     EnvVarSpec { name: "KIN_BYPASS_EMBEDDING_COVERAGE_CHECK", kind: Kind::Bool, default: "false", sensitivity: Sensitivity::Correctness, summary: "bypass the embedding-coverage correctness gate" },
     EnvVarSpec { name: "KIN_STRICT_BUILD_MATCH", kind: Kind::Bool, default: "false", sensitivity: Sensitivity::Correctness, summary: "require a strict historical build match when resolving a ref view" },
     EnvVarSpec { name: "KIN_ALLOW_MASS_DELETION", kind: Kind::Bool, default: "false", sensitivity: Sensitivity::Correctness, summary: "permit reconcile to apply mass deletions (data-destructive)" },
-    EnvVarSpec { name: "KIN_WRITE_VETO", kind: Kind::OneOf(&["enforce", "off"]), default: "off", sensitivity: Sensitivity::Correctness, summary: "write-veto mode; 'enforce' rejects writes into foreign-held scopes" },
+    EnvVarSpec { name: "KIN_WRITE_VETO", kind: Kind::OneOf(&["warn", "enforce", "off"]), default: "warn", sensitivity: Sensitivity::Correctness, summary: "write-veto mode: 'warn' (default) annotates would-be vetoes into foreign-held scopes, 'enforce' rejects them with a 409, 'off' disables" },
     EnvVarSpec { name: "KIN_DAEMON_LOCATE_ONLY", kind: Kind::Bool, default: "false", sensitivity: Sensitivity::Correctness, summary: "daemon serves locate-only from a snapshot, changing what it answers" },
     EnvVarSpec { name: "KIN_DAEMON_DISABLE_LSP", kind: Kind::Bool, default: "false", sensitivity: Sensitivity::Correctness, summary: "disable LSP enrichment in the daemon, reducing relation coverage" },
     EnvVarSpec { name: "KIN_COCHANGE_MAX_FAN_OUT", kind: Kind::Usize, default: "15", sensitivity: Sensitivity::Correctness, summary: "cap on co-change fan-out per entity (co-change ranking signal)" },

--- a/crates/kin-daemon/src/api.rs
+++ b/crates/kin-daemon/src/api.rs
@@ -5958,31 +5958,41 @@ async fn vfs_readdir(
 ///
 /// Under `KIN_WRITE_VETO=enforce`, returns `Err((409, body))` when the file's
 /// existing entity scopes or its artifact scope are held under another session's
-/// hard intent, rejecting the write *before* it is folded into the graph.
-/// Returns `Ok(())` when the veto is off (default) or the write is allowed,
-/// leaving the apply path byte-identical to prior behavior. `caller` is the
-/// writing session when attributed; a session is never blocked by its own
-/// intent. See [`crate::write_veto`].
+/// hard intent, rejecting the write *before* it is folded into the graph. Under
+/// the default warn mode the write is NOT rejected: returns
+/// `Ok(Some(annotation))` naming the blocking intent(s) so the caller can attach
+/// a `write_veto_warning` to the response envelope. Returns `Ok(None)` when the
+/// veto is off, no intents are active, or the write is allowed — leaving the
+/// response unchanged. `caller` is the writing session when attributed; a
+/// session is never blocked by its own intent. See [`crate::write_veto`].
 async fn write_veto_precheck(
     state: &Arc<DaemonState>,
     file_path: &FsPath,
     display_path: &str,
     caller: Option<SessionId>,
-) -> std::result::Result<(), (StatusCode, String)> {
-    if !crate::write_veto::WriteVetoMode::from_env().is_enforcing() {
-        return Ok(());
+) -> std::result::Result<Option<serde_json::Value>, (StatusCode, String)> {
+    let mode = crate::write_veto::WriteVetoMode::from_env();
+    if mode.is_off() {
+        return Ok(None);
+    }
+    // Cheap short-circuit: with no active intents a write can collide with
+    // nothing, so warn-by-default costs nothing on the common single-agent path
+    // (no per-file entity query, no scope build).
+    let intents = state.graph.list_all_intents().map_err(internal_error)?;
+    if intents.is_empty() {
+        return Ok(None);
     }
     let file_id = kin_index::normalize_file_path_id(file_path, state.layout.working_dir());
     let filter = kin_model::EntityFilter {
         file_path: Some(file_id.clone()),
         ..Default::default()
     };
-    // Perf: this `query_entities` runs once per write under enforce; it is
-    // O(entities-in-file) and is the only added cost on the hot path. Cap the
-    // per-file entity-scope comparison set so the veto can never cost more than
-    // the reconcile it guards — a file-level hard intent is still caught via the
-    // always-present Artifact scope, and the reconciler's own (uncapped) check
-    // remains the backstop.
+    // Perf: this `query_entities` runs once per write while intents are active;
+    // it is O(entities-in-file) and is the only added cost on the hot path. Cap
+    // the per-file entity-scope comparison set so the veto can never cost more
+    // than the reconcile it guards — a file-level hard intent is still caught via
+    // the always-present Artifact scope, and the reconciler's own (uncapped)
+    // check remains the backstop.
     const VETO_SCOPE_CAP: usize = 1024;
     let file_entities = state
         .graph
@@ -6003,46 +6013,103 @@ async fn write_veto_precheck(
         .collect();
     touched.push(IntentScope::Artifact(file_id));
 
-    let intents = state.graph.list_all_intents().map_err(internal_error)?;
     if let crate::write_veto::WriteVetoDecision::Deny { blocking } =
         crate::write_veto::evaluate_write_veto(&intents, &touched, caller)
     {
-        tracing::info!(
-            path = %display_path,
-            blocking = blocking.len(),
-            "write-veto: scope held by foreign hard intent"
-        );
-        let body = crate::write_veto::veto_conflict_body(display_path, &blocking);
-        return Err((StatusCode::CONFLICT, body.to_string()));
+        if mode.is_enforcing() {
+            tracing::info!(
+                path = %display_path,
+                blocking = blocking.len(),
+                "write-veto: rejecting write; scope held by foreign hard intent"
+            );
+            let body = crate::write_veto::veto_conflict_body(display_path, &blocking);
+            return Err((StatusCode::CONFLICT, body.to_string()));
+        }
+        // Warn (default): the write proceeds, but log the would-be veto with
+        // per-intent attribution and annotate the response so the agent sees who
+        // holds the colliding scope.
+        for b in &blocking {
+            tracing::warn!(
+                path = %display_path,
+                blocking_session = %b.session_id,
+                blocking_intent = %b.intent_id,
+                lock = ?b.lock_type,
+                "write-veto[warn]: write would be rejected under KIN_WRITE_VETO=enforce"
+            );
+        }
+        return Ok(Some(crate::write_veto::veto_warning_annotation(
+            display_path,
+            &blocking,
+        )));
     }
-    Ok(())
+    Ok(None)
 }
 
-/// Under `KIN_WRITE_VETO=enforce`, map a reconcile `CollisionBlocked` (e.g. a
-/// brand-new entity colliding with a foreign hard intent — a scope the precheck
-/// cannot see because the entity does not yet exist in the graph) to the same
-/// structured pre-write 409. Returns `None` otherwise, leaving the caller's
-/// soft-notification path intact.
+/// How a reconcile-detected hard collision maps under the active write-veto
+/// mode. Distinguishes enforce (reject) from warn (proceed + annotate) so the
+/// two handlers share one decision path.
+enum CollisionVeto {
+    /// Not a vetoable collision, or veto off — the caller's normal path.
+    Ignore,
+    /// Enforce: reject with this structured `409` body.
+    Block(serde_json::Value),
+    /// Warn: proceed, but annotate the response with this `write_veto_warning`.
+    Warn(serde_json::Value),
+}
+
+/// Map a reconcile `CollisionBlocked` (e.g. a brand-new entity colliding with a
+/// foreign hard intent — a scope the precheck cannot see because the entity does
+/// not yet exist in the graph) to the active mode's response: a pre-write `409`
+/// under enforce, a `write_veto_warning` annotation under warn, or `Ignore`
+/// otherwise (off, or a non-collision error).
 fn write_veto_collision_response(
     err: &kin_reconcile::ReconcileError,
     display_path: &str,
-) -> Option<(StatusCode, String)> {
-    if !crate::write_veto::WriteVetoMode::from_env().is_enforcing() {
-        return None;
+) -> CollisionVeto {
+    let mode = crate::write_veto::WriteVetoMode::from_env();
+    if mode.is_off() {
+        return CollisionVeto::Ignore;
     }
     if let kin_reconcile::ReconcileError::CollisionBlocked {
         blocking_intents, ..
     } = err
     {
-        tracing::info!(
-            path = %display_path,
-            blocking = blocking_intents.len(),
-            "write-veto: hard collision during reconcile"
-        );
-        let body = crate::write_veto::veto_conflict_body(display_path, blocking_intents);
-        return Some((StatusCode::CONFLICT, body.to_string()));
+        if mode.is_enforcing() {
+            tracing::info!(
+                path = %display_path,
+                blocking = blocking_intents.len(),
+                "write-veto: hard collision during reconcile"
+            );
+            let body = crate::write_veto::veto_conflict_body(display_path, blocking_intents);
+            return CollisionVeto::Block(body);
+        }
+        for b in blocking_intents {
+            tracing::warn!(
+                path = %display_path,
+                blocking_session = %b.session_id,
+                blocking_intent = %b.intent_id,
+                "write-veto[warn]: hard collision during reconcile (write not folded)"
+            );
+        }
+        return CollisionVeto::Warn(crate::write_veto::veto_warning_annotation(
+            display_path,
+            blocking_intents,
+        ));
     }
-    None
+    CollisionVeto::Ignore
+}
+
+/// Attach a `write_veto_warning` annotation to a JSON response body when the
+/// veto is in warn mode and the write would have been blocked. No-op when there
+/// is no warning or the body is not a JSON object.
+fn attach_veto_warning(
+    mut body: serde_json::Value,
+    warning: Option<serde_json::Value>,
+) -> serde_json::Value {
+    if let (Some(obj), Some(w)) = (body.as_object_mut(), warning) {
+        obj.insert("write_veto_warning".to_string(), w);
+    }
+    body
 }
 
 /// POST /vfs/file-changed — notify the daemon that a file was modified on disk.
@@ -6064,7 +6131,7 @@ async fn vfs_file_changed(
         .as_ref()
         .and_then(|s| s.parse::<Uuid>().ok())
         .map(SessionId);
-    write_veto_precheck(&state, &file_path, &request.path, caller).await?;
+    let veto_warning = write_veto_precheck(&state, &file_path, &request.path, caller).await?;
 
     let event = kin_index::FileEvent::Changed(file_path);
 
@@ -6190,28 +6257,38 @@ async fn vfs_file_changed(
                 }
             }
 
-            Ok(Json(json!({
-                "status": "reconciled",
-                "path": request.path,
-                "added": added_count,
-                "modified": modified_count,
-                "removed": removed_count,
-            })))
+            Ok(Json(attach_veto_warning(
+                json!({
+                    "status": "reconciled",
+                    "path": request.path,
+                    "added": added_count,
+                    "modified": modified_count,
+                    "removed": removed_count,
+                }),
+                veto_warning,
+            )))
         }
         Err(e) => {
             drop(wc);
             drop(reconciler);
             // Under enforce, surface a hard collision detected during reconcile
-            // as a pre-write 409 rather than the soft notification below.
-            if let Some(resp) = write_veto_collision_response(&e, &request.path) {
-                return Err(resp);
-            }
+            // as a pre-write 409; under warn, annotate the soft notification.
+            let warning = match write_veto_collision_response(&e, &request.path) {
+                CollisionVeto::Block(body) => {
+                    return Err((StatusCode::CONFLICT, body.to_string()));
+                }
+                CollisionVeto::Warn(w) => veto_warning.or(Some(w)),
+                CollisionVeto::Ignore => veto_warning,
+            };
             tracing::warn!(path = %request.path, error = %e, "reconciliation failed");
-            Ok(Json(json!({
-                "status": "error",
-                "path": request.path,
-                "error": e.to_string(),
-            })))
+            Ok(Json(attach_veto_warning(
+                json!({
+                    "status": "error",
+                    "path": request.path,
+                    "error": e.to_string(),
+                }),
+                warning,
+            )))
         }
     }
 }
@@ -6237,7 +6314,7 @@ async fn vfs_write_notify(
         .as_ref()
         .and_then(|s| s.parse::<Uuid>().ok())
         .map(SessionId);
-    write_veto_precheck(&state, &file_path, &request.file_path, caller).await?;
+    let veto_warning = write_veto_precheck(&state, &file_path, &request.file_path, caller).await?;
 
     let event = kin_index::FileEvent::Changed(file_path);
 
@@ -6349,26 +6426,36 @@ async fn vfs_write_notify(
                 }
             }
 
-            Ok(Json(json!({
-                "reindexed": true,
-                "entity_count": entity_count,
-            })))
+            Ok(Json(attach_veto_warning(
+                json!({
+                    "reindexed": true,
+                    "entity_count": entity_count,
+                }),
+                veto_warning,
+            )))
         }
         Err(e) => {
             drop(wc);
             drop(reconciler);
             // Under enforce, surface a hard collision detected during reconcile
             // (e.g. a brand-new entity the precheck cannot see) as a pre-write
-            // 409 rather than the soft notification below.
-            if let Some(resp) = write_veto_collision_response(&e, &request.file_path) {
-                return Err(resp);
-            }
+            // 409; under warn, annotate the soft notification below.
+            let warning = match write_veto_collision_response(&e, &request.file_path) {
+                CollisionVeto::Block(body) => {
+                    return Err((StatusCode::CONFLICT, body.to_string()));
+                }
+                CollisionVeto::Warn(w) => veto_warning.or(Some(w)),
+                CollisionVeto::Ignore => veto_warning,
+            };
             tracing::warn!(path = %request.file_path, error = %e, "write-notify reconciliation failed");
-            Ok(Json(json!({
-                "reindexed": false,
-                "entity_count": 0,
-                "error": e.to_string(),
-            })))
+            Ok(Json(attach_veto_warning(
+                json!({
+                    "reindexed": false,
+                    "entity_count": 0,
+                    "error": e.to_string(),
+                }),
+                warning,
+            )))
         }
     }
 }
@@ -11620,10 +11707,44 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn write_notify_flag_off_keeps_soft_notification() {
-        // Flag-off identity: with a foreign hard intent present, default
-        // behavior is unchanged — the reconciler's own check still declines to
-        // fold the write (reindexed:false) and NO 409 is produced.
+    async fn write_notify_off_keeps_soft_notification_without_annotation() {
+        // Explicit KIN_WRITE_VETO=off identity: with a foreign hard intent
+        // present the reconciler's own check still declines to fold the write
+        // (reindexed:false), NO 409 is produced, and — because the veto never
+        // evaluated — NO write_veto_warning is attached.
+        let _lock = VETO_ENV_LOCK.lock().await;
+        let _env = EnvVarGuard("KIN_WRITE_VETO");
+        std::env::set_var("KIN_WRITE_VETO", "off");
+
+        let state = test_state();
+        let (file_id, abs) = veto_file_target(&state, "src/lib.py");
+        write_disk_file(&state, "src/lib.py", "def foo():\n    return 1\n");
+        let foreign = register_foreign_session(&state, "other-agent");
+        state
+            .coordinator
+            .register_intent(
+                &foreign,
+                vec![IntentScope::Artifact(file_id)],
+                LockType::Hard,
+                "rewriting lib",
+                None,
+            )
+            .unwrap();
+
+        let (status, json) =
+            write_notify(router(state), serde_json::json!({ "file_path": abs })).await;
+
+        assert_eq!(status, StatusCode::OK);
+        assert_eq!(json["reindexed"], false);
+        assert!(json.get("write_veto_warning").is_none());
+    }
+
+    #[tokio::test]
+    async fn write_notify_warn_default_annotates_without_409() {
+        // Warn-by-default (KIN_WRITE_VETO unset): a foreign hard intent does NOT
+        // reject the write (status OK, no 409), but the response carries a
+        // write_veto_warning naming the blocking session so the agent sees the
+        // collision it would have hit under enforce.
         let _lock = VETO_ENV_LOCK.lock().await;
         let _env = EnvVarGuard("KIN_WRITE_VETO");
         std::env::remove_var("KIN_WRITE_VETO");
@@ -11647,7 +11768,47 @@ mod tests {
             write_notify(router(state), serde_json::json!({ "file_path": abs })).await;
 
         assert_eq!(status, StatusCode::OK);
-        assert_eq!(json["reindexed"], false);
+        let warning = &json["write_veto_warning"];
+        assert_eq!(warning["would_block"], true);
+        assert_eq!(
+            warning["blocking_intents"][0]["session_id"],
+            foreign.to_string()
+        );
+    }
+
+    #[tokio::test]
+    async fn write_notify_warn_own_intent_allows_without_annotation() {
+        // Warn own-write guard at the handler: a session editing a file it has
+        // itself hard-locked is folded (reindexed:true) and NOT flagged — no
+        // write_veto_warning on an own write.
+        let _lock = VETO_ENV_LOCK.lock().await;
+        let _env = EnvVarGuard("KIN_WRITE_VETO");
+        std::env::remove_var("KIN_WRITE_VETO");
+
+        let state = test_state();
+        let (file_id, abs) = veto_file_target(&state, "src/lib.py");
+        write_disk_file(&state, "src/lib.py", "def foo():\n    return 1\n");
+        let caller = register_foreign_session(&state, "me");
+        state
+            .coordinator
+            .register_intent(
+                &caller,
+                vec![IntentScope::Artifact(file_id)],
+                LockType::Hard,
+                "editing my own file",
+                None,
+            )
+            .unwrap();
+
+        let (status, json) = write_notify(
+            router(state),
+            serde_json::json!({ "file_path": abs, "session_id": caller.to_string() }),
+        )
+        .await;
+
+        assert_eq!(status, StatusCode::OK);
+        assert_eq!(json["reindexed"], true);
+        assert!(json.get("write_veto_warning").is_none());
     }
 
     #[tokio::test]
@@ -11758,9 +11919,41 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn file_changed_flag_off_keeps_soft_notification() {
-        // Flag-off identity for the file-changed path: foreign hard intent
-        // present, default behavior unchanged — soft 200 {status:"error"}, no 409.
+    async fn file_changed_off_keeps_soft_notification_without_annotation() {
+        // Explicit KIN_WRITE_VETO=off identity for the file-changed path:
+        // foreign hard intent present, soft 200 {status:"error"}, no 409, and no
+        // write_veto_warning (the veto never evaluated).
+        let _lock = VETO_ENV_LOCK.lock().await;
+        let _env = EnvVarGuard("KIN_WRITE_VETO");
+        std::env::set_var("KIN_WRITE_VETO", "off");
+
+        let state = test_state();
+        let (file_id, abs) = veto_file_target(&state, "src/lib.py");
+        write_disk_file(&state, "src/lib.py", "def foo():\n    return 1\n");
+        let foreign = register_foreign_session(&state, "other-agent");
+        state
+            .coordinator
+            .register_intent(
+                &foreign,
+                vec![IntentScope::Artifact(file_id)],
+                LockType::Hard,
+                "rewriting lib",
+                None,
+            )
+            .unwrap();
+
+        let (status, json) = file_changed(router(state), serde_json::json!({ "path": abs })).await;
+
+        assert_eq!(status, StatusCode::OK);
+        assert_eq!(json["status"], "error");
+        assert!(json.get("write_veto_warning").is_none());
+    }
+
+    #[tokio::test]
+    async fn file_changed_warn_default_annotates_without_409() {
+        // Warn-by-default on /vfs/file-changed: a foreign hard intent is not
+        // rejected (status OK, no 409) but the soft response carries a
+        // write_veto_warning naming the blocking session.
         let _lock = VETO_ENV_LOCK.lock().await;
         let _env = EnvVarGuard("KIN_WRITE_VETO");
         std::env::remove_var("KIN_WRITE_VETO");
@@ -11783,7 +11976,10 @@ mod tests {
         let (status, json) = file_changed(router(state), serde_json::json!({ "path": abs })).await;
 
         assert_eq!(status, StatusCode::OK);
-        assert_eq!(json["status"], "error");
+        assert_eq!(
+            json["write_veto_warning"]["blocking_intents"][0]["session_id"],
+            foreign.to_string()
+        );
     }
 
     #[tokio::test]

--- a/crates/kin-daemon/src/lib.rs
+++ b/crates/kin-daemon/src/lib.rs
@@ -34,16 +34,22 @@
 //!
 //! # Write veto (`KIN_WRITE_VETO`)
 //!
-//! Rung-3 of the write path. The agent-write apply path (`POST /vfs/write-notify`)
-//! can reject a write *before* it is folded into the graph when it touches a
-//! scope held under another session's hard intent.
+//! Rung-3 of the write path. The agent-write apply paths (`POST /vfs/write-notify`,
+//! `POST /vfs/file-changed`) evaluate whether a write touches a scope held under
+//! another session's hard intent and, by default, surface the collision without
+//! blocking.
 //!
-//! - Default (unset / any value other than `enforce`): **off**. The apply path
-//!   is byte-identical to prior behavior — a colliding write is declined by the
-//!   reconciler's own check and reported as a soft `200 {reindexed:false}`
-//!   notification.
-//! - `KIN_WRITE_VETO=enforce`: the write is rejected with a structured
-//!   `409 Conflict` (`error: "write_veto"`) naming the blocking intent(s).
+//! - Default (unset): **warn**. The write still proceeds — a colliding write is
+//!   declined by the reconciler's own check and reported as a soft notification —
+//!   but a would-be veto is logged and the response is annotated with
+//!   `write_veto_warning` naming the blocking intent(s), so an agent sees the
+//!   collision it would hit under enforce.
+//! - `KIN_WRITE_VETO=enforce`: the write is rejected *before* it is folded into
+//!   the graph with a structured `409 Conflict` (`error: "write_veto"`) naming
+//!   the blocking intent(s).
+//! - `KIN_WRITE_VETO=off` (`0`/`false`/`disabled`/`none`): the veto never
+//!   evaluates; the apply path is byte-identical to pre-veto behavior (no
+//!   annotation).
 //!
 //! What rung-3 enforces today is exactly **entity/artifact scope containment
 //! versus other sessions' hard intents** — the only "contract" expressible with
@@ -57,20 +63,22 @@
 //! ## Write-path inventory
 //!
 //! Every state-mutating route and its current *pre-write* gate, as of this
-//! change. The two VFS apply paths (`vfs_write_notify`, `vfs_file_changed`) are
-//! flag-gated by the write-veto and `graph_commit` is always-on; the rest
-//! either rely on the reconciler's own soft-block, gate upstream, or are out of
-//! this crate's veto scope.
+//! change. The two VFS apply paths (`vfs_write_notify`, `vfs_file_changed`)
+//! evaluate the write-veto (default **warn** → annotate; `enforce` → pre-write
+//! 409; `off` → byte-identical) and `graph_commit` is always-on; the rest either
+//! rely on the reconciler's own soft-block, gate upstream, or are out of this
+//! crate's veto scope.
 //!
-//! - `POST /vfs/write-notify` (`vfs_write_notify`): **write-veto** under
-//!   `KIN_WRITE_VETO=enforce` (pre-write 409); default = reconciler soft-block
-//!   (`200 {reindexed:false}`).
-//! - `POST /vfs/file-changed` (`vfs_file_changed`): **write-veto** under
-//!   `KIN_WRITE_VETO=enforce` (pre-write 409); default = reconciler soft-block
-//!   (`200 {status:"error"}`). The general-purpose sibling of write-notify;
-//!   gated through the same shared `write_veto_precheck` /
-//!   `write_veto_collision_response` helpers so the two paths cannot drift and
-//!   enforce cannot be bypassed by choosing one endpoint over the other.
+//! - `POST /vfs/write-notify` (`vfs_write_notify`): **write-veto**. Default
+//!   **warn** annotates the soft `200 {reindexed:false}` with `write_veto_warning`
+//!   on a would-be veto; `KIN_WRITE_VETO=enforce` upgrades to a pre-write `409`;
+//!   `KIN_WRITE_VETO=off` restores the byte-identical soft path.
+//! - `POST /vfs/file-changed` (`vfs_file_changed`): **write-veto**, same
+//!   default-warn / enforce-409 / off ladder (soft `200 {status:"error"}` under
+//!   warn/off). The general-purpose sibling of write-notify; gated through the
+//!   same shared `write_veto_precheck` / `write_veto_collision_response` helpers
+//!   so the two paths cannot drift and enforce cannot be bypassed by choosing one
+//!   endpoint over the other.
 //! - `POST /graph/commit` (`graph_commit`): always-on lease **409** on a
 //!   foreign hard intent (the CLI semantic-commit path).
 //! - `POST /commands/commit` (`command_commit`): commits the already-reconciled

--- a/crates/kin-daemon/src/write_veto.rs
+++ b/crates/kin-daemon/src/write_veto.rs
@@ -29,21 +29,35 @@
 //!   writes only ever produce `Entity` / `Artifact` touched-scopes, so nothing
 //!   emits a `Contract` touched-scope to check against.
 //!
-//! The veto is **off by default**: with `KIN_WRITE_VETO` unset (or any value
-//! other than `enforce`), the apply path is byte-identical to prior behavior.
+//! The veto **warns by default**: with `KIN_WRITE_VETO` unset it evaluates
+//! collisions and, on a would-be veto, logs and annotates the response envelope
+//! (`write_veto_warning`) naming the blocking intent(s) — but the write still
+//! proceeds (no `409`). `KIN_WRITE_VETO=enforce` upgrades the warn to a pre-write
+//! `409`; `KIN_WRITE_VETO=off` restores the byte-identical pre-veto path (no
+//! evaluation, no annotation).
 
 use kin_model::session::{Intent, IntentScope, IntentSummary, LockType};
 use kin_model::SessionId;
 
-/// Whether the write veto rejects colliding writes or stays out of the way.
+/// How the write veto reacts when a write collides with a foreign hard intent.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum WriteVetoMode {
-    /// Default. The veto never rejects; the apply path behaves exactly as it
-    /// did before this module existed.
+    /// Explicit escape hatch (`KIN_WRITE_VETO=off`). The veto never evaluates;
+    /// the apply path is byte-identical to pre-veto behavior.
     Off,
+    /// Default. A would-be veto is logged and annotated onto the response
+    /// envelope ("you would have been blocked, and by whom") but the write is
+    /// NOT rejected — no `409`.
+    Warn,
     /// Reject a write that touches a scope held under a foreign hard intent
-    /// with a pre-write `409`.
+    /// with a pre-write `409` (`KIN_WRITE_VETO=enforce`).
     Enforce,
+}
+
+impl Default for WriteVetoMode {
+    fn default() -> Self {
+        Self::Warn
+    }
 }
 
 impl WriteVetoMode {
@@ -52,20 +66,34 @@ impl WriteVetoMode {
         Self::parse(std::env::var("KIN_WRITE_VETO").ok().as_deref())
     }
 
-    /// Parse a raw flag value. Only the literal `enforce` (case-insensitive,
-    /// trimmed) enables the veto; every other value — including `None`, empty,
-    /// `off`, `0` — resolves to [`WriteVetoMode::Off`] so the default path is
-    /// unchanged. Pure, so it is testable without touching process env.
+    /// Parse a raw flag value into a mode. `enforce` selects hard rejection;
+    /// `off` selects [`WriteVetoMode::Off`]; every other value — including
+    /// `None`, empty, `warn`, and unrecognized strings — resolves to the default
+    /// [`WriteVetoMode::Warn`], matching the env registry's enum fallback (a
+    /// value outside the documented set falls back to the default at the read
+    /// site). Pure, so it is testable without touching process env.
     fn parse(raw: Option<&str>) -> Self {
-        match raw {
-            Some(v) if v.trim().eq_ignore_ascii_case("enforce") => Self::Enforce,
-            _ => Self::Off,
+        match raw.map(str::trim) {
+            Some(v) if v.eq_ignore_ascii_case("enforce") => Self::Enforce,
+            Some(v) if v.eq_ignore_ascii_case("off") => Self::Off,
+            _ => Self::Warn,
         }
     }
 
-    /// Whether the veto is in enforcing mode.
+    /// Whether the veto is in enforcing mode (rejects with `409`).
     pub fn is_enforcing(self) -> bool {
         matches!(self, Self::Enforce)
+    }
+
+    /// Whether the veto is fully off (never evaluates a collision).
+    pub fn is_off(self) -> bool {
+        matches!(self, Self::Off)
+    }
+
+    /// Whether the veto evaluates collisions at all (warn or enforce). When
+    /// false, the apply path stays byte-identical to pre-veto behavior.
+    pub fn evaluates(self) -> bool {
+        !self.is_off()
     }
 }
 
@@ -142,6 +170,23 @@ fn summarize(intent: &Intent) -> IntentSummary {
     }
 }
 
+/// Serialize the blocking intents into the attribution array shared by the
+/// enforce `409` body and the warn annotation: session, intent, lock, and task
+/// so an agent can see exactly who holds the colliding scope.
+fn blocking_intents_json(blocking: &[IntentSummary]) -> Vec<serde_json::Value> {
+    blocking
+        .iter()
+        .map(|b| {
+            serde_json::json!({
+                "intent_id": b.intent_id.to_string(),
+                "session_id": b.session_id.to_string(),
+                "lock_type": format!("{:?}", b.lock_type),
+                "task_description": b.task_description,
+            })
+        })
+        .collect()
+}
+
 /// Build the structured `409 Conflict` JSON body naming the blocking intents.
 ///
 /// Mirrors the shape of the existing commit-path `lease_conflict` body so a
@@ -152,17 +197,27 @@ pub fn veto_conflict_body(file_path: &str, blocking: &[IntentSummary]) -> serde_
         "error": "write_veto",
         "conflict_type": "HardCollision",
         "file_path": file_path,
-        "blocking_intents": blocking
-            .iter()
-            .map(|b| serde_json::json!({
-                "intent_id": b.intent_id.to_string(),
-                "session_id": b.session_id.to_string(),
-                "lock_type": format!("{:?}", b.lock_type),
-                "task_description": b.task_description,
-            }))
-            .collect::<Vec<_>>(),
+        "blocking_intents": blocking_intents_json(blocking),
         "message": format!(
             "write blocked: {} scope(s) held by active foreign hard intent(s)",
+            blocking.len()
+        ),
+    })
+}
+
+/// Build the `write_veto_warning` annotation attached to a write response under
+/// warn mode. The write PROCEEDED, but the annotation names the foreign hard
+/// intent(s) that WOULD have rejected it under `enforce`, so an agent (and the
+/// MCP envelope that carries this payload) sees the collision without a `409`.
+pub fn veto_warning_annotation(file_path: &str, blocking: &[IntentSummary]) -> serde_json::Value {
+    serde_json::json!({
+        "would_block": true,
+        "conflict_type": "HardCollision",
+        "file_path": file_path,
+        "blocking_intents": blocking_intents_json(blocking),
+        "message": format!(
+            "write would be rejected under KIN_WRITE_VETO=enforce: {} scope(s) held by \
+             active foreign hard intent(s); the write proceeded (warn mode)",
             blocking.len()
         ),
     })
@@ -186,12 +241,18 @@ mod tests {
     }
 
     #[test]
-    fn mode_parse_only_enforce_enables() {
-        assert_eq!(WriteVetoMode::parse(None), WriteVetoMode::Off);
-        assert_eq!(WriteVetoMode::parse(Some("")), WriteVetoMode::Off);
+    fn mode_parse_maps_off_warn_enforce() {
+        // Default (unset / empty / unrecognized, incl. "0"/"false") → Warn.
+        assert_eq!(WriteVetoMode::parse(None), WriteVetoMode::Warn);
+        assert_eq!(WriteVetoMode::parse(Some("")), WriteVetoMode::Warn);
+        assert_eq!(WriteVetoMode::parse(Some("warn")), WriteVetoMode::Warn);
+        assert_eq!(WriteVetoMode::parse(Some("banana")), WriteVetoMode::Warn);
+        assert_eq!(WriteVetoMode::parse(Some("0")), WriteVetoMode::Warn);
+        assert_eq!(WriteVetoMode::parse(Some("false")), WriteVetoMode::Warn);
+        // The documented off-switch → Off (case-insensitive, trimmed).
         assert_eq!(WriteVetoMode::parse(Some("off")), WriteVetoMode::Off);
-        assert_eq!(WriteVetoMode::parse(Some("0")), WriteVetoMode::Off);
-        assert_eq!(WriteVetoMode::parse(Some("warn")), WriteVetoMode::Off);
+        assert_eq!(WriteVetoMode::parse(Some("  OFF  ")), WriteVetoMode::Off);
+        // Enforce is explicit only.
         assert_eq!(
             WriteVetoMode::parse(Some("enforce")),
             WriteVetoMode::Enforce
@@ -200,8 +261,17 @@ mod tests {
             WriteVetoMode::parse(Some("  ENFORCE  ")),
             WriteVetoMode::Enforce
         );
+        // Predicates + default.
+        assert_eq!(WriteVetoMode::default(), WriteVetoMode::Warn);
         assert!(!WriteVetoMode::Off.is_enforcing());
+        assert!(!WriteVetoMode::Warn.is_enforcing());
         assert!(WriteVetoMode::Enforce.is_enforcing());
+        assert!(WriteVetoMode::Off.is_off());
+        assert!(!WriteVetoMode::Warn.is_off());
+        assert!(!WriteVetoMode::Enforce.is_off());
+        assert!(!WriteVetoMode::Off.evaluates());
+        assert!(WriteVetoMode::Warn.evaluates());
+        assert!(WriteVetoMode::Enforce.evaluates());
     }
 
     #[test]
@@ -311,5 +381,25 @@ mod tests {
         assert_eq!(body["blocking_intents"].as_array().unwrap().len(), 1);
         assert_eq!(body["blocking_intents"][0]["session_id"], other.to_string());
         assert_eq!(body["blocking_intents"][0]["lock_type"], "Hard");
+    }
+
+    #[test]
+    fn warning_annotation_names_blocking_intent_without_error() {
+        let other = SessionId::new();
+        let blocking = vec![summarize(&intent(
+            other,
+            IntentScope::Entity(EntityId::new()),
+            LockType::Hard,
+        ))];
+        let ann = veto_warning_annotation("src/lib.rs", &blocking);
+
+        // Warn annotation names who-would-block, carries no error code, and
+        // never claims the write was rejected.
+        assert_eq!(ann["would_block"], true);
+        assert!(ann.get("error").is_none());
+        assert_eq!(ann["file_path"], "src/lib.rs");
+        assert_eq!(ann["blocking_intents"].as_array().unwrap().len(), 1);
+        assert_eq!(ann["blocking_intents"][0]["session_id"], other.to_string());
+        assert_eq!(ann["blocking_intents"][0]["lock_type"], "Hard");
     }
 }

--- a/docs/env-vars.md
+++ b/docs/env-vars.md
@@ -59,7 +59,7 @@ Sensitivity legend: **correctness** (affects retrieval/ranking/output or data sa
 | `KIN_STORAGE` | string | local | operational | daemon storage backend selector (e.g. local, gcs) |
 | `KIN_STRICT_BUILD_MATCH` | bool | false | correctness | require a strict historical build match when resolving a ref view |
 | `KIN_WORKSPACE_ROOT` | path | *(unset)* | operational | workspace root override for orchestration commands |
-| `KIN_WRITE_VETO` | enum | off | correctness | write-veto mode; 'enforce' rejects writes into foreign-held scopes |
+| `KIN_WRITE_VETO` | enum | warn | correctness | write-veto mode: 'warn' (default) annotates would-be vetoes into foreign-held scopes, 'enforce' rejects them with a 409, 'off' disables |
 
 ## Daemon
 


### PR DESCRIPTION
## FIR-790 (phase 1): graduate write-veto off → warn by default

Phase 1 of FIR-790 (default-off ladder). Moves the rung-3 write veto from **off-by-default** to **warn-by-default** so the flagship multi-agent collision-safety mechanism is visible in the default experience, without yet blocking any write.

### Behavior ladder (`KIN_WRITE_VETO`)
- **unset → `warn` (new default):** the two agent-write apply paths (`/vfs/write-notify`, `/vfs/file-changed`) evaluate whether a write touches a scope held under another session's hard intent. On a would-be veto they log the collision (per-intent attribution) and annotate the response with `write_veto_warning` naming the blocking intent(s) — **the write proceeds, no 409**.
- **`enforce` → 409 (unchanged):** pre-write rejection naming the blocking intent(s).
- **`off` → byte-identical** pre-veto path (no evaluation, no annotation) — the documented escape hatch.

### Implementation
- `WriteVetoMode` gains a `Warn` variant and becomes the `Default`; `parse()` maps `enforce`/`off` explicitly and everything else to `warn` (matching the env-registry enum fallback).
- `write_veto_precheck` returns an optional warn annotation; `write_veto_collision_response` returns a `Block`/`Warn`/`Ignore` decision; both handlers thread the annotation into every response arm via `attach_veto_warning`.
- **Perf:** the precheck short-circuits when no intents are active, so warn-by-default adds no per-file entity query on the common single-agent path.
- Env registry (`KIN_WRITE_VETO` → enum `warn`/`enforce`/`off`, default `warn`), the generated `docs/env-vars.md`, and the daemon crate-doc write-path inventory are updated to match.

### Tests
- `write_veto` module: parse ladder, decision (foreign-hard/own/soft/no-intent), warn-annotation shape.
- Both handlers × {off (no annotation), warn (annotation, no 409), enforce (409), own-intent (no annotation)}.
- kin-core env-registry drift test (regenerated `env-vars.md`).

### Deferred to phase 2 (per ticket acceptance)
- The **enforce-by-default** flip is soak-gated (0 false-positive vetoes over ≥2 concurrent agent sessions; dogfood + bench). This PR keeps the default at `warn`.
- Extending pre-write gating to currently-ungated entity-truth routes (e.g. `command_commit`) — the write-path inventory documents current gating; extension tracked separately.
- Runtime/soak validation deferred to the post-spine window.