### PR TITLE
fix(git): close the truncated-import DAG so git refs resolve on fresh inits

### DIFF
--- a/crates/kin-cli/tests/locate_json_stdout.rs
+++ b/crates/kin-cli/tests/locate_json_stdout.rs
@@ -522,3 +522,154 @@ fn locate_ref_hydrates_missing_imported_git_history_on_demand() {
         files
     );
 }
+
+/// `kin init` imports a bounded history window (default `recent` = 50 commits).
+/// On a repo with more than 50 commits the oldest imported change used to
+/// reference an un-imported Git parent, so the ref-scoped history walk for
+/// `locate --ref git:<oid>` hit that dangling edge and 500'd "change <id> not
+/// found" — even for HEAD, whose own ancestry crosses the truncation boundary.
+/// Import now closes that boundary onto genesis (and the walk stops at the import
+/// horizon), so both HEAD and an out-of-window commit resolve without a 500.
+#[test]
+#[serial]
+fn locate_ref_resolves_head_and_out_of_window_commits_after_truncated_init() {
+    let repo = tempdir().expect("temp repo");
+
+    let git_init = Command::new("git")
+        .arg("init")
+        .arg("-q")
+        .current_dir(repo.path())
+        .output()
+        .expect("git init");
+    assert!(
+        git_init.status.success(),
+        "git init failed: {}",
+        String::from_utf8_lossy(&git_init.stderr)
+    );
+
+    // Neutralize any globally-configured commit-date-rewriting hook so the pinned
+    // dates below survive — the deterministic newest-50 window depends on them.
+    let _ = Command::new("git")
+        .args(["config", "core.hooksPath", "/dev/null"])
+        .current_dir(repo.path())
+        .output();
+
+    let commit = |message: &str, seq: u32| {
+        // Distinct, strictly increasing dates so the truncation window is
+        // time-ordered and deterministic (the fixtures gotcha: equal timestamps
+        // make the window oid-ordered instead, so "out of window" is ambiguous).
+        let date = format!("{} +0000", 1_600_000_000 + seq);
+        let out = Command::new("git")
+            .args([
+                "-c",
+                "user.name=kin-ci",
+                "-c",
+                "user.email=ci@kin.dev",
+                "commit",
+                "--allow-empty",
+                "-q",
+                "-m",
+                message,
+            ])
+            .env("GIT_AUTHOR_DATE", &date)
+            .env("GIT_COMMITTER_DATE", &date)
+            .current_dir(repo.path())
+            .output()
+            .expect("git commit");
+        assert!(
+            out.status.success(),
+            "git commit failed: {}",
+            String::from_utf8_lossy(&out.stderr)
+        );
+    };
+    let rev_parse = |rev: &str| -> String {
+        String::from_utf8_lossy(
+            &Command::new("git")
+                .args(["rev-parse", rev])
+                .current_dir(repo.path())
+                .output()
+                .expect("git rev-parse")
+                .stdout,
+        )
+        .trim()
+        .to_string()
+    };
+
+    // Commit 1 carries real content (so an out-of-window hydration has a file to
+    // surface) and is the oldest commit — it falls outside the newest-50 window.
+    fs::create_dir_all(repo.path().join("src")).expect("create src dir");
+    fs::write(
+        repo.path().join("src/lib.py"),
+        "def legacy_handler(value):\n    return value + 1\n",
+    )
+    .expect("write source");
+    let add = Command::new("git")
+        .args(["add", "."])
+        .current_dir(repo.path())
+        .output()
+        .expect("git add");
+    assert!(add.status.success());
+    commit("c1 initial", 1);
+    let out_of_window_sha = rev_parse("HEAD");
+
+    // 51 more commits (52 total) so the newest-50 window excludes commit 1 and
+    // its boundary parent — the dangling edge the fix closes.
+    for seq in 2..=52u32 {
+        commit(&format!("c{seq}"), seq);
+    }
+    let head_sha = rev_parse("HEAD");
+
+    let init = kin_command()
+        .arg("init")
+        .arg(".")
+        .arg("--no-lsp")
+        .current_dir(repo.path())
+        .output()
+        .expect("run kin init");
+    assert!(
+        init.status.success(),
+        "kin init failed: stdout={} stderr={}",
+        String::from_utf8_lossy(&init.stdout),
+        String::from_utf8_lossy(&init.stderr)
+    );
+
+    // HEAD resolves: the history walk reaches the genesis-closed horizon instead
+    // of a dangling parent, so the daemon does not 500.
+    let head_locate = kin_command()
+        .arg("locate")
+        .arg("--json")
+        .arg("--ref")
+        .arg(format!("git:{head_sha}"))
+        .arg("legacy_handler")
+        .current_dir(repo.path())
+        .output()
+        .expect("run head-ref locate");
+    assert!(
+        head_locate.status.success(),
+        "locate --ref git:<HEAD> failed (truncated-history regression): stdout={} stderr={}",
+        String::from_utf8_lossy(&head_locate.stdout),
+        String::from_utf8_lossy(&head_locate.stderr)
+    );
+    serde_json::from_slice::<serde_json::Value>(&head_locate.stdout)
+        .expect("HEAD-ref locate stdout should be valid JSON");
+
+    // An out-of-window commit resolves via on-demand hydration, which imports its
+    // full ancestry down to a genesis-rooted boundary.
+    let old_locate = kin_command()
+        .arg("locate")
+        .arg("--json")
+        .arg("--ref")
+        .arg(format!("git:{out_of_window_sha}"))
+        .arg("Investigate legacy_handler in src/lib.py")
+        .current_dir(repo.path())
+        .output()
+        .expect("run out-of-window-ref locate");
+    assert!(
+        old_locate.status.success(),
+        "locate --ref git:<out-of-window> failed: stdout={} stderr={}",
+        String::from_utf8_lossy(&old_locate.stdout),
+        String::from_utf8_lossy(&old_locate.stderr)
+    );
+    serde_json::from_slice::<serde_json::Value>(&old_locate.stdout)
+        .expect("out-of-window-ref locate stdout should be valid JSON");
+}

--- a/crates/kin-core/src/ref_view.rs
+++ b/crates/kin-core/src/ref_view.rs
@@ -851,13 +851,36 @@ where
                 if !seen.insert(id) {
                     continue;
                 }
-                let change = graph
+                match graph
                     .get_change(&id)
                     .map_err(|err| KinError::Graph(err.to_string()))?
-                    .ok_or_else(|| KinError::Graph(format!("change {} not found", id)))?;
-                stack.push(Frame::Emit(change.clone()));
-                for parent in change.parents.iter().rev() {
-                    stack.push(Frame::Visit(*parent));
+                {
+                    Some(change) => {
+                        stack.push(Frame::Emit(change.clone()));
+                        for parent in change.parents.iter().rev() {
+                            stack.push(Frame::Visit(*parent));
+                        }
+                    }
+                    None => {
+                        // An absent ancestor is the import horizon, not
+                        // corruption: `kin init --git-history recent` imports a
+                        // bounded window (default 50 commits), so the oldest
+                        // imported change can reference a Git parent that was
+                        // never imported. Stop the walk at that edge — treating
+                        // it as the root of the visible history — instead of
+                        // failing the whole ref-scoped read with a bare "change
+                        // not found", which otherwise 500s `locate --ref
+                        // git:<oid>` even for HEAD (HEAD's own ancestry crosses
+                        // the horizon). Newer imports close this gap by
+                        // re-pointing boundary parents at genesis (see
+                        // kin_git::import::close_truncated_history_dag), so this
+                        // only fires for histories imported before that fix or
+                        // pruned below the requested ref.
+                        tracing::warn!(
+                            change = %id,
+                            "ref history walk stopped at an unresolved ancestor (import horizon); returning the changes reachable above it"
+                        );
+                    }
                 }
             }
             Frame::Emit(change) => ordered.push(change),
@@ -2199,6 +2222,41 @@ def uri_encoder(value):\n    return value.replace(' ', '%20')\n",
         assert_eq!(ordered.len(), 3_001);
         assert_eq!(ordered.first().map(|change| change.id), Some(genesis_id));
         assert_eq!(ordered.last().map(|change| change.id), Some(head));
+    }
+
+    /// A truncated import can leave the oldest imported change pointing at a
+    /// parent that was never inserted (the import horizon). The ref-scoped
+    /// history walk must treat that dangling edge as the root of the visible
+    /// history and return the reachable changes, NOT fail "change not found" —
+    /// the bare error that 500s `locate --ref git:<oid>` even for HEAD.
+    #[test]
+    fn collect_changes_at_ref_stops_at_import_horizon_instead_of_erroring() {
+        let graph = InMemoryGraph::new();
+        let missing_ancestor = SemanticChangeId::from_hash(Hash256::from_bytes([0x77; 32]));
+        let boundary = SemanticChangeId::from_hash(Hash256::from_bytes([0x78; 32]));
+        let head = SemanticChangeId::from_hash(Hash256::from_bytes([0x79; 32]));
+
+        // `missing_ancestor` is deliberately never inserted, so `boundary`'s
+        // parent edge dangles exactly as a pre-fix truncated import would leave it.
+        graph
+            .create_change(&change(boundary, vec![missing_ancestor], vec![]))
+            .unwrap();
+        graph
+            .create_change(&change(head, vec![boundary], vec![]))
+            .unwrap();
+
+        let ordered = collect_changes_at_ref(&graph, &head)
+            .expect("history walk must not fail at the import horizon");
+        let ids: Vec<_> = ordered.iter().map(|change| change.id).collect();
+        assert_eq!(
+            ids,
+            vec![boundary, head],
+            "walk returns the changes reachable above the horizon, oldest first"
+        );
+        assert!(
+            !ids.contains(&missing_ancestor),
+            "the unresolved ancestor must not appear in the collected history"
+        );
     }
 
     fn test_entity(name: &str, path: &str) -> Entity {

--- a/crates/kin-git/src/import.rs
+++ b/crates/kin-git/src/import.rs
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 // Copyright 2026 Firelock, LLC
 
+use std::collections::HashSet;
 use std::path::Path;
 
 use chrono::TimeZone;
@@ -282,6 +283,9 @@ fn import_full(
             .collect::<Result<Vec<_>>>()?
     };
 
+    // Close the DAG at the truncation horizon before emitting (see the helper).
+    close_truncated_history_dag(&mut changes, genesis_id);
+
     // Reverse so oldest commit is first (topological order).
     changes.reverse();
 
@@ -332,8 +336,51 @@ fn import_full_serial(
         });
     }
 
+    close_truncated_history_dag(&mut changes, genesis_id);
+
     changes.reverse();
     Ok(changes)
+}
+
+/// Re-point dangling boundary parents at `genesis_id` so a truncated import is a
+/// self-contained DAG.
+///
+/// `max_commits` truncation keeps only the newest commits, so the oldest kept
+/// commit's Git parents can fall outside the imported set. `commit_to_change`
+/// derives every non-root commit's parents from its Git parent OIDs regardless
+/// of whether those parents were selected, so a truncated import emits changes
+/// whose parent ids were never inserted into the graph. A later ancestry walk
+/// (`kin_core::collect_changes_at_ref`, used by ref-scoped locate/log/blame)
+/// then fails "change <id> not found" the moment it reaches that dangling
+/// edge — 500ing `locate --ref git:<oid>` even for HEAD, because HEAD's own
+/// history walk crosses the horizon.
+///
+/// Re-pointing every parent that was not imported to `genesis_id` closes the DAG
+/// at the import horizon — the same shape a true root commit already has — so
+/// every parent reference resolves within the imported set ∪ {genesis}. A full
+/// import (`max_commits == 0`) walks the entire ancestry, so no parent is ever
+/// missing and this is a no-op; it only rewrites the boundary of a truncated
+/// window. The rewrite depends solely on the imported id set and `genesis_id`
+/// and preserves parent order (dedup keeps the first occurrence), so the
+/// parallel and serial import paths stay byte-identical.
+fn close_truncated_history_dag(changes: &mut [ImportedChange], genesis_id: SemanticChangeId) {
+    let imported: HashSet<SemanticChangeId> = changes.iter().map(|ic| ic.change.id).collect();
+    for ic in changes.iter_mut() {
+        let original = std::mem::take(&mut ic.change.parents);
+        let mut seen = HashSet::new();
+        let mut rewritten = Vec::with_capacity(original.len());
+        for parent in original {
+            let resolved = if parent == genesis_id || imported.contains(&parent) {
+                parent
+            } else {
+                genesis_id
+            };
+            if seen.insert(resolved) {
+                rewritten.push(resolved);
+            }
+        }
+        ic.change.parents = rewritten;
+    }
 }
 
 /// Convert a gitoxide commit into a SemanticChange.
@@ -871,6 +918,125 @@ mod tests {
                 got_ids, expected_ids,
                 "imported change ids must be stable across preps"
             );
+        }
+    }
+
+    /// A SemanticChange carrying only an id and parents — enough to exercise the
+    /// boundary-parent rewrite without a real Git commit.
+    fn bare_change(id: SemanticChangeId, parents: Vec<SemanticChangeId>) -> ImportedChange {
+        ImportedChange {
+            change: SemanticChange {
+                id,
+                parents,
+                timestamp: Timestamp::now(),
+                author: AuthorId::new("test"),
+                message: String::new(),
+                entity_deltas: vec![],
+                relation_deltas: vec![],
+                artifact_deltas: vec![],
+                projected_files: vec![],
+                spec_link: None,
+                evidence: vec![],
+                risk_summary: None,
+                authored_on: None,
+            },
+            git_oid: id.to_string(),
+        }
+    }
+
+    fn cid(byte: u8) -> SemanticChangeId {
+        SemanticChangeId::from_hash(Hash256::from_bytes([byte; 32]))
+    }
+
+    /// A parent dropped by truncation is re-pointed to genesis; an in-window
+    /// parent is left untouched. This is the edge that otherwise dangles and
+    /// fails a later `collect_changes_at_ref` history walk.
+    #[test]
+    fn close_truncated_history_dag_repoints_dangling_parents_to_genesis() {
+        let (genesis, a, b, c) = (cid(0x00), cid(0x0A), cid(0x0B), cid(0x0C));
+        // Window kept b (parent a) and c (parent b) but dropped a: b's parent is
+        // now dangling, c's parent is still present.
+        let mut changes = vec![bare_change(b, vec![a]), bare_change(c, vec![b])];
+        close_truncated_history_dag(&mut changes, genesis);
+        assert_eq!(
+            changes[0].change.parents,
+            vec![genesis],
+            "dangling boundary parent must collapse to genesis"
+        );
+        assert_eq!(
+            changes[1].change.parents,
+            vec![b],
+            "in-window parent must be preserved"
+        );
+    }
+
+    /// A merge commit whose parents were both dropped collapses to a single
+    /// genesis parent — never a duplicated `[genesis, genesis]`.
+    #[test]
+    fn close_truncated_history_dag_dedups_collapsed_parents() {
+        let (genesis, p1, p2, merge) = (cid(0x00), cid(0x01), cid(0x02), cid(0x0D));
+        let mut changes = vec![bare_change(merge, vec![p1, p2])];
+        close_truncated_history_dag(&mut changes, genesis);
+        assert_eq!(changes[0].change.parents, vec![genesis]);
+    }
+
+    /// A complete window (every parent present, root already on genesis) is
+    /// untouched — closing only rewrites genuinely dangling edges.
+    #[test]
+    fn close_truncated_history_dag_is_noop_for_complete_history() {
+        let (genesis, root, child) = (cid(0x00), cid(0x0A), cid(0x0B));
+        let mut changes = vec![
+            bare_change(root, vec![genesis]),
+            bare_change(child, vec![root]),
+        ];
+        let before = format!("{changes:?}");
+        close_truncated_history_dag(&mut changes, genesis);
+        assert_eq!(
+            format!("{changes:?}"),
+            before,
+            "a self-contained window must be left unchanged"
+        );
+    }
+
+    /// End-to-end through the real import path: a truncated import must yield a
+    /// DAG in which every parent resolves within the imported set ∪ {genesis},
+    /// so the oldest imported change can never dangle. Without closing, the
+    /// window's boundary commit points at an un-imported Git parent.
+    #[test]
+    fn truncated_import_produces_closed_dag() {
+        let Some(dir) = build_test_repo(12, 4) else {
+            eprintln!("git not available, skipping truncated-import closed-DAG test");
+            return;
+        };
+        let repo = open_repo(dir.path()).expect("open repo");
+        let head_id = repo
+            .head_ref()
+            .expect("head_ref")
+            .expect("non-empty repo")
+            .id()
+            .detach();
+        let genesis_id = SemanticChangeId::from_hash(Hash256::from_bytes([0x66; 32]));
+
+        let full = import_full(&repo, head_id, genesis_id, 0, None).expect("full import");
+        assert_eq!(full.len(), 12, "all commits import when max_commits == 0");
+
+        let limited = import_full(&repo, head_id, genesis_id, 5, None).expect("limited import");
+        assert_eq!(
+            limited.len(),
+            5,
+            "truncation must keep exactly max_commits changes"
+        );
+
+        let imported: HashSet<SemanticChangeId> = limited.iter().map(|ic| ic.change.id).collect();
+        for ic in &limited {
+            for parent in &ic.change.parents {
+                assert!(
+                    *parent == genesis_id || imported.contains(parent),
+                    "imported change {} has dangling parent {} (neither genesis nor in the imported window)",
+                    ic.change.id,
+                    parent
+                );
+            }
         }
     }
 


### PR DESCRIPTION
On a fresh kin init of a repo with more than 50 commits, kin locate --ref git:<oid> returned HTTP 500 'change … not found' — even for HEAD. The suspected cause (on-demand hydration failing to persist) is disproven: hydration persists through interior mutability, the daemon bumps and snapshots correctly, and the pre-existing hydration test passes on main.

The actual root is the truncated history import: init defaults to the most recent 50 commits, and the oldest imported commit keeps parent ids pointing at commits that were never imported. The ref-scoped history walk hard-errors when it crosses that dangling boundary, which surfaces as the 500 — identically live and after restart, because the snapshot faithfully persists the same dangling boundary.

Fix, at the root and at the walk:
- import_full closes the truncated DAG: any parent outside the imported set re-points to genesis (deduplicated, order-preserving, applied identically in the parallel and serial paths so the byte-identity guarantee holds; complete-history imports are a structural no-op).
- collect_changes_at_ref treats an absent ancestor as the import horizon (stop + warn) instead of erroring, matching the already-lenient topological collector — covers repositories imported before this fix, and 'bare change-not-found' can no longer surface from truncation.
- Out-of-window refs resolve via the existing on-demand hydration (which imports the full ancestry from the requested oid); genuinely unknown oids still fail with the actionable CommitNotFound.

Tests: DAG-closure unit tests (re-point, dedup, complete-history no-op, real import path), the horizon-walk regression, and a daemon integration test on a fresh 52-commit init asserting both git:<HEAD> and git:<out-of-window> locate succeed. Determinism guards (equal-timestamp truncation, parallel/serial byte-identity) intact. kin-git 31/0, kin-core 248/0.