### PR TITLE
fix(docker,daemon): persistent workspace volume + EADDRINUSE bind retry

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -29,6 +29,11 @@ COPY --from=builder /build/kin/target/release/kin-daemon /usr/local/bin/kin-daem
 COPY --from=builder /build/kin/target/release/kin /usr/local/bin/kin
 COPY docker-entrypoint.sh /usr/local/bin/docker-entrypoint.sh
 RUN chmod +x /usr/local/bin/docker-entrypoint.sh
+# Pre-create the default workspace owned by the runtime user. Docker seeds a
+# freshly created named volume from the image path's ownership, so a volume
+# mounted here (see docker-compose.yml) stays writable by the non-root daemon;
+# without this the volume is created root-owned and the daemon cannot write it.
+RUN mkdir -p /tmp/kin-workspace && chown kin:kin /tmp/kin-workspace
 USER kin
 EXPOSE 4219
 ENTRYPOINT ["/usr/local/bin/docker-entrypoint.sh"]

--- a/crates/kin-daemon/src/api.rs
+++ b/crates/kin-daemon/src/api.rs
@@ -6,7 +6,7 @@ use std::io::Write;
 use std::net::{IpAddr, Ipv4Addr, SocketAddr, TcpListener as StdTcpListener};
 use std::path::{Component, Path as FsPath, PathBuf};
 use std::sync::{Arc, OnceLock};
-use std::time::Duration;
+use std::time::{Duration, Instant};
 
 use crate::state::{
     CachedLocateRanking, CachedSemanticPage, DaemonEvent, DaemonState, ProjectionChangedSet,
@@ -7501,16 +7501,44 @@ fn bind_listener(
         IpAddr::V4(_) => Domain::IPV4,
         IpAddr::V6(_) => Domain::IPV6,
     };
-    let socket = Socket::new(domain, Type::STREAM, Some(Protocol::TCP))?;
-    socket.set_reuse_address(true)?;
-    if matches!(bind_ip, IpAddr::V6(_)) {
-        socket.set_only_v6(false)?;
-    }
-    socket.bind(&address.into())?;
-    socket.listen(1024)?;
 
-    let listener: StdTcpListener = socket.into();
-    listener.set_nonblocking(true)?;
+    // A failed bind leaves the socket unusable, so each attempt builds a fresh
+    // one and configures it before binding.
+    let bind_once = || -> std::io::Result<StdTcpListener> {
+        let socket = Socket::new(domain, Type::STREAM, Some(Protocol::TCP))?;
+        socket.set_reuse_address(true)?;
+        if matches!(bind_ip, IpAddr::V6(_)) {
+            socket.set_only_v6(false)?;
+        }
+        socket.bind(&address.into())?;
+        socket.listen(1024)?;
+        let listener: StdTcpListener = socket.into();
+        listener.set_nonblocking(true)?;
+        Ok(listener)
+    };
+
+    // A daemon restarted on the same explicit port can race the kernel's
+    // teardown of the previous process's listening socket: on macOS the bind
+    // observes EADDRINUSE for a short window after the old daemon dies, because
+    // SO_REUSEADDR does not cover a socket still being reclaimed. Retry the bind
+    // with bounded backoff so a same-port restart recovers instead of failing;
+    // a port that stays held still fails loudly once the budget is spent. An
+    // ephemeral (`:0`) bind never collides, so it returns on the first attempt.
+    let deadline = Instant::now() + Duration::from_secs(3);
+    let mut backoff = Duration::from_millis(20);
+    let listener = loop {
+        match bind_once() {
+            Ok(listener) => break listener,
+            Err(error)
+                if error.kind() == std::io::ErrorKind::AddrInUse
+                    && Instant::now() + backoff < deadline =>
+            {
+                std::thread::sleep(backoff);
+                backoff = (backoff * 2).min(Duration::from_millis(250));
+            }
+            Err(error) => return Err(error),
+        }
+    };
     tokio::net::TcpListener::from_std(listener)
 }
 
@@ -10979,6 +11007,30 @@ mod tests {
         assert!(err
             .to_string()
             .contains("KIN_DAEMON_AUTH_TOKEN is required"));
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn bind_listener_recovers_from_transient_addr_in_use() {
+        // Occupy an explicit loopback port, then free it shortly after a
+        // competing bind begins. bind_listener must ride out the EADDRINUSE with
+        // its bounded backoff and succeed once the port is released — the same
+        // recovery a daemon restarted on a still-closing port depends on.
+        let held = std::net::TcpListener::bind("127.0.0.1:0").unwrap();
+        let port = held.local_addr().unwrap().port();
+
+        let releaser = std::thread::spawn(move || {
+            std::thread::sleep(Duration::from_millis(150));
+            drop(held); // frees the port well within bind_listener's 3s budget
+        });
+
+        // bind_listener retries with a blocking backoff; on the multi-threaded
+        // test runtime that briefly parks this worker while the releaser thread
+        // frees the port, after which the bind succeeds.
+        let listener = bind_listener("127.0.0.1", port, false)
+            .expect("bind_listener should recover once the held port is released");
+        assert_eq!(listener.local_addr().unwrap().port(), port);
+
+        releaser.join().unwrap();
     }
 
     #[tokio::test]

--- a/crates/kin-daemon/tests/chaos_recovery.rs
+++ b/crates/kin-daemon/tests/chaos_recovery.rs
@@ -41,6 +41,36 @@ fn assert_child_alive(child: &mut Child, port: u16, what: &str) {
     }
 }
 
+/// Wait for the daemon to publish its OS-assigned port to `.kin/daemon.port`
+/// and return it. Spawning with `--port 0` lets the daemon own port selection
+/// and advertise the real bound port here — the same handshake the CLI uses —
+/// so a kill/restart never depends on reusing one port's teardown timing.
+async fn read_published_port(child: &mut Child, repo_root: &Path) -> u16 {
+    let port_file = repo_root.join(".kin/daemon.port");
+    let deadline = Instant::now() + Duration::from_secs(30);
+    let mut backoff = Duration::from_millis(20);
+
+    loop {
+        if let Ok(contents) = std::fs::read_to_string(&port_file) {
+            if let Ok(port) = contents.trim().parse::<u16>() {
+                if port != 0 {
+                    return port;
+                }
+            }
+        }
+
+        if let Ok(Some(status)) = child.try_wait() {
+            panic!("daemon exited before publishing its port: {status}");
+        }
+        if Instant::now() >= deadline {
+            panic!("daemon never published its port to {}", port_file.display());
+        }
+
+        tokio::time::sleep(backoff).await;
+        backoff = backoff_after(backoff);
+    }
+}
+
 fn init_repo(root: &Path) {
     kin_core::init(root).unwrap();
 }
@@ -176,8 +206,15 @@ async fn daemon_recovers_after_process_kill_and_restart() {
     let repo = tempfile::tempdir().unwrap();
     init_repo(repo.path());
 
-    let port = free_port();
-    let mut child = spawn_daemon(repo.path(), port);
+    // Bind an OS-assigned port (`--port 0`) and discover it from the handshake
+    // file the daemon publishes, rather than pre-reserving an explicit port.
+    // This asserts recovery semantics — the daemon comes back and serves on the
+    // same repo — without depending on reusing the same port across the
+    // kill/restart, which races the kernel's socket teardown on macOS
+    // (EADDRINUSE). The product bind path additionally retries EADDRINUSE, so a
+    // real same-port restart also recovers.
+    let mut child = spawn_daemon(repo.path(), 0);
+    let port = read_published_port(&mut child, repo.path()).await;
 
     let first = wait_for_health(&mut child, port).await;
     assert_eq!(first.status, "ok");
@@ -193,8 +230,13 @@ async fn daemon_recovers_after_process_kill_and_restart() {
         "killed kin-daemon should not report success"
     );
 
-    let mut restarted = spawn_daemon(repo.path(), port);
-    let second = wait_for_health(&mut restarted, port).await;
+    // A SIGKILL leaves the dead daemon's port file behind; remove it so the read
+    // below observes the restarted daemon's freshly published port.
+    let _ = std::fs::remove_file(repo.path().join(".kin/daemon.port"));
+
+    let mut restarted = spawn_daemon(repo.path(), 0);
+    let restarted_port = read_published_port(&mut restarted, repo.path()).await;
+    let second = wait_for_health(&mut restarted, restarted_port).await;
     assert_eq!(second.status, "ok");
     assert!(second.uptime_seconds < 20);
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -13,7 +13,11 @@ services:
     ports:
       - "4219:4219"
     volumes:
-      - workspace-data:/workspace
+      # Persist the daemon's on-disk repo. The mount target must match the
+      # workspace the entrypoint resolves (KIN_WORKSPACE_DIR, default
+      # /tmp/kin-workspace); mounting anywhere else leaves the daemon writing to
+      # an ephemeral path and the named volume vestigial.
+      - workspace-data:/tmp/kin-workspace
     environment:
       - RUST_LOG=${RUST_LOG:-info}
     healthcheck:


### PR DESCRIPTION
Two independent fixes:

**docker-compose workspace volume** — the named volume mounted at /workspace while the entrypoint's default workspace is KIN_WORKSPACE_DIR=/tmp/kin-workspace, leaving daemon state on an ephemeral path and the volume vestigial. Repoints the mount to /tmp/kin-workspace and pre-creates it kin-owned in the image (a fresh named volume seeds ownership from the image path; without the chown it materializes root-owned and the non-root daemon cannot write). Validated: docker compose config renders the new target; docker build --check clean.

**daemon API bind retry** — a daemon restarted on the same explicit port can race the kernel's teardown of the previous listener and observe transient EADDRINUSE (SO_REUSEADDR does not cover a socket still being reclaimed, notably on macOS — the source of the flaky port-reuse CI test). bind_listener now retries with bounded backoff (3s budget, 20→250ms exponential), building a fresh socket per attempt; a genuinely held port still fails loudly. The chaos_recovery test is rewritten to a :0 published-port handshake asserting recovery semantics rather than racing a fixed port, plus a unit test that holds a port, releases it mid-retry, and asserts recovery. Soak: 50/50 green on macOS.

Closes FIR-1242. Closes FIR-1235.
