### PR TITLE
chore: mechanical clippy burndown, chunk 1

### DIFF
--- a/crates/kin-cli/src/backend.rs
+++ b/crates/kin-cli/src/backend.rs
@@ -145,7 +145,7 @@ pub async fn open_snapshot_explicit_admin_read_only(
 ) -> std::result::Result<kin_db::SnapshotManager, kin_db::KinDbError> {
     // 1. Daemon-first: the canonical live authority. Auto-starts if needed.
     match open_snapshot_daemon_first_read_only(layout).await {
-        Ok(snapshot) => return Ok(snapshot),
+        Ok(snapshot) => Ok(snapshot),
         Err(daemon_err) => {
             // 2. Offline/admin escape hatch: explicit local snapshot read.
             if daemon_bootstrap_admin_allowed() {

--- a/crates/kin-cli/src/commands/approvals.rs
+++ b/crates/kin-cli/src/commands/approvals.rs
@@ -75,7 +75,7 @@ fn build_approvals_show_response(
     graph: &kin_db::InMemoryGraph,
     change_id: &str,
 ) -> Result<ApprovalsResponse> {
-    let id = parse_change_id(&change_id)?;
+    let id = parse_change_id(change_id)?;
     let approvals = graph.get_approvals_for_change(&id)?;
 
     if approvals.is_empty() {

--- a/crates/kin-cli/src/commands/bench_meta.rs
+++ b/crates/kin-cli/src/commands/bench_meta.rs
@@ -199,14 +199,14 @@ fn embedding_meta() -> EmbeddingMeta {
     #[cfg(feature = "embeddings")]
     {
         let runtime = kin_db::embed::configured_embedding_runtime();
-        return EmbeddingMeta {
+        EmbeddingMeta {
             vector_enabled: cfg!(feature = "vector"),
             embeddings_enabled: true,
             metal_enabled: metal_active(),
             model_id: Some(runtime.model_id),
             model_revision: Some(runtime.revision),
             pipeline_epoch: Some(runtime.pipeline_epoch),
-        };
+        }
     }
 
     #[cfg(not(feature = "embeddings"))]

--- a/crates/kin-cli/src/commands/checkout.rs
+++ b/crates/kin-cli/src/commands/checkout.rs
@@ -106,14 +106,14 @@ pub fn execute_checkout_request(
         // 2. Clean up any files in the working directory that are NOT in the tree
         let source_root = layout.working_dir();
         let mut files_to_delete = Vec::new();
-        collect_non_tree_files(&source_root, &source_root, &tree, &mut files_to_delete)?;
+        collect_non_tree_files(source_root, source_root, &tree, &mut files_to_delete)?;
 
         for file_path in files_to_delete {
             let _ = std::fs::remove_file(file_path);
         }
 
         // Clean up empty directories
-        clean_empty_dirs(&source_root, &source_root)?;
+        clean_empty_dirs(source_root, source_root)?;
 
         return Ok(CheckoutResponse {
             lines: vec![format!("Checked out all files from change {}", target_head)],

--- a/crates/kin-cli/src/commands/commit.rs
+++ b/crates/kin-cli/src/commands/commit.rs
@@ -719,6 +719,73 @@ fn collect_files_recursive(
     Ok(())
 }
 
+/// Fetch the remote repo catalog from a KinLab spine, if configured.
+/// Returns empty vec if no remote is configured or if the request fails.
+/// 3-second timeout to avoid blocking `kin commit`.
+///
+/// First fetches with no filter to get the full catalog (for small orgs).
+/// For large orgs (>1000 repos), the endpoint supports ?q=name1,name2,...
+/// filtering which the caller can use to narrow to dependency candidates.
+#[cfg(test)]
+#[allow(dead_code)]
+fn fetch_remote_catalog() -> Vec<String> {
+    let remote_url = match kin_core::registry::KinRegistry::remote_url() {
+        Some(url) => url,
+        None => return Vec::new(),
+    };
+
+    let base_url = remote_url.trim_end_matches('/');
+    let url = format!("{}/api/repos", base_url);
+    let auth_header = super::remote::native_remote_bearer_token(base_url)
+        .map(|t| format!("Authorization: Bearer {}", t));
+
+    let mut cmd = std::process::Command::new("curl");
+    cmd.args(["-s", "--max-time", "3"]);
+    if let Some(ref header) = auth_header {
+        cmd.args(["-H", header.as_str()]);
+    }
+    cmd.arg(&url);
+
+    match cmd.output() {
+        Ok(output) if output.status.success() => {
+            let body = String::from_utf8_lossy(&output.stdout);
+            kin_core::registry::KinRegistry::parse_repo_catalog(&body)
+        }
+        _ => Vec::new(),
+    }
+}
+
+/// Fetch only repos matching specific names from the remote catalog.
+/// Used when the caller already knows what dependency names to check.
+#[allow(dead_code)]
+fn fetch_remote_catalog_filtered(names: &[&str]) -> Vec<String> {
+    let remote_url = match kin_core::registry::KinRegistry::remote_url() {
+        Some(url) => url,
+        None => return Vec::new(),
+    };
+
+    let base_url = remote_url.trim_end_matches('/');
+    let query = names.join(",");
+    let url = format!("{}/api/repos?q={}", base_url, query);
+    let auth_header = super::remote::native_remote_bearer_token(base_url)
+        .map(|t| format!("Authorization: Bearer {}", t));
+
+    let mut cmd = std::process::Command::new("curl");
+    cmd.args(["-s", "--max-time", "3"]);
+    if let Some(ref header) = auth_header {
+        cmd.args(["-H", header.as_str()]);
+    }
+    cmd.arg(&url);
+
+    match cmd.output() {
+        Ok(output) if output.status.success() => {
+            let body = String::from_utf8_lossy(&output.stdout);
+            kin_core::registry::KinRegistry::parse_repo_catalog(&body)
+        }
+        _ => Vec::new(),
+    }
+}
+
 // should_skip_dir moved to kin_index::should_skip_dir (canonical skip list).
 
 #[cfg(test)]
@@ -799,72 +866,5 @@ mod tests {
         assert!(collected.contains("README.md"));
         assert!(!collected.contains(".kin-snapshot-tmp/nested/manifest.json"));
         assert!(!collected.contains(".kin-export/cache/state.json"));
-    }
-}
-
-/// Fetch the remote repo catalog from a KinLab spine, if configured.
-/// Returns empty vec if no remote is configured or if the request fails.
-/// 3-second timeout to avoid blocking `kin commit`.
-///
-/// First fetches with no filter to get the full catalog (for small orgs).
-/// For large orgs (>1000 repos), the endpoint supports ?q=name1,name2,...
-/// filtering which the caller can use to narrow to dependency candidates.
-#[cfg(test)]
-#[allow(dead_code)]
-fn fetch_remote_catalog() -> Vec<String> {
-    let remote_url = match kin_core::registry::KinRegistry::remote_url() {
-        Some(url) => url,
-        None => return Vec::new(),
-    };
-
-    let base_url = remote_url.trim_end_matches('/');
-    let url = format!("{}/api/repos", base_url);
-    let auth_header = super::remote::native_remote_bearer_token(base_url)
-        .map(|t| format!("Authorization: Bearer {}", t));
-
-    let mut cmd = std::process::Command::new("curl");
-    cmd.args(["-s", "--max-time", "3"]);
-    if let Some(ref header) = auth_header {
-        cmd.args(["-H", header.as_str()]);
-    }
-    cmd.arg(&url);
-
-    match cmd.output() {
-        Ok(output) if output.status.success() => {
-            let body = String::from_utf8_lossy(&output.stdout);
-            kin_core::registry::KinRegistry::parse_repo_catalog(&body)
-        }
-        _ => Vec::new(),
-    }
-}
-
-/// Fetch only repos matching specific names from the remote catalog.
-/// Used when the caller already knows what dependency names to check.
-#[allow(dead_code)]
-fn fetch_remote_catalog_filtered(names: &[&str]) -> Vec<String> {
-    let remote_url = match kin_core::registry::KinRegistry::remote_url() {
-        Some(url) => url,
-        None => return Vec::new(),
-    };
-
-    let base_url = remote_url.trim_end_matches('/');
-    let query = names.join(",");
-    let url = format!("{}/api/repos?q={}", base_url, query);
-    let auth_header = super::remote::native_remote_bearer_token(base_url)
-        .map(|t| format!("Authorization: Bearer {}", t));
-
-    let mut cmd = std::process::Command::new("curl");
-    cmd.args(["-s", "--max-time", "3"]);
-    if let Some(ref header) = auth_header {
-        cmd.args(["-H", header.as_str()]);
-    }
-    cmd.arg(&url);
-
-    match cmd.output() {
-        Ok(output) if output.status.success() => {
-            let body = String::from_utf8_lossy(&output.stdout);
-            kin_core::registry::KinRegistry::parse_repo_catalog(&body)
-        }
-        _ => Vec::new(),
     }
 }

--- a/crates/kin-cli/src/commands/contextbench_locate.rs
+++ b/crates/kin-cli/src/commands/contextbench_locate.rs
@@ -514,11 +514,11 @@ fn parse_gold(task: &Value) -> Vec<GoldEntry> {
 ///
 /// - `FOUND`    — gold is in the final emitted list.
 /// - `CAP`      — gold was pruned by the adaptive cap / cluster prune
-///                (`debug.pruned_files` carries the reason).
+///   (`debug.pruned_files` carries the reason).
 /// - `RANKING`  — gold reached the pre-cap pool but was ranked below the kept
-///                set without an explicit prune reason.
+///   set without an explicit prune reason.
 /// - `COVERAGE` — gold never reached the pre-cap pool (a retrieval gap, not a
-///                ranking/cap one). This is the most actionable miss class.
+///   ranking/cap one). This is the most actionable miss class.
 ///
 /// Returns `None` only when the task carries no gold at all.
 fn build_gold_trace(

--- a/crates/kin-cli/src/commands/diff.rs
+++ b/crates/kin-cli/src/commands/diff.rs
@@ -53,11 +53,11 @@ pub fn build_diff_response(
     match (&request.base, &request.head) {
         (Some(b), Some(h)) => {
             let base_id = kin_model::SemanticChangeId::from_hash(
-                kin_model::Hash256::from_hex(&b)
+                kin_model::Hash256::from_hex(b)
                     .map_err(|e| anyhow::anyhow!("invalid base hash: {}", e))?,
             );
             let head_id = kin_model::SemanticChangeId::from_hash(
-                kin_model::Hash256::from_hex(&h)
+                kin_model::Hash256::from_hex(h)
                     .map_err(|e| anyhow::anyhow!("invalid head hash: {}", e))?,
             );
             let changes = graph.get_changes_since(&base_id, &head_id)?;

--- a/crates/kin-cli/src/commands/graph.rs
+++ b/crates/kin-cli/src/commands/graph.rs
@@ -216,7 +216,7 @@ fn build_graph_status_response(
     let mut total_relations = 0usize;
     for e in &entities {
         for rel in graph.get_all_relations_for_entity(&e.id)? {
-            if seen_relation_ids.insert(rel.id.clone()) {
+            if seen_relation_ids.insert(rel.id) {
                 *relation_counts.entry(rel.kind).or_insert(0) += 1;
                 total_relations += 1;
             }

--- a/crates/kin-cli/src/commands/graph.rs
+++ b/crates/kin-cli/src/commands/graph.rs
@@ -399,7 +399,7 @@ fn build_graph_validate_response(
     }
 
     // Check for orphaned entities (file_origin that doesn't exist on disk)
-    let source_root = kin_core::source_dir(&layout);
+    let source_root = kin_core::source_dir(layout);
     let mut orphaned = 0usize;
     for e in &entities {
         if let Some(ref fo) = e.file_origin {

--- a/crates/kin-cli/src/commands/init.rs
+++ b/crates/kin-cli/src/commands/init.rs
@@ -1604,7 +1604,7 @@ fn stabilize_reparsed_file_entities(
 
         if let Some(old) = existing {
             parsed_entity.id = old.id;
-            parsed_entity.lineage_parent = old.lineage_parent.clone();
+            parsed_entity.lineage_parent = old.lineage_parent;
             parsed_entity.created_in = old.created_in;
             matched_old_entities.insert(old.id);
             remap.insert(parser_id, old.id);

--- a/crates/kin-cli/src/commands/init.rs
+++ b/crates/kin-cli/src/commands/init.rs
@@ -1696,7 +1696,7 @@ fn index_files_with_stable_entity_ids(
                         kin_index::extract_projection_source_markers(&file.rel_path, &source);
 
                     let done = parsed_count.fetch_add(1, Ordering::Relaxed) + 1;
-                    if done % 100 == 0 || done == total {
+                    if done.is_multiple_of(100) || done == total {
                         eprint!(
                             "\r  [parse {}/{}] {}% | {:.1}s",
                             done,

--- a/crates/kin-cli/src/commands/locate.rs
+++ b/crates/kin-cli/src/commands/locate.rs
@@ -4785,7 +4785,7 @@ fn query_backed_tracked_file_score(path: &str, term_lower: &str) -> Option<f32> 
     }
 
     let basename_exact_segment = basename_lower
-        .split(|ch: char| matches!(ch, '/' | '.' | '_' | '-'))
+        .split(['/', '.', '_', '-'])
         .filter(|segment| !segment.is_empty())
         .any(|segment| segment == term_lower);
     if basename_exact_segment {
@@ -4794,7 +4794,7 @@ fn query_backed_tracked_file_score(path: &str, term_lower: &str) -> Option<f32> 
 
     let path_lower = path.to_ascii_lowercase();
     let exact_segment = path_lower
-        .split(|ch: char| matches!(ch, '/' | '.' | '_' | '-'))
+        .split(['/', '.', '_', '-'])
         .filter(|segment| !segment.is_empty())
         .any(|segment| segment == term_lower);
     if exact_segment && is_manifest_like_basename(&basename_lower) {
@@ -14431,7 +14431,7 @@ fn explain_line_score(reason: &str) -> f32 {
     if let Some(idx) = reason.find("(score ") {
         let rest = &reason[idx + 7..];
         let end = rest
-            .find(|c: char| c == ',' || c == ')')
+            .find([',', ')'])
             .unwrap_or(rest.len());
         return rest[..end].trim().parse::<f32>().unwrap_or(-1.0);
     }

--- a/crates/kin-cli/src/commands/locate.rs
+++ b/crates/kin-cli/src/commands/locate.rs
@@ -3471,9 +3471,7 @@ const PRIORITY_FILE_EXCLUDED_BASENAMES: &[&str] = &[
 
 fn is_excluded_priority_basename(path: &str) -> bool {
     let basename = path.rsplit('/').next().unwrap_or(path);
-    PRIORITY_FILE_EXCLUDED_BASENAMES
-        .iter()
-        .any(|b| basename == *b)
+    PRIORITY_FILE_EXCLUDED_BASENAMES.contains(&basename)
 }
 
 fn note_priority_reason(

--- a/crates/kin-cli/src/commands/locate.rs
+++ b/crates/kin-cli/src/commands/locate.rs
@@ -655,7 +655,7 @@ fn split_identifier_parts(name: &str) -> Vec<String> {
             if !current.is_empty() {
                 // Check if this is start of a new word (camelCase boundary)
                 // but NOT a run of capitals (like "HTTP" in "HTTPClient")
-                let prev_was_lower = current.chars().last().map_or(false, |c| c.is_lowercase());
+                let prev_was_lower = current.chars().last().is_some_and(|c| c.is_lowercase());
                 if prev_was_lower {
                     parts.push(std::mem::take(&mut current).to_lowercase());
                 }
@@ -2671,7 +2671,7 @@ pub fn run_with_graph_capture_with_priority_files_and_vector_source(
                     .extra
                     .get("embedding_body_preview")
                     .and_then(|v| v.as_str())
-                    .map_or(false, |s| !s.is_empty());
+                    .is_some_and(|s| !s.is_empty());
                 let body_tag = if has_body { "DEF" } else { "ref" };
                 let test_tag = if is_test_by_role(file, Some(&e)) {
                     " [TEST]"
@@ -9715,7 +9715,7 @@ fn resolve_entities_to_files(
         let entity_is_test = entity
             .file_origin
             .as_ref()
-            .map_or(false, |fo| is_test_by_role(&fo.0, Some(&entity)));
+            .is_some_and(|fo| is_test_by_role(&fo.0, Some(&entity)));
 
         if let Some(ref fo) = entity.file_origin {
             let path = &fo.0;
@@ -9732,7 +9732,7 @@ fn resolve_entities_to_files(
                     .extra
                     .get("embedding_body_preview")
                     .and_then(|v| v.as_str())
-                    .map_or(false, |s| !s.is_empty());
+                    .is_some_and(|s| !s.is_empty());
 
                 // KIND-FLOOR lever (default OFF == current bytes): the definition
                 // flag (and its `definition_authority` score multiplier) key only
@@ -9988,7 +9988,7 @@ fn resolve_entities_to_files(
                     .extra
                     .get("embedding_body_preview")
                     .and_then(|v| v.as_str())
-                    .map_or(false, |s| !s.is_empty());
+                    .is_some_and(|s| !s.is_empty());
                 let def_mult = if neighbor_has_body {
                     definition_authority
                 } else {
@@ -13899,7 +13899,7 @@ fn enrich_empty_file_symbols(
     for (path, _) in results {
         if projection_symbols
             .get(path)
-            .map_or(false, |syms| !syms.is_empty())
+            .is_some_and(|syms| !syms.is_empty())
         {
             continue;
         }
@@ -14096,7 +14096,7 @@ fn emit_inner_methods(
 ) {
     let topk = locate_env_usize("KIN_LOCATE_INNER_METHOD_TOPK", 5);
     for (path, _) in results {
-        let has_class_like = projection_symbols.get(path).map_or(false, |syms| {
+        let has_class_like = projection_symbols.get(path).is_some_and(|syms| {
             syms.iter()
                 .any(|s| matches!(s.kind.as_str(), "class" | "interface" | "module"))
         });

--- a/crates/kin-cli/src/commands/locate.rs
+++ b/crates/kin-cli/src/commands/locate.rs
@@ -5834,7 +5834,7 @@ fn extract_traceback_signals(
         // still look like stdlib/venv noise.
         if let Some(ref path) = rel_path {
             hits.entry(path.clone()).or_default().push(FileHit {
-                score: score,
+                score,
                 spans: vec![[line, line]],
             });
         } else if is_stdlib_path(file_path) {

--- a/crates/kin-cli/src/commands/locate.rs
+++ b/crates/kin-cli/src/commands/locate.rs
@@ -10913,7 +10913,7 @@ fn apply_module_prefix_affinity(
         }
     }
     // Also count priority file prefixes with extra weight.
-    for (path, _trace) in priority_traces {
+    for path in priority_traces.keys() {
         if let Some(prefix) = top_level_module_prefix(path) {
             *prefix_counts.entry(prefix).or_default() += 2;
         }

--- a/crates/kin-cli/src/commands/locate.rs
+++ b/crates/kin-cli/src/commands/locate.rs
@@ -11618,10 +11618,8 @@ fn demote_cochange_only_outliers(
 
     let penalty = locate_env_f32("KIN_LOCATE_COCHANGE_ONLY_OUTLIER_PENALTY", 0.25);
     let noisy_path_penalty = locate_env_f32("KIN_LOCATE_NOISY_COCHANGE_ONLY_PENALTY", 0.08);
-    if penalty >= 1.0 {
-        if noisy_path_penalty >= 1.0 {
-            return;
-        }
+    if penalty >= 1.0 && noisy_path_penalty >= 1.0 {
+        return;
     }
 
     let mut changed = false;

--- a/crates/kin-cli/src/commands/locate.rs
+++ b/crates/kin-cli/src/commands/locate.rs
@@ -2745,7 +2745,7 @@ pub fn run_with_graph_capture_with_priority_files_and_vector_source(
                 top.sort_by(|a, b| {
                     b.1.partial_cmp(&a.1)
                         .unwrap_or(std::cmp::Ordering::Equal)
-                        .then_with(|| a.0.cmp(&b.0))
+                        .then_with(|| a.0.cmp(b.0))
                 });
                 let top_str: Vec<String> = top
                     .iter()
@@ -8438,7 +8438,7 @@ fn extract_source_text_signals(
             bonus += locate_env_f32("KIN_LOCATE_SOURCE_TEXT_SYMBOLIC_SUPPORT_BONUS", 8.0)
                 * (symbolic_count.min(2) as f32);
         }
-        if cli_flag_query && is_cli_surface_path(&path) {
+        if cli_flag_query && is_cli_surface_path(path) {
             bonus += locate_env_f32("KIN_LOCATE_SOURCE_TEXT_CLI_SURFACE_BONUS", 22.0);
         }
         if bonus > 0.0 {
@@ -12345,7 +12345,7 @@ fn promote_cli_surface_local_headers(
     let empty_paths = HashSet::new();
     let mut changed = false;
     for seed in seed_paths {
-        let Some(header_path) = sibling_header_for_cli_surface(&seed, &workspace_root) else {
+        let Some(header_path) = sibling_header_for_cli_surface(&seed, workspace_root) else {
             continue;
         };
         changed |= upsert_fused_floor(fused, header_path.clone(), direct_floor);
@@ -12361,7 +12361,7 @@ fn promote_cli_surface_local_headers(
             &header_path,
             &header_text,
             &empty_paths,
-            Some(&workspace_root),
+            Some(workspace_root),
         ) {
             if is_header_like_path(&include_path) {
                 changed |= upsert_fused_floor(fused, include_path, nested_floor);

--- a/crates/kin-cli/src/commands/locate.rs
+++ b/crates/kin-cli/src/commands/locate.rs
@@ -7535,7 +7535,7 @@ fn extract_multihop_signals(
                 continue;
             };
             let start = GraphNodeId::Artifact(start_artifact_id);
-            let mut visited = HashSet::from([start.clone()]);
+            let mut visited = HashSet::from([start]);
             let mut queue = VecDeque::from([(start, seed_path.clone(), 0usize)]);
             let seed_strength = (*seed_score / 72.0).clamp(0.35, 2.0);
 
@@ -7602,7 +7602,7 @@ fn extract_multihop_signals(
                         spans: vec![],
                     });
 
-                    if visited.insert(next.clone()) {
+                    if visited.insert(next) {
                         queue.push_back((next, path, depth + 1));
                     }
                 }
@@ -9672,7 +9672,7 @@ fn resolve_entities_to_files(
             // retained set so it never double-counts an entity.
             if locate_env_bool("KIN_LOCATE_BODY_SEED_PROTECT", false) {
                 let retained_ids: HashSet<kin_model::EntityId> =
-                    retained.iter().map(|pair| pair.0.clone()).collect();
+                    retained.iter().map(|pair| *pair.0).collect();
                 for seed in seeds[cut_at..].iter() {
                     if seed.1.signals.contains(&"body") && !retained_ids.contains(seed.0) {
                         retained.push(*seed);
@@ -9820,7 +9820,7 @@ fn resolve_entities_to_files(
                 graph.artifact_id_for_path(&kin_model::FilePathId::new(fo.0.as_str()));
             if let Some(start_artifact_id) = start_artifact_id {
                 let start_artifact = GraphNodeId::Artifact(start_artifact_id);
-                let mut visited_artifacts = HashSet::from([start_artifact.clone()]);
+                let mut visited_artifacts = HashSet::from([start_artifact]);
                 let mut artifact_frontier_queue =
                     VecDeque::from([(start_artifact, fo.0.clone(), 0usize)]);
 
@@ -9903,7 +9903,7 @@ fn resolve_entities_to_files(
                             );
                         }
 
-                        if visited_artifacts.insert(next_artifact.clone()) {
+                        if visited_artifacts.insert(next_artifact) {
                             artifact_frontier_queue.push_back((next_artifact, path, depth + 1));
                         }
                     }
@@ -17479,7 +17479,7 @@ mod tests {
                 .upsert_relation(&Relation {
                     id: RelationId::new(),
                     kind: RelationKind::Includes,
-                    src: GraphNodeId::Artifact(iter_artifact.clone()),
+                    src: GraphNodeId::Artifact(iter_artifact),
                     dst: GraphNodeId::Artifact(target_artifact),
                     confidence: 1.0,
                     origin: RelationOrigin::Parsed,

--- a/crates/kin-cli/src/commands/locate.rs
+++ b/crates/kin-cli/src/commands/locate.rs
@@ -3769,18 +3769,15 @@ fn direct_query_priority_paths(
 ) -> HashSet<String> {
     priority_traces
         .iter()
-        .filter_map(|(path, trace)| {
-            trace
-                .reasons
-                .iter()
-                .any(|reason| {
-                    matches!(
-                        reason.kind.as_str(),
-                        "explicit_path" | "tracked_explicit_name"
-                    )
-                })
-                .then(|| path.clone())
+        .filter(|&(_path, trace)| {
+            trace.reasons.iter().any(|reason| {
+                matches!(
+                    reason.kind.as_str(),
+                    "explicit_path" | "tracked_explicit_name"
+                )
+            })
         })
+        .map(|(path, _trace)| path.clone())
         .collect()
 }
 
@@ -3790,19 +3787,16 @@ fn injectable_priority_paths(
     let historical_paths = historical_priority_retention_paths(priority_traces);
     priority_traces
         .iter()
-        .filter_map(|(path, trace)| {
-            trace
-                .reasons
-                .iter()
-                .any(|reason| {
-                    if reason.kind == "historical_priority_seed" {
-                        historical_paths.contains(path)
-                    } else {
-                        priority_reason_allows_injection(&reason.kind)
-                    }
-                })
-                .then(|| path.clone())
+        .filter(|&(path, trace)| {
+            trace.reasons.iter().any(|reason| {
+                if reason.kind == "historical_priority_seed" {
+                    historical_paths.contains(path)
+                } else {
+                    priority_reason_allows_injection(&reason.kind)
+                }
+            })
         })
+        .map(|(path, _trace)| path.clone())
         .collect()
 }
 

--- a/crates/kin-cli/src/commands/locate.rs
+++ b/crates/kin-cli/src/commands/locate.rs
@@ -5880,8 +5880,8 @@ fn normalize_traceback_path(path: &str) -> String {
     let path = path.replace('\\', "/");
 
     // Strip ~ prefix (e.g. ~/dev/astropy/astropy/... → /dev/astropy/astropy/...)
-    let path = if path.starts_with("~/") {
-        format!("/{}", &path[2..])
+    let path = if let Some(rest) = path.strip_prefix("~/") {
+        format!("/{rest}")
     } else {
         path
     };

--- a/crates/kin-cli/src/commands/locate.rs
+++ b/crates/kin-cli/src/commands/locate.rs
@@ -7819,7 +7819,7 @@ fn extract_multihop_signals(
         }
     }
 
-    if let Some(ledger) = ledger.as_deref_mut() {
+    if let Some(ledger) = ledger {
         if cut_depth_limit_hits > 0 {
             ledger.push(PruneEvent {
                 stage: "multihop_depth".to_string(),
@@ -8455,13 +8455,13 @@ fn extract_source_text_signals(
         &source_previews,
         &source_paths,
         cli_flag_query,
-        workspace_root.as_deref(),
+        workspace_root,
     );
     promote_cli_surface_companion_headers_in_source_text(
         &mut hits,
         &path_term_support,
         &source_previews,
-        workspace_root.as_deref(),
+        workspace_root,
     );
 
     Ok(hits)
@@ -9040,7 +9040,7 @@ fn extract_embedding_signals(
     vector_source: Option<&kin_db::InMemoryGraph>,
     quality: crate::retrieval_profile::RetrievalProfile,
     degradations: &mut Vec<RetrievalDegradation>,
-    mut ledger: Option<&mut Vec<PruneEvent>>,
+    ledger: Option<&mut Vec<PruneEvent>>,
 ) -> Result<HashMap<kin_model::EntityId, EntityDiscovery>> {
     let _span =
         tracing::info_span!("locate.extract_embedding_signals", text_len = text.len()).entered();
@@ -9224,7 +9224,7 @@ fn extract_embedding_signals(
     }
 
     if floor_dropped > 0 {
-        if let Some(ledger) = ledger.as_deref_mut() {
+        if let Some(ledger) = ledger {
             let (best_name, best_relevance) = floor_best_dropped.unwrap_or_default();
             ledger.push(PruneEvent {
                 stage: "embedding_seed_floor".to_string(),

--- a/crates/kin-cli/src/commands/locate.rs
+++ b/crates/kin-cli/src/commands/locate.rs
@@ -14430,9 +14430,7 @@ fn rank_and_cap_symbols_with(mut symbols: Vec<LocateSymbol>, cap: usize) -> Vec<
 fn explain_line_score(reason: &str) -> f32 {
     if let Some(idx) = reason.find("(score ") {
         let rest = &reason[idx + 7..];
-        let end = rest
-            .find([',', ')'])
-            .unwrap_or(rest.len());
+        let end = rest.find([',', ')']).unwrap_or(rest.len());
         return rest[..end].trim().parse::<f32>().unwrap_or(-1.0);
     }
     -1.0

--- a/crates/kin-cli/src/commands/locate.rs
+++ b/crates/kin-cli/src/commands/locate.rs
@@ -4172,7 +4172,7 @@ fn extract_priority_file_traces(
             if let Ok(mut all) = graph.query_entities(&EntityFilter::default()) {
                 // Determinism: sort before the take() clip so the scanned subset
                 // is stable across processes (query order is not stable on its own).
-                all.sort_by(|a, b| a.id.cmp(&b.id));
+                all.sort_by_key(|a| a.id);
                 let mut seen_paths = HashSet::new();
                 let mut matched_paths = Vec::new();
                 for entity in all.iter().take(2000) {
@@ -4253,7 +4253,7 @@ fn extract_priority_file_traces(
             let mut dir_to_files: HashMap<String, Vec<String>> = HashMap::new();
             if let Ok(mut all_entities) = graph.query_entities(&EntityFilter::default()) {
                 // Determinism: stable subset under the take() clip.
-                all_entities.sort_by(|a, b| a.id.cmp(&b.id));
+                all_entities.sort_by_key(|a| a.id);
                 let mut seen_files = HashSet::new();
                 for entity in all_entities.iter().take(5000) {
                     if let Some(ref fo) = entity.file_origin {
@@ -8030,7 +8030,7 @@ fn extract_test_signals(
             };
             let mut name_matched = graph.query_entities(&filter)?;
             // Determinism: stable subset under the take() clip.
-            name_matched.sort_by(|a, b| a.id.cmp(&b.id));
+            name_matched.sort_by_key(|a| a.id);
             for entity in name_matched.into_iter().take(12) {
                 if !seen_entities.insert(entity.id) {
                     continue;
@@ -9393,7 +9393,7 @@ fn compute_import_centrality(
         // exact/near-tie candidates in/out of the cap (the #20 bug class). Sort
         // by entity id so the considered subset — and thus import_count — is
         // deterministic.
-        entities.sort_by(|a, b| a.id.cmp(&b.id));
+        entities.sort_by_key(|a| a.id);
 
         let mut importer_files: HashSet<String> = HashSet::new();
         for entity in entities

--- a/crates/kin-cli/src/commands/locate.rs
+++ b/crates/kin-cli/src/commands/locate.rs
@@ -1787,8 +1787,10 @@ pub fn run_with_graph_capture_with_priority_files_and_vector_source(
         });
         fallback_files.truncate(max_files);
         let debug_info = if explain {
-            let mut info = LocateDebugInfo::default();
-            info.skipped_signals = budget.warnings.clone();
+            let mut info = LocateDebugInfo {
+                skipped_signals: budget.warnings.clone(),
+                ..Default::default()
+            };
             prune_ledger.push(PruneEvent {
                 stage: "scoring".to_string(),
                 kind: "budget_skip".to_string(),

--- a/crates/kin-cli/src/commands/locate_debug.rs
+++ b/crates/kin-cli/src/commands/locate_debug.rs
@@ -113,7 +113,7 @@ fn parse_task_file(path: &str) -> Result<(String, Vec<String>)> {
         let mut seen = std::collections::HashSet::new();
         gold_context_value
             .iter()
-            .filter_map(|c| c["file"].as_str().map(|s| strip_workspace_prefix(s)))
+            .filter_map(|c| c["file"].as_str().map(strip_workspace_prefix))
             .filter(|path| seen.insert(path.clone()))
             .collect()
     };

--- a/crates/kin-cli/src/commands/mcp.rs
+++ b/crates/kin-cli/src/commands/mcp.rs
@@ -68,10 +68,11 @@ fn session_authority_notice() -> &'static str {
 }
 
 fn build_mcp_start_config() -> kin_mcp::McpServerConfig {
-    let mut config = kin_mcp::McpServerConfig::default();
-    config.session_authority_mode = kin_mcp::SessionAuthorityMode::DaemonRequired;
-    config.snapshot_path = None;
-    config
+    kin_mcp::McpServerConfig {
+        session_authority_mode: kin_mcp::SessionAuthorityMode::DaemonRequired,
+        snapshot_path: None,
+        ..Default::default()
+    }
 }
 
 #[cfg(test)]

--- a/crates/kin-cli/src/commands/overview.rs
+++ b/crates/kin-cli/src/commands/overview.rs
@@ -137,7 +137,7 @@ pub fn build_overview_response(
     }
     lines.push("--- Languages ---".to_string());
     let mut langs: Vec<_> = by_lang.iter().collect();
-    langs.sort_by(|a, b| b.1 .0.cmp(&a.1 .0));
+    langs.sort_by_key(|b| std::cmp::Reverse(b.1 .0));
     for (lang, (count, files)) in &langs {
         lines.push(format!(
             "  {}: {} entities across {} files",
@@ -158,7 +158,7 @@ pub fn build_overview_response(
         // Compact mode: just counts per kind, no entity listings
         lines.push("--- Entity Kinds ---".to_string());
         let mut kinds: Vec<_> = by_kind.iter().collect();
-        kinds.sort_by(|a, b| b.1.len().cmp(&a.1.len()));
+        kinds.sort_by_key(|b| std::cmp::Reverse(b.1.len()));
         for (kind, ents) in &kinds {
             lines.push(format!("  {}: {}", kind, ents.len()));
         }
@@ -167,7 +167,7 @@ pub fn build_overview_response(
         let top_n = 5;
         lines.push("--- Top Entities by Kind ---".to_string());
         let mut kinds: Vec<_> = by_kind.iter().collect();
-        kinds.sort_by(|a, b| b.1.len().cmp(&a.1.len()));
+        kinds.sort_by_key(|b| std::cmp::Reverse(b.1.len()));
         for (kind, ents) in &kinds {
             lines.push(format!("{} ({}):", kind, ents.len()));
             for e in ents.iter().take(top_n) {

--- a/crates/kin-cli/src/commands/reconcile.rs
+++ b/crates/kin-cli/src/commands/reconcile.rs
@@ -69,7 +69,7 @@ pub async fn reconcile_session_dir(
     {
         let snap = crate::backend::open_kindb_snapshot(layout)
             .map_err(|e| anyhow::anyhow!("failed to open graph store: {}", e))?;
-        return reconcile_session_dir_with_snapshot(layout, session_dir, snap);
+        reconcile_session_dir_with_snapshot(layout, session_dir, snap)
     }
 
     #[cfg(not(test))]

--- a/crates/kin-cli/src/commands/resolve.rs
+++ b/crates/kin-cli/src/commands/resolve.rs
@@ -266,7 +266,7 @@ async fn run_continue(
         ),
     );
 
-    crate::backend::require_daemon_commit(&layout, &merge, &state.target_branch).await?;
+    crate::backend::require_daemon_commit(layout, &merge, &state.target_branch).await?;
 
     // Clear the merge state.
     clear_merge_state(layout)?;

--- a/crates/kin-cli/src/commands/review.rs
+++ b/crates/kin-cli/src/commands/review.rs
@@ -1010,9 +1010,9 @@ fn show_review_with_graph(
         for d in &decisions {
             writeln!(
                 text,
-                "  {:?} by {}{}",
+                "  {:?} by {:?}{}",
                 d.state,
-                format!("{:?}", d.reviewer),
+                d.reviewer,
                 d.comment
                     .as_ref()
                     .map(|comment| format!(" - {}", comment))

--- a/crates/kin-cli/src/commands/search.rs
+++ b/crates/kin-cli/src/commands/search.rs
@@ -669,7 +669,7 @@ fn collect_search_results(
     }
 
     if pattern.trim().is_empty() {
-        results.sort_by(|left, right| record_sort_key(left).cmp(&record_sort_key(right)));
+        results.sort_by_key(|left| record_sort_key(left));
     }
     Ok(results)
 }

--- a/crates/kin-cli/src/commands/search.rs
+++ b/crates/kin-cli/src/commands/search.rs
@@ -669,7 +669,7 @@ fn collect_search_results(
     }
 
     if pattern.trim().is_empty() {
-        results.sort_by_key(|left| record_sort_key(left));
+        results.sort_by_key(record_sort_key);
     }
     Ok(results)
 }

--- a/crates/kin-cli/src/commands/setup.rs
+++ b/crates/kin-cli/src/commands/setup.rs
@@ -829,7 +829,7 @@ fn merge_mcp_config(path: &PathBuf) -> Result<()> {
     }
 
     // Ensure mcpServers key exists as an object
-    if !root.get("mcpServers").map_or(false, |v| v.is_object()) {
+    if !root.get("mcpServers").is_some_and(|v| v.is_object()) {
         root["mcpServers"] = serde_json::json!({});
     }
 

--- a/crates/kin-cli/src/commands/status.rs
+++ b/crates/kin-cli/src/commands/status.rs
@@ -147,8 +147,8 @@ pub fn build_status_summary(
     layout: &kin_core::KinLayout,
     graph: &kin_db::InMemoryGraph,
 ) -> Result<StatusSummary> {
-    let current = kin_core::read_current_branch(&layout)?;
-    let source_root = kin_core::source_dir(&layout);
+    let current = kin_core::read_current_branch(layout)?;
+    let source_root = kin_core::source_dir(layout);
     let config = kin_core::KinConfig::load_or_default(&layout.config_path())?;
     let default_remote = config
         .resolve_remote(None)
@@ -197,7 +197,7 @@ pub fn build_status_summary(
     };
 
     // Check for in-progress merge.
-    let merge_state = crate::commands::conflicts::load_merge_state(&layout)
+    let merge_state = crate::commands::conflicts::load_merge_state(layout)
         .ok()
         .flatten()
         .map(|ms| {

--- a/crates/kin-cli/src/commands/support.rs
+++ b/crates/kin-cli/src/commands/support.rs
@@ -171,7 +171,7 @@ fn render_support_json(report: &SupportJson) -> Vec<String> {
         let total = report.total_entities;
         let mut parts: Vec<String> = Vec::new();
         let mut sorted: Vec<_> = report.role_counts.iter().collect();
-        sorted.sort_by(|(a, _), (b, _)| a.cmp(b));
+        sorted.sort_by_key(|(a, _)| *a);
         for (role, count) in sorted {
             parts.push(format!("{}: {}", role.to_lowercase(), count));
         }
@@ -222,7 +222,7 @@ fn render_support_json(report: &SupportJson) -> Vec<String> {
 
 fn render_counts(counts: &BTreeMap<String, usize>) -> Vec<String> {
     let mut entries: Vec<_> = counts.iter().collect();
-    entries.sort_by(|(a, _), (b, _)| a.cmp(b));
+    entries.sort_by_key(|(a, _)| *a);
     if entries.is_empty() {
         return vec!["  (none)".to_string()];
     }

--- a/crates/kin-cli/src/commands/trace_data_flow.rs
+++ b/crates/kin-cli/src/commands/trace_data_flow.rs
@@ -29,7 +29,7 @@ const MAX_LIMIT_PER_STEP: usize = 25;
 const MAX_TOTAL_STEPS: usize = 200;
 
 /// Direction of traversal from the focal entity.
-#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, Default, Serialize, Deserialize, PartialEq, Eq)]
 #[serde(rename_all = "lowercase")]
 pub enum TraceDirection {
     /// Walk outgoing edges (the focal calls / imports / references these).
@@ -37,13 +37,8 @@ pub enum TraceDirection {
     /// Walk incoming edges (these call / import / reference the focal).
     Callers,
     /// Walk both directions and merge into a single chain.
+    #[default]
     Both,
-}
-
-impl Default for TraceDirection {
-    fn default() -> Self {
-        TraceDirection::Both
-    }
 }
 
 impl TraceDirection {

--- a/crates/kin-cli/src/commands/verify.rs
+++ b/crates/kin-cli/src/commands/verify.rs
@@ -362,7 +362,7 @@ pub fn execute_verify_run(
         }
     };
 
-    let evidence_blob = store_evidence_blob(&layout, &evidence_text);
+    let evidence_blob = store_evidence_blob(layout, &evidence_text);
     let run_id = VerificationRunId::new();
     let verification_run = VerificationRun {
         run_id,

--- a/crates/kin-cli/src/daemon_client.rs
+++ b/crates/kin-cli/src/daemon_client.rs
@@ -397,7 +397,7 @@ impl DaemonClient {
             let body = resp.text().await.unwrap_or_default();
             bail!("daemon locate error (HTTP {}): {}", status, body);
         }
-        Ok(resp.json().await.context("parse daemon locate response")?)
+        resp.json().await.context("parse daemon locate response")
     }
 
     pub async fn search(
@@ -417,7 +417,7 @@ impl DaemonClient {
             let body = resp.text().await.unwrap_or_default();
             bail!("daemon search error (HTTP {}): {}", status, body);
         }
-        Ok(resp.json().await.context("parse daemon search response")?)
+        resp.json().await.context("parse daemon search response")
     }
 
     pub async fn support(&self) -> Result<crate::commands::support::SupportJson> {
@@ -432,7 +432,7 @@ impl DaemonClient {
             let body = resp.text().await.unwrap_or_default();
             bail!("daemon support error (HTTP {}): {}", status, body);
         }
-        Ok(resp.json().await.context("parse daemon support response")?)
+        resp.json().await.context("parse daemon support response")
     }
 
     pub async fn context(
@@ -452,7 +452,7 @@ impl DaemonClient {
             let body = resp.text().await.unwrap_or_default();
             bail!("daemon context error (HTTP {}): {}", status, body);
         }
-        Ok(resp.json().await.context("parse daemon context response")?)
+        resp.json().await.context("parse daemon context response")
     }
 
     pub async fn trace(
@@ -472,7 +472,7 @@ impl DaemonClient {
             let body = resp.text().await.unwrap_or_default();
             bail!("daemon trace error (HTTP {}): {}", status, body);
         }
-        Ok(resp.json().await.context("parse daemon trace response")?)
+        resp.json().await.context("parse daemon trace response")
     }
 
     pub async fn impact(
@@ -492,7 +492,7 @@ impl DaemonClient {
             let body = resp.text().await.unwrap_or_default();
             bail!("daemon impact error (HTTP {}): {}", status, body);
         }
-        Ok(resp.json().await.context("parse daemon impact response")?)
+        resp.json().await.context("parse daemon impact response")
     }
 
     pub async fn review(
@@ -512,7 +512,7 @@ impl DaemonClient {
             let body = resp.text().await.unwrap_or_default();
             bail!("daemon review error (HTTP {}): {}", status, body);
         }
-        Ok(resp.json().await.context("parse daemon review response")?)
+        resp.json().await.context("parse daemon review response")
     }
 
     pub async fn embed(
@@ -555,7 +555,7 @@ impl DaemonClient {
             let body = resp.text().await.unwrap_or_default();
             bail!("daemon embed error (HTTP {}): {}", status, body);
         }
-        Ok(resp.json().await.context("parse daemon embed response")?)
+        resp.json().await.context("parse daemon embed response")
     }
 
     pub async fn blame(
@@ -575,7 +575,7 @@ impl DaemonClient {
             let body = resp.text().await.unwrap_or_default();
             bail!("daemon blame error (HTTP {}): {}", status, body);
         }
-        Ok(resp.json().await.context("parse daemon blame response")?)
+        resp.json().await.context("parse daemon blame response")
     }
 
     pub async fn history(
@@ -595,7 +595,7 @@ impl DaemonClient {
             let body = resp.text().await.unwrap_or_default();
             bail!("daemon history error (HTTP {}): {}", status, body);
         }
-        Ok(resp.json().await.context("parse daemon history response")?)
+        resp.json().await.context("parse daemon history response")
     }
 
     pub async fn verify_run(
@@ -615,10 +615,10 @@ impl DaemonClient {
             let body = resp.text().await.unwrap_or_default();
             bail!("daemon verify run error (HTTP {}): {}", status, body);
         }
-        Ok(resp
+        resp
             .json()
             .await
-            .context("parse daemon verify run response")?)
+            .context("parse daemon verify run response")
     }
 
     pub async fn verify_command(
@@ -638,7 +638,7 @@ impl DaemonClient {
             let body = resp.text().await.unwrap_or_default();
             bail!("daemon verify error (HTTP {}): {}", status, body);
         }
-        Ok(resp.json().await.context("parse daemon verify response")?)
+        resp.json().await.context("parse daemon verify response")
     }
 
     pub async fn reconcile(
@@ -658,10 +658,10 @@ impl DaemonClient {
             let body = resp.text().await.unwrap_or_default();
             bail!("daemon reconcile error (HTTP {}): {}", status, body);
         }
-        Ok(resp
+        resp
             .json()
             .await
-            .context("parse daemon reconcile response")?)
+            .context("parse daemon reconcile response")
     }
 
     pub async fn command_status(
@@ -681,10 +681,10 @@ impl DaemonClient {
             let body = resp.text().await.unwrap_or_default();
             bail!("daemon command status error (HTTP {}): {}", status, body);
         }
-        Ok(resp
+        resp
             .json()
             .await
-            .context("parse daemon command status response")?)
+            .context("parse daemon command status response")
     }
 
     pub async fn command_resources(
@@ -704,10 +704,10 @@ impl DaemonClient {
             let body = resp.text().await.unwrap_or_default();
             bail!("daemon command resources error (HTTP {}): {}", status, body);
         }
-        Ok(resp
+        resp
             .json()
             .await
-            .context("parse daemon command resources response")?)
+            .context("parse daemon command resources response")
     }
 
     pub async fn graph_command(
@@ -727,10 +727,10 @@ impl DaemonClient {
             let body = resp.text().await.unwrap_or_default();
             bail!("daemon graph command error (HTTP {}): {}", status, body);
         }
-        Ok(resp
+        resp
             .json()
             .await
-            .context("parse daemon graph command response")?)
+            .context("parse daemon graph command response")
     }
 
     pub async fn overview(
@@ -750,10 +750,10 @@ impl DaemonClient {
             let body = resp.text().await.unwrap_or_default();
             bail!("daemon overview error (HTTP {}): {}", status, body);
         }
-        Ok(resp
+        resp
             .json()
             .await
-            .context("parse daemon overview response")?)
+            .context("parse daemon overview response")
     }
 
     pub async fn dead_code(
@@ -773,10 +773,10 @@ impl DaemonClient {
             let body = resp.text().await.unwrap_or_default();
             bail!("daemon dead-code error (HTTP {}): {}", status, body);
         }
-        Ok(resp
+        resp
             .json()
             .await
-            .context("parse daemon dead-code response")?)
+            .context("parse daemon dead-code response")
     }
 
     pub async fn dead_code_seeded(
@@ -796,10 +796,10 @@ impl DaemonClient {
             let body = resp.text().await.unwrap_or_default();
             bail!("daemon seeded dead-code error (HTTP {}): {}", status, body);
         }
-        Ok(resp
+        resp
             .json()
             .await
-            .context("parse daemon seeded dead-code response")?)
+            .context("parse daemon seeded dead-code response")
     }
 
     pub async fn trace_data_flow(
@@ -819,10 +819,10 @@ impl DaemonClient {
             let body = resp.text().await.unwrap_or_default();
             bail!("daemon trace-data-flow error (HTTP {}): {}", status, body);
         }
-        Ok(resp
+        resp
             .json()
             .await
-            .context("parse daemon trace-data-flow response")?)
+            .context("parse daemon trace-data-flow response")
     }
 
     pub async fn refs(
@@ -842,7 +842,7 @@ impl DaemonClient {
             let body = resp.text().await.unwrap_or_default();
             bail!("daemon refs error (HTTP {}): {}", status, body);
         }
-        Ok(resp.json().await.context("parse daemon refs response")?)
+        resp.json().await.context("parse daemon refs response")
     }
 
     pub async fn bulk_refs(
@@ -862,10 +862,10 @@ impl DaemonClient {
             let body = resp.text().await.unwrap_or_default();
             bail!("daemon bulk-refs error (HTTP {}): {}", status, body);
         }
-        Ok(resp
+        resp
             .json()
             .await
-            .context("parse daemon bulk-refs response")?)
+            .context("parse daemon bulk-refs response")
     }
 
     pub async fn xref(
@@ -885,7 +885,7 @@ impl DaemonClient {
             let body = resp.text().await.unwrap_or_default();
             bail!("daemon xref error (HTTP {}): {}", status, body);
         }
-        Ok(resp.json().await.context("parse daemon xref response")?)
+        resp.json().await.context("parse daemon xref response")
     }
 
     pub async fn diff(
@@ -905,7 +905,7 @@ impl DaemonClient {
             let body = resp.text().await.unwrap_or_default();
             bail!("daemon diff error (HTTP {}): {}", status, body);
         }
-        Ok(resp.json().await.context("parse daemon diff response")?)
+        resp.json().await.context("parse daemon diff response")
     }
 
     pub async fn log(
@@ -925,7 +925,7 @@ impl DaemonClient {
             let body = resp.text().await.unwrap_or_default();
             bail!("daemon log error (HTTP {}): {}", status, body);
         }
-        Ok(resp.json().await.context("parse daemon log response")?)
+        resp.json().await.context("parse daemon log response")
     }
 
     pub async fn audit(
@@ -945,7 +945,7 @@ impl DaemonClient {
             let body = resp.text().await.unwrap_or_default();
             bail!("daemon audit error (HTTP {}): {}", status, body);
         }
-        Ok(resp.json().await.context("parse daemon audit response")?)
+        resp.json().await.context("parse daemon audit response")
     }
 
     pub async fn approvals(
@@ -965,10 +965,10 @@ impl DaemonClient {
             let body = resp.text().await.unwrap_or_default();
             bail!("daemon approvals error (HTTP {}): {}", status, body);
         }
-        Ok(resp
+        resp
             .json()
             .await
-            .context("parse daemon approvals response")?)
+            .context("parse daemon approvals response")
     }
 
     pub async fn security(
@@ -988,10 +988,10 @@ impl DaemonClient {
             let body = resp.text().await.unwrap_or_default();
             bail!("daemon security error (HTTP {}): {}", status, body);
         }
-        Ok(resp
+        resp
             .json()
             .await
-            .context("parse daemon security response")?)
+            .context("parse daemon security response")
     }
 
     pub async fn branch(
@@ -1011,7 +1011,7 @@ impl DaemonClient {
             let body = resp.text().await.unwrap_or_default();
             bail!("daemon branch error (HTTP {}): {}", status, body);
         }
-        Ok(resp.json().await.context("parse daemon branch response")?)
+        resp.json().await.context("parse daemon branch response")
     }
 
     pub async fn checkout(
@@ -1031,10 +1031,10 @@ impl DaemonClient {
             let body = resp.text().await.unwrap_or_default();
             bail!("daemon checkout error (HTTP {}): {}", status, body);
         }
-        Ok(resp
+        resp
             .json()
             .await
-            .context("parse daemon checkout response")?)
+            .context("parse daemon checkout response")
     }
 
     pub async fn rename(
@@ -1054,7 +1054,7 @@ impl DaemonClient {
             let body = resp.text().await.unwrap_or_default();
             bail!("daemon rename error (HTTP {}): {}", status, body);
         }
-        Ok(resp.json().await.context("parse daemon rename response")?)
+        resp.json().await.context("parse daemon rename response")
     }
 
     pub async fn session_workspace(
@@ -1074,10 +1074,10 @@ impl DaemonClient {
             let body = resp.text().await.unwrap_or_default();
             bail!("daemon session workspace error (HTTP {}): {}", status, body);
         }
-        Ok(resp
+        resp
             .json()
             .await
-            .context("parse daemon session workspace response")?)
+            .context("parse daemon session workspace response")
     }
 
     pub async fn exec(
@@ -1097,7 +1097,7 @@ impl DaemonClient {
             let body = resp.text().await.unwrap_or_default();
             bail!("daemon exec error (HTTP {}): {}", status, body);
         }
-        Ok(resp.json().await.context("parse daemon exec response")?)
+        resp.json().await.context("parse daemon exec response")
     }
 
     pub async fn work(
@@ -1117,7 +1117,7 @@ impl DaemonClient {
             let body = resp.text().await.unwrap_or_default();
             bail!("daemon work error (HTTP {}): {}", status, body);
         }
-        Ok(resp.json().await.context("parse daemon work response")?)
+        resp.json().await.context("parse daemon work response")
     }
 
     pub async fn note(
@@ -1137,7 +1137,7 @@ impl DaemonClient {
             let body = resp.text().await.unwrap_or_default();
             bail!("daemon note error (HTTP {}): {}", status, body);
         }
-        Ok(resp.json().await.context("parse daemon note response")?)
+        resp.json().await.context("parse daemon note response")
     }
 
     pub async fn set_scope(&self, session_id: &str, ref_string: &str) -> Result<ScopeResponse> {
@@ -1154,7 +1154,7 @@ impl DaemonClient {
             let body = resp.text().await.unwrap_or_default();
             bail!("daemon error (HTTP {}): {}", status, body);
         }
-        Ok(resp.json().await.context("parse scope response")?)
+        resp.json().await.context("parse scope response")
     }
 
     pub async fn clear_scope(&self, session_id: &str) -> Result<()> {
@@ -1922,7 +1922,7 @@ async fn wait_for_daemon_ready(
             match client.get(format!("{base_url}/readiness")).send().await {
                 Ok(resp) if resp.status().is_success() => {
                     let health_result: Result<HealthResponse> = async {
-                        Ok(client
+                        client
                             .get(format!("{base_url}/health"))
                             .send()
                             .await
@@ -1931,7 +1931,7 @@ async fn wait_for_daemon_ready(
                             .context("daemon health returned an error")?
                             .json()
                             .await
-                            .context("parse daemon health response")?)
+                            .context("parse daemon health response")
                     }
                     .await;
                     match health_result.and_then(|health| {

--- a/crates/kin-cli/src/daemon_client.rs
+++ b/crates/kin-cli/src/daemon_client.rs
@@ -615,8 +615,7 @@ impl DaemonClient {
             let body = resp.text().await.unwrap_or_default();
             bail!("daemon verify run error (HTTP {}): {}", status, body);
         }
-        resp
-            .json()
+        resp.json()
             .await
             .context("parse daemon verify run response")
     }
@@ -658,10 +657,7 @@ impl DaemonClient {
             let body = resp.text().await.unwrap_or_default();
             bail!("daemon reconcile error (HTTP {}): {}", status, body);
         }
-        resp
-            .json()
-            .await
-            .context("parse daemon reconcile response")
+        resp.json().await.context("parse daemon reconcile response")
     }
 
     pub async fn command_status(
@@ -681,8 +677,7 @@ impl DaemonClient {
             let body = resp.text().await.unwrap_or_default();
             bail!("daemon command status error (HTTP {}): {}", status, body);
         }
-        resp
-            .json()
+        resp.json()
             .await
             .context("parse daemon command status response")
     }
@@ -704,8 +699,7 @@ impl DaemonClient {
             let body = resp.text().await.unwrap_or_default();
             bail!("daemon command resources error (HTTP {}): {}", status, body);
         }
-        resp
-            .json()
+        resp.json()
             .await
             .context("parse daemon command resources response")
     }
@@ -727,8 +721,7 @@ impl DaemonClient {
             let body = resp.text().await.unwrap_or_default();
             bail!("daemon graph command error (HTTP {}): {}", status, body);
         }
-        resp
-            .json()
+        resp.json()
             .await
             .context("parse daemon graph command response")
     }
@@ -750,10 +743,7 @@ impl DaemonClient {
             let body = resp.text().await.unwrap_or_default();
             bail!("daemon overview error (HTTP {}): {}", status, body);
         }
-        resp
-            .json()
-            .await
-            .context("parse daemon overview response")
+        resp.json().await.context("parse daemon overview response")
     }
 
     pub async fn dead_code(
@@ -773,10 +763,7 @@ impl DaemonClient {
             let body = resp.text().await.unwrap_or_default();
             bail!("daemon dead-code error (HTTP {}): {}", status, body);
         }
-        resp
-            .json()
-            .await
-            .context("parse daemon dead-code response")
+        resp.json().await.context("parse daemon dead-code response")
     }
 
     pub async fn dead_code_seeded(
@@ -796,8 +783,7 @@ impl DaemonClient {
             let body = resp.text().await.unwrap_or_default();
             bail!("daemon seeded dead-code error (HTTP {}): {}", status, body);
         }
-        resp
-            .json()
+        resp.json()
             .await
             .context("parse daemon seeded dead-code response")
     }
@@ -819,8 +805,7 @@ impl DaemonClient {
             let body = resp.text().await.unwrap_or_default();
             bail!("daemon trace-data-flow error (HTTP {}): {}", status, body);
         }
-        resp
-            .json()
+        resp.json()
             .await
             .context("parse daemon trace-data-flow response")
     }
@@ -862,10 +847,7 @@ impl DaemonClient {
             let body = resp.text().await.unwrap_or_default();
             bail!("daemon bulk-refs error (HTTP {}): {}", status, body);
         }
-        resp
-            .json()
-            .await
-            .context("parse daemon bulk-refs response")
+        resp.json().await.context("parse daemon bulk-refs response")
     }
 
     pub async fn xref(
@@ -965,10 +947,7 @@ impl DaemonClient {
             let body = resp.text().await.unwrap_or_default();
             bail!("daemon approvals error (HTTP {}): {}", status, body);
         }
-        resp
-            .json()
-            .await
-            .context("parse daemon approvals response")
+        resp.json().await.context("parse daemon approvals response")
     }
 
     pub async fn security(
@@ -988,10 +967,7 @@ impl DaemonClient {
             let body = resp.text().await.unwrap_or_default();
             bail!("daemon security error (HTTP {}): {}", status, body);
         }
-        resp
-            .json()
-            .await
-            .context("parse daemon security response")
+        resp.json().await.context("parse daemon security response")
     }
 
     pub async fn branch(
@@ -1031,10 +1007,7 @@ impl DaemonClient {
             let body = resp.text().await.unwrap_or_default();
             bail!("daemon checkout error (HTTP {}): {}", status, body);
         }
-        resp
-            .json()
-            .await
-            .context("parse daemon checkout response")
+        resp.json().await.context("parse daemon checkout response")
     }
 
     pub async fn rename(
@@ -1074,8 +1047,7 @@ impl DaemonClient {
             let body = resp.text().await.unwrap_or_default();
             bail!("daemon session workspace error (HTTP {}): {}", status, body);
         }
-        resp
-            .json()
+        resp.json()
             .await
             .context("parse daemon session workspace response")
     }

--- a/crates/kin-cli/src/main.rs
+++ b/crates/kin-cli/src/main.rs
@@ -2126,18 +2126,13 @@ fn main() -> Result<()> {
                                                 }
                                             }
                                         }
-                                        if stage_info.is_empty() {
-                                            if !debug.resolved_files.is_empty() {
-                                                if let Some(rf) = debug
-                                                    .resolved_files
-                                                    .iter()
-                                                    .find(|r| r.path == *g)
-                                                {
-                                                    stage_info = format!(
-                                                        " (resolved at score {:.1})",
-                                                        rf.score
-                                                    );
-                                                }
+                                        if stage_info.is_empty() && !debug.resolved_files.is_empty()
+                                        {
+                                            if let Some(rf) =
+                                                debug.resolved_files.iter().find(|r| r.path == *g)
+                                            {
+                                                stage_info =
+                                                    format!(" (resolved at score {:.1})", rf.score);
                                             }
                                         }
                                         if stage_info.is_empty() {

--- a/crates/kin-cli/src/profile.rs
+++ b/crates/kin-cli/src/profile.rs
@@ -507,7 +507,7 @@ where
             if attrs.is_contextual() {
                 ctx.current_span()
                     .id()
-                    .and_then(|parent| span_profile_id(&parent, ctx))
+                    .and_then(|parent| span_profile_id(parent, ctx))
             } else {
                 None
             }

--- a/crates/kin-cli/src/progress.rs
+++ b/crates/kin-cli/src/progress.rs
@@ -43,7 +43,7 @@ impl Progress {
         } else {
             // Non-TTY: print every 10th update as a full line
             // (avoids flooding CI/pipe output with hundreds of lines)
-            if self.updates <= 1 || self.updates % 10 == 0 {
+            if self.updates <= 1 || self.updates.is_multiple_of(10) {
                 eprintln!("  {msg}");
             }
         }

--- a/crates/kin-cli/src/retrieval_profile.rs
+++ b/crates/kin-cli/src/retrieval_profile.rs
@@ -52,12 +52,13 @@ pub fn reset_daemon_serving_for_tests() {
 }
 
 /// Versioned retrieval quality profile. Selected via `KIN_PROFILE`.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
 pub enum RetrievalProfile {
     /// Measured-accuracy defaults (current version).
     AccuracyV1,
     /// Pre-profile behavior: cosine-only `semantic_locate`, historical lever
     /// defaults. Kept for A/B comparison and as an escape hatch.
+    #[default]
     CompatV0,
 }
 
@@ -190,12 +191,6 @@ impl RetrievalProfile {
             Self::AccuracyV1 => 0.625,
             Self::CompatV0 => 0.25,
         }
-    }
-}
-
-impl Default for RetrievalProfile {
-    fn default() -> Self {
-        Self::CompatV0
     }
 }
 

--- a/crates/kin-cli/tests/locate_json_stdout.rs
+++ b/crates/kin-cli/tests/locate_json_stdout.rs
@@ -383,7 +383,7 @@ fn locate_ref_can_resolve_historical_files_from_the_public_cli() {
         .collect();
 
     assert!(
-        historical_paths.iter().any(|path| *path == "src/lib.py"),
+        historical_paths.contains(&"src/lib.py"),
         "historical locate should surface src/lib.py, got {historical_paths:?}"
     );
     assert!(
@@ -517,7 +517,7 @@ fn locate_ref_hydrates_missing_imported_git_history_on_demand() {
         .filter_map(|entry| entry["path"].as_str())
         .collect::<Vec<_>>();
     assert!(
-        files.iter().any(|path| *path == "src/lib.py"),
+        files.contains(&"src/lib.py"),
         "historical locate should surface hydrated imported Git file, got {:?}",
         files
     );


### PR DESCRIPTION
First chunk of the kin-cli clippy debt burndown: 113 of 142 path-filtered warnings eliminated across 21 mechanical, behavior-preserving categories (needless_question_mark 37, needless_borrow 18, unnecessary_sort_by 10, clone_on_copy 8, unnecessary_map_or 8, and 16 more) — one commit per category, kin-cli lib suite (704 tests) green after every commit, each diff hand-reviewed. The remaining 29 are exactly the judgment-requiring set (too_many_arguments, ptr_arg, type_complexity, …) — all already in the CI allowlist, deliberately out of mechanical scope.

fmt clean; the exact ci.yml 45-lint allowlist invocation passes with -D warnings; all targets compile. Daemon-spawning integration tests compile and run in CI (not run locally — lane serialization).

Part of FIR-844 (chunk 1 of the burndown).
