### PR TITLE
Smooth Kin native first-run setup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.2.14] - 2026-07-08
+
+First-run setup becomes Kin-native by default for new repos and smoother for agent
+workflows, npm installs, shell sessions, and managed install roots.
+
 ### Added
 
 - Revert-history review channel: shadow review flags revert-shaped changes — an added
@@ -16,6 +21,26 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   bounded window of the base ref's ancestry at review time, and feeds the gate as
   ordinary warning findings; when the base has too little history to scan, the report
   carries an explicit evidence gap instead of a silent pass.
+- Fresh no-Git `kin init` bootstraps managed `AGENTS.md` guidance before the first
+  snapshot so brand-new repositories start Kin-native, with graph truth as authority
+  and Git kept as an optional export path.
+
+### Changed
+
+- `kin setup` and the native installers now prefer `KIN_HOME` for the managed install
+  root while keeping `KIN_DIR` as a compatibility alias; shell hooks, health checks,
+  docs, and the env-var registry all agree on that contract.
+- `kin shell` now exports the same session-coherent daemon/repo/session context used by
+  agent sessions (`KIN_SESSION`, `KIN_SESSION_ID`, `KIN_SESSION_DIR`,
+  `KIN_DAEMON_URL`, and `KIN_REPO_ID`).
+
+### Fixed
+
+- `kin setup` now appends and ledgers the managed-bin PATH block idempotently, and
+  `kin setup status` treats an rc-declared PATH as healthy after shell restart.
+- Setup shim discovery checks the managed `KIN_HOME/lib` before development fallback
+  paths, so cargo-bin launches no longer claim the VFS shim is missing when the
+  installed shim is already in place.
 
 ## [0.2.13] - 2026-07-07
 
@@ -42,17 +67,6 @@ Distribution becomes first-class: Kin installs from npm as `@kinlab/kin`, doctor
 ### Security
 
 - crossbeam-epoch updated to 0.9.20 (RUSTSEC-2026-0204).
-=======
-### Added
-
-- Revert-history review channel: shadow review flags revert-shaped changes — an added
-  entity that restores content removed in the recent past (behavior-fingerprint match),
-  a reintroduction of a recently-removed surface (same name and kind, modified content),
-  and removals of recently-introduced entities. The evidence is temporal, read from a
-  bounded window of the base ref's ancestry at review time, and feeds the gate as
-  ordinary warning findings; when the base has too little history to scan, the report
-  carries an explicit evidence gap instead of a silent pass.
->>>>>>> fbfdd830 (feat(review): revert-history evidence channel for shadow review)
 
 ## [0.2.12] - 2026-07-06
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3039,11 +3039,11 @@ dependencies = [
 
 [[package]]
 name = "kin-buildinfo"
-version = "0.2.13"
+version = "0.2.14"
 
 [[package]]
 name = "kin-cli"
-version = "0.2.13"
+version = "0.2.14"
 dependencies = [
  "age",
  "anyhow",
@@ -3110,7 +3110,7 @@ dependencies = [
 
 [[package]]
 name = "kin-context"
-version = "0.2.13"
+version = "0.2.14"
 dependencies = [
  "kin-blobs",
  "kin-db",
@@ -3126,7 +3126,7 @@ dependencies = [
 
 [[package]]
 name = "kin-core"
-version = "0.2.13"
+version = "0.2.14"
 dependencies = [
  "chrono",
  "directories 5.0.1",
@@ -3150,7 +3150,7 @@ dependencies = [
 
 [[package]]
 name = "kin-daemon"
-version = "0.2.13"
+version = "0.2.14"
 dependencies = [
  "async-stream",
  "axum",
@@ -3239,7 +3239,7 @@ dependencies = [
 
 [[package]]
 name = "kin-git"
-version = "0.2.13"
+version = "0.2.14"
 dependencies = [
  "chrono",
  "gix",
@@ -3257,7 +3257,7 @@ dependencies = [
 
 [[package]]
 name = "kin-index"
-version = "0.2.13"
+version = "0.2.14"
 dependencies = [
  "hex",
  "kin-blobs",
@@ -3303,7 +3303,7 @@ dependencies = [
 
 [[package]]
 name = "kin-integration-tests"
-version = "0.2.13"
+version = "0.2.14"
 dependencies = [
  "kin-blobs",
  "kin-cli",
@@ -3345,7 +3345,7 @@ dependencies = [
 
 [[package]]
 name = "kin-mcp"
-version = "0.2.13"
+version = "0.2.14"
 dependencies = [
  "kin-blobs",
  "kin-context",
@@ -3372,7 +3372,7 @@ dependencies = [
 
 [[package]]
 name = "kin-migrate"
-version = "0.2.13"
+version = "0.2.14"
 dependencies = [
  "chrono",
  "kin-blobs",
@@ -3414,7 +3414,7 @@ dependencies = [
 
 [[package]]
 name = "kin-parser"
-version = "0.2.13"
+version = "0.2.14"
 dependencies = [
  "kin-model",
  "pretty_assertions",
@@ -3443,7 +3443,7 @@ dependencies = [
 
 [[package]]
 name = "kin-projection"
-version = "0.2.13"
+version = "0.2.14"
 dependencies = [
  "kin-blobs",
  "kin-db",
@@ -3458,7 +3458,7 @@ dependencies = [
 
 [[package]]
 name = "kin-ranking"
-version = "0.2.13"
+version = "0.2.14"
 dependencies = [
  "kin-model",
  "serde",
@@ -3467,7 +3467,7 @@ dependencies = [
 
 [[package]]
 name = "kin-reconcile"
-version = "0.2.13"
+version = "0.2.14"
 dependencies = [
  "kin-blobs",
  "kin-db",
@@ -3487,7 +3487,7 @@ dependencies = [
 
 [[package]]
 name = "kin-registry"
-version = "0.2.13"
+version = "0.2.14"
 dependencies = [
  "axum",
  "base64 0.22.1",
@@ -3512,7 +3512,7 @@ dependencies = [
 
 [[package]]
 name = "kin-remote"
-version = "0.2.13"
+version = "0.2.14"
 dependencies = [
  "chrono",
  "kin-model",
@@ -3528,7 +3528,7 @@ dependencies = [
 
 [[package]]
 name = "kin-review"
-version = "0.2.13"
+version = "0.2.14"
 dependencies = [
  "kin-blobs",
  "kin-db",
@@ -3544,7 +3544,7 @@ dependencies = [
 
 [[package]]
 name = "kin-runtime"
-version = "0.2.13"
+version = "0.2.14"
 dependencies = [
  "chrono",
  "hex",
@@ -3576,7 +3576,7 @@ dependencies = [
 
 [[package]]
 name = "kin-semantic-contracts"
-version = "0.2.13"
+version = "0.2.14"
 dependencies = [
  "kin-db",
  "kin-model",
@@ -3591,7 +3591,7 @@ dependencies = [
 
 [[package]]
 name = "kin-spine"
-version = "0.2.13"
+version = "0.2.14"
 dependencies = [
  "chrono",
  "hashbrown 0.15.5",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,7 +27,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.2.13"
+version = "0.2.14"
 edition = "2021"
 license = "Apache-2.0"
 authors = ["Troy Fortin <troy@firelock.ai>"]

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 > **Kin helps teams trust AI-built software before it merges.**
 
 [![License: Apache-2.0](https://img.shields.io/badge/license-Apache--2.0-blue.svg)](LICENSE)
-[![Release](https://img.shields.io/badge/release-v0.2.12-6E56CF.svg)](https://github.com/firelock-ai/kin/releases)
+[![Release](https://img.shields.io/badge/release-v0.2.14-6E56CF.svg)](https://github.com/firelock-ai/kin/releases)
 [![kinlab.ai](https://img.shields.io/badge/hosted-kinlab.ai-111111.svg)](https://kinlab.ai)
 
 AI agents now generate code faster than teams can review it. The hard part is no longer
@@ -37,7 +37,7 @@ real blast radius of a merge is.
 ## Install
 
 Kin ships as native binaries on [GitHub Releases](https://github.com/firelock-ai/kin/releases)
-(currently **v0.2.12**) for five targets: macOS (Apple Silicon and Intel), Linux (x86_64 and
+(currently **v0.2.14**) for five targets: macOS (Apple Silicon and Intel), Linux (x86_64 and
 aarch64, static musl), and Windows (x86_64 — a limited, work-in-progress build; see below).
 
 **Direct download.** Grab the archive for your platform, verify its checksum, and extract.
@@ -45,8 +45,8 @@ The release publishes a `.sha256` next to every archive.
 
 ```sh
 # Apple Silicon macOS shown; swap in your platform's archive name.
-curl -fsSLO https://github.com/firelock-ai/kin/releases/download/v0.2.12/kin-macos-aarch64.tar.gz
-curl -fsSLO https://github.com/firelock-ai/kin/releases/download/v0.2.12/kin-macos-aarch64.tar.gz.sha256
+curl -fsSLO https://github.com/firelock-ai/kin/releases/download/v0.2.14/kin-macos-aarch64.tar.gz
+curl -fsSLO https://github.com/firelock-ai/kin/releases/download/v0.2.14/kin-macos-aarch64.tar.gz.sha256
 shasum -a 256 -c kin-macos-aarch64.tar.gz.sha256
 tar xzf kin-macos-aarch64.tar.gz      # contains the `kin` and `kin-daemon` binaries
 ```
@@ -67,12 +67,13 @@ Windows build is a limited, vector-free convenience binary with no filesystem pr
 the complete, vector-enabled Kin, install under WSL2 — see
 [docs/windows-wsl2.md](docs/windows-wsl2.md).
 
-**For AI agents.** The MCP server that exposes Kin's tools to assistants is published on npm
-as [`@kinlab/kin-mcp`](https://www.npmjs.com/package/@kinlab/kin-mcp) (**0.2.12**). You
-normally don't install it by hand — `kin setup` wires it into every detected agent for you.
+**For AI agents.** `kin setup --intent agent` wires Kin's built-in MCP server into every
+detected assistant with the curated `agent-default` tool profile. npm users can install the
+canonical launcher with `npm install -g @kinlab/kin` (**0.2.14**) and run the same setup
+command; the older `@kinlab/kin-mcp` package remains as a compatibility wrapper.
 
 See [docs/quickstart.md](docs/quickstart.md) for installer environment variables
-(`KIN_VERSION`, `KIN_DIR`, `KIN_NO_SETUP`, `KIN_BASE_URL`) and daemon/runtime configuration.
+(`KIN_VERSION`, `KIN_HOME`, `KIN_DIR`, `KIN_NO_SETUP`, `KIN_BASE_URL`) and daemon/runtime configuration.
 
 ---
 
@@ -83,8 +84,8 @@ With `kin` on your PATH:
 ```sh
 kin setup                            # wire Kin's MCP tools into your AI agents
                                      #   (detects Claude Code, Cursor, Codex, Gemini, Windsurf)
-kin init                             # build the semantic graph over your repo
-                                     #   (coexists with Git; imports recent history by default)
+kin init                             # new no-Git folders become Kin-native by default;
+                                     # existing Git repos import recent history by default
 kin locate "webhook retries twice"   # find the entities/files behind an issue
 kin refs charge_customer             # who calls, imports, or references this entity
 kin review shadow main..HEAD         # report-only merge-gate verdict:

--- a/crates/kin-cli/src/commands/health.rs
+++ b/crates/kin-cli/src/commands/health.rs
@@ -521,25 +521,36 @@ fn check_shell_path() -> HealthCheck {
     let hook_installed = hook_path.exists();
 
     let rc_path = shell_rc(shell).ok();
-    let rc_sources = rc_path
+    let rc_content = rc_path
         .as_ref()
-        .map(|rc| {
-            std::fs::read_to_string(rc)
-                .map(|c| c.contains("kin-vfs"))
-                .unwrap_or(false)
-        })
-        .unwrap_or(false);
+        .and_then(|rc| std::fs::read_to_string(rc).ok())
+        .unwrap_or_default();
+    let rc_sources = rc_content.contains("kin-vfs");
+    let bin_display = bin_dir.to_string_lossy();
+    let rc_sets_path = rc_content.contains(bin_display.as_ref())
+        || rc_content.contains(".kin/bin")
+        || rc_content.contains("kin/bin");
 
     let rc_display = rc_path
         .as_ref()
         .map(|p| p.display().to_string())
         .unwrap_or_else(|| "<unknown>".to_string());
 
-    if hook_installed && rc_sources {
-        let detail = if on_path {
-            format!("{shell} hook installed and sourced from {rc_display}; ~/.kin/bin on PATH")
-        } else {
-            format!("{shell} hook installed and sourced from {rc_display}")
+    if hook_installed && rc_sources && (on_path || rc_sets_path) {
+        let detail = match (on_path, rc_sets_path) {
+            (true, _) => {
+                format!(
+                    "{shell} hook installed and sourced from {rc_display}; {} on PATH",
+                    bin_dir.display()
+                )
+            }
+            (false, true) => {
+                format!(
+                    "{shell} hook installed and sourced from {rc_display}; {} will be on PATH after shell restart",
+                    bin_dir.display()
+                )
+            }
+            (false, false) => unreachable!(),
         };
         HealthCheck::new(
             "shell_path",
@@ -555,6 +566,12 @@ fn check_shell_path() -> HealthCheck {
         }
         if !rc_sources {
             missing.push(format!("{rc_display} does not source the kin-vfs hook"));
+        }
+        if !on_path && !rc_sets_path {
+            missing.push(format!(
+                "{rc_display} does not add {} to PATH",
+                bin_dir.display()
+            ));
         }
         HealthCheck::new(
             "shell_path",
@@ -986,6 +1003,36 @@ fn check_retrieval_profile() -> HealthCheck {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use serial_test::serial;
+    use std::ffi::{OsStr, OsString};
+
+    struct EnvGuard {
+        key: &'static str,
+        previous: Option<OsString>,
+    }
+
+    impl EnvGuard {
+        fn set(key: &'static str, value: impl AsRef<OsStr>) -> Self {
+            let previous = env::var_os(key);
+            env::set_var(key, value.as_ref());
+            Self { key, previous }
+        }
+
+        fn remove(key: &'static str) -> Self {
+            let previous = env::var_os(key);
+            env::remove_var(key);
+            Self { key, previous }
+        }
+    }
+
+    impl Drop for EnvGuard {
+        fn drop(&mut self) {
+            match &self.previous {
+                Some(value) => env::set_var(self.key, value),
+                None => env::remove_var(self.key),
+            }
+        }
+    }
 
     fn write_file(path: &Path, bytes: &[u8]) {
         use std::io::Write;
@@ -1080,6 +1127,52 @@ mod tests {
         assert!(json.contains("\"platform\""));
         assert!(json.contains("\"healthy\""));
         assert!(json.contains("\"retrieval_profile\""));
+    }
+
+    #[test]
+    #[serial]
+    fn shell_path_is_healthy_when_rc_declares_path_for_next_shell() {
+        let tmp = tempfile::tempdir().unwrap();
+        let home = tmp.path().join("home");
+        let kin_home = tmp.path().join("kin-home");
+        let hook_dir = kin_home.join("shell");
+        std::fs::create_dir_all(&home).unwrap();
+        std::fs::create_dir_all(&hook_dir).unwrap();
+
+        let hook = hook_dir.join(hook_filename("zsh"));
+        std::fs::write(&hook, "# kin-vfs test hook\n").unwrap();
+        std::fs::write(
+            home.join(".zshrc"),
+            format!(
+                "source \"{}\"\nexport PATH=\"{}:$PATH\"\n",
+                hook.display(),
+                kin_home.join("bin").display()
+            ),
+        )
+        .unwrap();
+
+        let _home = EnvGuard::set("HOME", &home);
+        let _kin_home = EnvGuard::set("KIN_HOME", &kin_home);
+        let _kin_dir = EnvGuard::remove("KIN_DIR");
+        let _shell = EnvGuard::set("SHELL", "/bin/zsh");
+        let _ps_module_path = EnvGuard::remove("PSModulePath");
+        let _ps_version_table = EnvGuard::remove("PSVersionTable");
+        let _profile = EnvGuard::remove("PROFILE");
+        let _path = EnvGuard::set("PATH", "/usr/bin");
+
+        let check = check_shell_path();
+        assert_eq!(check.id, "shell_path");
+        assert!(
+            matches!(check.status, HealthStatus::Healthy),
+            "rc-declared Kin PATH should be healthy after install; got {:?}: {}",
+            check.status,
+            check.detail
+        );
+        assert!(
+            check.detail.contains("after shell restart"),
+            "detail should explain why the current process PATH can lag: {}",
+            check.detail
+        );
     }
 
     fn check_with(id: &str, status: HealthStatus) -> HealthCheck {

--- a/crates/kin-cli/src/commands/init.rs
+++ b/crates/kin-cli/src/commands/init.rs
@@ -422,6 +422,50 @@ fn read_git_head(dir: &Path) -> Option<String> {
     None
 }
 
+fn bootstrap_fresh_native_agent_doc(dir: &Path) -> Result<bool> {
+    fs::create_dir_all(dir)
+        .with_context(|| format!("failed to create repository directory {}", dir.display()))?;
+    let target = kin_core::ManagedDocTarget {
+        path: "AGENTS.md".into(),
+        enabled: true,
+        sections: vec![
+            "summary".into(),
+            "kin-first".into(),
+            "conventions".into(),
+            "verification".into(),
+        ],
+    };
+    let managed = kin_core::generate_managed_content(&target, &kin_core::RepoSummary::default());
+    let result = kin_core::sync_doc(&dir.join("AGENTS.md"), &managed)?;
+    Ok(result.created || result.updated)
+}
+
+fn save_fresh_native_agent_config(layout: &kin_core::KinLayout) -> Result<()> {
+    let config = kin_core::ManagedDocConfig::default();
+    config.save(layout)?;
+    Ok(())
+}
+
+fn print_fresh_native_next_steps(layout: &kin_core::KinLayout, agent_doc_changed: bool) {
+    println!();
+    println!("Fresh Kin-native repository ready.");
+    if agent_doc_changed {
+        println!(
+            "  Agent guide: {}",
+            layout.working_dir().join("AGENTS.md").display()
+        );
+    } else {
+        println!(
+            "  Agent guide: {} (managed block already current)",
+            layout.working_dir().join("AGENTS.md").display()
+        );
+    }
+    println!("  Code with Kin: kin with --session codex -- \"build the first feature\"");
+    println!("  Run checks: kin exec -- <command>");
+    println!("  Commit graph truth: kin commit -m \"Create initial version\"");
+    println!("  Git escape hatch: kin git export --output <path>");
+}
+
 pub async fn run(
     path: Option<String>,
     json: bool,
@@ -436,6 +480,13 @@ pub async fn run(
         .unwrap_or_else(|| std::env::current_dir().expect("cannot determine current directory"));
 
     let is_git_repo = dir.join(".git").exists();
+    let kin_dir = dir.join(".kin");
+    let fresh_native_init = !is_git_repo && !kin_dir.exists();
+    let agent_doc_bootstrapped = if fresh_native_init {
+        bootstrap_fresh_native_agent_doc(&dir)?
+    } else {
+        false
+    };
     if is_git_repo && !json && !force {
         eprintln!(
             "Detected Git repository. Bootstrapping current state as semantic truth.\n\
@@ -459,7 +510,6 @@ pub async fn run(
     let (tmp_snapshot, snapshot_manifest) = snapshot_repo(&dir, force)?;
     phase!("snapshot_repo");
 
-    let kin_dir = dir.join(".kin");
     let is_warm = kin_dir.exists();
     let (layout, snap, blob_store, genesis_id) = if is_warm {
         let layout = kin_core::KinLayout::discover(&dir)
@@ -500,6 +550,9 @@ pub async fn run(
         }
         (layout, snap, blob_store, result.genesis_id)
     };
+    if fresh_native_init {
+        save_fresh_native_agent_config(&layout)?;
+    }
     phase!("kin_core::init");
 
     let all_files = collect_source_files(&tmp_snapshot)?;
@@ -961,6 +1014,8 @@ pub async fn run(
                 summary: init_summary,
             })?
         );
+    } else if fresh_native_init {
+        print_fresh_native_next_steps(&layout, agent_doc_bootstrapped);
     }
 
     Ok(())
@@ -6230,6 +6285,12 @@ func prCheckout(cmd *cobra.Command, args []string) error {
             .collect()
     }
 
+    fn repo_truth_fixture_with_agent_doc(root: &Path) -> BTreeSet<String> {
+        let mut paths = repo_truth_fixture(root);
+        paths.insert("AGENTS.md".to_string());
+        paths
+    }
+
     fn tracked_graph_paths(graph: &kin_db::InMemoryGraph) -> BTreeSet<String> {
         let mut tracked = BTreeSet::new();
 
@@ -6271,10 +6332,20 @@ func prCheckout(cmd *cobra.Command, args []string) error {
 
         assert_eq!(graph.indexed_file_paths().len(), expected_paths.len());
         // Swift is an entity-source language, so docs/guide.swift is fully
-        // indexed rather than shallow-tracked — no fixture file is shallow.
+        // indexed rather than shallow-tracked. Fresh native init also writes
+        // AGENTS.md before the first snapshot, so it is graph-tracked as
+        // repo-owned guidance, not as `.kin` control-plane state.
+        let expected_opaque_artifacts = if expected_paths.contains("AGENTS.md") {
+            2
+        } else {
+            1
+        };
         assert_eq!(graph.list_shallow_files().unwrap().len(), 0);
         assert_eq!(graph.list_structured_artifacts().unwrap().len(), 1);
-        assert_eq!(graph.list_opaque_artifacts().unwrap().len(), 1);
+        assert_eq!(
+            graph.list_opaque_artifacts().unwrap().len(),
+            expected_opaque_artifacts
+        );
     }
 
     fn assert_makefile_is_text_searchable(graph: &kin_db::InMemoryGraph) {
@@ -6655,7 +6726,7 @@ func prCheckout(cmd *cobra.Command, args []string) error {
     async fn run_keeps_control_plane_paths_out_of_graph_truth_on_cold_init() {
         let repo_dir = tempfile::tempdir().unwrap();
         let home_dir = tempfile::tempdir().unwrap();
-        let expected_paths = repo_truth_fixture(repo_dir.path());
+        let expected_paths = repo_truth_fixture_with_agent_doc(repo_dir.path());
 
         let _home_guard = EnvVarGuard::set("HOME", home_dir.path());
         let _cache_guard = EnvVarGuard::remove("KIN_INIT_CACHE_DIR");
@@ -6687,7 +6758,7 @@ func prCheckout(cmd *cobra.Command, args []string) error {
     async fn run_ignores_daemon_bootstrap_when_initializing_repo() {
         let repo_dir = tempfile::tempdir().unwrap();
         let home_dir = tempfile::tempdir().unwrap();
-        let expected_paths = repo_truth_fixture(repo_dir.path());
+        let expected_paths = repo_truth_fixture_with_agent_doc(repo_dir.path());
 
         let daemon_graph = kin_db::InMemoryGraph::new();
         daemon_graph.set_file_hash(".kin/snapshot/manifest.json", [5; 32]);

--- a/crates/kin-cli/src/commands/setup.rs
+++ b/crates/kin-cli/src/commands/setup.rs
@@ -39,7 +39,8 @@ _kin_vfs_find_workspace() {
 
 _kin_vfs_shim_path() {
     local lib
-    local kin_lib="$HOME/.kin/lib"
+    local kin_home="${KIN_HOME:-${KIN_DIR:-$HOME/.kin}}"
+    local kin_lib="$kin_home/lib"
     case "$(uname -s)" in
         Darwin) lib="$kin_lib/libkin_vfs_shim.dylib" ;;
         Linux)  lib="$kin_lib/libkin_vfs_shim.so" ;;
@@ -167,7 +168,8 @@ _kin_vfs_find_workspace() {
 
 _kin_vfs_shim_path() {
     local lib
-    local kin_lib="$HOME/.kin/lib"
+    local kin_home="${KIN_HOME:-${KIN_DIR:-$HOME/.kin}}"
+    local kin_lib="$kin_home/lib"
     case "$(uname -s)" in
         Darwin) lib="$kin_lib/libkin_vfs_shim.dylib" ;;
         Linux)  lib="$kin_lib/libkin_vfs_shim.so" ;;
@@ -383,7 +385,14 @@ function _kin_vfs_activate
         disown
     end
 
-    set -l shim "$HOME/.kin/lib/libkin_vfs_shim"
+    set -l kin_home "$HOME/.kin"
+    if set -q KIN_DIR
+        set kin_home $KIN_DIR
+    end
+    if set -q KIN_HOME
+        set kin_home $KIN_HOME
+    end
+    set -l shim "$kin_home/lib/libkin_vfs_shim"
     switch (uname -s)
         case Darwin
             set shim "$shim.dylib"
@@ -526,6 +535,13 @@ fn home_dir() -> Result<PathBuf> {
 }
 
 pub(crate) fn kin_dir() -> Result<PathBuf> {
+    for key in ["KIN_HOME", "KIN_DIR"] {
+        if let Some(value) = env::var_os(key) {
+            if !value.is_empty() {
+                return Ok(PathBuf::from(value));
+            }
+        }
+    }
     Ok(home_dir()?.join(".kin"))
 }
 
@@ -582,6 +598,13 @@ fn copy_shim(src: &Path, dest: &Path) -> Result<ShimCopy> {
 
 fn find_shim() -> Option<PathBuf> {
     let name = shim_filename();
+
+    if let Ok(kin_home) = kin_dir() {
+        let candidate = kin_home.join("lib").join(name);
+        if is_usable_shim(&candidate) {
+            return Some(candidate);
+        }
+    }
 
     if let Ok(exe) = env::current_exe() {
         if let Some(dir) = exe.parent() {
@@ -1094,8 +1117,40 @@ fn rc_integration_block(source_line: &str) -> String {
     format!("\n# kin-vfs shell integration\n{source_line}\n")
 }
 
+fn shell_path_separator() -> &'static str {
+    if cfg!(target_os = "windows") {
+        ";"
+    } else {
+        ":"
+    }
+}
+
+fn rc_path_line(shell_name: &str, bin_dir: &Path) -> String {
+    match shell_name {
+        "fish" => format!("fish_add_path {}", bin_dir.display()),
+        "powershell" => {
+            format!(
+                "$env:PATH = \"{}{}$env:PATH\"",
+                bin_dir.display(),
+                shell_path_separator()
+            )
+        }
+        _ => format!("export PATH=\"{}:$PATH\"", bin_dir.display()),
+    }
+}
+
+fn rc_path_block(shell_name: &str, bin_dir: &Path) -> String {
+    format!("\n# Kin\n{}\n", rc_path_line(shell_name, bin_dir))
+}
+
+fn rc_declares_kin_bin(content: &str, bin_dir: &Path) -> bool {
+    let bin = bin_dir.to_string_lossy();
+    content.contains(bin.as_ref()) || content.contains(".kin/bin") || content.contains("kin/bin")
+}
+
 fn install_shell_hook(shell_name: &str) -> Result<(PathBuf, String)> {
     let kin_home = kin_dir()?;
+    let bin_dir = kin_home.join("bin");
     let shell_dir = kin_home.join("shell");
     let lib_dir = kin_home.join("lib");
 
@@ -1133,32 +1188,47 @@ fn install_shell_hook(shell_name: &str) -> Result<(PathBuf, String)> {
     let source_line = rc_source_line(shell_name, &hook_file);
 
     let rc_path = shell_rc(shell_name)?;
-    let already_installed = if rc_path.exists() {
-        fs::read_to_string(&rc_path)
-            .map(|c| c.contains("kin-vfs"))
-            .unwrap_or(false)
+    let mut rc_content = if rc_path.exists() {
+        fs::read_to_string(&rc_path)?
     } else {
-        false
+        String::new()
     };
+    let hook_installed = rc_content.contains("kin-vfs");
+    let path_installed = rc_declares_kin_bin(&rc_content, &bin_dir);
 
-    if already_installed {
+    if hook_installed {
         println!(
             "  Shell rc already sources kin-vfs hook: {}",
             rc_path.display()
         );
     } else {
-        let mut rc_content = if rc_path.exists() {
-            fs::read_to_string(&rc_path)?
-        } else {
-            String::new()
-        };
         if !rc_content.ends_with('\n') && !rc_content.is_empty() {
             rc_content.push('\n');
         }
         rc_content.push_str(&rc_integration_block(&source_line));
+        println!("  Appended to {}", rc_path.display());
+    }
+
+    if path_installed {
+        println!("  Shell rc already adds {} to PATH", bin_dir.display());
+    } else {
+        if !rc_content.ends_with('\n') && !rc_content.is_empty() {
+            rc_content.push('\n');
+        }
+        rc_content.push_str(&rc_path_block(shell_name, &bin_dir));
+        println!(
+            "  Added {} to PATH for new shell sessions",
+            bin_dir.display()
+        );
+    }
+
+    if !hook_installed || !path_installed {
+        if let Some(parent) = rc_path.parent() {
+            fs::create_dir_all(parent)
+                .with_context(|| format!("failed to create {}", parent.display()))?;
+        }
         fs::write(&rc_path, &rc_content)
             .with_context(|| format!("failed to update {}", rc_path.display()))?;
-        println!("  Appended to {}", rc_path.display());
     }
 
     Ok((hook_file, source_line))
@@ -1660,8 +1730,22 @@ fn record_setup_ledger(plan: &SetupPlan, shell_name: &str) {
                     ledger.record(LedgerEntry::appended(
                         ArtifactKind::ShellRcLine,
                         shell_name,
-                        rc_path,
+                        rc_path.clone(),
                         block,
+                    ));
+                }
+
+                let bin_dir = kin_home.join("bin");
+                let path_block = rc_path_block(shell_name, &bin_dir);
+                let path_present = fs::read_to_string(&rc_path)
+                    .map(|c| c.contains(&path_block))
+                    .unwrap_or(false);
+                if path_present {
+                    ledger.record(LedgerEntry::appended(
+                        ArtifactKind::ShellPathLine,
+                        format!("{shell_name}-path"),
+                        rc_path,
+                        path_block,
                     ));
                 }
             }
@@ -2225,6 +2309,36 @@ pub fn uninstall(dry_run: bool, force: bool, json: bool) -> Result<()> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use serial_test::serial;
+    use std::ffi::{OsStr, OsString};
+
+    struct EnvGuard {
+        key: &'static str,
+        previous: Option<OsString>,
+    }
+
+    impl EnvGuard {
+        fn set(key: &'static str, value: impl AsRef<OsStr>) -> Self {
+            let previous = env::var_os(key);
+            env::set_var(key, value.as_ref());
+            Self { key, previous }
+        }
+
+        fn remove(key: &'static str) -> Self {
+            let previous = env::var_os(key);
+            env::remove_var(key);
+            Self { key, previous }
+        }
+    }
+
+    impl Drop for EnvGuard {
+        fn drop(&mut self) {
+            match &self.previous {
+                Some(value) => env::set_var(self.key, value),
+                None => env::remove_var(self.key),
+            }
+        }
+    }
 
     fn opts() -> WizardOptions {
         WizardOptions {
@@ -2341,6 +2455,21 @@ mod tests {
     }
 
     #[test]
+    #[serial]
+    fn find_shim_checks_managed_kin_home_lib() {
+        let tmp = tempfile::tempdir().unwrap();
+        let kin_home = tmp.path().join("kin-home");
+        let shim = kin_home.join("lib").join(shim_filename());
+        fs::create_dir_all(shim.parent().unwrap()).unwrap();
+        fs::write(&shim, b"MANAGED_SHIM").unwrap();
+
+        let _kin_home = EnvGuard::set("KIN_HOME", &kin_home);
+        let _kin_dir = EnvGuard::remove("KIN_DIR");
+
+        assert_eq!(find_shim().as_deref(), Some(shim.as_path()));
+    }
+
+    #[test]
     fn zsh_hook_clears_stale_preload_state() {
         assert!(ZSH_HOOK.contains("_kin_vfs_clear_preload"));
         assert!(ZSH_HOOK.contains("_kin_vfs_refresh_preload"));
@@ -2352,6 +2481,83 @@ mod tests {
         assert!(BASH_HOOK.contains("_kin_vfs_clear_preload"));
         assert!(BASH_HOOK.contains("_kin_vfs_refresh_preload"));
         assert!(BASH_HOOK.contains("else\n            _kin_vfs_refresh_preload"));
+    }
+
+    #[test]
+    fn shell_hooks_respect_custom_kin_home() {
+        let posix_home = r#"${KIN_HOME:-${KIN_DIR:-$HOME/.kin}}"#;
+        assert!(ZSH_HOOK.contains(posix_home));
+        assert!(BASH_HOOK.contains(posix_home));
+        assert!(FISH_HOOK.contains("if set -q KIN_DIR"));
+        assert!(FISH_HOOK.contains("if set -q KIN_HOME"));
+        assert!(FISH_HOOK.contains("\"$kin_home/lib/libkin_vfs_shim\""));
+    }
+
+    #[test]
+    fn rc_path_line_uses_shell_appropriate_syntax() {
+        let bin = Path::new("/tmp/kin-home/bin");
+        assert_eq!(
+            rc_path_line("zsh", bin),
+            "export PATH=\"/tmp/kin-home/bin:$PATH\""
+        );
+        assert_eq!(
+            rc_path_line("bash", bin),
+            "export PATH=\"/tmp/kin-home/bin:$PATH\""
+        );
+        assert_eq!(rc_path_line("fish", bin), "fish_add_path /tmp/kin-home/bin");
+        assert!(rc_path_line("powershell", bin).contains("$env:PATH"));
+    }
+
+    #[test]
+    #[serial]
+    fn kin_dir_honors_kin_home_before_kin_dir() {
+        let _kin_home = EnvGuard::remove("KIN_HOME");
+        let _kin_dir = EnvGuard::remove("KIN_DIR");
+        let fallback = PathBuf::from("/tmp/kin-dir-only");
+        let preferred = PathBuf::from("/tmp/kin-home-preferred");
+
+        env::set_var("KIN_DIR", &fallback);
+        assert_eq!(kin_dir().unwrap(), fallback);
+
+        env::set_var("KIN_HOME", &preferred);
+        assert_eq!(kin_dir().unwrap(), preferred);
+    }
+
+    #[test]
+    #[serial]
+    fn install_shell_hook_adds_path_and_hook_blocks_idempotently() {
+        let tmp = tempfile::tempdir().unwrap();
+        let home = tmp.path().join("home");
+        let kin_home = tmp.path().join("kin-home");
+        fs::create_dir_all(&home).unwrap();
+
+        let _home = EnvGuard::set("HOME", &home);
+        let _kin_home = EnvGuard::set("KIN_HOME", &kin_home);
+        let _kin_dir = EnvGuard::remove("KIN_DIR");
+        let _path = EnvGuard::set("PATH", "/usr/bin");
+
+        install_shell_hook("zsh").unwrap();
+        install_shell_hook("zsh").unwrap();
+
+        let rc = fs::read_to_string(home.join(".zshrc")).unwrap();
+        let path_line = rc_path_line("zsh", &kin_home.join("bin"));
+
+        assert_eq!(
+            rc.matches("kin-vfs.zsh").count(),
+            1,
+            "setup must not duplicate the shell hook source line"
+        );
+        assert_eq!(
+            rc.matches(&path_line).count(),
+            1,
+            "setup must not duplicate the Kin PATH line"
+        );
+        assert!(
+            fs::read_to_string(kin_home.join("shell").join("kin-vfs.zsh"))
+                .unwrap()
+                .contains(r#"${KIN_HOME:-${KIN_DIR:-$HOME/.kin}}"#),
+            "installed hook must resolve the active Kin home"
+        );
     }
 
     #[test]

--- a/crates/kin-cli/src/commands/setup_ledger.rs
+++ b/crates/kin-cli/src/commands/setup_ledger.rs
@@ -47,6 +47,9 @@ pub enum ArtifactKind {
     /// The `source <hook>` block Kin appended to a shell rc file. The owned
     /// slice is the appended text captured in [`LedgerEntry::snippet`].
     ShellRcLine,
+    /// The PATH export block Kin appended to a shell rc file so managed
+    /// binaries under `~/.kin/bin` are available in new shells.
+    ShellPathLine,
     /// The VFS shim copied into `~/.kin/lib`. Kin owns the file.
     VfsShim,
     /// The Kin-first discovery block appended to an agent instruction file
@@ -61,7 +64,10 @@ impl ArtifactKind {
     /// Whether the owned slice is a distinct substring appended to a shared file
     /// (rc line, discovery reminder) rather than a whole file or JSON key.
     fn is_appended_marker(self) -> bool {
-        matches!(self, Self::ShellRcLine | Self::DiscoveryReminder)
+        matches!(
+            self,
+            Self::ShellRcLine | Self::ShellPathLine | Self::DiscoveryReminder
+        )
     }
 
     fn label(self) -> &'static str {
@@ -69,6 +75,7 @@ impl ArtifactKind {
             Self::McpConfig => "MCP config",
             Self::ShellHook => "shell hook",
             Self::ShellRcLine => "shell rc line",
+            Self::ShellPathLine => "shell PATH line",
             Self::VfsShim => "VFS shim",
             Self::DiscoveryReminder => "discovery reminder",
             Self::DaemonConfig => "daemon config",
@@ -293,7 +300,9 @@ fn current_owned_fingerprint(entry: &LedgerEntry) -> Option<String> {
             let bytes = fs::read(&entry.path).ok()?;
             Some(sha256_hex(&bytes))
         }
-        ArtifactKind::ShellRcLine | ArtifactKind::DiscoveryReminder => {
+        ArtifactKind::ShellRcLine
+        | ArtifactKind::ShellPathLine
+        | ArtifactKind::DiscoveryReminder => {
             let snippet = entry.snippet.as_ref()?;
             let content = fs::read_to_string(&entry.path).ok()?;
             content
@@ -457,7 +466,9 @@ fn remove_owned_slice(entry: &LedgerEntry) -> Result<String> {
                 .with_context(|| format!("failed to remove {}", entry.path.display()))?;
             Ok(format!("removed {}", entry.path.display()))
         }
-        ArtifactKind::ShellRcLine | ArtifactKind::DiscoveryReminder => {
+        ArtifactKind::ShellRcLine
+        | ArtifactKind::ShellPathLine
+        | ArtifactKind::DiscoveryReminder => {
             let snippet = entry
                 .snippet
                 .as_ref()

--- a/crates/kin-cli/src/commands/shell.rs
+++ b/crates/kin-cli/src/commands/shell.rs
@@ -45,14 +45,24 @@ pub async fn run(
     // discovery commands see live, unreconciled workspace edits.
     let shim_env =
         native_session_shim_env(&layout, &ws.root, restrict_discovery, restrict_filesystem)?;
+    let daemon_url = match std::env::var("KIN_DAEMON_URL")
+        .ok()
+        .filter(|value| !value.trim().is_empty())
+    {
+        Some(url) => url,
+        None => crate::daemon_client::resolve_daemon_url(&layout)
+            .await?
+            .ok_or_else(|| anyhow::anyhow!("kin daemon is required for shell session binding"))?,
+    };
+    let repo_id = super::remote::resolve_repo_id(&layout).ok();
+    let mut launch_env = shell_session_env(session_id, &ws.root, &daemon_url, repo_id.as_deref());
+    launch_env.extend(shim_env);
 
     let shell = std::env::var("SHELL").unwrap_or_else(|_| "bash".into());
 
     let status = std::process::Command::new(&shell)
         .current_dir(&ws.root)
-        .env("KIN_SESSION", session_id.to_string())
-        .env("KIN_SESSION_DIR", ws.root.to_string_lossy().as_ref())
-        .envs(shim_env.iter().map(|(k, v)| (k.as_str(), v.as_str())))
+        .envs(launch_env.iter().map(|(k, v)| (k.as_str(), v.as_str())))
         .stdin(std::process::Stdio::inherit())
         .stdout(std::process::Stdio::inherit())
         .stderr(std::process::Stdio::inherit())
@@ -65,6 +75,27 @@ pub async fn run(
     close_session_after_shell(&layout, &session_dir).await?;
 
     Ok(())
+}
+
+fn shell_session_env(
+    session_id: uuid::Uuid,
+    ws_root: &std::path::Path,
+    daemon_url: &str,
+    repo_id: Option<&str>,
+) -> Vec<(String, String)> {
+    let mut env = vec![
+        ("KIN_SESSION".into(), session_id.to_string()),
+        ("KIN_SESSION_ID".into(), session_id.to_string()),
+        (
+            "KIN_SESSION_DIR".into(),
+            ws_root.to_string_lossy().into_owned(),
+        ),
+        ("KIN_DAEMON_URL".into(), daemon_url.to_string()),
+    ];
+    if let Some(repo_id) = repo_id {
+        env.push(("KIN_REPO_ID".into(), repo_id.to_string()));
+    }
+    env
 }
 
 async fn close_session_after_shell(
@@ -136,9 +167,29 @@ mod tests {
         // Validate that the env var names we use match expected conventions
         let session_id = uuid::Uuid::new_v4();
         let session_str = session_id.to_string();
+        let ws_root = std::path::Path::new("/tmp/test-repo/.kin/runs/session-test");
+        let env = super::shell_session_env(
+            session_id,
+            ws_root,
+            "http://127.0.0.1:4242",
+            Some("repo-uuid"),
+        );
 
         // KIN_SESSION should be a valid UUID string
         assert!(uuid::Uuid::parse_str(&session_str).is_ok());
+        for (key, expected) in [
+            ("KIN_SESSION", session_id.to_string()),
+            ("KIN_SESSION_ID", session_id.to_string()),
+            ("KIN_SESSION_DIR", ws_root.to_string_lossy().into_owned()),
+            ("KIN_DAEMON_URL", "http://127.0.0.1:4242".to_string()),
+            ("KIN_REPO_ID", "repo-uuid".to_string()),
+        ] {
+            assert_eq!(
+                env.iter().find(|(k, _)| k == key).map(|(_, v)| v.as_str()),
+                Some(expected.as_str()),
+                "missing or wrong {key}"
+            );
+        }
 
         // Session dir path construction
         let root = std::path::Path::new("/tmp/test-repo");

--- a/crates/kin-cli/tests/init_json.rs
+++ b/crates/kin-cli/tests/init_json.rs
@@ -242,6 +242,122 @@ fn checkout_branch_and_add_empty_commit(path: &Path, branch: &str) {
 }
 
 #[test]
+fn fresh_native_init_bootstraps_agent_docs_and_next_steps() {
+    let root = tempdir().expect("temp root");
+    let home_dir = root.path().join("home");
+    let repo = root.path().join("native");
+    fs::create_dir_all(&home_dir).expect("create home");
+
+    let output = Command::new(env!("CARGO_BIN_EXE_kin"))
+        .arg("init")
+        .arg(&repo)
+        .args(["--git-history", "off"])
+        .env("HOME", &home_dir)
+        .output()
+        .expect("run fresh native kin init");
+    assert!(
+        output.status.success(),
+        "fresh native kin init failed: stdout={} stderr={}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(stdout.contains("Fresh Kin-native repository ready."));
+    assert!(stdout.contains("kin with --session codex"));
+    assert!(stdout.contains("kin exec -- <command>"));
+    assert!(stdout.contains("kin git export --output <path>"));
+
+    let agents = fs::read_to_string(repo.join("AGENTS.md")).expect("read generated AGENTS.md");
+    assert!(agents.contains("This repository is Kin-native."));
+    assert!(agents.contains("Agent Coding Workflow"));
+    assert!(agents.contains("semantic_locate"));
+    assert!(agents.contains("get_context_pack"));
+    assert!(agents.contains("trace_data_flow"));
+    assert!(agents.contains("kin commit -m \"message\""));
+    assert!(agents.contains("kin git export --output <path>"));
+    assert!(repo.join(".kin/assistant-sync.toml").exists());
+
+    let config = fs::read_to_string(repo.join(".kin/config.toml")).expect("read kin config");
+    assert!(config.contains("mode = \"native\""));
+    assert!(!repo.join(".git").exists());
+}
+
+#[test]
+fn fresh_native_init_json_stays_machine_readable_and_bootstraps_docs() {
+    let root = tempdir().expect("temp root");
+    let home_dir = root.path().join("home");
+    let repo = root.path().join("native-json");
+    fs::create_dir_all(&home_dir).expect("create home");
+
+    let output = Command::new(env!("CARGO_BIN_EXE_kin"))
+        .arg("init")
+        .arg(&repo)
+        .args(["--json", "--git-history", "off"])
+        .env("HOME", &home_dir)
+        .output()
+        .expect("run fresh native kin init --json");
+    assert!(
+        output.status.success(),
+        "fresh native kin init --json failed: stdout={} stderr={}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    let payload: Value =
+        serde_json::from_slice(&output.stdout).expect("fresh native init stdout should be json");
+    assert_eq!(payload["schema"], "kin.init-result.v1");
+    assert_eq!(payload["warm_cache_hit"], false);
+    assert!(payload["total_files"].as_u64().unwrap_or(0) >= 1);
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(!stdout.contains("Fresh Kin-native repository ready."));
+    assert!(!stdout.contains("kin with --session codex"));
+    assert!(repo.join("AGENTS.md").exists());
+    assert!(repo.join(".kin/assistant-sync.toml").exists());
+}
+
+#[test]
+fn git_backed_init_does_not_emit_fresh_native_bootstrap() {
+    let root = tempdir().expect("temp root");
+    let home_dir = root.path().join("home");
+    let repo = root.path().join("git-backed");
+    fs::create_dir_all(&home_dir).expect("create home");
+    fs::create_dir_all(&repo).expect("create repo");
+
+    let init = Command::new("git")
+        .arg("init")
+        .current_dir(&repo)
+        .output()
+        .expect("git init");
+    assert!(
+        init.status.success(),
+        "git init failed: stdout={} stderr={}",
+        String::from_utf8_lossy(&init.stdout),
+        String::from_utf8_lossy(&init.stderr)
+    );
+
+    let output = Command::new(env!("CARGO_BIN_EXE_kin"))
+        .arg("init")
+        .arg(&repo)
+        .args(["--git-history", "off"])
+        .env("HOME", &home_dir)
+        .output()
+        .expect("run git-backed kin init");
+    assert!(
+        output.status.success(),
+        "git-backed kin init failed: stdout={} stderr={}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(!stdout.contains("Fresh Kin-native repository ready."));
+    assert!(!stdout.contains("kin with --session codex"));
+    assert!(!repo.join("AGENTS.md").exists());
+}
+
+#[test]
 fn init_json_reports_warm_cache_hits_for_same_repo_identity() {
     let root = tempdir().expect("temp root");
     let home_dir = root.path().join("home");

--- a/crates/kin-core/src/assistant.rs
+++ b/crates/kin-core/src/assistant.rs
@@ -784,19 +784,26 @@ pub fn generate_assistant_prompt(
     let mut out = String::new();
 
     // Compact benchmark content (shared by both modes)
-    out.push_str("# Kin — Semantic Code Search\n\n");
-    out.push_str("This repository uses Kin for semantic code navigation. ");
-    out.push_str("Use `kin` CLI commands instead of grep/find/cat for code discovery.\n\n");
+    out.push_str("# Kin - Native Semantic Repository\n\n");
+    out.push_str("This repository uses Kin as the semantic system of record. ");
+    out.push_str("The graph is authority; files are the projection and execution surface. ");
+    out.push_str("Use Kin tools instead of grep/find/cat for code discovery.\n\n");
     out.push_str("## Quick Start\n");
-    out.push_str("1. `kin overview --compact` — get codebase orientation\n");
-    out.push_str("2. `kin trace <ExactName> --compact` — resolve one entity and print the focused neighborhood\n");
+    out.push_str("1. MCP: `semantic_locate` to find the right entity or file by meaning\n");
+    out.push_str("2. MCP: `get_context_pack` to load the focused neighborhood\n");
     out.push_str(
-        "3. `kin search <name> --show-body --limit 5` — exact-name lookup with inline body\n",
+        "3. MCP: `trace_data_flow` when lineage or cross-file dependency direction matters\n",
     );
-    out.push_str("4. `kin search <name> --kind function --show-body --limit 5` — narrow by kind when needed\n");
-    out.push_str("5. `kin context <entity>` — get the full token-budgeted context pack\n\n");
+    out.push_str("4. CLI: `kin overview --compact` to get codebase orientation\n");
+    out.push_str("5. CLI: `kin trace <ExactName> --compact` to resolve one entity and print the focused neighborhood\n");
+    out.push_str(
+        "6. CLI: `kin search <name> --show-body --limit 5` for exact-name lookup with inline body\n",
+    );
+    out.push_str("7. CLI: `kin context <entity>` to get the full token-budgeted context pack\n\n");
     out.push_str("## Key Principle\n");
-    out.push_str("Trace semantically first, search semantically second, read files last.\n");
+    out.push_str(
+        "Ask the graph first, read projected files second, and use raw filesystem reads last.\n",
+    );
 
     // Append summary stats if available
     if let Some(s) = summary {
@@ -901,15 +908,23 @@ pub fn generate_bootstrap_docs(_layout: &KinLayout, kind: AssistantKind) -> Stri
 
     let mut out = String::new();
     out.push_str("# Kin-Native Repository\n\n");
-    out.push_str("This repo uses a Kin control root. Start with Kin commands, not broad filesystem discovery.\n\n");
+    out.push_str("This repo uses Kin as the semantic system of record. Start with Kin graph tools, not broad filesystem discovery.\n\n");
     out.push_str("## Workflow\n");
-    out.push_str("1. If the task already names exact symbols/files, start with `kin trace <ExactName> --compact`\n");
+    out.push_str("1. If MCP is connected, start with `semantic_locate` to find the right entity or file by meaning\n");
     out.push_str(
-        "2. Use `kin overview --compact` only for broad architecture/orientation questions\n",
+        "2. Use `get_context_pack` to load the focused neighborhood before reading broad files\n",
     );
-    out.push_str("3. After `kin trace` finds the file, inspect that file directly for local detail before running more Kin queries\n");
-    out.push_str("4. `kin search <ExactName> --kind function --show-body --limit 5` only if trace is too coarse\n");
-    out.push_str("5. `kin context <entity>` for the full pack\n\n");
+    out.push_str(
+        "3. Use `trace_data_flow` when lineage or cross-file dependency direction matters\n",
+    );
+    out.push_str(
+        "4. Use `kin overview --compact` only for broad architecture/orientation questions\n",
+    );
+    out.push_str(
+        "5. If MCP is unavailable, use `kin trace <ExactName> --compact` for exact named symbols\n",
+    );
+    out.push_str("6. `kin search <ExactName> --kind function --show-body --limit 5` only if trace is too coarse\n");
+    out.push_str("7. `kin context <entity>` for the full pack\n\n");
     out.push_str("## Rules\n");
     out.push_str("- Prefer exact names like `parseStrict`, `parse`, or `$MyType`\n");
     out.push_str("- Avoid broad shotgun searches\n");
@@ -1515,7 +1530,10 @@ mod tests {
             None,
         );
 
-        assert!(prompt.contains("# Kin — Semantic Code Search"));
+        assert!(prompt.contains("# Kin - Native Semantic Repository"));
+        assert!(prompt.contains("semantic_locate"));
+        assert!(prompt.contains("get_context_pack"));
+        assert!(prompt.contains("trace_data_flow"));
         assert!(prompt.contains("kin overview --compact"));
         assert!(prompt.contains("kin trace <ExactName>"));
         assert!(prompt.contains("kin search <name> --show-body --limit 5"));
@@ -1566,13 +1584,14 @@ mod tests {
             generate_assistant_prompt(AssistantKind::ClaudeCode, PromptMode::Normal, &layout, None);
 
         // Should contain benchmark content
-        assert!(prompt.contains("# Kin — Semantic Code Search"));
+        assert!(prompt.contains("# Kin - Native Semantic Repository"));
         // Should contain comparison tables
         assert!(prompt.contains("Finding Code (use Kin instead"));
         assert!(prompt.contains("Reading Code (use Kin instead"));
         // Should contain MCP mapping (Claude is MCP-capable)
         assert!(prompt.contains("MCP Tools"));
-        assert!(prompt.contains("semantic_search"));
+        assert!(prompt.contains("semantic_locate"));
+        assert!(prompt.contains("get_context_pack"));
         // Should contain Claude-specific tips
         assert!(prompt.contains("## Claude Code Tips"));
         assert!(prompt.contains("CLAUDE.md is managed by Kin"));
@@ -1681,12 +1700,15 @@ mod tests {
 
         let doc = generate_bootstrap_docs(&layout, AssistantKind::ClaudeCode);
         assert!(doc.contains("Kin-Native Repository"));
+        assert!(doc.contains("semantic_locate"));
+        assert!(doc.contains("get_context_pack"));
+        assert!(doc.contains("trace_data_flow"));
         assert!(doc.contains("kin overview --compact"));
         assert!(doc.contains("kin trace <ExactName>"));
         assert!(doc.contains("kin context <entity>"));
         assert!(doc.contains("## For Claude Code"));
         assert!(doc.contains("claude mcp add kin"));
-        assert!(doc.contains("control root"));
+        assert!(doc.contains("semantic system of record"));
         assert!(doc.contains(".kin/docs/imported/"));
     }
 

--- a/crates/kin-core/src/assistant_sync.rs
+++ b/crates/kin-core/src/assistant_sync.rs
@@ -527,9 +527,19 @@ fn render_kin_first_section(target_path: &str) -> String {
     let mut out = String::new();
 
     out.push_str("## Kin-First Workflow\n\n");
-    out.push_str("This repository uses Kin semantic VCS. Kin indexes every function, class,\n");
-    out.push_str("type, and trait into a graph with cross-file relations. **Use Kin tools\n");
-    out.push_str("instead of raw file operations whenever possible.**\n\n");
+    out.push_str("This repository is Kin-native. Kin's graph-owned semantic truth is the\n");
+    out.push_str("source of authority; ordinary files are the projection and execution\n");
+    out.push_str("surface for tools that still expect a filesystem. Kin indexes every\n");
+    out.push_str("function, class, type, and trait into a graph with cross-file relations.\n");
+    out.push_str("**Use Kin tools instead of raw file operations whenever possible.**\n\n");
+
+    out.push_str("### Agent Coding Workflow\n\n");
+    out.push_str("- Start agent work inside a graph-backed session: `kin with --session codex -- \"task\"`\n");
+    out.push_str("- For direct commands, prefer `kin exec -- <command>` so execution is tied to the Kin repo context\n");
+    out.push_str("- Discover with Kin first: `semantic_locate`, `get_context_pack`, then `trace_data_flow`\n");
+    out.push_str("- Record changes with `kin commit -m \"message\"` after verification passes\n");
+    out.push_str("- Export only when an external Git consumer needs it: `kin git export --output <path>` or `kin git export --in-place`\n");
+    out.push('\n');
 
     out.push_str(&render_comparison_tables());
     out.push_str(&render_quick_reference());
@@ -543,11 +553,11 @@ fn render_kin_first_section(target_path: &str) -> String {
     }
 
     out.push_str("### Key Principle\n\n");
-    out.push_str("**Search semantically first, read files second.** Kin search returns ranked\n");
-    out.push_str("entity definitions with file:line instead of raw text matches, and context\n");
-    out.push_str("packs assemble a focal entity with its callers and dependencies instead of\n");
-    out.push_str("reading whole files. Only fall back to raw file reads when Kin doesn't have\n");
-    out.push_str("what you need.\n");
+    out.push_str("**Ask the graph first, read projected files second.** Kin search returns\n");
+    out.push_str("ranked entity definitions with file:line instead of raw text matches, and\n");
+    out.push_str("context packs assemble a focal entity with its callers and dependencies\n");
+    out.push_str("instead of reading whole files. Only fall back to raw file reads when Kin\n");
+    out.push_str("doesn't have what you need.\n");
     out.push('\n');
 
     out

--- a/crates/kin-core/src/env_registry.rs
+++ b/crates/kin-core/src/env_registry.rs
@@ -142,6 +142,9 @@ impl EnvVarSpec {
 pub const OPERATIONAL: &[EnvVarSpec] = &[
     // ---- validation control ---------------------------------------------------
     EnvVarSpec { name: "KIN_ENV_VALIDATION", kind: Kind::OneOf(&["off", "warn", "strict"]), default: "warn", sensitivity: Sensitivity::Operational, summary: "startup env validation mode: off, warn (default), or strict" },
+    // ---- install / setup root -------------------------------------------------
+    EnvVarSpec { name: "KIN_HOME", kind: Kind::Path, default: "~/.kin", sensitivity: Sensitivity::Operational, summary: "preferred root for the managed Kin install used by the launcher, setup, and shell hooks" },
+    EnvVarSpec { name: "KIN_DIR", kind: Kind::Path, default: "", sensitivity: Sensitivity::Operational, summary: "compatibility alias for the managed Kin install root; KIN_HOME wins when both are set" },
     // ---- correctness / retrieval-affecting ------------------------------------
     EnvVarSpec { name: "KIN_INIT_WARM_CACHE", kind: Kind::Bool, default: "true", sensitivity: Sensitivity::Correctness, summary: "reuse a warm init cache; a cross-store warm cache can depress F1, so an override is loud" },
     EnvVarSpec { name: "KIN_SEMLOC_RERANK", kind: Kind::Bool, default: "false", sensitivity: Sensitivity::Correctness, summary: "enable semantic-locate reranking of daemon locate results" },
@@ -266,6 +269,7 @@ pub const OPERATIONAL: &[EnvVarSpec] = &[
     EnvVarSpec { name: "KIN_BUILD_GRAPH_TIMEOUT_SECS", kind: Kind::Secs, default: "60", sensitivity: Sensitivity::Operational, summary: "timeout for building a historical ref-view graph" },
     EnvVarSpec { name: "KIN_MCP_TOOL_PROFILE", kind: Kind::Str, default: "", sensitivity: Sensitivity::Operational, summary: "MCP tool exposure profile" },
     EnvVarSpec { name: "KIN_MCP_REPO", kind: Kind::Path, default: "", sensitivity: Sensitivity::Operational, summary: "bind `kin mcp start` to this repository instead of the launch directory" },
+    EnvVarSpec { name: "KIN_MCP_CACHE_DIR", kind: Kind::Path, default: "", sensitivity: Sensitivity::Operational, summary: "cache directory override for the npm MCP wrapper's managed Kin binary" },
 
     // ---- diagnostics / benchmarking ------------------------------------------
     EnvVarSpec { name: "KIN_LOCATE_DEBUG", kind: Kind::Bool, default: "false", sensitivity: Sensitivity::Diagnostic, summary: "emit locate pipeline debug output" },

--- a/docs/env-vars.md
+++ b/docs/env-vars.md
@@ -3,7 +3,7 @@
 
 # Kin environment variables
 
-This is the authoritative list of supported `KIN_*` environment variables (393 total, 294 correctness-relevant), generated from the central registry in `kin-core`.
+This is the authoritative list of supported `KIN_*` environment variables (396 total, 294 correctness-relevant), generated from the central registry in `kin-core`.
 
 At CLI and daemon startup Kin validates this surface (`KIN_ENV_VALIDATION`, default `warn`):
 
@@ -39,7 +39,10 @@ Sensitivity legend: **correctness** (affects retrieval/ranking/output or data sa
 | `KIN_BUILD_GRAPH_TIMEOUT_SECS` | seconds>=0 | 60 | operational | timeout for building a historical ref-view graph |
 | `KIN_BYPASS_EMBEDDING_COVERAGE_CHECK` | bool | false | correctness | bypass the embedding-coverage correctness gate |
 | `KIN_CLAUDE_DISALLOWED_TOOLS` | string | *(unset)* | operational | comma-separated tool names disallowed in a with-session |
+| `KIN_DIR` | path | *(unset)* | operational | compatibility alias for the managed Kin install root; KIN_HOME wins when both are set |
 | `KIN_DISABLE_SPINE` | bool | false | correctness | disable the spine federation layer, narrowing retrieval scope |
+| `KIN_HOME` | path | ~/.kin | operational | preferred root for the managed Kin install used by the launcher, setup, and shell hooks |
+| `KIN_MCP_CACHE_DIR` | path | *(unset)* | operational | cache directory override for the npm MCP wrapper's managed Kin binary |
 | `KIN_MCP_REPO` | path | *(unset)* | operational | bind `kin mcp start` to this repository instead of the launch directory |
 | `KIN_MCP_TOOL_PROFILE` | string | *(unset)* | operational | MCP tool exposure profile |
 | `KIN_NO_DAEMON` | bool | false | operational | force in-process execution instead of the daemon |

--- a/docs/mcp-tools.md
+++ b/docs/mcp-tools.md
@@ -35,8 +35,8 @@ small curated surface below instead of the full internal one):
 }
 ```
 
-To wire a client up by hand, or to use the npm wrapper (`@kinlab/kin-mcp`, which defaults
-to the same `agent-default` profile), see
+To wire a client up by hand, or to use the canonical npm wrapper (`@kinlab/kin`, which
+can run `kin mcp start` with the same `agent-default` profile), see
 [Advanced configuration](quickstart.md#9-advanced-configuration) in the quickstart.
 
 ---

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -5,7 +5,7 @@ Windows (via WSL2):
 
 1. **Install** the binaries with the one-line installer.
 2. **`kin setup`** — answer a couple of questions; the guided wizard configures your
-   shell, daemon, and AI clients.
+   shell, PATH, daemon, and AI clients.
 3. **`kin init`** + **`kin embed`** — build the semantic graph and the vector index.
 4. **Verify** with `kin setup status` and read the health checklist.
 
@@ -31,6 +31,25 @@ archive bundles them — into `~/.kin/bin` (and `~/.kin/lib`), updates your shel
 the installer aborts cleanly rather than leaving a daemon-less install. Re-running the
 installer upgrades an existing install in place and reports the version change.
 
+### npm / npx
+
+If your workflow starts from npm, use the canonical launcher and then run the same setup:
+
+```sh
+npm install -g @kinlab/kin
+kin setup --intent agent
+```
+
+For zero-install provisioning:
+
+```sh
+npx -y @kinlab/kin setup --intent agent --no-interactive
+```
+
+The launcher provisions the same managed native `kin` + `kin-daemon` release under
+`~/.kin/bin`; `kin setup` writes MCP configs with an absolute path to that binary and
+adds the managed bin directory to your shell profile for new sessions.
+
 ### Windows
 
 On native Windows, use PowerShell:
@@ -51,7 +70,8 @@ Configure the installer with environment variables (supported by both `install.s
 
 - `KIN_VERSION`: pin a specific version (e.g. `0.1.0`); otherwise the latest release is
   resolved automatically.
-- `KIN_DIR`: custom install directory (defaults to `~/.kin`).
+- `KIN_HOME`: custom managed install directory (preferred; defaults to `~/.kin`).
+- `KIN_DIR`: compatibility alias for `KIN_HOME`.
 - `KIN_NO_SETUP=1`: skip the `kin setup` wizard after the binaries are installed (run
   `kin setup` yourself when ready).
 - `KIN_BASE_URL`: install from a mirror or local path instead of GitHub releases
@@ -98,7 +118,20 @@ When the wizard finishes, it prints the **health checklist** (the same engine as
 
 ## 3. Initialize a repository
 
-Build a semantic graph over an existing Git repository or folder:
+Start a brand-new Kin-native repository:
+
+```sh
+mkdir my-app
+kin init my-app --git-history off
+cd my-app
+```
+
+In a directory with no `.git/`, `kin init` creates the native `.kin/` graph store and a
+managed `AGENTS.md` before the first snapshot. Agents that open the folder immediately see
+the Kin-native workflow: graph tools first, session workspaces for execution, `kin commit`
+for graph history, and `kin git export` only as an interoperability escape hatch.
+
+Convert an existing Git repository or folder:
 
 ```sh
 # Initialize in the current directory
@@ -107,6 +140,10 @@ kin init
 # Or initialize a specific path
 kin init path/to/project
 ```
+
+In a detected Git repository, `kin init` bootstraps the current tree as semantic truth and
+imports recent Git history by default. Git stays in place; Kin adds the semantic graph and
+agent/runtime surfaces beside it.
 
 *Flags:*
 - `--git-history <off|recent|full>`: how much Git history to import into the graph on init
@@ -295,7 +332,7 @@ The checks (IDs as emitted in `--json`):
 | `kin_daemon_binary` | `kin-daemon` found beside `kin` or on `PATH`. |
 | `vfs_projection` | The VFS shim is installed and non-zero in `~/.kin/lib` (macOS/Linux). On Windows this is **n/a** — projection uses ProjFS (planned), not the shell-injected shim. |
 | `repo_init` | The current directory is inside a Kin repository. |
-| `shell_path` | The `kin-vfs` shell hook is installed and sourced from your rc. |
+| `shell_path` | The `kin-vfs` shell hook is installed and sourced from your rc, and the managed `~/.kin/bin` directory is on PATH now or will be after shell restart. |
 | `mcp_client_*` (e.g. `mcp_client_claude`) | A detected AI client has the `kin` MCP server with the `agent-default` profile. With no client configs present, a single `mcp_clients` check reports ok ("nothing to configure"). |
 | `editor` | The `kin-editor` VS Code extension is detected in `~/.vscode/extensions`. **n/a** if not found / non-VS Code. |
 | `kinlab_connect` | A stored KinLab credential is present. **n/a** today — hosted connect is not yet a first-run flow. |
@@ -375,28 +412,31 @@ per invocation: it uses `KIN_DAEMON_URL` when set (agent sessions launched with
 from the working directory — so each agent session talks to the daemon of the
 repository it is actually working in.
 
-### npm wrapper (`@kinlab/kin-mcp`)
+### npm wrapper (`@kinlab/kin`)
 
-If you'd rather not install the binaries first, the published `@kinlab/kin-mcp` package
-downloads, checksum-verifies, and runs Kin's MCP server for you. Point your client at it:
+If you'd rather not install the binaries first, the canonical `@kinlab/kin` package
+downloads, checksum-verifies, and runs the managed Kin CLI for you. For setup:
+
+```sh
+npx -y @kinlab/kin setup --intent agent --no-interactive
+```
+
+For a manually configured MCP client:
 
 ```json
 {
   "mcpServers": {
     "kin": {
       "command": "npx",
-      "args": ["-y", "@kinlab/kin-mcp"]
+      "args": ["-y", "@kinlab/kin", "mcp", "start"],
+      "env": { "KIN_MCP_TOOL_PROFILE": "agent-default" }
     }
   }
 }
 ```
 
-On first run it provisions `kin-daemon` next to `kin`, defaults
-`KIN_MCP_TOOL_PROFILE=agent-default`, starts (or reuses) the repo daemon, and **requires an
-explicit `kin init`** (no silent init) unless you set `KIN_MCP_AUTO_INIT=1`. Requires
-Node.js 20+ on macOS or Linux (Windows users go through WSL2). See the
-[`@kinlab/kin-mcp` README](../packages/kin-mcp/README.md) for cache locations and the full
-environment-variable surface.
+The older `@kinlab/kin-mcp` package remains published for existing configurations. New
+setups should use `@kinlab/kin`, which includes the same MCP server as `kin mcp start`.
 
 ### Runtime / daemon configuration
 

--- a/docs/session-runtime.md
+++ b/docs/session-runtime.md
@@ -35,6 +35,9 @@ Codex, Gemini, Windsurf) and your shell hook. In short:
    resolved against the graph and fail loudly if the entity does not exist.
 2. **Run.** The command executes locally in that workspace (never through the
    daemon), with `KIN_SESSION`, `KIN_SESSION_ID`, and `KIN_SESSION_DIR` set.
+   Interactive shells and agent sessions also pin `KIN_DAEMON_URL` and
+   `KIN_REPO_ID` when available so nested Kin/MCP calls bind to the same repo
+   and session.
 3. **Reconcile.** On success, Kin reconciles the workspace's own changes into
    the graph — a change-set replay against the base state it was materialized
    from, not a whole-tree overwrite — then removes the workspace.
@@ -152,6 +155,10 @@ Semantic answers stay graph-backed throughout: `semantic_locate`,
 `get_context_pack`, `trace_data_flow`, and the other MCP tools are answered by
 the daemon's graph authority, never by grepping the materialized workspace.
 The workspace is an execution surface, not a search authority.
+
+`kin shell` uses the same session identity and daemon binding, so any agent or
+MCP client you launch manually from that shell inherits the session-coherent
+environment.
 
 Agent-session launches do **not** require the daemon's remote command
 execution endpoint, which stays disabled unless an operator explicitly opts in

--- a/packages/kin-mcp/package.json
+++ b/packages/kin-mcp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kinlab/kin-mcp",
-  "version": "0.2.13",
+  "version": "0.2.14",
   "description": "Start Kin's MCP server — the semantic system of record for software work — through an npm-friendly wrapper.",
   "type": "module",
   "bin": {

--- a/packages/kin/README.md
+++ b/packages/kin/README.md
@@ -6,12 +6,14 @@ semantic system of record for software work.
 ```sh
 npm install -g @kinlab/kin
 kin --version
+kin setup --intent agent
 ```
 
 or zero-install:
 
 ```sh
 npx -y @kinlab/kin --version
+npx -y @kinlab/kin setup --intent agent --no-interactive
 ```
 
 ## What it does
@@ -28,6 +30,11 @@ npx -y @kinlab/kin --version
 The launcher and the shell installer (`scripts/install.sh`) share the same install
 contract (`$KIN_HOME`, default `~/.kin`): either lane satisfies the other, and neither
 silently downgrades an install the other made.
+
+Run `kin setup --intent agent` after provisioning. Setup writes the Kin MCP server into
+detected AI clients with the `agent-default` tool profile, adds the managed bin directory
+to your shell profile, installs the shell/session hook, and records the install ledger used
+by `kin setup status`, `kin doctor --fix`, and `kin setup uninstall`.
 
 ## Version pinning
 
@@ -55,10 +62,17 @@ the installed version already matches.
 
 ## MCP setup
 
-Any MCP client can use the included server:
+`kin setup --intent agent` is the preferred MCP setup path. It writes an absolute path to
+the managed native `kin` binary, so agents do not depend on inheriting your shell `PATH`.
+
+Any MCP client can also use the included server manually:
 
 ```json
-{ "command": "npx", "args": ["-y", "@kinlab/kin", "mcp", "start"] }
+{
+  "command": "npx",
+  "args": ["-y", "@kinlab/kin", "mcp", "start"],
+  "env": { "KIN_MCP_TOOL_PROFILE": "agent-default" }
+}
 ```
 
 `@kinlab/kin-mcp` remains published for existing configurations; new setups should use

--- a/packages/kin/package.json
+++ b/packages/kin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kinlab/kin",
-  "version": "0.2.13",
+  "version": "0.2.14",
   "description": "Canonical installer and launcher for Kin, the semantic system of record for software work — provisions and runs the managed kin + kin-daemon release. MCP is one included mode (kin mcp start).",
   "license": "Apache-2.0",
   "type": "module",

--- a/scripts/install.ps1
+++ b/scripts/install.ps1
@@ -8,7 +8,8 @@
 #
 # Options (via env vars):
 #   $env:KIN_VERSION = "0.1.0"   Pin a specific version (default: latest)
-#   $env:KIN_DIR = "$HOME\.kin"  Install directory (default: ~/.kin)
+#   $env:KIN_HOME = "$HOME\.kin" Install directory (preferred; default: ~/.kin)
+#   $env:KIN_DIR = "$HOME\.kin"  Install directory compatibility alias
 #   $env:KIN_NO_SETUP = "1"     Skip interactive setup after install
 #   $env:KIN_BASE_URL = "..."   Install from a mirror (CI smoke tests / offline)
 #
@@ -20,9 +21,17 @@ $ErrorActionPreference = "Stop"
 
 # ── Config ──────────────────────────────────────────────────────────────
 
-$KinDir = if ($env:KIN_DIR) { $env:KIN_DIR } else { Join-Path $HOME ".kin" }
+$KinDir = if ($env:KIN_HOME) {
+    $env:KIN_HOME
+} elseif ($env:KIN_DIR) {
+    $env:KIN_DIR
+} else {
+    Join-Path $HOME ".kin"
+}
 $KinBin = Join-Path $KinDir "bin"
 $KinLib = Join-Path $KinDir "lib"
+$env:KIN_HOME = $KinDir
+$env:KIN_DIR = $KinDir
 $GitHubOrg = "firelock-ai"
 $GitHubRepo = "kin"
 # Override KIN_BASE_URL to install from a mirror or a local path (offline /

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -9,16 +9,19 @@
 #
 # Options (via env vars):
 #   KIN_VERSION=0.1.0    Pin a specific version (default: latest)
-#   KIN_DIR=~/.kin        Install directory (default: ~/.kin)
+#   KIN_HOME=~/.kin       Install directory (preferred; default: ~/.kin)
+#   KIN_DIR=~/.kin        Install directory compatibility alias
 #   KIN_NO_SETUP=1        Skip interactive setup after install
 
 set -eu
 
 # ── Config ──────────────────────────────────────────────────────────────
 
-KIN_DIR="${KIN_DIR:-$HOME/.kin}"
+KIN_DIR="${KIN_HOME:-${KIN_DIR:-$HOME/.kin}}"
 KIN_BIN="$KIN_DIR/bin"
 KIN_LIB="$KIN_DIR/lib"
+export KIN_HOME="$KIN_DIR"
+export KIN_DIR="$KIN_DIR"
 GITHUB_ORG="firelock-ai"
 GITHUB_REPO="kin"
 # Override KIN_BASE_URL to install from a mirror or a local `file://` path
@@ -222,7 +225,7 @@ add_to_path() {
     local rc_file="$1"
     local line="export PATH=\"$KIN_BIN:\$PATH\""
 
-    if [ -f "$rc_file" ] && grep -q "kin/bin" "$rc_file" 2>/dev/null; then
+    if [ -f "$rc_file" ] && grep -F -q "$KIN_BIN" "$rc_file" 2>/dev/null; then
         return 0  # Already configured
     fi
 


### PR DESCRIPTION
## Summary
- Make fresh no-Git `kin init` bootstrap Kin-native agent guidance and next steps, with Git remaining an export path.
- Smooth `kin setup`, installer, PATH, health, and `kin shell` behavior around `KIN_HOME` and session context.
- Bump release metadata/packages to 0.2.14 and clean the residual changelog conflict markers.

## Verification
- `cargo fmt -- --check`
- `RUSTFLAGS="-D warnings" cargo clippy --all-targets --all-features -- <existing CI allowlist>`
- `RUSTFLAGS="-D warnings" cargo build --all-targets --locked`
- `RUSTFLAGS="-D warnings" cargo test --locked`
- `cargo test -p kin-cli setup`
- `cargo test -p kin-cli shell_path`
- `cargo test -p kin-cli --test init_json`
- `cargo test -p kin-core assistant`
- `cargo test -p kin-core env_doc_matches_registry`
- `cargo check -p kin-cli`
- `cargo build --release -p kin-cli -p kin-daemon`
- `npm test --prefix packages/kin`
- `npm run lint --prefix packages/kin`
- `npm test --prefix packages/kin-mcp`
- `npm run test:unit --prefix packages/kin-mcp`
- `npm run lint --prefix packages/kin-mcp`
- `python3 scripts/verify-zero-file-search.py`
- `bash scripts/check_runtime_boundaries.sh`
- `bash scripts/check_private_repo_coupling.sh`
- `sh -n scripts/install.sh`
- `bin/kin-dev release-check kin` from the umbrella workspace

## Notes
- `install.ps1` was updated but not executed locally because `pwsh` is not installed on this machine.
- Release-clean passed with registry-only resolution. It warned that some external Kin crate pins are behind registry latest, but no local patches were used.