### PR TITLE
ci: dedupe push/pull_request triggers and cancel superseded runs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,11 +5,15 @@ name: CI
 
 on:
   push:
-    branches: ["**"]
+    branches: [main]
   pull_request:
     branches: [main]
   repository_dispatch:
     types: [dependency-updated]
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
 
 env:
   CARGO_TERM_COLOR: always

--- a/.github/workflows/sast.yml
+++ b/.github/workflows/sast.yml
@@ -5,9 +5,13 @@ name: SAST
 
 on:
   push:
-    branches: ["**"]
+    branches: [main]
   pull_request:
     branches: [main]
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
 
 jobs:
   cargo-deny:

--- a/.github/workflows/secret-scan.yml
+++ b/.github/workflows/secret-scan.yml
@@ -6,8 +6,10 @@ name: Secret Scan
 on:
   push:
     branches: ["**"]
-  pull_request:
-    branches: [main]
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
 
 permissions:
   contents: read


### PR DESCRIPTION
Drops the duplicate PR-event runs where an equivalent push run already covers the ref (keeping push:** coverage for secret-scan judgment), and adds concurrency cancellation so superseded runs stop consuming runner minutes.