### PR TITLE
feat(kin-parser): extract C/C++ unions and Java records and annotation types

### DIFF
--- a/crates/kin-parser/src/languages/c_lang.rs
+++ b/crates/kin-parser/src/languages/c_lang.rs
@@ -129,6 +129,23 @@ fn extract_c_node(
                 }
             }
         }
+        // A union is modeled as a Class, mirroring struct handling.
+        "union_specifier" => {
+            if let Some(name_node) = node.child_by_field_name("name") {
+                let name = name_node.utf8_text(source).unwrap_or("").to_string();
+                if !name.is_empty() {
+                    entities.push(ExtractedEntity {
+                        kind: EntityKind::Class,
+                        name,
+                        signature: node_signature(node, source),
+                        visibility: Visibility::Public,
+                        doc_summary: extract_preceding_comment(node, source),
+                        fingerprint: compute_fingerprint(node, source),
+                        span: span_from_node(node, file_id),
+                    });
+                }
+            }
+        }
         "enum_specifier" => {
             if let Some(name_node) = node.child_by_field_name("name") {
                 let name = name_node.utf8_text(source).unwrap_or("").to_string();
@@ -246,6 +263,25 @@ fn extract_declaration(
     // Check for struct_specifier inside the declaration
     if let Some(struct_node) = find_child_of_kind(node, "struct_specifier") {
         if let Some(name_node) = struct_node.child_by_field_name("name") {
+            let name = name_node.utf8_text(source).unwrap_or("").to_string();
+            if !name.is_empty() {
+                entities.push(ExtractedEntity {
+                    kind: EntityKind::Class,
+                    name,
+                    signature: node_signature(node, source),
+                    visibility: Visibility::Public,
+                    doc_summary: extract_preceding_comment(node, source),
+                    fingerprint: compute_fingerprint(node, source),
+                    span: span_from_node(node, file_id),
+                });
+                return;
+            }
+        }
+    }
+
+    // Check for union_specifier inside the declaration (mirrors struct handling)
+    if let Some(union_node) = find_child_of_kind(node, "union_specifier") {
+        if let Some(name_node) = union_node.child_by_field_name("name") {
             let name = name_node.utf8_text(source).unwrap_or("").to_string();
             if !name.is_empty() {
                 entities.push(ExtractedEntity {
@@ -871,6 +907,39 @@ int compute(Point p) { return internal_helper() + p.x; }
         for call in &calls {
             assert_eq!(call.src_name, "my_func");
         }
+    }
+
+    #[test]
+    fn extract_union() {
+        let adapter = CAdapter;
+        let source = b"union Value { int i; float f; };";
+        let tree = adapter.parse(source).unwrap();
+        let file_id = FilePathId::new("test.c");
+        let output = adapter.extract(&tree, source, &file_id).unwrap();
+        let unions: Vec<_> = output
+            .entities
+            .iter()
+            .filter(|e| e.kind == EntityKind::Class)
+            .collect();
+        assert_eq!(unions.len(), 1);
+        assert_eq!(unions[0].name, "Value");
+        assert_eq!(unions[0].visibility, Visibility::Public);
+    }
+
+    #[test]
+    fn extract_union_declared_with_variable() {
+        let adapter = CAdapter;
+        let source = b"union Data { int i; float f; } shared;";
+        let tree = adapter.parse(source).unwrap();
+        let file_id = FilePathId::new("test.c");
+        let output = adapter.extract(&tree, source, &file_id).unwrap();
+        let unions: Vec<_> = output
+            .entities
+            .iter()
+            .filter(|e| e.kind == EntityKind::Class)
+            .collect();
+        assert_eq!(unions.len(), 1);
+        assert_eq!(unions[0].name, "Data");
     }
 }
 

--- a/crates/kin-parser/src/languages/cpp_lang.rs
+++ b/crates/kin-parser/src/languages/cpp_lang.rs
@@ -196,6 +196,10 @@ fn extract_cpp_node(
         "struct_specifier" => {
             extract_class_or_struct(node, source, file_id, true, entities, relations);
         }
+        // A union is modeled as a Class; its members default to public like a struct.
+        "union_specifier" => {
+            extract_class_or_struct(node, source, file_id, true, entities, relations);
+        }
         "enum_specifier" => {
             if let Some(name_node) = node.child_by_field_name("name") {
                 let name = name_node.utf8_text(source).unwrap_or("").to_string();
@@ -298,6 +302,7 @@ fn extract_cpp_node(
                 match child.kind() {
                     "class_specifier"
                     | "struct_specifier"
+                    | "union_specifier"
                     | "function_definition"
                     | "declaration" => {
                         extract_cpp_node(
@@ -1549,6 +1554,60 @@ namespace ns {
         for call in &calls {
             assert_eq!(call.src_name, "MyClass::my_method");
         }
+    }
+
+    #[test]
+    fn extract_union() {
+        let adapter = CppAdapter;
+        let source = b"union Value { int i; float f; };";
+        let tree = adapter.parse(source).unwrap();
+        let file_id = FilePathId::new("value.cpp");
+        let output = adapter.extract(&tree, source, &file_id).unwrap();
+        let unions: Vec<_> = output
+            .entities
+            .iter()
+            .filter(|e| e.kind == EntityKind::Class)
+            .collect();
+        assert_eq!(unions.len(), 1);
+        assert_eq!(unions[0].name, "Value");
+    }
+
+    #[test]
+    fn extract_union_with_method() {
+        let adapter = CppAdapter;
+        let source = br#"
+union Tagged {
+    int as_int() { return 0; }
+};
+"#;
+        let tree = adapter.parse(source).unwrap();
+        let file_id = FilePathId::new("tagged.cpp");
+        let output = adapter.extract(&tree, source, &file_id).unwrap();
+
+        let unions: Vec<_> = output
+            .entities
+            .iter()
+            .filter(|e| e.kind == EntityKind::Class)
+            .collect();
+        assert_eq!(unions.len(), 1);
+        assert_eq!(unions[0].name, "Tagged");
+
+        let methods: Vec<_> = output
+            .entities
+            .iter()
+            .filter(|e| e.kind == EntityKind::Method)
+            .collect();
+        assert_eq!(methods.len(), 1);
+        assert_eq!(methods[0].name, "Tagged::as_int");
+        // Union members default to public, mirroring struct.
+        assert_eq!(methods[0].visibility, Visibility::Public);
+
+        assert!(output
+            .relations
+            .iter()
+            .any(|r| r.kind == kin_model::RelationKind::Contains
+                && r.src_name == "Tagged"
+                && r.dst_name == "Tagged::as_int"));
     }
 }
 

--- a/crates/kin-parser/src/languages/java.rs
+++ b/crates/kin-parser/src/languages/java.rs
@@ -163,7 +163,72 @@ fn extract_java_node(
                 }
             }
         }
+        "record_declaration" => {
+            if let Some(name_node) = node.child_by_field_name("name") {
+                let name = name_node.utf8_text(source).unwrap_or("").to_string();
+                let vis = detect_java_visibility(node, source);
+                // A record is modeled as a Class; its components live in the
+                // signature via node_signature (the record header line).
+                entities.push(ExtractedEntity {
+                    kind: EntityKind::Class,
+                    name: name.clone(),
+                    signature: node_signature(node, source),
+                    visibility: vis,
+                    doc_summary: extract_preceding_comment(node, source),
+                    fingerprint: compute_fingerprint(node, source),
+                    span: span_from_node(node, file_id),
+                });
+
+                // Records cannot extend a superclass, but they may implement interfaces.
+                if let Some(ifaces) = node.child_by_field_name("interfaces") {
+                    let mut iface_cursor = ifaces.walk();
+                    for iface in ifaces.children(&mut iface_cursor) {
+                        if iface.is_named() {
+                            let iface_name = iface.utf8_text(source).unwrap_or("").to_string();
+                            if !iface_name.is_empty() {
+                                relations.push(ExtractedRelation {
+                                    kind: kin_model::RelationKind::Implements,
+                                    src_name: name.clone(),
+                                    dst_name: iface_name,
+                                    import_source: None,
+                                });
+                            }
+                        }
+                    }
+                }
+
+                // Recurse into the record body, mirroring the class arm's member handling.
+                if let Some(body) = node.child_by_field_name("body") {
+                    let mut body_cursor = body.walk();
+                    for member in body.children(&mut body_cursor) {
+                        extract_java_node(
+                            &member,
+                            source,
+                            file_id,
+                            Some(&name),
+                            entities,
+                            relations,
+                        );
+                    }
+                }
+            }
+        }
         "interface_declaration" => {
+            if let Some(name_node) = node.child_by_field_name("name") {
+                let name = name_node.utf8_text(source).unwrap_or("").to_string();
+                entities.push(ExtractedEntity {
+                    kind: EntityKind::Interface,
+                    name,
+                    signature: node_signature(node, source),
+                    visibility: detect_java_visibility(node, source),
+                    doc_summary: extract_preceding_comment(node, source),
+                    fingerprint: compute_fingerprint(node, source),
+                    span: span_from_node(node, file_id),
+                });
+            }
+        }
+        // An annotation type (`@interface`) is modeled as an Interface.
+        "annotation_type_declaration" => {
             if let Some(name_node) = node.child_by_field_name("name") {
                 let name = name_node.utf8_text(source).unwrap_or("").to_string();
                 entities.push(ExtractedEntity {
@@ -677,5 +742,69 @@ public class Service {
             .filter(|r| r.kind == kin_model::RelationKind::Contains && r.src_name == "Color")
             .collect();
         assert_eq!(contains.len(), 3);
+    }
+
+    #[test]
+    fn parse_java_record() {
+        let adapter = JavaAdapter;
+        let source =
+            b"public record Point(int x, int y) implements Comparable { public int sum() { return x + y; } }";
+        let tree = adapter.parse(source).unwrap();
+        let file_id = FilePathId::new("Point.java");
+        let output = adapter.extract(&tree, source, &file_id).unwrap();
+
+        let classes: Vec<_> = output
+            .entities
+            .iter()
+            .filter(|e| e.kind == EntityKind::Class)
+            .collect();
+        assert_eq!(classes.len(), 1);
+        assert_eq!(classes[0].name, "Point");
+        // Record components are carried in the signature.
+        assert!(
+            classes[0].signature.contains("(int x, int y)"),
+            "record signature should include components, got {:?}",
+            classes[0].signature
+        );
+
+        // Body members are extracted and Contained, mirroring the class arm.
+        let methods: Vec<_> = output
+            .entities
+            .iter()
+            .filter(|e| e.kind == EntityKind::Method)
+            .collect();
+        assert_eq!(methods.len(), 1);
+        assert_eq!(methods[0].name, "Point.sum");
+        assert!(output
+            .relations
+            .iter()
+            .any(|r| r.kind == kin_model::RelationKind::Contains
+                && r.src_name == "Point"
+                && r.dst_name == "Point.sum"));
+
+        // Implemented interfaces become Implements relations.
+        assert!(output
+            .relations
+            .iter()
+            .any(|r| r.kind == kin_model::RelationKind::Implements
+                && r.src_name == "Point"
+                && r.dst_name == "Comparable"));
+    }
+
+    #[test]
+    fn parse_java_annotation_type() {
+        let adapter = JavaAdapter;
+        let source = b"public @interface Marker { String value(); }";
+        let tree = adapter.parse(source).unwrap();
+        let file_id = FilePathId::new("Marker.java");
+        let output = adapter.extract(&tree, source, &file_id).unwrap();
+        let ifaces: Vec<_> = output
+            .entities
+            .iter()
+            .filter(|e| e.kind == EntityKind::Interface)
+            .collect();
+        assert_eq!(ifaces.len(), 1);
+        assert_eq!(ifaces[0].name, "Marker");
+        assert_eq!(ifaces[0].visibility, Visibility::Public);
     }
 }


### PR DESCRIPTION
Gaps 2 and 3 from the FIR-832 fidelity ranking (gap 1, Rust macro_rules!, is #183). Constructs that yielded zero entities lose their names as retrieval surface terms, so their misses present as ranking failures when they are ingestion failures.

- C and C++: union_specifier now extracts as a Class entity in both adapters, mirroring the existing struct handling in both the bare and inside-declaration positions. Top-level unions — common in C systems code — were previously graph-invisible (the node type appeared only in enclosing-scope naming).
- Java: record_declaration extracts as a Class with the record components carried in the signature, and annotation_type_declaration extracts as an Interface. Modern-Java records and custom annotations were previously invisible.

Extraction conventions (naming, visibility, spans, signatures) mirror the neighboring struct/class/enum arms. Parser suite 189 passed / 0 failed; fmt and clippy clean.