### PR TITLE
chore(release): cut v0.2.17

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -448,7 +448,7 @@ jobs:
           repository: firelock-ai/kin-vfs
           path: kin-vfs
           # Release inputs must never move under an unchanged Kin tag.
-          ref: 48c757dfda2ca6b115f32d86875c6adde587b861
+          ref: 64d94af54cd049a54c999e20857f5eec4bcde45c
           persist-credentials: false
 
       - name: Verify canonical release input bytes
@@ -839,7 +839,7 @@ jobs:
           ARTIFACT: ${{ matrix.artifact }}
           TARGET: ${{ matrix.target }}
           VFS_TARGET: ${{ matrix.vfs_target || matrix.target }}
-          EXPECTED_VFS_COMMIT: 48c757dfda2ca6b115f32d86875c6adde587b861
+          EXPECTED_VFS_COMMIT: 64d94af54cd049a54c999e20857f5eec4bcde45c
         run: |
           set -euo pipefail
           node <<'NODE'
@@ -1054,7 +1054,7 @@ jobs:
         with:
           repository: firelock-ai/kin-vfs
           path: release-inputs/kin-vfs
-          ref: 48c757dfda2ca6b115f32d86875c6adde587b861
+          ref: 64d94af54cd049a54c999e20857f5eec4bcde45c
           persist-credentials: false
 
       - name: Download all artifacts
@@ -1112,7 +1112,7 @@ jobs:
 
       - name: Verify and aggregate release provenance
         env:
-          EXPECTED_VFS_COMMIT: 48c757dfda2ca6b115f32d86875c6adde587b861
+          EXPECTED_VFS_COMMIT: 64d94af54cd049a54c999e20857f5eec4bcde45c
         run: |
           set -euo pipefail
           node <<'NODE'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1348,6 +1348,15 @@ jobs:
   install_proof:
     name: Public Install Proof
     needs: publish
+    # publish intentionally tolerates a skipped optional notarization job. Force
+    # this reusable workflow to run after that successful publish instead of
+    # inheriting the skipped ancestor, and fail closed on every other outcome.
+    if: >-
+      ${{
+        always() &&
+        needs.publish.result == 'success' &&
+        startsWith(github.ref, 'refs/tags/v')
+      }}
     uses: ./.github/workflows/install-proof.yml
     with:
       release_tag: ${{ github.ref_name }}
@@ -1358,7 +1367,13 @@ jobs:
   npm_publish_preflight:
     name: Preflight Both npm Packages
     needs: [publish, install_proof]
-    if: ${{ always() && !failure() && !cancelled() && startsWith(github.ref, 'refs/tags/v') }}
+    if: >-
+      ${{
+        always() &&
+        needs.publish.result == 'success' &&
+        needs.install_proof.result == 'success' &&
+        startsWith(github.ref, 'refs/tags/v')
+      }}
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -1394,10 +1409,14 @@ jobs:
   publish_npm_compatibility:
     name: Publish npm Compatibility Wrapper (@kinlab/kin-mcp)
     needs: [publish, install_proof, npm_publish_preflight]
-    # publish uses always() to survive a skipped notarize_linux (the default
-    # macOS-notarytool path); mirror that guard here or GitHub transitively skips
-    # this job whenever notarize_linux is skipped.
-    if: ${{ always() && !failure() && !cancelled() && startsWith(github.ref, 'refs/tags/v') }}
+    if: >-
+      ${{
+        always() &&
+        needs.publish.result == 'success' &&
+        needs.install_proof.result == 'success' &&
+        needs.npm_publish_preflight.result == 'success' &&
+        startsWith(github.ref, 'refs/tags/v')
+      }}
     runs-on: ubuntu-latest
     environment: release
     permissions:
@@ -1450,7 +1469,14 @@ jobs:
     # Both publish jobs are mandatory. A transient failure can make one package
     # public before the other; an idempotent rerun verifies the first and
     # completes the second while GitHub Latest remains blocked.
-    if: ${{ always() && !failure() && !cancelled() && startsWith(github.ref, 'refs/tags/v') }}
+    if: >-
+      ${{
+        always() &&
+        needs.publish.result == 'success' &&
+        needs.install_proof.result == 'success' &&
+        needs.npm_publish_preflight.result == 'success' &&
+        startsWith(github.ref, 'refs/tags/v')
+      }}
     runs-on: ubuntu-latest
     environment: release
     permissions:
@@ -1500,7 +1526,14 @@ jobs:
   verify_npm_published:
     name: Verify Published npm Provenance (${{ matrix.package }})
     needs: [publish_npm_canonical, publish_npm_compatibility, version_tag_image]
-    if: ${{ always() && !failure() && !cancelled() && startsWith(github.ref, 'refs/tags/v') }}
+    if: >-
+      ${{
+        always() &&
+        needs.publish_npm_canonical.result == 'success' &&
+        needs.publish_npm_compatibility.result == 'success' &&
+        needs.version_tag_image.result == 'success' &&
+        startsWith(github.ref, 'refs/tags/v')
+      }}
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -1542,7 +1575,12 @@ jobs:
   smoke_npm_published:
     name: Anonymous Published npm Smoke (${{ matrix.package }})
     needs: verify_npm_published
-    if: ${{ always() && !failure() && !cancelled() && startsWith(github.ref, 'refs/tags/v') }}
+    if: >-
+      ${{
+        always() &&
+        needs.verify_npm_published.result == 'success' &&
+        startsWith(github.ref, 'refs/tags/v')
+      }}
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -1609,7 +1647,15 @@ jobs:
   finalize_release:
     name: Promote Proven Release
     needs: [publish, install_proof, version_tag_image, smoke_npm_published]
-    if: ${{ always() && !failure() && !cancelled() && startsWith(github.ref, 'refs/tags/v') }}
+    if: >-
+      ${{
+        always() &&
+        needs.publish.result == 'success' &&
+        needs.install_proof.result == 'success' &&
+        needs.version_tag_image.result == 'success' &&
+        needs.smoke_npm_published.result == 'success' &&
+        startsWith(github.ref, 'refs/tags/v')
+      }}
     runs-on: ubuntu-latest
     environment: release
     permissions:
@@ -1671,9 +1717,14 @@ jobs:
   publish_boundary_contracts:
     name: Post-release boundary contracts publish
     needs: [publish, install_proof, finalize_release]
-    # Mirror publish's always() guard so a skipped notarize_linux does not
-    # transitively skip this job.
-    if: ${{ always() && !failure() && !cancelled() && startsWith(github.ref, 'refs/tags/v') }}
+    if: >-
+      ${{
+        always() &&
+        needs.publish.result == 'success' &&
+        needs.install_proof.result == 'success' &&
+        needs.finalize_release.result == 'success' &&
+        startsWith(github.ref, 'refs/tags/v')
+      }}
     runs-on: ubuntu-latest
     environment: release
     # The public release is already final. This private-registry integration is
@@ -1719,12 +1770,18 @@ jobs:
   bump_homebrew:
     name: Post-release Homebrew formula update
     needs: [publish, install_proof, finalize_release]
-    # Mirror publish's always() guard so a skipped notarize_linux does not
-    # transitively skip this job.
     # The tap follows GitHub Latest, so prereleases must not enter this path.
     # Homebrew is a post-release integration and cannot atomically gate a
     # GitHub/npm release that is already public.
-    if: ${{ always() && !failure() && !cancelled() && startsWith(github.ref, 'refs/tags/v') && !contains(github.ref_name, '-') }}
+    if: >-
+      ${{
+        always() &&
+        needs.publish.result == 'success' &&
+        needs.install_proof.result == 'success' &&
+        needs.finalize_release.result == 'success' &&
+        startsWith(github.ref, 'refs/tags/v') &&
+        !contains(github.ref_name, '-')
+      }}
     runs-on: ubuntu-latest
     environment: release
     continue-on-error: true
@@ -1779,10 +1836,16 @@ jobs:
   version_tag_image:
     name: Version-tag ghcr image
     needs: [publish, install_proof, build_daemon_image, attest_daemon_image]
-    # Mirror publish's always() guard so a skipped notarize_linux does not
-    # transitively skip this job, and only tag real version-tag pushes so
-    # `:<version>` never points at an unreleased build.
-    if: ${{ always() && !failure() && !cancelled() && startsWith(github.ref, 'refs/tags/v') }}
+    # Only tag real version pushes after every direct authority input succeeds.
+    if: >-
+      ${{
+        always() &&
+        needs.publish.result == 'success' &&
+        needs.install_proof.result == 'success' &&
+        needs.build_daemon_image.result == 'success' &&
+        needs.attest_daemon_image.result == 'success' &&
+        startsWith(github.ref, 'refs/tags/v')
+      }}
     runs-on: ubuntu-latest
     environment: release
     # Least privilege: read the repo (to peel the tag to its commit) and push

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -248,7 +248,13 @@ jobs:
   attest_daemon_image:
     name: Attest immutable daemon image
     needs: [config, build_daemon_image]
-    if: ${{ always() && !failure() && !cancelled() && startsWith(github.ref, 'refs/tags/v') }}
+    if: >-
+      ${{
+        always() &&
+        needs.config.result == 'success' &&
+        needs.build_daemon_image.result == 'success' &&
+        startsWith(github.ref, 'refs/tags/v')
+      }}
     runs-on: ubuntu-latest
     environment: release
     permissions:
@@ -1030,12 +1036,29 @@ jobs:
 
   publish:
     name: Publish Release
-    needs: [build, notarize_linux, attest_daemon_image]
-    # notarize_linux is skipped on the default (macOS notarytool) path; publish
-    # must still run then, but must NOT run if notarization actually failed or
-    # was cancelled. `always() && !failure() && !cancelled()` lets a skipped
-    # dependency through while still gating on a real Linux-notarize failure.
-    if: ${{ always() && !failure() && !cancelled() && github.ref_type == 'tag' }}
+    needs: [config, build, notarize_linux, attest_daemon_image]
+    # A skipped Linux notarization job is admissible only when the reviewed
+    # config selected native macOS notarytool. Every other direct authority
+    # input must report an exact successful result before the first public
+    # GitHub Release write is allowed.
+    if: >-
+      ${{
+        always() &&
+        needs.config.result == 'success' &&
+        needs.build.result == 'success' &&
+        needs.attest_daemon_image.result == 'success' &&
+        (
+          (
+            needs.config.outputs.notarize_on_linux == 'true' &&
+            needs.notarize_linux.result == 'success'
+          ) ||
+          (
+            needs.config.outputs.notarize_on_linux == 'false' &&
+            needs.notarize_linux.result == 'skipped'
+          )
+        ) &&
+        github.ref_type == 'tag'
+      }}
     runs-on: ubuntu-latest
     environment: release
     permissions:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,8 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.2.17] - 2026-07-11
+
+This patch restores the promised graph-backed filesystem bridge and tightens the
+automatic release verifier without changing Kin's public CLI surface.
+
 ### Fixed
 
+- `kin-vfs` now translates intercepted host paths into repo-relative graph keys before
+  daemon requests, preserves launcher-verified canonical and lexical workspace roots,
+  and rejects traversal, containment, or alias ambiguity from graph authority.
 - Post-release verification now waits for complete npm integrity metadata, and
   cross-platform checksum aggregation normalizes Windows CRLF sidecars to LF.
 
@@ -476,7 +484,8 @@ Historical note: this snapshot predates the public GitHub prerelease series and 
 - Daemon mode for background file watching (`kin-daemon`)
 - 19-crate workspace architecture
 
-[unreleased]: https://github.com/firelock-ai/kin/compare/v0.2.16...HEAD
+[unreleased]: https://github.com/firelock-ai/kin/compare/v0.2.17...HEAD
+[0.2.17]: https://github.com/firelock-ai/kin/compare/v0.2.16...v0.2.17
 [0.2.16]: https://github.com/firelock-ai/kin/compare/v0.2.15...v0.2.16
 [0.2.1]: https://github.com/firelock-ai/kin/compare/v0.2.0...v0.2.1
 [0.2.0]: https://github.com/firelock-ai/kin/compare/v0.1.0-alpha.25...v0.2.0

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3039,14 +3039,14 @@ dependencies = [
 
 [[package]]
 name = "kin-buildinfo"
-version = "0.2.16"
+version = "0.2.17"
 dependencies = [
  "sha2 0.11.0",
 ]
 
 [[package]]
 name = "kin-cli"
-version = "0.2.16"
+version = "0.2.17"
 dependencies = [
  "age",
  "anyhow",
@@ -3114,7 +3114,7 @@ dependencies = [
 
 [[package]]
 name = "kin-context"
-version = "0.2.16"
+version = "0.2.17"
 dependencies = [
  "kin-blobs",
  "kin-db",
@@ -3130,7 +3130,7 @@ dependencies = [
 
 [[package]]
 name = "kin-core"
-version = "0.2.16"
+version = "0.2.17"
 dependencies = [
  "chrono",
  "directories 5.0.1",
@@ -3154,7 +3154,7 @@ dependencies = [
 
 [[package]]
 name = "kin-daemon"
-version = "0.2.16"
+version = "0.2.17"
 dependencies = [
  "async-stream",
  "axum",
@@ -3244,7 +3244,7 @@ dependencies = [
 
 [[package]]
 name = "kin-git"
-version = "0.2.16"
+version = "0.2.17"
 dependencies = [
  "chrono",
  "gix",
@@ -3262,7 +3262,7 @@ dependencies = [
 
 [[package]]
 name = "kin-index"
-version = "0.2.16"
+version = "0.2.17"
 dependencies = [
  "hex",
  "kin-blobs",
@@ -3310,7 +3310,7 @@ dependencies = [
 
 [[package]]
 name = "kin-integration-tests"
-version = "0.2.16"
+version = "0.2.17"
 dependencies = [
  "kin-blobs",
  "kin-cli",
@@ -3352,7 +3352,7 @@ dependencies = [
 
 [[package]]
 name = "kin-mcp"
-version = "0.2.16"
+version = "0.2.17"
 dependencies = [
  "kin-blobs",
  "kin-context",
@@ -3379,7 +3379,7 @@ dependencies = [
 
 [[package]]
 name = "kin-migrate"
-version = "0.2.16"
+version = "0.2.17"
 dependencies = [
  "chrono",
  "kin-blobs",
@@ -3421,7 +3421,7 @@ dependencies = [
 
 [[package]]
 name = "kin-parser"
-version = "0.2.16"
+version = "0.2.17"
 dependencies = [
  "kin-model",
  "pretty_assertions",
@@ -3451,7 +3451,7 @@ dependencies = [
 
 [[package]]
 name = "kin-projection"
-version = "0.2.16"
+version = "0.2.17"
 dependencies = [
  "kin-blobs",
  "kin-db",
@@ -3466,7 +3466,7 @@ dependencies = [
 
 [[package]]
 name = "kin-ranking"
-version = "0.2.16"
+version = "0.2.17"
 dependencies = [
  "kin-model",
  "serde",
@@ -3475,7 +3475,7 @@ dependencies = [
 
 [[package]]
 name = "kin-reconcile"
-version = "0.2.16"
+version = "0.2.17"
 dependencies = [
  "kin-blobs",
  "kin-db",
@@ -3495,7 +3495,7 @@ dependencies = [
 
 [[package]]
 name = "kin-registry"
-version = "0.2.16"
+version = "0.2.17"
 dependencies = [
  "axum",
  "base64 0.22.1",
@@ -3520,7 +3520,7 @@ dependencies = [
 
 [[package]]
 name = "kin-remote"
-version = "0.2.16"
+version = "0.2.17"
 dependencies = [
  "chrono",
  "kin-model",
@@ -3536,7 +3536,7 @@ dependencies = [
 
 [[package]]
 name = "kin-review"
-version = "0.2.16"
+version = "0.2.17"
 dependencies = [
  "kin-blobs",
  "kin-db",
@@ -3552,7 +3552,7 @@ dependencies = [
 
 [[package]]
 name = "kin-runtime"
-version = "0.2.16"
+version = "0.2.17"
 dependencies = [
  "chrono",
  "hex",
@@ -3584,7 +3584,7 @@ dependencies = [
 
 [[package]]
 name = "kin-semantic-contracts"
-version = "0.2.16"
+version = "0.2.17"
 dependencies = [
  "kin-db",
  "kin-model",
@@ -3599,7 +3599,7 @@ dependencies = [
 
 [[package]]
 name = "kin-spine"
-version = "0.2.16"
+version = "0.2.17"
 dependencies = [
  "chrono",
  "hashbrown 0.15.5",
@@ -3637,9 +3637,9 @@ dependencies = [
 
 [[package]]
 name = "kin-vfs-core"
-version = "0.1.3"
+version = "0.1.4"
 source = "sparse+https://kinlab.ai/registry/cargo/"
-checksum = "53c4139066ae6384a2939b87634cf0ce9ca772821936c8f8d641376ed9fa8b7a"
+checksum = "2fbdfd41caf204a56ab7f6153cc9c9199a02c01a37b932d494fbbb506d85d644"
 dependencies = [
  "lru",
  "parking_lot",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,7 +27,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.2.16"
+version = "0.2.17"
 edition = "2021"
 license = "Apache-2.0"
 authors = ["Troy Fortin <troy@firelock.ai>"]
@@ -144,7 +144,7 @@ kin-lsp = { version = "0.2.2", registry = "kin" }
 # additively on macOS via a `[target.'cfg(target_os = "macos")'.dependencies]` block in the
 # binary/runtime crates (kin-cli, kin-daemon). Feature unification makes that additive.
 kin-db = { version = "0.2.35", registry = "kin", default-features = false }
-kin-vfs-core = { version = "0.1.3", registry = "kin" }
+kin-vfs-core = { version = "0.1.4", registry = "kin" }
 
 [profile.release]
 opt-level = 3

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 > AI made code cheap to write and expensive to trust.
 
 [![License: Apache-2.0](https://img.shields.io/badge/license-Apache--2.0-blue.svg)](LICENSE)
-[![Release](https://img.shields.io/badge/release-v0.2.16-6E56CF.svg)](https://github.com/firelock-ai/kin/releases)
+[![Release](https://img.shields.io/badge/release-v0.2.17-6E56CF.svg)](https://github.com/firelock-ai/kin/releases)
 [![kinlab.ai](https://img.shields.io/badge/hosted-kinlab.ai-111111.svg)](https://kinlab.ai)
 
 AI agents now generate code faster than teams can review it. The hard part is no longer
@@ -37,7 +37,7 @@ real blast radius of a merge is.
 ## Install
 
 Kin ships as native binaries on [GitHub Releases](https://github.com/firelock-ai/kin/releases)
-(currently **v0.2.16**) for five targets: macOS (Apple Silicon and Intel), Linux (x86_64 and
+(currently **v0.2.17**) for five targets: macOS (Apple Silicon and Intel), Linux (x86_64 and
 aarch64, static musl), and Windows (x86_64, supported for the vector-free surface described below).
 
 **Direct download.** Grab the archive for your platform, verify its checksum, and extract.
@@ -45,8 +45,8 @@ The release publishes a `.sha256` next to every archive.
 
 ```sh
 # Apple Silicon macOS shown; swap in your platform's archive name.
-curl -fsSLO https://github.com/firelock-ai/kin/releases/download/v0.2.16/kin-macos-aarch64.tar.gz
-curl -fsSLO https://github.com/firelock-ai/kin/releases/download/v0.2.16/kin-macos-aarch64.tar.gz.sha256
+curl -fsSLO https://github.com/firelock-ai/kin/releases/download/v0.2.17/kin-macos-aarch64.tar.gz
+curl -fsSLO https://github.com/firelock-ai/kin/releases/download/v0.2.17/kin-macos-aarch64.tar.gz.sha256
 shasum -a 256 -c kin-macos-aarch64.tar.gz.sha256
 tar xzf kin-macos-aarch64.tar.gz      # contains the `kin` and `kin-daemon` binaries
 ```
@@ -70,7 +70,7 @@ complete vector-enabled/projection experience, install under WSL2 — see
 
 **For AI agents.** `kin setup --intent agent` wires Kin's built-in MCP server into every
 detected assistant with the curated `agent-default` tool profile. npm users can install the
-canonical launcher with `npm install -g @kinlab/kin` (**0.2.16**) and run the same setup
+canonical launcher with `npm install -g @kinlab/kin` (**0.2.17**) and run the same setup
 command; the older `@kinlab/kin-mcp` package remains as a compatibility wrapper.
 
 See [docs/quickstart.md](docs/quickstart.md) for installer environment variables

--- a/packages/boundary-contracts/package.json
+++ b/packages/boundary-contracts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kin/boundary-contracts",
-  "version": "0.2.16",
+  "version": "0.2.17",
   "private": false,
   "description": "Shared contracts for Kin ecosystem boundaries.",
   "type": "module",

--- a/packages/kin-mcp/package.json
+++ b/packages/kin-mcp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kinlab/kin-mcp",
-  "version": "0.2.16",
+  "version": "0.2.17",
   "description": "Start Kin's MCP server — the system of record for AI-written software — through an npm-friendly wrapper.",
   "type": "module",
   "bin": {

--- a/packages/kin/package.json
+++ b/packages/kin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kinlab/kin",
-  "version": "0.2.16",
+  "version": "0.2.17",
   "description": "Canonical installer and launcher for Kin, the system of record for AI-written software — provisions and runs the managed kin + kin-daemon release. MCP is one included mode (kin mcp start).",
   "license": "Apache-2.0",
   "type": "module",

--- a/scripts/test-npm-automatic-release.py
+++ b/scripts/test-npm-automatic-release.py
@@ -16,9 +16,9 @@ from pathlib import Path
 ROOT = Path(__file__).resolve().parent.parent
 SCRIPTS = ROOT / "scripts"
 PUBLISHER = SCRIPTS / "publish-npm-release.sh"
-VERSION = "0.2.16"
-OLD_VERSION = "0.2.15"
-NEWER_VERSION = "0.2.17"
+VERSION = "0.2.17"
+OLD_VERSION = "0.2.16"
+NEWER_VERSION = "0.2.18"
 REF = f"refs/tags/v{VERSION}"
 PACKAGE = "@kinlab/kin"
 OTHER_PACKAGE = "@kinlab/kin-mcp"
@@ -417,7 +417,7 @@ def test_symlinked_checkout_runs_channel_and_rollback_preflight() -> None:
     assert result.returncode == 0, result.stderr
     assert snapshot.get("channel_reads") == 1
     assert snapshot.get("rollback_checks") == 1
-    assert "latest=0.2.15" in result.stdout
+    assert "latest=0.2.16" in result.stdout
     assert "no registry mutation performed" in result.stdout
     assert not any(command[:1] == ["publish"] for command in snapshot["commands"])
     print("PASS: symlinked checkout executes channel and rollback preflight")
@@ -504,7 +504,7 @@ def test_newer_channel_during_publish_blocks_finalization() -> None:
     actual = json.loads(snapshot["state.json"])
     assert VERSION in actual["public"][PACKAGE]
     assert actual["tags"][PACKAGE]["latest"] == NEWER_VERSION
-    assert "resolves to 0.2.17" in result.stderr
+    assert "resolves to 0.2.18" in result.stderr
     assert "GitHub Latest remains blocked" in result.stderr
     assert "verify.json" in snapshot
     print("PASS: concurrent channel advancement leaves GitHub Latest blocked")

--- a/scripts/test-release-workflow-authority.py
+++ b/scripts/test-release-workflow-authority.py
@@ -299,6 +299,8 @@ def main() -> None:
     npm_preflight = release[preflight_start:preflight_end]
     for policy in (
         "needs: [publish, install_proof]",
+        "needs.publish.result == 'success'",
+        "needs.install_proof.result == 'success'",
         "npm test --prefix ./packages/kin",
         "npm test --prefix ./packages/kin-mcp",
         "for package_dir in ./packages/kin ./packages/kin-mcp",
@@ -322,6 +324,9 @@ def main() -> None:
         publish_job = release[start:end]
         for policy in (
             "needs: [publish, install_proof, npm_publish_preflight]",
+            "needs.publish.result == 'success'",
+            "needs.install_proof.result == 'success'",
+            "needs.npm_publish_preflight.result == 'success'",
             "environment: release",
             "id-token: write",
             "npm@11.15.0",
@@ -329,6 +334,60 @@ def main() -> None:
             package_dir,
         ):
             require(publish_job, policy, f"{job} trusted publishing")
+
+    install_proof_start = release.index("  install_proof:")
+    install_proof_end = release.index(
+        "\n  npm_publish_preflight:", install_proof_start
+    )
+    install_proof_job = release[install_proof_start:install_proof_end]
+    for policy in (
+        "needs: publish",
+        "always()",
+        "needs.publish.result == 'success'",
+        "uses: ./.github/workflows/install-proof.yml",
+    ):
+        require(install_proof_job, policy, "mandatory public install proof")
+
+    exact_result_gates = {
+        "verify_npm_published": (
+            "needs.publish_npm_canonical.result == 'success'",
+            "needs.publish_npm_compatibility.result == 'success'",
+            "needs.version_tag_image.result == 'success'",
+        ),
+        "smoke_npm_published": (
+            "needs.verify_npm_published.result == 'success'",
+        ),
+        "finalize_release": (
+            "needs.publish.result == 'success'",
+            "needs.install_proof.result == 'success'",
+            "needs.version_tag_image.result == 'success'",
+            "needs.smoke_npm_published.result == 'success'",
+        ),
+        "publish_boundary_contracts": (
+            "needs.publish.result == 'success'",
+            "needs.install_proof.result == 'success'",
+            "needs.finalize_release.result == 'success'",
+        ),
+        "bump_homebrew": (
+            "needs.publish.result == 'success'",
+            "needs.install_proof.result == 'success'",
+            "needs.finalize_release.result == 'success'",
+        ),
+        "version_tag_image": (
+            "needs.publish.result == 'success'",
+            "needs.install_proof.result == 'success'",
+            "needs.build_daemon_image.result == 'success'",
+            "needs.attest_daemon_image.result == 'success'",
+        ),
+    }
+    for job, policies in exact_result_gates.items():
+        start = release.index(f"  {job}:")
+        match = re.search(r"(?m)^  [a-zA-Z0-9_]+:\s*$", release[start + 3 :])
+        end = start + 3 + match.start() if match else len(release)
+        job_body = release[start:end]
+        require(job_body, "always()", f"{job} exact result admission")
+        for policy in policies:
+            require(job_body, policy, f"{job} exact result admission")
 
     for policy in (
         "needs: [publish_npm_canonical, publish_npm_compatibility, version_tag_image]",

--- a/scripts/test-release-workflow-authority.py
+++ b/scripts/test-release-workflow-authority.py
@@ -158,6 +158,9 @@ def main() -> None:
     attestation_job = release[attestation_start:attestation_end]
     for policy in (
         "needs: [config, build_daemon_image]",
+        "always()",
+        "needs.config.result == 'success'",
+        "needs.build_daemon_image.result == 'success'",
         "environment: release",
         "packages: write",
         "id-token: write",
@@ -199,11 +202,27 @@ def main() -> None:
             "release daemon path must contain exactly one image build command"
         )
 
-    require(
-        release,
-        "needs: [build, notarize_linux, attest_daemon_image]",
-        "public release daemon attestation gate",
-    )
+    publish_start = release.index("  publish:")
+    publish_end = release.index("\n  install_proof:", publish_start)
+    publish_job = release[publish_start:publish_end]
+    for policy in (
+        "needs: [config, build, notarize_linux, attest_daemon_image]",
+        "always()",
+        "needs.config.result == 'success'",
+        "needs.build.result == 'success'",
+        "needs.attest_daemon_image.result == 'success'",
+        "needs.config.outputs.notarize_on_linux == 'true'",
+        "needs.notarize_linux.result == 'success'",
+        "needs.config.outputs.notarize_on_linux == 'false'",
+        "needs.notarize_linux.result == 'skipped'",
+    ):
+        require(publish_job, policy, "first GitHub Release write admission")
+    for forbidden in ("!failure()", "!cancelled()"):
+        if forbidden in publish_job:
+            raise AssertionError(
+                "first GitHub Release write must use exact direct-needs results, "
+                f"not permissive aggregate state: {forbidden}"
+            )
     require(
         release,
         "needs: [publish, install_proof, build_daemon_image, attest_daemon_image]",
@@ -240,9 +259,6 @@ def main() -> None:
     ):
         require(build_job, policy, "cross-platform release lockfile authority")
 
-    publish_start = release.index("  publish:")
-    publish_end = release.index("\n  install_proof:", publish_start)
-    publish_job = release[publish_start:publish_end]
     aggregate_start = publish_job.index(
         "      - name: Aggregate per-artifact checksums"
     )

--- a/scripts/test-verify-npm-release.py
+++ b/scripts/test-verify-npm-release.py
@@ -17,7 +17,7 @@ from pathlib import Path
 ROOT = Path(__file__).resolve().parent.parent
 VERIFIER = ROOT / "scripts" / "verify-npm-release.sh"
 PACKAGE = "@kinlab/kin"
-VERSION = "0.2.16"
+VERSION = "0.2.17"
 REF = f"refs/tags/v{VERSION}"
 COMMIT = "a" * 40
 INTEGRITY_BYTES = bytes([7]) * 64

--- a/scripts/test_installer_parity.py
+++ b/scripts/test_installer_parity.py
@@ -18,7 +18,7 @@ from verify_installer_parity import (
 )
 
 
-TAG = "v0.2.16"
+TAG = "v0.2.17"
 COMMIT = "a" * 40
 INSTALL = b"#!/bin/sh\necho kin\n"
 INSTALL_PS1 = b'Write-Output "Kin"\n'
@@ -65,7 +65,7 @@ class InstallerParityTests(unittest.TestCase):
 
     def test_manifest_must_bind_exact_tag(self) -> None:
         wrong = json.loads(manifest())
-        wrong["tag"] = "v0.2.15"
+        wrong["tag"] = "v0.2.16"
         with self.assertRaisesRegex(ParityError, "current.json tag"):
             self.verify(public_manifest=json.dumps(wrong).encode())
 

--- a/scripts/verify_installer_parity.py
+++ b/scripts/verify_installer_parity.py
@@ -174,7 +174,7 @@ def resolve_tag(repository: str, tag: str) -> str:
 
 def main() -> int:
     parser = argparse.ArgumentParser(description=__doc__)
-    parser.add_argument("tag", help="Exact stable release tag, for example v0.2.16")
+    parser.add_argument("tag", help="Exact stable release tag, for example v0.2.17")
     parser.add_argument("--expected-sha", help="Optional expected peeled 40-hex commit")
     parser.add_argument("--repository", default=DEFAULT_REPOSITORY)
     parser.add_argument("--base-url", default=DEFAULT_BASE_URL)


### PR DESCRIPTION
## Summary

- bump Kin, its workspace crates, and the canonical npm packages to 0.2.17
- consume registry-published `kin-vfs-core@0.1.4` with exact checksum `2fbdfd41caf204a56ab7f6153cc9c9199a02c01a37b932d494fbbb506d85d644`
- pin all release and provenance checkouts to reviewed kin-vfs main commit `64d94af54cd049a54c999e20857f5eec4bcde45c`
- document the restored graph-backed host-path bridge and keep the claim limited to graph authority
- advance automatic npm and installer verification fixtures to 0.2.17
- force the public install proof to run after the intentionally optional notarization path and require exact successful outcomes at every downstream release gate

## Evidence before PR

- kin-vfs PR 30 merged with reviewed tree identity, full hosted/local/release-clean gates, and 10/10 real-daemon bridge proof
- kin-vfs Registry Publish run 29173550633 passed publish, fresh-consumer, checksum, provenance, and downstream notification
- detached patch-free lock generation and `cargo check --locked --workspace --all-targets` passed outside `$HOME`
- lock diff is limited to 20 workspace versions plus `kin-vfs-core` 0.1.4 source/checksum; no unrelated dependency movement
- full local fmt, clippy with warnings denied, all-target build, and workspace tests passed
- release intent, npm automatic-release failure injection, npm verifier, installer parity, actionlint, and release-authority tests pass
- the v0.2.16 release proves both npm Trusted Publisher identities can perform direct OIDC publication with signed provenance; the v0.2.17 path adds the exact-result gate regression

## Release sequence

This PR does not publish by itself. After exact-head review and all hosted/post-merge gates pass, the captain will create annotated tag `v0.2.17` on the reviewed main merge commit. The protected release workflow will publish both public npm packages automatically through npm Trusted Publishing/OIDC only after the five-OS public install proof succeeds. GitHub Latest remains blocked until public release assets, install proof, both npm byte/provenance/install proofs, and the immutable GHCR version tag all succeed.

Homebrew and the separate public installer mirrors are post-release integrations and cannot atomically gate GitHub Latest in the current architecture. The captain will require both live outcomes before broad announcement. The automatic installer callback is not armed in repository administration, so v0.2.17 will use the already-proven KinInfra break-glass workflow and then verify public parity.

## Claims not being made

- no public v0.2.17 artifact exists until the protected tag workflow succeeds
- Homebrew or installer completion is not being represented as a GitHub Latest prerequisite
- no standalone kin-vfs tag is being created
- KinLab production promotion is not part of this PR