### PR TITLE
docs: describe the workspace config loading generically

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -10,7 +10,7 @@ workspace `AGENTS.md`:
 **`kin-ecosystem/AGENTS.md`** (also symlinked as `kin-ecosystem/CLAUDE.md`)
 
 When working inside this repo as part of the umbrella workspace, that file is
-loaded automatically by Claude Code. If working in this repo in isolation,
+loaded automatically by agent CLIs that read `CLAUDE.md`. If working in this repo in isolation,
 read the umbrella `AGENTS.md` before making architectural or process decisions.
 
 ## This repo's role


### PR DESCRIPTION
The umbrella-workspace note in AGENTS.md named a specific agent CLI as the loader of the symlinked config; any agent CLI that reads CLAUDE.md loads it. Describes the mechanism tool-neutrally.