### PR TITLE
Harden post-release npm and checksum verification

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -76,6 +76,7 @@ jobs:
           python3 ./scripts/test-release-workflow-authority.py
           python3 ./scripts/test_installer_parity.py
           python3 ./scripts/test-npm-automatic-release.py
+          python3 ./scripts/test-verify-npm-release.py
           node --test \
             ./scripts/release-order.test.mjs \
             ./scripts/verify-npm-attestation.test.mjs

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1072,14 +1072,21 @@ jobs:
 
       - name: Aggregate per-artifact checksums
         run: |
+          set -euo pipefail
           # Forward-compat: combine the per-artifact "*.sha256" files into a
           # single checksums-sha256.txt. Installers verify against the
           # per-artifact files, so this is published as a convenience only.
+          # PowerShell writes the Windows sidecar with CRLF; make the aggregate
+          # byte-canonical on the Linux publisher without changing any record.
           : > checksums-sha256.txt
           for f in *.tar.gz.sha256 *.zip.sha256; do
             [ -e "$f" ] || continue
-            cat "$f" >> checksums-sha256.txt
+            tr -d '\r' < "$f" >> checksums-sha256.txt
           done
+          if LC_ALL=C grep -q $'\r' checksums-sha256.txt; then
+            echo "::error::aggregate checksum file still contains carriage returns" >&2
+            exit 1
+          fi
 
       - name: Verify complete release asset inventory
         run: |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Post-release verification now waits for complete npm integrity metadata, and
+  cross-platform checksum aggregation normalizes Windows CRLF sidecars to LF.
+
 ## [0.2.16] - 2026-07-11
 
 Graph authority is more durable across long imports and daemon restarts, while

--- a/scripts/test-release-workflow-authority.py
+++ b/scripts/test-release-workflow-authority.py
@@ -240,6 +240,28 @@ def main() -> None:
     ):
         require(build_job, policy, "cross-platform release lockfile authority")
 
+    publish_start = release.index("  publish:")
+    publish_end = release.index("\n  install_proof:", publish_start)
+    publish_job = release[publish_start:publish_end]
+    aggregate_start = publish_job.index(
+        "      - name: Aggregate per-artifact checksums"
+    )
+    aggregate_end = publish_job.index(
+        "      - name: Verify complete release asset inventory", aggregate_start
+    )
+    aggregate_step = publish_job[aggregate_start:aggregate_end]
+    for policy in (
+        "set -euo pipefail",
+        "tr -d '\\r' < \"$f\" >> checksums-sha256.txt",
+        "grep -q $'\\r' checksums-sha256.txt",
+        "aggregate checksum file still contains carriage returns",
+    ):
+        require(aggregate_step, policy, "cross-platform checksum aggregate")
+    if 'cat "$f" >> checksums-sha256.txt' in aggregate_step:
+        raise AssertionError(
+            "release checksum aggregation must not preserve Windows CRLF bytes"
+        )
+
     windows_start = ci_workflow.index("  windows-installer:")
     windows_end = ci_workflow.index("\n  check:", windows_start)
     windows_job = ci_workflow[windows_start:windows_end]
@@ -341,6 +363,17 @@ def main() -> None:
         require(publisher, policy, "OIDC npm publisher")
 
     verifier = (ROOT / "scripts" / "verify-npm-release.sh").read_text(encoding="utf-8")
+    for policy in (
+        'if remote_integrity="$(printf \'%s\\n\' "$remote_dist" | node -e',
+        'typeof dist.integrity !== "string"',
+        "complete dist metadata with integrity",
+    ):
+        require(verifier, policy, "retryable npm dist metadata verifier")
+    require(
+        ci_workflow,
+        "python3 ./scripts/test-verify-npm-release.py",
+        "partial npm metadata failure-injection regression",
+    )
     for helper_name, helper in (
         ("OIDC npm publisher", publisher),
         ("anonymous npm provenance verifier", verifier),

--- a/scripts/test-verify-npm-release.py
+++ b/scripts/test-verify-npm-release.py
@@ -1,0 +1,216 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2026 Firelock, LLC
+
+"""Failure-injection regression for anonymous npm release verification."""
+
+from __future__ import annotations
+
+import base64
+import json
+import os
+import subprocess
+import tempfile
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parent.parent
+VERIFIER = ROOT / "scripts" / "verify-npm-release.sh"
+PACKAGE = "@kinlab/kin"
+VERSION = "0.2.16"
+REF = f"refs/tags/v{VERSION}"
+COMMIT = "a" * 40
+INTEGRITY_BYTES = bytes([7]) * 64
+INTEGRITY = f"sha512-{base64.b64encode(INTEGRITY_BYTES).decode()}"
+
+
+FAKE_NPM = r"""#!/usr/bin/env python3
+import base64
+import json
+import os
+import pathlib
+import sys
+
+state_path = pathlib.Path(os.environ["FAKE_NPM_STATE"])
+state = json.loads(state_path.read_text())
+args = sys.argv[1:]
+state.setdefault("commands", []).append(args)
+
+def save():
+    state_path.write_text(json.dumps(state, sort_keys=True))
+
+if args[:1] in (["pack"], ["view"], ["install"], ["audit"]):
+    if os.environ.get("NODE_AUTH_TOKEN") or os.environ.get("NPM_TOKEN"):
+        save()
+        print("fake npm detected inherited registry credentials", file=sys.stderr)
+        raise SystemExit(96)
+
+package = os.environ["FAKE_NPM_PACKAGE"]
+version = os.environ["FAKE_NPM_VERSION"]
+integrity = os.environ["FAKE_NPM_INTEGRITY"]
+commit = os.environ["FAKE_NPM_COMMIT"]
+ref = os.environ["FAKE_NPM_REF"]
+
+if args[:1] == ["pack"]:
+    destination = pathlib.Path(args[args.index("--pack-destination") + 1])
+    destination.mkdir(parents=True, exist_ok=True)
+    (destination / "fake-package.tgz").write_bytes(b"deterministic npm proof fixture")
+    save()
+    print(json.dumps([{"filename": "fake-package.tgz", "integrity": integrity}]))
+elif args[:1] == ["view"]:
+    state["view_calls"] = state.get("view_calls", 0) + 1
+    if state["view_calls"] == 1:
+        # Registry propagation can expose a non-null dist object before its SRI.
+        response = {
+            "shasum": "0123456789abcdef0123456789abcdef01234567",
+            "tarball": f"https://registry.npmjs.org/{package}/-/{version}.tgz",
+        }
+    else:
+        response = {
+            "integrity": integrity,
+            "shasum": "0123456789abcdef0123456789abcdef01234567",
+            "tarball": f"https://registry.npmjs.org/{package}/-/{version}.tgz",
+        }
+    save()
+    print(json.dumps(response))
+elif args[:1] == ["init"]:
+    save()
+    print(json.dumps({"name": "npm-proof-audit", "version": "1.0.0"}))
+elif args[:1] == ["install"]:
+    state["install_calls"] = state.get("install_calls", 0) + 1
+    save()
+elif args[:2] == ["audit", "signatures"]:
+    state["audit_calls"] = state.get("audit_calls", 0) + 1
+    digest = base64.b64decode(integrity.removeprefix("sha512-")).hex()
+    statement = {
+        "predicateType": "https://slsa.dev/provenance/v1",
+        "subject": [{
+            "name": f"pkg:npm/{package.replace('@', '%40', 1)}@{version}",
+            "digest": {"sha512": digest},
+        }],
+        "predicate": {
+            "buildDefinition": {
+                "externalParameters": {
+                    "workflow": {
+                        "repository": "https://github.com/firelock-ai/kin",
+                        "path": ".github/workflows/release.yml",
+                        "ref": ref,
+                    }
+                },
+                "resolvedDependencies": [{
+                    "uri": f"git+https://github.com/firelock-ai/kin@{ref}",
+                    "digest": {"gitCommit": commit},
+                }],
+            },
+            "runDetails": {
+                "builder": {
+                    "id": "https://github.com/actions/runner/github-hosted"
+                }
+            },
+        },
+    }
+    payload = base64.b64encode(json.dumps(statement).encode()).decode()
+    audit = {
+        "invalid": [],
+        "missing": [],
+        "verified": [{
+            "name": package,
+            "version": version,
+            "attestations": {
+                "provenance": {
+                    "predicateType": "https://slsa.dev/provenance/v1"
+                }
+            },
+            "attestationBundles": [{
+                "predicateType": "https://slsa.dev/provenance/v1",
+                "bundle": {"dsseEnvelope": {"payload": payload}},
+            }],
+        }],
+    }
+    save()
+    print(json.dumps(audit))
+else:
+    save()
+    print(f"unsupported fake npm command: {args}", file=sys.stderr)
+    raise SystemExit(98)
+"""
+
+
+FAKE_SLEEP = r"""#!/usr/bin/env python3
+import json
+import os
+import pathlib
+import sys
+
+state_path = pathlib.Path(os.environ["FAKE_NPM_STATE"])
+state = json.loads(state_path.read_text())
+state.setdefault("sleeps", []).append(sys.argv[1:])
+state_path.write_text(json.dumps(state, sort_keys=True))
+"""
+
+
+def write_executable(path: Path, body: str) -> None:
+    path.write_text(body, encoding="utf-8")
+    path.chmod(0o755)
+
+
+def main() -> None:
+    with tempfile.TemporaryDirectory() as owner:
+        tmp = Path(owner)
+        bin_dir = tmp / "bin"
+        package_dir = tmp / "package"
+        bin_dir.mkdir()
+        package_dir.mkdir()
+        write_executable(bin_dir / "npm", FAKE_NPM)
+        write_executable(bin_dir / "sleep", FAKE_SLEEP)
+        (package_dir / "package.json").write_text(
+            json.dumps({"name": PACKAGE, "version": VERSION}), encoding="utf-8"
+        )
+        state_path = tmp / "state.json"
+        state_path.write_text(json.dumps({"commands": []}), encoding="utf-8")
+
+        env = os.environ.copy()
+        env.update(
+            {
+                "PATH": f"{bin_dir}:{env['PATH']}",
+                "FAKE_NPM_STATE": str(state_path),
+                "FAKE_NPM_PACKAGE": PACKAGE,
+                "FAKE_NPM_VERSION": VERSION,
+                "FAKE_NPM_INTEGRITY": INTEGRITY,
+                "FAKE_NPM_COMMIT": COMMIT,
+                "FAKE_NPM_REF": REF,
+                "NODE_AUTH_TOKEN": "must-not-reach-registry-commands",
+                "NPM_TOKEN": "must-not-reach-registry-commands",
+            }
+        )
+        result = subprocess.run(
+            [
+                "bash",
+                str(VERIFIER),
+                PACKAGE,
+                VERSION,
+                str(package_dir),
+                REF,
+                COMMIT,
+            ],
+            cwd=ROOT,
+            env=env,
+            text=True,
+            capture_output=True,
+            check=False,
+        )
+        state = json.loads(state_path.read_text(encoding="utf-8"))
+
+    assert result.returncode == 0, result.stderr
+    assert state.get("view_calls") == 2, state
+    assert state.get("sleeps") == [["10"]], state
+    assert state.get("install_calls") == 1, state
+    assert state.get("audit_calls") == 1, state
+    assert "Verified exact npm bytes and provenance" in result.stdout
+    print(
+        "PASS: verifier retries a partial non-null npm dist object until integrity is visible"
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/verify-npm-release.sh
+++ b/scripts/verify-npm-release.sh
@@ -40,23 +40,33 @@ local_integrity="$(printf '%s\n' "$pack_json" | node -e '
 ')"
 
 remote_dist=""
+remote_integrity=""
 for attempt in $(seq 1 18); do
   remote_dist="$(env -u NODE_AUTH_TOKEN -u NPM_TOKEN NPM_CONFIG_USERCONFIG="$tmp/empty-npmrc" \
     npm view "${package}@${version}" dist --json 2>/dev/null || true)"
-  if [ -n "$remote_dist" ] && [ "$remote_dist" != "null" ]; then
+  if remote_integrity="$(printf '%s\n' "$remote_dist" | node -e '
+    let input=""; process.stdin.on("data", chunk => input += chunk); process.stdin.on("end", () => {
+      try {
+        const dist=JSON.parse(input);
+        if (!dist || Array.isArray(dist) || typeof dist !== "object"
+            || typeof dist.integrity !== "string" || dist.integrity.length === 0) {
+          process.exit(2);
+        }
+        process.stdout.write(dist.integrity);
+      } catch {
+        process.exit(2);
+      }
+    });
+  ')"; then
     break
   fi
+  remote_integrity=""
   if [ "$attempt" -eq 18 ]; then
-    echo "error: npm did not expose ${package}@${version} for identity verification" >&2
+    echo "error: npm did not expose complete dist metadata with integrity for ${package}@${version}" >&2
     exit 1
   fi
   sleep 10
 done
-remote_integrity="$(printf '%s\n' "$remote_dist" | node -e '
-  let input=""; process.stdin.on("data", chunk => input += chunk); process.stdin.on("end", () => {
-    const dist=JSON.parse(input); if (!dist.integrity) process.exit(2); process.stdout.write(dist.integrity);
-  });
-')"
 if [ "$remote_integrity" != "$local_integrity" ]; then
   echo "error: ${package}@${version} registry integrity does not match the checked-out package" >&2
   echo "local:  $local_integrity" >&2


### PR DESCRIPTION
## Summary

- keep anonymous npm verification inside its bounded retry loop until registry metadata is a valid object with integrity
- add a fake-registry failure-injection test for the non-null but incomplete npm propagation state
- normalize CRLF checksum sidecars to LF while building the cross-platform aggregate, then fail if any carriage return remains
- pin both behaviors in release-authority policy and CI

## Root causes

The npm verifier previously broke out of its retry loop for any non-null `dist` response. If npm exposed a partial object before `dist.integrity`, the subsequent parser exited under `set -e` instead of retrying.

The Windows checksum sidecar is written by PowerShell with CRLF. Concatenating it byte-for-byte on the Linux release publisher left one carriage return in `checksums-sha256.txt`.

## Verification

- `python3 scripts/test-release-workflow-authority.py`
- `python3 scripts/test-npm-automatic-release.py`
- `python3 scripts/test-verify-npm-release.py`
- `python3 scripts/test_installer_parity.py`
- `node --test scripts/release-order.test.mjs scripts/verify-npm-attestation.test.mjs`
- package tests and lint for `@kinlab/kin` and `@kinlab/kin-mcp`
- `shellcheck`, `actionlint`, Ruff format/check, Bash and Node syntax checks
- live v0.2.16 aggregate normalized locally to the exact concatenation of its five normalized sidecars
