### PR TITLE
perf(review): resolve shadow head before base so ancestor pairs hydrate history once

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- `kin review shadow` resolves the head ref before the base ref, so an
+  ancestor..descendant pair (the common review shape) hydrates git history in a
+  single pass instead of re-walking the ancestry for each side — first reviews on
+  large-history repos start substantially faster.
+
 ## [0.2.11] - 2026-07-06
 
 Python inheritance-aware dispatch: the graph now knows that a subclass calling an inherited method consumes the ancestor that defines it.

--- a/crates/kin-cli/src/commands/review.rs
+++ b/crates/kin-cli/src/commands/review.rs
@@ -298,13 +298,10 @@ fn build_shadow_run_response(
     author: Option<String>,
     json: bool,
 ) -> Result<(ReviewResponse, bool)> {
-    let resolved_base =
-        crate::commands::ref_lookup::resolve_ref_importing_git_if_needed_with_report(
-            graph,
-            layout,
-            Some(base.as_str()),
-        )
-        .with_context(|| format!("resolve shadow base ref '{}'", base))?;
+    // Resolve the head ref before the base ref. A review pair is almost always
+    // ancestor..descendant, so importing the head first hydrates the full git
+    // ancestry in a single pass; the base is then already present in the graph
+    // and resolves on the fast path instead of re-walking the shared history.
     let resolved_head =
         crate::commands::ref_lookup::resolve_ref_importing_git_if_needed_with_report(
             graph,
@@ -312,6 +309,13 @@ fn build_shadow_run_response(
             Some(head.as_str()),
         )
         .with_context(|| format!("resolve shadow head ref '{}'", head))?;
+    let resolved_base =
+        crate::commands::ref_lookup::resolve_ref_importing_git_if_needed_with_report(
+            graph,
+            layout,
+            Some(base.as_str()),
+        )
+        .with_context(|| format!("resolve shadow base ref '{}'", base))?;
     let hydrated_git_history =
         resolved_base.hydrated_git_history || resolved_head.hydrated_git_history;
 

--- a/crates/kin-cli/tests/review_shadow_json.rs
+++ b/crates/kin-cli/tests/review_shadow_json.rs
@@ -7,6 +7,9 @@
 //! fail-loud contract: a change the graph cannot see must surface as an
 //! explicit evidence gap, never as a silent pass.
 
+use kin_cli::commands::ref_lookup::{
+    git_ref_requires_hydration, resolve_ref_importing_git_if_needed_with_report,
+};
 use serde_json::Value;
 use std::path::Path;
 use std::process::Command;
@@ -276,5 +279,65 @@ fn shadow_report_fails_loud_on_unknown_ref() {
         !output.status.success(),
         "unknown base ref must fail loud, got stdout={}",
         String::from_utf8_lossy(&output.stdout)
+    );
+}
+
+/// A review pair is almost always ancestor..descendant, and `review shadow`
+/// resolves the head ref before the base ref so that ancestry hydrates in a
+/// single pass. This proves the invariant that makes head-first cheap: once the
+/// head is imported, its ancestor base is already in the graph and needs no
+/// second hydration, so the base resolve takes the fast path with no re-walk of
+/// the shared history. Base-first and head-first yield the same graph state and
+/// the same `hydrated_git_history` union — the only difference is that head-first
+/// avoids re-importing the ancestry the base and head share.
+#[test]
+fn shadow_head_import_hydrates_ancestor_base_in_single_pass() {
+    let dir = tempdir().expect("tempdir");
+    let repo = dir.path();
+    // `base` -> `head` is a linear ancestor pair (head's parent is base).
+    let (base, head, _artifact_head) = setup_fixture_repo(repo);
+    kin_init(repo);
+
+    // A fresh in-memory graph: the git commits exist on disk, but neither ref is
+    // imported as a semantic change yet, so both would require hydration.
+    let layout = kin_core::KinLayout::new(repo.join(".kin"));
+    let graph = kin_db::InMemoryGraph::new();
+    assert!(
+        git_ref_requires_hydration(&graph, &head),
+        "head must require hydration before any import"
+    );
+    assert!(
+        git_ref_requires_hydration(&graph, &base),
+        "base must require hydration before any import"
+    );
+
+    // Resolve ONLY the head. Its import walks genesis..head, which contains base.
+    let resolved_head =
+        resolve_ref_importing_git_if_needed_with_report(&graph, &layout, Some(head.as_str()))
+            .expect("resolve head imports its git ancestry");
+    assert!(
+        resolved_head.hydrated_git_history,
+        "resolving the head on a fresh graph must hydrate git history"
+    );
+
+    // Single-pass invariant: base is now already present, so it needs no further
+    // hydration — the head's import subsumed the ancestor.
+    assert!(
+        !git_ref_requires_hydration(&graph, &base),
+        "after importing the head, its ancestor base must need no second pass"
+    );
+
+    // Resolving the base now takes the fast path: it resolves to a distinct
+    // change without re-walking (hydrated_git_history == false).
+    let resolved_base =
+        resolve_ref_importing_git_if_needed_with_report(&graph, &layout, Some(base.as_str()))
+            .expect("resolve base after head takes the fast path");
+    assert!(
+        !resolved_base.hydrated_git_history,
+        "base must resolve without a second hydration pass"
+    );
+    assert_ne!(
+        resolved_base.head, resolved_head.head,
+        "base and head must resolve to distinct semantic changes"
     );
 }


### PR DESCRIPTION
## Summary
`kin review shadow` resolves the head ref before the base ref. A review pair is almost always ancestor..descendant (merge-trust scenarios are always base=head^), so importing the head first hydrates the full git ancestry in one pass — the base then resolves on the fast path (`get_change` hit) instead of re-walking the shared history. Pure ordering change: the two resolves are independent lookups, the resulting graph state is the same union of imported changes, and head-first enriches the ancestry as one continuous genesis→head pass (the same chronological sequence the two-pass path produced).

Measured motivation (django, 32,865 commits): 33.7 min hydration with cross-file linking at 48%, plus a ~20 min avoidable second-pass re-walk observed on first-touch reviews (FIR-1262).

Single change site: `build_shadow_run_response` serves both the CLI path and the daemon's `/review` handler via `execute_review_request`.

## Tests
- New `shadow_head_import_hydrates_ancestor_base_in_single_pass` proves the enabling invariant on a real temp repo: resolving only the head imports the ancestry; the ancestor base then requires no hydration and resolves fast-path. (A black-box assertion of the ordering itself is impossible for a pure-perf change — the invariant plus the durable comment guard it.)
- kin-cli: 711 lib + all integration targets green. kin-daemon: 305 + integration green (consumes the shared path).
- Determinism proof rides the 0.2.12 sealed slice: n=3 bit-identity + byte-comparison against the 0.2.11 slice's canonical row hashes on identical scenarios.

Fixes the first rung of FIR-1262 (suffix hydration, init prewarm, and checkpointed snapshots remain on the ticket).