### PR TITLE
docs: point manual MCP setup at the published npm package

### DIFF
--- a/README.md
+++ b/README.md
@@ -193,9 +193,9 @@ else to configure. The wizard writes a `kin` server entry running `kin mcp start
 with `KIN_MCP_TOOL_PROFILE=agent-default` (the small curated tool surface).
 
 `kin mcp start` runs as a stdio server that the MCP client launches as a subprocess; you
-normally do not run it by hand. To wire up a client manually, use the canonical npm
-package (`npx -y @kinlab/kin mcp start`; `@kinlab/kin-mcp` remains as a compatibility
-wrapper), or see the exact config and config-file locations, read the
+normally do not run it by hand. To wire up a client manually, use the published npm
+package (`npx -y @kinlab/kin-mcp`; the canonical `@kinlab/kin` package ships with an
+upcoming release), or see the exact config and config-file locations, read the
 [Advanced configuration](docs/quickstart.md#9-advanced-configuration) section of the
 quickstart. For the full tool surface, see [docs/mcp-tools.md](docs/mcp-tools.md).
 


### PR DESCRIPTION
One-line truth fix: main's README (via #230) instructs `npx -y @kinlab/kin mcp start`, which 404s until the npm Trusted Publisher is configured and the next release publishes the canonical package (FIR-1100's one remaining action). Until then the working command is the published `@kinlab/kin-mcp`. The full README rewrite (FIR-1332) is a separate held PR.