### PR TITLE
chore(deps): refresh Kin registry dependency pins

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -146,7 +146,7 @@ version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -157,7 +157,7 @@ checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1144,7 +1144,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users 0.5.2",
- "windows-sys 0.60.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -1253,7 +1253,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.60.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -1910,7 +1910,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "19753d40da53d0ec41604750eeb969097a90fb2d7f7992730d904541c04e2c19"
 dependencies = [
  "bstr",
- "hashbrown 0.16.1",
+ "hashbrown 0.17.1",
 ]
 
 [[package]]
@@ -3025,9 +3025,9 @@ dependencies = [
 
 [[package]]
 name = "kin-blobs"
-version = "0.1.0"
+version = "0.1.1"
 source = "sparse+https://kinlab.ai/registry/cargo/"
-checksum = "44903add90c5bdc9cd68dabe4babc846729caa795b4d50c9c3a138d560646216"
+checksum = "8881418b6b53f75f8321ee8b3b200295c254e6807824ddf53997623044c9fc68"
 dependencies = [
  "hex",
  "schemars",
@@ -3628,9 +3628,9 @@ dependencies = [
 
 [[package]]
 name = "kin-vfs-core"
-version = "0.1.0"
+version = "0.1.1"
 source = "sparse+https://kinlab.ai/registry/cargo/"
-checksum = "a1babf750c02b623cf820b217794d1811b1acdb7527ff0b67400c21c2c47d50a"
+checksum = "6fd24dfa362060cd6cfdc2360b59dc144d69feb3312932364e9bd29c3831d33d"
 dependencies = [
  "lru",
  "parking_lot",
@@ -4009,7 +4009,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.60.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -4511,7 +4511,7 @@ dependencies = [
  "once_cell",
  "socket2",
  "tracing",
- "windows-sys 0.60.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -4915,7 +4915,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.60.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -4974,7 +4974,7 @@ dependencies = [
  "security-framework 3.7.0",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.60.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -5418,7 +5418,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "52d1cfed4120b4d927bf7c0f86d2087a4a7d6027c906d9f9d525a80573b9be51"
 dependencies = [
  "libc",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -5551,7 +5551,7 @@ dependencies = [
  "getrandom 0.4.3",
  "once_cell",
  "rustix",
- "windows-sys 0.60.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -6458,7 +6458,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.60.2",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -117,7 +117,7 @@ serial_test = "3"
 
 # Internal crates
 kin-model = { version = "0.2.1", registry = "kin" }
-kin-blobs = { version = "0.1.0", registry = "kin" }
+kin-blobs = { version = "0.1.1", registry = "kin" }
 kin-core = { path = "crates/kin-core" }
 kin-parser = { path = "crates/kin-parser" }
 kin-index = { path = "crates/kin-index" }
@@ -143,8 +143,8 @@ kin-lsp = { version = "0.2.1", registry = "kin" }
 # backend on every target (incl. Linux, where it cannot compile). Metal is re-enabled
 # additively on macOS via a `[target.'cfg(target_os = "macos")'.dependencies]` block in the
 # binary/runtime crates (kin-cli, kin-daemon). Feature unification makes that additive.
-kin-db = { version = "0.2.26", registry = "kin", default-features = false, features = ["vector", "embeddings"] }
-kin-vfs-core = { version = "0.1.0", registry = "kin" }
+kin-db = { version = "0.2.27", registry = "kin", default-features = false, features = ["vector", "embeddings"] }
+kin-vfs-core = { version = "0.1.1", registry = "kin" }
 
 [profile.release]
 opt-level = 3


### PR DESCRIPTION
Automated Kin registry dependency wave.

This PR updates Cargo registry dependency pins after a verified Kin registry publish and runs the repo smoke command before opening the PR.