### PR TITLE
chore(release): bump to 0.2.10 — review-accuracy hardening

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,27 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.2.10] - 2026-07-06
+
+Review-accuracy hardening across the shadow-review gate, the semantic substrate, and the language adapters — the graph now reasons about entity roles and the base-vs-head sides of a change the way a reviewer does.
+
+### Added
+
+- Toolchain-surface channel: edits that only add or remove lint-suppression and deprecation directives (`//nolint`, `# noqa`, `eslint-disable`, `#[allow]`, `@deprecated`, …) now surface a non-blocking review signal, diffed graph-natively from content-addressed blobs.
+- Executable per-language capability matrix covering all thirteen full adapters (entity extraction, cosmetic stability, call/import edges, cross-file resolution) as permanent regression tests.
+
+### Changed
+
+- Fingerprints and declaration signatures are formatting-independent across every language adapter: comment-only, whitespace-only, and line-wrapping edits no longer read as behavior or signature changes.
+- Entity role now scopes review findings consistently: test, generated, and vendored declarations are covering evidence, never a contract surface — a test's signature change no longer escalates a benign diff, and amalgamated single-header bundles no longer count as consumers.
+- Adding a strengthening qualifier (`constexpr`/`inline`/`[[nodiscard]]`) is no longer reported as a signature change.
+- One shared definition of "entity semantically changed" now governs every write path (commit, history hydration, daemon delta generation), so graph truth no longer depends on which path recorded a change.
+
+### Fixed
+
+- Deleting a public entity that has live non-test consumers is now flagged as a breaking change: removed-entity impact is harvested from the base graph (where the entity and its inbound edges still exist) instead of the head graph (where it is already gone), and the removed entity resolves to its real name rather than an opaque id.
+- Java and C# method calls resolve to their rightmost name (matching every other adapter), so cross-file call edges are no longer lost to dotted callees; Kotlin declaration signatures no longer leak the method body.
+
 ## [0.2.9] - 2026-07-04
 
 First-touch hardening: the daemon's git-ancestry hydration is serialized (no more concurrent-review crashes), whole-repo ingest routes every full language adapter, and agents get a budgeted batch source tool.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3039,11 +3039,11 @@ dependencies = [
 
 [[package]]
 name = "kin-buildinfo"
-version = "0.2.9"
+version = "0.2.10"
 
 [[package]]
 name = "kin-cli"
-version = "0.2.9"
+version = "0.2.10"
 dependencies = [
  "age",
  "anyhow",
@@ -3110,7 +3110,7 @@ dependencies = [
 
 [[package]]
 name = "kin-context"
-version = "0.2.9"
+version = "0.2.10"
 dependencies = [
  "kin-blobs",
  "kin-db",
@@ -3126,7 +3126,7 @@ dependencies = [
 
 [[package]]
 name = "kin-core"
-version = "0.2.9"
+version = "0.2.10"
 dependencies = [
  "chrono",
  "directories 5.0.1",
@@ -3150,7 +3150,7 @@ dependencies = [
 
 [[package]]
 name = "kin-daemon"
-version = "0.2.9"
+version = "0.2.10"
 dependencies = [
  "async-stream",
  "axum",
@@ -3239,7 +3239,7 @@ dependencies = [
 
 [[package]]
 name = "kin-git"
-version = "0.2.9"
+version = "0.2.10"
 dependencies = [
  "chrono",
  "gix",
@@ -3257,7 +3257,7 @@ dependencies = [
 
 [[package]]
 name = "kin-index"
-version = "0.2.9"
+version = "0.2.10"
 dependencies = [
  "hex",
  "kin-blobs",
@@ -3303,7 +3303,7 @@ dependencies = [
 
 [[package]]
 name = "kin-integration-tests"
-version = "0.2.9"
+version = "0.2.10"
 dependencies = [
  "kin-blobs",
  "kin-cli",
@@ -3345,7 +3345,7 @@ dependencies = [
 
 [[package]]
 name = "kin-mcp"
-version = "0.2.9"
+version = "0.2.10"
 dependencies = [
  "kin-blobs",
  "kin-context",
@@ -3372,7 +3372,7 @@ dependencies = [
 
 [[package]]
 name = "kin-migrate"
-version = "0.2.9"
+version = "0.2.10"
 dependencies = [
  "chrono",
  "kin-blobs",
@@ -3414,7 +3414,7 @@ dependencies = [
 
 [[package]]
 name = "kin-parser"
-version = "0.2.9"
+version = "0.2.10"
 dependencies = [
  "kin-model",
  "pretty_assertions",
@@ -3443,7 +3443,7 @@ dependencies = [
 
 [[package]]
 name = "kin-projection"
-version = "0.2.9"
+version = "0.2.10"
 dependencies = [
  "kin-blobs",
  "kin-db",
@@ -3458,7 +3458,7 @@ dependencies = [
 
 [[package]]
 name = "kin-ranking"
-version = "0.2.9"
+version = "0.2.10"
 dependencies = [
  "kin-model",
  "serde",
@@ -3467,7 +3467,7 @@ dependencies = [
 
 [[package]]
 name = "kin-reconcile"
-version = "0.2.9"
+version = "0.2.10"
 dependencies = [
  "kin-blobs",
  "kin-db",
@@ -3487,7 +3487,7 @@ dependencies = [
 
 [[package]]
 name = "kin-registry"
-version = "0.2.9"
+version = "0.2.10"
 dependencies = [
  "axum",
  "base64 0.22.1",
@@ -3512,7 +3512,7 @@ dependencies = [
 
 [[package]]
 name = "kin-remote"
-version = "0.2.9"
+version = "0.2.10"
 dependencies = [
  "chrono",
  "kin-model",
@@ -3528,7 +3528,7 @@ dependencies = [
 
 [[package]]
 name = "kin-review"
-version = "0.2.9"
+version = "0.2.10"
 dependencies = [
  "kin-blobs",
  "kin-db",
@@ -3544,7 +3544,7 @@ dependencies = [
 
 [[package]]
 name = "kin-runtime"
-version = "0.2.9"
+version = "0.2.10"
 dependencies = [
  "chrono",
  "hex",
@@ -3576,7 +3576,7 @@ dependencies = [
 
 [[package]]
 name = "kin-semantic-contracts"
-version = "0.2.9"
+version = "0.2.10"
 dependencies = [
  "kin-db",
  "kin-model",
@@ -3591,7 +3591,7 @@ dependencies = [
 
 [[package]]
 name = "kin-spine"
-version = "0.2.9"
+version = "0.2.10"
 dependencies = [
  "chrono",
  "hashbrown 0.15.5",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,7 +27,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.2.9"
+version = "0.2.10"
 edition = "2021"
 license = "Apache-2.0"
 authors = ["Troy Fortin <troy@firelock.ai>"]

--- a/packages/kin-mcp/package.json
+++ b/packages/kin-mcp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kinlab/kin-mcp",
-  "version": "0.2.9",
+  "version": "0.2.10",
   "description": "Start Kin's MCP server through an npm-friendly wrapper.",
   "type": "module",
   "bin": {


### PR DESCRIPTION
Version bump 0.2.9 → 0.2.10. On merge, auto-tag-release.yml cuts v0.2.10 and release.yml publishes (5 platforms + npm).

Ships the merge-trust review-accuracy wave (all merged to main via #232): removed-API breaking detection, role-scoped surface findings (test/generated/vendored), generated-bundle demotion, qualifier-aware signatures, toolchain-surface channel, unified write-path delta semantics, per-language capability matrix + Java/C#/Kotlin adapter fixes.

release-check: RELEASE-CLEAN (registry-resolved, no local patches). CHANGELOG updated.