### PR TITLE
fix: v6 residual hardening — generated-consumer demotion, qualifier-aware signatures, unified delta semantics, toolchain-surface channel

### DIFF
--- a/crates/kin-cli/src/commands/commit.rs
+++ b/crates/kin-cli/src/commands/commit.rs
@@ -227,6 +227,13 @@ async fn run_local_commit_pipeline_for_tests(
                         &file_id,
                         &file_imports,
                     );
+                    if language == kin_model::LanguageId::Go {
+                        kin_parser::attach_go_command_effect_contract_metadata(
+                            &tree,
+                            &source,
+                            std::slice::from_mut(&mut new_entity),
+                        );
+                    }
                     parsed_names.insert(new_entity.name.clone());
                     let existing = existing_file_entities
                         .and_then(|entities| entities.iter().find(|e| e.name == new_entity.name));

--- a/crates/kin-cli/src/commands/commit.rs
+++ b/crates/kin-cli/src/commands/commit.rs
@@ -239,9 +239,7 @@ async fn run_local_commit_pipeline_for_tests(
                         .and_then(|entities| entities.iter().find(|e| e.name == new_entity.name));
 
                     match existing {
-                        Some(old)
-                            if old.fingerprint.ast_hash != new_entity.fingerprint.ast_hash =>
-                        {
+                        Some(old) if super::init::entity_fingerprint_changed(old, &new_entity) => {
                             // Modified — reuse old ID for a true update, not a duplicate insert
                             let mut updated = new_entity.clone();
                             updated.id = old.id;

--- a/crates/kin-cli/src/commands/init.rs
+++ b/crates/kin-cli/src/commands/init.rs
@@ -1732,21 +1732,8 @@ fn imported_relations_equivalent(old: &Relation, new: &Relation) -> bool {
 
 const COMMAND_EFFECT_CONTRACT_KEY: &str = "command_effect_contract";
 
-fn entity_fingerprint_changed(old: &Entity, new: &Entity) -> bool {
-    // The contract key participates only when BOTH sides carry it: not every
-    // persist path attaches the contract, so key-absent vs key-present is
-    // coverage skew between paths, never evidence that behavior changed.
-    let contract_changed = match (
-        old.metadata.extra.get(COMMAND_EFFECT_CONTRACT_KEY),
-        new.metadata.extra.get(COMMAND_EFFECT_CONTRACT_KEY),
-    ) {
-        (Some(a), Some(b)) => a != b,
-        _ => false,
-    };
-    old.fingerprint.ast_hash != new.fingerprint.ast_hash
-        || old.fingerprint.signature_hash != new.fingerprint.signature_hash
-        || old.fingerprint.behavior_hash != new.fingerprint.behavior_hash
-        || contract_changed
+pub(crate) fn entity_fingerprint_changed(old: &Entity, new: &Entity) -> bool {
+    kin_index::entity_semantics_changed(old, new)
 }
 
 fn reconcile_imported_file_entities(

--- a/crates/kin-cli/src/commands/init.rs
+++ b/crates/kin-cli/src/commands/init.rs
@@ -1733,11 +1733,20 @@ fn imported_relations_equivalent(old: &Relation, new: &Relation) -> bool {
 const COMMAND_EFFECT_CONTRACT_KEY: &str = "command_effect_contract";
 
 fn entity_fingerprint_changed(old: &Entity, new: &Entity) -> bool {
+    // The contract key participates only when BOTH sides carry it: not every
+    // persist path attaches the contract, so key-absent vs key-present is
+    // coverage skew between paths, never evidence that behavior changed.
+    let contract_changed = match (
+        old.metadata.extra.get(COMMAND_EFFECT_CONTRACT_KEY),
+        new.metadata.extra.get(COMMAND_EFFECT_CONTRACT_KEY),
+    ) {
+        (Some(a), Some(b)) => a != b,
+        _ => false,
+    };
     old.fingerprint.ast_hash != new.fingerprint.ast_hash
         || old.fingerprint.signature_hash != new.fingerprint.signature_hash
         || old.fingerprint.behavior_hash != new.fingerprint.behavior_hash
-        || old.metadata.extra.get(COMMAND_EFFECT_CONTRACT_KEY)
-            != new.metadata.extra.get(COMMAND_EFFECT_CONTRACT_KEY)
+        || contract_changed
 }
 
 fn reconcile_imported_file_entities(
@@ -1961,6 +1970,13 @@ fn index_files_with_stable_entity_ids(
                                     &file_imports,
                                 );
                                 file_entities.push(entity);
+                            }
+                            if language == kin_model::LanguageId::Go {
+                                kin_parser::attach_go_command_effect_contract_metadata(
+                                    &tree,
+                                    &source,
+                                    &mut file_entities,
+                                );
                             }
                             let discovered_tests = promote_discovered_tests(
                                 &file_id,

--- a/crates/kin-cli/src/commands/init.rs
+++ b/crates/kin-cli/src/commands/init.rs
@@ -1730,7 +1730,7 @@ fn imported_relations_equivalent(old: &Relation, new: &Relation) -> bool {
         && (old.confidence - new.confidence).abs() < f32::EPSILON
 }
 
-const COMMAND_EFFECT_CONTRACT_KEY: &str = "command_effect_contract";
+use kin_index::COMMAND_EFFECT_CONTRACT_KEY;
 
 pub(crate) fn entity_fingerprint_changed(old: &Entity, new: &Entity) -> bool {
     kin_index::entity_semantics_changed(old, new)

--- a/crates/kin-cli/src/commands/init.rs
+++ b/crates/kin-cli/src/commands/init.rs
@@ -1730,8 +1730,6 @@ fn imported_relations_equivalent(old: &Relation, new: &Relation) -> bool {
         && (old.confidence - new.confidence).abs() < f32::EPSILON
 }
 
-use kin_index::COMMAND_EFFECT_CONTRACT_KEY;
-
 pub(crate) fn entity_fingerprint_changed(old: &Entity, new: &Entity) -> bool {
     kin_index::entity_semantics_changed(old, new)
 }
@@ -3781,6 +3779,7 @@ fn whoami() -> String {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use kin_index::COMMAND_EFFECT_CONTRACT_KEY;
     use kin_model::{
         EntityKind, EntityMetadata, EntityRole, FingerprintAlgorithm, LanguageId,
         SemanticFingerprint, Visibility,

--- a/crates/kin-cli/src/commands/review.rs
+++ b/crates/kin-cli/src/commands/review.rs
@@ -1113,6 +1113,7 @@ fn inline_comment_severity(kind: kin_review::InlineCommentKind) -> &'static str 
         | InlineCommentKind::SignatureChange
         | InlineCommentKind::VisibilityChange
         | InlineCommentKind::CommandEffectContract
+        | InlineCommentKind::ToolchainSurfaceChange
         | InlineCommentKind::ConsumerFanout
         | InlineCommentKind::Renamed
         | InlineCommentKind::AgentUnreviewed => "warning",

--- a/crates/kin-daemon/src/commit_deltas.rs
+++ b/crates/kin-daemon/src/commit_deltas.rs
@@ -116,7 +116,7 @@ pub fn compute_deltas_vs_last_commit(
                 // Not in last commit → Added
                 entity_deltas.push(EntityDelta::Added(entity.clone()));
             }
-            Some(committed) if committed.fingerprint.ast_hash != entity.fingerprint.ast_hash => {
+            Some(committed) if kin_index::entity_semantics_changed(committed, entity) => {
                 // Fingerprint changed → Modified (old from DAG, new from graph)
                 entity_deltas.push(EntityDelta::Modified {
                     old: committed.clone(),

--- a/crates/kin-index/src/lib.rs
+++ b/crates/kin-index/src/lib.rs
@@ -31,7 +31,8 @@ pub use linker::{
 };
 pub use overlay::{apply_file_removal, apply_to_graph, ApplyResult};
 pub use pipeline::{
-    classify_file_role, normalize_file_path_id, IndexPipeline, IndexedAny, IndexedFile,
+    classify_file_role, entity_semantics_changed, normalize_file_path_id, IndexPipeline,
+    IndexedAny, IndexedFile,
 };
 pub use support::{compute_coverage_report, CoverageReport};
 pub use watcher::{FileEvent, FileWatcher};

--- a/crates/kin-index/src/lib.rs
+++ b/crates/kin-index/src/lib.rs
@@ -32,7 +32,7 @@ pub use linker::{
 pub use overlay::{apply_file_removal, apply_to_graph, ApplyResult};
 pub use pipeline::{
     classify_file_role, entity_semantics_changed, normalize_file_path_id, IndexPipeline,
-    IndexedAny, IndexedFile,
+    IndexedAny, IndexedFile, COMMAND_EFFECT_CONTRACT_KEY,
 };
 pub use support::{compute_coverage_report, CoverageReport};
 pub use watcher::{FileEvent, FileWatcher};

--- a/crates/kin-index/src/pipeline.rs
+++ b/crates/kin-index/src/pipeline.rs
@@ -647,11 +647,16 @@ pub fn classify_file_role(path: &str) -> EntityRole {
         return EntityRole::External;
     }
 
-    // Generated paths
+    // Generated paths. Amalgamated single-header bundles are byte-copies of
+    // real sources regenerated out-of-band: their entities must never read as
+    // independent consumers of the sources they were copied from.
     if lower.starts_with("generated/")
         || lower.contains("/generated/")
         || lower.starts_with("__generated__/")
         || lower.contains("/__generated__/")
+        || lower.starts_with("single_include/")
+        || lower.contains("/single_include/")
+        || lower.contains("amalgamated")
         || lower.ends_with(".pb.go")
         || lower.ends_with("_pb2.py")
         || lower.ends_with(".generated.ts")

--- a/crates/kin-index/src/pipeline.rs
+++ b/crates/kin-index/src/pipeline.rs
@@ -588,6 +588,29 @@ pub fn normalize_file_path_id(path: &Path, root: &Path) -> FilePathId {
     FilePathId::new(normalized)
 }
 
+/// Key under which language adapters attach command-effect contracts to
+/// entity metadata.
+pub const COMMAND_EFFECT_CONTRACT_KEY: &str = "command_effect_contract";
+
+/// Whether two versions of the same entity differ semantically: any of the
+/// three fingerprint hashes, or an attached command-effect contract when BOTH
+/// sides carry one (key-absent vs key-present is persist-path coverage skew,
+/// never evidence of change). Every entity-delta producer must use this one
+/// definition so graph truth does not depend on which write path recorded it.
+pub fn entity_semantics_changed(old: &Entity, new: &Entity) -> bool {
+    let contract_changed = match (
+        old.metadata.extra.get(COMMAND_EFFECT_CONTRACT_KEY),
+        new.metadata.extra.get(COMMAND_EFFECT_CONTRACT_KEY),
+    ) {
+        (Some(a), Some(b)) => a != b,
+        _ => false,
+    };
+    old.fingerprint.ast_hash != new.fingerprint.ast_hash
+        || old.fingerprint.signature_hash != new.fingerprint.signature_hash
+        || old.fingerprint.behavior_hash != new.fingerprint.behavior_hash
+        || contract_changed
+}
+
 /// Classify a file path into an [`EntityRole`] based on directory and filename patterns.
 ///
 /// Entities from the same file share the same role. The classifier checks path

--- a/crates/kin-index/tests/language_matrix_linker.rs
+++ b/crates/kin-index/tests/language_matrix_linker.rs
@@ -12,9 +12,9 @@
 //!    (the linker picks one, it does not fan out for exact free-function names);
 //!  * a receiver-method name defined in several classes fans out to every
 //!    implementor, bounded by the fan-out cap;
-//!  * a dotted `obj.execute` callee (what the Java/C# adapters emit today) does
-//!    NOT resolve — the fix belongs in those adapters, not the linker. This test
-//!    encodes that contract: simple names resolve, dotted ones do not.
+//!  * a dotted `obj.execute` callee (what a non-narrowing adapter would emit)
+//!    does NOT resolve — narrowing belongs in the adapters, not the linker. This
+//!    test encodes that contract: simple names resolve, dotted ones do not.
 //!
 //! The linker is language-agnostic (it matches `dst_name` against entity
 //! `name`), so these behaviors hold for every language once the adapter hands it
@@ -26,7 +26,9 @@ use kin_model::{
     GraphNodeId, Hash256, LanguageId, Relation, RelationKind, SemanticFingerprint, SourceSpan,
     Visibility,
 };
-use kin_parser::{ExtractedRelation, LanguageAdapter, TypeScriptAdapter};
+use kin_parser::{
+    CSharpAdapter, ExtractedRelation, JavaAdapter, LanguageAdapter, TypeScriptAdapter,
+};
 
 // ---- helpers: direct entity construction (mirrors linker.rs unit-test idiom) ----
 
@@ -107,8 +109,7 @@ const FANOUT_CAP: usize = 8;
 
 // ---- (A) name-based cross-file resolution through the real parser ----
 
-fn parse_ts(path: &str, src: &str) -> FileParseData {
-    let adapter = TypeScriptAdapter;
+fn parse_with(adapter: &dyn LanguageAdapter, path: &str, src: &str) -> FileParseData {
     let file_id = FilePathId::new(path);
     let bytes = src.as_bytes();
     let tree = adapter.parse(bytes).expect("parse");
@@ -126,7 +127,7 @@ fn parse_ts(path: &str, src: &str) -> FileParseData {
     }
 }
 
-fn ts_entity_id(files: &[FileParseData], file: &str, name: &str) -> EntityId {
+fn entity_id_in(files: &[FileParseData], file: &str, name: &str) -> EntityId {
     files
         .iter()
         .flat_map(|f| f.entities.iter())
@@ -140,19 +141,68 @@ fn name_based_cross_file_call_resolves() {
     // caller.ts imports and calls a function defined in m.ts; the simple-name
     // call must resolve to the real cross-file target.
     let files = vec![
-        parse_ts(
+        parse_with(
+            &TypeScriptAdapter,
             "caller.ts",
             "import { compute } from \"./m\";\nfunction run() { compute(); }\n",
         ),
-        parse_ts("m.ts", "export function compute() { return 1; }\n"),
+        parse_with(
+            &TypeScriptAdapter,
+            "m.ts",
+            "export function compute() { return 1; }\n",
+        ),
     ];
-    let run = ts_entity_id(&files, "caller.ts", "run");
-    let compute = ts_entity_id(&files, "m.ts", "compute");
+    let run = entity_id_in(&files, "caller.ts", "run");
+    let compute = entity_id_in(&files, "m.ts", "compute");
 
     let rels = link_cross_file(&files);
     assert!(
         has_call(&rels, run, compute),
         "imported call `compute()` should resolve run -> m.ts::compute"
+    );
+}
+
+#[test]
+fn java_and_csharp_narrowed_method_calls_resolve_cross_file() {
+    // The Java and C# adapters narrow `w.execute()` / `w.Execute()` to the
+    // rightmost simple name; the linker resolves that leaf to the method
+    // defined in the other file.
+    let java = vec![
+        parse_with(
+            &JavaAdapter,
+            "Caller.java",
+            "class Caller { void run() { w.execute(); } }",
+        ),
+        parse_with(
+            &JavaAdapter,
+            "Worker.java",
+            "class Worker { public void execute() {} }",
+        ),
+    ];
+    let run = entity_id_in(&java, "Caller.java", "Caller.run");
+    let execute = entity_id_in(&java, "Worker.java", "Worker.execute");
+    assert!(
+        has_call(&link_cross_file(&java), run, execute),
+        "narrowed Java method call should resolve Caller.run -> Worker.execute"
+    );
+
+    let csharp = vec![
+        parse_with(
+            &CSharpAdapter,
+            "Caller.cs",
+            "namespace N { class C { void Run() { w.Execute(); } } }",
+        ),
+        parse_with(
+            &CSharpAdapter,
+            "Worker.cs",
+            "namespace N { class Worker { public void Execute() {} } }",
+        ),
+    ];
+    let run = entity_id_in(&csharp, "Caller.cs", "N.C.Run");
+    let execute = entity_id_in(&csharp, "Worker.cs", "N.Worker.Execute");
+    assert!(
+        has_call(&link_cross_file(&csharp), run, execute),
+        "narrowed C# method call should resolve N.C.Run -> N.Worker.Execute"
     );
 }
 
@@ -243,9 +293,9 @@ fn receiver_method_fanout_respects_cap() {
 #[test]
 fn simple_name_resolves_but_dotted_receiver_name_does_not() {
     // The linker matches `dst_name` against entity `name`. A simple `execute`
-    // resolves cross-file; the dotted `obj.execute` that the Java/C# adapters
-    // still emit resolves to nothing — proof the dotted-callee fix belongs in
-    // those adapters (narrow to the rightmost name), not in the linker.
+    // resolves cross-file; a dotted `obj.execute` resolves to nothing — which
+    // is why every adapter narrows callees to the rightmost simple name rather
+    // than the linker splitting dotted text.
     let target = func("execute", "target.rs");
 
     let simple = vec![

--- a/crates/kin-index/tests/language_matrix_linker.rs
+++ b/crates/kin-index/tests/language_matrix_linker.rs
@@ -1,0 +1,290 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Firelock, LLC
+
+//! Cross-file linker arm of the language matrix (FIR-1313).
+//!
+//! The parser adapters narrow callees to simple names; this file drives the
+//! real linker (`link_cross_file`) to prove those names resolve across files and
+//! to pin the ambiguity behaviors that matter to the matrix:
+//!
+//!  * a name-based cross-file call resolves (real parser -> real linker);
+//!  * two same-named free functions resolve to a single deterministic target
+//!    (the linker picks one, it does not fan out for exact free-function names);
+//!  * a receiver-method name defined in several classes fans out to every
+//!    implementor, bounded by the fan-out cap;
+//!  * a dotted `obj.execute` callee (what the Java/C# adapters emit today) does
+//!    NOT resolve — the fix belongs in those adapters, not the linker. This test
+//!    encodes that contract: simple names resolve, dotted ones do not.
+//!
+//! The linker is language-agnostic (it matches `dst_name` against entity
+//! `name`), so these behaviors hold for every language once the adapter hands it
+//! a simple name.
+
+use kin_index::{link_cross_file, FileParseData};
+use kin_model::{
+    Entity, EntityId, EntityKind, EntityMetadata, EntityRole, FilePathId, FingerprintAlgorithm,
+    GraphNodeId, Hash256, LanguageId, Relation, RelationKind, SemanticFingerprint, SourceSpan,
+    Visibility,
+};
+use kin_parser::{ExtractedRelation, LanguageAdapter, TypeScriptAdapter};
+
+// ---- helpers: direct entity construction (mirrors linker.rs unit-test idiom) ----
+
+fn zero_fp() -> SemanticFingerprint {
+    let zero = Hash256::from_bytes([0u8; 32]);
+    SemanticFingerprint {
+        algorithm: FingerprintAlgorithm::V1TreeSitter,
+        ast_hash: zero,
+        signature_hash: zero,
+        behavior_hash: zero,
+        stability_score: 1.0,
+    }
+}
+
+fn entity(name: &str, file_path: &str, kind: EntityKind) -> Entity {
+    let file_id = FilePathId::new(file_path);
+    Entity {
+        id: EntityId::new(),
+        kind,
+        name: name.to_string(),
+        language: LanguageId::Rust,
+        fingerprint: zero_fp(),
+        file_origin: Some(file_id.clone()),
+        span: Some(SourceSpan {
+            file: file_id,
+            start_byte: 0,
+            end_byte: 10,
+            start_line: 1,
+            start_col: 0,
+            end_line: 1,
+            end_col: 10,
+        }),
+        signature: name.to_string(),
+        visibility: Visibility::Public,
+        role: EntityRole::Source,
+        doc_summary: None,
+        metadata: EntityMetadata::default(),
+        lineage_parent: None,
+        created_in: None,
+        superseded_by: None,
+    }
+}
+
+fn func(name: &str, file_path: &str) -> Entity {
+    entity(name, file_path, EntityKind::Function)
+}
+
+fn method(name: &str, file_path: &str) -> Entity {
+    entity(name, file_path, EntityKind::Method)
+}
+
+fn calls_relation(src: &str, dst: &str) -> ExtractedRelation {
+    ExtractedRelation {
+        kind: RelationKind::Calls,
+        src_name: src.to_string(),
+        dst_name: dst.to_string(),
+        import_source: None,
+    }
+}
+
+fn count_calls(rels: &[Relation]) -> usize {
+    rels.iter()
+        .filter(|r| r.kind == RelationKind::Calls)
+        .count()
+}
+
+fn has_call(rels: &[Relation], src: EntityId, dst: EntityId) -> bool {
+    rels.iter().any(|r| {
+        r.kind == RelationKind::Calls
+            && r.src == GraphNodeId::Entity(src)
+            && r.dst == GraphNodeId::Entity(dst)
+    })
+}
+
+/// The fan-out cap mirrors `linker::AMBIGUOUS_CALL_FANOUT_CAP` (private). If the
+/// cap changes, update this constant; the boundary test below documents it.
+const FANOUT_CAP: usize = 8;
+
+// ---- (A) name-based cross-file resolution through the real parser ----
+
+fn parse_ts(path: &str, src: &str) -> FileParseData {
+    let adapter = TypeScriptAdapter;
+    let file_id = FilePathId::new(path);
+    let bytes = src.as_bytes();
+    let tree = adapter.parse(bytes).expect("parse");
+    let output = adapter.extract(&tree, bytes, &file_id).expect("extract");
+    let entities: Vec<Entity> = output
+        .entities
+        .into_iter()
+        .map(|e| e.into_entity_with_source(adapter.language_id(), &file_id, Some(bytes)))
+        .collect();
+    FileParseData {
+        file_path: path.to_string(),
+        entities,
+        relations: output.relations,
+        imports: output.imports,
+    }
+}
+
+fn ts_entity_id(files: &[FileParseData], file: &str, name: &str) -> EntityId {
+    files
+        .iter()
+        .flat_map(|f| f.entities.iter())
+        .find(|e| e.name == name && e.file_origin.as_ref().map(|p| p.0.as_str()) == Some(file))
+        .unwrap_or_else(|| panic!("entity `{name}` in `{file}` not found"))
+        .id
+}
+
+#[test]
+fn name_based_cross_file_call_resolves() {
+    // caller.ts imports and calls a function defined in m.ts; the simple-name
+    // call must resolve to the real cross-file target.
+    let files = vec![
+        parse_ts(
+            "caller.ts",
+            "import { compute } from \"./m\";\nfunction run() { compute(); }\n",
+        ),
+        parse_ts("m.ts", "export function compute() { return 1; }\n"),
+    ];
+    let run = ts_entity_id(&files, "caller.ts", "run");
+    let compute = ts_entity_id(&files, "m.ts", "compute");
+
+    let rels = link_cross_file(&files);
+    assert!(
+        has_call(&rels, run, compute),
+        "imported call `compute()` should resolve run -> m.ts::compute"
+    );
+}
+
+// ---- (B) same-name free functions: linker picks one, no fan-out ----
+
+#[test]
+fn same_name_free_functions_resolve_to_single_target() {
+    // A bare `shared()` call with two same-named free-function targets and no
+    // disambiguating locality signal resolves to exactly one target (bucket
+    // order), NOT a fan-out. This is distinct from the receiver-method path.
+    let caller = func("run", "c.rs");
+    let files = vec![
+        FileParseData {
+            file_path: "c.rs".to_string(),
+            entities: vec![caller.clone()],
+            relations: vec![calls_relation("run", "shared")],
+            imports: vec![],
+        },
+        FileParseData {
+            file_path: "a.rs".to_string(),
+            entities: vec![func("shared", "a.rs")],
+            relations: vec![],
+            imports: vec![],
+        },
+        FileParseData {
+            file_path: "b.rs".to_string(),
+            entities: vec![func("shared", "b.rs")],
+            relations: vec![],
+            imports: vec![],
+        },
+    ];
+
+    let rels = link_cross_file(&files);
+    assert_eq!(
+        count_calls(&rels),
+        1,
+        "two same-named free functions must resolve to a single target, not fan out"
+    );
+}
+
+// ---- (C) receiver-method fan-out to every implementor, bounded by the cap ----
+
+fn receiver_fanout_call_count(n: usize) -> usize {
+    let caller = method("build", "caller.rs");
+    let mut files = vec![FileParseData {
+        file_path: "caller.rs".to_string(),
+        entities: vec![caller],
+        relations: vec![calls_relation("build", "make")],
+        imports: vec![],
+    }];
+    for i in 0..n {
+        let path = format!("impl{i}.rs");
+        files.push(FileParseData {
+            file_path: path.clone(),
+            entities: vec![method(&format!("Impl{i}::make"), &path)],
+            relations: vec![],
+            imports: vec![],
+        });
+    }
+    count_calls(&link_cross_file(&files))
+}
+
+#[test]
+fn receiver_method_call_fans_out_to_all_implementors() {
+    // Three classes define `make`; a bare `make()` call has an unknowable
+    // receiver type, so it fans out to every implementor.
+    assert_eq!(receiver_fanout_call_count(3), 3);
+}
+
+#[test]
+fn receiver_method_fanout_respects_cap() {
+    // At the cap every implementor links; one beyond it, the name is too
+    // ubiquitous to guess and none link.
+    assert_eq!(
+        receiver_fanout_call_count(FANOUT_CAP),
+        FANOUT_CAP,
+        "at the cap every implementor links"
+    );
+    assert_eq!(
+        receiver_fanout_call_count(FANOUT_CAP + 1),
+        0,
+        "above the cap the receiver-method call stays unresolved"
+    );
+}
+
+// ---- (D) dotted-callee contract: simple names resolve, dotted ones do not ----
+
+#[test]
+fn simple_name_resolves_but_dotted_receiver_name_does_not() {
+    // The linker matches `dst_name` against entity `name`. A simple `execute`
+    // resolves cross-file; the dotted `obj.execute` that the Java/C# adapters
+    // still emit resolves to nothing — proof the dotted-callee fix belongs in
+    // those adapters (narrow to the rightmost name), not in the linker.
+    let target = func("execute", "target.rs");
+
+    let simple = vec![
+        FileParseData {
+            file_path: "caller.rs".to_string(),
+            entities: vec![func("run", "caller.rs")],
+            relations: vec![calls_relation("run", "execute")],
+            imports: vec![],
+        },
+        FileParseData {
+            file_path: "target.rs".to_string(),
+            entities: vec![target.clone()],
+            relations: vec![],
+            imports: vec![],
+        },
+    ];
+    assert_eq!(
+        count_calls(&link_cross_file(&simple)),
+        1,
+        "a simple-name call must resolve cross-file"
+    );
+
+    let dotted = vec![
+        FileParseData {
+            file_path: "caller.rs".to_string(),
+            entities: vec![func("run", "caller.rs")],
+            relations: vec![calls_relation("run", "obj.execute")],
+            imports: vec![],
+        },
+        FileParseData {
+            file_path: "target.rs".to_string(),
+            entities: vec![target],
+            relations: vec![],
+            imports: vec![],
+        },
+    ];
+    assert_eq!(
+        count_calls(&link_cross_file(&dotted)),
+        0,
+        "a dotted `obj.execute` callee must not resolve — the adapter must narrow it first"
+    );
+}

--- a/crates/kin-parser/src/adapter.rs
+++ b/crates/kin-parser/src/adapter.rs
@@ -120,10 +120,13 @@ fn hash_token_stream(node: &Node, source: &[u8], hasher: &mut Sha256) {
 
 /// Whitespace-collapsed declaration text of a node, cut before its `body`
 /// child and any C++ member-initializer list, falling back to the full node
-/// text for body-less declarations. Line wrapping and indentation must not
-/// leak into signatures: a multi-line declarator and its single-line
-/// reformat are the same declaration, and a signature string that differs
-/// only by formatting reads as a false signature change downstream.
+/// text for body-less declarations. Grammars that expose the body as a
+/// plainly-kinded child instead of a `body` field (e.g. Kotlin's
+/// `function_body`/`class_body`) are cut at that child by kind. Line
+/// wrapping and indentation must not leak into signatures: a multi-line
+/// declarator and its single-line reformat are the same declaration, and a
+/// signature string that differs only by formatting reads as a false
+/// signature change downstream.
 pub fn declaration_signature(node: &Node, source: &[u8]) -> String {
     let start = node.start_byte();
     let mut end = node.end_byte();
@@ -132,7 +135,10 @@ pub fn declaration_signature(node: &Node, source: &[u8]) -> String {
     }
     let mut cursor = node.walk();
     for child in node.children(&mut cursor) {
-        if child.kind() == "field_initializer_list" {
+        if matches!(
+            child.kind(),
+            "field_initializer_list" | "function_body" | "class_body" | "enum_class_body"
+        ) {
             end = end.min(child.start_byte());
         }
     }

--- a/crates/kin-parser/src/languages/java.rs
+++ b/crates/kin-parser/src/languages/java.rs
@@ -411,6 +411,11 @@ fn extract_preceding_comment(node: &tree_sitter::Node, source: &[u8]) -> Option<
 }
 
 /// Recursively walk a method body to find `method_invocation` nodes.
+///
+/// A `method_invocation` carries the invoked method in its `name` field, so
+/// `obj.execute()` and `a.b.execute()` both emit the simple `execute`. Graph
+/// edges key on that rightmost name rather than the dotted source text, which
+/// no name index could match.
 fn extract_calls_from_body(
     node: &tree_sitter::Node,
     source: &[u8],
@@ -423,26 +428,10 @@ fn extract_calls_from_body(
             if let Some(name_node) = child.child_by_field_name("name") {
                 let method_name = name_node.utf8_text(source).unwrap_or("");
                 if !method_name.is_empty() {
-                    // Qualify with the receiver object when available.
-                    let callee = match child.child_by_field_name("object") {
-                        Some(obj) => {
-                            let obj_text = obj.utf8_text(source).unwrap_or("");
-                            // Use the last segment of the receiver for qualification.
-                            // e.g., `this.mapper.copy()` → `mapper.copy`
-                            let qualifier = obj_text.rsplit('.').next().unwrap_or(obj_text);
-                            if qualifier == "this" || qualifier == "super" {
-                                // `this.method()` or `super.method()` — just use method name
-                                method_name.to_string()
-                            } else {
-                                format!("{}.{}", qualifier, method_name)
-                            }
-                        }
-                        None => method_name.to_string(),
-                    };
                     relations.push(ExtractedRelation {
                         kind: kin_model::RelationKind::Calls,
                         src_name: context_name.to_string(),
-                        dst_name: callee,
+                        dst_name: method_name.to_string(),
                         import_source: None,
                     });
                 }
@@ -603,10 +592,10 @@ mod tests {
             calls.len()
         );
         let dst_names: Vec<&str> = calls.iter().map(|c| c.dst_name.as_str()).collect();
-        // System.out.println → qualified as out.println (last segment of receiver)
+        // System.out.println → narrowed to the rightmost name
         assert!(
-            dst_names.contains(&"out.println"),
-            "expected out.println in {:?}",
+            dst_names.contains(&"println"),
+            "expected println in {:?}",
             dst_names
         );
         assert!(
@@ -665,10 +654,10 @@ public class Service {
             .filter(|r| r.kind == kin_model::RelationKind::Calls)
             .map(|r| r.dst_name.as_str())
             .collect();
-        // mapper.writeValue — simple receiver qualification
+        // mapper.writeValue(...) → rightmost name
         assert!(
-            calls.contains(&"mapper.writeValue"),
-            "expected mapper.writeValue in {:?}",
+            calls.contains(&"writeValue"),
+            "expected writeValue in {:?}",
             calls
         );
         // this.init() → bare method name
@@ -683,16 +672,22 @@ public class Service {
             "expected close (super stripped) in {:?}",
             calls
         );
-        // helper.nested.transform → last segment is nested
+        // helper.nested.transform(...) → rightmost name, chained receiver dropped
         assert!(
-            calls.contains(&"nested.transform"),
-            "expected nested.transform in {:?}",
+            calls.contains(&"transform"),
+            "expected transform in {:?}",
             calls
         );
         // standalone() → bare method name (no receiver)
         assert!(
             calls.contains(&"standalone"),
             "expected standalone in {:?}",
+            calls
+        );
+        // No dotted callee may survive narrowing.
+        assert!(
+            calls.iter().all(|c| !c.contains('.')),
+            "expected only simple callee names in {:?}",
             calls
         );
     }

--- a/crates/kin-parser/src/languages/shallow_backed.rs
+++ b/crates/kin-parser/src/languages/shallow_backed.rs
@@ -411,7 +411,17 @@ fn extract_csharp_calls(
     recurse_children(node, source, |child| {
         if child.kind() == "invocation_expression" {
             if let Some(function) = child.child_by_field_name("function") {
-                let callee = normalize_scoped_name(text_of(&function, source).trim());
+                // A member access carries the invoked method in its `name`
+                // field, so `obj.Execute()` and `Console.WriteLine(...)` emit
+                // the rightmost simple name the name index can match, never
+                // the dotted source text.
+                let callee = match function.kind() {
+                    "member_access_expression" | "member_binding_expression" => function
+                        .child_by_field_name("name")
+                        .map(|name| text_of(&name, source).trim().to_string())
+                        .unwrap_or_default(),
+                    _ => normalize_scoped_name(text_of(&function, source).trim()),
+                };
                 if !callee.is_empty() {
                     relations.push(ExtractedRelation {
                         kind: kin_model::RelationKind::Calls,

--- a/crates/kin-parser/tests/fingerprint_semantics.rs
+++ b/crates/kin-parser/tests/fingerprint_semantics.rs
@@ -12,7 +12,11 @@
 //! changed" evidence to review gates.
 
 use kin_model::{FilePathId, Hash256};
-use kin_parser::{CppAdapter, GoAdapter, LanguageAdapter, PythonAdapter, RustAdapter};
+use kin_parser::{
+    CAdapter, CSharpAdapter, CppAdapter, GoAdapter, JavaAdapter, JavaScriptAdapter, KotlinAdapter,
+    LanguageAdapter, PhpAdapter, PythonAdapter, RubyAdapter, RustAdapter, SwiftAdapter,
+    TypeScriptAdapter,
+};
 
 fn entity_hashes(
     adapter: &dyn LanguageAdapter,
@@ -224,5 +228,135 @@ public:
     assert!(
         !a.contains("m_mode"),
         "member-initializer list must not leak into the signature, got: {a}"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Cosmetic-stability matrix (FIR-1313): extend the comment-only + whitespace-
+// only invariant to every full-adapter language not covered above. Go, C++,
+// Rust, and Python are already exercised earlier in this file; the block below
+// adds TypeScript, JavaScript, Java, C, C#, Ruby, PHP, Kotlin, and Swift. All
+// are GREEN — `compute_fingerprint` is shared and skips comment `extra` nodes
+// and inter-token whitespace, so every adapter inherits the invariant.
+// ---------------------------------------------------------------------------
+
+/// A comment-only edit and a whitespace-only reformat must each leave all three
+/// fingerprint hashes of `name` unchanged.
+fn assert_cosmetic_stable(
+    adapter: &dyn LanguageAdapter,
+    name: &str,
+    base: &str,
+    comment_only: &str,
+    whitespace_only: &str,
+) {
+    let b = entity_hashes(adapter, base, name);
+    assert_eq!(
+        b,
+        entity_hashes(adapter, comment_only, name),
+        "comment-only edit must not change any fingerprint hash ({name})"
+    );
+    assert_eq!(
+        b,
+        entity_hashes(adapter, whitespace_only, name),
+        "whitespace-only edit must not change any fingerprint hash ({name})"
+    );
+}
+
+#[test]
+fn typescript_cosmetic_edits_keep_fingerprint() {
+    assert_cosmetic_stable(
+        &TypeScriptAdapter,
+        "total",
+        "function total(a: number, b: number): number { return a + b; }",
+        "function total(a: number, b: number): number {\n  // sum them\n  return a + b;\n}",
+        "function total(a:number,b:number):number{return a+b;}",
+    );
+}
+
+#[test]
+fn javascript_cosmetic_edits_keep_fingerprint() {
+    assert_cosmetic_stable(
+        &JavaScriptAdapter,
+        "total",
+        "function total(a, b) { return a + b; }",
+        "function total(a, b) {\n  // sum them\n  return a + b;\n}",
+        "function total(a,b){return a+b;}",
+    );
+}
+
+#[test]
+fn java_cosmetic_edits_keep_fingerprint() {
+    assert_cosmetic_stable(
+        &JavaAdapter,
+        "C.total",
+        "class C { int total(int a, int b) { return a + b; } }",
+        "class C { int total(int a, int b) {\n    // sum them\n    return a + b; } }",
+        "class C{int total(int a,int b){return a+b;}}",
+    );
+}
+
+#[test]
+fn c_cosmetic_edits_keep_fingerprint() {
+    assert_cosmetic_stable(
+        &CAdapter,
+        "total",
+        "int total(int a, int b) { return a + b; }",
+        "int total(int a, int b) {\n    /* sum them */\n    return a + b;\n}",
+        "int total(int a,int b){return a+b;}",
+    );
+}
+
+#[test]
+fn csharp_cosmetic_edits_keep_fingerprint() {
+    assert_cosmetic_stable(
+        &CSharpAdapter,
+        "N.C.Total",
+        "namespace N { class C { int Total(int a, int b) { return a + b; } } }",
+        "namespace N { class C { int Total(int a, int b) {\n    // sum them\n    return a + b; } } }",
+        "namespace N{class C{int Total(int a,int b){return a+b;}}}",
+    );
+}
+
+#[test]
+fn ruby_cosmetic_edits_keep_fingerprint() {
+    assert_cosmetic_stable(
+        &RubyAdapter,
+        "C.total",
+        "class C\n    def total(a, b)\n        a + b\n    end\nend\n",
+        "class C\n    def total(a, b)\n        # sum them\n        a + b\n    end\nend\n",
+        "class C\n  def total(a,b)\n    a + b\n  end\nend\n",
+    );
+}
+
+#[test]
+fn php_cosmetic_edits_keep_fingerprint() {
+    assert_cosmetic_stable(
+        &PhpAdapter,
+        "total",
+        "<?php\nfunction total($a, $b) { return $a + $b; }\n",
+        "<?php\nfunction total($a, $b) {\n    // sum them\n    return $a + $b;\n}\n",
+        "<?php\nfunction total($a,$b){return $a+$b;}\n",
+    );
+}
+
+#[test]
+fn kotlin_cosmetic_edits_keep_fingerprint() {
+    assert_cosmetic_stable(
+        &KotlinAdapter,
+        "total",
+        "fun total(a: Int, b: Int): Int { return a + b }",
+        "fun total(a: Int, b: Int): Int {\n    // sum them\n    return a + b\n}",
+        "fun total(a:Int,b:Int):Int{return a+b}",
+    );
+}
+
+#[test]
+fn swift_cosmetic_edits_keep_fingerprint() {
+    assert_cosmetic_stable(
+        &SwiftAdapter,
+        "total",
+        "func total(a: Int, b: Int) -> Int { return a + b }",
+        "func total(a: Int, b: Int) -> Int {\n    // sum them\n    return a + b\n}",
+        "func total(a:Int,b:Int)->Int{return a+b}",
     );
 }

--- a/crates/kin-parser/tests/language_matrix_calls.rs
+++ b/crates/kin-parser/tests/language_matrix_calls.rs
@@ -1,0 +1,454 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Firelock, LLC
+
+//! Per-language call-relation matrix (FIR-1313).
+//!
+//! Three probes per language: (1) a plain same-file call emits a `Calls` edge
+//! whose `dst_name` is a simple, index-matchable identifier; (2) a method call
+//! on an object emits the rightmost name (never the dotted `obj.method` form);
+//! (3) handlers wired as values/callbacks — whatever the language idiomatically
+//! uses — probed for what the adapter *actually* emits.
+//!
+//! GREEN cells are locked as regression tests. The dotted-callee bug still lives
+//! in the Java and C# adapters (they emit `obj.execute` / `Console.WriteLine`),
+//! and several callback shapes are not wired to edges; those cells are written
+//! and `#[ignore]`d with the observed behavior named on the reason line.
+
+use kin_model::{FilePathId, RelationKind};
+use kin_parser::{
+    CAdapter, CSharpAdapter, CppAdapter, ExtractedRelation, GoAdapter, JavaAdapter,
+    JavaScriptAdapter, KotlinAdapter, LanguageAdapter, ParseOutput, PhpAdapter, PythonAdapter,
+    RubyAdapter, RustAdapter, SwiftAdapter, TypeScriptAdapter,
+};
+
+fn extract(adapter: &dyn LanguageAdapter, path: &str, src: &str) -> ParseOutput {
+    let bytes = src.as_bytes();
+    let tree = adapter.parse(bytes).expect("parse should succeed");
+    adapter
+        .extract(&tree, bytes, &FilePathId::new(path))
+        .expect("extract should succeed")
+}
+
+fn rels_of(out: &ParseOutput, kind: RelationKind) -> Vec<&ExtractedRelation> {
+    out.relations.iter().filter(|r| r.kind == kind).collect()
+}
+
+fn has_edge(out: &ParseOutput, kind: RelationKind, src: &str, dst: &str) -> bool {
+    out.relations
+        .iter()
+        .any(|r| r.kind == kind && r.src_name == src && r.dst_name == dst)
+}
+
+fn no_dotted_call_dst(out: &ParseOutput) {
+    let dotted: Vec<&str> = rels_of(out, RelationKind::Calls)
+        .iter()
+        .map(|r| r.dst_name.as_str())
+        .filter(|n| n.contains('.'))
+        .collect();
+    assert!(
+        dotted.is_empty(),
+        "Calls dst_names must be simple identifiers, got dotted: {dotted:?}"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// (1) plain same-file call -> simple dst_name  [GREEN, all languages]
+// ---------------------------------------------------------------------------
+
+#[test]
+fn typescript_plain_call_emits_simple_name() {
+    let out = extract(
+        &TypeScriptAdapter,
+        "s.ts",
+        "function caller() { target(); }\n",
+    );
+    assert!(has_edge(&out, RelationKind::Calls, "caller", "target"));
+}
+
+#[test]
+fn javascript_plain_call_emits_simple_name() {
+    let out = extract(
+        &JavaScriptAdapter,
+        "s.js",
+        "function caller() { target(); }\n",
+    );
+    assert!(has_edge(&out, RelationKind::Calls, "caller", "target"));
+}
+
+#[test]
+fn python_plain_call_emits_simple_name() {
+    let out = extract(&PythonAdapter, "s.py", "def caller():\n    target()\n");
+    assert!(has_edge(&out, RelationKind::Calls, "caller", "target"));
+}
+
+#[test]
+fn go_plain_call_emits_simple_name() {
+    let out = extract(
+        &GoAdapter,
+        "s.go",
+        "package main\nfunc caller() { target() }\n",
+    );
+    assert!(has_edge(&out, RelationKind::Calls, "caller", "target"));
+}
+
+#[test]
+fn java_plain_call_emits_simple_name() {
+    let out = extract(
+        &JavaAdapter,
+        "S.java",
+        "class C { void caller() { target(); } void target() {} }",
+    );
+    assert!(has_edge(&out, RelationKind::Calls, "C.caller", "target"));
+}
+
+#[test]
+fn rust_plain_call_emits_simple_name() {
+    let out = extract(&RustAdapter, "s.rs", "fn caller() { target(); }\n");
+    assert!(has_edge(&out, RelationKind::Calls, "caller", "target"));
+}
+
+#[test]
+fn c_plain_call_emits_simple_name() {
+    let out = extract(&CAdapter, "s.c", "void caller() { target(); }\n");
+    assert!(has_edge(&out, RelationKind::Calls, "caller", "target"));
+}
+
+#[test]
+fn cpp_plain_call_emits_simple_name() {
+    let out = extract(&CppAdapter, "s.cpp", "void caller() { target(); }\n");
+    assert!(has_edge(&out, RelationKind::Calls, "caller", "target"));
+}
+
+#[test]
+fn csharp_plain_call_emits_simple_name() {
+    let out = extract(
+        &CSharpAdapter,
+        "S.cs",
+        "namespace N { class C { void Caller() { Target(); } void Target() {} } }",
+    );
+    assert!(has_edge(&out, RelationKind::Calls, "N.C.Caller", "Target"));
+}
+
+#[test]
+fn ruby_parenthesized_call_emits_simple_name() {
+    // Ruby needs parentheses (or a receiver) for the extractor to see a `call`
+    // node; the paren-less form is pinned in the ignored section below.
+    let out = extract(
+        &RubyAdapter,
+        "s.rb",
+        "class C\n    def caller\n        target()\n    end\nend\n",
+    );
+    assert!(has_edge(&out, RelationKind::Calls, "C.caller", "target"));
+}
+
+#[test]
+fn php_plain_call_emits_simple_name() {
+    let out = extract(
+        &PhpAdapter,
+        "s.php",
+        "<?php\nfunction caller() { target(); }\n",
+    );
+    assert!(has_edge(&out, RelationKind::Calls, "caller", "target"));
+}
+
+#[test]
+fn kotlin_plain_call_emits_simple_name() {
+    let out = extract(&KotlinAdapter, "s.kt", "fun caller() { target() }\n");
+    assert!(has_edge(&out, RelationKind::Calls, "caller", "target"));
+}
+
+#[test]
+fn swift_plain_call_emits_simple_name() {
+    let out = extract(&SwiftAdapter, "s.swift", "func caller() { target() }\n");
+    assert!(has_edge(&out, RelationKind::Calls, "caller", "target"));
+}
+
+// ---------------------------------------------------------------------------
+// (2) method call on an object -> rightmost name  [GREEN where narrowed]
+// ---------------------------------------------------------------------------
+
+#[test]
+fn typescript_method_call_emits_rightmost_name() {
+    let out = extract(
+        &TypeScriptAdapter,
+        "s.ts",
+        "class S { run() { obj.execute(); } }",
+    );
+    assert!(has_edge(&out, RelationKind::Calls, "S.run", "execute"));
+    no_dotted_call_dst(&out);
+}
+
+#[test]
+fn javascript_method_call_emits_rightmost_name() {
+    let out = extract(
+        &JavaScriptAdapter,
+        "s.js",
+        "class S { run() { obj.execute(); } }",
+    );
+    assert!(has_edge(&out, RelationKind::Calls, "S.run", "execute"));
+    no_dotted_call_dst(&out);
+}
+
+#[test]
+fn python_method_call_emits_rightmost_name() {
+    let out = extract(
+        &PythonAdapter,
+        "s.py",
+        "class S:\n    def run(self):\n        obj.execute()\n",
+    );
+    assert!(has_edge(&out, RelationKind::Calls, "S.run", "execute"));
+    no_dotted_call_dst(&out);
+}
+
+#[test]
+fn go_selector_call_emits_rightmost_name() {
+    let out = extract(
+        &GoAdapter,
+        "s.go",
+        "package main\nimport \"fmt\"\nfunc run() { fmt.Println(\"x\") }\n",
+    );
+    assert!(has_edge(&out, RelationKind::Calls, "run", "Println"));
+    no_dotted_call_dst(&out);
+}
+
+#[test]
+fn rust_self_method_call_emits_rightmost_name() {
+    let out = extract(
+        &RustAdapter,
+        "s.rs",
+        "struct S;\nimpl S {\n    fn run(&self) { self.helper(); }\n    fn helper(&self) {}\n}\n",
+    );
+    assert!(has_edge(&out, RelationKind::Calls, "S::run", "helper"));
+}
+
+#[test]
+fn cpp_method_call_emits_rightmost_name() {
+    let out = extract(
+        &CppAdapter,
+        "s.cpp",
+        "class S {\npublic:\n    void run() { obj.execute(); }\n};\n",
+    );
+    assert!(has_edge(&out, RelationKind::Calls, "S::run", "execute"));
+    no_dotted_call_dst(&out);
+}
+
+#[test]
+fn ruby_receiver_call_emits_rightmost_name() {
+    let out = extract(
+        &RubyAdapter,
+        "s.rb",
+        "class S\n    def run\n        obj.execute\n    end\nend\n",
+    );
+    assert!(has_edge(&out, RelationKind::Calls, "S.run", "execute"));
+    no_dotted_call_dst(&out);
+}
+
+#[test]
+fn php_method_call_emits_rightmost_name() {
+    let out = extract(
+        &PhpAdapter,
+        "s.php",
+        "<?php\nclass S {\n    public function run() { $obj->execute(); }\n}\n",
+    );
+    assert!(has_edge(&out, RelationKind::Calls, "S.run", "execute"));
+    no_dotted_call_dst(&out);
+}
+
+#[test]
+fn kotlin_method_call_emits_rightmost_name() {
+    let out = extract(
+        &KotlinAdapter,
+        "s.kt",
+        "class S {\n    fun run() { obj.execute() }\n}\n",
+    );
+    assert!(has_edge(&out, RelationKind::Calls, "S.run", "execute"));
+    no_dotted_call_dst(&out);
+}
+
+#[test]
+fn swift_method_call_emits_rightmost_name() {
+    let out = extract(
+        &SwiftAdapter,
+        "s.swift",
+        "class S {\n    func run() { obj.execute() }\n}\n",
+    );
+    assert!(has_edge(&out, RelationKind::Calls, "S.run", "execute"));
+    no_dotted_call_dst(&out);
+}
+
+// ---------------------------------------------------------------------------
+// (3) value-position / callback handlers — what the adapter ACTUALLY emits.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn go_function_value_argument_emits_reference() {
+    // Go is the only adapter that turns a bare function passed as a value into a
+    // graph edge: `register(plain)` yields a References edge to `plain`.
+    let out = extract(
+        &GoAdapter,
+        "s.go",
+        "package main\nfunc plain() {}\nfunc run() { register(plain) }\n",
+    );
+    assert!(
+        has_edge(&out, RelationKind::References, "run", "plain"),
+        "expected References run -> plain, got {:?}",
+        out.relations
+            .iter()
+            .map(|r| (r.kind, r.src_name.as_str(), r.dst_name.as_str()))
+            .collect::<Vec<_>>()
+    );
+}
+
+#[test]
+fn csharp_object_creation_emits_reference() {
+    let out = extract(
+        &CSharpAdapter,
+        "S.cs",
+        "namespace N { class C { void Run() { var w = new Widget(); } } }",
+    );
+    assert!(has_edge(
+        &out,
+        RelationKind::References,
+        "N.C.Run",
+        "Widget"
+    ));
+}
+
+#[test]
+fn kotlin_lambda_body_calls_are_captured() {
+    // A handler wired as a trailing lambda: the calls *inside* the lambda body
+    // attribute to the enclosing method.
+    let out = extract(
+        &KotlinAdapter,
+        "s.kt",
+        "class S {\n    fun run() { register { handle() } }\n}\n",
+    );
+    assert!(has_edge(&out, RelationKind::Calls, "S.run", "register"));
+    assert!(has_edge(&out, RelationKind::Calls, "S.run", "handle"));
+}
+
+#[test]
+fn java_lambda_body_calls_are_captured() {
+    let out = extract(
+        &JavaAdapter,
+        "S.java",
+        "class C { void run() { list.forEach(x -> handle(x)); } }",
+    );
+    assert!(has_edge(&out, RelationKind::Calls, "C.run", "handle"));
+}
+
+#[test]
+fn ruby_block_body_calls_are_captured() {
+    let out = extract(
+        &RubyAdapter,
+        "s.rb",
+        "class C\n    def run\n        items.each { |x| handle(x) }\n    end\nend\n",
+    );
+    assert!(has_edge(&out, RelationKind::Calls, "C.run", "handle"));
+}
+
+#[test]
+fn typescript_arrow_body_calls_are_captured() {
+    let out = extract(
+        &TypeScriptAdapter,
+        "s.ts",
+        "function run() { arr.forEach(x => handle(x)); }\n",
+    );
+    assert!(has_edge(&out, RelationKind::Calls, "run", "handle"));
+}
+
+// ---------------------------------------------------------------------------
+// Pinned gaps (RED/YELLOW) — executable, #[ignore]d with observed behavior.
+// ---------------------------------------------------------------------------
+
+#[test]
+#[ignore = "RED: Java emits the dotted `obj.execute` as the Calls dst_name (not narrowed to `execute`), so name-based cross-file resolution can never match it"]
+fn java_method_call_should_narrow_to_rightmost_name() {
+    let out = extract(
+        &JavaAdapter,
+        "S.java",
+        "class C { void run() { obj.execute(); } }",
+    );
+    assert!(has_edge(&out, RelationKind::Calls, "C.run", "execute"));
+    no_dotted_call_dst(&out);
+}
+
+#[test]
+#[ignore = "RED: C# emits the dotted `obj.Execute` as the Calls dst_name (not narrowed to `Execute`) via normalize_scoped_name on the whole invocation function text"]
+fn csharp_method_call_should_narrow_to_rightmost_name() {
+    let out = extract(
+        &CSharpAdapter,
+        "S.cs",
+        "namespace N { class C { void Run() { obj.Execute(); } } }",
+    );
+    assert!(has_edge(&out, RelationKind::Calls, "N.C.Run", "Execute"));
+    no_dotted_call_dst(&out);
+}
+
+#[test]
+#[ignore = "RED: C# emits the dotted `Console.WriteLine` for a namespace/static call instead of the rightmost `WriteLine`"]
+fn csharp_static_qualified_call_should_narrow_to_rightmost_name() {
+    let out = extract(
+        &CSharpAdapter,
+        "S.cs",
+        "namespace N { class C { void Run() { Console.WriteLine(\"x\"); } } }",
+    );
+    assert!(has_edge(&out, RelationKind::Calls, "N.C.Run", "WriteLine"));
+    no_dotted_call_dst(&out);
+}
+
+#[test]
+#[ignore = "YELLOW: Ruby drops a paren-less, receiver-less call — bare `target` parses as an identifier, not a `call` node, so no Calls edge is emitted"]
+fn ruby_parenless_call_should_be_emitted() {
+    let out = extract(
+        &RubyAdapter,
+        "s.rb",
+        "class C\n    def caller\n        target\n    end\nend\n",
+    );
+    assert!(has_edge(&out, RelationKind::Calls, "C.caller", "target"));
+}
+
+#[test]
+#[ignore = "YELLOW: a bare function passed as a JS/TS callback value (`register(plain)`) emits no edge to `plain` — only the receiving call `register` is recorded"]
+fn typescript_callback_value_should_emit_reference() {
+    let out = extract(
+        &TypeScriptAdapter,
+        "s.ts",
+        "function plain() {}\nfunction run() { register(plain); }\n",
+    );
+    assert!(
+        has_edge(&out, RelationKind::References, "run", "plain")
+            || has_edge(&out, RelationKind::Calls, "run", "plain"),
+        "expected an edge run -> plain for the callback value"
+    );
+}
+
+#[test]
+#[ignore = "YELLOW: a Java method reference (`this::helper`) passed as a value emits no edge to `helper`"]
+fn java_method_reference_should_emit_edge() {
+    let out = extract(
+        &JavaAdapter,
+        "S.java",
+        "class C { void run() { register(this::helper); } void helper() {} }",
+    );
+    assert!(
+        has_edge(&out, RelationKind::References, "C.run", "helper")
+            || has_edge(&out, RelationKind::Calls, "C.run", "helper"),
+        "expected an edge C.run -> helper for the method reference"
+    );
+}
+
+#[test]
+#[ignore = "YELLOW: a Ruby symbol callback (`register(:helper)`) emits no edge to `helper` — the symbol argument is not resolved to a reference"]
+fn ruby_symbol_callback_should_emit_reference() {
+    let out = extract(
+        &RubyAdapter,
+        "s.rb",
+        "class C\n    def run\n        register(:helper)\n    end\n    def helper\n    end\nend\n",
+    );
+    assert!(
+        has_edge(&out, RelationKind::References, "C.run", "helper")
+            || has_edge(&out, RelationKind::Calls, "C.run", "helper"),
+        "expected an edge C.run -> helper for the symbol callback"
+    );
+}

--- a/crates/kin-parser/tests/language_matrix_calls.rs
+++ b/crates/kin-parser/tests/language_matrix_calls.rs
@@ -9,10 +9,10 @@
 //! (3) handlers wired as values/callbacks — whatever the language idiomatically
 //! uses — probed for what the adapter *actually* emits.
 //!
-//! GREEN cells are locked as regression tests. The dotted-callee bug still lives
-//! in the Java and C# adapters (they emit `obj.execute` / `Console.WriteLine`),
-//! and several callback shapes are not wired to edges; those cells are written
-//! and `#[ignore]`d with the observed behavior named on the reason line.
+//! GREEN cells are locked as regression tests, including the rightmost-name
+//! narrowing of dotted method calls in every adapter. Several callback shapes
+//! are not wired to edges; those cells are written and `#[ignore]`d with the
+//! observed behavior named on the reason line.
 
 use kin_model::{FilePathId, RelationKind};
 use kin_parser::{
@@ -362,7 +362,6 @@ fn typescript_arrow_body_calls_are_captured() {
 // ---------------------------------------------------------------------------
 
 #[test]
-#[ignore = "RED: Java emits the dotted `obj.execute` as the Calls dst_name (not narrowed to `execute`), so name-based cross-file resolution can never match it"]
 fn java_method_call_should_narrow_to_rightmost_name() {
     let out = extract(
         &JavaAdapter,
@@ -374,7 +373,6 @@ fn java_method_call_should_narrow_to_rightmost_name() {
 }
 
 #[test]
-#[ignore = "RED: C# emits the dotted `obj.Execute` as the Calls dst_name (not narrowed to `Execute`) via normalize_scoped_name on the whole invocation function text"]
 fn csharp_method_call_should_narrow_to_rightmost_name() {
     let out = extract(
         &CSharpAdapter,
@@ -386,7 +384,6 @@ fn csharp_method_call_should_narrow_to_rightmost_name() {
 }
 
 #[test]
-#[ignore = "RED: C# emits the dotted `Console.WriteLine` for a namespace/static call instead of the rightmost `WriteLine`"]
 fn csharp_static_qualified_call_should_narrow_to_rightmost_name() {
     let out = extract(
         &CSharpAdapter,

--- a/crates/kin-parser/tests/language_matrix_entities.rs
+++ b/crates/kin-parser/tests/language_matrix_entities.rs
@@ -1,0 +1,461 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Firelock, LLC
+
+//! Per-language entity-extraction matrix (FIR-1313).
+//!
+//! For every language with a full adapter, asserts that functions, methods, and
+//! classes/types are extracted with non-empty canonical signatures, and that a
+//! multi-line declaration collapses to the same signature string as its
+//! single-line form (the shared `declaration_signature` contract exercised by
+//! `cpp_multiline_declarator_keeps_signature_string`).
+//!
+//! Signatures come from the shared `declaration_signature`, which cuts before a
+//! node's `body` field. Adapters that expose a `body` field get clean,
+//! body-free signatures automatically; the `#[ignore]`d tests at the bottom pin
+//! the two cells where that contract is not met today (Kotlin: no body field, so
+//! the whole body leaks into the signature; Ruby: an empty-body method keeps a
+//! trailing `end`) plus the shared trailing-comma wart.
+
+use kin_model::{EntityKind, FilePathId};
+use kin_parser::{
+    CAdapter, CSharpAdapter, CppAdapter, ExtractedEntity, GoAdapter, JavaAdapter,
+    JavaScriptAdapter, KotlinAdapter, LanguageAdapter, ParseOutput, PhpAdapter, PythonAdapter,
+    RubyAdapter, RustAdapter, SwiftAdapter, TypeScriptAdapter,
+};
+
+fn extract(adapter: &dyn LanguageAdapter, path: &str, src: &str) -> ParseOutput {
+    let bytes = src.as_bytes();
+    let tree = adapter.parse(bytes).expect("parse should succeed");
+    adapter
+        .extract(&tree, bytes, &FilePathId::new(path))
+        .expect("extract should succeed")
+}
+
+fn entity<'a>(out: &'a ParseOutput, kind: EntityKind, name: &str) -> &'a ExtractedEntity {
+    out.entities
+        .iter()
+        .find(|e| e.kind == kind && e.name == name)
+        .unwrap_or_else(|| {
+            panic!(
+                "no {kind:?} named {name:?}; have: {:?}",
+                out.entities
+                    .iter()
+                    .map(|e| (e.kind, e.name.as_str()))
+                    .collect::<Vec<_>>()
+            )
+        })
+}
+
+/// A callable entity must have a non-empty signature that names it, shows its
+/// parameter list, and does not leak its body (`{`).
+fn assert_clean_callable_sig(e: &ExtractedEntity, simple_name: &str) {
+    assert!(!e.signature.is_empty(), "empty signature for {}", e.name);
+    assert!(
+        e.signature.contains(simple_name),
+        "signature {:?} should name {:?}",
+        e.signature,
+        simple_name
+    );
+    assert!(
+        e.signature.contains('('),
+        "signature {:?} should carry a parameter list",
+        e.signature
+    );
+    assert!(
+        !e.signature.contains('{'),
+        "signature {:?} must not leak the body",
+        e.signature
+    );
+}
+
+fn sig_of(adapter: &dyn LanguageAdapter, path: &str, src: &str, name: &str) -> String {
+    extract(adapter, path, src)
+        .entities
+        .into_iter()
+        .find(|e| e.name == name)
+        .unwrap_or_else(|| panic!("entity {name:?} not found"))
+        .signature
+}
+
+/// Assert a pure line-wrap of a declaration (no added tokens) collapses to the
+/// same signature string as its single-line form.
+fn assert_multiline_stable(
+    adapter: &dyn LanguageAdapter,
+    path: &str,
+    single: &str,
+    multi: &str,
+    name: &str,
+) {
+    let a = sig_of(adapter, path, single, name);
+    let b = sig_of(adapter, path, multi, name);
+    assert_eq!(a, b, "line-wrapping must not change the signature ({name})");
+    assert!(!a.is_empty(), "signature must be non-empty ({name})");
+}
+
+// ---------------------------------------------------------------------------
+// Entity extraction — one test per language.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn typescript_entities() {
+    let out = extract(
+        &TypeScriptAdapter,
+        "s.ts",
+        "export function plain(): number { return 1; }\nclass Service {\n  run(): void {}\n}\ninterface Greeter { greet(): string; }\ntype Id = string;\n",
+    );
+    assert_clean_callable_sig(entity(&out, EntityKind::Function, "plain"), "plain");
+    assert_clean_callable_sig(entity(&out, EntityKind::Method, "Service.run"), "run");
+    assert!(!entity(&out, EntityKind::Class, "Service")
+        .signature
+        .is_empty());
+    assert!(!entity(&out, EntityKind::Interface, "Greeter")
+        .signature
+        .is_empty());
+    assert!(!entity(&out, EntityKind::TypeAlias, "Id")
+        .signature
+        .is_empty());
+    assert_multiline_stable(
+        &TypeScriptAdapter,
+        "s.ts",
+        "function total(a: number, b: number): number { return a + b; }",
+        "function total(\n  a: number,\n  b: number\n): number { return a + b; }",
+        "total",
+    );
+}
+
+#[test]
+fn javascript_entities() {
+    let out = extract(
+        &JavaScriptAdapter,
+        "s.js",
+        "export function plain() { return 1; }\nclass Service {\n  run() {}\n}\n",
+    );
+    assert_clean_callable_sig(entity(&out, EntityKind::Function, "plain"), "plain");
+    assert_clean_callable_sig(entity(&out, EntityKind::Method, "Service.run"), "run");
+    assert!(!entity(&out, EntityKind::Class, "Service")
+        .signature
+        .is_empty());
+    assert_multiline_stable(
+        &JavaScriptAdapter,
+        "s.js",
+        "function total(a, b) { return a + b; }",
+        "function total(\n  a,\n  b\n) { return a + b; }",
+        "total",
+    );
+}
+
+#[test]
+fn python_entities() {
+    let out = extract(
+        &PythonAdapter,
+        "s.py",
+        "def plain():\n    return 1\n\nclass Service:\n    def run(self):\n        pass\n",
+    );
+    assert_clean_callable_sig(entity(&out, EntityKind::Function, "plain"), "plain");
+    assert_clean_callable_sig(entity(&out, EntityKind::Method, "Service.run"), "run");
+    assert!(!entity(&out, EntityKind::Class, "Service")
+        .signature
+        .is_empty());
+    assert_multiline_stable(
+        &PythonAdapter,
+        "s.py",
+        "def total(a, b):\n    return a + b\n",
+        "def total(\n    a,\n    b):\n    return a + b\n",
+        "total",
+    );
+}
+
+#[test]
+fn go_entities() {
+    let out = extract(
+        &GoAdapter,
+        "s.go",
+        "package main\n\nfunc plain() {}\n\ntype Server struct{}\n\nfunc (s *Server) Run() {}\n",
+    );
+    assert_clean_callable_sig(entity(&out, EntityKind::Function, "plain"), "plain");
+    assert_clean_callable_sig(entity(&out, EntityKind::Method, "Server.Run"), "Run");
+    assert!(!entity(&out, EntityKind::Class, "Server")
+        .signature
+        .is_empty());
+    assert_multiline_stable(
+        &GoAdapter,
+        "s.go",
+        "package main\nfunc total(a int, b int) int { return a + b }\n",
+        "package main\nfunc total(\n    a int,\n    b int) int { return a + b }\n",
+        "total",
+    );
+}
+
+#[test]
+fn java_entities() {
+    let out = extract(
+        &JavaAdapter,
+        "S.java",
+        "class Service {\n    void run() {}\n}\ninterface Greeter { String greet(); }\n",
+    );
+    assert_clean_callable_sig(entity(&out, EntityKind::Method, "Service.run"), "run");
+    assert!(!entity(&out, EntityKind::Class, "Service")
+        .signature
+        .is_empty());
+    assert!(!entity(&out, EntityKind::Interface, "Greeter")
+        .signature
+        .is_empty());
+    assert_multiline_stable(
+        &JavaAdapter,
+        "S.java",
+        "class C { int total(int a, int b) { return a + b; } }",
+        "class C { int total(\n    int a,\n    int b\n) { return a + b; } }",
+        "C.total",
+    );
+}
+
+#[test]
+fn rust_entities() {
+    let out = extract(
+        &RustAdapter,
+        "s.rs",
+        "fn plain() -> i32 { 1 }\n\nstruct Service;\n\nimpl Service {\n    fn run(&self) {}\n}\ntrait Greeter { fn greet(&self) -> String; }\n",
+    );
+    assert_clean_callable_sig(entity(&out, EntityKind::Function, "plain"), "plain");
+    assert_clean_callable_sig(entity(&out, EntityKind::Method, "Service::run"), "run");
+    assert!(!entity(&out, EntityKind::Class, "Service")
+        .signature
+        .is_empty());
+    assert!(!entity(&out, EntityKind::TraitDef, "Greeter")
+        .signature
+        .is_empty());
+    assert_multiline_stable(
+        &RustAdapter,
+        "s.rs",
+        "fn total(a: i32, b: i32) -> i32 { a + b }",
+        "fn total(\n    a: i32,\n    b: i32) -> i32 { a + b }",
+        "total",
+    );
+}
+
+#[test]
+fn c_entities() {
+    let out = extract(
+        &CAdapter,
+        "s.c",
+        "int plain() { return 1; }\nvoid run() {}\nstruct Point { int x; int y; };\n",
+    );
+    assert_clean_callable_sig(entity(&out, EntityKind::Function, "plain"), "plain");
+    assert_clean_callable_sig(entity(&out, EntityKind::Function, "run"), "run");
+    assert!(!entity(&out, EntityKind::Class, "Point")
+        .signature
+        .is_empty());
+    assert_multiline_stable(
+        &CAdapter,
+        "s.c",
+        "int total(int a, int b) { return a + b; }",
+        "int total(\n    int a,\n    int b\n) { return a + b; }",
+        "total",
+    );
+}
+
+#[test]
+fn cpp_entities() {
+    let out = extract(
+        &CppAdapter,
+        "s.cpp",
+        "int plain() { return 1; }\nclass Service {\npublic:\n    void run() {}\n};\n",
+    );
+    assert_clean_callable_sig(entity(&out, EntityKind::Function, "plain"), "plain");
+    assert_clean_callable_sig(entity(&out, EntityKind::Method, "Service::run"), "run");
+    assert!(!entity(&out, EntityKind::Class, "Service")
+        .signature
+        .is_empty());
+    assert_multiline_stable(
+        &CppAdapter,
+        "s.cpp",
+        "int total(int a, int b) { return a + b; }",
+        "int total(\n    int a,\n    int b\n) { return a + b; }",
+        "total",
+    );
+}
+
+#[test]
+fn csharp_entities() {
+    let out = extract(
+        &CSharpAdapter,
+        "S.cs",
+        "namespace Demo {\n    class Service {\n        void Run() {}\n    }\n}\n",
+    );
+    assert_clean_callable_sig(entity(&out, EntityKind::Method, "Demo.Service.Run"), "Run");
+    assert!(!entity(&out, EntityKind::Class, "Demo.Service")
+        .signature
+        .is_empty());
+    assert!(!entity(&out, EntityKind::Module, "Demo")
+        .signature
+        .is_empty());
+    assert_multiline_stable(
+        &CSharpAdapter,
+        "S.cs",
+        "namespace N { class C { int Total(int a, int b) { return a + b; } } }",
+        "namespace N { class C { int Total(\n    int a,\n    int b\n) { return a + b; } } }",
+        "N.C.Total",
+    );
+}
+
+#[test]
+fn ruby_entities() {
+    let out = extract(
+        &RubyAdapter,
+        "s.rb",
+        "class Service\n    def run\n        work\n    end\nend\n",
+    );
+    // A method with a body gets a clean `def run` signature.
+    assert_clean_callable_sig_ruby(entity(&out, EntityKind::Method, "Service.run"), "run");
+    assert!(!entity(&out, EntityKind::Class, "Service")
+        .signature
+        .is_empty());
+    assert_multiline_stable(
+        &RubyAdapter,
+        "s.rb",
+        "class C\n    def total(a, b)\n        a + b\n    end\nend\n",
+        "class C\n    def total(\n        a,\n        b)\n        a + b\n    end\nend\n",
+        "C.total",
+    );
+}
+
+/// Ruby signatures have no parameter parens for a paren-less `def`, so the
+/// generic paren assertion does not apply; only name + non-empty + no body.
+fn assert_clean_callable_sig_ruby(e: &ExtractedEntity, simple_name: &str) {
+    assert!(!e.signature.is_empty(), "empty signature for {}", e.name);
+    assert!(
+        e.signature.contains(simple_name),
+        "signature {:?} should name {:?}",
+        e.signature,
+        simple_name
+    );
+    assert!(
+        !e.signature.contains('{'),
+        "signature {:?} must not leak a brace body",
+        e.signature
+    );
+}
+
+#[test]
+fn php_entities() {
+    let out = extract(
+        &PhpAdapter,
+        "s.php",
+        "<?php\nfunction plain() { return 1; }\nclass Service {\n    public function run() {}\n}\n",
+    );
+    assert_clean_callable_sig(entity(&out, EntityKind::Function, "plain"), "plain");
+    assert_clean_callable_sig(entity(&out, EntityKind::Method, "Service.run"), "run");
+    assert!(!entity(&out, EntityKind::Class, "Service")
+        .signature
+        .is_empty());
+    assert_multiline_stable(
+        &PhpAdapter,
+        "s.php",
+        "<?php\nfunction total($a, $b) { return $a + $b; }\n",
+        "<?php\nfunction total(\n    $a,\n    $b\n) { return $a + $b; }\n",
+        "total",
+    );
+}
+
+#[test]
+fn swift_entities() {
+    let out = extract(
+        &SwiftAdapter,
+        "s.swift",
+        "func plain() -> Int { return 1 }\nclass Service {\n    func run() {}\n}\n",
+    );
+    assert_clean_callable_sig(entity(&out, EntityKind::Function, "plain"), "plain");
+    assert_clean_callable_sig(entity(&out, EntityKind::Method, "Service.run"), "run");
+    assert!(!entity(&out, EntityKind::Class, "Service")
+        .signature
+        .is_empty());
+    assert_multiline_stable(
+        &SwiftAdapter,
+        "s.swift",
+        "func total(a: Int, b: Int) -> Int { return a + b }",
+        "func total(\n    a: Int,\n    b: Int\n) -> Int { return a + b }",
+        "total",
+    );
+}
+
+#[test]
+fn kotlin_entities_extract_with_nonempty_signatures() {
+    // Kotlin entities are extracted with the right kinds and names, and the
+    // multi-line form is stable. The *quality* gap (body in signature) is pinned
+    // separately below.
+    let out = extract(
+        &KotlinAdapter,
+        "s.kt",
+        "fun plain(): Int { return 1 }\nclass Service {\n    fun run() {}\n}\n",
+    );
+    assert!(!entity(&out, EntityKind::Function, "plain")
+        .signature
+        .is_empty());
+    assert!(!entity(&out, EntityKind::Method, "Service.run")
+        .signature
+        .is_empty());
+    assert!(!entity(&out, EntityKind::Class, "Service")
+        .signature
+        .is_empty());
+    assert_multiline_stable(
+        &KotlinAdapter,
+        "s.kt",
+        "fun total(a: Int, b: Int): Int { return a + b }",
+        "fun total(\n    a: Int,\n    b: Int\n): Int { return a + b }",
+        "total",
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Pinned gaps (RED/YELLOW cells) — executable, #[ignore]d with the observed
+// behavior named on the reason line.
+// ---------------------------------------------------------------------------
+
+#[test]
+#[ignore = "RED: Kotlin function/method signatures leak the whole body — declaration_signature finds no `body` field on Kotlin function_declaration, so it falls back to full node text (`fun total(...): Int { return a + b }`)"]
+fn kotlin_signature_should_exclude_body() {
+    let sig = sig_of(
+        &KotlinAdapter,
+        "s.kt",
+        "fun total(a: Int, b: Int): Int {\n    return a + b\n}\n",
+        "total",
+    );
+    assert!(
+        !sig.contains('{'),
+        "Kotlin signature should exclude the body, got {sig:?}"
+    );
+}
+
+#[test]
+#[ignore = "YELLOW: Ruby empty-body method keeps a trailing `end` in the signature (`def helper end`) because there is no `body` field to cut before"]
+fn ruby_empty_body_method_signature_should_exclude_end() {
+    let sig = sig_of(
+        &RubyAdapter,
+        "s.rb",
+        "class C\n    def helper\n    end\nend\n",
+        "C.helper",
+    );
+    assert_eq!(sig, "def helper", "got {sig:?}");
+}
+
+#[test]
+#[ignore = "YELLOW: shared declaration_signature does not collapse a trailing `,)` — a multi-line param list with a trailing comma yields `total(a, b,)` vs single-line `total(a, b)`. Affects every trailing-comma grammar (Rust/Python/Go/TS/JS/Kotlin/Swift)"]
+fn trailing_comma_multiline_signature_should_match_single_line() {
+    // Representative sample across three grammars; the wart is in the shared
+    // signature canonicalizer, so any trailing-comma language reproduces it.
+    let rust = |s: &str| sig_of(&RustAdapter, "s.rs", s, "total");
+    assert_eq!(
+        rust("fn total(a: i32, b: i32) -> i32 { a + b }"),
+        rust("fn total(a: i32, b: i32,) -> i32 { a + b }"),
+    );
+    let py = |s: &str| sig_of(&PythonAdapter, "s.py", s, "total");
+    assert_eq!(
+        py("def total(a, b):\n    return a + b\n"),
+        py("def total(a, b,):\n    return a + b\n"),
+    );
+    let go = |s: &str| sig_of(&GoAdapter, "s.go", s, "total");
+    assert_eq!(
+        go("package main\nfunc total(a int, b int) int { return a + b }\n"),
+        go("package main\nfunc total(a int, b int,) int { return a + b }\n"),
+    );
+}

--- a/crates/kin-parser/tests/language_matrix_entities.rs
+++ b/crates/kin-parser/tests/language_matrix_entities.rs
@@ -10,11 +10,11 @@
 //! `cpp_multiline_declarator_keeps_signature_string`).
 //!
 //! Signatures come from the shared `declaration_signature`, which cuts before a
-//! node's `body` field. Adapters that expose a `body` field get clean,
-//! body-free signatures automatically; the `#[ignore]`d tests at the bottom pin
-//! the two cells where that contract is not met today (Kotlin: no body field, so
-//! the whole body leaks into the signature; Ruby: an empty-body method keeps a
-//! trailing `end`) plus the shared trailing-comma wart.
+//! node's `body` field, or before a plainly-kinded body child (Kotlin's
+//! `function_body`/`class_body`) when the grammar exposes no such field. The
+//! `#[ignore]`d tests at the bottom pin the cells where that contract is not met
+//! today (Ruby: an empty-body method keeps a trailing `end`) plus the shared
+//! trailing-comma wart.
 
 use kin_model::{EntityKind, FilePathId};
 use kin_parser::{
@@ -412,7 +412,6 @@ fn kotlin_entities_extract_with_nonempty_signatures() {
 // ---------------------------------------------------------------------------
 
 #[test]
-#[ignore = "RED: Kotlin function/method signatures leak the whole body — declaration_signature finds no `body` field on Kotlin function_declaration, so it falls back to full node text (`fun total(...): Int { return a + b }`)"]
 fn kotlin_signature_should_exclude_body() {
     let sig = sig_of(
         &KotlinAdapter,

--- a/crates/kin-parser/tests/language_matrix_imports.rs
+++ b/crates/kin-parser/tests/language_matrix_imports.rs
@@ -1,0 +1,195 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Firelock, LLC
+
+//! Per-language import/module-edge matrix (FIR-1313).
+//!
+//! Every language with a full adapter must turn an import/use/require/include
+//! statement into a `FileImport` the cross-file linker can key on. All 13
+//! adapters do (GREEN). The `#[ignore]`d cells pin two YELLOW warts: PHP
+//! `require`/`include` (as opposed to `use`) produces no FileImport, and a C#
+//! `using Alias = Ns.Target;` records the alias as the module path and loses the
+//! target namespace.
+
+use kin_model::FilePathId;
+use kin_parser::{
+    CAdapter, CSharpAdapter, CppAdapter, GoAdapter, JavaAdapter, JavaScriptAdapter, KotlinAdapter,
+    LanguageAdapter, ParseOutput, PhpAdapter, PythonAdapter, RubyAdapter, RustAdapter,
+    SwiftAdapter, TypeScriptAdapter,
+};
+
+fn extract(adapter: &dyn LanguageAdapter, path: &str, src: &str) -> ParseOutput {
+    let bytes = src.as_bytes();
+    let tree = adapter.parse(bytes).expect("parse should succeed");
+    adapter
+        .extract(&tree, bytes, &FilePathId::new(path))
+        .expect("extract should succeed")
+}
+
+fn has_import(out: &ParseOutput, module_path: &str) -> bool {
+    out.imports.iter().any(|i| i.module_path == module_path)
+}
+
+fn has_specifier(out: &ParseOutput, module_path: &str, local_name: &str) -> bool {
+    out.imports.iter().any(|i| {
+        i.module_path == module_path && i.specifiers.iter().any(|s| s.local_name == local_name)
+    })
+}
+
+#[test]
+fn typescript_named_and_aliased_imports() {
+    let out = extract(
+        &TypeScriptAdapter,
+        "s.ts",
+        "import { helper, other as aliased } from \"./util\";\n",
+    );
+    assert!(has_specifier(&out, "./util", "helper"));
+    let aliased = out
+        .imports
+        .iter()
+        .flat_map(|i| &i.specifiers)
+        .find(|s| s.local_name == "aliased")
+        .expect("aliased specifier");
+    assert_eq!(aliased.original_name.as_deref(), Some("other"));
+}
+
+#[test]
+fn javascript_import_and_require() {
+    let out = extract(
+        &JavaScriptAdapter,
+        "s.js",
+        "import { helper } from \"./util\";\nconst mod = require(\"./mod\");\n",
+    );
+    assert!(has_specifier(&out, "./util", "helper"));
+    assert!(
+        has_import(&out, "./mod"),
+        "require() should yield a FileImport"
+    );
+}
+
+#[test]
+fn python_import_and_from_import() {
+    let out = extract(
+        &PythonAdapter,
+        "s.py",
+        "import os\nfrom helpers import compute\n",
+    );
+    assert!(has_specifier(&out, "os", "os"));
+    assert!(has_specifier(&out, "helpers", "compute"));
+}
+
+#[test]
+fn go_import() {
+    let out = extract(&GoAdapter, "s.go", "package main\nimport \"fmt\"\n");
+    assert!(has_import(&out, "fmt"));
+}
+
+#[test]
+fn java_import_and_static_import() {
+    let out = extract(
+        &JavaAdapter,
+        "S.java",
+        "import java.util.List;\nimport static java.lang.Math.max;\nclass C {}\n",
+    );
+    assert!(has_specifier(&out, "java.util", "List"));
+    assert!(has_specifier(&out, "java.lang.Math", "max"));
+}
+
+#[test]
+fn rust_use() {
+    let out = extract(
+        &RustAdapter,
+        "s.rs",
+        "use std::collections::HashMap;\nfn f() {}\n",
+    );
+    assert!(has_specifier(&out, "std::collections", "HashMap"));
+}
+
+#[test]
+fn c_include() {
+    let out = extract(
+        &CAdapter,
+        "s.c",
+        "#include <stdio.h>\n#include \"local.h\"\n",
+    );
+    assert!(has_import(&out, "stdio.h"));
+    assert!(has_import(&out, "local.h"));
+}
+
+#[test]
+fn cpp_include() {
+    let out = extract(
+        &CppAdapter,
+        "s.cpp",
+        "#include <string>\n#include \"local.h\"\n",
+    );
+    assert!(has_import(&out, "string"));
+    assert!(has_import(&out, "local.h"));
+}
+
+#[test]
+fn csharp_using() {
+    let out = extract(&CSharpAdapter, "S.cs", "using System;\nclass C {}\n");
+    assert!(has_import(&out, "System"));
+}
+
+#[test]
+fn ruby_require_and_require_relative() {
+    let out = extract(
+        &RubyAdapter,
+        "s.rb",
+        "require 'json'\nrequire_relative 'helper'\n",
+    );
+    assert!(has_import(&out, "json"));
+    assert!(has_import(&out, "helper"));
+}
+
+#[test]
+fn php_use() {
+    let out = extract(&PhpAdapter, "s.php", "<?php\nuse App\\Helper;\n");
+    assert!(has_specifier(&out, "App\\Helper", "Helper"));
+}
+
+#[test]
+fn kotlin_import() {
+    let out = extract(
+        &KotlinAdapter,
+        "s.kt",
+        "import kotlin.collections.List\nfun f() {}\n",
+    );
+    assert!(has_specifier(&out, "kotlin.collections", "List"));
+}
+
+#[test]
+fn swift_import() {
+    let out = extract(&SwiftAdapter, "s.swift", "import Foundation\n");
+    assert!(has_import(&out, "Foundation"));
+}
+
+// ---------------------------------------------------------------------------
+// Pinned gaps (YELLOW) — executable, #[ignore]d with observed behavior.
+// ---------------------------------------------------------------------------
+
+#[test]
+#[ignore = "YELLOW: PHP `require`/`include` produces no FileImport — only `use` statements are captured, so file-inclusion dependencies are invisible to the linker"]
+fn php_require_should_produce_import() {
+    let out = extract(&PhpAdapter, "s.php", "<?php\nrequire 'bootstrap.php';\n");
+    assert!(has_import(&out, "bootstrap.php"));
+}
+
+#[test]
+#[ignore = "YELLOW: a C# `using Alias = Ns.Target;` records the alias (`Data`) as the module path and drops the target namespace `System.Collections.Generic`"]
+fn csharp_using_alias_should_record_target_namespace() {
+    let out = extract(
+        &CSharpAdapter,
+        "S.cs",
+        "using Data = System.Collections.Generic;\nclass C {}\n",
+    );
+    assert!(
+        has_import(&out, "System.Collections.Generic"),
+        "alias import should record the target namespace, got {:?}",
+        out.imports
+            .iter()
+            .map(|i| &i.module_path)
+            .collect::<Vec<_>>()
+    );
+}

--- a/crates/kin-review/src/impact.rs
+++ b/crates/kin-review/src/impact.rs
@@ -311,6 +311,11 @@ pub fn analyze_impact_at<I: ImpactGraph>(
                 let is_test = entity.role == EntityRole::Test || rel.kind == RelationKind::Tests;
                 if is_test {
                     ent_tests.insert(affected_id);
+                } else if matches!(entity.role, EntityRole::Generated | EntityRole::Vendored) {
+                    // Derived copies (amalgamated bundles, vendored snapshots)
+                    // regenerate from their sources; they appear in the blast
+                    // radius for navigation but cannot be "broken" consumers,
+                    // so they never feed consumer counts or breaking findings.
                 } else {
                     ent_consumers.insert(affected_id);
                     if rel.confidence >= STRONG_CONSUMER_CONFIDENCE {

--- a/crates/kin-review/src/inline.rs
+++ b/crates/kin-review/src/inline.rs
@@ -36,6 +36,7 @@ pub enum InlineCommentKind {
     Removed,
     Renamed,
     AgentUnreviewed,
+    ToolchainSurfaceChange,
 }
 
 impl InlineCommentKind {
@@ -52,6 +53,7 @@ impl InlineCommentKind {
             Self::Removed => "-",
             Self::Renamed => "~",
             Self::AgentUnreviewed => "@",
+            Self::ToolchainSurfaceChange => "~",
         }
     }
 }

--- a/crates/kin-review/src/inline.rs
+++ b/crates/kin-review/src/inline.rs
@@ -70,6 +70,18 @@ pub const CONSUMER_FANOUT_THRESHOLD: usize = 2;
 /// any existing caller. Removal of one is a real surface change.
 const STRENGTHENING_QUALIFIERS: &[&str] = &["constexpr", "inline", "[[nodiscard]]"];
 
+/// True for roles that are not a contract surface: a test's, a generated
+/// artifact's, or a vendored copy's declaration is consumed by nothing the
+/// review protects, so a signature/visibility change to one is not a
+/// downstream risk and must not produce a gate-feeding surface finding.
+/// Mirrors the consumer-exclusion set the impact harvest already applies.
+pub(crate) fn is_non_contract_surface_role(role: EntityRole) -> bool {
+    matches!(
+        role,
+        EntityRole::Test | EntityRole::Generated | EntityRole::Vendored
+    )
+}
+
 /// True when `old` → `new` differs ONLY by adding strengthening qualifiers:
 /// the qualifier-stripped declarations are identical and `new` carries more
 /// strengthening qualifiers than `old`.
@@ -217,7 +229,8 @@ fn collect_modified_comments(
     // (constexpr/inline/[[nodiscard]]) cannot invalidate existing callers and
     // is not a contract-surface change; anything else — including removing
     // such qualifiers — remains one.
-    if old.signature != new.signature
+    if !is_non_contract_surface_role(new.role)
+        && old.signature != new.signature
         && !signature_strengthened_only(&old.signature, &new.signature)
     {
         comments.push(InlineComment {
@@ -249,7 +262,10 @@ fn collect_modified_comments(
     }
 
     // Visibility reduction
-    if old.visibility == Visibility::Public && new.visibility != Visibility::Public {
+    if !is_non_contract_surface_role(new.role)
+        && old.visibility == Visibility::Public
+        && new.visibility != Visibility::Public
+    {
         comments.push(InlineComment {
             file: span.file.to_string(),
             start_line: span.start_line,

--- a/crates/kin-review/src/inline.rs
+++ b/crates/kin-review/src/inline.rs
@@ -64,6 +64,37 @@ impl InlineCommentKind {
 /// channels own contract-surface changes.
 pub const CONSUMER_FANOUT_THRESHOLD: usize = 2;
 
+/// Qualifiers whose ADDITION strengthens a declaration without invalidating
+/// any existing caller. Removal of one is a real surface change.
+const STRENGTHENING_QUALIFIERS: &[&str] = &["constexpr", "inline", "[[nodiscard]]"];
+
+/// True when `old` → `new` differs ONLY by adding strengthening qualifiers:
+/// the qualifier-stripped declarations are identical and `new` carries more
+/// strengthening qualifiers than `old`.
+pub fn signature_strengthened_only(old: &str, new: &str) -> bool {
+    if old == new {
+        return false;
+    }
+    fn strip(sig: &str) -> (String, usize) {
+        let mut removed = 0usize;
+        let kept: Vec<&str> = sig
+            .split_whitespace()
+            .filter(|tok| {
+                if STRENGTHENING_QUALIFIERS.contains(tok) {
+                    removed += 1;
+                    false
+                } else {
+                    true
+                }
+            })
+            .collect();
+        (kept.join(" "), removed)
+    }
+    let (old_core, old_quals) = strip(old);
+    let (new_core, new_quals) = strip(new);
+    old_core == new_core && new_quals > old_quals
+}
+
 /// Collect line-level inline comments from a review's diff and impact data.
 ///
 /// Each comment is anchored to a file + line range derived from the entity's
@@ -180,8 +211,13 @@ fn collect_modified_comments(
         consumer_count
     };
 
-    // Signature change
-    if old.signature != new.signature {
+    // Signature change. A difference that only ADDS strengthening qualifiers
+    // (constexpr/inline/[[nodiscard]]) cannot invalidate existing callers and
+    // is not a contract-surface change; anything else — including removing
+    // such qualifiers — remains one.
+    if old.signature != new.signature
+        && !signature_strengthened_only(&old.signature, &new.signature)
+    {
         comments.push(InlineComment {
             file: span.file.to_string(),
             start_line: span.start_line,
@@ -266,19 +302,25 @@ fn collect_modified_comments(
         });
     }
 
-    if old.metadata.extra.get(COMMAND_EFFECT_CONTRACT_KEY)
-        != new.metadata.extra.get(COMMAND_EFFECT_CONTRACT_KEY)
-    {
-        comments.push(InlineComment {
-            file: span.file.to_string(),
-            start_line: span.start_line,
-            end_line: span.end_line,
-            kind: InlineCommentKind::CommandEffectContract,
-            message: format!(
-                "Command-effect contract for `{}` changed; external command behavior needs review",
-                new.name,
-            ),
-        });
+    // Fire only when BOTH sides carry a contract: persist paths differ in
+    // whether they attach the key, so one-sided presence is path-coverage
+    // skew, not a behavior change.
+    if let (Some(old_contract), Some(new_contract)) = (
+        old.metadata.extra.get(COMMAND_EFFECT_CONTRACT_KEY),
+        new.metadata.extra.get(COMMAND_EFFECT_CONTRACT_KEY),
+    ) {
+        if old_contract != new_contract {
+            comments.push(InlineComment {
+                file: span.file.to_string(),
+                start_line: span.start_line,
+                end_line: span.end_line,
+                kind: InlineCommentKind::CommandEffectContract,
+                message: format!(
+                    "Command-effect contract for `{}` changed; external command behavior needs review",
+                    new.name,
+                ),
+            });
+        }
     }
 
     // Body-only modification with wide consumer fanout. The contract surface
@@ -904,6 +946,91 @@ mod tests {
             .collect();
         assert_eq!(fanout.len(), 1, "strong consumers at threshold must fire");
         assert!(fanout[0].message.contains("2 distinct non-test consumer"));
+    }
+
+    #[test]
+    fn strengthened_only_signature_is_not_a_signature_change() {
+        assert!(signature_strengthened_only(
+            "TestRunInfo(StringRef _name)",
+            "constexpr TestRunInfo(StringRef _name)"
+        ));
+        assert!(!signature_strengthened_only(
+            "constexpr TestRunInfo(StringRef _name)",
+            "TestRunInfo(StringRef _name)"
+        ));
+        assert!(!signature_strengthened_only(
+            "TestRunInfo(StringRef _name)",
+            "TestRunInfo(StringRef _name, int mode)"
+        ));
+        assert!(!signature_strengthened_only(
+            "inline int f()",
+            "constexpr int f()"
+        ));
+        assert!(!signature_strengthened_only("int f()", "int f()"));
+    }
+
+    #[test]
+    fn strengthened_only_change_emits_no_signature_or_breaking_comment() {
+        let old = test_entity_with_span("hot_path", "src/hot.rs", 1, 20);
+        let mut new = old.clone();
+        new.signature = format!("constexpr {}", old.signature);
+        let diff = SemanticDiff {
+            entity_changes: vec![EntityChange {
+                entity_id: new.id,
+                kind: EntityChangeKind::Modified {
+                    old: old.clone(),
+                    new: new.clone(),
+                },
+            }],
+            ..Default::default()
+        };
+        let impact = ImpactReport {
+            changed_ids: vec![new.id],
+            entity_impacts: vec![EntityImpact {
+                entity_id: new.id,
+                consumer_count: 3,
+                strong_consumer_count: 3,
+                contract_consumer_count: 0,
+                consumer_files: vec!["src/a.rs".to_string()],
+                covering_tests: 0,
+            }],
+            ..Default::default()
+        };
+        let comments = collect_inline_comments(&diff, &impact);
+        assert!(
+            !comments.iter().any(|c| matches!(
+                c.kind,
+                InlineCommentKind::SignatureChange | InlineCommentKind::Breaking
+            )),
+            "qualifier strengthening must not read as signature change or breaking"
+        );
+    }
+
+    #[test]
+    fn command_contract_absent_on_one_side_is_no_signal() {
+        let old = test_entity_with_span("runner", "cmd/run.go", 1, 20);
+        let mut new = old.clone();
+        new.metadata.extra.insert(
+            COMMAND_EFFECT_CONTRACT_KEY.to_string(),
+            serde_json::json!({"schema_version": 1, "effects": []}),
+        );
+        let diff = SemanticDiff {
+            entity_changes: vec![EntityChange {
+                entity_id: new.id,
+                kind: EntityChangeKind::Modified {
+                    old: old.clone(),
+                    new: new.clone(),
+                },
+            }],
+            ..Default::default()
+        };
+        let comments = collect_inline_comments(&diff, &ImpactReport::default());
+        assert!(
+            !comments
+                .iter()
+                .any(|c| c.kind == InlineCommentKind::CommandEffectContract),
+            "key present on only one side is persist-path coverage skew, not a change"
+        );
     }
 
     #[test]

--- a/crates/kin-review/src/shadow.rs
+++ b/crates/kin-review/src/shadow.rs
@@ -19,7 +19,7 @@
 use std::collections::{BTreeMap, BTreeSet};
 
 use kin_blobs::{BlobStore, Hash256};
-use kin_model::entity::Entity;
+use kin_model::entity::{Entity, EntityRole};
 use kin_model::graph::GraphStore;
 use kin_model::ids::{EntityId, SemanticChangeId};
 use kin_model::timestamp::Timestamp;
@@ -93,7 +93,14 @@ pub struct ShadowChangedEntity {
     pub end_line: Option<u32>,
     pub signature_changed: bool,
     pub visibility_changed: bool,
+    /// Graph role of the changed entity. Test/Generated/Vendored entities are
+    /// not a contract surface any non-test consumer depends on, so their
+    /// signature/visibility changes must not feed the gate.
+    #[serde(default)]
+    pub role: EntityRole,
 }
+
+use crate::inline::is_non_contract_surface_role;
 
 /// One entity reached by blast-radius traversal, with the graph relationship
 /// bucket that proves why it is affected.
@@ -563,6 +570,7 @@ fn collect_changed_entities<G: GraphStore>(
                     end_line,
                     signature_changed: false,
                     visibility_changed: false,
+                    role: entity.role,
                 });
             }
             EntityChangeKind::Modified { old, new } => {
@@ -581,6 +589,7 @@ fn collect_changed_entities<G: GraphStore>(
                             &new.signature,
                         ),
                     visibility_changed: old.visibility != new.visibility,
+                    role: new.role,
                 });
             }
             EntityChangeKind::Removed(id) => {
@@ -599,12 +608,22 @@ fn collect_changed_entities<G: GraphStore>(
                     Some(entity) => Some(entity),
                     None => store.get_entity(id).map_err(ReviewError::graph)?,
                 };
-                let (name, kind, file) = match removed {
+                let (name, kind, file, role) = match removed {
                     Some(entity) => {
                         let (file, _, _) = entity_location(&entity);
-                        (entity.name.clone(), format!("{:?}", entity.kind), file)
+                        (
+                            entity.name.clone(),
+                            format!("{:?}", entity.kind),
+                            file,
+                            entity.role,
+                        )
                     }
-                    None => (id.to_string(), "unknown".to_string(), None),
+                    None => (
+                        id.to_string(),
+                        "unknown".to_string(),
+                        None,
+                        EntityRole::Source,
+                    ),
                 };
                 changed.push(ShadowChangedEntity {
                     entity_id: id.to_string(),
@@ -616,6 +635,7 @@ fn collect_changed_entities<G: GraphStore>(
                     end_line: None,
                     signature_changed: false,
                     visibility_changed: false,
+                    role,
                 });
             }
         }
@@ -803,6 +823,13 @@ fn derive_policy(
         .filter(|entity| entity.change == "added")
         .map(|entity| entity.name.as_str())
         .collect();
+    // Graph role per changed entity, so the surface-finding loop can skip
+    // roles that are not a contract surface (test/generated/vendored) even for
+    // removed entities, whose role was resolved from the base graph.
+    let resolved_roles: BTreeMap<&str, EntityRole> = changed_entities
+        .iter()
+        .map(|entity| (entity.entity_id.as_str(), entity.role))
+        .collect();
     // Removed entities the graph can no longer resolve are surfaced as a raw
     // UUID (kind "unknown" from `collect_changed_entities`). We cannot certify
     // a confident BLOCKING breakage for a surface we cannot even name, so such
@@ -854,6 +881,15 @@ fn derive_policy(
                 EntityChangeKind::Added(_) => continue,
             };
             if !surface_changed {
+                continue;
+            }
+            // A test's, generated artifact's, or vendored copy's declaration is
+            // not a contract surface — its signature change breaks no consumer
+            // the review protects, so it never emits a downstream-risk finding.
+            if resolved_roles
+                .get(change.entity_id.to_string().as_str())
+                .is_some_and(|role| is_non_contract_surface_role(*role))
+            {
                 continue;
             }
             let entity_consumers = review
@@ -952,9 +988,10 @@ fn derive_policy(
     // must feed the gate on its own weight even when the contract surface is
     // unchanged. The decision is on graph-owned consumer entities, never files.
     let has_blocking_finding = findings.iter().any(|finding| finding.blocking);
-    let has_surface_change = changed_entities
-        .iter()
-        .any(|entity| entity.signature_changed || entity.visibility_changed);
+    let has_surface_change = changed_entities.iter().any(|entity| {
+        (entity.signature_changed || entity.visibility_changed)
+            && !is_non_contract_surface_role(entity.role)
+    });
     let coverage_gap_feeds_gate = has_blocking_finding || has_surface_change;
 
     // Informational findings (entity added/removed) describe the diff, not a
@@ -2362,6 +2399,7 @@ mod tests {
             end_line: None,
             signature_changed: false,
             visibility_changed: false,
+            role: EntityRole::Source,
         };
         let added_entry = ShadowChangedEntity {
             entity_id: readded.id.to_string(),
@@ -2373,6 +2411,7 @@ mod tests {
             end_line: Some(3),
             signature_changed: false,
             visibility_changed: false,
+            role: EntityRole::Source,
         };
 
         // With the same-name re-add present, the removal is a move: no
@@ -2858,6 +2897,7 @@ mod tests {
             end_line: Some(20),
             signature_changed: false,
             visibility_changed: false,
+            role: EntityRole::Source,
         }];
 
         // Body-only: the coverage gap is reported but withheld from the gate —
@@ -2924,6 +2964,7 @@ mod tests {
             end_line: Some(20),
             signature_changed: false,
             visibility_changed: false,
+            role: EntityRole::Source,
         }];
 
         // Body-only, but the wide consumer fanout gates: the verdict escalates
@@ -2994,6 +3035,7 @@ mod tests {
             end_line: Some(102),
             signature_changed: false,
             visibility_changed: false,
+            role: EntityRole::Source,
         }];
 
         let policy = derive_policy(&review, &[], &changed);
@@ -3062,6 +3104,7 @@ mod tests {
             end_line: None,
             signature_changed: false,
             visibility_changed: false,
+            role: EntityRole::Source,
         }];
         let policy = derive_policy(&review, &[], &unresolvable);
         let finding = policy
@@ -3204,6 +3247,77 @@ mod tests {
             .any(|finding| finding.kind == "signature_change"));
         // ... and, because isolation is unprovable, still feeds the gate.
         assert_eq!(report.policy.verdict, ShadowGateVerdict::NeedsAttention);
+    }
+
+    #[test]
+    fn test_role_surface_change_does_not_feed_gate() {
+        // A test method whose signature changed (e.g. a decorator/async edit)
+        // is not a contract surface: nothing the review protects depends on it,
+        // so it must not emit a downstream-risk finding or drive the verdict —
+        // even with a live caller. The Source-role twin below still fires. This
+        // is the c042 false positive: benign prod change + a test-method
+        // signature edit escalated to needs_attention.
+        for (role, expect_risk) in [(EntityRole::Test, false), (EntityRole::Source, true)] {
+            let graph = InMemoryGraph::new();
+            let target_v1 = entity_with_span("streaming_case", "tests/handlers.rs", 4, role);
+            let mut target_v2 = target_v1.clone();
+            target_v2.signature = "fn streaming_case(scale: u8)".into();
+            let caller = entity_with_span("driver", "src/driver.rs", 6, EntityRole::Source);
+            graph.upsert_entity(&target_v2).unwrap();
+            graph.upsert_entity(&caller).unwrap();
+            graph
+                .upsert_relation(&relation(&caller, &target_v2, RelationKind::Calls))
+                .unwrap();
+
+            let base_id = change_id(0x73);
+            let head_id = change_id(0x74);
+            let base = change_with_deltas(
+                base_id,
+                vec![],
+                vec![
+                    EntityDelta::Added(target_v1.clone()),
+                    EntityDelta::Added(caller.clone()),
+                ],
+                vec![],
+                vec![],
+            );
+            let head = change_with_deltas(
+                head_id,
+                vec![base_id],
+                vec![EntityDelta::Modified {
+                    old: target_v1,
+                    new: target_v2,
+                }],
+                vec![],
+                vec![],
+            );
+            graph.create_change(&base).unwrap();
+            graph.create_change(&head).unwrap();
+
+            let report = build_shadow_report(&graph, &request(base_id, head_id)).unwrap();
+            let has_surface_finding = report.policy.findings.iter().any(|finding| {
+                finding.kind == "signature_change"
+                    || finding.kind == "downstream_risk"
+                    || finding.kind == "breaking"
+            });
+            assert_eq!(
+                has_surface_finding,
+                expect_risk,
+                "role {:?} should {}emit a contract-surface finding",
+                role,
+                if expect_risk { "" } else { "not " }
+            );
+            let expected_verdict = if expect_risk {
+                ShadowGateVerdict::NeedsAttention
+            } else {
+                ShadowGateVerdict::Pass
+            };
+            assert_eq!(
+                report.policy.verdict, expected_verdict,
+                "role {:?} verdict",
+                role
+            );
+        }
     }
 
     // ── Toolchain-surface directive channel ─────────────────────────────

--- a/crates/kin-review/src/shadow.rs
+++ b/crates/kin-review/src/shadow.rs
@@ -21,13 +21,13 @@ use std::collections::{BTreeMap, BTreeSet};
 use kin_blobs::{BlobStore, Hash256};
 use kin_model::entity::Entity;
 use kin_model::graph::GraphStore;
-use kin_model::ids::SemanticChangeId;
+use kin_model::ids::{EntityId, SemanticChangeId};
 use kin_model::timestamp::Timestamp;
 use serde::{Deserialize, Serialize};
 
 use crate::diff::{self, EntityChangeKind, SemanticDiff};
 use crate::gate::{derive_decision, GateStatus, ReviewFinding, ReviewSignalKind};
-use crate::impact::ImpactReport;
+use crate::impact::{analyze_impact_at, ImpactGraph, ImpactReport};
 use crate::inline::{self, InlineComment, InlineCommentKind};
 use crate::ref_graph::GraphAtRef;
 use crate::review::{Review, SemanticReview};
@@ -303,7 +303,7 @@ pub fn build_shadow_report_at<G: GraphStore>(
     let base_ancestry = crate::ref_graph::collect_ancestry(store, &request.resolved_base)?;
     let in_range =
         |id: &SemanticChangeId| at_head.ancestry_contains(id) && !base_ancestry.contains(id);
-    let review = SemanticReview::create_review_scoped(
+    let mut review = SemanticReview::create_review_scoped(
         &request.resolved_base,
         &request.resolved_head,
         store,
@@ -316,7 +316,70 @@ pub fn build_shadow_report_at<G: GraphStore>(
         .into_iter()
         .filter(|change| in_range(&change.id))
         .collect();
-    assemble_report_with_changes(store, request, review, None, &changes, Some(at_head))
+    // A removed entity is absent at head: its head-scoped inbound edges and
+    // its own name/kind cannot be read there. The base ref still holds the
+    // entity and the edges its removal severs, so removed-entity impact and
+    // identity are harvested from base state. Materialization is sound here —
+    // `at_head` already validated the base is on-ancestry and every ancestry
+    // row is present, so the base state (a subset of that ancestry) resolves.
+    let at_base = GraphAtRef::materialize(store, &request.resolved_base)?;
+    overlay_removed_entity_impact_from_base(&mut review, &at_base)?;
+    assemble_report_with_changes(
+        store,
+        request,
+        review,
+        None,
+        &changes,
+        Some(at_head),
+        Some(&at_base),
+    )
+}
+
+/// Overlay base-side inbound attribution onto the head-computed impact for
+/// every REMOVED entity.
+///
+/// A removed entity does not exist at head, so its head-scoped
+/// `consumer_count` understates (often to zero) the surviving non-test
+/// consumers that still reference the deleted surface. The base ref still
+/// holds the entity and its inbound edges, so the breaking-removal rule reads
+/// the surviving-consumer count from there. Only removed-entity entries are
+/// replaced; Added/Modified attribution stays head-scoped. The FULL diff is
+/// harvested so a consumer that was itself changed in the same range is
+/// excluded exactly as the head-side harvest excludes a co-updated consumer —
+/// a consumer that let go of the removed surface in the same change is not a
+/// broken contract. Removed ids are iterated in sorted order and the impacts
+/// are re-sorted by id, so the overlay is replay-deterministic.
+fn overlay_removed_entity_impact_from_base<G: GraphStore>(
+    review: &mut Review,
+    at_base: &GraphAtRef<'_, G>,
+) -> Result<(), ReviewError> {
+    let removed_ids: BTreeSet<EntityId> = review
+        .diff
+        .entity_changes
+        .iter()
+        .filter_map(|change| match &change.kind {
+            EntityChangeKind::Removed(id) => Some(*id),
+            _ => None,
+        })
+        .collect();
+    if removed_ids.is_empty() {
+        return Ok(());
+    }
+    let base_impact = analyze_impact_at(at_base, &review.diff)?;
+    for removed_id in &removed_ids {
+        if let Some(base_entry) = base_impact.entity_impact(removed_id) {
+            review
+                .impact
+                .entity_impacts
+                .retain(|entry| entry.entity_id != *removed_id);
+            review.impact.entity_impacts.push(base_entry.clone());
+        }
+    }
+    review
+        .impact
+        .entity_impacts
+        .sort_by_key(|entry| entry.entity_id);
+    Ok(())
 }
 
 /// The graph state at the head ref could not be materialized. Report the gap
@@ -395,8 +458,8 @@ fn build_report_with_base_off_ancestry<G: GraphStore>(
         ),
     };
     // No range was walked, so there are no artifact deltas to reclassify;
-    // pass no head state.
-    assemble_report_with_changes(store, request, review, Some(gap), &[], None)
+    // pass no head or base state.
+    assemble_report_with_changes(store, request, review, Some(gap), &[], None, None)
 }
 
 fn assemble_report<G: GraphStore>(
@@ -409,7 +472,7 @@ fn assemble_report<G: GraphStore>(
     let changes = store
         .get_changes_since(&request.resolved_base, &request.resolved_head)
         .map_err(ReviewError::graph)?;
-    assemble_report_with_changes(store, request, review, range_gap, &changes, at_head)
+    assemble_report_with_changes(store, request, review, range_gap, &changes, at_head, None)
 }
 
 fn assemble_report_with_changes<G: GraphStore>(
@@ -419,8 +482,9 @@ fn assemble_report_with_changes<G: GraphStore>(
     range_gap: Option<ShadowEvidenceGap>,
     changes: &[kin_model::change::SemanticChange],
     at_head: Option<&GraphAtRef<'_, G>>,
+    at_base: Option<&GraphAtRef<'_, G>>,
 ) -> Result<ShadowGateReport, ReviewError> {
-    let changed_entities = collect_changed_entities(store, &review)?;
+    let changed_entities = collect_changed_entities(store, &review, at_base)?;
     let blast_radius = collect_blast_radius(&review);
     // No blob reader is reachable here: the shadow entry points take only the
     // graph store, and threading a real reader would change their public
@@ -482,6 +546,7 @@ fn entity_location(entity: &Entity) -> (Option<String>, Option<u32>, Option<u32>
 fn collect_changed_entities<G: GraphStore>(
     store: &G,
     review: &Review,
+    at_base: Option<&GraphAtRef<'_, G>>,
 ) -> Result<Vec<ShadowChangedEntity>, ReviewError> {
     let mut changed = Vec::new();
     for change in &review.diff.entity_changes {
@@ -519,12 +584,21 @@ fn collect_changed_entities<G: GraphStore>(
                 });
             }
             EntityChangeKind::Removed(id) => {
-                // The diff carries only the removed entity's id; the graph
-                // still knows what the id named. Resolve so findings and the
-                // entity list read as code, not opaque ids. When the graph
-                // has genuinely forgotten the entity, fall back to the id
-                // string rather than inventing a name.
-                let removed = store.get_entity(id).map_err(ReviewError::graph)?;
+                // The diff carries only the removed entity's id, and the entity
+                // is absent at head. Resolve its name/kind/file where it still
+                // exists — the base ref — so findings and the entity list read
+                // as code, not opaque ids, and the breaking-removal rule keeps
+                // demotion only for a surface the BASE graph also cannot name.
+                // Fall back to the live store, then to the id string when the
+                // graph has genuinely forgotten the entity.
+                let removed = match at_base {
+                    Some(base) => base.get_entity(id)?,
+                    None => None,
+                };
+                let removed = match removed {
+                    Some(entity) => Some(entity),
+                    None => store.get_entity(id).map_err(ReviewError::graph)?,
+                };
                 let (name, kind, file) = match removed {
                     Some(entity) => {
                         let (file, _, _) = entity_location(&entity);
@@ -2028,6 +2102,205 @@ mod tests {
             downstream.message
         );
         assert_eq!(report.policy.verdict, ShadowGateVerdict::WouldBlock);
+    }
+
+    /// Committed DAG modelling a real deletion: a base change adds a public
+    /// entity, a non-test consumer, and (optionally) a covering test wired by
+    /// committed relations; the head change removes the entity. Nothing is
+    /// mirrored into the live adjacency, so the removed entity is genuinely
+    /// absent at head — `store.get_entity` on the live store returns `None`,
+    /// exactly as after a real removal. The removed entity and its inbound
+    /// edges survive only in the base ref's replayed state.
+    fn removal_graph(
+        consumer_role: EntityRole,
+        include_consumer: bool,
+    ) -> (InMemoryGraph, SemanticChangeId, SemanticChangeId) {
+        let graph = InMemoryGraph::new();
+        let validate = entity_with_span("validate", "src/base.rs", 111, EntityRole::Source);
+        let (consumer_file, consumer_name) = match consumer_role {
+            EntityRole::Test => ("tests/base.rs", "test_validate"),
+            _ => ("src/runserver.rs", "run_from_argv"),
+        };
+        let consumer = entity_with_span(consumer_name, consumer_file, 111, consumer_role);
+        let calls_kind = match consumer_role {
+            EntityRole::Test => RelationKind::Tests,
+            _ => RelationKind::Calls,
+        };
+        let consume_rel = relation(&consumer, &validate, calls_kind);
+
+        let base_id = change_id(20);
+        let head_id = change_id(21);
+        let mut base_entities = vec![EntityDelta::Added(validate.clone())];
+        let mut base_relations = vec![];
+        if include_consumer {
+            base_entities.push(EntityDelta::Added(consumer));
+            base_relations.push(RelationDelta::Added(consume_rel));
+        }
+        let base = change_with_deltas(base_id, vec![], base_entities, base_relations, vec![]);
+        let head = change_with_deltas(
+            head_id,
+            vec![base_id],
+            vec![EntityDelta::Removed(validate.id)],
+            vec![],
+            vec![],
+        );
+        graph.create_change(&base).unwrap();
+        graph.create_change(&head).unwrap();
+        (graph, base_id, head_id)
+    }
+
+    #[test]
+    fn removed_public_entity_with_live_consumer_blocks_from_base_state() {
+        // (a) `validate` is deleted while a live non-test consumer still calls
+        // it. The consumer edge and the entity's identity survive only in the
+        // base ref, so the breaking-removal rule must harvest the
+        // surviving-consumer count and the entity name from base state: a
+        // blocking downstream_risk that names `validate`, verdict WouldBlock.
+        let (graph, base_id, head_id) = removal_graph(EntityRole::Source, true);
+        let report = build_shadow_report(&graph, &request(base_id, head_id)).unwrap();
+
+        let downstream = report
+            .policy
+            .findings
+            .iter()
+            .find(|finding| finding.kind == "downstream_risk")
+            .expect("deleting a consumed public entity is a downstream risk");
+        assert!(
+            downstream.blocking,
+            "a deleted-yet-consumed API is a genuine block, not a demoted warning"
+        );
+        assert_eq!(downstream.severity, "error");
+        assert!(
+            downstream.message.contains("validate"),
+            "finding must name the removed entity from base state: {}",
+            downstream.message
+        );
+        assert_eq!(report.policy.verdict, ShadowGateVerdict::WouldBlock);
+    }
+
+    #[test]
+    fn removed_entity_with_only_test_consumers_does_not_block() {
+        // (b) The only base consumer of the removed entity is a test. Tests
+        // that cover a deleted thing are co-updated, not a broken contract, so
+        // the base harvest excludes them: no downstream_risk, no block.
+        let (graph, base_id, head_id) = removal_graph(EntityRole::Test, true);
+        let report = build_shadow_report(&graph, &request(base_id, head_id)).unwrap();
+
+        assert!(
+            !report
+                .policy
+                .findings
+                .iter()
+                .any(|finding| finding.kind == "downstream_risk" || finding.kind == "breaking"),
+            "a removal whose only base consumers are tests is not a breaking removal"
+        );
+        assert_ne!(report.policy.verdict, ShadowGateVerdict::WouldBlock);
+        // The name still resolves from base even without a blocking finding.
+        let removed = report
+            .changed_entities
+            .iter()
+            .find(|entity| entity.change == "removed")
+            .expect("removed entity is listed");
+        assert_eq!(removed.name, "validate");
+    }
+
+    #[test]
+    fn removed_entity_with_no_base_consumers_does_not_block() {
+        // (c) The removed entity has zero base consumers. There is no surviving
+        // surface to break, so no downstream_risk fires and the gate does not
+        // block.
+        let (graph, base_id, head_id) = removal_graph(EntityRole::Source, false);
+        let report = build_shadow_report(&graph, &request(base_id, head_id)).unwrap();
+
+        assert!(
+            !report
+                .policy
+                .findings
+                .iter()
+                .any(|finding| finding.kind == "downstream_risk" || finding.kind == "breaking"),
+            "a removal with no base consumers is not a breaking removal"
+        );
+        assert_ne!(report.policy.verdict, ShadowGateVerdict::WouldBlock);
+    }
+
+    #[test]
+    fn remove_and_readd_same_name_is_move_not_breaking_from_base() {
+        // (d) One diff removes `validate` (which has a base consumer) and adds a
+        // fresh entity of the SAME name. Because the removed id now resolves to
+        // `validate` from base, the same-name re-add is recognised as a move:
+        // no downstream_risk despite the base consumer. Without base-side name
+        // resolution the removed side reads as a uuid, fails the move match,
+        // and fires a demoted downstream_risk instead.
+        let graph = InMemoryGraph::new();
+        let validate_old = entity_with_span("validate", "src/base.rs", 111, EntityRole::Source);
+        let validate_new = entity_with_span("validate", "src/base_v2.rs", 5, EntityRole::Source);
+        let consumer =
+            entity_with_span("run_from_argv", "src/runserver.rs", 111, EntityRole::Source);
+        let calls_rel = relation(&consumer, &validate_old, RelationKind::Calls);
+
+        let base_id = change_id(22);
+        let head_id = change_id(23);
+        let base = change_with_deltas(
+            base_id,
+            vec![],
+            vec![
+                EntityDelta::Added(validate_old.clone()),
+                EntityDelta::Added(consumer),
+            ],
+            vec![RelationDelta::Added(calls_rel)],
+            vec![],
+        );
+        let head = change_with_deltas(
+            head_id,
+            vec![base_id],
+            vec![
+                EntityDelta::Removed(validate_old.id),
+                EntityDelta::Added(validate_new),
+            ],
+            vec![],
+            vec![],
+        );
+        graph.create_change(&base).unwrap();
+        graph.create_change(&head).unwrap();
+
+        let report = build_shadow_report(&graph, &request(base_id, head_id)).unwrap();
+        assert!(
+            !report
+                .policy
+                .findings
+                .iter()
+                .any(|finding| finding.kind == "downstream_risk"),
+            "same-diff remove + re-add of one name is a move, not a breaking removal"
+        );
+        assert_ne!(report.policy.verdict, ShadowGateVerdict::WouldBlock);
+        let removed = report
+            .changed_entities
+            .iter()
+            .find(|entity| entity.change == "removed")
+            .expect("removed entity is listed");
+        assert_eq!(removed.name, "validate");
+    }
+
+    #[test]
+    fn removed_entity_name_resolves_from_base_not_uuid() {
+        // (e) A removed entity absent at head still resolves its name, kind, and
+        // file from the base ref for the changed-entities output — never the
+        // raw uuid / "unknown" fallback the head-only lookup produced.
+        let (graph, base_id, head_id) = removal_graph(EntityRole::Source, false);
+        let report = build_shadow_report(&graph, &request(base_id, head_id)).unwrap();
+
+        let removed = report
+            .changed_entities
+            .iter()
+            .find(|entity| entity.change == "removed")
+            .expect("removed entity is listed");
+        assert_eq!(removed.name, "validate");
+        assert_eq!(removed.kind, "Function");
+        assert_eq!(removed.file.as_deref(), Some("src/base.rs"));
+        assert_ne!(
+            removed.name, removed.entity_id,
+            "the name must not fall back to the raw id"
+        );
     }
 
     #[test]

--- a/crates/kin-review/src/shadow.rs
+++ b/crates/kin-review/src/shadow.rs
@@ -18,6 +18,7 @@
 
 use std::collections::{BTreeMap, BTreeSet};
 
+use kin_blobs::{BlobStore, Hash256};
 use kin_model::entity::Entity;
 use kin_model::graph::GraphStore;
 use kin_model::ids::SemanticChangeId;
@@ -27,7 +28,7 @@ use serde::{Deserialize, Serialize};
 use crate::diff::{self, EntityChangeKind, SemanticDiff};
 use crate::gate::{derive_decision, GateStatus, ReviewFinding, ReviewSignalKind};
 use crate::impact::ImpactReport;
-use crate::inline::{self, InlineCommentKind};
+use crate::inline::{self, InlineComment, InlineCommentKind};
 use crate::ref_graph::GraphAtRef;
 use crate::review::{Review, SemanticReview};
 use crate::risk;
@@ -414,14 +415,19 @@ fn assemble_report<G: GraphStore>(
 fn assemble_report_with_changes<G: GraphStore>(
     store: &G,
     request: &ShadowRequest,
-    review: Review,
+    mut review: Review,
     range_gap: Option<ShadowEvidenceGap>,
     changes: &[kin_model::change::SemanticChange],
     at_head: Option<&GraphAtRef<'_, G>>,
 ) -> Result<ShadowGateReport, ReviewError> {
     let changed_entities = collect_changed_entities(store, &review)?;
     let blast_radius = collect_blast_radius(&review);
-    let mut evidence_gaps = collect_evidence_gaps(&review, changes, &changed_entities, at_head);
+    // No blob reader is reachable here: the shadow entry points take only the
+    // graph store, and threading a real reader would change their public
+    // signature and their out-of-crate callers. The toolchain-surface channel
+    // is therefore inert on this path (blobs = None) until that wiring lands.
+    let (mut evidence_gaps, toolchain_findings) =
+        collect_evidence_gaps(&review, changes, &changed_entities, at_head, None);
     if let Some(gap) = range_gap {
         // The generic empty-impact gap advises verifying relation ingestion,
         // which misleads here: impact was not computed at all. The specific
@@ -430,6 +436,9 @@ fn assemble_report_with_changes<G: GraphStore>(
         evidence_gaps.retain(|existing| existing.kind != "impact_signal_absent");
         evidence_gaps.insert(0, gap);
     }
+    // Toolchain-surface findings feed the gate as ordinary warning findings via
+    // the inline-comment channel, never through the evidence-gap demotion path.
+    review.inline_comments.extend(toolchain_findings);
     let policy = derive_policy(&review, &evidence_gaps, &changed_entities);
     let repair_context = collect_repair_context(&policy.findings, &review);
     let audit = collect_audit_evidence(store, request, &review, changes.len())?;
@@ -612,6 +621,7 @@ fn finding_kind_label(kind: InlineCommentKind) -> &'static str {
         InlineCommentKind::Removed => "entity_removed",
         InlineCommentKind::Renamed => "entity_renamed",
         InlineCommentKind::AgentUnreviewed => "agent_unreviewed",
+        InlineCommentKind::ToolchainSurfaceChange => "toolchain_surface_change",
     }
 }
 
@@ -624,7 +634,8 @@ fn finding_severity(kind: InlineCommentKind) -> &'static str {
         | InlineCommentKind::CommandEffectContract
         | InlineCommentKind::ConsumerFanout
         | InlineCommentKind::Renamed
-        | InlineCommentKind::AgentUnreviewed => "warning",
+        | InlineCommentKind::AgentUnreviewed
+        | InlineCommentKind::ToolchainSurfaceChange => "warning",
         InlineCommentKind::Added | InlineCommentKind::Removed => "info",
     }
 }
@@ -972,6 +983,10 @@ fn repair_guidance(kind: &str) -> &'static str {
             "The contract surface changed with graph-known downstream entities; verify each \
              listed dependent and consumer, then run the covering tests."
         }
+        "toolchain_surface_change" => {
+            "Inline lint or deprecation directives changed; confirm the shift in toolchain \
+             enforcement is intended before merging."
+        }
         _ => "Review the change against the listed blast radius.",
     }
 }
@@ -1026,30 +1041,133 @@ fn collect_repair_context(
         .collect()
 }
 
+/// Inline lint-suppression and deprecation directives whose presence changes
+/// what the toolchain enforces. A source edit touching only these lines alters
+/// no semantic entity — comment-insensitive fingerprints produce zero entity
+/// deltas — yet it shifts lint or deprecation enforcement, which is
+/// review-worthy. Matched as case-sensitive substrings: a line counts only when
+/// one of these tokens appears in it.
+const TOOLCHAIN_DIRECTIVE_TOKENS: &[&str] = &[
+    "//nolint",
+    "# noqa",
+    "# type: ignore",
+    "eslint-disable",
+    "#[allow(",
+    "#[expect(",
+    "@SuppressWarnings",
+    "// Deprecated:",
+    "@deprecated",
+];
+
+/// Whether a single line carries a toolchain-surface directive token.
+fn line_has_directive(line: &str) -> bool {
+    TOOLCHAIN_DIRECTIVE_TOKENS
+        .iter()
+        .any(|token| line.contains(token))
+}
+
+/// The set of directive-bearing lines in `bytes`, trimmed so relocation or
+/// re-indentation of an otherwise unchanged directive does not read as a
+/// change. Non-UTF8 bytes are decoded lossily; directive tokens are ASCII, so
+/// that never changes which lines match.
+fn directive_line_set(bytes: &[u8]) -> BTreeSet<String> {
+    String::from_utf8_lossy(bytes)
+        .lines()
+        .map(str::trim)
+        .filter(|line| line_has_directive(line))
+        .map(str::to_string)
+        .collect()
+}
+
+/// Directive lines added and removed between two blob revisions of a file.
+/// Compares directive-line SETS, so a directive moved with identical text nets
+/// to zero. Returns `None` when neither set changed. Deterministic: the sets
+/// are ordered and the difference counts are order-independent.
+fn directive_surface_delta(old: &[u8], new: &[u8]) -> Option<(usize, usize)> {
+    let old_set = directive_line_set(old);
+    let new_set = directive_line_set(new);
+    let added = new_set.difference(&old_set).count();
+    let removed = old_set.difference(&new_set).count();
+    if added == 0 && removed == 0 {
+        None
+    } else {
+        Some((added, removed))
+    }
+}
+
+/// Build a toolchain-surface finding for one inert source edit when its two
+/// blob revisions differ in directive lines. Reads are hash-addressed against
+/// the blob store — never the filesystem. Silent when either hash is absent,
+/// the two hashes are identical, a blob cannot be read, or no directive line
+/// changed.
+fn toolchain_surface_finding(
+    blobs: &BlobStore,
+    file: &str,
+    old_hash: Option<Hash256>,
+    new_hash: Option<Hash256>,
+) -> Option<InlineComment> {
+    let (old_hash, new_hash) = (old_hash?, new_hash?);
+    if old_hash == new_hash {
+        return None;
+    }
+    let old_bytes = blobs.read(&old_hash).ok()?;
+    let new_bytes = blobs.read(&new_hash).ok()?;
+    let (added, removed) = directive_surface_delta(&old_bytes, &new_bytes)?;
+    Some(InlineComment {
+        file: file.to_string(),
+        start_line: 1,
+        end_line: 1,
+        kind: InlineCommentKind::ToolchainSurfaceChange,
+        message: format!(
+            "Toolchain directives changed in {file}: {added} added, {removed} removed; \
+             lint/deprecation enforcement shifted"
+        ),
+    })
+}
+
+/// Collect evidence gaps for the report, plus any toolchain-surface findings
+/// discovered while classifying inert source edits.
+///
+/// The findings are returned separately from the gaps: a directive change on an
+/// inert edit is a normal warning finding that feeds the gate through
+/// [`derive_policy`], NOT an evidence-gap demotion. `blobs` is `Option` because
+/// the current shadow entry points cannot reach a blob reader without changing
+/// their public signature (and their out-of-crate callers); the toolchain
+/// channel is emitted only when a reader is supplied.
 fn collect_evidence_gaps<G: GraphStore>(
     review: &Review,
     changes: &[kin_model::change::SemanticChange],
     changed_entities: &[ShadowChangedEntity],
     at_head: Option<&GraphAtRef<'_, G>>,
-) -> Vec<ShadowEvidenceGap> {
+    blobs: Option<&BlobStore>,
+) -> (Vec<ShadowEvidenceGap>, Vec<InlineComment>) {
     let mut gaps = Vec::new();
+    let mut toolchain_findings: Vec<InlineComment> = Vec::new();
 
     // Files whose changes were recorded only as raw artifacts: the graph has
     // no entities for them, so they are invisible to blast radius and policy.
+    // Retain each file's net old->new blob hashes across the range — first old,
+    // last new, folded in stable slice order — so an inert source edit can be
+    // inspected for toolchain-directive churn. Ordered by file (BTreeMap) so
+    // both the gaps and any findings emit deterministically.
     let entity_files: BTreeSet<String> = changed_entities
         .iter()
         .filter_map(|entity| entity.file.clone())
         .collect();
-    let mut artifact_only: BTreeSet<String> = BTreeSet::new();
+    let mut artifact_hashes: BTreeMap<String, (Option<Hash256>, Option<Hash256>)> = BTreeMap::new();
     for change in changes {
         for delta in &change.artifact_deltas {
             let file = delta.file_id.to_string();
-            if !entity_files.contains(&file) {
-                artifact_only.insert(file);
+            if entity_files.contains(&file) {
+                continue;
             }
+            let entry = artifact_hashes
+                .entry(file)
+                .or_insert((delta.old_hash, delta.new_hash));
+            entry.1 = delta.new_hash;
         }
     }
-    for file in artifact_only {
+    for (file, (old_hash, new_hash)) in &artifact_hashes {
         // A source-class file whose raw bytes changed but whose entities the
         // graph DID capture at head is an inert edit — a comment, formatting,
         // or preprocessor-only change that altered no entity — not an
@@ -1057,9 +1175,20 @@ fn collect_evidence_gaps<G: GraphStore>(
         // source file with living entities does not flip the verdict merely
         // for a comment touch. Genuinely uncaptured files (no entity anchored
         // at head, or head state unavailable) keep the demoting kind.
-        let inert_source_edit = artifact_subject_is_source_class(&file)
-            && at_head.is_some_and(|at| at.has_entity_in_file(&file));
+        let inert_source_edit = artifact_subject_is_source_class(file)
+            && at_head.is_some_and(|at| at.has_entity_in_file(file));
         let (kind, detail) = if inert_source_edit {
+            // The edit altered no entity, but if it changed inline lint or
+            // deprecation directives it shifted what the toolchain enforces —
+            // review-worthy on its own. Surface that as a normal warning
+            // finding (not an evidence-gap demotion) when a blob reader is
+            // available to diff the two revisions hash-addressed.
+            if let Some(blobs) = blobs {
+                if let Some(finding) = toolchain_surface_finding(blobs, file, *old_hash, *new_hash)
+                {
+                    toolchain_findings.push(finding);
+                }
+            }
             (
                 "entity_inert_change",
                 "source file changed but no semantic entity was altered (comment, formatting, or \
@@ -1076,7 +1205,7 @@ fn collect_evidence_gaps<G: GraphStore>(
         };
         gaps.push(ShadowEvidenceGap {
             kind: kind.to_string(),
-            subject: file,
+            subject: file.clone(),
             detail: detail.to_string(),
         });
     }
@@ -1128,7 +1257,7 @@ fn collect_evidence_gaps<G: GraphStore>(
             .to_string(),
     });
 
-    gaps
+    (gaps, toolchain_findings)
 }
 
 fn actor_kind_label(actor: &str) -> &'static str {
@@ -2802,5 +2931,209 @@ mod tests {
             .any(|finding| finding.kind == "signature_change"));
         // ... and, because isolation is unprovable, still feeds the gate.
         assert_eq!(report.policy.verdict, ShadowGateVerdict::NeedsAttention);
+    }
+
+    // ── Toolchain-surface directive channel ─────────────────────────────
+
+    fn empty_review() -> Review {
+        use crate::diff::SemanticDiff;
+        use crate::impact::ImpactReport;
+        use kin_model::review::{RiskLevel, RiskSummary};
+        Review {
+            base: None,
+            head: None,
+            diff: SemanticDiff::default(),
+            impact: ImpactReport::default(),
+            risk: RiskSummary {
+                overall_risk: RiskLevel::Low,
+                breaking_changes: vec![],
+                test_coverage_gaps: vec![],
+                contract_violations: vec![],
+                work_risks: vec![],
+                notes: vec![],
+            },
+            inline_comments: vec![],
+        }
+    }
+
+    #[test]
+    fn directive_added_blob_pair_fires() {
+        // A source edit that only adds a lint-suppression directive alters no
+        // entity, but it shifts what the toolchain enforces: the directive
+        // delta must be detected.
+        let old = b"fn compute() -> i32 {\n    let x = 1;\n    x\n}\n";
+        let new = b"#[allow(dead_code)]\nfn compute() -> i32 {\n    let x = 1;\n    x\n}\n";
+        let delta = directive_surface_delta(old, new).expect("added directive must be detected");
+        assert_eq!(delta, (1, 0), "one directive added, none removed");
+    }
+
+    #[test]
+    fn plain_comment_edit_is_silent() {
+        // Editing an ordinary comment carrying no directive token is not a
+        // toolchain-surface change.
+        let old = b"// old note\nfn f() {}\n";
+        let new = b"// a completely different note\nfn f() {}\n";
+        assert!(
+            directive_surface_delta(old, new).is_none(),
+            "a plain comment edit carries no toolchain directive"
+        );
+    }
+
+    #[test]
+    fn relocated_directive_is_silent() {
+        // The same directive line moved to a new position nets to zero against
+        // the directive-line SET: no enforcement changed.
+        let old = b"#[allow(unused)]\nfn a() {}\nfn b() {}\n";
+        let new = b"fn a() {}\nfn b() {}\n#[allow(unused)]\n";
+        assert!(
+            directive_surface_delta(old, new).is_none(),
+            "relocating an unchanged directive is not a surface change"
+        );
+    }
+
+    #[test]
+    fn one_sided_hash_is_silent() {
+        // A delta missing either side's blob hash cannot be diffed; emit
+        // nothing rather than guessing.
+        use kin_blobs::BlobStore;
+        let dir = tempfile::tempdir().unwrap();
+        let blobs = BlobStore::new(dir.path().to_path_buf()).unwrap();
+        let present = blobs.write(b"#[allow(dead_code)]\nfn f() {}\n").unwrap();
+
+        assert!(
+            toolchain_surface_finding(&blobs, "src/foo.rs", None, Some(present)).is_none(),
+            "missing old hash must stay silent"
+        );
+        assert!(
+            toolchain_surface_finding(&blobs, "src/foo.rs", Some(present), None).is_none(),
+            "missing new hash must stay silent"
+        );
+    }
+
+    #[test]
+    fn toolchain_finding_maps_like_command_effect_contract() {
+        // Mirror the command-effect-contract mapping: a reported, non-blocking
+        // warning finding — never an error, never blocking.
+        assert_eq!(
+            finding_kind_label(InlineCommentKind::ToolchainSurfaceChange),
+            "toolchain_surface_change"
+        );
+        assert_eq!(
+            finding_severity(InlineCommentKind::ToolchainSurfaceChange),
+            "warning"
+        );
+        assert!(!is_blocking(InlineCommentKind::ToolchainSurfaceChange));
+
+        // Same gate shape as the channel it mirrors.
+        assert_eq!(
+            finding_severity(InlineCommentKind::CommandEffectContract),
+            finding_severity(InlineCommentKind::ToolchainSurfaceChange)
+        );
+        assert_eq!(
+            is_blocking(InlineCommentKind::CommandEffectContract),
+            is_blocking(InlineCommentKind::ToolchainSurfaceChange)
+        );
+    }
+
+    #[test]
+    fn toolchain_finding_feeds_gate_as_needs_attention() {
+        // A toolchain-surface finding moves the verdict to needs_attention as
+        // an ordinary non-blocking warning — through the finding channel, not
+        // the evidence-gap demotion path (no gaps supplied here).
+        let mut review = empty_review();
+        review.inline_comments.push(InlineComment {
+            file: "src/foo.rs".to_string(),
+            start_line: 1,
+            end_line: 1,
+            kind: InlineCommentKind::ToolchainSurfaceChange,
+            message: "Toolchain directives changed in src/foo.rs: 1 added, 0 removed; \
+                      lint/deprecation enforcement shifted"
+                .to_string(),
+        });
+
+        let policy = derive_policy(&review, &[], &[]);
+        assert!(
+            policy
+                .findings
+                .iter()
+                .any(|finding| finding.kind == "toolchain_surface_change"
+                    && finding.severity == "warning"
+                    && !finding.blocking),
+            "the toolchain finding is reported as a non-blocking warning"
+        );
+        assert_eq!(policy.verdict, ShadowGateVerdict::NeedsAttention);
+    }
+
+    #[test]
+    fn inert_directive_edit_emits_toolchain_finding_through_collect() {
+        // End-to-end through collect_evidence_gaps: an inert edit of a captured
+        // source file whose directive lines changed yields a toolchain finding
+        // when a blob reader is present, and stays silent without one — while
+        // the inert edit itself is still reported as a non-demoting gap either
+        // way.
+        use kin_blobs::BlobStore;
+        let dir = tempfile::tempdir().unwrap();
+        let blobs = BlobStore::new(dir.path().to_path_buf()).unwrap();
+        let old_hash = blobs.write(b"fn sensor() {}\n").unwrap();
+        let new_hash = blobs
+            .write(b"// Deprecated: use sensor_v2\nfn sensor() {}\n")
+            .unwrap();
+
+        // Graph with an entity anchored in src/sensor.c at head, so the
+        // artifact edit classifies as an inert source edit (entity captured,
+        // none altered).
+        let graph = InMemoryGraph::new();
+        let sensor = entity_with_span("sensor", "src/sensor.c", 2, EntityRole::Source);
+        let base_id = change_id(0x91);
+        let base = change_with_deltas(
+            base_id,
+            vec![],
+            vec![EntityDelta::Added(sensor.clone())],
+            vec![],
+            vec![],
+        );
+        graph.create_change(&base).unwrap();
+        let at_head = GraphAtRef::materialize(&graph, &base_id).unwrap();
+
+        let changes = vec![change_with_deltas(
+            change_id(0x92),
+            vec![base_id],
+            vec![],
+            vec![],
+            vec![ArtifactDelta {
+                file_id: FilePathId::new("src/sensor.c"),
+                kind: ArtifactDeltaKind::Modified,
+                old_hash: Some(old_hash),
+                new_hash: Some(new_hash),
+            }],
+        )];
+
+        let review = empty_review();
+
+        let (gaps, findings) =
+            collect_evidence_gaps(&review, &changes, &[], Some(&at_head), Some(&blobs));
+        assert!(
+            gaps.iter()
+                .any(|gap| gap.kind == "entity_inert_change" && gap.subject == "src/sensor.c"),
+            "the inert edit is still reported as a non-demoting gap"
+        );
+        assert!(
+            findings.iter().any(|finding| finding.kind
+                == InlineCommentKind::ToolchainSurfaceChange
+                && finding.file == "src/sensor.c"),
+            "the directive change surfaces as a toolchain finding"
+        );
+
+        // No blob reader → the branch cannot inspect directives, so it stays
+        // silent even though the inert-edit gap is unchanged.
+        let (gaps_no_blob, findings_no_blob) =
+            collect_evidence_gaps(&review, &changes, &[], Some(&at_head), None);
+        assert!(gaps_no_blob
+            .iter()
+            .any(|gap| gap.kind == "entity_inert_change" && gap.subject == "src/sensor.c"));
+        assert!(
+            findings_no_blob.is_empty(),
+            "without a blob reader the toolchain channel emits nothing"
+        );
     }
 }

--- a/crates/kin-review/src/shadow.rs
+++ b/crates/kin-review/src/shadow.rs
@@ -501,7 +501,11 @@ fn collect_changed_entities<G: GraphStore>(
                     file,
                     start_line,
                     end_line,
-                    signature_changed: old.signature != new.signature,
+                    signature_changed: old.signature != new.signature
+                        && !crate::inline::signature_strengthened_only(
+                            &old.signature,
+                            &new.signature,
+                        ),
                     visibility_changed: old.visibility != new.visibility,
                 });
             }


### PR DESCRIPTION
## Summary

Four hardening fixes from the v6 run's residual-miss analysis, each root-caused from live artifacts:

- **Generated/amalgamated demotion**: single_include/amalgamated files classify as Generated role; their entities stay in the blast radius for navigation but no longer count as consumers — stale bundle copies stop producing false breaking findings on co-updated internal refactors.
- **Qualifier-aware signatures**: adding constexpr/inline/[[nodiscard]] no longer reads as a signature change (removal still does).
- **Unified delta semantics**: one shared `entity_semantics_changed` (three fingerprint hashes + both-sides-guarded command-effect contract) across every delta producer — daemon commit, CLI commit pipeline, and history hydration previously disagreed about what "modified" means.
- **Toolchain-surface channel**: entity-inert edits that add/remove lint-suppression or deprecation directives (nolint/noqa/eslint-disable/allow/deprecated) now surface a non-blocking warning via hash-addressed blob diffs — no filesystem reads. Channel is Option-gated pending blob-reader threading through the public report API.

Also closes the command-effect persist-path parity gap (contract attached at commit/init paths; comparisons fire only when both sides carry the key).

## Validation

kin-review 133, kin-cli 711, kin-daemon 305, kin-index 198, kin-core 248 — all green; fmt/clippy clean (no new warnings, stash-compared).

Refs: FIR-1307, FIR-1308, FIR-1311, FIR-1300, FIR-1302