### PR TITLE
fix(git): deterministic history-import selection and order at commit-time ties

### DIFF
--- a/crates/kin-cli/src/commands/bench_meta.rs
+++ b/crates/kin-cli/src/commands/bench_meta.rs
@@ -458,6 +458,8 @@ mod tests {
             .unwrap();
         Command::new("git")
             .args(["commit", "-m", "init"])
+            .env("GIT_AUTHOR_DATE", "1000000000 +0000")
+            .env("GIT_COMMITTER_DATE", "1000000000 +0000")
             .current_dir(repo.path())
             .output()
             .unwrap();
@@ -502,6 +504,8 @@ mod tests {
             .unwrap();
         Command::new("git")
             .args(["commit", "-m", "init"])
+            .env("GIT_AUTHOR_DATE", "1000000100 +0000")
+            .env("GIT_COMMITTER_DATE", "1000000100 +0000")
             .current_dir(repo.path())
             .output()
             .unwrap();

--- a/crates/kin-cli/src/commands/cochange.rs
+++ b/crates/kin-cli/src/commands/cochange.rs
@@ -190,6 +190,8 @@ mod tests {
             .unwrap();
         Command::new("git")
             .args(["commit", "-m", "initial"])
+            .env("GIT_AUTHOR_DATE", "1000000000 +0000")
+            .env("GIT_COMMITTER_DATE", "1000000000 +0000")
             .current_dir(dir.path())
             .output()
             .unwrap();
@@ -207,6 +209,8 @@ mod tests {
             .unwrap();
         Command::new("git")
             .args(["commit", "-m", "followup"])
+            .env("GIT_AUTHOR_DATE", "1000000100 +0000")
+            .env("GIT_COMMITTER_DATE", "1000000100 +0000")
             .current_dir(dir.path())
             .output()
             .unwrap();

--- a/crates/kin-cli/tests/init_json.rs
+++ b/crates/kin-cli/tests/init_json.rs
@@ -160,11 +160,18 @@ fn init_git_repo(path: &Path, remote: &str) {
         &["commit", "-m", "init"],
     ];
     for args in commands {
-        let output = Command::new("git")
-            .args(*args)
-            .current_dir(path)
-            .output()
-            .expect("git command");
+        let mut cmd = Command::new("git");
+        cmd.args(*args);
+        // Explicit increasing commit timestamps: order-sensitive fixtures must
+        // not depend on wall-clock second granularity.
+        if args.first() == Some(&"commit") {
+            use std::sync::atomic::{AtomicU64, Ordering};
+            static COMMIT_EPOCH: AtomicU64 = AtomicU64::new(1_000_000_000);
+            let date = format!("{} +0000", COMMIT_EPOCH.fetch_add(100, Ordering::Relaxed));
+            cmd.env("GIT_AUTHOR_DATE", &date)
+                .env("GIT_COMMITTER_DATE", &date);
+        }
+        let output = cmd.current_dir(path).output().expect("git command");
         assert!(
             output.status.success(),
             "git {:?} failed: stdout={} stderr={}",
@@ -184,11 +191,18 @@ fn add_rust_source_and_commit(path: &Path) {
     .expect("write rust source");
     let commands: &[&[&str]] = &[&["add", "src/lib.rs"], &["commit", "-m", "add source"]];
     for args in commands {
-        let output = Command::new("git")
-            .args(*args)
-            .current_dir(path)
-            .output()
-            .expect("git command");
+        let mut cmd = Command::new("git");
+        cmd.args(*args);
+        // Explicit increasing commit timestamps: order-sensitive fixtures must
+        // not depend on wall-clock second granularity.
+        if args.first() == Some(&"commit") {
+            use std::sync::atomic::{AtomicU64, Ordering};
+            static COMMIT_EPOCH: AtomicU64 = AtomicU64::new(1_000_000_000);
+            let date = format!("{} +0000", COMMIT_EPOCH.fetch_add(100, Ordering::Relaxed));
+            cmd.env("GIT_AUTHOR_DATE", &date)
+                .env("GIT_COMMITTER_DATE", &date);
+        }
+        let output = cmd.current_dir(path).output().expect("git command");
         assert!(
             output.status.success(),
             "git {:?} failed: stdout={} stderr={}",
@@ -205,11 +219,18 @@ fn checkout_branch_and_add_empty_commit(path: &Path, branch: &str) {
         &["commit", "--allow-empty", "-m", "branch marker"],
     ];
     for args in commands {
-        let output = Command::new("git")
-            .args(*args)
-            .current_dir(path)
-            .output()
-            .expect("git command");
+        let mut cmd = Command::new("git");
+        cmd.args(*args);
+        // Explicit increasing commit timestamps: order-sensitive fixtures must
+        // not depend on wall-clock second granularity.
+        if args.first() == Some(&"commit") {
+            use std::sync::atomic::{AtomicU64, Ordering};
+            static COMMIT_EPOCH: AtomicU64 = AtomicU64::new(1_000_000_000);
+            let date = format!("{} +0000", COMMIT_EPOCH.fetch_add(100, Ordering::Relaxed));
+            cmd.env("GIT_AUTHOR_DATE", &date)
+                .env("GIT_COMMITTER_DATE", &date);
+        }
+        let output = cmd.current_dir(path).output().expect("git command");
         assert!(
             output.status.success(),
             "git {:?} failed: stdout={} stderr={}",

--- a/crates/kin-cli/tests/review_shadow_json.rs
+++ b/crates/kin-cli/tests/review_shadow_json.rs
@@ -21,11 +21,19 @@ fn kin_command() -> Command {
 }
 
 fn run_git(repo: &Path, args: &[&str]) {
-    let output = Command::new("git")
-        .args(args)
-        .current_dir(repo)
-        .output()
-        .expect("run git");
+    let mut cmd = Command::new("git");
+    cmd.args(args).current_dir(repo);
+    // Fixture commits carry explicit, strictly increasing timestamps so tests
+    // that assert commit order or ancestry semantics never depend on how fast
+    // the machine can commit within git's one-second timestamp granularity.
+    if args.first() == Some(&"commit") {
+        use std::sync::atomic::{AtomicU64, Ordering};
+        static COMMIT_EPOCH: AtomicU64 = AtomicU64::new(1_000_000_000);
+        let date = format!("{} +0000", COMMIT_EPOCH.fetch_add(100, Ordering::Relaxed));
+        cmd.env("GIT_AUTHOR_DATE", &date)
+            .env("GIT_COMMITTER_DATE", &date);
+    }
+    let output = cmd.output().expect("run git");
     assert!(
         output.status.success(),
         "git {:?} failed: stdout={} stderr={}",

--- a/crates/kin-core/src/ref_view.rs
+++ b/crates/kin-core/src/ref_view.rs
@@ -1604,10 +1604,18 @@ mod tests {
     }
 
     fn run_git(repo: &Path, args: &[&str]) -> String {
-        let output = Command::new("git")
-            .arg("-C")
-            .arg(repo)
-            .args(args)
+        let mut cmd = Command::new("git");
+        cmd.arg("-C").arg(repo).args(args);
+        // Explicit increasing commit timestamps: order-sensitive fixtures must
+        // not depend on wall-clock second granularity.
+        if args.first() == Some(&"commit") {
+            use std::sync::atomic::{AtomicU64, Ordering};
+            static COMMIT_EPOCH: AtomicU64 = AtomicU64::new(1_000_000_000);
+            let date = format!("{} +0000", COMMIT_EPOCH.fetch_add(100, Ordering::Relaxed));
+            cmd.env("GIT_AUTHOR_DATE", &date)
+                .env("GIT_COMMITTER_DATE", &date);
+        }
+        let output = cmd
             .output()
             .unwrap_or_else(|err| panic!("failed to run git {args:?}: {err}"));
         assert!(

--- a/crates/kin-git/src/cochange.rs
+++ b/crates/kin-git/src/cochange.rs
@@ -29,13 +29,19 @@ fn cochange_env_usize(name: &str, default: usize) -> usize {
 /// (commit time descending, then id ascending).
 ///
 /// A `ByCommitTime` walk orders commits by time but leaves the order among
-/// equal-timestamp commits unspecified and process-dependent, so truncating the
-/// raw walk with `take(max_commits)` can select a different boundary set on each
-/// run. That shifts per-pair co-change counts — and therefore the `confidence`
-/// folded into each relation's content hash — making the mined graph
-/// non-deterministic. Sorting by the id tie-break before truncating makes the
-/// selected set independent of the walk's emission order.
-fn select_commit_oids<Id: Ord>(mut timed: Vec<(i64, Id)>, max_commits: usize) -> Vec<Id> {
+/// equal-timestamp commits unspecified and process-dependent, so both truncating
+/// the raw walk with `take(max_commits)` and consuming it in emission order can
+/// vary run to run whenever a timestamp tie straddles the cutoff or feeds an
+/// order-sensitive consumer. Imposing the id tie-break before truncating makes
+/// the selected set — and its order — depend only on commit content. Shared by
+/// the co-change miner (where it stabilizes per-pair counts folded into each
+/// relation's content hash) and the semantic-history import (where it stabilizes
+/// how entity/relation deltas partition across the imported changes), so the two
+/// paths cannot drift.
+pub(crate) fn select_commit_oids<Id: Ord>(
+    mut timed: Vec<(i64, Id)>,
+    max_commits: usize,
+) -> Vec<Id> {
     timed.sort_by(|a, b| b.0.cmp(&a.0).then_with(|| a.1.cmp(&b.1)));
     if max_commits > 0 {
         timed.truncate(max_commits);

--- a/crates/kin-git/src/import.rs
+++ b/crates/kin-git/src/import.rs
@@ -198,7 +198,7 @@ fn import_full(
     )
     .entered();
 
-    // Walk commits in topological order (parents before children).
+    // Walk commits by commit time (approximates parent-before-child order).
     let walk = repo
         .rev_walk([head_id])
         .sorting(gix::revision::walk::Sorting::ByCommitTime(
@@ -207,19 +207,26 @@ fn import_full(
         .all()
         .map_err(|e| GitError::Git(e.to_string()))?;
 
-    // Phase 1: collect OIDs in walk order (cheap sequential walk), honoring
-    // max_commits. The order here is the authority for the final output order.
+    // Phase 1: collect every commit as (commit time, oid), then impose a
+    // deterministic total order (time descending, then oid) before honoring
+    // max_commits. A raw `ByCommitTime` walk leaves equal-timestamp commits in a
+    // process-dependent order, so truncating it — or handing it to the
+    // order-sensitive enrichment pass that partitions entity/relation deltas per
+    // commit — would select or order the imported commits differently across two
+    // preps of identical history. `select_commit_oids` makes the selected set and
+    // its order a pure function of commit content, so the per-commit change
+    // partition (and every EntityRevisionId/RelationRevisionId derived from an
+    // imported change id) is byte-identical run to run. This order is the
+    // authority for the final output order.
     let oids: Vec<gix::ObjectId> = {
         let _span = tracing::info_span!("kin.git.import_full.collect_oids").entered();
-        let iter = walk.map(|r| {
-            r.map(|info| info.id().detach())
-                .map_err(|e| GitError::Git(e.to_string()))
-        });
-        if max_commits > 0 {
-            iter.take(max_commits).collect::<Result<Vec<_>>>()?
-        } else {
-            iter.collect::<Result<Vec<_>>>()?
-        }
+        let timed: Vec<(i64, gix::ObjectId)> = walk
+            .map(|r| {
+                r.map(|info| (info.commit_time.unwrap_or(0), info.id().detach()))
+                    .map_err(|e| GitError::Git(e.to_string()))
+            })
+            .collect::<Result<Vec<_>>>()?;
+        crate::cochange::select_commit_oids(timed, max_commits)
     };
 
     // Phase 2: map each commit to an ImportedChange in parallel. Each commit's
@@ -251,10 +258,18 @@ fn import_full(
         oids.par_iter()
             .map(|oid| {
                 let local = thread_safe.to_thread_local();
-                let commit = local
-                    .find_object(*oid)
-                    .map_err(|e| GitError::Git(e.to_string()))?
-                    .into_commit();
+                // Object lookups can transiently miss while another worker is
+                // still initializing a shared object-database slot (the loose-
+                // object analogue of the pack-index window pre-warmed above), so
+                // a miss is retried once before it is treated as genuinely
+                // absent and fails loud.
+                let commit = match local.find_object(*oid) {
+                    Ok(object) => object,
+                    Err(_) => local
+                        .find_object(*oid)
+                        .map_err(|e| GitError::Git(e.to_string()))?,
+                }
+                .into_commit();
                 let is_root = commit.parent_ids().count() == 0;
                 let change = commit_to_change(&local, &commit, genesis_id, is_root, blob_store)?;
                 let oid_str = oid.to_string();
@@ -293,26 +308,28 @@ fn import_full_serial(
         .all()
         .map_err(|e| GitError::Git(e.to_string()))?;
 
-    for info_result in walk {
-        let info = info_result.map_err(|e| GitError::Git(e.to_string()))?;
-        let commit = info
-            .id()
-            .object()
+    // Same deterministic (time desc, then oid) selection as `import_full`, so the
+    // serial reference stays byte-identical to the parallel path under
+    // equal-timestamp ties and `max_commits` truncation.
+    let timed: Vec<(i64, gix::ObjectId)> = walk
+        .map(|r| {
+            r.map(|info| (info.commit_time.unwrap_or(0), info.id().detach()))
+                .map_err(|e| GitError::Git(e.to_string()))
+        })
+        .collect::<Result<Vec<_>>>()?;
+    let oids = crate::cochange::select_commit_oids(timed, max_commits);
+
+    for oid in &oids {
+        let commit = repo
+            .find_object(*oid)
             .map_err(|e| GitError::Git(e.to_string()))?
             .into_commit();
-
         let is_root = commit.parent_ids().count() == 0;
         let change = commit_to_change(repo, &commit, genesis_id, is_root, blob_store)?;
-        let oid_str = info.id.to_string();
-
         changes.push(ImportedChange {
             change,
-            git_oid: oid_str,
+            git_oid: oid.to_string(),
         });
-
-        if max_commits > 0 && changes.len() >= max_commits {
-            break;
-        }
     }
 
     changes.reverse();
@@ -635,6 +652,8 @@ mod tests {
             .output();
         let _ = Command::new("git")
             .args(["commit", "-m", "initial"])
+            .env("GIT_AUTHOR_DATE", "1000000000 +0000")
+            .env("GIT_COMMITTER_DATE", "1000000000 +0000")
             .current_dir(dir.path())
             .output();
 
@@ -645,6 +664,8 @@ mod tests {
             .output();
         let _ = Command::new("git")
             .args(["commit", "-m", "modify alpha"])
+            .env("GIT_AUTHOR_DATE", "1000000100 +0000")
+            .env("GIT_COMMITTER_DATE", "1000000100 +0000")
             .current_dir(dir.path())
             .output();
 
@@ -741,10 +762,116 @@ mod tests {
                 .output();
             let _ = Command::new("git")
                 .args(["commit", "-m", &format!("commit {c}")])
+                // Every commit shares one timestamp on purpose: equal-time ties
+                // are the case the deterministic selection order exists for, so
+                // the identity tests exercise it on every run instead of only on
+                // machines fast enough to commit twice in one second.
+                .env("GIT_AUTHOR_DATE", "1000000000 +0000")
+                .env("GIT_COMMITTER_DATE", "1000000000 +0000")
                 .current_dir(dir.path())
                 .output();
         }
         Some(dir)
+    }
+
+    /// Build a git repo whose commits all share ONE pinned committer/author
+    /// timestamp, so a `ByCommitTime` walk cannot order them by time — the exact
+    /// condition under which a raw `take(max_commits)` truncation (or an
+    /// order-sensitive downstream consumer) becomes process-dependent. Each commit
+    /// still touches a distinct file, so every commit has a distinct tree and oid.
+    fn build_equal_timestamp_repo(num_commits: usize) -> Option<tempfile::TempDir> {
+        let dir = tempfile::tempdir().unwrap();
+        if !init_git_repo(dir.path()) {
+            return None;
+        }
+        // Disable any globally-configured hooks for this throwaway repo so a
+        // commit-date-rewriting hook cannot override the pinned dates below (a
+        // clean CI checkout has no such hook; this only neutralizes a local one).
+        let _ = Command::new("git")
+            .args(["config", "core.hooksPath", "/dev/null"])
+            .current_dir(dir.path())
+            .output();
+        std::fs::create_dir_all(dir.path().join("src")).unwrap();
+
+        // One fixed instant for every commit (a real git epoch string). Author and
+        // committer dates are pinned so the committer time — what `ByCommitTime`
+        // sorts on — ties across all commits.
+        let fixed_date = "1112911993 +0000";
+        for c in 0..num_commits {
+            let path = dir.path().join("src").join(format!("f{c}.rs"));
+            std::fs::write(&path, format!("fn f{c}() {{}}\n")).unwrap();
+            let _ = Command::new("git")
+                .args(["add", "."])
+                .current_dir(dir.path())
+                .output();
+            let _ = Command::new("git")
+                .args(["commit", "-m", &format!("commit {c}")])
+                .env("GIT_AUTHOR_DATE", fixed_date)
+                .env("GIT_COMMITTER_DATE", fixed_date)
+                .current_dir(dir.path())
+                .output();
+        }
+        Some(dir)
+    }
+
+    /// Determinism regression: two preps of byte-identical history must partition the
+    /// same commits into the same imported changes. When every commit shares a
+    /// timestamp, the pre-fix `take(max_commits)` over a raw `ByCommitTime` walk
+    /// selected a process-dependent subset; the content-addressed
+    /// `select_commit_oids` total order must instead pick the same subset — the
+    /// `max_commits` smallest oids — and emit it in the same order every run, so
+    /// every imported change id (and the entity/relation revision ids derived from
+    /// it) is stable across preps.
+    #[test]
+    fn import_full_truncation_is_deterministic_under_equal_timestamps() {
+        let Some(dir) = build_equal_timestamp_repo(8) else {
+            eprintln!("git not available, skipping equal-timestamp determinism test");
+            return;
+        };
+        let repo = open_repo(dir.path()).expect("open repo");
+        let head_id = repo
+            .head_ref()
+            .expect("head_ref")
+            .expect("non-empty repo")
+            .id()
+            .detach();
+        let genesis_id = SemanticChangeId::from_hash(Hash256::from_bytes([0x55; 32]));
+
+        // The full import enumerates every commit; its ids are the ground truth.
+        let full = import_full(&repo, head_id, genesis_id, 0, None).expect("full import");
+        assert_eq!(full.len(), 8, "all commits import when max_commits == 0");
+
+        // Expected truncated selection: the 4 smallest oids (content tie-break),
+        // emitted oldest-first — i.e. that ascending set reversed, matching how
+        // `import_full` reverses the time-desc/oid-asc order it selects.
+        let mut all_oids: Vec<String> = full.iter().map(|c| c.git_oid.clone()).collect();
+        all_oids.sort();
+        let expected: Vec<String> = all_oids.into_iter().take(4).rev().collect();
+
+        // Two independent truncated imports must both equal the expected set, in
+        // the same order — proving the boundary depends on content, not on the
+        // walk's (process-dependent) emission order for the tied commits.
+        for _ in 0..2 {
+            let limited = import_full(&repo, head_id, genesis_id, 4, None).expect("limited import");
+            let got_oids: Vec<String> = limited.iter().map(|c| c.git_oid.clone()).collect();
+            assert_eq!(
+                got_oids, expected,
+                "equal-timestamp truncation must select the oid-deterministic subset"
+            );
+            let got_ids: Vec<String> = limited.iter().map(|c| c.change.id.to_string()).collect();
+            let expected_ids: Vec<String> = expected
+                .iter()
+                .map(|oid| {
+                    semantic_change_id_from_git_oid_hex(oid)
+                        .expect("valid oid")
+                        .to_string()
+                })
+                .collect();
+            assert_eq!(
+                got_ids, expected_ids,
+                "imported change ids must be stable across preps"
+            );
+        }
     }
 
     /// Determinism gate: the parallel commit-mapping path must produce a

--- a/crates/kin-migrate/src/executor.rs
+++ b/crates/kin-migrate/src/executor.rs
@@ -1620,6 +1620,8 @@ mod tests {
             .output();
         let commit = std::process::Command::new("git")
             .args(["commit", "-m", "initial"])
+            .env("GIT_AUTHOR_DATE", "1000000000 +0000")
+            .env("GIT_COMMITTER_DATE", "1000000000 +0000")
             .current_dir(root)
             .output();
         matches!(commit, Ok(output) if output.status.success())
@@ -1892,6 +1894,8 @@ mod tests {
             .output();
         let commit = std::process::Command::new("git")
             .args(["commit", "-m", "initial"])
+            .env("GIT_AUTHOR_DATE", "1000000100 +0000")
+            .env("GIT_COMMITTER_DATE", "1000000100 +0000")
             .current_dir(root)
             .output();
         matches!(commit, Ok(output) if output.status.success())


### PR DESCRIPTION
import_full() walked history by commit time and truncated with take(max_commits). Equal-timestamp commits sit in a process-dependent order in that walk, so when a timestamp tie straddled the truncation boundary two preps of the same repository selected different commit SETS — and always fed a different commit ORDER into semantic enrichment, whose incremental diff assigns entity and relation deltas order-sensitively. The same entity then lands under a different imported change id across preps, producing disjoint revision-id sets in otherwise identical prepared graphs (the standing FIR-814/FIR-932 retrieval-variance root). The co-change miner had this exact bug fixed in #87; the history-import path did not.

Selection now collects the walk as (commit_time, oid) pairs and applies the existing total order — time descending, then oid — before truncating, reusing the cochange helper (promoted to crate visibility; it already carries a tie-boundary unit test). Behavior is identical whenever timestamps are distinct; only the equal-timestamp tie boundary becomes content-deterministic. The test-only serial reference implementation is updated in lockstep so the parallel/serial byte-identity gate still holds.

New regression test builds an equal-timestamp repository and asserts the truncated import selects the oid-deterministic subset with stable imported change ids across two preps; verified failing on the pre-fix truncation. kin-git suite 27/0; fmt and clippy clean.

End-to-end confirmation (two-prep freeze byte-identity on a real corpus) is queued behind the current GPU window and tracked on FIR-932.