### PR TITLE
fix(review): recalibrate shadow gate on per-entity inbound evidence

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3532,6 +3532,7 @@ version = "0.2.8"
 dependencies = [
  "kin-blobs",
  "kin-db",
+ "kin-index",
  "kin-model",
  "pretty_assertions",
  "serde",

--- a/crates/kin-cli/src/commands/review.rs
+++ b/crates/kin-cli/src/commands/review.rs
@@ -1078,6 +1078,7 @@ fn inline_comment_severity(kind: kin_review::InlineCommentKind) -> &'static str 
         InlineCommentKind::CoverageGap
         | InlineCommentKind::SignatureChange
         | InlineCommentKind::VisibilityChange
+        | InlineCommentKind::ConsumerFanout
         | InlineCommentKind::Renamed
         | InlineCommentKind::AgentUnreviewed => "warning",
         InlineCommentKind::Added | InlineCommentKind::Removed => "info",

--- a/crates/kin-cli/tests/review_shadow_json.rs
+++ b/crates/kin-cli/tests/review_shadow_json.rs
@@ -228,7 +228,7 @@ fn shadow_report_end_to_end_change_in_report_out() {
 }
 
 #[test]
-fn shadow_report_fails_loud_on_unparsed_artifact_change() {
+fn shadow_report_labels_config_only_change_without_demoting() {
     let dir = tempdir().expect("tempdir");
     let repo = dir.path();
     let (_base, head, artifact_head) = setup_fixture_repo(repo);
@@ -237,7 +237,7 @@ fn shadow_report_fails_loud_on_unparsed_artifact_change() {
     let report = run_shadow_json(repo, &head, &artifact_head);
 
     // The YAML-only change is invisible to the semantic graph: the report
-    // must say so explicitly instead of passing green.
+    // must say so explicitly as an evidence gap.
     let gaps = report["evidence_gaps"].as_array().unwrap();
     assert!(
         gaps.iter()
@@ -245,10 +245,13 @@ fn shadow_report_fails_loud_on_unparsed_artifact_change() {
         "artifact-only change must surface as an explicit evidence gap: {gaps:?}"
     );
 
+    // A config-class artifact carries no semantic entities by design, so the
+    // reported gap does not demote the verdict: a config-only change is an
+    // honest pass with the gap attached, not an attention signal.
     let verdict = report["policy"]["verdict"].as_str().unwrap();
-    assert_ne!(
+    assert_eq!(
         verdict, "pass",
-        "missing evidence must never certify a pass"
+        "config-class artifact gap must be reported without demoting the verdict"
     );
 }
 

--- a/crates/kin-review/Cargo.toml
+++ b/crates/kin-review/Cargo.toml
@@ -12,6 +12,7 @@ description = "Semantic review engine for Kin"
 kin-model = { workspace = true }
 kin-db = { workspace = true }
 kin-blobs = { workspace = true }
+kin-index = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
 thiserror = { workspace = true }

--- a/crates/kin-review/src/impact.rs
+++ b/crates/kin-review/src/impact.rs
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 // Copyright 2026 Firelock, LLC
 
-use std::collections::HashSet;
+use std::collections::{BTreeSet, HashSet};
 
 use kin_model::entity::{Entity, EntityRole};
 use kin_model::graph::GraphStore;
@@ -35,6 +35,39 @@ pub struct ImpactReport {
     pub unreviewed_agent_changes: Vec<EntityId>,
     /// Attribution of who changed each entity (entity ID → actor kind).
     pub actor_attribution: Vec<(EntityId, ActorKind)>,
+    /// Per-entity inbound attribution, sorted by entity id. Policy rules that
+    /// judge one changed entity (breaking, coverage, fanout) key on the entry
+    /// for that entity instead of the diff-global buckets above.
+    pub entity_impacts: Vec<EntityImpact>,
+}
+
+/// Graph-proven inbound impact attributed to one directly changed entity.
+///
+/// All counts are inbound-only: entities that reach the changed entity via
+/// `Calls`, `DependsOn`, `References`, or `ConsumesContract` relations (plus
+/// the incoming-edge downstream walk). The changed entity's own callees are
+/// its dependencies, not its consumers, and never count here.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct EntityImpact {
+    /// The directly changed entity these counts belong to.
+    pub entity_id: EntityId,
+    /// Distinct non-test entities that consume this entity.
+    pub consumer_count: usize,
+    /// Distinct non-test entities consuming this entity as a contract.
+    pub contract_consumer_count: usize,
+    /// Sorted distinct source files of the non-test consumers above.
+    pub consumer_files: Vec<String>,
+    /// Distinct test entities covering this entity (test-kind edges plus
+    /// test-role inbound entities).
+    pub covering_tests: usize,
+}
+
+impl EntityImpact {
+    /// Total distinct inbound entities (consumers plus covering tests).
+    /// Zero means the graph connects nothing to this entity.
+    pub fn inbound_total(&self) -> usize {
+        self.consumer_count + self.covering_tests
+    }
 }
 
 impl ImpactReport {
@@ -46,6 +79,13 @@ impl ImpactReport {
             && self.affected_work_items.is_empty()
             && self.affected_annotations.is_empty()
             && self.unreviewed_agent_changes.is_empty()
+    }
+
+    /// Per-entity inbound attribution for one directly changed entity.
+    pub fn entity_impact(&self, entity_id: &EntityId) -> Option<&EntityImpact> {
+        self.entity_impacts
+            .iter()
+            .find(|impact| impact.entity_id == *entity_id)
     }
 
     /// Total number of affected entities (deduplicated).
@@ -86,32 +126,44 @@ pub fn analyze_impact<G: GraphStore>(
     let mut seen_consumers = HashSet::new();
     let mut seen_tests = HashSet::new();
 
+    let mut entity_impacts: Vec<EntityImpact> = Vec::new();
+
     for &entity_id in &changed_ids {
-        // Find relations pointing TO this entity (callers, dependents, etc.)
+        // Per-entity inbound attribution accumulated alongside the global
+        // buckets. Sets are used only for distinct counts, never for output
+        // ordering, so iteration order cannot leak into the report.
+        let mut ent_consumers: HashSet<EntityId> = HashSet::new();
+        let mut ent_contract_consumers: HashSet<EntityId> = HashSet::new();
+        let mut ent_tests: HashSet<EntityId> = HashSet::new();
+        let mut ent_consumer_files: BTreeSet<String> = BTreeSet::new();
+
+        // Find relations pointing TO this entity (callers, dependents, etc.).
+        // `get_relations` serves outgoing edges only, so the inbound harvest
+        // reads the full edge set and keeps the incoming side.
         let relations = store
-            .get_relations(
-                &entity_id,
-                &[
-                    RelationKind::Calls,
-                    RelationKind::DependsOn,
-                    RelationKind::ConsumesContract,
-                    RelationKind::Tests,
-                    RelationKind::References,
-                ],
-            )
+            .get_all_relations_for_entity(&entity_id)
             .map_err(ReviewError::graph)?;
 
         for rel in &relations {
-            // We want entities that reference the changed entity.
-            // Relations where dst == entity_id mean src depends on entity_id.
-            let affected_id = if rel.dst == GraphNodeId::Entity(entity_id) {
-                rel.src.as_entity()
-            } else if rel.src == GraphNodeId::Entity(entity_id) {
-                rel.dst.as_entity()
-            } else {
+            if !matches!(
+                rel.kind,
+                RelationKind::Calls
+                    | RelationKind::DependsOn
+                    | RelationKind::ConsumesContract
+                    | RelationKind::Tests
+                    | RelationKind::References
+            ) {
                 continue;
-            };
-            let Some(affected_id) = affected_id else {
+            }
+            // Only inbound edges prove impact: `dst == entity_id` means `src`
+            // consumes the changed entity. Outbound edges point at the
+            // change's own callees/dependencies — those are what the change
+            // uses, not what the change can break — so they never count as
+            // downstream impact.
+            if rel.dst != GraphNodeId::Entity(entity_id) {
+                continue;
+            }
+            let Some(affected_id) = rel.src.as_entity() else {
                 continue;
             };
 
@@ -121,6 +173,18 @@ pub fn analyze_impact<G: GraphStore>(
             }
 
             if let Some(entity) = store.get_entity(&affected_id).map_err(ReviewError::graph)? {
+                let is_test = entity.role == EntityRole::Test || rel.kind == RelationKind::Tests;
+                if is_test {
+                    ent_tests.insert(affected_id);
+                } else {
+                    ent_consumers.insert(affected_id);
+                    if rel.kind == RelationKind::ConsumesContract {
+                        ent_contract_consumers.insert(affected_id);
+                    }
+                    if let Some(file) = entity_file(&entity) {
+                        ent_consumer_files.insert(file);
+                    }
+                }
                 match rel.kind {
                     RelationKind::Calls => {
                         if seen_callers.insert(affected_id) {
@@ -147,7 +211,8 @@ pub fn analyze_impact<G: GraphStore>(
             }
         }
 
-        // Also use get_downstream_impact for transitive effects
+        // Also use get_downstream_impact for transitive effects; the walk
+        // follows incoming edges, so its results are inbound by construction.
         let downstream = store
             .get_downstream_impact(&entity_id, 2)
             .map_err(ReviewError::graph)?;
@@ -157,14 +222,31 @@ pub fn analyze_impact<G: GraphStore>(
                 continue;
             }
             if entity.role == EntityRole::Test {
+                ent_tests.insert(entity.id);
                 if seen_tests.insert(entity.id) {
                     tests.push(entity);
                 }
-            } else if seen_dependents.insert(entity.id) {
-                dependents.push(entity);
+            } else {
+                ent_consumers.insert(entity.id);
+                if let Some(file) = entity_file(&entity) {
+                    ent_consumer_files.insert(file);
+                }
+                if seen_dependents.insert(entity.id) {
+                    dependents.push(entity);
+                }
             }
         }
+
+        entity_impacts.push(EntityImpact {
+            entity_id,
+            consumer_count: ent_consumers.len(),
+            contract_consumer_count: ent_contract_consumers.len(),
+            consumer_files: ent_consumer_files.into_iter().collect(),
+            covering_tests: ent_tests.len(),
+        });
     }
+
+    entity_impacts.sort_by_key(|impact| impact.entity_id);
 
     // Query work items and annotations scoped to changed entities.
     let mut work_items = Vec::new();
@@ -238,7 +320,16 @@ pub fn analyze_impact<G: GraphStore>(
         changed_ids,
         unreviewed_agent_changes,
         actor_attribution,
+        entity_impacts,
     })
+}
+
+/// Source file a consumer entity lives in, from its span or file origin.
+fn entity_file(entity: &Entity) -> Option<String> {
+    match &entity.span {
+        Some(span) => Some(span.file.to_string()),
+        None => entity.file_origin.as_ref().map(|file| file.to_string()),
+    }
 }
 
 #[cfg(test)]

--- a/crates/kin-review/src/inline.rs
+++ b/crates/kin-review/src/inline.rs
@@ -4,6 +4,7 @@
 use std::collections::BTreeMap;
 
 use kin_model::entity::{Entity, EntityKind, EntityRole, Visibility};
+use kin_model::ids::EntityId;
 use serde::{Deserialize, Serialize};
 
 use crate::diff::{EntityChangeKind, SemanticDiff};
@@ -27,6 +28,7 @@ pub enum InlineCommentKind {
     ContractViolation,
     SignatureChange,
     VisibilityChange,
+    ConsumerFanout,
     Added,
     Removed,
     Renamed,
@@ -41,6 +43,7 @@ impl InlineCommentKind {
             Self::CoverageGap => "?",
             Self::SignatureChange => "~",
             Self::VisibilityChange => "~",
+            Self::ConsumerFanout => "~",
             Self::Added => "+",
             Self::Removed => "-",
             Self::Renamed => "~",
@@ -48,6 +51,13 @@ impl InlineCommentKind {
         }
     }
 }
+
+/// Distinct non-test consumer files at or above which a body-only
+/// modification (signature and visibility unchanged) emits a consumer-fanout
+/// attention comment. Body changes below this fanout stay silent: the
+/// signature channels own contract-surface changes, and a body edit consumed
+/// from a single file is ordinary local iteration.
+pub const CONSUMER_FANOUT_FILE_THRESHOLD: usize = 2;
 
 /// Collect line-level inline comments from a review's diff and impact data.
 ///
@@ -77,6 +87,13 @@ pub fn collect_inline_comments(diff: &SemanticDiff, impact: &ImpactReport) -> Ve
     comments
 }
 
+/// Graph-known tests covering one changed entity.
+fn covering_tests(impact: &ImpactReport, entity_id: &EntityId) -> usize {
+    impact
+        .entity_impact(entity_id)
+        .map_or(0, |entry| entry.covering_tests)
+}
+
 fn collect_added_comments(
     entity: &Entity,
     impact: &ImpactReport,
@@ -98,10 +115,15 @@ fn collect_added_comments(
         ),
     });
 
-    // Public entity without test coverage
+    // Public entity without test coverage. Keyed on THIS entity's covering
+    // tests, not the diff-global test bucket, and suppressed when the diff
+    // has no impact signal at all — an empty channel cannot distinguish
+    // "uncovered" from "relations never ingested", and the report already
+    // carries that deficit as an `impact_signal_absent` evidence gap.
     if entity.visibility == Visibility::Public
         && entity.role != EntityRole::Test
-        && impact.affected_tests.is_empty()
+        && !impact.is_empty()
+        && covering_tests(impact, &entity.id) == 0
     {
         comments.push(InlineComment {
             file: span.file.to_string(),
@@ -139,8 +161,13 @@ fn collect_modified_comments(
         None => return,
     };
 
-    let has_callers = !impact.affected_callers.is_empty();
-    let has_consumers = !impact.affected_contract_consumers.is_empty();
+    // All gate-relevant rules key on THIS entity's inbound edges. Another
+    // entity's consumers are that entity's risk, not this one's.
+    let per_entity = impact.entity_impact(&new.id);
+    let consumer_count = per_entity.map_or(0, |e| e.consumer_count);
+    let contract_consumer_count = per_entity.map_or(0, |e| e.contract_consumer_count);
+    let consumer_file_count = per_entity.map_or(0, |e| e.consumer_files.len());
+    let entity_covering_tests = per_entity.map_or(0, |e| e.covering_tests);
 
     // Signature change
     if old.signature != new.signature {
@@ -155,9 +182,10 @@ fn collect_modified_comments(
             ),
         });
 
-        // Breaking if callers or consumers exist
-        if has_callers || has_consumers {
-            let affected = impact.affected_callers.len() + impact.affected_contract_consumers.len();
+        // Breaking only when THIS entity has non-test consumers to break.
+        // Test-only consumers are the covering evidence for the change, not
+        // a contract it is breaking.
+        if consumer_count > 0 {
             comments.push(InlineComment {
                 file: span.file.to_string(),
                 start_line: span.start_line,
@@ -165,7 +193,7 @@ fn collect_modified_comments(
                 kind: InlineCommentKind::Breaking,
                 message: format!(
                     "Breaking change: signature modification affects {} downstream entity(ies)",
-                    affected,
+                    consumer_count,
                 ),
             });
         }
@@ -184,15 +212,15 @@ fn collect_modified_comments(
             ),
         });
 
-        if has_callers {
+        if consumer_count > 0 {
             comments.push(InlineComment {
                 file: span.file.to_string(),
                 start_line: span.start_line,
                 end_line: span.end_line,
                 kind: InlineCommentKind::Breaking,
                 message: format!(
-                    "Breaking change: visibility reduced with {} caller(s)",
-                    impact.affected_callers.len(),
+                    "Breaking change: visibility reduced with {} consumer(s)",
+                    consumer_count,
                 ),
             });
         }
@@ -209,11 +237,11 @@ fn collect_modified_comments(
         });
     }
 
-    // Contract entity with consumers
+    // Contract entity whose own consumers are exposed to this modification.
     if matches!(
         new.kind,
         EntityKind::ApiEndpoint | EntityKind::EventContract | EntityKind::Schema
-    ) && has_consumers
+    ) && contract_consumer_count > 0
     {
         comments.push(InlineComment {
             file: span.file.to_string(),
@@ -222,15 +250,34 @@ fn collect_modified_comments(
             kind: InlineCommentKind::ContractViolation,
             message: format!(
                 "Contract {:?} `{}` modified with {} consumer(s)",
-                new.kind,
-                new.name,
-                impact.affected_contract_consumers.len(),
+                new.kind, new.name, contract_consumer_count,
             ),
         });
     }
 
-    // No test coverage
-    if new.role != EntityRole::Test && impact.affected_tests.is_empty() {
+    // Body-only modification with wide consumer fanout. The contract surface
+    // is unchanged, so the breaking channels stay silent, but a behavior
+    // change consumed from many distinct non-test files deserves attention.
+    if old.signature == new.signature
+        && old.visibility == new.visibility
+        && consumer_file_count >= CONSUMER_FANOUT_FILE_THRESHOLD
+    {
+        comments.push(InlineComment {
+            file: span.file.to_string(),
+            start_line: span.start_line,
+            end_line: span.end_line,
+            kind: InlineCommentKind::ConsumerFanout,
+            message: format!(
+                "Behavior of `{}` changed with {} distinct non-test consumer file(s)",
+                new.name, consumer_file_count,
+            ),
+        });
+    }
+
+    // No test coverage. Keyed on THIS entity's covering tests and suppressed
+    // when the diff-wide impact signal is absent — that deficit is already
+    // reported as an `impact_signal_absent` evidence gap.
+    if new.role != EntityRole::Test && !impact.is_empty() && entity_covering_tests == 0 {
         comments.push(InlineComment {
             file: span.file.to_string(),
             start_line: span.start_line,
@@ -270,7 +317,7 @@ pub fn group_by_file(comments: &[InlineComment]) -> BTreeMap<&str, Vec<&InlineCo
 mod tests {
     use super::*;
     use crate::diff::{EntityChange, EntityChangeKind, SemanticDiff};
-    use crate::impact::ImpactReport;
+    use crate::impact::{EntityImpact, ImpactReport};
     use kin_model::entity::{
         Entity, EntityKind, EntityMetadata, EntityRole, FingerprintAlgorithm, SemanticFingerprint,
         SourceSpan, Visibility,
@@ -418,10 +465,328 @@ mod tests {
         let impact = ImpactReport {
             affected_callers: vec![caller],
             changed_ids: vec![new.id],
+            entity_impacts: vec![EntityImpact {
+                entity_id: new.id,
+                consumer_count: 1,
+                contract_consumer_count: 0,
+                consumer_files: vec!["src/client.rs".to_string()],
+                covering_tests: 0,
+            }],
             ..Default::default()
         };
 
         let comments = collect_inline_comments(&diff, &impact);
+        assert!(comments
+            .iter()
+            .any(|c| c.kind == InlineCommentKind::Breaking));
+    }
+
+    #[test]
+    fn breaking_requires_this_entitys_consumers_not_the_diffs() {
+        // Entity A changes signature but nothing consumes A; the diff-global
+        // caller belongs to entity B. A must NOT be reported as breaking.
+        let old_a = test_entity_with_span("isolated_fn", "src/a.rs", 1, 10);
+        let mut new_a = old_a.clone();
+        new_a.signature = "fn isolated_fn(x: i32)".to_string();
+        let b = test_entity_with_span("popular_fn", "src/b.rs", 1, 10);
+        let caller_of_b = test_entity_with_span("caller_fn", "src/client.rs", 1, 5);
+
+        let diff = SemanticDiff {
+            entity_changes: vec![
+                EntityChange {
+                    entity_id: new_a.id,
+                    kind: EntityChangeKind::Modified {
+                        old: old_a.clone(),
+                        new: new_a.clone(),
+                    },
+                },
+                EntityChange {
+                    entity_id: b.id,
+                    kind: EntityChangeKind::Modified {
+                        old: b.clone(),
+                        new: b.clone(),
+                    },
+                },
+            ],
+            ..Default::default()
+        };
+        let impact = ImpactReport {
+            affected_callers: vec![caller_of_b],
+            changed_ids: vec![new_a.id, b.id],
+            entity_impacts: vec![
+                EntityImpact {
+                    entity_id: new_a.id,
+                    consumer_count: 0,
+                    contract_consumer_count: 0,
+                    consumer_files: vec![],
+                    covering_tests: 0,
+                },
+                EntityImpact {
+                    entity_id: b.id,
+                    consumer_count: 1,
+                    contract_consumer_count: 0,
+                    consumer_files: vec!["src/client.rs".to_string()],
+                    covering_tests: 0,
+                },
+            ],
+            ..Default::default()
+        };
+
+        let comments = collect_inline_comments(&diff, &impact);
+        assert!(
+            !comments
+                .iter()
+                .any(|c| c.kind == InlineCommentKind::Breaking),
+            "another entity's consumers must not make this signature change breaking"
+        );
+        assert!(comments
+            .iter()
+            .any(|c| c.kind == InlineCommentKind::SignatureChange));
+    }
+
+    #[test]
+    fn breaking_suppressed_when_only_tests_consume() {
+        // Signature change whose only inbound edges are tests: the tests are
+        // the covering evidence, not a broken contract. Not breaking.
+        let old = test_entity_with_span("tested_fn", "src/core.rs", 1, 10);
+        let mut new = old.clone();
+        new.signature = "fn tested_fn(flag: bool)".to_string();
+        let test_entity = test_entity_with_span("test_tested_fn", "tests/core.rs", 1, 5);
+
+        let diff = SemanticDiff {
+            entity_changes: vec![EntityChange {
+                entity_id: new.id,
+                kind: EntityChangeKind::Modified {
+                    old: old.clone(),
+                    new: new.clone(),
+                },
+            }],
+            ..Default::default()
+        };
+        let impact = ImpactReport {
+            affected_tests: vec![test_entity],
+            changed_ids: vec![new.id],
+            entity_impacts: vec![EntityImpact {
+                entity_id: new.id,
+                consumer_count: 0,
+                contract_consumer_count: 0,
+                consumer_files: vec![],
+                covering_tests: 1,
+            }],
+            ..Default::default()
+        };
+
+        let comments = collect_inline_comments(&diff, &impact);
+        assert!(
+            !comments
+                .iter()
+                .any(|c| c.kind == InlineCommentKind::Breaking),
+            "test-only consumers must not produce a breaking finding"
+        );
+        assert!(
+            !comments
+                .iter()
+                .any(|c| c.kind == InlineCommentKind::CoverageGap),
+            "a tested entity has no coverage gap"
+        );
+    }
+
+    #[test]
+    fn coverage_gap_keys_on_the_entity_not_the_diff() {
+        // Covered entity + uncovered entity in one diff: exactly the
+        // uncovered one carries the gap. Under the old diff-global rule the
+        // covered entity's test silenced both.
+        let covered = test_entity_with_span("covered_fn", "src/covered.rs", 1, 10);
+        let uncovered = test_entity_with_span("uncovered_fn", "src/uncovered.rs", 1, 10);
+        let test_entity = test_entity_with_span("test_covered_fn", "tests/covered.rs", 1, 5);
+
+        let diff = SemanticDiff {
+            entity_changes: vec![
+                EntityChange {
+                    entity_id: covered.id,
+                    kind: EntityChangeKind::Modified {
+                        old: covered.clone(),
+                        new: covered.clone(),
+                    },
+                },
+                EntityChange {
+                    entity_id: uncovered.id,
+                    kind: EntityChangeKind::Modified {
+                        old: uncovered.clone(),
+                        new: uncovered.clone(),
+                    },
+                },
+            ],
+            ..Default::default()
+        };
+        let impact = ImpactReport {
+            affected_tests: vec![test_entity],
+            changed_ids: vec![covered.id, uncovered.id],
+            entity_impacts: vec![
+                EntityImpact {
+                    entity_id: covered.id,
+                    consumer_count: 0,
+                    contract_consumer_count: 0,
+                    consumer_files: vec![],
+                    covering_tests: 1,
+                },
+                EntityImpact {
+                    entity_id: uncovered.id,
+                    consumer_count: 0,
+                    contract_consumer_count: 0,
+                    consumer_files: vec![],
+                    covering_tests: 0,
+                },
+            ],
+            ..Default::default()
+        };
+
+        let comments = collect_inline_comments(&diff, &impact);
+        let gaps: Vec<&InlineComment> = comments
+            .iter()
+            .filter(|c| c.kind == InlineCommentKind::CoverageGap)
+            .collect();
+        assert_eq!(gaps.len(), 1, "exactly the uncovered entity carries a gap");
+        assert_eq!(gaps[0].file, "src/uncovered.rs");
+    }
+
+    #[test]
+    fn coverage_gap_suppressed_when_impact_signal_absent() {
+        // The graph connects nothing to this diff: an empty channel cannot
+        // prove a coverage gap, and the shadow report already carries the
+        // deficit as an impact_signal_absent evidence gap.
+        let old = test_entity_with_span("quiet_fn", "src/quiet.rs", 1, 10);
+        let new = old.clone();
+
+        let diff = SemanticDiff {
+            entity_changes: vec![EntityChange {
+                entity_id: new.id,
+                kind: EntityChangeKind::Modified {
+                    old: old.clone(),
+                    new: new.clone(),
+                },
+            }],
+            ..Default::default()
+        };
+        let impact = ImpactReport {
+            changed_ids: vec![new.id],
+            ..Default::default()
+        };
+
+        let comments = collect_inline_comments(&diff, &impact);
+        assert!(
+            !comments
+                .iter()
+                .any(|c| c.kind == InlineCommentKind::CoverageGap),
+            "no coverage gap may be claimed from an absent impact signal"
+        );
+    }
+
+    #[test]
+    fn consumer_fanout_fires_on_body_change_at_threshold() {
+        // Body-only modification (signature and visibility unchanged)
+        // consumed from two distinct non-test files -> attention comment.
+        let old = test_entity_with_span("hot_path", "src/hot.rs", 1, 20);
+        let new = old.clone();
+
+        let diff = SemanticDiff {
+            entity_changes: vec![EntityChange {
+                entity_id: new.id,
+                kind: EntityChangeKind::Modified {
+                    old: old.clone(),
+                    new: new.clone(),
+                },
+            }],
+            ..Default::default()
+        };
+        let consumer_a = test_entity_with_span("use_a", "src/a.rs", 1, 5);
+        let consumer_b = test_entity_with_span("use_b", "src/b.rs", 1, 5);
+        let impact = ImpactReport {
+            affected_callers: vec![consumer_a, consumer_b],
+            changed_ids: vec![new.id],
+            entity_impacts: vec![EntityImpact {
+                entity_id: new.id,
+                consumer_count: 2,
+                contract_consumer_count: 0,
+                consumer_files: vec!["src/a.rs".to_string(), "src/b.rs".to_string()],
+                covering_tests: 1,
+            }],
+            ..Default::default()
+        };
+
+        let comments = collect_inline_comments(&diff, &impact);
+        let fanout: Vec<&InlineComment> = comments
+            .iter()
+            .filter(|c| c.kind == InlineCommentKind::ConsumerFanout)
+            .collect();
+        assert_eq!(fanout.len(), 1);
+        assert!(fanout[0].message.contains("2 distinct non-test consumer"));
+    }
+
+    #[test]
+    fn consumer_fanout_silent_below_threshold_and_on_surface_changes() {
+        let old = test_entity_with_span("narrow_fn", "src/narrow.rs", 1, 20);
+        let new = old.clone();
+        let consumer = test_entity_with_span("only_use", "src/only.rs", 1, 5);
+
+        // One consumer file: below threshold, silent.
+        let diff = SemanticDiff {
+            entity_changes: vec![EntityChange {
+                entity_id: new.id,
+                kind: EntityChangeKind::Modified {
+                    old: old.clone(),
+                    new: new.clone(),
+                },
+            }],
+            ..Default::default()
+        };
+        let impact = ImpactReport {
+            affected_callers: vec![consumer.clone()],
+            changed_ids: vec![new.id],
+            entity_impacts: vec![EntityImpact {
+                entity_id: new.id,
+                consumer_count: 1,
+                contract_consumer_count: 0,
+                consumer_files: vec!["src/only.rs".to_string()],
+                covering_tests: 0,
+            }],
+            ..Default::default()
+        };
+        let comments = collect_inline_comments(&diff, &impact);
+        assert!(!comments
+            .iter()
+            .any(|c| c.kind == InlineCommentKind::ConsumerFanout));
+
+        // Signature change with wide fanout: the breaking/signature channels
+        // own it; fanout stays silent.
+        let mut resigned = old.clone();
+        resigned.signature = "fn narrow_fn(extra: u8)".to_string();
+        let diff = SemanticDiff {
+            entity_changes: vec![EntityChange {
+                entity_id: resigned.id,
+                kind: EntityChangeKind::Modified {
+                    old: old.clone(),
+                    new: resigned.clone(),
+                },
+            }],
+            ..Default::default()
+        };
+        let impact = ImpactReport {
+            affected_callers: vec![consumer],
+            changed_ids: vec![resigned.id],
+            entity_impacts: vec![EntityImpact {
+                entity_id: resigned.id,
+                consumer_count: 2,
+                contract_consumer_count: 0,
+                consumer_files: vec!["src/a.rs".to_string(), "src/b.rs".to_string()],
+                covering_tests: 0,
+            }],
+            ..Default::default()
+        };
+        let comments = collect_inline_comments(&diff, &impact);
+        assert!(!comments
+            .iter()
+            .any(|c| c.kind == InlineCommentKind::ConsumerFanout));
         assert!(comments
             .iter()
             .any(|c| c.kind == InlineCommentKind::Breaking));

--- a/crates/kin-review/src/lib.rs
+++ b/crates/kin-review/src/lib.rs
@@ -21,8 +21,11 @@ pub use format::{
     format_diff, format_impact, format_inline_comments, format_review, format_risk_highlights,
 };
 pub use gate::{derive_decision, GateStatus, ReviewDecision, ReviewFinding, ReviewSignalKind};
-pub use impact::{analyze_impact, ImpactReport};
-pub use inline::{collect_inline_comments, group_by_file, InlineComment, InlineCommentKind};
+pub use impact::{analyze_impact, EntityImpact, ImpactReport};
+pub use inline::{
+    collect_inline_comments, group_by_file, InlineComment, InlineCommentKind,
+    CONSUMER_FANOUT_FILE_THRESHOLD,
+};
 pub use release_gate::{
     entities_touched_by_change, security_findings, unapproved_agent_changes, SecurityFinding,
     SecurityFindingCounts, SecuritySeverity, UnapprovedAgentChange,

--- a/crates/kin-review/src/shadow.rs
+++ b/crates/kin-review/src/shadow.rs
@@ -1279,13 +1279,12 @@ mod tests {
         assert!(report.blast_radius.total_affected >= 2);
 
         // Signature change with graph-known downstream entities -> would block.
+        // The blocking anchor is the per-entity breaking finding; downstream_risk
+        // dedups against an existing blocking finding at the same location.
         assert_eq!(report.policy.verdict, ShadowGateVerdict::WouldBlock);
         assert!(report.policy.blocking_count >= 1);
-        assert!(report
-            .policy
-            .findings
-            .iter()
-            .any(|finding| finding.blocking && finding.kind == "downstream_risk"));
+        assert!(report.policy.findings.iter().any(|finding| finding.blocking
+            && (finding.kind == "breaking" || finding.kind == "downstream_risk")));
 
         // Repair context points at the covering test.
         assert!(!report.repair_context.is_empty());

--- a/crates/kin-review/src/shadow.rs
+++ b/crates/kin-review/src/shadow.rs
@@ -16,7 +16,7 @@
 //! signal, cross-repo federation not evaluated — the report carries an
 //! explicit entry in `evidence_gaps` instead of passing silently.
 
-use std::collections::BTreeSet;
+use std::collections::{BTreeMap, BTreeSet};
 
 use kin_model::entity::Entity;
 use kin_model::graph::GraphStore;
@@ -267,10 +267,10 @@ pub fn build_shadow_report<G: GraphStore>(
         .get_changes_since(&request.resolved_base, &request.resolved_head)
         .map_err(ReviewError::graph)?;
 
-    let changed_entities = collect_changed_entities(&review);
+    let changed_entities = collect_changed_entities(store, &review)?;
     let blast_radius = collect_blast_radius(&review);
     let evidence_gaps = collect_evidence_gaps(&review, &changes, &changed_entities);
-    let policy = derive_policy(&review, &evidence_gaps);
+    let policy = derive_policy(&review, &evidence_gaps, &changed_entities);
     let repair_context = collect_repair_context(&policy.findings, &review);
     let audit = collect_audit_evidence(store, request, &review, changes.len())?;
 
@@ -310,7 +310,10 @@ fn entity_location(entity: &Entity) -> (Option<String>, Option<u32>, Option<u32>
     }
 }
 
-fn collect_changed_entities(review: &Review) -> Vec<ShadowChangedEntity> {
+fn collect_changed_entities<G: GraphStore>(
+    store: &G,
+    review: &Review,
+) -> Result<Vec<ShadowChangedEntity>, ReviewError> {
     let mut changed = Vec::new();
     for change in &review.diff.entity_changes {
         match &change.kind {
@@ -343,12 +346,25 @@ fn collect_changed_entities(review: &Review) -> Vec<ShadowChangedEntity> {
                 });
             }
             EntityChangeKind::Removed(id) => {
+                // The diff carries only the removed entity's id; the graph
+                // still knows what the id named. Resolve so findings and the
+                // entity list read as code, not opaque ids. When the graph
+                // has genuinely forgotten the entity, fall back to the id
+                // string rather than inventing a name.
+                let removed = store.get_entity(id).map_err(ReviewError::graph)?;
+                let (name, kind, file) = match removed {
+                    Some(entity) => {
+                        let (file, _, _) = entity_location(&entity);
+                        (entity.name.clone(), format!("{:?}", entity.kind), file)
+                    }
+                    None => (id.to_string(), "unknown".to_string(), None),
+                };
                 changed.push(ShadowChangedEntity {
                     entity_id: id.to_string(),
-                    name: id.to_string(),
-                    kind: "unknown".to_string(),
+                    name,
+                    kind,
                     change: "removed".to_string(),
-                    file: None,
+                    file,
                     start_line: None,
                     end_line: None,
                     signature_changed: false,
@@ -363,7 +379,7 @@ fn collect_changed_entities(review: &Review) -> Vec<ShadowChangedEntity> {
             .then_with(|| a.name.cmp(&b.name))
             .then_with(|| a.entity_id.cmp(&b.entity_id))
     });
-    changed
+    Ok(changed)
 }
 
 fn affected_from(entities: &[Entity], via: &str) -> Vec<ShadowAffectedEntity> {
@@ -426,6 +442,7 @@ fn finding_kind_label(kind: InlineCommentKind) -> &'static str {
         InlineCommentKind::ContractViolation => "contract_violation",
         InlineCommentKind::SignatureChange => "signature_change",
         InlineCommentKind::VisibilityChange => "visibility_change",
+        InlineCommentKind::ConsumerFanout => "consumer_fanout",
         InlineCommentKind::Added => "entity_added",
         InlineCommentKind::Removed => "entity_removed",
         InlineCommentKind::Renamed => "entity_renamed",
@@ -439,6 +456,7 @@ fn finding_severity(kind: InlineCommentKind) -> &'static str {
         InlineCommentKind::CoverageGap
         | InlineCommentKind::SignatureChange
         | InlineCommentKind::VisibilityChange
+        | InlineCommentKind::ConsumerFanout
         | InlineCommentKind::Renamed
         | InlineCommentKind::AgentUnreviewed => "warning",
         InlineCommentKind::Added | InlineCommentKind::Removed => "info",
@@ -452,18 +470,54 @@ fn is_blocking(kind: InlineCommentKind) -> bool {
     )
 }
 
-/// Evidence-gap kinds that describe a deficit in what the graph could prove
-/// about THIS change. A gate cannot certify `pass` over them. Structural v1
-/// limits (cross-repo not evaluated, attribution unavailable) do not demote
-/// the verdict — they are constant framing, reported but not change-specific.
-fn gap_blocks_pass(kind: &str) -> bool {
+/// Whether an evidence gap describes a deficit severe enough that the gate
+/// cannot certify `pass` over it.
+///
+/// Only gaps that hide SOURCE the graph should have captured demote:
+///
+/// - `missing_span`: a changed semantic entity has no source anchor — code
+///   changed that findings cannot point at.
+/// - `artifact_only_change` on a source-class file: the ingest classifier
+///   says the file should have produced entities and none were captured, so
+///   real code changed invisibly. The same gap on docs, CI, config, or other
+///   non-source artifacts stays reported but does not demote — those files
+///   are EXPECTED to carry no entities, and demoting on them turns every
+///   docs-only change into a false attention signal.
+/// - `impact_signal_absent` is reported but never demotes the verdict: an
+///   empty relation channel cannot distinguish "genuinely isolated" from
+///   "relations never ingested", and treating that ambiguity as risk flags
+///   every change in a sparsely-related region of the graph. The gap entry
+///   itself remains the honest record of the deficit, and the coverage-gap
+///   channel is suppressed on the same condition so the empty channel is
+///   never double-counted.
+/// - Structural v1 limits (cross-repo not evaluated, attribution
+///   unavailable) are constant framing, reported but never demoting.
+fn gap_blocks_pass(gap: &ShadowEvidenceGap) -> bool {
+    match gap.kind.as_str() {
+        "missing_span" => true,
+        "artifact_only_change" => artifact_subject_is_source_class(&gap.subject),
+        _ => false,
+    }
+}
+
+/// Whether an artifact-only changed file is source-class per the ingest
+/// classifier — the same verdict the indexing pipeline used when it failed
+/// to capture entities for it. Reusing the classifier keeps this rule
+/// aligned with what ingestion actually attempts; no separate path
+/// heuristics are introduced here.
+fn artifact_subject_is_source_class(subject: &str) -> bool {
     matches!(
-        kind,
-        "artifact_only_change" | "missing_span" | "impact_signal_absent"
+        kin_index::FileClassifier::classify(std::path::Path::new(subject)),
+        kin_index::FileClassification::EntitySource
+            | kin_index::FileClassification::ShallowSyntax { .. }
     )
 }
 
-fn derive_policy(review: &Review, evidence_gaps: &[ShadowEvidenceGap]) -> ShadowPolicyResult {
+fn derive_policy(
+    review: &Review,
+    evidence_gaps: &[ShadowEvidenceGap],
+    changed_entities: &[ShadowChangedEntity],
+) -> ShadowPolicyResult {
     let mut findings: Vec<ShadowPolicyFinding> = review
         .inline_comments
         .iter()
@@ -477,15 +531,25 @@ fn derive_policy(review: &Review, evidence_gaps: &[ShadowEvidenceGap]) -> Shadow
         })
         .collect();
 
-    // Gate rule: a contract-surface change (signature/visibility/removal) with
-    // ANY graph-known downstream entity is a blocking downstream risk. The
-    // impact walker buckets incoming consumers under `dependents`, which the
-    // inline `Breaking` rule does not consult, so the gate consults the full
-    // affected set here.
-    let downstream_count = review.impact.affected_callers.len()
-        + review.impact.affected_dependents.len()
-        + review.impact.affected_contract_consumers.len();
-    if downstream_count > 0 {
+    // Resolved names for changed entities (removed entities carry only an id
+    // in the diff), and the set of names added in this same diff: a removal
+    // whose name is re-added in the same change set is a move, not a
+    // breaking removal.
+    let resolved_names: BTreeMap<&str, &str> = changed_entities
+        .iter()
+        .map(|entity| (entity.entity_id.as_str(), entity.name.as_str()))
+        .collect();
+    let added_names: BTreeSet<&str> = changed_entities
+        .iter()
+        .filter(|entity| entity.change == "added")
+        .map(|entity| entity.name.as_str())
+        .collect();
+
+    // Gate rule: a contract-surface change (signature/visibility/removal) is
+    // a blocking downstream risk when THAT entity has graph-known non-test
+    // consumers. Another entity's consumers do not make this entity's
+    // surface change risky; the per-entity inbound attribution decides.
+    {
         // Emit contract-surface findings in a deterministic entity-id order.
         // Removed entities have no span, so several collapse onto the same
         // `(file=None, line=None)` dedup key; iterating in a stable order fixes
@@ -502,10 +566,29 @@ fn derive_policy(review: &Review, evidence_gaps: &[ShadowEvidenceGap]) -> Shadow
                         .map(|span| (span.file.to_string(), span.start_line)),
                     old.signature != new.signature || old.visibility != new.visibility,
                 ),
-                EntityChangeKind::Removed(id) => (id.to_string(), None, true),
+                EntityChangeKind::Removed(id) => {
+                    let id_string = id.to_string();
+                    let name = resolved_names
+                        .get(id_string.as_str())
+                        .map(|name| name.to_string())
+                        .unwrap_or(id_string);
+                    // Same-diff remove + re-add of the same entity name is a
+                    // move; the surviving entity carries any surface risk.
+                    if added_names.contains(name.as_str()) {
+                        continue;
+                    }
+                    (name, None, true)
+                }
                 EntityChangeKind::Added(_) => continue,
             };
             if !surface_changed {
+                continue;
+            }
+            let entity_consumers = review
+                .impact
+                .entity_impact(&change.entity_id)
+                .map_or(0, |entry| entry.consumer_count);
+            if entity_consumers == 0 {
                 continue;
             }
             let already_blocking = findings.iter().any(|finding| {
@@ -522,7 +605,7 @@ fn derive_policy(review: &Review, evidence_gaps: &[ShadowEvidenceGap]) -> Shadow
                 blocking: true,
                 message: format!(
                     "Contract surface of `{}` changed with {} graph-known downstream entity(ies)",
-                    name, downstream_count
+                    name, entity_consumers
                 ),
                 file: location.as_ref().map(|(file, _)| file.clone()),
                 line: location.as_ref().map(|(_, line)| *line),
@@ -530,11 +613,49 @@ fn derive_policy(review: &Review, evidence_gaps: &[ShadowEvidenceGap]) -> Shadow
         }
     }
 
+    // Per-anchor inbound totals for the gate feed below: a signature or
+    // visibility finding on an entity the graph connects to NOTHING (no
+    // consumer, no test) is reported but cannot justify an attention verdict
+    // by itself — with zero graph-known inbound edges there is no proven
+    // audience for the surface change. Anchors resolve by the same
+    // (file, start_line) key the findings carry.
+    let mut anchor_inbound: BTreeMap<(String, u32), usize> = BTreeMap::new();
+    for change in &review.diff.entity_changes {
+        if let EntityChangeKind::Modified { new, .. } = &change.kind {
+            if let Some(span) = &new.span {
+                let inbound = review
+                    .impact
+                    .entity_impact(&new.id)
+                    .map_or(0, |entry| entry.inbound_total());
+                let slot = anchor_inbound
+                    .entry((span.file.to_string(), span.start_line))
+                    .or_insert(0);
+                *slot = (*slot).max(inbound);
+            }
+        }
+    }
+    let surface_finding_feeds_gate = |finding: &ShadowPolicyFinding| -> bool {
+        if finding.kind != "signature_change" && finding.kind != "visibility_change" {
+            return true;
+        }
+        match (&finding.file, finding.line) {
+            (Some(file), Some(line)) => anchor_inbound
+                .get(&(file.clone(), line))
+                // Unresolvable anchors keep feeding the gate: suppression
+                // requires proof of isolation, not absence of a lookup.
+                .is_none_or(|inbound| *inbound > 0),
+            _ => true,
+        }
+    };
+
     // Informational findings (entity added/removed) describe the diff, not a
-    // gate signal; they are reported but do not feed the verdict.
+    // gate signal; they are reported but do not feed the verdict. Surface
+    // findings on graph-isolated entities are likewise reported without
+    // feeding the gate.
     let gate_findings: Vec<ReviewFinding> = findings
         .iter()
         .filter(|finding| finding.severity != "info")
+        .filter(|finding| surface_finding_feeds_gate(finding))
         .map(|finding| ReviewFinding {
             kind: match finding.kind.as_str() {
                 "contract_violation" | "agent_unreviewed" => ReviewSignalKind::PolicyViolation,
@@ -553,12 +674,13 @@ fn derive_policy(review: &Review, evidence_gaps: &[ShadowEvidenceGap]) -> Shadow
         GateStatus::Blocked => ShadowGateVerdict::WouldBlock,
     };
 
-    // Missing evidence is never a pass: when the graph could not prove parts
-    // of this change, the gate reports needs_attention instead of certifying
-    // a clean result it did not actually verify.
+    // Missing SOURCE evidence is never a pass: when the graph could not
+    // capture code this change touched, the gate reports needs_attention
+    // instead of certifying a clean result it did not actually verify. See
+    // `gap_blocks_pass` for which gap kinds carry that weight.
     let pass_blocking_gaps = evidence_gaps
         .iter()
-        .filter(|gap| gap_blocks_pass(&gap.kind))
+        .filter(|gap| gap_blocks_pass(gap))
         .count();
     if verdict == ShadowGateVerdict::Pass && pass_blocking_gaps > 0 {
         verdict = ShadowGateVerdict::NeedsAttention;
@@ -616,6 +738,10 @@ fn repair_guidance(kind: &str) -> &'static str {
             "Record a human review decision for the agent-authored change before enforcing."
         }
         "entity_renamed" => "Confirm references were updated for the rename.",
+        "consumer_fanout" => {
+            "Behavior changed on an entity consumed from multiple files; verify each listed \
+             consumer still gets the behavior it expects, then run the covering tests."
+        }
         "downstream_risk" => {
             "The contract surface changed with graph-known downstream entities; verify each \
              listed dependent and consumer, then run the covering tests."
@@ -1187,7 +1313,7 @@ mod tests {
     #[test]
     fn contract_surface_representative_is_deterministic() {
         use crate::diff::{EntityChange, EntityChangeKind, SemanticDiff};
-        use crate::impact::ImpactReport;
+        use crate::impact::{EntityImpact, ImpactReport};
         use kin_model::review::{RiskLevel, RiskSummary};
 
         // A tie of removed entities: each renders with location=None, so the
@@ -1217,7 +1343,8 @@ mod tests {
                     entity_changes,
                     relation_changes: vec![],
                 },
-                // One downstream dependent makes the contract-surface rule fire.
+                // One graph-known consumer per removed entity makes the
+                // per-entity contract-surface rule fire for each candidate.
                 impact: ImpactReport {
                     affected_dependents: vec![entity_with_span(
                         "downstream_consumer",
@@ -1225,6 +1352,16 @@ mod tests {
                         1,
                         EntityRole::Source,
                     )],
+                    entity_impacts: ids
+                        .iter()
+                        .map(|&entity_id| EntityImpact {
+                            entity_id,
+                            consumer_count: 1,
+                            contract_consumer_count: 0,
+                            consumer_files: vec!["src/consumer.rs".to_string()],
+                            covering_tests: 0,
+                        })
+                        .collect(),
                     ..Default::default()
                 },
                 risk: RiskSummary {
@@ -1241,7 +1378,7 @@ mod tests {
 
         // Exactly one contract-surface representative survives, naming the
         // smallest entity id regardless of the input order.
-        let natural = derive_policy(&build_review(&[0, 1, 2, 3]), &[]);
+        let natural = derive_policy(&build_review(&[0, 1, 2, 3]), &[], &[]);
         let contract: Vec<&ShadowPolicyFinding> = natural
             .findings
             .iter()
@@ -1263,11 +1400,11 @@ mod tests {
         // runs and across every input order — the determinism the merge-trust
         // n=3 bit-identity gate depends on.
         let baseline =
-            serde_json::to_string(&derive_policy(&build_review(&[0, 1, 2, 3]), &[]).findings)
+            serde_json::to_string(&derive_policy(&build_review(&[0, 1, 2, 3]), &[], &[]).findings)
                 .unwrap();
         for order in [[0, 1, 2, 3], [3, 2, 1, 0], [1, 3, 0, 2], [2, 0, 3, 1]] {
             for _ in 0..3 {
-                let result = derive_policy(&build_review(&order), &[]);
+                let result = derive_policy(&build_review(&order), &[], &[]);
                 assert_eq!(result.verdict, ShadowGateVerdict::WouldBlock);
                 assert_eq!(
                     serde_json::to_string(&result.findings).unwrap(),
@@ -1279,7 +1416,11 @@ mod tests {
     }
 
     #[test]
-    fn artifact_only_change_is_an_explicit_evidence_gap() {
+    fn benign_class_artifact_gap_reports_without_demoting() {
+        // Named forensic case: a benign body-touch plus a config-only
+        // artifact change. Every deficit stays reported as an explicit gap,
+        // but a non-source artifact and an empty relation channel are not
+        // treated as risk: the verdict is an honest pass with gaps attached.
         let graph = InMemoryGraph::new();
         let entity = entity_with_span("helper", "src/lib.rs", 1, EntityRole::Source);
         graph.upsert_entity(&entity).unwrap();
@@ -1318,7 +1459,7 @@ mod tests {
             .expect("artifact-only change must surface as an evidence gap");
         assert_eq!(artifact_gap.subject, "config/policy.yaml");
 
-        // No relations exist -> empty impact must be flagged, not passed.
+        // No relations exist -> the empty impact channel stays reported.
         assert!(report
             .evidence_gaps
             .iter()
@@ -1328,8 +1469,338 @@ mod tests {
             .iter()
             .any(|gap| gap.kind == "actor_attribution_unavailable"));
 
-        // Missing evidence must never certify a pass.
-        assert_ne!(report.policy.verdict, ShadowGateVerdict::Pass);
+        // A config-class artifact and an ambiguous-empty channel are
+        // reported, not flagged: the gate passes while saying what it could
+        // not see.
+        assert_eq!(report.policy.verdict, ShadowGateVerdict::Pass);
+    }
+
+    #[test]
+    fn source_class_artifact_gap_still_demotes() {
+        // Counter-case: the same artifact-only gap on a file the ingest
+        // classifier calls source means real code changed that the graph
+        // never captured. That deficit still demotes the pass.
+        let graph = InMemoryGraph::new();
+        let entity = entity_with_span("helper", "src/lib.rs", 1, EntityRole::Source);
+        graph.upsert_entity(&entity).unwrap();
+
+        let base_id = change_id(6);
+        let head_id = change_id(7);
+        let base = change_with_deltas(
+            base_id,
+            vec![],
+            vec![EntityDelta::Added(entity.clone())],
+            vec![],
+        );
+        let head = change_with_deltas(
+            head_id,
+            vec![base_id],
+            vec![EntityDelta::Modified {
+                old: entity.clone(),
+                new: entity,
+            }],
+            vec![ArtifactDelta {
+                file_id: FilePathId::new("src/legacy.c"),
+                kind: ArtifactDeltaKind::Modified,
+                old_hash: Some(Hash256::from_bytes([9; 32])),
+                new_hash: Some(Hash256::from_bytes([10; 32])),
+            }],
+        );
+        graph.create_change(&base).unwrap();
+        graph.create_change(&head).unwrap();
+
+        let report = build_shadow_report(&graph, &request(base_id, head_id)).unwrap();
+
+        assert!(report
+            .evidence_gaps
+            .iter()
+            .any(|gap| gap.kind == "artifact_only_change" && gap.subject == "src/legacy.c"));
+        assert_eq!(report.policy.verdict, ShadowGateVerdict::NeedsAttention);
+    }
+
+    #[test]
+    fn gap_demotion_is_artifact_class_aware() {
+        use crate::diff::SemanticDiff;
+        use crate::impact::ImpactReport;
+        use kin_model::review::{RiskLevel, RiskSummary};
+
+        let empty_review = Review {
+            base: None,
+            head: None,
+            diff: SemanticDiff::default(),
+            impact: ImpactReport::default(),
+            risk: RiskSummary {
+                overall_risk: RiskLevel::Low,
+                breaking_changes: vec![],
+                test_coverage_gaps: vec![],
+                contract_violations: vec![],
+                work_risks: vec![],
+                notes: vec![],
+            },
+            inline_comments: vec![],
+        };
+        let gap = |kind: &str, subject: &str| ShadowEvidenceGap {
+            kind: kind.to_string(),
+            subject: subject.to_string(),
+            detail: "test gap".to_string(),
+        };
+
+        // Docs / CI / config-class artifacts report without demoting.
+        for subject in ["README.md", ".github/workflows/ci.yml", "policy.yaml"] {
+            let policy = derive_policy(&empty_review, &[gap("artifact_only_change", subject)], &[]);
+            assert_eq!(
+                policy.verdict,
+                ShadowGateVerdict::Pass,
+                "non-source artifact gap must not demote: {subject}"
+            );
+        }
+
+        // Source-class artifacts demote: code changed invisibly.
+        for subject in ["src/legacy.c", "pkg/util.go", "app/views.py"] {
+            let policy = derive_policy(&empty_review, &[gap("artifact_only_change", subject)], &[]);
+            assert_eq!(
+                policy.verdict,
+                ShadowGateVerdict::NeedsAttention,
+                "source-class artifact gap must demote: {subject}"
+            );
+        }
+
+        // A changed entity without a source anchor always demotes.
+        let policy = derive_policy(&empty_review, &[gap("missing_span", "helper")], &[]);
+        assert_eq!(policy.verdict, ShadowGateVerdict::NeedsAttention);
+
+        // The empty relation channel is reported but does not flip the
+        // verdict by itself; the coverage channel is suppressed on the same
+        // condition so the ambiguity is neither hidden nor double-counted.
+        let policy = derive_policy(
+            &empty_review,
+            &[gap("impact_signal_absent", "blast_radius")],
+            &[],
+        );
+        assert_eq!(policy.verdict, ShadowGateVerdict::Pass);
+    }
+
+    #[test]
+    fn removed_entity_names_resolve_from_graph() {
+        // The diff carries only the removed entity's id; findings and the
+        // changed-entity list must read as code, not opaque ids.
+        let graph = InMemoryGraph::new();
+        let legacy = entity_with_span("legacy_helper", "src/old.rs", 4, EntityRole::Source);
+        let consumer = entity_with_span("still_calls_it", "src/live.rs", 9, EntityRole::Source);
+        graph.upsert_entity(&legacy).unwrap();
+        graph.upsert_entity(&consumer).unwrap();
+        graph
+            .upsert_relation(&relation(&consumer, &legacy, RelationKind::Calls))
+            .unwrap();
+
+        let base_id = change_id(8);
+        let head_id = change_id(9);
+        let base = change_with_deltas(
+            base_id,
+            vec![],
+            vec![
+                EntityDelta::Added(legacy.clone()),
+                EntityDelta::Added(consumer.clone()),
+            ],
+            vec![],
+        );
+        let head = change_with_deltas(
+            head_id,
+            vec![base_id],
+            vec![EntityDelta::Removed(legacy.id)],
+            vec![],
+        );
+        graph.create_change(&base).unwrap();
+        graph.create_change(&head).unwrap();
+
+        let report = build_shadow_report(&graph, &request(base_id, head_id)).unwrap();
+
+        let removed = report
+            .changed_entities
+            .iter()
+            .find(|entity| entity.change == "removed")
+            .expect("removed entity must be listed");
+        assert_eq!(removed.name, "legacy_helper");
+        assert_eq!(removed.file.as_deref(), Some("src/old.rs"));
+
+        // Removal with a live graph-known consumer is a blocking downstream
+        // risk, and the finding names the entity, not its uuid.
+        let downstream = report
+            .policy
+            .findings
+            .iter()
+            .find(|finding| finding.kind == "downstream_risk")
+            .expect("removal with consumers must carry a downstream risk");
+        assert!(
+            downstream.message.contains("legacy_helper"),
+            "finding must name the removed entity: {}",
+            downstream.message
+        );
+        assert_eq!(report.policy.verdict, ShadowGateVerdict::WouldBlock);
+    }
+
+    #[test]
+    fn same_diff_remove_and_readd_is_move_not_breaking() {
+        use crate::diff::{EntityChange, EntityChangeKind, SemanticDiff};
+        use crate::impact::{EntityImpact, ImpactReport};
+        use kin_model::review::{RiskLevel, RiskSummary};
+
+        let moved_old_id = EntityId::from_content("src/before.rs", "mover", "function", 1);
+        let readded = entity_with_span("mover", "src/after.rs", 1, EntityRole::Source);
+
+        let review = Review {
+            base: None,
+            head: None,
+            diff: SemanticDiff {
+                base: None,
+                head: None,
+                entity_changes: vec![
+                    EntityChange {
+                        entity_id: moved_old_id,
+                        kind: EntityChangeKind::Removed(moved_old_id),
+                    },
+                    EntityChange {
+                        entity_id: readded.id,
+                        kind: EntityChangeKind::Added(readded.clone()),
+                    },
+                ],
+                relation_changes: vec![],
+            },
+            impact: ImpactReport {
+                entity_impacts: vec![EntityImpact {
+                    entity_id: moved_old_id,
+                    consumer_count: 1,
+                    contract_consumer_count: 0,
+                    consumer_files: vec!["src/consumer.rs".to_string()],
+                    covering_tests: 0,
+                }],
+                ..Default::default()
+            },
+            risk: RiskSummary {
+                overall_risk: RiskLevel::Low,
+                breaking_changes: vec![],
+                test_coverage_gaps: vec![],
+                contract_violations: vec![],
+                work_risks: vec![],
+                notes: vec![],
+            },
+            inline_comments: vec![],
+        };
+
+        let removed_entry = ShadowChangedEntity {
+            entity_id: moved_old_id.to_string(),
+            name: "mover".to_string(),
+            kind: "Function".to_string(),
+            change: "removed".to_string(),
+            file: Some("src/before.rs".to_string()),
+            start_line: None,
+            end_line: None,
+            signature_changed: false,
+            visibility_changed: false,
+        };
+        let added_entry = ShadowChangedEntity {
+            entity_id: readded.id.to_string(),
+            name: "mover".to_string(),
+            kind: "Function".to_string(),
+            change: "added".to_string(),
+            file: Some("src/after.rs".to_string()),
+            start_line: Some(1),
+            end_line: Some(3),
+            signature_changed: false,
+            visibility_changed: false,
+        };
+
+        // With the same-name re-add present, the removal is a move: no
+        // downstream risk, nothing to block.
+        let policy = derive_policy(&review, &[], &[removed_entry.clone(), added_entry]);
+        assert!(
+            !policy
+                .findings
+                .iter()
+                .any(|finding| finding.kind == "downstream_risk"),
+            "same-diff remove+re-add of one name is a move, not a removal"
+        );
+        assert_eq!(policy.verdict, ShadowGateVerdict::Pass);
+
+        // Without the re-add the identical removal is a breaking removal.
+        let policy = derive_policy(&review, &[], &[removed_entry]);
+        assert!(policy
+            .findings
+            .iter()
+            .any(|finding| finding.kind == "downstream_risk" && finding.message.contains("mover")));
+        assert_eq!(policy.verdict, ShadowGateVerdict::WouldBlock);
+    }
+
+    #[test]
+    fn isolated_signature_change_reports_without_gating() {
+        // A signature change on an entity the graph connects to nothing is
+        // reported as a finding but cannot justify an attention verdict by
+        // itself: with zero inbound edges there is no proven audience.
+        use crate::diff::{EntityChange, EntityChangeKind, SemanticDiff};
+        use crate::impact::{EntityImpact, ImpactReport};
+        use crate::inline::InlineComment;
+        use kin_model::review::{RiskLevel, RiskSummary};
+
+        let old = entity_with_span("loner", "src/loner.rs", 2, EntityRole::Source);
+        let mut new = old.clone();
+        new.signature = "fn loner(flag: bool)".to_string();
+
+        let review = Review {
+            base: None,
+            head: None,
+            diff: SemanticDiff {
+                base: None,
+                head: None,
+                entity_changes: vec![EntityChange {
+                    entity_id: new.id,
+                    kind: EntityChangeKind::Modified {
+                        old,
+                        new: new.clone(),
+                    },
+                }],
+                relation_changes: vec![],
+            },
+            impact: ImpactReport {
+                entity_impacts: vec![EntityImpact {
+                    entity_id: new.id,
+                    consumer_count: 0,
+                    contract_consumer_count: 0,
+                    consumer_files: vec![],
+                    covering_tests: 0,
+                }],
+                ..Default::default()
+            },
+            risk: RiskSummary {
+                overall_risk: RiskLevel::Low,
+                breaking_changes: vec![],
+                test_coverage_gaps: vec![],
+                contract_violations: vec![],
+                work_risks: vec![],
+                notes: vec![],
+            },
+            inline_comments: vec![InlineComment {
+                file: "src/loner.rs".to_string(),
+                start_line: 2,
+                end_line: 4,
+                kind: InlineCommentKind::SignatureChange,
+                message: "Signature changed: `fn loner()` → `fn loner(flag: bool)`".to_string(),
+            }],
+        };
+
+        let policy = derive_policy(&review, &[], &[]);
+        assert!(
+            policy
+                .findings
+                .iter()
+                .any(|finding| finding.kind == "signature_change"),
+            "the signature change stays reported"
+        );
+        assert_eq!(
+            policy.verdict,
+            ShadowGateVerdict::Pass,
+            "an isolated surface change must not gate on its own"
+        );
+        assert_eq!(policy.attention_count, 0);
     }
 
     #[test]


### PR DESCRIPTION
Recalibrates the shadow-review verdict policy from diff-global, absence-of-evidence flagging to per-entity, presence-of-impact flagging. Root-caused and measured against the merge-trust prereg run's 120-scenario artifact corpus (a bit-exact forensic taxonomy partitioned every false positive; simulators banked durably as the oracle).

**Changes**
- Per-entity impact attribution: new per-entity records (consumer/contract-consumer/test coverage, consumer files) harvested INBOUND-ONLY via the bidirectional relation query — the previous harvest read outgoing edges where it intended callers, so its inbound branch was structurally dead and outbound callees polluted the downstream buckets.
- breaking / contract_violation / coverage_gap / downstream_risk key on THAT entity's evidence; coverage_gap is suppressed when the impact channel is empty; removed entities resolve names from graph truth (no raw UUIDs in findings); same-diff remove+re-add of one name reads as a move.
- New consumer-fanout attention channel: body-only change on an entity consumed from ≥2 distinct non-test files (recovers both measured misses, blast 65/88).
- Artifact-class-aware gap demotion via the ingest classifier's verdict: docs/CI/config artifact gaps report without demoting a pass; source-class gaps still demote. (Boundary note: classifier verdict could move onto change records at ingestion — flagged for follow-up rather than blocking this fix.)
- Verdict tiers and gate thresholds unchanged; all new paths BTree-deterministic; determinism fixtures unchanged in semantics.

**Measured on the banked corpus** (gap/gate policy replay; per-entity + fanout effects only manifest on fresh reports): specificity 0.204 → 0.816, accuracy .550 → .674 at recall .500 — with the authoritative measure being the pre-registered benchmark re-run once ref-scoped impact (in draft) lands.

**Tests**: forensic-named cases across inline/shadow + CLI e2e (docs-only change passes; global-coverage-gap benign passes; test-anchored breaking not blocking; big-blast body change flags; UUID→name resolution; move-not-breaking); full workspace suite green locally.