### PR TITLE
Fix VFS install-proof probe namespace

### DIFF
--- a/.github/workflows/install-proof.yml
+++ b/.github/workflows/install-proof.yml
@@ -496,7 +496,10 @@ jobs:
         working-directory: kin-install-proof
         run: |
           set -euo pipefail
-          probe_bin="$RUNNER_TEMP/kin-vfs-open-probe"
+          # The shipped shim deliberately bypasses Kin-family control-plane
+          # processes (basenames beginning with `kin-`). Keep this external
+          # probe outside that namespace so the proof exercises interposition.
+          probe_bin="$RUNNER_TEMP/vfs-open-probe"
           cc -O2 -Wall -Wextra -Werror -x c -o "$probe_bin" - <<'C'
           #include <errno.h>
           #include <fcntl.h>
@@ -506,7 +509,7 @@ jobs:
 
           int main(int argc, char **argv) {
               if (argc != 2) {
-                  fputs("usage: kin-vfs-open-probe <path>\n", stderr);
+                  fputs("usage: vfs-open-probe <path>\n", stderr);
                   return 2;
               }
 

--- a/scripts/test-release-workflow-authority.py
+++ b/scripts/test-release-workflow-authority.py
@@ -111,6 +111,7 @@ def main() -> None:
 
     for policy in (
         "Graph-backed VFS projection proof",
+        'probe_bin="$RUNNER_TEMP/vfs-open-probe"',
         "fstat(STDOUT_FILENO, &stdout_stat)",
         "chmod 000 probe.py",
         "KIN_VFS_STRICT=1 kin-vfs exec --workspace .",
@@ -127,6 +128,11 @@ def main() -> None:
         "trap 'on_vfs_signal 143' TERM",
     ):
         require(install_proof, policy, "public VFS and installed-artifact proof")
+    if "kin-vfs-open-probe" in install_proof:
+        raise AssertionError(
+            "public VFS probe must not use a Kin-family basename; the shipped "
+            "shim intentionally bypasses basenames beginning with 'kin-'"
+        )
     proof_upload = install_proof[install_proof.index("- name: Preserve proof reports") :]
     for report in (
         "release-provenance.json",


### PR DESCRIPTION
## Status

This fixes the v0.2.22 Unix install-proof false negative without changing product code or any published artifact.

## Root cause

The external C probe was named `kin-vfs-open-probe`. The shipped kin-vfs shim intentionally bypasses Kin-family control-plane processes whose basename begins with `kin-`, so all four Unix release legs exercised the bypass policy and exited 78 instead of exercising interposition. Windows was unaffected and passed.

Failed release run: https://github.com/firelock-ai/kin/actions/runs/29353754245

## Change

- Rename the external helper to `vfs-open-probe`.
- Keep the negative control, graph-backed read, strict mode, cleanup, and signal handling unchanged.
- Add a release-authority regression check that rejects the reserved `kin-vfs-open-probe` basename.

## Verification

- `python3 scripts/test-release-workflow-authority.py`
- `actionlint .github/workflows/install-proof.yml .github/workflows/release.yml`
- `git diff --check 21dc2754a24105711e3fc0c97a5690ae71484103..128200db0371614fee05dea71668842f9f31c669`
- Commit is directly based on the exact v0.2.22 merge commit `21dc2754a24105711e3fc0c97a5690ae71484103`.

## Release posture

The existing v0.2.22 tag and prerelease remain immutable audit evidence. After this PR lands, the standalone five-platform Install Proof workflow will be dispatched against the existing v0.2.22 artifacts. No retagging or manual publication bypass is proposed.
