### PR TITLE
chore(release): bump version to 0.2.7

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -146,7 +146,7 @@ version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -157,7 +157,7 @@ checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -1144,7 +1144,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users 0.5.2",
- "windows-sys 0.59.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -1253,7 +1253,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.59.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -3039,11 +3039,11 @@ dependencies = [
 
 [[package]]
 name = "kin-buildinfo"
-version = "0.2.6"
+version = "0.2.7"
 
 [[package]]
 name = "kin-cli"
-version = "0.2.6"
+version = "0.2.7"
 dependencies = [
  "age",
  "anyhow",
@@ -3110,7 +3110,7 @@ dependencies = [
 
 [[package]]
 name = "kin-context"
-version = "0.2.6"
+version = "0.2.7"
 dependencies = [
  "kin-blobs",
  "kin-db",
@@ -3126,7 +3126,7 @@ dependencies = [
 
 [[package]]
 name = "kin-core"
-version = "0.2.6"
+version = "0.2.7"
 dependencies = [
  "chrono",
  "directories 5.0.1",
@@ -3150,7 +3150,7 @@ dependencies = [
 
 [[package]]
 name = "kin-daemon"
-version = "0.2.6"
+version = "0.2.7"
 dependencies = [
  "async-stream",
  "axum",
@@ -3199,9 +3199,9 @@ dependencies = [
 
 [[package]]
 name = "kin-db"
-version = "0.2.26"
+version = "0.2.27"
 source = "sparse+https://kinlab.ai/registry/cargo/"
-checksum = "2b9223f61913207f41deccaffec0bce403c8fae9f4204ef214013565990fe242"
+checksum = "1e70164ad8fb11ca2ebfa1faa827c965753efbd1a01a16390fe98ab0f8569502"
 dependencies = [
  "bincode",
  "bytes",
@@ -3239,7 +3239,7 @@ dependencies = [
 
 [[package]]
 name = "kin-git"
-version = "0.2.6"
+version = "0.2.7"
 dependencies = [
  "chrono",
  "gix",
@@ -3257,7 +3257,7 @@ dependencies = [
 
 [[package]]
 name = "kin-index"
-version = "0.2.6"
+version = "0.2.7"
 dependencies = [
  "hex",
  "kin-blobs",
@@ -3279,9 +3279,9 @@ dependencies = [
 
 [[package]]
 name = "kin-infer"
-version = "0.2.37"
+version = "0.2.38"
 source = "sparse+https://kinlab.ai/registry/cargo/"
-checksum = "57d6ff11d1bf1744481b6fc81601b059dcaa650912ad9ed841c360c137242659"
+checksum = "4c025d1d3f9f57340298c18205fa6eec1cc25644ade3790eeda5c6cf0b3091c3"
 dependencies = [
  "block",
  "half",
@@ -3303,7 +3303,7 @@ dependencies = [
 
 [[package]]
 name = "kin-integration-tests"
-version = "0.2.6"
+version = "0.2.7"
 dependencies = [
  "kin-blobs",
  "kin-cli",
@@ -3345,7 +3345,7 @@ dependencies = [
 
 [[package]]
 name = "kin-mcp"
-version = "0.2.6"
+version = "0.2.7"
 dependencies = [
  "kin-blobs",
  "kin-context",
@@ -3372,7 +3372,7 @@ dependencies = [
 
 [[package]]
 name = "kin-migrate"
-version = "0.2.6"
+version = "0.2.7"
 dependencies = [
  "chrono",
  "kin-blobs",
@@ -3414,7 +3414,7 @@ dependencies = [
 
 [[package]]
 name = "kin-parser"
-version = "0.2.6"
+version = "0.2.7"
 dependencies = [
  "kin-model",
  "pretty_assertions",
@@ -3443,7 +3443,7 @@ dependencies = [
 
 [[package]]
 name = "kin-projection"
-version = "0.2.6"
+version = "0.2.7"
 dependencies = [
  "kin-blobs",
  "kin-db",
@@ -3458,7 +3458,7 @@ dependencies = [
 
 [[package]]
 name = "kin-ranking"
-version = "0.2.6"
+version = "0.2.7"
 dependencies = [
  "kin-model",
  "serde",
@@ -3467,7 +3467,7 @@ dependencies = [
 
 [[package]]
 name = "kin-reconcile"
-version = "0.2.6"
+version = "0.2.7"
 dependencies = [
  "kin-blobs",
  "kin-db",
@@ -3487,7 +3487,7 @@ dependencies = [
 
 [[package]]
 name = "kin-registry"
-version = "0.2.6"
+version = "0.2.7"
 dependencies = [
  "axum",
  "base64 0.22.1",
@@ -3512,7 +3512,7 @@ dependencies = [
 
 [[package]]
 name = "kin-remote"
-version = "0.2.6"
+version = "0.2.7"
 dependencies = [
  "chrono",
  "kin-model",
@@ -3528,7 +3528,7 @@ dependencies = [
 
 [[package]]
 name = "kin-review"
-version = "0.2.6"
+version = "0.2.7"
 dependencies = [
  "kin-blobs",
  "kin-db",
@@ -3543,7 +3543,7 @@ dependencies = [
 
 [[package]]
 name = "kin-runtime"
-version = "0.2.6"
+version = "0.2.7"
 dependencies = [
  "chrono",
  "hex",
@@ -3575,7 +3575,7 @@ dependencies = [
 
 [[package]]
 name = "kin-semantic-contracts"
-version = "0.2.6"
+version = "0.2.7"
 dependencies = [
  "kin-db",
  "kin-model",
@@ -3590,7 +3590,7 @@ dependencies = [
 
 [[package]]
 name = "kin-spine"
-version = "0.2.6"
+version = "0.2.7"
 dependencies = [
  "chrono",
  "hashbrown 0.15.5",
@@ -4009,7 +4009,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -4511,7 +4511,7 @@ dependencies = [
  "once_cell",
  "socket2",
  "tracing",
- "windows-sys 0.59.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -4915,7 +4915,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.59.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -4974,7 +4974,7 @@ dependencies = [
  "security-framework 3.7.0",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.59.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -5418,7 +5418,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "52d1cfed4120b4d927bf7c0f86d2087a4a7d6027c906d9f9d525a80573b9be51"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -5551,7 +5551,7 @@ dependencies = [
  "getrandom 0.4.3",
  "once_cell",
  "rustix",
- "windows-sys 0.59.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -6458,7 +6458,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.48.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,7 +27,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.2.6"
+version = "0.2.7"
 edition = "2021"
 license = "Apache-2.0"
 authors = ["Troy Fortin <troy@firelock.ai>"]


### PR DESCRIPTION
Cuts kin 0.2.7. Both release gates are satisfied: the freeze gate passed on real inference (five independent cache-off runs bit-identical on the accelerate-compiled binary), and the accuracy-v1 default question resolved to keeping compat-v0 (the 6-arm ablation showed the regression is emergent from pipeline composition, with two levers inert and one protective — the profile graduates lever-by-lever separately).

Ships since 0.2.6: the accelerate compiled default with runtime pure-rust proof pinning, change-set session reconcile with base-version tracking (closes the stale-workspace data-loss edge), deterministic git-history import at commit-time ties, behavior-env divergence warnings at the daemon boundary, the env-registry downstream-lever union, line spans on default MCP locate hits with search limit clamping, parser fidelity for Rust macro_rules! / C and C++ unions / Java records and annotation types, the container entrypoint workspace fix with its CI smoke, update-channel and doctor-drift surfaces, entity re-key, port handshake, write-veto warnings, and the --explain profile field.

Dependency pins refresh to kin-db 0.2.27 and kin-infer 0.2.38 (both published today; lock stays registry-pure).