### PR TITLE
fix(review): peel relative refs and fast-path ancestry gap in shadow review

### DIFF
--- a/crates/kin-cli/src/commands/ref_lookup.rs
+++ b/crates/kin-cli/src/commands/ref_lookup.rs
@@ -6,6 +6,48 @@ use kin_model::{BranchName, ChangeStore, Entity, EntityFilter, GraphStore};
 use kin_model::{Hash256, SemanticChangeId};
 use tracing::warn;
 
+/// A reference did not resolve to a semantic change — unknown ref syntax, a
+/// ref that legitimately does not exist, or a relative-ref hop (`^N`/`~N`)
+/// that runs past the start of history.
+///
+/// Distinguished from other failure modes (graph/backend faults) so callers
+/// can report it as a client-input error (e.g. HTTP 400) rather than an
+/// internal server error, without matching on message text.
+#[derive(Debug)]
+pub struct RefResolutionError {
+    reference: String,
+    reason: String,
+}
+
+impl std::fmt::Display for RefResolutionError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(
+            f,
+            "cannot resolve ref '{}': {}",
+            self.reference, self.reason
+        )
+    }
+}
+
+impl std::error::Error for RefResolutionError {}
+
+fn ref_error(reference: impl Into<String>, reason: impl Into<String>) -> anyhow::Error {
+    anyhow::Error::new(RefResolutionError {
+        reference: reference.into(),
+        reason: reason.into(),
+    })
+}
+
+/// True when `err` is, or wraps via added context, a [`RefResolutionError`].
+/// Lets callers outside this crate classify a failure as a client-input
+/// problem (bad ref) without depending on `anyhow` themselves or matching on
+/// message text — they only need to name the error type, which they can
+/// reach through their existing dependency on this crate.
+pub fn is_ref_resolution_error(err: &anyhow::Error) -> bool {
+    err.chain()
+        .any(|cause| cause.downcast_ref::<RefResolutionError>().is_some())
+}
+
 pub(crate) fn parse_change_id(input: &str) -> Result<SemanticChangeId> {
     Ok(SemanticChangeId::from_hash(
         Hash256::from_hex(input).map_err(|err| anyhow!("invalid change hash: {}", err))?,
@@ -141,6 +183,95 @@ where
     choose_entity_match(entities, entity_query)
 }
 
+/// One relative-ref hop applied after a base ref resolves: select the Nth
+/// parent (1-indexed) of the commit reached so far.
+#[derive(Debug, Clone, Copy)]
+struct ParentHop(usize);
+
+/// Split trailing `^`, `^N`, `~`, `~N` operators off the end of `reference`,
+/// returning the remaining base-ref text and the hops to apply, in
+/// application order (closest to the base first). Mirrors git's own suffix
+/// grammar (see `git-rev-parse(1)`, "Specifying Revisions"): bare `^`/`~` is
+/// one first-parent hop, `~N` desugars to N repeated first-parent hops, and
+/// `^N` selects the Nth parent directly (relevant only at merge commits,
+/// where parent order matters). Branch/tag names cannot themselves contain
+/// `^` or `~` under Git's own ref-name rules, so peeling trailing operators
+/// never misreads a legitimate name.
+fn split_relative_hops(reference: &str) -> Result<(&str, Vec<ParentHop>)> {
+    let mut hops = Vec::new();
+    let mut rest = reference;
+    while let Some(&last) = rest.as_bytes().last() {
+        if last == b'^' || last == b'~' {
+            hops.push(ParentHop(1));
+            rest = &rest[..rest.len() - 1];
+            continue;
+        }
+        if last.is_ascii_digit() {
+            let digits_start = rest
+                .rfind(|c: char| !c.is_ascii_digit())
+                .map(|i| i + 1)
+                .unwrap_or(0);
+            if digits_start == 0 {
+                // The whole remaining string is digits (e.g. a bare numeric
+                // ref) — not a `^N`/`~N` suffix, stop peeling.
+                break;
+            }
+            let marker = rest.as_bytes()[digits_start - 1];
+            if marker != b'^' && marker != b'~' {
+                break;
+            }
+            let n: usize = rest[digits_start..]
+                .parse()
+                .map_err(|_| ref_error(reference, "parent index is out of range"))?;
+            if marker == b'^' {
+                if n == 0 {
+                    // `^0` names the commit itself, not a parent hop — stop
+                    // peeling and let core resolution handle (or reject) it.
+                    break;
+                }
+                hops.push(ParentHop(n));
+            } else {
+                hops.extend(std::iter::repeat_n(ParentHop(1), n));
+            }
+            rest = &rest[..digits_start - 1];
+            continue;
+        }
+        break;
+    }
+    Ok((rest, hops))
+}
+
+/// Walk `hops` from `head`, following recorded parents in the graph.
+fn apply_parent_hops<G>(
+    graph: &G,
+    original: &str,
+    mut head: SemanticChangeId,
+    hops: &[ParentHop],
+) -> Result<SemanticChangeId>
+where
+    G: GraphStore,
+    <G as GraphStore>::Error: std::fmt::Display + Send + Sync + 'static,
+{
+    for hop in hops {
+        let change = graph
+            .get_change(&head)
+            .map_err(|err| anyhow!(err.to_string()))?
+            .ok_or_else(|| ref_error(original, format!("change {} not found in history", head)))?;
+        head = *change.parents.get(hop.0 - 1).ok_or_else(|| {
+            ref_error(
+                original,
+                format!(
+                    "{} has {} parent(s), no parent #{}",
+                    head,
+                    change.parents.len(),
+                    hop.0
+                ),
+            )
+        })?;
+    }
+    Ok(head)
+}
+
 fn resolve_explicit_ref<G>(
     graph: &G,
     layout: &kin_core::KinLayout,
@@ -150,69 +281,78 @@ where
     G: GraphStore,
     <G as GraphStore>::Error: std::fmt::Display + Send + Sync + 'static,
 {
-    if let Some(suffix) = reference.strip_prefix("HEAD") {
+    if reference.contains("@{") {
+        return Err(ref_error(
+            reference,
+            "reflog/upstream '@{...}' ref syntax is not supported",
+        ));
+    }
+
+    let (core, hops) = split_relative_hops(reference)?;
+    let head = resolve_ref_core(graph, layout, reference, core)?;
+    apply_parent_hops(graph, reference, head, &hops)
+}
+
+/// Resolve the non-relative "core" of a reference: exactly `HEAD`, a
+/// `branch:`/`git:`/`kin:`/`change:`-prefixed form, a bare branch name, a
+/// 40-character Git commit hash, or a Kin change id. `original` is the full,
+/// pre-peel reference text the caller supplied, threaded through only so
+/// error messages point at what was actually typed.
+fn resolve_ref_core<G>(
+    graph: &G,
+    layout: &kin_core::KinLayout,
+    original: &str,
+    core: &str,
+) -> Result<SemanticChangeId>
+where
+    G: GraphStore,
+    <G as GraphStore>::Error: std::fmt::Display + Send + Sync + 'static,
+{
+    if core == "HEAD" {
         let current = kin_core::read_current_branch(layout)?;
         let branch = graph
             .get_branch(&current)
             .map_err(|err| anyhow!(err.to_string()))?
-            .ok_or_else(|| anyhow!("branch '{}' not found", current))?;
-        let mut head = branch.head;
-        if let Some(tilde_part) = suffix.strip_prefix('~') {
-            let distance = tilde_part
-                .parse::<usize>()
-                .map_err(|_| anyhow!("invalid HEAD~N syntax: {}", reference))?;
-            for _ in 0..distance {
-                let change = graph
-                    .get_change(&head)
-                    .map_err(|err| anyhow!(err.to_string()))?
-                    .ok_or_else(|| anyhow!("change {} not found in history", head))?;
-                head = *change
-                    .parents
-                    .first()
-                    .ok_or_else(|| anyhow!("{} exceeds history depth", reference))?;
-            }
-        } else if !suffix.is_empty() {
-            bail!("unknown ref syntax: {}", reference);
-        }
-        return Ok(head);
+            .ok_or_else(|| ref_error(original, format!("branch '{}' not found", current)))?;
+        return Ok(branch.head);
     }
 
-    if let Some(branch_name) = reference.strip_prefix("branch:") {
-        return resolve_branch_head(graph, branch_name);
+    if let Some(branch_name) = core.strip_prefix("branch:") {
+        return resolve_branch_head(graph, original, branch_name);
     }
 
-    if let Some(git_oid) = reference.strip_prefix("git:") {
-        return resolve_imported_git_ref(graph, git_oid);
+    if let Some(git_oid) = core.strip_prefix("git:") {
+        return resolve_imported_git_ref(graph, original, git_oid);
     }
 
-    if let Some(change_ref) = reference
+    if let Some(change_ref) = core
         .strip_prefix("kin:")
-        .or_else(|| reference.strip_prefix("change:"))
+        .or_else(|| core.strip_prefix("change:"))
     {
-        return resolve_semantic_change(graph, change_ref);
+        return resolve_semantic_change(graph, original, change_ref);
     }
 
     if let Some(branch) = graph
-        .get_branch(&BranchName::new(reference))
+        .get_branch(&BranchName::new(core))
         .map_err(|err| anyhow!(err.to_string()))?
     {
         return Ok(branch.head);
     }
 
-    if reference.len() == 40 {
-        if let Ok(imported_change_id) = resolve_imported_git_ref(graph, reference) {
+    if core.len() == 40 {
+        if let Ok(imported_change_id) = resolve_imported_git_ref(graph, original, core) {
             return Ok(imported_change_id);
         }
     }
 
-    if parse_change_id(reference).is_ok() {
-        return resolve_semantic_change(graph, reference);
+    if parse_change_id(core).is_ok() {
+        return resolve_semantic_change(graph, original, core);
     }
 
-    bail!("unknown ref '{}'", reference)
+    Err(ref_error(original, format!("unknown ref '{}'", core)))
 }
 
-fn resolve_branch_head<G>(graph: &G, branch_name: &str) -> Result<SemanticChangeId>
+fn resolve_branch_head<G>(graph: &G, original: &str, branch_name: &str) -> Result<SemanticChangeId>
 where
     G: GraphStore,
     <G as GraphStore>::Error: std::fmt::Display + Send + Sync + 'static,
@@ -224,10 +364,13 @@ where
         return Ok(branch.head);
     }
 
-    bail!("branch '{}' not found", branch_name);
+    Err(ref_error(
+        original,
+        format!("branch '{}' not found", branch_name),
+    ))
 }
 
-fn resolve_imported_git_ref<G>(graph: &G, git_oid: &str) -> Result<SemanticChangeId>
+fn resolve_imported_git_ref<G>(graph: &G, original: &str, git_oid: &str) -> Result<SemanticChangeId>
 where
     G: GraphStore,
     <G as GraphStore>::Error: std::fmt::Display + Send + Sync + 'static,
@@ -240,16 +383,29 @@ where
     {
         Ok(imported_change_id)
     } else {
-        bail!("imported Git commit '{}' not found", git_oid);
+        Err(ref_error(
+            original,
+            format!("imported Git commit '{}' not found", git_oid),
+        ))
     }
 }
 
-fn extract_git_ref(reference: &str) -> Option<&str> {
-    if let Some(git_oid) = reference.strip_prefix("git:") {
+/// Extract the bare Git commit oid a reference names, if any, peeling any
+/// trailing `^`/`~N` relative-ref hops first so a not-yet-imported commit
+/// referenced as e.g. `<oid>~2` is still recognized as needing hydration for
+/// its `<oid>` core. Returns a slice of `reference`, so hydrating the
+/// returned oid and then re-resolving the original (unpeeled) string
+/// resolves the hop against the now-present history.
+pub fn extract_git_ref(reference: &str) -> Option<&str> {
+    if reference.contains("@{") {
+        return None;
+    }
+    let (core, _hops) = split_relative_hops(reference).ok()?;
+    if let Some(git_oid) = core.strip_prefix("git:") {
         return Some(git_oid);
     }
-    if reference.len() == 40 {
-        return Some(reference);
+    if core.len() == 40 {
+        return Some(core);
     }
     None
 }
@@ -314,16 +470,20 @@ fn hydrate_imported_git_ref(
     }
 
     if graph.get_change(&imported_change_id)?.is_none() {
-        bail!(
-            "imported Git commit '{}' not found after hydration",
-            git_oid
-        );
+        return Err(ref_error(
+            git_oid,
+            "imported Git commit not found after hydration",
+        ));
     }
 
     Ok(inserted > 0)
 }
 
-fn resolve_semantic_change<G>(graph: &G, change_ref: &str) -> Result<SemanticChangeId>
+fn resolve_semantic_change<G>(
+    graph: &G,
+    original: &str,
+    change_ref: &str,
+) -> Result<SemanticChangeId>
 where
     G: GraphStore,
     <G as GraphStore>::Error: std::fmt::Display + Send + Sync + 'static,
@@ -336,7 +496,10 @@ where
     {
         Ok(change_id)
     } else {
-        bail!("change {} not found", change_id);
+        Err(ref_error(
+            original,
+            format!("change {} not found", change_id),
+        ))
     }
 }
 
@@ -523,5 +686,212 @@ mod tests {
 
         let resolved = resolve_ref(&graph, &layout, Some("branch:feature/history")).unwrap();
         assert_eq!(resolved, branch.head);
+    }
+
+    fn make_change(id: SemanticChangeId, parents: Vec<SemanticChangeId>) -> SemanticChange {
+        SemanticChange {
+            id,
+            parents,
+            timestamp: Timestamp::now(),
+            author: AuthorId::new("test"),
+            message: "test change".to_string(),
+            entity_deltas: vec![],
+            relation_deltas: vec![],
+            artifact_deltas: vec![],
+            projected_files: vec![],
+            spec_link: None,
+            evidence: vec![],
+            risk_summary: None,
+            authored_on: None,
+        }
+    }
+
+    fn change_id(byte: u8) -> SemanticChangeId {
+        SemanticChangeId::from_hash(Hash256::from_bytes([byte; 32]))
+    }
+
+    /// A layout with `main` checked out as the current branch, backed by a
+    /// native chain `grandparent <- parent <- head`, where `head` is a merge
+    /// of `parent` and `other_parent` (so `^2`-style parent selection has
+    /// something real to select).
+    fn temp_layout_on_main(graph: &InMemoryGraph) -> (kin_core::KinLayout, [SemanticChangeId; 4]) {
+        let layout = temp_layout();
+        kin_core::write_current_branch(&layout, &BranchName::new("main")).unwrap();
+
+        let grandparent = change_id(0x01);
+        let parent = change_id(0x02);
+        let other_parent = change_id(0x03);
+        let head = change_id(0x04);
+
+        graph
+            .create_change(&make_change(grandparent, vec![]))
+            .unwrap();
+        graph
+            .create_change(&make_change(parent, vec![grandparent]))
+            .unwrap();
+        graph
+            .create_change(&make_change(other_parent, vec![]))
+            .unwrap();
+        graph
+            .create_change(&make_change(head, vec![parent, other_parent]))
+            .unwrap();
+        graph
+            .create_branch(&Branch {
+                name: BranchName::new("main"),
+                head,
+            })
+            .unwrap();
+
+        (layout, [grandparent, parent, other_parent, head])
+    }
+
+    // ── Caret/tilde/relative-ref peeling ──
+
+    #[test]
+    fn resolve_ref_head_caret_matches_head_tilde_one() {
+        let graph = InMemoryGraph::new();
+        let (layout, [_grandparent, parent, _other_parent, _head]) = temp_layout_on_main(&graph);
+
+        let caret = resolve_ref(&graph, &layout, Some("HEAD^")).unwrap();
+        let tilde = resolve_ref(&graph, &layout, Some("HEAD~1")).unwrap();
+        assert_eq!(caret, parent, "HEAD^ must select the first parent");
+        assert_eq!(caret, tilde, "HEAD^ and HEAD~1 must agree");
+    }
+
+    #[test]
+    fn resolve_ref_caret_n_selects_that_parent_by_position() {
+        let graph = InMemoryGraph::new();
+        let (layout, [_grandparent, parent, other_parent, _head]) = temp_layout_on_main(&graph);
+
+        let first = resolve_ref(&graph, &layout, Some("HEAD^1")).unwrap();
+        let second = resolve_ref(&graph, &layout, Some("HEAD^2")).unwrap();
+        assert_eq!(
+            first, parent,
+            "HEAD^1 must select the first recorded parent"
+        );
+        assert_eq!(
+            second, other_parent,
+            "HEAD^2 must select the second recorded parent (the merged-in side)"
+        );
+    }
+
+    #[test]
+    fn resolve_ref_chained_hops_walk_in_order() {
+        let graph = InMemoryGraph::new();
+        let (layout, [grandparent, _parent, _other_parent, _head]) = temp_layout_on_main(&graph);
+
+        let resolved = resolve_ref(&graph, &layout, Some("HEAD^1~1")).unwrap();
+        assert_eq!(
+            resolved, grandparent,
+            "HEAD^1~1 is first-parent then first-parent again"
+        );
+
+        let resolved_bare = resolve_ref(&graph, &layout, Some("HEAD^^")).unwrap();
+        assert_eq!(
+            resolved_bare, grandparent,
+            "HEAD^^ is two first-parent hops, same as HEAD^1~1 here"
+        );
+    }
+
+    #[test]
+    fn resolve_ref_tilde_n_desugars_to_n_first_parent_hops() {
+        let graph = InMemoryGraph::new();
+        let (layout, [grandparent, _parent, _other_parent, _head]) = temp_layout_on_main(&graph);
+
+        let resolved = resolve_ref(&graph, &layout, Some("HEAD~2")).unwrap();
+        assert_eq!(resolved, grandparent);
+    }
+
+    #[test]
+    fn resolve_ref_hop_past_history_start_fails_cleanly_not_opaque() {
+        let graph = InMemoryGraph::new();
+        let (layout, _ids) = temp_layout_on_main(&graph);
+
+        let err = resolve_ref(&graph, &layout, Some("HEAD~50")).unwrap_err();
+        assert!(
+            is_ref_resolution_error(&err),
+            "a hop past the start of history must be a RefResolutionError, not an opaque error: {err:#}"
+        );
+    }
+
+    #[test]
+    fn resolve_ref_rejects_reflog_upstream_syntax_cleanly() {
+        let graph = InMemoryGraph::new();
+        let (layout, _ids) = temp_layout_on_main(&graph);
+
+        let err = resolve_ref(&graph, &layout, Some("HEAD@{upstream}")).unwrap_err();
+        assert!(
+            is_ref_resolution_error(&err),
+            "unsupported '@{{...}}' syntax must fail as a clean ref-resolution error, not panic or 500: {err:#}"
+        );
+    }
+
+    #[test]
+    fn resolve_ref_unknown_ref_is_classified_as_ref_resolution_error() {
+        let graph = InMemoryGraph::new();
+        let layout = temp_layout();
+
+        let err = resolve_ref(&graph, &layout, Some("this-branch-does-not-exist")).unwrap_err();
+        assert!(
+            is_ref_resolution_error(&err),
+            "an unknown ref must be classified as a client-input error: {err:#}"
+        );
+    }
+
+    #[test]
+    fn resolve_ref_caret_applies_after_any_core_form_not_just_head() {
+        let graph = InMemoryGraph::new();
+        let layout = temp_layout();
+        let git_oid = "2222222222222222222222222222222222222222";
+        let imported_id = kin_git::semantic_change_id_from_git_oid_hex(git_oid).unwrap();
+        let parent_id = change_id(0x09);
+        graph
+            .create_change(&make_change(parent_id, vec![]))
+            .unwrap();
+        graph
+            .create_change(&make_change(imported_id, vec![parent_id]))
+            .unwrap();
+
+        let resolved = resolve_ref(&graph, &layout, Some(&format!("{git_oid}^"))).unwrap();
+        assert_eq!(
+            resolved, parent_id,
+            "relative hops must apply after any resolved core ref, not just HEAD"
+        );
+    }
+
+    #[test]
+    fn split_relative_hops_parses_caret_and_tilde_chains() {
+        let (core, hops) = split_relative_hops("HEAD").unwrap();
+        assert_eq!(core, "HEAD");
+        assert!(hops.is_empty());
+
+        let (core, hops) = split_relative_hops("HEAD^").unwrap();
+        assert_eq!(core, "HEAD");
+        assert_eq!(hops.len(), 1);
+        assert_eq!(hops[0].0, 1);
+
+        let (core, hops) = split_relative_hops("HEAD^2").unwrap();
+        assert_eq!(core, "HEAD");
+        assert_eq!(hops.len(), 1);
+        assert_eq!(hops[0].0, 2);
+
+        let (core, hops) = split_relative_hops("HEAD~3").unwrap();
+        assert_eq!(core, "HEAD");
+        assert_eq!(hops.len(), 3);
+        assert!(hops.iter().all(|h| h.0 == 1));
+
+        let (core, hops) = split_relative_hops("HEAD~2^").unwrap();
+        assert_eq!(core, "HEAD");
+        assert_eq!(hops.len(), 3);
+        assert!(hops.iter().all(|h| h.0 == 1));
+    }
+
+    #[test]
+    fn extract_git_ref_recognizes_hop_suffixed_sha() {
+        let sha = "3333333333333333333333333333333333333333";
+        assert_eq!(extract_git_ref(&format!("{sha}~2")), Some(sha));
+        assert_eq!(extract_git_ref(&format!("git:{sha}^")), Some(sha));
+        assert_eq!(extract_git_ref("HEAD^"), None);
+        assert_eq!(extract_git_ref("HEAD@{upstream}"), None);
     }
 }

--- a/crates/kin-cli/src/commands/ref_lookup.rs
+++ b/crates/kin-cli/src/commands/ref_lookup.rs
@@ -345,11 +345,46 @@ where
         }
     }
 
+    if is_abbreviated_git_hex(core) {
+        match kin_git::expand_git_commit_prefix(layout.working_dir(), core) {
+            kin_git::GitOidPrefixExpansion::Commit(full_oid) => {
+                if let Ok(imported_change_id) = resolve_imported_git_ref(graph, original, &full_oid)
+                {
+                    return Ok(imported_change_id);
+                }
+                return Err(ref_error(
+                    original,
+                    format!(
+                        "git commit '{}' (full id {}) is not imported into this repository's history; use the full 40-character id to hydrate it",
+                        core, full_oid
+                    ),
+                ));
+            }
+            kin_git::GitOidPrefixExpansion::Ambiguous => {
+                return Err(ref_error(
+                    original,
+                    format!(
+                        "git commit prefix '{}' is ambiguous; use more characters or the full 40-character id",
+                        core
+                    ),
+                ));
+            }
+            kin_git::GitOidPrefixExpansion::NotFound => {}
+        }
+    }
+
     if parse_change_id(core).is_ok() {
         return resolve_semantic_change(graph, original, core);
     }
 
     Err(ref_error(original, format!("unknown ref '{}'", core)))
+}
+
+/// True for a plausible abbreviated Git commit hash: 4–39 hex characters.
+/// Full 40-character ids resolve through the exact-id path instead, and
+/// anything shorter than Git's 4-character minimum never expands.
+fn is_abbreviated_git_hex(core: &str) -> bool {
+    (4..40).contains(&core.len()) && core.bytes().all(|b| b.is_ascii_hexdigit())
 }
 
 fn resolve_branch_head<G>(graph: &G, original: &str, branch_name: &str) -> Result<SemanticChangeId>

--- a/crates/kin-cli/src/commands/review.rs
+++ b/crates/kin-cli/src/commands/review.rs
@@ -298,6 +298,18 @@ fn build_shadow_run_response(
     author: Option<String>,
     json: bool,
 ) -> Result<(ReviewResponse, bool)> {
+    // The everyday "your branch is behind main" case: base is not on head's
+    // ancestry. That gap is provable from the Git commit-parent DAG alone —
+    // no semantic hydration needed — so it is checked before either ref pays
+    // for a full history import. Returns `None` whenever the fast
+    // conclusion can't be drawn, in which case the normal resolve-and-hydrate
+    // path below runs exactly as it always has.
+    if let Some(report) =
+        shadow_ancestry_fast_path_gap(graph, layout, &base, &head, &title, &source_url, &author)?
+    {
+        return Ok((shadow_response_from_report(&report, json)?, false));
+    }
+
     // Resolve the head ref before the base ref. A review pair is almost always
     // ancestor..descendant, so importing the head first hydrates the full git
     // ancestry in a single pass; the base is then already present in the graph
@@ -331,24 +343,82 @@ fn build_shadow_run_response(
     };
 
     let report = kin_review::build_shadow_report(graph, &request)?;
-
-    if json {
-        return Ok((
-            ReviewResponse {
-                text: String::new(),
-                json: Some(serde_json::to_string_pretty(&report)?),
-            },
-            hydrated_git_history,
-        ));
-    }
-
     Ok((
-        ReviewResponse {
-            text: kin_review::format_shadow_report(&report),
-            json: None,
-        },
+        shadow_response_from_report(&report, json)?,
         hydrated_git_history,
     ))
+}
+
+/// Cheap pre-check for the shadow path's `base_not_on_head_ancestry` gap.
+///
+/// Applies only when both refs are bare Git commit forms (`git:<oid>` or a
+/// 40-character hex oid) and at least one is not yet present in the graph —
+/// the only situation where the default path below pays for a full history
+/// import before `kin_review::build_shadow_report`'s own ancestry check
+/// would run. Reads only the on-disk Git commit-parent graph (via
+/// `kin_git::is_ancestor_commit`), never the working tree or blobs, so a
+/// stale base returns the existing gap report without importing anything.
+///
+/// Returns `Ok(None)` whenever the fast conclusion can't be drawn — either
+/// ref isn't a bare Git commit form, either commit is missing from the Git
+/// object database, or ancestry actually holds — so the caller falls
+/// through to the exact existing resolve-and-hydrate path, unchanged.
+#[allow(clippy::too_many_arguments)]
+fn shadow_ancestry_fast_path_gap(
+    graph: &kin_db::InMemoryGraph,
+    layout: &kin_core::KinLayout,
+    base: &str,
+    head: &str,
+    title: &Option<String>,
+    source_url: &Option<String>,
+    author: &Option<String>,
+) -> Result<Option<kin_review::ShadowGateReport>> {
+    let Some(base_oid) = crate::commands::ref_lookup::extract_git_ref(base) else {
+        return Ok(None);
+    };
+    let Some(head_oid) = crate::commands::ref_lookup::extract_git_ref(head) else {
+        return Ok(None);
+    };
+    let needs_check = crate::commands::ref_lookup::git_ref_requires_hydration(graph, base)
+        || crate::commands::ref_lookup::git_ref_requires_hydration(graph, head);
+    if !needs_check {
+        return Ok(None);
+    }
+
+    let Some(false) = kin_git::is_ancestor_commit(layout.working_dir(), base_oid, head_oid) else {
+        return Ok(None);
+    };
+
+    let request = kin_review::ShadowRequest {
+        base_ref: base.to_string(),
+        head_ref: head.to_string(),
+        resolved_base: kin_git::semantic_change_id_from_git_oid_hex(base_oid)?,
+        resolved_head: kin_git::semantic_change_id_from_git_oid_hex(head_oid)?,
+        title: title.clone(),
+        source_url: source_url.clone(),
+        author: author.clone(),
+        actor: crate::provenance::current_actor_label(),
+    };
+    Ok(Some(kin_review::build_shadow_report_base_off_ancestry(
+        graph, &request,
+    )?))
+}
+
+fn shadow_response_from_report(
+    report: &kin_review::ShadowGateReport,
+    json: bool,
+) -> Result<ReviewResponse> {
+    if json {
+        return Ok(ReviewResponse {
+            text: String::new(),
+            json: Some(serde_json::to_string_pretty(report)?),
+        });
+    }
+
+    Ok(ReviewResponse {
+        text: kin_review::format_shadow_report(report),
+        json: None,
+    })
 }
 
 fn compute_review(
@@ -1193,5 +1263,123 @@ mod tests {
         // query_audit_events returns most-recent first.
         assert_eq!(events[0].action, "review.decide");
         assert_eq!(events[1].action, "review.create");
+    }
+
+    /// The everyday "your branch is behind main" case: a stale, unrelated
+    /// base against a raw Git commit head that has never been imported.
+    /// Proves the fast path returns the identical `base_not_on_head_ancestry`
+    /// gap report without ever hydrating either side — checked structurally
+    /// (both refs still report "requires hydration" afterward), not by wall
+    /// clock, per the fix's own contract.
+    #[test]
+    fn shadow_stale_base_returns_gap_report_without_hydrating() {
+        use std::process::Command;
+
+        let dir = tempfile::tempdir().unwrap();
+        let repo = dir.path();
+
+        let git = |args: &[&str]| {
+            let output = Command::new("git")
+                .args(args)
+                .current_dir(repo)
+                .output()
+                .expect("run git");
+            assert!(
+                output.status.success(),
+                "git {:?} failed: stdout={} stderr={}",
+                args,
+                String::from_utf8_lossy(&output.stdout),
+                String::from_utf8_lossy(&output.stderr)
+            );
+        };
+        let commit = |file: &str, content: &str, message: &str, epoch: &str| {
+            std::fs::write(repo.join(file), content).unwrap();
+            git(&["add", "."]);
+            let date = format!("{epoch} +0000");
+            let output = Command::new("git")
+                .args(["commit", "-m", message])
+                .env("GIT_AUTHOR_DATE", &date)
+                .env("GIT_COMMITTER_DATE", &date)
+                .current_dir(repo)
+                .output()
+                .expect("git commit");
+            assert!(output.status.success(), "git commit failed");
+        };
+        let head_sha = || {
+            let output = Command::new("git")
+                .args(["rev-parse", "HEAD"])
+                .current_dir(repo)
+                .output()
+                .expect("git rev-parse HEAD");
+            String::from_utf8(output.stdout)
+                .expect("utf8 sha")
+                .trim()
+                .to_string()
+        };
+
+        git(&["init"]);
+        git(&["config", "user.email", "shadow-fastpath@example.com"]);
+        git(&["config", "user.name", "Shadow Fastpath Test"]);
+
+        commit("a.txt", "1\n", "root", "1000000000");
+        let root = head_sha();
+
+        commit("a.txt", "a\n", "branch a", "1000000100");
+        let branch_a = head_sha();
+
+        // Fork branch b from root, independent of branch a — neither is an
+        // ancestor of the other.
+        git(&["checkout", &root]);
+        commit("a.txt", "b\n", "branch b", "1000000200");
+        let branch_b = head_sha();
+
+        let layout = kin_core::KinLayout::new(repo.join(".kin"));
+        let graph = kin_db::InMemoryGraph::new();
+
+        assert!(
+            crate::commands::ref_lookup::git_ref_requires_hydration(&graph, &branch_a),
+            "branch a must not be imported before the call"
+        );
+        assert!(
+            crate::commands::ref_lookup::git_ref_requires_hydration(&graph, &branch_b),
+            "branch b must not be imported before the call"
+        );
+
+        let (response, hydrated) = build_shadow_run_response(
+            &layout,
+            &graph,
+            branch_a.clone(),
+            branch_b.clone(),
+            None,
+            None,
+            None,
+            true,
+        )
+        .expect("a stale base must produce a gap report, not an error");
+
+        assert!(
+            !hydrated,
+            "the fast path must report no hydration was performed"
+        );
+
+        let json: serde_json::Value =
+            serde_json::from_str(response.json.as_deref().expect("json response")).unwrap();
+        let gaps = json["evidence_gaps"].as_array().unwrap();
+        assert!(
+            gaps.iter()
+                .any(|gap| gap["kind"] == "base_not_on_head_ancestry"),
+            "expected a base_not_on_head_ancestry gap: {gaps:?}"
+        );
+
+        // Structural proof, not a timing assertion: neither commit was ever
+        // imported into the graph, so both still report "requires hydration".
+        assert!(
+            crate::commands::ref_lookup::git_ref_requires_hydration(&graph, &branch_a),
+            "branch a must remain un-imported: the fast path must not hydrate it"
+        );
+        assert!(
+            crate::commands::ref_lookup::git_ref_requires_hydration(&graph, &branch_b),
+            "branch b must remain un-imported: the fast path must not hydrate it"
+        );
     }
 }

--- a/crates/kin-cli/tests/review_shadow_json.rs
+++ b/crates/kin-cli/tests/review_shadow_json.rs
@@ -282,6 +282,86 @@ fn shadow_report_fails_loud_on_unknown_ref() {
     );
 }
 
+/// `HEAD^` — the idiomatic "review my last commit" — must resolve on a
+/// freshly-inited repo with no further Git ancestry import: `kin init`
+/// shallow-imports the current Git HEAD as a single change parented on
+/// genesis, so `HEAD^` walks straight to genesis in the graph.
+#[test]
+fn shadow_report_head_caret_resolves_from_a_fresh_init() {
+    let dir = tempdir().expect("tempdir");
+    let repo = dir.path();
+    setup_fixture_repo(repo);
+    kin_init(repo);
+
+    let report = run_shadow_json(repo, "HEAD^", "HEAD");
+
+    assert_eq!(report["schema_version"], 1);
+    assert_eq!(report["mode"], "shadow");
+    assert!(!report["input"]["resolved_base"]
+        .as_str()
+        .unwrap()
+        .is_empty());
+    assert!(!report["input"]["resolved_head"]
+        .as_str()
+        .unwrap()
+        .is_empty());
+}
+
+/// Caret and tilde relative-ref syntax must resolve to the same change on
+/// the shadow CLI path.
+#[test]
+fn shadow_report_head_caret_and_head_tilde_one_agree() {
+    let dir = tempdir().expect("tempdir");
+    let repo = dir.path();
+    setup_fixture_repo(repo);
+    kin_init(repo);
+
+    let caret_report = run_shadow_json(repo, "HEAD^", "HEAD");
+    let tilde_report = run_shadow_json(repo, "HEAD~1", "HEAD");
+
+    assert_eq!(
+        caret_report["input"]["resolved_base"], tilde_report["input"]["resolved_base"],
+        "HEAD^ and HEAD~1 must resolve to the same change"
+    );
+}
+
+/// A ref the resolver genuinely cannot make sense of must still fail the
+/// command, but with a friendly, specific message rather than an opaque
+/// HTTP 500 — the daemon now reports it as a client error.
+#[test]
+fn shadow_report_unsupported_ref_syntax_fails_friendly_not_opaque() {
+    let dir = tempdir().expect("tempdir");
+    let repo = dir.path();
+    let (_base, head, _artifact_head) = setup_fixture_repo(repo);
+    kin_init(repo);
+
+    let output = kin_command()
+        .args([
+            "review",
+            "shadow",
+            &format!("HEAD@{{upstream}}..{head}"),
+            "--json",
+        ])
+        .current_dir(repo)
+        .output()
+        .expect("run kin review shadow with unsupported ref syntax");
+
+    assert!(
+        !output.status.success(),
+        "unresolvable ref must still fail the command, got stdout={}",
+        String::from_utf8_lossy(&output.stdout)
+    );
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains("cannot resolve ref"),
+        "error must name the ref-resolution problem plainly: {stderr}"
+    );
+    assert!(
+        !stderr.contains("HTTP 500"),
+        "an unresolvable ref must not surface as an opaque server error: {stderr}"
+    );
+}
+
 /// A review pair is almost always ancestor..descendant, and `review shadow`
 /// resolves the head ref before the base ref so that ancestry hydrates in a
 /// single pass. This proves the invariant that makes head-first cheap: once the

--- a/crates/kin-cli/tests/review_shadow_json.rs
+++ b/crates/kin-cli/tests/review_shadow_json.rs
@@ -107,6 +107,33 @@ fn setup_fixture_repo(repo: &Path) -> (String, String, String) {
     (base, head, artifact_head)
 }
 
+/// Fixture: a root commit followed by two commits on divergent named
+/// branches — neither is an ancestor of the other. Forks via a named branch
+/// (not a detached checkout) so the repo's Git HEAD stays on a normal branch
+/// throughout, same as every other fixture in this file.
+fn setup_divergent_repo(repo: &Path) -> (String, String) {
+    std::fs::write(repo.join("shared.txt"), "root\n").expect("write shared.txt");
+    run_git(repo, &["init"]);
+    run_git(repo, &["config", "user.email", "shadow-test@example.com"]);
+    run_git(repo, &["config", "user.name", "Shadow Test"]);
+    run_git(repo, &["add", "-A"]);
+    run_git(repo, &["commit", "-m", "root"]);
+    let root = git_head(repo);
+
+    std::fs::write(repo.join("shared.txt"), "branch a\n").expect("write branch a");
+    run_git(repo, &["add", "-A"]);
+    run_git(repo, &["commit", "-m", "branch a"]);
+    let branch_a = git_head(repo);
+
+    run_git(repo, &["checkout", "-b", "diverged", &root]);
+    std::fs::write(repo.join("shared.txt"), "branch b\n").expect("write branch b");
+    run_git(repo, &["add", "-A"]);
+    run_git(repo, &["commit", "-m", "branch b"]);
+    let branch_b = git_head(repo);
+
+    (branch_a, branch_b)
+}
+
 fn kin_init(repo: &Path) {
     let init = kin_command()
         .arg("init")
@@ -359,6 +386,26 @@ fn shadow_report_unsupported_ref_syntax_fails_friendly_not_opaque() {
     assert!(
         !stderr.contains("HTTP 500"),
         "an unresolvable ref must not surface as an opaque server error: {stderr}"
+    );
+}
+
+/// The everyday "your branch is behind main" case — base is not on head's
+/// ancestry — must still surface the existing gap report end to end through
+/// the real CLI and daemon, not just at the unit level.
+#[test]
+fn shadow_report_stale_base_surfaces_ancestry_gap_end_to_end() {
+    let dir = tempdir().expect("tempdir");
+    let repo = dir.path();
+    let (branch_a, branch_b) = setup_divergent_repo(repo);
+    kin_init(repo);
+
+    let report = run_shadow_json(repo, &branch_a, &branch_b);
+
+    let gaps = report["evidence_gaps"].as_array().unwrap();
+    assert!(
+        gaps.iter()
+            .any(|gap| gap["kind"] == "base_not_on_head_ancestry"),
+        "divergent refs must surface the base_not_on_head_ancestry gap: {gaps:?}"
     );
 }
 

--- a/crates/kin-cli/tests/review_shadow_json.rs
+++ b/crates/kin-cli/tests/review_shadow_json.rs
@@ -468,3 +468,82 @@ fn shadow_head_import_hydrates_ancestor_base_in_single_pass() {
         "base and head must resolve to distinct semantic changes"
     );
 }
+
+/// Abbreviated commit hashes — the form users copy from `git log --oneline`
+/// — must resolve to the same changes as their full 40-character ids.
+#[test]
+fn shadow_report_abbreviated_shas_resolve_like_full() {
+    let dir = tempdir().expect("tempdir");
+    let repo = dir.path();
+    let (base, head, _artifact_head) = setup_fixture_repo(repo);
+    kin_init(repo);
+
+    let full_report = run_shadow_json(repo, &base, &head);
+    let abbrev_report = run_shadow_json(repo, &base[..8], &head[..8]);
+
+    assert_eq!(
+        abbrev_report["input"]["resolved_base"], full_report["input"]["resolved_base"],
+        "abbreviated base must resolve to the same change as the full id"
+    );
+    assert_eq!(
+        abbrev_report["input"]["resolved_head"], full_report["input"]["resolved_head"],
+        "abbreviated head must resolve to the same change as the full id"
+    );
+    assert_eq!(
+        abbrev_report["verdict"], full_report["verdict"],
+        "abbreviated and full ranges must produce the same verdict"
+    );
+}
+
+/// Abbreviated hashes compose with relative-ref hops: `<abbrev>~1..<abbrev>`
+/// names the same range as `<full-base>..<full-head>` in a linear history.
+#[test]
+fn shadow_report_abbreviated_sha_with_hop_composes() {
+    let dir = tempdir().expect("tempdir");
+    let repo = dir.path();
+    let (base, head, _artifact_head) = setup_fixture_repo(repo);
+    kin_init(repo);
+
+    let full_report = run_shadow_json(repo, &base, &head);
+    let hop_report = run_shadow_json(repo, &format!("{}~1", &head[..8]), &head[..8]);
+
+    assert_eq!(
+        hop_report["input"]["resolved_base"], full_report["input"]["resolved_base"],
+        "<abbrev>~1 must resolve to the full head's parent"
+    );
+    assert_eq!(
+        hop_report["input"]["resolved_head"], full_report["input"]["resolved_head"],
+        "abbreviated hop head must match the full head"
+    );
+}
+
+/// An abbreviated hash matching nothing must fail with the friendly
+/// ref-resolution error, exactly like any other unresolvable ref.
+#[test]
+fn shadow_report_unknown_abbreviated_sha_fails_friendly() {
+    let dir = tempdir().expect("tempdir");
+    let repo = dir.path();
+    let (_base, head, _artifact_head) = setup_fixture_repo(repo);
+    kin_init(repo);
+
+    let output = kin_command()
+        .args(["review", "shadow", &format!("deadbeef..{head}"), "--json"])
+        .current_dir(repo)
+        .output()
+        .expect("run kin review shadow with an unknown abbreviated sha");
+
+    assert!(
+        !output.status.success(),
+        "an unknown abbreviated sha must fail the command, got stdout={}",
+        String::from_utf8_lossy(&output.stdout)
+    );
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains("cannot resolve ref"),
+        "error must name the ref-resolution problem plainly: {stderr}"
+    );
+    assert!(
+        !stderr.contains("HTTP 500"),
+        "unknown abbreviated shas must not surface as opaque server errors: {stderr}"
+    );
+}

--- a/crates/kin-daemon/src/api.rs
+++ b/crates/kin-daemon/src/api.rs
@@ -3398,7 +3398,19 @@ async fn review(
     let execution =
         kin_cli::commands::review::execute_review_request(&state.layout, graph.as_ref(), req)
             .await
-            .map_err(internal_error)?;
+            .map_err(|err| {
+                // A ref the resolver cannot make sense of is the caller's
+                // input, not a server fault — e.g. a shadow request naming a
+                // ref that doesn't exist or uses syntax the resolver doesn't
+                // understand — so it is reported as a client error with the
+                // full "why" chain instead of falling into the generic
+                // internal-error path.
+                if kin_cli::commands::ref_lookup::is_ref_resolution_error(&err) {
+                    (StatusCode::BAD_REQUEST, format!("{err:#}"))
+                } else {
+                    internal_error(err)
+                }
+            })?;
     if execution.hydrated_git_history {
         state.bump_version();
         state.save_snapshot().map_err(internal_error)?;

--- a/crates/kin-git/src/import.rs
+++ b/crates/kin-git/src/import.rs
@@ -192,6 +192,47 @@ pub fn is_ancestor_commit(
     Some(false)
 }
 
+/// Outcome of expanding an abbreviated Git commit hash against the object
+/// database of the repository at `repo_path`.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum GitOidPrefixExpansion {
+    /// Exactly one object matches the prefix and it is a commit; carries the
+    /// full 40-character hex id.
+    Commit(String),
+    /// More than one object in the repository shares the prefix.
+    Ambiguous,
+    /// No object matches, the unique match is not a commit, or the
+    /// repository/prefix cannot be inspected at all.
+    NotFound,
+}
+
+/// Expand an abbreviated (4–39 hex character) Git commit hash to its full id.
+///
+/// Only the Git object database is consulted for the expansion; whether the
+/// expanded commit exists as imported semantic history stays the caller's
+/// decision, so graph authority over history is unchanged. Repository-open
+/// and prefix-parse failures report as `NotFound` — callers treat that
+/// exactly like an unknown ref.
+pub fn expand_git_commit_prefix(repo_path: &Path, prefix_hex: &str) -> GitOidPrefixExpansion {
+    let Ok(repo) = open_repo(repo_path) else {
+        return GitOidPrefixExpansion::NotFound;
+    };
+    let Ok(prefix) = gix::hash::Prefix::from_hex(prefix_hex) else {
+        return GitOidPrefixExpansion::NotFound;
+    };
+    match repo.objects.lookup_prefix(prefix, None) {
+        Ok(Some(Ok(id))) => {
+            if repo.find_commit(id).is_ok() {
+                GitOidPrefixExpansion::Commit(id.to_string())
+            } else {
+                GitOidPrefixExpansion::NotFound
+            }
+        }
+        Ok(Some(Err(()))) => GitOidPrefixExpansion::Ambiguous,
+        _ => GitOidPrefixExpansion::NotFound,
+    }
+}
+
 /// Shallow import: create a single SemanticChange from HEAD's tree.
 fn import_shallow(
     repo: &gix::Repository,
@@ -1682,5 +1723,77 @@ mod tests {
         let dir = tempfile::tempdir().unwrap();
         let sha = "1111111111111111111111111111111111111111";
         assert_eq!(is_ancestor_commit(dir.path(), sha, sha), None);
+    }
+
+    #[test]
+    fn expand_git_commit_prefix_unique_absent_and_too_short() {
+        let dir = tempfile::tempdir().unwrap();
+        if !init_git_repo(dir.path()) {
+            eprintln!("git not available, skipping prefix expansion test");
+            return;
+        }
+
+        commit_file(dir.path(), "a.txt", "1\n", "base", "1000000000");
+        let full = commit_sha(dir.path());
+
+        match expand_git_commit_prefix(dir.path(), &full[..8]) {
+            GitOidPrefixExpansion::Commit(expanded) => assert_eq!(
+                expanded, full,
+                "a unique prefix must expand to its full commit id"
+            ),
+            other => panic!("unique prefix must expand to a commit, got {:?}", other),
+        }
+        assert_eq!(
+            expand_git_commit_prefix(dir.path(), "deadbeef"),
+            GitOidPrefixExpansion::NotFound,
+            "a prefix matching no object must report NotFound"
+        );
+        assert_eq!(
+            expand_git_commit_prefix(dir.path(), "abc"),
+            GitOidPrefixExpansion::NotFound,
+            "prefixes below git's 4-character minimum never expand"
+        );
+    }
+
+    #[test]
+    fn expand_git_commit_prefix_outside_a_repo_is_not_found() {
+        let dir = tempfile::tempdir().unwrap();
+        assert_eq!(
+            expand_git_commit_prefix(dir.path(), "deadbeef"),
+            GitOidPrefixExpansion::NotFound
+        );
+    }
+
+    #[test]
+    fn expand_git_commit_prefix_reports_ambiguity() {
+        let dir = tempfile::tempdir().unwrap();
+        if !init_git_repo(dir.path()) {
+            eprintln!("git not available, skipping prefix ambiguity test");
+            return;
+        }
+
+        commit_file(dir.path(), "a.txt", "1\n", "base", "1000000000");
+
+        // Two loose-object entries sharing the 8-hex prefix `aabbccdd`; prefix
+        // lookup disambiguates on object ids (file names), so placeholder
+        // contents are enough to make the prefix ambiguous.
+        let loose_dir = dir.path().join(".git/objects/aa");
+        std::fs::create_dir_all(&loose_dir).unwrap();
+        std::fs::write(
+            loose_dir.join("bbccdd00000000000000000000000000000001"),
+            b"placeholder",
+        )
+        .unwrap();
+        std::fs::write(
+            loose_dir.join("bbccdd00000000000000000000000000000002"),
+            b"placeholder",
+        )
+        .unwrap();
+
+        assert_eq!(
+            expand_git_commit_prefix(dir.path(), "aabbccdd"),
+            GitOidPrefixExpansion::Ambiguous,
+            "two objects sharing a prefix must report Ambiguous"
+        );
     }
 }

--- a/crates/kin-git/src/import.rs
+++ b/crates/kin-git/src/import.rs
@@ -155,6 +155,43 @@ pub fn import_git_history_to_commit_with_blobs(
     import_full(&repo, target_id, genesis_id, 0, blob_store)
 }
 
+/// Cheap, Git-native ancestry check: is `ancestor_oid_hex` reachable by
+/// walking parents from `descendant_oid_hex`? This is the same DAG
+/// relationship `git merge-base --is-ancestor` reports. The walk visits only
+/// commit objects — no trees, blobs, or diffing — so it costs a fraction of
+/// a full history import with semantic enrichment, and callers can use it to
+/// decide whether that expensive import is even worth starting.
+///
+/// Returns `None` when the question cannot be answered cheaply: either oid
+/// fails to parse, either commit is absent from the repository's object
+/// database, or the repository cannot be opened at `repo_path`. Callers
+/// should treat `None` as "unknown" and fall back to their normal resolve
+/// path rather than treating it as a negative answer.
+pub fn is_ancestor_commit(
+    repo_path: &Path,
+    ancestor_oid_hex: &str,
+    descendant_oid_hex: &str,
+) -> Option<bool> {
+    let repo = open_repo(repo_path).ok()?;
+    let ancestor_id = gix::ObjectId::from_hex(ancestor_oid_hex.as_bytes()).ok()?;
+    let descendant_id = gix::ObjectId::from_hex(descendant_oid_hex.as_bytes()).ok()?;
+    repo.find_commit(ancestor_id).ok()?;
+    repo.find_commit(descendant_id).ok()?;
+
+    if ancestor_id == descendant_id {
+        return Some(true);
+    }
+
+    let walk = repo.rev_walk([descendant_id]).all().ok()?;
+    for step in walk {
+        let info = step.ok()?;
+        if info.id().detach() == ancestor_id {
+            return Some(true);
+        }
+    }
+    Some(false)
+}
+
 /// Shallow import: create a single SemanticChange from HEAD's tree.
 fn import_shallow(
     repo: &gix::Repository,
@@ -1526,5 +1563,124 @@ mod tests {
             serial_ms / parallel_ms.max(0.0001)
         );
         assert_eq!(parallel.len(), serial.len());
+    }
+
+    fn commit_sha(repo: &Path) -> String {
+        let output = Command::new("git")
+            .args(["rev-parse", "HEAD"])
+            .current_dir(repo)
+            .output()
+            .expect("git rev-parse HEAD");
+        String::from_utf8(output.stdout)
+            .expect("utf8 sha")
+            .trim()
+            .to_string()
+    }
+
+    fn commit_file(repo: &Path, name: &str, content: &str, message: &str, epoch: &str) {
+        std::fs::write(repo.join(name), content).unwrap();
+        let _ = Command::new("git")
+            .args(["add", "."])
+            .current_dir(repo)
+            .output();
+        let date = format!("{epoch} +0000");
+        let _ = Command::new("git")
+            .args(["commit", "-m", message])
+            .env("GIT_AUTHOR_DATE", &date)
+            .env("GIT_COMMITTER_DATE", &date)
+            .current_dir(repo)
+            .output();
+    }
+
+    #[test]
+    fn is_ancestor_commit_true_for_direct_ancestor_and_self() {
+        let dir = tempfile::tempdir().unwrap();
+        if !init_git_repo(dir.path()) {
+            eprintln!("git not available, skipping ancestry test");
+            return;
+        }
+
+        commit_file(dir.path(), "a.txt", "1\n", "base", "1000000000");
+        let base = commit_sha(dir.path());
+        commit_file(dir.path(), "a.txt", "2\n", "head", "1000000100");
+        let head = commit_sha(dir.path());
+
+        assert_eq!(
+            is_ancestor_commit(dir.path(), &base, &head),
+            Some(true),
+            "base must be reported as an ancestor of head"
+        );
+        assert_eq!(
+            is_ancestor_commit(dir.path(), &head, &base),
+            Some(false),
+            "head must not be reported as an ancestor of base"
+        );
+        assert_eq!(
+            is_ancestor_commit(dir.path(), &base, &base),
+            Some(true),
+            "a commit is its own ancestor"
+        );
+    }
+
+    #[test]
+    fn is_ancestor_commit_false_for_unrelated_forked_commits() {
+        let dir = tempfile::tempdir().unwrap();
+        if !init_git_repo(dir.path()) {
+            eprintln!("git not available, skipping ancestry test");
+            return;
+        }
+
+        commit_file(dir.path(), "a.txt", "1\n", "root", "1000000000");
+        let root = commit_sha(dir.path());
+
+        commit_file(dir.path(), "a.txt", "a\n", "branch a", "1000000100");
+        let branch_a = commit_sha(dir.path());
+
+        // Fork a second line of history from `root`, independent of branch a.
+        let _ = Command::new("git")
+            .args(["checkout", &root])
+            .current_dir(dir.path())
+            .output();
+        commit_file(dir.path(), "a.txt", "b\n", "branch b", "1000000200");
+        let branch_b = commit_sha(dir.path());
+
+        assert_eq!(
+            is_ancestor_commit(dir.path(), &branch_a, &branch_b),
+            Some(false),
+            "unrelated forked commits must not be reported as ancestors of each other"
+        );
+        assert_eq!(is_ancestor_commit(dir.path(), &root, &branch_a), Some(true));
+        assert_eq!(is_ancestor_commit(dir.path(), &root, &branch_b), Some(true));
+    }
+
+    #[test]
+    fn is_ancestor_commit_none_when_a_commit_is_absent() {
+        let dir = tempfile::tempdir().unwrap();
+        if !init_git_repo(dir.path()) {
+            eprintln!("git not available, skipping ancestry test");
+            return;
+        }
+
+        commit_file(dir.path(), "a.txt", "1\n", "root", "1000000000");
+        let root = commit_sha(dir.path());
+        let absent = "0".repeat(40);
+
+        assert_eq!(
+            is_ancestor_commit(dir.path(), &absent, &root),
+            None,
+            "an absent ancestor commit must report None (undetermined), not a hard failure"
+        );
+        assert_eq!(
+            is_ancestor_commit(dir.path(), &root, &absent),
+            None,
+            "an absent descendant commit must report None (undetermined), not a hard failure"
+        );
+    }
+
+    #[test]
+    fn is_ancestor_commit_none_when_repo_path_is_not_a_git_repo() {
+        let dir = tempfile::tempdir().unwrap();
+        let sha = "1111111111111111111111111111111111111111";
+        assert_eq!(is_ancestor_commit(dir.path(), sha, sha), None);
     }
 }

--- a/crates/kin-git/src/lib.rs
+++ b/crates/kin-git/src/lib.rs
@@ -22,6 +22,6 @@ pub use export::{export_changes, export_to_git, ExportOptions, ExportResult};
 pub use genesis::is_genesis_change;
 pub use import::{
     anchor_imported_history_at_base_link, import_git_history,
-    import_git_history_to_commit_with_blobs, import_git_history_with_blobs,
+    import_git_history_to_commit_with_blobs, import_git_history_with_blobs, is_ancestor_commit,
     semantic_change_id_from_git_oid_hex, ImportOptions, ImportedChange,
 };

--- a/crates/kin-git/src/lib.rs
+++ b/crates/kin-git/src/lib.rs
@@ -21,7 +21,7 @@ pub use error::{GitError, Result};
 pub use export::{export_changes, export_to_git, ExportOptions, ExportResult};
 pub use genesis::is_genesis_change;
 pub use import::{
-    anchor_imported_history_at_base_link, import_git_history,
+    anchor_imported_history_at_base_link, expand_git_commit_prefix, import_git_history,
     import_git_history_to_commit_with_blobs, import_git_history_with_blobs, is_ancestor_commit,
-    semantic_change_id_from_git_oid_hex, ImportOptions, ImportedChange,
+    semantic_change_id_from_git_oid_hex, GitOidPrefixExpansion, ImportOptions, ImportedChange,
 };

--- a/crates/kin-review/src/lib.rs
+++ b/crates/kin-review/src/lib.rs
@@ -35,7 +35,7 @@ pub use release_gate::{
 pub use review::{Review, SemanticReview};
 pub use risk::assess_risk;
 pub use shadow::{
-    build_shadow_report, build_shadow_report_at, format_shadow_report, ShadowGateReport,
-    ShadowGateVerdict, ShadowRequest, SHADOW_ENFORCEMENT_REPORT_ONLY,
-    SHADOW_GATE_REPORT_SCHEMA_VERSION,
+    build_shadow_report, build_shadow_report_at, build_shadow_report_base_off_ancestry,
+    format_shadow_report, ShadowGateReport, ShadowGateVerdict, ShadowRequest,
+    SHADOW_ENFORCEMENT_REPORT_ONLY, SHADOW_GATE_REPORT_SCHEMA_VERSION,
 };

--- a/crates/kin-review/src/shadow.rs
+++ b/crates/kin-review/src/shadow.rs
@@ -299,7 +299,7 @@ pub fn build_shadow_report_at<G: GraphStore>(
     at_head: &GraphAtRef<'_, G>,
 ) -> Result<ShadowGateReport, ReviewError> {
     if !at_head.ancestry_contains(&request.resolved_base) {
-        return build_report_with_base_off_ancestry(store, request);
+        return build_shadow_report_base_off_ancestry(store, request);
     }
     // DAG-true `base..head` membership: reachable from head, not reachable
     // from base. The store's backward walk stops only at the literal base
@@ -433,7 +433,15 @@ fn build_report_without_ref_state<G: GraphStore>(
 /// into a sweep across unrelated eras of the DAG — so the range is refused
 /// loudly: no diff, no blast radius, no impact, no range walk, and an
 /// explicit blocking evidence gap in their place.
-fn build_report_with_base_off_ancestry<G: GraphStore>(
+///
+/// Unlike [`build_shadow_report`], this entry point never materializes graph
+/// state at either ref, so it is safe to call with a `resolved_base` and
+/// `resolved_head` that are not present in `store` at all. Callers that can
+/// prove ancestry does not hold through a cheaper channel than full
+/// resolution (e.g. a Git-native ancestry check ahead of importing either
+/// side) can go straight to this report instead of paying for resolution
+/// first only to reach the same conclusion.
+pub fn build_shadow_report_base_off_ancestry<G: GraphStore>(
     store: &G,
     request: &ShadowRequest,
 ) -> Result<ShadowGateReport, ReviewError> {


### PR DESCRIPTION
## Summary

- `kin review shadow HEAD^..HEAD` — the idiomatic "review my last commit" — returned an opaque HTTP 500 because the ref resolver only understood `HEAD~N`, not caret syntax. The resolver now peels `^`, `^N`, and `~N` (chained, on any ref form) by walking recorded parents in the graph, so it works the same whether history is native or Git-imported, and needs no backing Git repository.
- Refs that still can't be resolved (bad syntax, unknown ref, unsupported `@{...}` forms) now carry a distinct, downcastable error. The daemon uses it to answer with a client error and a clear "cannot resolve ref" message instead of a bare 500.
- `kin review shadow <base>..<head>` where `base` is not on `head`'s ancestry (the everyday "your branch is behind main" case) correctly reported the `base_not_on_head_ancestry` gap, but only after fully importing and semantically enriching both refs' Git history first. A cheap, Git-native ancestry check (commit-parent walk only, no trees/blobs/diffing) now runs before either side's history import, and short-circuits straight to the identical gap report when it proves the base isn't reachable from the head. Ranges that pass the check take the existing path unchanged.

## How tested

- New unit tests in `kin-cli` (`ref_lookup.rs`, `review.rs`) covering caret/tilde/chained-hop resolution, `@{...}` and unknown-ref rejection, and a structural proof (via `git_ref_requires_hydration`) that the stale-base fast path performs no import.
- New unit tests in `kin-git` (`import.rs`) for the Git-native ancestry check: direct ancestor, self, unrelated forked commits, and absent commits.
- New end-to-end tests in `kin-cli`'s `review_shadow_json` integration suite (real `kin` + daemon binaries) covering `HEAD^..HEAD` on a fresh init, caret/tilde agreement, the friendly-error path, and the stale-base gap report.
- All pre-existing tests in the touched crates (`kin-cli`, `kin-git`, `kin-review`, `kin-daemon` review tests) remain green.
- `cargo fmt --all -- --check`, `cargo clippy --all-targets` (no new warnings), full workspace `cargo check --workspace --all-targets`.

https://linear.app/firelock-ai/issue/FIR-1413
https://linear.app/firelock-ai/issue/FIR-1412