### PR TITLE
chore(deps): update crossbeam-epoch to 0.9.20 for RUSTSEC-2026-0204

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -829,9 +829,9 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-epoch"
-version = "0.9.18"
+version = "0.9.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e"
+checksum = "2d6914041f254d6e9176c01941b21115dcfb7089e55135a35411081bd106ef3f"
 dependencies = [
  "crossbeam-utils",
 ]


### PR DESCRIPTION
RUSTSEC-2026-0204 (invalid pointer dereference in `fmt::Pointer`/`Display` impls, crossbeam-epoch <0.9.20) published upstream tonight and fails `cargo-deny` on every PR — first observed on #239 after the FIR-1405 registry-outage recovery (independent second failure).

Lock-only transitive bump per the advisory's stated solution: one crate, version+checksum lines only, crates.io source preserved, zero patch leaks. Unblocks #238/#239 once their branches take main.