### PR TITLE
docs(readme): correct npm publish status for @kinlab/kin

### DIFF
--- a/README.md
+++ b/README.md
@@ -182,7 +182,7 @@ Supporting substrate:
 Kin is **0.2.x** — pre-1.0 and under active development. Expect rough edges and breaking
 changes between releases. Being precise about what is and isn't ready today:
 
-- **Install surface.** Native binaries ship on GitHub Releases and via the install script. A canonical `@kinlab/kin` npm package is not published yet; the MCP wrapper `@kinlab/kin-mcp` is.
+- **Install surface.** Native binaries ship on GitHub Releases and via the install script; the canonical `@kinlab/kin` npm package (`npm i -g @kinlab/kin`, or `npx -y @kinlab/kin`) provisions the same managed `kin` + `kin-daemon` release for npm-based workflows. `@kinlab/kin-mcp` remains published as a compatibility wrapper.
 - **Windows.** The native Windows binary is a limited, vector-free build with no filesystem projection. Use WSL2 for the complete experience.
 - **Semantic search.** `kin init` builds the graph without embeddings; run `kin embed` to enable vector search. Until then, `locate`/`search` run on lexical + graph signals and say so.
 - **Hosted KinLab.** Connecting a repo to hosted KinLab is coming soon; it is not yet a first-run flow.


### PR DESCRIPTION
## Summary
- The "Install surface" bullet in the Status & roadmap section claimed the canonical `@kinlab/kin` npm package was "not published yet." It has been live on public npm since Jul 7 (install-verified on macOS + Linux; see FIR-1329) and is already assumed to exist a few paragraphs above, in the MCP advanced-configuration note (`npx -y @kinlab/kin`).
- Rewrote the bullet to state the package is live (`npm i -g @kinlab/kin` / `npx -y @kinlab/kin`), version-agnostic (no hardcoded version number), and kept the `@kinlab/kin-mcp` compatibility-wrapper framing accurate and consistent with the rest of the README.

## Judgment calls (not changed, flagging for a human/product call)
- README "Status & roadmap" and `docs/quickstart.md`'s setup-intent table both still say connecting a repo to hosted KinLab is "coming soon" / "not yet a first-run flow." This isn't an npm-publish claim, so left untouched, but worth a separate look given hosted org-graph ingestion has since gone live for other purposes — the specific claim here is about the `kin setup` first-run wizard flow, which I did not verify independently.
- GitHub Releases / the install script are still pinned to v0.2.12 in the README while `@kinlab/kin` and `@kinlab/kin-mcp` are already at 0.2.13 on npm. Didn't touch version numbers (out of scope / would need a real release bump), but flagging the drift.

## Test plan
- [x] Grepped README.md + docs/ for other "not published" / "not yet published" / npm-stale phrasing — no other false claims found (see judgment calls above for non-npm "coming soon" phrasing left as-is).
- [x] Confirmed on npm registry: `@kinlab/kin` dist-tags latest = 0.2.13, `@kinlab/kin-mcp` = 0.2.13.
- [x] Diff is docs-only; no code/build implications.