### PR TITLE
Harden Homebrew formula scope parsing

### DIFF
--- a/scripts/test-homebrew-release-gate.py
+++ b/scripts/test-homebrew-release-gate.py
@@ -611,6 +611,29 @@ def test_escaped_character_literals_cannot_hide_comment_boundaries() -> None:
         )
 
 
+def test_numeric_and_variable_ternaries_cannot_bypass_question_guard() -> None:
+    for condition in ("1", "1_000", "0xff", "@ivar", "@@cvar", "$gvar"):
+        formula = current_real_formula_shape().replace(
+            '    bin.install "kin"',
+            f'    value = {condition}?2:3\n    bin.install "kin"',
+            1,
+        )
+
+        assert_ruby_syntax_valid(formula)
+        assert_validator_rejects(
+            formula, "Ruby character literals and ternary expressions"
+        )
+
+
+def test_predicate_identifier_with_digit_remains_supported() -> None:
+    formula = current_real_formula_shape().replace("File.exist?", "File.ready1?", 1)
+    assert_ruby_syntax_valid(formula)
+
+    result = run_validator(formula)
+
+    assert result.returncode == 0, result.stdout.decode() + result.stderr.decode()
+
+
 def test_percent_characters_inside_strings_and_comments_remain_data() -> None:
     formula = current_real_formula_shape().replace(
         '    bin.install "kin"',
@@ -867,6 +890,8 @@ def main() -> None:
         test_hash_character_literal_cannot_hide_percent_scope_escape,
         test_hash_character_literal_cannot_escape_install_scope_without_percent,
         test_escaped_character_literals_cannot_hide_comment_boundaries,
+        test_numeric_and_variable_ternaries_cannot_bypass_question_guard,
+        test_predicate_identifier_with_digit_remains_supported,
         test_percent_characters_inside_strings_and_comments_remain_data,
         test_unparsed_ruby_regex_cannot_supply_inactive_version,
         test_multiline_ruby_regex_inside_install_body_is_rejected,

--- a/scripts/test-homebrew-release-gate.py
+++ b/scripts/test-homebrew-release-gate.py
@@ -373,6 +373,19 @@ def replace_fixture_version(replacement: str) -> str:
     return formula.replace(marker, replacement)
 
 
+def replace_fixture_install(replacement: str) -> str:
+    formula = current_real_formula_shape()
+    canonical_install = """  def install
+    bin.install "kin"
+    bin.install "kin-daemon"
+    bin.install "kin-vfs" if File.exist?("kin-vfs")
+    lib.install "libkin_vfs_shim.dylib" if File.exist?("libkin_vfs_shim.dylib")
+    lib.install "libkin_vfs_shim.so" if File.exist?("libkin_vfs_shim.so")
+  end"""
+    assert formula.count(canonical_install) == 1
+    return formula.replace(canonical_install, replacement, 1)
+
+
 def assert_ruby_syntax_valid(formula: str) -> None:
     ruby = shutil.which("ruby")
     if ruby is None:
@@ -548,29 +561,45 @@ def test_ruby_percent_literal_cannot_supply_inactive_version() -> None:
 
 
 def test_hash_delimited_percent_literal_cannot_escape_install_scope() -> None:
-    formula = current_real_formula_shape()
-    canonical_install = """  def install
-    bin.install "kin"
-    bin.install "kin-daemon"
-    bin.install "kin-vfs" if File.exist?("kin-vfs")
-    lib.install "libkin_vfs_shim.dylib" if File.exist?("libkin_vfs_shim.dylib")
-    lib.install "libkin_vfs_shim.so" if File.exist?("libkin_vfs_shim.so")
-  end"""
     scope_escape = """  def install
     %q=#=; end
     $kin_gate_bypass = :executed_at_class_scope
     %q=#=; if true
   end"""
-    assert canonical_install in formula
-    formula = formula.replace(canonical_install, scope_escape, 1)
+    formula = replace_fixture_install(scope_escape)
 
+    assert_ruby_syntax_valid(formula)
     assert_validator_rejects(formula, "Ruby percent literals")
+
+
+def test_hash_character_literal_cannot_hide_percent_scope_escape() -> None:
+    scope_escape = """  def install
+    ?#; %q=#=; end
+    $kin_gate_bypass = :executed_at_class_scope
+    ?#; %q=#=; if true
+  end"""
+    formula = replace_fixture_install(scope_escape)
+
+    assert_ruby_syntax_valid(formula)
+    assert_validator_rejects(formula, "Ruby hash character literals")
+
+
+def test_hash_character_literal_cannot_escape_install_scope_without_percent() -> None:
+    scope_escape = """  def install
+    ?#; end
+    $kin_gate_bypass = :executed_at_class_scope
+    ?#; if true
+  end"""
+    formula = replace_fixture_install(scope_escape)
+
+    assert_ruby_syntax_valid(formula)
+    assert_validator_rejects(formula, "Ruby hash character literals")
 
 
 def test_percent_characters_inside_strings_and_comments_remain_data() -> None:
     formula = current_real_formula_shape().replace(
         '    bin.install "kin"',
-        '    puts "100% verified"\n    # 100% comment\n    bin.install "kin"',
+        '    puts "100% verified ?#"\n    # 100% comment ?#\n    bin.install "kin"',
         1,
     )
     assert_ruby_syntax_valid(formula)
@@ -820,6 +849,8 @@ def main() -> None:
         test_ruby_brace_block_cannot_supply_inactive_version,
         test_ruby_percent_literal_cannot_supply_inactive_version,
         test_hash_delimited_percent_literal_cannot_escape_install_scope,
+        test_hash_character_literal_cannot_hide_percent_scope_escape,
+        test_hash_character_literal_cannot_escape_install_scope_without_percent,
         test_percent_characters_inside_strings_and_comments_remain_data,
         test_unparsed_ruby_regex_cannot_supply_inactive_version,
         test_multiline_ruby_regex_inside_install_body_is_rejected,

--- a/scripts/test-homebrew-release-gate.py
+++ b/scripts/test-homebrew-release-gate.py
@@ -547,6 +547,39 @@ def test_ruby_percent_literal_cannot_supply_inactive_version() -> None:
     assert_validator_rejects(formula, "Ruby percent literals")
 
 
+def test_hash_delimited_percent_literal_cannot_escape_install_scope() -> None:
+    formula = current_real_formula_shape()
+    canonical_install = """  def install
+    bin.install "kin"
+    bin.install "kin-daemon"
+    bin.install "kin-vfs" if File.exist?("kin-vfs")
+    lib.install "libkin_vfs_shim.dylib" if File.exist?("libkin_vfs_shim.dylib")
+    lib.install "libkin_vfs_shim.so" if File.exist?("libkin_vfs_shim.so")
+  end"""
+    scope_escape = """  def install
+    %q=#=; end
+    $kin_gate_bypass = :executed_at_class_scope
+    %q=#=; if true
+  end"""
+    assert canonical_install in formula
+    formula = formula.replace(canonical_install, scope_escape, 1)
+
+    assert_validator_rejects(formula, "Ruby percent literals")
+
+
+def test_percent_characters_inside_strings_and_comments_remain_data() -> None:
+    formula = current_real_formula_shape().replace(
+        '    bin.install "kin"',
+        '    puts "100% verified"\n    # 100% comment\n    bin.install "kin"',
+        1,
+    )
+    assert_ruby_syntax_valid(formula)
+
+    result = run_validator(formula)
+
+    assert result.returncode == 0, result.stdout.decode() + result.stderr.decode()
+
+
 def test_unparsed_ruby_regex_cannot_supply_inactive_version() -> None:
     formula = replace_fixture_version('  ignored_version = /\n    version "1.2.3"\n  /')
     assert_validator_rejects(
@@ -786,6 +819,8 @@ def main() -> None:
         test_ruby_heredoc_cannot_supply_inactive_version,
         test_ruby_brace_block_cannot_supply_inactive_version,
         test_ruby_percent_literal_cannot_supply_inactive_version,
+        test_hash_delimited_percent_literal_cannot_escape_install_scope,
+        test_percent_characters_inside_strings_and_comments_remain_data,
         test_unparsed_ruby_regex_cannot_supply_inactive_version,
         test_multiline_ruby_regex_inside_install_body_is_rejected,
         test_reopened_kin_class_is_rejected,

--- a/scripts/test-homebrew-release-gate.py
+++ b/scripts/test-homebrew-release-gate.py
@@ -581,7 +581,7 @@ def test_hash_character_literal_cannot_hide_percent_scope_escape() -> None:
     formula = replace_fixture_install(scope_escape)
 
     assert_ruby_syntax_valid(formula)
-    assert_validator_rejects(formula, "Ruby hash character literals")
+    assert_validator_rejects(formula, "Ruby character literals and ternary expressions")
 
 
 def test_hash_character_literal_cannot_escape_install_scope_without_percent() -> None:
@@ -593,7 +593,22 @@ def test_hash_character_literal_cannot_escape_install_scope_without_percent() ->
     formula = replace_fixture_install(scope_escape)
 
     assert_ruby_syntax_valid(formula)
-    assert_validator_rejects(formula, "Ruby hash character literals")
+    assert_validator_rejects(formula, "Ruby character literals and ternary expressions")
+
+
+def test_escaped_character_literals_cannot_hide_comment_boundaries() -> None:
+    for character_literal in (r"?\C-#", r"?\c#", r"?\M-#"):
+        scope_escape = f"""  def install
+    {character_literal}; end
+    $kin_gate_bypass = :executed_at_class_scope
+    {character_literal}; if true
+  end"""
+        formula = replace_fixture_install(scope_escape)
+
+        assert_ruby_syntax_valid(formula)
+        assert_validator_rejects(
+            formula, "Ruby character literals and ternary expressions"
+        )
 
 
 def test_percent_characters_inside_strings_and_comments_remain_data() -> None:
@@ -851,6 +866,7 @@ def main() -> None:
         test_hash_delimited_percent_literal_cannot_escape_install_scope,
         test_hash_character_literal_cannot_hide_percent_scope_escape,
         test_hash_character_literal_cannot_escape_install_scope_without_percent,
+        test_escaped_character_literals_cannot_hide_comment_boundaries,
         test_percent_characters_inside_strings_and_comments_remain_data,
         test_unparsed_ruby_regex_cannot_supply_inactive_version,
         test_multiline_ruby_regex_inside_install_body_is_rejected,

--- a/scripts/test-homebrew-release-gate.py
+++ b/scripts/test-homebrew-release-gate.py
@@ -612,7 +612,24 @@ def test_escaped_character_literals_cannot_hide_comment_boundaries() -> None:
 
 
 def test_numeric_and_variable_ternaries_cannot_bypass_question_guard() -> None:
-    for condition in ("1", "1_000", "0xff", "@ivar", "@@cvar", "$gvar"):
+    for condition in (
+        "1",
+        "1_000",
+        "0xff",
+        "@ivar",
+        "@@cvar",
+        "$gvar",
+        "$-a",
+        "$-d",
+        "$-F",
+        "$-i",
+        "$-I",
+        "$-l",
+        "$-p",
+        "$-v",
+        "$-w",
+        "$-W",
+    ):
         formula = current_real_formula_shape().replace(
             '    bin.install "kin"',
             f'    value = {condition}?2:3\n    bin.install "kin"',

--- a/scripts/validate-homebrew-formula.py
+++ b/scripts/validate-homebrew-formula.py
@@ -77,14 +77,23 @@ class PendingUrl:
     url: str
 
 
+@dataclass(frozen=True)
+class RubyLineScan:
+    code: str
+    structure: str
+    has_unquoted_percent: bool
+    has_hash_character_literal: bool
+    has_unterminated_quote: bool
+
+
 def expected_url(artifact: str) -> str:
     return (
         f"https://github.com/firelock-ai/kin/releases/download/v#{{version}}/{artifact}"
     )
 
 
-def has_unquoted_ruby_percent(line: str) -> bool:
-    """Return whether code before a comment contains unsupported ``%`` syntax.
+def scan_ruby_line(line: str) -> RubyLineScan:
+    """Scan one generated-formula line with the Ruby tokens relevant here.
 
     Ruby percent literals may use ``#`` as their delimiter. Comment stripping cannot
     therefore run before this check: doing so can hide both the delimiter and arbitrary
@@ -92,56 +101,22 @@ def has_unquoted_ruby_percent(line: str) -> bool:
     grammar needs neither percent literals nor modulo expressions, so every unquoted
     percent token fails closed. Percent signs inside quoted metadata/URLs and comments
     remain ordinary data.
+
+    Ruby also parses ``?#`` as the character literal ``"#"``, not as ``?`` followed by
+    a comment. That token must be recognized before deciding that ``#`` starts a comment;
+    otherwise its trailing statements can desynchronize the validator's block stack.
     """
-
-    quote: str | None = None
-    escaped = False
-    for character in line:
-        if quote is not None:
-            if escaped:
-                escaped = False
-            elif character == "\\":
-                escaped = True
-            elif character == quote:
-                quote = None
-            continue
-        if character in {'"', "'"}:
-            quote = character
-        elif character == "#":
-            return False
-        elif character == "%":
-            return True
-    return False
-
-
-def ruby_code(line: str) -> str:
-    """Return code before a Ruby comment, preserving hashes inside strings."""
-
-    quote: str | None = None
-    escaped = False
-    for index, character in enumerate(line):
-        if quote is not None:
-            if escaped:
-                escaped = False
-            elif character == "\\":
-                escaped = True
-            elif character == quote:
-                quote = None
-            continue
-        if character in {'"', "'"}:
-            quote = character
-        elif character == "#":
-            return line[:index].strip()
-    return line.strip()
-
-
-def ruby_structure_code(line: str) -> str:
-    """Return Ruby code with strings/comments blanked for keyword checks."""
 
     retained: list[str] = []
     quote: str | None = None
     escaped = False
-    for character in line:
+    has_unquoted_percent = False
+    has_hash_character_literal = False
+    comment_index: int | None = None
+    index = 0
+
+    while index < len(line):
+        character = line[index]
         if quote is not None:
             retained.append(" ")
             if escaped:
@@ -150,40 +125,41 @@ def ruby_structure_code(line: str) -> str:
                 escaped = True
             elif character == quote:
                 quote = None
+            index += 1
             continue
         if character in {'"', "'"}:
             quote = character
             retained.append(" ")
+        elif character == "?" and index + 1 < len(line) and line[index + 1] == "#":
+            has_hash_character_literal = True
+            retained.extend((" ", " "))
+            index += 2
+            continue
         elif character == "#":
+            comment_index = index
             break
+        elif character == "%":
+            has_unquoted_percent = True
+            retained.append(character)
         else:
             retained.append(character)
-    return "".join(retained).strip()
+        index += 1
+
+    code = line[:comment_index].strip() if comment_index is not None else line.strip()
+    return RubyLineScan(
+        code=code,
+        structure="".join(retained).strip(),
+        has_unquoted_percent=has_unquoted_percent,
+        has_hash_character_literal=has_hash_character_literal,
+        has_unterminated_quote=quote is not None,
+    )
 
 
-def has_unterminated_ruby_quote(line: str) -> bool:
-    quote: str | None = None
-    escaped = False
-    for character in line:
-        if quote is not None:
-            if escaped:
-                escaped = False
-            elif character == "\\":
-                escaped = True
-            elif character == quote:
-                quote = None
-            continue
-        if character in {'"', "'"}:
-            quote = character
-        elif character == "#":
-            break
-    return quote is not None
-
-
-def reject_unsupported_ruby_syntax(line: str, code: str, line_number: int) -> None:
+def reject_unsupported_ruby_syntax(scan: RubyLineScan, line_number: int) -> None:
     """Fail closed where this deliberately small Ruby parser has no authority."""
 
-    structure = ruby_structure_code(line)
+    code = scan.code
+    structure = scan.structure
     reason: str | None = None
     if BLOCK_COMMENT_RE.match(code):
         reason = "Ruby block comments"
@@ -191,7 +167,7 @@ def reject_unsupported_ruby_syntax(line: str, code: str, line_number: int) -> No
         reason = "Ruby data sections"
     elif GENERIC_CLASS_RE.match(code) and not KIN_CLASS_RE.fullmatch(code):
         reason = "Ruby class reopening and additional class declarations"
-    elif has_unterminated_ruby_quote(line):
+    elif scan.has_unterminated_quote:
         reason = "multiline quoted strings"
     elif "<<" in structure:
         reason = "Ruby heredocs and shift expressions"
@@ -199,7 +175,9 @@ def reject_unsupported_ruby_syntax(line: str, code: str, line_number: int) -> No
         reason = "Ruby brace blocks and hash literals"
     elif "`" in structure:
         reason = "Ruby command literals"
-    elif has_unquoted_ruby_percent(line):
+    elif scan.has_hash_character_literal:
+        reason = "Ruby hash character literals"
+    elif scan.has_unquoted_percent:
         reason = "Ruby percent literals"
     elif "/" in structure:
         reason = "Ruby regular expressions and division expressions"
@@ -262,10 +240,11 @@ def parse_formula(formula: str, expected_version: str) -> dict[str, FormulaPair]
 
     for index, line in enumerate(lines):
         line_number = index + 1
-        code = ruby_code(line)
+        scan = scan_ruby_line(line)
+        code = scan.code
         if not code:
             continue
-        reject_unsupported_ruby_syntax(line, code, line_number)
+        reject_unsupported_ruby_syntax(scan, line_number)
 
         if code == "end":
             if pending_url is not None:

--- a/scripts/validate-homebrew-formula.py
+++ b/scripts/validate-homebrew-formula.py
@@ -99,8 +99,9 @@ def question_follows_predicate_identifier(line: str, index: int) -> bool:
     ternaries after numeric, instance, class, and global variables (for example
     ``1?2:3`` and ``@flag?2:3``). Predicate method names instead end in an
     identifier whose first character is alphabetic or ``_`` and whose token is
-    not introduced by a variable sigil. Qualified calls such as ``File.exist?``
-    and identifiers containing digits such as ``ready1?`` remain supported.
+    not introduced by a variable sigil, including Ruby's ``$-w`` option-global
+    form. Qualified calls such as ``File.exist?`` and identifiers containing
+    digits such as ``ready1?`` remain supported.
     """
 
     start = index
@@ -109,7 +110,9 @@ def question_follows_predicate_identifier(line: str, index: int) -> bool:
     identifier = line[start:index]
     if not identifier or not (identifier[0].isalpha() or identifier[0] == "_"):
         return False
-    return start == 0 or line[start - 1] not in {"@", "$"}
+    if start > 0 and line[start - 1] in {"@", "$"}:
+        return False
+    return start < 2 or line[start - 2 : start] != "$-"
 
 
 def scan_ruby_line(line: str) -> RubyLineScan:

--- a/scripts/validate-homebrew-formula.py
+++ b/scripts/validate-homebrew-formula.py
@@ -24,7 +24,6 @@ BLOCK_KEYWORD_RE = re.compile(
 DO_BLOCK_RE = re.compile(r"(?:^|\s)do(?:\s*\|[^|]*\|)?$")
 INLINE_END_RE = re.compile(r"(?:^|;)\s*end\b")
 BLOCK_COMMENT_RE = re.compile(r"^=(?:begin|end)\b")
-PERCENT_LITERAL_RE = re.compile(r"(?<![\w%])%(?:[qQwWiIrxs])?[^\w\s=]")
 GENERIC_CLASS_RE = re.compile(r"^class\b")
 ON_PLATFORM_RE = re.compile(r"^(on_[A-Za-z0-9_!?]+)\b")
 FORMULA_METADATA_PREFIX_RE = re.compile(r"^(?:desc|homepage|license)\b")
@@ -82,6 +81,37 @@ def expected_url(artifact: str) -> str:
     return (
         f"https://github.com/firelock-ai/kin/releases/download/v#{{version}}/{artifact}"
     )
+
+
+def has_unquoted_ruby_percent(line: str) -> bool:
+    """Return whether code before a comment contains unsupported ``%`` syntax.
+
+    Ruby percent literals may use ``#`` as their delimiter. Comment stripping cannot
+    therefore run before this check: doing so can hide both the delimiter and arbitrary
+    Ruby that follows it on the same physical line. This validator's generated-formula
+    grammar needs neither percent literals nor modulo expressions, so every unquoted
+    percent token fails closed. Percent signs inside quoted metadata/URLs and comments
+    remain ordinary data.
+    """
+
+    quote: str | None = None
+    escaped = False
+    for character in line:
+        if quote is not None:
+            if escaped:
+                escaped = False
+            elif character == "\\":
+                escaped = True
+            elif character == quote:
+                quote = None
+            continue
+        if character in {'"', "'"}:
+            quote = character
+        elif character == "#":
+            return False
+        elif character == "%":
+            return True
+    return False
 
 
 def ruby_code(line: str) -> str:
@@ -169,7 +199,7 @@ def reject_unsupported_ruby_syntax(line: str, code: str, line_number: int) -> No
         reason = "Ruby brace blocks and hash literals"
     elif "`" in structure:
         reason = "Ruby command literals"
-    elif PERCENT_LITERAL_RE.search(structure):
+    elif has_unquoted_ruby_percent(line):
         reason = "Ruby percent literals"
     elif "/" in structure:
         reason = "Ruby regular expressions and division expressions"

--- a/scripts/validate-homebrew-formula.py
+++ b/scripts/validate-homebrew-formula.py
@@ -82,7 +82,7 @@ class RubyLineScan:
     code: str
     structure: str
     has_unquoted_percent: bool
-    has_hash_character_literal: bool
+    has_unsupported_question_syntax: bool
     has_unterminated_quote: bool
 
 
@@ -102,16 +102,19 @@ def scan_ruby_line(line: str) -> RubyLineScan:
     percent token fails closed. Percent signs inside quoted metadata/URLs and comments
     remain ordinary data.
 
-    Ruby also parses ``?#`` as the character literal ``"#"``, not as ``?`` followed by
-    a comment. That token must be recognized before deciding that ``#`` starts a comment;
-    otherwise its trailing statements can desynchronize the validator's block stack.
+    Ruby character literals begin with ``?`` and include escaped control/meta forms whose
+    final character may be ``#``. They must be rejected before deciding that ``#`` starts
+    a comment; otherwise trailing statements can desynchronize the validator's block
+    stack. Predicate-method suffixes such as ``File.exist?`` remain supported because
+    their ``?`` immediately follows an identifier character. The generated grammar uses
+    neither standalone character literals nor ternary expressions.
     """
 
     retained: list[str] = []
     quote: str | None = None
     escaped = False
     has_unquoted_percent = False
-    has_hash_character_literal = False
+    has_unsupported_question_syntax = False
     comment_index: int | None = None
     index = 0
 
@@ -130,11 +133,11 @@ def scan_ruby_line(line: str) -> RubyLineScan:
         if character in {'"', "'"}:
             quote = character
             retained.append(" ")
-        elif character == "?" and index + 1 < len(line) and line[index + 1] == "#":
-            has_hash_character_literal = True
-            retained.extend((" ", " "))
-            index += 2
-            continue
+        elif character == "?" and (
+            index == 0 or not (line[index - 1].isalnum() or line[index - 1] == "_")
+        ):
+            has_unsupported_question_syntax = True
+            retained.append(character)
         elif character == "#":
             comment_index = index
             break
@@ -150,7 +153,7 @@ def scan_ruby_line(line: str) -> RubyLineScan:
         code=code,
         structure="".join(retained).strip(),
         has_unquoted_percent=has_unquoted_percent,
-        has_hash_character_literal=has_hash_character_literal,
+        has_unsupported_question_syntax=has_unsupported_question_syntax,
         has_unterminated_quote=quote is not None,
     )
 
@@ -175,8 +178,8 @@ def reject_unsupported_ruby_syntax(scan: RubyLineScan, line_number: int) -> None
         reason = "Ruby brace blocks and hash literals"
     elif "`" in structure:
         reason = "Ruby command literals"
-    elif scan.has_hash_character_literal:
-        reason = "Ruby hash character literals"
+    elif scan.has_unsupported_question_syntax:
+        reason = "Ruby character literals and ternary expressions"
     elif scan.has_unquoted_percent:
         reason = "Ruby percent literals"
     elif "/" in structure:

--- a/scripts/validate-homebrew-formula.py
+++ b/scripts/validate-homebrew-formula.py
@@ -92,6 +92,26 @@ def expected_url(artifact: str) -> str:
     )
 
 
+def question_follows_predicate_identifier(line: str, index: int) -> bool:
+    """Return whether ``line[index]`` terminates a Ruby predicate identifier.
+
+    A single preceding alphanumeric is insufficient: Ruby parses no-space
+    ternaries after numeric, instance, class, and global variables (for example
+    ``1?2:3`` and ``@flag?2:3``). Predicate method names instead end in an
+    identifier whose first character is alphabetic or ``_`` and whose token is
+    not introduced by a variable sigil. Qualified calls such as ``File.exist?``
+    and identifiers containing digits such as ``ready1?`` remain supported.
+    """
+
+    start = index
+    while start > 0 and (line[start - 1].isalnum() or line[start - 1] == "_"):
+        start -= 1
+    identifier = line[start:index]
+    if not identifier or not (identifier[0].isalpha() or identifier[0] == "_"):
+        return False
+    return start == 0 or line[start - 1] not in {"@", "$"}
+
+
 def scan_ruby_line(line: str) -> RubyLineScan:
     """Scan one generated-formula line with the Ruby tokens relevant here.
 
@@ -133,8 +153,8 @@ def scan_ruby_line(line: str) -> RubyLineScan:
         if character in {'"', "'"}:
             quote = character
             retained.append(" ")
-        elif character == "?" and (
-            index == 0 or not (line[index - 1].isalnum() or line[index - 1] == "_")
+        elif character == "?" and not question_follows_predicate_identifier(
+            line, index
         ):
             has_unsupported_question_syntax = True
             retained.append(character)


### PR DESCRIPTION
## Summary

- reject unsupported unquoted Ruby percent syntax before comment stripping
- consolidate formula-line parsing into one quote/escape/comment authority
- reject standalone Ruby question syntax so character literals and ternary expressions cannot desynchronize the validator's block stack
- distinguish real predicate identifiers from numeric, sigiled-variable, and Ruby option-global no-space ternaries
- preserve predicate methods such as `File.exist?` and `ready1?` plus question/percent characters inside quoted strings and real comments

## Root causes corrected

The original validator stripped `#` as a comment before recognizing a percent-literal delimiter. That hid semicolons and `end` tokens inside a Ruby-valid percent literal and desynchronized the block stack.

Independent review of the first hotfix found a second ambiguity: Ruby parses `?#` as a character literal, not as `?` followed by a comment. Review of the next head then found the broader escaped control/meta forms `?\C-#`, `?\c#`, and `?\M-#`. The scanner now rejects that unsupported unquoted question-token family before comment classification.

Later exact-head review found a separate fail-closed coverage gap: Ruby accepts no-space ternaries after numeric and sigiled-variable expressions, including `1?2:3`, `@ivar?2:3`, `@@cvar?2:3`, `$gvar?2:3`, and option globals such as `$-w?2:3`. A preceding alphanumeric was therefore not enough to prove `?` was a predicate suffix. Predicate recognition now requires an alphabetic/underscore-starting identifier token not introduced by `@`, `$`, or `$-`; qualified predicates and digit-bearing method names remain supported.

## Verification

Exact head `52b799353dafadc84fd5a926bcdfc19b50bb98e4`, based on current main `8fc3945d6349429ca985f0906f800a7088669185`:

- 49 Homebrew release-gate tests
- 8 installer checksum fixture/product-wiring cases
- independent audit: CLEAN across 25 Ruby-valid ternary condition classes, 34 character/ternary forms, all 10 percent-literal families, and predicate/quoted/comment/multiline controls
- Ruff format/lint, Python compile, and clean diff/worktree checks
- actionlint plus shell syntax/lint on the earlier workflow/shell exact head; those files are unchanged by later deltas
- fresh GitHub CI: every check green, including both platforms, coverage, Docker, daemon smoke, SAST, DCO/CLA, secrets, npm, and Windows checksum checks

## Review and claim boundary

This PR is ready and at the head of the merge captain queue. FIR-1270 is In Review until the merge is verified on main. No new release has been cut; v0.2.15 remains public. No benchmark or proof claim is being made.

Linear: FIR-1270