### PR TITLE
chore(release): 0.2.9

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,26 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.2.9] - 2026-07-04
+
+First-touch hardening: the daemon's git-ancestry hydration is serialized (no more concurrent-review crashes), whole-repo ingest routes every full language adapter, and agents get a budgeted batch source tool.
+
+### Added
+
+- `get_entity_sources` MCP tool: batched entity-source fetch (1–50 ids) with a shared token budget, per-body line/byte clamps, compact signature-only mode, and per-row fault isolation — one envelope instead of N iterative calls.
+- `docs/language-support.md`: the honest per-language support matrix (extraction depth, shallow tiers, LSP enrichment, and current routing gaps).
+
+### Changed
+
+- Shadow review verdicts are calibrated on per-entity inbound evidence: findings key on each entity's own consumers and covering tests (never diff-global counts), docs/CI-only changes can pass cleanly, removed entities are named in findings, and a consumer-fanout check flags body-only changes consumed from multiple files.
+- Whole-repo ingest now routes Swift, PHP, and HCL/Terraform to their full semantic adapters (previously shallow or opaque despite complete adapters), and no longer advertises shallow support for nine languages that have no grammar wired — they classify opaque, honestly.
+- The coverage self-report recognizes import syntax across all deep-adapter languages, so cross-file depth is no longer understated for C, C++, C#, Ruby, and Kotlin.
+
+### Fixed
+
+- Concurrent reviews (or review + locate/blame/history) that both needed git-ancestry hydration could double peak memory and crash the daemon mid-request; hydration is now single-flight behind a per-daemon gate with a lock-free warm path.
+- A test-suite race on process-global environment reads in the status command's tests.
+
 ## [0.2.8] - 2026-07-03
 
 Call-graph recall and byte-deterministic review on the blast-radius surface, plus default-on SIMD and container-aware resource planning through refreshed primitives.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3039,11 +3039,11 @@ dependencies = [
 
 [[package]]
 name = "kin-buildinfo"
-version = "0.2.8"
+version = "0.2.9"
 
 [[package]]
 name = "kin-cli"
-version = "0.2.8"
+version = "0.2.9"
 dependencies = [
  "age",
  "anyhow",
@@ -3110,7 +3110,7 @@ dependencies = [
 
 [[package]]
 name = "kin-context"
-version = "0.2.8"
+version = "0.2.9"
 dependencies = [
  "kin-blobs",
  "kin-db",
@@ -3126,7 +3126,7 @@ dependencies = [
 
 [[package]]
 name = "kin-core"
-version = "0.2.8"
+version = "0.2.9"
 dependencies = [
  "chrono",
  "directories 5.0.1",
@@ -3150,7 +3150,7 @@ dependencies = [
 
 [[package]]
 name = "kin-daemon"
-version = "0.2.8"
+version = "0.2.9"
 dependencies = [
  "async-stream",
  "axum",
@@ -3239,7 +3239,7 @@ dependencies = [
 
 [[package]]
 name = "kin-git"
-version = "0.2.8"
+version = "0.2.9"
 dependencies = [
  "chrono",
  "gix",
@@ -3257,7 +3257,7 @@ dependencies = [
 
 [[package]]
 name = "kin-index"
-version = "0.2.8"
+version = "0.2.9"
 dependencies = [
  "hex",
  "kin-blobs",
@@ -3303,7 +3303,7 @@ dependencies = [
 
 [[package]]
 name = "kin-integration-tests"
-version = "0.2.8"
+version = "0.2.9"
 dependencies = [
  "kin-blobs",
  "kin-cli",
@@ -3345,7 +3345,7 @@ dependencies = [
 
 [[package]]
 name = "kin-mcp"
-version = "0.2.8"
+version = "0.2.9"
 dependencies = [
  "kin-blobs",
  "kin-context",
@@ -3372,7 +3372,7 @@ dependencies = [
 
 [[package]]
 name = "kin-migrate"
-version = "0.2.8"
+version = "0.2.9"
 dependencies = [
  "chrono",
  "kin-blobs",
@@ -3414,7 +3414,7 @@ dependencies = [
 
 [[package]]
 name = "kin-parser"
-version = "0.2.8"
+version = "0.2.9"
 dependencies = [
  "kin-model",
  "pretty_assertions",
@@ -3443,7 +3443,7 @@ dependencies = [
 
 [[package]]
 name = "kin-projection"
-version = "0.2.8"
+version = "0.2.9"
 dependencies = [
  "kin-blobs",
  "kin-db",
@@ -3458,7 +3458,7 @@ dependencies = [
 
 [[package]]
 name = "kin-ranking"
-version = "0.2.8"
+version = "0.2.9"
 dependencies = [
  "kin-model",
  "serde",
@@ -3467,7 +3467,7 @@ dependencies = [
 
 [[package]]
 name = "kin-reconcile"
-version = "0.2.8"
+version = "0.2.9"
 dependencies = [
  "kin-blobs",
  "kin-db",
@@ -3487,7 +3487,7 @@ dependencies = [
 
 [[package]]
 name = "kin-registry"
-version = "0.2.8"
+version = "0.2.9"
 dependencies = [
  "axum",
  "base64 0.22.1",
@@ -3512,7 +3512,7 @@ dependencies = [
 
 [[package]]
 name = "kin-remote"
-version = "0.2.8"
+version = "0.2.9"
 dependencies = [
  "chrono",
  "kin-model",
@@ -3528,7 +3528,7 @@ dependencies = [
 
 [[package]]
 name = "kin-review"
-version = "0.2.8"
+version = "0.2.9"
 dependencies = [
  "kin-blobs",
  "kin-db",
@@ -3544,7 +3544,7 @@ dependencies = [
 
 [[package]]
 name = "kin-runtime"
-version = "0.2.8"
+version = "0.2.9"
 dependencies = [
  "chrono",
  "hex",
@@ -3576,7 +3576,7 @@ dependencies = [
 
 [[package]]
 name = "kin-semantic-contracts"
-version = "0.2.8"
+version = "0.2.9"
 dependencies = [
  "kin-db",
  "kin-model",
@@ -3591,7 +3591,7 @@ dependencies = [
 
 [[package]]
 name = "kin-spine"
-version = "0.2.8"
+version = "0.2.9"
 dependencies = [
  "chrono",
  "hashbrown 0.15.5",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,7 +27,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.2.8"
+version = "0.2.9"
 edition = "2021"
 license = "Apache-2.0"
 authors = ["Troy Fortin <troy@firelock.ai>"]

--- a/packages/kin-mcp/package.json
+++ b/packages/kin-mcp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kinlab/kin-mcp",
-  "version": "0.2.8",
+  "version": "0.2.9",
   "description": "Start Kin's MCP server through an npm-friendly wrapper.",
   "type": "module",
   "bin": {


### PR DESCRIPTION
First-touch hardening release: single-flight git-ancestry hydration (no more concurrent-review crashes), full-adapter ingest routing for Swift/PHP/Terraform, the batched `get_entity_sources` MCP tool, the honest language-support matrix, and shadow-review verdicts recalibrated on per-entity inbound evidence.

Version bump (workspace + kin-mcp) + CHANGELOG in one commit per the auto-tag gate. On merge: auto-tag → release.yml distributes (5 platforms, npm, Homebrew, ghcr); distribution verified before this is called done.