### PR TITLE
feat(cli): kin daemon status and stop

### DIFF
--- a/crates/kin-cli/src/commands/daemon.rs
+++ b/crates/kin-cli/src/commands/daemon.rs
@@ -1,0 +1,717 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Firelock, LLC
+
+//! `kin daemon` — inspect and gracefully stop the Kin daemon topology.
+//!
+//! The Kin daemon is a mandatory, long-lived per-user runtime: one supervisor
+//! per user plus one worker daemon per repo it has served. Because the worker
+//! outlives the command that spawned it and freezes that command's environment,
+//! operators need a supported way to see what is running and to stop it (the
+//! behavior-env divergence warning tells them to). This command group is that
+//! surface, replacing raw `kill $(cat .kin/daemon.pid)`.
+//!
+//! Neither the worker daemon nor the supervisor exposes an HTTP shutdown route,
+//! so a graceful stop is SIGTERM plus a bounded wait for the process to exit.
+//! The daemon's own shutdown-escalation watchdog guarantees the process dies
+//! within its grace window, so the wait is a ceiling, not a fixed delay.
+
+use anyhow::{bail, Result};
+use std::path::Path;
+use std::time::{Duration, Instant};
+
+use crate::daemon_client::{
+    fetch_registered_daemons, is_port_open, is_process_alive, remove_stale_daemon_files,
+    remove_stale_supervisor_files, repo_daemon_pid_path, repo_daemon_port_path,
+    repo_daemon_recorded_endpoint, supervisor_pid_path, supervisor_port_path,
+    supervisor_recorded_endpoint, RegisteredRepoDaemon,
+};
+
+/// Liveness of a recorded daemon/supervisor endpoint. Pure classification of the
+/// recorded pid plus the observed process/port state, so the policy is testable
+/// without a live process.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum DaemonLiveness {
+    /// Recorded process is alive and its port accepts connections.
+    Running,
+    /// Recorded process is alive but its port does not accept connections —
+    /// still starting up, or wedged.
+    Unresponsive,
+    /// A pid was recorded but that process is not alive: the endpoint files are
+    /// stale and should be cleared.
+    Stale,
+    /// No pid was recorded — no endpoint files present.
+    NotRunning,
+}
+
+impl DaemonLiveness {
+    fn label(self) -> &'static str {
+        match self {
+            DaemonLiveness::Running => "running",
+            DaemonLiveness::Unresponsive => "unresponsive (process alive, port closed)",
+            DaemonLiveness::Stale => "stale (recorded process is gone)",
+            DaemonLiveness::NotRunning => "not running",
+        }
+    }
+
+    fn is_stale(self) -> bool {
+        matches!(self, DaemonLiveness::Stale)
+    }
+}
+
+/// Classify liveness from the recorded pid and the observed process/port state.
+/// `process_alive` and `port_open` are only meaningful when `pid` is `Some`.
+pub fn classify_liveness(pid: Option<u32>, process_alive: bool, port_open: bool) -> DaemonLiveness {
+    match pid {
+        None => DaemonLiveness::NotRunning,
+        Some(_) if !process_alive => DaemonLiveness::Stale,
+        Some(_) if port_open => DaemonLiveness::Running,
+        Some(_) => DaemonLiveness::Unresponsive,
+    }
+}
+
+/// Bounded wait for a stop to complete. The daemon's shutdown-escalation
+/// watchdog force-exits ~25s after SIGTERM, so 30s comfortably covers a graceful
+/// stop plus a final snapshot flush. Override with `KIN_DAEMON_STOP_TIMEOUT_SECS`.
+fn stop_timeout() -> Duration {
+    let secs = std::env::var("KIN_DAEMON_STOP_TIMEOUT_SECS")
+        .ok()
+        .and_then(|value| value.parse::<u64>().ok())
+        .unwrap_or(30);
+    Duration::from_secs(secs)
+}
+
+/// Outcome of a graceful stop request against one recorded pid.
+#[derive(Debug, Clone, PartialEq, Eq)]
+enum StopOutcome {
+    /// No live process was found for the pid — nothing to stop.
+    NotRunning,
+    /// SIGTERM delivered and the process exited within the wait window.
+    Stopped,
+    /// SIGTERM delivered but the process was still alive after the wait window.
+    Timeout,
+    /// Delivering SIGTERM failed for a reason other than the process being gone.
+    SignalFailed(String),
+}
+
+impl StopOutcome {
+    /// Whether this outcome leaves nothing alive: a clean stop or an
+    /// already-dead process both satisfy "it is not running".
+    fn is_success(&self) -> bool {
+        matches!(self, StopOutcome::NotRunning | StopOutcome::Stopped)
+    }
+
+    fn detail(&self) -> &str {
+        match self {
+            StopOutcome::NotRunning => "not-running",
+            StopOutcome::Stopped => "stopped",
+            StopOutcome::Timeout => "timeout",
+            StopOutcome::SignalFailed(_) => "signal-failed",
+        }
+    }
+}
+
+#[cfg(unix)]
+fn send_sigterm(pid: u32) -> std::io::Result<()> {
+    let rc = unsafe { libc::kill(pid as libc::pid_t, libc::SIGTERM) };
+    if rc == 0 {
+        Ok(())
+    } else {
+        Err(std::io::Error::last_os_error())
+    }
+}
+
+#[cfg(not(unix))]
+fn send_sigterm(pid: u32) -> std::io::Result<()> {
+    let _ = pid;
+    Err(std::io::Error::new(
+        std::io::ErrorKind::Unsupported,
+        "signal-based daemon stop is only supported on unix platforms",
+    ))
+}
+
+/// Send SIGTERM to `pid` and wait up to `wait` for the process to exit. Returns
+/// the classified outcome; never kills a process we did not intend to (the pid
+/// comes from Kin's own endpoint files).
+fn stop_pid_graceful(pid: u32, wait: Duration) -> StopOutcome {
+    if !is_process_alive(pid) {
+        return StopOutcome::NotRunning;
+    }
+    if let Err(error) = send_sigterm(pid) {
+        // A signal failure right after the alive check is almost always a race:
+        // the process exited on its own between the two. Re-check before
+        // reporting a hard failure.
+        if !is_process_alive(pid) {
+            return StopOutcome::NotRunning;
+        }
+        return StopOutcome::SignalFailed(error.to_string());
+    }
+    let deadline = Instant::now() + wait;
+    while Instant::now() < deadline {
+        if !is_process_alive(pid) {
+            return StopOutcome::Stopped;
+        }
+        std::thread::sleep(Duration::from_millis(50));
+    }
+    if is_process_alive(pid) {
+        StopOutcome::Timeout
+    } else {
+        StopOutcome::Stopped
+    }
+}
+
+/// The supervisor URL if a live supervisor is recorded, without ever spawning
+/// one. `status` and `stop` must observe the running topology, not create it.
+fn supervisor_url_if_running() -> Option<String> {
+    let (pid, port) = supervisor_recorded_endpoint();
+    let (pid, port) = (pid?, port?);
+    if is_process_alive(pid) && is_port_open(port) {
+        Some(format!("http://127.0.0.1:{port}"))
+    } else {
+        None
+    }
+}
+
+fn repo_label(working_dir: &Path) -> String {
+    working_dir
+        .file_name()
+        .and_then(|name| name.to_str())
+        .filter(|name| !name.trim().is_empty())
+        .unwrap_or("unknown")
+        .to_string()
+}
+
+fn canonical(path: &Path) -> String {
+    path.canonicalize()
+        .unwrap_or_else(|_| path.to_path_buf())
+        .display()
+        .to_string()
+}
+
+// ── status ──────────────────────────────────────────────────────────────────
+
+/// `kin daemon status` — report the supervisor and every repo worker daemon.
+pub async fn status(json: bool) -> Result<()> {
+    let (sup_pid, sup_port) = supervisor_recorded_endpoint();
+    let sup_alive = sup_pid.map(is_process_alive).unwrap_or(false);
+    let sup_port_open = sup_port.map(is_port_open).unwrap_or(false);
+    let sup_state = classify_liveness(sup_pid, sup_alive, sup_port_open);
+
+    // The per-repo worker list comes from the supervisor's `/daemons` registry —
+    // the same surface `kin registry daemons` reads. Only reachable when the
+    // supervisor is actually up; never spawn one just to list.
+    let supervisor_url = supervisor_url_if_running();
+    let daemons: Vec<RegisteredRepoDaemon> = match &supervisor_url {
+        Some(url) => fetch_registered_daemons(url).await.unwrap_or_default(),
+        None => Vec::new(),
+    };
+
+    // The current repo's own worker endpoint files, classified independently so a
+    // stale local endpoint is visible even when the supervisor has pruned it.
+    let current = current_repo_status();
+
+    if json {
+        let daemons_json: Vec<_> = daemons
+            .iter()
+            .map(|d| {
+                let alive = is_process_alive(d.pid);
+                let port_open = is_port_open(d.port);
+                let state = classify_liveness(Some(d.pid), alive, port_open);
+                serde_json::json!({
+                    "repo_id": d.repo_id,
+                    "display_name": d.display_name,
+                    "repo_root": d.repo_root,
+                    "pid": d.pid,
+                    "port": d.port,
+                    "endpoint": d.endpoint,
+                    "graph_entity_count": d.graph_entity_count,
+                    "last_heartbeat_at": d.last_heartbeat_at,
+                    "state": state.label(),
+                })
+            })
+            .collect();
+        let payload = serde_json::json!({
+            "schema": "kin.daemon-status.v1",
+            "supervisor": {
+                "state": sup_state.label(),
+                "pid": sup_pid,
+                "port": sup_port,
+                "pid_file": supervisor_pid_path().display().to_string(),
+                "port_file": supervisor_port_path().display().to_string(),
+            },
+            "repo_daemons": daemons_json,
+            "current_repo": current.as_ref().map(|c| serde_json::json!({
+                "label": c.label,
+                "repo_root": c.repo_root,
+                "state": c.state.label(),
+                "pid": c.pid,
+                "port": c.port,
+                "pid_file": c.pid_file,
+                "port_file": c.port_file,
+            })),
+        });
+        println!("{}", serde_json::to_string_pretty(&payload)?);
+        return Ok(());
+    }
+
+    match (sup_pid, sup_port) {
+        (Some(pid), port) => {
+            println!(
+                "Supervisor: {} (pid {}{})",
+                sup_state.label(),
+                pid,
+                port.map(|p| format!(", port {p}")).unwrap_or_default(),
+            );
+        }
+        (None, _) => println!("Supervisor: not running"),
+    }
+    println!("  pid file:  {}", supervisor_pid_path().display());
+    println!("  port file: {}", supervisor_port_path().display());
+    if sup_state.is_stale() {
+        println!("  note: supervisor endpoint files are stale; run `kin daemon stop --all` to clear them");
+    }
+
+    println!();
+    if supervisor_url.is_none() {
+        println!("Repo daemons: unavailable (supervisor not running)");
+    } else if daemons.is_empty() {
+        println!("Repo daemons: none registered");
+    } else {
+        println!("Repo daemons ({}):", daemons.len());
+        for daemon in &daemons {
+            let alive = is_process_alive(daemon.pid);
+            let port_open = is_port_open(daemon.port);
+            let state = classify_liveness(Some(daemon.pid), alive, port_open);
+            let label = if daemon.display_name.trim().is_empty() {
+                daemon.repo_id.clone()
+            } else {
+                daemon.display_name.clone()
+            };
+            let entities = daemon
+                .graph_entity_count
+                .map(|n| format!("{n} entities"))
+                .unwrap_or_else(|| "- entities".to_string());
+            println!(
+                "  {}  {}  pid {}  port {}  {}  {}",
+                label,
+                state.label(),
+                daemon.pid,
+                daemon.port,
+                entities,
+                daemon.repo_root
+            );
+            println!("    route:     {}", daemon.repo_id);
+            println!("    endpoint:  {}", daemon.endpoint);
+            if !daemon.last_heartbeat_at.trim().is_empty() {
+                println!("    heartbeat: {}", daemon.last_heartbeat_at);
+            }
+        }
+    }
+
+    if let Some(current) = current {
+        println!();
+        println!(
+            "Current repo ({}): worker daemon {}",
+            current.label,
+            current.state.label(),
+        );
+        if current.state.is_stale() {
+            println!("  note: endpoint files are stale; `kin daemon stop` will clear them");
+        }
+    }
+
+    Ok(())
+}
+
+struct CurrentRepoStatus {
+    label: String,
+    repo_root: String,
+    state: DaemonLiveness,
+    pid: Option<u32>,
+    port: Option<u16>,
+    pid_file: String,
+    port_file: String,
+}
+
+fn current_repo_status() -> Option<CurrentRepoStatus> {
+    let cwd = std::env::current_dir().ok()?;
+    let layout = kin_core::KinLayout::discover(&cwd)?;
+    let kin_root = layout.root();
+    let working_dir = kin_root.parent().unwrap_or(kin_root);
+    let (pid, port) = repo_daemon_recorded_endpoint(kin_root);
+    let alive = pid.map(is_process_alive).unwrap_or(false);
+    let port_open = port.map(is_port_open).unwrap_or(false);
+    let state = classify_liveness(pid, alive, port_open);
+    Some(CurrentRepoStatus {
+        label: repo_label(working_dir),
+        repo_root: canonical(working_dir),
+        state,
+        pid,
+        port,
+        pid_file: repo_daemon_pid_path(kin_root).display().to_string(),
+        port_file: repo_daemon_port_path(kin_root).display().to_string(),
+    })
+}
+
+// ── stop ────────────────────────────────────────────────────────────────────
+
+/// `kin daemon stop` — gracefully stop the current repo's worker daemon, or with
+/// `--all` every worker plus the supervisor (supervisor last).
+pub async fn stop(all: bool, json: bool) -> Result<()> {
+    if all {
+        stop_all(json).await
+    } else {
+        stop_current_repo(json).await
+    }
+}
+
+/// One stopped (or attempted-to-stop) endpoint, for the report.
+struct StopReport {
+    kind: &'static str,
+    label: String,
+    pid: u32,
+    outcome: StopOutcome,
+}
+
+async fn stop_current_repo(json: bool) -> Result<()> {
+    let cwd = std::env::current_dir()?;
+    let Some(layout) = kin_core::KinLayout::discover(&cwd) else {
+        bail!(
+            "not inside a Kin repository — run `kin daemon stop` from a repo, or \
+             `kin daemon stop --all` to stop every daemon"
+        );
+    };
+    let kin_root = layout.root().to_path_buf();
+    let working_dir = kin_root.parent().unwrap_or(&kin_root).to_path_buf();
+    let label = repo_label(&working_dir);
+
+    let pid = resolve_repo_worker_pid(&kin_root, &working_dir).await;
+
+    let Some(pid) = pid else {
+        // Nothing live to stop. Clear any stale endpoint files so a later status
+        // does not report a dead endpoint.
+        remove_stale_daemon_files(&kin_root);
+        if json {
+            let payload = serde_json::json!({
+                "schema": "kin.daemon-stop.v1",
+                "scope": "current-repo",
+                "repo": label,
+                "stopped": [],
+                "all_stopped": true,
+            });
+            println!("{}", serde_json::to_string_pretty(&payload)?);
+        } else {
+            println!("No worker daemon running for repo '{label}' (nothing to stop).");
+        }
+        return Ok(());
+    };
+
+    let outcome = stop_pid_graceful(pid, stop_timeout());
+    if outcome.is_success() {
+        remove_stale_daemon_files(&kin_root);
+    }
+    let report = vec![StopReport {
+        kind: "repo-daemon",
+        label: label.clone(),
+        pid,
+        outcome,
+    }];
+    finish_stop("current-repo", &report, json)
+}
+
+/// Resolve the pid of the current repo's worker daemon, the way the daemon
+/// client resolves it: prefer the local `.kin/daemon.pid` record, and if that is
+/// absent or dead, fall back to the supervisor's `/daemons` registry (matched by
+/// canonical repo root). Returns a pid only when the process is actually alive.
+async fn resolve_repo_worker_pid(kin_root: &Path, working_dir: &Path) -> Option<u32> {
+    let (local_pid, _) = repo_daemon_recorded_endpoint(kin_root);
+    if let Some(pid) = local_pid {
+        if is_process_alive(pid) {
+            return Some(pid);
+        }
+    }
+    // Local file missing or stale — ask the supervisor if it still routes a live
+    // worker for this repo root.
+    let url = supervisor_url_if_running()?;
+    let daemons = fetch_registered_daemons(&url).await.ok()?;
+    let target = canonical(working_dir);
+    daemons
+        .into_iter()
+        .find(|d| canonical(Path::new(&d.repo_root)) == target && is_process_alive(d.pid))
+        .map(|d| d.pid)
+}
+
+async fn stop_all(json: bool) -> Result<()> {
+    let wait = stop_timeout();
+    let mut reports: Vec<StopReport> = Vec::new();
+
+    // Stop every worker the supervisor knows about first, so the supervisor is
+    // the last thing standing (it can prune its own routes as workers die).
+    let supervisor_url = supervisor_url_if_running();
+    if let Some(url) = &supervisor_url {
+        let daemons = fetch_registered_daemons(url).await.unwrap_or_default();
+        for daemon in daemons {
+            let label = if daemon.display_name.trim().is_empty() {
+                daemon.repo_id.clone()
+            } else {
+                daemon.display_name.clone()
+            };
+            let outcome = stop_pid_graceful(daemon.pid, wait);
+            if outcome.is_success() {
+                // Clear the worker's endpoint files too (repo_root/.kin/daemon.*).
+                remove_stale_daemon_files(&Path::new(&daemon.repo_root).join(".kin"));
+            }
+            reports.push(StopReport {
+                kind: "repo-daemon",
+                label,
+                pid: daemon.pid,
+                outcome,
+            });
+        }
+    }
+
+    // Also stop the current repo's worker if it is not registered with the
+    // supervisor (e.g. supervisor down but a worker process lingering).
+    if let Ok(cwd) = std::env::current_dir() {
+        if let Some(layout) = kin_core::KinLayout::discover(&cwd) {
+            let kin_root = layout.root().to_path_buf();
+            let (pid, _) = repo_daemon_recorded_endpoint(&kin_root);
+            if let Some(pid) = pid {
+                let already = reports.iter().any(|r| r.pid == pid);
+                if !already && is_process_alive(pid) {
+                    let working_dir = kin_root.parent().unwrap_or(&kin_root).to_path_buf();
+                    let outcome = stop_pid_graceful(pid, wait);
+                    if outcome.is_success() {
+                        remove_stale_daemon_files(&kin_root);
+                    }
+                    reports.push(StopReport {
+                        kind: "repo-daemon",
+                        label: repo_label(&working_dir),
+                        pid,
+                        outcome,
+                    });
+                }
+            }
+        }
+    }
+
+    // Supervisor last.
+    let (sup_pid, _) = supervisor_recorded_endpoint();
+    if let Some(pid) = sup_pid {
+        if is_process_alive(pid) {
+            let outcome = stop_pid_graceful(pid, wait);
+            if outcome.is_success() {
+                remove_stale_supervisor_files();
+            }
+            reports.push(StopReport {
+                kind: "supervisor",
+                label: "supervisor".to_string(),
+                pid,
+                outcome,
+            });
+        } else {
+            // Recorded but dead — clear stale files.
+            remove_stale_supervisor_files();
+        }
+    }
+
+    if reports.is_empty() {
+        if json {
+            let payload = serde_json::json!({
+                "schema": "kin.daemon-stop.v1",
+                "scope": "all",
+                "stopped": [],
+                "all_stopped": true,
+            });
+            println!("{}", serde_json::to_string_pretty(&payload)?);
+        } else {
+            println!("No Kin daemons running.");
+        }
+        return Ok(());
+    }
+
+    finish_stop("all", &reports, json)
+}
+
+/// Emit the stop report and fail loud (nonzero exit) if any endpoint would not
+/// die, so scripts can trust the exit code.
+fn finish_stop(scope: &str, reports: &[StopReport], json: bool) -> Result<()> {
+    let all_stopped = reports.iter().all(|r| r.outcome.is_success());
+
+    if json {
+        let stopped: Vec<_> = reports
+            .iter()
+            .map(|r| {
+                serde_json::json!({
+                    "kind": r.kind,
+                    "label": r.label,
+                    "pid": r.pid,
+                    "result": r.outcome.detail(),
+                })
+            })
+            .collect();
+        let payload = serde_json::json!({
+            "schema": "kin.daemon-stop.v1",
+            "scope": scope,
+            "stopped": stopped,
+            "all_stopped": all_stopped,
+        });
+        println!("{}", serde_json::to_string_pretty(&payload)?);
+    } else {
+        for r in reports {
+            let line = match &r.outcome {
+                StopOutcome::Stopped => format!("{} (pid {}): stopped", r.label, r.pid),
+                StopOutcome::NotRunning => {
+                    format!("{} (pid {}): was not running", r.label, r.pid)
+                }
+                StopOutcome::Timeout => format!(
+                    "{} (pid {}): STILL ALIVE after SIGTERM + {}s wait",
+                    r.label,
+                    r.pid,
+                    stop_timeout().as_secs()
+                ),
+                StopOutcome::SignalFailed(err) => {
+                    format!("{} (pid {}): SIGTERM failed: {}", r.label, r.pid, err)
+                }
+            };
+            println!("  {line}");
+        }
+        if all_stopped {
+            println!("All targeted Kin daemons stopped.");
+        }
+    }
+
+    if !all_stopped {
+        let failed: Vec<String> = reports
+            .iter()
+            .filter(|r| !r.outcome.is_success())
+            .map(|r| format!("{} (pid {})", r.label, r.pid))
+            .collect();
+        bail!(
+            "one or more Kin daemons did not stop: {}",
+            failed.join(", ")
+        );
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn classify_liveness_covers_every_state() {
+        // No pid recorded → nothing is running, regardless of the probes.
+        assert_eq!(
+            classify_liveness(None, false, false),
+            DaemonLiveness::NotRunning
+        );
+        assert_eq!(
+            classify_liveness(None, true, true),
+            DaemonLiveness::NotRunning
+        );
+        // Recorded pid, dead process → stale files.
+        assert_eq!(
+            classify_liveness(Some(4219), false, false),
+            DaemonLiveness::Stale
+        );
+        // A dead process is stale even if some unrelated process holds the port.
+        assert_eq!(
+            classify_liveness(Some(4219), false, true),
+            DaemonLiveness::Stale
+        );
+        // Alive but port closed → unresponsive (starting up or wedged).
+        assert_eq!(
+            classify_liveness(Some(4219), true, false),
+            DaemonLiveness::Unresponsive
+        );
+        // Alive and serving → running.
+        assert_eq!(
+            classify_liveness(Some(4219), true, true),
+            DaemonLiveness::Running
+        );
+    }
+
+    #[test]
+    fn liveness_labels_are_distinct_and_stable() {
+        let states = [
+            DaemonLiveness::Running,
+            DaemonLiveness::Unresponsive,
+            DaemonLiveness::Stale,
+            DaemonLiveness::NotRunning,
+        ];
+        for (i, a) in states.iter().enumerate() {
+            for b in &states[i + 1..] {
+                assert_ne!(a.label(), b.label(), "labels must be distinct");
+            }
+        }
+        assert!(DaemonLiveness::Stale.is_stale());
+        assert!(!DaemonLiveness::Running.is_stale());
+    }
+
+    #[test]
+    fn recorded_endpoint_parsing_handles_good_absent_and_garbage() {
+        let dir = tempfile::tempdir().unwrap();
+        let kin_root = dir.path().join(".kin");
+        std::fs::create_dir_all(&kin_root).unwrap();
+
+        // Absent files → both components None.
+        assert_eq!(repo_daemon_recorded_endpoint(&kin_root), (None, None));
+
+        // Well-formed files (with surrounding whitespace) parse cleanly.
+        std::fs::write(kin_root.join("daemon.pid"), "  12345\n").unwrap();
+        std::fs::write(kin_root.join("daemon.port"), "51234\n").unwrap();
+        assert_eq!(
+            repo_daemon_recorded_endpoint(&kin_root),
+            (Some(12345), Some(51234))
+        );
+
+        // Garbage / out-of-range values parse to None rather than panicking.
+        std::fs::write(kin_root.join("daemon.pid"), "not-a-pid").unwrap();
+        std::fs::write(kin_root.join("daemon.port"), "99999999").unwrap();
+        assert_eq!(repo_daemon_recorded_endpoint(&kin_root), (None, None));
+    }
+
+    #[test]
+    fn stop_outcome_success_semantics() {
+        assert!(StopOutcome::Stopped.is_success());
+        assert!(StopOutcome::NotRunning.is_success());
+        assert!(!StopOutcome::Timeout.is_success());
+        assert!(!StopOutcome::SignalFailed("boom".to_string()).is_success());
+    }
+
+    #[test]
+    fn stop_pid_graceful_reports_not_running_for_dead_pid() {
+        // A pid that is essentially guaranteed not to exist must classify as
+        // NotRunning without sending a signal anywhere.
+        let outcome = stop_pid_graceful(u32::MAX - 1, Duration::from_millis(50));
+        assert_eq!(outcome, StopOutcome::NotRunning);
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn stop_pid_graceful_stops_a_live_process() {
+        // Spawn a real process that sleeps, then prove SIGTERM stops it and the
+        // wait observes the process actually gone.
+        //
+        // A SIGTERM'd *child* becomes a zombie until its parent reaps it, and
+        // `kill(pid, 0)` still succeeds for a zombie — so we reap concurrently in
+        // a background thread. In production this models reality rather than
+        // hiding it: the daemon is never the stopping CLI's child (it is detached
+        // with setsid and reparented to init), so init reaps it and
+        // `is_process_alive` returns false the moment it dies.
+        let mut child = std::process::Command::new("sleep")
+            .arg("30")
+            .spawn()
+            .expect("spawn sleep child");
+        let pid = child.id();
+        assert!(is_process_alive(pid));
+
+        let reaper = std::thread::spawn(move || {
+            let _ = child.wait();
+        });
+        let outcome = stop_pid_graceful(pid, Duration::from_secs(10));
+        let _ = reaper.join();
+
+        assert_eq!(outcome, StopOutcome::Stopped);
+    }
+}

--- a/crates/kin-cli/src/commands/mod.rs
+++ b/crates/kin-cli/src/commands/mod.rs
@@ -18,6 +18,7 @@ pub mod commit;
 pub mod conflicts;
 pub mod context;
 pub mod contextbench_locate;
+pub mod daemon;
 pub mod dead_code;
 pub mod deps;
 pub mod diff;

--- a/crates/kin-cli/src/commands/registry.rs
+++ b/crates/kin-cli/src/commands/registry.rs
@@ -5,24 +5,9 @@ use anyhow::Result;
 use kin_core::registry::KinRegistry;
 use std::collections::HashSet;
 
-use super::deps;
+use crate::daemon_client::RegisteredRepoDaemon;
 
-#[derive(Debug, serde::Deserialize, serde::Serialize)]
-struct RegisteredRepoDaemon {
-    repo_id: String,
-    #[serde(default)]
-    display_name: String,
-    #[serde(default)]
-    instance_id: String,
-    repo_root: String,
-    pid: u32,
-    port: u16,
-    endpoint: String,
-    graph_entity_count: Option<usize>,
-    #[serde(default)]
-    registered_at: Option<String>,
-    last_heartbeat_at: String,
-}
+use super::deps;
 
 #[derive(Debug, serde::Serialize)]
 struct RegisteredRepoDaemonsOutput {
@@ -63,13 +48,7 @@ pub async fn list() -> Result<()> {
 /// List repo daemons registered with the central local supervisor.
 pub async fn daemons(json: bool) -> Result<()> {
     let supervisor_url = crate::daemon_client::ensure_supervisor_running().await?;
-    let daemons: Vec<RegisteredRepoDaemon> = reqwest::Client::new()
-        .get(format!("{}/daemons", supervisor_url.trim_end_matches('/')))
-        .send()
-        .await?
-        .error_for_status()?
-        .json()
-        .await?;
+    let daemons = crate::daemon_client::fetch_registered_daemons(&supervisor_url).await?;
 
     if json {
         let output = RegisteredRepoDaemonsOutput {

--- a/crates/kin-cli/src/daemon_client.rs
+++ b/crates/kin-cli/src/daemon_client.rs
@@ -80,6 +80,44 @@ struct SupervisorRegistration {
     graph_entity_count: Option<usize>,
 }
 
+/// A repo worker daemon as recorded by the per-user supervisor's `/daemons`
+/// registry. Mirrors the supervisor's own `RegisteredRepoDaemon` payload; shared
+/// by `kin registry daemons` and `kin daemon status`/`stop` so the supervisor
+/// listing plumbing lives in one place.
+#[derive(Debug, Clone, Deserialize, Serialize)]
+pub struct RegisteredRepoDaemon {
+    pub repo_id: String,
+    #[serde(default)]
+    pub display_name: String,
+    #[serde(default)]
+    pub instance_id: String,
+    pub repo_root: String,
+    pub pid: u32,
+    pub port: u16,
+    pub endpoint: String,
+    #[serde(default)]
+    pub graph_entity_count: Option<usize>,
+    #[serde(default)]
+    pub registered_at: Option<String>,
+    #[serde(default)]
+    pub last_heartbeat_at: String,
+}
+
+/// Fetch the repo daemons registered with a running supervisor via `GET
+/// /daemons`. The caller supplies a supervisor URL it already resolved (e.g. via
+/// [`ensure_supervisor_running`] or [`supervisor_recorded_endpoint`]); this does
+/// not itself start a supervisor.
+pub async fn fetch_registered_daemons(supervisor_url: &str) -> Result<Vec<RegisteredRepoDaemon>> {
+    let daemons = reqwest::Client::new()
+        .get(format!("{}/daemons", supervisor_url.trim_end_matches('/')))
+        .send()
+        .await?
+        .error_for_status()?
+        .json()
+        .await?;
+    Ok(daemons)
+}
+
 /// A single entity entry from the daemon's entity search.
 #[derive(Debug, Deserialize)]
 pub struct DaemonEntityEntry {
@@ -1231,8 +1269,8 @@ fn behavior_env_divergence_message(divergences: &[kin_core::behavior_env::Diverg
     }
     message.push_str(
         "\nremedy: restart the daemon so it re-inherits the current environment — stop it with \
-         `kill $(cat .kin/daemon.pid)` (it also self-stops after its KIN_DAEMON_IDLE_TIMEOUT_SECS \
-         idle window) and the next kin command respawns it. \
+         `kin daemon stop` (or `kill $(cat .kin/daemon.pid)`; it also self-stops after its \
+         KIN_DAEMON_IDLE_TIMEOUT_SECS idle window) and the next kin command respawns it. \
          Set KIN_STRICT_BEHAVIOR_ENV=1 to make this a hard error.",
     );
     message
@@ -1269,7 +1307,10 @@ pub fn daemon_required() -> bool {
     true
 }
 
-fn is_process_alive(pid: u32) -> bool {
+/// Whether a process with the given pid currently exists (signal 0 probe on
+/// unix). Used by the daemon lifecycle and by `kin daemon status`/`stop` to
+/// classify a recorded pid as live or stale.
+pub fn is_process_alive(pid: u32) -> bool {
     #[cfg(unix)]
     {
         unsafe { libc::kill(pid as libc::pid_t, 0) == 0 }
@@ -1281,7 +1322,10 @@ fn is_process_alive(pid: u32) -> bool {
     }
 }
 
-fn is_port_open(port: u16) -> bool {
+/// Whether a TCP port on localhost is accepting connections. Distinguishes a
+/// daemon that is alive and serving from one whose process exists but whose
+/// port is not (yet) bound.
+pub fn is_port_open(port: u16) -> bool {
     let addr: std::net::SocketAddr = ([127, 0, 0, 1], port).into();
     std::net::TcpStream::connect_timeout(&addr, Duration::from_millis(200)).is_ok()
 }
@@ -1292,9 +1336,22 @@ struct LiveDaemonEndpoint {
     port: u16,
 }
 
-fn remove_stale_daemon_files(kin_root: &Path) {
-    let _ = std::fs::remove_file(kin_root.join("daemon.pid"));
-    let _ = std::fs::remove_file(kin_root.join("daemon.port"));
+/// Path to the current repo's worker daemon pid file.
+pub fn repo_daemon_pid_path(kin_root: &Path) -> PathBuf {
+    kin_root.join("daemon.pid")
+}
+
+/// Path to the current repo's worker daemon port file.
+pub fn repo_daemon_port_path(kin_root: &Path) -> PathBuf {
+    kin_root.join("daemon.port")
+}
+
+/// Remove a repo worker daemon's pid/port endpoint files. The daemon deletes
+/// these itself on graceful shutdown; `kin daemon stop` also calls this after a
+/// confirmed stop so a later `status` never reports the dead endpoint as stale.
+pub fn remove_stale_daemon_files(kin_root: &Path) {
+    let _ = std::fs::remove_file(repo_daemon_pid_path(kin_root));
+    let _ = std::fs::remove_file(repo_daemon_port_path(kin_root));
 }
 
 fn supervisor_dir() -> PathBuf {
@@ -1304,29 +1361,54 @@ fn supervisor_dir() -> PathBuf {
         .unwrap_or_else(|| PathBuf::from(".kin"))
 }
 
-fn supervisor_pid_path() -> PathBuf {
+/// Path to the per-user supervisor pid file (under the Kin registry directory).
+pub fn supervisor_pid_path() -> PathBuf {
     supervisor_dir().join("supervisor.pid")
 }
 
-fn supervisor_port_path() -> PathBuf {
+/// Path to the per-user supervisor port file (under the Kin registry directory).
+pub fn supervisor_port_path() -> PathBuf {
     supervisor_dir().join("supervisor.port")
 }
 
-fn remove_stale_supervisor_files() {
+/// Remove the supervisor's pid/port endpoint files. Called after a confirmed
+/// supervisor stop so a later `status` never reports the dead endpoint as stale.
+pub fn remove_stale_supervisor_files() {
     let _ = std::fs::remove_file(supervisor_pid_path());
     let _ = std::fs::remove_file(supervisor_port_path());
 }
 
 fn read_pid_file(kin_root: &Path) -> Option<u32> {
-    std::fs::read_to_string(kin_root.join("daemon.pid"))
+    std::fs::read_to_string(repo_daemon_pid_path(kin_root))
         .ok()
         .and_then(|s| s.trim().parse().ok())
 }
 
 fn read_port_file(kin_root: &Path) -> Option<u16> {
-    std::fs::read_to_string(kin_root.join("daemon.port"))
+    std::fs::read_to_string(repo_daemon_port_path(kin_root))
         .ok()
         .and_then(|s| s.trim().parse().ok())
+}
+
+/// The (pid, port) recorded for the current repo's worker daemon, read from its
+/// `.kin/daemon.{pid,port}` files with no liveness probe. Either component is
+/// `None` when its file is absent or unparseable. Callers classify liveness
+/// separately via [`is_process_alive`]/[`is_port_open`].
+pub fn repo_daemon_recorded_endpoint(kin_root: &Path) -> (Option<u32>, Option<u16>) {
+    (read_pid_file(kin_root), read_port_file(kin_root))
+}
+
+/// The (pid, port) recorded for the per-user supervisor, read from its
+/// `supervisor.{pid,port}` files with no liveness probe. Either component is
+/// `None` when its file is absent or unparseable.
+pub fn supervisor_recorded_endpoint() -> (Option<u32>, Option<u16>) {
+    let pid = std::fs::read_to_string(supervisor_pid_path())
+        .ok()
+        .and_then(|s| s.trim().parse().ok());
+    let port = std::fs::read_to_string(supervisor_port_path())
+        .ok()
+        .and_then(|s| s.trim().parse().ok());
+    (pid, port)
 }
 
 fn live_daemon_endpoint(kin_root: &Path) -> Option<LiveDaemonEndpoint> {
@@ -2692,6 +2774,9 @@ mod tests {
         assert!(message.contains("KIN_EMBED_HYBRID: cli=\"balanced\" daemon=(unset)"));
         assert!(message.contains("KIN_RESOURCE_PROFILE: cli=(unset) daemon=\"throughput\""));
         // ...and the message states the accurate remedy and the strict escalation.
+        // The remedy now names the supported `kin daemon stop` command and keeps
+        // the raw kill as a fallback.
+        assert!(message.contains("kin daemon stop"));
         assert!(message.contains(".kin/daemon.pid"));
         assert!(message.contains("KIN_STRICT_BEHAVIOR_ENV=1"));
     }

--- a/crates/kin-cli/src/main.rs
+++ b/crates/kin-cli/src/main.rs
@@ -833,6 +833,11 @@ enum Command {
         #[command(subcommand)]
         action: Option<RegistryAction>,
     },
+    /// Inspect and gracefully stop Kin daemons
+    Daemon {
+        #[command(subcommand)]
+        action: DaemonAction,
+    },
     /// Probe first-run health and optionally apply safe repairs
     Doctor {
         /// Apply safe automatic repairs (shell hook, MCP configs, config dirs)
@@ -1615,6 +1620,25 @@ enum RegistryAction {
     },
     /// Remove stale entries (paths that no longer contain .kin/)
     Clean,
+}
+
+#[derive(Subcommand)]
+enum DaemonAction {
+    /// Show the supervisor and every repo worker daemon, with stale-file detection
+    Status {
+        /// Emit machine-readable JSON
+        #[arg(long)]
+        json: bool,
+    },
+    /// Gracefully stop the current repo's worker daemon (or every daemon with --all)
+    Stop {
+        /// Stop every worker daemon and the supervisor (supervisor last)
+        #[arg(long)]
+        all: bool,
+        /// Emit machine-readable JSON
+        #[arg(long)]
+        json: bool,
+    },
 }
 
 #[derive(Subcommand)]
@@ -2665,6 +2689,10 @@ fn main() -> Result<()> {
                     }
                     Some(RegistryAction::Clean) => commands::registry::clean().await,
                     None => commands::registry::list().await,
+                },
+                Command::Daemon { action } => match action {
+                    DaemonAction::Status { json } => commands::daemon::status(json).await,
+                    DaemonAction::Stop { all, json } => commands::daemon::stop(all, json).await,
                 },
                 Command::Doctor {
                     fix,

--- a/crates/kin-cli/tests/daemon_stop.rs
+++ b/crates/kin-cli/tests/daemon_stop.rs
@@ -1,0 +1,168 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Firelock, LLC
+
+//! End-to-end proof of `kin daemon status` / `kin daemon stop`.
+//!
+//! Brings a real worker daemon up through a normal daemon-backed command, then
+//! drives the new command group against it: `status` reports the running
+//! topology, `stop` gracefully terminates the current repo's worker (clean exit
+//! 0, process actually gone), and `stop --all` reaps the supervisor.
+//!
+//! Hermetic: `KIN_REGISTRY_PATH` points the supervisor/registry state at a
+//! scratch dir so the test never touches the user's real `~/.kin` supervisor or
+//! any daemon serving another repo. The scratch repo has no source files, so the
+//! daemon's background embedding worker has nothing to embed and never loads a
+//! model — the test needs no GPU.
+
+use kin_cli::daemon_client::is_process_alive;
+use serde_json::Value;
+use std::path::Path;
+use std::process::{Command, Output};
+use std::time::{Duration, Instant};
+
+mod common;
+
+/// Run `kin <args>` in `repo` with a fully isolated daemon/supervisor
+/// environment. The long idle timeouts keep the daemon from self-stopping mid
+/// test; the fresh daemon binary matches this CLI's graph schema.
+fn kin(repo: &Path, registry_path: &Path, args: &[&str]) -> Output {
+    Command::new(env!("CARGO_BIN_EXE_kin"))
+        .args(args)
+        .current_dir(repo)
+        .env("KIN_DAEMON_BIN", common::fresh_daemon_bin())
+        .env("KIN_REGISTRY_PATH", registry_path)
+        .env("KIN_DAEMON_DISABLE_LSP", "1")
+        .env("KIN_DAEMON_IDLE_TIMEOUT_SECS", "120")
+        .env("KIN_SUPERVISOR_IDLE_TIMEOUT_SECS", "120")
+        .env("KIN_DAEMON_READY_TIMEOUT_SECS", "60")
+        .output()
+        .expect("run kin")
+}
+
+fn stdout_json(output: &Output, context: &str) -> Value {
+    assert!(
+        output.status.success(),
+        "{context} failed: stdout={} stderr={}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+    serde_json::from_slice(&output.stdout).unwrap_or_else(|e| {
+        panic!(
+            "{context} stdout is not valid JSON ({e}): {}",
+            String::from_utf8_lossy(&output.stdout)
+        )
+    })
+}
+
+fn read_pid(path: &Path) -> Option<u32> {
+    std::fs::read_to_string(path)
+        .ok()
+        .and_then(|s| s.trim().parse().ok())
+}
+
+fn wait_until_dead(pid: u32, timeout: Duration) {
+    let deadline = Instant::now() + timeout;
+    while is_process_alive(pid) && Instant::now() < deadline {
+        std::thread::sleep(Duration::from_millis(50));
+    }
+}
+
+#[test]
+fn daemon_status_and_stop_lifecycle() {
+    let root = tempfile::tempdir().expect("temp root");
+    let repo = root.path().join("repo");
+    let kin_home = root.path().join("kinhome");
+    let registry = kin_home.join("registry.toml");
+    std::fs::create_dir_all(&kin_home).expect("create kin home");
+    std::fs::create_dir_all(&repo).expect("create repo dir");
+
+    kin_core::init(&repo).expect("init scratch repo");
+
+    // ── status with nothing running: must NOT autostart a supervisor ──────────
+    let status = stdout_json(
+        &kin(&repo, &registry, &["daemon", "status", "--json"]),
+        "kin daemon status (idle)",
+    );
+    assert_eq!(status["schema"], "kin.daemon-status.v1");
+    assert_eq!(status["supervisor"]["state"], "not running");
+    assert!(
+        !kin_home.join("supervisor.pid").exists(),
+        "status must not spawn a supervisor"
+    );
+
+    // ── bring the worker daemon up through a normal daemon-backed command ─────
+    let up = kin(&repo, &registry, &["support", "--json"]);
+    assert!(
+        up.status.success(),
+        "kin support (autostart) failed: stdout={} stderr={}",
+        String::from_utf8_lossy(&up.stdout),
+        String::from_utf8_lossy(&up.stderr)
+    );
+
+    let pid_path = repo.join(".kin/daemon.pid");
+    let worker_pid = read_pid(&pid_path).expect("worker daemon.pid after autostart");
+    assert!(
+        is_process_alive(worker_pid),
+        "worker daemon pid {worker_pid} should be alive after autostart"
+    );
+
+    // ── status with the worker up: current repo reports running, pid matches ──
+    let status = stdout_json(
+        &kin(&repo, &registry, &["daemon", "status", "--json"]),
+        "kin daemon status (running)",
+    );
+    assert_eq!(status["supervisor"]["state"], "running");
+    assert_eq!(status["current_repo"]["state"], "running");
+    assert_eq!(
+        status["current_repo"]["pid"].as_u64(),
+        Some(worker_pid as u64)
+    );
+
+    // ── stop the current repo's worker: clean exit 0, process gone ────────────
+    let stop = kin(&repo, &registry, &["daemon", "stop"]);
+    assert!(
+        stop.status.success(),
+        "kin daemon stop exited nonzero: stdout={} stderr={}",
+        String::from_utf8_lossy(&stop.stdout),
+        String::from_utf8_lossy(&stop.stderr)
+    );
+    assert!(
+        String::from_utf8_lossy(&stop.stdout).contains("stopped"),
+        "stop report should say stopped: {}",
+        String::from_utf8_lossy(&stop.stdout)
+    );
+
+    wait_until_dead(worker_pid, Duration::from_secs(5));
+    assert!(
+        !is_process_alive(worker_pid),
+        "worker daemon pid {worker_pid} still alive after `kin daemon stop`"
+    );
+    assert!(
+        !pid_path.exists(),
+        "daemon.pid must be cleared after a confirmed stop"
+    );
+
+    // ── status after stop: current repo no longer running ─────────────────────
+    let status = stdout_json(
+        &kin(&repo, &registry, &["daemon", "status", "--json"]),
+        "kin daemon status (after stop)",
+    );
+    assert_eq!(status["current_repo"]["state"], "not running");
+
+    // ── stop --all: reaps the supervisor (supervisor last), clean exit 0 ──────
+    let sup_pid = read_pid(&kin_home.join("supervisor.pid"));
+    let stop_all = kin(&repo, &registry, &["daemon", "stop", "--all"]);
+    assert!(
+        stop_all.status.success(),
+        "kin daemon stop --all exited nonzero: stdout={} stderr={}",
+        String::from_utf8_lossy(&stop_all.stdout),
+        String::from_utf8_lossy(&stop_all.stderr)
+    );
+    if let Some(sup_pid) = sup_pid {
+        wait_until_dead(sup_pid, Duration::from_secs(5));
+        assert!(
+            !is_process_alive(sup_pid),
+            "supervisor pid {sup_pid} still alive after `kin daemon stop --all`"
+        );
+    }
+}

--- a/crates/kin-core/src/env_registry.rs
+++ b/crates/kin-core/src/env_registry.rs
@@ -188,6 +188,7 @@ pub const OPERATIONAL: &[EnvVarSpec] = &[
     EnvVarSpec { name: "KIN_DAEMON_URL", kind: Kind::Url, default: "", sensitivity: Sensitivity::Operational, summary: "explicit daemon endpoint URL (skip local discovery)" },
     EnvVarSpec { name: "KIN_DAEMON_BIN", kind: Kind::Path, default: "", sensitivity: Sensitivity::Operational, summary: "override path to the kin-daemon binary" },
     EnvVarSpec { name: "KIN_DAEMON_BIND_HOST", kind: Kind::Str, default: "", sensitivity: Sensitivity::Operational, summary: "host/interface the daemon binds its HTTP endpoint to" },
+    EnvVarSpec { name: "KIN_DAEMON_STOP_TIMEOUT_SECS", kind: Kind::Secs, default: "30", sensitivity: Sensitivity::Operational, summary: "ceiling in seconds kin daemon stop waits for a signaled daemon to exit" },
     EnvVarSpec { name: "KIN_DAEMON_REQUIRE_TOKEN", kind: Kind::Bool, default: "false", sensitivity: Sensitivity::Operational, summary: "require a bearer token for all daemon requests" },
     EnvVarSpec { name: "KIN_DAEMON_ALLOW_EXEC", kind: Kind::Bool, default: "false", sensitivity: Sensitivity::Operational, summary: "permit the daemon to run exec commands" },
     EnvVarSpec { name: "KIN_DAEMON_WATCH_PID", kind: Kind::Usize, default: "", sensitivity: Sensitivity::Operational, summary: "pid the daemon watches; it exits when that process dies" },

--- a/docs/env-vars.md
+++ b/docs/env-vars.md
@@ -3,7 +3,7 @@
 
 # Kin environment variables
 
-This is the authoritative list of supported `KIN_*` environment variables (383 total, 290 correctness-relevant), generated from the central registry in `kin-core`.
+This is the authoritative list of supported `KIN_*` environment variables (384 total, 290 correctness-relevant), generated from the central registry in `kin-core`.
 
 At CLI and daemon startup Kin validates this surface (`KIN_ENV_VALIDATION`, default `warn`):
 
@@ -87,6 +87,7 @@ Sensitivity legend: **correctness** (affects retrieval/ranking/output or data sa
 | `KIN_DAEMON_SCOPE_BUILD_TIMEOUT_SECS` | seconds>=0 | *(unset)* | operational | timeout for a daemon-side scope graph build |
 | `KIN_DAEMON_SHUTDOWN_GRACE_SECS` | seconds>=0 | 25 | operational | grace before the shutdown watchdog force-exits; 0 escalates immediately |
 | `KIN_DAEMON_STARTUP_LOCK_TIMEOUT_SECS` | seconds>=0 | *(unset)* | operational | how long to wait for the daemon startup lock |
+| `KIN_DAEMON_STOP_TIMEOUT_SECS` | seconds>=0 | 30 | operational | ceiling in seconds kin daemon stop waits for a signaled daemon to exit |
 | `KIN_DAEMON_URL` | url | *(unset)* | operational | explicit daemon endpoint URL (skip local discovery) |
 | `KIN_DAEMON_WATCH_PID` | usize | *(unset)* | operational | pid the daemon watches; it exits when that process dies |
 

--- a/docs/session-runtime.md
+++ b/docs/session-runtime.md
@@ -185,8 +185,8 @@ Kin makes that mismatch loud rather than fixing the value in place:
   current environment against that report and, on any divergence, print a
   warning to stderr naming each variable with both sides' values.
 - The remedy is to restart the daemon so it re-inherits the current environment:
-  stop it (`kill $(cat .kin/daemon.pid)`; it also self-stops after its
-  `KIN_DAEMON_IDLE_TIMEOUT_SECS` idle window) and the next `kin` command
+  stop it (`kin daemon stop`, or `kill $(cat .kin/daemon.pid)`; it also self-stops
+  after its `KIN_DAEMON_IDLE_TIMEOUT_SECS` idle window) and the next `kin` command
   respawns it.
 - Set `KIN_STRICT_BEHAVIOR_ENV=1` to escalate the warning to a hard error, so
   scripted and proof runs fail closed instead of measuring the wrong lever.


### PR DESCRIPTION
The daemon is mandatory-by-design and a per-user supervisor outlives every command, but there was no supported way to stop either short of an OS-level kill — the behavior-env divergence warning literally had to recommend kill-by-pid.

kin daemon status lists the supervisor (pid/port liveness-checked with stale-file detection) and all repo workers through the same supervisor surface the registry command reads — that plumbing is now shared rather than duplicated. kin daemon stop gracefully stops the current repo's worker (SIGTERM + bounded wait; neither the daemon nor supervisor exposes an HTTP shutdown route, and the daemon's own shutdown-escalation watchdog caps termination, so the wait is a ceiling); --all stops every worker then the supervisor last, exiting non-zero if anything survives. Endpoint files are cleared on confirmed stops. The divergence warning and the session-runtime docs now name the supported command.

Unit tests cover liveness classification, endpoint-file parsing, and stop semantics; a hermetic integration test drives the full lifecycle (autostart → status → stop → --all reaps the supervisor). kin-cli 659/659, clippy/fmt clean.