### PR TITLE
test(kin-cli): serialize status tests that read process-global env

### DIFF
--- a/crates/kin-cli/src/commands/status.rs
+++ b/crates/kin-cli/src/commands/status.rs
@@ -514,6 +514,7 @@ mod tests {
     }
 
     #[tokio::test]
+    #[serial_test::serial]
     async fn load_status_rejects_non_kin_repo() {
         let dir = tempfile::tempdir().unwrap();
         let err = load_status(dir.path()).await.unwrap_err();
@@ -523,6 +524,7 @@ mod tests {
     }
 
     #[tokio::test]
+    #[serial_test::serial]
     async fn load_status_marks_bootstrap_only_repo_as_blocked() {
         let dir = tempfile::tempdir().unwrap();
         let result = kin_core::init(dir.path()).unwrap();
@@ -550,6 +552,7 @@ mod tests {
     }
 
     #[tokio::test]
+    #[serial_test::serial]
     async fn load_status_marks_materialized_repo_as_ready() {
         let dir = tempfile::tempdir().unwrap();
         let result = kin_core::init(dir.path()).unwrap();
@@ -576,6 +579,7 @@ mod tests {
     }
 
     #[tokio::test]
+    #[serial_test::serial]
     async fn run_for_cwd_returns_error_for_bootstrap_only_repo() {
         let dir = tempfile::tempdir().unwrap();
         kin_core::init(dir.path()).unwrap();
@@ -589,6 +593,7 @@ mod tests {
     }
 
     #[tokio::test]
+    #[serial_test::serial]
     async fn status_hints_do_not_mention_git_import() {
         let dir = tempfile::tempdir().unwrap();
         kin_core::init(dir.path()).unwrap();
@@ -607,6 +612,7 @@ mod tests {
     }
 
     #[tokio::test]
+    #[serial_test::serial]
     async fn run_for_cwd_returns_error_when_current_branch_is_missing_from_graph() {
         let dir = tempfile::tempdir().unwrap();
         let result = kin_core::init(dir.path()).unwrap();


### PR DESCRIPTION
## Problem

`commands::status::tests::load_status_rejects_non_kin_repo` — and its five sibling async tests in the same module — pass in isolation but intermittently fail under the default parallel test scheduler.

All six tests drive `load_status` / `run_for_cwd`, which resolve a repository through `kin_core::KinLayout::discover`. `discover` consults the **process environment** to decide repository membership:

- it short-circuits to `Some(..)` when `KIN_DAEMON_URL` is set, bypassing the on-disk `.kin/` check entirely;
- it reads `KIN_ALLOW_PARENT_STORE` when a nested-repository boundary is crossed.

These are `std::env::var` reads against the shared, process-global `environ`. Many other tests in the same `kin-cli` test binary mutate the environment via `std::env::set_var` / `remove_var` (e.g. `locate.rs`, `retrieval_profile.rs`, `with.rs`). Concurrent reads and writes of the process environment are a data race: a status test can observe a torn value for the vars `discover` reads, so discovery returns an unexpected result and the assertion (`starts_with("not a Kin repository ...")`, plus the readiness/branch assertions in the siblings) flakes.

The environment-mutating tests are already `#[serial_test::serial]`, but `serial` only excludes *other serial tests* — it does not stop a non-serial reader from running concurrently with a serial writer. The status tests were not serial, so they raced.

## Fix

Mark the six `discover`-backed async tests `#[serial_test::serial]`. serial_test's default (keyless) lock is process-global, so these now run mutually exclusive with every existing environment-mutating serial test in the crate. This is the established pattern across the CLI suite (`init.rs`, `with.rs`, `locate.rs`, `auth.rs`, `session_workspace.rs`). `serial_test` is already a dev-dependency; no production code and no test assertions change.

The pure `#[test]` unit tests in the module (`semantic_coverage_*`, `command_status_response_*`) do not read the environment and are intentionally left unserialized.

## Note on the branch name

The branch is named for a "cwd race", but the mechanism verified in source is the **process-environment** read inside `discover`, not `current_dir()`: the test helper already takes an explicit directory argument, so the checked path is not global. Serializing against the crate's env-mutating tests is the correct remedy for the real shared-global dependency.

## Verification

Not run locally by design — a citable benchmark currently owns this machine and must not share the test runtime. CI (`fmt` + `clippy` + `build --all-targets` + `cargo test --workspace`) verifies the change remotely. The edit is attribute-only (+6 lines) and additive.
