### PR TITLE
Bump kin-vfs-core to 0.1.5

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3639,9 +3639,9 @@ dependencies = [
 
 [[package]]
 name = "kin-vfs-core"
-version = "0.1.4"
+version = "0.1.5"
 source = "sparse+https://kinlab.ai/registry/cargo/"
-checksum = "2fbdfd41caf204a56ab7f6153cc9c9199a02c01a37b932d494fbbb506d85d644"
+checksum = "0a6c0383abd5fdf900c67427ac5f9ab40306cd2165e8d4c86c1e2cfa3d57bbba"
 dependencies = [
  "lru",
  "parking_lot",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -144,7 +144,7 @@ kin-lsp = { version = "0.2.2", registry = "kin" }
 # additively on macOS via a `[target.'cfg(target_os = "macos")'.dependencies]` block in the
 # binary/runtime crates (kin-cli, kin-daemon). Feature unification makes that additive.
 kin-db = { version = "0.2.37", registry = "kin", default-features = false }
-kin-vfs-core = { version = "0.1.4", registry = "kin" }
+kin-vfs-core = { version = "0.1.5", registry = "kin" }
 
 [profile.release]
 opt-level = 3


### PR DESCRIPTION
## What changed

- require `kin-vfs-core` 0.1.5
- refresh the registry-backed lock entry and published checksum
- keep every other dependency pin byte-for-byte unchanged

## Why

The public v0.2.21 Linux/arm64 VFS acceptance run reproduced `fstat(stdout) = EINVAL`. The source repair merged in firelock-ai/kin-vfs#32 and `kin-vfs-core` 0.1.5 is published. Kin still pinned 0.1.4 because the automatic dependency-wave callback was not armed, so this is the narrow consumer bump needed for the next public release and exact Linux rerun.

## Verification

- `cargo check --locked -p kin-cli --all-targets --all-features`
- `cargo test --locked -p kin-cli vfs --lib` (1 passed; 843 filtered)
- detached `/tmp` registry-only check with a fresh Cargo home
- registry-clean lock audit: 8 external Kin dependencies retain registry sources/checksums
- `kin-vfs-core` 0.1.5 checksum: `0a6c0383abd5fdf900c67427ac5f9ab40306cd2165e8d4c86c1e2cfa3d57bbba`
- `git diff --check`

## Claim boundary

This consumes the published source fix. It does not repair the already-published v0.2.21 bundle. FIR-1384 remains open until a later Kin release passes the unchanged public Linux/arm64 acceptance run.