### PR TITLE
fix(session): change-set reconcile with base-version tracking

### DIFF
--- a/crates/kin-cli/src/commands/exec.rs
+++ b/crates/kin-cli/src/commands/exec.rs
@@ -729,6 +729,7 @@ mod tests {
         std::fs::write(repo.path().join("package.json"), "{\"name\":\"app\"}\n").unwrap();
         std::fs::create_dir_all(&session_dir).unwrap();
         std::fs::write(session_dir.join("package.json"), "{\"name\":\"app\"}\n").unwrap();
+        crate::commands::session_base::record_materialized_base(&session_dir, None).unwrap();
 
         // Fake npm: emits a lockfile plus a node_modules tree, like a real install.
         let mut env = stub_tool(
@@ -819,6 +820,7 @@ mod tests {
             "services:\n  app:\n    image: alpine\n",
         )
         .unwrap();
+        crate::commands::session_base::record_materialized_base(&session_dir, None).unwrap();
 
         // Fake docker: validates that the compose file is visible from the
         // workspace cwd, like `docker compose config` would.

--- a/crates/kin-cli/src/commands/mod.rs
+++ b/crates/kin-cli/src/commands/mod.rs
@@ -69,6 +69,7 @@ pub mod scope;
 pub mod search;
 pub mod secret;
 pub mod security;
+pub mod session_base;
 pub mod session_closeout;
 pub mod session_workspace;
 pub mod setup;

--- a/crates/kin-cli/src/commands/reconcile.rs
+++ b/crates/kin-cli/src/commands/reconcile.rs
@@ -135,7 +135,7 @@ pub fn execute_reconcile_session_dir_scoped(
     );
     println!("Against source: {}", source.display());
 
-    let changes = diff_directories(session_dir, &source)?;
+    let changes = plan_reconcile_changes(session_dir, &source)?;
 
     if changes.is_empty() {
         return Ok(ReconcileSummary {
@@ -313,7 +313,7 @@ where
     println!("Reconciling session workspace: {}", session_dir.display());
     println!("Against source: {}", source.display());
 
-    let changes = diff_directories(session_dir, &source)?;
+    let changes = plan_reconcile_changes(session_dir, &source)?;
 
     if changes.is_empty() {
         return Ok(ReconcileSummary {
@@ -659,6 +659,157 @@ fn resolve_session_dir(
     Ok(sessions.last().unwrap().path())
 }
 
+/// Compute the change-set to apply when reconciling a session workspace.
+///
+/// Reconcile replays only the workspace's own edits — the delta between the
+/// base state captured when the workspace was materialized and the workspace's
+/// current contents — instead of force-syncing the entire tree. Files the
+/// workspace never touched are left untouched even when the source has advanced
+/// past the base, so a workspace reconciled late never reverts intervening
+/// source truth. When the workspace and the source both changed the same file,
+/// the edits are merged when they agree and reported as a conflict when they do
+/// not; the source is never silently overwritten with older content.
+fn plan_reconcile_changes(session_dir: &Path, source: &Path) -> Result<Vec<FileChange>> {
+    match super::session_base::load_base(session_dir)? {
+        Some(base) => plan_from_base(session_dir, source, &base),
+        None => plan_without_base(session_dir, source),
+    }
+}
+
+/// Change-set plan for a workspace with a recorded base: a file-level three-way
+/// merge of base -> workspace against base -> source.
+fn plan_from_base(
+    session_dir: &Path,
+    source: &Path,
+    base: &super::session_base::SessionBase,
+) -> Result<Vec<FileChange>> {
+    let workspace_state = super::session_base::hash_dir(session_dir)?;
+    let source_state = super::session_base::hash_dir(source)?;
+    let base_state = &base.files;
+
+    let mut candidate_paths: std::collections::BTreeSet<String> = std::collections::BTreeSet::new();
+    candidate_paths.extend(base_state.keys().cloned());
+    candidate_paths.extend(workspace_state.keys().cloned());
+
+    let mut changes = Vec::new();
+    let mut conflicts = Vec::new();
+
+    for path in candidate_paths {
+        let base_hash = base_state.get(&path);
+        let workspace_hash = workspace_state.get(&path);
+        if base_hash == workspace_hash {
+            // The workspace never changed this path; leave it untouched even if
+            // the source advanced it. This is the change-set guarantee.
+            continue;
+        }
+
+        let source_hash = source_state.get(&path);
+        if source_hash != base_hash {
+            // Both the workspace and the source moved this path off the base.
+            if workspace_hash == source_hash {
+                // They converged to identical content — nothing to apply.
+                continue;
+            }
+            conflicts.push(describe_reconcile_conflict(
+                &path,
+                base_hash,
+                workspace_hash,
+                source_hash,
+            ));
+            continue;
+        }
+
+        // Disjoint edit: the source is still at the base here, so the
+        // workspace's own change applies cleanly.
+        let kind = match (base_hash.is_some(), workspace_hash.is_some()) {
+            (false, true) => ChangeKind::Added,
+            (true, true) => ChangeKind::Modified,
+            (true, false) => ChangeKind::Deleted,
+            // Unreachable: base_hash != workspace_hash is guaranteed above.
+            (false, false) => continue,
+        };
+        changes.push(FileChange {
+            relative_path: PathBuf::from(path),
+            kind,
+        });
+    }
+
+    if !conflicts.is_empty() {
+        let base_head = base.base_head.as_deref().unwrap_or("unknown");
+        anyhow::bail!(
+            "session reconcile conflict for {}: {} file(s) changed both in the session workspace \
+             and in the source since it was materialized (base graph head {base_head}). Kin will \
+             not overwrite newer source truth. Resolve the workspace by hand or discard it. \
+             Conflicting files:\n  {}",
+            session_dir.display(),
+            conflicts.len(),
+            conflicts.join("\n  "),
+        );
+    }
+
+    Ok(changes)
+}
+
+/// Human-readable description of how a file diverged in both the workspace and
+/// the source, for conflict reporting.
+fn describe_reconcile_conflict(
+    path: &str,
+    base: Option<&String>,
+    workspace: Option<&String>,
+    source: Option<&String>,
+) -> String {
+    let workspace_action = match (base.is_some(), workspace.is_some()) {
+        (false, true) => "added in session",
+        (true, true) => "modified in session",
+        (true, false) => "deleted in session",
+        (false, false) => "unchanged in session",
+    };
+    let source_action = match (base.is_some(), source.is_some()) {
+        (false, true) => "added in source",
+        (true, true) => "modified in source",
+        (true, false) => "deleted in source",
+        (false, false) => "unchanged in source",
+    };
+    format!("{path} ({workspace_action}; {source_action})")
+}
+
+/// Change-set plan for a legacy workspace with no recorded base.
+///
+/// Without a base the workspace's own edits cannot be separated from source
+/// changes made since it was materialized. Additions are the one provably safe
+/// class — the path does not exist in the source tree, so writing it cannot
+/// overwrite or remove source truth — and they apply. Modifications and
+/// deletions of source-existing paths could revert newer source truth, so any
+/// of those fails loud and asks the operator to rematerialize.
+fn plan_without_base(session_dir: &Path, source: &Path) -> Result<Vec<FileChange>> {
+    let changes = diff_directories(session_dir, source)?;
+    let dangerous: Vec<String> = changes
+        .iter()
+        .filter(|change| !matches!(change.kind, ChangeKind::Added))
+        .map(|change| {
+            let action = match change.kind {
+                ChangeKind::Modified => "modified in session",
+                ChangeKind::Deleted => "missing from session",
+                ChangeKind::Added => unreachable!("filtered above"),
+            };
+            format!("{} ({action})", change.relative_path.display())
+        })
+        .collect();
+    if dangerous.is_empty() {
+        return Ok(changes);
+    }
+    anyhow::bail!(
+        "session workspace {} has no recorded base version, so its edits to {} existing source \
+         path(s) cannot be separated from source changes made since it was materialized; \
+         reconciling could revert newer source truth. Re-run the work in a fresh session \
+         (kin exec/shell/with) or discard this workspace (rm -rf {}). Affected:\n  {}",
+        session_dir.display(),
+        dangerous.len(),
+        session_dir.display(),
+        dangerous.join("\n  "),
+    )
+}
+
 /// Compare two directories and find differences.
 fn diff_directories(session: &Path, source: &Path) -> Result<Vec<FileChange>> {
     let mut changes = Vec::new();
@@ -701,7 +852,7 @@ fn diff_directories(session: &Path, source: &Path) -> Result<Vec<FileChange>> {
 }
 
 /// Collect all file paths relative to root, skipping hidden dirs and common large dirs.
-fn collect_relative_files(root: &Path) -> Result<Vec<PathBuf>> {
+pub(crate) fn collect_relative_files(root: &Path) -> Result<Vec<PathBuf>> {
     let mut files = Vec::new();
     collect_recursive(root, root, &mut files)?;
     Ok(files)
@@ -761,6 +912,22 @@ mod tests {
     use super::*;
     use std::fs;
     use tempfile::tempdir;
+
+    /// Record a base manifest for a hand-built session workspace, modeling the
+    /// base a real materialization captures: a snapshot of the source tree at
+    /// the moment the workspace was materialized. With the source unchanged
+    /// afterward, the change-set plan reduces to the workspace's own edits.
+    fn record_base_from_source(layout: &kin_core::KinLayout, session_dir: &Path) {
+        let files = crate::commands::session_base::hash_dir(&kin_core::source_dir(layout)).unwrap();
+        crate::commands::session_base::write_base(
+            session_dir,
+            &crate::commands::session_base::SessionBase {
+                base_head: None,
+                files,
+            },
+        )
+        .unwrap();
+    }
 
     // --- files_differ tests ---
 
@@ -835,6 +1002,7 @@ mod tests {
             "pub fn persisted_reconcile() -> &'static str { \"ok\" }\n",
         )
         .unwrap();
+        record_base_from_source(&layout, &session_dir);
 
         let summary = reconcile_session_dir_sync(&layout, &session_dir).unwrap();
         assert_eq!(summary.files_indexed, 1);
@@ -858,6 +1026,7 @@ mod tests {
         fs::write(&source_file, original).unwrap();
         fs::create_dir_all(session_dir.join("src")).unwrap();
         fs::write(session_dir.join("src/lib.rs"), "pub fn stable_source( {\n").unwrap();
+        record_base_from_source(&layout, &session_dir);
 
         let err = reconcile_session_dir_sync(&layout, &session_dir)
             .unwrap_err()
@@ -880,6 +1049,7 @@ mod tests {
         fs::write(&source_file, original).unwrap();
         fs::create_dir_all(session_dir.join("src")).unwrap();
         fs::write(session_dir.join("src/lib.rs"), updated).unwrap();
+        record_base_from_source(&layout, &session_dir);
 
         // Block the snapshot's atomic-write tmp path so the persist fails. The
         // tmp name is the full snapshot path with `.tmp` APPENDED (graph.kndb ->
@@ -897,6 +1067,211 @@ mod tests {
             .to_string();
         assert!(err.contains("failed to persist reconciled graph snapshot"));
         assert_eq!(fs::read_to_string(&source_file).unwrap(), original);
+    }
+
+    // --- change-set reconcile tests ---
+
+    const A_V1: &str = "pub fn a() -> u8 { 1 }\n";
+    const A_V2: &str = "pub fn a() -> u8 { 2 }\n";
+    const A_V3: &str = "pub fn a() -> u8 { 3 }\n";
+
+    /// Fast path: with the source still at the base, the workspace's own edit
+    /// applies exactly as before — behavior is unchanged for the common case.
+    #[test]
+    fn change_set_fast_path_applies_workspace_edit() {
+        let repo = tempdir().unwrap();
+        let layout = kin_core::init(repo.path()).unwrap().layout;
+        let source = kin_core::source_dir(&layout);
+
+        fs::create_dir_all(source.join("src")).unwrap();
+        fs::write(source.join("src/a.rs"), A_V1).unwrap();
+
+        let session_dir = layout.root().join("runs/session-fast-path");
+        fs::create_dir_all(session_dir.join("src")).unwrap();
+        fs::write(session_dir.join("src/a.rs"), A_V2).unwrap();
+        record_base_from_source(&layout, &session_dir);
+
+        let summary = reconcile_session_dir_sync(&layout, &session_dir).unwrap();
+
+        assert_eq!(summary.change_count, 1);
+        assert!(summary
+            .changes
+            .contains(&("modified".into(), "src/a.rs".into())));
+        assert_eq!(fs::read_to_string(source.join("src/a.rs")).unwrap(), A_V2);
+    }
+
+    /// Regression for the session-workspace data-loss edge: a file created in
+    /// the source after the workspace was materialized must survive a late
+    /// reconcile, never be deleted as "absent from the workspace".
+    #[test]
+    fn change_set_preserves_source_file_added_after_materialization() {
+        let repo = tempdir().unwrap();
+        let layout = kin_core::init(repo.path()).unwrap().layout;
+        let source = kin_core::source_dir(&layout);
+
+        // Base state: the source has only a.rs.
+        fs::create_dir_all(source.join("src")).unwrap();
+        fs::write(source.join("src/a.rs"), A_V1).unwrap();
+
+        // Materialize + edit a.rs in the workspace.
+        let session_dir = layout.root().join("runs/session-late-add");
+        fs::create_dir_all(session_dir.join("src")).unwrap();
+        fs::write(session_dir.join("src/a.rs"), A_V2).unwrap();
+        record_base_from_source(&layout, &session_dir);
+
+        // The source advances after materialization: a new file appears.
+        let new_source_file = "pub fn b() -> u8 { 9 }\n";
+        fs::write(source.join("src/b.rs"), new_source_file).unwrap();
+
+        let summary = reconcile_session_dir_sync(&layout, &session_dir).unwrap();
+
+        // The workspace's own edit is applied...
+        assert_eq!(fs::read_to_string(source.join("src/a.rs")).unwrap(), A_V2);
+        // ...and the intervening source file is preserved, not reverted.
+        assert!(
+            source.join("src/b.rs").exists(),
+            "reconcile must not delete source files created after materialization"
+        );
+        assert_eq!(
+            fs::read_to_string(source.join("src/b.rs")).unwrap(),
+            new_source_file
+        );
+        assert_eq!(summary.change_count, 1);
+        assert!(!summary.changes.iter().any(|(_, path)| path == "src/b.rs"));
+    }
+
+    /// A source file modified after materialization but never touched by the
+    /// workspace must keep the newer source content, not be reverted to base.
+    #[test]
+    fn change_set_preserves_unrelated_source_edit() {
+        let repo = tempdir().unwrap();
+        let layout = kin_core::init(repo.path()).unwrap().layout;
+        let source = kin_core::source_dir(&layout);
+
+        fs::create_dir_all(source.join("src")).unwrap();
+        fs::write(source.join("src/a.rs"), A_V1).unwrap();
+        fs::write(source.join("src/c.rs"), "pub fn c() -> u8 { 1 }\n").unwrap();
+
+        // Workspace edits a.rs, leaves c.rs at the base content.
+        let session_dir = layout.root().join("runs/session-unrelated");
+        fs::create_dir_all(session_dir.join("src")).unwrap();
+        fs::write(session_dir.join("src/a.rs"), A_V2).unwrap();
+        fs::write(session_dir.join("src/c.rs"), "pub fn c() -> u8 { 1 }\n").unwrap();
+        record_base_from_source(&layout, &session_dir);
+
+        // The source advances c.rs after materialization.
+        let advanced_c = "pub fn c() -> u8 { 2 }\n";
+        fs::write(source.join("src/c.rs"), advanced_c).unwrap();
+
+        let summary = reconcile_session_dir_sync(&layout, &session_dir).unwrap();
+
+        assert_eq!(fs::read_to_string(source.join("src/a.rs")).unwrap(), A_V2);
+        assert_eq!(
+            fs::read_to_string(source.join("src/c.rs")).unwrap(),
+            advanced_c,
+            "reconcile must not revert a source edit the workspace never touched"
+        );
+        assert_eq!(summary.change_count, 1);
+    }
+
+    /// When the workspace and the source both change the same file to different
+    /// content, reconcile fails loud and leaves the newer source truth intact.
+    #[test]
+    fn change_set_conflicting_edit_fails_loud() {
+        let repo = tempdir().unwrap();
+        let layout = kin_core::init(repo.path()).unwrap().layout;
+        let source = kin_core::source_dir(&layout);
+
+        fs::create_dir_all(source.join("src")).unwrap();
+        fs::write(source.join("src/a.rs"), A_V1).unwrap();
+
+        let session_dir = layout.root().join("runs/session-conflict");
+        fs::create_dir_all(session_dir.join("src")).unwrap();
+        fs::write(session_dir.join("src/a.rs"), A_V2).unwrap();
+        record_base_from_source(&layout, &session_dir);
+
+        // The source moves the same file to a third state.
+        fs::write(source.join("src/a.rs"), A_V3).unwrap();
+
+        let err = reconcile_session_dir_sync(&layout, &session_dir)
+            .unwrap_err()
+            .to_string();
+
+        assert!(err.contains("conflict"), "unexpected error: {err}");
+        assert!(err.contains("src/a.rs"), "unexpected error: {err}");
+        // Newer source truth is untouched, and the workspace is preserved.
+        assert_eq!(fs::read_to_string(source.join("src/a.rs")).unwrap(), A_V3);
+        assert_eq!(
+            fs::read_to_string(session_dir.join("src/a.rs")).unwrap(),
+            A_V2
+        );
+    }
+
+    /// If the workspace and source converged to identical content, there is no
+    /// conflict and nothing to apply.
+    #[test]
+    fn change_set_converged_edit_is_noop() {
+        let repo = tempdir().unwrap();
+        let layout = kin_core::init(repo.path()).unwrap().layout;
+        let source = kin_core::source_dir(&layout);
+
+        fs::create_dir_all(source.join("src")).unwrap();
+        fs::write(source.join("src/a.rs"), A_V1).unwrap();
+
+        let session_dir = layout.root().join("runs/session-converged");
+        fs::create_dir_all(session_dir.join("src")).unwrap();
+        fs::write(session_dir.join("src/a.rs"), A_V2).unwrap();
+        record_base_from_source(&layout, &session_dir);
+
+        // The source independently reaches the same content as the workspace.
+        fs::write(source.join("src/a.rs"), A_V2).unwrap();
+
+        let summary = reconcile_session_dir_sync(&layout, &session_dir).unwrap();
+        assert_eq!(summary.change_count, 0);
+        assert_eq!(fs::read_to_string(source.join("src/a.rs")).unwrap(), A_V2);
+    }
+
+    /// A legacy workspace with no recorded base refuses to reconcile when its
+    /// contents differ from the source, rather than risk reverting source truth.
+    #[test]
+    fn change_set_without_base_refuses_when_workspace_differs() {
+        let repo = tempdir().unwrap();
+        let layout = kin_core::init(repo.path()).unwrap().layout;
+        let source = kin_core::source_dir(&layout);
+
+        fs::create_dir_all(source.join("src")).unwrap();
+        fs::write(source.join("src/a.rs"), A_V1).unwrap();
+
+        // Hand-built session with no base manifest (legacy workspace).
+        let session_dir = layout.root().join("runs/session-legacy-diff");
+        fs::create_dir_all(session_dir.join("src")).unwrap();
+        fs::write(session_dir.join("src/a.rs"), A_V2).unwrap();
+
+        let err = reconcile_session_dir_sync(&layout, &session_dir)
+            .unwrap_err()
+            .to_string();
+        assert!(err.contains("no recorded base"), "unexpected error: {err}");
+        // The source is untouched — reconcile refused before applying anything.
+        assert_eq!(fs::read_to_string(source.join("src/a.rs")).unwrap(), A_V1);
+    }
+
+    /// A legacy workspace already identical to the source is a provable no-op
+    /// and is allowed.
+    #[test]
+    fn change_set_without_base_allows_identical_noop() {
+        let repo = tempdir().unwrap();
+        let layout = kin_core::init(repo.path()).unwrap().layout;
+        let source = kin_core::source_dir(&layout);
+
+        fs::create_dir_all(source.join("src")).unwrap();
+        fs::write(source.join("src/a.rs"), A_V1).unwrap();
+
+        let session_dir = layout.root().join("runs/session-legacy-noop");
+        fs::create_dir_all(session_dir.join("src")).unwrap();
+        fs::write(session_dir.join("src/a.rs"), A_V1).unwrap();
+
+        let summary = reconcile_session_dir_sync(&layout, &session_dir).unwrap();
+        assert_eq!(summary.change_count, 0);
     }
 
     // --- collect_relative_files tests ---

--- a/crates/kin-cli/src/commands/session_base.rs
+++ b/crates/kin-cli/src/commands/session_base.rs
@@ -1,0 +1,120 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Firelock, LLC
+
+//! Base-version tracking for session workspaces.
+//!
+//! When a session workspace is materialized from graph truth, Kin records the
+//! state it started from: the graph head it was projected from and a content
+//! hash for every file materialized into it. Reconcile reads this recorded base
+//! to replay only the workspace's own change-set instead of force-syncing whole
+//! tree state, so a workspace reconciled after the source has advanced never
+//! reverts the intervening source changes.
+//!
+//! The manifest is stored under a `.kin-session/` directory inside the
+//! workspace. That prefix is excluded by every graph file-collection path
+//! (`kin_index::should_skip_dir`), so the manifest is never materialized,
+//! diffed, reconciled, or indexed as project content, and it is removed with
+//! the workspace on cleanup.
+
+use std::collections::BTreeMap;
+use std::path::{Path, PathBuf};
+
+use anyhow::Result;
+use serde::{Deserialize, Serialize};
+
+/// Workspace-relative directory that holds Kin's session-runtime metadata.
+const META_DIR: &str = ".kin-session";
+/// File (within [`META_DIR`]) that records the workspace's base state.
+const BASE_FILE: &str = "reconcile-base.json";
+
+/// Recorded starting point of a session workspace.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct SessionBase {
+    /// Graph head (branch head change id) the workspace was projected from.
+    ///
+    /// Used for provenance and conflict reporting; the file manifest is the
+    /// authoritative base for change-set computation.
+    #[serde(default)]
+    pub base_head: Option<String>,
+    /// Repo-relative path -> content hash for every materialized file.
+    pub files: BTreeMap<String, String>,
+}
+
+/// Path to the base manifest for a session workspace.
+fn base_manifest_path(session_dir: &Path) -> PathBuf {
+    session_dir.join(META_DIR).join(BASE_FILE)
+}
+
+/// Hash every collectable file under `root` into a `path -> content-hash` map.
+///
+/// Uses the same file-collection policy as reconcile (`collect_relative_files`)
+/// so a base captured at materialization and a state hashed at reconcile are
+/// directly comparable.
+pub fn hash_dir(root: &Path) -> Result<BTreeMap<String, String>> {
+    let mut manifest = BTreeMap::new();
+    for rel in super::reconcile::collect_relative_files(root)? {
+        let abs = root.join(&rel);
+        let content = std::fs::read(&abs).map_err(|e| {
+            anyhow::anyhow!(
+                "failed to read {} for session base manifest: {}",
+                abs.display(),
+                e
+            )
+        })?;
+        manifest.insert(
+            rel.to_string_lossy().into_owned(),
+            kin_blobs::digest(&content).to_string(),
+        );
+    }
+    Ok(manifest)
+}
+
+/// Persist a base manifest into a session workspace.
+pub fn write_base(session_dir: &Path, base: &SessionBase) -> Result<()> {
+    let path = base_manifest_path(session_dir);
+    if let Some(parent) = path.parent() {
+        std::fs::create_dir_all(parent).map_err(|e| {
+            anyhow::anyhow!(
+                "failed to create session metadata directory {}: {}",
+                parent.display(),
+                e
+            )
+        })?;
+    }
+    let json = serde_json::to_vec_pretty(base)
+        .map_err(|e| anyhow::anyhow!("failed to serialize session base: {}", e))?;
+    std::fs::write(&path, json)
+        .map_err(|e| anyhow::anyhow!("failed to write session base {}: {}", path.display(), e))?;
+    Ok(())
+}
+
+/// Load a session workspace's recorded base, if one was captured.
+///
+/// Returns `Ok(None)` for legacy workspaces materialized before base tracking.
+pub(crate) fn load_base(session_dir: &Path) -> Result<Option<SessionBase>> {
+    let path = base_manifest_path(session_dir);
+    match std::fs::read(&path) {
+        Ok(bytes) => {
+            let base = serde_json::from_slice(&bytes).map_err(|e| {
+                anyhow::anyhow!("failed to parse session base {}: {}", path.display(), e)
+            })?;
+            Ok(Some(base))
+        }
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => Ok(None),
+        Err(e) => Err(anyhow::anyhow!(
+            "failed to read session base {}: {}",
+            path.display(),
+            e
+        )),
+    }
+}
+
+/// Record the base state of a freshly materialized session workspace.
+///
+/// Immediately after materialization the workspace is byte-identical to the
+/// graph truth it was projected from, so hashing the workspace itself captures
+/// the correct base.
+pub fn record_materialized_base(session_dir: &Path, base_head: Option<String>) -> Result<()> {
+    let files = hash_dir(session_dir)?;
+    write_base(session_dir, &SessionBase { base_head, files })
+}

--- a/crates/kin-cli/src/commands/session_workspace.rs
+++ b/crates/kin-cli/src/commands/session_workspace.rs
@@ -94,14 +94,22 @@ pub fn create_session_workspace_from_graph(
     let blob_store = kin_blobs::BlobStore::new(layout.objects_dir())
         .map_err(|e| anyhow::anyhow!("failed to open blob store: {}", e))?;
 
-    Ok(MaterializedWorkspace::create_from_source(
+    let workspace = MaterializedWorkspace::create_from_source(
         MaterializationSource::BlobTree {
             blob_store: &blob_store,
             tree: &tree,
         },
         session_dir,
         scope,
-    )?)
+    )?;
+
+    // Record the workspace's base version so a later reconcile replays only the
+    // workspace's own change-set instead of force-syncing whole-tree state.
+    // Immediately after materialization the workspace mirrors the projected
+    // graph head, so hashing it captures the correct base.
+    super::session_base::record_materialized_base(session_dir, Some(branch.head.to_string()))?;
+
+    Ok(workspace)
 }
 
 pub fn materialize_session_workspace(

--- a/docs/session-runtime.md
+++ b/docs/session-runtime.md
@@ -35,8 +35,9 @@ Codex, Gemini, Windsurf) and your shell hook. In short:
    resolved against the graph and fail loudly if the entity does not exist.
 2. **Run.** The command executes locally in that workspace (never through the
    daemon), with `KIN_SESSION`, `KIN_SESSION_ID`, and `KIN_SESSION_DIR` set.
-3. **Reconcile.** On success, Kin diffs the workspace against the source
-   surface and reconciles changes into the graph, then removes the workspace.
+3. **Reconcile.** On success, Kin reconciles the workspace's own changes into
+   the graph — a change-set replay against the base state it was materialized
+   from, not a whole-tree overwrite — then removes the workspace.
 4. **Fail loud, lose nothing.** On a non-zero exit — or if reconcile itself
    fails — the workspace is **preserved** and Kin prints the recovery
    commands:
@@ -167,9 +168,18 @@ with `KIN_DAEMON_ALLOW_EXEC=1`.
 | Ran with `--discard` | delete workspace, no reconcile | nothing |
 | Not sure what's pending | — | `kin doctor` lists leftover session workspaces |
 
-One reconcile semantic to know: reconcile diffs the **entire workspace** against
-the current source surface — it is a state sync, not a change-set replay. A
-workspace kept around while the repo moves on will, when reconciled later,
-also revert whatever changed in the meantime (including deleting files created
-after the workspace was materialized). Reconcile kept workspaces promptly, or
-discard them.
+One reconcile semantic to know: reconcile replays the **workspace's own
+change-set**, not a whole-tree state sync. When a workspace is materialized Kin
+records the base graph version it started from; at reconcile it applies only the
+edits the workspace itself made relative to that base and leaves files the
+workspace never touched alone — even if the source advanced in the meantime. So a
+kept workspace reconciled late does **not** revert source changes made since it
+was materialized, and does not delete files created in the source afterward.
+
+If the workspace and the source both changed the same file, reconcile merges
+them when they agree and **fails loud** — naming the conflicting files and
+exiting non-zero — when they do not, rather than overwriting newer source truth.
+The workspace is preserved on conflict so you can resolve it by hand or discard
+it. Workspaces materialized before base tracking carry no recorded base;
+reconcile refuses them unless they are already identical to the source, and asks
+you to re-run the work in a fresh session or discard the workspace.

--- a/tests/integration/src/p11_mutation_parity.rs
+++ b/tests/integration/src/p11_mutation_parity.rs
@@ -15,6 +15,23 @@ use kin_runtime::workspace::{MaterializeStrategy, MaterializedWorkspace};
 
 use crate::helpers::*;
 
+/// Record a base manifest for a hand-built session workspace, modeling the base
+/// a real materialization captures: a snapshot of the source tree at the moment
+/// the workspace was materialized. With the source unchanged afterward,
+/// change-set reconcile reduces to the workspace's own edits, so these
+/// end-to-end mutation-parity assertions hold exactly as before.
+fn record_session_base(layout: &kin_core::KinLayout, session_dir: &std::path::Path) {
+    let files = kin_cli::commands::session_base::hash_dir(&kin_core::source_dir(layout)).unwrap();
+    kin_cli::commands::session_base::write_base(
+        session_dir,
+        &kin_cli::commands::session_base::SessionBase {
+            base_head: None,
+            files,
+        },
+    )
+    .unwrap();
+}
+
 // ---------------------------------------------------------------------------
 // 42. Edit source file, re-index, verify entity updated in graph
 // ---------------------------------------------------------------------------
@@ -294,6 +311,7 @@ async fn test_session_reconcile_adds_doc_file() {
         "# Session-created Doc\n\nThis file should survive reconcile.\n",
     )
     .unwrap();
+    record_session_base(&layout, &session_dir);
 
     let summary = reconcile_session_dir(&layout, &session_dir).await.unwrap();
     assert_eq!(summary.change_count, 1);
@@ -333,6 +351,7 @@ async fn test_session_reconcile_deletes_doc_file() {
     )
     .unwrap();
     std::fs::create_dir_all(&session_dir).unwrap();
+    record_session_base(&layout, &session_dir);
 
     let summary = reconcile_session_dir(&layout, &session_dir).await.unwrap();
     assert_eq!(summary.change_count, 1);
@@ -386,6 +405,7 @@ async fn test_session_reconcile_renames_source_file() {
         "pub fn renamed_from_session() -> &'static str { \"ok\" }\n",
     )
     .unwrap();
+    record_session_base(&layout, &session_dir);
 
     let summary = reconcile_session_dir(&layout, &session_dir).await.unwrap();
     assert_eq!(summary.change_count, 2);
@@ -478,6 +498,7 @@ async fn test_session_reconcile_rejects_broken_source_edit_without_copying_back(
         "pub fn stable_reconcile_target( {\n",
     )
     .unwrap();
+    record_session_base(&layout, &session_dir);
 
     let err = reconcile_session_dir(&layout, &session_dir)
         .await
@@ -545,6 +566,7 @@ async fn test_session_reconcile_ignores_generated_artifacts() {
     )
     .unwrap();
     std::fs::write(session_dir.join("build/report.txt"), "generated report").unwrap();
+    record_session_base(&layout, &session_dir);
 
     let summary = reconcile_session_dir(&layout, &session_dir).await.unwrap();
     assert_eq!(summary.change_count, 1);
@@ -668,6 +690,7 @@ async fn test_session_edit_test_fix_reconcile_loop() {
         passing.status.success(),
         "repo-local check should pass after the session fix"
     );
+    record_session_base(&layout, &session_dir);
 
     let summary = reconcile_session_dir(&layout, &session_dir).await.unwrap();
     assert_eq!(summary.change_count, 1);
@@ -741,6 +764,7 @@ async fn test_session_round_trip() {
         "pub fn mode_value() -> &'static str {\n    \"after\"\n}\n",
     )
     .unwrap();
+    record_session_base(&layout, &session_dir);
 
     let summary = reconcile_session_dir(&layout, &session_dir).await.unwrap();
     assert_eq!(summary.change_count, 1);


### PR DESCRIPTION
Session-workspace reconcile was a full-state sync: reconciling a stale kept workspace (--keep, or preserved after failure) wrote the workspace's old tree over newer source truth, silently reverting intervening changes (FIR-1208; hit live during FIR-1199/1201 validation).

Materialization now records the workspace's base — the projected graph head plus a content hash for every materialized file — under .kin-session/ (excluded from all graph file-collection paths). Reconcile replays only the workspace's own change-set: files the workspace never touched are left alone even when the source advanced; converged edits are skipped; genuine both-moved divergence fails loud naming each conflicting file and the base head, never overwriting newer truth.

Legacy workspaces with no recorded base get the one provably safe class — pure additions (paths absent from the source tree) apply, since writing them cannot overwrite or remove source truth; modifications or deletions of source-existing paths refuse with a rematerialize/discard remedy.

Covered by regression tests reproducing the data-loss edge (late reconcile after source advance must not revert), fast-path/disjoint/conflict/legacy cases, and the p11 mutation-parity suite; docs/session-runtime.md replaces the interim reconcile-promptly warning with the new semantics. Full workspace suite green (2565 tests).