### PR TITLE
Release Kin v0.2.22 with Linux VFS acceptance

### DIFF
--- a/.github/workflows/install-proof.yml
+++ b/.github/workflows/install-proof.yml
@@ -15,6 +15,10 @@ on:
         description: Exact public release tag to install and verify.
         required: true
         type: string
+      expected_vfs_commit:
+        description: Reviewed kin-vfs commit pinned by the calling release workflow.
+        required: true
+        type: string
   workflow_dispatch:
     inputs:
       release_tag:
@@ -86,6 +90,7 @@ jobs:
         shell: bash
         env:
           RELEASE_EVENT_TAG: ${{ inputs.release_tag || github.event.release.tag_name || '' }}
+          REVIEWED_VFS_COMMIT: ${{ inputs.expected_vfs_commit || '' }}
           GH_TOKEN: ${{ github.token }}
         run: |
           set -euo pipefail
@@ -176,6 +181,7 @@ jobs:
             if gh attestation verify "attested-$release_asset" \
               --repo firelock-ai/kin \
               --signer-workflow firelock-ai/kin/.github/workflows/release.yml \
+              --signer-digest "$expected_commit" \
               --source-ref "refs/tags/$expected_tag" \
               --source-digest "$expected_commit" \
               --deny-self-hosted-runners \
@@ -190,6 +196,151 @@ jobs:
             sleep 10
           done
           test "$verified" = true
+
+          curl -fsSL --retry 5 --retry-all-errors --retry-delay 2 \
+            "https://github.com/firelock-ai/kin/releases/download/$expected_tag/release-provenance.json" \
+            -o release-provenance.json
+          curl -fsSL --retry 5 --retry-all-errors --retry-delay 2 \
+            "https://github.com/firelock-ai/kin/releases/download/$expected_tag/release-provenance.json.sha256" \
+            -o release-provenance.json.sha256
+
+          expected_vfs_commit="$REVIEWED_VFS_COMMIT"
+          if [ -z "$expected_vfs_commit" ]; then
+            expected_vfs_commit="$(node -e \
+              'process.stdout.write(JSON.parse(require("fs").readFileSync("release-provenance.json", "utf8")).kin_vfs?.commit || "")')"
+          fi
+          if ! printf '%s\n' "$expected_vfs_commit" | grep -Eq '^[0-9a-f]{40}$'; then
+            echo "could not resolve the reviewed kin-vfs commit for $expected_tag" >&2
+            exit 1
+          fi
+
+          RELEASE_ASSET="$release_asset" EXPECTED_TAG="$expected_tag" \
+          EXPECTED_COMMIT="$expected_commit" \
+          EXPECTED_VFS_COMMIT="$expected_vfs_commit" node <<'NODE'
+          const crypto = require("crypto");
+          const fs = require("fs");
+
+          const fail = (condition, message) => {
+            if (!condition) throw new Error(message);
+          };
+          const sha256 = (file) =>
+            crypto.createHash("sha256").update(fs.readFileSync(file)).digest("hex");
+          const sidecar = fs.readFileSync("release-provenance.json.sha256", "utf8").trim();
+          const sidecarMatch = sidecar.match(/^([0-9a-f]{64})\s+\*?release-provenance\.json$/);
+          fail(sidecarMatch, "release provenance checksum sidecar is malformed");
+          fail(sidecarMatch[1] === sha256("release-provenance.json"),
+            "release provenance checksum does not match its public sidecar");
+
+          const manifest = JSON.parse(fs.readFileSync("release-provenance.json", "utf8"));
+          fail(manifest.schema_version === 1, "release provenance schema is unsupported");
+          fail(manifest.release_tag === process.env.EXPECTED_TAG,
+            "release provenance tag does not match the installed release");
+          fail(manifest.kin?.commit === process.env.EXPECTED_COMMIT,
+            "release provenance Kin commit does not match the installed release tag");
+          fail(manifest.kin_vfs?.commit === process.env.EXPECTED_VFS_COMMIT,
+            "release provenance does not bind the reviewed kin-vfs commit");
+          fail(manifest.kin_vfs?.dirty === false,
+            "release provenance does not certify a clean kin-vfs checkout");
+          const platform = manifest.artifacts?.find(
+            (artifact) => artifact.archive?.name === process.env.RELEASE_ASSET
+          );
+          fail(platform, `release provenance omits ${process.env.RELEASE_ASSET}`);
+          fail(platform.release_tag === process.env.EXPECTED_TAG,
+            "platform provenance tag does not match the installed release");
+          fail(platform.kin?.commit === process.env.EXPECTED_COMMIT,
+            "platform provenance Kin commit does not match the installed release");
+          fail(platform.kin_vfs?.commit === process.env.EXPECTED_VFS_COMMIT,
+            "platform provenance does not bind the reviewed kin-vfs commit");
+          fail(platform.archive?.sha256 === sha256(`attested-${process.env.RELEASE_ASSET}`),
+            "attested archive bytes do not match aggregate release provenance");
+          NODE
+
+          aggregate_verified=false
+          for attempt in $(seq 1 18); do
+            if gh attestation verify release-provenance.json \
+              --repo firelock-ai/kin \
+              --signer-workflow firelock-ai/kin/.github/workflows/release.yml \
+              --signer-digest "$expected_commit" \
+              --source-ref "refs/tags/$expected_tag" \
+              --source-digest "$expected_commit" \
+              --deny-self-hosted-runners \
+              --format json > release-provenance-attestation.json; then
+              aggregate_verified=true
+              break
+            fi
+            if [ "$attempt" -eq 18 ]; then
+              echo "aggregate release provenance attestation did not become verifiable" >&2
+              exit 1
+            fi
+            sleep 10
+          done
+          test "$aggregate_verified" = true
+
+          content_root=""
+          shim_name=""
+          if [ "$RUNNER_OS" != "Windows" ]; then
+            extract_root="$RUNNER_TEMP/attested-release"
+            rm -rf "$extract_root"
+            mkdir -p "$extract_root"
+            tar -xzf "attested-$release_asset" -C "$extract_root"
+            artifact_name="${release_asset%.tar.gz}"
+            content_root="$extract_root/$artifact_name"
+            test -d "$content_root"
+            case "$RUNNER_OS" in
+              Linux) shim_name="libkin_vfs_shim.so" ;;
+              macOS) shim_name="libkin_vfs_shim.dylib" ;;
+              *) echo "unsupported Unix runner $RUNNER_OS" >&2; exit 1 ;;
+            esac
+          fi
+
+          RUN_COMPONENT_COMPARE="$([ "$RUNNER_OS" != "Windows" ] && printf true || printf false)" \
+          RELEASE_ASSET="$release_asset" EXPECTED_TAG="$expected_tag" \
+          EXPECTED_COMMIT="$expected_commit" CONTENT_ROOT="$content_root" \
+          EXPECTED_VFS_COMMIT="$expected_vfs_commit" \
+          INSTALLED_VFS="$HOME/.kin/bin/kin-vfs" \
+          INSTALLED_SHIM="$HOME/.kin/lib/$shim_name" \
+          SHIM_NAME="$shim_name" node <<'NODE'
+          if (process.env.RUN_COMPONENT_COMPARE !== "true") process.exit(0);
+          const crypto = require("crypto");
+          const fs = require("fs");
+          const path = require("path");
+
+          const fail = (condition, message) => {
+            if (!condition) throw new Error(message);
+          };
+          const sha256Bytes = (bytes) => crypto.createHash("sha256").update(bytes).digest("hex");
+          const manifest = JSON.parse(fs.readFileSync("release-provenance.json", "utf8"));
+          const platform = manifest.artifacts.find(
+            (artifact) => artifact.archive?.name === process.env.RELEASE_ASSET
+          );
+          const records = new Map(platform.archive_contents.map((entry) => [entry.name, entry]));
+          const components = [
+            { name: "kin-vfs", installed: process.env.INSTALLED_VFS },
+            { name: process.env.SHIM_NAME, installed: process.env.INSTALLED_SHIM },
+          ].map((component) => {
+            const archived = path.join(process.env.CONTENT_ROOT, component.name);
+            const installedBytes = fs.readFileSync(component.installed);
+            const archivedBytes = fs.readFileSync(archived);
+            fail(installedBytes.equals(archivedBytes),
+              `installed ${component.name} differs from the attested public archive`);
+            const digest = sha256Bytes(installedBytes);
+            fail(records.get(component.name)?.sha256 === digest,
+              `installed ${component.name} hash differs from aggregate release provenance`);
+            return {
+              name: component.name,
+              installed_path: component.installed,
+              sha256: digest,
+            };
+          });
+          fs.writeFileSync("installed-vfs-provenance.json", `${JSON.stringify({
+            schema_version: 1,
+            release_tag: process.env.EXPECTED_TAG,
+            kin_commit: process.env.EXPECTED_COMMIT,
+            kin_vfs_commit: process.env.EXPECTED_VFS_COMMIT,
+            archive: process.env.RELEASE_ASSET,
+            components,
+          }, null, 2)}\n`);
+          NODE
 
       - name: First-run repository, daemon, and setup proof
         shell: bash
@@ -338,6 +489,176 @@ jobs:
           });
           child.stdin.end(`${requests.map((request) => JSON.stringify(request)).join("\n")}\n`);
           NODE
+
+      - name: Graph-backed VFS projection proof
+        if: runner.os != 'Windows'
+        shell: bash
+        working-directory: kin-install-proof
+        run: |
+          set -euo pipefail
+          probe_bin="$RUNNER_TEMP/kin-vfs-open-probe"
+          cc -O2 -Wall -Wextra -Werror -x c -o "$probe_bin" - <<'C'
+          #include <errno.h>
+          #include <fcntl.h>
+          #include <stdio.h>
+          #include <sys/stat.h>
+          #include <unistd.h>
+
+          int main(int argc, char **argv) {
+              if (argc != 2) {
+                  fputs("usage: kin-vfs-open-probe <path>\n", stderr);
+                  return 2;
+              }
+
+              struct stat stdout_stat;
+              if (fstat(STDOUT_FILENO, &stdout_stat) != 0) {
+                  perror("fstat(stdout)");
+                  return 3;
+              }
+
+              int fd = open(argv[1], O_RDONLY);
+              if (fd < 0) {
+                  perror("open");
+                  return 4;
+              }
+
+              char buffer[4096];
+              for (;;) {
+                  ssize_t count = read(fd, buffer, sizeof(buffer));
+                  if (count == 0) {
+                      break;
+                  }
+                  if (count < 0) {
+                      if (errno == EINTR) {
+                          continue;
+                      }
+                      perror("read");
+                      close(fd);
+                      return 5;
+                  }
+                  for (ssize_t written = 0; written < count;) {
+                      ssize_t step = write(STDOUT_FILENO, buffer + written, (size_t)(count - written));
+                      if (step < 0 && errno == EINTR) {
+                          continue;
+                      }
+                      if (step <= 0) {
+                          perror("write");
+                          close(fd);
+                          return 6;
+                      }
+                      written += step;
+                  }
+              }
+
+              if (close(fd) != 0) {
+                  perror("close");
+                  return 7;
+              }
+              return 0;
+          }
+          C
+
+          vfs_pid=""
+          cleanup_vfs() {
+            cleanup_status=0
+            chmod u+rw probe.py || cleanup_status=1
+            if [ -n "$vfs_pid" ]; then
+              kin-vfs stop --workspace . >> kin-vfs-daemon.log 2>&1 || cleanup_status=1
+              stopped=false
+              for _ in $(seq 1 150); do
+                process_state="$(ps -o stat= -p "$vfs_pid" 2>/dev/null | tr -d '[:space:]')"
+                if [ -z "$process_state" ] || printf '%s\n' "$process_state" | grep -q 'Z'; then
+                  stopped=true
+                  break
+                fi
+                sleep 0.1
+              done
+              if [ "$stopped" != true ]; then
+                cat kin-vfs-daemon.log >&2
+                echo "installed kin-vfs daemon did not stop cleanly" >&2
+                kill "$vfs_pid" 2>/dev/null || true
+                sleep 1
+                kill -9 "$vfs_pid" 2>/dev/null || true
+                wait "$vfs_pid" 2>/dev/null || true
+                cleanup_status=1
+              else
+                wait_status=0
+                wait "$vfs_pid" || wait_status=$?
+                case "$wait_status" in
+                  0|143) ;;
+                  *)
+                    echo "installed kin-vfs daemon exited with unexpected status $wait_status" >&2
+                    cleanup_status=1
+                    ;;
+                esac
+              fi
+            fi
+            if [ -S .kin/vfs.sock ]; then
+              echo "installed kin-vfs socket remained after shutdown" >&2
+              cleanup_status=1
+            fi
+            test -r probe.py || cleanup_status=1
+            return "$cleanup_status"
+          }
+          on_vfs_signal() {
+            signal_status="$1"
+            trap - EXIT INT TERM
+            cleanup_vfs || true
+            exit "$signal_status"
+          }
+          trap 'cleanup_vfs || true' EXIT
+          trap 'on_vfs_signal 130' INT
+          trap 'on_vfs_signal 143' TERM
+
+          kin-vfs start --workspace . > kin-vfs-daemon.log 2>&1 &
+          vfs_pid=$!
+          socket_ready=false
+          for _ in $(seq 1 150); do
+            if [ -S .kin/vfs.sock ]; then
+              socket_ready=true
+              break
+            fi
+            if ! kill -0 "$vfs_pid" 2>/dev/null; then
+              break
+            fi
+            sleep 0.1
+          done
+          if [ "$socket_ready" != true ]; then
+            cat kin-vfs-daemon.log >&2
+            echo "installed kin-vfs daemon did not bind its socket" >&2
+            exit 1
+          fi
+
+          # The direct read is the negative control. With raw disk unreadable,
+          # only the installed shim and real Kin daemon can return probe.py.
+          chmod 000 probe.py
+          set +e
+          "$probe_bin" "$PWD/probe.py" > vfs-negative.txt 2>&1
+          negative_status=$?
+          set -e
+          if [ "$negative_status" -ne 4 ]; then
+            cat vfs-negative.txt >&2
+            echo "negative control failed before the expected raw-disk open denial (status $negative_status)" >&2
+            exit 1
+          fi
+          if ! grep -Eq '^open: (Permission denied|Operation not permitted)$' vfs-negative.txt; then
+            cat vfs-negative.txt >&2
+            echo "negative control did not fail with the expected raw-disk permission error" >&2
+            exit 1
+          fi
+
+          KIN_VFS_STRICT=1 kin-vfs exec --workspace . -- \
+            "$probe_bin" "$PWD/probe.py" \
+            > vfs-graph-read.txt 2> vfs-graph-read.stderr.txt
+          printf 'def hello():\n    return 42\n' > vfs-expected.txt
+          if ! cmp -s vfs-expected.txt vfs-graph-read.txt; then
+            cmp -l vfs-expected.txt vfs-graph-read.txt >&2 || true
+            echo "installed VFS did not return the exact graph-owned probe.py bytes" >&2
+            exit 1
+          fi
+
+          cleanup_vfs
+          trap - EXIT INT TERM
 
       - name: Unix embedding and semantic retrieval proof
         if: runner.os != 'Windows'
@@ -560,6 +881,11 @@ jobs:
             expected-commit.txt
             expected-lock-sha.txt
             attestation-verification.json
+            release-provenance.json
+            release-provenance.json.sha256
+            release-provenance-attestation.json
+            installed-vfs-provenance.json
             latest-release-url.txt
             kin-install-proof/*.txt
             kin-install-proof/*.json
+            kin-install-proof/*.log

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1764,6 +1764,376 @@ jobs:
             fi
           fi
 
+  # Move GHCR's mutable convenience tag only after every stable release proof
+  # has succeeded and GitHub Latest names this exact tag. The commit and
+  # version tags remain the immutable authority; `latest` is a verified alias
+  # to that already-attested digest and is never rebuilt here.
+  promote_ghcr_latest:
+    name: Promote stable ghcr latest
+    needs: [config, finalize_release, version_tag_image, build_daemon_image, attest_daemon_image]
+    if: >-
+      ${{
+        always() &&
+        needs.config.result == 'success' &&
+        needs.finalize_release.result == 'success' &&
+        needs.version_tag_image.result == 'success' &&
+        needs.build_daemon_image.result == 'success' &&
+        needs.attest_daemon_image.result == 'success' &&
+        needs.config.outputs.release_channel == 'latest' &&
+        startsWith(github.ref, 'refs/tags/v') &&
+        !contains(github.ref_name, '-')
+      }}
+    runs-on: ubuntu-latest
+    environment: release
+    # Least privilege for one registry-side tag move plus readback of the
+    # existing OCI attestation. This job cannot create releases or attestations.
+    permissions:
+      contents: read
+      packages: write
+      attestations: read
+    steps:
+      - name: Checkout release source
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
+          fetch-depth: 0
+
+      - name: Log in to GitHub Container Registry
+        uses: docker/login-action@af1e73f918a031802d376d3c8bbc3fe56130a9b0 # v4.0.0
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3.12.0
+
+      - name: Promote the proven stable digest to ghcr latest
+        shell: bash
+        env:
+          GH_TOKEN: ${{ github.token }}
+          IMAGE: ghcr.io/firelock-ai/kin
+          EXPECTED_COMMIT: ${{ needs.build_daemon_image.outputs.commit }}
+          EXPECTED_SOURCE_DIGEST: ${{ needs.build_daemon_image.outputs.digest }}
+        run: |
+          set -euo pipefail
+
+          VERSION="${GITHUB_REF_NAME#v}"
+          if ! printf '%s\n' "$GITHUB_REF_NAME" \
+            | grep -Eq '^v(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)$'; then
+            echo "::error::$GITHUB_REF_NAME is not an exact stable release tag"
+            exit 1
+          fi
+          if [ "$GITHUB_REF" != "refs/tags/${GITHUB_REF_NAME}" ]; then
+            echo "::error::release ref $GITHUB_REF does not match tag $GITHUB_REF_NAME"
+            exit 1
+          fi
+          channel="$(node scripts/release-order.mjs channel "$VERSION")"
+          if [ "$channel" != "latest" ]; then
+            echo "::error::$GITHUB_REF_NAME resolved to release channel $channel, not latest"
+            exit 1
+          fi
+
+          COMMIT="$(git rev-parse "${GITHUB_REF_NAME}^{commit}")"
+          checkout_commit="$(git rev-parse HEAD)"
+          if [ "$COMMIT" != "$checkout_commit" ]; then
+            echo "::error::release tag peels to $COMMIT, checkout resolved to $checkout_commit"
+            exit 1
+          fi
+          if [ "$COMMIT" != "$EXPECTED_COMMIT" ]; then
+            echo "::error::release tag peels to $COMMIT, image job resolved to $EXPECTED_COMMIT"
+            exit 1
+          fi
+          if ! printf '%s\n' "$COMMIT" | grep -Eq '^[0-9a-f]{40}$'; then
+            echo "::error::release tag did not resolve to a full commit id"
+            exit 1
+          fi
+          if ! printf '%s\n' "$EXPECTED_SOURCE_DIGEST" \
+            | grep -Eq '^sha256:[0-9a-f]{64}$'; then
+            echo "::error::image job did not provide an exact sha256 digest"
+            exit 1
+          fi
+
+          SRC="${IMAGE}:${COMMIT}"
+          VERSION_TAG="${IMAGE}:${VERSION}"
+          V_VERSION_TAG="${IMAGE}:${GITHUB_REF_NAME}"
+          LATEST="${IMAGE}:latest"
+
+          inspect_digest() {
+            local reference="$1"
+            local output
+            for attempt in 1 2 3 4 5; do
+              if output="$(docker buildx imagetools inspect "$reference" \
+                --format '{{.Manifest.Digest}}' 2>&1)"; then
+                printf '%s\n' "$output"
+                return 0
+              fi
+              if [ "$output" = "ERROR: ${reference}: not found" ]; then
+                return 44
+              fi
+              if [ "$attempt" -eq 5 ]; then
+                printf '%s\n' "$output" >&2
+                echo "::error::could not establish registry state for $reference" >&2
+                return 1
+              fi
+              sleep $(( attempt * 2 ))
+            done
+          }
+
+          resolve_required_digest() {
+            local reference="$1"
+            local label="$2"
+            local digest
+            local status
+            if digest="$(inspect_digest "$reference")"; then
+              :
+            else
+              status=$?
+              if [ "$status" -eq 44 ]; then
+                echo "::error::$label $reference does not exist" >&2
+              fi
+              return "$status"
+            fi
+            if ! printf '%s\n' "$digest" | grep -Eq '^sha256:[0-9a-f]{64}$'; then
+              echo "::error::$label $reference did not resolve to an exact sha256 digest" >&2
+              return 1
+            fi
+            printf '%s\n' "$digest"
+          }
+
+          wait_for_expected_digest() {
+            local reference="$1"
+            local expected="$2"
+            local label="$3"
+            local digest="<missing>"
+            local status
+            local matching_reads=0
+            for attempt in $(seq 1 12); do
+              if digest="$(inspect_digest "$reference")"; then
+                if ! printf '%s\n' "$digest" | grep -Eq '^sha256:[0-9a-f]{64}$'; then
+                  echo "::error::$label $reference did not resolve to an exact sha256 digest" >&2
+                  return 1
+                fi
+                if [ "$digest" = "$expected" ]; then
+                  matching_reads=$((matching_reads + 1))
+                  if [ "$matching_reads" -eq 2 ]; then
+                    printf '%s\n' "$digest"
+                    return 0
+                  fi
+                else
+                  matching_reads=0
+                fi
+              else
+                status=$?
+                if [ "$status" -ne 44 ]; then
+                  return "$status"
+                fi
+                digest="<missing>"
+                matching_reads=0
+              fi
+              if [ "$attempt" -lt 12 ]; then
+                sleep 2
+              fi
+            done
+            echo "::error::$label $reference did not converge to $expected; last observed $digest" >&2
+            return 1
+          }
+
+          verify_stable_release_authority() {
+            local latest_tag
+            local prerelease
+            latest_tag="$(gh api \
+              "repos/${GITHUB_REPOSITORY}/releases/latest" --jq '.tag_name')"
+            if [ "$latest_tag" != "$GITHUB_REF_NAME" ]; then
+              echo "::error::GitHub Latest moved to $latest_tag; expected $GITHUB_REF_NAME"
+              return 1
+            fi
+            prerelease="$(gh api \
+              "repos/${GITHUB_REPOSITORY}/releases/tags/${GITHUB_REF_NAME}" \
+              --jq '.prerelease')"
+            if [ "$prerelease" != "false" ]; then
+              echo "::error::$GITHUB_REF_NAME is prerelease=$prerelease, expected false"
+              return 1
+            fi
+          }
+
+          verify_attestation() {
+            local digest="$1"
+            local verified=false
+            for attempt in 1 2 3 4 5; do
+              if gh attestation verify \
+                "oci://${IMAGE}@${digest}" \
+                --repo "$GITHUB_REPOSITORY" \
+                --bundle-from-oci \
+                --predicate-type https://slsa.dev/provenance/v1 \
+                --signer-workflow "$GITHUB_REPOSITORY/.github/workflows/release.yml" \
+                --signer-digest "$COMMIT" \
+                --source-digest "$COMMIT" \
+                --source-ref "$GITHUB_REF" \
+                --deny-self-hosted-runners; then
+                verified=true
+                break
+              fi
+              sleep $(( attempt * 2 ))
+            done
+            if [ "$verified" != true ]; then
+              echo "::error::could not verify the exact daemon image attestation"
+              return 1
+            fi
+          }
+
+          verify_immutable_authority() {
+            local phase="$1"
+            local actual_source
+            local actual_version
+            local actual_v_version
+            actual_source="$(resolve_required_digest "$SRC" "$phase source")"
+            if [ "$actual_source" != "$EXPECTED_SOURCE_DIGEST" ]; then
+              echo "::error::$phase $SRC resolved to $actual_source, expected $EXPECTED_SOURCE_DIGEST"
+              return 1
+            fi
+            actual_version="$(resolve_required_digest "$VERSION_TAG" "$phase version tag")"
+            actual_v_version="$(resolve_required_digest "$V_VERSION_TAG" "$phase v-version tag")"
+            if [ "$actual_version" != "$EXPECTED_SOURCE_DIGEST" ] || \
+              [ "$actual_v_version" != "$EXPECTED_SOURCE_DIGEST" ]; then
+              echo "::error::$phase version tags do not resolve to $EXPECTED_SOURCE_DIGEST"
+              return 1
+            fi
+            bash scripts/verify-container-build-info.sh \
+              "${IMAGE}@${actual_source}" "$COMMIT"
+            verify_attestation "$actual_source"
+          }
+
+          # Initial fail-closed admission. Finalization must already have made
+          # this exact stable tag GitHub Latest, and every immutable image
+          # identity must still resolve to the build job's attested digest.
+          verify_stable_release_authority
+          verify_immutable_authority "initial"
+
+          initial_latest_state=missing
+          initial_latest_digest=""
+          if initial_latest_digest="$(inspect_digest "$LATEST")"; then
+            initial_latest_state=present
+            if ! printf '%s\n' "$initial_latest_digest" \
+              | grep -Eq '^sha256:[0-9a-f]{64}$'; then
+              echo "::error::$LATEST did not resolve to an exact sha256 digest"
+              exit 1
+            fi
+          else
+            inspect_status=$?
+            if [ "$inspect_status" -ne 44 ]; then
+              exit "$inspect_status"
+            fi
+          fi
+
+          action="Verified existing"
+          mutation_required=true
+          if [ "$initial_latest_digest" = "$EXPECTED_SOURCE_DIGEST" ]; then
+            mutation_required=false
+          fi
+
+          if [ "$mutation_required" = true ]; then
+            # Recheck every authority immediately before the sole mutable write.
+            # A concurrent correct promotion is idempotently accepted. Changes
+            # observed before the write fail closed; GHCR offers no atomic
+            # compare-and-swap, so bounded post-write convergence checks guard
+            # the remaining read/write race window.
+            verify_stable_release_authority
+            verify_immutable_authority "pre-write"
+
+            prewrite_latest_state=missing
+            prewrite_latest_digest=""
+            if prewrite_latest_digest="$(inspect_digest "$LATEST")"; then
+              prewrite_latest_state=present
+              if ! printf '%s\n' "$prewrite_latest_digest" \
+                | grep -Eq '^sha256:[0-9a-f]{64}$'; then
+                echo "::error::pre-write $LATEST did not resolve to an exact sha256 digest"
+                exit 1
+              fi
+            else
+              inspect_status=$?
+              if [ "$inspect_status" -ne 44 ]; then
+                exit "$inspect_status"
+              fi
+            fi
+
+            if [ "$prewrite_latest_digest" = "$EXPECTED_SOURCE_DIGEST" ]; then
+              mutation_required=false
+              action="Verified concurrent"
+            elif [ "$prewrite_latest_state" != "$initial_latest_state" ] || \
+              [ "$prewrite_latest_digest" != "$initial_latest_digest" ]; then
+              echo "::error::$LATEST changed from ${initial_latest_state}:${initial_latest_digest:-<missing>} to ${prewrite_latest_state}:${prewrite_latest_digest:-<missing>} during admission"
+              exit 1
+            fi
+
+            if [ "$mutation_required" = true ]; then
+              # Last-moment rollback and source checks bound the remaining race
+              # window before the one registry mutation in this job.
+              verify_stable_release_authority
+              prewrite_source_digest="$(resolve_required_digest "$SRC" "pre-write source recheck")"
+              if [ "$prewrite_source_digest" != "$EXPECTED_SOURCE_DIGEST" ]; then
+                echo "::error::pre-write source moved to $prewrite_source_digest"
+                exit 1
+              fi
+
+              final_prewrite_latest_state=missing
+              final_prewrite_latest_digest=""
+              if final_prewrite_latest_digest="$(inspect_digest "$LATEST")"; then
+                final_prewrite_latest_state=present
+                if ! printf '%s\n' "$final_prewrite_latest_digest" \
+                  | grep -Eq '^sha256:[0-9a-f]{64}$'; then
+                  echo "::error::final pre-write $LATEST did not resolve to an exact sha256 digest"
+                  exit 1
+                fi
+              else
+                inspect_status=$?
+                if [ "$inspect_status" -ne 44 ]; then
+                  exit "$inspect_status"
+                fi
+              fi
+
+              if [ "$final_prewrite_latest_digest" = "$EXPECTED_SOURCE_DIGEST" ]; then
+                mutation_required=false
+                action="Verified concurrent"
+              elif [ "$final_prewrite_latest_state" != "$prewrite_latest_state" ] || \
+                [ "$final_prewrite_latest_digest" != "$prewrite_latest_digest" ]; then
+                echo "::error::$LATEST changed from ${prewrite_latest_state}:${prewrite_latest_digest:-<missing>} to ${final_prewrite_latest_state}:${final_prewrite_latest_digest:-<missing>} during final admission"
+                exit 1
+              fi
+
+              if [ "$mutation_required" = true ]; then
+                docker buildx imagetools create \
+                  --prefer-index=false \
+                  --tag "$LATEST" \
+                  "${IMAGE}@${EXPECTED_SOURCE_DIGEST}"
+                action="Promoted"
+              fi
+            fi
+          fi
+
+          # Post-write verification is mandatory on both the mutation and
+          # idempotent rerun paths. Resolve through :latest itself, then verify
+          # its embedded build identity and the immutable digest's attestation.
+          verify_stable_release_authority
+          verify_immutable_authority "post-write"
+          actual_latest_digest="$(wait_for_expected_digest \
+            "$LATEST" "$EXPECTED_SOURCE_DIGEST" "post-write latest")"
+          bash scripts/verify-container-build-info.sh "$LATEST" "$COMMIT"
+          verify_attestation "$actual_latest_digest"
+          wait_for_expected_digest \
+            "$LATEST" "$EXPECTED_SOURCE_DIGEST" "final latest readback" \
+            >/dev/null
+
+          {
+            echo "${action} stable daemon image alias:"
+            echo ""
+            echo "- GitHub Latest: \`${GITHUB_REF_NAME}\`"
+            echo "- source: \`${SRC}\`"
+            echo "- destination: \`${LATEST}\`"
+            echo "- digest: \`${EXPECTED_SOURCE_DIGEST}\`"
+            echo "- no image was rebuilt"
+          } >> "$GITHUB_STEP_SUMMARY"
+
   publish_boundary_contracts:
     name: Post-release boundary contracts publish
     needs: [publish, install_proof, finalize_release]

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -454,7 +454,7 @@ jobs:
           repository: firelock-ai/kin-vfs
           path: kin-vfs
           # Release inputs must never move under an unchanged Kin tag.
-          ref: 64d94af54cd049a54c999e20857f5eec4bcde45c
+          ref: 1c531216c65b734fb5e7c996094e01e030b8eec7
           persist-credentials: false
 
       - name: Verify canonical release input bytes
@@ -484,6 +484,32 @@ jobs:
             }
             console.log(`Verified canonical ${label} Cargo.lock bytes: ${sha256(tracked)}`);
           }
+
+          const lockPackages = (lockPath) => fs.readFileSync(lockPath, "utf8")
+            .split("[[package]]")
+            .slice(1)
+            .map((block) => ({
+              name: block.match(/^name = "([^"]+)"/m)?.[1],
+              version: block.match(/^version = "([^"]+)"/m)?.[1],
+              source: block.match(/^source = "([^"]+)"/m)?.[1] ?? null,
+            }));
+          const kinVfsCore = lockPackages(path.join(process.cwd(), "Cargo.lock"))
+            .filter((pkg) => pkg.name === "kin-vfs-core" && pkg.source?.startsWith("sparse+"));
+          const pinnedVfsCore = lockPackages(path.join(process.cwd(), "kin-vfs", "Cargo.lock"))
+            .filter((pkg) => pkg.name === "kin-vfs-core" && pkg.source === null);
+          if (kinVfsCore.length !== 1 || pinnedVfsCore.length !== 1) {
+            throw new Error(
+              `expected one registry Kin kin-vfs-core and one pinned local kin-vfs-core; ` +
+              `found ${kinVfsCore.length} and ${pinnedVfsCore.length}`
+            );
+          }
+          if (kinVfsCore[0].version !== pinnedVfsCore[0].version) {
+            throw new Error(
+              `Kin resolves kin-vfs-core ${kinVfsCore[0].version}, but the pinned release ` +
+              `checkout builds ${pinnedVfsCore[0].version}; update the immutable kin-vfs pin`
+            );
+          }
+          console.log(`Verified Kin/kin-vfs release compatibility at kin-vfs-core ${kinVfsCore[0].version}`);
           NODE
 
       - name: Cache Cargo registry and build artifacts
@@ -845,7 +871,7 @@ jobs:
           ARTIFACT: ${{ matrix.artifact }}
           TARGET: ${{ matrix.target }}
           VFS_TARGET: ${{ matrix.vfs_target || matrix.target }}
-          EXPECTED_VFS_COMMIT: 64d94af54cd049a54c999e20857f5eec4bcde45c
+          EXPECTED_VFS_COMMIT: 1c531216c65b734fb5e7c996094e01e030b8eec7
         run: |
           set -euo pipefail
           node <<'NODE'
@@ -1077,7 +1103,7 @@ jobs:
         with:
           repository: firelock-ai/kin-vfs
           path: release-inputs/kin-vfs
-          ref: 64d94af54cd049a54c999e20857f5eec4bcde45c
+          ref: 1c531216c65b734fb5e7c996094e01e030b8eec7
           persist-credentials: false
 
       - name: Download all artifacts
@@ -1135,7 +1161,7 @@ jobs:
 
       - name: Verify and aggregate release provenance
         env:
-          EXPECTED_VFS_COMMIT: 64d94af54cd049a54c999e20857f5eec4bcde45c
+          EXPECTED_VFS_COMMIT: 1c531216c65b734fb5e7c996094e01e030b8eec7
         run: |
           set -euo pipefail
           node <<'NODE'
@@ -1383,6 +1409,7 @@ jobs:
     uses: ./.github/workflows/install-proof.yml
     with:
       release_tag: ${{ github.ref_name }}
+      expected_vfs_commit: 1c531216c65b734fb5e7c996094e01e030b8eec7
     permissions:
       contents: read
       attestations: read

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.2.22] - 2026-07-14
+
+This patch restores Linux AArch64 VFS passthrough and makes the public install
+gate exercise the shipped graph-backed projection instead of setup metadata
+alone.
+
+### Fixed
+
+- Release archives now build Kin VFS from the reviewed 0.1.5 source containing
+  the Linux AArch64 `fstat(stdout)` passthrough repair, with an immutable source
+  pin and a lock-version compatibility check against Kin's registry dependency.
+- Public install proof now makes a tracked source file unreadable on raw disk,
+  then requires the installed shim and real daemon to return the exact
+  graph-owned bytes while exercising the stdout `fstat` regression path.
+
 ## [0.2.21] - 2026-07-13
 
 This patch gives hosted clients one bounded, graph-authoritative read of the
@@ -569,7 +584,8 @@ Historical note: this snapshot predates the public GitHub prerelease series and 
 - Daemon mode for background file watching (`kin-daemon`)
 - 19-crate workspace architecture
 
-[unreleased]: https://github.com/firelock-ai/kin/compare/v0.2.21...HEAD
+[unreleased]: https://github.com/firelock-ai/kin/compare/v0.2.22...HEAD
+[0.2.22]: https://github.com/firelock-ai/kin/compare/v0.2.21...v0.2.22
 [0.2.21]: https://github.com/firelock-ai/kin/compare/v0.2.20...v0.2.21
 [0.2.20]: https://github.com/firelock-ai/kin/compare/v0.2.19...v0.2.20
 [0.2.19]: https://github.com/firelock-ai/kin/compare/v0.2.18...v0.2.19

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3039,14 +3039,14 @@ dependencies = [
 
 [[package]]
 name = "kin-buildinfo"
-version = "0.2.21"
+version = "0.2.22"
 dependencies = [
  "sha2 0.11.0",
 ]
 
 [[package]]
 name = "kin-cli"
-version = "0.2.21"
+version = "0.2.22"
 dependencies = [
  "age",
  "anyhow",
@@ -3114,7 +3114,7 @@ dependencies = [
 
 [[package]]
 name = "kin-context"
-version = "0.2.21"
+version = "0.2.22"
 dependencies = [
  "kin-blobs",
  "kin-db",
@@ -3130,7 +3130,7 @@ dependencies = [
 
 [[package]]
 name = "kin-core"
-version = "0.2.21"
+version = "0.2.22"
 dependencies = [
  "chrono",
  "directories 5.0.1",
@@ -3154,7 +3154,7 @@ dependencies = [
 
 [[package]]
 name = "kin-daemon"
-version = "0.2.21"
+version = "0.2.22"
 dependencies = [
  "async-stream",
  "axum",
@@ -3244,7 +3244,7 @@ dependencies = [
 
 [[package]]
 name = "kin-git"
-version = "0.2.21"
+version = "0.2.22"
 dependencies = [
  "chrono",
  "gix",
@@ -3262,7 +3262,7 @@ dependencies = [
 
 [[package]]
 name = "kin-index"
-version = "0.2.21"
+version = "0.2.22"
 dependencies = [
  "hex",
  "kin-blobs",
@@ -3310,7 +3310,7 @@ dependencies = [
 
 [[package]]
 name = "kin-integration-tests"
-version = "0.2.21"
+version = "0.2.22"
 dependencies = [
  "kin-blobs",
  "kin-cli",
@@ -3352,7 +3352,7 @@ dependencies = [
 
 [[package]]
 name = "kin-mcp"
-version = "0.2.21"
+version = "0.2.22"
 dependencies = [
  "kin-blobs",
  "kin-context",
@@ -3379,7 +3379,7 @@ dependencies = [
 
 [[package]]
 name = "kin-migrate"
-version = "0.2.21"
+version = "0.2.22"
 dependencies = [
  "chrono",
  "kin-blobs",
@@ -3421,7 +3421,7 @@ dependencies = [
 
 [[package]]
 name = "kin-parser"
-version = "0.2.21"
+version = "0.2.22"
 dependencies = [
  "kin-model",
  "pretty_assertions",
@@ -3451,7 +3451,7 @@ dependencies = [
 
 [[package]]
 name = "kin-projection"
-version = "0.2.21"
+version = "0.2.22"
 dependencies = [
  "kin-blobs",
  "kin-db",
@@ -3466,7 +3466,7 @@ dependencies = [
 
 [[package]]
 name = "kin-ranking"
-version = "0.2.21"
+version = "0.2.22"
 dependencies = [
  "kin-model",
  "serde",
@@ -3475,7 +3475,7 @@ dependencies = [
 
 [[package]]
 name = "kin-reconcile"
-version = "0.2.21"
+version = "0.2.22"
 dependencies = [
  "kin-blobs",
  "kin-db",
@@ -3495,7 +3495,7 @@ dependencies = [
 
 [[package]]
 name = "kin-registry"
-version = "0.2.21"
+version = "0.2.22"
 dependencies = [
  "axum",
  "base64 0.22.1",
@@ -3520,7 +3520,7 @@ dependencies = [
 
 [[package]]
 name = "kin-remote"
-version = "0.2.21"
+version = "0.2.22"
 dependencies = [
  "chrono",
  "kin-model",
@@ -3536,7 +3536,7 @@ dependencies = [
 
 [[package]]
 name = "kin-review"
-version = "0.2.21"
+version = "0.2.22"
 dependencies = [
  "kin-blobs",
  "kin-db",
@@ -3552,7 +3552,7 @@ dependencies = [
 
 [[package]]
 name = "kin-runtime"
-version = "0.2.21"
+version = "0.2.22"
 dependencies = [
  "chrono",
  "hex",
@@ -3584,7 +3584,7 @@ dependencies = [
 
 [[package]]
 name = "kin-semantic-contracts"
-version = "0.2.21"
+version = "0.2.22"
 dependencies = [
  "kin-db",
  "kin-model",
@@ -3599,7 +3599,7 @@ dependencies = [
 
 [[package]]
 name = "kin-spine"
-version = "0.2.21"
+version = "0.2.22"
 dependencies = [
  "chrono",
  "hashbrown 0.15.5",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,7 +27,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.2.21"
+version = "0.2.22"
 edition = "2021"
 license = "Apache-2.0"
 authors = ["Troy Fortin <troy@firelock.ai>"]

--- a/docs/security/signing-and-update-trust.md
+++ b/docs/security/signing-and-update-trust.md
@@ -45,11 +45,15 @@ proof installs all five archives (Linux x86_64/aarch64, macOS x86_64/aarch64,
 and Windows x86_64), verifies the GitHub attestation plus exact tag/commit/lock
 provenance, and exercises a fresh repository, graph search/locate, MCP
 initialize/list/call, and all supported agent configuration writers. The four
-Unix legs additionally build embeddings and prove semantic search/locate at
-complete coverage. Both npm packages are then published under their final
-channel through protected npm Trusted Publishing with short-lived OIDC.
-Anonymous exact-byte, provenance, and install proof runs after publication.
-GitHub Latest is promoted only after both packages pass every gate.
+Unix legs additionally make the source file unreadable on raw disk, then require
+the installed VFS shim and real Kin daemon to return the exact graph-owned bytes.
+That probe also calls `fstat` on stdout before opening the workspace path, which
+guards the Linux AArch64 passthrough ABI. The same legs build embeddings and
+prove semantic search/locate at complete coverage. Both npm packages are then
+published under their final channel through protected npm Trusted Publishing
+with short-lived OIDC. Anonymous exact-byte, provenance, and install proof runs
+after publication. GitHub Latest is promoted only after both packages pass
+every gate.
 
 The protected `release` environment intentionally has no required reviewer.
 After the release captain creates an authorized version tag on reviewed `main`,

--- a/packages/boundary-contracts/package.json
+++ b/packages/boundary-contracts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kin/boundary-contracts",
-  "version": "0.2.21",
+  "version": "0.2.22",
   "private": false,
   "description": "Shared contracts for Kin ecosystem boundaries.",
   "type": "module",

--- a/packages/kin-mcp/package.json
+++ b/packages/kin-mcp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kinlab/kin-mcp",
-  "version": "0.2.21",
+  "version": "0.2.22",
   "description": "Start Kin's MCP server, the system of record for AI-written software, through an npm-friendly wrapper.",
   "type": "module",
   "bin": {

--- a/packages/kin/package.json
+++ b/packages/kin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kinlab/kin",
-  "version": "0.2.21",
+  "version": "0.2.22",
   "description": "Canonical installer and launcher for Kin, the system of record for AI-written software. Provisions and runs the managed kin + kin-daemon release. MCP is one included mode (kin mcp start).",
   "license": "Apache-2.0",
   "type": "module",

--- a/scripts/test-npm-automatic-release.py
+++ b/scripts/test-npm-automatic-release.py
@@ -16,9 +16,9 @@ from pathlib import Path
 ROOT = Path(__file__).resolve().parent.parent
 SCRIPTS = ROOT / "scripts"
 PUBLISHER = SCRIPTS / "publish-npm-release.sh"
-VERSION = "0.2.21"
-OLD_VERSION = "0.2.20"
-NEWER_VERSION = "0.2.22"
+VERSION = "0.2.22"
+OLD_VERSION = "0.2.21"
+NEWER_VERSION = "0.2.23"
 REF = f"refs/tags/v{VERSION}"
 PACKAGE = "@kinlab/kin"
 OTHER_PACKAGE = "@kinlab/kin-mcp"
@@ -417,7 +417,7 @@ def test_symlinked_checkout_runs_channel_and_rollback_preflight() -> None:
     assert result.returncode == 0, result.stderr
     assert snapshot.get("channel_reads") == 1
     assert snapshot.get("rollback_checks") == 1
-    assert "latest=0.2.20" in result.stdout
+    assert "latest=0.2.21" in result.stdout
     assert "no registry mutation performed" in result.stdout
     assert not any(command[:1] == ["publish"] for command in snapshot["commands"])
     print("PASS: symlinked checkout executes channel and rollback preflight")
@@ -504,7 +504,7 @@ def test_newer_channel_during_publish_blocks_finalization() -> None:
     actual = json.loads(snapshot["state.json"])
     assert VERSION in actual["public"][PACKAGE]
     assert actual["tags"][PACKAGE]["latest"] == NEWER_VERSION
-    assert "resolves to 0.2.22" in result.stderr
+    assert "resolves to 0.2.23" in result.stderr
     assert "GitHub Latest remains blocked" in result.stderr
     assert "verify.json" in snapshot
     print("PASS: concurrent channel advancement leaves GitHub Latest blocked")

--- a/scripts/test-release-workflow-authority.py
+++ b/scripts/test-release-workflow-authority.py
@@ -110,6 +110,76 @@ def main() -> None:
         require(install_proof, policy, "actionable install-proof health failure")
 
     for policy in (
+        "Graph-backed VFS projection proof",
+        "fstat(STDOUT_FILENO, &stdout_stat)",
+        "chmod 000 probe.py",
+        "KIN_VFS_STRICT=1 kin-vfs exec --workspace .",
+        "cmp -s vfs-expected.txt vfs-graph-read.txt",
+        "installed VFS did not return the exact graph-owned probe.py bytes",
+        "release-provenance-attestation.json",
+        "installed-vfs-provenance.json",
+        "installed ${component.name} differs from the attested public archive",
+        '--signer-digest "$expected_commit"',
+        'if [ "$negative_status" -ne 4 ]',
+        "negative control did not fail with the expected raw-disk permission error",
+        "installed kin-vfs socket remained after shutdown",
+        "trap 'on_vfs_signal 130' INT",
+        "trap 'on_vfs_signal 143' TERM",
+    ):
+        require(install_proof, policy, "public VFS and installed-artifact proof")
+    proof_upload = install_proof[install_proof.index("- name: Preserve proof reports") :]
+    for report in (
+        "release-provenance.json",
+        "release-provenance.json.sha256",
+        "release-provenance-attestation.json",
+        "installed-vfs-provenance.json",
+    ):
+        require(proof_upload, report, "preserved installed-artifact proof report")
+
+    vfs_checkout_count = len(
+        re.findall(r"repository:\s*firelock-ai/kin-vfs\s*$", release, re.MULTILINE)
+    )
+    vfs_checkout_refs = re.findall(
+        r"repository:\s*firelock-ai/kin-vfs\s*$"
+        r"(?:(?!^\s+- name:).)*?^\s+ref:\s*([^\s#]+)",
+        release,
+        re.MULTILINE | re.DOTALL,
+    )
+    if len(vfs_checkout_refs) != vfs_checkout_count or any(
+        re.fullmatch(r"[0-9a-f]{40}", ref) is None for ref in vfs_checkout_refs
+    ):
+        raise AssertionError(
+            "every kin-vfs release checkout must declare a full immutable commit; "
+            f"checkouts={vfs_checkout_count}, refs={vfs_checkout_refs}"
+        )
+    vfs_refs = set(vfs_checkout_refs)
+    vfs_expected = set(
+        re.findall(r"EXPECTED_VFS_COMMIT:\s*([0-9a-f]{40})", release)
+    )
+    install_proof_vfs_expected = set(
+        re.findall(r"expected_vfs_commit:\s*([0-9a-f]{40})", release)
+    )
+    if len(vfs_refs) != 1 or vfs_expected != vfs_refs:
+        raise AssertionError(
+            "release workflow must use one immutable kin-vfs commit for build "
+            f"and provenance verification; refs={sorted(vfs_refs)}, "
+            f"expected={sorted(vfs_expected)}"
+        )
+    if install_proof_vfs_expected != vfs_refs:
+        raise AssertionError(
+            "install proof must bind the same immutable kin-vfs commit as the "
+            f"release workflow; release={sorted(vfs_refs)}, "
+            f"install-proof={sorted(install_proof_vfs_expected)}"
+        )
+    for policy in (
+        "Verified Kin/kin-vfs release compatibility at kin-vfs-core",
+        'pkg.name === "kin-vfs-core" && pkg.source?.startsWith("sparse+")',
+        'pkg.name === "kin-vfs-core" && pkg.source === null',
+        "update the immutable kin-vfs pin",
+    ):
+        require(release, policy, "Kin and pinned kin-vfs release compatibility gate")
+
+    for policy in (
         "Reopen a fresh Windows graph through the daemon",
         "kin.exe status --json > kin-status.json",
         "test -s .kin/kindb/head-generation",
@@ -466,6 +536,7 @@ def main() -> None:
         "always()",
         "needs.publish.result == 'success'",
         "uses: ./.github/workflows/install-proof.yml",
+        "expected_vfs_commit: 1c531216c65b734fb5e7c996094e01e030b8eec7",
     ):
         require(install_proof_job, policy, "mandatory public install proof")
 

--- a/scripts/test-release-workflow-authority.py
+++ b/scripts/test-release-workflow-authority.py
@@ -377,6 +377,121 @@ def main() -> None:
             "release daemon path must contain exactly one image build command"
         )
 
+    finalize_start = release.index("  finalize_release:")
+    latest_promotion_start = release.index("  promote_ghcr_latest:")
+    boundary_publish_start = release.index("  publish_boundary_contracts:")
+    if not finalize_start < latest_promotion_start < boundary_publish_start:
+        raise AssertionError(
+            "GHCR latest promotion must be a separate job after release finalization"
+        )
+    latest_promotion_job = release[
+        latest_promotion_start:boundary_publish_start
+    ]
+    for policy in (
+        "needs: [config, finalize_release, version_tag_image, build_daemon_image, attest_daemon_image]",
+        "always()",
+        "needs.config.result == 'success'",
+        "needs.finalize_release.result == 'success'",
+        "needs.version_tag_image.result == 'success'",
+        "needs.build_daemon_image.result == 'success'",
+        "needs.attest_daemon_image.result == 'success'",
+        "needs.config.outputs.release_channel == 'latest'",
+        "startsWith(github.ref, 'refs/tags/v')",
+        "!contains(github.ref_name, '-')",
+        "environment: release",
+        "contents: read",
+        "packages: write",
+        "attestations: read",
+        "persist-credentials: false",
+        "fetch-depth: 0",
+        "docker/login-action@af1e73f918a031802d376d3c8bbc3fe56130a9b0",
+        "docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f",
+        "EXPECTED_COMMIT: ${{ needs.build_daemon_image.outputs.commit }}",
+        "EXPECTED_SOURCE_DIGEST: ${{ needs.build_daemon_image.outputs.digest }}",
+        "is not an exact stable release tag",
+        'if [ "$GITHUB_REF" != "refs/tags/${GITHUB_REF_NAME}" ]',
+        'channel="$(node scripts/release-order.mjs channel "$VERSION")"',
+        'git rev-parse "${GITHUB_REF_NAME}^{commit}"',
+        'if [ "$COMMIT" != "$EXPECTED_COMMIT" ]',
+        'SRC="${IMAGE}:${COMMIT}"',
+        'VERSION_TAG="${IMAGE}:${VERSION}"',
+        'V_VERSION_TAG="${IMAGE}:${GITHUB_REF_NAME}"',
+        'LATEST="${IMAGE}:latest"',
+        "inspect_digest()",
+        "resolve_required_digest()",
+        "wait_for_expected_digest()",
+        "for attempt in $(seq 1 12)",
+        "matching_reads=$((matching_reads + 1))",
+        'if [ "$matching_reads" -eq 2 ]',
+        "did not converge to $expected",
+        "verify_stable_release_authority()",
+        '"repos/${GITHUB_REPOSITORY}/releases/latest"',
+        '"repos/${GITHUB_REPOSITORY}/releases/tags/${GITHUB_REF_NAME}"',
+        "GitHub Latest moved to",
+        "verify_immutable_authority()",
+        "scripts/verify-container-build-info.sh",
+        "verify_attestation()",
+        '"oci://${IMAGE}@${digest}"',
+        "--bundle-from-oci",
+        "--predicate-type https://slsa.dev/provenance/v1",
+        '--signer-workflow "$GITHUB_REPOSITORY/.github/workflows/release.yml"',
+        '--signer-digest "$COMMIT"',
+        '--source-digest "$COMMIT"',
+        '--source-ref "$GITHUB_REF"',
+        "--deny-self-hosted-runners",
+        "initial_latest_state=missing",
+        "mutation_required=true",
+        'if [ "$initial_latest_digest" = "$EXPECTED_SOURCE_DIGEST" ]',
+        "GHCR offers no atomic",
+        'verify_immutable_authority "pre-write"',
+        "prewrite_latest_state=missing",
+        'if [ "$prewrite_latest_digest" = "$EXPECTED_SOURCE_DIGEST" ]',
+        'action="Verified concurrent"',
+        'changed from ${initial_latest_state}:${initial_latest_digest:-<missing>}',
+        'prewrite_source_digest="$(resolve_required_digest "$SRC" "pre-write source recheck")"',
+        "final_prewrite_latest_state=missing",
+        'if [ "$final_prewrite_latest_digest" = "$EXPECTED_SOURCE_DIGEST" ]',
+        "during final admission",
+        "docker buildx imagetools create",
+        "--prefer-index=false",
+        '--tag "$LATEST"',
+        '"${IMAGE}@${EXPECTED_SOURCE_DIGEST}"',
+        'verify_immutable_authority "post-write"',
+        'actual_latest_digest="$(wait_for_expected_digest',
+        '"$LATEST" "$EXPECTED_SOURCE_DIGEST" "post-write latest")"',
+        'scripts/verify-container-build-info.sh "$LATEST" "$COMMIT"',
+        'verify_attestation "$actual_latest_digest"',
+        '"$LATEST" "$EXPECTED_SOURCE_DIGEST" "final latest readback"',
+    ):
+        require(latest_promotion_job, policy, "stable GHCR latest promotion")
+
+    if latest_promotion_job.count("docker buildx imagetools create") != 1:
+        raise AssertionError(
+            "stable GHCR latest promotion must contain exactly one registry mutation"
+        )
+    for forbidden in (
+        "contents: write",
+        "id-token: write",
+        "attestations: write",
+        "artifact-metadata: write",
+        "actions/attest@",
+        "docker buildx build",
+        "docker push",
+        "gh release edit",
+        "continue-on-error",
+        "!failure()",
+        "!cancelled()",
+        "|| true",
+        "WIF_PROVIDER",
+        "WIF_SERVICE_ACCOUNT",
+        "us-central1-docker.pkg.dev",
+    ):
+        if forbidden in latest_promotion_job:
+            raise AssertionError(
+                "stable GHCR latest promotion contains forbidden authority or "
+                f"fail-open behavior: {forbidden}"
+            )
+
     publish_start = release.index("  publish:")
     publish_end = release.index("\n  install_proof:", publish_start)
     publish_job = release[publish_start:publish_end]
@@ -554,6 +669,13 @@ def main() -> None:
             "needs.install_proof.result == 'success'",
             "needs.version_tag_image.result == 'success'",
             "needs.smoke_npm_published.result == 'success'",
+        ),
+        "promote_ghcr_latest": (
+            "needs.config.result == 'success'",
+            "needs.finalize_release.result == 'success'",
+            "needs.version_tag_image.result == 'success'",
+            "needs.build_daemon_image.result == 'success'",
+            "needs.attest_daemon_image.result == 'success'",
         ),
         "publish_boundary_contracts": (
             "needs.publish.result == 'success'",

--- a/scripts/test-verify-npm-release.py
+++ b/scripts/test-verify-npm-release.py
@@ -17,7 +17,7 @@ from pathlib import Path
 ROOT = Path(__file__).resolve().parent.parent
 VERIFIER = ROOT / "scripts" / "verify-npm-release.sh"
 PACKAGE = "@kinlab/kin"
-VERSION = "0.2.21"
+VERSION = "0.2.22"
 REF = f"refs/tags/v{VERSION}"
 COMMIT = "a" * 40
 INTEGRITY_BYTES = bytes([7]) * 64

--- a/scripts/test_installer_parity.py
+++ b/scripts/test_installer_parity.py
@@ -18,7 +18,7 @@ from verify_installer_parity import (
 )
 
 
-TAG = "v0.2.21"
+TAG = "v0.2.22"
 COMMIT = "a" * 40
 INSTALL = b"#!/bin/sh\necho kin\n"
 INSTALL_PS1 = b'Write-Output "Kin"\n'
@@ -65,7 +65,7 @@ class InstallerParityTests(unittest.TestCase):
 
     def test_manifest_must_bind_exact_tag(self) -> None:
         wrong = json.loads(manifest())
-        wrong["tag"] = "v0.2.20"
+        wrong["tag"] = "v0.2.21"
         with self.assertRaisesRegex(ParityError, "current.json tag"):
             self.verify(public_manifest=json.dumps(wrong).encode())
 

--- a/scripts/verify_installer_parity.py
+++ b/scripts/verify_installer_parity.py
@@ -174,7 +174,7 @@ def resolve_tag(repository: str, tag: str) -> str:
 
 def main() -> int:
     parser = argparse.ArgumentParser(description=__doc__)
-    parser.add_argument("tag", help="Exact stable release tag, for example v0.2.21")
+    parser.add_argument("tag", help="Exact stable release tag, for example v0.2.22")
     parser.add_argument("--expected-sha", help="Optional expected peeled 40-hex commit")
     parser.add_argument("--repository", default=DEFAULT_REPOSITORY)
     parser.add_argument("--base-url", default=DEFAULT_BASE_URL)


### PR DESCRIPTION
## Summary

- Bump every Kin workspace and npm package surface to `0.2.22`.
- Pin all release builds to reviewed `kin-vfs` commit `1c531216c65b734fb5e7c996094e01e030b8eec7` and fail if its `kin-vfs-core` version differs from the registry lock.
- Add an installed-artifact VFS proof that reproduces the Linux `fstat(stdout)` path, proves graph-backed reads with a raw-disk negative control, and preserves exact attestation/provenance reports.
- Promote only a fully proven stable GHCR digest to `ghcr.io/firelock-ai/kin:latest`, with stable-channel, build-info, digest, and SLSA checks.

## Why

The public v0.2.21 Linux arm64 archive still carries the buggy `kin-vfs` 0.1.4 shim. FIR-1384 requires a public v0.2.22 artifact built from the reviewed VFS fix and an exact native-arm64 acceptance rerun.

## Verification

- Exact CI clippy policy with `RUSTFLAGS=-D warnings`
- `cargo build --all-targets --locked`
- `cargo test --workspace --locked`
- `cargo fmt -- --check`
- Candidate `bin/kin-dev release-check kin` from `/tmp`: registry-only, checksum-clean, all Kin dependency pins current
- Release authority and `actionlint`
- Homebrew release gate: 49/49
- Installer parity: 7/7
- Installer checksum fixtures: 8/8
- npm automatic-release scenarios: 12/12
- npm package tests: 33/33 and 13/13, with lint
- Release ordering and npm attestation tests: 9/9
- Two independent exact-diff reviews: no P0/P1

## Post-merge release gates

1. Tag `v0.2.22` from the exact merged commit.
2. Require the full Release workflow, including public install proof and stable GHCR `latest` promotion.
3. Run the native `ubuntu-24.04-arm` public install acceptance against `v0.2.22`.
4. Verify GitHub Release, npm, Homebrew, installer, and GHCR identities before closing FIR-1384.

## Claims not being made

- No public v0.2.22 artifact exists until the tag workflow succeeds.
- FIR-1476 updater hardening is intentionally excluded from this release.
- Cursor and Windsurf owner-validation rows remain separate FIR-1384 closure gates.

Linear: FIR-1384