### PR TITLE
Arity-aware C++ overload call binding

### DIFF
--- a/crates/kin-cli/src/commands/init.rs
+++ b/crates/kin-cli/src/commands/init.rs
@@ -1153,6 +1153,7 @@ impl Clone for ImportedCommitSemanticState {
                 entity_by_name: self.linker.entity_by_name.clone(),
                 entity_by_bare_name: self.linker.entity_by_bare_name.clone(),
                 entity_kind_by_id: self.linker.entity_kind_by_id.clone(),
+                entity_arity_by_id: self.linker.entity_arity_by_id.clone(),
                 known_files: self.linker.known_files.clone(),
                 entities_by_file: self.linker.entities_by_file.clone(),
                 include_targets_by_file: self.linker.include_targets_by_file.clone(),

--- a/crates/kin-index/src/linker.rs
+++ b/crates/kin-index/src/linker.rs
@@ -11,10 +11,10 @@ use tracing::debug;
 use sha2::{Digest, Sha256};
 
 use kin_model::{
-    ArtifactId, Entity, EntityId, EntityKind, GraphNodeId, Relation, RelationEvidence, RelationId,
-    RelationKind, RelationOrigin, Visibility,
+    ArtifactId, Entity, EntityId, EntityKind, GraphNodeId, LanguageId, Relation, RelationEvidence,
+    RelationId, RelationKind, RelationOrigin, Visibility,
 };
-use kin_parser::{ExtractedRelation, FileImport};
+use kin_parser::{CallArgShape, ExtractedRelation, FileImport};
 
 /// Result of resolving a single unresolved relation.
 #[derive(Debug)]
@@ -233,6 +233,12 @@ struct LinkContext<'a> {
     entity_by_name: HashMap<&'a str, Vec<(&'a str, EntityId)>>,
     entity_by_bare_name: HashMap<&'a str, Vec<(&'a str, EntityId)>>,
     entity_kind_by_id: HashMap<EntityId, EntityKind>,
+    /// C/C++ callee id -> the argument-count bounds parsed from its signature.
+    /// Absent for a callee whose language does not carry call arity or whose
+    /// parameter list could not be read, so the linker prunes an overloaded
+    /// callee's arity-incompatible candidates without ever pruning on missing
+    /// evidence.
+    entity_arity_by_id: HashMap<EntityId, ArityBounds>,
     entity_count_by_file: HashMap<&'a str, usize>,
     known_files: HashSet<&'a str>,
     import_map: HashMap<&'a str, HashMap<&'a str, (&'a str, &'a str)>>,
@@ -261,6 +267,7 @@ fn build_link_context<'a>(
         entity_by_name,
         entity_by_bare_name,
         entity_kind_by_id,
+        entity_arity_by_id,
         entity_count_by_file,
         known_files,
     ) = {
@@ -273,6 +280,7 @@ fn build_link_context<'a>(
         let mut entity_by_name: HashMap<&str, Vec<(&str, EntityId)>> = HashMap::new();
         let mut entity_by_bare_name: HashMap<&str, Vec<(&str, EntityId)>> = HashMap::new();
         let mut entity_kind_by_id: HashMap<EntityId, EntityKind> = HashMap::new();
+        let mut entity_arity_by_id: HashMap<EntityId, ArityBounds> = HashMap::new();
         let mut entity_count_by_file: HashMap<&str, usize> = HashMap::new();
         let mut known_files: HashSet<&str> = HashSet::new();
 
@@ -296,6 +304,10 @@ fn build_link_context<'a>(
                     .or_default()
                     .push((file_path, entity.id));
             }
+
+            if let Some(bounds) = callee_arity_bounds(entity) {
+                entity_arity_by_id.insert(entity.id, bounds);
+            }
         }
 
         for file in files {
@@ -307,6 +319,7 @@ fn build_link_context<'a>(
             entity_by_name,
             entity_by_bare_name,
             entity_kind_by_id,
+            entity_arity_by_id,
             entity_count_by_file,
             known_files,
         )
@@ -367,6 +380,7 @@ fn build_link_context<'a>(
         entity_by_name,
         entity_by_bare_name,
         entity_kind_by_id,
+        entity_arity_by_id,
         entity_count_by_file,
         known_files,
         import_map,
@@ -406,6 +420,11 @@ fn resolve_one_file(file: &FileParseData, ctx: &LinkContext<'_>) -> Vec<Relation
                 continue;
             }
         };
+
+        // Positional arity the call's overloads are pruned by, `None` when the
+        // shape is absent or splat-widened (fail-open). Resolved once per
+        // relation and threaded through every same-name fan-out tier below.
+        let call_arity = call_positional_arity(&rel.call_shape);
 
         if rel.kind == RelationKind::UsesMacro {
             if let Some(&dst_id) = dst_same_file {
@@ -457,6 +476,8 @@ fn resolve_one_file(file: &FileParseData, ctx: &LinkContext<'_>) -> Vec<Relation
                 file.file_path.as_str(),
                 &mut cross_file_twins,
             );
+            let cross_file_twins =
+                prune_ids_by_arity(cross_file_twins, call_arity, &ctx.entity_arity_by_id);
             if !cross_file_twins.is_empty() && cross_file_twins.len() < AMBIGUOUS_CALL_FANOUT_CAP {
                 for cross_id in sorted_fanout_targets(cross_file_twins) {
                     if add_deduped(&mut seen, src_id, cross_id, rel.kind) {
@@ -605,6 +626,14 @@ fn resolve_one_file(file: &FileParseData, ctx: &LinkContext<'_>) -> Vec<Relation
 
         let mut linked = false;
 
+        // Arity gate for the exact-name fallbacks below: an overloaded C/C++
+        // callee recorded its call-site argument count, so drop the same-name
+        // candidates whose parameter count cannot accept it before (c) picks a
+        // target or (c2) fans out. Fail-open and a no-op for callees without
+        // recorded arity, so non-overloaded and non-C/C++ binding is unchanged.
+        let other_file_candidates =
+            prune_pairs_by_arity(other_file_candidates, call_arity, &ctx.entity_arity_by_id);
+
         if name_fallback_allowed && !other_file_candidates.is_empty() {
             let distinct_ids: HashSet<EntityId> =
                 other_file_candidates.iter().map(|&(_, id)| id).collect();
@@ -651,6 +680,8 @@ fn resolve_one_file(file: &FileParseData, ctx: &LinkContext<'_>) -> Vec<Relation
                     distinct_targets.insert(dst_id);
                 }
             }
+            let distinct_targets =
+                prune_ids_by_arity(distinct_targets, call_arity, &ctx.entity_arity_by_id);
             if (1..=AMBIGUOUS_CALL_FANOUT_CAP).contains(&distinct_targets.len()) {
                 for dst_id in sorted_fanout_targets(distinct_targets) {
                     if add_deduped(&mut seen, src_id, dst_id, rel.kind) {
@@ -703,10 +734,15 @@ fn resolve_one_file(file: &FileParseData, ctx: &LinkContext<'_>) -> Vec<Relation
             && matches!(rel.kind, RelationKind::Calls | RelationKind::References)
         {
             // Fan out: an ambiguous qualified leaf resolves to every distinct
-            // cross-file target (overloads / amalgamated copies), not just one.
-            for dst_id in
-                resolve_qualified_suffix(rel.dst_name.as_str(), file.file_path.as_str(), ctx)
-            {
+            // cross-file target (overloads / amalgamated copies), not just one —
+            // arity-pruned so an overloaded callee (`Catch::Main`) drops the
+            // overloads the call site's argument count cannot reach.
+            for dst_id in resolve_qualified_suffix(
+                rel.dst_name.as_str(),
+                file.file_path.as_str(),
+                call_arity,
+                ctx,
+            ) {
                 if add_deduped(&mut seen, src_id, dst_id, rel.kind) {
                     resolved.push(make_relation(
                         rel.kind,
@@ -1200,6 +1236,256 @@ fn sorted_fanout_targets(targets: HashSet<EntityId>) -> Vec<EntityId> {
     ids
 }
 
+/// Argument-count bounds a callee accepts, read from its signature: `min`
+/// required parameters (those without a default), `max` declared parameters,
+/// and whether a trailing C variadic (`...`) or parameter pack lets it accept
+/// unboundedly many. A call of `n` positional arguments is arity-compatible
+/// with the callee iff `min <= n && (variadic || n <= max)`.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct ArityBounds {
+    min: usize,
+    max: usize,
+    variadic: bool,
+}
+
+impl ArityBounds {
+    fn accepts(&self, args: usize) -> bool {
+        args >= self.min && (self.variadic || args <= self.max)
+    }
+}
+
+/// The argument-count bounds of an entity that can be a call target, or `None`
+/// when arity should not be inferred for it. Only C/C++ function and method
+/// entities qualify: their call sites are the ones that record arity (so only
+/// their candidates are ever pruned), and their signatures share one parameter
+/// grammar. Every other language yields `None`, leaving its callees arity-blind
+/// exactly as before.
+fn callee_arity_bounds(entity: &Entity) -> Option<ArityBounds> {
+    if !matches!(entity.language, LanguageId::Cpp | LanguageId::C) {
+        return None;
+    }
+    if !matches!(entity.kind, EntityKind::Function | EntityKind::Method) {
+        return None;
+    }
+    parse_signature_arity(&entity.signature)
+}
+
+/// Compute a C/C++ callee's [`ArityBounds`] from its stored signature, or `None`
+/// when the parameter list cannot be located (arity then stays unknown and the
+/// callee is never pruned). The signature is the declaration text with
+/// whitespace normalized (`declaration_signature`): the parameter list is its
+/// first top-level `(...)` group (an `operator()` name is skipped), split into
+/// parameters on top-level commas so nested templates/parens/braces never
+/// miscount. A `void`-only list is zero; a parameter carrying a top-level `=`
+/// is optional (counts toward `max`, not `min`); a `...` or parameter-pack
+/// parameter sets `variadic`.
+fn parse_signature_arity(signature: &str) -> Option<ArityBounds> {
+    let (open, close) = param_list_span(signature)?;
+    let inner = signature[open + 1..close].trim();
+    if inner.is_empty() || inner == "void" {
+        return Some(ArityBounds {
+            min: 0,
+            max: 0,
+            variadic: false,
+        });
+    }
+    let mut min = 0usize;
+    let mut max = 0usize;
+    let mut variadic = false;
+    for param in split_top_level_commas(inner) {
+        let param = param.trim();
+        if param.is_empty() {
+            continue;
+        }
+        // `...` (C varargs) is not a counted parameter; a parameter pack
+        // (`Args... args`) accepts zero or more, so it too adds no required
+        // argument. Either way the callee accepts unboundedly many.
+        if param == "..." || param.contains("...") {
+            variadic = true;
+            continue;
+        }
+        max += 1;
+        if !param_has_default(param) {
+            min += 1;
+        }
+    }
+    Some(ArityBounds { min, max, variadic })
+}
+
+/// Byte offsets of the `(` and matching `)` of a signature's parameter list:
+/// the first `(` at top level (outside a template `<...>`) whose name is not
+/// `operator`. Returns `None` for a signature with no such group.
+fn param_list_span(sig: &str) -> Option<(usize, usize)> {
+    let bytes = sig.as_bytes();
+    let mut angle: usize = 0;
+    let mut i = 0;
+    while i < bytes.len() {
+        match bytes[i] {
+            b'<' => angle += 1,
+            b'>' => angle = angle.saturating_sub(1),
+            b'(' if angle == 0 => {
+                let close = matching_close_paren(bytes, i)?;
+                // `operator()`: the call-operator name, not the parameter list —
+                // skip it so the real parameter list after it is found.
+                if sig[..i].trim_end().ends_with("operator") {
+                    i = close + 1;
+                    continue;
+                }
+                return Some((i, close));
+            }
+            _ => {}
+        }
+        i += 1;
+    }
+    None
+}
+
+/// Byte index of the `)` matching the `(` at `open`, tracking nested parens.
+/// `None` when the parentheses are unbalanced.
+fn matching_close_paren(bytes: &[u8], open: usize) -> Option<usize> {
+    let mut depth = 0usize;
+    let mut i = open;
+    while i < bytes.len() {
+        match bytes[i] {
+            b'(' => depth += 1,
+            b')' => {
+                depth -= 1;
+                if depth == 0 {
+                    return Some(i);
+                }
+            }
+            _ => {}
+        }
+        i += 1;
+    }
+    None
+}
+
+/// Split a parameter list's inner text on commas at the top nesting level so a
+/// comma inside `<...>`, `(...)`, `[...]`, or `{...}` (template arguments,
+/// function-pointer parameters, array bounds, brace-init defaults) never splits
+/// one parameter into several.
+fn split_top_level_commas(inner: &str) -> Vec<&str> {
+    let bytes = inner.as_bytes();
+    let mut parts = Vec::new();
+    let mut depth = 0i32;
+    let mut start = 0usize;
+    for (i, &b) in bytes.iter().enumerate() {
+        match b {
+            b'<' | b'(' | b'[' | b'{' => depth += 1,
+            b'>' | b')' | b']' | b'}' => depth = (depth - 1).max(0),
+            b',' if depth == 0 => {
+                parts.push(&inner[start..i]);
+                start = i + 1;
+            }
+            _ => {}
+        }
+    }
+    parts.push(&inner[start..]);
+    parts
+}
+
+/// Whether a single parameter carries a default value: a top-level `=` that is
+/// the assignment, not a `==`/`<=`/`>=`/`!=` fragment inside a default
+/// expression.
+fn param_has_default(param: &str) -> bool {
+    let bytes = param.as_bytes();
+    let mut depth = 0i32;
+    let mut i = 0;
+    while i < bytes.len() {
+        match bytes[i] {
+            b'<' | b'(' | b'[' | b'{' => depth += 1,
+            b'>' | b')' | b']' | b'}' => depth = (depth - 1).max(0),
+            b'=' if depth == 0 => {
+                let prev = bytes[..i].last().copied();
+                let next = bytes.get(i + 1).copied();
+                let is_comparison =
+                    matches!(prev, Some(b'<' | b'>' | b'!' | b'=')) || next == Some(b'=');
+                if !is_comparison {
+                    return true;
+                }
+            }
+            _ => {}
+        }
+        i += 1;
+    }
+    false
+}
+
+/// Keep only the entity ids a call of `arg_count` positional arguments could
+/// bind to. A candidate stays when its arity is unknown (unparsed signature or
+/// a non-C/C++ callee — never pruned on missing evidence) or accepts the count;
+/// a candidate whose known arity rejects the count is dropped. `None`
+/// `arg_count` returns the set unchanged. Fail-open: if every candidate is
+/// known-incompatible the original set is returned, so an arity read prunes
+/// wrong overloads but never erases the edge outright.
+fn prune_ids_by_arity(
+    ids: HashSet<EntityId>,
+    arg_count: Option<usize>,
+    arity_by_id: &HashMap<EntityId, ArityBounds>,
+) -> HashSet<EntityId> {
+    let Some(args) = arg_count else {
+        return ids;
+    };
+    let kept: HashSet<EntityId> = ids
+        .iter()
+        .copied()
+        .filter(|id| arity_admits(arity_by_id.get(id), args))
+        .collect();
+    if kept.is_empty() {
+        ids
+    } else {
+        kept
+    }
+}
+
+/// `(file, id)` counterpart of [`prune_ids_by_arity`] for the exact-name
+/// candidate lists, with the same fail-open semantics.
+fn prune_pairs_by_arity<'a>(
+    pairs: Vec<(&'a str, EntityId)>,
+    arg_count: Option<usize>,
+    arity_by_id: &HashMap<EntityId, ArityBounds>,
+) -> Vec<(&'a str, EntityId)> {
+    let Some(args) = arg_count else {
+        return pairs;
+    };
+    let kept: Vec<(&str, EntityId)> = pairs
+        .iter()
+        .copied()
+        .filter(|(_, id)| arity_admits(arity_by_id.get(id), args))
+        .collect();
+    if kept.is_empty() {
+        pairs
+    } else {
+        kept
+    }
+}
+
+/// Whether a candidate with the given (possibly unknown) arity admits a call of
+/// `args` positional arguments. Unknown arity always admits — the linker never
+/// prunes a candidate whose parameter count it could not read.
+fn arity_admits(bounds: Option<&ArityBounds>, args: usize) -> bool {
+    match bounds {
+        Some(bounds) => bounds.accepts(args),
+        None => true,
+    }
+}
+
+/// The exact positional argument count to prune a call's overloads by, or `None`
+/// when arity is not pinnable. A recorded [`CallArgShape`] pins arity only when
+/// no pack/splat expansion widens it: a `*args`/`args...` positional splat or a
+/// `**kwargs` keyword splat makes the positional count a lower bound, so the
+/// call is treated as arity-unknown and no overload is pruned. `None` shape
+/// (adapter recorded nothing) is likewise unknown — fail-open on both.
+fn call_positional_arity(shape: &Option<CallArgShape>) -> Option<usize> {
+    match shape {
+        Some(shape) if !shape.has_var_positional && !shape.has_var_keyword => {
+            Some(shape.positional as usize)
+        }
+        _ => None,
+    }
+}
+
 /// Resolve a Rust-style path-qualified call/reference target to a unique local
 /// entity by matching the path's resolvable suffixes against the entity indices.
 ///
@@ -1225,6 +1511,7 @@ fn sorted_fanout_targets(targets: HashSet<EntityId>) -> Vec<EntityId> {
 fn resolve_qualified_suffix(
     dst_name: &str,
     current_file: &str,
+    arg_count: Option<usize>,
     ctx: &LinkContext<'_>,
 ) -> Vec<EntityId> {
     let segments: Vec<&str> = dst_name.split("::").collect();
@@ -1238,7 +1525,8 @@ fn resolve_qualified_suffix(
     // Tier 1: type-qualified suffix `Penult::last` against the full-name index.
     // Resolves a method reached through a module/crate prefix. If this pinned
     // suffix is itself ambiguous, stop — widening to the bare leaf would be less
-    // precise, not more.
+    // precise, not more. Arity pruning first can settle that ambiguity when the
+    // rival suffix targets are overloads the call's argument count separates.
     let type_qualified = format!("{}::{}", segments[segments.len() - 2], last);
     let mut tq_targets: HashSet<EntityId> = HashSet::new();
     distinct_cross_file_targets(
@@ -1246,6 +1534,7 @@ fn resolve_qualified_suffix(
         current_file,
         &mut tq_targets,
     );
+    let tq_targets = prune_ids_by_arity(tq_targets, arg_count, &ctx.entity_arity_by_id);
     match tq_targets.len() {
         1 => return tq_targets.into_iter().collect(),
         n if n > 1 => {
@@ -1275,6 +1564,7 @@ fn resolve_qualified_suffix(
         current_file,
         &mut leaf_targets,
     );
+    let leaf_targets = prune_ids_by_arity(leaf_targets, arg_count, &ctx.entity_arity_by_id);
     match leaf_targets.len() {
         0 => Vec::new(),
         n if n <= AMBIGUOUS_CALL_FANOUT_CAP => sorted_fanout_targets(leaf_targets),
@@ -1299,6 +1589,7 @@ fn resolve_qualified_suffix(
 fn resolve_qualified_suffix_incremental(
     dst_name: &str,
     current_file: &str,
+    arg_count: Option<usize>,
     linker: &IncrementalLinker,
 ) -> Vec<EntityId> {
     let segments: Vec<&str> = dst_name.split("::").collect();
@@ -1317,6 +1608,7 @@ fn resolve_qualified_suffix_incremental(
             }
         }
     }
+    let tq_targets = prune_ids_by_arity(tq_targets, arg_count, &linker.entity_arity_by_id);
     match tq_targets.len() {
         1 => return tq_targets.into_iter().collect(),
         n if n > 1 => {
@@ -1350,6 +1642,7 @@ fn resolve_qualified_suffix_incremental(
             }
         }
     }
+    let leaf_targets = prune_ids_by_arity(leaf_targets, arg_count, &linker.entity_arity_by_id);
     match leaf_targets.len() {
         0 => Vec::new(),
         n if n <= AMBIGUOUS_CALL_FANOUT_CAP => sorted_fanout_targets(leaf_targets),
@@ -2546,6 +2839,10 @@ pub struct IncrementalLinker {
     pub entity_by_bare_name: HashMap<String, Vec<(String, EntityId)>>,
     /// entity_id -> kind
     pub entity_kind_by_id: HashMap<EntityId, EntityKind>,
+    /// C/C++ callee id -> argument-count bounds parsed from its signature. The
+    /// incremental mirror of the batch linker's `entity_arity_by_id`; backs
+    /// overload arity pruning on the live-edit path.
+    pub entity_arity_by_id: HashMap<EntityId, ArityBounds>,
     /// Set of all known files
     pub known_files: HashSet<String>,
     /// file_path -> Vec<(EntityId, Visibility)>
@@ -2571,6 +2868,7 @@ impl IncrementalLinker {
             entity_by_name: HashMap::new(),
             entity_by_bare_name: HashMap::new(),
             entity_kind_by_id: HashMap::new(),
+            entity_arity_by_id: HashMap::new(),
             known_files: HashSet::new(),
             entities_by_file: HashMap::new(),
             include_targets_by_file: HashMap::new(),
@@ -2585,6 +2883,7 @@ impl IncrementalLinker {
         if let Some(file_entities) = self.entity_by_file_name.remove(file_path) {
             for (entity_name, entity_id) in file_entities {
                 self.entity_kind_by_id.remove(&entity_id);
+                self.entity_arity_by_id.remove(&entity_id);
                 if let Some(candidates) = self.entity_by_name.get_mut(&entity_name) {
                     candidates.retain(|(fp, _)| fp != file_path);
                     if candidates.is_empty() {
@@ -2655,6 +2954,9 @@ impl IncrementalLinker {
         for entity in entities {
             file_entities_map.insert(entity.name.clone(), entity.id);
             self.entity_kind_by_id.insert(entity.id, entity.kind);
+            if let Some(bounds) = callee_arity_bounds(entity) {
+                self.entity_arity_by_id.insert(entity.id, bounds);
+            }
 
             self.entity_by_name
                 .entry(entity.name.clone())
@@ -2809,6 +3111,11 @@ fn resolve_one_file_incremental(
             }
         };
 
+        // Positional arity the call's overloads are pruned by (fail-open on an
+        // absent or splat-widened shape) — the incremental mirror of the batch
+        // linker's per-relation derivation.
+        let call_arity = call_positional_arity(&rel.call_shape);
+
         if rel.kind == RelationKind::UsesMacro {
             if let Some(dst_id) = dst_same_file {
                 if linker.entity_kind_by_id.get(&dst_id) == Some(&EntityKind::Macro) {
@@ -2858,6 +3165,8 @@ fn resolve_one_file_incremental(
                     }
                 }
             }
+            let cross_file_twins =
+                prune_ids_by_arity(cross_file_twins, call_arity, &linker.entity_arity_by_id);
             if !cross_file_twins.is_empty() && cross_file_twins.len() < AMBIGUOUS_CALL_FANOUT_CAP {
                 for cross_id in sorted_fanout_targets(cross_file_twins) {
                     if add_deduped(&mut seen, src_id, cross_id, rel.kind) {
@@ -2998,6 +3307,16 @@ fn resolve_one_file_incremental(
             ImportPinnedTarget::NoPin => {}
         }
 
+        // Arity gate mirroring the batch linker: drop the exact-name candidates
+        // an overloaded C/C++ callee's recorded call-site argument count cannot
+        // reach before (c)/(c2) bind. Fail-open and a no-op without recorded
+        // arity, so non-overloaded and non-C/C++ binding is unchanged.
+        let other_file_candidates = prune_pairs_by_arity(
+            other_file_candidates,
+            call_arity,
+            &linker.entity_arity_by_id,
+        );
+
         // (c) Global name-match fallback
         if name_fallback_allowed && !other_file_candidates.is_empty() {
             let distinct_ids: HashSet<EntityId> =
@@ -3056,6 +3375,8 @@ fn resolve_one_file_incremental(
                     .filter(|(fp, _)| fp != &file.file_path)
                     .map(|(_, id)| *id)
                     .collect();
+                let distinct_targets =
+                    prune_ids_by_arity(distinct_targets, call_arity, &linker.entity_arity_by_id);
                 if (1..=AMBIGUOUS_CALL_FANOUT_CAP).contains(&distinct_targets.len()) {
                     for dst_id in sorted_fanout_targets(distinct_targets) {
                         if add_deduped(&mut seen, src_id, dst_id, rel.kind) {
@@ -3106,9 +3427,13 @@ fn resolve_one_file_incremental(
             && matches!(rel.kind, RelationKind::Calls | RelationKind::References)
         {
             // Fan out: an ambiguous qualified leaf resolves to every distinct
-            // cross-file target, matching the batch resolver.
-            let qualified_targets =
-                resolve_qualified_suffix_incremental(&rel.dst_name, &file.file_path, linker);
+            // cross-file target, arity-pruned, matching the batch resolver.
+            let qualified_targets = resolve_qualified_suffix_incremental(
+                &rel.dst_name,
+                &file.file_path,
+                call_arity,
+                linker,
+            );
             if !qualified_targets.is_empty() {
                 for dst_id in qualified_targets {
                     if add_deduped(&mut seen, src_id, dst_id, rel.kind) {
@@ -3350,6 +3675,88 @@ mod tests {
         entity
     }
 
+    fn arity(min: usize, max: usize, variadic: bool) -> ArityBounds {
+        ArityBounds { min, max, variadic }
+    }
+
+    #[test]
+    fn parse_signature_arity_plain_and_empty_parameter_lists() {
+        assert_eq!(
+            parse_signature_arity("int Main(int argc, char* const argv[])"),
+            Some(arity(2, 2, false))
+        );
+        assert_eq!(
+            parse_signature_arity("void add(int value)"),
+            Some(arity(1, 1, false))
+        );
+        assert_eq!(
+            parse_signature_arity("void run()"),
+            Some(arity(0, 0, false))
+        );
+        // A C-style `(void)` list declares zero parameters, not one.
+        assert_eq!(
+            parse_signature_arity("int shutdown(void)"),
+            Some(arity(0, 0, false))
+        );
+        // No locatable parameter list: arity is unknown, never a false zero.
+        assert_eq!(parse_signature_arity("struct Widget"), None);
+    }
+
+    #[test]
+    fn parse_signature_arity_counts_template_typed_parameters_as_one() {
+        // The `<Config>` / `<int, Alloc>` commas sit inside a parameter's type,
+        // so depth-aware splitting must not read them as parameter separators.
+        assert_eq!(
+            parse_signature_arity("Ptr<Config> Main(Ptr<Config> const& config)"),
+            Some(arity(1, 1, false))
+        );
+        assert_eq!(
+            parse_signature_arity("void insert(std::map<int, Alloc> m, int key)"),
+            Some(arity(2, 2, false))
+        );
+    }
+
+    #[test]
+    fn parse_signature_arity_defaulted_parameters_widen_max_only() {
+        // A defaulted parameter is optional: it lifts `max` but not `min`.
+        assert_eq!(
+            parse_signature_arity("void f(int a, int b = 0)"),
+            Some(arity(1, 2, false))
+        );
+        assert_eq!(
+            parse_signature_arity("void g(int a, int b = 0, int c = 1)"),
+            Some(arity(1, 3, false))
+        );
+        // A relational operator inside a default expression is not the default
+        // marker and must not be miscounted as an extra parameter.
+        assert_eq!(
+            parse_signature_arity("void h(int a, bool ok = a >= 0)"),
+            Some(arity(1, 2, false))
+        );
+    }
+
+    #[test]
+    fn parse_signature_arity_variadics_accept_unbounded() {
+        // C varargs and parameter packs both make the callee accept any count at
+        // or above its required parameters.
+        let printf = parse_signature_arity("int printf(const char* fmt, ...)").unwrap();
+        assert_eq!(printf, arity(1, 1, true));
+        assert!(printf.accepts(1) && printf.accepts(5) && !printf.accepts(0));
+
+        let pack = parse_signature_arity("void emit(Args... args)").unwrap();
+        assert!(pack.variadic && pack.accepts(0) && pack.accepts(3));
+    }
+
+    #[test]
+    fn arity_bounds_accepts_matches_overload_selection() {
+        let two = arity(2, 2, false);
+        assert!(two.accepts(2));
+        assert!(!two.accepts(1));
+        assert!(!two.accepts(3));
+        let optional = arity(1, 2, false);
+        assert!(optional.accepts(1) && optional.accepts(2) && !optional.accepts(3));
+    }
+
     #[test]
     fn same_file_resolution() {
         let e1 = make_entity("foo", "src/a.ts");
@@ -3359,6 +3766,7 @@ mod tests {
             file_path: "src/a.ts".to_string(),
             entities: vec![e1.clone(), e2.clone()],
             relations: vec![ExtractedRelation {
+                call_shape: None,
                 kind: RelationKind::Calls,
                 src_name: "foo".to_string(),
                 dst_name: "bar".to_string(),
@@ -3384,6 +3792,7 @@ mod tests {
                 file_path: "src/routes/api.ts".to_string(),
                 entities: vec![caller.clone()],
                 relations: vec![ExtractedRelation {
+                    call_shape: None,
                     kind: RelationKind::Calls,
                     src_name: "handler".to_string(),
                     dst_name: "executeTool".to_string(),
@@ -3440,6 +3849,7 @@ mod tests {
             file_path: "src/routes/api.ts".to_string(),
             entities: vec![caller.clone()],
             relations: vec![ExtractedRelation {
+                call_shape: None,
                 kind: RelationKind::Calls,
                 src_name: "handler".to_string(),
                 dst_name: "executeTool".to_string(),
@@ -3492,6 +3902,7 @@ mod tests {
             file_path: "src/app.ts".to_string(),
             entities: vec![caller.clone()],
             relations: vec![ExtractedRelation {
+                call_shape: None,
                 kind: RelationKind::Calls,
                 src_name: "run".to_string(),
                 dst_name: "helper".to_string(),
@@ -3522,6 +3933,7 @@ mod tests {
     #[test]
     fn parallel_resolution_is_byte_identical_to_serial() {
         let calls = |src: &str, dst: &str| ExtractedRelation {
+            call_shape: None,
             kind: RelationKind::Calls,
             src_name: src.to_string(),
             dst_name: dst.to_string(),
@@ -3741,6 +4153,7 @@ mod tests {
                 file_path: "src/app.ts".to_string(),
                 entities: vec![caller.clone()],
                 relations: vec![ExtractedRelation {
+                    call_shape: None,
                     kind: RelationKind::Calls,
                     src_name: "main".to_string(),
                     dst_name: "helper".to_string(),
@@ -3773,6 +4186,7 @@ mod tests {
                 file_path: "src/app.cpp".to_string(),
                 entities: vec![caller.clone()],
                 relations: vec![ExtractedRelation {
+                    call_shape: None,
                     kind: RelationKind::UsesMacro,
                     src_name: "main".to_string(),
                     dst_name: "JSON_PRIVATE_UNLESS_TESTED".to_string(),
@@ -3826,6 +4240,7 @@ mod tests {
                 file_path: "src/app.cpp".to_string(),
                 entities: vec![caller],
                 relations: vec![ExtractedRelation {
+                    call_shape: None,
                     kind: RelationKind::UsesMacro,
                     src_name: "main".to_string(),
                     dst_name: "JSON_PRIVATE_UNLESS_TESTED".to_string(),
@@ -3942,6 +4357,7 @@ void f();
                 file_path: "src/parse.ts".to_string(),
                 entities: vec![caller.clone()],
                 relations: vec![ExtractedRelation {
+                    call_shape: None,
                     kind: RelationKind::Calls,
                     src_name: "_safeParse".to_string(),
                     dst_name: "util.finalizeIssue".to_string(),
@@ -3986,12 +4402,14 @@ void f();
             entities: vec![e1.clone(), e2.clone()],
             relations: vec![
                 ExtractedRelation {
+                    call_shape: None,
                     kind: RelationKind::Calls,
                     src_name: "foo".to_string(),
                     dst_name: "bar".to_string(),
                     import_source: None,
                 },
                 ExtractedRelation {
+                    call_shape: None,
                     kind: RelationKind::Calls,
                     src_name: "foo".to_string(),
                     dst_name: "bar".to_string(),
@@ -4013,6 +4431,7 @@ void f();
             file_path: "src/a.ts".to_string(),
             entities: vec![e1],
             relations: vec![ExtractedRelation {
+                call_shape: None,
                 kind: RelationKind::Calls,
                 src_name: "foo".to_string(),
                 dst_name: "nonexistent".to_string(),
@@ -4038,6 +4457,7 @@ void f();
                 file_path: "src/wiring.rs".to_string(),
                 entities: vec![caller.clone()],
                 relations: vec![ExtractedRelation {
+                    call_shape: None,
                     kind: RelationKind::Calls,
                     src_name: "project_after_mcp_commit".to_string(),
                     dst_name: "project_overlay_to_files".to_string(),
@@ -4078,6 +4498,7 @@ void f();
                 file_path: "src/caller.rs".to_string(),
                 entities: vec![caller.clone()],
                 relations: vec![ExtractedRelation {
+                    call_shape: None,
                     kind: RelationKind::Calls,
                     src_name: "build".to_string(),
                     dst_name: "new".to_string(),
@@ -4133,6 +4554,7 @@ void f();
             file_path: "src/wiring.rs".to_string(),
             entities: vec![caller.clone()],
             relations: vec![ExtractedRelation {
+                call_shape: None,
                 kind: RelationKind::Calls,
                 src_name: "project_after_mcp_commit".to_string(),
                 dst_name: "project_overlay_to_files".to_string(),
@@ -4194,24 +4616,28 @@ void f();
                 entities: vec![a, b],
                 relations: vec![
                     ExtractedRelation {
+                        call_shape: None,
                         kind: RelationKind::Calls,
                         src_name: format!("a{i}"),
                         dst_name: format!("b{i}"),
                         import_source: None,
                     },
                     ExtractedRelation {
+                        call_shape: None,
                         kind: RelationKind::Calls,
                         src_name: format!("a{i}"),
                         dst_name: "shared_target".to_string(),
                         import_source: None,
                     },
                     ExtractedRelation {
+                        call_shape: None,
                         kind: RelationKind::Calls,
                         src_name: format!("b{i}"),
                         dst_name: "common".to_string(),
                         import_source: None,
                     },
                     ExtractedRelation {
+                        call_shape: None,
                         kind: RelationKind::Calls,
                         src_name: format!("b{i}"),
                         dst_name: "work".to_string(),
@@ -4266,6 +4692,7 @@ void f();
             file_path: "src/caller.rs".to_string(),
             entities: vec![caller.clone()],
             relations: vec![ExtractedRelation {
+                call_shape: None,
                 kind: RelationKind::Calls,
                 src_name: "build".to_string(),
                 dst_name: "new".to_string(),
@@ -4403,6 +4830,7 @@ void f();
                 file_path: "src/api.ts".to_string(),
                 entities: vec![caller.clone()],
                 relations: vec![ExtractedRelation {
+                    call_shape: None,
                     kind: RelationKind::Calls,
                     src_name: "handler".to_string(),
                     dst_name: "myWork".to_string(),
@@ -4551,6 +4979,7 @@ void f();
                 file_path: "src/routes/api.ts".to_string(),
                 entities: vec![caller.clone()],
                 relations: vec![ExtractedRelation {
+                    call_shape: None,
                     kind: RelationKind::Calls,
                     src_name: "handler".to_string(),
                     dst_name: "executeTool".to_string(),
@@ -4643,6 +5072,7 @@ void f();
                 file_path: "a.ts".to_string(),
                 entities: vec![e1.clone()],
                 relations: vec![ExtractedRelation {
+                    call_shape: None,
                     kind: RelationKind::Calls,
                     src_name: "caller".to_string(),
                     dst_name: "callee".to_string(),
@@ -4678,6 +5108,7 @@ void f();
             file_path: "src/app.rs".to_string(),
             entities: vec![caller.clone()],
             relations: vec![ExtractedRelation {
+                call_shape: None,
                 kind: RelationKind::Calls,
                 src_name: "run_task".to_string(),
                 dst_name: "InMemoryGraph".to_string(),
@@ -4713,6 +5144,7 @@ void f();
             file_path: "src/app.rs".to_string(),
             entities: vec![caller.clone()],
             relations: vec![ExtractedRelation {
+                call_shape: None,
                 kind: RelationKind::Calls,
                 src_name: "run_task".to_string(),
                 dst_name: "InMemoryGraph".to_string(),
@@ -4740,12 +5172,14 @@ void f();
             entities,
             relations: vec![
                 ExtractedRelation {
+                    call_shape: None,
                     kind: RelationKind::Calls,
                     src_name: "run_task".to_string(),
                     dst_name: "InMemoryGraph".to_string(),
                     import_source: Some("kin_db".to_string()),
                 },
                 ExtractedRelation {
+                    call_shape: None,
                     kind: RelationKind::Calls,
                     src_name: "run_again".to_string(),
                     dst_name: "InMemoryGraph".to_string(),
@@ -4785,6 +5219,7 @@ void f();
                 file_path: "src/routes/api.ts".to_string(),
                 entities: vec![handler.clone()],
                 relations: vec![ExtractedRelation {
+                    call_shape: None,
                     kind: RelationKind::Calls,
                     src_name: "handler".to_string(),
                     dst_name: "executeTool".to_string(),
@@ -4839,6 +5274,7 @@ void f();
 
     fn calls_relation(src: &str, dst: &str) -> ExtractedRelation {
         ExtractedRelation {
+            call_shape: None,
             kind: RelationKind::Calls,
             src_name: src.to_string(),
             dst_name: dst.to_string(),
@@ -5542,6 +5978,7 @@ void f();
 
     fn pinned_calls_relation(src: &str, dst: &str, import_source: &str) -> ExtractedRelation {
         ExtractedRelation {
+            call_shape: None,
             kind: RelationKind::Calls,
             src_name: src.to_string(),
             dst_name: dst.to_string(),

--- a/crates/kin-index/tests/cpp_call_resolution.rs
+++ b/crates/kin-index/tests/cpp_call_resolution.rs
@@ -257,3 +257,340 @@ void drain() {
         "an unresolvable receiver-method fan-out stays at the weak ambiguous confidence"
     );
 }
+
+// ── Arity-aware overload binding ─────────────────────────────────────────────
+//
+// Overloaded free functions and methods share one entity name, so the linker
+// cannot tell them apart by name. Each of these scenarios binds a call to the
+// overload its call-site argument count admits and drops the arity-incompatible
+// siblings the pre-fix bare-leaf / same-name fan-out phantom-attached. On the
+// old linker the argument count is ignored, so the asserted `!has_call` (or the
+// mismatched single pick) fails — every test here is red before the fix.
+
+/// Resolve the id of the overload of `name` in `file` whose signature contains
+/// `sig_needle`. Overloads share a name, so a signature fragment is the only way
+/// to name one of them from a test.
+fn overload_id(files: &[FileParseData], file: &str, name: &str, sig_needle: &str) -> EntityId {
+    files
+        .iter()
+        .flat_map(|f| f.entities.iter())
+        .find(|e| {
+            e.name == name
+                && e.file_origin.as_ref().map(|p| p.0.as_str()) == Some(file)
+                && e.signature.contains(sig_needle)
+        })
+        .unwrap_or_else(|| {
+            panic!("overload `{name}` matching `{sig_needle}` in `{file}` not found")
+        })
+        .id
+}
+
+fn call_edges(relations: &[Relation]) -> std::collections::HashSet<(EntityId, EntityId)> {
+    relations
+        .iter()
+        .filter(|r| r.kind == RelationKind::Calls)
+        .filter_map(|r| Some((r.src.as_entity()?, r.dst.as_entity()?)))
+        .collect()
+}
+
+#[test]
+fn namespaced_overload_binds_only_the_arity_compatible_overload() {
+    // The Catch2 two-overload shape: `Catch::Main` has two overloads, and the
+    // untouched caller invokes the two-argument one. The qualifier `Catch` is a
+    // namespace, so the receiver-scope fix (#265) does not apply; only call-site
+    // arity keeps the two-argument caller off the signature-changed one-arg
+    // overload that the bare-leaf `Main` fan-out otherwise phantom-attaches.
+    let files = vec![
+        parse_cpp(
+            "runner.hpp",
+            r#"
+namespace Catch {
+    int Main( int argc, char* const argv[] ) { return 0; }
+    int Main( Config const& config ) { return 1; }
+}
+"#,
+        ),
+        parse_cpp(
+            "main.hpp",
+            r#"
+namespace Catch {
+    int defaultMain( int argc, char* const argv[] ) {
+        return Catch::Main( argc, argv );
+    }
+}
+"#,
+        ),
+    ];
+
+    let relations = link_both(&files);
+    let caller = entity_id(&files, "main.hpp", "defaultMain");
+    let main_two = overload_id(&files, "runner.hpp", "Main", "argv");
+    let main_one = overload_id(&files, "runner.hpp", "Main", "Config");
+
+    assert!(
+        has_call(&relations, caller, main_two),
+        "the two-argument caller must bind the two-argument Catch::Main"
+    );
+    assert!(
+        !has_call(&relations, caller, main_one),
+        "the phantom `defaultMain -> Main(Config const&)` (arity 1) must be gone"
+    );
+}
+
+#[test]
+fn bare_free_function_overloads_bind_by_call_arity() {
+    // Bare (unqualified) calls to overloaded free functions: each caller's
+    // argument count must select its matching overload. The old linker picks one
+    // bucket-order overload for BOTH callers regardless of arity, so one caller
+    // is always mis-bound.
+    let files = vec![
+        parse_cpp(
+            "shapes.hpp",
+            r#"
+void render( int only ) {}
+void render( int width, int height ) {}
+"#,
+        ),
+        parse_cpp(
+            "canvas.hpp",
+            r#"
+void draw_one() { render( a ); }
+void draw_two() { render( a, b ); }
+"#,
+        ),
+    ];
+
+    let relations = link_both(&files);
+    let draw_one = entity_id(&files, "canvas.hpp", "draw_one");
+    let draw_two = entity_id(&files, "canvas.hpp", "draw_two");
+    let render_one = overload_id(&files, "shapes.hpp", "render", "only");
+    let render_two = overload_id(&files, "shapes.hpp", "render", "height");
+
+    assert!(has_call(&relations, draw_one, render_one));
+    assert!(
+        !has_call(&relations, draw_one, render_two),
+        "a one-argument call must not bind the two-argument render"
+    );
+    assert!(has_call(&relations, draw_two, render_two));
+    assert!(
+        !has_call(&relations, draw_two, render_one),
+        "a two-argument call must not bind the one-argument render"
+    );
+}
+
+#[test]
+fn default_parameters_widen_the_accepted_arity() {
+    // A defaulted parameter makes one overload accept a range of arities; the
+    // strict sibling accepts only its exact count. Both a one-arg and a two-arg
+    // caller must reach the defaulted overload and neither the strict three-arg
+    // one — proving `min`/`max` (not just an exact match) drives compatibility.
+    let files = vec![
+        parse_cpp(
+            "cfg.hpp",
+            r#"
+namespace Cfg {
+    void configure( int mode, int retries = 0 ) {}
+    void configure( int mode, int lo, int hi ) {}
+}
+"#,
+        ),
+        parse_cpp(
+            "boot.hpp",
+            r#"
+namespace Cfg {
+    void boot_one() { Cfg::configure( m ); }
+    void boot_two() { Cfg::configure( m, r ); }
+}
+"#,
+        ),
+    ];
+
+    let relations = link_both(&files);
+    let boot_one = entity_id(&files, "boot.hpp", "boot_one");
+    let boot_two = entity_id(&files, "boot.hpp", "boot_two");
+    let defaulted = overload_id(&files, "cfg.hpp", "configure", "retries");
+    let strict = overload_id(&files, "cfg.hpp", "configure", "hi");
+
+    assert!(
+        has_call(&relations, boot_one, defaulted),
+        "a one-argument call fits `configure(int, int = 0)`"
+    );
+    assert!(
+        has_call(&relations, boot_two, defaulted),
+        "a two-argument call fits `configure(int, int = 0)`"
+    );
+    assert!(
+        !has_call(&relations, boot_one, strict),
+        "a one-argument call cannot reach `configure(int, int, int)`"
+    );
+    assert!(
+        !has_call(&relations, boot_two, strict),
+        "a two-argument call cannot reach `configure(int, int, int)`"
+    );
+}
+
+#[test]
+fn method_overloads_combine_receiver_scope_and_arity() {
+    // Receiver scoping (#265) pins the class; arity pins the overload. A typed
+    // receiver whose class declares `run(int)` and `run(int, int)` must bind the
+    // overload matching each call's argument count — the two fixes composing.
+    let files = vec![
+        parse_cpp(
+            "widget.hpp",
+            r#"
+struct Widget {
+    void run( int once ) {}
+    void run( int lhs, int rhs ) {}
+};
+"#,
+        ),
+        parse_cpp(
+            "driver.hpp",
+            r#"
+void use_one() {
+    Widget w;
+    w.run( x );
+}
+void use_two() {
+    Widget w;
+    w.run( x, y );
+}
+"#,
+        ),
+    ];
+
+    let relations = link_both(&files);
+    let use_one = entity_id(&files, "driver.hpp", "use_one");
+    let use_two = entity_id(&files, "driver.hpp", "use_two");
+    let run_one = overload_id(&files, "widget.hpp", "Widget::run", "once");
+    let run_two = overload_id(&files, "widget.hpp", "Widget::run", "rhs");
+
+    assert!(has_call(&relations, use_one, run_one));
+    assert!(
+        !has_call(&relations, use_one, run_two),
+        "receiver-scoped one-arg call must bind Widget::run(int), not the 2-arg overload"
+    );
+    assert!(has_call(&relations, use_two, run_two));
+    assert!(
+        !has_call(&relations, use_two, run_one),
+        "receiver-scoped two-arg call must bind Widget::run(int, int), not the 1-arg overload"
+    );
+}
+
+#[test]
+fn no_compatible_overload_keeps_the_existing_fan_out() {
+    // Fail-open guard: when the call's argument count matches NO overload's known
+    // arity, arity pruning must not erase the edge. The call keeps the existing
+    // fan-out to every same-named overload rather than dropping to a silent miss.
+    let files = vec![
+        parse_cpp(
+            "probe.hpp",
+            r#"
+namespace Diag {
+    void probe( int solo ) {}
+    void probe( int pair_a, int pair_b ) {}
+}
+"#,
+        ),
+        parse_cpp(
+            "trace.hpp",
+            r#"
+namespace Diag {
+    void trace() { Diag::probe( a, b, c ); }
+}
+"#,
+        ),
+    ];
+
+    let relations = link_both(&files);
+    let trace = entity_id(&files, "trace.hpp", "trace");
+    let probe_one = overload_id(&files, "probe.hpp", "probe", "solo");
+    let probe_two = overload_id(&files, "probe.hpp", "probe", "pair_b");
+
+    assert!(
+        has_call(&relations, trace, probe_one) && has_call(&relations, trace, probe_two),
+        "an all-incompatible arity read must keep the fan-out, not erase the edge"
+    );
+}
+
+#[test]
+fn arity_pruned_binding_is_deterministic() {
+    // Determinism: re-linking identical input yields an identical Calls edge set,
+    // and (via `link_both`) the batch and incremental linkers already agree. The
+    // prune is a set operation and emission stays ordered by content-derived
+    // EntityId, so no HashMap iteration order can leak into the result.
+    let build = || {
+        vec![
+            parse_cpp(
+                "over.hpp",
+                r#"
+namespace N {
+    int dispatch( int solo ) { return 0; }
+    int dispatch( int pair_a, int pair_b ) { return 1; }
+    int dispatch( int trio_a, int trio_b, int trio_c ) { return 2; }
+}
+"#,
+            ),
+            parse_cpp(
+                "call.hpp",
+                r#"
+namespace N {
+    int go() { return N::dispatch( a, b ); }
+}
+"#,
+            ),
+        ]
+    };
+
+    let first = call_edges(&link_both(&build()));
+    let second = call_edges(&link_both(&build()));
+    assert_eq!(
+        first, second,
+        "arity-pruned overload binding must be byte-stable across runs"
+    );
+    let go = entity_id(&build(), "call.hpp", "go");
+    let dispatch_two = overload_id(&build(), "over.hpp", "dispatch", "pair_b");
+    assert!(
+        first.contains(&(go, dispatch_two)),
+        "the two-argument call binds the two-argument dispatch overload"
+    );
+}
+
+#[test]
+fn pack_expansion_call_is_arity_unknown_and_keeps_all_overloads() {
+    // A variadic forwarder spreads a pack (`dispatch(args...)`): the call shape
+    // is splat-widened, so its positional count is a lower bound and pins no
+    // arity. The call must stay bound to every overload (arity-unknown → prune
+    // nothing), not be narrowed to the literal expanded count.
+    let files = vec![
+        parse_cpp(
+            "over.hpp",
+            r#"
+namespace N {
+    int dispatch( int solo ) { return 0; }
+    int dispatch( int pair_a, int pair_b ) { return 1; }
+}
+"#,
+        ),
+        parse_cpp(
+            "fwd.hpp",
+            r#"
+namespace N {
+    template<typename... A>
+    int forward_all( A... args ) { return N::dispatch( args... ); }
+}
+"#,
+        ),
+    ];
+
+    let relations = link_both(&files);
+    let forward_all = entity_id(&files, "fwd.hpp", "forward_all");
+    let dispatch_one = overload_id(&files, "over.hpp", "dispatch", "solo");
+    let dispatch_two = overload_id(&files, "over.hpp", "dispatch", "pair_b");
+
+    assert!(
+        has_call(&relations, forward_all, dispatch_one)
+            && has_call(&relations, forward_all, dispatch_two),
+        "a pack-expansion call is arity-unknown and must keep every overload"
+    );
+}

--- a/crates/kin-index/tests/language_matrix_linker.rs
+++ b/crates/kin-index/tests/language_matrix_linker.rs
@@ -82,6 +82,7 @@ fn method(name: &str, file_path: &str) -> Entity {
 
 fn calls_relation(src: &str, dst: &str) -> ExtractedRelation {
     ExtractedRelation {
+        call_shape: None,
         kind: RelationKind::Calls,
         src_name: src.to_string(),
         dst_name: dst.to_string(),

--- a/crates/kin-parser/src/extract.rs
+++ b/crates/kin-parser/src/extract.rs
@@ -129,6 +129,25 @@ fn take_char_range(text: &str, start: usize, end: usize) -> String {
         .collect()
 }
 
+/// The argument shape written at a call site, letting the linker bind an
+/// overloaded callee by how it is called. Shared across language adapters: C++
+/// records positional arity; Python-style adapters additionally record keyword
+/// and splat shape. This is the canonical type for the parser -> linker seam; a
+/// mirror is materialized at the storage boundary when a call edge is persisted.
+#[derive(Debug, Clone, PartialEq, Eq, Default)]
+pub struct CallArgShape {
+    /// Positional arguments at the call site (`f(a, b)` -> 2).
+    pub positional: u32,
+    /// Named-argument names used at the call site, sorted and deduped at
+    /// construction. Always empty for C++ (no keyword arguments).
+    pub keywords: Vec<String>,
+    /// A positional pack/splat expansion is present (C++ `args...`, Python
+    /// `*args`), so the positional count is a lower bound, not exact.
+    pub has_var_positional: bool,
+    /// A keyword splat is present (Python `**kwargs`); always false for C++.
+    pub has_var_keyword: bool,
+}
+
 /// Raw extracted relation between two named entities.
 #[derive(Debug, Clone)]
 pub struct ExtractedRelation {
@@ -139,6 +158,12 @@ pub struct ExtractedRelation {
     /// e.g., `Some("requests")` for `from requests import get`,
     ///        `Some("kin_db")` for `use kin_db::InMemoryGraph`
     pub import_source: Option<String>,
+    /// For a `Calls` edge, the call site's argument shape when the adapter
+    /// records it. `None` means the adapter does not track it, so the linker
+    /// binds shape-blind as before. Lets the linker keep an overloaded callee's
+    /// argument-incompatible candidates out of the call's binding set instead of
+    /// fanning out to every same-named overload.
+    pub call_shape: Option<CallArgShape>,
 }
 
 /// A single import declaration from source code.

--- a/crates/kin-parser/src/languages/c_lang.rs
+++ b/crates/kin-parser/src/languages/c_lang.rs
@@ -536,6 +536,7 @@ fn extract_calls_from_body(
                 let callee = function.utf8_text(source).unwrap_or("").to_string();
                 if is_valid_callee(&callee) {
                     relations.push(ExtractedRelation {
+                        call_shape: None,
                         kind: kin_model::RelationKind::Calls,
                         src_name: context_name.to_string(),
                         dst_name: callee,
@@ -989,6 +990,7 @@ fn extract_includes_and_macros_recursive(
                 if let Some(src_name) = find_enclosing_entity(node, source) {
                     if src_name != name && !src_name.ends_with(&format!("::{}", name)) {
                         relations.push(crate::extract::ExtractedRelation {
+                            call_shape: None,
                             kind: kin_model::RelationKind::UsesMacro,
                             src_name,
                             dst_name: name.to_string(),

--- a/crates/kin-parser/src/languages/cpp_lang.rs
+++ b/crates/kin-parser/src/languages/cpp_lang.rs
@@ -9,8 +9,8 @@ use crate::adapter::{
 };
 use crate::error::Result;
 use crate::extract::{
-    ExtractedEntity, ExtractedRelation, ExtractedTest, ExtractedTestKind, FileImport, ImportedName,
-    ParseOutput,
+    CallArgShape, ExtractedEntity, ExtractedRelation, ExtractedTest, ExtractedTestKind, FileImport,
+    ImportedName, ParseOutput,
 };
 
 pub struct CppAdapter;
@@ -144,6 +144,7 @@ fn extract_cpp_node(
 
                 if let Some(cls) = class_ctx {
                     relations.push(ExtractedRelation {
+                        call_shape: None,
                         kind: kin_model::RelationKind::Contains,
                         src_name: cls.to_string(),
                         dst_name: qualified.clone(),
@@ -171,6 +172,7 @@ fn extract_cpp_node(
                         span: span_from_node(node, file_id),
                     });
                     relations.push(ExtractedRelation {
+                        call_shape: None,
                         kind: kin_model::RelationKind::Contains,
                         src_name: cls.to_string(),
                         dst_name: qualified,
@@ -287,6 +289,7 @@ fn extract_cpp_node(
                     .unwrap_or_else(|| alias_name.clone());
                 for referenced_type in referenced_types {
                     relations.push(ExtractedRelation {
+                        call_shape: None,
                         kind: kin_model::RelationKind::References,
                         src_name: src_name.clone(),
                         dst_name: referenced_type,
@@ -369,6 +372,7 @@ fn extract_cpp_node(
                                 && seen.insert(token.to_string())
                             {
                                 relations.push(ExtractedRelation {
+                                    call_shape: None,
                                     kind: kin_model::RelationKind::UsesMacro,
                                     src_name: name.clone(),
                                     dst_name: token.to_string(),
@@ -470,6 +474,7 @@ fn extract_base_classes(
                 let base_name = child.utf8_text(source).unwrap_or("").to_string();
                 if !base_name.is_empty() {
                     relations.push(ExtractedRelation {
+                        call_shape: None,
                         kind: kin_model::RelationKind::Extends,
                         src_name: class_name.to_string(),
                         dst_name: base_name,
@@ -902,12 +907,56 @@ fn collect_scoped_calls(
                         src_name: context_name.to_string(),
                         dst_name,
                         import_source: None,
+                        call_shape: cpp_call_shape(&child, source),
                     });
                 }
             }
         }
         collect_scoped_calls(&child, source, context_name, scope, relations);
     }
+}
+
+/// The [`CallArgShape`] of a C++ `call_expression`. tree-sitter groups a call's
+/// arguments into an `argument_list` whose named children are the argument
+/// expressions, so the positional count is nesting-correct: `f(g(x), y)` is 2,
+/// `f(Ptr<A, B>{})` is 1 (the template comma is inside one argument), `f()` is
+/// 0. Interspersed comments are skipped. C++ has no keyword arguments, so
+/// `keywords` is empty and `has_var_keyword` is always false; a pack expansion
+/// (`args...`) sets `has_var_positional` so the linker treats the count as a
+/// lower bound and prunes nothing. `None` when the call carries no argument
+/// list, leaving the linker to bind that call shape-blind.
+fn cpp_call_shape(call_expr: &tree_sitter::Node, source: &[u8]) -> Option<CallArgShape> {
+    let arguments = call_expr.child_by_field_name("arguments")?;
+    let mut cursor = arguments.walk();
+    let mut positional: u32 = 0;
+    let mut has_var_positional = false;
+    for arg in arguments.named_children(&mut cursor) {
+        if arg.kind() == "comment" {
+            continue;
+        }
+        positional += 1;
+        if argument_is_pack_expansion(&arg, source) {
+            has_var_positional = true;
+        }
+    }
+    Some(CallArgShape {
+        positional,
+        keywords: Vec::new(),
+        has_var_positional,
+        has_var_keyword: false,
+    })
+}
+
+/// Whether a call argument is a pack/splat expansion (`args...`,
+/// `std::forward<T>(args)...`). tree-sitter can model the trailing `...` as its
+/// own token rather than part of the argument node, so this keys on the
+/// argument's text ending in `...` — the reliable surface signal, and
+/// conservative: a missed pack only forgoes an optimization, a spurious hit only
+/// widens the accepted arity, and neither drops a real edge.
+fn argument_is_pack_expansion(arg: &tree_sitter::Node, source: &[u8]) -> bool {
+    arg.utf8_text(source)
+        .map(|text| text.trim_end().ends_with("..."))
+        .unwrap_or(false)
 }
 
 /// Resolve a `field_expression` receiver to a class name: `this` binds to the
@@ -1128,6 +1177,7 @@ fn extract_includes_and_macros_recursive(
                 if let Some(src_name) = find_enclosing_entity(node, source) {
                     if src_name != name && !src_name.ends_with(&format!("::{}", name)) {
                         relations.push(ExtractedRelation {
+                            call_shape: None,
                             kind: kin_model::RelationKind::UsesMacro,
                             src_name,
                             dst_name: name.to_string(),

--- a/crates/kin-parser/src/languages/go.rs
+++ b/crates/kin-parser/src/languages/go.rs
@@ -112,6 +112,7 @@ impl LanguageAdapter for GoAdapter {
                     .all(|m| type_method_names.contains(m))
                 {
                     relations.push(ExtractedRelation {
+                        call_shape: None,
                         kind: kin_model::RelationKind::Implements,
                         src_name: type_name.clone(),
                         dst_name: iface_name.clone(),
@@ -489,6 +490,7 @@ fn extract_go_node(
                 // Emit Contains relation from receiver type to method
                 if !receiver_type.is_empty() {
                     relations.push(ExtractedRelation {
+                        call_shape: None,
                         kind: kin_model::RelationKind::Contains,
                         src_name: receiver_type.clone(),
                         dst_name: qualified.clone(),
@@ -543,6 +545,7 @@ fn extract_go_node(
                                         span: member.span.clone(),
                                     });
                                     relations.push(ExtractedRelation {
+                                        call_shape: None,
                                         kind: kin_model::RelationKind::Contains,
                                         src_name: name.clone(),
                                         dst_name: qualified,
@@ -551,6 +554,7 @@ fn extract_go_node(
                                 }
                                 for embedded in &members.embedded {
                                     relations.push(ExtractedRelation {
+                                        call_shape: None,
                                         kind: kin_model::RelationKind::Extends,
                                         src_name: name.clone(),
                                         dst_name: embedded.clone(),
@@ -578,6 +582,7 @@ fn extract_go_node(
                             if let Some(ref struct_node) = type_node {
                                 for embedded in extract_embedded_types(struct_node, source) {
                                     relations.push(ExtractedRelation {
+                                        call_shape: None,
                                         kind: kin_model::RelationKind::Extends,
                                         src_name: name.clone(),
                                         dst_name: embedded,
@@ -955,6 +960,7 @@ fn extract_calls_from_body(
                 if is_valid_callee_name(&callee) {
                     let idx = relations.len();
                     relations.push(ExtractedRelation {
+                        call_shape: None,
                         kind: kin_model::RelationKind::Calls,
                         src_name: context_name.to_string(),
                         dst_name: callee,
@@ -971,6 +977,7 @@ fn extract_calls_from_body(
                 let channel_name = channel.utf8_text(source).unwrap_or("").to_string();
                 if !channel_name.is_empty() {
                     relations.push(ExtractedRelation {
+                        call_shape: None,
                         kind: kin_model::RelationKind::SendsMessage,
                         src_name: context_name.to_string(),
                         dst_name: channel_name,
@@ -987,6 +994,7 @@ fn extract_calls_from_body(
                         let spawned = function.utf8_text(source).unwrap_or("").to_string();
                         if !spawned.is_empty() {
                             relations.push(ExtractedRelation {
+                                call_shape: None,
                                 kind: kin_model::RelationKind::Spawns,
                                 src_name: context_name.to_string(),
                                 dst_name: spawned,
@@ -1025,6 +1033,7 @@ fn emit_value_references(
     for name in names {
         if name != context_name && ref_seen.insert(name.clone()) {
             relations.push(ExtractedRelation {
+                call_shape: None,
                 kind: kin_model::RelationKind::References,
                 src_name: context_name.to_string(),
                 dst_name: name,

--- a/crates/kin-parser/src/languages/hcl.rs
+++ b/crates/kin-parser/src/languages/hcl.rs
@@ -210,6 +210,7 @@ fn extract_hcl_block(
                         }],
                     });
                     relations.push(ExtractedRelation {
+                        call_shape: None,
                         kind: RelationKind::Imports,
                         src_name: format!("module.{}", mod_name),
                         dst_name: source_val,
@@ -321,6 +322,7 @@ fn extract_required_providers(
                     let source_val = extract_object_attr(&child, source, "source")
                         .unwrap_or_else(|| format!("hashicorp/{}", provider_name));
                     relations.push(ExtractedRelation {
+                        call_shape: None,
                         kind: RelationKind::References,
                         src_name: "terraform".to_string(),
                         dst_name: source_val,

--- a/crates/kin-parser/src/languages/java.rs
+++ b/crates/kin-parser/src/languages/java.rs
@@ -121,6 +121,7 @@ fn extract_java_node(
                     let parent_name = sc.utf8_text(source).unwrap_or("").to_string();
                     if !parent_name.is_empty() {
                         relations.push(ExtractedRelation {
+                            call_shape: None,
                             kind: kin_model::RelationKind::Extends,
                             src_name: name.clone(),
                             dst_name: parent_name,
@@ -137,6 +138,7 @@ fn extract_java_node(
                             let iface_name = iface.utf8_text(source).unwrap_or("").to_string();
                             if !iface_name.is_empty() {
                                 relations.push(ExtractedRelation {
+                                    call_shape: None,
                                     kind: kin_model::RelationKind::Implements,
                                     src_name: name.clone(),
                                     dst_name: iface_name,
@@ -187,6 +189,7 @@ fn extract_java_node(
                             let iface_name = iface.utf8_text(source).unwrap_or("").to_string();
                             if !iface_name.is_empty() {
                                 relations.push(ExtractedRelation {
+                                    call_shape: None,
                                     kind: kin_model::RelationKind::Implements,
                                     src_name: name.clone(),
                                     dst_name: iface_name,
@@ -279,6 +282,7 @@ fn extract_java_node(
                                     span: span_from_node(&member, file_id),
                                 });
                                 relations.push(ExtractedRelation {
+                                    call_shape: None,
                                     kind: kin_model::RelationKind::Contains,
                                     src_name: name.clone(),
                                     dst_name: qualified,
@@ -309,6 +313,7 @@ fn extract_java_node(
                 });
                 if let Some(cls) = class_ctx {
                     relations.push(ExtractedRelation {
+                        call_shape: None,
                         kind: kin_model::RelationKind::Contains,
                         src_name: cls.to_string(),
                         dst_name: qualified.clone(),
@@ -429,6 +434,7 @@ fn extract_calls_from_body(
                 let method_name = name_node.utf8_text(source).unwrap_or("");
                 if !method_name.is_empty() {
                     relations.push(ExtractedRelation {
+                        call_shape: None,
                         kind: kin_model::RelationKind::Calls,
                         src_name: context_name.to_string(),
                         dst_name: method_name.to_string(),

--- a/crates/kin-parser/src/languages/javascript.rs
+++ b/crates/kin-parser/src/languages/javascript.rs
@@ -164,6 +164,7 @@ fn extract_js_node(
                                         hchild.utf8_text(source).unwrap_or("").to_string();
                                     if !parent_name.is_empty() {
                                         relations.push(ExtractedRelation {
+                                            call_shape: None,
                                             kind: kin_model::RelationKind::Extends,
                                             src_name: name.clone(),
                                             dst_name: parent_name,
@@ -196,6 +197,7 @@ fn extract_js_node(
                                     span: span_from_node(&member, file_id),
                                 });
                                 relations.push(ExtractedRelation {
+                                    call_shape: None,
                                     kind: kin_model::RelationKind::Contains,
                                     src_name: name.clone(),
                                     dst_name: qualified.clone(),
@@ -576,6 +578,7 @@ fn extract_calls_from_context(
                 };
                 if is_valid_callee_name(&callee_name) {
                     relations.push(ExtractedRelation {
+                        call_shape: None,
                         kind: kin_model::RelationKind::Calls,
                         src_name: context_name.to_string(),
                         dst_name: callee_name,

--- a/crates/kin-parser/src/languages/kotlin.rs
+++ b/crates/kin-parser/src/languages/kotlin.rs
@@ -172,6 +172,7 @@ fn extract_kotlin_node(
                                             span: span_from_node(&member, file_id),
                                         });
                                         relations.push(ExtractedRelation {
+                                            call_shape: None,
                                             kind: kin_model::RelationKind::Contains,
                                             src_name: name.clone(),
                                             dst_name: qualified,
@@ -283,6 +284,7 @@ fn extract_kotlin_node(
 
                 if let Some(cls) = class_ctx {
                     relations.push(ExtractedRelation {
+                        call_shape: None,
                         kind: kin_model::RelationKind::Contains,
                         src_name: cls.to_string(),
                         dst_name: qualified.clone(),
@@ -306,6 +308,7 @@ fn extract_kotlin_node(
                     span: span_from_node(node, file_id),
                 });
                 relations.push(ExtractedRelation {
+                    call_shape: None,
                     kind: kin_model::RelationKind::Contains,
                     src_name: cls.to_string(),
                     dst_name: ctor_name.clone(),
@@ -347,6 +350,7 @@ fn extract_kotlin_node(
 
                 if let Some(cls) = class_ctx {
                     relations.push(ExtractedRelation {
+                        call_shape: None,
                         kind: kin_model::RelationKind::Contains,
                         src_name: cls.to_string(),
                         dst_name: qualified,
@@ -570,6 +574,7 @@ fn extract_delegation_specifier(
             "constructor_invocation" => {
                 if let Some(parent_name) = extract_user_type_name(&child, source) {
                     relations.push(ExtractedRelation {
+                        call_shape: None,
                         kind: kin_model::RelationKind::Extends,
                         src_name: type_name.to_string(),
                         dst_name: parent_name,
@@ -587,6 +592,7 @@ fn extract_delegation_specifier(
                         kin_model::RelationKind::Implements
                     };
                     relations.push(ExtractedRelation {
+                        call_shape: None,
                         kind: rel_kind,
                         src_name: type_name.to_string(),
                         dst_name: parent_name,
@@ -622,6 +628,7 @@ fn extract_calls_from_body(
             if let Some(callee) = extract_callee_name(&child, source) {
                 if !callee.is_empty() {
                     relations.push(ExtractedRelation {
+                        call_shape: None,
                         kind: kin_model::RelationKind::Calls,
                         src_name: context_name.to_string(),
                         dst_name: callee,

--- a/crates/kin-parser/src/languages/php.rs
+++ b/crates/kin-parser/src/languages/php.rs
@@ -158,6 +158,7 @@ fn extract_php_node(
                     });
                     if let Some(cls) = class_ctx {
                         relations.push(ExtractedRelation {
+                            call_shape: None,
                             kind: kin_model::RelationKind::Contains,
                             src_name: cls.to_string(),
                             dst_name: qualified.clone(),
@@ -196,6 +197,7 @@ fn extract_php_node(
                             .to_string();
                         if !base_name.is_empty() {
                             relations.push(ExtractedRelation {
+                                call_shape: None,
                                 kind: kin_model::RelationKind::Extends,
                                 src_name: name.clone(),
                                 dst_name: base_name,
@@ -353,6 +355,7 @@ fn extract_php_implements(
                     let iface_name = iface.utf8_text(source).unwrap_or("").to_string();
                     if !iface_name.is_empty() {
                         relations.push(ExtractedRelation {
+                            call_shape: None,
                             kind: kin_model::RelationKind::Implements,
                             src_name: class_name.to_string(),
                             dst_name: iface_name,
@@ -426,6 +429,7 @@ fn extract_calls_from_body(
                 let callee = name_node.utf8_text(source).unwrap_or("").to_string();
                 if !callee.is_empty() {
                     relations.push(ExtractedRelation {
+                        call_shape: None,
                         kind: kin_model::RelationKind::Calls,
                         src_name: context_name.to_string(),
                         dst_name: callee,
@@ -439,6 +443,7 @@ fn extract_calls_from_body(
                     let callee = func_node.utf8_text(source).unwrap_or("").to_string();
                     if !callee.is_empty() && !callee.starts_with('"') && !callee.starts_with('\'') {
                         relations.push(ExtractedRelation {
+                            call_shape: None,
                             kind: kin_model::RelationKind::Calls,
                             src_name: context_name.to_string(),
                             dst_name: callee,

--- a/crates/kin-parser/src/languages/python.rs
+++ b/crates/kin-parser/src/languages/python.rs
@@ -187,6 +187,7 @@ fn extract_py_node(
                 extract_calls_from_context(node, source, &name, class_ctx, relations);
                 if let Some(cls) = class_ctx {
                     relations.push(ExtractedRelation {
+                        call_shape: None,
                         kind: kin_model::RelationKind::Contains,
                         src_name: cls.to_string(),
                         dst_name: name,
@@ -236,6 +237,7 @@ fn extract_py_node(
                                     is_enum = true;
                                 }
                                 relations.push(ExtractedRelation {
+                                    call_shape: None,
                                     kind: kin_model::RelationKind::Extends,
                                     src_name: name.clone(),
                                     dst_name: base,
@@ -284,6 +286,7 @@ fn extract_py_node(
                             for dec in &decorators {
                                 if is_valid_callee_name(dec) {
                                     relations.push(ExtractedRelation {
+                                        call_shape: None,
                                         kind: kin_model::RelationKind::Calls,
                                         src_name: src_name.clone(),
                                         dst_name: dec.clone(),
@@ -497,6 +500,7 @@ fn extract_calls_from_context(
                 };
                 if is_valid_callee_name(&callee_name) {
                     relations.push(ExtractedRelation {
+                        call_shape: None,
                         kind: kin_model::RelationKind::Calls,
                         src_name: context_name.to_string(),
                         dst_name: callee_name,

--- a/crates/kin-parser/src/languages/rust_lang.rs
+++ b/crates/kin-parser/src/languages/rust_lang.rs
@@ -161,6 +161,7 @@ fn extract_rust_node(
                 // Emit Implements relations for #[derive(...)] traits.
                 for trait_name in extract_derive_traits(node, source) {
                     relations.push(ExtractedRelation {
+                        call_shape: None,
                         kind: kin_model::RelationKind::Implements,
                         src_name: name.clone(),
                         dst_name: trait_name,
@@ -185,6 +186,7 @@ fn extract_rust_node(
                 // Emit Implements relations for #[derive(...)] traits.
                 for trait_name in extract_derive_traits(node, source) {
                     relations.push(ExtractedRelation {
+                        call_shape: None,
                         kind: kin_model::RelationKind::Implements,
                         src_name: enum_name.clone(),
                         dst_name: trait_name,
@@ -211,6 +213,7 @@ fn extract_rust_node(
                                     span: span_from_node(&variant, file_id),
                                 });
                                 relations.push(ExtractedRelation {
+                                    call_shape: None,
                                     kind: kin_model::RelationKind::Contains,
                                     src_name: enum_name.clone(),
                                     dst_name: qualified,
@@ -293,6 +296,7 @@ fn extract_rust_node(
             if let Some(ref trait_n) = trait_name {
                 if !trait_n.is_empty() && !type_name.is_empty() {
                     relations.push(ExtractedRelation {
+                        call_shape: None,
                         kind: kin_model::RelationKind::Implements,
                         src_name: type_name.clone(),
                         dst_name: trait_n.clone(),
@@ -324,6 +328,7 @@ fn extract_rust_node(
                             extract_calls_from_context(&member, source, &qualified, relations);
                             if !type_name.is_empty() {
                                 relations.push(ExtractedRelation {
+                                    call_shape: None,
                                     kind: kin_model::RelationKind::Contains,
                                     src_name: type_name.clone(),
                                     dst_name: qualified,
@@ -533,6 +538,7 @@ fn extract_calls_from_context(
                 };
                 if is_valid_callee_name(&callee_name) {
                     relations.push(ExtractedRelation {
+                        call_shape: None,
                         kind: kin_model::RelationKind::Calls,
                         src_name: context_name.to_string(),
                         dst_name: callee_name,
@@ -620,6 +626,7 @@ fn extract_calls_from_token_tree(
         }
         if is_valid_callee_name(&callee_name) {
             relations.push(ExtractedRelation {
+                call_shape: None,
                 kind: kin_model::RelationKind::Calls,
                 src_name: context_name.to_string(),
                 dst_name: callee_name,

--- a/crates/kin-parser/src/languages/shallow_backed.rs
+++ b/crates/kin-parser/src/languages/shallow_backed.rs
@@ -147,6 +147,7 @@ fn extract_csharp_node(
                 });
                 if let Some(parent) = namespace_ctx {
                     relations.push(ExtractedRelation {
+                        call_shape: None,
                         kind: kin_model::RelationKind::Contains,
                         src_name: parent.to_string(),
                         dst_name: full_name.clone(),
@@ -196,6 +197,7 @@ fn extract_csharp_node(
                 });
                 if let Some(parent) = namespace_ctx.or(type_ctx) {
                     relations.push(ExtractedRelation {
+                        call_shape: None,
                         kind: kin_model::RelationKind::Contains,
                         src_name: parent.to_string(),
                         dst_name: full_name.clone(),
@@ -211,6 +213,7 @@ fn extract_csharp_node(
                 ) {
                     for base in extract_csharp_base_types(node, source) {
                         relations.push(ExtractedRelation {
+                            call_shape: None,
                             kind: kin_model::RelationKind::Extends,
                             src_name: full_name.clone(),
                             dst_name: base,
@@ -250,6 +253,7 @@ fn extract_csharp_node(
                         span: span_from_node(node, file_id),
                     });
                     relations.push(ExtractedRelation {
+                        call_shape: None,
                         kind: kin_model::RelationKind::Contains,
                         src_name: owner.to_string(),
                         dst_name: full_name.clone(),
@@ -273,6 +277,7 @@ fn extract_csharp_node(
                         span: span_from_node(node, file_id),
                     });
                     relations.push(ExtractedRelation {
+                        call_shape: None,
                         kind: kin_model::RelationKind::Contains,
                         src_name: owner.to_string(),
                         dst_name: full_name,
@@ -295,6 +300,7 @@ fn extract_csharp_node(
                         span: span_from_node(node, file_id),
                     });
                     relations.push(ExtractedRelation {
+                        call_shape: None,
                         kind: kin_model::RelationKind::Contains,
                         src_name: owner.to_string(),
                         dst_name: full_name,
@@ -317,6 +323,7 @@ fn extract_csharp_node(
                         span: span_from_node(node, file_id),
                     });
                     relations.push(ExtractedRelation {
+                        call_shape: None,
                         kind: kin_model::RelationKind::Contains,
                         src_name: owner.to_string(),
                         dst_name: full_name,
@@ -424,6 +431,7 @@ fn extract_csharp_calls(
                 };
                 if !callee.is_empty() {
                     relations.push(ExtractedRelation {
+                        call_shape: None,
                         kind: kin_model::RelationKind::Calls,
                         src_name: context_name.to_string(),
                         dst_name: callee,
@@ -436,6 +444,7 @@ fn extract_csharp_calls(
                 let target = normalize_scoped_name(text_of(&ty, source).trim());
                 if !target.is_empty() {
                     relations.push(ExtractedRelation {
+                        call_shape: None,
                         kind: kin_model::RelationKind::References,
                         src_name: context_name.to_string(),
                         dst_name: target,
@@ -551,6 +560,7 @@ fn extract_ruby_node(
                 });
                 if let Some(parent) = container_ctx {
                     relations.push(ExtractedRelation {
+                        call_shape: None,
                         kind: kin_model::RelationKind::Contains,
                         src_name: parent.to_string(),
                         dst_name: full_name.clone(),
@@ -562,6 +572,7 @@ fn extract_ruby_node(
                         let base_name = normalize_ruby_name(text_of(&superclass, source).trim());
                         if !base_name.is_empty() {
                             relations.push(ExtractedRelation {
+                                call_shape: None,
                                 kind: kin_model::RelationKind::Extends,
                                 src_name: full_name.clone(),
                                 dst_name: base_name,
@@ -615,6 +626,7 @@ fn extract_ruby_node(
                 });
                 if let Some(owner_name) = owner {
                     relations.push(ExtractedRelation {
+                        call_shape: None,
                         kind: kin_model::RelationKind::Contains,
                         src_name: owner_name,
                         dst_name: full_name.clone(),
@@ -652,6 +664,7 @@ fn extract_ruby_node(
                     });
                     if let Some(owner) = container_ctx {
                         relations.push(ExtractedRelation {
+                            call_shape: None,
                             kind: kin_model::RelationKind::Contains,
                             src_name: owner.to_string(),
                             dst_name: full_name,
@@ -676,6 +689,7 @@ fn extract_ruby_node(
                     if let Some(target) = extract_ruby_first_argument(node, source) {
                         if let Some(owner) = container_ctx {
                             relations.push(ExtractedRelation {
+                                call_shape: None,
                                 kind: kin_model::RelationKind::References,
                                 src_name: owner.to_string(),
                                 dst_name: normalize_ruby_name(target.trim()),
@@ -685,6 +699,7 @@ fn extract_ruby_node(
                     }
                 } else if let Some(current_callable) = callable_ctx {
                     relations.push(ExtractedRelation {
+                        call_shape: None,
                         kind: kin_model::RelationKind::Calls,
                         src_name: current_callable.to_string(),
                         dst_name: normalize_ruby_name(&method_name),

--- a/crates/kin-parser/src/languages/swift.rs
+++ b/crates/kin-parser/src/languages/swift.rs
@@ -256,6 +256,7 @@ fn extract_swift_node(
 
                 if let Some(cls) = class_ctx {
                     relations.push(ExtractedRelation {
+                        call_shape: None,
                         kind: kin_model::RelationKind::Contains,
                         src_name: cls.to_string(),
                         dst_name: qualified.clone(),
@@ -285,6 +286,7 @@ fn extract_swift_node(
 
             if let Some(cls) = class_ctx {
                 relations.push(ExtractedRelation {
+                    call_shape: None,
                     kind: kin_model::RelationKind::Contains,
                     src_name: cls.to_string(),
                     dst_name: init_name.clone(),
@@ -308,6 +310,7 @@ fn extract_swift_node(
                 });
 
                 relations.push(ExtractedRelation {
+                    call_shape: None,
                     kind: kin_model::RelationKind::Contains,
                     src_name: cls.to_string(),
                     dst_name: deinit_name,
@@ -347,6 +350,7 @@ fn extract_swift_node(
 
                 if let Some(cls) = class_ctx {
                     relations.push(ExtractedRelation {
+                        call_shape: None,
                         kind: kin_model::RelationKind::Contains,
                         src_name: cls.to_string(),
                         dst_name: qualified,
@@ -393,6 +397,7 @@ fn extract_swift_node(
 
                     if let Some(cls) = class_ctx {
                         relations.push(ExtractedRelation {
+                            call_shape: None,
                             kind: kin_model::RelationKind::Contains,
                             src_name: cls.to_string(),
                             dst_name: qualified,
@@ -502,6 +507,7 @@ fn extract_type_names_from_inheritance(
                 // we emit Implements (protocol conformance) for all, which is the
                 // safer assumption.
                 relations.push(ExtractedRelation {
+                    call_shape: None,
                     kind: kin_model::RelationKind::Implements,
                     src_name: type_name.to_string(),
                     dst_name: parent_name,
@@ -589,6 +595,7 @@ fn extract_calls_from_body(
             if let Some(callee) = extract_callee_name(&child, source) {
                 if !callee.is_empty() {
                     relations.push(ExtractedRelation {
+                        call_shape: None,
                         kind: kin_model::RelationKind::Calls,
                         src_name: context_name.to_string(),
                         dst_name: callee,

--- a/crates/kin-parser/src/languages/typescript.rs
+++ b/crates/kin-parser/src/languages/typescript.rs
@@ -227,6 +227,7 @@ fn extract_ts_node(
                                     span: span_from_node(&member, file_id),
                                 });
                                 relations.push(ExtractedRelation {
+                                    call_shape: None,
                                     kind: kin_model::RelationKind::Contains,
                                     src_name: name.clone(),
                                     dst_name: qualified,
@@ -358,6 +359,7 @@ fn extract_ts_class_member(
                     span: span_from_node(node, file_id),
                 });
                 relations.push(ExtractedRelation {
+                    call_shape: None,
                     kind: kin_model::RelationKind::Contains,
                     src_name: class_name.to_string(),
                     dst_name: qualified.clone(),
@@ -523,6 +525,7 @@ fn extract_ts_heritage(
                             let parent = value.utf8_text(source).unwrap_or("").to_string();
                             if !parent.is_empty() {
                                 relations.push(ExtractedRelation {
+                                    call_shape: None,
                                     kind: kin_model::RelationKind::Extends,
                                     src_name: class_name.to_string(),
                                     dst_name: parent,
@@ -538,6 +541,7 @@ fn extract_ts_heritage(
                                 let iface_name = iface.utf8_text(source).unwrap_or("").to_string();
                                 if !iface_name.is_empty() {
                                     relations.push(ExtractedRelation {
+                                        call_shape: None,
                                         kind: kin_model::RelationKind::Implements,
                                         src_name: class_name.to_string(),
                                         dst_name: iface_name,
@@ -631,6 +635,7 @@ fn extract_calls_from_context(
                 };
                 if is_valid_callee_name(&callee_name) {
                     relations.push(ExtractedRelation {
+                        call_shape: None,
                         kind: kin_model::RelationKind::Calls,
                         src_name: context_name.to_string(),
                         dst_name: callee_name,

--- a/crates/kin-parser/src/lib.rs
+++ b/crates/kin-parser/src/lib.rs
@@ -40,7 +40,7 @@ pub mod todos;
 pub use adapter::{EditHint, LanguageAdapter};
 pub use error::{ParseError, Result};
 pub use extract::{
-    attach_file_context_metadata, ExtractedEntity, ExtractedRelation, ExtractedTest,
+    attach_file_context_metadata, CallArgShape, ExtractedEntity, ExtractedRelation, ExtractedTest,
     ExtractedTestKind, FileImport, ImportedName, ParseOutput, COMMAND_EFFECT_CONTRACT_KEY,
     FILE_IMPORT_CONTEXT_KEY, FILE_SURFACE_CONTEXT_KEY,
 };

--- a/crates/kin-parser/tests/cpp_call_resolution.rs
+++ b/crates/kin-parser/tests/cpp_call_resolution.rs
@@ -11,7 +11,7 @@
 //! names no name index could match.
 
 use kin_model::{FilePathId, RelationKind};
-use kin_parser::{CppAdapter, ExtractedRelation, LanguageAdapter};
+use kin_parser::{CallArgShape, CppAdapter, ExtractedRelation, LanguageAdapter};
 
 fn parse_and_extract(source: &str) -> Vec<ExtractedRelation> {
     let adapter = CppAdapter;
@@ -247,4 +247,87 @@ namespace Catch {
         calls.contains(&"Catch::helper"),
         "explicit `Catch::helper()` must keep its qualified callee, got: {calls:?}"
     );
+}
+
+/// The call shape of the one call named `name`; panics if the callee was emitted
+/// zero or multiple times so a test never reads a stale duplicate.
+fn call_shape_of<'a>(rels: &'a [ExtractedRelation], name: &str) -> &'a CallArgShape {
+    let matches = calls_named(rels, name);
+    assert_eq!(
+        matches.len(),
+        1,
+        "expected exactly one `{name}` call, got {}",
+        matches.len()
+    );
+    matches[0]
+        .call_shape
+        .as_ref()
+        .unwrap_or_else(|| panic!("`{name}` call recorded no call shape"))
+}
+
+fn call_arg_count(rels: &[ExtractedRelation], name: &str) -> u32 {
+    call_shape_of(rels, name).positional
+}
+
+#[test]
+fn call_site_records_positional_argument_count() {
+    // The extractor must record each call's positional argument count so the
+    // linker can keep an overloaded callee's arity-incompatible overloads out of
+    // the binding set. Counts come from the argument list, so a nested call is
+    // counted by its own arguments, not folded into the outer call's.
+    let source = r#"
+void driver() {
+    two_args( a, b );
+    zero_args();
+    one_arg( x );
+    outer( inner( p ), q );
+}
+"#;
+    let rels = parse_and_extract(source);
+    assert_eq!(call_arg_count(&rels, "two_args"), 2);
+    assert_eq!(call_arg_count(&rels, "zero_args"), 0);
+    assert_eq!(call_arg_count(&rels, "one_arg"), 1);
+    // `outer(inner(p), q)`: two arguments to outer, one to the nested inner.
+    assert_eq!(call_arg_count(&rels, "outer"), 2);
+    assert_eq!(call_arg_count(&rels, "inner"), 1);
+    // No keyword args and no splats in plain C++ calls.
+    let two = call_shape_of(&rels, "two_args");
+    assert!(two.keywords.is_empty() && !two.has_var_positional && !two.has_var_keyword);
+}
+
+#[test]
+fn call_arg_count_is_not_inflated_by_callee_template_arguments() {
+    // A template-instantiated callee carries a comma-bearing `<...>` list. That
+    // list is part of the callee, not the call's arguments, so it must not lift
+    // the recorded argument count.
+    let source = r#"
+void driver() {
+    make< int, long >( only );
+}
+"#;
+    let rels = parse_and_extract(source);
+    assert_eq!(
+        call_arg_count(&rels, "make"),
+        1,
+        "callee template args (`<int, long>`) are not call arguments"
+    );
+}
+
+#[test]
+fn pack_expansion_argument_marks_shape_var_positional() {
+    // A forwarding call spreads a parameter pack (`args...`). The positional
+    // count is then a lower bound, so the shape must flag `has_var_positional`
+    // and the linker treats the call as arity-unknown (prunes no overload).
+    let source = r#"
+void driver() {
+    forward( first, rest... );
+}
+"#;
+    let rels = parse_and_extract(source);
+    let shape = call_shape_of(&rels, "forward");
+    assert!(
+        shape.has_var_positional,
+        "a `rest...` pack-expansion argument must set has_var_positional"
+    );
+    assert!(!shape.has_var_keyword, "C++ has no keyword splats");
 }

--- a/tests/integration/src/cross_file_relations.rs
+++ b/tests/integration/src/cross_file_relations.rs
@@ -138,6 +138,7 @@ fn link_cross_file_calls_after_indexing() {
                 .unresolved_relations
                 .iter()
                 .map(|u| ExtractedRelation {
+                    call_shape: None,
                     kind: u.kind,
                     src_name: main_idx
                         .entities
@@ -311,6 +312,7 @@ export function divide(a: number, b: number): number {
                 .unresolved_relations
                 .iter()
                 .map(|u| ExtractedRelation {
+                    call_shape: None,
                     kind: u.kind,
                     src_name: idx
                         .entities

--- a/tests/integration/src/p9_acceptance.rs
+++ b/tests/integration/src/p9_acceptance.rs
@@ -33,6 +33,7 @@ fn ts_import_creates_relation() {
             file_path: "src/api/route.ts".to_string(),
             entities: vec![post.clone()],
             relations: vec![ExtractedRelation {
+                call_shape: None,
                 kind: RelationKind::Imports,
                 src_name: "POST".to_string(),
                 dst_name: "helper".to_string(),
@@ -84,6 +85,7 @@ fn ts_call_creates_cross_file_relation() {
             file_path: "src/api/chat/route.ts".to_string(),
             entities: vec![post.clone()],
             relations: vec![ExtractedRelation {
+                call_shape: None,
                 kind: RelationKind::Calls,
                 src_name: "POST".to_string(),
                 dst_name: "executeTool".to_string(),
@@ -131,6 +133,7 @@ fn same_file_relation_resolves() {
         file_path: "src/animals.ts".to_string(),
         entities: vec![dog.clone(), bark.clone()],
         relations: vec![ExtractedRelation {
+            call_shape: None,
             kind: RelationKind::Contains,
             src_name: "Dog".to_string(),
             dst_name: "Dog.bark".to_string(),
@@ -165,6 +168,7 @@ fn unresolved_call_skipped_gracefully() {
         file_path: "src/api.ts".to_string(),
         entities: vec![handler.clone()],
         relations: vec![ExtractedRelation {
+            call_shape: None,
             kind: RelationKind::Calls,
             src_name: "handler".to_string(),
             dst_name: "console.log".to_string(),
@@ -306,6 +310,7 @@ fn renamed_import_resolves() {
             file_path: "src/api.ts".to_string(),
             entities: vec![handler.clone()],
             relations: vec![ExtractedRelation {
+                call_shape: None,
                 kind: RelationKind::Calls,
                 src_name: "handler".to_string(),
                 // The local alias "bar" is used in the call expression.
@@ -359,6 +364,7 @@ fn multiple_files_cross_link() {
             file_path: "src/routes.ts".to_string(),
             entities: vec![entity_a.clone()],
             relations: vec![ExtractedRelation {
+                call_shape: None,
                 kind: RelationKind::Calls,
                 src_name: "routeHandler".to_string(),
                 dst_name: "processOrder".to_string(),
@@ -377,6 +383,7 @@ fn multiple_files_cross_link() {
             file_path: "src/services/order.ts".to_string(),
             entities: vec![entity_b.clone()],
             relations: vec![ExtractedRelation {
+                call_shape: None,
                 kind: RelationKind::Calls,
                 src_name: "processOrder".to_string(),
                 dst_name: "saveToDb".to_string(),


### PR DESCRIPTION
## Problem

A caller of one overload phantom-attaches to a same-named sibling of a different arity. After the receiver-scope fix (#265), free functions and namespace-qualified calls with overloads were still bound arity-blind: `Catch::Main(argc, argv)` (the unchanged 2-arg overload) fans out through the qualified-suffix leaf tier to **both** `Catch::Main` overloads, so the untouched caller is minted as a consumer of the signature-changed `Main(Config const&)` 1-arg overload. The qualifier `Catch` is a namespace, not a class, so #265's receiver scoping does not apply.

## Fix

**Parser.** A new **`CallArgShape`** (in `kin-parser`'s `extract.rs`) records the call site's argument shape, carried on the `Calls` relation via optional `ExtractedRelation::call_shape`:

```rust
pub struct CallArgShape {
    pub positional: u32,           // positional args at the call site
    pub keywords: Vec<String>,     // named-arg names, sorted+deduped (empty for C++)
    pub has_var_positional: bool,  // C++ pack expansion / Python *args
    pub has_var_keyword: bool,     // Python **kwargs (always false for C++)
}
```

The C++ adapter populates `{positional: n, keywords: [], has_var_positional: <pack expansion present>, has_var_keyword: false}` — nesting-aware, so callee template args and nested-call commas do not miscount. Every other adapter leaves `call_shape` `None` and binds shape-blind as before.

**Linker (batch + incremental).** Build a per-entity arity index from C/C++ function and method signatures (`min`/`max`/`variadic`, honoring defaulted + parameter-pack params). A call's pinnable arity is `shape.positional` **unless a splat widens it** (`has_var_positional || has_var_keyword` → arity unknown). Prune arity-incompatible candidates in every same-name fan-out tier: cross-file twins (a), exact (c), bare-method fan-out (c2), qualified-suffix tiers 1+2 (c3).

Pruning is **fail-open**: a callee whose arity cannot be read is never pruned, and if *every* candidate is known-incompatible the original set is kept — an arity read narrows a binding but never erases the edge. Confidence tiers unchanged; emission stays ordered by content-derived entity id → batch == incremental, byte-stable.

## Tests (red before / green after)

| Test | Crate | Proves |
|---|---|---|
| `namespaced_overload_binds_only_the_arity_compatible_overload` | kin-index | The `Catch::Main(argc,argv)` shape binds the 2-arg overload only (core defect) |
| `bare_free_function_overloads_bind_by_call_arity` | kin-index | Bare-call overloads; each caller's arity selects its overload |
| `default_parameters_widen_the_accepted_arity` | kin-index | Defaulted overload accepts a range; strict sibling excluded |
| `method_overloads_combine_receiver_scope_and_arity` | kin-index | #265 receiver scope (class) + arity (overload) compose |
| `no_compatible_overload_keeps_the_existing_fan_out` | kin-index | Fail-open: all-incompatible arity keeps the edge |
| `pack_expansion_call_is_arity_unknown_and_keeps_all_overloads` | kin-index | A splat call (`dispatch(args...)`) is arity-unknown → keeps every overload |
| `arity_pruned_binding_is_deterministic` | kin-index | Re-link byte-stable; batch == incremental |
| `call_site_records_positional_argument_count` / `..._not_inflated_by_callee_template_arguments` / `pack_expansion_argument_marks_shape_var_positional` | kin-parser | Nesting-aware count + pack-expansion flag |
| `parse_signature_arity_*` (5) | kin-index unit | Signature→arity: plain, `void`, templates, defaults, variadics, `operator()` |

Red-on-old verified by neutering the arity check: the 4 fix tests fail; the fail-open / pack-expansion / determinism / #265 tests stay green.

**Validation:** `cargo test -p kin-parser -p kin-index` green (new + all existing); `cargo fmt --check`; clippy (CI allowlist, `-D warnings`); zero-file-search invariant passes; full-workspace `--all-targets` compiles. No benchmark/proof/corpus runs.

## Shared seam — merge order

`CallArgShape` + `ExtractedRelation::call_shape` is the **jointly-designed shared carrier** the **FIR-1430** (call-shape) lane also builds on. Per captain ruling, the canonical type lives **in `kin-parser` (`extract.rs`), not `kin-model`** — so this PR is CI-green now with no dependency on any unpublished `kin-model` type. `kin-model` will carry a **mirror** type only at the storage boundary, materialized when a call edge is persisted (FIR-1430's persistence commit converts at write time — candidate-time-coupled by design).

This PR lands the field FIRST with the inert `call_shape: None` swept across every adapter (incl. `python.rs`) + one `kin-cli` clone-sync; FIR-1430 rebases onto this commit and replaces its Nones with real Python shapes. Merge order: **#267 → FIR-1430** (#266 independent), each rebasing.

Do not merge until the founder-gated combined-candidate fresh-graph proof is run (graph-truth change).

https://linear.app/firelock-ai/issue/FIR-1434