### PR TITLE
Resolve C++ method calls by receiver scope instead of name fan-out

### DIFF
--- a/crates/kin-index/src/linker.rs
+++ b/crates/kin-index/src/linker.rs
@@ -661,6 +661,37 @@ fn resolve_one_file(file: &FileParseData, ctx: &LinkContext<'_>) -> Vec<Relation
             }
         }
 
+        // (c4) C++ receiver-scoped inherited method. A `Owner::method` call
+        // whose receiver type the parser pinned matched no exact entity above
+        // (own method — same-file (a) or cross-file (c)) resolves through the
+        // receiver class's Extends chain to the defining ancestor: the C++
+        // counterpart of the (a2) `self.m()` walk, keyed on `::` methods.
+        // Running before (c3) keeps an inherited call pinned to its true base
+        // rather than fanning out to every same-named method the bare leaf
+        // would reach. Only a located class owner binds, so a namespace-scoped
+        // free function (`Catch::Main`) is left for the tiers below.
+        if name_fallback_allowed && !linked && rel.kind == RelationKind::Calls {
+            if let Some((owner, method)) = split_scoped_receiver_method(rel.dst_name.as_str()) {
+                if let Some((owner_file, owner_class)) =
+                    locate_base_class(&file.file_path, owner, ctx)
+                {
+                    if let Some(dst_id) =
+                        resolve_inherited_method(&owner_file, &owner_class, method, ctx)
+                    {
+                        if add_deduped(&mut seen, src_id, dst_id, rel.kind) {
+                            resolved.push(make_relation(
+                                rel.kind,
+                                src_id,
+                                dst_id,
+                                INHERITED_METHOD_CONFIDENCE,
+                            ));
+                            linked = true;
+                        }
+                    }
+                }
+            }
+        }
+
         // (c3) Path-qualified calls (`crate::mod::func`, `Type::method`,
         // `alias::Type::method`) arrive with the full lexical path as `dst_name`
         // and no import source, so they miss (a)/(b) and the exact/bare indices
@@ -1080,6 +1111,33 @@ fn split_owner_method(name: &str) -> Option<(&str, &str)> {
     (!owner.is_empty() && !method.is_empty()).then_some((owner, method))
 }
 
+/// The two receiver-method entity keys a class + method can form: the Python
+/// adapter stores methods as `Class.method`, the C++ adapter as `Class::method`.
+/// The inheritance walk tries both so one Extends-chain resolver serves every
+/// language's method naming.
+fn receiver_method_keys(class: &str, method: &str) -> [String; 2] {
+    [format!("{class}.{method}"), format!("{class}::{method}")]
+}
+
+/// Split a C++-style receiver-qualified call `Owner::method` (or a longer
+/// `A::B::Owner::method`) into its receiver-class leaf and method name. Returns
+/// `None` for names without `::`, with non-identifier segments (turbofish,
+/// operators), or with an empty half — so only a genuine receiver-scoped method
+/// key reaches the Extends-chain walk. The owner is validated as a class at the
+/// call site, so a namespace-qualified free function (`Catch::Main`) never binds.
+fn split_scoped_receiver_method(name: &str) -> Option<(&str, &str)> {
+    let (owner_path, method) = name.rsplit_once("::")?;
+    let owner = owner_path.rsplit("::").next()?;
+    if owner.is_empty()
+        || method.is_empty()
+        || !is_path_identifier(owner)
+        || !is_path_identifier(method)
+    {
+        return None;
+    }
+    Some((owner, method))
+}
+
 /// Upper bound on how many classes an inheritance walk may visit before giving
 /// up. Real hierarchies are shallow; the cap is cycle/pathology insurance so a
 /// malformed `Extends` graph (self-inheritance, giant generated lattices) can
@@ -1460,12 +1518,13 @@ fn resolve_inherited_method(
             else {
                 continue;
             };
-            let method_key = format!("{}.{}", base_class, method);
-            if let Some(&dst_id) = ctx
-                .entity_by_file_name
-                .get(&(base_file.as_str(), method_key.as_str()))
-            {
-                return Some(dst_id);
+            for method_key in receiver_method_keys(&base_class, method) {
+                if let Some(&dst_id) = ctx
+                    .entity_by_file_name
+                    .get(&(base_file.as_str(), method_key.as_str()))
+                {
+                    return Some(dst_id);
+                }
             }
             if visited.len() >= INHERITANCE_WALK_CAP {
                 return None;
@@ -1580,13 +1639,14 @@ fn resolve_inherited_method_incremental(
             else {
                 continue;
             };
-            let method_key = format!("{}.{}", base_class, method);
-            if let Some(&dst_id) = linker
-                .entity_by_file_name
-                .get(&base_file)
-                .and_then(|m| m.get(method_key.as_str()))
-            {
-                return Some(dst_id);
+            for method_key in receiver_method_keys(&base_class, method) {
+                if let Some(&dst_id) = linker
+                    .entity_by_file_name
+                    .get(&base_file)
+                    .and_then(|m| m.get(method_key.as_str()))
+                {
+                    return Some(dst_id);
+                }
             }
             if visited.len() >= INHERITANCE_WALK_CAP {
                 return None;
@@ -3003,6 +3063,38 @@ fn resolve_one_file_incremental(
                         }
                     }
                     continue;
+                }
+            }
+        }
+
+        // (c4) C++ receiver-scoped inherited method — the incremental
+        // counterpart of the batch linker's (c4). A `Owner::method` call with
+        // no exact entity above resolves through the receiver class's Extends
+        // chain to the defining ancestor, keeping an inherited call pinned to
+        // its true base instead of the bare-leaf fan-out (c3) would reach.
+        if name_fallback_allowed && rel.kind == RelationKind::Calls {
+            if let Some((owner, method)) = split_scoped_receiver_method(rel.dst_name.as_str()) {
+                if let Some((owner_file, owner_class)) =
+                    locate_base_class_incremental(&file.file_path, owner, linker, &import_map)
+                {
+                    if let Some(dst_id) = resolve_inherited_method_incremental(
+                        &owner_file,
+                        &owner_class,
+                        method,
+                        linker,
+                        &import_map,
+                        &class_bases,
+                    ) {
+                        if add_deduped(&mut seen, src_id, dst_id, rel.kind) {
+                            resolved.push(make_relation(
+                                rel.kind,
+                                src_id,
+                                dst_id,
+                                INHERITED_METHOD_CONFIDENCE,
+                            ));
+                        }
+                        continue;
+                    }
                 }
             }
         }

--- a/crates/kin-index/tests/cpp_call_resolution.rs
+++ b/crates/kin-index/tests/cpp_call_resolution.rs
@@ -1,0 +1,259 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Firelock, LLC
+
+//! Cross-file arm of the C++ call-resolution regression net.
+//!
+//! The extractor resolves a method call's receiver static type and emits it as
+//! `Type::method`, so the linker binds `recv.method()` to the receiver's own
+//! class instead of fanning the bare method name out to every same-named method
+//! in the graph — the phantom-consumer defect that inflated review impact on
+//! partially-migrated C++ APIs.
+//! These tests drive the real parser -> real linker pipeline (both the batch and
+//! incremental linkers, asserting parity) to prove: a typed receiver binds only
+//! to its class; a call through a derived receiver reaches the base-declared
+//! method and nothing else; and an unresolvable receiver still fans out weakly.
+
+use kin_index::{link_cross_file, link_cross_file_incremental, FileParseData, IncrementalLinker};
+use kin_model::{Entity, EntityId, FilePathId, Relation, RelationKind};
+use kin_parser::{CppAdapter, LanguageAdapter};
+
+fn parse_cpp(file_path: &str, source: &str) -> FileParseData {
+    let adapter = CppAdapter;
+    let file_id = FilePathId::new(file_path);
+    let bytes = source.as_bytes();
+    let tree = adapter.parse(bytes).expect("parse");
+    let output = adapter.extract(&tree, bytes, &file_id).expect("extract");
+    let entities: Vec<Entity> = output
+        .entities
+        .into_iter()
+        .map(|e| e.into_entity_with_source(adapter.language_id(), &file_id, Some(bytes)))
+        .collect();
+    FileParseData {
+        file_path: file_path.to_string(),
+        entities,
+        relations: output.relations,
+        imports: output.imports,
+    }
+}
+
+fn entity_id(files: &[FileParseData], file: &str, name: &str) -> EntityId {
+    files
+        .iter()
+        .flat_map(|f| f.entities.iter())
+        .find(|e| e.name == name && e.file_origin.as_ref().map(|p| p.0.as_str()) == Some(file))
+        .unwrap_or_else(|| panic!("entity `{name}` in `{file}` not found"))
+        .id
+}
+
+fn has_call(relations: &[Relation], src: EntityId, dst: EntityId) -> bool {
+    relations.iter().any(|r| {
+        r.kind == RelationKind::Calls
+            && r.src.as_entity() == Some(src)
+            && r.dst.as_entity() == Some(dst)
+    })
+}
+
+fn call_confidence(relations: &[Relation], src: EntityId, dst: EntityId) -> Option<f32> {
+    relations
+        .iter()
+        .find(|r| {
+            r.kind == RelationKind::Calls
+                && r.src.as_entity() == Some(src)
+                && r.dst.as_entity() == Some(dst)
+        })
+        .map(|r| r.confidence)
+}
+
+/// Link `files` through both the batch and incremental linkers, assert the two
+/// agree on every `Calls` edge, and return the batch edges. Receiver-scoped
+/// resolution has a batch tier and an incremental twin, so every scenario is
+/// proved on both paths at once.
+fn link_both(files: &[FileParseData]) -> Vec<Relation> {
+    let batch = link_cross_file(files);
+
+    let mut linker = IncrementalLinker::new();
+    for f in files {
+        linker.add_file(&f.file_path, &f.entities);
+    }
+    let incremental = link_cross_file_incremental(files, &linker);
+
+    let call_set = |rels: &[Relation]| -> std::collections::HashSet<(EntityId, EntityId)> {
+        rels.iter()
+            .filter(|r| r.kind == RelationKind::Calls)
+            .filter_map(|r| Some((r.src.as_entity()?, r.dst.as_entity()?)))
+            .collect()
+    };
+    assert_eq!(
+        call_set(&batch),
+        call_set(&incremental),
+        "batch and incremental linkers must resolve the same C++ call edges"
+    );
+    batch
+}
+
+#[test]
+fn typed_receiver_binds_to_own_class_not_same_named_sibling() {
+    // A factory builds typed generator locals and calls `.add()` / `->add()` on
+    // them. An unrelated `MultipleReporters::add` in another file shares the bare
+    // leaf `add` — the phantom consumer the pre-fix bare-name fan-out minted onto
+    // every same-named method regardless of receiver class.
+    let files = vec![
+        parse_cpp(
+            "generators.hpp",
+            r#"
+namespace Catch {
+    struct ValuesGenerator {
+        void add( int value ) {}
+    };
+    struct CompositeGenerator {
+        void add( int g ) {}
+    };
+    CompositeGenerator values( int v1 ) {
+        CompositeGenerator generators;
+        ValuesGenerator* valuesGen = new ValuesGenerator();
+        valuesGen->add( v1 );
+        generators.add( 0 );
+        return generators;
+    }
+}
+"#,
+        ),
+        parse_cpp(
+            "reporters.hpp",
+            r#"
+namespace Catch {
+    struct MultipleReporters {
+        void add( int reporter ) {}
+    };
+}
+"#,
+        ),
+    ];
+
+    let relations = link_both(&files);
+    let values = entity_id(&files, "generators.hpp", "values");
+    let vg_add = entity_id(&files, "generators.hpp", "ValuesGenerator::add");
+    let cg_add = entity_id(&files, "generators.hpp", "CompositeGenerator::add");
+    let mr_add = entity_id(&files, "reporters.hpp", "MultipleReporters::add");
+
+    assert!(
+        has_call(&relations, values, vg_add),
+        "`valuesGen->add` must bind to ValuesGenerator::add"
+    );
+    assert!(
+        has_call(&relations, values, cg_add),
+        "`generators.add` must bind to CompositeGenerator::add"
+    );
+    assert!(
+        !has_call(&relations, values, mr_add),
+        "the bare-name fan-out phantom `values -> MultipleReporters::add` must be gone"
+    );
+    // Same-file, receiver-pinned binding is parser-certain.
+    assert_eq!(call_confidence(&relations, values, vg_add), Some(1.0));
+}
+
+#[test]
+fn derived_receiver_resolves_to_base_method_only() {
+    // A call through a derived-typed local must reach the base-declared method by
+    // walking the Extends chain — not fan out to an unrelated same-named method.
+    let files = vec![
+        parse_cpp(
+            "base.hpp",
+            r#"
+struct Base {
+    void poll() {}
+};
+"#,
+        ),
+        parse_cpp(
+            "other.hpp",
+            r#"
+struct Other {
+    void poll() {}
+};
+"#,
+        ),
+        parse_cpp(
+            "use.hpp",
+            r#"
+struct Derived : Base {};
+void use_it() {
+    Derived d;
+    d.poll();
+}
+"#,
+        ),
+    ];
+
+    let relations = link_both(&files);
+    let use_it = entity_id(&files, "use.hpp", "use_it");
+    let base_poll = entity_id(&files, "base.hpp", "Base::poll");
+    let other_poll = entity_id(&files, "other.hpp", "Other::poll");
+
+    assert!(
+        has_call(&relations, use_it, base_poll),
+        "`d.poll()` through `Derived : Base` must resolve to Base::poll"
+    );
+    assert!(
+        !has_call(&relations, use_it, other_poll),
+        "inheritance resolution must not reach the unrelated Other::poll"
+    );
+    assert_eq!(
+        call_confidence(&relations, use_it, base_poll),
+        Some(0.85),
+        "an inherited receiver-method edge carries INHERITED_METHOD_CONFIDENCE"
+    );
+}
+
+#[test]
+fn unresolvable_receiver_fans_out_weakly() {
+    // `sink.flush()` with no visible declaration of `sink`: the receiver type is
+    // unknown, so the call keeps its bare leaf and the ambiguous receiver-method
+    // tier fans out to same-named implementors at low confidence — never as
+    // strong truth.
+    let files = vec![
+        parse_cpp(
+            "writer.hpp",
+            r#"
+struct Writer {
+    void flush() {}
+};
+"#,
+        ),
+        parse_cpp(
+            "logger.hpp",
+            r#"
+struct Logger {
+    void flush() {}
+};
+"#,
+        ),
+        parse_cpp(
+            "drain.hpp",
+            r#"
+void drain() {
+    sink.flush();
+}
+"#,
+        ),
+    ];
+
+    let relations = link_both(&files);
+    let drain = entity_id(&files, "drain.hpp", "drain");
+    let writer_flush = entity_id(&files, "writer.hpp", "Writer::flush");
+    let logger_flush = entity_id(&files, "logger.hpp", "Logger::flush");
+
+    assert!(
+        has_call(&relations, drain, writer_flush),
+        "unresolvable receiver keeps its bare leaf and fans out to Writer::flush"
+    );
+    assert!(
+        has_call(&relations, drain, logger_flush),
+        "unresolvable receiver keeps its bare leaf and fans out to Logger::flush"
+    );
+    assert_eq!(
+        call_confidence(&relations, drain, writer_flush),
+        Some(0.3),
+        "an unresolvable receiver-method fan-out stays at the weak ambiguous confidence"
+    );
+}

--- a/crates/kin-parser/src/languages/cpp_lang.rs
+++ b/crates/kin-parser/src/languages/cpp_lang.rs
@@ -827,39 +827,242 @@ fn strip_callee_template_args(raw: &str) -> String {
     out
 }
 
-/// Recursively walk a function/method body to find `call_expression` nodes.
+/// Static receiver types visible inside one function/method body: local
+/// variables and parameters (`var_types`), the enclosing class name for a
+/// `this` receiver (`enclosing_class`), and the enclosing class's data members
+/// (`member_types`). A `recv.method()` / `recv->method()` whose receiver type
+/// resolves here is emitted as `Type::method`, so the linker binds it to that
+/// class instead of fanning the call out to every same-named method.
+#[derive(Default)]
+struct ReceiverScope {
+    enclosing_class: Option<String>,
+    var_types: std::collections::HashMap<String, String>,
+    member_types: std::collections::HashMap<String, String>,
+}
+
+impl ReceiverScope {
+    fn owner_of(&self, receiver: &str) -> Option<&str> {
+        self.var_types
+            .get(receiver)
+            .or_else(|| self.member_types.get(receiver))
+            .map(String::as_str)
+    }
+}
+
+/// Walk a function/method body and emit its `call_expression` edges. A method
+/// call's receiver static type is resolved through the body's [`ReceiverScope`]
+/// so a typed receiver binds to `Type::method`; an unresolvable receiver keeps
+/// the bare rightmost name (the linker's ambiguous-fanout tier weighs those).
 fn extract_calls_from_body(
     node: &tree_sitter::Node,
     source: &[u8],
     context_name: &str,
     relations: &mut Vec<ExtractedRelation>,
 ) {
+    let mut scope = ReceiverScope {
+        enclosing_class: context_name
+            .rsplit_once("::")
+            .map(|(owner, _)| owner.to_string()),
+        ..ReceiverScope::default()
+    };
+    collect_param_types(node, source, &mut scope.var_types);
+    collect_local_var_types(node, source, &mut scope.var_types);
+    collect_member_field_types(node, source, &mut scope.member_types);
+    collect_scoped_calls(node, source, context_name, &scope, relations);
+}
+
+fn collect_scoped_calls(
+    node: &tree_sitter::Node,
+    source: &[u8],
+    context_name: &str,
+    scope: &ReceiverScope,
+    relations: &mut Vec<ExtractedRelation>,
+) {
     let mut cursor = node.walk();
     for child in node.children(&mut cursor) {
         if child.kind() == "call_expression" {
             if let Some(function) = child.child_by_field_name("function") {
-                let callee_name = match function.kind() {
-                    "field_expression" => {
-                        // obj.method() or obj->method()
+                let dst_name = if function.kind() == "field_expression" {
+                    let method = strip_callee_template_args(
                         function
                             .child_by_field_name("field")
-                            .map(|f| f.utf8_text(source).unwrap_or("").to_string())
-                            .unwrap_or_default()
+                            .and_then(|f| f.utf8_text(source).ok())
+                            .unwrap_or_default(),
+                    );
+                    match receiver_owner(&function, source, scope) {
+                        Some(owner) if is_valid_callee(&method) => format!("{owner}::{method}"),
+                        _ => method,
                     }
-                    _ => function.utf8_text(source).unwrap_or("").to_string(),
+                } else {
+                    strip_callee_template_args(function.utf8_text(source).unwrap_or(""))
                 };
-                let callee_name = strip_callee_template_args(&callee_name);
-                if is_valid_callee(&callee_name) {
+                if is_valid_callee(&dst_name) {
                     relations.push(ExtractedRelation {
                         kind: kin_model::RelationKind::Calls,
                         src_name: context_name.to_string(),
-                        dst_name: callee_name,
+                        dst_name,
                         import_source: None,
                     });
                 }
             }
         }
-        extract_calls_from_body(&child, source, context_name, relations);
+        collect_scoped_calls(&child, source, context_name, scope, relations);
+    }
+}
+
+/// Resolve a `field_expression` receiver to a class name: `this` binds to the
+/// enclosing class; a bare identifier binds to its local/parameter type, then to
+/// an enclosing-class member's type. Any other receiver shape (chained access,
+/// call result, subscript) is left unresolved so the call keeps its bare name.
+fn receiver_owner(
+    field_expr: &tree_sitter::Node,
+    source: &[u8],
+    scope: &ReceiverScope,
+) -> Option<String> {
+    let receiver = field_expr.child_by_field_name("argument")?;
+    match receiver.kind() {
+        "this" => scope.enclosing_class.clone(),
+        "identifier" => scope
+            .owner_of(receiver.utf8_text(source).ok()?)
+            .map(str::to_string),
+        _ => None,
+    }
+}
+
+/// Collect `name -> class type` for the parameters under a function declarator.
+fn collect_param_types(
+    node: &tree_sitter::Node,
+    source: &[u8],
+    out: &mut std::collections::HashMap<String, String>,
+) {
+    if node.kind() == "parameter_list" {
+        let mut cursor = node.walk();
+        for param in node.children(&mut cursor) {
+            if matches!(
+                param.kind(),
+                "parameter_declaration" | "optional_parameter_declaration"
+            ) {
+                record_typed_declarators(&param, source, out);
+            }
+        }
+        return;
+    }
+    let mut cursor = node.walk();
+    for child in node.children(&mut cursor) {
+        collect_param_types(&child, source, out);
+    }
+}
+
+/// Collect `name -> class type` for every local `declaration` in a body.
+fn collect_local_var_types(
+    node: &tree_sitter::Node,
+    source: &[u8],
+    out: &mut std::collections::HashMap<String, String>,
+) {
+    let mut cursor = node.walk();
+    for child in node.children(&mut cursor) {
+        if child.kind() == "declaration" {
+            record_typed_declarators(&child, source, out);
+        }
+        collect_local_var_types(&child, source, out);
+    }
+}
+
+/// Collect `member -> class type` for the enclosing class's data members, found
+/// by walking up to the nearest class/struct/union and reading its field list.
+fn collect_member_field_types(
+    node: &tree_sitter::Node,
+    source: &[u8],
+    out: &mut std::collections::HashMap<String, String>,
+) {
+    let mut current = node.parent();
+    while let Some(ancestor) = current {
+        if matches!(
+            ancestor.kind(),
+            "class_specifier" | "struct_specifier" | "union_specifier"
+        ) {
+            if let Some(body) = ancestor.child_by_field_name("body") {
+                let mut cursor = body.walk();
+                for member in body.children(&mut cursor) {
+                    if member.kind() == "field_declaration" {
+                        record_typed_declarators(&member, source, out);
+                    }
+                }
+            }
+            return;
+        }
+        current = ancestor.parent();
+    }
+}
+
+/// Map each of a declaration's named declarators to its class type. Function
+/// declarators (method prototypes) carry no receiver type and are skipped, as
+/// are non-class types (`int`, `auto`, ...).
+fn record_typed_declarators(
+    node: &tree_sitter::Node,
+    source: &[u8],
+    out: &mut std::collections::HashMap<String, String>,
+) {
+    let Some(class_type) = node
+        .child_by_field_name("type")
+        .and_then(|t| type_class_name(&t, source))
+    else {
+        return;
+    };
+    let mut cursor = node.walk();
+    for declarator in node.children_by_field_name("declarator", &mut cursor) {
+        if declarator_is_function(&declarator) {
+            continue;
+        }
+        if let Some(name) = declarator_name(&declarator, source) {
+            out.entry(name).or_insert_with(|| class_type.clone());
+        }
+    }
+}
+
+/// Reduce a `type` node to the bare class name usable as an entity key: a plain
+/// or template type yields its identifier, a qualified type its leaf; primitive
+/// and inferred (`auto`) types yield nothing.
+fn type_class_name(node: &tree_sitter::Node, source: &[u8]) -> Option<String> {
+    match node.kind() {
+        "type_identifier" | "identifier" => node.utf8_text(source).ok().map(str::to_string),
+        "template_type" | "qualified_identifier" => node
+            .child_by_field_name("name")
+            .and_then(|n| type_class_name(&n, source)),
+        _ => None,
+    }
+}
+
+/// Descend a declarator through pointer/reference/array/init wrappers to the
+/// declared identifier.
+fn declarator_name(node: &tree_sitter::Node, source: &[u8]) -> Option<String> {
+    match node.kind() {
+        "identifier" | "field_identifier" => node.utf8_text(source).ok().map(str::to_string),
+        "pointer_declarator" | "array_declarator" | "init_declarator" => node
+            .child_by_field_name("declarator")
+            .and_then(|c| declarator_name(&c, source)),
+        "reference_declarator" | "parenthesized_declarator" => node
+            .named_child(0)
+            .and_then(|c| declarator_name(&c, source)),
+        _ => None,
+    }
+}
+
+/// Whether a declarator declares a function (a method prototype), which has no
+/// receiver type to record.
+fn declarator_is_function(node: &tree_sitter::Node) -> bool {
+    match node.kind() {
+        "function_declarator" => true,
+        "pointer_declarator"
+        | "reference_declarator"
+        | "init_declarator"
+        | "array_declarator"
+        | "parenthesized_declarator" => node
+            .child_by_field_name("declarator")
+            .or_else(|| node.named_child(0))
+            .map(|c| declarator_is_function(&c))
+            .unwrap_or(false),
+        _ => false,
     }
 }
 

--- a/crates/kin-parser/tests/cpp_call_resolution.rs
+++ b/crates/kin-parser/tests/cpp_call_resolution.rs
@@ -117,3 +117,134 @@ void caller() {
         "free-function template instantiation must emit the bare callee name"
     );
 }
+
+fn calls_from<'a>(rels: &'a [ExtractedRelation], src: &str) -> Vec<&'a str> {
+    rels.iter()
+        .filter(|r| r.kind == RelationKind::Calls && r.src_name == src)
+        .map(|r| r.dst_name.as_str())
+        .collect()
+}
+
+#[test]
+fn typed_local_receiver_binds_call_to_its_class() {
+    // Local generators whose `.add()`/`->add()` must resolve to their own class,
+    // never fan out to every same-named `add` across unrelated classes.
+    let source = r#"
+namespace Catch {
+    template<typename T>
+    struct ValuesGenerator {
+        void add( T value ) {}
+    };
+    template<typename T>
+    struct CompositeGenerator {
+        void add( const T* g ) {}
+    };
+    template<typename T>
+    CompositeGenerator<T> values( T v1, T v2 ) {
+        CompositeGenerator<T> generators;
+        ValuesGenerator<T>* valuesGen = new ValuesGenerator<T>();
+        valuesGen->add( v1 );
+        generators.add( valuesGen );
+        return generators;
+    }
+}
+"#;
+    let rels = parse_and_extract(source);
+    let calls = calls_from(&rels, "values");
+    assert!(
+        calls.contains(&"ValuesGenerator::add"),
+        "pointer-local `valuesGen->add` must bind to ValuesGenerator, got: {calls:?}"
+    );
+    assert!(
+        calls.contains(&"CompositeGenerator::add"),
+        "value-local `generators.add` must bind to CompositeGenerator, got: {calls:?}"
+    );
+    assert!(
+        !calls.contains(&"add"),
+        "no bare `add` may survive when both receivers are typed, got: {calls:?}"
+    );
+}
+
+#[test]
+fn this_receiver_binds_call_to_enclosing_class() {
+    let source = r#"
+struct Widget {
+    void run() { this->helper(); }
+    void helper() {}
+};
+"#;
+    let rels = parse_and_extract(source);
+    let calls = calls_from(&rels, "Widget::run");
+    assert!(
+        calls.contains(&"Widget::helper"),
+        "`this->helper()` must bind to the enclosing class, got: {calls:?}"
+    );
+}
+
+#[test]
+fn member_field_receiver_binds_call_to_field_class() {
+    let source = r#"
+struct Engine { void start() {} };
+struct Car {
+    Engine m_engine;
+    void drive() { m_engine.start(); }
+};
+"#;
+    let rels = parse_and_extract(source);
+    let calls = calls_from(&rels, "Car::drive");
+    assert!(
+        calls.contains(&"Engine::start"),
+        "member-field receiver `m_engine.start()` must bind to Engine, got: {calls:?}"
+    );
+}
+
+#[test]
+fn parameter_receiver_binds_call_to_parameter_class() {
+    let source = r#"
+struct Sink { void write() {} };
+void pump( Sink& out ) { out.write(); }
+"#;
+    let rels = parse_and_extract(source);
+    let calls = calls_from(&rels, "pump");
+    assert!(
+        calls.contains(&"Sink::write"),
+        "parameter receiver `out.write()` must bind to Sink, got: {calls:?}"
+    );
+}
+
+#[test]
+fn unresolvable_receiver_keeps_bare_method_name() {
+    // No declaration for `obj`: the receiver type is unknown, so the call keeps
+    // its bare rightmost name for the linker's weak ambiguous-fanout tier.
+    let source = r#"
+struct S {
+    void run() { obj.execute(); }
+};
+"#;
+    let rels = parse_and_extract(source);
+    let calls = calls_from(&rels, "S::run");
+    assert!(
+        calls.contains(&"execute"),
+        "unresolvable receiver must keep the bare method name, got: {calls:?}"
+    );
+    assert!(
+        !calls.iter().any(|c| c.contains("::execute")),
+        "unresolvable receiver must not invent a class qualifier, got: {calls:?}"
+    );
+}
+
+#[test]
+fn explicit_scope_qualified_static_call_is_preserved() {
+    let source = r#"
+namespace Catch {
+    int helper() { return 0; }
+    int caller() { return Catch::helper(); }
+}
+"#;
+    let rels = parse_and_extract(source);
+    let calls = calls_from(&rels, "caller");
+    assert!(
+        calls.contains(&"Catch::helper"),
+        "explicit `Catch::helper()` must keep its qualified callee, got: {calls:?}"
+    );
+}


### PR DESCRIPTION
## Problem

The C++ adapter extracted method calls (`obj.method()`, `obj->method()`) by keeping only the method name and discarding the receiver. The linker then resolved that bare name through its ambiguous receiver-method tier, linking the call to **every** same-named method across all classes. On partially-migrated C++ surfaces this minted phantom "consumer" edges onto unrelated classes, inflating review blast-radius and blocking otherwise-coherent migrations.

Confirmed mechanism (Catch2, older single-header layout): `MultipleReporters::add`'s only real caller is `addReporter`, but `catch_generators.hpp`'s `.add()` calls — which target `ValuesGenerator::add` / `CompositeGenerator::add` on typed local receivers — fanned out by bare name to `MultipleReporters::add`, making it look like a partially-migrated public API with residual consumers.

## Fix

**Parser (kin-parser C++ adapter).** Resolve a method call's receiver static type within the function body and emit `Type::method` instead of the bare method name. Receivers resolved:
- `this` → enclosing class
- local variables (`Foo f; f.m()`, `Foo* p = ...; p->m()`)
- parameters (`void g(Foo& o){ o.m(); }`)
- member fields (`Foo m_f; ... m_f.m()`)

Explicit `Class::method(...)` static calls already carried their qualifier and are unchanged. When the receiver type cannot be resolved, the call keeps its bare rightmost name and flows to the linker's existing ambiguous receiver-method tier, which weighs it at low confidence — so unknowable dispatch is marked weak rather than dropped or over-trusted.

**Linker (kin-index).** A receiver-scoped `Type::method` binds exactly to that class through the existing same-file (1.0) and cross-file (0.7) exact tiers. Added a tier that, when no exact `Type::method` exists, walks the receiver class's `Extends` chain to an inherited base method and binds it at the inherited-method confidence (0.85) — the C++ counterpart of the existing `self.m()` inheritance walk, generalized to match both `.` and `::` method keys. Mirrored across the batch and incremental resolvers and kept in exact parity.

### Edge-confidence vocabulary (reused, not reinvented)
| resolution | confidence |
|---|---|
| same-file exact `Type::method` | 1.0 |
| cross-file exact `Type::method` | 0.7 |
| inherited via Extends walk | 0.85 |
| ambiguous receiver-method fan-out (unresolvable receiver) | 0.3 |

### Known follow-up
A receiver whose type resolves but whose method is on neither the class nor its graph-known bases (e.g. inherited from an unparsed/template base) currently falls through to the qualified-suffix bare-leaf tier (0.6). This is narrow and does not affect the confirmed rows, which bind exactly; tightening it to suppress bare-leaf widening for a pinned class receiver is a candidate follow-up.

## Tests
- `kin-parser/tests/cpp_call_resolution.rs`: typed local / `this` / member-field / parameter receivers → `Type::method`; unresolvable receiver → bare name; explicit `Class::method` preserved.
- `kin-index/tests/cpp_call_resolution.rs`: end-to-end parse→link through **both** batch and incremental linkers (parity asserted): typed receiver binds to its own class and the cross-file same-named sibling gets **no** edge (phantom eliminated); derived-typed receiver resolves to the base-declared method only (0.85), not an unrelated same-named method; unresolvable receiver fans out weakly (0.3).
- Full kin-parser (372) and kin-index (221) suites green; fmt + clippy (CI allowlist) clean.

## Second-row classification (read-only, no code change)

The second partially-migrated row's residual consumer — `Main` at `catch_runner.hpp` — was classified against source. It is an **artifact**, same root-cause family (name-based over-resolution) but a different mechanism: **free-function overload fan-out**.

At that commit `catch_runner.hpp` has two `Main` overloads:
- `inline int Main( Ptr<Config> const& config )` — signature **changed** by the diff
- `inline int Main( int argc, char* const argv[], ConfigData configData = ConfigData() )` — signature **unchanged** (only its body was co-updated: `Ptr<Config> config = new Config( configData ); return Main( config );`)

The residual consumer is the untouched `include/internal/catch_default_main.hpp`:
```cpp
int main (int argc, char * const argv[]) {
    return Catch::Main( argc, argv );   // calls the argc/argv overload
}
```
`Catch::Main` resolves by bare leaf `Main` and fans out to **both** overloads, phantom-attaching the untouched caller to the signature-changed `Main(Ptr<Config>)`. The real callee is the argc/argv overload, whose signature did not change → no true external consumer is broken. **Verdict: artifact, benign.** This is arity-blind overload fan-out, distinct from the receiver-method fan-out fixed here (the receiver `Catch` is a namespace, not a class), so this row would need a complementary overload-arity disambiguation and is reported for the frontier tracker, not fixed in this PR.

## Sequencing
This is a graph-truth change: it only takes effect on re-ingestion and must not land mid-measurement-wave. No corpus was re-ingested and no benchmark was run for this PR; the benign-set effect measures on the next fresh-graph sweep. No row-movement is claimed here.

Refs: FIR-1429
