### PR TITLE
chore: remove ticket references from source comments

### DIFF
--- a/crates/kin-cli/src/commands/health.rs
+++ b/crates/kin-cli/src/commands/health.rs
@@ -286,8 +286,7 @@ fn check_vfs_projection() -> HealthCheck {
 /// The durable step that repairs a missing or corrupt shim when `kin doctor
 /// --fix` cannot source one locally. It must NEVER name `kin doctor --fix`
 /// itself: this text is reprinted in the post-`--fix` "still needs manual steps"
-/// list, where pointing back at the command that just ran is a dead loop
-/// (FIR-1409).
+/// list, where pointing back at the command that just ran is a dead loop.
 const SHIM_REINSTALL_HINT: &str =
     "reinstall kin to restore the shim: curl -fsSL https://get.kinlab.dev/install | sh";
 
@@ -1103,7 +1102,7 @@ mod tests {
 
     #[test]
     fn vfs_remediation_never_points_back_at_the_failed_fix() {
-        // FIR-1409: the repair text for a broken shim must name a real working
+        // The repair text for a broken shim must name a real working
         // step, never `kin doctor --fix` (the command that just failed).
         let dir = tempfile::tempdir().unwrap();
         let missing = dir.path().join("missing");

--- a/crates/kin-cli/src/commands/setup.rs
+++ b/crates/kin-cli/src/commands/setup.rs
@@ -2031,7 +2031,7 @@ pub async fn doctor(fix: bool, json: bool) -> Result<()> {
     // Try a local copy first; a standalone binary (no sibling shim, no ledger
     // source) has none, so fall back to downloading the shim from the release
     // that matches THIS binary's version. Only if both fail do we print a manual
-    // step — and never one that points back at `kin doctor --fix` (FIR-1409).
+    // step — and never one that points back at `kin doctor --fix`.
     let vfs_needs_fix = report.checks.iter().any(|c| {
         c.id == "vfs_projection"
             && c.fixable
@@ -2366,7 +2366,7 @@ mod tests {
 
     #[test]
     fn restore_shim_repairs_a_zeroed_shim_from_a_usable_source() {
-        // FIR-1409 repair path: a deliberately-zeroed shim + a usable source is
+        // Repair path: a deliberately-zeroed shim + a usable source is
         // restored to the real bytes.
         let tmp = tempfile::tempdir().unwrap();
         let source = tmp.path().join("source-shim");
@@ -2386,7 +2386,7 @@ mod tests {
 
     #[test]
     fn restore_shim_reports_none_when_no_usable_source_exists() {
-        // FIR-1409 honest path: with no usable source, the repair reports None
+        // Honest path: with no usable source, the repair reports None
         // (so the caller escalates / prints a manual step) and never fabricates
         // content over the zeroed shim.
         let tmp = tempfile::tempdir().unwrap();

--- a/crates/kin-review/src/shadow.rs
+++ b/crates/kin-review/src/shadow.rs
@@ -48,7 +48,7 @@ pub const SHADOW_ENFORCEMENT_REPORT_ONLY: &str = "report_only";
 /// A review whose base..head range spans this many committed changes reaches
 /// far enough back that the persisted graph substrate it reads at the head ref
 /// — replayed faithfully, but built long ago — drifts further from what a live
-/// re-index would produce than a nearby range does (FIR-1267): the deeper the
+/// re-index would produce than a nearby range does: the deeper the
 /// range, the more the persisted relation closure and entity roles diverge.
 /// When such a range ALSO
 /// yields an empty blast radius, that emptiness is more plausibly a ceiling of
@@ -274,7 +274,7 @@ pub struct ShadowAuditEvidence {
 
 /// Provenance for how deep the reviewed `base..head` range reaches, stamped on
 /// every report so downstream scoring can attribute an accepted historical-
-/// substrate ceiling (FIR-1267) instead of scoring a deep-history row as clean.
+/// substrate ceiling instead of scoring a deep-history row as clean.
 ///
 /// The raw count is ALWAYS present and independent of any threshold; the
 /// threshold gates only the non-demoting `deep_history_impact_ceiling` evidence
@@ -866,7 +866,7 @@ fn is_blocking(kind: InlineCommentKind) -> bool {
 ///   never double-counted.
 /// - `deep_history_impact_ceiling` is reported but never demotes: it is a
 ///   range-depth PROXY attributing an empty blast radius on a deep range to a
-///   historical-substrate ceiling (FIR-1267). Absence of evidence is not
+///   historical-substrate ceiling. Absence of evidence is not
 ///   evidence of risk, so it makes the ceiling attributable without changing
 ///   the verdict.
 /// - Structural v1 limits (cross-repo not evaluated, attribution
@@ -1526,7 +1526,7 @@ fn collect_evidence_gaps<G: GraphStore>(
 
         // A deep base..head range reaches far enough back that the persisted
         // graph substrate the review replays at head drifts further from a live
-        // re-index than a nearby range does (FIR-1267). When such a range ALSO
+        // re-index than a nearby range does. When such a range ALSO
         // yields an empty blast radius (the condition above), attribute that
         // emptiness explicitly to the range-depth ceiling instead of leaving it
         // folded into the generic impact_signal_absent gap. This is a
@@ -1540,8 +1540,8 @@ fn collect_evidence_gaps<G: GraphStore>(
                 subject: "blast_radius".to_string(),
                 detail: format!(
                     "reviewed range spans {} committed changes (over the {} deep-history \
-                     threshold). This is a RANGE-DEPTH PROXY for historical-substrate fidelity \
-                     (FIR-1267): across a range this deep the graph state materialized at the \
+                     threshold). This is a RANGE-DEPTH PROXY for historical-substrate fidelity: \
+                     across a range this deep the graph state materialized at the \
                      head ref is a less faithful representation than a live re-index, so an empty \
                      blast radius is more plausibly a substrate ceiling than proof the change is \
                      isolated. Reported as an accepted ceiling and NON-DEMOTING; the raw range \
@@ -3625,7 +3625,7 @@ mod tests {
 
     #[test]
     fn shadow_downstream_risk_demotes_runtime_neutral_positional_rename() {
-        // FIR-1440: the shadow `downstream_risk` channel is a SEPARATE gate from
+        // The shadow `downstream_risk` channel is a SEPARATE gate from
         // the inline signature-change channel. An arity-preserving rename whose
         // graph-known call sites all pass positionally is runtime-neutral, yet
         // pre-fix this channel still emitted a BLOCKING downstream_risk (verdict
@@ -3645,7 +3645,7 @@ mod tests {
             .find(|f| f.kind == "downstream_risk")
             .expect("a renamed contract surface with 3 consumers carries a downstream risk");
         // GREEN (post-fix): demoted to attention. Pre-fix this was blocking/error
-        // with a WouldBlock verdict — the shipped FIR-1440 bug.
+        // with a WouldBlock verdict — the previously shipped bug.
         assert!(
             !finding.blocking,
             "a positional-safe rename must not block the shadow gate"


### PR DESCRIPTION
## What

Removes internal tracker ids from source comments and one user-facing runtime string, so the public source describes durable technical behavior only.

## Changes

- `crates/kin-cli/src/commands/health.rs` — drop the tracker id from the shim-reinstall-hint doc comment and the VFS-remediation test comment.
- `crates/kin-cli/src/commands/setup.rs` — drop the tracker id from the `doctor` VFS-repair comment and two shim-restore test comments.
- `crates/kin-review/src/shadow.rs` — drop the tracker id from four doc/line comments describing the deep-history impact ceiling, from two `downstream_risk` test comments, and from the user-facing `deep_history_impact_ceiling` evidence-detail string. The evidence-detail string is behavior-visible, so its emitted text changes (`...historical-substrate fidelity: across a range this deep...`); the meaning is unchanged.

All edits are comment/string-literal only; each sentence keeps its technical meaning.

## Verification

`cargo check -p kin-cli -p kin-review` passes.

Draft — held for post-freeze review. Do not merge during the launch freeze.
