### PR TITLE
docs: carry the locked public one-liner and category noun

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,17 +1,17 @@
 # Kin
 
+> **AI writes code. Kin proves it safe to ship.**
 > AI made code cheap to write and expensive to trust.
-> **Kin helps teams trust AI-built software before it merges.**
 
 [![License: Apache-2.0](https://img.shields.io/badge/license-Apache--2.0-blue.svg)](LICENSE)
-[![Release](https://img.shields.io/badge/release-v0.2.14-6E56CF.svg)](https://github.com/firelock-ai/kin/releases)
+[![Release](https://img.shields.io/badge/release-v0.2.15-6E56CF.svg)](https://github.com/firelock-ai/kin/releases)
 [![kinlab.ai](https://img.shields.io/badge/hosted-kinlab.ai-111111.svg)](https://kinlab.ai)
 
 AI agents now generate code faster than teams can review it. The hard part is no longer
 writing a change — it's trusting one: knowing what it actually touches, whether it silently
 reverts an earlier fix, and how far its blast radius reaches before it merges. Git tracks
-lines and files, so it can't answer those questions directly. Kin is the **semantic system
-of record** for software work: it represents your codebase as a graph of entities and
+lines and files, so it can't answer those questions directly. Kin is **the system of record
+for AI-written software**: it represents your codebase as a graph of entities and
 relations and reasons over that graph instead of over text diffs.
 
 ---

--- a/docs/ecosystem-manifest.json
+++ b/docs/ecosystem-manifest.json
@@ -7,7 +7,7 @@
     "summary": "Firelock (the company) builds Kin (the semantic repo and collaboration substrate). KinLab is the hosted collaboration product; @kinlab is the shared package and registry scope.",
     "product": {
       "name": "Kin",
-      "descriptor": "The semantic repo and collaboration substrate — the system of record for software work.",
+      "descriptor": "The semantic repo and collaboration substrate — the system of record for AI-written software.",
       "github": "https://github.com/firelock-ai/kin"
     },
     "company": {

--- a/llms.txt
+++ b/llms.txt
@@ -1,6 +1,6 @@
 # Kin
 
-> Kin is the semantic system of record for software work — a graph-native repository and collaboration substrate that replaces the file-first, diff-first model. Code becomes a graph of entities, relations, and intents that AI agents and humans navigate semantically.
+> Kin is the system of record for AI-written software — a graph-native repository and collaboration substrate that replaces the file-first, diff-first model. Code becomes a graph of entities, relations, and intents that AI agents and humans navigate semantically.
 
 Kin coexists with Git and projects graph-owned truth back to a normal filesystem through a transparent VFS, so any tool or agent works unchanged. The fastest way for an agent to use Kin is the MCP server, which exposes semantic tools (locate, context, trace) backed by the graph rather than filesystem heuristics.
 

--- a/packages/kin-mcp/package.json
+++ b/packages/kin-mcp/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@kinlab/kin-mcp",
   "version": "0.2.15",
-  "description": "Start Kin's MCP server — the semantic system of record for software work — through an npm-friendly wrapper.",
+  "description": "Start Kin's MCP server — the system of record for AI-written software — through an npm-friendly wrapper.",
   "type": "module",
   "bin": {
     "kin-mcp": "./bin/kin-mcp.js"

--- a/packages/kin/README.md
+++ b/packages/kin/README.md
@@ -1,7 +1,7 @@
 # @kinlab/kin
 
 The canonical npm install surface for [Kin](https://github.com/firelock-ai/kin), the
-semantic system of record for software work.
+system of record for AI-written software.
 
 ```sh
 npm install -g @kinlab/kin

--- a/packages/kin/package.json
+++ b/packages/kin/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@kinlab/kin",
   "version": "0.2.15",
-  "description": "Canonical installer and launcher for Kin, the semantic system of record for software work — provisions and runs the managed kin + kin-daemon release. MCP is one included mode (kin mcp start).",
+  "description": "Canonical installer and launcher for Kin, the system of record for AI-written software — provisions and runs the managed kin + kin-daemon release. MCP is one included mode (kin mcp start).",
   "license": "Apache-2.0",
   "type": "module",
   "bin": {


### PR DESCRIPTION
Propagates the locked public one-liner and category noun into this repo's public copy. Positioning/tagline strings only — no code, no technical-doc content.

- README header now leads with **AI writes code. Kin proves it safe to ship.** (the "AI made code cheap to write and expensive to trust." problem-statement line is kept beneath it)
- README "what Kin is" paragraph, the npm package README + description, the MCP package description, and llms.txt now use the category noun **the system of record for AI-written software**
- ecosystem-manifest.json product descriptor SOR clause updated to the same noun
- Release badge bumped v0.2.14 → v0.2.15

Minimal diff: 6 files, 9 insertions / 9 deletions. Terse ecosystem-list role labels (e.g. "the semantic system of record (this repo)") left unchanged to keep the diff minimal.