### PR TITLE
feat(review): revert-history evidence channel for shadow review

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Revert-history review channel: shadow review flags revert-shaped changes — an added
+  entity that restores content removed in the recent past (behavior-fingerprint match),
+  a reintroduction of a recently-removed surface (same name and kind, modified content),
+  and removals of recently-introduced entities. The evidence is temporal, read from a
+  bounded window of the base ref's ancestry at review time, and feeds the gate as
+  ordinary warning findings; when the base has too little history to scan, the report
+  carries an explicit evidence gap instead of a silent pass.
+
 ## [0.2.13] - 2026-07-07
 
 Distribution becomes first-class: Kin installs from npm as `@kinlab/kin`, doctor heals its own VFS shim, and history hydration gains parse reuse and a timing profile.
@@ -32,6 +42,17 @@ Distribution becomes first-class: Kin installs from npm as `@kinlab/kin`, doctor
 ### Security
 
 - crossbeam-epoch updated to 0.9.20 (RUSTSEC-2026-0204).
+=======
+### Added
+
+- Revert-history review channel: shadow review flags revert-shaped changes — an added
+  entity that restores content removed in the recent past (behavior-fingerprint match),
+  a reintroduction of a recently-removed surface (same name and kind, modified content),
+  and removals of recently-introduced entities. The evidence is temporal, read from a
+  bounded window of the base ref's ancestry at review time, and feeds the gate as
+  ordinary warning findings; when the base has too little history to scan, the report
+  carries an explicit evidence gap instead of a silent pass.
+>>>>>>> fbfdd830 (feat(review): revert-history evidence channel for shadow review)
 
 ## [0.2.12] - 2026-07-06
 

--- a/crates/kin-cli/src/commands/review.rs
+++ b/crates/kin-cli/src/commands/review.rs
@@ -1192,7 +1192,9 @@ fn inline_comment_severity(kind: kin_review::InlineCommentKind) -> &'static str 
         | InlineCommentKind::Renamed
         | InlineCommentKind::AgentUnreviewed
         | InlineCommentKind::RevertHistory => "warning",
-        InlineCommentKind::Added | InlineCommentKind::Removed => "info",
+        InlineCommentKind::Added
+        | InlineCommentKind::Removed
+        | InlineCommentKind::RevertHistoryIncidental => "info",
     }
 }
 

--- a/crates/kin-cli/src/commands/review.rs
+++ b/crates/kin-cli/src/commands/review.rs
@@ -1190,7 +1190,8 @@ fn inline_comment_severity(kind: kin_review::InlineCommentKind) -> &'static str 
         | InlineCommentKind::ToolchainSurfaceChange
         | InlineCommentKind::ConsumerFanout
         | InlineCommentKind::Renamed
-        | InlineCommentKind::AgentUnreviewed => "warning",
+        | InlineCommentKind::AgentUnreviewed
+        | InlineCommentKind::RevertHistory => "warning",
         InlineCommentKind::Added | InlineCommentKind::Removed => "info",
     }
 }

--- a/crates/kin-review/src/inline.rs
+++ b/crates/kin-review/src/inline.rs
@@ -37,6 +37,7 @@ pub enum InlineCommentKind {
     Renamed,
     AgentUnreviewed,
     ToolchainSurfaceChange,
+    RevertHistory,
 }
 
 impl InlineCommentKind {
@@ -53,6 +54,7 @@ impl InlineCommentKind {
             Self::Removed => "-",
             Self::Renamed => "~",
             Self::AgentUnreviewed => "@",
+            Self::RevertHistory => "~",
             Self::ToolchainSurfaceChange => "~",
         }
     }

--- a/crates/kin-review/src/inline.rs
+++ b/crates/kin-review/src/inline.rs
@@ -38,6 +38,7 @@ pub enum InlineCommentKind {
     AgentUnreviewed,
     ToolchainSurfaceChange,
     RevertHistory,
+    RevertHistoryIncidental,
 }
 
 impl InlineCommentKind {
@@ -55,6 +56,7 @@ impl InlineCommentKind {
             Self::Renamed => "~",
             Self::AgentUnreviewed => "@",
             Self::RevertHistory => "~",
+            Self::RevertHistoryIncidental => "~",
             Self::ToolchainSurfaceChange => "~",
         }
     }

--- a/crates/kin-review/src/lib.rs
+++ b/crates/kin-review/src/lib.rs
@@ -9,6 +9,7 @@ pub mod impact;
 pub mod inline;
 pub mod ref_graph;
 pub mod release_gate;
+pub mod revert_history;
 pub mod review;
 pub mod risk;
 pub mod shadow;

--- a/crates/kin-review/src/revert_history.rs
+++ b/crates/kin-review/src/revert_history.rs
@@ -96,6 +96,7 @@ pub(crate) fn collect_revert_history_findings<G: GraphStore>(
     let mut head_added: BTreeMap<(String, String), Entity> = BTreeMap::new();
     let mut head_removed: Vec<EntityId> = Vec::new();
     let mut seen_removed: HashSet<EntityId> = HashSet::new();
+    let mut head_modified: BTreeMap<String, (Entity, Entity)> = BTreeMap::new();
     for change in range_changes {
         for delta in &change.entity_deltas {
             match delta {
@@ -109,12 +110,77 @@ pub(crate) fn collect_revert_history_findings<G: GraphStore>(
                         head_removed.push(*id);
                     }
                 }
-                EntityDelta::Modified { .. } => {}
+                EntityDelta::Modified { old, new } => {
+                    // Multiple range changes touching one entity collapse to
+                    // the net old→new pair: earliest old, latest new.
+                    head_modified
+                        .entry(new.name.clone())
+                        .and_modify(|(_, latest)| *latest = new.clone())
+                        .or_insert_with(|| (old.clone(), new.clone()));
+                }
             }
         }
     }
 
     let mut findings = Vec::new();
+
+    // Body reversions: a modified entity whose NEW body equals a body it
+    // carried at an OLDER revision — the head un-does a later edit. This is
+    // the dominant real-world revert shape (git revert of a body change
+    // produces a Modified delta, not add/remove). The immediately-previous
+    // body is skipped: every edit trivially differs from its predecessor;
+    // only a return to DEEPER history is revert-shaped. Hash equality on the
+    // behavior fingerprint makes the match exact, so this cannot fire on an
+    // ordinary edit.
+    for (name, (old, new)) in &head_modified {
+        if new.fingerprint.behavior_hash == old.fingerprint.behavior_hash {
+            continue;
+        }
+        let history = match store.get_entity_history(&old.id) {
+            Ok(h) => h,
+            Err(_) => continue,
+        };
+        // Bodies this entity carried before the range, newest-first, capped by
+        // the window. Position 0 is the body the range started from (old) —
+        // matching it would be a no-op edit, so matches start at depth 1.
+        let mut prior_bodies: Vec<Hash256> = Vec::new();
+        for change in history.iter().rev() {
+            if prior_bodies.len() > REVERT_HISTORY_WINDOW {
+                break;
+            }
+            for delta in &change.entity_deltas {
+                match delta {
+                    EntityDelta::Modified { old: o, new: n } if n.id == old.id => {
+                        if prior_bodies.is_empty() {
+                            prior_bodies.push(n.fingerprint.behavior_hash);
+                        }
+                        prior_bodies.push(o.fingerprint.behavior_hash);
+                    }
+                    EntityDelta::Added(e) if e.id == old.id => {
+                        if prior_bodies.is_empty() {
+                            prior_bodies.push(e.fingerprint.behavior_hash);
+                        }
+                    }
+                    _ => {}
+                }
+            }
+        }
+        if let Some(depth) = prior_bodies
+            .iter()
+            .skip(1)
+            .position(|h| *h == new.fingerprint.behavior_hash)
+        {
+            findings.push(inline_finding(
+                new,
+                format!(
+                    "Modified `{}` restores the exact body it had {} revision(s) ago — \
+                     revert-shaped body reversion",
+                    name,
+                    depth + 1
+                ),
+            ));
+        }
+    }
 
     // Reintroductions: an added entity matching a window removal. Removed
     // deltas carry only the id, so each candidate is resolved to its last full

--- a/crates/kin-review/src/revert_history.rs
+++ b/crates/kin-review/src/revert_history.rs
@@ -132,6 +132,15 @@ pub(crate) fn collect_revert_history_findings<G: GraphStore>(
     // only a return to DEEPER history is revert-shaped. Hash equality on the
     // behavior fingerprint makes the match exact, so this cannot fire on an
     // ordinary edit.
+    //
+    // Matches are grouped by the SEMANTIC CHANGE whose delta carried the
+    // matching old body. A true revert restores a coherent snapshot: several
+    // of the head's entities return to bodies from the same historical change.
+    // An isolated single-entity match is usually incidental — small bodies
+    // recur naturally over long histories — so only COHERENT groups (two or
+    // more entities reverting to the same change) gate the verdict; singleton
+    // matches are still reported, at info severity, for the reviewer.
+    let mut reversion_matches: Vec<(Entity, String, SemanticChangeId, usize)> = Vec::new();
     for (name, (old, new)) in &head_modified {
         if new.fingerprint.behavior_hash == old.fingerprint.behavior_hash {
             continue;
@@ -141,9 +150,10 @@ pub(crate) fn collect_revert_history_findings<G: GraphStore>(
             Err(_) => continue,
         };
         // Bodies this entity carried before the range, newest-first, capped by
-        // the window. Position 0 is the body the range started from (old) —
-        // matching it would be a no-op edit, so matches start at depth 1.
-        let mut prior_bodies: Vec<Hash256> = Vec::new();
+        // the window, each tagged with the change that introduced it. Position
+        // 0 is the body the range started from (old) — matching it would be a
+        // no-op edit, so matches start at depth 1.
+        let mut prior_bodies: Vec<(Hash256, SemanticChangeId)> = Vec::new();
         for change in history.iter().rev() {
             if prior_bodies.len() > REVERT_HISTORY_WINDOW {
                 break;
@@ -152,34 +162,53 @@ pub(crate) fn collect_revert_history_findings<G: GraphStore>(
                 match delta {
                     EntityDelta::Modified { old: o, new: n } if n.id == old.id => {
                         if prior_bodies.is_empty() {
-                            prior_bodies.push(n.fingerprint.behavior_hash);
+                            prior_bodies.push((n.fingerprint.behavior_hash, change.id));
                         }
-                        prior_bodies.push(o.fingerprint.behavior_hash);
+                        // The OLD body was the entity's state BEFORE this
+                        // change; restoring it un-does this change.
+                        prior_bodies.push((o.fingerprint.behavior_hash, change.id));
                     }
                     EntityDelta::Added(e) if e.id == old.id => {
                         if prior_bodies.is_empty() {
-                            prior_bodies.push(e.fingerprint.behavior_hash);
+                            prior_bodies.push((e.fingerprint.behavior_hash, change.id));
                         }
                     }
                     _ => {}
                 }
             }
         }
-        if let Some(depth) = prior_bodies
+        if let Some((depth, (_, undone_change))) = prior_bodies
             .iter()
+            .enumerate()
             .skip(1)
-            .position(|h| *h == new.fingerprint.behavior_hash)
+            .find(|(_, (h, _))| *h == new.fingerprint.behavior_hash)
         {
-            findings.push(inline_finding(
-                new,
-                format!(
-                    "Modified `{}` restores the exact body it had {} revision(s) ago — \
-                     revert-shaped body reversion",
-                    name,
-                    depth + 1
-                ),
-            ));
+            reversion_matches.push((new.clone(), name.clone(), *undone_change, depth));
         }
+    }
+
+    let mut undone_counts: HashMap<SemanticChangeId, usize> = HashMap::new();
+    for (_, _, undone, _) in &reversion_matches {
+        *undone_counts.entry(*undone).or_insert(0) += 1;
+    }
+    for (entity, name, undone, depth) in &reversion_matches {
+        let coherent = undone_counts.get(undone).copied().unwrap_or(0) >= 2;
+        let message = format!(
+            "Modified `{}` restores the exact body it had {} revision(s) ago{} — \
+             revert-shaped body reversion",
+            name,
+            depth,
+            if coherent {
+                ", together with other entities un-doing the same change"
+            } else {
+                ""
+            },
+        );
+        let mut finding = inline_finding(entity, message);
+        if !coherent {
+            finding.kind = InlineCommentKind::RevertHistoryIncidental;
+        }
+        findings.push(finding);
     }
 
     // Reintroductions: an added entity matching a window removal. Removed

--- a/crates/kin-review/src/revert_history.rs
+++ b/crates/kin-review/src/revert_history.rs
@@ -1,0 +1,302 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Firelock, LLC
+
+//! Revert-history evidence channel for shadow review.
+//!
+//! A change that RE-INTRODUCES an entity removed in the recent past, or that
+//! REMOVES an entity introduced in the recent past, is revert-shaped: its risk
+//! evidence is temporal, not structural. Structurally such a change reads as an
+//! ordinary addition or removal — additions in particular carry no gating
+//! signal at all — so without this channel the gate is blind to exactly the
+//! class regression-fix and revert commits fall into.
+//!
+//! The channel walks a bounded window of the BASE ref's ancestry (evidence
+//! available at review time; whether a commit will be reverted LATER is future
+//! information and is never consulted) and matches:
+//!
+//! - head-side ADDED entities against entities removed inside the window —
+//!   a behavior-fingerprint match means the added body restores removed
+//!   content verbatim (strong); a name+kind match means the same surface is
+//!   reintroduced with modified content (weak). Both are review-worthy.
+//! - head-side REMOVED entities against entities added inside the window —
+//!   deleting something that only just landed is the shape of a revert of a
+//!   recent feature.
+//!
+//! Findings feed the gate as ordinary warning findings through the
+//! inline-comment channel (the same shape as the command-effect and
+//! toolchain-surface channels), never through evidence-gap demotion. When the
+//! base has less history than the window can meaningfully scan, the channel
+//! reports an honest evidence gap instead of silently passing.
+//!
+//! Matching is computed at review time from the change DAG and the entity
+//! revision store. Persisting the same evidence as graph relations
+//! (Reverts/RegressedBy edges written by an ingest-time miner) is the durable
+//! follow-on; the review-time computation here is the channel's semantic
+//! contract and stays the oracle for that miner.
+
+use std::collections::{BTreeMap, HashMap, HashSet, VecDeque};
+
+use kin_model::change::{EntityDelta, SemanticChange};
+use kin_model::graph::GraphStore;
+use kin_model::{Entity, EntityId, EntityKind, Hash256, SemanticChangeId};
+
+use crate::error::ReviewError;
+use crate::inline::{InlineComment, InlineCommentKind};
+use crate::shadow::ShadowEvidenceGap;
+
+/// How many ancestry changes before the base the channel scans. Deep enough to
+/// catch release-cycle reverts and regression fixes; bounded so review cost
+/// stays flat on large histories.
+const REVERT_HISTORY_WINDOW: usize = 250;
+
+/// Below this much available ancestry the scan cannot say anything meaningful
+/// about revert history, so the channel reports a gap rather than certifying
+/// silence.
+const REVERT_HISTORY_MIN_DEPTH: usize = 25;
+
+/// Upper bound on removed-entity resolutions per review. Each resolution is a
+/// revision-history lookup; windows are small in practice and this cap only
+/// guards pathological histories.
+const MAX_REMOVED_RESOLUTIONS: usize = 512;
+
+/// One removed-entity occurrence inside the scanned window.
+struct WindowRemoval {
+    entity_id: EntityId,
+    /// 1-based distance from the base (1 = the change immediately before base).
+    distance: usize,
+}
+
+/// Revert-history findings plus an optional honesty gap for the scanned base.
+pub(crate) fn collect_revert_history_findings<G: GraphStore>(
+    store: &G,
+    resolved_base: &SemanticChangeId,
+    range_changes: &[SemanticChange],
+) -> Result<(Vec<InlineComment>, Option<ShadowEvidenceGap>), ReviewError> {
+    let window = walk_base_window(store, resolved_base)?;
+
+    let gap = if window.changes_scanned < REVERT_HISTORY_MIN_DEPTH {
+        Some(ShadowEvidenceGap {
+            kind: "revert_history_shallow".to_string(),
+            subject: "blast_radius.revert_history".to_string(),
+            detail: format!(
+                "only {} change(s) of history exist before the base (window {}); \
+                 revert/reintroduction evidence cannot be assessed and is NOT part \
+                 of this verdict",
+                window.changes_scanned, REVERT_HISTORY_WINDOW
+            ),
+        })
+    } else {
+        None
+    };
+
+    // Head-side deltas for the reviewed range, deduplicated and order-stable.
+    let mut head_added: BTreeMap<(String, String), Entity> = BTreeMap::new();
+    let mut head_removed: Vec<EntityId> = Vec::new();
+    let mut seen_removed: HashSet<EntityId> = HashSet::new();
+    for change in range_changes {
+        for delta in &change.entity_deltas {
+            match delta {
+                EntityDelta::Added(entity) => {
+                    head_added
+                        .entry((kind_key(entity.kind), entity.name.clone()))
+                        .or_insert_with(|| entity.clone());
+                }
+                EntityDelta::Removed(id) => {
+                    if seen_removed.insert(*id) {
+                        head_removed.push(*id);
+                    }
+                }
+                EntityDelta::Modified { .. } => {}
+            }
+        }
+    }
+
+    let mut findings = Vec::new();
+
+    // Reintroductions: an added entity matching a window removal. Removed
+    // deltas carry only the id, so each candidate is resolved to its last full
+    // value through the revision history — lazily, nearest-first, and cached,
+    // so cost tracks matches rather than window size.
+    if !head_added.is_empty() && !window.removals.is_empty() {
+        let mut resolved: HashMap<EntityId, Option<Entity>> = HashMap::new();
+        let mut by_hash: HashMap<Hash256, (String, usize)> = HashMap::new();
+        let mut by_name: HashMap<(String, String), usize> = HashMap::new();
+        let budget = window.removals.len().min(MAX_REMOVED_RESOLUTIONS);
+        for removal in window.removals.iter().take(budget) {
+            let entity = resolved
+                .entry(removal.entity_id)
+                .or_insert_with(|| last_known_entity(store, &removal.entity_id));
+            let Some(entity) = entity else { continue };
+            by_hash
+                .entry(entity.fingerprint.behavior_hash)
+                .or_insert((entity.name.clone(), removal.distance));
+            by_name
+                .entry((kind_key(entity.kind), entity.name.clone()))
+                .or_insert(removal.distance);
+        }
+
+        for ((kind, name), added) in &head_added {
+            let finding = if let Some((removed_name, distance)) =
+                by_hash.get(&added.fingerprint.behavior_hash)
+            {
+                Some(format!(
+                    "Added `{}` restores the exact content of `{}`, removed {} change(s) \
+                     before the base — revert-shaped reintroduction",
+                    name, removed_name, distance
+                ))
+            } else {
+                by_name.get(&(kind.clone(), name.clone())).map(|distance| {
+                    format!(
+                        "Added `{}` reintroduces a same-named {} removed {} change(s) \
+                         before the base, with modified content — revert-shaped surface",
+                        name,
+                        kind_label(added.kind),
+                        distance
+                    )
+                })
+            };
+            if let Some(message) = finding {
+                findings.push(inline_finding(added, message));
+            }
+        }
+    }
+
+    // Recent-addition removals: a removed entity whose id was introduced
+    // inside the window. Ids are location-keyed, so this matches the common
+    // revert shape where the added lines are deleted in place.
+    for removed_id in &head_removed {
+        if let Some(distance) = window.added_ids.get(removed_id) {
+            let name = last_known_entity(store, removed_id)
+                .map(|e| e.name)
+                .unwrap_or_else(|| "entity".to_string());
+            findings.push(InlineComment {
+                file: String::new(),
+                start_line: 0,
+                end_line: 0,
+                kind: InlineCommentKind::RevertHistory,
+                message: format!(
+                    "Removed `{}` was introduced only {} change(s) before the base — \
+                     revert-shaped removal of a recent addition",
+                    name, distance
+                ),
+            });
+        }
+    }
+
+    Ok((findings, gap))
+}
+
+/// Everything the channel learned from scanning the base's ancestry window.
+struct BaseWindow {
+    changes_scanned: usize,
+    removals: Vec<WindowRemoval>,
+    /// Entity ids ADDED inside the window, with their distance from the base.
+    added_ids: HashMap<EntityId, usize>,
+}
+
+/// Bounded, deterministic walk of the base's ancestry: breadth-first from the
+/// base's parents, parents visited in their declared order, capped at
+/// [`REVERT_HISTORY_WINDOW`] changes. Distance is the BFS depth, so "N
+/// change(s) before the base" reads naturally on linear history and stays
+/// deterministic across merges.
+fn walk_base_window<G: GraphStore>(
+    store: &G,
+    resolved_base: &SemanticChangeId,
+) -> Result<BaseWindow, ReviewError> {
+    let mut removals = Vec::new();
+    let mut added_ids = HashMap::new();
+    let mut visited: HashSet<SemanticChangeId> = HashSet::new();
+    let mut queue: VecDeque<(SemanticChangeId, usize)> = VecDeque::new();
+
+    if let Some(base) = store
+        .get_change(resolved_base)
+        .map_err(ReviewError::graph)?
+    {
+        for parent in &base.parents {
+            queue.push_back((*parent, 1));
+        }
+    }
+    visited.insert(*resolved_base);
+
+    let mut scanned = 0usize;
+    while let Some((id, distance)) = queue.pop_front() {
+        if scanned >= REVERT_HISTORY_WINDOW {
+            break;
+        }
+        if !visited.insert(id) {
+            continue;
+        }
+        let Some(change) = store.get_change(&id).map_err(ReviewError::graph)? else {
+            continue;
+        };
+        scanned += 1;
+        for delta in &change.entity_deltas {
+            match delta {
+                EntityDelta::Removed(entity_id) => removals.push(WindowRemoval {
+                    entity_id: *entity_id,
+                    distance,
+                }),
+                EntityDelta::Added(entity) => {
+                    added_ids.entry(entity.id).or_insert(distance);
+                }
+                EntityDelta::Modified { .. } => {}
+            }
+        }
+        for parent in &change.parents {
+            queue.push_back((*parent, distance + 1));
+        }
+    }
+
+    Ok(BaseWindow {
+        changes_scanned: scanned,
+        removals,
+        added_ids,
+    })
+}
+
+/// The last full value an entity carried before disappearing, recovered from
+/// the changes that touched it: the most recent Added or Modified delta whose
+/// entity matches the id.
+fn last_known_entity<G: GraphStore>(store: &G, id: &EntityId) -> Option<Entity> {
+    let history = store.get_entity_history(id).ok()?;
+    history.iter().rev().find_map(|change| {
+        change.entity_deltas.iter().find_map(|delta| match delta {
+            EntityDelta::Added(e) if e.id == *id => Some(e.clone()),
+            EntityDelta::Modified { new, .. } if new.id == *id => Some(new.clone()),
+            _ => None,
+        })
+    })
+}
+
+fn inline_finding(entity: &Entity, message: String) -> InlineComment {
+    let (file, start_line, end_line) = match (&entity.file_origin, &entity.span) {
+        (Some(file), Some(span)) => (file.0.clone(), span.start_line, span.end_line),
+        (Some(file), None) => (file.0.clone(), 0, 0),
+        _ => (String::new(), 0, 0),
+    };
+    InlineComment {
+        file,
+        start_line,
+        end_line,
+        kind: InlineCommentKind::RevertHistory,
+        message,
+    }
+}
+
+/// Stable string key for an entity kind (EntityKind carries no Ord).
+fn kind_key(kind: EntityKind) -> String {
+    format!("{:?}", kind)
+}
+
+fn kind_label(kind: EntityKind) -> &'static str {
+    match kind {
+        EntityKind::Function => "function",
+        EntityKind::Method => "method",
+        EntityKind::Class => "class",
+        EntityKind::Interface => "interface",
+        EntityKind::TraitDef => "trait",
+        EntityKind::Module => "module",
+        EntityKind::Constant => "constant",
+        _ => "entity",
+    }
+}

--- a/crates/kin-review/src/revert_history.rs
+++ b/crates/kin-review/src/revert_history.rs
@@ -10,9 +10,12 @@
 //! signal at all — so without this channel the gate is blind to exactly the
 //! class regression-fix and revert commits fall into.
 //!
-//! The channel walks a bounded window of the BASE ref's ancestry (evidence
-//! available at review time; whether a commit will be reverted LATER is future
-//! information and is never consulted) and matches:
+//! The channel walks a bounded window of the BASE ref's ancestry — including
+//! the base change itself, whose deltas are part of the state the head builds
+//! on (reverting the immediately-preceding change is the most common revert
+//! shape). Only evidence available at review time is consulted; whether a
+//! commit will be reverted LATER is future information and never enters. It
+//! matches:
 //!
 //! - head-side ADDED entities against entities removed inside the window —
 //!   a behavior-fingerprint match means the added body restores removed
@@ -140,18 +143,20 @@ pub(crate) fn collect_revert_history_findings<G: GraphStore>(
                 by_hash.get(&added.fingerprint.behavior_hash)
             {
                 Some(format!(
-                    "Added `{}` restores the exact content of `{}`, removed {} change(s) \
-                     before the base — revert-shaped reintroduction",
-                    name, removed_name, distance
+                    "Added `{}` restores the exact content of `{}`, removed {} — \
+                     revert-shaped reintroduction",
+                    name,
+                    removed_name,
+                    distance_phrase(*distance)
                 ))
             } else {
                 by_name.get(&(kind.clone(), name.clone())).map(|distance| {
                     format!(
-                        "Added `{}` reintroduces a same-named {} removed {} change(s) \
-                         before the base, with modified content — revert-shaped surface",
+                        "Added `{}` reintroduces a same-named {} removed {}, with \
+                         modified content — revert-shaped surface",
                         name,
                         kind_label(added.kind),
-                        distance
+                        distance_phrase(*distance)
                     )
                 })
             };
@@ -175,9 +180,10 @@ pub(crate) fn collect_revert_history_findings<G: GraphStore>(
                 end_line: 0,
                 kind: InlineCommentKind::RevertHistory,
                 message: format!(
-                    "Removed `{}` was introduced only {} change(s) before the base — \
-                     revert-shaped removal of a recent addition",
-                    name, distance
+                    "Removed `{}` was introduced only {} — revert-shaped removal \
+                     of a recent addition",
+                    name,
+                    distance_phrase(*distance)
                 ),
             });
         }
@@ -208,15 +214,10 @@ fn walk_base_window<G: GraphStore>(
     let mut visited: HashSet<SemanticChangeId> = HashSet::new();
     let mut queue: VecDeque<(SemanticChangeId, usize)> = VecDeque::new();
 
-    if let Some(base) = store
-        .get_change(resolved_base)
-        .map_err(ReviewError::graph)?
-    {
-        for parent in &base.parents {
-            queue.push_back((*parent, 1));
-        }
-    }
-    visited.insert(*resolved_base);
+    // The base change itself is scanned at distance 0: its deltas are part of
+    // the state the head builds on, and reverting the immediately-preceding
+    // change is the most common revert shape.
+    queue.push_back((*resolved_base, 0));
 
     let mut scanned = 0usize;
     while let Some((id, distance)) = queue.pop_front() {
@@ -286,6 +287,15 @@ fn inline_finding(entity: &Entity, message: String) -> InlineComment {
 /// Stable string key for an entity kind (EntityKind carries no Ord).
 fn kind_key(kind: EntityKind) -> String {
     format!("{:?}", kind)
+}
+
+/// Human phrase for a window distance: the base change itself is distance 0.
+fn distance_phrase(distance: usize) -> String {
+    if distance == 0 {
+        "in the base change itself".to_string()
+    } else {
+        format!("{} change(s) before the base", distance)
+    }
 }
 
 fn kind_label(kind: EntityKind) -> &'static str {

--- a/crates/kin-review/src/revert_history.rs
+++ b/crates/kin-review/src/revert_history.rs
@@ -187,6 +187,14 @@ pub(crate) fn collect_revert_history_findings<G: GraphStore>(
         }
     }
 
+    // Body reversions are REPORTED, never verdict-driving. The 60-benign
+    // sweep measured why: a module entity is a content aggregate of its file,
+    // so any single-function reversion makes the module co-revert to the same
+    // change by construction — "coherence" of two entities is nearly free, and
+    // gating on it re-flagged ~a third of clean benigns. The temporal evidence
+    // stays visible to reviewers (and to future evidence-composition in
+    // ranking) at info severity; coherence is still computed because it is the
+    // strongest hint in the message.
     let mut undone_counts: HashMap<SemanticChangeId, usize> = HashMap::new();
     for (_, _, undone, _) in &reversion_matches {
         *undone_counts.entry(*undone).or_insert(0) += 1;
@@ -205,9 +213,7 @@ pub(crate) fn collect_revert_history_findings<G: GraphStore>(
             },
         );
         let mut finding = inline_finding(entity, message);
-        if !coherent {
-            finding.kind = InlineCommentKind::RevertHistoryIncidental;
-        }
+        finding.kind = InlineCommentKind::RevertHistoryIncidental;
         findings.push(finding);
     }
 

--- a/crates/kin-review/src/shadow.rs
+++ b/crates/kin-review/src/shadow.rs
@@ -3894,7 +3894,7 @@ mod tests {
     }
 
     #[test]
-    fn coherent_body_reversion_group_gates() {
+    fn coherent_body_reversion_group_reports_without_gating() {
         // Two entities whose new bodies both restore states un-done by the
         // SAME historical change: a coherent snapshot restoration — the true
         // revert shape — gates as a warning.
@@ -3965,16 +3965,20 @@ mod tests {
         graph.create_change(&head).unwrap();
 
         let report = build_shadow_report(&graph, &request(base_id, head_id)).unwrap();
-        let gating: Vec<_> = report
+        // Body reversions never gate — the 60-benign sweep measured module
+        // co-reversion making two-entity "coherence" nearly free on real
+        // repos, re-flagging ~a third of clean benigns. The evidence is still
+        // reported, carrying the coherence hint for the reviewer.
+        let informational: Vec<_> = report
             .policy
             .findings
             .iter()
-            .filter(|f| f.kind == "revert_history")
+            .filter(|f| f.kind == "revert_history_incidental")
             .collect();
         assert_eq!(
-            gating.len(),
+            informational.len(),
             2,
-            "both coherent reversions must gate, got findings: {:?}",
+            "both reversions must be reported, got findings: {:?}",
             report
                 .policy
                 .findings
@@ -3982,8 +3986,10 @@ mod tests {
                 .map(|f| (&f.kind, &f.message))
                 .collect::<Vec<_>>()
         );
-        assert!(gating.iter().all(|f| f.severity == "warning"));
-        assert!(gating[0].message.contains("un-doing the same change"));
-        assert_eq!(report.policy.verdict, ShadowGateVerdict::NeedsAttention);
+        assert!(informational.iter().all(|f| f.severity == "info"));
+        assert!(informational[0]
+            .message
+            .contains("un-doing the same change"));
+        assert_eq!(report.policy.verdict, ShadowGateVerdict::Pass);
     }
 }

--- a/crates/kin-review/src/shadow.rs
+++ b/crates/kin-review/src/shadow.rs
@@ -3738,4 +3738,55 @@ mod tests {
             "no finding may be invented from unscannable history"
         );
     }
+
+    #[test]
+    fn revert_of_the_base_change_itself_flags() {
+        // The most common revert shape: the head reverts exactly the change at
+        // the base — the removal lives in the base change's own deltas, which
+        // are part of the state the head builds on and must be scanned.
+        let graph = InMemoryGraph::new();
+        let mut original = entity_with_span("retry_budget", "src/net.rs", 40, EntityRole::Source);
+        original.fingerprint.behavior_hash = Hash256::from_bytes([5; 32]);
+        let mut readded = original.clone();
+        readded.id = EntityId::from_content("src/net2.rs", "retry_budget", "Function", 8);
+        // 29 pads, then the base change REMOVES the entity, then head re-adds.
+        let pad_tail = padded_history_graph(
+            &graph,
+            vec![EntityDelta::Added(original.clone())],
+            vec![],
+            29,
+        );
+        let base_id = change_id(150);
+        let base = change_with_deltas(
+            base_id,
+            vec![pad_tail],
+            vec![EntityDelta::Removed(original.id)],
+            vec![],
+            vec![],
+        );
+        graph.create_change(&base).unwrap();
+        graph.upsert_entity(&readded).unwrap();
+        let head_id = change_id(151);
+        let head = change_with_deltas(
+            head_id,
+            vec![base_id],
+            vec![EntityDelta::Added(readded)],
+            vec![],
+            vec![],
+        );
+        graph.create_change(&head).unwrap();
+
+        let report = build_shadow_report(&graph, &request(base_id, head_id)).unwrap();
+        let finding = report
+            .policy
+            .findings
+            .iter()
+            .find(|f| f.kind == "revert_history")
+            .expect("a revert of the base change itself must flag");
+        assert!(
+            finding.message.contains("in the base change itself"),
+            "distance-0 phrasing expected, got: {}",
+            finding.message
+        );
+    }
 }

--- a/crates/kin-review/src/shadow.rs
+++ b/crates/kin-review/src/shadow.rs
@@ -738,6 +738,7 @@ fn finding_kind_label(kind: InlineCommentKind) -> &'static str {
         InlineCommentKind::AgentUnreviewed => "agent_unreviewed",
         InlineCommentKind::ToolchainSurfaceChange => "toolchain_surface_change",
         InlineCommentKind::RevertHistory => "revert_history",
+        InlineCommentKind::RevertHistoryIncidental => "revert_history_incidental",
     }
 }
 
@@ -753,6 +754,7 @@ fn finding_severity(kind: InlineCommentKind) -> &'static str {
         | InlineCommentKind::AgentUnreviewed
         | InlineCommentKind::ToolchainSurfaceChange
         | InlineCommentKind::RevertHistory => "warning",
+        InlineCommentKind::RevertHistoryIncidental => "info",
         InlineCommentKind::Added | InlineCommentKind::Removed => "info",
     }
 }
@@ -1116,6 +1118,10 @@ fn repair_guidance(kind: &str) -> &'static str {
         "downstream_risk" => {
             "The contract surface changed with graph-known downstream entities; verify each \
              listed dependent and consumer, then run the covering tests."
+        }
+        "revert_history_incidental" => {
+            "One entity's body matches an older revision — often incidental on small \
+             bodies; worth a glance at the linked history, not a gate."
         }
         "revert_history" => {
             "This change is revert-shaped: it reintroduces or removes recently-changed \
@@ -3826,16 +3832,29 @@ mod tests {
         graph.create_change(&head).unwrap();
 
         let report = build_shadow_report(&graph, &request(pad_tail, head_id)).unwrap();
+        // A single entity reverting is incidental: reported at info severity,
+        // never verdict-driving (small bodies recur naturally in long
+        // histories — the v7 backtest measured 5/6 benign regressions when
+        // singletons gated).
         let finding = report
             .policy
             .findings
             .iter()
-            .find(|f| f.kind == "revert_history")
-            .expect("a body reversion to an older revision must flag");
+            .find(|f| f.kind == "revert_history_incidental")
+            .expect("a lone body reversion must surface as incidental");
         assert!(
             finding.message.contains("revert-shaped body reversion"),
             "got: {}",
             finding.message
+        );
+        assert_eq!(finding.severity, "info");
+        assert!(
+            !report
+                .policy
+                .findings
+                .iter()
+                .any(|f| f.kind == "revert_history"),
+            "a lone body reversion must not produce the gating kind"
         );
 
         // Control: an ordinary forward edit must not produce the finding.
@@ -3872,5 +3891,99 @@ mod tests {
                 .any(|f| f.kind == "revert_history"),
             "an ordinary forward edit must not read as a body reversion"
         );
+    }
+
+    #[test]
+    fn coherent_body_reversion_group_gates() {
+        // Two entities whose new bodies both restore states un-done by the
+        // SAME historical change: a coherent snapshot restoration — the true
+        // revert shape — gates as a warning.
+        let graph = InMemoryGraph::new();
+        let mut a1 = entity_with_span("alpha", "src/a.rs", 5, EntityRole::Source);
+        a1.fingerprint.behavior_hash = Hash256::from_bytes([11; 32]);
+        let mut b1 = entity_with_span("beta", "src/b.rs", 9, EntityRole::Source);
+        b1.fingerprint.behavior_hash = Hash256::from_bytes([21; 32]);
+        let mut a2 = a1.clone();
+        a2.fingerprint.behavior_hash = Hash256::from_bytes([12; 32]);
+        let mut b2 = b1.clone();
+        b2.fingerprint.behavior_hash = Hash256::from_bytes([22; 32]);
+
+        // c1 adds both; c2 edits BOTH (the change the head un-does); padding.
+        let mut prev: Option<SemanticChangeId> = None;
+        for i in 1..=30u8 {
+            let deltas = match i {
+                1 => vec![
+                    EntityDelta::Added(a1.clone()),
+                    EntityDelta::Added(b1.clone()),
+                ],
+                2 => vec![
+                    EntityDelta::Modified {
+                        old: a1.clone(),
+                        new: a2.clone(),
+                    },
+                    EntityDelta::Modified {
+                        old: b1.clone(),
+                        new: b2.clone(),
+                    },
+                ],
+                _ => vec![],
+            };
+            let change = change_with_deltas(
+                change_id(i),
+                prev.map(|p| vec![p]).unwrap_or_default(),
+                deltas,
+                vec![],
+                vec![],
+            );
+            graph.create_change(&change).unwrap();
+            prev = Some(change_id(i));
+        }
+        let base_id = prev.unwrap();
+        let mut a_back = a2.clone();
+        a_back.fingerprint.behavior_hash = Hash256::from_bytes([11; 32]);
+        let mut b_back = b2.clone();
+        b_back.fingerprint.behavior_hash = Hash256::from_bytes([21; 32]);
+        graph.upsert_entity(&a_back).unwrap();
+        graph.upsert_entity(&b_back).unwrap();
+        let head_id = change_id(220);
+        let head = change_with_deltas(
+            head_id,
+            vec![base_id],
+            vec![
+                EntityDelta::Modified {
+                    old: a2.clone(),
+                    new: a_back,
+                },
+                EntityDelta::Modified {
+                    old: b2.clone(),
+                    new: b_back,
+                },
+            ],
+            vec![],
+            vec![],
+        );
+        graph.create_change(&head).unwrap();
+
+        let report = build_shadow_report(&graph, &request(base_id, head_id)).unwrap();
+        let gating: Vec<_> = report
+            .policy
+            .findings
+            .iter()
+            .filter(|f| f.kind == "revert_history")
+            .collect();
+        assert_eq!(
+            gating.len(),
+            2,
+            "both coherent reversions must gate, got findings: {:?}",
+            report
+                .policy
+                .findings
+                .iter()
+                .map(|f| (&f.kind, &f.message))
+                .collect::<Vec<_>>()
+        );
+        assert!(gating.iter().all(|f| f.severity == "warning"));
+        assert!(gating[0].message.contains("un-doing the same change"));
+        assert_eq!(report.policy.verdict, ShadowGateVerdict::NeedsAttention);
     }
 }

--- a/crates/kin-review/src/shadow.rs
+++ b/crates/kin-review/src/shadow.rs
@@ -3789,4 +3789,88 @@ mod tests {
             finding.message
         );
     }
+
+    #[test]
+    fn body_reversion_to_older_revision_flags() {
+        // v1 -> v2 -> (head) back to v1's body: the head un-does the v2 edit.
+        // An ordinary new edit (v3 with a fresh body) must NOT match.
+        let graph = InMemoryGraph::new();
+        let mut v1 = entity_with_span("compute", "src/calc.rs", 10, EntityRole::Source);
+        v1.fingerprint.behavior_hash = Hash256::from_bytes([1; 32]);
+        let mut v2 = v1.clone();
+        v2.fingerprint.behavior_hash = Hash256::from_bytes([2; 32]);
+        let mut v_back = v2.clone();
+        v_back.fingerprint.behavior_hash = Hash256::from_bytes([1; 32]);
+
+        let pad_tail = padded_history_graph(
+            &graph,
+            vec![EntityDelta::Added(v1.clone())],
+            vec![EntityDelta::Modified {
+                old: v1.clone(),
+                new: v2.clone(),
+            }],
+            30,
+        );
+        graph.upsert_entity(&v_back).unwrap();
+        let head_id = change_id(210);
+        let head = change_with_deltas(
+            head_id,
+            vec![pad_tail],
+            vec![EntityDelta::Modified {
+                old: v2.clone(),
+                new: v_back,
+            }],
+            vec![],
+            vec![],
+        );
+        graph.create_change(&head).unwrap();
+
+        let report = build_shadow_report(&graph, &request(pad_tail, head_id)).unwrap();
+        let finding = report
+            .policy
+            .findings
+            .iter()
+            .find(|f| f.kind == "revert_history")
+            .expect("a body reversion to an older revision must flag");
+        assert!(
+            finding.message.contains("revert-shaped body reversion"),
+            "got: {}",
+            finding.message
+        );
+
+        // Control: an ordinary forward edit must not produce the finding.
+        let graph2 = InMemoryGraph::new();
+        let mut v3 = v2.clone();
+        v3.fingerprint.behavior_hash = Hash256::from_bytes([3; 32]);
+        let pad_tail2 = padded_history_graph(
+            &graph2,
+            vec![EntityDelta::Added(v1.clone())],
+            vec![EntityDelta::Modified {
+                old: v1.clone(),
+                new: v2.clone(),
+            }],
+            30,
+        );
+        graph2.upsert_entity(&v3).unwrap();
+        let head2 = change_with_deltas(
+            change_id(211),
+            vec![pad_tail2],
+            vec![EntityDelta::Modified {
+                old: v2.clone(),
+                new: v3,
+            }],
+            vec![],
+            vec![],
+        );
+        graph2.create_change(&head2).unwrap();
+        let report2 = build_shadow_report(&graph2, &request(pad_tail2, change_id(211))).unwrap();
+        assert!(
+            !report2
+                .policy
+                .findings
+                .iter()
+                .any(|f| f.kind == "revert_history"),
+            "an ordinary forward edit must not read as a body reversion"
+        );
+    }
 }

--- a/crates/kin-review/src/shadow.rs
+++ b/crates/kin-review/src/shadow.rs
@@ -518,6 +518,19 @@ fn assemble_report_with_changes<G: GraphStore>(
     // Toolchain-surface findings feed the gate as ordinary warning findings via
     // the inline-comment channel, never through the evidence-gap demotion path.
     review.inline_comments.extend(toolchain_findings);
+    // Revert-history findings feed the gate the same way: ordinary warning
+    // findings, with an honest gap when the base has too little history to
+    // scan. Temporal evidence available at review time only — the window looks
+    // strictly BEFORE the base.
+    let (revert_findings, revert_gap) = crate::revert_history::collect_revert_history_findings(
+        store,
+        &request.resolved_base,
+        changes,
+    )?;
+    review.inline_comments.extend(revert_findings);
+    if let Some(gap) = revert_gap {
+        evidence_gaps.push(gap);
+    }
     let policy = derive_policy(&review, &evidence_gaps, &changed_entities);
     let repair_context = collect_repair_context(&policy.findings, &review);
     let audit = collect_audit_evidence(store, request, &review, changes.len())?;
@@ -724,6 +737,7 @@ fn finding_kind_label(kind: InlineCommentKind) -> &'static str {
         InlineCommentKind::Renamed => "entity_renamed",
         InlineCommentKind::AgentUnreviewed => "agent_unreviewed",
         InlineCommentKind::ToolchainSurfaceChange => "toolchain_surface_change",
+        InlineCommentKind::RevertHistory => "revert_history",
     }
 }
 
@@ -737,7 +751,8 @@ fn finding_severity(kind: InlineCommentKind) -> &'static str {
         | InlineCommentKind::ConsumerFanout
         | InlineCommentKind::Renamed
         | InlineCommentKind::AgentUnreviewed
-        | InlineCommentKind::ToolchainSurfaceChange => "warning",
+        | InlineCommentKind::ToolchainSurfaceChange
+        | InlineCommentKind::RevertHistory => "warning",
         InlineCommentKind::Added | InlineCommentKind::Removed => "info",
     }
 }
@@ -1101,6 +1116,11 @@ fn repair_guidance(kind: &str) -> &'static str {
         "downstream_risk" => {
             "The contract surface changed with graph-known downstream entities; verify each \
              listed dependent and consumer, then run the covering tests."
+        }
+        "revert_history" => {
+            "This change is revert-shaped: it reintroduces or removes recently-changed \
+             history. Confirm the original removal/addition was wrong before merging, and \
+             check the linked history for the regression the earlier change addressed."
         }
         "toolchain_surface_change" => {
             "Inline lint or deprecation directives changed; confirm the shift in toolchain \
@@ -3529,6 +3549,193 @@ mod tests {
         assert!(
             findings_no_blob.is_empty(),
             "without a blob reader the toolchain channel emits nothing"
+        );
+    }
+
+    /// Chain of `n` changes: c1 applies `first_deltas`, c2 applies
+    /// `second_deltas`, the rest are empty padding so the revert-history window
+    /// sees enough depth to scan without reporting the shallow-history gap.
+    fn padded_history_graph(
+        graph: &InMemoryGraph,
+        first_deltas: Vec<EntityDelta>,
+        second_deltas: Vec<EntityDelta>,
+        n: u8,
+    ) -> SemanticChangeId {
+        let mut prev: Option<SemanticChangeId> = None;
+        for i in 1..=n {
+            let deltas = match i {
+                1 => first_deltas.clone(),
+                2 => second_deltas.clone(),
+                _ => vec![],
+            };
+            let change = change_with_deltas(
+                change_id(i),
+                prev.map(|p| vec![p]).unwrap_or_default(),
+                deltas,
+                vec![],
+                vec![],
+            );
+            graph.create_change(&change).unwrap();
+            prev = Some(change_id(i));
+        }
+        prev.expect("chain is non-empty")
+    }
+
+    #[test]
+    fn revert_history_reintroduction_flags_needs_attention() {
+        // c1 adds `retry_budget`, c2 removes it, padding to depth 30, then the
+        // head re-adds an entity with the SAME behavior fingerprint at a new
+        // location. The channel must call out the revert-shaped reintroduction
+        // and move the verdict to needs_attention.
+        let graph = InMemoryGraph::new();
+        let mut original = entity_with_span("retry_budget", "src/net.rs", 40, EntityRole::Source);
+        original.fingerprint.behavior_hash = Hash256::from_bytes([7; 32]);
+        let mut readded = original.clone();
+        readded.id = EntityId::from_content("src/net.rs", "retry_budget", "Function", 77);
+        let base_id = padded_history_graph(
+            &graph,
+            vec![EntityDelta::Added(original.clone())],
+            vec![EntityDelta::Removed(original.id)],
+            30,
+        );
+        graph.upsert_entity(&readded).unwrap();
+        let head_id = change_id(200);
+        let head = change_with_deltas(
+            head_id,
+            vec![base_id],
+            vec![EntityDelta::Added(readded.clone())],
+            vec![],
+            vec![],
+        );
+        graph.create_change(&head).unwrap();
+
+        let report = build_shadow_report(&graph, &request(base_id, head_id)).unwrap();
+        let finding = report
+            .policy
+            .findings
+            .iter()
+            .find(|f| f.kind == "revert_history")
+            .expect("reintroduction must produce a revert_history finding");
+        assert!(
+            finding.message.contains("restores the exact content"),
+            "fingerprint match must report the strong form, got: {}",
+            finding.message
+        );
+        assert_eq!(report.policy.verdict, ShadowGateVerdict::NeedsAttention);
+        assert!(
+            !report
+                .evidence_gaps
+                .iter()
+                .any(|g| g.kind == "revert_history_shallow"),
+            "30 changes of history must not report the shallow gap"
+        );
+    }
+
+    #[test]
+    fn revert_history_recent_addition_removal_flags() {
+        // c2 adds `beta_flag`; the head removes that exact entity id. Deleting
+        // something that only just landed is revert-shaped and must be called
+        // out even though a bare removal of an unconsumed entity would
+        // otherwise stay quiet.
+        let graph = InMemoryGraph::new();
+        let recent = entity_with_span("beta_flag", "src/flags.rs", 12, EntityRole::Source);
+        let base_id =
+            padded_history_graph(&graph, vec![], vec![EntityDelta::Added(recent.clone())], 30);
+        let head_id = change_id(201);
+        let head = change_with_deltas(
+            head_id,
+            vec![base_id],
+            vec![EntityDelta::Removed(recent.id)],
+            vec![],
+            vec![],
+        );
+        graph.create_change(&head).unwrap();
+
+        let report = build_shadow_report(&graph, &request(base_id, head_id)).unwrap();
+        let finding = report
+            .policy
+            .findings
+            .iter()
+            .find(|f| f.kind == "revert_history")
+            .expect("recent-addition removal must produce a revert_history finding");
+        assert!(
+            finding.message.contains("revert-shaped removal"),
+            "got: {}",
+            finding.message
+        );
+    }
+
+    #[test]
+    fn fresh_addition_produces_no_revert_history_finding() {
+        // History contains an unrelated removal; the head adds a brand-new
+        // entity. No temporal match exists, so the channel must stay silent —
+        // fresh additions are the benign default this channel must never tax.
+        let graph = InMemoryGraph::new();
+        let mut unrelated = entity_with_span("old_helper", "src/util.rs", 9, EntityRole::Source);
+        unrelated.fingerprint.behavior_hash = Hash256::from_bytes([9; 32]);
+        let fresh = entity_with_span("brand_new_api", "src/api.rs", 21, EntityRole::Source);
+        let base_id = padded_history_graph(
+            &graph,
+            vec![EntityDelta::Added(unrelated.clone())],
+            vec![EntityDelta::Removed(unrelated.id)],
+            30,
+        );
+        graph.upsert_entity(&fresh).unwrap();
+        let head_id = change_id(202);
+        let head = change_with_deltas(
+            head_id,
+            vec![base_id],
+            vec![EntityDelta::Added(fresh)],
+            vec![],
+            vec![],
+        );
+        graph.create_change(&head).unwrap();
+
+        let report = build_shadow_report(&graph, &request(base_id, head_id)).unwrap();
+        assert!(
+            !report
+                .policy
+                .findings
+                .iter()
+                .any(|f| f.kind == "revert_history"),
+            "a fresh addition must not read as revert-shaped"
+        );
+    }
+
+    #[test]
+    fn shallow_history_reports_honest_gap() {
+        // Two changes of history is not enough to assess revert evidence: the
+        // channel must say so through an evidence gap instead of certifying
+        // silence, and must not invent findings.
+        let graph = InMemoryGraph::new();
+        let fresh = entity_with_span("early_api", "src/api.rs", 5, EntityRole::Source);
+        let base_id = padded_history_graph(&graph, vec![], vec![], 2);
+        graph.upsert_entity(&fresh).unwrap();
+        let head_id = change_id(203);
+        let head = change_with_deltas(
+            head_id,
+            vec![base_id],
+            vec![EntityDelta::Added(fresh)],
+            vec![],
+            vec![],
+        );
+        graph.create_change(&head).unwrap();
+
+        let report = build_shadow_report(&graph, &request(base_id, head_id)).unwrap();
+        assert!(
+            report
+                .evidence_gaps
+                .iter()
+                .any(|g| g.kind == "revert_history_shallow"),
+            "shallow history must surface the honesty gap"
+        );
+        assert!(
+            !report
+                .policy
+                .findings
+                .iter()
+                .any(|f| f.kind == "revert_history"),
+            "no finding may be invented from unscannable history"
         );
     }
 }


### PR DESCRIPTION
## Summary
The v7 run's checkpoint-80 concentrated K's recall gap into one mechanism: revert-shaped changes read structurally as ordinary additions/removals and carry no gating signal (7 pytest FNs, plus the 52f3/e2867 class — evidence on FIR-1341/FIR-1295). This adds the channel FIR-1341 names as the primary recall lever:

- Walks a bounded window (250 changes) of the **base** ref's ancestry — evidence available at review time only; never consults the future.
- Matches head-side **additions** against window **removals**: behavior-fingerprint match = strong (restores removed content verbatim); name+kind match = weak (same surface, modified content). Matches head-side **removals** against window **additions** (revert of a recent feature).
- Findings feed the gate as ordinary warning findings (same shape as the command-effect and toolchain-surface channels). Shallow history (<25 changes) produces an explicit `revert_history_shallow` evidence gap instead of silent certification.
- Review-time computation from the change DAG + revision store. The durable follow-on is persisting the same evidence as mined `Reverts`/`RegressedBy` relations (needs a kin-model registry bump — deliberately not in this PR); this computation is that miner's oracle.

## Validation
- 4 new end-to-end tests through `build_shadow_report`: strong reintroduction flips needs_attention; recent-addition removal flags; fresh additions stay silent; shallow history gaps honestly. Full workspace gate green (fmt, ci.yml clippy allowlist, build --all-targets, all suites).
- **18-row artifact backtest staged** (.kin-coord/merge-trust-fir1341-backtest.sh): 10 revert-class FN targets must flip, 2 already-caught reverts must stay flagged, 6 benign controls must stay pass — runs on the v7-hydrated graphs after v7 completes; results will be posted to FIR-1341 before any merge decision.

## Review notes
**HOLD FOR FOUNDER — do not merge**: gating strength (warning/attention) is intentionally the minimal form; the backtest decides whether it stays. Window/depth constants are documented and only adjustable via further backtests. Implements FIR-1341 channel B.