### PR TITLE
fix(review): compute shadow impact from ref-scoped graph state

### DIFF
--- a/crates/kin-cli/src/commands/init.rs
+++ b/crates/kin-cli/src/commands/init.rs
@@ -639,6 +639,12 @@ pub async fn run(
                 }
             }
         }
+        // Store-iteration order is not a contract; sort by relation id so the
+        // committed change record is deterministic.
+        relation_deltas.sort_by_key(|delta| match delta {
+            RelationDelta::Added(relation) => relation.id.0,
+            RelationDelta::Removed(relation_id) => relation_id.0,
+        });
         let entity_deltas = all_entities.into_iter().map(EntityDelta::Added).collect();
 
         let change = SemanticChange {
@@ -1316,6 +1322,14 @@ pub(crate) fn enrich_imported_changes_with_semantics(
             total_closure_diffing_time += post_link_start.elapsed();
         }
 
+        // Relation deltas accumulate from HashMap iteration above; sort by
+        // relation id so the committed change record is byte-stable across
+        // runs. The sort is stable, so a Removed(id)+Added(id) replacement
+        // pair keeps its replay order.
+        relation_deltas.sort_by_key(|delta| match delta {
+            RelationDelta::Added(relation) => relation.id.0,
+            RelationDelta::Removed(relation_id) => relation_id.0,
+        });
         imported_change.change.entity_deltas = entity_deltas;
         imported_change.change.relation_deltas = relation_deltas;
     }

--- a/crates/kin-cli/src/commands/review.rs
+++ b/crates/kin-cli/src/commands/review.rs
@@ -79,6 +79,10 @@ pub struct ReviewResponse {
 pub struct ReviewExecution {
     pub response: ReviewResponse,
     pub mutated: bool,
+    /// A shadow evaluation lazily imported Git ancestry into the graph;
+    /// daemon owners should persist the hydrated state so the import happens
+    /// once per repo instead of once per process.
+    pub hydrated_git_history: bool,
 }
 
 #[derive(Serialize)]
@@ -176,6 +180,7 @@ pub async fn execute_review_request(
                 layout, graph, change, entities, files, changes, json,
             )?,
             mutated: false,
+            hydrated_git_history: false,
         }),
         ReviewRequest::Shadow {
             base,
@@ -184,12 +189,16 @@ pub async fn execute_review_request(
             source_url,
             author,
             json,
-        } => Ok(ReviewExecution {
-            response: build_shadow_run_response(
+        } => {
+            let (response, hydrated_git_history) = build_shadow_run_response(
                 layout, graph, base, head, title, source_url, author, json,
-            )?,
-            mutated: false,
-        }),
+            )?;
+            Ok(ReviewExecution {
+                response,
+                mutated: false,
+                hydrated_git_history,
+            })
+        }
         ReviewRequest::Create {
             title,
             base,
@@ -288,25 +297,29 @@ fn build_shadow_run_response(
     source_url: Option<String>,
     author: Option<String>,
     json: bool,
-) -> Result<ReviewResponse> {
-    let resolved_base = crate::commands::ref_lookup::resolve_ref_importing_git_if_needed(
-        graph,
-        layout,
-        Some(base.as_str()),
-    )
-    .with_context(|| format!("resolve shadow base ref '{}'", base))?;
-    let resolved_head = crate::commands::ref_lookup::resolve_ref_importing_git_if_needed(
-        graph,
-        layout,
-        Some(head.as_str()),
-    )
-    .with_context(|| format!("resolve shadow head ref '{}'", head))?;
+) -> Result<(ReviewResponse, bool)> {
+    let resolved_base =
+        crate::commands::ref_lookup::resolve_ref_importing_git_if_needed_with_report(
+            graph,
+            layout,
+            Some(base.as_str()),
+        )
+        .with_context(|| format!("resolve shadow base ref '{}'", base))?;
+    let resolved_head =
+        crate::commands::ref_lookup::resolve_ref_importing_git_if_needed_with_report(
+            graph,
+            layout,
+            Some(head.as_str()),
+        )
+        .with_context(|| format!("resolve shadow head ref '{}'", head))?;
+    let hydrated_git_history =
+        resolved_base.hydrated_git_history || resolved_head.hydrated_git_history;
 
     let request = kin_review::ShadowRequest {
         base_ref: base,
         head_ref: head,
-        resolved_base,
-        resolved_head,
+        resolved_base: resolved_base.head,
+        resolved_head: resolved_head.head,
         title,
         source_url,
         author,
@@ -316,16 +329,22 @@ fn build_shadow_run_response(
     let report = kin_review::build_shadow_report(graph, &request)?;
 
     if json {
-        return Ok(ReviewResponse {
-            text: String::new(),
-            json: Some(serde_json::to_string_pretty(&report)?),
-        });
+        return Ok((
+            ReviewResponse {
+                text: String::new(),
+                json: Some(serde_json::to_string_pretty(&report)?),
+            },
+            hydrated_git_history,
+        ));
     }
 
-    Ok(ReviewResponse {
-        text: kin_review::format_shadow_report(&report),
-        json: None,
-    })
+    Ok((
+        ReviewResponse {
+            text: kin_review::format_shadow_report(&report),
+            json: None,
+        },
+        hydrated_git_history,
+    ))
 }
 
 fn compute_review(
@@ -425,6 +444,11 @@ fn compute_review(
     let review = if let Some(parent_id) = semantic_change.parents.first() {
         match kin_review::SemanticReview::create_review(parent_id, &change_id, graph) {
             Ok(r) => r,
+            // An unmaterializable ref state must surface, not degrade into a
+            // live-adjacency review of another era's graph.
+            Err(err @ kin_review::ReviewError::RefStateUnavailable { .. }) => {
+                return Err(err.into())
+            }
             Err(_) => {
                 let diff = kin_review::diff_from_change(&semantic_change);
                 kin_review::SemanticReview::review_from_diff(diff, graph)?
@@ -654,6 +678,7 @@ fn create_review_with_graph(
             json: None,
         },
         mutated: true,
+        hydrated_git_history: false,
     })
 }
 
@@ -713,6 +738,7 @@ fn decide_review_with_graph(
             json: None,
         },
         mutated: true,
+        hydrated_git_history: false,
     })
 }
 
@@ -759,6 +785,7 @@ fn add_note_with_graph(
     Ok(ReviewExecution {
         response: ReviewResponse { text, json: None },
         mutated: true,
+        hydrated_git_history: false,
     })
 }
 
@@ -819,6 +846,7 @@ fn start_discussion_with_graph(
     Ok(ReviewExecution {
         response: ReviewResponse { text, json: None },
         mutated: true,
+        hydrated_git_history: false,
     })
 }
 
@@ -855,6 +883,7 @@ fn reply_discussion_with_graph(
             json: None,
         },
         mutated: true,
+        hydrated_git_history: false,
     })
 }
 
@@ -877,6 +906,7 @@ fn resolve_discussion_with_graph(
             json: None,
         },
         mutated: true,
+        hydrated_git_history: false,
     })
 }
 
@@ -914,6 +944,7 @@ fn assign_reviewer_with_graph(
             json: None,
         },
         mutated: true,
+        hydrated_git_history: false,
     })
 }
 
@@ -956,6 +987,7 @@ fn list_reviews_with_graph(
                 json: None,
             },
             mutated: false,
+            hydrated_git_history: false,
         });
     }
 
@@ -975,6 +1007,7 @@ fn list_reviews_with_graph(
     Ok(ReviewExecution {
         response: ReviewResponse { text, json: None },
         mutated: false,
+        hydrated_git_history: false,
     })
 }
 
@@ -1067,6 +1100,7 @@ fn show_review_with_graph(
     Ok(ReviewExecution {
         response: ReviewResponse { text, json: None },
         mutated: false,
+        hydrated_git_history: false,
     })
 }
 

--- a/crates/kin-daemon/src/api.rs
+++ b/crates/kin-daemon/src/api.rs
@@ -3399,6 +3399,11 @@ async fn review(
         kin_cli::commands::review::execute_review_request(&state.layout, graph.as_ref(), req)
             .await
             .map_err(internal_error)?;
+    if execution.hydrated_git_history {
+        state.bump_version();
+        state.save_snapshot().map_err(internal_error)?;
+        state.mark_clean();
+    }
     if execution.mutated {
         state.bump_version();
         state.emit_event(DaemonEvent::GraphRootChanged {

--- a/crates/kin-parser/src/languages/rust_lang.rs
+++ b/crates/kin-parser/src/languages/rust_lang.rs
@@ -546,9 +546,92 @@ fn extract_calls_from_context(
                     });
                 }
             }
+        } else if child.kind() == "macro_invocation" {
+            // Macro arguments are token soup: tree-sitter does not parse
+            // expressions inside token trees, so `format!("{}", total(x))`
+            // carries no call_expression node for `total(x)`. Without this,
+            // calls made inside format!/println!/assert!-style invocations
+            // never become graph relations and downstream consumers vanish
+            // from cross-file adjacency. Reconstruct call-shaped token runs
+            // from the delimited token tree instead.
+            let mut macro_cursor = child.walk();
+            for macro_child in child.children(&mut macro_cursor) {
+                if macro_child.kind() == "token_tree" {
+                    extract_calls_from_token_tree(&macro_child, source, context_name, relations);
+                }
+            }
         }
         // Recurse into child nodes
         extract_calls_from_context(&child, source, context_name, relations);
+    }
+}
+
+/// Extract call-shaped token runs from a macro-invocation token tree.
+///
+/// Inside a token tree an invocation like `billing::compute_total(amount)`
+/// is a flat token run: `identifier ("::" identifier)*` followed by a
+/// parenthesized `token_tree`. Treat that shape as a call, mirroring the
+/// `call_expression` extraction rules:
+/// - method calls (`x.method(..)`) collapse to the bare method name, exactly
+///   like the `field_expression` arm above;
+/// - qualified paths keep their `a::b` text, exactly like scoped callees;
+/// - `name!(..)` runs are nested macro uses, not calls (the identifier is
+///   followed by `!`, never directly by the token tree);
+/// - bracket/brace groups (`v[i]`, `S { .. }`) are not argument lists.
+///
+/// Nested token trees are scanned recursively so calls inside argument lists
+/// and nested macro bodies are also captured.
+fn extract_calls_from_token_tree(
+    node: &tree_sitter::Node,
+    source: &[u8],
+    context_name: &str,
+    relations: &mut Vec<ExtractedRelation>,
+) {
+    let mut cursor = node.walk();
+    let tokens: Vec<tree_sitter::Node> = node.children(&mut cursor).collect();
+
+    for (index, token) in tokens.iter().enumerate() {
+        if token.kind() == "token_tree" {
+            extract_calls_from_token_tree(token, source, context_name, relations);
+            continue;
+        }
+        if token.kind() != "identifier" {
+            continue;
+        }
+        // A call needs a parenthesized group immediately after the name.
+        let Some(next) = tokens.get(index + 1) else {
+            continue;
+        };
+        if next.kind() != "token_tree" || next.child(0).map(|open| open.kind()) != Some("(") {
+            continue;
+        }
+        // `x.method(..)`: bare method name, matching the field_expression arm.
+        let is_method_call = index > 0 && tokens[index - 1].kind() == ".";
+        let mut callee_name = token.utf8_text(source).unwrap_or("").to_string();
+        if !is_method_call {
+            // Reconstruct a leading `a::b::` path so qualified callees keep
+            // the same shape the call_expression arm extracts.
+            let mut start = index;
+            while start >= 2
+                && tokens[start - 1].kind() == "::"
+                && tokens[start - 2].kind() == "identifier"
+            {
+                start -= 2;
+                callee_name = format!(
+                    "{}::{}",
+                    tokens[start].utf8_text(source).unwrap_or(""),
+                    callee_name
+                );
+            }
+        }
+        if is_valid_callee_name(&callee_name) {
+            relations.push(ExtractedRelation {
+                kind: kin_model::RelationKind::Calls,
+                src_name: context_name.to_string(),
+                dst_name: callee_name,
+                import_source: None,
+            });
+        }
     }
 }
 
@@ -803,6 +886,61 @@ macro_rules! assemble_widget {
             macros[0].signature.contains("assemble_widget"),
             "signature should carry the macro name, got {:?}",
             macros[0].signature
+        );
+    }
+
+    #[test]
+    fn extracts_calls_inside_macro_token_trees() {
+        // Macro arguments are token trees, not parsed expressions: without
+        // token-run reconstruction, a consumer calling through `format!` has
+        // no Calls edge and disappears from cross-file impact entirely.
+        let adapter = RustAdapter;
+        let source = br#"
+pub fn render_invoice(amount: u64) -> String {
+    format!("total: {}", compute_total(amount))
+}
+
+fn callers() {
+    assert_eq!(outer(inner(1)), billing::qualified(2));
+    println!("{}", target.method(3));
+    let v = vec![element(4)];
+    log!("{}", matches!(v, _));
+}
+"#;
+        let tree = adapter.parse(source).unwrap();
+        let file_id = FilePathId::new("src/invoice.rs");
+        let output = adapter.extract(&tree, source, &file_id).unwrap();
+
+        let calls: Vec<(&str, &str)> = output
+            .relations
+            .iter()
+            .filter(|r| r.kind == kin_model::RelationKind::Calls)
+            .map(|r| (r.src_name.as_str(), r.dst_name.as_str()))
+            .collect();
+
+        // The cross-file consumer edge the shadow gate depends on.
+        assert!(
+            calls.contains(&("render_invoice", "compute_total")),
+            "call inside format! must be extracted, got {calls:?}"
+        );
+        // Nested argument-list calls, qualified paths, method calls, and
+        // bracket-delimited macro bodies are all reconstructed.
+        for expected in [
+            ("callers", "outer"),
+            ("callers", "inner"),
+            ("callers", "billing::qualified"),
+            ("callers", "method"),
+            ("callers", "element"),
+        ] {
+            assert!(
+                calls.contains(&expected),
+                "expected {expected:?} in {calls:?}"
+            );
+        }
+        // `matches!` is a nested macro use inside the token tree, not a call.
+        assert!(
+            !calls.iter().any(|(_, dst)| *dst == "matches"),
+            "nested macro names must not become Calls edges, got {calls:?}"
         );
     }
 

--- a/crates/kin-review/src/error.rs
+++ b/crates/kin-review/src/error.rs
@@ -15,6 +15,15 @@ pub enum ReviewError {
     #[error("graph store error: {0}")]
     GraphStore(#[source] Box<dyn std::error::Error + Send + Sync>),
 
+    #[error(
+        "graph state at ref not materialized: change {missing} in the ancestry of {at} is not \
+         in the graph"
+    )]
+    RefStateUnavailable {
+        at: SemanticChangeId,
+        missing: SemanticChangeId,
+    },
+
     #[error("no changes between base and head")]
     NoChanges,
 

--- a/crates/kin-review/src/impact.rs
+++ b/crates/kin-review/src/impact.rs
@@ -5,14 +5,121 @@ use std::collections::{BTreeSet, HashSet};
 
 use kin_model::entity::{Entity, EntityRole};
 use kin_model::graph::GraphStore;
-use kin_model::ids::EntityId;
-use kin_model::provenance::{ActorKind, ApprovalDecision};
-use kin_model::relation::{GraphNodeId, RelationKind};
+use kin_model::ids::{EntityId, SemanticChangeId};
+use kin_model::provenance::{Actor, ActorId, ActorKind, Approval, ApprovalDecision, AuditEvent};
+use kin_model::relation::{GraphNodeId, Relation, RelationKind};
 use kin_model::work::{Annotation, StalenessState, WorkItem, WorkScope};
 use serde::{Deserialize, Serialize};
 
 use crate::diff::SemanticDiff;
 use crate::error::ReviewError;
+
+/// The exact read surface the impact walker consumes.
+///
+/// Structural queries (`get_entity`, `get_relations`,
+/// `get_all_relations_for_entity`, `get_downstream_impact`) determine the
+/// blast radius and must be answered by the graph state the review is scoped
+/// to. Overlay queries (work items, annotations, approvals, audit events,
+/// actors) are operational state keyed by stable IDs, not part of the
+/// replayed structural graph, and are answered by the live store.
+///
+/// The trait deliberately has no write surface: impact analysis is read-only
+/// by construction, so a ref-scoped implementation cannot be misused to
+/// mutate graph state.
+pub trait ImpactGraph {
+    fn get_entity(&self, id: &EntityId) -> Result<Option<Entity>, ReviewError>;
+    fn get_relations(
+        &self,
+        id: &EntityId,
+        kinds: &[RelationKind],
+    ) -> Result<Vec<Relation>, ReviewError>;
+    /// Every entity-to-entity edge touching `id`, outgoing and incoming,
+    /// deduplicated and sorted by relation id. The inbound-only impact
+    /// harvest reads this full set and keeps the incoming side.
+    fn get_all_relations_for_entity(&self, id: &EntityId) -> Result<Vec<Relation>, ReviewError>;
+    fn get_downstream_impact(
+        &self,
+        id: &EntityId,
+        max_depth: u32,
+    ) -> Result<Vec<Entity>, ReviewError>;
+    fn get_work_for_scope(&self, scope: &WorkScope) -> Result<Vec<WorkItem>, ReviewError>;
+    fn get_annotations_for_scope(&self, scope: &WorkScope) -> Result<Vec<Annotation>, ReviewError>;
+    fn get_approvals_for_change(&self, id: &SemanticChangeId)
+        -> Result<Vec<Approval>, ReviewError>;
+    fn query_audit_events(
+        &self,
+        actor_id: Option<&ActorId>,
+        limit: usize,
+    ) -> Result<Vec<AuditEvent>, ReviewError>;
+    fn get_actor(&self, id: &ActorId) -> Result<Option<Actor>, ReviewError>;
+}
+
+/// Live-store view of [`ImpactGraph`]: every query answered by the current
+/// graph state.
+pub struct LiveGraph<'a, G>(pub &'a G);
+
+impl<G: GraphStore> ImpactGraph for LiveGraph<'_, G> {
+    fn get_entity(&self, id: &EntityId) -> Result<Option<Entity>, ReviewError> {
+        self.0.get_entity(id).map_err(ReviewError::graph)
+    }
+
+    fn get_relations(
+        &self,
+        id: &EntityId,
+        kinds: &[RelationKind],
+    ) -> Result<Vec<Relation>, ReviewError> {
+        self.0.get_relations(id, kinds).map_err(ReviewError::graph)
+    }
+
+    fn get_all_relations_for_entity(&self, id: &EntityId) -> Result<Vec<Relation>, ReviewError> {
+        self.0
+            .get_all_relations_for_entity(id)
+            .map_err(ReviewError::graph)
+    }
+
+    fn get_downstream_impact(
+        &self,
+        id: &EntityId,
+        max_depth: u32,
+    ) -> Result<Vec<Entity>, ReviewError> {
+        self.0
+            .get_downstream_impact(id, max_depth)
+            .map_err(ReviewError::graph)
+    }
+
+    fn get_work_for_scope(&self, scope: &WorkScope) -> Result<Vec<WorkItem>, ReviewError> {
+        self.0.get_work_for_scope(scope).map_err(ReviewError::graph)
+    }
+
+    fn get_annotations_for_scope(&self, scope: &WorkScope) -> Result<Vec<Annotation>, ReviewError> {
+        self.0
+            .get_annotations_for_scope(scope)
+            .map_err(ReviewError::graph)
+    }
+
+    fn get_approvals_for_change(
+        &self,
+        id: &SemanticChangeId,
+    ) -> Result<Vec<Approval>, ReviewError> {
+        self.0
+            .get_approvals_for_change(id)
+            .map_err(ReviewError::graph)
+    }
+
+    fn query_audit_events(
+        &self,
+        actor_id: Option<&ActorId>,
+        limit: usize,
+    ) -> Result<Vec<AuditEvent>, ReviewError> {
+        self.0
+            .query_audit_events(actor_id, limit)
+            .map_err(ReviewError::graph)
+    }
+
+    fn get_actor(&self, id: &ActorId) -> Result<Option<Actor>, ReviewError> {
+        self.0.get_actor(id).map_err(ReviewError::graph)
+    }
+}
 
 /// Structured impact report for a set of changed entities.
 #[derive(Debug, Clone, Default, Serialize, Deserialize)]
@@ -108,9 +215,23 @@ impl ImpactReport {
 }
 
 /// Analyze the impact of changes described in a `SemanticDiff` by walking
-/// the graph for each changed entity.
+/// the current (live) graph for each changed entity.
 pub fn analyze_impact<G: GraphStore>(
     store: &G,
+    diff: &SemanticDiff,
+) -> Result<ImpactReport, ReviewError> {
+    analyze_impact_at(&LiveGraph(store), diff)
+}
+
+/// Analyze the impact of changes described in a `SemanticDiff` by walking
+/// the supplied [`ImpactGraph`] for each changed entity.
+///
+/// Callers reviewing a committed `base..head` range should pass a graph
+/// scoped to the head ref (see `GraphAtRef`) so the blast radius reflects
+/// the adjacency at that ref rather than whatever the mutable live adjacency
+/// happens to hold.
+pub fn analyze_impact_at<I: ImpactGraph>(
+    graph: &I,
     diff: &SemanticDiff,
 ) -> Result<ImpactReport, ReviewError> {
     let changed_ids = diff.changed_entity_ids();
@@ -140,9 +261,7 @@ pub fn analyze_impact<G: GraphStore>(
         // Find relations pointing TO this entity (callers, dependents, etc.).
         // `get_relations` serves outgoing edges only, so the inbound harvest
         // reads the full edge set and keeps the incoming side.
-        let relations = store
-            .get_all_relations_for_entity(&entity_id)
-            .map_err(ReviewError::graph)?;
+        let relations = graph.get_all_relations_for_entity(&entity_id)?;
 
         for rel in &relations {
             if !matches!(
@@ -172,7 +291,7 @@ pub fn analyze_impact<G: GraphStore>(
                 continue;
             }
 
-            if let Some(entity) = store.get_entity(&affected_id).map_err(ReviewError::graph)? {
+            if let Some(entity) = graph.get_entity(&affected_id)? {
                 let is_test = entity.role == EntityRole::Test || rel.kind == RelationKind::Tests;
                 if is_test {
                     ent_tests.insert(affected_id);
@@ -213,9 +332,7 @@ pub fn analyze_impact<G: GraphStore>(
 
         // Also use get_downstream_impact for transitive effects; the walk
         // follows incoming edges, so its results are inbound by construction.
-        let downstream = store
-            .get_downstream_impact(&entity_id, 2)
-            .map_err(ReviewError::graph)?;
+        let downstream = graph.get_downstream_impact(&entity_id, 2)?;
 
         for entity in downstream {
             if changed_set.contains(&entity.id) {
@@ -257,7 +374,7 @@ pub fn analyze_impact<G: GraphStore>(
     for &entity_id in &changed_ids {
         let scope = WorkScope::Entity(entity_id);
 
-        if let Ok(items) = store.get_work_for_scope(&scope) {
+        if let Ok(items) = graph.get_work_for_scope(&scope) {
             for item in items {
                 if !item.is_closed() && seen_work_ids.insert(item.work_id) {
                     work_items.push(item);
@@ -265,7 +382,7 @@ pub fn analyze_impact<G: GraphStore>(
             }
         }
 
-        if let Ok(anns) = store.get_annotations_for_scope(&scope) {
+        if let Ok(anns) = graph.get_annotations_for_scope(&scope) {
             for ann in anns {
                 if ann.staleness != StalenessState::Stale && seen_ann_ids.insert(ann.annotation_id)
                 {
@@ -281,13 +398,13 @@ pub fn analyze_impact<G: GraphStore>(
 
     if let Some(head_id) = &diff.head {
         // Query approvals for the head change to find unapproved agent modifications.
-        if let Ok(approvals) = store.get_approvals_for_change(head_id) {
+        if let Ok(approvals) = graph.get_approvals_for_change(head_id) {
             let has_human_approval = approvals
                 .iter()
                 .any(|a| a.decision == ApprovalDecision::Approved);
 
             // Query audit events to determine who made the changes.
-            if let Ok(events) = store.query_audit_events(None, 100) {
+            if let Ok(events) = graph.query_audit_events(None, 100) {
                 for &entity_id in &changed_ids {
                     // Find the most recent audit event targeting this entity.
                     let actor_event = events.iter().find(|e| {
@@ -296,7 +413,7 @@ pub fn analyze_impact<G: GraphStore>(
 
                     if let Some(event) = actor_event {
                         // Resolve actor kind from the actor ID.
-                        if let Ok(Some(actor)) = store.get_actor(&event.actor_id) {
+                        if let Ok(Some(actor)) = graph.get_actor(&event.actor_id) {
                             actor_attribution.push((entity_id, actor.kind));
 
                             // Non-human actors without approval are unreviewed.

--- a/crates/kin-review/src/lib.rs
+++ b/crates/kin-review/src/lib.rs
@@ -7,6 +7,7 @@ pub mod format;
 pub mod gate;
 pub mod impact;
 pub mod inline;
+pub mod ref_graph;
 pub mod release_gate;
 pub mod review;
 pub mod risk;
@@ -21,11 +22,12 @@ pub use format::{
     format_diff, format_impact, format_inline_comments, format_review, format_risk_highlights,
 };
 pub use gate::{derive_decision, GateStatus, ReviewDecision, ReviewFinding, ReviewSignalKind};
-pub use impact::{analyze_impact, EntityImpact, ImpactReport};
+pub use impact::{analyze_impact, analyze_impact_at, EntityImpact, ImpactGraph, ImpactReport};
 pub use inline::{
     collect_inline_comments, group_by_file, InlineComment, InlineCommentKind,
     CONSUMER_FANOUT_FILE_THRESHOLD,
 };
+pub use ref_graph::GraphAtRef;
 pub use release_gate::{
     entities_touched_by_change, security_findings, unapproved_agent_changes, SecurityFinding,
     SecurityFindingCounts, SecuritySeverity, UnapprovedAgentChange,
@@ -33,6 +35,7 @@ pub use release_gate::{
 pub use review::{Review, SemanticReview};
 pub use risk::assess_risk;
 pub use shadow::{
-    build_shadow_report, format_shadow_report, ShadowGateReport, ShadowGateVerdict, ShadowRequest,
-    SHADOW_ENFORCEMENT_REPORT_ONLY, SHADOW_GATE_REPORT_SCHEMA_VERSION,
+    build_shadow_report, build_shadow_report_at, format_shadow_report, ShadowGateReport,
+    ShadowGateVerdict, ShadowRequest, SHADOW_ENFORCEMENT_REPORT_ONLY,
+    SHADOW_GATE_REPORT_SCHEMA_VERSION,
 };

--- a/crates/kin-review/src/ref_graph.rs
+++ b/crates/kin-review/src/ref_graph.rs
@@ -1,0 +1,592 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Firelock, LLC
+
+//! Ref-scoped graph reads for review.
+//!
+//! The live adjacency indexes are mutable current state: they reflect the
+//! latest ingest, not the graph as committed at a semantic ref. Blast-radius
+//! queries for a `base..head` review must therefore not consult them —
+//! whatever they return for entities of another era is residency-accidental.
+//!
+//! [`GraphAtRef`] materializes the committed graph state at a ref by
+//! replaying the change DAG (`resolve_graph_at`) and serves the structural
+//! read surface of impact analysis from that state alone. For an entity the
+//! replayed history REMOVED, the at-ref adjacency is empty by construction
+//! (the replay prunes its edges at the removing change), so its blast radius
+//! is served from the replay's own tombstones: the edges that removal
+//! severed. Work items, annotations, approvals, audit events, and actors are
+//! operational overlay state keyed by stable IDs — not part of the replayed
+//! structural graph — and stay answered by the live store.
+//!
+//! If the ancestry of the ref is not fully present in the graph, the state
+//! cannot be trusted and materialization fails loud. It never falls back to
+//! the live adjacency.
+
+use std::collections::{BTreeMap, HashMap, HashSet, VecDeque};
+
+use kin_model::entity::Entity;
+use kin_model::graph::{GraphStore, ResolvedGraphState};
+use kin_model::ids::{EntityId, RelationId, SemanticChangeId};
+use kin_model::provenance::{Actor, ActorId, Approval, AuditEvent};
+use kin_model::relation::{Relation, RelationKind};
+use kin_model::work::{Annotation, WorkItem, WorkScope};
+
+use crate::error::ReviewError;
+use crate::impact::ImpactGraph;
+
+/// Committed graph state at a semantic ref, exposed through the impact read
+/// surface. Read-only by construction: [`ImpactGraph`] has no write methods.
+pub struct GraphAtRef<'a, G> {
+    live: &'a G,
+    at: SemanticChangeId,
+    entities: HashMap<EntityId, Entity>,
+    relations: HashMap<RelationId, Relation>,
+    // BTree-keyed with relation-id-sorted edge lists: every traversal is
+    // deterministic by construction, independent of replay or hash order.
+    outgoing: BTreeMap<EntityId, Vec<RelationId>>,
+    incoming: BTreeMap<EntityId, Vec<RelationId>>,
+    // Edges severed by an entity's own removal, for entities absent at the
+    // ref. The replay prunes a removed entity's relations at the removing
+    // change, so the at-ref adjacency cannot say who consumed it — but the
+    // replay's tombstones can: exactly the entity-only relations whose
+    // ending change is the change that removed the entity. Edges a relation
+    // delta removed EARLIER are excluded — those consumers had already let
+    // go before the removal. Id-sorted; committed state, never live.
+    severed: BTreeMap<EntityId, Vec<Relation>>,
+}
+
+// Manual impl: `G` is a store handle, not data — deriving would bound on
+// `G: Debug` and dump the full replayed maps. Summarize the state instead.
+impl<G> std::fmt::Debug for GraphAtRef<'_, G> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("GraphAtRef")
+            .field("at", &self.at)
+            .field("entities", &self.entities.len())
+            .field("relations", &self.relations.len())
+            .finish_non_exhaustive()
+    }
+}
+
+impl<'a, G: GraphStore> GraphAtRef<'a, G> {
+    /// Materialize the committed graph state at `at`.
+    ///
+    /// Fails with [`ReviewError::RefStateUnavailable`] if any change in the
+    /// ancestry of `at` is missing from the store: `resolve_graph_at` skips
+    /// missing rows silently, and a partial replay would understate the
+    /// blast radius while looking authoritative.
+    pub fn materialize(live: &'a G, at: &SemanticChangeId) -> Result<Self, ReviewError> {
+        let mut visited = HashSet::new();
+        let mut pending = vec![*at];
+        while let Some(id) = pending.pop() {
+            if !visited.insert(id) {
+                continue;
+            }
+            match live.get_change(&id).map_err(ReviewError::graph)? {
+                Some(change) => pending.extend(change.parents.iter().copied()),
+                None => {
+                    return Err(ReviewError::RefStateUnavailable {
+                        at: *at,
+                        missing: id,
+                    })
+                }
+            }
+        }
+
+        let state = live.resolve_graph_at(at).map_err(ReviewError::graph)?;
+        Ok(Self::from_state(live, *at, state))
+    }
+
+    /// The ref this state was materialized at (cache key for reuse across
+    /// repeated evaluations of the same head).
+    pub fn at(&self) -> &SemanticChangeId {
+        &self.at
+    }
+
+    fn from_state(live: &'a G, at: SemanticChangeId, state: ResolvedGraphState) -> Self {
+        let mut outgoing: BTreeMap<EntityId, Vec<RelationId>> = BTreeMap::new();
+        let mut incoming: BTreeMap<EntityId, Vec<RelationId>> = BTreeMap::new();
+        for relation in state.relations.values() {
+            if let Some(src) = relation.src.as_entity() {
+                outgoing.entry(src).or_default().push(relation.id);
+            }
+            if let Some(dst) = relation.dst.as_entity() {
+                incoming.entry(dst).or_default().push(relation.id);
+            }
+        }
+        for edge_ids in outgoing.values_mut().chain(incoming.values_mut()) {
+            edge_ids.sort_unstable_by_key(|relation_id| relation_id.0);
+        }
+
+        // Removal-severed edges: a tombstoned relation belongs to a removed
+        // endpoint's severed set only when the relation was ended by the
+        // same change that removed the entity — the prune the removal itself
+        // caused. Entities re-added after an old removal are present at the
+        // ref and keep their (empty-by-prune or rebuilt) live adjacency; the
+        // severed surface is only for entities absent at the ref.
+        let mut severed: BTreeMap<EntityId, Vec<Relation>> = BTreeMap::new();
+        for (relation, ended_in) in state.relation_tombstones.values() {
+            let (Some(src), Some(dst)) = (relation.src.as_entity(), relation.dst.as_entity())
+            else {
+                continue;
+            };
+            let endpoints = if src == dst {
+                [Some(src), None]
+            } else {
+                [Some(src), Some(dst)]
+            };
+            for endpoint in endpoints.into_iter().flatten() {
+                if state.entities.contains_key(&endpoint) {
+                    continue;
+                }
+                if let Some((_, removed_in)) = state.entity_tombstones.get(&endpoint) {
+                    if removed_in == ended_in {
+                        severed.entry(endpoint).or_default().push(relation.clone());
+                    }
+                }
+            }
+        }
+        for edges in severed.values_mut() {
+            edges.sort_unstable_by_key(|relation| relation.id.0);
+        }
+
+        Self {
+            live,
+            at,
+            entities: state.entities,
+            relations: state.relations,
+            outgoing,
+            incoming,
+            severed,
+        }
+    }
+}
+
+impl<G: GraphStore> ImpactGraph for GraphAtRef<'_, G> {
+    fn get_entity(&self, id: &EntityId) -> Result<Option<Entity>, ReviewError> {
+        Ok(self.entities.get(id).cloned())
+    }
+
+    fn get_relations(
+        &self,
+        id: &EntityId,
+        kinds: &[RelationKind],
+    ) -> Result<Vec<Relation>, ReviewError> {
+        let mut result = Vec::new();
+        if let Some(edge_ids) = self.outgoing.get(id) {
+            for relation_id in edge_ids {
+                if let Some(relation) = self.relations.get(relation_id) {
+                    let entity_only =
+                        relation.src.as_entity().is_some() && relation.dst.as_entity().is_some();
+                    if entity_only && (kinds.is_empty() || kinds.contains(&relation.kind)) {
+                        result.push(relation.clone());
+                    }
+                }
+            }
+        }
+        result.sort_unstable_by_key(|relation| relation.id.0);
+        Ok(result)
+    }
+
+    fn get_all_relations_for_entity(&self, id: &EntityId) -> Result<Vec<Relation>, ReviewError> {
+        // An entity absent at the ref was either never committed or was
+        // removed by the ref's history. The replay pruned a removed entity's
+        // edges at the removing change, so its blast radius is served from
+        // the edges that removal severed — still committed state, never the
+        // live adjacency.
+        if !self.entities.contains_key(id) {
+            return Ok(self.severed.get(id).cloned().unwrap_or_default());
+        }
+
+        // Union of both edge directions, mirroring the live store: entity-only
+        // relations, deduplicated (a self-loop sits in both lists), sorted by
+        // relation id so the order is insertion-independent.
+        let mut result = Vec::new();
+        let mut seen: HashSet<RelationId> = HashSet::new();
+        let outgoing = self.outgoing.get(id).into_iter().flatten();
+        let incoming = self.incoming.get(id).into_iter().flatten();
+        for relation_id in outgoing.chain(incoming) {
+            if let Some(relation) = self.relations.get(relation_id) {
+                let entity_only =
+                    relation.src.as_entity().is_some() && relation.dst.as_entity().is_some();
+                if entity_only && seen.insert(relation.id) {
+                    result.push(relation.clone());
+                }
+            }
+        }
+        result.sort_unstable_by_key(|relation| relation.id.0);
+        Ok(result)
+    }
+
+    fn get_downstream_impact(
+        &self,
+        id: &EntityId,
+        max_depth: u32,
+    ) -> Result<Vec<Entity>, ReviewError> {
+        // BFS over incoming edges, mirroring the live store's traversal; the
+        // era of the adjacency is the only intended difference.
+        let mut visited: HashSet<EntityId> = HashSet::new();
+        let mut impacted_ids: Vec<EntityId> = Vec::new();
+        let mut queue: VecDeque<(EntityId, u32)> = VecDeque::new();
+
+        visited.insert(*id);
+        queue.push_back((*id, 0));
+
+        while let Some((current, depth)) = queue.pop_front() {
+            if depth >= max_depth {
+                continue;
+            }
+
+            let live_inbound = self
+                .incoming
+                .get(&current)
+                .into_iter()
+                .flatten()
+                .filter_map(|relation_id| self.relations.get(relation_id));
+            // An entity removed by the ref's history has no live inbound
+            // edges; walk the edges its own removal severed instead so the
+            // consumers a removal breaks stay reachable. `severed` only
+            // holds entities absent at the ref, so present entities never
+            // pick up historical edges here.
+            let severed_inbound = self
+                .severed
+                .get(&current)
+                .into_iter()
+                .flatten()
+                .filter(|relation| relation.dst.as_entity() == Some(current));
+            for relation in live_inbound.chain(severed_inbound) {
+                let Some(caller) = relation.src.as_entity() else {
+                    continue;
+                };
+                if visited.insert(caller) {
+                    impacted_ids.push(caller);
+                    queue.push_back((caller, depth + 1));
+                }
+            }
+        }
+
+        Ok(impacted_ids
+            .iter()
+            .filter_map(|entity_id| self.entities.get(entity_id).cloned())
+            .collect())
+    }
+
+    fn get_work_for_scope(&self, scope: &WorkScope) -> Result<Vec<WorkItem>, ReviewError> {
+        self.live
+            .get_work_for_scope(scope)
+            .map_err(ReviewError::graph)
+    }
+
+    fn get_annotations_for_scope(&self, scope: &WorkScope) -> Result<Vec<Annotation>, ReviewError> {
+        self.live
+            .get_annotations_for_scope(scope)
+            .map_err(ReviewError::graph)
+    }
+
+    fn get_approvals_for_change(
+        &self,
+        id: &SemanticChangeId,
+    ) -> Result<Vec<Approval>, ReviewError> {
+        self.live
+            .get_approvals_for_change(id)
+            .map_err(ReviewError::graph)
+    }
+
+    fn query_audit_events(
+        &self,
+        actor_id: Option<&ActorId>,
+        limit: usize,
+    ) -> Result<Vec<AuditEvent>, ReviewError> {
+        self.live
+            .query_audit_events(actor_id, limit)
+            .map_err(ReviewError::graph)
+    }
+
+    fn get_actor(&self, id: &ActorId) -> Result<Option<Actor>, ReviewError> {
+        self.live.get_actor(id).map_err(ReviewError::graph)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use kin_db::InMemoryGraph;
+    use kin_model::change::{EntityDelta, RelationDelta, SemanticChange};
+    use kin_model::entity::{
+        Entity, EntityKind, EntityMetadata, EntityRole, FingerprintAlgorithm, SemanticFingerprint,
+        Visibility,
+    };
+    use kin_model::graph::{ChangeStore, EntityStore};
+    use kin_model::ids::*;
+    use kin_model::relation::{GraphNodeId, RelationOrigin};
+    use kin_model::timestamp::Timestamp;
+
+    fn test_entity(name: &str) -> Entity {
+        Entity {
+            id: EntityId::from_content("src/lib.rs", name, "function", 1),
+            kind: EntityKind::Function,
+            name: name.to_string(),
+            language: LanguageId::Rust,
+            fingerprint: SemanticFingerprint {
+                algorithm: FingerprintAlgorithm::V1TreeSitter,
+                ast_hash: Hash256::from_bytes([0; 32]),
+                signature_hash: Hash256::from_bytes([0; 32]),
+                behavior_hash: Hash256::from_bytes([0; 32]),
+                stability_score: 1.0,
+            },
+            file_origin: None,
+            span: None,
+            signature: format!("fn {}()", name),
+            visibility: Visibility::Public,
+            role: EntityRole::Source,
+            doc_summary: None,
+            metadata: EntityMetadata::default(),
+            lineage_parent: None,
+            created_in: None,
+            superseded_by: None,
+        }
+    }
+
+    fn test_relation(byte: u8, src: EntityId, dst: EntityId, kind: RelationKind) -> Relation {
+        Relation {
+            id: RelationId::from_bytes([byte; 16]),
+            kind,
+            src: GraphNodeId::Entity(src),
+            dst: GraphNodeId::Entity(dst),
+            confidence: 1.0,
+            origin: RelationOrigin::Parsed,
+            created_in: None,
+            import_source: None,
+            evidence: vec![],
+        }
+    }
+
+    fn change_id(byte: u8) -> SemanticChangeId {
+        SemanticChangeId::from_hash(Hash256::from_bytes([byte; 32]))
+    }
+
+    fn change(
+        id: SemanticChangeId,
+        parents: Vec<SemanticChangeId>,
+        entity_deltas: Vec<EntityDelta>,
+        relation_deltas: Vec<RelationDelta>,
+    ) -> SemanticChange {
+        SemanticChange {
+            id,
+            parents,
+            timestamp: Timestamp::now(),
+            author: AuthorId::new("test"),
+            message: "test change".into(),
+            entity_deltas,
+            relation_deltas,
+            artifact_deltas: vec![],
+            projected_files: vec![],
+            spec_link: None,
+            evidence: vec![],
+            risk_summary: None,
+            authored_on: None,
+        }
+    }
+
+    /// Committed DAG: change 1 adds target/caller/test wired by committed
+    /// relations; change 2 removes the caller->target relation; change 3
+    /// removes the target entity itself (pruning its remaining edges).
+    fn committed_graph() -> (InMemoryGraph, Entity, Entity, Entity) {
+        let graph = InMemoryGraph::new();
+        let target = test_entity("target");
+        let caller = test_entity("caller");
+        let test = test_entity("covering_test");
+
+        let calls = test_relation(1, caller.id, target.id, RelationKind::Calls);
+        let tests = test_relation(2, test.id, target.id, RelationKind::Tests);
+
+        graph
+            .create_change(&change(
+                change_id(1),
+                vec![],
+                vec![
+                    EntityDelta::Added(target.clone()),
+                    EntityDelta::Added(caller.clone()),
+                    EntityDelta::Added(test.clone()),
+                ],
+                vec![
+                    RelationDelta::Added(calls.clone()),
+                    RelationDelta::Added(tests),
+                ],
+            ))
+            .unwrap();
+        graph
+            .create_change(&change(
+                change_id(2),
+                vec![change_id(1)],
+                vec![],
+                vec![RelationDelta::Removed(calls.id)],
+            ))
+            .unwrap();
+        graph
+            .create_change(&change(
+                change_id(3),
+                vec![change_id(2)],
+                vec![EntityDelta::Removed(target.id)],
+                vec![],
+            ))
+            .unwrap();
+
+        (graph, target, caller, test)
+    }
+
+    #[test]
+    fn adjacency_is_replayed_from_committed_changes() {
+        let (graph, target, caller, test) = committed_graph();
+
+        // The live adjacency has none of the committed relations: the store
+        // records change rows without applying relation deltas.
+        assert!(graph.get_relations(&caller.id, &[]).unwrap().is_empty());
+        assert!(graph
+            .get_downstream_impact(&target.id, 2)
+            .unwrap()
+            .is_empty());
+
+        let at_one = GraphAtRef::materialize(&graph, &change_id(1)).unwrap();
+
+        let outgoing = at_one.get_relations(&caller.id, &[]).unwrap();
+        assert_eq!(outgoing.len(), 1);
+        assert_eq!(outgoing[0].kind, RelationKind::Calls);
+        assert_eq!(outgoing[0].dst, GraphNodeId::Entity(target.id));
+
+        let kind_filtered = at_one
+            .get_relations(&caller.id, &[RelationKind::Tests])
+            .unwrap();
+        assert!(kind_filtered.is_empty());
+
+        // The full-edge read unions both directions: target's inbound Calls
+        // and Tests edges surface even though target has no outgoing edges,
+        // in relation-id order.
+        let all_for_target = at_one.get_all_relations_for_entity(&target.id).unwrap();
+        assert_eq!(all_for_target.len(), 2);
+        assert_eq!(all_for_target[0].kind, RelationKind::Calls);
+        assert_eq!(all_for_target[1].kind, RelationKind::Tests);
+        assert!(all_for_target
+            .iter()
+            .all(|relation| relation.dst == GraphNodeId::Entity(target.id)));
+
+        let downstream = at_one.get_downstream_impact(&target.id, 2).unwrap();
+        let mut names: Vec<&str> = downstream.iter().map(|e| e.name.as_str()).collect();
+        names.sort_unstable();
+        assert_eq!(names, vec!["caller", "covering_test"]);
+
+        // Entity bodies come from the replayed state.
+        assert_eq!(
+            at_one.get_entity(&test.id).unwrap().unwrap().name,
+            "covering_test"
+        );
+    }
+
+    #[test]
+    fn adjacency_respects_relation_removal_at_later_ref() {
+        let (graph, target, caller, _test) = committed_graph();
+
+        let at_two = GraphAtRef::materialize(&graph, &change_id(2)).unwrap();
+
+        let downstream = at_two.get_downstream_impact(&target.id, 2).unwrap();
+        let names: Vec<&str> = downstream.iter().map(|e| e.name.as_str()).collect();
+        assert_eq!(names, vec!["covering_test"]);
+        assert!(at_two.get_relations(&caller.id, &[]).unwrap().is_empty());
+
+        // The removed Calls edge is gone from the full-edge read too; only
+        // the Tests edge survives at this ref.
+        let all_for_target = at_two.get_all_relations_for_entity(&target.id).unwrap();
+        assert_eq!(all_for_target.len(), 1);
+        assert_eq!(all_for_target[0].kind, RelationKind::Tests);
+    }
+
+    #[test]
+    fn live_only_relations_are_invisible_at_ref() {
+        let (graph, target, _caller, _test) = committed_graph();
+
+        // A relation upserted into the live adjacency but never committed to
+        // the change DAG must not leak into ref-scoped reads.
+        let ghost = test_entity("ghost_consumer");
+        graph.upsert_entity(&ghost).unwrap();
+        graph
+            .upsert_relation(&test_relation(9, ghost.id, target.id, RelationKind::Calls))
+            .unwrap();
+        assert!(!graph
+            .get_downstream_impact(&target.id, 2)
+            .unwrap()
+            .is_empty());
+
+        let at_two = GraphAtRef::materialize(&graph, &change_id(2)).unwrap();
+        let downstream = at_two.get_downstream_impact(&target.id, 2).unwrap();
+        assert!(downstream.iter().all(|e| e.name != "ghost_consumer"));
+    }
+
+    #[test]
+    fn removed_entity_serves_edges_severed_by_its_own_removal() {
+        let (graph, target, _caller, test) = committed_graph();
+
+        // Change 3 removed `target`; the replay pruned its edges there. The
+        // full-edge read serves exactly what that removal severed: the Tests
+        // edge. The Calls edge was removed by change 2 — that consumer had
+        // already let go before the removal, and must not resurrect.
+        let at_three = GraphAtRef::materialize(&graph, &change_id(3)).unwrap();
+        assert!(at_three.get_entity(&target.id).unwrap().is_none());
+
+        let severed = at_three.get_all_relations_for_entity(&target.id).unwrap();
+        assert_eq!(severed.len(), 1);
+        assert_eq!(severed[0].kind, RelationKind::Tests);
+        assert_eq!(severed[0].src, GraphNodeId::Entity(test.id));
+
+        // The downstream walk from the removed entity reaches the surviving
+        // consumer through the severed edge.
+        let downstream = at_three.get_downstream_impact(&target.id, 2).unwrap();
+        let names: Vec<&str> = downstream.iter().map(|e| e.name.as_str()).collect();
+        assert_eq!(names, vec!["covering_test"]);
+    }
+
+    #[test]
+    fn missing_ancestry_fails_loud() {
+        let graph = InMemoryGraph::new();
+        let ghost_parent = change_id(7);
+        graph
+            .create_change(&change(change_id(8), vec![ghost_parent], vec![], vec![]))
+            .unwrap();
+
+        let err = GraphAtRef::materialize(&graph, &change_id(8)).unwrap_err();
+        match err {
+            ReviewError::RefStateUnavailable { at, missing } => {
+                assert_eq!(at, change_id(8));
+                assert_eq!(missing, ghost_parent);
+            }
+            other => panic!("expected RefStateUnavailable, got {other:?}"),
+        }
+
+        let err = GraphAtRef::materialize(&graph, &change_id(9)).unwrap_err();
+        assert!(matches!(
+            err,
+            ReviewError::RefStateUnavailable { missing, .. } if missing == change_id(9)
+        ));
+    }
+
+    #[test]
+    fn downstream_impact_order_is_deterministic() {
+        let (graph, target, _caller, _test) = committed_graph();
+
+        let baseline: Vec<EntityId> = GraphAtRef::materialize(&graph, &change_id(1))
+            .unwrap()
+            .get_downstream_impact(&target.id, 2)
+            .unwrap()
+            .iter()
+            .map(|e| e.id)
+            .collect();
+        for _ in 0..5 {
+            let pass: Vec<EntityId> = GraphAtRef::materialize(&graph, &change_id(1))
+                .unwrap()
+                .get_downstream_impact(&target.id, 2)
+                .unwrap()
+                .iter()
+                .map(|e| e.id)
+                .collect();
+            assert_eq!(pass, baseline);
+        }
+    }
+}

--- a/crates/kin-review/src/review.rs
+++ b/crates/kin-review/src/review.rs
@@ -13,6 +13,7 @@ use crate::diff::{self, SemanticDiff};
 use crate::error::ReviewError;
 use crate::impact::{self, ImpactReport};
 use crate::inline::{self, InlineComment};
+use crate::ref_graph::GraphAtRef;
 use crate::risk;
 
 /// A complete semantic review: diff + impact + risk + inline comments.
@@ -34,15 +35,35 @@ impl SemanticReview {
     ///
     /// This computes:
     /// 1. Entity-level diff between base and head
-    /// 2. Impact analysis (callers, dependents, contracts, tests)
+    /// 2. Impact analysis (callers, dependents, contracts, tests) against
+    ///    the graph state materialized at `head`
     /// 3. Risk assessment (breaking changes, coverage gaps, violations)
+    ///
+    /// Fails with [`ReviewError::RefStateUnavailable`] when the graph state
+    /// at `head` cannot be materialized; it never answers impact from the
+    /// live adjacency for a committed range.
     pub fn create_review<G: GraphStore>(
         base: &SemanticChangeId,
         head: &SemanticChangeId,
         store: &G,
     ) -> Result<Review, ReviewError> {
+        let at_head = GraphAtRef::materialize(store, head)?;
+        Self::create_review_at(base, head, store, &at_head)
+    }
+
+    /// Create a full semantic review between a base and head change, with
+    /// impact analysis answered by an already-materialized head state.
+    ///
+    /// Callers evaluating the same head repeatedly can materialize the
+    /// [`GraphAtRef`] once and reuse it across evaluations.
+    pub fn create_review_at<G: GraphStore>(
+        base: &SemanticChangeId,
+        head: &SemanticChangeId,
+        store: &G,
+        at_head: &GraphAtRef<'_, G>,
+    ) -> Result<Review, ReviewError> {
         let semantic_diff = diff::compute_diff(store, base, head)?;
-        let impact_report = impact::analyze_impact(store, &semantic_diff)?;
+        let impact_report = impact::analyze_impact_at(at_head, &semantic_diff)?;
         let risk_summary = risk::assess_risk(&semantic_diff, &impact_report);
         let inline_comments = inline::collect_inline_comments(&semantic_diff, &impact_report);
 

--- a/crates/kin-review/src/shadow.rs
+++ b/crates/kin-review/src/shadow.rs
@@ -24,10 +24,13 @@ use kin_model::ids::SemanticChangeId;
 use kin_model::timestamp::Timestamp;
 use serde::{Deserialize, Serialize};
 
-use crate::diff::EntityChangeKind;
+use crate::diff::{self, EntityChangeKind};
 use crate::gate::{derive_decision, GateStatus, ReviewFinding, ReviewSignalKind};
-use crate::inline::InlineCommentKind;
+use crate::impact::ImpactReport;
+use crate::inline::{self, InlineCommentKind};
+use crate::ref_graph::GraphAtRef;
 use crate::review::{Review, SemanticReview};
+use crate::risk;
 use crate::ReviewError;
 
 /// Version of the shadow gate report payload schema. Mirrored by
@@ -201,7 +204,7 @@ pub struct ShadowRepairItem {
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct ShadowEvidenceGap {
     /// "artifact_only_change" | "missing_span" | "actor_attribution_unavailable"
-    /// | "impact_signal_absent" | "cross_repo_not_evaluated"
+    /// | "impact_signal_absent" | "cross_repo_not_evaluated" | "ref_state_unavailable"
     pub kind: String,
     pub subject: String,
     pub detail: String,
@@ -256,20 +259,101 @@ pub struct ShadowGateReport {
 /// Build a shadow-mode merge-gate report for a resolved base..head range.
 ///
 /// Read-only: consumes graph truth, produces a report, records nothing.
+///
+/// Blast radius and impact are computed against the graph state materialized
+/// at the resolved head ref, never against the mutable live adjacency. When
+/// that state cannot be materialized the report carries an explicit
+/// `ref_state_unavailable` evidence gap with an empty blast radius instead of
+/// silently answering from another era's adjacency.
 pub fn build_shadow_report<G: GraphStore>(
     store: &G,
     request: &ShadowRequest,
 ) -> Result<ShadowGateReport, ReviewError> {
-    let review =
-        SemanticReview::create_review(&request.resolved_base, &request.resolved_head, store)?;
+    match GraphAtRef::materialize(store, &request.resolved_head) {
+        Ok(at_head) => build_shadow_report_at(store, request, &at_head),
+        Err(ReviewError::RefStateUnavailable { at, missing }) => {
+            build_report_without_ref_state(store, request, at, missing)
+        }
+        Err(other) => Err(other),
+    }
+}
 
+/// Build a shadow report with an already-materialized head state.
+///
+/// Callers evaluating the same head repeatedly (e.g. repeated determinism
+/// passes) can materialize the [`GraphAtRef`] once and reuse it here;
+/// [`build_shadow_report`] materializes per call.
+pub fn build_shadow_report_at<G: GraphStore>(
+    store: &G,
+    request: &ShadowRequest,
+    at_head: &GraphAtRef<'_, G>,
+) -> Result<ShadowGateReport, ReviewError> {
+    let review = SemanticReview::create_review_at(
+        &request.resolved_base,
+        &request.resolved_head,
+        store,
+        at_head,
+    )?;
+    assemble_report(store, request, review, None)
+}
+
+/// The graph state at the head ref could not be materialized. Report the gap
+/// loudly with an empty blast radius; the live adjacency is deliberately not
+/// consulted — it reflects another era's graph, not this ref.
+fn build_report_without_ref_state<G: GraphStore>(
+    store: &G,
+    request: &ShadowRequest,
+    at: SemanticChangeId,
+    missing: SemanticChangeId,
+) -> Result<ShadowGateReport, ReviewError> {
+    let semantic_diff = diff::compute_diff(store, &request.resolved_base, &request.resolved_head)?;
+    let impact_report = ImpactReport {
+        changed_ids: semantic_diff.changed_entity_ids(),
+        ..Default::default()
+    };
+    let risk_summary = risk::assess_risk(&semantic_diff, &impact_report);
+    let inline_comments = inline::collect_inline_comments(&semantic_diff, &impact_report);
+    let review = Review {
+        base: Some(request.resolved_base),
+        head: Some(request.resolved_head),
+        diff: semantic_diff,
+        impact: impact_report,
+        risk: risk_summary,
+        inline_comments,
+    };
+
+    let gap = ShadowEvidenceGap {
+        kind: "ref_state_unavailable".to_string(),
+        subject: request.head_ref.clone(),
+        detail: format!(
+            "graph state at ref not materialized: change {missing} in the ancestry of {at} is \
+             not in the graph; blast radius and impact were NOT computed for this report, and \
+             the live adjacency was deliberately not consulted in its place"
+        ),
+    };
+    assemble_report(store, request, review, Some(gap))
+}
+
+fn assemble_report<G: GraphStore>(
+    store: &G,
+    request: &ShadowRequest,
+    review: Review,
+    ref_state_gap: Option<ShadowEvidenceGap>,
+) -> Result<ShadowGateReport, ReviewError> {
     let changes = store
         .get_changes_since(&request.resolved_base, &request.resolved_head)
         .map_err(ReviewError::graph)?;
 
     let changed_entities = collect_changed_entities(store, &review)?;
     let blast_radius = collect_blast_radius(&review);
-    let evidence_gaps = collect_evidence_gaps(&review, &changes, &changed_entities);
+    let mut evidence_gaps = collect_evidence_gaps(&review, &changes, &changed_entities);
+    if let Some(gap) = ref_state_gap {
+        // The generic empty-impact gap advises verifying relation ingestion,
+        // which misleads here: impact was not computed at all. The specific
+        // ref-state gap subsumes it.
+        evidence_gaps.retain(|existing| existing.kind != "impact_signal_absent");
+        evidence_gaps.insert(0, gap);
+    }
     let policy = derive_policy(&review, &evidence_gaps, &changed_entities);
     let repair_context = collect_repair_context(&policy.findings, &review);
     let audit = collect_audit_evidence(store, request, &review, changes.len())?;
@@ -483,6 +567,10 @@ fn is_blocking(kind: InlineCommentKind) -> bool {
 ///   non-source artifacts stays reported but does not demote — those files
 ///   are EXPECTED to carry no entities, and demoting on them turns every
 ///   docs-only change into a false attention signal.
+/// - `ref_state_unavailable`: the graph state at the reviewed head ref could
+///   not be materialized, so blast radius and impact were not computed at
+///   all. The gate cannot certify `pass` over an impact surface it never
+///   evaluated.
 /// - `impact_signal_absent` is reported but never demotes the verdict: an
 ///   empty relation channel cannot distinguish "genuinely isolated" from
 ///   "relations never ingested", and treating that ambiguity as risk flags
@@ -494,7 +582,7 @@ fn is_blocking(kind: InlineCommentKind) -> bool {
 ///   unavailable) are constant framing, reported but never demoting.
 fn gap_blocks_pass(gap: &ShadowEvidenceGap) -> bool {
     match gap.kind.as_str() {
-        "missing_span" => true,
+        "missing_span" | "ref_state_unavailable" => true,
         "artifact_only_change" => artifact_subject_is_source_class(&gap.subject),
         _ => false,
     }
@@ -1095,7 +1183,9 @@ pub fn format_shadow_report(report: &ShadowGateReport) -> String {
 mod tests {
     use super::*;
     use kin_db::InMemoryGraph;
-    use kin_model::change::{ArtifactDelta, ArtifactDeltaKind, EntityDelta, SemanticChange};
+    use kin_model::change::{
+        ArtifactDelta, ArtifactDeltaKind, EntityDelta, RelationDelta, SemanticChange,
+    };
     use kin_model::entity::{
         Entity, EntityKind, EntityMetadata, EntityRole, FingerprintAlgorithm, SemanticFingerprint,
         SourceSpan, Visibility,
@@ -1148,6 +1238,7 @@ mod tests {
         id: SemanticChangeId,
         parents: Vec<SemanticChangeId>,
         entity_deltas: Vec<EntityDelta>,
+        relation_deltas: Vec<RelationDelta>,
         artifact_deltas: Vec<ArtifactDelta>,
     ) -> SemanticChange {
         SemanticChange {
@@ -1157,7 +1248,7 @@ mod tests {
             author: AuthorId::new("test-author"),
             message: "test change".into(),
             entity_deltas,
-            relation_deltas: vec![],
+            relation_deltas,
             artifact_deltas,
             projected_files: vec![],
             spec_link: None,
@@ -1196,7 +1287,8 @@ mod tests {
 
     /// Graph with: base change adding `target` + `caller` + `test`, head
     /// change modifying `target`'s signature. Caller and test are wired to
-    /// `target` via graph relations.
+    /// `target` via relations recorded in the committed change DAG and
+    /// mirrored into the live adjacency (a consistent repo).
     fn signature_change_graph() -> (InMemoryGraph, SemanticChangeId, SemanticChangeId) {
         let graph = InMemoryGraph::new();
 
@@ -1212,15 +1304,14 @@ mod tests {
             EntityRole::Test,
         );
 
+        let calls_rel = relation(&caller, &target_v2, RelationKind::Calls);
+        let tests_rel = relation(&test, &target_v2, RelationKind::Tests);
+
         graph.upsert_entity(&target_v2).unwrap();
         graph.upsert_entity(&caller).unwrap();
         graph.upsert_entity(&test).unwrap();
-        graph
-            .upsert_relation(&relation(&caller, &target_v2, RelationKind::Calls))
-            .unwrap();
-        graph
-            .upsert_relation(&relation(&test, &target_v2, RelationKind::Tests))
-            .unwrap();
+        graph.upsert_relation(&calls_rel).unwrap();
+        graph.upsert_relation(&tests_rel).unwrap();
 
         let base_id = change_id(1);
         let head_id = change_id(2);
@@ -1232,6 +1323,10 @@ mod tests {
                 EntityDelta::Added(caller),
                 EntityDelta::Added(test),
             ],
+            vec![
+                RelationDelta::Added(calls_rel),
+                RelationDelta::Added(tests_rel),
+            ],
             vec![],
         );
         let head = change_with_deltas(
@@ -1241,6 +1336,7 @@ mod tests {
                 old: target_v1,
                 new: target_v2,
             }],
+            vec![],
             vec![],
         );
         graph.create_change(&base).unwrap();
@@ -1431,6 +1527,7 @@ mod tests {
             vec![],
             vec![EntityDelta::Added(entity.clone())],
             vec![],
+            vec![],
         );
         let head = change_with_deltas(
             head_id,
@@ -1439,6 +1536,7 @@ mod tests {
                 old: entity.clone(),
                 new: entity,
             }],
+            vec![],
             vec![ArtifactDelta {
                 file_id: FilePathId::new("config/policy.yaml"),
                 kind: ArtifactDeltaKind::Modified,
@@ -1490,6 +1588,7 @@ mod tests {
             vec![],
             vec![EntityDelta::Added(entity.clone())],
             vec![],
+            vec![],
         );
         let head = change_with_deltas(
             head_id,
@@ -1498,6 +1597,7 @@ mod tests {
                 old: entity.clone(),
                 new: entity,
             }],
+            vec![],
             vec![ArtifactDelta {
                 file_id: FilePathId::new("src/legacy.c"),
                 kind: ArtifactDeltaKind::Modified,
@@ -1586,11 +1686,10 @@ mod tests {
         let graph = InMemoryGraph::new();
         let legacy = entity_with_span("legacy_helper", "src/old.rs", 4, EntityRole::Source);
         let consumer = entity_with_span("still_calls_it", "src/live.rs", 9, EntityRole::Source);
+        let calls_rel = relation(&consumer, &legacy, RelationKind::Calls);
         graph.upsert_entity(&legacy).unwrap();
         graph.upsert_entity(&consumer).unwrap();
-        graph
-            .upsert_relation(&relation(&consumer, &legacy, RelationKind::Calls))
-            .unwrap();
+        graph.upsert_relation(&calls_rel).unwrap();
 
         let base_id = change_id(8);
         let head_id = change_id(9);
@@ -1601,12 +1700,14 @@ mod tests {
                 EntityDelta::Added(legacy.clone()),
                 EntityDelta::Added(consumer.clone()),
             ],
+            vec![RelationDelta::Added(calls_rel)],
             vec![],
         );
         let head = change_with_deltas(
             head_id,
             vec![base_id],
             vec![EntityDelta::Removed(legacy.id)],
+            vec![],
             vec![],
         );
         graph.create_change(&base).unwrap();
@@ -1622,8 +1723,9 @@ mod tests {
         assert_eq!(removed.name, "legacy_helper");
         assert_eq!(removed.file.as_deref(), Some("src/old.rs"));
 
-        // Removal with a live graph-known consumer is a blocking downstream
-        // risk, and the finding names the entity, not its uuid.
+        // Removal with a graph-known consumer — committed at base, severed
+        // by the removal at head — is a blocking downstream risk, and the
+        // finding names the entity, not its uuid.
         let downstream = report
             .policy
             .findings
@@ -1803,10 +1905,153 @@ mod tests {
     }
 
     #[test]
+    fn blast_radius_derives_from_ref_state_not_live_adjacency() {
+        // The production bug shape: committed changes carry relation deltas,
+        // but the live adjacency was never updated from them and holds a
+        // divergent set. The blast radius must come from the committed state
+        // at the head ref, not from whatever happens to be resident.
+        let graph = InMemoryGraph::new();
+
+        let target_v1 = entity_with_span("compute_total", "src/billing.rs", 10, EntityRole::Source);
+        let mut target_v2 = target_v1.clone();
+        target_v2.signature = "fn compute_total(currency: &str)".into();
+        let caller = entity_with_span("render_invoice", "src/invoice.rs", 5, EntityRole::Source);
+        let live_only =
+            entity_with_span("live_only_consumer", "src/live.rs", 8, EntityRole::Source);
+
+        // Live store: entities present, but the ONLY resident relation is one
+        // the committed history never recorded.
+        graph.upsert_entity(&target_v2).unwrap();
+        graph.upsert_entity(&caller).unwrap();
+        graph.upsert_entity(&live_only).unwrap();
+        graph
+            .upsert_relation(&relation(&live_only, &target_v2, RelationKind::Calls))
+            .unwrap();
+
+        let base_id = change_id(0x21);
+        let head_id = change_id(0x22);
+        let base = change_with_deltas(
+            base_id,
+            vec![],
+            vec![
+                EntityDelta::Added(target_v1.clone()),
+                EntityDelta::Added(caller.clone()),
+            ],
+            vec![RelationDelta::Added(relation(
+                &caller,
+                &target_v1,
+                RelationKind::Calls,
+            ))],
+            vec![],
+        );
+        let head = change_with_deltas(
+            head_id,
+            vec![base_id],
+            vec![EntityDelta::Modified {
+                old: target_v1,
+                new: target_v2,
+            }],
+            vec![],
+            vec![],
+        );
+        graph.create_change(&base).unwrap();
+        graph.create_change(&head).unwrap();
+
+        let report = build_shadow_report(&graph, &request(base_id, head_id)).unwrap();
+
+        // The committed caller is reached through the replayed ref state even
+        // though the live adjacency never held that relation.
+        assert!(report
+            .blast_radius
+            .dependents
+            .iter()
+            .any(|dependent| dependent.name == "render_invoice"));
+
+        // The live-only relation is invisible: it belongs to another era.
+        let mentions_live_only = report
+            .blast_radius
+            .callers
+            .iter()
+            .chain(report.blast_radius.dependents.iter())
+            .chain(report.blast_radius.contract_consumers.iter())
+            .chain(report.blast_radius.tests.iter())
+            .any(|affected| affected.name == "live_only_consumer");
+        assert!(!mentions_live_only);
+    }
+
+    #[test]
+    fn unmaterializable_ref_state_reports_loud_gap_not_live_fallback() {
+        let graph = InMemoryGraph::new();
+
+        let target_v1 = entity_with_span("orphan_target", "src/orphan.rs", 4, EntityRole::Source);
+        let mut target_v2 = target_v1.clone();
+        target_v2.signature = "fn orphan_target(x: u8)".into();
+        let live_caller = entity_with_span("live_caller", "src/live.rs", 6, EntityRole::Source);
+
+        // The live adjacency has a caller wired to the changed entity; a
+        // silent fallback would report it as blast radius.
+        graph.upsert_entity(&target_v2).unwrap();
+        graph.upsert_entity(&live_caller).unwrap();
+        graph
+            .upsert_relation(&relation(&live_caller, &target_v2, RelationKind::Calls))
+            .unwrap();
+
+        // base's parent was never imported, so the state at head cannot be
+        // replayed even though the base..head rows themselves exist.
+        let ghost_parent = change_id(0x31);
+        let base_id = change_id(0x32);
+        let head_id = change_id(0x33);
+        let base = change_with_deltas(
+            base_id,
+            vec![ghost_parent],
+            vec![EntityDelta::Added(target_v1.clone())],
+            vec![],
+            vec![],
+        );
+        let head = change_with_deltas(
+            head_id,
+            vec![base_id],
+            vec![EntityDelta::Modified {
+                old: target_v1,
+                new: target_v2,
+            }],
+            vec![],
+            vec![],
+        );
+        graph.create_change(&base).unwrap();
+        graph.create_change(&head).unwrap();
+
+        let report = build_shadow_report(&graph, &request(base_id, head_id)).unwrap();
+
+        let gap = report
+            .evidence_gaps
+            .iter()
+            .find(|gap| gap.kind == "ref_state_unavailable")
+            .expect("unmaterializable ref state must surface as an evidence gap");
+        assert!(gap.detail.contains("graph state at ref not materialized"));
+        assert!(gap.detail.contains(&ghost_parent.to_string()));
+
+        // No silent fallback: the blast radius stays empty even though the
+        // live adjacency holds a caller for the changed entity.
+        assert_eq!(report.blast_radius.total_affected, 0);
+        assert!(report.blast_radius.callers.is_empty());
+        assert!(report.blast_radius.dependents.is_empty());
+
+        // The specific ref-state gap subsumes the generic empty-impact gap.
+        assert!(!report
+            .evidence_gaps
+            .iter()
+            .any(|gap| gap.kind == "impact_signal_absent"));
+
+        // Missing evidence never certifies a pass.
+        assert_ne!(report.policy.verdict, ShadowGateVerdict::Pass);
+    }
+
+    #[test]
     fn empty_range_fails_loud() {
         let graph = InMemoryGraph::new();
         let base_id = change_id(5);
-        let base = change_with_deltas(base_id, vec![], vec![], vec![]);
+        let base = change_with_deltas(base_id, vec![], vec![], vec![], vec![]);
         graph.create_change(&base).unwrap();
 
         let result = build_shadow_report(&graph, &request(base_id, base_id));


### PR DESCRIPTION
Review blast radius at historical refs was residency-accidental: the live adjacency reflects latest ingest, and `create_change` never applies relation deltas to it — so whether a `base..head` review found impact depended on which era's subgraph happened to be resident (measured ~53% hit / 47% blast=0 across a 120-scenario benchmark).

**Changes**
- `GraphAtRef`: materializes committed graph state at the resolved head via a strict ancestry pre-walk + `resolve_graph_at` replay, serving impact through an exact 8-method read trait (`ImpactGraph`) — read-only by construction, BTree/relation-id-ordered adjacency (deterministic by construction). Impact/blast is now a pure function of (graph, ref).
- Loud gap, never fallback: an unmaterializable ref becomes a blocking `ref_state_unavailable` evidence gap; the live adjacency is deliberately never consulted; a pre-existing CLI catch-all that silently degraded this to a live-store review now propagates.
- Hydration persists from the shadow path (matching blame/history) — full git-ancestry hydration is once-per-repo.
- Relation deltas are id-sorted at both attach sites (removes a HashMap-order leak into committed change records).
- Parser: Rust calls inside macro token trees (`format!`, `println!`, …) are now extracted — previously they produced no relation anywhere, which the ref-scoped e2e exposed (the old e2e passed only via live-adjacency residency).

**Tests**: the bug-died fixture (committed-but-not-live relations must appear; live-only bogus relations must not), era-correctness incl. relation removal, fail-loud ancestry, 5-pass determinism, macro-call extraction regression; full sweep across kin-parser/kin-index/kin-review/kin-cli/kin-daemon = 1585 passed, 0 failed locally.

**Note for benchmark consumers**: graphs hydrated pre-fix lack macro-call edges — re-hydrate before citing blast numbers.