### PR TITLE
fix(kin-review): extend rename-neutral downgrade to the shadow downstream_risk channel

### DIFF
--- a/crates/kin-cli/tests/call_shape_rename_e2e.rs
+++ b/crates/kin-cli/tests/call_shape_rename_e2e.rs
@@ -14,14 +14,21 @@
 //! strands no caller and must not gate as a breaking change. The keyword-caller
 //! and `**kwargs` variants prove the gate still blocks a rename that a call site
 //! actually names.
+//!
+//! Both gate channels are exercised: the inline `signature_change`/`Breaking`
+//! channel (`collect_inline_comments`) AND the SHADOW `downstream_risk` channel
+//! (`derive_shadow_policy`). FIR-1440 shipped because only the inline channel had
+//! e2e coverage — the shadow gate, which is the real merge-trust verdict,
+//! re-blocked the positional-safe rename with no test to catch it.
 
 use kin_db::{EntityStore, InMemoryGraph};
 use kin_index::{link_cross_file, FileParseData};
+use kin_model::review::{RiskLevel, RiskSummary};
 use kin_model::{Entity, FilePathId, GraphNodeId, RelationKind};
 use kin_parser::{LanguageAdapter, PythonAdapter};
 use kin_review::{
-    analyze_impact, collect_inline_comments, EntityChange, EntityChangeKind, InlineCommentKind,
-    SemanticDiff,
+    analyze_impact, collect_inline_comments, derive_shadow_policy, EntityChange, EntityChangeKind,
+    InlineCommentKind, Review, SemanticDiff, ShadowGateVerdict,
 };
 
 fn parse_python(file_path: &str, source: &str) -> FileParseData {
@@ -52,16 +59,10 @@ fn find_entity(files: &[FileParseData], name: &str) -> Entity {
         .clone()
 }
 
-/// Parse `source`, link it into a fresh graph (persisting each call site's
-/// argument shape onto its `Calls` edge), then run the review gate over a
-/// rename of `target` from `old_sig` to `new_sig`. Returns the emitted comment
-/// kinds and the linked relations (so the caller can also assert on the
-/// persisted shape directly).
-fn link_and_review(
-    source: &str,
-    old_sig: &str,
-    new_sig: &str,
-) -> (Vec<InlineCommentKind>, Vec<kin_model::Relation>) {
+/// Parse `source` and link it into a fresh persisted graph, exactly as ingest
+/// does — each `Calls` edge carries its call-site argument shape. Returns the
+/// parsed files (for entity lookup), the linked relations, and the graph store.
+fn link_into_graph(source: &str) -> (Vec<FileParseData>, Vec<kin_model::Relation>, InMemoryGraph) {
     let files = vec![parse_python("mod.py", source)];
 
     // Real linker: resolves calls and persists each Calls edge's argument shape.
@@ -77,27 +78,69 @@ fn link_and_review(
     for rel in &relations {
         graph.upsert_relation(rel).expect("upsert relation");
     }
+    (files, relations, graph)
+}
 
-    // The rename diff: same entity id, signature old -> new.
-    let target = find_entity(&files, "target");
+/// The rename diff for `target`: same entity id, signature `old_sig` -> `new_sig`.
+fn rename_diff(files: &[FileParseData], old_sig: &str, new_sig: &str) -> SemanticDiff {
+    let target = find_entity(files, "target");
     let mut old = target.clone();
     old.signature = old_sig.to_string();
     let mut new = target.clone();
     new.signature = new_sig.to_string();
-    let diff = SemanticDiff {
+    SemanticDiff {
         entity_changes: vec![EntityChange {
             entity_id: new.id,
             kind: EntityChangeKind::Modified { old, new },
         }],
         ..Default::default()
-    };
+    }
+}
 
+/// Parse, link, persist, and run the INLINE review gate over a rename of
+/// `target` from `old_sig` to `new_sig`. Returns the emitted comment kinds and
+/// the linked relations (so the caller can also assert on the persisted shape).
+fn link_and_review(
+    source: &str,
+    old_sig: &str,
+    new_sig: &str,
+) -> (Vec<InlineCommentKind>, Vec<kin_model::Relation>) {
+    let (files, relations, graph) = link_into_graph(source);
+    let diff = rename_diff(&files, old_sig, new_sig);
     let report = analyze_impact(&graph, &diff).expect("analyze impact");
     let kinds = collect_inline_comments(&diff, &report)
         .into_iter()
         .map(|c| c.kind)
         .collect();
     (kinds, relations)
+}
+
+/// Drive the SHADOW gate (the `downstream_risk` channel) over the same real
+/// mini-graph. This is the merge-trust verdict the shipped FIR-1440 bug slipped
+/// through: the inline-only assertions above never exercised it. Builds a
+/// `Review` from the real diff + impact + inline comments — reproducing the
+/// exact production seam — and returns the gate verdict.
+fn link_and_shadow_verdict(source: &str, old_sig: &str, new_sig: &str) -> ShadowGateVerdict {
+    let (files, _relations, graph) = link_into_graph(source);
+    let diff = rename_diff(&files, old_sig, new_sig);
+    let report = analyze_impact(&graph, &diff).expect("analyze impact");
+    let inline_comments = collect_inline_comments(&diff, &report);
+    let review = Review {
+        base: None,
+        head: None,
+        diff,
+        impact: report,
+        risk: RiskSummary {
+            overall_risk: RiskLevel::Low,
+            breaking_changes: vec![],
+            test_coverage_gaps: vec![],
+            contract_violations: vec![],
+            work_risks: vec![],
+            notes: vec![],
+        },
+        inline_comments,
+    };
+    derive_shadow_policy(&review, &[], &[]).verdict
 }
 
 const POSITIONAL_CALLERS: &str = "\
@@ -226,4 +269,69 @@ fn e2e_review_output_is_deterministic() {
         .0
     };
     assert_eq!(run(), run(), "review output must be stable across runs");
+}
+
+#[test]
+fn e2e_shadow_gate_positional_rename_needs_attention_not_would_block() {
+    // FIR-1440, the shipped blind spot: the inline assertions above pass for this
+    // rename, but the real merge-trust verdict is the SHADOW gate. Pre-fix the
+    // shadow `downstream_risk` channel re-blocked the positional-safe rename
+    // (WouldBlock); post-fix it demotes to attention, matching the inline channel.
+    let verdict = link_and_shadow_verdict(
+        POSITIONAL_CALLERS,
+        "def target(ext, args)",
+        "def target(ext, lines)",
+    );
+    assert_eq!(
+        verdict,
+        ShadowGateVerdict::NeedsAttention,
+        "positional-safe rename must not block the shadow gate"
+    );
+    assert_ne!(verdict, ShadowGateVerdict::WouldBlock);
+}
+
+#[test]
+fn e2e_shadow_gate_keyword_caller_rename_would_block() {
+    // A caller names the renamed parameter -> the rename strands it -> the shadow
+    // gate must still block (no over-suppression from the FIR-1440 fix).
+    let verdict = link_and_shadow_verdict(
+        KEYWORD_CALLER,
+        "def target(ext, args)",
+        "def target(ext, lines)",
+    );
+    assert_eq!(
+        verdict,
+        ShadowGateVerdict::WouldBlock,
+        "keyword caller of the renamed param keeps the shadow gate blocking"
+    );
+}
+
+#[test]
+fn e2e_shadow_gate_var_keyword_caller_rename_would_block() {
+    // A `**kwargs` caller could forward the renamed key -> unknown -> the shadow
+    // gate must still block.
+    let verdict = link_and_shadow_verdict(
+        VAR_KEYWORD_CALLER,
+        "def target(ext, args)",
+        "def target(ext, lines)",
+    );
+    assert_eq!(
+        verdict,
+        ShadowGateVerdict::WouldBlock,
+        "**kwargs caller keeps the shadow gate blocking"
+    );
+}
+
+#[test]
+fn e2e_shadow_gate_verdict_is_deterministic() {
+    // The demoted shadow verdict reads only counts and sorted call_shapes, so the
+    // same input yields the same verdict across runs (citable-gate determinism).
+    let run = || {
+        link_and_shadow_verdict(
+            POSITIONAL_CALLERS,
+            "def target(ext, args)",
+            "def target(ext, lines)",
+        )
+    };
+    assert_eq!(run(), run(), "shadow verdict must be stable across runs");
 }

--- a/crates/kin-review/src/lib.rs
+++ b/crates/kin-review/src/lib.rs
@@ -42,6 +42,7 @@ pub use review::{Review, SemanticReview};
 pub use risk::assess_risk;
 pub use shadow::{
     build_shadow_report, build_shadow_report_at, build_shadow_report_base_off_ancestry,
-    format_shadow_report, ShadowGateReport, ShadowGateVerdict, ShadowRequest,
+    derive_shadow_policy, format_shadow_report, ShadowChangedEntity, ShadowEvidenceGap,
+    ShadowGateReport, ShadowGateVerdict, ShadowPolicyFinding, ShadowPolicyResult, ShadowRequest,
     SHADOW_ENFORCEMENT_REPORT_ONLY, SHADOW_GATE_REPORT_SCHEMA_VERSION,
 };

--- a/crates/kin-review/src/shadow.rs
+++ b/crates/kin-review/src/shadow.rs
@@ -826,6 +826,22 @@ fn artifact_subject_is_source_class(subject: &str) -> bool {
     )
 }
 
+/// Derive the shadow gate policy from an already-assembled [`Review`].
+///
+/// The production path materializes ref-state to build the `Review`,
+/// `evidence_gaps`, and `changed_entities` before running the internal policy
+/// step. Callers and tests that already hold a `Review` (diff + impact + inline
+/// comments) — a review-only re-evaluation over an existing prepared graph, or
+/// an end-to-end gate assertion — derive the same verdict here without
+/// re-materializing ref-state. Mirrors the crate-public [`crate::derive_decision`].
+pub fn derive_shadow_policy(
+    review: &Review,
+    evidence_gaps: &[ShadowEvidenceGap],
+    changed_entities: &[ShadowChangedEntity],
+) -> ShadowPolicyResult {
+    derive_policy(review, evidence_gaps, changed_entities)
+}
+
 fn derive_policy(
     review: &Review,
     evidence_gaps: &[ShadowEvidenceGap],
@@ -889,36 +905,64 @@ fn derive_policy(
         let mut surface_candidates: Vec<_> = review.diff.entity_changes.iter().collect();
         surface_candidates.sort_by_key(|change| change.entity_id);
         for change in surface_candidates {
-            let (name, location, surface_changed, demote_removal) = match &change.kind {
-                EntityChangeKind::Modified { old, new } => (
-                    new.name.clone(),
-                    new.span
-                        .as_ref()
-                        .map(|span| (span.file.to_string(), span.start_line)),
-                    (old.signature != new.signature
-                        && !crate::inline::signature_runtime_neutral(
+            let (name, location, surface_changed, demote_removal, rename_neutral) =
+                match &change.kind {
+                    EntityChangeKind::Modified { old, new } => {
+                        // An arity-preserving parameter rename whose graph-known
+                        // call sites all pass positionally strands no consumer.
+                        // Mirror the inline signature-change channel (inline.rs)
+                        // so this shadow downstream_risk channel demotes the same
+                        // runtime-neutral rename instead of re-blocking it. Reuse
+                        // the shipped classifiers (single source of truth); they
+                        // are Python-only, so a non-Python rename yields `None`
+                        // here and stays blocking.
+                        let rename_neutral = match crate::inline::arity_preserving_rename(
                             &old.signature,
                             &new.signature,
-                        ))
-                        || old.visibility != new.visibility,
-                    false,
-                ),
-                EntityChangeKind::Removed(id) => {
-                    let id_string = id.to_string();
-                    let unresolvable = unresolvable_removed.contains(id_string.as_str());
-                    let name = resolved_names
-                        .get(id_string.as_str())
-                        .map(|name| name.to_string())
-                        .unwrap_or(id_string);
-                    // Same-diff remove + re-add of the same entity name is a
-                    // move; the surviving entity carries any surface risk.
-                    if added_names.contains(name.as_str()) {
-                        continue;
+                        ) {
+                            Some(renamed) => {
+                                let summary = review
+                                    .impact
+                                    .entity_impact(&change.entity_id)
+                                    .map(|entry| entry.call_shapes.clone())
+                                    .unwrap_or_default();
+                                crate::inline::rename_is_runtime_neutral_for_consumers(
+                                    &renamed, &summary,
+                                )
+                            }
+                            None => false,
+                        };
+                        (
+                            new.name.clone(),
+                            new.span
+                                .as_ref()
+                                .map(|span| (span.file.to_string(), span.start_line)),
+                            (old.signature != new.signature
+                                && !crate::inline::signature_runtime_neutral(
+                                    &old.signature,
+                                    &new.signature,
+                                ))
+                                || old.visibility != new.visibility,
+                            false,
+                            rename_neutral,
+                        )
                     }
-                    (name, None, true, unresolvable)
-                }
-                EntityChangeKind::Added(_) => continue,
-            };
+                    EntityChangeKind::Removed(id) => {
+                        let id_string = id.to_string();
+                        let unresolvable = unresolvable_removed.contains(id_string.as_str());
+                        let name = resolved_names
+                            .get(id_string.as_str())
+                            .map(|name| name.to_string())
+                            .unwrap_or(id_string);
+                        // Same-diff remove + re-add of the same entity name is a
+                        // move; the surviving entity carries any surface risk.
+                        if added_names.contains(name.as_str()) {
+                            continue;
+                        }
+                        (name, None, true, unresolvable, false)
+                    }
+                    EntityChangeKind::Added(_) => continue,
+                };
             if !surface_changed {
                 continue;
             }
@@ -946,17 +990,29 @@ fn derive_policy(
             if already_blocking {
                 continue;
             }
-            // An unresolvable removal reports its downstream risk as attention,
-            // not a would_block: naming the severed surface as a raw UUID is
-            // not enough proof to certify a blocking breakage.
+            // Demote (do not suppress) this downstream risk to attention when we
+            // cannot certify a block: an unresolvable removal (severed surface
+            // named only as a raw UUID) or an arity-preserving rename proven
+            // runtime-neutral by its call sites. The contract surface genuinely
+            // changed, so the finding stays visible evidence; it just no longer
+            // gates. A rename carries the positional-safety proof in its message
+            // for parity with the inline signature-change channel.
+            let demote = demote_removal || rename_neutral;
             findings.push(ShadowPolicyFinding {
                 kind: "downstream_risk".to_string(),
-                severity: if demote_removal { "warning" } else { "error" }.to_string(),
-                blocking: !demote_removal,
-                message: format!(
-                    "Contract surface of `{}` changed with {} graph-known downstream entity(ies)",
-                    name, entity_consumers
-                ),
+                severity: if demote { "warning" } else { "error" }.to_string(),
+                blocking: !demote,
+                message: if rename_neutral {
+                    format!(
+                        "Contract surface of `{}` changed with {} graph-known downstream entity(ies); all {} graph-known call site(s) pass positionally — no runtime break",
+                        name, entity_consumers, entity_consumers
+                    )
+                } else {
+                    format!(
+                        "Contract surface of `{}` changed with {} graph-known downstream entity(ies)",
+                        name, entity_consumers
+                    )
+                },
                 file: location.as_ref().map(|(file, _)| file.clone()),
                 line: location.as_ref().map(|(_, line)| *line),
             });
@@ -3222,6 +3278,214 @@ mod tests {
             .expect("resolvable removal with a consumer carries a downstream risk");
         assert!(finding.blocking);
         assert_eq!(policy.verdict, ShadowGateVerdict::WouldBlock);
+    }
+
+    /// Build a Review for an arity-preserving positional rename
+    /// (`def makefile_target(ext, args)` → `def makefile_target(ext, lines)`)
+    /// with 3 graph-known consumers whose call shapes are `call_shapes`. Exercises
+    /// the shadow `downstream_risk` channel in isolation (no inline comments).
+    fn positional_rename_review(call_shapes: crate::impact::ConsumerCallShapeSummary) -> Review {
+        use crate::diff::{EntityChange, EntityChangeKind, SemanticDiff};
+        use crate::impact::{EntityImpact, ImpactReport};
+        use kin_model::review::{RiskLevel, RiskSummary};
+
+        let mut old = entity_with_span(
+            "makefile_target",
+            "src/pytester.py",
+            610,
+            EntityRole::Source,
+        );
+        old.signature = "def makefile_target(ext, args)".to_string();
+        let mut new = old.clone();
+        new.signature = "def makefile_target(ext, lines)".to_string();
+
+        Review {
+            base: None,
+            head: None,
+            diff: SemanticDiff {
+                base: None,
+                head: None,
+                entity_changes: vec![EntityChange {
+                    entity_id: new.id,
+                    kind: EntityChangeKind::Modified {
+                        old,
+                        new: new.clone(),
+                    },
+                }],
+                relation_changes: vec![],
+            },
+            impact: ImpactReport {
+                entity_impacts: vec![EntityImpact {
+                    entity_id: new.id,
+                    consumer_count: 3,
+                    strong_consumer_count: 3,
+                    contract_consumer_count: 0,
+                    consumer_files: vec![
+                        "src/pytester.py".to_string(),
+                        "src/pytester.py".to_string(),
+                        "src/pytester.py".to_string(),
+                    ],
+                    covering_tests: 0,
+                    consumers_migrated_in_diff: 0,
+                    call_shapes,
+                }],
+                ..Default::default()
+            },
+            risk: RiskSummary {
+                overall_risk: RiskLevel::Low,
+                breaking_changes: vec![],
+                test_coverage_gaps: vec![],
+                contract_violations: vec![],
+                work_risks: vec![],
+                notes: vec![],
+            },
+            inline_comments: vec![],
+        }
+    }
+
+    #[test]
+    fn shadow_downstream_risk_demotes_runtime_neutral_positional_rename() {
+        // FIR-1440: the shadow `downstream_risk` channel is a SEPARATE gate from
+        // the inline signature-change channel. An arity-preserving rename whose
+        // graph-known call sites all pass positionally is runtime-neutral, yet
+        // pre-fix this channel still emitted a BLOCKING downstream_risk (verdict
+        // WouldBlock) because it consulted only `signature_runtime_neutral`, not
+        // the rename classifiers. Post-fix it demotes to a non-blocking warning
+        // (verdict NeedsAttention), matching the inline channel.
+        let call_shapes = crate::impact::ConsumerCallShapeSummary {
+            caller_keyword_names: std::collections::BTreeSet::new(),
+            any_var_keyword_caller: false,
+            all_consumers_shaped_calls: true,
+        };
+        let review = positional_rename_review(call_shapes);
+        let policy = derive_policy(&review, &[], &[]);
+        let finding = policy
+            .findings
+            .iter()
+            .find(|f| f.kind == "downstream_risk")
+            .expect("a renamed contract surface with 3 consumers carries a downstream risk");
+        // GREEN (post-fix): demoted to attention. Pre-fix this was blocking/error
+        // with a WouldBlock verdict — the shipped FIR-1440 bug.
+        assert!(
+            !finding.blocking,
+            "a positional-safe rename must not block the shadow gate"
+        );
+        assert_eq!(finding.severity, "warning");
+        assert!(
+            finding
+                .message
+                .contains("pass positionally — no runtime break"),
+            "the demoted message carries the positional-safety proof for parity with \
+             the inline channel; got: {}",
+            finding.message
+        );
+        assert!(
+            finding
+                .message
+                .contains("3 graph-known downstream entity(ies)"),
+            "message names the consumer count; got: {}",
+            finding.message
+        );
+        assert_eq!(policy.verdict, ShadowGateVerdict::NeedsAttention);
+        assert_ne!(policy.verdict, ShadowGateVerdict::WouldBlock);
+    }
+
+    /// Negative-control helper: a rename we cannot prove runtime-neutral must keep
+    /// blocking the shadow gate — guards against over-suppression.
+    fn assert_positional_rename_stays_blocking(
+        call_shapes: crate::impact::ConsumerCallShapeSummary,
+        case: &str,
+    ) {
+        let review = positional_rename_review(call_shapes);
+        let policy = derive_policy(&review, &[], &[]);
+        let finding = policy
+            .findings
+            .iter()
+            .find(|f| f.kind == "downstream_risk")
+            .unwrap_or_else(|| panic!("{case}: expected a downstream_risk finding"));
+        assert!(
+            finding.blocking,
+            "{case}: an unprovable rename must stay blocking (no over-suppression)"
+        );
+        assert_eq!(finding.severity, "error", "{case}: stays error severity");
+        assert!(
+            !finding.message.contains("no runtime break"),
+            "{case}: must not carry the positional-safe proof"
+        );
+        assert_eq!(
+            policy.verdict,
+            ShadowGateVerdict::WouldBlock,
+            "{case}: a rename that is not provably neutral still blocks"
+        );
+    }
+
+    #[test]
+    fn shadow_downstream_risk_blocks_keyword_caller_rename() {
+        // A consumer passes the RENAMED parameter (`args`) by keyword, so the
+        // rename strands it. Stays blocking.
+        let mut kw = std::collections::BTreeSet::new();
+        kw.insert("args".to_string());
+        assert_positional_rename_stays_blocking(
+            crate::impact::ConsumerCallShapeSummary {
+                caller_keyword_names: kw,
+                any_var_keyword_caller: false,
+                all_consumers_shaped_calls: true,
+            },
+            "keyword-caller",
+        );
+    }
+
+    #[test]
+    fn shadow_downstream_risk_blocks_var_keyword_caller_rename() {
+        // A consumer forwards `**kwargs`; its keyword set is unknown and could
+        // carry the renamed name. Stays blocking.
+        assert_positional_rename_stays_blocking(
+            crate::impact::ConsumerCallShapeSummary {
+                caller_keyword_names: std::collections::BTreeSet::new(),
+                any_var_keyword_caller: true,
+                all_consumers_shaped_calls: true,
+            },
+            "var-keyword-caller",
+        );
+    }
+
+    #[test]
+    fn shadow_downstream_risk_blocks_unshaped_consumer_rename() {
+        // A counted consumer carries no call-shape evidence (non-call edge or an
+        // uncaptured shape), so the rename cannot be proven safe. Stays blocking.
+        assert_positional_rename_stays_blocking(
+            crate::impact::ConsumerCallShapeSummary {
+                caller_keyword_names: std::collections::BTreeSet::new(),
+                any_var_keyword_caller: false,
+                all_consumers_shaped_calls: false,
+            },
+            "unshaped-consumer",
+        );
+    }
+
+    #[test]
+    fn shadow_demoted_rename_message_is_deterministic() {
+        // The demoted message reads only a count and sorted BTreeSet call_shapes,
+        // so repeated evaluation must be byte-identical (citable-gate determinism).
+        let call_shapes = crate::impact::ConsumerCallShapeSummary {
+            caller_keyword_names: std::collections::BTreeSet::new(),
+            any_var_keyword_caller: false,
+            all_consumers_shaped_calls: true,
+        };
+        let message_of = || {
+            let review = positional_rename_review(call_shapes.clone());
+            derive_policy(&review, &[], &[])
+                .findings
+                .into_iter()
+                .find(|f| f.kind == "downstream_risk")
+                .expect("downstream_risk present")
+                .message
+        };
+        assert_eq!(
+            message_of(),
+            message_of(),
+            "the demoted rename message must be byte-identical across runs"
+        );
     }
 
     #[test]


### PR DESCRIPTION
## What

A benign, arity-preserving parameter rename whose graph-known call sites all pass positionally is runtime-neutral and must not gate as a breaking change. The inline review channel already handles this, but the **shadow gate re-blocked it**. This extends the same rename-neutral downgrade to the shadow `downstream_risk` channel.

## Mechanism (why the earlier inline-channel fix was insufficient)

The review gate has **two parallel channels**, and the prior rename-neutral fix only patched one:

- **Inline channel** (`inline.rs`, `collect_inline_comments`) — already downgrades a positional-safe rename: emits a non-blocking `SignatureChange` and suppresses the `Breaking` finding.
- **Shadow `downstream_risk` channel** (`shadow.rs::derive_policy`, the contract-surface loop) — a *separate* pass over `review.diff.entity_changes` that was never extended. It re-blocked the rename for two compounding reasons:
  1. Its `surface_changed` predicate consulted only `signature_runtime_neutral` (annotation/qualifier-only edits) — it never called `arity_preserving_rename` / `rename_is_runtime_neutral_for_consumers`, so a parameter rename always read as a gating surface change.
  2. Removing the inline `Breaking` finding also removed the finding that used to **dedup-absorb** this `downstream_risk` at the same anchor (`already_blocking`). The prior fix's own change unmasked this channel.

Net effect: the inline channel said "no runtime break" while the shadow channel emitted a blocking `error` → `WouldBlock`.

**Coverage blind spot that shipped it:** `crates/kin-cli/tests/call_shape_rename_e2e.rs` asserted **only** on `collect_inline_comments` output — it never drove `derive_policy` / the shadow gate, which is the real merge-trust verdict. The fix was proven at the inline surface with the gating path untested.

## Fix (demote, don't suppress)

In the `Modified { old, new }` arm of the contract-surface loop, compute `rename_neutral` by **reusing the shipped `pub` classifiers** (single source of truth — no reimplementation): `arity_preserving_rename` ∧ `rename_is_runtime_neutral_for_consumers` over this entity's `call_shapes` (already reachable via `entity_impact`). At emission, when `rename_neutral`, the `downstream_risk` finding is demoted to a non-blocking `warning` with a message enriched for parity with the inline channel (`… ; all N graph-known call site(s) pass positionally — no runtime break`).

- **Demote, not suppress:** the finding stays as visible evidence (the contract surface genuinely changed; kin merely proved the known callers survive), so dedup semantics for other anchors are unchanged.
- **Blast radius:** ~15 impl lines. Does **not** touch `surface_changed`, `has_surface_change`, or coverage-gap gating.
- **Python-only:** `arity_preserving_rename` parses Python signatures; a non-Python rename yields `None` → stays blocking. No cross-language behavior change.

A small `pub fn derive_shadow_policy` wrapper (mirroring the crate-public `derive_decision`) exposes the gate-policy step so the e2e can drive the shadow verdict from an assembled `Review`.

## Test coverage

**Shadow unit tests (`shadow.rs`):**
- RED/GREEN primary: a positional-safe rename (3 shaped positional consumers) demotes to a non-blocking `warning` → `NeedsAttention`. Verified RED by toggling the fix off (pre-fix: blocking `error` → `WouldBlock`).
- **Three negative controls** (guard against over-suppression) — each stays blocking → `WouldBlock`:
  - keyword-caller passing the renamed param by keyword (`caller_keyword_names ⊇ {"args"}`)
  - `**kwargs` caller (`any_var_keyword_caller`)
  - unshaped consumer (`all_consumers_shaped_calls = false`)
- Determinism: the demoted message is byte-identical across repeated evaluation.

**E2E (`call_shape_rename_e2e.rs`) — closes the blind spot:** the real parse → link → persist → impact → **shadow gate** chain now asserts the verdict flips `WouldBlock → NeedsAttention` for the positional rename and stays `WouldBlock` for the keyword / `**kwargs` variants, plus a shadow-verdict determinism check. Verified RED at the e2e level too (pre-fix: `WouldBlock`) — this is the test that would have caught the shipped gap.

## Verification

- `cargo fmt -- --check`: clean
- `cargo clippy --all-targets --all-features` (CI allowlist, `RUSTFLAGS=-D warnings`): clean
- `cargo build --all-targets`: clean
- `cargo test -p kin-review`: 201 passed
- `cargo test -p kin-cli --test call_shape_rename_e2e`: 9 passed
- Zero File-Search Invariant: holds

## Not claiming

No citable benchmark row-flip is asserted here — this is the review-logic fix plus coverage. The citable re-review over the pinned substrate rides the shared full re-run slot, not this PR.
