### PR TITLE
Read Codex MCP config from ~/.codex/config.toml

### DIFF
--- a/crates/kin-cli/src/commands/health.rs
+++ b/crates/kin-cli/src/commands/health.rs
@@ -596,7 +596,12 @@ pub(crate) fn mcp_client_config_paths() -> Vec<(&'static str, &'static str, Path
             },
         ),
         ("cursor", "Cursor", home.join(".cursor").join("mcp.json")),
-        ("codex", "Codex CLI", home.join(".codex").join("mcp.json")),
+        (
+            "codex",
+            "Codex CLI",
+            // Codex reads MCP servers from config.toml, not an mcp.json.
+            home.join(".codex").join("config.toml"),
+        ),
         (
             "gemini",
             "Gemini CLI",
@@ -614,6 +619,10 @@ pub(crate) fn mcp_client_config_paths() -> Vec<(&'static str, &'static str, Path
 
 /// Inspect a single MCP config file for a `kin` server entry carrying the
 /// agent-default tool profile.
+///
+/// Handles both JSON configs (`mcpServers.kin`) and TOML configs such as
+/// Codex's `~/.codex/config.toml` (`mcp_servers.kin`); TOML is normalized to
+/// JSON so the same checks apply.
 pub(crate) fn evaluate_mcp_client(path: &PathBuf) -> (HealthStatus, String) {
     let content = match std::fs::read_to_string(path) {
         Ok(c) => c,
@@ -624,20 +633,36 @@ pub(crate) fn evaluate_mcp_client(path: &PathBuf) -> (HealthStatus, String) {
             )
         }
     };
-    let root: Value = match serde_json::from_str(&content) {
-        Ok(v) => v,
-        Err(e) => {
-            return (
-                HealthStatus::Misconfigured,
-                format!("{} is not valid JSON: {e}", path.display()),
-            )
+    let is_toml = path.extension().and_then(|e| e.to_str()) == Some("toml");
+    let (root, servers_key): (Value, &str) = if is_toml {
+        match toml::from_str::<toml::Value>(&content)
+            .ok()
+            .and_then(|v| serde_json::to_value(v).ok())
+        {
+            Some(v) => (v, "mcp_servers"),
+            None => {
+                return (
+                    HealthStatus::Misconfigured,
+                    format!("{} is not valid TOML", path.display()),
+                )
+            }
+        }
+    } else {
+        match serde_json::from_str(&content) {
+            Ok(v) => (v, "mcpServers"),
+            Err(e) => {
+                return (
+                    HealthStatus::Misconfigured,
+                    format!("{} is not valid JSON: {e}", path.display()),
+                )
+            }
         }
     };
-    let kin_entry = root.get("mcpServers").and_then(|s| s.get("kin"));
+    let kin_entry = root.get(servers_key).and_then(|s| s.get("kin"));
     match kin_entry {
         None => (
             HealthStatus::Missing,
-            format!("no mcpServers.kin entry in {}", path.display()),
+            format!("no {servers_key}.kin entry in {}", path.display()),
         ),
         Some(entry) => {
             // Entries written by older releases pass `--global`, which the MCP
@@ -650,7 +675,7 @@ pub(crate) fn evaluate_mcp_client(path: &PathBuf) -> (HealthStatus, String) {
                 return (
                     HealthStatus::Misconfigured,
                     format!(
-                        "mcpServers.kin uses the retired `--global` mode and cannot start in {}",
+                        "{servers_key}.kin uses the retired `--global` mode and cannot start in {}",
                         path.display()
                     ),
                 );
@@ -663,7 +688,7 @@ pub(crate) fn evaluate_mcp_client(path: &PathBuf) -> (HealthStatus, String) {
                 (
                     HealthStatus::Healthy,
                     format!(
-                        "mcpServers.kin present with agent-default profile ({})",
+                        "{servers_key}.kin present with agent-default profile ({})",
                         path.display()
                     ),
                 )
@@ -671,7 +696,7 @@ pub(crate) fn evaluate_mcp_client(path: &PathBuf) -> (HealthStatus, String) {
                 (
                     HealthStatus::Misconfigured,
                     format!(
-                        "mcpServers.kin present but KIN_MCP_TOOL_PROFILE is {} (expected agent-default) in {}",
+                        "{servers_key}.kin present but KIN_MCP_TOOL_PROFILE is {} (expected agent-default) in {}",
                         profile.unwrap_or("unset"),
                         path.display()
                     ),
@@ -1228,6 +1253,33 @@ mod tests {
         let path = dir.path().join("does-not-exist.json");
         let (status, _detail) = evaluate_mcp_client(&path);
         assert!(matches!(status, HealthStatus::Missing));
+    }
+
+    #[test]
+    fn mcp_config_toml_with_agent_default_profile_is_healthy() {
+        // Codex registers MCP servers in ~/.codex/config.toml, not mcp.json.
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("config.toml");
+        std::fs::write(
+            &path,
+            "[mcp_servers.kin]\ncommand = \"kin\"\nargs = [\"mcp\", \"start\"]\nenv = { KIN_MCP_TOOL_PROFILE = \"agent-default\" }\n",
+        )
+        .unwrap();
+
+        let (status, detail) = evaluate_mcp_client(&path);
+        assert!(matches!(status, HealthStatus::Healthy), "got: {detail}");
+        assert!(detail.contains("mcp_servers.kin"));
+    }
+
+    #[test]
+    fn mcp_config_toml_without_kin_entry_is_missing() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("config.toml");
+        std::fs::write(&path, "model = \"o3\"\n").unwrap();
+
+        let (status, detail) = evaluate_mcp_client(&path);
+        assert!(matches!(status, HealthStatus::Missing), "got: {detail}");
+        assert!(detail.contains("mcp_servers.kin"));
     }
 
     #[test]

--- a/crates/kin-cli/src/commands/setup.rs
+++ b/crates/kin-cli/src/commands/setup.rs
@@ -889,12 +889,86 @@ fn configure_cursor() -> Result<PathBuf> {
     Ok(target)
 }
 
+/// Merge the "kin" MCP server entry into a TOML MCP config (Codex CLI's
+/// `~/.codex/config.toml`). Creates the file if it doesn't exist.
+///
+/// Codex reads MCP servers from `[mcp_servers.<name>]` tables in
+/// `config.toml` — it does not read an `mcp.json`. Uses a format-preserving
+/// TOML edit so unrelated keys, tables, and comments in the user's config are
+/// left untouched.
+fn merge_mcp_config_toml(path: &PathBuf) -> Result<()> {
+    use toml_edit::{value, Array, DocumentMut, InlineTable, Item, Table};
+
+    let mut doc: DocumentMut = if path.exists() {
+        let content = fs::read_to_string(path)
+            .with_context(|| format!("failed to read {}", path.display()))?;
+        content.parse().with_context(|| {
+            format!(
+                "existing file {} is not valid TOML — refusing to overwrite it. \
+                 Fix or remove the file and try again.",
+                path.display()
+            )
+        })?
+    } else {
+        DocumentMut::new()
+    };
+
+    // Ensure mcp_servers is a standard table we can nest [mcp_servers.kin]
+    // under, preserving any existing server entries (including ones written
+    // as an inline `mcp_servers = { ... }` value).
+    if !matches!(doc.get("mcp_servers"), Some(Item::Table(_))) {
+        let mut servers = match doc.remove("mcp_servers") {
+            Some(item) => match item.into_table() {
+                Ok(table) => table,
+                Err(item) => match item.into_value() {
+                    Ok(toml_edit::Value::InlineTable(inline)) => inline.into_table(),
+                    _ => Table::new(),
+                },
+            },
+            None => Table::new(),
+        };
+        servers.set_implicit(true);
+        doc.insert("mcp_servers", Item::Table(servers));
+    }
+
+    // Build the kin entry from the same source of truth as the JSON configs.
+    let entry = kin_mcp_entry();
+    let command = entry
+        .get("command")
+        .and_then(|c| c.as_str())
+        .unwrap_or("kin")
+        .to_string();
+
+    let mut kin = Table::new();
+    kin.insert("command", value(command));
+    let mut args = Array::new();
+    args.push("mcp");
+    args.push("start");
+    kin.insert("args", value(args));
+    let mut env = InlineTable::new();
+    env.insert("KIN_MCP_TOOL_PROFILE", "agent-default".into());
+    kin.insert("env", value(env));
+
+    doc["mcp_servers"]["kin"] = Item::Table(kin);
+
+    if let Some(parent) = path.parent() {
+        fs::create_dir_all(parent)
+            .with_context(|| format!("failed to create directory {}", parent.display()))?;
+    }
+    fs::write(path, doc.to_string())
+        .with_context(|| format!("failed to write {}", path.display()))?;
+
+    Ok(())
+}
+
 /// Configure MCP for Codex CLI.
+///
+/// Codex reads MCP servers from `~/.codex/config.toml` (`[mcp_servers.<name>]`
+/// tables with `command`/`args`/`env`), not from an `mcp.json` file.
 fn configure_codex() -> Result<PathBuf> {
     let home = home_dir()?;
-    // Codex uses ~/.codex/mcp.json
-    let target = home.join(".codex").join("mcp.json");
-    merge_mcp_config(&target)?;
+    let target = home.join(".codex").join("config.toml");
+    merge_mcp_config_toml(&target)?;
     Ok(target)
 }
 
@@ -978,6 +1052,9 @@ fn inject_discovery_reminder(path: &PathBuf) -> Result<()> {
 }
 
 /// Check if a given MCP config file already has the "kin" server entry.
+///
+/// Understands both JSON configs (`mcpServers.kin`) and TOML configs such as
+/// Codex's `config.toml` (`mcp_servers.kin`).
 fn has_kin_mcp_config(path: &PathBuf) -> bool {
     if !path.exists() {
         return false;
@@ -985,6 +1062,12 @@ fn has_kin_mcp_config(path: &PathBuf) -> bool {
     let Ok(content) = fs::read_to_string(path) else {
         return false;
     };
+    if path.extension().and_then(|e| e.to_str()) == Some("toml") {
+        let Ok(root) = toml::from_str::<toml::Value>(&content) else {
+            return false;
+        };
+        return root.get("mcp_servers").and_then(|s| s.get("kin")).is_some();
+    }
     let Ok(root) = serde_json::from_str::<serde_json::Value>(&content) else {
         return false;
     };
@@ -1119,7 +1202,16 @@ pub(crate) fn reinstall_vfs_shim() -> Result<Option<PathBuf>> {
 pub(crate) fn remerge_existing_mcp_configs() -> Vec<PathBuf> {
     let mut repaired = Vec::new();
     for (_id, _label, path) in crate::commands::health::mcp_client_config_paths() {
-        if path.exists() && merge_mcp_config(&path).is_ok() {
+        if !path.exists() {
+            continue;
+        }
+        // Codex's config.toml is TOML; every other client config is JSON.
+        let merged = if path.extension().and_then(|e| e.to_str()) == Some("toml") {
+            merge_mcp_config_toml(&path)
+        } else {
+            merge_mcp_config(&path)
+        };
+        if merged.is_ok() {
             repaired.push(path);
         }
     }
@@ -1502,9 +1594,18 @@ fn client_id_for_index(idx: usize) -> &'static str {
     }
 }
 
-/// Read the `mcpServers.kin` sub-value from a client config, if present.
+/// Read the kin MCP server sub-value from a client config, if present.
+///
+/// Handles both JSON configs (`mcpServers.kin`) and TOML configs such as
+/// Codex's `config.toml` (`mcp_servers.kin`), normalizing the entry to JSON
+/// for the install ledger.
 fn read_kin_mcp_entry(path: &Path) -> Option<serde_json::Value> {
     let content = fs::read_to_string(path).ok()?;
+    if path.extension().and_then(|e| e.to_str()) == Some("toml") {
+        let root: toml::Value = toml::from_str(&content).ok()?;
+        let entry = root.get("mcp_servers")?.get("kin")?;
+        return serde_json::to_value(entry).ok();
+    }
     let root: serde_json::Value = serde_json::from_str(&content).ok()?;
     root.get("mcpServers")?.get("kin").cloned()
 }
@@ -1638,7 +1739,7 @@ fn mcp_config_path_for_index(idx: usize) -> Option<PathBuf> {
             })
         }
         IDX_CURSOR => Some(home.join(".cursor").join("mcp.json")),
-        IDX_CODEX => Some(home.join(".codex").join("mcp.json")),
+        IDX_CODEX => Some(home.join(".codex").join("config.toml")),
         IDX_GEMINI => Some(home.join(".gemini").join("settings.json")),
         IDX_WINDSURF => Some(
             home.join(".codeium")
@@ -2375,6 +2476,103 @@ mod tests {
         assert!(
             val["mcpServers"]["kin"].is_object(),
             "kin entry must be added"
+        );
+    }
+
+    #[test]
+    fn merge_mcp_config_toml_refuses_to_overwrite_corrupt_toml() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("config.toml");
+        std::fs::write(&path, b"this is not toml [[[").unwrap();
+
+        let original = std::fs::read(&path).unwrap();
+        let err = merge_mcp_config_toml(&path).unwrap_err();
+        let msg = err.to_string();
+
+        assert!(
+            msg.contains("not valid TOML"),
+            "expected 'not valid TOML' in error, got: {msg}"
+        );
+        assert!(
+            msg.contains("refusing to overwrite"),
+            "expected 'refusing to overwrite' in error, got: {msg}"
+        );
+        assert_eq!(
+            std::fs::read(&path).unwrap(),
+            original,
+            "corrupt file must not be modified"
+        );
+    }
+
+    #[test]
+    fn merge_mcp_config_toml_preserves_existing_codex_config() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("config.toml");
+        std::fs::write(
+            &path,
+            "# user settings\nmodel = \"o3\"\n\n[mcp_servers.other]\ncommand = \"other-server\"\n",
+        )
+        .unwrap();
+
+        merge_mcp_config_toml(&path).unwrap();
+
+        let content = std::fs::read_to_string(&path).unwrap();
+        let root: toml::Value = toml::from_str(&content).unwrap();
+        assert_eq!(
+            root.get("model").and_then(|v| v.as_str()),
+            Some("o3"),
+            "unrelated keys must be preserved"
+        );
+        assert!(
+            content.contains("# user settings"),
+            "comments must be preserved"
+        );
+        assert_eq!(
+            root["mcp_servers"]["other"]["command"].as_str(),
+            Some("other-server"),
+            "other MCP servers must be preserved"
+        );
+        let kin = &root["mcp_servers"]["kin"];
+        assert!(kin.get("command").is_some(), "kin entry must be added");
+        assert_eq!(
+            kin["args"].as_array().map(|a| a.len()),
+            Some(2),
+            "kin args must be [mcp, start]"
+        );
+        assert_eq!(
+            kin["env"]["KIN_MCP_TOOL_PROFILE"].as_str(),
+            Some("agent-default"),
+            "agent-default profile must be set"
+        );
+    }
+
+    #[test]
+    fn merge_mcp_config_toml_creates_missing_file_and_is_idempotent() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join(".codex").join("config.toml");
+
+        merge_mcp_config_toml(&path).unwrap();
+        merge_mcp_config_toml(&path).unwrap();
+
+        let content = std::fs::read_to_string(&path).unwrap();
+        let root: toml::Value = toml::from_str(&content).unwrap();
+        assert!(
+            root["mcp_servers"]["kin"].get("command").is_some(),
+            "kin entry must exist"
+        );
+        assert_eq!(
+            content.matches("[mcp_servers.kin]").count(),
+            1,
+            "re-running must not duplicate the kin table"
+        );
+        assert!(
+            has_kin_mcp_config(&path),
+            "TOML-aware config check must see the entry"
+        );
+        let ledger_entry = read_kin_mcp_entry(&path).expect("ledger read must parse TOML");
+        assert_eq!(
+            ledger_entry["env"]["KIN_MCP_TOOL_PROFILE"], "agent-default",
+            "ledger entry must normalize the TOML entry to JSON"
         );
     }
 }

--- a/crates/kin-cli/src/commands/setup_ledger.rs
+++ b/crates/kin-cli/src/commands/setup_ledger.rs
@@ -37,8 +37,10 @@ pub const LEDGER_SCHEMA_VERSION: u32 = 1;
 #[derive(Debug, Clone, Copy, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
 #[serde(rename_all = "snake_case")]
 pub enum ArtifactKind {
-    /// The `mcpServers.kin` entry merged into an AI client's JSON config. The
-    /// owned slice is that one sub-value; siblings are untouched.
+    /// The kin MCP server entry merged into an AI client's config — the
+    /// `mcpServers.kin` sub-value of a JSON config, or the `mcp_servers.kin`
+    /// table of a TOML config (Codex). The owned slice is that one sub-value;
+    /// siblings are untouched.
     McpConfig,
     /// A `~/.kin/shell/kin-vfs.<shell>` hook file Kin owns entirely.
     ShellHook,
@@ -122,7 +124,8 @@ impl LedgerEntry {
         }
     }
 
-    /// Build an entry for a merged `mcpServers.kin` JSON sub-value.
+    /// Build an entry for a merged kin MCP server sub-value (JSON `mcpServers.kin`
+    /// or TOML `mcp_servers.kin`, normalized to JSON by the caller).
     pub fn mcp(target: impl Into<String>, path: PathBuf, kin_entry: &serde_json::Value) -> Self {
         let now = now_rfc3339();
         Self {
@@ -273,9 +276,18 @@ fn current_owned_fingerprint(entry: &LedgerEntry) -> Option<String> {
     match entry.kind {
         ArtifactKind::McpConfig => {
             let content = fs::read_to_string(&entry.path).ok()?;
-            let root: serde_json::Value = serde_json::from_str(&content).ok()?;
-            let kin = root.get("mcpServers")?.get("kin")?;
-            Some(fingerprint_mcp_entry(kin))
+            // Codex's config.toml is TOML (`mcp_servers.kin`); every other
+            // client config is JSON (`mcpServers.kin`). Normalize to JSON so
+            // the fingerprint matches what the install path recorded.
+            let kin = if entry.path.extension().and_then(|e| e.to_str()) == Some("toml") {
+                let root: toml::Value = toml::from_str(&content).ok()?;
+                let kin = root.get("mcp_servers")?.get("kin")?;
+                serde_json::to_value(kin).ok()?
+            } else {
+                let root: serde_json::Value = serde_json::from_str(&content).ok()?;
+                root.get("mcpServers")?.get("kin")?.clone()
+            };
+            Some(fingerprint_mcp_entry(&kin))
         }
         ArtifactKind::ShellHook | ArtifactKind::VfsShim | ArtifactKind::DaemonConfig => {
             let bytes = fs::read(&entry.path).ok()?;
@@ -404,6 +416,26 @@ fn remove_owned_slice(entry: &LedgerEntry) -> Result<String> {
         ArtifactKind::McpConfig => {
             let content = fs::read_to_string(&entry.path)
                 .with_context(|| format!("failed to read {}", entry.path.display()))?;
+            if entry.path.extension().and_then(|e| e.to_str()) == Some("toml") {
+                // Codex's config.toml: excise only the [mcp_servers.kin] table
+                // with a format-preserving edit; the rest of the user's config
+                // (keys, tables, comments) is left byte-for-byte intact.
+                let mut doc: toml_edit::DocumentMut = content
+                    .parse()
+                    .with_context(|| format!("{} is not valid TOML", entry.path.display()))?;
+                if let Some(servers) = doc
+                    .get_mut("mcp_servers")
+                    .and_then(|s| s.as_table_like_mut())
+                {
+                    servers.remove("kin");
+                }
+                fs::write(&entry.path, doc.to_string())
+                    .with_context(|| format!("failed to write {}", entry.path.display()))?;
+                return Ok(format!(
+                    "removed mcp_servers.kin from {}",
+                    entry.path.display()
+                ));
+            }
             let mut root: serde_json::Value = serde_json::from_str(&content)
                 .with_context(|| format!("{} is not valid JSON", entry.path.display()))?;
             if let Some(servers) = root.get_mut("mcpServers").and_then(|s| s.as_object_mut()) {
@@ -755,6 +787,45 @@ mod tests {
             "sibling server kept"
         );
         assert_eq!(root["userSetting"], true, "unrelated keys kept");
+    }
+
+    #[test]
+    fn verify_and_uninstall_mcp_toml_config() {
+        // Codex registers its MCP entry in config.toml (`mcp_servers.kin`),
+        // not an mcp.json — the ledger must verify and excise it there.
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("config.toml");
+        write(
+            &path,
+            "# codex settings\nmodel = \"o3\"\n\n[mcp_servers.other]\ncommand = \"x\"\n\n[mcp_servers.kin]\ncommand = \"kin\"\nargs = [\"mcp\", \"start\"]\nenv = { KIN_MCP_TOOL_PROFILE = \"agent-default\" }\n",
+        );
+        let kin = serde_json::json!({
+            "command": "kin",
+            "args": ["mcp", "start"],
+            "env": { "KIN_MCP_TOOL_PROFILE": "agent-default" }
+        });
+        let entry = LedgerEntry::mcp("codex", path.clone(), &kin);
+
+        // The on-disk TOML entry fingerprints identically to the recorded
+        // JSON-normalized value.
+        assert_eq!(verify_entry(&entry).state, EntryState::Verified);
+
+        let outcome = uninstall_entry(&entry, false, false);
+        assert_eq!(outcome.action, RemovalAction::Removed);
+
+        let content = fs::read_to_string(&path).unwrap();
+        let root: toml::Value = toml::from_str(&content).unwrap();
+        assert!(
+            root["mcp_servers"].get("kin").is_none(),
+            "kin table removed"
+        );
+        assert_eq!(
+            root["mcp_servers"]["other"]["command"].as_str(),
+            Some("x"),
+            "sibling server kept"
+        );
+        assert_eq!(root["model"].as_str(), Some("o3"), "unrelated keys kept");
+        assert!(content.contains("# codex settings"), "comments kept");
     }
 
     #[test]

--- a/crates/kin-core/src/assistant.rs
+++ b/crates/kin-core/src/assistant.rs
@@ -1038,7 +1038,8 @@ pub fn generate_config_snippets(kind: AssistantKind) -> Vec<ConfigSnippet> {
                 .into(),
             content: r#"[mcp_servers.kin]
 command = "kin"
-args = ["mcp", "start"]"#
+args = ["mcp", "start"]
+env = { KIN_MCP_TOOL_PROFILE = "agent-default" }"#
                 .into(),
             target_path: "~/.codex/config.toml".into(),
         }],

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -354,9 +354,19 @@ Config file locations the wizard targets (and `kin setup status` inspects):
 | --- | --- |
 | Claude Code | `~/.claude.json` (falls back to `~/.claude/config.json`) |
 | Cursor | `~/.cursor/mcp.json` |
-| Codex CLI | `~/.codex/mcp.json` |
+| Codex CLI | `~/.codex/config.toml` (TOML — see below) |
 | Gemini CLI | `~/.gemini/settings.json` |
 | Windsurf | `~/.codeium/windsurf/mcp_config.json` |
+
+Codex is the exception: it reads TOML (`[mcp_servers.<name>]` tables), not JSON. The wizard
+merges this table into `~/.codex/config.toml`, leaving the rest of the file untouched:
+
+```toml
+[mcp_servers.kin]
+command = "kin"
+args = ["mcp", "start"]
+env = { KIN_MCP_TOOL_PROFILE = "agent-default" }
+```
 
 `kin mcp start` launches the MCP **stdio** server. You normally do not run this by hand —
 your AI client launches it as a subprocess via the config above. The server binds

--- a/packages/boundary-contracts/schemas/semantic-fingerprint.schema.json
+++ b/packages/boundary-contracts/schemas/semantic-fingerprint.schema.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
   "$id": "kin://contracts/semantic-fingerprint",
-  "description": "Kin's identity moat. Survives renames, moves, formatting.",
+  "description": "Content-based fingerprint of an entity, used to detect what changed between revisions (structure, signature, and exact contents).",
   "type": "object",
   "required": ["algorithm", "ast_hash", "behavior_hash", "signature_hash", "stability_score"],
   "properties": {


### PR DESCRIPTION
## What
`kin setup`, `kin setup status`, `kin doctor --fix`, the install ledger, and the assistant config snippets now read and write Codex's MCP configuration in `~/.codex/config.toml` (TOML `[mcp_servers.kin]`) instead of `~/.codex/mcp.json`.

## Why
Codex CLI registers MCP servers from `config.toml` (`[mcp_servers.<name>]` tables), not from an `mcp.json` file. The old path wrote a file Codex never reads, so the `kin setup → Codex sees Kin` first-run adoption path silently failed.

## Behavior
- `configure_codex` merges `[mcp_servers.kin]` into `~/.codex/config.toml` with a format-preserving TOML edit — unrelated keys, tables, and comments stay byte-for-byte intact.
- Corrupt existing TOML is refused, never overwritten.
- Health / `setup status` / ledger read the TOML surface (`mcp_servers.kin`), normalizing to JSON for fingerprinting so verify/uninstall match what setup wrote.
- Uninstall excises only the `[mcp_servers.kin]` table; sibling servers and user config remain.
- Docs (quickstart) and assistant snippets use the TOML form; no remaining `~/.codex/mcp.json` references for Codex.

## Tests
New unit tests: healthy TOML with agent-default profile, missing entry, corrupt-TOML refusal, idempotent merge, ledger fingerprint round-trip, uninstall table removal. `cargo test -p kin-cli mcp` → 24 passed, 0 failed; the 6 new tests pass by name. fmt clean; clippy clean on the changed files.

https://linear.app/firelock-ai/issue/FIR-1411