### PR TITLE
ci(release): verify the Homebrew tap actually bumped, not just dispatched

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -704,7 +704,7 @@ jobs:
             | curl -fsS -H "Content-Type: application/json" -d @- "$DISCORD_WEBHOOK_URL"
 
   bump_homebrew:
-    name: Trigger Homebrew formula bump
+    name: Trigger & verify Homebrew formula bump
     needs: publish
     # Mirror publish's always() guard so a skipped notarize_linux does not
     # transitively skip this job.
@@ -712,16 +712,20 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Dispatch update to the homebrew-kin tap
+        id: dispatch
         env:
           TAP_DISPATCH_TOKEN: ${{ secrets.KIN_CI_BOT_TOKEN }}
         run: |
           if [ -z "${TAP_DISPATCH_TOKEN:-}" ]; then
             echo "KIN_CI_BOT_TOKEN not configured; the tap self-updates on its 6h schedule"
+            echo "dispatched=false" >> "$GITHUB_OUTPUT"
             exit 0
           fi
           # Convenience dispatch: the tap also self-updates on its 6h schedule, so a
           # failure here (e.g. a token without homebrew-kin access) warns rather than
-          # failing an already-published release.
+          # failing an already-published release. A 204 only proves GitHub accepted
+          # the POST, not that the tap's own workflow ran or bumped the formula — the
+          # step below verifies that outcome.
           code=$(curl -sS -o /tmp/tap-dispatch.out -w '%{http_code}' -X POST \
             -H "Authorization: Bearer ${TAP_DISPATCH_TOKEN}" \
             -H "Accept: application/vnd.github+json" \
@@ -729,10 +733,45 @@ jobs:
             -d '{"event_type":"kin-release"}' || echo "000")
           if [ "$code" = "204" ]; then
             echo "Dispatched kin-release to firelock-ai/homebrew-kin"
+            echo "dispatched=true" >> "$GITHUB_OUTPUT"
           else
             echo "::warning::Homebrew tap dispatch returned HTTP ${code}; the tap self-updates on its 6h schedule, not failing the release."
             cat /tmp/tap-dispatch.out 2>/dev/null || true
+            echo "dispatched=false" >> "$GITHUB_OUTPUT"
           fi
+
+      # The dispatch above only proves the POST was accepted, not that
+      # homebrew-kin's own workflow ran and actually bumped the formula (a
+      # prior release's dispatch reported success while the tap workflow
+      # never fired and the formula stayed stale for hours until a manual
+      # rerun). Poll the tap's published formula for the version this release
+      # actually cut, mirroring version_tag_image's bounded poll-for-outcome
+      # below rather than trusting the dispatch response as release proof.
+      - name: Verify the tap formula actually bumped to this version
+        if: steps.dispatch.outputs.dispatched == 'true'
+        env:
+          TAP_DISPATCH_TOKEN: ${{ secrets.KIN_CI_BOT_TOKEN }}
+        run: |
+          set -euo pipefail
+          VERSION="${GITHUB_REF_NAME#v}"
+
+          check_formula() {
+            curl -sS -H "Authorization: Bearer ${TAP_DISPATCH_TOKEN}" \
+              -H "Accept: application/vnd.github.v3.raw" \
+              "https://api.github.com/repos/firelock-ai/homebrew-kin/contents/Formula/kin.rb" \
+              | grep -qF "version \"${VERSION}\""
+          }
+
+          deadline=$(( SECONDS + 1800 ))
+          until check_formula; do
+            if [ "$SECONDS" -ge "$deadline" ]; then
+              echo "::error::firelock-ai/homebrew-kin Formula/kin.rb did not report version \"${VERSION}\" after 30m — the kin-release dispatch was accepted but the tap's Update Formula workflow did not land the bump. Check https://github.com/firelock-ai/homebrew-kin/actions."
+              exit 1
+            fi
+            echo "Waiting for firelock-ai/homebrew-kin Formula/kin.rb to report version \"${VERSION}\"…"
+            sleep 20
+          done
+          echo "Confirmed firelock-ai/homebrew-kin Formula/kin.rb is at version \"${VERSION}\""
 
   # Version-tag the public daemon image so operators can pin a release
   # (`docker pull ghcr.io/firelock-ai/kin:0.2.7`). daemon-image.yml already pushed


### PR DESCRIPTION
## Summary
- `bump_homebrew` treated a `204` from the `repository_dispatch` POST to `homebrew-kin` as success — but that only proves GitHub queued the event, not that the tap's own "Update Formula" workflow ran or produced a commit. During the 0.2.9 release, the dispatch reported success while the tap workflow never fired and the formula stayed stale for ~4h until a manual `gh workflow run`.
- After a successful dispatch, the job now polls the tap's published `Formula/kin.rb` for the version this release actually cut (bounded at 30m, `sleep 20` between checks) and fails the job loudly (`::error::` + `exit 1`) if it never lands — mirroring the exact bounded poll-for-outcome pattern `version_tag_image` already uses lower in this same file to wait on `daemon-image.yml`.
- Minimal, workflow-only change: no new tooling/dependency, reuses the same `KIN_CI_BOT_TOKEN` secret and `curl` already used by the dispatch step. The "token not configured" and "dispatch rejected" fallback behavior (tap self-updates on its 6h schedule) is unchanged — verification only runs after a genuinely accepted dispatch.

## Validation
- [x] `actionlint .github/workflows/release.yml` — identical pre-existing `matrix.cross` warnings only (confirmed present on `origin/main` before this change too); zero new findings, including in the embedded shell (shellcheck-backed)
- [x] `python3 -c "import yaml; yaml.safe_load(open(...))"` — parses clean
- [x] Grepped for other references to the old job name ("Trigger Homebrew formula bump") — none, safe rename to "Trigger & verify Homebrew formula bump"

https://linear.app/firelock-ai/issue/FIR-1270/releasehomebrew-dispatch-is-fire-and-forget-029s-trigger-succeeded-but