### PR TITLE
Reject intra-repo spine edges

### DIFF
--- a/crates/kin-spine/src/firestore.rs
+++ b/crates/kin-spine/src/firestore.rs
@@ -94,7 +94,7 @@ impl FirestoreSpineBackend {
 
         let repo_count = repos.len();
         let entity_count: usize = repos.iter().map(|r| r.entries.len()).sum();
-        let edge_count = edges.len();
+        let loaded_edge_count = edges.len();
 
         // Populate the inner cache directly (not via `self`) so hydration does
         // not write the loaded data straight back to the store.
@@ -102,8 +102,11 @@ impl FirestoreSpineBackend {
             self.cache
                 .register_repo(&repo.repo_id, repo.entries, &repo.root_hash);
         }
+        let mut edge_count = 0;
         for edge in edges {
-            self.cache.add_cross_repo_edge(edge);
+            if self.cache.index().add_cross_repo_edge(edge) {
+                edge_count += 1;
+            }
         }
 
         self.hydrated.store(true, Ordering::Release);
@@ -111,6 +114,7 @@ impl FirestoreSpineBackend {
             repos = repo_count,
             entities = entity_count,
             edges = edge_count,
+            rejected_edges = loaded_edge_count - edge_count,
             "spine cache hydration complete"
         );
         Ok(())
@@ -169,7 +173,9 @@ impl SpineBackend for FirestoreSpineBackend {
 
     fn add_cross_repo_edge(&self, edge: CrossRepoEdge) {
         // Write-through: local cache + durable store.
-        self.cache.add_cross_repo_edge(edge.clone());
+        if !self.cache.index().add_cross_repo_edge(edge.clone()) {
+            return;
+        }
 
         if let Err(e) = self.store.write_edge(&edge) {
             error!(error = %e, "failed to write edge to store");
@@ -764,6 +770,25 @@ mod tests {
     }
 
     #[test]
+    fn hydrate_rejects_legacy_same_repo_edges_from_store() {
+        let store = Arc::new(FakeSpineStore::default());
+        store
+            .write_edge(&CrossRepoEdge {
+                src_repo: "kin".to_string(),
+                src_entity: EntityId::new(),
+                dst_repo: "kin".to_string(),
+                dst_entity: EntityId::new(),
+                confidence: 0.5,
+            })
+            .expect("seed legacy invalid edge");
+
+        let reader = FirestoreSpineBackend::with_store(store);
+        reader.hydrate().expect("hydrate");
+
+        assert_eq!(reader.edge_count(), 0);
+    }
+
+    #[test]
     fn hydrate_is_idempotent_and_guards_against_reload() {
         let store = Arc::new(FakeSpineStore::default());
         let writer = FirestoreSpineBackend::with_store(store.clone());
@@ -836,6 +861,23 @@ mod tests {
         assert_eq!(edges.len(), 1);
         assert_eq!(edges[0].src_repo, "repo-a");
         assert_eq!(edges[0].dst_repo, "repo-b");
+    }
+
+    #[test]
+    fn add_cross_repo_edge_rejects_same_repo_before_persistence() {
+        let store = Arc::new(FakeSpineStore::default());
+        let backend = FirestoreSpineBackend::with_store(store.clone());
+
+        backend.add_cross_repo_edge(CrossRepoEdge {
+            src_repo: "repo-a".to_string(),
+            src_entity: EntityId::new(),
+            dst_repo: "repo-a".to_string(),
+            dst_entity: EntityId::new(),
+            confidence: 0.5,
+        });
+
+        assert_eq!(backend.edge_count(), 0);
+        assert!(store.load_edges().unwrap().is_empty());
     }
 
     #[test]

--- a/crates/kin-spine/src/index.rs
+++ b/crates/kin-spine/src/index.rs
@@ -181,9 +181,18 @@ impl SpineIndex {
     }
 
     /// Add a cross-repo edge to the index.
-    pub fn add_cross_repo_edge(&self, edge: CrossRepoEdge) {
+    ///
+    /// Returns `false` when the candidate does not cross a repository
+    /// boundary. Keeping this invariant at the storage boundary prevents a
+    /// resolver bug or stale durable row from making an intra-repo reference
+    /// look like hosted cross-repo proof.
+    pub fn add_cross_repo_edge(&self, edge: CrossRepoEdge) -> bool {
+        if edge.src_repo == edge.dst_repo {
+            return false;
+        }
         let mut inner = self.inner.write();
         inner.cross_repo_edges.push(edge);
+        true
     }
 
     /// Look up an entity by (repo_id, entity_id).
@@ -436,5 +445,24 @@ mod tests {
         assert_eq!(edges[0].dst_repo, "repo-b");
 
         assert_eq!(index.edge_count(), 1);
+    }
+
+    #[test]
+    fn rejects_intra_repo_edges_at_the_index_boundary() {
+        let index = SpineIndex::new();
+        let caller = test_entry("repo-a", "caller", EntityKind::Function);
+        let callee = test_entry("repo-a", "callee", EntityKind::Function);
+
+        assert!(!index.add_cross_repo_edge(CrossRepoEdge {
+            src_repo: "repo-a".to_string(),
+            src_entity: caller.entity_id,
+            dst_repo: "repo-a".to_string(),
+            dst_entity: callee.entity_id,
+            confidence: 0.95,
+        }));
+        assert_eq!(index.edge_count(), 0);
+        assert!(index
+            .cross_repo_edges_for("repo-a", &caller.entity_id)
+            .is_empty());
     }
 }

--- a/crates/kin-spine/src/xref.rs
+++ b/crates/kin-spine/src/xref.rs
@@ -112,6 +112,15 @@ fn resolve_single(
     if let Some(ref source) = import.import_source {
         let normalized_source = normalize_repo_token(import_source_root(source));
 
+        // A relation whose module root names its own repository is not a
+        // cross-repo import. Parser/linker gaps can still represent a local
+        // target as an external placeholder, but that must remain unresolved
+        // here instead of becoming a same-repo "cross-repo" proof edge (or
+        // falling through to a similarly named sibling repo).
+        if normalize_repo_token(&import.source_repo) == normalized_source {
+            return ResolveResult::NotFound;
+        }
+
         // Tier 1: the import's crate/package root names a registered repo.
         if let Some(matched_repo) = registered_repos
             .iter()
@@ -271,26 +280,28 @@ pub fn materialize_edges(
                 target_entity,
                 confidence,
             } => {
-                index.add_cross_repo_edge(CrossRepoEdge {
+                if index.add_cross_repo_edge(CrossRepoEdge {
                     src_repo: import.source_repo.clone(),
                     src_entity: import.source_entity,
                     dst_repo: target_repo.clone(),
                     dst_entity: *target_entity,
                     confidence: *confidence,
-                });
-                count += 1;
+                }) {
+                    count += 1;
+                }
             }
             ResolveResult::Ambiguous { candidates } => {
                 // Add edges for all candidates with their confidence scores
                 for (repo, entity_id, confidence) in candidates {
-                    index.add_cross_repo_edge(CrossRepoEdge {
+                    if index.add_cross_repo_edge(CrossRepoEdge {
                         src_repo: import.source_repo.clone(),
                         src_entity: import.source_entity,
                         dst_repo: repo.clone(),
                         dst_entity: *entity_id,
                         confidence: *confidence,
-                    });
-                    count += 1;
+                    }) {
+                        count += 1;
+                    }
                 }
             }
             ResolveResult::NotFound => {}
@@ -633,6 +644,59 @@ mod tests {
             }
             other => panic!("expected Resolved to requests repo, got {other:?}"),
         }
+    }
+
+    #[test]
+    fn import_source_naming_the_source_repo_never_materializes_cross_repo_proof() {
+        let index = SpineIndex::new();
+        let local = test_entry("kin", "platform", EntityKind::Function);
+        let collision = test_entry("kin-vfs", "platform", EntityKind::Function);
+        index.register_repo("kin", vec![local], "hash-kin");
+        index.register_repo("kin-vfs", vec![collision], "hash-vfs");
+
+        let imports = vec![UnresolvedImport {
+            source_repo: "kin".to_string(),
+            source_entity: EntityId::new(),
+            imported_name: "platform".to_string(),
+            imported_kind: Some(EntityKind::Function),
+            candidate_repos: vec!["kin-vfs".to_string()],
+            language: Some("rust".to_string()),
+            reference_fingerprint: None,
+            import_source: Some("kin::platform".to_string()),
+        }];
+
+        let results = resolve_imports(&index, &imports);
+        assert!(matches!(results[0].1, ResolveResult::NotFound));
+        assert_eq!(materialize_edges(&index, &imports, &results), 0);
+        assert_eq!(index.edge_count(), 0);
+    }
+
+    #[test]
+    fn materialization_defensively_discards_a_forged_same_repo_resolution() {
+        let index = SpineIndex::new();
+        let source_entity = EntityId::new();
+        let target_entity = EntityId::new();
+        let imports = vec![UnresolvedImport {
+            source_repo: "kin".to_string(),
+            source_entity,
+            imported_name: "platform".to_string(),
+            imported_kind: Some(EntityKind::Function),
+            candidate_repos: vec![],
+            language: Some("rust".to_string()),
+            reference_fingerprint: None,
+            import_source: None,
+        }];
+        let forged = vec![(
+            0,
+            ResolveResult::Resolved {
+                target_repo: "kin".to_string(),
+                target_entity,
+                confidence: 0.5,
+            },
+        )];
+
+        assert_eq!(materialize_edges(&index, &imports, &forged), 0);
+        assert_eq!(index.edge_count(), 0);
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- reject same-repo candidates before cross-repo resolution
- enforce the cross-repo invariant at the in-memory index boundary
- ignore legacy invalid durable rows and prevent new invalid rows from persisting

## Verification

- `cargo fmt --all -- --check`
- `cargo test -p kin-spine` (45 unit + 19 integration)
- `cargo clippy -p kin-spine --all-targets -- -D warnings`
- `cargo build -p kin-spine --all-targets`
- `cargo test -p kin-daemon spine_` (12 daemon spine tests)

## Claim boundary

This fixes the source defect on main. It does not alter the already-published v0.2.19 daemon image; KinLab also validates distinct-repo endpoints fail closed for the current hosted launch.