### PR TITLE
docs: align manifest repo naming and README release pins

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ real blast radius of a merge is.
 ## Install
 
 Kin ships as native binaries on [GitHub Releases](https://github.com/firelock-ai/kin/releases)
-(currently **v0.2.14**) for five targets: macOS (Apple Silicon and Intel), Linux (x86_64 and
+(currently **v0.2.15**) for five targets: macOS (Apple Silicon and Intel), Linux (x86_64 and
 aarch64, static musl), and Windows (x86_64 — a limited, work-in-progress build; see below).
 
 **Direct download.** Grab the archive for your platform, verify its checksum, and extract.
@@ -45,8 +45,8 @@ The release publishes a `.sha256` next to every archive.
 
 ```sh
 # Apple Silicon macOS shown; swap in your platform's archive name.
-curl -fsSLO https://github.com/firelock-ai/kin/releases/download/v0.2.14/kin-macos-aarch64.tar.gz
-curl -fsSLO https://github.com/firelock-ai/kin/releases/download/v0.2.14/kin-macos-aarch64.tar.gz.sha256
+curl -fsSLO https://github.com/firelock-ai/kin/releases/download/v0.2.15/kin-macos-aarch64.tar.gz
+curl -fsSLO https://github.com/firelock-ai/kin/releases/download/v0.2.15/kin-macos-aarch64.tar.gz.sha256
 shasum -a 256 -c kin-macos-aarch64.tar.gz.sha256
 tar xzf kin-macos-aarch64.tar.gz      # contains the `kin` and `kin-daemon` binaries
 ```
@@ -69,7 +69,7 @@ the complete, vector-enabled Kin, install under WSL2 — see
 
 **For AI agents.** `kin setup --intent agent` wires Kin's built-in MCP server into every
 detected assistant with the curated `agent-default` tool profile. npm users can install the
-canonical launcher with `npm install -g @kinlab/kin` (**0.2.14**) and run the same setup
+canonical launcher with `npm install -g @kinlab/kin` (**0.2.15**) and run the same setup
 command; the older `@kinlab/kin-mcp` package remains as a compatibility wrapper.
 
 See [docs/quickstart.md](docs/quickstart.md) for installer environment variables

--- a/docs/ecosystem-manifest.json
+++ b/docs/ecosystem-manifest.json
@@ -165,7 +165,7 @@
       "note": "kin depends directly on the standalone kin-lsp repo."
     },
     {
-      "name": "infra",
+      "name": "kin-infra",
       "layer": "proprietary",
       "role": "deployment-and-ops",
       "dependsOn": [


### PR DESCRIPTION
Docs-only alignment pass.

## Changes
- `docs/ecosystem-manifest.json`: rename the ops repo entry `infra` -> `kin-infra` (the actual GitHub repo; `firelock-ai/infra` 404s, `firelock-ai/kin-infra` verified live). The entry carries no URL fields, so the name field is the only change; no other manifest entry references `infra`. JSON validated with `python3 -m json.tool`.
- `README.md`: pin every release reference from v0.2.14 to v0.2.15 — prose install line, both curl download URLs, and the `@kinlab/kin` npm mention. Verified before writing: `gh release view v0.2.15` lists `kin-macos-aarch64.tar.gz` + `.sha256` among the five-platform assets, and `@kinlab/kin@0.2.15` is published on npm. No 0.2.14 occurrences remain in the README.

## Notes
- The naming descriptor in the manifest already reads the locked line ('the system of record for AI-written software') on main, so no descriptor change was needed.

FIR context: docs hygiene, no code paths touched.
