### PR TITLE
Fix VFS proof cleanup lifecycle

### DIFF
--- a/.github/workflows/install-proof.yml
+++ b/.github/workflows/install-proof.yml
@@ -569,7 +569,10 @@ jobs:
               kin-vfs stop --workspace . >> kin-vfs-daemon.log 2>&1 || cleanup_status=1
               stopped=false
               for _ in $(seq 1 150); do
-                process_state="$(ps -o stat= -p "$vfs_pid" 2>/dev/null | tr -d '[:space:]')"
+                # A missing PID is the expected successful-stop state. Keep
+                # that `ps` miss from tripping `set -euo pipefail`.
+                process_state="$(ps -o stat= -p "$vfs_pid" 2>/dev/null || true)"
+                process_state="$(printf '%s' "$process_state" | tr -d '[:space:]')"
                 if [ -z "$process_state" ] || printf '%s\n' "$process_state" | grep -q 'Z'; then
                   stopped=true
                   break
@@ -595,6 +598,7 @@ jobs:
                     ;;
                 esac
               fi
+              vfs_pid=""
             fi
             if [ -S .kin/vfs.sock ]; then
               echo "installed kin-vfs socket remained after shutdown" >&2
@@ -660,8 +664,11 @@ jobs:
             exit 1
           fi
 
+          # Prevent a cleanup failure from re-entering cleanup through EXIT;
+          # keep the signal handlers until normal cleanup has completed.
+          trap - EXIT
           cleanup_vfs
-          trap - EXIT INT TERM
+          trap - INT TERM
 
       - name: Unix embedding and semantic retrieval proof
         if: runner.os != 'Windows'

--- a/scripts/test-release-workflow-authority.py
+++ b/scripts/test-release-workflow-authority.py
@@ -124,10 +124,26 @@ def main() -> None:
         'if [ "$negative_status" -ne 4 ]',
         "negative control did not fail with the expected raw-disk permission error",
         "installed kin-vfs socket remained after shutdown",
+        'process_state="$(ps -o stat= -p "$vfs_pid" 2>/dev/null || true)"',
+        'process_state="$(printf \'%s\' "$process_state" | tr -d \'[:space:]\')"',
         "trap 'on_vfs_signal 130' INT",
         "trap 'on_vfs_signal 143' TERM",
     ):
         require(install_proof, policy, "public VFS and installed-artifact proof")
+    cleanup_start = install_proof.index("          cleanup_vfs() {")
+    signal_start = install_proof.index("          on_vfs_signal() {", cleanup_start)
+    cleanup_vfs = install_proof[cleanup_start:signal_start]
+    require(cleanup_vfs, 'vfs_pid=""', "idempotent public VFS cleanup")
+    if "ps -o stat= -p \"$vfs_pid\" 2>/dev/null | tr" in cleanup_vfs:
+        raise AssertionError(
+            "public VFS cleanup must treat a disappeared daemon PID as the "
+            "expected successful-stop state under set -euo pipefail"
+        )
+    require(
+        install_proof,
+        "          trap - EXIT\n          cleanup_vfs\n          trap - INT TERM",
+        "non-reentrant public VFS normal cleanup",
+    )
     if "kin-vfs-open-probe" in install_proof:
         raise AssertionError(
             "public VFS probe must not use a Kin-family basename; the shipped "


### PR DESCRIPTION
## Status

This fixes the teardown-only false negative exposed by standalone Install Proof run 29358887859. It changes no product code or published v0.2.22 artifact.

## Runtime evidence

The PR #340 probe rename worked on all four Unix runners:

- Raw-disk negative control failed with permission denied.
- VFS canary verdict was Active.
- Graph-read stderr was empty.
- Returned bytes exactly matched the graph-owned expected file.

The step then failed after `VFS daemon stopped` because `cleanup_vfs` ran under `set -euo pipefail`. Once the daemon PID disappeared, `ps -p` returned 1; the substitution assignment inherited that status and triggered `errexit`. Since the EXIT trap was still armed, cleanup re-entered and attempted a second stop, producing `no PID file found`.

Failed proof run: https://github.com/firelock-ai/kin/actions/runs/29358887859

## Change

- Treat the expected missing PID after successful stop as non-fatal without swallowing `tr` failures.
- Clear the recorded PID after teardown.
- Disarm the EXIT trap before explicit normal cleanup while retaining signal handlers until cleanup completes, so cleanup failures still propagate once.
- Add release-authority guards for the missing-PID handling and non-reentrant ordering.

## Verification

- `python3 scripts/test-release-workflow-authority.py`
- `actionlint .github/workflows/install-proof.yml .github/workflows/release.yml`
- `git diff --check 6e2510ac141a6460622ea94a343f5b88848aa95e..fbd1f92f26184eb5a14b7fd389de95acec4b0015`
- Local Bash regression: absent `ps -p` under `set -euo pipefail` returns an empty state without exiting.
- Local non-reentrancy regression: a failing explicit cleanup executes exactly once and still returns status 1.

## Stop gate

After exact-head CI and merge, rerun the standalone five-platform proof against immutable v0.2.22. Do not create a v0.2.23 candidate unless all five jobs pass.
