### PR TITLE
Tier-2 behavior equivalence: type-identity + annotation neutrality

### DIFF
--- a/crates/kin-index/src/fingerprint.rs
+++ b/crates/kin-index/src/fingerprint.rs
@@ -153,7 +153,8 @@ fn finalize_hash(hasher: Sha256) -> Hash256 {
 /// residual, behavior-irrelevant sensitivity and nothing more.
 pub fn behavior_equivalence_hash(node: &Node, source: &[u8], language: LanguageId) -> Hash256 {
     let mut hasher = Sha256::new();
-    hash_equivalence_stream(node, source, language, &mut hasher);
+    let ctx = EquivalenceContext::for_entity_file(node, source, language);
+    hash_equivalence_stream(node, source, language, ctx, &mut hasher);
     finalize_hash(hasher)
 }
 
@@ -176,11 +177,42 @@ pub fn language_supports_equivalence(language: LanguageId) -> bool {
 /// statement (a Python docstring or any bare, non-interpolated string
 /// expression statement) is dropped, because evaluating a string literal and
 /// discarding it has no runtime effect.
-fn hash_equivalence_stream(node: &Node, source: &[u8], language: LanguageId, hasher: &mut Sha256) {
+fn hash_equivalence_stream(
+    node: &Node,
+    source: &[u8],
+    language: LanguageId,
+    ctx: EquivalenceContext,
+    hasher: &mut Sha256,
+) {
     if node.is_extra() {
         return;
     }
     if is_pure_noop_string_statement(node, language) {
+        return;
+    }
+    if is_pure_annotation_statement(node, language) {
+        return;
+    }
+    if is_canonical_none_type(node, source, language, ctx) {
+        hasher.update(CANONICAL_NONE_TYPE);
+        return;
+    }
+    if language_supports_equivalence(language) && is_neutralizable_annotated_assignment(node) {
+        // A valued PEP 526 annotated assignment `x: T = v` hashes as `x = v`: the
+        // annotation and its `:` drop out (metadata-only), so an annotation-only
+        // edit collapses to one class while any change to the assigned value still
+        // differs. Applies only when the annotation is side-effect-free.
+        hasher.update(node.kind().as_bytes());
+        hasher.update(b"(");
+        let annotation_id = node.child_by_field_name("type").map(|t| t.id());
+        let mut cursor = node.walk();
+        for child in node.children(&mut cursor) {
+            if Some(child.id()) == annotation_id || (!child.is_named() && child.kind() == ":") {
+                continue;
+            }
+            hash_equivalence_stream(&child, source, language, ctx, hasher);
+        }
+        hasher.update(b")");
         return;
     }
     if node.child_count() == 0 {
@@ -197,7 +229,7 @@ fn hash_equivalence_stream(node: &Node, source: &[u8], language: LanguageId, has
     }
     let mut cursor = node.walk();
     for child in node.children(&mut cursor) {
-        hash_equivalence_stream(&child, source, language, hasher);
+        hash_equivalence_stream(&child, source, language, ctx, hasher);
     }
     if named {
         hasher.update(b")");
@@ -247,6 +279,425 @@ fn subtree_has_interpolation(node: &Node) -> bool {
         .children(&mut cursor)
         .any(|child| subtree_has_interpolation(&child));
     has
+}
+
+/// Canonical digest marker emitted in place of the interchangeable explicit
+/// spellings of the `NoneType` singleton (`type(None)`, `types.NoneType`) so a
+/// body differing only by that swap hashes identically. The `\x1d`
+/// group-separator bytes cannot collide with any tree-sitter token text.
+const CANONICAL_NONE_TYPE: &[u8] = b"\x1dcanon:none_type\x1d";
+
+/// File-level facts that gate the `NoneType` canonicalization so it fires only
+/// where the referenced names provably resolve to the Python stdlib. Computed
+/// once per entity from its enclosing file's parse tree (imports + name
+/// bindings) — graph-native, never a bare textual match. `Copy` so it threads
+/// cheaply through the hash walk.
+#[derive(Clone, Copy)]
+struct EquivalenceContext {
+    /// `type` is the un-shadowed builtin: no binding of `type` in the file.
+    type_builtin_available: bool,
+    /// `types` resolves to the stdlib module: `import types` present and `types`
+    /// not otherwise bound.
+    types_module_is_stdlib: bool,
+    /// Bare `NoneType` resolves to the stdlib singleton: `from types import
+    /// NoneType` present and `NoneType` not otherwise bound.
+    bare_none_type_is_stdlib: bool,
+}
+
+impl EquivalenceContext {
+    /// Every gate closed — the conservative default for non-participating
+    /// languages, where no NoneType spelling is ever canonicalized.
+    const CLOSED: Self = Self {
+        type_builtin_available: false,
+        types_module_is_stdlib: false,
+        bare_none_type_is_stdlib: false,
+    };
+
+    /// Derive the context from the file that contains `node`: walk to the file
+    /// root and scan its imports and name bindings once.
+    fn for_entity_file(node: &Node, source: &[u8], language: LanguageId) -> Self {
+        if !language_supports_equivalence(language) {
+            return Self::CLOSED;
+        }
+        let mut root = *node;
+        while let Some(parent) = root.parent() {
+            root = parent;
+        }
+        let mut scan = BindingScan::default();
+        scan_name_bindings(&root, source, &mut scan);
+        Self {
+            type_builtin_available: !scan.type_shadowed,
+            types_module_is_stdlib: scan.import_types && !scan.types_shadowed,
+            bare_none_type_is_stdlib: scan.from_types_none_type && !scan.none_type_shadowed,
+        }
+    }
+}
+
+/// Accumulates the file-level import and shadowing facts for the three names
+/// (`type`, `types`, `NoneType`) the NoneType canonicalization depends on.
+#[derive(Default)]
+struct BindingScan {
+    import_types: bool,
+    from_types_none_type: bool,
+    type_shadowed: bool,
+    types_shadowed: bool,
+    none_type_shadowed: bool,
+}
+
+impl BindingScan {
+    fn shadow(&mut self, name: &str) {
+        match name {
+            "type" => self.type_shadowed = true,
+            "types" => self.types_shadowed = true,
+            "NoneType" => self.none_type_shadowed = true,
+            _ => {}
+        }
+    }
+}
+
+/// Walk the file recording the two stdlib imports and any local rebinding of the
+/// three tracked names. Covers the realistic binding forms — import, class/def,
+/// (augmented) assignment, parameters, `for`/`with`/`except`/walrus targets. A
+/// tracked name bound by a rarer form (comprehension target, match capture) is
+/// simply not observed here; because canonicalization also requires the positive
+/// stdlib-import gate, an unobserved rebinding stays conservative.
+fn scan_name_bindings(node: &Node, source: &[u8], scan: &mut BindingScan) {
+    match node.kind() {
+        "import_statement" => scan_import(node, source, scan),
+        "import_from_statement" => scan_import_from(node, source, scan),
+        "class_definition" | "function_definition" => {
+            if let Some(name) = node.child_by_field_name("name") {
+                scan.shadow(node_text(&name, source));
+            }
+        }
+        "assignment" | "augmented_assignment" | "for_statement" => {
+            if let Some(left) = node.child_by_field_name("left") {
+                shadow_targets(&left, source, scan);
+            }
+        }
+        "parameters" | "lambda_parameters" => shadow_parameters(node, source, scan),
+        "named_expression" => {
+            if let Some(name) = node.child_by_field_name("name") {
+                scan.shadow(node_text(&name, source));
+            }
+        }
+        "as_pattern" | "except_clause" => {
+            if let Some(alias) = node.child_by_field_name("alias") {
+                shadow_targets(&alias, source, scan);
+            }
+        }
+        _ => {}
+    }
+    let mut cursor = node.walk();
+    for child in node.children(&mut cursor) {
+        scan_name_bindings(&child, source, scan);
+    }
+}
+
+fn scan_import(node: &Node, source: &[u8], scan: &mut BindingScan) {
+    let mut cursor = node.walk();
+    for name in node.children_by_field_name("name", &mut cursor) {
+        match name.kind() {
+            "dotted_name" => match first_component(&name, source) {
+                Some("types") => scan.import_types = true,
+                Some(other) => scan.shadow(other),
+                None => {}
+            },
+            "aliased_import" => {
+                if let Some(alias) = name.child_by_field_name("alias") {
+                    scan.shadow(node_text(&alias, source));
+                }
+            }
+            _ => {}
+        }
+    }
+}
+
+fn scan_import_from(node: &Node, source: &[u8], scan: &mut BindingScan) {
+    let module_is_types = node
+        .child_by_field_name("module_name")
+        .map(|m| m.kind() == "dotted_name" && node_text(&m, source) == "types")
+        .unwrap_or(false);
+    let mut wildcard_cursor = node.walk();
+    let has_wildcard = node
+        .children(&mut wildcard_cursor)
+        .any(|c| c.kind() == "wildcard_import");
+    if has_wildcard {
+        // `from X import *` may bind any tracked name; stay conservative.
+        scan.type_shadowed = true;
+        scan.types_shadowed = true;
+        scan.none_type_shadowed = true;
+    }
+    let mut cursor = node.walk();
+    for name in node.children_by_field_name("name", &mut cursor) {
+        match name.kind() {
+            "dotted_name" => {
+                let bound = node_text(&name, source);
+                if module_is_types && bound == "NoneType" {
+                    scan.from_types_none_type = true;
+                } else {
+                    scan.shadow(bound);
+                }
+            }
+            "aliased_import" => {
+                let orig = name
+                    .child_by_field_name("name")
+                    .map(|n| node_text(&n, source));
+                let alias = name
+                    .child_by_field_name("alias")
+                    .map(|a| node_text(&a, source));
+                if module_is_types && orig == Some("NoneType") && alias == Some("NoneType") {
+                    scan.from_types_none_type = true;
+                } else if let Some(alias) = alias {
+                    scan.shadow(alias);
+                }
+            }
+            _ => {}
+        }
+    }
+}
+
+/// Shadow every identifier bound by an assignment/loop/with/except target,
+/// descending through tuple and list destructuring. Attribute and subscript
+/// targets (`a.b = …`, `a[0] = …`) bind no bare name and are ignored.
+fn shadow_targets(node: &Node, source: &[u8], scan: &mut BindingScan) {
+    match node.kind() {
+        "identifier" => scan.shadow(node_text(node, source)),
+        "pattern_list"
+        | "tuple_pattern"
+        | "list_splat_pattern"
+        | "dictionary_splat_pattern"
+        | "as_pattern_target" => {
+            let mut cursor = node.walk();
+            for child in node.children(&mut cursor) {
+                shadow_targets(&child, source, scan);
+            }
+        }
+        _ => {}
+    }
+}
+
+/// Shadow the NAME of each parameter (never its annotation or default, which are
+/// read positions): a simple `identifier`, or the leading identifier of a typed,
+/// defaulted, or splat parameter.
+fn shadow_parameters(params: &Node, source: &[u8], scan: &mut BindingScan) {
+    let mut cursor = params.walk();
+    for param in params.children(&mut cursor) {
+        match param.kind() {
+            "identifier" => scan.shadow(node_text(&param, source)),
+            "typed_parameter" | "list_splat_pattern" | "dictionary_splat_pattern" => {
+                let mut inner = param.walk();
+                let name = param
+                    .children(&mut inner)
+                    .find(|c| c.kind() == "identifier");
+                if let Some(id) = name {
+                    scan.shadow(node_text(&id, source));
+                }
+            }
+            "default_parameter" | "typed_default_parameter" => {
+                if let Some(name) = param.child_by_field_name("name") {
+                    if name.kind() == "identifier" {
+                        scan.shadow(node_text(&name, source));
+                    }
+                }
+            }
+            _ => {}
+        }
+    }
+}
+
+/// First `identifier` component of a `dotted_name` (`a` in `a.b.c`).
+fn first_component<'a>(dotted: &Node, source: &'a [u8]) -> Option<&'a str> {
+    let mut cursor = dotted.walk();
+    for child in dotted.children(&mut cursor) {
+        if child.kind() == "identifier" {
+            return Some(node_text(&child, source));
+        }
+    }
+    None
+}
+
+/// True when `node` denotes the `NoneType` singleton in a spelling this file
+/// proves resolves to the stdlib: `type(None)` (un-shadowed builtin `type`),
+/// `types.NoneType` (stdlib `types` module), or bare `NoneType` (bound by
+/// `from types import NoneType`). Python 3.10+ guarantees all three are the same
+/// object, so folding them to one marker collapses exactly that swap. Every gate
+/// is graph-derived from the file's imports and bindings; when a gate is closed
+/// (name shadowed, or the import absent) the spelling is left untouched.
+fn is_canonical_none_type(
+    node: &Node,
+    source: &[u8],
+    language: LanguageId,
+    ctx: EquivalenceContext,
+) -> bool {
+    if !language_supports_equivalence(language) {
+        return false;
+    }
+    match node.kind() {
+        "attribute" => ctx.types_module_is_stdlib && is_types_none_type_attribute(node, source),
+        "call" => ctx.type_builtin_available && is_type_of_none_call(node, source),
+        "identifier" => {
+            ctx.bare_none_type_is_stdlib
+                && node_text(node, source) == "NoneType"
+                && is_value_reference_position(node)
+        }
+        _ => false,
+    }
+}
+
+/// `types.NoneType` exactly: object identifier `types`, attribute `NoneType`.
+fn is_types_none_type_attribute(node: &Node, source: &[u8]) -> bool {
+    let object_is_types = node
+        .child_by_field_name("object")
+        .map(|o| o.kind() == "identifier" && node_text(&o, source) == "types")
+        .unwrap_or(false);
+    let attr_is_none_type = node
+        .child_by_field_name("attribute")
+        .map(|a| node_text(&a, source) == "NoneType")
+        .unwrap_or(false);
+    object_is_types && attr_is_none_type
+}
+
+/// `type(None)` exactly: a call to the bare `type` identifier with the single
+/// argument `None`.
+fn is_type_of_none_call(node: &Node, source: &[u8]) -> bool {
+    let function_is_type = node
+        .child_by_field_name("function")
+        .map(|f| f.kind() == "identifier" && node_text(&f, source) == "type")
+        .unwrap_or(false);
+    if !function_is_type {
+        return false;
+    }
+    let Some(args) = node.child_by_field_name("arguments") else {
+        return false;
+    };
+    let mut cursor = args.walk();
+    let mut named = args
+        .children(&mut cursor)
+        .filter(|c| c.is_named() && !c.is_extra());
+    let Some(only) = named.next() else {
+        return false;
+    };
+    named.next().is_none() && only.kind() == "none"
+}
+
+/// True when a bare `NoneType` identifier is a value reference, not the member
+/// side of an attribute access (`x.NoneType`) or a keyword-argument name
+/// (`f(NoneType=…)`) — positions where the token is not the imported name.
+fn is_value_reference_position(node: &Node) -> bool {
+    let Some(parent) = node.parent() else {
+        return true;
+    };
+    match parent.kind() {
+        "attribute" => parent.child_by_field_name("attribute").map(|a| a.id()) != Some(node.id()),
+        "keyword_argument" => parent.child_by_field_name("name").map(|n| n.id()) != Some(node.id()),
+        _ => true,
+    }
+}
+
+/// True for a bare PEP 526 variable annotation with no assigned value —
+/// `name: T` — whose annotation `T` is a side-effect-free type expression. Such
+/// a statement binds nothing; at function scope it is never evaluated, and at
+/// class/module scope it only records an entry in `__annotations__`. Either way
+/// it changes no runtime behavior, so adding, removing, or editing it is
+/// behavior-preserving.
+///
+/// Guards that keep this sound:
+/// - restricted to `language_supports_equivalence` languages (Python),
+/// - the statement's only named child must be an `assignment` carrying a `type`
+///   field and NO `right` field — an assigned value is behavior-relevant and is
+///   never dropped, and
+/// - the annotation must contain only side-effect-free type-expression nodes; a
+///   `call` or other evaluable-with-effects form keeps the statement in the hash.
+fn is_pure_annotation_statement(node: &Node, language: LanguageId) -> bool {
+    if !language_supports_equivalence(language) {
+        return false;
+    }
+    if node.kind() != "expression_statement" {
+        return false;
+    }
+    let mut cursor = node.walk();
+    let mut named_children = node
+        .children(&mut cursor)
+        .filter(|c| c.is_named() && !c.is_extra());
+    let Some(assignment) = named_children.next() else {
+        return false;
+    };
+    if named_children.next().is_some() || assignment.kind() != "assignment" {
+        return false;
+    }
+    if assignment.child_by_field_name("right").is_some() {
+        return false;
+    }
+    let Some(annotation) = assignment.child_by_field_name("type") else {
+        return false;
+    };
+    is_side_effect_free_type_expr(&annotation)
+}
+
+/// True for a valued PEP 526 annotated assignment — `name: T = value` — whose
+/// annotation `T` is a side-effect-free type expression. Its annotation may be
+/// dropped from the hash (leaving `name = value`), because a type hint on an
+/// assignment records only `__annotations__` metadata and never changes what the
+/// assignment binds. The assigned value is retained, so any value change differs.
+fn is_neutralizable_annotated_assignment(node: &Node) -> bool {
+    if node.kind() != "assignment" || node.child_by_field_name("right").is_none() {
+        return false;
+    }
+    match node.child_by_field_name("type") {
+        Some(annotation) => is_side_effect_free_type_expr(&annotation),
+        None => false,
+    }
+}
+
+/// Whether a type-annotation subtree is free of runtime side effects: composed
+/// only of identifiers, dotted/attribute names, subscripts (`List[int]`), unions
+/// (`int | None`), tuples/lists of the same, string forward-references, and
+/// literal atoms. Any `call` — or any node kind not on the allow-list — makes it
+/// NOT side-effect-free, so an annotation that evaluates something with effects
+/// is never dropped.
+fn is_side_effect_free_type_expr(node: &Node) -> bool {
+    match node.kind() {
+        "identifier"
+        | "dotted_name"
+        | "none"
+        | "true"
+        | "false"
+        | "string"
+        | "concatenated_string"
+        | "integer"
+        | "float"
+        | "ellipsis" => true,
+        "type"
+        | "constrained_type"
+        | "generic_type"
+        | "member_type"
+        | "union_type"
+        | "splat_type"
+        | "type_parameter"
+        | "attribute"
+        | "subscript"
+        | "binary_operator"
+        | "unary_operator"
+        | "tuple"
+        | "list"
+        | "slice"
+        | "parenthesized_expression"
+        | "expression_list" => {
+            let mut cursor = node.walk();
+            let all_free = node
+                .children(&mut cursor)
+                .filter(|c| c.is_named() && !c.is_extra())
+                .all(|c| is_side_effect_free_type_expr(&c));
+            all_free
+        }
+        _ => false,
+    }
+}
+
+/// UTF-8 text of a node, or the empty string if it is not valid UTF-8.
+fn node_text<'a>(node: &Node, source: &'a [u8]) -> &'a str {
+    node.utf8_text(source).unwrap_or("")
 }
 
 #[cfg(test)]
@@ -543,6 +994,304 @@ mod equivalence_tests {
         );
     }
 
+    // ---- Type-identity: type(None) == types.NoneType (Python 3.10+) ---------
+    // Each canonicalization is gated on the file proving the referenced name
+    // resolves to the stdlib (import present, name un-shadowed).
+
+    /// `type(None)` and `types.NoneType` are the same singleton at runtime, so a
+    /// body swapping one explicit spelling for the other is behavior-preserving
+    /// when `types` is the stdlib module (mirrors django fd21f82aa8's serializer).
+    #[test]
+    fn python_type_none_and_types_nonetype_are_equivalent() {
+        let a = "def check(x):\n    return isinstance(x, (type(None), int))\n";
+        let b = "import types\ndef check(x):\n    return isinstance(x, (types.NoneType, int))\n";
+        assert_eq!(
+            equiv(&PythonAdapter, a, "check"),
+            equiv(&PythonAdapter, b, "check"),
+            "type(None) and stdlib types.NoneType denote the same singleton and must be equivalent"
+        );
+    }
+
+    /// The canonicalization holds for a standalone type reference too.
+    #[test]
+    fn python_type_none_standalone_is_equivalent() {
+        let a = "def f():\n    t = type(None)\n    return t\n";
+        let b = "import types\ndef f():\n    t = types.NoneType\n    return t\n";
+        assert_eq!(equiv(&PythonAdapter, a, "f"), equiv(&PythonAdapter, b, "f"));
+    }
+
+    /// Bare `NoneType` bound by `from types import NoneType` is the stdlib
+    /// singleton, so swapping `type(None)` for it is behavior-preserving (mirrors
+    /// django fd21f82aa8's `SpatialReference`/`Index` isinstance checks).
+    #[test]
+    fn python_bare_nonetype_from_stdlib_import_is_equivalent() {
+        let before = "def check(x):\n    return isinstance(x, (type(None), int))\n";
+        let after =
+            "from types import NoneType\ndef check(x):\n    return isinstance(x, (NoneType, int))\n";
+        assert_eq!(
+            equiv(&PythonAdapter, before, "check"),
+            equiv(&PythonAdapter, after, "check"),
+            "bare NoneType imported from stdlib types must fold to the same class as type(None)"
+        );
+    }
+
+    /// GUARD: a co-located REAL type change is not masked by the None-type
+    /// canonicalization — `int` -> `str` beside an unchanged `type(None)` stays
+    /// a behavior change.
+    #[test]
+    fn python_type_none_canon_does_not_mask_sibling_type_change() {
+        let a = "def check(x):\n    return isinstance(x, (type(None), int))\n";
+        let b = "def check(x):\n    return isinstance(x, (type(None), str))\n";
+        assert_ne!(
+            equiv(&PythonAdapter, a, "check"),
+            equiv(&PythonAdapter, b, "check"),
+            "a real sibling type change (int->str) must not be normalized away"
+        );
+    }
+
+    /// GUARD: `type(None)` canonicalizes only for `None` — `type(0)` is a
+    /// different type and must stay non-equivalent.
+    #[test]
+    fn python_type_of_other_value_is_not_canonicalized() {
+        let a = "def f():\n    return type(None)\n";
+        let b = "def f():\n    return type(0)\n";
+        assert_ne!(
+            equiv(&PythonAdapter, a, "f"),
+            equiv(&PythonAdapter, b, "f"),
+            "type(0) is not the NoneType singleton and must not be canonicalized"
+        );
+    }
+
+    /// GATE: `types.NoneType` is NOT canonicalized without `import types` — the
+    /// file has not proven `types` is the stdlib module.
+    #[test]
+    fn python_types_nonetype_without_import_not_canonicalized() {
+        let a = "def check(x):\n    return isinstance(x, (type(None), int))\n";
+        let b = "def check(x):\n    return isinstance(x, (types.NoneType, int))\n";
+        assert_ne!(
+            equiv(&PythonAdapter, a, "check"),
+            equiv(&PythonAdapter, b, "check"),
+            "types.NoneType without `import types` must stay conservatively non-equivalent"
+        );
+    }
+
+    /// GATE: bare `NoneType` is NOT canonicalized without `from types import
+    /// NoneType` — the name is not proven to bind the stdlib singleton.
+    #[test]
+    fn python_bare_nonetype_without_import_not_canonicalized() {
+        let a = "def check(x):\n    return isinstance(x, (type(None), int))\n";
+        let b = "def check(x):\n    return isinstance(x, (NoneType, int))\n";
+        assert_ne!(
+            equiv(&PythonAdapter, a, "check"),
+            equiv(&PythonAdapter, b, "check"),
+            "bare NoneType with no stdlib import must stay conservatively non-equivalent"
+        );
+    }
+
+    /// GATE: a file-local `class NoneType` shadows the import, so bare `NoneType`
+    /// is NOT canonicalized even with `from types import NoneType` present.
+    #[test]
+    fn python_local_class_nonetype_blocks_canonicalization() {
+        let a = "from types import NoneType\ndef check(x):\n    return isinstance(x, (type(None), int))\n";
+        let b = "from types import NoneType\nclass NoneType:\n    pass\ndef check(x):\n    return isinstance(x, (NoneType, int))\n";
+        assert_ne!(
+            equiv(&PythonAdapter, a, "check"),
+            equiv(&PythonAdapter, b, "check"),
+            "a local class NoneType shadows the stdlib import; bare NoneType must not canonicalize"
+        );
+    }
+
+    /// GATE: a file-local rebinding `NoneType = ...` shadows the import, so bare
+    /// `NoneType` is NOT canonicalized.
+    #[test]
+    fn python_local_rebind_nonetype_blocks_canonicalization() {
+        let a = "from types import NoneType\ndef check(x):\n    return isinstance(x, (type(None), int))\n";
+        let b = "from types import NoneType\nNoneType = object()\ndef check(x):\n    return isinstance(x, (NoneType, int))\n";
+        assert_ne!(
+            equiv(&PythonAdapter, a, "check"),
+            equiv(&PythonAdapter, b, "check"),
+            "a local rebinding of NoneType shadows the stdlib import; bare NoneType must not canonicalize"
+        );
+    }
+
+    /// GATE: a shadowed `type` (here a parameter) is not the builtin, so
+    /// `type(None)` is NOT canonicalized.
+    #[test]
+    fn python_shadowed_type_blocks_type_none() {
+        let a = "import types\ndef f(type):\n    return isinstance(f, (type(None), int))\n";
+        let b = "import types\ndef f(type):\n    return isinstance(f, (types.NoneType, int))\n";
+        assert_ne!(
+            equiv(&PythonAdapter, a, "f"),
+            equiv(&PythonAdapter, b, "f"),
+            "when `type` is shadowed, type(None) is not the builtin and must not canonicalize"
+        );
+    }
+
+    // ---- Annotation-only body changes are behavior-preserving ---------------
+
+    /// Adding a bare PEP 526 annotation statement inside a function body (mirrors
+    /// sphinx d25c3ad241's `subtarget: Optional[str]`) changes no runtime
+    /// behavior: it binds nothing and is never evaluated at function scope.
+    #[test]
+    fn python_added_bare_annotation_in_body_is_equivalent() {
+        let without = "def f(warnings):\n    for w in warnings:\n        emit(w)\n";
+        let with =
+            "def f(warnings):\n    subtarget: Optional[str]\n    for w in warnings:\n        emit(w)\n";
+        assert_eq!(
+            equiv(&PythonAdapter, without, "f"),
+            equiv(&PythonAdapter, with, "f"),
+            "a bare local annotation is a no-op and must not change the equivalence class"
+        );
+    }
+
+    /// Adding class-level attribute annotations (mirrors d25c3ad241's `Sphinx`
+    /// `warningiserror: bool` / `_warncount: int`) records only `__annotations__`
+    /// metadata and is behavior-preserving for the class.
+    #[test]
+    fn python_added_class_attribute_annotation_is_equivalent() {
+        let without = "class Sphinx:\n    def __init__(self):\n        self.x = 1\n";
+        let with = "class Sphinx:\n    warningiserror: bool\n    _warncount: int\n    def __init__(self):\n        self.x = 1\n";
+        assert_eq!(
+            equiv(&PythonAdapter, without, "Sphinx"),
+            equiv(&PythonAdapter, with, "Sphinx"),
+            "class attribute annotations are metadata-only and must not change the class equivalence class"
+        );
+    }
+
+    /// Editing an annotation's TYPE (bare, no value) is behavior-preserving.
+    #[test]
+    fn python_bare_annotation_type_edit_is_equivalent() {
+        let a = "class C:\n    x: int\n    def m(self):\n        return 1\n";
+        let b = "class C:\n    x: str\n    def m(self):\n        return 1\n";
+        assert_eq!(equiv(&PythonAdapter, a, "C"), equiv(&PythonAdapter, b, "C"));
+    }
+
+    /// GUARD: an annotation carrying a VALUE is a real assignment, never dropped
+    /// — `x: int` (no value) vs `x: int = compute()` must be non-equivalent.
+    #[test]
+    fn python_annotated_assignment_with_value_is_not_equivalent() {
+        let bare = "class C:\n    x: int\n    def m(self):\n        return 1\n";
+        let valued = "class C:\n    x: int = compute()\n    def m(self):\n        return 1\n";
+        assert_ne!(
+            equiv(&PythonAdapter, bare, "C"),
+            equiv(&PythonAdapter, valued, "C"),
+            "an annotation with an assigned value is behavior-relevant and must not be dropped"
+        );
+    }
+
+    /// GUARD: a bare annotation whose type expression is a CALL can have side
+    /// effects at class/module scope and must not be dropped.
+    #[test]
+    fn python_bare_annotation_with_call_is_not_dropped() {
+        let without = "class C:\n    def m(self):\n        return 1\n";
+        let with = "class C:\n    x: make_type()\n    def m(self):\n        return 1\n";
+        assert_ne!(
+            equiv(&PythonAdapter, without, "C"),
+            equiv(&PythonAdapter, with, "C"),
+            "an annotation that evaluates a call is not side-effect-free and must stay in the hash"
+        );
+    }
+
+    /// A valued annotated assignment whose ONLY delta is the annotation is
+    /// behavior-preserving — the annotation is metadata; the bound value is
+    /// unchanged (`x: int = 5` vs `x: str = 5`).
+    #[test]
+    fn python_annotated_assignment_annotation_only_is_equivalent() {
+        let a = "class C:\n    x: int = 5\n    def m(self):\n        return 1\n";
+        let b = "class C:\n    x: str = 5\n    def m(self):\n        return 1\n";
+        assert_eq!(
+            equiv(&PythonAdapter, a, "C"),
+            equiv(&PythonAdapter, b, "C"),
+            "an annotation-only edit on a valued assignment (value unchanged) must be equivalent"
+        );
+    }
+
+    /// GUARD: the VALUE of a valued annotated assignment is behavior-relevant —
+    /// `x: int = 5` vs `x: int = 6` must be non-equivalent even though the
+    /// annotation is unchanged.
+    #[test]
+    fn python_annotated_assignment_value_change_is_not_equivalent() {
+        let a = "class C:\n    x: int = 5\n    def m(self):\n        return 1\n";
+        let b = "class C:\n    x: int = 6\n    def m(self):\n        return 1\n";
+        assert_ne!(
+            equiv(&PythonAdapter, a, "C"),
+            equiv(&PythonAdapter, b, "C"),
+            "a change to the assigned value must never pass through the annotation-only path"
+        );
+    }
+
+    // ---- Protected true positives (FIR-1306 shapes) stay non-equivalent -----
+
+    /// FIR-1306 origin shape (cli b9cacbc347): adding a narrowing conjunct to a
+    /// predicate is a real domain change and must stay non-equivalent.
+    #[test]
+    fn python_added_narrowing_conjunct_is_not_equivalent() {
+        let before = "def find(files):\n    return [f for f in files if f.is_md()]\n";
+        let after =
+            "def find(files):\n    return [f for f in files if f.is_md() and not f.is_symlink()]\n";
+        assert_ne!(
+            equiv(&PythonAdapter, before, "find"),
+            equiv(&PythonAdapter, after, "find"),
+            "an added narrowing conjunct (b9cacbc347 shape) is a behavior change"
+        );
+    }
+
+    /// Protected-TP shape (b55526f4e8): removing a try/except fallback is a
+    /// control-flow behavior change and must stay non-equivalent.
+    #[test]
+    fn python_removed_try_except_fallback_is_not_equivalent() {
+        let with_fallback = "def parse(s):\n    try:\n        return strict(s)\n    except ValueError:\n        return fallback(s)\n";
+        let without = "def parse(s):\n    return strict(s)\n";
+        assert_ne!(
+            equiv(&PythonAdapter, with_fallback, "parse"),
+            equiv(&PythonAdapter, without, "parse"),
+            "removing a try/except fallback (b55526f4e8 shape) is a behavior change"
+        );
+    }
+
+    /// Protected-TP shape (f195c4ae87): adding an `__eq__` method converts
+    /// identity equality to structural equality — a real semantic change the
+    /// annotation-stripping normalization must never absorb.
+    #[test]
+    fn python_added_eq_method_is_not_equivalent() {
+        let without = "class Op:\n    def __init__(self, op):\n        self.op = op\n";
+        let with = "class Op:\n    def __init__(self, op):\n        self.op = op\n    def __eq__(self, other):\n        return self.op == other.op\n";
+        assert_ne!(
+            equiv(&PythonAdapter, without, "Op"),
+            equiv(&PythonAdapter, with, "Op"),
+            "adding __eq__ (f195c4ae87 shape) changes equality semantics"
+        );
+    }
+
+    /// Protected-TP shape (f97a6123c0 / 883faaa568): an added `raise` guard is a
+    /// behavior change even when a bare annotation is edited in the same body —
+    /// annotation-stripping must be surgical and never absorb the raise.
+    #[test]
+    fn python_added_raise_beside_annotation_is_not_equivalent() {
+        let before =
+            "def safe(obj, name, *args):\n    result: object\n    return getattr(obj, name, *args)\n";
+        let after = "def safe(obj, name, *args):\n    result: object\n    if len(args) > 1:\n        raise TypeError('too many')\n    return getattr(obj, name, *args)\n";
+        assert_ne!(
+            equiv(&PythonAdapter, before, "safe"),
+            equiv(&PythonAdapter, after, "safe"),
+            "an added raise guard (f97a6123c0 shape) must stay non-equivalent despite an edited annotation"
+        );
+    }
+
+    /// A commutative operand reorder whose operand is a CALL is not proven
+    /// side-effect-free (the svelte 432763a03e `set`/`get` shape): it is never
+    /// canonicalized and stays non-equivalent.
+    #[test]
+    fn python_operand_reorder_with_call_is_not_equivalent() {
+        let a = "def g(o, x):\n    return o.has(x) and o.ready == x\n";
+        let b = "def g(o, x):\n    return o.ready == x and o.has(x)\n";
+        assert_ne!(
+            equiv(&PythonAdapter, a, "g"),
+            equiv(&PythonAdapter, b, "g"),
+            "reordering a boolean whose operand is a call is not proven equivalent (432763a03e shape)"
+        );
+    }
+
     // ---- Determinism --------------------------------------------------------
 
     #[test]
@@ -552,6 +1301,23 @@ mod equivalence_tests {
             equiv(&PythonAdapter, src, "clone"),
             equiv(&PythonAdapter, src, "clone"),
             "the equivalence hash must be deterministic across runs"
+        );
+    }
+
+    /// The composed normalization pipeline is invariant to comments and
+    /// whitespace even when every canonicalization fires at once: bare-annotation
+    /// stripping, valued-annotation stripping, and NoneType folding together must
+    /// yield one identical hash regardless of formatting.
+    #[test]
+    fn python_canonicalizations_are_formatting_deterministic() {
+        let plain = "from types import NoneType\n\
+             def check(x):\n    y: int\n    z: int = 5\n    return isinstance(x, (NoneType, int))\n";
+        let noisy = "from types import NoneType\n\
+             def check(x):  # trailing comment\n    # leading comment\n    y:    int\n    z: int =  5\n    return isinstance(x, ( NoneType , int ))\n";
+        assert_eq!(
+            equiv(&PythonAdapter, plain, "check"),
+            equiv(&PythonAdapter, noisy, "check"),
+            "the composed canonicalization pipeline must be formatting-invariant"
         );
     }
 

--- a/crates/kin-review/src/inline.rs
+++ b/crates/kin-review/src/inline.rs
@@ -140,7 +140,23 @@ pub fn signature_runtime_neutral(old: &str, new: &str) -> bool {
     }
     signature_strengthened_only(old, new)
         || python_signatures_runtime_neutral(old, new)
+        || python_none_type_spelling_neutral(old, new)
         || go_struct_field_addition_only(old, new)
+}
+
+/// True when `old` and `new` are identical once the two explicit spellings of
+/// the `NoneType` singleton — `type(None)` and `types.NoneType` — are folded to
+/// one form. Python 3.10+ guarantees `type(None) is types.NoneType`, so a
+/// declaration that swaps one spelling for the other (a default value, or a
+/// non-`def` module-level declaration whose text carries the reference) changes
+/// no runtime contract. Only that exact spelling is folded, so any other type
+/// difference still counts and is never masked. Bare `NoneType` is not folded —
+/// its meaning depends on a `from types import` binding absent from the text.
+fn python_none_type_spelling_neutral(old: &str, new: &str) -> bool {
+    fn fold(signature: &str) -> String {
+        signature.replace("type(None)", "types.NoneType")
+    }
+    fold(old) == fold(new)
 }
 
 /// The callable name and normalized parameter list of a Python `def`, or
@@ -1836,6 +1852,52 @@ mod tests {
         assert!(!signature_runtime_neutral(
             "class Item(Node, Request)",
             "class Item(Node)"
+        ));
+    }
+
+    /// d25c3ad241 shape: widening a return annotation (`-> str` to
+    /// `-> Optional[str]`) changes no call contract — the parameter list (name +
+    /// arity + param names) is unchanged. Regression lock so the return-annotation
+    /// path is never quietly turned into a breaking finding.
+    #[test]
+    fn python_return_annotation_widen_is_runtime_neutral() {
+        assert!(signature_runtime_neutral(
+            "def get_node_location(node: Node) -> str",
+            "def get_node_location(node: Node) -> Optional[str]"
+        ));
+    }
+
+    /// fd21f82aa8 shape: swapping the `type(None)` spelling for `types.NoneType`
+    /// changes no runtime contract, whether it appears in a default value or a
+    /// bare module-level declaration whose text carries the reference.
+    #[test]
+    fn python_none_type_spelling_swap_is_runtime_neutral() {
+        assert!(signature_runtime_neutral(
+            "def f(x=type(None))",
+            "def f(x=types.NoneType)"
+        ));
+        assert!(signature_runtime_neutral(
+            "PROTECTED = (bool, int, type(None), bytes)",
+            "PROTECTED = (bool, int, types.NoneType, bytes)"
+        ));
+    }
+
+    /// GUARD: the None-type fold masks ONLY that exact spelling. A genuine
+    /// default-value change (d25c3ad241's `deprecated_alias` `= None` -> `= {}`),
+    /// any other type in place of `type(None)`, and bare `NoneType` all still fire.
+    #[test]
+    fn python_none_type_fold_does_not_mask_real_changes() {
+        assert!(!signature_runtime_neutral(
+            "def deprecated_alias(modname, objects, warning, names=None)",
+            "def deprecated_alias(modname, objects, warning, names={})"
+        ));
+        assert!(!signature_runtime_neutral(
+            "def f(x=type(None))",
+            "def f(x=type(int))"
+        ));
+        assert!(!signature_runtime_neutral(
+            "PROTECTED = (bool, int, type(None), bytes)",
+            "PROTECTED = (bool, int, NoneType, bytes)"
         ));
     }
 


### PR DESCRIPTION
## Tier-2 behavior equivalence: type-identity + annotation neutrality

Stacked on `feat/behavior-equivalence-fingerprint` (#266). Two bounded, conservative,
graph-native normalizations extend #266's ingest-time behavior-equivalence hash and the
review-time signature-neutrality check, so a class of provably behavior-preserving Python
refactors stops reading as behavior changes.

### What this adds

Both normalizations are per-entity, computed at ingest, and strictly bounded — any operator,
constant, call, assigned value, default change, or real type change still changes the hash or
fires the finding. Each **widens the equivalence class globally**, so each ships with its own
adversarial fixture pinning the protected-true-positive shape it must never absorb.

**1. Type identity — `type(None)` ≡ `types.NoneType` ≡ bare `NoneType`.**
Python 3.10+ guarantees `type(None) is types.NoneType`, so swapping one spelling for another is
behavior-preserving. Folded to one canonical marker in both the ingest equivalence hash
(`kin-index/fingerprint.rs`) and the review signature-neutrality check
(`kin-review/inline.rs`). Every spelling is **gated on the file's own parse tree proving the
name resolves to the stdlib** — graph-native, never a bare textual match:

- `type(None)` — only when `type` is the un-shadowed builtin (no local binding of `type`).
- `types.NoneType` — only when `import types` is present and `types` is not otherwise bound.
- bare `NoneType` — only when `from types import NoneType` is present and `NoneType` is not
  otherwise bound (a file-local `class NoneType`, `NoneType = …`, parameter, or shadowing
  import closes the gate).

**2. Annotation neutrality — PEP 526 annotations are metadata.**
A bare annotation statement (`x: T`, no value) binds nothing at function scope and only records
`__annotations__` at class scope — the same acceptability class as the docstrings #266 already
canonicalizes away. Dropped from the hash when `T` is a side-effect-free type expression. A
valued annotated assignment (`x: T = v`) hashes as `x = v`: the annotation drops, the assigned
value is retained, so an annotation-only edit is neutral while any value change still differs.
Return-annotation changes (`-> str` → `-> Optional[str]`) were already runtime-neutral (the
signature parser compares name + parameters only); a regression fixture pins that so it can
never silently become a breaking finding.

---

### FIX 1 — svelte `432763a03e` is an honest non-flip (residual-table justification)

This row is **not** flipped, by design. Four independent blockers; the fourth is decisive and
holds regardless of how much machinery is built:

1. **Language.** The change is JavaScript. The equivalence relation participates for Python only
   (JS bare strings can be `"use strict"`-style directive prologues, guarded by an existing
   protected-TP test). Enabling JS is a separate, larger soundness question.
2. **Module-global rename.** `reaction_sources` → `source_ownership` renames a module-level
   `export let`, a free variable in each of the four entities — not a local. α-rename / De-Bruijn
   canonicalization is sound only for bound locals; canonicalizing a free identifier would
   collapse distinct globals.
3. **Cross-entity reshape map.** The tuple→object mapping (`[0]`↔`.reaction`, `[1]`↔`.sources`)
   is defined by the co-changed container in a *different* entity. A per-entity ingest hash has
   no diff/sibling context to witness that mapping.
4. **Call-operand reorder (decisive).** `set` and `get` reorder a `&&`/`||` whose operand is a
   `.includes()` **method call** ("put equality statements first"). A JS method call cannot be
   proven total/side-effect-free statically (dynamic dispatch), so the commutative-reorder rule —
   *reorder only when both operands are side-effect-free* — excludes it. All four entities must
   prove equivalent for the row to flip; `set` and `get` cannot, **independent of blockers 1–3**.

Framing for a future Tier-2 decision: review-time body access would be **graph-blob reads
(graph-owned truth, not file-first thesis drift)**, so the rejection is on cost/scope and the
decisiveness of blocker 4 — not on thesis grounds. Building the cross-entity/body-plumbing
architecture would still buy a row that cannot flip under the soundness constraint. The existing
conservative guard is strengthened with a fixture pinning the call-operand reorder as
non-equivalent.

---

### Expected per-entity attention deltas (fd21, d25c)

Fresh-graph corpus measurement is founder-gated and NOT run here; the values below are the
**expected** per-entity behavior derived from the real diffs + the verified gate mechanics
(`inline.rs`/`shadow.rs`), labeled honestly.

**`fd21f82aa8` (django) — att 13 = 3 consumer_fanout + 10 coverage_gap.**

| entity | change | under these fixes |
|---|---|---|
| `SpatialReference` (14/14/56) | `isinstance(axis_order, (type(None), AxisOrder))` → bare `NoneType` (file imports it from `types`) | cf **downgrades** to informational |
| `Index` (2/2/237) | `isinstance(condition, (type(None), Q))` → bare `NoneType` | cf **downgrades** to informational |
| `serializer` (3/3/1) | pure module-dict `type(None)`→`types.NoneType` **downgrades**; the `serialize` method's `"type(None)"`→`"types.NoneType"` *string* + import-list change is a real value change and **stays** | mixed / entity-dependent |
| co-fired `signature_change` | most plausibly the module-level `types.NoneType` constant swap → **neutralized** by the signature-side fold; coverage_gaps then stop gating | conditional |

Expected: if the co-fired signature_change is the type-swap (most plausible), att 13 → 0–1 (near/full flip); if it is a non-type surface change, the row stays `needs_attention`. **Unverifiable without a fresh-graph run** — the decisive unknown is the exact signature_change entity.

**`d25c3ad241` (sphinx) — att 14 = 2 consumer_fanout + 12 coverage_gap.**

| entity | change | under these fixes |
|---|---|---|
| `Sphinx` (8/8/7) | added class-attribute annotations `warningiserror: bool`, `_warncount: int` | cf **downgrades** to informational |
| `is_suppressed_warning` (3/3/56) | added bare annotation `subtarget: Optional[str]` | cf **downgrades** to informational |
| `deprecated_alias` | default `= None` → `= {}` — a real defaults-semantics change | signature_change **correctly stays** |
| `init` | annotation neutral, but a real `elif/else` control-flow change | cf **correctly stays** |

Expected: att 14 → ~12. The 2 annotation-only consumer_fanout findings downgrade, but
`deprecated_alias`'s genuine default change keeps a surface finding, so the 12 coverage_gaps
still gate. **Still `needs_attention`** — a partial precision improvement, not a flip.

---

### Honest headline

**0 full row flips proven; 2 partial precision improvements (fd21, d25c); protected-TP guards
hardened.** fd21 *may* fully flip pending a fresh-graph run; d25c stays `needs_attention`
because its genuine `deprecated_alias`/`init` changes correctly remain flagged; 432763a03e is
an honest non-flip.

### Validation (dev-local)

- `cargo test -p kin-index -p kin-review`: green (kin-index 238 + kin-review 172).
- `cargo test --workspace`: green (no regressions).
- `cargo fmt --check` clean; `cargo clippy` (ci.yml allowlist, `-D warnings`) clean.
- Red-on-old proven per canonicalization: neutering each fails exactly its fix tests while every
  gate/guard stays green.
- Protected-TP fixtures (FIR-1306 shapes): added guard/raise, removed try/except fallback,
  `__eq__` addition, call-operand reorder, sibling type change, import-gate negatives, local
  `class NoneType` / `NoneType = …` shadowing, shadowed `type`, valued-annotation value change.

