### PR TITLE
fix(parser,index): resolve Python self/cls calls through class inheritance

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Python method calls dispatched through `self`/`cls` now resolve through the class's
+  inheritance chain to the defining ancestor, in batch linking, incremental linking, and
+  reopened graphs alike: `self.validate()` inside `Command(BaseCommand)` links to
+  `BaseCommand.validate` as a verdict-driving consumer edge instead of vanishing into the
+  bare-name fan-out. Deleting an inherited-but-consumed API is therefore flagged as
+  breaking — this extends 0.2.10's removed-entity rule, whose consumer harvest was scoped
+  to directly-captured edges, to inheritance-reached consumers. Local overrides still
+  shadow the base, unknown-receiver calls keep their previous behavior, and unresolvable
+  hierarchies fall back to the old fan-out so recall never regresses.
+
 ## [0.2.10] - 2026-07-06
 
 Review-accuracy hardening across the shadow-review gate, the semantic substrate, and the language adapters — the graph now reasons about entity roles and the base-vs-head sides of a change the way a reviewer does.

--- a/crates/kin-cli/src/commands/init.rs
+++ b/crates/kin-cli/src/commands/init.rs
@@ -1146,6 +1146,7 @@ impl Clone for ImportedCommitSemanticState {
                 known_files: self.linker.known_files.clone(),
                 entities_by_file: self.linker.entities_by_file.clone(),
                 include_targets_by_file: self.linker.include_targets_by_file.clone(),
+                class_bases_by_file: self.linker.class_bases_by_file.clone(),
             },
         }
     }
@@ -1445,6 +1446,7 @@ pub(crate) fn enrich_imported_changes_with_semantics(
         if !changed_parse_data.is_empty() {
             let link_start_time = std::time::Instant::now();
             incremental_linker.record_file_includes(&changed_parse_data);
+            incremental_linker.record_class_bases(&changed_parse_data);
             let mut new_relations_by_id = HashMap::<RelationId, Relation>::new();
             for relation in
                 kin_index::link_cross_file_incremental(&changed_parse_data, &incremental_linker)
@@ -2880,14 +2882,48 @@ fn build_incremental_linker_from_graph(
     }
 
     let mut entities_by_file = BTreeMap::<String, Vec<Entity>>::new();
+    let mut entity_meta = HashMap::<EntityId, (String, String)>::new();
     for entity in graph.query_entities(&EntityFilter::default())? {
         let Some(file_path) = entity.file_origin.as_ref().map(|path| path.0.clone()) else {
             continue;
         };
+        entity_meta.insert(entity.id, (entity.name.clone(), file_path.clone()));
         entities_by_file.entry(file_path).or_default().push(entity);
     }
     for (file_path, entities) in entities_by_file {
         linker.add_file(&file_path, &entities);
+    }
+
+    // Rehydrate per-file class hierarchies from the committed Extends edges so
+    // inheritance-aware method resolution keeps working across reopen — the
+    // reparsed subset alone would only see step-local hierarchies, and an
+    // inheritance walk crossing into an unchanged file would dead-end.
+    // Committed edges carry no declaration order, so bases are sorted
+    // lexicographically — the same order every other recording path uses.
+    let mut bases_by_file_class = BTreeMap::<(String, String), Vec<String>>::new();
+    for (src, kind, dst, _confidence) in graph.list_all_entity_edges() {
+        if kind != RelationKind::Extends {
+            continue;
+        }
+        let (Some((src_name, src_file)), Some((dst_name, _))) =
+            (entity_meta.get(&src), entity_meta.get(&dst))
+        else {
+            continue;
+        };
+        let bases = bases_by_file_class
+            .entry((src_file.clone(), src_name.clone()))
+            .or_default();
+        if !bases.contains(dst_name) {
+            bases.push(dst_name.clone());
+        }
+    }
+    for ((file_path, class_name), mut bases) in bases_by_file_class {
+        bases.sort_unstable();
+        linker
+            .class_bases_by_file
+            .entry(file_path)
+            .or_default()
+            .push((class_name, bases));
     }
 
     // Rehydrate per-file include state from the committed artifact include

--- a/crates/kin-index/src/linker.rs
+++ b/crates/kin-index/src/linker.rs
@@ -237,6 +237,11 @@ struct LinkContext<'a> {
     known_files: HashSet<&'a str>,
     import_map: HashMap<&'a str, HashMap<&'a str, (&'a str, &'a str)>>,
     include_graph: HashMap<String, Vec<String>>,
+    /// (file, class name) -> that class's declared base names, lexicographically
+    /// sorted, deduped. Backs inheritance-aware receiver-method resolution;
+    /// keyed per file because class names repeat across a repo (django alone
+    /// has dozens of `Command` classes).
+    class_bases_by_file_class: HashMap<(&'a str, &'a str), Vec<&'a str>>,
 }
 
 fn build_link_context<'a>(
@@ -333,6 +338,29 @@ fn build_link_context<'a>(
 
     let include_graph = build_include_graph(files, &known_files);
 
+    // Step 3: class hierarchy from parser-emitted Extends relations, keyed per
+    // (file, class). Bases are sorted lexicographically — NOT declaration
+    // order — because the reopen path rehydrates this index from committed
+    // graph edges, which carry no declaration order; one uniform order keeps
+    // cold, incremental, and reopened graphs resolving identically.
+    let mut class_bases_by_file_class: HashMap<(&str, &str), Vec<&str>> = HashMap::new();
+    for file in files {
+        for rel in &file.relations {
+            if rel.kind != RelationKind::Extends {
+                continue;
+            }
+            let bases = class_bases_by_file_class
+                .entry((file.file_path.as_str(), rel.src_name.as_str()))
+                .or_default();
+            if !bases.contains(&rel.dst_name.as_str()) {
+                bases.push(rel.dst_name.as_str());
+            }
+        }
+    }
+    for bases in class_bases_by_file_class.values_mut() {
+        bases.sort_unstable();
+    }
+
     LinkContext {
         sorted_universe,
         entity_by_file_name,
@@ -343,6 +371,7 @@ fn build_link_context<'a>(
         known_files,
         import_map,
         include_graph,
+        class_bases_by_file_class,
     }
 }
 
@@ -438,6 +467,44 @@ fn resolve_one_file(file: &FileParseData, ctx: &LinkContext<'_>) -> Vec<Relation
             continue;
         }
 
+        // (a2) Inheritance-aware receiver-method resolution. The Python adapter
+        // emits `self.m()` / `cls.m()` class-qualified (`EnclosingClass.m`), so
+        // when the owner half names a class in this file — i.e. the parser
+        // pinned the dispatch class — and (a) found no local override, walk the
+        // class's Extends chain to the defining ancestor. That edge is dispatch
+        // evidence and must not fall through to the blind bare-name fan-out.
+        // When the walk finds nothing in-graph (builtin/external base, dynamic
+        // hierarchy), the call continues through the tiers below as its bare
+        // leaf, so recall never drops below the pre-qualification behavior.
+        // Dotted callees whose owner is NOT a local class (namespace members
+        // like `util.finalize()`) skip this tier untouched.
+        let mut dst_lookup: &str = rel.dst_name.as_str();
+        if rel.kind == RelationKind::Calls {
+            if let Some((owner, method)) = split_owner_method(rel.dst_name.as_str()) {
+                let owner_is_class = ctx
+                    .entity_by_file_name
+                    .get(&(file.file_path.as_str(), owner))
+                    .map(|id| is_class_like(ctx.entity_kind_by_id.get(id)))
+                    .unwrap_or(false);
+                if owner_is_class {
+                    if let Some(dst_id) =
+                        resolve_inherited_method(&file.file_path, owner, method, ctx)
+                    {
+                        if add_deduped(&mut seen, src_id, dst_id, rel.kind) {
+                            resolved.push(make_relation(
+                                rel.kind,
+                                src_id,
+                                dst_id,
+                                INHERITED_METHOD_CONFIDENCE,
+                            ));
+                        }
+                        continue;
+                    }
+                    dst_lookup = method;
+                }
+            }
+        }
+
         // (b) Import-based cross-file resolution
         if let Some(file_imports) = ctx.import_map.get(file.file_path.as_str()) {
             if let Some(&(module_path, original_name)) = file_imports.get(rel.dst_name.as_str()) {
@@ -490,7 +557,7 @@ fn resolve_one_file(file: &FileParseData, ctx: &LinkContext<'_>) -> Vec<Relation
 
         let exact_candidates = ctx
             .entity_by_name
-            .get(rel.dst_name.as_str())
+            .get(dst_lookup)
             .map(|v| v.as_slice())
             .unwrap_or(&[]);
         let other_file_candidates: Vec<(&str, EntityId)> = exact_candidates
@@ -529,7 +596,7 @@ fn resolve_one_file(file: &FileParseData, ctx: &LinkContext<'_>) -> Vec<Relation
         // (c) Global name-match fallback
         let bare_candidates = if rel.kind == RelationKind::Calls {
             ctx.entity_by_bare_name
-                .get(rel.dst_name.as_str())
+                .get(dst_lookup)
                 .map(|v| v.as_slice())
                 .unwrap_or(&[])
         } else {
@@ -990,6 +1057,35 @@ fn split_member_access(name: &str) -> Option<(&str, &str)> {
 /// the same whether one target or several survive.
 const QUALIFIED_SUFFIX_CONFIDENCE: f32 = 0.6;
 
+/// Confidence for a method call resolved through the receiver class's Extends
+/// chain (`self.m()` in `Sub(Base)` linking to `Base.m`). The parser pinned the
+/// dispatch class and the class hierarchy pinned the defining ancestor, so this
+/// is dispatch evidence, not a name guess — above locality disambiguation (0.8)
+/// and well above the review-side strong-consumer floor, below an
+/// import-verified edge (0.95) because the base-class link itself may have been
+/// name-resolved.
+const INHERITED_METHOD_CONFIDENCE: f32 = 0.85;
+
+/// Split a dotted `Owner.method` dst_name into its owner and method parts at
+/// the FINAL dot (`N.Class.Method` → (`N.Class`, `Method`)). Returns `None` for
+/// undotted names, `::` paths (those belong to the qualified-suffix resolver),
+/// and empty halves, so only receiver-qualified method keys reach the
+/// inheritance walk.
+fn split_owner_method(name: &str) -> Option<(&str, &str)> {
+    if name.contains("::") {
+        return None;
+    }
+    let idx = name.rfind('.')?;
+    let (owner, method) = (&name[..idx], &name[idx + 1..]);
+    (!owner.is_empty() && !method.is_empty()).then_some((owner, method))
+}
+
+/// Upper bound on how many classes an inheritance walk may visit before giving
+/// up. Real hierarchies are shallow; the cap is cycle/pathology insurance so a
+/// malformed `Extends` graph (self-inheritance, giant generated lattices) can
+/// never stall linking.
+const INHERITANCE_WALK_CAP: usize = 64;
+
 /// Whether a `::`-path segment is a plain Rust identifier (`crate`, `self`,
 /// `Widget`, `run`). Rejects generic/turbofish fragments (`<T>`, `run::<T>`) and
 /// other non-identifier forms so suffix resolution never keys off a mangled
@@ -1209,6 +1305,300 @@ fn resolve_qualified_suffix_incremental(
             Vec::new()
         }
     }
+}
+
+/// Whether an entity id names a type that can anchor an inheritance walk.
+fn is_class_like(kind: Option<&EntityKind>) -> bool {
+    matches!(
+        kind,
+        Some(
+            EntityKind::Class | EntityKind::EnumDef | EntityKind::Interface | EntityKind::TraitDef
+        )
+    )
+}
+
+/// Collapse a file's Extends relations into per-class base lists, sorted
+/// lexicographically (see the batch index comment: committed graph edges carry
+/// no declaration order, so one uniform order keeps every linking path
+/// bit-identical).
+fn collect_class_bases(relations: &[ExtractedRelation]) -> Vec<(String, Vec<String>)> {
+    let mut classes: Vec<(String, Vec<String>)> = Vec::new();
+    for rel in relations {
+        if rel.kind != RelationKind::Extends {
+            continue;
+        }
+        match classes.iter_mut().find(|(class, _)| class == &rel.src_name) {
+            Some((_, bases)) => {
+                if !bases.contains(&rel.dst_name) {
+                    bases.push(rel.dst_name.clone());
+                }
+            }
+            None => classes.push((rel.src_name.clone(), vec![rel.dst_name.clone()])),
+        }
+    }
+    for (_, bases) in &mut classes {
+        bases.sort_unstable();
+    }
+    classes
+}
+
+/// Declared base names of `class_name` in `file_path` within a per-file
+/// hierarchy map, if recorded.
+fn class_bases_in<'m>(
+    map: &'m HashMap<String, Vec<(String, Vec<String>)>>,
+    file_path: &str,
+    class_name: &str,
+) -> Option<&'m [String]> {
+    map.get(file_path)?
+        .iter()
+        .find(|(class, _)| class == class_name)
+        .map(|(_, bases)| bases.as_slice())
+}
+
+/// Locate the class a declared base NAME refers to, from `class_file`'s point
+/// of view: a same-file class shadows everything; then the file's own import
+/// bindings (`from pkg.base import Base [as B]`, or a `models.Model` member of
+/// an imported module); then a repo-globally unique class name (Python's
+/// absolute `pkg.mod` imports do not resolve to files — see
+/// `resolve_import_pinned_target` — so uniqueness is the honest cross-file
+/// evidence tier). Returns the (file, class entity name) to continue the walk
+/// from, or `None` when the base is external, builtin, or ambiguous — a walk
+/// must never guess a hierarchy.
+fn locate_base_class(
+    class_file: &str,
+    base_raw: &str,
+    ctx: &LinkContext<'_>,
+) -> Option<(String, String)> {
+    let base_leaf = bare_entity_name(base_raw);
+
+    if let Some(id) = ctx.entity_by_file_name.get(&(class_file, base_leaf)) {
+        if is_class_like(ctx.entity_kind_by_id.get(id)) {
+            return Some((class_file.to_string(), base_leaf.to_string()));
+        }
+    }
+
+    if let Some(file_imports) = ctx.import_map.get(class_file) {
+        let (binding, target_name) = match base_raw.split_once('.') {
+            // `models.Model`: the binding is the first segment, the class is
+            // the leaf inside the imported module.
+            Some((first, _)) => (first, base_leaf),
+            // `Base` bound by `from m import Base [as B]`: the target file
+            // declares the original name.
+            None => (base_raw, ""),
+        };
+        if let Some(&(module_path, original_name)) = file_imports.get(binding) {
+            let target_name = if target_name.is_empty() {
+                original_name
+            } else {
+                target_name
+            };
+            if let Some(target_file) =
+                resolve_module_path(class_file, module_path, &ctx.known_files)
+            {
+                if let Some(id) = ctx
+                    .entity_by_file_name
+                    .get(&(target_file.as_str(), target_name))
+                {
+                    if is_class_like(ctx.entity_kind_by_id.get(id)) {
+                        return Some((target_file, target_name.to_string()));
+                    }
+                }
+            }
+        }
+    }
+
+    let mut unique: Option<(&str, EntityId)> = None;
+    if let Some(candidates) = ctx.entity_by_name.get(base_leaf) {
+        for &(fp, id) in candidates {
+            match unique {
+                None => unique = Some((fp, id)),
+                Some((_, seen)) if seen == id => {}
+                Some(_) => return None,
+            }
+        }
+    }
+    if let Some((fp, id)) = unique {
+        if is_class_like(ctx.entity_kind_by_id.get(&id)) {
+            return Some((fp.to_string(), base_leaf.to_string()));
+        }
+    }
+    None
+}
+
+/// Resolve an inherited receiver-method call (`Sub.method` where `Sub` does
+/// not define `method`) to the defining ancestor's method entity by walking
+/// `Sub`'s Extends chain breadth-first. Level order matches Python's MRO
+/// property that nearer ancestors shadow farther ones; among a level's several
+/// bases the walk visits lexicographically (a documented approximation of C3's
+/// left-to-right rule — declaration order cannot be rehydrated from committed
+/// graph edges, and one uniform order keeps cold/incremental/reopened graphs
+/// bit-identical). The walk is bounded by [`INHERITANCE_WALK_CAP`] and
+/// cycle-guarded, and ends any branch whose base cannot be located
+/// ([`locate_base_class`]) — it never guesses. Kept in exact resolution parity
+/// with [`resolve_inherited_method_incremental`].
+fn resolve_inherited_method(
+    src_file: &str,
+    owner: &str,
+    method: &str,
+    ctx: &LinkContext<'_>,
+) -> Option<EntityId> {
+    let start = (src_file.to_string(), owner.to_string());
+    let mut visited: HashSet<(String, String)> = HashSet::new();
+    let mut queue: std::collections::VecDeque<(String, String)> = std::collections::VecDeque::new();
+    visited.insert(start.clone());
+    queue.push_back(start);
+
+    while let Some((class_file, class_name)) = queue.pop_front() {
+        let Some(bases) = ctx
+            .class_bases_by_file_class
+            .get(&(class_file.as_str(), class_name.as_str()))
+        else {
+            continue;
+        };
+        for &base_raw in bases {
+            let Some((base_file, base_class)) = locate_base_class(&class_file, base_raw, ctx)
+            else {
+                continue;
+            };
+            let method_key = format!("{}.{}", base_class, method);
+            if let Some(&dst_id) = ctx
+                .entity_by_file_name
+                .get(&(base_file.as_str(), method_key.as_str()))
+            {
+                return Some(dst_id);
+            }
+            if visited.len() >= INHERITANCE_WALK_CAP {
+                return None;
+            }
+            let key = (base_file, base_class);
+            if !visited.contains(&key) {
+                visited.insert(key.clone());
+                queue.push_back(key);
+            }
+        }
+    }
+    None
+}
+
+/// Incremental-linker counterpart of [`locate_base_class`], kept in exact
+/// resolution parity: same-file class, then the caller file's import bindings,
+/// then a repo-globally unique class name. `import_map` is the step-local
+/// import index, so the import tier only sees files parsed this step — files
+/// recorded at earlier steps still resolve through the same-file and
+/// global-unique tiers.
+fn locate_base_class_incremental(
+    class_file: &str,
+    base_raw: &str,
+    linker: &IncrementalLinker,
+    import_map: &HashMap<&str, HashMap<&str, (&str, &str)>>,
+) -> Option<(String, String)> {
+    let base_leaf = bare_entity_name(base_raw);
+
+    if let Some(id) = linker
+        .entity_by_file_name
+        .get(class_file)
+        .and_then(|m| m.get(base_leaf))
+    {
+        if is_class_like(linker.entity_kind_by_id.get(id)) {
+            return Some((class_file.to_string(), base_leaf.to_string()));
+        }
+    }
+
+    if let Some(file_imports) = import_map.get(class_file) {
+        let (binding, target_name) = match base_raw.split_once('.') {
+            Some((first, _)) => (first, base_leaf),
+            None => (base_raw, ""),
+        };
+        if let Some(&(module_path, original_name)) = file_imports.get(binding) {
+            let target_name = if target_name.is_empty() {
+                original_name
+            } else {
+                target_name
+            };
+            if let Some(target_file) =
+                resolve_module_path(class_file, module_path, &linker.known_files)
+            {
+                if let Some(id) = linker
+                    .entity_by_file_name
+                    .get(&target_file)
+                    .and_then(|m| m.get(target_name))
+                {
+                    if is_class_like(linker.entity_kind_by_id.get(id)) {
+                        return Some((target_file, target_name.to_string()));
+                    }
+                }
+            }
+        }
+    }
+
+    let mut unique: Option<(&str, EntityId)> = None;
+    if let Some(candidates) = linker.entity_by_name.get(base_leaf) {
+        for (fp, id) in candidates {
+            match unique {
+                None => unique = Some((fp.as_str(), *id)),
+                Some((_, seen)) if seen == *id => {}
+                Some(_) => return None,
+            }
+        }
+    }
+    if let Some((fp, id)) = unique {
+        if is_class_like(linker.entity_kind_by_id.get(&id)) {
+            return Some((fp.to_string(), base_leaf.to_string()));
+        }
+    }
+    None
+}
+
+/// Incremental-linker counterpart of [`resolve_inherited_method`], kept in
+/// exact resolution parity: breadth-first over declaration-ordered bases,
+/// cycle-guarded, bounded by [`INHERITANCE_WALK_CAP`], never guessing an
+/// unlocatable base. Without this twin an inherited-method edge resolved into a
+/// full-tree snapshot would drop the moment an incremental relink of the
+/// caller re-derives its edges — the exact failure mode the (c2) parity work
+/// fixed for bare receiver methods.
+fn resolve_inherited_method_incremental(
+    src_file: &str,
+    owner: &str,
+    method: &str,
+    linker: &IncrementalLinker,
+    import_map: &HashMap<&str, HashMap<&str, (&str, &str)>>,
+    class_bases: &HashMap<String, Vec<(String, Vec<String>)>>,
+) -> Option<EntityId> {
+    let start = (src_file.to_string(), owner.to_string());
+    let mut visited: HashSet<(String, String)> = HashSet::new();
+    let mut queue: std::collections::VecDeque<(String, String)> = std::collections::VecDeque::new();
+    visited.insert(start.clone());
+    queue.push_back(start);
+
+    while let Some((class_file, class_name)) = queue.pop_front() {
+        let Some(bases) = class_bases_in(class_bases, &class_file, &class_name) else {
+            continue;
+        };
+        for base_raw in bases {
+            let Some((base_file, base_class)) =
+                locate_base_class_incremental(&class_file, base_raw, linker, import_map)
+            else {
+                continue;
+            };
+            let method_key = format!("{}.{}", base_class, method);
+            if let Some(&dst_id) = linker
+                .entity_by_file_name
+                .get(&base_file)
+                .and_then(|m| m.get(method_key.as_str()))
+            {
+                return Some(dst_id);
+            }
+            if visited.len() >= INHERITANCE_WALK_CAP {
+                return None;
+            }
+            let key = (base_file, base_class);
+            if !visited.contains(&key) {
+                visited.insert(key.clone());
+                queue.push_back(key);
+            }
+        }
+    }
+    None
 }
 
 /// Directory component of a repo-relative path (`""` for top-level files).
@@ -2106,6 +2496,12 @@ pub struct IncrementalLinker {
     /// walks see edges recorded when other files were parsed, not only the
     /// step-local ones.
     pub include_targets_by_file: HashMap<String, Vec<String>>,
+    /// file_path -> that file's classes with their declared base names,
+    /// lexicographically sorted, deduped. The incremental mirror of the batch
+    /// linker's per-(file, class) hierarchy index; persists across steps like
+    /// `include_targets_by_file` so an inheritance walk can cross into files
+    /// recorded at earlier steps.
+    pub class_bases_by_file: HashMap<String, Vec<(String, Vec<String>)>>,
 }
 
 impl IncrementalLinker {
@@ -2118,6 +2514,7 @@ impl IncrementalLinker {
             known_files: HashSet::new(),
             entities_by_file: HashMap::new(),
             include_targets_by_file: HashMap::new(),
+            class_bases_by_file: HashMap::new(),
         }
     }
 
@@ -2148,6 +2545,24 @@ impl IncrementalLinker {
 
         self.entities_by_file.remove(file_path);
         self.include_targets_by_file.remove(file_path);
+        self.class_bases_by_file.remove(file_path);
+    }
+
+    /// Record each file's class hierarchy (Extends declarations), replacing any
+    /// prior entry — a file whose classes lost all bases is cleared. The
+    /// incremental counterpart of the batch linker's hierarchy index; call
+    /// alongside [`IncrementalLinker::record_file_includes`] wherever a step's
+    /// parse data is recorded.
+    pub fn record_class_bases(&mut self, files: &[FileParseData]) {
+        for file in files {
+            let classes = collect_class_bases(&file.relations);
+            if classes.is_empty() {
+                self.class_bases_by_file.remove(&file.file_path);
+            } else {
+                self.class_bases_by_file
+                    .insert(file.file_path.clone(), classes);
+            }
+        }
     }
 
     /// Record the resolved include targets of each file, replacing any prior
@@ -2269,6 +2684,26 @@ pub fn link_cross_file_incremental(
         merged
     };
 
+    // Step-local class hierarchy overlays the linker's persistent per-file
+    // state, exactly like the include graph above: files parsed this step
+    // resolve from their fresh Extends declarations (including files whose
+    // classes lost every base), every other file keeps the hierarchy recorded
+    // when it was last parsed or rehydrated. Inheritance walks therefore cross
+    // step boundaries without reading committed-stale bases for edited files.
+    let class_bases = {
+        let mut merged = linker.class_bases_by_file.clone();
+        for file in files {
+            merged.remove(&file.file_path);
+        }
+        for file in files {
+            let classes = collect_class_bases(&file.relations);
+            if !classes.is_empty() {
+                merged.insert(file.file_path.clone(), classes);
+            }
+        }
+        merged
+    };
+
     let total_files = files.len();
     let progress_interval = std::cmp::max(total_files / 50, 1);
     let link_start = std::time::Instant::now();
@@ -2373,6 +2808,44 @@ pub fn link_cross_file_incremental(
                 continue;
             }
 
+            // (a2) Inheritance-aware receiver-method resolution — mirrors the
+            // batch linker: a class-qualified `self.m()`/`cls.m()` callee whose
+            // owner is a class in this file resolves through the recorded
+            // Extends chain to the defining ancestor; an unresolvable hierarchy
+            // falls back to the bare leaf for the tiers below.
+            let mut dst_lookup: &str = rel.dst_name.as_str();
+            if rel.kind == RelationKind::Calls {
+                if let Some((owner, method)) = split_owner_method(rel.dst_name.as_str()) {
+                    let owner_is_class = linker
+                        .entity_by_file_name
+                        .get(&file.file_path)
+                        .and_then(|m| m.get(owner))
+                        .map(|id| is_class_like(linker.entity_kind_by_id.get(id)))
+                        .unwrap_or(false);
+                    if owner_is_class {
+                        if let Some(dst_id) = resolve_inherited_method_incremental(
+                            &file.file_path,
+                            owner,
+                            method,
+                            linker,
+                            &import_map,
+                            &class_bases,
+                        ) {
+                            if add_deduped(&mut seen, src_id, dst_id, rel.kind) {
+                                resolved.push(make_relation(
+                                    rel.kind,
+                                    src_id,
+                                    dst_id,
+                                    INHERITED_METHOD_CONFIDENCE,
+                                ));
+                            }
+                            continue;
+                        }
+                        dst_lookup = method;
+                    }
+                }
+            }
+
             // (b) Import-based cross-file resolution
             if let Some(file_imports) = import_map.get(file.file_path.as_str()) {
                 if let Some(&(module_path, original_name)) = file_imports.get(rel.dst_name.as_str())
@@ -2428,7 +2901,7 @@ pub fn link_cross_file_incremental(
 
             let other_file_candidates: Vec<(&str, EntityId)> = linker
                 .entity_by_name
-                .get(&rel.dst_name)
+                .get(dst_lookup)
                 .map(|candidates| {
                     candidates
                         .iter()
@@ -2523,8 +2996,7 @@ pub fn link_cross_file_incremental(
             // snapshot is dropped the moment an incremental relink of the caller
             // re-derives its edges.
             if name_fallback_allowed && rel.kind == RelationKind::Calls {
-                if let Some(bare_candidates) = linker.entity_by_bare_name.get(rel.dst_name.as_str())
-                {
+                if let Some(bare_candidates) = linker.entity_by_bare_name.get(dst_lookup) {
                     let distinct_targets: HashSet<EntityId> = bare_candidates
                         .iter()
                         .filter(|(fp, _)| fp != &file.file_path)

--- a/crates/kin-index/tests/python_call_resolution.rs
+++ b/crates/kin-index/tests/python_call_resolution.rs
@@ -122,3 +122,260 @@ fn cross_file_method_call_on_instance_resolves() {
         "method call `svc.process()` should resolve run -> service.py::Service.process"
     );
 }
+
+// ---- inheritance-aware receiver-method resolution (self./cls. dispatch) ----
+
+fn call_confidence(relations: &[kin_model::Relation], src: EntityId, dst: EntityId) -> Option<f32> {
+    relations
+        .iter()
+        .find(|r| {
+            r.kind == RelationKind::Calls
+                && r.src.as_entity() == Some(src)
+                && r.dst.as_entity() == Some(dst)
+        })
+        .map(|r| r.confidence)
+}
+
+#[test]
+fn inherited_self_call_resolves_to_base_method_cross_file() {
+    // The FIR-1342 / django 0f169098ef shape: Command(BaseCommand) calls
+    // self.validate(), and validate is defined only on the base class in
+    // another file. The edge must exist AND carry verdict-driving confidence
+    // (>= 0.6, the review-side strong-consumer floor) — a weak fan-out edge
+    // would not count the caller as a consumer of a removed API.
+    let files = vec![
+        parse_py(
+            "base.py",
+            "class BaseCommand:\n    def validate(self, display_num_errors=False):\n        return 1\n",
+        ),
+        parse_py(
+            "runserver.py",
+            "from base import BaseCommand\n\nclass Command(BaseCommand):\n    def inner_run(self):\n        self.validate(display_num_errors=True)\n",
+        ),
+    ];
+
+    let caller = entity_id(&files, "runserver.py", "Command.inner_run");
+    let target = entity_id(&files, "base.py", "BaseCommand.validate");
+
+    let relations = link_cross_file(&files);
+    assert!(
+        has_call(&relations, caller, target),
+        "self.validate() in Command(BaseCommand) must resolve to the inherited BaseCommand.validate"
+    );
+    let confidence = call_confidence(&relations, caller, target).unwrap();
+    assert!(
+        confidence >= 0.6,
+        "inherited-method edge must drive review verdicts (confidence {confidence} < 0.6)"
+    );
+}
+
+#[test]
+fn inherited_self_call_resolves_same_file() {
+    // Same-file base class: the pre-qualification linker could never link ANY
+    // same-file self-call (the bare-name tier is cross-file-only); the
+    // qualified form + hierarchy walk closes that gap too.
+    let files = vec![parse_py(
+        "base.py",
+        "class BaseCommand:\n    def validate(self):\n        return 1\n\nclass AppCommand(BaseCommand):\n    def handle(self):\n        self.validate()\n",
+    )];
+
+    let caller = entity_id(&files, "base.py", "AppCommand.handle");
+    let target = entity_id(&files, "base.py", "BaseCommand.validate");
+
+    let relations = link_cross_file(&files);
+    assert!(
+        has_call(&relations, caller, target),
+        "self.validate() in a same-file subclass must resolve to BaseCommand.validate"
+    );
+}
+
+#[test]
+fn self_call_resolves_to_own_override_not_base() {
+    // When the subclass overrides the method, self.m() dispatches to the
+    // override: the same-file exact tier wins at full confidence and the walk
+    // never fires. The base's copy must NOT be linked.
+    let files = vec![
+        parse_py(
+            "base.py",
+            "class BaseCommand:\n    def validate(self):\n        return 1\n",
+        ),
+        parse_py(
+            "sub.py",
+            "from base import BaseCommand\n\nclass Command(BaseCommand):\n    def validate(self):\n        return 2\n    def handle(self):\n        self.validate()\n",
+        ),
+    ];
+
+    let caller = entity_id(&files, "sub.py", "Command.handle");
+    let override_target = entity_id(&files, "sub.py", "Command.validate");
+    let base_target = entity_id(&files, "base.py", "BaseCommand.validate");
+
+    let relations = link_cross_file(&files);
+    assert!(
+        has_call(&relations, caller, override_target),
+        "self.validate() must resolve to the local override Command.validate"
+    );
+    assert!(
+        !has_call(&relations, caller, base_target),
+        "the shadowed base method must not receive the dispatch edge"
+    );
+}
+
+#[test]
+fn transitive_inheritance_resolves_through_chain() {
+    // A -> B -> C across three files: the walk crosses multiple hops and links
+    // to the ancestor that actually defines the method.
+    let files = vec![
+        parse_py(
+            "a.py",
+            "from b import Middle\n\nclass Leaf(Middle):\n    def run(self):\n        self.shared_helper()\n",
+        ),
+        parse_py("b.py", "from c import Root\n\nclass Middle(Root):\n    pass\n"),
+        parse_py(
+            "c.py",
+            "class Root:\n    def shared_helper(self):\n        return 3\n",
+        ),
+    ];
+
+    let caller = entity_id(&files, "a.py", "Leaf.run");
+    let target = entity_id(&files, "c.py", "Root.shared_helper");
+
+    let relations = link_cross_file(&files);
+    assert!(
+        has_call(&relations, caller, target),
+        "self.shared_helper() must resolve transitively Leaf -> Middle -> Root.shared_helper"
+    );
+}
+
+#[test]
+fn unresolvable_base_falls_back_to_bare_fanout() {
+    // The class extends something outside the graph (external package /
+    // builtin), so the walk finds nothing — the call must then keep the
+    // pre-qualification recall by fanning out on the bare leaf like any
+    // receiver-method call.
+    let files = vec![
+        parse_py(
+            "caller.py",
+            "from ext.pkg import ExternalBase\n\nclass Sub(ExternalBase):\n    def run(self):\n        self.helper()\n",
+        ),
+        parse_py(
+            "impl_one.py",
+            "class One:\n    def helper(self):\n        return 1\n",
+        ),
+        parse_py(
+            "impl_two.py",
+            "class Two:\n    def helper(self):\n        return 2\n",
+        ),
+    ];
+
+    let caller = entity_id(&files, "caller.py", "Sub.run");
+    let one = entity_id(&files, "impl_one.py", "One.helper");
+    let two = entity_id(&files, "impl_two.py", "Two.helper");
+
+    let relations = link_cross_file(&files);
+    assert!(
+        has_call(&relations, caller, one) && has_call(&relations, caller, two),
+        "an unresolvable hierarchy must fall back to the bare-leaf fan-out, keeping both candidates"
+    );
+}
+
+#[test]
+fn inheritance_cycle_terminates_without_edge() {
+    // A malformed cyclic hierarchy must terminate (cycle guard) and honestly
+    // resolve nothing rather than hang or fabricate an edge.
+    let files = vec![parse_py(
+        "cyc.py",
+        "class Alpha(Beta):\n    def run(self):\n        self.nowhere()\n\nclass Beta(Alpha):\n    pass\n",
+    )];
+
+    let caller = entity_id(&files, "cyc.py", "Alpha.run");
+    let relations = link_cross_file(&files);
+    assert!(
+        !relations
+            .iter()
+            .any(|r| r.kind == RelationKind::Calls && r.src.as_entity() == Some(caller)),
+        "a cyclic hierarchy with an undefined method must produce no Calls edge"
+    );
+}
+
+// ---- incremental-linker parity (the historical-replay path) ----
+
+#[test]
+fn incremental_inherited_self_call_resolves_with_batch_parity() {
+    use kin_index::{link_cross_file_incremental, IncrementalLinker};
+
+    let files = vec![
+        parse_py(
+            "base.py",
+            "class BaseCommand:\n    def validate(self, display_num_errors=False):\n        return 1\n",
+        ),
+        parse_py(
+            "runserver.py",
+            "from base import BaseCommand\n\nclass Command(BaseCommand):\n    def inner_run(self):\n        self.validate(display_num_errors=True)\n",
+        ),
+    ];
+
+    let mut linker = IncrementalLinker::new();
+    for file in &files {
+        linker.add_file(&file.file_path, &file.entities);
+    }
+    linker.record_class_bases(&files);
+
+    let caller = entity_id(&files, "runserver.py", "Command.inner_run");
+    let target = entity_id(&files, "base.py", "BaseCommand.validate");
+
+    let relations = link_cross_file_incremental(&files, &linker);
+    assert!(
+        has_call(&relations, caller, target),
+        "incremental linking must resolve the inherited method exactly like the batch linker"
+    );
+    let confidence = call_confidence(&relations, caller, target).unwrap();
+    assert!(
+        confidence >= 0.6,
+        "incremental inherited-method edge must drive review verdicts (confidence {confidence} < 0.6)"
+    );
+}
+
+#[test]
+fn incremental_hierarchy_persists_across_steps() {
+    use kin_index::{link_cross_file_incremental, IncrementalLinker};
+
+    // Step 1 records the base file; step 2 relinks ONLY the caller file. The
+    // walk must cross the step boundary through the linker's persistent
+    // hierarchy state — this is the historical-replay shape, where a later
+    // commit touches the subclass while the base class last changed many
+    // commits earlier.
+    let base = parse_py(
+        "base.py",
+        "class BaseCommand:\n    def validate(self):\n        return 1\n",
+    );
+    let caller = parse_py(
+        "runserver.py",
+        "from base import BaseCommand\n\nclass Command(BaseCommand):\n    def inner_run(self):\n        self.validate()\n",
+    );
+
+    let mut linker = IncrementalLinker::new();
+    linker.add_file(&base.file_path, &base.entities);
+    linker.record_class_bases(std::slice::from_ref(&base));
+
+    linker.add_file(&caller.file_path, &caller.entities);
+
+    let caller_id = entity_id(
+        std::slice::from_ref(&caller),
+        "runserver.py",
+        "Command.inner_run",
+    );
+    let target_id = entity_id(
+        std::slice::from_ref(&base),
+        "base.py",
+        "BaseCommand.validate",
+    );
+
+    // Only the caller file is in this step's parse data; base.py's hierarchy
+    // lives in the persistent linker state (and the caller's own hierarchy in
+    // the step-local overlay).
+    let relations = link_cross_file_incremental(std::slice::from_ref(&caller), &linker);
+    assert!(
+        has_call(&relations, caller_id, target_id),
+        "an inheritance walk must cross incremental step boundaries via recorded hierarchy state"
+    );
+}

--- a/crates/kin-parser/src/languages/python.rs
+++ b/crates/kin-parser/src/languages/python.rs
@@ -184,7 +184,7 @@ fn extract_py_node(
                     span: span_from_node(node, file_id),
                 });
                 // Extract calls within function/method body
-                extract_calls_from_context(node, source, &name, relations);
+                extract_calls_from_context(node, source, &name, class_ctx, relations);
                 if let Some(cls) = class_ctx {
                     relations.push(ExtractedRelation {
                         kind: kin_model::RelationKind::Contains,
@@ -454,6 +454,7 @@ fn extract_calls_from_context(
     node: &tree_sitter::Node,
     source: &[u8],
     context_name: &str,
+    class_ctx: Option<&str>,
     relations: &mut Vec<ExtractedRelation>,
 ) {
     let mut cursor = node.walk();
@@ -461,10 +462,30 @@ fn extract_calls_from_context(
         if child.kind() == "call" {
             if let Some(function) = child.child_by_field_name("function") {
                 let callee_name = match function.kind() {
-                    "attribute" => function
-                        .child_by_field_name("attribute")
-                        .map(|f| f.utf8_text(source).unwrap_or("").to_string())
-                        .unwrap_or_default(),
+                    "attribute" => {
+                        let attr = function
+                            .child_by_field_name("attribute")
+                            .map(|f| f.utf8_text(source).unwrap_or("").to_string())
+                            .unwrap_or_default();
+                        // `self.m()` / `cls.m()` dispatch through the enclosing
+                        // class, so qualify the callee with it: the linker can
+                        // then resolve an inherited method through the class's
+                        // Extends chain instead of fanning out on the bare name.
+                        // Any other receiver (`obj.m()`, `self.store.m()`) stays
+                        // bare — its type is unknown at parse time.
+                        let self_or_cls_receiver = function
+                            .child_by_field_name("object")
+                            .filter(|obj| obj.kind() == "identifier")
+                            .and_then(|obj| obj.utf8_text(source).ok())
+                            .map(|text| text == "self" || text == "cls")
+                            .unwrap_or(false);
+                        match class_ctx {
+                            Some(cls) if self_or_cls_receiver && !attr.is_empty() => {
+                                format!("{}.{}", cls, attr)
+                            }
+                            _ => attr,
+                        }
+                    }
                     "identifier" => {
                         let raw = function.utf8_text(source).unwrap_or("");
                         raw.strip_prefix("self.")
@@ -485,7 +506,7 @@ fn extract_calls_from_context(
             }
         }
         // Recurse into child nodes
-        extract_calls_from_context(&child, source, context_name, relations);
+        extract_calls_from_context(&child, source, context_name, class_ctx, relations);
     }
 }
 
@@ -733,7 +754,7 @@ mod tests {
     }
 
     #[test]
-    fn self_prefix_stripped_from_calls() {
+    fn self_calls_qualified_with_enclosing_class() {
         let adapter = PythonAdapter;
         let source =
             b"class Foo:\n    def run(self):\n        self.process()\n        self.helper(1)";
@@ -746,12 +767,13 @@ mod tests {
             .filter(|r| r.kind == kin_model::RelationKind::Calls)
             .collect();
         assert_eq!(calls.len(), 2);
-        assert_eq!(calls[0].dst_name, "process");
-        assert_eq!(calls[1].dst_name, "helper");
+        assert_eq!(calls[0].src_name, "Foo.run");
+        assert_eq!(calls[0].dst_name, "Foo.process");
+        assert_eq!(calls[1].dst_name, "Foo.helper");
     }
 
     #[test]
-    fn cls_prefix_stripped_from_calls() {
+    fn cls_calls_qualified_with_enclosing_class() {
         let adapter = PythonAdapter;
         let source = b"class Foo:\n    @classmethod\n    def make(cls):\n        cls.create()";
         let tree = adapter.parse(source).unwrap();
@@ -763,7 +785,26 @@ mod tests {
             .filter(|r| r.kind == kin_model::RelationKind::Calls && r.dst_name != "classmethod")
             .collect();
         assert_eq!(body_calls.len(), 1);
-        assert_eq!(body_calls[0].dst_name, "create");
+        assert_eq!(body_calls[0].dst_name, "Foo.create");
+    }
+
+    #[test]
+    fn non_self_receivers_stay_bare() {
+        let adapter = PythonAdapter;
+        let source = b"class Foo:\n    def run(self):\n        obj.render()\n        self.store.save()\n\ndef free():\n    conn.close()";
+        let tree = adapter.parse(source).unwrap();
+        let file_id = FilePathId::new("test.py");
+        let output = adapter.extract(&tree, source, &file_id).unwrap();
+        let dsts: Vec<&str> = output
+            .relations
+            .iter()
+            .filter(|r| r.kind == kin_model::RelationKind::Calls)
+            .map(|r| r.dst_name.as_str())
+            .collect();
+        // `obj.render()` has an unknown receiver type; `self.store.save()`
+        // dispatches through an attribute, not the class itself — both stay
+        // bare. Only direct self./cls. receivers gain the class qualifier.
+        assert_eq!(dsts, vec!["render", "save", "close"]);
     }
 
     #[test]

--- a/crates/kin-parser/tests/adapter_conformance.rs
+++ b/crates/kin-parser/tests/adapter_conformance.rs
@@ -824,7 +824,7 @@ fn python_resolves_attribute_calls_as_method_name() {
 }
 
 #[test]
-fn python_self_calls_strip_to_method_name() {
+fn python_self_calls_qualify_with_enclosing_class() {
     let adapter = PythonAdapter;
     let source = load_fixture("python", "calls.py");
     let output = parse_fixture(&adapter, &source);
@@ -836,9 +836,11 @@ fn python_self_calls_strip_to_method_name() {
         .map(|r| r.dst_name.as_str())
         .collect();
 
+    // A self-receiver dispatches through the enclosing class, so the callee is
+    // emitted class-qualified — the key the linker's inheritance walk resolves.
     assert!(
-        call_dsts.contains(&"validate"),
-        "Python should strip self. prefix and emit method name as Calls dst, got: {:?}",
+        call_dsts.contains(&"Service.validate"),
+        "Python should emit self.validate() as the class-qualified 'Service.validate', got: {:?}",
         call_dsts
     );
     assert!(

--- a/crates/kin-parser/tests/python_call_resolution.rs
+++ b/crates/kin-parser/tests/python_call_resolution.rs
@@ -7,15 +7,18 @@
 //! call-resolution test, even though every other one (Go, JS/TS, Kotlin, Swift,
 //! C++ qualified-name) does. This file closes that gap.
 //!
-//! Python narrows attribute callees to their **leaf name at extraction time**:
-//! `module.func()`, `obj.method()`, and `self.member.save()` all emit a `Calls`
-//! edge whose `dst_name` is the trailing identifier (`func`, `method`, `save`),
-//! never the dotted form. Because the parser already hands the linker a simple
-//! name, name-based cross-file resolution matches the target's own simple name —
-//! so the qualified-callee gap that let dotted `dst_name`s slip past resolution
-//! in other adapters never applied to Python. These tests are the regression net
-//! that keeps it that way; they would already have been green before that
-//! resolution work landed.
+//! Python narrows attribute callees to their **leaf name at extraction time**,
+//! with one deliberate exception. `module.func()`, `obj.method()`, and
+//! `self.member.save()` all emit a `Calls` edge whose `dst_name` is the trailing
+//! identifier (`func`, `method`, `save`) — their receiver's type is unknowable
+//! at parse time. But `self.m()` / `cls.m()` dispatch through the *enclosing
+//! class*, so they emit the class-qualified form (`Service.validate`): that
+//! qualifier is what lets the linker resolve an inherited method through the
+//! class's Extends chain instead of fanning out on the bare name. Because the
+//! parser hands the linker either a simple name or a `Class.method` key that
+//! matches how method entities are named, name-based cross-file resolution
+//! stays aligned with the entity keyspace. These tests are the regression net
+//! for both halves of that contract.
 //!
 //! Same-file extraction (entities + `Calls` `dst_name`s) is asserted here. The
 //! cross-file dimension of the matrix — the same three call shapes resolving to
@@ -242,7 +245,29 @@ fn class_method_nested_def_calls_attribute_to_method_entity() {
     );
 }
 
-// ---- fixture: every Calls dst_name is a simple leaf identifier ----
+// ---- self/cls receivers: class-qualified dst_name ----
+
+#[test]
+fn self_call_emits_class_qualified_dst() {
+    let output = extract(
+        "class Command:\n    def handle(self):\n        self.validate()\n        cls_free()\n",
+    );
+    assert!(
+        calls_named(&output, "Command.validate")
+            .iter()
+            .any(|r| r.src_name == "Command.handle"),
+        "self.validate() inside Command must emit the class-qualified dst \
+         'Command.validate' so the linker can walk the Extends chain, got {:?}",
+        calls(&output)
+    );
+    assert!(
+        calls_named(&output, "validate").is_empty(),
+        "the bare form must not be emitted alongside the qualified one, got {:?}",
+        calls(&output)
+    );
+}
+
+// ---- fixture: dst_names are leaf identifiers, except self/cls dispatch ----
 
 #[test]
 fn fixture_calls_are_all_leaf_names() {
@@ -254,29 +279,31 @@ fn fixture_calls_are_all_leaf_names() {
         .expect("extract fixture");
     let call_edges = calls(&output);
 
-    // Regression invariant: attribute/method callees are always narrowed, so a
-    // dotted dst_name would mean the narrowing broke.
+    // Regression invariant: attribute/method callees are narrowed unless the
+    // receiver is `self`/`cls`, whose dispatch class is known — those emit the
+    // `Class.method` form. Any other dotted dst_name means the narrowing broke.
     let dotted: Vec<&str> = call_edges
         .iter()
         .map(|r| r.dst_name.as_str())
-        .filter(|n| n.contains('.'))
+        .filter(|n| n.contains('.') && *n != "Service.validate")
         .collect();
     assert!(
         dotted.is_empty(),
-        "Calls dst_names must be simple identifiers, but got dotted: {:?}",
+        "Calls dst_names must be simple identifiers (or self/cls-qualified \
+         Class.method), but got dotted: {:?}",
         dotted
     );
 
-    // Every call shape in the matrix is represented as a leaf name.
+    // Every call shape in the matrix is represented.
     for expected in &[
-        "handler",       // bare call in plain()
-        "add_url_rule",  // attribute call on a local (app.add_url_rule)
-        "query",         // chained attribute call (db.session.query())
-        "save",          // attribute call on an instance member (self.store.save)
-        "validate",      // self-call (self.validate)
-        "Store",         // constructor call
-        "route",         // decorator call @app.route(...)
-        "requires_auth", // bare decorator @requires_auth
+        "handler",          // bare call in plain()
+        "add_url_rule",     // attribute call on a local (app.add_url_rule)
+        "query",            // chained attribute call (db.session.query())
+        "save",             // attribute call on an instance member (self.store.save)
+        "Service.validate", // self-call (self.validate) — class-qualified
+        "Store",            // constructor call
+        "route",            // decorator call @app.route(...)
+        "requires_auth",    // bare decorator @requires_auth
     ] {
         assert!(
             call_edges.iter().any(|r| r.dst_name == *expected),


### PR DESCRIPTION
## Summary
- Python `self.m()` / `cls.m()` callees are extracted class-qualified (`EnclosingClass.m`), giving the linker the dispatch class the call actually goes through.
- The linker gains an inheritance-aware receiver-method tier: when the owner names a class in the calling file and the method is not defined locally, it walks the class's `Extends` chain (BFS, cycle-guarded, bounded, never guessing an ambiguous base) to the defining ancestor and links at confidence 0.85 — above the review strong-consumer floor, so the edge drives verdicts.
- Parity across all three linking paths: batch, incremental (step-local hierarchy overlay mirroring the include-graph pattern), and reopened graphs (hierarchy rehydrated from committed `Extends` edges). Base ordering is uniformly lexicographic so every path resolves bit-identically.
- Local overrides still win at full confidence; unknown receivers (`obj.m()`, chained attributes) keep their existing behavior; unresolvable hierarchies fall back to the bare-leaf fan-out so recall never regresses.
- Removed-API breaking findings now count inheritance-reached consumers (extends the 0.2.10 removed-entity rule to the FIR-1342 class).

Fixes FIR-1342. Real-graph validation: django `0f169098ef` (removes `BaseCommand.validate()` with a live `self.validate()` caller in `runserver.py`) must flip to FLAG; benign `c042fe3a74` must stay pass — dev-lane run on a fresh django graph in flight, results on the ticket.

## Tests
- kin-parser: self/cls qualification, non-self receivers stay bare, conformance + fixture updates (345 green).
- kin-index: the 0f16 shape cross-file (asserting verdict-driving confidence), same-file base, override shadowing, transitive chain, external-base fallback to fan-out, cycle termination, incremental batch-parity, cross-step hierarchy persistence (all green).
- Full workspace: fmt, clippy (ci.yml allowlist), build --all-targets, 50 test suites green.