### PR TITLE
Automate post-release distribution follow-ups

### DIFF
--- a/.github/workflows/publish-release-installers.yml
+++ b/.github/workflows/publish-release-installers.yml
@@ -1,13 +1,14 @@
 # SPDX-License-Identifier: Apache-2.0
 # Copyright 2026 Firelock, LLC
 
-name: Dispatch Release Installers
+name: Publish Release Follow-Ups
 
 # This callback runs from reviewed default-branch workflow bytes only after the
 # tag-only Release workflow has fully completed successfully. It has no cloud
 # credential and cannot write Kin contents; its single capability is minting a
-# short-lived GitHub App token scoped to firelock-ai/kin-infra and requesting
-# the protected downstream atomic publisher.
+# short-lived GitHub App token scoped only to firelock-ai/homebrew-kin and
+# firelock-ai/kin-infra. It requests both downstream publishers and proves the
+# workflows completed before accepting either public outcome.
 on:
   workflow_run:
     workflows: ["Release"]
@@ -18,21 +19,21 @@ permissions:
   contents: read
 
 concurrency:
-  group: kin-installer-dispatch-${{ github.event.workflow_run.id }}
+  group: kin-release-follow-ups-${{ github.event.workflow_run.id }}
   cancel-in-progress: false
 
 jobs:
   dispatch:
     if: >-
-      vars.INSTALLER_DISPATCH_READY == 'true' &&
+      vars.RELEASE_FOLLOWUP_READY == 'true' &&
       github.event.workflow_run.status == 'completed' &&
       github.event.workflow_run.conclusion == 'success' &&
       github.event.workflow_run.event == 'push' &&
       startsWith(github.event.workflow_run.head_branch, 'v') &&
       !contains(github.event.workflow_run.head_branch, '-')
     runs-on: ubuntu-latest
-    timeout-minutes: 15
-    environment: installer-dispatch
+    timeout-minutes: 30
+    environment: release-followups
     env:
       SOURCE_RUN_ID: ${{ github.event.workflow_run.id }}
       KIN_TAG: ${{ github.event.workflow_run.head_branch }}
@@ -123,19 +124,47 @@ jobs:
           echo "install_sha256=$install_sha256" >> "$GITHUB_OUTPUT"
           echo "install_ps1_sha256=$install_ps1_sha256" >> "$GITHUB_OUTPUT"
 
-      - name: Mint installer-dispatch GitHub App token
+      - name: Mint release-follow-up GitHub App token
         id: app-token
         uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
         with:
-          app-id: ${{ secrets.KIN_INSTALLER_APP_ID }}
-          private-key: ${{ secrets.KIN_INSTALLER_APP_PRIVATE_KEY }}
+          app-id: ${{ secrets.KIN_RELEASE_APP_ID }}
+          private-key: ${{ secrets.KIN_RELEASE_APP_PRIVATE_KEY }}
           owner: firelock-ai
-          repositories: kin-infra
+          repositories: |
+            homebrew-kin
+            kin-infra
           permission-actions: read
           permission-contents: write
 
+      - name: Request Homebrew formula update
+        id: homebrew-dispatch
+        env:
+          DISPATCH_TOKEN: ${{ steps.app-token.outputs.token }}
+        run: |
+          set -euo pipefail
+          dispatched_at="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+          payload="$(jq -n \
+            --arg tag "$KIN_TAG" \
+            --arg sha "$KIN_SHA" \
+            --arg run_id "$SOURCE_RUN_ID" \
+            '{event_type:"kin-release",client_payload:{schema_version:1,kin_tag:$tag,kin_sha:$sha,release_workflow_run_id:$run_id}}')"
+          code="$(curl -sS -o /tmp/homebrew-dispatch-response -w '%{http_code}' \
+            -X POST \
+            -H "Authorization: Bearer ${DISPATCH_TOKEN}" \
+            -H "Accept: application/vnd.github+json" \
+            -H "X-GitHub-Api-Version: 2022-11-28" \
+            https://api.github.com/repos/firelock-ai/homebrew-kin/dispatches \
+            -d "$payload")"
+          if [ "$code" != 204 ]; then
+            echo "::error::Homebrew repository dispatch returned HTTP $code"
+            cat /tmp/homebrew-dispatch-response
+            exit 1
+          fi
+          echo "dispatched_at=$dispatched_at" >> "$GITHUB_OUTPUT"
+
       - name: Request protected atomic installer publication
-        id: dispatch
+        id: installer-dispatch
         env:
           DISPATCH_TOKEN: ${{ steps.app-token.outputs.token }}
           RELEASE_ID: ${{ steps.provenance.outputs.release_id }}
@@ -175,10 +204,57 @@ jobs:
             echo "- install.ps1: \`${INSTALL_PS1_SHA256}\`"
           } >> "$GITHUB_STEP_SUMMARY"
 
-      - name: Prove downstream activation and public byte parity
+      - name: Prove Homebrew workflow and public formula
         env:
           GH_TOKEN: ${{ steps.app-token.outputs.token }}
-          DISPATCHED_AT: ${{ steps.dispatch.outputs.dispatched_at }}
+          DISPATCHED_AT: ${{ steps.homebrew-dispatch.outputs.dispatched_at }}
+          KIN_HOMEBREW_VERIFY_MAX_WAIT_SECONDS: 900
+        run: |
+          set -euo pipefail
+          expected_title="Update formula ${KIN_TAG} from Kin run ${SOURCE_RUN_ID}"
+          downstream_id=""
+          for _ in $(seq 1 36); do
+            runs="$(gh api \
+              'repos/firelock-ai/homebrew-kin/actions/workflows/update-formula.yml/runs?event=repository_dispatch&per_page=20')"
+            downstream_id="$(jq -r \
+              --arg title "$expected_title" --arg dispatched_at "$DISPATCHED_AT" \
+              '[.workflow_runs[] | select(.display_title == $title and .created_at >= $dispatched_at)] | sort_by(.created_at) | last | .id // empty' \
+              <<< "$runs")"
+            if [ -n "$downstream_id" ]; then
+              state="$(gh api "repos/firelock-ai/homebrew-kin/actions/runs/${downstream_id}")"
+              status="$(jq -r .status <<< "$state")"
+              if [ "$status" = completed ]; then
+                [ "$(jq -r .conclusion <<< "$state")" = success ]
+                [ "$(jq -r .event <<< "$state")" = repository_dispatch ]
+                [ "$(jq -r .path <<< "$state")" = .github/workflows/update-formula.yml ]
+                [ "$(jq -r .head_branch <<< "$state")" = main ]
+                [ "$(jq -r .repository.full_name <<< "$state")" = firelock-ai/homebrew-kin ]
+                break
+              fi
+            fi
+            sleep 10
+          done
+          [ -n "$downstream_id" ] || {
+            echo "::error::no downstream Homebrew workflow run started"
+            exit 1
+          }
+          [ "${status:-}" = completed ] || {
+            echo "::error::downstream Homebrew workflow did not complete within the proof window"
+            exit 1
+          }
+
+          bash scripts/verify-homebrew-formula.sh "$KIN_TAG"
+          {
+            echo "Homebrew proof:"
+            echo ""
+            echo "- homebrew-kin run: \`${downstream_id}\`"
+            echo "- public formula version, URLs, and all four checksums match the release"
+          } >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Prove installer activation and public byte parity
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+          DISPATCHED_AT: ${{ steps.installer-dispatch.outputs.dispatched_at }}
         run: |
           set -euo pipefail
           expected_title="Publish installers ${KIN_TAG} from Kin run ${SOURCE_RUN_ID}"

--- a/.github/workflows/publish-release-installers.yml
+++ b/.github/workflows/publish-release-installers.yml
@@ -46,7 +46,7 @@ jobs:
           fetch-depth: 0
           persist-credentials: false
 
-      - name: Require exact current default-branch callback
+      - name: Require current callback authority without blocking unrelated main progress
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
@@ -54,7 +54,29 @@ jobs:
           [ "$GITHUB_REF" = refs/heads/main ]
           current="$(gh api "repos/${GITHUB_REPOSITORY}/git/ref/heads/main" --jq .object.sha)"
           [ "$(git rev-parse HEAD)" = "$GITHUB_SHA" ]
-          [ "$current" = "$GITHUB_SHA" ]
+          ancestry="$(gh api \
+            "repos/${GITHUB_REPOSITORY}/compare/${GITHUB_SHA}...${current}" \
+            --jq .status)"
+          [ "$ancestry" = ahead ] || [ "$ancestry" = identical ]
+
+          authority_paths=(
+            .github/workflows/publish-release-installers.yml
+            scripts/verify-homebrew-formula.sh
+            scripts/validate-homebrew-formula.py
+            scripts/verify_installer_parity.py
+          )
+          for path in "${authority_paths[@]}"; do
+            event_blob="$(gh api \
+              "repos/${GITHUB_REPOSITORY}/contents/${path}?ref=${GITHUB_SHA}" \
+              --jq .sha)"
+            current_blob="$(gh api \
+              "repos/${GITHUB_REPOSITORY}/contents/${path}?ref=${current}" \
+              --jq .sha)"
+            if [ "$event_blob" != "$current_blob" ]; then
+              echo "::error::callback authority changed on main after this event: ${path}"
+              exit 1
+            fi
+          done
 
       - name: Revalidate completed public release provenance
         id: provenance

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1790,69 +1790,6 @@ jobs:
           jq -nc --arg c "📦 \`@kin/boundary-contracts\` ${REF} published to the **KinLab registry**." '{content:$c}' \
             | curl -fsS -H "Content-Type: application/json" -d @- "$DISCORD_WEBHOOK_URL"
 
-  bump_homebrew:
-    name: Post-release Homebrew formula update
-    needs: [publish, install_proof, finalize_release]
-    # The tap follows GitHub Latest, so prereleases must not enter this path.
-    # Homebrew is a post-release integration and cannot atomically gate a
-    # GitHub/npm release that is already public.
-    if: >-
-      ${{
-        always() &&
-        needs.publish.result == 'success' &&
-        needs.install_proof.result == 'success' &&
-        needs.finalize_release.result == 'success' &&
-        startsWith(github.ref, 'refs/tags/v') &&
-        !contains(github.ref_name, '-')
-      }}
-    runs-on: ubuntu-latest
-    environment: release
-    continue-on-error: true
-    steps:
-      - name: Checkout
-        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
-        with:
-          persist-credentials: false
-
-      - name: Dispatch update to the homebrew-kin tap
-        env:
-          TAP_DISPATCH_TOKEN: ${{ secrets.KIN_CI_BOT_TOKEN }}
-        run: |
-          if [ -z "${TAP_DISPATCH_TOKEN:-}" ]; then
-            echo "::warning::KIN_CI_BOT_TOKEN is not configured; skipping the best-effort dispatch. The post-release formula check below still runs."
-            exit 0
-          fi
-          # Convenience dispatch: the tap also self-updates on its 6h schedule, so a
-          # failure here (e.g. a token without homebrew-kin access) warns rather than
-          # failing an already-published release. A 204 only proves GitHub accepted
-          # the POST, not that the tap's own workflow ran or bumped the formula — the
-          # step below verifies that outcome.
-          code=$(curl -sS -o /tmp/tap-dispatch.out -w '%{http_code}' -X POST \
-            -H "Authorization: Bearer ${TAP_DISPATCH_TOKEN}" \
-            -H "Accept: application/vnd.github+json" \
-            https://api.github.com/repos/firelock-ai/homebrew-kin/dispatches \
-            -d '{"event_type":"kin-release"}' || echo "000")
-          if [ "$code" = "204" ]; then
-            echo "Dispatched kin-release to firelock-ai/homebrew-kin"
-          else
-            echo "::warning::Homebrew tap dispatch returned HTTP ${code}; continuing to the post-release public formula check."
-            cat /tmp/tap-dispatch.out 2>/dev/null || true
-          fi
-
-      # The dispatch above only proves the POST was accepted, not that
-      # homebrew-kin's own workflow ran and actually bumped the formula (a
-      # prior release's dispatch reported success while the tap workflow
-      # never fired and the formula stayed stale for hours until a manual
-      # rerun). Poll the tap's published formula for the version this release
-      # actually cut, mirroring version_tag_image's bounded poll-for-outcome
-      # below rather than trusting the dispatch response as release proof.
-      - name: Verify the tap formula actually bumped to this version
-        # Dispatch is only an accelerator. Record the real public tap outcome,
-        # including when the token is absent or GitHub rejects the dispatch.
-        if: ${{ startsWith(github.ref, 'refs/tags/v') }}
-        run: |
-          bash scripts/verify-homebrew-formula.sh "$GITHUB_REF_NAME"
-
   # Promote the immutable commit image built by this release workflow so
   # operators can pin a version (`docker pull ghcr.io/firelock-ai/kin:0.2.7`).
   # No main-push workflow, GCP identity, or mutable latest tag participates.

--- a/docs/security/signing-and-update-trust.md
+++ b/docs/security/signing-and-update-trust.md
@@ -62,31 +62,35 @@ without rebuilding and never writes an implicit `latest` image.
 Hosted infrastructure may copy the exact manifest into its private registry,
 but that operation is a separately attested promotion, not a second build.
 
-The public convenience installers are also a post-release promotion, not
-mutable `main` content. After the complete tag-only Release workflow succeeds,
+The Homebrew formula and public convenience installers are post-release
+promotions, not mutable `main` content. After the complete tag-only Release
+workflow succeeds,
 [`publish-release-installers.yml`](../../.github/workflows/publish-release-installers.yml)
 revalidates the completed run, exact tag and peeled commit, published Latest
-release, and both installer hashes. It then uses a short-lived GitHub App token
-scoped only to `firelock-ai/kin-infra` to request the protected atomic
-publisher. The callback has no cloud credential. The downstream publisher
-stages immutable objects, generation-CAS activates `/install`, `/install.ps1`,
-and `/current.json`, proves all three public bytes, and restores the previous
-generations if proof fails.
+release, and both installer hashes. It then uses one short-lived GitHub App
+token scoped only to `firelock-ai/homebrew-kin` and `firelock-ai/kin-infra` to
+request both downstream updates. The callback waits for each exact correlated
+workflow run, verifies the public formula version, URLs, and all four release
+checksums, then verifies installer byte parity. It has no cloud credential. The
+downstream installer publisher stages immutable objects, generation-CAS
+activates `/install`, `/install.ps1`, and `/current.json`, proves all three
+public bytes, and restores the previous generations if proof fails.
 
-The callback runs in the `installer-dispatch` GitHub environment, admitted only
-from protected `main`. That environment holds `KIN_INSTALLER_APP_ID` and
-`KIN_INSTALLER_APP_PRIVATE_KEY`; the GitHub App must be installed only on
+The callback runs in the `release-followups` GitHub environment, admitted only
+from protected `main`. That environment holds `KIN_RELEASE_APP_ID` and
+`KIN_RELEASE_APP_PRIVATE_KEY`. The GitHub App must be installed only on
+`firelock-ai/homebrew-kin` and
 `firelock-ai/kin-infra` with repository Contents write permission, which is the
 minimum permission required to create a repository dispatch, plus Actions read
-permission so the callback can wait for and verify the exact downstream run.
+permission so the callback can wait for and verify both exact downstream runs.
 The downstream `installer` environment and its dedicated WIF identity remain a
 separate approval and authorization boundary. Missing environments, secrets, a
 disabled downstream workflow, or a non-successful Release run fail closed and
 leave the currently served installer generations unchanged.
 
-The repository variable `INSTALLER_DISPATCH_READY` must equal `true` before the
+The repository variable `RELEASE_FOLLOWUP_READY` must equal `true` before the
 callback job is admitted. Leave it unset until the environment, GitHub App,
-downstream workflow, bucket versioning, and public readback path are all
+downstream workflows, bucket versioning, and public readback paths are all
 verified; this prevents a merged workflow from creating or using an unprotected
 environment during bootstrap.
 
@@ -97,9 +101,9 @@ before an announcement or public-launch claim. The gate compares both served
 scripts with the exact peeled release commit and requires `/current.json` to
 bind the same tag, commit, hashes, and GCS generations. Even wording-only drift
 in `install.ps1` fails this gate. For the first migration to the atomic
-publisher, leave `INSTALLER_DISPATCH_READY` unset, publish the exact release via
-the protected break-glass workflow, prove parity, and only then set the variable
-to `true` for future completed-release callbacks.
+publisher, leave both readiness variables unset, publish the exact release via
+the protected break-glass workflow, prove parity, and only then set
+`RELEASE_FOLLOWUP_READY` to `true` for future completed-release callbacks.
 
 ## Three Independent Integrity Layers
 

--- a/docs/security/signing-and-update-trust.md
+++ b/docs/security/signing-and-update-trust.md
@@ -101,7 +101,7 @@ before an announcement or public-launch claim. The gate compares both served
 scripts with the exact peeled release commit and requires `/current.json` to
 bind the same tag, commit, hashes, and GCS generations. Even wording-only drift
 in `install.ps1` fails this gate. For the first migration to the atomic
-publisher, leave both readiness variables unset, publish the exact release via
+publisher, leave `RELEASE_FOLLOWUP_READY` unset, publish the exact release via
 the protected break-glass workflow, prove parity, and only then set
 `RELEASE_FOLLOWUP_READY` to `true` for future completed-release callbacks.
 

--- a/scripts/test-homebrew-release-gate.py
+++ b/scripts/test-homebrew-release-gate.py
@@ -2,7 +2,7 @@
 # SPDX-License-Identifier: Apache-2.0
 # Copyright 2026 Firelock, LLC
 
-"""Deterministic tests for the mandatory public Homebrew release gate."""
+"""Deterministic tests for the public Homebrew release follow-up proof."""
 
 from __future__ import annotations
 
@@ -18,7 +18,7 @@ SCRIPTS_DIR = Path(__file__).resolve().parent
 ROOT = SCRIPTS_DIR.parent
 VERIFIER = SCRIPTS_DIR / "verify-homebrew-formula.sh"
 VALIDATOR = SCRIPTS_DIR / "validate-homebrew-formula.py"
-WORKFLOW = ROOT / ".github/workflows/release.yml"
+WORKFLOW = ROOT / ".github/workflows/publish-release-installers.yml"
 
 FIXTURE_CHECKSUMS = {
     "kin-macos-aarch64.tar.gz": "a" * 64,
@@ -868,17 +868,14 @@ def test_release_defaults_remain_1800_seconds_and_90_attempts() -> None:
 
 def test_dispatch_result_cannot_skip_verification() -> None:
     workflow = WORKFLOW.read_text(encoding="utf-8")
-    marker = "      - name: Verify the tap formula actually bumped to this version\n"
+    marker = "      - name: Prove Homebrew workflow and public formula\n"
     start = workflow.index(marker)
     next_step = workflow.find("\n      - name:", start + len(marker))
     verification_step = workflow[start : next_step if next_step != -1 else None]
 
-    assert "startsWith(github.ref, 'refs/tags/v')" in verification_step
-    assert (
-        'bash scripts/verify-homebrew-formula.sh "$GITHUB_REF_NAME"'
-        in verification_step
-    )
-    assert "steps.dispatch.outputs" not in verification_step
+    assert 'bash scripts/verify-homebrew-formula.sh "$KIN_TAG"' in verification_step
+    assert "steps.homebrew-dispatch.outputs.dispatched_at" in verification_step
+    assert "if:" not in verification_step
     assert "TAP_DISPATCH_TOKEN" not in verification_step
 
 

--- a/scripts/test-release-workflow-authority.py
+++ b/scripts/test-release-workflow-authority.py
@@ -16,6 +16,7 @@ README = ROOT / "README.md"
 RELEASE = WORKFLOWS / "release.yml"
 INSTALL_PROOF = WORKFLOWS / "install-proof.yml"
 INSTALLER_CALLBACK = WORKFLOWS / "publish-release-installers.yml"
+UPDATE_TRUST = ROOT / "docs" / "security" / "signing-and-update-trust.md"
 
 
 def require(content: str, needle: str, context: str) -> None:
@@ -41,7 +42,13 @@ def main() -> None:
     readme = README.read_text(encoding="utf-8")
     ci_workflow = (WORKFLOWS / "ci.yml").read_text(encoding="utf-8")
     installer_callback = INSTALLER_CALLBACK.read_text(encoding="utf-8")
+    update_trust = UPDATE_TRUST.read_text(encoding="utf-8")
     docker_workflow = (WORKFLOWS / "docker.yml").read_text(encoding="utf-8")
+    if "KIN_CI_BOT_TOKEN" in release or "bump_homebrew:" in release:
+        raise AssertionError(
+            "release.yml must not use a long-lived PAT or wait on cross-repo "
+            "follow-ups before the completed-release callback can run"
+        )
     if "workflow_dispatch:" in release:
         raise AssertionError(
             "release.yml must not expose branch-selectable workflow_dispatch"
@@ -115,14 +122,14 @@ def main() -> None:
         "types: [completed]",
         "actions: read",
         "contents: read",
-        "vars.INSTALLER_DISPATCH_READY == 'true'",
+        "vars.RELEASE_FOLLOWUP_READY == 'true'",
         "github.event.workflow_run.status == 'completed'",
         "github.event.workflow_run.conclusion == 'success'",
         "github.event.workflow_run.event == 'push'",
         "startsWith(github.event.workflow_run.head_branch, 'v')",
         "!contains(github.event.workflow_run.head_branch, '-')",
-        "environment: installer-dispatch",
-        "timeout-minutes: 15",
+        "environment: release-followups",
+        "timeout-minutes: 30",
         "SOURCE_RUN_ID: ${{ github.event.workflow_run.id }}",
         "KIN_TAG: ${{ github.event.workflow_run.head_branch }}",
         "KIN_SHA: ${{ github.event.workflow_run.head_sha }}",
@@ -135,11 +142,18 @@ def main() -> None:
         'gh api "repos/${GITHUB_REPOSITORY}/releases/latest"',
         "ref: ${{ env.KIN_SHA }}",
         "actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1",
-        "secrets.KIN_INSTALLER_APP_ID",
-        "secrets.KIN_INSTALLER_APP_PRIVATE_KEY",
-        "repositories: kin-infra",
+        "secrets.KIN_RELEASE_APP_ID",
+        "secrets.KIN_RELEASE_APP_PRIVATE_KEY",
+        "repositories: |",
+        "homebrew-kin",
+        "kin-infra",
         "permission-actions: read",
         "permission-contents: write",
+        'event_type:"kin-release"',
+        "https://api.github.com/repos/firelock-ai/homebrew-kin/dispatches",
+        "Update formula ${KIN_TAG} from Kin run ${SOURCE_RUN_ID}",
+        "actions/workflows/update-formula.yml/runs?event=repository_dispatch",
+        'bash scripts/verify-homebrew-formula.sh "$KIN_TAG"',
         'event_type:"publish-install"',
         "schema_version:1",
         "release_workflow_run_id:$run_id",
@@ -150,7 +164,17 @@ def main() -> None:
         "the workflow may still be disabled",
         'python3 scripts/verify_installer_parity.py "$KIN_TAG" --expected-sha "$KIN_SHA"',
     ):
-        require(installer_callback, policy, "completed-release installer callback")
+        require(installer_callback, policy, "completed-release follow-up callback")
+
+    for policy in (
+        "`firelock-ai/homebrew-kin` and `firelock-ai/kin-infra`",
+        "`KIN_RELEASE_APP_ID`",
+        "`KIN_RELEASE_APP_PRIVATE_KEY`",
+        "`RELEASE_FOLLOWUP_READY`",
+        "Contents write permission",
+        "Actions read",
+    ):
+        require(update_trust, policy, "release follow-up trust documentation")
 
     callback_admission_start = installer_callback.index("    if: >-")
     callback_admission_end = installer_callback.index(
@@ -444,11 +468,6 @@ def main() -> None:
             "needs.smoke_npm_published.result == 'success'",
         ),
         "publish_boundary_contracts": (
-            "needs.publish.result == 'success'",
-            "needs.install_proof.result == 'success'",
-            "needs.finalize_release.result == 'success'",
-        ),
-        "bump_homebrew": (
             "needs.publish.result == 'success'",
             "needs.install_proof.result == 'success'",
             "needs.finalize_release.result == 'success'",

--- a/scripts/test-release-workflow-authority.py
+++ b/scripts/test-release-workflow-authority.py
@@ -133,6 +133,17 @@ def main() -> None:
         "SOURCE_RUN_ID: ${{ github.event.workflow_run.id }}",
         "KIN_TAG: ${{ github.event.workflow_run.head_branch }}",
         "KIN_SHA: ${{ github.event.workflow_run.head_sha }}",
+        "Require current callback authority without blocking unrelated main progress",
+        '"repos/${GITHUB_REPOSITORY}/compare/${GITHUB_SHA}...${current}"',
+        '[ "$ancestry" = ahead ] || [ "$ancestry" = identical ]',
+        "authority_paths=(",
+        ".github/workflows/publish-release-installers.yml",
+        "scripts/verify-homebrew-formula.sh",
+        "scripts/validate-homebrew-formula.py",
+        "scripts/verify_installer_parity.py",
+        '"repos/${GITHUB_REPOSITORY}/contents/${path}?ref=${GITHUB_SHA}"',
+        '"repos/${GITHUB_REPOSITORY}/contents/${path}?ref=${current}"',
+        "callback authority changed on main after this event",
         'gh api "repos/${GITHUB_REPOSITORY}/actions/runs/${SOURCE_RUN_ID}"',
         '[ "$(jq -r .status <<< "$run")" = completed ]',
         '[ "$(jq -r .conclusion <<< "$run")" = success ]',
@@ -165,6 +176,12 @@ def main() -> None:
         'python3 scripts/verify_installer_parity.py "$KIN_TAG" --expected-sha "$KIN_SHA"',
     ):
         require(installer_callback, policy, "completed-release follow-up callback")
+
+    if '[ "$current" = "$GITHUB_SHA" ]' in installer_callback:
+        raise AssertionError(
+            "the callback must tolerate unrelated forward progress on main while "
+            "pinning its runtime authority blobs"
+        )
 
     for policy in (
         "`firelock-ai/homebrew-kin` and `firelock-ai/kin-infra`",


### PR DESCRIPTION
Replaces the failed long-lived PAT Homebrew callback and the unarmed installer-only callback with one completed-release follow-up workflow. It mints a short-lived GitHub App token scoped only to homebrew-kin and kin-infra, dispatches both downstream workflows, correlates their exact runs, and verifies public Homebrew checksums plus installer byte parity. The workflow is dormant until the protected release-followups environment receives the App credentials and RELEASE_FOLLOWUP_READY is set.\n\nHomebrew dependency PR #1 and its main-authority security hotfix #2 are merged with green post-merge CI. The release-followups environment exists, is restricted to main, and intentionally has no credentials or readiness variable yet.\n\nIndependent review found and closed two HIGH findings: branch-selectable mutating Homebrew dispatch was removed, and callback admission now tolerates unrelated forward progress on main while requiring identical runtime authority blobs. Exact-fix re-review returned GO.\n\nVerification:\n- full actionlint\n- release workflow authority test\n- 49 Homebrew release gate tests\n- 7 installer parity tests\n- Python compile checks\n- live v0.2.18 Homebrew checksum proof\n- live v0.2.18 installer byte-parity proof\n- git diff --check