### PR TITLE
Document automatic release admission

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,7 +13,7 @@ permissions:
 
 # External authority boundary: repository ruleset "Protect version release
 # tags" limits v* creation/update/deletion to the release captain, while the
-# protected `release` environment admits only v* tags and requires approval.
+# protected `release` environment automatically admits only v* tags.
 # Every credential-bearing or public-write job below must keep that environment.
 # Both public npm packages trust only firelock-ai/kin + release.yml + environment
 # `release`, allow `npm publish` through short-lived OIDC, and disallow

--- a/docs/security/signing-and-update-trust.md
+++ b/docs/security/signing-and-update-trust.md
@@ -51,6 +51,12 @@ channel through protected npm Trusted Publishing with short-lived OIDC.
 Anonymous exact-byte, provenance, and install proof runs after publication.
 GitHub Latest is promoted only after both packages pass every gate.
 
+The protected `release` environment intentionally has no required reviewer.
+After the release captain creates an authorized version tag on reviewed `main`,
+the tag policy, main-ancestor check, exact Trusted Publishing identity, and
+post-publication proofs admit and verify every public release surface without a
+second manual approval.
+
 The daemon container is a separate attested subject. The protected tag workflow
 builds one exact commit-tagged image in GHCR, verifies its embedded source and
 lockfile identity, then passes that digest to a separate attestation-only job.
@@ -84,7 +90,7 @@ from protected `main`. That environment holds `KIN_RELEASE_APP_ID` and
 minimum permission required to create a repository dispatch, plus Actions read
 permission so the callback can wait for and verify both exact downstream runs.
 The downstream `installer` environment and its dedicated WIF identity remain a
-separate approval and authorization boundary. Missing environments, secrets, a
+separate cloud authorization boundary. Missing environments, secrets, a
 disabled downstream workflow, or a non-successful Release run fail closed and
 leave the currently served installer generations unchanged.
 


### PR DESCRIPTION
## Summary

- document that protected version tags enter the `release` environment without a second manual approval
- preserve the existing restricted tag authority, reviewed-main ancestry check, exact npm OIDC identity, and post-publication proof gates
- clarify that the downstream installer environment is a cloud authorization boundary, not a human approval gate

## Verification

- `actionlint .github/workflows/release.yml`
- `python3 scripts/test-release-workflow-authority.py`
- `git diff --check`

## Activation order

The repository environment is unchanged by this PR. After this exact head merges and post-merge CI is green, the release captain will remove the sole required reviewer from the existing `release` environment while preserving its `v*.*.*` tag-only deployment policy.
