### PR TITLE
Upgrade tree-sitter to 0.26

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -146,7 +146,7 @@ version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -157,7 +157,7 @@ checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1144,7 +1144,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users 0.5.2",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1253,7 +1253,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4010,7 +4010,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4909,7 +4909,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4968,7 +4968,7 @@ dependencies = [
  "security-framework 3.7.0",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -5412,7 +5412,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "52d1cfed4120b4d927bf7c0f86d2087a4a7d6027c906d9f9d525a80573b9be51"
 dependencies = [
  "libc",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -5545,7 +5545,7 @@ dependencies = [
  "getrandom 0.4.3",
  "once_cell",
  "rustix",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -5920,9 +5920,9 @@ dependencies = [
 
 [[package]]
 name = "tree-sitter"
-version = "0.25.10"
+version = "0.26.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "78f873475d258561b06f1c595d93308a7ed124d9977cb26b148c2084a4a3cc87"
+checksum = "3c343ed63e3f5c64d1acdecb5d2c13d4e169cb5fde0052106ebaa6c6f27f9e55"
 dependencies = [
  "cc",
  "regex",
@@ -6474,7 +6474,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -69,7 +69,7 @@ clap = { version = "4", features = ["derive"] }
 notify = "8"
 
 # Tree-sitter
-tree-sitter = "0.25"
+tree-sitter = "0.26"
 tree-sitter-typescript = "0.23"
 tree-sitter-python = "0.25"
 tree-sitter-go = "0.25"

--- a/crates/kin-parser/src/languages/c_lang.rs
+++ b/crates/kin-parser/src/languages/c_lang.rs
@@ -429,7 +429,10 @@ fn find_child_of_kind<'a>(
 ) -> Option<tree_sitter::Node<'a>> {
     let count = node.child_count();
     for i in 0..count {
-        if let Some(child) = node.child(i) {
+        let Ok(child_index) = i.try_into() else {
+            continue;
+        };
+        if let Some(child) = node.child(child_index) {
             if child.kind() == kind {
                 return Some(child);
             }
@@ -493,7 +496,7 @@ fn extract_c_include(
         // Use index-based iteration to avoid borrow-checker issues with cursor.
         let count = node.child_count();
         (0..count)
-            .filter_map(|i| node.child(i))
+            .filter_map(|i| i.try_into().ok().and_then(|index| node.child(index)))
             .find(|c| c.kind() == "system_lib_string" || c.kind() == "string_literal")
     });
 

--- a/crates/kin-parser/src/lib.rs
+++ b/crates/kin-parser/src/lib.rs
@@ -28,7 +28,7 @@ pub const PARSER_SCHEMA_EPOCH: &str = "parser-schema-2026-03-29-v1";
 /// doubt, bump — a spurious bump only costs a cold re-parse, while a missed bump
 /// silently serves stale semantics (the stale-binary class of bug). Mirrors
 /// kin-db's `GraphSnapshot::CURRENT_VERSION` convention.
-pub const PARSER_SEMANTICS_VERSION: u32 = 1;
+pub const PARSER_SEMANTICS_VERSION: u32 = 2;
 
 pub mod adapter;
 pub mod error;


### PR DESCRIPTION
## Summary

- upgrade the workspace `tree-sitter` dependency from 0.25.10 to 0.26.10
- adapt the two C-language child-index call sites to tree-sitter 0.26's checked `u32` index API
- bump `PARSER_SEMANTICS_VERSION` so memoized parses cannot reuse output produced under the old grammar runtime
- keep the lockfile change limited to the tree-sitter version and checksum

## Why this replaces #285

Dependabot PR #285 updated the dependency but did not compile because `Node::child` now accepts `u32` while the existing C adapter passed `usize`. It also omitted the parser-semantics invalidation required for a grammar/runtime change. This replacement carries the dependency update, the minimal compatibility adaptation at both failing sites, and the cache-version bump.

## Verification

Exact head `080ab4f03e30c94a7bf717e3f2eaf28b169398d7`, based on main before the active captain queue advanced:

- full `kin-parser`: 381 passed, 8 intentional ignores
- full `kin-index` + `kin-reconcile`: 344 passed
- focused parse-memo version-key regression passed
- parser all-target Clippy with warnings denied
- cargo fmt, locked metadata resolution, and diff check
- fresh GitHub CI fully green, including both fuzz targets and coverage
- independent exact-object review: CLEAN

The audit confirms:

- the lock resolves exactly one tree-sitter runtime, 0.26.10, with no stale 0.25 reference
- grammar ABI compatibility remains versions 13 through 15
- the only used breaking API is `Node::child(usize)` becoming `Node::child(u32)`; both dynamic C indices use checked conversion
- parser semantics version 1 -> 2 participates in the only persisted parse-output memo key

## Dependency boundary

PR #306 fixes the independent verification-shell PATH race exposed by the exact-head full workspace run. PR #307 separately advances parser semantics for declaration extraction. Both are ready and ahead of this PR in the captain queue.

After #306 and #307 land, this branch must integrate current main, resolve the combined parser-semantics version monotonically (the tree-sitter change becomes the next version, not a duplicate `2`), and rerun the full workspace suite/CI. Until then this stays draft even though its isolated implementation/review/CI gates are clean.

## Review and claim boundary

No merge, release, benchmark, or proof claim is being made.

Supersedes #285.

Linear: FIR-1463