### PR TITLE
fix(review): classify test-named product packages + calibrate policy for the newly-visible product code

### DIFF
--- a/crates/kin-index/src/pipeline.rs
+++ b/crates/kin-index/src/pipeline.rs
@@ -617,7 +617,7 @@ pub fn entity_semantics_changed(old: &Entity, new: &Entity) -> bool {
 /// `pytest`, `contest`, `latest` — out of the test role, while still catching
 /// compound test dirs such as `unit_tests`, `acceptance_test`, and `__tests__`.
 fn is_test_dir_component(component: &str) -> bool {
-    const TEST_DIR_WORDS: [&str; 4] = ["test", "tests", "spec", "specs"];
+    const TEST_DIR_WORDS: [&str; 5] = ["test", "tests", "testing", "spec", "specs"];
     component
         .split(['_', '-', '.'])
         .any(|word| TEST_DIR_WORDS.contains(&word))
@@ -951,6 +951,14 @@ mod tests {
             EntityRole::Test
         );
         assert_eq!(classify_file_role("_tests/helper.py"), EntityRole::Test);
+        // A bare helper in a `testing/` tree is still test infrastructure even
+        // without a `test_*` filename — `testing` is a test word, while
+        // `_pytest`/`contest`/`latest` embed `test` only as a substring.
+        assert_eq!(
+            classify_file_role("testing/util_helper.py"),
+            EntityRole::Test
+        );
+        assert_eq!(classify_file_role("testing/conftest.py"), EntityRole::Test);
     }
 
     #[test]

--- a/crates/kin-index/src/pipeline.rs
+++ b/crates/kin-index/src/pipeline.rs
@@ -611,36 +611,53 @@ pub fn entity_semantics_changed(old: &Entity, new: &Entity) -> bool {
         || contract_changed
 }
 
+/// Whether a single path component names a test directory: one of its
+/// `[_-.]`-delimited words is an exact test keyword. Word-level matching (never a
+/// raw substring) keeps a testing tool's shipped product package — `_pytest`,
+/// `pytest`, `contest`, `latest` — out of the test role, while still catching
+/// compound test dirs such as `unit_tests`, `acceptance_test`, and `__tests__`.
+fn is_test_dir_component(component: &str) -> bool {
+    const TEST_DIR_WORDS: [&str; 4] = ["test", "tests", "spec", "specs"];
+    component
+        .split(['_', '-', '.'])
+        .any(|word| TEST_DIR_WORDS.contains(&word))
+}
+
 /// Classify a file path into an [`EntityRole`] based on directory and filename patterns.
 ///
 /// Entities from the same file share the same role. The classifier checks path
 /// components against well-known patterns (test dirs, vendor dirs, docs, generated
 /// markers) and falls back to `Source` for everything else.
+///
+/// Test-directory detection matches whole path components (via
+/// [`is_test_dir_component`]) rather than raw substrings, so a testing tool's own
+/// product package — e.g. pytest's `_pytest/` — classifies as source and keeps its
+/// signature/breaking changes on the contract surface. A repo's actual test tree
+/// (`tests/`, `__tests__/`, or any `test_*`/`*_test` file) still resolves to the
+/// test role.
 pub fn classify_file_role(path: &str) -> EntityRole {
     let lower = path.to_ascii_lowercase();
+    let components: Vec<&str> = lower.split('/').filter(|c| !c.is_empty()).collect();
+    let file_name = components.last().copied().unwrap_or("");
+    let dir_len = components.len().saturating_sub(1);
 
-    // Test paths
-    let test_markers = [
-        "test/",
-        "tests/",
-        "/test/",
-        "/tests/",
-        "/test_",
-        "/_test",
-        "/spec/",
-        "/specs/",
-        "__tests__",
-    ];
-    if test_markers.iter().any(|m| lower.contains(m))
-        || lower.ends_with("_test.py")
-        || lower.ends_with("_test.rs")
-        || lower.ends_with("_test.go")
-        || lower.ends_with(".test.ts")
-        || lower.ends_with(".test.js")
-        || lower.ends_with(".spec.ts")
-        || lower.ends_with(".spec.js")
-        || lower.contains("/test_")
-    {
+    // Test paths. A directory is a test tree only when one of its words is an
+    // exact test keyword (component match, never a substring), so `_pytest/` and
+    // peers are not swept in. Test *files* are recognized by filename convention
+    // regardless of the directory they live in.
+    let in_test_dir = components
+        .iter()
+        .take(dir_len)
+        .any(|c| is_test_dir_component(c));
+    let is_test_file = file_name.starts_with("test_")
+        || file_name.ends_with("_test.py")
+        || file_name.ends_with("_test.rs")
+        || file_name.ends_with("_test.go")
+        || file_name.ends_with(".test.ts")
+        || file_name.ends_with(".test.js")
+        || file_name.ends_with(".spec.ts")
+        || file_name.ends_with(".spec.js");
+    if in_test_dir || is_test_file {
         return EntityRole::Test;
     }
 
@@ -886,6 +903,54 @@ mod tests {
             classify_file_role("__tests__/App.test.ts"),
             EntityRole::Test
         );
+    }
+
+    /// A testing tool ships product code whose package name embeds "test"
+    /// (pytest's `_pytest/`). That code is the framework's own public API — its
+    /// signature/breaking changes are a contract surface — so it must classify
+    /// as source, never test, even though a naive substring match on "test/"
+    /// would sweep it into the test role and suppress those findings. The tool's
+    /// actual test tree (`testing/`) still classifies as test.
+    #[test]
+    fn classify_test_named_product_package_as_source() {
+        // pytest's shipped product package, in both `src/` layout and bare form.
+        assert_eq!(
+            classify_file_role("src/_pytest/python.py"),
+            EntityRole::Source
+        );
+        assert_eq!(classify_file_role("_pytest/main.py"), EntityRole::Source);
+        assert_eq!(classify_file_role("_pytest/nodes.py"), EntityRole::Source);
+        assert_eq!(
+            classify_file_role("src/_pytest/__init__.py"),
+            EntityRole::Source
+        );
+        assert_eq!(
+            classify_file_role("src/pytest/__init__.py"),
+            EntityRole::Source
+        );
+        // Other product packages whose names merely embed a test keyword.
+        assert_eq!(
+            classify_file_role("src/contest/round.py"),
+            EntityRole::Source
+        );
+        assert_eq!(classify_file_role("latest/release.rs"), EntityRole::Source);
+
+        // pytest's own test tree stays test-role: a `test_*` file is a test
+        // wherever it lives, and compound / underscore-prefixed test dirs still
+        // resolve to a `test` word.
+        assert_eq!(
+            classify_file_role("testing/test_collection.py"),
+            EntityRole::Test
+        );
+        assert_eq!(
+            classify_file_role("integration_tests/api.py"),
+            EntityRole::Test
+        );
+        assert_eq!(
+            classify_file_role("acceptance_test/flow.py"),
+            EntityRole::Test
+        );
+        assert_eq!(classify_file_role("_tests/helper.py"), EntityRole::Test);
     }
 
     #[test]

--- a/crates/kin-review/src/inline.rs
+++ b/crates/kin-review/src/inline.rs
@@ -58,12 +58,14 @@ impl InlineCommentKind {
     }
 }
 
-/// Distinct non-test consumer ENTITIES at or above which a body-only
+/// Distinct non-test consumer ENTITIES at or above which a public body-only
 /// modification (signature and visibility unchanged) emits a consumer-fanout
 /// attention comment. The decision is graph-native — it counts consuming
 /// entities (typed inbound edges), not the files they happen to live in; a body
-/// change reaching a single consumer is ordinary local iteration. The signature
-/// channels own contract-surface changes.
+/// change reaching a single consumer is ordinary local iteration. Private
+/// helper body changes are reported through coverage/evidence context, but do
+/// not gate unless their contract surface changes. The signature channels own
+/// contract-surface changes.
 pub const CONSUMER_FANOUT_THRESHOLD: usize = 2;
 
 /// Qualifiers whose ADDITION strengthens a declaration without invalidating
@@ -107,6 +109,150 @@ pub fn signature_strengthened_only(old: &str, new: &str) -> bool {
     let (old_core, old_quals) = strip(old);
     let (new_core, new_quals) = strip(new);
     old_core == new_core && new_quals > old_quals
+}
+
+/// True when a textual signature delta changes no runtime call contract.
+///
+/// Python type annotations are useful surface information, but adding or
+/// tightening them does not change the callable argument contract at runtime.
+/// The graph still records the changed body/signature text; the review gate just
+/// must not turn annotation-only edits into breaking downstream-risk findings.
+pub fn signature_runtime_neutral(old: &str, new: &str) -> bool {
+    signature_strengthened_only(old, new)
+        || python_runtime_signature_key(old)
+            .zip(python_runtime_signature_key(new))
+            .is_some_and(|(old_key, new_key)| old_key == new_key)
+}
+
+fn python_runtime_signature_key(signature: &str) -> Option<String> {
+    let without_comment = signature.split('#').next().unwrap_or(signature).trim();
+    let def_pos = without_comment.find("def ")?;
+    let after_def = &without_comment[def_pos + 4..];
+    let name_end = after_def.find('(')?;
+    let name = after_def[..name_end].trim();
+    if name.is_empty() {
+        return None;
+    }
+
+    let params_start = def_pos + 4 + name_end;
+    let params_end = matching_paren(without_comment, params_start)?;
+    let params = &without_comment[params_start + 1..params_end];
+    let params = split_python_params(params)
+        .into_iter()
+        .map(|param| normalize_python_param(&param))
+        .collect::<Vec<_>>()
+        .join(",");
+    Some(format!("def {name}({params})"))
+}
+
+fn matching_paren(input: &str, open_byte: usize) -> Option<usize> {
+    if input.as_bytes().get(open_byte).copied() != Some(b'(') {
+        return None;
+    }
+    let mut depth = 0i32;
+    for (idx, ch) in input.char_indices().skip_while(|(idx, _)| *idx < open_byte) {
+        match ch {
+            '(' => depth += 1,
+            ')' => {
+                depth -= 1;
+                if depth == 0 {
+                    return Some(idx);
+                }
+            }
+            _ => {}
+        }
+    }
+    None
+}
+
+fn split_python_params(params: &str) -> Vec<String> {
+    let mut parts = Vec::new();
+    let mut current = String::new();
+    let mut bracket_depth = 0i32;
+    let mut quote: Option<char> = None;
+    let mut escaped = false;
+
+    for ch in params.chars() {
+        if let Some(q) = quote {
+            current.push(ch);
+            if escaped {
+                escaped = false;
+            } else if ch == '\\' {
+                escaped = true;
+            } else if ch == q {
+                quote = None;
+            }
+            continue;
+        }
+
+        match ch {
+            '\'' | '"' => {
+                quote = Some(ch);
+                current.push(ch);
+            }
+            '[' | '(' | '{' => {
+                bracket_depth += 1;
+                current.push(ch);
+            }
+            ']' | ')' | '}' => {
+                bracket_depth -= 1;
+                current.push(ch);
+            }
+            ',' if bracket_depth == 0 => {
+                parts.push(current.trim().to_string());
+                current.clear();
+            }
+            _ => current.push(ch),
+        }
+    }
+
+    if !current.trim().is_empty() {
+        parts.push(current.trim().to_string());
+    }
+    parts
+}
+
+fn normalize_python_param(param: &str) -> String {
+    let trimmed = param.trim();
+    let (before_default, default) = match top_level_char(trimmed, '=') {
+        Some(idx) => (&trimmed[..idx], Some(&trimmed[idx + 1..])),
+        None => (trimmed, None),
+    };
+    let name = match top_level_char(before_default, ':') {
+        Some(idx) => before_default[..idx].trim(),
+        None => before_default.trim(),
+    };
+    let name = name.split_whitespace().collect::<String>();
+    match default {
+        Some(default) => format!("{name}={}", default.split_whitespace().collect::<String>()),
+        None => name,
+    }
+}
+
+fn top_level_char(input: &str, needle: char) -> Option<usize> {
+    let mut bracket_depth = 0i32;
+    let mut quote: Option<char> = None;
+    let mut escaped = false;
+    for (idx, ch) in input.char_indices() {
+        if let Some(q) = quote {
+            if escaped {
+                escaped = false;
+            } else if ch == '\\' {
+                escaped = true;
+            } else if ch == q {
+                quote = None;
+            }
+            continue;
+        }
+        match ch {
+            '\'' | '"' => quote = Some(ch),
+            '[' | '(' | '{' => bracket_depth += 1,
+            ']' | ')' | '}' => bracket_depth -= 1,
+            _ if ch == needle && bracket_depth == 0 => return Some(idx),
+            _ => {}
+        }
+    }
+    None
 }
 
 /// Collect line-level inline comments from a review's diff and impact data.
@@ -231,7 +377,7 @@ fn collect_modified_comments(
     // such qualifiers — remains one.
     if !is_non_contract_surface_role(new.role)
         && old.signature != new.signature
-        && !signature_strengthened_only(&old.signature, &new.signature)
+        && !signature_runtime_neutral(&old.signature, &new.signature)
     {
         comments.push(InlineComment {
             file: span.file.to_string(),
@@ -342,16 +488,19 @@ fn collect_modified_comments(
     }
 
     // Body-only modification with wide consumer fanout. The contract surface
-    // is unchanged, so the breaking channels stay silent, but a behavior
+    // is unchanged, so the breaking channels stay silent, but a public behavior
     // change reaching many distinct non-test consumer entities deserves
     // attention. Graph-known covering tests can absorb weak/ambiguous fanout,
     // so covered body-only changes gate on strong consumers only. Uncovered
-    // body-only changes gate on all graph-native consumer entities: weak
-    // fanout plus no tests is still a review risk. The file list is reported
-    // only as human-readable context.
+    // public body-only changes gate on all graph-native consumer entities:
+    // weak fanout plus no tests is still a review risk. Private helper body
+    // changes remain visible through coverage/evidence findings, but they do
+    // not feed the gate without a signature or visibility surface change.
+    let body_only_fanout_has_enough_shape = new.visibility == Visibility::Public
+        && fanout_gate_consumer_count >= CONSUMER_FANOUT_THRESHOLD;
     if old.signature == new.signature
         && old.visibility == new.visibility
-        && fanout_gate_consumer_count >= CONSUMER_FANOUT_THRESHOLD
+        && body_only_fanout_has_enough_shape
     {
         comments.push(InlineComment {
             file: span.file.to_string(),
@@ -988,6 +1137,30 @@ mod tests {
     }
 
     #[test]
+    fn python_annotation_only_signature_is_runtime_neutral() {
+        assert!(signature_runtime_neutral(
+            "def __init__(self, reprlocation_lines): # List of(reprlocation, lines) tuples",
+            "def __init__(self, reprlocation_lines: Sequence[Tuple[ReprFileLocation, Sequence[str]]])"
+        ));
+        assert!(signature_runtime_neutral(
+            "def toterminal(self, tw)",
+            "def toterminal(self, tw) -> None"
+        ));
+        assert!(signature_runtime_neutral(
+            "def make(self, value = (1, 2), *, flag: bool = True)",
+            "def make(self, value=(1,2), *, flag=True) -> object"
+        ));
+        assert!(!signature_runtime_neutral(
+            "def _makefile(self, ext, args, kwargs, encoding=\"utf-8\")",
+            "def _makefile(self, ext, lines, files, encoding=\"utf-8\")"
+        ));
+        assert!(!signature_runtime_neutral(
+            "class Item(Node, Request)",
+            "class Item(Node)"
+        ));
+    }
+
+    #[test]
     fn strengthened_only_change_emits_no_signature_or_breaking_comment() {
         let old = test_entity_with_span("hot_path", "src/hot.rs", 1, 20);
         let mut new = old.clone();
@@ -1021,6 +1194,52 @@ mod tests {
                 InlineCommentKind::SignatureChange | InlineCommentKind::Breaking
             )),
             "qualifier strengthening must not read as signature change or breaking"
+        );
+    }
+
+    #[test]
+    fn python_annotation_only_change_emits_no_signature_or_breaking_comment() {
+        let mut old = test_entity_with_span(
+            "ReprFailDoctest.toterminal",
+            "src/_pytest/doctest.py",
+            122,
+            126,
+        );
+        old.signature = "def toterminal(self, tw)".to_string();
+        let mut new = old.clone();
+        new.signature = "def toterminal(self, tw) -> None".to_string();
+        let diff = SemanticDiff {
+            entity_changes: vec![EntityChange {
+                entity_id: new.id,
+                kind: EntityChangeKind::Modified {
+                    old: old.clone(),
+                    new: new.clone(),
+                },
+            }],
+            ..Default::default()
+        };
+        let impact = ImpactReport {
+            changed_ids: vec![new.id],
+            entity_impacts: vec![EntityImpact {
+                entity_id: new.id,
+                consumer_count: 5,
+                strong_consumer_count: 5,
+                contract_consumer_count: 0,
+                consumer_files: vec![
+                    "src/_pytest/doctest.py".to_string(),
+                    "testing/test_doctest.py".to_string(),
+                ],
+                covering_tests: 0,
+            }],
+            ..Default::default()
+        };
+        let comments = collect_inline_comments(&diff, &impact);
+        assert!(
+            !comments.iter().any(|c| matches!(
+                c.kind,
+                InlineCommentKind::SignatureChange | InlineCommentKind::Breaking
+            )),
+            "annotation-only Python changes must not read as runtime contract changes: {comments:?}"
         );
     }
 
@@ -1098,6 +1317,50 @@ mod tests {
         assert!(fanout[0]
             .message
             .contains("2 distinct non-test consumer(s) across 1 file(s)"));
+    }
+
+    #[test]
+    fn private_body_only_consumer_fanout_does_not_gate() {
+        let mut old = test_entity_with_span(
+            "_getconftestmodules",
+            "src/_pytest/config/__init__.py",
+            399,
+            422,
+        );
+        old.visibility = Visibility::Private;
+        let new = old.clone();
+        let diff = SemanticDiff {
+            entity_changes: vec![EntityChange {
+                entity_id: new.id,
+                kind: EntityChangeKind::Modified {
+                    old: old.clone(),
+                    new: new.clone(),
+                },
+            }],
+            ..Default::default()
+        };
+        let impact = ImpactReport {
+            changed_ids: vec![new.id],
+            entity_impacts: vec![EntityImpact {
+                entity_id: new.id,
+                consumer_count: 4,
+                strong_consumer_count: 2,
+                contract_consumer_count: 0,
+                consumer_files: vec![
+                    "src/_pytest/config/__init__.py".to_string(),
+                    "testing/test_conftest.py".to_string(),
+                ],
+                covering_tests: 0,
+            }],
+            ..Default::default()
+        };
+        let comments = collect_inline_comments(&diff, &impact);
+        assert!(
+            !comments
+                .iter()
+                .any(|c| c.kind == InlineCommentKind::ConsumerFanout),
+            "private helper body-only fanout must stay visible as context, not gate: {comments:?}"
+        );
     }
 
     #[test]

--- a/crates/kin-review/src/shadow.rs
+++ b/crates/kin-review/src/shadow.rs
@@ -592,7 +592,7 @@ fn collect_changed_entities<G: GraphStore>(
                     start_line,
                     end_line,
                     signature_changed: old.signature != new.signature
-                        && !crate::inline::signature_strengthened_only(
+                        && !crate::inline::signature_runtime_neutral(
                             &old.signature,
                             &new.signature,
                         ),
@@ -869,7 +869,12 @@ fn derive_policy(
                     new.span
                         .as_ref()
                         .map(|span| (span.file.to_string(), span.start_line)),
-                    old.signature != new.signature || old.visibility != new.visibility,
+                    (old.signature != new.signature
+                        && !crate::inline::signature_runtime_neutral(
+                            &old.signature,
+                            &new.signature,
+                        ))
+                        || old.visibility != new.visibility,
                     false,
                 ),
                 EntityChangeKind::Removed(id) => {


### PR DESCRIPTION
fix(review): classify test-named product packages correctly and calibrate the review policy for the newly-visible product code

## What

Two layers, one coherent change to how the merge-trust review reasons about
test-named product packages like pytest's `_pytest/`:

1. **Classifier (from #247):** test-named PRODUCT packages (`src/_pytest/…`)
   classify as source-role, and `testing/` directories classify as test-role.
   pytest's `_pytest` package is the product implementation, not tests, so its
   changes must be reviewable. The FIR-1324 role-scoping invariant for real
   `testing/` trees is preserved.

2. **Review-policy calibration (new):** once product code becomes visible, the
   policy must not over-flag benign changes in it. Two graph-native rules:
   - **Annotation-only Python signature edits are runtime-neutral.** Adding or
     tightening type/return annotations while parameter names, defaults, and
     order are unchanged is not a call-contract change. `signature_runtime_neutral`
     parses the `def`, strips annotations/comments, and compares the runtime key.
     Real parameter renames, removals, reorders, and default-value changes still
     flag.
   - **Private-helper body-only fanout does not gate.** Body-only consumer
     fanout drives `needs_attention` only for `Public` entities; private
     (underscore-prefixed) helpers stay visible as evidence context without
     gating. Public body-only fanout still gates (regression protection intact).

## Why

On the pytest block, the classifier alone (#247) correctly surfaces two real
regressions that were previously suppressed (`8adac2878f`, `6c89f9261c`) but
also produced four benign false positives, because at the local signal level a
benign refactor and a buggy one look identical — the distinguishing truth is
semantic. This change makes the policy more semantic (annotation ≠ contract,
private helper ≠ public surface) rather than tuning a threshold. Net effect:
keep the recall gain, recover the precision.

`cdc7e13067` (a real `_makefile` argument-shape change with downstream
consumers) intentionally remains a defensible flag — it is a genuine contract
change, not a false positive.

## Validation

- kin-review unit suite green (142 passing), incl. new annotation-neutral,
  real-rename-still-flags, and private-vs-public fanout cases.
- Behavioral probe on the built binary through `kin review shadow`:
  annotation-only `_pytest/` edit → `pass` (0 signature findings); real param
  rename → `would_block` (signature + breaking). Discrimination confirmed.
- Full 22-row pytest-block dev-lane slice (NON-CITABLE): TP 8 / FP 1 / FN 4,
  P 0.889 / R 0.667 / **F1 0.762** — beats v7 (F1 0.500) and #247-alone (F1 0.667).
  All three fixable FPs cleared to `pass` (`1371b`, `29bb`, `33c6`); `cdc7e`
  remains the one booked-defensible flag; all 8 protected TPs held. The slice's
  hydration-counter VARYING warning is a harness canonicalization gap fixed in
  kin-bench #94 — after that fix all 22 rows are bit-identical (verdicts stable).
  V8-readiness depends on both this PR and kin-bench #94.

Supersedes #247 (this branch cherry-picks its two classifier commits onto
current main and adds the policy calibration; #247 can close in favor of this).

Base: current origin/main (no stale-base confound).