### PR TITLE
Enforce multi-agent coordination at write boundaries

### DIFF
--- a/crates/kin-cli/src/commands/bench_meta.rs
+++ b/crates/kin-cli/src/commands/bench_meta.rs
@@ -20,8 +20,42 @@ pub(crate) struct BenchMeta {
     vector_index_metadata_version: Option<u32>,
     feature_flags: Vec<&'static str>,
     embeddings: EmbeddingMeta,
+    coordination: CoordinationMeta,
     kin_commit: &'static str,
     kin_dirty: bool,
+}
+
+#[derive(Debug, Clone, Serialize, serde::Deserialize)]
+pub struct CoordinationMeta {
+    pub schema: String,
+    pub effective_mode: String,
+    pub default_mode: String,
+    pub hard_rejection_active: bool,
+    pub capability_evaluation_active: bool,
+    pub capability_fail_closed_active: bool,
+    pub intent_registration_linearized: bool,
+    pub max_concurrent_intents_enforced: bool,
+    pub hard_intent_capabilities_checked: Vec<String>,
+    pub transaction_capabilities_covered: Vec<String>,
+    pub surfaces: CoordinationSurfaceMeta,
+    pub durable_event_schema: String,
+    pub durable_event_store: String,
+    pub durable_event_fsync_before_broadcast: bool,
+    pub durable_event_families: Vec<String>,
+    pub contract_scope_claim_eligible: bool,
+    pub all_write_surfaces_claim_eligible: bool,
+}
+
+#[derive(Debug, Clone, Serialize, serde::Deserialize)]
+pub struct CoordinationSurfaceMeta {
+    pub vfs_agent_write_entity: bool,
+    pub vfs_agent_write_artifact: bool,
+    pub mcp_transaction_entity: bool,
+    pub mcp_transaction_artifact: bool,
+    pub mcp_relation_endpoint_entities: bool,
+    pub contract: bool,
+    pub direct_filesystem_write: bool,
+    pub non_transaction_graph_mutation_tools: bool,
 }
 
 #[derive(Debug, Clone, Serialize)]
@@ -131,6 +165,14 @@ pub async fn run(json: bool, prepared_state: bool) -> Result<()> {
             println!("vector_index_metadata_version: disabled");
         }
         println!("feature_flags: {}", meta.feature_flags.join(","));
+        println!(
+            "coordination_enforcement_mode: {}",
+            meta.coordination.effective_mode
+        );
+        println!(
+            "coordination_contract_scope_claim_eligible: {}",
+            meta.coordination.contract_scope_claim_eligible
+        );
         println!("kin_commit: {}", meta.kin_commit);
         println!("kin_dirty: {}", meta.kin_dirty);
         if let Some(model_id) = meta.embeddings.model_id.as_deref() {
@@ -160,9 +202,49 @@ pub(crate) fn build_meta() -> Result<BenchMeta> {
         vector_index_metadata_version: vector_index_metadata_version(),
         feature_flags: feature_flags(),
         embeddings: embedding_meta(),
+        coordination: coordination_meta(),
         kin_commit: build.sha,
         kin_dirty: build.dirty,
     })
+}
+
+pub fn coordination_meta() -> CoordinationMeta {
+    coordination_meta_for_mode(kin_mcp::CoordinationEnforcementMode::from_env())
+}
+
+pub fn coordination_meta_for_mode(mode: kin_mcp::CoordinationEnforcementMode) -> CoordinationMeta {
+    CoordinationMeta {
+        schema: "kin.coordination-enforcement.v1".to_string(),
+        effective_mode: mode.as_str().to_string(),
+        default_mode: "warn".to_string(),
+        hard_rejection_active: mode.is_enforcing(),
+        capability_evaluation_active: mode.evaluates(),
+        capability_fail_closed_active: mode.is_enforcing(),
+        intent_registration_linearized: true,
+        max_concurrent_intents_enforced: true,
+        hard_intent_capabilities_checked: vec!["can_write".to_string()],
+        transaction_capabilities_covered: vec!["can_write".to_string(), "can_commit".to_string()],
+        surfaces: CoordinationSurfaceMeta {
+            vfs_agent_write_entity: true,
+            vfs_agent_write_artifact: true,
+            mcp_transaction_entity: true,
+            mcp_transaction_artifact: true,
+            mcp_relation_endpoint_entities: true,
+            contract: false,
+            direct_filesystem_write: false,
+            non_transaction_graph_mutation_tools: false,
+        },
+        durable_event_schema: "kin.coordination-event.v1".to_string(),
+        durable_event_store: ".kin/coordination_events.jsonl".to_string(),
+        durable_event_fsync_before_broadcast: true,
+        durable_event_families: vec![
+            "intent_registration".to_string(),
+            "intent_release".to_string(),
+            "transaction_outcome".to_string(),
+        ],
+        contract_scope_claim_eligible: false,
+        all_write_surfaces_claim_eligible: false,
+    }
 }
 
 /// Whether the Metal embedding backend is *actually* compiled into this binary.

--- a/crates/kin-cli/tests/bench_meta_json.rs
+++ b/crates/kin-cli/tests/bench_meta_json.rs
@@ -32,6 +32,31 @@ fn bench_meta_json_reports_cache_key_dimensions() {
     assert!(payload["kin_commit"].is_string());
     assert!(payload["kin_dirty"].is_boolean());
 
+    let coordination = payload["coordination"]
+        .as_object()
+        .expect("coordination attestation object");
+    assert_eq!(coordination["schema"], "kin.coordination-enforcement.v1");
+    assert!(matches!(
+        coordination["effective_mode"].as_str(),
+        Some("off" | "warn" | "enforce")
+    ));
+    assert_eq!(coordination["default_mode"], "warn");
+    assert_eq!(
+        coordination["hard_rejection_active"],
+        coordination["effective_mode"] == "enforce"
+    );
+    assert_eq!(coordination["intent_registration_linearized"], true);
+    assert_eq!(coordination["max_concurrent_intents_enforced"], true);
+    assert_eq!(coordination["contract_scope_claim_eligible"], false);
+    assert_eq!(coordination["all_write_surfaces_claim_eligible"], false);
+    assert_eq!(coordination["surfaces"]["mcp_transaction_entity"], true);
+    assert_eq!(coordination["surfaces"]["contract"], false);
+    assert_eq!(
+        coordination["durable_event_schema"],
+        "kin.coordination-event.v1"
+    );
+    assert_eq!(coordination["durable_event_fsync_before_broadcast"], true);
+
     let embeddings = payload["embeddings"]
         .as_object()
         .expect("embeddings object");

--- a/crates/kin-daemon/src/api.rs
+++ b/crates/kin-daemon/src/api.rs
@@ -9,8 +9,8 @@ use std::sync::{Arc, OnceLock};
 use std::time::{Duration, Instant};
 
 use crate::state::{
-    CachedLocateRanking, CachedSemanticPage, DaemonEvent, DaemonState, ProjectionChangedSet,
-    VfsTreeCacheKey, VfsTreeSnapshot, LOCATE_RANKING_CACHE_CAP,
+    CachedLocateRanking, CachedSemanticPage, CoordinationEventDraft, DaemonEvent, DaemonState,
+    ProjectionChangedSet, VfsTreeCacheKey, VfsTreeSnapshot, LOCATE_RANKING_CACHE_CAP,
 };
 
 use axum::extract::{Path, Query, State};
@@ -112,6 +112,14 @@ pub struct HealthResponse {
     /// `kin_core::behavior_env`.
     #[serde(default)]
     pub behavior_env: kin_core::behavior_env::BehaviorEnv,
+    /// Effective coordination mode and exact surface/capability coverage for
+    /// operator and benchmark attestation.
+    #[serde(default = "kin_cli::commands::bench_meta::coordination_meta")]
+    pub coordination: kin_cli::commands::bench_meta::CoordinationMeta,
+    /// Must remain zero for a coordination-event stream to be eligible as a
+    /// complete citable measurement source during this daemon lifetime.
+    #[serde(default)]
+    pub coordination_event_persist_failures: u64,
     pub build: BuildResponse,
 }
 
@@ -232,6 +240,12 @@ struct RegisterIntentResponse {
     status: String,
     conflicts: Vec<IntentSummary>,
     downstream_warnings: Vec<IntentSummary>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    active_intents: Option<usize>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    max_concurrent_intents: Option<usize>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    required_capability: Option<String>,
 }
 
 #[derive(Debug, Serialize, Deserialize)]
@@ -1268,6 +1282,12 @@ async fn health(
         embed_worker_failed,
         graph_generation: DaemonState::read_generation_marker(&state.layout),
         behavior_env: kin_core::behavior_env::snapshot_from_process(),
+        coordination: kin_cli::commands::bench_meta::coordination_meta_for_mode(
+            state.coordination_mode(),
+        ),
+        coordination_event_persist_failures: state
+            .coordination_event_persist_failures
+            .load(std::sync::atomic::Ordering::Relaxed),
         build: current_build_response(),
     }))
 }
@@ -2759,6 +2779,7 @@ async fn end_session(
     Path(session_id): Path<String>,
     State(state): State<Arc<DaemonState>>,
 ) -> Result<impl IntoResponse, (StatusCode, String)> {
+    let _coordination = state.coordination_gate.lock().await;
     let session_id = parse_session_id(&session_id)?;
     let session = state
         .coordinator
@@ -2770,10 +2791,27 @@ async fn end_session(
                 format!("session not found: {session_id}"),
             )
         })?;
+    let intents = state
+        .coordinator
+        .list_intents(&session_id)
+        .map_err(internal_error)?;
     state
         .coordinator
         .deregister_session(&session_id)
         .map_err(internal_error)?;
+    for intent in intents {
+        state.record_coordination_event(CoordinationEventDraft {
+            event: "intent_release",
+            outcome: "session_ended".to_string(),
+            session_id: Some(session_id.to_string()),
+            intent_id: Some(intent.intent_id.to_string()),
+            intent_ids: vec![intent.intent_id.to_string()],
+            transaction_id: None,
+            scopes: intent.scopes.iter().map(format_scope).collect(),
+            enforcement_mode: state.coordination_mode().as_str().to_string(),
+            blocking_intent_ids: Vec::new(),
+        });
+    }
 
     Ok(Json(SessionEndResponse {
         session_id: session.session_id.to_string(),
@@ -2807,6 +2845,7 @@ async fn clear_session_intents(
     Path(session_id): Path<String>,
     State(state): State<Arc<DaemonState>>,
 ) -> Result<impl IntoResponse, (StatusCode, String)> {
+    let _coordination = state.coordination_gate.lock().await;
     let session_id = parse_session_id(&session_id)?;
     let intents = state
         .coordinator
@@ -2818,6 +2857,17 @@ async fn clear_session_intents(
             .coordinator
             .release_intent(&session_id, &intent.intent_id)
             .map_err(internal_error)?;
+        state.record_coordination_event(CoordinationEventDraft {
+            event: "intent_release",
+            outcome: "cleared".to_string(),
+            session_id: Some(session_id.to_string()),
+            intent_id: Some(intent.intent_id.to_string()),
+            intent_ids: vec![intent.intent_id.to_string()],
+            transaction_id: None,
+            scopes: intent.scopes.iter().map(format_scope).collect(),
+            enforcement_mode: state.coordination_mode().as_str().to_string(),
+            blocking_intent_ids: Vec::new(),
+        });
     }
 
     Ok(Json(ClearedIntentsResponse {
@@ -2843,6 +2893,10 @@ async fn register_intent(
     State(state): State<Arc<DaemonState>>,
     Json(request): Json<RegisterIntentRequest>,
 ) -> Result<impl IntoResponse, (StatusCode, String)> {
+    // Serialize the full check+register decision with transaction preflight and
+    // apply. This daemon gate complements the coordinator's own linearization
+    // lock and closes the cross-surface HTTP race.
+    let _coordination = state.coordination_gate.lock().await;
     let mut scope_values = request.scopes;
     if scope_values.is_empty() {
         if request.scope.trim().is_empty() {
@@ -2857,6 +2911,7 @@ async fn register_intent(
         .iter()
         .map(|scope| parse_scope(scope))
         .collect::<Result<Vec<_>, _>>()?;
+    let scope_labels = scopes.iter().map(format_scope).collect::<Vec<_>>();
     let lock_type = parse_lock_type(&request.lock_type)?;
     let session_id = resolve_or_create_session(&state, request.session_id.as_deref())?;
     let result = state
@@ -2874,28 +2929,95 @@ async fn register_intent(
         )
         .map_err(internal_error)?;
 
-    let response = match result {
+    let (response, outcome, blocking_intent_ids) = match result {
         crate::session_registry::IntentRegistrationResult::Registered {
             intent_id,
             downstream_warnings,
-        } => RegisterIntentResponse {
-            intent_id: intent_id.to_string(),
-            session_id: session_id.to_string(),
-            status: "registered".to_string(),
-            conflicts: Vec::new(),
-            downstream_warnings,
-        },
+        } => (
+            RegisterIntentResponse {
+                intent_id: intent_id.to_string(),
+                session_id: session_id.to_string(),
+                status: "registered".to_string(),
+                conflicts: Vec::new(),
+                downstream_warnings,
+                active_intents: None,
+                max_concurrent_intents: None,
+                required_capability: None,
+            },
+            "registered".to_string(),
+            Vec::new(),
+        ),
         crate::session_registry::IntentRegistrationResult::Blocked {
             intent_id,
             conflicts,
-        } => RegisterIntentResponse {
-            intent_id: intent_id.to_string(),
-            session_id: session_id.to_string(),
-            status: "blocked".to_string(),
-            conflicts,
-            downstream_warnings: Vec::new(),
-        },
+        } => {
+            let blocking = conflicts
+                .iter()
+                .map(|conflict| conflict.intent_id.to_string())
+                .collect();
+            (
+                RegisterIntentResponse {
+                    intent_id: intent_id.to_string(),
+                    session_id: session_id.to_string(),
+                    status: "blocked".to_string(),
+                    conflicts,
+                    downstream_warnings: Vec::new(),
+                    active_intents: None,
+                    max_concurrent_intents: None,
+                    required_capability: None,
+                },
+                "blocked".to_string(),
+                blocking,
+            )
+        }
+        crate::session_registry::IntentRegistrationResult::LimitExceeded {
+            intent_id,
+            active,
+            limit,
+        } => (
+            RegisterIntentResponse {
+                intent_id: intent_id.to_string(),
+                session_id: session_id.to_string(),
+                status: "limit_exceeded".to_string(),
+                conflicts: Vec::new(),
+                downstream_warnings: Vec::new(),
+                active_intents: Some(active),
+                max_concurrent_intents: Some(limit),
+                required_capability: None,
+            },
+            "limit_exceeded".to_string(),
+            Vec::new(),
+        ),
+        crate::session_registry::IntentRegistrationResult::CapabilityDenied {
+            intent_id,
+            capability,
+        } => (
+            RegisterIntentResponse {
+                intent_id: intent_id.to_string(),
+                session_id: session_id.to_string(),
+                status: "capability_denied".to_string(),
+                conflicts: Vec::new(),
+                downstream_warnings: Vec::new(),
+                active_intents: None,
+                max_concurrent_intents: None,
+                required_capability: Some(capability.to_string()),
+            },
+            "capability_denied".to_string(),
+            Vec::new(),
+        ),
     };
+
+    state.record_coordination_event(CoordinationEventDraft {
+        event: "intent_registration",
+        outcome,
+        session_id: Some(session_id.to_string()),
+        intent_id: Some(response.intent_id.clone()),
+        intent_ids: vec![response.intent_id.clone()],
+        transaction_id: None,
+        scopes: scope_labels,
+        enforcement_mode: state.coordination_mode().as_str().to_string(),
+        blocking_intent_ids,
+    });
 
     Ok(Json(response))
 }
@@ -2905,6 +3027,7 @@ async fn release_intent(
     Path(intent_id): Path<String>,
     State(state): State<Arc<DaemonState>>,
 ) -> Result<impl IntoResponse, (StatusCode, String)> {
+    let _coordination = state.coordination_gate.lock().await;
     let intent_id = parse_intent_id(&intent_id)?;
     let intent = state
         .graph
@@ -2921,6 +3044,17 @@ async fn release_intent(
         .coordinator
         .release_intent(&intent.session_id, &intent_id)
         .map_err(internal_error)?;
+    state.record_coordination_event(CoordinationEventDraft {
+        event: "intent_release",
+        outcome: "released".to_string(),
+        session_id: Some(intent.session_id.to_string()),
+        intent_id: Some(intent_id.to_string()),
+        intent_ids: vec![intent_id.to_string()],
+        transaction_id: None,
+        scopes: intent.scopes.iter().map(format_scope).collect(),
+        enforcement_mode: state.coordination_mode().as_str().to_string(),
+        blocking_intent_ids: Vec::new(),
+    });
     Ok(StatusCode::NO_CONTENT)
 }
 
@@ -3999,6 +4133,7 @@ fn mcp_session_registry_snapshot(
     let sessions = state.coordinator.list_sessions().map_err(internal_error)?;
     let intents = state.graph.list_all_intents().map_err(internal_error)?;
     let registry = kin_mcp::SessionRegistry::new();
+    registry.set_coordination_mode(state.coordination_mode());
     registry.replace_agent_sessions_and_intents(sessions, intents);
     // Restore in-flight transactions so a registry built fresh for this request
     // sees what earlier requests staged; sessions/intents persist via the graph,
@@ -4089,6 +4224,83 @@ fn collect_pre_commit_entities(
         }
     }
     (entities, supplied_bodies)
+}
+
+fn transaction_coordination_context(
+    state: &DaemonState,
+    sessions: &kin_mcp::SessionRegistry,
+    arguments: &HashMap<String, serde_json::Value>,
+) -> (
+    Option<String>,
+    Option<String>,
+    Vec<IntentScope>,
+    Vec<String>,
+) {
+    let transaction_id = arguments
+        .get("transaction_id")
+        .and_then(serde_json::Value::as_str)
+        .map(str::to_string);
+    let Some(transaction) = transaction_id
+        .as_deref()
+        .and_then(|id| sessions.get_transaction(id))
+    else {
+        return (None, transaction_id, Vec::new(), Vec::new());
+    };
+
+    let mut touched = Vec::new();
+    let mut push = |scope: IntentScope| {
+        if !touched.contains(&scope) {
+            touched.push(scope);
+        }
+    };
+    let mut operations = transaction.staged_operations;
+    if let Some(inline) = arguments.get("operations") {
+        if let Ok(mut parsed) =
+            serde_json::from_value::<Vec<kin_mcp::McpMutationOperation>>(inline.clone())
+        {
+            operations.append(&mut parsed);
+        }
+    }
+    for operation in &operations {
+        match operation.payload.as_ref() {
+            Some(kin_mcp::McpMutationPayload::Entity(entity)) => {
+                push(IntentScope::Entity(entity.id));
+                if let Some(file) = entity.file_origin.clone() {
+                    push(IntentScope::Artifact(file));
+                }
+                let mut existing = state.graph.get_entity(&entity.id).ok().flatten();
+                if existing.is_none() {
+                    existing = state
+                        .graph
+                        .query_entities(&kin_model::EntityFilter {
+                            name_pattern: Some(entity.name.clone()),
+                            kinds: Some(vec![entity.kind]),
+                            ..Default::default()
+                        })
+                        .ok()
+                        .and_then(|mut matches| matches.pop());
+                }
+                if let Some(existing) = existing {
+                    push(IntentScope::Entity(existing.id));
+                    if let Some(file) = existing.file_origin {
+                        push(IntentScope::Artifact(file));
+                    }
+                }
+            }
+            Some(kin_mcp::McpMutationPayload::Relation { from, to, .. }) => {
+                push(IntentScope::Entity(*from));
+                push(IntentScope::Entity(*to));
+            }
+            Some(kin_mcp::McpMutationPayload::Blob(_)) | None => {}
+        }
+    }
+    let labels = touched.iter().map(format_scope).collect();
+    (
+        Some(transaction.session_id),
+        transaction_id,
+        touched,
+        labels,
+    )
 }
 
 /// The transaction id a terminal transaction tool (commit/abort) acted on, used
@@ -5143,7 +5355,45 @@ async fn mcp_tools_call(
         )));
     }
 
+    // Serialize the full daemon transaction lifecycle and other graph-mutating
+    // MCP tools. Commit holds this gate from final intent/capability preflight
+    // through graph application and projection; intent registration uses it
+    // too, closing transaction-state races and keeping touched-scope derivation
+    // stable until apply. Non-transaction mutators are sequenced here but remain
+    // explicitly unattested for intent-veto coverage in bench-meta.
+    let _coordination_guard = if mcp_tool_is_transaction(&request.name) || mutates {
+        Some(state.coordination_gate.lock().await)
+    } else {
+        None
+    };
+
     let sessions = mcp_session_registry_snapshot(&state)?;
+    let (transaction_session_id, transaction_id, transaction_scopes, transaction_scope_labels) =
+        if request.name == "kin_transaction_commit" {
+            transaction_coordination_context(&state, &sessions, &request.arguments)
+        } else {
+            (None, None, Vec::new(), Vec::new())
+        };
+    let transaction_preflight = transaction_session_id.as_deref().map(|session_id| {
+        sessions.evaluate_transaction_write(session_id, transaction_scopes.clone())
+    });
+    let transaction_intent_ids = transaction_session_id
+        .as_deref()
+        .and_then(|session_id| uuid::Uuid::parse_str(session_id).ok().map(SessionId))
+        .map(|session_id| {
+            sessions
+                .list_intents_for_session(&session_id)
+                .into_iter()
+                .filter(|intent| {
+                    intent
+                        .scopes
+                        .iter()
+                        .any(|scope| transaction_scopes.contains(scope))
+                })
+                .map(|intent| intent.intent_id.to_string())
+                .collect::<Vec<_>>()
+        })
+        .unwrap_or_default();
 
     // Snapshot entity state before the commit so we can project the
     // mutations into working-directory files after the graph is updated.
@@ -5179,6 +5429,33 @@ async fn mcp_tools_call(
                 forget_mcp_transaction(&state, &tx_id);
             }
         }
+    }
+
+    if request.name == "kin_transaction_commit" && result.is_error == Some(true) {
+        state.record_coordination_event(CoordinationEventDraft {
+            event: "transaction_outcome",
+            outcome: "rejected_before_graph_apply".to_string(),
+            session_id: transaction_session_id.clone(),
+            intent_id: None,
+            intent_ids: transaction_intent_ids.clone(),
+            transaction_id: transaction_id.clone(),
+            scopes: transaction_scope_labels.clone(),
+            enforcement_mode: transaction_preflight
+                .as_ref()
+                .map(|preflight| preflight.mode.as_str())
+                .unwrap_or_else(|| state.coordination_mode().as_str())
+                .to_string(),
+            blocking_intent_ids: transaction_preflight
+                .as_ref()
+                .map(|preflight| {
+                    preflight
+                        .blocking_intents
+                        .iter()
+                        .map(|intent| intent.intent_id.to_string())
+                        .collect()
+                })
+                .unwrap_or_default(),
+        });
     }
 
     if mutates && result.is_error != Some(true) {
@@ -5217,6 +5494,21 @@ async fn mcp_tools_call(
             .await
             {
                 Err(proj_err) => {
+                    state.record_coordination_event(CoordinationEventDraft {
+                        event: "transaction_outcome",
+                        outcome: "projection_failed_after_graph_apply".to_string(),
+                        session_id: transaction_session_id.clone(),
+                        intent_id: None,
+                        intent_ids: transaction_intent_ids.clone(),
+                        transaction_id: transaction_id.clone(),
+                        scopes: transaction_scope_labels.clone(),
+                        enforcement_mode: transaction_preflight
+                            .as_ref()
+                            .map(|preflight| preflight.mode.as_str())
+                            .unwrap_or("warn")
+                            .to_string(),
+                        blocking_intent_ids: Vec::new(),
+                    });
                     return Ok(Json(kin_mcp::ToolCallResult::error(format!(
                         "graph commit succeeded but file projection failed — agent intent is \
                          preserved in the graph; retry projection or inspect the source file. \
@@ -5239,6 +5531,21 @@ async fn mcp_tools_call(
                             )
                         })
                         .collect();
+                    state.record_coordination_event(CoordinationEventDraft {
+                        event: "transaction_outcome",
+                        outcome: "projection_conflict_after_graph_apply".to_string(),
+                        session_id: transaction_session_id.clone(),
+                        intent_id: None,
+                        intent_ids: transaction_intent_ids.clone(),
+                        transaction_id: transaction_id.clone(),
+                        scopes: transaction_scope_labels.clone(),
+                        enforcement_mode: transaction_preflight
+                            .as_ref()
+                            .map(|preflight| preflight.mode.as_str())
+                            .unwrap_or("warn")
+                            .to_string(),
+                        blocking_intent_ids: Vec::new(),
+                    });
                     return Ok(Json(kin_mcp::ToolCallResult::error(format!(
                         "graph commit succeeded but {n} entity/entities had concurrent file \
                          edits — those entities were NOT projected (human edits preserved). \
@@ -5255,6 +5562,30 @@ async fn mcp_tools_call(
         // response so a commit reports what it did instead of an opaque
         // "committed". `ops_applied`/`empty` already rode in from the handler.
         result = enrich_commit_result(result, &new_root_hash, &modified_files, &collision_warnings);
+        state.record_coordination_event(CoordinationEventDraft {
+            event: "transaction_outcome",
+            outcome: "committed".to_string(),
+            session_id: transaction_session_id,
+            intent_id: None,
+            intent_ids: transaction_intent_ids,
+            transaction_id,
+            scopes: transaction_scope_labels,
+            enforcement_mode: transaction_preflight
+                .as_ref()
+                .map(|preflight| preflight.mode.as_str())
+                .unwrap_or("warn")
+                .to_string(),
+            blocking_intent_ids: transaction_preflight
+                .as_ref()
+                .map(|preflight| {
+                    preflight
+                        .blocking_intents
+                        .iter()
+                        .map(|intent| intent.intent_id.to_string())
+                        .collect()
+                })
+                .unwrap_or_default(),
+        });
     }
 
     Ok(Json(result))
@@ -6755,6 +7086,9 @@ async fn vfs_file_changed(
     State(state): State<Arc<DaemonState>>,
     Json(request): Json<FileChangedRequest>,
 ) -> Result<impl IntoResponse, (StatusCode, String)> {
+    // One ordering with intent registration and transaction commits: no hard
+    // intent can appear after this path's precheck but before graph apply.
+    let _coordination = state.coordination_gate.lock().await;
     let file_path = std::path::PathBuf::from(&request.path);
     tracing::info!(path = %request.path, "VFS file-changed notification received");
 
@@ -6938,6 +7272,7 @@ async fn vfs_write_notify(
     State(state): State<Arc<DaemonState>>,
     Json(request): Json<WriteNotifyRequest>,
 ) -> Result<impl IntoResponse, (StatusCode, String)> {
+    let _coordination = state.coordination_gate.lock().await;
     let file_path = std::path::PathBuf::from(&request.file_path);
     tracing::info!(path = %request.file_path, "VFS write-notify received");
 
@@ -7098,7 +7433,7 @@ async fn vfs_write_notify(
 /// GET /vfs/subscribe — SSE stream for real-time invalidation events.
 ///
 /// Subscribers receive DaemonEvent messages (EntityChanged, TreeChanged,
-/// OverlayUpdated, GraphRootChanged) as they happen. The VFS daemon uses
+/// OverlayUpdated, GraphRootChanged, Coordination) as they happen. The VFS daemon uses
 /// these to invalidate its cache; the spine uses them to update its metadata index.
 ///
 /// Protocol: Server-Sent Events (text/event-stream). Each event is a JSON
@@ -7444,7 +7779,10 @@ fn resolve_or_create_session(
             SessionTransport::Cli,
             None,
             state.layout.working_dir().to_path_buf(),
-            SessionCapabilities::default(),
+            SessionCapabilities {
+                can_write: true,
+                ..SessionCapabilities::default()
+            },
         )
         .map_err(internal_error)
 }
@@ -8594,6 +8932,11 @@ mod tests {
         assert!(!json.build.built_at.is_empty());
         // Additive freshness marker present; 0 before any snapshot is committed.
         assert_eq!(json.graph_generation, 0);
+        assert_eq!(json.coordination.schema, "kin.coordination-enforcement.v1");
+        assert!(json.coordination.surfaces.mcp_transaction_entity);
+        assert!(!json.coordination.surfaces.contract);
+        assert!(!json.coordination.contract_scope_claim_eligible);
+        assert_eq!(json.coordination_event_persist_failures, 0);
     }
 
     #[tokio::test]
@@ -9091,6 +9434,221 @@ mod tests {
             before + 1,
             "committed entity must land in the canonical graph"
         );
+    }
+
+    #[tokio::test]
+    async fn mcp_transaction_enforce_rejects_before_graph_apply_and_records_event() {
+        let state = test_state();
+        *state
+            .coordination_mode
+            .write()
+            .unwrap_or_else(std::sync::PoisonError::into_inner) =
+            kin_mcp::CoordinationEnforcementMode::Enforce;
+        state
+            .is_initialized
+            .store(true, std::sync::atomic::Ordering::Relaxed);
+
+        let capabilities = SessionCapabilities {
+            can_write: true,
+            can_commit: true,
+            ..SessionCapabilities::default()
+        };
+        let owner = state
+            .coordinator
+            .register_session(
+                "claude-code",
+                "owner",
+                SessionTransport::Mcp,
+                None,
+                state.layout.working_dir().to_path_buf(),
+                capabilities.clone(),
+            )
+            .unwrap();
+        let caller = state
+            .coordinator
+            .register_session(
+                "codex",
+                "caller",
+                SessionTransport::Mcp,
+                None,
+                state.layout.working_dir().to_path_buf(),
+                capabilities,
+            )
+            .unwrap();
+        let entity = test_entity("blocked_fn", "src/lib.rs");
+        let registration = state
+            .coordinator
+            .register_intent(
+                &owner,
+                vec![IntentScope::Entity(entity.id)],
+                LockType::Hard,
+                "exclusive edit",
+                None,
+            )
+            .unwrap();
+        assert!(matches!(
+            registration,
+            crate::session_registry::IntentRegistrationResult::Registered { .. }
+        ));
+        let before = state.graph.entity_count();
+
+        let begin = mcp_call(
+            router(Arc::clone(&state)),
+            "kin_transaction_begin",
+            serde_json::json!({
+                "session_id": caller.to_string(),
+                "scope": "file:src/lib.rs"
+            }),
+        )
+        .await;
+        let begin_json: serde_json::Value = serde_json::from_str(&mcp_result_text(&begin)).unwrap();
+        let tx_id = begin_json["transaction_id"].as_str().unwrap().to_string();
+        let stage = mcp_call(
+            router(Arc::clone(&state)),
+            "kin_transaction_stage",
+            serde_json::json!({
+                "transaction_id": tx_id,
+                "operations": [{
+                    "verb": "create",
+                    "target": "",
+                    "payload": { "Entity": entity },
+                    "description": "must be vetoed"
+                }]
+            }),
+        )
+        .await;
+        assert_ne!(stage.is_error, Some(true));
+
+        let commit = mcp_call(
+            router(Arc::clone(&state)),
+            "kin_transaction_commit",
+            serde_json::json!({ "transaction_id": tx_id }),
+        )
+        .await;
+        assert_eq!(commit.is_error, Some(true));
+        assert!(mcp_result_text(&commit).contains("before graph apply"));
+        assert_eq!(
+            state.graph.entity_count(),
+            before,
+            "rejected transaction must not mutate graph truth"
+        );
+
+        let records = std::fs::read_to_string(state.coordination_events.path()).unwrap();
+        let last: crate::state::CoordinationEventEnvelope =
+            serde_json::from_str(records.lines().last().unwrap()).unwrap();
+        assert_eq!(last.event, "transaction_outcome");
+        assert_eq!(last.outcome, "rejected_before_graph_apply");
+        assert_eq!(last.transaction_id.as_deref(), Some(tx_id.as_str()));
+        assert_eq!(last.session_id, Some(caller.to_string()));
+        assert_eq!(last.enforcement_mode, "enforce");
+        assert_eq!(last.blocking_intent_ids.len(), 1);
+    }
+
+    #[tokio::test]
+    async fn mcp_transaction_preflight_covers_name_kind_upsert_resolution() {
+        let state = test_state();
+        *state
+            .coordination_mode
+            .write()
+            .unwrap_or_else(std::sync::PoisonError::into_inner) =
+            kin_mcp::CoordinationEnforcementMode::Enforce;
+        state
+            .is_initialized
+            .store(true, std::sync::atomic::Ordering::Relaxed);
+
+        let capabilities = SessionCapabilities {
+            can_write: true,
+            can_commit: true,
+            ..SessionCapabilities::default()
+        };
+        let owner = state
+            .coordinator
+            .register_session(
+                "claude-code",
+                "owner",
+                SessionTransport::Mcp,
+                None,
+                state.layout.working_dir().to_path_buf(),
+                capabilities.clone(),
+            )
+            .unwrap();
+        let caller = state
+            .coordinator
+            .register_session(
+                "codex",
+                "caller",
+                SessionTransport::Mcp,
+                None,
+                state.layout.working_dir().to_path_buf(),
+                capabilities,
+            )
+            .unwrap();
+
+        let existing = test_entity("resolved_by_name", "src/protected.py");
+        state.graph.upsert_entity(&existing).unwrap();
+        assert!(matches!(
+            state
+                .coordinator
+                .register_intent(
+                    &owner,
+                    vec![IntentScope::Entity(existing.id)],
+                    LockType::Hard,
+                    "protect existing entity",
+                    None,
+                )
+                .unwrap(),
+            crate::session_registry::IntentRegistrationResult::Registered { .. }
+        ));
+
+        // The commit path resolves an unknown payload id by name+kind. The
+        // preflight must mirror that resolution or a caller could bypass an
+        // intent on `existing.id` by submitting a fresh id with the same name.
+        let mut alias_payload = existing.clone();
+        alias_payload.id = EntityId::new();
+        alias_payload.signature = "def resolved_by_name(changed)".to_string();
+        let alias_id = alias_payload.id;
+        let begin = mcp_call(
+            router(Arc::clone(&state)),
+            "kin_transaction_begin",
+            json!({ "session_id": caller.to_string(), "scope": "entity" }),
+        )
+        .await;
+        let begin_json: serde_json::Value = serde_json::from_str(&mcp_result_text(&begin)).unwrap();
+        let tx_id = begin_json["transaction_id"].as_str().unwrap().to_string();
+        let stage = mcp_call(
+            router(Arc::clone(&state)),
+            "kin_transaction_stage",
+            json!({
+                "transaction_id": tx_id,
+                "operations": [{
+                    "verb": "upsert",
+                    "target": "",
+                    "payload": { "Entity": alias_payload },
+                    "description": "attempt id-alias bypass"
+                }]
+            }),
+        )
+        .await;
+        assert_ne!(stage.is_error, Some(true));
+
+        let commit = mcp_call(
+            router(Arc::clone(&state)),
+            "kin_transaction_commit",
+            json!({ "transaction_id": tx_id }),
+        )
+        .await;
+        assert_eq!(commit.is_error, Some(true));
+        assert!(mcp_result_text(&commit).contains(&existing.id.to_string()));
+        assert_eq!(
+            state
+                .graph
+                .get_entity(&existing.id)
+                .unwrap()
+                .unwrap()
+                .signature,
+            existing.signature
+        );
+        assert!(state.graph.get_entity(&alias_id).unwrap().is_none());
     }
 
     #[test]
@@ -10226,7 +10784,10 @@ mod tests {
                 SessionTransport::Cli,
                 None,
                 state.layout.working_dir().to_path_buf(),
-                SessionCapabilities::default(),
+                SessionCapabilities {
+                    can_write: true,
+                    ..SessionCapabilities::default()
+                },
             )
             .unwrap();
         let entity_id = EntityId::new();
@@ -10299,6 +10860,62 @@ mod tests {
         let registered: RegisterIntentResponse = serde_json::from_slice(&body).unwrap();
         assert_eq!(registered.status, "registered");
         assert!(!registered.session_id.is_empty());
+
+        let records = std::fs::read_to_string(state.coordination_events.path()).unwrap();
+        let registered_event: crate::state::CoordinationEventEnvelope =
+            serde_json::from_str(records.lines().last().unwrap()).unwrap();
+        assert_eq!(registered_event.event, "intent_registration");
+        assert_eq!(registered_event.outcome, "registered");
+        assert_eq!(
+            registered_event.intent_id.as_deref(),
+            Some(registered.intent_id.as_str())
+        );
+        assert_eq!(registered_event.kin_version, kin_buildinfo::version());
+
+        let contender = state
+            .coordinator
+            .register_session(
+                "claude-code",
+                "contender",
+                SessionTransport::Mcp,
+                None,
+                state.layout.working_dir().to_path_buf(),
+                SessionCapabilities {
+                    can_write: true,
+                    ..SessionCapabilities::default()
+                },
+            )
+            .unwrap();
+        let blocked = app
+            .clone()
+            .oneshot(
+                Request::post("/intent/register")
+                    .header("content-type", "application/json")
+                    .body(Body::from(
+                        json!({
+                            "session_id": contender.to_string(),
+                            "scope": "file:src/lib.rs",
+                            "lock_type": "hard",
+                            "task_description": "conflicting edit"
+                        })
+                        .to_string(),
+                    ))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(blocked.status(), StatusCode::OK);
+        let blocked_body = axum::body::to_bytes(blocked.into_body(), 4096)
+            .await
+            .unwrap();
+        let blocked: RegisterIntentResponse = serde_json::from_slice(&blocked_body).unwrap();
+        assert_eq!(blocked.status, "blocked");
+        assert_eq!(blocked.conflicts.len(), 1);
+        let records = std::fs::read_to_string(state.coordination_events.path()).unwrap();
+        let blocked_event: crate::state::CoordinationEventEnvelope =
+            serde_json::from_str(records.lines().last().unwrap()).unwrap();
+        assert_eq!(blocked_event.outcome, "blocked");
+        assert_eq!(blocked_event.blocking_intent_ids.len(), 1);
 
         let traffic = app
             .clone()
@@ -13164,7 +13781,10 @@ mod tests {
                 SessionTransport::Mcp,
                 None,
                 state.layout.working_dir().to_path_buf(),
-                SessionCapabilities::default(),
+                SessionCapabilities {
+                    can_write: true,
+                    ..SessionCapabilities::default()
+                },
             )
             .unwrap()
     }

--- a/crates/kin-daemon/src/lib.rs
+++ b/crates/kin-daemon/src/lib.rs
@@ -35,9 +35,11 @@
 //! # Write veto (`KIN_WRITE_VETO`)
 //!
 //! Rung-3 of the write path. The agent-write apply paths (`POST /vfs/write-notify`,
-//! `POST /vfs/file-changed`) evaluate whether a write touches a scope held under
-//! another session's hard intent and, by default, surface the collision without
-//! blocking.
+//! `POST /vfs/file-changed`, and MCP `kin_transaction_commit`) evaluate whether
+//! a write touches a scope held under another session's hard intent and, by
+//! default, surface the collision without blocking. Intent registration and
+//! transaction apply share a coordinator gate, so enforce mode cannot race a
+//! hard-intent registration between preflight and graph apply.
 //!
 //! - Default (unset): **warn**. The write still proceeds — a colliding write is
 //!   declined by the reconciler's own check and reported as a soft notification —
@@ -47,13 +49,14 @@
 //! - `KIN_WRITE_VETO=enforce`: the write is rejected *before* it is folded into
 //!   the graph with a structured `409 Conflict` (`error: "write_veto"`) naming
 //!   the blocking intent(s).
-//! - `KIN_WRITE_VETO=off` (`0`/`false`/`disabled`/`none`): the veto never
-//!   evaluates; the apply path is byte-identical to pre-veto behavior (no
-//!   annotation).
+//! - `KIN_WRITE_VETO=off`: the veto never evaluates and never annotates or
+//!   rejects. MCP transaction responses still carry the additive coordination
+//!   coverage attestation with `evaluated:false`.
 //!
 //! What rung-3 enforces today is exactly **entity/artifact scope containment
 //! versus other sessions' hard intents** — the only "contract" expressible with
-//! current intent data. A session is never blocked by its own intent, and soft
+//! current intent data. MCP relation mutations cover their endpoint entities.
+//! A session is never blocked by its own intent, and soft
 //! intents stay advisory. Content-hash and semantic-contract (e.g.
 //! [`IntentScope::Contract`](kin_model::session::IntentScope)) vetoes are future
 //! work: no contract-content data exists at the apply boundary, and file writes
@@ -90,9 +93,16 @@
 //!   metadata, not entity truth; ungated.
 //! - `PUT /graph/branches/{name}/head`, `DELETE /graph/branches/{name}`: branch
 //!   ref operations; ungated.
-//! - `POST /mcp/tools/call` (`mcp_tools_call`): MCP write transactions — out of
-//!   this crate's veto scope (kin-mcp lane), with its own stage/commit
-//!   validation.
+//! - `POST /mcp/tools/call` (`kin_transaction_commit`): **write-veto** before
+//!   `apply_transaction_delta`, plus `can_write`/`can_commit` capability checks.
+//!   Enforce mode fails closed for an unknown/non-rich session. Exact entity,
+//!   entity-file artifact, and relation-endpoint scopes are covered; contract
+//!   scopes and non-transaction graph-mutating MCP tools are explicitly not
+//!   claim-eligible yet. Each terminal outcome is submitted to
+//!   `.kin/coordination_events.jsonl` with sequence, repo/session/intent,
+//!   effective mode, and release attribution; a successful append is fsynced
+//!   before live broadcast, and persistence failures are logged without a
+//!   misleading broadcast.
 
 pub mod api;
 pub mod commit_deltas;

--- a/crates/kin-daemon/src/session_registry.rs
+++ b/crates/kin-daemon/src/session_registry.rs
@@ -2,7 +2,7 @@
 // Copyright 2026 Firelock, LLC
 
 use std::path::PathBuf;
-use std::sync::Arc;
+use std::sync::{Arc, Mutex};
 use std::time::Duration;
 
 use tracing::{debug, info, warn};
@@ -30,6 +30,19 @@ pub enum IntentRegistrationResult {
         intent_id: IntentId,
         conflicts: Vec<IntentSummary>,
     },
+    /// Registration rejected because the session has reached the concurrency
+    /// limit it declared at session start.
+    LimitExceeded {
+        intent_id: IntentId,
+        active: usize,
+        limit: usize,
+    },
+    /// A hard intent can block other writers, so only a session that declared
+    /// write capability may register one.
+    CapabilityDenied {
+        intent_id: IntentId,
+        capability: &'static str,
+    },
 }
 
 /// Traffic check result for a set of scopes.
@@ -48,6 +61,12 @@ pub struct TrafficCheck {
 /// higher-level lifecycle operations described in PLAN_P2.md Section 4.7.
 pub struct SessionCoordinator {
     graph: Arc<kin_db::InMemoryGraph>,
+    /// Linearization point for session/intent lifecycle mutations. `kin-db`'s
+    /// public `SessionStore` API exposes individual CRUD calls, so the
+    /// conflict-check + limit-check + insert sequence must be serialized here
+    /// at the owning coordinator boundary rather than performed as racy reads
+    /// followed by a later write.
+    arbitration: Mutex<()>,
     /// Heartbeat interval used for stale-session detection.
     heartbeat_interval: Duration,
 }
@@ -57,6 +76,7 @@ impl SessionCoordinator {
     pub fn new(graph: Arc<kin_db::InMemoryGraph>) -> Self {
         Self {
             graph,
+            arbitration: Mutex::new(()),
             heartbeat_interval: Duration::from_secs(30),
         }
     }
@@ -65,6 +85,7 @@ impl SessionCoordinator {
     pub fn with_heartbeat_interval(graph: Arc<kin_db::InMemoryGraph>, interval: Duration) -> Self {
         Self {
             graph,
+            arbitration: Mutex::new(()),
             heartbeat_interval: interval,
         }
     }
@@ -135,6 +156,10 @@ impl SessionCoordinator {
 
     /// Deregister a session and clean up all its intents.
     pub fn deregister_session(&self, session_id: &SessionId) -> Result<()> {
+        let _arbitration = self
+            .arbitration
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
         for intent in self.list_intents(session_id)? {
             self.graph
                 .delete_intent(&intent.intent_id)
@@ -179,12 +204,21 @@ impl SessionCoordinator {
         task_description: &str,
         expires_at: Option<Timestamp>,
     ) -> Result<IntentRegistrationResult> {
+        // This guard is the linearization point for the whole arbitration
+        // decision. Concurrent hard registrations cannot both observe an
+        // empty conflict set, and a release/deregister cannot race the session
+        // limit check.
+        let _arbitration = self
+            .arbitration
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
+
         // 1. Validate session exists.
         let session = self
             .graph
             .get_session(session_id)
             .map_err(DaemonError::from)?;
-        let _session = session.ok_or_else(|| {
+        let session = session.ok_or_else(|| {
             DaemonError::Graph(kin_db::KinDbError::NotFound(format!(
                 "session not found: {}",
                 session_id
@@ -193,6 +227,27 @@ impl SessionCoordinator {
 
         let intent_id = IntentId::new();
         let now = Timestamp::now();
+
+        if lock_type == LockType::Hard && !session.capabilities.can_write {
+            return Ok(IntentRegistrationResult::CapabilityDenied {
+                intent_id,
+                capability: "can_write",
+            });
+        }
+
+        let active = self
+            .graph
+            .list_intents_for_session(session_id)
+            .map_err(DaemonError::from)?
+            .len();
+        let limit = session.capabilities.max_concurrent_intents;
+        if active >= limit {
+            return Ok(IntentRegistrationResult::LimitExceeded {
+                intent_id,
+                active,
+                limit,
+            });
+        }
 
         // 2. Check for hard collisions on all scope types.
         let mut all_conflicts = Vec::new();
@@ -204,6 +259,11 @@ impl SessionCoordinator {
                         .hard_collisions_for_entity(entity_id, &intent_id)
                         .map_err(DaemonError::from)?;
                     for collision in &collisions {
+                        // A session's own intent is not a collision: own-write
+                        // exclusion is the invariant used by every apply path.
+                        if collision.session_id == *session_id {
+                            continue;
+                        }
                         let col_session = self
                             .graph
                             .get_session(&collision.session_id)
@@ -328,6 +388,10 @@ impl SessionCoordinator {
 
     /// Release (delete) an intent.
     pub fn release_intent(&self, session_id: &SessionId, intent_id: &IntentId) -> Result<()> {
+        let _arbitration = self
+            .arbitration
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
         // Verify the intent belongs to this session.
         let intent = self
             .graph
@@ -784,6 +848,21 @@ mod tests {
         SessionCoordinator::new(graph)
     }
 
+    fn write_capabilities() -> SessionCapabilities {
+        SessionCapabilities {
+            can_write: true,
+            ..SessionCapabilities::default()
+        }
+    }
+
+    fn write_capabilities_with_limit(limit: usize) -> SessionCapabilities {
+        SessionCapabilities {
+            can_write: true,
+            max_concurrent_intents: limit,
+            ..SessionCapabilities::default()
+        }
+    }
+
     #[test]
     fn register_and_get_session() {
         let coord = make_coordinator();
@@ -921,7 +1000,7 @@ mod tests {
                 SessionTransport::Mcp,
                 None,
                 PathBuf::from("/"),
-                SessionCapabilities::default(),
+                write_capabilities(),
             )
             .unwrap();
         let s2 = coord
@@ -931,7 +1010,7 @@ mod tests {
                 SessionTransport::Cli,
                 None,
                 PathBuf::from("/"),
-                SessionCapabilities::default(),
+                write_capabilities(),
             )
             .unwrap();
 
@@ -1049,7 +1128,7 @@ mod tests {
                 SessionTransport::Mcp,
                 None,
                 PathBuf::from("/"),
-                SessionCapabilities::default(),
+                write_capabilities(),
             )
             .unwrap();
 
@@ -1102,7 +1181,7 @@ mod tests {
                 SessionTransport::Mcp,
                 None,
                 PathBuf::from("/"),
-                SessionCapabilities::default(),
+                write_capabilities(),
             )
             .unwrap();
         let s2 = coord
@@ -1112,7 +1191,7 @@ mod tests {
                 SessionTransport::Cli,
                 None,
                 PathBuf::from("/"),
-                SessionCapabilities::default(),
+                write_capabilities(),
             )
             .unwrap();
 
@@ -1153,7 +1232,7 @@ mod tests {
                 SessionTransport::Mcp,
                 None,
                 PathBuf::from("/"),
-                SessionCapabilities::default(),
+                write_capabilities(),
             )
             .unwrap();
         let s2 = coord
@@ -1163,7 +1242,7 @@ mod tests {
                 SessionTransport::Cli,
                 None,
                 PathBuf::from("/"),
-                SessionCapabilities::default(),
+                write_capabilities(),
             )
             .unwrap();
 
@@ -1206,7 +1285,7 @@ mod tests {
                 SessionTransport::Mcp,
                 None,
                 PathBuf::from("/"),
-                SessionCapabilities::default(),
+                write_capabilities_with_limit(3),
             )
             .unwrap();
 
@@ -1357,7 +1436,7 @@ mod tests {
                 SessionTransport::Mcp,
                 None,
                 PathBuf::from("/"),
-                SessionCapabilities::default(),
+                write_capabilities(),
             )
             .unwrap();
         coord
@@ -1402,7 +1481,7 @@ mod tests {
                 SessionTransport::Mcp,
                 None,
                 PathBuf::from("/"),
-                SessionCapabilities::default(),
+                write_capabilities(),
             )
             .unwrap();
         let s2 = coord
@@ -1412,7 +1491,7 @@ mod tests {
                 SessionTransport::Cli,
                 None,
                 PathBuf::from("/"),
-                SessionCapabilities::default(),
+                write_capabilities(),
             )
             .unwrap();
 
@@ -1454,7 +1533,10 @@ mod tests {
                 SessionTransport::Mcp,
                 None,
                 PathBuf::from("/"),
-                SessionCapabilities::default(),
+                SessionCapabilities {
+                    max_concurrent_intents: 5,
+                    ..SessionCapabilities::default()
+                },
             )
             .unwrap();
 
@@ -1479,6 +1561,135 @@ mod tests {
     }
 
     #[test]
+    fn max_concurrent_intents_is_enforced_at_registration_boundary() {
+        let coord = make_coordinator();
+        let sid = coord
+            .register_session(
+                "codex",
+                "bounded",
+                SessionTransport::Mcp,
+                None,
+                PathBuf::from("/"),
+                write_capabilities_with_limit(1),
+            )
+            .unwrap();
+
+        let first = coord
+            .register_intent(
+                &sid,
+                vec![IntentScope::Entity(EntityId::new())],
+                LockType::Hard,
+                "first",
+                None,
+            )
+            .unwrap();
+        assert!(matches!(first, IntentRegistrationResult::Registered { .. }));
+
+        let second = coord
+            .register_intent(
+                &sid,
+                vec![IntentScope::Entity(EntityId::new())],
+                LockType::Hard,
+                "second",
+                None,
+            )
+            .unwrap();
+        assert!(matches!(
+            second,
+            IntentRegistrationResult::LimitExceeded {
+                active: 1,
+                limit: 1,
+                ..
+            }
+        ));
+        assert_eq!(coord.list_intents(&sid).unwrap().len(), 1);
+    }
+
+    #[test]
+    fn hard_intent_requires_session_write_capability() {
+        let coord = make_coordinator();
+        let sid = coord
+            .register_session(
+                "read-only-agent",
+                "reader",
+                SessionTransport::Mcp,
+                None,
+                PathBuf::from("/"),
+                SessionCapabilities::default(),
+            )
+            .unwrap();
+
+        let result = coord
+            .register_intent(
+                &sid,
+                vec![IntentScope::Entity(EntityId::new())],
+                LockType::Hard,
+                "must not block writers",
+                None,
+            )
+            .unwrap();
+        assert!(matches!(
+            result,
+            IntentRegistrationResult::CapabilityDenied {
+                capability: "can_write",
+                ..
+            }
+        ));
+        assert!(coord.list_intents(&sid).unwrap().is_empty());
+    }
+
+    #[test]
+    fn concurrent_hard_registration_has_one_linearizable_winner() {
+        use std::sync::{Arc, Barrier};
+
+        let coord = Arc::new(make_coordinator());
+        let entity = make_test_entity(&coord);
+        let sessions = ["one", "two"].map(|name| {
+            coord
+                .register_session(
+                    "codex",
+                    name,
+                    SessionTransport::Mcp,
+                    None,
+                    PathBuf::from("/"),
+                    write_capabilities(),
+                )
+                .unwrap()
+        });
+        let barrier = Arc::new(Barrier::new(2));
+
+        let handles = sessions.map(|session_id| {
+            let coord = Arc::clone(&coord);
+            let barrier = Arc::clone(&barrier);
+            std::thread::spawn(move || {
+                barrier.wait();
+                coord
+                    .register_intent(
+                        &session_id,
+                        vec![IntentScope::Entity(entity)],
+                        LockType::Hard,
+                        "racing registration",
+                        None,
+                    )
+                    .unwrap()
+            })
+        });
+        let outcomes = handles.map(|handle| handle.join().unwrap());
+        let registered = outcomes
+            .iter()
+            .filter(|result| matches!(result, IntentRegistrationResult::Registered { .. }))
+            .count();
+        let blocked = outcomes
+            .iter()
+            .filter(|result| matches!(result, IntentRegistrationResult::Blocked { .. }))
+            .count();
+
+        assert_eq!(registered, 1);
+        assert_eq!(blocked, 1);
+        assert_eq!(coord.graph.list_all_intents().unwrap().len(), 1);
+    }
+
+    #[test]
     fn soft_lock_does_not_block_hard_lock_from_other_session() {
         let coord = make_coordinator();
         let entity = make_test_entity(&coord);
@@ -1490,7 +1701,7 @@ mod tests {
                 SessionTransport::Mcp,
                 None,
                 PathBuf::from("/"),
-                SessionCapabilities::default(),
+                write_capabilities(),
             )
             .unwrap();
         let s2 = coord
@@ -1500,7 +1711,7 @@ mod tests {
                 SessionTransport::Cli,
                 None,
                 PathBuf::from("/"),
-                SessionCapabilities::default(),
+                write_capabilities(),
             )
             .unwrap();
 
@@ -1651,7 +1862,7 @@ mod tests {
                 SessionTransport::Mcp,
                 None,
                 PathBuf::from("/"),
-                SessionCapabilities::default(),
+                write_capabilities(),
             )
             .unwrap();
 

--- a/crates/kin-daemon/src/state.rs
+++ b/crates/kin-daemon/src/state.rs
@@ -2,6 +2,7 @@
 // Copyright 2026 Firelock, LLC
 
 use std::collections::{HashMap, HashSet};
+use std::io::Write;
 use std::sync::atomic::{AtomicBool, AtomicU32, AtomicU64, AtomicU8, Ordering};
 use std::sync::{Arc, Mutex};
 use std::time::{Duration, Instant};
@@ -95,6 +96,128 @@ pub(crate) fn write_persisted_mcp_transactions(
     }
 }
 
+/// One append-only, release-attributed coordination event. This is the durable
+/// collector boundary used by citable multi-agent metrics; every record names
+/// its exact enforcement mode and scopes instead of implying unsupported
+/// contract coverage.
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
+pub struct CoordinationEventEnvelope {
+    pub schema: String,
+    pub sequence: u64,
+    pub timestamp: String,
+    pub event: String,
+    pub outcome: String,
+    pub repo_id: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub session_id: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub intent_id: Option<String>,
+    #[serde(default)]
+    pub intent_ids: Vec<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub transaction_id: Option<String>,
+    #[serde(default)]
+    pub scopes: Vec<String>,
+    pub enforcement_mode: String,
+    #[serde(default)]
+    pub blocking_intent_ids: Vec<String>,
+    pub kin_version: String,
+    pub kin_commit: String,
+    pub kin_dirty: bool,
+}
+
+#[derive(Debug, Clone)]
+pub struct CoordinationEventDraft {
+    pub event: &'static str,
+    pub outcome: String,
+    pub session_id: Option<String>,
+    pub intent_id: Option<String>,
+    pub intent_ids: Vec<String>,
+    pub transaction_id: Option<String>,
+    pub scopes: Vec<String>,
+    pub enforcement_mode: String,
+    pub blocking_intent_ids: Vec<String>,
+}
+
+/// Append-only JSONL writer with a monotonic sequence recovered from disk on
+/// daemon restart. Appends are serialized and `sync_data` is called before an
+/// event is broadcast, so live consumers never observe an event the durable
+/// collector failed to record.
+pub struct CoordinationEventLog {
+    path: std::path::PathBuf,
+    repo_id: String,
+    next_sequence: Mutex<u64>,
+}
+
+impl CoordinationEventLog {
+    pub fn open(layout: &KinLayout, repo_id: &str) -> Self {
+        let path = layout.root().join("coordination_events.jsonl");
+        let next_sequence = std::fs::read_to_string(&path)
+            .ok()
+            .and_then(|contents| {
+                contents.lines().rev().find_map(|line| {
+                    serde_json::from_str::<serde_json::Value>(line)
+                        .ok()
+                        .and_then(|value| value.get("sequence")?.as_u64())
+                })
+            })
+            .unwrap_or(0)
+            .saturating_add(1);
+        Self {
+            path,
+            repo_id: repo_id.to_string(),
+            next_sequence: Mutex::new(next_sequence),
+        }
+    }
+
+    pub fn append(
+        &self,
+        draft: CoordinationEventDraft,
+    ) -> std::io::Result<CoordinationEventEnvelope> {
+        let mut next = self
+            .next_sequence
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
+        let build = kin_buildinfo::get();
+        let envelope = CoordinationEventEnvelope {
+            schema: "kin.coordination-event.v1".to_string(),
+            sequence: *next,
+            timestamp: kin_model::Timestamp::now().to_string(),
+            event: draft.event.to_string(),
+            outcome: draft.outcome,
+            repo_id: self.repo_id.clone(),
+            session_id: draft.session_id,
+            intent_id: draft.intent_id,
+            intent_ids: draft.intent_ids,
+            transaction_id: draft.transaction_id,
+            scopes: draft.scopes,
+            enforcement_mode: draft.enforcement_mode,
+            blocking_intent_ids: draft.blocking_intent_ids,
+            kin_version: kin_buildinfo::version().to_string(),
+            kin_commit: build.sha.to_string(),
+            kin_dirty: build.dirty,
+        };
+        let mut bytes = serde_json::to_vec(&envelope).map_err(std::io::Error::other)?;
+        bytes.push(b'\n');
+        if let Some(parent) = self.path.parent() {
+            std::fs::create_dir_all(parent)?;
+        }
+        let mut file = std::fs::OpenOptions::new()
+            .create(true)
+            .append(true)
+            .open(&self.path)?;
+        file.write_all(&bytes)?;
+        file.sync_data()?;
+        *next = next.saturating_add(1);
+        Ok(envelope)
+    }
+
+    #[cfg(test)]
+    pub(crate) fn path(&self) -> &std::path::Path {
+        &self.path
+    }
+}
+
 /// SSE invalidation events pushed to subscribers (VFS daemon, spine, KinLab).
 #[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
 #[serde(tag = "type")]
@@ -124,6 +247,8 @@ pub enum DaemonEvent {
         old_root_hash: Option<String>,
         new_root_hash: String,
     },
+    /// Durable coordination lifecycle event, appended before broadcast.
+    Coordination { event: CoordinationEventEnvelope },
 }
 
 /// Type of entity change for SSE events.
@@ -288,6 +413,18 @@ pub struct DaemonState {
     pub projection: RwLock<ProjectionState>,
     /// Session and intent coordinator (Phase 7).
     pub coordinator: SessionCoordinator,
+    /// Serializes daemon intent lifecycle mutations with MCP transaction
+    /// preflight+apply so those two authority paths have one ordering.
+    pub coordination_gate: tokio::sync::Mutex<()>,
+    /// Mode captured when the daemon state is created. Requests use this
+    /// stable value instead of re-reading process-global environment mid-run.
+    pub coordination_mode: std::sync::RwLock<kin_mcp::CoordinationEnforcementMode>,
+    /// Durable, release-attributed coordination event collector.
+    pub coordination_events: CoordinationEventLog,
+    /// Runtime completeness signal for the durable collector. Citable runs
+    /// must require zero; an append failure never masquerades as a recorded
+    /// event merely because the product action itself completed.
+    pub coordination_event_persist_failures: AtomicU64,
     /// When the daemon was started (for uptime reporting).
     pub started_at: Instant,
     /// Whether the daemon has been initialized (snapshot loaded or first reconciliation done).
@@ -480,6 +617,33 @@ pub(crate) fn graph_collapse_is_wipe(current: u64, baseline: u64) -> bool {
 }
 
 impl DaemonState {
+    pub fn coordination_mode(&self) -> kin_mcp::CoordinationEnforcementMode {
+        *self
+            .coordination_mode
+            .read()
+            .unwrap_or_else(std::sync::PoisonError::into_inner)
+    }
+
+    pub(crate) fn record_coordination_event(
+        &self,
+        draft: CoordinationEventDraft,
+    ) -> Option<CoordinationEventEnvelope> {
+        match self.coordination_events.append(draft) {
+            Ok(event) => {
+                self.emit_event(DaemonEvent::Coordination {
+                    event: event.clone(),
+                });
+                Some(event)
+            }
+            Err(error) => {
+                self.coordination_event_persist_failures
+                    .fetch_add(1, Ordering::Relaxed);
+                warn!(error = %error, "failed to persist coordination event; event not broadcast");
+                None
+            }
+        }
+    }
+
     /// Load a persisted vector-index sidecar into a graph that was NOT built
     /// through `SnapshotManager` (the storage-backend path uses
     /// `InMemoryGraph::from_snapshot_with_text_index`, which does not load the
@@ -667,6 +831,7 @@ impl DaemonState {
         // from the on-disk snapshot. Read before `graph` is moved into the state.
         let loaded_entity_count = graph.entity_count();
 
+        let coordination_events = CoordinationEventLog::open(&layout, &cached_repo_id);
         let mut state = Self {
             layout,
             graph,
@@ -675,6 +840,12 @@ impl DaemonState {
             reconciler: RwLock::new(reconciler),
             projection: RwLock::new(ProjectionState::new()),
             coordinator,
+            coordination_gate: tokio::sync::Mutex::new(()),
+            coordination_mode: std::sync::RwLock::new(
+                kin_mcp::CoordinationEnforcementMode::from_env(),
+            ),
+            coordination_events,
+            coordination_event_persist_failures: AtomicU64::new(0),
             started_at: Instant::now(),
             is_initialized: AtomicBool::new(loaded_snapshot),
             reconciliation_status: AtomicU8::new(RECON_IDLE),
@@ -811,6 +982,7 @@ impl DaemonState {
         // the backend snapshot).
         let loaded_entity_count = graph.entity_count();
 
+        let coordination_events = CoordinationEventLog::open(&layout, repo_id);
         let mut state = Self {
             layout,
             graph: Arc::clone(&graph),
@@ -819,6 +991,12 @@ impl DaemonState {
             reconciler: RwLock::new(reconciler),
             projection: RwLock::new(ProjectionState::new()),
             coordinator,
+            coordination_gate: tokio::sync::Mutex::new(()),
+            coordination_mode: std::sync::RwLock::new(
+                kin_mcp::CoordinationEnforcementMode::from_env(),
+            ),
+            coordination_events,
+            coordination_event_persist_failures: AtomicU64::new(0),
             started_at: Instant::now(),
             is_initialized: AtomicBool::new(loaded_snapshot),
             reconciliation_status: AtomicU8::new(RECON_IDLE),
@@ -2100,6 +2278,7 @@ mod tests {
         };
         let coordinator = SessionCoordinator::new(Arc::clone(&graph));
         let loaded_entity_count = graph.entity_count();
+        let coordination_events = CoordinationEventLog::open(&layout, "test-repo");
 
         DaemonState {
             layout,
@@ -2109,6 +2288,12 @@ mod tests {
             reconciler: RwLock::new(Reconciler::new(working_dir.to_path_buf())),
             projection: RwLock::new(ProjectionState::new()),
             coordinator,
+            coordination_gate: tokio::sync::Mutex::new(()),
+            coordination_mode: std::sync::RwLock::new(
+                kin_mcp::CoordinationEnforcementMode::from_env(),
+            ),
+            coordination_events,
+            coordination_event_persist_failures: AtomicU64::new(0),
             started_at: Instant::now(),
             is_initialized: AtomicBool::new(false),
             reconciliation_status: AtomicU8::new(RECON_IDLE),
@@ -2190,6 +2375,55 @@ mod tests {
         let v = serde_json::to_value(&event).unwrap();
         assert_eq!(v["type"], json!("EntityChanged"));
         assert_eq!(v["session_id"], json!("mission-ctl-7"));
+    }
+
+    #[test]
+    fn coordination_event_log_is_durable_and_sequence_resumes() {
+        let dir = tempfile::tempdir().unwrap();
+        let layout = KinLayout::new(dir.path().join(".kin"));
+        std::fs::create_dir_all(layout.root()).unwrap();
+        let log = CoordinationEventLog::open(&layout, "test-repo");
+        let first = log
+            .append(CoordinationEventDraft {
+                event: "intent_registration",
+                outcome: "registered".to_string(),
+                session_id: Some("session-1".to_string()),
+                intent_id: Some("intent-1".to_string()),
+                intent_ids: vec!["intent-1".to_string()],
+                transaction_id: None,
+                scopes: vec!["entity:e1".to_string()],
+                enforcement_mode: "warn".to_string(),
+                blocking_intent_ids: vec![],
+            })
+            .unwrap();
+        assert_eq!(first.sequence, 1);
+        assert_eq!(first.schema, "kin.coordination-event.v1");
+
+        let reopened = CoordinationEventLog::open(&layout, "test-repo");
+        let second = reopened
+            .append(CoordinationEventDraft {
+                event: "transaction_outcome",
+                outcome: "committed".to_string(),
+                session_id: Some("session-1".to_string()),
+                intent_id: None,
+                intent_ids: Vec::new(),
+                transaction_id: Some("tx-1".to_string()),
+                scopes: vec!["artifact:src/lib.rs".to_string()],
+                enforcement_mode: "enforce".to_string(),
+                blocking_intent_ids: vec![],
+            })
+            .unwrap();
+        assert_eq!(second.sequence, 2);
+
+        let lines = std::fs::read_to_string(reopened.path()).unwrap();
+        let records: Vec<CoordinationEventEnvelope> = lines
+            .lines()
+            .map(|line| serde_json::from_str(line).unwrap())
+            .collect();
+        assert_eq!(records.len(), 2);
+        assert_eq!(records[1].repo_id, "test-repo");
+        assert_eq!(records[1].transaction_id.as_deref(), Some("tx-1"));
+        assert!(!records[1].kin_commit.is_empty());
     }
 
     #[test]

--- a/crates/kin-daemon/src/write_veto.rs
+++ b/crates/kin-daemon/src/write_veto.rs
@@ -95,6 +95,14 @@ impl WriteVetoMode {
     pub fn evaluates(self) -> bool {
         !self.is_off()
     }
+
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::Off => "off",
+            Self::Warn => "warn",
+            Self::Enforce => "enforce",
+        }
+    }
 }
 
 /// Outcome of [`evaluate_write_veto`].

--- a/crates/kin-mcp/src/handlers/mod.rs
+++ b/crates/kin-mcp/src/handlers/mod.rs
@@ -1122,7 +1122,10 @@ mod tests {
             SessionTransport::Cli,
             None,
             PathBuf::from("/tmp"),
-            SessionCapabilities::default(),
+            SessionCapabilities {
+                can_write: true,
+                ..SessionCapabilities::default()
+            },
         );
         let session_id_str = session.session_id.to_string();
 

--- a/crates/kin-mcp/src/handlers/sessions.rs
+++ b/crates/kin-mcp/src/handlers/sessions.rs
@@ -292,8 +292,14 @@ pub async fn handle_register_intent(
         }
     }
 
-    match sessions.register_intent(session_id, scopes, lock_type, task_description, expires_at) {
-        Some(intent) => {
+    match sessions.register_intent_checked(
+        session_id,
+        scopes,
+        lock_type,
+        task_description,
+        expires_at,
+    ) {
+        crate::session::IntentRegistrationAttempt::Registered(intent) => {
             let result = serde_json::json!({
                 "intent_id": intent.intent_id.to_string(),
                 "session_id": intent.session_id.to_string(),
@@ -307,10 +313,56 @@ pub async fn handle_register_intent(
                 serde_json::to_string_pretty(&result).map_err(crate::error::McpError::Json)?;
             Ok(ToolCallResult::text(json))
         }
-        None => Ok(ToolCallResult::error(format!(
-            "Session not found: {}. Start a session with kin_session_start first.",
-            id_str
-        ))),
+        crate::session::IntentRegistrationAttempt::Blocked {
+            intent_id,
+            conflicts,
+        } => {
+            let result = serde_json::json!({
+                "intent_id": intent_id.to_string(),
+                "session_id": session_id.to_string(),
+                "status": "blocked",
+                "conflicts": conflicts,
+            });
+            let json =
+                serde_json::to_string_pretty(&result).map_err(crate::error::McpError::Json)?;
+            Ok(ToolCallResult::text(json))
+        }
+        crate::session::IntentRegistrationAttempt::LimitExceeded {
+            intent_id,
+            active,
+            limit,
+        } => {
+            let result = serde_json::json!({
+                "intent_id": intent_id.to_string(),
+                "session_id": session_id.to_string(),
+                "status": "limit_exceeded",
+                "active_intents": active,
+                "max_concurrent_intents": limit,
+            });
+            let json =
+                serde_json::to_string_pretty(&result).map_err(crate::error::McpError::Json)?;
+            Ok(ToolCallResult::text(json))
+        }
+        crate::session::IntentRegistrationAttempt::CapabilityDenied {
+            intent_id,
+            capability,
+        } => {
+            let result = serde_json::json!({
+                "intent_id": intent_id.to_string(),
+                "session_id": session_id.to_string(),
+                "status": "capability_denied",
+                "required_capability": capability,
+            });
+            let json =
+                serde_json::to_string_pretty(&result).map_err(crate::error::McpError::Json)?;
+            Ok(ToolCallResult::text(json))
+        }
+        crate::session::IntentRegistrationAttempt::SessionNotFound => {
+            Ok(ToolCallResult::error(format!(
+                "Session not found: {}. Start a session with kin_session_start first.",
+                id_str
+            )))
+        }
     }
 }
 
@@ -448,6 +500,7 @@ pub async fn handle_transaction_begin(
         }
     }
 
+    let _coordination_apply = sessions.lock_coordination_apply();
     match sessions.begin_transaction(&session_id, &scope) {
         Ok(tx) => {
             let result = serde_json::json!({
@@ -505,6 +558,7 @@ pub async fn handle_transaction_stage(
         }
     }
 
+    let _coordination_apply = sessions.lock_coordination_apply();
     match sessions.stage_transaction(&transaction_id, operations) {
         Ok(tx) => {
             let result = serde_json::json!({
@@ -542,6 +596,7 @@ pub async fn handle_transaction_validate(
         }
     }
 
+    let _coordination_apply = sessions.lock_coordination_apply();
     match sessions.validate_transaction(&transaction_id) {
         Ok(tx) => {
             let result = serde_json::json!({
@@ -563,7 +618,62 @@ returns status, ops_applied (entity+relation deltas applied), empty (true for a 
 no-op commit), new_root_hash (graph Merkle root after the commit), modified_files \
 (working-directory files the projection wrote — entity-body edits reach disk here), \
 collision_warnings, and conflicts (entities skipped due to a concurrent file edit; a \
-non-empty set is surfaced as an error instead).";
+non-empty set is surfaced as an error instead). Before graph application, exact entity/artifact \
+intent conflicts and session write/commit capabilities are attested; enforce mode rejects \
+before graph truth changes. Contract-scope coverage remains explicitly false until touched \
+contracts can be derived from the semantic delta.";
+
+fn push_scope_once(scopes: &mut Vec<kin_model::IntentScope>, scope: kin_model::IntentScope) {
+    if !scopes.contains(&scope) {
+        scopes.push(scope);
+    }
+}
+
+/// Derive only the scopes the transaction payload can prove it touches. Entity
+/// ids and their old/new file origins are exact. Relation mutations cover both
+/// endpoint entities. Contract scopes are intentionally absent: the current
+/// delta carries no touched-contract derivation, so claiming them would be a
+/// false enforcement guarantee.
+fn transaction_touched_scopes<G: GraphStore>(
+    store: &G,
+    operations: &[McpMutationOperation],
+) -> Vec<kin_model::IntentScope> {
+    let mut scopes = Vec::new();
+    for operation in operations {
+        match operation.payload.as_ref() {
+            Some(McpMutationPayload::Entity(entity)) => {
+                push_scope_once(&mut scopes, kin_model::IntentScope::Entity(entity.id));
+                if let Some(file) = entity.file_origin.clone() {
+                    push_scope_once(&mut scopes, kin_model::IntentScope::Artifact(file));
+                }
+                let mut existing = store.get_entity(&entity.id).ok().flatten();
+                if existing.is_none() {
+                    let filter = kin_model::EntityFilter {
+                        name_pattern: Some(entity.name.clone()),
+                        kinds: Some(vec![entity.kind]),
+                        ..Default::default()
+                    };
+                    existing = store
+                        .query_entities(&filter)
+                        .ok()
+                        .and_then(|mut matches| matches.pop());
+                }
+                if let Some(existing) = existing {
+                    push_scope_once(&mut scopes, kin_model::IntentScope::Entity(existing.id));
+                    if let Some(file) = existing.file_origin {
+                        push_scope_once(&mut scopes, kin_model::IntentScope::Artifact(file));
+                    }
+                }
+            }
+            Some(McpMutationPayload::Relation { from, to, .. }) => {
+                push_scope_once(&mut scopes, kin_model::IntentScope::Entity(*from));
+                push_scope_once(&mut scopes, kin_model::IntentScope::Entity(*to));
+            }
+            Some(McpMutationPayload::Blob(_)) | None => {}
+        }
+    }
+    scopes
+}
 
 pub async fn handle_transaction_commit<G: GraphStore>(
     args: &HashMap<String, serde_json::Value>,
@@ -596,6 +706,11 @@ pub async fn handle_transaction_commit<G: GraphStore>(
             Err(err) => return Ok(ToolCallResult::error(err)),
         }
     }
+
+    // Serialize the entire local/offline transaction transition, final
+    // preflight, graph apply, and terminal state change with intent mutation
+    // and the other transaction lifecycle handlers.
+    let _coordination_apply = sessions.lock_coordination_apply();
 
     if let Some(ops) = inline_ops {
         match sessions.stage_transaction(&transaction_id, ops) {
@@ -634,6 +749,19 @@ pub async fn handle_transaction_commit<G: GraphStore>(
             transaction_id,
             uncommittable.len(),
             uncommittable.join("\n  - ")
+        )));
+    }
+
+    // Load-bearing ordering: run coordination enforcement against the fully
+    // staged operation set before constructing or applying any graph delta.
+    // A denied transaction remains active and graph truth is unchanged.
+    let touched_scopes = transaction_touched_scopes(store, &tx.staged_operations);
+    let coordination = sessions.evaluate_transaction_write(&tx.session_id, touched_scopes);
+    if !coordination.allowed {
+        let evidence =
+            serde_json::to_string(&coordination).map_err(crate::error::McpError::Json)?;
+        return Ok(ToolCallResult::error(format!(
+            "coordination enforcement rejected transaction {transaction_id} before graph apply: {evidence}"
         )));
     }
 
@@ -773,6 +901,7 @@ pub async fn handle_transaction_commit<G: GraphStore>(
         "status": "committed",
         "ops_applied": ops_applied,
         "empty": ops_applied == 0,
+        "coordination": coordination,
     });
     let json = serde_json::to_string_pretty(&result).map_err(crate::error::McpError::Json)?;
     Ok(ToolCallResult::text(json))
@@ -799,6 +928,7 @@ pub async fn handle_transaction_abort(
         }
     }
 
+    let _coordination_apply = sessions.lock_coordination_apply();
     match sessions.abort_transaction(&transaction_id) {
         Ok(tx) => {
             let result = serde_json::json!({

--- a/crates/kin-mcp/src/lib.rs
+++ b/crates/kin-mcp/src/lib.rs
@@ -22,7 +22,9 @@ pub use server::{
     SessionAuthorityMode,
 };
 pub use session::{
-    AssistantSession, McpMutationOperation, McpMutationPayload, McpTransaction, SessionRegistry,
+    AssistantSession, CoordinationEnforcementMode, CoordinationSurfaceCoverage,
+    CoordinationWritePreflight, IntentRegistrationAttempt, McpMutationOperation,
+    McpMutationPayload, McpTransaction, SessionRegistry,
 };
 pub use tools::{
     agent_default_tool_names, benchmark_tool_names, context_bench_tool_names, tool_definitions,

--- a/crates/kin-mcp/src/session.rs
+++ b/crates/kin-mcp/src/session.rs
@@ -60,6 +60,105 @@ pub struct McpTransaction {
     pub staged_operations: Vec<McpMutationOperation>,
 }
 
+/// Linearized outcome of an in-process intent registration attempt.
+#[derive(Debug, Clone)]
+pub enum IntentRegistrationAttempt {
+    Registered(Intent),
+    Blocked {
+        intent_id: IntentId,
+        conflicts: Vec<IntentSummary>,
+    },
+    LimitExceeded {
+        intent_id: IntentId,
+        active: usize,
+        limit: usize,
+    },
+    CapabilityDenied {
+        intent_id: IntentId,
+        capability: &'static str,
+    },
+    SessionNotFound,
+}
+
+/// Effective coordination enforcement mode shared by transaction preflight
+/// and proof/build attestation. Warn remains the default; only explicit
+/// `enforce` may reject a write.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum CoordinationEnforcementMode {
+    Off,
+    Warn,
+    Enforce,
+}
+
+impl CoordinationEnforcementMode {
+    pub fn from_env() -> Self {
+        Self::parse(std::env::var("KIN_WRITE_VETO").ok().as_deref())
+    }
+
+    pub fn parse(raw: Option<&str>) -> Self {
+        match raw.map(str::trim) {
+            Some(value) if value.eq_ignore_ascii_case("enforce") => Self::Enforce,
+            Some(value) if value.eq_ignore_ascii_case("off") => Self::Off,
+            _ => Self::Warn,
+        }
+    }
+
+    pub fn is_enforcing(self) -> bool {
+        matches!(self, Self::Enforce)
+    }
+
+    pub fn evaluates(self) -> bool {
+        !matches!(self, Self::Off)
+    }
+
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::Off => "off",
+            Self::Warn => "warn",
+            Self::Enforce => "enforce",
+        }
+    }
+}
+
+/// Honest surface attestation for MCP transaction coordination. Contract
+/// scopes stay explicitly ineligible until a transaction can derive a touched
+/// contract from the actual semantic delta.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct CoordinationSurfaceCoverage {
+    pub entity_scopes: bool,
+    pub artifact_scopes_from_entity_origin: bool,
+    pub relation_endpoint_entities: bool,
+    pub contract_scopes: bool,
+    pub direct_filesystem_writes: bool,
+}
+
+impl Default for CoordinationSurfaceCoverage {
+    fn default() -> Self {
+        Self {
+            entity_scopes: true,
+            artifact_scopes_from_entity_origin: true,
+            relation_endpoint_entities: true,
+            contract_scopes: false,
+            direct_filesystem_writes: false,
+        }
+    }
+}
+
+/// Result of checking a transaction immediately before graph application.
+#[derive(Debug, Clone, Serialize)]
+pub struct CoordinationWritePreflight {
+    pub schema: &'static str,
+    pub mode: CoordinationEnforcementMode,
+    pub evaluated: bool,
+    pub allowed: bool,
+    pub session_id: String,
+    pub touched_scopes: Vec<IntentScope>,
+    pub blocking_intents: Vec<IntentSummary>,
+    pub capability_violations: Vec<String>,
+    pub coverage: CoordinationSurfaceCoverage,
+}
+
 /// The mutation verbs the transaction commit path understands, listed for
 /// actionable error messages.
 const KNOWN_MUTATION_VERBS: &str = "create/add/upsert/insert, update/modify, or delete/remove";
@@ -201,6 +300,15 @@ pub struct SessionRegistry {
     intents: Mutex<HashMap<IntentId, Intent>>,
     /// Active transactions keyed by TransactionId.
     transactions: Mutex<HashMap<String, McpTransaction>>,
+    /// Linearization point for rich-session and intent lifecycle mutations.
+    /// The maps stay separate for low-impact compatibility, but registration's
+    /// session lookup + concurrency check + conflict check + insert is one
+    /// indivisible coordinator operation under this gate.
+    intent_registration_gate: Mutex<()>,
+    /// Daemon-owned mode snapshot. `None` keeps standalone/offline MCP behavior
+    /// environment-driven; the daemon sets this explicitly so a request cannot
+    /// observe a process-global env change mid-run.
+    coordination_mode: Mutex<Option<CoordinationEnforcementMode>>,
 }
 
 impl SessionRegistry {
@@ -210,6 +318,8 @@ impl SessionRegistry {
             agent_sessions: Mutex::new(HashMap::new()),
             intents: Mutex::new(HashMap::new()),
             transactions: Mutex::new(HashMap::new()),
+            intent_registration_gate: Mutex::new(()),
+            coordination_mode: Mutex::new(None),
         }
     }
 
@@ -274,6 +384,10 @@ impl SessionRegistry {
         cwd: PathBuf,
         capabilities: SessionCapabilities,
     ) -> AgentSession {
+        let _gate = self
+            .intent_registration_gate
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
         let now = Timestamp::now();
         let session = AgentSession {
             session_id: SessionId::new(),
@@ -310,6 +424,10 @@ impl SessionRegistry {
 
     /// End an agent session and release all its intents.
     pub fn end_agent_session(&self, session_id: &SessionId) -> Option<AgentSession> {
+        let _gate = self
+            .intent_registration_gate
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
         let session = self
             .agent_sessions
             .lock()
@@ -354,6 +472,10 @@ impl SessionRegistry {
         agent_sessions: Vec<AgentSession>,
         intents: Vec<Intent>,
     ) {
+        let _gate = self
+            .intent_registration_gate
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
         let mut sessions_map = self
             .agent_sessions
             .lock()
@@ -373,7 +495,22 @@ impl SessionRegistry {
 
     // ── Intent API ──
 
-    /// Register a new intent. Returns the created Intent.
+    pub fn set_coordination_mode(&self, mode: CoordinationEnforcementMode) {
+        *self
+            .coordination_mode
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner) = Some(mode);
+    }
+
+    pub(crate) fn lock_coordination_apply(&self) -> std::sync::MutexGuard<'_, ()> {
+        self.intent_registration_gate
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner)
+    }
+
+    /// Backward-compatible registration API. Callers that need to distinguish
+    /// conflict, capability, and concurrency-limit rejection should use
+    /// [`Self::register_intent_checked`].
     pub fn register_intent(
         &self,
         session_id: SessionId,
@@ -382,15 +519,42 @@ impl SessionRegistry {
         task_description: String,
         expires_at: Option<Timestamp>,
     ) -> Option<Intent> {
-        // Verify session exists.
-        let sessions = self
+        match self.register_intent_checked(
+            session_id,
+            scopes,
+            lock_type,
+            task_description,
+            expires_at,
+        ) {
+            IntentRegistrationAttempt::Registered(intent) => Some(intent),
+            _ => None,
+        }
+    }
+
+    /// Register a new intent as one linearized arbitration operation and
+    /// preserve the exact rejection reason.
+    pub fn register_intent_checked(
+        &self,
+        session_id: SessionId,
+        scopes: Vec<IntentScope>,
+        lock_type: LockType,
+        task_description: String,
+        expires_at: Option<Timestamp>,
+    ) -> IntentRegistrationAttempt {
+        let _gate = self
+            .intent_registration_gate
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
+
+        let session = self
             .agent_sessions
             .lock()
-            .expect("agent_sessions lock poisoned");
-        if !sessions.contains_key(&session_id) {
-            return None;
-        }
-        drop(sessions);
+            .unwrap_or_else(std::sync::PoisonError::into_inner)
+            .get(&session_id)
+            .cloned();
+        let Some(session) = session else {
+            return IntentRegistrationAttempt::SessionNotFound;
+        };
 
         let now = Timestamp::now();
         let intent = Intent {
@@ -403,15 +567,76 @@ impl SessionRegistry {
             expires_at,
         };
         let id = intent.intent_id;
-        self.intents
+        let mut intents = self
+            .intents
             .lock()
-            .expect("intents lock poisoned")
-            .insert(id, intent.clone());
-        Some(intent)
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
+
+        if lock_type == LockType::Hard && !session.capabilities.can_write {
+            return IntentRegistrationAttempt::CapabilityDenied {
+                intent_id: id,
+                capability: "can_write",
+            };
+        }
+
+        let active = intents
+            .values()
+            .filter(|active| active.session_id == session_id)
+            .count();
+        let limit = session.capabilities.max_concurrent_intents;
+        if active >= limit {
+            return IntentRegistrationAttempt::LimitExceeded {
+                intent_id: id,
+                active,
+                limit,
+            };
+        }
+
+        if lock_type == LockType::Hard {
+            let sessions = self
+                .agent_sessions
+                .lock()
+                .unwrap_or_else(std::sync::PoisonError::into_inner);
+            let conflicts: Vec<IntentSummary> = intents
+                .values()
+                .filter(|active| {
+                    active.session_id != session_id
+                        && active.lock_type == LockType::Hard
+                        && active
+                            .scopes
+                            .iter()
+                            .any(|scope| intent.scopes.contains(scope))
+                })
+                .map(|active| IntentSummary {
+                    intent_id: active.intent_id,
+                    session_id: active.session_id,
+                    vendor: sessions
+                        .get(&active.session_id)
+                        .map(|owner| owner.vendor.clone())
+                        .unwrap_or_else(|| "unknown".to_string()),
+                    task_description: active.task_description.clone(),
+                    lock_type: active.lock_type,
+                    registered_at: active.registered_at.clone(),
+                })
+                .collect();
+            if !conflicts.is_empty() {
+                return IntentRegistrationAttempt::Blocked {
+                    intent_id: id,
+                    conflicts,
+                };
+            }
+        }
+
+        intents.insert(id, intent.clone());
+        IntentRegistrationAttempt::Registered(intent)
     }
 
     /// Release a specific intent. Returns it if it existed.
     pub fn release_intent(&self, session_id: &SessionId, intent_id: &IntentId) -> Option<Intent> {
+        let _gate = self
+            .intent_registration_gate
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
         let mut intents = self.intents.lock().expect("intents lock poisoned");
         if let Some(intent) = intents.get(intent_id) {
             if intent.session_id == *session_id {
@@ -430,6 +655,105 @@ impl SessionRegistry {
             .filter(|i| i.session_id == *session_id)
             .cloned()
             .collect()
+    }
+
+    /// Evaluate exact-scope intent conflicts and declared write capabilities
+    /// immediately before a transaction delta is applied. In enforce mode an
+    /// unknown/non-rich session fails closed; warn mode records the same
+    /// violations while preserving the historical proceed behavior.
+    pub fn evaluate_transaction_write(
+        &self,
+        session_id: &str,
+        touched_scopes: Vec<IntentScope>,
+    ) -> CoordinationWritePreflight {
+        let mode = self
+            .coordination_mode
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner)
+            .unwrap_or_else(CoordinationEnforcementMode::from_env);
+        self.evaluate_transaction_write_with_mode(session_id, touched_scopes, mode)
+    }
+
+    pub fn evaluate_transaction_write_with_mode(
+        &self,
+        session_id: &str,
+        touched_scopes: Vec<IntentScope>,
+        mode: CoordinationEnforcementMode,
+    ) -> CoordinationWritePreflight {
+        if !mode.evaluates() {
+            return CoordinationWritePreflight {
+                schema: "kin.coordination-preflight.v1",
+                mode,
+                evaluated: false,
+                allowed: true,
+                session_id: session_id.to_string(),
+                touched_scopes,
+                blocking_intents: Vec::new(),
+                capability_violations: Vec::new(),
+                coverage: CoordinationSurfaceCoverage::default(),
+            };
+        }
+
+        let parsed_session = uuid::Uuid::parse_str(session_id).ok().map(SessionId);
+        let session = parsed_session.and_then(|id| self.get_agent_session(&id));
+        let mut capability_violations = Vec::new();
+
+        match session.as_ref() {
+            Some(session) => {
+                if !session.capabilities.can_write {
+                    capability_violations.push("can_write=false".to_string());
+                }
+                if !session.capabilities.can_commit {
+                    capability_violations.push("can_commit=false".to_string());
+                }
+            }
+            None => capability_violations
+                .push("transaction session is not an active rich agent session".to_string()),
+        }
+
+        let intents = self
+            .intents
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
+        let sessions = self
+            .agent_sessions
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
+        let blocking_intents: Vec<IntentSummary> = intents
+            .values()
+            .filter(|intent| {
+                Some(intent.session_id) != parsed_session
+                    && intent.lock_type == LockType::Hard
+                    && intent
+                        .scopes
+                        .iter()
+                        .any(|scope| touched_scopes.contains(scope))
+            })
+            .map(|intent| IntentSummary {
+                intent_id: intent.intent_id,
+                session_id: intent.session_id,
+                vendor: sessions
+                    .get(&intent.session_id)
+                    .map(|owner| owner.vendor.clone())
+                    .unwrap_or_else(|| "unknown".to_string()),
+                task_description: intent.task_description.clone(),
+                lock_type: intent.lock_type,
+                registered_at: intent.registered_at.clone(),
+            })
+            .collect();
+
+        let violates_policy = !blocking_intents.is_empty() || !capability_violations.is_empty();
+        CoordinationWritePreflight {
+            schema: "kin.coordination-preflight.v1",
+            mode,
+            evaluated: true,
+            allowed: !mode.is_enforcing() || !violates_policy,
+            session_id: session_id.to_string(),
+            touched_scopes,
+            blocking_intents,
+            capability_violations,
+            coverage: CoordinationSurfaceCoverage::default(),
+        }
     }
 
     /// Check traffic for the given scopes. Returns a TrafficReport per scope.
@@ -746,15 +1070,16 @@ mod tests {
             SessionCapabilities::default(),
         );
 
-        let intent = registry
-            .register_intent(
-                session.session_id,
-                vec![IntentScope::Entity(EntityId::new())],
-                LockType::Soft,
-                "testing".into(),
-                None,
-            )
-            .unwrap();
+        let intent = match registry.register_intent_checked(
+            session.session_id,
+            vec![IntentScope::Entity(EntityId::new())],
+            LockType::Soft,
+            "testing".into(),
+            None,
+        ) {
+            IntentRegistrationAttempt::Registered(intent) => intent,
+            other => panic!("expected registered intent, got {other:?}"),
+        };
 
         assert_eq!(
             registry.list_intents_for_session(&session.session_id).len(),
@@ -809,14 +1134,182 @@ mod tests {
         let registry = SessionRegistry::new();
         let fake_session = SessionId::new();
 
-        let result = registry.register_intent(
+        let result = registry.register_intent_checked(
             fake_session,
             vec![IntentScope::Entity(EntityId::new())],
             LockType::Soft,
             "test".into(),
             None,
         );
-        assert!(result.is_none());
+        assert!(matches!(result, IntentRegistrationAttempt::SessionNotFound));
+    }
+
+    #[test]
+    fn intent_registration_enforces_limit_and_foreign_hard_conflict() {
+        let registry = SessionRegistry::new();
+        let capabilities = SessionCapabilities {
+            can_write: true,
+            can_commit: true,
+            max_concurrent_intents: 1,
+            ..SessionCapabilities::default()
+        };
+        let first = registry.start_agent_session(
+            "codex",
+            "first",
+            SessionTransport::Mcp,
+            None,
+            PathBuf::from("/tmp"),
+            capabilities.clone(),
+        );
+        let second = registry.start_agent_session(
+            "claude-code",
+            "second",
+            SessionTransport::Mcp,
+            None,
+            PathBuf::from("/tmp"),
+            capabilities,
+        );
+        let entity = EntityId::new();
+
+        let registered = registry.register_intent_checked(
+            first.session_id,
+            vec![IntentScope::Entity(entity)],
+            LockType::Hard,
+            "first write".into(),
+            None,
+        );
+        assert!(matches!(
+            registered,
+            IntentRegistrationAttempt::Registered(_)
+        ));
+
+        let limited = registry.register_intent_checked(
+            first.session_id,
+            vec![IntentScope::Entity(EntityId::new())],
+            LockType::Hard,
+            "second write".into(),
+            None,
+        );
+        assert!(matches!(
+            limited,
+            IntentRegistrationAttempt::LimitExceeded {
+                active: 1,
+                limit: 1,
+                ..
+            }
+        ));
+
+        let blocked = registry.register_intent_checked(
+            second.session_id,
+            vec![IntentScope::Entity(entity)],
+            LockType::Hard,
+            "conflicting write".into(),
+            None,
+        );
+        assert!(matches!(blocked, IntentRegistrationAttempt::Blocked { .. }));
+    }
+
+    #[test]
+    fn hard_intent_requires_declared_write_capability() {
+        let registry = SessionRegistry::new();
+        let session = registry.start_agent_session(
+            "read-only-agent",
+            "reader",
+            SessionTransport::Mcp,
+            None,
+            PathBuf::from("/tmp"),
+            SessionCapabilities::default(),
+        );
+        let result = registry.register_intent_checked(
+            session.session_id,
+            vec![IntentScope::Entity(EntityId::new())],
+            LockType::Hard,
+            "must not block writers".into(),
+            None,
+        );
+        assert!(matches!(
+            result,
+            IntentRegistrationAttempt::CapabilityDenied {
+                capability: "can_write",
+                ..
+            }
+        ));
+        assert!(registry
+            .list_intents_for_session(&session.session_id)
+            .is_empty());
+    }
+
+    #[test]
+    fn transaction_preflight_enforce_fails_closed_before_apply() {
+        let registry = SessionRegistry::new();
+        let capabilities = SessionCapabilities {
+            can_write: true,
+            can_commit: true,
+            ..SessionCapabilities::default()
+        };
+        let owner = registry.start_agent_session(
+            "claude-code",
+            "owner",
+            SessionTransport::Mcp,
+            None,
+            PathBuf::from("/tmp"),
+            capabilities.clone(),
+        );
+        let caller = registry.start_agent_session(
+            "codex",
+            "caller",
+            SessionTransport::Mcp,
+            None,
+            PathBuf::from("/tmp"),
+            capabilities,
+        );
+        let entity = EntityId::new();
+        assert!(matches!(
+            registry.register_intent_checked(
+                owner.session_id,
+                vec![IntentScope::Entity(entity)],
+                LockType::Hard,
+                "owner write".into(),
+                None,
+            ),
+            IntentRegistrationAttempt::Registered(_)
+        ));
+
+        let denied = registry.evaluate_transaction_write_with_mode(
+            &caller.session_id.to_string(),
+            vec![IntentScope::Entity(entity)],
+            CoordinationEnforcementMode::Enforce,
+        );
+        assert!(!denied.allowed);
+        assert_eq!(denied.blocking_intents.len(), 1);
+        assert!(denied.capability_violations.is_empty());
+        assert!(!denied.coverage.contract_scopes);
+
+        let warned = registry.evaluate_transaction_write_with_mode(
+            &caller.session_id.to_string(),
+            vec![IntentScope::Entity(entity)],
+            CoordinationEnforcementMode::Warn,
+        );
+        assert!(warned.allowed);
+        assert_eq!(warned.blocking_intents.len(), 1);
+
+        let off = registry.evaluate_transaction_write_with_mode(
+            "legacy-session",
+            vec![IntentScope::Entity(entity)],
+            CoordinationEnforcementMode::Off,
+        );
+        assert!(off.allowed);
+        assert!(!off.evaluated);
+        assert!(off.blocking_intents.is_empty());
+        assert!(off.capability_violations.is_empty());
+
+        let unknown = registry.evaluate_transaction_write_with_mode(
+            "legacy-session",
+            vec![IntentScope::Entity(EntityId::new())],
+            CoordinationEnforcementMode::Enforce,
+        );
+        assert!(!unknown.allowed);
+        assert!(!unknown.capability_violations.is_empty());
     }
 
     #[test]
@@ -828,18 +1321,22 @@ mod tests {
             SessionTransport::Mcp,
             None,
             PathBuf::from("/tmp"),
-            SessionCapabilities::default(),
+            SessionCapabilities {
+                can_write: true,
+                ..SessionCapabilities::default()
+            },
         );
 
-        let intent = registry
-            .register_intent(
-                session.session_id,
-                vec![IntentScope::Entity(EntityId::new())],
-                LockType::Hard,
-                "editing".into(),
-                None,
-            )
-            .unwrap();
+        let intent = match registry.register_intent_checked(
+            session.session_id,
+            vec![IntentScope::Entity(EntityId::new())],
+            LockType::Hard,
+            "editing".into(),
+            None,
+        ) {
+            IntentRegistrationAttempt::Registered(intent) => intent,
+            other => panic!("expected registered intent, got {other:?}"),
+        };
 
         // Wrong session cannot release.
         let other_session = SessionId::new();
@@ -894,7 +1391,10 @@ mod tests {
             SessionTransport::Mcp,
             None,
             PathBuf::from("/tmp"),
-            SessionCapabilities::default(),
+            SessionCapabilities {
+                can_write: true,
+                ..SessionCapabilities::default()
+            },
         );
 
         let entity_id = EntityId::new();

--- a/tests/integration/src/concurrency_enforcement.rs
+++ b/tests/integration/src/concurrency_enforcement.rs
@@ -12,6 +12,7 @@
 
 use std::path::PathBuf;
 
+use kin_daemon::session_registry::IntentRegistrationResult;
 use kin_daemon::traffic_adapter::CoordinatorTrafficChecker;
 use kin_daemon::SessionCoordinator;
 use kin_model::session::{IntentScope, LockType, SessionCapabilities, SessionTransport};
@@ -20,6 +21,13 @@ use kin_reconcile::collision::{CollisionCheck, TrafficChecker};
 use kin_reconcile::{ReconcileError, Reconciler};
 
 use crate::helpers::{init_kin_repo, make_entity};
+
+fn writable_capabilities() -> SessionCapabilities {
+    SessionCapabilities {
+        can_write: true,
+        ..SessionCapabilities::default()
+    }
+}
 
 // -----------------------------------------------------------------------
 // 1. CoordinatorTrafficChecker blocks hard-locked scope
@@ -37,7 +45,7 @@ fn coordinator_checker_blocks_hard_locked_scope() {
             SessionTransport::Mcp,
             None,
             PathBuf::from("/project"),
-            SessionCapabilities::default(),
+            writable_capabilities(),
         )
         .unwrap();
 
@@ -55,7 +63,7 @@ fn coordinator_checker_blocks_hard_locked_scope() {
     let entity_id = EntityId::new();
 
     // Session 1 takes a hard lock on the entity.
-    coord
+    let registration = coord
         .register_intent(
             &s1,
             vec![IntentScope::Entity(entity_id)],
@@ -64,6 +72,10 @@ fn coordinator_checker_blocks_hard_locked_scope() {
             None,
         )
         .unwrap();
+    assert!(matches!(
+        registration,
+        IntentRegistrationResult::Registered { .. }
+    ));
 
     // Session 2 tries to check traffic on the same scope.
     let checker = CoordinatorTrafficChecker::new(graph.clone());
@@ -99,7 +111,7 @@ fn coordinator_checker_allows_disjoint_scopes() {
             SessionTransport::Mcp,
             None,
             PathBuf::from("/project"),
-            SessionCapabilities::default(),
+            writable_capabilities(),
         )
         .unwrap();
 
@@ -107,7 +119,7 @@ fn coordinator_checker_allows_disjoint_scopes() {
     let entity_b = EntityId::new();
 
     // Session 1 hard-locks entity A.
-    coord
+    let registration = coord
         .register_intent(
             &s1,
             vec![IntentScope::Entity(entity_a)],
@@ -116,6 +128,10 @@ fn coordinator_checker_allows_disjoint_scopes() {
             None,
         )
         .unwrap();
+    assert!(matches!(
+        registration,
+        IntentRegistrationResult::Registered { .. }
+    ));
 
     // Check traffic on entity B — should be clear.
     let checker = CoordinatorTrafficChecker::new(graph.clone());
@@ -147,14 +163,14 @@ fn coordinator_checker_allows_own_session() {
             SessionTransport::Mcp,
             None,
             PathBuf::from("/project"),
-            SessionCapabilities::default(),
+            writable_capabilities(),
         )
         .unwrap();
 
     let entity_id = EntityId::new();
 
     // Session 1 hard-locks the entity.
-    coord
+    let registration = coord
         .register_intent(
             &s1,
             vec![IntentScope::Entity(entity_id)],
@@ -163,6 +179,10 @@ fn coordinator_checker_allows_own_session() {
             None,
         )
         .unwrap();
+    assert!(matches!(
+        registration,
+        IntentRegistrationResult::Registered { .. }
+    ));
 
     // Session 1 checks traffic on the same entity — should NOT be blocked.
     let checker = CoordinatorTrafficChecker::new(graph.clone());
@@ -200,7 +220,7 @@ fn coordinator_checker_warns_on_soft_lease() {
     let entity_id = EntityId::new();
 
     // Session 1 takes a soft lock on the entity.
-    coord
+    let registration = coord
         .register_intent(
             &s1,
             vec![IntentScope::Entity(entity_id)],
@@ -209,6 +229,10 @@ fn coordinator_checker_warns_on_soft_lease() {
             None,
         )
         .unwrap();
+    assert!(matches!(
+        registration,
+        IntentRegistrationResult::Registered { .. }
+    ));
 
     // Another session checks traffic — should get warnings, not blocked.
     let checker = CoordinatorTrafficChecker::new(graph.clone());
@@ -243,7 +267,7 @@ fn reconciler_with_coordinator_checker_blocks_hard_lock() {
             SessionTransport::Mcp,
             None,
             PathBuf::from("/project"),
-            SessionCapabilities::default(),
+            writable_capabilities(),
         )
         .unwrap();
 
@@ -251,7 +275,7 @@ fn reconciler_with_coordinator_checker_blocks_hard_lock() {
     let entity_id = entity.id;
 
     // Session 1 hard-locks the entity.
-    coord
+    let registration = coord
         .register_intent(
             &s1,
             vec![IntentScope::Entity(entity_id)],
@@ -260,6 +284,10 @@ fn reconciler_with_coordinator_checker_blocks_hard_lock() {
             None,
         )
         .unwrap();
+    assert!(matches!(
+        registration,
+        IntentRegistrationResult::Registered { .. }
+    ));
 
     // Set up reconciler with the coordinator-backed traffic checker.
     let checker = CoordinatorTrafficChecker::new(graph.clone());

--- a/tests/integration/src/p7_acceptance.rs
+++ b/tests/integration/src/p7_acceptance.rs
@@ -14,6 +14,13 @@ use kin_reconcile::{CollisionCheck, ReconcileError, Reconciler, TrafficChecker};
 
 use crate::helpers::*;
 
+fn writable_capabilities() -> SessionCapabilities {
+    SessionCapabilities {
+        can_write: true,
+        ..SessionCapabilities::default()
+    }
+}
+
 // -----------------------------------------------------------------------
 // 8. Session lifecycle: register -> heartbeat -> verify active -> end -> gone
 // -----------------------------------------------------------------------
@@ -78,7 +85,7 @@ fn intent_hard_collision_blocks_second_agent() {
             SessionTransport::Mcp,
             None,
             PathBuf::from("/project"),
-            SessionCapabilities::default(),
+            writable_capabilities(),
         )
         .unwrap();
 
@@ -89,7 +96,7 @@ fn intent_hard_collision_blocks_second_agent() {
             SessionTransport::Cli,
             None,
             PathBuf::from("/project"),
-            SessionCapabilities::default(),
+            writable_capabilities(),
         )
         .unwrap();
 
@@ -571,7 +578,7 @@ fn contract_scope_collision() {
             SessionTransport::Mcp,
             None,
             PathBuf::from("/project"),
-            SessionCapabilities::default(),
+            writable_capabilities(),
         )
         .unwrap();
 
@@ -582,7 +589,7 @@ fn contract_scope_collision() {
             SessionTransport::Cli,
             None,
             PathBuf::from("/project"),
-            SessionCapabilities::default(),
+            writable_capabilities(),
         )
         .unwrap();
 
@@ -641,7 +648,7 @@ fn artifact_scope_collision() {
             SessionTransport::Mcp,
             None,
             PathBuf::from("/project"),
-            SessionCapabilities::default(),
+            writable_capabilities(),
         )
         .unwrap();
 
@@ -652,7 +659,7 @@ fn artifact_scope_collision() {
             SessionTransport::Cli,
             None,
             PathBuf::from("/project"),
-            SessionCapabilities::default(),
+            writable_capabilities(),
         )
         .unwrap();
 


### PR DESCRIPTION
## Summary

- make intent registration and conflict checks atomic, including hard-intent limits and foreign-scope collision handling
- add `can_write` and `can_commit` preflight decisions across session, daemon, MCP transaction, and covered VFS mutation paths
- support `off`, `warn`, and `enforce` modes, with warn as the default and enforce rejecting covered writes before graph mutation
- represent entity, artifact, relation, endpoint, and declared contract scopes
- persist fsync-backed coordination events to `.kin/coordination_events.jsonl`
- expose coordination capability coverage through `kin bench-meta --json`

## Why

Multi-agent coordination cannot be measured honestly if Kin only observes collisions after writes land. This closes the covered daemon/MCP/VFS mutation boundaries so the benchmark can distinguish prevented conflicts from post-hoc warnings.

## Impact

Agents using Kin sessions and covered transaction/write APIs receive deterministic conflict decisions and evidence-bearing events. Existing users keep warn-mode compatibility unless enforcement is explicitly enabled.

## Verification

- daemon write-notify veto suite (6 passed)
- daemon file-changed veto suite (4 passed)
- daemon MCP transaction suite (7 passed)
- daemon intent registration filter (8 passed)
- durable coordination-event log test (1 passed)
- MCP session filter (34 passed)
- `cargo test -p kin-cli --test bench_meta_json` (2 passed)
- `cargo test -p kin-integration-tests --lib` (107 passed)
- `cargo fmt --all -- --check`
- `git diff --check origin/main...HEAD`

The existing `block v0.1.6` future-incompatibility warning remains unchanged.

## CI repair

The first Linux run exposed five legacy collision fixtures that created hard-intent sessions with `SessionCapabilities::default()`, which correctly means `can_write=false`. The new gate returned `CapabilityDenied`, so no lock was persisted and the later collision assertions observed `Clear`. The fixtures now declare `can_write=true` and explicitly assert successful registration. Product enforcement remains fail-closed.

## Known boundaries

- this is not a blanket veto for arbitrary direct filesystem writes outside the covered Kin surfaces
- semantic contract-content scopes are not yet emitted automatically at every mutation boundary
- an event-log append failure cannot roll back an action that already completed
- future lower-level callers must continue routing through the guarded APIs

## Claim boundary

This PR creates the enforcement and telemetry surface. It does not provide a citable multi-agent collision, rework, or token-efficiency result until a sealed benchmark is run against a release containing the code.

## Integration

Draft only. Rebased onto current `main` after PR #280 merged; the daemon API conflict was resolved by preserving both VFS snapshot-cache imports and coordination-event imports. Post-rebase verification passed: full `kin-daemon`, `kin-mcp`, and `kin-integration-tests` package suites, the bench-meta integration test, formatting, and diff checks. Keep it behind the existing queue and behind the smaller ranked-impact PR; rebase once more if earlier queue entries move `main` before this reaches the head.
