### PR TITLE
feat(cli): stable/alpha update channels for `kin update`

### DIFF
--- a/crates/kin-cli/src/commands/update.rs
+++ b/crates/kin-cli/src/commands/update.rs
@@ -90,8 +90,7 @@ impl UpdateConfig {
         if let Some(dir) = path.parent() {
             std::fs::create_dir_all(dir).context("failed to create ~/.kin")?;
         }
-        let contents =
-            toml::to_string_pretty(self).context("failed to serialize update config")?;
+        let contents = toml::to_string_pretty(self).context("failed to serialize update config")?;
         std::fs::write(&path, contents)
             .with_context(|| format!("failed to write {}", path.display()))?;
         Ok(())
@@ -441,7 +440,10 @@ fn split_version(v: &str) -> (Vec<u64>, Option<Vec<String>>) {
         Some((core, pre)) => (core, Some(pre)),
         None => (v, None),
     };
-    let core_nums = core.split('.').map(|s| s.parse::<u64>().unwrap_or(0)).collect();
+    let core_nums = core
+        .split('.')
+        .map(|s| s.parse::<u64>().unwrap_or(0))
+        .collect();
     let pre_ids = pre.map(|p| p.split('.').map(str::to_string).collect());
     (core_nums, pre_ids)
 }
@@ -694,7 +696,7 @@ mod tests {
         };
 
         let picked = select_alpha(vec![
-            mk("v0.2.6", false),        // stable, must be ignored
+            mk("v0.2.6", false), // stable, must be ignored
             mk("v0.2.7-alpha.1", true),
             mk("v0.2.7-alpha.3", true), // newest pre-release
             mk("v0.2.7-alpha.2", true),

--- a/crates/kin-cli/src/commands/update.rs
+++ b/crates/kin-cli/src/commands/update.rs
@@ -3,10 +3,14 @@
 
 use anyhow::{Context, Result};
 use sha2::{Digest, Sha256};
+use std::cmp::Ordering;
 use std::path::PathBuf;
 
 const CURRENT_VERSION: &str = env!("CARGO_PKG_VERSION");
-const GITHUB_RELEASES_URL: &str = "https://api.github.com/repos/firelock-ai/kin/releases/latest";
+const GITHUB_RELEASES_LATEST_URL: &str =
+    "https://api.github.com/repos/firelock-ai/kin/releases/latest";
+const GITHUB_RELEASES_LIST_URL: &str =
+    "https://api.github.com/repos/firelock-ai/kin/releases?per_page=30";
 
 /// Expected release asset names for integrity verification.
 const CHECKSUMS_ASSET: &str = "checksums-sha256.txt";
@@ -24,7 +28,95 @@ const RELEASE_PUBLIC_KEY_HEX: Option<&str> = option_env!("KIN_RELEASE_PUBLIC_KEY
 #[derive(serde::Deserialize)]
 struct GithubRelease {
     tag_name: String,
+    /// GitHub marks any tag containing `-` (e.g. `-alpha`/`-beta`/`-rc`) as a
+    /// pre-release. Used to select builds for the alpha channel.
+    #[serde(default)]
+    prerelease: bool,
     assets: Vec<GithubAsset>,
+}
+
+/// Release channel selected for `kin update`.
+#[derive(
+    Clone,
+    Copy,
+    Debug,
+    Default,
+    PartialEq,
+    Eq,
+    serde::Serialize,
+    serde::Deserialize,
+    clap::ValueEnum,
+)]
+#[serde(rename_all = "lowercase")]
+pub enum Channel {
+    /// Stable releases only. The default.
+    #[default]
+    Stable,
+    /// Latest pre-release (alpha/beta/rc) build. Unstable — not for production.
+    Alpha,
+}
+
+fn channel_name(channel: Channel) -> &'static str {
+    match channel {
+        Channel::Stable => "stable",
+        Channel::Alpha => "alpha",
+    }
+}
+
+/// Persisted update preferences, stored at `~/.kin/update.toml`.
+#[derive(Debug, Default, serde::Serialize, serde::Deserialize)]
+struct UpdateConfig {
+    #[serde(default)]
+    channel: Channel,
+}
+
+impl UpdateConfig {
+    fn path() -> Result<PathBuf> {
+        Ok(kin_home_dir()?.join("update.toml"))
+    }
+
+    /// Load stored preferences, falling back to defaults on any missing file or
+    /// parse error (the preference is advisory, never a hard failure).
+    fn load() -> Self {
+        Self::path()
+            .ok()
+            .and_then(|p| std::fs::read_to_string(p).ok())
+            .and_then(|s| toml::from_str(&s).ok())
+            .unwrap_or_default()
+    }
+
+    fn save(&self) -> Result<()> {
+        let path = Self::path()?;
+        if let Some(dir) = path.parent() {
+            std::fs::create_dir_all(dir).context("failed to create ~/.kin")?;
+        }
+        let contents =
+            toml::to_string_pretty(self).context("failed to serialize update config")?;
+        std::fs::write(&path, contents)
+            .with_context(|| format!("failed to write {}", path.display()))?;
+        Ok(())
+    }
+}
+
+/// Resolve the effective channel: an explicit `--channel` flag wins and is saved
+/// as the new default; otherwise the stored default is used; otherwise `stable`.
+fn resolve_channel(flag: Option<Channel>) -> Channel {
+    let stored = UpdateConfig::load().channel;
+    if let Some(requested) = flag {
+        if requested != stored {
+            // Persisting is best-effort: a write failure must not block the update.
+            match (UpdateConfig { channel: requested }).save() {
+                Ok(()) => println!("Saved default update channel: {}", channel_name(requested)),
+                Err(e) => eprintln!("Note: could not persist update channel preference: {e}"),
+            }
+        }
+    }
+    effective_channel(flag, stored)
+}
+
+/// Pure channel-precedence rule (flag over stored default), split out for tests.
+fn effective_channel(flag: Option<Channel>, stored: Channel) -> Channel {
+    flag.unwrap_or(stored)
 }
 
 #[derive(serde::Deserialize)]
@@ -33,22 +125,26 @@ struct GithubAsset {
     browser_download_url: String,
 }
 
-pub async fn run(skip_verify: bool) -> Result<()> {
+pub async fn run(skip_verify: bool, channel_flag: Option<Channel>) -> Result<()> {
     println!("Current version: v{CURRENT_VERSION}");
+
+    let channel = resolve_channel(channel_flag);
+    match channel {
+        Channel::Stable => println!("Update channel: stable"),
+        Channel::Alpha => {
+            println!("Update channel: alpha (pre-release)");
+            eprintln!(
+                "WARNING: alpha builds are pre-releases. They are unstable, may change \
+                 or break without notice, and are not recommended for production use. \
+                 Switch back with `kin update --channel stable`."
+            );
+        }
+    }
     println!("Checking for updates...");
 
     let client = reqwest::Client::builder().user_agent("kin-cli").build()?;
 
-    let release: GithubRelease = client
-        .get(GITHUB_RELEASES_URL)
-        .send()
-        .await
-        .context("failed to reach GitHub releases API")?
-        .error_for_status()
-        .context("GitHub API returned an error")?
-        .json()
-        .await
-        .context("failed to parse release JSON")?;
+    let release = resolve_release(&client, channel).await?;
 
     let latest = release.tag_name.trim_start_matches('v');
 
@@ -111,6 +207,57 @@ pub async fn run(skip_verify: bool) -> Result<()> {
 
     println!("Updated to v{latest} successfully.");
     Ok(())
+}
+
+/// Fetch the release to install for the requested channel.
+///
+/// Stable uses the GitHub `releases/latest` endpoint (which never returns a
+/// pre-release). Alpha lists releases and picks the newest pre-release.
+async fn resolve_release(client: &reqwest::Client, channel: Channel) -> Result<GithubRelease> {
+    match channel {
+        Channel::Stable => {
+            let release: GithubRelease = client
+                .get(GITHUB_RELEASES_LATEST_URL)
+                .send()
+                .await
+                .context("failed to reach GitHub releases API")?
+                .error_for_status()
+                .context("GitHub API returned an error")?
+                .json()
+                .await
+                .context("failed to parse release JSON")?;
+            Ok(release)
+        }
+        Channel::Alpha => {
+            let releases: Vec<GithubRelease> = client
+                .get(GITHUB_RELEASES_LIST_URL)
+                .send()
+                .await
+                .context("failed to reach GitHub releases API")?
+                .error_for_status()
+                .context("GitHub API returned an error")?
+                .json()
+                .await
+                .context("failed to parse releases JSON")?;
+            select_alpha(releases).context(
+                "no pre-release build is available on the alpha channel yet. \
+                 See https://github.com/firelock-ai/kin/releases",
+            )
+        }
+    }
+}
+
+/// Select the newest pre-release from a list of releases (highest version wins).
+fn select_alpha(releases: Vec<GithubRelease>) -> Option<GithubRelease> {
+    releases
+        .into_iter()
+        .filter(|r| r.prerelease || r.tag_name.contains('-'))
+        .max_by(|a, b| {
+            compare_versions(
+                a.tag_name.trim_start_matches('v'),
+                b.tag_name.trim_start_matches('v'),
+            )
+        })
 }
 
 /// Download the checksums file and its ed25519 signature from the release,
@@ -269,12 +416,80 @@ fn remove_existing_binaries(bin_dir: &std::path::Path) {
 }
 
 /// Compare two semver-style version strings. Returns true if `latest` > `current`.
+///
+/// Understands pre-release suffixes (e.g. `0.2.7-alpha.1`) per semver precedence:
+/// a pre-release ranks below its released version, and pre-release identifiers are
+/// compared numerically when numeric, otherwise lexically. This keeps the alpha
+/// channel from ever offering a downgrade from a newer stable build.
 fn is_newer(latest: &str, current: &str) -> bool {
-    let parse =
-        |v: &str| -> Vec<u64> { v.split('.').filter_map(|s| s.parse::<u64>().ok()).collect() };
-    let l = parse(latest);
-    let c = parse(current);
-    l > c
+    compare_versions(latest, current) == Ordering::Greater
+}
+
+fn compare_versions(a: &str, b: &str) -> Ordering {
+    let (a_core, a_pre) = split_version(a);
+    let (b_core, b_pre) = split_version(b);
+    match compare_numeric(&a_core, &b_core) {
+        Ordering::Equal => compare_prerelease(a_pre.as_deref(), b_pre.as_deref()),
+        ord => ord,
+    }
+}
+
+/// Split `1.2.3-alpha.4` into `([1, 2, 3], Some(["alpha", "4"]))`.
+fn split_version(v: &str) -> (Vec<u64>, Option<Vec<String>>) {
+    let v = v.trim_start_matches('v');
+    let (core, pre) = match v.split_once('-') {
+        Some((core, pre)) => (core, Some(pre)),
+        None => (v, None),
+    };
+    let core_nums = core.split('.').map(|s| s.parse::<u64>().unwrap_or(0)).collect();
+    let pre_ids = pre.map(|p| p.split('.').map(str::to_string).collect());
+    (core_nums, pre_ids)
+}
+
+fn compare_numeric(a: &[u64], b: &[u64]) -> Ordering {
+    for i in 0..a.len().max(b.len()) {
+        let x = a.get(i).copied().unwrap_or(0);
+        let y = b.get(i).copied().unwrap_or(0);
+        match x.cmp(&y) {
+            Ordering::Equal => continue,
+            ord => return ord,
+        }
+    }
+    Ordering::Equal
+}
+
+fn compare_prerelease(a: Option<&[String]>, b: Option<&[String]>) -> Ordering {
+    match (a, b) {
+        (None, None) => Ordering::Equal,
+        // A released version outranks any pre-release of the same core.
+        (None, Some(_)) => Ordering::Greater,
+        (Some(_), None) => Ordering::Less,
+        (Some(a), Some(b)) => {
+            for i in 0..a.len().max(b.len()) {
+                match (a.get(i), b.get(i)) {
+                    (Some(x), Some(y)) => match compare_prerelease_id(x, y) {
+                        Ordering::Equal => continue,
+                        ord => return ord,
+                    },
+                    // More identifiers wins when the shared prefix is equal.
+                    (Some(_), None) => return Ordering::Greater,
+                    (None, Some(_)) => return Ordering::Less,
+                    (None, None) => break,
+                }
+            }
+            Ordering::Equal
+        }
+    }
+}
+
+fn compare_prerelease_id(a: &str, b: &str) -> Ordering {
+    match (a.parse::<u64>(), b.parse::<u64>()) {
+        (Ok(x), Ok(y)) => x.cmp(&y),
+        // Numeric identifiers always rank lower than alphanumeric ones.
+        (Ok(_), Err(_)) => Ordering::Less,
+        (Err(_), Ok(_)) => Ordering::Greater,
+        (Err(_), Err(_)) => a.cmp(b),
+    }
 }
 
 fn detect_platform() -> Result<(&'static str, &'static str)> {
@@ -416,6 +631,79 @@ mod tests {
         assert!(is_newer("1.0.0", "0.9.9"));
         assert!(!is_newer("0.1.0", "0.1.0"));
         assert!(!is_newer("0.1.0", "0.2.0"));
+    }
+
+    #[test]
+    fn version_comparison_understands_prereleases() {
+        // A pre-release of a higher core beats a lower stable release.
+        assert!(is_newer("0.2.7-alpha.1", "0.2.6"));
+        // A newer alpha beats an older alpha of the same core.
+        assert!(is_newer("0.2.7-alpha.2", "0.2.7-alpha.1"));
+        // A stable release outranks its own pre-release.
+        assert!(is_newer("0.2.7", "0.2.7-alpha.9"));
+        // A pre-release never outranks its released version (no downgrade).
+        assert!(!is_newer("0.2.7-alpha.1", "0.2.7"));
+        // Equal pre-releases are not newer.
+        assert!(!is_newer("0.2.7-alpha.1", "0.2.7-alpha.1"));
+        // Alphanumeric identifiers rank above numeric; 'beta' > 'alpha' lexically.
+        assert!(is_newer("0.2.7-beta", "0.2.7-alpha.1"));
+        // Leading 'v' is tolerated on either side.
+        assert!(is_newer("v0.2.7", "v0.2.6"));
+    }
+
+    #[test]
+    fn effective_channel_precedence() {
+        // An explicit flag wins over the stored default.
+        assert_eq!(
+            effective_channel(Some(Channel::Alpha), Channel::Stable),
+            Channel::Alpha
+        );
+        assert_eq!(
+            effective_channel(Some(Channel::Stable), Channel::Alpha),
+            Channel::Stable
+        );
+        // No flag falls back to the stored default.
+        assert_eq!(effective_channel(None, Channel::Alpha), Channel::Alpha);
+        assert_eq!(effective_channel(None, Channel::Stable), Channel::Stable);
+        // The out-of-the-box default is stable.
+        assert_eq!(Channel::default(), Channel::Stable);
+    }
+
+    #[test]
+    fn update_config_toml_roundtrip() {
+        let text = toml::to_string_pretty(&UpdateConfig {
+            channel: Channel::Alpha,
+        })
+        .unwrap();
+        assert!(text.contains("channel = \"alpha\""));
+
+        let parsed: UpdateConfig = toml::from_str(&text).unwrap();
+        assert_eq!(parsed.channel, Channel::Alpha);
+
+        // A missing/empty config deserializes to the stable default.
+        let empty: UpdateConfig = toml::from_str("").unwrap();
+        assert_eq!(empty.channel, Channel::Stable);
+    }
+
+    #[test]
+    fn select_alpha_picks_newest_prerelease() {
+        let mk = |tag: &str, prerelease: bool| GithubRelease {
+            tag_name: tag.to_string(),
+            prerelease,
+            assets: vec![],
+        };
+
+        let picked = select_alpha(vec![
+            mk("v0.2.6", false),        // stable, must be ignored
+            mk("v0.2.7-alpha.1", true),
+            mk("v0.2.7-alpha.3", true), // newest pre-release
+            mk("v0.2.7-alpha.2", true),
+        ])
+        .expect("a pre-release should be selected");
+        assert_eq!(picked.tag_name, "v0.2.7-alpha.3");
+
+        // No pre-releases available → nothing to select.
+        assert!(select_alpha(vec![mk("v0.2.6", false)]).is_none());
     }
 
     #[test]

--- a/crates/kin-cli/src/main.rs
+++ b/crates/kin-cli/src/main.rs
@@ -810,6 +810,10 @@ enum Command {
         /// Skip signature and checksum verification (NOT recommended)
         #[arg(long)]
         skip_verify: bool,
+        /// Release channel: `stable` (default) or `alpha` (latest pre-release,
+        /// unstable). The chosen channel is saved as the default for future updates.
+        #[arg(long, value_enum)]
+        channel: Option<commands::update::Channel>,
     },
     /// Show or manage the global Kin repository registry
     Registry {
@@ -2607,7 +2611,10 @@ fn main() -> Result<()> {
                     );
                     Ok(())
                 }
-                Command::Update { skip_verify } => commands::update::run(skip_verify).await,
+                Command::Update {
+                    skip_verify,
+                    channel,
+                } => commands::update::run(skip_verify, channel).await,
                 Command::Registry { action } => match action {
                     Some(RegistryAction::Daemons { json }) => {
                         commands::registry::daemons(json).await


### PR DESCRIPTION
## What

Adds a release-channel selector to `kin update` so users can follow
pre-release (alpha) builds, not just stable.

- New `Channel { stable, alpha }` enum.
- `kin update --channel <stable|alpha>` flag.
- The chosen channel is persisted to `~/.kin/update.toml` and becomes the
  default for future `kin update` runs (the config setting).
- **Default stays `stable`.**

## Why

`update.rs` previously always hit GitHub's `releases/latest`, which by
definition never returns a pre-release — so there was no way to track the
`-alpha`/`-beta`/`-rc` builds that `release.yml` already publishes and marks
as pre-releases.

## How

- **stable** → unchanged `releases/latest` behavior.
- **alpha** → lists `/releases` and installs the newest pre-release
  (filtered on GitHub's `prerelease` flag / `-` suffix tags).
- Version comparison is now semver-pre-release-aware: a pre-release ranks
  below its released version and pre-release identifiers compare
  numerically/lexically, so alpha upgrades between pre-releases and never
  downgrades you from a newer stable build.
- Honest messaging: the alpha channel prints an explicit "unstable,
  pre-release, not for production" warning and how to switch back.

## Tests

Hermetic unit tests (no network, no filesystem): pre-release version
precedence, channel precedence (flag over stored default over stable),
`UpdateConfig` TOML round-trip, and newest-pre-release selection.

Closes FIR-1016.

> Note: like all current kin PRs, cargo-deny will be red until the deny fix
> (#169) lands on main; no new dependencies are introduced here.