### PR TITLE
fix(docker): writable workspace resolution in the entrypoint for both storage modes

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -94,7 +94,12 @@ jobs:
           echo "::group::Unwritable workspace — loud fatal, no bare mkdir death"
           # KIN_WORKSPACE_DIR=/workspace is an unwritable image-root path with no
           # mount: the entrypoint must print an actionable fatal and exit 1.
-          out_bad="$(docker run --rm -e KIN_WORKSPACE_DIR=/workspace "$IMAGE" 2>&1)"; code_bad=$?
+          # Expected-failure capture: suspend errexit so the nonzero exit lands
+          # in code_bad instead of aborting the step at the assignment.
+          set +e
+          out_bad="$(docker run --rm -e KIN_WORKSPACE_DIR=/workspace "$IMAGE" 2>&1)"
+          code_bad=$?
+          set -e
           echo "$out_bad"
           if [ "$code_bad" -ne 1 ]; then echo "::error::unwritable workspace should exit 1 (got $code_bad)"; exit 1; fi
           if ! printf '%s\n' "$out_bad" | grep -q "FATAL: workspace '/workspace' is not writable"; then echo "::error::missing actionable fatal naming the dir"; exit 1; fi

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -32,7 +32,73 @@ jobs:
           context: .
           file: ./Dockerfile
           push: false
-          load: false
+          # Load the built image into the local Docker daemon so the smoke step
+          # below can `docker run` it. Single-platform, so `load` is supported.
+          load: true
           tags: kin:ci
           cache-from: type=gha
           cache-to: type=gha,mode=max
+
+      # Container-level smoke on the freshly built image. Proves the entrypoint
+      # boots the daemon in local mode with NO /workspace volume — the case that
+      # previously crash-looped on a bare `mkdir /workspace` — that GCS mode
+      # prepares the same workspace path, and that an unwritable workspace fails
+      # loudly instead of dying on mkdir. Creds-free and bounded well under 2 min.
+      - name: Entrypoint smoke (local boot + SIGTERM, gcs prep, unwritable fail)
+        run: |
+          set -uo pipefail
+          IMAGE=kin:ci
+
+          dump() { echo "---- docker logs $1 ----"; docker logs "$1" 2>&1 || true; }
+
+          echo "::group::Local mode — no /workspace mount, default workspace"
+          docker rm -f kin-local >/dev/null 2>&1 || true
+          docker run -d --name kin-local "$IMAGE" >/dev/null
+          # The daemon binds and logs "daemon API server listening" before the
+          # slower graph/model startup, so it is the deterministic offline signal
+          # that it reached serving state — independent of reconcile/embed timing.
+          listening=0
+          for _ in $(seq 1 40); do
+            if docker logs kin-local 2>&1 | grep -q "daemon API server listening"; then listening=1; break; fi
+            if [ "$(docker inspect -f '{{.State.Running}}' kin-local 2>/dev/null)" != "true" ]; then break; fi
+            sleep 1
+          done
+          if [ "$listening" -ne 1 ]; then echo "::error::kin-daemon never reached its listening line in local mode"; dump kin-local; exit 1; fi
+          if ! docker logs kin-local 2>&1 | grep -q "Starting kin-daemon (storage=local"; then echo "::error::entrypoint did not report local storage prep"; dump kin-local; exit 1; fi
+          # Best-effort readiness probe (an empty repo may still be initializing);
+          # logged for signal only — the listening line is the hard gate.
+          if docker exec kin-local sh -c 'curl -fsS http://127.0.0.1:4219/readiness' >/dev/null 2>&1; then
+            echo "readiness: 200 (ready)"
+          else
+            echo "readiness: not yet 200 (empty-repo init timing; listening already asserted)"
+          fi
+          # SIGTERM must shut the daemon down cleanly (exit 0), not get SIGKILLed.
+          docker stop -t 15 kin-local >/dev/null
+          code="$(docker inspect -f '{{.State.ExitCode}}' kin-local)"
+          if [ "$code" != "0" ]; then echo "::error::kin-daemon did not exit cleanly on SIGTERM (exit=$code)"; dump kin-local; exit 1; fi
+          echo "local mode: reached listening + clean SIGTERM (exit 0)"
+          docker rm -f kin-local >/dev/null 2>&1 || true
+          echo "::endgroup::"
+
+          echo "::group::GCS mode — same workspace prep path (creds-free)"
+          # No bucket/creds in CI, so the daemon exits right after workspace prep;
+          # assert the unified prep ran on the same /tmp/kin-workspace and reached
+          # daemon exec without the unwritable fatal — i.e. prep is mode-agnostic.
+          out_gcs="$(timeout 30 docker run --rm -e KIN_STORAGE=gcs "$IMAGE" 2>&1)" || true
+          echo "$out_gcs"
+          if ! printf '%s\n' "$out_gcs" | grep -q "Starting kin-daemon (storage=gcs"; then echo "::error::gcs mode did not reach daemon exec after workspace prep"; exit 1; fi
+          if printf '%s\n' "$out_gcs" | grep -q "FATAL: workspace"; then echo "::error::gcs mode hit the unwritable-workspace fatal on the default path"; exit 1; fi
+          echo "gcs mode: workspace prepared and reached daemon exec"
+          echo "::endgroup::"
+
+          echo "::group::Unwritable workspace — loud fatal, no bare mkdir death"
+          # KIN_WORKSPACE_DIR=/workspace is an unwritable image-root path with no
+          # mount: the entrypoint must print an actionable fatal and exit 1.
+          out_bad="$(docker run --rm -e KIN_WORKSPACE_DIR=/workspace "$IMAGE" 2>&1)"; code_bad=$?
+          echo "$out_bad"
+          if [ "$code_bad" -ne 1 ]; then echo "::error::unwritable workspace should exit 1 (got $code_bad)"; exit 1; fi
+          if ! printf '%s\n' "$out_bad" | grep -q "FATAL: workspace '/workspace' is not writable"; then echo "::error::missing actionable fatal naming the dir"; exit 1; fi
+          if ! printf '%s\n' "$out_bad" | grep -q "KIN_WORKSPACE_DIR"; then echo "::error::fatal should name the KIN_WORKSPACE_DIR remedy"; exit 1; fi
+          if printf '%s\n' "$out_bad" | grep -qi "Permission denied"; then echo "::error::leaked a bare mkdir permission-denied death"; exit 1; fi
+          echo "unwritable workspace: loud fatal + exit 1, no bare mkdir death"
+          echo "::endgroup::"

--- a/Dockerfile
+++ b/Dockerfile
@@ -32,4 +32,8 @@ RUN chmod +x /usr/local/bin/docker-entrypoint.sh
 USER kin
 EXPOSE 4219
 ENTRYPOINT ["/usr/local/bin/docker-entrypoint.sh"]
-CMD ["--repo", "/workspace", "--port", "4219"]
+# The entrypoint owns --repo: it resolves and prepares the workspace
+# (KIN_WORKSPACE_DIR, default /tmp/kin-workspace) and passes it to the daemon.
+# Hardcoding --repo /workspace here would name an unwritable image-root path with
+# no volume mounted, so only pass the port and let the entrypoint set the repo.
+CMD ["--port", "4219"]

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -3,26 +3,35 @@
 # Copyright 2026 Firelock, LLC
 set -e
 
-# In GCS storage mode, no local workspace is needed — the daemon loads
-# graph snapshots from GCS. In local mode, ensure the workspace exists.
-if [ "${KIN_STORAGE}" != "gcs" ]; then
-    mkdir -p /workspace/.kin/objects /workspace/.kin/refs
+# Resolve the on-disk workspace that backs the daemon's Kin repo layout. Both
+# storage modes need a real, writable `.kin/` tree: local mode keeps its graph
+# objects there, and GCS mode still needs a valid repo layout on disk so
+# sidecars and health checks never observe a half-initialized tree. Default to
+# an in-image tmp path that a plain emptyDir volume can back identically in
+# either mode; override with KIN_WORKSPACE_DIR (for example a volume mounted at
+# /workspace on legacy deployments).
+WORKSPACE_DIR="${KIN_WORKSPACE_DIR:-/tmp/kin-workspace}"
+
+# Fail with an actionable message instead of dying on a bare mkdir when the
+# resolved path is not writable for the container's runtime user — e.g. an
+# image-root path such as /workspace with no volume mounted over it.
+if ! mkdir -p "${WORKSPACE_DIR}/.kin" 2>/dev/null || [ ! -w "${WORKSPACE_DIR}/.kin" ]; then
+    echo "[entrypoint] FATAL: workspace '${WORKSPACE_DIR}' is not writable for uid $(id -u)." >&2
+    echo "[entrypoint] Mount a writable volume there, or set KIN_WORKSPACE_DIR to a writable path (an emptyDir-backed /tmp/kin-workspace is the default)." >&2
+    exit 1
 fi
 
-# In GCS mode the daemon still needs a real Kin repo layout so sidecars and
-# health checks do not inherit a half-initialized `.kin/` tree.
-if [ "${KIN_STORAGE}" = "gcs" ]; then
-    mkdir -p /tmp/kin-workspace
-    if [ ! -f /tmp/kin-workspace/.kin/manifest.json ] || [ ! -f /tmp/kin-workspace/.kin/config.toml ] || [ ! -f /tmp/kin-workspace/.kin/HEAD ] || [ ! -d /tmp/kin-workspace/.kin/objects ] || [ ! -f /tmp/kin-workspace/.kin/kindb/graph.kndb ]; then
-        rm -rf /tmp/kin-workspace/.kin
-        kin init /tmp/kin-workspace
-    fi
-    REPO_ARG="--repo /tmp/kin-workspace"
-else
-    REPO_ARG="--repo /workspace"
+# Materialize a real Kin repo layout. Re-init only when the tree is missing or
+# incomplete so an existing repo on a persistent volume is never clobbered.
+if [ ! -f "${WORKSPACE_DIR}/.kin/manifest.json" ] || [ ! -f "${WORKSPACE_DIR}/.kin/config.toml" ] || [ ! -f "${WORKSPACE_DIR}/.kin/HEAD" ] || [ ! -d "${WORKSPACE_DIR}/.kin/objects" ] || [ ! -f "${WORKSPACE_DIR}/.kin/kindb/graph.kndb" ]; then
+    rm -rf "${WORKSPACE_DIR}/.kin"
+    kin init "${WORKSPACE_DIR}"
 fi
 
-# Start kin-daemon. Let K8s handle restarts via restartPolicy.
-# Using exec so the daemon receives signals (SIGTERM) directly.
-echo "[entrypoint] Starting kin-daemon (storage=${KIN_STORAGE:-local})..."
-exec /usr/local/bin/kin-daemon ${REPO_ARG} "$@"
+# Start kin-daemon. Let K8s handle restarts via restartPolicy. Using exec so the
+# daemon is PID 1 and receives signals (SIGTERM) directly for a clean shutdown.
+# kin-daemon parses --repo last-wins, so appending the resolved workspace keeps
+# the prepared directory authoritative regardless of any --repo carried by the
+# image CMD or pod args; configure the workspace via KIN_WORKSPACE_DIR instead.
+echo "[entrypoint] Starting kin-daemon (storage=${KIN_STORAGE:-local}, workspace=${WORKSPACE_DIR})..."
+exec /usr/local/bin/kin-daemon "$@" --repo "${WORKSPACE_DIR}"


### PR DESCRIPTION
The entrypoint's local-storage branch did mkdir on the image-root /workspace, which is unwritable for the runtime user and unmounted in k8s — any non-gcs pod crash-looped (the kin-registry pod hit this; infra bypasses the entrypoint today). Two further latent defects sat behind it: the local skeleton created bare .kin dirs without a manifest, which resolve_repo_id requires, and the image CMD's hardcoded --repo /workspace silently overrode the entrypoint's repo because the daemon's flag parsing is last-wins.

Both modes now resolve the workspace identically: KIN_WORKSPACE_DIR when set (set it to /workspace to opt into a legacy mounted volume), else /tmp/kin-workspace, which a plain emptyDir backs; the dir is created and writability-checked with a single fatal diagnostic naming the dir, uid, and remedy; a guarded kin init materializes a complete repo layout non-destructively; and the entrypoint appends the authoritative --repo after passthrough args, with the CMD reduced to the port.

The Docker workflow gains a creds-free entrypoint smoke (local boot + clean SIGTERM shutdown, gcs-mode prep, and unwritable-dir loud-failure), running against the just-built image.

Acceptance per FIR-1236: with this in a release, kin-infra can revert its command: bypass on the registry Deployment and boot through the image entrypoint.