### PR TITLE
chore(release): bump to 0.2.13 — canonical npm install surface and self-healing doctor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,32 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.2.13] - 2026-07-07
+
+Distribution becomes first-class: Kin installs from npm as `@kinlab/kin`, doctor heals its own VFS shim, and history hydration gains parse reuse and a timing profile.
+
+### Added
+
+- Canonical npm package `@kinlab/kin`: installs the platform Kin CLI + daemon and
+  exposes the `kin` and `kin-mcp` binaries; MCP stays included via `kin mcp start`.
+  `@kinlab/kin-mcp` remains as a compatibility wrapper.
+- History hydration can emit a machine-readable per-stage timing profile
+  (`KIN_HYDRATE_STAGE_TIMINGS`) for replay analysis.
+- Blob parses are memoized across history hydration: identical file contents parse
+  once per adapter version instead of once per touching commit.
+
+### Fixed
+
+- `kin doctor --fix` repairs a missing or zero-byte VFS shim by fetching the release
+  shim matching the installed version — or fails honestly — instead of printing
+  circular fix advice.
+- `kin refs` and rename queries answer only from graph truth; the raw source-tree
+  scan fallback is removed from the authority path.
+
+### Security
+
+- crossbeam-epoch updated to 0.9.20 (RUSTSEC-2026-0204).
+
 ## [0.2.12] - 2026-07-06
 
 First-touch review latency: ancestor..descendant review pairs hydrate git history once instead of twice.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3039,11 +3039,11 @@ dependencies = [
 
 [[package]]
 name = "kin-buildinfo"
-version = "0.2.12"
+version = "0.2.13"
 
 [[package]]
 name = "kin-cli"
-version = "0.2.12"
+version = "0.2.13"
 dependencies = [
  "age",
  "anyhow",
@@ -3110,7 +3110,7 @@ dependencies = [
 
 [[package]]
 name = "kin-context"
-version = "0.2.12"
+version = "0.2.13"
 dependencies = [
  "kin-blobs",
  "kin-db",
@@ -3126,7 +3126,7 @@ dependencies = [
 
 [[package]]
 name = "kin-core"
-version = "0.2.12"
+version = "0.2.13"
 dependencies = [
  "chrono",
  "directories 5.0.1",
@@ -3150,7 +3150,7 @@ dependencies = [
 
 [[package]]
 name = "kin-daemon"
-version = "0.2.12"
+version = "0.2.13"
 dependencies = [
  "async-stream",
  "axum",
@@ -3239,7 +3239,7 @@ dependencies = [
 
 [[package]]
 name = "kin-git"
-version = "0.2.12"
+version = "0.2.13"
 dependencies = [
  "chrono",
  "gix",
@@ -3257,7 +3257,7 @@ dependencies = [
 
 [[package]]
 name = "kin-index"
-version = "0.2.12"
+version = "0.2.13"
 dependencies = [
  "hex",
  "kin-blobs",
@@ -3303,7 +3303,7 @@ dependencies = [
 
 [[package]]
 name = "kin-integration-tests"
-version = "0.2.12"
+version = "0.2.13"
 dependencies = [
  "kin-blobs",
  "kin-cli",
@@ -3345,7 +3345,7 @@ dependencies = [
 
 [[package]]
 name = "kin-mcp"
-version = "0.2.12"
+version = "0.2.13"
 dependencies = [
  "kin-blobs",
  "kin-context",
@@ -3372,7 +3372,7 @@ dependencies = [
 
 [[package]]
 name = "kin-migrate"
-version = "0.2.12"
+version = "0.2.13"
 dependencies = [
  "chrono",
  "kin-blobs",
@@ -3414,7 +3414,7 @@ dependencies = [
 
 [[package]]
 name = "kin-parser"
-version = "0.2.12"
+version = "0.2.13"
 dependencies = [
  "kin-model",
  "pretty_assertions",
@@ -3443,7 +3443,7 @@ dependencies = [
 
 [[package]]
 name = "kin-projection"
-version = "0.2.12"
+version = "0.2.13"
 dependencies = [
  "kin-blobs",
  "kin-db",
@@ -3458,7 +3458,7 @@ dependencies = [
 
 [[package]]
 name = "kin-ranking"
-version = "0.2.12"
+version = "0.2.13"
 dependencies = [
  "kin-model",
  "serde",
@@ -3467,7 +3467,7 @@ dependencies = [
 
 [[package]]
 name = "kin-reconcile"
-version = "0.2.12"
+version = "0.2.13"
 dependencies = [
  "kin-blobs",
  "kin-db",
@@ -3487,7 +3487,7 @@ dependencies = [
 
 [[package]]
 name = "kin-registry"
-version = "0.2.12"
+version = "0.2.13"
 dependencies = [
  "axum",
  "base64 0.22.1",
@@ -3512,7 +3512,7 @@ dependencies = [
 
 [[package]]
 name = "kin-remote"
-version = "0.2.12"
+version = "0.2.13"
 dependencies = [
  "chrono",
  "kin-model",
@@ -3528,7 +3528,7 @@ dependencies = [
 
 [[package]]
 name = "kin-review"
-version = "0.2.12"
+version = "0.2.13"
 dependencies = [
  "kin-blobs",
  "kin-db",
@@ -3544,7 +3544,7 @@ dependencies = [
 
 [[package]]
 name = "kin-runtime"
-version = "0.2.12"
+version = "0.2.13"
 dependencies = [
  "chrono",
  "hex",
@@ -3576,7 +3576,7 @@ dependencies = [
 
 [[package]]
 name = "kin-semantic-contracts"
-version = "0.2.12"
+version = "0.2.13"
 dependencies = [
  "kin-db",
  "kin-model",
@@ -3591,7 +3591,7 @@ dependencies = [
 
 [[package]]
 name = "kin-spine"
-version = "0.2.12"
+version = "0.2.13"
 dependencies = [
  "chrono",
  "hashbrown 0.15.5",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,7 +27,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.2.12"
+version = "0.2.13"
 edition = "2021"
 license = "Apache-2.0"
 authors = ["Troy Fortin <troy@firelock.ai>"]

--- a/packages/kin-mcp/package.json
+++ b/packages/kin-mcp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kinlab/kin-mcp",
-  "version": "0.2.12",
+  "version": "0.2.13",
   "description": "Start Kin's MCP server through an npm-friendly wrapper.",
   "type": "module",
   "bin": {

--- a/packages/kin/package.json
+++ b/packages/kin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kinlab/kin",
-  "version": "0.2.9",
+  "version": "0.2.13",
   "description": "Canonical installer and launcher for Kin — provisions and runs the managed kin + kin-daemon release. MCP is one included mode (kin mcp start).",
   "license": "Apache-2.0",
   "type": "module",


### PR DESCRIPTION
Bump the workspace and npm packages to 0.2.13.

Ships (merged since v0.2.12):
- Canonical npm package `@kinlab/kin` — first publish through the release workflow's Trusted Publishing path. `packages/kin/package.json` is lifted from its pre-release 0.2.9 placeholder so the workflow's tag-match guard passes.
- `kin doctor --fix` VFS shim self-repair with honest failure text.
- `kin refs`/rename answer from graph truth only; source-tree scan fallback removed.
- History hydration: per-stage timing profile behind `KIN_HYDRATE_STAGE_TIMINGS` + blob parse memoization per (blob hash, adapter version).
- crossbeam-epoch 0.9.20 (RUSTSEC-2026-0204).

Verification:
- `cargo update --workspace` under an isolated registry-only CARGO_HOME; the lock diff is workspace-member version fields only — every external pin keeps its registry source and checksum.
- packages/kin launcher tests: 24/24 pass (node 22).
- CHANGELOG entry added.

Driver: https://linear.app/firelock-ai/issue/FIR-1100