### PR TITLE
fix(npm): make the kin launcher's version pin directional

### DIFF
--- a/packages/kin/README.md
+++ b/packages/kin/README.md
@@ -29,6 +29,21 @@ The launcher and the shell installer (`scripts/install.sh`) share the same insta
 contract (`$KIN_HOME`, default `~/.kin`): either lane satisfies the other, and neither
 silently downgrades an install the other made.
 
+## Version pinning
+
+Every `@kinlab/kin` release pins one managed `kin` release — its own package version.
+Each run compares that pin against whatever is already installed at `$KIN_HOME`:
+
+- **installed is older than the pin** — upgrades it automatically (a one-line notice
+  on stderr, no prompt, no opt-in required).
+- **installed is newer than the pin** — refuses the downgrade and exits with an
+  actionable error instead of running anything; re-run with `KIN_LAUNCHER_ADOPT=1` to
+  force it on purpose (e.g. deliberately pinning to an older release).
+- **installed matches the pin** — runs it as-is.
+
+`KIN_LAUNCHER_ADOPT=1` always forces a fresh provision of the pinned release, even when
+the installed version already matches.
+
 ## Environment
 
 | Variable | Effect |
@@ -36,7 +51,7 @@ silently downgrades an install the other made.
 | `KIN_HOME` | Root of the managed install (default `~/.kin`). |
 | `KIN_MANAGED_BIN` | Explicit path to a `kin` binary; disables provisioning entirely. |
 | `KIN_NO_PROVISION=1` | Never touch the network; fail loud if no binary is present. |
-| `KIN_LAUNCHER_ADOPT=1` | Allow re-provisioning over a version-skewed non-npm install. |
+| `KIN_LAUNCHER_ADOPT=1` | Force re-provisioning to the pinned release, including over a newer install that would otherwise be refused as a downgrade. |
 
 ## MCP setup
 

--- a/packages/kin/bin/kin-mcp.mjs
+++ b/packages/kin/bin/kin-mcp.mjs
@@ -26,14 +26,22 @@ if (argv.includes('--version') || argv.includes('-V')) {
 }
 
 let binary = null;
+let provisionError = null;
 try {
   binary = await ensureProvisioned();
 } catch (error) {
-  process.stderr.write(`kin-mcp: provisioning failed: ${error.message}\n`);
+  provisionError = error;
 }
 
 if (!binary) {
-  process.stderr.write(`${notProvisionedMessage('kin')}\n`);
+  // The error message is already complete and actionable (e.g. a declined
+  // downgrade names the binary that IS present) — printing the generic
+  // not-provisioned message on top of it would contradict it.
+  if (provisionError) {
+    process.stderr.write(`kin-mcp: provisioning failed: ${provisionError.message}\n`);
+  } else {
+    process.stderr.write(`${notProvisionedMessage('kin')}\n`);
+  }
   process.exit(1);
 }
 

--- a/packages/kin/bin/kin.mjs
+++ b/packages/kin/bin/kin.mjs
@@ -33,13 +33,20 @@ try {
 
 if (!binary) {
   if (provisionError) {
+    // The error message is already complete and actionable (e.g. a declined
+    // downgrade names the binary that IS present) — printing the generic
+    // not-provisioned message on top of it would contradict it.
     process.stderr.write(`kin: provisioning failed: ${provisionError.message}\n`);
+    if (wantsVersion) {
+      process.stdout.write(launcherVersionLine(', provisioning failed'));
+    }
+    process.exit(1);
   }
   if (wantsVersion) {
     // Honest launcher identity; success only when provisioning was explicitly
     // disabled rather than broken.
-    process.stdout.write(launcherVersionLine(provisionError ? ', provisioning failed' : ', not installed'));
-    process.exit(provisionError ? 1 : 0);
+    process.stdout.write(launcherVersionLine(', not installed'));
+    process.exit(0);
   }
   process.stderr.write(`${notProvisionedMessage('kin')}\n`);
   process.exit(1);

--- a/packages/kin/lib/provision.mjs
+++ b/packages/kin/lib/provision.mjs
@@ -20,6 +20,7 @@ import { spawnSync } from 'node:child_process';
 
 import {
   binaryName,
+  compareVersions,
   kinHome,
   managedBinaryPath,
   readLauncherStamp,
@@ -196,16 +197,26 @@ export function probeBinaryVersion(binary, spawnImpl = spawnSync) {
  * Ensure the managed `kin` binary matching this launcher's pinned release is
  * present, provisioning (or re-provisioning) when needed. Returns the binary
  * path, or null when nothing usable exists and provisioning is unavailable.
+ * Throws when an installed release outranks the pin and the caller has not
+ * opted into a downgrade — this function never returns a value while quietly
+ * declining to honor the pin.
  *
  * Policy, in order:
  *   - $KIN_MANAGED_BIN is an explicit user pin: use it as-is, never provision.
  *   - $KIN_NO_PROVISION=1: resolve-only, no network.
- *   - launcher stamp == target and the binary exists: run it (no probe cost).
- *   - stamp differs or binary missing: provision the pinned release.
- *   - no stamp but a binary exists (foreign install, e.g. install.sh): probe
- *     its version; adopt on match. On mismatch respect the foreign install —
- *     run it with a one-line notice — unless $KIN_LAUNCHER_ADOPT=1 opts into
- *     re-provisioning. Never silently downgrade someone else's install.
+ *   - $KIN_LAUNCHER_ADOPT=1: always (re-)provision the pinned release,
+ *     regardless of what is already installed.
+ *   - nothing installed yet: provision the pinned release.
+ *   - installed version is known — from the launcher stamp when this package
+ *     provisioned it (no probe needed), otherwise by probing a foreign
+ *     install's `--version` once:
+ *       - installed == pinned: reuse it (a foreign match adopts the stamp).
+ *       - installed < pinned: the pin is an upgrade — provision it
+ *         automatically with a one-line notice. Never a silent no-op.
+ *       - installed > pinned: the pin would downgrade a newer install — fail
+ *         loud with an actionable message instead of running anything.
+ *   - installed version unparseable (foreign binary that will not report a
+ *     version): can't prove direction, so respect it — notice and reuse.
  */
 export async function ensureProvisioned(opts = {}) {
   const {
@@ -229,29 +240,37 @@ export async function ensureProvisioned(opts = {}) {
 
   const doProvision = () => provision(target, { env, platform, arch, fetchImpl, log });
 
+  if (env.KIN_LAUNCHER_ADOPT === '1') {
+    return doProvision();
+  }
   if (!existing) {
     return doProvision();
   }
 
+  const installedPath = managedBinaryPath('kin', env, platform);
   const stamp = readLauncherStamp(env);
-  if (stamp === target) {
+  const installed = stamp ?? probeBinaryVersion(existing, spawnImpl);
+
+  if (installed === null) {
+    log(
+      `kin: using existing managed kin (version unknown) at ${installedPath} ` +
+        `(this @kinlab/kin pins ${target}; set KIN_LAUNCHER_ADOPT=1 to re-provision).`,
+    );
     return existing;
-  }
-  if (stamp !== null) {
-    return doProvision();
   }
 
-  const probed = probeBinaryVersion(existing, spawnImpl);
-  if (probed === target) {
-    writeLauncherStamp(target, env);
+  const cmp = compareVersions(target, installed);
+  if (cmp === 0) {
+    if (stamp === null) writeLauncherStamp(target, env);
     return existing;
   }
-  if (env.KIN_LAUNCHER_ADOPT === '1') {
+  if (cmp > 0) {
+    log(`kin: managed kin ${installed} is older than the pinned ${target}; upgrading automatically.`);
     return doProvision();
   }
-  log(
-    `kin: using existing managed kin ${probed ?? 'unknown'} at ${managedBinaryPath('kin', env, platform)} ` +
-      `(this @kinlab/kin pins ${target}; set KIN_LAUNCHER_ADOPT=1 to re-provision).`,
+  throw new Error(
+    `refusing to downgrade managed kin ${installed} to the pinned ${target} (at ${installedPath}). ` +
+      'This @kinlab/kin would replace a newer managed install with an older one; nothing was run. ' +
+      'Set KIN_LAUNCHER_ADOPT=1 to force it if the downgrade is intended.',
   );
-  return existing;
 }

--- a/packages/kin/lib/resolve.mjs
+++ b/packages/kin/lib/resolve.mjs
@@ -34,6 +34,73 @@ export function targetKinVersion() {
 }
 
 /**
+ * Compare two dotted version strings by semver precedence: numeric release
+ * segments first, then any `-prerelease` suffix (a release outranks its own
+ * prerelease; prerelease identifiers compare numerically when both sides are
+ * numeric, else lexically; on an equal shared prefix, fewer identifiers ranks
+ * lower). Mirrors the precedence `kin update` applies on the native side
+ * (crates/kin-cli/src/commands/update.rs). Returns -1 when `a` is older than
+ * `b`, 0 when equal, 1 when `a` is newer than `b`. Non-numeric release
+ * segments parse as 0 rather than throwing, so a malformed string degrades to
+ * a comparison instead of crashing the launcher.
+ */
+export function compareVersions(a, b) {
+  const [aCore, aPre] = splitVersion(a);
+  const [bCore, bPre] = splitVersion(b);
+  const core = compareNumericParts(aCore, bCore);
+  return core !== 0 ? core : comparePrereleaseParts(aPre, bPre);
+}
+
+function splitVersion(version) {
+  const trimmed = String(version).trim().replace(/^v/, '');
+  const dash = trimmed.indexOf('-');
+  const core = dash === -1 ? trimmed : trimmed.slice(0, dash);
+  const pre = dash === -1 ? null : trimmed.slice(dash + 1).split('.');
+  const nums = core.split('.').map((part) => {
+    const n = Number.parseInt(part, 10);
+    return Number.isFinite(n) ? n : 0;
+  });
+  return [nums, pre];
+}
+
+function compareNumericParts(a, b) {
+  const len = Math.max(a.length, b.length);
+  for (let i = 0; i < len; i += 1) {
+    const x = a[i] ?? 0;
+    const y = b[i] ?? 0;
+    if (x !== y) return x < y ? -1 : 1;
+  }
+  return 0;
+}
+
+function comparePrereleaseParts(a, b) {
+  if (a === null && b === null) return 0;
+  if (a === null) return 1; // a released version outranks its own prerelease
+  if (b === null) return -1;
+  const len = Math.max(a.length, b.length);
+  for (let i = 0; i < len; i += 1) {
+    if (i >= a.length) return -1; // shared prefix equal, fewer identifiers ranks lower
+    if (i >= b.length) return 1;
+    const cmp = comparePrereleaseIdentifier(a[i], b[i]);
+    if (cmp !== 0) return cmp;
+  }
+  return 0;
+}
+
+function comparePrereleaseIdentifier(a, b) {
+  const aNumeric = /^\d+$/.test(a);
+  const bNumeric = /^\d+$/.test(b);
+  if (aNumeric && bNumeric) {
+    const x = Number.parseInt(a, 10);
+    const y = Number.parseInt(b, 10);
+    return x === y ? 0 : x < y ? -1 : 1;
+  }
+  if (aNumeric) return -1; // numeric identifiers rank below alphanumeric
+  if (bNumeric) return 1;
+  return a === b ? 0 : a < b ? -1 : 1;
+}
+
+/**
  * Map a Node platform+arch pair to the Rust target triple of the managed
  * binary. Pure and injectable so it is testable for every supported host.
  */

--- a/packages/kin/test/provision.test.mjs
+++ b/packages/kin/test/provision.test.mjs
@@ -191,8 +191,17 @@ test('ensureProvisioned runs a stamped current install without probing or networ
   fs.rmSync(home, { recursive: true, force: true });
 });
 
-test('ensureProvisioned respects a foreign install on version mismatch (no adopt)', async () => {
-  const home = fs.mkdtempSync(path.join(os.tmpdir(), 'kin-foreign-'));
+// ── mismatch matrix ─────────────────────────────────────────────────────────
+//
+// ensureProvisioned's pin-vs-installed policy, exercised on both the stamped
+// (this package provisioned it before; no probe needed) and foreign (probed
+// via `--version`) code paths: an older install upgrades automatically, a
+// newer install is refused loudly, an equal install just runs, and
+// KIN_LAUNCHER_ADOPT=1 forces a re-provision regardless.
+
+test('ensureProvisioned auto-provisions over an older foreign install (no ADOPT needed)', async () => {
+  const { work, fetchImpl } = makeFixture();
+  const home = path.join(work, 'kin-home');
   const env = { KIN_HOME: home };
   const binDir = path.join(home, 'bin');
   fs.mkdirSync(binDir, { recursive: true });
@@ -200,15 +209,160 @@ test('ensureProvisioned respects a foreign install on version mismatch (no adopt
   const notices = [];
   const result = await ensureProvisioned({
     env,
-    platform: process.platform,
-    fetchImpl: async () => {
-      throw new Error('must not re-provision a foreign install without opt-in');
-    },
+    platform: 'darwin',
+    arch: 'arm64',
+    fetchImpl,
     spawnImpl: () => ({ status: 0, stdout: 'kin 0.0.1-foreign (x)\n' }),
     log: (line) => notices.push(line),
   });
+  const { targetKinVersion } = await import('../lib/resolve.mjs');
   assert.equal(result, path.join(binDir, 'kin'));
+  assert.match(fs.readFileSync(result, 'utf8'), /9\.9\.9/);
+  assert.equal(readLauncherStamp(env), targetKinVersion());
+  assert.ok(notices.some((l) => l.includes('older') && l.includes('upgrading automatically')));
+  fs.rmSync(work, { recursive: true, force: true });
+});
+
+test('ensureProvisioned auto-provisions when a stamped install is older than the pin', async () => {
+  const { work, fetchImpl } = makeFixture();
+  const home = path.join(work, 'kin-home');
+  const env = { KIN_HOME: home };
+  const binDir = path.join(home, 'bin');
+  fs.mkdirSync(binDir, { recursive: true });
+  fs.writeFileSync(path.join(binDir, 'kin'), '#!/bin/sh\n');
+  writeLauncherStamp('0.0.1', env);
+  const notices = [];
+  const result = await ensureProvisioned({
+    env,
+    platform: 'darwin',
+    arch: 'arm64',
+    fetchImpl,
+    spawnImpl: () => {
+      throw new Error('a stamped install must not be probed');
+    },
+    log: (line) => notices.push(line),
+  });
+  const { targetKinVersion } = await import('../lib/resolve.mjs');
+  assert.equal(result, path.join(binDir, 'kin'));
+  assert.match(fs.readFileSync(result, 'utf8'), /9\.9\.9/);
+  assert.equal(readLauncherStamp(env), targetKinVersion());
+  assert.ok(notices.some((l) => l.includes('older') && l.includes('upgrading automatically')));
+  fs.rmSync(work, { recursive: true, force: true });
+});
+
+test('ensureProvisioned refuses to downgrade a newer foreign install (fail loud, no ADOPT)', async () => {
+  const home = fs.mkdtempSync(path.join(os.tmpdir(), 'kin-newer-foreign-'));
+  const env = { KIN_HOME: home };
+  const binDir = path.join(home, 'bin');
+  fs.mkdirSync(binDir, { recursive: true });
+  fs.writeFileSync(path.join(binDir, 'kin'), '#!/bin/sh\n');
+  await assert.rejects(
+    ensureProvisioned({
+      env,
+      platform: process.platform,
+      fetchImpl: async () => {
+        throw new Error('must not provision when refusing a downgrade');
+      },
+      spawnImpl: () => ({ status: 0, stdout: 'kin 99.0.0 (newer)\n' }),
+      log: () => {},
+    }),
+    /refusing to downgrade.*KIN_LAUNCHER_ADOPT=1/s,
+  );
   assert.equal(readLauncherStamp(env), null);
-  assert.ok(notices.some((l) => l.includes('KIN_LAUNCHER_ADOPT=1')));
+  assert.ok(fs.existsSync(path.join(binDir, 'kin')), 'the existing binary must be left in place');
   fs.rmSync(home, { recursive: true, force: true });
+});
+
+test('ensureProvisioned refuses to downgrade when the stamp itself is newer than the pin', async () => {
+  const home = fs.mkdtempSync(path.join(os.tmpdir(), 'kin-newer-stamped-'));
+  const env = { KIN_HOME: home };
+  const binDir = path.join(home, 'bin');
+  fs.mkdirSync(binDir, { recursive: true });
+  fs.writeFileSync(path.join(binDir, 'kin'), '#!/bin/sh\n');
+  writeLauncherStamp('99.0.0', env);
+  await assert.rejects(
+    ensureProvisioned({
+      env,
+      platform: process.platform,
+      fetchImpl: async () => {
+        throw new Error('must not provision when refusing a downgrade');
+      },
+      spawnImpl: () => {
+        throw new Error('a stamped install must not be probed');
+      },
+      log: () => {},
+    }),
+    /refusing to downgrade.*KIN_LAUNCHER_ADOPT=1/s,
+  );
+  assert.equal(readLauncherStamp(env), '99.0.0');
+  fs.rmSync(home, { recursive: true, force: true });
+});
+
+test('ensureProvisioned adopts a foreign install when its version already matches the pin', async () => {
+  const home = fs.mkdtempSync(path.join(os.tmpdir(), 'kin-foreign-equal-'));
+  const env = { KIN_HOME: home };
+  const binDir = path.join(home, 'bin');
+  fs.mkdirSync(binDir, { recursive: true });
+  fs.writeFileSync(path.join(binDir, 'kin'), '#!/bin/sh\n');
+  const { targetKinVersion } = await import('../lib/resolve.mjs');
+  const result = await ensureProvisioned({
+    env,
+    platform: process.platform,
+    fetchImpl: async () => {
+      throw new Error('must not provision when the foreign install already matches');
+    },
+    spawnImpl: () => ({ status: 0, stdout: `kin ${targetKinVersion()} (foreign)\n` }),
+    log: () => {},
+  });
+  assert.equal(result, path.join(binDir, 'kin'));
+  assert.equal(readLauncherStamp(env), targetKinVersion());
+  fs.rmSync(home, { recursive: true, force: true });
+});
+
+test('KIN_LAUNCHER_ADOPT=1 forces re-provisioning even when the stamped version already matches', async () => {
+  const { work, fetchImpl } = makeFixture();
+  const home = path.join(work, 'kin-home');
+  const env = { KIN_HOME: home, KIN_LAUNCHER_ADOPT: '1' };
+  const binDir = path.join(home, 'bin');
+  fs.mkdirSync(binDir, { recursive: true });
+  fs.writeFileSync(path.join(binDir, 'kin'), '#!/bin/sh\n');
+  const { targetKinVersion } = await import('../lib/resolve.mjs');
+  writeLauncherStamp(targetKinVersion(), env);
+  const result = await ensureProvisioned({
+    env,
+    platform: 'darwin',
+    arch: 'arm64',
+    fetchImpl,
+    spawnImpl: () => {
+      throw new Error('ADOPT must skip the probe and provision unconditionally');
+    },
+    log: () => {},
+  });
+  assert.equal(result, path.join(binDir, 'kin'));
+  // Reprovisioned from the fixture archive, not the pre-existing stub.
+  assert.match(fs.readFileSync(result, 'utf8'), /9\.9\.9/);
+  fs.rmSync(work, { recursive: true, force: true });
+});
+
+test('KIN_LAUNCHER_ADOPT=1 forces the downgrade it would otherwise refuse', async () => {
+  const { work, fetchImpl } = makeFixture();
+  const home = path.join(work, 'kin-home');
+  const env = { KIN_HOME: home, KIN_LAUNCHER_ADOPT: '1' };
+  const binDir = path.join(home, 'bin');
+  fs.mkdirSync(binDir, { recursive: true });
+  fs.writeFileSync(path.join(binDir, 'kin'), '#!/bin/sh\n');
+  writeLauncherStamp('99.0.0', env);
+  const result = await ensureProvisioned({
+    env,
+    platform: 'darwin',
+    arch: 'arm64',
+    fetchImpl,
+    spawnImpl: () => {
+      throw new Error('ADOPT must skip the probe and provision unconditionally');
+    },
+    log: () => {},
+  });
+  assert.equal(result, path.join(binDir, 'kin'));
+  assert.match(fs.readFileSync(result, 'utf8'), /9\.9\.9/);
+  fs.rmSync(work, { recursive: true, force: true });
 });

--- a/packages/kin/test/resolve.test.mjs
+++ b/packages/kin/test/resolve.test.mjs
@@ -10,6 +10,7 @@ import { test } from 'node:test';
 import {
   packageVersion,
   targetKinVersion,
+  compareVersions,
   platformTarget,
   binaryName,
   kinHome,
@@ -27,6 +28,35 @@ test('packageVersion reads a semver from the manifest', () => {
 
 test('targetKinVersion tracks the package version', () => {
   assert.equal(targetKinVersion(), packageVersion());
+});
+
+test('compareVersions orders numeric cores', () => {
+  assert.equal(compareVersions('0.2.0', '0.1.0'), 1);
+  assert.equal(compareVersions('1.0.0', '0.9.9'), 1);
+  assert.equal(compareVersions('0.1.0', '0.1.0'), 0);
+  assert.equal(compareVersions('0.1.0', '0.2.0'), -1);
+});
+
+test('compareVersions understands prereleases', () => {
+  // A pre-release of a higher core beats a lower stable release.
+  assert.equal(compareVersions('0.2.7-alpha.1', '0.2.6'), 1);
+  // A newer alpha beats an older alpha of the same core.
+  assert.equal(compareVersions('0.2.7-alpha.2', '0.2.7-alpha.1'), 1);
+  // A stable release outranks its own pre-release.
+  assert.equal(compareVersions('0.2.7', '0.2.7-alpha.9'), 1);
+  // A pre-release never outranks its released version (no downgrade).
+  assert.equal(compareVersions('0.2.7-alpha.1', '0.2.7'), -1);
+  // Equal pre-releases compare equal.
+  assert.equal(compareVersions('0.2.7-alpha.1', '0.2.7-alpha.1'), 0);
+  // Alphanumeric identifiers rank above numeric; 'beta' > 'alpha' lexically.
+  assert.equal(compareVersions('0.2.7-beta', '0.2.7-alpha.1'), 1);
+  // A leading 'v' is tolerated on either side.
+  assert.equal(compareVersions('v0.2.7', 'v0.2.6'), 1);
+});
+
+test('compareVersions treats unparseable segments as 0 instead of throwing', () => {
+  assert.equal(compareVersions('unknown', '0.0.0'), 0);
+  assert.equal(compareVersions('1.x.0', '1.0.0'), 0);
 });
 
 test('platformTarget maps every supported host to a Rust triple', () => {


### PR DESCRIPTION
## Summary

- `ensureProvisioned()` in `packages/kin/lib/provision.mjs` now applies a directional policy when the launcher's pinned `kin` release differs from what's already managed at `$KIN_HOME`, instead of treating every mismatch as "notice and keep the existing binary":
  - **pin newer than installed** → auto-provision the pin (one-line stderr notice, no opt-in required)
  - **pin older than installed (a downgrade)** → refuse and exit with an actionable error; nothing runs silently. `KIN_LAUNCHER_ADOPT=1` forces it on purpose.
  - **equal** → reuse as-is
  - `KIN_LAUNCHER_ADOPT=1` → always forces a fresh provision, even on a version match
- Adds `compareVersions()` to `lib/resolve.mjs` — a pure semver-precedence comparator mirroring the one `crates/kin-cli/src/commands/update.rs` already uses natively (numeric core, then prerelease precedence; ported and re-tested against the same cases as the Rust `version_comparison*` tests).
- `bin/kin.mjs` / `bin/kin-mcp.mjs`: stop printing the generic "managed binary not found" message alongside a thrown provisioning error — those were contradictory whenever the refused binary was sitting right there on disk (this was already latent for any provisioning-error path, not just the new downgrade refusal).
- `README.md`: new "Version pinning" section documenting the policy; `KIN_LAUNCHER_ADOPT` row updated to match.

`packages/kin/package.json` was not touched (no new dependency needed — the comparator is hand-rolled, no `semver` package added).

Linear: https://linear.app/firelock/issue/FIR-1419

## Test plan

- [x] `npm test --prefix packages/kin` — 33/33 green, including the full mismatch matrix (older→auto-provision on both the stamped and foreign-probe paths, newer→fail loud on both paths, equal→reuse on both paths, `KIN_LAUNCHER_ADOPT=1` override on both a match and a would-be-refused downgrade)
- [x] `npm run lint --prefix packages/kin` — clean
- [x] No network calls, no writes outside `node:fs.mkdtemp` temp dirs (existing fake-fetch/fake-spawn fixture idioms)