### PR TITLE
docs: rewrite README around trust positioning and graph-first substrate

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,209 +1,157 @@
-# Kin — The Semantic System of Record for Software Work
+# Kin
+
+> AI made code cheap to write and expensive to trust.
+> **Kin helps teams trust AI-built software before it merges.**
 
 [![License: Apache-2.0](https://img.shields.io/badge/license-Apache--2.0-blue.svg)](LICENSE)
-[![Install](https://img.shields.io/badge/install-get.kinlab.dev-6E56CF.svg)](https://get.kinlab.dev/install)
-[![Homebrew](https://img.shields.io/badge/brew-firelock--ai%2Fkin-orange.svg)](https://github.com/firelock-ai/homebrew-kin)
+[![Release](https://img.shields.io/badge/release-v0.2.12-6E56CF.svg)](https://github.com/firelock-ai/kin/releases)
 [![kinlab.ai](https://img.shields.io/badge/hosted-kinlab.ai-111111.svg)](https://kinlab.ai)
 
-Kin is a semantic, graph-first repository and collaboration substrate for AI-native software development. Unlike traditional file-first, diff-first systems (like Git), Kin represents software as a semantic graph of entities (functions, methods, classes, structs, traits, enums, interfaces, types, constants) and relations (calls, imports, references, inheritance).
-
-In Kin, the graph is the source of authority. The filesystem is a derived projection over that graph truth, made transparently available to existing editors and compilers through the `kin-vfs` virtual filesystem.
-
-## Core Features
-
-- **Semantic VCS**: Version control at the level of entities and relations instead of lines and files.
-- **AI-native context packs**: Build structured context packs containing a target entity plus its caller/callee neighborhood in a single call (`kin context`).
-- **Trace & dataflow**: Trace call chains and dataflow dependencies in one step instead of looping over file reads (`kin trace`, `kin trace-data-flow`).
-- **Ejectable brownfield compatibility**: Works alongside Git and traditional toolchains. `kin eject` removes Kin and leaves your working files untouched; `kin eject --revert-files` additionally restores files to their byte-for-byte pre-init state. Git history is never touched, so there is no data lock-in.
+AI agents now generate code faster than teams can review it. The hard part is no longer
+writing a change — it's trusting one: knowing what it actually touches, whether it silently
+reverts an earlier fix, and how far its blast radius reaches before it merges. Git tracks
+lines and files, so it can't answer those questions directly. Kin is the **semantic system
+of record** for software work: it represents your codebase as a graph of entities and
+relations and reasons over that graph instead of over text diffs.
 
 ---
 
-## Installation
+## What Kin is
 
-Install Kin with a single command:
+Kin is a graph-native repository substrate. Instead of files and line diffs, it models
+software as a semantic graph:
+
+- **Entities** — functions, methods, classes, structs, traits, enums, interfaces, types, constants.
+- **Relations** — calls, imports, references, inheritance.
+
+The graph is the source of authority. Your filesystem becomes a derived projection over that
+graph truth, served transparently to existing editors and compilers through the `kin-vfs`
+virtual filesystem — so every tool you already use keeps working, unchanged.
+
+Because Kin reasons over entities and relations, it can answer questions a line-diff tool
+can't: which callers a change reaches, whether an edit undoes an earlier one, and what the
+real blast radius of a merge is.
+
+---
+
+## Install
+
+Kin ships as native binaries on [GitHub Releases](https://github.com/firelock-ai/kin/releases)
+(currently **v0.2.12**) for five targets: macOS (Apple Silicon and Intel), Linux (x86_64 and
+aarch64, static musl), and Windows (x86_64 — a limited, work-in-progress build; see below).
+
+**Direct download.** Grab the archive for your platform, verify its checksum, and extract.
+The release publishes a `.sha256` next to every archive.
+
+```sh
+# Apple Silicon macOS shown; swap in your platform's archive name.
+curl -fsSLO https://github.com/firelock-ai/kin/releases/download/v0.2.12/kin-macos-aarch64.tar.gz
+curl -fsSLO https://github.com/firelock-ai/kin/releases/download/v0.2.12/kin-macos-aarch64.tar.gz.sha256
+shasum -a 256 -c kin-macos-aarch64.tar.gz.sha256
+tar xzf kin-macos-aarch64.tar.gz      # contains the `kin` and `kin-daemon` binaries
+```
+
+Archive names: `kin-macos-aarch64`, `kin-macos-x86_64`, `kin-linux-x86_64`,
+`kin-linux-aarch64`, `kin-windows-x86_64`.
+
+**Install script.** The convenience installer downloads the latest release, verifies its
+SHA-256 checksum (and refuses to install a tampered or unverified download), places `kin` and
+`kin-daemon` in `~/.kin/bin`, updates your shell profile, and launches setup:
 
 ```sh
 curl -fsSL https://get.kinlab.dev/install | sh
 ```
 
-The installer downloads the latest release from GitHub, verifies its SHA-256 checksum
-(and refuses to install an unverified or tampered download), places the `kin` and
-`kin-daemon` binaries — plus the optional `kin-vfs` projection client where bundled —
-into `~/.kin/bin`, updates your shell profile (`.zshrc` / `.bashrc`), and then runs the
-interactive setup wizard. Re-running the installer upgrades an existing install in place.
+On **Windows**, use PowerShell (`irm https://get.kinlab.dev/install.ps1 | iex`). The native
+Windows build is a limited, vector-free convenience binary with no filesystem projection. For
+the complete, vector-enabled Kin, install under WSL2 — see
+[docs/windows-wsl2.md](docs/windows-wsl2.md).
 
-On **Windows**, use PowerShell:
+**For AI agents.** The MCP server that exposes Kin's tools to assistants is published on npm
+as [`@kinlab/kin-mcp`](https://www.npmjs.com/package/@kinlab/kin-mcp) (**0.2.12**). You
+normally don't install it by hand — `kin setup` wires it into every detected agent for you.
 
-```powershell
-irm https://get.kinlab.dev/install.ps1 | iex
-```
-
-The native Windows build is a limited, vector-free convenience binary with no filesystem
-projection. For the complete, vector-enabled Kin with working projection, install under
-WSL2 — see [docs/windows-wsl2.md](docs/windows-wsl2.md).
-
-### Installer configuration
-
-Configure the installer with environment variables:
-
-- `KIN_VERSION`: Pin a specific version to download (e.g. `0.1.0`). If omitted, the latest release is resolved automatically.
-- `KIN_DIR`: Custom installation directory (defaults to `~/.kin`).
-- `KIN_NO_SETUP`: Set to `1` to skip the interactive setup wizard after the binaries are downloaded.
-- `KIN_BASE_URL`: Install from a mirror or local path instead of GitHub releases (offline/airgapped installs and CI smoke tests). Supported by both the `sh` and PowerShell installers.
-
-### Runtime configuration
-
-The Kin daemon is the canonical authority for graph truth. Commands that analyze the
-graph in-process (`kin merge`, `kin tag`, `kin semver`, `kin rollback`, `kin git export`)
-read from the daemon and auto-start it as needed — no configuration required for normal use.
-
-- `KIN_NO_DAEMON`: Set to `1` to disable daemon auto-start. The CLI will only use an
-  already-running daemon (or `KIN_DAEMON_URL`).
-- `KIN_DAEMON_URL`: Point the CLI at an explicit daemon endpoint instead of the
-  repo-local one.
-- `KIN_ALLOW_DAEMON_BOOTSTRAP_ADMIN`: Offline/admin escape hatch. Set to `1` to let
-  the above read-only commands fall back to reading the local `.kin` snapshot directly
-  when the daemon cannot be reached. Not needed for normal use, and never used for
-  writes — all graph mutations still route through the daemon.
+See [docs/quickstart.md](docs/quickstart.md) for installer environment variables
+(`KIN_VERSION`, `KIN_DIR`, `KIN_NO_SETUP`, `KIN_BASE_URL`) and daemon/runtime configuration.
 
 ---
 
-## Quickstart
+## 60-second quickstart
 
-There is **one recommended first-run path**, and it's the same on macOS, Linux, and
-Windows (via WSL2): install → run the guided `kin setup` wizard → build the graph → verify.
-See [docs/quickstart.md](docs/quickstart.md) for the full end-to-end walkthrough.
-
-### 1. Run guided setup
-
-The installer above already launches `kin setup` for you (run it again any time). It opens
-with **"What do you want Kin for?"** and asks for your **intent**, then configures the
-matching pieces:
+With `kin` on your PATH:
 
 ```sh
-kin setup
+kin setup                            # wire Kin's MCP tools into your AI agents
+                                     #   (detects Claude Code, Cursor, Codex, Gemini, Windsurf)
+kin init                             # build the semantic graph over your repo
+                                     #   (coexists with Git; imports recent history by default)
+kin locate "webhook retries twice"   # find the entities/files behind an issue
+kin refs charge_customer             # who calls, imports, or references this entity
+kin review shadow main..HEAD         # report-only merge-gate verdict:
+                                     #   blast radius, repair context, audit evidence
 ```
 
-- **AI agents** (default) — wires Kin's MCP server into every detected AI client
-  (Claude Code, Cursor, Codex, Gemini, Windsurf), plus shell integration and daemon
-  auto-start. The smallest path to value.
-- **Local-only** — shell integration + daemon auto-start; no AI client config.
-- **Editor** — local-only, plus how to install the `kin-editor` VS Code extension.
-- **Hosted / KinLab** — local setup, plus a note that hosted connect is coming soon (not
-  yet a first-run flow).
-- **Advanced / manual** — choose shell, per-client MCP, and daemon options yourself.
-
-*Flags* (global; `kin setup --intent agent --no-interactive` for scripts/CI):
-- `--intent <local|agent|editor|hosted|advanced>`: pick the first-run intent up front.
-- `--shell <zsh|bash|powershell>`: target shell for profile updates.
-- `--auto-daemon`: force daemon auto-start on (default on for every intent).
-- `--no-interactive`: run with defaults / provided flags (default intent: `agent`).
-
-*Subcommands:*
-- `kin setup status [--json]`: probe and show what's installed (the health checklist).
-- `kin setup doctor [--fix]` (or top-level `kin doctor [--fix]`): run health checks and
-  optionally apply safe repairs.
-
-### 2. Initialize a repository
-
-Build a semantic graph over your codebase:
-
-```sh
-kin init
-```
-
-*Options:*
-- `[PATH]`: Directory to initialize (defaults to the current directory).
-- `--force`: Initialize even if a `.git/` directory is detected.
-- `--git-history <off|recent|full>`: Git history import depth (default: `recent`).
-- `--no-lsp`: Skip LSP enrichment for a faster, tree-sitter-only init.
-
-### 3. Add embeddings (enables semantic search)
-
-`kin init` builds the graph instantly without embeddings. Run `kin embed` to add the
-vector index that powers semantic search and `kin locate`:
-
-```sh
-kin embed
-```
-
-Embeddings are generated locally with `nomic-embed-text-v1.5` (768 dimensions; override
-via `KIN_EMBED_MODEL_ID`). `kin status --json` reports embedding coverage under its
-`enrichment` block (`embeddingsIndexed` / `embeddingsPending` / `embeddingsTotal`).
-
-### 4. Verify
-
-Run the health checklist any time — it probes real filesystem, daemon, and agent state:
-
-```sh
-kin setup status
-```
-
-Checks cover the `kin` and `kin-daemon` binaries, VFS projection (macOS/Linux; **n/a** on
-native Windows), shell integration, repository init, AI-client MCP config (the
-`agent-default` profile), editor extension, KinLab connect (**n/a** — coming soon), and
-semantic query readiness (**STALE** until you run `kin embed`). Failing checks print their
-own `fix:` line; `kin doctor --fix` applies the safe repairs. See
-[docs/quickstart.md](docs/quickstart.md#8-verify-your-setup-kin-setup-status) for the full
-check table and what to do for each state.
-
-### 5. Everyday commands
-
-- **Status of the working copy**:
-  ```sh
-  kin status [--json]
-  ```
-- **Commit changes semantically**:
-  ```sh
-  kin commit -m "commit message"
-  ```
-- **Show the change log**:
-  ```sh
-  kin log [-n <count>]
-  ```
-- **Semantic diff**:
-  ```sh
-  kin diff [<base>] [<head>]
-  ```
-- **Search entities** (add `--semantic` for vector similarity over what is embedded):
-  ```sh
-  kin search "<pattern>" [--semantic] [--show-body]
-  ```
-- **Locate files relevant to an issue**:
-  ```sh
-  kin locate "<problem text>" [--explain]
-  ```
-- **Remove Kin (working files untouched)**:
-  ```sh
-  kin eject
-  ```
-- **Remove Kin and restore files to their pre-init state**:
-  ```sh
-  kin eject --revert-files
-  ```
+`kin init` builds the graph instantly without embeddings; `kin locate` and `kin search` still
+work over lexical and graph signals and tell you when the semantic signal is only partial. Run
+`kin embed` once to add the local vector index that powers full semantic search. `kin setup
+status` (or `kin doctor --fix`) verifies your setup end to end.
 
 ---
 
-## MCP Server Integration
+## What you get
 
-Kin ships with a built-in MCP (Model Context Protocol) server that exposes semantic tools
-to AI assistants (Claude, Cursor, Gemini, Codex, Windsurf, etc.). The **AI agents** intent
-in `kin setup` wires this up for every detected client automatically — there is nothing
-else to configure. The wizard writes a `kin` server entry running `kin mcp start --global`
-with `KIN_MCP_TOOL_PROFILE=agent-default` (the small curated tool surface).
+**Report-only review — the shadow merge gate.** `kin review shadow <base>..<head>` evaluates a
+PR-shaped change and emits a report-only verdict: blast radius, repair context, and audit
+evidence. It never blocks and never mutates graph state, so you can run it in CI or locally as
+evidence. Because Kin tracks entities over time, the report surfaces what a text diff misses —
+for example, a change that silently reverts an earlier fix shows up as evidence instead of
+slipping through.
 
-`kin mcp start` runs as a stdio server that the MCP client launches as a subprocess; you
-normally do not run it by hand. To wire up a client manually, use the published npm
-package (`npx -y @kinlab/kin-mcp`; the canonical `@kinlab/kin` package ships with an
-upcoming release), or see the exact config and config-file locations, read the
+**Semantic locate, refs, and trace.** Ask for the entities behind an issue (`kin locate`), the
+upstream callers/importers/references of an entity (`kin refs`), or an entire call and
+data-flow chain in a single call (`kin trace`, `kin trace-data-flow`) — instead of looping over
+file reads. Add embeddings (`kin embed`) for vector similarity in `kin locate` and
+`kin search --semantic`.
+
+**MCP tools for agents.** Kin ships a built-in MCP server that exposes these same operations as
+tools to any MCP-capable assistant (Claude Code, Cursor, Codex, Gemini, Windsurf). `kin setup`
+configures every detected client automatically. `kin mcp start` runs as a stdio server that the
+MCP client launches as a subprocess; for manual configuration use the canonical npm package
+(`npx -y @kinlab/kin`, which provisions the Kin CLI and daemon; `@kinlab/kin-mcp` remains as a
+compatibility wrapper), or read the
 [Advanced configuration](docs/quickstart.md#9-advanced-configuration) section of the
 quickstart. For the full tool surface, see [docs/mcp-tools.md](docs/mcp-tools.md).
 
+**Transparent filesystem projection.** `kin-vfs` serves graph-backed files to any tool as
+ordinary files, so your editor, compiler, and scripts operate over graph truth without
+modification.
+
 ---
 
-## Architecture & Thesis
+## How it relates to Git
 
-To understand the philosophy behind Kin, see the [thesis document](docs/thesis.md).
+Kin coexists with Git — it does not rewrite or replace your Git history or remotes. `kin init`
+bootstraps your current tree as semantic truth and imports recent Git history by default
+(`--git-history off|recent|full`); `kin migrate` handles deep, full-history import.
+
+There is no lock-in:
+
+- `kin eject` removes Kin's `.kin/` graph and metadata and leaves your working files exactly as they are.
+- `kin eject --revert-files` additionally restores files to their byte-for-byte pre-init state.
+
+Eject never touches `.git`. After ejecting, the directory is a plain Git repository again.
+Today Kin runs alongside Git as the semantic layer; the file and Git surfaces remain the
+interop boundary.
+
+---
+
+## Proof posture
+
+We keep benchmark claims narrow and reproducible. On the current citable evaluation, Kin's
+`locate` is a **statistical tie with `grep` on F1**, with Kin ahead on **precision and
+specificity**, and Kin's retrieval pipeline is **bit-identical across runs** (deterministic).
+We are not claiming a speed or token-savings win. Full methodology, tasks, and artifacts live
+in the [kin-bench](https://github.com/firelock-ai/kin-bench) proof package.
 
 ---
 
@@ -214,10 +162,35 @@ Kin is one system with a few clear surfaces:
 - **[kin](https://github.com/firelock-ai/kin)** — the semantic system of record (this repo): CLI, daemon, MCP server, projections, reconcile, review, provenance.
 - **[kin-vfs](https://github.com/firelock-ai/kin-vfs)** — the transparent virtual filesystem that serves graph-backed files to any tool, unchanged.
 - **[kin-editor](https://github.com/firelock-ai/kin-editor)** — the VS Code extension: entity explorer, semantic search, trace, rename/review.
-- **[kin-db](https://github.com/firelock-ai/kin-db)** — the semantic engine: graph storage, snapshots, indexing, text + vector search.
+- **[kin-mcp](https://www.npmjs.com/package/@kinlab/kin-mcp)** — the MCP server that gives AI agents Kin's semantic tools (bundled in this repo; published as `@kinlab/kin-mcp`).
 - **[kinlab.ai](https://kinlab.ai)** — the hosted collaboration and control-plane layer.
 
-Supporting substrate: [kin-blobs](https://github.com/firelock-ai/kin-blobs) · [kin-search](https://github.com/firelock-ai/kin-search) · [kin-vector](https://github.com/firelock-ai/kin-vector) · [kin-infer](https://github.com/firelock-ai/kin-infer) · [kin-lsp](https://github.com/firelock-ai/kin-lsp) · [kin-model](https://github.com/firelock-ai/kin-model).
+Supporting substrate:
+[kin-db](https://github.com/firelock-ai/kin-db) (graph storage, snapshots, text + vector search) ·
+[kin-blobs](https://github.com/firelock-ai/kin-blobs) ·
+[kin-search](https://github.com/firelock-ai/kin-search) ·
+[kin-vector](https://github.com/firelock-ai/kin-vector) ·
+[kin-infer](https://github.com/firelock-ai/kin-infer) ·
+[kin-lsp](https://github.com/firelock-ai/kin-lsp) ·
+[kin-model](https://github.com/firelock-ai/kin-model) ·
+[kin-bench](https://github.com/firelock-ai/kin-bench).
+
+---
+
+## Status & roadmap
+
+Kin is **0.2.x** — pre-1.0 and under active development. Expect rough edges and breaking
+changes between releases. Being precise about what is and isn't ready today:
+
+- **Install surface.** Native binaries ship on GitHub Releases and via the install script. A canonical `@kinlab/kin` npm package is not published yet; the MCP wrapper `@kinlab/kin-mcp` is.
+- **Windows.** The native Windows binary is a limited, vector-free build with no filesystem projection. Use WSL2 for the complete experience.
+- **Semantic search.** `kin init` builds the graph without embeddings; run `kin embed` to enable vector search. Until then, `locate`/`search` run on lexical + graph signals and say so.
+- **Hosted KinLab.** Connecting a repo to hosted KinLab is coming soon; it is not yet a first-run flow.
+- **Graph-first, with transitional compatibility.** The graph is the authority for Kin's own commands. File-first and Git-interop paths are supported as a migration boundary, not the long-term model.
+
+To understand the philosophy behind Kin, see the [thesis document](docs/thesis.md).
+
+---
 
 ## License
 


### PR DESCRIPTION
**HELD FOR FOUNDER — voice/positioning review requested; do not merge without Troy's read.**

Full README rewrite per FIR-1332: leads with the trust problem and the FIR-1331 one-liner candidate (**PENDING FOUNDER LOCK**), graph-first positioning per the Public Narrative rules, 60-second quickstart of verified-real commands, honest proof posture (the v7 statistical tie + precision/specificity + determinism, nothing more), install truth exact (kin-mcp published, binaries direct, @kinlab/kin marked not-yet-published), Windows/WSL2 honesty, ecosystem map ordered per the manifest, and a Status section that says what's rough.

Every factual claim was source-verified (truth-check table in the lane report; no retracted numbers anywhere). Supersedes the #243 one-line hotfix when it merges — this branch needs a trivial rebase (whole-file rewrite wins) after founder approval.