### PR TITLE
fix(kin-cli): report hydration honestly from history and blame

### DIFF
--- a/crates/kin-cli/src/commands/blame.rs
+++ b/crates/kin-cli/src/commands/blame.rs
@@ -19,7 +19,14 @@ pub struct BlameResponse {
 
 pub struct BlameExecution {
     pub response: BlameResponse,
-    pub hydrated_git_history: bool,
+    /// Count of historical changes resolving this request's ref lazily
+    /// hydrated into the graph (0 when the ref was already present, or when
+    /// no ref was supplied and the current head resolved with no import).
+    /// Reported as a real count rather than a swallowed "did anything
+    /// hydrate" boolean, so a cold multi-thousand-change import is never
+    /// described the same way as a no-op: daemon owners persist the hydrated
+    /// state and broadcast the growth on this count being non-zero.
+    pub hydrated_changes: usize,
 }
 
 /// `kin blame <entity>` — Show who/when each version of an entity was committed.
@@ -79,7 +86,7 @@ pub fn execute_blame_request(
         lines.push("  No history recorded for this entity.".to_string());
         return Ok(BlameExecution {
             response: BlameResponse { lines },
-            hydrated_git_history: resolved.hydrated_git_history,
+            hydrated_changes: resolved.hydrated_changes,
         });
     }
 
@@ -113,6 +120,6 @@ pub fn execute_blame_request(
 
     Ok(BlameExecution {
         response: BlameResponse { lines },
-        hydrated_git_history: resolved.hydrated_git_history,
+        hydrated_changes: resolved.hydrated_changes,
     })
 }

--- a/crates/kin-cli/src/commands/history.rs
+++ b/crates/kin-cli/src/commands/history.rs
@@ -19,7 +19,14 @@ pub struct HistoryResponse {
 
 pub struct HistoryExecution {
     pub response: HistoryResponse,
-    pub hydrated_git_history: bool,
+    /// Count of historical changes resolving this request's ref lazily
+    /// hydrated into the graph (0 when the ref was already present, or when
+    /// no ref was supplied and the current head resolved with no import).
+    /// Reported as a real count rather than a swallowed "did anything
+    /// hydrate" boolean, so a cold multi-thousand-change import is never
+    /// described the same way as a no-op: daemon owners persist the hydrated
+    /// state and broadcast the growth on this count being non-zero.
+    pub hydrated_changes: usize,
 }
 
 pub async fn run(entity: String, reference: Option<String>) -> Result<()> {
@@ -92,6 +99,6 @@ pub fn execute_history_request(
 
     Ok(HistoryExecution {
         response: HistoryResponse { lines },
-        hydrated_git_history: resolved.hydrated_git_history,
+        hydrated_changes: resolved.hydrated_changes,
     })
 }

--- a/crates/kin-cli/src/commands/mcp.rs
+++ b/crates/kin-cli/src/commands/mcp.rs
@@ -219,7 +219,11 @@ mod tests {
         assert_eq!(resolve_repo_override(None), None);
     }
 
+    // Serialized against every other test that mutates the process-global
+    // `KIN_DAEMON_URL` (its sibling below, and the init bootstrap test) so a
+    // concurrent set/remove from another test can never be observed mid-body.
     #[tokio::test]
+    #[serial_test::serial]
     async fn bind_daemon_reports_missing_repo_without_hard_error() {
         // A directory with no .kin/ must produce an `Err` reason string for
         // the caller to log, never a panic or a process-killing error
@@ -236,6 +240,7 @@ mod tests {
     }
 
     #[tokio::test]
+    #[serial_test::serial]
     async fn bind_daemon_short_circuits_on_explicit_daemon_url() {
         // When KIN_DAEMON_URL is already set (e.g. by a supervising session),
         // binding must trust it directly rather than requiring a local .kin/

--- a/crates/kin-cli/tests/history_blame_hydration.rs
+++ b/crates/kin-cli/tests/history_blame_hydration.rs
@@ -1,0 +1,193 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Firelock, LLC
+
+//! End-to-end proof that `history` and `blame` report ref hydration honestly
+//! (FIR-1431). Resolving either command at an unimported Git ref lazily walks
+//! and imports that ref's ancestry into the graph. That import must surface as
+//! a truthful `hydrated_changes` count — a cold multi-change import and a warm
+//! no-op are not the same event — instead of the old swallowed boolean. This
+//! mirrors the shadow-review hydration contract proven in
+//! `review_shadow_json.rs` (PR #256), applied to the two commands that share
+//! the same resolving path.
+
+use kin_cli::commands::blame::{execute_blame_request, BlameRequest};
+use kin_cli::commands::history::{execute_history_request, HistoryRequest};
+use std::path::Path;
+use std::process::Command;
+use tempfile::tempdir;
+
+mod common;
+
+fn kin_command() -> Command {
+    let mut cmd = Command::new(env!("CARGO_BIN_EXE_kin"));
+    cmd.env("KIN_DAEMON_BIN", common::fresh_daemon_bin());
+    cmd
+}
+
+fn run_git(repo: &Path, args: &[&str]) {
+    let mut cmd = Command::new("git");
+    cmd.args(args).current_dir(repo);
+    // Fixture commits carry explicit, strictly increasing timestamps so ancestry
+    // ordering never depends on git's one-second timestamp granularity.
+    if args.first() == Some(&"commit") {
+        use std::sync::atomic::{AtomicU64, Ordering};
+        static COMMIT_EPOCH: AtomicU64 = AtomicU64::new(1_000_000_000);
+        let date = format!("{} +0000", COMMIT_EPOCH.fetch_add(100, Ordering::Relaxed));
+        cmd.env("GIT_AUTHOR_DATE", &date)
+            .env("GIT_COMMITTER_DATE", &date);
+    }
+    let output = cmd.output().expect("run git");
+    assert!(
+        output.status.success(),
+        "git {:?} failed: stdout={} stderr={}",
+        args,
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+}
+
+fn git_head(repo: &Path) -> String {
+    let output = Command::new("git")
+        .args(["rev-parse", "HEAD"])
+        .current_dir(repo)
+        .output()
+        .expect("git rev-parse HEAD");
+    assert!(output.status.success(), "git rev-parse HEAD failed");
+    String::from_utf8(output.stdout)
+        .expect("utf8 git head")
+        .trim()
+        .to_string()
+}
+
+fn kin_init(repo: &Path) {
+    let init = kin_command()
+        .arg("init")
+        .current_dir(repo)
+        .output()
+        .expect("run kin init");
+    assert!(
+        init.status.success(),
+        "kin init failed: stdout={} stderr={}",
+        String::from_utf8_lossy(&init.stdout),
+        String::from_utf8_lossy(&init.stderr)
+    );
+}
+
+/// A two-commit Rust repo whose head defines a resolvable `pub fn` entity
+/// (`compute_total`) with recorded revision history — enough for both `history`
+/// and `blame` to render at the head ref. Returns the head commit oid.
+fn setup_history_fixture(repo: &Path) -> String {
+    std::fs::create_dir_all(repo.join("src")).expect("create src");
+    std::fs::write(
+        repo.join("src/billing.rs"),
+        "pub fn compute_total(amount: u64) -> u64 {\n    amount + fee()\n}\n\nfn fee() -> u64 {\n    3\n}\n",
+    )
+    .expect("write billing.rs");
+    std::fs::write(repo.join("src/lib.rs"), "pub mod billing;\n").expect("write lib.rs");
+
+    run_git(repo, &["init"]);
+    run_git(
+        repo,
+        &["config", "user.email", "hydration-test@example.com"],
+    );
+    run_git(repo, &["config", "user.name", "Hydration Test"]);
+    run_git(repo, &["add", "-A"]);
+    run_git(repo, &["commit", "-m", "base: compute_total"]);
+
+    std::fs::write(
+        repo.join("src/billing.rs"),
+        "pub fn compute_total(amount: u64, currency: &str) -> u64 {\n    let _ = currency;\n    amount + fee()\n}\n\nfn fee() -> u64 {\n    3\n}\n",
+    )
+    .expect("rewrite billing.rs");
+    run_git(repo, &["add", "-A"]);
+    run_git(
+        repo,
+        &["commit", "-m", "head: add currency to compute_total"],
+    );
+
+    git_head(repo)
+}
+
+/// Cold import then warm re-resolve, both `history` and `blame`, on one graph:
+/// the first resolve at an unimported head walks git ancestry and must report a
+/// truthful non-zero `hydrated_changes`; every later resolve against the now
+/// already-present head must report exactly zero. Proves the count is never
+/// collapsed to a "did anything hydrate" boolean in either command.
+#[test]
+fn history_and_blame_report_hydration_count_honestly() {
+    let dir = tempdir().expect("tempdir");
+    let repo = dir.path();
+    let head = setup_history_fixture(repo);
+    kin_init(repo);
+
+    // Fresh in-memory graph: the git commits exist on disk but no ref is
+    // imported as a semantic change yet, so the first resolve must hydrate.
+    let layout = kin_core::KinLayout::new(repo.join(".kin"));
+    let graph = kin_db::InMemoryGraph::new();
+
+    // Cold import via `history`: walks genesis..head, inserting real changes.
+    let cold_history = execute_history_request(
+        &layout,
+        &graph,
+        &HistoryRequest {
+            entity: "compute_total".to_string(),
+            reference: Some(head.clone()),
+        },
+    )
+    .expect("history resolves and cold-imports the head ref");
+    assert!(
+        cold_history.hydrated_changes > 0,
+        "cold history import must report a nonzero hydrated_changes count, got {}",
+        cold_history.hydrated_changes
+    );
+    assert!(
+        cold_history
+            .response
+            .lines
+            .iter()
+            .any(|line| line.contains("History for")),
+        "history output must render the entity header: {:?}",
+        cold_history.response.lines
+    );
+
+    // Warm re-resolve via `history`: the head is already present, so this
+    // imports nothing and must report exactly zero — not a falsy flag.
+    let warm_history = execute_history_request(
+        &layout,
+        &graph,
+        &HistoryRequest {
+            entity: "compute_total".to_string(),
+            reference: Some(head.clone()),
+        },
+    )
+    .expect("warm history resolve takes the fast path");
+    assert_eq!(
+        warm_history.hydrated_changes, 0,
+        "warm history resolve (already imported) must report exactly zero hydrated changes"
+    );
+
+    // `blame` shares the same resolving path; against the now-warm graph it too
+    // must report exactly zero hydrated changes while still rendering output.
+    let warm_blame = execute_blame_request(
+        &layout,
+        &graph,
+        &BlameRequest {
+            entity: "compute_total".to_string(),
+            reference: Some(head.clone()),
+        },
+    )
+    .expect("blame resolves against the warm graph");
+    assert_eq!(
+        warm_blame.hydrated_changes, 0,
+        "warm blame resolve (already imported) must report exactly zero hydrated changes"
+    );
+    assert!(
+        warm_blame
+            .response
+            .lines
+            .iter()
+            .any(|line| line.contains("Blame for")),
+        "blame output must render the entity header: {:?}",
+        warm_blame.response.lines
+    );
+}

--- a/crates/kin-daemon/src/api.rs
+++ b/crates/kin-daemon/src/api.rs
@@ -3835,10 +3835,22 @@ async fn blame(
     let execution =
         kin_cli::commands::blame::execute_blame_request(&state.layout, graph.as_ref(), &req)
             .map_err(internal_error)?;
-    if execution.hydrated_git_history {
+    if execution.hydrated_changes > 0 {
+        tracing::info!(
+            hydrated_changes = execution.hydrated_changes,
+            "blame hydrated historical changes into the graph"
+        );
         state.bump_version();
         state.save_snapshot().map_err(internal_error)?;
         state.mark_clean();
+        // A live SSE subscriber (e.g. the VFS daemon) should hear about this
+        // graph growth exactly like any other root change — otherwise a
+        // hydration-only blame is invisible to anything watching /events in
+        // real time, even though it just persisted a potentially large import.
+        state.emit_event(DaemonEvent::GraphRootChanged {
+            old_root_hash: None,
+            new_root_hash: "blame-hydration".to_string(),
+        });
     }
     Ok(Json(execution.response))
 }
@@ -3875,10 +3887,22 @@ async fn history(
     let execution =
         kin_cli::commands::history::execute_history_request(&state.layout, graph.as_ref(), &req)
             .map_err(internal_error)?;
-    if execution.hydrated_git_history {
+    if execution.hydrated_changes > 0 {
+        tracing::info!(
+            hydrated_changes = execution.hydrated_changes,
+            "history hydrated historical changes into the graph"
+        );
         state.bump_version();
         state.save_snapshot().map_err(internal_error)?;
         state.mark_clean();
+        // A live SSE subscriber (e.g. the VFS daemon) should hear about this
+        // graph growth exactly like any other root change — otherwise a
+        // hydration-only history is invisible to anything watching /events in
+        // real time, even though it just persisted a potentially large import.
+        state.emit_event(DaemonEvent::GraphRootChanged {
+            old_root_hash: None,
+            new_root_hash: "history-hydration".to_string(),
+        });
     }
     Ok(Json(execution.response))
 }
@@ -10448,6 +10472,82 @@ mod tests {
             .lines
             .iter()
             .any(|line| line.contains("add handler")));
+    }
+
+    // A blame/history request that resolves an already-present head imports
+    // nothing (hydrated_changes == 0), so neither handler may broadcast a
+    // hydration `GraphRootChanged`. A spurious event would wake every /events
+    // subscriber (the VFS daemon) for a read-only query that grew no graph
+    // state. This guards the gate on the new truthful count: the event fires
+    // only when an import actually happened.
+    #[tokio::test]
+    async fn warm_blame_and_history_emit_no_graph_root_changed_event() {
+        let state = test_state();
+        state
+            .is_initialized
+            .store(true, std::sync::atomic::Ordering::Relaxed);
+
+        let entity = test_entity("handler", "src/lib.py");
+        let change_id = SemanticChangeId::from_hash(Hash256::from_bytes([0x43; 32]));
+        state
+            .graph
+            .create_change(&SemanticChange {
+                id: change_id,
+                parents: vec![],
+                timestamp: Timestamp::now(),
+                author: AuthorId::new("test"),
+                message: "add handler".to_string(),
+                entity_deltas: vec![EntityDelta::Added(entity.clone())],
+                relation_deltas: vec![],
+                artifact_deltas: vec![],
+                projected_files: vec![],
+                spec_link: None,
+                evidence: vec![],
+                risk_summary: None,
+                authored_on: None,
+            })
+            .unwrap();
+        state.graph.upsert_entity(&entity).unwrap();
+        state
+            .graph
+            .create_branch(&Branch {
+                name: BranchName::new("main"),
+                head: change_id,
+            })
+            .unwrap();
+        kin_core::write_current_branch(&state.layout, &BranchName::new("main")).unwrap();
+
+        // Subscribe before issuing any request so every broadcast is observable.
+        let mut events = state.event_tx.subscribe();
+        let app = router(state);
+
+        for endpoint in ["/blame", "/history"] {
+            let response = app
+                .clone()
+                .oneshot(
+                    Request::post(endpoint)
+                        .header("content-type", "application/json")
+                        .body(Body::from(
+                            serde_json::json!({ "entity": "handler" }).to_string(),
+                        ))
+                        .unwrap(),
+                )
+                .await
+                .unwrap();
+            assert_eq!(response.status(), StatusCode::OK, "{endpoint} must succeed");
+        }
+
+        // No reference was supplied, so resolution imported nothing: neither
+        // handler may have broadcast a hydration GraphRootChanged.
+        loop {
+            match events.try_recv() {
+                Ok(DaemonEvent::GraphRootChanged { new_root_hash, .. }) => panic!(
+                    "warm blame/history must not emit GraphRootChanged, got new_root_hash={new_root_hash:?}"
+                ),
+                Ok(_) => continue,
+                Err(_) => break,
+            }
+        }
     }
 
     #[tokio::test]


### PR DESCRIPTION
## What

`history` and `blame` resolve their ref through the same lazily-hydrating path a shadow review uses. They previously collapsed the real hydration insert count into a `hydrated_git_history` bool on their execution structs, and their daemon handlers persisted hydrated graph state without broadcasting it — so a cold multi-thousand-change import and a no-op looked identical, and live `/events` subscribers (the VFS daemon) never heard about graph growth these read-only commands had just committed.

## Change

- Thread the truthful `hydrated_changes: usize` count (already carried on `ResolvedRef`) onto `BlameExecution` / `HistoryExecution`, replacing the swallowed bool.
- Emit `GraphRootChanged { new_root_hash: "blame-hydration" / "history-hydration" }` from the daemon `blame` / `history` handlers on hydration, mirroring the review handler's existing `review-hydration` broadcast. The version bump + snapshot persistence that already ran on hydration are unchanged — only the trigger condition and the broadcast become truthful.

## Tests

- `tests/history_blame_hydration.rs`: cold import reports a nonzero `hydrated_changes`; a warm re-resolve reports exactly zero — for both commands, end-to-end through a real Git fixture.
- daemon `warm_blame_and_history_emit_no_graph_root_changed_event`: the warm path broadcasts no spurious `GraphRootChanged`.

## Note on the second commit

`test(kin-cli): serialize KIN_DAEMON_URL-mutating mcp bind tests` is an **unrelated pre-existing flake** surfaced by the full-suite gate run: two `bind_daemon_for_repo_dir` tests raced on the process-global `KIN_DAEMON_URL` (one sets, one removes) under the parallel runner. Fixed by placing both in the default serial group. Happy to split it into its own PR if preferred.

## Local gate

`fmt --check` / `clippy` (CI allowlist, `-D warnings`) / `check_runtime_boundaries.sh` / `check_private_repo_coupling.sh` / `build --all-targets --locked` / `test --workspace --locked`: all green.
