### PR TITLE
chore(release): bump to 0.2.11 — Python inheritance-aware dispatch resolution

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.2.11] - 2026-07-06
+
+Python inheritance-aware dispatch: the graph now knows that a subclass calling an inherited method consumes the ancestor that defines it.
+
 ### Fixed
 
 - Python method calls dispatched through `self`/`cls` now resolve through the class's

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3039,11 +3039,11 @@ dependencies = [
 
 [[package]]
 name = "kin-buildinfo"
-version = "0.2.10"
+version = "0.2.11"
 
 [[package]]
 name = "kin-cli"
-version = "0.2.10"
+version = "0.2.11"
 dependencies = [
  "age",
  "anyhow",
@@ -3110,7 +3110,7 @@ dependencies = [
 
 [[package]]
 name = "kin-context"
-version = "0.2.10"
+version = "0.2.11"
 dependencies = [
  "kin-blobs",
  "kin-db",
@@ -3126,7 +3126,7 @@ dependencies = [
 
 [[package]]
 name = "kin-core"
-version = "0.2.10"
+version = "0.2.11"
 dependencies = [
  "chrono",
  "directories 5.0.1",
@@ -3150,7 +3150,7 @@ dependencies = [
 
 [[package]]
 name = "kin-daemon"
-version = "0.2.10"
+version = "0.2.11"
 dependencies = [
  "async-stream",
  "axum",
@@ -3239,7 +3239,7 @@ dependencies = [
 
 [[package]]
 name = "kin-git"
-version = "0.2.10"
+version = "0.2.11"
 dependencies = [
  "chrono",
  "gix",
@@ -3257,7 +3257,7 @@ dependencies = [
 
 [[package]]
 name = "kin-index"
-version = "0.2.10"
+version = "0.2.11"
 dependencies = [
  "hex",
  "kin-blobs",
@@ -3303,7 +3303,7 @@ dependencies = [
 
 [[package]]
 name = "kin-integration-tests"
-version = "0.2.10"
+version = "0.2.11"
 dependencies = [
  "kin-blobs",
  "kin-cli",
@@ -3345,7 +3345,7 @@ dependencies = [
 
 [[package]]
 name = "kin-mcp"
-version = "0.2.10"
+version = "0.2.11"
 dependencies = [
  "kin-blobs",
  "kin-context",
@@ -3372,7 +3372,7 @@ dependencies = [
 
 [[package]]
 name = "kin-migrate"
-version = "0.2.10"
+version = "0.2.11"
 dependencies = [
  "chrono",
  "kin-blobs",
@@ -3414,7 +3414,7 @@ dependencies = [
 
 [[package]]
 name = "kin-parser"
-version = "0.2.10"
+version = "0.2.11"
 dependencies = [
  "kin-model",
  "pretty_assertions",
@@ -3443,7 +3443,7 @@ dependencies = [
 
 [[package]]
 name = "kin-projection"
-version = "0.2.10"
+version = "0.2.11"
 dependencies = [
  "kin-blobs",
  "kin-db",
@@ -3458,7 +3458,7 @@ dependencies = [
 
 [[package]]
 name = "kin-ranking"
-version = "0.2.10"
+version = "0.2.11"
 dependencies = [
  "kin-model",
  "serde",
@@ -3467,7 +3467,7 @@ dependencies = [
 
 [[package]]
 name = "kin-reconcile"
-version = "0.2.10"
+version = "0.2.11"
 dependencies = [
  "kin-blobs",
  "kin-db",
@@ -3487,7 +3487,7 @@ dependencies = [
 
 [[package]]
 name = "kin-registry"
-version = "0.2.10"
+version = "0.2.11"
 dependencies = [
  "axum",
  "base64 0.22.1",
@@ -3512,7 +3512,7 @@ dependencies = [
 
 [[package]]
 name = "kin-remote"
-version = "0.2.10"
+version = "0.2.11"
 dependencies = [
  "chrono",
  "kin-model",
@@ -3528,7 +3528,7 @@ dependencies = [
 
 [[package]]
 name = "kin-review"
-version = "0.2.10"
+version = "0.2.11"
 dependencies = [
  "kin-blobs",
  "kin-db",
@@ -3544,7 +3544,7 @@ dependencies = [
 
 [[package]]
 name = "kin-runtime"
-version = "0.2.10"
+version = "0.2.11"
 dependencies = [
  "chrono",
  "hex",
@@ -3576,7 +3576,7 @@ dependencies = [
 
 [[package]]
 name = "kin-semantic-contracts"
-version = "0.2.10"
+version = "0.2.11"
 dependencies = [
  "kin-db",
  "kin-model",
@@ -3591,7 +3591,7 @@ dependencies = [
 
 [[package]]
 name = "kin-spine"
-version = "0.2.10"
+version = "0.2.11"
 dependencies = [
  "chrono",
  "hashbrown 0.15.5",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,7 +27,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.2.10"
+version = "0.2.11"
 edition = "2021"
 license = "Apache-2.0"
 authors = ["Troy Fortin <troy@firelock.ai>"]

--- a/packages/kin-mcp/package.json
+++ b/packages/kin-mcp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kinlab/kin-mcp",
-  "version": "0.2.10",
+  "version": "0.2.11",
   "description": "Start Kin's MCP server through an npm-friendly wrapper.",
   "type": "module",
   "bin": {


### PR DESCRIPTION
Release 0.2.11: Python `self`/`cls` calls resolve through the class's Extends chain to the defining ancestor across batch, incremental, and reopened-graph linking (FIR-1342, PR #234) — deleting an inherited-but-consumed API now flags as breaking.

Bump: workspace Cargo.toml + 20 lock members + kin-mcp package.json + CHANGELOG (0.2.11 section). Lock audited: version lines only, all external kin-* deps keep sparse-registry sources + checksums. `kin-dev release-check` on merged main: RELEASE-CLEAN.

On merge: auto-tag-release cuts v0.2.11 → release workflow publishes → proof bundle sealed from the tag → citable slice re-validation (0f16 FLAG, c042 PASS, controls) → v7.