### PR TITLE
review: gate arity-preserving Python param renames on call-site argument shapes

### DIFF
--- a/crates/kin-cli/tests/call_shape_rename_e2e.rs
+++ b/crates/kin-cli/tests/call_shape_rename_e2e.rs
@@ -1,0 +1,229 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Firelock, LLC
+
+//! End-to-end proof for call-site argument-shape gating.
+//!
+//! A fresh mini-graph is built by the real Python parser and the real linker;
+//! the resolved `Calls` edges carry the persisted call-site argument shape; and
+//! the review gate reads that shape from the stored graph to judge an
+//! arity-preserving parameter rename. This exercises the whole chain —
+//! parse -> link -> persist -> review — not the review logic in isolation.
+//!
+//! It mirrors the cdc7e13067 `Testdir._makefile` defect: a parameter is renamed
+//! with arity preserved and every call site passes positionally, so the rename
+//! strands no caller and must not gate as a breaking change. The keyword-caller
+//! and `**kwargs` variants prove the gate still blocks a rename that a call site
+//! actually names.
+
+use kin_db::{EntityStore, InMemoryGraph};
+use kin_index::{link_cross_file, FileParseData};
+use kin_model::{Entity, FilePathId, GraphNodeId, RelationKind};
+use kin_parser::{LanguageAdapter, PythonAdapter};
+use kin_review::{
+    analyze_impact, collect_inline_comments, EntityChange, EntityChangeKind, InlineCommentKind,
+    SemanticDiff,
+};
+
+fn parse_python(file_path: &str, source: &str) -> FileParseData {
+    let adapter = PythonAdapter;
+    let file_id = FilePathId::new(file_path);
+    let bytes = source.as_bytes();
+    let tree = adapter.parse(bytes).expect("parse");
+    let output = adapter.extract(&tree, bytes, &file_id).expect("extract");
+    let entities: Vec<Entity> = output
+        .entities
+        .into_iter()
+        .map(|e| e.into_entity_with_source(adapter.language_id(), &file_id, Some(bytes)))
+        .collect();
+    FileParseData {
+        file_path: file_path.to_string(),
+        entities,
+        relations: output.relations,
+        imports: output.imports,
+    }
+}
+
+fn find_entity(files: &[FileParseData], name: &str) -> Entity {
+    files
+        .iter()
+        .flat_map(|f| f.entities.iter())
+        .find(|e| e.name == name)
+        .unwrap_or_else(|| panic!("entity `{name}` not found"))
+        .clone()
+}
+
+/// Parse `source`, link it into a fresh graph (persisting each call site's
+/// argument shape onto its `Calls` edge), then run the review gate over a
+/// rename of `target` from `old_sig` to `new_sig`. Returns the emitted comment
+/// kinds and the linked relations (so the caller can also assert on the
+/// persisted shape directly).
+fn link_and_review(
+    source: &str,
+    old_sig: &str,
+    new_sig: &str,
+) -> (Vec<InlineCommentKind>, Vec<kin_model::Relation>) {
+    let files = vec![parse_python("mod.py", source)];
+
+    // Real linker: resolves calls and persists each Calls edge's argument shape.
+    let relations = link_cross_file(&files);
+
+    // Persist entities and edges into a real graph store, exactly as ingest does.
+    let graph = InMemoryGraph::new();
+    for file in &files {
+        for entity in &file.entities {
+            graph.upsert_entity(entity).expect("upsert entity");
+        }
+    }
+    for rel in &relations {
+        graph.upsert_relation(rel).expect("upsert relation");
+    }
+
+    // The rename diff: same entity id, signature old -> new.
+    let target = find_entity(&files, "target");
+    let mut old = target.clone();
+    old.signature = old_sig.to_string();
+    let mut new = target.clone();
+    new.signature = new_sig.to_string();
+    let diff = SemanticDiff {
+        entity_changes: vec![EntityChange {
+            entity_id: new.id,
+            kind: EntityChangeKind::Modified { old, new },
+        }],
+        ..Default::default()
+    };
+
+    let report = analyze_impact(&graph, &diff).expect("analyze impact");
+    let kinds = collect_inline_comments(&diff, &report)
+        .into_iter()
+        .map(|c| c.kind)
+        .collect();
+    (kinds, relations)
+}
+
+const POSITIONAL_CALLERS: &str = "\
+def target(ext, args):
+    return ext, args
+
+
+def caller_one():
+    return target(1, 2)
+
+
+def caller_two():
+    return target(3, 4)
+
+
+def caller_three():
+    return target(5, 6)
+";
+
+const KEYWORD_CALLER: &str = "\
+def target(ext, args):
+    return ext, args
+
+
+def caller_one():
+    return target(1, 2)
+
+
+def caller_two():
+    return target(3, args=4)
+";
+
+const VAR_KEYWORD_CALLER: &str = "\
+def target(ext, args):
+    return ext, args
+
+
+def caller_one():
+    return target(1, 2)
+
+
+def caller_two(**opts):
+    return target(**opts)
+";
+
+#[test]
+fn linker_persists_positional_call_shape_on_calls_edges() {
+    // Persist proof: the real linker attaches the call-site shape to the target's
+    // inbound Calls edges — three positional callers, no keywords.
+    let (_kinds, relations) = link_and_review(
+        POSITIONAL_CALLERS,
+        "def target(ext, args)",
+        "def target(ext, lines)",
+    );
+    let target = find_entity(&[parse_python("mod.py", POSITIONAL_CALLERS)], "target");
+    let inbound_shapes: Vec<_> = relations
+        .iter()
+        .filter(|r| r.kind == RelationKind::Calls && r.dst == GraphNodeId::Entity(target.id))
+        .filter_map(|r| r.evidence.iter().find_map(|e| e.call_shape.as_ref()))
+        .collect();
+    assert_eq!(inbound_shapes.len(), 3, "three call sites carry a shape");
+    for shape in inbound_shapes {
+        assert_eq!(shape.positional, 2);
+        assert!(shape.keywords.is_empty());
+        assert!(!shape.has_var_keyword);
+    }
+}
+
+#[test]
+fn e2e_positional_rename_is_not_breaking() {
+    // The _makefile shape: rename with every call site positional -> the gate
+    // records the signature change but does not block.
+    let (kinds, _relations) = link_and_review(
+        POSITIONAL_CALLERS,
+        "def target(ext, args)",
+        "def target(ext, lines)",
+    );
+    assert!(
+        kinds.contains(&InlineCommentKind::SignatureChange),
+        "signature evidence is preserved: {kinds:?}"
+    );
+    assert!(
+        !kinds.contains(&InlineCommentKind::Breaking),
+        "positional-only callers -> no breaking finding: {kinds:?}"
+    );
+}
+
+#[test]
+fn e2e_keyword_caller_rename_is_breaking() {
+    // A caller names the renamed parameter -> the rename strands it -> breaking.
+    let (kinds, _relations) = link_and_review(
+        KEYWORD_CALLER,
+        "def target(ext, args)",
+        "def target(ext, lines)",
+    );
+    assert!(
+        kinds.contains(&InlineCommentKind::Breaking),
+        "keyword caller of the renamed param must break: {kinds:?}"
+    );
+}
+
+#[test]
+fn e2e_var_keyword_caller_rename_is_breaking() {
+    // A `**kwargs` caller could forward the renamed key -> unknown -> breaking.
+    let (kinds, _relations) = link_and_review(
+        VAR_KEYWORD_CALLER,
+        "def target(ext, args)",
+        "def target(ext, lines)",
+    );
+    assert!(
+        kinds.contains(&InlineCommentKind::Breaking),
+        "**kwargs caller keeps the rename breaking: {kinds:?}"
+    );
+}
+
+#[test]
+fn e2e_review_output_is_deterministic() {
+    // The whole chain — shape capture, persistence, harvest, and gate — sorts
+    // its intermediate sets, so the same input yields byte-identical output.
+    let run = || {
+        link_and_review(
+            POSITIONAL_CALLERS,
+            "def target(ext, args)",
+            "def target(ext, lines)",
+        )
+        .0
+    };
+    assert_eq!(run(), run(), "review output must be stable across runs");
+}

--- a/crates/kin-index/src/linker.rs
+++ b/crates/kin-index/src/linker.rs
@@ -430,7 +430,7 @@ fn resolve_one_file(file: &FileParseData, ctx: &LinkContext<'_>) -> Vec<Relation
             if let Some(&dst_id) = dst_same_file {
                 if ctx.entity_kind_by_id.get(&dst_id) == Some(&EntityKind::Macro) {
                     if add_deduped(&mut seen, src_id, dst_id, rel.kind) {
-                        resolved.push(make_relation(rel.kind, src_id, dst_id, 1.0));
+                        resolved.push(make_relation(rel, src_id, dst_id, 1.0));
                     }
                     continue;
                 }
@@ -444,7 +444,7 @@ fn resolve_one_file(file: &FileParseData, ctx: &LinkContext<'_>) -> Vec<Relation
                 &ctx.entity_kind_by_id,
             ) {
                 if add_deduped(&mut seen, src_id, dst_id, rel.kind) {
-                    resolved.push(make_relation(rel.kind, src_id, dst_id, 0.95));
+                    resolved.push(make_relation(rel, src_id, dst_id, 0.95));
                 }
                 continue;
             }
@@ -468,7 +468,7 @@ fn resolve_one_file(file: &FileParseData, ctx: &LinkContext<'_>) -> Vec<Relation
         // parser-certain same-file edge (1.0).
         if let Some(&dst_id) = dst_same_file {
             if add_deduped(&mut seen, src_id, dst_id, rel.kind) {
-                resolved.push(make_relation(rel.kind, src_id, dst_id, 1.0));
+                resolved.push(make_relation(rel, src_id, dst_id, 1.0));
             }
             let mut cross_file_twins: HashSet<EntityId> = HashSet::new();
             distinct_cross_file_targets(
@@ -481,7 +481,7 @@ fn resolve_one_file(file: &FileParseData, ctx: &LinkContext<'_>) -> Vec<Relation
             if !cross_file_twins.is_empty() && cross_file_twins.len() < AMBIGUOUS_CALL_FANOUT_CAP {
                 for cross_id in sorted_fanout_targets(cross_file_twins) {
                     if add_deduped(&mut seen, src_id, cross_id, rel.kind) {
-                        resolved.push(make_relation(rel.kind, src_id, cross_id, 0.7));
+                        resolved.push(make_relation(rel, src_id, cross_id, 0.7));
                     }
                 }
             }
@@ -513,7 +513,7 @@ fn resolve_one_file(file: &FileParseData, ctx: &LinkContext<'_>) -> Vec<Relation
                     {
                         if add_deduped(&mut seen, src_id, dst_id, rel.kind) {
                             resolved.push(make_relation(
-                                rel.kind,
+                                rel,
                                 src_id,
                                 dst_id,
                                 INHERITED_METHOD_CONFIDENCE,
@@ -546,7 +546,7 @@ fn resolve_one_file(file: &FileParseData, ctx: &LinkContext<'_>) -> Vec<Relation
                     };
                     if let Some(dst_id) = dst_id {
                         if add_deduped(&mut seen, src_id, dst_id, rel.kind) {
-                            resolved.push(make_relation(rel.kind, src_id, dst_id, 0.95));
+                            resolved.push(make_relation(rel, src_id, dst_id, 0.95));
                         }
                         continue;
                     }
@@ -567,7 +567,7 @@ fn resolve_one_file(file: &FileParseData, ctx: &LinkContext<'_>) -> Vec<Relation
                             .get(&(target_file.as_str(), member_name))
                         {
                             if add_deduped(&mut seen, src_id, dst_id, rel.kind) {
-                                resolved.push(make_relation(rel.kind, src_id, dst_id, 0.9));
+                                resolved.push(make_relation(rel, src_id, dst_id, 0.9));
                             }
                             continue;
                         }
@@ -602,7 +602,7 @@ fn resolve_one_file(file: &FileParseData, ctx: &LinkContext<'_>) -> Vec<Relation
             ImportPinnedTarget::Resolved(dst_id) => {
                 if add_deduped(&mut seen, src_id, dst_id, rel.kind) {
                     resolved.push(make_relation(
-                        rel.kind,
+                        rel,
                         src_id,
                         dst_id,
                         IMPORT_PINNED_CONFIDENCE,
@@ -660,7 +660,7 @@ fn resolve_one_file(file: &FileParseData, ctx: &LinkContext<'_>) -> Vec<Relation
                 }
             };
             if add_deduped(&mut seen, src_id, dst_id, rel.kind) {
-                resolved.push(make_relation(rel.kind, src_id, dst_id, confidence));
+                resolved.push(make_relation(rel, src_id, dst_id, confidence));
                 linked = true;
             }
         }
@@ -685,7 +685,7 @@ fn resolve_one_file(file: &FileParseData, ctx: &LinkContext<'_>) -> Vec<Relation
             if (1..=AMBIGUOUS_CALL_FANOUT_CAP).contains(&distinct_targets.len()) {
                 for dst_id in sorted_fanout_targets(distinct_targets) {
                     if add_deduped(&mut seen, src_id, dst_id, rel.kind) {
-                        resolved.push(make_relation(rel.kind, src_id, dst_id, 0.3));
+                        resolved.push(make_relation(rel, src_id, dst_id, 0.3));
                         linked = true;
                     }
                 }
@@ -711,7 +711,7 @@ fn resolve_one_file(file: &FileParseData, ctx: &LinkContext<'_>) -> Vec<Relation
                     {
                         if add_deduped(&mut seen, src_id, dst_id, rel.kind) {
                             resolved.push(make_relation(
-                                rel.kind,
+                                rel,
                                 src_id,
                                 dst_id,
                                 INHERITED_METHOD_CONFIDENCE,
@@ -745,7 +745,7 @@ fn resolve_one_file(file: &FileParseData, ctx: &LinkContext<'_>) -> Vec<Relation
             ) {
                 if add_deduped(&mut seen, src_id, dst_id, rel.kind) {
                     resolved.push(make_relation(
-                        rel.kind,
+                        rel,
                         src_id,
                         dst_id,
                         QUALIFIED_SUFFIX_CONFIDENCE,
@@ -2156,7 +2156,8 @@ const LOCALITY_DISAMBIGUATED_CONFIDENCE: f32 = 0.8;
 /// Using a stable ID ensures the same logical relation (A calls B) gets the
 /// same RelationId across commits, preventing duplicate rows when the MERGE
 /// query matches on `{rel_id: $rel_id}`.
-fn make_relation(kind: RelationKind, src: EntityId, dst: EntityId, confidence: f32) -> Relation {
+fn make_relation(rel: &ExtractedRelation, src: EntityId, dst: EntityId, confidence: f32) -> Relation {
+    let kind = rel.kind;
     let origin = if confidence >= 1.0 {
         RelationOrigin::Parsed
     } else {
@@ -2175,7 +2176,25 @@ fn make_relation(kind: RelationKind, src: EntityId, dst: EntityId, confidence: f
         origin,
         created_in: None,
         import_source: None,
-        evidence: Vec::new(),
+        evidence: call_shape_evidence(rel.call_shape.as_ref()),
+    }
+}
+
+/// Convert a parser-side [`CallArgShape`] into stored relation evidence carrying
+/// the graph-model shape mirror. Empty when the call site recorded no shape, so
+/// non-call and shape-blind edges stay evidence-free as before.
+pub(crate) fn call_shape_evidence(shape: Option<&CallArgShape>) -> Vec<RelationEvidence> {
+    match shape {
+        Some(shape) => vec![RelationEvidence {
+            call_shape: Some(kin_model::CallArgShape::new(
+                shape.positional,
+                shape.keywords.clone(),
+                shape.has_var_positional,
+                shape.has_var_keyword,
+            )),
+            ..RelationEvidence::default()
+        }],
+        None => Vec::new(),
     }
 }
 
@@ -3120,7 +3139,7 @@ fn resolve_one_file_incremental(
             if let Some(dst_id) = dst_same_file {
                 if linker.entity_kind_by_id.get(&dst_id) == Some(&EntityKind::Macro) {
                     if add_deduped(&mut seen, src_id, dst_id, rel.kind) {
-                        resolved.push(make_relation(rel.kind, src_id, dst_id, 1.0));
+                        resolved.push(make_relation(rel, src_id, dst_id, 1.0));
                     }
                     continue;
                 }
@@ -3133,7 +3152,7 @@ fn resolve_one_file_incremental(
                 linker,
             ) {
                 if add_deduped(&mut seen, src_id, dst_id, rel.kind) {
-                    resolved.push(make_relation(rel.kind, src_id, dst_id, 0.95));
+                    resolved.push(make_relation(rel, src_id, dst_id, 0.95));
                 }
                 continue;
             }
@@ -3155,7 +3174,7 @@ fn resolve_one_file_incremental(
         // Cross-file twins carry the (c) name-match confidence (0.7).
         if let Some(dst_id) = dst_same_file {
             if add_deduped(&mut seen, src_id, dst_id, rel.kind) {
-                resolved.push(make_relation(rel.kind, src_id, dst_id, 1.0));
+                resolved.push(make_relation(rel, src_id, dst_id, 1.0));
             }
             let mut cross_file_twins: HashSet<EntityId> = HashSet::new();
             if let Some(candidates) = linker.entity_by_name.get(&rel.dst_name) {
@@ -3170,7 +3189,7 @@ fn resolve_one_file_incremental(
             if !cross_file_twins.is_empty() && cross_file_twins.len() < AMBIGUOUS_CALL_FANOUT_CAP {
                 for cross_id in sorted_fanout_targets(cross_file_twins) {
                     if add_deduped(&mut seen, src_id, cross_id, rel.kind) {
-                        resolved.push(make_relation(rel.kind, src_id, cross_id, 0.7));
+                        resolved.push(make_relation(rel, src_id, cross_id, 0.7));
                     }
                 }
             }
@@ -3202,7 +3221,7 @@ fn resolve_one_file_incremental(
                     ) {
                         if add_deduped(&mut seen, src_id, dst_id, rel.kind) {
                             resolved.push(make_relation(
-                                rel.kind,
+                                rel,
                                 src_id,
                                 dst_id,
                                 INHERITED_METHOD_CONFIDENCE,
@@ -3235,7 +3254,7 @@ fn resolve_one_file_incremental(
                     };
                     if let Some(dst_id) = dst_id {
                         if add_deduped(&mut seen, src_id, dst_id, rel.kind) {
-                            resolved.push(make_relation(rel.kind, src_id, dst_id, 0.95));
+                            resolved.push(make_relation(rel, src_id, dst_id, 0.95));
                         }
                         continue;
                     }
@@ -3254,7 +3273,7 @@ fn resolve_one_file_incremental(
                             .and_then(|m| m.get(member_name))
                         {
                             if add_deduped(&mut seen, src_id, dst_id, rel.kind) {
-                                resolved.push(make_relation(rel.kind, src_id, dst_id, 0.9));
+                                resolved.push(make_relation(rel, src_id, dst_id, 0.9));
                             }
                             continue;
                         }
@@ -3295,7 +3314,7 @@ fn resolve_one_file_incremental(
             ImportPinnedTarget::Resolved(dst_id) => {
                 if add_deduped(&mut seen, src_id, dst_id, rel.kind) {
                     resolved.push(make_relation(
-                        rel.kind,
+                        rel,
                         src_id,
                         dst_id,
                         IMPORT_PINNED_CONFIDENCE,
@@ -3353,7 +3372,7 @@ fn resolve_one_file_incremental(
                 }
             };
             if add_deduped(&mut seen, src_id, dst_id, rel.kind) {
-                resolved.push(make_relation(rel.kind, src_id, dst_id, confidence));
+                resolved.push(make_relation(rel, src_id, dst_id, confidence));
             }
             continue;
         }
@@ -3380,7 +3399,7 @@ fn resolve_one_file_incremental(
                 if (1..=AMBIGUOUS_CALL_FANOUT_CAP).contains(&distinct_targets.len()) {
                     for dst_id in sorted_fanout_targets(distinct_targets) {
                         if add_deduped(&mut seen, src_id, dst_id, rel.kind) {
-                            resolved.push(make_relation(rel.kind, src_id, dst_id, 0.3));
+                            resolved.push(make_relation(rel, src_id, dst_id, 0.3));
                         }
                     }
                     continue;
@@ -3408,7 +3427,7 @@ fn resolve_one_file_incremental(
                     ) {
                         if add_deduped(&mut seen, src_id, dst_id, rel.kind) {
                             resolved.push(make_relation(
-                                rel.kind,
+                                rel,
                                 src_id,
                                 dst_id,
                                 INHERITED_METHOD_CONFIDENCE,
@@ -3438,7 +3457,7 @@ fn resolve_one_file_incremental(
                 for dst_id in qualified_targets {
                     if add_deduped(&mut seen, src_id, dst_id, rel.kind) {
                         resolved.push(make_relation(
-                            rel.kind,
+                            rel,
                             src_id,
                             dst_id,
                             QUALIFIED_SUFFIX_CONFIDENCE,

--- a/crates/kin-index/src/linker.rs
+++ b/crates/kin-index/src/linker.rs
@@ -601,12 +601,7 @@ fn resolve_one_file(file: &FileParseData, ctx: &LinkContext<'_>) -> Vec<Relation
         ) {
             ImportPinnedTarget::Resolved(dst_id) => {
                 if add_deduped(&mut seen, src_id, dst_id, rel.kind) {
-                    resolved.push(make_relation(
-                        rel,
-                        src_id,
-                        dst_id,
-                        IMPORT_PINNED_CONFIDENCE,
-                    ));
+                    resolved.push(make_relation(rel, src_id, dst_id, IMPORT_PINNED_CONFIDENCE));
                 }
                 continue;
             }
@@ -2156,7 +2151,12 @@ const LOCALITY_DISAMBIGUATED_CONFIDENCE: f32 = 0.8;
 /// Using a stable ID ensures the same logical relation (A calls B) gets the
 /// same RelationId across commits, preventing duplicate rows when the MERGE
 /// query matches on `{rel_id: $rel_id}`.
-fn make_relation(rel: &ExtractedRelation, src: EntityId, dst: EntityId, confidence: f32) -> Relation {
+fn make_relation(
+    rel: &ExtractedRelation,
+    src: EntityId,
+    dst: EntityId,
+    confidence: f32,
+) -> Relation {
     let kind = rel.kind;
     let origin = if confidence >= 1.0 {
         RelationOrigin::Parsed
@@ -3313,12 +3313,7 @@ fn resolve_one_file_incremental(
         ) {
             ImportPinnedTarget::Resolved(dst_id) => {
                 if add_deduped(&mut seen, src_id, dst_id, rel.kind) {
-                    resolved.push(make_relation(
-                        rel,
-                        src_id,
-                        dst_id,
-                        IMPORT_PINNED_CONFIDENCE,
-                    ));
+                    resolved.push(make_relation(rel, src_id, dst_id, IMPORT_PINNED_CONFIDENCE));
                 }
                 continue;
             }

--- a/crates/kin-index/src/pipeline.rs
+++ b/crates/kin-index/src/pipeline.rs
@@ -786,7 +786,7 @@ fn resolve_relations(
                     origin: RelationOrigin::Parsed,
                     created_in: None,
                     import_source: rel.import_source.clone(),
-                    evidence: Vec::new(),
+                    evidence: crate::linker::call_shape_evidence(rel.call_shape.as_ref()),
                 });
             }
             (Some(s), None) => {

--- a/crates/kin-parser/src/languages/python.rs
+++ b/crates/kin-parser/src/languages/python.rs
@@ -9,8 +9,8 @@ use crate::adapter::{
 };
 use crate::error::Result;
 use crate::extract::{
-    ExtractedEntity, ExtractedRelation, ExtractedTest, ExtractedTestKind, FileImport, ImportedName,
-    ParseOutput,
+    CallArgShape, ExtractedEntity, ExtractedRelation, ExtractedTest, ExtractedTestKind, FileImport,
+    ImportedName, ParseOutput,
 };
 
 pub struct PythonAdapter;
@@ -500,7 +500,7 @@ fn extract_calls_from_context(
                 };
                 if is_valid_callee_name(&callee_name) {
                     relations.push(ExtractedRelation {
-                        call_shape: None,
+                        call_shape: Some(extract_call_arg_shape(&child, source)),
                         kind: kin_model::RelationKind::Calls,
                         src_name: context_name.to_string(),
                         dst_name: callee_name,
@@ -511,6 +511,50 @@ fn extract_calls_from_context(
         }
         // Recurse into child nodes
         extract_calls_from_context(&child, source, context_name, class_ctx, relations);
+    }
+}
+
+/// Extract the [`CallArgShape`] of a tree-sitter `call` node: count positional
+/// arguments, collect explicit keyword-argument names, and note `*args` /
+/// `**kwargs` splats. Only the call's own argument list is inspected — arguments
+/// of nested calls belong to those calls, not this one. A call with no argument
+/// list yields the default (empty) shape. Keyword names are sorted and
+/// deduplicated so the shape is order- and duplicate-independent.
+pub fn extract_call_arg_shape(call: &tree_sitter::Node, source: &[u8]) -> CallArgShape {
+    let Some(arguments) = call.child_by_field_name("arguments") else {
+        return CallArgShape::default();
+    };
+
+    let mut positional = 0u32;
+    let mut keywords = Vec::new();
+    let mut has_var_positional = false;
+    let mut has_var_keyword = false;
+
+    let mut cursor = arguments.walk();
+    for arg in arguments.named_children(&mut cursor) {
+        match arg.kind() {
+            "keyword_argument" => {
+                if let Some(name) = arg
+                    .child_by_field_name("name")
+                    .and_then(|n| n.utf8_text(source).ok())
+                {
+                    keywords.push(name.to_string());
+                }
+            }
+            "list_splat" => has_var_positional = true,
+            "dictionary_splat" => has_var_keyword = true,
+            "comment" => {}
+            _ => positional += 1,
+        }
+    }
+
+    keywords.sort();
+    keywords.dedup();
+    CallArgShape {
+        positional,
+        keywords,
+        has_var_positional,
+        has_var_keyword,
     }
 }
 
@@ -602,6 +646,78 @@ fn extract_py_from_import(node: &tree_sitter::Node, source: &[u8]) -> Option<Fil
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    /// Depth-first search for the first `call` node in a parsed tree.
+    fn first_call_node<'a>(node: tree_sitter::Node<'a>) -> Option<tree_sitter::Node<'a>> {
+        if node.kind() == "call" {
+            return Some(node);
+        }
+        let mut cursor = node.walk();
+        for child in node.children(&mut cursor) {
+            if let Some(found) = first_call_node(child) {
+                return Some(found);
+            }
+        }
+        None
+    }
+
+    fn shape_of(src: &[u8]) -> CallArgShape {
+        let adapter = PythonAdapter;
+        let tree = adapter.parse(src).unwrap();
+        let call = first_call_node(tree.root_node()).expect("a call node");
+        extract_call_arg_shape(&call, src)
+    }
+
+    #[test]
+    fn call_arg_shape_positional_only() {
+        let shape = shape_of(b"f(a, b, c)");
+        assert_eq!(shape.positional, 3);
+        assert!(shape.keywords.is_empty());
+        assert!(!shape.has_var_positional);
+        assert!(!shape.has_var_keyword);
+    }
+
+    #[test]
+    fn call_arg_shape_keyword_and_mixed() {
+        let shape = shape_of(b"f(a, kw=c, other=d)");
+        assert_eq!(shape.positional, 1);
+        assert_eq!(shape.keywords, vec!["kw".to_string(), "other".to_string()]);
+        assert!(!shape.has_var_keyword);
+    }
+
+    #[test]
+    fn call_arg_shape_star_and_double_star() {
+        let shape = shape_of(b"f(a, *args, **kwargs)");
+        assert_eq!(shape.positional, 1);
+        assert!(shape.has_var_positional);
+        assert!(shape.has_var_keyword);
+        assert!(shape.keywords.is_empty());
+    }
+
+    #[test]
+    fn call_arg_shape_empty_call_is_default() {
+        assert_eq!(shape_of(b"f()"), CallArgShape::default());
+    }
+
+    #[test]
+    fn call_arg_shape_keyword_names_sorted_and_deduped() {
+        let shape = shape_of(b"f(zebra=1, alpha=2)");
+        assert_eq!(
+            shape.keywords,
+            vec!["alpha".to_string(), "zebra".to_string()]
+        );
+    }
+
+    #[test]
+    fn call_arg_shape_nested_call_counts_outer_args_only() {
+        // The inner `y=1` keyword belongs to `g`, not the outer `f` call.
+        let shape = shape_of(b"f(g(x, y=1), z)");
+        assert_eq!(shape.positional, 2);
+        assert!(
+            shape.keywords.is_empty(),
+            "inner keyword must not leak to the outer call"
+        );
+    }
 
     #[test]
     fn parse_python_function() {

--- a/crates/kin-review/src/impact.rs
+++ b/crates/kin-review/src/impact.rs
@@ -196,6 +196,30 @@ pub struct EntityImpact {
     /// surface change did have consumers and that they all moved with it.
     #[serde(default)]
     pub consumers_migrated_in_diff: usize,
+    /// How the counted (non-migrated, non-test) consumers invoke this entity,
+    /// distilled from the inbound `Calls` edges' argument-shape evidence. Lets
+    /// an arity-preserving parameter rename be judged against actual call sites.
+    #[serde(default)]
+    pub call_shapes: ConsumerCallShapeSummary,
+}
+
+/// How a changed callable's counted consumers invoke it, distilled from the
+/// inbound `Calls` edges' argument-shape evidence over the same real-consumer
+/// set that drives `consumer_count`. Lets an arity-preserving rename be judged
+/// against actual call sites instead of assumed keyword usage.
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+pub struct ConsumerCallShapeSummary {
+    /// Union of keyword-argument names any counted call site passes. Sorted for
+    /// deterministic output.
+    pub caller_keyword_names: BTreeSet<String>,
+    /// Some counted call site forwards `**mapping`, so its keyword set is not
+    /// statically known — it could carry any renamed parameter.
+    pub any_var_keyword_caller: bool,
+    /// Every counted consumer is a `Calls` edge carrying argument-shape
+    /// evidence. False when a counted consumer is a non-call edge, or a call
+    /// whose shape was not captured (older snapshot, unresolved, or a language
+    /// that does not emit shapes) — either way a rename cannot be proven safe.
+    pub all_consumers_shaped_calls: bool,
 }
 
 impl EntityImpact {
@@ -320,6 +344,15 @@ pub fn analyze_impact_at<I: ImpactGraph>(
         // decision input: a consumer that happens to share the changed entity's
         // file is still a distinct consumer entity with a real inbound edge.
         let mut ent_consumer_files: BTreeSet<String> = BTreeSet::new();
+        // Argument-shape distillation over the SAME counted-consumer set: the
+        // union of keyword names any inbound call site uses, whether any caller
+        // forwards `**kwargs` (keyword set then unknown), and whether every
+        // counted consumer is a shaped call site. A non-call consumer or a call
+        // whose shape was not captured leaves the rename unprovable-safe. Sets
+        // accumulate a distinct union only; iteration order never reaches output.
+        let mut ent_caller_keyword_names: BTreeSet<String> = BTreeSet::new();
+        let mut ent_any_var_keyword_caller = false;
+        let mut ent_all_consumers_shaped_calls = true;
 
         // Find relations pointing TO this entity (callers, dependents, etc.).
         // `get_relations` serves outgoing edges only, so the inbound harvest
@@ -395,6 +428,25 @@ pub fn analyze_impact_at<I: ImpactGraph>(
                 if let Some(file) = entity_file(&entity) {
                     ent_consumer_files.insert(file);
                 }
+                // Distill this consumer edge's call-site argument shape. A rename
+                // is only provably safe when every counted consumer is a call
+                // carrying shape evidence; a non-call edge, or a call with no
+                // captured shape, leaves it unprovable.
+                if rel.kind == RelationKind::Calls {
+                    match rel.evidence.iter().find_map(|ev| ev.call_shape.as_ref()) {
+                        Some(shape) => {
+                            for keyword in &shape.keywords {
+                                ent_caller_keyword_names.insert(keyword.clone());
+                            }
+                            if shape.has_var_keyword {
+                                ent_any_var_keyword_caller = true;
+                            }
+                        }
+                        None => ent_all_consumers_shaped_calls = false,
+                    }
+                } else {
+                    ent_all_consumers_shaped_calls = false;
+                }
             }
             match rel.kind {
                 RelationKind::Calls => {
@@ -456,6 +508,11 @@ pub fn analyze_impact_at<I: ImpactGraph>(
             consumer_files: ent_consumer_files.into_iter().collect(),
             covering_tests: ent_tests.len(),
             consumers_migrated_in_diff: ent_migrated.len(),
+            call_shapes: ConsumerCallShapeSummary {
+                caller_keyword_names: ent_caller_keyword_names,
+                any_var_keyword_caller: ent_any_var_keyword_caller,
+                all_consumers_shaped_calls: ent_all_consumers_shaped_calls,
+            },
         });
     }
 
@@ -645,9 +702,12 @@ mod tests {
     // ── Per-entity attribution: direct-only consumer_count / consumer_files ──
 
     use crate::diff::{EntityChange, EntityChangeKind};
+    use crate::inline::InlineCommentKind;
     use kin_model::entity::SourceSpan;
     use kin_model::provenance::{Actor, ActorId, Approval, AuditEvent};
-    use kin_model::relation::{GraphNodeId, Relation, RelationKind, RelationOrigin};
+    use kin_model::relation::{
+        CallArgShape, GraphNodeId, Relation, RelationEvidence, RelationKind, RelationOrigin,
+    };
     use kin_model::work::{Annotation, WorkItem, WorkScope};
     use std::collections::HashMap;
 
@@ -851,6 +911,187 @@ mod tests {
             vec!["src/bar.rs".to_string(), "src/foo.rs".to_string()],
             "consumer_files is the projected file set of the consumer entities (both), report-only"
         );
+    }
+
+    // ── Call-site argument-shape harvest + arity-preserving rename gating ──
+
+    fn calls_with_shape(src: &Entity, dst: &Entity, shape: CallArgShape) -> Relation {
+        Relation {
+            id: RelationId::new(),
+            kind: RelationKind::Calls,
+            src: GraphNodeId::Entity(src.id),
+            dst: GraphNodeId::Entity(dst.id),
+            confidence: 1.0,
+            origin: RelationOrigin::Parsed,
+            created_in: None,
+            import_source: None,
+            evidence: vec![RelationEvidence {
+                call_shape: Some(shape),
+                ..RelationEvidence::default()
+            }],
+        }
+    }
+
+    fn target_entity(signature: &str) -> Entity {
+        let mut e = entity_in_file("target", "src/mod.py", 10);
+        e.signature = signature.to_string();
+        e
+    }
+
+    /// Comment kinds emitted when `target`'s signature changes `old_sig` →
+    /// `new_sig` and each caller invokes it with the given shape (`None` = a
+    /// `Calls` edge with no captured shape).
+    fn rename_review_kinds(
+        old_sig: &str,
+        new_sig: &str,
+        caller_shapes: Vec<Option<CallArgShape>>,
+    ) -> Vec<InlineCommentKind> {
+        let new_target = target_entity(new_sig);
+        let mut old_target = new_target.clone();
+        old_target.signature = old_sig.to_string();
+
+        let mut graph = MockImpactGraph::default();
+        graph.entities.insert(new_target.id, new_target.clone());
+        let mut edges = Vec::new();
+        for (i, shape) in caller_shapes.into_iter().enumerate() {
+            let caller = entity_in_file(&format!("caller{i}"), &format!("src/c{i}.py"), 1);
+            graph.entities.insert(caller.id, caller.clone());
+            edges.push(match shape {
+                Some(s) => calls_with_shape(&caller, &new_target, s),
+                None => calls(&caller, &new_target),
+            });
+        }
+        graph.inbound.insert(new_target.id, edges);
+
+        let diff = SemanticDiff {
+            entity_changes: vec![EntityChange {
+                entity_id: new_target.id,
+                kind: EntityChangeKind::Modified {
+                    old: old_target,
+                    new: new_target.clone(),
+                },
+            }],
+            ..Default::default()
+        };
+        let report = analyze_impact_at(&graph, &diff).unwrap();
+        crate::inline::collect_inline_comments(&diff, &report)
+            .into_iter()
+            .map(|c| c.kind)
+            .collect()
+    }
+
+    const RENAME_OLD: &str = "def target(self, ext, args)";
+    const RENAME_NEW: &str = "def target(self, ext, lines)";
+
+    #[test]
+    fn harvest_distills_call_shapes_over_counted_consumers() {
+        let target = target_entity(RENAME_NEW);
+        let positional = entity_in_file("pos_caller", "src/a.py", 1);
+        let keyword = entity_in_file("kw_caller", "src/b.py", 1);
+        let mut graph = MockImpactGraph::default();
+        for e in [&target, &positional, &keyword] {
+            graph.entities.insert(e.id, e.clone());
+        }
+        graph.inbound.insert(
+            target.id,
+            vec![
+                calls_with_shape(
+                    &positional,
+                    &target,
+                    CallArgShape::new(2, vec![], false, false),
+                ),
+                calls_with_shape(
+                    &keyword,
+                    &target,
+                    CallArgShape::new(1, vec!["args".to_string()], false, false),
+                ),
+            ],
+        );
+        let diff = SemanticDiff {
+            entity_changes: vec![modified(&target)],
+            ..Default::default()
+        };
+        let report = analyze_impact_at(&graph, &diff).unwrap();
+        let summary = &report.entity_impact(&target.id).unwrap().call_shapes;
+        assert!(
+            summary.all_consumers_shaped_calls,
+            "both consumers are shaped calls"
+        );
+        assert!(!summary.any_var_keyword_caller);
+        assert!(summary.caller_keyword_names.contains("args"));
+    }
+
+    #[test]
+    fn rename_with_only_positional_callers_is_not_breaking() {
+        // (a) every call site positional → runtime-neutral, non-blocking.
+        let kinds = rename_review_kinds(
+            RENAME_OLD,
+            RENAME_NEW,
+            vec![Some(CallArgShape::new(2, vec![], false, false))],
+        );
+        assert!(kinds.contains(&InlineCommentKind::SignatureChange));
+        assert!(!kinds.contains(&InlineCommentKind::Breaking));
+        assert!(!kinds.contains(&InlineCommentKind::BreakingMigrated));
+    }
+
+    #[test]
+    fn rename_with_keyword_caller_of_renamed_param_is_breaking() {
+        // (b) a caller passes the renamed parameter by keyword → breaking.
+        let kinds = rename_review_kinds(
+            RENAME_OLD,
+            RENAME_NEW,
+            vec![Some(CallArgShape::new(
+                1,
+                vec!["args".to_string()],
+                false,
+                false,
+            ))],
+        );
+        assert!(kinds.contains(&InlineCommentKind::Breaking));
+    }
+
+    #[test]
+    fn rename_with_mixed_callers_is_breaking() {
+        // (c) one positional, one keyword-of-renamed → breaking.
+        let kinds = rename_review_kinds(
+            RENAME_OLD,
+            RENAME_NEW,
+            vec![
+                Some(CallArgShape::new(2, vec![], false, false)),
+                Some(CallArgShape::new(1, vec!["args".to_string()], false, false)),
+            ],
+        );
+        assert!(kinds.contains(&InlineCommentKind::Breaking));
+    }
+
+    #[test]
+    fn rename_with_var_keyword_caller_is_breaking() {
+        // (d) a `**kwargs` caller has an unknown keyword set → breaking.
+        let kinds = rename_review_kinds(
+            RENAME_OLD,
+            RENAME_NEW,
+            vec![Some(CallArgShape::new(1, vec![], false, true))],
+        );
+        assert!(kinds.contains(&InlineCommentKind::Breaking));
+    }
+
+    #[test]
+    fn arity_change_not_rename_is_breaking() {
+        // (e) an added required parameter is a real arity change, not a rename;
+        // positional callers are stranded → still breaking.
+        let kinds = rename_review_kinds(
+            "def target(self, ext)",
+            "def target(self, ext, extra)",
+            vec![Some(CallArgShape::new(1, vec![], false, false))],
+        );
+        assert!(kinds.contains(&InlineCommentKind::Breaking));
+    }
+
+    #[test]
+    fn rename_with_missing_shape_is_breaking() {
+        // (f) a call edge with no captured shape cannot prove safety → breaking.
+        let kinds = rename_review_kinds(RENAME_OLD, RENAME_NEW, vec![None]);
+        assert!(kinds.contains(&InlineCommentKind::Breaking));
     }
 
     #[test]

--- a/crates/kin-review/src/inline.rs
+++ b/crates/kin-review/src/inline.rs
@@ -201,6 +201,149 @@ fn python_param_adds_no_required_arg(param: &str) -> bool {
     param.contains('=') || param == "/" || param.starts_with('*')
 }
 
+/// The call-contract role of a normalized Python parameter. A rename is only
+/// caller-relevant when the position keeps its role; reclassifying a position
+/// (e.g. a normal parameter becoming `*args`) is a structural change, not a
+/// rename.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum PyParamRole {
+    /// A by-name/by-position parameter (`name`, `name=default`).
+    Normal,
+    /// Variadic positional collector (`*args`).
+    VarPositional,
+    /// Variadic keyword collector (`**kwargs`).
+    VarKeyword,
+    /// A bare `*` or `/` boundary marker.
+    Marker,
+}
+
+/// Classify a normalized Python parameter by call-contract role.
+fn python_param_role(param: &str) -> PyParamRole {
+    if param == "*" || param == "/" {
+        PyParamRole::Marker
+    } else if param.starts_with("**") {
+        PyParamRole::VarKeyword
+    } else if param.starts_with('*') {
+        PyParamRole::VarPositional
+    } else {
+        PyParamRole::Normal
+    }
+}
+
+/// The bare identifier of a normalized Python parameter, with any splat prefix
+/// and default value stripped. Boundary markers (`*`, `/`) have no identifier
+/// and yield an empty string.
+fn python_param_identifier(param: &str) -> &str {
+    if param == "*" || param == "/" {
+        return "";
+    }
+    let stripped = param
+        .strip_prefix("**")
+        .or_else(|| param.strip_prefix('*'))
+        .unwrap_or(param);
+    match stripped.find('=') {
+        Some(idx) => &stripped[..idx],
+        None => stripped,
+    }
+}
+
+/// When `old` → `new` is an arity-preserving pure parameter RENAME of the same
+/// Python `def` — same callable name, same parameter count, every position
+/// keeps its role, and at least one normal parameter's identifier changes —
+/// returns the OLD identifiers of the renamed normal positions. Returns `None`
+/// otherwise.
+///
+/// The result is the set of names whose by-keyword call sites a rename could
+/// strand, so a caller-shape check can decide whether the rename is actually
+/// runtime-neutral. Excluded, because they are not caller-safe renames or not
+/// renames at all:
+/// - reorders — a new identifier that reuses any old parameter's identifier;
+///   swapping positions changes positional call semantics, not just names;
+/// - role changes at any position (normal ↔ `*args`/`**kwargs`/marker);
+/// - retype- or default-only edits (identifier unchanged);
+/// - arity changes or non-`def` text.
+///
+/// Renames of `*args`/`**kwargs` collectors are not reported: no caller can
+/// target them by name, so renaming one strands nothing. Positions are visited
+/// left to right, so the returned order is deterministic.
+pub fn arity_preserving_rename(old: &str, new: &str) -> Option<Vec<String>> {
+    if old == new {
+        return None;
+    }
+    let (old_name, old_params) = python_signature_parts(old)?;
+    let (new_name, new_params) = python_signature_parts(new)?;
+    if old_name != new_name || old_params.len() != new_params.len() {
+        return None;
+    }
+    let old_identifiers: std::collections::BTreeSet<&str> = old_params
+        .iter()
+        .map(|p| python_param_identifier(p))
+        .filter(|id| !id.is_empty())
+        .collect();
+
+    let mut renamed = Vec::new();
+    for (old_param, new_param) in old_params.iter().zip(new_params.iter()) {
+        let old_role = python_param_role(old_param);
+        if old_role != python_param_role(new_param) {
+            return None;
+        }
+        let old_id = python_param_identifier(old_param);
+        let new_id = python_param_identifier(new_param);
+        if old_id == new_id {
+            continue;
+        }
+        if old_role != PyParamRole::Normal {
+            // Renaming a `*args`/`**kwargs` collector strands no caller.
+            continue;
+        }
+        if old_identifiers.contains(new_id) {
+            // The new name reuses an existing parameter name: a reorder, which
+            // changes positional semantics and is never a safe rename.
+            return None;
+        }
+        renamed.push(old_id.to_string());
+    }
+
+    if renamed.is_empty() {
+        None
+    } else {
+        Some(renamed)
+    }
+}
+
+/// How a changed callable's graph-known consumers invoke it, distilled from the
+/// inbound `Calls` edges' argument-shape evidence over the same real-consumer
+/// set that drives the breaking decision. Lets an arity-preserving rename be
+/// judged against actual call sites instead of assumed keyword usage.
+#[derive(Debug, Clone, Default)]
+pub struct ConsumerCallShapeSummary {
+    /// Union of keyword-argument names any inbound call site passes.
+    pub caller_keyword_names: std::collections::BTreeSet<String>,
+    /// Some call site forwards `**mapping`, so its keyword set is not
+    /// statically known — it could carry any renamed parameter.
+    pub any_var_keyword_caller: bool,
+    /// Every counted consumer is a `Calls` edge carrying argument-shape
+    /// evidence. False when a consumer is a non-call edge, or a call whose
+    /// shape was not captured (older snapshot, unresolved, or a language that
+    /// does not emit shapes) — either way a rename cannot be proven safe.
+    pub all_consumers_shaped_calls: bool,
+}
+
+/// True when an arity-preserving rename of `renamed_old_names` strands no
+/// graph-known consumer: every consumer is a shaped call site, none forwards
+/// `**kwargs`, and none passes a renamed parameter by keyword. Any gap in the
+/// evidence is conservative — the rename stays potentially breaking.
+pub fn rename_is_runtime_neutral_for_consumers(
+    renamed_old_names: &[String],
+    summary: &ConsumerCallShapeSummary,
+) -> bool {
+    summary.all_consumers_shaped_calls
+        && !summary.any_var_keyword_caller
+        && renamed_old_names
+            .iter()
+            .all(|name| !summary.caller_keyword_names.contains(name.as_str()))
+}
+
 /// True when `old` and `new` are Go struct type signatures that differ ONLY by
 /// added fields: identical `Name struct` header, and every whitespace token of
 /// the old field body still appears, in order, inside a strictly larger new
@@ -1672,6 +1815,141 @@ mod tests {
             "class Item(Node, Request)",
             "class Item(Node)"
         ));
+    }
+
+    #[test]
+    fn arity_preserving_rename_detects_normal_param_renames() {
+        // The _makefile defect shape: two arity-preserving positional renames,
+        // annotations/defaults on other positions unchanged.
+        assert_eq!(
+            arity_preserving_rename(
+                "def _makefile(self, ext, args, kwargs, encoding=\"utf-8\")",
+                "def _makefile(self, ext, lines, files, encoding=\"utf-8\")"
+            ),
+            Some(vec!["args".to_string(), "kwargs".to_string()])
+        );
+        // Single rename with a leading `self`.
+        assert_eq!(
+            arity_preserving_rename("def f(self, config)", "def f(self, options)"),
+            Some(vec!["config".to_string()])
+        );
+        // Rename survives an annotation/default reformat on the same position.
+        assert_eq!(
+            arity_preserving_rename("def f(a: int = 1)", "def f(b: int = 1)"),
+            Some(vec!["a".to_string()])
+        );
+    }
+
+    #[test]
+    fn arity_preserving_rename_rejects_reorders() {
+        // Swapping two names is not a safe rename: positional callers shift.
+        assert_eq!(arity_preserving_rename("def f(a, b)", "def f(b, a)"), None);
+        // A new name that reuses an existing parameter name (a shift) is rejected.
+        assert_eq!(arity_preserving_rename("def f(a, b)", "def f(b, c)"), None);
+        // Renaming both positions to fresh names is a clean rename, not a reorder.
+        assert_eq!(
+            arity_preserving_rename("def f(a, b)", "def f(x, y)"),
+            Some(vec!["a".to_string(), "b".to_string()])
+        );
+    }
+
+    #[test]
+    fn arity_preserving_rename_rejects_non_renames() {
+        // Retype-only and default-only edits keep the identifier.
+        assert_eq!(
+            arity_preserving_rename("def f(a: int)", "def f(a: str)"),
+            None
+        );
+        assert_eq!(arity_preserving_rename("def f(a=1)", "def f(a=2)"), None);
+        // Arity changes are not renames.
+        assert_eq!(arity_preserving_rename("def f(a)", "def f(a, b)"), None);
+        assert_eq!(arity_preserving_rename("def f(a, b)", "def f(a)"), None);
+        // Appended optional parameter.
+        assert_eq!(arity_preserving_rename("def f(a)", "def f(a, b=1)"), None);
+        // Different callable, identical text, and non-`def` text.
+        assert_eq!(arity_preserving_rename("def f(a)", "def g(b)"), None);
+        assert_eq!(arity_preserving_rename("def f(a)", "def f(a)"), None);
+        assert_eq!(arity_preserving_rename("class A(B)", "class A(C)"), None);
+    }
+
+    #[test]
+    fn arity_preserving_rename_ignores_collectors_and_role_changes() {
+        // Renaming `*args`/`**kwargs` collectors strands no caller.
+        assert_eq!(
+            arity_preserving_rename("def f(a, *args, **kwargs)", "def f(a, *rest, **opts)"),
+            None
+        );
+        // A normal rename alongside a collector rename reports only the normal one.
+        assert_eq!(
+            arity_preserving_rename("def f(a, *args)", "def f(b, *rest)"),
+            Some(vec!["a".to_string()])
+        );
+        // Reclassifying a position (normal → `*args`) is structural, not a rename.
+        assert_eq!(arity_preserving_rename("def f(a, b)", "def f(a, *b)"), None);
+    }
+
+    #[test]
+    fn rename_neutral_only_when_every_caller_is_positional_and_shaped() {
+        let renamed = vec!["args".to_string(), "kwargs".to_string()];
+
+        // (a) every caller positional, every consumer a shaped call → neutral.
+        let all_positional = ConsumerCallShapeSummary {
+            all_consumers_shaped_calls: true,
+            ..Default::default()
+        };
+        assert!(rename_is_runtime_neutral_for_consumers(
+            &renamed,
+            &all_positional
+        ));
+
+        // (b) a caller passes a renamed parameter by keyword → breaking.
+        let mut keyword_caller = all_positional.clone();
+        keyword_caller
+            .caller_keyword_names
+            .insert("args".to_string());
+        assert!(!rename_is_runtime_neutral_for_consumers(
+            &renamed,
+            &keyword_caller
+        ));
+
+        // (c) a keyword unrelated to the rename is fine; a renamed one is not.
+        let mut mixed = ConsumerCallShapeSummary {
+            all_consumers_shaped_calls: true,
+            ..Default::default()
+        };
+        mixed.caller_keyword_names.insert("encoding".to_string());
+        assert!(rename_is_runtime_neutral_for_consumers(&renamed, &mixed));
+        mixed.caller_keyword_names.insert("kwargs".to_string());
+        assert!(!rename_is_runtime_neutral_for_consumers(&renamed, &mixed));
+
+        // (d) a `**kwargs` caller has an unknown keyword set → breaking.
+        let var_keyword = ConsumerCallShapeSummary {
+            all_consumers_shaped_calls: true,
+            any_var_keyword_caller: true,
+            ..Default::default()
+        };
+        assert!(!rename_is_runtime_neutral_for_consumers(
+            &renamed,
+            &var_keyword
+        ));
+
+        // (f) any consumer without captured shape evidence → breaking.
+        let missing_shape = ConsumerCallShapeSummary {
+            all_consumers_shaped_calls: false,
+            ..Default::default()
+        };
+        assert!(!rename_is_runtime_neutral_for_consumers(
+            &renamed,
+            &missing_shape
+        ));
+
+        // A rename with no consumers at all is vacuously neutral: an empty
+        // real-consumer set is already handled upstream as no downstream risk.
+        let no_consumers = ConsumerCallShapeSummary {
+            all_consumers_shaped_calls: true,
+            ..Default::default()
+        };
+        assert!(rename_is_runtime_neutral_for_consumers(&[], &no_consumers));
     }
 
     #[test]

--- a/crates/kin-review/src/inline.rs
+++ b/crates/kin-review/src/inline.rs
@@ -1616,6 +1616,7 @@ mod tests {
                     consumer_files: vec!["src/x.rs".to_string(), "src/y.rs".to_string()],
                     covering_tests: 1,
                     consumers_migrated_in_diff: 0,
+                    call_shapes: crate::impact::ConsumerCallShapeSummary::default(),
                 },
                 EntityImpact {
                     entity_id: b_new.id,
@@ -1625,6 +1626,7 @@ mod tests {
                     consumer_files: vec!["src/x.rs".to_string(), "src/y.rs".to_string()],
                     covering_tests: 1,
                     consumers_migrated_in_diff: 0,
+                    call_shapes: crate::impact::ConsumerCallShapeSummary::default(),
                 },
             ],
             ..Default::default()
@@ -1694,6 +1696,7 @@ mod tests {
                 consumer_files: vec!["src/a.rs".to_string(), "src/b.rs".to_string()],
                 covering_tests: 1,
                 consumers_migrated_in_diff: 0,
+                call_shapes: crate::impact::ConsumerCallShapeSummary::default(),
             }],
             ..Default::default()
         }

--- a/crates/kin-review/src/inline.rs
+++ b/crates/kin-review/src/inline.rs
@@ -9,7 +9,7 @@ use kin_model::Hash256;
 use serde::{Deserialize, Serialize};
 
 use crate::diff::{EntityChangeKind, SemanticDiff};
-use crate::impact::ImpactReport;
+use crate::impact::{ConsumerCallShapeSummary, ImpactReport};
 
 const COMMAND_EFFECT_CONTRACT_KEY: &str = "command_effect_contract";
 
@@ -309,24 +309,6 @@ pub fn arity_preserving_rename(old: &str, new: &str) -> Option<Vec<String>> {
     } else {
         Some(renamed)
     }
-}
-
-/// How a changed callable's graph-known consumers invoke it, distilled from the
-/// inbound `Calls` edges' argument-shape evidence over the same real-consumer
-/// set that drives the breaking decision. Lets an arity-preserving rename be
-/// judged against actual call sites instead of assumed keyword usage.
-#[derive(Debug, Clone, Default)]
-pub struct ConsumerCallShapeSummary {
-    /// Union of keyword-argument names any inbound call site passes.
-    pub caller_keyword_names: std::collections::BTreeSet<String>,
-    /// Some call site forwards `**mapping`, so its keyword set is not
-    /// statically known — it could carry any renamed parameter.
-    pub any_var_keyword_caller: bool,
-    /// Every counted consumer is a `Calls` edge carrying argument-shape
-    /// evidence. False when a consumer is a non-call edge, or a call whose
-    /// shape was not captured (older snapshot, unresolved, or a language that
-    /// does not emit shapes) — either way a rename cannot be proven safe.
-    pub all_consumers_shaped_calls: bool,
 }
 
 /// True when an arity-preserving rename of `renamed_old_names` strands no
@@ -665,24 +647,48 @@ fn collect_modified_comments(
         && old.signature != new.signature
         && !signature_runtime_neutral(&old.signature, &new.signature)
     {
+        // An arity-preserving parameter rename cannot break a caller that
+        // passes the renamed parameter positionally. When the graph-known call
+        // sites prove every external consumer is a shaped positional call — no
+        // keyword use of a renamed name, no `**kwargs`, no unshaped consumer —
+        // the rename is runtime-neutral for those consumers: the signature
+        // change is still recorded as evidence, but it is not a blocking break.
+        let rename_is_neutral = consumer_count > 0
+            && match arity_preserving_rename(&old.signature, &new.signature) {
+                Some(renamed) => {
+                    let summary = per_entity
+                        .map(|e| e.call_shapes.clone())
+                        .unwrap_or_default();
+                    rename_is_runtime_neutral_for_consumers(&renamed, &summary)
+                }
+                None => false,
+            };
+
         comments.push(InlineComment {
             file: span.file.to_string(),
             start_line: span.start_line,
             end_line: span.end_line,
             kind: InlineCommentKind::SignatureChange,
-            message: format!(
-                "Signature changed: `{}` → `{}`",
-                old.signature, new.signature,
-            ),
+            message: if rename_is_neutral {
+                format!(
+                    "Signature changed: `{}` → `{}` (parameter rename; all {} graph-known call site(s) pass positionally — no runtime break)",
+                    old.signature, new.signature, consumer_count,
+                )
+            } else {
+                format!("Signature changed: `{}` → `{}`", old.signature, new.signature)
+            },
         });
 
         // Breaking only when THIS entity has EXTERNAL non-test consumers to
-        // break. Test-only consumers are covering evidence, not a broken
-        // contract. Consumers that were themselves modified in this diff are
-        // excluded from `consumer_count`; when they are the ONLY consumers the
-        // change is a coherent in-diff migration — reported as visible evidence
-        // but not a blocking break.
-        if consumer_count > 0 {
+        // break. A rename proven runtime-neutral by its call sites strands none
+        // of them, so it emits no blocking finding. Test-only consumers are
+        // covering evidence, not a broken contract. Consumers that were
+        // themselves modified in this diff are excluded from `consumer_count`;
+        // when they are the ONLY consumers the change is a coherent in-diff
+        // migration — reported as visible evidence but not a blocking break.
+        if rename_is_neutral {
+            // Proven safe by call-site shapes; the signature evidence above stands.
+        } else if consumer_count > 0 {
             comments.push(InlineComment {
                 file: span.file.to_string(),
                 start_line: span.start_line,
@@ -1049,6 +1055,7 @@ mod tests {
                 consumer_files: vec!["src/client.rs".to_string()],
                 covering_tests: 0,
                 consumers_migrated_in_diff: 0,
+                call_shapes: crate::impact::ConsumerCallShapeSummary::default(),
             }],
             ..Default::default()
         };
@@ -1100,6 +1107,7 @@ mod tests {
                     consumer_files: vec![],
                     covering_tests: 0,
                     consumers_migrated_in_diff: 0,
+                    call_shapes: crate::impact::ConsumerCallShapeSummary::default(),
                 },
                 EntityImpact {
                     entity_id: b.id,
@@ -1109,6 +1117,7 @@ mod tests {
                     consumer_files: vec!["src/client.rs".to_string()],
                     covering_tests: 0,
                     consumers_migrated_in_diff: 0,
+                    call_shapes: crate::impact::ConsumerCallShapeSummary::default(),
                 },
             ],
             ..Default::default()
@@ -1156,6 +1165,7 @@ mod tests {
                 consumer_files: vec![],
                 covering_tests: 1,
                 consumers_migrated_in_diff: 0,
+                call_shapes: crate::impact::ConsumerCallShapeSummary::default(),
             }],
             ..Default::default()
         };
@@ -1205,6 +1215,7 @@ mod tests {
                 consumer_files: vec![],
                 covering_tests: 0,
                 consumers_migrated_in_diff: 2,
+                call_shapes: crate::impact::ConsumerCallShapeSummary::default(),
             }],
             ..Default::default()
         };
@@ -1255,6 +1266,7 @@ mod tests {
                 consumer_files: vec!["src/client.rs".to_string()],
                 covering_tests: 0,
                 consumers_migrated_in_diff: 2,
+                call_shapes: crate::impact::ConsumerCallShapeSummary::default(),
             }],
             ..Default::default()
         };
@@ -1314,6 +1326,7 @@ mod tests {
                     consumer_files: vec![],
                     covering_tests: 1,
                     consumers_migrated_in_diff: 0,
+                    call_shapes: crate::impact::ConsumerCallShapeSummary::default(),
                 },
                 EntityImpact {
                     entity_id: uncovered.id,
@@ -1323,6 +1336,7 @@ mod tests {
                     consumer_files: vec![],
                     covering_tests: 0,
                     consumers_migrated_in_diff: 0,
+                    call_shapes: crate::impact::ConsumerCallShapeSummary::default(),
                 },
             ],
             ..Default::default()
@@ -1416,6 +1430,7 @@ mod tests {
                 consumer_files: vec![],
                 covering_tests: 1,
                 consumers_migrated_in_diff: 0,
+                call_shapes: crate::impact::ConsumerCallShapeSummary::default(),
             }],
             ..Default::default()
         };
@@ -1459,6 +1474,7 @@ mod tests {
                 consumer_files: vec!["src/a.rs".to_string(), "src/b.rs".to_string()],
                 covering_tests: 1,
                 consumers_migrated_in_diff: 0,
+                call_shapes: crate::impact::ConsumerCallShapeSummary::default(),
             }],
             ..Default::default()
         };
@@ -1711,6 +1727,7 @@ mod tests {
                 consumer_files: vec!["src/a.rs".to_string(), "src/b.rs".to_string()],
                 covering_tests: 1,
                 consumers_migrated_in_diff: 0,
+                call_shapes: crate::impact::ConsumerCallShapeSummary::default(),
             }],
             ..Default::default()
         };
@@ -1732,6 +1749,7 @@ mod tests {
                 consumer_files: vec!["src/a.rs".to_string(), "src/b.rs".to_string()],
                 covering_tests: 0,
                 consumers_migrated_in_diff: 0,
+                call_shapes: crate::impact::ConsumerCallShapeSummary::default(),
             }],
             ..Default::default()
         };
@@ -1760,6 +1778,7 @@ mod tests {
                 consumer_files: vec!["src/a.rs".to_string(), "src/b.rs".to_string()],
                 covering_tests: 1,
                 consumers_migrated_in_diff: 0,
+                call_shapes: crate::impact::ConsumerCallShapeSummary::default(),
             }],
             ..Default::default()
         };
@@ -2075,6 +2094,7 @@ mod tests {
                 consumer_files: vec!["src/a.rs".to_string()],
                 covering_tests: 0,
                 consumers_migrated_in_diff: 0,
+                call_shapes: crate::impact::ConsumerCallShapeSummary::default(),
             }],
             ..Default::default()
         };
@@ -2122,6 +2142,7 @@ mod tests {
                 ],
                 covering_tests: 0,
                 consumers_migrated_in_diff: 0,
+                call_shapes: crate::impact::ConsumerCallShapeSummary::default(),
             }],
             ..Default::default()
         };
@@ -2194,6 +2215,7 @@ mod tests {
                 consumer_files: vec!["src/shared.rs".to_string()],
                 covering_tests: 0,
                 consumers_migrated_in_diff: 0,
+                call_shapes: crate::impact::ConsumerCallShapeSummary::default(),
             }],
             ..Default::default()
         };
@@ -2245,6 +2267,7 @@ mod tests {
                 ],
                 covering_tests: 0,
                 consumers_migrated_in_diff: 0,
+                call_shapes: crate::impact::ConsumerCallShapeSummary::default(),
             }],
             ..Default::default()
         };
@@ -2285,6 +2308,7 @@ mod tests {
                 consumer_files: vec!["src/only.rs".to_string()],
                 covering_tests: 0,
                 consumers_migrated_in_diff: 0,
+                call_shapes: crate::impact::ConsumerCallShapeSummary::default(),
             }],
             ..Default::default()
         };
@@ -2318,6 +2342,7 @@ mod tests {
                 consumer_files: vec!["src/a.rs".to_string(), "src/b.rs".to_string()],
                 covering_tests: 0,
                 consumers_migrated_in_diff: 0,
+                call_shapes: crate::impact::ConsumerCallShapeSummary::default(),
             }],
             ..Default::default()
         };

--- a/crates/kin-review/src/shadow.rs
+++ b/crates/kin-review/src/shadow.rs
@@ -1938,6 +1938,7 @@ mod tests {
                             consumer_files: vec!["src/consumer.rs".to_string()],
                             covering_tests: 0,
                             consumers_migrated_in_diff: 0,
+                            call_shapes: crate::impact::ConsumerCallShapeSummary::default(),
                         })
                         .collect(),
                     ..Default::default()
@@ -2458,6 +2459,7 @@ mod tests {
                     consumer_files: vec!["src/consumer.rs".to_string()],
                     covering_tests: 0,
                     consumers_migrated_in_diff: 0,
+                    call_shapes: crate::impact::ConsumerCallShapeSummary::default(),
                 }],
                 ..Default::default()
             },
@@ -2556,6 +2558,7 @@ mod tests {
                     consumer_files: vec![],
                     covering_tests: 0,
                     consumers_migrated_in_diff: 0,
+                    call_shapes: crate::impact::ConsumerCallShapeSummary::default(),
                 }],
                 ..Default::default()
             },
@@ -3164,6 +3167,7 @@ mod tests {
                     consumer_files: vec!["src/consumer.rs".to_string()],
                     covering_tests: 0,
                     consumers_migrated_in_diff: 0,
+                    call_shapes: crate::impact::ConsumerCallShapeSummary::default(),
                 }],
                 ..Default::default()
             },


### PR DESCRIPTION
Teaches the review gate to tell a positional caller (unaffected by a parameter rename) from a keyword caller (which a rename strands), so an arity-preserving Python rename whose every graph-known call site passes positionally is runtime-neutral for those consumers instead of a false breaking block. Mirrors the cdc7e13067 `Testdir._makefile` case.

## The chain (parse → link → persist → review)
- **parser** (`ca9c35f3`): `extract_call_arg_shape` reads each `call` node's own argument list into `CallArgShape` (positional count, sorted/deduped keyword names, `*args`/`**kwargs` flags); populated onto `ExtractedRelation.call_shape` for Python body calls. Uses the kin-parser `CallArgShape` seam — **CI-green standalone**.
- **review** (`a4407a19`, `c153008c`): impact analysis distills the inbound `Calls` edges' shapes into `EntityImpact.call_shapes`; the signature-change gate downgrades a proven-safe arity-preserving rename from `Breaking` to a non-blocking `SignatureChange`. Any keyword use of a renamed name, any `**kwargs` caller, any unshaped/non-call consumer, or a genuine arity change stays breaking. In-diff migration path unchanged.
- **linker** (`b4dc345b`): persists each resolved `Calls` edge's shape onto `RelationEvidence.call_shape`, converting the parser type to the graph-model mirror at both write sites (`make_relation`, `resolve_relations`).
- **e2e** (`06f31446`): fresh mini-graph through the real parser + linker + graph + review — positional-only rename non-blocking; keyword and `**kwargs` callers still breaking; asserts the shape is actually persisted.

## CI-coupling (separable tail)
The parser commit is CI-green against the registry. The review + linker + e2e commits reference `kin_model::CallArgShape` (the storage mirror), so they go CI-green once kin-model publishes — proven now DEV-LOCAL via `[patch.kin]` (kin-parser 220/220, kin-review 175/175, kin-index 205/205, e2e 4/4; clippy + fmt clean).

## Dependencies / sequencing
- **Stacked on** the FIR-1434 branch (`fix/cpp-overload-arity-binding`), which defines the shared `ExtractedRelation.call_shape` + `CallArgShape` seam in kin-parser. Retarget to `main` after 1434 merges.
- **Needs** kin-model PR https://github.com/firelock-ai/kin-model/pull/24 (the `RelationEvidence.call_shape` storage mirror). No publish — rides the combined-candidate assembly.
- `Cargo.lock` unchanged from base (registry-clean); no path-patch residue.

Linear: https://linear.app/firelock-ai/issue/FIR-1430