### PR TITLE
fix: restore cross-platform release proof for v0.2.18

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -174,6 +174,37 @@ jobs:
           }
           NODE
 
+      - name: Reopen a fresh Windows graph through the daemon
+        shell: bash
+        run: |
+          set -euo pipefail
+          trap 'taskkill.exe /F /IM kin-daemon.exe >/dev/null 2>&1 || true' EXIT
+          bin_dir="$GITHUB_WORKSPACE/target/x86_64-pc-windows-msvc/release"
+          export PATH="$bin_dir:$PATH"
+          repo_dir="$RUNNER_TEMP/kin-windows-daemon-reopen"
+          mkdir -p "$repo_dir"
+          cd "$repo_dir"
+          git init -q
+          git config user.email ci@firelock.ai
+          git config user.name ci
+          printf 'fn probe() {}\n' > probe.rs
+          git add probe.rs
+          git commit -qm "probe"
+          kin.exe init > kin-init.txt
+          kin.exe status --json > kin-status.json
+          node <<'NODE'
+          const fs = require("fs");
+          const status = JSON.parse(fs.readFileSync("kin-status.json", "utf8"));
+          if (status.build?.daemon_source_known !== true) {
+            throw new Error("Windows status did not return known daemon build provenance");
+          }
+          if (status.semantic_coverage?.supported !== false) {
+            throw new Error("Windows vector-free daemon reported semantic vectors as supported");
+          }
+          NODE
+          test -s .kin/kindb/head-generation
+          test -s .kin/kindb/graph.kidx
+
   check:
     name: Check & Test
     runs-on: ${{ matrix.os }}

--- a/.github/workflows/install-proof.yml
+++ b/.github/workflows/install-proof.yml
@@ -197,15 +197,22 @@ jobs:
           PROOF_SHELL: ${{ matrix.setup-shell }}
         run: |
           set -euo pipefail
-          case "$RUNNER_OS" in
-            Linux)
+          case "$PROOF_SHELL" in
+            bash)
               unset PSModulePath PSVersionTable
               export SHELL=/bin/bash
+              printf 'SHELL=%s\n' "$SHELL" >> "$GITHUB_ENV"
               ;;
-            macOS)
+            zsh)
               unset PSModulePath PSVersionTable
               export SHELL=/bin/zsh
+              printf 'SHELL=%s\n' "$SHELL" >> "$GITHUB_ENV"
               ;;
+            powershell)
+              # Windows has no Unix embedding follow-up and setup receives the
+              # explicit PowerShell choice below.
+              ;;
+            *) echo "unsupported install-proof setup shell: $PROOF_SHELL" >&2; exit 1 ;;
           esac
 
           # A fresh repo so the daemon has something to initialize against —
@@ -336,8 +343,24 @@ jobs:
         if: runner.os != 'Windows'
         shell: bash
         working-directory: kin-install-proof
+        env:
+          PROOF_SHELL: ${{ matrix.setup-shell }}
         run: |
           set -euo pipefail
+          # Every Actions step receives a fresh process environment. Reassert
+          # the shell under test here and remove ambient PowerShell markers
+          # before setup health re-detects the installed hook.
+          case "$PROOF_SHELL" in
+            bash)
+              unset PSModulePath PSVersionTable
+              export SHELL=/bin/bash
+              ;;
+            zsh)
+              unset PSModulePath PSVersionTable
+              export SHELL=/bin/zsh
+              ;;
+            *) echo "unsupported Unix install-proof shell: $PROOF_SHELL" >&2; exit 1 ;;
+          esac
           kin embed --max-seconds 300 --json | tee kin-embed.json
           kin status --json | tee kin-embedded-status.json
           kin setup status --json | tee kin-embedded-health.json
@@ -409,6 +432,10 @@ jobs:
             path,
             JSON.parse(fs.readFileSync(path, "utf8")),
           ]);
+          const nonHealthyChecks = (report) => (report.checks ?? [])
+            .filter((check) => check.status !== "healthy")
+            .map((check) => `${check.id}=${check.status}`)
+            .join(", ") || "none";
           const required = new Map([
             ["kin_binary", "healthy"],
             ["kin_daemon_binary", "healthy"],
@@ -426,7 +453,9 @@ jobs:
 
           for (const [path, report] of reports) {
             if (report.healthy !== true) {
-              throw new Error(`${path}: overall health is not true`);
+              throw new Error(
+                `${path}: overall healthy=${report.healthy}; non-healthy checks: ${nonHealthyChecks(report)}`
+              );
             }
             const checks = new Map(report.checks.map((check) => [check.id, check]));
             for (const [id, expected] of required) {
@@ -499,7 +528,11 @@ jobs:
               const report = JSON.parse(fs.readFileSync(reportPath, "utf8"));
               const readiness = report.checks?.find((check) => check.id === "semantic_query_readiness")?.status;
               if (report.healthy !== true || readiness !== "healthy") {
-                throw new Error(`${reportPath}: semantic_query_readiness is ${readiness ?? "missing"}, expected healthy`);
+                throw new Error(
+                  `${reportPath}: overall healthy=${report.healthy}; ` +
+                  `semantic_query_readiness=${readiness ?? "missing"}; ` +
+                  `non-healthy checks: ${nonHealthyChecks(report)}`
+                );
               }
             }
             const semanticSearch = JSON.parse(fs.readFileSync("kin-semantic-search.json", "utf8"));

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,29 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.2.18] - 2026-07-11
+
+This patch supersedes the quarantined v0.2.17 prerelease. It carries forward
+the graph-backed VFS bridge and release-verification hardening from that tag,
+then fixes the defects exposed by the mandatory clean-install proof.
+
+The v0.2.17 signed assets remain available for audit, but npm, GHCR version
+tags, Homebrew, installers, and GitHub Latest were never promoted. The complete
+last-stable diff is [v0.2.16...v0.2.18](https://github.com/firelock-ai/kin/compare/v0.2.16...v0.2.18).
+
+### Fixed
+
+- `kin-vfs` translates intercepted host paths into repo-relative graph keys,
+  preserves canonical and lexical workspace roots, and rejects ambiguous or
+  escaping paths before they can reach graph authority.
+- Windows daemon reopen no longer applies the Unix-only parent-directory fsync
+  primitive that caused `ERROR_ACCESS_DENIED` after loading a persisted graph.
+- Public install proof now preserves the selected Unix shell across Actions
+  steps, reports the exact unhealthy checks, and exercises a native Windows
+  init-to-daemon-reopen smoke before a release can reach npm or GitHub Latest.
+- README install links now follow the proven GitHub Latest release instead of
+  advertising an unpromoted tag.
+
 ## [0.2.17] - 2026-07-11
 
 This patch restores the promised graph-backed filesystem bridge and tightens the
@@ -484,7 +507,8 @@ Historical note: this snapshot predates the public GitHub prerelease series and 
 - Daemon mode for background file watching (`kin-daemon`)
 - 19-crate workspace architecture
 
-[unreleased]: https://github.com/firelock-ai/kin/compare/v0.2.17...HEAD
+[unreleased]: https://github.com/firelock-ai/kin/compare/v0.2.18...HEAD
+[0.2.18]: https://github.com/firelock-ai/kin/compare/v0.2.17...v0.2.18
 [0.2.17]: https://github.com/firelock-ai/kin/compare/v0.2.16...v0.2.17
 [0.2.16]: https://github.com/firelock-ai/kin/compare/v0.2.15...v0.2.16
 [0.2.1]: https://github.com/firelock-ai/kin/compare/v0.2.0...v0.2.1

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3039,14 +3039,14 @@ dependencies = [
 
 [[package]]
 name = "kin-buildinfo"
-version = "0.2.17"
+version = "0.2.18"
 dependencies = [
  "sha2 0.11.0",
 ]
 
 [[package]]
 name = "kin-cli"
-version = "0.2.17"
+version = "0.2.18"
 dependencies = [
  "age",
  "anyhow",
@@ -3114,7 +3114,7 @@ dependencies = [
 
 [[package]]
 name = "kin-context"
-version = "0.2.17"
+version = "0.2.18"
 dependencies = [
  "kin-blobs",
  "kin-db",
@@ -3130,7 +3130,7 @@ dependencies = [
 
 [[package]]
 name = "kin-core"
-version = "0.2.17"
+version = "0.2.18"
 dependencies = [
  "chrono",
  "directories 5.0.1",
@@ -3154,7 +3154,7 @@ dependencies = [
 
 [[package]]
 name = "kin-daemon"
-version = "0.2.17"
+version = "0.2.18"
 dependencies = [
  "async-stream",
  "axum",
@@ -3244,7 +3244,7 @@ dependencies = [
 
 [[package]]
 name = "kin-git"
-version = "0.2.17"
+version = "0.2.18"
 dependencies = [
  "chrono",
  "gix",
@@ -3262,7 +3262,7 @@ dependencies = [
 
 [[package]]
 name = "kin-index"
-version = "0.2.17"
+version = "0.2.18"
 dependencies = [
  "hex",
  "kin-blobs",
@@ -3310,7 +3310,7 @@ dependencies = [
 
 [[package]]
 name = "kin-integration-tests"
-version = "0.2.17"
+version = "0.2.18"
 dependencies = [
  "kin-blobs",
  "kin-cli",
@@ -3352,7 +3352,7 @@ dependencies = [
 
 [[package]]
 name = "kin-mcp"
-version = "0.2.17"
+version = "0.2.18"
 dependencies = [
  "kin-blobs",
  "kin-context",
@@ -3379,7 +3379,7 @@ dependencies = [
 
 [[package]]
 name = "kin-migrate"
-version = "0.2.17"
+version = "0.2.18"
 dependencies = [
  "chrono",
  "kin-blobs",
@@ -3421,7 +3421,7 @@ dependencies = [
 
 [[package]]
 name = "kin-parser"
-version = "0.2.17"
+version = "0.2.18"
 dependencies = [
  "kin-model",
  "pretty_assertions",
@@ -3451,7 +3451,7 @@ dependencies = [
 
 [[package]]
 name = "kin-projection"
-version = "0.2.17"
+version = "0.2.18"
 dependencies = [
  "kin-blobs",
  "kin-db",
@@ -3466,7 +3466,7 @@ dependencies = [
 
 [[package]]
 name = "kin-ranking"
-version = "0.2.17"
+version = "0.2.18"
 dependencies = [
  "kin-model",
  "serde",
@@ -3475,7 +3475,7 @@ dependencies = [
 
 [[package]]
 name = "kin-reconcile"
-version = "0.2.17"
+version = "0.2.18"
 dependencies = [
  "kin-blobs",
  "kin-db",
@@ -3495,7 +3495,7 @@ dependencies = [
 
 [[package]]
 name = "kin-registry"
-version = "0.2.17"
+version = "0.2.18"
 dependencies = [
  "axum",
  "base64 0.22.1",
@@ -3520,7 +3520,7 @@ dependencies = [
 
 [[package]]
 name = "kin-remote"
-version = "0.2.17"
+version = "0.2.18"
 dependencies = [
  "chrono",
  "kin-model",
@@ -3536,7 +3536,7 @@ dependencies = [
 
 [[package]]
 name = "kin-review"
-version = "0.2.17"
+version = "0.2.18"
 dependencies = [
  "kin-blobs",
  "kin-db",
@@ -3552,7 +3552,7 @@ dependencies = [
 
 [[package]]
 name = "kin-runtime"
-version = "0.2.17"
+version = "0.2.18"
 dependencies = [
  "chrono",
  "hex",
@@ -3584,7 +3584,7 @@ dependencies = [
 
 [[package]]
 name = "kin-semantic-contracts"
-version = "0.2.17"
+version = "0.2.18"
 dependencies = [
  "kin-db",
  "kin-model",
@@ -3599,7 +3599,7 @@ dependencies = [
 
 [[package]]
 name = "kin-spine"
-version = "0.2.17"
+version = "0.2.18"
 dependencies = [
  "chrono",
  "hashbrown 0.15.5",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,7 +27,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.2.17"
+version = "0.2.18"
 edition = "2021"
 license = "Apache-2.0"
 authors = ["Troy Fortin <troy@firelock.ai>"]

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 > AI made code cheap to write and expensive to trust.
 
 [![License: Apache-2.0](https://img.shields.io/badge/license-Apache--2.0-blue.svg)](LICENSE)
-[![Release](https://img.shields.io/badge/release-v0.2.17-6E56CF.svg)](https://github.com/firelock-ai/kin/releases)
+[![Latest release](https://img.shields.io/badge/release-latest-6E56CF.svg)](https://github.com/firelock-ai/kin/releases/latest)
 [![kinlab.ai](https://img.shields.io/badge/hosted-kinlab.ai-111111.svg)](https://kinlab.ai)
 
 AI agents now generate code faster than teams can review it. The hard part is no longer
@@ -36,8 +36,8 @@ real blast radius of a merge is.
 
 ## Install
 
-Kin ships as native binaries on [GitHub Releases](https://github.com/firelock-ai/kin/releases)
-(currently **v0.2.17**) for five targets: macOS (Apple Silicon and Intel), Linux (x86_64 and
+Kin ships as native binaries on [GitHub Releases](https://github.com/firelock-ai/kin/releases/latest)
+for five targets: macOS (Apple Silicon and Intel), Linux (x86_64 and
 aarch64, static musl), and Windows (x86_64, supported for the vector-free surface described below).
 
 **Direct download.** Grab the archive for your platform, verify its checksum, and extract.
@@ -45,8 +45,8 @@ The release publishes a `.sha256` next to every archive.
 
 ```sh
 # Apple Silicon macOS shown; swap in your platform's archive name.
-curl -fsSLO https://github.com/firelock-ai/kin/releases/download/v0.2.17/kin-macos-aarch64.tar.gz
-curl -fsSLO https://github.com/firelock-ai/kin/releases/download/v0.2.17/kin-macos-aarch64.tar.gz.sha256
+curl -fsSLO https://github.com/firelock-ai/kin/releases/latest/download/kin-macos-aarch64.tar.gz
+curl -fsSLO https://github.com/firelock-ai/kin/releases/latest/download/kin-macos-aarch64.tar.gz.sha256
 shasum -a 256 -c kin-macos-aarch64.tar.gz.sha256
 tar xzf kin-macos-aarch64.tar.gz      # contains the `kin` and `kin-daemon` binaries
 ```
@@ -70,7 +70,7 @@ complete vector-enabled/projection experience, install under WSL2 — see
 
 **For AI agents.** `kin setup --intent agent` wires Kin's built-in MCP server into every
 detected assistant with the curated `agent-default` tool profile. npm users can install the
-canonical launcher with `npm install -g @kinlab/kin` (**0.2.17**) and run the same setup
+canonical launcher with `npm install -g @kinlab/kin@latest` and run the same setup
 command; the older `@kinlab/kin-mcp` package remains as a compatibility wrapper.
 
 See [docs/quickstart.md](docs/quickstart.md) for installer environment variables

--- a/crates/kin-daemon/src/state.rs
+++ b/crates/kin-daemon/src/state.rs
@@ -24,6 +24,23 @@ use crate::session_registry::SessionCoordinator;
 pub const RECON_IDLE: u8 = 0;
 pub const RECON_PROCESSING: u8 = 1;
 
+/// Flush a directory entry after an atomic namespace update where the host
+/// supports opening directories as files. Windows rejects
+/// `std::fs::File::open(directory)` with ERROR_ACCESS_DENIED, so attempting the
+/// Unix durability primitive there prevents an otherwise healthy persisted
+/// graph from reopening at all. The file payload is still flushed before its
+/// atomic rename on every platform; only the stronger parent-directory power-
+/// loss guarantee is Unix-specific.
+#[cfg(unix)]
+fn sync_directory_metadata(path: &std::path::Path) -> std::io::Result<()> {
+    std::fs::File::open(path).and_then(|directory| directory.sync_all())
+}
+
+#[cfg(not(unix))]
+fn sync_directory_metadata(_path: &std::path::Path) -> std::io::Result<()> {
+    Ok(())
+}
+
 /// On-disk home for in-flight MCP transactions.
 ///
 /// Lives under `.kin/` (not the working tree), so it is never reconciled or
@@ -2029,9 +2046,7 @@ impl DaemonState {
             return Err(DaemonError::Io(error));
         }
         if let Some(parent) = index_path.parent() {
-            std::fs::File::open(parent)
-                .and_then(|directory| directory.sync_all())
-                .map_err(DaemonError::Io)?;
+            sync_directory_metadata(parent).map_err(DaemonError::Io)?;
         }
         self.persisted_entity_count
             .store(persisted_entity_count, Ordering::SeqCst);
@@ -2048,9 +2063,7 @@ impl DaemonState {
             Err(error) => return Err(DaemonError::Io(error)),
         }
         if let Some(parent) = index_path.parent() {
-            std::fs::File::open(parent)
-                .and_then(|directory| directory.sync_all())
-                .map_err(DaemonError::Io)?;
+            sync_directory_metadata(parent).map_err(DaemonError::Io)?;
         }
         Ok(index_path)
     }
@@ -2151,9 +2164,7 @@ impl DaemonState {
             let _ = std::fs::remove_file(&tmp_path);
             return Err(DaemonError::Io(error));
         }
-        std::fs::File::open(parent)
-            .and_then(|directory| directory.sync_all())
-            .map_err(DaemonError::Io)?;
+        sync_directory_metadata(parent).map_err(DaemonError::Io)?;
         Ok(())
     }
 
@@ -2567,6 +2578,13 @@ mod tests {
     };
     use kin_reconcile::ReconcileOutcome;
     use serde_json::json;
+
+    #[test]
+    fn directory_metadata_sync_is_portable() {
+        let directory = tempfile::tempdir().unwrap();
+        sync_directory_metadata(directory.path())
+            .expect("directory metadata sync must not reject a valid host directory");
+    }
 
     struct CleanupFailOnceBackend {
         inner: kin_db::LocalFileBackend,

--- a/packages/boundary-contracts/package.json
+++ b/packages/boundary-contracts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kin/boundary-contracts",
-  "version": "0.2.17",
+  "version": "0.2.18",
   "private": false,
   "description": "Shared contracts for Kin ecosystem boundaries.",
   "type": "module",

--- a/packages/kin-mcp/package.json
+++ b/packages/kin-mcp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kinlab/kin-mcp",
-  "version": "0.2.17",
+  "version": "0.2.18",
   "description": "Start Kin's MCP server — the system of record for AI-written software — through an npm-friendly wrapper.",
   "type": "module",
   "bin": {

--- a/packages/kin/package.json
+++ b/packages/kin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kinlab/kin",
-  "version": "0.2.17",
+  "version": "0.2.18",
   "description": "Canonical installer and launcher for Kin, the system of record for AI-written software — provisions and runs the managed kin + kin-daemon release. MCP is one included mode (kin mcp start).",
   "license": "Apache-2.0",
   "type": "module",

--- a/scripts/test-npm-automatic-release.py
+++ b/scripts/test-npm-automatic-release.py
@@ -16,9 +16,9 @@ from pathlib import Path
 ROOT = Path(__file__).resolve().parent.parent
 SCRIPTS = ROOT / "scripts"
 PUBLISHER = SCRIPTS / "publish-npm-release.sh"
-VERSION = "0.2.17"
-OLD_VERSION = "0.2.16"
-NEWER_VERSION = "0.2.18"
+VERSION = "0.2.18"
+OLD_VERSION = "0.2.17"
+NEWER_VERSION = "0.2.19"
 REF = f"refs/tags/v{VERSION}"
 PACKAGE = "@kinlab/kin"
 OTHER_PACKAGE = "@kinlab/kin-mcp"
@@ -417,7 +417,7 @@ def test_symlinked_checkout_runs_channel_and_rollback_preflight() -> None:
     assert result.returncode == 0, result.stderr
     assert snapshot.get("channel_reads") == 1
     assert snapshot.get("rollback_checks") == 1
-    assert "latest=0.2.16" in result.stdout
+    assert "latest=0.2.17" in result.stdout
     assert "no registry mutation performed" in result.stdout
     assert not any(command[:1] == ["publish"] for command in snapshot["commands"])
     print("PASS: symlinked checkout executes channel and rollback preflight")
@@ -504,7 +504,7 @@ def test_newer_channel_during_publish_blocks_finalization() -> None:
     actual = json.loads(snapshot["state.json"])
     assert VERSION in actual["public"][PACKAGE]
     assert actual["tags"][PACKAGE]["latest"] == NEWER_VERSION
-    assert "resolves to 0.2.18" in result.stderr
+    assert "resolves to 0.2.19" in result.stderr
     assert "GitHub Latest remains blocked" in result.stderr
     assert "verify.json" in snapshot
     print("PASS: concurrent channel advancement leaves GitHub Latest blocked")

--- a/scripts/test-release-workflow-authority.py
+++ b/scripts/test-release-workflow-authority.py
@@ -12,7 +12,9 @@ from pathlib import Path
 
 ROOT = Path(__file__).resolve().parent.parent
 WORKFLOWS = ROOT / ".github" / "workflows"
+README = ROOT / "README.md"
 RELEASE = WORKFLOWS / "release.yml"
+INSTALL_PROOF = WORKFLOWS / "install-proof.yml"
 INSTALLER_CALLBACK = WORKFLOWS / "publish-release-installers.yml"
 
 
@@ -35,6 +37,8 @@ def main() -> None:
             )
 
     release = RELEASE.read_text(encoding="utf-8")
+    install_proof = INSTALL_PROOF.read_text(encoding="utf-8")
+    readme = README.read_text(encoding="utf-8")
     ci_workflow = (WORKFLOWS / "ci.yml").read_text(encoding="utf-8")
     installer_callback = INSTALLER_CALLBACK.read_text(encoding="utf-8")
     docker_workflow = (WORKFLOWS / "docker.yml").read_text(encoding="utf-8")
@@ -45,6 +49,66 @@ def main() -> None:
     require(release, 'tags:\n      - "v*.*.*"', "release trigger")
     require(release, "  build_daemon_image:", "release daemon image job")
     require(release, "  attest_daemon_image:", "release daemon attestation job")
+
+    pinned_readme_version = re.search(r"\bv?\d+\.\d+\.\d+\b", readme)
+    if pinned_readme_version:
+        raise AssertionError(
+            "README must follow the proven latest release instead of pinning "
+            f"{pinned_readme_version.group(0)}"
+        )
+    for policy in (
+        "[![Latest release](https://img.shields.io/badge/release-latest-6E56CF.svg)]",
+        "https://github.com/firelock-ai/kin/releases/latest",
+        "https://github.com/firelock-ai/kin/releases/latest/download/",
+        "npm install -g @kinlab/kin@latest",
+    ):
+        require(readme, policy, "moving latest-release README reference")
+    if "img.shields.io/github/v/release" in readme:
+        raise AssertionError(
+            "README release badge must follow /releases/latest, not an unpromoted GitHub tag"
+        )
+
+    first_run_start = install_proof.index(
+        "      - name: First-run repository, daemon, and setup proof"
+    )
+    embedding_start = install_proof.index(
+        "      - name: Unix embedding and semantic retrieval proof",
+        first_run_start,
+    )
+    validation_start = install_proof.index(
+        "      - name: Validate installed capability proof",
+        embedding_start,
+    )
+    first_run = install_proof[first_run_start:embedding_start]
+    embedding = install_proof[embedding_start:validation_start]
+    for policy in (
+        'case "$PROOF_SHELL" in',
+        "export SHELL=/bin/bash",
+        "export SHELL=/bin/zsh",
+        "printf 'SHELL=%s\\n' \"$SHELL\" >> \"$GITHUB_ENV\"",
+    ):
+        require(first_run, policy, "cross-step install-proof shell pin")
+    for policy in (
+        "PROOF_SHELL: ${{ matrix.setup-shell }}",
+        'case "$PROOF_SHELL" in',
+        "unset PSModulePath PSVersionTable",
+        "export SHELL=/bin/bash",
+        "export SHELL=/bin/zsh",
+    ):
+        require(embedding, policy, "embedded-health shell reset")
+    for policy in (
+        "overall healthy=${report.healthy}",
+        "non-healthy checks: ${nonHealthyChecks(report)}",
+    ):
+        require(install_proof, policy, "actionable install-proof health failure")
+
+    for policy in (
+        "Reopen a fresh Windows graph through the daemon",
+        "kin.exe status --json > kin-status.json",
+        "test -s .kin/kindb/head-generation",
+        "test -s .kin/kindb/graph.kidx",
+    ):
+        require(ci_workflow, policy, "Windows daemon reopen regression")
 
     for policy in (
         'workflows: ["Release"]',

--- a/scripts/test-verify-npm-release.py
+++ b/scripts/test-verify-npm-release.py
@@ -17,7 +17,7 @@ from pathlib import Path
 ROOT = Path(__file__).resolve().parent.parent
 VERIFIER = ROOT / "scripts" / "verify-npm-release.sh"
 PACKAGE = "@kinlab/kin"
-VERSION = "0.2.17"
+VERSION = "0.2.18"
 REF = f"refs/tags/v{VERSION}"
 COMMIT = "a" * 40
 INTEGRITY_BYTES = bytes([7]) * 64

--- a/scripts/test_installer_parity.py
+++ b/scripts/test_installer_parity.py
@@ -18,7 +18,7 @@ from verify_installer_parity import (
 )
 
 
-TAG = "v0.2.17"
+TAG = "v0.2.18"
 COMMIT = "a" * 40
 INSTALL = b"#!/bin/sh\necho kin\n"
 INSTALL_PS1 = b'Write-Output "Kin"\n'
@@ -65,7 +65,7 @@ class InstallerParityTests(unittest.TestCase):
 
     def test_manifest_must_bind_exact_tag(self) -> None:
         wrong = json.loads(manifest())
-        wrong["tag"] = "v0.2.16"
+        wrong["tag"] = "v0.2.17"
         with self.assertRaisesRegex(ParityError, "current.json tag"):
             self.verify(public_manifest=json.dumps(wrong).encode())
 

--- a/scripts/verify_installer_parity.py
+++ b/scripts/verify_installer_parity.py
@@ -174,7 +174,7 @@ def resolve_tag(repository: str, tag: str) -> str:
 
 def main() -> int:
     parser = argparse.ArgumentParser(description=__doc__)
-    parser.add_argument("tag", help="Exact stable release tag, for example v0.2.17")
+    parser.add_argument("tag", help="Exact stable release tag, for example v0.2.18")
     parser.add_argument("--expected-sha", help="Optional expected peeled 40-hex commit")
     parser.add_argument("--repository", default=DEFAULT_REPOSITORY)
     parser.add_argument("--base-url", default=DEFAULT_BASE_URL)


### PR DESCRIPTION
## Context

Release v0.2.17 was quarantined after the mandatory public install proof failed on all five runners. Its signed assets exist for audit, but npm, GHCR version tags, Homebrew, installers, and GitHub Latest were not promoted. Failed run: https://github.com/firelock-ai/kin/actions/runs/29175301078

## Fixes

- keep Unix install-proof shell selection stable across Actions steps and report exact unhealthy checks
- replace three nonportable Windows parent-directory fsync calls with Unix-only metadata sync while preserving file flushes and atomic namespace operations
- add a native Windows init, daemon reopen, and persisted-index smoke to normal CI
- make README installation links follow the proven GitHub Latest release instead of an unpromoted tag
- cut the workspace and npm packages to v0.2.18, with transparent quarantine notes

## Verified locally

- actionlint on edited release workflows
- release authority, installer parity, npm automatic release, and npm verifier regressions
- npm tests and lint for both public packages
- cargo fmt
- exact directory portability and save/restart authority tests
- full kin-daemon suite
- registry-only lock provenance preserved; exactly 20 workspace lock entries changed to 0.2.18
- kin-vfs-core remains 0.1.4 at checksum 2fbdfd41caf204a56ab7f6153cc9c9199a02c01a37b932d494fbbb506d85d644 and all four VFS release pins remain 64d94af54cd049a54c999e20857f5eec4bcde45c

## Required before merge and release

- all hosted checks green, especially the Windows vector-free runtime smoke
- independent exact-head review
- release-clean registry-only build

After merge, v0.2.18 must pass all five public install-proof jobs before automatic npm publication or GitHub Latest promotion. This PR does not claim v0.2.18 is live.
