### PR TITLE
chore(release): bump to 0.2.15 — sharper shadow review via behavior equivalence and call-site argument shapes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,36 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.2.15] - 2026-07-08
+
+Sharper shadow review: behavior-equivalence fingerprinting, call-site argument shapes,
+and arity-aware overload binding let review distinguish behavior-preserving refactors
+from real changes with far less noise.
+
+### Added
+
+- Behavior-equivalence fingerprint: `SemanticFingerprint` now carries an
+  `equivalence_hash` capturing a change's behavior-equivalence class. Review uses it to
+  downgrade behavior-preserving consumer fanout instead of flagging it, so a refactor
+  that keeps behavior no longer cascades warnings across its callers.
+- Type-identity and annotation-neutral equivalence: type-only and annotation-only edits
+  are recognized as behavior-preserving and folded into the same equivalence class,
+  keeping their review impact proportionate.
+- Call-site argument shapes: the Python parser records the argument shape at each call
+  site on `Calls` edges and the linker persists it onto resolved calls, so review can
+  gate arity-preserving parameter renames against how a function is actually called.
+- Arity-aware C++ overload binding: overloaded C++ calls bind to the overload whose
+  arity matches the call site rather than fanning out across every same-named overload.
+
+### Changed
+
+- Pin `kin-model` 0.2.4 for the `SemanticFingerprint.equivalence_hash` surface.
+
+### Fixed
+
+- `kin-cli`: cover the equivalence-downgrade fanout kind in `inline_comment_severity`
+  so downgraded fanout is rendered at its intended severity.
+
 ## [0.2.14] - 2026-07-08
 
 First-run setup becomes Kin-native by default for new repos and smoother for agent

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3039,11 +3039,11 @@ dependencies = [
 
 [[package]]
 name = "kin-buildinfo"
-version = "0.2.14"
+version = "0.2.15"
 
 [[package]]
 name = "kin-cli"
-version = "0.2.14"
+version = "0.2.15"
 dependencies = [
  "age",
  "anyhow",
@@ -3110,7 +3110,7 @@ dependencies = [
 
 [[package]]
 name = "kin-context"
-version = "0.2.14"
+version = "0.2.15"
 dependencies = [
  "kin-blobs",
  "kin-db",
@@ -3126,7 +3126,7 @@ dependencies = [
 
 [[package]]
 name = "kin-core"
-version = "0.2.14"
+version = "0.2.15"
 dependencies = [
  "chrono",
  "directories 5.0.1",
@@ -3150,7 +3150,7 @@ dependencies = [
 
 [[package]]
 name = "kin-daemon"
-version = "0.2.14"
+version = "0.2.15"
 dependencies = [
  "async-stream",
  "axum",
@@ -3239,7 +3239,7 @@ dependencies = [
 
 [[package]]
 name = "kin-git"
-version = "0.2.14"
+version = "0.2.15"
 dependencies = [
  "chrono",
  "gix",
@@ -3257,7 +3257,7 @@ dependencies = [
 
 [[package]]
 name = "kin-index"
-version = "0.2.14"
+version = "0.2.15"
 dependencies = [
  "hex",
  "kin-blobs",
@@ -3303,7 +3303,7 @@ dependencies = [
 
 [[package]]
 name = "kin-integration-tests"
-version = "0.2.14"
+version = "0.2.15"
 dependencies = [
  "kin-blobs",
  "kin-cli",
@@ -3345,7 +3345,7 @@ dependencies = [
 
 [[package]]
 name = "kin-mcp"
-version = "0.2.14"
+version = "0.2.15"
 dependencies = [
  "kin-blobs",
  "kin-context",
@@ -3372,7 +3372,7 @@ dependencies = [
 
 [[package]]
 name = "kin-migrate"
-version = "0.2.14"
+version = "0.2.15"
 dependencies = [
  "chrono",
  "kin-blobs",
@@ -3414,7 +3414,7 @@ dependencies = [
 
 [[package]]
 name = "kin-parser"
-version = "0.2.14"
+version = "0.2.15"
 dependencies = [
  "kin-model",
  "pretty_assertions",
@@ -3443,7 +3443,7 @@ dependencies = [
 
 [[package]]
 name = "kin-projection"
-version = "0.2.14"
+version = "0.2.15"
 dependencies = [
  "kin-blobs",
  "kin-db",
@@ -3458,7 +3458,7 @@ dependencies = [
 
 [[package]]
 name = "kin-ranking"
-version = "0.2.14"
+version = "0.2.15"
 dependencies = [
  "kin-model",
  "serde",
@@ -3467,7 +3467,7 @@ dependencies = [
 
 [[package]]
 name = "kin-reconcile"
-version = "0.2.14"
+version = "0.2.15"
 dependencies = [
  "kin-blobs",
  "kin-db",
@@ -3487,7 +3487,7 @@ dependencies = [
 
 [[package]]
 name = "kin-registry"
-version = "0.2.14"
+version = "0.2.15"
 dependencies = [
  "axum",
  "base64 0.22.1",
@@ -3512,7 +3512,7 @@ dependencies = [
 
 [[package]]
 name = "kin-remote"
-version = "0.2.14"
+version = "0.2.15"
 dependencies = [
  "chrono",
  "kin-model",
@@ -3528,7 +3528,7 @@ dependencies = [
 
 [[package]]
 name = "kin-review"
-version = "0.2.14"
+version = "0.2.15"
 dependencies = [
  "kin-blobs",
  "kin-db",
@@ -3544,7 +3544,7 @@ dependencies = [
 
 [[package]]
 name = "kin-runtime"
-version = "0.2.14"
+version = "0.2.15"
 dependencies = [
  "chrono",
  "hex",
@@ -3576,7 +3576,7 @@ dependencies = [
 
 [[package]]
 name = "kin-semantic-contracts"
-version = "0.2.14"
+version = "0.2.15"
 dependencies = [
  "kin-db",
  "kin-model",
@@ -3591,7 +3591,7 @@ dependencies = [
 
 [[package]]
 name = "kin-spine"
-version = "0.2.14"
+version = "0.2.15"
 dependencies = [
  "chrono",
  "hashbrown 0.15.5",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,7 +27,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.2.14"
+version = "0.2.15"
 edition = "2021"
 license = "Apache-2.0"
 authors = ["Troy Fortin <troy@firelock.ai>"]

--- a/packages/kin-mcp/package.json
+++ b/packages/kin-mcp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kinlab/kin-mcp",
-  "version": "0.2.14",
+  "version": "0.2.15",
   "description": "Start Kin's MCP server — the semantic system of record for software work — through an npm-friendly wrapper.",
   "type": "module",
   "bin": {

--- a/packages/kin/package.json
+++ b/packages/kin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kinlab/kin",
-  "version": "0.2.14",
+  "version": "0.2.15",
   "description": "Canonical installer and launcher for Kin, the semantic system of record for software work — provisions and runs the managed kin + kin-daemon release. MCP is one included mode (kin mcp start).",
   "license": "Apache-2.0",
   "type": "module",


### PR DESCRIPTION
Cut Kin 0.2.15 from the reviewed candidate (`kin` main @ 44638a07): version bump only, frozen dependency pins preserved.

## Release contents (since 0.2.14)

Sharper shadow review — behavior-equivalence fingerprinting, call-site argument shapes, and arity-aware overload binding let review distinguish behavior-preserving refactors from real changes with far less noise.

- Behavior-equivalence fingerprint on `SemanticFingerprint` (`equivalence_hash`); review downgrades behavior-preserving consumer fanout via the equivalence class instead of flagging it.
- Type-identity and annotation-neutral equivalence (tier 2): type-only and annotation-only edits are treated as behavior-preserving.
- Call-site argument shapes recorded on `Calls` edges and persisted onto resolved calls; review gates arity-preserving Python parameter renames against them.
- Arity-aware C++ overload call binding.
- Pin `kin-model` 0.2.4 for the `SemanticFingerprint.equivalence_hash` surface.
- `kin-cli`: cover the equivalence-downgrade fanout kind in `inline_comment_severity`.

## Mechanics

- `Cargo.toml` workspace version 0.2.14 → 0.2.15; both npm manifests (`@kinlab/kin`, `@kinlab/kin-mcp`) → 0.2.15; `CHANGELOG.md` `[0.2.15]` section added.
- `Cargo.lock` refreshed workspace-members-only (`cargo update --workspace`, 20 members 0.2.14 → 0.2.15); all external `kin-*` pins left frozen and registry-sourced. Registry-clean release-check passed at the candidate.
- `release-intent` gate: coherent — ready to tag. On merge to `main`, auto-tag cuts `v0.2.15` and `release.yml` builds the platform binaries and publishes the npm wrapper.
