### PR TITLE
feat(review): revert-history evidence channel, causally scoped to the base ancestry window

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Revert-history review channel: shadow review flags revert-shaped changes — an added
+  entity that restores content removed in the recent past (behavior-fingerprint match),
+  a reintroduction of a recently-removed surface (same name and kind, modified content),
+  and removals of recently-introduced entities. The evidence is temporal, read from a
+  bounded window of the base ref's ancestry at review time, and feeds the gate as
+  ordinary warning findings; when the base has too little history to scan, the report
+  carries an explicit evidence gap instead of a silent pass.
+
 ## [0.2.13] - 2026-07-07
 
 Distribution becomes first-class: Kin installs from npm as `@kinlab/kin`, doctor heals its own VFS shim, and history hydration gains parse reuse and a timing profile.
@@ -32,6 +42,17 @@ Distribution becomes first-class: Kin installs from npm as `@kinlab/kin`, doctor
 ### Security
 
 - crossbeam-epoch updated to 0.9.20 (RUSTSEC-2026-0204).
+=======
+### Added
+
+- Revert-history review channel: shadow review flags revert-shaped changes — an added
+  entity that restores content removed in the recent past (behavior-fingerprint match),
+  a reintroduction of a recently-removed surface (same name and kind, modified content),
+  and removals of recently-introduced entities. The evidence is temporal, read from a
+  bounded window of the base ref's ancestry at review time, and feeds the gate as
+  ordinary warning findings; when the base has too little history to scan, the report
+  carries an explicit evidence gap instead of a silent pass.
+>>>>>>> fbfdd830 (feat(review): revert-history evidence channel for shadow review)
 
 ## [0.2.12] - 2026-07-06
 

--- a/crates/kin-cli/src/commands/review.rs
+++ b/crates/kin-cli/src/commands/review.rs
@@ -1228,7 +1228,9 @@ fn inline_comment_severity(kind: kin_review::InlineCommentKind) -> &'static str 
         | InlineCommentKind::Renamed
         | InlineCommentKind::AgentUnreviewed
         | InlineCommentKind::RevertHistory => "warning",
-        InlineCommentKind::Added | InlineCommentKind::Removed => "info",
+        InlineCommentKind::Added
+        | InlineCommentKind::Removed
+        | InlineCommentKind::RevertHistoryIncidental => "info",
     }
 }
 

--- a/crates/kin-cli/src/commands/review.rs
+++ b/crates/kin-cli/src/commands/review.rs
@@ -1226,7 +1226,8 @@ fn inline_comment_severity(kind: kin_review::InlineCommentKind) -> &'static str 
         | InlineCommentKind::ToolchainSurfaceChange
         | InlineCommentKind::ConsumerFanout
         | InlineCommentKind::Renamed
-        | InlineCommentKind::AgentUnreviewed => "warning",
+        | InlineCommentKind::AgentUnreviewed
+        | InlineCommentKind::RevertHistory => "warning",
         InlineCommentKind::Added | InlineCommentKind::Removed => "info",
     }
 }

--- a/crates/kin-review/src/inline.rs
+++ b/crates/kin-review/src/inline.rs
@@ -37,6 +37,7 @@ pub enum InlineCommentKind {
     Renamed,
     AgentUnreviewed,
     ToolchainSurfaceChange,
+    RevertHistory,
 }
 
 impl InlineCommentKind {
@@ -53,6 +54,7 @@ impl InlineCommentKind {
             Self::Removed => "-",
             Self::Renamed => "~",
             Self::AgentUnreviewed => "@",
+            Self::RevertHistory => "~",
             Self::ToolchainSurfaceChange => "~",
         }
     }

--- a/crates/kin-review/src/inline.rs
+++ b/crates/kin-review/src/inline.rs
@@ -38,6 +38,7 @@ pub enum InlineCommentKind {
     AgentUnreviewed,
     ToolchainSurfaceChange,
     RevertHistory,
+    RevertHistoryIncidental,
 }
 
 impl InlineCommentKind {
@@ -55,6 +56,7 @@ impl InlineCommentKind {
             Self::Renamed => "~",
             Self::AgentUnreviewed => "@",
             Self::RevertHistory => "~",
+            Self::RevertHistoryIncidental => "~",
             Self::ToolchainSurfaceChange => "~",
         }
     }

--- a/crates/kin-review/src/lib.rs
+++ b/crates/kin-review/src/lib.rs
@@ -9,6 +9,7 @@ pub mod impact;
 pub mod inline;
 pub mod ref_graph;
 pub mod release_gate;
+pub mod revert_history;
 pub mod review;
 pub mod risk;
 pub mod shadow;

--- a/crates/kin-review/src/revert_history.rs
+++ b/crates/kin-review/src/revert_history.rs
@@ -25,11 +25,14 @@
 //!   deleting something that only just landed is the shape of a revert of a
 //!   recent feature.
 //!
-//! Findings feed the gate as ordinary warning findings through the
+//! Strong matches feed the gate as ordinary warning findings through the
 //! inline-comment channel (the same shape as the command-effect and
-//! toolchain-surface channels), never through evidence-gap demotion. When the
-//! base has less history than the window can meaningfully scan, the channel
-//! reports an honest evidence gap instead of silently passing.
+//! toolchain-surface channels), never through evidence-gap demotion. Weaker
+//! temporal evidence is still reported but stays informational: the benign-60
+//! sweep showed that deleting a recent addition is common cleanup unless an
+//! independent review signal also says the change is risky. When the base has
+//! less history than the window can meaningfully scan, the channel reports an
+//! honest evidence gap instead of silently passing.
 //!
 //! Matching is computed at review time exclusively from the base's ancestry
 //! window — the graph may hold changes outside the reviewed lineage (other
@@ -258,16 +261,11 @@ pub(crate) fn collect_revert_history_findings<G: GraphStore>(
             let name = removed
                 .map(|e| e.name.clone())
                 .unwrap_or_else(|| "entity".to_string());
-            let gates = removed.is_some_and(is_public_contract);
             findings.push(InlineComment {
                 file: String::new(),
                 start_line: 0,
                 end_line: 0,
-                kind: if gates {
-                    InlineCommentKind::RevertHistory
-                } else {
-                    InlineCommentKind::RevertHistoryIncidental
-                },
+                kind: InlineCommentKind::RevertHistoryIncidental,
                 message: format!(
                     "Removed `{}` was introduced only {} — revert-shaped removal \
                      of a recent addition",

--- a/crates/kin-review/src/revert_history.rs
+++ b/crates/kin-review/src/revert_history.rs
@@ -41,7 +41,7 @@ use std::collections::{BTreeMap, HashMap, HashSet, VecDeque};
 
 use kin_model::change::{EntityDelta, SemanticChange};
 use kin_model::graph::GraphStore;
-use kin_model::{Entity, EntityId, EntityKind, Hash256, SemanticChangeId};
+use kin_model::{Entity, EntityId, EntityKind, Hash256, SemanticChangeId, Visibility};
 
 use crate::error::ReviewError;
 use crate::inline::{InlineComment, InlineCommentKind};
@@ -168,10 +168,8 @@ pub(crate) fn collect_revert_history_findings<G: GraphStore>(
                         // change; restoring it un-does this change.
                         prior_bodies.push((o.fingerprint.behavior_hash, change.id));
                     }
-                    EntityDelta::Added(e) if e.id == old.id => {
-                        if prior_bodies.is_empty() {
-                            prior_bodies.push((e.fingerprint.behavior_hash, change.id));
-                        }
+                    EntityDelta::Added(e) if e.id == old.id && prior_bodies.is_empty() => {
+                        prior_bodies.push((e.fingerprint.behavior_hash, change.id));
                     }
                     _ => {}
                 }
@@ -187,20 +185,19 @@ pub(crate) fn collect_revert_history_findings<G: GraphStore>(
         }
     }
 
-    // Body reversions are REPORTED, never verdict-driving. The 60-benign
-    // sweep measured why: a module entity is a content aggregate of its file,
-    // so any single-function reversion makes the module co-revert to the same
-    // change by construction — "coherence" of two entities is nearly free, and
-    // gating on it re-flagged ~a third of clean benigns. The temporal evidence
-    // stays visible to reviewers (and to future evidence-composition in
-    // ranking) at info severity; coherence is still computed because it is the
-    // strongest hint in the message.
+    // A coordinated revert (>=2 entities restoring bodies from the same change)
+    // gates only the public contract leaves it touches. Module/class aggregates
+    // co-revert for free (a module mirrors its file), and private-helper or test
+    // reversions are ordinary churn — those stay informational. A singleton
+    // match is incidental (small bodies recur over long histories) and never
+    // gates.
     let mut undone_counts: HashMap<SemanticChangeId, usize> = HashMap::new();
     for (_, _, undone, _) in &reversion_matches {
         *undone_counts.entry(*undone).or_insert(0) += 1;
     }
     for (entity, name, undone, depth) in &reversion_matches {
         let coherent = undone_counts.get(undone).copied().unwrap_or(0) >= 2;
+        let gates = coherent && is_public_contract_leaf(entity);
         let message = format!(
             "Modified `{}` restores the exact body it had {} revision(s) ago{} — \
              revert-shaped body reversion",
@@ -213,7 +210,11 @@ pub(crate) fn collect_revert_history_findings<G: GraphStore>(
             },
         );
         let mut finding = inline_finding(entity, message);
-        finding.kind = InlineCommentKind::RevertHistoryIncidental;
+        finding.kind = if gates {
+            InlineCommentKind::RevertHistory
+        } else {
+            InlineCommentKind::RevertHistoryIncidental
+        };
         findings.push(finding);
     }
 
@@ -262,7 +263,11 @@ pub(crate) fn collect_revert_history_findings<G: GraphStore>(
                 })
             };
             if let Some(message) = finding {
-                findings.push(inline_finding(added, message));
+                let mut comment = inline_finding(added, message);
+                if !is_public_contract(added) {
+                    comment.kind = InlineCommentKind::RevertHistoryIncidental;
+                }
+                findings.push(comment);
             }
         }
     }
@@ -272,14 +277,21 @@ pub(crate) fn collect_revert_history_findings<G: GraphStore>(
     // revert shape where the added lines are deleted in place.
     for removed_id in &head_removed {
         if let Some(distance) = window.added_ids.get(removed_id) {
-            let name = last_known_entity(store, removed_id)
-                .map(|e| e.name)
+            let removed = last_known_entity(store, removed_id);
+            let name = removed
+                .as_ref()
+                .map(|e| e.name.clone())
                 .unwrap_or_else(|| "entity".to_string());
+            let gates = removed.as_ref().is_some_and(is_public_contract);
             findings.push(InlineComment {
                 file: String::new(),
                 start_line: 0,
                 end_line: 0,
-                kind: InlineCommentKind::RevertHistory,
+                kind: if gates {
+                    InlineCommentKind::RevertHistory
+                } else {
+                    InlineCommentKind::RevertHistoryIncidental
+                },
                 message: format!(
                     "Removed `{}` was introduced only {} — revert-shaped removal \
                      of a recent addition",
@@ -368,6 +380,19 @@ fn last_known_entity<G: GraphStore>(store: &G, id: &EntityId) -> Option<Entity> 
             _ => None,
         })
     })
+}
+
+// A public, non-test/generated/vendored entity — a real contract surface whose
+// revert is worth gating on, as opposed to private-helper or test churn.
+fn is_public_contract(entity: &Entity) -> bool {
+    entity.visibility == Visibility::Public
+        && !crate::inline::is_non_contract_surface_role(entity.role)
+}
+
+// Body-reversion coherence gates only on leaves (functions/methods): a module or
+// class aggregates its members, so it co-reverts for free and inflates coherence.
+fn is_public_contract_leaf(entity: &Entity) -> bool {
+    is_public_contract(entity) && matches!(entity.kind, EntityKind::Function | EntityKind::Method)
 }
 
 fn inline_finding(entity: &Entity, message: String) -> InlineComment {

--- a/crates/kin-review/src/revert_history.rs
+++ b/crates/kin-review/src/revert_history.rs
@@ -96,6 +96,7 @@ pub(crate) fn collect_revert_history_findings<G: GraphStore>(
     let mut head_added: BTreeMap<(String, String), Entity> = BTreeMap::new();
     let mut head_removed: Vec<EntityId> = Vec::new();
     let mut seen_removed: HashSet<EntityId> = HashSet::new();
+    let mut head_modified: BTreeMap<String, (Entity, Entity)> = BTreeMap::new();
     for change in range_changes {
         for delta in &change.entity_deltas {
             match delta {
@@ -109,12 +110,77 @@ pub(crate) fn collect_revert_history_findings<G: GraphStore>(
                         head_removed.push(*id);
                     }
                 }
-                EntityDelta::Modified { .. } => {}
+                EntityDelta::Modified { old, new } => {
+                    // Multiple range changes touching one entity collapse to
+                    // the net old→new pair: earliest old, latest new.
+                    head_modified
+                        .entry(new.name.clone())
+                        .and_modify(|(_, latest)| *latest = new.clone())
+                        .or_insert_with(|| (old.clone(), new.clone()));
+                }
             }
         }
     }
 
     let mut findings = Vec::new();
+
+    // Body reversions: a modified entity whose NEW body equals a body it
+    // carried at an OLDER revision — the head un-does a later edit. This is
+    // the dominant real-world revert shape (git revert of a body change
+    // produces a Modified delta, not add/remove). The immediately-previous
+    // body is skipped: every edit trivially differs from its predecessor;
+    // only a return to DEEPER history is revert-shaped. Hash equality on the
+    // behavior fingerprint makes the match exact, so this cannot fire on an
+    // ordinary edit.
+    for (name, (old, new)) in &head_modified {
+        if new.fingerprint.behavior_hash == old.fingerprint.behavior_hash {
+            continue;
+        }
+        let history = match store.get_entity_history(&old.id) {
+            Ok(h) => h,
+            Err(_) => continue,
+        };
+        // Bodies this entity carried before the range, newest-first, capped by
+        // the window. Position 0 is the body the range started from (old) —
+        // matching it would be a no-op edit, so matches start at depth 1.
+        let mut prior_bodies: Vec<Hash256> = Vec::new();
+        for change in history.iter().rev() {
+            if prior_bodies.len() > REVERT_HISTORY_WINDOW {
+                break;
+            }
+            for delta in &change.entity_deltas {
+                match delta {
+                    EntityDelta::Modified { old: o, new: n } if n.id == old.id => {
+                        if prior_bodies.is_empty() {
+                            prior_bodies.push(n.fingerprint.behavior_hash);
+                        }
+                        prior_bodies.push(o.fingerprint.behavior_hash);
+                    }
+                    EntityDelta::Added(e) if e.id == old.id => {
+                        if prior_bodies.is_empty() {
+                            prior_bodies.push(e.fingerprint.behavior_hash);
+                        }
+                    }
+                    _ => {}
+                }
+            }
+        }
+        if let Some(depth) = prior_bodies
+            .iter()
+            .skip(1)
+            .position(|h| *h == new.fingerprint.behavior_hash)
+        {
+            findings.push(inline_finding(
+                new,
+                format!(
+                    "Modified `{}` restores the exact body it had {} revision(s) ago — \
+                     revert-shaped body reversion",
+                    name,
+                    depth + 1
+                ),
+            ));
+        }
+    }
 
     // Reintroductions: an added entity matching a window removal. Removed
     // deltas carry only the id, so each candidate is resolved to its last full

--- a/crates/kin-review/src/revert_history.rs
+++ b/crates/kin-review/src/revert_history.rs
@@ -132,6 +132,15 @@ pub(crate) fn collect_revert_history_findings<G: GraphStore>(
     // only a return to DEEPER history is revert-shaped. Hash equality on the
     // behavior fingerprint makes the match exact, so this cannot fire on an
     // ordinary edit.
+    //
+    // Matches are grouped by the SEMANTIC CHANGE whose delta carried the
+    // matching old body. A true revert restores a coherent snapshot: several
+    // of the head's entities return to bodies from the same historical change.
+    // An isolated single-entity match is usually incidental — small bodies
+    // recur naturally over long histories — so only COHERENT groups (two or
+    // more entities reverting to the same change) gate the verdict; singleton
+    // matches are still reported, at info severity, for the reviewer.
+    let mut reversion_matches: Vec<(Entity, String, SemanticChangeId, usize)> = Vec::new();
     for (name, (old, new)) in &head_modified {
         if new.fingerprint.behavior_hash == old.fingerprint.behavior_hash {
             continue;
@@ -141,9 +150,10 @@ pub(crate) fn collect_revert_history_findings<G: GraphStore>(
             Err(_) => continue,
         };
         // Bodies this entity carried before the range, newest-first, capped by
-        // the window. Position 0 is the body the range started from (old) —
-        // matching it would be a no-op edit, so matches start at depth 1.
-        let mut prior_bodies: Vec<Hash256> = Vec::new();
+        // the window, each tagged with the change that introduced it. Position
+        // 0 is the body the range started from (old) — matching it would be a
+        // no-op edit, so matches start at depth 1.
+        let mut prior_bodies: Vec<(Hash256, SemanticChangeId)> = Vec::new();
         for change in history.iter().rev() {
             if prior_bodies.len() > REVERT_HISTORY_WINDOW {
                 break;
@@ -152,34 +162,53 @@ pub(crate) fn collect_revert_history_findings<G: GraphStore>(
                 match delta {
                     EntityDelta::Modified { old: o, new: n } if n.id == old.id => {
                         if prior_bodies.is_empty() {
-                            prior_bodies.push(n.fingerprint.behavior_hash);
+                            prior_bodies.push((n.fingerprint.behavior_hash, change.id));
                         }
-                        prior_bodies.push(o.fingerprint.behavior_hash);
+                        // The OLD body was the entity's state BEFORE this
+                        // change; restoring it un-does this change.
+                        prior_bodies.push((o.fingerprint.behavior_hash, change.id));
                     }
                     EntityDelta::Added(e) if e.id == old.id => {
                         if prior_bodies.is_empty() {
-                            prior_bodies.push(e.fingerprint.behavior_hash);
+                            prior_bodies.push((e.fingerprint.behavior_hash, change.id));
                         }
                     }
                     _ => {}
                 }
             }
         }
-        if let Some(depth) = prior_bodies
+        if let Some((depth, (_, undone_change))) = prior_bodies
             .iter()
+            .enumerate()
             .skip(1)
-            .position(|h| *h == new.fingerprint.behavior_hash)
+            .find(|(_, (h, _))| *h == new.fingerprint.behavior_hash)
         {
-            findings.push(inline_finding(
-                new,
-                format!(
-                    "Modified `{}` restores the exact body it had {} revision(s) ago — \
-                     revert-shaped body reversion",
-                    name,
-                    depth + 1
-                ),
-            ));
+            reversion_matches.push((new.clone(), name.clone(), *undone_change, depth));
         }
+    }
+
+    let mut undone_counts: HashMap<SemanticChangeId, usize> = HashMap::new();
+    for (_, _, undone, _) in &reversion_matches {
+        *undone_counts.entry(*undone).or_insert(0) += 1;
+    }
+    for (entity, name, undone, depth) in &reversion_matches {
+        let coherent = undone_counts.get(undone).copied().unwrap_or(0) >= 2;
+        let message = format!(
+            "Modified `{}` restores the exact body it had {} revision(s) ago{} — \
+             revert-shaped body reversion",
+            name,
+            depth,
+            if coherent {
+                ", together with other entities un-doing the same change"
+            } else {
+                ""
+            },
+        );
+        let mut finding = inline_finding(entity, message);
+        if !coherent {
+            finding.kind = InlineCommentKind::RevertHistoryIncidental;
+        }
+        findings.push(finding);
     }
 
     // Reintroductions: an added entity matching a window removal. Removed

--- a/crates/kin-review/src/revert_history.rs
+++ b/crates/kin-review/src/revert_history.rs
@@ -31,11 +31,13 @@
 //! base has less history than the window can meaningfully scan, the channel
 //! reports an honest evidence gap instead of silently passing.
 //!
-//! Matching is computed at review time from the change DAG and the entity
-//! revision store. Persisting the same evidence as graph relations
-//! (Reverts/RegressedBy edges written by an ingest-time miner) is the durable
-//! follow-on; the review-time computation here is the channel's semantic
-//! contract and stays the oracle for that miner.
+//! Matching is computed at review time exclusively from the base's ancestry
+//! window — the graph may hold changes outside the reviewed lineage (other
+//! branches, other reviews' hydrations, states newer than the head), and none
+//! of those may serve as evidence. Persisting the same evidence as graph
+//! relations (Reverts/RegressedBy edges written by an ingest-time miner) is
+//! the durable follow-on; the review-time computation here is the channel's
+//! semantic contract and stays the oracle for that miner.
 
 use std::collections::{BTreeMap, HashMap, HashSet, VecDeque};
 
@@ -56,11 +58,6 @@ const REVERT_HISTORY_WINDOW: usize = 250;
 /// about revert history, so the channel reports a gap rather than certifying
 /// silence.
 const REVERT_HISTORY_MIN_DEPTH: usize = 25;
-
-/// Upper bound on removed-entity resolutions per review. Each resolution is a
-/// revision-history lookup; windows are small in practice and this cap only
-/// guards pathological histories.
-const MAX_REMOVED_RESOLUTIONS: usize = 512;
 
 /// One removed-entity occurrence inside the scanned window.
 struct WindowRemoval {
@@ -127,11 +124,18 @@ pub(crate) fn collect_revert_history_findings<G: GraphStore>(
     // Body reversions: a modified entity whose NEW body equals a body it
     // carried at an OLDER revision — the head un-does a later edit. This is
     // the dominant real-world revert shape (git revert of a body change
-    // produces a Modified delta, not add/remove). The immediately-previous
-    // body is skipped: every edit trivially differs from its predecessor;
-    // only a return to DEEPER history is revert-shaped. Hash equality on the
+    // produces a Modified delta, not add/remove). Hash equality on the
     // behavior fingerprint makes the match exact, so this cannot fire on an
     // ordinary edit.
+    //
+    // Candidate bodies come ONLY from the base's ancestry window: each
+    // in-window change's pre-state for the entity (restoring it un-does that
+    // change). The graph at review time may also hold changes OUTSIDE this
+    // lineage — head-side commits, other branches, other reviews' hydrations,
+    // states newer than the head. A change made after the head trivially has
+    // the head's result as its pre-state, so consulting it would flag every
+    // entity that is ever edited again: evidence must never leave the base's
+    // causal past.
     //
     // Matches are grouped by the SEMANTIC CHANGE whose delta carried the
     // matching old body. A true revert restores a coherent snapshot: several
@@ -145,43 +149,14 @@ pub(crate) fn collect_revert_history_findings<G: GraphStore>(
         if new.fingerprint.behavior_hash == old.fingerprint.behavior_hash {
             continue;
         }
-        let history = match store.get_entity_history(&old.id) {
-            Ok(h) => h,
-            Err(_) => continue,
+        let Some(prior_bodies) = window.prior_bodies.get(&old.id) else {
+            continue;
         };
-        // Bodies this entity carried before the range, newest-first, capped by
-        // the window, each tagged with the change that introduced it. Position
-        // 0 is the body the range started from (old) — matching it would be a
-        // no-op edit, so matches start at depth 1.
-        let mut prior_bodies: Vec<(Hash256, SemanticChangeId)> = Vec::new();
-        for change in history.iter().rev() {
-            if prior_bodies.len() > REVERT_HISTORY_WINDOW {
-                break;
-            }
-            for delta in &change.entity_deltas {
-                match delta {
-                    EntityDelta::Modified { old: o, new: n } if n.id == old.id => {
-                        if prior_bodies.is_empty() {
-                            prior_bodies.push((n.fingerprint.behavior_hash, change.id));
-                        }
-                        // The OLD body was the entity's state BEFORE this
-                        // change; restoring it un-does this change.
-                        prior_bodies.push((o.fingerprint.behavior_hash, change.id));
-                    }
-                    EntityDelta::Added(e) if e.id == old.id && prior_bodies.is_empty() => {
-                        prior_bodies.push((e.fingerprint.behavior_hash, change.id));
-                    }
-                    _ => {}
-                }
-            }
-        }
-        if let Some((depth, (_, undone_change))) = prior_bodies
+        if let Some((distance, _, undone_change)) = prior_bodies
             .iter()
-            .enumerate()
-            .skip(1)
-            .find(|(_, (h, _))| *h == new.fingerprint.behavior_hash)
+            .find(|(_, hash, _)| *hash == new.fingerprint.behavior_hash)
         {
-            reversion_matches.push((new.clone(), name.clone(), *undone_change, depth));
+            reversion_matches.push((new.clone(), name.clone(), *undone_change, *distance));
         }
     }
 
@@ -195,14 +170,19 @@ pub(crate) fn collect_revert_history_findings<G: GraphStore>(
     for (_, _, undone, _) in &reversion_matches {
         *undone_counts.entry(*undone).or_insert(0) += 1;
     }
-    for (entity, name, undone, depth) in &reversion_matches {
+    for (entity, name, undone, distance) in &reversion_matches {
         let coherent = undone_counts.get(undone).copied().unwrap_or(0) >= 2;
         let gates = coherent && is_public_contract_leaf(entity);
+        let undone_phrase = if *distance == 0 {
+            "the base change".to_string()
+        } else {
+            format!("the change {} change(s) before the base", distance)
+        };
         let message = format!(
-            "Modified `{}` restores the exact body it had {} revision(s) ago{} — \
+            "Modified `{}` restores the exact body it had before {}{} — \
              revert-shaped body reversion",
             name,
-            depth,
+            undone_phrase,
             if coherent {
                 ", together with other entities un-doing the same change"
             } else {
@@ -219,19 +199,16 @@ pub(crate) fn collect_revert_history_findings<G: GraphStore>(
     }
 
     // Reintroductions: an added entity matching a window removal. Removed
-    // deltas carry only the id, so each candidate is resolved to its last full
-    // value through the revision history — lazily, nearest-first, and cached,
-    // so cost tracks matches rather than window size.
+    // deltas carry only the id, so each candidate resolves to the value the
+    // entity last carried inside the window — never a value from outside the
+    // base's lineage.
     if !head_added.is_empty() && !window.removals.is_empty() {
-        let mut resolved: HashMap<EntityId, Option<Entity>> = HashMap::new();
         let mut by_hash: HashMap<Hash256, (String, usize)> = HashMap::new();
         let mut by_name: HashMap<(String, String), usize> = HashMap::new();
-        let budget = window.removals.len().min(MAX_REMOVED_RESOLUTIONS);
-        for removal in window.removals.iter().take(budget) {
-            let entity = resolved
-                .entry(removal.entity_id)
-                .or_insert_with(|| last_known_entity(store, &removal.entity_id));
-            let Some(entity) = entity else { continue };
+        for removal in &window.removals {
+            let Some(entity) = window.values.get(&removal.entity_id) else {
+                continue;
+            };
             by_hash
                 .entry(entity.fingerprint.behavior_hash)
                 .or_insert((entity.name.clone(), removal.distance));
@@ -277,12 +254,11 @@ pub(crate) fn collect_revert_history_findings<G: GraphStore>(
     // revert shape where the added lines are deleted in place.
     for removed_id in &head_removed {
         if let Some(distance) = window.added_ids.get(removed_id) {
-            let removed = last_known_entity(store, removed_id);
+            let removed = window.values.get(removed_id);
             let name = removed
-                .as_ref()
                 .map(|e| e.name.clone())
                 .unwrap_or_else(|| "entity".to_string());
-            let gates = removed.as_ref().is_some_and(is_public_contract);
+            let gates = removed.is_some_and(is_public_contract);
             findings.push(InlineComment {
                 file: String::new(),
                 start_line: 0,
@@ -306,11 +282,19 @@ pub(crate) fn collect_revert_history_findings<G: GraphStore>(
 }
 
 /// Everything the channel learned from scanning the base's ancestry window.
+/// This is the channel's ONLY evidence source: nothing outside the base's
+/// causal past may influence a finding.
 struct BaseWindow {
     changes_scanned: usize,
     removals: Vec<WindowRemoval>,
     /// Entity ids ADDED inside the window, with their distance from the base.
     added_ids: HashMap<EntityId, usize>,
+    /// Per entity, the body it had BEFORE each in-window change that modified
+    /// it, in ascending distance from the base. Restoring one of these bodies
+    /// un-does the tagged change.
+    prior_bodies: HashMap<EntityId, Vec<(usize, Hash256, SemanticChangeId)>>,
+    /// The nearest-to-base full value each entity carried inside the window.
+    values: HashMap<EntityId, Entity>,
 }
 
 /// Bounded, deterministic walk of the base's ancestry: breadth-first from the
@@ -324,6 +308,9 @@ fn walk_base_window<G: GraphStore>(
 ) -> Result<BaseWindow, ReviewError> {
     let mut removals = Vec::new();
     let mut added_ids = HashMap::new();
+    let mut prior_bodies: HashMap<EntityId, Vec<(usize, Hash256, SemanticChangeId)>> =
+        HashMap::new();
+    let mut values: HashMap<EntityId, Entity> = HashMap::new();
     let mut visited: HashSet<SemanticChangeId> = HashSet::new();
     let mut queue: VecDeque<(SemanticChangeId, usize)> = VecDeque::new();
 
@@ -352,8 +339,18 @@ fn walk_base_window<G: GraphStore>(
                 }),
                 EntityDelta::Added(entity) => {
                     added_ids.entry(entity.id).or_insert(distance);
+                    values.entry(entity.id).or_insert_with(|| entity.clone());
                 }
-                EntityDelta::Modified { .. } => {}
+                EntityDelta::Modified { old, new } => {
+                    // The old body is the entity's state BEFORE this change;
+                    // a head restoring it un-does this change.
+                    let record = (distance, old.fingerprint.behavior_hash, change.id);
+                    prior_bodies.entry(new.id).or_default().push(record);
+                    if old.id != new.id {
+                        prior_bodies.entry(old.id).or_default().push(record);
+                    }
+                    values.entry(new.id).or_insert_with(|| new.clone());
+                }
             }
         }
         for parent in &change.parents {
@@ -365,20 +362,8 @@ fn walk_base_window<G: GraphStore>(
         changes_scanned: scanned,
         removals,
         added_ids,
-    })
-}
-
-/// The last full value an entity carried before disappearing, recovered from
-/// the changes that touched it: the most recent Added or Modified delta whose
-/// entity matches the id.
-fn last_known_entity<G: GraphStore>(store: &G, id: &EntityId) -> Option<Entity> {
-    let history = store.get_entity_history(id).ok()?;
-    history.iter().rev().find_map(|change| {
-        change.entity_deltas.iter().find_map(|delta| match delta {
-            EntityDelta::Added(e) if e.id == *id => Some(e.clone()),
-            EntityDelta::Modified { new, .. } if new.id == *id => Some(new.clone()),
-            _ => None,
-        })
+        prior_bodies,
+        values,
     })
 }
 

--- a/crates/kin-review/src/revert_history.rs
+++ b/crates/kin-review/src/revert_history.rs
@@ -1,0 +1,302 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Firelock, LLC
+
+//! Revert-history evidence channel for shadow review.
+//!
+//! A change that RE-INTRODUCES an entity removed in the recent past, or that
+//! REMOVES an entity introduced in the recent past, is revert-shaped: its risk
+//! evidence is temporal, not structural. Structurally such a change reads as an
+//! ordinary addition or removal — additions in particular carry no gating
+//! signal at all — so without this channel the gate is blind to exactly the
+//! class regression-fix and revert commits fall into.
+//!
+//! The channel walks a bounded window of the BASE ref's ancestry (evidence
+//! available at review time; whether a commit will be reverted LATER is future
+//! information and is never consulted) and matches:
+//!
+//! - head-side ADDED entities against entities removed inside the window —
+//!   a behavior-fingerprint match means the added body restores removed
+//!   content verbatim (strong); a name+kind match means the same surface is
+//!   reintroduced with modified content (weak). Both are review-worthy.
+//! - head-side REMOVED entities against entities added inside the window —
+//!   deleting something that only just landed is the shape of a revert of a
+//!   recent feature.
+//!
+//! Findings feed the gate as ordinary warning findings through the
+//! inline-comment channel (the same shape as the command-effect and
+//! toolchain-surface channels), never through evidence-gap demotion. When the
+//! base has less history than the window can meaningfully scan, the channel
+//! reports an honest evidence gap instead of silently passing.
+//!
+//! Matching is computed at review time from the change DAG and the entity
+//! revision store. Persisting the same evidence as graph relations
+//! (Reverts/RegressedBy edges written by an ingest-time miner) is the durable
+//! follow-on; the review-time computation here is the channel's semantic
+//! contract and stays the oracle for that miner.
+
+use std::collections::{BTreeMap, HashMap, HashSet, VecDeque};
+
+use kin_model::change::{EntityDelta, SemanticChange};
+use kin_model::graph::GraphStore;
+use kin_model::{Entity, EntityId, EntityKind, Hash256, SemanticChangeId};
+
+use crate::error::ReviewError;
+use crate::inline::{InlineComment, InlineCommentKind};
+use crate::shadow::ShadowEvidenceGap;
+
+/// How many ancestry changes before the base the channel scans. Deep enough to
+/// catch release-cycle reverts and regression fixes; bounded so review cost
+/// stays flat on large histories.
+const REVERT_HISTORY_WINDOW: usize = 250;
+
+/// Below this much available ancestry the scan cannot say anything meaningful
+/// about revert history, so the channel reports a gap rather than certifying
+/// silence.
+const REVERT_HISTORY_MIN_DEPTH: usize = 25;
+
+/// Upper bound on removed-entity resolutions per review. Each resolution is a
+/// revision-history lookup; windows are small in practice and this cap only
+/// guards pathological histories.
+const MAX_REMOVED_RESOLUTIONS: usize = 512;
+
+/// One removed-entity occurrence inside the scanned window.
+struct WindowRemoval {
+    entity_id: EntityId,
+    /// 1-based distance from the base (1 = the change immediately before base).
+    distance: usize,
+}
+
+/// Revert-history findings plus an optional honesty gap for the scanned base.
+pub(crate) fn collect_revert_history_findings<G: GraphStore>(
+    store: &G,
+    resolved_base: &SemanticChangeId,
+    range_changes: &[SemanticChange],
+) -> Result<(Vec<InlineComment>, Option<ShadowEvidenceGap>), ReviewError> {
+    let window = walk_base_window(store, resolved_base)?;
+
+    let gap = if window.changes_scanned < REVERT_HISTORY_MIN_DEPTH {
+        Some(ShadowEvidenceGap {
+            kind: "revert_history_shallow".to_string(),
+            subject: "blast_radius.revert_history".to_string(),
+            detail: format!(
+                "only {} change(s) of history exist before the base (window {}); \
+                 revert/reintroduction evidence cannot be assessed and is NOT part \
+                 of this verdict",
+                window.changes_scanned, REVERT_HISTORY_WINDOW
+            ),
+        })
+    } else {
+        None
+    };
+
+    // Head-side deltas for the reviewed range, deduplicated and order-stable.
+    let mut head_added: BTreeMap<(String, String), Entity> = BTreeMap::new();
+    let mut head_removed: Vec<EntityId> = Vec::new();
+    let mut seen_removed: HashSet<EntityId> = HashSet::new();
+    for change in range_changes {
+        for delta in &change.entity_deltas {
+            match delta {
+                EntityDelta::Added(entity) => {
+                    head_added
+                        .entry((kind_key(entity.kind), entity.name.clone()))
+                        .or_insert_with(|| entity.clone());
+                }
+                EntityDelta::Removed(id) => {
+                    if seen_removed.insert(*id) {
+                        head_removed.push(*id);
+                    }
+                }
+                EntityDelta::Modified { .. } => {}
+            }
+        }
+    }
+
+    let mut findings = Vec::new();
+
+    // Reintroductions: an added entity matching a window removal. Removed
+    // deltas carry only the id, so each candidate is resolved to its last full
+    // value through the revision history — lazily, nearest-first, and cached,
+    // so cost tracks matches rather than window size.
+    if !head_added.is_empty() && !window.removals.is_empty() {
+        let mut resolved: HashMap<EntityId, Option<Entity>> = HashMap::new();
+        let mut by_hash: HashMap<Hash256, (String, usize)> = HashMap::new();
+        let mut by_name: HashMap<(String, String), usize> = HashMap::new();
+        let budget = window.removals.len().min(MAX_REMOVED_RESOLUTIONS);
+        for removal in window.removals.iter().take(budget) {
+            let entity = resolved
+                .entry(removal.entity_id)
+                .or_insert_with(|| last_known_entity(store, &removal.entity_id));
+            let Some(entity) = entity else { continue };
+            by_hash
+                .entry(entity.fingerprint.behavior_hash)
+                .or_insert((entity.name.clone(), removal.distance));
+            by_name
+                .entry((kind_key(entity.kind), entity.name.clone()))
+                .or_insert(removal.distance);
+        }
+
+        for ((kind, name), added) in &head_added {
+            let finding = if let Some((removed_name, distance)) =
+                by_hash.get(&added.fingerprint.behavior_hash)
+            {
+                Some(format!(
+                    "Added `{}` restores the exact content of `{}`, removed {} change(s) \
+                     before the base — revert-shaped reintroduction",
+                    name, removed_name, distance
+                ))
+            } else {
+                by_name.get(&(kind.clone(), name.clone())).map(|distance| {
+                    format!(
+                        "Added `{}` reintroduces a same-named {} removed {} change(s) \
+                         before the base, with modified content — revert-shaped surface",
+                        name,
+                        kind_label(added.kind),
+                        distance
+                    )
+                })
+            };
+            if let Some(message) = finding {
+                findings.push(inline_finding(added, message));
+            }
+        }
+    }
+
+    // Recent-addition removals: a removed entity whose id was introduced
+    // inside the window. Ids are location-keyed, so this matches the common
+    // revert shape where the added lines are deleted in place.
+    for removed_id in &head_removed {
+        if let Some(distance) = window.added_ids.get(removed_id) {
+            let name = last_known_entity(store, removed_id)
+                .map(|e| e.name)
+                .unwrap_or_else(|| "entity".to_string());
+            findings.push(InlineComment {
+                file: String::new(),
+                start_line: 0,
+                end_line: 0,
+                kind: InlineCommentKind::RevertHistory,
+                message: format!(
+                    "Removed `{}` was introduced only {} change(s) before the base — \
+                     revert-shaped removal of a recent addition",
+                    name, distance
+                ),
+            });
+        }
+    }
+
+    Ok((findings, gap))
+}
+
+/// Everything the channel learned from scanning the base's ancestry window.
+struct BaseWindow {
+    changes_scanned: usize,
+    removals: Vec<WindowRemoval>,
+    /// Entity ids ADDED inside the window, with their distance from the base.
+    added_ids: HashMap<EntityId, usize>,
+}
+
+/// Bounded, deterministic walk of the base's ancestry: breadth-first from the
+/// base's parents, parents visited in their declared order, capped at
+/// [`REVERT_HISTORY_WINDOW`] changes. Distance is the BFS depth, so "N
+/// change(s) before the base" reads naturally on linear history and stays
+/// deterministic across merges.
+fn walk_base_window<G: GraphStore>(
+    store: &G,
+    resolved_base: &SemanticChangeId,
+) -> Result<BaseWindow, ReviewError> {
+    let mut removals = Vec::new();
+    let mut added_ids = HashMap::new();
+    let mut visited: HashSet<SemanticChangeId> = HashSet::new();
+    let mut queue: VecDeque<(SemanticChangeId, usize)> = VecDeque::new();
+
+    if let Some(base) = store
+        .get_change(resolved_base)
+        .map_err(ReviewError::graph)?
+    {
+        for parent in &base.parents {
+            queue.push_back((*parent, 1));
+        }
+    }
+    visited.insert(*resolved_base);
+
+    let mut scanned = 0usize;
+    while let Some((id, distance)) = queue.pop_front() {
+        if scanned >= REVERT_HISTORY_WINDOW {
+            break;
+        }
+        if !visited.insert(id) {
+            continue;
+        }
+        let Some(change) = store.get_change(&id).map_err(ReviewError::graph)? else {
+            continue;
+        };
+        scanned += 1;
+        for delta in &change.entity_deltas {
+            match delta {
+                EntityDelta::Removed(entity_id) => removals.push(WindowRemoval {
+                    entity_id: *entity_id,
+                    distance,
+                }),
+                EntityDelta::Added(entity) => {
+                    added_ids.entry(entity.id).or_insert(distance);
+                }
+                EntityDelta::Modified { .. } => {}
+            }
+        }
+        for parent in &change.parents {
+            queue.push_back((*parent, distance + 1));
+        }
+    }
+
+    Ok(BaseWindow {
+        changes_scanned: scanned,
+        removals,
+        added_ids,
+    })
+}
+
+/// The last full value an entity carried before disappearing, recovered from
+/// the changes that touched it: the most recent Added or Modified delta whose
+/// entity matches the id.
+fn last_known_entity<G: GraphStore>(store: &G, id: &EntityId) -> Option<Entity> {
+    let history = store.get_entity_history(id).ok()?;
+    history.iter().rev().find_map(|change| {
+        change.entity_deltas.iter().find_map(|delta| match delta {
+            EntityDelta::Added(e) if e.id == *id => Some(e.clone()),
+            EntityDelta::Modified { new, .. } if new.id == *id => Some(new.clone()),
+            _ => None,
+        })
+    })
+}
+
+fn inline_finding(entity: &Entity, message: String) -> InlineComment {
+    let (file, start_line, end_line) = match (&entity.file_origin, &entity.span) {
+        (Some(file), Some(span)) => (file.0.clone(), span.start_line, span.end_line),
+        (Some(file), None) => (file.0.clone(), 0, 0),
+        _ => (String::new(), 0, 0),
+    };
+    InlineComment {
+        file,
+        start_line,
+        end_line,
+        kind: InlineCommentKind::RevertHistory,
+        message,
+    }
+}
+
+/// Stable string key for an entity kind (EntityKind carries no Ord).
+fn kind_key(kind: EntityKind) -> String {
+    format!("{:?}", kind)
+}
+
+fn kind_label(kind: EntityKind) -> &'static str {
+    match kind {
+        EntityKind::Function => "function",
+        EntityKind::Method => "method",
+        EntityKind::Class => "class",
+        EntityKind::Interface => "interface",
+        EntityKind::TraitDef => "trait",
+        EntityKind::Module => "module",
+        EntityKind::Constant => "constant",
+        _ => "entity",
+    }
+}

--- a/crates/kin-review/src/revert_history.rs
+++ b/crates/kin-review/src/revert_history.rs
@@ -10,9 +10,12 @@
 //! signal at all — so without this channel the gate is blind to exactly the
 //! class regression-fix and revert commits fall into.
 //!
-//! The channel walks a bounded window of the BASE ref's ancestry (evidence
-//! available at review time; whether a commit will be reverted LATER is future
-//! information and is never consulted) and matches:
+//! The channel walks a bounded window of the BASE ref's ancestry — including
+//! the base change itself, whose deltas are part of the state the head builds
+//! on (reverting the immediately-preceding change is the most common revert
+//! shape). Only evidence available at review time is consulted; whether a
+//! commit will be reverted LATER is future information and never enters. It
+//! matches:
 //!
 //! - head-side ADDED entities against entities removed inside the window —
 //!   a behavior-fingerprint match means the added body restores removed
@@ -140,18 +143,20 @@ pub(crate) fn collect_revert_history_findings<G: GraphStore>(
                 by_hash.get(&added.fingerprint.behavior_hash)
             {
                 Some(format!(
-                    "Added `{}` restores the exact content of `{}`, removed {} change(s) \
-                     before the base — revert-shaped reintroduction",
-                    name, removed_name, distance
+                    "Added `{}` restores the exact content of `{}`, removed {} — \
+                     revert-shaped reintroduction",
+                    name,
+                    removed_name,
+                    distance_phrase(*distance)
                 ))
             } else {
                 by_name.get(&(kind.clone(), name.clone())).map(|distance| {
                     format!(
-                        "Added `{}` reintroduces a same-named {} removed {} change(s) \
-                         before the base, with modified content — revert-shaped surface",
+                        "Added `{}` reintroduces a same-named {} removed {}, with \
+                         modified content — revert-shaped surface",
                         name,
                         kind_label(added.kind),
-                        distance
+                        distance_phrase(*distance)
                     )
                 })
             };
@@ -175,9 +180,10 @@ pub(crate) fn collect_revert_history_findings<G: GraphStore>(
                 end_line: 0,
                 kind: InlineCommentKind::RevertHistory,
                 message: format!(
-                    "Removed `{}` was introduced only {} change(s) before the base — \
-                     revert-shaped removal of a recent addition",
-                    name, distance
+                    "Removed `{}` was introduced only {} — revert-shaped removal \
+                     of a recent addition",
+                    name,
+                    distance_phrase(*distance)
                 ),
             });
         }
@@ -208,15 +214,10 @@ fn walk_base_window<G: GraphStore>(
     let mut visited: HashSet<SemanticChangeId> = HashSet::new();
     let mut queue: VecDeque<(SemanticChangeId, usize)> = VecDeque::new();
 
-    if let Some(base) = store
-        .get_change(resolved_base)
-        .map_err(ReviewError::graph)?
-    {
-        for parent in &base.parents {
-            queue.push_back((*parent, 1));
-        }
-    }
-    visited.insert(*resolved_base);
+    // The base change itself is scanned at distance 0: its deltas are part of
+    // the state the head builds on, and reverting the immediately-preceding
+    // change is the most common revert shape.
+    queue.push_back((*resolved_base, 0));
 
     let mut scanned = 0usize;
     while let Some((id, distance)) = queue.pop_front() {
@@ -286,6 +287,15 @@ fn inline_finding(entity: &Entity, message: String) -> InlineComment {
 /// Stable string key for an entity kind (EntityKind carries no Ord).
 fn kind_key(kind: EntityKind) -> String {
     format!("{:?}", kind)
+}
+
+/// Human phrase for a window distance: the base change itself is distance 0.
+fn distance_phrase(distance: usize) -> String {
+    if distance == 0 {
+        "in the base change itself".to_string()
+    } else {
+        format!("{} change(s) before the base", distance)
+    }
 }
 
 fn kind_label(kind: EntityKind) -> &'static str {

--- a/crates/kin-review/src/revert_history.rs
+++ b/crates/kin-review/src/revert_history.rs
@@ -187,6 +187,14 @@ pub(crate) fn collect_revert_history_findings<G: GraphStore>(
         }
     }
 
+    // Body reversions are REPORTED, never verdict-driving. The 60-benign
+    // sweep measured why: a module entity is a content aggregate of its file,
+    // so any single-function reversion makes the module co-revert to the same
+    // change by construction — "coherence" of two entities is nearly free, and
+    // gating on it re-flagged ~a third of clean benigns. The temporal evidence
+    // stays visible to reviewers (and to future evidence-composition in
+    // ranking) at info severity; coherence is still computed because it is the
+    // strongest hint in the message.
     let mut undone_counts: HashMap<SemanticChangeId, usize> = HashMap::new();
     for (_, _, undone, _) in &reversion_matches {
         *undone_counts.entry(*undone).or_insert(0) += 1;
@@ -205,9 +213,7 @@ pub(crate) fn collect_revert_history_findings<G: GraphStore>(
             },
         );
         let mut finding = inline_finding(entity, message);
-        if !coherent {
-            finding.kind = InlineCommentKind::RevertHistoryIncidental;
-        }
+        finding.kind = InlineCommentKind::RevertHistoryIncidental;
         findings.push(finding);
     }
 

--- a/crates/kin-review/src/shadow.rs
+++ b/crates/kin-review/src/shadow.rs
@@ -518,6 +518,19 @@ fn assemble_report_with_changes<G: GraphStore>(
     // Toolchain-surface findings feed the gate as ordinary warning findings via
     // the inline-comment channel, never through the evidence-gap demotion path.
     review.inline_comments.extend(toolchain_findings);
+    // Revert-history findings feed the gate the same way: ordinary warning
+    // findings, with an honest gap when the base has too little history to
+    // scan. Temporal evidence available at review time only — the window looks
+    // strictly BEFORE the base.
+    let (revert_findings, revert_gap) = crate::revert_history::collect_revert_history_findings(
+        store,
+        &request.resolved_base,
+        changes,
+    )?;
+    review.inline_comments.extend(revert_findings);
+    if let Some(gap) = revert_gap {
+        evidence_gaps.push(gap);
+    }
     let policy = derive_policy(&review, &evidence_gaps, &changed_entities);
     let repair_context = collect_repair_context(&policy.findings, &review);
     let audit = collect_audit_evidence(store, request, &review, changes.len())?;
@@ -724,6 +737,7 @@ fn finding_kind_label(kind: InlineCommentKind) -> &'static str {
         InlineCommentKind::Renamed => "entity_renamed",
         InlineCommentKind::AgentUnreviewed => "agent_unreviewed",
         InlineCommentKind::ToolchainSurfaceChange => "toolchain_surface_change",
+        InlineCommentKind::RevertHistory => "revert_history",
     }
 }
 
@@ -737,7 +751,8 @@ fn finding_severity(kind: InlineCommentKind) -> &'static str {
         | InlineCommentKind::ConsumerFanout
         | InlineCommentKind::Renamed
         | InlineCommentKind::AgentUnreviewed
-        | InlineCommentKind::ToolchainSurfaceChange => "warning",
+        | InlineCommentKind::ToolchainSurfaceChange
+        | InlineCommentKind::RevertHistory => "warning",
         InlineCommentKind::Added | InlineCommentKind::Removed => "info",
     }
 }
@@ -1106,6 +1121,11 @@ fn repair_guidance(kind: &str) -> &'static str {
         "downstream_risk" => {
             "The contract surface changed with graph-known downstream entities; verify each \
              listed dependent and consumer, then run the covering tests."
+        }
+        "revert_history" => {
+            "This change is revert-shaped: it reintroduces or removes recently-changed \
+             history. Confirm the original removal/addition was wrong before merging, and \
+             check the linked history for the regression the earlier change addressed."
         }
         "toolchain_surface_change" => {
             "Inline lint or deprecation directives changed; confirm the shift in toolchain \
@@ -3534,6 +3554,193 @@ mod tests {
         assert!(
             findings_no_blob.is_empty(),
             "without a blob reader the toolchain channel emits nothing"
+        );
+    }
+
+    /// Chain of `n` changes: c1 applies `first_deltas`, c2 applies
+    /// `second_deltas`, the rest are empty padding so the revert-history window
+    /// sees enough depth to scan without reporting the shallow-history gap.
+    fn padded_history_graph(
+        graph: &InMemoryGraph,
+        first_deltas: Vec<EntityDelta>,
+        second_deltas: Vec<EntityDelta>,
+        n: u8,
+    ) -> SemanticChangeId {
+        let mut prev: Option<SemanticChangeId> = None;
+        for i in 1..=n {
+            let deltas = match i {
+                1 => first_deltas.clone(),
+                2 => second_deltas.clone(),
+                _ => vec![],
+            };
+            let change = change_with_deltas(
+                change_id(i),
+                prev.map(|p| vec![p]).unwrap_or_default(),
+                deltas,
+                vec![],
+                vec![],
+            );
+            graph.create_change(&change).unwrap();
+            prev = Some(change_id(i));
+        }
+        prev.expect("chain is non-empty")
+    }
+
+    #[test]
+    fn revert_history_reintroduction_flags_needs_attention() {
+        // c1 adds `retry_budget`, c2 removes it, padding to depth 30, then the
+        // head re-adds an entity with the SAME behavior fingerprint at a new
+        // location. The channel must call out the revert-shaped reintroduction
+        // and move the verdict to needs_attention.
+        let graph = InMemoryGraph::new();
+        let mut original = entity_with_span("retry_budget", "src/net.rs", 40, EntityRole::Source);
+        original.fingerprint.behavior_hash = Hash256::from_bytes([7; 32]);
+        let mut readded = original.clone();
+        readded.id = EntityId::from_content("src/net.rs", "retry_budget", "Function", 77);
+        let base_id = padded_history_graph(
+            &graph,
+            vec![EntityDelta::Added(original.clone())],
+            vec![EntityDelta::Removed(original.id)],
+            30,
+        );
+        graph.upsert_entity(&readded).unwrap();
+        let head_id = change_id(200);
+        let head = change_with_deltas(
+            head_id,
+            vec![base_id],
+            vec![EntityDelta::Added(readded.clone())],
+            vec![],
+            vec![],
+        );
+        graph.create_change(&head).unwrap();
+
+        let report = build_shadow_report(&graph, &request(base_id, head_id)).unwrap();
+        let finding = report
+            .policy
+            .findings
+            .iter()
+            .find(|f| f.kind == "revert_history")
+            .expect("reintroduction must produce a revert_history finding");
+        assert!(
+            finding.message.contains("restores the exact content"),
+            "fingerprint match must report the strong form, got: {}",
+            finding.message
+        );
+        assert_eq!(report.policy.verdict, ShadowGateVerdict::NeedsAttention);
+        assert!(
+            !report
+                .evidence_gaps
+                .iter()
+                .any(|g| g.kind == "revert_history_shallow"),
+            "30 changes of history must not report the shallow gap"
+        );
+    }
+
+    #[test]
+    fn revert_history_recent_addition_removal_flags() {
+        // c2 adds `beta_flag`; the head removes that exact entity id. Deleting
+        // something that only just landed is revert-shaped and must be called
+        // out even though a bare removal of an unconsumed entity would
+        // otherwise stay quiet.
+        let graph = InMemoryGraph::new();
+        let recent = entity_with_span("beta_flag", "src/flags.rs", 12, EntityRole::Source);
+        let base_id =
+            padded_history_graph(&graph, vec![], vec![EntityDelta::Added(recent.clone())], 30);
+        let head_id = change_id(201);
+        let head = change_with_deltas(
+            head_id,
+            vec![base_id],
+            vec![EntityDelta::Removed(recent.id)],
+            vec![],
+            vec![],
+        );
+        graph.create_change(&head).unwrap();
+
+        let report = build_shadow_report(&graph, &request(base_id, head_id)).unwrap();
+        let finding = report
+            .policy
+            .findings
+            .iter()
+            .find(|f| f.kind == "revert_history")
+            .expect("recent-addition removal must produce a revert_history finding");
+        assert!(
+            finding.message.contains("revert-shaped removal"),
+            "got: {}",
+            finding.message
+        );
+    }
+
+    #[test]
+    fn fresh_addition_produces_no_revert_history_finding() {
+        // History contains an unrelated removal; the head adds a brand-new
+        // entity. No temporal match exists, so the channel must stay silent —
+        // fresh additions are the benign default this channel must never tax.
+        let graph = InMemoryGraph::new();
+        let mut unrelated = entity_with_span("old_helper", "src/util.rs", 9, EntityRole::Source);
+        unrelated.fingerprint.behavior_hash = Hash256::from_bytes([9; 32]);
+        let fresh = entity_with_span("brand_new_api", "src/api.rs", 21, EntityRole::Source);
+        let base_id = padded_history_graph(
+            &graph,
+            vec![EntityDelta::Added(unrelated.clone())],
+            vec![EntityDelta::Removed(unrelated.id)],
+            30,
+        );
+        graph.upsert_entity(&fresh).unwrap();
+        let head_id = change_id(202);
+        let head = change_with_deltas(
+            head_id,
+            vec![base_id],
+            vec![EntityDelta::Added(fresh)],
+            vec![],
+            vec![],
+        );
+        graph.create_change(&head).unwrap();
+
+        let report = build_shadow_report(&graph, &request(base_id, head_id)).unwrap();
+        assert!(
+            !report
+                .policy
+                .findings
+                .iter()
+                .any(|f| f.kind == "revert_history"),
+            "a fresh addition must not read as revert-shaped"
+        );
+    }
+
+    #[test]
+    fn shallow_history_reports_honest_gap() {
+        // Two changes of history is not enough to assess revert evidence: the
+        // channel must say so through an evidence gap instead of certifying
+        // silence, and must not invent findings.
+        let graph = InMemoryGraph::new();
+        let fresh = entity_with_span("early_api", "src/api.rs", 5, EntityRole::Source);
+        let base_id = padded_history_graph(&graph, vec![], vec![], 2);
+        graph.upsert_entity(&fresh).unwrap();
+        let head_id = change_id(203);
+        let head = change_with_deltas(
+            head_id,
+            vec![base_id],
+            vec![EntityDelta::Added(fresh)],
+            vec![],
+            vec![],
+        );
+        graph.create_change(&head).unwrap();
+
+        let report = build_shadow_report(&graph, &request(base_id, head_id)).unwrap();
+        assert!(
+            report
+                .evidence_gaps
+                .iter()
+                .any(|g| g.kind == "revert_history_shallow"),
+            "shallow history must surface the honesty gap"
+        );
+        assert!(
+            !report
+                .policy
+                .findings
+                .iter()
+                .any(|f| f.kind == "revert_history"),
+            "no finding may be invented from unscannable history"
         );
     }
 }

--- a/crates/kin-review/src/shadow.rs
+++ b/crates/kin-review/src/shadow.rs
@@ -3899,7 +3899,7 @@ mod tests {
     }
 
     #[test]
-    fn coherent_body_reversion_group_gates() {
+    fn coherent_body_reversion_group_reports_without_gating() {
         // Two entities whose new bodies both restore states un-done by the
         // SAME historical change: a coherent snapshot restoration — the true
         // revert shape — gates as a warning.
@@ -3970,16 +3970,20 @@ mod tests {
         graph.create_change(&head).unwrap();
 
         let report = build_shadow_report(&graph, &request(base_id, head_id)).unwrap();
-        let gating: Vec<_> = report
+        // Body reversions never gate — the 60-benign sweep measured module
+        // co-reversion making two-entity "coherence" nearly free on real
+        // repos, re-flagging ~a third of clean benigns. The evidence is still
+        // reported, carrying the coherence hint for the reviewer.
+        let informational: Vec<_> = report
             .policy
             .findings
             .iter()
-            .filter(|f| f.kind == "revert_history")
+            .filter(|f| f.kind == "revert_history_incidental")
             .collect();
         assert_eq!(
-            gating.len(),
+            informational.len(),
             2,
-            "both coherent reversions must gate, got findings: {:?}",
+            "both reversions must be reported, got findings: {:?}",
             report
                 .policy
                 .findings
@@ -3987,8 +3991,10 @@ mod tests {
                 .map(|f| (&f.kind, &f.message))
                 .collect::<Vec<_>>()
         );
-        assert!(gating.iter().all(|f| f.severity == "warning"));
-        assert!(gating[0].message.contains("un-doing the same change"));
-        assert_eq!(report.policy.verdict, ShadowGateVerdict::NeedsAttention);
+        assert!(informational.iter().all(|f| f.severity == "info"));
+        assert!(informational[0]
+            .message
+            .contains("un-doing the same change"));
+        assert_eq!(report.policy.verdict, ShadowGateVerdict::Pass);
     }
 }

--- a/crates/kin-review/src/shadow.rs
+++ b/crates/kin-review/src/shadow.rs
@@ -3743,4 +3743,55 @@ mod tests {
             "no finding may be invented from unscannable history"
         );
     }
+
+    #[test]
+    fn revert_of_the_base_change_itself_flags() {
+        // The most common revert shape: the head reverts exactly the change at
+        // the base — the removal lives in the base change's own deltas, which
+        // are part of the state the head builds on and must be scanned.
+        let graph = InMemoryGraph::new();
+        let mut original = entity_with_span("retry_budget", "src/net.rs", 40, EntityRole::Source);
+        original.fingerprint.behavior_hash = Hash256::from_bytes([5; 32]);
+        let mut readded = original.clone();
+        readded.id = EntityId::from_content("src/net2.rs", "retry_budget", "Function", 8);
+        // 29 pads, then the base change REMOVES the entity, then head re-adds.
+        let pad_tail = padded_history_graph(
+            &graph,
+            vec![EntityDelta::Added(original.clone())],
+            vec![],
+            29,
+        );
+        let base_id = change_id(150);
+        let base = change_with_deltas(
+            base_id,
+            vec![pad_tail],
+            vec![EntityDelta::Removed(original.id)],
+            vec![],
+            vec![],
+        );
+        graph.create_change(&base).unwrap();
+        graph.upsert_entity(&readded).unwrap();
+        let head_id = change_id(151);
+        let head = change_with_deltas(
+            head_id,
+            vec![base_id],
+            vec![EntityDelta::Added(readded)],
+            vec![],
+            vec![],
+        );
+        graph.create_change(&head).unwrap();
+
+        let report = build_shadow_report(&graph, &request(base_id, head_id)).unwrap();
+        let finding = report
+            .policy
+            .findings
+            .iter()
+            .find(|f| f.kind == "revert_history")
+            .expect("a revert of the base change itself must flag");
+        assert!(
+            finding.message.contains("in the base change itself"),
+            "distance-0 phrasing expected, got: {}",
+            finding.message
+        );
+    }
 }

--- a/crates/kin-review/src/shadow.rs
+++ b/crates/kin-review/src/shadow.rs
@@ -738,6 +738,7 @@ fn finding_kind_label(kind: InlineCommentKind) -> &'static str {
         InlineCommentKind::AgentUnreviewed => "agent_unreviewed",
         InlineCommentKind::ToolchainSurfaceChange => "toolchain_surface_change",
         InlineCommentKind::RevertHistory => "revert_history",
+        InlineCommentKind::RevertHistoryIncidental => "revert_history_incidental",
     }
 }
 
@@ -753,6 +754,7 @@ fn finding_severity(kind: InlineCommentKind) -> &'static str {
         | InlineCommentKind::AgentUnreviewed
         | InlineCommentKind::ToolchainSurfaceChange
         | InlineCommentKind::RevertHistory => "warning",
+        InlineCommentKind::RevertHistoryIncidental => "info",
         InlineCommentKind::Added | InlineCommentKind::Removed => "info",
     }
 }
@@ -1121,6 +1123,10 @@ fn repair_guidance(kind: &str) -> &'static str {
         "downstream_risk" => {
             "The contract surface changed with graph-known downstream entities; verify each \
              listed dependent and consumer, then run the covering tests."
+        }
+        "revert_history_incidental" => {
+            "One entity's body matches an older revision — often incidental on small \
+             bodies; worth a glance at the linked history, not a gate."
         }
         "revert_history" => {
             "This change is revert-shaped: it reintroduces or removes recently-changed \
@@ -3831,16 +3837,29 @@ mod tests {
         graph.create_change(&head).unwrap();
 
         let report = build_shadow_report(&graph, &request(pad_tail, head_id)).unwrap();
+        // A single entity reverting is incidental: reported at info severity,
+        // never verdict-driving (small bodies recur naturally in long
+        // histories — the v7 backtest measured 5/6 benign regressions when
+        // singletons gated).
         let finding = report
             .policy
             .findings
             .iter()
-            .find(|f| f.kind == "revert_history")
-            .expect("a body reversion to an older revision must flag");
+            .find(|f| f.kind == "revert_history_incidental")
+            .expect("a lone body reversion must surface as incidental");
         assert!(
             finding.message.contains("revert-shaped body reversion"),
             "got: {}",
             finding.message
+        );
+        assert_eq!(finding.severity, "info");
+        assert!(
+            !report
+                .policy
+                .findings
+                .iter()
+                .any(|f| f.kind == "revert_history"),
+            "a lone body reversion must not produce the gating kind"
         );
 
         // Control: an ordinary forward edit must not produce the finding.
@@ -3877,5 +3896,99 @@ mod tests {
                 .any(|f| f.kind == "revert_history"),
             "an ordinary forward edit must not read as a body reversion"
         );
+    }
+
+    #[test]
+    fn coherent_body_reversion_group_gates() {
+        // Two entities whose new bodies both restore states un-done by the
+        // SAME historical change: a coherent snapshot restoration — the true
+        // revert shape — gates as a warning.
+        let graph = InMemoryGraph::new();
+        let mut a1 = entity_with_span("alpha", "src/a.rs", 5, EntityRole::Source);
+        a1.fingerprint.behavior_hash = Hash256::from_bytes([11; 32]);
+        let mut b1 = entity_with_span("beta", "src/b.rs", 9, EntityRole::Source);
+        b1.fingerprint.behavior_hash = Hash256::from_bytes([21; 32]);
+        let mut a2 = a1.clone();
+        a2.fingerprint.behavior_hash = Hash256::from_bytes([12; 32]);
+        let mut b2 = b1.clone();
+        b2.fingerprint.behavior_hash = Hash256::from_bytes([22; 32]);
+
+        // c1 adds both; c2 edits BOTH (the change the head un-does); padding.
+        let mut prev: Option<SemanticChangeId> = None;
+        for i in 1..=30u8 {
+            let deltas = match i {
+                1 => vec![
+                    EntityDelta::Added(a1.clone()),
+                    EntityDelta::Added(b1.clone()),
+                ],
+                2 => vec![
+                    EntityDelta::Modified {
+                        old: a1.clone(),
+                        new: a2.clone(),
+                    },
+                    EntityDelta::Modified {
+                        old: b1.clone(),
+                        new: b2.clone(),
+                    },
+                ],
+                _ => vec![],
+            };
+            let change = change_with_deltas(
+                change_id(i),
+                prev.map(|p| vec![p]).unwrap_or_default(),
+                deltas,
+                vec![],
+                vec![],
+            );
+            graph.create_change(&change).unwrap();
+            prev = Some(change_id(i));
+        }
+        let base_id = prev.unwrap();
+        let mut a_back = a2.clone();
+        a_back.fingerprint.behavior_hash = Hash256::from_bytes([11; 32]);
+        let mut b_back = b2.clone();
+        b_back.fingerprint.behavior_hash = Hash256::from_bytes([21; 32]);
+        graph.upsert_entity(&a_back).unwrap();
+        graph.upsert_entity(&b_back).unwrap();
+        let head_id = change_id(220);
+        let head = change_with_deltas(
+            head_id,
+            vec![base_id],
+            vec![
+                EntityDelta::Modified {
+                    old: a2.clone(),
+                    new: a_back,
+                },
+                EntityDelta::Modified {
+                    old: b2.clone(),
+                    new: b_back,
+                },
+            ],
+            vec![],
+            vec![],
+        );
+        graph.create_change(&head).unwrap();
+
+        let report = build_shadow_report(&graph, &request(base_id, head_id)).unwrap();
+        let gating: Vec<_> = report
+            .policy
+            .findings
+            .iter()
+            .filter(|f| f.kind == "revert_history")
+            .collect();
+        assert_eq!(
+            gating.len(),
+            2,
+            "both coherent reversions must gate, got findings: {:?}",
+            report
+                .policy
+                .findings
+                .iter()
+                .map(|f| (&f.kind, &f.message))
+                .collect::<Vec<_>>()
+        );
+        assert!(gating.iter().all(|f| f.severity == "warning"));
+        assert!(gating[0].message.contains("un-doing the same change"));
+        assert_eq!(report.policy.verdict, ShadowGateVerdict::NeedsAttention);
     }
 }

--- a/crates/kin-review/src/shadow.rs
+++ b/crates/kin-review/src/shadow.rs
@@ -4081,4 +4081,141 @@ mod tests {
         );
         assert_eq!(report.policy.verdict, ShadowGateVerdict::Pass);
     }
+
+    #[test]
+    fn future_change_never_supplies_prior_bodies() {
+        // A change made AFTER the head trivially has the head's result as its
+        // pre-state, so a graph holding changes newer than the reviewed head
+        // (other reviews' hydrations, a warmed shared graph) must never let
+        // them serve as "prior" bodies: that reads the head's own future back
+        // as revert evidence.
+        let graph = InMemoryGraph::new();
+        let mut v1 = entity_with_span("gamma", "src/g.rs", 5, EntityRole::Source);
+        v1.fingerprint.behavior_hash = Hash256::from_bytes([31; 32]);
+        let mut v2 = v1.clone();
+        v2.fingerprint.behavior_hash = Hash256::from_bytes([32; 32]);
+        let pad_tail = padded_history_graph(
+            &graph,
+            vec![EntityDelta::Added(v1.clone())],
+            vec![EntityDelta::Modified {
+                old: v1.clone(),
+                new: v2.clone(),
+            }],
+            30,
+        );
+        // Head gives gamma a body it has NEVER carried before.
+        let mut v_new = v2.clone();
+        v_new.fingerprint.behavior_hash = Hash256::from_bytes([33; 32]);
+        graph.upsert_entity(&v_new).unwrap();
+        let head_id = change_id(240);
+        let head = change_with_deltas(
+            head_id,
+            vec![pad_tail],
+            vec![EntityDelta::Modified {
+                old: v2.clone(),
+                new: v_new.clone(),
+            }],
+            vec![],
+            vec![],
+        );
+        graph.create_change(&head).unwrap();
+        // A future edit whose pre-state IS the head's result.
+        let mut v_future = v_new.clone();
+        v_future.fingerprint.behavior_hash = Hash256::from_bytes([34; 32]);
+        let future = change_with_deltas(
+            change_id(241),
+            vec![head_id],
+            vec![EntityDelta::Modified {
+                old: v_new.clone(),
+                new: v_future,
+            }],
+            vec![],
+            vec![],
+        );
+        graph.create_change(&future).unwrap();
+
+        let report = build_shadow_report(&graph, &request(pad_tail, head_id)).unwrap();
+        assert!(
+            report
+                .policy
+                .findings
+                .iter()
+                .all(|f| !f.kind.starts_with("revert_history")),
+            "a future change must never read as revert history: {:?}",
+            report
+                .policy
+                .findings
+                .iter()
+                .map(|f| (&f.kind, &f.message))
+                .collect::<Vec<_>>()
+        );
+    }
+
+    #[test]
+    fn merge_branch_side_never_supplies_prior_bodies() {
+        // Changes reachable only through the head's merge (the branch being
+        // merged) are not part of the BASE's causal past; their pre-states
+        // must not serve as prior bodies either.
+        let graph = InMemoryGraph::new();
+        let mut v1 = entity_with_span("delta_fn", "src/d.rs", 5, EntityRole::Source);
+        v1.fingerprint.behavior_hash = Hash256::from_bytes([51; 32]);
+        let mut v2 = v1.clone();
+        v2.fingerprint.behavior_hash = Hash256::from_bytes([52; 32]);
+        let pad_tail = padded_history_graph(
+            &graph,
+            vec![EntityDelta::Added(v1.clone())],
+            vec![EntityDelta::Modified {
+                old: v1.clone(),
+                new: v2.clone(),
+            }],
+            30,
+        );
+        // The merge result: a body delta_fn never carried on the base lineage.
+        let mut v_new = v2.clone();
+        v_new.fingerprint.behavior_hash = Hash256::from_bytes([53; 32]);
+        // Branch-side change (parented off c1, reachable only via the merge):
+        // its pre-state equals the merge result's body.
+        let mut v_branch = v_new.clone();
+        v_branch.fingerprint.behavior_hash = Hash256::from_bytes([54; 32]);
+        let branch = change_with_deltas(
+            change_id(250),
+            vec![change_id(1)],
+            vec![EntityDelta::Modified {
+                old: v_new.clone(),
+                new: v_branch,
+            }],
+            vec![],
+            vec![],
+        );
+        graph.create_change(&branch).unwrap();
+        graph.upsert_entity(&v_new).unwrap();
+        let head_id = change_id(251);
+        let head = change_with_deltas(
+            head_id,
+            vec![pad_tail, change_id(250)],
+            vec![EntityDelta::Modified {
+                old: v2.clone(),
+                new: v_new.clone(),
+            }],
+            vec![],
+            vec![],
+        );
+        graph.create_change(&head).unwrap();
+
+        let report = build_shadow_report(&graph, &request(pad_tail, head_id)).unwrap();
+        assert!(
+            report
+                .policy
+                .findings
+                .iter()
+                .all(|f| !f.kind.starts_with("revert_history")),
+            "branch-side changes must never read as revert history: {:?}",
+            report
+                .policy
+                .findings
+                .iter()
+                .map(|f| (&f.kind, &f.message))
+                .collect::<Vec<_>>()
+        );
+    }
 }

--- a/crates/kin-review/src/shadow.rs
+++ b/crates/kin-review/src/shadow.rs
@@ -3794,4 +3794,88 @@ mod tests {
             finding.message
         );
     }
+
+    #[test]
+    fn body_reversion_to_older_revision_flags() {
+        // v1 -> v2 -> (head) back to v1's body: the head un-does the v2 edit.
+        // An ordinary new edit (v3 with a fresh body) must NOT match.
+        let graph = InMemoryGraph::new();
+        let mut v1 = entity_with_span("compute", "src/calc.rs", 10, EntityRole::Source);
+        v1.fingerprint.behavior_hash = Hash256::from_bytes([1; 32]);
+        let mut v2 = v1.clone();
+        v2.fingerprint.behavior_hash = Hash256::from_bytes([2; 32]);
+        let mut v_back = v2.clone();
+        v_back.fingerprint.behavior_hash = Hash256::from_bytes([1; 32]);
+
+        let pad_tail = padded_history_graph(
+            &graph,
+            vec![EntityDelta::Added(v1.clone())],
+            vec![EntityDelta::Modified {
+                old: v1.clone(),
+                new: v2.clone(),
+            }],
+            30,
+        );
+        graph.upsert_entity(&v_back).unwrap();
+        let head_id = change_id(210);
+        let head = change_with_deltas(
+            head_id,
+            vec![pad_tail],
+            vec![EntityDelta::Modified {
+                old: v2.clone(),
+                new: v_back,
+            }],
+            vec![],
+            vec![],
+        );
+        graph.create_change(&head).unwrap();
+
+        let report = build_shadow_report(&graph, &request(pad_tail, head_id)).unwrap();
+        let finding = report
+            .policy
+            .findings
+            .iter()
+            .find(|f| f.kind == "revert_history")
+            .expect("a body reversion to an older revision must flag");
+        assert!(
+            finding.message.contains("revert-shaped body reversion"),
+            "got: {}",
+            finding.message
+        );
+
+        // Control: an ordinary forward edit must not produce the finding.
+        let graph2 = InMemoryGraph::new();
+        let mut v3 = v2.clone();
+        v3.fingerprint.behavior_hash = Hash256::from_bytes([3; 32]);
+        let pad_tail2 = padded_history_graph(
+            &graph2,
+            vec![EntityDelta::Added(v1.clone())],
+            vec![EntityDelta::Modified {
+                old: v1.clone(),
+                new: v2.clone(),
+            }],
+            30,
+        );
+        graph2.upsert_entity(&v3).unwrap();
+        let head2 = change_with_deltas(
+            change_id(211),
+            vec![pad_tail2],
+            vec![EntityDelta::Modified {
+                old: v2.clone(),
+                new: v3,
+            }],
+            vec![],
+            vec![],
+        );
+        graph2.create_change(&head2).unwrap();
+        let report2 = build_shadow_report(&graph2, &request(pad_tail2, change_id(211))).unwrap();
+        assert!(
+            !report2
+                .policy
+                .findings
+                .iter()
+                .any(|f| f.kind == "revert_history"),
+            "an ordinary forward edit must not read as a body reversion"
+        );
+    }
 }

--- a/crates/kin-review/src/shadow.rs
+++ b/crates/kin-review/src/shadow.rs
@@ -518,10 +518,10 @@ fn assemble_report_with_changes<G: GraphStore>(
     // Toolchain-surface findings feed the gate as ordinary warning findings via
     // the inline-comment channel, never through the evidence-gap demotion path.
     review.inline_comments.extend(toolchain_findings);
-    // Revert-history findings feed the gate the same way: ordinary warning
-    // findings, with an honest gap when the base has too little history to
-    // scan. Temporal evidence available at review time only — the window looks
-    // strictly BEFORE the base.
+    // Revert-history findings use the same inline-comment channel, with an
+    // honest gap when the base has too little history to scan. Strong matches
+    // may gate as warnings; weak temporal hints stay informational. Evidence is
+    // available at review time only: the window looks strictly BEFORE the base.
     let (revert_findings, revert_gap) = crate::revert_history::collect_revert_history_findings(
         store,
         &request.resolved_base,
@@ -1308,7 +1308,9 @@ fn collect_evidence_gaps<G: GraphStore>(
     for change in changes {
         for delta in &change.artifact_deltas {
             let file = delta.file_id.to_string();
-            if entity_files.contains(&file) {
+            if entity_files.contains(&file)
+                || semantic_removed_entity_accounts_for_artifact_file(&file, changed_entities)
+            {
                 continue;
             }
             let entry = artifact_hashes
@@ -1408,6 +1410,31 @@ fn collect_evidence_gaps<G: GraphStore>(
     });
 
     (gaps, toolchain_findings)
+}
+
+fn semantic_removed_entity_accounts_for_artifact_file(
+    file: &str,
+    changed_entities: &[ShadowChangedEntity],
+) -> bool {
+    changed_entities.iter().any(|entity| {
+        entity.change == "removed"
+            && entity.kind != "unknown"
+            && entity.role == EntityRole::Source
+            && entity
+                .file
+                .as_deref()
+                .is_some_and(|entity_file| same_filename(entity_file, file))
+    })
+}
+
+fn same_filename(left: &str, right: &str) -> bool {
+    let left = std::path::Path::new(left)
+        .file_name()
+        .and_then(|name| name.to_str());
+    let right = std::path::Path::new(right)
+        .file_name()
+        .and_then(|name| name.to_str());
+    left.is_some() && left == right
 }
 
 fn actor_kind_label(actor: &str) -> &'static str {
@@ -3238,6 +3265,56 @@ mod tests {
     }
 
     #[test]
+    fn removed_entity_under_historical_path_accounts_for_source_artifact_delta() {
+        // Historical rename shape: the source file changed at its current path,
+        // but the removed entity still carries the pre-rename file origin. The
+        // semantic diff did capture the deletion, so the artifact delta must
+        // not be treated as unparsed source.
+        let graph = InMemoryGraph::new();
+        let legacy = entity_with_span(
+            "animate",
+            "src/shared/keyed-each.js",
+            105,
+            EntityRole::Source,
+        );
+        graph.upsert_entity(&legacy).unwrap();
+
+        let base_id = change_id(0x71);
+        let head_id = change_id(0x72);
+        let base = change_with_deltas(
+            base_id,
+            vec![],
+            vec![EntityDelta::Added(legacy.clone())],
+            vec![],
+            vec![],
+        );
+        let head = change_with_deltas(
+            head_id,
+            vec![base_id],
+            vec![EntityDelta::Removed(legacy.id)],
+            vec![],
+            vec![ArtifactDelta {
+                file_id: FilePathId::new("src/internal/keyed-each.js"),
+                kind: ArtifactDeltaKind::Modified,
+                old_hash: Some(Hash256::from_bytes([21; 32])),
+                new_hash: Some(Hash256::from_bytes([22; 32])),
+            }],
+        );
+        graph.create_change(&base).unwrap();
+        graph.create_change(&head).unwrap();
+
+        let report = build_shadow_report(&graph, &request(base_id, head_id)).unwrap();
+
+        assert!(
+            !report.evidence_gaps.iter().any(|gap| {
+                gap.kind == "artifact_only_change" && gap.subject == "src/internal/keyed-each.js"
+            }),
+            "a captured removed entity under a historical path must account for the source delta"
+        );
+        assert_eq!(report.policy.verdict, ShadowGateVerdict::Pass);
+    }
+
+    #[test]
     fn absent_relation_channel_keeps_surface_change_feeding_gate() {
         // A real signature change in a repo whose relation channel was never
         // ingested: the empty channel cannot prove the change is isolated, so
@@ -3643,11 +3720,11 @@ mod tests {
     }
 
     #[test]
-    fn revert_history_recent_addition_removal_flags() {
+    fn revert_history_recent_addition_removal_is_evidence_only() {
         // c2 adds `beta_flag`; the head removes that exact entity id. Deleting
         // something that only just landed is revert-shaped and must be called
-        // out even though a bare removal of an unconsumed entity would
-        // otherwise stay quiet.
+        // out, but benign-60 proved the signal is too weak to drive the gate
+        // without an independent risk channel.
         let graph = InMemoryGraph::new();
         let recent = entity_with_span("beta_flag", "src/flags.rs", 12, EntityRole::Source);
         let base_id =
@@ -3667,13 +3744,15 @@ mod tests {
             .policy
             .findings
             .iter()
-            .find(|f| f.kind == "revert_history")
-            .expect("recent-addition removal must produce a revert_history finding");
+            .find(|f| f.kind == "revert_history_incidental")
+            .expect("recent-addition removal must produce an evidence-only finding");
         assert!(
             finding.message.contains("revert-shaped removal"),
             "got: {}",
             finding.message
         );
+        assert_eq!(finding.severity, "info");
+        assert_eq!(report.policy.verdict, ShadowGateVerdict::Pass);
     }
 
     #[test]

--- a/crates/kin-review/src/shadow.rs
+++ b/crates/kin-review/src/shadow.rs
@@ -3899,7 +3899,7 @@ mod tests {
     }
 
     #[test]
-    fn coherent_body_reversion_group_reports_without_gating() {
+    fn coherent_public_leaf_body_reversion_gates() {
         // Two entities whose new bodies both restore states un-done by the
         // SAME historical change: a coherent snapshot restoration — the true
         // revert shape — gates as a warning.
@@ -3970,20 +3970,16 @@ mod tests {
         graph.create_change(&head).unwrap();
 
         let report = build_shadow_report(&graph, &request(base_id, head_id)).unwrap();
-        // Body reversions never gate — the 60-benign sweep measured module
-        // co-reversion making two-entity "coherence" nearly free on real
-        // repos, re-flagging ~a third of clean benigns. The evidence is still
-        // reported, carrying the coherence hint for the reviewer.
-        let informational: Vec<_> = report
+        let gating: Vec<_> = report
             .policy
             .findings
             .iter()
-            .filter(|f| f.kind == "revert_history_incidental")
+            .filter(|f| f.kind == "revert_history")
             .collect();
         assert_eq!(
-            informational.len(),
+            gating.len(),
             2,
-            "both reversions must be reported, got findings: {:?}",
+            "both public-leaf reversions must gate, got findings: {:?}",
             report
                 .policy
                 .findings
@@ -3991,10 +3987,98 @@ mod tests {
                 .map(|f| (&f.kind, &f.message))
                 .collect::<Vec<_>>()
         );
-        assert!(informational.iter().all(|f| f.severity == "info"));
-        assert!(informational[0]
-            .message
-            .contains("un-doing the same change"));
+        assert!(gating.iter().all(|f| f.severity == "warning"));
+        assert!(gating[0].message.contains("un-doing the same change"));
+        assert_eq!(report.policy.verdict, ShadowGateVerdict::NeedsAttention);
+    }
+
+    #[test]
+    fn coherent_module_body_reversion_does_not_gate() {
+        // Module/class aggregates co-revert for free (a module mirrors its
+        // file), so a coherent group with no public leaf stays informational —
+        // the false-coherence protection that motivated the leaf filter.
+        let graph = InMemoryGraph::new();
+        let mut a1 = entity_with_span("mod_a", "src/a.rs", 1, EntityRole::Source);
+        a1.kind = EntityKind::Module;
+        a1.fingerprint.behavior_hash = Hash256::from_bytes([11; 32]);
+        let mut b1 = entity_with_span("_helper", "src/b.rs", 9, EntityRole::Source);
+        b1.visibility = Visibility::Private;
+        b1.fingerprint.behavior_hash = Hash256::from_bytes([21; 32]);
+        let mut a2 = a1.clone();
+        a2.fingerprint.behavior_hash = Hash256::from_bytes([12; 32]);
+        let mut b2 = b1.clone();
+        b2.fingerprint.behavior_hash = Hash256::from_bytes([22; 32]);
+
+        let mut prev: Option<SemanticChangeId> = None;
+        for i in 1..=30u8 {
+            let deltas = match i {
+                1 => vec![
+                    EntityDelta::Added(a1.clone()),
+                    EntityDelta::Added(b1.clone()),
+                ],
+                2 => vec![
+                    EntityDelta::Modified {
+                        old: a1.clone(),
+                        new: a2.clone(),
+                    },
+                    EntityDelta::Modified {
+                        old: b1.clone(),
+                        new: b2.clone(),
+                    },
+                ],
+                _ => vec![],
+            };
+            let change = change_with_deltas(
+                change_id(i),
+                prev.map(|p| vec![p]).unwrap_or_default(),
+                deltas,
+                vec![],
+                vec![],
+            );
+            graph.create_change(&change).unwrap();
+            prev = Some(change_id(i));
+        }
+        let base_id = prev.unwrap();
+        let mut a_back = a2.clone();
+        a_back.fingerprint.behavior_hash = Hash256::from_bytes([11; 32]);
+        let mut b_back = b2.clone();
+        b_back.fingerprint.behavior_hash = Hash256::from_bytes([21; 32]);
+        graph.upsert_entity(&a_back).unwrap();
+        graph.upsert_entity(&b_back).unwrap();
+        let head_id = change_id(220);
+        let head = change_with_deltas(
+            head_id,
+            vec![base_id],
+            vec![
+                EntityDelta::Modified {
+                    old: a2.clone(),
+                    new: a_back,
+                },
+                EntityDelta::Modified {
+                    old: b2.clone(),
+                    new: b_back,
+                },
+            ],
+            vec![],
+            vec![],
+        );
+        graph.create_change(&head).unwrap();
+
+        let report = build_shadow_report(&graph, &request(base_id, head_id)).unwrap();
+        assert!(
+            report
+                .policy
+                .findings
+                .iter()
+                .all(|f| f.kind != "revert_history"),
+            "module/private coherent reversion must not gate: {:?}",
+            report
+                .policy
+                .findings
+                .iter()
+                .map(|f| &f.kind)
+                .collect::<Vec<_>>()
+        );
         assert_eq!(report.policy.verdict, ShadowGateVerdict::Pass);
     }
 }


### PR DESCRIPTION
Adds the revert-history evidence channel to shadow review, rebased onto the refine calibration baseline, with all evidence sourced from the reviewed base's causal ancestry.

## What

- Reintroduction and recent-addition-removal matchers over a bounded base-ancestry window (250 changes), gating only on public contract entities; private-helper and test churn stays informational.
- Body-reversion matching: a modified entity whose new body exactly restores a pre-change state from the base's ancestry window. Coherent groups (two or more entities un-doing the same historical change) gate only when they restore a public non-test leaf; singletons and aggregates stay informational.
- All candidate evidence comes from one bounded BFS over the base's ancestry. Unanchored entity-history reads are removed from the channel: a graph may hold changes outside the reviewed lineage (other branches, other reviews' hydrations, states newer than the head), and a change made after the head trivially has the head's result as its pre-state — consulting it would flag every entity that is ever edited again and made match depth dependent on timestamp tie-breaking. Removed-entity resolution is window-scoped for the same reason.
- Shallow-history bases report an honest evidence gap instead of certifying silence.

## Verification

- kin-review 152/152, including leak-shaped regression tests: a future child change whose old state equals the head's result must not match (fails against the previous implementation), and merge-branch-side commits must not serve as prior bodies.
- 22-row dev-lane block: decisions row-for-row identical to the refine baseline, bit-identical across passes.
- Benign-60 precision sweep in flight; measurement thread: https://linear.app/firelock-ai/issue/FIR-1341

Supersedes #238.