### PR TITLE
feat(npm): publish @kinlab/kin as the canonical install surface

### DIFF
--- a/.github/workflows/auto-tag-release.yml
+++ b/.github/workflows/auto-tag-release.yml
@@ -15,6 +15,7 @@ on:
     paths:
       - Cargo.toml
       - packages/kin-mcp/package.json
+      - packages/kin/package.json
       - CHANGELOG.md
 
 permissions:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -65,8 +65,10 @@ jobs:
       - name: Test @kinlab/kin (canonical launcher)
         run: npm test --prefix ./packages/kin && npm run lint --prefix ./packages/kin
 
+      # test:unit, not test: full `node --test` discovery pulls in the first-run
+      # smoke, which requires a built kin binary a fresh CI runner does not have.
       - name: Test @kinlab/kin-mcp (compatibility wrapper)
-        run: npm test --prefix ./packages/kin-mcp && npm run lint --prefix ./packages/kin-mcp
+        run: npm run test:unit --prefix ./packages/kin-mcp && npm run lint --prefix ./packages/kin-mcp
 
   check:
     name: Check & Test

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -51,6 +51,23 @@ jobs:
           done < <(git rev-list "${base}..${head}")
           exit "$missing"
 
+  npm-launchers:
+    name: npm launcher tests
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@v7
+
+      - uses: actions/setup-node@v6
+        with:
+          node-version: 20
+
+      - name: Test @kinlab/kin (canonical launcher)
+        run: npm test --prefix ./packages/kin && npm run lint --prefix ./packages/kin
+
+      - name: Test @kinlab/kin-mcp (compatibility wrapper)
+        run: npm test --prefix ./packages/kin-mcp && npm run lint --prefix ./packages/kin-mcp
+
   check:
     name: Check & Test
     runs-on: ${{ matrix.os }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -582,6 +582,85 @@ jobs:
           jq -nc --arg c "📦 \`${PKG}@${VER}\` published to **npm**." '{content:$c}' \
             | curl -fsS -H "Content-Type: application/json" -d @- "$DISCORD_WEBHOOK_URL"
 
+  publish_npm_canonical:
+    name: Publish npm Canonical Package (@kinlab/kin)
+    needs: publish
+    # Runs parallel to publish_npm (independent packages: a kin-mcp registry
+    # failure must not block the canonical package, and vice versa). Mirror
+    # publish's always() guard so a skipped notarize_linux does not
+    # transitively skip this job.
+    if: ${{ always() && !failure() && !cancelled() }}
+    runs-on: ubuntu-latest
+    # Trusted Publishing (OIDC), same as publish_npm. Requires a Trusted
+    # Publisher configured on npm for @kinlab/kin pointing at firelock-ai/kin +
+    # this workflow (release.yml). Until that npm-side configuration (or a
+    # one-time manual first publish) exists, this job fails visibly here
+    # without affecting the release or the kin-mcp compatibility publish.
+    permissions:
+      contents: read
+      id-token: write
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7
+
+      - name: Install Node
+        uses: actions/setup-node@v6
+        with:
+          node-version: 20
+          registry-url: https://registry.npmjs.org
+
+      - name: Upgrade npm for OIDC trusted publishing (needs >= 11.5.1)
+        run: npm install -g npm@latest
+
+      - name: Verify npm package version matches tag
+        run: |
+          PACKAGE_VERSION=$(node -p "require('./packages/kin/package.json').version")
+          TAG_VERSION="${GITHUB_REF_NAME#v}"
+          test "$PACKAGE_VERSION" = "$TAG_VERSION"
+
+      - name: Run launcher tests
+        run: npm test --prefix ./packages/kin
+
+      - name: Resolve npm dist-tag
+        id: dist-tag
+        shell: bash
+        run: |
+          ref="${GITHUB_REF_NAME#v}"
+          case "$ref" in
+            *-alpha*) tag="alpha" ;;
+            *-beta*) tag="beta" ;;
+            *-rc*) tag="rc" ;;
+            *) tag="latest" ;;
+          esac
+          echo "tag=$tag" >> "$GITHUB_OUTPUT"
+
+      - name: Publish npm package (Trusted Publishing via OIDC)
+        id: npm_pub_kin
+        run: |
+          PKG=$(node -p "require('./packages/kin/package.json').name")
+          VER=$(node -p "require('./packages/kin/package.json').version")
+          echo "pkg=$PKG" >> "$GITHUB_OUTPUT"
+          echo "ver=$VER" >> "$GITHUB_OUTPUT"
+          if npm view "${PKG}@${VER}" version >/dev/null 2>&1; then
+            echo "${PKG}@${VER} already published — skipping (idempotent recut)."
+            echo "published=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          npm publish ./packages/kin --access public --tag "${NPM_DIST_TAG}"
+          echo "published=true" >> "$GITHUB_OUTPUT"
+        env:
+          NPM_DIST_TAG: ${{ steps.dist-tag.outputs.tag }}
+
+      - name: Notify Discord (npm publish)
+        if: steps.npm_pub_kin.outputs.published == 'true' && env.DISCORD_WEBHOOK_URL != ''
+        env:
+          DISCORD_WEBHOOK_URL: ${{ secrets.DISCORD_WEBHOOK_URL }}
+          PKG: ${{ steps.npm_pub_kin.outputs.pkg }}
+          VER: ${{ steps.npm_pub_kin.outputs.ver }}
+        run: |
+          jq -nc --arg c "📦 \`${PKG}@${VER}\` published to **npm** (canonical Kin install surface)." '{content:$c}' \
+            | curl -fsS -H "Content-Type: application/json" -d @- "$DISCORD_WEBHOOK_URL"
+
   publish_boundary_contracts:
     name: Publish boundary contracts to KinLab
     needs: publish

--- a/README.md
+++ b/README.md
@@ -193,8 +193,9 @@ else to configure. The wizard writes a `kin` server entry running `kin mcp start
 with `KIN_MCP_TOOL_PROFILE=agent-default` (the small curated tool surface).
 
 `kin mcp start` runs as a stdio server that the MCP client launches as a subprocess; you
-normally do not run it by hand. To wire up a client manually, use the npm wrapper
-(`@kinlab/kin-mcp`), or see the exact config and config-file locations, read the
+normally do not run it by hand. To wire up a client manually, use the canonical npm
+package (`npx -y @kinlab/kin mcp start`; `@kinlab/kin-mcp` remains as a compatibility
+wrapper), or see the exact config and config-file locations, read the
 [Advanced configuration](docs/quickstart.md#9-advanced-configuration) section of the
 quickstart. For the full tool surface, see [docs/mcp-tools.md](docs/mcp-tools.md).
 

--- a/packages/kin-mcp/README.md
+++ b/packages/kin-mcp/README.md
@@ -1,5 +1,10 @@
 # @kinlab/kin-mcp
 
+> **Superseded by [`@kinlab/kin`](https://www.npmjs.com/package/@kinlab/kin)** — the
+> canonical Kin install surface, which includes the MCP server (`kin mcp start`) along
+> with the full CLI. This package keeps working for existing configurations; new setups
+> should install `@kinlab/kin`.
+
 `@kinlab/kin-mcp` is the npm-friendly launcher for Kin's MCP server (the installed
 command is still `kin-mcp`).
 

--- a/packages/kin-mcp/package.json
+++ b/packages/kin-mcp/package.json
@@ -14,6 +14,7 @@
   ],
   "scripts": {
     "test": "node --test",
+    "test:unit": "node --test ./test/index.test.js",
     "lint": "node --check ./bin/kin-mcp.js && node --check ./src/index.js && node --check ./test/index.test.js && node --check ./test/smoke-first-run.mjs",
     "smoke": "node ./test/smoke-first-run.mjs"
   },

--- a/packages/kin/README.md
+++ b/packages/kin/README.md
@@ -1,0 +1,50 @@
+# @kinlab/kin
+
+The canonical npm install surface for [Kin](https://github.com/firelock-ai/kin), the
+semantic system of record for software work.
+
+```sh
+npm install -g @kinlab/kin
+kin --version
+```
+
+or zero-install:
+
+```sh
+npx -y @kinlab/kin --version
+```
+
+## What it does
+
+`@kinlab/kin` ships two thin launchers, not a JavaScript reimplementation:
+
+- **`kin`** — provisions the managed native `kin` + `kin-daemon` release for your
+  platform on first run (downloaded from the matching GitHub release, verified against
+  its published SHA-256), installs it under `~/.kin/bin`, then passes every invocation
+  straight through to the real binary and mirrors its exit.
+- **`kin-mcp`** — compatibility entrypoint that starts Kin's MCP server
+  (`kin mcp start`). MCP is one included mode of Kin, not a separate product.
+
+The launcher and the shell installer (`scripts/install.sh`) share the same install
+contract (`$KIN_HOME`, default `~/.kin`): either lane satisfies the other, and neither
+silently downgrades an install the other made.
+
+## Environment
+
+| Variable | Effect |
+| --- | --- |
+| `KIN_HOME` | Root of the managed install (default `~/.kin`). |
+| `KIN_MANAGED_BIN` | Explicit path to a `kin` binary; disables provisioning entirely. |
+| `KIN_NO_PROVISION=1` | Never touch the network; fail loud if no binary is present. |
+| `KIN_LAUNCHER_ADOPT=1` | Allow re-provisioning over a version-skewed non-npm install. |
+
+## MCP setup
+
+Any MCP client can use the included server:
+
+```json
+{ "command": "npx", "args": ["-y", "@kinlab/kin", "mcp", "start"] }
+```
+
+`@kinlab/kin-mcp` remains published for existing configurations; new setups should use
+this package.

--- a/packages/kin/bin/kin-mcp.mjs
+++ b/packages/kin/bin/kin-mcp.mjs
@@ -1,0 +1,48 @@
+#!/usr/bin/env node
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Firelock, LLC
+
+// `kin-mcp` — compatibility launcher for Kin's MCP server.
+//
+// MCP is one included mode of Kin, not a separate product. This bin exists so
+// existing `@kinlab/kin-mcp` users keep a working `kin-mcp` entrypoint; it
+// provisions the managed release like the `kin` launcher and starts
+// `kin mcp start`, forwarding any extra argv. Progress and failures go to
+// stderr only — stdout belongs to the MCP stdio protocol.
+
+import os from 'node:os';
+import { spawnSync } from 'node:child_process';
+
+import { packageVersion, targetKinVersion, notProvisionedMessage } from '../lib/resolve.mjs';
+import { ensureProvisioned } from '../lib/provision.mjs';
+
+const argv = process.argv.slice(2);
+
+if (argv.includes('--version') || argv.includes('-V')) {
+  process.stdout.write(
+    `@kinlab/kin ${packageVersion()} (kin-mcp compatibility launcher; provisions kin ${targetKinVersion()})\n`,
+  );
+  process.exit(0);
+}
+
+let binary = null;
+try {
+  binary = await ensureProvisioned();
+} catch (error) {
+  process.stderr.write(`kin-mcp: provisioning failed: ${error.message}\n`);
+}
+
+if (!binary) {
+  process.stderr.write(`${notProvisionedMessage('kin')}\n`);
+  process.exit(1);
+}
+
+const result = spawnSync(binary, ['mcp', 'start', ...argv], { stdio: 'inherit' });
+if (result.error) {
+  process.stderr.write(`kin-mcp: failed to launch managed binary: ${result.error.message}\n`);
+  process.exit(1);
+}
+if (result.signal) {
+  process.exit(128 + (os.constants.signals[result.signal] ?? 0));
+}
+process.exit(result.status ?? 0);

--- a/packages/kin/bin/kin.mjs
+++ b/packages/kin/bin/kin.mjs
@@ -1,0 +1,57 @@
+#!/usr/bin/env node
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Firelock, LLC
+
+// `kin` — canonical launcher/passthrough for the Kin CLI.
+//
+// Provisions the managed native `kin` (+ `kin-daemon`) release on first run,
+// then forwards argv straight to it and mirrors its exit. `--version` therefore
+// proves provisioning end-to-end: it answers with the real binary's version.
+// When provisioning is unavailable (offline, disabled), it fails loud with an
+// actionable message — it never pretends to run.
+
+import os from 'node:os';
+import { spawnSync } from 'node:child_process';
+
+import { packageVersion, targetKinVersion, notProvisionedMessage } from '../lib/resolve.mjs';
+import { ensureProvisioned } from '../lib/provision.mjs';
+
+const argv = process.argv.slice(2);
+const wantsVersion = argv.includes('--version') || argv.includes('-V');
+
+function launcherVersionLine(note) {
+  return `@kinlab/kin ${packageVersion()} (launcher; provisions kin ${targetKinVersion()}${note})\n`;
+}
+
+let binary = null;
+let provisionError = null;
+try {
+  binary = await ensureProvisioned();
+} catch (error) {
+  provisionError = error;
+}
+
+if (!binary) {
+  if (provisionError) {
+    process.stderr.write(`kin: provisioning failed: ${provisionError.message}\n`);
+  }
+  if (wantsVersion) {
+    // Honest launcher identity; success only when provisioning was explicitly
+    // disabled rather than broken.
+    process.stdout.write(launcherVersionLine(provisionError ? ', provisioning failed' : ', not installed'));
+    process.exit(provisionError ? 1 : 0);
+  }
+  process.stderr.write(`${notProvisionedMessage('kin')}\n`);
+  process.exit(1);
+}
+
+const result = spawnSync(binary, argv, { stdio: 'inherit' });
+if (result.error) {
+  process.stderr.write(`kin: failed to launch managed binary: ${result.error.message}\n`);
+  process.exit(1);
+}
+if (result.signal) {
+  // Mirror signal deaths honestly instead of reporting success.
+  process.exit(128 + (os.constants.signals[result.signal] ?? 0));
+}
+process.exit(result.status ?? 0);

--- a/packages/kin/lib/provision.mjs
+++ b/packages/kin/lib/provision.mjs
@@ -1,0 +1,257 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Firelock, LLC
+
+// Binary provisioning for the @kinlab/kin launcher.
+//
+// Downloads the platform archive of the pinned Kin release from GitHub
+// Releases, verifies it against the per-artifact SHA-256 published next to it,
+// and installs the binaries into <kinHome>/bin — the same directory and the
+// same refusal semantics as scripts/install.sh, so the two install lanes are
+// interchangeable. kin-daemon is mandatory (status/search/MCP require it): a
+// daemon-less archive aborts before anything is moved rather than leaving a
+// half-installed environment. Network, spawning, and the environment are all
+// injectable so every decision here is unit testable offline.
+
+import crypto from 'node:crypto';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { spawnSync } from 'node:child_process';
+
+import {
+  binaryName,
+  kinHome,
+  managedBinaryPath,
+  readLauncherStamp,
+  resolveManagedBinary,
+  targetKinVersion,
+  writeLauncherStamp,
+} from './resolve.mjs';
+
+/**
+ * Release-artifact file name for a host. Follows the release workflow's
+ * naming (kin-{macos|linux|windows}-{x86_64|aarch64}); Windows ships as .zip.
+ * There is no native windows-aarch64 artifact — fail honestly rather than
+ * fabricate a URL (Windows-on-ARM can run the x64 build under emulation).
+ */
+export function artifactName(platform = process.platform, arch = process.arch) {
+  const artifacts = {
+    'darwin:arm64': 'kin-macos-aarch64.tar.gz',
+    'darwin:x64': 'kin-macos-x86_64.tar.gz',
+    'linux:arm64': 'kin-linux-aarch64.tar.gz',
+    'linux:x64': 'kin-linux-x86_64.tar.gz',
+    'win32:x64': 'kin-windows-x86_64.zip',
+  };
+  const key = `${platform}:${arch}`;
+  const file = artifacts[key];
+  if (!file) {
+    const supported = Object.keys(artifacts).join(', ');
+    throw new Error(
+      key === 'win32:arm64'
+        ? 'no native windows-aarch64 Kin release artifact exists; use an x64 Node ' +
+          'under emulation (the x86_64 build runs on Windows-on-ARM), or build from source.'
+        : `no Kin release artifact for "${key}"; supported: ${supported}`,
+    );
+  }
+  return file;
+}
+
+/** Download URL of a file attached to the v<version> GitHub release. */
+export function releaseDownloadUrl(version, file) {
+  return `https://github.com/firelock-ai/kin/releases/download/v${version}/${file}`;
+}
+
+/**
+ * Extract the hex digest from a `shasum -a 256` style checksum file
+ * ("<hex>  <name>"). Refuses anything that does not look like SHA-256.
+ */
+export function parseSha256File(text) {
+  const token = String(text).trim().split(/\s+/)[0] ?? '';
+  if (!/^[0-9a-f]{64}$/i.test(token)) {
+    throw new Error(`malformed .sha256 file (expected a 64-hex digest, got "${token.slice(0, 80)}")`);
+  }
+  return token.toLowerCase();
+}
+
+/** SHA-256 hex digest of a buffer. */
+export function sha256Hex(buf) {
+  return crypto.createHash('sha256').update(buf).digest('hex');
+}
+
+async function fetchBuffer(url, fetchImpl) {
+  const res = await fetchImpl(url);
+  if (!res.ok) {
+    throw new Error(`download failed (${res.status}) for ${url}`);
+  }
+  return Buffer.from(await res.arrayBuffer());
+}
+
+/**
+ * Locate the extraction root: release archives contain a kin-* subdirectory;
+ * tolerate a flat archive the way install.sh does.
+ */
+function extractionRoot(tmp) {
+  const sub = fs
+    .readdirSync(tmp, { withFileTypes: true })
+    .find((e) => e.isDirectory() && e.name.startsWith('kin-'));
+  return sub ? path.join(tmp, sub.name) : tmp;
+}
+
+/** Replace-then-move a binary into place (never overwrite in place: replacing
+ * a running executable's inode causes launch deadlocks on macOS). */
+function installFile(src, dest, mode) {
+  fs.rmSync(dest, { force: true });
+  fs.copyFileSync(src, dest);
+  fs.chmodSync(dest, mode);
+}
+
+/**
+ * Download, verify, and install the pinned Kin release. Returns the installed
+ * managed `kin` path. Mirrors scripts/install.sh: kin + kin-daemon are
+ * mandatory, kin-vfs and the projection shim library are optional extras.
+ */
+export async function provision(version, opts = {}) {
+  const {
+    env = process.env,
+    platform = process.platform,
+    arch = process.arch,
+    fetchImpl = fetch,
+    log = (line) => process.stderr.write(`${line}\n`),
+  } = opts;
+
+  const file = artifactName(platform, arch);
+  const url = releaseDownloadUrl(version, file);
+  log(`kin: provisioning managed kin ${version} (${file})...`);
+
+  const [archive, shaText] = await Promise.all([
+    fetchBuffer(url, fetchImpl),
+    fetchBuffer(`${url}.sha256`, fetchImpl),
+  ]);
+  const expected = parseSha256File(shaText.toString('utf8'));
+  const actual = sha256Hex(archive);
+  if (actual !== expected) {
+    throw new Error(
+      `SHA-256 mismatch for ${file}: expected ${expected}, got ${actual}. ` +
+        'The download may be corrupted or tampered with; refusing to install.',
+    );
+  }
+
+  const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'kinlab-kin-'));
+  try {
+    const archivePath = path.join(tmp, file);
+    fs.writeFileSync(archivePath, archive);
+    // bsdtar reads both .tar.gz and .zip with -xf, on macOS, Linux, and
+    // Windows 10+ (tar.exe ships in System32).
+    const tar = spawnSync('tar', ['-xf', archivePath, '-C', tmp], { encoding: 'utf8' });
+    if (tar.status !== 0) {
+      throw new Error(`archive extraction failed: ${tar.stderr || tar.error?.message || 'tar exited non-zero'}`);
+    }
+
+    const root = extractionRoot(tmp);
+    const kinSrc = path.join(root, binaryName('kin', platform));
+    const daemonSrc = path.join(root, binaryName('kin-daemon', platform));
+    if (!fs.existsSync(kinSrc) || !fs.existsSync(daemonSrc)) {
+      throw new Error(
+        'kin-daemon (or kin) missing from the downloaded archive. kin status/search and ' +
+          'the MCP server require the daemon; refusing a daemon-less install.',
+      );
+    }
+
+    const binDir = path.join(kinHome(env), 'bin');
+    const libDir = path.join(kinHome(env), 'lib');
+    fs.mkdirSync(binDir, { recursive: true });
+
+    installFile(kinSrc, path.join(binDir, binaryName('kin', platform)), 0o755);
+    installFile(daemonSrc, path.join(binDir, binaryName('kin-daemon', platform)), 0o755);
+
+    const vfsSrc = path.join(root, binaryName('kin-vfs', platform));
+    if (fs.existsSync(vfsSrc)) {
+      installFile(vfsSrc, path.join(binDir, binaryName('kin-vfs', platform)), 0o755);
+    }
+    for (const lib of ['libkin_vfs_shim.so', 'libkin_vfs_shim.dylib']) {
+      const libSrc = path.join(root, lib);
+      if (fs.existsSync(libSrc)) {
+        fs.mkdirSync(libDir, { recursive: true });
+        installFile(libSrc, path.join(libDir, lib), 0o644);
+      }
+    }
+
+    writeLauncherStamp(version, env);
+    log(`kin: managed kin ${version} installed at ${binDir}`);
+    return path.join(binDir, binaryName('kin', platform));
+  } finally {
+    fs.rmSync(tmp, { recursive: true, force: true });
+  }
+}
+
+/** First line of `<binary> --version`, or null if it cannot be run. */
+export function probeBinaryVersion(binary, spawnImpl = spawnSync) {
+  const res = spawnImpl(binary, ['--version'], { encoding: 'utf8' });
+  if (res.error || res.status !== 0) return null;
+  const m = String(res.stdout).match(/^kin\s+(\S+)/);
+  return m ? m[1] : null;
+}
+
+/**
+ * Ensure the managed `kin` binary matching this launcher's pinned release is
+ * present, provisioning (or re-provisioning) when needed. Returns the binary
+ * path, or null when nothing usable exists and provisioning is unavailable.
+ *
+ * Policy, in order:
+ *   - $KIN_MANAGED_BIN is an explicit user pin: use it as-is, never provision.
+ *   - $KIN_NO_PROVISION=1: resolve-only, no network.
+ *   - launcher stamp == target and the binary exists: run it (no probe cost).
+ *   - stamp differs or binary missing: provision the pinned release.
+ *   - no stamp but a binary exists (foreign install, e.g. install.sh): probe
+ *     its version; adopt on match. On mismatch respect the foreign install —
+ *     run it with a one-line notice — unless $KIN_LAUNCHER_ADOPT=1 opts into
+ *     re-provisioning. Never silently downgrade someone else's install.
+ */
+export async function ensureProvisioned(opts = {}) {
+  const {
+    env = process.env,
+    platform = process.platform,
+    arch = process.arch,
+    fetchImpl = fetch,
+    log = (line) => process.stderr.write(`${line}\n`),
+    spawnImpl = spawnSync,
+  } = opts;
+
+  const target = targetKinVersion();
+
+  if (env.KIN_MANAGED_BIN && env.KIN_MANAGED_BIN.trim()) {
+    return resolveManagedBinary('kin', env, platform);
+  }
+  const existing = resolveManagedBinary('kin', env, platform);
+  if (env.KIN_NO_PROVISION === '1') {
+    return existing;
+  }
+
+  const doProvision = () => provision(target, { env, platform, arch, fetchImpl, log });
+
+  if (!existing) {
+    return doProvision();
+  }
+
+  const stamp = readLauncherStamp(env);
+  if (stamp === target) {
+    return existing;
+  }
+  if (stamp !== null) {
+    return doProvision();
+  }
+
+  const probed = probeBinaryVersion(existing, spawnImpl);
+  if (probed === target) {
+    writeLauncherStamp(target, env);
+    return existing;
+  }
+  if (env.KIN_LAUNCHER_ADOPT === '1') {
+    return doProvision();
+  }
+  log(
+    `kin: using existing managed kin ${probed ?? 'unknown'} at ${managedBinaryPath('kin', env, platform)} ` +
+      `(this @kinlab/kin pins ${target}; set KIN_LAUNCHER_ADOPT=1 to re-provision).`,
+  );
+  return existing;
+}

--- a/packages/kin/lib/resolve.mjs
+++ b/packages/kin/lib/resolve.mjs
@@ -1,0 +1,138 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Firelock, LLC
+
+// Managed-binary resolution for the @kinlab/kin launcher.
+//
+// This package is the canonical install surface for Kin: `npm i -g @kinlab/kin`
+// gives you the `kin` and `kin-mcp` bins. The bins are thin launchers over a
+// *managed* native binary (the real `kin` + `kin-daemon` release). This module
+// owns the pure, side-effect-free part of that story — computing the platform
+// target, where the managed binary is expected to live, and which release the
+// launcher pins — so it is unit testable without spawning or touching the
+// network. Downloading and installing live in ./provision.mjs.
+
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const HERE = path.dirname(fileURLToPath(import.meta.url));
+
+/** This package's own version, read from its package.json (single source). */
+export function packageVersion() {
+  const manifest = JSON.parse(fs.readFileSync(path.join(HERE, '..', 'package.json'), 'utf8'));
+  return manifest.version;
+}
+
+/**
+ * The Kin release this launcher provisions. It tracks the package version: the
+ * canonical package is versioned in lockstep with the `kin` + `kin-daemon`
+ * release it installs (the release workflow asserts package version == tag).
+ */
+export function targetKinVersion() {
+  return packageVersion();
+}
+
+/**
+ * Map a Node platform+arch pair to the Rust target triple of the managed
+ * binary. Pure and injectable so it is testable for every supported host.
+ */
+export function platformTarget(platform = process.platform, arch = process.arch) {
+  const targets = {
+    'darwin:arm64': 'aarch64-apple-darwin',
+    'darwin:x64': 'x86_64-apple-darwin',
+    'linux:arm64': 'aarch64-unknown-linux-gnu',
+    'linux:x64': 'x86_64-unknown-linux-gnu',
+    'win32:x64': 'x86_64-pc-windows-msvc',
+    'win32:arm64': 'aarch64-pc-windows-msvc',
+  };
+  const key = `${platform}:${arch}`;
+  const triple = targets[key];
+  if (!triple) {
+    throw new Error(
+      `unsupported platform "${key}" for @kinlab/kin; supported: ${Object.keys(targets).join(', ')}`,
+    );
+  }
+  return triple;
+}
+
+/** Executable file name for a bin on the host platform (adds .exe on Windows). */
+export function binaryName(name, platform = process.platform) {
+  return platform === 'win32' ? `${name}.exe` : name;
+}
+
+/** Root of Kin's managed install, honoring $KIN_HOME (default ~/.kin). */
+export function kinHome(env = process.env, home = os.homedir()) {
+  return env.KIN_HOME && env.KIN_HOME.trim() ? env.KIN_HOME : path.join(home, '.kin');
+}
+
+/**
+ * Absolute path where the managed `name` binary is expected. An explicit
+ * $KIN_MANAGED_BIN overrides the whole computation (an explicit user pin;
+ * provisioning never writes through it); otherwise it is
+ * <kinHome>/bin/<name>[.exe] — the same directory the shell installer
+ * (scripts/install.sh) populates, so either lane satisfies the other.
+ */
+export function managedBinaryPath(name = 'kin', env = process.env, platform = process.platform) {
+  if (env.KIN_MANAGED_BIN && env.KIN_MANAGED_BIN.trim()) {
+    return env.KIN_MANAGED_BIN;
+  }
+  return path.join(kinHome(env), 'bin', binaryName(name, platform));
+}
+
+/**
+ * Resolve the managed `name` binary to an absolute path if it exists on disk,
+ * else null. Never fabricates a path that is not really present.
+ */
+export function resolveManagedBinary(name = 'kin', env = process.env, platform = process.platform) {
+  const candidate = managedBinaryPath(name, env, platform);
+  try {
+    return fs.existsSync(candidate) ? candidate : null;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Path of the launcher's version stamp: which Kin release this launcher last
+ * provisioned into <kinHome>/bin. Lets the normal launch path skip a
+ * `kin --version` probe; a binary installed by other means (install.sh) has no
+ * stamp and is probed instead of being silently trusted or clobbered.
+ */
+export function launcherStampPath(env = process.env) {
+  return path.join(kinHome(env), 'bin', '.kinlab-kin-version');
+}
+
+/** The stamped provisioned version, or null when absent/unreadable. */
+export function readLauncherStamp(env = process.env) {
+  try {
+    const text = fs.readFileSync(launcherStampPath(env), 'utf8').trim();
+    return text.length ? text : null;
+  } catch {
+    return null;
+  }
+}
+
+/** Record `version` as the provisioned release (directory must exist). */
+export function writeLauncherStamp(version, env = process.env) {
+  fs.writeFileSync(launcherStampPath(env), `${version}\n`);
+}
+
+/** Human-readable, honest explanation for when the managed binary is absent. */
+export function notProvisionedMessage(name = 'kin', env = process.env, platform = process.platform) {
+  const expected = managedBinaryPath(name, env, platform);
+  const triple = (() => {
+    try {
+      return platformTarget();
+    } catch {
+      return 'unknown-target';
+    }
+  })();
+  return [
+    `kin: managed "${name}" binary not found (expected at ${expected}).`,
+    `Host target: ${triple}. @kinlab/kin ${packageVersion()} provisions the managed Kin`,
+    'release on first run; if you are seeing this, provisioning failed or was disabled',
+    '(KIN_NO_PROVISION=1). Re-run with network access, set KIN_MANAGED_BIN to an existing',
+    'kin binary, or install via https://github.com/firelock-ai/kin (scripts/install.sh).',
+  ].join('\n');
+}

--- a/packages/kin/package.json
+++ b/packages/kin/package.json
@@ -1,0 +1,43 @@
+{
+  "name": "@kinlab/kin",
+  "version": "0.2.9",
+  "description": "Canonical installer and launcher for Kin — provisions and runs the managed kin + kin-daemon release. MCP is one included mode (kin mcp start).",
+  "license": "Apache-2.0",
+  "type": "module",
+  "bin": {
+    "kin": "bin/kin.mjs",
+    "kin-mcp": "bin/kin-mcp.mjs"
+  },
+  "files": [
+    "bin/",
+    "lib/",
+    "README.md"
+  ],
+  "engines": {
+    "node": ">=20"
+  },
+  "publishConfig": {
+    "access": "public"
+  },
+  "homepage": "https://github.com/firelock-ai/kin",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/firelock-ai/kin.git",
+    "directory": "packages/kin"
+  },
+  "bugs": {
+    "url": "https://github.com/firelock-ai/kin/issues"
+  },
+  "keywords": [
+    "kin",
+    "kinlab",
+    "cli",
+    "mcp",
+    "semantic"
+  ],
+  "scripts": {
+    "test": "node --test",
+    "lint": "node --check ./bin/kin.mjs && node --check ./bin/kin-mcp.mjs && node --check ./lib/resolve.mjs && node --check ./lib/provision.mjs",
+    "smoke": "node bin/kin.mjs --version"
+  }
+}

--- a/packages/kin/test/provision.test.mjs
+++ b/packages/kin/test/provision.test.mjs
@@ -1,0 +1,214 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Firelock, LLC
+
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { spawnSync } from 'node:child_process';
+import { test } from 'node:test';
+
+import {
+  artifactName,
+  releaseDownloadUrl,
+  parseSha256File,
+  sha256Hex,
+  provision,
+  probeBinaryVersion,
+  ensureProvisioned,
+} from '../lib/provision.mjs';
+import { readLauncherStamp, writeLauncherStamp } from '../lib/resolve.mjs';
+
+test('artifactName maps every released host and matches release.yml naming', () => {
+  assert.equal(artifactName('darwin', 'arm64'), 'kin-macos-aarch64.tar.gz');
+  assert.equal(artifactName('darwin', 'x64'), 'kin-macos-x86_64.tar.gz');
+  assert.equal(artifactName('linux', 'arm64'), 'kin-linux-aarch64.tar.gz');
+  assert.equal(artifactName('linux', 'x64'), 'kin-linux-x86_64.tar.gz');
+  assert.equal(artifactName('win32', 'x64'), 'kin-windows-x86_64.zip');
+});
+
+test('artifactName is honest about windows-aarch64 having no artifact', () => {
+  assert.throws(() => artifactName('win32', 'arm64'), /no native windows-aarch64/);
+});
+
+test('releaseDownloadUrl pins the tag and file', () => {
+  assert.equal(
+    releaseDownloadUrl('1.2.3', 'kin-macos-aarch64.tar.gz'),
+    'https://github.com/firelock-ai/kin/releases/download/v1.2.3/kin-macos-aarch64.tar.gz',
+  );
+});
+
+test('parseSha256File accepts shasum output and rejects junk', () => {
+  const hex = 'a'.repeat(64);
+  assert.equal(parseSha256File(`${hex}  kin-macos-aarch64.tar.gz\n`), hex);
+  assert.equal(parseSha256File(`${hex.toUpperCase()}  x`), hex);
+  assert.throws(() => parseSha256File('not-a-digest  file'), /malformed \.sha256/);
+  assert.throws(() => parseSha256File(''), /malformed \.sha256/);
+});
+
+// ── offline provision fixture ──────────────────────────────────────────────
+//
+// Builds a real tar.gz in a tempdir (via the same `tar` the provisioner uses)
+// containing the archive layout install.sh documents: a kin-* subdirectory
+// with kin + kin-daemon. The fake fetch serves those bytes; no network.
+
+function makeFixture({ withDaemon = true } = {}) {
+  const work = fs.mkdtempSync(path.join(os.tmpdir(), 'kin-prov-fixture-'));
+  const stage = path.join(work, 'kin-macos-aarch64');
+  fs.mkdirSync(stage, { recursive: true });
+  fs.writeFileSync(path.join(stage, 'kin'), '#!/bin/sh\necho "kin 9.9.9 (test)"\n');
+  if (withDaemon) {
+    fs.writeFileSync(path.join(stage, 'kin-daemon'), '#!/bin/sh\necho daemon\n');
+  }
+  const archivePath = path.join(work, 'kin-macos-aarch64.tar.gz');
+  const tar = spawnSync('tar', ['-czf', archivePath, '-C', work, 'kin-macos-aarch64'], {
+    encoding: 'utf8',
+  });
+  assert.equal(tar.status, 0, tar.stderr);
+  const bytes = fs.readFileSync(archivePath);
+  const sha = `${sha256Hex(bytes)}  kin-macos-aarch64.tar.gz\n`;
+  const fetchImpl = async (url) => {
+    const body = url.endsWith('.sha256') ? Buffer.from(sha) : bytes;
+    return {
+      ok: true,
+      status: 200,
+      arrayBuffer: async () => body.buffer.slice(body.byteOffset, body.byteOffset + body.byteLength),
+    };
+  };
+  return { work, bytes, sha, fetchImpl };
+}
+
+test('provision verifies, installs kin + kin-daemon, and stamps the version', async () => {
+  const { work, fetchImpl } = makeFixture();
+  const home = path.join(work, 'kin-home');
+  const env = { KIN_HOME: home };
+  const installed = await provision('9.9.9', {
+    env,
+    platform: 'darwin',
+    arch: 'arm64',
+    fetchImpl,
+    log: () => {},
+  });
+  assert.equal(installed, path.join(home, 'bin', 'kin'));
+  assert.ok(fs.existsSync(path.join(home, 'bin', 'kin')));
+  assert.ok(fs.existsSync(path.join(home, 'bin', 'kin-daemon')));
+  assert.equal(fs.statSync(installed).mode & 0o111 && true, true);
+  assert.equal(readLauncherStamp(env), '9.9.9');
+  fs.rmSync(work, { recursive: true, force: true });
+});
+
+test('provision refuses a checksum mismatch without installing', async () => {
+  const { work, bytes } = makeFixture();
+  const home = path.join(work, 'kin-home');
+  const badSha = `${'0'.repeat(64)}  kin-macos-aarch64.tar.gz\n`;
+  const fetchImpl = async (url) => {
+    const body = url.endsWith('.sha256') ? Buffer.from(badSha) : bytes;
+    return {
+      ok: true,
+      status: 200,
+      arrayBuffer: async () => body.buffer.slice(body.byteOffset, body.byteOffset + body.byteLength),
+    };
+  };
+  await assert.rejects(
+    provision('9.9.9', { env: { KIN_HOME: home }, platform: 'darwin', arch: 'arm64', fetchImpl, log: () => {} }),
+    /SHA-256 mismatch/,
+  );
+  assert.ok(!fs.existsSync(path.join(home, 'bin', 'kin')));
+  fs.rmSync(work, { recursive: true, force: true });
+});
+
+test('provision refuses a daemon-less archive before moving anything', async () => {
+  const { work, fetchImpl } = makeFixture({ withDaemon: false });
+  const home = path.join(work, 'kin-home');
+  await assert.rejects(
+    provision('9.9.9', { env: { KIN_HOME: home }, platform: 'darwin', arch: 'arm64', fetchImpl, log: () => {} }),
+    /daemon-less/,
+  );
+  assert.ok(!fs.existsSync(path.join(home, 'bin', 'kin')));
+  fs.rmSync(work, { recursive: true, force: true });
+});
+
+test('provision surfaces a failed download loudly', async () => {
+  const fetchImpl = async () => ({ ok: false, status: 404, arrayBuffer: async () => new ArrayBuffer(0) });
+  await assert.rejects(
+    provision('9.9.9', { env: { KIN_HOME: '/nonexistent-home' }, platform: 'darwin', arch: 'arm64', fetchImpl, log: () => {} }),
+    /download failed \(404\)/,
+  );
+});
+
+test('probeBinaryVersion parses the kin version line and null on failure', () => {
+  const okSpawn = () => ({ status: 0, stdout: 'kin 1.2.3 (abc detached)\n' });
+  const badSpawn = () => ({ status: 1, stdout: '', stderr: 'boom' });
+  assert.equal(probeBinaryVersion('/any', okSpawn), '1.2.3');
+  assert.equal(probeBinaryVersion('/any', badSpawn), null);
+});
+
+test('ensureProvisioned respects KIN_MANAGED_BIN and never provisions over it', async () => {
+  const real = process.execPath;
+  const result = await ensureProvisioned({
+    env: { KIN_MANAGED_BIN: real },
+    fetchImpl: async () => {
+      throw new Error('network must not be touched');
+    },
+    log: () => {},
+  });
+  assert.equal(result, real);
+});
+
+test('ensureProvisioned is resolve-only under KIN_NO_PROVISION', async () => {
+  const home = fs.mkdtempSync(path.join(os.tmpdir(), 'kin-noprov-'));
+  const result = await ensureProvisioned({
+    env: { KIN_HOME: home, KIN_NO_PROVISION: '1' },
+    fetchImpl: async () => {
+      throw new Error('network must not be touched');
+    },
+    log: () => {},
+  });
+  assert.equal(result, null);
+  fs.rmSync(home, { recursive: true, force: true });
+});
+
+test('ensureProvisioned runs a stamped current install without probing or network', async () => {
+  const home = fs.mkdtempSync(path.join(os.tmpdir(), 'kin-stamped-'));
+  const env = { KIN_HOME: home };
+  const binDir = path.join(home, 'bin');
+  fs.mkdirSync(binDir, { recursive: true });
+  const { targetKinVersion } = await import('../lib/resolve.mjs');
+  fs.writeFileSync(path.join(binDir, 'kin'), '#!/bin/sh\n');
+  writeLauncherStamp(targetKinVersion(), env);
+  const result = await ensureProvisioned({
+    env,
+    platform: process.platform,
+    fetchImpl: async () => {
+      throw new Error('network must not be touched');
+    },
+    spawnImpl: () => {
+      throw new Error('probe must not run');
+    },
+    log: () => {},
+  });
+  assert.equal(result, path.join(binDir, 'kin'));
+  fs.rmSync(home, { recursive: true, force: true });
+});
+
+test('ensureProvisioned respects a foreign install on version mismatch (no adopt)', async () => {
+  const home = fs.mkdtempSync(path.join(os.tmpdir(), 'kin-foreign-'));
+  const env = { KIN_HOME: home };
+  const binDir = path.join(home, 'bin');
+  fs.mkdirSync(binDir, { recursive: true });
+  fs.writeFileSync(path.join(binDir, 'kin'), '#!/bin/sh\n');
+  const notices = [];
+  const result = await ensureProvisioned({
+    env,
+    platform: process.platform,
+    fetchImpl: async () => {
+      throw new Error('must not re-provision a foreign install without opt-in');
+    },
+    spawnImpl: () => ({ status: 0, stdout: 'kin 0.0.1-foreign (x)\n' }),
+    log: (line) => notices.push(line),
+  });
+  assert.equal(result, path.join(binDir, 'kin'));
+  assert.equal(readLauncherStamp(env), null);
+  assert.ok(notices.some((l) => l.includes('KIN_LAUNCHER_ADOPT=1')));
+  fs.rmSync(home, { recursive: true, force: true });
+});

--- a/packages/kin/test/resolve.test.mjs
+++ b/packages/kin/test/resolve.test.mjs
@@ -1,0 +1,94 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Firelock, LLC
+
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { test } from 'node:test';
+
+import {
+  packageVersion,
+  targetKinVersion,
+  platformTarget,
+  binaryName,
+  kinHome,
+  managedBinaryPath,
+  resolveManagedBinary,
+  launcherStampPath,
+  readLauncherStamp,
+  writeLauncherStamp,
+  notProvisionedMessage,
+} from '../lib/resolve.mjs';
+
+test('packageVersion reads a semver from the manifest', () => {
+  assert.match(packageVersion(), /^\d+\.\d+\.\d+/);
+});
+
+test('targetKinVersion tracks the package version', () => {
+  assert.equal(targetKinVersion(), packageVersion());
+});
+
+test('platformTarget maps every supported host to a Rust triple', () => {
+  assert.equal(platformTarget('darwin', 'arm64'), 'aarch64-apple-darwin');
+  assert.equal(platformTarget('darwin', 'x64'), 'x86_64-apple-darwin');
+  assert.equal(platformTarget('linux', 'arm64'), 'aarch64-unknown-linux-gnu');
+  assert.equal(platformTarget('linux', 'x64'), 'x86_64-unknown-linux-gnu');
+  assert.equal(platformTarget('win32', 'x64'), 'x86_64-pc-windows-msvc');
+});
+
+test('platformTarget throws loudly on an unsupported host', () => {
+  assert.throws(() => platformTarget('sunos', 'sparc'), /unsupported platform/);
+});
+
+test('binaryName adds .exe only on Windows', () => {
+  assert.equal(binaryName('kin', 'linux'), 'kin');
+  assert.equal(binaryName('kin', 'darwin'), 'kin');
+  assert.equal(binaryName('kin', 'win32'), 'kin.exe');
+});
+
+test('kinHome honors $KIN_HOME then falls back to ~/.kin', () => {
+  assert.equal(kinHome({ KIN_HOME: '/custom/kin' }, '/home/u'), '/custom/kin');
+  assert.equal(kinHome({}, '/home/u'), path.join('/home/u', '.kin'));
+  assert.equal(kinHome({ KIN_HOME: '   ' }, '/home/u'), path.join('/home/u', '.kin'));
+});
+
+test('managedBinaryPath defaults under kinHome and is overridable', () => {
+  const def = managedBinaryPath('kin', { HOME: '/home/u' }, 'linux');
+  assert.ok(def.endsWith(path.join('.kin', 'bin', 'kin')));
+  assert.equal(
+    managedBinaryPath('kin', { KIN_MANAGED_BIN: '/opt/kin/bin/kin' }, 'linux'),
+    '/opt/kin/bin/kin',
+  );
+});
+
+test('resolveManagedBinary returns null when nothing is installed', () => {
+  assert.equal(
+    resolveManagedBinary('kin', { KIN_MANAGED_BIN: '/nonexistent/kin-binary-xyz' }, 'linux'),
+    null,
+  );
+});
+
+test('resolveManagedBinary returns the path when the binary exists', () => {
+  // Any real file proves existence-resolution without shipping a fake binary.
+  const real = process.execPath;
+  assert.equal(resolveManagedBinary('kin', { KIN_MANAGED_BIN: real }, process.platform), real);
+});
+
+test('launcher stamp round-trips under kinHome and reads null when absent', () => {
+  const home = fs.mkdtempSync(path.join(os.tmpdir(), 'kin-stamp-'));
+  const env = { KIN_HOME: home };
+  assert.equal(readLauncherStamp(env), null);
+  fs.mkdirSync(path.join(home, 'bin'), { recursive: true });
+  writeLauncherStamp('9.9.9', env);
+  assert.equal(readLauncherStamp(env), '9.9.9');
+  assert.ok(launcherStampPath(env).startsWith(home));
+  fs.rmSync(home, { recursive: true, force: true });
+});
+
+test('notProvisionedMessage names the expected path and stays honest', () => {
+  const msg = notProvisionedMessage('kin', { KIN_MANAGED_BIN: '/opt/kin/bin/kin' }, 'linux');
+  assert.match(msg, /managed "kin" binary not found/);
+  assert.match(msg, /\/opt\/kin\/bin\/kin/);
+  assert.match(msg, /provisioning failed or was disabled/);
+});

--- a/scripts/release-intent.mjs
+++ b/scripts/release-intent.mjs
@@ -10,9 +10,10 @@ const run = promisify(execFile);
 // the workspace version and asserts every surface that a tag-driven release
 // depends on is already in sync, BEFORE a tag is cut:
 //
-//   - the npm wrapper (packages/kin-mcp/package.json) version equals the
-//     workspace version — release.yml's publish_npm job hard-asserts this, so a
-//     mismatch would otherwise only surface AFTER the tag is already pushed;
+//   - every npm package version (packages/kin-mcp and the canonical
+//     packages/kin) equals the workspace version — release.yml's npm publish
+//     jobs hard-assert this, so a mismatch would otherwise only surface AFTER
+//     the tag is already pushed;
 //   - a CHANGELOG section exists for the version (required for a stable
 //     release; a warning for a prerelease, which falls back to auto-notes);
 //   - the version moves strictly forward of the newest existing vX.Y.Z tag.
@@ -46,7 +47,10 @@ function parseArgs(argv) {
   }
   return {
     manifest: args.get('manifest') ?? 'Cargo.toml',
-    npm: args.get('npm') ?? 'packages/kin-mcp/package.json',
+    npm: (args.get('npm') ?? 'packages/kin-mcp/package.json,packages/kin/package.json')
+      .split(',')
+      .map((p) => p.trim())
+      .filter(Boolean),
     changelog: args.get('changelog') ?? 'CHANGELOG.md',
     json: args.get('json') === 'true',
   };
@@ -155,17 +159,22 @@ async function main() {
   const failures = [];
   const warnings = [];
 
-  // 1. npm wrapper version must equal the workspace version.
-  const npmText = await readFileOrNull(opts.npm);
-  let npmVersion = null;
-  if (npmText === null) {
-    failures.push(`npm wrapper manifest not found: ${opts.npm}`);
-  } else {
-    npmVersion = JSON.parse(npmText).version;
-    if (npmVersion !== version) {
-      failures.push(`npm wrapper ${opts.npm} is ${npmVersion}, workspace is ${version} — they must match (publish_npm asserts it)`);
+  // 1. Every npm package version must equal the workspace version.
+  const npmVersions = [];
+  for (const manifest of opts.npm) {
+    const npmText = await readFileOrNull(manifest);
+    if (npmText === null) {
+      failures.push(`npm manifest not found: ${manifest}`);
+      npmVersions.push({ manifest, version: null });
+      continue;
+    }
+    const v = JSON.parse(npmText).version;
+    npmVersions.push({ manifest, version: v });
+    if (v !== version) {
+      failures.push(`npm manifest ${manifest} is ${v}, workspace is ${version} — they must match (the npm publish jobs assert it)`);
     }
   }
+  const npmVersion = npmVersions.map((n) => `${n.manifest.split('/').slice(-2, -1)[0] ?? n.manifest}@${n.version ?? '<missing>'}`).join(', ');
 
   // 2. CHANGELOG section: required for a stable release, advisory for prereleases.
   const changelogText = await readFileOrNull(opts.changelog);
@@ -206,7 +215,7 @@ async function main() {
   } else {
     console.log('Kin release-intent gate');
     console.log(`  workspace version : ${version}`);
-    console.log(`  npm wrapper       : ${npmVersion ?? '<missing>'}`);
+    console.log(`  npm packages      : ${npmVersion || '<missing>'}`);
     console.log(`  changelog section : ${hasChangelog ? 'present' : 'absent'}`);
     console.log(`  newest tag        : ${newest ?? '<none>'}`);
     console.log(`  tag ${tag}${' '.repeat(Math.max(0, 13 - tag.length))}: ${tagExists ? 'exists' : 'absent'}`);


### PR DESCRIPTION
## What

Adds the canonical `@kinlab/kin` npm package (`packages/kin`) and wires it into the release chain. The package ships two thin launchers over the managed native release — `kin` (full CLI passthrough) and `kin-mcp` (compatibility entrypoint for `kin mcp start`) — plus the provisioning module the launcher contract deferred to the release lane: download the platform archive of the pinned release, verify the published per-artifact SHA-256, install `kin` + `kin-daemon` under `$KIN_HOME/bin`.

The install contract is shared with `scripts/install.sh`: same directory layout, same refusal semantics (a daemon-less archive aborts before anything moves). A version-skewed install made by other means is respected with a one-line notice, never silently downgraded (`KIN_LAUNCHER_ADOPT=1` opts into re-provisioning). Signal deaths of the child are mirrored as `128+signo` instead of reading as success.

## Release wiring

- `release.yml`: new `publish_npm_canonical` job, parallel to `publish_npm` — independent packages, so a registry failure on one never blocks the other. OIDC trusted publishing, version==tag assert, launcher tests, idempotent recut skip.
- `release-intent.mjs` + `auto-tag-release.yml`: every npm manifest (kin-mcp and kin) must equal the workspace version before a tag cuts.
- `ci.yml`: fast `npm-launchers` job so launcher regressions fail at PR time, not release time.
- `@kinlab/kin-mcp` remains published for existing configurations; its README and the root README now point new setups at `@kinlab/kin`.

## Verification

- `packages/kin`: 24/24 tests (offline provisioning fixtures: checksum gate, daemon-mandatory refusal, install layout, stamp/adopt policy), lint clean.
- `packages/kin-mcp`: 14/14 tests.
- `node scripts/release-intent.mjs` from this branch: coherent — `kin-mcp@0.2.9, kin@0.2.9`, `should_tag=false` (idempotent; this PR cannot cut a release).

## Operational note

First publish of `@kinlab/kin` requires the npm-side Trusted Publisher configuration for the new package name (or a one-time manual first publish). Until that exists, `publish_npm_canonical` fails visibly on release without affecting the GitHub release, kin-mcp, or any other job.