### PR TITLE
chore: bump version to 0.2.8

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3039,11 +3039,11 @@ dependencies = [
 
 [[package]]
 name = "kin-buildinfo"
-version = "0.2.7"
+version = "0.2.8"
 
 [[package]]
 name = "kin-cli"
-version = "0.2.7"
+version = "0.2.8"
 dependencies = [
  "age",
  "anyhow",
@@ -3110,7 +3110,7 @@ dependencies = [
 
 [[package]]
 name = "kin-context"
-version = "0.2.7"
+version = "0.2.8"
 dependencies = [
  "kin-blobs",
  "kin-db",
@@ -3126,7 +3126,7 @@ dependencies = [
 
 [[package]]
 name = "kin-core"
-version = "0.2.7"
+version = "0.2.8"
 dependencies = [
  "chrono",
  "directories 5.0.1",
@@ -3150,7 +3150,7 @@ dependencies = [
 
 [[package]]
 name = "kin-daemon"
-version = "0.2.7"
+version = "0.2.8"
 dependencies = [
  "async-stream",
  "axum",
@@ -3239,7 +3239,7 @@ dependencies = [
 
 [[package]]
 name = "kin-git"
-version = "0.2.7"
+version = "0.2.8"
 dependencies = [
  "chrono",
  "gix",
@@ -3257,7 +3257,7 @@ dependencies = [
 
 [[package]]
 name = "kin-index"
-version = "0.2.7"
+version = "0.2.8"
 dependencies = [
  "hex",
  "kin-blobs",
@@ -3303,7 +3303,7 @@ dependencies = [
 
 [[package]]
 name = "kin-integration-tests"
-version = "0.2.7"
+version = "0.2.8"
 dependencies = [
  "kin-blobs",
  "kin-cli",
@@ -3345,7 +3345,7 @@ dependencies = [
 
 [[package]]
 name = "kin-mcp"
-version = "0.2.7"
+version = "0.2.8"
 dependencies = [
  "kin-blobs",
  "kin-context",
@@ -3372,7 +3372,7 @@ dependencies = [
 
 [[package]]
 name = "kin-migrate"
-version = "0.2.7"
+version = "0.2.8"
 dependencies = [
  "chrono",
  "kin-blobs",
@@ -3414,7 +3414,7 @@ dependencies = [
 
 [[package]]
 name = "kin-parser"
-version = "0.2.7"
+version = "0.2.8"
 dependencies = [
  "kin-model",
  "pretty_assertions",
@@ -3443,7 +3443,7 @@ dependencies = [
 
 [[package]]
 name = "kin-projection"
-version = "0.2.7"
+version = "0.2.8"
 dependencies = [
  "kin-blobs",
  "kin-db",
@@ -3458,7 +3458,7 @@ dependencies = [
 
 [[package]]
 name = "kin-ranking"
-version = "0.2.7"
+version = "0.2.8"
 dependencies = [
  "kin-model",
  "serde",
@@ -3467,7 +3467,7 @@ dependencies = [
 
 [[package]]
 name = "kin-reconcile"
-version = "0.2.7"
+version = "0.2.8"
 dependencies = [
  "kin-blobs",
  "kin-db",
@@ -3487,7 +3487,7 @@ dependencies = [
 
 [[package]]
 name = "kin-registry"
-version = "0.2.7"
+version = "0.2.8"
 dependencies = [
  "axum",
  "base64 0.22.1",
@@ -3512,7 +3512,7 @@ dependencies = [
 
 [[package]]
 name = "kin-remote"
-version = "0.2.7"
+version = "0.2.8"
 dependencies = [
  "chrono",
  "kin-model",
@@ -3528,7 +3528,7 @@ dependencies = [
 
 [[package]]
 name = "kin-review"
-version = "0.2.7"
+version = "0.2.8"
 dependencies = [
  "kin-blobs",
  "kin-db",
@@ -3543,7 +3543,7 @@ dependencies = [
 
 [[package]]
 name = "kin-runtime"
-version = "0.2.7"
+version = "0.2.8"
 dependencies = [
  "chrono",
  "hex",
@@ -3575,7 +3575,7 @@ dependencies = [
 
 [[package]]
 name = "kin-semantic-contracts"
-version = "0.2.7"
+version = "0.2.8"
 dependencies = [
  "kin-db",
  "kin-model",
@@ -3590,7 +3590,7 @@ dependencies = [
 
 [[package]]
 name = "kin-spine"
-version = "0.2.7"
+version = "0.2.8"
 dependencies = [
  "chrono",
  "hashbrown 0.15.5",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,7 +27,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.2.7"
+version = "0.2.8"
 edition = "2021"
 license = "Apache-2.0"
 authors = ["Troy Fortin <troy@firelock.ai>"]


### PR DESCRIPTION
Release 0.2.8 — ships today's landed work to users: qualified-path call resolution + module-body recursion (blast-radius recall), deterministic review output (finding-representative stabilization), kin-vector 0.1.6 with SIMD default-on, kin-infer 0.2.40 with cgroup-aware resource planning, the setup ledger/doctor/verified-uninstall trio, small-machine fixes (capability-tier honesty, bounded embed, genesis RSS), the toml 1.x port, and the clippy chunk. On merge the auto-tag fires release.yml across all platforms — including the first live exercise of the new version_tag_image job (ghcr :0.2.8/:v0.2.8 pins).
