### PR TITLE
perf(index): parallelize per-commit parse and incremental linking in history hydration

### DIFF
--- a/crates/kin-cli/src/commands/init.rs
+++ b/crates/kin-cli/src/commands/init.rs
@@ -1211,6 +1211,32 @@ struct CachedParse {
     imports: Vec<kin_parser::FileImport>,
 }
 
+/// One artifact delta's resolved parse disposition for a commit's reconcile
+/// pass, computed by the plan/parse phases so the serial reconcile is a pure
+/// fold over pre-resolved parses with no blob I/O or parsing on its path.
+enum ImportedFileResolution {
+    /// Non-source file, deletion, or a blob whose read/parse failed: drop any
+    /// prior semantic state for this path.
+    Remove,
+    /// Parse available (memo hit or freshly parsed this commit): reconcile the
+    /// path against it.
+    Parsed(Arc<CachedParse>),
+}
+
+/// A distinct source blob scheduled for parsing within one commit. Parsing is a
+/// pure function of (blob bytes, parser semantics), so each distinct blob is
+/// read and parsed once and its `Arc` result shared across every delta in the
+/// commit that names it — the same reuse the per-pass memo gives across commits.
+struct ImportedParseJob {
+    blob_hash: kin_blobs::Hash256,
+    file_id: FilePathId,
+    /// Indices into the commit's `artifact_deltas` this parse resolves. The
+    /// first entry was counted as a memo miss when the job was scheduled; any
+    /// later entries are same-commit reappearances whose hit/miss accounting is
+    /// settled in the merge once the parse's success is known.
+    served_deltas: Vec<usize>,
+}
+
 pub(crate) fn enrich_imported_changes_with_semantics(
     imported: &mut [kin_git::ImportedChange],
     blob_store: &kin_blobs::BlobStore,
@@ -1226,8 +1252,6 @@ fn enrich_imported_changes_with_semantics_inner(
     blob_store: &kin_blobs::BlobStore,
     parse_memo_enabled: bool,
 ) -> Result<(usize, usize)> {
-    let pipeline = kin_index::IndexPipeline::new();
-
     // Profiling timers (accumulated across every commit in the pass).
     let mut total_blob_read_time = std::time::Duration::ZERO;
     let mut total_parsing_time = std::time::Duration::ZERO;
@@ -1323,160 +1347,230 @@ fn enrich_imported_changes_with_semantics_inner(
         let mut changed_source_files = BTreeSet::<String>::new();
         let mut previous_file_states = HashMap::<String, ImportedSemanticFileState>::new();
 
-        for artifact_delta in &imported[i].change.artifact_deltas {
+        // Rung-3 intra-commit parallel compute. The outer commit loop stays
+        // sequential (each commit forks its first parent's resulting semantic
+        // state), so parallelism lives inside a commit: (1) plan each delta's
+        // disposition in delta order, scheduling every distinct memo-missing
+        // source blob as a parse job; (2) read and (3) parse those jobs across
+        // the Rayon pool; (4) fold the results into the memo and reconcile
+        // serially in the original delta order. Parsing is a pure function of
+        // (blob bytes, parser semantics) and every order-sensitive step
+        // (reconcile, linker mutation, current_files, delta accumulation) stays
+        // serial, so the resulting graph is byte-identical to the serial path.
+        let deltas = &imported[i].change.artifact_deltas;
+        let mut resolutions: Vec<Option<ImportedFileResolution>> =
+            (0..deltas.len()).map(|_| None).collect();
+        let mut parse_jobs: Vec<ImportedParseJob> = Vec::new();
+        let mut scheduled_jobs: HashMap<(kin_blobs::Hash256, u32), usize> = HashMap::new();
+
+        for (delta_idx, artifact_delta) in deltas.iter().enumerate() {
+            let file_path = &artifact_delta.file_id.0;
+
+            if !matches!(
+                FileClassifier::classify(Path::new(file_path)),
+                FileClassification::EntitySource
+            ) {
+                resolutions[delta_idx] = Some(ImportedFileResolution::Remove);
+                continue;
+            }
+
+            let Some(new_hash) = artifact_delta.new_hash else {
+                resolutions[delta_idx] = Some(ImportedFileResolution::Remove);
+                continue;
+            };
+
+            // A blob hash uniquely determines the file bytes, and a parse is a
+            // pure function of (bytes, parser semantics), so the same file
+            // version recurring across commits — git blobs dedup across history —
+            // is read and parsed once. The parser-semantics version is part of
+            // the key so a grammar/extractor upgrade never serves a stale parse.
+            let memo_key = (
+                kin_blobs::Hash256::from_bytes(*new_hash.as_bytes()),
+                kin_parser::PARSER_SEMANTICS_VERSION,
+            );
+
+            if parse_memo_enabled {
+                if let Some(hit) = parse_memo.get(&memo_key) {
+                    parse_memo_hits += 1;
+                    resolutions[delta_idx] = Some(ImportedFileResolution::Parsed(Arc::clone(hit)));
+                    continue;
+                }
+                if let Some(&job_idx) = scheduled_jobs.get(&memo_key) {
+                    // Served by the parse scheduled earlier this commit; whether
+                    // it counts as a hit (parse succeeds and is memoized) or
+                    // another miss (parse fails and is never memoized) is settled
+                    // in the merge, matching the serial memo's per-appearance
+                    // accounting exactly.
+                    parse_jobs[job_idx].served_deltas.push(delta_idx);
+                    continue;
+                }
+                parse_memo_misses += 1;
+                scheduled_jobs.insert(memo_key, parse_jobs.len());
+                parse_jobs.push(ImportedParseJob {
+                    blob_hash: memo_key.0,
+                    file_id: FilePathId::new(file_path),
+                    served_deltas: vec![delta_idx],
+                });
+            } else {
+                // Memo disabled (serial oracle): every appearance re-parses.
+                parse_memo_misses += 1;
+                parse_jobs.push(ImportedParseJob {
+                    blob_hash: memo_key.0,
+                    file_id: FilePathId::new(file_path),
+                    served_deltas: vec![delta_idx],
+                });
+            }
+        }
+
+        if !parse_jobs.is_empty() {
+            // Stage 1: read each distinct blob once, in parallel. The stage's
+            // wall-clock (not summed thread time) is attributed to blob-read.
+            let blob_read_start = std::time::Instant::now();
+            let job_contents: Vec<Result<Vec<u8>, String>> = parse_jobs
+                .par_iter()
+                .map(|job| {
+                    blob_store
+                        .read(&job.blob_hash)
+                        .map_err(|err| err.to_string())
+                })
+                .collect();
+            total_blob_read_time += blob_read_start.elapsed();
+
+            // Stage 2: parse the successfully-read blobs in parallel. Each worker
+            // thread builds its own IndexPipeline (tree-sitter parsers are
+            // per-thread). Results collect in job order (`par_iter().collect()`
+            // preserves order) and the parse is pure, so the pass is
+            // deterministic. The stage's wall-clock is attributed to parsing.
+            let parse_start = std::time::Instant::now();
+            let job_parses: Vec<Option<Result<Arc<CachedParse>, String>>> = parse_jobs
+                .par_iter()
+                .zip(job_contents.par_iter())
+                .map_init(kin_index::IndexPipeline::new, |pipeline, (job, content)| {
+                    let content = content.as_ref().ok()?;
+                    Some(
+                        pipeline
+                            .index_file_content_with_tests(&job.file_id, content, job.blob_hash)
+                            .map(|indexed| {
+                                Arc::new(CachedParse {
+                                    entities: indexed.indexed_file.entities,
+                                    extracted_relations: indexed.indexed_file.extracted_relations,
+                                    imports: indexed.indexed_file.imports,
+                                })
+                            })
+                            .map_err(|err| err.to_string()),
+                    )
+                })
+                .collect();
+            total_parsing_time += parse_start.elapsed();
+
+            // Merge (serial, deterministic): populate the content-keyed memo,
+            // resolve every served delta, settle same-commit reappearance
+            // accounting, and warn on failures in job order. Memo insertion order
+            // never affects the memo's contents (keyed by blob hash + semantics).
+            let read_errors: Vec<Option<String>> = job_contents
+                .into_iter()
+                .map(|content| content.err())
+                .collect();
+            for (job_idx, job) in parse_jobs.iter().enumerate() {
+                let extra_appearances = job.served_deltas.len() - 1;
+                match &job_parses[job_idx] {
+                    Some(Ok(parsed)) => {
+                        if parse_memo_enabled {
+                            parse_memo.insert(
+                                (job.blob_hash, kin_parser::PARSER_SEMANTICS_VERSION),
+                                Arc::clone(parsed),
+                            );
+                        }
+                        // Extra same-commit appearances were served from this one
+                        // parse: hits, exactly as the serial memo would count.
+                        parse_memo_hits += extra_appearances;
+                        for &delta_idx in &job.served_deltas {
+                            resolutions[delta_idx] =
+                                Some(ImportedFileResolution::Parsed(Arc::clone(parsed)));
+                        }
+                    }
+                    Some(Err(err)) => {
+                        // Parse failed: never memoized, so every appearance is a
+                        // miss (the first was already counted at schedule time).
+                        parse_memo_misses += extra_appearances;
+                        warn!(
+                            file = %job.file_id.0,
+                            error = %err,
+                            "skipping semantic enrichment for imported source blob that could not be parsed"
+                        );
+                        for &delta_idx in &job.served_deltas {
+                            resolutions[delta_idx] = Some(ImportedFileResolution::Remove);
+                        }
+                    }
+                    None => {
+                        // Blob read failed: same removal + miss accounting.
+                        parse_memo_misses += extra_appearances;
+                        let err = read_errors[job_idx].as_deref().unwrap_or("missing content");
+                        warn!(
+                            file = %job.file_id.0,
+                            error = %err,
+                            "skipping semantic enrichment for imported blob with missing content"
+                        );
+                        for &delta_idx in &job.served_deltas {
+                            resolutions[delta_idx] = Some(ImportedFileResolution::Remove);
+                        }
+                    }
+                }
+            }
+        }
+
+        // Reconcile serially in delta order — byte-identical to the pre-rung-3
+        // per-file body, now fed pre-resolved parses. Each commit changes a given
+        // path at most once, so a delta's baseline `old_state` is independent of
+        // its siblings and this fold reproduces the serial result exactly.
+        for (delta_idx, artifact_delta) in imported[i].change.artifact_deltas.iter().enumerate() {
             let file_path = artifact_delta.file_id.0.clone();
             let old_state = current_files.get(&file_path).cloned();
             if let Some(old_state) = &old_state {
                 previous_file_states.insert(file_path.clone(), old_state.clone());
             }
 
-            if !matches!(
-                FileClassifier::classify(Path::new(&file_path)),
-                FileClassification::EntitySource
-            ) {
-                if remove_imported_file_semantic_state(
-                    &file_path,
-                    old_state,
-                    &mut current_files,
-                    &mut entity_deltas,
-                ) {
-                    changed_source_files.insert(file_path.clone());
-                    incremental_linker.remove_file(&file_path);
-                }
-                continue;
-            }
-
-            let Some(new_hash) = artifact_delta.new_hash else {
-                if remove_imported_file_semantic_state(
-                    &file_path,
-                    old_state,
-                    &mut current_files,
-                    &mut entity_deltas,
-                ) {
-                    changed_source_files.insert(file_path.clone());
-                    incremental_linker.remove_file(&file_path);
-                }
-                continue;
-            };
-
-            let blob_hash = kin_blobs::Hash256::from_bytes(*new_hash.as_bytes());
-
-            // Consult the per-pass parse memo before touching the blob store or
-            // the parser. A blob hash uniquely determines the file bytes, and a
-            // parse is a pure function of (bytes, parser semantics), so the same
-            // file version recurring across commits — git blobs dedup across
-            // history — is read and parsed once. The parser-semantics version is
-            // part of the key so a grammar/extractor upgrade never serves a stale
-            // parse.
-            let memo_key = (blob_hash, kin_parser::PARSER_SEMANTICS_VERSION);
-            let memoized = if parse_memo_enabled {
-                parse_memo.get(&memo_key).cloned()
-            } else {
-                None
-            };
-            let parsed = match memoized {
-                Some(hit) => {
-                    parse_memo_hits += 1;
-                    hit
-                }
-                None => {
-                    parse_memo_misses += 1;
-
-                    let blob_start_time = std::time::Instant::now();
-                    let content = match blob_store.read(&blob_hash) {
-                        Ok(content) => {
-                            total_blob_read_time += blob_start_time.elapsed();
-                            content
-                        }
-                        Err(err) => {
-                            total_blob_read_time += blob_start_time.elapsed();
-                            warn!(
-                                file = %file_path,
-                                hash = %new_hash,
-                                error = %err,
-                                "skipping semantic enrichment for imported blob with missing content"
-                            );
-                            if remove_imported_file_semantic_state(
-                                &file_path,
-                                old_state,
-                                &mut current_files,
-                                &mut entity_deltas,
-                            ) {
-                                changed_source_files.insert(file_path.clone());
-                                incremental_linker.remove_file(&file_path);
-                            }
-                            continue;
-                        }
-                    };
-
-                    let file_id = FilePathId::new(&file_path);
-                    let parse_start_time = std::time::Instant::now();
-                    let indexed = match pipeline
-                        .index_file_content_with_tests(&file_id, &content, blob_hash)
-                    {
-                        Ok(indexed) => {
-                            total_parsing_time += parse_start_time.elapsed();
-                            indexed
-                        }
-                        Err(err) => {
-                            total_parsing_time += parse_start_time.elapsed();
-                            warn!(
-                                file = %file_path,
-                                hash = %new_hash,
-                                error = %err,
-                                "skipping semantic enrichment for imported source blob that could not be parsed"
-                            );
-                            if remove_imported_file_semantic_state(
-                                &file_path,
-                                old_state,
-                                &mut current_files,
-                                &mut entity_deltas,
-                            ) {
-                                changed_source_files.insert(file_path.clone());
-                                incremental_linker.remove_file(&file_path);
-                            }
-                            continue;
-                        }
-                    };
-
-                    // Cache the pre-reconciliation payload only. Entity-id
-                    // reconciliation below is commit-relative and must run per
-                    // commit, so it is deliberately kept outside the memo.
-                    let parsed = Arc::new(CachedParse {
-                        entities: indexed.indexed_file.entities,
-                        extracted_relations: indexed.indexed_file.extracted_relations,
-                        imports: indexed.indexed_file.imports,
-                    });
-                    if parse_memo_enabled {
-                        parse_memo.insert(memo_key, Arc::clone(&parsed));
+            match resolutions[delta_idx]
+                .take()
+                .expect("every artifact delta must be resolved by the plan/parse phase")
+            {
+                ImportedFileResolution::Remove => {
+                    if remove_imported_file_semantic_state(
+                        &file_path,
+                        old_state,
+                        &mut current_files,
+                        &mut entity_deltas,
+                    ) {
+                        changed_source_files.insert(file_path.clone());
+                        incremental_linker.remove_file(&file_path);
                     }
-                    parsed
                 }
-            };
+                ImportedFileResolution::Parsed(parsed) => {
+                    let old_entities = old_state
+                        .as_ref()
+                        .map(|state| state.entities.as_slice())
+                        .unwrap_or(&[]);
+                    // Reconcile borrows the shared parse output and clones only
+                    // the entities it stabilizes, so a memo hit never deep-clones
+                    // the entire entity vector.
+                    let (file_entity_deltas, stabilized_entities) =
+                        reconcile_imported_file_entities(old_entities, &parsed.entities);
+                    entity_deltas.extend(file_entity_deltas);
 
-            let old_entities = old_state
-                .as_ref()
-                .map(|state| state.entities.as_slice())
-                .unwrap_or(&[]);
-            // Reconcile borrows the shared parse output and clones only the
-            // entities it stabilizes, so a memo hit never deep-clones the entire
-            // entity vector.
-            let (file_entity_deltas, stabilized_entities) =
-                reconcile_imported_file_entities(old_entities, &parsed.entities);
-            entity_deltas.extend(file_entity_deltas);
+                    incremental_linker.add_file(&file_path, &stabilized_entities);
 
-            incremental_linker.add_file(&file_path, &stabilized_entities);
-
-            current_files.insert(
-                file_path.clone(),
-                ImportedSemanticFileState {
-                    file_path: file_path.clone(),
-                    entities: stabilized_entities,
-                    relations: parsed.extracted_relations.clone(),
-                    imports: parsed.imports.clone(),
-                },
-            );
-            changed_source_files.insert(file_path);
+                    current_files.insert(
+                        file_path.clone(),
+                        ImportedSemanticFileState {
+                            file_path: file_path.clone(),
+                            entities: stabilized_entities,
+                            relations: parsed.extracted_relations.clone(),
+                            imports: parsed.imports.clone(),
+                        },
+                    );
+                    changed_source_files.insert(file_path);
+                }
+            }
         }
 
         let closure_diff_start = std::time::Instant::now();
@@ -4477,6 +4571,206 @@ mod tests {
                 "relation_deltas diverged at commit {i}"
             );
         }
+    }
+
+    #[test]
+    fn replay_is_bit_identical_under_serial_and_parallel_execution() {
+        // End-to-end oracle for the intra-commit parallelism: the parse fan-out
+        // (parallel blob read + parse) and the parallel incremental linker both
+        // dispatch their per-item work onto the ambient Rayon pool. Pinning that
+        // pool to a single worker forces the whole hydration pass to run fully
+        // serially; a multi-worker pool exercises the concurrent path. Both arms
+        // run the identical production code with the memo enabled — the ONLY
+        // variable is worker-thread count — so any order-dependence, shared-state
+        // hazard, or nondeterministic merge in the fan-out would make the two
+        // diverge. The fixture spans several commits with cross-file imports,
+        // calls, a class-inheritance receiver-method call, a blob that reverts to
+        // an earlier version (memo hit), and a non-source file, so entities,
+        // relations, and their per-entity fingerprints are all exercised.
+        let dir = tempfile::tempdir().unwrap();
+        let blob_store = kin_blobs::BlobStore::new(dir.path().join("objects")).unwrap();
+
+        // Leaf callees imported across the tree.
+        let log_v1 = blob_store
+            .write(b"export function log(msg: string) { return msg; }\n")
+            .unwrap();
+        // math v1 is reused verbatim by commit 3, so it parses once (commit 1)
+        // then serves from the memo.
+        let math_v1 = blob_store
+            .write(b"export function add(a: number, b: number) { return a + b; }\n")
+            .unwrap();
+        let math_v2 = blob_store
+            .write(
+                b"export function add(a: number, b: number) { return a + b; }\n\
+                  export function mul(a: number, b: number) { return a * b; }\n",
+            )
+            .unwrap();
+        // Base class for the inheritance-aware receiver-method tier.
+        let base_v1 = blob_store
+            .write(b"export class Base { greet() { return 0; } }\n")
+            .unwrap();
+        // Imports log + add, extends Base, and calls this.greet(): a single file
+        // that reaches the cross-file import/call tiers and the inherited-method
+        // tier at once.
+        let main_v1 = blob_store
+            .write(
+                b"import { log } from '../util/log';\n\
+                  import { add } from '../util/math';\n\
+                  import { Base } from '../core/base';\n\
+                  export class App extends Base { run() { log('x'); add(1, 2); this.greet(); } }\n",
+            )
+            .unwrap();
+        // A second importer of log so commit 2 adds independent cross-file work.
+        let worker_v1 = blob_store
+            .write(b"import { log } from '../util/log';\nexport function work() { log('w'); }\n")
+            .unwrap();
+        let readme = blob_store.write(b"# Title\n").unwrap();
+
+        let fixture = || {
+            vec![
+                imported_change(
+                    [0x41; 32],
+                    [0x40; 32],
+                    "seed the tree",
+                    vec![
+                        artifact_delta(
+                            "src/util/log.ts",
+                            kin_model::ArtifactDeltaKind::Added,
+                            None,
+                            Some(Hash256::from_bytes(log_v1.0)),
+                        ),
+                        artifact_delta(
+                            "src/util/math.ts",
+                            kin_model::ArtifactDeltaKind::Added,
+                            None,
+                            Some(Hash256::from_bytes(math_v1.0)),
+                        ),
+                        artifact_delta(
+                            "src/core/base.ts",
+                            kin_model::ArtifactDeltaKind::Added,
+                            None,
+                            Some(Hash256::from_bytes(base_v1.0)),
+                        ),
+                        artifact_delta(
+                            "src/app/main.ts",
+                            kin_model::ArtifactDeltaKind::Added,
+                            None,
+                            Some(Hash256::from_bytes(main_v1.0)),
+                        ),
+                    ],
+                ),
+                imported_change(
+                    [0x42; 32],
+                    [0x41; 32],
+                    "grow math + add a worker",
+                    vec![
+                        artifact_delta(
+                            "src/util/math.ts",
+                            kin_model::ArtifactDeltaKind::Modified,
+                            Some(Hash256::from_bytes(math_v1.0)),
+                            Some(Hash256::from_bytes(math_v2.0)),
+                        ),
+                        artifact_delta(
+                            "src/app/worker.ts",
+                            kin_model::ArtifactDeltaKind::Added,
+                            None,
+                            Some(Hash256::from_bytes(worker_v1.0)),
+                        ),
+                    ],
+                ),
+                imported_change(
+                    [0x43; 32],
+                    [0x42; 32],
+                    "revert math + add docs",
+                    vec![
+                        // Reverts to commit 1's exact bytes: a memo hit whose
+                        // reconciliation still runs against commit 2's state.
+                        artifact_delta(
+                            "src/util/math.ts",
+                            kin_model::ArtifactDeltaKind::Modified,
+                            Some(Hash256::from_bytes(math_v2.0)),
+                            Some(Hash256::from_bytes(math_v1.0)),
+                        ),
+                        // Non-source file: takes the removal path, never a job.
+                        artifact_delta(
+                            "README.md",
+                            kin_model::ArtifactDeltaKind::Added,
+                            None,
+                            Some(Hash256::from_bytes(readme.0)),
+                        ),
+                    ],
+                ),
+            ]
+        };
+
+        let serial_pool = rayon::ThreadPoolBuilder::new()
+            .num_threads(1)
+            .build()
+            .unwrap();
+        let parallel_pool = rayon::ThreadPoolBuilder::new()
+            .num_threads(4)
+            .build()
+            .unwrap();
+
+        let mut serial = fixture();
+        let (serial_hits, serial_misses) = serial_pool
+            .install(|| {
+                enrich_imported_changes_with_semantics_inner(&mut serial, &blob_store, true)
+            })
+            .unwrap();
+
+        let mut parallel = fixture();
+        let (parallel_hits, parallel_misses) = parallel_pool
+            .install(|| {
+                enrich_imported_changes_with_semantics_inner(&mut parallel, &blob_store, true)
+            })
+            .unwrap();
+
+        // Memo hit/miss accounting must not depend on worker-thread count.
+        assert_eq!(
+            (serial_hits, serial_misses),
+            (parallel_hits, parallel_misses),
+            "memo accounting diverged between serial and parallel execution"
+        );
+        assert!(
+            serial_hits >= 1,
+            "fixture must exercise a memo hit (the reverted blob)"
+        );
+
+        // Bit-identity across every commit: the enriched entity and relation
+        // deltas must match exactly. Entity deltas embed each entity's
+        // `SemanticFingerprint` (ast/signature/behavior hashes), so this
+        // comparison is also the fingerprint oracle.
+        assert_eq!(serial.len(), parallel.len());
+        let mut saw_entities = false;
+        let mut saw_relations = false;
+        let mut saw_fingerprint = false;
+        for (i, (serial_change, parallel_change)) in serial.iter().zip(parallel.iter()).enumerate()
+        {
+            let serial_entities = canonical_json(&serial_change.change.entity_deltas);
+            assert_eq!(
+                serial_entities,
+                canonical_json(&parallel_change.change.entity_deltas),
+                "entity_deltas diverged at commit {i} under parallel execution"
+            );
+            assert_eq!(
+                canonical_json(&serial_change.change.relation_deltas),
+                canonical_json(&parallel_change.change.relation_deltas),
+                "relation_deltas diverged at commit {i} under parallel execution"
+            );
+            saw_entities |= !serial_change.change.entity_deltas.is_empty();
+            saw_relations |= !serial_change.change.relation_deltas.is_empty();
+            saw_fingerprint |= serial_entities.contains("fingerprint");
+        }
+        assert!(saw_entities, "fixture must materialize entity deltas");
+        assert!(
+            saw_relations,
+            "fixture must materialize cross-file relation deltas"
+        );
+        assert!(
+            saw_fingerprint,
+            "entity deltas must carry fingerprints for the fingerprint oracle to bite"
+        );
     }
 
     #[test]

--- a/crates/kin-index/src/linker.rs
+++ b/crates/kin-index/src/linker.rs
@@ -2649,7 +2649,423 @@ pub fn link_cross_file_incremental(
     let _span =
         tracing::info_span!("kin.index.link_cross_file_incremental", files = files.len()).entered();
 
-    // Step 2: Build import map per file
+    // Read-only step-local overlays shared by every per-file resolution. Built
+    // once so the parallel per-file pass and its serial reference both resolve
+    // against byte-identical context.
+    let IncrementalLinkOverlays {
+        import_map,
+        include_graph,
+        class_bases,
+    } = build_incremental_link_overlays(files, linker);
+
+    // Resolve each file independently: every relation's source entity is owned
+    // by its own file, so the (src, dst, kind) triples produced by different
+    // files never collide. Per-file resolution carries its own dedup state and
+    // is therefore order-independent; results are collected in input-file order
+    // (`par_iter().collect()` preserves order) and merged serially below so the
+    // materialized relation set and ordering are identical to a serial pass —
+    // mirroring the batch `link_cross_file` resolver.
+    let total_files = files.len();
+    let progress_interval = std::cmp::max(total_files / 50, 1);
+    let link_start = std::time::Instant::now();
+    let completed = AtomicUsize::new(0);
+    let found = AtomicUsize::new(0);
+    let per_file_relations: Vec<Vec<Relation>> = files
+        .par_iter()
+        .map(|file| {
+            let relations = resolve_one_file_incremental(
+                file,
+                linker,
+                &import_map,
+                &include_graph,
+                &class_bases,
+            );
+            if total_files > 50 {
+                let done = completed.fetch_add(1, Ordering::Relaxed) + 1;
+                let total = found.fetch_add(relations.len(), Ordering::Relaxed) + relations.len();
+                if done % progress_interval == 0 || done == total_files {
+                    eprint!(
+                        "\r  Linking: [{}/{}] {}% | {} relations | {:.1}s",
+                        done,
+                        total_files,
+                        (done * 100) / total_files,
+                        total,
+                        link_start.elapsed().as_secs_f64()
+                    );
+                }
+            }
+            relations
+        })
+        .collect();
+    if total_files > 50 {
+        eprintln!(); // newline after \r progress
+    }
+
+    merge_incremental_resolved(per_file_relations, files, linker)
+}
+
+/// Resolve the name-based relations of a single file into entity-ID relations
+/// using the incrementally updated linker state.
+///
+/// All reads are against the shared read-only `linker` and the step-local
+/// overlays (`import_map`, `include_graph`, `class_bases`); the only mutable
+/// state is a file-local dedup set, so this is pure with respect to other files
+/// and safe to run across files in parallel. Mirrors the batch
+/// [`resolve_one_file`].
+fn resolve_one_file_incremental(
+    file: &FileParseData,
+    linker: &IncrementalLinker,
+    import_map: &HashMap<&str, HashMap<&str, (&str, &str)>>,
+    include_graph: &HashMap<String, Vec<String>>,
+    class_bases: &HashMap<String, Vec<(String, Vec<String>)>>,
+) -> Vec<Relation> {
+    let mut resolved = Vec::new();
+    let mut seen: HashSet<(EntityId, EntityId, RelationKind)> = HashSet::new();
+    // Lazily resolved once per file: only ambiguous name buckets need them.
+    let mut caller_import_targets: Option<HashSet<String>> = None;
+    let mut caller_include_closure: Option<HashMap<String, usize>> = None;
+    for rel in &file.relations {
+        let src_id = linker
+            .entity_by_file_name
+            .get(&file.file_path)
+            .and_then(|m| m.get(&rel.src_name))
+            .copied();
+        let dst_same_file = linker
+            .entity_by_file_name
+            .get(&file.file_path)
+            .and_then(|m| m.get(&rel.dst_name))
+            .copied();
+
+        let src_id = match src_id {
+            Some(id) => id,
+            None => {
+                debug!(
+                    src = %rel.src_name,
+                    dst = %rel.dst_name,
+                    file = %file.file_path,
+                    "linker: src entity not found, skipping"
+                );
+                continue;
+            }
+        };
+
+        if rel.kind == RelationKind::UsesMacro {
+            if let Some(dst_id) = dst_same_file {
+                if linker.entity_kind_by_id.get(&dst_id) == Some(&EntityKind::Macro) {
+                    if add_deduped(&mut seen, src_id, dst_id, rel.kind) {
+                        resolved.push(make_relation(rel.kind, src_id, dst_id, 1.0));
+                    }
+                    continue;
+                }
+            }
+
+            if let Some(dst_id) = resolve_reachable_macro_target_incremental(
+                &file.file_path,
+                &rel.dst_name,
+                &include_graph,
+                linker,
+            ) {
+                if add_deduped(&mut seen, src_id, dst_id, rel.kind) {
+                    resolved.push(make_relation(rel.kind, src_id, dst_id, 0.95));
+                }
+                continue;
+            }
+
+            debug!(
+                src = %rel.src_name,
+                dst = %rel.dst_name,
+                file = %file.file_path,
+                "linker: macro use unresolved through same-file/include closure"
+            );
+            continue;
+        }
+
+        // (a) Same-file resolution. Mirrors the batch linker: the same-file
+        // entity wins and is emitted first at full confidence, but when
+        // cross-file entities share the exact name (a declaration/prototype
+        // whose definition lives elsewhere) also fan out to them, bounded so
+        // the same-file target plus its cross-file twins stay within the cap.
+        // Cross-file twins carry the (c) name-match confidence (0.7).
+        if let Some(dst_id) = dst_same_file {
+            if add_deduped(&mut seen, src_id, dst_id, rel.kind) {
+                resolved.push(make_relation(rel.kind, src_id, dst_id, 1.0));
+            }
+            let mut cross_file_twins: HashSet<EntityId> = HashSet::new();
+            if let Some(candidates) = linker.entity_by_name.get(&rel.dst_name) {
+                for (fp, id) in candidates {
+                    if fp != &file.file_path {
+                        cross_file_twins.insert(*id);
+                    }
+                }
+            }
+            if !cross_file_twins.is_empty() && cross_file_twins.len() < AMBIGUOUS_CALL_FANOUT_CAP {
+                for cross_id in sorted_fanout_targets(cross_file_twins) {
+                    if add_deduped(&mut seen, src_id, cross_id, rel.kind) {
+                        resolved.push(make_relation(rel.kind, src_id, cross_id, 0.7));
+                    }
+                }
+            }
+            continue;
+        }
+
+        // (a2) Inheritance-aware receiver-method resolution — mirrors the
+        // batch linker: a class-qualified `self.m()`/`cls.m()` callee whose
+        // owner is a class in this file resolves through the recorded
+        // Extends chain to the defining ancestor; an unresolvable hierarchy
+        // falls back to the bare leaf for the tiers below.
+        let mut dst_lookup: &str = rel.dst_name.as_str();
+        if rel.kind == RelationKind::Calls {
+            if let Some((owner, method)) = split_owner_method(rel.dst_name.as_str()) {
+                let owner_is_class = linker
+                    .entity_by_file_name
+                    .get(&file.file_path)
+                    .and_then(|m| m.get(owner))
+                    .map(|id| is_class_like(linker.entity_kind_by_id.get(id)))
+                    .unwrap_or(false);
+                if owner_is_class {
+                    if let Some(dst_id) = resolve_inherited_method_incremental(
+                        &file.file_path,
+                        owner,
+                        method,
+                        linker,
+                        &import_map,
+                        &class_bases,
+                    ) {
+                        if add_deduped(&mut seen, src_id, dst_id, rel.kind) {
+                            resolved.push(make_relation(
+                                rel.kind,
+                                src_id,
+                                dst_id,
+                                INHERITED_METHOD_CONFIDENCE,
+                            ));
+                        }
+                        continue;
+                    }
+                    dst_lookup = method;
+                }
+            }
+        }
+
+        // (b) Import-based cross-file resolution
+        if let Some(file_imports) = import_map.get(file.file_path.as_str()) {
+            if let Some(&(module_path, original_name)) = file_imports.get(rel.dst_name.as_str()) {
+                if let Some(target_file) =
+                    resolve_module_path(&file.file_path, module_path, &linker.known_files)
+                {
+                    let direct = linker
+                        .entity_by_file_name
+                        .get(&target_file)
+                        .and_then(|m| m.get(original_name))
+                        .copied();
+                    let dst_id = if direct.is_some() {
+                        direct
+                    } else if original_name == "default" {
+                        resolve_default_export_incremental(&target_file, &linker.entities_by_file)
+                    } else {
+                        None
+                    };
+                    if let Some(dst_id) = dst_id {
+                        if add_deduped(&mut seen, src_id, dst_id, rel.kind) {
+                            resolved.push(make_relation(rel.kind, src_id, dst_id, 0.95));
+                        }
+                        continue;
+                    }
+                }
+            }
+
+            // (b2) Namespace/package import member resolution
+            if let Some((import_name, member_name)) = split_member_access(rel.dst_name.as_str()) {
+                if let Some(&(module_path, _original_name)) = file_imports.get(import_name) {
+                    if let Some(target_file) =
+                        resolve_module_path(&file.file_path, module_path, &linker.known_files)
+                    {
+                        if let Some(&dst_id) = linker
+                            .entity_by_file_name
+                            .get(&target_file)
+                            .and_then(|m| m.get(member_name))
+                        {
+                            if add_deduped(&mut seen, src_id, dst_id, rel.kind) {
+                                resolved.push(make_relation(rel.kind, src_id, dst_id, 0.9));
+                            }
+                            continue;
+                        }
+                    }
+                }
+            }
+        }
+
+        let other_file_candidates: Vec<(&str, EntityId)> = linker
+            .entity_by_name
+            .get(dst_lookup)
+            .map(|candidates| {
+                candidates
+                    .iter()
+                    .filter(|(fp, _)| fp != &file.file_path)
+                    .map(|(fp, id)| (fp.as_str(), *id))
+                    .collect()
+            })
+            .unwrap_or_default();
+
+        // (b3) Parser-pinned import resolution — mirrors the batch linker:
+        // a callee pinned to a module must resolve inside that module (or
+        // its package directory), never through the global name bucket.
+        let mut name_fallback_allowed = true;
+        match resolve_import_pinned_target(
+            rel,
+            &file.file_path,
+            &linker.known_files,
+            |target_file, name| {
+                linker
+                    .entity_by_file_name
+                    .get(target_file)
+                    .and_then(|m| m.get(name))
+                    .copied()
+            },
+            &other_file_candidates,
+        ) {
+            ImportPinnedTarget::Resolved(dst_id) => {
+                if add_deduped(&mut seen, src_id, dst_id, rel.kind) {
+                    resolved.push(make_relation(
+                        rel.kind,
+                        src_id,
+                        dst_id,
+                        IMPORT_PINNED_CONFIDENCE,
+                    ));
+                }
+                continue;
+            }
+            ImportPinnedTarget::PinnedMiss => name_fallback_allowed = false,
+            ImportPinnedTarget::NoPin => {}
+        }
+
+        // (c) Global name-match fallback
+        if name_fallback_allowed && !other_file_candidates.is_empty() {
+            let distinct_ids: HashSet<EntityId> =
+                other_file_candidates.iter().map(|&(_, id)| id).collect();
+            let (dst_id, confidence) = if distinct_ids.len() == 1 {
+                (other_file_candidates[0].1, 0.7)
+            } else {
+                let targets = caller_import_targets.get_or_insert_with(|| {
+                    resolve_caller_import_targets(
+                        &file.file_path,
+                        &file.imports,
+                        &linker.known_files,
+                    )
+                });
+                let closure = caller_include_closure
+                    .get_or_insert_with(|| include_closure_depths(&file.file_path, &include_graph));
+                match disambiguate_same_name_candidates(
+                    &file.file_path,
+                    targets,
+                    closure,
+                    &other_file_candidates,
+                    |path| {
+                        linker
+                            .entities_by_file
+                            .get(path)
+                            .map(|entities| entities.len())
+                            .unwrap_or(0)
+                    },
+                ) {
+                    Some(dst_id) => (dst_id, LOCALITY_DISAMBIGUATED_CONFIDENCE),
+                    // No locality signal: keep the historical bucket-order
+                    // pick so signal-less repos do not lose existing edges.
+                    None => (other_file_candidates[0].1, 0.7),
+                }
+            };
+            if add_deduped(&mut seen, src_id, dst_id, rel.kind) {
+                resolved.push(make_relation(rel.kind, src_id, dst_id, confidence));
+            }
+            continue;
+        }
+
+        // (c2) Receiver-method calls (`x.method()`) arrive as the bare method
+        // name with no exact cross-file entity of that name, so (c) above
+        // never fires. Resolve them through the bare-name index, mirroring
+        // the batch linker's (c2): a single distinct cross-file method links,
+        // and several implementor classes fan out to all of them up to the
+        // cap (virtual dispatch has an unknowable receiver type). Beyond the
+        // cap the name is too ubiquitous to guess and stays unresolved.
+        // Without this step a receiver method resolved into a full-tree
+        // snapshot is dropped the moment an incremental relink of the caller
+        // re-derives its edges.
+        if name_fallback_allowed && rel.kind == RelationKind::Calls {
+            if let Some(bare_candidates) = linker.entity_by_bare_name.get(dst_lookup) {
+                let distinct_targets: HashSet<EntityId> = bare_candidates
+                    .iter()
+                    .filter(|(fp, _)| fp != &file.file_path)
+                    .map(|(_, id)| *id)
+                    .collect();
+                if (1..=AMBIGUOUS_CALL_FANOUT_CAP).contains(&distinct_targets.len()) {
+                    for dst_id in sorted_fanout_targets(distinct_targets) {
+                        if add_deduped(&mut seen, src_id, dst_id, rel.kind) {
+                            resolved.push(make_relation(rel.kind, src_id, dst_id, 0.3));
+                        }
+                    }
+                    continue;
+                }
+            }
+        }
+
+        // (c3) Path-qualified suffix resolution — the incremental counterpart
+        // of the batch linker's (c3). Live edits reach this daemon path, so
+        // qualified calls must resolve here too, not only on a full re-index.
+        if name_fallback_allowed
+            && matches!(rel.kind, RelationKind::Calls | RelationKind::References)
+        {
+            // Fan out: an ambiguous qualified leaf resolves to every distinct
+            // cross-file target, matching the batch resolver.
+            let qualified_targets =
+                resolve_qualified_suffix_incremental(&rel.dst_name, &file.file_path, linker);
+            if !qualified_targets.is_empty() {
+                for dst_id in qualified_targets {
+                    if add_deduped(&mut seen, src_id, dst_id, rel.kind) {
+                        resolved.push(make_relation(
+                            rel.kind,
+                            src_id,
+                            dst_id,
+                            QUALIFIED_SUFFIX_CONFIDENCE,
+                        ));
+                    }
+                }
+                continue;
+            }
+        }
+
+        // (d) Cross-repo external reference: preserve an unresolved
+        // reference to an external module as an inferred edge carrying the
+        // imported symbol and source, so the spine cross-repo resolver can
+        // match it against a sibling repo. See
+        // `make_external_reference_relation`.
+        if let Some(external) =
+            make_external_reference_relation(rel, src_id, &file.file_path, &linker.known_files)
+        {
+            if let GraphNodeId::Entity(dst_id) = external.dst {
+                if add_deduped(&mut seen, src_id, dst_id, rel.kind) {
+                    resolved.push(external);
+                }
+            }
+            continue;
+        }
+    }
+
+    resolved
+}
+
+/// Read-only step-local overlays shared by every per-file incremental
+/// resolution, built once per link so the parallel per-file pass and its serial
+/// reference resolve against byte-identical context.
+struct IncrementalLinkOverlays<'a> {
+    import_map: HashMap<&'a str, HashMap<&'a str, (&'a str, &'a str)>>,
+    include_graph: HashMap<String, Vec<String>>,
+    class_bases: HashMap<String, Vec<(String, Vec<String>)>>,
+}
+
+fn build_incremental_link_overlays<'a>(
+    files: &'a [FileParseData],
+    linker: &IncrementalLinker,
+) -> IncrementalLinkOverlays<'a> {
+    // Import map per file: local_name -> (module_path, original_name).
     let import_map: HashMap<&str, HashMap<&str, (&str, &str)>> = {
         let mut import_map: HashMap<&str, HashMap<&str, (&str, &str)>> = HashMap::new();
         for file in files {
@@ -2667,12 +3083,10 @@ pub fn link_cross_file_incremental(
         import_map
     };
 
-    let mut resolved = Vec::new();
-    let mut seen: HashSet<(EntityId, EntityId, RelationKind)> = HashSet::new();
-    // Step-local include edges overlay the linker's persistent per-file
-    // include state: files parsed this step resolve fresh (including files
-    // that dropped every include), every other file keeps the edges recorded
-    // when it was last parsed. Closure walks therefore cross step boundaries.
+    // Step-local include edges overlay the linker's persistent per-file include
+    // state: files parsed this step resolve fresh (including files that dropped
+    // every include), every other file keeps the edges recorded when it was last
+    // parsed. Closure walks therefore cross step boundaries.
     let include_graph = {
         let mut merged = linker.include_targets_by_file.clone();
         for file in files {
@@ -2684,12 +3098,12 @@ pub fn link_cross_file_incremental(
         merged
     };
 
-    // Step-local class hierarchy overlays the linker's persistent per-file
-    // state, exactly like the include graph above: files parsed this step
-    // resolve from their fresh Extends declarations (including files whose
-    // classes lost every base), every other file keeps the hierarchy recorded
-    // when it was last parsed or rehydrated. Inheritance walks therefore cross
-    // step boundaries without reading committed-stale bases for edited files.
+    // Step-local class hierarchy overlays the linker's persistent per-file state,
+    // exactly like the include graph above: files parsed this step resolve from
+    // their fresh Extends declarations (including files whose classes lost every
+    // base), every other file keeps the hierarchy recorded when it was last
+    // parsed or rehydrated. Inheritance walks therefore cross step boundaries
+    // without reading committed-stale bases for edited files.
     let class_bases = {
         let mut merged = linker.class_bases_by_file.clone();
         for file in files {
@@ -2704,354 +3118,29 @@ pub fn link_cross_file_incremental(
         merged
     };
 
-    let total_files = files.len();
-    let progress_interval = std::cmp::max(total_files / 50, 1);
-    let link_start = std::time::Instant::now();
+    IncrementalLinkOverlays {
+        import_map,
+        include_graph,
+        class_bases,
+    }
+}
 
-    for (file_idx, file) in files.iter().enumerate() {
-        if total_files > 50 && (file_idx % progress_interval == 0 || file_idx + 1 == total_files) {
-            eprint!(
-                "\r  Linking: [{}/{}] {}% | {} relations | {:.1}s",
-                file_idx + 1,
-                total_files,
-                ((file_idx + 1) * 100) / total_files,
-                resolved.len(),
-                link_start.elapsed().as_secs_f64()
-            );
-        }
-        // Lazily resolved once per file: only ambiguous name buckets need them.
-        let mut caller_import_targets: Option<HashSet<String>> = None;
-        let mut caller_include_closure: Option<HashMap<String, usize>> = None;
-        for rel in &file.relations {
-            let src_id = linker
-                .entity_by_file_name
-                .get(&file.file_path)
-                .and_then(|m| m.get(&rel.src_name))
-                .copied();
-            let dst_same_file = linker
-                .entity_by_file_name
-                .get(&file.file_path)
-                .and_then(|m| m.get(&rel.dst_name))
-                .copied();
-
-            let src_id = match src_id {
-                Some(id) => id,
-                None => {
-                    debug!(
-                        src = %rel.src_name,
-                        dst = %rel.dst_name,
-                        file = %file.file_path,
-                        "linker: src entity not found, skipping"
-                    );
-                    continue;
-                }
-            };
-
-            if rel.kind == RelationKind::UsesMacro {
-                if let Some(dst_id) = dst_same_file {
-                    if linker.entity_kind_by_id.get(&dst_id) == Some(&EntityKind::Macro) {
-                        if add_deduped(&mut seen, src_id, dst_id, rel.kind) {
-                            resolved.push(make_relation(rel.kind, src_id, dst_id, 1.0));
-                        }
-                        continue;
-                    }
-                }
-
-                if let Some(dst_id) = resolve_reachable_macro_target_incremental(
-                    &file.file_path,
-                    &rel.dst_name,
-                    &include_graph,
-                    linker,
-                ) {
-                    if add_deduped(&mut seen, src_id, dst_id, rel.kind) {
-                        resolved.push(make_relation(rel.kind, src_id, dst_id, 0.95));
-                    }
-                    continue;
-                }
-
-                debug!(
-                    src = %rel.src_name,
-                    dst = %rel.dst_name,
-                    file = %file.file_path,
-                    "linker: macro use unresolved through same-file/include closure"
-                );
-                continue;
-            }
-
-            // (a) Same-file resolution. Mirrors the batch linker: the same-file
-            // entity wins and is emitted first at full confidence, but when
-            // cross-file entities share the exact name (a declaration/prototype
-            // whose definition lives elsewhere) also fan out to them, bounded so
-            // the same-file target plus its cross-file twins stay within the cap.
-            // Cross-file twins carry the (c) name-match confidence (0.7).
-            if let Some(dst_id) = dst_same_file {
-                if add_deduped(&mut seen, src_id, dst_id, rel.kind) {
-                    resolved.push(make_relation(rel.kind, src_id, dst_id, 1.0));
-                }
-                let mut cross_file_twins: HashSet<EntityId> = HashSet::new();
-                if let Some(candidates) = linker.entity_by_name.get(&rel.dst_name) {
-                    for (fp, id) in candidates {
-                        if fp != &file.file_path {
-                            cross_file_twins.insert(*id);
-                        }
-                    }
-                }
-                if !cross_file_twins.is_empty()
-                    && cross_file_twins.len() < AMBIGUOUS_CALL_FANOUT_CAP
-                {
-                    for cross_id in sorted_fanout_targets(cross_file_twins) {
-                        if add_deduped(&mut seen, src_id, cross_id, rel.kind) {
-                            resolved.push(make_relation(rel.kind, src_id, cross_id, 0.7));
-                        }
-                    }
-                }
-                continue;
-            }
-
-            // (a2) Inheritance-aware receiver-method resolution — mirrors the
-            // batch linker: a class-qualified `self.m()`/`cls.m()` callee whose
-            // owner is a class in this file resolves through the recorded
-            // Extends chain to the defining ancestor; an unresolvable hierarchy
-            // falls back to the bare leaf for the tiers below.
-            let mut dst_lookup: &str = rel.dst_name.as_str();
-            if rel.kind == RelationKind::Calls {
-                if let Some((owner, method)) = split_owner_method(rel.dst_name.as_str()) {
-                    let owner_is_class = linker
-                        .entity_by_file_name
-                        .get(&file.file_path)
-                        .and_then(|m| m.get(owner))
-                        .map(|id| is_class_like(linker.entity_kind_by_id.get(id)))
-                        .unwrap_or(false);
-                    if owner_is_class {
-                        if let Some(dst_id) = resolve_inherited_method_incremental(
-                            &file.file_path,
-                            owner,
-                            method,
-                            linker,
-                            &import_map,
-                            &class_bases,
-                        ) {
-                            if add_deduped(&mut seen, src_id, dst_id, rel.kind) {
-                                resolved.push(make_relation(
-                                    rel.kind,
-                                    src_id,
-                                    dst_id,
-                                    INHERITED_METHOD_CONFIDENCE,
-                                ));
-                            }
-                            continue;
-                        }
-                        dst_lookup = method;
-                    }
-                }
-            }
-
-            // (b) Import-based cross-file resolution
-            if let Some(file_imports) = import_map.get(file.file_path.as_str()) {
-                if let Some(&(module_path, original_name)) = file_imports.get(rel.dst_name.as_str())
-                {
-                    if let Some(target_file) =
-                        resolve_module_path(&file.file_path, module_path, &linker.known_files)
-                    {
-                        let direct = linker
-                            .entity_by_file_name
-                            .get(&target_file)
-                            .and_then(|m| m.get(original_name))
-                            .copied();
-                        let dst_id = if direct.is_some() {
-                            direct
-                        } else if original_name == "default" {
-                            resolve_default_export_incremental(
-                                &target_file,
-                                &linker.entities_by_file,
-                            )
-                        } else {
-                            None
-                        };
-                        if let Some(dst_id) = dst_id {
-                            if add_deduped(&mut seen, src_id, dst_id, rel.kind) {
-                                resolved.push(make_relation(rel.kind, src_id, dst_id, 0.95));
-                            }
-                            continue;
-                        }
-                    }
-                }
-
-                // (b2) Namespace/package import member resolution
-                if let Some((import_name, member_name)) = split_member_access(rel.dst_name.as_str())
-                {
-                    if let Some(&(module_path, _original_name)) = file_imports.get(import_name) {
-                        if let Some(target_file) =
-                            resolve_module_path(&file.file_path, module_path, &linker.known_files)
-                        {
-                            if let Some(&dst_id) = linker
-                                .entity_by_file_name
-                                .get(&target_file)
-                                .and_then(|m| m.get(member_name))
-                            {
-                                if add_deduped(&mut seen, src_id, dst_id, rel.kind) {
-                                    resolved.push(make_relation(rel.kind, src_id, dst_id, 0.9));
-                                }
-                                continue;
-                            }
-                        }
-                    }
-                }
-            }
-
-            let other_file_candidates: Vec<(&str, EntityId)> = linker
-                .entity_by_name
-                .get(dst_lookup)
-                .map(|candidates| {
-                    candidates
-                        .iter()
-                        .filter(|(fp, _)| fp != &file.file_path)
-                        .map(|(fp, id)| (fp.as_str(), *id))
-                        .collect()
-                })
-                .unwrap_or_default();
-
-            // (b3) Parser-pinned import resolution — mirrors the batch linker:
-            // a callee pinned to a module must resolve inside that module (or
-            // its package directory), never through the global name bucket.
-            let mut name_fallback_allowed = true;
-            match resolve_import_pinned_target(
-                rel,
-                &file.file_path,
-                &linker.known_files,
-                |target_file, name| {
-                    linker
-                        .entity_by_file_name
-                        .get(target_file)
-                        .and_then(|m| m.get(name))
-                        .copied()
-                },
-                &other_file_candidates,
-            ) {
-                ImportPinnedTarget::Resolved(dst_id) => {
-                    if add_deduped(&mut seen, src_id, dst_id, rel.kind) {
-                        resolved.push(make_relation(
-                            rel.kind,
-                            src_id,
-                            dst_id,
-                            IMPORT_PINNED_CONFIDENCE,
-                        ));
-                    }
-                    continue;
-                }
-                ImportPinnedTarget::PinnedMiss => name_fallback_allowed = false,
-                ImportPinnedTarget::NoPin => {}
-            }
-
-            // (c) Global name-match fallback
-            if name_fallback_allowed && !other_file_candidates.is_empty() {
-                let distinct_ids: HashSet<EntityId> =
-                    other_file_candidates.iter().map(|&(_, id)| id).collect();
-                let (dst_id, confidence) = if distinct_ids.len() == 1 {
-                    (other_file_candidates[0].1, 0.7)
-                } else {
-                    let targets = caller_import_targets.get_or_insert_with(|| {
-                        resolve_caller_import_targets(
-                            &file.file_path,
-                            &file.imports,
-                            &linker.known_files,
-                        )
-                    });
-                    let closure = caller_include_closure.get_or_insert_with(|| {
-                        include_closure_depths(&file.file_path, &include_graph)
-                    });
-                    match disambiguate_same_name_candidates(
-                        &file.file_path,
-                        targets,
-                        closure,
-                        &other_file_candidates,
-                        |path| {
-                            linker
-                                .entities_by_file
-                                .get(path)
-                                .map(|entities| entities.len())
-                                .unwrap_or(0)
-                        },
-                    ) {
-                        Some(dst_id) => (dst_id, LOCALITY_DISAMBIGUATED_CONFIDENCE),
-                        // No locality signal: keep the historical bucket-order
-                        // pick so signal-less repos do not lose existing edges.
-                        None => (other_file_candidates[0].1, 0.7),
-                    }
-                };
-                if add_deduped(&mut seen, src_id, dst_id, rel.kind) {
-                    resolved.push(make_relation(rel.kind, src_id, dst_id, confidence));
-                }
-                continue;
-            }
-
-            // (c2) Receiver-method calls (`x.method()`) arrive as the bare method
-            // name with no exact cross-file entity of that name, so (c) above
-            // never fires. Resolve them through the bare-name index, mirroring
-            // the batch linker's (c2): a single distinct cross-file method links,
-            // and several implementor classes fan out to all of them up to the
-            // cap (virtual dispatch has an unknowable receiver type). Beyond the
-            // cap the name is too ubiquitous to guess and stays unresolved.
-            // Without this step a receiver method resolved into a full-tree
-            // snapshot is dropped the moment an incremental relink of the caller
-            // re-derives its edges.
-            if name_fallback_allowed && rel.kind == RelationKind::Calls {
-                if let Some(bare_candidates) = linker.entity_by_bare_name.get(dst_lookup) {
-                    let distinct_targets: HashSet<EntityId> = bare_candidates
-                        .iter()
-                        .filter(|(fp, _)| fp != &file.file_path)
-                        .map(|(_, id)| *id)
-                        .collect();
-                    if (1..=AMBIGUOUS_CALL_FANOUT_CAP).contains(&distinct_targets.len()) {
-                        for dst_id in sorted_fanout_targets(distinct_targets) {
-                            if add_deduped(&mut seen, src_id, dst_id, rel.kind) {
-                                resolved.push(make_relation(rel.kind, src_id, dst_id, 0.3));
-                            }
-                        }
-                        continue;
-                    }
-                }
-            }
-
-            // (c3) Path-qualified suffix resolution — the incremental counterpart
-            // of the batch linker's (c3). Live edits reach this daemon path, so
-            // qualified calls must resolve here too, not only on a full re-index.
-            if name_fallback_allowed
-                && matches!(rel.kind, RelationKind::Calls | RelationKind::References)
-            {
-                // Fan out: an ambiguous qualified leaf resolves to every distinct
-                // cross-file target, matching the batch resolver.
-                let qualified_targets =
-                    resolve_qualified_suffix_incremental(&rel.dst_name, &file.file_path, linker);
-                if !qualified_targets.is_empty() {
-                    for dst_id in qualified_targets {
-                        if add_deduped(&mut seen, src_id, dst_id, rel.kind) {
-                            resolved.push(make_relation(
-                                rel.kind,
-                                src_id,
-                                dst_id,
-                                QUALIFIED_SUFFIX_CONFIDENCE,
-                            ));
-                        }
-                    }
-                    continue;
-                }
-            }
-
-            // (d) Cross-repo external reference: preserve an unresolved
-            // reference to an external module as an inferred edge carrying the
-            // imported symbol and source, so the spine cross-repo resolver can
-            // match it against a sibling repo. See
-            // `make_external_reference_relation`.
-            if let Some(external) =
-                make_external_reference_relation(rel, src_id, &file.file_path, &linker.known_files)
-            {
-                if let GraphNodeId::Entity(dst_id) = external.dst {
-                    if add_deduped(&mut seen, src_id, dst_id, rel.kind) {
-                        resolved.push(external);
-                    }
-                }
-                continue;
+/// Merge per-file incremental relations in input-file order, then append
+/// artifact-level import/include edges. The cross-file dedup is a no-op across
+/// files (each relation's source entity is file-local) but is preserved so the
+/// emitted set and order match a serial pass exactly. Mirrors the batch
+/// [`merge_resolved`].
+fn merge_incremental_resolved(
+    per_file_relations: Vec<Vec<Relation>>,
+    files: &[FileParseData],
+    linker: &IncrementalLinker,
+) -> Vec<Relation> {
+    let mut resolved = Vec::new();
+    let mut seen: HashSet<(GraphNodeId, GraphNodeId, RelationKind)> = HashSet::new();
+    for file_relations in per_file_relations {
+        for rel in file_relations {
+            if seen.insert((rel.src, rel.dst, rel.kind)) {
+                resolved.push(rel);
             }
         }
     }
@@ -3072,6 +3161,27 @@ pub fn link_cross_file_incremental(
     }
 
     resolved
+}
+
+/// Serial counterpart of [`link_cross_file_incremental`], retained as the
+/// byte-identical reference for the parallel per-file resolution path.
+#[cfg(test)]
+fn link_cross_file_incremental_serial(
+    files: &[FileParseData],
+    linker: &IncrementalLinker,
+) -> Vec<Relation> {
+    let IncrementalLinkOverlays {
+        import_map,
+        include_graph,
+        class_bases,
+    } = build_incremental_link_overlays(files, linker);
+    let per_file_relations: Vec<Vec<Relation>> = files
+        .iter()
+        .map(|file| {
+            resolve_one_file_incremental(file, linker, &import_map, &include_graph, &class_bases)
+        })
+        .collect();
+    merge_incremental_resolved(per_file_relations, files, linker)
 }
 
 /// Normalize a path by resolving `.` and `..` components without touching the filesystem.
@@ -3946,6 +4056,103 @@ void f();
             .expect("incremental unambiguous receiver-method call should resolve to Type::method");
         assert_eq!(calls.src, GraphNodeId::Entity(caller.id));
         assert_eq!(calls.dst, GraphNodeId::Entity(callee.id));
+    }
+
+    #[test]
+    fn link_cross_file_incremental_parallel_matches_serial() {
+        // Rung-3 oracle for the parallel per-file resolver: exercise enough files,
+        // relation tiers, and ambiguous name buckets that any ordering or
+        // shared-state hazard in the fan-out would surface, then assert the
+        // parallel path is byte-identical to the serial reference and stable
+        // across re-runs. Mirrors `link_cross_file_against_entities`'s own
+        // parallel-vs-serial guard.
+        let mut linker = IncrementalLinker::new();
+        let mut files: Vec<FileParseData> = Vec::new();
+
+        // Two cross-file definitions of a shared ambiguous name so callers reach
+        // the same-name disambiguation tier (which picks by bucket order — a
+        // determinism-sensitive path).
+        let common_a = make_entity("common", "src/common_a.ts");
+        let common_b = make_entity("common", "src/common_b.ts");
+        linker.add_file("src/common_a.ts", std::slice::from_ref(&common_a));
+        linker.add_file("src/common_b.ts", std::slice::from_ref(&common_b));
+
+        // A single unambiguous cross-file call target.
+        let target = make_entity("shared_target", "src/target.ts");
+        linker.add_file("src/target.ts", std::slice::from_ref(&target));
+
+        // Two receiver-method implementors sharing a bare leaf `work`, so bare
+        // `work` calls fan out through `sorted_fanout_targets` (a canonical sort
+        // whose stability the parallel pass must preserve).
+        let widget_work = make_entity("Widget::work", "src/impl_foo.ts");
+        let gadget_work = make_entity("Gadget::work", "src/impl_bar.ts");
+        linker.add_file("src/impl_foo.ts", std::slice::from_ref(&widget_work));
+        linker.add_file("src/impl_bar.ts", std::slice::from_ref(&gadget_work));
+
+        // Many caller files spread the parallel pass across worker threads. Each
+        // mixes a same-file call, an unambiguous cross-file call, an ambiguous
+        // fan-out call, and a bare receiver-method call.
+        for i in 0..48 {
+            let path = format!("src/caller{i}.ts");
+            let a = make_entity(&format!("a{i}"), &path);
+            let b = make_entity(&format!("b{i}"), &path);
+            linker.add_file(&path, &[a.clone(), b.clone()]);
+            files.push(FileParseData {
+                file_path: path,
+                entities: vec![a, b],
+                relations: vec![
+                    ExtractedRelation {
+                        kind: RelationKind::Calls,
+                        src_name: format!("a{i}"),
+                        dst_name: format!("b{i}"),
+                        import_source: None,
+                    },
+                    ExtractedRelation {
+                        kind: RelationKind::Calls,
+                        src_name: format!("a{i}"),
+                        dst_name: "shared_target".to_string(),
+                        import_source: None,
+                    },
+                    ExtractedRelation {
+                        kind: RelationKind::Calls,
+                        src_name: format!("b{i}"),
+                        dst_name: "common".to_string(),
+                        import_source: None,
+                    },
+                    ExtractedRelation {
+                        kind: RelationKind::Calls,
+                        src_name: format!("b{i}"),
+                        dst_name: "work".to_string(),
+                        import_source: None,
+                    },
+                ],
+                imports: vec![],
+            });
+        }
+
+        let parallel = link_cross_file_incremental(&files, &linker);
+        let serial = link_cross_file_incremental_serial(&files, &linker);
+        assert_eq!(
+            format!("{parallel:?}"),
+            format!("{serial:?}"),
+            "parallel incremental linking must produce byte-identical relations to the serial path"
+        );
+
+        // Re-running the parallel path must also be byte-stable.
+        let parallel_again = link_cross_file_incremental(&files, &linker);
+        assert_eq!(
+            format!("{parallel:?}"),
+            format!("{parallel_again:?}"),
+            "parallel incremental linking must be byte-stable across runs"
+        );
+
+        // Guard against a vacuous fixture: every caller resolves at least its
+        // same-file, cross-file, disambiguated, and fanned-out edges.
+        assert!(
+            parallel.len() >= 48 * 4,
+            "fixture should resolve real cross-file work, got {}",
+            parallel.len()
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Parallelizes the per-commit compute inside `kin` history hydration. Two always-on changes, both bit-identical to the serial path:

1. **Blob parse fan-out** (`kin-cli` init replay) — within each commit, distinct memo-missing source blobs are read and parsed across the Rayon pool, deduped by `(blob hash, parser-semantics version)` so each distinct blob is read and parsed once and its `Arc` result is shared across every delta that names it (coherent with the existing cross-commit parse memo — no duplicate parses under concurrency). The outer commit loop stays serial because each commit forks its first parent's semantic state; every order-sensitive step (plan, merge, reconcile, linker mutation, delta accumulation) stays serial in delta order.
2. **Incremental linking parallelism** (`kin-index`) — ports the batch linker's per-file `par_iter` resolution into `link_cross_file_incremental` (the daemon/replay linking path). Each file resolves its relations independently with a file-local dedup; results collect in input-file order and merge serially, mirroring `link_cross_file_against_entities`. The FIR-1342 inheritance tier resolves identically in both paths.

## Bit-identical invariant

A relation's source entity is always owned by its own file, so the `(src, dst, kind)` triples produced by different files never collide. Per-file resolution carries its own dedup state and is order-independent; results are collected in input-file order (`par_iter().collect()` preserves order) and merged serially, so the materialized relation set and its ordering match a serial pass exactly. The plan/merge/reconcile phases of the parse fan-out are serial and deterministic (memo keyed by content hash, never iterated for output).

## Stage-timing semantics

`blob_read_s` / `parsing_s` now record each **parallel stage's wall-clock** (not summed per-thread time): the read stage and the parse stage are each timed end-to-end around the `par_iter`. This is documented at the call sites. Bucketed stage accounting therefore stays truthful under parallelism — the number reflects wall-clock spent in that stage.

## Tests (serial-vs-parallel oracles)

- `kin-cli` — `replay_is_bit_identical_under_serial_and_parallel_execution`: runs the **identical** production replay under a 1-worker vs 4-worker Rayon pool over a multi-commit fixture (cross-file imports/calls, a class-inheritance receiver-method call, a blob that reverts to an earlier version → memo hit, and a non-source file). Asserts entity deltas, relation deltas (which embed each entity's `SemanticFingerprint`), and memo hit/miss accounting are identical, plus non-vacuous coverage of all three.
- `kin-index` — `link_cross_file_incremental_parallel_matches_serial`: parallel per-file resolution vs a serial reference (`link_cross_file_incremental_serial`), byte-identical and stable across reruns, over a fixture that exercises ambiguous name buckets and receiver-method fan-out (the determinism-sensitive sorts).

```
test commands::init::tests::replay_is_bit_identical_under_serial_and_parallel_execution ... ok
test commands::init::tests::parse_memo_matches_unmemoized_reconciliation_across_commits ... ok
test commands::init::tests::base_link_anchor_and_enrichment_are_byte_stable_across_runs ... ok
test result: ok. 728 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 5.52s

test linker::tests::link_cross_file_incremental_parallel_matches_serial ... ok
test linker::tests::build_include_graph_parallel_matches_serial ... ok
test result: ok. 199 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.12s
```

## Verification

- `cargo fmt --all -- --check`: clean
- `cargo clippy -p kin-cli -p kin-index --all-targets` under the CI allow-list + `-D warnings`: clean (no new lint outside the existing debt allow-list)
- `cargo test -p kin-cli -p kin-index`: green (all integration suites included)

No new dependencies (rayon already in-tree in both crates). `Cargo.lock` untouched.

## Release / merge sequencing

- Rides **0.2.15**; merges **after** the 0.2.14 bump. No version bump in this PR.
- **Conflict surface:** kin #251 (inbound-edge closure index) also touched `crates/kin-cli/src/commands/init.rs` on a separate branch. This branch is implemented against its own base; expect a rebase conflict in `init.rs` at merge time. Captain sequences.

Linear: FIR-1371
