### PR TITLE
Recognize coherent in-diff consumer migration and additive signature changes in review gating

### DIFF
--- a/crates/kin-cli/src/commands/review.rs
+++ b/crates/kin-cli/src/commands/review.rs
@@ -1230,6 +1230,7 @@ fn inline_comment_severity(kind: kin_review::InlineCommentKind) -> &'static str 
         | InlineCommentKind::RevertHistory => "warning",
         InlineCommentKind::Added
         | InlineCommentKind::Removed
+        | InlineCommentKind::BreakingMigrated
         | InlineCommentKind::RevertHistoryIncidental => "info",
     }
 }

--- a/crates/kin-review/src/impact.rs
+++ b/crates/kin-review/src/impact.rs
@@ -11,8 +11,20 @@ use kin_model::relation::{GraphNodeId, Relation, RelationKind};
 use kin_model::work::{Annotation, StalenessState, WorkItem, WorkScope};
 use serde::{Deserialize, Serialize};
 
-use crate::diff::SemanticDiff;
+use crate::diff::{EntityChangeKind, SemanticDiff};
 use crate::error::ReviewError;
+
+/// Line-independent identity of an entity: `(file, name, kind)`. `EntityId`
+/// folds in `start_line`, so a declaration that only moved carries a new id
+/// under the same identity. Co-change matching keys on this so a co-updated
+/// consumer is recognized whether or not its line (and thus id) shifted.
+fn entity_identity_key(entity: &Entity) -> (String, String, String) {
+    (
+        entity_file(entity).unwrap_or_default(),
+        entity.name.clone(),
+        format!("{:?}", entity.kind),
+    )
+}
 
 /// The exact read surface the impact walker consumes.
 ///
@@ -177,6 +189,13 @@ pub struct EntityImpact {
     /// Distinct test entities covering this entity (test-kind edges plus
     /// test-role inbound entities).
     pub covering_tests: usize,
+    /// Distinct non-test, non-derived consumers that were themselves modified
+    /// in the reviewed range — the coherent in-diff migration signal. These
+    /// are excluded from `consumer_count` (a co-updated consumer is not a
+    /// stranded external break); this field preserves the evidence that the
+    /// surface change did have consumers and that they all moved with it.
+    #[serde(default)]
+    pub consumers_migrated_in_diff: usize,
 }
 
 impl EntityImpact {
@@ -184,6 +203,15 @@ impl EntityImpact {
     /// Zero means the graph connects nothing to this entity.
     pub fn inbound_total(&self) -> usize {
         self.consumer_count + self.covering_tests
+    }
+
+    /// True when this entity has graph-known consumers and EVERY one was
+    /// itself modified in the reviewed range: a self-contained migration with
+    /// no stranded external consumer. `consumer_count` counts only external
+    /// (non-migrated) consumers, so zero external plus at least one migrated
+    /// consumer is a fully coherent in-diff migration.
+    pub fn all_consumers_migrated(&self) -> bool {
+        self.consumer_count == 0 && self.consumers_migrated_in_diff > 0
     }
 }
 
@@ -246,6 +274,22 @@ pub fn analyze_impact_at<I: ImpactGraph>(
 ) -> Result<ImpactReport, ReviewError> {
     let changed_ids = diff.changed_entity_ids();
     let changed_set: HashSet<EntityId> = changed_ids.iter().copied().collect();
+    // Line-independent identity of every entity touched in the reviewed range,
+    // for both base and head sides of a modification. A co-updated consumer
+    // that moved lines or changed its own signature keeps its (file, name,
+    // kind) even as its content-derived id changes, so this key recognizes it
+    // as migrated when exact-id matching cannot.
+    let changed_keys: HashSet<(String, String, String)> = diff
+        .entity_changes
+        .iter()
+        .flat_map(|change| match &change.kind {
+            EntityChangeKind::Added(entity) => vec![entity_identity_key(entity)],
+            EntityChangeKind::Modified { old, new } => {
+                vec![entity_identity_key(old), entity_identity_key(new)]
+            }
+            EntityChangeKind::Removed(_) => Vec::new(),
+        })
+        .collect();
 
     let mut callers = Vec::new();
     let mut dependents = Vec::new();
@@ -267,6 +311,9 @@ pub fn analyze_impact_at<I: ImpactGraph>(
         let mut ent_strong_consumers: HashSet<EntityId> = HashSet::new();
         let mut ent_contract_consumers: HashSet<EntityId> = HashSet::new();
         let mut ent_tests: HashSet<EntityId> = HashSet::new();
+        // Non-test, non-derived consumers that were themselves modified in the
+        // reviewed range: the coherent in-diff migration signal.
+        let mut ent_migrated: HashSet<EntityId> = HashSet::new();
         // `consumer_files` is the human-readable projection of the consumer
         // ENTITY set below (which the fanout decision keys on) — the files those
         // consuming entities live in, for the report message only. It is never a
@@ -302,55 +349,75 @@ pub fn analyze_impact_at<I: ImpactGraph>(
                 continue;
             };
 
-            // Skip if the affected entity is itself a changed entity
-            if changed_set.contains(&affected_id) {
+            let Some(entity) = graph.get_entity(&affected_id)? else {
+                continue;
+            };
+
+            // A consumer that was itself modified in the reviewed range is a
+            // MIGRATED consumer — it moved with the changed surface in the same
+            // diff — not a stranded external break. Match on the exact id AND a
+            // line-independent (file, name, kind) key: `EntityId` is
+            // content-derived from (file, name, kind, start_line), so a
+            // co-updated consumer whose declaration shifted lines or whose own
+            // signature changed carries a different id at head than the id its
+            // inbound edge resolves under. Exact-id matching alone would read
+            // that coherent migration as an external break.
+            if changed_set.contains(&affected_id)
+                || changed_keys.contains(&entity_identity_key(&entity))
+            {
+                let is_test = entity.role == EntityRole::Test || rel.kind == RelationKind::Tests;
+                let is_derived =
+                    matches!(entity.role, EntityRole::Generated | EntityRole::Vendored);
+                // Only a real consumer surface counts as a migrated consumer;
+                // a co-updated test or regenerated copy was never a break.
+                if !is_test && !is_derived {
+                    ent_migrated.insert(affected_id);
+                }
                 continue;
             }
 
-            if let Some(entity) = graph.get_entity(&affected_id)? {
-                let is_test = entity.role == EntityRole::Test || rel.kind == RelationKind::Tests;
-                if is_test {
-                    ent_tests.insert(affected_id);
-                } else if matches!(entity.role, EntityRole::Generated | EntityRole::Vendored) {
-                    // Derived copies (amalgamated bundles, vendored snapshots)
-                    // regenerate from their sources; they appear in the blast
-                    // radius for navigation but cannot be "broken" consumers,
-                    // so they never feed consumer counts or breaking findings.
-                } else {
-                    ent_consumers.insert(affected_id);
-                    if rel.confidence >= STRONG_CONSUMER_CONFIDENCE {
-                        ent_strong_consumers.insert(affected_id);
-                    }
-                    if rel.kind == RelationKind::ConsumesContract {
-                        ent_contract_consumers.insert(affected_id);
-                    }
-                    if let Some(file) = entity_file(&entity) {
-                        ent_consumer_files.insert(file);
+            let is_test = entity.role == EntityRole::Test || rel.kind == RelationKind::Tests;
+            if is_test {
+                ent_tests.insert(affected_id);
+            } else if matches!(entity.role, EntityRole::Generated | EntityRole::Vendored) {
+                // Derived copies (amalgamated bundles, vendored snapshots)
+                // regenerate from their sources; they appear in the blast
+                // radius for navigation but cannot be "broken" consumers,
+                // so they never feed consumer counts or breaking findings.
+            } else {
+                ent_consumers.insert(affected_id);
+                if rel.confidence >= STRONG_CONSUMER_CONFIDENCE {
+                    ent_strong_consumers.insert(affected_id);
+                }
+                if rel.kind == RelationKind::ConsumesContract {
+                    ent_contract_consumers.insert(affected_id);
+                }
+                if let Some(file) = entity_file(&entity) {
+                    ent_consumer_files.insert(file);
+                }
+            }
+            match rel.kind {
+                RelationKind::Calls => {
+                    if seen_callers.insert(affected_id) {
+                        callers.push(entity);
                     }
                 }
-                match rel.kind {
-                    RelationKind::Calls => {
-                        if seen_callers.insert(affected_id) {
-                            callers.push(entity);
-                        }
+                RelationKind::DependsOn | RelationKind::References => {
+                    if seen_dependents.insert(affected_id) {
+                        dependents.push(entity);
                     }
-                    RelationKind::DependsOn | RelationKind::References => {
-                        if seen_dependents.insert(affected_id) {
-                            dependents.push(entity);
-                        }
-                    }
-                    RelationKind::ConsumesContract => {
-                        if seen_consumers.insert(affected_id) {
-                            contract_consumers.push(entity);
-                        }
-                    }
-                    RelationKind::Tests => {
-                        if seen_tests.insert(affected_id) {
-                            tests.push(entity);
-                        }
-                    }
-                    _ => {}
                 }
+                RelationKind::ConsumesContract => {
+                    if seen_consumers.insert(affected_id) {
+                        contract_consumers.push(entity);
+                    }
+                }
+                RelationKind::Tests => {
+                    if seen_tests.insert(affected_id) {
+                        tests.push(entity);
+                    }
+                }
+                _ => {}
             }
         }
 
@@ -388,6 +455,7 @@ pub fn analyze_impact_at<I: ImpactGraph>(
             contract_consumer_count: ent_contract_consumers.len(),
             consumer_files: ent_consumer_files.into_iter().collect(),
             covering_tests: ent_tests.len(),
+            consumers_migrated_in_diff: ent_migrated.len(),
         });
     }
 
@@ -781,5 +849,116 @@ mod tests {
             vec!["src/bar.rs".to_string(), "src/foo.rs".to_string()],
             "consumer_files is the projected file set of the consumer entities (both), report-only"
         );
+    }
+
+    #[test]
+    fn line_shifted_co_updated_consumer_is_migrated_not_an_external_break() {
+        // `target` changed its signature. Its only consumer, `mover`, was ALSO
+        // modified in the diff — but its declaration shifted lines, so the
+        // head-graph inbound edge resolves to an id that differs from the id
+        // the diff recorded for `mover`. Exact-id matching would miscount this
+        // coherent migration as an external break; the (file, name, kind)
+        // identity key recognizes it.
+        let target = entity_in_file("target", "src/http.rs", 10);
+        let mover_in_diff = entity_in_file("mover", "src/create.rs", 20);
+        let mut mover_at_head = mover_in_diff.clone();
+        mover_at_head.id = EntityId::new();
+
+        let mut graph = MockImpactGraph::default();
+        graph.entities.insert(target.id, target.clone());
+        graph
+            .entities
+            .insert(mover_at_head.id, mover_at_head.clone());
+        graph
+            .inbound
+            .insert(target.id, vec![calls(&mover_at_head, &target)]);
+
+        let diff = SemanticDiff {
+            entity_changes: vec![modified(&target), modified(&mover_in_diff)],
+            ..Default::default()
+        };
+
+        let report = analyze_impact_at(&graph, &diff).unwrap();
+        let impact = report.entity_impact(&target.id).expect("target impact");
+        assert_eq!(
+            impact.consumer_count, 0,
+            "a co-updated consumer whose id shifted is not a stranded external break"
+        );
+        assert_eq!(
+            impact.consumers_migrated_in_diff, 1,
+            "the line-shifted co-update is recognized as migrated by identity key"
+        );
+        assert!(impact.all_consumers_migrated());
+    }
+
+    #[test]
+    fn partial_migration_keeps_the_external_consumer_counted() {
+        // `target` has two consumers: `mover` (co-updated, line-shifted id) and
+        // `stranger` (untouched, in a file the diff never mentions). The
+        // migration is PARTIAL — `stranger` still counts as an external break,
+        // so the entity is not "all migrated".
+        let target = entity_in_file("target", "src/http.rs", 10);
+        let mover_in_diff = entity_in_file("mover", "src/create.rs", 20);
+        let mut mover_at_head = mover_in_diff.clone();
+        mover_at_head.id = EntityId::new();
+        let stranger = entity_in_file("stranger", "src/other.rs", 5);
+
+        let mut graph = MockImpactGraph::default();
+        for entity in [&target, &mover_at_head, &stranger] {
+            graph.entities.insert(entity.id, entity.clone());
+        }
+        graph.inbound.insert(
+            target.id,
+            vec![calls(&mover_at_head, &target), calls(&stranger, &target)],
+        );
+
+        let diff = SemanticDiff {
+            entity_changes: vec![modified(&target), modified(&mover_in_diff)],
+            ..Default::default()
+        };
+
+        let report = analyze_impact_at(&graph, &diff).unwrap();
+        let impact = report.entity_impact(&target.id).expect("target impact");
+        assert_eq!(
+            impact.consumer_count, 1,
+            "the untouched external consumer still counts"
+        );
+        assert_eq!(impact.consumers_migrated_in_diff, 1);
+        assert!(
+            !impact.all_consumers_migrated(),
+            "a partial migration is not fully coherent"
+        );
+    }
+
+    #[test]
+    fn same_name_different_file_consumer_is_not_treated_as_migrated() {
+        // A consumer that merely shares a NAME with a co-changed entity but
+        // lives in a different file is a distinct entity and a real external
+        // consumer — the identity key includes the file, so it is not
+        // misread as a migration.
+        let target = entity_in_file("target", "src/http.rs", 10);
+        let changed_helper = entity_in_file("helper", "src/a.rs", 1);
+        let unrelated_helper = entity_in_file("helper", "src/b.rs", 1);
+
+        let mut graph = MockImpactGraph::default();
+        for entity in [&target, &changed_helper, &unrelated_helper] {
+            graph.entities.insert(entity.id, entity.clone());
+        }
+        graph
+            .inbound
+            .insert(target.id, vec![calls(&unrelated_helper, &target)]);
+
+        let diff = SemanticDiff {
+            entity_changes: vec![modified(&target), modified(&changed_helper)],
+            ..Default::default()
+        };
+
+        let report = analyze_impact_at(&graph, &diff).unwrap();
+        let impact = report.entity_impact(&target.id).expect("target impact");
+        assert_eq!(
+            impact.consumer_count, 1,
+            "a same-name consumer in a different file is a real external consumer"
+        );
+        assert_eq!(impact.consumers_migrated_in_diff, 0);
     }
 }

--- a/crates/kin-review/src/inline.rs
+++ b/crates/kin-review/src/inline.rs
@@ -26,6 +26,10 @@ pub struct InlineComment {
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 pub enum InlineCommentKind {
     Breaking,
+    /// A contract-surface change whose every graph-known consumer was itself
+    /// modified in the reviewed range — a coherent in-diff migration. Visible
+    /// evidence, but not a blocking break: nothing external was stranded.
+    BreakingMigrated,
     CoverageGap,
     ContractViolation,
     CommandEffectContract,
@@ -45,6 +49,7 @@ impl InlineCommentKind {
     pub fn prefix(&self) -> &'static str {
         match self {
             Self::Breaking => "!!",
+            Self::BreakingMigrated => "~",
             Self::ContractViolation => "!!",
             Self::CommandEffectContract => "~",
             Self::CoverageGap => "?",
@@ -122,13 +127,18 @@ pub fn signature_strengthened_only(old: &str, new: &str) -> bool {
 /// The graph still records the changed body/signature text; the review gate just
 /// must not turn annotation-only edits into breaking downstream-risk findings.
 pub fn signature_runtime_neutral(old: &str, new: &str) -> bool {
+    if old == new {
+        return false;
+    }
     signature_strengthened_only(old, new)
-        || python_runtime_signature_key(old)
-            .zip(python_runtime_signature_key(new))
-            .is_some_and(|(old_key, new_key)| old_key == new_key)
+        || python_signatures_runtime_neutral(old, new)
+        || go_struct_field_addition_only(old, new)
 }
 
-fn python_runtime_signature_key(signature: &str) -> Option<String> {
+/// The callable name and normalized parameter list of a Python `def`, or
+/// `None` when the text is not one. Annotations, comments, and whitespace are
+/// normalized away so two annotation-only variants compare equal.
+fn python_signature_parts(signature: &str) -> Option<(String, Vec<String>)> {
     let without_comment = signature.split('#').next().unwrap_or(signature).trim();
     let def_pos = without_comment.find("def ")?;
     let after_def = &without_comment[def_pos + 4..];
@@ -144,9 +154,107 @@ fn python_runtime_signature_key(signature: &str) -> Option<String> {
     let params = split_python_params(params)
         .into_iter()
         .map(|param| normalize_python_param(&param))
-        .collect::<Vec<_>>()
-        .join(",");
-    Some(format!("def {name}({params})"))
+        .collect::<Vec<_>>();
+    Some((name.to_string(), params))
+}
+
+/// True when `old` → `new` preserves the Python runtime call contract: same
+/// callable, and either identical normalized parameters (annotation- or
+/// default-format-only edit) or `new` only APPENDS trailing parameters that
+/// each add no required argument — a default value or a `*`/`*args`/`**kwargs`
+/// marker. Existing positional and keyword call sites stay valid. Reordering,
+/// renaming, retyping, or removing a parameter — or appending a required one —
+/// is never neutral.
+fn python_signatures_runtime_neutral(old: &str, new: &str) -> bool {
+    let (Some((old_name, old_params)), Some((new_name, new_params))) =
+        (python_signature_parts(old), python_signature_parts(new))
+    else {
+        return false;
+    };
+    if old_name != new_name {
+        return false;
+    }
+    if old_params == new_params {
+        return true;
+    }
+    if new_params.len() <= old_params.len() || new_params[..old_params.len()] != old_params[..] {
+        return false;
+    }
+    new_params[old_params.len()..]
+        .iter()
+        .all(|param| python_param_adds_no_required_arg(param))
+}
+
+/// A normalized Python parameter that a caller can omit: it carries a default
+/// (`name=…`) or is a `*`, `/`, `*args`, or `**kwargs` marker rather than a
+/// bare required parameter.
+fn python_param_adds_no_required_arg(param: &str) -> bool {
+    let param = param.trim();
+    param.contains('=') || param == "/" || param.starts_with('*')
+}
+
+/// True when `old` and `new` are Go struct type signatures that differ ONLY by
+/// added fields: identical `Name struct` header, and every whitespace token of
+/// the old field body still appears, in order, inside a strictly larger new
+/// body. A consumer reading existing fields by name cannot be broken by the
+/// additions. Removing, renaming, reordering, or retyping a field breaks the
+/// ordered-subsequence match and is never neutral.
+fn go_struct_field_addition_only(old: &str, new: &str) -> bool {
+    let (Some((old_header, old_body)), Some((new_header, new_body))) =
+        (go_struct_parts(old), go_struct_parts(new))
+    else {
+        return false;
+    };
+    if old_header != new_header {
+        return false;
+    }
+    let old_tokens: Vec<&str> = old_body.split_whitespace().collect();
+    let new_tokens: Vec<&str> = new_body.split_whitespace().collect();
+    new_tokens.len() > old_tokens.len() && is_ordered_subsequence(&old_tokens, &new_tokens)
+}
+
+/// Split a Go `Name struct { … }` signature into its header (`Name struct`)
+/// and brace-delimited field body. `None` unless the `struct` keyword directly
+/// precedes the field brace, which excludes Rust's `struct Name { … }` form
+/// (a name sits between keyword and brace) and partial-word matches.
+fn go_struct_parts(signature: &str) -> Option<(&str, &str)> {
+    let struct_kw = signature.find("struct")?;
+    let after_kw = struct_kw + "struct".len();
+    let brace_open = signature[after_kw..].find('{')? + after_kw;
+    if !signature[after_kw..brace_open].trim().is_empty() {
+        return None;
+    }
+    let brace_close = matching_brace(signature, brace_open)?;
+    let header = signature[..brace_open].trim_end();
+    let body = signature[brace_open + 1..brace_close].trim();
+    Some((header, body))
+}
+
+fn matching_brace(input: &str, open_byte: usize) -> Option<usize> {
+    if input.as_bytes().get(open_byte).copied() != Some(b'{') {
+        return None;
+    }
+    let mut depth = 0i32;
+    for (idx, ch) in input.char_indices().skip_while(|(idx, _)| *idx < open_byte) {
+        match ch {
+            '{' => depth += 1,
+            '}' => {
+                depth -= 1;
+                if depth == 0 {
+                    return Some(idx);
+                }
+            }
+            _ => {}
+        }
+    }
+    None
+}
+
+/// True when `needle`'s items appear in `haystack` in order (not necessarily
+/// contiguously): `haystack` is `needle` with insertions only.
+fn is_ordered_subsequence(needle: &[&str], haystack: &[&str]) -> bool {
+    let mut haystack = haystack.iter();
+    needle.iter().all(|tok| haystack.any(|hay| hay == tok))
 }
 
 fn matching_paren(input: &str, open_byte: usize) -> Option<usize> {
@@ -369,6 +477,11 @@ fn collect_modified_comments(
     let contract_consumer_count = per_entity.map_or(0, |e| e.contract_consumer_count);
     let consumer_file_count = per_entity.map_or(0, |e| e.consumer_files.len());
     let entity_covering_tests = per_entity.map_or(0, |e| e.covering_tests);
+    // Consumers that were themselves modified in the reviewed range. When a
+    // surface change has NO external consumer left but did have consumers that
+    // all moved with it, the break is a coherent in-diff migration: visible
+    // evidence, not a blocking break.
+    let consumers_migrated = per_entity.map_or(0, |e| e.consumers_migrated_in_diff);
     let fanout_gate_consumer_count = if entity_covering_tests > 0 {
         strong_consumer_count
     } else {
@@ -394,9 +507,12 @@ fn collect_modified_comments(
             ),
         });
 
-        // Breaking only when THIS entity has non-test consumers to break.
-        // Test-only consumers are the covering evidence for the change, not
-        // a contract it is breaking.
+        // Breaking only when THIS entity has EXTERNAL non-test consumers to
+        // break. Test-only consumers are covering evidence, not a broken
+        // contract. Consumers that were themselves modified in this diff are
+        // excluded from `consumer_count`; when they are the ONLY consumers the
+        // change is a coherent in-diff migration — reported as visible evidence
+        // but not a blocking break.
         if consumer_count > 0 {
             comments.push(InlineComment {
                 file: span.file.to_string(),
@@ -406,6 +522,17 @@ fn collect_modified_comments(
                 message: format!(
                     "Breaking change: signature modification affects {} downstream entity(ies)",
                     consumer_count,
+                ),
+            });
+        } else if consumers_migrated > 0 {
+            comments.push(InlineComment {
+                file: span.file.to_string(),
+                start_line: span.start_line,
+                end_line: span.end_line,
+                kind: InlineCommentKind::BreakingMigrated,
+                message: format!(
+                    "Signature changed; all {} graph-known consumer(s) were co-updated in this diff (migration verified in-range)",
+                    consumers_migrated,
                 ),
             });
         }
@@ -436,6 +563,17 @@ fn collect_modified_comments(
                 message: format!(
                     "Breaking change: visibility reduced with {} consumer(s)",
                     consumer_count,
+                ),
+            });
+        } else if consumers_migrated > 0 {
+            comments.push(InlineComment {
+                file: span.file.to_string(),
+                start_line: span.start_line,
+                end_line: span.end_line,
+                kind: InlineCommentKind::BreakingMigrated,
+                message: format!(
+                    "Visibility reduced; all {} graph-known consumer(s) were co-updated in this diff (migration verified in-range)",
+                    consumers_migrated,
                 ),
             });
         }
@@ -716,6 +854,7 @@ mod tests {
                 contract_consumer_count: 0,
                 consumer_files: vec!["src/client.rs".to_string()],
                 covering_tests: 0,
+                consumers_migrated_in_diff: 0,
             }],
             ..Default::default()
         };
@@ -766,6 +905,7 @@ mod tests {
                     contract_consumer_count: 0,
                     consumer_files: vec![],
                     covering_tests: 0,
+                    consumers_migrated_in_diff: 0,
                 },
                 EntityImpact {
                     entity_id: b.id,
@@ -774,6 +914,7 @@ mod tests {
                     contract_consumer_count: 0,
                     consumer_files: vec!["src/client.rs".to_string()],
                     covering_tests: 0,
+                    consumers_migrated_in_diff: 0,
                 },
             ],
             ..Default::default()
@@ -820,6 +961,7 @@ mod tests {
                 contract_consumer_count: 0,
                 consumer_files: vec![],
                 covering_tests: 1,
+                consumers_migrated_in_diff: 0,
             }],
             ..Default::default()
         };
@@ -836,6 +978,105 @@ mod tests {
                 .iter()
                 .any(|c| c.kind == InlineCommentKind::CoverageGap),
             "a tested entity has no coverage gap"
+        );
+    }
+
+    #[test]
+    fn all_consumers_migrated_downgrades_breaking_to_visible_evidence() {
+        // Signature changed, no external consumer left, but two consumers were
+        // co-updated in the same diff: a coherent migration. The blocking
+        // Breaking finding is replaced by a non-blocking BreakingMigrated one,
+        // and the signature change itself is still surfaced.
+        let old = test_entity_with_span("api_handler", "src/api.rs", 1, 10);
+        let mut new = old.clone();
+        new.signature = "fn api_handler(req: Request, extra: bool)".to_string();
+
+        let diff = SemanticDiff {
+            entity_changes: vec![EntityChange {
+                entity_id: new.id,
+                kind: EntityChangeKind::Modified {
+                    old: old.clone(),
+                    new: new.clone(),
+                },
+            }],
+            ..Default::default()
+        };
+        let impact = ImpactReport {
+            changed_ids: vec![new.id],
+            entity_impacts: vec![EntityImpact {
+                entity_id: new.id,
+                consumer_count: 0,
+                strong_consumer_count: 0,
+                contract_consumer_count: 0,
+                consumer_files: vec![],
+                covering_tests: 0,
+                consumers_migrated_in_diff: 2,
+            }],
+            ..Default::default()
+        };
+
+        let comments = collect_inline_comments(&diff, &impact);
+        assert!(
+            !comments
+                .iter()
+                .any(|c| c.kind == InlineCommentKind::Breaking),
+            "a fully co-updated migration is not a blocking break"
+        );
+        let migrated: Vec<&InlineComment> = comments
+            .iter()
+            .filter(|c| c.kind == InlineCommentKind::BreakingMigrated)
+            .collect();
+        assert_eq!(migrated.len(), 1);
+        assert!(migrated[0].message.contains("2 graph-known consumer"));
+        assert!(comments
+            .iter()
+            .any(|c| c.kind == InlineCommentKind::SignatureChange));
+    }
+
+    #[test]
+    fn partial_migration_still_breaks_and_emits_no_migrated_finding() {
+        // One external consumer remains alongside migrated ones: still a real,
+        // blocking break — not a coherent migration.
+        let old = test_entity_with_span("api_handler", "src/api.rs", 1, 10);
+        let mut new = old.clone();
+        new.signature = "fn api_handler(req: Request, extra: bool)".to_string();
+
+        let diff = SemanticDiff {
+            entity_changes: vec![EntityChange {
+                entity_id: new.id,
+                kind: EntityChangeKind::Modified {
+                    old: old.clone(),
+                    new: new.clone(),
+                },
+            }],
+            ..Default::default()
+        };
+        let impact = ImpactReport {
+            changed_ids: vec![new.id],
+            entity_impacts: vec![EntityImpact {
+                entity_id: new.id,
+                consumer_count: 1,
+                strong_consumer_count: 1,
+                contract_consumer_count: 0,
+                consumer_files: vec!["src/client.rs".to_string()],
+                covering_tests: 0,
+                consumers_migrated_in_diff: 2,
+            }],
+            ..Default::default()
+        };
+
+        let comments = collect_inline_comments(&diff, &impact);
+        assert!(
+            comments
+                .iter()
+                .any(|c| c.kind == InlineCommentKind::Breaking),
+            "a stranded external consumer still blocks"
+        );
+        assert!(
+            !comments
+                .iter()
+                .any(|c| c.kind == InlineCommentKind::BreakingMigrated),
+            "partial migration is a real break, not migrated evidence"
         );
     }
 
@@ -878,6 +1119,7 @@ mod tests {
                     contract_consumer_count: 0,
                     consumer_files: vec![],
                     covering_tests: 1,
+                    consumers_migrated_in_diff: 0,
                 },
                 EntityImpact {
                     entity_id: uncovered.id,
@@ -886,6 +1128,7 @@ mod tests {
                     contract_consumer_count: 0,
                     consumer_files: vec![],
                     covering_tests: 0,
+                    consumers_migrated_in_diff: 0,
                 },
             ],
             ..Default::default()
@@ -978,6 +1221,7 @@ mod tests {
                 contract_consumer_count: 0,
                 consumer_files: vec![],
                 covering_tests: 1,
+                consumers_migrated_in_diff: 0,
             }],
             ..Default::default()
         };
@@ -1020,6 +1264,7 @@ mod tests {
                 contract_consumer_count: 0,
                 consumer_files: vec!["src/a.rs".to_string(), "src/b.rs".to_string()],
                 covering_tests: 1,
+                consumers_migrated_in_diff: 0,
             }],
             ..Default::default()
         };
@@ -1060,6 +1305,7 @@ mod tests {
                 contract_consumer_count: 0,
                 consumer_files: vec!["src/a.rs".to_string(), "src/b.rs".to_string()],
                 covering_tests: 1,
+                consumers_migrated_in_diff: 0,
             }],
             ..Default::default()
         };
@@ -1080,6 +1326,7 @@ mod tests {
                 contract_consumer_count: 0,
                 consumer_files: vec!["src/a.rs".to_string(), "src/b.rs".to_string()],
                 covering_tests: 0,
+                consumers_migrated_in_diff: 0,
             }],
             ..Default::default()
         };
@@ -1107,6 +1354,7 @@ mod tests {
                 contract_consumer_count: 0,
                 consumer_files: vec!["src/a.rs".to_string(), "src/b.rs".to_string()],
                 covering_tests: 1,
+                consumers_migrated_in_diff: 0,
             }],
             ..Default::default()
         };
@@ -1165,6 +1413,104 @@ mod tests {
     }
 
     #[test]
+    fn python_appended_defaulted_params_are_runtime_neutral() {
+        // Trailing parameter with a default: existing calls stay valid.
+        assert!(signature_runtime_neutral(
+            "def render(self, node)",
+            "def render(self, node, inline=False)"
+        ));
+        // Trailing *args / **kwargs markers add no required argument.
+        assert!(signature_runtime_neutral(
+            "def emit(self, event)",
+            "def emit(self, event, *args, **kwargs)"
+        ));
+        // Keyword-only defaulted tail is neutral.
+        assert!(signature_runtime_neutral(
+            "def build(self, app)",
+            "def build(self, app, *, force=False)"
+        ));
+    }
+
+    #[test]
+    fn python_appended_required_param_is_not_neutral() {
+        // A new trailing parameter WITHOUT a default breaks existing calls.
+        assert!(!signature_runtime_neutral(
+            "def render(self, node)",
+            "def render(self, node, inline)"
+        ));
+        // A required keyword-only parameter still breaks callers that omit it.
+        assert!(!signature_runtime_neutral(
+            "def build(self, app)",
+            "def build(self, app, *, force)"
+        ));
+        // Removing a parameter is never neutral.
+        assert!(!signature_runtime_neutral(
+            "def render(self, node, inline=False)",
+            "def render(self, node)"
+        ));
+        // Reordering a defaulted param ahead of a positional is not a prefix.
+        assert!(!signature_runtime_neutral(
+            "def f(self, a, b)",
+            "def f(self, b, a, c=1)"
+        ));
+    }
+
+    #[test]
+    fn go_struct_added_field_is_runtime_neutral() {
+        // The real a742e9f8df row: ListOptions gains a `Config` field mid-list.
+        // Existing named-field consumers are unaffected.
+        assert!(signature_runtime_neutral(
+            "ListOptions struct { HttpClient func()(*http.Client, error) IO *iostreams.IOStreams BaseRepo func()(ghrepo.Interface, error) Organization string }",
+            "ListOptions struct { HttpClient func()(*http.Client, error) IO *iostreams.IOStreams Config func()(config.Config, error) BaseRepo func()(ghrepo.Interface, error) Organization string }"
+        ));
+        // Appended field at the end is also additive.
+        assert!(signature_runtime_neutral(
+            "Opts struct { A int B string }",
+            "Opts struct { A int B string C bool }"
+        ));
+    }
+
+    #[test]
+    fn go_struct_non_additive_changes_are_not_neutral() {
+        // Field removal.
+        assert!(!signature_runtime_neutral(
+            "Opts struct { A int B string C bool }",
+            "Opts struct { A int B string }"
+        ));
+        // Field rename.
+        assert!(!signature_runtime_neutral(
+            "Opts struct { A int Name string }",
+            "Opts struct { A int Label string }"
+        ));
+        // Field retype.
+        assert!(!signature_runtime_neutral(
+            "Opts struct { A int B string }",
+            "Opts struct { A int64 B string }"
+        ));
+        // Field reorder (no additions).
+        assert!(!signature_runtime_neutral(
+            "Opts struct { A int B string }",
+            "Opts struct { B string A int }"
+        ));
+        // Type header rename is not a neutral field addition.
+        assert!(!signature_runtime_neutral(
+            "Opts struct { A int }",
+            "Config struct { A int B string }"
+        ));
+    }
+
+    #[test]
+    fn rust_struct_is_not_treated_as_go_additive() {
+        // Rust's `struct Name { … }` puts a name between keyword and brace, so
+        // the Go-additive rule must not fire — a Rust field addition can still
+        // break exhaustive constructors and is not silently neutralized here.
+        assert!(!signature_runtime_neutral(
+            "struct Opts { a: i32 }",
+            "struct Opts { a: i32, b: bool }"
+        ));
+    }
+
+    #[test]
     fn strengthened_only_change_emits_no_signature_or_breaking_comment() {
         let old = test_entity_with_span("hot_path", "src/hot.rs", 1, 20);
         let mut new = old.clone();
@@ -1188,6 +1534,7 @@ mod tests {
                 contract_consumer_count: 0,
                 consumer_files: vec!["src/a.rs".to_string()],
                 covering_tests: 0,
+                consumers_migrated_in_diff: 0,
             }],
             ..Default::default()
         };
@@ -1234,6 +1581,7 @@ mod tests {
                     "testing/test_doctest.py".to_string(),
                 ],
                 covering_tests: 0,
+                consumers_migrated_in_diff: 0,
             }],
             ..Default::default()
         };
@@ -1305,6 +1653,7 @@ mod tests {
                 // entity count (2) is at it.
                 consumer_files: vec!["src/shared.rs".to_string()],
                 covering_tests: 0,
+                consumers_migrated_in_diff: 0,
             }],
             ..Default::default()
         };
@@ -1355,6 +1704,7 @@ mod tests {
                     "testing/test_conftest.py".to_string(),
                 ],
                 covering_tests: 0,
+                consumers_migrated_in_diff: 0,
             }],
             ..Default::default()
         };
@@ -1394,6 +1744,7 @@ mod tests {
                 contract_consumer_count: 0,
                 consumer_files: vec!["src/only.rs".to_string()],
                 covering_tests: 0,
+                consumers_migrated_in_diff: 0,
             }],
             ..Default::default()
         };
@@ -1426,6 +1777,7 @@ mod tests {
                 contract_consumer_count: 0,
                 consumer_files: vec!["src/a.rs".to_string(), "src/b.rs".to_string()],
                 covering_tests: 0,
+                consumers_migrated_in_diff: 0,
             }],
             ..Default::default()
         };

--- a/crates/kin-review/src/shadow.rs
+++ b/crates/kin-review/src/shadow.rs
@@ -726,6 +726,7 @@ fn collect_blast_radius(review: &Review) -> ShadowBlastRadius {
 fn finding_kind_label(kind: InlineCommentKind) -> &'static str {
     match kind {
         InlineCommentKind::Breaking => "breaking",
+        InlineCommentKind::BreakingMigrated => "breaking_migrated",
         InlineCommentKind::CoverageGap => "coverage_gap",
         InlineCommentKind::ContractViolation => "contract_violation",
         InlineCommentKind::CommandEffectContract => "command_effect_contract_change",
@@ -756,6 +757,9 @@ fn finding_severity(kind: InlineCommentKind) -> &'static str {
         | InlineCommentKind::RevertHistory => "warning",
         InlineCommentKind::RevertHistoryIncidental => "info",
         InlineCommentKind::Added | InlineCommentKind::Removed => "info",
+        // Coherent-migration evidence: reported, but never a gate signal — the
+        // break has no stranded external consumer to escalate on.
+        InlineCommentKind::BreakingMigrated => "info",
     }
 }
 
@@ -1098,6 +1102,11 @@ fn repair_guidance(kind: &str) -> &'static str {
         "breaking" => {
             "Update the listed consumers to the new contract or restore compatibility, then run \
              the covering tests."
+        }
+        "breaking_migrated" => {
+            "The contract surface changed but every graph-known consumer was co-updated in this \
+             same change — a coherent migration. Confirm no consumer outside the graph (e.g. a \
+             cross-repo caller) still depends on the old surface."
         }
         "contract_violation" => {
             "The contract has graph-known consumers; version the contract or migrate every \
@@ -1922,6 +1931,7 @@ mod tests {
                             contract_consumer_count: 0,
                             consumer_files: vec!["src/consumer.rs".to_string()],
                             covering_tests: 0,
+                            consumers_migrated_in_diff: 0,
                         })
                         .collect(),
                     ..Default::default()
@@ -2441,6 +2451,7 @@ mod tests {
                     contract_consumer_count: 0,
                     consumer_files: vec!["src/consumer.rs".to_string()],
                     covering_tests: 0,
+                    consumers_migrated_in_diff: 0,
                 }],
                 ..Default::default()
             },
@@ -2538,6 +2549,7 @@ mod tests {
                     contract_consumer_count: 0,
                     consumer_files: vec![],
                     covering_tests: 0,
+                    consumers_migrated_in_diff: 0,
                 }],
                 ..Default::default()
             },
@@ -3145,6 +3157,7 @@ mod tests {
                     contract_consumer_count: 0,
                     consumer_files: vec!["src/consumer.rs".to_string()],
                     covering_tests: 0,
+                    consumers_migrated_in_diff: 0,
                 }],
                 ..Default::default()
             },


### PR DESCRIPTION
## What

Two graph-native, proof-obligated precision refinements to the kin-review contract-surface channels. Both fix benign rows the merge-trust gate over-blocks / over-flags, without weakening true-positive break detection.

### Coherent in-diff consumer migration (breaking channel)
A signature/visibility change whose **every** graph-known consumer was itself modified in the reviewed range is a self-contained migration, not a stranded external break. Consumers are attributed as migrated when they match a changed entity by exact id **or** by a line-independent `(file, name, kind)` identity — `EntityId` folds in `start_line`, so a co-updated consumer whose declaration shifted lines (or whose own signature changed) otherwise resolves to an id outside the changed set and reads as an external break. When a surface change has no external consumer left but did have migrated ones, the blocking `breaking` finding is replaced by a non-blocking `breaking_migrated` finding (info severity) that preserves the evidence. **Partial migration — any external consumer remaining — still blocks.**

### Additive signature normalization (signature channel)
A Go struct type that only **gains** fields, and a Python `def` that only **appends** trailing parameters carrying defaults (or `*args`/`**kwargs` markers), keep every existing call site valid → runtime-neutral via `signature_runtime_neutral`. Reordering, renaming, retyping, or removing a field/parameter — or appending a required one — remains a surface change.

## Measured results (dev-lane, NON-CITABLE)

Central-graph `kin review shadow` with this branch's binary vs the recorded baseline decisions. Review is graph-invariant to this change, so the delta is exactly the review-policy change.

| Row | Shape | Baseline | After | Mechanism |
|-----|-------|----------|-------|-----------|
| `a742e9f8df` cli/cli | `ListOptions` gains a `Config` field | needs_attention | **pass** | additive Go struct field neutralized |
| `9b87b13b80` cli/cli | `repoCreate` return type; sole caller `createRun` co-updated (line-shifted) | would_block | **needs_attention** | line-shifted co-update recognized as migrated |
| `687437fcd1` Catch2 | IStreamingReporter → unique_ptr | would_block | would_block | 2 breaks → `breaking_migrated`; 1 partial-migration break remains |
| `f6892bfdf0` Catch2 | ConfigData → Ptr\<Config\> | would_block | would_block | 4 breaks → `breaking_migrated`; 1 partial-migration break remains |
| `cdc7e13067` pytest | `_makefile` param rename (same arity) | would_block | would_block | consumers not co-updated (positional-safe rename) |

**Regression:**
- 22-row pytest revert-channel block: **22/22 verdict-identical to the refine baseline; zero true-positive regressions**, bit-stable.
- benign-60: **42 pass / 14 na / 4 would_block → 43 pass / 14 na / 3 would_block** — exactly two rows moved (`a742` na→pass, `9b87` would_block→na), no other row changed, no pass→non-pass regression.

## Adjudication packet (rows the principled design correctly leaves blocked)

- **`687437fcd1` / `f6892bfdf0`** — public C++ header surfaces. The coherence rule downgraded 2 (resp. 4) breaking findings to `breaking_migrated`, but one break each survives on a partially-migrated public method (`MultipleReporters::add` @ `catch_reporter_multi.hpp:19`, 4 downstream not all co-updated in the 5-file commit; `Main`/`Runner2` @ `catch_runner.hpp:112`, 1 downstream in an untouched file). Partial migration stays strict by the proof obligation. Open question: whether those residual downstream edges are true external consumers or C++ inheritance/overload graph artifacts — a consumer-attribution question distinct from the coherence rule.
- **`cdc7e13067`** — private Python `_makefile` param rename (`args,kwargs`→`lines,files`), same arity. The 3 sibling callers pass positionally and were not modified in the commit, so there is no in-diff migration to recognize; the graph cannot prove the calls are positional (a keyword caller would break), so it stays strict. Resolving this needs call-site argument analysis the graph does not carry.

## Tests
kin-review suite green (163 tests incl. new coverage): line-shifted co-update recognition, partial-migration blocking, same-name/different-file discrimination, additive vs non-additive struct/param shapes, downgrade / no-downgrade channel behavior. `cargo fmt` clean; clippy clean under the CI allowlist.

Linear: https://linear.app/firelock-ai/issue/FIR-1426 · https://linear.app/firelock-ai/issue/FIR-1327
