### PR TITLE
feat(mcp): line spans on default semantic_locate hits; clamp semantic_search limit

### DIFF
--- a/crates/kin-daemon/src/api.rs
+++ b/crates/kin-daemon/src/api.rs
@@ -4360,6 +4360,10 @@ fn build_semantic_locate_result(
         };
 
         let score = 1.0_f32 - distance;
+        let span = match &item {
+            kin_db::ResolvedRetrievalItem::Entity(entity) => entity.span.as_ref(),
+            _ => None,
+        };
         let mut hit = json!({
             "entity_id": entity_id,
             "kind": kind,
@@ -4368,6 +4372,10 @@ fn build_semantic_locate_result(
             "score": score,
             "provenance": { "file": file },
         });
+        if let Some(span) = span {
+            hit["start_line"] = json!(span.start_line);
+            hit["end_line"] = json!(span.end_line);
+        }
         if let Some(snippet) = snippet {
             hit["snippet"] = json!(snippet);
         }

--- a/crates/kin-mcp/src/handlers/common.rs
+++ b/crates/kin-mcp/src/handlers/common.rs
@@ -1462,8 +1462,9 @@ pub fn parse_capabilities(args: &HashMap<String, serde_json::Value>) -> SessionC
 pub fn build_semantic_search_request(
     args: &HashMap<String, serde_json::Value>,
 ) -> Result<(String, usize, EntityFilter)> {
+    const MAX_LIMIT: usize = 200;
     let query = get_string_param(args, "query")?;
-    let limit = get_optional_u64(args, "limit", 20) as usize;
+    let limit = (get_optional_u64(args, "limit", 20) as usize).clamp(1, MAX_LIMIT);
 
     let kind_str = args.get("kind").and_then(|v| v.as_str());
     let kind_filter = kind_str.and_then(parse_kind_filter);


### PR DESCRIPTION
Two small agent-surface hardenings from the FIR-1180 audit:

- The default (cosine) semantic_locate hit now carries start_line/end_line from the entity span, matching the fused path's fields. Agents on the default profile could previously see snippet+score+kind but no line anchors, forcing file re-reads to disambiguate.
- build_semantic_search_request now clamps the caller-supplied limit to the same maximum the seeded entity tools already enforce, closing the unbounded-result tail (a caller could previously request arbitrarily large result sets).

CLI locate --json is unchanged; both changes are additive on the MCP surface.