### PR TITLE
Attest immutable release daemon images

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -116,8 +116,6 @@ jobs:
     permissions:
       contents: read
       packages: write
-      id-token: write
-      attestations: write
     outputs:
       digest: ${{ steps.publish.outputs.digest }}
       commit: ${{ steps.source.outputs.commit }}
@@ -243,35 +241,110 @@ jobs:
             echo "- no mutable latest tag was written"
           } >> "$GITHUB_STEP_SUMMARY"
 
+  # Attestation is intentionally separate from the image build. It may only
+  # inspect the immutable commit tag emitted above, and cannot rebuild or move
+  # it. This keeps OIDC/attestation authority out of the build job while still
+  # blocking every public release surface if exact OCI provenance is absent.
+  attest_daemon_image:
+    name: Attest immutable daemon image
+    needs: [config, build_daemon_image]
+    if: ${{ always() && !failure() && !cancelled() && startsWith(github.ref, 'refs/tags/v') }}
+    runs-on: ubuntu-latest
+    environment: release
+    permissions:
+      contents: read
+      packages: write
+      id-token: write
+      attestations: write
+    steps:
+      - name: Checkout release source
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
+          fetch-depth: 0
+
+      - name: Resolve peeled release commit
+        id: source
+        shell: bash
+        env:
+          EXPECTED_COMMIT: ${{ needs.build_daemon_image.outputs.commit }}
+        run: |
+          set -euo pipefail
+          commit="$(git rev-parse "${GITHUB_REF_NAME}^{commit}")"
+          test "$commit" = "$(git rev-parse HEAD)"
+          if [ "$commit" != "$EXPECTED_COMMIT" ]; then
+            echo "::error::release tag peels to $commit, image job resolved to $EXPECTED_COMMIT"
+            exit 1
+          fi
+          if ! printf '%s\n' "$commit" | grep -Eq '^[0-9a-f]{40}$'; then
+            echo "::error::release tag did not resolve to a full commit id"
+            exit 1
+          fi
+          echo "commit=$commit" >> "$GITHUB_OUTPUT"
+
+      - name: Log in to GitHub Container Registry
+        uses: docker/login-action@af1e73f918a031802d376d3c8bbc3fe56130a9b0 # v4.0.0
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3.12.0
+
+      - name: Resolve exact immutable daemon digest
+        id: subject
+        shell: bash
+        env:
+          COMMIT: ${{ steps.source.outputs.commit }}
+          EXPECTED_DIGEST: ${{ needs.build_daemon_image.outputs.digest }}
+          IMAGE: ghcr.io/firelock-ai/kin
+        run: |
+          set -euo pipefail
+          reference="${IMAGE}:${COMMIT}"
+          digest="$(docker buildx imagetools inspect \
+            "$reference" --format '{{.Manifest.Digest}}')"
+          if ! printf '%s\n' "$digest" | grep -Eq '^sha256:[0-9a-f]{64}$'; then
+            echo "::error::could not resolve an immutable manifest digest for $reference"
+            exit 1
+          fi
+          if [ "$digest" != "$EXPECTED_DIGEST" ]; then
+            echo "::error::$reference moved from release-built $EXPECTED_DIGEST to $digest"
+            exit 1
+          fi
+          bash scripts/verify-container-build-info.sh \
+            "${IMAGE}@${digest}" "$COMMIT"
+          echo "digest=$digest" >> "$GITHUB_OUTPUT"
+
       - name: Attest immutable daemon image
-        # Store SLSA provenance next to the exact digest in GHCR so staging and
-        # production admission can verify the protected tag workflow identity.
+        # With no predicate inputs actions/attest emits SLSA provenance. Store
+        # the bundle next to the exact digest in GHCR for downstream admission.
         uses: actions/attest@a1948c3f048ba23858d222213b7c278aabede763 # v4.1.1
         with:
           subject-name: ghcr.io/firelock-ai/kin
-          subject-digest: ${{ steps.publish.outputs.digest }}
+          subject-digest: ${{ steps.subject.outputs.digest }}
           push-to-registry: true
-          # Keep authority minimal: the registry attestation is required, but
-          # the optional linked-artifact storage record is not.
+          # The OCI bundle is required; the optional linked-artifact storage
+          # record (and its broader artifact-metadata permission) is not.
           create-storage-record: false
 
       - name: Verify immutable daemon image attestation
         env:
           GH_TOKEN: ${{ github.token }}
-          DIGEST: ${{ steps.publish.outputs.digest }}
+          DIGEST: ${{ steps.subject.outputs.digest }}
           COMMIT: ${{ steps.source.outputs.commit }}
         run: |
           set -euo pipefail
-          identity="https://github.com/${GITHUB_REPOSITORY}/.github/workflows/release.yml@${GITHUB_REF}"
           verified=false
           for attempt in 1 2 3 4 5; do
             if gh attestation verify \
               "oci://ghcr.io/firelock-ai/kin@${DIGEST}" \
               --repo "$GITHUB_REPOSITORY" \
+              --bundle-from-oci \
               --predicate-type https://slsa.dev/provenance/v1 \
               --signer-workflow "$GITHUB_REPOSITORY/.github/workflows/release.yml" \
               --signer-digest "$COMMIT" \
-              --cert-identity "$identity" \
+              --source-digest "$COMMIT" \
               --source-ref "$GITHUB_REF" \
               --deny-self-hosted-runners; then
               verified=true
@@ -923,7 +996,7 @@ jobs:
 
   publish:
     name: Publish Release
-    needs: [build, notarize_linux]
+    needs: [build, notarize_linux, attest_daemon_image]
     # notarize_linux is skipped on the default (macOS notarytool) path; publish
     # must still run then, but must NOT run if notarization actually failed or
     # was cancelled. `always() && !failure() && !cancelled()` lets a skipped
@@ -1656,7 +1729,7 @@ jobs:
   # No main-push workflow, GCP identity, or mutable latest tag participates.
   version_tag_image:
     name: Version-tag ghcr image
-    needs: [publish, install_proof, build_daemon_image]
+    needs: [publish, install_proof, build_daemon_image, attest_daemon_image]
     # Mirror publish's always() guard so a skipped notarize_linux does not
     # transitively skip this job, and only tag real version-tag pushes so
     # `:<version>` never points at an unreleased build.

--- a/docs/security/signing-and-update-trust.md
+++ b/docs/security/signing-and-update-trust.md
@@ -54,9 +54,12 @@ every gate passes.
 
 The daemon container is a separate attested subject. The protected tag workflow
 builds one exact commit-tagged image in GHCR, verifies its embedded source and
-lockfile identity, attaches SLSA provenance to that immutable digest, and
-self-verifies the tag/ref/workflow identity. Later version-tag promotion reuses
-that digest without rebuilding and never writes an implicit `latest` image.
+lockfile identity, then passes that digest to a separate attestation-only job.
+That job re-resolves the commit tag, refuses digest drift, attaches SLSA
+provenance to the immutable digest in GHCR, and self-verifies the repository,
+release workflow, source tag, peeled source commit, and hosted-runner identity.
+It cannot rebuild the image. Later version-tag promotion reuses that digest
+without rebuilding and never writes an implicit `latest` image.
 Hosted infrastructure may copy the exact manifest into its private registry,
 but that operation is a separately attested promotion, not a second build.
 

--- a/scripts/test-release-workflow-authority.py
+++ b/scripts/test-release-workflow-authority.py
@@ -41,6 +41,7 @@ def main() -> None:
         )
     require(release, 'tags:\n      - "v*.*.*"', "release trigger")
     require(release, "  build_daemon_image:", "release daemon image job")
+    require(release, "  attest_daemon_image:", "release daemon attestation job")
 
     for policy in (
         "actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0",
@@ -51,31 +52,80 @@ def main() -> None:
         require(docker_workflow, policy, "Docker CI authority and smoke gate")
 
     image_start = release.index("  build_daemon_image:")
-    image_end = release.index("\n  build:", image_start)
+    image_end = release.index("\n  attest_daemon_image:", image_start)
     image_job = release[image_start:image_end]
     for policy in (
         "needs: config",
         "environment: release",
         "packages: write",
-        "id-token: write",
-        "attestations: write",
         "ghcr.io/firelock-ai/kin",
         "verify-container-build-info.sh",
+        "docker buildx build",
+    ):
+        require(image_job, policy, "release daemon image build job")
+
+    for forbidden in (
+        "id-token: write",
+        "attestations: write",
+        "actions/attest@",
+    ):
+        if forbidden in image_job:
+            raise AssertionError(
+                f"release daemon image build job contains attestation authority: {forbidden}"
+            )
+
+    attestation_start = release.index("  attest_daemon_image:")
+    attestation_end = release.index("\n  build:", attestation_start)
+    attestation_job = release[attestation_start:attestation_end]
+    for policy in (
+        "needs: [config, build_daemon_image]",
+        "environment: release",
+        "packages: write",
+        "id-token: write",
+        "attestations: write",
+        "EXPECTED_COMMIT: ${{ needs.build_daemon_image.outputs.commit }}",
+        "EXPECTED_DIGEST: ${{ needs.build_daemon_image.outputs.digest }}",
+        'git rev-parse "${GITHUB_REF_NAME}^{commit}"',
+        'reference="${IMAGE}:${COMMIT}"',
+        "docker buildx imagetools inspect",
+        "^sha256:[0-9a-f]{64}$",
+        'if [ "$digest" != "$EXPECTED_DIGEST" ]',
+        '"${IMAGE}@${digest}" "$COMMIT"',
         "Attest immutable daemon image",
+        "actions/attest@a1948c3f048ba23858d222213b7c278aabede763",
         "subject-name: ghcr.io/firelock-ai/kin",
-        "subject-digest: ${{ steps.publish.outputs.digest }}",
+        "subject-digest: ${{ steps.subject.outputs.digest }}",
         "push-to-registry: true",
         "create-storage-record: false",
         "Verify immutable daemon image attestation",
         '"oci://ghcr.io/firelock-ai/kin@${DIGEST}"',
+        "--bundle-from-oci",
         "--predicate-type https://slsa.dev/provenance/v1",
         '--signer-workflow "$GITHUB_REPOSITORY/.github/workflows/release.yml"',
         '--signer-digest "$COMMIT"',
-        '--cert-identity "$identity"',
+        '--source-digest "$COMMIT"',
         '--source-ref "$GITHUB_REF"',
         "--deny-self-hosted-runners",
     ):
-        require(image_job, policy, "release daemon image job")
+        require(attestation_job, policy, "release daemon image attestation job")
+
+    if "docker buildx build" in attestation_job or re.search(
+        r"(?m)^\s*docker\s+build\s", attestation_job
+    ):
+        raise AssertionError("release daemon attestation job must not rebuild the image")
+    if image_job.count("docker buildx build") != 1:
+        raise AssertionError("release daemon path must contain exactly one image build command")
+
+    require(
+        release,
+        "needs: [build, notarize_linux, attest_daemon_image]",
+        "public release daemon attestation gate",
+    )
+    require(
+        release,
+        "needs: [publish, install_proof, build_daemon_image, attest_daemon_image]",
+        "version image daemon attestation gate",
+    )
     require(
         release,
         "EXPECTED_SOURCE_DIGEST: ${{ needs.build_daemon_image.outputs.digest }}",
@@ -199,9 +249,9 @@ def main() -> None:
         "us-central1-docker.pkg.dev",
         ":latest",
     ):
-        if forbidden in image_job:
+        if forbidden in image_job or forbidden in attestation_job:
             raise AssertionError(
-                f"release daemon image job contains forbidden authority: {forbidden}"
+                f"release daemon image path contains forbidden authority: {forbidden}"
             )
 
     unpinned: list[str] = []


### PR DESCRIPTION
## Summary

- isolate OCI image attestation from the daemon image build
- bind the attestation to the exact protected release tag, peeled commit, and immutable GHCR digest
- make public release publication and version-tag promotion fail closed when the attestation is absent
- self-verify the OCI bundle with the signer workflow, source ref, source commit, and hosted-runner policy

## Verification

- python3 scripts/test-release-workflow-authority.py
- actionlint .github/workflows/release.yml
- git diff --check
- independent cross-repo review against the kin-infra admission contract

## Boundary

This lands release authority only. It does not create a tag, publish a release, push an image, promote to Artifact Registry, or deploy. The live end-to-end gate still requires the coordinated kin-infra change and external bootstrap.