### PR TITLE
chore(release): prepare v0.2.19

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,12 +7,28 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.2.19] - 2026-07-12
+
+This patch makes Python rename review fail closed on incomplete evidence, hardens
+the post-release follow-up boundary, and aligns the public OSS surface with the
+behavior and proof that Kin actually ships.
+
 ### Changed
 
+- Post-release Homebrew and installer follow-ups are consolidated behind a
+  main-only protected environment and short-lived GitHub App authority. The
+  workflow remains dormant until its credentials are installed and
+  `RELEASE_FOLLOWUP_READY` is explicitly enabled.
 - Public positioning now separates citable retrieval evidence from report-only
   review behavior and links the artifact-backed public proof package.
 - External contributions now use the documented DCO sign-off only; the
   nonfunctional base-branch CLA allowlist gate has been removed.
+
+### Fixed
+
+- Python parameter rename review now preserves declaration defaults and every
+  call-site shape. Default changes, incomplete call coverage, ambiguous receiver
+  resolution, and otherwise unproven calls remain blocking.
 
 ## [0.2.18] - 2026-07-11
 
@@ -514,7 +530,8 @@ Historical note: this snapshot predates the public GitHub prerelease series and 
 - Daemon mode for background file watching (`kin-daemon`)
 - 19-crate workspace architecture
 
-[unreleased]: https://github.com/firelock-ai/kin/compare/v0.2.18...HEAD
+[unreleased]: https://github.com/firelock-ai/kin/compare/v0.2.19...HEAD
+[0.2.19]: https://github.com/firelock-ai/kin/compare/v0.2.18...v0.2.19
 [0.2.18]: https://github.com/firelock-ai/kin/compare/v0.2.17...v0.2.18
 [0.2.17]: https://github.com/firelock-ai/kin/compare/v0.2.16...v0.2.17
 [0.2.16]: https://github.com/firelock-ai/kin/compare/v0.2.15...v0.2.16

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [0.2.19] - 2026-07-12
+## [0.2.19] - 2026-07-13
 
 This patch restores legacy graph snapshot reopening, makes Python rename review
 fail closed on incomplete evidence, hardens the post-release follow-up boundary,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,9 +9,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [0.2.19] - 2026-07-12
 
-This patch makes Python rename review fail closed on incomplete evidence, hardens
-the post-release follow-up boundary, and aligns the public OSS surface with the
-behavior and proof that Kin actually ships.
+This patch restores legacy graph snapshot reopening, makes Python rename review
+fail closed on incomplete evidence, hardens the post-release follow-up boundary,
+and aligns the public OSS surface with the behavior and proof that Kin actually
+ships.
 
 ### Changed
 
@@ -26,6 +27,10 @@ behavior and proof that Kin actually ships.
 
 ### Fixed
 
+- Daemon reopen now reads persisted graph snapshots whose positional
+  `SemanticFingerprint` records predate `equivalence_hash`; the missing field uses
+  the zero not-computed sentinel, while current six-field fingerprints preserve
+  their recorded value.
 - Python parameter rename review now preserves declaration defaults and every
   call-site shape. Default changes, incomplete call coverage, ambiguous receiver
   resolution, and otherwise unproven calls remain blocking.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3203,9 +3203,9 @@ dependencies = [
 
 [[package]]
 name = "kin-db"
-version = "0.2.35"
+version = "0.2.37"
 source = "sparse+https://kinlab.ai/registry/cargo/"
-checksum = "575441e5874da45a01d89bf45e35c5729875ba12d4a062d1bc3443e811163c0d"
+checksum = "2950735f6cc9d43efd579d2a1d34f9f7c36cc5c4b48b64e2e026ad7298fa6e87"
 dependencies = [
  "bincode",
  "bytes",
@@ -3403,9 +3403,9 @@ dependencies = [
 
 [[package]]
 name = "kin-model"
-version = "0.2.4"
+version = "0.2.5"
 source = "sparse+https://kinlab.ai/registry/cargo/"
-checksum = "3e21480583d921a38f4c1d781a76ab6e058e55e5944ca47000089f9a4236fd00"
+checksum = "f0fb9f21abc67a9f9c1374e6d8f304ca496fba96d98586fa3a8ff0ca2d5a91bd"
 dependencies = [
  "chrono",
  "hex",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3039,14 +3039,14 @@ dependencies = [
 
 [[package]]
 name = "kin-buildinfo"
-version = "0.2.18"
+version = "0.2.19"
 dependencies = [
  "sha2 0.11.0",
 ]
 
 [[package]]
 name = "kin-cli"
-version = "0.2.18"
+version = "0.2.19"
 dependencies = [
  "age",
  "anyhow",
@@ -3114,7 +3114,7 @@ dependencies = [
 
 [[package]]
 name = "kin-context"
-version = "0.2.18"
+version = "0.2.19"
 dependencies = [
  "kin-blobs",
  "kin-db",
@@ -3130,7 +3130,7 @@ dependencies = [
 
 [[package]]
 name = "kin-core"
-version = "0.2.18"
+version = "0.2.19"
 dependencies = [
  "chrono",
  "directories 5.0.1",
@@ -3154,7 +3154,7 @@ dependencies = [
 
 [[package]]
 name = "kin-daemon"
-version = "0.2.18"
+version = "0.2.19"
 dependencies = [
  "async-stream",
  "axum",
@@ -3244,7 +3244,7 @@ dependencies = [
 
 [[package]]
 name = "kin-git"
-version = "0.2.18"
+version = "0.2.19"
 dependencies = [
  "chrono",
  "gix",
@@ -3262,7 +3262,7 @@ dependencies = [
 
 [[package]]
 name = "kin-index"
-version = "0.2.18"
+version = "0.2.19"
 dependencies = [
  "hex",
  "kin-blobs",
@@ -3310,7 +3310,7 @@ dependencies = [
 
 [[package]]
 name = "kin-integration-tests"
-version = "0.2.18"
+version = "0.2.19"
 dependencies = [
  "kin-blobs",
  "kin-cli",
@@ -3352,7 +3352,7 @@ dependencies = [
 
 [[package]]
 name = "kin-mcp"
-version = "0.2.18"
+version = "0.2.19"
 dependencies = [
  "kin-blobs",
  "kin-context",
@@ -3379,7 +3379,7 @@ dependencies = [
 
 [[package]]
 name = "kin-migrate"
-version = "0.2.18"
+version = "0.2.19"
 dependencies = [
  "chrono",
  "kin-blobs",
@@ -3421,7 +3421,7 @@ dependencies = [
 
 [[package]]
 name = "kin-parser"
-version = "0.2.18"
+version = "0.2.19"
 dependencies = [
  "kin-model",
  "pretty_assertions",
@@ -3451,7 +3451,7 @@ dependencies = [
 
 [[package]]
 name = "kin-projection"
-version = "0.2.18"
+version = "0.2.19"
 dependencies = [
  "kin-blobs",
  "kin-db",
@@ -3466,7 +3466,7 @@ dependencies = [
 
 [[package]]
 name = "kin-ranking"
-version = "0.2.18"
+version = "0.2.19"
 dependencies = [
  "kin-model",
  "serde",
@@ -3475,7 +3475,7 @@ dependencies = [
 
 [[package]]
 name = "kin-reconcile"
-version = "0.2.18"
+version = "0.2.19"
 dependencies = [
  "kin-blobs",
  "kin-db",
@@ -3495,7 +3495,7 @@ dependencies = [
 
 [[package]]
 name = "kin-registry"
-version = "0.2.18"
+version = "0.2.19"
 dependencies = [
  "axum",
  "base64 0.22.1",
@@ -3520,7 +3520,7 @@ dependencies = [
 
 [[package]]
 name = "kin-remote"
-version = "0.2.18"
+version = "0.2.19"
 dependencies = [
  "chrono",
  "kin-model",
@@ -3536,7 +3536,7 @@ dependencies = [
 
 [[package]]
 name = "kin-review"
-version = "0.2.18"
+version = "0.2.19"
 dependencies = [
  "kin-blobs",
  "kin-db",
@@ -3552,7 +3552,7 @@ dependencies = [
 
 [[package]]
 name = "kin-runtime"
-version = "0.2.18"
+version = "0.2.19"
 dependencies = [
  "chrono",
  "hex",
@@ -3584,7 +3584,7 @@ dependencies = [
 
 [[package]]
 name = "kin-semantic-contracts"
-version = "0.2.18"
+version = "0.2.19"
 dependencies = [
  "kin-db",
  "kin-model",
@@ -3599,7 +3599,7 @@ dependencies = [
 
 [[package]]
 name = "kin-spine"
-version = "0.2.18"
+version = "0.2.19"
 dependencies = [
  "chrono",
  "hashbrown 0.15.5",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -116,7 +116,7 @@ pretty_assertions = "1"
 serial_test = "3"
 
 # Internal crates
-kin-model = { version = "0.2.4", registry = "kin" }
+kin-model = { version = "0.2.5", registry = "kin" }
 kin-blobs = { version = "0.1.1", registry = "kin" }
 kin-core = { path = "crates/kin-core" }
 kin-parser = { path = "crates/kin-parser" }
@@ -143,7 +143,7 @@ kin-lsp = { version = "0.2.2", registry = "kin" }
 # backend on every target (incl. Linux, where it cannot compile). Metal is re-enabled
 # additively on macOS via a `[target.'cfg(target_os = "macos")'.dependencies]` block in the
 # binary/runtime crates (kin-cli, kin-daemon). Feature unification makes that additive.
-kin-db = { version = "0.2.35", registry = "kin", default-features = false }
+kin-db = { version = "0.2.37", registry = "kin", default-features = false }
 kin-vfs-core = { version = "0.1.4", registry = "kin" }
 
 [profile.release]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,7 +27,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.2.18"
+version = "0.2.19"
 edition = "2021"
 license = "Apache-2.0"
 authors = ["Troy Fortin <troy@firelock.ai>"]

--- a/packages/boundary-contracts/package.json
+++ b/packages/boundary-contracts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kin/boundary-contracts",
-  "version": "0.2.18",
+  "version": "0.2.19",
   "private": false,
   "description": "Shared contracts for Kin ecosystem boundaries.",
   "type": "module",

--- a/packages/kin-mcp/package.json
+++ b/packages/kin-mcp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kinlab/kin-mcp",
-  "version": "0.2.18",
+  "version": "0.2.19",
   "description": "Start Kin's MCP server — the system of record for AI-written software — through an npm-friendly wrapper.",
   "type": "module",
   "bin": {

--- a/packages/kin/package.json
+++ b/packages/kin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kinlab/kin",
-  "version": "0.2.18",
+  "version": "0.2.19",
   "description": "Canonical installer and launcher for Kin, the system of record for AI-written software — provisions and runs the managed kin + kin-daemon release. MCP is one included mode (kin mcp start).",
   "license": "Apache-2.0",
   "type": "module",

--- a/scripts/test-npm-automatic-release.py
+++ b/scripts/test-npm-automatic-release.py
@@ -16,9 +16,9 @@ from pathlib import Path
 ROOT = Path(__file__).resolve().parent.parent
 SCRIPTS = ROOT / "scripts"
 PUBLISHER = SCRIPTS / "publish-npm-release.sh"
-VERSION = "0.2.18"
-OLD_VERSION = "0.2.17"
-NEWER_VERSION = "0.2.19"
+VERSION = "0.2.19"
+OLD_VERSION = "0.2.18"
+NEWER_VERSION = "0.2.20"
 REF = f"refs/tags/v{VERSION}"
 PACKAGE = "@kinlab/kin"
 OTHER_PACKAGE = "@kinlab/kin-mcp"
@@ -417,7 +417,7 @@ def test_symlinked_checkout_runs_channel_and_rollback_preflight() -> None:
     assert result.returncode == 0, result.stderr
     assert snapshot.get("channel_reads") == 1
     assert snapshot.get("rollback_checks") == 1
-    assert "latest=0.2.17" in result.stdout
+    assert "latest=0.2.18" in result.stdout
     assert "no registry mutation performed" in result.stdout
     assert not any(command[:1] == ["publish"] for command in snapshot["commands"])
     print("PASS: symlinked checkout executes channel and rollback preflight")
@@ -504,7 +504,7 @@ def test_newer_channel_during_publish_blocks_finalization() -> None:
     actual = json.loads(snapshot["state.json"])
     assert VERSION in actual["public"][PACKAGE]
     assert actual["tags"][PACKAGE]["latest"] == NEWER_VERSION
-    assert "resolves to 0.2.19" in result.stderr
+    assert "resolves to 0.2.20" in result.stderr
     assert "GitHub Latest remains blocked" in result.stderr
     assert "verify.json" in snapshot
     print("PASS: concurrent channel advancement leaves GitHub Latest blocked")

--- a/scripts/test-verify-npm-release.py
+++ b/scripts/test-verify-npm-release.py
@@ -17,7 +17,7 @@ from pathlib import Path
 ROOT = Path(__file__).resolve().parent.parent
 VERIFIER = ROOT / "scripts" / "verify-npm-release.sh"
 PACKAGE = "@kinlab/kin"
-VERSION = "0.2.18"
+VERSION = "0.2.19"
 REF = f"refs/tags/v{VERSION}"
 COMMIT = "a" * 40
 INTEGRITY_BYTES = bytes([7]) * 64

--- a/scripts/test_installer_parity.py
+++ b/scripts/test_installer_parity.py
@@ -18,7 +18,7 @@ from verify_installer_parity import (
 )
 
 
-TAG = "v0.2.18"
+TAG = "v0.2.19"
 COMMIT = "a" * 40
 INSTALL = b"#!/bin/sh\necho kin\n"
 INSTALL_PS1 = b'Write-Output "Kin"\n'
@@ -65,7 +65,7 @@ class InstallerParityTests(unittest.TestCase):
 
     def test_manifest_must_bind_exact_tag(self) -> None:
         wrong = json.loads(manifest())
-        wrong["tag"] = "v0.2.17"
+        wrong["tag"] = "v0.2.18"
         with self.assertRaisesRegex(ParityError, "current.json tag"):
             self.verify(public_manifest=json.dumps(wrong).encode())
 

--- a/scripts/verify_installer_parity.py
+++ b/scripts/verify_installer_parity.py
@@ -174,7 +174,7 @@ def resolve_tag(repository: str, tag: str) -> str:
 
 def main() -> int:
     parser = argparse.ArgumentParser(description=__doc__)
-    parser.add_argument("tag", help="Exact stable release tag, for example v0.2.18")
+    parser.add_argument("tag", help="Exact stable release tag, for example v0.2.19")
     parser.add_argument("--expected-sha", help="Optional expected peeled 40-hex commit")
     parser.add_argument("--repository", default=DEFAULT_REPOSITORY)
     parser.add_argument("--base-url", default=DEFAULT_BASE_URL)


### PR DESCRIPTION
## What changed

- bumps the Rust workspace and all three npm package surfaces from 0.2.18 to 0.2.19
- pins `kin-model` 0.2.5 and `kin-db` 0.2.37 from the Kin registry with exact checksums
- restores daemon reopen for legacy graph snapshots whose positional `SemanticFingerprint` records predate `equivalence_hash`
- advances release and installer parity fixtures to 0.2.19
- carries the Python rename-safety, release-boundary, and public OSS corrections landed since v0.2.18

## Why

The runtime rename-safety work landed after v0.2.18 and needs a coherent patch candidate. The production promotion trial also exposed that legacy graph snapshots could not be decoded after `SemanticFingerprint` gained a positional field. The compatibility reader is now published bottom-up and this candidate consumes the exact corrected crates.

## User impact

Existing graph snapshots reopen without rewriting their bytes. Legacy fingerprints receive the zero not-computed sentinel, while current six-field fingerprints preserve their recorded value. Python parameter renames continue to fail closed when defaults, call coverage, or receiver resolution are not proven.

## Dependency evidence

- `kin-model` 0.2.5 checksum: `f0fb9f21abc67a9f9c1374e6d8f304ca496fba96d98586fa3a8ff0ca2d5a91bd`
- `kin-db` 0.2.37 checksum: `2950735f6cc9d43efd579d2a1d34f9f7c36cc5c4b48b64e2e026ad7298fa6e87`
- `kin-db` publish and fresh-consumer run: `29223500747`
- read-only production snapshot audit: all five copied snapshots decoded twice with unchanged SHA-256 values

## Validation

- exact base: `327a6d5a506aacec9d77345e1ceb0138e1766878`
- exact head: `342dafe9372883ad0ea2b6014665f3dc0d318b4a`
- `node scripts/release-intent.mjs --json`: `shouldTag: true`, no failures or warnings
- formatting, zero-file-search, runtime-boundary, and private-repo-coupling guards
- CI-policy clippy with `RUSTFLAGS=-D warnings`
- `cargo build --all-targets --locked`
- `cargo test --locked`, including 844 Kin CLI unit tests and all integration and doc-test suites
- installer checksum fixtures: 8/8
- Homebrew release gate: 49/49
- canonical npm launcher: 33/33 plus lint
- compatibility npm launcher: 13/13 plus lint
- release workflow authority, installer parity, npm automatic release, npm verification, release ordering, and npm attestation tests
- exact-head registry-only `kin-dev release-check kin` from `/tmp`; every external Kin dependency is sparse-sourced, checksummed, and at the latest registry version
- exact-head hosted checks are running

## Release boundary

This remains a draft candidate until the exact hosted checks, merge queue, release workflow, corrected KinLab image promotion, staging verification, production promotion, and live browser QA all pass. It does not yet tag, publish, or claim broad OSS launch readiness. Production is healthy on the verified rollback baseline.