### PR TITLE
fix(embed): adopt kin-db 0.2.33 sidecar throttle + daemon end-of-pass sidecar write

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3199,9 +3199,9 @@ dependencies = [
 
 [[package]]
 name = "kin-db"
-version = "0.2.31"
+version = "0.2.33"
 source = "sparse+https://kinlab.ai/registry/cargo/"
-checksum = "0a0f75ffa9eaeac70cd85699908392c122f3071270676a8ff177983b912aeb73"
+checksum = "48dbae484d52e67dd92a80d7538c30585c9852e9e51395009ec246a2947c6891"
 dependencies = [
  "bincode",
  "bytes",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -143,7 +143,7 @@ kin-lsp = { version = "0.2.2", registry = "kin" }
 # backend on every target (incl. Linux, where it cannot compile). Metal is re-enabled
 # additively on macOS via a `[target.'cfg(target_os = "macos")'.dependencies]` block in the
 # binary/runtime crates (kin-cli, kin-daemon). Feature unification makes that additive.
-kin-db = { version = "0.2.31", registry = "kin", default-features = false, features = ["vector", "embeddings"] }
+kin-db = { version = "0.2.33", registry = "kin", default-features = false, features = ["vector", "embeddings"] }
 kin-vfs-core = { version = "0.1.2", registry = "kin" }
 
 [profile.release]

--- a/crates/kin-daemon/src/api.rs
+++ b/crates/kin-daemon/src/api.rs
@@ -3617,6 +3617,17 @@ async fn embed(
                 .save_snapshot()
                 .map_err(|error| format!("embed snapshot save failed: {error:#}"))?;
             state_for_embed.mark_clean();
+            // A time-limited pass stopped mid-drain, so the throttled per-batch
+            // sidecar flush may not have captured the vectors embedded since the
+            // last throttle tick. Force one sidecar write at the pass boundary so
+            // a graceful daemon exit before the next pass resumes with the full
+            // pass persisted. A pass that drained the queue already wrote the
+            // sidecar unconditionally, so this only fires when work remains.
+            if result.result.time_limited {
+                state_for_embed
+                    .persist_vector_sidecar()
+                    .map_err(|error| format!("embed sidecar persist failed: {error:#}"))?;
+            }
         }
         Ok::<_, String>(result)
     })

--- a/crates/kin-daemon/src/api.rs
+++ b/crates/kin-daemon/src/api.rs
@@ -9882,7 +9882,7 @@ mod tests {
     }
 
     #[test]
-    fn foreground_embed_batch_flush_defers_sidecar_while_queue_pending() {
+    fn foreground_embed_batch_flush_checkpoints_sidecar_on_throttle() {
         let state = test_state();
         state
             .graph
@@ -9897,11 +9897,23 @@ mod tests {
         state.graph.queue_missing_for_embedding();
         assert!(state.graph.pending_embeddings() > 0);
 
+        // The first in-run flush checkpoints the sidecar so persisted coverage
+        // tracks compute from the first batch (the persist-wedge fix).
+        std::fs::remove_file(&vector_path).unwrap();
+        persist_foreground_embed_batch(state.as_ref()).unwrap();
+        assert!(
+            vector_path.exists(),
+            "the first foreground per-batch flush must checkpoint the sidecar"
+        );
+
+        // An immediate follow-up flush is throttled (within the interval and the
+        // batch backstop), so a long run is not billed a full index serialize on
+        // every batch while work is still pending.
         std::fs::remove_file(&vector_path).unwrap();
         persist_foreground_embed_batch(state.as_ref()).unwrap();
         assert!(
             !vector_path.exists(),
-            "foreground per-batch flush must defer the sidecar while work is pending"
+            "an immediate follow-up foreground flush must be throttled while work is pending"
         );
     }
 

--- a/crates/kin-daemon/src/state.rs
+++ b/crates/kin-daemon/src/state.rs
@@ -1603,6 +1603,32 @@ impl DaemonState {
         Ok(outcome.status.pending)
     }
 
+    /// Force the derived vector sidecar to disk regardless of the in-run flush
+    /// throttle.
+    ///
+    /// While an embed drains, `flush_embed_progress` checkpoints the sidecar on a
+    /// throttle rather than every batch, so a pass that ends time-limited (queue
+    /// not yet drained) can leave the vectors embedded since the last throttle
+    /// tick in memory only. Calling this at a pass boundary lands them durably,
+    /// so a graceful daemon exit before the next pass resumes with the full pass
+    /// persisted instead of re-deriving that last window. The vector index is a
+    /// pure sidecar (not in the merkle root), so this never advances the graph
+    /// generation. Cost is one index serialize per time-limited pass, not per
+    /// batch.
+    pub fn persist_vector_sidecar(&self) -> Result<()> {
+        let _persist_guard = self
+            .persist_lock
+            .lock()
+            .map_err(|_| DaemonError::Io(std::io::Error::other("persist lock poisoned")))?;
+        let embedder_identity = kin_buildinfo::sha_with_dirty(kin_buildinfo::get());
+        kin_db::SnapshotManager::save_vector_index_for_graph(
+            self.layout.kindb_snapshot_path(),
+            self.graph.as_ref(),
+            Some(embedder_identity.as_str()),
+        )
+        .map_err(DaemonError::from)
+    }
+
     fn save_read_index(&self) -> Result<()> {
         let index =
             kin_db::ReadIndex::from_graph(self.graph.as_ref()).map_err(DaemonError::from)?;


### PR DESCRIPTION
## What

Adopt the kin-db embed persist-wedge fix and add a daemon-side durability backstop.

1. **Bump `kin-db` 0.2.31 → 0.2.33** (registry, re-locked patch-off — registry source + checksum preserved). 0.2.33 carries the vector-sidecar throttle fix: `flush_embed_progress` now checkpoints the derived sidecar on a throttle while embedding is in flight (first batch, then every 30s or 64 batches) instead of deferring it until the queue drains. That fixes the cache-cold bulk-embed wedge where persisted coverage froze at a batch boundary while compute kept advancing.

2. **Daemon end-of-pass sidecar write** (`DaemonState::persist_vector_sidecar`, called from the `/embed` handler): a pass that ends time-limited (queue not yet drained) can leave the vectors embedded since the last throttle tick in memory only. This forces one sidecar write at the pass boundary so a graceful daemon exit before the next pass resumes with the full pass persisted — closing the graceful-exit half of the residual window the throttle alone leaves open. A pass that drained the queue already wrote the sidecar unconditionally, so this fires only when work remains: one index serialize per time-limited pass, not per batch.

## Why

Cache-cold `kin embed` of a large repo (≳20k entities) wedged: the vector index advanced in memory (`process_embedding_queue`) while the on-disk `graph.kvec` stayed frozen at a batch-size multiple, because the per-batch flush deferred the sidecar for the whole run. A persisted-progress watchdog then reaped the run, which re-embedded from scratch. The kin-db throttle makes persisted track compute; this daemon change makes a graceful pass boundary durable too.

## Lock

Only the `kin-db` lock entry changes (0.2.31 → 0.2.33, checksum updated). Verified against the registry: kin-db 0.2.33 adds/removes no dependencies vs 0.2.31 — its sole changed requirement is `kin-model` 0.2.2 → 0.2.3, already satisfied by the lock's existing `kin-model` 0.2.4. Source stays `sparse+` with checksum (no path patch).

## Notes

Timing-only behavior change (sidecar write cadence); no throughput claim is made without measurement. The end-to-end large-repo unwedge is verified separately on registry-clean binaries.
