### PR TITLE
fix(setup): doctor --fix restores the VFS shim or says honestly why it can't

### DIFF
--- a/crates/kin-cli/src/commands/health.rs
+++ b/crates/kin-cli/src/commands/health.rs
@@ -8,7 +8,7 @@
 //! truth behind `kin setup status [--json]` and `kin doctor [--fix]`.
 
 use std::env;
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 
 use serde_json::Value;
 
@@ -280,16 +280,114 @@ fn check_vfs_projection() -> HealthCheck {
         }
     };
 
-    let size = lib_path.metadata().map(|m| m.len()).unwrap_or(0);
-    if lib_path.exists() && size > 0 {
-        HealthCheck::new(
+    vfs_projection_check_for(&lib_path)
+}
+
+/// The durable step that repairs a missing or corrupt shim when `kin doctor
+/// --fix` cannot source one locally. It must NEVER name `kin doctor --fix`
+/// itself: this text is reprinted in the post-`--fix` "still needs manual steps"
+/// list, where pointing back at the command that just ran is a dead loop
+/// (FIR-1409).
+const SHIM_REINSTALL_HINT: &str =
+    "reinstall kin to restore the shim: curl -fsSL https://get.kinlab.dev/install | sh";
+
+/// On-disk state of the VFS shim. Existence alone is not health: a 0-byte file
+/// crashes every process the shim is injected into, and a non-object blob is a
+/// truncated or partially-written artifact the dynamic linker will reject.
+#[derive(Debug, PartialEq, Eq)]
+enum ShimState {
+    /// No file at the path.
+    Missing,
+    /// The file exists but is empty — the crash hazard doctor warns about.
+    Empty,
+    /// The file is non-empty but is not a valid platform object file.
+    Invalid,
+    /// A usable shim of the given size.
+    Valid(u64),
+}
+
+/// Classify the shim at `lib_path`. Path is explicit so this is unit-testable
+/// without a real `$HOME`, mirroring [`session_runtime_check_for`].
+fn classify_shim(lib_path: &Path) -> ShimState {
+    let meta = match std::fs::metadata(lib_path) {
+        Ok(meta) if meta.is_file() => meta,
+        _ => return ShimState::Missing,
+    };
+    if meta.len() == 0 {
+        return ShimState::Empty;
+    }
+    match read_prefix(lib_path, 4) {
+        Ok(header) if shim_magic_ok(&header) => ShimState::Valid(meta.len()),
+        _ => ShimState::Invalid,
+    }
+}
+
+/// Read up to `n` leading bytes of `path`, tolerating short reads.
+fn read_prefix(path: &Path, n: usize) -> std::io::Result<Vec<u8>> {
+    use std::io::Read;
+    let mut file = std::fs::File::open(path)?;
+    let mut buf = vec![0u8; n];
+    let mut filled = 0;
+    while filled < n {
+        match file.read(&mut buf[filled..])? {
+            0 => break,
+            read => filled += read,
+        }
+    }
+    buf.truncate(filled);
+    Ok(buf)
+}
+
+/// Whether `header` carries the object-file magic Kin's shim must have on this
+/// platform: Mach-O on macOS, ELF on Linux. Platforms that don't inject through
+/// this shim accept any non-empty content.
+fn shim_magic_ok(header: &[u8]) -> bool {
+    if cfg!(target_os = "macos") {
+        is_macho_magic(header)
+    } else if cfg!(target_os = "linux") {
+        header.starts_with(b"\x7fELF")
+    } else {
+        !header.is_empty()
+    }
+}
+
+/// Mach-O magic numbers as the first four bytes appear on disk — thin objects
+/// (32/64-bit, both byte orders) and universal ("fat") archives. A real
+/// `libkin_vfs_shim.dylib` on arm64/x86_64 begins `CF FA ED FE` (MH_MAGIC_64).
+fn is_macho_magic(header: &[u8]) -> bool {
+    const MAGICS: [[u8; 4]; 6] = [
+        [0xFE, 0xED, 0xFA, 0xCE], // MH_MAGIC (32-bit)
+        [0xCE, 0xFA, 0xED, 0xFE], // MH_CIGAM (32-bit, byte-swapped)
+        [0xFE, 0xED, 0xFA, 0xCF], // MH_MAGIC_64
+        [0xCF, 0xFA, 0xED, 0xFE], // MH_CIGAM_64 (typical dylib on disk)
+        [0xCA, 0xFE, 0xBA, 0xBE], // FAT_MAGIC (universal)
+        [0xCA, 0xFE, 0xBA, 0xBF], // FAT_MAGIC_64 (universal)
+    ];
+    header.len() >= 4 && MAGICS.iter().any(|magic| header[..4] == *magic)
+}
+
+/// Human name for the platform's shared-object format, for the corrupt-shim message.
+fn shim_object_kind() -> &'static str {
+    if cfg!(target_os = "macos") {
+        "Mach-O library"
+    } else if cfg!(target_os = "linux") {
+        "ELF library"
+    } else {
+        "shared library"
+    }
+}
+
+/// Build the `vfs_projection` check from a resolved shim path. Split out from
+/// [`check_vfs_projection`] so the size/magic classification is testable.
+fn vfs_projection_check_for(lib_path: &Path) -> HealthCheck {
+    match classify_shim(lib_path) {
+        ShimState::Valid(size) => HealthCheck::new(
             "vfs_projection",
             "VFS projection",
             HealthStatus::Healthy,
-            format!("shim installed ({} bytes, {})", size, lib_path.display()),
-        )
-    } else if lib_path.exists() {
-        HealthCheck::new(
+            format!("shim installed ({size} bytes, {})", lib_path.display()),
+        ),
+        ShimState::Empty => HealthCheck::new(
             "vfs_projection",
             "VFS projection",
             HealthStatus::Misconfigured,
@@ -299,18 +397,27 @@ fn check_vfs_projection() -> HealthCheck {
             ),
         )
         .fixable()
-        .with_manual_fix("run `kin doctor --fix` to reinstall the shim (or reinstall kin if no local copy remains)")
-    } else {
-        HealthCheck::new(
+        .with_manual_fix(SHIM_REINSTALL_HINT),
+        ShimState::Invalid => HealthCheck::new(
+            "vfs_projection",
+            "VFS projection",
+            HealthStatus::Misconfigured,
+            format!(
+                "shim at {} is not a valid {} — it is truncated or corrupt",
+                lib_path.display(),
+                shim_object_kind()
+            ),
+        )
+        .fixable()
+        .with_manual_fix(SHIM_REINSTALL_HINT),
+        ShimState::Missing => HealthCheck::new(
             "vfs_projection",
             "VFS projection",
             HealthStatus::Missing,
             format!("shim not installed at {}", lib_path.display()),
         )
         .fixable()
-        .with_manual_fix(
-            "run `kin doctor --fix` (or `kin setup`) to install the VFS shim into ~/.kin/lib",
-        )
+        .with_manual_fix(SHIM_REINSTALL_HINT),
     }
 }
 
@@ -854,6 +961,85 @@ fn check_retrieval_profile() -> HealthCheck {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    fn write_file(path: &Path, bytes: &[u8]) {
+        use std::io::Write;
+        std::fs::File::create(path)
+            .unwrap()
+            .write_all(bytes)
+            .unwrap();
+    }
+
+    /// The magic bytes a valid shim carries on the current platform.
+    fn platform_object_magic() -> &'static [u8] {
+        if cfg!(target_os = "macos") {
+            &[0xCF, 0xFA, 0xED, 0xFE] // MH_MAGIC_64 as it lands on disk
+        } else if cfg!(target_os = "linux") {
+            b"\x7fELF"
+        } else {
+            &[0x00, 0x01, 0x02, 0x03]
+        }
+    }
+
+    #[test]
+    fn classify_shim_flags_missing_empty_and_corrupt() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("libkin_vfs_shim");
+
+        assert_eq!(classify_shim(&path), ShimState::Missing);
+
+        write_file(&path, b"");
+        assert_eq!(classify_shim(&path), ShimState::Empty);
+
+        // A non-empty blob without object-file magic is a truncated/corrupt
+        // artifact on the platforms that enforce a magic.
+        write_file(&path, b"this is not a shared library");
+        if cfg!(any(target_os = "macos", target_os = "linux")) {
+            assert_eq!(classify_shim(&path), ShimState::Invalid);
+        }
+    }
+
+    #[test]
+    fn classify_shim_accepts_a_real_object_header() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("libkin_vfs_shim");
+        let mut bytes = platform_object_magic().to_vec();
+        bytes.extend_from_slice(&[0u8; 128]);
+        write_file(&path, &bytes);
+        assert!(matches!(classify_shim(&path), ShimState::Valid(_)));
+    }
+
+    #[test]
+    fn macho_magic_matches_the_shipped_dylib_header() {
+        // The v0.2.x macOS shim begins CF FA ED FE (MH_MAGIC_64 little-endian).
+        assert!(is_macho_magic(&[0xCF, 0xFA, 0xED, 0xFE, 0x0C, 0x00]));
+        assert!(!is_macho_magic(b"junk"));
+        assert!(!is_macho_magic(&[0xCF, 0xFA])); // too short
+    }
+
+    #[test]
+    fn vfs_remediation_never_points_back_at_the_failed_fix() {
+        // FIR-1409: the repair text for a broken shim must name a real working
+        // step, never `kin doctor --fix` (the command that just failed).
+        let dir = tempfile::tempdir().unwrap();
+        let missing = dir.path().join("missing");
+        let empty = dir.path().join("empty");
+        write_file(&empty, b"");
+        let corrupt = dir.path().join("corrupt");
+        write_file(&corrupt, b"not an object file");
+
+        for path in [&missing, &empty, &corrupt] {
+            let check = vfs_projection_check_for(path);
+            assert!(check.fixable, "{}: should be fixable", path.display());
+            let fix = check.manual_fix.clone().unwrap_or_default();
+            assert!(!fix.is_empty(), "{}: missing manual fix", path.display());
+            assert!(
+                !fix.contains("doctor --fix"),
+                "{}: circular fix text: {fix}",
+                path.display()
+            );
+        }
+    }
 
     #[tokio::test]
     async fn report_is_non_empty_and_serializes_with_ids() {

--- a/crates/kin-cli/src/commands/setup.rs
+++ b/crates/kin-cli/src/commands/setup.rs
@@ -616,6 +616,21 @@ fn find_shim() -> Option<PathBuf> {
     None
 }
 
+/// Restore the shim at `dest` from the first usable source in `sources` (a
+/// source is usable when it exists and is non-empty). Returns the dest path when
+/// a source was copied, or `None` when no usable local source exists — the
+/// caller then escalates (download) or prints a manual step. Explicit sources
+/// keep the copy logic unit-testable without a real `$HOME`.
+fn restore_shim_from_sources(dest: &Path, sources: &[PathBuf]) -> Result<Option<PathBuf>> {
+    for src in sources {
+        if is_usable_shim(src) {
+            copy_shim(src, dest)?;
+            return Ok(Some(dest.to_path_buf()));
+        }
+    }
+    Ok(None)
+}
+
 pub(crate) fn detect_shell() -> &'static str {
     if env::var("PSModulePath").is_ok() || env::var("PSVersionTable").is_ok() {
         return "powershell";
@@ -1089,13 +1104,11 @@ pub(crate) fn reinstall_vfs_shim() -> Result<Option<PathBuf>> {
     let dest = lib_dir.join(shim_filename());
 
     // `find_shim` only returns non-empty candidates, so a truncated shim is
-    // never re-selected as the source. `copy_shim` no-ops if the usable shim
-    // already is the destination.
-    let Some(shim_path) = find_shim() else {
-        return Ok(None);
-    };
-    copy_shim(&shim_path, &dest)?;
-    Ok(Some(dest))
+    // never re-selected as the source. `restore_shim_from_sources` copies the
+    // first usable one and `copy_shim` no-ops if that source already is the
+    // destination.
+    let sources: Vec<PathBuf> = find_shim().into_iter().collect();
+    restore_shim_from_sources(&dest, &sources)
 }
 
 /// Re-merge the kin MCP server entry (with the agent-default profile) into the
@@ -1829,7 +1842,11 @@ pub async fn doctor(fix: bool, json: bool) -> Result<()> {
         }
     }
 
-    // Re-source the VFS shim when it is missing or was truncated to 0 bytes.
+    // Repair the VFS shim when it is missing, truncated to 0 bytes, or corrupt.
+    // Try a local copy first; a standalone binary (no sibling shim, no ledger
+    // source) has none, so fall back to downloading the shim from the release
+    // that matches THIS binary's version. Only if both fail do we print a manual
+    // step — and never one that points back at `kin doctor --fix` (FIR-1409).
     let vfs_needs_fix = report.checks.iter().any(|c| {
         c.id == "vfs_projection"
             && c.fixable
@@ -1837,12 +1854,35 @@ pub async fn doctor(fix: bool, json: bool) -> Result<()> {
     });
     if vfs_needs_fix {
         match reinstall_vfs_shim() {
-            Ok(Some(dest)) => applied.push(format!("reinstalled VFS shim ({})", dest.display())),
-            Ok(None) => println!(
-                "  {} no usable VFS shim found to reinstall — re-run the installer \
-                 (curl -fsSL https://get.kinlab.dev/install | sh)",
-                style("✗").red()
-            ),
+            Ok(Some(dest)) => applied.push(format!(
+                "reinstalled VFS shim from a local copy ({})",
+                dest.display()
+            )),
+            Ok(None) => {
+                // No local shim source. Fetch the shim from the matching release.
+                let dest = kin_dir()?.join("lib").join(shim_filename());
+                println!(
+                    "  No local VFS shim found; fetching it from the v{} release...",
+                    env!("CARGO_PKG_VERSION")
+                );
+                match crate::commands::update::download_shim_for_current_version(&dest).await {
+                    Ok(()) => applied.push(format!(
+                        "downloaded the VFS shim from the v{} release ({})",
+                        env!("CARGO_PKG_VERSION"),
+                        dest.display()
+                    )),
+                    Err(e) => {
+                        println!(
+                            "  {} could not restore the VFS shim automatically: {e}",
+                            style("✗").red()
+                        );
+                        println!(
+                            "      reinstall kin to restore it: \
+                             curl -fsSL https://get.kinlab.dev/install | sh"
+                        );
+                    }
+                }
+            }
             Err(e) => println!("  {} VFS shim reinstall failed: {e}", style("✗").red()),
         }
     }
@@ -2107,6 +2147,47 @@ mod tests {
         assert!(!is_usable_shim(&empty), "0-byte shim must not be usable");
         assert!(is_usable_shim(&full));
         assert!(!is_usable_shim(&missing));
+    }
+
+    #[test]
+    fn restore_shim_repairs_a_zeroed_shim_from_a_usable_source() {
+        // FIR-1409 repair path: a deliberately-zeroed shim + a usable source is
+        // restored to the real bytes.
+        let tmp = tempfile::tempdir().unwrap();
+        let source = tmp.path().join("source-shim");
+        fs::write(&source, b"\xCF\xFA\xED\xFEreal-shim-bytes").unwrap();
+        let dest = tmp.path().join("lib").join(shim_filename());
+        fs::create_dir_all(dest.parent().unwrap()).unwrap();
+        fs::write(&dest, b"").unwrap(); // the 0-byte crash hazard
+
+        let restored = restore_shim_from_sources(&dest, std::slice::from_ref(&source)).unwrap();
+        assert_eq!(restored.as_deref(), Some(dest.as_path()));
+        assert_eq!(
+            fs::read(&dest).unwrap(),
+            b"\xCF\xFA\xED\xFEreal-shim-bytes",
+            "dest must hold the source bytes after repair"
+        );
+    }
+
+    #[test]
+    fn restore_shim_reports_none_when_no_usable_source_exists() {
+        // FIR-1409 honest path: with no usable source, the repair reports None
+        // (so the caller escalates / prints a manual step) and never fabricates
+        // content over the zeroed shim.
+        let tmp = tempfile::tempdir().unwrap();
+        let empty = tmp.path().join("empty-source");
+        fs::write(&empty, b"").unwrap();
+        let missing = tmp.path().join("missing-source");
+        let dest = tmp.path().join("dest-shim");
+        fs::write(&dest, b"").unwrap();
+
+        let restored = restore_shim_from_sources(&dest, &[empty, missing]).unwrap();
+        assert!(restored.is_none(), "no usable source must yield None");
+        assert_eq!(
+            fs::metadata(&dest).unwrap().len(),
+            0,
+            "dest must stay untouched when there is nothing to copy"
+        );
     }
 
     #[test]

--- a/crates/kin-cli/src/commands/update.rs
+++ b/crates/kin-cli/src/commands/update.rs
@@ -4,7 +4,7 @@
 use anyhow::{Context, Result};
 use sha2::{Digest, Sha256};
 use std::cmp::Ordering;
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 
 const CURRENT_VERSION: &str = env!("CARGO_PKG_VERSION");
 const GITHUB_RELEASES_LATEST_URL: &str =
@@ -402,6 +402,207 @@ fn parse_checksum(checksums_text: &str, filename: &str) -> Option<String> {
     None
 }
 
+// ---------------------------------------------------------------------------
+// Doctor shim repair (FIR-1409)
+//
+// `kin doctor --fix` uses this to reinstall the VFS shim when the running
+// binary has no local copy to source from (e.g. a standalone/proof-bundle
+// binary). It pins to the release matching THIS binary's version — never
+// "latest" — because a newer release can ship an ABI-incompatible shim.
+// ---------------------------------------------------------------------------
+
+/// The `firelock-ai/kin` release for an exact tag. Suffix `v{VERSION}`.
+const GITHUB_RELEASES_TAG_URL: &str =
+    "https://api.github.com/repos/firelock-ai/kin/releases/tags/v";
+
+/// Platform stem used in Kin's release archive names, e.g. `kin-macos-aarch64`.
+///
+/// NOTE: this is the naming the release pipeline actually publishes
+/// (`macos|linux|windows` + `aarch64|x86_64`). It intentionally differs from
+/// [`detect_platform`]'s legacy `darwin`/`amd64` mapping, which does not match
+/// any current release asset.
+fn release_platform_stem() -> Result<String> {
+    let os = if cfg!(target_os = "macos") {
+        "macos"
+    } else if cfg!(target_os = "linux") {
+        "linux"
+    } else if cfg!(target_os = "windows") {
+        "windows"
+    } else {
+        anyhow::bail!("unsupported OS for shim download");
+    };
+    let arch = if cfg!(target_arch = "x86_64") {
+        "x86_64"
+    } else if cfg!(target_arch = "aarch64") {
+        "aarch64"
+    } else {
+        anyhow::bail!("unsupported architecture for shim download");
+    };
+    Ok(format!("kin-{os}-{arch}"))
+}
+
+/// Download the VFS shim from the GitHub release matching the running version
+/// and install it atomically at `dest`.
+///
+/// Verifies the downloaded archive's SHA-256 against the release's
+/// `checksums-sha256.txt`, requires the extracted shim to be non-empty, and
+/// writes via a temp file + atomic rename so a partial download can never land
+/// as the 0-byte shim this repairs. Returns `Err` — honestly — when offline,
+/// when the release or asset is absent, or when verification fails, so the
+/// caller can print a manual reinstall step instead of looping.
+pub(crate) async fn download_shim_for_current_version(dest: &Path) -> Result<()> {
+    let shim_name = crate::commands::setup::shim_filename();
+    let archive_name = format!("{}.tar.gz", release_platform_stem()?);
+
+    let client = reqwest::Client::builder()
+        .user_agent("kin-cli")
+        .build()
+        .context("failed to build HTTP client")?;
+
+    let tag_url = format!("{GITHUB_RELEASES_TAG_URL}{CURRENT_VERSION}");
+    let release: GithubRelease = client
+        .get(&tag_url)
+        .send()
+        .await
+        .context("failed to reach the GitHub releases API (offline?)")?
+        .error_for_status()
+        .with_context(|| format!("no published release found for v{CURRENT_VERSION}"))?
+        .json()
+        .await
+        .context("failed to parse release JSON")?;
+
+    let asset = release
+        .assets
+        .iter()
+        .find(|a| a.name == archive_name)
+        .with_context(|| format!("release v{CURRENT_VERSION} has no asset '{archive_name}'"))?;
+
+    let archive_bytes = client
+        .get(&asset.browser_download_url)
+        .send()
+        .await
+        .context("failed to download release archive")?
+        .error_for_status()
+        .context("archive download returned an error")?
+        .bytes()
+        .await
+        .context("failed to read archive bytes")?;
+
+    if archive_bytes.is_empty() {
+        anyhow::bail!("downloaded archive '{archive_name}' was empty");
+    }
+
+    verify_archive_checksum(&client, &release, &archive_name, &archive_bytes).await?;
+
+    let shim_bytes = extract_named_file_from_tar_gz(&archive_bytes, shim_name)
+        .with_context(|| format!("archive '{archive_name}' did not contain '{shim_name}'"))?;
+    if shim_bytes.is_empty() {
+        anyhow::bail!("the shim '{shim_name}' extracted from '{archive_name}' was empty");
+    }
+
+    write_atomically(dest, &shim_bytes)
+        .with_context(|| format!("failed to install the shim at {}", dest.display()))?;
+    Ok(())
+}
+
+/// Verify `archive_bytes` against the SHA-256 recorded for `archive_name` in the
+/// release's `checksums-sha256.txt`. Returns `Err` if the checksums asset is
+/// missing, the entry is absent, or the hash mismatches — a repair must never
+/// install unverified bytes.
+async fn verify_archive_checksum(
+    client: &reqwest::Client,
+    release: &GithubRelease,
+    archive_name: &str,
+    archive_bytes: &[u8],
+) -> Result<()> {
+    let checksums_asset = release
+        .assets
+        .iter()
+        .find(|a| a.name == CHECKSUMS_ASSET)
+        .with_context(|| {
+            format!("release is missing '{CHECKSUMS_ASSET}' — cannot verify the download")
+        })?;
+
+    let checksums_bytes = client
+        .get(&checksums_asset.browser_download_url)
+        .send()
+        .await
+        .context("failed to download checksums file")?
+        .error_for_status()?
+        .bytes()
+        .await
+        .context("failed to read checksums bytes")?;
+
+    let checksums_text =
+        std::str::from_utf8(&checksums_bytes).context("checksums file is not valid UTF-8")?;
+    let expected = parse_checksum(checksums_text, archive_name)
+        .with_context(|| format!("'{archive_name}' not found in the checksums file"))?;
+
+    let mut hasher = Sha256::new();
+    hasher.update(archive_bytes);
+    let actual = hex::encode(hasher.finalize());
+
+    if actual != expected {
+        anyhow::bail!("SHA-256 mismatch for '{archive_name}': expected {expected}, got {actual}");
+    }
+    Ok(())
+}
+
+/// Extract the bytes of the archive entry whose file name is exactly `target`.
+fn extract_named_file_from_tar_gz(bytes: &[u8], target: &str) -> Result<Vec<u8>> {
+    use std::io::Read;
+    let decoder = flate2::read::GzDecoder::new(bytes);
+    let mut archive = tar::Archive::new(decoder);
+    for entry in archive.entries().context("failed to read tar entries")? {
+        let mut entry = entry.context("corrupt tar entry")?;
+        let path = entry.path().context("invalid entry path")?.into_owned();
+        if path.file_name().and_then(|n| n.to_str()) == Some(target) {
+            let mut buf = Vec::new();
+            entry
+                .read_to_end(&mut buf)
+                .context("failed to read shim bytes from archive")?;
+            return Ok(buf);
+        }
+    }
+    anyhow::bail!("'{target}' not found in archive")
+}
+
+/// Write `bytes` to `dest` via a sibling temp file + rename, so a crash or
+/// partial write never leaves a truncated file at `dest`.
+fn write_atomically(dest: &Path, bytes: &[u8]) -> Result<()> {
+    use std::io::Write;
+    let parent = dest
+        .parent()
+        .context("destination path has no parent directory")?;
+    std::fs::create_dir_all(parent)
+        .with_context(|| format!("failed to create {}", parent.display()))?;
+
+    let file_name = dest
+        .file_name()
+        .and_then(|n| n.to_str())
+        .context("destination path has no file name")?;
+    let tmp = parent.join(format!(".{file_name}.tmp-download"));
+
+    {
+        let mut file = std::fs::File::create(&tmp)
+            .with_context(|| format!("failed to create {}", tmp.display()))?;
+        file.write_all(bytes)
+            .context("failed to write shim bytes")?;
+        file.sync_all().ok();
+    }
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        let _ = std::fs::set_permissions(&tmp, std::fs::Permissions::from_mode(0o644));
+    }
+    std::fs::rename(&tmp, dest).with_context(|| {
+        // Clean up the temp file if the rename fails so we don't leave litter.
+        let _ = std::fs::remove_file(&tmp);
+        format!("failed to move the shim into place at {}", dest.display())
+    })?;
+    Ok(())
+}
+
 /// Remove existing kin binaries before writing new ones.
 /// This avoids the dyld deadlock described in the debugging guide:
 /// `cp` over a mapped inode can wedge the dynamic linker on macOS.
@@ -626,6 +827,79 @@ fn is_lib(name: &str) -> bool {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    /// Build an in-memory `.tar.gz` with the given (name, bytes) entries.
+    fn make_tar_gz(entries: &[(&str, &[u8])]) -> Vec<u8> {
+        use flate2::write::GzEncoder;
+        use flate2::Compression;
+        let mut gz = GzEncoder::new(Vec::new(), Compression::fast());
+        {
+            let mut builder = tar::Builder::new(&mut gz);
+            for (name, data) in entries {
+                let mut header = tar::Header::new_gnu();
+                header.set_size(data.len() as u64);
+                header.set_mode(0o644);
+                header.set_cksum();
+                builder.append_data(&mut header, name, *data).unwrap();
+            }
+            builder.finish().unwrap();
+        }
+        gz.finish().unwrap()
+    }
+
+    #[test]
+    fn release_platform_stem_targets_real_asset_naming() {
+        let stem = release_platform_stem().unwrap();
+        // Must match the actual v0.2.x asset names, NOT detect_platform's legacy
+        // darwin/amd64 mapping (which matches no published asset).
+        assert!(stem.starts_with("kin-"), "unexpected stem: {stem}");
+        #[cfg(target_os = "macos")]
+        assert!(stem.contains("macos"), "stem: {stem}");
+        #[cfg(target_os = "linux")]
+        assert!(stem.contains("linux"), "stem: {stem}");
+        #[cfg(target_arch = "aarch64")]
+        assert!(stem.contains("aarch64"), "stem: {stem}");
+        #[cfg(target_arch = "x86_64")]
+        assert!(stem.contains("x86_64"), "stem: {stem}");
+    }
+
+    #[test]
+    fn extract_named_file_pulls_the_shim_out_of_the_archive() {
+        let archive = make_tar_gz(&[
+            ("kin-macos-aarch64/kin", b"binary-bytes"),
+            (
+                "kin-macos-aarch64/libkin_vfs_shim.dylib",
+                b"\xCF\xFA\xED\xFEshim-body",
+            ),
+        ]);
+        let shim = extract_named_file_from_tar_gz(&archive, "libkin_vfs_shim.dylib").unwrap();
+        assert_eq!(shim, b"\xCF\xFA\xED\xFEshim-body");
+    }
+
+    #[test]
+    fn extract_named_file_errors_when_absent() {
+        let archive = make_tar_gz(&[("kin-macos-aarch64/kin", b"binary-bytes")]);
+        assert!(extract_named_file_from_tar_gz(&archive, "libkin_vfs_shim.dylib").is_err());
+    }
+
+    #[test]
+    fn write_atomically_installs_bytes_and_leaves_no_temp() {
+        let dir = tempfile::tempdir().unwrap();
+        // Parent dir does not exist yet — write_atomically must create it.
+        let dest = dir.path().join("lib").join("libkin_vfs_shim.dylib");
+        write_atomically(&dest, b"\xCF\xFA\xED\xFEbody").unwrap();
+
+        assert_eq!(std::fs::read(&dest).unwrap(), b"\xCF\xFA\xED\xFEbody");
+        let leftovers: Vec<_> = std::fs::read_dir(dest.parent().unwrap())
+            .unwrap()
+            .filter_map(|e| e.ok())
+            .filter(|e| e.file_name().to_string_lossy().contains(".tmp"))
+            .collect();
+        assert!(
+            leftovers.is_empty(),
+            "temp download file was not cleaned up"
+        );
+    }
 
     #[test]
     fn version_comparison() {


### PR DESCRIPTION
FIR-1409 (found dogfooding): a 0-byte VFS shim was unrepairable — `doctor --fix` silently no-op'd when no local shim source existed (standalone/proof-bundle binaries have none; the ledger records destinations, not sources; nothing is embedded) and its remediation text pointed back at `doctor --fix`.

- Repair chain: local sibling sources → **download from the GitHub release matching the running version** (platform archive located via the release listing, checksum-verified against checksums-sha256.txt, size>0 required, temp-file + atomic rename) → honest failure naming the working installer one-liner. No message anywhere points at the command that just failed.
- The doctor check now asserts size>0 AND platform object magic (Mach-O/ELF) — corrupt or truncated shims can no longer pass.
- End-to-end verified with a throwaway $HOME: online --fix restores 0→830KB valid Mach-O; offline --fix fails honestly and leaves the broken shim untouched.
- 10 new tests; kin-cli 727 green; fmt + ci.yml clippy clean.

Separate latent bug discovered while wiring the download (NOT touched here, ticketed): `kin update` cannot match real release assets — detect_platform emits darwin/amd64/arm64 vs actual kin-{macos|linux|windows}-{aarch64|x86_64} naming, and verify_archive requires a checksums-sha256.txt.sig that releases don't publish.