### PR TITLE
Preserve canonical release lock bytes on Windows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -89,6 +89,10 @@ jobs:
     runs-on: windows-latest
     timeout-minutes: 30
     steps:
+      - name: Preserve tracked bytes on Windows
+        shell: bash
+        run: git config --global core.autocrlf false
+
       - uses: actions/checkout@v7
 
       - name: Test exact archive checksum selection (PowerShell 7)
@@ -140,13 +144,27 @@ jobs:
           "$bin_dir/kin-daemon.exe" --version
           "$bin_dir/kin.exe" bench-meta --json > "$RUNNER_TEMP/kin-build-meta.json"
           EXPECTED_SHA="$(git rev-parse HEAD)" node <<'NODE'
+          const childProcess = require("child_process");
+          const crypto = require("crypto");
           const fs = require("fs");
           const meta = JSON.parse(fs.readFileSync(`${process.env.RUNNER_TEMP}/kin-build-meta.json`, "utf8"));
           if (meta.kin_commit !== process.env.EXPECTED_SHA || meta.kin_dirty !== false || meta.kin_source_known !== true) {
             throw new Error("Windows release build did not prove a clean, known checkout");
           }
-          if (!/^[0-9a-f]{64}$/.test(meta.dependency_provenance ?? "")) {
-            throw new Error("Windows release build lacks Cargo.lock provenance");
+          const trackedLock = childProcess.execFileSync(
+            "git",
+            ["cat-file", "blob", "HEAD:Cargo.lock"]
+          );
+          const workingLock = fs.readFileSync("Cargo.lock");
+          if (!workingLock.equals(trackedLock)) {
+            throw new Error("Windows Cargo.lock working bytes do not match the tracked Git blob");
+          }
+          const expectedLock = crypto.createHash("sha256").update(trackedLock).digest("hex");
+          if (meta.dependency_provenance !== expectedLock) {
+            throw new Error(
+              `Windows embedded Cargo.lock provenance ${meta.dependency_provenance ?? "missing"} ` +
+              `does not match tracked Git bytes ${expectedLock}`
+            );
           }
           for (const feature of ["vector", "embeddings", "metal"]) {
             if (meta.feature_flags.includes(feature)) {

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -414,6 +414,11 @@ jobs:
             cross: false
 
     steps:
+      - name: Preserve tracked bytes on Windows
+        if: runner.os == 'Windows'
+        shell: bash
+        run: git config --global core.autocrlf false
+
       - name: Checkout
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
@@ -445,6 +450,35 @@ jobs:
           # Release inputs must never move under an unchanged Kin tag.
           ref: 48c757dfda2ca6b115f32d86875c6adde587b861
           persist-credentials: false
+
+      - name: Verify canonical release input bytes
+        shell: bash
+        run: |
+          set -euo pipefail
+          node <<'NODE'
+          const childProcess = require("child_process");
+          const crypto = require("crypto");
+          const fs = require("fs");
+          const path = require("path");
+
+          const sha256 = (bytes) =>
+            crypto.createHash("sha256").update(bytes).digest("hex");
+          for (const [label, root] of [["Kin", process.cwd()], ["kin-vfs", path.join(process.cwd(), "kin-vfs")]]) {
+            const tracked = childProcess.execFileSync(
+              "git",
+              ["cat-file", "blob", "HEAD:Cargo.lock"],
+              { cwd: root }
+            );
+            const working = fs.readFileSync(path.join(root, "Cargo.lock"));
+            if (!working.equals(tracked)) {
+              throw new Error(
+                `${label} Cargo.lock working bytes ${sha256(working)} do not match ` +
+                `tracked Git bytes ${sha256(tracked)}; refusing platform-specific release provenance`
+              );
+            }
+            console.log(`Verified canonical ${label} Cargo.lock bytes: ${sha256(tracked)}`);
+          }
+          NODE
 
       - name: Cache Cargo registry and build artifacts
         uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.0.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,8 +43,8 @@ release path fails closed on artifact provenance.
   the first batch.
 - Release automation now binds Windows checksums to exact archives, gates GitHub Latest
   on anonymous install proof and automatically published, provenance-verified npm
-  packages, validates the public Homebrew formula outcome, and attests the immutable
-  daemon image.
+  packages, preserves tracked lockfile bytes across operating systems, validates the
+  public Homebrew formula outcome, and attests the immutable daemon image.
 
 ## [0.2.15] - 2026-07-08
 

--- a/scripts/test-release-workflow-authority.py
+++ b/scripts/test-release-workflow-authority.py
@@ -35,6 +35,7 @@ def main() -> None:
             )
 
     release = RELEASE.read_text(encoding="utf-8")
+    ci_workflow = (WORKFLOWS / "ci.yml").read_text(encoding="utf-8")
     installer_callback = INSTALLER_CALLBACK.read_text(encoding="utf-8")
     docker_workflow = (WORKFLOWS / "docker.yml").read_text(encoding="utf-8")
     if "workflow_dispatch:" in release:
@@ -213,6 +214,51 @@ def main() -> None:
         "EXPECTED_SOURCE_DIGEST: ${{ needs.build_daemon_image.outputs.digest }}",
         "release daemon image promotion",
     )
+
+    build_start = release.index("  build:")
+    build_end = release.index("\n  notarize_linux:", build_start)
+    build_job = release[build_start:build_end]
+    windows_bytes = build_job.index("      - name: Preserve tracked bytes on Windows")
+    checkout = build_job.index("      - name: Checkout\n")
+    vfs_checkout = build_job.index("      - name: Checkout kin-vfs")
+    lock_assertion = build_job.index(
+        "      - name: Verify canonical release input bytes"
+    )
+    first_compile = build_job.index("      - name: Build kin-cli + kin-daemon (native)")
+    if not windows_bytes < checkout < vfs_checkout < lock_assertion < first_compile:
+        raise AssertionError(
+            "release build must disable Windows conversion before checkout and verify "
+            "both tracked lockfiles before compilation"
+        )
+    for policy in (
+        "if: runner.os == 'Windows'",
+        "git config --global core.autocrlf false",
+        '["cat-file", "blob", "HEAD:Cargo.lock"]',
+        '[["Kin", process.cwd()], ["kin-vfs", path.join(process.cwd(), "kin-vfs")]]',
+        "if (!working.equals(tracked))",
+        "refusing platform-specific release provenance",
+    ):
+        require(build_job, policy, "cross-platform release lockfile authority")
+
+    windows_start = ci_workflow.index("  windows-installer:")
+    windows_end = ci_workflow.index("\n  check:", windows_start)
+    windows_job = ci_workflow[windows_start:windows_end]
+    ci_windows_bytes = windows_job.index(
+        "      - name: Preserve tracked bytes on Windows"
+    )
+    ci_checkout = windows_job.index("      - uses: actions/checkout@v7")
+    if ci_windows_bytes >= ci_checkout:
+        raise AssertionError(
+            "Windows CI must disable line-ending conversion before checkout"
+        )
+    for policy in (
+        "git config --global core.autocrlf false",
+        '["cat-file", "blob", "HEAD:Cargo.lock"]',
+        "if (!workingLock.equals(trackedLock))",
+        "meta.dependency_provenance !== expectedLock",
+        "does not match tracked Git bytes",
+    ):
+        require(windows_job, policy, "Windows exact lockfile provenance regression")
 
     for obsolete in (
         ROOT / "scripts" / "promote-npm-release.sh",
@@ -408,7 +454,8 @@ def main() -> None:
 
     print(
         "release workflow authority is tag-only, protected, pinned, GCP-free, "
-        "and npm automatic through short-lived OIDC with post-public proof"
+        "cross-platform byte-canonical, and npm automatic through short-lived "
+        "OIDC with post-public proof"
     )
 
 


### PR DESCRIPTION
Summary

- disable Windows Git line-ending conversion before release and CI checkouts
- require Kin and kin-vfs Cargo.lock worktree bytes to match their tracked Git blobs before compilation
- verify Windows embedded dependency provenance against the exact tracked Cargo.lock SHA-256
- extend release authority policy coverage for the cross-platform invariant

Why

The first v0.2.16 attempt stopped safely because Windows converted both lockfiles to CRLF. The Windows artifacts were internally self-consistent but did not match the tagged LF bytes used by release aggregation.

Verification

- release workflow authority policy
- 12 automatic npm failure-injection scenarios
- 9 release ordering and npm provenance tests
- actionlint on release.yml and ci.yml
- ruff format/check
- cargo fmt
- exact current Kin and pinned kin-vfs lock hashes