### PR TITLE
docs: honest per-language support matrix

### DIFF
--- a/docs/language-support.md
+++ b/docs/language-support.md
@@ -1,0 +1,69 @@
+# Language Support
+
+Kin classifies every file at ingest and extracts as much semantic structure as
+the language's adapter provides. This page states exactly what each language
+gets today — no tier is implied beyond what the extraction actually emits.
+
+## How classification works
+
+Whole-repo ingest (`kin init`) routes each file into one of four tiers:
+
+| Tier | What the graph stores |
+| --- | --- |
+| **Full semantic** | Entities (functions, classes, methods, types…), relations (calls, containment, inheritance…), test detection, doc/comment summaries |
+| **Shallow syntax** | Coarse top-level declarations + imports + a syntax fingerprint — no call graph, no nested entities, no tests, no docs |
+| **Structured artifact** | Dedicated extractors for manifests and configs (Cargo.toml, package.json, go.mod, pom.xml, Dockerfile, CI configs, SQL migrations…) |
+| **Opaque artifact** | Content hash + MIME hint. Never dropped, never parsed |
+
+Incremental edits (reconcile/watch) resolve adapters by file extension and can
+reach further than whole-repo ingest for a few languages — noted below.
+
+## Full semantic support
+
+| Language | Entities | Relations | Tests | Docs | LSP enrichment |
+| --- | --- | --- | --- | --- | --- |
+| TypeScript | ✓ | calls, contains, extends, implements, references | ✓ (jest) | ✓ | ✓ typescript-language-server |
+| JavaScript | ✓ | calls, contains, extends, references | ✓ | ✓ | ✓ typescript-language-server |
+| Python | ✓ | calls, contains, extends, references | ✓ (pytest) | ✓ | ✓ pyright / pylsp |
+| Go | ✓ | calls, contains, extends, implements, references, sends-message, spawns | ✓ | ✓ | ✓ gopls |
+| Java | ✓ | calls, contains, extends, implements, references | ✓ (junit) | ✓ | ✓ jdtls |
+| Rust | ✓ | calls, contains, implements, references | ✓ (cargo) | ✓ | ✓ rust-analyzer |
+| C++ | ✓ | calls, contains, extends, imports, references, uses-macro | ✓ | ✓ | ✓ clangd |
+| C | ✓ | calls, imports, references, uses-macro | — | ✓ | ✓ clangd |
+| Kotlin | ✓ | calls, contains, extends, implements, references | ✓ | ✓ | — |
+| C# | ✓ | calls, contains, extends, references | — | ✓ | — |
+| Ruby | ✓ | calls, contains, extends, references | — | ✓ | — |
+
+## Full adapters not yet routed by whole-repo ingest
+
+Swift, PHP, and HCL/Terraform have complete adapters (with relations, and for
+Swift/PHP test + doc extraction) that currently apply only on incremental
+edits. Whole-repo ingest classifies Swift and PHP as shallow syntax and
+HCL/Terraform as opaque. Until ingest routing is unified, treat their
+effective support as the lower tier.
+
+## Shallow syntax support
+
+Grammar-backed shallow extraction (declarations + imports + fingerprint, no
+call graph): C, C++, C#, Ruby, PHP, Swift — used when a file reaches the
+shallow tier.
+
+The following extensions are currently **classified as shallow but have no
+grammar wired**, so they degrade to opaque in practice: Scala, Lua, R, Zig,
+Elixir, Erlang, Haskell, OCaml, Perl. Treat these as unsupported for semantic
+extraction today.
+
+## LSP enrichment
+
+When the corresponding language server binary is installed, Kin adds
+type-resolved relations on top of the parser output (call hierarchy,
+overrides, uses-type, references — each tagged with LSP origin and a
+confidence weight): Rust, Python, TypeScript, JavaScript, Go, Java, C, C++.
+Enrichment is skipped silently when the server binary is absent.
+
+## Everything else
+
+Any file without an adapter is stored as an opaque artifact: content-addressed
+and versioned, visible to file-level operations, invisible to semantic
+queries. Markdown, JSON, YAML, and other structured-text formats currently
+fall in this tier unless a structured-artifact extractor matches them.


### PR DESCRIPTION
Adds `docs/language-support.md` — the per-language truth of what extraction actually emits, source-verified against the parser registry, the ingest classifier, and kin-lsp:

- Full-semantic table (11 languages) with per-language relations/tests/docs/LSP columns.
- Honest callout: Swift, PHP, and HCL ship complete adapters that whole-repo ingest does not yet route (classifier gap — tracked internally); effective support documented at the lower tier until routing is unified.
- Grammar-backed shallow set vs the classified-but-grammarless extensions that silently degrade to opaque (documented as unsupported).
- LSP enrichment: 8 languages, 4 type-resolved relation kinds, runtime-gated on server binaries.

Docs-only.