### PR TITLE
Prepare v0.2.21 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,27 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.2.21] - 2026-07-13
+
+This patch gives hosted clients one bounded, graph-authoritative read of the
+cross-repository edge universe while keeping completeness fail closed during
+authority changes and durable-cache recovery.
+
+### Added
+
+- The protected `GET /v1/spine/edges` route returns a deterministic snapshot
+  with an explicit completeness marker, revision, repo and root watermark, and
+  sorted, deduplicated cross-repository edges.
+
+### Fixed
+
+- Repository authority changes now invalidate global edge completeness, and
+  per-source refreshes are serialized, computed separately, and installed
+  atomically before dirty state can clear.
+- Firestore hydration is treated as a warm-start cache rather than proof
+  authority. Mixed roots, orphan endpoints, empty roots, and partial refreshes
+  keep the snapshot incomplete until graph-authoritative rebuilding succeeds.
+
 ## [0.2.20] - 2026-07-13
 
 This patch makes cross-repository spine evidence fail closed when a resolver or
@@ -548,7 +569,8 @@ Historical note: this snapshot predates the public GitHub prerelease series and 
 - Daemon mode for background file watching (`kin-daemon`)
 - 19-crate workspace architecture
 
-[unreleased]: https://github.com/firelock-ai/kin/compare/v0.2.20...HEAD
+[unreleased]: https://github.com/firelock-ai/kin/compare/v0.2.21...HEAD
+[0.2.21]: https://github.com/firelock-ai/kin/compare/v0.2.20...v0.2.21
 [0.2.20]: https://github.com/firelock-ai/kin/compare/v0.2.19...v0.2.20
 [0.2.19]: https://github.com/firelock-ai/kin/compare/v0.2.18...v0.2.19
 [0.2.18]: https://github.com/firelock-ai/kin/compare/v0.2.17...v0.2.18

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3039,14 +3039,14 @@ dependencies = [
 
 [[package]]
 name = "kin-buildinfo"
-version = "0.2.20"
+version = "0.2.21"
 dependencies = [
  "sha2 0.11.0",
 ]
 
 [[package]]
 name = "kin-cli"
-version = "0.2.20"
+version = "0.2.21"
 dependencies = [
  "age",
  "anyhow",
@@ -3114,7 +3114,7 @@ dependencies = [
 
 [[package]]
 name = "kin-context"
-version = "0.2.20"
+version = "0.2.21"
 dependencies = [
  "kin-blobs",
  "kin-db",
@@ -3130,7 +3130,7 @@ dependencies = [
 
 [[package]]
 name = "kin-core"
-version = "0.2.20"
+version = "0.2.21"
 dependencies = [
  "chrono",
  "directories 5.0.1",
@@ -3154,7 +3154,7 @@ dependencies = [
 
 [[package]]
 name = "kin-daemon"
-version = "0.2.20"
+version = "0.2.21"
 dependencies = [
  "async-stream",
  "axum",
@@ -3244,7 +3244,7 @@ dependencies = [
 
 [[package]]
 name = "kin-git"
-version = "0.2.20"
+version = "0.2.21"
 dependencies = [
  "chrono",
  "gix",
@@ -3262,7 +3262,7 @@ dependencies = [
 
 [[package]]
 name = "kin-index"
-version = "0.2.20"
+version = "0.2.21"
 dependencies = [
  "hex",
  "kin-blobs",
@@ -3310,7 +3310,7 @@ dependencies = [
 
 [[package]]
 name = "kin-integration-tests"
-version = "0.2.20"
+version = "0.2.21"
 dependencies = [
  "kin-blobs",
  "kin-cli",
@@ -3352,7 +3352,7 @@ dependencies = [
 
 [[package]]
 name = "kin-mcp"
-version = "0.2.20"
+version = "0.2.21"
 dependencies = [
  "kin-blobs",
  "kin-context",
@@ -3379,7 +3379,7 @@ dependencies = [
 
 [[package]]
 name = "kin-migrate"
-version = "0.2.20"
+version = "0.2.21"
 dependencies = [
  "chrono",
  "kin-blobs",
@@ -3421,7 +3421,7 @@ dependencies = [
 
 [[package]]
 name = "kin-parser"
-version = "0.2.20"
+version = "0.2.21"
 dependencies = [
  "kin-model",
  "pretty_assertions",
@@ -3451,7 +3451,7 @@ dependencies = [
 
 [[package]]
 name = "kin-projection"
-version = "0.2.20"
+version = "0.2.21"
 dependencies = [
  "kin-blobs",
  "kin-db",
@@ -3466,7 +3466,7 @@ dependencies = [
 
 [[package]]
 name = "kin-ranking"
-version = "0.2.20"
+version = "0.2.21"
 dependencies = [
  "kin-model",
  "serde",
@@ -3475,7 +3475,7 @@ dependencies = [
 
 [[package]]
 name = "kin-reconcile"
-version = "0.2.20"
+version = "0.2.21"
 dependencies = [
  "kin-blobs",
  "kin-db",
@@ -3495,7 +3495,7 @@ dependencies = [
 
 [[package]]
 name = "kin-registry"
-version = "0.2.20"
+version = "0.2.21"
 dependencies = [
  "axum",
  "base64 0.22.1",
@@ -3520,7 +3520,7 @@ dependencies = [
 
 [[package]]
 name = "kin-remote"
-version = "0.2.20"
+version = "0.2.21"
 dependencies = [
  "chrono",
  "kin-model",
@@ -3536,7 +3536,7 @@ dependencies = [
 
 [[package]]
 name = "kin-review"
-version = "0.2.20"
+version = "0.2.21"
 dependencies = [
  "kin-blobs",
  "kin-db",
@@ -3552,7 +3552,7 @@ dependencies = [
 
 [[package]]
 name = "kin-runtime"
-version = "0.2.20"
+version = "0.2.21"
 dependencies = [
  "chrono",
  "hex",
@@ -3584,7 +3584,7 @@ dependencies = [
 
 [[package]]
 name = "kin-semantic-contracts"
-version = "0.2.20"
+version = "0.2.21"
 dependencies = [
  "kin-db",
  "kin-model",
@@ -3599,7 +3599,7 @@ dependencies = [
 
 [[package]]
 name = "kin-spine"
-version = "0.2.20"
+version = "0.2.21"
 dependencies = [
  "chrono",
  "hashbrown 0.15.5",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,7 +27,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.2.20"
+version = "0.2.21"
 edition = "2021"
 license = "Apache-2.0"
 authors = ["Troy Fortin <troy@firelock.ai>"]

--- a/packages/boundary-contracts/package.json
+++ b/packages/boundary-contracts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kin/boundary-contracts",
-  "version": "0.2.20",
+  "version": "0.2.21",
   "private": false,
   "description": "Shared contracts for Kin ecosystem boundaries.",
   "type": "module",

--- a/packages/kin-mcp/package.json
+++ b/packages/kin-mcp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kinlab/kin-mcp",
-  "version": "0.2.20",
+  "version": "0.2.21",
   "description": "Start Kin's MCP server — the system of record for AI-written software — through an npm-friendly wrapper.",
   "type": "module",
   "bin": {

--- a/packages/kin/package.json
+++ b/packages/kin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kinlab/kin",
-  "version": "0.2.20",
+  "version": "0.2.21",
   "description": "Canonical installer and launcher for Kin, the system of record for AI-written software — provisions and runs the managed kin + kin-daemon release. MCP is one included mode (kin mcp start).",
   "license": "Apache-2.0",
   "type": "module",

--- a/scripts/test-npm-automatic-release.py
+++ b/scripts/test-npm-automatic-release.py
@@ -16,9 +16,9 @@ from pathlib import Path
 ROOT = Path(__file__).resolve().parent.parent
 SCRIPTS = ROOT / "scripts"
 PUBLISHER = SCRIPTS / "publish-npm-release.sh"
-VERSION = "0.2.20"
-OLD_VERSION = "0.2.19"
-NEWER_VERSION = "0.2.21"
+VERSION = "0.2.21"
+OLD_VERSION = "0.2.20"
+NEWER_VERSION = "0.2.22"
 REF = f"refs/tags/v{VERSION}"
 PACKAGE = "@kinlab/kin"
 OTHER_PACKAGE = "@kinlab/kin-mcp"
@@ -417,7 +417,7 @@ def test_symlinked_checkout_runs_channel_and_rollback_preflight() -> None:
     assert result.returncode == 0, result.stderr
     assert snapshot.get("channel_reads") == 1
     assert snapshot.get("rollback_checks") == 1
-    assert "latest=0.2.19" in result.stdout
+    assert "latest=0.2.20" in result.stdout
     assert "no registry mutation performed" in result.stdout
     assert not any(command[:1] == ["publish"] for command in snapshot["commands"])
     print("PASS: symlinked checkout executes channel and rollback preflight")
@@ -504,7 +504,7 @@ def test_newer_channel_during_publish_blocks_finalization() -> None:
     actual = json.loads(snapshot["state.json"])
     assert VERSION in actual["public"][PACKAGE]
     assert actual["tags"][PACKAGE]["latest"] == NEWER_VERSION
-    assert "resolves to 0.2.21" in result.stderr
+    assert "resolves to 0.2.22" in result.stderr
     assert "GitHub Latest remains blocked" in result.stderr
     assert "verify.json" in snapshot
     print("PASS: concurrent channel advancement leaves GitHub Latest blocked")

--- a/scripts/test-verify-npm-release.py
+++ b/scripts/test-verify-npm-release.py
@@ -17,7 +17,7 @@ from pathlib import Path
 ROOT = Path(__file__).resolve().parent.parent
 VERIFIER = ROOT / "scripts" / "verify-npm-release.sh"
 PACKAGE = "@kinlab/kin"
-VERSION = "0.2.20"
+VERSION = "0.2.21"
 REF = f"refs/tags/v{VERSION}"
 COMMIT = "a" * 40
 INTEGRITY_BYTES = bytes([7]) * 64

--- a/scripts/test_installer_parity.py
+++ b/scripts/test_installer_parity.py
@@ -18,7 +18,7 @@ from verify_installer_parity import (
 )
 
 
-TAG = "v0.2.20"
+TAG = "v0.2.21"
 COMMIT = "a" * 40
 INSTALL = b"#!/bin/sh\necho kin\n"
 INSTALL_PS1 = b'Write-Output "Kin"\n'
@@ -65,7 +65,7 @@ class InstallerParityTests(unittest.TestCase):
 
     def test_manifest_must_bind_exact_tag(self) -> None:
         wrong = json.loads(manifest())
-        wrong["tag"] = "v0.2.19"
+        wrong["tag"] = "v0.2.20"
         with self.assertRaisesRegex(ParityError, "current.json tag"):
             self.verify(public_manifest=json.dumps(wrong).encode())
 

--- a/scripts/verify_installer_parity.py
+++ b/scripts/verify_installer_parity.py
@@ -174,7 +174,7 @@ def resolve_tag(repository: str, tag: str) -> str:
 
 def main() -> int:
     parser = argparse.ArgumentParser(description=__doc__)
-    parser.add_argument("tag", help="Exact stable release tag, for example v0.2.20")
+    parser.add_argument("tag", help="Exact stable release tag, for example v0.2.21")
     parser.add_argument("--expected-sha", help="Optional expected peeled 40-hex commit")
     parser.add_argument("--repository", default=DEFAULT_REPOSITORY)
     parser.add_argument("--base-url", default=DEFAULT_BASE_URL)


### PR DESCRIPTION
## Summary

- bump the Kin workspace and public npm packages to v0.2.21
- ship the merged atomic cross-repository edge snapshot surface from PR #331
- add focused release notes and advance release-policy and installer fixtures

## Product impact

The protected `GET /v1/spine/edges` endpoint gives the hosted client one deterministic graph-authoritative snapshot with an explicit completeness marker. Completeness remains fail closed across authority changes, incomplete refreshes, invalid roots or endpoints, and durable-cache hydration.

## Verification

- `node scripts/release-intent.mjs --json`: `shouldTag=true`, v0.2.21 absent, changelog and all npm versions coherent
- `cargo check --workspace --locked`
- `cargo fmt -- --check`
- `cargo test -p kin-spine`: 58 unit + 19 integration passed
- `cargo test -p kin-spine --features firestore`: 59 unit + 19 integration passed
- `cargo test -p kin-daemon spine_`: 14/14 passed
- npm launcher tests: 46/46 passed, with both lint suites green
- release authority, installer parity, automatic npm, npm verifier, release-order, and attestation policy suites passed
- zero-file-search, version consistency, exact-scope, and diff checks passed
- `bin/kin-dev release-check kin`: registry-only all-targets check passed from a detached `/tmp` checkout; all external Kin dependencies retained registry sources, checksums, and current published pins

## Release boundary

This remains a draft release-preparation PR. It does not merge, tag, publish, deploy, or change runtime state. KinLab PR #82 and production use of the bulk endpoint remain blocked until this patch is reviewed, merged, and released through the protected release workflow.