### PR TITLE
fix(install): bind Windows checksums to exact archives

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -70,6 +70,21 @@ jobs:
       - name: Test @kinlab/kin-mcp (compatibility wrapper)
         run: npm run test:unit --prefix ./packages/kin-mcp && npm run lint --prefix ./packages/kin-mcp
 
+  windows-installer:
+    name: Windows installer checksum tests
+    runs-on: windows-latest
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@v7
+
+      - name: Test exact archive checksum selection (PowerShell 7)
+        shell: pwsh
+        run: ./scripts/test-install-checksum.ps1
+
+      - name: Test exact archive checksum selection (Windows PowerShell 5.1)
+        shell: powershell
+        run: ./scripts/test-install-checksum.ps1
+
   check:
     name: Check & Test
     runs-on: ${{ matrix.os }}
@@ -79,6 +94,9 @@ jobs:
         os: [ubuntu-latest, macos-latest]
     steps:
       - uses: actions/checkout@v7
+
+      - name: Validate installer checksum fixtures
+        run: python3 scripts/test-install-checksum.py
 
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@1.96.0

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -359,7 +359,9 @@ jobs:
             Write-Error "kin-daemon.exe missing from $env:ARTIFACT.zip — refusing to publish a daemon-less archive"
             exit 1
           }
-          Get-FileHash -Algorithm SHA256 "$env:ARTIFACT.zip" | Format-List Hash | Out-File -Encoding utf8 "$env:ARTIFACT.zip.sha256"
+          $ArchivePath = "$env:ARTIFACT.zip"
+          $Hash = (Get-FileHash -Algorithm SHA256 $ArchivePath).Hash.ToLowerInvariant()
+          "$Hash  $ArchivePath" | Set-Content -Encoding ascii "$ArchivePath.sha256"
         env:
           TARGET: ${{ matrix.target }}
           ARTIFACT: ${{ matrix.artifact }}

--- a/scripts/install-checksum-fixtures.json
+++ b/scripts/install-checksum-fixtures.json
@@ -1,0 +1,52 @@
+{
+  "cases": [
+    {
+      "name": "multi-platform manifest selects exact Windows archive",
+      "archive": "kin-windows-x86_64.zip",
+      "content": "# Kin release checksums\naaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa  kin-linux-x86_64.tar.gz\nbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb  kin-windows-x86_64.zip\ncccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc  kin-macos-aarch64.tar.gz\n",
+      "expected": "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
+    },
+    {
+      "name": "standard binary marker is accepted",
+      "archive": "kin-windows-x86_64.zip",
+      "content": "dddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd *kin-windows-x86_64.zip\r\n",
+      "expected": "dddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd"
+    },
+    {
+      "name": "identical duplicate entries are unambiguous",
+      "archive": "kin-windows-x86_64.zip",
+      "content": "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb  kin-windows-x86_64.zip\nBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBB *kin-windows-x86_64.zip\n",
+      "expected": "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
+    },
+    {
+      "name": "missing exact archive rejects near matches",
+      "archive": "kin-windows-x86_64.zip",
+      "content": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa  kin-windows-aarch64.zip\nbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb  kin-windows-x86_64.zip.sha256\n",
+      "error_contains": "no entry for exact archive"
+    },
+    {
+      "name": "trailing filename whitespace is not an exact match",
+      "archive": "kin-windows-x86_64.zip",
+      "content": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa  kin-windows-x86_64.zip \n",
+      "error_contains": "no entry for exact archive"
+    },
+    {
+      "name": "conflicting exact archive entries fail closed",
+      "archive": "kin-windows-x86_64.zip",
+      "content": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa  kin-windows-x86_64.zip\nbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb  kin-windows-x86_64.zip\n",
+      "error_contains": "conflicting entries"
+    },
+    {
+      "name": "bare hash is rejected because it binds no filename",
+      "archive": "kin-windows-x86_64.zip",
+      "content": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa\n",
+      "error_contains": "malformed entry"
+    },
+    {
+      "name": "PowerShell Format-List hash is rejected because it binds no filename",
+      "archive": "kin-windows-x86_64.zip",
+      "content": "Hash : aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa\n",
+      "error_contains": "malformed entry"
+    }
+  ]
+}

--- a/scripts/install.ps1
+++ b/scripts/install.ps1
@@ -40,9 +40,9 @@ $BaseUrl = if ($env:KIN_BASE_URL) { $env:KIN_BASE_URL } else { "https://github.c
 
 # ── Helpers ─────────────────────────────────────────────────────────────
 
-function Write-Info  { Write-Host "  → $args" -ForegroundColor Cyan }
-function Write-Ok    { Write-Host "  ✓ $args" -ForegroundColor Green }
-function Write-Err   { Write-Host "  ✗ $args" -ForegroundColor Red }
+function Write-Info  { Write-Host "  -> $args" -ForegroundColor Cyan }
+function Write-Ok    { Write-Host "  [ok] $args" -ForegroundColor Green }
+function Write-Err   { Write-Host "  [error] $args" -ForegroundColor Red }
 
 function Resolve-ArchiveChecksum {
     param(
@@ -274,7 +274,7 @@ if (Test-Path $KinExe) {
         Write-Ok "kin $InstalledVersion"
     }
 } else {
-    Write-Err "Installation failed — kin.exe not found"
+    Write-Err "Installation failed: kin.exe not found"
     exit 1
 }
 

--- a/scripts/install.ps1
+++ b/scripts/install.ps1
@@ -44,6 +44,57 @@ function Write-Info  { Write-Host "  → $args" -ForegroundColor Cyan }
 function Write-Ok    { Write-Host "  ✓ $args" -ForegroundColor Green }
 function Write-Err   { Write-Host "  ✗ $args" -ForegroundColor Red }
 
+function Resolve-ArchiveChecksum {
+    param(
+        [Parameter(Mandatory = $true)]
+        [AllowEmptyString()]
+        [string]$ChecksumContent,
+
+        [Parameter(Mandatory = $true)]
+        [ValidateNotNullOrEmpty()]
+        [string]$ArchiveName
+    )
+
+    $MatchingHashes = @()
+    $LineNumber = 0
+    foreach ($RawLine in [regex]::Split($ChecksumContent, "\r?\n")) {
+        $LineNumber++
+        if ([string]::IsNullOrWhiteSpace($RawLine) -or $RawLine.TrimStart().StartsWith("#")) {
+            continue
+        }
+
+        $Match = [regex]::Match(
+            $RawLine,
+            '^(?<hash>[0-9a-fA-F]{64})[ \t]+(?<filename>\*?.+?)$',
+            [System.Text.RegularExpressions.RegexOptions]::CultureInvariant
+        )
+        if (-not $Match.Success) {
+            throw "Checksum file contains malformed entry on line $LineNumber"
+        }
+
+        $Filename = $Match.Groups["filename"].Value
+        if ($Filename.StartsWith("*")) {
+            $Filename = $Filename.Substring(1)
+        }
+        if ($Filename -cne $ArchiveName) {
+            continue
+        }
+
+        $MatchingHashes += $Match.Groups["hash"].Value.ToLowerInvariant()
+    }
+
+    if ($MatchingHashes.Count -eq 0) {
+        throw "Checksum file has no entry for exact archive '$ArchiveName'"
+    }
+
+    $UniqueHashes = @($MatchingHashes | Sort-Object -Unique)
+    if ($UniqueHashes.Count -gt 1) {
+        throw "Checksum file has conflicting entries for exact archive '$ArchiveName'"
+    }
+
+    return $UniqueHashes[0]
+}
+
 # ── Detect architecture ─────────────────────────────────────────────────
 
 $Arch = if ([Environment]::Is64BitOperatingSystem) {
@@ -121,8 +172,9 @@ try {
 
 # ── Verify checksum ───────────────────────────────────────────────────
 # The release workflow publishes "<archive>.sha256" next to every archive
-# (Get-FileHash format). Download it and fail loudly if it is missing,
-# malformed, or does not match — never install an unverified download.
+# in standard "<hash>  <archive>" format. Download it and fail loudly if it
+# is missing, malformed, ambiguous, or does not match — never install an
+# unverified download.
 
 $ChecksumUrl = "$Url.sha256"
 $ChecksumFile = Join-Path $TmpDir "$Archive.sha256"
@@ -136,23 +188,16 @@ try {
 }
 
 $ChecksumContent = Get-Content $ChecksumFile -Raw
-# Match the hash on the line referencing this archive; tolerate either a bare
-# hash line or "<hash>  <filename>". Hashes are 64 hex chars.
-$ExpectedHash = $null
-foreach ($line in ($ChecksumContent -split "`n")) {
-    if ($line -match '([0-9a-fA-F]{64})') {
-        $ExpectedHash = $Matches[1].ToLower()
-        break
-    }
-}
-
-if (-not $ExpectedHash) {
-    Write-Err "Checksum file was empty or malformed: $ChecksumUrl"
+try {
+    $ExpectedHash = Resolve-ArchiveChecksum -ChecksumContent $ChecksumContent -ArchiveName $Archive
+} catch {
+    Write-Err "Checksum file is invalid: $ChecksumUrl"
+    Write-Err $_.Exception.Message
     Write-Err "Refusing to install an unverified download. Aborting."
     exit 1
 }
 
-$ActualHash = (Get-FileHash -Path (Join-Path $TmpDir $Archive) -Algorithm SHA256).Hash.ToLower()
+$ActualHash = (Get-FileHash -Path (Join-Path $TmpDir $Archive) -Algorithm SHA256).Hash.ToLowerInvariant()
 if ($ActualHash -ne $ExpectedHash) {
     Write-Err "SHA-256 checksum mismatch!"
     Write-Err "Expected: $ExpectedHash"

--- a/scripts/test-install-checksum.ps1
+++ b/scripts/test-install-checksum.ps1
@@ -1,0 +1,73 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2026 Firelock, LLC
+
+$ErrorActionPreference = "Stop"
+Set-StrictMode -Version Latest
+
+$ScriptsDir = Split-Path -Parent $MyInvocation.MyCommand.Path
+$InstallerPath = Join-Path $ScriptsDir "install.ps1"
+$FixturesPath = Join-Path $ScriptsDir "install-checksum-fixtures.json"
+
+$Tokens = $null
+$ParseErrors = $null
+$InstallerAst = [System.Management.Automation.Language.Parser]::ParseFile(
+    $InstallerPath,
+    [ref]$Tokens,
+    [ref]$ParseErrors
+)
+if (@($ParseErrors).Count -gt 0) {
+    $Messages = @($ParseErrors | ForEach-Object { $_.Message }) -join "; "
+    throw "install.ps1 failed PowerShell parsing: $Messages"
+}
+
+$FunctionAst = $InstallerAst.Find(
+    {
+        param($Node)
+        $Node -is [System.Management.Automation.Language.FunctionDefinitionAst] -and
+            $Node.Name -ceq "Resolve-ArchiveChecksum"
+    },
+    $true
+)
+if ($null -eq $FunctionAst) {
+    throw "Resolve-ArchiveChecksum was not found in install.ps1"
+}
+
+. ([ScriptBlock]::Create($FunctionAst.Extent.Text))
+$Fixtures = Get-Content $FixturesPath -Raw | ConvertFrom-Json
+$Passed = 0
+
+foreach ($Case in $Fixtures.cases) {
+    $Actual = $null
+    $Failure = $null
+    try {
+        $Actual = Resolve-ArchiveChecksum `
+            -ChecksumContent ([string]$Case.content) `
+            -ArchiveName ([string]$Case.archive)
+    } catch {
+        $Failure = $_.Exception.Message
+    }
+
+    $ErrorProperty = $Case.PSObject.Properties["error_contains"]
+    if ($null -ne $ErrorProperty) {
+        $ExpectedError = [string]$ErrorProperty.Value
+        if ($null -eq $Failure) {
+            throw "$($Case.name): expected failure containing '$ExpectedError', got success '$Actual'"
+        }
+        if (-not $Failure.Contains($ExpectedError)) {
+            throw "$($Case.name): expected failure containing '$ExpectedError', got '$Failure'"
+        }
+    } else {
+        $Expected = [string]$Case.expected
+        if ($null -ne $Failure) {
+            throw "$($Case.name): unexpected failure '$Failure'"
+        }
+        if ($Actual -cne $Expected) {
+            throw "$($Case.name): expected '$Expected', got '$Actual'"
+        }
+    }
+
+    $Passed++
+    Write-Host "PASS: $($Case.name)"
+}
+
+Write-Host "$Passed checksum fixture cases passed"

--- a/scripts/test-install-checksum.py
+++ b/scripts/test-install-checksum.py
@@ -1,0 +1,131 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2026 Firelock, LLC
+
+"""Portable fixture and wiring checks for the Windows installer checksum gate."""
+
+from __future__ import annotations
+
+import json
+import re
+from pathlib import Path
+
+
+SCRIPTS_DIR = Path(__file__).resolve().parent
+ROOT = SCRIPTS_DIR.parent
+CHECKSUM_LINE = re.compile(r"^([0-9a-fA-F]{64})[ \t]+(\*?.+?)$")
+
+
+def resolve_archive_checksum(content: str, archive: str) -> str:
+    matches: list[str] = []
+    for line_number, raw_line in enumerate(content.splitlines(), start=1):
+        if not raw_line.strip() or raw_line.lstrip().startswith("#"):
+            continue
+        parsed = CHECKSUM_LINE.fullmatch(raw_line)
+        if parsed is None:
+            raise ValueError(
+                f"Checksum file contains malformed entry on line {line_number}"
+            )
+        checksum, filename = parsed.groups()
+        if filename.startswith("*"):
+            filename = filename[1:]
+        if filename == archive:
+            matches.append(checksum.lower())
+
+    if not matches:
+        raise ValueError(f"Checksum file has no entry for exact archive '{archive}'")
+    unique = sorted(set(matches))
+    if len(unique) > 1:
+        raise ValueError(
+            f"Checksum file has conflicting entries for exact archive '{archive}'"
+        )
+    return unique[0]
+
+
+def check_fixtures() -> int:
+    fixture_path = SCRIPTS_DIR / "install-checksum-fixtures.json"
+    fixture_data = json.loads(fixture_path.read_text(encoding="utf-8"))
+    cases = fixture_data.get("cases")
+    if not isinstance(cases, list) or not cases:
+        raise AssertionError(
+            "checksum fixture file must contain a non-empty cases array"
+        )
+
+    passed = 0
+    for case in cases:
+        failure: str | None = None
+        actual: str | None = None
+        try:
+            actual = resolve_archive_checksum(case["content"], case["archive"])
+        except ValueError as error:
+            failure = str(error)
+
+        expected_error = case.get("error_contains")
+        if expected_error is not None:
+            if failure is None or expected_error not in failure:
+                raise AssertionError(
+                    f"{case['name']}: expected error containing {expected_error!r}, got {failure!r}"
+                )
+        else:
+            if failure is not None:
+                raise AssertionError(f"{case['name']}: unexpected error: {failure}")
+            if actual != case["expected"]:
+                raise AssertionError(
+                    f"{case['name']}: expected {case['expected']!r}, got {actual!r}"
+                )
+
+        passed += 1
+        print(f"PASS: {case['name']}")
+    return passed
+
+
+def check_product_wiring() -> None:
+    installer = (SCRIPTS_DIR / "install.ps1").read_text(encoding="utf-8")
+    ci_workflow = (ROOT / ".github/workflows/ci.yml").read_text(encoding="utf-8")
+    release_workflow = (ROOT / ".github/workflows/release.yml").read_text(
+        encoding="utf-8"
+    )
+
+    installer_requirements = (
+        "function Resolve-ArchiveChecksum",
+        "$Filename -cne $ArchiveName",
+        "$UniqueHashes.Count -gt 1",
+        "Resolve-ArchiveChecksum -ChecksumContent $ChecksumContent -ArchiveName $Archive",
+    )
+    for requirement in installer_requirements:
+        if requirement not in installer:
+            raise AssertionError(
+                f"install.ps1 is missing checksum guard wiring: {requirement}"
+            )
+
+    release_requirements = (
+        '$ArchivePath = "$env:ARTIFACT.zip"',
+        "$Hash = (Get-FileHash -Algorithm SHA256 $ArchivePath).Hash.ToLowerInvariant()",
+        '"$Hash  $ArchivePath" | Set-Content -Encoding ascii "$ArchivePath.sha256"',
+    )
+    for requirement in release_requirements:
+        if requirement not in release_workflow:
+            raise AssertionError(
+                f"release.yml is missing filename-bound checksum output: {requirement}"
+            )
+
+    ci_requirements = (
+        "shell: pwsh",
+        "shell: powershell",
+        "run: ./scripts/test-install-checksum.ps1",
+    )
+    for requirement in ci_requirements:
+        if requirement not in ci_workflow:
+            raise AssertionError(
+                f"ci.yml is missing Windows installer test coverage: {requirement}"
+            )
+
+
+def main() -> None:
+    passed = check_fixtures()
+    check_product_wiring()
+    print(f"{passed} checksum fixture cases and product wiring passed")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- bind Windows installer checksums to the exact archive filename
- reject bare, malformed, missing, near-match, and conflicting checksum records
- emit standard filename-bound Windows SHA256 sidecars
- test shared fixtures under PowerShell 7, Windows PowerShell 5.1, Linux, and macOS

## Verification
- `python3 scripts/test-install-checksum.py` (8 fixtures + wiring)
- `ruff check scripts/test-install-checksum.py`
- `ruff format --check scripts/test-install-checksum.py`
- `actionlint .github/workflows/ci.yml`
- `actionlint -ignore 'property "cross" is not defined' .github/workflows/release.yml`
- `cargo fmt --all -- --check`
- `git diff --check HEAD^`

Native PowerShell execution is covered by the new Windows CI job because neither PowerShell runtime is installed on the local Mac.

Linear: FIR-1281