### PR TITLE
feat(daemon): warn when behavior env diverges from the running daemon

### DIFF
--- a/crates/kin-cli/src/commands/embed.rs
+++ b/crates/kin-cli/src/commands/embed.rs
@@ -255,6 +255,10 @@ async fn run_daemon_embed(
         anyhow::anyhow!("Kin daemon is required for embed but no daemon endpoint is available")
     })?;
     let client = crate::daemon_client::DaemonClient::from_base_url(base_url)?;
+    // Embedding behavior is decided in the long-lived daemon worker; warn loudly
+    // (or fail under KIN_STRICT_BEHAVIOR_ENV) if this command's environment
+    // diverges from what that worker captured at start.
+    client.warn_on_behavior_env_divergence().await?;
     client
         .embed(request)
         .await

--- a/crates/kin-cli/src/commands/resources.rs
+++ b/crates/kin-cli/src/commands/resources.rs
@@ -320,6 +320,11 @@ async fn run_daemon_resources(
         )
     })?;
     let client = crate::daemon_client::DaemonClient::from_base_url(base_url)?;
+    // Resource sizing reflects the daemon worker's captured environment; warn
+    // loudly (or fail under KIN_STRICT_BEHAVIOR_ENV) if this command's
+    // environment diverges from what that worker started with, so an inspector
+    // is not misled about which levers are actually in effect.
+    client.warn_on_behavior_env_divergence().await?;
     client
         .command_resources(request)
         .await

--- a/crates/kin-cli/src/daemon_client.rs
+++ b/crates/kin-cli/src/daemon_client.rs
@@ -37,6 +37,11 @@ pub struct HealthResponse {
     pub repo_root: Option<String>,
     #[serde(default)]
     pub pid: Option<u32>,
+    /// Behavior-relevant environment the daemon captured at start (see
+    /// `kin_core::behavior_env`). Empty when the daemon predates this surface,
+    /// which yields no divergence rather than a false one.
+    #[serde(default)]
+    pub behavior_env: kin_core::behavior_env::BehaviorEnv,
     #[serde(default)]
     pub build: Option<BuildResponse>,
 }
@@ -254,6 +259,35 @@ impl DaemonClient {
             anyhow::bail!("daemon error (HTTP {}): {}", status, body);
         }
         Ok(resp.json().await?)
+    }
+
+    /// Compare this command's behavior-relevant environment against what the
+    /// running daemon captured at start, and surface any divergence.
+    ///
+    /// A repo daemon is a long-lived per-user singleton: it inherited its
+    /// environment from whichever command first started it, and later commands
+    /// reach it over HTTP without re-exporting their own environment. So a
+    /// behavior knob set on *this* command (e.g. `KIN_EMBED_HYBRID`) is silently
+    /// ignored by the already-running worker. This makes that mismatch loud.
+    ///
+    /// Best-effort: if the daemon cannot be reached, or predates the
+    /// `behavior_env` health field, this is a no-op — the command's own request
+    /// still surfaces any genuine connectivity failure, so the check never
+    /// double-reports one. On divergence it warns to stderr; under
+    /// `KIN_STRICT_BEHAVIOR_ENV` it returns an error so scripted and proof runs
+    /// fail closed instead of measuring the wrong lever.
+    pub async fn warn_on_behavior_env_divergence(&self) -> Result<()> {
+        let Ok(health) = self.health().await else {
+            return Ok(());
+        };
+        let divergences = kin_core::behavior_env::compare(
+            &kin_core::behavior_env::snapshot_from_process(),
+            &health.behavior_env,
+        );
+        report_behavior_env_divergence(
+            &divergences,
+            is_transient_bool_env("KIN_STRICT_BEHAVIOR_ENV"),
+        )
     }
 
     /// Get the working copy status from the daemon.
@@ -1161,6 +1195,47 @@ fn build_match_error(cli: &str, daemon: &str, strict: bool) -> Result<Option<Str
         bail!("{message}");
     }
     Ok(Some(message))
+}
+
+/// Route a behavior-env divergence report to a warning or, in strict mode, an
+/// error. Pure in its inputs so the warn-vs-error policy and the message are
+/// unit-testable without a live daemon. Returns `Err` under strict mode when
+/// there is any divergence; otherwise warns to stderr and returns `Ok`.
+fn report_behavior_env_divergence(
+    divergences: &[kin_core::behavior_env::Divergence],
+    strict: bool,
+) -> Result<()> {
+    if divergences.is_empty() {
+        return Ok(());
+    }
+    let message = behavior_env_divergence_message(divergences);
+    if strict {
+        bail!("{message}");
+    }
+    warn!("{message}");
+    Ok(())
+}
+
+/// Human-facing message for a behavior-env divergence: the boundary that causes
+/// it, each diverging variable with both sides' values, and the accurate remedy.
+fn behavior_env_divergence_message(divergences: &[kin_core::behavior_env::Divergence]) -> String {
+    let mut message = String::from(
+        "behavior-relevant environment differs between this command and the running kin daemon. \
+         The daemon inherited its environment when it started and does not pick up a later \
+         command's overrides, so these variables take effect from the daemon, not from this \
+         invocation:",
+    );
+    for d in divergences {
+        message.push_str("\n  - ");
+        message.push_str(&d.describe());
+    }
+    message.push_str(
+        "\nremedy: restart the daemon so it re-inherits the current environment — stop it with \
+         `kill $(cat .kin/daemon.pid)` (it also self-stops after its KIN_DAEMON_IDLE_TIMEOUT_SECS \
+         idle window) and the next kin command respawns it. \
+         Set KIN_STRICT_BEHAVIOR_ENV=1 to make this a hard error.",
+    );
+    message
 }
 
 fn check_response_build_match(headers: &reqwest::header::HeaderMap) -> Result<()> {
@@ -2485,6 +2560,7 @@ mod tests {
             repo_id: Some("wrong".to_string()),
             repo_root: Some(canonical_path_string(other.path())),
             pid: Some(std::process::id()),
+            behavior_env: Default::default(),
             build: None,
         };
 
@@ -2503,6 +2579,7 @@ mod tests {
             repo_id: Some("repo".to_string()),
             repo_root: Some(canonical_path_string(repo_root)),
             pid: Some(std::process::id()),
+            behavior_env: Default::default(),
             build: None,
         }
     }
@@ -2566,6 +2643,86 @@ mod tests {
         let err = build_match_error("bd7cd12", "a09f882", true).unwrap_err();
 
         assert!(err.to_string().contains("restart the daemon to match"));
+    }
+
+    fn one_divergence() -> Vec<kin_core::behavior_env::Divergence> {
+        vec![kin_core::behavior_env::Divergence {
+            var: "KIN_EMBED_HYBRID".to_string(),
+            cli: Some("balanced".to_string()),
+            daemon: None,
+        }]
+    }
+
+    #[test]
+    fn behavior_env_no_divergence_is_ok_in_either_mode() {
+        assert!(report_behavior_env_divergence(&[], false).is_ok());
+        assert!(report_behavior_env_divergence(&[], true).is_ok());
+    }
+
+    #[test]
+    fn behavior_env_divergence_warns_without_strict_mode() {
+        // Non-strict: surfaced as a warning; the command is allowed to continue.
+        assert!(report_behavior_env_divergence(&one_divergence(), false).is_ok());
+    }
+
+    #[test]
+    fn behavior_env_divergence_errors_in_strict_mode() {
+        let err = report_behavior_env_divergence(&one_divergence(), true).unwrap_err();
+        let text = err.to_string();
+        assert!(text.contains("KIN_EMBED_HYBRID"));
+        assert!(text.contains("restart the daemon"));
+    }
+
+    #[test]
+    fn behavior_env_message_names_each_var_and_remedy() {
+        let divergences = vec![
+            kin_core::behavior_env::Divergence {
+                var: "KIN_EMBED_HYBRID".to_string(),
+                cli: Some("balanced".to_string()),
+                daemon: None,
+            },
+            kin_core::behavior_env::Divergence {
+                var: "KIN_RESOURCE_PROFILE".to_string(),
+                cli: None,
+                daemon: Some("throughput".to_string()),
+            },
+        ];
+        let message = behavior_env_divergence_message(&divergences);
+        // Each diverging var names both sides' values...
+        assert!(message.contains("KIN_EMBED_HYBRID: cli=\"balanced\" daemon=(unset)"));
+        assert!(message.contains("KIN_RESOURCE_PROFILE: cli=(unset) daemon=\"throughput\""));
+        // ...and the message states the accurate remedy and the strict escalation.
+        assert!(message.contains(".kin/daemon.pid"));
+        assert!(message.contains("KIN_STRICT_BEHAVIOR_ENV=1"));
+    }
+
+    #[test]
+    fn health_without_behavior_env_defaults_empty() {
+        // A daemon that predates the behavior_env field must still deserialize,
+        // with an empty surface, so an old daemon yields no divergence warnings.
+        let json = r#"{
+            "status":"ok","version":"0.0.0","uptime_seconds":1,
+            "graph_entity_count":10,"graph_loaded":true,
+            "reconciliation_status":"idle"
+        }"#;
+        let health: HealthResponse = serde_json::from_str(json).unwrap();
+        assert!(health.behavior_env.is_empty());
+    }
+
+    #[test]
+    fn health_with_behavior_env_deserializes_surface() {
+        let json = r#"{
+            "status":"ok","version":"0.0.0","uptime_seconds":1,
+            "graph_entity_count":10,"graph_loaded":true,
+            "reconciliation_status":"idle",
+            "behavior_env":{"KIN_EMBED_HYBRID":"balanced","KIN_RESOURCE_PROFILE":null}
+        }"#;
+        let health: HealthResponse = serde_json::from_str(json).unwrap();
+        assert_eq!(
+            health.behavior_env.get("KIN_EMBED_HYBRID"),
+            Some(&Some("balanced".to_string()))
+        );
+        assert_eq!(health.behavior_env.get("KIN_RESOURCE_PROFILE"), Some(&None));
     }
 
     #[test]

--- a/crates/kin-core/src/behavior_env.rs
+++ b/crates/kin-core/src/behavior_env.rs
@@ -1,0 +1,278 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Firelock, LLC
+
+//! Shared list of behavior-relevant environment variables that a long-lived
+//! repo daemon captures at process start, plus the pure comparison used to
+//! detect when a CLI invocation's environment has diverged from the daemon's.
+//!
+//! A repo worker daemon is a per-user singleton: the first `kin` command spawns
+//! it, and it inherits *that* command's environment. Every later command talks
+//! to the already-running daemon over HTTP and does not re-export its own
+//! environment into the worker. So a behavior knob like `KIN_EMBED_HYBRID` —
+//! read deep in the embedding / inference substrate the worker hosts — is fixed
+//! at the value the daemon captured when it started. A later
+//! `KIN_EMBED_HYBRID=balanced kin embed` against that daemon is silently
+//! ignored, and the operator gets the old lever with no signal.
+//!
+//! Request-scoped propagation of these knobs is a larger change that crosses the
+//! daemon boundary into substrate that reads them at its own process start.
+//! Until that lands, the mismatch must at least be loud: the daemon reports the
+//! value it holds for each listed variable via its health payload, and the CLI
+//! compares its own environment against that report and warns (or, under
+//! `KIN_STRICT_BEHAVIOR_ENV`, errors) on any divergence.
+//!
+//! Both sides read [`BEHAVIOR_ENV_VARS`], so the daemon's report and the CLI's
+//! comparison can never drift apart. [`compare`] is pure over its two inputs and
+//! therefore fully unit-testable.
+
+use std::collections::BTreeMap;
+
+/// Behavior-relevant variables whose effect is decided in the daemon worker
+/// process (or the embedding / inference substrate it hosts), not per request.
+///
+/// This is intentionally *not* limited to the `KIN_*` prefix: `EMBED_MAX_SEQ_LEN`
+/// is consumed by the inference substrate under its own name. Membership here is
+/// about "does the value get baked into the worker at start" — not about naming.
+pub const BEHAVIOR_ENV_VARS: &[&str] = &[
+    "KIN_RESOURCE_PROFILE",
+    "KIN_EMBED_HYBRID",
+    "KIN_EMBED_HYBRID_CPU_MAX_SEQ_LEN",
+    "KIN_EMBED_HYBRID_GPU_TPUT_RATIO",
+    "KIN_INFER_CPU_BACKEND",
+    "KIN_INFER_OCCUPANCY_DISPATCH",
+    "KIN_EMBED_CACHE",
+    "KIN_EMBED_CACHE_DIR",
+    "KIN_EMBED_BACKEND",
+    "KIN_INIT_WARM_CACHE",
+    "EMBED_MAX_SEQ_LEN",
+];
+
+/// A snapshot of the behavior-env surface: variable name → `Some(value)` when
+/// the variable is set (including to an empty string) or `None` when unset in
+/// that process. Serializes as a plain JSON object of `string | null` values.
+pub type BehaviorEnv = BTreeMap<String, Option<String>>;
+
+/// Capture the behavior-env surface using an arbitrary `lookup` (typically
+/// `|name| std::env::var(name).ok()`). Pure in the lookup, so it is
+/// deterministic and testable; [`snapshot_from_process`] wires it to the live
+/// process environment.
+pub fn snapshot_with<F>(mut lookup: F) -> BehaviorEnv
+where
+    F: FnMut(&str) -> Option<String>,
+{
+    BEHAVIOR_ENV_VARS
+        .iter()
+        .map(|name| ((*name).to_string(), lookup(name)))
+        .collect()
+}
+
+/// Capture the behavior-env surface from the live process environment. Called by
+/// the daemon to build its health report and by the CLI to build the snapshot it
+/// compares against that report.
+pub fn snapshot_from_process() -> BehaviorEnv {
+    snapshot_with(|name| std::env::var(name).ok())
+}
+
+/// A single behavior-env divergence between the invoking CLI and the running
+/// daemon for one variable.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct Divergence {
+    /// Variable name.
+    pub var: String,
+    /// Raw value in the invoking CLI's environment (`None` = unset).
+    pub cli: Option<String>,
+    /// Raw value the daemon captured at start (`None` = unset).
+    pub daemon: Option<String>,
+}
+
+impl Divergence {
+    /// One line: `VAR: cli=<value> daemon=<value>`, where an unset side renders
+    /// as `(unset)` and a present value is quoted.
+    pub fn describe(&self) -> String {
+        format!(
+            "{}: cli={} daemon={}",
+            self.var,
+            show(&self.cli),
+            show(&self.daemon),
+        )
+    }
+}
+
+/// Render an optional raw value for a human: quoted string, or `(unset)`.
+fn show(value: &Option<String>) -> String {
+    match value {
+        Some(v) => format!("{v:?}"),
+        None => "(unset)".to_string(),
+    }
+}
+
+/// The comparison-effective form of a raw value: trimmed, with empty-after-trim
+/// treated as unset. This mirrors how Kin's read sites treat an empty value as
+/// "unset", so an empty string on one side and a genuinely-unset variable on the
+/// other do not read as a spurious divergence.
+fn effective(value: &Option<String>) -> Option<&str> {
+    value.as_deref().map(str::trim).filter(|s| !s.is_empty())
+}
+
+/// Compare a CLI snapshot against a daemon-reported snapshot and return one
+/// [`Divergence`] per behavior-relevant variable whose values differ. Pure: only
+/// the two maps are consulted.
+///
+/// Only variables the daemon actually reported are compared. A daemon that
+/// predates this surface (or a given variable) simply omits it from its report,
+/// and an omitted variable yields no divergence — we never invent a mismatch for
+/// a value we cannot observe. Comparison is on the trimmed raw value (see
+/// [`effective`]); the returned [`Divergence`] carries the untrimmed originals so
+/// the operator sees exactly what each side holds. Results are in
+/// [`BEHAVIOR_ENV_VARS`] order.
+pub fn compare(cli: &BehaviorEnv, daemon: &BehaviorEnv) -> Vec<Divergence> {
+    let mut out = Vec::new();
+    for &var in BEHAVIOR_ENV_VARS {
+        let Some(daemon_val) = daemon.get(var) else {
+            continue;
+        };
+        let cli_val = cli.get(var).cloned().flatten();
+        if effective(&cli_val) != effective(daemon_val) {
+            out.push(Divergence {
+                var: var.to_string(),
+                cli: cli_val,
+                daemon: daemon_val.clone(),
+            });
+        }
+    }
+    out
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn env(pairs: &[(&str, Option<&str>)]) -> BehaviorEnv {
+        pairs
+            .iter()
+            .map(|(k, v)| (k.to_string(), v.map(str::to_string)))
+            .collect()
+    }
+
+    #[test]
+    fn snapshot_covers_every_listed_var() {
+        let snap = snapshot_with(|name| Some(format!("val-{name}")));
+        assert_eq!(snap.len(), BEHAVIOR_ENV_VARS.len());
+        for name in BEHAVIOR_ENV_VARS {
+            assert_eq!(snap.get(*name), Some(&Some(format!("val-{name}"))));
+        }
+    }
+
+    #[test]
+    fn snapshot_records_unset_as_none() {
+        let snap = snapshot_with(|_| None);
+        assert_eq!(snap.len(), BEHAVIOR_ENV_VARS.len());
+        assert!(snap.values().all(|v| v.is_none()));
+    }
+
+    #[test]
+    fn identical_env_has_no_divergence() {
+        let cli = env(&[("KIN_EMBED_HYBRID", Some("balanced"))]);
+        let daemon = env(&[("KIN_EMBED_HYBRID", Some("balanced"))]);
+        assert!(compare(&cli, &daemon).is_empty());
+    }
+
+    #[test]
+    fn override_ignored_by_daemon_is_flagged() {
+        // The motivating case: the operator sets a lever on this command, but the
+        // long-lived daemon started without it and never sees the override.
+        let cli = env(&[("KIN_EMBED_HYBRID", Some("balanced"))]);
+        let daemon = env(&[("KIN_EMBED_HYBRID", None)]);
+        let diffs = compare(&cli, &daemon);
+        assert_eq!(diffs.len(), 1);
+        assert_eq!(diffs[0].var, "KIN_EMBED_HYBRID");
+        assert_eq!(diffs[0].cli.as_deref(), Some("balanced"));
+        assert_eq!(diffs[0].daemon, None);
+    }
+
+    #[test]
+    fn daemon_only_value_is_flagged() {
+        // The reverse: the daemon carries a lever this command did not set, so
+        // the command silently runs under it.
+        let cli = env(&[("KIN_RESOURCE_PROFILE", None)]);
+        let daemon = env(&[("KIN_RESOURCE_PROFILE", Some("throughput"))]);
+        let diffs = compare(&cli, &daemon);
+        assert_eq!(diffs.len(), 1);
+        assert_eq!(diffs[0].var, "KIN_RESOURCE_PROFILE");
+        assert_eq!(diffs[0].cli, None);
+        assert_eq!(diffs[0].daemon.as_deref(), Some("throughput"));
+    }
+
+    #[test]
+    fn differing_values_are_flagged() {
+        let cli = env(&[("EMBED_MAX_SEQ_LEN", Some("256"))]);
+        let daemon = env(&[("EMBED_MAX_SEQ_LEN", Some("512"))]);
+        let diffs = compare(&cli, &daemon);
+        assert_eq!(diffs.len(), 1);
+        assert_eq!(diffs[0].var, "EMBED_MAX_SEQ_LEN");
+    }
+
+    #[test]
+    fn empty_and_unset_do_not_diverge() {
+        // Empty-after-trim is treated as unset on both sides, matching read-site
+        // semantics, so this is not a spurious divergence.
+        let cli = env(&[("KIN_EMBED_CACHE_DIR", Some("   "))]);
+        let daemon = env(&[("KIN_EMBED_CACHE_DIR", None)]);
+        assert!(compare(&cli, &daemon).is_empty());
+    }
+
+    #[test]
+    fn surrounding_whitespace_is_ignored() {
+        let cli = env(&[("KIN_EMBED_BACKEND", Some("metal"))]);
+        let daemon = env(&[("KIN_EMBED_BACKEND", Some(" metal "))]);
+        assert!(compare(&cli, &daemon).is_empty());
+    }
+
+    #[test]
+    fn daemon_without_surface_yields_no_divergence() {
+        // An older daemon reports no behavior_env at all; the CLI must not invent
+        // divergences it cannot observe.
+        let cli = snapshot_with(|_| Some("set".to_string()));
+        let daemon: BehaviorEnv = BTreeMap::new();
+        assert!(compare(&cli, &daemon).is_empty());
+    }
+
+    #[test]
+    fn unlisted_daemon_key_is_ignored() {
+        // Only the shared list is compared; stray keys in a report are inert.
+        let cli = env(&[("KIN_EMBED_HYBRID", Some("balanced"))]);
+        let mut daemon = env(&[("KIN_EMBED_HYBRID", Some("balanced"))]);
+        daemon.insert("KIN_SOMETHING_ELSE".to_string(), Some("x".to_string()));
+        assert!(compare(&cli, &daemon).is_empty());
+    }
+
+    #[test]
+    fn multiple_divergences_sorted_by_list_order() {
+        let cli = env(&[
+            ("EMBED_MAX_SEQ_LEN", Some("256")),
+            ("KIN_RESOURCE_PROFILE", Some("throughput")),
+        ]);
+        let daemon = env(&[
+            ("EMBED_MAX_SEQ_LEN", Some("512")),
+            ("KIN_RESOURCE_PROFILE", None),
+        ]);
+        let diffs = compare(&cli, &daemon);
+        assert_eq!(diffs.len(), 2);
+        // KIN_RESOURCE_PROFILE precedes EMBED_MAX_SEQ_LEN in BEHAVIOR_ENV_VARS.
+        assert_eq!(diffs[0].var, "KIN_RESOURCE_PROFILE");
+        assert_eq!(diffs[1].var, "EMBED_MAX_SEQ_LEN");
+    }
+
+    #[test]
+    fn describe_renders_unset_and_quoted_values() {
+        let d = Divergence {
+            var: "KIN_EMBED_HYBRID".to_string(),
+            cli: Some("balanced".to_string()),
+            daemon: None,
+        };
+        assert_eq!(
+            d.describe(),
+            "KIN_EMBED_HYBRID: cli=\"balanced\" daemon=(unset)"
+        );
+    }
+}

--- a/crates/kin-core/src/env_registry.rs
+++ b/crates/kin-core/src/env_registry.rs
@@ -204,6 +204,7 @@ pub const OPERATIONAL: &[EnvVarSpec] = &[
     EnvVarSpec { name: "KIN_DAEMON_SHUTDOWN_GRACE_SECS", kind: Kind::Secs, default: "25", sensitivity: Sensitivity::Operational, summary: "grace before the shutdown watchdog force-exits; 0 escalates immediately" },
     EnvVarSpec { name: "KIN_DAEMON_RUNTIME_SHUTDOWN_GRACE_SECS", kind: Kind::Secs, default: "8", sensitivity: Sensitivity::Operational, summary: "bound on tokio runtime teardown waiting for blocking tasks" },
     EnvVarSpec { name: "KIN_ALLOW_DAEMON_BOOTSTRAP_ADMIN", kind: Kind::Bool, default: "false", sensitivity: Sensitivity::Operational, summary: "allow the CLI to bootstrap an admin-scoped daemon" },
+    EnvVarSpec { name: "KIN_STRICT_BEHAVIOR_ENV", kind: Kind::Bool, default: "false", sensitivity: Sensitivity::Operational, summary: "escalate a CLI/daemon behavior-env divergence from a warning to a hard error" },
 
     // ---- supervisor -----------------------------------------------------------
     EnvVarSpec { name: "KIN_SUPERVISOR_URL", kind: Kind::Url, default: "", sensitivity: Sensitivity::Operational, summary: "explicit supervisor endpoint URL" },

--- a/crates/kin-core/src/lib.rs
+++ b/crates/kin-core/src/lib.rs
@@ -3,6 +3,7 @@
 
 pub mod assistant;
 pub mod assistant_sync;
+pub mod behavior_env;
 pub mod config;
 pub mod dependencies;
 pub mod diff;

--- a/crates/kin-daemon/src/api.rs
+++ b/crates/kin-daemon/src/api.rs
@@ -104,6 +104,14 @@ pub struct HealthResponse {
     /// reads. Additive; `0` before the first snapshot is committed.
     #[serde(default)]
     pub graph_generation: u64,
+    /// Behavior-relevant environment the daemon worker captured at process
+    /// start (variable name → value, or `null` when unset). A repo daemon
+    /// inherits its environment from whichever command first started it and does
+    /// not pick up a later command's per-invocation overrides; a client compares
+    /// this against its own environment to surface a silently-ignored knob. See
+    /// `kin_core::behavior_env`.
+    #[serde(default)]
+    pub behavior_env: kin_core::behavior_env::BehaviorEnv,
     pub build: BuildResponse,
 }
 
@@ -1259,6 +1267,7 @@ async fn health(
         mass_deletion_blocked,
         embed_worker_failed,
         graph_generation: DaemonState::read_generation_marker(&state.layout),
+        behavior_env: kin_core::behavior_env::snapshot_from_process(),
         build: current_build_response(),
     }))
 }
@@ -7876,6 +7885,35 @@ mod tests {
         assert!(!json.build.built_at.is_empty());
         // Additive freshness marker present; 0 before any snapshot is committed.
         assert_eq!(json.graph_generation, 0);
+    }
+
+    #[tokio::test]
+    async fn health_reports_full_behavior_env_surface() {
+        // The health payload must carry every behavior-relevant variable (value
+        // or null) so a client can compare it against its own environment and
+        // detect a knob the long-lived daemon silently ignores.
+        let state = test_state();
+        let app = router(state);
+        let response = app
+            .oneshot(Request::get("/health").body(Body::empty()).unwrap())
+            .await
+            .unwrap();
+        assert_eq!(response.status(), StatusCode::OK);
+        let body = axum::body::to_bytes(response.into_body(), 8192)
+            .await
+            .unwrap();
+        let json: HealthResponse = serde_json::from_slice(&body).unwrap();
+        assert_eq!(
+            json.behavior_env.len(),
+            kin_core::behavior_env::BEHAVIOR_ENV_VARS.len(),
+            "health must report exactly the shared behavior-env surface"
+        );
+        for var in kin_core::behavior_env::BEHAVIOR_ENV_VARS {
+            assert!(
+                json.behavior_env.contains_key(*var),
+                "health payload missing behavior-env var {var}"
+            );
+        }
     }
 
     #[tokio::test]

--- a/docs/env-vars.md
+++ b/docs/env-vars.md
@@ -3,7 +3,7 @@
 
 # Kin environment variables
 
-This is the authoritative list of supported `KIN_*` environment variables (372 total, 284 correctness-relevant), generated from the central registry in `kin-core`.
+This is the authoritative list of supported `KIN_*` environment variables (373 total, 284 correctness-relevant), generated from the central registry in `kin-core`.
 
 At CLI and daemon startup Kin validates this surface (`KIN_ENV_VALIDATION`, default `warn`):
 
@@ -57,6 +57,7 @@ Sensitivity legend: **correctness** (affects retrieval/ranking/output or data sa
 | `KIN_SCOPE_TIMING` | bool | false | diagnostic | print scope graph build timing to stderr |
 | `KIN_SEARCH_MODE` | enum | *(unset)* | correctness | search strictness; 'precise' rejects broad show-body searches |
 | `KIN_STORAGE` | string | local | operational | daemon storage backend selector (e.g. local, gcs) |
+| `KIN_STRICT_BEHAVIOR_ENV` | bool | false | operational | escalate a CLI/daemon behavior-env divergence from a warning to a hard error |
 | `KIN_STRICT_BUILD_MATCH` | bool | false | correctness | require a strict historical build match when resolving a ref view |
 | `KIN_WORKSPACE_ROOT` | path | *(unset)* | operational | workspace root override for orchestration commands |
 | `KIN_WRITE_VETO` | enum | warn | correctness | write-veto mode: 'warn' (default) annotates would-be vetoes into foreign-held scopes, 'enforce' rejects them with a 409, 'off' disables |

--- a/docs/session-runtime.md
+++ b/docs/session-runtime.md
@@ -156,6 +156,44 @@ Agent-session launches do **not** require the daemon's remote command
 execution endpoint, which stays disabled unless an operator explicitly opts in
 with `KIN_DAEMON_ALLOW_EXEC=1`.
 
+## Daemon environment boundary
+
+The repo daemon is a long-lived, per-user singleton. The **first** `kin` command
+that needs it spawns it, and the daemon inherits **that** command's environment.
+Every later command reaches the already-running daemon over HTTP and does **not**
+re-export its own environment into the worker. So a behavior-relevant knob that
+is read inside the daemon worker — or in the embedding / inference substrate it
+hosts — is fixed at whatever value the daemon captured when it started.
+
+The consequence is a quiet footgun: running
+
+```
+KIN_EMBED_HYBRID=balanced kin embed
+```
+
+against a daemon that started **without** that variable applies the daemon's
+captured value, not the one on this command line. The override is silently
+ignored, because the substrate reads it at the worker's process start, not per
+request.
+
+Kin makes that mismatch loud rather than fixing the value in place:
+
+- The daemon reports the value it holds for each behavior-relevant variable in
+  its `/health` payload (`behavior_env`).
+- Environment-sensitive commands (`kin embed`, `kin resources`) compare the
+  current environment against that report and, on any divergence, print a
+  warning to stderr naming each variable with both sides' values.
+- The remedy is to restart the daemon so it re-inherits the current environment:
+  stop it (`kill $(cat .kin/daemon.pid)`; it also self-stops after its
+  `KIN_DAEMON_IDLE_TIMEOUT_SECS` idle window) and the next `kin` command
+  respawns it.
+- Set `KIN_STRICT_BEHAVIOR_ENV=1` to escalate the warning to a hard error, so
+  scripted and proof runs fail closed instead of measuring the wrong lever.
+
+The authoritative list of behavior-relevant variables is defined once in
+`kin-core` (`behavior_env`) and shared by both the daemon (which reports them)
+and the CLI (which compares them), so the two sides cannot drift apart.
+
 ## Recovery reference
 
 | Situation | What Kin does | Your move |


### PR DESCRIPTION
Repo worker daemons inherit their environment from a long-lived supervisor — a per-user singleton spawned by the first kin command — not from the invoking command. A user running KIN_EMBED_HYBRID=balanced kin embed against a live daemon gets the lever silently ignored (FIR-1239; this nulled a 12-cell measurement grid before being root-caused).

The daemon's /health now reports its effective behavior-relevant env (shared list in kin_core::behavior_env covering the resource profile, embed levers, CPU backend, occupancy, embed cache, warm-cache, and sequence cap). Before env-sensitive requests (embed, resources), the CLI compares its own environment against the daemon's report and emits one warning per diverging variable, naming both values and the actual remedy (stop the daemon so the next command respawns it with the current environment). KIN_STRICT_BEHAVIOR_ENV=1 escalates the warning to a hard error. Older daemons that don't report the map produce no false positives, and a failed health fetch never double-reports connectivity.

docs/session-runtime.md documents the boundary; docs/env-vars.md regenerated for the new flag. Full workspace suite green.