### PR TITLE
fix(review): deterministic ordering for emitted diff changes and finding representatives

### DIFF
--- a/crates/kin-review/src/diff.rs
+++ b/crates/kin-review/src/diff.rs
@@ -91,6 +91,18 @@ impl SemanticDiff {
     }
 }
 
+/// Stable ordering key for a relation change. Relation deltas are accumulated
+/// through HashMaps whose iteration order is not stable, so emitted diffs sort
+/// on this key to stay byte-identical across repeated runs. A relation id is
+/// unique to a single add-or-remove within one diff, so the id alone totally
+/// orders the set.
+fn relation_change_key(change: &RelationChange) -> String {
+    match &change.kind {
+        RelationChangeKind::Added(rel) => rel.id.to_string(),
+        RelationChangeKind::Removed(id) => id.to_string(),
+    }
+}
+
 /// Compute a semantic diff between two change IDs by collecting all
 /// intermediate changes from the graph store.
 pub fn compute_diff<G: GraphStore>(
@@ -166,10 +178,16 @@ pub fn compute_diff<G: GraphStore>(
         }
     }
 
-    diff.entity_changes = entity_states
+    // `entity_states` is a HashMap, so its iteration order is not stable across
+    // runs. Emit entity changes in a deterministic entity-id order so every
+    // downstream consumer (findings, inline comments, JSON payloads) is
+    // byte-identical across repeated evaluations of the same change.
+    let mut entity_changes: Vec<EntityChange> = entity_states
         .into_iter()
         .map(|(entity_id, kind)| EntityChange { entity_id, kind })
         .collect();
+    entity_changes.sort_by_key(|change| change.entity_id);
+    diff.entity_changes = entity_changes;
 
     // Accumulate relation deltas
     let mut relation_added: HashMap<RelationId, Relation> = HashMap::new();
@@ -201,6 +219,8 @@ pub fn compute_diff<G: GraphStore>(
             kind: RelationChangeKind::Removed(id),
         });
     }
+    diff.relation_changes
+        .sort_by(|a, b| relation_change_key(a).cmp(&relation_change_key(b)));
 
     Ok(diff)
 }
@@ -296,10 +316,14 @@ pub fn diff_from_changes(changes: &[SemanticChange]) -> SemanticDiff {
         }
     }
 
-    diff.entity_changes = entity_states
+    // Deterministic entity-id order: `entity_states` is a HashMap whose
+    // iteration order varies run-to-run.
+    let mut entity_changes: Vec<EntityChange> = entity_states
         .into_iter()
         .map(|(entity_id, kind)| EntityChange { entity_id, kind })
         .collect();
+    entity_changes.sort_by_key(|change| change.entity_id);
+    diff.entity_changes = entity_changes;
 
     // Accumulate relation deltas
     let mut relation_added: HashMap<RelationId, Relation> = HashMap::new();
@@ -331,6 +355,8 @@ pub fn diff_from_changes(changes: &[SemanticChange]) -> SemanticDiff {
             kind: RelationChangeKind::Removed(id),
         });
     }
+    diff.relation_changes
+        .sort_by(|a, b| relation_change_key(a).cmp(&relation_change_key(b)));
 
     diff
 }
@@ -721,6 +747,52 @@ mod tests {
         assert!(diff.added_entities().is_empty());
         assert!(diff.modified_entities().is_empty());
         assert_eq!(diff.removed_entity_ids().len(), 2);
+    }
+
+    #[test]
+    fn diff_from_changes_emits_entity_changes_in_id_order() {
+        // Deltas arrive out of id order and are accumulated through a HashMap,
+        // whose iteration order is not stable. The builder must emit entity
+        // changes in a deterministic entity-id order so anything derived from
+        // them (findings, inline comments, JSON payloads) is byte-identical
+        // across repeated runs of the same change.
+        let ids: Vec<EntityId> = (0..6u32)
+            .map(|i| EntityId::from_content("src/tie.rs", &format!("e{i}"), "function", i))
+            .collect();
+        let entity_deltas: Vec<EntityDelta> = ids
+            .iter()
+            .rev()
+            .map(|id| EntityDelta::Removed(*id))
+            .collect();
+        let change = SemanticChange {
+            id: test_change_id(21),
+            parents: vec![test_change_id(20)],
+            timestamp: Timestamp::now(),
+            author: AuthorId::new("test"),
+            message: "remove many".into(),
+            entity_deltas,
+            relation_deltas: vec![],
+            artifact_deltas: vec![],
+            projected_files: vec![],
+            spec_link: None,
+            evidence: vec![],
+            risk_summary: None,
+            authored_on: None,
+        };
+
+        let emitted: Vec<EntityId> = diff_from_changes(&[change])
+            .entity_changes
+            .iter()
+            .map(|change| change.entity_id)
+            .collect();
+
+        assert_eq!(emitted.len(), ids.len());
+        let mut sorted = emitted.clone();
+        sorted.sort();
+        assert_eq!(
+            emitted, sorted,
+            "entity_changes must be emitted in ascending entity-id order"
+        );
     }
 
     #[test]

--- a/crates/kin-review/src/shadow.rs
+++ b/crates/kin-review/src/shadow.rs
@@ -486,7 +486,14 @@ fn derive_policy(review: &Review, evidence_gaps: &[ShadowEvidenceGap]) -> Shadow
         + review.impact.affected_dependents.len()
         + review.impact.affected_contract_consumers.len();
     if downstream_count > 0 {
-        for change in &review.diff.entity_changes {
+        // Emit contract-surface findings in a deterministic entity-id order.
+        // Removed entities have no span, so several collapse onto the same
+        // `(file=None, line=None)` dedup key; iterating in a stable order fixes
+        // which one survives as the representative, keeping the finding prose
+        // byte-identical across repeated evaluations.
+        let mut surface_candidates: Vec<_> = review.diff.entity_changes.iter().collect();
+        surface_candidates.sort_by_key(|change| change.entity_id);
+        for change in surface_candidates {
             let (name, location, surface_changed) = match &change.kind {
                 EntityChangeKind::Modified { old, new } => (
                     new.name.clone(),
@@ -1175,6 +1182,100 @@ mod tests {
             .evidence_gaps
             .iter()
             .any(|gap| gap.kind == "cross_repo_not_evaluated"));
+    }
+
+    #[test]
+    fn contract_surface_representative_is_deterministic() {
+        use crate::diff::{EntityChange, EntityChangeKind, SemanticDiff};
+        use crate::impact::ImpactReport;
+        use kin_model::review::{RiskLevel, RiskSummary};
+
+        // A tie of removed entities: each renders with location=None, so the
+        // finding builder's (file,line) dedup collapses them onto a single
+        // representative. Before the fix the survivor was whichever the source
+        // collection happened to yield first; it must now be the smallest id.
+        let ids: Vec<EntityId> = ["gamma", "alpha", "beta", "delta"]
+            .iter()
+            .map(|&name| EntityId::from_content("src/tie.rs", name, "function", 1))
+            .collect();
+        let expected = *ids.iter().min().unwrap();
+
+        let build_review = |order: &[usize]| -> Review {
+            let entity_changes: Vec<EntityChange> = order
+                .iter()
+                .map(|&i| EntityChange {
+                    entity_id: ids[i],
+                    kind: EntityChangeKind::Removed(ids[i]),
+                })
+                .collect();
+            Review {
+                base: None,
+                head: None,
+                diff: SemanticDiff {
+                    base: None,
+                    head: None,
+                    entity_changes,
+                    relation_changes: vec![],
+                },
+                // One downstream dependent makes the contract-surface rule fire.
+                impact: ImpactReport {
+                    affected_dependents: vec![entity_with_span(
+                        "downstream_consumer",
+                        "src/consumer.rs",
+                        1,
+                        EntityRole::Source,
+                    )],
+                    ..Default::default()
+                },
+                risk: RiskSummary {
+                    overall_risk: RiskLevel::Low,
+                    breaking_changes: vec![],
+                    test_coverage_gaps: vec![],
+                    contract_violations: vec![],
+                    work_risks: vec![],
+                    notes: vec![],
+                },
+                inline_comments: vec![],
+            }
+        };
+
+        // Exactly one contract-surface representative survives, naming the
+        // smallest entity id regardless of the input order.
+        let natural = derive_policy(&build_review(&[0, 1, 2, 3]), &[]);
+        let contract: Vec<&ShadowPolicyFinding> = natural
+            .findings
+            .iter()
+            .filter(|finding| finding.kind == "downstream_risk")
+            .collect();
+        assert_eq!(
+            contract.len(),
+            1,
+            "removed tie must collapse to a single representative finding"
+        );
+        assert_eq!(
+            contract[0].message,
+            format!(
+                "Contract surface of `{expected}` changed with 1 graph-known downstream entity(ies)"
+            ),
+        );
+
+        // Emitted findings must be byte-identical across repeated in-process
+        // runs and across every input order — the determinism the merge-trust
+        // n=3 bit-identity gate depends on.
+        let baseline =
+            serde_json::to_string(&derive_policy(&build_review(&[0, 1, 2, 3]), &[]).findings)
+                .unwrap();
+        for order in [[0, 1, 2, 3], [3, 2, 1, 0], [1, 3, 0, 2], [2, 0, 3, 1]] {
+            for _ in 0..3 {
+                let result = derive_policy(&build_review(&order), &[]);
+                assert_eq!(result.verdict, ShadowGateVerdict::WouldBlock);
+                assert_eq!(
+                    serde_json::to_string(&result.findings).unwrap(),
+                    baseline,
+                    "findings must be byte-identical regardless of entity_changes order"
+                );
+            }
+        }
     }
 
     #[test]


### PR DESCRIPTION
Caught live by the merge-trust prereg run's n=3 bit-identity gate: the 'Contract surface of <entity-id>' finding named a different entity each pass. Root cause is the FIR-1099 HashMap class in kin-review's diff builders — entity_changes collected from a HashMap in nondeterministic order (diff.rs compute_diff + diff_from_changes), surfacing through derive_policy's already_blocking dedup where all Removed entities collapse onto one (file=None,line=None) key and the first-iterated survives as the representative.

Fixed at the source: entity_changes sorted by entity id and relation_changes by relation key in both builders — stabilizing findings, inline comments, MCP output, and human diff in one change — plus defense-in-depth sorting at the contract-surface candidate iteration so the representative is the minimum id regardless of construction. Ordering-only: no verdict, count, or ranking behavior changes. The rest of shadow.rs was swept — every other emitted source already sorts.

kin-review suite 91 green incl. the existing determinism-modulo-timestamp test; two new regression tests (source-order pin; a 4-way Removed tie asserting the min-id survivor and serde byte-identity across 4 input orders × 3 runs, verdict stable at WouldBlock). fmt/clippy CI-allowlist clean.

End-to-end n=3 acceptance on the two Catch2 scenarios rides the v2 benchmark relaunch (citable rebuild + gate happening next in-session). Part of FIR-1258.
