### PR TITLE
docs(cli): enumerate detected AI assistants in setup doc comment

### DIFF
--- a/crates/kin-cli/src/commands/setup.rs
+++ b/crates/kin-cli/src/commands/setup.rs
@@ -757,6 +757,14 @@ const IDX_CODEX: usize = 2;
 const IDX_GEMINI: usize = 3;
 const IDX_WINDSURF: usize = 4;
 
+/// Detect installed AI assistants eligible for MCP auto-configuration.
+///
+/// Detection heuristics per client:
+/// - Claude Code: `claude` binary on PATH
+/// - Cursor: `cursor` binary on PATH, or `/Applications/Cursor.app`
+/// - Codex CLI: `codex` binary on PATH
+/// - Gemini CLI: `gemini` binary on PATH, or `~/.gemini` directory
+/// - Windsurf: `windsurf` binary on PATH, or `/Applications/Windsurf.app`
 fn detect_ai_assistants() -> Vec<AiAssistant> {
     let claude_detected = check_binary_in_path("claude").is_some();
     let cursor_detected = check_binary_in_path("cursor").is_some()


### PR DESCRIPTION
Adds the missing doc comment on detect_ai_assistants() enumerating every currently-detected client and its real heuristic, read from the code: Claude Code (PATH), Cursor (PATH or /Applications/Cursor.app), Codex CLI (PATH), Gemini CLI (PATH or ~/.gemini), Windsurf (PATH or /Applications/Windsurf.app).

Closes FIR-1215.
