### PR TITLE
fix: merge-trust review accuracy — parser references, historical deltas, review gates, linker parity, fingerprint semantics

### DIFF
--- a/crates/kin-cli/src/commands/init.rs
+++ b/crates/kin-cli/src/commands/init.rs
@@ -22,7 +22,7 @@ use std::fs;
 use std::path::{Path, PathBuf};
 use std::process::Command;
 use std::sync::atomic::{AtomicUsize, Ordering};
-use tracing::{info, warn};
+use tracing::{debug, info, warn};
 
 /// Discovery cap for `kin init`. When more than this many indexable files are
 /// found, init refuses to grind unless the caller explicitly opts in (`--force`)
@@ -696,6 +696,31 @@ pub async fn run(
                     Some(&blob_store),
                 ) {
                     Ok(mut imported) if !imported.is_empty() => {
+                        // Anchor the (possibly truncated) history at a full base
+                        // universe so ref-scoped blast at historical refs sees
+                        // committed inbound edges across files untouched inside
+                        // the window. Must run BEFORE enrichment: the base-link
+                        // change is then parsed, linked, and used as each
+                        // windowed commit's semantic baseline by the same pass.
+                        match kin_git::anchor_imported_history_at_base_link(
+                            &dir,
+                            &mut imported,
+                            genesis_id,
+                            Some(&blob_store),
+                        ) {
+                            Ok(Some(base_id)) => {
+                                debug!(base_link = %base_id, "anchored imported history at base-link change");
+                            }
+                            Ok(None) => {}
+                            Err(err) => {
+                                warn!(
+                                    error = %err,
+                                    mode = %git_history,
+                                    "failed to anchor imported Git history at a base-link change; continuing without base-universe anchoring"
+                                );
+                            }
+                        }
+
                         if let Err(err) =
                             enrich_imported_changes_with_semantics(&mut imported, &blob_store)
                         {
@@ -4268,6 +4293,381 @@ mod tests {
                 .iter()
                 .any(|delta| matches!(delta, EntityDelta::Removed(id) if *id == f_id)),
             "branch B must not report a phantom Removed for `f`, got {b_deltas:?}"
+        );
+    }
+
+    /// Minimal git repo bootstrap for history-import tests. Returns false when
+    /// git is unavailable so the caller can skip (mirrors the kin-git tests).
+    fn init_git_repo_for_test(dir: &Path) -> bool {
+        let ok = Command::new("git")
+            .args(["init"])
+            .current_dir(dir)
+            .output()
+            .map(|o| o.status.success())
+            .unwrap_or(false);
+        if !ok {
+            return false;
+        }
+        for (k, v) in [("user.email", "test@test.com"), ("user.name", "Test")] {
+            let _ = Command::new("git")
+                .args(["config", k, v])
+                .current_dir(dir)
+                .output();
+        }
+        true
+    }
+
+    /// Replay the DAG reachable from `head` and report whether a LIVE relation
+    /// exists whose source entity is named `src_name` and destination entity is
+    /// named `dst_name`. Names are resolved from the reachable entity deltas;
+    /// relation deltas are applied in the returned parents-first order.
+    fn replayed_edge_present(
+        imported: &[kin_git::ImportedChange],
+        head: SemanticChangeId,
+        src_name: &str,
+        dst_name: &str,
+    ) -> bool {
+        let graph = kin_db::InMemoryGraph::new();
+        for ic in imported {
+            graph.create_change(&ic.change).unwrap();
+        }
+        let reachable = kin_core::collect_changes_at_ref(&graph, &head).unwrap();
+
+        let mut names: HashMap<EntityId, String> = HashMap::new();
+        for change in &reachable {
+            for delta in &change.entity_deltas {
+                match delta {
+                    EntityDelta::Added(entity) => {
+                        names.insert(entity.id, entity.name.clone());
+                    }
+                    EntityDelta::Modified { new, .. } => {
+                        names.insert(new.id, new.name.clone());
+                    }
+                    EntityDelta::Removed(_) => {}
+                }
+            }
+        }
+
+        let mut live: HashMap<RelationId, Relation> = HashMap::new();
+        for change in &reachable {
+            for delta in &change.relation_deltas {
+                match delta {
+                    RelationDelta::Added(relation) => {
+                        live.insert(relation.id, relation.clone());
+                    }
+                    RelationDelta::Removed(id) => {
+                        live.remove(id);
+                    }
+                }
+            }
+        }
+
+        let node_name = |node: &GraphNodeId| -> Option<&str> {
+            match node {
+                GraphNodeId::Entity(id) => names.get(id).map(String::as_str),
+                _ => None,
+            }
+        };
+        live.values().any(|relation| {
+            node_name(&relation.src) == Some(src_name) && node_name(&relation.dst) == Some(dst_name)
+        })
+    }
+
+    #[test]
+    fn base_link_anchor_surfaces_untouched_consumer_edge_at_historical_head() {
+        // End-to-end proof of FIR-1267 Fix D: a consumer living in a file NEVER
+        // touched inside a truncated import window must still yield a committed
+        // inbound relation delta that ref-scoped replay surfaces at a historical
+        // head. Pre-Fix-D the window base linked against a touched-files-only
+        // universe, so the consumer edge existed ONLY in live adjacency and the
+        // genesis auto-parse change — both siblings of the historical chain — and
+        // blast radius at a historical ref replayed as 0.
+        let dir = tempfile::tempdir().unwrap();
+        if !init_git_repo_for_test(dir.path()) {
+            eprintln!("git not available, skipping base-link anchor e2e test");
+            return;
+        }
+
+        let tools_path = dir.path().join("src/utils/tools.ts");
+        let api_path = dir.path().join("src/routes/api.ts");
+        fs::create_dir_all(tools_path.parent().unwrap()).unwrap();
+        fs::create_dir_all(api_path.parent().unwrap()).unwrap();
+
+        let commit = |msg: &str, epoch: i64| {
+            let stamp = format!("{epoch} +0000");
+            let _ = Command::new("git")
+                .args(["add", "."])
+                .current_dir(dir.path())
+                .output();
+            let _ = Command::new("git")
+                .args(["commit", "-m", msg])
+                .env("GIT_AUTHOR_DATE", &stamp)
+                .env("GIT_COMMITTER_DATE", &stamp)
+                .current_dir(dir.path())
+                .output();
+        };
+
+        // c1 (base, will fall OUTSIDE a 3-commit window): callee `foo` and its
+        // cross-file consumer `handler`, which calls `foo`.
+        fs::write(&tools_path, "export function foo() { return 1; }\n").unwrap();
+        fs::write(
+            &api_path,
+            "import { foo } from '../utils/tools';\nexport function handler() { foo(); }\n",
+        )
+        .unwrap();
+        commit("c1 base", 1_000_000_000);
+        // c2..c4 touch ONLY tools.ts — api.ts (the consumer) is never touched
+        // anywhere inside the imported window.
+        for (epoch, body) in [
+            (1_000_000_100_i64, "2"),
+            (1_000_000_200, "3"),
+            (1_000_000_300, "4"),
+        ] {
+            fs::write(
+                &tools_path,
+                format!("export function foo() {{ return {body}; }}\n"),
+            )
+            .unwrap();
+            commit("touch tools", epoch);
+        }
+
+        let blob_store = kin_blobs::BlobStore::new(dir.path().join("objects")).unwrap();
+        let genesis_id = SemanticChangeId::from_hash(Hash256::from_bytes([0x60; 32]));
+        let opts = kin_git::ImportOptions {
+            max_commits: 3,
+            ..Default::default()
+        };
+
+        // --- Anchored path (Fix D) ---
+        let mut anchored = kin_git::import_git_history_with_blobs(
+            dir.path(),
+            genesis_id,
+            &opts,
+            Some(&blob_store),
+        )
+        .unwrap();
+        let base_id = kin_git::anchor_imported_history_at_base_link(
+            dir.path(),
+            &mut anchored,
+            genesis_id,
+            Some(&blob_store),
+        )
+        .unwrap()
+        .expect("a truncated window must yield a base-link change");
+        enrich_imported_changes_with_semantics(&mut anchored, &blob_store).unwrap();
+
+        // The base-link root change itself must carry the inbound handler→foo
+        // edge, resolved against the FULL base universe.
+        let base_change = &anchored[0].change;
+        assert_eq!(base_change.id, base_id, "base-link is the prepended root");
+        let mut base_names: HashMap<EntityId, String> = HashMap::new();
+        for delta in &base_change.entity_deltas {
+            match delta {
+                EntityDelta::Added(entity) => {
+                    base_names.insert(entity.id, entity.name.clone());
+                }
+                EntityDelta::Modified { new, .. } => {
+                    base_names.insert(new.id, new.name.clone());
+                }
+                EntityDelta::Removed(_) => {}
+            }
+        }
+        let base_node_name = |node: &GraphNodeId| -> Option<&str> {
+            match node {
+                GraphNodeId::Entity(id) => base_names.get(id).map(String::as_str),
+                _ => None,
+            }
+        };
+        assert!(
+            base_change.relation_deltas.iter().any(|delta| matches!(
+                delta,
+                RelationDelta::Added(relation)
+                    if base_node_name(&relation.src) == Some("handler")
+                        && base_node_name(&relation.dst) == Some("foo")
+            )),
+            "base-link must carry the committed inbound handler→foo edge, got {:?}",
+            base_change.relation_deltas
+        );
+
+        // ...and ref-scoped replay from the historical head must surface it live.
+        let head = anchored.last().unwrap().change.id;
+        assert!(
+            replayed_edge_present(&anchored, head, "handler", "foo"),
+            "anchored: the inbound handler→foo edge must be live at the historical head"
+        );
+
+        // --- Negative control: the SAME window with NO base-link anchor ---
+        // This is the pre-Fix-D behavior; the untouched consumer edge must be
+        // absent, proving the anchor is what surfaces it.
+        let mut control = kin_git::import_git_history_with_blobs(
+            dir.path(),
+            genesis_id,
+            &opts,
+            Some(&blob_store),
+        )
+        .unwrap();
+        enrich_imported_changes_with_semantics(&mut control, &blob_store).unwrap();
+        let control_head = control.last().unwrap().change.id;
+        assert!(
+            !replayed_edge_present(&control, control_head, "handler", "foo"),
+            "pre-Fix-D control: an untouched consumer edge must NOT be reachable at the head"
+        );
+    }
+
+    #[test]
+    fn base_link_anchor_and_enrichment_are_byte_stable_across_runs() {
+        // Determinism is the whole risk of Fix D: a citable proof is void if the
+        // anchored, enriched history is not byte-identical run to run. Build one
+        // truncated-window history, then run import → anchor → enrich twice and
+        // assert every change (id, parents, and the ORDER of every delta list) is
+        // identical. This exercises: the deterministic first-parent walk to the
+        // window base, the sorted-path base-tree enumeration, content-addressed
+        // entity ids, and the relation-delta id sort.
+        let dir = tempfile::tempdir().unwrap();
+        if !init_git_repo_for_test(dir.path()) {
+            eprintln!("git not available, skipping base-link determinism test");
+            return;
+        }
+
+        let tools_path = dir.path().join("src/utils/tools.ts");
+        let api_path = dir.path().join("src/routes/api.ts");
+        let extra_path = dir.path().join("src/utils/extra.ts");
+        fs::create_dir_all(tools_path.parent().unwrap()).unwrap();
+        fs::create_dir_all(api_path.parent().unwrap()).unwrap();
+
+        let commit = |msg: &str, epoch: i64| {
+            let stamp = format!("{epoch} +0000");
+            let _ = Command::new("git")
+                .args(["add", "."])
+                .current_dir(dir.path())
+                .output();
+            let _ = Command::new("git")
+                .args(["commit", "-m", msg])
+                .env("GIT_AUTHOR_DATE", &stamp)
+                .env("GIT_COMMITTER_DATE", &stamp)
+                .current_dir(dir.path())
+                .output();
+        };
+
+        // Base carries several files (multiple consumers) so the base-link's
+        // delta ordering has real surface to be unstable if anything is unsorted.
+        fs::write(&tools_path, "export function foo() { return 1; }\n").unwrap();
+        fs::write(&extra_path, "export function bar() { return 9; }\n").unwrap();
+        fs::write(
+            &api_path,
+            "import { foo } from '../utils/tools';\nimport { bar } from '../utils/extra';\n\
+             export function handler() { foo(); bar(); }\n",
+        )
+        .unwrap();
+        commit("c1 base", 1_000_000_000);
+        for (epoch, body) in [
+            (1_000_000_100_i64, "2"),
+            (1_000_000_200, "3"),
+            (1_000_000_300, "4"),
+        ] {
+            fs::write(
+                &tools_path,
+                format!("export function foo() {{ return {body}; }}\n"),
+            )
+            .unwrap();
+            commit("touch tools", epoch);
+        }
+
+        let genesis_id = SemanticChangeId::from_hash(Hash256::from_bytes([0x61; 32]));
+        let opts = kin_git::ImportOptions {
+            max_commits: 3,
+            ..Default::default()
+        };
+
+        let run = || -> Vec<SemanticChange> {
+            // A fresh blob store per run proves the output does not depend on
+            // pre-existing store state either.
+            let blob_root = tempfile::tempdir().unwrap();
+            let blob_store = kin_blobs::BlobStore::new(blob_root.path().join("objects")).unwrap();
+            let mut imported = kin_git::import_git_history_with_blobs(
+                dir.path(),
+                genesis_id,
+                &opts,
+                Some(&blob_store),
+            )
+            .unwrap();
+            kin_git::anchor_imported_history_at_base_link(
+                dir.path(),
+                &mut imported,
+                genesis_id,
+                Some(&blob_store),
+            )
+            .unwrap();
+            enrich_imported_changes_with_semantics(&mut imported, &blob_store).unwrap();
+            imported.into_iter().map(|ic| ic.change).collect()
+        };
+
+        let first = run();
+        let second = run();
+
+        // Guard against a vacuous pass: the base-link plus the 3-commit window.
+        assert_eq!(first.len(), 4, "expected base-link + 3 windowed commits");
+
+        // (1) THE Fix-D determinism guarantee: change ids, parents, and the ORDER
+        // and identity of every entity/relation/artifact delta are byte-identical.
+        // The only non-deterministic surface in a SemanticChange is
+        // `Entity.metadata.extra`, a `HashMap` of auxiliary embedding-context
+        // strings (a pre-existing, kin-wide parser artifact that no entity id,
+        // relation id, blast, or review path keys on — those derive from
+        // (file, name, kind, index) and (src, dst, kind)). Neutralize only that
+        // key-iteration order, then require the rest to match exactly.
+        let structural = |changes: &[SemanticChange]| -> Vec<String> {
+            changes
+                .iter()
+                .map(|change| {
+                    let mut change = change.clone();
+                    for delta in &mut change.entity_deltas {
+                        match delta {
+                            EntityDelta::Added(entity) => entity.metadata.extra.clear(),
+                            EntityDelta::Modified { old, new } => {
+                                old.metadata.extra.clear();
+                                new.metadata.extra.clear();
+                            }
+                            EntityDelta::Removed(_) => {}
+                        }
+                    }
+                    format!("{change:#?}")
+                })
+                .collect()
+        };
+        assert_eq!(
+            structural(&first),
+            structural(&second),
+            "anchored + enriched history (ids, fingerprints, spans, delta ordering, \
+             relations, artifacts) must be byte-identical across runs"
+        );
+
+        // (2) The auxiliary metadata.extra CONTENT is itself stable — only its
+        // key order varies. Compare as a sorted multiset so a genuine content
+        // drift would still fail, but key-order alone does not.
+        let extra_multiset = |changes: &[SemanticChange]| -> Vec<String> {
+            let mut lines = Vec::new();
+            for change in changes {
+                for delta in &change.entity_deltas {
+                    let entities: Vec<&Entity> = match delta {
+                        EntityDelta::Added(entity) => vec![entity],
+                        EntityDelta::Modified { old, new } => vec![old, new],
+                        EntityDelta::Removed(_) => vec![],
+                    };
+                    for entity in entities {
+                        for (key, value) in &entity.metadata.extra {
+                            lines.push(format!("{:?}|{key}={value}", entity.id));
+                        }
+                    }
+                }
+            }
+            lines.sort();
+            lines
+        };
+        assert_eq!(
+            extra_multiset(&first),
+            extra_multiset(&second),
+            "metadata.extra content must be identical across runs (order-independent)"
         );
     }
 

--- a/crates/kin-cli/src/commands/init.rs
+++ b/crates/kin-cli/src/commands/init.rs
@@ -1141,6 +1141,7 @@ impl Clone for ImportedCommitSemanticState {
             linker: kin_index::IncrementalLinker {
                 entity_by_file_name: self.linker.entity_by_file_name.clone(),
                 entity_by_name: self.linker.entity_by_name.clone(),
+                entity_by_bare_name: self.linker.entity_by_bare_name.clone(),
                 entity_kind_by_id: self.linker.entity_kind_by_id.clone(),
                 known_files: self.linker.known_files.clone(),
                 entities_by_file: self.linker.entities_by_file.clone(),
@@ -4511,6 +4512,128 @@ mod tests {
         assert!(
             !replayed_edge_present(&control, control_head, "handler", "foo"),
             "pre-Fix-D control: an untouched consumer edge must NOT be reachable at the head"
+        );
+    }
+
+    #[test]
+    fn base_link_cpp_receiver_method_edge_survives_at_historical_head() {
+        // Regression guard for the FIR-1267 (c2) parity fix. A C++ receiver-method
+        // call `w.work()` resolves to a `Type::method` (`Widget::work`) only through
+        // the linker's bare-name index. The batch resolver has always had that
+        // index; the incremental linker did not, so a base-link built as a
+        // full-tree snapshot would carry the edge but the FIRST windowed commit
+        // that touches the callee re-links the consumer via the reverse-dependency
+        // closure with the incremental linker, which could not reproduce the edge
+        // and emitted a spurious Removed — deleting it at exactly the historical
+        // head a revert lands on. The existing TS e2e test cannot catch this: TS
+        // import edges resolve in BOTH linkers, so they always survive. This test
+        // uses a batch-only edge shape and asserts survival at the HEAD ref (not
+        // just the base-link), which is what a ref-scoped blast query reads.
+        let dir = tempfile::tempdir().unwrap();
+        if !init_git_repo_for_test(dir.path()) {
+            eprintln!("git not available, skipping c2 survival test");
+            return;
+        }
+
+        let lib_path = dir.path().join("widget.hpp");
+        let app_path = dir.path().join("app.cpp");
+
+        let commit = |msg: &str, epoch: i64| {
+            let stamp = format!("{epoch} +0000");
+            let _ = Command::new("git")
+                .args(["add", "."])
+                .current_dir(dir.path())
+                .output();
+            let _ = Command::new("git")
+                .args(["commit", "-m", msg])
+                .env("GIT_AUTHOR_DATE", &stamp)
+                .env("GIT_COMMITTER_DATE", &stamp)
+                .current_dir(dir.path())
+                .output();
+        };
+
+        // c1 (base, falls OUTSIDE a 3-commit window): the callee `Widget::work`
+        // and its cross-file consumer `run`, which calls it via `w.work()` — a
+        // bare-name receiver-method call resolvable only through the bare-name
+        // index, never an exact cross-file name match or an ES-style import.
+        fs::write(&lib_path, "struct Widget { int work() { return 1; } };\n").unwrap();
+        fs::write(
+            &app_path,
+            "#include \"widget.hpp\"\nint run() { Widget w; return w.work(); }\n",
+        )
+        .unwrap();
+        commit("c1 base", 1_000_000_000);
+        // c2..c4 touch ONLY widget.hpp (the callee); app.cpp (the consumer) is
+        // never touched anywhere inside the imported window.
+        for (epoch, body) in [
+            (1_000_000_100_i64, "2"),
+            (1_000_000_200, "3"),
+            (1_000_000_300, "4"),
+        ] {
+            fs::write(
+                &lib_path,
+                format!("struct Widget {{ int work() {{ return {body}; }} }};\n"),
+            )
+            .unwrap();
+            commit("touch widget", epoch);
+        }
+
+        let blob_store = kin_blobs::BlobStore::new(dir.path().join("objects")).unwrap();
+        let genesis_id = SemanticChangeId::from_hash(Hash256::from_bytes([0x71; 32]));
+        let opts = kin_git::ImportOptions {
+            max_commits: 3,
+            ..Default::default()
+        };
+
+        // --- Anchored path (Fix D base-link + incremental (c2) parity) ---
+        let mut anchored = kin_git::import_git_history_with_blobs(
+            dir.path(),
+            genesis_id,
+            &opts,
+            Some(&blob_store),
+        )
+        .unwrap();
+        let base_id = kin_git::anchor_imported_history_at_base_link(
+            dir.path(),
+            &mut anchored,
+            genesis_id,
+            Some(&blob_store),
+        )
+        .unwrap()
+        .expect("a truncated window must yield a base-link change");
+        enrich_imported_changes_with_semantics(&mut anchored, &blob_store).unwrap();
+
+        // The base-link carries the bare-name receiver-method edge...
+        assert!(
+            replayed_edge_present(&anchored, base_id, "run", "Widget::work"),
+            "base-link must carry the receiver-method edge run->Widget::work"
+        );
+        // ...and it must SURVIVE at the historical head, even though every windowed
+        // commit touches the callee (pulling the consumer into the reverse-dep
+        // closure). Before the (c2) parity fix the incremental relink dropped it
+        // here, so this assertion is the one that fails on the half-fix.
+        let head = anchored.last().unwrap().change.id;
+        assert!(
+            replayed_edge_present(&anchored, head, "run", "Widget::work"),
+            "anchored: the receiver-method edge must remain live at the historical head"
+        );
+
+        // --- Negative control: the SAME window with NO base-link anchor ---
+        // Without the anchor the consumer file is never in the graph at any
+        // windowed ref, so the edge cannot exist — proving the anchor is what
+        // brings the base universe in and the (c2) parity is what keeps it.
+        let mut control = kin_git::import_git_history_with_blobs(
+            dir.path(),
+            genesis_id,
+            &opts,
+            Some(&blob_store),
+        )
+        .unwrap();
+        enrich_imported_changes_with_semantics(&mut control, &blob_store).unwrap();
+        let control_head = control.last().unwrap().change.id;
+        assert!(
+            !replayed_edge_present(&control, control_head, "run", "Widget::work"),
+            "unanchored control: an untouched consumer edge must NOT be reachable at the head"
         );
     }
 

--- a/crates/kin-cli/src/commands/init.rs
+++ b/crates/kin-cli/src/commands/init.rs
@@ -1076,18 +1076,108 @@ impl ImportedSemanticFileState {
     }
 }
 
+/// Per-commit semantic accumulator state: file entities, cross-file relations
+/// (plus their src indexes), and the incremental linker index. Historical
+/// ingest forks a fresh copy of this state from each commit's FIRST git parent,
+/// so a commit's entity and relation deltas are computed against its true DAG
+/// parent rather than the linearized running state of an interleaved
+/// commit-time walk.
+struct ImportedCommitSemanticState {
+    files: HashMap<String, ImportedSemanticFileState>,
+    relations: HashMap<RelationId, Relation>,
+    relations_by_src: HashMap<EntityId, HashSet<RelationId>>,
+    relations_by_src_artifact: HashMap<ArtifactId, HashSet<RelationId>>,
+    linker: kin_index::IncrementalLinker,
+}
+
+impl Default for ImportedCommitSemanticState {
+    fn default() -> Self {
+        Self {
+            files: HashMap::new(),
+            relations: HashMap::new(),
+            relations_by_src: HashMap::new(),
+            relations_by_src_artifact: HashMap::new(),
+            linker: kin_index::IncrementalLinker::new(),
+        }
+    }
+}
+
+impl Clone for ImportedCommitSemanticState {
+    fn clone(&self) -> Self {
+        Self {
+            files: self.files.clone(),
+            relations: self.relations.clone(),
+            relations_by_src: self.relations_by_src.clone(),
+            relations_by_src_artifact: self.relations_by_src_artifact.clone(),
+            // `IncrementalLinker` derives no `Clone`; its fields are all public
+            // and cloneable, so copy them explicitly. A new field there makes
+            // this fail to compile (fail loud) rather than silently drop linker
+            // state from a forked baseline.
+            linker: kin_index::IncrementalLinker {
+                entity_by_file_name: self.linker.entity_by_file_name.clone(),
+                entity_by_name: self.linker.entity_by_name.clone(),
+                entity_kind_by_id: self.linker.entity_kind_by_id.clone(),
+                known_files: self.linker.known_files.clone(),
+                entities_by_file: self.linker.entities_by_file.clone(),
+                include_targets_by_file: self.linker.include_targets_by_file.clone(),
+            },
+        }
+    }
+}
+
+/// Deterministic topological order over the first-parent forest.
+///
+/// `first_parent_index[c]` is the slice index of commit `c`'s first git parent
+/// when that parent is itself in the imported set (`None` for a root or a parent
+/// below the import horizon). Each commit has at most one in-set first parent,
+/// so "process a commit after its first parent" is a forest constraint; Kahn's
+/// algorithm seeded and drained in ascending index order yields a stable order
+/// in which every commit follows its first parent, staying as close as possible
+/// to the input order. Any commit left unvisited by an (impossible for git)
+/// cycle is appended in index order so no commit is silently dropped.
+fn first_parent_topological_order(first_parent_index: &[Option<usize>]) -> Vec<usize> {
+    let n = first_parent_index.len();
+    let mut children: Vec<Vec<usize>> = vec![Vec::new(); n];
+    let mut indegree = vec![0usize; n];
+    for (child, parent) in first_parent_index.iter().enumerate() {
+        if let Some(parent) = *parent {
+            children[parent].push(child);
+            indegree[child] += 1;
+        }
+    }
+
+    let mut queue: std::collections::VecDeque<usize> =
+        (0..n).filter(|&i| indegree[i] == 0).collect();
+    let mut order = Vec::with_capacity(n);
+    let mut seen = vec![false; n];
+    while let Some(i) = queue.pop_front() {
+        if seen[i] {
+            continue;
+        }
+        seen[i] = true;
+        order.push(i);
+        for &child in &children[i] {
+            indegree[child] -= 1;
+            if indegree[child] == 0 {
+                queue.push_back(child);
+            }
+        }
+    }
+    for (i, visited) in seen.iter().enumerate() {
+        if !visited {
+            order.push(i);
+        }
+    }
+    order
+}
+
 pub(crate) fn enrich_imported_changes_with_semantics(
     imported: &mut [kin_git::ImportedChange],
     blob_store: &kin_blobs::BlobStore,
 ) -> Result<()> {
     let pipeline = kin_index::IndexPipeline::new();
-    let mut current_files = HashMap::<String, ImportedSemanticFileState>::new();
-    let mut current_relations = HashMap::<RelationId, Relation>::new();
-    let mut relations_by_src = HashMap::<EntityId, HashSet<RelationId>>::new();
-    let mut relations_by_src_artifact = HashMap::<ArtifactId, HashSet<RelationId>>::new();
-    let mut incremental_linker = kin_index::IncrementalLinker::new();
 
-    // Profiling timers
+    // Profiling timers (accumulated across every commit in the pass).
     let mut total_blob_read_time = std::time::Duration::ZERO;
     let mut total_parsing_time = std::time::Duration::ZERO;
     let mut total_linking_time = std::time::Duration::ZERO;
@@ -1096,25 +1186,86 @@ pub(crate) fn enrich_imported_changes_with_semantics(
     let total_commits = imported.len();
     let start_time = std::time::Instant::now();
 
-    for (i, imported_change) in imported.iter_mut().enumerate() {
+    // Resolve each imported commit's FIRST git parent to an in-set slice index.
+    // kin-git derives a commit's artifact deltas by diffing its tree against its
+    // first parent's tree, so the first parent's semantic state is the correct
+    // baseline for that commit's entity and relation deltas. Diffing against a
+    // linearized commit-time running map instead attributes an interleaved
+    // sibling commit's entities/signatures to the wrong commit on a non-linear
+    // history (merges or branch interleaving), producing phantom deltas at
+    // historical refs.
+    let mut index_by_change_id = HashMap::<SemanticChangeId, usize>::with_capacity(total_commits);
+    for (i, imported_change) in imported.iter().enumerate() {
+        index_by_change_id.insert(imported_change.change.id, i);
+    }
+    let first_parent_index: Vec<Option<usize>> = imported
+        .iter()
+        .map(|imported_change| {
+            imported_change
+                .change
+                .parents
+                .first()
+                .and_then(|parent| index_by_change_id.get(parent).copied())
+        })
+        .collect();
+
+    // Count how many in-set commits fork from each commit as their first parent,
+    // so a commit's snapshot is retained only while children still need it. This
+    // bounds live snapshots to the DAG's branch width, not the whole history.
+    let mut remaining_children = vec![0usize; total_commits];
+    for parent in first_parent_index.iter().flatten() {
+        remaining_children[*parent] += 1;
+    }
+
+    let order = first_parent_topological_order(&first_parent_index);
+    let mut snapshots = HashMap::<SemanticChangeId, ImportedCommitSemanticState>::new();
+
+    for (processed, &i) in order.iter().enumerate() {
         if total_commits > 0 {
-            let percent = ((i + 1) * 100) / total_commits;
-            let short_oid: String = imported_change.git_oid.chars().take(7).collect();
+            let percent = ((processed + 1) * 100) / total_commits;
+            let short_oid: String = imported[i].git_oid.chars().take(7).collect();
             eprint!(
                 "\r  Hydrating History: [{}/{}] {}% | Commit: {} | {:.1}s",
-                i + 1,
+                processed + 1,
                 total_commits,
                 percent,
                 short_oid,
                 start_time.elapsed().as_secs_f64()
             );
         }
+
+        // Fork this commit's baseline from its first parent's resulting state.
+        // The parent's last child moves the snapshot (zero-copy, so a purely
+        // linear history keeps the original single-accumulator cost); earlier
+        // children clone it. Roots and below-horizon parents start from empty
+        // state. Then rebind the forked accumulators into the names the
+        // per-commit body below already uses.
+        let baseline = match first_parent_index[i] {
+            Some(parent_idx) => {
+                remaining_children[parent_idx] -= 1;
+                let parent_id = imported[parent_idx].change.id;
+                if remaining_children[parent_idx] == 0 {
+                    snapshots.remove(&parent_id).unwrap_or_default()
+                } else {
+                    snapshots.get(&parent_id).cloned().unwrap_or_default()
+                }
+            }
+            None => ImportedCommitSemanticState::default(),
+        };
+        let ImportedCommitSemanticState {
+            files: mut current_files,
+            relations: mut current_relations,
+            mut relations_by_src,
+            mut relations_by_src_artifact,
+            linker: mut incremental_linker,
+        } = baseline;
+
         let mut entity_deltas = Vec::new();
         let mut relation_deltas = Vec::new();
         let mut changed_source_files = BTreeSet::<String>::new();
         let mut previous_file_states = HashMap::<String, ImportedSemanticFileState>::new();
 
-        for artifact_delta in &imported_change.change.artifact_deltas {
+        for artifact_delta in &imported[i].change.artifact_deltas {
             let file_path = artifact_delta.file_id.0.clone();
             let old_state = current_files.get(&file_path).cloned();
             if let Some(old_state) = &old_state {
@@ -1331,8 +1482,23 @@ pub(crate) fn enrich_imported_changes_with_semantics(
             RelationDelta::Added(relation) => relation.id.0,
             RelationDelta::Removed(relation_id) => relation_id.0,
         });
-        imported_change.change.entity_deltas = entity_deltas;
-        imported_change.change.relation_deltas = relation_deltas;
+        imported[i].change.entity_deltas = entity_deltas;
+        imported[i].change.relation_deltas = relation_deltas;
+
+        // Retain this commit's resulting state only while a later child will
+        // fork from it; leaves are dropped immediately.
+        if remaining_children[i] > 0 {
+            snapshots.insert(
+                imported[i].change.id,
+                ImportedCommitSemanticState {
+                    files: current_files,
+                    relations: current_relations,
+                    relations_by_src,
+                    relations_by_src_artifact,
+                    linker: incremental_linker,
+                },
+            );
+        }
     }
 
     if total_commits > 0 {
@@ -3997,6 +4163,111 @@ mod tests {
                 .any(|delta| matches!(delta, EntityDelta::Removed(entity_id) if *entity_id == first_entity_id)),
             "expected stale imported function removal, got {:?}",
             imported[1].change.entity_deltas
+        );
+    }
+
+    #[test]
+    fn enrich_imported_changes_keys_entity_deltas_to_git_parent_not_linear_running_map() {
+        // Non-linear history: a root R forks into two sibling commits that both
+        // touch the SAME file. Branch A rewrites `f`'s body; branch B leaves `f`
+        // byte-identical to R and only adds `g`. In commit-time slice order the
+        // sibling A is processed between R and B, so a linear running-map keying
+        // would diff B against A's state and report a PHANTOM `Modified f`. DAG
+        // keying diffs B against its real first parent R, where `f` is unchanged.
+        let dir = tempfile::tempdir().unwrap();
+        let blob_store = kin_blobs::BlobStore::new(dir.path().join("objects")).unwrap();
+
+        let f_v1 = blob_store.write(b"def f():\n    return 1\n").unwrap();
+        let f_v2 = blob_store.write(b"def f():\n    return 2\n").unwrap();
+        // `f` here is byte-identical to f_v1; only `g` is new.
+        let f_v3 = blob_store
+            .write(b"def f():\n    return 1\ndef g():\n    return 2\n")
+            .unwrap();
+
+        // R id = 0x51; both branches list R (0x51) as their first parent.
+        let mut imported = vec![
+            imported_change(
+                [0x51; 32],
+                [0x50; 32],
+                "root: add f",
+                vec![artifact_delta(
+                    "src/lib.py",
+                    kin_model::ArtifactDeltaKind::Added,
+                    None,
+                    Some(Hash256::from_bytes(f_v1.0)),
+                )],
+            ),
+            imported_change(
+                [0x52; 32],
+                [0x51; 32],
+                "branch A: rewrite f body",
+                vec![artifact_delta(
+                    "src/lib.py",
+                    kin_model::ArtifactDeltaKind::Modified,
+                    Some(Hash256::from_bytes(f_v1.0)),
+                    Some(Hash256::from_bytes(f_v2.0)),
+                )],
+            ),
+            imported_change(
+                [0x53; 32],
+                [0x51; 32],
+                "branch B: add g, f unchanged",
+                vec![artifact_delta(
+                    "src/lib.py",
+                    kin_model::ArtifactDeltaKind::Modified,
+                    Some(Hash256::from_bytes(f_v1.0)),
+                    Some(Hash256::from_bytes(f_v3.0)),
+                )],
+            ),
+        ];
+
+        enrich_imported_changes_with_semantics(&mut imported, &blob_store).unwrap();
+
+        // Sanity: R adds function `f`; branch A really did modify `f` (its body)
+        // against its parent R. `single_modified_function` filters to the
+        // function-kind delta, so the file's module-level entity is ignored here.
+        let f_id = single_added_function_id(&imported[0].change.entity_deltas);
+        let (a_old, a_new) = single_modified_function(&imported[1].change.entity_deltas);
+        assert_eq!(
+            a_old.id, f_id,
+            "branch A should modify the same `f` R added"
+        );
+        assert_eq!(a_new.id, f_id);
+
+        // Branch B is keyed to its git parent R, where `f` is byte-identical, so
+        // the ONLY function-level change B introduces is `Added g`. The phantom
+        // this fix eliminates is a function-level `Modified f`/`Removed f`, which
+        // the old linear running-map keying produced by diffing B against sibling
+        // A's rewritten `f`. (The file's module-level entity legitimately changes
+        // because `g` was added — that is a real delta under old and new code and
+        // is intentionally not asserted against.)
+        let b_deltas = &imported[2].change.entity_deltas;
+        let added_functions: Vec<&str> = b_deltas
+            .iter()
+            .filter_map(|delta| match delta {
+                EntityDelta::Added(entity) if entity.kind == EntityKind::Function => {
+                    Some(entity.name.as_str())
+                }
+                _ => None,
+            })
+            .collect();
+        assert_eq!(
+            added_functions,
+            vec!["g"],
+            "branch B should add exactly function `g` against its git parent, got {b_deltas:?}"
+        );
+        assert!(
+            !b_deltas.iter().any(|delta| matches!(
+                delta,
+                EntityDelta::Modified { old, .. } if old.kind == EntityKind::Function
+            )),
+            "branch B must not report a phantom function Modified for the unchanged `f`, got {b_deltas:?}"
+        );
+        assert!(
+            !b_deltas
+                .iter()
+                .any(|delta| matches!(delta, EntityDelta::Removed(id) if *id == f_id)),
+            "branch B must not report a phantom Removed for `f`, got {b_deltas:?}"
         );
     }
 

--- a/crates/kin-cli/src/commands/init.rs
+++ b/crates/kin-cli/src/commands/init.rs
@@ -1730,10 +1730,14 @@ fn imported_relations_equivalent(old: &Relation, new: &Relation) -> bool {
         && (old.confidence - new.confidence).abs() < f32::EPSILON
 }
 
+const COMMAND_EFFECT_CONTRACT_KEY: &str = "command_effect_contract";
+
 fn entity_fingerprint_changed(old: &Entity, new: &Entity) -> bool {
     old.fingerprint.ast_hash != new.fingerprint.ast_hash
         || old.fingerprint.signature_hash != new.fingerprint.signature_hash
         || old.fingerprint.behavior_hash != new.fingerprint.behavior_hash
+        || old.metadata.extra.get(COMMAND_EFFECT_CONTRACT_KEY)
+            != new.metadata.extra.get(COMMAND_EFFECT_CONTRACT_KEY)
 }
 
 fn reconcile_imported_file_entities(
@@ -3995,6 +3999,148 @@ mod tests {
         assert!(
             entity_fingerprint_changed(old, new),
             "modified imported entity should record a semantic fingerprint change"
+        );
+    }
+
+    #[test]
+    fn entity_fingerprint_changed_includes_command_effect_contract_metadata() {
+        let mut old = test_entity("prCheckout", "command/pr_checkout.go");
+        let mut new = old.clone();
+        old.metadata.extra.insert(
+            COMMAND_EFFECT_CONTRACT_KEY.into(),
+            serde_json::json!({
+                "effects": [{
+                    "kind": "queued_git_argv",
+                    "bindings": { "newBranchName": "pr.HeadRefName" }
+                }]
+            }),
+        );
+        new.metadata.extra.insert(
+            COMMAND_EFFECT_CONTRACT_KEY.into(),
+            serde_json::json!({
+                "effects": [{
+                    "kind": "queued_git_argv",
+                    "bindings": {
+                        "newBranchName": "fmt.Sprintf(\"pr/%d/%s\", pr.Number, pr.HeadRefName)"
+                    }
+                }]
+            }),
+        );
+
+        assert!(
+            entity_fingerprint_changed(&old, &new),
+            "command-effect contract metadata changes must produce an imported entity delta"
+        );
+    }
+
+    #[test]
+    fn imported_go_command_effect_contract_change_records_entity_delta() {
+        let dir = tempfile::tempdir().unwrap();
+        let blob_store = kin_blobs::BlobStore::new(dir.path().join("objects")).unwrap();
+        let old_source = br#"
+package command
+
+import (
+    "fmt"
+    "os/exec"
+
+    "github.com/cli/cli/git"
+    "github.com/spf13/cobra"
+)
+
+type pullRequest struct {
+    Number int
+    HeadRefName string
+}
+
+func prCheckout(cmd *cobra.Command, args []string) error {
+    pr := pullRequest{Number: 123, HeadRefName: "feature"}
+    cmdQueue := [][]string{}
+    newBranchName := pr.HeadRefName
+    if git.VerifyRef("refs/heads/" + newBranchName) {
+        cmdQueue = append(cmdQueue, []string{"git", "checkout", newBranchName})
+    } else {
+        cmdQueue = append(cmdQueue, []string{"git", "checkout", "-b", newBranchName, "--no-track", "origin/feature"})
+    }
+    exec.Command("git", "config", fmt.Sprintf("branch.%s.remote", newBranchName), "origin")
+    _ = cmdQueue
+    return nil
+}
+"#;
+        let new_source = br#"
+package command
+
+import (
+    "fmt"
+    "os/exec"
+
+    "github.com/cli/cli/git"
+    "github.com/spf13/cobra"
+)
+
+type pullRequest struct {
+    Number int
+    HeadRefName string
+}
+
+func prCheckout(cmd *cobra.Command, args []string) error {
+    pr := pullRequest{Number: 123, HeadRefName: "feature"}
+    cmdQueue := [][]string{}
+    newBranchName := fmt.Sprintf("pr/%d/%s", pr.Number, pr.HeadRefName)
+    if git.VerifyRef("refs/heads/" + newBranchName) {
+        cmdQueue = append(cmdQueue, []string{"git", "checkout", newBranchName})
+    } else {
+        cmdQueue = append(cmdQueue, []string{"git", "checkout", "-b", newBranchName, "--no-track", "origin/feature"})
+    }
+    exec.Command("git", "config", fmt.Sprintf("branch.%s.remote", newBranchName), "origin")
+    _ = cmdQueue
+    return nil
+}
+"#;
+        let blob_v1 = blob_store.write(old_source).unwrap();
+        let blob_v2 = blob_store.write(new_source).unwrap();
+        let mut imported = vec![
+            imported_change(
+                [0x21; 32],
+                [0x20; 32],
+                "imported root",
+                vec![artifact_delta(
+                    "command/pr_checkout.go",
+                    kin_model::ArtifactDeltaKind::Added,
+                    None,
+                    Some(Hash256::from_bytes(blob_v1.0)),
+                )],
+            ),
+            imported_change(
+                [0x22; 32],
+                [0x21; 32],
+                "prefix branch names",
+                vec![artifact_delta(
+                    "command/pr_checkout.go",
+                    kin_model::ArtifactDeltaKind::Modified,
+                    Some(Hash256::from_bytes(blob_v1.0)),
+                    Some(Hash256::from_bytes(blob_v2.0)),
+                )],
+            ),
+        ];
+
+        enrich_imported_changes_with_semantics(&mut imported, &blob_store).unwrap();
+        let (old, new) = imported[1]
+            .change
+            .entity_deltas
+            .iter()
+            .find_map(|delta| match delta {
+                EntityDelta::Modified { old, new } if new.name == "prCheckout" => Some((old, new)),
+                _ => None,
+            })
+            .expect("prCheckout should be recorded as a modified entity");
+        let old_contract = old.metadata.extra.get(COMMAND_EFFECT_CONTRACT_KEY);
+        let new_contract = new.metadata.extra.get(COMMAND_EFFECT_CONTRACT_KEY);
+        assert!(old_contract.is_some(), "old contract metadata missing");
+        assert!(new_contract.is_some(), "new contract metadata missing");
+        assert_ne!(
+            old_contract, new_contract,
+            "branch naming contract change must be visible in metadata"
         );
     }
 

--- a/crates/kin-cli/src/commands/review.rs
+++ b/crates/kin-cli/src/commands/review.rs
@@ -1112,6 +1112,7 @@ fn inline_comment_severity(kind: kin_review::InlineCommentKind) -> &'static str 
         InlineCommentKind::CoverageGap
         | InlineCommentKind::SignatureChange
         | InlineCommentKind::VisibilityChange
+        | InlineCommentKind::CommandEffectContract
         | InlineCommentKind::ConsumerFanout
         | InlineCommentKind::Renamed
         | InlineCommentKind::AgentUnreviewed => "warning",

--- a/crates/kin-cli/src/commands/review.rs
+++ b/crates/kin-cli/src/commands/review.rs
@@ -1126,6 +1126,14 @@ mod tests {
     use kin_model::ProvenanceStore;
 
     #[test]
+    fn command_effect_contract_comment_severity_is_warning() {
+        assert_eq!(
+            inline_comment_severity(kin_review::InlineCommentKind::CommandEffectContract),
+            "warning"
+        );
+    }
+
+    #[test]
     fn create_review_records_audit_event() {
         let graph = kin_db::InMemoryGraph::new();
 

--- a/crates/kin-daemon/src/supervisor.rs
+++ b/crates/kin-daemon/src/supervisor.rs
@@ -988,6 +988,12 @@ const REAPER_SIGTERM_GRACE: Duration = Duration::from_secs(5);
 const REAPER_DEFAULT_CPU_PINNED_PERCENT: f32 = 80.0;
 /// Default consecutive pinned sweeps before the CPU heuristic fires.
 const REAPER_DEFAULT_CPU_PINNED_SWEEPS: u32 = 2;
+/// Consecutive sweeps a daemon must show zero persisted progress — no growth in
+/// its repo `daemon.log` — before an unreachable or CPU-pinned daemon becomes
+/// reap-eligible. 4 sweeps × 15s = a minute of zero persisted progress while
+/// unreachable, long enough that a merely-busy daemon that missed a probe
+/// deadline is never mistaken for a wedged one.
+const REAPER_STALL_SWEEPS: u32 = 4;
 /// Default slack (in seconds) a daemon's start_time may lag the deployed binary
 /// mtime before it counts as stale — absorbs clock/filesystem timestamp jitter.
 const REDEPLOY_DEFAULT_GRACE_SECS: u64 = 2;
@@ -1003,8 +1009,14 @@ const SUPERVISOR_REEXECED_FOR_MTIME_ENV: &str = "KIN_SUPERVISOR_REEXECED_FOR_MTI
 enum DaemonHealth {
     /// `/health` responded 2xx; carries observed activity.
     Healthy(DaemonActivity),
-    /// `/health` failed, timed out, or returned non-2xx.
+    /// The daemon ANSWERED but the answer was broken: a served non-success HTTP
+    /// status, or a 2xx body that could not be parsed. It is responding, just
+    /// wrong — a genuinely broken daemon.
     Unhealthy,
+    /// The `/health` probe could not reach the daemon at all: it timed out or the
+    /// connection failed. A daemon pinned doing real work can miss a probe
+    /// deadline, so this is treated as "no answer yet", not proof of breakage.
+    Unreachable,
     /// No port was discoverable, so health could not be probed.
     Unknown,
 }
@@ -1019,10 +1031,16 @@ struct DaemonActivity {
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 enum ReapReason {
-    /// Orphaned (reparented to init) and the health probe failed/timed out.
+    /// Orphaned (reparented to init) and the daemon ANSWERED its health probe
+    /// with a broken response (non-success status or unparseable body).
     OrphanedUnhealthy,
-    /// Orphaned, healthy but idle (no clients, not reconciling), and CPU-pinned
-    /// across enough consecutive sweeps — the busy-spinner case.
+    /// Orphaned and UNREACHABLE (probe timed out or the connection failed) across
+    /// the full stall window with zero persisted progress — a wedged daemon,
+    /// distinguished from a merely-busy one that keeps advancing its log.
+    OrphanedUnreachableStalled,
+    /// Orphaned, healthy but idle (no clients, not reconciling), CPU-pinned across
+    /// enough consecutive sweeps, AND showing no persisted progress across the
+    /// stall window — the busy-spinner case, never a daemon still advancing work.
     OrphanedBusyNoClients,
     /// Orphaned duplicate of a registered, healthy daemon on the same repo root.
     DuplicateOrphanTwin,
@@ -1201,6 +1219,10 @@ struct DaemonObservation {
     health: DaemonHealth,
     /// Consecutive sweeps this pid has been CPU-pinned.
     cpu_pinned_sweeps: u32,
+    /// Consecutive sweeps this pid's repo `daemon.log` has not grown — a
+    /// persisted-progress stall. Gates the unreachable and CPU-pinned reap
+    /// criteria so a busy-but-advancing daemon is never reaped.
+    stall_sweeps: u32,
     /// How this daemon relates to the registry entry for its repo root.
     registry: RegistryRelation,
     /// The deployed binary was rebuilt after this process started — it is running
@@ -1217,8 +1239,14 @@ struct DaemonObservation {
 /// - A daemon doing real work (active clients or active reconciliation) is NEVER
 ///   reaped, even if unregistered — but it MAY still be adopted to restore
 ///   visibility (adoption never reaps).
-/// - The safe reap criterion (orphaned + unhealthy) is always enabled.
-/// - The CPU-pinned and duplicate-twin reap criteria are policy-gated.
+/// - The safe reap criteria are always enabled: an orphaned daemon that ANSWERED
+///   its probe with a broken response is reaped at once; an orphaned daemon that
+///   is merely UNREACHABLE (probe timed out / connection failed) is reaped only
+///   after it has also shown zero persisted progress across the stall window, so a
+///   busy daemon that missed a probe deadline is never mistaken for a wedged one.
+/// - The CPU-pinned and duplicate-twin reap criteria are policy-gated. The
+///   CPU-pinned criterion additionally requires the same persisted-progress stall,
+///   so a busy-but-advancing daemon is never reaped.
 /// - Reaping always wins over redeploy, which wins over adoption. The only
 ///   healthy reap path is the orphaned idle busy-spinner; a daemon matching it is
 ///   reaped, not redeployed or adopted.
@@ -1239,9 +1267,23 @@ fn classify_daemon(obs: &DaemonObservation, policy: &ReapPolicy) -> DaemonDecisi
     );
 
     if !active {
-        // (a) Safe criterion, always on: orphaned and its health probe failed.
+        // (a) Safe criterion, always on: orphaned and the daemon ANSWERED its
+        //     probe with a broken response (non-success status or unparseable
+        //     body). A daemon that answers with garbage is genuinely broken, so it
+        //     is reaped at once — no progress grace.
         if obs.orphaned && obs.health == DaemonHealth::Unhealthy {
             return DaemonDecision::Reap(ReapReason::OrphanedUnhealthy);
+        }
+
+        // (a') Orphaned and UNREACHABLE (probe timed out / connection failed). A
+        //      busy daemon can miss a probe deadline, so an unreachable probe alone
+        //      is not proof of a rogue daemon. Reap only once it has ALSO made zero
+        //      persisted progress across the stall window — unreachable AND wedged.
+        if obs.orphaned
+            && obs.health == DaemonHealth::Unreachable
+            && obs.stall_sweeps >= REAPER_STALL_SWEEPS
+        {
+            return DaemonDecision::Reap(ReapReason::OrphanedUnreachableStalled);
         }
 
         // (c) Orphaned, IDLE duplicate twin of a registered, alive daemon on the
@@ -1254,12 +1296,15 @@ fn classify_daemon(obs: &DaemonObservation, policy: &ReapPolicy) -> DaemonDecisi
             return DaemonDecision::Reap(ReapReason::DuplicateOrphanTwin);
         }
 
-        // (b) Orphaned busy-spinner: healthy but idle (ensured by `!active`)
-        //     and CPU-pinned across enough consecutive sweeps.
+        // (b) Orphaned busy-spinner: healthy but idle (ensured by `!active`),
+        //     CPU-pinned across enough consecutive sweeps, AND making no persisted
+        //     progress across the stall window. The stall gate is what separates a
+        //     rogue spinner from a daemon legitimately busy advancing its log.
         if policy.cpu_heuristic_enabled
             && obs.orphaned
             && matches!(obs.health, DaemonHealth::Healthy(_))
             && obs.cpu_pinned_sweeps >= policy.cpu_pinned_min_sweeps
+            && obs.stall_sweeps >= REAPER_STALL_SWEEPS
         {
             return DaemonDecision::Reap(ReapReason::OrphanedBusyNoClients);
         }
@@ -1317,6 +1362,8 @@ fn spawn_rogue_daemon_reaper(
         let mut sys = sysinfo::System::new();
         // pid -> consecutive CPU-pinned sweep count.
         let mut pinned_sweeps: HashMap<u32, u32> = HashMap::new();
+        // pid -> (last observed repo daemon.log length, consecutive no-growth sweeps).
+        let mut stalled_sweeps: HashMap<u32, (u64, u32)> = HashMap::new();
         loop {
             tokio::select! {
                 _ = tokio::time::sleep(REAPER_SWEEP_INTERVAL) => {}
@@ -1330,6 +1377,7 @@ fn spawn_rogue_daemon_reaper(
                 &client,
                 &mut sys,
                 &mut pinned_sweeps,
+                &mut stalled_sweeps,
                 self_pid,
                 policy,
             )
@@ -1366,6 +1414,7 @@ async fn reaper_sweep(
     client: &reqwest::Client,
     sys: &mut sysinfo::System,
     pinned_sweeps: &mut HashMap<u32, u32>,
+    stalled_sweeps: &mut HashMap<u32, (u64, u32)>,
     self_pid: u32,
     policy: ReapPolicy,
 ) {
@@ -1406,6 +1455,29 @@ async fn reaper_sweep(
             *counter = counter.saturating_add(1);
         } else {
             *counter = 0;
+        }
+    }
+
+    // Update persisted-progress streaks alongside the CPU streaks: a daemon whose
+    // repo `daemon.log` has not grown since the last sweep made no persisted
+    // progress this sweep. A daemon that IS growing its log is doing real work even
+    // when its health probe looks idle or times out, so its streak resets to 0. The
+    // first sighting of a pid only records a baseline length (no stall counted yet).
+    stalled_sweeps.retain(|pid, _| live_pids.contains(pid));
+    for daemon in &discovered {
+        let log_len = daemon_log_len(&daemon.repo_root);
+        match stalled_sweeps.get_mut(&daemon.pid) {
+            Some((last_len, no_growth)) => {
+                if log_len > *last_len {
+                    *no_growth = 0;
+                } else {
+                    *no_growth = no_growth.saturating_add(1);
+                }
+                *last_len = log_len;
+            }
+            None => {
+                stalled_sweeps.insert(daemon.pid, (log_len, 0));
+            }
         }
     }
 
@@ -1453,6 +1525,10 @@ async fn reaper_sweep(
             orphaned: daemon.ppid == Some(1),
             health,
             cpu_pinned_sweeps: pinned_sweeps.get(&daemon.pid).copied().unwrap_or(0),
+            stall_sweeps: stalled_sweeps
+                .get(&daemon.pid)
+                .map(|(_, no_growth)| *no_growth)
+                .unwrap_or(0),
             registry: registry_relation,
             stale_binary,
         };
@@ -1460,10 +1536,12 @@ async fn reaper_sweep(
             DaemonDecision::Reap(reason) => {
                 reap_daemon(&observation, reason).await;
                 pinned_sweeps.remove(&daemon.pid);
+                stalled_sweeps.remove(&daemon.pid);
             }
             DaemonDecision::Redeploy(reason) => {
                 redeploy_daemon(&observation, reason).await;
                 pinned_sweeps.remove(&daemon.pid);
+                stalled_sweeps.remove(&daemon.pid);
             }
             DaemonDecision::Adopt(reason) => {
                 adopt_daemon(state, daemon, reason).await;
@@ -1628,6 +1706,16 @@ fn same_binary(a: Option<&std::path::Path>, b: Option<&std::path::Path>) -> bool
     }
 }
 
+/// Size in bytes of a repo daemon's persisted activity log — the reaper's
+/// persisted-progress signal. A daemon doing real work grows
+/// `<repo_root>/.kin/daemon.log`; a missing or unreadable log reads as 0 so a
+/// daemon that has simply never written one never looks like it is "shrinking".
+#[cfg(unix)]
+fn daemon_log_len(repo_root: &str) -> u64 {
+    let log_path = Path::new(repo_root).join(".kin").join("daemon.log");
+    std::fs::metadata(&log_path).map(|m| m.len()).unwrap_or(0)
+}
+
 /// Probe a repo daemon's unauthenticated `/health` endpoint and classify it.
 #[cfg(unix)]
 async fn probe_daemon_health(client: &reqwest::Client, port: u16) -> DaemonHealth {
@@ -1640,7 +1728,7 @@ async fn probe_daemon_health(client: &reqwest::Client, port: u16) -> DaemonHealt
     {
         Ok(response) if response.status().is_success() => response,
         Ok(_) => return DaemonHealth::Unhealthy,
-        Err(_) => return DaemonHealth::Unhealthy,
+        Err(_) => return DaemonHealth::Unreachable,
     };
     let Ok(body) = response.json::<serde_json::Value>().await else {
         return DaemonHealth::Unhealthy;
@@ -1704,13 +1792,26 @@ async fn graceful_terminate(pid: u32, repo_root: &str, action: &str, reason: &st
 }
 
 /// Reap a daemon: graceful SIGTERM, then SIGKILL if it survives the grace window.
+/// The logged reason carries the evidence the decision rested on — the probe
+/// outcome plus the CPU-pinned and persisted-progress-stall streak counts — so an
+/// operator can see exactly why a daemon was judged rogue.
 #[cfg(unix)]
 async fn reap_daemon(observation: &DaemonObservation, reason: ReapReason) {
+    let probe = match observation.health {
+        DaemonHealth::Healthy(_) => "healthy",
+        DaemonHealth::Unhealthy => "answered-unhealthy",
+        DaemonHealth::Unreachable => "unreachable",
+        DaemonHealth::Unknown => "unknown",
+    };
+    let context = format!(
+        "{reason:?} (probe={probe}, cpu_pinned_sweeps={}, stall_sweeps={})",
+        observation.cpu_pinned_sweeps, observation.stall_sweeps
+    );
     graceful_terminate(
         observation.pid,
         &observation.repo_root,
         "reaping misbehaving repo daemon",
-        &format!("{reason:?}"),
+        &context,
     )
     .await;
 }
@@ -2010,6 +2111,7 @@ mod tests {
             orphaned,
             health,
             cpu_pinned_sweeps: 0,
+            stall_sweeps: 0,
             registry: RegistryRelation::RegisteredSelf,
             stale_binary: false,
         }
@@ -2062,14 +2164,76 @@ mod tests {
     }
 
     #[test]
+    fn reaper_reaps_answered_unhealthy_without_waiting_for_stall() {
+        // A daemon that ANSWERED with a broken response is genuinely broken, so it
+        // is reaped immediately — the stall window only guards the unreachable and
+        // CPU-pinned paths, not this one.
+        let policy = ReapPolicy::default();
+        let mut obs = observation(DaemonHealth::Unhealthy, true);
+        obs.stall_sweeps = 0;
+        assert_eq!(
+            classify_daemon(&obs, &policy),
+            DaemonDecision::Reap(ReapReason::OrphanedUnhealthy)
+        );
+    }
+
+    #[test]
+    fn reaper_keeps_orphaned_unreachable_without_stall() {
+        // Orphaned and unreachable (probe timed out / connection failed) but still
+        // making persisted progress: a busy daemon that missed a probe deadline is
+        // never reaped on the probe result alone.
+        let policy = ReapPolicy::default();
+        let mut obs = observation(DaemonHealth::Unreachable, true);
+        obs.stall_sweeps = REAPER_STALL_SWEEPS - 1;
+        assert_eq!(classify_daemon(&obs, &policy), DaemonDecision::Keep);
+    }
+
+    #[test]
+    fn reaper_reaps_orphaned_unreachable_when_stalled() {
+        // Orphaned, unreachable, AND no persisted progress across the full stall
+        // window: a wedged daemon, reaped.
+        let policy = ReapPolicy::default();
+        let mut obs = observation(DaemonHealth::Unreachable, true);
+        obs.stall_sweeps = REAPER_STALL_SWEEPS;
+        assert_eq!(
+            classify_daemon(&obs, &policy),
+            DaemonDecision::Reap(ReapReason::OrphanedUnreachableStalled)
+        );
+    }
+
+    #[test]
+    fn reaper_keeps_non_orphaned_unreachable_even_when_stalled() {
+        // A daemon with a live parent is never reaped by the safe criteria, even
+        // unreachable and stalled: its launching process still owns its lifecycle.
+        let policy = ReapPolicy::default();
+        let mut obs = observation(DaemonHealth::Unreachable, false);
+        obs.stall_sweeps = REAPER_STALL_SWEEPS;
+        assert_eq!(classify_daemon(&obs, &policy), DaemonDecision::Keep);
+    }
+
+    #[test]
     fn reaper_reaps_orphaned_idle_cpu_spinner() {
+        // CPU-pinned past threshold AND stalled (no persisted progress): a genuine
+        // busy-spinner, reaped.
         let policy = ReapPolicy::default();
         let mut obs = observation(healthy(false, false), true);
         obs.cpu_pinned_sweeps = REAPER_DEFAULT_CPU_PINNED_SWEEPS;
+        obs.stall_sweeps = REAPER_STALL_SWEEPS;
         assert_eq!(
             classify_daemon(&obs, &policy),
             DaemonDecision::Reap(ReapReason::OrphanedBusyNoClients)
         );
+    }
+
+    #[test]
+    fn reaper_keeps_progressing_cpu_spinner() {
+        // CPU-pinned past threshold but STILL advancing its log (stall_sweeps below
+        // the window): busy doing real work, never reaped.
+        let policy = ReapPolicy::default();
+        let mut obs = observation(healthy(false, false), true);
+        obs.cpu_pinned_sweeps = 99;
+        obs.stall_sweeps = REAPER_STALL_SWEEPS - 1;
+        assert_eq!(classify_daemon(&obs, &policy), DaemonDecision::Keep);
     }
 
     #[test]
@@ -2241,6 +2405,7 @@ mod tests {
         let mut obs = observation(healthy(false, false), true);
         obs.registry = RegistryRelation::Unregistered;
         obs.cpu_pinned_sweeps = REAPER_DEFAULT_CPU_PINNED_SWEEPS;
+        obs.stall_sweeps = REAPER_STALL_SWEEPS;
         assert_eq!(
             classify_daemon(&obs, &policy),
             DaemonDecision::Reap(ReapReason::OrphanedBusyNoClients)
@@ -2416,6 +2581,7 @@ mod tests {
         let policy = ReapPolicy::default();
         let mut obs = observation(healthy(false, false), true);
         obs.cpu_pinned_sweeps = REAPER_DEFAULT_CPU_PINNED_SWEEPS;
+        obs.stall_sweeps = REAPER_STALL_SWEEPS;
         obs.stale_binary = true;
         assert_eq!(
             classify_daemon(&obs, &policy),

--- a/crates/kin-git/src/import.rs
+++ b/crates/kin-git/src/import.rs
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 // Copyright 2026 Firelock, LLC
 
-use std::collections::HashSet;
+use std::collections::{HashMap, HashSet};
 use std::path::Path;
 
 use chrono::TimeZone;
@@ -574,6 +574,232 @@ fn blob_hash(
     Ok(Hash256::from_bytes(kin_blobs::digest(&content).0))
 }
 
+/// Deterministic id for the synthetic base-link change, derived from the import
+/// window base's first-parent Git OID.
+///
+/// A domain prefix distinct from `change_id_from_git_oid`'s keeps this id from
+/// ever colliding with a real imported commit's id — even if a later, wider
+/// import window brings that parent commit in-set and imports it directly.
+fn base_link_change_id_from_git_oid(oid: &gix::ObjectId) -> SemanticChangeId {
+    let mut hasher = Sha256::new();
+    hasher.update(b"kin-git-base-link-v1:");
+    hasher.update(oid.as_bytes());
+    let result = hasher.finalize();
+    let mut bytes = [0u8; 32];
+    bytes.copy_from_slice(&result);
+    SemanticChangeId::from_hash(Hash256::from_bytes(bytes))
+}
+
+/// Enumerate every blob in a tree as `(path, blob_oid)`, sorted by path.
+///
+/// Implemented as a diff of the tree against the empty tree (`None`), which
+/// yields one Addition per blob — the same machinery `commit_file_deltas` uses
+/// for a root commit. The explicit path sort makes the output a pure, stable
+/// function of the tree's content, independent of traversal order.
+fn full_tree_blob_entries(
+    repo: &gix::Repository,
+    tree: &gix::Tree<'_>,
+) -> Result<Vec<(String, gix::ObjectId)>> {
+    let options = gix::diff::Options::default().with_rewrites(None);
+    let changes = repo
+        .diff_tree_to_tree(None, Some(tree), Some(options))
+        .map_err(|e| GitError::Git(e.to_string()))?;
+
+    let mut entries = Vec::new();
+    for change in changes {
+        if let gix::object::tree::diff::ChangeDetached::Addition {
+            location,
+            entry_mode,
+            id,
+            ..
+        } = change
+        {
+            if entry_mode.is_blob() {
+                entries.push((location.to_string(), id));
+            }
+        }
+    }
+    entries.sort_by(|a, b| a.0.cmp(&b.0));
+    Ok(entries)
+}
+
+/// Anchor a (possibly truncated) imported history at a synthetic "base-link"
+/// change carrying the FULL file universe present at the import window's base.
+///
+/// # Why
+///
+/// `import_git_history_*` diffs every commit against its first parent, so a
+/// truncated window (`--git-history recent`, default 50 commits) records only
+/// the files each windowed commit *touched*. The oldest kept commit's own
+/// artifact deltas therefore cover just its changed files, never the whole tree
+/// it was built on. Semantic enrichment then links each commit against that
+/// touched-files-only universe, so a cross-file inbound edge whose *consumer*
+/// lives in a file untouched anywhere inside the window is never committed into
+/// any imported change — it exists only in live adjacency and the genesis
+/// auto-parse change, both of which sit *outside* every historical head's
+/// ancestry. Ref-scoped replay (`kin review shadow`, `locate --ref git:<oid>`)
+/// then reports blast radius 0 for entities whose only consumers are in those
+/// untouched files.
+///
+/// # What
+///
+/// This walks the complete Git tree at the window base's first parent — the
+/// state the window was built on — and inserts one root change carrying every
+/// base file as an Addition (`parents = [genesis_id]`), then re-points the
+/// window base's dangling first parent from `genesis_id` to this change. The
+/// subsequent semantic-enrichment pass (in `kin-cli`) then parses and links the
+/// whole base universe into the base-link change exactly as it does a true root
+/// commit, and forks each windowed commit's baseline from it,
+/// so every imported head inherits the base-era inbound edges and each commit's
+/// delta only records what it actually changed.
+///
+/// `changes` must be oldest-first, as returned by `import_git_history_*`.
+///
+/// Returns the inserted base-link change id, or `None` when no anchoring is
+/// needed: an empty import, or a full import whose oldest commit is a true Git
+/// root (its own artifact deltas already carry the entire tree).
+///
+/// # Determinism
+///
+/// The window base is found by a first-parent walk from the newest change (a
+/// pure function of the already-deterministic imported DAG). The base id is a
+/// hash of the base commit's parent OID. The base-link's artifact deltas are
+/// built in sorted-path order with content-addressed blob hashes, and its
+/// author/timestamp come from Git commit content, never wall-clock. The output
+/// is therefore byte-identical across runs for identical history + window.
+pub fn anchor_imported_history_at_base_link(
+    repo_path: &Path,
+    changes: &mut Vec<ImportedChange>,
+    genesis_id: SemanticChangeId,
+    blob_store: Option<&BlobStore>,
+) -> Result<Option<SemanticChangeId>> {
+    if changes.is_empty() {
+        return Ok(None);
+    }
+
+    // Map change id -> slice position so the first-parent walk stays in-set.
+    let index_by_id: HashMap<SemanticChangeId, usize> = changes
+        .iter()
+        .enumerate()
+        .map(|(i, ic)| (ic.change.id, i))
+        .collect();
+
+    // Window base = the oldest commit reachable from the import head (the newest
+    // change, last in oldest-first order) by following the FIRST parent while it
+    // stays inside the imported set. `close_truncated_history_dag` has already
+    // re-pointed the base's out-of-window first parent to `genesis_id`, so the
+    // walk halts there (or at a true root, whose first parent is also genesis).
+    let mut cursor = changes.len() - 1;
+    loop {
+        match changes[cursor].change.parents.first().copied() {
+            Some(pid) if pid != genesis_id => match index_by_id.get(&pid) {
+                Some(&next) => cursor = next,
+                // Dangling parent (should not occur post-close): treat as base.
+                None => break,
+            },
+            // First parent is genesis (re-pointed horizon or true root) or none.
+            _ => break,
+        }
+    }
+    let window_base_idx = cursor;
+
+    let repo = open_repo(repo_path).map_err(|e| GitError::Git(e.to_string()))?;
+
+    let base_git_oid = gix::ObjectId::from_hex(changes[window_base_idx].git_oid.as_bytes())
+        .map_err(|e| {
+            GitError::Git(format!(
+                "invalid git oid '{}': {}",
+                changes[window_base_idx].git_oid, e
+            ))
+        })?;
+    let base_commit = repo
+        .find_commit(base_git_oid)
+        .map_err(|e| GitError::CommitNotFound(format!("{base_git_oid}: {e}")))?;
+
+    // The state the window was built on is the base commit's FIRST parent tree.
+    // No first parent means this is a true Git root: a full import whose own
+    // deltas already carry the whole tree, so there is nothing to anchor.
+    let parent_oid = match base_commit.parent_ids().next() {
+        Some(pid) => pid.detach(),
+        None => return Ok(None),
+    };
+    let parent_commit = repo
+        .find_commit(parent_oid)
+        .map_err(|e| GitError::CommitNotFound(format!("{parent_oid}: {e}")))?;
+    let parent_tree = parent_commit
+        .tree()
+        .map_err(|e| GitError::Git(e.to_string()))?;
+
+    // Full base universe as Added artifact deltas, in stable path order. Blobs
+    // are materialized into the store so the semantic pass can read and parse
+    // them (mirrors how imported commits materialize their changed blobs).
+    let entries = full_tree_blob_entries(&repo, &parent_tree)?;
+    let mut artifact_deltas = Vec::with_capacity(entries.len());
+    for (path, blob_id) in entries {
+        let new_hash = blob_hash(&repo, blob_id, blob_store)?;
+        artifact_deltas.push(ArtifactDelta {
+            file_id: FilePathId::new(path),
+            kind: ArtifactDeltaKind::Added,
+            old_hash: None,
+            new_hash: Some(new_hash),
+        });
+    }
+
+    // Author/timestamp come from the base parent commit so the synthetic change
+    // is a pure function of Git content (no wall-clock), matching how
+    // `commit_to_change` derives them for every real imported commit.
+    let author_sig = parent_commit
+        .author()
+        .map_err(|e| GitError::Git(e.to_string()))?;
+    let author = AuthorId::new(format!("{} <{}>", author_sig.name, author_sig.email));
+    let git_time = author_sig
+        .time()
+        .map_err(|e| GitError::Git(e.to_string()))?;
+    let timestamp = Timestamp::from(
+        chrono::Utc
+            .timestamp_opt(git_time.seconds, 0)
+            .single()
+            .unwrap_or_else(chrono::Utc::now),
+    );
+
+    let base_id = base_link_change_id_from_git_oid(&parent_oid);
+    let base_change = SemanticChange {
+        id: base_id,
+        parents: vec![genesis_id],
+        timestamp,
+        author,
+        message: "kin import: base-link (window base universe)".to_string(),
+        entity_deltas: vec![],   // populated by the semantic enrichment pass
+        relation_deltas: vec![], // populated by the semantic enrichment pass
+        artifact_deltas,
+        projected_files: vec![],
+        spec_link: None,
+        evidence: vec![],
+        risk_summary: None,
+        authored_on: Some(BranchName::new("main")),
+    };
+
+    // Re-point the window base's first parent from genesis to the base-link so
+    // every head's first-parent ancestry now flows through the base universe.
+    if let Some(first) = changes[window_base_idx].change.parents.first_mut() {
+        if *first == genesis_id {
+            *first = base_id;
+        }
+    }
+
+    // Prepend: created before its child, and processed first by the topological
+    // enrichment pass (its own parent, genesis, is out of the imported set).
+    changes.insert(
+        0,
+        ImportedChange {
+            change: base_change,
+            git_oid: parent_oid.to_string(),
+        },
+    );
+
+    Ok(Some(base_id))
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -730,6 +956,163 @@ mod tests {
         assert_eq!(
             paths,
             vec![("alpha.txt".to_string(), ArtifactDeltaKind::Modified)]
+        );
+    }
+
+    #[test]
+    fn anchor_base_link_carries_full_base_tree_and_reparents_window_base() {
+        let dir = tempfile::tempdir().unwrap();
+        if !init_git_repo(dir.path()) {
+            eprintln!("git not available, skipping base-link anchor test");
+            return;
+        }
+
+        let commit = |msg: &str, epoch: i64| {
+            let stamp = format!("{epoch} +0000");
+            let _ = Command::new("git")
+                .args(["add", "."])
+                .current_dir(dir.path())
+                .output();
+            let _ = Command::new("git")
+                .args(["commit", "-m", msg])
+                .env("GIT_AUTHOR_DATE", &stamp)
+                .env("GIT_COMMITTER_DATE", &stamp)
+                .current_dir(dir.path())
+                .output();
+        };
+
+        // c1 (base, will fall OUTSIDE a 3-commit window): both files exist.
+        std::fs::write(dir.path().join("alpha.txt"), "a1\n").unwrap();
+        std::fs::write(dir.path().join("beta.txt"), "b1\n").unwrap();
+        commit("c1 base", 1_000_000_000);
+        // c2..c4: touch alpha.txt only — beta.txt is untouched across the window.
+        std::fs::write(dir.path().join("alpha.txt"), "a2\n").unwrap();
+        commit("c2", 1_000_000_100);
+        std::fs::write(dir.path().join("alpha.txt"), "a3\n").unwrap();
+        commit("c3", 1_000_000_200);
+        std::fs::write(dir.path().join("alpha.txt"), "a4\n").unwrap();
+        commit("c4", 1_000_000_300);
+
+        let blob_store = BlobStore::new(dir.path().join("kin-blobs")).unwrap();
+        let genesis_id = SemanticChangeId::from_hash(Hash256::from_bytes([0x33; 32]));
+        let mut imported = import_git_history_with_blobs(
+            dir.path(),
+            genesis_id,
+            &ImportOptions {
+                max_commits: 3,
+                ..Default::default()
+            },
+            Some(&blob_store),
+        )
+        .expect("git import should succeed");
+
+        // Truncated to the newest 3 commits (c2, c3, c4); c2's real parent (c1)
+        // is out of window, so beta.txt appears in NO windowed artifact delta.
+        assert_eq!(imported.len(), 3, "window should hold exactly 3 commits");
+        assert!(
+            imported
+                .iter()
+                .flat_map(|ic| ic.change.artifact_deltas.iter())
+                .all(|d| d.file_id.0 != "beta.txt"),
+            "pre-anchor: the untouched consumer file must not appear in any windowed commit"
+        );
+        let window_base_id = imported[0].change.id;
+        assert_eq!(
+            imported[0].change.parents,
+            vec![genesis_id],
+            "pre-anchor: window base's out-of-window parent is re-pointed to genesis"
+        );
+
+        let base_id = anchor_imported_history_at_base_link(
+            dir.path(),
+            &mut imported,
+            genesis_id,
+            Some(&blob_store),
+        )
+        .expect("anchoring should succeed")
+        .expect("a truncated window should yield a base-link change");
+
+        // The base-link is prepended, rooted at genesis, and carries the FULL
+        // base tree (both files) — including the untouched consumer beta.txt.
+        assert_eq!(imported.len(), 4, "base-link prepended to the window");
+        assert_eq!(imported[0].change.id, base_id);
+        assert_eq!(imported[0].change.parents, vec![genesis_id]);
+        let base_paths: Vec<(String, ArtifactDeltaKind)> = imported[0]
+            .change
+            .artifact_deltas
+            .iter()
+            .map(|d| (d.file_id.0.clone(), d.kind))
+            .collect();
+        assert_eq!(
+            base_paths,
+            vec![
+                ("alpha.txt".to_string(), ArtifactDeltaKind::Added),
+                ("beta.txt".to_string(), ArtifactDeltaKind::Added),
+            ],
+            "base-link must carry the full base universe as sorted Additions"
+        );
+
+        // The window base is re-parented off genesis onto the base-link, so
+        // every head's first-parent ancestry now flows through the base universe.
+        let reparented = imported
+            .iter()
+            .find(|ic| ic.change.id == window_base_id)
+            .expect("window base still present");
+        assert_eq!(
+            reparented.change.parents.first().copied(),
+            Some(base_id),
+            "window base's first parent must be re-pointed to the base-link"
+        );
+    }
+
+    #[test]
+    fn anchor_base_link_is_noop_for_full_import_true_root() {
+        let dir = tempfile::tempdir().unwrap();
+        if !init_git_repo(dir.path()) {
+            eprintln!("git not available, skipping base-link no-op test");
+            return;
+        }
+
+        std::fs::write(dir.path().join("alpha.txt"), "a1\n").unwrap();
+        std::fs::write(dir.path().join("beta.txt"), "b1\n").unwrap();
+        let _ = Command::new("git")
+            .args(["add", "."])
+            .current_dir(dir.path())
+            .output();
+        let _ = Command::new("git")
+            .args(["commit", "-m", "root"])
+            .env("GIT_AUTHOR_DATE", "1000000000 +0000")
+            .env("GIT_COMMITTER_DATE", "1000000000 +0000")
+            .current_dir(dir.path())
+            .output();
+
+        let blob_store = BlobStore::new(dir.path().join("kin-blobs")).unwrap();
+        let genesis_id = SemanticChangeId::from_hash(Hash256::from_bytes([0x44; 32]));
+        let mut imported = import_git_history_with_blobs(
+            dir.path(),
+            genesis_id,
+            &ImportOptions::default(),
+            Some(&blob_store),
+        )
+        .expect("git import should succeed");
+        let before = imported.len();
+
+        let result = anchor_imported_history_at_base_link(
+            dir.path(),
+            &mut imported,
+            genesis_id,
+            Some(&blob_store),
+        )
+        .expect("anchoring should succeed");
+
+        assert!(
+            result.is_none(),
+            "a full import whose oldest commit is a true Git root needs no base-link"
+        );
+        assert_eq!(
+            imported.len(),
+            before,
+            "no synthetic change should be added"
         );
     }
 

--- a/crates/kin-git/src/lib.rs
+++ b/crates/kin-git/src/lib.rs
@@ -21,6 +21,7 @@ pub use error::{GitError, Result};
 pub use export::{export_changes, export_to_git, ExportOptions, ExportResult};
 pub use genesis::is_genesis_change;
 pub use import::{
-    import_git_history, import_git_history_to_commit_with_blobs, import_git_history_with_blobs,
+    anchor_imported_history_at_base_link, import_git_history,
+    import_git_history_to_commit_with_blobs, import_git_history_with_blobs,
     semantic_change_id_from_git_oid_hex, ImportOptions, ImportedChange,
 };

--- a/crates/kin-index/src/linker.rs
+++ b/crates/kin-index/src/linker.rs
@@ -410,10 +410,30 @@ fn resolve_one_file(file: &FileParseData, ctx: &LinkContext<'_>) -> Vec<Relation
             continue;
         }
 
-        // (a) Same-file resolution
+        // (a) Same-file resolution. A same-file entity still wins and is emitted
+        // first at full confidence, but it is frequently a declaration/prototype
+        // whose definition lives in another file; when cross-file entities share
+        // the exact name, also fan out to them (bounded so the same-file target
+        // plus its cross-file twins stay within the cap) so the real definition
+        // is linked, not just the local stub. Cross-file twins are name-inferred,
+        // so they carry the (c) name-match confidence (0.7), below the
+        // parser-certain same-file edge (1.0).
         if let Some(&dst_id) = dst_same_file {
             if add_deduped(&mut seen, src_id, dst_id, rel.kind) {
                 resolved.push(make_relation(rel.kind, src_id, dst_id, 1.0));
+            }
+            let mut cross_file_twins: HashSet<EntityId> = HashSet::new();
+            distinct_cross_file_targets(
+                ctx.entity_by_name.get(rel.dst_name.as_str()),
+                file.file_path.as_str(),
+                &mut cross_file_twins,
+            );
+            if !cross_file_twins.is_empty() && cross_file_twins.len() < AMBIGUOUS_CALL_FANOUT_CAP {
+                for cross_id in sorted_fanout_targets(cross_file_twins) {
+                    if add_deduped(&mut seen, src_id, cross_id, rel.kind) {
+                        resolved.push(make_relation(rel.kind, src_id, cross_id, 0.7));
+                    }
+                }
             }
             continue;
         }
@@ -551,10 +571,12 @@ fn resolve_one_file(file: &FileParseData, ctx: &LinkContext<'_>) -> Vec<Relation
 
         // (c2) Receiver-method calls (`x.method()`) arrive as the bare method
         // name and never match (b)'s `Type::method` key. Resolve them through
-        // the bare-name index only when unambiguous — exactly one method of
-        // that name in another file. Ambiguous names (`new`, `run`, `get`) have
-        // an unknowable receiver type, so linking every candidate would mint
-        // spurious callers; leave those to the inconclusive-absence gate.
+        // the bare-name index. A single distinct cross-file method links as
+        // before; when several implementor classes define the name — virtual
+        // dispatch has an unknowable receiver type — fan out to all of them up
+        // to the cap so every plausible dispatch target is counted rather than
+        // dropped. Beyond the cap the name is too ubiquitous to guess, so it
+        // stays unlinked for the inconclusive-absence gate.
         if name_fallback_allowed && !linked && !bare_candidates.is_empty() {
             let mut distinct_targets: HashSet<EntityId> = HashSet::new();
             for &(fp, dst_id) in bare_candidates {
@@ -562,11 +584,12 @@ fn resolve_one_file(file: &FileParseData, ctx: &LinkContext<'_>) -> Vec<Relation
                     distinct_targets.insert(dst_id);
                 }
             }
-            if distinct_targets.len() == 1 {
-                let dst_id = *distinct_targets.iter().next().expect("len checked == 1");
-                if add_deduped(&mut seen, src_id, dst_id, rel.kind) {
-                    resolved.push(make_relation(rel.kind, src_id, dst_id, 0.3));
-                    linked = true;
+            if (1..=AMBIGUOUS_CALL_FANOUT_CAP).contains(&distinct_targets.len()) {
+                for dst_id in sorted_fanout_targets(distinct_targets) {
+                    if add_deduped(&mut seen, src_id, dst_id, rel.kind) {
+                        resolved.push(make_relation(rel.kind, src_id, dst_id, 0.3));
+                        linked = true;
+                    }
                 }
             }
         }
@@ -581,7 +604,9 @@ fn resolve_one_file(file: &FileParseData, ctx: &LinkContext<'_>) -> Vec<Relation
             && !linked
             && matches!(rel.kind, RelationKind::Calls | RelationKind::References)
         {
-            if let Some(dst_id) =
+            // Fan out: an ambiguous qualified leaf resolves to every distinct
+            // cross-file target (overloads / amalgamated copies), not just one.
+            for dst_id in
                 resolve_qualified_suffix(rel.dst_name.as_str(), file.file_path.as_str(), ctx)
             {
                 if add_deduped(&mut seen, src_id, dst_id, rel.kind) {
@@ -956,11 +981,13 @@ fn split_member_access(name: &str) -> Option<(&str, &str)> {
 }
 
 /// Confidence for a call/reference edge resolved by reducing a path-qualified
-/// callee (`crate::mod::func`, `Type::method`, `alias::Type::method`) to a unique
-/// local entity via suffix matching. Inferred: the module/crate prefix is dropped
-/// before matching, so it ranks below an import-verified edge (0.95) yet above the
-/// ambiguous receiver-method guess (0.3) because the suffix match is required to
-/// be unambiguous.
+/// callee (`crate::mod::func`, `Type::method`, `alias::Type::method`) to local
+/// entities via suffix matching. Inferred: the module/crate prefix is dropped
+/// before matching, so it ranks below an import-verified edge (0.95) yet above
+/// the ambiguous receiver-method guess (0.3). A single suffix target and a
+/// fanned-out set of ambiguous ones share this confidence: every emitted target
+/// is a real definition the suffix genuinely names, so the resolution quality is
+/// the same whether one target or several survive.
 const QUALIFIED_SUFFIX_CONFIDENCE: f32 = 0.6;
 
 /// Whether a `::`-path segment is a plain Rust identifier (`crate`, `self`,
@@ -975,6 +1002,20 @@ fn is_path_identifier(seg: &str) -> bool {
     }
     chars.all(|c| c == '_' || c.is_alphanumeric())
 }
+
+/// Upper bound on how many ambiguous same-name targets one call or reference
+/// may fan out to.
+///
+/// A virtual-dispatch method call, a set of overloads, or a
+/// declaration/definition split has several equally-plausible definitions.
+/// Linking every one keeps the caller visible in refs/impact instead of
+/// silently dropping the edge when the target cannot be pinned to exactly one.
+/// The cap bounds that over-approximation: a ubiquitous leaf name (`new`,
+/// `get`, `run`) can occur in dozens of files, and fanning out to all of them
+/// would flood the graph with low-value guesses. At or below the cap every
+/// distinct candidate is linked; above it the resolver stays silent rather than
+/// emit a wall of edges.
+const AMBIGUOUS_CALL_FANOUT_CAP: usize = 8;
 
 /// Collect the distinct target entity ids among `candidates` that live in a file
 /// other than `current_file`.
@@ -992,6 +1033,19 @@ fn distinct_cross_file_targets(
     }
 }
 
+/// Order a fanned-out target set deterministically before emitting relations.
+///
+/// Fan-out gathers candidates into a `HashSet`, whose iteration order is not
+/// stable across processes. Sorting by [`EntityId`] — content-derived, hence
+/// reproducible — fixes the emitted relation order so a re-run is byte-stable
+/// and the batch and incremental linkers emit identical edges for identical
+/// input.
+fn sorted_fanout_targets(targets: HashSet<EntityId>) -> Vec<EntityId> {
+    let mut ids: Vec<EntityId> = targets.into_iter().collect();
+    ids.sort_unstable();
+    ids
+}
+
 /// Resolve a Rust-style path-qualified call/reference target to a unique local
 /// entity by matching the path's resolvable suffixes against the entity indices.
 ///
@@ -1006,19 +1060,24 @@ fn distinct_cross_file_targets(
 ///   2. the bare leaf `func`/`method`, which resolves a module-qualified free
 ///      function (`crate::work::run`) and receiver methods stored bare.
 ///
-/// It links only when exactly one distinct target entity exists in a file other
-/// than the caller's. Ambiguous suffixes (more than one distinct target) resolve
-/// to `None` and are logged — a missing edge is preferred over a wrong one.
+/// Returns every distinct cross-file target the suffix can name, in a
+/// deterministic order; an empty vector is an honest miss. The type-qualified
+/// suffix is precise, so it resolves a single target and stops (empty) when it
+/// is itself ambiguous — widening to the bare leaf would be less precise, not
+/// more. The bare leaf is the ambiguous tier: when it names several cross-file
+/// targets (overloads, or amalgamated header copies of one symbol) it fans out
+/// to all of them, bounded by [`AMBIGUOUS_CALL_FANOUT_CAP`]; beyond the cap it
+/// stays silent and is logged — a wall of guesses is worse than a missing edge.
 fn resolve_qualified_suffix(
     dst_name: &str,
     current_file: &str,
     ctx: &LinkContext<'_>,
-) -> Option<EntityId> {
+) -> Vec<EntityId> {
     let segments: Vec<&str> = dst_name.split("::").collect();
     // Must be a genuine `::` path of identifier-like segments. Rejects bare names
     // (handled by (c)/(c2)), leading/trailing `::`, and turbofish/exotic forms.
     if segments.len() < 2 || !segments.iter().all(|s| is_path_identifier(s)) {
-        return None;
+        return Vec::new();
     }
     let last = segments[segments.len() - 1];
 
@@ -1034,7 +1093,7 @@ fn resolve_qualified_suffix(
         &mut tq_targets,
     );
     match tq_targets.len() {
-        1 => return tq_targets.into_iter().next(),
+        1 => return tq_targets.into_iter().collect(),
         n if n > 1 => {
             debug!(
                 dst = %dst_name,
@@ -1042,14 +1101,15 @@ fn resolve_qualified_suffix(
                 count = n,
                 "linker: ambiguous type-qualified suffix, leaving unresolved"
             );
-            return None;
+            return Vec::new();
         }
         _ => {}
     }
 
     // Tier 2: bare leaf. Free functions live in `entity_by_name` under `last`;
-    // methods live in `entity_by_bare_name` under `last`. Union both and require
-    // a single distinct target.
+    // methods live in `entity_by_bare_name` under `last`. Union both, then fan
+    // out to every distinct cross-file target up to the cap so overload sets and
+    // amalgamated duplicate definitions all link instead of dropping the edge.
     let mut leaf_targets: HashSet<EntityId> = HashSet::new();
     distinct_cross_file_targets(
         ctx.entity_by_name.get(last),
@@ -1062,32 +1122,34 @@ fn resolve_qualified_suffix(
         &mut leaf_targets,
     );
     match leaf_targets.len() {
-        1 => leaf_targets.into_iter().next(),
-        0 => None,
+        0 => Vec::new(),
+        n if n <= AMBIGUOUS_CALL_FANOUT_CAP => sorted_fanout_targets(leaf_targets),
         n => {
             debug!(
                 dst = %dst_name,
                 leaf = %last,
                 count = n,
-                "linker: ambiguous qualified-call leaf, leaving unresolved"
+                "linker: qualified-call leaf beyond fan-out cap, leaving unresolved"
             );
-            None
+            Vec::new()
         }
     }
 }
 
-/// Incremental-linker counterpart of [`resolve_qualified_suffix`]. The
-/// incremental index keys entities by their owned simple name and carries no
-/// bare-name index, so only the type-qualified suffix (`Type::method`) and the
-/// bare leaf free-function name are matched; ambiguous suffixes stay unresolved.
+/// Incremental-linker counterpart of [`resolve_qualified_suffix`], kept in exact
+/// resolution parity with it: the type-qualified suffix (`Type::method`) resolves
+/// a single target or stops on ambiguity, and the bare leaf unions the
+/// simple-name and bare-name indices, then fans out to every distinct cross-file
+/// target up to [`AMBIGUOUS_CALL_FANOUT_CAP`]. Returns the targets in the same
+/// deterministic order as the batch resolver; an empty vector is an honest miss.
 fn resolve_qualified_suffix_incremental(
     dst_name: &str,
     current_file: &str,
     linker: &IncrementalLinker,
-) -> Option<EntityId> {
+) -> Vec<EntityId> {
     let segments: Vec<&str> = dst_name.split("::").collect();
     if segments.len() < 2 || !segments.iter().all(|s| is_path_identifier(s)) {
-        return None;
+        return Vec::new();
     }
     let last = segments[segments.len() - 1];
 
@@ -1102,7 +1164,7 @@ fn resolve_qualified_suffix_incremental(
         }
     }
     match tq_targets.len() {
-        1 => return tq_targets.into_iter().next(),
+        1 => return tq_targets.into_iter().collect(),
         n if n > 1 => {
             debug!(
                 dst = %dst_name,
@@ -1110,15 +1172,15 @@ fn resolve_qualified_suffix_incremental(
                 count = n,
                 "linker(incremental): ambiguous type-qualified suffix, leaving unresolved"
             );
-            return None;
+            return Vec::new();
         }
         _ => {}
     }
 
-    // Tier 2: bare leaf (free functions) resolved through `entity_by_name`. A
-    // qualified path whose leaf is a receiver method (`Type::method`) is not in
-    // `entity_by_name` under the bare leaf; those are resolved by the caller's
-    // (c2) bare-name step via `entity_by_bare_name`, not here.
+    // Tier 2: bare leaf. Free functions live in `entity_by_name` under `last`;
+    // methods live in `entity_by_bare_name` under `last`. Union both so the
+    // incremental linker resolves the same leaf targets as the batch resolver,
+    // then fan out to every distinct cross-file target up to the cap.
     let mut leaf_targets: HashSet<EntityId> = HashSet::new();
     if let Some(cands) = linker.entity_by_name.get(last) {
         for (fp, id) in cands {
@@ -1127,17 +1189,24 @@ fn resolve_qualified_suffix_incremental(
             }
         }
     }
+    if let Some(cands) = linker.entity_by_bare_name.get(last) {
+        for (fp, id) in cands {
+            if fp != current_file {
+                leaf_targets.insert(*id);
+            }
+        }
+    }
     match leaf_targets.len() {
-        1 => leaf_targets.into_iter().next(),
-        0 => None,
+        0 => Vec::new(),
+        n if n <= AMBIGUOUS_CALL_FANOUT_CAP => sorted_fanout_targets(leaf_targets),
         n => {
             debug!(
                 dst = %dst_name,
                 leaf = %last,
                 count = n,
-                "linker(incremental): ambiguous qualified-call leaf, leaving unresolved"
+                "linker(incremental): qualified-call leaf beyond fan-out cap, leaving unresolved"
             );
-            None
+            Vec::new()
         }
     }
 }
@@ -2274,10 +2343,32 @@ pub fn link_cross_file_incremental(
                 continue;
             }
 
-            // (a) Same-file resolution
+            // (a) Same-file resolution. Mirrors the batch linker: the same-file
+            // entity wins and is emitted first at full confidence, but when
+            // cross-file entities share the exact name (a declaration/prototype
+            // whose definition lives elsewhere) also fan out to them, bounded so
+            // the same-file target plus its cross-file twins stay within the cap.
+            // Cross-file twins carry the (c) name-match confidence (0.7).
             if let Some(dst_id) = dst_same_file {
                 if add_deduped(&mut seen, src_id, dst_id, rel.kind) {
                     resolved.push(make_relation(rel.kind, src_id, dst_id, 1.0));
+                }
+                let mut cross_file_twins: HashSet<EntityId> = HashSet::new();
+                if let Some(candidates) = linker.entity_by_name.get(&rel.dst_name) {
+                    for (fp, id) in candidates {
+                        if fp != &file.file_path {
+                            cross_file_twins.insert(*id);
+                        }
+                    }
+                }
+                if !cross_file_twins.is_empty()
+                    && cross_file_twins.len() < AMBIGUOUS_CALL_FANOUT_CAP
+                {
+                    for cross_id in sorted_fanout_targets(cross_file_twins) {
+                        if add_deduped(&mut seen, src_id, cross_id, rel.kind) {
+                            resolved.push(make_relation(rel.kind, src_id, cross_id, 0.7));
+                        }
+                    }
                 }
                 continue;
             }
@@ -2423,14 +2514,14 @@ pub fn link_cross_file_incremental(
 
             // (c2) Receiver-method calls (`x.method()`) arrive as the bare method
             // name with no exact cross-file entity of that name, so (c) above
-            // never fires. Resolve them through the bare-name index only when
-            // unambiguous — exactly one method of that name in another file —
-            // mirroring the batch linker's (c2). Ambiguous names have an
-            // unknowable receiver type, so linking every candidate would mint
-            // spurious callers; leave those unresolved. This is the incremental
-            // counterpart the batch resolver already had; without it a receiver
-            // method resolved into a full-tree snapshot is dropped the moment an
-            // incremental relink of the caller re-derives its edges.
+            // never fires. Resolve them through the bare-name index, mirroring
+            // the batch linker's (c2): a single distinct cross-file method links,
+            // and several implementor classes fan out to all of them up to the
+            // cap (virtual dispatch has an unknowable receiver type). Beyond the
+            // cap the name is too ubiquitous to guess and stays unresolved.
+            // Without this step a receiver method resolved into a full-tree
+            // snapshot is dropped the moment an incremental relink of the caller
+            // re-derives its edges.
             if name_fallback_allowed && rel.kind == RelationKind::Calls {
                 if let Some(bare_candidates) = linker.entity_by_bare_name.get(rel.dst_name.as_str())
                 {
@@ -2439,10 +2530,11 @@ pub fn link_cross_file_incremental(
                         .filter(|(fp, _)| fp != &file.file_path)
                         .map(|(_, id)| *id)
                         .collect();
-                    if distinct_targets.len() == 1 {
-                        let dst_id = *distinct_targets.iter().next().expect("len checked == 1");
-                        if add_deduped(&mut seen, src_id, dst_id, rel.kind) {
-                            resolved.push(make_relation(rel.kind, src_id, dst_id, 0.3));
+                    if (1..=AMBIGUOUS_CALL_FANOUT_CAP).contains(&distinct_targets.len()) {
+                        for dst_id in sorted_fanout_targets(distinct_targets) {
+                            if add_deduped(&mut seen, src_id, dst_id, rel.kind) {
+                                resolved.push(make_relation(rel.kind, src_id, dst_id, 0.3));
+                            }
                         }
                         continue;
                     }
@@ -2455,16 +2547,20 @@ pub fn link_cross_file_incremental(
             if name_fallback_allowed
                 && matches!(rel.kind, RelationKind::Calls | RelationKind::References)
             {
-                if let Some(dst_id) =
-                    resolve_qualified_suffix_incremental(&rel.dst_name, &file.file_path, linker)
-                {
-                    if add_deduped(&mut seen, src_id, dst_id, rel.kind) {
-                        resolved.push(make_relation(
-                            rel.kind,
-                            src_id,
-                            dst_id,
-                            QUALIFIED_SUFFIX_CONFIDENCE,
-                        ));
+                // Fan out: an ambiguous qualified leaf resolves to every distinct
+                // cross-file target, matching the batch resolver.
+                let qualified_targets =
+                    resolve_qualified_suffix_incremental(&rel.dst_name, &file.file_path, linker);
+                if !qualified_targets.is_empty() {
+                    for dst_id in qualified_targets {
+                        if add_deduped(&mut seen, src_id, dst_id, rel.kind) {
+                            resolved.push(make_relation(
+                                rel.kind,
+                                src_id,
+                                dst_id,
+                                QUALIFIED_SUFFIX_CONFIDENCE,
+                            ));
+                        }
                     }
                     continue;
                 }
@@ -3293,10 +3389,12 @@ void f();
     }
 
     #[test]
-    fn receiver_method_call_skipped_when_bare_name_ambiguous() {
-        // A call to bare `new` could target either `Foo::new` or `Bar::new`; the
-        // receiver type is unknowable from the name, so linking to either would mint
-        // a spurious caller. Leave it unlinked for the inconclusive gate.
+    fn receiver_method_call_fans_out_to_all_implementors() {
+        // A call to bare `new` could target either `Foo::new` or `Bar::new`. The
+        // receiver type is unknowable from the name, so rather than drop the edge
+        // the resolver fans out to every implementor (bounded by the cap): both
+        // `Foo::new` and `Bar::new` link, keeping the caller visible in refs.
+        // (Updated from the old refuse-on-ambiguity contract.)
         let caller = make_entity("build", "src/caller.rs");
         let foo_new = make_entity("Foo::new", "src/foo.rs");
         let bar_new = make_entity("Bar::new", "src/bar.rs");
@@ -3315,27 +3413,33 @@ void f();
             },
             FileParseData {
                 file_path: "src/foo.rs".to_string(),
-                entities: vec![foo_new],
+                entities: vec![foo_new.clone()],
                 relations: vec![],
                 imports: vec![],
             },
             FileParseData {
                 file_path: "src/bar.rs".to_string(),
-                entities: vec![bar_new],
+                entities: vec![bar_new.clone()],
                 relations: vec![],
                 imports: vec![],
             },
         ];
 
         let result = link_cross_file(&files);
-        let calls = result
+        let calls: Vec<&Relation> = result
             .iter()
-            .filter(|r| r.kind == RelationKind::Calls)
-            .count();
+            .filter(|r| r.kind == RelationKind::Calls && r.src == GraphNodeId::Entity(caller.id))
+            .collect();
+        let targets: HashSet<GraphNodeId> = calls.iter().map(|r| r.dst).collect();
         assert_eq!(
-            calls, 0,
-            "ambiguous bare-name receiver call must not link to any candidate, got {calls} edges"
+            targets.len(),
+            2,
+            "ambiguous bare-name receiver call must fan out to both implementors, got {targets:?}"
         );
+        assert!(targets.contains(&GraphNodeId::Entity(foo_new.id)));
+        assert!(targets.contains(&GraphNodeId::Entity(bar_new.id)));
+        // Fan-out edges keep the ambiguous receiver-method confidence.
+        assert!(calls.iter().all(|r| r.confidence == 0.3));
     }
 
     #[test]
@@ -3373,11 +3477,11 @@ void f();
     }
 
     #[test]
-    fn incremental_receiver_method_call_skipped_when_bare_name_ambiguous() {
-        // Incremental (c2) parity with `receiver_method_call_skipped_when_bare_name_ambiguous`:
-        // bare `new` could be `Foo::new` or `Bar::new`; the receiver type is
-        // unknowable, so it must stay unlinked (matching the batch resolver's
-        // conservatism — no spurious callers).
+    fn incremental_receiver_method_call_fans_out_to_all_implementors() {
+        // Incremental (c2) parity with `receiver_method_call_fans_out_to_all_implementors`:
+        // bare `new` could be `Foo::new` or `Bar::new`; both implementors link,
+        // matching the batch resolver's fan-out. (Updated from the old
+        // refuse-on-ambiguity contract.)
         let caller = make_entity("build", "src/caller.rs");
         let foo_new = make_entity("Foo::new", "src/foo.rs");
         let bar_new = make_entity("Bar::new", "src/bar.rs");
@@ -3400,14 +3504,18 @@ void f();
         }];
 
         let result = link_cross_file_incremental(&files, &linker);
-        let calls = result
+        let targets: HashSet<GraphNodeId> = result
             .iter()
-            .filter(|r| r.kind == RelationKind::Calls)
-            .count();
+            .filter(|r| r.kind == RelationKind::Calls && r.src == GraphNodeId::Entity(caller.id))
+            .map(|r| r.dst)
+            .collect();
         assert_eq!(
-            calls, 0,
-            "incremental ambiguous bare-name receiver call must not link, got {calls} edges"
+            targets.len(),
+            2,
+            "incremental ambiguous bare-name receiver call must fan out to both implementors, got {targets:?}"
         );
+        assert!(targets.contains(&GraphNodeId::Entity(foo_new.id)));
+        assert!(targets.contains(&GraphNodeId::Entity(bar_new.id)));
     }
 
     #[test]
@@ -4121,12 +4229,15 @@ void f();
     }
 
     #[test]
-    fn ambiguous_qualified_leaf_leaves_unresolved() {
-        // Two distinct free fns named `run` in different files; the qualified
-        // call cannot be pinned to one -> conservative miss (no wrong edge).
+    fn qualified_leaf_fans_out_to_all_overloads() {
+        // Three distinct free fns named `run` in different files (overloads /
+        // amalgamated copies of one symbol). The qualified call's leaf cannot be
+        // pinned to one, so it fans out to all three rather than dropping the
+        // edge. (Updated from the old refuse-on-ambiguity contract.)
         let caller = rust_fn("caller", "src/caller.rs");
         let run_a = rust_fn("run", "src/a.rs");
         let run_b = rust_fn("run", "src/b.rs");
+        let run_c = rust_fn("run", "src/c.rs");
 
         let files = vec![
             FileParseData {
@@ -4147,17 +4258,25 @@ void f();
                 relations: vec![],
                 imports: vec![],
             },
+            FileParseData {
+                file_path: "src/c.rs".to_string(),
+                entities: vec![run_c.clone()],
+                relations: vec![],
+                imports: vec![],
+            },
         ];
 
         let result = link_cross_file(&files);
-        assert!(
-            result.iter().all(|r| r.kind != RelationKind::Calls),
-            "ambiguous qualified leaf must not mint a Calls edge, got {:?}",
-            result
-                .iter()
-                .filter(|r| r.kind == RelationKind::Calls)
-                .collect::<Vec<_>>()
-        );
+        for target in [&run_a, &run_b, &run_c] {
+            let edge = find_calls_edge(&result, &caller, target)
+                .expect("qualified leaf must fan out to every overload");
+            assert_eq!(edge.confidence, QUALIFIED_SUFFIX_CONFIDENCE);
+        }
+        let count = result
+            .iter()
+            .filter(|r| r.kind == RelationKind::Calls)
+            .count();
+        assert_eq!(count, 3, "exactly the three overloads should link");
     }
 
     #[test]
@@ -4281,15 +4400,20 @@ void f();
     }
 
     #[test]
-    fn incremental_linker_ambiguous_qualified_leaf_is_miss() {
+    fn incremental_qualified_leaf_fans_out_to_all_overloads() {
+        // Incremental parity with `qualified_leaf_fans_out_to_all_overloads`:
+        // the qualified leaf fans out to all three overloads. (Updated from the
+        // old refuse-on-ambiguity contract.)
         let caller = rust_fn("caller", "src/caller.rs");
         let run_a = rust_fn("run", "src/a.rs");
         let run_b = rust_fn("run", "src/b.rs");
+        let run_c = rust_fn("run", "src/c.rs");
 
         let mut linker = IncrementalLinker::new();
         linker.add_file("src/caller.rs", std::slice::from_ref(&caller));
         linker.add_file("src/a.rs", std::slice::from_ref(&run_a));
         linker.add_file("src/b.rs", std::slice::from_ref(&run_b));
+        linker.add_file("src/c.rs", std::slice::from_ref(&run_c));
 
         let files = vec![FileParseData {
             file_path: "src/caller.rs".to_string(),
@@ -4299,10 +4423,332 @@ void f();
         }];
 
         let result = link_cross_file_incremental(&files, &linker);
-        assert!(
-            result.iter().all(|r| r.kind != RelationKind::Calls),
-            "incremental ambiguous qualified leaf must not mint a Calls edge"
+        for target in [&run_a, &run_b, &run_c] {
+            assert!(
+                find_calls_edge(&result, &caller, target).is_some(),
+                "incremental qualified leaf must fan out to every overload"
+            );
+        }
+        let count = result
+            .iter()
+            .filter(|r| r.kind == RelationKind::Calls)
+            .count();
+        assert_eq!(count, 3, "exactly the three overloads should link");
+    }
+
+    #[test]
+    fn qualified_leaf_fanout_respects_cap() {
+        // A qualified call whose leaf `run` has `n` distinct cross-file targets:
+        // at the cap every target links; one beyond the cap it stays unresolved.
+        let calls_for = |n: usize| -> usize {
+            let caller = rust_fn("caller", "src/caller.rs");
+            let mut files = vec![FileParseData {
+                file_path: "src/caller.rs".to_string(),
+                entities: vec![caller],
+                relations: vec![calls_relation("caller", "crate::somewhere::run")],
+                imports: vec![],
+            }];
+            for i in 0..n {
+                let path = format!("src/t{i}.rs");
+                files.push(FileParseData {
+                    file_path: path.clone(),
+                    entities: vec![rust_fn("run", &path)],
+                    relations: vec![],
+                    imports: vec![],
+                });
+            }
+            link_cross_file(&files)
+                .iter()
+                .filter(|r| r.kind == RelationKind::Calls)
+                .count()
+        };
+
+        assert_eq!(
+            calls_for(AMBIGUOUS_CALL_FANOUT_CAP),
+            AMBIGUOUS_CALL_FANOUT_CAP,
+            "at the cap every distinct target links"
         );
+        assert_eq!(
+            calls_for(AMBIGUOUS_CALL_FANOUT_CAP + 1),
+            0,
+            "above the cap the qualified leaf stays unresolved"
+        );
+    }
+
+    #[test]
+    fn receiver_method_fanout_respects_cap() {
+        // A bare receiver-method call `make` with `n` distinct implementor
+        // methods: at the cap every implementor links; beyond it, none do.
+        let calls_for = |n: usize| -> usize {
+            let caller = make_entity("build", "src/caller.rs");
+            let mut files = vec![FileParseData {
+                file_path: "src/caller.rs".to_string(),
+                entities: vec![caller],
+                relations: vec![calls_relation("build", "make")],
+                imports: vec![],
+            }];
+            for i in 0..n {
+                let path = format!("src/impl{i}.rs");
+                files.push(FileParseData {
+                    file_path: path.clone(),
+                    entities: vec![make_entity(&format!("Impl{i}::make"), &path)],
+                    relations: vec![],
+                    imports: vec![],
+                });
+            }
+            link_cross_file(&files)
+                .iter()
+                .filter(|r| r.kind == RelationKind::Calls)
+                .count()
+        };
+
+        assert_eq!(
+            calls_for(AMBIGUOUS_CALL_FANOUT_CAP),
+            AMBIGUOUS_CALL_FANOUT_CAP,
+            "at the cap every implementor links"
+        );
+        assert_eq!(
+            calls_for(AMBIGUOUS_CALL_FANOUT_CAP + 1),
+            0,
+            "above the cap the receiver-method call stays unresolved"
+        );
+    }
+
+    #[test]
+    fn same_file_prototype_and_cross_file_definition_both_link() {
+        // The caller's own file declares a prototype `compute`; the definition
+        // lives in another file. (a) links the same-file prototype at full
+        // confidence and (D) also fans out to the cross-file definition, so the
+        // real definition is not dropped onto the local stub.
+        let caller = rust_fn("run_caller", "src/caller.rs");
+        let prototype = rust_fn("compute", "src/caller.rs");
+        let definition = rust_fn("compute", "src/impl.rs");
+
+        let files = vec![
+            FileParseData {
+                file_path: "src/caller.rs".to_string(),
+                entities: vec![caller.clone(), prototype.clone()],
+                relations: vec![calls_relation("run_caller", "compute")],
+                imports: vec![],
+            },
+            FileParseData {
+                file_path: "src/impl.rs".to_string(),
+                entities: vec![definition.clone()],
+                relations: vec![],
+                imports: vec![],
+            },
+        ];
+
+        let result = link_cross_file(&files);
+        let same_file = find_calls_edge(&result, &caller, &prototype)
+            .expect("same-file prototype must still link");
+        assert_eq!(same_file.confidence, 1.0);
+        let cross_file = find_calls_edge(&result, &caller, &definition)
+            .expect("cross-file definition must also link");
+        assert_eq!(cross_file.confidence, 0.7);
+    }
+
+    #[test]
+    fn incremental_same_file_prototype_and_cross_file_definition_both_link() {
+        // Incremental parity with
+        // `same_file_prototype_and_cross_file_definition_both_link`.
+        let caller = rust_fn("run_caller", "src/caller.rs");
+        let prototype = rust_fn("compute", "src/caller.rs");
+        let definition = rust_fn("compute", "src/impl.rs");
+
+        let mut linker = IncrementalLinker::new();
+        linker.add_file("src/caller.rs", &[caller.clone(), prototype.clone()]);
+        linker.add_file("src/impl.rs", std::slice::from_ref(&definition));
+
+        let files = vec![FileParseData {
+            file_path: "src/caller.rs".to_string(),
+            entities: vec![caller.clone(), prototype.clone()],
+            relations: vec![calls_relation("run_caller", "compute")],
+            imports: vec![],
+        }];
+
+        let result = link_cross_file_incremental(&files, &linker);
+        let same_file = find_calls_edge(&result, &caller, &prototype)
+            .expect("same-file prototype must still link");
+        assert_eq!(same_file.confidence, 1.0);
+        let cross_file = find_calls_edge(&result, &caller, &definition)
+            .expect("cross-file definition must also link");
+        assert_eq!(cross_file.confidence, 0.7);
+    }
+
+    #[test]
+    fn fanout_relation_order_is_deterministic() {
+        // The qualified-leaf fan-out orders targets by EntityId, so repeated runs
+        // and a reordered universe both yield identically ordered edges — no
+        // HashSet iteration order leaks into the output.
+        let caller = rust_fn("caller", "src/caller.rs");
+        let run_a = rust_fn("run", "src/a.rs");
+        let run_b = rust_fn("run", "src/b.rs");
+        let run_c = rust_fn("run", "src/c.rs");
+
+        let make_files = || {
+            vec![
+                FileParseData {
+                    file_path: "src/caller.rs".to_string(),
+                    entities: vec![caller.clone()],
+                    relations: vec![calls_relation("caller", "crate::somewhere::run")],
+                    imports: vec![],
+                },
+                FileParseData {
+                    file_path: "src/a.rs".to_string(),
+                    entities: vec![run_a.clone()],
+                    relations: vec![],
+                    imports: vec![],
+                },
+                FileParseData {
+                    file_path: "src/b.rs".to_string(),
+                    entities: vec![run_b.clone()],
+                    relations: vec![],
+                    imports: vec![],
+                },
+                FileParseData {
+                    file_path: "src/c.rs".to_string(),
+                    entities: vec![run_c.clone()],
+                    relations: vec![],
+                    imports: vec![],
+                },
+            ]
+        };
+
+        let calls_order = |result: &[Relation]| -> Vec<GraphNodeId> {
+            result
+                .iter()
+                .filter(|r| r.kind == RelationKind::Calls)
+                .map(|r| r.dst)
+                .collect()
+        };
+
+        let files = make_files();
+        let first = link_cross_file(&files);
+        let second = link_cross_file(&files);
+        assert_eq!(
+            calls_order(&first),
+            calls_order(&second),
+            "repeated runs must emit fan-out edges in the same order"
+        );
+        assert_eq!(calls_order(&first).len(), 3, "expected the full fan-out");
+
+        // Same entities, universe presented in reversed order: the EntityId sort
+        // makes the emitted order independent of input order.
+        let universe = vec![caller.clone(), run_a.clone(), run_b.clone(), run_c.clone()];
+        let mut reversed_universe = universe.clone();
+        reversed_universe.reverse();
+        let forward = link_cross_file_against_entities(&files, &universe);
+        let backward = link_cross_file_against_entities(&files, &reversed_universe);
+        assert_eq!(
+            calls_order(&forward),
+            calls_order(&backward),
+            "fan-out order must not depend on universe entity order"
+        );
+    }
+
+    #[test]
+    fn batch_and_incremental_fanout_are_identical() {
+        // Each fan-out scenario must resolve to the same Calls edge set in the
+        // batch and incremental linkers. Compares sorted debug renderings so the
+        // check needs no `Ord` on graph ids.
+        let scenarios: Vec<Vec<FileParseData>> = vec![
+            // Qualified-leaf fan-out (three overloads).
+            vec![
+                FileParseData {
+                    file_path: "src/caller.rs".to_string(),
+                    entities: vec![rust_fn("caller", "src/caller.rs")],
+                    relations: vec![calls_relation("caller", "crate::somewhere::run")],
+                    imports: vec![],
+                },
+                FileParseData {
+                    file_path: "src/a.rs".to_string(),
+                    entities: vec![rust_fn("run", "src/a.rs")],
+                    relations: vec![],
+                    imports: vec![],
+                },
+                FileParseData {
+                    file_path: "src/b.rs".to_string(),
+                    entities: vec![rust_fn("run", "src/b.rs")],
+                    relations: vec![],
+                    imports: vec![],
+                },
+                FileParseData {
+                    file_path: "src/c.rs".to_string(),
+                    entities: vec![rust_fn("run", "src/c.rs")],
+                    relations: vec![],
+                    imports: vec![],
+                },
+            ],
+            // Receiver-method fan-out (two implementors).
+            vec![
+                FileParseData {
+                    file_path: "src/caller.rs".to_string(),
+                    entities: vec![make_entity("build", "src/caller.rs")],
+                    relations: vec![calls_relation("build", "new")],
+                    imports: vec![],
+                },
+                FileParseData {
+                    file_path: "src/foo.rs".to_string(),
+                    entities: vec![make_entity("Foo::new", "src/foo.rs")],
+                    relations: vec![],
+                    imports: vec![],
+                },
+                FileParseData {
+                    file_path: "src/bar.rs".to_string(),
+                    entities: vec![make_entity("Bar::new", "src/bar.rs")],
+                    relations: vec![],
+                    imports: vec![],
+                },
+            ],
+            // Same-file prototype + cross-file definition.
+            vec![
+                FileParseData {
+                    file_path: "src/caller.rs".to_string(),
+                    entities: vec![
+                        rust_fn("run_caller", "src/caller.rs"),
+                        rust_fn("compute", "src/caller.rs"),
+                    ],
+                    relations: vec![calls_relation("run_caller", "compute")],
+                    imports: vec![],
+                },
+                FileParseData {
+                    file_path: "src/impl.rs".to_string(),
+                    entities: vec![rust_fn("compute", "src/impl.rs")],
+                    relations: vec![],
+                    imports: vec![],
+                },
+            ],
+        ];
+
+        let calls_set = |rels: &[Relation]| -> Vec<String> {
+            let mut v: Vec<String> = rels
+                .iter()
+                .filter(|r| r.kind == RelationKind::Calls)
+                .map(|r| format!("{:?}->{:?}@{}", r.src, r.dst, r.confidence))
+                .collect();
+            v.sort();
+            v
+        };
+
+        for files in scenarios {
+            let batch = calls_set(&link_cross_file(&files));
+
+            let mut linker = IncrementalLinker::new();
+            for file in &files {
+                linker.add_file(&file.file_path, &file.entities);
+            }
+            let incremental = calls_set(&link_cross_file_incremental(&files, &linker));
+
+            assert!(
+                batch.len() >= 2,
+                "scenario should fan out to multiple targets, got {batch:?}"
+            );
+            assert_eq!(
+                batch, incremental,
+                "batch and incremental must resolve identical Calls edges"
+            );
+        }
     }
 
     #[test]

--- a/crates/kin-index/src/linker.rs
+++ b/crates/kin-index/src/linker.rs
@@ -138,6 +138,23 @@ fn entity_link_order(a: &Entity, b: &Entity) -> std::cmp::Ordering {
         .then_with(|| a.id.0.cmp(&b.id.0))
 }
 
+/// The bare (unqualified) leaf of an entity name: the part after the final
+/// `::` or `.` separator, or the whole name when it carries no qualifier.
+///
+/// Shared by the batch [`link_cross_file`] entity index and the
+/// [`IncrementalLinker`] bare-name index so both derive receiver-method leaf
+/// names identically — a divergence here would resolve the same call to
+/// different entities across the two linkers.
+fn bare_entity_name(name: &str) -> &str {
+    match name.rfind("::") {
+        Some(idx) => &name[idx + 2..],
+        None => match name.rfind('.') {
+            Some(idx) => &name[idx + 1..],
+            None => name,
+        },
+    }
+}
+
 /// Resolve cross-file relations for `files` against a broader target universe.
 ///
 /// This is used by warm/incremental indexing paths where only a subset of files
@@ -267,13 +284,7 @@ fn build_link_context<'a>(
                 .or_default()
                 .push((file_path, entity.id));
 
-            let bare_name = match entity.name.rfind("::") {
-                Some(idx) => &entity.name[idx + 2..],
-                None => match entity.name.rfind('.') {
-                    Some(idx) => &entity.name[idx + 1..],
-                    None => &*entity.name,
-                },
-            };
+            let bare_name = bare_entity_name(&entity.name);
             if bare_name != entity.name {
                 entity_by_bare_name
                     .entry(bare_name)
@@ -1104,8 +1115,10 @@ fn resolve_qualified_suffix_incremental(
         _ => {}
     }
 
-    // Tier 2: bare leaf (free functions; the incremental index has no bare-method
-    // index, so receiver methods reached without their type stay unresolved here).
+    // Tier 2: bare leaf (free functions) resolved through `entity_by_name`. A
+    // qualified path whose leaf is a receiver method (`Type::method`) is not in
+    // `entity_by_name` under the bare leaf; those are resolved by the caller's
+    // (c2) bare-name step via `entity_by_bare_name`, not here.
     let mut leaf_targets: HashSet<EntityId> = HashSet::new();
     if let Some(cands) = linker.entity_by_name.get(last) {
         for (fp, id) in cands {
@@ -2007,6 +2020,11 @@ pub struct IncrementalLinker {
     pub entity_by_file_name: HashMap<String, HashMap<String, EntityId>>,
     /// entity_name -> Vec<(file_path, EntityId)>
     pub entity_by_name: HashMap<String, Vec<(String, EntityId)>>,
+    /// bare (unqualified) leaf name -> Vec<(file_path, EntityId)>, for entities
+    /// whose name carries a `::`/`.` qualifier (e.g. `Widget::work` -> `work`).
+    /// Backs the incremental (c2) receiver-method resolution, mirroring the
+    /// batch linker's `entity_by_bare_name`.
+    pub entity_by_bare_name: HashMap<String, Vec<(String, EntityId)>>,
     /// entity_id -> kind
     pub entity_kind_by_id: HashMap<EntityId, EntityKind>,
     /// Set of all known files
@@ -2026,6 +2044,7 @@ impl IncrementalLinker {
         Self {
             entity_by_file_name: HashMap::new(),
             entity_by_name: HashMap::new(),
+            entity_by_bare_name: HashMap::new(),
             entity_kind_by_id: HashMap::new(),
             known_files: HashSet::new(),
             entities_by_file: HashMap::new(),
@@ -2044,6 +2063,15 @@ impl IncrementalLinker {
                     candidates.retain(|(fp, _)| fp != file_path);
                     if candidates.is_empty() {
                         self.entity_by_name.remove(&entity_name);
+                    }
+                }
+                let bare = bare_entity_name(&entity_name);
+                if bare != entity_name {
+                    if let Some(candidates) = self.entity_by_bare_name.get_mut(bare) {
+                        candidates.retain(|(fp, _)| fp != file_path);
+                        if candidates.is_empty() {
+                            self.entity_by_bare_name.remove(bare);
+                        }
                     }
                 }
             }
@@ -2088,6 +2116,14 @@ impl IncrementalLinker {
                 .entry(entity.name.clone())
                 .or_default()
                 .push((file_path.to_string(), entity.id));
+
+            let bare = bare_entity_name(&entity.name);
+            if bare != entity.name {
+                self.entity_by_bare_name
+                    .entry(bare.to_string())
+                    .or_default()
+                    .push((file_path.to_string(), entity.id));
+            }
 
             file_entities_list.push((entity.id, entity.visibility));
         }
@@ -2383,6 +2419,34 @@ pub fn link_cross_file_incremental(
                     resolved.push(make_relation(rel.kind, src_id, dst_id, confidence));
                 }
                 continue;
+            }
+
+            // (c2) Receiver-method calls (`x.method()`) arrive as the bare method
+            // name with no exact cross-file entity of that name, so (c) above
+            // never fires. Resolve them through the bare-name index only when
+            // unambiguous — exactly one method of that name in another file —
+            // mirroring the batch linker's (c2). Ambiguous names have an
+            // unknowable receiver type, so linking every candidate would mint
+            // spurious callers; leave those unresolved. This is the incremental
+            // counterpart the batch resolver already had; without it a receiver
+            // method resolved into a full-tree snapshot is dropped the moment an
+            // incremental relink of the caller re-derives its edges.
+            if name_fallback_allowed && rel.kind == RelationKind::Calls {
+                if let Some(bare_candidates) = linker.entity_by_bare_name.get(rel.dst_name.as_str())
+                {
+                    let distinct_targets: HashSet<EntityId> = bare_candidates
+                        .iter()
+                        .filter(|(fp, _)| fp != &file.file_path)
+                        .map(|(_, id)| *id)
+                        .collect();
+                    if distinct_targets.len() == 1 {
+                        let dst_id = *distinct_targets.iter().next().expect("len checked == 1");
+                        if add_deduped(&mut seen, src_id, dst_id, rel.kind) {
+                            resolved.push(make_relation(rel.kind, src_id, dst_id, 0.3));
+                        }
+                        continue;
+                    }
+                }
             }
 
             // (c3) Path-qualified suffix resolution — the incremental counterpart
@@ -3271,6 +3335,78 @@ void f();
         assert_eq!(
             calls, 0,
             "ambiguous bare-name receiver call must not link to any candidate, got {calls} edges"
+        );
+    }
+
+    #[test]
+    fn incremental_receiver_method_call_resolves_when_bare_name_unambiguous() {
+        // Incremental (c2) parity with `receiver_method_call_resolves_when_bare_name_unambiguous`:
+        // a bare receiver-method call resolves to the single `Type::method` through
+        // the incremental bare-name index. Before the parity fix the incremental
+        // linker had no bare-name index and left this unresolved.
+        let caller = make_entity("project_after_mcp_commit", "src/wiring.rs");
+        let callee = make_entity("Reconciler::project_overlay_to_files", "src/reconciler.rs");
+
+        let mut linker = IncrementalLinker::new();
+        linker.add_file("src/wiring.rs", std::slice::from_ref(&caller));
+        linker.add_file("src/reconciler.rs", std::slice::from_ref(&callee));
+
+        let files = vec![FileParseData {
+            file_path: "src/wiring.rs".to_string(),
+            entities: vec![caller.clone()],
+            relations: vec![ExtractedRelation {
+                kind: RelationKind::Calls,
+                src_name: "project_after_mcp_commit".to_string(),
+                dst_name: "project_overlay_to_files".to_string(),
+                import_source: None,
+            }],
+            imports: vec![],
+        }];
+
+        let result = link_cross_file_incremental(&files, &linker);
+        let calls = result
+            .iter()
+            .find(|r| r.kind == RelationKind::Calls)
+            .expect("incremental unambiguous receiver-method call should resolve to Type::method");
+        assert_eq!(calls.src, GraphNodeId::Entity(caller.id));
+        assert_eq!(calls.dst, GraphNodeId::Entity(callee.id));
+    }
+
+    #[test]
+    fn incremental_receiver_method_call_skipped_when_bare_name_ambiguous() {
+        // Incremental (c2) parity with `receiver_method_call_skipped_when_bare_name_ambiguous`:
+        // bare `new` could be `Foo::new` or `Bar::new`; the receiver type is
+        // unknowable, so it must stay unlinked (matching the batch resolver's
+        // conservatism — no spurious callers).
+        let caller = make_entity("build", "src/caller.rs");
+        let foo_new = make_entity("Foo::new", "src/foo.rs");
+        let bar_new = make_entity("Bar::new", "src/bar.rs");
+
+        let mut linker = IncrementalLinker::new();
+        linker.add_file("src/caller.rs", std::slice::from_ref(&caller));
+        linker.add_file("src/foo.rs", std::slice::from_ref(&foo_new));
+        linker.add_file("src/bar.rs", std::slice::from_ref(&bar_new));
+
+        let files = vec![FileParseData {
+            file_path: "src/caller.rs".to_string(),
+            entities: vec![caller.clone()],
+            relations: vec![ExtractedRelation {
+                kind: RelationKind::Calls,
+                src_name: "build".to_string(),
+                dst_name: "new".to_string(),
+                import_source: None,
+            }],
+            imports: vec![],
+        }];
+
+        let result = link_cross_file_incremental(&files, &linker);
+        let calls = result
+            .iter()
+            .filter(|r| r.kind == RelationKind::Calls)
+            .count();
+        assert_eq!(
+            calls, 0,
+            "incremental ambiguous bare-name receiver call must not link, got {calls} edges"
         );
     }
 

--- a/crates/kin-index/src/pipeline.rs
+++ b/crates/kin-index/src/pipeline.rs
@@ -150,6 +150,9 @@ impl IndexPipeline {
             })
             .collect();
         attach_file_context_metadata(&mut entities, file_id, &imports);
+        if language == LanguageId::Go {
+            kin_parser::attach_go_command_effect_contract_metadata(&tree, source, &mut entities);
+        }
 
         let (relations, unresolved_relations) = resolve_relations(&extracted_relations, &entities);
         let file_layout = build_layout(
@@ -286,6 +289,9 @@ impl IndexPipeline {
             })
             .collect();
         attach_file_context_metadata(&mut entities, file_id, &imports);
+        if language == LanguageId::Go {
+            kin_parser::attach_go_command_effect_contract_metadata(&tree, &source, &mut entities);
+        }
 
         // Resolve extracted relations to model relations using entity name mapping
         let (relations, unresolved_relations) = resolve_relations(&extracted_relations, &entities);

--- a/crates/kin-parser/src/adapter.rs
+++ b/crates/kin-parser/src/adapter.rs
@@ -118,6 +118,61 @@ fn hash_token_stream(node: &Node, source: &[u8], hasher: &mut Sha256) {
     }
 }
 
+/// Whitespace-collapsed declaration text of a node, cut before its `body`
+/// child and any C++ member-initializer list, falling back to the full node
+/// text for body-less declarations. Line wrapping and indentation must not
+/// leak into signatures: a multi-line declarator and its single-line
+/// reformat are the same declaration, and a signature string that differs
+/// only by formatting reads as a false signature change downstream.
+pub fn declaration_signature(node: &Node, source: &[u8]) -> String {
+    let start = node.start_byte();
+    let mut end = node.end_byte();
+    if let Some(body) = node.child_by_field_name("body") {
+        end = end.min(body.start_byte());
+    }
+    let mut cursor = node.walk();
+    for child in node.children(&mut cursor) {
+        if child.kind() == "field_initializer_list" {
+            end = end.min(child.start_byte());
+        }
+    }
+    let end = end.max(start);
+    let text = source
+        .get(start..end)
+        .map(String::from_utf8_lossy)
+        .unwrap_or_default();
+    let collapsed = text.split_whitespace().collect::<Vec<_>>().join(" ");
+    canonicalize_signature_spacing(&collapsed)
+        .trim_end_matches(['{', ':'])
+        .trim()
+        .to_string()
+}
+
+/// Canonicalize spacing around punctuation in a collapsed signature so that
+/// a line break at a token boundary (`ArgParser\n(...)`) and its inline form
+/// (`ArgParser(...)`) render identically: no space before `()[],;<>`, none
+/// after an opening bracket.
+fn canonicalize_signature_spacing(s: &str) -> String {
+    let mut out = String::with_capacity(s.len());
+    for ch in s.chars() {
+        match ch {
+            '(' | ')' | ',' | '[' | ']' | ';' | '<' | '>' => {
+                while out.ends_with(' ') {
+                    out.pop();
+                }
+                out.push(ch);
+            }
+            ' ' => {
+                if !matches!(out.chars().last(), Some('(') | Some('[') | Some('<') | None) {
+                    out.push(' ');
+                }
+            }
+            c => out.push(c),
+        }
+    }
+    out
+}
+
 fn finalize_hash(hasher: Sha256) -> Hash256 {
     let result = hasher.finalize();
     let mut bytes = [0u8; 32];

--- a/crates/kin-parser/src/adapter.rs
+++ b/crates/kin-parser/src/adapter.rs
@@ -41,9 +41,12 @@ pub trait LanguageAdapter: Send + Sync {
 }
 
 /// Compute a semantic fingerprint by hashing different aspects of a node.
+///
+/// All three hashes skip grammar `extra` nodes (comments), and the behavior
+/// hash is built from the leaf-token stream rather than raw source bytes, so
+/// comment-only and formatting-only edits produce identical fingerprints
+/// while any token or structure change still alters the behavior hash.
 pub fn compute_fingerprint(node: &Node, source: &[u8]) -> SemanticFingerprint {
-    let text = node.utf8_text(source).unwrap_or("");
-
     let mut ast_hasher = Sha256::new();
     hash_ast_shape(node, &mut ast_hasher);
     let ast_hash = finalize_hash(ast_hasher);
@@ -53,14 +56,14 @@ pub fn compute_fingerprint(node: &Node, source: &[u8]) -> SemanticFingerprint {
     // Hash children kinds as a proxy for the signature shape
     let mut cursor = node.walk();
     for child in node.children(&mut cursor) {
-        if child.is_named() {
+        if child.is_named() && !child.is_extra() {
             sig_hasher.update(child.kind().as_bytes());
         }
     }
     let signature_hash = finalize_hash(sig_hasher);
 
     let mut behavior_hasher = Sha256::new();
-    behavior_hasher.update(text.as_bytes());
+    hash_token_stream(node, source, &mut behavior_hasher);
     let behavior_hash = finalize_hash(behavior_hasher);
 
     SemanticFingerprint {
@@ -77,11 +80,42 @@ fn hash_ast_shape(node: &Node, hasher: &mut Sha256) {
     hasher.update(b"(");
     let mut cursor = node.walk();
     for child in node.children(&mut cursor) {
-        if child.is_named() {
+        if child.is_named() && !child.is_extra() {
             hash_ast_shape(&child, hasher);
         }
     }
     hasher.update(b")");
+}
+
+/// Hash the semantic token content of a subtree: named-node open/close
+/// markers plus the kind and text of every leaf token, skipping `extra`
+/// subtrees entirely. Inter-token whitespace never appears in the tree, so
+/// the digest is stable across formatting and comment edits, while the
+/// structural markers keep it sensitive to nesting moves that reuse the
+/// same token text (e.g. a statement moving into an adjacent block).
+fn hash_token_stream(node: &Node, source: &[u8], hasher: &mut Sha256) {
+    if node.is_extra() {
+        return;
+    }
+    if node.child_count() == 0 {
+        hasher.update(node.kind().as_bytes());
+        hasher.update([0x1f]);
+        hasher.update(node.utf8_text(source).unwrap_or("").as_bytes());
+        hasher.update([0x1e]);
+        return;
+    }
+    let named = node.is_named();
+    if named {
+        hasher.update(node.kind().as_bytes());
+        hasher.update(b"(");
+    }
+    let mut cursor = node.walk();
+    for child in node.children(&mut cursor) {
+        hash_token_stream(&child, source, hasher);
+    }
+    if named {
+        hasher.update(b")");
+    }
 }
 
 fn finalize_hash(hasher: Sha256) -> Hash256 {

--- a/crates/kin-parser/src/extract.rs
+++ b/crates/kin-parser/src/extract.rs
@@ -7,6 +7,7 @@ use kin_model::{
 };
 
 pub const EMBEDDING_BODY_PREVIEW_KEY: &str = "embedding_body_preview";
+pub const COMMAND_EFFECT_CONTRACT_KEY: &str = "command_effect_contract";
 pub const FILE_IMPORT_CONTEXT_KEY: &str = "file_import_context";
 pub const FILE_SURFACE_CONTEXT_KEY: &str = "file_surface_context";
 

--- a/crates/kin-parser/src/languages/c_lang.rs
+++ b/crates/kin-parser/src/languages/c_lang.rs
@@ -455,13 +455,7 @@ fn c_visibility(node: &tree_sitter::Node, source: &[u8]) -> Visibility {
 }
 
 fn node_signature(node: &tree_sitter::Node, source: &[u8]) -> String {
-    let text = node.utf8_text(source).unwrap_or("");
-    text.lines()
-        .next()
-        .unwrap_or(text)
-        .trim_end_matches('{')
-        .trim()
-        .to_string()
+    crate::adapter::declaration_signature(node, source)
 }
 
 fn extract_preceding_comment(node: &tree_sitter::Node, source: &[u8]) -> Option<String> {

--- a/crates/kin-parser/src/languages/cpp_lang.rs
+++ b/crates/kin-parser/src/languages/cpp_lang.rs
@@ -341,13 +341,42 @@ fn extract_cpp_node(
                 if !name.is_empty() {
                     entities.push(ExtractedEntity {
                         kind: EntityKind::Macro,
-                        name,
+                        name: name.clone(),
                         signature: node_signature(node, source),
                         visibility: Visibility::Public,
                         doc_summary: extract_preceding_comment(node, source),
                         fingerprint: compute_fingerprint(node, source),
                         span: span_from_node(node, file_id),
                     });
+
+                    // tree-sitter leaves a macro's replacement list as an opaque
+                    // `preproc_arg`, so references made INSIDE a macro body are
+                    // never walked as identifier nodes. Lex the body text and
+                    // emit `UsesMacro` edges to the ALL_CAPS macros it expands to
+                    // (e.g. Catch2's INTERNAL_CATCH_* chains), sourced from this
+                    // macro. The macro's own name, its parameters, and reserved
+                    // `__`-prefixed identifiers are excluded; the linker drops
+                    // any target that resolves to no Macro entity.
+                    if let Some(value_node) = node.child_by_field_name("value") {
+                        let body = value_node.utf8_text(source).unwrap_or("");
+                        let params = macro_parameter_names(node, source);
+                        let mut seen = std::collections::HashSet::new();
+                        for token in lex_identifiers(body) {
+                            if token != name
+                                && !token.starts_with("__")
+                                && !params.contains(token)
+                                && is_all_caps_macro(token)
+                                && seen.insert(token.to_string())
+                            {
+                                relations.push(ExtractedRelation {
+                                    kind: kin_model::RelationKind::UsesMacro,
+                                    src_name: name.clone(),
+                                    dst_name: token.to_string(),
+                                    import_source: None,
+                                });
+                            }
+                        }
+                    }
                 }
             }
         }
@@ -908,6 +937,70 @@ fn is_all_caps_macro(name: &str) -> bool {
         }
     }
     has_upper && name.len() >= 3 // avoid single-letter macros
+}
+
+/// Collect the parameter names of a function-like macro (`#define M(a, b) ...`)
+/// so they are not mistaken for referenced macros in the replacement list.
+fn macro_parameter_names(
+    node: &tree_sitter::Node,
+    source: &[u8],
+) -> std::collections::HashSet<String> {
+    let mut names = std::collections::HashSet::new();
+    if let Some(params) = node.child_by_field_name("parameters") {
+        let mut cursor = params.walk();
+        for child in params.children(&mut cursor) {
+            if child.kind() == "identifier" {
+                if let Ok(text) = child.utf8_text(source) {
+                    if !text.is_empty() {
+                        names.insert(text.to_string());
+                    }
+                }
+            }
+        }
+    }
+    names
+}
+
+/// Lex identifier tokens from raw text, skipping the contents of string and
+/// char literals so quoted words are never treated as identifiers. Used to
+/// scan opaque macro-body text that tree-sitter does not tokenize.
+fn lex_identifiers(text: &str) -> Vec<&str> {
+    let bytes = text.as_bytes();
+    let mut tokens = Vec::new();
+    let mut i = 0;
+    while i < bytes.len() {
+        let c = bytes[i];
+        match c {
+            b'"' | b'\'' => {
+                let quote = c;
+                i += 1;
+                while i < bytes.len() {
+                    if bytes[i] == b'\\' {
+                        i += 2;
+                        continue;
+                    }
+                    let closed = bytes[i] == quote;
+                    i += 1;
+                    if closed {
+                        break;
+                    }
+                }
+            }
+            _ if c == b'_' || c.is_ascii_alphabetic() => {
+                let start = i;
+                while i < bytes.len() && (bytes[i] == b'_' || bytes[i].is_ascii_alphanumeric()) {
+                    i += 1;
+                }
+                if let Ok(tok) = std::str::from_utf8(&bytes[start..i]) {
+                    tokens.push(tok);
+                }
+            }
+            _ => {
+                i += 1;
+            }
+        }
+    }
+    tokens
 }
 
 /// Extract a `#include` directive into a `FileImport`.
@@ -1554,6 +1647,88 @@ namespace ns {
         for call in &calls {
             assert_eq!(call.src_name, "MyClass::my_method");
         }
+    }
+
+    #[test]
+    fn macro_body_references_emit_uses_macro_edges() {
+        // Catch2-style macros expand to INTERNAL_CATCH_* chains. tree-sitter
+        // leaves the replacement list as opaque text, so without lexing the body
+        // these macro->macro references are lost and a behavioral revert made
+        // inside a macro body is invisible to impact analysis.
+        let adapter = CppAdapter;
+        let source = br#"
+#define CATCH_FLAG 1
+#define INTERNAL_CATCH_TEST(expr, flag) do_check(expr, flag)
+#define INTERNAL_CATCH_TESTCASE2(name) do_register(name)
+#define INTERNAL_CATCH_TEST_CASE(...) INTERNAL_CATCH_TESTCASE2(__VA_ARGS__)
+#define CATCH_REQUIRE(expr) INTERNAL_CATCH_TEST(expr, CATCH_FLAG)
+"#;
+        let tree = adapter.parse(source).unwrap();
+        let file_id = FilePathId::new("catch.hpp");
+        let output = adapter.extract(&tree, source, &file_id).unwrap();
+
+        let uses: Vec<(&str, &str)> = output
+            .relations
+            .iter()
+            .filter(|r| r.kind == kin_model::RelationKind::UsesMacro)
+            .map(|r| (r.src_name.as_str(), r.dst_name.as_str()))
+            .collect();
+
+        assert!(
+            uses.contains(&("INTERNAL_CATCH_TEST_CASE", "INTERNAL_CATCH_TESTCASE2")),
+            "a macro should reference the macro its body expands to, found: {uses:?}"
+        );
+        assert!(
+            uses.contains(&("CATCH_REQUIRE", "INTERNAL_CATCH_TEST")),
+            "CATCH_REQUIRE should reference INTERNAL_CATCH_TEST from its body, found: {uses:?}"
+        );
+        assert!(
+            uses.contains(&("CATCH_REQUIRE", "CATCH_FLAG")),
+            "CATCH_REQUIRE should reference the CATCH_FLAG token in its body, found: {uses:?}"
+        );
+        // `__VA_ARGS__` is a reserved builtin, not a repo macro.
+        assert!(
+            !uses.iter().any(|(_, dst)| *dst == "__VA_ARGS__"),
+            "reserved __-prefixed identifiers must not be referenced, found: {uses:?}"
+        );
+        // `expr` is a macro parameter (and lowercase) — never a macro reference.
+        assert!(
+            !uses.iter().any(|(_, dst)| *dst == "expr"),
+            "macro parameters must not be referenced, found: {uses:?}"
+        );
+        // A macro must never reference itself.
+        assert!(
+            !uses.iter().any(|(src, dst)| src == dst),
+            "a macro must not reference itself, found: {uses:?}"
+        );
+    }
+
+    #[test]
+    fn macro_body_ignores_string_literal_contents() {
+        // ALL_CAPS words inside a string literal are text, not macro references.
+        let adapter = CppAdapter;
+        let source = br#"
+#define LOG_MESSAGE(x) emit("ERROR", x, OTHER_MACRO)
+"#;
+        let tree = adapter.parse(source).unwrap();
+        let file_id = FilePathId::new("log.hpp");
+        let output = adapter.extract(&tree, source, &file_id).unwrap();
+
+        let uses: Vec<(&str, &str)> = output
+            .relations
+            .iter()
+            .filter(|r| r.kind == kin_model::RelationKind::UsesMacro)
+            .map(|r| (r.src_name.as_str(), r.dst_name.as_str()))
+            .collect();
+
+        assert!(
+            uses.contains(&("LOG_MESSAGE", "OTHER_MACRO")),
+            "the bare macro token should be referenced, found: {uses:?}"
+        );
+        assert!(
+            !uses.iter().any(|(_, dst)| *dst == "ERROR"),
+            "ALL_CAPS words inside a string literal must not be referenced, found: {uses:?}"
+        );
     }
 
     #[test]

--- a/crates/kin-parser/src/languages/cpp_lang.rs
+++ b/crates/kin-parser/src/languages/cpp_lang.rs
@@ -810,6 +810,29 @@ fn extract_preceding_comment(node: &tree_sitter::Node, source: &[u8]) -> Option<
     }
 }
 
+/// Strip template-argument lists from a callee path while preserving its
+/// `::` structure: `ratio_string<Ratio>::symbol` → `ratio_string::symbol`.
+/// Template args in a callee name defeat every name index downstream (the
+/// suffix resolver rejects `<`/`>` outright), so the emitted reference must
+/// carry the instantiation-free path. Operator names are kept verbatim —
+/// their angle brackets are not template arguments.
+fn strip_callee_template_args(raw: &str) -> String {
+    if !raw.contains('<') || raw.contains("operator") {
+        return raw.to_string();
+    }
+    let mut out = String::with_capacity(raw.len());
+    let mut depth = 0usize;
+    for ch in raw.chars() {
+        match ch {
+            '<' => depth += 1,
+            '>' => depth = depth.saturating_sub(1),
+            c if depth == 0 => out.push(c),
+            _ => {}
+        }
+    }
+    out
+}
+
 /// Recursively walk a function/method body to find `call_expression` nodes.
 fn extract_calls_from_body(
     node: &tree_sitter::Node,
@@ -831,6 +854,7 @@ fn extract_calls_from_body(
                     }
                     _ => function.utf8_text(source).unwrap_or("").to_string(),
                 };
+                let callee_name = strip_callee_template_args(&callee_name);
                 if is_valid_callee(&callee_name) {
                     relations.push(ExtractedRelation {
                         kind: kin_model::RelationKind::Calls,

--- a/crates/kin-parser/src/languages/cpp_lang.rs
+++ b/crates/kin-parser/src/languages/cpp_lang.rs
@@ -768,13 +768,7 @@ fn detect_file_scope_visibility(node: &tree_sitter::Node, source: &[u8]) -> Visi
 
 /// First line of the node text, trimmed of trailing `{`.
 fn node_signature(node: &tree_sitter::Node, source: &[u8]) -> String {
-    let text = node.utf8_text(source).unwrap_or("");
-    text.lines()
-        .next()
-        .unwrap_or(text)
-        .trim_end_matches('{')
-        .trim()
-        .to_string()
+    crate::adapter::declaration_signature(node, source)
 }
 
 /// Extract the preceding comment (// or /* ... */) as a doc summary.

--- a/crates/kin-parser/src/languages/go.rs
+++ b/crates/kin-parser/src/languages/go.rs
@@ -183,7 +183,15 @@ fn extract_go_node(
                     fingerprint: compute_fingerprint(node, source),
                     span: span_from_node(node, file_id),
                 });
-                extract_calls_from_body(node, source, &name, relations, call_prefixes);
+                let mut ref_seen = std::collections::HashSet::new();
+                extract_calls_from_body(
+                    node,
+                    source,
+                    &name,
+                    relations,
+                    call_prefixes,
+                    &mut ref_seen,
+                );
             }
         }
         "method_declaration" => {
@@ -229,7 +237,15 @@ fn extract_go_node(
                     });
                 }
 
-                extract_calls_from_body(node, source, &qualified, relations, call_prefixes);
+                let mut ref_seen = std::collections::HashSet::new();
+                extract_calls_from_body(
+                    node,
+                    source,
+                    &qualified,
+                    relations,
+                    call_prefixes,
+                    &mut ref_seen,
+                );
             }
         }
         "type_declaration" => {
@@ -338,13 +354,23 @@ fn extract_go_node(
                         };
                         entities.push(ExtractedEntity {
                             kind,
-                            name,
+                            name: name.clone(),
                             signature: node_signature(&spec, source),
                             visibility: go_visibility(name_node.utf8_text(source).unwrap_or("")),
                             doc_summary: extract_preceding_comment(node, source),
                             fingerprint: compute_fingerprint(&spec, source),
                             span: span_from_node(&spec, file_id),
                         });
+
+                        // A package-level const/var initializer references the
+                        // identifiers read in its value expression (e.g. a
+                        // cobra `&cobra.Command{RunE: prCheckout}` var
+                        // references the handler `prCheckout`). Emit those as
+                        // References edges sourced from the declared name.
+                        if let Some(value) = spec.child_by_field_name("value") {
+                            let mut ref_seen = std::collections::HashSet::new();
+                            emit_value_references(&value, source, &name, relations, &mut ref_seen);
+                        }
                     }
                 }
             }
@@ -624,9 +650,32 @@ fn extract_calls_from_body(
     context_name: &str,
     relations: &mut Vec<ExtractedRelation>,
     call_prefixes: &mut Vec<(usize, String)>,
+    ref_seen: &mut std::collections::HashSet<String>,
 ) {
     let mut cursor = node.walk();
     for child in node.children(&mut cursor) {
+        // Value-position references: an identifier read as a VALUE (passed as a
+        // call argument, used as a composite-literal element value, or on the
+        // RHS of an assignment/declaration/return) is a `References` edge — not
+        // a `Calls` edge. This is what wires cobra-style `RunE: prCheckout`
+        // function-value handoffs and package-level const/var reads into impact.
+        match child.kind() {
+            "argument_list" | "literal_value" | "return_statement" => {
+                emit_value_references(&child, source, context_name, relations, ref_seen);
+            }
+            "assignment_statement" | "short_var_declaration" => {
+                if let Some(rhs) = child.child_by_field_name("right") {
+                    emit_value_references(&rhs, source, context_name, relations, ref_seen);
+                }
+            }
+            "var_spec" | "const_spec" => {
+                if let Some(value) = child.child_by_field_name("value") {
+                    emit_value_references(&value, source, context_name, relations, ref_seen);
+                }
+            }
+            _ => {}
+        }
+
         if child.kind() == "call_expression" {
             if let Some(function) = child.child_by_field_name("function") {
                 let (callee, prefix) = match function.kind() {
@@ -695,7 +744,100 @@ fn extract_calls_from_body(
                 }
             }
         }
-        extract_calls_from_body(&child, source, context_name, relations, call_prefixes);
+        extract_calls_from_body(
+            &child,
+            source,
+            context_name,
+            relations,
+            call_prefixes,
+            ref_seen,
+        );
+    }
+}
+
+/// Emit `References` edges for the value-position identifiers read within
+/// `node`, sourced from `context_name`. Deduped by destination name against
+/// `ref_seen` so a name referenced several times in one body yields one edge.
+/// The linker resolves References by name and drops unresolvables, so locals
+/// and parameters that match no package-level entity are harmless.
+fn emit_value_references(
+    node: &tree_sitter::Node,
+    source: &[u8],
+    context_name: &str,
+    relations: &mut Vec<ExtractedRelation>,
+    ref_seen: &mut std::collections::HashSet<String>,
+) {
+    let mut names = Vec::new();
+    collect_value_refs(node, source, &mut names);
+    for name in names {
+        if name != context_name && ref_seen.insert(name.clone()) {
+            relations.push(ExtractedRelation {
+                kind: kin_model::RelationKind::References,
+                src_name: context_name.to_string(),
+                dst_name: name,
+                import_source: None,
+            });
+        }
+    }
+}
+
+/// Collect bare identifier names read as VALUES within an expression subtree.
+///
+/// Walks value expressions while pruning positions that are not value reads:
+/// a call's callee (already captured as a `Calls` edge), a selector's `.field`
+/// selector, a composite literal's `type`, and a `keyed_element`'s key. Type
+/// identifiers and the blank identifier `_` are never collected. The receiver
+/// of a method call (`obj` in `obj.M()`) and every call argument ARE collected,
+/// since they are genuine value reads.
+fn collect_value_refs(node: &tree_sitter::Node, source: &[u8], out: &mut Vec<String>) {
+    match node.kind() {
+        "identifier" => {
+            let name = node.utf8_text(source).unwrap_or("");
+            if !name.is_empty() && name != "_" {
+                out.push(name.to_string());
+            }
+        }
+        // `x.Field` reads the operand value `x`; the `.Field` selector itself
+        // is not an independent value read.
+        "selector_expression" => {
+            if let Some(operand) = node.child_by_field_name("operand") {
+                collect_value_refs(&operand, source, out);
+            }
+        }
+        // A call in value position contributes its receiver (for `obj.M()`) and
+        // its arguments; the callee is captured as a `Calls` edge elsewhere.
+        "call_expression" => {
+            if let Some(function) = node.child_by_field_name("function") {
+                if function.kind() == "selector_expression" {
+                    if let Some(operand) = function.child_by_field_name("operand") {
+                        collect_value_refs(&operand, source, out);
+                    }
+                }
+            }
+            if let Some(args) = node.child_by_field_name("arguments") {
+                collect_value_refs(&args, source, out);
+            }
+        }
+        // `T{...}`: element values are reads, the `type` field is not.
+        "composite_literal" => {
+            if let Some(body) = node.child_by_field_name("body") {
+                collect_value_refs(&body, source, out);
+            }
+        }
+        // `Key: Value`: only the value is a read (the key names a field).
+        "keyed_element" => {
+            if let Some(value) = node.child_by_field_name("value") {
+                collect_value_refs(&value, source, out);
+            }
+        }
+        // Leaf type positions are never value reads.
+        "type_identifier" | "qualified_type" | "package_identifier" | "field_identifier" => {}
+        _ => {
+            let mut cursor = node.walk();
+            for child in node.children(&mut cursor) {
+                collect_value_refs(&child, source, out);
+            }
+        }
     }
 }
 
@@ -1172,5 +1314,182 @@ func (s *Server) Start() { fmt.Println("starting") }
         assert_eq!(spawns.len(), 1, "expected 1 Spawns, got {:?}", spawns);
         assert_eq!(spawns[0].src_name, "main");
         assert_eq!(spawns[0].dst_name, "processItem");
+    }
+
+    fn go_references(output: &ParseOutput) -> Vec<(&str, &str)> {
+        output
+            .relations
+            .iter()
+            .filter(|r| r.kind == kin_model::RelationKind::References)
+            .map(|r| (r.src_name.as_str(), r.dst_name.as_str()))
+            .collect()
+    }
+
+    #[test]
+    fn func_value_in_composite_literal_emits_reference() {
+        // cobra-style: a function passed by name as a struct-field value
+        // (`RunE: prCheckout`) must reference the handler, not silently drop it.
+        let adapter = GoAdapter;
+        let source = br#"
+package cmd
+
+func prCheckout() {}
+
+func newCmd() {
+    cmd := &Command{RunE: prCheckout}
+    _ = cmd
+}
+"#;
+        let tree = adapter.parse(source).unwrap();
+        let file_id = FilePathId::new("cmd.go");
+        let output = adapter.extract(&tree, source, &file_id).unwrap();
+        let refs = go_references(&output);
+        assert!(
+            refs.contains(&("newCmd", "prCheckout")),
+            "newCmd should reference prCheckout via the RunE field value, found: {refs:?}"
+        );
+        // The struct type name and the field key are not value reads.
+        assert!(
+            !refs
+                .iter()
+                .any(|(_, dst)| *dst == "Command" || *dst == "RunE"),
+            "composite-literal type name and keys must not be referenced, found: {refs:?}"
+        );
+    }
+
+    #[test]
+    fn package_var_initializer_references_function_value() {
+        // `var prCheckoutCmd = &cobra.Command{RunE: prCheckout}` must yield a
+        // References edge prCheckoutCmd -> prCheckout so a change to the handler
+        // shows impact on the command var.
+        let adapter = GoAdapter;
+        let source = br#"
+package cmd
+
+import "github.com/spf13/cobra"
+
+func prCheckout(cmd *cobra.Command, args []string) error { return nil }
+
+var prCheckoutCmd = &cobra.Command{
+    Use:  "checkout",
+    RunE: prCheckout,
+}
+"#;
+        let tree = adapter.parse(source).unwrap();
+        let file_id = FilePathId::new("checkout.go");
+        let output = adapter.extract(&tree, source, &file_id).unwrap();
+        let refs = go_references(&output);
+        assert!(
+            refs.contains(&("prCheckoutCmd", "prCheckout")),
+            "package var initializer should reference prCheckout, found: {refs:?}"
+        );
+        // `cobra.Command` is the composite type, not a value read.
+        assert!(
+            !refs.iter().any(|(_, dst)| *dst == "Command"),
+            "composite-literal type must not be referenced, found: {refs:?}"
+        );
+    }
+
+    #[test]
+    fn call_argument_var_emits_reference_not_the_callee() {
+        // A package-level var passed as a call argument
+        // (`RunCommand(prCheckoutCmd, ...)`) must be referenced; the callee is a
+        // Call, never a References edge.
+        let adapter = GoAdapter;
+        let source = br#"
+package cmd
+
+var prCheckoutCmd = 0
+
+func run() {
+    RunCommand(prCheckoutCmd, "arg")
+}
+"#;
+        let tree = adapter.parse(source).unwrap();
+        let file_id = FilePathId::new("run.go");
+        let output = adapter.extract(&tree, source, &file_id).unwrap();
+        let refs = go_references(&output);
+        assert!(
+            refs.contains(&("run", "prCheckoutCmd")),
+            "run should reference prCheckoutCmd passed as an argument, found: {refs:?}"
+        );
+        assert!(
+            !refs.iter().any(|(_, dst)| *dst == "RunCommand"),
+            "the callee must be a Calls edge, not a References edge, found: {refs:?}"
+        );
+        let calls: Vec<_> = output
+            .relations
+            .iter()
+            .filter(|r| r.kind == kin_model::RelationKind::Calls)
+            .map(|r| (r.src_name.as_str(), r.dst_name.as_str()))
+            .collect();
+        assert!(
+            calls.contains(&("run", "RunCommand")),
+            "run should still Call RunCommand, found: {calls:?}"
+        );
+    }
+
+    #[test]
+    fn package_const_read_in_body_emits_reference() {
+        // A plain read of a package-level const inside a body is a reference.
+        let adapter = GoAdapter;
+        let source = br#"
+package cmd
+
+const defaultConfigStr = "default"
+
+func load() string {
+    return defaultConfigStr
+}
+"#;
+        let tree = adapter.parse(source).unwrap();
+        let file_id = FilePathId::new("load.go");
+        let output = adapter.extract(&tree, source, &file_id).unwrap();
+        let refs = go_references(&output);
+        assert!(
+            refs.contains(&("load", "defaultConfigStr")),
+            "load should reference defaultConfigStr it returns, found: {refs:?}"
+        );
+    }
+
+    #[test]
+    fn value_references_skip_lhs_types_and_blank() {
+        // Binding names (LHS), type identifiers, keys, and the blank identifier
+        // are not value reads — keep References targeted to bound noise.
+        let adapter = GoAdapter;
+        let source = br#"
+package cmd
+
+type Config struct { Name string }
+
+func handler() {}
+
+func build() {
+    var h = handler
+    _ = h
+    cfg := Config{Name: "x"}
+    _ = cfg
+}
+"#;
+        let tree = adapter.parse(source).unwrap();
+        let file_id = FilePathId::new("build.go");
+        let output = adapter.extract(&tree, source, &file_id).unwrap();
+        let refs = go_references(&output);
+        assert!(
+            refs.contains(&("build", "handler")),
+            "the RHS function value `handler` should be referenced, found: {refs:?}"
+        );
+        assert!(
+            !refs
+                .iter()
+                .any(|(_, dst)| matches!(*dst, "Config" | "Name" | "_")),
+            "type name, struct key, and blank identifier must not be referenced, found: {refs:?}"
+        );
+        // A reference edge is deduped to one per (src, dst) within a body.
+        assert_eq!(
+            refs.iter().filter(|(_, dst)| *dst == "handler").count(),
+            1,
+            "handler should be referenced exactly once, found: {refs:?}"
+        );
     }
 }

--- a/crates/kin-parser/src/languages/go.rs
+++ b/crates/kin-parser/src/languages/go.rs
@@ -1,9 +1,10 @@
 // SPDX-License-Identifier: Apache-2.0
 // Copyright 2026 Firelock, LLC
 
-use std::collections::HashMap;
+use std::collections::{BTreeMap, BTreeSet, HashMap};
 
-use kin_model::{EntityKind, FilePathId, LanguageId, ParseState, Visibility};
+use kin_model::{Entity, EntityKind, FilePathId, LanguageId, ParseState, Visibility};
+use serde_json::{json, Value};
 use tree_sitter::Tree;
 
 use crate::adapter::{
@@ -12,10 +13,30 @@ use crate::adapter::{
 use crate::error::Result;
 use crate::extract::{
     ExtractedEntity, ExtractedRelation, ExtractedTest, ExtractedTestKind, FileImport, ImportedName,
-    ParseOutput,
+    ParseOutput, COMMAND_EFFECT_CONTRACT_KEY,
 };
 
 pub struct GoAdapter;
+
+pub fn attach_go_command_effect_contract_metadata(
+    tree: &Tree,
+    source: &[u8],
+    entities: &mut [Entity],
+) {
+    let contracts = extract_go_command_effect_contracts(tree, source);
+    if contracts.is_empty() {
+        return;
+    }
+
+    for entity in entities {
+        if let Some(contract) = contracts.get(entity.name.as_str()) {
+            entity
+                .metadata
+                .extra
+                .insert(COMMAND_EFFECT_CONTRACT_KEY.into(), contract.clone());
+        }
+    }
+}
 
 impl LanguageAdapter for GoAdapter {
     fn language_id(&self) -> LanguageId {
@@ -156,6 +177,198 @@ impl LanguageAdapter for GoAdapter {
             parse_state,
         })
     }
+}
+
+fn extract_go_command_effect_contracts(tree: &Tree, source: &[u8]) -> BTreeMap<String, Value> {
+    let mut contracts = BTreeMap::new();
+    let root = tree.root_node();
+    let mut cursor = root.walk();
+
+    for child in root.children(&mut cursor) {
+        if child.kind() != "function_declaration" {
+            continue;
+        }
+        let Some(name_node) = child.child_by_field_name("name") else {
+            continue;
+        };
+        let name = name_node.utf8_text(source).unwrap_or("").to_string();
+        if name.is_empty() {
+            continue;
+        }
+        let Some(body) = child.child_by_field_name("body") else {
+            continue;
+        };
+        let Some(contract) = command_effect_contract_for_body(&body, source) else {
+            continue;
+        };
+        contracts.insert(name, contract);
+    }
+
+    contracts
+}
+
+fn command_effect_contract_for_body(node: &tree_sitter::Node, source: &[u8]) -> Option<Value> {
+    let mut bindings = BTreeMap::new();
+    collect_go_bindings(node, source, &mut bindings);
+
+    let mut effects = Vec::new();
+    let mut seen = BTreeSet::new();
+    collect_go_command_effects(node, source, &bindings, &mut effects, &mut seen);
+    if effects.is_empty() {
+        return None;
+    }
+
+    Some(json!({
+        "schema_version": 1,
+        "language": "go",
+        "effects": effects,
+    }))
+}
+
+fn collect_go_bindings(
+    node: &tree_sitter::Node,
+    source: &[u8],
+    bindings: &mut BTreeMap<String, String>,
+) {
+    match node.kind() {
+        "short_var_declaration" | "assignment_statement" => {
+            if let (Some(left), Some(right)) = (
+                node.child_by_field_name("left"),
+                node.child_by_field_name("right"),
+            ) {
+                let names = assigned_identifier_names(&left, source);
+                if names.len() == 1 {
+                    let rhs = normalize_go_contract_expr(&right, source);
+                    if !rhs.is_empty() {
+                        bindings.insert(names[0].clone(), rhs);
+                    }
+                }
+            }
+        }
+        "var_spec" | "const_spec" => {
+            if let (Some(name), Some(value)) = (
+                node.child_by_field_name("name"),
+                node.child_by_field_name("value"),
+            ) {
+                let name = name.utf8_text(source).unwrap_or("").trim().to_string();
+                let rhs = normalize_go_contract_expr(&value, source);
+                if !name.is_empty() && !rhs.is_empty() {
+                    bindings.insert(name, rhs);
+                }
+            }
+        }
+        _ => {}
+    }
+
+    let mut cursor = node.walk();
+    for child in node.children(&mut cursor) {
+        collect_go_bindings(&child, source, bindings);
+    }
+}
+
+fn collect_go_command_effects(
+    node: &tree_sitter::Node,
+    source: &[u8],
+    bindings: &BTreeMap<String, String>,
+    effects: &mut Vec<Value>,
+    seen: &mut BTreeSet<String>,
+) {
+    if node.kind() == "call_expression" {
+        if let Some((kind, expr)) = classify_go_command_effect_call(node, source) {
+            if seen.insert(format!("{kind}\n{expr}")) {
+                let identifiers = identifiers_in_node(node, source);
+                let mut consumed_bindings = serde_json::Map::new();
+                for ident in identifiers {
+                    if let Some(value) = bindings.get(&ident) {
+                        consumed_bindings.insert(ident, Value::String(value.clone()));
+                    }
+                }
+                effects.push(json!({
+                    "kind": kind,
+                    "expr": expr,
+                    "bindings": consumed_bindings,
+                }));
+            }
+        }
+    }
+
+    let mut cursor = node.walk();
+    for child in node.children(&mut cursor) {
+        collect_go_command_effects(&child, source, bindings, effects, seen);
+    }
+}
+
+fn classify_go_command_effect_call(
+    node: &tree_sitter::Node,
+    source: &[u8],
+) -> Option<(&'static str, String)> {
+    let function = node.child_by_field_name("function")?;
+    let callee = normalize_go_contract_expr(&function, source);
+    let expr = normalize_go_contract_expr(node, source);
+
+    if callee == "exec.Command" {
+        return Some(("subprocess_argv", expr));
+    }
+    if callee == "git.Config" || callee == "git.VerifyRef" {
+        return Some(("git_state_query", expr));
+    }
+    if callee == "append" && expr.contains("\"git\"") {
+        return Some(("queued_git_argv", expr));
+    }
+
+    None
+}
+
+fn assigned_identifier_names(node: &tree_sitter::Node, source: &[u8]) -> Vec<String> {
+    let mut names = Vec::new();
+    match node.kind() {
+        "identifier" => {
+            let name = node.utf8_text(source).unwrap_or("").trim();
+            if !name.is_empty() && name != "_" {
+                names.push(name.to_string());
+            }
+        }
+        _ => {
+            let mut cursor = node.walk();
+            for child in node.children(&mut cursor) {
+                names.extend(assigned_identifier_names(&child, source));
+            }
+        }
+    }
+    names
+}
+
+fn identifiers_in_node(node: &tree_sitter::Node, source: &[u8]) -> BTreeSet<String> {
+    let mut names = BTreeSet::new();
+    collect_identifiers_in_node(node, source, &mut names);
+    names
+}
+
+fn collect_identifiers_in_node(
+    node: &tree_sitter::Node,
+    source: &[u8],
+    names: &mut BTreeSet<String>,
+) {
+    if node.kind() == "identifier" {
+        let name = node.utf8_text(source).unwrap_or("").trim();
+        if !name.is_empty() && name != "_" {
+            names.insert(name.to_string());
+        }
+        return;
+    }
+
+    let mut cursor = node.walk();
+    for child in node.children(&mut cursor) {
+        collect_identifiers_in_node(&child, source, names);
+    }
+}
+
+fn normalize_go_contract_expr(node: &tree_sitter::Node, source: &[u8]) -> String {
+    node.utf8_text(source)
+        .unwrap_or("")
+        .split_whitespace()
+        .collect::<Vec<_>>()
+        .join(" ")
 }
 
 #[allow(clippy::too_many_arguments)]
@@ -1317,6 +1530,84 @@ func (s *Server) Start() { fmt.Println("starting") }
             .filter(|r| r.kind == kin_model::RelationKind::References)
             .map(|r| (r.src_name.as_str(), r.dst_name.as_str()))
             .collect()
+    }
+
+    #[test]
+    fn command_effect_contract_captures_git_branch_binding() {
+        let adapter = GoAdapter;
+        let source = br#"
+package command
+
+import (
+    "fmt"
+    "os/exec"
+
+    "github.com/spf13/cobra"
+)
+
+func prCheckout(cmd *cobra.Command, args []string) error {
+    newBranchName := fmt.Sprintf("pr/%d/%s", pr.Number, pr.HeadRefName)
+    if git.VerifyRef("refs/heads/" + newBranchName) {
+        cmdQueue = append(cmdQueue, []string{"git", "checkout", newBranchName})
+    } else {
+        cmdQueue = append(cmdQueue, []string{"git", "checkout", "-b", newBranchName, "--no-track", remoteBranch})
+    }
+    exec.Command("git", "config", fmt.Sprintf("branch.%s.remote", newBranchName), remote)
+    return nil
+}
+"#;
+        let tree = adapter.parse(source).unwrap();
+        let file_id = FilePathId::new("checkout.go");
+        let output = adapter.extract(&tree, source, &file_id).unwrap();
+        let mut entities: Vec<_> = output
+            .entities
+            .into_iter()
+            .map(|entity| entity.into_entity(LanguageId::Go, &file_id))
+            .collect();
+        attach_go_command_effect_contract_metadata(&tree, source, &mut entities);
+        let entity = entities
+            .iter()
+            .find(|entity| entity.name == "prCheckout")
+            .expect("handler entity should exist");
+        let contract = entity
+            .metadata
+            .extra
+            .get(COMMAND_EFFECT_CONTRACT_KEY)
+            .expect("command contract metadata should be attached")
+            .to_string();
+
+        assert!(
+            contract.contains("queued_git_argv"),
+            "queued git argv effects should be captured: {contract}"
+        );
+        assert!(
+            contract.contains("subprocess_argv"),
+            "direct exec.Command effects should be captured: {contract}"
+        );
+        assert!(
+            contract.contains("fmt.Sprintf(\\\"pr/%d/%s\\\", pr.Number, pr.HeadRefName)"),
+            "branch-name binding should be captured: {contract}"
+        );
+    }
+
+    #[test]
+    fn debug_print_change_does_not_emit_command_effect_contract() {
+        let adapter = GoAdapter;
+        let source = br#"
+package command
+
+import "fmt"
+
+func prCheckout() error {
+    fmt.Println("debug")
+    return nil
+}
+"#;
+        let tree = adapter.parse(source).unwrap();
+        assert!(
+            extract_go_command_effect_contracts(&tree, source).is_empty(),
+            "debug-only output must not become a command-effect contract"
+        );
     }
 
     #[test]

--- a/crates/kin-parser/src/languages/go.rs
+++ b/crates/kin-parser/src/languages/go.rs
@@ -609,13 +609,7 @@ fn go_visibility_with_path(name: &str, file_id: &FilePathId) -> Visibility {
 }
 
 fn node_signature(node: &tree_sitter::Node, source: &[u8]) -> String {
-    let text = node.utf8_text(source).unwrap_or("");
-    text.lines()
-        .next()
-        .unwrap_or(text)
-        .trim_end_matches('{')
-        .trim()
-        .to_string()
+    crate::adapter::declaration_signature(node, source)
 }
 
 fn extract_preceding_comment(node: &tree_sitter::Node, source: &[u8]) -> Option<String> {

--- a/crates/kin-parser/src/languages/go.rs
+++ b/crates/kin-parser/src/languages/go.rs
@@ -185,23 +185,33 @@ fn extract_go_command_effect_contracts(tree: &Tree, source: &[u8]) -> BTreeMap<S
     let mut cursor = root.walk();
 
     for child in root.children(&mut cursor) {
-        if child.kind() != "function_declaration" {
-            continue;
+        let name = match child.kind() {
+            "function_declaration" => child
+                .child_by_field_name("name")
+                .map(|name| name.utf8_text(source).unwrap_or("").to_string()),
+            "method_declaration" => child.child_by_field_name("name").map(|name| {
+                let method_name = name.utf8_text(source).unwrap_or("").to_string();
+                let receiver_type = child
+                    .child_by_field_name("receiver")
+                    .and_then(|receiver| extract_receiver_type(&receiver, source))
+                    .unwrap_or_default();
+                if receiver_type.is_empty() {
+                    method_name
+                } else {
+                    format!("{receiver_type}.{method_name}")
+                }
+            }),
+            _ => None,
+        };
+
+        if let (Some(name), Some(body)) = (name, child.child_by_field_name("body")) {
+            if name.is_empty() {
+                continue;
+            }
+            if let Some(contract) = command_effect_contract_for_body(&body, source) {
+                contracts.insert(name, contract);
+            }
         }
-        let Some(name_node) = child.child_by_field_name("name") else {
-            continue;
-        };
-        let name = name_node.utf8_text(source).unwrap_or("").to_string();
-        if name.is_empty() {
-            continue;
-        }
-        let Some(body) = child.child_by_field_name("body") else {
-            continue;
-        };
-        let Some(contract) = command_effect_contract_for_body(&body, source) else {
-            continue;
-        };
-        contracts.insert(name, contract);
     }
 
     contracts
@@ -209,11 +219,9 @@ fn extract_go_command_effect_contracts(tree: &Tree, source: &[u8]) -> BTreeMap<S
 
 fn command_effect_contract_for_body(node: &tree_sitter::Node, source: &[u8]) -> Option<Value> {
     let mut bindings = BTreeMap::new();
-    collect_go_bindings(node, source, &mut bindings);
-
     let mut effects = Vec::new();
     let mut seen = BTreeSet::new();
-    collect_go_command_effects(node, source, &bindings, &mut effects, &mut seen);
+    collect_go_command_effects_flow(node, source, &mut bindings, &mut effects, &mut seen);
     if effects.is_empty() {
         return None;
     }
@@ -225,10 +233,12 @@ fn command_effect_contract_for_body(node: &tree_sitter::Node, source: &[u8]) -> 
     }))
 }
 
-fn collect_go_bindings(
+fn collect_go_command_effects_flow(
     node: &tree_sitter::Node,
     source: &[u8],
     bindings: &mut BTreeMap<String, String>,
+    effects: &mut Vec<Value>,
+    seen: &mut BTreeSet<String>,
 ) {
     match node.kind() {
         "short_var_declaration" | "assignment_statement" => {
@@ -236,24 +246,74 @@ fn collect_go_bindings(
                 node.child_by_field_name("left"),
                 node.child_by_field_name("right"),
             ) {
+                collect_go_command_effects_flow(&right, source, bindings, effects, seen);
                 let names = assigned_identifier_names(&left, source);
-                if names.len() == 1 {
+                if names.len() == 1 && is_contract_binding_value(&right, source) {
                     let rhs = normalize_go_contract_expr(&right, source);
                     if !rhs.is_empty() {
                         bindings.insert(names[0].clone(), rhs);
                     }
                 }
             }
+            return;
         }
         "var_spec" | "const_spec" => {
             if let (Some(name), Some(value)) = (
                 node.child_by_field_name("name"),
                 node.child_by_field_name("value"),
             ) {
+                collect_go_command_effects_flow(&value, source, bindings, effects, seen);
                 let name = name.utf8_text(source).unwrap_or("").trim().to_string();
-                let rhs = normalize_go_contract_expr(&value, source);
-                if !name.is_empty() && !rhs.is_empty() {
-                    bindings.insert(name, rhs);
+                if !name.is_empty() && is_contract_binding_value(&value, source) {
+                    let rhs = normalize_go_contract_expr(&value, source);
+                    if !rhs.is_empty() {
+                        bindings.insert(name, rhs);
+                    }
+                }
+            }
+            return;
+        }
+        "if_statement" => {
+            let mut cursor = node.walk();
+            for child in node.children(&mut cursor) {
+                if child.kind() == "block" || child.kind() == "else" {
+                    let mut branch_bindings = bindings.clone();
+                    collect_go_command_effects_flow(
+                        &child,
+                        source,
+                        &mut branch_bindings,
+                        effects,
+                        seen,
+                    );
+                } else {
+                    collect_go_command_effects_flow(&child, source, bindings, effects, seen);
+                }
+            }
+            return;
+        }
+        "for_statement" | "range_clause" => {
+            let mut loop_bindings = bindings.clone();
+            let mut cursor = node.walk();
+            for child in node.children(&mut cursor) {
+                collect_go_command_effects_flow(&child, source, &mut loop_bindings, effects, seen);
+            }
+            return;
+        }
+        "call_expression" => {
+            if let Some((kind, expr)) = classify_go_command_effect_call(node, source) {
+                if seen.insert(format!("{kind}\n{expr}")) {
+                    let identifiers = identifiers_in_node(node, source);
+                    let mut consumed_bindings = serde_json::Map::new();
+                    for ident in identifiers {
+                        if let Some(value) = bindings.get(&ident) {
+                            consumed_bindings.insert(ident, Value::String(value.clone()));
+                        }
+                    }
+                    effects.push(json!({
+                        "kind": kind,
+                        "expr": expr,
+                        "bindings": consumed_bindings,
+                    }));
                 }
             }
         }
@@ -262,40 +322,26 @@ fn collect_go_bindings(
 
     let mut cursor = node.walk();
     for child in node.children(&mut cursor) {
-        collect_go_bindings(&child, source, bindings);
+        collect_go_command_effects_flow(&child, source, bindings, effects, seen);
     }
 }
 
-fn collect_go_command_effects(
-    node: &tree_sitter::Node,
-    source: &[u8],
-    bindings: &BTreeMap<String, String>,
-    effects: &mut Vec<Value>,
-    seen: &mut BTreeSet<String>,
-) {
-    if node.kind() == "call_expression" {
-        if let Some((kind, expr)) = classify_go_command_effect_call(node, source) {
-            if seen.insert(format!("{kind}\n{expr}")) {
-                let identifiers = identifiers_in_node(node, source);
-                let mut consumed_bindings = serde_json::Map::new();
-                for ident in identifiers {
-                    if let Some(value) = bindings.get(&ident) {
-                        consumed_bindings.insert(ident, Value::String(value.clone()));
-                    }
-                }
-                effects.push(json!({
-                    "kind": kind,
-                    "expr": expr,
-                    "bindings": consumed_bindings,
-                }));
-            }
-        }
+fn is_contract_binding_value(node: &tree_sitter::Node, source: &[u8]) -> bool {
+    if node.kind() == "composite_literal" {
+        return false;
     }
+    !contains_go_command_effect_call(node, source)
+}
 
-    let mut cursor = node.walk();
-    for child in node.children(&mut cursor) {
-        collect_go_command_effects(&child, source, bindings, effects, seen);
+fn contains_go_command_effect_call(node: &tree_sitter::Node, source: &[u8]) -> bool {
+    if node.kind() == "call_expression" && classify_go_command_effect_call(node, source).is_some() {
+        return true;
     }
+    let mut cursor = node.walk();
+    let found = node
+        .children(&mut cursor)
+        .any(|child| contains_go_command_effect_call(&child, source));
+    found
 }
 
 fn classify_go_command_effect_call(
@@ -1607,6 +1653,81 @@ func prCheckout() error {
         assert!(
             extract_go_command_effect_contracts(&tree, source).is_empty(),
             "debug-only output must not become a command-effect contract"
+        );
+    }
+
+    #[test]
+    fn command_effect_contract_uses_bindings_at_call_site() {
+        let adapter = GoAdapter;
+        let source = br#"
+package command
+
+import (
+    "fmt"
+    "os/exec"
+)
+
+func prCheckout() error {
+    newBranchName := pr.HeadRefName
+    exec.Command("git", "checkout", newBranchName)
+    newBranchName = fmt.Sprintf("pr/%d/%s", pr.Number, pr.HeadRefName)
+    exec.Command("git", "config", fmt.Sprintf("branch.%s.remote", newBranchName), "origin")
+    return nil
+}
+"#;
+        let tree = adapter.parse(source).unwrap();
+        let contracts = extract_go_command_effect_contracts(&tree, source);
+        let contract = contracts
+            .get("prCheckout")
+            .expect("contract should be extracted");
+        let effects = contract["effects"].as_array().expect("effects array");
+        assert_eq!(effects.len(), 2, "expected two command effects: {contract}");
+        assert_eq!(
+            effects[0]["bindings"]["newBranchName"], "pr.HeadRefName",
+            "first command must use the binding visible before reassignment"
+        );
+        assert_eq!(
+            effects[1]["bindings"]["newBranchName"],
+            "fmt.Sprintf(\"pr/%d/%s\", pr.Number, pr.HeadRefName)",
+            "second command must use the reassigned binding"
+        );
+    }
+
+    #[test]
+    fn command_effect_contract_attaches_to_go_methods() {
+        let adapter = GoAdapter;
+        let source = br#"
+package command
+
+import "os/exec"
+
+type Runner struct{}
+
+func (r *Runner) prCheckout() error {
+    newBranchName := pr.HeadRefName
+    exec.Command("git", "checkout", newBranchName)
+    return nil
+}
+"#;
+        let tree = adapter.parse(source).unwrap();
+        let file_id = FilePathId::new("checkout.go");
+        let output = adapter.extract(&tree, source, &file_id).unwrap();
+        let mut entities: Vec<_> = output
+            .entities
+            .into_iter()
+            .map(|entity| entity.into_entity(LanguageId::Go, &file_id))
+            .collect();
+        attach_go_command_effect_contract_metadata(&tree, source, &mut entities);
+        let entity = entities
+            .iter()
+            .find(|entity| entity.name == "Runner.prCheckout")
+            .expect("method entity should be qualified by receiver type");
+        assert!(
+            entity
+                .metadata
+                .extra
+                .contains_key(COMMAND_EFFECT_CONTRACT_KEY),
+            "command-effect metadata should attach to method entities"
         );
     }
 

--- a/crates/kin-parser/src/languages/hcl.rs
+++ b/crates/kin-parser/src/languages/hcl.rs
@@ -399,13 +399,7 @@ fn find_child_by_kind<'a>(
 }
 
 fn node_signature(node: &tree_sitter::Node, source: &[u8]) -> String {
-    let text = node.utf8_text(source).unwrap_or("");
-    text.lines()
-        .next()
-        .unwrap_or(text)
-        .trim_end_matches('{')
-        .trim()
-        .to_string()
+    crate::adapter::declaration_signature(node, source)
 }
 
 fn extract_preceding_comment(node: &tree_sitter::Node, source: &[u8]) -> Option<String> {

--- a/crates/kin-parser/src/languages/java.rs
+++ b/crates/kin-parser/src/languages/java.rs
@@ -381,13 +381,7 @@ fn detect_java_visibility(node: &tree_sitter::Node, source: &[u8]) -> Visibility
 }
 
 fn node_signature(node: &tree_sitter::Node, source: &[u8]) -> String {
-    let text = node.utf8_text(source).unwrap_or("");
-    text.lines()
-        .next()
-        .unwrap_or(text)
-        .trim_end_matches('{')
-        .trim()
-        .to_string()
+    crate::adapter::declaration_signature(node, source)
 }
 
 fn extract_preceding_comment(node: &tree_sitter::Node, source: &[u8]) -> Option<String> {

--- a/crates/kin-parser/src/languages/javascript.rs
+++ b/crates/kin-parser/src/languages/javascript.rs
@@ -523,13 +523,7 @@ fn detect_js_visibility(node: &tree_sitter::Node) -> Visibility {
 }
 
 fn node_signature(node: &tree_sitter::Node, source: &[u8]) -> String {
-    let text = node.utf8_text(source).unwrap_or("");
-    text.lines()
-        .next()
-        .unwrap_or(text)
-        .trim_end_matches('{')
-        .trim()
-        .to_string()
+    crate::adapter::declaration_signature(node, source)
 }
 
 fn extract_preceding_comment(node: &tree_sitter::Node, source: &[u8]) -> Option<String> {

--- a/crates/kin-parser/src/languages/kotlin.rs
+++ b/crates/kin-parser/src/languages/kotlin.rs
@@ -490,13 +490,7 @@ fn detect_kotlin_visibility(node: &tree_sitter::Node, source: &[u8]) -> Visibili
 }
 
 fn node_signature(node: &tree_sitter::Node, source: &[u8]) -> String {
-    let text = node.utf8_text(source).unwrap_or("");
-    text.lines()
-        .next()
-        .unwrap_or(text)
-        .trim_end_matches('{')
-        .trim()
-        .to_string()
+    crate::adapter::declaration_signature(node, source)
 }
 
 fn extract_preceding_comment(node: &tree_sitter::Node, source: &[u8]) -> Option<String> {

--- a/crates/kin-parser/src/languages/mod.rs
+++ b/crates/kin-parser/src/languages/mod.rs
@@ -17,7 +17,7 @@ pub mod typescript;
 
 pub use c_lang::CAdapter;
 pub use cpp_lang::CppAdapter;
-pub use go::GoAdapter;
+pub use go::{attach_go_command_effect_contract_metadata, GoAdapter};
 pub use hcl::HclAdapter;
 pub use java::JavaAdapter;
 pub use javascript::JavaScriptAdapter;

--- a/crates/kin-parser/src/languages/php.rs
+++ b/crates/kin-parser/src/languages/php.rs
@@ -383,13 +383,7 @@ fn detect_php_visibility(node: &tree_sitter::Node, source: &[u8]) -> Visibility 
 }
 
 fn node_signature(node: &tree_sitter::Node, source: &[u8]) -> String {
-    let text = node.utf8_text(source).unwrap_or("");
-    text.lines()
-        .next()
-        .unwrap_or(text)
-        .trim_end_matches('{')
-        .trim()
-        .to_string()
+    crate::adapter::declaration_signature(node, source)
 }
 
 fn extract_preceding_comment(node: &tree_sitter::Node, source: &[u8]) -> Option<String> {

--- a/crates/kin-parser/src/languages/python.rs
+++ b/crates/kin-parser/src/languages/python.rs
@@ -403,13 +403,7 @@ fn extract_decorator_payload_name(node: &tree_sitter::Node, source: &[u8]) -> Op
 }
 
 fn node_signature(node: &tree_sitter::Node, source: &[u8]) -> String {
-    let text = node.utf8_text(source).unwrap_or("");
-    text.lines()
-        .next()
-        .unwrap_or(text)
-        .trim_end_matches(':')
-        .trim()
-        .to_string()
+    crate::adapter::declaration_signature(node, source)
 }
 
 fn extract_docstring(node: &tree_sitter::Node, source: &[u8]) -> Option<String> {

--- a/crates/kin-parser/src/languages/rust_lang.rs
+++ b/crates/kin-parser/src/languages/rust_lang.rs
@@ -481,13 +481,7 @@ fn has_macro_export(node: &tree_sitter::Node, source: &[u8]) -> bool {
 }
 
 fn node_signature(node: &tree_sitter::Node, source: &[u8]) -> String {
-    let text = node.utf8_text(source).unwrap_or("");
-    text.lines()
-        .next()
-        .unwrap_or(text)
-        .trim_end_matches('{')
-        .trim()
-        .to_string()
+    crate::adapter::declaration_signature(node, source)
 }
 
 fn extract_doc_comment(node: &tree_sitter::Node, source: &[u8]) -> Option<String> {

--- a/crates/kin-parser/src/languages/shallow_backed.rs
+++ b/crates/kin-parser/src/languages/shallow_backed.rs
@@ -839,13 +839,7 @@ fn ruby_visibility(name: &str) -> Visibility {
 }
 
 fn node_signature(node: &Node, source: &[u8]) -> String {
-    let text = node.utf8_text(source).unwrap_or("");
-    text.lines()
-        .next()
-        .unwrap_or(text)
-        .trim_end_matches('{')
-        .trim()
-        .to_string()
+    crate::adapter::declaration_signature(node, source)
 }
 
 fn extract_preceding_comment(node: &Node, source: &[u8]) -> Option<String> {

--- a/crates/kin-parser/src/languages/swift.rs
+++ b/crates/kin-parser/src/languages/swift.rs
@@ -538,13 +538,7 @@ fn detect_swift_visibility(node: &tree_sitter::Node, source: &[u8]) -> Visibilit
 }
 
 fn node_signature(node: &tree_sitter::Node, source: &[u8]) -> String {
-    let text = node.utf8_text(source).unwrap_or("");
-    text.lines()
-        .next()
-        .unwrap_or(text)
-        .trim_end_matches('{')
-        .trim()
-        .to_string()
+    crate::adapter::declaration_signature(node, source)
 }
 
 fn extract_preceding_comment(node: &tree_sitter::Node, source: &[u8]) -> Option<String> {

--- a/crates/kin-parser/src/languages/typescript.rs
+++ b/crates/kin-parser/src/languages/typescript.rs
@@ -576,15 +576,7 @@ fn detect_ts_member_visibility(node: &tree_sitter::Node, source: &[u8]) -> Visib
 }
 
 fn node_signature(node: &tree_sitter::Node, source: &[u8]) -> String {
-    let text = node.utf8_text(source).unwrap_or("");
-    // Take first line or up to opening brace
-    let sig = text
-        .lines()
-        .next()
-        .unwrap_or(text)
-        .trim_end_matches('{')
-        .trim();
-    sig.to_string()
+    crate::adapter::declaration_signature(node, source)
 }
 
 fn extract_preceding_comment(node: &tree_sitter::Node, source: &[u8]) -> Option<String> {

--- a/crates/kin-parser/src/lib.rs
+++ b/crates/kin-parser/src/lib.rs
@@ -19,13 +19,13 @@ pub use adapter::{EditHint, LanguageAdapter};
 pub use error::{ParseError, Result};
 pub use extract::{
     attach_file_context_metadata, ExtractedEntity, ExtractedRelation, ExtractedTest,
-    ExtractedTestKind, FileImport, ImportedName, ParseOutput, FILE_IMPORT_CONTEXT_KEY,
-    FILE_SURFACE_CONTEXT_KEY,
+    ExtractedTestKind, FileImport, ImportedName, ParseOutput, COMMAND_EFFECT_CONTRACT_KEY,
+    FILE_IMPORT_CONTEXT_KEY, FILE_SURFACE_CONTEXT_KEY,
 };
 pub use languages::{
-    AdapterRegistry, CAdapter, CSharpAdapter, CppAdapter, GoAdapter, HclAdapter, JavaAdapter,
-    JavaScriptAdapter, KotlinAdapter, PhpAdapter, PythonAdapter, RubyAdapter, RustAdapter,
-    SwiftAdapter, TypeScriptAdapter,
+    attach_go_command_effect_contract_metadata, AdapterRegistry, CAdapter, CSharpAdapter,
+    CppAdapter, GoAdapter, HclAdapter, JavaAdapter, JavaScriptAdapter, KotlinAdapter, PhpAdapter,
+    PythonAdapter, RubyAdapter, RustAdapter, SwiftAdapter, TypeScriptAdapter,
 };
 pub use shallow::{
     extract_shallow, get_shallow_grammar, parse_shallow_file, ShallowDecl, ShallowDeclKind,

--- a/crates/kin-parser/tests/cpp_call_resolution.rs
+++ b/crates/kin-parser/tests/cpp_call_resolution.rs
@@ -1,0 +1,119 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Firelock, LLC
+
+//! Regression tests for C++ call-reference extraction.
+//!
+//! Callee names must reach the linker in instantiation-free, index-matchable
+//! form: template-argument lists are stripped from qualified callee paths
+//! (`ratio_string<Ratio>::symbol` → `ratio_string::symbol`), and calls inside
+//! template-struct member bodies and preprocessor-guarded blocks must emit
+//! References at all — the merge-trust Catch2 misses traced back to callee
+//! names no name index could match.
+
+use kin_model::{FilePathId, RelationKind};
+use kin_parser::{CppAdapter, ExtractedRelation, LanguageAdapter};
+
+fn parse_and_extract(source: &str) -> Vec<ExtractedRelation> {
+    let adapter = CppAdapter;
+    let bytes = source.as_bytes();
+    let tree = adapter.parse(bytes).expect("parse should succeed");
+    let file_id = FilePathId("test/calls.hpp".to_string());
+    let output = adapter
+        .extract(&tree, bytes, &file_id)
+        .expect("extract should succeed");
+    output.relations
+}
+
+fn calls_named<'a>(rels: &'a [ExtractedRelation], name: &str) -> Vec<&'a ExtractedRelation> {
+    rels.iter()
+        .filter(|r| r.kind == RelationKind::Calls && r.dst_name == name)
+        .collect()
+}
+
+#[test]
+fn template_member_call_strips_template_args_from_qualified_callee() {
+    let source = r#"
+namespace Catch {
+    template<class Ratio>
+    struct ratio_string {
+        static std::string symbol();
+    };
+
+    template<class Value, class Ratio>
+    struct StringMaker {
+        static std::string convert(Value const& duration) {
+            return ratio_string<Ratio>::symbol();
+        }
+    };
+}
+"#;
+    let rels = parse_and_extract(source);
+    assert!(
+        !calls_named(&rels, "ratio_string::symbol").is_empty(),
+        "template-arg-laden callee must be emitted instantiation-free, got: {:?}",
+        rels.iter()
+            .filter(|r| r.kind == RelationKind::Calls)
+            .map(|r| &r.dst_name)
+            .collect::<Vec<_>>()
+    );
+    assert!(
+        calls_named(&rels, "ratio_string<Ratio>::symbol").is_empty(),
+        "raw template-arg callee name must not leak into references"
+    );
+}
+
+#[test]
+fn call_in_template_member_body_emits_plain_callee() {
+    let source = r#"
+namespace Catch {
+    std::string time_t_toString(time_t const& toConvert);
+
+    template<typename Duration>
+    struct StringMaker {
+        static std::string convert(time_t const& value) {
+            return time_t_toString(value);
+        }
+    };
+}
+"#;
+    let rels = parse_and_extract(source);
+    assert!(
+        !calls_named(&rels, "time_t_toString").is_empty(),
+        "plain call inside a template member body must emit a Calls reference"
+    );
+}
+
+#[test]
+fn preproc_guarded_qualified_call_emits_reference() {
+    let source = r#"
+#ifndef TWOBLUECUBES_CATCH_DEFAULT_MAIN_HPP_INCLUDED
+#define TWOBLUECUBES_CATCH_DEFAULT_MAIN_HPP_INCLUDED
+
+#ifndef __OBJC__
+int main(int argc, char* const argv[]) {
+    return Catch::Main(argc, argv);
+}
+#endif
+
+#endif
+"#;
+    let rels = parse_and_extract(source);
+    assert!(
+        !calls_named(&rels, "Catch::Main").is_empty(),
+        "qualified call inside nested preprocessor guards must emit a Calls reference"
+    );
+}
+
+#[test]
+fn free_function_template_call_reduces_to_bare_name() {
+    let source = r#"
+void caller() {
+    process<int>(42);
+}
+"#;
+    let rels = parse_and_extract(source);
+    assert!(
+        !calls_named(&rels, "process").is_empty(),
+        "free-function template instantiation must emit the bare callee name"
+    );
+}

--- a/crates/kin-parser/tests/fingerprint_semantics.rs
+++ b/crates/kin-parser/tests/fingerprint_semantics.rs
@@ -1,0 +1,174 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Firelock, LLC
+
+//! Regression tests for fingerprint semantics.
+//!
+//! `compute_fingerprint` must produce identical fingerprints across
+//! comment-only and formatting-only edits (comments are grammar `extra`
+//! nodes; inter-token whitespace never reaches the tree), while staying
+//! sensitive to token changes and to structure moves that reuse the same
+//! token text. Raw-byte hashing violated this: a deleted comment or a
+//! reformat registered as a behavior change and fed false "behavior of X
+//! changed" evidence to review gates.
+
+use kin_model::{FilePathId, Hash256};
+use kin_parser::{CppAdapter, GoAdapter, LanguageAdapter, PythonAdapter, RustAdapter};
+
+fn entity_hashes(
+    adapter: &dyn LanguageAdapter,
+    source: &str,
+    name: &str,
+) -> (Hash256, Hash256, Hash256) {
+    let bytes = source.as_bytes();
+    let tree = adapter.parse(bytes).expect("parse should succeed");
+    let file_id = FilePathId(format!("test/fp.{}", adapter.file_extensions()[0]));
+    let output = adapter
+        .extract(&tree, bytes, &file_id)
+        .expect("extract should succeed");
+    let entity = output
+        .entities
+        .iter()
+        .find(|e| e.name == name)
+        .unwrap_or_else(|| {
+            panic!(
+                "entity '{}' not found; have: {:?}",
+                name,
+                output.entities.iter().map(|e| &e.name).collect::<Vec<_>>()
+            )
+        });
+    (
+        entity.fingerprint.ast_hash,
+        entity.fingerprint.signature_hash,
+        entity.fingerprint.behavior_hash,
+    )
+}
+
+#[test]
+fn go_comment_only_edit_keeps_fingerprint() {
+    let with_comment = r#"
+package config
+
+type AuthConfig struct{}
+
+func (c *AuthConfig) HasEnvToken() bool {
+    // This will check the token in the environment.
+    // It mirrors the lookup order used at auth time.
+    return len(envToken()) > 0
+}
+"#;
+    let without_comment = r#"
+package config
+
+type AuthConfig struct{}
+
+func (c *AuthConfig) HasEnvToken() bool {
+    return len(envToken()) > 0
+}
+"#;
+    let adapter = GoAdapter;
+    let a = entity_hashes(&adapter, with_comment, "AuthConfig.HasEnvToken");
+    let b = entity_hashes(&adapter, without_comment, "AuthConfig.HasEnvToken");
+    assert_eq!(
+        a, b,
+        "comment-only edit must not change any fingerprint hash"
+    );
+}
+
+#[test]
+fn cpp_whitespace_only_edit_keeps_fingerprint() {
+    let formatted = r#"
+int add(int a, int b) {
+    return a + b;
+}
+"#;
+    let compact = r#"
+int add(int a,int b){return a+b;}
+"#;
+    let adapter = CppAdapter;
+    let a = entity_hashes(&adapter, formatted, "add");
+    let b = entity_hashes(&adapter, compact, "add");
+    assert_eq!(
+        a, b,
+        "whitespace-only edit must not change any fingerprint hash"
+    );
+}
+
+#[test]
+fn cpp_member_comment_keeps_class_fingerprint() {
+    let with_comment = r#"
+class Widget {
+public:
+    // Rebuilds the cached layout.
+    void refresh();
+    int size() const;
+};
+"#;
+    let without_comment = r#"
+class Widget {
+public:
+    void refresh();
+    int size() const;
+};
+"#;
+    let adapter = CppAdapter;
+    let a = entity_hashes(&adapter, with_comment, "Widget");
+    let b = entity_hashes(&adapter, without_comment, "Widget");
+    assert_eq!(a, b, "member comment must not change the class fingerprint");
+}
+
+#[test]
+fn rust_token_change_alters_behavior_hash_only() {
+    let plus = "fn total(a: i32, b: i32) -> i32 { a + b }";
+    let minus = "fn total(a: i32, b: i32) -> i32 { a - b }";
+    let adapter = RustAdapter;
+    let (ast_a, sig_a, beh_a) = entity_hashes(&adapter, plus, "total");
+    let (ast_b, sig_b, beh_b) = entity_hashes(&adapter, minus, "total");
+    assert_eq!(ast_a, ast_b, "operator swap keeps the AST shape");
+    assert_eq!(sig_a, sig_b, "operator swap keeps the signature");
+    assert_ne!(beh_a, beh_b, "operator swap must alter the behavior hash");
+}
+
+#[test]
+fn rust_comment_only_edit_keeps_fingerprint() {
+    let with_comment = r#"
+fn total(a: i32, b: i32) -> i32 {
+    // Sum the operands.
+    a + b
+}
+"#;
+    let without_comment = r#"
+fn total(a: i32, b: i32) -> i32 {
+    a + b
+}
+"#;
+    let adapter = RustAdapter;
+    let a = entity_hashes(&adapter, with_comment, "total");
+    let b = entity_hashes(&adapter, without_comment, "total");
+    assert_eq!(
+        a, b,
+        "comment-only edit must not change any fingerprint hash"
+    );
+}
+
+#[test]
+fn python_block_move_alters_behavior_hash() {
+    let outside = r#"
+def guard(x):
+    if x:
+        prepare()
+    launch()
+"#;
+    let inside = r#"
+def guard(x):
+    if x:
+        prepare()
+        launch()
+"#;
+    let adapter = PythonAdapter;
+    let (_, _, beh_a) = entity_hashes(&adapter, outside, "guard");
+    let (_, _, beh_b) = entity_hashes(&adapter, inside, "guard");
+    assert_ne!(
+        beh_a, beh_b,
+        "moving a statement between blocks reuses the same tokens but must alter the behavior hash"
+    );
+}

--- a/crates/kin-parser/tests/fingerprint_semantics.rs
+++ b/crates/kin-parser/tests/fingerprint_semantics.rs
@@ -172,3 +172,57 @@ def guard(x):
         "moving a statement between blocks reuses the same tokens but must alter the behavior hash"
     );
 }
+
+#[test]
+fn cpp_multiline_declarator_keeps_signature_string() {
+    let single_line = r#"
+class ArgParser {
+public:
+    ArgParser( int argc, char* const argv[], Config& config )
+    : m_mode( modeNone )
+    {
+        parse();
+    }
+};
+"#;
+    let multi_line = r#"
+class ArgParser {
+public:
+    ArgParser
+    (   int argc, char* const argv[], Config& config )
+    :   m_mode( modeNone )
+    {
+        parse();
+    }
+};
+"#;
+    let adapter = CppAdapter;
+    let sig = |src: &str| {
+        let bytes = src.as_bytes();
+        let tree = adapter.parse(bytes).expect("parse should succeed");
+        let file_id = FilePathId("test/sig.hpp".to_string());
+        let output = adapter
+            .extract(&tree, bytes, &file_id)
+            .expect("extract should succeed");
+        output
+            .entities
+            .iter()
+            .find(|e| e.name == "ArgParser::ArgParser")
+            .map(|e| e.signature.clone())
+            .expect("constructor entity")
+    };
+    let a = sig(single_line);
+    let b = sig(multi_line);
+    assert_eq!(
+        a, b,
+        "line wrapping must not change the extracted signature string"
+    );
+    assert!(
+        a.contains("int argc"),
+        "signature must carry the parameter list, got: {a}"
+    );
+    assert!(
+        !a.contains("m_mode"),
+        "member-initializer list must not leak into the signature, got: {a}"
+    );
+}

--- a/crates/kin-review/src/impact.rs
+++ b/crates/kin-review/src/impact.rs
@@ -256,14 +256,12 @@ pub fn analyze_impact_at<I: ImpactGraph>(
         let mut ent_consumers: HashSet<EntityId> = HashSet::new();
         let mut ent_contract_consumers: HashSet<EntityId> = HashSet::new();
         let mut ent_tests: HashSet<EntityId> = HashSet::new();
+        // `consumer_files` is the human-readable projection of the consumer
+        // ENTITY set below (which the fanout decision keys on) — the files those
+        // consuming entities live in, for the report message only. It is never a
+        // decision input: a consumer that happens to share the changed entity's
+        // file is still a distinct consumer entity with a real inbound edge.
         let mut ent_consumer_files: BTreeSet<String> = BTreeSet::new();
-
-        // The changed entity's own source file. Consumer-fanout counts
-        // DISTINCT EXTERNAL consumer files, so a sibling consumer living in
-        // the same file is ordinary local iteration, not fanout: its file is
-        // excluded from the set below. A removed entity is absent at the ref
-        // and has no own file, so nothing is excluded for it.
-        let changed_own_file = graph.get_entity(&entity_id)?.as_ref().and_then(entity_file);
 
         // Find relations pointing TO this entity (callers, dependents, etc.).
         // `get_relations` serves outgoing edges only, so the inbound harvest
@@ -308,11 +306,7 @@ pub fn analyze_impact_at<I: ImpactGraph>(
                         ent_contract_consumers.insert(affected_id);
                     }
                     if let Some(file) = entity_file(&entity) {
-                        // A consumer in the changed entity's own file is not
-                        // fanout; only distinct EXTERNAL consumer files count.
-                        if Some(&file) != changed_own_file.as_ref() {
-                            ent_consumer_files.insert(file);
-                        }
+                        ent_consumer_files.insert(file);
                     }
                 }
                 match rel.kind {
@@ -732,12 +726,13 @@ mod tests {
     }
 
     #[test]
-    fn consumer_files_exclude_the_changed_entitys_own_file() {
-        // A (changed) in src/foo.rs is consumed by a same-file sibling B and
-        // by an external C in src/bar.rs. Fanout counts DISTINCT EXTERNAL
-        // consumer files, so A's own file must not count — only src/bar.rs.
-        // Before this fix the own file counted and a self-contained change
-        // could trip fanout.
+    fn consumer_count_is_entity_native_including_a_same_file_consumer() {
+        // A (changed) in src/foo.rs is consumed by a same-file sibling B and by
+        // an external C in src/bar.rs. Both B and C are distinct consumer
+        // ENTITIES with real inbound edges, so both count — the fanout decision
+        // is graph-native and never special-cases a consumer by the file it
+        // lives in. `consumer_files` is the reported projection of that entity
+        // set (both files), used only for the message, never for the decision.
         let a = entity_in_file("hot_path", "src/foo.rs", 1);
         let b = entity_in_file("sibling", "src/foo.rs", 40);
         let c = entity_in_file("external", "src/bar.rs", 1);
@@ -758,13 +753,13 @@ mod tests {
         let report = analyze_impact_at(&graph, &diff).unwrap();
         let impact_a = report.entity_impact(&a.id).expect("A has an impact entry");
         assert_eq!(
-            impact_a.consumer_files,
-            vec!["src/bar.rs".to_string()],
-            "the changed entity's own file is not a fanout consumer file"
+            impact_a.consumer_count, 2,
+            "both consumer entities count, regardless of the file they live in"
         );
         assert_eq!(
-            impact_a.consumer_count, 2,
-            "both consumers still count toward consumer_count; only the file set drops the own file"
+            impact_a.consumer_files,
+            vec!["src/bar.rs".to_string(), "src/foo.rs".to_string()],
+            "consumer_files is the projected file set of the consumer entities (both), report-only"
         );
     }
 }

--- a/crates/kin-review/src/impact.rs
+++ b/crates/kin-review/src/impact.rs
@@ -148,6 +148,12 @@ pub struct ImpactReport {
     pub entity_impacts: Vec<EntityImpact>,
 }
 
+/// Minimum inbound-edge confidence for a consumer to count toward
+/// verdict-driving fanout decisions. Ambiguous-dispatch fan-out links carry
+/// low confidence: they are real enough to display in the blast radius, but a
+/// possibly-reaching edge must not alone escalate a verdict.
+pub const STRONG_CONSUMER_CONFIDENCE: f32 = 0.6;
+
 /// Graph-proven inbound impact attributed to one directly changed entity.
 ///
 /// All counts are inbound-only: entities that reach the changed entity via
@@ -160,6 +166,10 @@ pub struct EntityImpact {
     pub entity_id: EntityId,
     /// Distinct non-test entities that consume this entity.
     pub consumer_count: usize,
+    /// Subset of `consumer_count` whose inbound edge confidence is at least
+    /// [`STRONG_CONSUMER_CONFIDENCE`] — the count verdict gates key on.
+    #[serde(default)]
+    pub strong_consumer_count: usize,
     /// Distinct non-test entities consuming this entity as a contract.
     pub contract_consumer_count: usize,
     /// Sorted distinct source files of the non-test consumers above.
@@ -254,6 +264,7 @@ pub fn analyze_impact_at<I: ImpactGraph>(
         // buckets. Sets are used only for distinct counts, never for output
         // ordering, so iteration order cannot leak into the report.
         let mut ent_consumers: HashSet<EntityId> = HashSet::new();
+        let mut ent_strong_consumers: HashSet<EntityId> = HashSet::new();
         let mut ent_contract_consumers: HashSet<EntityId> = HashSet::new();
         let mut ent_tests: HashSet<EntityId> = HashSet::new();
         // `consumer_files` is the human-readable projection of the consumer
@@ -302,6 +313,9 @@ pub fn analyze_impact_at<I: ImpactGraph>(
                     ent_tests.insert(affected_id);
                 } else {
                     ent_consumers.insert(affected_id);
+                    if rel.confidence >= STRONG_CONSUMER_CONFIDENCE {
+                        ent_strong_consumers.insert(affected_id);
+                    }
                     if rel.kind == RelationKind::ConsumesContract {
                         ent_contract_consumers.insert(affected_id);
                     }
@@ -365,6 +379,7 @@ pub fn analyze_impact_at<I: ImpactGraph>(
         entity_impacts.push(EntityImpact {
             entity_id,
             consumer_count: ent_consumers.len(),
+            strong_consumer_count: ent_strong_consumers.len(),
             contract_consumer_count: ent_contract_consumers.len(),
             consumer_files: ent_consumer_files.into_iter().collect(),
             covering_tests: ent_tests.len(),

--- a/crates/kin-review/src/impact.rs
+++ b/crates/kin-review/src/impact.rs
@@ -258,6 +258,13 @@ pub fn analyze_impact_at<I: ImpactGraph>(
         let mut ent_tests: HashSet<EntityId> = HashSet::new();
         let mut ent_consumer_files: BTreeSet<String> = BTreeSet::new();
 
+        // The changed entity's own source file. Consumer-fanout counts
+        // DISTINCT EXTERNAL consumer files, so a sibling consumer living in
+        // the same file is ordinary local iteration, not fanout: its file is
+        // excluded from the set below. A removed entity is absent at the ref
+        // and has no own file, so nothing is excluded for it.
+        let changed_own_file = graph.get_entity(&entity_id)?.as_ref().and_then(entity_file);
+
         // Find relations pointing TO this entity (callers, dependents, etc.).
         // `get_relations` serves outgoing edges only, so the inbound harvest
         // reads the full edge set and keeps the incoming side.
@@ -301,7 +308,11 @@ pub fn analyze_impact_at<I: ImpactGraph>(
                         ent_contract_consumers.insert(affected_id);
                     }
                     if let Some(file) = entity_file(&entity) {
-                        ent_consumer_files.insert(file);
+                        // A consumer in the changed entity's own file is not
+                        // fanout; only distinct EXTERNAL consumer files count.
+                        if Some(&file) != changed_own_file.as_ref() {
+                            ent_consumer_files.insert(file);
+                        }
                     }
                 }
                 match rel.kind {
@@ -344,10 +355,13 @@ pub fn analyze_impact_at<I: ImpactGraph>(
                     tests.push(entity);
                 }
             } else {
-                ent_consumers.insert(entity.id);
-                if let Some(file) = entity_file(&entity) {
-                    ent_consumer_files.insert(file);
-                }
+                // Transitive (2-hop) reach populates the blast-radius
+                // dependents bucket for the report, but must NOT feed the
+                // per-entity consumer_count / consumer_files that drive the
+                // breaking and consumer-fanout signals. Those attribute from
+                // DIRECT inbound edges outside the changed set only, so a path
+                // that routes through a co-updated intermediate cannot inflate
+                // this entity's contract-surface risk.
                 if seen_dependents.insert(entity.id) {
                     dependents.push(entity);
                 }
@@ -543,5 +557,214 @@ mod tests {
             ..Default::default()
         };
         assert!(!report.is_empty());
+    }
+
+    // ── Per-entity attribution: direct-only consumer_count / consumer_files ──
+
+    use crate::diff::{EntityChange, EntityChangeKind};
+    use kin_model::entity::SourceSpan;
+    use kin_model::provenance::{Actor, ActorId, Approval, AuditEvent};
+    use kin_model::relation::{GraphNodeId, Relation, RelationKind, RelationOrigin};
+    use kin_model::work::{Annotation, WorkItem, WorkScope};
+    use std::collections::HashMap;
+
+    fn entity_in_file(name: &str, file: &str, line: u32) -> Entity {
+        Entity {
+            id: EntityId::new(),
+            kind: EntityKind::Function,
+            name: name.to_string(),
+            language: LanguageId::Rust,
+            fingerprint: SemanticFingerprint {
+                algorithm: FingerprintAlgorithm::V1TreeSitter,
+                ast_hash: Hash256::from_bytes([0; 32]),
+                signature_hash: Hash256::from_bytes([0; 32]),
+                behavior_hash: Hash256::from_bytes([0; 32]),
+                stability_score: 1.0,
+            },
+            file_origin: Some(FilePathId::new(file)),
+            span: Some(SourceSpan {
+                file: FilePathId::new(file),
+                start_byte: 0,
+                end_byte: 10,
+                start_line: line,
+                start_col: 0,
+                end_line: line + 1,
+                end_col: 0,
+            }),
+            signature: format!("fn {}()", name),
+            visibility: Visibility::Public,
+            role: EntityRole::Source,
+            doc_summary: None,
+            metadata: EntityMetadata::default(),
+            lineage_parent: None,
+            created_in: None,
+            superseded_by: None,
+        }
+    }
+
+    fn calls(src: &Entity, dst: &Entity) -> Relation {
+        Relation {
+            id: RelationId::new(),
+            kind: RelationKind::Calls,
+            src: GraphNodeId::Entity(src.id),
+            dst: GraphNodeId::Entity(dst.id),
+            confidence: 1.0,
+            origin: RelationOrigin::Parsed,
+            created_in: None,
+            import_source: None,
+            evidence: vec![],
+        }
+    }
+
+    fn modified(entity: &Entity) -> EntityChange {
+        EntityChange {
+            entity_id: entity.id,
+            kind: EntityChangeKind::Modified {
+                old: entity.clone(),
+                new: entity.clone(),
+            },
+        }
+    }
+
+    /// Hand-built [`ImpactGraph`] returning exactly the inbound edges and
+    /// transitive downstream entities each test wires — no dependency on
+    /// live-store or ref-replay traversal semantics.
+    #[derive(Default)]
+    struct MockImpactGraph {
+        entities: HashMap<EntityId, Entity>,
+        inbound: HashMap<EntityId, Vec<Relation>>,
+        downstream: HashMap<EntityId, Vec<Entity>>,
+    }
+
+    impl ImpactGraph for MockImpactGraph {
+        fn get_entity(&self, id: &EntityId) -> Result<Option<Entity>, ReviewError> {
+            Ok(self.entities.get(id).cloned())
+        }
+        fn get_relations(
+            &self,
+            _id: &EntityId,
+            _kinds: &[RelationKind],
+        ) -> Result<Vec<Relation>, ReviewError> {
+            Ok(vec![])
+        }
+        fn get_all_relations_for_entity(
+            &self,
+            id: &EntityId,
+        ) -> Result<Vec<Relation>, ReviewError> {
+            Ok(self.inbound.get(id).cloned().unwrap_or_default())
+        }
+        fn get_downstream_impact(
+            &self,
+            id: &EntityId,
+            _max_depth: u32,
+        ) -> Result<Vec<Entity>, ReviewError> {
+            Ok(self.downstream.get(id).cloned().unwrap_or_default())
+        }
+        fn get_work_for_scope(&self, _scope: &WorkScope) -> Result<Vec<WorkItem>, ReviewError> {
+            Ok(vec![])
+        }
+        fn get_annotations_for_scope(
+            &self,
+            _scope: &WorkScope,
+        ) -> Result<Vec<Annotation>, ReviewError> {
+            Ok(vec![])
+        }
+        fn get_approvals_for_change(
+            &self,
+            _id: &SemanticChangeId,
+        ) -> Result<Vec<Approval>, ReviewError> {
+            Ok(vec![])
+        }
+        fn query_audit_events(
+            &self,
+            _actor_id: Option<&ActorId>,
+            _limit: usize,
+        ) -> Result<Vec<AuditEvent>, ReviewError> {
+            Ok(vec![])
+        }
+        fn get_actor(&self, _id: &ActorId) -> Result<Option<Actor>, ReviewError> {
+            Ok(None)
+        }
+    }
+
+    #[test]
+    fn consumer_count_counts_direct_inbound_not_two_hop_through_changed() {
+        // A and B are both changed (co-updated). B consumes A directly, C
+        // consumes B, and D consumes A directly. The 2-hop walk from A reaches
+        // C through the co-updated intermediate B. C must NOT inflate A's
+        // consumer_count — breaking risk is attributed from DIRECT external
+        // consumers only, so A counts D alone. Before this fix C leaked in via
+        // the 2-hop walk and A's consumer_count was 2.
+        let a = entity_in_file("target_a", "src/a.rs", 1);
+        let b = entity_in_file("mid_b", "src/b.rs", 1);
+        let c = entity_in_file("far_c", "src/c.rs", 1);
+        let d = entity_in_file("direct_d", "src/d.rs", 1);
+
+        let mut graph = MockImpactGraph::default();
+        for entity in [&a, &b, &c, &d] {
+            graph.entities.insert(entity.id, entity.clone());
+        }
+        // Direct inbound to A: B and D call A.
+        graph
+            .inbound
+            .insert(a.id, vec![calls(&b, &a), calls(&d, &a)]);
+        // Direct inbound to B: C calls B.
+        graph.inbound.insert(b.id, vec![calls(&c, &b)]);
+        // Transitive downstream of A reaches B (depth 1) and C (depth 2).
+        graph
+            .downstream
+            .insert(a.id, vec![b.clone(), c.clone(), d.clone()]);
+
+        let diff = SemanticDiff {
+            entity_changes: vec![modified(&a), modified(&b)],
+            ..Default::default()
+        };
+
+        let report = analyze_impact_at(&graph, &diff).unwrap();
+        let impact_a = report.entity_impact(&a.id).expect("A has an impact entry");
+        assert_eq!(
+            impact_a.consumer_count, 1,
+            "only the direct external consumer D counts; C (2-hop via co-updated B) must not"
+        );
+        // C is still reachable as transitive blast radius (report surface),
+        // just not as a direct-consumer attribution.
+        assert!(report.affected_dependents.iter().any(|e| e.id == c.id));
+    }
+
+    #[test]
+    fn consumer_files_exclude_the_changed_entitys_own_file() {
+        // A (changed) in src/foo.rs is consumed by a same-file sibling B and
+        // by an external C in src/bar.rs. Fanout counts DISTINCT EXTERNAL
+        // consumer files, so A's own file must not count — only src/bar.rs.
+        // Before this fix the own file counted and a self-contained change
+        // could trip fanout.
+        let a = entity_in_file("hot_path", "src/foo.rs", 1);
+        let b = entity_in_file("sibling", "src/foo.rs", 40);
+        let c = entity_in_file("external", "src/bar.rs", 1);
+
+        let mut graph = MockImpactGraph::default();
+        for entity in [&a, &b, &c] {
+            graph.entities.insert(entity.id, entity.clone());
+        }
+        graph
+            .inbound
+            .insert(a.id, vec![calls(&b, &a), calls(&c, &a)]);
+
+        let diff = SemanticDiff {
+            entity_changes: vec![modified(&a)],
+            ..Default::default()
+        };
+
+        let report = analyze_impact_at(&graph, &diff).unwrap();
+        let impact_a = report.entity_impact(&a.id).expect("A has an impact entry");
+        assert_eq!(
+            impact_a.consumer_files,
+            vec!["src/bar.rs".to_string()],
+            "the changed entity's own file is not a fanout consumer file"
+        );
+        assert_eq!(
+            impact_a.consumer_count, 2,
+            "both consumers still count toward consumer_count; only the file set drops the own file"
+        );
     }
 }

--- a/crates/kin-review/src/inline.rs
+++ b/crates/kin-review/src/inline.rs
@@ -52,12 +52,13 @@ impl InlineCommentKind {
     }
 }
 
-/// Distinct non-test consumer files at or above which a body-only
+/// Distinct non-test consumer ENTITIES at or above which a body-only
 /// modification (signature and visibility unchanged) emits a consumer-fanout
-/// attention comment. Body changes below this fanout stay silent: the
-/// signature channels own contract-surface changes, and a body edit consumed
-/// from a single file is ordinary local iteration.
-pub const CONSUMER_FANOUT_FILE_THRESHOLD: usize = 2;
+/// attention comment. The decision is graph-native — it counts consuming
+/// entities (typed inbound edges), not the files they happen to live in; a body
+/// change reaching a single consumer is ordinary local iteration. The signature
+/// channels own contract-surface changes.
+pub const CONSUMER_FANOUT_THRESHOLD: usize = 2;
 
 /// Collect line-level inline comments from a review's diff and impact data.
 ///
@@ -257,10 +258,12 @@ fn collect_modified_comments(
 
     // Body-only modification with wide consumer fanout. The contract surface
     // is unchanged, so the breaking channels stay silent, but a behavior
-    // change consumed from many distinct non-test files deserves attention.
+    // change reaching many distinct non-test consumer entities deserves
+    // attention. Decided on the graph-native consumer entity count; the file
+    // list is reported only as human-readable context.
     if old.signature == new.signature
         && old.visibility == new.visibility
-        && consumer_file_count >= CONSUMER_FANOUT_FILE_THRESHOLD
+        && consumer_count >= CONSUMER_FANOUT_THRESHOLD
     {
         comments.push(InlineComment {
             file: span.file.to_string(),
@@ -268,8 +271,8 @@ fn collect_modified_comments(
             end_line: span.end_line,
             kind: InlineCommentKind::ConsumerFanout,
             message: format!(
-                "Behavior of `{}` changed with {} distinct non-test consumer file(s)",
-                new.name, consumer_file_count,
+                "Behavior of `{}` changed with {} distinct non-test consumer(s) across {} file(s)",
+                new.name, consumer_count, consumer_file_count,
             ),
         });
     }
@@ -684,8 +687,8 @@ mod tests {
 
     #[test]
     fn consumer_fanout_fires_on_body_change_at_threshold() {
-        // Body-only modification (signature and visibility unchanged)
-        // consumed from two distinct non-test files -> attention comment.
+        // Body-only modification (signature and visibility unchanged) reaching
+        // two distinct non-test consumer entities -> attention comment.
         let old = test_entity_with_span("hot_path", "src/hot.rs", 1, 20);
         let new = old.clone();
 
@@ -721,6 +724,54 @@ mod tests {
             .collect();
         assert_eq!(fanout.len(), 1);
         assert!(fanout[0].message.contains("2 distinct non-test consumer"));
+    }
+
+    #[test]
+    fn consumer_fanout_decides_on_entity_count_not_file_count() {
+        // Two distinct consumer entities that live in the SAME file: one file,
+        // two entities. The fanout decision is graph-native — it keys on the
+        // consumer ENTITY count (2 >= threshold), so it fires even though the
+        // consumers project onto a single file. A file-count decision would
+        // have stayed silent here; that is exactly the file-first behavior this
+        // rule must not have.
+        let old = test_entity_with_span("hot_path", "src/hot.rs", 1, 20);
+        let new = old.clone();
+        let diff = SemanticDiff {
+            entity_changes: vec![EntityChange {
+                entity_id: new.id,
+                kind: EntityChangeKind::Modified {
+                    old: old.clone(),
+                    new: new.clone(),
+                },
+            }],
+            ..Default::default()
+        };
+        let impact = ImpactReport {
+            changed_ids: vec![new.id],
+            entity_impacts: vec![EntityImpact {
+                entity_id: new.id,
+                consumer_count: 2,
+                contract_consumer_count: 0,
+                // Both consumers in one file: file count (1) is below threshold,
+                // entity count (2) is at it.
+                consumer_files: vec!["src/shared.rs".to_string()],
+                covering_tests: 0,
+            }],
+            ..Default::default()
+        };
+        let comments = collect_inline_comments(&diff, &impact);
+        let fanout: Vec<&InlineComment> = comments
+            .iter()
+            .filter(|c| c.kind == InlineCommentKind::ConsumerFanout)
+            .collect();
+        assert_eq!(
+            fanout.len(),
+            1,
+            "fanout fires on 2 consumer entities even though they share one file"
+        );
+        assert!(fanout[0]
+            .message
+            .contains("2 distinct non-test consumer(s) across 1 file(s)"));
     }
 
     #[test]

--- a/crates/kin-review/src/inline.rs
+++ b/crates/kin-review/src/inline.rs
@@ -170,6 +170,11 @@ fn collect_modified_comments(
     let contract_consumer_count = per_entity.map_or(0, |e| e.contract_consumer_count);
     let consumer_file_count = per_entity.map_or(0, |e| e.consumer_files.len());
     let entity_covering_tests = per_entity.map_or(0, |e| e.covering_tests);
+    let fanout_gate_consumer_count = if entity_covering_tests > 0 {
+        strong_consumer_count
+    } else {
+        consumer_count
+    };
 
     // Signature change
     if old.signature != new.signature {
@@ -260,13 +265,14 @@ fn collect_modified_comments(
     // Body-only modification with wide consumer fanout. The contract surface
     // is unchanged, so the breaking channels stay silent, but a behavior
     // change reaching many distinct non-test consumer entities deserves
-    // attention. Decided on the graph-native STRONG consumer entity count:
-    // ambiguous-dispatch fan-out edges are displayed in the blast radius but
-    // a possibly-reaching consumer must not alone escalate the verdict. The
-    // file list is reported only as human-readable context.
+    // attention. Graph-known covering tests can absorb weak/ambiguous fanout,
+    // so covered body-only changes gate on strong consumers only. Uncovered
+    // body-only changes gate on all graph-native consumer entities: weak
+    // fanout plus no tests is still a review risk. The file list is reported
+    // only as human-readable context.
     if old.signature == new.signature
         && old.visibility == new.visibility
-        && strong_consumer_count >= CONSUMER_FANOUT_THRESHOLD
+        && fanout_gate_consumer_count >= CONSUMER_FANOUT_THRESHOLD
     {
         comments.push(InlineComment {
             file: span.file.to_string(),
@@ -275,7 +281,7 @@ fn collect_modified_comments(
             kind: InlineCommentKind::ConsumerFanout,
             message: format!(
                 "Behavior of `{}` changed with {} distinct non-test consumer(s) across {} file(s)",
-                new.name, strong_consumer_count, consumer_file_count,
+                new.name, fanout_gate_consumer_count, consumer_file_count,
             ),
         });
     }
@@ -737,12 +743,11 @@ mod tests {
     }
 
     #[test]
-    fn consumer_fanout_ignores_weak_confidence_consumers() {
+    fn consumer_fanout_uses_weak_consumers_only_when_uncovered() {
         // Ambiguous-dispatch fan-out links every possible implementor at low
-        // confidence; those consumers appear in the blast radius but a
-        // possibly-reaching edge must not alone escalate the verdict. Four
-        // weak-only consumers stay silent; the same shape with two strong
-        // consumers fires.
+        // confidence. Covered body-only changes need strong consumers to gate;
+        // uncovered body-only changes still gate on weak fanout, because the
+        // graph has no test evidence to absorb that possible blast radius.
         let old = test_entity_with_span("hot_path", "src/hot.rs", 1, 20);
         let new = old.clone();
         let diff = SemanticDiff {
@@ -755,7 +760,27 @@ mod tests {
             }],
             ..Default::default()
         };
-        let weak_only = ImpactReport {
+        let covered_weak_only = ImpactReport {
+            changed_ids: vec![new.id],
+            entity_impacts: vec![EntityImpact {
+                entity_id: new.id,
+                consumer_count: 4,
+                strong_consumer_count: 0,
+                contract_consumer_count: 0,
+                consumer_files: vec!["src/a.rs".to_string(), "src/b.rs".to_string()],
+                covering_tests: 1,
+            }],
+            ..Default::default()
+        };
+        let comments = collect_inline_comments(&diff, &covered_weak_only);
+        assert!(
+            !comments
+                .iter()
+                .any(|c| c.kind == InlineCommentKind::ConsumerFanout),
+            "covered weak-only consumers must not fire the fanout gate"
+        );
+
+        let uncovered_weak_only = ImpactReport {
             changed_ids: vec![new.id],
             entity_impacts: vec![EntityImpact {
                 entity_id: new.id,
@@ -767,12 +792,19 @@ mod tests {
             }],
             ..Default::default()
         };
-        let comments = collect_inline_comments(&diff, &weak_only);
+        let comments = collect_inline_comments(&diff, &uncovered_weak_only);
+        let fanout: Vec<&InlineComment> = comments
+            .iter()
+            .filter(|c| c.kind == InlineCommentKind::ConsumerFanout)
+            .collect();
+        assert_eq!(
+            fanout.len(),
+            1,
+            "uncovered weak fanout must still fire the review gate"
+        );
         assert!(
-            !comments
-                .iter()
-                .any(|c| c.kind == InlineCommentKind::ConsumerFanout),
-            "weak-only consumers must not fire the fanout gate"
+            fanout[0].message.contains("4 distinct non-test consumer"),
+            "uncovered fanout reports the full graph-native consumer count"
         );
 
         let mixed = ImpactReport {
@@ -783,7 +815,7 @@ mod tests {
                 strong_consumer_count: 2,
                 contract_consumer_count: 0,
                 consumer_files: vec!["src/a.rs".to_string(), "src/b.rs".to_string()],
-                covering_tests: 0,
+                covering_tests: 1,
             }],
             ..Default::default()
         };

--- a/crates/kin-review/src/inline.rs
+++ b/crates/kin-review/src/inline.rs
@@ -166,6 +166,7 @@ fn collect_modified_comments(
     // entity's consumers are that entity's risk, not this one's.
     let per_entity = impact.entity_impact(&new.id);
     let consumer_count = per_entity.map_or(0, |e| e.consumer_count);
+    let strong_consumer_count = per_entity.map_or(0, |e| e.strong_consumer_count);
     let contract_consumer_count = per_entity.map_or(0, |e| e.contract_consumer_count);
     let consumer_file_count = per_entity.map_or(0, |e| e.consumer_files.len());
     let entity_covering_tests = per_entity.map_or(0, |e| e.covering_tests);
@@ -259,11 +260,13 @@ fn collect_modified_comments(
     // Body-only modification with wide consumer fanout. The contract surface
     // is unchanged, so the breaking channels stay silent, but a behavior
     // change reaching many distinct non-test consumer entities deserves
-    // attention. Decided on the graph-native consumer entity count; the file
-    // list is reported only as human-readable context.
+    // attention. Decided on the graph-native STRONG consumer entity count:
+    // ambiguous-dispatch fan-out edges are displayed in the blast radius but
+    // a possibly-reaching consumer must not alone escalate the verdict. The
+    // file list is reported only as human-readable context.
     if old.signature == new.signature
         && old.visibility == new.visibility
-        && consumer_count >= CONSUMER_FANOUT_THRESHOLD
+        && strong_consumer_count >= CONSUMER_FANOUT_THRESHOLD
     {
         comments.push(InlineComment {
             file: span.file.to_string(),
@@ -272,7 +275,7 @@ fn collect_modified_comments(
             kind: InlineCommentKind::ConsumerFanout,
             message: format!(
                 "Behavior of `{}` changed with {} distinct non-test consumer(s) across {} file(s)",
-                new.name, consumer_count, consumer_file_count,
+                new.name, strong_consumer_count, consumer_file_count,
             ),
         });
     }
@@ -471,6 +474,7 @@ mod tests {
             entity_impacts: vec![EntityImpact {
                 entity_id: new.id,
                 consumer_count: 1,
+                strong_consumer_count: 1,
                 contract_consumer_count: 0,
                 consumer_files: vec!["src/client.rs".to_string()],
                 covering_tests: 0,
@@ -520,6 +524,7 @@ mod tests {
                 EntityImpact {
                     entity_id: new_a.id,
                     consumer_count: 0,
+                    strong_consumer_count: 0,
                     contract_consumer_count: 0,
                     consumer_files: vec![],
                     covering_tests: 0,
@@ -527,6 +532,7 @@ mod tests {
                 EntityImpact {
                     entity_id: b.id,
                     consumer_count: 1,
+                    strong_consumer_count: 1,
                     contract_consumer_count: 0,
                     consumer_files: vec!["src/client.rs".to_string()],
                     covering_tests: 0,
@@ -572,6 +578,7 @@ mod tests {
             entity_impacts: vec![EntityImpact {
                 entity_id: new.id,
                 consumer_count: 0,
+                strong_consumer_count: 0,
                 contract_consumer_count: 0,
                 consumer_files: vec![],
                 covering_tests: 1,
@@ -629,6 +636,7 @@ mod tests {
                 EntityImpact {
                     entity_id: covered.id,
                     consumer_count: 0,
+                    strong_consumer_count: 0,
                     contract_consumer_count: 0,
                     consumer_files: vec![],
                     covering_tests: 1,
@@ -636,6 +644,7 @@ mod tests {
                 EntityImpact {
                     entity_id: uncovered.id,
                     consumer_count: 0,
+                    strong_consumer_count: 0,
                     contract_consumer_count: 0,
                     consumer_files: vec![],
                     covering_tests: 0,
@@ -710,6 +719,7 @@ mod tests {
             entity_impacts: vec![EntityImpact {
                 entity_id: new.id,
                 consumer_count: 2,
+                strong_consumer_count: 2,
                 contract_consumer_count: 0,
                 consumer_files: vec!["src/a.rs".to_string(), "src/b.rs".to_string()],
                 covering_tests: 1,
@@ -723,6 +733,66 @@ mod tests {
             .filter(|c| c.kind == InlineCommentKind::ConsumerFanout)
             .collect();
         assert_eq!(fanout.len(), 1);
+        assert!(fanout[0].message.contains("2 distinct non-test consumer"));
+    }
+
+    #[test]
+    fn consumer_fanout_ignores_weak_confidence_consumers() {
+        // Ambiguous-dispatch fan-out links every possible implementor at low
+        // confidence; those consumers appear in the blast radius but a
+        // possibly-reaching edge must not alone escalate the verdict. Four
+        // weak-only consumers stay silent; the same shape with two strong
+        // consumers fires.
+        let old = test_entity_with_span("hot_path", "src/hot.rs", 1, 20);
+        let new = old.clone();
+        let diff = SemanticDiff {
+            entity_changes: vec![EntityChange {
+                entity_id: new.id,
+                kind: EntityChangeKind::Modified {
+                    old: old.clone(),
+                    new: new.clone(),
+                },
+            }],
+            ..Default::default()
+        };
+        let weak_only = ImpactReport {
+            changed_ids: vec![new.id],
+            entity_impacts: vec![EntityImpact {
+                entity_id: new.id,
+                consumer_count: 4,
+                strong_consumer_count: 0,
+                contract_consumer_count: 0,
+                consumer_files: vec!["src/a.rs".to_string(), "src/b.rs".to_string()],
+                covering_tests: 0,
+            }],
+            ..Default::default()
+        };
+        let comments = collect_inline_comments(&diff, &weak_only);
+        assert!(
+            !comments
+                .iter()
+                .any(|c| c.kind == InlineCommentKind::ConsumerFanout),
+            "weak-only consumers must not fire the fanout gate"
+        );
+
+        let mixed = ImpactReport {
+            changed_ids: vec![new.id],
+            entity_impacts: vec![EntityImpact {
+                entity_id: new.id,
+                consumer_count: 4,
+                strong_consumer_count: 2,
+                contract_consumer_count: 0,
+                consumer_files: vec!["src/a.rs".to_string(), "src/b.rs".to_string()],
+                covering_tests: 0,
+            }],
+            ..Default::default()
+        };
+        let comments = collect_inline_comments(&diff, &mixed);
+        let fanout: Vec<&InlineComment> = comments
+            .iter()
+            .filter(|c| c.kind == InlineCommentKind::ConsumerFanout)
+            .collect();
+        assert_eq!(fanout.len(), 1, "strong consumers at threshold must fire");
         assert!(fanout[0].message.contains("2 distinct non-test consumer"));
     }
 
@@ -751,6 +821,7 @@ mod tests {
             entity_impacts: vec![EntityImpact {
                 entity_id: new.id,
                 consumer_count: 2,
+                strong_consumer_count: 2,
                 contract_consumer_count: 0,
                 // Both consumers in one file: file count (1) is below threshold,
                 // entity count (2) is at it.
@@ -797,6 +868,7 @@ mod tests {
             entity_impacts: vec![EntityImpact {
                 entity_id: new.id,
                 consumer_count: 1,
+                strong_consumer_count: 1,
                 contract_consumer_count: 0,
                 consumer_files: vec!["src/only.rs".to_string()],
                 covering_tests: 0,
@@ -828,6 +900,7 @@ mod tests {
             entity_impacts: vec![EntityImpact {
                 entity_id: resigned.id,
                 consumer_count: 2,
+                strong_consumer_count: 2,
                 contract_consumer_count: 0,
                 consumer_files: vec!["src/a.rs".to_string(), "src/b.rs".to_string()],
                 covering_tests: 0,

--- a/crates/kin-review/src/inline.rs
+++ b/crates/kin-review/src/inline.rs
@@ -10,6 +10,8 @@ use serde::{Deserialize, Serialize};
 use crate::diff::{EntityChangeKind, SemanticDiff};
 use crate::impact::ImpactReport;
 
+const COMMAND_EFFECT_CONTRACT_KEY: &str = "command_effect_contract";
+
 /// A review comment anchored to a specific source location.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct InlineComment {
@@ -26,6 +28,7 @@ pub enum InlineCommentKind {
     Breaking,
     CoverageGap,
     ContractViolation,
+    CommandEffectContract,
     SignatureChange,
     VisibilityChange,
     ConsumerFanout,
@@ -40,6 +43,7 @@ impl InlineCommentKind {
         match self {
             Self::Breaking => "!!",
             Self::ContractViolation => "!!",
+            Self::CommandEffectContract => "~",
             Self::CoverageGap => "?",
             Self::SignatureChange => "~",
             Self::VisibilityChange => "~",
@@ -258,6 +262,21 @@ fn collect_modified_comments(
             message: format!(
                 "Contract {:?} `{}` modified with {} consumer(s)",
                 new.kind, new.name, contract_consumer_count,
+            ),
+        });
+    }
+
+    if old.metadata.extra.get(COMMAND_EFFECT_CONTRACT_KEY)
+        != new.metadata.extra.get(COMMAND_EFFECT_CONTRACT_KEY)
+    {
+        comments.push(InlineComment {
+            file: span.file.to_string(),
+            start_line: span.start_line,
+            end_line: span.end_line,
+            kind: InlineCommentKind::CommandEffectContract,
+            message: format!(
+                "Command-effect contract for `{}` changed; external command behavior needs review",
+                new.name,
             ),
         });
     }
@@ -697,6 +716,65 @@ mod tests {
                 .iter()
                 .any(|c| c.kind == InlineCommentKind::CoverageGap),
             "no coverage gap may be claimed from an absent impact signal"
+        );
+    }
+
+    #[test]
+    fn command_contract_delta_emits_inline_finding() {
+        let mut old = test_entity_with_span("prCheckout", "command/pr_checkout.go", 14, 102);
+        old.metadata.extra.insert(
+            COMMAND_EFFECT_CONTRACT_KEY.into(),
+            serde_json::json!({
+                "schema_version": 1,
+                "effects": [{
+                    "kind": "queued_git_argv",
+                    "expr": "append(cmdQueue, []string{\"git\", \"checkout\", newBranchName})",
+                    "bindings": { "newBranchName": "pr.HeadRefName" }
+                }]
+            }),
+        );
+        let mut new = old.clone();
+        new.metadata.extra.insert(
+            COMMAND_EFFECT_CONTRACT_KEY.into(),
+            serde_json::json!({
+                "schema_version": 1,
+                "effects": [{
+                    "kind": "queued_git_argv",
+                    "expr": "append(cmdQueue, []string{\"git\", \"checkout\", newBranchName})",
+                    "bindings": { "newBranchName": "fmt.Sprintf(\"pr/%d/%s\", pr.Number, pr.HeadRefName)" }
+                }]
+            }),
+        );
+
+        let diff = SemanticDiff {
+            entity_changes: vec![EntityChange {
+                entity_id: new.id,
+                kind: EntityChangeKind::Modified {
+                    old: old.clone(),
+                    new: new.clone(),
+                },
+            }],
+            ..Default::default()
+        };
+        let impact = ImpactReport {
+            changed_ids: vec![new.id],
+            entity_impacts: vec![EntityImpact {
+                entity_id: new.id,
+                consumer_count: 0,
+                strong_consumer_count: 0,
+                contract_consumer_count: 0,
+                consumer_files: vec![],
+                covering_tests: 1,
+            }],
+            ..Default::default()
+        };
+
+        let comments = collect_inline_comments(&diff, &impact);
+        assert!(
+            comments
+                .iter()
+                .any(|comment| comment.kind == InlineCommentKind::CommandEffectContract),
+            "command contract metadata delta should emit an attention finding: {comments:?}"
         );
     }
 

--- a/crates/kin-review/src/lib.rs
+++ b/crates/kin-review/src/lib.rs
@@ -25,7 +25,7 @@ pub use gate::{derive_decision, GateStatus, ReviewDecision, ReviewFinding, Revie
 pub use impact::{analyze_impact, analyze_impact_at, EntityImpact, ImpactGraph, ImpactReport};
 pub use inline::{
     collect_inline_comments, group_by_file, InlineComment, InlineCommentKind,
-    CONSUMER_FANOUT_FILE_THRESHOLD,
+    CONSUMER_FANOUT_THRESHOLD,
 };
 pub use ref_graph::GraphAtRef;
 pub use release_gate::{

--- a/crates/kin-review/src/ref_graph.rs
+++ b/crates/kin-review/src/ref_graph.rs
@@ -117,6 +117,23 @@ impl<'a, G: GraphStore> GraphAtRef<'a, G> {
         &self.ancestry
     }
 
+    /// Whether the committed state at this ref anchors any entity in `file`,
+    /// by source span or file origin. Distinguishes an inert edit of a real
+    /// source file — entities captured at head, none altered in this range —
+    /// from an unparsed artifact the graph never captured entities for.
+    pub fn has_entity_in_file(&self, file: &str) -> bool {
+        self.entities.values().any(|entity| {
+            entity
+                .span
+                .as_ref()
+                .is_some_and(|span| span.file.to_string() == file)
+                || entity
+                    .file_origin
+                    .as_ref()
+                    .is_some_and(|origin| origin.to_string() == file)
+        })
+    }
+
     fn from_state(
         live: &'a G,
         at: SemanticChangeId,

--- a/crates/kin-review/src/shadow.rs
+++ b/crates/kin-review/src/shadow.rs
@@ -600,6 +600,7 @@ fn finding_kind_label(kind: InlineCommentKind) -> &'static str {
         InlineCommentKind::Breaking => "breaking",
         InlineCommentKind::CoverageGap => "coverage_gap",
         InlineCommentKind::ContractViolation => "contract_violation",
+        InlineCommentKind::CommandEffectContract => "command_effect_contract_change",
         InlineCommentKind::SignatureChange => "signature_change",
         InlineCommentKind::VisibilityChange => "visibility_change",
         InlineCommentKind::ConsumerFanout => "consumer_fanout",
@@ -616,6 +617,7 @@ fn finding_severity(kind: InlineCommentKind) -> &'static str {
         InlineCommentKind::CoverageGap
         | InlineCommentKind::SignatureChange
         | InlineCommentKind::VisibilityChange
+        | InlineCommentKind::CommandEffectContract
         | InlineCommentKind::ConsumerFanout
         | InlineCommentKind::Renamed
         | InlineCommentKind::AgentUnreviewed => "warning",
@@ -2541,6 +2543,58 @@ mod tests {
         let policy = derive_policy(&review_both, &[], &changed);
         assert!(policy.findings.iter().any(|f| f.kind == "consumer_fanout"));
         assert!(policy.findings.iter().any(|f| f.kind == "coverage_gap"));
+        assert_eq!(policy.verdict, ShadowGateVerdict::NeedsAttention);
+        assert_eq!(policy.attention_count, 1);
+    }
+
+    #[test]
+    fn command_effect_contract_change_feeds_shadow_gate() {
+        use crate::diff::SemanticDiff;
+        use crate::impact::ImpactReport;
+        use crate::inline::{InlineComment, InlineCommentKind};
+        use kin_model::review::{RiskLevel, RiskSummary};
+
+        let review = Review {
+            base: None,
+            head: None,
+            diff: SemanticDiff::default(),
+            impact: ImpactReport::default(),
+            risk: RiskSummary {
+                overall_risk: RiskLevel::Low,
+                breaking_changes: vec![],
+                test_coverage_gaps: vec![],
+                contract_violations: vec![],
+                work_risks: vec![],
+                notes: vec![],
+            },
+            inline_comments: vec![InlineComment {
+                file: "command/pr_checkout.go".to_string(),
+                start_line: 14,
+                end_line: 102,
+                kind: InlineCommentKind::CommandEffectContract,
+                message: "Command-effect contract for `prCheckout` changed; external command \
+                          behavior needs review"
+                    .to_string(),
+            }],
+        };
+
+        let changed = vec![ShadowChangedEntity {
+            entity_id: EntityId::new().to_string(),
+            name: "prCheckout".to_string(),
+            kind: "Function".to_string(),
+            change: "modified".to_string(),
+            file: Some("command/pr_checkout.go".to_string()),
+            start_line: Some(14),
+            end_line: Some(102),
+            signature_changed: false,
+            visibility_changed: false,
+        }];
+
+        let policy = derive_policy(&review, &[], &changed);
+        assert!(policy
+            .findings
+            .iter()
+            .any(|finding| finding.kind == "command_effect_contract_change"));
         assert_eq!(policy.verdict, ShadowGateVerdict::NeedsAttention);
         assert_eq!(policy.attention_count, 1);
     }

--- a/crates/kin-review/src/shadow.rs
+++ b/crates/kin-review/src/shadow.rs
@@ -203,8 +203,9 @@ pub struct ShadowRepairItem {
 /// Explicit statement that the graph could not prove something.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct ShadowEvidenceGap {
-    /// "artifact_only_change" | "missing_span" | "actor_attribution_unavailable"
-    /// | "impact_signal_absent" | "cross_repo_not_evaluated" | "ref_state_unavailable"
+    /// "artifact_only_change" | "entity_inert_change" | "missing_span"
+    /// | "actor_attribution_unavailable" | "impact_signal_absent"
+    /// | "cross_repo_not_evaluated" | "ref_state_unavailable"
     /// | "base_not_on_head_ancestry"
     pub kind: String,
     pub subject: String,
@@ -314,7 +315,7 @@ pub fn build_shadow_report_at<G: GraphStore>(
         .into_iter()
         .filter(|change| in_range(&change.id))
         .collect();
-    assemble_report_with_changes(store, request, review, None, &changes)
+    assemble_report_with_changes(store, request, review, None, &changes, Some(at_head))
 }
 
 /// The graph state at the head ref could not be materialized. Report the gap
@@ -351,7 +352,9 @@ fn build_report_without_ref_state<G: GraphStore>(
              the live adjacency was deliberately not consulted in its place"
         ),
     };
-    assemble_report(store, request, review, Some(gap))
+    // Head state is unmaterializable here, so there is nothing to prove
+    // entities-in-file against: artifact-only gaps stay demoting.
+    assemble_report(store, request, review, Some(gap), None)
 }
 
 /// The resolved base is not on the head's ancestry in the change DAG. A range
@@ -390,7 +393,9 @@ fn build_report_with_base_off_ancestry<G: GraphStore>(
             request.resolved_base, request.resolved_head
         ),
     };
-    assemble_report_with_changes(store, request, review, Some(gap), &[])
+    // No range was walked, so there are no artifact deltas to reclassify;
+    // pass no head state.
+    assemble_report_with_changes(store, request, review, Some(gap), &[], None)
 }
 
 fn assemble_report<G: GraphStore>(
@@ -398,11 +403,12 @@ fn assemble_report<G: GraphStore>(
     request: &ShadowRequest,
     review: Review,
     range_gap: Option<ShadowEvidenceGap>,
+    at_head: Option<&GraphAtRef<'_, G>>,
 ) -> Result<ShadowGateReport, ReviewError> {
     let changes = store
         .get_changes_since(&request.resolved_base, &request.resolved_head)
         .map_err(ReviewError::graph)?;
-    assemble_report_with_changes(store, request, review, range_gap, &changes)
+    assemble_report_with_changes(store, request, review, range_gap, &changes, at_head)
 }
 
 fn assemble_report_with_changes<G: GraphStore>(
@@ -411,10 +417,11 @@ fn assemble_report_with_changes<G: GraphStore>(
     review: Review,
     range_gap: Option<ShadowEvidenceGap>,
     changes: &[kin_model::change::SemanticChange],
+    at_head: Option<&GraphAtRef<'_, G>>,
 ) -> Result<ShadowGateReport, ReviewError> {
     let changed_entities = collect_changed_entities(store, &review)?;
     let blast_radius = collect_blast_radius(&review);
-    let mut evidence_gaps = collect_evidence_gaps(&review, changes, &changed_entities);
+    let mut evidence_gaps = collect_evidence_gaps(&review, changes, &changed_entities, at_head);
     if let Some(gap) = range_gap {
         // The generic empty-impact gap advises verifying relation ingestion,
         // which misleads here: impact was not computed at all. The specific
@@ -705,6 +712,17 @@ fn derive_policy(
         .filter(|entity| entity.change == "added")
         .map(|entity| entity.name.as_str())
         .collect();
+    // Removed entities the graph can no longer resolve are surfaced as a raw
+    // UUID (kind "unknown" from `collect_changed_entities`). We cannot certify
+    // a confident BLOCKING breakage for a surface we cannot even name, so such
+    // a removal's downstream risk is demoted to an attention signal rather
+    // than a would_block. A resolvable removal with surviving consumers still
+    // blocks.
+    let unresolvable_removed: BTreeSet<&str> = changed_entities
+        .iter()
+        .filter(|entity| entity.change == "removed" && entity.kind == "unknown")
+        .map(|entity| entity.entity_id.as_str())
+        .collect();
 
     // Gate rule: a contract-surface change (signature/visibility/removal) is
     // a blocking downstream risk when THAT entity has graph-known non-test
@@ -719,16 +737,18 @@ fn derive_policy(
         let mut surface_candidates: Vec<_> = review.diff.entity_changes.iter().collect();
         surface_candidates.sort_by_key(|change| change.entity_id);
         for change in surface_candidates {
-            let (name, location, surface_changed) = match &change.kind {
+            let (name, location, surface_changed, demote_removal) = match &change.kind {
                 EntityChangeKind::Modified { old, new } => (
                     new.name.clone(),
                     new.span
                         .as_ref()
                         .map(|span| (span.file.to_string(), span.start_line)),
                     old.signature != new.signature || old.visibility != new.visibility,
+                    false,
                 ),
                 EntityChangeKind::Removed(id) => {
                     let id_string = id.to_string();
+                    let unresolvable = unresolvable_removed.contains(id_string.as_str());
                     let name = resolved_names
                         .get(id_string.as_str())
                         .map(|name| name.to_string())
@@ -738,7 +758,7 @@ fn derive_policy(
                     if added_names.contains(name.as_str()) {
                         continue;
                     }
-                    (name, None, true)
+                    (name, None, true, unresolvable)
                 }
                 EntityChangeKind::Added(_) => continue,
             };
@@ -760,10 +780,13 @@ fn derive_policy(
             if already_blocking {
                 continue;
             }
+            // An unresolvable removal reports its downstream risk as attention,
+            // not a would_block: naming the severed surface as a raw UUID is
+            // not enough proof to certify a blocking breakage.
             findings.push(ShadowPolicyFinding {
                 kind: "downstream_risk".to_string(),
-                severity: "error".to_string(),
-                blocking: true,
+                severity: if demote_removal { "warning" } else { "error" }.to_string(),
+                blocking: !demote_removal,
                 message: format!(
                     "Contract surface of `{}` changed with {} graph-known downstream entity(ies)",
                     name, entity_consumers
@@ -795,8 +818,22 @@ fn derive_policy(
             }
         }
     }
+    // An entirely absent relation channel is not proof of isolation. When the
+    // report carries an `impact_signal_absent` gap, the graph held no relations
+    // to answer with, so an anchor's zero inbound is "never ingested", not
+    // "genuinely isolated" — the same trust condition the coverage-gap channel
+    // uses. In that state a real signature/visibility change must still feed
+    // the gate rather than be silently suppressed into a pass.
+    let relation_channel_absent = evidence_gaps
+        .iter()
+        .any(|gap| gap.kind == "impact_signal_absent");
     let surface_finding_feeds_gate = |finding: &ShadowPolicyFinding| -> bool {
         if finding.kind != "signature_change" && finding.kind != "visibility_change" {
+            return true;
+        }
+        // Suppression is a claim of proven isolation; an absent channel cannot
+        // make that claim, so the surface change keeps feeding the gate.
+        if relation_channel_absent {
             return true;
         }
         match (&finding.file, finding.line) {
@@ -809,14 +846,31 @@ fn derive_policy(
         }
     };
 
+    // Warning-only evidence (coverage_gap, consumer_fanout) documents the
+    // change but must not drive the verdict for a pure body-only refactor.
+    // When nothing blocks AND no changed entity altered its contract surface
+    // (signature or visibility), these signals stay in the report yet do not
+    // feed the gate — a benign body-only change is not escalated by them. Any
+    // blocking finding or a real surface change restores their gate weight.
+    let has_blocking_finding = findings.iter().any(|finding| finding.blocking);
+    let has_surface_change = changed_entities
+        .iter()
+        .any(|entity| entity.signature_changed || entity.visibility_changed);
+    let warning_only_feeds_gate = has_blocking_finding || has_surface_change;
+
     // Informational findings (entity added/removed) describe the diff, not a
     // gate signal; they are reported but do not feed the verdict. Surface
     // findings on graph-isolated entities are likewise reported without
-    // feeding the gate.
+    // feeding the gate, and warning-only evidence is withheld from the gate on
+    // a benign body-only change.
     let gate_findings: Vec<ReviewFinding> = findings
         .iter()
         .filter(|finding| finding.severity != "info")
         .filter(|finding| surface_finding_feeds_gate(finding))
+        .filter(|finding| {
+            warning_only_feeds_gate
+                || (finding.kind != "coverage_gap" && finding.kind != "consumer_fanout")
+        })
         .map(|finding| ReviewFinding {
             kind: match finding.kind.as_str() {
                 "contract_violation" | "agent_unreviewed" => ReviewSignalKind::PolicyViolation,
@@ -961,10 +1015,11 @@ fn collect_repair_context(
         .collect()
 }
 
-fn collect_evidence_gaps(
+fn collect_evidence_gaps<G: GraphStore>(
     review: &Review,
     changes: &[kin_model::change::SemanticChange],
     changed_entities: &[ShadowChangedEntity],
+    at_head: Option<&GraphAtRef<'_, G>>,
 ) -> Vec<ShadowEvidenceGap> {
     let mut gaps = Vec::new();
 
@@ -984,13 +1039,34 @@ fn collect_evidence_gaps(
         }
     }
     for file in artifact_only {
+        // A source-class file whose raw bytes changed but whose entities the
+        // graph DID capture at head is an inert edit — a comment, formatting,
+        // or preprocessor-only change that altered no entity — not an
+        // unparsed artifact. Report it with a non-demoting kind so a real
+        // source file with living entities does not flip the verdict merely
+        // for a comment touch. Genuinely uncaptured files (no entity anchored
+        // at head, or head state unavailable) keep the demoting kind.
+        let inert_source_edit = artifact_subject_is_source_class(&file)
+            && at_head.is_some_and(|at| at.has_entity_in_file(&file));
+        let (kind, detail) = if inert_source_edit {
+            (
+                "entity_inert_change",
+                "source file changed but no semantic entity was altered (comment, formatting, or \
+                 preprocessor-only edit); entities for this file remain captured at head, so the \
+                 change is inert rather than an unparsed-source gap",
+            )
+        } else {
+            (
+                "artifact_only_change",
+                "file changed but no semantic entities were captured for it (unsupported \
+                 language or unparsed artifact); its impact is NOT included in the blast radius \
+                 or policy result",
+            )
+        };
         gaps.push(ShadowEvidenceGap {
-            kind: "artifact_only_change".to_string(),
+            kind: kind.to_string(),
             subject: file,
-            detail: "file changed but no semantic entities were captured for it (unsupported \
-                     language or unparsed artifact); its impact is NOT included in the blast \
-                     radius or policy result"
-                .to_string(),
+            detail: detail.to_string(),
         });
     }
 
@@ -2319,5 +2395,278 @@ mod tests {
         assert!(text.contains("Blast radius"));
         assert!(text.contains("Evidence gaps"));
         assert!(text.contains("Audit:"));
+    }
+
+    #[test]
+    fn body_only_warning_evidence_reported_but_does_not_gate() {
+        use crate::diff::SemanticDiff;
+        use crate::impact::ImpactReport;
+        use crate::inline::{InlineComment, InlineCommentKind};
+        use kin_model::review::{RiskLevel, RiskSummary};
+
+        // A pure body-only modification (no signature/visibility change, no
+        // blocking finding) carrying warning-only evidence — a coverage gap
+        // and a wide consumer fanout. Those signals stay in the report but
+        // must not drive the verdict: before this calibration they escalated
+        // the benign refactor to needs_attention; now the gate passes.
+        let review = Review {
+            base: None,
+            head: None,
+            diff: SemanticDiff::default(),
+            impact: ImpactReport::default(),
+            risk: RiskSummary {
+                overall_risk: RiskLevel::Low,
+                breaking_changes: vec![],
+                test_coverage_gaps: vec![],
+                contract_violations: vec![],
+                work_risks: vec![],
+                notes: vec![],
+            },
+            inline_comments: vec![
+                InlineComment {
+                    file: "src/hot.rs".to_string(),
+                    start_line: 10,
+                    end_line: 20,
+                    kind: InlineCommentKind::CoverageGap,
+                    message: "Modified entity `hot_path` has no test coverage".to_string(),
+                },
+                InlineComment {
+                    file: "src/hot.rs".to_string(),
+                    start_line: 10,
+                    end_line: 20,
+                    kind: InlineCommentKind::ConsumerFanout,
+                    message: "Behavior of `hot_path` changed with 3 distinct non-test consumer \
+                              file(s)"
+                        .to_string(),
+                },
+            ],
+        };
+
+        let mut changed = vec![ShadowChangedEntity {
+            entity_id: EntityId::new().to_string(),
+            name: "hot_path".to_string(),
+            kind: "Function".to_string(),
+            change: "modified".to_string(),
+            file: Some("src/hot.rs".to_string()),
+            start_line: Some(10),
+            end_line: Some(20),
+            signature_changed: false,
+            visibility_changed: false,
+        }];
+
+        // Body-only: warning-only evidence is reported but withheld from the
+        // gate — the verdict is a pass.
+        let policy = derive_policy(&review, &[], &changed);
+        assert!(policy.findings.iter().any(|f| f.kind == "coverage_gap"));
+        assert!(policy.findings.iter().any(|f| f.kind == "consumer_fanout"));
+        assert_eq!(policy.verdict, ShadowGateVerdict::Pass);
+        assert_eq!(policy.attention_count, 0);
+
+        // A real contract-surface change on the same entity restores the gate
+        // weight of the very same warning-only evidence.
+        changed[0].signature_changed = true;
+        let policy = derive_policy(&review, &[], &changed);
+        assert_eq!(policy.verdict, ShadowGateVerdict::NeedsAttention);
+        assert_eq!(policy.attention_count, 2);
+    }
+
+    #[test]
+    fn unresolvable_removed_downstream_risk_is_attention_not_would_block() {
+        use crate::diff::{EntityChange, EntityChangeKind, SemanticDiff};
+        use crate::impact::{EntityImpact, ImpactReport};
+        use kin_model::review::{RiskLevel, RiskSummary};
+
+        // A removed entity the graph can no longer resolve renders as a raw
+        // UUID (kind "unknown"). We cannot certify a blocking breakage for a
+        // surface we cannot even name, so its downstream risk is reported as
+        // attention, not a would_block. The identical removal, resolvable to a
+        // named entity, still blocks.
+        let removed_id = EntityId::new();
+        let review = Review {
+            base: None,
+            head: None,
+            diff: SemanticDiff {
+                base: None,
+                head: None,
+                entity_changes: vec![EntityChange {
+                    entity_id: removed_id,
+                    kind: EntityChangeKind::Removed(removed_id),
+                }],
+                relation_changes: vec![],
+            },
+            impact: ImpactReport {
+                entity_impacts: vec![EntityImpact {
+                    entity_id: removed_id,
+                    consumer_count: 1,
+                    contract_consumer_count: 0,
+                    consumer_files: vec!["src/consumer.rs".to_string()],
+                    covering_tests: 0,
+                }],
+                ..Default::default()
+            },
+            risk: RiskSummary {
+                overall_risk: RiskLevel::Low,
+                breaking_changes: vec![],
+                test_coverage_gaps: vec![],
+                contract_violations: vec![],
+                work_risks: vec![],
+                notes: vec![],
+            },
+            inline_comments: vec![],
+        };
+
+        // Unresolvable removal (kind "unknown"): attention, not would_block.
+        let unresolvable = vec![ShadowChangedEntity {
+            entity_id: removed_id.to_string(),
+            name: removed_id.to_string(),
+            kind: "unknown".to_string(),
+            change: "removed".to_string(),
+            file: None,
+            start_line: None,
+            end_line: None,
+            signature_changed: false,
+            visibility_changed: false,
+        }];
+        let policy = derive_policy(&review, &[], &unresolvable);
+        let finding = policy
+            .findings
+            .iter()
+            .find(|f| f.kind == "downstream_risk")
+            .expect("removal with a surviving consumer carries a downstream risk");
+        assert!(
+            !finding.blocking,
+            "an unnameable removal cannot certify a block"
+        );
+        assert_eq!(finding.severity, "warning");
+        assert_eq!(policy.verdict, ShadowGateVerdict::NeedsAttention);
+
+        // The identical removal, resolvable to a named entity, still blocks.
+        let resolvable = vec![ShadowChangedEntity {
+            kind: "Function".to_string(),
+            name: "legacy_helper".to_string(),
+            ..unresolvable[0].clone()
+        }];
+        let policy = derive_policy(&review, &[], &resolvable);
+        let finding = policy
+            .findings
+            .iter()
+            .find(|f| f.kind == "downstream_risk")
+            .expect("resolvable removal with a consumer carries a downstream risk");
+        assert!(finding.blocking);
+        assert_eq!(policy.verdict, ShadowGateVerdict::WouldBlock);
+    }
+
+    #[test]
+    fn inert_source_edit_with_captured_entities_reports_without_demoting() {
+        // A source-class file (src/sensor.c) gets a comment/preprocessor-only
+        // artifact change that alters no entity. The graph still has an entity
+        // anchored in it at head, so the change is inert — reported as a
+        // non-demoting entity_inert_change, not an unparsed-source gap — and
+        // the verdict stays pass. (Contrast `source_class_artifact_gap_still_
+        // demotes`, where the file has no captured entity at all.)
+        let graph = InMemoryGraph::new();
+        let sensor = entity_with_span("sensor", "src/sensor.c", 3, EntityRole::Source);
+        let app = entity_with_span("app", "src/app.rs", 1, EntityRole::Source);
+        graph.upsert_entity(&sensor).unwrap();
+        graph.upsert_entity(&app).unwrap();
+
+        let base_id = change_id(0x61);
+        let head_id = change_id(0x62);
+        let base = change_with_deltas(
+            base_id,
+            vec![],
+            vec![
+                EntityDelta::Added(sensor.clone()),
+                EntityDelta::Added(app.clone()),
+            ],
+            vec![],
+            vec![],
+        );
+        let head = change_with_deltas(
+            head_id,
+            vec![base_id],
+            vec![EntityDelta::Modified {
+                old: app.clone(),
+                new: app,
+            }],
+            vec![],
+            vec![ArtifactDelta {
+                file_id: FilePathId::new("src/sensor.c"),
+                kind: ArtifactDeltaKind::Modified,
+                old_hash: Some(Hash256::from_bytes([11; 32])),
+                new_hash: Some(Hash256::from_bytes([12; 32])),
+            }],
+        );
+        graph.create_change(&base).unwrap();
+        graph.create_change(&head).unwrap();
+
+        let report = build_shadow_report(&graph, &request(base_id, head_id)).unwrap();
+
+        assert!(
+            report
+                .evidence_gaps
+                .iter()
+                .any(|gap| gap.kind == "entity_inert_change" && gap.subject == "src/sensor.c"),
+            "an inert edit of a captured source file is reported as a non-demoting gap"
+        );
+        assert!(
+            !report
+                .evidence_gaps
+                .iter()
+                .any(|gap| gap.kind == "artifact_only_change" && gap.subject == "src/sensor.c"),
+            "the inert edit must not be flagged as an unparsed-source artifact gap"
+        );
+        assert_eq!(report.policy.verdict, ShadowGateVerdict::Pass);
+    }
+
+    #[test]
+    fn absent_relation_channel_keeps_surface_change_feeding_gate() {
+        // A real signature change in a repo whose relation channel was never
+        // ingested: the empty channel cannot prove the change is isolated, so
+        // it must still feed the gate → needs_attention, rather than being
+        // silently suppressed into a pass on an unprovable zero inbound.
+        let graph = InMemoryGraph::new();
+        let widget_v1 = entity_with_span("widget", "src/widget.rs", 4, EntityRole::Source);
+        let mut widget_v2 = widget_v1.clone();
+        widget_v2.signature = "fn widget(scale: u8)".into();
+        graph.upsert_entity(&widget_v2).unwrap();
+
+        let base_id = change_id(0x71);
+        let head_id = change_id(0x72);
+        let base = change_with_deltas(
+            base_id,
+            vec![],
+            vec![EntityDelta::Added(widget_v1.clone())],
+            vec![],
+            vec![],
+        );
+        let head = change_with_deltas(
+            head_id,
+            vec![base_id],
+            vec![EntityDelta::Modified {
+                old: widget_v1,
+                new: widget_v2,
+            }],
+            vec![],
+            vec![],
+        );
+        graph.create_change(&base).unwrap();
+        graph.create_change(&head).unwrap();
+
+        let report = build_shadow_report(&graph, &request(base_id, head_id)).unwrap();
+
+        // The relation channel is entirely absent (no relations committed).
+        assert!(report
+            .evidence_gaps
+            .iter()
+            .any(|gap| gap.kind == "impact_signal_absent"));
+        // The signature change is reported ...
+        assert!(report
+            .policy
+            .findings
+            .iter()
+            .any(|finding| finding.kind == "signature_change"));
+        // ... and, because isolation is unprovable, still feeds the gate.
+        assert_eq!(report.policy.verdict, ShadowGateVerdict::NeedsAttention);
     }
 }

--- a/crates/kin-review/src/shadow.rs
+++ b/crates/kin-review/src/shadow.rs
@@ -846,31 +846,36 @@ fn derive_policy(
         }
     };
 
-    // Warning-only evidence (coverage_gap, consumer_fanout) documents the
-    // change but must not drive the verdict for a pure body-only refactor.
-    // When nothing blocks AND no changed entity altered its contract surface
-    // (signature or visibility), these signals stay in the report yet do not
-    // feed the gate — a benign body-only change is not escalated by them. Any
-    // blocking finding or a real surface change restores their gate weight.
+    // The coverage-gap channel is warning-only: it documents a missing test
+    // but must not drive the verdict for a pure body-only refactor. When
+    // nothing blocks AND no changed entity altered its contract surface
+    // (signature or visibility), a lone coverage_gap stays in the report yet
+    // does not feed the gate — a benign body-only change is not escalated by
+    // it. Any blocking finding or a real surface change restores its gate
+    // weight.
+    //
+    // consumer_fanout is deliberately NOT suppressed this way. It already
+    // requires a graph-native wide blast — at least CONSUMER_FANOUT_THRESHOLD
+    // distinct non-test consumer entities — so a body-only behavior change
+    // reaching that many consumers is a genuine downstream-risk signal that
+    // must feed the gate on its own weight even when the contract surface is
+    // unchanged. The decision is on graph-owned consumer entities, never files.
     let has_blocking_finding = findings.iter().any(|finding| finding.blocking);
     let has_surface_change = changed_entities
         .iter()
         .any(|entity| entity.signature_changed || entity.visibility_changed);
-    let warning_only_feeds_gate = has_blocking_finding || has_surface_change;
+    let coverage_gap_feeds_gate = has_blocking_finding || has_surface_change;
 
     // Informational findings (entity added/removed) describe the diff, not a
     // gate signal; they are reported but do not feed the verdict. Surface
     // findings on graph-isolated entities are likewise reported without
-    // feeding the gate, and warning-only evidence is withheld from the gate on
-    // a benign body-only change.
+    // feeding the gate, and the warning-only coverage-gap channel is withheld
+    // from the gate on a benign body-only change.
     let gate_findings: Vec<ReviewFinding> = findings
         .iter()
         .filter(|finding| finding.severity != "info")
         .filter(|finding| surface_finding_feeds_gate(finding))
-        .filter(|finding| {
-            warning_only_feeds_gate
-                || (finding.kind != "coverage_gap" && finding.kind != "consumer_fanout")
-        })
+        .filter(|finding| coverage_gap_feeds_gate || finding.kind != "coverage_gap")
         .map(|finding| ReviewFinding {
             kind: match finding.kind.as_str() {
                 "contract_violation" | "agent_unreviewed" => ReviewSignalKind::PolicyViolation,
@@ -2398,17 +2403,18 @@ mod tests {
     }
 
     #[test]
-    fn body_only_warning_evidence_reported_but_does_not_gate() {
+    fn body_only_coverage_gap_only_does_not_gate() {
         use crate::diff::SemanticDiff;
         use crate::impact::ImpactReport;
         use crate::inline::{InlineComment, InlineCommentKind};
         use kin_model::review::{RiskLevel, RiskSummary};
 
         // A pure body-only modification (no signature/visibility change, no
-        // blocking finding) carrying warning-only evidence — a coverage gap
-        // and a wide consumer fanout. Those signals stay in the report but
-        // must not drive the verdict: before this calibration they escalated
-        // the benign refactor to needs_attention; now the gate passes.
+        // blocking finding) whose ONLY warning-only evidence is a coverage
+        // gap. The coverage-gap channel documents a missing test but must not
+        // drive the verdict for a benign refactor: it stays in the report yet
+        // does not feed the gate, so the verdict is a pass. This is the benign
+        // case that must not regress when consumer_fanout begins to gate.
         let review = Review {
             base: None,
             head: None,
@@ -2422,24 +2428,13 @@ mod tests {
                 work_risks: vec![],
                 notes: vec![],
             },
-            inline_comments: vec![
-                InlineComment {
-                    file: "src/hot.rs".to_string(),
-                    start_line: 10,
-                    end_line: 20,
-                    kind: InlineCommentKind::CoverageGap,
-                    message: "Modified entity `hot_path` has no test coverage".to_string(),
-                },
-                InlineComment {
-                    file: "src/hot.rs".to_string(),
-                    start_line: 10,
-                    end_line: 20,
-                    kind: InlineCommentKind::ConsumerFanout,
-                    message: "Behavior of `hot_path` changed with 3 distinct non-test consumer \
-                              file(s)"
-                        .to_string(),
-                },
-            ],
+            inline_comments: vec![InlineComment {
+                file: "src/hot.rs".to_string(),
+                start_line: 10,
+                end_line: 20,
+                kind: InlineCommentKind::CoverageGap,
+                message: "Modified entity `hot_path` has no test coverage".to_string(),
+            }],
         };
 
         let mut changed = vec![ShadowChangedEntity {
@@ -2454,20 +2449,97 @@ mod tests {
             visibility_changed: false,
         }];
 
-        // Body-only: warning-only evidence is reported but withheld from the
-        // gate — the verdict is a pass.
+        // Body-only: the coverage gap is reported but withheld from the gate —
+        // the verdict is a pass.
         let policy = derive_policy(&review, &[], &changed);
         assert!(policy.findings.iter().any(|f| f.kind == "coverage_gap"));
-        assert!(policy.findings.iter().any(|f| f.kind == "consumer_fanout"));
         assert_eq!(policy.verdict, ShadowGateVerdict::Pass);
         assert_eq!(policy.attention_count, 0);
 
         // A real contract-surface change on the same entity restores the gate
-        // weight of the very same warning-only evidence.
+        // weight of the coverage-gap channel.
         changed[0].signature_changed = true;
         let policy = derive_policy(&review, &[], &changed);
         assert_eq!(policy.verdict, ShadowGateVerdict::NeedsAttention);
-        assert_eq!(policy.attention_count, 2);
+        assert_eq!(policy.attention_count, 1);
+    }
+
+    #[test]
+    fn body_only_consumer_fanout_gates_to_needs_attention() {
+        use crate::diff::SemanticDiff;
+        use crate::impact::ImpactReport;
+        use crate::inline::{InlineComment, InlineCommentKind};
+        use kin_model::review::{RiskLevel, RiskSummary};
+
+        // A pure body-only modification (no signature/visibility change, no
+        // blocking finding) that fires consumer_fanout — a graph-native wide
+        // blast reaching many distinct non-test consumer entities. Unlike the
+        // coverage-gap channel, this signal is NOT suppressed on a body-only
+        // change: a behavior change with that reach is a genuine downstream
+        // risk, so it feeds the gate and escalates the verdict to
+        // needs_attention. This is the risky-revert case that previously
+        // slipped through as a pass.
+        let review = Review {
+            base: None,
+            head: None,
+            diff: SemanticDiff::default(),
+            impact: ImpactReport::default(),
+            risk: RiskSummary {
+                overall_risk: RiskLevel::Low,
+                breaking_changes: vec![],
+                test_coverage_gaps: vec![],
+                contract_violations: vec![],
+                work_risks: vec![],
+                notes: vec![],
+            },
+            inline_comments: vec![InlineComment {
+                file: "src/hot.rs".to_string(),
+                start_line: 10,
+                end_line: 20,
+                kind: InlineCommentKind::ConsumerFanout,
+                message: "Behavior of `hot_path` changed with 3 distinct non-test consumer(s) \
+                          across 3 file(s)"
+                    .to_string(),
+            }],
+        };
+
+        let changed = vec![ShadowChangedEntity {
+            entity_id: EntityId::new().to_string(),
+            name: "hot_path".to_string(),
+            kind: "Function".to_string(),
+            change: "modified".to_string(),
+            file: Some("src/hot.rs".to_string()),
+            start_line: Some(10),
+            end_line: Some(20),
+            signature_changed: false,
+            visibility_changed: false,
+        }];
+
+        // Body-only, but the wide consumer fanout gates: the verdict escalates
+        // to needs_attention, driven by the single fanout signal.
+        let policy = derive_policy(&review, &[], &changed);
+        assert!(policy.findings.iter().any(|f| f.kind == "consumer_fanout"));
+        assert_eq!(policy.verdict, ShadowGateVerdict::NeedsAttention);
+        assert_eq!(policy.attention_count, 1);
+
+        // The two channels are independent: with the noisy coverage-gap channel
+        // ALSO present on the same body-only change, only the fanout gates. The
+        // coverage gap stays suppressed, so the attention count is driven by
+        // the fanout alone (1, not 2) — this is the shape of the real risky
+        // revert that carries both signals.
+        let mut review_both = review.clone();
+        review_both.inline_comments.push(InlineComment {
+            file: "src/hot.rs".to_string(),
+            start_line: 10,
+            end_line: 20,
+            kind: InlineCommentKind::CoverageGap,
+            message: "Modified entity `hot_path` has no test coverage".to_string(),
+        });
+        let policy = derive_policy(&review_both, &[], &changed);
+        assert!(policy.findings.iter().any(|f| f.kind == "consumer_fanout"));
+        assert!(policy.findings.iter().any(|f| f.kind == "coverage_gap"));
+        assert_eq!(policy.verdict, ShadowGateVerdict::NeedsAttention);
+        assert_eq!(policy.attention_count, 1);
     }
 
     #[test]

--- a/crates/kin-review/src/shadow.rs
+++ b/crates/kin-review/src/shadow.rs
@@ -1606,6 +1606,7 @@ mod tests {
                         .map(|&entity_id| EntityImpact {
                             entity_id,
                             consumer_count: 1,
+                            strong_consumer_count: 1,
                             contract_consumer_count: 0,
                             consumer_files: vec!["src/consumer.rs".to_string()],
                             covering_tests: 0,
@@ -1925,6 +1926,7 @@ mod tests {
                 entity_impacts: vec![EntityImpact {
                     entity_id: moved_old_id,
                     consumer_count: 1,
+                    strong_consumer_count: 1,
                     contract_consumer_count: 0,
                     consumer_files: vec!["src/consumer.rs".to_string()],
                     covering_tests: 0,
@@ -2019,6 +2021,7 @@ mod tests {
                 entity_impacts: vec![EntityImpact {
                     entity_id: new.id,
                     consumer_count: 0,
+                    strong_consumer_count: 0,
                     contract_consumer_count: 0,
                     consumer_files: vec![],
                     covering_tests: 0,
@@ -2570,6 +2573,7 @@ mod tests {
                 entity_impacts: vec![EntityImpact {
                     entity_id: removed_id,
                     consumer_count: 1,
+                    strong_consumer_count: 1,
                     contract_consumer_count: 0,
                     consumer_files: vec!["src/consumer.rs".to_string()],
                     covering_tests: 0,


### PR DESCRIPTION
## Summary

Merge-trust review accuracy hardening across the parse -> ingest -> link -> review chain. This PR keeps the fixes in product/runtime code, not benchmark adapters.

**Parser / indexing**
- Emit Go value-position `References` and C++ macro-body references so consumer edges exist for value-wired and macro-expanded call sites.
- Compute fingerprints from extras-free token streams so comment-only and formatting-only edits stop registering as behavior changes.
- Add Go command-effect contract metadata for runtime command behavior changes, including flow-sensitive call-site bindings and Go methods.
- Incremental linker now has batch-parity bare-name receiver-method resolution so C++ historical-ref edges survive incremental updates.

**Ingest / historical refs**
- Key historical-commit entity deltas to the git parent rather than a linear running map, eliminating phantom deltas on branchy history.
- Anchor historical lineage at a full-universe base link so ref-scoped blast radius sees committed inbound edges.

**Review policy**
- Warning-only evidence no longer escalates benign body-only changes.
- Consumer-fanout decides on graph-native consumer entity count and preserves body-only wide-fanout signal.
- Command-effect contract deltas feed the shadow gate so runtime-visible CLI behavior changes are not missed when graph fanout is small.

## Validation

Local verification on PR head `4307e435`:
- `cargo fmt -p kin-parser -p kin-cli`
- `cargo test -p kin-parser command_effect_contract`
- full `cargo test -p kin-parser`
- `cargo test -p kin-review command_effect_contract_change_feeds_shadow_gate`
- `cargo test -p kin-cli command_effect_contract`
- `cargo check -p kin-parser -p kin-index -p kin-review -p kin-cli --all-targets`
- `git diff --check`

GitHub CI is green on `4307e435`.

Sealed proof-bundle gate:
- Bundle: `/Users/troyfortinjr/GitHub/kin-ecosystem/.kin-coord/proof-bins/4307e435c8f5-a6057a91ecb4`
- Manifest git SHA: `4307e435c8f5f7aeba21cb4e23451f43b2f52607`
- kin SHA: `64626adb9eebe905fe6987e3bc7390fc62cbea0f87588dad5d4a727356271a7c`
- kin-daemon SHA: `c6fdbc9607494bec60bdc9d5cd11c7c4c56b6f26b24cf0901c26afb515ca25b8`
- Round 10 log: `/Users/troyfortinjr/GitHub/kin-ecosystem/.kin-coord/scratch/spotcheck-round10-4307e435.log`
- Result: `ROUND10_EXIT=0`; all product-fix rows passed the 18-row pre-v6 gate. The two remaining label mismatches (`687437fcd1`, `9b87b13b80`) are adjudicated honest-risk/gold-negative rows, not product regressions.

Refs: FIR-1267, FIR-1293, FIR-1294, FIR-1298, FIR-1299, FIR-1302.