### PR TITLE
fix(index): align ingest classifier with parser adapter registry

### DIFF
--- a/crates/kin-cli/src/commands/init.rs
+++ b/crates/kin-cli/src/commands/init.rs
@@ -4181,7 +4181,9 @@ mod tests {
             .all(|path| is_repo_owned_graph_path(path)));
 
         assert_eq!(graph.indexed_file_paths().len(), expected_paths.len());
-        assert_eq!(graph.list_shallow_files().unwrap().len(), 1);
+        // Swift is an entity-source language, so docs/guide.swift is fully
+        // indexed rather than shallow-tracked — no fixture file is shallow.
+        assert_eq!(graph.list_shallow_files().unwrap().len(), 0);
         assert_eq!(graph.list_structured_artifacts().unwrap().len(), 1);
         assert_eq!(graph.list_opaque_artifacts().unwrap().len(), 1);
     }

--- a/crates/kin-index/src/classifier.rs
+++ b/crates/kin-index/src/classifier.rs
@@ -25,30 +25,28 @@ pub enum FileClassification {
 }
 
 /// Extensions that have tree-sitter adapters for full entity extraction.
+///
+/// This must mirror the adapters registered in `kin-parser`'s `AdapterRegistry`:
+/// an extension the registry parses via `get_by_extension` but that is missing
+/// here would route whole-repo ingest to a shallower tier than incremental edits
+/// (which resolve the adapter directly), producing a smaller graph for the same
+/// repo depending on ingest path.
 const ENTITY_SOURCE_EXTENSIONS: &[&str] = &[
     "ts", "tsx", "js", "jsx", "py", "go", "java", "rs", "c", "h", "cpp", "hpp", "cc", "cxx", "cs",
-    "rb", "kt", "kts",
+    "rb", "kt", "kts", "swift", "php", "tf", "tfvars",
 ];
 
-/// Extensions eligible for C2 shallow syntax extraction.
-/// These have tree-sitter grammars available but no full Kin semantic adapter.
-const SHALLOW_SYNTAX_EXTENSIONS: &[(&str, &str)] = &[
-    ("swift", "swift"),
-    ("scala", "scala"),
-    ("lua", "lua"),
-    ("r", "r"),
-    ("R", "r"),
-    ("zig", "zig"),
-    ("ex", "elixir"),
-    ("exs", "elixir"),
-    ("erl", "erlang"),
-    ("hs", "haskell"),
-    ("ml", "ocaml"),
-    ("mli", "ocaml"),
-    ("php", "php"),
-    ("pl", "perl"),
-    ("pm", "perl"),
-];
+/// Extensions eligible for C2 shallow syntax extraction: a tree-sitter grammar
+/// exists (see `get_shallow_grammar` in `kin-parser`) but there is no full Kin
+/// semantic adapter.
+///
+/// Currently empty by design. Every language that has a shallow grammar
+/// (c, cpp, csharp, ruby, php, swift) also has a full entity-extraction adapter,
+/// so all of them classify as `EntitySource` above. Only add an extension here
+/// if `get_shallow_grammar` can parse it AND it has no full adapter — otherwise
+/// `classify` returns `ShallowSyntax` for a language that shallow parsing cannot
+/// handle, and ingest silently falls back to opaque (see `pipeline.rs`).
+const SHALLOW_SYNTAX_EXTENSIONS: &[(&str, &str)] = &[];
 
 /// Package manifest filenames.
 const PACKAGE_MANIFEST_FILENAMES: &[&str] = &[
@@ -635,7 +633,7 @@ mod tests {
         );
     }
 
-    // ── ShallowSyntax (C2) ───────────────────────────────────────────
+    // ── Grammar-backed languages with full adapters (EntitySource) ───
 
     #[test]
     fn entity_source_c() {
@@ -664,12 +662,10 @@ mod tests {
     }
 
     #[test]
-    fn shallow_syntax_swift() {
+    fn entity_source_swift() {
         assert_eq!(
             classify("Sources/App.swift"),
-            FileClassification::ShallowSyntax {
-                language_hint: "swift".to_string(),
-            },
+            FileClassification::EntitySource
         );
     }
 
@@ -692,20 +688,54 @@ mod tests {
     }
 
     #[test]
-    fn shallow_syntax_php() {
+    fn entity_source_php() {
+        assert_eq!(classify("index.php"), FileClassification::EntitySource);
+    }
+
+    #[test]
+    fn entity_source_tf() {
+        assert_eq!(classify("infra/main.tf"), FileClassification::EntitySource);
+    }
+
+    #[test]
+    fn entity_source_tfvars() {
         assert_eq!(
-            classify("index.php"),
-            FileClassification::ShallowSyntax {
-                language_hint: "php".to_string(),
-            },
+            classify("infra/prod.tfvars"),
+            FileClassification::EntitySource
         );
     }
 
     #[test]
-    fn shallow_syntax_does_not_override_entity_source() {
-        // .rs is EntitySource (C3+), NOT ShallowSyntax
+    fn entity_source_precedence_over_other_tiers() {
+        // EntitySource is checked first, so full-adapter languages never fall
+        // through to shallow/opaque classification.
         assert_eq!(classify("src/lib.rs"), FileClassification::EntitySource);
         assert_eq!(classify("main.py"), FileClassification::EntitySource);
+    }
+
+    // ── Grammarless extensions: honest opaque (no shallow grammar) ───
+
+    #[test]
+    fn removed_grammarless_shallow_extensions_are_opaque() {
+        // These languages were listed for C2 shallow extraction, but
+        // `get_shallow_grammar` in kin-parser has no grammar for them: shallow
+        // parsing always returned None and ingest silently fell back to opaque.
+        // Classify them as opaque directly instead of advertising a tier that
+        // cannot be delivered.
+        let opaque = FileClassification::OpaqueArtifact { mime_hint: None };
+        assert_eq!(classify("Main.scala"), opaque);
+        assert_eq!(classify("script.lua"), opaque);
+        assert_eq!(classify("analysis.r"), opaque);
+        assert_eq!(classify("analysis.R"), opaque);
+        assert_eq!(classify("main.zig"), opaque);
+        assert_eq!(classify("app.ex"), opaque);
+        assert_eq!(classify("app.exs"), opaque);
+        assert_eq!(classify("gen_server.erl"), opaque);
+        assert_eq!(classify("Main.hs"), opaque);
+        assert_eq!(classify("types.ml"), opaque);
+        assert_eq!(classify("types.mli"), opaque);
+        assert_eq!(classify("script.pl"), opaque);
+        assert_eq!(classify("Module.pm"), opaque);
     }
 
     // ── Edge cases ──────────────────────────────────────────────────

--- a/crates/kin-index/src/support.rs
+++ b/crates/kin-index/src/support.rs
@@ -238,7 +238,16 @@ fn file_has_imports(ext: &str, content: &str) -> bool {
         "py" => content.contains("import ") || content.contains("from "),
         "rs" => content.contains("use "),
         "go" => content.contains("import "),
-        "java" => content.contains("import "),
+        // `import` declarations: Java, Kotlin, Swift.
+        "java" | "kt" | "kts" | "swift" => content.contains("import "),
+        // C / C++ preprocessor includes.
+        "c" | "h" | "cpp" | "hpp" | "cc" | "cxx" => content.contains("#include"),
+        // C# `using` namespace imports.
+        "cs" => content.contains("using "),
+        // Ruby `require` / `require_relative`.
+        "rb" => content.contains("require ") || content.contains("require_relative"),
+        // PHP `use` imports and `require`/`require_once` file loads.
+        "php" => content.contains("use ") || content.contains("require"),
         _ => false,
     }
 }
@@ -564,6 +573,59 @@ mod tests {
             report.c5_cross_file_count + report.c4_intra_file_count,
             report.entity_source_count,
         );
+    }
+
+    #[test]
+    fn coverage_report_c4_vs_c5_additional_languages() {
+        let tmp = tempfile::tempdir().unwrap();
+        let root = tmp.path();
+
+        // C5: import-bearing files across the languages whose import syntax was
+        // previously unrecognized (permanently bucketing them as C4).
+        fs::write(
+            root.join("main.c"),
+            "#include <stdio.h>\nint main() { return 0; }",
+        )
+        .unwrap();
+        fs::write(
+            root.join("engine.cpp"),
+            "#include \"engine.h\"\nvoid run() {}",
+        )
+        .unwrap();
+        fs::write(root.join("Program.cs"), "using System;\nclass P {}").unwrap();
+        fs::write(root.join("app.rb"), "require 'set'\nclass Foo; end").unwrap();
+        fs::write(root.join("Main.kt"), "import kotlin.math.PI\nfun main() {}").unwrap();
+        fs::write(
+            root.join("App.swift"),
+            "import Foundation\nfunc render() {}",
+        )
+        .unwrap();
+        fs::write(root.join("index.php"), "<?php\nuse App\\Model;\n").unwrap();
+
+        // C4: same languages, no imports.
+        fs::write(
+            root.join("pure.c"),
+            "int add(int a, int b) { return a + b; }",
+        )
+        .unwrap();
+        fs::write(root.join("plain.rb"), "class Bar; end").unwrap();
+
+        let report = compute_coverage_report(root).unwrap();
+
+        assert_eq!(report.entity_source_count, 9);
+        assert_eq!(report.c5_cross_file_count, 7);
+        assert_eq!(report.c4_intra_file_count, 2);
+
+        assert_eq!(report.c5_languages.get("c"), Some(&1));
+        assert_eq!(report.c5_languages.get("cpp"), Some(&1));
+        assert_eq!(report.c5_languages.get("cs"), Some(&1));
+        assert_eq!(report.c5_languages.get("rb"), Some(&1));
+        assert_eq!(report.c5_languages.get("kt"), Some(&1));
+        assert_eq!(report.c5_languages.get("swift"), Some(&1));
+        assert_eq!(report.c5_languages.get("php"), Some(&1));
+
+        assert_eq!(report.c4_languages.get("c"), Some(&1));
+        assert_eq!(report.c4_languages.get("rb"), Some(&1));
     }
 
     /// Serial counterpart of [`compute_coverage_report`], retained as the


### PR DESCRIPTION
## Summary

The whole-repo ingest classifier (`kin-index/src/classifier.rs`) maintained its own hardcoded
extension lists that had drifted from the `kin-parser` `AdapterRegistry`. Incremental edits resolve
adapters through `registry.get_by_extension`, while whole-repo ingest goes through the classifier — so
the two paths disagreed and a repo's graph shape depended on how it was ingested. This aligns the
classifier with the registry and makes the shallow tier honest.

## Two-way drift fixed

**1. Missing full-adapter languages (`ENTITY_SOURCE_EXTENSIONS`)**

`swift`, `php`, `tf`, and `tfvars` were absent, even though the registry has full,
conformance-passing adapters for all of them (`SwiftAdapter`, `PhpAdapter`, `HclAdapter`). Whole-repo
ingest routed those files to a shallower tier (shallow for swift/php, opaque for tf/tfvars) than
incremental edits, which fully parsed them.

They are now `EntitySource`. **This is an intended behavior change: the graph grows for repos containing
Swift, PHP, or Terraform** — those files now get full entity extraction (functions, types, imports,
relations) on first ingest instead of shallow/opaque tracking. The adapters were always meant to serve
ingest; the classifier simply hadn't been updated to route to them.

**2. Grammarless shallow tiers (`SHALLOW_SYNTAX_EXTENSIONS`)**

`scala`, `lua`, `r`/`R`, `zig`, `ex`/`exs`, `erl`, `hs`, `ml`/`mli`, and `pl`/`pm` were listed as C2
shallow-syntax languages, but `get_shallow_grammar` (kin-parser `shallow.rs`) has **no grammar** for any
of them. At ingest, `parse_shallow_file` returned `None` and the pipeline silently fell back to opaque
(`pipeline.rs`). Classification advertised a tier that could never be delivered.

These are now classified `Opaque` directly. **This is a truth fix, not a capability change** — the
effective behavior (opaque tracking) is identical; the classifier just stops lying about the tier and
skips a wasted read+parse attempt. `get_shallow_grammar` and the six grammar-backed languages are left
untouched. Every language that *does* have a shallow grammar (c, cpp, csharp, ruby, php, swift) also has
a full adapter and is `EntitySource`, so the C2 shallow tier is now empty by design (documented on the
const).

## Coverage-report import heuristic (C4 vs C5)

`file_has_imports` (`kin-index/src/support.rs`) recognized import syntax only for
ts/tsx/js/jsx/py/rs/go/java, so C/C++, C#, Ruby, and Kotlin entity-source files were permanently
bucketed as C4 (intra-file). Extended per-language detection:

- Java / Kotlin / Swift → `import `
- C / C++ → `#include`
- C# → `using `
- Ruby → `require` / `require_relative`
- PHP → `use` / `require`

Swift and PHP are included here (beyond the originally-scoped C/C++/C#/Ruby/Kotlin set) because they
become `EntitySource` in this same change — leaving them always-C4 would reintroduce the exact bug for
the newly-routed languages. **Terraform (`tf`/`tfvars`) is intentionally left as C4:** HCL cross-file
linkage is via `module`/`source` blocks, not import statements, so an import-substring heuristic doesn't
apply — a follow-up could add a module-reference heuristic.

## Tests

- `classifier.rs`: `shallow_syntax_swift` / `shallow_syntax_php` → `entity_source_swift` /
  `entity_source_php` (now assert `EntitySource`); added `entity_source_tf` / `entity_source_tfvars`;
  added `removed_grammarless_shallow_extensions_are_opaque` (all 13 removed extensions assert `Opaque`);
  renamed the precedence test.
- `support.rs`: added `coverage_report_c4_vs_c5_additional_languages` exercising the new import
  detection across the extended languages.
- `init.rs`: `assert_repo_owned_graph_truth` now expects **0** shallow files (its `docs/guide.swift`
  fixture is now entity-source). The three cold/warm-init graph-truth tests flow through this. Manual
  `upsert_shallow_file` graph-mechanism tests are untouched — they don't go through the classifier.

An exhaustive repo sweep confirmed no other test ingests any affected extension through
`FileClassifier`. Parser-level tests (`adapter_conformance`, `kotlin_swift_call_resolution`) and
locate's module-path candidate lists are independent of the classifier and unaffected.

## Follow-up (not in this PR)

`docs/language-support.md` should be updated once this lands to reflect Swift/PHP/Terraform as full
entity-source languages and to drop the grammarless languages from any shallow-tier claims.
Intentionally left out of this PR to keep the change scoped to runtime routing.
