### PR TITLE
test(parser,index): Python call-resolution regression net

### DIFF
--- a/crates/kin-index/tests/python_call_resolution.rs
+++ b/crates/kin-index/tests/python_call_resolution.rs
@@ -1,0 +1,124 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Firelock, LLC
+
+//! Cross-file arm of the Python call-resolution regression net.
+//!
+//! The extractor narrows Python attribute callees to their leaf name
+//! (`module.func()` -> `func`, `obj.method()` -> `method`); this test drives the
+//! real parser -> real linker pipeline to prove that the narrowed simple name
+//! resolves to the *actual* target entity defined in another file. The
+//! same-file extraction arm (leaf-name narrowing, import_source, and the
+//! nesting-recursion pin) lives in `kin-parser/tests/python_call_resolution.rs`;
+//! together they cover {bare call, module-attribute call, method call} x
+//! {same-file, cross-file}.
+
+use kin_index::{link_cross_file, FileParseData};
+use kin_model::{Entity, EntityId, FilePathId, RelationKind};
+use kin_parser::{LanguageAdapter, PythonAdapter};
+
+fn parse_py(file_path: &str, source: &str) -> FileParseData {
+    let adapter = PythonAdapter;
+    let file_id = FilePathId::new(file_path);
+    let bytes = source.as_bytes();
+    let tree = adapter.parse(bytes).expect("parse");
+    let output = adapter.extract(&tree, bytes, &file_id).expect("extract");
+
+    let entities: Vec<Entity> = output
+        .entities
+        .into_iter()
+        .map(|e| e.into_entity_with_source(adapter.language_id(), &file_id, Some(bytes)))
+        .collect();
+
+    FileParseData {
+        file_path: file_path.to_string(),
+        entities,
+        relations: output.relations,
+        imports: output.imports,
+    }
+}
+
+/// EntityId of the entity named `name` originating in `file`, across all files.
+fn entity_id(files: &[FileParseData], file: &str, name: &str) -> EntityId {
+    files
+        .iter()
+        .flat_map(|f| f.entities.iter())
+        .find(|e| e.name == name && e.file_origin.as_ref().map(|p| p.0.as_str()) == Some(file))
+        .unwrap_or_else(|| panic!("entity `{name}` in `{file}` not found"))
+        .id
+}
+
+fn has_call(relations: &[kin_model::Relation], src: EntityId, dst: EntityId) -> bool {
+    relations.iter().any(|r| {
+        r.kind == RelationKind::Calls
+            && r.src.as_entity() == Some(src)
+            && r.dst.as_entity() == Some(dst)
+    })
+}
+
+#[test]
+fn cross_file_bare_call_with_import_resolves() {
+    // caller.py imports and calls a free function defined in helpers.py.
+    let files = vec![
+        parse_py(
+            "caller.py",
+            "from helpers import compute\n\ndef run():\n    compute()\n",
+        ),
+        parse_py("helpers.py", "def compute():\n    return 1\n"),
+    ];
+
+    let run = entity_id(&files, "caller.py", "run");
+    let compute = entity_id(&files, "helpers.py", "compute");
+
+    let relations = link_cross_file(&files);
+    assert!(
+        has_call(&relations, run, compute),
+        "bare imported call `compute()` should resolve run -> helpers.py::compute"
+    );
+}
+
+#[test]
+fn cross_file_module_attribute_call_resolves() {
+    // caller.py calls `mathlib.compute()`; the leaf `compute` must resolve to
+    // the function defined in mathlib.py.
+    let files = vec![
+        parse_py(
+            "caller.py",
+            "import mathlib\n\ndef run():\n    mathlib.compute()\n",
+        ),
+        parse_py("mathlib.py", "def compute():\n    return 2\n"),
+    ];
+
+    let run = entity_id(&files, "caller.py", "run");
+    let compute = entity_id(&files, "mathlib.py", "compute");
+
+    let relations = link_cross_file(&files);
+    assert!(
+        has_call(&relations, run, compute),
+        "module-attribute call `mathlib.compute()` should resolve run -> mathlib.py::compute"
+    );
+}
+
+#[test]
+fn cross_file_method_call_on_instance_resolves() {
+    // caller.py builds a Service and calls `svc.process()`; the leaf `process`
+    // must resolve to the method Service.process defined in service.py.
+    let files = vec![
+        parse_py(
+            "caller.py",
+            "from service import Service\n\ndef run():\n    svc = Service()\n    svc.process()\n",
+        ),
+        parse_py(
+            "service.py",
+            "class Service:\n    def process(self):\n        return 3\n",
+        ),
+    ];
+
+    let run = entity_id(&files, "caller.py", "run");
+    let process = entity_id(&files, "service.py", "Service.process");
+
+    let relations = link_cross_file(&files);
+    assert!(
+        has_call(&relations, run, process),
+        "method call `svc.process()` should resolve run -> service.py::Service.process"
+    );
+}

--- a/crates/kin-parser/tests/python_call_resolution.rs
+++ b/crates/kin-parser/tests/python_call_resolution.rs
@@ -1,0 +1,308 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Firelock, LLC
+
+//! Regression net for Python call-resolution.
+//!
+//! Python is the only call-extracting adapter that previously had no dedicated
+//! call-resolution test, even though every other one (Go, JS/TS, Kotlin, Swift,
+//! C++ qualified-name) does. This file closes that gap.
+//!
+//! Python narrows attribute callees to their **leaf name at extraction time**:
+//! `module.func()`, `obj.method()`, and `self.member.save()` all emit a `Calls`
+//! edge whose `dst_name` is the trailing identifier (`func`, `method`, `save`),
+//! never the dotted form. Because the parser already hands the linker a simple
+//! name, name-based cross-file resolution matches the target's own simple name —
+//! so the qualified-callee gap that let dotted `dst_name`s slip past resolution
+//! in other adapters never applied to Python. These tests are the regression net
+//! that keeps it that way; they would already have been green before that
+//! resolution work landed.
+//!
+//! Same-file extraction (entities + `Calls` `dst_name`s) is asserted here. The
+//! cross-file dimension of the matrix — the same three call shapes resolving to
+//! an entity in another file through the real linker — lives in
+//! `kin-index/tests/python_call_resolution.rs`, since cross-file linking is a
+//! kin-index responsibility.
+//!
+//! Matrix (same-file arm):
+//!   * bare call (`target()`), with and without an import binding
+//!   * module-attribute call (`module.func()`) — narrowed to `func`
+//!   * method call on an instance (`obj.method()`) — narrowed to `method`
+//!   * nesting recursion: calls inside nested `def`s and inside class methods
+//!     attribute to the innermost *enclosing function entity* (nested `def`s
+//!     produce no entity of their own, so their calls roll up to the method or
+//!     top-level function that encloses them).
+
+use kin_model::{EntityKind, FilePathId, RelationKind};
+use kin_parser::{ExtractedRelation, LanguageAdapter, ParseOutput, PythonAdapter};
+
+fn extract(source: &str) -> ParseOutput {
+    let adapter = PythonAdapter;
+    let bytes = source.as_bytes();
+    let tree = adapter.parse(bytes).expect("parse should succeed");
+    let file_id = FilePathId::new("test/calls.py");
+    adapter
+        .extract(&tree, bytes, &file_id)
+        .expect("extract should succeed")
+}
+
+fn calls(output: &ParseOutput) -> Vec<&ExtractedRelation> {
+    output
+        .relations
+        .iter()
+        .filter(|r| r.kind == RelationKind::Calls)
+        .collect()
+}
+
+fn calls_named<'a>(output: &'a ParseOutput, name: &str) -> Vec<&'a ExtractedRelation> {
+    calls(output)
+        .into_iter()
+        .filter(|r| r.dst_name == name)
+        .collect()
+}
+
+fn has_entity(output: &ParseOutput, kind: EntityKind, name: &str) -> bool {
+    output
+        .entities
+        .iter()
+        .any(|e| e.kind == kind && e.name == name)
+}
+
+const CALLS_FIXTURE: &[u8] = include_bytes!("../../../tests/adapter-fixtures/python/calls.py");
+
+// ---- bare calls ----
+
+#[test]
+fn bare_call_emits_identifier_name() {
+    let output = extract("def target():\n    pass\n\ndef caller():\n    target()\n");
+    let hits = calls_named(&output, "target");
+    assert_eq!(
+        hits.len(),
+        1,
+        "expected exactly one Calls edge named 'target', got {:?}",
+        calls(&output)
+    );
+    assert_eq!(hits[0].src_name, "caller");
+    assert!(
+        hits[0].import_source.is_none(),
+        "a locally-defined callee carries no import source, got {:?}",
+        hits[0].import_source
+    );
+    assert!(has_entity(&output, EntityKind::Function, "caller"));
+    assert!(has_entity(&output, EntityKind::Function, "target"));
+}
+
+#[test]
+fn bare_call_with_import_carries_import_source() {
+    // `from helpers import compute` binds the simple name `compute`, so the
+    // extractor annotates the `compute()` edge with its module of origin.
+    let output = extract("from helpers import compute\n\ndef caller():\n    compute()\n");
+    let hits = calls_named(&output, "compute");
+    assert_eq!(
+        hits.len(),
+        1,
+        "expected exactly one Calls edge named 'compute', got {:?}",
+        calls(&output)
+    );
+    assert_eq!(hits[0].src_name, "caller");
+    assert_eq!(
+        hits[0].import_source.as_deref(),
+        Some("helpers"),
+        "an imported bare callee carries its import path as import_source"
+    );
+}
+
+// ---- module-attribute calls ----
+
+#[test]
+fn module_attribute_call_narrows_to_leaf_name() {
+    // `mathlib.compute()` narrows to the leaf `compute`. The dotted form must
+    // never survive, and because narrowing drops the `mathlib` binding the leaf
+    // name is not an imported name, so it carries no import_source.
+    let output = extract("import mathlib\n\ndef caller():\n    mathlib.compute()\n");
+    let hits = calls_named(&output, "compute");
+    assert_eq!(
+        hits.len(),
+        1,
+        "expected leaf-name edge 'compute' (not 'mathlib.compute'), got {:?}",
+        calls(&output)
+    );
+    assert_eq!(hits[0].src_name, "caller");
+    assert!(
+        hits[0].import_source.is_none(),
+        "leaf name is not the imported binding `mathlib`, so no import_source"
+    );
+    assert!(
+        !calls(&output).iter().any(|r| r.dst_name.contains('.')),
+        "dotted form must not appear as a Calls dst_name, got {:?}",
+        calls(&output)
+    );
+}
+
+// ---- method calls on an instance ----
+
+#[test]
+fn method_call_on_instance_narrows_to_leaf_name() {
+    let output = extract(
+        "class Service:\n    def run(self):\n        pass\n\ndef driver():\n    svc = Service()\n    svc.run()\n",
+    );
+    let run_hits = calls_named(&output, "run");
+    assert!(
+        run_hits.iter().any(|r| r.src_name == "driver"),
+        "expected driver -> run (from `svc.run()`), got {:?}",
+        calls(&output)
+    );
+    // Constructor call `Service()` is a plain identifier callee.
+    assert!(
+        calls_named(&output, "Service")
+            .iter()
+            .any(|r| r.src_name == "driver"),
+        "expected driver -> Service (constructor), got {:?}",
+        calls(&output)
+    );
+    assert!(
+        !calls(&output).iter().any(|r| r.dst_name.contains('.')),
+        "no Calls dst_name may be dotted (e.g. 'svc.run'), got {:?}",
+        calls(&output)
+    );
+    assert!(has_entity(&output, EntityKind::Method, "Service.run"));
+}
+
+// ---- nesting recursion ----
+
+#[test]
+fn nested_def_calls_attribute_to_innermost_enclosing_function() {
+    // `inner` is a nested def and gets no entity of its own, so the innermost
+    // enclosing *entity* for both `leaf()` and `inner()` is `outer`.
+    let output = extract("def outer():\n    def inner():\n        leaf()\n    inner()\n");
+
+    assert!(has_entity(&output, EntityKind::Function, "outer"));
+    assert!(
+        !has_entity(&output, EntityKind::Function, "inner"),
+        "a nested def must not produce its own function entity"
+    );
+
+    assert!(
+        calls_named(&output, "leaf")
+            .iter()
+            .all(|r| r.src_name == "outer"),
+        "call inside the nested def must attribute to the enclosing entity `outer`, got {:?}",
+        calls(&output)
+    );
+    assert!(
+        !calls_named(&output, "leaf").is_empty(),
+        "the call inside the nested def must not be dropped, got {:?}",
+        calls(&output)
+    );
+    assert!(
+        calls_named(&output, "inner")
+            .iter()
+            .any(|r| r.src_name == "outer"),
+        "the call to the nested def itself attributes to `outer`, got {:?}",
+        calls(&output)
+    );
+    assert!(
+        !calls(&output).iter().any(|r| r.src_name == "inner"),
+        "no call may attribute to the entity-less nested def `inner`, got {:?}",
+        calls(&output)
+    );
+}
+
+#[test]
+fn class_method_nested_def_calls_attribute_to_method_entity() {
+    // A class method that wraps a nested def: both the method's own call and the
+    // call inside the nested def roll up to the method entity `Holder.method`.
+    let output = extract(
+        "class Holder:\n    def method(self):\n        def nested():\n            deep()\n        nested()\n",
+    );
+
+    assert!(has_entity(&output, EntityKind::Method, "Holder.method"));
+    assert!(
+        !has_entity(&output, EntityKind::Function, "nested"),
+        "a nested def inside a method must not produce its own entity"
+    );
+
+    assert!(
+        calls_named(&output, "deep")
+            .iter()
+            .all(|r| r.src_name == "Holder.method"),
+        "call inside the method's nested def attributes to `Holder.method`, got {:?}",
+        calls(&output)
+    );
+    assert!(
+        !calls_named(&output, "deep").is_empty(),
+        "the deeply-nested call must not be dropped, got {:?}",
+        calls(&output)
+    );
+    assert!(
+        calls_named(&output, "nested")
+            .iter()
+            .any(|r| r.src_name == "Holder.method"),
+        "the method's call to its nested def attributes to `Holder.method`, got {:?}",
+        calls(&output)
+    );
+}
+
+// ---- fixture: every Calls dst_name is a simple leaf identifier ----
+
+#[test]
+fn fixture_calls_are_all_leaf_names() {
+    let adapter = PythonAdapter;
+    let tree = adapter.parse(CALLS_FIXTURE).expect("parse fixture");
+    let file_id = FilePathId::new("adapter-fixtures/python/calls.py");
+    let output = adapter
+        .extract(&tree, CALLS_FIXTURE, &file_id)
+        .expect("extract fixture");
+    let call_edges = calls(&output);
+
+    // Regression invariant: attribute/method callees are always narrowed, so a
+    // dotted dst_name would mean the narrowing broke.
+    let dotted: Vec<&str> = call_edges
+        .iter()
+        .map(|r| r.dst_name.as_str())
+        .filter(|n| n.contains('.'))
+        .collect();
+    assert!(
+        dotted.is_empty(),
+        "Calls dst_names must be simple identifiers, but got dotted: {:?}",
+        dotted
+    );
+
+    // Every call shape in the matrix is represented as a leaf name.
+    for expected in &[
+        "handler",       // bare call in plain()
+        "add_url_rule",  // attribute call on a local (app.add_url_rule)
+        "query",         // chained attribute call (db.session.query())
+        "save",          // attribute call on an instance member (self.store.save)
+        "validate",      // self-call (self.validate)
+        "Store",         // constructor call
+        "route",         // decorator call @app.route(...)
+        "requires_auth", // bare decorator @requires_auth
+    ] {
+        assert!(
+            call_edges.iter().any(|r| r.dst_name == *expected),
+            "fixture should produce a Calls edge to '{}', got {:?}",
+            expected,
+            call_edges.iter().map(|r| &r.dst_name).collect::<Vec<_>>()
+        );
+    }
+
+    // Spot-check source attribution for representative shapes.
+    assert!(
+        call_edges
+            .iter()
+            .any(|r| r.src_name == "plain" && r.dst_name == "handler"),
+        "expected plain -> handler"
+    );
+    assert!(
+        call_edges
+            .iter()
+            .any(|r| r.src_name == "Service.process" && r.dst_name == "save"),
+        "expected Service.process -> save (from self.store.save)"
+    );
+    assert!(
+        call_edges
+            .iter()
+            .any(|r| r.src_name == "home" && r.dst_name == "route"),
+        "expected home -> route (from the @app.route decorator)"
+    );
+}


### PR DESCRIPTION
Python was the only language adapter with call extraction but no dedicated call-resolution test file — the exact coverage condition that let the Rust qualified-call gap survive undetected. Adds the standard matrix mirrored from the Go/JS family: {bare-with-import, module.attribute, method-on-instance} × {same-file, cross-file} through the real parser→linker pipeline, plus nesting pins (calls in nested defs and class methods attribute to the innermost enclosing entity) and a fixture-driven no-dotted-dst-names assertion. The module doc records that Python narrows attribute calls to leaf names at extraction — the value here is the regression net.

kin-parser suite 269 across bins + kin-index 176 across bins, all green; the 10 new tests pass; fmt/clippy clean.

Closes FIR-1257.
