### PR TITLE
chore: lock kin-vector 0.1.6 and kin-infer 0.2.40

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3279,9 +3279,9 @@ dependencies = [
 
 [[package]]
 name = "kin-infer"
-version = "0.2.38"
+version = "0.2.40"
 source = "sparse+https://kinlab.ai/registry/cargo/"
-checksum = "4c025d1d3f9f57340298c18205fa6eec1cc25644ade3790eeda5c6cf0b3091c3"
+checksum = "97fd7176da2b74e8e261285856d812f917b35a7e13eab7c2589e1868652f94a1"
 dependencies = [
  "block",
  "half",
@@ -3609,9 +3609,9 @@ dependencies = [
 
 [[package]]
 name = "kin-vector"
-version = "0.1.4"
+version = "0.1.6"
 source = "sparse+https://kinlab.ai/registry/cargo/"
-checksum = "66280d81b3a20f465351aa9cab72e63d4eff8643bb30314e1beca369b564b732"
+checksum = "4a0675c99c00faf3fd2a8cb71f73513677daef4fb35b2eb7d300da07f4990550"
 dependencies = [
  "fs2",
  "hashbrown 0.15.5",


### PR DESCRIPTION
The pins wave for today's releases: kin-vector 0.1.6 (SIMD kernel default-ON — unset→enabled, 0/false/no/off→scalar) and kin-infer 0.2.40 (cgroup-aware ResourcePlan detection). Lock-only re-lock per this repo's established convention for these two crates (exact versions are lock-driven; the kin-infer >=0.2.1 floor and kin-db caret pins are untouched) — kin-vector rides transitively via kin-db/kin-model constraints. Both lock entries verified registry source + checksum, patch-off; two unrelated crates.io downgrades cargo attempted during re-resolution were surgically reverted so the diff is exactly the two kin crates.

Full workspace validation under --locked and -D warnings: build green, 2676 tests passed / 0 failed / 3 by-design-ignored across 59 binaries, clippy CI-allowlist clean, zero new warnings — SIMD-on and cgroup detection are behavior-compatible for kin's consumers.
