### PR TITLE
Prepare Kin v0.2.23 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.2.23] - 2026-07-14
+
+This patch republishes the reviewed v0.2.22 payload through the corrected
+cross-platform public install proof. The runtime product code is unchanged;
+the delta is release workflow and test plumbing plus version metadata.
+
+### Fixed
+
+- The Unix graph-backed VFS acceptance helper now uses an external-tool
+  basename so the shipped shim exercises interposition instead of its
+  intentional Kin control-plane bypass.
+- Normal VFS proof teardown now treats a disappeared daemon PID as a
+  successful stop and prevents EXIT cleanup from re-entering, while preserving
+  fail-closed cleanup errors and signal handling.
+
 ## [0.2.22] - 2026-07-14
 
 This patch restores Linux AArch64 VFS passthrough and makes the public install
@@ -584,7 +599,8 @@ Historical note: this snapshot predates the public GitHub prerelease series and 
 - Daemon mode for background file watching (`kin-daemon`)
 - 19-crate workspace architecture
 
-[unreleased]: https://github.com/firelock-ai/kin/compare/v0.2.22...HEAD
+[unreleased]: https://github.com/firelock-ai/kin/compare/v0.2.23...HEAD
+[0.2.23]: https://github.com/firelock-ai/kin/compare/v0.2.22...v0.2.23
 [0.2.22]: https://github.com/firelock-ai/kin/compare/v0.2.21...v0.2.22
 [0.2.21]: https://github.com/firelock-ai/kin/compare/v0.2.20...v0.2.21
 [0.2.20]: https://github.com/firelock-ai/kin/compare/v0.2.19...v0.2.20

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3039,14 +3039,14 @@ dependencies = [
 
 [[package]]
 name = "kin-buildinfo"
-version = "0.2.22"
+version = "0.2.23"
 dependencies = [
  "sha2 0.11.0",
 ]
 
 [[package]]
 name = "kin-cli"
-version = "0.2.22"
+version = "0.2.23"
 dependencies = [
  "age",
  "anyhow",
@@ -3114,7 +3114,7 @@ dependencies = [
 
 [[package]]
 name = "kin-context"
-version = "0.2.22"
+version = "0.2.23"
 dependencies = [
  "kin-blobs",
  "kin-db",
@@ -3130,7 +3130,7 @@ dependencies = [
 
 [[package]]
 name = "kin-core"
-version = "0.2.22"
+version = "0.2.23"
 dependencies = [
  "chrono",
  "directories 5.0.1",
@@ -3154,7 +3154,7 @@ dependencies = [
 
 [[package]]
 name = "kin-daemon"
-version = "0.2.22"
+version = "0.2.23"
 dependencies = [
  "async-stream",
  "axum",
@@ -3244,7 +3244,7 @@ dependencies = [
 
 [[package]]
 name = "kin-git"
-version = "0.2.22"
+version = "0.2.23"
 dependencies = [
  "chrono",
  "gix",
@@ -3262,7 +3262,7 @@ dependencies = [
 
 [[package]]
 name = "kin-index"
-version = "0.2.22"
+version = "0.2.23"
 dependencies = [
  "hex",
  "kin-blobs",
@@ -3310,7 +3310,7 @@ dependencies = [
 
 [[package]]
 name = "kin-integration-tests"
-version = "0.2.22"
+version = "0.2.23"
 dependencies = [
  "kin-blobs",
  "kin-cli",
@@ -3352,7 +3352,7 @@ dependencies = [
 
 [[package]]
 name = "kin-mcp"
-version = "0.2.22"
+version = "0.2.23"
 dependencies = [
  "kin-blobs",
  "kin-context",
@@ -3379,7 +3379,7 @@ dependencies = [
 
 [[package]]
 name = "kin-migrate"
-version = "0.2.22"
+version = "0.2.23"
 dependencies = [
  "chrono",
  "kin-blobs",
@@ -3421,7 +3421,7 @@ dependencies = [
 
 [[package]]
 name = "kin-parser"
-version = "0.2.22"
+version = "0.2.23"
 dependencies = [
  "kin-model",
  "pretty_assertions",
@@ -3451,7 +3451,7 @@ dependencies = [
 
 [[package]]
 name = "kin-projection"
-version = "0.2.22"
+version = "0.2.23"
 dependencies = [
  "kin-blobs",
  "kin-db",
@@ -3466,7 +3466,7 @@ dependencies = [
 
 [[package]]
 name = "kin-ranking"
-version = "0.2.22"
+version = "0.2.23"
 dependencies = [
  "kin-model",
  "serde",
@@ -3475,7 +3475,7 @@ dependencies = [
 
 [[package]]
 name = "kin-reconcile"
-version = "0.2.22"
+version = "0.2.23"
 dependencies = [
  "kin-blobs",
  "kin-db",
@@ -3495,7 +3495,7 @@ dependencies = [
 
 [[package]]
 name = "kin-registry"
-version = "0.2.22"
+version = "0.2.23"
 dependencies = [
  "axum",
  "base64 0.22.1",
@@ -3520,7 +3520,7 @@ dependencies = [
 
 [[package]]
 name = "kin-remote"
-version = "0.2.22"
+version = "0.2.23"
 dependencies = [
  "chrono",
  "kin-model",
@@ -3536,7 +3536,7 @@ dependencies = [
 
 [[package]]
 name = "kin-review"
-version = "0.2.22"
+version = "0.2.23"
 dependencies = [
  "kin-blobs",
  "kin-db",
@@ -3552,7 +3552,7 @@ dependencies = [
 
 [[package]]
 name = "kin-runtime"
-version = "0.2.22"
+version = "0.2.23"
 dependencies = [
  "chrono",
  "hex",
@@ -3584,7 +3584,7 @@ dependencies = [
 
 [[package]]
 name = "kin-semantic-contracts"
-version = "0.2.22"
+version = "0.2.23"
 dependencies = [
  "kin-db",
  "kin-model",
@@ -3599,7 +3599,7 @@ dependencies = [
 
 [[package]]
 name = "kin-spine"
-version = "0.2.22"
+version = "0.2.23"
 dependencies = [
  "chrono",
  "hashbrown 0.15.5",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,7 +27,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.2.22"
+version = "0.2.23"
 edition = "2021"
 license = "Apache-2.0"
 authors = ["Troy Fortin <troy@firelock.ai>"]

--- a/packages/boundary-contracts/package.json
+++ b/packages/boundary-contracts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kin/boundary-contracts",
-  "version": "0.2.22",
+  "version": "0.2.23",
   "private": false,
   "description": "Shared contracts for Kin ecosystem boundaries.",
   "type": "module",

--- a/packages/kin-mcp/package.json
+++ b/packages/kin-mcp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kinlab/kin-mcp",
-  "version": "0.2.22",
+  "version": "0.2.23",
   "description": "Start Kin's MCP server, the system of record for AI-written software, through an npm-friendly wrapper.",
   "type": "module",
   "bin": {

--- a/packages/kin/package.json
+++ b/packages/kin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kinlab/kin",
-  "version": "0.2.22",
+  "version": "0.2.23",
   "description": "Canonical installer and launcher for Kin, the system of record for AI-written software. Provisions and runs the managed kin + kin-daemon release. MCP is one included mode (kin mcp start).",
   "license": "Apache-2.0",
   "type": "module",

--- a/scripts/test-npm-automatic-release.py
+++ b/scripts/test-npm-automatic-release.py
@@ -16,9 +16,9 @@ from pathlib import Path
 ROOT = Path(__file__).resolve().parent.parent
 SCRIPTS = ROOT / "scripts"
 PUBLISHER = SCRIPTS / "publish-npm-release.sh"
-VERSION = "0.2.22"
-OLD_VERSION = "0.2.21"
-NEWER_VERSION = "0.2.23"
+VERSION = "0.2.23"
+OLD_VERSION = "0.2.22"
+NEWER_VERSION = "0.2.24"
 REF = f"refs/tags/v{VERSION}"
 PACKAGE = "@kinlab/kin"
 OTHER_PACKAGE = "@kinlab/kin-mcp"
@@ -417,7 +417,7 @@ def test_symlinked_checkout_runs_channel_and_rollback_preflight() -> None:
     assert result.returncode == 0, result.stderr
     assert snapshot.get("channel_reads") == 1
     assert snapshot.get("rollback_checks") == 1
-    assert "latest=0.2.21" in result.stdout
+    assert "latest=0.2.22" in result.stdout
     assert "no registry mutation performed" in result.stdout
     assert not any(command[:1] == ["publish"] for command in snapshot["commands"])
     print("PASS: symlinked checkout executes channel and rollback preflight")
@@ -504,7 +504,7 @@ def test_newer_channel_during_publish_blocks_finalization() -> None:
     actual = json.loads(snapshot["state.json"])
     assert VERSION in actual["public"][PACKAGE]
     assert actual["tags"][PACKAGE]["latest"] == NEWER_VERSION
-    assert "resolves to 0.2.23" in result.stderr
+    assert "resolves to 0.2.24" in result.stderr
     assert "GitHub Latest remains blocked" in result.stderr
     assert "verify.json" in snapshot
     print("PASS: concurrent channel advancement leaves GitHub Latest blocked")

--- a/scripts/test-verify-npm-release.py
+++ b/scripts/test-verify-npm-release.py
@@ -17,7 +17,7 @@ from pathlib import Path
 ROOT = Path(__file__).resolve().parent.parent
 VERIFIER = ROOT / "scripts" / "verify-npm-release.sh"
 PACKAGE = "@kinlab/kin"
-VERSION = "0.2.22"
+VERSION = "0.2.23"
 REF = f"refs/tags/v{VERSION}"
 COMMIT = "a" * 40
 INTEGRITY_BYTES = bytes([7]) * 64

--- a/scripts/test_installer_parity.py
+++ b/scripts/test_installer_parity.py
@@ -18,7 +18,7 @@ from verify_installer_parity import (
 )
 
 
-TAG = "v0.2.22"
+TAG = "v0.2.23"
 COMMIT = "a" * 40
 INSTALL = b"#!/bin/sh\necho kin\n"
 INSTALL_PS1 = b'Write-Output "Kin"\n'
@@ -65,7 +65,7 @@ class InstallerParityTests(unittest.TestCase):
 
     def test_manifest_must_bind_exact_tag(self) -> None:
         wrong = json.loads(manifest())
-        wrong["tag"] = "v0.2.21"
+        wrong["tag"] = "v0.2.22"
         with self.assertRaisesRegex(ParityError, "current.json tag"):
             self.verify(public_manifest=json.dumps(wrong).encode())
 

--- a/scripts/verify_installer_parity.py
+++ b/scripts/verify_installer_parity.py
@@ -174,7 +174,7 @@ def resolve_tag(repository: str, tag: str) -> str:
 
 def main() -> int:
     parser = argparse.ArgumentParser(description=__doc__)
-    parser.add_argument("tag", help="Exact stable release tag, for example v0.2.22")
+    parser.add_argument("tag", help="Exact stable release tag, for example v0.2.23")
     parser.add_argument("--expected-sha", help="Optional expected peeled 40-hex commit")
     parser.add_argument("--repository", default=DEFAULT_REPOSITORY)
     parser.add_argument("--base-url", default=DEFAULT_BASE_URL)


### PR DESCRIPTION
## Scope

- Bump the Kin workspace and npm package metadata from 0.2.22 to 0.2.23.
- Add the v0.2.23 changelog entry.
- Advance rolling release-test fixtures to 0.2.23 / 0.2.24.
- Leave product runtime code, installer code, workflow pins, and release workflows unchanged from the reviewed fixed-main base.

## Why

v0.2.22 is preserved as a quarantined prerelease after its original release run exposed two install-proof harness defects. Both defects are now fixed on main, and the standalone fixed-main v0.2.22 install proof is green on all five platforms. A fresh v0.2.23 tag is required so the corrected public release DAG can publish the same reviewed runtime payload without moving or rewriting v0.2.22.

## Exact provenance

- Candidate: `e43a2f89b6fcc2a774404fb77059d46d5f1f1885`
- Parent: `04eec84f717f64efdae82783f60e4ace705b62c6`
- Fixed-main install proof: [run 29360771712](https://github.com/firelock-ai/kin/actions/runs/29360771712), 5/5 green

## Verification

- `cargo fmt -- --check`
- CI clippy allowlist with `RUSTFLAGS=-D warnings`
- `RUSTFLAGS=-D warnings cargo build --all-targets --locked`
- `RUSTFLAGS=-D warnings cargo test --workspace --locked`
- zero-file-search and runtime/private-boundary checks
- release workflow authority and `actionlint`
- installer parity/checksum, Homebrew, npm policy/provenance, package test/lint suites
- exact-candidate `kin-dev release-check kin` from `/tmp`: registry-only, all external Kin sources/checksums valid, all pins at registry latest
- independent review: no P0, P1, or P2 findings

## Boundaries

This PR does not move, delete, or retag v0.2.22. It does not publish packages or images by itself. The unchanged base already contains the reviewed stable-only `promote_ghcr_latest` release job, so v0.2.23 inherits immutable version tagging plus bounded mutable `latest` promotion after publication, install proof, attestation, and GitHub Latest succeed. No separate manual GHCR mutation is planned; a failed promotion remains a release blocker to inspect and rerun.