### PR TITLE
chore(deps): refresh Kin registry dependency pins

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3199,9 +3199,9 @@ dependencies = [
 
 [[package]]
 name = "kin-db"
-version = "0.2.29"
+version = "0.2.31"
 source = "sparse+https://kinlab.ai/registry/cargo/"
-checksum = "b8db25ed526e6ba34c69d1d1f4db648c63dabceb61c3549b9399c09662d801c7"
+checksum = "0a0f75ffa9eaeac70cd85699908392c122f3071270676a8ff177983b912aeb73"
 dependencies = [
  "bincode",
  "bytes",
@@ -3330,9 +3330,9 @@ dependencies = [
 
 [[package]]
 name = "kin-lsp"
-version = "0.2.1"
+version = "0.2.2"
 source = "sparse+https://kinlab.ai/registry/cargo/"
-checksum = "9c7c7e73c7a2baadbecfc93e3c9603346b688d49359bf75f341cba6c5549f3a2"
+checksum = "b6f4d495f89be0c1538ae99be3855fca0469c0c68be5522aac1caa04f02e0f51"
 dependencies = [
  "kin-model",
  "serde",
@@ -3562,9 +3562,9 @@ dependencies = [
 
 [[package]]
 name = "kin-search"
-version = "0.1.2"
+version = "0.1.4"
 source = "sparse+https://kinlab.ai/registry/cargo/"
-checksum = "370ae50ac9eede78dba38b45ff5e9ea24f5c3c634b626a2408a20981db5c2769"
+checksum = "c22df488cae18fe19e80f2e07e5a117f2c8362bf776509a3cb8a0b8a818bbbfa"
 dependencies = [
  "bincode",
  "parking_lot",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -137,13 +137,13 @@ kin-daemon = { path = "crates/kin-daemon" }
 kin-mcp = { path = "crates/kin-mcp" }
 kin-spine = { path = "crates/kin-spine" }
 kin-registry = { path = "crates/kin-registry" }
-kin-lsp = { version = "0.2.1", registry = "kin" }
+kin-lsp = { version = "0.2.2", registry = "kin" }
 # Cross-platform base: NO "metal" here. `[workspace.dependencies]` entries cannot be
 # `[target.'cfg(...)']`-gated, so listing "metal" here forces the macOS-only kin-infer/metal
 # backend on every target (incl. Linux, where it cannot compile). Metal is re-enabled
 # additively on macOS via a `[target.'cfg(target_os = "macos")'.dependencies]` block in the
 # binary/runtime crates (kin-cli, kin-daemon). Feature unification makes that additive.
-kin-db = { version = "0.2.29", registry = "kin", default-features = false, features = ["vector", "embeddings"] }
+kin-db = { version = "0.2.31", registry = "kin", default-features = false, features = ["vector", "embeddings"] }
 kin-vfs-core = { version = "0.1.2", registry = "kin" }
 
 [profile.release]


### PR DESCRIPTION
Automated Kin registry dependency wave.

This PR updates Cargo registry dependency pins after a verified Kin registry publish and runs the repo smoke command before opening the PR.