### PR TITLE
docs: align npm package descriptions with the locked one-liner

### DIFF
--- a/packages/kin-mcp/package.json
+++ b/packages/kin-mcp/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@kinlab/kin-mcp",
   "version": "0.2.13",
-  "description": "Start Kin's MCP server through an npm-friendly wrapper.",
+  "description": "Start Kin's MCP server — the semantic system of record for software work — through an npm-friendly wrapper.",
   "type": "module",
   "bin": {
     "kin-mcp": "./bin/kin-mcp.js"

--- a/packages/kin/package.json
+++ b/packages/kin/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@kinlab/kin",
   "version": "0.2.13",
-  "description": "Canonical installer and launcher for Kin — provisions and runs the managed kin + kin-daemon release. MCP is one included mode (kin mcp start).",
+  "description": "Canonical installer and launcher for Kin, the semantic system of record for software work — provisions and runs the managed kin + kin-daemon release. MCP is one included mode (kin mcp start).",
   "license": "Apache-2.0",
   "type": "module",
   "bin": {


### PR DESCRIPTION
## Summary

Locks in the public one-liner (README top-of-file, unchanged in this PR — it is already canonical) and aligns the two npm wrapper package descriptions that previously had no ecosystem framing.

**Locked line** (from `README.md`, unchanged):
> AI made code cheap to write and expensive to trust. Kin helps teams trust AI-built software before it merges.

**Locked category noun** (from `README.md` / umbrella `AGENTS.md` Public Narrative): *the semantic system of record for software work*

## Before → After

| Surface | Before | After |
|---|---|---|
| `packages/kin/package.json` description | "Canonical installer and launcher for Kin — provisions and runs the managed kin + kin-daemon release. MCP is one included mode (kin mcp start)." | "Canonical installer and launcher for Kin, **the semantic system of record for software work** — provisions and runs the managed kin + kin-daemon release. MCP is one included mode (kin mcp start)." |
| `packages/kin-mcp/package.json` description | "Start Kin's MCP server through an npm-friendly wrapper." | "Start Kin's MCP server — **the semantic system of record for software work** — through an npm-friendly wrapper." |

No version-bump or quantified performance claims included; this is copy-only.

## Test plan
- [x] `node --check` covered by repo lint script (unaffected — JSON-only change)
- [x] Diff reviewed for scope: only the two `description` fields touched