### PR TITLE
Restore registry dependency waves

### DIFF
--- a/.github/workflows/kin-dependency-wave.yml
+++ b/.github/workflows/kin-dependency-wave.yml
@@ -1,0 +1,54 @@
+name: Kin Dependency Wave
+
+on:
+  repository_dispatch:
+    types: [kin-registry-release]
+  schedule:
+    # Recover any missed registry callback by resolving every watched crate.
+    - cron: "17 * * * *"
+
+# The reusable workflow receives the dedicated PR token below. Keep the
+# per-run GITHUB_TOKEN read-only so a caller-controlled token cannot become a
+# second write path.
+permissions:
+  contents: read
+
+concurrency:
+  group: kin-registry-dependency-wave
+  cancel-in-progress: false
+
+jobs:
+  app-token:
+    # The private key stays behind a main-only environment. The minted token is
+    # scoped to this repository and expires automatically after one hour.
+    runs-on: ubuntu-latest
+    environment: release-followups
+    outputs:
+      token: ${{ steps.app-token.outputs.token }}
+    steps:
+      - name: Mint dependency-wave GitHub App token
+        id: app-token
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
+        with:
+          app-id: ${{ secrets.KIN_RELEASE_APP_ID }}
+          private-key: ${{ secrets.KIN_RELEASE_APP_PRIVATE_KEY }}
+          owner: firelock-ai
+          repositories: kin
+          permission-contents: write
+          permission-pull-requests: write
+          # The reusable workflow runs in the next job. The token remains
+          # short-lived and cannot outlive GitHub App installation policy.
+          skip-token-revoke: true
+
+  dependency-wave:
+    # Keep both the reusable workflow and its helper checkout pinned to the
+    # same reviewed kin-actions commit. Do not add a manual trigger: it could
+    # select branch-controlled caller code while carrying the PR token.
+    needs: app-token
+    uses: firelock-ai/kin-actions/.github/workflows/cargo-dependency-wave.yml@d06908b534ad5a70bb0f39a1b2b8d6228acf70a4 # v0.1.9
+    with:
+      manifests: Cargo.toml
+      test-command: cargo check -p kin-core -p kin-cli -p kin-daemon -p kin-mcp
+      kin-actions-ref: d06908b534ad5a70bb0f39a1b2b8d6228acf70a4
+    secrets:
+      KIN_CI_BOT_TOKEN: ${{ needs.app-token.outputs.token }}

--- a/scripts/test-release-workflow-authority.py
+++ b/scripts/test-release-workflow-authority.py
@@ -28,7 +28,6 @@ def main() -> None:
     retired = (
         "auto-tag-release.yml",
         "daemon-image.yml",
-        "kin-dependency-wave.yml",
         "publish-install-scripts.yml",
     )
     for name in retired:
@@ -660,10 +659,38 @@ def main() -> None:
                 f"{workflow.name} exposes branch-selectable dispatch with a release-capable secret"
             )
 
+    dependency_wave = (WORKFLOWS / "kin-dependency-wave.yml").read_text(
+        encoding="utf-8"
+    )
+    dependency_pin = "d06908b534ad5a70bb0f39a1b2b8d6228acf70a4"
+    for policy in (
+        "types: [kin-registry-release]",
+        'cron: "17 * * * *"',
+        "contents: read",
+        "cancel-in-progress: false",
+        "environment: release-followups",
+        "actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1",
+        "secrets.KIN_RELEASE_APP_ID",
+        "secrets.KIN_RELEASE_APP_PRIVATE_KEY",
+        "repositories: kin",
+        "permission-contents: write",
+        "permission-pull-requests: write",
+        "skip-token-revoke: true",
+        "needs: app-token",
+        f"cargo-dependency-wave.yml@{dependency_pin}",
+        f"kin-actions-ref: {dependency_pin}",
+        "KIN_CI_BOT_TOKEN: ${{ needs.app-token.outputs.token }}",
+    ):
+        require(dependency_wave, policy, "dependency-wave recovery workflow")
+    if "workflow_dispatch" in dependency_wave:
+        raise AssertionError(
+            "dependency wave must not expose branch-selectable workflow_dispatch"
+        )
+
     print(
         "release workflow authority is tag-only, protected, pinned, GCP-free, "
         "cross-platform byte-canonical, and npm automatic through short-lived "
-        "OIDC with post-public proof"
+        "OIDC with post-public proof; dependency-wave recovery is active"
     )
 
 


### PR DESCRIPTION
## Outcome

Restores the dependency-wave workflow that was removed in the unrelated npm-recovery commit. The current registry publisher sends `kin-registry-release`, but Kin has no matching workflow, so the successful kin-vfs-core 0.1.5 dispatch created no consumer PR.

This workflow:

- consumes the canonical `kin-registry-release` event;
- runs an hourly missed-callback reconciliation at minute 17;
- serializes events instead of cancelling in-flight updates;
- keeps the default GITHUB_TOKEN read-only;
- mints a one-hour selected-repository GitHub App token behind the main-only `release-followups` environment;
- calls the SHA-pinned kin-actions v0.1.9 dependency workflow and opens a signed-off PR only after the Kin smoke command passes.

## Verification

- actionlint over every workflow
- release authority policy test
- diff check
- DCO sign-off

## Activation gate

Do not merge until the selected-repository GitHub App is installed for `kin`, `homebrew-kin`, and `kin-infra`, with Actions read, Contents write, and Pull requests write, and its ID/private key are stored in the main-only `release-followups` environment. The same App then activates the existing immediate release follow-up callback.