### PR TITLE
Stabilize temporal scope TTL refresh coverage test

### DIFF
--- a/crates/kin-daemon/src/state.rs
+++ b/crates/kin-daemon/src/state.rs
@@ -4226,7 +4226,12 @@ mod tests {
         let scoped_graph = make_scoped_graph_with_entity("scoped_fn", "src/scoped.rs");
         let session_id = kin_model::SessionId::new();
         let head = kin_model::SemanticChangeId::from_hash(kin_model::Hash256::from_bytes([5; 32]));
-        // Plant a scope with a short TTL whose deadline is close.
+        // Plant a live scope whose original expiry is well clear of ordinary
+        // test and coverage-instrumentation latency. The refresh contract is
+        // proven from the timestamps themselves instead of racing a tiny TTL.
+        let ttl = Duration::from_secs(60 * 60);
+        let original_created_at = Instant::now() - Duration::from_secs(60);
+        let original_expires_at = original_created_at + ttl;
         {
             let mut scopes = state.session_scopes.write().await;
             scopes.insert(
@@ -4235,21 +4240,37 @@ mod tests {
                     ref_string: "git:abc123".to_string(),
                     head,
                     cached_graph: Arc::clone(&scoped_graph),
-                    created_at: Instant::now() - Duration::from_millis(80),
-                    ttl: Duration::from_millis(100),
+                    created_at: original_created_at,
+                    ttl,
                 },
             );
         }
 
-        // First write succeeds AND slides the TTL window (created_at reset).
-        assert!(state.scoped_graph_for_write(&session_id).await.is_some());
+        // The write must return the private graph and reset created_at during
+        // this call, which moves the absolute expiry beyond its old deadline.
+        let before_refresh = Instant::now();
+        let resolved = state
+            .scoped_graph_for_write(&session_id)
+            .await
+            .expect("live scope should yield a write graph");
+        let after_refresh = Instant::now();
+        assert!(Arc::ptr_eq(&resolved, &scoped_graph));
 
-        // Sleep past the ORIGINAL deadline. Without the TTL slide the scope
-        // would now be expired; with it, the scope is still live.
-        tokio::time::sleep(Duration::from_millis(40)).await;
+        let (refreshed_created_at, refreshed_ttl) = {
+            let scopes = state.session_scopes.read().await;
+            let scope = scopes
+                .get(&session_id)
+                .expect("write refresh must retain the live scope");
+            (scope.created_at, scope.ttl)
+        };
         assert!(
-            state.scoped_graph_for_write(&session_id).await.is_some(),
-            "in-use scope must not expire mid-task; TTL should slide on each write"
+            (before_refresh..=after_refresh).contains(&refreshed_created_at),
+            "write must reset created_at inside the call boundary: before={before_refresh:?} refreshed={refreshed_created_at:?} after={after_refresh:?}"
+        );
+        assert_eq!(refreshed_ttl, ttl, "refresh must preserve the scope TTL");
+        assert!(
+            refreshed_created_at + refreshed_ttl > original_expires_at,
+            "write must slide the scope's expiry beyond its original deadline"
         );
     }
 


### PR DESCRIPTION
## What changed

- Replace the 20 ms wall-clock race in `scoped_graph_for_write_refreshes_ttl` with direct relative timestamp assertions.
- Prove the write returns the session's private graph, resets `created_at` inside the call boundary, preserves the configured TTL, and extends the absolute expiry deadline.
- Keep runtime behavior unchanged; this is a test-only repair.

## Root cause

The test planted a 100 ms TTL that was already 80 ms old. Tarpaulin instrumentation could consume the remaining approximately 20 ms before the first assertion, so the scope was correctly removed as expired and the test failed. Main run 29253286379 recorded 344 passed and 1 failed even though the coverage job is temporarily non-blocking.

## Impact

The coverage test now measures the sliding-TTL contract directly instead of depending on scheduler and instrumentation timing. No production code, API, or cache policy changes.

## Validation

- `cargo fmt --all -- --check`
- Final focused test: 20/20 repeated passes (70/70 across the full iteration)
- `cargo test -p kin-daemon --locked`: 345 unit tests, 3 daemon binary tests, and all daemon integration tests passed
- `cargo clippy -p kin-daemon --all-targets --all-features --no-deps` with the repository CI warning policy and allowlist
- Hosted Linux tarpaulin, run 29257036370 / job 86840368090: 345 passed, 0 failed; 64.13% coverage; Cobertura and JSON reports generated and uploaded
- All exact-head PR checks green, including `codecov/patch`, Ubuntu, macOS, Windows, Docker, DCO, SAST, daemon smoke, and secret scan
- Independent exact-head review: GO with no P0, P1, or P2 findings

## Merge posture

- Ready as a draft and queued through `kin-lane`.
- Do not merge outside captain and queue policy.
