### PR TITLE
fix(daemon): single-flight git-ancestry hydration

### DIFF
--- a/crates/kin-cli/src/commands/ref_lookup.rs
+++ b/crates/kin-cli/src/commands/ref_lookup.rs
@@ -254,6 +254,22 @@ fn extract_git_ref(reference: &str) -> Option<&str> {
     None
 }
 
+/// Returns true when resolving `reference` would import a full Git ancestry that
+/// is not yet present in `graph`. Callers use this to decide whether a request
+/// must take a serialized hydration gate before resolving: already-imported or
+/// non-Git refs stay on the lock-free fast path. Conservative on lookup error —
+/// an unresolved presence check reports `true` so a real import is never left
+/// unserialized.
+pub fn git_ref_requires_hydration(graph: &kin_db::InMemoryGraph, reference: &str) -> bool {
+    let Some(git_oid) = extract_git_ref(reference) else {
+        return false;
+    };
+    let Ok(imported_change_id) = kin_git::semantic_change_id_from_git_oid_hex(git_oid) else {
+        return false;
+    };
+    !matches!(graph.get_change(&imported_change_id), Ok(Some(_)))
+}
+
 fn hydrate_imported_git_ref(
     graph: &kin_db::InMemoryGraph,
     layout: &kin_core::KinLayout,

--- a/crates/kin-daemon/src/api.rs
+++ b/crates/kin-daemon/src/api.rs
@@ -1444,8 +1444,22 @@ async fn set_scope(
     let state_clone = Arc::clone(&state);
     let ref_string = req.ref_string.clone();
     let timeout = scope_build_timeout();
+    // A deep scope base_commit lazily imports its full ancestry; serialize that
+    // against every other daemon hydration so two deep imports never run at once
+    // (roughly 2x peak memory → OOM). Already-imported refs skip the gate and
+    // stay on the fast path. Acquired here (async) and moved into the blocking
+    // task so it is held for the whole import.
+    let hydration_gate = if kin_cli::commands::ref_lookup::git_ref_requires_hydration(
+        state.graph.as_ref(),
+        &ref_string,
+    ) {
+        Some(Arc::clone(&state.hydration_gate).lock_owned().await)
+    } else {
+        None
+    };
     let scope_task = tokio::task::spawn_blocking(
         move || -> std::result::Result<_, (StatusCode, String)> {
+            let _hydration_gate = hydration_gate;
             // Resolve the ref to a SemanticChangeId using the LOCATE resolve mode
             // (enrich_semantics=false). Scope-for-retrieval only needs the
             // base_commit's tree state; the full per-commit semantic-delta enrichment
@@ -3069,6 +3083,17 @@ async fn locate(
 
     let mut result = if let Some(reference) = req.reference.as_deref() {
         // Explicit --ref always takes precedence over session scope.
+        // Locating at an unimported Git ref lazily imports its full ancestry;
+        // serialize that against every other daemon hydration. Already-imported
+        // refs skip the gate and stay on the fast path.
+        let _hydration_gate = if kin_cli::commands::ref_lookup::git_ref_requires_hydration(
+            state.graph.as_ref(),
+            reference,
+        ) {
+            Some(state.hydration_gate.lock().await)
+        } else {
+            None
+        };
         let resolved = kin_cli::commands::ref_lookup::resolve_ref_importing_git_if_needed_for_locate_with_report(
             state.graph.as_ref(),
             &state.layout,
@@ -3354,6 +3379,22 @@ async fn review(
         let session_id = extract_session_id_from_headers(&headers)?;
         resolve_session_graph(&state, session_id.as_ref()).await
     };
+    // A shadow review over an unimported Git ref lazily imports its full
+    // ancestry; serialize that against every other daemon hydration so two deep
+    // imports never run at once. Already-imported (or non-Git) refs skip the
+    // gate and stay on the fast path.
+    let needs_hydration = match &req {
+        kin_cli::commands::review::ReviewRequest::Shadow { base, head, .. } => {
+            kin_cli::commands::ref_lookup::git_ref_requires_hydration(graph.as_ref(), base)
+                || kin_cli::commands::ref_lookup::git_ref_requires_hydration(graph.as_ref(), head)
+        }
+        _ => false,
+    };
+    let _hydration_gate = if needs_hydration {
+        Some(state.hydration_gate.lock().await)
+    } else {
+        None
+    };
     let execution =
         kin_cli::commands::review::execute_review_request(&state.layout, graph.as_ref(), req)
             .await
@@ -3578,6 +3619,17 @@ async fn blame(
 
     let session_id = extract_session_id_from_headers(&headers)?;
     let graph = resolve_session_graph(&state, session_id.as_ref()).await;
+    // Blaming at an unimported Git ref lazily imports its full ancestry;
+    // serialize that against every other daemon hydration. Already-imported (or
+    // absent) refs skip the gate and stay on the fast path.
+    let needs_hydration = req.reference.as_deref().is_some_and(|reference| {
+        kin_cli::commands::ref_lookup::git_ref_requires_hydration(graph.as_ref(), reference)
+    });
+    let _hydration_gate = if needs_hydration {
+        Some(state.hydration_gate.lock().await)
+    } else {
+        None
+    };
     let execution =
         kin_cli::commands::blame::execute_blame_request(&state.layout, graph.as_ref(), &req)
             .map_err(internal_error)?;
@@ -3607,6 +3659,17 @@ async fn history(
 
     let session_id = extract_session_id_from_headers(&headers)?;
     let graph = resolve_session_graph(&state, session_id.as_ref()).await;
+    // History at an unimported Git ref lazily imports its full ancestry;
+    // serialize that against every other daemon hydration. Already-imported (or
+    // absent) refs skip the gate and stay on the fast path.
+    let needs_hydration = req.reference.as_deref().is_some_and(|reference| {
+        kin_cli::commands::ref_lookup::git_ref_requires_hydration(graph.as_ref(), reference)
+    });
+    let _hydration_gate = if needs_hydration {
+        Some(state.hydration_gate.lock().await)
+    } else {
+        None
+    };
     let execution =
         kin_cli::commands::history::execute_history_request(&state.layout, graph.as_ref(), &req)
             .map_err(internal_error)?;

--- a/crates/kin-daemon/src/state.rs
+++ b/crates/kin-daemon/src/state.rs
@@ -389,6 +389,17 @@ pub struct DaemonState {
     pub locate_rankings: Mutex<HashMap<String, CachedLocateRanking>>,
     /// Cached `semantic_locate` result pages keyed by paging-cursor key.
     pub semantic_locate_pages: Mutex<HashMap<String, CachedSemanticPage>>,
+    /// Serializes lazy git-ancestry hydration — the full-history import behind a
+    /// `review`/`history`/`blame`/`locate --ref`/`scope` ref that names an
+    /// unimported Git commit. At most one such import runs at a time: two
+    /// concurrent deep imports roughly double peak memory and can OOM-kill the
+    /// daemon. Concurrent requests for the SAME unimported commit coalesce —
+    /// whoever wins the gate imports it, and later waiters observe it already
+    /// present (the get-or-build guard in `hydrate_imported_git_ref`) and skip
+    /// the re-import. Held across the request `.await` (and moved into the
+    /// `set_scope` blocking task), so it is a tokio mutex behind an `Arc` — not
+    /// the std locks used for the synchronous critical sections above.
+    pub hydration_gate: Arc<tokio::sync::Mutex<()>>,
 }
 
 /// Cached full locate entity-ranking for cursor paging. The daemon caches the
@@ -661,6 +672,7 @@ impl DaemonState {
             mcp_transactions: Mutex::new(HashMap::new()),
             locate_rankings: Mutex::new(HashMap::new()),
             semantic_locate_pages: Mutex::new(HashMap::new()),
+            hydration_gate: Arc::new(tokio::sync::Mutex::new(())),
         };
         // Restore in-flight MCP transactions persisted before a restart
         // so staged-but-uncommitted work is not silently dropped across a daemon
@@ -798,6 +810,7 @@ impl DaemonState {
             mcp_transactions: Mutex::new(HashMap::new()),
             locate_rankings: Mutex::new(HashMap::new()),
             semantic_locate_pages: Mutex::new(HashMap::new()),
+            hydration_gate: Arc::new(tokio::sync::Mutex::new(())),
         };
 
         // Restore in-flight MCP transactions persisted before a restart.
@@ -2072,6 +2085,7 @@ mod tests {
             mcp_transactions: Mutex::new(HashMap::new()),
             locate_rankings: Mutex::new(HashMap::new()),
             semantic_locate_pages: Mutex::new(HashMap::new()),
+            hydration_gate: Arc::new(tokio::sync::Mutex::new(())),
         }
     }
 


### PR DESCRIPTION
Serializes the daemon's lazy git-ancestry hydration behind one async gate, with a lock-free warm-path pre-check.

**Problem**: any request whose ref is absent from the change DAG triggers a full-ancestry import + per-commit semantic enrich (~35 min on django-scale history). Nothing serializes it: two concurrent hydrations (same or different oids) duplicate the import and roughly double peak memory — the observed daemon OOM death ("connection closed before message completed"). Five daemon paths can trigger it: review, blame, history, locate --ref, set_scope.

**Change** (+93 lines, 3 files):
- `git_ref_requires_hydration` (ref_lookup.rs): O(1) presence pre-check — warm/non-git refs never touch the gate.
- `DaemonState.hydration_gate: Arc<tokio::sync::Mutex<()>>` — held across await; owned guard moved into set_scope's spawn_blocking closure.
- All five hydrating entrypoints gated. Same-oid coalescing falls out of the existing double-checked guard in `hydrate_imported_git_ref`; cross-oid serialization is intentional (any two concurrent full imports is the memory-death recipe).

**Byte-stability**: only scheduling changes — what gets hydrated and all response bytes are unchanged. The n=3 shadow determinism fixture test covers this in CI.

**Verification split**: CI verifies build, fmt/clippy, and the full kin-daemon/kin-cli suites. The live two-client OOM repro and a django-scale before/after byte comparison run on dedicated hardware next window before the tracking issue closes.