### PR TITLE
fix(index,review): C++ header visibility and DAG-true review ranges

### DIFF
--- a/crates/kin-cli/src/commands/commit.rs
+++ b/crates/kin-cli/src/commands/commit.rs
@@ -182,7 +182,7 @@ async fn run_local_commit_pipeline_for_tests(
                 // Parse the file for entities
                 let ext = file_path.extension().and_then(|e| e.to_str()).unwrap_or("");
 
-                let adapter = match registry.get_by_extension(ext) {
+                let adapter = match registry.get_by_extension_and_content(ext, &source) {
                     Some(a) => a,
                     None => {
                         eprintln!(

--- a/crates/kin-cli/src/commands/import.rs
+++ b/crates/kin-cli/src/commands/import.rs
@@ -243,7 +243,7 @@ fn parse_and_index(
         }
 
         let ext = file_path.extension().and_then(|e| e.to_str()).unwrap_or("");
-        let adapter = match registry.get_by_extension(ext) {
+        let adapter = match registry.get_by_extension_and_content(ext, &source) {
             Some(a) => a,
             None => continue,
         };

--- a/crates/kin-cli/src/commands/init.rs
+++ b/crates/kin-cli/src/commands/init.rs
@@ -1267,6 +1267,7 @@ pub(crate) fn enrich_imported_changes_with_semantics(
 
         if !changed_parse_data.is_empty() {
             let link_start_time = std::time::Instant::now();
+            incremental_linker.record_file_includes(&changed_parse_data);
             let mut new_relations_by_id = HashMap::<RelationId, Relation>::new();
             for relation in
                 kin_index::link_cross_file_incremental(&changed_parse_data, &incremental_linker)
@@ -1728,7 +1729,8 @@ fn index_files_with_stable_entity_ids(
                                 .extension()
                                 .and_then(|e| e.to_str())
                                 .unwrap_or("");
-                            let adapter = match registry.get_by_extension(ext) {
+                            let adapter = match registry.get_by_extension_and_content(ext, &source)
+                            {
                                 Some(adapter) => adapter,
                                 None => return ParsedFileResult::Skipped,
                             };
@@ -2675,8 +2677,9 @@ fn build_incremental_linker_from_graph(
     graph: &kin_db::InMemoryGraph,
 ) -> Result<kin_index::IncrementalLinker> {
     let mut linker = kin_index::IncrementalLinker::new();
-    for path in graph.indexed_file_paths() {
-        linker.known_files.insert(path);
+    let indexed_paths = graph.indexed_file_paths();
+    for path in &indexed_paths {
+        linker.known_files.insert(path.clone());
     }
 
     let mut entities_by_file = BTreeMap::<String, Vec<Entity>>::new();
@@ -2688,6 +2691,31 @@ fn build_incremental_linker_from_graph(
     }
     for (file_path, entities) in entities_by_file {
         linker.add_file(&file_path, &entities);
+    }
+
+    // Rehydrate per-file include state from the committed artifact include
+    // edges so include-closure disambiguation keeps working across reopen —
+    // the reparsed subset alone would only see step-local includes.
+    for path in &indexed_paths {
+        let artifact_node = GraphNodeId::Artifact(artifact_id_for_file(graph, path));
+        let mut targets = Vec::new();
+        for relation in graph.get_all_relations_for_node(&artifact_node)? {
+            if relation.kind != RelationKind::Includes || relation.src != artifact_node {
+                continue;
+            }
+            let GraphNodeId::Artifact(dst_artifact) = relation.dst else {
+                continue;
+            };
+            let Some(dst_path) = graph.path_for_artifact_id(&dst_artifact) else {
+                continue;
+            };
+            targets.push(dst_path.0);
+        }
+        if !targets.is_empty() {
+            targets.sort();
+            targets.dedup();
+            linker.include_targets_by_file.insert(path.clone(), targets);
+        }
     }
 
     Ok(linker)

--- a/crates/kin-daemon/src/api.rs
+++ b/crates/kin-daemon/src/api.rs
@@ -10418,12 +10418,12 @@ mod tests {
             .extension()
             .and_then(|e| e.to_str())
             .expect("file extension");
-        let adapter = registry
-            .get_by_extension(ext)
-            .expect("language adapter for extension");
-        let language = adapter.language_id();
         let file_id = FilePathId::new(file_path);
         let bytes = source.as_bytes();
+        let adapter = registry
+            .get_by_extension_and_content(ext, bytes)
+            .expect("language adapter for extension");
+        let language = adapter.language_id();
         let tree = adapter.parse(bytes).expect("parse");
         let output = adapter.extract(&tree, bytes, &file_id).expect("extract");
         let entities = output

--- a/crates/kin-index/src/linker.rs
+++ b/crates/kin-index/src/linker.rs
@@ -216,6 +216,7 @@ struct LinkContext<'a> {
     entity_by_name: HashMap<&'a str, Vec<(&'a str, EntityId)>>,
     entity_by_bare_name: HashMap<&'a str, Vec<(&'a str, EntityId)>>,
     entity_kind_by_id: HashMap<EntityId, EntityKind>,
+    entity_count_by_file: HashMap<&'a str, usize>,
     known_files: HashSet<&'a str>,
     import_map: HashMap<&'a str, HashMap<&'a str, (&'a str, &'a str)>>,
     include_graph: HashMap<String, Vec<String>>,
@@ -233,7 +234,14 @@ fn build_link_context<'a>(
     };
     // Step 1: Build entity indices
     //   (file_path, entity_name) -> EntityId
-    let (entity_by_file_name, entity_by_name, entity_by_bare_name, entity_kind_by_id, known_files) = {
+    let (
+        entity_by_file_name,
+        entity_by_name,
+        entity_by_bare_name,
+        entity_kind_by_id,
+        entity_count_by_file,
+        known_files,
+    ) = {
         let _span = tracing::info_span!(
             "kin.index.link_cross_file.build_entity_indices",
             universe_entities = sorted_universe.len()
@@ -243,6 +251,7 @@ fn build_link_context<'a>(
         let mut entity_by_name: HashMap<&str, Vec<(&str, EntityId)>> = HashMap::new();
         let mut entity_by_bare_name: HashMap<&str, Vec<(&str, EntityId)>> = HashMap::new();
         let mut entity_kind_by_id: HashMap<EntityId, EntityKind> = HashMap::new();
+        let mut entity_count_by_file: HashMap<&str, usize> = HashMap::new();
         let mut known_files: HashSet<&str> = HashSet::new();
 
         for &entity in &sorted_universe {
@@ -251,6 +260,7 @@ fn build_link_context<'a>(
                 continue;
             };
             known_files.insert(file_path);
+            *entity_count_by_file.entry(file_path).or_insert(0) += 1;
             entity_by_file_name.insert((file_path, &entity.name), entity.id);
             entity_by_name
                 .entry(&*entity.name)
@@ -281,6 +291,7 @@ fn build_link_context<'a>(
             entity_by_name,
             entity_by_bare_name,
             entity_kind_by_id,
+            entity_count_by_file,
             known_files,
         )
     };
@@ -317,6 +328,7 @@ fn build_link_context<'a>(
         entity_by_name,
         entity_by_bare_name,
         entity_kind_by_id,
+        entity_count_by_file,
         known_files,
         import_map,
         include_graph,
@@ -330,8 +342,9 @@ fn build_link_context<'a>(
 fn resolve_one_file(file: &FileParseData, ctx: &LinkContext<'_>) -> Vec<Relation> {
     let mut resolved = Vec::new();
     let mut seen: HashSet<(EntityId, EntityId, RelationKind)> = HashSet::new();
-    // Lazily resolved once per file: only ambiguous name buckets need it.
+    // Lazily resolved once per file: only ambiguous name buckets need them.
     let mut caller_import_targets: Option<HashSet<String>> = None;
+    let mut caller_include_closure: Option<HashMap<String, usize>> = None;
 
     for rel in &file.relations {
         let src_id = ctx
@@ -503,10 +516,15 @@ fn resolve_one_file(file: &FileParseData, ctx: &LinkContext<'_>) -> Vec<Relation
                 let targets = caller_import_targets.get_or_insert_with(|| {
                     resolve_caller_import_targets(&file.file_path, &file.imports, &ctx.known_files)
                 });
+                let closure = caller_include_closure.get_or_insert_with(|| {
+                    include_closure_depths(&file.file_path, &ctx.include_graph)
+                });
                 match disambiguate_same_name_candidates(
                     &file.file_path,
                     targets,
+                    closure,
                     &other_file_candidates,
+                    |path| ctx.entity_count_by_file.get(path).copied().unwrap_or(0),
                 ) {
                     Some(dst_id) => (dst_id, LOCALITY_DISAMBIGUATED_CONFIDENCE),
                     // No locality signal: keep the historical bucket-order
@@ -739,6 +757,33 @@ fn merge_resolved_serial(
     resolved
 }
 
+/// Resolve the include-like import targets of one file, sorted and deduped.
+///
+/// Shared by batch include-graph construction and the incremental linker's
+/// persistent per-file include state so both record identical edges.
+fn resolve_include_targets<S>(
+    file_path: &str,
+    imports: &[FileImport],
+    known_files: &HashSet<S>,
+) -> Vec<String>
+where
+    S: std::borrow::Borrow<str> + std::hash::Hash + Eq,
+{
+    let mut targets = Vec::new();
+    for import in imports {
+        let Some(resolved_path) = resolve_module_path(file_path, &import.module_path, known_files)
+        else {
+            continue;
+        };
+        if is_include_like_path(&import.module_path) || is_include_like_path(&resolved_path) {
+            targets.push(resolved_path);
+        }
+    }
+    targets.sort();
+    targets.dedup();
+    targets
+}
+
 fn build_include_graph<S>(
     files: &[FileParseData],
     known_files: &HashSet<S>,
@@ -755,18 +800,7 @@ where
     let per_file: Vec<(String, Vec<String>)> = files
         .par_iter()
         .filter_map(|file| {
-            let mut targets = Vec::new();
-            for import in &file.imports {
-                let Some(resolved_path) =
-                    resolve_module_path(&file.file_path, &import.module_path, known_files)
-                else {
-                    continue;
-                };
-                if is_include_like_path(&import.module_path) || is_include_like_path(&resolved_path)
-                {
-                    targets.push(resolved_path);
-                }
-            }
+            let targets = resolve_include_targets(&file.file_path, &file.imports, known_files);
             if targets.is_empty() {
                 None
             } else {
@@ -812,6 +846,40 @@ fn reachable_include_files(
     let mut reachable = seen.into_iter().collect::<Vec<_>>();
     reachable.sort();
     reachable
+}
+
+/// Depth bound for include-closure traversal. Real header trees stay well
+/// inside this; the bound keeps closure construction linear on pathological
+/// include chains.
+const INCLUDE_CLOSURE_MAX_DEPTH: usize = 16;
+
+/// Files reachable through the caller's include edges, keyed by resolved path
+/// with the shortest include distance (1 = directly included).
+///
+/// The walk is level-by-level, so every recorded depth is minimal regardless
+/// of visit order within a level, and cycles terminate on the visited check.
+fn include_closure_depths(
+    caller_file: &str,
+    include_graph: &HashMap<String, Vec<String>>,
+) -> HashMap<String, usize> {
+    let mut depth_by_file: HashMap<String, usize> = HashMap::new();
+    let mut frontier: Vec<String> = include_graph.get(caller_file).cloned().unwrap_or_default();
+    let mut depth = 1usize;
+    while !frontier.is_empty() && depth <= INCLUDE_CLOSURE_MAX_DEPTH {
+        let mut next = Vec::new();
+        for path in frontier {
+            if depth_by_file.contains_key(&path) || path == caller_file {
+                continue;
+            }
+            if let Some(targets) = include_graph.get(&path) {
+                next.extend(targets.iter().cloned());
+            }
+            depth_by_file.insert(path, depth);
+        }
+        frontier = next;
+        depth += 1;
+    }
+    depth_by_file
 }
 
 fn resolve_reachable_macro_target<'a>(
@@ -1096,13 +1164,30 @@ where
 /// Tier 1: exactly one distinct target in the caller's own directory — the
 /// same Go package, or a C-family sibling header/impl pair. Tier 2: exactly
 /// one distinct target among the files the caller itself imports/includes.
-/// Both tiers are count-based over entity-id sets, so bucket insertion order
-/// can never pick the winner. No unique winner → `None`; the caller decides
-/// whether a legacy fallback applies.
+/// Tier 3: exactly one distinct target among the files in the caller's
+/// include closure — a C-family caller reaching a definition through an
+/// umbrella header sees no direct-import signal, but the transitive include
+/// walk pins the defining header.
+///
+/// When several closure candidates remain, the most *specific* defining file
+/// wins: the file defining the fewest entities. An amalgamated single-include
+/// bundles the whole library and so re-defines the symbol alongside thousands
+/// of others, while the focused header that owns it defines a handful —
+/// entity count identifies the authoritative definition site structurally,
+/// without path heuristics. Nearness (minimal include depth) breaks ties only
+/// between equally specific files: an umbrella is *nearer* by construction
+/// (the caller includes it, it includes the focused header), so depth alone
+/// would systematically prefer the bundle.
+///
+/// All tiers are count-based over entity-id sets and integer minima, so
+/// bucket insertion order can never pick the winner. No unique winner →
+/// `None`; the caller decides whether a legacy fallback applies.
 fn disambiguate_same_name_candidates(
     caller_file: &str,
     caller_import_targets: &HashSet<String>,
+    caller_include_closure: &HashMap<String, usize>,
     candidates: &[(&str, EntityId)],
+    defined_entity_count: impl Fn(&str) -> usize,
 ) -> Option<EntityId> {
     let caller_dir = parent_dir(caller_file);
     let mut same_dir: HashSet<EntityId> = HashSet::new();
@@ -1123,6 +1208,48 @@ fn disambiguate_same_name_candidates(
     }
     if imported.len() == 1 {
         return imported.into_iter().next();
+    }
+
+    // Tier 3: candidates whose defining file the caller (transitively)
+    // includes, carried as (id, include depth, defining-file entity count).
+    let mut in_closure: Vec<(EntityId, usize, usize)> = Vec::new();
+    let mut closure_ids: HashSet<EntityId> = HashSet::new();
+    for (candidate_file, candidate_id) in candidates {
+        if let Some(&depth) = caller_include_closure.get(*candidate_file) {
+            in_closure.push((*candidate_id, depth, defined_entity_count(candidate_file)));
+            closure_ids.insert(*candidate_id);
+        }
+    }
+    if closure_ids.len() == 1 {
+        return closure_ids.into_iter().next();
+    }
+    if closure_ids.len() > 1 {
+        let min_count = in_closure
+            .iter()
+            .map(|&(_, _, count)| count)
+            .min()
+            .expect("closure candidates checked non-empty");
+        let specific: Vec<&(EntityId, usize, usize)> = in_closure
+            .iter()
+            .filter(|&&(_, _, count)| count == min_count)
+            .collect();
+        let specific_ids: HashSet<EntityId> = specific.iter().map(|&&(id, _, _)| id).collect();
+        if specific_ids.len() == 1 {
+            return specific_ids.into_iter().next();
+        }
+        let min_depth = specific
+            .iter()
+            .map(|&&(_, depth, _)| depth)
+            .min()
+            .expect("specific candidates checked non-empty");
+        let nearest_ids: HashSet<EntityId> = specific
+            .iter()
+            .filter(|&&&(_, depth, _)| depth == min_depth)
+            .map(|&&(id, _, _)| id)
+            .collect();
+        if nearest_ids.len() == 1 {
+            return nearest_ids.into_iter().next();
+        }
     }
     None
 }
@@ -1886,6 +2013,12 @@ pub struct IncrementalLinker {
     pub known_files: HashSet<String>,
     /// file_path -> Vec<(EntityId, Visibility)>
     pub entities_by_file: HashMap<String, Vec<(EntityId, Visibility)>>,
+    /// file_path -> resolved include targets (sorted, deduped).
+    ///
+    /// Evolves across steps alongside the entity indexes so include-closure
+    /// walks see edges recorded when other files were parsed, not only the
+    /// step-local ones.
+    pub include_targets_by_file: HashMap<String, Vec<String>>,
 }
 
 impl IncrementalLinker {
@@ -1896,6 +2029,7 @@ impl IncrementalLinker {
             entity_kind_by_id: HashMap::new(),
             known_files: HashSet::new(),
             entities_by_file: HashMap::new(),
+            include_targets_by_file: HashMap::new(),
         }
     }
 
@@ -1916,6 +2050,25 @@ impl IncrementalLinker {
         }
 
         self.entities_by_file.remove(file_path);
+        self.include_targets_by_file.remove(file_path);
+    }
+
+    /// Record the resolved include targets of each file, replacing any prior
+    /// entry (a file whose includes all resolved away is cleared).
+    ///
+    /// Call after the step's entity indexes are up to date so module
+    /// resolution sees every file known at this point in history.
+    pub fn record_file_includes(&mut self, files: &[FileParseData]) {
+        for file in files {
+            let targets =
+                resolve_include_targets(&file.file_path, &file.imports, &self.known_files);
+            if targets.is_empty() {
+                self.include_targets_by_file.remove(&file.file_path);
+            } else {
+                self.include_targets_by_file
+                    .insert(file.file_path.clone(), targets);
+            }
+        }
     }
 
     /// Add or update a file and its entities in the indexes.
@@ -1996,7 +2149,20 @@ pub fn link_cross_file_incremental(
 
     let mut resolved = Vec::new();
     let mut seen: HashSet<(EntityId, EntityId, RelationKind)> = HashSet::new();
-    let include_graph = build_include_graph(files, &linker.known_files);
+    // Step-local include edges overlay the linker's persistent per-file
+    // include state: files parsed this step resolve fresh (including files
+    // that dropped every include), every other file keeps the edges recorded
+    // when it was last parsed. Closure walks therefore cross step boundaries.
+    let include_graph = {
+        let mut merged = linker.include_targets_by_file.clone();
+        for file in files {
+            merged.remove(&file.file_path);
+        }
+        for (file_path, targets) in build_include_graph(files, &linker.known_files) {
+            merged.insert(file_path, targets);
+        }
+        merged
+    };
 
     let total_files = files.len();
     let progress_interval = std::cmp::max(total_files / 50, 1);
@@ -2013,8 +2179,9 @@ pub fn link_cross_file_incremental(
                 link_start.elapsed().as_secs_f64()
             );
         }
-        // Lazily resolved once per file: only ambiguous name buckets need it.
+        // Lazily resolved once per file: only ambiguous name buckets need them.
         let mut caller_import_targets: Option<HashSet<String>> = None;
+        let mut caller_include_closure: Option<HashMap<String, usize>> = None;
         for rel in &file.relations {
             let src_id = linker
                 .entity_by_file_name
@@ -2190,10 +2357,21 @@ pub fn link_cross_file_incremental(
                             &linker.known_files,
                         )
                     });
+                    let closure = caller_include_closure.get_or_insert_with(|| {
+                        include_closure_depths(&file.file_path, &include_graph)
+                    });
                     match disambiguate_same_name_candidates(
                         &file.file_path,
                         targets,
+                        closure,
                         &other_file_candidates,
+                        |path| {
+                            linker
+                                .entities_by_file
+                                .get(path)
+                                .map(|entities| entities.len())
+                                .unwrap_or(0)
+                        },
                     ) {
                         Some(dst_id) => (dst_id, LOCALITY_DISAMBIGUATED_CONFIDENCE),
                         // No locality signal: keep the historical bucket-order
@@ -4276,5 +4454,352 @@ void f();
             .expect("impl file must resolve into its sibling header");
         assert_eq!(edge.confidence, LOCALITY_DISAMBIGUATED_CONFIDENCE);
         assert!(find_calls_edge(&result, &caller, &bundled).is_none());
+    }
+
+    fn cpp_entity(name: &str, file_path: &str) -> Entity {
+        let mut e = make_entity(name, file_path);
+        e.language = LanguageId::Cpp;
+        e
+    }
+
+    fn include_import(module_path: &str) -> FileImport {
+        FileImport {
+            module_path: module_path.to_string(),
+            specifiers: vec![],
+        }
+    }
+
+    /// A caller reaching a definition through an umbrella header has no
+    /// direct-import signal for the defining file; the transitive include
+    /// closure must pin it over a same-named duplicate elsewhere.
+    #[test]
+    fn cpp_include_closure_resolves_transitive_header_target() {
+        let bundled = cpp_entity("convert", "single_include/catch2/catch.hpp");
+        let target = cpp_entity("convert", "include/internal/catch_tostring.h");
+        let caller = cpp_entity("TestToString", "projects/SelfTest/ToStringTests.cpp");
+
+        let files = vec![
+            // Bundled duplicate first: bucket order would pick it without the
+            // closure signal.
+            FileParseData {
+                file_path: "single_include/catch2/catch.hpp".to_string(),
+                entities: vec![bundled.clone()],
+                relations: vec![],
+                imports: vec![],
+            },
+            FileParseData {
+                file_path: "include/internal/catch_tostring.h".to_string(),
+                entities: vec![target.clone()],
+                relations: vec![],
+                imports: vec![],
+            },
+            FileParseData {
+                file_path: "include/catch.hpp".to_string(),
+                entities: vec![],
+                relations: vec![],
+                imports: vec![include_import("internal/catch_tostring.h")],
+            },
+            FileParseData {
+                file_path: "projects/SelfTest/ToStringTests.cpp".to_string(),
+                entities: vec![caller.clone()],
+                relations: vec![calls_relation("TestToString", "convert")],
+                imports: vec![include_import("catch.hpp")],
+            },
+        ];
+
+        let result = link_cross_file(&files);
+        let edge = find_calls_edge(&result, &caller, &target)
+            .expect("include closure must resolve the transitively included header");
+        assert_eq!(edge.confidence, LOCALITY_DISAMBIGUATED_CONFIDENCE);
+        assert!(
+            find_calls_edge(&result, &caller, &bundled).is_none(),
+            "closure-resolved call must not bind to the bundled duplicate"
+        );
+    }
+
+    /// When both the amalgamated single include and the focused header sit in
+    /// the caller's closure, the focused header (fewer defined entities) wins.
+    #[test]
+    fn cpp_umbrella_duplicate_loses_to_specific_header_in_closure() {
+        let bundled = cpp_entity("Session", "single_include/catch2/catch.hpp");
+        let bundled_extra_a = cpp_entity("Approx", "single_include/catch2/catch.hpp");
+        let bundled_extra_b = cpp_entity("AutoReg", "single_include/catch2/catch.hpp");
+        let target = cpp_entity("Session", "include/internal/catch_session.h");
+        let caller = cpp_entity("runMain", "projects/SelfTest/MainTests.cpp");
+
+        let files = vec![
+            FileParseData {
+                file_path: "single_include/catch2/catch.hpp".to_string(),
+                entities: vec![bundled.clone(), bundled_extra_a, bundled_extra_b],
+                relations: vec![],
+                imports: vec![],
+            },
+            FileParseData {
+                file_path: "include/internal/catch_session.h".to_string(),
+                entities: vec![target.clone()],
+                relations: vec![],
+                imports: vec![],
+            },
+            FileParseData {
+                file_path: "projects/SelfTest/MainTests.cpp".to_string(),
+                entities: vec![caller.clone()],
+                relations: vec![calls_relation("runMain", "Session")],
+                imports: vec![
+                    include_import("catch2/catch.hpp"),
+                    include_import("internal/catch_session.h"),
+                ],
+            },
+        ];
+
+        let result = link_cross_file(&files);
+        let edge = find_calls_edge(&result, &caller, &target)
+            .expect("focused header must win over the amalgamated duplicate");
+        assert_eq!(edge.confidence, LOCALITY_DISAMBIGUATED_CONFIDENCE);
+        assert!(
+            find_calls_edge(&result, &caller, &bundled).is_none(),
+            "amalgamated single include must lose to the focused header"
+        );
+    }
+
+    /// Same-named candidates in headers the caller never includes carry no
+    /// closure signal; the historical first-bucket pick must survive.
+    #[test]
+    fn cpp_closure_ambiguity_without_signal_keeps_first_candidate() {
+        let first = cpp_entity("format", "alpha/format.hpp");
+        let second = cpp_entity("format", "beta/format.hpp");
+        let caller = cpp_entity("render", "src/render.cpp");
+
+        let files = vec![
+            FileParseData {
+                file_path: "alpha/format.hpp".to_string(),
+                entities: vec![first.clone()],
+                relations: vec![],
+                imports: vec![],
+            },
+            FileParseData {
+                file_path: "beta/format.hpp".to_string(),
+                entities: vec![second.clone()],
+                relations: vec![],
+                imports: vec![],
+            },
+            FileParseData {
+                file_path: "src/other.hpp".to_string(),
+                entities: vec![],
+                relations: vec![],
+                imports: vec![],
+            },
+            FileParseData {
+                file_path: "src/render.cpp".to_string(),
+                entities: vec![caller.clone()],
+                relations: vec![calls_relation("render", "format")],
+                imports: vec![include_import("src/other.hpp")],
+            },
+        ];
+
+        let result = link_cross_file(&files);
+        let edge = find_calls_edge(&result, &caller, &first)
+            .expect("signal-less closure ambiguity keeps the historical first-bucket pick");
+        assert_eq!(edge.confidence, 0.7);
+    }
+
+    /// Incremental counterpart of the transitive-closure test: the umbrella's
+    /// include edge was recorded in an earlier step, so resolution must walk
+    /// the linker's persistent include state, not only the step-local edges.
+    #[test]
+    fn incremental_include_closure_resolves_transitive_header_target() {
+        let bundled = cpp_entity("convert", "single_include/catch2/catch.hpp");
+        let target = cpp_entity("convert", "include/internal/catch_tostring.h");
+        let caller = cpp_entity("TestToString", "projects/SelfTest/ToStringTests.cpp");
+
+        let mut linker = IncrementalLinker::new();
+        // Bundled duplicate first: bucket order would pick it without the
+        // closure signal.
+        linker.add_file(
+            "single_include/catch2/catch.hpp",
+            std::slice::from_ref(&bundled),
+        );
+        linker.add_file(
+            "include/internal/catch_tostring.h",
+            std::slice::from_ref(&target),
+        );
+        linker.add_file("include/catch.hpp", &[]);
+        linker.add_file(
+            "projects/SelfTest/ToStringTests.cpp",
+            std::slice::from_ref(&caller),
+        );
+        // Earlier step: the umbrella header was parsed and its include edge
+        // recorded into persistent state.
+        linker.record_file_includes(&[FileParseData {
+            file_path: "include/catch.hpp".to_string(),
+            entities: vec![],
+            relations: vec![],
+            imports: vec![include_import("internal/catch_tostring.h")],
+        }]);
+
+        // Later step: only the caller is (re)parsed.
+        let files = vec![FileParseData {
+            file_path: "projects/SelfTest/ToStringTests.cpp".to_string(),
+            entities: vec![caller.clone()],
+            relations: vec![calls_relation("TestToString", "convert")],
+            imports: vec![include_import("catch.hpp")],
+        }];
+
+        let result = link_cross_file_incremental(&files, &linker);
+        let edge = find_calls_edge(&result, &caller, &target)
+            .expect("persistent include state must resolve the transitive header");
+        assert_eq!(edge.confidence, LOCALITY_DISAMBIGUATED_CONFIDENCE);
+        assert!(find_calls_edge(&result, &caller, &bundled).is_none());
+    }
+
+    /// Incremental counterpart of the umbrella-specificity test, with the
+    /// defining-file entity counts served by the incremental indexes.
+    #[test]
+    fn incremental_umbrella_duplicate_loses_to_specific_header_in_closure() {
+        let bundled = cpp_entity("Session", "single_include/catch2/catch.hpp");
+        let bundled_extra_a = cpp_entity("Approx", "single_include/catch2/catch.hpp");
+        let bundled_extra_b = cpp_entity("AutoReg", "single_include/catch2/catch.hpp");
+        let target = cpp_entity("Session", "include/internal/catch_session.h");
+        let caller = cpp_entity("runMain", "projects/SelfTest/MainTests.cpp");
+
+        let mut linker = IncrementalLinker::new();
+        linker.add_file(
+            "single_include/catch2/catch.hpp",
+            &[bundled.clone(), bundled_extra_a, bundled_extra_b],
+        );
+        linker.add_file(
+            "include/internal/catch_session.h",
+            std::slice::from_ref(&target),
+        );
+        linker.add_file(
+            "projects/SelfTest/MainTests.cpp",
+            std::slice::from_ref(&caller),
+        );
+
+        let files = vec![FileParseData {
+            file_path: "projects/SelfTest/MainTests.cpp".to_string(),
+            entities: vec![caller.clone()],
+            relations: vec![calls_relation("runMain", "Session")],
+            imports: vec![
+                include_import("catch2/catch.hpp"),
+                include_import("internal/catch_session.h"),
+            ],
+        }];
+
+        let result = link_cross_file_incremental(&files, &linker);
+        let edge = find_calls_edge(&result, &caller, &target)
+            .expect("incremental focused header must win over the amalgamated duplicate");
+        assert_eq!(edge.confidence, LOCALITY_DISAMBIGUATED_CONFIDENCE);
+        assert!(find_calls_edge(&result, &caller, &bundled).is_none());
+    }
+
+    /// Persistent include state must evolve with reparses: when the umbrella
+    /// drops its include of the focused header, the closure signal disappears
+    /// and the legacy bucket-order pick returns — no edge is lost.
+    #[test]
+    fn incremental_include_state_evolves_with_reparse() {
+        let bundled = cpp_entity("convert", "single_include/catch2/catch.hpp");
+        let target = cpp_entity("convert", "include/internal/catch_tostring.h");
+        let caller = cpp_entity("TestToString", "projects/SelfTest/ToStringTests.cpp");
+
+        let mut linker = IncrementalLinker::new();
+        linker.add_file(
+            "single_include/catch2/catch.hpp",
+            std::slice::from_ref(&bundled),
+        );
+        linker.add_file(
+            "include/internal/catch_tostring.h",
+            std::slice::from_ref(&target),
+        );
+        linker.add_file("include/catch.hpp", &[]);
+        linker.add_file(
+            "projects/SelfTest/ToStringTests.cpp",
+            std::slice::from_ref(&caller),
+        );
+        linker.record_file_includes(&[FileParseData {
+            file_path: "include/catch.hpp".to_string(),
+            entities: vec![],
+            relations: vec![],
+            imports: vec![include_import("internal/catch_tostring.h")],
+        }]);
+
+        let caller_step = vec![FileParseData {
+            file_path: "projects/SelfTest/ToStringTests.cpp".to_string(),
+            entities: vec![caller.clone()],
+            relations: vec![calls_relation("TestToString", "convert")],
+            imports: vec![include_import("catch.hpp")],
+        }];
+
+        let before = link_cross_file_incremental(&caller_step, &linker);
+        assert!(
+            find_calls_edge(&before, &caller, &target).is_some(),
+            "closure signal must resolve the focused header before the reparse"
+        );
+
+        // Later step: the umbrella is reparsed without the include.
+        linker.record_file_includes(&[FileParseData {
+            file_path: "include/catch.hpp".to_string(),
+            entities: vec![],
+            relations: vec![],
+            imports: vec![],
+        }]);
+
+        let after = link_cross_file_incremental(&caller_step, &linker);
+        let edge = find_calls_edge(&after, &caller, &bundled)
+            .expect("losing the closure signal falls back to the first-bucket pick");
+        assert_eq!(edge.confidence, 0.7);
+        assert!(find_calls_edge(&after, &caller, &target).is_none());
+    }
+
+    /// The closure walk is depth-bounded: a definition past the bound carries
+    /// no signal, so the legacy pick survives instead of an unbounded scan.
+    #[test]
+    fn include_closure_depth_is_bounded() {
+        let decoy = cpp_entity("probe", "aux/probe.hpp");
+        let chain_len = INCLUDE_CLOSURE_MAX_DEPTH + 1;
+        let deep_file = format!("chain/h{:02}.hpp", chain_len - 1);
+        let deep = cpp_entity("probe", &deep_file);
+        let caller = cpp_entity("drive", "src/drive.cpp");
+
+        let mut files = vec![
+            FileParseData {
+                file_path: "aux/probe.hpp".to_string(),
+                entities: vec![decoy.clone()],
+                relations: vec![],
+                imports: vec![],
+            },
+            FileParseData {
+                file_path: "src/drive.cpp".to_string(),
+                entities: vec![caller.clone()],
+                relations: vec![calls_relation("drive", "probe")],
+                imports: vec![include_import("chain/h00.hpp")],
+            },
+        ];
+        // h00 -> h01 -> ... -> h{chain_len-1}; the caller reaches h00 at depth
+        // 1, so the deep definition sits at depth chain_len, past the bound.
+        for i in 0..chain_len {
+            let file_path = format!("chain/h{i:02}.hpp");
+            let entities = if i == chain_len - 1 {
+                vec![deep.clone()]
+            } else {
+                vec![]
+            };
+            let imports = if i + 1 < chain_len {
+                vec![include_import(&format!("chain/h{:02}.hpp", i + 1))]
+            } else {
+                vec![]
+            };
+            files.push(FileParseData {
+                file_path,
+                entities,
+                relations: vec![],
+                imports,
+            });
+        }
+
+        let result = link_cross_file(&files);
+        let edge = find_calls_edge(&result, &caller, &decoy)
+            .expect("definition past the closure bound keeps the historical pick");
+        assert_eq!(edge.confidence, 0.7);
+        assert!(find_calls_edge(&result, &caller, &deep).is_none());
     }
 }

--- a/crates/kin-index/src/pipeline.rs
+++ b/crates/kin-index/src/pipeline.rs
@@ -126,7 +126,7 @@ impl IndexPipeline {
 
         let adapter = self
             .registry
-            .get_by_extension(ext)
+            .get_by_extension_and_content(ext, source)
             .ok_or_else(|| IndexError::UnsupportedFile(ext.to_string()))?;
         let language = adapter.language_id();
 
@@ -234,13 +234,13 @@ impl IndexPipeline {
             .and_then(|e| e.to_str())
             .ok_or_else(|| IndexError::UnsupportedFile(path.display().to_string()))?;
 
-        let adapter = self
-            .registry
-            .get_by_extension(ext)
-            .ok_or_else(|| IndexError::UnsupportedFile(ext.to_string()))?;
-
         let source =
             std::fs::read(path).map_err(|e| IndexError::io(path.display().to_string(), e))?;
+
+        let adapter = self
+            .registry
+            .get_by_extension_and_content(ext, &source)
+            .ok_or_else(|| IndexError::UnsupportedFile(ext.to_string()))?;
 
         // Store the raw source as a blob
         let blob_hash = blob_store.write(&source)?;
@@ -248,9 +248,13 @@ impl IndexPipeline {
 
         let language = adapter.language_id();
 
-        // Parse: incremental when hints are available, full otherwise
+        // Parse: incremental when hints are available, full otherwise. An
+        // edit can flip a content-disambiguated extension to another
+        // adapter, and an old tree from the other grammar must never seed an
+        // incremental parse — those files always take the full parse.
+        let content_disambiguated = ext == "h";
         let tree = match (old_tree, edit_hint) {
-            (Some(old), Some(hint)) => {
+            (Some(old), Some(hint)) if !content_disambiguated => {
                 debug!(
                     path = %path.display(),
                     start = hint.start_byte,

--- a/crates/kin-parser/examples/dump_parsed.rs
+++ b/crates/kin-parser/examples/dump_parsed.rs
@@ -20,7 +20,7 @@ fn main() {
         .unwrap_or("");
     let registry = AdapterRegistry::new();
     let adapter = registry
-        .get_by_extension(extension)
+        .get_by_extension_and_content(extension, &content)
         .unwrap_or_else(|| panic!("no parser adapter for extension `{extension}`"));
     let tree = adapter.parse(&content).expect("failed to parse");
     let path_id = kin_model::FilePathId::new(path);

--- a/crates/kin-parser/src/languages/mod.rs
+++ b/crates/kin-parser/src/languages/mod.rs
@@ -77,6 +77,27 @@ impl AdapterRegistry {
             .map(|a| a.as_ref())
     }
 
+    /// Find an adapter by file extension, disambiguating extensions shared
+    /// between languages by inspecting the content.
+    ///
+    /// `.h` is the C/C++ collision: a C++ header under a `.h` name parsed
+    /// with the C grammar shreds namespaces and templates into error
+    /// recovery, so entity and call extraction silently degrades. A scan for
+    /// constructs that exist only in C++ routes those headers to the C++
+    /// adapter. The scan is biased toward C++ on ambiguity (a marker inside
+    /// a comment still routes to C++): the C++ grammar parses C headers
+    /// essentially intact, while the C grammar destroys C++ ones.
+    pub fn get_by_extension_and_content(
+        &self,
+        ext: &str,
+        source: &[u8],
+    ) -> Option<&dyn LanguageAdapter> {
+        if ext == "h" && header_content_is_cpp(source) {
+            return self.get_by_language(LanguageId::Cpp);
+        }
+        self.get_by_extension(ext)
+    }
+
     /// List all supported language IDs.
     pub fn supported_languages(&self) -> Vec<LanguageId> {
         self.adapters.iter().map(|a| a.language_id()).collect()
@@ -87,6 +108,88 @@ impl Default for AdapterRegistry {
     fn default() -> Self {
         Self::new()
     }
+}
+
+/// Whether header bytes carry constructs that only exist in C++.
+///
+/// Markers are matched at identifier boundaries so `subclass` or
+/// `mytemplate` never trigger. `class` alone is not proof (it is a legal C
+/// identifier), so it counts only when followed by an identifier — the shape
+/// of a declaration. Deterministic: a pure function of the bytes.
+fn header_content_is_cpp(source: &[u8]) -> bool {
+    const KEYWORD_MARKERS: &[&[u8]] = &[b"namespace", b"typename", b"constexpr", b"template"];
+    for marker in KEYWORD_MARKERS {
+        if contains_identifier_token(source, marker) {
+            return true;
+        }
+    }
+    if cpp_class_declaration_present(source) {
+        return true;
+    }
+    // Access specifiers are C++-only syntax even without other keywords.
+    for marker in [b"public:".as_slice(), b"private:", b"protected:"] {
+        if find_token_boundary_match(source, marker, false).is_some() {
+            return true;
+        }
+    }
+    false
+}
+
+fn is_identifier_byte(byte: u8) -> bool {
+    byte == b'_' || byte.is_ascii_alphanumeric()
+}
+
+/// Whether `needle` occurs in `haystack` with non-identifier bytes (or the
+/// buffer edge) on both sides.
+fn contains_identifier_token(haystack: &[u8], needle: &[u8]) -> bool {
+    find_token_boundary_match(haystack, needle, true).is_some()
+}
+
+/// Position of the first occurrence of `needle` whose left side is a
+/// non-identifier byte or the buffer start; when `check_right` is set the
+/// right side must also be a non-identifier byte or the buffer end.
+fn find_token_boundary_match(haystack: &[u8], needle: &[u8], check_right: bool) -> Option<usize> {
+    if needle.is_empty() || haystack.len() < needle.len() {
+        return None;
+    }
+    let mut start = 0;
+    while start + needle.len() <= haystack.len() {
+        let offset = haystack[start..]
+            .windows(needle.len())
+            .position(|window| window == needle)?;
+        let idx = start + offset;
+        let left_ok = idx == 0 || !is_identifier_byte(haystack[idx - 1]);
+        let right_ok = !check_right
+            || idx + needle.len() == haystack.len()
+            || !is_identifier_byte(haystack[idx + needle.len()]);
+        if left_ok && right_ok {
+            return Some(idx);
+        }
+        start = idx + 1;
+    }
+    None
+}
+
+/// Whether the bytes contain `class <identifier>` — the shape of a C++ class
+/// declaration. `class` is a legal identifier in C, so the bare token is not
+/// proof by itself.
+fn cpp_class_declaration_present(source: &[u8]) -> bool {
+    let mut start = 0;
+    while let Some(idx) = find_token_boundary_match(&source[start..], b"class", true) {
+        let after = start + idx + b"class".len();
+        let mut cursor = after;
+        while cursor < source.len() && (source[cursor] == b' ' || source[cursor] == b'\t') {
+            cursor += 1;
+        }
+        if cursor > after
+            && cursor < source.len()
+            && (source[cursor] == b'_' || source[cursor].is_ascii_alphabetic())
+        {
+            return true;
+        }
+        start = after;
+    }
+    false
 }
 
 #[cfg(test)]
@@ -146,5 +249,54 @@ mod tests {
         assert!(registry.get_by_language(LanguageId::CSharp).is_some());
         assert!(registry.get_by_language(LanguageId::Ruby).is_some());
         assert!(registry.get_by_language(LanguageId::Php).is_some());
+    }
+
+    #[test]
+    fn dot_h_header_with_cpp_constructs_routes_to_cpp() {
+        let registry = AdapterRegistry::new();
+        let cpp_header =
+            b"namespace Catch {\n    struct ratio_string {\n        static int symbol();\n    };\n}\n";
+        let adapter = registry
+            .get_by_extension_and_content("h", cpp_header)
+            .unwrap();
+        assert_eq!(adapter.language_id(), LanguageId::Cpp);
+
+        let template_header = b"template <class T>\nstruct maker { T value; };\n";
+        let adapter = registry
+            .get_by_extension_and_content("h", template_header)
+            .unwrap();
+        assert_eq!(adapter.language_id(), LanguageId::Cpp);
+    }
+
+    #[test]
+    fn dot_h_header_without_cpp_constructs_stays_c() {
+        let registry = AdapterRegistry::new();
+        // `classic_config` and `subclass_id` must not trip the
+        // identifier-boundary markers.
+        let c_header = b"#include <stdio.h>\n\nstruct classic_config { int subclass_id; };\nint parse_config(struct classic_config *cfg);\n";
+        let adapter = registry
+            .get_by_extension_and_content("h", c_header)
+            .unwrap();
+        assert_eq!(adapter.language_id(), LanguageId::C);
+    }
+
+    #[test]
+    fn non_header_extensions_ignore_content() {
+        let registry = AdapterRegistry::new();
+        let adapter = registry
+            .get_by_extension_and_content("c", b"namespace fake {}\n")
+            .unwrap();
+        assert_eq!(adapter.language_id(), LanguageId::C);
+    }
+
+    #[test]
+    fn cpp_header_markers_are_identifier_bounded() {
+        assert!(header_content_is_cpp(b"class Session;\n"));
+        assert!(header_content_is_cpp(b"struct S { public: int x; };\n"));
+        // A declaration-shaped `class <identifier>` is required: `class` used
+        // as a C identifier does not count.
+        assert!(!header_content_is_cpp(b"int class = 1;\n"));
+        assert!(!header_content_is_cpp(b"struct subclass_t { int x; };\n"));
+        assert!(!header_content_is_cpp(b"int mytemplate(int namespaces);\n"));
     }
 }

--- a/crates/kin-review/src/diff.rs
+++ b/crates/kin-review/src/diff.rs
@@ -110,9 +110,30 @@ pub fn compute_diff<G: GraphStore>(
     base: &SemanticChangeId,
     head: &SemanticChangeId,
 ) -> Result<SemanticDiff, ReviewError> {
-    let changes = store
+    compute_diff_scoped(store, base, head, |_| true)
+}
+
+/// Compute a semantic diff accumulating only the walked changes `in_range`
+/// accepts, in their walked order.
+///
+/// The store's backward walk stops at the literal base node, not at the
+/// base's ancestors, so on a merge head it crosses into the base's own
+/// history through the other parent and the accumulated diff spans eras the
+/// range never touched. Range-aware callers pass the DAG-true membership
+/// test (reachable from head, not reachable from base) to restore
+/// `base..head` semantics without a storage-layer change.
+pub fn compute_diff_scoped<G: GraphStore>(
+    store: &G,
+    base: &SemanticChangeId,
+    head: &SemanticChangeId,
+    in_range: impl Fn(&SemanticChangeId) -> bool,
+) -> Result<SemanticDiff, ReviewError> {
+    let changes: Vec<_> = store
         .get_changes_since(base, head)
-        .map_err(ReviewError::graph)?;
+        .map_err(ReviewError::graph)?
+        .into_iter()
+        .filter(|change| in_range(&change.id))
+        .collect();
 
     if changes.is_empty() {
         return Err(ReviewError::NoChanges);

--- a/crates/kin-review/src/ref_graph.rs
+++ b/crates/kin-review/src/ref_graph.rs
@@ -39,6 +39,10 @@ use crate::impact::ImpactGraph;
 pub struct GraphAtRef<'a, G> {
     live: &'a G,
     at: SemanticChangeId,
+    // Every change id reachable from `at` through parent edges, including
+    // `at` itself — the set the materialization walk already visited. Range
+    // queries use it to refuse bases that are not on this head's history.
+    ancestry: HashSet<SemanticChangeId>,
     entities: HashMap<EntityId, Entity>,
     relations: HashMap<RelationId, Relation>,
     // BTree-keyed with relation-id-sorted edge lists: every traversal is
@@ -93,7 +97,7 @@ impl<'a, G: GraphStore> GraphAtRef<'a, G> {
         }
 
         let state = live.resolve_graph_at(at).map_err(ReviewError::graph)?;
-        Ok(Self::from_state(live, *at, state))
+        Ok(Self::from_state(live, *at, visited, state))
     }
 
     /// The ref this state was materialized at (cache key for reuse across
@@ -102,7 +106,23 @@ impl<'a, G: GraphStore> GraphAtRef<'a, G> {
         &self.at
     }
 
-    fn from_state(live: &'a G, at: SemanticChangeId, state: ResolvedGraphState) -> Self {
+    /// Whether `id` is the materialized ref itself or one of its ancestors
+    /// in the change DAG.
+    pub fn ancestry_contains(&self, id: &SemanticChangeId) -> bool {
+        self.ancestry.contains(id)
+    }
+
+    /// Every change reachable from the materialized ref, including itself.
+    pub fn ancestry(&self) -> &HashSet<SemanticChangeId> {
+        &self.ancestry
+    }
+
+    fn from_state(
+        live: &'a G,
+        at: SemanticChangeId,
+        ancestry: HashSet<SemanticChangeId>,
+        state: ResolvedGraphState,
+    ) -> Self {
         let mut outgoing: BTreeMap<EntityId, Vec<RelationId>> = BTreeMap::new();
         let mut incoming: BTreeMap<EntityId, Vec<RelationId>> = BTreeMap::new();
         for relation in state.relations.values() {
@@ -152,6 +172,7 @@ impl<'a, G: GraphStore> GraphAtRef<'a, G> {
         Self {
             live,
             at,
+            ancestry,
             entities: state.entities,
             relations: state.relations,
             outgoing,
@@ -159,6 +180,32 @@ impl<'a, G: GraphStore> GraphAtRef<'a, G> {
             severed,
         }
     }
+}
+
+/// Every change reachable from `at` through parent edges, including `at`
+/// itself. Fails like [`GraphAtRef::materialize`] when a row in the walk is
+/// missing: a partial ancestry would silently misscope range queries.
+pub fn collect_ancestry<G: GraphStore>(
+    store: &G,
+    at: &SemanticChangeId,
+) -> Result<HashSet<SemanticChangeId>, ReviewError> {
+    let mut visited = HashSet::new();
+    let mut pending = vec![*at];
+    while let Some(id) = pending.pop() {
+        if !visited.insert(id) {
+            continue;
+        }
+        match store.get_change(&id).map_err(ReviewError::graph)? {
+            Some(change) => pending.extend(change.parents.iter().copied()),
+            None => {
+                return Err(ReviewError::RefStateUnavailable {
+                    at: *at,
+                    missing: id,
+                })
+            }
+        }
+    }
+    Ok(visited)
 }
 
 impl<G: GraphStore> ImpactGraph for GraphAtRef<'_, G> {

--- a/crates/kin-review/src/review.rs
+++ b/crates/kin-review/src/review.rs
@@ -62,7 +62,20 @@ impl SemanticReview {
         store: &G,
         at_head: &GraphAtRef<'_, G>,
     ) -> Result<Review, ReviewError> {
-        let semantic_diff = diff::compute_diff(store, base, head)?;
+        Self::create_review_scoped(base, head, store, at_head, |_| true)
+    }
+
+    /// Create a review whose diff accumulates only the walked changes
+    /// `in_range` accepts — the DAG-true `base..head` membership test for
+    /// range-aware callers. See [`diff::compute_diff_scoped`].
+    pub fn create_review_scoped<G: GraphStore>(
+        base: &SemanticChangeId,
+        head: &SemanticChangeId,
+        store: &G,
+        at_head: &GraphAtRef<'_, G>,
+        in_range: impl Fn(&SemanticChangeId) -> bool,
+    ) -> Result<Review, ReviewError> {
+        let semantic_diff = diff::compute_diff_scoped(store, base, head, in_range)?;
         let impact_report = impact::analyze_impact_at(at_head, &semantic_diff)?;
         let risk_summary = risk::assess_risk(&semantic_diff, &impact_report);
         let inline_comments = inline::collect_inline_comments(&semantic_diff, &impact_report);

--- a/crates/kin-review/src/shadow.rs
+++ b/crates/kin-review/src/shadow.rs
@@ -24,7 +24,7 @@ use kin_model::ids::SemanticChangeId;
 use kin_model::timestamp::Timestamp;
 use serde::{Deserialize, Serialize};
 
-use crate::diff::{self, EntityChangeKind};
+use crate::diff::{self, EntityChangeKind, SemanticDiff};
 use crate::gate::{derive_decision, GateStatus, ReviewFinding, ReviewSignalKind};
 use crate::impact::ImpactReport;
 use crate::inline::{self, InlineCommentKind};
@@ -205,6 +205,7 @@ pub struct ShadowRepairItem {
 pub struct ShadowEvidenceGap {
     /// "artifact_only_change" | "missing_span" | "actor_attribution_unavailable"
     /// | "impact_signal_absent" | "cross_repo_not_evaluated" | "ref_state_unavailable"
+    /// | "base_not_on_head_ancestry"
     pub kind: String,
     pub subject: String,
     pub detail: String,
@@ -288,13 +289,32 @@ pub fn build_shadow_report_at<G: GraphStore>(
     request: &ShadowRequest,
     at_head: &GraphAtRef<'_, G>,
 ) -> Result<ShadowGateReport, ReviewError> {
-    let review = SemanticReview::create_review_at(
+    if !at_head.ancestry_contains(&request.resolved_base) {
+        return build_report_with_base_off_ancestry(store, request);
+    }
+    // DAG-true `base..head` membership: reachable from head, not reachable
+    // from base. The store's backward walk stops only at the literal base
+    // node, so on a merge head it crosses into the base's own history
+    // through the other parent; every consumer of the walked rows below
+    // scopes them with this test so the diff and the audited range describe
+    // the reviewed range and nothing older.
+    let base_ancestry = crate::ref_graph::collect_ancestry(store, &request.resolved_base)?;
+    let in_range =
+        |id: &SemanticChangeId| at_head.ancestry_contains(id) && !base_ancestry.contains(id);
+    let review = SemanticReview::create_review_scoped(
         &request.resolved_base,
         &request.resolved_head,
         store,
         at_head,
+        in_range,
     )?;
-    assemble_report(store, request, review, None)
+    let changes: Vec<_> = store
+        .get_changes_since(&request.resolved_base, &request.resolved_head)
+        .map_err(ReviewError::graph)?
+        .into_iter()
+        .filter(|change| in_range(&change.id))
+        .collect();
+    assemble_report_with_changes(store, request, review, None, &changes)
 }
 
 /// The graph state at the head ref could not be materialized. Report the gap
@@ -334,23 +354,72 @@ fn build_report_without_ref_state<G: GraphStore>(
     assemble_report(store, request, review, Some(gap))
 }
 
+/// The resolved base is not on the head's ancestry in the change DAG. A range
+/// walk from that base would not describe this head's history — it degrades
+/// into a sweep across unrelated eras of the DAG — so the range is refused
+/// loudly: no diff, no blast radius, no impact, no range walk, and an
+/// explicit blocking evidence gap in their place.
+fn build_report_with_base_off_ancestry<G: GraphStore>(
+    store: &G,
+    request: &ShadowRequest,
+) -> Result<ShadowGateReport, ReviewError> {
+    let semantic_diff = SemanticDiff {
+        base: Some(request.resolved_base),
+        head: Some(request.resolved_head),
+        ..Default::default()
+    };
+    let impact_report = ImpactReport::default();
+    let risk_summary = risk::assess_risk(&semantic_diff, &impact_report);
+    let inline_comments = inline::collect_inline_comments(&semantic_diff, &impact_report);
+    let review = Review {
+        base: Some(request.resolved_base),
+        head: Some(request.resolved_head),
+        diff: semantic_diff,
+        impact: impact_report,
+        risk: risk_summary,
+        inline_comments,
+    };
+
+    let gap = ShadowEvidenceGap {
+        kind: "base_not_on_head_ancestry".to_string(),
+        subject: format!("{}..{}", request.base_ref, request.head_ref),
+        detail: format!(
+            "resolved base {} is not on the ancestry of head {} in the change DAG; a range walk \
+             from this base would span unrelated history, so diff, blast radius, and impact were \
+             NOT computed for this report",
+            request.resolved_base, request.resolved_head
+        ),
+    };
+    assemble_report_with_changes(store, request, review, Some(gap), &[])
+}
+
 fn assemble_report<G: GraphStore>(
     store: &G,
     request: &ShadowRequest,
     review: Review,
-    ref_state_gap: Option<ShadowEvidenceGap>,
+    range_gap: Option<ShadowEvidenceGap>,
 ) -> Result<ShadowGateReport, ReviewError> {
     let changes = store
         .get_changes_since(&request.resolved_base, &request.resolved_head)
         .map_err(ReviewError::graph)?;
+    assemble_report_with_changes(store, request, review, range_gap, &changes)
+}
 
+fn assemble_report_with_changes<G: GraphStore>(
+    store: &G,
+    request: &ShadowRequest,
+    review: Review,
+    range_gap: Option<ShadowEvidenceGap>,
+    changes: &[kin_model::change::SemanticChange],
+) -> Result<ShadowGateReport, ReviewError> {
     let changed_entities = collect_changed_entities(store, &review)?;
     let blast_radius = collect_blast_radius(&review);
-    let mut evidence_gaps = collect_evidence_gaps(&review, &changes, &changed_entities);
-    if let Some(gap) = ref_state_gap {
+    let mut evidence_gaps = collect_evidence_gaps(&review, changes, &changed_entities);
+    if let Some(gap) = range_gap {
         // The generic empty-impact gap advises verifying relation ingestion,
         // which misleads here: impact was not computed at all. The specific
-        // ref-state gap subsumes it.
+        // range gap (unmaterializable ref state, base off the head ancestry)
+        // subsumes it.
         evidence_gaps.retain(|existing| existing.kind != "impact_signal_absent");
         evidence_gaps.insert(0, gap);
     }
@@ -571,6 +640,10 @@ fn is_blocking(kind: InlineCommentKind) -> bool {
 ///   not be materialized, so blast radius and impact were not computed at
 ///   all. The gate cannot certify `pass` over an impact surface it never
 ///   evaluated.
+/// - `base_not_on_head_ancestry`: the resolved base is not on the head's
+///   ancestry in the change DAG, so the requested range does not describe
+///   this head's history and diff, blast radius, and impact were refused.
+///   The gate cannot certify `pass` over a range it never evaluated.
 /// - `impact_signal_absent` is reported but never demotes the verdict: an
 ///   empty relation channel cannot distinguish "genuinely isolated" from
 ///   "relations never ingested", and treating that ambiguity as risk flags
@@ -582,7 +655,7 @@ fn is_blocking(kind: InlineCommentKind) -> bool {
 ///   unavailable) are constant framing, reported but never demoting.
 fn gap_blocks_pass(gap: &ShadowEvidenceGap) -> bool {
     match gap.kind.as_str() {
-        "missing_span" | "ref_state_unavailable" => true,
+        "missing_span" | "ref_state_unavailable" | "base_not_on_head_ancestry" => true,
         "artifact_only_change" => artifact_subject_is_source_class(&gap.subject),
         _ => false,
     }
@@ -2045,6 +2118,164 @@ mod tests {
 
         // Missing evidence never certifies a pass.
         assert_ne!(report.policy.verdict, ShadowGateVerdict::Pass);
+    }
+
+    #[test]
+    fn base_off_head_ancestry_reports_loud_gap_not_range_walk() {
+        let graph = InMemoryGraph::new();
+
+        let target_v1 = entity_with_span("routed_target", "src/routed.rs", 4, EntityRole::Source);
+        let mut target_v2 = target_v1.clone();
+        target_v2.signature = "fn routed_target(x: u8)".into();
+        let stray = entity_with_span("stray_entity", "src/stray.rs", 9, EntityRole::Source);
+
+        // Main line: root -> head, fully materializable.
+        let root_id = change_id(0x41);
+        let head_id = change_id(0x42);
+        let root = change_with_deltas(
+            root_id,
+            vec![],
+            vec![EntityDelta::Added(target_v1.clone())],
+            vec![],
+            vec![],
+        );
+        let head = change_with_deltas(
+            head_id,
+            vec![root_id],
+            vec![EntityDelta::Modified {
+                old: target_v1,
+                new: target_v2,
+            }],
+            vec![],
+            vec![],
+        );
+        // Disjoint branch: a change that is NOT on head's ancestry.
+        let disjoint_id = change_id(0x43);
+        let disjoint = change_with_deltas(
+            disjoint_id,
+            vec![],
+            vec![EntityDelta::Added(stray)],
+            vec![],
+            vec![],
+        );
+        graph.create_change(&root).unwrap();
+        graph.create_change(&head).unwrap();
+        graph.create_change(&disjoint).unwrap();
+
+        let report = build_shadow_report(&graph, &request(disjoint_id, head_id)).unwrap();
+
+        let gap = report
+            .evidence_gaps
+            .iter()
+            .find(|gap| gap.kind == "base_not_on_head_ancestry")
+            .expect("a base off the head ancestry must surface as an evidence gap");
+        assert!(gap.detail.contains("not on the ancestry"));
+        assert!(gap.detail.contains(&disjoint_id.to_string()));
+
+        // The range walk is refused: no genesis-spanning diff, no changed
+        // entities, no blast radius, and zero changes in range.
+        assert!(report.changed_entities.is_empty());
+        assert_eq!(report.blast_radius.total_affected, 0);
+        assert_eq!(report.audit.changes_in_range, 0);
+
+        // The specific range gap subsumes the generic empty-impact gap.
+        assert!(!report
+            .evidence_gaps
+            .iter()
+            .any(|gap| gap.kind == "impact_signal_absent"));
+
+        // A range the gate never evaluated is never certified as a pass.
+        assert_ne!(report.policy.verdict, ShadowGateVerdict::Pass);
+
+        // The refusal is deterministic modulo the generation timestamp.
+        let strip = |report: ShadowGateReport| {
+            let mut value = serde_json::to_value(&report).unwrap();
+            value["audit"]["generated_at"] = serde_json::json!(null);
+            value
+        };
+        let second = build_shadow_report(&graph, &request(disjoint_id, head_id)).unwrap();
+        assert_eq!(strip(report), strip(second));
+    }
+
+    #[test]
+    fn merge_head_range_excludes_base_side_history() {
+        let graph = InMemoryGraph::new();
+
+        let stale = entity_with_span("stale_entity", "src/stale.rs", 3, EntityRole::Source);
+        let mainline = entity_with_span("mainline_entity", "src/main.rs", 5, EntityRole::Source);
+        let branch_v1 = entity_with_span("branch_entity", "src/branch.rs", 7, EntityRole::Source);
+        let mut branch_v2 = branch_v1.clone();
+        branch_v2.signature = "fn branch_entity(x: u8)".into();
+
+        // G -> A (base, mainline); G -> B (branch); head merges [A, B]. The
+        // store's backward walk from head reaches G through B because it
+        // only stops at the literal base node, so an unscoped diff would
+        // carry G's deltas — history the base already contains.
+        let genesis_id = change_id(0x51);
+        let base_id = change_id(0x52);
+        let branch_id = change_id(0x53);
+        let head_id = change_id(0x54);
+        let genesis = change_with_deltas(
+            genesis_id,
+            vec![],
+            vec![EntityDelta::Added(stale.clone())],
+            vec![],
+            vec![],
+        );
+        let base = change_with_deltas(
+            base_id,
+            vec![genesis_id],
+            vec![EntityDelta::Added(mainline.clone())],
+            vec![],
+            vec![],
+        );
+        let branch = change_with_deltas(
+            branch_id,
+            vec![genesis_id],
+            vec![EntityDelta::Added(branch_v1.clone())],
+            vec![],
+            vec![],
+        );
+        let head = change_with_deltas(
+            head_id,
+            vec![base_id, branch_id],
+            vec![EntityDelta::Modified {
+                old: branch_v1,
+                new: branch_v2,
+            }],
+            vec![],
+            vec![],
+        );
+        graph.create_change(&genesis).unwrap();
+        graph.create_change(&base).unwrap();
+        graph.create_change(&branch).unwrap();
+        graph.create_change(&head).unwrap();
+
+        let report = build_shadow_report(&graph, &request(base_id, head_id)).unwrap();
+
+        // Only the merged-in side of the range is in scope: two changes
+        // (branch + head), one changed entity.
+        assert_eq!(report.audit.changes_in_range, 2);
+        let changed_names: Vec<&str> = report
+            .changed_entities
+            .iter()
+            .map(|entity| entity.name.as_str())
+            .collect();
+        assert!(changed_names.contains(&"branch_entity"));
+        assert!(
+            !changed_names.contains(&"stale_entity"),
+            "history reachable from the base must not enter the range diff"
+        );
+        assert!(!changed_names.contains(&"mainline_entity"));
+
+        // The scoped range stays deterministic modulo the timestamp.
+        let strip = |report: ShadowGateReport| {
+            let mut value = serde_json::to_value(&report).unwrap();
+            value["audit"]["generated_at"] = serde_json::json!(null);
+            value
+        };
+        let second = build_shadow_report(&graph, &request(base_id, head_id)).unwrap();
+        assert_eq!(strip(report), strip(second));
     }
 
     #[test]


### PR DESCRIPTION
Closes the last three verified gaps on the review/blast-radius surface.

**C++ header visibility**: `.h` files routed to the C grammar, shredding C++ headers (namespaces/templates collapsed, call extraction dying mid-file) — the single_include umbrella was often the only richly-parsed same-name candidate. Content-aware dispatch (C++-only-construct scan, all five parse surfaces, no incremental parse across a grammar flip) plus include-closure disambiguation in both linkers (persistent per-file include state, depth-bounded closure, fewest-defined-entities-then-nearest specificity so umbrellas lose to focused headers; zero edge loss on signal-less ambiguity). Catch2 head relations 2581→4040; a false generic-name consumer drops from a known scenario (16→15, remainder byte-identical); Go-family scenario exactly unchanged.

**DAG-true review ranges**: `get_changes_since` stops only at the literal base node, so a merge-parented head walks through its second parent into pre-base history (observed live: 13,310 'changes' / 9,997 phantom entities for a one-PR revert). The shadow path now scopes diff, gaps, and audit to reachable(head) ∖ reachable(base) using the ancestry walk materialization already performs; truly disjoint bases refuse loudly (blocking `base_not_on_head_ancestry` gap, empty diff, no genesis walk). Live gate: 13,310→3 changes, 9,997→9 entities (the gold file + tests), blast 22 real consumers; linear-history byte-identical no-op proven.

Tests: 7 include-closure + 4 dispatch + merge-range/off-ancestry fixtures with in-test determinism; full workspace suites green.