### PR TITLE
Fix optional VFS installer reporting

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -74,6 +74,7 @@ jobs:
       - name: Test release ordering and npm provenance policy
         run: |
           python3 ./scripts/test-release-workflow-authority.py
+          python3 ./scripts/test_install_optional_vfs.py
           python3 ./scripts/test_installer_parity.py
           python3 ./scripts/test-npm-automatic-release.py
           python3 ./scripts/test-verify-npm-release.py

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -214,7 +214,19 @@ done
 ok "Binaries installed (kin, kin-daemon)"
 
 if [ "$HAVE_VFS" = "1" ] && [ "$HAVE_SHIM" = "1" ]; then
-    ok "Filesystem projection installed (kin-vfs + shim)"
+    # The release archive can contain a projection built for a different libc
+    # than the host. In particular, the static-musl Kin core runs on Alpine,
+    # while today's kin-vfs and shim are glibc-linked. Test the installed CLI
+    # before claiming the optional projection is usable, and do not leave a
+    # command behind that the host loader cannot execute.
+    if "$KIN_BIN/kin-vfs" --help >/dev/null 2>&1; then
+        ok "Filesystem projection installed (kin-vfs + shim)"
+    else
+        rm -f "$KIN_BIN/kin-vfs" \
+            "$KIN_LIB/libkin_vfs_shim.so" \
+            "$KIN_LIB/libkin_vfs_shim.dylib"
+        info "Filesystem projection is unavailable on this platform; core CLI and daemon are fully functional without it."
+    fi
 else
     info "Filesystem projection (kin-vfs) not bundled in this archive — core CLI and daemon are fully functional without it."
 fi

--- a/scripts/test_install_optional_vfs.py
+++ b/scripts/test_install_optional_vfs.py
@@ -1,0 +1,121 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2026 Firelock, LLC
+
+"""Behavior tests for the optional VFS portion of the Unix installer."""
+
+from __future__ import annotations
+
+import hashlib
+import os
+import platform
+import stat
+import subprocess
+import tarfile
+import tempfile
+import unittest
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parent.parent
+INSTALLER = ROOT / "scripts" / "install.sh"
+VERSION = "9.9.9"
+
+
+def target_name() -> str:
+    system = platform.system()
+    machine = platform.machine().lower()
+    os_name = {"Darwin": "macos", "Linux": "linux"}[system]
+    arch = {
+        "x86_64": "x86_64",
+        "amd64": "x86_64",
+        "arm64": "aarch64",
+        "aarch64": "aarch64",
+    }[machine]
+    return f"{os_name}-{arch}"
+
+
+def executable(path: Path, body: str) -> None:
+    path.write_text(body, encoding="utf-8")
+    path.chmod(path.stat().st_mode | stat.S_IXUSR)
+
+
+class OptionalVfsInstallerTests(unittest.TestCase):
+    def run_installer(
+        self, *, vfs_exit: int
+    ) -> tuple[subprocess.CompletedProcess[str], Path]:
+        temp = tempfile.TemporaryDirectory()
+        self.addCleanup(temp.cleanup)
+        root = Path(temp.name)
+        target = target_name()
+        archive_root = root / f"kin-{target}"
+        archive_root.mkdir()
+
+        executable(
+            archive_root / "kin",
+            "#!/bin/sh\nprintf 'kin 9.9.9\\n'\n",
+        )
+        executable(archive_root / "kin-daemon", "#!/bin/sh\nexit 0\n")
+        executable(
+            archive_root / "kin-vfs",
+            f"#!/bin/sh\nexit {vfs_exit}\n",
+        )
+        shim_name = (
+            "libkin_vfs_shim.dylib"
+            if platform.system() == "Darwin"
+            else "libkin_vfs_shim.so"
+        )
+        (archive_root / shim_name).write_bytes(b"test shim")
+
+        release_dir = root / "download" / f"v{VERSION}"
+        release_dir.mkdir(parents=True)
+        archive = release_dir / f"kin-{target}.tar.gz"
+        with tarfile.open(archive, "w:gz") as bundle:
+            bundle.add(archive_root, arcname=archive_root.name)
+        digest = hashlib.sha256(archive.read_bytes()).hexdigest()
+        archive.with_suffix(archive.suffix + ".sha256").write_text(
+            f"{digest}  {archive.name}\n", encoding="utf-8"
+        )
+
+        home = root / "home"
+        home.mkdir()
+        kin_home = home / ".kin"
+        env = os.environ.copy()
+        env.update(
+            {
+                "HOME": str(home),
+                "KIN_BASE_URL": root.as_uri(),
+                "KIN_HOME": str(kin_home),
+                "KIN_NO_SETUP": "1",
+                "KIN_VERSION": VERSION,
+                "SHELL": "/bin/sh",
+            }
+        )
+        result = subprocess.run(
+            ["sh", str(INSTALLER)],
+            env=env,
+            check=False,
+            capture_output=True,
+            text=True,
+        )
+        return result, kin_home
+
+    def test_reports_projection_only_when_vfs_is_executable(self) -> None:
+        result, kin_home = self.run_installer(vfs_exit=0)
+
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertIn("Filesystem projection installed", result.stdout)
+        self.assertTrue((kin_home / "bin" / "kin-vfs").exists())
+
+    def test_removes_and_reports_unusable_projection(self) -> None:
+        result, kin_home = self.run_installer(vfs_exit=127)
+
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertNotIn("Filesystem projection installed", result.stdout)
+        self.assertIn("Filesystem projection is unavailable", result.stdout)
+        self.assertFalse((kin_home / "bin" / "kin-vfs").exists())
+        self.assertFalse(any((kin_home / "lib").glob("libkin_vfs_shim.*")))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## What changed

- probe the installed `kin-vfs` binary before claiming filesystem projection is available
- remove the unusable optional VFS binary and shim when the host loader cannot execute them
- preserve the working `kin` and `kin-daemon` installation
- cover both runnable and non-runnable projection paths in CI

## Why

The v0.2.23 static core runs on Alpine, but the optional VFS payload is currently glibc-linked. Debian 12 can also reject the VFS binary because it requires a newer glibc. The installer previously reported the projection as installed whenever the files existed, even when the host could not load them.

This closes [FIR-1478](https://linear.app/firelock-ai/issue/FIR-1478/installer-falsely-reports-vfs-projection-installed-when-the-host) without weakening the core install. Portable VFS build targets remain separate in FIR-1480.

## Validation

- `shellcheck -e SC3043 scripts/install.sh`
- `python3 scripts/test_install_optional_vfs.py` — 2 passed
- `python3 scripts/test_installer_parity.py` — 7 passed
- `python3 scripts/test-release-workflow-authority.py` — passed
- exact public v0.2.23 Alpine 3.24 arm64 negative-path acceptance
- exact public v0.2.23 Ubuntu 24.04 arm64 positive-path acceptance

## Claim boundary

This PR does not make the VFS payload musl-compatible or lower its glibc requirement. It makes installer reporting and installed optional state truthful.