### PR TITLE
build(docker): apply security upgrades in the runtime image layer

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1144,7 +1144,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users 0.5.2",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -1253,7 +1253,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -3199,9 +3199,9 @@ dependencies = [
 
 [[package]]
 name = "kin-db"
-version = "0.2.27"
+version = "0.2.28"
 source = "sparse+https://kinlab.ai/registry/cargo/"
-checksum = "1e70164ad8fb11ca2ebfa1faa827c965753efbd1a01a16390fe98ab0f8569502"
+checksum = "29b7c18d93f5010b727254bf70648e92a4c2c980a51f25e1351b8875cf5f98e8"
 dependencies = [
  "bincode",
  "bytes",
@@ -4009,7 +4009,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -4504,7 +4504,7 @@ dependencies = [
  "once_cell",
  "socket2",
  "tracing",
- "windows-sys 0.60.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -4908,7 +4908,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -4967,7 +4967,7 @@ dependencies = [
  "security-framework 3.7.0",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -5544,7 +5544,7 @@ dependencies = [
  "getrandom 0.4.3",
  "once_cell",
  "rustix",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -6451,7 +6451,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -143,7 +143,7 @@ kin-lsp = { version = "0.2.1", registry = "kin" }
 # backend on every target (incl. Linux, where it cannot compile). Metal is re-enabled
 # additively on macOS via a `[target.'cfg(target_os = "macos")'.dependencies]` block in the
 # binary/runtime crates (kin-cli, kin-daemon). Feature unification makes that additive.
-kin-db = { version = "0.2.27", registry = "kin", default-features = false, features = ["vector", "embeddings"] }
+kin-db = { version = "0.2.28", registry = "kin", default-features = false, features = ["vector", "embeddings"] }
 kin-vfs-core = { version = "0.1.1", registry = "kin" }
 
 [profile.release]

--- a/Dockerfile
+++ b/Dockerfile
@@ -22,7 +22,7 @@ ENV CARGO_NET_RETRY=10
 RUN cargo build --release --features gcs --bin kin-daemon --bin kin
 
 FROM debian:trixie-slim
-RUN apt-get update && apt-get install -y ca-certificates curl libssl3 && rm -rf /var/lib/apt/lists/*
+RUN apt-get update && apt-get upgrade -y && apt-get install -y ca-certificates curl libssl3 && rm -rf /var/lib/apt/lists/*
 RUN groupadd -r kin && useradd -r -g kin kin
 WORKDIR /app
 COPY --from=builder /build/kin/target/release/kin-daemon /usr/local/bin/kin-daemon

--- a/crates/kin-cli/src/commands/cache.rs
+++ b/crates/kin-cli/src/commands/cache.rs
@@ -1,0 +1,352 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Firelock, LLC
+
+//! `kin cache` — inspect and bound the on-disk embedding cache.
+//!
+//! kin-db writes embedding vectors under `~/.kin/cache/embeddings` (or
+//! `$KIN_EMBED_CACHE_DIR`) and never evicts from the disk layer, so on a heavy
+//! bench/proof machine that tree grows without bound. These subcommands are the
+//! operator surface over the capacity policy that lives in
+//! [`kin_db::embed::cache_admin`]:
+//!
+//! - `kin cache status` reports size, entry count, per-schema-version breakdown,
+//!   and an age distribution, and warns loudly when a configured budget is
+//!   exceeded.
+//! - `kin cache gc` reclaims space: it can drop abandoned schema-version
+//!   subtrees and evict the oldest entries down to a byte budget.
+//!
+//! Eviction is **non-destructive by default**: with no budget configured (via
+//! `--budget-gb` or `KIN_EMBED_CACHE_BUDGET_GB`) and without
+//! `--prune-stale-schema`, `kin cache gc` deletes nothing and only reports. All
+//! deletion removes whole finalized entries (or whole abandoned subtrees), so a
+//! concurrent reader either sees the entry or takes a cache miss — never a
+//! corrupt read.
+
+use std::time::{Duration, SystemTime};
+
+use anyhow::Result;
+
+use kin_db::embed::cache_admin::{self, CacheStats, GcOptions, GcReport};
+
+/// Render a byte count as a short human-readable string.
+fn human_bytes(bytes: u64) -> String {
+    const UNITS: [&str; 6] = ["B", "KB", "MB", "GB", "TB", "PB"];
+    let mut value = bytes as f64;
+    let mut unit = 0;
+    while value >= 1024.0 && unit < UNITS.len() - 1 {
+        value /= 1024.0;
+        unit += 1;
+    }
+    if unit == 0 {
+        format!("{bytes} {}", UNITS[unit])
+    } else {
+        format!("{value:.1} {}", UNITS[unit])
+    }
+}
+
+/// Render a duration as a coarse age string (`3d`, `2h`, `5m`, `10s`).
+fn human_age(age: Duration) -> String {
+    let secs = age.as_secs();
+    if secs >= 86_400 {
+        format!("{}d", secs / 86_400)
+    } else if secs >= 3_600 {
+        format!("{}h", secs / 3_600)
+    } else if secs >= 60 {
+        format!("{}m", secs / 60)
+    } else {
+        format!("{secs}s")
+    }
+}
+
+/// Age of `t` relative to `now`, clamped at zero for clock skew.
+fn age_of(t: SystemTime, now: SystemTime) -> Duration {
+    now.duration_since(t).unwrap_or(Duration::ZERO)
+}
+
+/// Convert a `--budget-gb` flag / env value in gigabytes to bytes, rejecting
+/// non-positive or non-finite input the same way the env parser does.
+fn budget_gb_to_bytes(gb: f64) -> Option<u64> {
+    if !gb.is_finite() || gb <= 0.0 {
+        return None;
+    }
+    Some((gb * 1024.0 * 1024.0 * 1024.0) as u64)
+}
+
+/// Resolve the effective budget in bytes: an explicit `--budget-gb` flag wins,
+/// otherwise the `KIN_EMBED_CACHE_BUDGET_GB` environment default.
+fn resolve_budget(budget_gb: Option<f64>) -> Option<u64> {
+    match budget_gb {
+        Some(gb) => budget_gb_to_bytes(gb),
+        None => cache_admin::budget_bytes_from_env(),
+    }
+}
+
+/// `kin cache status [--json]` — report cache size, composition, and age.
+pub async fn status(json: bool) -> Result<()> {
+    let Some(base) = cache_admin::embedding_cache_base_dir() else {
+        println!("kin cache status: no cache directory resolved (no home directory and KIN_EMBED_CACHE_DIR unset)");
+        return Ok(());
+    };
+
+    let now = SystemTime::now();
+    let stats = cache_admin::scan_cache(&base, now);
+    let budget = cache_admin::budget_bytes_from_env();
+
+    if json {
+        print_status_json(&stats, budget, now);
+    } else {
+        print_status_human(&stats, budget, now);
+    }
+    Ok(())
+}
+
+fn print_status_human(stats: &CacheStats, budget: Option<u64>, now: SystemTime) {
+    println!("kin cache status");
+    println!("  location: {}", stats.base.display());
+
+    if stats.entry_count == 0 {
+        println!("  cache is empty");
+    } else {
+        println!(
+            "  size:     {} across {} entr{}",
+            human_bytes(stats.total_bytes),
+            stats.entry_count,
+            if stats.entry_count == 1 { "y" } else { "ies" }
+        );
+        if let (Some(oldest), Some(newest)) = (stats.oldest, stats.newest) {
+            println!(
+                "  age:      oldest {}, newest {}",
+                human_age(age_of(oldest, now)),
+                human_age(age_of(newest, now))
+            );
+        }
+
+        println!(
+            "  schema versions (current is {}):",
+            stats.current_schema_version
+        );
+        for sv in &stats.schema_versions {
+            let tag = if sv.is_current {
+                "current".to_string()
+            } else {
+                "stale — reclaim with: kin cache gc --prune-stale-schema".to_string()
+            };
+            println!(
+                "    {:<20} {:>10}  {:>12} entries  ({tag})",
+                sv.version,
+                human_bytes(sv.bytes),
+                sv.entry_count
+            );
+        }
+
+        println!("  age distribution:");
+        for bucket in &stats.age_buckets {
+            if bucket.entry_count == 0 {
+                continue;
+            }
+            println!(
+                "    {:<8} {:>10}  {:>12} entries",
+                bucket.label,
+                human_bytes(bucket.bytes),
+                bucket.entry_count
+            );
+        }
+    }
+
+    match budget {
+        Some(budget_bytes) => {
+            println!(
+                "  budget:   {} ({})",
+                human_bytes(budget_bytes),
+                cache_admin::BUDGET_ENV
+            );
+            if stats.total_bytes > budget_bytes {
+                let over = stats.total_bytes - budget_bytes;
+                println!(
+                    "  WARNING: cache is OVER BUDGET by {} — run `kin cache gc` to reclaim space",
+                    human_bytes(over)
+                );
+            } else {
+                println!("  within budget");
+            }
+        }
+        None => {
+            println!(
+                "  budget:   not set — eviction is opt-in (set {} or pass `kin cache gc --budget-gb N`)",
+                cache_admin::BUDGET_ENV
+            );
+        }
+    }
+}
+
+fn print_status_json(stats: &CacheStats, budget: Option<u64>, now: SystemTime) {
+    let schema_versions: Vec<_> = stats
+        .schema_versions
+        .iter()
+        .map(|sv| {
+            serde_json::json!({
+                "version": sv.version,
+                "bytes": sv.bytes,
+                "entry_count": sv.entry_count,
+                "is_current": sv.is_current,
+            })
+        })
+        .collect();
+    let age_buckets: Vec<_> = stats
+        .age_buckets
+        .iter()
+        .map(|b| {
+            serde_json::json!({
+                "label": b.label,
+                "bytes": b.bytes,
+                "entry_count": b.entry_count,
+            })
+        })
+        .collect();
+    let payload = serde_json::json!({
+        "base": stats.base.display().to_string(),
+        "total_bytes": stats.total_bytes,
+        "entry_count": stats.entry_count,
+        "oldest_age_secs": stats.oldest.map(|t| age_of(t, now).as_secs()),
+        "newest_age_secs": stats.newest.map(|t| age_of(t, now).as_secs()),
+        "current_schema_version": stats.current_schema_version,
+        "stale_schema_bytes": stats.stale_schema_bytes(),
+        "schema_versions": schema_versions,
+        "age_buckets": age_buckets,
+        "budget_bytes": budget,
+        "over_budget": budget.is_some_and(|b| stats.total_bytes > b),
+    });
+    println!(
+        "{}",
+        serde_json::to_string_pretty(&payload).unwrap_or_default()
+    );
+}
+
+/// `kin cache gc [--dry-run] [--budget-gb N] [--prune-stale-schema]` — reclaim
+/// space from the embedding cache.
+pub async fn gc(dry_run: bool, budget_gb: Option<f64>, prune_stale_schema: bool) -> Result<()> {
+    let Some(base) = cache_admin::embedding_cache_base_dir() else {
+        println!("kin cache gc: no cache directory resolved (no home directory and KIN_EMBED_CACHE_DIR unset)");
+        return Ok(());
+    };
+
+    let budget_bytes = resolve_budget(budget_gb);
+
+    if budget_bytes.is_none() && !prune_stale_schema {
+        println!("kin cache gc: nothing to do — non-destructive default.");
+        println!(
+            "  set a budget (`--budget-gb N` or {}) to evict oldest entries,",
+            cache_admin::BUDGET_ENV
+        );
+        println!("  and/or pass `--prune-stale-schema` to drop abandoned schema-version subtrees.");
+        println!("  `kin cache status` shows current size.");
+        return Ok(());
+    }
+
+    let report = cache_admin::gc_cache(
+        &base,
+        GcOptions {
+            budget_bytes,
+            prune_stale_schema,
+            dry_run,
+        },
+        SystemTime::now(),
+    );
+
+    print_gc_report(&report);
+    Ok(())
+}
+
+fn print_gc_report(report: &GcReport) {
+    let verb = if report.dry_run {
+        "would reclaim"
+    } else {
+        "reclaimed"
+    };
+    println!(
+        "kin cache gc{}: {} across the cache at {}",
+        if report.dry_run { " (dry run)" } else { "" },
+        human_bytes(report.total_bytes_before),
+        report.base.display()
+    );
+
+    if !report.stale_schema_versions_removed.is_empty() {
+        let verb = if report.dry_run {
+            "would drop"
+        } else {
+            "dropped"
+        };
+        println!(
+            "  {verb} {} abandoned schema version(s) [{}]: {}",
+            report.stale_schema_versions_removed.len(),
+            human_bytes(report.stale_schema_bytes),
+            report.stale_schema_versions_removed.join(", ")
+        );
+    }
+
+    if let Some(budget) = report.budget_bytes {
+        if report.over_budget {
+            let verb = if report.dry_run {
+                "would evict"
+            } else {
+                "evicted"
+            };
+            println!(
+                "  over budget ({}): {verb} {} oldest entr{} ({})",
+                human_bytes(budget),
+                report.evicted_entries,
+                if report.evicted_entries == 1 {
+                    "y"
+                } else {
+                    "ies"
+                },
+                human_bytes(report.evicted_bytes)
+            );
+        } else {
+            println!(
+                "  within budget ({}) — no entries evicted",
+                human_bytes(budget)
+            );
+        }
+    }
+
+    println!(
+        "kin cache gc: {verb} {} total{}",
+        human_bytes(report.reclaimed_bytes()),
+        if report.dry_run {
+            ". Re-run without --dry-run to delete."
+        } else {
+            ""
+        }
+    );
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn human_bytes_formats_units() {
+        assert_eq!(human_bytes(512), "512 B");
+        assert_eq!(human_bytes(1536), "1.5 KB");
+        assert_eq!(human_bytes(1024 * 1024 * 1024), "1.0 GB");
+    }
+
+    #[test]
+    fn human_age_formats_coarsely() {
+        assert_eq!(human_age(Duration::from_secs(5)), "5s");
+        assert_eq!(human_age(Duration::from_secs(120)), "2m");
+        assert_eq!(human_age(Duration::from_secs(7_200)), "2h");
+        assert_eq!(human_age(Duration::from_secs(3 * 86_400)), "3d");
+    }
+
+    #[test]
+    fn budget_flag_overrides_and_validates() {
+        assert_eq!(budget_gb_to_bytes(1.0), Some(1024 * 1024 * 1024));
+        assert_eq!(budget_gb_to_bytes(0.0), None);
+        assert_eq!(budget_gb_to_bytes(-1.0), None);
+        assert_eq!(budget_gb_to_bytes(f64::NAN), None);
+        // Explicit flag wins over env resolution.
+        assert_eq!(resolve_budget(Some(2.0)), Some(2 * 1024 * 1024 * 1024));
+    }
+}

--- a/crates/kin-cli/src/commands/mod.rs
+++ b/crates/kin-cli/src/commands/mod.rs
@@ -11,6 +11,7 @@ pub mod bench_meta;
 pub mod blame;
 pub mod branch;
 pub mod branch_bootstrap;
+pub mod cache;
 pub mod checkout;
 pub mod clone;
 pub mod cochange;

--- a/crates/kin-cli/src/main.rs
+++ b/crates/kin-cli/src/main.rs
@@ -689,6 +689,11 @@ enum Command {
         #[arg(long)]
         resume: bool,
     },
+    /// Inspect and bound the on-disk embedding cache
+    Cache {
+        #[command(subcommand)]
+        action: CacheAction,
+    },
     /// Reclaim space from the global ~/.kin warm-start cache
     Gc {
         /// Report what would be reclaimed without deleting anything
@@ -1036,6 +1041,29 @@ enum GraphAction {
         /// Open the visualization in the system default browser
         #[arg(long, default_value_t = false)]
         open: bool,
+    },
+}
+
+#[derive(Subcommand)]
+enum CacheAction {
+    /// Report embedding-cache size, composition, and age distribution
+    Status {
+        /// Output machine-readable JSON instead of a human summary
+        #[arg(long, default_value_t = false)]
+        json: bool,
+    },
+    /// Reclaim space: drop abandoned schema versions and/or evict oldest entries to a budget
+    Gc {
+        /// Report what would be reclaimed without deleting anything
+        #[arg(long)]
+        dry_run: bool,
+        /// Evict the oldest entries until the cache fits this many gigabytes.
+        /// Overrides KIN_EMBED_CACHE_BUDGET_GB; unset means no budget eviction.
+        #[arg(long, value_name = "GB")]
+        budget_gb: Option<f64>,
+        /// Also remove every abandoned (non-current) schema-version subtree
+        #[arg(long)]
+        prune_stale_schema: bool,
     },
 }
 
@@ -2517,6 +2545,14 @@ fn main() -> Result<()> {
                     depth,
                     resume,
                 } => commands::migrate::run(source, depth, resume).await,
+                Command::Cache { action } => match action {
+                    CacheAction::Status { json } => commands::cache::status(json).await,
+                    CacheAction::Gc {
+                        dry_run,
+                        budget_gb,
+                        prune_stale_schema,
+                    } => commands::cache::gc(dry_run, budget_gb, prune_stale_schema).await,
+                },
                 Command::Gc {
                     dry_run,
                     max_age_days,

--- a/crates/kin-core/src/env_registry.rs
+++ b/crates/kin-core/src/env_registry.rs
@@ -310,6 +310,7 @@ pub const DOWNSTREAM: &[EnvVarSpec] = &[
     EnvVarSpec { name: "KIN_EMBED_HYBRID_GPU_TPUT_RATIO", kind: Kind::NonNegF32, default: "", sensitivity: Sensitivity::Correctness, summary: "kin-db hybrid split ratio: pins the GPU:CPU throughput ratio for the balanced split; unset (or <= 0) measures it adaptively per batch" },
     // ---- kin-db: embedding cache (perf/lifecycle, identical vectors) ----------
     EnvVarSpec { name: "KIN_EMBED_CACHE", kind: Kind::Bool, default: "true", sensitivity: Sensitivity::Operational, summary: "kin-db on-disk embedding cache; set to 0 to disable and always recompute (only the literal '0' disables), default on" },
+    EnvVarSpec { name: "KIN_EMBED_CACHE_BUDGET_GB", kind: Kind::NonNegF32, default: "", sensitivity: Sensitivity::Operational, summary: "kin-db on-disk embedding cache disk budget in GB for `kin cache gc`; unset (default) evicts nothing — the cache is pruned only by an explicit budget or command" },
     EnvVarSpec { name: "KIN_EMBED_CACHE_DIR", kind: Kind::Path, default: "", sensitivity: Sensitivity::Operational, summary: "kin-db on-disk embedding cache directory; unset uses ~/.kin/cache/embeddings" },
     // ---- kin-vfs shim: projection bypass --------------------------------------
     EnvVarSpec { name: "KIN_NO_VFS", kind: Kind::Bool, default: "false", sensitivity: Sensitivity::Operational, summary: "kin-vfs shim projection bypass: set to 1 to skip VFS initialization and exec the real binary directly (only the literal '1' bypasses), default off" },

--- a/docs/env-vars.md
+++ b/docs/env-vars.md
@@ -3,7 +3,7 @@
 
 # Kin environment variables
 
-This is the authoritative list of supported `KIN_*` environment variables (384 total, 290 correctness-relevant), generated from the central registry in `kin-core`.
+This is the authoritative list of supported `KIN_*` environment variables (385 total, 290 correctness-relevant), generated from the central registry in `kin-core`.
 
 At CLI and daemon startup Kin validates this surface (`KIN_ENV_VALIDATION`, default `warn`):
 
@@ -126,6 +126,7 @@ Sensitivity legend: **correctness** (affects retrieval/ranking/output or data sa
 | --- | --- | --- | --- | --- |
 | `KIN_EMBED_BACKEND` | enum | auto | correctness | kin-db embedding compute backend: auto (default) uses batched Metal, 'cpu' forces the SIMD/pure path, 'metal'/'gpu' forces Metal; cpu vs metal shifts embeddings in the last ULPs |
 | `KIN_EMBED_CACHE` | bool | true | operational | kin-db on-disk embedding cache; set to 0 to disable and always recompute (only the literal '0' disables), default on |
+| `KIN_EMBED_CACHE_BUDGET_GB` | float>=0 | *(unset)* | operational | kin-db on-disk embedding cache disk budget in GB for `kin cache gc`; unset (default) evicts nothing — the cache is pruned only by an explicit budget or command |
 | `KIN_EMBED_CACHE_DIR` | path | *(unset)* | operational | kin-db on-disk embedding cache directory; unset uses ~/.kin/cache/embeddings |
 | `KIN_EMBED_HTTP_TIMEOUT_SECS` | seconds>=0 | *(unset)* | operational | HTTP timeout for the embedding service client |
 | `KIN_EMBED_HYBRID` | string | off | correctness | kin-db hybrid CPU/GPU embedding split: off (default), 'seq'/'floor' for the sequence-length floor, or any other truthy value for the balanced split; engaging the CPU twin computes some vectors off the Metal device |


### PR DESCRIPTION
The runtime stage installs packages on debian:trixie-slim but never applies pending security updates, so any fix Debian publishes after the base snapshot is missed until the base tag itself moves. Adds apt-get upgrade -y to the runtime layer — the now-working kin-infra Trivy gate flagged libssh2 CVE-2026-55199 (DoS, fixed in 1.11.1-1+deb13u1) as fixable-but-unapplied in the deployed image; this picks that up and every future u-release at build time.
