### PR TITLE
feat(locate): --explain reports active retrieval profile (FIR-783 down-payment)

### DIFF
--- a/crates/kin-cli/src/commands/locate.rs
+++ b/crates/kin-cli/src/commands/locate.rs
@@ -220,6 +220,12 @@ impl SnippetOptions {
 pub struct LocateDebugInfo {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub scoring_track: Option<String>,
+    /// Active retrieval quality profile (name + version, e.g. `compat-v0` /
+    /// `accuracy-v1`) resolved from `KIN_PROFILE` for this query, so every
+    /// `--explain` result is attributable to the serving profile that produced
+    /// it.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub retrieval_profile: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub traceback_top: Option<f32>,
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -1963,6 +1969,7 @@ pub fn run_with_graph_capture_with_priority_files_and_vector_source(
         let resolve_identity = entity_resolve_identity(&all_entity_seeds, graph)?;
         Some(LocateDebugInfo {
             scoring_track: Some(format!("{track:?}")),
+            retrieval_profile: Some(quality.name().to_string()),
             traceback_top: Some(traceback_top),
             resolve_top: Some(resolve_top),
             resolve_gap: Some(resolve_gap),
@@ -15318,6 +15325,26 @@ mod tests {
         let json = serde_json::to_string(&tagged).unwrap();
         assert!(json.contains("\"origin\":\"vector\""));
         assert!(json.contains("\"cosine\":0.87"));
+    }
+
+    #[test]
+    fn locate_debug_info_serializes_retrieval_profile_and_omits_when_unset() {
+        let with_profile = LocateDebugInfo {
+            retrieval_profile: Some("compat-v0".to_string()),
+            ..Default::default()
+        };
+        let json = serde_json::to_string(&with_profile).unwrap();
+        assert!(
+            json.contains("\"retrieval_profile\":\"compat-v0\""),
+            "--explain debug must carry the active profile name+version: {json}"
+        );
+
+        let unset = LocateDebugInfo::default();
+        let json = serde_json::to_string(&unset).unwrap();
+        assert!(
+            !json.contains("retrieval_profile"),
+            "retrieval_profile is omitted from output when unset: {json}"
+        );
     }
 
     fn sym(name: &str, score: f32, definition: bool) -> LocateSymbol {

--- a/crates/kin-cli/src/commands/locate_debug.rs
+++ b/crates/kin-cli/src/commands/locate_debug.rs
@@ -70,6 +70,8 @@ pub struct DebugInfoReport {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub scoring_track: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
+    pub retrieval_profile: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub fast_path: Option<String>,
     #[serde(skip_serializing_if = "Vec::is_empty")]
     pub skipped_signals: Vec<String>,
@@ -280,6 +282,7 @@ fn build_report(query: &str, gold_files: &[String], result: &LocateResult) -> De
 
     let debug_info = result.debug.as_ref().map(|d| DebugInfoReport {
         scoring_track: d.scoring_track.clone(),
+        retrieval_profile: d.retrieval_profile.clone(),
         fast_path: d.fast_path.clone(),
         skipped_signals: d.skipped_signals.clone(),
         query_terms: d.query_terms.clone(),
@@ -331,6 +334,9 @@ fn print_human_report(report: &DebugReport) {
     if let Some(ref info) = report.debug_info {
         if let Some(ref track) = info.scoring_track {
             println!("Track:    {}", track);
+        }
+        if let Some(ref profile) = info.retrieval_profile {
+            println!("Profile:  {}", profile);
         }
         if let Some(ref fp) = info.fast_path {
             println!("Fast path: {}", fp);


### PR DESCRIPTION
## FIR-783 down-payment: `kin locate --explain` reports the active retrieval profile

Per the captain's ruling, the FIR-783 **collapse** (≈160 KIN_LOCATE_* knobs → versioned profile) is deferred to one coordinated bench-gated PR after accuracy-v1 graduates (FIR-1226). This lands the one safe, non-bench-gated acceptance criterion now — and it's diagnostic gold for A2's mf16 A/B runs.

### What
`kin locate --explain` (and the context-bench debug report) now records the active retrieval quality profile — **name + version** (`compat-v0` / `accuracy-v1`), resolved from `KIN_PROFILE` — so every result is attributable to the serving profile that produced it, and profile A/B runs are self-describing in their JSON.

- `retrieval_profile: Option<String>` added to `LocateDebugInfo` (serialized under `--explain`, `skip_serializing_if` when unset), populated at the debug construction from the `RetrievalProfile` already resolved on the locate path (`quality.name()`).
- Mirrored into the context-bench `DebugInfoReport` + printed in the human debug report (`Profile:` line next to `Track:`).

### Not in scope (deferred, per ruling)
- The knob collapse itself (≤12 tuning surfaces, delete-inert, config.toml override) — one coordinated bench-gated PR post-FIR-1226; the Jun-9 RRF-inertness partition is Notion-archived.

### Tests
- `locate_debug_info_serializes_retrieval_profile_and_omits_when_unset` (present when set, omitted when None).
- Full kin-cli locate suite green (202 tests); `entity_fusion_is_disabled_by_default` + `rrf_output_is_byte_identical_across_runs` confirm no ranking/determinism change.