### PR TITLE
fix(daemon): default-on loopback auth, truthful shadow hydration reporting, flake fix

### DIFF
--- a/crates/kin-cli/src/backend.rs
+++ b/crates/kin-cli/src/backend.rs
@@ -271,6 +271,18 @@ fn graph_from_bootstrap_snapshot(
     }
 }
 
+/// Attach the daemon's bearer token to a request built against a bare
+/// `reqwest::Client` (as opposed to `DaemonClient`, which attaches this
+/// automatically at construction). Every helper in this module talks to the
+/// repo-scoped daemon directly rather than through `DaemonClient`, so each
+/// one needs this explicitly.
+fn with_daemon_auth(request: reqwest::RequestBuilder) -> reqwest::RequestBuilder {
+    match crate::daemon_client::resolve_daemon_auth_token() {
+        Some(token) => request.bearer_auth(token),
+        None => request,
+    }
+}
+
 async fn fetch_daemon_graph(
     daemon_url: &str,
 ) -> std::result::Result<kin_db::GraphSnapshot, String> {
@@ -286,14 +298,13 @@ async fn fetch_daemon_graph(
         .build()
         .map_err(|error| format!("build daemon bootstrap client: {error}"))?;
 
-    let resp = client
-        .get(format!(
-            "{}/graph/bootstrap",
-            daemon_url.trim_end_matches('/')
-        ))
-        .send()
-        .await
-        .map_err(|error| format!("send graph bootstrap request: {error}"))?;
+    let resp = with_daemon_auth(client.get(format!(
+        "{}/graph/bootstrap",
+        daemon_url.trim_end_matches('/')
+    )))
+    .send()
+    .await
+    .map_err(|error| format!("send graph bootstrap request: {error}"))?;
 
     if !resp.status().is_success() {
         let status = resp.status();
@@ -329,15 +340,14 @@ pub async fn require_daemon_update_head(
         "head": head_id,
     });
 
-    let resp = client
-        .put(format!(
-            "{}/v1/graph/branches/{}/head",
-            daemon_url.trim_end_matches('/'),
-            branch_name
-        ))
-        .json(&payload)
-        .send()
-        .await?;
+    let resp = with_daemon_auth(client.put(format!(
+        "{}/v1/graph/branches/{}/head",
+        daemon_url.trim_end_matches('/'),
+        branch_name
+    )))
+    .json(&payload)
+    .send()
+    .await?;
 
     if !resp.status().is_success() {
         let status = resp.status();
@@ -368,14 +378,13 @@ pub async fn require_daemon_commit(
         "branch_name": branch_name,
     });
 
-    let resp = client
-        .post(format!(
-            "{}/v1/graph/commit",
-            daemon_url.trim_end_matches('/')
-        ))
-        .json(&payload)
-        .send()
-        .await?;
+    let resp = with_daemon_auth(client.post(format!(
+        "{}/v1/graph/commit",
+        daemon_url.trim_end_matches('/')
+    )))
+    .json(&payload)
+    .send()
+    .await?;
 
     if !resp.status().is_success() {
         let status = resp.status();
@@ -423,14 +432,13 @@ pub async fn require_daemon_graph_mutations(
     let client = reqwest::Client::builder()
         .timeout(Duration::from_secs(10))
         .build()?;
-    let resp = client
-        .post(format!(
-            "{}/v1/graph/mutations",
-            daemon_url.trim_end_matches('/')
-        ))
-        .json(&batch)
-        .send()
-        .await?;
+    let resp = with_daemon_auth(client.post(format!(
+        "{}/v1/graph/mutations",
+        daemon_url.trim_end_matches('/')
+    )))
+    .json(&batch)
+    .send()
+    .await?;
     if !resp.status().is_success() {
         let status = resp.status();
         let body = resp.text().await.unwrap_or_default();
@@ -463,18 +471,17 @@ pub async fn get_spine_impact(
         .timeout(Duration::from_secs(10))
         .build()?;
 
-    let resp = client
-        .get(format!(
-            "{}/v1/spine/impact",
-            daemon_url.trim_end_matches('/')
-        ))
-        .query(&[
-            ("repo", repo_id),
-            ("entity", &entity_id.to_string()),
-            ("depth", &depth.to_string()),
-        ])
-        .send()
-        .await;
+    let resp = with_daemon_auth(client.get(format!(
+        "{}/v1/spine/impact",
+        daemon_url.trim_end_matches('/')
+    )))
+    .query(&[
+        ("repo", repo_id),
+        ("entity", &entity_id.to_string()),
+        ("depth", &depth.to_string()),
+    ])
+    .send()
+    .await;
     let status = resp.as_ref().ok().map(|r| r.status().as_u16());
 
     match classify_spine_probe(true, status) {
@@ -510,14 +517,13 @@ pub async fn get_spine_xref(
         .timeout(Duration::from_secs(10))
         .build()?;
 
-    let resp = client
-        .get(format!(
-            "{}/v1/spine/xref",
-            daemon_url.trim_end_matches('/')
-        ))
-        .query(&[("repo", repo_id), ("entity", &entity_id.to_string())])
-        .send()
-        .await;
+    let resp = with_daemon_auth(client.get(format!(
+        "{}/v1/spine/xref",
+        daemon_url.trim_end_matches('/')
+    )))
+    .query(&[("repo", repo_id), ("entity", &entity_id.to_string())])
+    .send()
+    .await;
     let status = resp.as_ref().ok().map(|r| r.status().as_u16());
 
     match classify_spine_probe(true, status) {

--- a/crates/kin-cli/src/commands/commit.rs
+++ b/crates/kin-cli/src/commands/commit.rs
@@ -622,14 +622,16 @@ async fn try_daemon_command_commit(
         "dry_run": false,
     });
 
-    let resp = client
+    let mut request = client
         .post(format!(
             "{}/v1/commands/commit",
             daemon_url.trim_end_matches('/')
         ))
-        .json(&payload)
-        .send()
-        .await?;
+        .json(&payload);
+    if let Some(token) = crate::daemon_client::resolve_daemon_auth_token() {
+        request = request.bearer_auth(token);
+    }
+    let resp = request.send().await?;
 
     if !resp.status().is_success() {
         let status = resp.status();

--- a/crates/kin-cli/src/commands/reconcile.rs
+++ b/crates/kin-cli/src/commands/reconcile.rs
@@ -77,7 +77,8 @@ pub async fn reconcile_session_dir(
         let daemon_url = crate::daemon_client::resolve_daemon_url(layout)
             .await?
             .ok_or_else(|| anyhow::anyhow!("Kin daemon is required for reconcile"))?;
-        let client = crate::daemon_client::DaemonClient::from_base_url(daemon_url)?;
+        let client =
+            crate::daemon_client::DaemonClient::from_base_url_for_layout(daemon_url, layout)?;
         client
             .reconcile(&ReconcileRequest {
                 session_dir: session_dir.to_path_buf(),

--- a/crates/kin-cli/src/commands/ref_lookup.rs
+++ b/crates/kin-cli/src/commands/ref_lookup.rs
@@ -57,7 +57,15 @@ pub(crate) fn parse_change_id(input: &str) -> Result<SemanticChangeId> {
 #[derive(Debug, Clone, Copy)]
 pub struct ResolvedRef {
     pub head: SemanticChangeId,
+    /// Whether resolving this ref lazily imported Git ancestry into the graph.
+    /// Derived from `hydrated_changes > 0`; kept for callers that only need
+    /// the yes/no signal.
     pub hydrated_git_history: bool,
+    /// Count of historical changes hydration actually inserted into the
+    /// graph (0 when the ref was already present and no import ran). Distinct
+    /// from `hydrated_git_history`: a caller reporting on hydration should
+    /// show this count rather than collapse it to a boolean.
+    pub hydrated_changes: usize,
 }
 
 pub fn resolve_ref<G>(
@@ -124,6 +132,7 @@ fn resolve_ref_importing_git_if_needed_with_mode(
         Ok(head) => Ok(ResolvedRef {
             head,
             hydrated_git_history: false,
+            hydrated_changes: 0,
         }),
         Err(original_err) => {
             let Some(reference) = reference else {
@@ -132,12 +141,13 @@ fn resolve_ref_importing_git_if_needed_with_mode(
             let Some(git_oid) = extract_git_ref(reference) else {
                 return Err(original_err);
             };
-            let hydrated_git_history =
+            let hydrated_changes =
                 hydrate_imported_git_ref(graph, layout, git_oid, enrich_semantics)?;
             let head = resolve_ref(graph, layout, Some(reference))?;
             Ok(ResolvedRef {
                 head,
-                hydrated_git_history,
+                hydrated_git_history: hydrated_changes > 0,
+                hydrated_changes,
             })
         }
     }
@@ -461,15 +471,20 @@ pub fn git_ref_requires_hydration(graph: &kin_db::InMemoryGraph, reference: &str
     !matches!(graph.get_change(&imported_change_id), Ok(Some(_)))
 }
 
+/// Lazily import the Git ancestry of `git_oid` into `graph`, returning the
+/// count of changes actually inserted (0 when the ref was already present and
+/// no import ran). Callers report this count directly rather than collapsing
+/// it to a boolean, so a cold multi-thousand-change import is never described
+/// the same way as a no-op.
 fn hydrate_imported_git_ref(
     graph: &kin_db::InMemoryGraph,
     layout: &kin_core::KinLayout,
     git_oid: &str,
     enrich_semantics: bool,
-) -> Result<bool> {
+) -> Result<usize> {
     let imported_change_id = kin_git::semantic_change_id_from_git_oid_hex(git_oid)?;
     if graph.get_change(&imported_change_id)?.is_some() {
-        return Ok(false);
+        return Ok(0);
     }
 
     let blob_store = kin_blobs::BlobStore::new(layout.objects_dir())
@@ -511,7 +526,7 @@ fn hydrate_imported_git_ref(
         ));
     }
 
-    Ok(inserted > 0)
+    Ok(inserted)
 }
 
 fn resolve_semantic_change<G>(

--- a/crates/kin-cli/src/commands/review.rs
+++ b/crates/kin-cli/src/commands/review.rs
@@ -78,11 +78,17 @@ pub struct ReviewResponse {
 #[derive(Debug, Clone)]
 pub struct ReviewExecution {
     pub response: ReviewResponse,
+    /// Whether this review op itself mutated review/graph state (a decision,
+    /// note, discussion, etc.). Always `false` for `Run` and `Shadow`, which
+    /// are read-only evaluations.
     pub mutated: bool,
-    /// A shadow evaluation lazily imported Git ancestry into the graph;
-    /// daemon owners should persist the hydrated state so the import happens
-    /// once per repo instead of once per process.
-    pub hydrated_git_history: bool,
+    /// Count of historical changes a shadow evaluation lazily hydrated into
+    /// the graph (0 for every op other than `Shadow`, and 0 for a `Shadow`
+    /// whose base/head were already imported). Reported distinctly from
+    /// `mutated` so a cold import that persists thousands of changes is never
+    /// described the same way as a no-op: daemon owners persist the hydrated
+    /// state so the import happens once per repo instead of once per process.
+    pub hydrated_changes: usize,
 }
 
 #[derive(Serialize)]
@@ -180,7 +186,7 @@ pub async fn execute_review_request(
                 layout, graph, change, entities, files, changes, json,
             )?,
             mutated: false,
-            hydrated_git_history: false,
+            hydrated_changes: 0,
         }),
         ReviewRequest::Shadow {
             base,
@@ -190,13 +196,13 @@ pub async fn execute_review_request(
             author,
             json,
         } => {
-            let (response, hydrated_git_history) = build_shadow_run_response(
+            let (response, hydrated_changes) = build_shadow_run_response(
                 layout, graph, base, head, title, source_url, author, json,
             )?;
             Ok(ReviewExecution {
                 response,
                 mutated: false,
-                hydrated_git_history,
+                hydrated_changes,
             })
         }
         ReviewRequest::Create {
@@ -287,6 +293,26 @@ fn build_review_run_response(
     Ok(ReviewResponse { text, json: None })
 }
 
+/// Shadow review JSON payload: the gate report plus the two distinct
+/// bookkeeping signals a shadow evaluation can produce. Flattened alongside
+/// `report`'s own fields so existing consumers keep reading the report shape
+/// unchanged and additionally see these two counts.
+#[derive(Serialize)]
+struct ShadowReviewResponseJson<'a> {
+    #[serde(flatten)]
+    report: &'a kin_review::ShadowGateReport,
+    /// Historical changes lazily imported into the graph while resolving the
+    /// base/head refs (0 when both were already present). Reported as a real
+    /// count, never collapsed to a boolean, so a cold multi-thousand-change
+    /// import is never described the same way as a no-op.
+    hydrated_changes: usize,
+    /// Mutations the review operation itself made to review/graph state.
+    /// Always 0: a shadow evaluation is read-only by construction. Reported
+    /// explicitly, distinct from `hydrated_changes`, so the two never blur
+    /// into a single collapsed signal.
+    review_mutations: usize,
+}
+
 #[allow(clippy::too_many_arguments)]
 fn build_shadow_run_response(
     layout: &kin_core::KinLayout,
@@ -297,7 +323,7 @@ fn build_shadow_run_response(
     source_url: Option<String>,
     author: Option<String>,
     json: bool,
-) -> Result<(ReviewResponse, bool)> {
+) -> Result<(ReviewResponse, usize)> {
     // The everyday "your branch is behind main" case: base is not on head's
     // ancestry. That gap is provable from the Git commit-parent DAG alone —
     // no semantic hydration needed — so it is checked before either ref pays
@@ -307,7 +333,9 @@ fn build_shadow_run_response(
     if let Some(report) =
         shadow_ancestry_fast_path_gap(graph, layout, &base, &head, &title, &source_url, &author)?
     {
-        return Ok((shadow_response_from_report(&report, json)?, false));
+        // The fast path never hydrates anything, so this is always a true
+        // zero, not a placeholder.
+        return Ok((shadow_response_from_report(&report, json, 0)?, 0));
     }
 
     // Resolve the head ref before the base ref. A review pair is almost always
@@ -328,8 +356,7 @@ fn build_shadow_run_response(
             Some(base.as_str()),
         )
         .with_context(|| format!("resolve shadow base ref '{}'", base))?;
-    let hydrated_git_history =
-        resolved_base.hydrated_git_history || resolved_head.hydrated_git_history;
+    let hydrated_changes = resolved_base.hydrated_changes + resolved_head.hydrated_changes;
 
     let request = kin_review::ShadowRequest {
         base_ref: base,
@@ -344,8 +371,8 @@ fn build_shadow_run_response(
 
     let report = kin_review::build_shadow_report(graph, &request)?;
     Ok((
-        shadow_response_from_report(&report, json)?,
-        hydrated_git_history,
+        shadow_response_from_report(&report, json, hydrated_changes)?,
+        hydrated_changes,
     ))
 }
 
@@ -407,18 +434,27 @@ fn shadow_ancestry_fast_path_gap(
 fn shadow_response_from_report(
     report: &kin_review::ShadowGateReport,
     json: bool,
+    hydrated_changes: usize,
 ) -> Result<ReviewResponse> {
     if json {
         return Ok(ReviewResponse {
             text: String::new(),
-            json: Some(serde_json::to_string_pretty(report)?),
+            json: Some(serde_json::to_string_pretty(&ShadowReviewResponseJson {
+                report,
+                hydrated_changes,
+                review_mutations: 0,
+            })?),
         });
     }
 
-    Ok(ReviewResponse {
-        text: kin_review::format_shadow_report(report),
-        json: None,
-    })
+    let mut text = kin_review::format_shadow_report(report);
+    if hydrated_changes > 0 {
+        writeln!(
+            text,
+            "\n(hydrated {hydrated_changes} historical change(s) into the graph; 0 review mutations)"
+        )?;
+    }
+    Ok(ReviewResponse { text, json: None })
 }
 
 fn compute_review(
@@ -752,7 +788,7 @@ fn create_review_with_graph(
             json: None,
         },
         mutated: true,
-        hydrated_git_history: false,
+        hydrated_changes: 0,
     })
 }
 
@@ -812,7 +848,7 @@ fn decide_review_with_graph(
             json: None,
         },
         mutated: true,
-        hydrated_git_history: false,
+        hydrated_changes: 0,
     })
 }
 
@@ -859,7 +895,7 @@ fn add_note_with_graph(
     Ok(ReviewExecution {
         response: ReviewResponse { text, json: None },
         mutated: true,
-        hydrated_git_history: false,
+        hydrated_changes: 0,
     })
 }
 
@@ -920,7 +956,7 @@ fn start_discussion_with_graph(
     Ok(ReviewExecution {
         response: ReviewResponse { text, json: None },
         mutated: true,
-        hydrated_git_history: false,
+        hydrated_changes: 0,
     })
 }
 
@@ -957,7 +993,7 @@ fn reply_discussion_with_graph(
             json: None,
         },
         mutated: true,
-        hydrated_git_history: false,
+        hydrated_changes: 0,
     })
 }
 
@@ -980,7 +1016,7 @@ fn resolve_discussion_with_graph(
             json: None,
         },
         mutated: true,
-        hydrated_git_history: false,
+        hydrated_changes: 0,
     })
 }
 
@@ -1018,7 +1054,7 @@ fn assign_reviewer_with_graph(
             json: None,
         },
         mutated: true,
-        hydrated_git_history: false,
+        hydrated_changes: 0,
     })
 }
 
@@ -1061,7 +1097,7 @@ fn list_reviews_with_graph(
                 json: None,
             },
             mutated: false,
-            hydrated_git_history: false,
+            hydrated_changes: 0,
         });
     }
 
@@ -1081,7 +1117,7 @@ fn list_reviews_with_graph(
     Ok(ReviewExecution {
         response: ReviewResponse { text, json: None },
         mutated: false,
-        hydrated_git_history: false,
+        hydrated_changes: 0,
     })
 }
 
@@ -1174,7 +1210,7 @@ fn show_review_with_graph(
     Ok(ReviewExecution {
         response: ReviewResponse { text, json: None },
         mutated: false,
-        hydrated_git_history: false,
+        hydrated_changes: 0,
     })
 }
 
@@ -1345,7 +1381,7 @@ mod tests {
             "branch b must not be imported before the call"
         );
 
-        let (response, hydrated) = build_shadow_run_response(
+        let (response, hydrated_changes) = build_shadow_run_response(
             &layout,
             &graph,
             branch_a.clone(),
@@ -1357,13 +1393,15 @@ mod tests {
         )
         .expect("a stale base must produce a gap report, not an error");
 
-        assert!(
-            !hydrated,
+        assert_eq!(
+            hydrated_changes, 0,
             "the fast path must report no hydration was performed"
         );
 
         let json: serde_json::Value =
             serde_json::from_str(response.json.as_deref().expect("json response")).unwrap();
+        assert_eq!(json["hydrated_changes"], 0);
+        assert_eq!(json["review_mutations"], 0);
         let gaps = json["evidence_gaps"].as_array().unwrap();
         assert!(
             gaps.iter()
@@ -1381,5 +1419,76 @@ mod tests {
             crate::commands::ref_lookup::git_ref_requires_hydration(&graph, &branch_b),
             "branch b must remain un-imported: the fast path must not hydrate it"
         );
+    }
+
+    /// Warm case: both `kin:` refs already resolve directly, so no Git
+    /// hydration ever runs. The response must report `hydrated_changes: 0`
+    /// distinctly from `review_mutations: 0` — two truthful zeros, not a
+    /// single collapsed flag — both in the returned count and in the actual
+    /// JSON payload a client parses.
+    #[test]
+    fn shadow_reports_zero_hydrated_changes_when_refs_need_no_import() {
+        let graph = kin_db::InMemoryGraph::new();
+        let layout = kin_core::KinLayout::new(std::path::PathBuf::from("/nonexistent/.kin"));
+
+        let base_id =
+            kin_model::SemanticChangeId::from_hash(kin_model::Hash256::from_bytes([0x10; 32]));
+        let head_id =
+            kin_model::SemanticChangeId::from_hash(kin_model::Hash256::from_bytes([0x20; 32]));
+        graph
+            .create_change(&kin_model::SemanticChange {
+                id: base_id,
+                parents: vec![],
+                timestamp: kin_model::Timestamp::now(),
+                author: kin_model::AuthorId::new("test"),
+                message: "base".into(),
+                entity_deltas: vec![],
+                relation_deltas: vec![],
+                artifact_deltas: vec![],
+                projected_files: vec![],
+                spec_link: None,
+                evidence: vec![],
+                risk_summary: None,
+                authored_on: None,
+            })
+            .unwrap();
+        graph
+            .create_change(&kin_model::SemanticChange {
+                id: head_id,
+                parents: vec![base_id],
+                timestamp: kin_model::Timestamp::now(),
+                author: kin_model::AuthorId::new("test"),
+                message: "head".into(),
+                entity_deltas: vec![],
+                relation_deltas: vec![],
+                artifact_deltas: vec![],
+                projected_files: vec![],
+                spec_link: None,
+                evidence: vec![],
+                risk_summary: None,
+                authored_on: None,
+            })
+            .unwrap();
+
+        let (response, hydrated_changes) = build_shadow_run_response(
+            &layout,
+            &graph,
+            format!("kin:{base_id}"),
+            format!("kin:{head_id}"),
+            None,
+            None,
+            None,
+            true,
+        )
+        .unwrap();
+
+        assert_eq!(
+            hydrated_changes, 0,
+            "already-resolved refs must report zero hydrated changes"
+        );
+        let json: serde_json::Value =
+            serde_json::from_str(response.json.as_deref().expect("json response")).unwrap();
+        assert_eq!(json["hydrated_changes"], 0);
+        assert_eq!(json["review_mutations"], 0);
     }
 }

--- a/crates/kin-cli/src/commands/status.rs
+++ b/crates/kin-cli/src/commands/status.rs
@@ -360,9 +360,21 @@ fn build_id(sha: &str, dirty: bool) -> String {
     }
 }
 
+/// Test-only: open the local snapshot directly, bypassing the daemon, for
+/// exercising [`build_status_summary`] against a real repo fixture.
+///
+/// Deliberately calls `discover_with_daemon_url(cwd, None)` rather than
+/// `KinLayout::discover(cwd)`: this helper's whole point is local-only
+/// discovery, so it must never pick up whatever `KIN_DAEMON_URL` happens to
+/// be set in the process at the moment it runs. `cargo test` runs unit tests
+/// from many modules concurrently in one process and process env is global,
+/// so reading the ambient var here would make this function's result depend
+/// on which *other*, unrelated test happens to be mid-flight — parameterizing
+/// it out entirely removes that hazard rather than papering over it with
+/// serialization.
 #[cfg(test)]
 async fn load_status(cwd: &Path) -> Result<StatusSummary> {
-    let layout = kin_core::KinLayout::discover(cwd).ok_or_else(|| {
+    let layout = kin_core::KinLayout::discover_with_daemon_url(cwd, None).ok_or_else(|| {
         anyhow::anyhow!(
             "not a Kin repository (no .kin/ found)\nhint: run `kin init .` to initialize a Kin repository here"
         )

--- a/crates/kin-cli/src/daemon_client.rs
+++ b/crates/kin-cli/src/daemon_client.rs
@@ -195,10 +195,11 @@ pub struct LocateRequest {
 ///
 /// Matches the daemon's own `resolve_serve_auth_token` order:
 /// `KIN_DAEMON_AUTH_TOKEN` env if set, else the auto-provisioned per-install
-/// `.kin/daemon.token` file, else none. When the daemon is not enforcing a
-/// token (the default), an absent value just means no header is sent and the
-/// request is still accepted.
-fn resolve_daemon_auth_token() -> Option<String> {
+/// `.kin/daemon.token` file, else none. `pub(crate)` so any other in-crate
+/// caller that builds its own client for a direct daemon request (rather
+/// than going through `DaemonClient`, which attaches this automatically)
+/// can still authenticate correctly.
+pub(crate) fn resolve_daemon_auth_token() -> Option<String> {
     if let Ok(token) = std::env::var("KIN_DAEMON_AUTH_TOKEN") {
         let token = token.trim().to_string();
         if !token.is_empty() {

--- a/crates/kin-cli/src/daemon_client.rs
+++ b/crates/kin-cli/src/daemon_client.rs
@@ -200,15 +200,32 @@ pub struct LocateRequest {
 /// than going through `DaemonClient`, which attaches this automatically)
 /// can still authenticate correctly.
 pub(crate) fn resolve_daemon_auth_token() -> Option<String> {
-    if let Ok(token) = std::env::var("KIN_DAEMON_AUTH_TOKEN") {
-        let token = token.trim().to_string();
-        if !token.is_empty() {
-            return Some(token);
-        }
+    if let Some(token) = daemon_auth_token_from_env() {
+        return Some(token);
     }
     let layout = std::env::current_dir()
         .ok()
         .and_then(|cwd| KinLayout::discover(&cwd))?;
+    daemon_auth_token_from_layout(&layout)
+}
+
+/// Layout-explicit variant for callers that already hold the repo's layout —
+/// the process working directory says nothing about which repo's daemon is
+/// being addressed (in-process library callers and tests run from arbitrary
+/// working directories).
+pub(crate) fn resolve_daemon_auth_token_for_layout(layout: &KinLayout) -> Option<String> {
+    daemon_auth_token_from_env().or_else(|| daemon_auth_token_from_layout(layout))
+}
+
+fn daemon_auth_token_from_env() -> Option<String> {
+    let token = std::env::var("KIN_DAEMON_AUTH_TOKEN")
+        .ok()?
+        .trim()
+        .to_string();
+    (!token.is_empty()).then_some(token)
+}
+
+fn daemon_auth_token_from_layout(layout: &KinLayout) -> Option<String> {
     let token = std::fs::read_to_string(layout.root().join("daemon.token"))
         .ok()?
         .trim()
@@ -218,6 +235,22 @@ pub(crate) fn resolve_daemon_auth_token() -> Option<String> {
 
 impl DaemonClient {
     pub fn from_base_url(base_url: impl Into<String>) -> Result<Self> {
+        Self::from_base_url_with_token(base_url, resolve_daemon_auth_token())
+    }
+
+    /// Build a client for `layout`'s daemon, resolving the bearer token from
+    /// that layout rather than from the process working directory.
+    pub fn from_base_url_for_layout(
+        base_url: impl Into<String>,
+        layout: &KinLayout,
+    ) -> Result<Self> {
+        Self::from_base_url_with_token(base_url, resolve_daemon_auth_token_for_layout(layout))
+    }
+
+    fn from_base_url_with_token(
+        base_url: impl Into<String>,
+        auth_token: Option<String>,
+    ) -> Result<Self> {
         let base_url = base_url.into();
         let mut headers = reqwest::header::HeaderMap::new();
         if let Ok(session_id) = std::env::var("KIN_SESSION_ID") {
@@ -235,7 +268,7 @@ impl DaemonClient {
             "X-Kin-CLI-Dirty",
             reqwest::header::HeaderValue::from_static(if build.dirty { "true" } else { "false" }),
         );
-        if let Some(token) = resolve_daemon_auth_token() {
+        if let Some(token) = auth_token {
             if let Ok(mut value) =
                 reqwest::header::HeaderValue::from_str(&format!("Bearer {token}"))
             {

--- a/crates/kin-cli/tests/review_shadow_json.rs
+++ b/crates/kin-cli/tests/review_shadow_json.rs
@@ -446,6 +446,14 @@ fn shadow_head_import_hydrates_ancestor_base_in_single_pass() {
         resolved_head.hydrated_git_history,
         "resolving the head on a fresh graph must hydrate git history"
     );
+    // Cold-import case: hydration reports a real count, never a collapsed
+    // boolean — the ancestry it just walked (genesis..head) inserted at least
+    // one change, so this must be a truthful non-zero number, not just true.
+    assert!(
+        resolved_head.hydrated_changes > 0,
+        "cold import must report a nonzero hydrated_changes count, got {}",
+        resolved_head.hydrated_changes
+    );
 
     // Single-pass invariant: base is now already present, so it needs no further
     // hydration — the head's import subsumed the ancestor.
@@ -462,6 +470,12 @@ fn shadow_head_import_hydrates_ancestor_base_in_single_pass() {
     assert!(
         !resolved_base.hydrated_git_history,
         "base must resolve without a second hydration pass"
+    );
+    // Warm case: already-imported (via the head's ancestry walk) resolves with
+    // an exact zero count, not just a falsy flag.
+    assert_eq!(
+        resolved_base.hydrated_changes, 0,
+        "warm resolve (already imported) must report exactly zero hydrated changes"
     );
     assert_ne!(
         resolved_base.head, resolved_head.head,

--- a/crates/kin-core/src/env_registry.rs
+++ b/crates/kin-core/src/env_registry.rs
@@ -189,7 +189,7 @@ pub const OPERATIONAL: &[EnvVarSpec] = &[
     EnvVarSpec { name: "KIN_DAEMON_BIN", kind: Kind::Path, default: "", sensitivity: Sensitivity::Operational, summary: "override path to the kin-daemon binary" },
     EnvVarSpec { name: "KIN_DAEMON_BIND_HOST", kind: Kind::Str, default: "", sensitivity: Sensitivity::Operational, summary: "host/interface the daemon binds its HTTP endpoint to" },
     EnvVarSpec { name: "KIN_DAEMON_STOP_TIMEOUT_SECS", kind: Kind::Secs, default: "30", sensitivity: Sensitivity::Operational, summary: "ceiling in seconds kin daemon stop waits for a signaled daemon to exit" },
-    EnvVarSpec { name: "KIN_DAEMON_REQUIRE_TOKEN", kind: Kind::Bool, default: "false", sensitivity: Sensitivity::Operational, summary: "require a bearer token for all daemon requests" },
+    EnvVarSpec { name: "KIN_DAEMON_REQUIRE_TOKEN", kind: Kind::Bool, default: "true", sensitivity: Sensitivity::Operational, summary: "require a bearer token for all daemon requests; set falsy to opt out" },
     EnvVarSpec { name: "KIN_DAEMON_ALLOW_EXEC", kind: Kind::Bool, default: "false", sensitivity: Sensitivity::Operational, summary: "permit the daemon to run exec commands" },
     EnvVarSpec { name: "KIN_DAEMON_WATCH_PID", kind: Kind::Usize, default: "", sensitivity: Sensitivity::Operational, summary: "pid the daemon watches; it exits when that process dies" },
     EnvVarSpec { name: "KIN_DAEMON_EMBED_BATCH_SIZE", kind: Kind::Usize, default: "", sensitivity: Sensitivity::Operational, summary: "embedding batch size for daemon-side embed passes" },

--- a/crates/kin-core/src/layout.rs
+++ b/crates/kin-core/src/layout.rs
@@ -39,8 +39,24 @@ impl KinLayout {
     /// reported as having no store rather than silently sharing the parent's
     /// graph (the failure mode behind the parent-store poisoning incident). Set
     /// `KIN_ALLOW_PARENT_STORE=1` to opt back into binding the parent store.
+    ///
+    /// Reads `KIN_DAEMON_URL` once from the process environment and delegates
+    /// to [`Self::discover_with_daemon_url`]; call that directly to make the
+    /// daemon-URL input an explicit parameter instead of an ambient process
+    /// read (e.g. so a test is immune to a concurrent, unrelated test
+    /// mutating the same process-global env var).
     pub fn discover(start: &Path) -> Option<Self> {
-        if std::env::var("KIN_DAEMON_URL").is_ok() {
+        Self::discover_with_daemon_url(start, std::env::var("KIN_DAEMON_URL").ok().as_deref())
+    }
+
+    /// Same contract as [`Self::discover`], but with the daemon-URL input
+    /// taken as an explicit parameter rather than read from the process
+    /// environment. `daemon_url` mirrors what an already-resolved
+    /// `KIN_DAEMON_URL` would be: `Some(_)` (any value, content unused) skips
+    /// straight to `<start>/.kin` exactly as the env-sensing path does;
+    /// `None` runs the normal upward walk.
+    pub fn discover_with_daemon_url(start: &Path, daemon_url: Option<&str>) -> Option<Self> {
+        if daemon_url.is_some() {
             return Some(Self::new(start.join(".kin")));
         }
         let mut current = start.to_path_buf();
@@ -394,6 +410,33 @@ mod tests {
     fn discover_returns_none_when_missing() {
         let dir = tempfile::tempdir().unwrap();
         assert!(KinLayout::discover(dir.path()).is_none());
+    }
+
+    #[test]
+    fn discover_with_daemon_url_short_circuits_on_any_value() {
+        // A `Some(_)` daemon-URL input skips the walk and the missing-.kin/
+        // check entirely, exactly like the env-sensing `discover` does when
+        // `KIN_DAEMON_URL` is set to anything — content is never inspected.
+        let dir = tempfile::tempdir().unwrap();
+        let found = KinLayout::discover_with_daemon_url(dir.path(), Some("http://127.0.0.1:1"))
+            .expect("Some(_) daemon_url must short-circuit even with no .kin/ present");
+        assert_eq!(found.root(), dir.path().join(".kin"));
+    }
+
+    #[test]
+    fn discover_with_daemon_url_none_runs_the_normal_walk() {
+        // `None` must behave identically to the env-sensing `discover` with
+        // KIN_DAEMON_URL unset: no .kin/ anywhere up the tree resolves to
+        // `None`, not a fabricated layout — the explicit-parameter path and
+        // the ambient-env path must never diverge in behavior, only in how
+        // the daemon-URL input is supplied.
+        let dir = tempfile::tempdir().unwrap();
+        assert!(KinLayout::discover_with_daemon_url(dir.path(), None).is_none());
+
+        let kin_dir = dir.path().join(".kin");
+        std::fs::create_dir(&kin_dir).unwrap();
+        let found = KinLayout::discover_with_daemon_url(dir.path(), None).unwrap();
+        assert_eq!(found.root(), kin_dir);
     }
 
     #[test]

--- a/crates/kin-daemon/src/api.rs
+++ b/crates/kin-daemon/src/api.rs
@@ -3411,10 +3411,24 @@ async fn review(
                     internal_error(err)
                 }
             })?;
-    if execution.hydrated_git_history {
+    if execution.hydrated_changes > 0 {
+        tracing::info!(
+            hydrated_changes = execution.hydrated_changes,
+            review_mutations = 0u64,
+            "shadow review hydrated historical changes into the graph"
+        );
         state.bump_version();
         state.save_snapshot().map_err(internal_error)?;
         state.mark_clean();
+        // A live SSE subscriber (e.g. the VFS daemon) should hear about this
+        // graph growth exactly like any other root change, not just the
+        // `mutated` case below — otherwise a hydration-only shadow review is
+        // invisible to anything watching /events in real time, even though
+        // it just persisted a potentially large import.
+        state.emit_event(DaemonEvent::GraphRootChanged {
+            old_root_hash: None,
+            new_root_hash: "review-hydration".to_string(),
+        });
     }
     if execution.mutated {
         state.bump_version();

--- a/crates/kin-daemon/src/api.rs
+++ b/crates/kin-daemon/src/api.rs
@@ -7579,29 +7579,33 @@ fn ensure_loopback_token(layout: &kin_core::KinLayout) -> std::io::Result<String
 
 /// Whether the daemon should ENFORCE the per-install loopback token.
 ///
-/// Enforcement is opt-in (`KIN_DAEMON_REQUIRE_TOKEN`) because turning it on by
-/// default would `401` every local client that does not yet send the token —
-/// the CLI (`daemon_client.rs`) and any un-updated path. The file is still
-/// auto-provisioned so clients can adopt it; once CLI + MCP delegate both read
-/// it, flip this flag to require it. The primary DNS-rebinding defense
-/// (`validate_host_and_origin`) is always active regardless of this flag.
+/// Enforcement is default-on: the CLI (`daemon_client.rs`'s
+/// `resolve_daemon_auth_token`) and the MCP delegate
+/// (`daemon_delegate.rs`'s `daemon_auth_token`) both auto-read
+/// `.kin/daemon.token` and send it as a bearer token, so a fresh install
+/// authenticates out of the box with no operator setup. `KIN_DAEMON_REQUIRE_TOKEN`
+/// is the documented escape hatch: set it to a falsy value (`0`/`false`/`no`/
+/// `off`) to run without bearer auth for a local client that cannot yet send
+/// the header. The primary DNS-rebinding defense (`validate_host_and_origin`)
+/// is always active regardless of this flag.
 fn loopback_token_enforced() -> bool {
     std::env::var("KIN_DAEMON_REQUIRE_TOKEN")
         .map(|value| {
-            matches!(
+            !matches!(
                 value.trim().to_ascii_lowercase().as_str(),
-                "1" | "true" | "yes" | "on"
+                "0" | "false" | "no" | "off"
             )
         })
-        .unwrap_or(false)
+        .unwrap_or(true)
 }
 
 /// Resolve the auth token the serving daemon enforces: an explicit
 /// `KIN_DAEMON_AUTH_TOKEN` override always wins. Otherwise the per-install
 /// loopback token is auto-provisioned under `.kin/` (so local clients can adopt
-/// it) but only returned for enforcement when `KIN_DAEMON_REQUIRE_TOKEN`
-/// is set. If provisioning fails the daemon still starts (loopback Host/Origin
-/// validation remains active) but logs a warning.
+/// it) and returned for enforcement unless `KIN_DAEMON_REQUIRE_TOKEN` is set to
+/// a falsy value (the opt-out escape hatch). If provisioning fails the daemon
+/// still starts (loopback Host/Origin validation remains active) but logs a
+/// warning.
 fn resolve_serve_auth_token(layout: &kin_core::KinLayout) -> Option<String> {
     if let Some(env_token) = auth_token_from_env() {
         return Some(env_token);
@@ -11916,28 +11920,103 @@ mod tests {
         std::fs::create_dir_all(dir.join(".kin")).unwrap();
         let layout = kin_core::KinLayout::new(dir.join(".kin"));
 
-        // Default: enforcement is OFF, so no token is enforced — this is what
-        // keeps existing unauthenticated local clients (CLI, integration tests,
-        // env-only MCP delegate) working. The file is still provisioned so they
-        // can adopt it ahead of a future enforcement flip.
-        assert!(resolve_serve_auth_token(&layout).is_none());
+        // Default (no env configured at all): enforcement is ON, so a fresh
+        // install requires the auto-provisioned token out of the box.
+        let provisioned_default = resolve_serve_auth_token(&layout)
+            .expect("fresh install must enforce the auto-provisioned token by default");
         let provisioned = std::fs::read_to_string(loopback_token_path(&layout)).unwrap();
         assert!(!provisioned.trim().is_empty());
+        assert_eq!(provisioned_default, provisioned.trim());
 
-        // Opt-in: enforcement returns the provisioned loopback token.
+        // Escape hatch: an explicit falsy value opts back out of enforcement —
+        // for a local client that cannot yet send the header — while the file
+        // stays provisioned.
+        std::env::set_var("KIN_DAEMON_REQUIRE_TOKEN", "0");
+        assert!(resolve_serve_auth_token(&layout).is_none());
+        std::env::set_var("KIN_DAEMON_REQUIRE_TOKEN", "false");
+        assert!(resolve_serve_auth_token(&layout).is_none());
+
+        // Explicit truthy values are equivalent to the default.
         std::env::set_var("KIN_DAEMON_REQUIRE_TOKEN", "1");
         assert_eq!(
             resolve_serve_auth_token(&layout).as_deref(),
             Some(provisioned.trim())
         );
+        std::env::remove_var("KIN_DAEMON_REQUIRE_TOKEN");
 
-        // An explicit KIN_DAEMON_AUTH_TOKEN override always wins over the gate.
+        // An explicit KIN_DAEMON_AUTH_TOKEN override always wins over the gate,
+        // even while the gate is opted out.
+        std::env::set_var("KIN_DAEMON_REQUIRE_TOKEN", "0");
         std::env::set_var("KIN_DAEMON_AUTH_TOKEN", "explicit-override");
         assert_eq!(
             resolve_serve_auth_token(&layout).as_deref(),
             Some("explicit-override")
         );
 
+        std::env::remove_var("KIN_DAEMON_AUTH_TOKEN");
+        std::env::remove_var("KIN_DAEMON_REQUIRE_TOKEN");
+    }
+
+    /// Round-trip proof of the default-on posture through the real production
+    /// entry point (`serve_bound_with_shutdown`, what `kin-daemon` itself
+    /// calls) rather than the test-only `router_with_auth` helper: with no
+    /// `KIN_DAEMON_REQUIRE_TOKEN`/`KIN_DAEMON_AUTH_TOKEN` configured, a fresh
+    /// install (a) provisions its own token, (b) rejects a request carrying no
+    /// token, (c) rejects a request carrying the wrong token, and (d) accepts
+    /// the request that presents the provisioned token.
+    #[tokio::test]
+    async fn daemon_enforces_loopback_token_by_default_end_to_end() {
+        let _env = env_test_lock();
+        std::env::remove_var("KIN_DAEMON_AUTH_TOKEN");
+        std::env::remove_var("KIN_DAEMON_REQUIRE_TOKEN");
+
+        let state = test_state();
+        // Pre-provision deterministically so this test does not race the
+        // server task's own first-call provisioning; `ensure_loopback_token`
+        // is idempotent, so whichever side calls it first, both observe the
+        // same persisted value.
+        let token = ensure_loopback_token(&state.layout).unwrap();
+
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let addr = listener.local_addr().unwrap();
+        let (_shutdown_tx, shutdown_rx) = tokio::sync::watch::channel(false);
+        let server = tokio::spawn(serve_bound_with_shutdown(state, listener, shutdown_rx));
+        let base = format!("http://{addr}");
+
+        let http = reqwest::Client::new();
+
+        let no_token = http.get(format!("{base}/status")).send().await.unwrap();
+        assert_eq!(
+            no_token.status(),
+            StatusCode::UNAUTHORIZED,
+            "a fresh install must reject an unauthenticated request by default"
+        );
+
+        let wrong_token = http
+            .get(format!("{base}/status"))
+            .header("authorization", "Bearer not-the-real-token")
+            .send()
+            .await
+            .unwrap();
+        assert_eq!(
+            wrong_token.status(),
+            StatusCode::UNAUTHORIZED,
+            "an incorrect bearer token must be rejected, not just a missing one"
+        );
+
+        let accepted = http
+            .get(format!("{base}/status"))
+            .header("authorization", format!("Bearer {token}"))
+            .send()
+            .await
+            .unwrap();
+        assert_eq!(
+            accepted.status(),
+            StatusCode::OK,
+            "the auto-provisioned token must be accepted"
+        );
+
+        server.abort();
         std::env::remove_var("KIN_DAEMON_AUTH_TOKEN");
         std::env::remove_var("KIN_DAEMON_REQUIRE_TOKEN");
     }

--- a/crates/kin-daemon/tests/chaos_recovery.rs
+++ b/crates/kin-daemon/tests/chaos_recovery.rs
@@ -174,19 +174,30 @@ async fn wait_for_path_removed(path: &Path, what: &str, timeout: Duration) {
     }
 }
 
-async fn create_branch(port: u16, name: &str) {
+async fn create_branch(repo_root: &Path, port: u16, name: &str) {
     let client = reqwest::Client::new();
     let url = format!("http://127.0.0.1:{port}/graph/branches");
     let deadline = Instant::now() + Duration::from_secs(30);
     let mut backoff = Duration::from_millis(50);
 
     loop {
-        let result = client
-            .post(&url)
-            .json(&serde_json::json!({
-                "name": name,
-                "head": "0000000000000000000000000000000000000000000000000000000000000001"
-            }))
+        // Re-read on every attempt rather than once before the loop: this
+        // closes over the daemon's own startup ordering (listener bind vs.
+        // token provisioning) instead of assuming one happens before the
+        // other, and self-heals if the file is not there yet on an early
+        // retry.
+        let token = std::fs::read_to_string(repo_root.join(".kin/daemon.token"))
+            .ok()
+            .map(|contents| contents.trim().to_string())
+            .filter(|token| !token.is_empty());
+        let mut request = client.post(&url).json(&serde_json::json!({
+            "name": name,
+            "head": "0000000000000000000000000000000000000000000000000000000000000001"
+        }));
+        if let Some(token) = token {
+            request = request.bearer_auth(token);
+        }
+        let result = request
             .send()
             .await
             .and_then(|response| response.error_for_status());
@@ -331,7 +342,7 @@ async fn daemon_exits_after_dirty_repo_control_dir_is_removed() {
     );
 
     wait_for_serving(&mut child, port).await;
-    create_branch(port, "dirty-before-delete").await;
+    create_branch(repo.path(), port, "dirty-before-delete").await;
 
     std::fs::remove_dir_all(repo.path().join(".kin")).unwrap();
 

--- a/crates/kin-mcp/src/daemon_delegate.rs
+++ b/crates/kin-mcp/src/daemon_delegate.rs
@@ -115,7 +115,11 @@ fn discover_kin_dir() -> Option<std::path::PathBuf> {
 }
 
 /// Attach the daemon bearer token to a request when auth is configured.
-fn with_auth(request: reqwest::RequestBuilder) -> reqwest::RequestBuilder {
+///
+/// `pub(crate)`: also used by `handlers::common`'s spine federation client,
+/// which talks to the daemon's `/v1/spine/*` routes directly rather than
+/// through this module's own forwarding helpers.
+pub(crate) fn with_auth(request: reqwest::RequestBuilder) -> reqwest::RequestBuilder {
     match daemon_auth_token() {
         Some(token) => request.bearer_auth(token),
         None => request,

--- a/crates/kin-mcp/src/handlers/common.rs
+++ b/crates/kin-mcp/src/handlers/common.rs
@@ -167,18 +167,17 @@ pub async fn fetch_spine_impact_typed(
         Err(e) => return SpineQuery::Unavailable(format!("failed to build reqwest client: {e}")),
     };
 
-    let resp = match client
-        .get(format!(
-            "{}/v1/spine/impact",
-            daemon_url.trim_end_matches('/')
-        ))
-        .query(&[
-            ("repo", repo_id),
-            ("entity", &entity_id.to_string()),
-            ("depth", &depth.to_string()),
-        ])
-        .send()
-        .await
+    let resp = match crate::daemon_delegate::with_auth(client.get(format!(
+        "{}/v1/spine/impact",
+        daemon_url.trim_end_matches('/')
+    )))
+    .query(&[
+        ("repo", repo_id),
+        ("entity", &entity_id.to_string()),
+        ("depth", &depth.to_string()),
+    ])
+    .send()
+    .await
     {
         Ok(resp) => resp,
         Err(e) => return SpineQuery::Unavailable(format!("spine request failed: {e}")),
@@ -214,14 +213,13 @@ pub async fn fetch_spine_xref(
         Err(e) => return SpineQuery::Unavailable(format!("failed to build reqwest client: {e}")),
     };
 
-    let resp = match client
-        .get(format!(
-            "{}/v1/spine/xref",
-            daemon_url.trim_end_matches('/')
-        ))
-        .query(&[("repo", repo_id), ("entity", &entity_id.to_string())])
-        .send()
-        .await
+    let resp = match crate::daemon_delegate::with_auth(client.get(format!(
+        "{}/v1/spine/xref",
+        daemon_url.trim_end_matches('/')
+    )))
+    .query(&[("repo", repo_id), ("entity", &entity_id.to_string())])
+    .send()
+    .await
     {
         Ok(resp) => resp,
         Err(e) => return SpineQuery::Unavailable(format!("spine request failed: {e}")),

--- a/docs/env-vars.md
+++ b/docs/env-vars.md
@@ -83,7 +83,7 @@ Sensitivity legend: **correctness** (affects retrieval/ranking/output or data sa
 | `KIN_DAEMON_LOCATE_ONLY` | bool | false | correctness | daemon serves locate-only from a snapshot, changing what it answers |
 | `KIN_DAEMON_PERIODIC_FLUSH_SECS` | seconds>=0 | 30 | operational | maximum interval before dirty graph state is flushed |
 | `KIN_DAEMON_READY_TIMEOUT_SECS` | seconds>=0 | 300 | operational | how long to wait for a starting daemon to become ready |
-| `KIN_DAEMON_REQUIRE_TOKEN` | bool | false | operational | require a bearer token for all daemon requests |
+| `KIN_DAEMON_REQUIRE_TOKEN` | bool | true | operational | require a bearer token for all daemon requests; set falsy to opt out |
 | `KIN_DAEMON_RUNTIME_SHUTDOWN_GRACE_SECS` | seconds>=0 | 8 | operational | bound on tokio runtime teardown waiting for blocking tasks |
 | `KIN_DAEMON_SCOPE_BUILD_TIMEOUT_SECS` | seconds>=0 | *(unset)* | operational | timeout for a daemon-side scope graph build |
 | `KIN_DAEMON_SHUTDOWN_GRACE_SECS` | seconds>=0 | 25 | operational | grace before the shutdown watchdog force-exits; 0 escalates immediately |

--- a/docs/security/threat-model.md
+++ b/docs/security/threat-model.md
@@ -81,17 +81,23 @@ daemon's own control routes — the package-registry routes (cargo/npm/oci/go) s
 public so that build tooling, which does not send credentials on reads, can fetch
 from a token-protected daemon.
 
-Enforcement of the per-install token is **opt-in** and **off by default**:
+Enforcement of the per-install token is **on by default**:
 
-- With no configuration, the token file is provisioned (so clients can adopt it)
-  but the daemon does **not** require it. In this default state the daemon relies
-  on the loopback bind, the Host/Origin guard, and OS-level filesystem and
-  process isolation rather than on bearer authentication.
-- Setting `KIN_DAEMON_REQUIRE_TOKEN` to a truthy value makes the daemon enforce
-  the per-install token, returning `401` to requests that do not present it.
+- On first run the daemon provisions the token file and requires it: requests to
+  non-public routes without a valid `Authorization: Bearer <token>` header get
+  `401`. The CLI (`daemon_client.rs`) and the MCP delegate (`daemon_delegate.rs`,
+  and the spine federation client in `handlers/common.rs`) all auto-read
+  `.kin/daemon.token` and send it, so a fresh install authenticates out of the
+  box with no operator setup.
+- `KIN_DAEMON_REQUIRE_TOKEN` is the documented escape hatch: set it to a falsy
+  value (`0`, `false`, `no`, or `off`) to run without bearer auth — for example, an
+  older local client that predates token support and cannot yet send the header.
+  In that state the daemon relies on the loopback bind, the Host/Origin guard,
+  and OS-level filesystem and process isolation rather than on bearer
+  authentication. An explicit truthy value is equivalent to the default.
 - Setting `KIN_DAEMON_AUTH_TOKEN` to an explicit value always takes precedence
-  and is always enforced; this is also the token required to bind a non-loopback
-  address.
+  and is always enforced, even while `KIN_DAEMON_REQUIRE_TOKEN` is opted out;
+  this is also the token required to bind a non-loopback address.
 
 ### Resulting trust boundary
 


### PR DESCRIPTION
## Summary

Three independent fixes, one commit each:

**1. Daemon loopback bearer-auth enforcement, default-on**
The daemon's per-install token (`.kin/daemon.token`, 0600) was already
auto-provisioned and already read by the CLI and MCP delegate, but
enforcement stayed opt-in behind `KIN_DAEMON_REQUIRE_TOKEN`. Flips the
default to on now that every in-repo client sends the header. The same
env var is the documented escape hatch (explicit falsy value disables
it) for a client that cannot yet send it. Also wires every direct
daemon-facing HTTP call site that built its own bare `reqwest::Client`
instead of going through the CLI's `DaemonClient` or the MCP delegate's
token-resolving paths — found by running the full local test suite
against the new default, not just by code review, which missed two of
these on a first pass: the MCP spine federation queries, the CLI's
commit/branch-head/graph-mutation/spine backend helpers, and the
kin-daemon chaos-recovery test harness's own branch-creation call.

**2. Truthful shadow-review hydration reporting**
Resolving a shadow review's base/head refs can lazily import Git
ancestry — sometimes thousands of historical changes on a cold
repo — but the insert count was computed and then discarded in favor
of a bare "did anything hydrate" bool. Threads the real count through
as `hydrated_changes: usize`, reported distinctly from the review's own
(always-zero) mutation count in both the JSON and text shadow response,
so a cold multi-thousand-change import is never described the same way
as a no-op.

**3. Flaky `load_status_rejects_non_kin_repo` fixed at the root**
`KinLayout::discover` short-circuits whenever `KIN_DAEMON_URL` is set
in the process env — by design, for callers that already know a daemon
is authoritative. Reading that env var ambiently made a test helper's
result depend on whatever unrelated, concurrently-running test last
touched the same process-global var. Split the pure logic into
`discover_with_daemon_url(start, daemon_url: Option<&str>)`, with
`discover()` as a thin env-reading wrapper for every existing caller
(zero behavior change there); the status command's local-snapshot test
helper now calls the explicit-parameter form with `None`.

Rebased onto current `main` to reconcile with upstream's shadow-review
ancestry-fast-path and abbreviated-ref work, which landed in the same
functions while this was in flight.

## Test plan
- [x] `cargo fmt --check` clean on all touched crates
- [x] `cargo clippy --all-targets --all-features` clean (CI allowlist) on all touched crates
- [x] Full `cargo test` green: kin-core (250), kin-mcp (182), kin-daemon lib+integration (314), kin-cli lib+integration (781)
- [x] New end-to-end test through the real daemon serve path proves default-on: missing token → 401, wrong token → 401, provisioned token → 200
- [x] Warm (0) and cold-import (>0) hydration-count cases covered at the ref-resolution layer, the response layer, and the existing end-to-end shadow fixture
- [x] Flaky test fix proven with 15+ concurrent repeated runs against the exact contending test, plus repeated full-suite runs, all green

Linear: /FIR-1255 /FIR-1264 /FIR-1260