### PR TITLE
ci: run the dependency wave on the dedicated dispatch token

### DIFF
--- a/.github/workflows/kin-dependency-wave.yml
+++ b/.github/workflows/kin-dependency-wave.yml
@@ -9,9 +9,9 @@ on:
 
 jobs:
   dependency-wave:
-    uses: firelock-ai/kin-actions/.github/workflows/cargo-dependency-wave.yml@v0.1.8
+    uses: firelock-ai/kin-actions/.github/workflows/cargo-dependency-wave.yml@v0.1.9
     with:
       manifests: Cargo.toml
       test-command: cargo check -p kin-core -p kin-cli -p kin-daemon -p kin-mcp
     secrets:
-      KIN_CI_BOT_TOKEN: ${{ secrets.KIN_CI_BOT_TOKEN }}
+      KIN_CI_BOT_TOKEN: ${{ secrets.KIN_DOWNSTREAM_DISPATCH_TOKEN }}


### PR DESCRIPTION
The wave previously ran on KIN_CI_BOT_TOKEN, which is under-scoped for parts of the chain (kin's leg failed with 'Resource not accessible by personal access token'). The dedicated kin-downstream-dispatch token (org-owned fine-grained PAT: contents, pull requests, issues, actions — read/write, all org repos, expires Jul 2027) is now stored as KIN_DOWNSTREAM_DISPATCH_TOKEN on every kin repo; the wave sources it while keeping the reusable workflow's input name. Where the reference was stale, kin-actions bumps to v0.1.9.