### PR TITLE
feat(locate): multi-query fan-out + RRF fusion on CLI and MCP surfaces

### DIFF
--- a/crates/kin-cli/src/commands/contextbench_locate.rs
+++ b/crates/kin-cli/src/commands/contextbench_locate.rs
@@ -149,6 +149,7 @@ pub async fn run(task_file: PathBuf, json: bool, debug: bool) -> Result<()> {
     let max_files_explicit = std::env::var("KIN_CONTEXTBENCH_MAX_FILES").is_ok();
     let locate_result = crate::commands::locate::capture(
         &bounded_query,
+        Vec::new(),
         true,
         max_files,
         max_files_explicit,

--- a/crates/kin-cli/src/commands/locate.rs
+++ b/crates/kin-cli/src/commands/locate.rs
@@ -71,6 +71,11 @@ pub struct LocateResult {
     /// tell a strong answer from a degraded one without parsing logs.
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub degradations: Vec<RetrievalDegradation>,
+    /// In multi-query fusion mode, the ordered query variants whose per-variant
+    /// rankings were RRF-fused into this result (index 0 is the primary query).
+    /// Empty for a single-query locate, so single-query output is byte-identical.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub queries: Vec<String>,
 }
 
 /// One retrieval capability that did not fully run for a query, with the
@@ -120,7 +125,7 @@ impl LocateResult {
     }
 }
 
-#[derive(Serialize, Deserialize)]
+#[derive(Serialize, Deserialize, Clone)]
 pub struct LocateFileEntry {
     pub path: String,
     pub score: f32,
@@ -146,6 +151,11 @@ pub struct LocateFileEntry {
     /// Per-stage score breakdown (only with --explain).
     #[serde(skip_serializing_if = "Option::is_none")]
     pub score_breakdown: Option<std::collections::HashMap<String, f32>>,
+    /// Under multi-query RRF fusion, the query variants that surfaced this file
+    /// (each is one of [`LocateResult::queries`]). Empty (and omitted) for a
+    /// single-query locate.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub matched_queries: Vec<String>,
 }
 
 /// A single ranked symbol (graph entity) attributed to a file by `kin locate`.
@@ -223,6 +233,12 @@ pub struct LocateEntity {
     pub body: Option<String>,
     /// Where this entity lives. The file is provenance, not the result.
     pub provenance: LocateProvenance,
+    /// Under multi-query RRF fusion, the query variants that surfaced this entity
+    /// (each is one of [`LocateResult::queries`]). Travels with the entity through
+    /// paging and the daemon ranking cache so a paged hit keeps its attribution.
+    /// Empty (and omitted) for a single-query locate.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub matched_queries: Vec<String>,
 }
 
 /// Provenance for a [`LocateEntity`]: the file (and resolution origin) the entity
@@ -1153,8 +1169,10 @@ pub struct LocatePaging {
     pub page_size: Option<usize>,
 }
 
+#[allow(clippy::too_many_arguments)]
 pub async fn run(
     text: &str,
+    queries: Vec<String>,
     json: bool,
     explain: bool,
     max_files: usize,
@@ -1173,6 +1191,7 @@ pub async fn run(
     .entered();
     let result = capture(
         text,
+        queries,
         explain,
         max_files,
         max_files_explicit,
@@ -1188,8 +1207,10 @@ pub async fn run(
     Ok(())
 }
 
+#[allow(clippy::too_many_arguments)]
 pub async fn capture(
     text: &str,
+    queries: Vec<String>,
     explain: bool,
     max_files: usize,
     max_files_explicit: bool,
@@ -1208,6 +1229,7 @@ pub async fn capture(
     let result = try_locate_via_daemon(
         &layout,
         text,
+        queries,
         explain,
         max_files,
         max_files_explicit,
@@ -1289,9 +1311,11 @@ fn emit_telemetry_disclosure_once() {
     });
 }
 
+#[allow(clippy::too_many_arguments)]
 async fn try_locate_via_daemon(
     layout: &kin_core::KinLayout,
     text: &str,
+    queries: Vec<String>,
     explain: bool,
     max_files: usize,
     max_files_explicit: bool,
@@ -1310,6 +1334,7 @@ async fn try_locate_via_daemon(
     let client = crate::daemon_client::DaemonClient::from_base_url(base_url)?;
     let request = crate::daemon_client::LocateRequest {
         text: text.to_string(),
+        queries,
         explain,
         max_files,
         max_files_explicit,
@@ -14877,6 +14902,7 @@ pub fn build_entity_view(
                         origin: sym.origin.clone(),
                         cosine: sym.cosine,
                     },
+                    matched_queries: Vec::new(),
                 },
             ));
         }
@@ -14975,6 +15001,143 @@ pub fn apply_entity_page(
     });
 }
 
+/// Reciprocal-rank-fusion constant `k` (`KIN_LOCATE_RRF_K`, default 60). Larger
+/// `k` flattens the rank-position weighting; the standard literature value is 60.
+/// Floored at 1 so the denominator can never collapse.
+pub fn locate_rrf_k() -> f64 {
+    locate_env_usize("KIN_LOCATE_RRF_K", 60).max(1) as f64
+}
+
+/// Reciprocal Rank Fusion over several already-ranked item lists. Each item
+/// contributes `1 / (k + rank + 1)` (0-based `rank`) to the fused score of its
+/// dedup key; contributions from every list that surfaced the key are summed.
+/// Returns one entry per distinct key: the best-ranked record (lowest rank, ties
+/// broken by lowest list index), the sorted indices of the lists that surfaced
+/// it, and the fused score. Order of the returned Vec is unspecified — the caller
+/// applies a total-order sort — but the computation is fully deterministic for a
+/// given input. Pure: no graph, no clock, no randomness.
+pub fn rrf_fuse<T, K, FKey>(
+    per_list: &[Vec<T>],
+    key_of: FKey,
+    rrf_k: f64,
+) -> Vec<(T, Vec<usize>, f64)>
+where
+    T: Clone,
+    K: Eq + std::hash::Hash,
+    FKey: Fn(&T) -> K,
+{
+    // (fused_score, contributing list indices, best_rank, best_list, best_record)
+    let mut acc: HashMap<K, (f64, Vec<usize>, usize, usize, T)> = HashMap::new();
+    for (list_idx, items) in per_list.iter().enumerate() {
+        for (rank, item) in items.iter().enumerate() {
+            let key = key_of(item);
+            let contribution = 1.0 / (rrf_k + rank as f64 + 1.0);
+            match acc.get_mut(&key) {
+                Some(entry) => {
+                    entry.0 += contribution;
+                    if !entry.1.contains(&list_idx) {
+                        entry.1.push(list_idx);
+                    }
+                    if rank < entry.2 || (rank == entry.2 && list_idx < entry.3) {
+                        entry.2 = rank;
+                        entry.3 = list_idx;
+                        entry.4 = item.clone();
+                    }
+                }
+                None => {
+                    acc.insert(key, (contribution, vec![list_idx], rank, list_idx, item.clone()));
+                }
+            }
+        }
+    }
+    acc.into_values()
+        .map(|(score, mut lists, _, _, record)| {
+            lists.sort_unstable();
+            (record, lists, score)
+        })
+        .collect()
+}
+
+/// The file path a located entity resolves to, for a stable fusion tie-break.
+fn locate_entity_tiebreak_path(entity: &LocateEntity) -> &str {
+    entity.provenance.file.as_deref().unwrap_or("")
+}
+
+/// Fuse the per-variant [`LocateResult`]s of a multi-query locate into a single
+/// deduped result via Reciprocal Rank Fusion. `variants` is the ordered variant
+/// text (index-aligned with `results`; index 0 is the primary query). Entities
+/// are fused by `entity_id`, files by path; each fused hit records which variant
+/// texts surfaced it in `matched_queries`. Ordering is RRF-score-descending with
+/// deterministic tie-breaks (entities by file path then id; files by path). The
+/// per-hit composite `score` is preserved from the hit's best-ranked variant —
+/// array order carries the fused ranking. `degradations` are unioned; the debug
+/// object and semantic coverage are taken from the primary variant. With a single
+/// variant this returns that result unchanged (no fusion, no attribution).
+pub fn fuse_locate_results(
+    variants: Vec<String>,
+    results: Vec<LocateResult>,
+    rrf_k: f64,
+) -> LocateResult {
+    if variants.len() <= 1 || results.len() <= 1 {
+        return results.into_iter().next().unwrap_or_default();
+    }
+
+    let entity_lists: Vec<Vec<LocateEntity>> =
+        results.iter().map(|r| r.entities.clone()).collect();
+    let file_lists: Vec<Vec<LocateFileEntry>> = results.iter().map(|r| r.files.clone()).collect();
+
+    let mut fused_entities = rrf_fuse(&entity_lists, |e| e.entity_id.clone(), rrf_k);
+    fused_entities.sort_by(|(a, _, sa), (b, _, sb)| {
+        sb.partial_cmp(sa)
+            .unwrap_or(std::cmp::Ordering::Equal)
+            .then_with(|| locate_entity_tiebreak_path(a).cmp(locate_entity_tiebreak_path(b)))
+            .then_with(|| a.entity_id.cmp(&b.entity_id))
+    });
+    let entities: Vec<LocateEntity> = fused_entities
+        .into_iter()
+        .map(|(mut entity, lists, _)| {
+            entity.matched_queries = lists.iter().map(|&i| variants[i].clone()).collect();
+            entity
+        })
+        .collect();
+
+    let mut fused_files = rrf_fuse(&file_lists, |f| f.path.clone(), rrf_k);
+    fused_files.sort_by(|(a, _, sa), (b, _, sb)| {
+        sb.partial_cmp(sa)
+            .unwrap_or(std::cmp::Ordering::Equal)
+            .then_with(|| a.path.cmp(&b.path))
+    });
+    let files: Vec<LocateFileEntry> = fused_files
+        .into_iter()
+        .map(|(mut file, lists, _)| {
+            file.matched_queries = lists.iter().map(|&i| variants[i].clone()).collect();
+            file
+        })
+        .collect();
+
+    let mut degradations: Vec<RetrievalDegradation> = Vec::new();
+    for result in &results {
+        for degradation in &result.degradations {
+            if !degradations.contains(degradation) {
+                degradations.push(degradation.clone());
+            }
+        }
+    }
+
+    let primary = results.into_iter().next().unwrap_or_default();
+    LocateResult {
+        entities,
+        next_cursor: None,
+        page: 0,
+        total_ranked: 0,
+        files,
+        debug: primary.debug,
+        semantic_coverage: primary.semantic_coverage,
+        degradations,
+        queries: variants,
+    }
+}
+
 fn build_result(
     results: &[(String, f32)],
     all_hits: &[HashMap<String, Vec<FileHit>>],
@@ -15027,6 +15190,7 @@ fn build_result(
             } else {
                 None
             },
+            matched_queries: Vec::new(),
         })
         .collect();
 
@@ -15199,6 +15363,7 @@ mod tests {
                 origin: "vector".to_string(),
                 cosine: Some(0.5),
             },
+            matched_queries: Vec::new(),
         }
     }
 
@@ -15331,6 +15496,125 @@ mod tests {
         assert_ne!(a, locate_cursor_key("find the parser", Some("main"), 42));
     }
 
+    fn fusion_entity(id: &str, path: &str, score: f32) -> LocateEntity {
+        LocateEntity {
+            entity_id: id.to_string(),
+            kind: "function".to_string(),
+            name: id.to_string(),
+            signature: String::new(),
+            score,
+            definition: true,
+            span: None,
+            body: None,
+            provenance: LocateProvenance {
+                file: Some(path.to_string()),
+                origin: String::new(),
+                cosine: None,
+            },
+            matched_queries: Vec::new(),
+        }
+    }
+
+    fn fusion_result(entities: Vec<LocateEntity>) -> LocateResult {
+        LocateResult {
+            entities,
+            ..Default::default()
+        }
+    }
+
+    #[test]
+    fn rrf_fuse_sums_contributions_and_attributes_lists() {
+        // "a" is rank 0 in list 0 and rank 1 in list 1; "b" only in list 1.
+        let lists = vec![vec!["a", "c"], vec!["b", "a"]];
+        let mut fused = rrf_fuse(&lists, |s| s.to_string(), 60.0);
+        fused.sort_by(|(_, _, sa), (_, _, sb)| {
+            sb.partial_cmp(sa).unwrap_or(std::cmp::Ordering::Equal)
+        });
+        // "a" surfaced in both lists → highest fused score and both list indices.
+        let (top, lists_of_top, _score) = &fused[0];
+        assert_eq!(*top, "a");
+        assert_eq!(lists_of_top, &vec![0, 1]);
+        // Singleton keys carry exactly one contributing list.
+        let b = fused.iter().find(|(k, _, _)| *k == "b").unwrap();
+        assert_eq!(b.1, vec![1]);
+    }
+
+    #[test]
+    fn fuse_locate_results_single_variant_is_passthrough() {
+        let result = fusion_result(vec![
+            fusion_entity("e1", "src/a.rs", 2.0),
+            fusion_entity("e2", "src/b.rs", 1.0),
+        ]);
+        let fused = fuse_locate_results(
+            vec!["only query".to_string()],
+            vec![result],
+            locate_rrf_k(),
+        );
+        // No fusion: order and records untouched, no attribution emitted.
+        assert_eq!(fused.entities.len(), 2);
+        assert_eq!(fused.entities[0].entity_id, "e1");
+        assert!(fused.queries.is_empty());
+        assert!(fused.entities.iter().all(|e| e.matched_queries.is_empty()));
+    }
+
+    #[test]
+    fn fuse_locate_results_unions_and_attributes_variants() {
+        // v0 ranks e1 > e2; v1 ranks e3 > e1. e1 appears in both → should win.
+        let v0 = fusion_result(vec![
+            fusion_entity("e1", "src/one.rs", 5.0),
+            fusion_entity("e2", "src/two.rs", 4.0),
+        ]);
+        let v1 = fusion_result(vec![
+            fusion_entity("e3", "src/three.rs", 5.0),
+            fusion_entity("e1", "src/one.rs", 3.0),
+        ]);
+        let variants = vec!["identifier query".to_string(), "behavior query".to_string()];
+        let fused = fuse_locate_results(variants.clone(), vec![v0, v1], 60.0);
+
+        assert_eq!(fused.queries, variants);
+        // e1 (in both variants) fuses to the top.
+        assert_eq!(fused.entities[0].entity_id, "e1");
+        assert_eq!(
+            fused.entities[0].matched_queries,
+            vec!["identifier query".to_string(), "behavior query".to_string()]
+        );
+        // Union covers every distinct entity across the variants.
+        let ids: Vec<&str> = fused
+            .entities
+            .iter()
+            .map(|e| e.entity_id.as_str())
+            .collect();
+        assert!(ids.contains(&"e1") && ids.contains(&"e2") && ids.contains(&"e3"));
+        // Single-variant hits attribute to exactly the variant that surfaced them.
+        let e2 = fused.entities.iter().find(|e| e.entity_id == "e2").unwrap();
+        assert_eq!(e2.matched_queries, vec!["identifier query".to_string()]);
+        let e3 = fused.entities.iter().find(|e| e.entity_id == "e3").unwrap();
+        assert_eq!(e3.matched_queries, vec!["behavior query".to_string()]);
+    }
+
+    #[test]
+    fn fuse_locate_results_is_deterministic() {
+        let build = || {
+            vec![
+                fusion_result(vec![
+                    fusion_entity("e1", "src/one.rs", 5.0),
+                    fusion_entity("e2", "src/two.rs", 4.0),
+                ]),
+                fusion_result(vec![
+                    fusion_entity("e2", "src/two.rs", 3.0),
+                    fusion_entity("e3", "src/three.rs", 2.0),
+                ]),
+            ]
+        };
+        let variants = vec!["q0".to_string(), "q1".to_string()];
+        let first = fuse_locate_results(variants.clone(), build(), 60.0);
+        let second = fuse_locate_results(variants, build(), 60.0);
+        let first_ids: Vec<&str> = first.entities.iter().map(|e| e.entity_id.as_str()).collect();
+        let second_ids: Vec<&str> =
+            second.entities.iter().map(|e| e.entity_id.as_str()).collect();
+        assert_eq!(first_ids, second_ids);
+    }
+
     #[test]
     fn build_entity_view_is_noop_when_snippets_disabled() {
         let graph = kin_db::InMemoryGraph::new();
@@ -15345,6 +15629,7 @@ mod tests {
                 provenance: None,
                 signal_scores: None,
                 score_breakdown: None,
+                matched_queries: Vec::new(),
             }],
             ..Default::default()
         };
@@ -22349,6 +22634,7 @@ mod tests {
                 provenance: None,
                 signal_scores: None,
                 score_breakdown: None,
+                matched_queries: Vec::new(),
             }],
             debug: None,
             semantic_coverage: None,

--- a/crates/kin-cli/src/commands/locate.rs
+++ b/crates/kin-cli/src/commands/locate.rs
@@ -15003,9 +15003,10 @@ pub fn apply_entity_page(
 
 /// Reciprocal-rank-fusion constant `k` (`KIN_LOCATE_RRF_K`, default 60). Larger
 /// `k` flattens the rank-position weighting; the standard literature value is 60.
-/// Floored at 1 so the denominator can never collapse.
+/// Floored at 1 so the denominator can never collapse. Shares the same knob the
+/// internal signal-fusion RRF reads, so both fusions stay on one constant.
 pub fn locate_rrf_k() -> f64 {
-    locate_env_usize("KIN_LOCATE_RRF_K", 60).max(1) as f64
+    locate_env_f32("KIN_LOCATE_RRF_K", 60.0).max(1.0) as f64
 }
 
 /// Reciprocal Rank Fusion over several already-ranked item lists. Each item

--- a/crates/kin-cli/src/commands/locate.rs
+++ b/crates/kin-cli/src/commands/locate.rs
@@ -15046,7 +15046,10 @@ where
                     }
                 }
                 None => {
-                    acc.insert(key, (contribution, vec![list_idx], rank, list_idx, item.clone()));
+                    acc.insert(
+                        key,
+                        (contribution, vec![list_idx], rank, list_idx, item.clone()),
+                    );
                 }
             }
         }
@@ -15083,8 +15086,7 @@ pub fn fuse_locate_results(
         return results.into_iter().next().unwrap_or_default();
     }
 
-    let entity_lists: Vec<Vec<LocateEntity>> =
-        results.iter().map(|r| r.entities.clone()).collect();
+    let entity_lists: Vec<Vec<LocateEntity>> = results.iter().map(|r| r.entities.clone()).collect();
     let file_lists: Vec<Vec<LocateFileEntry>> = results.iter().map(|r| r.files.clone()).collect();
 
     let mut fused_entities = rrf_fuse(&entity_lists, |e| e.entity_id.clone(), rrf_k);
@@ -15546,11 +15548,8 @@ mod tests {
             fusion_entity("e1", "src/a.rs", 2.0),
             fusion_entity("e2", "src/b.rs", 1.0),
         ]);
-        let fused = fuse_locate_results(
-            vec!["only query".to_string()],
-            vec![result],
-            locate_rrf_k(),
-        );
+        let fused =
+            fuse_locate_results(vec!["only query".to_string()], vec![result], locate_rrf_k());
         // No fusion: order and records untouched, no attribution emitted.
         assert_eq!(fused.entities.len(), 2);
         assert_eq!(fused.entities[0].entity_id, "e1");
@@ -15610,9 +15609,16 @@ mod tests {
         let variants = vec!["q0".to_string(), "q1".to_string()];
         let first = fuse_locate_results(variants.clone(), build(), 60.0);
         let second = fuse_locate_results(variants, build(), 60.0);
-        let first_ids: Vec<&str> = first.entities.iter().map(|e| e.entity_id.as_str()).collect();
-        let second_ids: Vec<&str> =
-            second.entities.iter().map(|e| e.entity_id.as_str()).collect();
+        let first_ids: Vec<&str> = first
+            .entities
+            .iter()
+            .map(|e| e.entity_id.as_str())
+            .collect();
+        let second_ids: Vec<&str> = second
+            .entities
+            .iter()
+            .map(|e| e.entity_id.as_str())
+            .collect();
         assert_eq!(first_ids, second_ids);
     }
 

--- a/crates/kin-cli/src/commands/locate_debug.rs
+++ b/crates/kin-cli/src/commands/locate_debug.rs
@@ -504,6 +504,7 @@ pub async fn run(
     // 2. Run locate with explain=true and wider max_files
     let result = crate::commands::locate::capture(
         &query_text,
+        Vec::new(),
         true,
         max_files,
         true,

--- a/crates/kin-cli/src/daemon_client.rs
+++ b/crates/kin-cli/src/daemon_client.rs
@@ -163,6 +163,12 @@ pub struct DaemonClient {
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct LocateRequest {
     pub text: String,
+    /// Additional query variants for multi-query fan-out. When non-empty the
+    /// daemon retrieves `text` plus each variant independently and RRF-fuses the
+    /// rankings into one deduped result, with per-hit variant attribution. Empty
+    /// (the default) is a single-query locate, serialized identically to before.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub queries: Vec<String>,
     pub explain: bool,
     pub max_files: usize,
     pub max_files_explicit: bool,

--- a/crates/kin-cli/src/main.rs
+++ b/crates/kin-cli/src/main.rs
@@ -216,6 +216,13 @@ enum Command {
     Locate {
         /// Problem text (inline)
         text: Option<String>,
+        /// Additional query variant(s) for multi-query fan-out (repeatable).
+        /// The primary text plus each variant are retrieved independently and
+        /// their rankings RRF-fused into one deduped result. Diverse variants
+        /// (identifiers, behavior, subsystem) recover more relevant files than
+        /// any single phrasing. Omit for a normal single-query locate.
+        #[arg(long = "query", value_name = "QUERY")]
+        query: Vec<String>,
         /// Read problem text from file
         #[arg(long)]
         file: Option<String>,
@@ -1992,6 +1999,7 @@ fn main() -> Result<()> {
                 }
                 Command::Locate {
                     text,
+                    query,
                     file,
                     stdin,
                     json,
@@ -2050,6 +2058,7 @@ fn main() -> Result<()> {
                         // print gold file comparison to stderr.
                         let result = commands::locate::capture(
                             &problem_text,
+                            query.clone(),
                             true, // always explain in diagnose mode
                             max_files_val,
                             max_files_explicit,
@@ -2169,6 +2178,7 @@ fn main() -> Result<()> {
                     } else {
                         commands::locate::run(
                             &problem_text,
+                            query,
                             json,
                             explain,
                             max_files_val,

--- a/crates/kin-daemon/src/api.rs
+++ b/crates/kin-daemon/src/api.rs
@@ -12779,6 +12779,7 @@ mod tests {
                     .body(Body::from(
                         serde_json::to_string(&kin_cli::daemon_client::LocateRequest {
                             text: "parse config".to_string(),
+                            queries: Vec::new(),
                             explain: false,
                             max_files: 10,
                             max_files_explicit: true,
@@ -12968,6 +12969,7 @@ mod tests {
                     .body(Body::from(
                         serde_json::to_string(&kin_cli::daemon_client::LocateRequest {
                             text: "parse config".to_string(),
+                            queries: Vec::new(),
                             explain: false,
                             max_files: 10,
                             max_files_explicit: true,

--- a/crates/kin-daemon/src/api.rs
+++ b/crates/kin-daemon/src/api.rs
@@ -3081,6 +3081,12 @@ async fn locate(
         state.graph.compute_root_hash()
     );
 
+    // Multi-query fan-out: primary text plus any additional variants, deduped.
+    // Two-or-more distinct variants trigger RRF fusion; otherwise the single
+    // path runs exactly as before (byte-identical).
+    let variants = build_locate_variants(&req.text, &req.queries);
+    let multi_query = variants.len() >= 2;
+
     let mut result = if let Some(reference) = req.reference.as_deref() {
         // Explicit --ref always takes precedence over session scope.
         // Locating at an unimported Git ref lazily imports its full ancestry;
@@ -3106,41 +3112,75 @@ async fn locate(
             state.mark_clean();
         }
         let head = resolved.head;
-        kin_cli::commands::locate::run_with_graph_capture_at_ref(
-            &state.layout,
-            state.graph.as_ref(),
-            state.blobs.as_ref(),
-            &head,
-            reference,
-            &req.text,
-            req.explain,
-            req.max_files,
-            req.max_files_explicit,
-            snippet_opts,
-        )
-        .map_err(|error| error.to_string())
+        if multi_query {
+            run_multiquery_locate_at_ref(
+                &state,
+                &head,
+                reference,
+                &variants,
+                req.explain,
+                req.max_files,
+                req.max_files_explicit,
+                snippet_opts,
+            )
+        } else {
+            kin_cli::commands::locate::run_with_graph_capture_at_ref(
+                &state.layout,
+                state.graph.as_ref(),
+                state.blobs.as_ref(),
+                &head,
+                reference,
+                &req.text,
+                req.explain,
+                req.max_files,
+                req.max_files_explicit,
+                snippet_opts,
+            )
+            .map_err(|error| error.to_string())
+        }
     } else {
         // Use scoped graph if session has a temporal scope, otherwise HEAD.
         let graph = resolve_session_graph(&state, session_id.as_ref()).await;
-        run_fused_locate_for_state(
-            &state,
-            session_id.as_ref(),
-            graph.as_ref(),
-            &req.text,
-            req.explain,
-            req.max_files,
-            req.max_files_explicit,
-            snippet_opts,
-        )
-        .await
+        if multi_query {
+            run_multiquery_fused_locate(
+                &state,
+                session_id.as_ref(),
+                graph.as_ref(),
+                &variants,
+                req.explain,
+                req.max_files,
+                req.max_files_explicit,
+                snippet_opts,
+            )
+            .await
+        } else {
+            run_fused_locate_for_state(
+                &state,
+                session_id.as_ref(),
+                graph.as_ref(),
+                &req.text,
+                req.explain,
+                req.max_files,
+                req.max_files_explicit,
+                snippet_opts,
+            )
+            .await
+        }
     }
     .map_err(internal_error)?;
 
     // Cache the full entity ranking and window page 0 so a follow-up `--next`
     // pages it from cache without re-running retrieval. Keyed by
-    // (query, ref/scope, graph-version) so any edit invalidates the page.
+    // (query, ref/scope, graph-version) so any edit invalidates the page. A
+    // multi-query ranking keys off the joined variants so it cannot collide with
+    // any single-variant cursor.
+    let key_text = if multi_query {
+        multiquery_cursor_text(&variants)
+    } else {
+        req.text.clone()
+    };
     let key = kin_cli::commands::locate::locate_cursor_key(
-        &req.text,
+        &key_text,
         scope_token.as_deref(),
         graph_version,
     );
@@ -3212,6 +3252,126 @@ async fn run_fused_locate_for_state(
         snippet_opts,
     )
     .map_err(|error| error.to_string())
+}
+
+/// Build the ordered, deduped query-variant list for a multi-query locate: the
+/// primary query first (when non-empty), then each extra variant, trimmed and
+/// de-duplicated exactly so the same phrasing is never retrieved twice. A result
+/// with fewer than two entries means a single-query locate (no fan-out).
+fn build_locate_variants(primary: &str, extra: &[String]) -> Vec<String> {
+    let mut variants: Vec<String> = Vec::new();
+    let mut seen: HashSet<String> = HashSet::new();
+    for candidate in std::iter::once(primary).chain(extra.iter().map(String::as_str)) {
+        let trimmed = candidate.trim();
+        if trimmed.is_empty() {
+            continue;
+        }
+        if seen.insert(trimmed.to_string()) {
+            variants.push(trimmed.to_string());
+        }
+    }
+    variants
+}
+
+/// Canonical cursor-key text for a multi-query ranking: the variants joined by a
+/// unit-separator control char so a fused ranking can never collide with any
+/// single-variant ranking's cursor key.
+fn multiquery_cursor_text(variants: &[String]) -> String {
+    variants.join("\u{1f}")
+}
+
+/// Read a JSON string-array MCP argument into an owned `Vec<String>`, dropping
+/// non-string and blank entries. Absent or non-array → empty (single-query).
+fn arg_string_array(arguments: &HashMap<String, serde_json::Value>, key: &str) -> Vec<String> {
+    arguments
+        .get(key)
+        .and_then(serde_json::Value::as_array)
+        .map(|items| {
+            items
+                .iter()
+                .filter_map(serde_json::Value::as_str)
+                .map(str::to_string)
+                .collect()
+        })
+        .unwrap_or_default()
+}
+
+/// Fan out a multi-query locate over daemon state: retrieve each variant through
+/// the same fused pipeline `run_fused_locate_for_state` serves, then RRF-fuse the
+/// per-variant rankings into one deduped result with per-hit variant attribution.
+/// Variants are retrieved in order so the fusion is fully deterministic.
+#[allow(clippy::too_many_arguments)]
+async fn run_multiquery_fused_locate(
+    state: &Arc<DaemonState>,
+    session_id: Option<&SessionId>,
+    graph: &kin_db::InMemoryGraph,
+    variants: &[String],
+    explain: bool,
+    max_files: usize,
+    max_files_explicit: bool,
+    snippet_opts: kin_cli::commands::locate::SnippetOptions,
+) -> Result<kin_cli::commands::locate::LocateResult, String> {
+    let mut per_variant = Vec::with_capacity(variants.len());
+    for variant in variants {
+        per_variant.push(
+            run_fused_locate_for_state(
+                state,
+                session_id,
+                graph,
+                variant,
+                explain,
+                max_files,
+                max_files_explicit,
+                snippet_opts,
+            )
+            .await?,
+        );
+    }
+    Ok(kin_cli::commands::locate::fuse_locate_results(
+        variants.to_vec(),
+        per_variant,
+        kin_cli::commands::locate::locate_rrf_k(),
+    ))
+}
+
+/// Fan out a multi-query locate at an explicit ref: retrieve each variant against
+/// the resolved head graph, then RRF-fuse. Mirrors `run_multiquery_fused_locate`
+/// for the `--ref` path so multi-query is honored there too rather than silently
+/// dropping the extra variants.
+#[allow(clippy::too_many_arguments)]
+fn run_multiquery_locate_at_ref(
+    state: &Arc<DaemonState>,
+    head: &kin_model::SemanticChangeId,
+    reference: &str,
+    variants: &[String],
+    explain: bool,
+    max_files: usize,
+    max_files_explicit: bool,
+    snippet_opts: kin_cli::commands::locate::SnippetOptions,
+) -> Result<kin_cli::commands::locate::LocateResult, String> {
+    let mut per_variant = Vec::with_capacity(variants.len());
+    for variant in variants {
+        per_variant.push(
+            kin_cli::commands::locate::run_with_graph_capture_at_ref(
+                &state.layout,
+                state.graph.as_ref(),
+                state.blobs.as_ref(),
+                head,
+                reference,
+                variant,
+                explain,
+                max_files,
+                max_files_explicit,
+                snippet_opts,
+            )
+            .map_err(|error| error.to_string())?,
+        );
+    }
+    Ok(kin_cli::commands::locate::fuse_locate_results(
+        variants.to_vec(),
+        per_variant,
+        kin_cli::commands::locate::locate_rrf_k(),
+    ))
 }
 
 /// Insert a full locate ranking into the paging cache, evicting the oldest entry
@@ -4270,6 +4430,11 @@ fn fused_match_evidence(
     if let Some(cosine) = entity.provenance.cosine {
         evidence["seed_cosine"] = json!(cosine);
     }
+    // Under multi-query fusion, report which query variants surfaced this hit.
+    // Absent for a single-query locate, so the evidence object is unchanged.
+    if !entity.matched_queries.is_empty() {
+        evidence["matched_variants"] = json!(entity.matched_queries);
+    }
     evidence
 }
 
@@ -4812,22 +4977,42 @@ async fn build_fused_semantic_locate_result(
         kin_cli::commands::locate::SnippetOptions::default()
     };
 
+    // Multi-query fan-out: `query` plus any additional `queries` variants,
+    // deduped. Two-or-more distinct variants trigger RRF fusion; otherwise the
+    // single fused path runs exactly as before.
+    let variants = build_locate_variants(&query, &arg_string_array(arguments, "queries"));
+    let multi_query = variants.len() >= 2;
+
     // The agent asked for `limit` ranked hits; give the fused pipeline the
     // same number of file slots EXPLICITLY so the adaptive cap cannot shrink
     // the pool below what the caller asked to see (the graph-native entity
     // ranking is projected from the file ranking).
-    let mut locate_result = match run_fused_locate_for_state(
-        state,
-        session_id,
-        graph,
-        &query,
-        explain,
-        limit,
-        true,
-        snippet_opts,
-    )
-    .await
-    {
+    let run_result = if multi_query {
+        run_multiquery_fused_locate(
+            state,
+            session_id,
+            graph,
+            &variants,
+            explain,
+            limit,
+            true,
+            snippet_opts,
+        )
+        .await
+    } else {
+        run_fused_locate_for_state(
+            state,
+            session_id,
+            graph,
+            &query,
+            explain,
+            limit,
+            true,
+            snippet_opts,
+        )
+        .await
+    };
+    let mut locate_result = match run_result {
         Ok(result) => result,
         Err(error) => {
             return kin_mcp::ToolCallResult::error(format!("fused locate failed: {error}"));
@@ -4836,9 +5021,19 @@ async fn build_fused_semantic_locate_result(
 
     // Cache the full entity ranking and window page 0 so a follow-up cursor
     // pages it from cache without re-running retrieval — the same paging the
-    // `POST /locate` endpoint and the cosine arm provide (arm-symmetric).
-    let key =
-        kin_cli::commands::locate::locate_cursor_key(&query, scope_token.as_deref(), graph_version);
+    // `POST /locate` endpoint and the cosine arm provide (arm-symmetric). A
+    // multi-query ranking keys off the joined variants so it cannot collide with
+    // any single-variant cursor.
+    let key_text = if multi_query {
+        multiquery_cursor_text(&variants)
+    } else {
+        query.clone()
+    };
+    let key = kin_cli::commands::locate::locate_cursor_key(
+        &key_text,
+        scope_token.as_deref(),
+        graph_version,
+    );
     cache_locate_ranking(state, &key, &locate_result.entities, graph_version);
     kin_cli::commands::locate::apply_entity_page(&mut locate_result, &key, 0, page_size);
 
@@ -5113,16 +5308,33 @@ async fn mcp_tools_call(
             .arguments
             .get("pipeline")
             .and_then(serde_json::Value::as_str);
+        // Multi-query fan-out (`queries`) is inherently a multi-signal fusion, so
+        // it is served by the fused arm regardless of the default profile — the
+        // legacy single-vector cosine arm does not fuse variant rankings. An
+        // explicit `pipeline: "cosine"` alongside `queries` is a genuine conflict
+        // and is rejected rather than silently dropping the extra variants.
+        let has_extra_queries = !arg_string_array(&request.arguments, "queries").is_empty();
         let use_fused = match pipeline_override {
             Some(value) if value.eq_ignore_ascii_case("fused") => true,
-            Some(value) if value.eq_ignore_ascii_case("cosine") => false,
+            Some(value) if value.eq_ignore_ascii_case("cosine") => {
+                if has_extra_queries {
+                    return Ok(Json(kin_mcp::ToolCallResult::error(
+                        "multi-query `queries` requires the fused pipeline; omit `pipeline` \
+                         or set it to \"fused\""
+                            .to_string(),
+                    )));
+                }
+                false
+            }
             Some(other) => {
                 return Ok(Json(kin_mcp::ToolCallResult::error(format!(
                     "invalid pipeline '{other}': expected \"fused\" or \"cosine\""
                 ))));
             }
             None => {
-                kin_cli::retrieval_profile::RetrievalProfile::from_env().semantic_locate_fused()
+                has_extra_queries
+                    || kin_cli::retrieval_profile::RetrievalProfile::from_env()
+                        .semantic_locate_fused()
             }
         };
         if use_fused {
@@ -8075,6 +8287,7 @@ mod tests {
                 origin: "vector".into(),
                 cosine: Some(0.42),
             },
+            matched_queries: Vec::new(),
         };
         let ev = fused_match_evidence("parse the request", &with_explain);
         assert_eq!(ev["ranker"], json!("fused-v1"));
@@ -8101,6 +8314,85 @@ mod tests {
     }
 
     #[test]
+    fn build_locate_variants_dedups_and_keeps_primary_first() {
+        // Primary first, blanks dropped, exact duplicates collapsed, order stable.
+        let variants = build_locate_variants(
+            "primary query",
+            &[
+                "  ".to_string(),
+                "variant two".to_string(),
+                "primary query".to_string(),
+                "variant three".to_string(),
+                "variant two".to_string(),
+            ],
+        );
+        assert_eq!(
+            variants,
+            vec![
+                "primary query".to_string(),
+                "variant two".to_string(),
+                "variant three".to_string(),
+            ]
+        );
+        // An empty primary with variants yields a variant-only list.
+        assert_eq!(
+            build_locate_variants("", &["only".to_string()]),
+            vec!["only".to_string()]
+        );
+        // No variants → the single primary; a single entry means no fan-out.
+        assert_eq!(build_locate_variants("solo", &[]), vec!["solo".to_string()]);
+    }
+
+    #[test]
+    fn arg_string_array_reads_only_string_items() {
+        let mut args: HashMap<String, serde_json::Value> = HashMap::new();
+        args.insert(
+            "queries".to_string(),
+            json!(["alpha", 7, "beta", null, "gamma"]),
+        );
+        assert_eq!(
+            arg_string_array(&args, "queries"),
+            vec!["alpha".to_string(), "beta".to_string(), "gamma".to_string()]
+        );
+        // Absent or non-array → empty (a single-query call).
+        assert!(arg_string_array(&args, "missing").is_empty());
+        args.insert("queries".to_string(), json!("not-an-array"));
+        assert!(arg_string_array(&args, "queries").is_empty());
+    }
+
+    #[test]
+    fn fused_match_evidence_reports_matched_variants_under_fusion() {
+        use kin_cli::commands::locate::{LocateEntity, LocateProvenance};
+        let mut entity = LocateEntity {
+            entity_id: "e1".into(),
+            kind: "function".into(),
+            name: "parse_request".into(),
+            signature: String::new(),
+            score: 0.9,
+            definition: true,
+            span: None,
+            body: None,
+            provenance: LocateProvenance {
+                file: Some("src/lib.rs".into()),
+                origin: String::new(),
+                cosine: None,
+            },
+            matched_queries: Vec::new(),
+        };
+        // No attribution → no matched_variants key (single-query byte-identical).
+        assert!(fused_match_evidence("q", &entity)
+            .get("matched_variants")
+            .is_none());
+        // With attribution → the variant texts are surfaced additively.
+        entity.matched_queries = vec!["ParseRequest".into(), "parse the request".into()];
+        let ev = fused_match_evidence("q", &entity);
+        assert_eq!(
+            ev["matched_variants"],
+            json!(["ParseRequest", "parse the request"])
+        );
+    }
+
+    #[test]
     fn fused_payload_attaches_match_evidence_additively_and_in_order() {
         use kin_cli::commands::locate::{LocateEntity, LocateProvenance, LocateResult};
         let mk = |id: &str, name: &str| LocateEntity {
@@ -8117,6 +8409,7 @@ mod tests {
                 origin: String::new(),
                 cosine: None,
             },
+            matched_queries: Vec::new(),
         };
         let result = LocateResult {
             entities: vec![mk("a", "alpha"), mk("b", "beta")],

--- a/crates/kin-mcp/src/handlers/entities.rs
+++ b/crates/kin-mcp/src/handlers/entities.rs
@@ -95,7 +95,12 @@ the fused pipeline (also selectable per call with `pipeline: \"fused\"`). Every 
 carries an additive `match_evidence` object explaining why it ranked — the ranker that \
 produced it, the score source, whether the query matched the entity name, and the \
 ranking signals that applied — derived from graph-owned retrieval data, never a \
-working-tree read. Both pipelines report semantic_coverage — the fraction of the graph \
+working-tree read. Pass an optional `queries` array of additional query variants to fan \
+out: `query` plus each variant are retrieved independently and their rankings RRF-fused \
+into one deduped result, with each hit's `match_evidence.matched_variants` naming the \
+variants that surfaced it (diverse variants — identifiers, behavior, subsystem — recover \
+more than any single phrasing); multi-query fusion always uses the fused pipeline. Both \
+pipelines report semantic_coverage — the fraction of the graph \
 that has embeddings indexed; the fused arm additionally reports a `degradations` array \
 naming any retrieval capability that could not fully run (empty vector index, reranker \
 model not cached, …), so a thin result set is attributable instead of silent. Requires \

--- a/crates/kin-mcp/src/tools.rs
+++ b/crates/kin-mcp/src/tools.rs
@@ -29,6 +29,11 @@ pub fn tool_definitions() -> ToolsListResult {
                     "type": "object",
                     "properties": {
                         "query": { "type": "string", "description": "Natural-language description of the code to find. Optional when paging with `cursor`." },
+                        "queries": {
+                            "type": "array",
+                            "items": { "type": "string" },
+                            "description": "Optional additional query variants for multi-query fan-out. When present, `query` plus each variant are retrieved independently and their rankings RRF-fused into one deduped result, with each hit's `match_evidence.matched_variants` naming the variants that surfaced it. Diverse variants (identifiers, behavior, subsystem) recover more relevant hits than any single phrasing. Requires the fused pipeline (automatic when set)."
+                        },
                         "limit": { "type": "integer", "description": "Max ranked entities per page (page size). Default 20.", "default": 20 },
                         "page_size": { "type": "integer", "description": "Entities per page; overrides `limit` for paging when set." },
                         "cursor": { "type": "string", "description": "Opaque cursor from a prior result's `next_cursor`: returns the NEXT page of ranked entities from the cached ranking with no re-search. Omit for a fresh query." },


### PR DESCRIPTION
Lands the multi-query fusion change on main. The stacked review branch merged into its base before GitHub's retarget, so this re-targets the identical, already-reviewed content: repeatable --query on the CLI and an additive queries array on semantic_locate, fanned out through the fused pipeline and merged server-side with deterministic Reciprocal Rank Fusion (stable tie-breaks, per-hit variant attribution in match_evidence, unioned degradations). Single-query behavior is byte-identical; explicit pipeline=cosine combined with queries is rejected as a conflict rather than silently dropping variants.