### PR TITLE
fix(mcp): never hard-exit kin mcp start outside a Kin repository

### DIFF
--- a/crates/kin-cli/src/commands/mcp.rs
+++ b/crates/kin-cli/src/commands/mcp.rs
@@ -3,38 +3,54 @@
 
 use anyhow::Result;
 use std::collections::HashSet;
+use std::path::{Path, PathBuf};
 
 /// `kin mcp start` — Start the MCP stdio server.
 ///
 /// Starts a transport-only MCP server. Graph-backed tools are executed by the
 /// repo daemon resolved through the supervisor route; MCP never loads or serves
 /// a local graph snapshot in product mode.
-pub async fn start(global: bool) -> Result<()> {
+///
+/// Never hard-exits on a missing repository or an unreachable daemon: an agent
+/// CLI that launches this as a global MCP entry from a non-Kin directory must
+/// still get a working `initialize`/`tools/list` handshake, not a dead process
+/// before the handshake. When no repository can be bound at startup, the
+/// server starts anyway and each `tools/call` fails loud with a structured,
+/// actionable error (see `kin_mcp::daemon_delegate::daemon_unavailable_tool_result`)
+/// instead of the process silently never having started at all.
+pub async fn start(global: bool, repo: Option<PathBuf>) -> Result<()> {
     if global {
         anyhow::bail!(
             "`kin mcp start --global` (multi-repo registry mode) is not yet implemented.\n\
              Omit --global to start in single-repo mode, or set KIN_DAEMON_URL to a running daemon."
         );
     }
-    let daemon_url = if let Ok(url) = std::env::var("KIN_DAEMON_URL") {
-        url
-    } else {
-        let cwd = std::env::current_dir()?;
-        let layout = kin_core::KinLayout::discover(&cwd).ok_or_else(|| {
-            anyhow::anyhow!("not a Kin repository (no .kin/ found); run `kin init .` first")
-        })?;
-        let url = crate::daemon_client::resolve_daemon_url_for_mcp(&layout)
-            .await?
-            .ok_or_else(|| {
-                anyhow::anyhow!(
-                    "Kin daemon is required for MCP startup but no daemon endpoint is available"
-                )
-            })?;
-        std::env::set_var("KIN_DAEMON_URL", &url);
-        url
-    };
-    eprintln!("{}", session_authority_notice());
-    eprintln!("Kin MCP: forwarding graph tools to repo daemon at {daemon_url}");
+
+    if let Some(repo_dir) = resolve_repo_override(repo) {
+        if let Err(err) = std::env::set_current_dir(&repo_dir) {
+            eprintln!(
+                "Kin MCP: --repo/KIN_MCP_REPO path {} could not be used as the working directory \
+                 ({err}); continuing from the launch directory.",
+                repo_dir.display()
+            );
+        }
+    }
+
+    let cwd = std::env::current_dir().unwrap_or_else(|_| PathBuf::from("."));
+    match bind_daemon_for_repo_dir(&cwd).await {
+        Ok(daemon_url) => {
+            eprintln!("{}", session_authority_notice());
+            eprintln!("Kin MCP: forwarding graph tools to repo daemon at {daemon_url}");
+        }
+        Err(reason) => {
+            eprintln!(
+                "Kin MCP: starting without a bound Kin repository ({reason}). Tool calls will \
+                 return a structured error until a repository is bound: run `kin init .`, \
+                 relaunch this MCP server with its working directory inside a Kin repository, or \
+                 pass --repo <path> (or set KIN_MCP_REPO=<path>)."
+            );
+        }
+    }
 
     let mut config = build_mcp_start_config();
     let profile_tools: Option<&'static [&'static str]> =
@@ -75,9 +91,85 @@ fn build_mcp_start_config() -> kin_mcp::McpServerConfig {
     }
 }
 
+/// Resolve an explicit repository override for MCP startup: an explicit
+/// `--repo` flag wins, then `KIN_MCP_REPO`. Returns `None` when neither is
+/// set, in which case MCP binds whatever repository (if any) contains the
+/// launching process's working directory — the pre-existing behavior for a
+/// per-repo MCP entry.
+///
+/// This is the fix-shape the agent-global wiring case needs: a global agent
+/// CLI MCP entry always launches with cwd at the session's project directory,
+/// which is frequently not a Kin repository at all (an umbrella workspace
+/// root, brownfield code before `kin init`, etc). Pointing that entry at
+/// --repo/KIN_MCP_REPO lets it bind a specific repository regardless of cwd.
+fn resolve_repo_override(repo_arg: Option<PathBuf>) -> Option<PathBuf> {
+    repo_arg.or_else(|| std::env::var_os("KIN_MCP_REPO").map(PathBuf::from))
+}
+
+/// Resolve (autostarting if needed) the repo daemon for `dir` and pin
+/// `KIN_DAEMON_URL` so the stdio server's per-call tool forwarding routes to
+/// it. Returns a human-readable reason on failure instead of propagating a
+/// hard error: `kin mcp start` must always reach the stdio loop so
+/// `initialize`/`tools/list` succeed even when no repository is bound yet,
+/// with individual `tools/call` requests failing loud instead.
+async fn bind_daemon_for_repo_dir(dir: &Path) -> std::result::Result<String, String> {
+    if let Ok(url) = std::env::var("KIN_DAEMON_URL") {
+        if !url.trim().is_empty() {
+            return Ok(url);
+        }
+    }
+    let layout = kin_core::KinLayout::discover(dir).ok_or_else(|| {
+        "not inside a kin repository (no .kin/ found); run `kin init .` first".to_string()
+    })?;
+    let url = crate::daemon_client::resolve_daemon_url_for_mcp(&layout)
+        .await
+        .map_err(|e| format!("{e:#}"))?
+        .ok_or_else(|| {
+            "Kin daemon is required for MCP startup but no daemon endpoint is available".to_string()
+        })?;
+    std::env::set_var("KIN_DAEMON_URL", &url);
+    Ok(url)
+}
+
 #[cfg(test)]
 mod tests {
-    use super::{build_mcp_start_config, session_authority_notice, start};
+    use super::{
+        bind_daemon_for_repo_dir, build_mcp_start_config, resolve_repo_override,
+        session_authority_notice, start,
+    };
+    use std::path::PathBuf;
+
+    /// RAII guard that saves and restores a single env var around a test, so
+    /// tests that mutate process-global env state (unavoidable — cwd/env are
+    /// how `kin mcp start` binds its repo) don't leak into other tests in this
+    /// binary.
+    struct EnvVarGuard {
+        key: &'static str,
+        previous: Option<String>,
+    }
+
+    impl EnvVarGuard {
+        fn set(key: &'static str, value: impl AsRef<std::ffi::OsStr>) -> Self {
+            let previous = std::env::var(key).ok();
+            std::env::set_var(key, value);
+            Self { key, previous }
+        }
+
+        fn remove(key: &'static str) -> Self {
+            let previous = std::env::var(key).ok();
+            std::env::remove_var(key);
+            Self { key, previous }
+        }
+    }
+
+    impl Drop for EnvVarGuard {
+        fn drop(&mut self) {
+            match &self.previous {
+                Some(value) => std::env::set_var(self.key, value),
+                None => std::env::remove_var(self.key),
+            }
+        }
+    }
 
     #[test]
     fn daemon_available_notice_mentions_daemon_authority() {
@@ -98,12 +190,62 @@ mod tests {
 
     #[tokio::test]
     async fn global_flag_returns_clear_error() {
-        let err = start(true).await.unwrap_err();
+        let err = start(true, None).await.unwrap_err();
         let msg = err.to_string();
         assert!(
             msg.contains("not yet implemented"),
             "unexpected message: {msg}"
         );
         assert!(msg.contains("--global"), "missing flag hint: {msg}");
+    }
+
+    #[test]
+    fn repo_override_prefers_explicit_flag_over_env() {
+        let _guard = EnvVarGuard::set("KIN_MCP_REPO", "/env/path");
+        let resolved = resolve_repo_override(Some(PathBuf::from("/flag/path")));
+        assert_eq!(resolved, Some(PathBuf::from("/flag/path")));
+    }
+
+    #[test]
+    fn repo_override_falls_back_to_env_var() {
+        let _guard = EnvVarGuard::set("KIN_MCP_REPO", "/env/path");
+        let resolved = resolve_repo_override(None);
+        assert_eq!(resolved, Some(PathBuf::from("/env/path")));
+    }
+
+    #[test]
+    fn repo_override_none_when_neither_flag_nor_env_set() {
+        let _guard = EnvVarGuard::remove("KIN_MCP_REPO");
+        assert_eq!(resolve_repo_override(None), None);
+    }
+
+    #[tokio::test]
+    async fn bind_daemon_reports_missing_repo_without_hard_error() {
+        // A directory with no .kin/ must produce an `Err` reason string for
+        // the caller to log, never a panic or a process-killing error
+        // propagated out of `start`.
+        let _daemon_guard = EnvVarGuard::remove("KIN_DAEMON_URL");
+        let tmp = tempfile::tempdir().unwrap();
+        let reason = bind_daemon_for_repo_dir(tmp.path())
+            .await
+            .expect_err("a directory with no .kin/ must not resolve a daemon");
+        assert!(
+            reason.contains("not inside a kin repository"),
+            "unexpected reason: {reason}"
+        );
+    }
+
+    #[tokio::test]
+    async fn bind_daemon_short_circuits_on_explicit_daemon_url() {
+        // When KIN_DAEMON_URL is already set (e.g. by a supervising session),
+        // binding must trust it directly rather than requiring a local .kin/
+        // — this is the existing multi-process pinning contract and must
+        // survive the lazy-binding rework unchanged.
+        let _guard = EnvVarGuard::set("KIN_DAEMON_URL", "http://127.0.0.1:4242");
+        let tmp = tempfile::tempdir().unwrap();
+        let url = bind_daemon_for_repo_dir(tmp.path())
+            .await
+            .expect("an explicit KIN_DAEMON_URL must be trusted without repo discovery");
+        assert_eq!(url, "http://127.0.0.1:4242");
     }
 }

--- a/crates/kin-cli/src/main.rs
+++ b/crates/kin-cli/src/main.rs
@@ -1407,6 +1407,12 @@ enum McpAction {
         /// Run in global mode, serving all registered repos from ~/.kin/registry.toml
         #[arg(long)]
         global: bool,
+        /// Bind this server to a specific Kin repository instead of relying on
+        /// the launching process's working directory. Overrides KIN_MCP_REPO.
+        /// Use this for a global agent-CLI MCP entry that may launch outside
+        /// any Kin repository (e.g. an umbrella workspace root).
+        #[arg(long, value_name = "PATH")]
+        repo: Option<PathBuf>,
     },
 }
 
@@ -2372,7 +2378,7 @@ fn main() -> Result<()> {
                     }
                 },
                 Command::Mcp { action } => match action {
-                    McpAction::Start { global } => commands::mcp::start(global).await,
+                    McpAction::Start { global, repo } => commands::mcp::start(global, repo).await,
                 },
                 Command::Auth { action } => match action {
                     AuthAction::Login {

--- a/crates/kin-core/src/env_registry.rs
+++ b/crates/kin-core/src/env_registry.rs
@@ -265,6 +265,7 @@ pub const OPERATIONAL: &[EnvVarSpec] = &[
     EnvVarSpec { name: "KIN_BINARY_PATH", kind: Kind::Path, default: "", sensitivity: Sensitivity::Operational, summary: "override the kin binary path for bench dispatch" },
     EnvVarSpec { name: "KIN_BUILD_GRAPH_TIMEOUT_SECS", kind: Kind::Secs, default: "60", sensitivity: Sensitivity::Operational, summary: "timeout for building a historical ref-view graph" },
     EnvVarSpec { name: "KIN_MCP_TOOL_PROFILE", kind: Kind::Str, default: "", sensitivity: Sensitivity::Operational, summary: "MCP tool exposure profile" },
+    EnvVarSpec { name: "KIN_MCP_REPO", kind: Kind::Path, default: "", sensitivity: Sensitivity::Operational, summary: "bind `kin mcp start` to this repository instead of the launch directory" },
 
     // ---- diagnostics / benchmarking ------------------------------------------
     EnvVarSpec { name: "KIN_LOCATE_DEBUG", kind: Kind::Bool, default: "false", sensitivity: Sensitivity::Diagnostic, summary: "emit locate pipeline debug output" },

--- a/crates/kin-mcp/src/daemon_delegate.rs
+++ b/crates/kin-mcp/src/daemon_delegate.rs
@@ -831,6 +831,27 @@ async fn forward_graph_status(
 }
 
 pub fn daemon_unavailable_tool_result(name: &str) -> ToolCallResult {
+    unavailable_tool_result_for(name, discover_kin_dir().as_deref())
+}
+
+/// Pure core of [`daemon_unavailable_tool_result`]: given the `.kin/`
+/// directory (if any) discovered from the server's working directory, decide
+/// whether the tool call failed because no repository is bound at all, versus
+/// a repository being bound but its daemon being unreachable. The two cases
+/// get distinct, actionable messages so an agent session that never bound a
+/// repository (e.g. a global MCP entry launched outside any Kin repo) is told
+/// how to bind one, rather than being handed a generic daemon-availability
+/// error. Factored out with an explicit `kin_dir` parameter so the branch is
+/// unit-testable without mutating the process working directory.
+fn unavailable_tool_result_for(name: &str, kin_dir: Option<&Path>) -> ToolCallResult {
+    if kin_dir.is_none() {
+        return ToolCallResult::error(format!(
+            "kin-mcp has no Kin repository bound for '{name}': not inside a kin repository (no \
+             .kin/ found from the server's working directory). Run `kin init .` in the target \
+             repository and restart this MCP server from there, or relaunch `kin mcp start` with \
+             --repo <path> (or KIN_MCP_REPO=<path>) to bind one explicitly."
+        ));
+    }
     daemon_required_unavailable(name)
 }
 
@@ -1533,5 +1554,35 @@ mod tests {
             serde_json::json!("explicit-session"),
         );
         assert_eq!(session_key(&args), "explicit-session");
+    }
+
+    #[test]
+    fn unavailable_result_reports_missing_repo_when_no_kin_dir() {
+        let result = unavailable_tool_result_for("semantic_search", None);
+        assert_eq!(result.is_error, Some(true));
+        let ContentBlock::Text { text } = result.content.first().unwrap();
+        assert!(
+            text.contains("not inside a kin repository"),
+            "expected no-repo-bound message, got: {text}"
+        );
+        assert!(
+            text.contains("--repo") && text.contains("KIN_MCP_REPO"),
+            "expected message to tell the caller how to bind a repo, got: {text}"
+        );
+    }
+
+    #[test]
+    fn unavailable_result_reports_daemon_unreachable_when_repo_is_bound() {
+        let tmp = tempfile::tempdir().unwrap();
+        let result = unavailable_tool_result_for("semantic_search", Some(tmp.path()));
+        let ContentBlock::Text { text } = result.content.first().unwrap();
+        assert!(
+            text.contains("Kin daemon is required"),
+            "expected daemon-unreachable message, got: {text}"
+        );
+        assert!(
+            !text.contains("not inside a kin repository"),
+            "a bound repo must not report itself as unbound, got: {text}"
+        );
     }
 }

--- a/docs/env-vars.md
+++ b/docs/env-vars.md
@@ -3,7 +3,7 @@
 
 # Kin environment variables
 
-This is the authoritative list of supported `KIN_*` environment variables (392 total, 294 correctness-relevant), generated from the central registry in `kin-core`.
+This is the authoritative list of supported `KIN_*` environment variables (393 total, 294 correctness-relevant), generated from the central registry in `kin-core`.
 
 At CLI and daemon startup Kin validates this surface (`KIN_ENV_VALIDATION`, default `warn`):
 
@@ -40,6 +40,7 @@ Sensitivity legend: **correctness** (affects retrieval/ranking/output or data sa
 | `KIN_BYPASS_EMBEDDING_COVERAGE_CHECK` | bool | false | correctness | bypass the embedding-coverage correctness gate |
 | `KIN_CLAUDE_DISALLOWED_TOOLS` | string | *(unset)* | operational | comma-separated tool names disallowed in a with-session |
 | `KIN_DISABLE_SPINE` | bool | false | correctness | disable the spine federation layer, narrowing retrieval scope |
+| `KIN_MCP_REPO` | path | *(unset)* | operational | bind `kin mcp start` to this repository instead of the launch directory |
 | `KIN_MCP_TOOL_PROFILE` | string | *(unset)* | operational | MCP tool exposure profile |
 | `KIN_NO_DAEMON` | bool | false | operational | force in-process execution instead of the daemon |
 | `KIN_NO_KEYRING` | bool | false | operational | skip the OS keyring for credential storage |


### PR DESCRIPTION
## Summary
- `kin mcp start` resolved the repo + daemon before the stdio loop began, so a missing `.kin/` or an unreachable daemon killed the process before the MCP `initialize` handshake — a global agent-CLI MCP entry launched outside a Kin repository (e.g. an umbrella workspace root) got zero tools with no visible cause.
- Repo/daemon binding is now best-effort at startup: on failure the server still starts, `initialize`/`tools/list` still succeed, and each `tools/call` fails loud with a structured error that distinguishes "no repository bound" from "repository bound but daemon unreachable," telling the caller how to fix it.
- Adds `--repo <path>` / `KIN_MCP_REPO` to bind an explicit repository regardless of the launch working directory, for MCP entries that can't control their cwd. Registered in the `KIN_*` env registry and `docs/env-vars.md`.

## Out of scope (belongs to other lanes/PRs)
- `kin setup` / `doctor --fix` acceptance adding a real MCP handshake probe — owned by the setup/doctor lane (`crates/kin-cli/src/commands/{health,setup,setup_ledger}.rs`, currently open in PR #259), intentionally not touched here.
- True per-tool-call multi-repo binding (switching repos based on tool args/client roots) for a single long-lived global MCP process — the ticket names this as the "preferred" long-term shape but it's a much larger change (would need a repo argument threaded through every tool schema). This PR ships the smaller, immediately-actionable fix: never die at boot, fail loud per call, and support explicit repo pinning via `--repo`/`KIN_MCP_REPO`.

## Test plan
- [x] `cargo test -p kin-cli --lib commands::mcp::` — 8 passed (repo-override resolution, daemon-binding success/failure paths, existing `--global` test)
- [x] `cargo test -p kin-mcp --lib daemon_delegate::tests::` — 26 passed (incl. 2 new: no-repo vs daemon-unreachable message branching)
- [x] `cargo clippy -p kin-cli -p kin-mcp -p kin-core --all-targets --all-features` with the CI allow-list — clean
- [x] `cargo fmt --check` — clean
- [x] `cargo test -p kin-core env_doc_matches_registry` — clean (doc regenerated for the new `KIN_MCP_REPO` entry)

https://linear.app/firelock-ai/issue/FIR-1417/kin-mcp-server-exits-at-startup-when-cwd-is-not-a-kin-repo-agent