### PR TITLE
fix(review): exclude derived-copy consumers by path — FIR-1267 687 false would_block

### DIFF
--- a/crates/kin-cli/tests/review_shadow_json.rs
+++ b/crates/kin-cli/tests/review_shadow_json.rs
@@ -561,3 +561,95 @@ fn shadow_report_unknown_abbreviated_sha_fails_friendly() {
         "unknown abbreviated shas must not surface as opaque server errors: {stderr}"
     );
 }
+
+/// Fixture: base defines `compute_total` plus a single-header amalgamated copy
+/// under `single_include/` that "consumes" it; head changes `compute_total`'s
+/// signature. The amalgamated bundle is a byte-regenerated copy of the sources,
+/// so `classify_file_role` maps `single_include/*` to `Generated` and it must
+/// never count as an independent breaking consumer.
+fn setup_generated_consumer_repo(repo: &Path) -> (String, String) {
+    std::fs::create_dir_all(repo.join("src")).expect("create src");
+    std::fs::create_dir_all(repo.join("single_include")).expect("create single_include");
+    std::fs::write(
+        repo.join("src/billing.rs"),
+        "pub fn compute_total(amount: u64) -> u64 {\n    amount + fee()\n}\n\nfn fee() -> u64 {\n    3\n}\n",
+    )
+    .expect("write billing.rs");
+    std::fs::write(
+        repo.join("single_include/billing_amalgamated.rs"),
+        "use crate::billing::compute_total;\n\npub fn bundled_total(amount: u64) -> u64 {\n    compute_total(amount)\n}\n",
+    )
+    .expect("write amalgamated bundle");
+    std::fs::write(repo.join("src/lib.rs"), "pub mod billing;\n").expect("write lib.rs");
+
+    run_git(repo, &["init"]);
+    run_git(repo, &["config", "user.email", "shadow-test@example.com"]);
+    run_git(repo, &["config", "user.name", "Shadow Test"]);
+    run_git(repo, &["add", "-A"]);
+    run_git(
+        repo,
+        &["commit", "-m", "base: billing with amalgamated bundle"],
+    );
+    let base = git_head(repo);
+
+    std::fs::write(
+        repo.join("src/billing.rs"),
+        "pub fn compute_total(amount: u64, currency: &str) -> u64 {\n    let _ = currency;\n    amount + fee()\n}\n\nfn fee() -> u64 {\n    3\n}\n",
+    )
+    .expect("rewrite billing.rs");
+    run_git(repo, &["add", "-A"]);
+    run_git(
+        repo,
+        &["commit", "-m", "head: change compute_total signature"],
+    );
+    let head = git_head(repo);
+
+    (base, head)
+}
+
+/// FIR-1267 (687 false would_block), end-to-end: a signature change whose only
+/// cross-file consumer is a generated single-header copy must not raise a
+/// blocking breaking finding. This exercises the same `Generated`-consumer
+/// exclusion through the full CLI + graph gate that
+/// `ref_view::tests::generated_consumer_excluded_at_historical_ref` proves for
+/// the historical-ref reconstruction path.
+#[test]
+fn shadow_generated_copy_consumer_does_not_block() {
+    let dir = tempdir().expect("tempdir");
+    let repo = dir.path();
+    let (base, head) = setup_generated_consumer_repo(repo);
+    kin_init(repo);
+
+    let report = run_shadow_json(repo, &base, &head);
+
+    // The signature change is still captured as a real change...
+    let changed = report["changed_entities"].as_array().unwrap();
+    assert!(
+        changed
+            .iter()
+            .any(|entity| entity["name"] == "compute_total" && entity["signature_changed"] == true),
+        "compute_total signature change must be captured: {report}"
+    );
+
+    // ...but its only consumer is a generated copy, so the verdict must not block.
+    let verdict = report["policy"]["verdict"].as_str().unwrap();
+    assert_ne!(
+        verdict, "would_block",
+        "a signature change whose only consumer is a generated single-header copy \
+         must not block: {report}"
+    );
+
+    // And no blocking breaking finding may be raised on the generated consumer.
+    let blocking_breaking =
+        report["policy"]["findings"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .any(|finding| {
+                finding["blocking"].as_bool().unwrap_or(false) && finding["kind"] == "breaking"
+            });
+    assert!(
+        !blocking_breaking,
+        "generated-copy-only consumer must not produce a blocking breaking finding: {report}"
+    );
+}

--- a/crates/kin-core/src/ref_view.rs
+++ b/crates/kin-core/src/ref_view.rs
@@ -939,6 +939,26 @@ fn normalize_entity_file_origins_to_historical_tree(
                 span.file = canonical;
             }
         }
+        // Re-derive the entity role from its canonical historical path.
+        //
+        // `resolve_graph_at` replays persisted entities verbatim, and this
+        // reconstruction is the only stage that re-canonicalizes their paths --
+        // yet it never re-derived `role`. An entity persisted before the
+        // amalgamated-bundle / vendored path rules landed (e.g. `single_include/`
+        // single-header copies persisted with `role=Source`) therefore replays
+        // with a stale role. `impact.rs` excludes `Generated`/`Vendored`
+        // consumers from `consumer_count`, so a stale-`Source` derived copy leaks
+        // into the count and inflates a benign refactor's blast radius into a
+        // false breaking finding.
+        //
+        // `classify_file_role` is the same pure path function ingest applies
+        // (`pipeline.rs`), so re-applying it here is idempotent for correctly
+        // classified entities and only upgrades stale ones. `role` is not part of
+        // entity identity (`EntityId::from_content` keys on path/kind/name/line),
+        // so re-deriving it cannot desync persisted-vs-reconstructed identity.
+        if let Some(file_origin) = entity.file_origin.as_ref() {
+            entity.role = kin_index::classify_file_role(&file_origin.0);
+        }
     }
 }
 
@@ -2292,6 +2312,60 @@ def uri_encoder(value):\n    return value.replace(' ', '%20')\n",
             created_in: None,
             superseded_by: None,
         }
+    }
+
+    /// FIR-1267 (687 false would_block): the historical-ref reconstruction
+    /// replays persisted entities verbatim and is the only stage that
+    /// re-canonicalizes their paths, so it must also re-derive `role`. A
+    /// single-header amalgamated copy persisted before the `single_include/`
+    /// rule landed replays with a stale `role=Source`; `impact.rs` only excludes
+    /// `Generated`/`Vendored` consumers, so the stale copy leaks into
+    /// `consumer_count` and inflates a benign refactor's blast radius into a
+    /// false breaking finding. Reconstruction must reclassify it to `Generated`
+    /// while leaving a genuine source consumer at a real path as `Source`.
+    #[test]
+    fn generated_consumer_excluded_at_historical_ref() {
+        let mut amalgamated = test_entity("addReporter", "single_include/catch.hpp");
+        amalgamated.role = EntityRole::Source; // stale persisted role (pre-rule ingest)
+        let amalgamated_id = amalgamated.id;
+
+        let mut real_source =
+            test_entity("addReporter", "include/reporters/catch_reporter_multi.hpp");
+        real_source.role = EntityRole::Source;
+        let real_source_id = real_source.id;
+
+        let mut snapshot = GraphSnapshot::empty();
+        snapshot.entities.insert(amalgamated_id, amalgamated);
+        snapshot.entities.insert(real_source_id, real_source);
+
+        let file_tree: HashMap<FilePathId, Hash256> = [
+            (
+                FilePathId::new("single_include/catch.hpp"),
+                Hash256::from_bytes([0x11; 32]),
+            ),
+            (
+                FilePathId::new("include/reporters/catch_reporter_multi.hpp"),
+                Hash256::from_bytes([0x22; 32]),
+            ),
+        ]
+        .into_iter()
+        .collect();
+
+        let path_resolver = HistoricalPathResolver::from_changes(&[], &file_tree);
+        normalize_entity_file_origins_to_historical_tree(&mut snapshot, &file_tree, &path_resolver);
+
+        assert_eq!(
+            snapshot.entities[&amalgamated_id].role,
+            EntityRole::Generated,
+            "a single_include/ amalgamated copy persisted as Source must be re-derived to \
+             Generated during historical-ref reconstruction so impact.rs excludes it from \
+             consumer_count (the FIR-1267 687 divergence)"
+        );
+        assert_eq!(
+            snapshot.entities[&real_source_id].role,
+            EntityRole::Source,
+            "a genuine source consumer at a real path must remain a counted consumer"
+        );
     }
 
     #[test]

--- a/crates/kin-review/src/impact.rs
+++ b/crates/kin-review/src/impact.rs
@@ -399,8 +399,7 @@ pub fn analyze_impact_at<I: ImpactGraph>(
                 || changed_keys.contains(&entity_identity_key(&entity))
             {
                 let is_test = entity.role == EntityRole::Test || rel.kind == RelationKind::Tests;
-                let is_derived =
-                    matches!(entity.role, EntityRole::Generated | EntityRole::Vendored);
+                let is_derived = consumer_is_derived(&entity);
                 // Only a real consumer surface counts as a migrated consumer;
                 // a co-updated test or regenerated copy was never a break.
                 if !is_test && !is_derived {
@@ -412,7 +411,7 @@ pub fn analyze_impact_at<I: ImpactGraph>(
             let is_test = entity.role == EntityRole::Test || rel.kind == RelationKind::Tests;
             if is_test {
                 ent_tests.insert(affected_id);
-            } else if matches!(entity.role, EntityRole::Generated | EntityRole::Vendored) {
+            } else if consumer_is_derived(&entity) {
                 // Derived copies (amalgamated bundles, vendored snapshots)
                 // regenerate from their sources; they appear in the blast
                 // radius for navigation but cannot be "broken" consumers,
@@ -600,6 +599,35 @@ fn entity_file(entity: &Entity) -> Option<String> {
         Some(span) => Some(span.file.to_string()),
         None => entity.file_origin.as_ref().map(|file| file.to_string()),
     }
+}
+
+/// Whether a consumer is a derived copy (amalgamated single-header bundle,
+/// vendored snapshot) that regenerates from its sources and so can never be a
+/// broken consumer.
+///
+/// The persisted `role` is the primary signal, but the review evaluates a graph
+/// materialized by `resolve_graph_at`, which replays persisted entities verbatim
+/// and never reparses. An entity ingested before the amalgamated-bundle /
+/// vendored path rules landed (e.g. a `single_include/*` copy persisted with
+/// `role=Source`) therefore replays with a stale role and would be counted as a
+/// real breaking consumer. The path-based check is the read-time backstop: it
+/// re-derives the derived-copy status from the entity's canonical path with the
+/// same pure `classify_file_role` function ingest applies. It only ever adds
+/// exclusions (a derived path can never turn a real Source consumer into a
+/// counted one it was not already), and `role` is not part of entity identity,
+/// so this changes no persisted state.
+fn consumer_is_derived(entity: &Entity) -> bool {
+    if matches!(entity.role, EntityRole::Generated | EntityRole::Vendored) {
+        return true;
+    }
+    entity_file(entity)
+        .map(|path| {
+            matches!(
+                kin_index::classify_file_role(&path),
+                EntityRole::Generated | EntityRole::Vendored
+            )
+        })
+        .unwrap_or(false)
 }
 
 #[cfg(test)]
@@ -873,6 +901,54 @@ mod tests {
         // C is still reachable as transitive blast radius (report surface),
         // just not as a direct-consumer attribution.
         assert!(report.affected_dependents.iter().any(|e| e.id == c.id));
+    }
+
+    #[test]
+    fn stale_source_amalgamated_consumer_excluded_from_consumer_count_by_path() {
+        // FIR-1267 (687 false would_block): the review evaluates a graph
+        // materialized by resolve_graph_at, which replays persisted entities
+        // verbatim and never reparses. A single-header amalgamated copy ingested
+        // before the single_include/ rule landed replays with a stale
+        // role=Source, yet it must still be excluded from consumer_count by its
+        // path so a benign signature change is not inflated with a phantom
+        // breaking consumer. Only the real src/invoice.rs consumer counts.
+        let target = entity_in_file("compute_total", "src/billing.rs", 1);
+        let real = entity_in_file("render_invoice", "src/invoice.rs", 1);
+        let amalgamated = entity_in_file("bundled_total", "single_include/catch.hpp", 1);
+        assert_eq!(
+            amalgamated.role,
+            EntityRole::Source,
+            "fixture: the amalgamated copy carries a stale persisted role"
+        );
+
+        let mut graph = MockImpactGraph::default();
+        for entity in [&target, &real, &amalgamated] {
+            graph.entities.insert(entity.id, entity.clone());
+        }
+        graph.inbound.insert(
+            target.id,
+            vec![calls(&real, &target), calls(&amalgamated, &target)],
+        );
+
+        let diff = SemanticDiff {
+            entity_changes: vec![modified(&target)],
+            ..Default::default()
+        };
+
+        let report = analyze_impact_at(&graph, &diff).unwrap();
+        let impact = report
+            .entity_impact(&target.id)
+            .expect("target has an impact entry");
+        assert_eq!(
+            impact.consumer_count, 1,
+            "the single_include/ amalgamated copy must be excluded by path; only the real \
+             src/invoice.rs consumer counts"
+        );
+        assert_eq!(
+            impact.consumer_files,
+            vec!["src/invoice.rs".to_string()],
+            "consumer_files must not include the generated single-header bundle"
+        );
     }
 
     #[test]


### PR DESCRIPTION
## What

Re-derive derived-copy status (amalgamated single-header / vendored snapshot) at
read time so persisted-`Source` copies stop being counted as real breaking
consumers. Two read paths are covered:

- **the review gate (the 687 path)** — `kin-review` `impact.rs` consumer exclusion.
- **locate / daemon-api** — `kin-core` `ref_view.rs` historical reconstruction.

## Why (FIR-1267 — the 687 false `would_block`)

The shadow review materializes the graph at a ref via
`GraphAtRef::materialize → store.resolve_graph_at` (kin-review `ref_graph.rs`) — a
faithful replay of PERSISTED entities that never reparses. `impact.rs` then
excludes only `Generated`/`Vendored` consumers from `consumer_count`, keyed on the
persisted `role`.

Entities persisted before the amalgamated-bundle / vendored path rules landed
(`single_include/*` copies persisted with `role=Source`) therefore replay with a
stale role and are counted as real consumers. On the Catch2 `687437fcd1` benign
reporter refactor this counts the 8 `single_include/catch.hpp` copies as
downstream consumers of `MultipleReporters::add`, tripping a blocking "breaking
change affects N downstream" finding → false `would_block`. (`single_include/catch.hpp`
does not even exist in the tree at `687437fcd1`; the copies are persisted entities
replayed from later history, so they can only carry a persisted role — not a
freshly reparsed one.)

## How

- **Review path (this is what moves 687):** `impact.rs` gains a
  `consumer_is_derived` backstop — a consumer is a derived copy if its persisted
  `role` is `Generated`/`Vendored` **or** its path classifies as one via
  `kin_index::classify_file_role`. Applied at both consumer-exclusion sites. It is
  additive (only ever adds exclusions; a derived path can never turn a real Source
  consumer into a counted one it was not already), read-time, and changes no
  persisted state.
- **Locate / daemon path (consistency):** `ref_view.rs::normalize_entity_file_origins_to_historical_tree`
  also re-derives `entity.role = classify_file_role(&canonical_path)`. This keeps
  the two read paths consistent — the review path does **not** use this function
  (`build_graph_at_ref*` serves only `locate.rs` + daemon `api.rs`), so it is not
  what clears 687, but the fidelity fix belongs on both read surfaces.

`classify_file_role` is the same pure path function ingest applies (`pipeline.rs`),
so re-applying it is idempotent for correctly classified entities and only upgrades
stale ones.

**Safety:** `role` is not part of entity identity (`EntityId::from_content` keys on
path/kind/name/line), so re-deriving it at read time changes no persisted state and
cannot desync persisted-vs-reconstructed identity.

## Tests

- `kin-review` `stale_source_amalgamated_consumer_excluded_from_consumer_count_by_path`
  — **the review-gate proof:** a persisted-`Source` `single_include/` consumer is
  excluded from `consumer_count` (fails without the impact.rs fix).
- `kin-core` `generated_consumer_excluded_at_historical_ref` — the ref_view
  reconstruction reclassifies a persisted-`Source` `single_include/` entity to
  `Generated` (locate/daemon path).
- `kin-cli` `shadow_generated_copy_consumer_does_not_block` — end-to-end, a
  signature change whose only cross-file consumer is a generated single-header copy
  does not raise a blocking breaking finding.

## NON-GATING — do not cite as clearing 687

This is a bounded substrate-fidelity fix and is **NON-GATING**. It must **not** be
presented as citably clearing the 687 false-block until the full backtest books at
the fix sha: golden re-prep + benign-60 (assert 687 flips `would_block`→`pass`,
zero new benign regressions) + 16-TP recall integrity + determinism re-seal, on a
booked/serialized GPU window. Any verdict-changing gate change invalidates the
sealed determinism proof and the pinned goldens; re-prep + re-seal are mandatory
before this is cited.

Scope note: this removes the 8 `single_include` phantom consumers. The remaining
`catch_matchers.hpp` (4) + `generateSingleHeader.py` (1) phantoms are separate
linker precision (C++ overload arity + cross-language binding) and are **out of
scope** here; whether the derived-copy exclusion alone drops `consumer_count` below
the blocking threshold for `MultipleReporters::add` is a backtest question.
