### PR TITLE
Release Kin v0.2.24

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -145,11 +145,20 @@ jobs:
           "$bin_dir/kin.exe" --version
           "$bin_dir/kin-daemon.exe" --version
           "$bin_dir/kin.exe" bench-meta --json > "$RUNNER_TEMP/kin-build-meta.json"
+          "$bin_dir/kin.exe" registry authority --json > "$RUNNER_TEMP/kin-registry-authority.json"
+          if "$bin_dir/kin.exe" registry authority --fix > /dev/null 2>&1; then
+            echo "::error::Windows registry authority --fix must fail as unsupported"
+            exit 1
+          fi
           EXPECTED_SHA="$(git rev-parse HEAD)" node <<'NODE'
           const childProcess = require("child_process");
           const crypto = require("crypto");
           const fs = require("fs");
           const meta = JSON.parse(fs.readFileSync(`${process.env.RUNNER_TEMP}/kin-build-meta.json`, "utf8"));
+          const authority = JSON.parse(fs.readFileSync(`${process.env.RUNNER_TEMP}/kin-registry-authority.json`, "utf8"));
+          if (authority.checks?.length !== 1 || authority.checks[0]?.state !== "unsupported") {
+            throw new Error("Windows registry authority must report exactly one unsupported capability check");
+          }
           if (meta.kin_commit !== process.env.EXPECTED_SHA || meta.kin_dirty !== false || meta.kin_source_known !== true) {
             throw new Error("Windows release build did not prove a clean, known checkout");
           }

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -63,6 +63,16 @@ jobs:
 
           dump() { echo "---- docker logs $1 ----"; docker logs "$1" 2>&1 || true; }
 
+          # The non-root runtime must own a private home before Kin can create
+          # its fail-closed registry authority files there. Keep this explicit
+          # so a base-image/useradd change cannot silently regress first boot.
+          docker run --rm --entrypoint sh "$IMAGE" -c '
+            test "$HOME" = /home/kin
+            test -d "$HOME"
+            test "$(stat -c %a "$HOME")" = 700
+            test "$(stat -c %u "$HOME")" = "$(id -u)"
+          '
+
           echo "::group::Local mode — no /workspace mount, default workspace"
           docker rm -f kin-local >/dev/null 2>&1 || true
           docker run -d --name kin-local "$IMAGE" >/dev/null

--- a/.github/workflows/install-proof.yml
+++ b/.github/workflows/install-proof.yml
@@ -774,6 +774,7 @@ jobs:
             ["repo_init", "healthy"],
             ["shell_path", "healthy"],
             ["setup_ledger", "healthy"],
+            ["registry_authority", runnerOs === "Windows" ? "unsupported" : "healthy"],
             ["vfs_projection", runnerOs === "Windows" ? "unsupported" : "healthy"],
             ["mcp_client_claude", "healthy"],
             ["mcp_client_cursor", "healthy"],

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -454,7 +454,7 @@ jobs:
           repository: firelock-ai/kin-vfs
           path: kin-vfs
           # Release inputs must never move under an unchanged Kin tag.
-          ref: 1c531216c65b734fb5e7c996094e01e030b8eec7
+          ref: c782905f39500a7a107aba5a91e85119c77726fa
           persist-credentials: false
 
       - name: Verify canonical release input bytes
@@ -871,7 +871,7 @@ jobs:
           ARTIFACT: ${{ matrix.artifact }}
           TARGET: ${{ matrix.target }}
           VFS_TARGET: ${{ matrix.vfs_target || matrix.target }}
-          EXPECTED_VFS_COMMIT: 1c531216c65b734fb5e7c996094e01e030b8eec7
+          EXPECTED_VFS_COMMIT: c782905f39500a7a107aba5a91e85119c77726fa
         run: |
           set -euo pipefail
           node <<'NODE'
@@ -1103,7 +1103,7 @@ jobs:
         with:
           repository: firelock-ai/kin-vfs
           path: release-inputs/kin-vfs
-          ref: 1c531216c65b734fb5e7c996094e01e030b8eec7
+          ref: c782905f39500a7a107aba5a91e85119c77726fa
           persist-credentials: false
 
       - name: Download all artifacts
@@ -1161,7 +1161,7 @@ jobs:
 
       - name: Verify and aggregate release provenance
         env:
-          EXPECTED_VFS_COMMIT: 1c531216c65b734fb5e7c996094e01e030b8eec7
+          EXPECTED_VFS_COMMIT: c782905f39500a7a107aba5a91e85119c77726fa
         run: |
           set -euo pipefail
           node <<'NODE'
@@ -1409,7 +1409,7 @@ jobs:
     uses: ./.github/workflows/install-proof.yml
     with:
       release_tag: ${{ github.ref_name }}
-      expected_vfs_commit: 1c531216c65b734fb5e7c996094e01e030b8eec7
+      expected_vfs_commit: c782905f39500a7a107aba5a91e85119c77726fa
     permissions:
       contents: read
       attestations: read

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,8 @@ VFS support, and easier to follow from install through graph-backed proof.
 
 - The installer now reports unsupported or unavailable optional VFS targets as
   skipped instead of falsely claiming that a shim was installed.
+- Workspace-root binding now normalizes Windows drive `file://` URIs and bare
+  drive paths, while preserving local POSIX roots and Windows UNC shares.
 
 ## [0.2.23] - 2026-07-14
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,8 @@ VFS support, and easier to follow from install through graph-backed proof.
 - The MCP server now accepts standard client workspace roots, binds the first
   initialized Kin repository without a hardcoded `--repo`, and keeps semantic
   answers fail closed on graph authority.
+- `kin registry authority` exposes a content-free, machine-readable check of
+  the local registry trust boundary used by setup, doctor, update, and installers.
 
 ### Changed
 
@@ -33,9 +35,12 @@ VFS support, and easier to follow from install through graph-backed proof.
   skipped instead of falsely claiming that a shim was installed.
 - Workspace-root binding now normalizes Windows drive `file://` URIs and bare
   drive paths, while preserving local POSIX roots and Windows UNC shares.
-- On Unix, the global registry now keeps `registry.toml` and `registry.lock`
-  private at mode 0600, rejects unsafe link/type/ownership state, and serializes
-  atomic read-modify-write updates so concurrent writers cannot lose entries.
+- On Unix, the global registry now creates `registry.toml` and `registry.lock`
+  at mode 0600, refuses permissive modes, links, special files, wrong ownership,
+  hard links, unsafe parents, and reserved-path collisions without reading or
+  replacing their contents, and requires explicit `kin doctor --fix` permission
+  repair. Install and update preflights enforce the same contract, while locked
+  atomic updates prevent concurrent writers from losing entries.
 
 ## [0.2.23] - 2026-07-14
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,31 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.2.24] - 2026-07-15
+
+This patch makes Kin's first-use path workspace-aware, truthful about optional
+VFS support, and easier to follow from install through graph-backed proof.
+
+### Added
+
+- The MCP server now accepts standard client workspace roots, binds the first
+  initialized Kin repository without a hardcoded `--repo`, and keeps semantic
+  answers fail closed on graph authority.
+
+### Changed
+
+- Public onboarding now leads with the semantic system-of-record workflow,
+  distinguishes graph-backed runtime proof from setup metadata, and links each
+  supported install path from one concise entry point.
+- Release builds now pin the reviewed `kin-vfs` source at
+  `c782905f39500a7a107aba5a91e85119c77726fa`; its local `kin-vfs-core` remains
+  version 0.1.5, matching Kin's registry-resolved dependency.
+
+### Fixed
+
+- The installer now reports unsupported or unavailable optional VFS targets as
+  skipped instead of falsely claiming that a shim was installed.
+
 ## [0.2.23] - 2026-07-14
 
 This patch republishes the reviewed v0.2.22 payload through the corrected
@@ -599,7 +624,8 @@ Historical note: this snapshot predates the public GitHub prerelease series and 
 - Daemon mode for background file watching (`kin-daemon`)
 - 19-crate workspace architecture
 
-[unreleased]: https://github.com/firelock-ai/kin/compare/v0.2.23...HEAD
+[unreleased]: https://github.com/firelock-ai/kin/compare/v0.2.24...HEAD
+[0.2.24]: https://github.com/firelock-ai/kin/compare/v0.2.23...v0.2.24
 [0.2.23]: https://github.com/firelock-ai/kin/compare/v0.2.22...v0.2.23
 [0.2.22]: https://github.com/firelock-ai/kin/compare/v0.2.21...v0.2.22
 [0.2.21]: https://github.com/firelock-ai/kin/compare/v0.2.20...v0.2.21

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,9 @@ VFS support, and easier to follow from install through graph-backed proof.
   skipped instead of falsely claiming that a shim was installed.
 - Workspace-root binding now normalizes Windows drive `file://` URIs and bare
   drive paths, while preserving local POSIX roots and Windows UNC shares.
+- On Unix, the global registry now keeps `registry.toml` and `registry.lock`
+  private at mode 0600, rejects unsafe link/type/ownership state, and serializes
+  atomic read-modify-write updates so concurrent writers cannot lose entries.
 
 ## [0.2.23] - 2026-07-14
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,8 +39,10 @@ VFS support, and easier to follow from install through graph-backed proof.
   at mode 0600, refuses permissive modes, links, special files, wrong ownership,
   hard links, unsafe parents, and reserved-path collisions without reading or
   replacing their contents, and requires explicit `kin doctor --fix` permission
-  repair. Install and update preflights enforce the same contract, while locked
-  atomic updates prevent concurrent writers from losing entries.
+  repair. The Unix installer initializes both missing authority files without
+  rewriting existing data, install and update preflights enforce the same
+  contract, and locked atomic updates prevent concurrent writers from losing
+  entries. Native Windows reports this Unix permission contract as unsupported.
 
 ## [0.2.23] - 2026-07-14
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3141,6 +3141,7 @@ dependencies = [
  "kin-index",
  "kin-model",
  "kin-parser",
+ "libc",
  "pretty_assertions",
  "serde",
  "serde_json",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3039,14 +3039,14 @@ dependencies = [
 
 [[package]]
 name = "kin-buildinfo"
-version = "0.2.23"
+version = "0.2.24"
 dependencies = [
  "sha2 0.11.0",
 ]
 
 [[package]]
 name = "kin-cli"
-version = "0.2.23"
+version = "0.2.24"
 dependencies = [
  "age",
  "anyhow",
@@ -3114,7 +3114,7 @@ dependencies = [
 
 [[package]]
 name = "kin-context"
-version = "0.2.23"
+version = "0.2.24"
 dependencies = [
  "kin-blobs",
  "kin-db",
@@ -3130,7 +3130,7 @@ dependencies = [
 
 [[package]]
 name = "kin-core"
-version = "0.2.23"
+version = "0.2.24"
 dependencies = [
  "chrono",
  "directories 5.0.1",
@@ -3154,7 +3154,7 @@ dependencies = [
 
 [[package]]
 name = "kin-daemon"
-version = "0.2.23"
+version = "0.2.24"
 dependencies = [
  "async-stream",
  "axum",
@@ -3244,7 +3244,7 @@ dependencies = [
 
 [[package]]
 name = "kin-git"
-version = "0.2.23"
+version = "0.2.24"
 dependencies = [
  "chrono",
  "gix",
@@ -3262,7 +3262,7 @@ dependencies = [
 
 [[package]]
 name = "kin-index"
-version = "0.2.23"
+version = "0.2.24"
 dependencies = [
  "hex",
  "kin-blobs",
@@ -3310,7 +3310,7 @@ dependencies = [
 
 [[package]]
 name = "kin-integration-tests"
-version = "0.2.23"
+version = "0.2.24"
 dependencies = [
  "kin-blobs",
  "kin-cli",
@@ -3352,7 +3352,7 @@ dependencies = [
 
 [[package]]
 name = "kin-mcp"
-version = "0.2.23"
+version = "0.2.24"
 dependencies = [
  "kin-blobs",
  "kin-context",
@@ -3379,7 +3379,7 @@ dependencies = [
 
 [[package]]
 name = "kin-migrate"
-version = "0.2.23"
+version = "0.2.24"
 dependencies = [
  "chrono",
  "kin-blobs",
@@ -3421,7 +3421,7 @@ dependencies = [
 
 [[package]]
 name = "kin-parser"
-version = "0.2.23"
+version = "0.2.24"
 dependencies = [
  "kin-model",
  "pretty_assertions",
@@ -3451,7 +3451,7 @@ dependencies = [
 
 [[package]]
 name = "kin-projection"
-version = "0.2.23"
+version = "0.2.24"
 dependencies = [
  "kin-blobs",
  "kin-db",
@@ -3466,7 +3466,7 @@ dependencies = [
 
 [[package]]
 name = "kin-ranking"
-version = "0.2.23"
+version = "0.2.24"
 dependencies = [
  "kin-model",
  "serde",
@@ -3475,7 +3475,7 @@ dependencies = [
 
 [[package]]
 name = "kin-reconcile"
-version = "0.2.23"
+version = "0.2.24"
 dependencies = [
  "kin-blobs",
  "kin-db",
@@ -3495,7 +3495,7 @@ dependencies = [
 
 [[package]]
 name = "kin-registry"
-version = "0.2.23"
+version = "0.2.24"
 dependencies = [
  "axum",
  "base64 0.22.1",
@@ -3520,7 +3520,7 @@ dependencies = [
 
 [[package]]
 name = "kin-remote"
-version = "0.2.23"
+version = "0.2.24"
 dependencies = [
  "chrono",
  "kin-model",
@@ -3536,7 +3536,7 @@ dependencies = [
 
 [[package]]
 name = "kin-review"
-version = "0.2.23"
+version = "0.2.24"
 dependencies = [
  "kin-blobs",
  "kin-db",
@@ -3552,7 +3552,7 @@ dependencies = [
 
 [[package]]
 name = "kin-runtime"
-version = "0.2.23"
+version = "0.2.24"
 dependencies = [
  "chrono",
  "hex",
@@ -3584,7 +3584,7 @@ dependencies = [
 
 [[package]]
 name = "kin-semantic-contracts"
-version = "0.2.23"
+version = "0.2.24"
 dependencies = [
  "kin-db",
  "kin-model",
@@ -3599,7 +3599,7 @@ dependencies = [
 
 [[package]]
 name = "kin-spine"
-version = "0.2.23"
+version = "0.2.24"
 dependencies = [
  "chrono",
  "hashbrown 0.15.5",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,7 +27,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.2.23"
+version = "0.2.24"
 edition = "2021"
 license = "Apache-2.0"
 authors = ["Troy Fortin <troy@firelock.ai>"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -37,7 +37,10 @@ RUN if [ -n "$KIN_BUILD_GIT_SHA" ] || [ -n "$KIN_BUILD_DIRTY" ] || [ -n "$KIN_BU
 
 FROM debian:trixie-slim
 RUN apt-get update && apt-get upgrade -y && apt-get install -y ca-certificates curl libssl3 && rm -rf /var/lib/apt/lists/*
-RUN groupadd -r kin && useradd -r -g kin kin
+RUN groupadd -r kin \
+    && useradd -r -g kin -d /home/kin -m kin \
+    && chmod 0700 /home/kin
+ENV HOME=/home/kin
 WORKDIR /app
 COPY --from=builder /build/kin/target/release/kin-daemon /usr/local/bin/kin-daemon
 COPY --from=builder /build/kin/target/release/kin /usr/local/bin/kin

--- a/crates/kin-cli/src/commands/commit.rs
+++ b/crates/kin-cli/src/commands/commit.rs
@@ -593,22 +593,17 @@ async fn run_local_commit_pipeline_for_tests(
         }
     }
 
-    // Update the global ~/.kin/registry.toml with current entity count
-    if let Ok(mut registry) = kin_core::registry::KinRegistry::load() {
-        let cwd = layout.working_dir().to_path_buf();
-        let repo_id = crate::commands::remote::resolve_repo_id(&layout)?;
-        // Fetch remote repo catalog for cross-repo dependency matching.
-        // Checks KIN_REMOTE_URL env var or ~/.kin/remote.toml for a remote spine URL.
-        // Returns empty if no remote configured or unreachable (3-second timeout).
-        let remote_ids = fetch_remote_catalog();
-        registry.upsert_with_remote(
-            repo_id,
-            cwd.canonicalize().unwrap_or(cwd),
-            total_entity_count,
-            &remote_ids,
-        );
-        let _ = registry.save();
-    }
+    // Update the global ~/.kin/registry.toml with current entity count.
+    let cwd = layout.working_dir().to_path_buf();
+    let repo_id = crate::commands::remote::resolve_repo_id(&layout)?;
+    // Fetch remote repo catalog for cross-repo dependency matching.
+    // Checks KIN_REMOTE_URL env var or ~/.kin/remote.toml for a remote spine URL.
+    // Returns empty if no remote configured or unreachable (3-second timeout).
+    let remote_ids = fetch_remote_catalog();
+    let canonical_cwd = cwd.canonicalize().unwrap_or(cwd);
+    let _ = kin_core::registry::KinRegistry::update(|registry| {
+        registry.upsert_with_remote(repo_id, canonical_cwd, total_entity_count, &remote_ids);
+    });
 
     Ok(())
 }

--- a/crates/kin-cli/src/commands/commit.rs
+++ b/crates/kin-cli/src/commands/commit.rs
@@ -601,9 +601,14 @@ async fn run_local_commit_pipeline_for_tests(
     // Returns empty if no remote configured or unreachable (3-second timeout).
     let remote_ids = fetch_remote_catalog();
     let canonical_cwd = cwd.canonicalize().unwrap_or(cwd);
-    let _ = kin_core::registry::KinRegistry::update(|registry| {
+    kin_core::registry::KinRegistry::update(|registry| {
         registry.upsert_with_remote(repo_id, canonical_cwd, total_entity_count, &remote_ids);
-    });
+    })
+    .map_err(|error| {
+        anyhow::anyhow!(
+            "semantic change landed, but the local registry authority update failed: {error}"
+        )
+    })?;
 
     Ok(())
 }

--- a/crates/kin-cli/src/commands/health.rs
+++ b/crates/kin-cli/src/commands/health.rs
@@ -128,6 +128,7 @@ pub async fn run_health_checks() -> HealthReport {
         check_repo_init(),
         check_session_runtime(),
         check_shell_path(),
+        check_registry_authority(),
     ];
     checks.extend(check_mcp_clients());
     checks.push(check_setup_ledger());
@@ -142,6 +143,66 @@ pub async fn run_health_checks() -> HealthReport {
         platform: env::consts::OS.to_string(),
         checks,
         healthy,
+    }
+}
+
+fn check_registry_authority() -> HealthCheck {
+    use kin_core::registry::RegistryAuthorityState;
+
+    let report = kin_core::registry::inspect_registry_authority();
+    if report
+        .checks
+        .iter()
+        .all(|check| check.state == RegistryAuthorityState::Unsupported)
+    {
+        return HealthCheck::new(
+            "registry_authority",
+            "Registry authority",
+            HealthStatus::Unsupported,
+            "Unix ownership and mode checks do not apply on this platform",
+        );
+    }
+    if report.is_secure() {
+        let secure = report
+            .checks
+            .iter()
+            .filter(|check| check.state == RegistryAuthorityState::Secure)
+            .count();
+        let absent = report
+            .checks
+            .iter()
+            .filter(|check| check.state == RegistryAuthorityState::Absent)
+            .count();
+        return HealthCheck::new(
+            "registry_authority",
+            "Registry authority",
+            HealthStatus::Healthy,
+            format!(
+                "{secure} private authority file(s); {absent} not created yet; no contents read"
+            ),
+        );
+    }
+
+    let detail = report.failure_summary();
+    if report.has_unsafe_object() {
+        HealthCheck::new(
+            "registry_authority",
+            "Registry authority",
+            HealthStatus::Misconfigured,
+            detail,
+        )
+        .with_manual_fix(
+            "inspect and move the unsafe object aside; Kin will not follow, overwrite, or auto-repair it",
+        )
+    } else {
+        HealthCheck::new(
+            "registry_authority",
+            "Registry authority",
+            HealthStatus::Misconfigured,
+            detail,
+        )
+        .fixable()
+        .with_manual_fix("run `kin doctor --fix` to authorize a permission-only 0600 repair")
     }
 }
 
@@ -1135,10 +1196,45 @@ mod tests {
         assert!(json.contains("\"daemon_running\""));
         assert!(json.contains("\"vfs_projection\""));
         assert!(json.contains("\"shell_path\""));
+        assert!(json.contains("\"registry_authority\""));
         assert!(json.contains("\"setup_ledger\""));
         assert!(json.contains("\"platform\""));
         assert!(json.contains("\"healthy\""));
         assert!(json.contains("\"retrieval_profile\""));
+    }
+
+    #[cfg(unix)]
+    #[test]
+    #[serial]
+    fn registry_authority_health_is_read_only_and_explicitly_fixable() {
+        use std::os::unix::fs::PermissionsExt;
+
+        let tmp = tempfile::tempdir().unwrap();
+        let registry = tmp.path().join("registry.toml");
+        let lock = tmp.path().join("registry.lock");
+        std::fs::write(&registry, "repos = []\n").unwrap();
+        std::fs::write(&lock, b"").unwrap();
+        for path in [&registry, &lock] {
+            std::fs::set_permissions(path, std::fs::Permissions::from_mode(0o644)).unwrap();
+        }
+        let _registry_path = EnvGuard::set("KIN_REGISTRY_PATH", &registry);
+
+        let check = check_registry_authority();
+        assert!(matches!(check.status, HealthStatus::Misconfigured));
+        assert!(check.fixable);
+        assert!(check.detail.contains("expected 0600"));
+        assert_eq!(
+            std::fs::metadata(&registry).unwrap().permissions().mode() & 0o777,
+            0o644
+        );
+        assert_eq!(
+            std::fs::metadata(&lock).unwrap().permissions().mode() & 0o777,
+            0o644
+        );
+
+        kin_core::registry::repair_registry_authority_permissions().unwrap();
+        let check = check_registry_authority();
+        assert!(matches!(check.status, HealthStatus::Healthy));
     }
 
     #[test]

--- a/crates/kin-cli/src/commands/import.rs
+++ b/crates/kin-cli/src/commands/import.rs
@@ -200,10 +200,9 @@ pub async fn run(url: String) -> Result<()> {
 }
 
 fn register_in_registry(repo_name: &str, path: &Path, entity_count: usize) {
-    if let Ok(mut registry) = kin_core::registry::KinRegistry::load() {
+    let _ = kin_core::registry::KinRegistry::update(|registry| {
         registry.upsert(repo_name.to_string(), path.to_path_buf(), entity_count);
-        let _ = registry.save();
-    }
+    });
 }
 
 /// Parse all source files, extract entities, store blobs, link cross-file relations.

--- a/crates/kin-cli/src/commands/import.rs
+++ b/crates/kin-cli/src/commands/import.rs
@@ -119,7 +119,7 @@ pub async fn run(url: String) -> Result<()> {
     if kin_dir.exists() {
         println!("Kin already initialized at {}", local_path.display());
         // Still register it
-        register_in_registry(&repo_name, &local_path, 0);
+        register_in_registry(&repo_name, &local_path, 0)?;
         println!("Imported {}: already initialized", repo_name);
         return Ok(());
     }
@@ -185,7 +185,7 @@ pub async fn run(url: String) -> Result<()> {
     }
 
     // Register in global registry
-    register_in_registry(&repo_name, &local_path, total_entity_count);
+    register_in_registry(&repo_name, &local_path, total_entity_count)?;
 
     println!(
         "Imported {}: {} entities, {} relations",
@@ -199,10 +199,12 @@ pub async fn run(url: String) -> Result<()> {
     Ok(())
 }
 
-fn register_in_registry(repo_name: &str, path: &Path, entity_count: usize) {
-    let _ = kin_core::registry::KinRegistry::update(|registry| {
+fn register_in_registry(repo_name: &str, path: &Path, entity_count: usize) -> Result<()> {
+    kin_core::registry::KinRegistry::update(|registry| {
         registry.upsert(repo_name.to_string(), path.to_path_buf(), entity_count);
-    });
+    })
+    .map_err(|e| anyhow::anyhow!("failed to update local registry authority: {e}"))?;
+    Ok(())
 }
 
 /// Parse all source files, extract entities, store blobs, link cross-file relations.

--- a/crates/kin-cli/src/commands/init.rs
+++ b/crates/kin-cli/src/commands/init.rs
@@ -1458,19 +1458,15 @@ pub async fn run(
     }
 
     // Register in the global ~/.kin/registry.toml with the current-tree count.
-    if let Ok(mut registry) = kin_core::registry::KinRegistry::load() {
-        let repo_id = dir
-            .file_name()
-            .and_then(|n| n.to_str())
-            .unwrap_or("unknown")
-            .to_string();
-        registry.upsert(
-            repo_id,
-            dir.canonicalize().unwrap_or(dir),
-            init_summary.total_entity_count,
-        );
-        let _ = registry.save();
-    }
+    let repo_id = dir
+        .file_name()
+        .and_then(|n| n.to_str())
+        .unwrap_or("unknown")
+        .to_string();
+    let canonical_dir = dir.canonicalize().unwrap_or(dir);
+    let _ = kin_core::registry::KinRegistry::update(|registry| {
+        registry.upsert(repo_id, canonical_dir, init_summary.total_entity_count);
+    });
 
     if json {
         println!(

--- a/crates/kin-cli/src/commands/init.rs
+++ b/crates/kin-cli/src/commands/init.rs
@@ -1464,9 +1464,10 @@ pub async fn run(
         .unwrap_or("unknown")
         .to_string();
     let canonical_dir = dir.canonicalize().unwrap_or(dir);
-    let _ = kin_core::registry::KinRegistry::update(|registry| {
+    kin_core::registry::KinRegistry::update(|registry| {
         registry.upsert(repo_id, canonical_dir, init_summary.total_entity_count);
-    });
+    })
+    .map_err(|e| anyhow!("graph initialized, but local registry authority update failed: {e}"))?;
 
     if json {
         println!(

--- a/crates/kin-cli/src/commands/registry.rs
+++ b/crates/kin-cli/src/commands/registry.rs
@@ -16,10 +16,16 @@ struct RegisteredRepoDaemonsOutput {
 }
 
 /// Verify registry authority without reading or printing file contents.
-pub async fn authority(json: bool, fix: bool) -> Result<()> {
+pub async fn authority(json: bool, fix: bool, initialize: bool) -> Result<()> {
     let repaired = if fix {
         kin_core::registry::repair_registry_authority_permissions()
             .map_err(|e| anyhow::anyhow!("registry permission repair refused: {e}"))?
+    } else {
+        Vec::new()
+    };
+    let initialized = if initialize {
+        kin_core::registry::initialize_registry_authority()
+            .map_err(|e| anyhow::anyhow!("registry authority initialization refused: {e}"))?
     } else {
         Vec::new()
     };
@@ -29,6 +35,9 @@ pub async fn authority(json: bool, fix: bool) -> Result<()> {
     } else {
         for path in repaired {
             println!("Repaired mode to 0600: {}", path.display());
+        }
+        for path in initialized {
+            println!("Initialized private authority: {}", path.display());
         }
         println!("Local registry authority:");
         for check in &report.checks {

--- a/crates/kin-cli/src/commands/registry.rs
+++ b/crates/kin-cli/src/commands/registry.rs
@@ -15,6 +15,47 @@ struct RegisteredRepoDaemonsOutput {
     daemons: Vec<RegisteredRepoDaemon>,
 }
 
+/// Verify registry authority without reading or printing file contents.
+pub async fn authority(json: bool, fix: bool) -> Result<()> {
+    let repaired = if fix {
+        kin_core::registry::repair_registry_authority_permissions()
+            .map_err(|e| anyhow::anyhow!("registry permission repair refused: {e}"))?
+    } else {
+        Vec::new()
+    };
+    let report = kin_core::registry::inspect_registry_authority();
+    if json {
+        println!("{}", serde_json::to_string_pretty(&report)?);
+    } else {
+        for path in repaired {
+            println!("Repaired mode to 0600: {}", path.display());
+        }
+        println!("Local registry authority:");
+        for check in &report.checks {
+            println!(
+                "  {:<28} {:<24} {}",
+                check.label,
+                authority_state_label(check.state),
+                check.path.display()
+            );
+            println!("    {}", check.detail);
+        }
+    }
+    kin_core::registry::require_registry_authority_secure()
+        .map_err(|e| anyhow::anyhow!(e.to_string()))
+}
+
+fn authority_state_label(state: kin_core::registry::RegistryAuthorityState) -> &'static str {
+    use kin_core::registry::RegistryAuthorityState;
+    match state {
+        RegistryAuthorityState::Secure => "secure",
+        RegistryAuthorityState::Absent => "absent",
+        RegistryAuthorityState::RepairablePermissions => "repairable-permissions",
+        RegistryAuthorityState::Unsafe => "unsafe",
+        RegistryAuthorityState::Unsupported => "not-applicable",
+    }
+}
+
 /// List all registered Kin repositories.
 pub async fn list() -> Result<()> {
     let registry =

--- a/crates/kin-cli/src/commands/registry.rs
+++ b/crates/kin-cli/src/commands/registry.rs
@@ -95,14 +95,8 @@ pub async fn daemons(json: bool) -> Result<()> {
 
 /// Remove stale entries (paths that no longer contain .kin/).
 pub async fn clean() -> Result<()> {
-    let mut registry =
-        KinRegistry::load().map_err(|e| anyhow::anyhow!("failed to load registry: {}", e))?;
-
-    let removed = registry.clean();
-
-    registry
-        .save()
-        .map_err(|e| anyhow::anyhow!("failed to save registry: {}", e))?;
+    let removed = KinRegistry::update(KinRegistry::clean)
+        .map_err(|e| anyhow::anyhow!("failed to update registry: {}", e))?;
 
     println!("Removed {} stale entries.", removed);
     Ok(())

--- a/crates/kin-cli/src/commands/setup.rs
+++ b/crates/kin-cli/src/commands/setup.rs
@@ -2001,6 +2001,28 @@ pub async fn doctor(fix: bool, json: bool) -> Result<()> {
     println!();
     let mut applied: Vec<String> = Vec::new();
 
+    let registry_needs_fix = report.checks.iter().any(|c| {
+        c.id == "registry_authority"
+            && c.fixable
+            && !matches!(c.status, crate::commands::health::HealthStatus::Healthy)
+    });
+    if registry_needs_fix {
+        match kin_core::registry::repair_registry_authority_permissions() {
+            Ok(paths) => {
+                for path in paths {
+                    applied.push(format!(
+                        "repaired registry authority permissions to 0600 ({})",
+                        path.display()
+                    ));
+                }
+            }
+            Err(e) => println!(
+                "  {} registry permission repair refused: {e}",
+                style("✗").red()
+            ),
+        }
+    }
+
     let shell_needs_fix = report.checks.iter().any(|c| {
         c.id == "shell_path"
             && c.fixable
@@ -2095,9 +2117,15 @@ pub async fn doctor(fix: bool, json: bool) -> Result<()> {
     }
 
     // Clean orphaned daemon PID/port files across registered repos.
-    let cleaned = cleanup_stale_daemons();
-    if cleaned > 0 {
-        applied.push(format!("cleaned {cleaned} stale daemon(s)"));
+    match cleanup_stale_daemons() {
+        Ok(cleaned) if cleaned > 0 => {
+            applied.push(format!("cleaned {cleaned} stale daemon(s)"));
+        }
+        Ok(_) => {}
+        Err(e) => println!(
+            "  {} stale-daemon cleanup refused registry authority: {e}",
+            style("✗").red()
+        ),
     }
 
     if applied.is_empty() {
@@ -2156,26 +2184,26 @@ async fn start_repo_daemon() -> Result<Option<String>> {
 
 /// Scan all registered repos for stale daemon PID/port files and clean them up.
 /// Returns the number of stale daemons cleaned.
-fn cleanup_stale_daemons() -> usize {
+fn cleanup_stale_daemons() -> Result<usize> {
     let mut cleaned = 0;
-    if let Ok(registry) = kin_core::registry::KinRegistry::load() {
-        for repo in &registry.repos {
-            let kin_root = repo.path.join(".kin");
-            if !kin_root.exists() {
-                continue;
-            }
-            // daemon_is_up() cleans stale files as a side effect
-            let _ = crate::daemon_client::daemon_is_up(&kin_root);
-            // Also check for orphaned port files without a PID file
-            let has_port = kin_root.join("daemon.port").exists();
-            let has_pid = kin_root.join("daemon.pid").exists();
-            if has_port && !has_pid {
-                let _ = std::fs::remove_file(kin_root.join("daemon.port"));
-                cleaned += 1;
-            }
+    let registry = kin_core::registry::KinRegistry::load()
+        .map_err(|e| anyhow::anyhow!("failed to load registry: {e}"))?;
+    for repo in &registry.repos {
+        let kin_root = repo.path.join(".kin");
+        if !kin_root.exists() {
+            continue;
+        }
+        // daemon_is_up() cleans stale files as a side effect
+        let _ = crate::daemon_client::daemon_is_up(&kin_root);
+        // Also check for orphaned port files without a PID file
+        let has_port = kin_root.join("daemon.port").exists();
+        let has_pid = kin_root.join("daemon.pid").exists();
+        if has_port && !has_pid {
+            let _ = std::fs::remove_file(kin_root.join("daemon.port"));
+            cleaned += 1;
         }
     }
-    cleaned
+    Ok(cleaned)
 }
 
 // ---------------------------------------------------------------------------

--- a/crates/kin-cli/src/commands/update.rs
+++ b/crates/kin-cli/src/commands/update.rs
@@ -117,6 +117,7 @@ struct GithubAsset {
 }
 
 pub async fn run(skip_verify: bool, channel_flag: Option<Channel>) -> Result<()> {
+    registry_authority_preflight()?;
     println!("Current version: v{CURRENT_VERSION}");
 
     let channel = resolve_channel(channel_flag);
@@ -189,6 +190,14 @@ pub async fn run(skip_verify: bool, channel_flag: Option<Channel>) -> Result<()>
 
     println!("Updated to v{latest} successfully.");
     Ok(())
+}
+
+fn registry_authority_preflight() -> Result<()> {
+    kin_core::registry::require_registry_authority_secure().map_err(|error| {
+        anyhow::anyhow!(
+            "update preflight refused unsafe local registry authority; no release bytes were downloaded: {error}"
+        )
+    })
 }
 
 /// Fetch the release to install for the requested channel.
@@ -712,6 +721,8 @@ fn is_lib(name: &str) -> bool {
 #[cfg(test)]
 mod tests {
     use super::*;
+    #[cfg(unix)]
+    use serial_test::serial;
 
     /// Build an in-memory `.tar.gz` with the given (name, bytes) entries.
     fn make_tar_gz(entries: &[(&str, &[u8])]) -> Vec<u8> {
@@ -927,6 +938,37 @@ mod tests {
         assert!(is_newer("1.0.0", "0.9.9"));
         assert!(!is_newer("0.1.0", "0.1.0"));
         assert!(!is_newer("0.1.0", "0.2.0"));
+    }
+
+    #[cfg(unix)]
+    #[test]
+    #[serial]
+    fn update_preflight_refuses_unsafe_registry_without_repairing_it() {
+        use std::os::unix::fs::PermissionsExt;
+
+        let dir = tempfile::tempdir().unwrap();
+        let registry = dir.path().join("registry.toml");
+        let lock = dir.path().join("registry.lock");
+        std::fs::write(&registry, "repos = []\n").unwrap();
+        std::fs::write(&lock, b"").unwrap();
+        std::fs::set_permissions(&registry, std::fs::Permissions::from_mode(0o644)).unwrap();
+        std::fs::set_permissions(&lock, std::fs::Permissions::from_mode(0o600)).unwrap();
+        let previous = std::env::var_os("KIN_REGISTRY_PATH");
+        std::env::set_var("KIN_REGISTRY_PATH", &registry);
+
+        let error = registry_authority_preflight().unwrap_err();
+        assert!(error
+            .to_string()
+            .contains("no release bytes were downloaded"));
+        assert_eq!(
+            std::fs::metadata(&registry).unwrap().permissions().mode() & 0o777,
+            0o644
+        );
+
+        match previous {
+            Some(value) => std::env::set_var("KIN_REGISTRY_PATH", value),
+            None => std::env::remove_var("KIN_REGISTRY_PATH"),
+        }
     }
 
     #[test]

--- a/crates/kin-cli/src/main.rs
+++ b/crates/kin-cli/src/main.rs
@@ -1671,6 +1671,15 @@ enum SetupAction {
 
 #[derive(Subcommand)]
 enum RegistryAction {
+    /// Verify local registry authority without reading its contents
+    Authority {
+        /// Emit machine-readable JSON
+        #[arg(long)]
+        json: bool,
+        /// Explicitly repair mode bits on structurally safe authority files
+        #[arg(long)]
+        fix: bool,
+    },
     /// Show repo daemons registered with the central local supervisor
     Daemons {
         /// Emit machine-readable JSON
@@ -2749,6 +2758,9 @@ fn main() -> Result<()> {
                     channel,
                 } => commands::update::run(skip_verify, channel).await,
                 Command::Registry { action } => match action {
+                    Some(RegistryAction::Authority { json, fix }) => {
+                        commands::registry::authority(json, fix).await
+                    }
                     Some(RegistryAction::Daemons { json }) => {
                         commands::registry::daemons(json).await
                     }

--- a/crates/kin-cli/src/main.rs
+++ b/crates/kin-cli/src/main.rs
@@ -1679,6 +1679,9 @@ enum RegistryAction {
         /// Explicitly repair mode bits on structurally safe authority files
         #[arg(long)]
         fix: bool,
+        /// Create missing private authority files without replacing existing data
+        #[arg(long)]
+        initialize: bool,
     },
     /// Show repo daemons registered with the central local supervisor
     Daemons {
@@ -2758,9 +2761,11 @@ fn main() -> Result<()> {
                     channel,
                 } => commands::update::run(skip_verify, channel).await,
                 Command::Registry { action } => match action {
-                    Some(RegistryAction::Authority { json, fix }) => {
-                        commands::registry::authority(json, fix).await
-                    }
+                    Some(RegistryAction::Authority {
+                        json,
+                        fix,
+                        initialize,
+                    }) => commands::registry::authority(json, fix, initialize).await,
                     Some(RegistryAction::Daemons { json }) => {
                         commands::registry::daemons(json).await
                     }

--- a/crates/kin-cli/tests/registry_authority.rs
+++ b/crates/kin-cli/tests/registry_authority.rs
@@ -1,0 +1,116 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Firelock, LLC
+
+#![cfg(unix)]
+
+use std::os::unix::fs::PermissionsExt;
+use std::path::Path;
+use std::process::Command;
+
+fn mode(path: &Path) -> u32 {
+    std::fs::metadata(path).unwrap().permissions().mode() & 0o777
+}
+
+fn unsafe_authority() -> (tempfile::TempDir, std::path::PathBuf, std::path::PathBuf) {
+    let root = tempfile::tempdir().unwrap();
+    let registry = root.path().join("registry.toml");
+    let lock = root.path().join("registry.lock");
+    std::fs::write(&registry, "repos = []\n").unwrap();
+    std::fs::write(&lock, b"").unwrap();
+    std::fs::set_permissions(&registry, std::fs::Permissions::from_mode(0o644)).unwrap();
+    std::fs::set_permissions(&lock, std::fs::Permissions::from_mode(0o644)).unwrap();
+    (root, registry, lock)
+}
+
+fn kin(root: &Path, registry: &Path) -> Command {
+    let home = root.join("home");
+    std::fs::create_dir_all(&home).unwrap();
+    let mut command = Command::new(env!("CARGO_BIN_EXE_kin"));
+    command
+        .current_dir(root)
+        .env("HOME", &home)
+        .env("KIN_HOME", home.join(".kin"))
+        .env("KIN_REGISTRY_PATH", registry)
+        .env("PATH", "/usr/bin:/bin");
+    command
+}
+
+#[test]
+fn registry_authority_json_fails_closed_without_reading_or_repairing() {
+    let (root, registry, lock) = unsafe_authority();
+    let private_sentinel = "FIR_1481_CONTENT_MUST_NOT_ESCAPE";
+    std::fs::write(
+        &registry,
+        format!("repos = []\nprivate = \"{private_sentinel}\"\n"),
+    )
+    .unwrap();
+    let output = kin(root.path(), &registry)
+        .args(["registry", "authority", "--json"])
+        .output()
+        .unwrap();
+
+    assert!(!output.status.success());
+    assert!(!String::from_utf8_lossy(&output.stdout).contains(private_sentinel));
+    assert!(!String::from_utf8_lossy(&output.stderr).contains(private_sentinel));
+    let report: serde_json::Value = serde_json::from_slice(&output.stdout).unwrap();
+    assert!(report["checks"].as_array().unwrap().iter().any(|check| {
+        check["state"] == "repairable_permissions"
+            && check["detail"]
+                .as_str()
+                .is_some_and(|detail| detail.contains("expected 0600"))
+    }));
+    assert_eq!(mode(&registry), 0o644);
+    assert_eq!(mode(&lock), 0o644);
+}
+
+#[test]
+fn doctor_json_and_human_report_the_same_read_only_contract() {
+    let (root, registry, lock) = unsafe_authority();
+    let json = kin(root.path(), &registry)
+        .args(["doctor", "--json"])
+        .output()
+        .unwrap();
+    assert!(
+        json.status.success(),
+        "{}",
+        String::from_utf8_lossy(&json.stderr)
+    );
+    let report: serde_json::Value = serde_json::from_slice(&json.stdout).unwrap();
+    let check = report["checks"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .find(|check| check["id"] == "registry_authority")
+        .unwrap();
+    assert_eq!(check["status"], "misconfigured");
+    assert_eq!(check["fixable"], true);
+
+    let human = kin(root.path(), &registry).arg("doctor").output().unwrap();
+    assert!(human.status.success());
+    let stdout = String::from_utf8_lossy(&human.stdout);
+    assert!(stdout.contains("Registry authority"));
+    assert!(stdout.contains("expected 0600"));
+    assert!(stdout.contains("kin doctor --fix"));
+    assert_eq!(mode(&registry), 0o644);
+    assert_eq!(mode(&lock), 0o644);
+}
+
+#[test]
+fn doctor_fix_is_the_explicit_permission_only_repair() {
+    let (root, registry, lock) = unsafe_authority();
+    let output = kin(root.path(), &registry)
+        .args(["doctor", "--fix"])
+        .output()
+        .unwrap();
+
+    assert!(
+        output.status.success(),
+        "stdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+    assert_eq!(mode(&registry), 0o600);
+    assert_eq!(mode(&lock), 0o600);
+    assert!(String::from_utf8_lossy(&output.stdout)
+        .contains("repaired registry authority permissions to 0600"));
+}

--- a/crates/kin-core/Cargo.toml
+++ b/crates/kin-core/Cargo.toml
@@ -29,6 +29,9 @@ gix = { workspace = true }
 directories = "5"
 fs2 = { workspace = true }
 
+[target.'cfg(unix)'.dependencies]
+libc = "0.2"
+
 [dev-dependencies]
 tempfile = { workspace = true }
 pretty_assertions = { workspace = true }

--- a/crates/kin-core/src/registry.rs
+++ b/crates/kin-core/src/registry.rs
@@ -16,6 +16,77 @@ use std::fs::OpenOptions;
 use std::io::{Read, Write};
 use std::path::{Path, PathBuf};
 
+/// Read-only classification of one local registry-authority path.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, serde::Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum RegistryAuthorityState {
+    /// A regular, single-link, current-user-owned file with mode 0600.
+    Secure,
+    /// The path does not exist yet. Kin will create it privately when needed.
+    Absent,
+    /// The object is structurally safe, but its mode is not exactly 0600.
+    RepairablePermissions,
+    /// The object or its parent cannot be trusted or repaired automatically.
+    Unsafe,
+    /// Unix ownership and mode checks do not apply on this platform.
+    Unsupported,
+}
+
+/// One content-free registry-authority check.
+#[derive(Debug, Clone, PartialEq, Eq, serde::Serialize)]
+pub struct RegistryAuthorityCheck {
+    pub label: String,
+    pub path: PathBuf,
+    pub state: RegistryAuthorityState,
+    pub detail: String,
+}
+
+/// Content-free authority report shared by doctor, setup/install, and update.
+#[derive(Debug, Clone, PartialEq, Eq, serde::Serialize)]
+pub struct RegistryAuthorityReport {
+    pub checks: Vec<RegistryAuthorityCheck>,
+}
+
+impl RegistryAuthorityReport {
+    /// Missing authority files are safe: Kin creates them at 0600 on first use.
+    pub fn is_secure(&self) -> bool {
+        self.checks.iter().all(|check| {
+            matches!(
+                check.state,
+                RegistryAuthorityState::Secure
+                    | RegistryAuthorityState::Absent
+                    | RegistryAuthorityState::Unsupported
+            )
+        })
+    }
+
+    pub fn has_repairable_permissions(&self) -> bool {
+        self.checks
+            .iter()
+            .any(|check| check.state == RegistryAuthorityState::RepairablePermissions)
+    }
+
+    pub fn has_unsafe_object(&self) -> bool {
+        self.checks
+            .iter()
+            .any(|check| check.state == RegistryAuthorityState::Unsafe)
+    }
+
+    pub fn failure_summary(&self) -> String {
+        self.checks
+            .iter()
+            .filter(|check| {
+                matches!(
+                    check.state,
+                    RegistryAuthorityState::RepairablePermissions | RegistryAuthorityState::Unsafe
+                )
+            })
+            .map(|check| format!("{}: {}", check.path.display(), check.detail))
+            .collect::<Vec<_>>()
+            .join("; ")
+    }
+}
+
 #[derive(Debug, Serialize, Deserialize, Default)]
 pub struct KinRegistry {
     pub repos: Vec<RegisteredRepo>,
@@ -244,6 +315,76 @@ impl KinRegistry {
     }
 }
 
+/// Inspect the default local registry authority without reading file contents.
+pub fn inspect_registry_authority() -> RegistryAuthorityReport {
+    inspect_registry_authority_at(&registry_path())
+}
+
+/// Inspect a registry authority path without following links or reading contents.
+pub fn inspect_registry_authority_at(path: &Path) -> RegistryAuthorityReport {
+    #[cfg(unix)]
+    {
+        return inspect_registry_authority_at_unix(path);
+    }
+    #[cfg(not(unix))]
+    {
+        RegistryAuthorityReport {
+            checks: vec![RegistryAuthorityCheck {
+                label: "registry authority".to_string(),
+                path: path.to_path_buf(),
+                state: RegistryAuthorityState::Unsupported,
+                detail: "Unix ownership and mode checks do not apply on this platform".to_string(),
+            }],
+        }
+    }
+}
+
+/// Refuse an operation when existing registry authority is not trustworthy.
+pub fn require_registry_authority_secure() -> Result<(), Box<dyn std::error::Error>> {
+    require_registry_authority_secure_at(&registry_path())
+}
+
+pub fn require_registry_authority_secure_at(path: &Path) -> Result<(), Box<dyn std::error::Error>> {
+    let report = inspect_registry_authority_at(path);
+    if report.is_secure() {
+        return Ok(());
+    }
+    let remediation = if report.has_unsafe_object() {
+        "Refusing to trust or replace it. Move the unsafe object aside after inspecting it, then retry."
+    } else {
+        "Run `kin doctor --fix` to authorize a local permission-only repair, then retry."
+    };
+    Err(Box::new(std::io::Error::new(
+        std::io::ErrorKind::PermissionDenied,
+        format!(
+            "unsafe local registry authority: {} {remediation}",
+            report.failure_summary()
+        ),
+    )))
+}
+
+/// Explicitly repair mode bits on structurally safe registry-authority files.
+///
+/// This never reads or replaces contents and refuses symlinks, non-regular
+/// files, wrong ownership, hard links, unsafe parents, and path collisions.
+pub fn repair_registry_authority_permissions() -> Result<Vec<PathBuf>, Box<dyn std::error::Error>> {
+    repair_registry_authority_permissions_at(&registry_path())
+}
+
+pub fn repair_registry_authority_permissions_at(
+    path: &Path,
+) -> Result<Vec<PathBuf>, Box<dyn std::error::Error>> {
+    #[cfg(unix)]
+    {
+        return repair_registry_authority_permissions_at_unix(path);
+    }
+    #[cfg(not(unix))]
+    {
+        let _ = path;
+        Ok(Vec::new())
+    }
+}
+
 #[cfg(unix)]
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 struct FileIdentity {
@@ -297,6 +438,16 @@ impl RegistryAnchor {
             })?
             .to_os_string();
 
+        if registry_name == lock_name
+            || registry_name == legacy_tmp_name
+            || lock_name == legacy_tmp_name
+        {
+            return Err(std::io::Error::new(
+                std::io::ErrorKind::InvalidInput,
+                "registry path collides with its reserved .lock or .tmp authority path",
+            ));
+        }
+
         let parent_c =
             std::ffi::CString::new(parent_path.as_os_str().as_bytes()).map_err(|_| {
                 std::io::Error::new(
@@ -337,9 +488,194 @@ fn normalized_parent(path: &Path) -> PathBuf {
 
 #[cfg(unix)]
 fn prepare_anchor(path: &Path) -> Result<RegistryAnchor, Box<dyn std::error::Error>> {
+    use std::os::unix::fs::DirBuilderExt;
+
     let parent = normalized_parent(path);
-    std::fs::create_dir_all(&parent)?;
+    let mut builder = std::fs::DirBuilder::new();
+    builder.recursive(true).mode(0o700);
+    builder.create(&parent)?;
     Ok(RegistryAnchor::open(path)?)
+}
+
+#[cfg(unix)]
+fn absent_authority_report(path: &Path) -> RegistryAuthorityReport {
+    RegistryAuthorityReport {
+        checks: vec![
+            authority_check(
+                "registry file",
+                path.to_path_buf(),
+                RegistryAuthorityState::Absent,
+                "not created yet; Kin will create it with mode 0600",
+            ),
+            authority_check(
+                "registry lock",
+                path.with_extension("lock"),
+                RegistryAuthorityState::Absent,
+                "not created yet; Kin will create it with mode 0600",
+            ),
+        ],
+    }
+}
+
+#[cfg(unix)]
+fn authority_check(
+    label: &str,
+    path: PathBuf,
+    state: RegistryAuthorityState,
+    detail: impl Into<String>,
+) -> RegistryAuthorityCheck {
+    RegistryAuthorityCheck {
+        label: label.to_string(),
+        path,
+        state,
+        detail: detail.into(),
+    }
+}
+
+#[cfg(unix)]
+fn inspect_registry_authority_at_unix(path: &Path) -> RegistryAuthorityReport {
+    let anchor = match RegistryAnchor::open(path) {
+        Ok(anchor) => anchor,
+        Err(err) if err.kind() == std::io::ErrorKind::NotFound => {
+            return absent_authority_report(path);
+        }
+        Err(err) => {
+            return RegistryAuthorityReport {
+                checks: vec![authority_check(
+                    "registry authority",
+                    path.to_path_buf(),
+                    RegistryAuthorityState::Unsafe,
+                    err.to_string(),
+                )],
+            };
+        }
+    };
+
+    let mut checks = vec![
+        inspect_named_authority(
+            &anchor,
+            &anchor.registry_name,
+            "registry file",
+            path.to_path_buf(),
+        ),
+        inspect_named_authority(
+            &anchor,
+            &anchor.lock_name,
+            "registry lock",
+            path.with_extension("lock"),
+        ),
+    ];
+    let legacy_tmp = inspect_named_authority(
+        &anchor,
+        &anchor.legacy_tmp_name,
+        "legacy registry temp file",
+        path.with_extension("tmp"),
+    );
+    if legacy_tmp.state != RegistryAuthorityState::Absent {
+        checks.push(legacy_tmp);
+    }
+    RegistryAuthorityReport { checks }
+}
+
+#[cfg(unix)]
+fn inspect_named_authority(
+    anchor: &RegistryAnchor,
+    name: &std::ffi::OsStr,
+    label: &str,
+    path: PathBuf,
+) -> RegistryAuthorityCheck {
+    let stat = match stat_at(anchor, name) {
+        Ok(stat) => stat,
+        Err(err) if err.kind() == std::io::ErrorKind::NotFound => {
+            return authority_check(
+                label,
+                path,
+                RegistryAuthorityState::Absent,
+                "not created yet; Kin will create it with mode 0600",
+            );
+        }
+        Err(err) => {
+            return authority_check(
+                label,
+                path,
+                RegistryAuthorityState::Unsafe,
+                format!("could not inspect without following links: {err}"),
+            );
+        }
+    };
+    if let Err(err) = validate_regular_stat(&stat, label) {
+        return authority_check(label, path, RegistryAuthorityState::Unsafe, err.to_string());
+    }
+    let mode = stat.st_mode & 0o7777;
+    if mode != 0o600 {
+        return authority_check(
+            label,
+            path,
+            RegistryAuthorityState::RepairablePermissions,
+            format!(
+                "mode {mode:04o}; expected 0600. Contents were not read. Run `kin doctor --fix` to authorize repair"
+            ),
+        );
+    }
+    authority_check(
+        label,
+        path,
+        RegistryAuthorityState::Secure,
+        "regular, single-link, current-user-owned, mode 0600",
+    )
+}
+
+#[cfg(unix)]
+fn repair_registry_authority_permissions_at_unix(
+    path: &Path,
+) -> Result<Vec<PathBuf>, Box<dyn std::error::Error>> {
+    let anchor = match RegistryAnchor::open(path) {
+        Ok(anchor) => anchor,
+        Err(err) if err.kind() == std::io::ErrorKind::NotFound => return Ok(Vec::new()),
+        Err(err) => return Err(Box::new(err)),
+    };
+    let report = inspect_registry_authority_at_unix(path);
+    if report.has_unsafe_object() {
+        return Err(Box::new(registry_security_error(format!(
+            "permission repair refused: {}",
+            report.failure_summary()
+        ))));
+    }
+
+    let candidates = [
+        (&anchor.registry_name, "registry file", path.to_path_buf()),
+        (
+            &anchor.lock_name,
+            "registry lock",
+            path.with_extension("lock"),
+        ),
+        (
+            &anchor.legacy_tmp_name,
+            "legacy registry temp file",
+            path.with_extension("tmp"),
+        ),
+    ];
+    let mut opened = Vec::new();
+    for (name, label, candidate_path) in candidates {
+        let file = match open_at(&anchor, name, libc::O_RDONLY | libc::O_NONBLOCK, 0) {
+            Ok(file) => file,
+            Err(err) if err.kind() == std::io::ErrorKind::NotFound => continue,
+            Err(err) => return Err(Box::new(err)),
+        };
+        let identity = validate_regular_file(&file, label)?;
+        verify_named_structural_identity(&anchor, name, identity, label)?;
+        opened.push((name.to_os_string(), label, candidate_path, file, identity));
+    }
+
+    let mut repaired = Vec::new();
+    for (name, label, candidate_path, file, identity) in opened {
+        if stat_file(&file)?.st_mode & 0o7777 != 0o600 {
+            set_private_mode(&file)?;
+            verify_named_identity(&anchor, &name, identity, label)?;
+            repaired.push(candidate_path);
+        }
+    }
+    Ok(repaired)
 }
 
 #[cfg(unix)]
@@ -354,7 +690,7 @@ fn load_from_unix(path: &Path) -> Result<KinRegistry, Box<dyn std::error::Error>
     let lock_file = open_private_lock_at(&anchor)?;
     lock_file.lock_shared()?;
     verify_named_file(&anchor, &anchor.lock_name, &lock_file, "registry lock")?;
-    tighten_legacy_tmp_at(&anchor)?;
+    validate_legacy_tmp_at(&anchor)?;
     read_registry_at(&anchor)
 }
 
@@ -389,7 +725,7 @@ fn update_at_unix<T>(
             format!("failed to revalidate locked registry lock: {err}"),
         )
     })?;
-    tighten_legacy_tmp_at(&anchor).map_err(|err| {
+    validate_legacy_tmp_at(&anchor).map_err(|err| {
         std::io::Error::new(
             err.kind(),
             format!("failed to validate legacy registry temp: {err}"),
@@ -406,8 +742,7 @@ fn update_at_unix<T>(
 
 #[cfg(unix)]
 fn read_registry_at(anchor: &RegistryAnchor) -> Result<KinRegistry, Box<dyn std::error::Error>> {
-    let Some(mut file) =
-        open_existing_regular_at(anchor, &anchor.registry_name, "registry file", true)?
+    let Some(mut file) = open_existing_regular_at(anchor, &anchor.registry_name, "registry file")?
     else {
         return Ok(KinRegistry::default());
     };
@@ -423,22 +758,22 @@ fn save_registry_at(
     anchor: &RegistryAnchor,
     contents: &[u8],
 ) -> Result<(), Box<dyn std::error::Error>> {
-    tighten_legacy_tmp_at(anchor)?;
-    let _ = open_existing_regular_at(anchor, &anchor.registry_name, "registry file", true)?;
+    validate_legacy_tmp_at(anchor)?;
+    let _ = open_existing_regular_at(anchor, &anchor.registry_name, "registry file")?;
     write_registry_atomically_at(anchor, contents)
 }
 
 #[cfg(unix)]
 fn open_private_lock_at(anchor: &RegistryAnchor) -> std::io::Result<File> {
-    let file = match open_at(
+    let (file, created) = match open_at(
         anchor,
         &anchor.lock_name,
         libc::O_RDWR | libc::O_CREAT | libc::O_EXCL,
         0o600,
     ) {
-        Ok(file) => Ok(file),
+        Ok(file) => Ok((file, true)),
         Err(err) if err.kind() == std::io::ErrorKind::AlreadyExists => {
-            open_lock_after_create_race(anchor)
+            open_lock_after_create_race(anchor).map(|file| (file, false))
         }
         Err(err) => Err(err),
     }
@@ -451,9 +786,13 @@ fn open_private_lock_at(anchor: &RegistryAnchor) -> std::io::Result<File> {
     validate_regular_file(&file, "registry lock").map_err(|err| {
         std::io::Error::new(err.kind(), format!("registry lock fd invalid: {err}"))
     })?;
-    set_private_mode(&file).map_err(|err| {
-        std::io::Error::new(err.kind(), format!("registry lock fchmod failed: {err}"))
-    })?;
+    if created {
+        set_private_mode(&file).map_err(|err| {
+            std::io::Error::new(err.kind(), format!("registry lock fchmod failed: {err}"))
+        })?;
+    } else {
+        validate_private_file(&file, "registry lock")?;
+    }
     verify_named_file(anchor, &anchor.lock_name, &file, "registry lock").map_err(|err| {
         std::io::Error::new(err.kind(), format!("registry lock pathname invalid: {err}"))
     })?;
@@ -464,7 +803,12 @@ fn open_private_lock_at(anchor: &RegistryAnchor) -> std::io::Result<File> {
 fn open_lock_after_create_race(anchor: &RegistryAnchor) -> std::io::Result<File> {
     let mut last_error = None;
     for _ in 0..50 {
-        match open_at(anchor, &anchor.lock_name, libc::O_RDWR, 0) {
+        match open_at(
+            anchor,
+            &anchor.lock_name,
+            libc::O_RDWR | libc::O_NONBLOCK,
+            0,
+        ) {
             Ok(file) => return Ok(file),
             Err(err)
                 if matches!(
@@ -487,29 +831,20 @@ fn open_existing_regular_at(
     anchor: &RegistryAnchor,
     name: &std::ffi::OsStr,
     label: &str,
-    tighten: bool,
 ) -> std::io::Result<Option<File>> {
-    let file = match open_at(anchor, name, libc::O_RDONLY, 0) {
+    let file = match open_at(anchor, name, libc::O_RDONLY | libc::O_NONBLOCK, 0) {
         Ok(file) => file,
         Err(err) if err.kind() == std::io::ErrorKind::NotFound => return Ok(None),
         Err(err) => return Err(err),
     };
-    validate_regular_file(&file, label)?;
-    if tighten {
-        set_private_mode(&file)?;
-    }
+    validate_private_file(&file, label)?;
     verify_named_file(anchor, name, &file, label)?;
     Ok(Some(file))
 }
 
 #[cfg(unix)]
-fn tighten_legacy_tmp_at(anchor: &RegistryAnchor) -> std::io::Result<()> {
-    let _ = open_existing_regular_at(
-        anchor,
-        &anchor.legacy_tmp_name,
-        "legacy registry temp file",
-        true,
-    )?;
+fn validate_legacy_tmp_at(anchor: &RegistryAnchor) -> std::io::Result<()> {
+    let _ = open_existing_regular_at(anchor, &anchor.legacy_tmp_name, "legacy registry temp file")?;
     Ok(())
 }
 
@@ -565,12 +900,23 @@ fn validate_parent(parent: &File) -> std::io::Result<()> {
             "registry parent must be owned by the current user",
         ));
     }
+    if stat.st_mode & 0o022 != 0 {
+        return Err(registry_security_error(format!(
+            "registry parent must not be group/world writable (found mode {:04o})",
+            stat.st_mode & 0o7777
+        )));
+    }
     Ok(())
 }
 
 #[cfg(unix)]
 fn validate_regular_file(file: &File, label: &str) -> std::io::Result<FileIdentity> {
     validate_regular_stat(&stat_file(file)?, label)
+}
+
+#[cfg(unix)]
+fn validate_private_file(file: &File, label: &str) -> std::io::Result<FileIdentity> {
+    validate_private_stat(&stat_file(file)?, label)
 }
 
 #[cfg(unix)]
@@ -596,6 +942,18 @@ fn validate_regular_stat(stat: &libc::stat, label: &str) -> std::io::Result<File
         device: stat.st_dev as u64,
         inode: stat.st_ino as u64,
     })
+}
+
+#[cfg(unix)]
+fn validate_private_stat(stat: &libc::stat, label: &str) -> std::io::Result<FileIdentity> {
+    let identity = validate_regular_stat(stat, label)?;
+    let mode = stat.st_mode & 0o7777;
+    if mode != 0o600 {
+        return Err(registry_security_error(format!(
+            "{label} has mode {mode:04o}; expected 0600. Refusing to trust or replace it. Run `kin doctor --fix` to authorize a permission-only repair"
+        )));
+    }
+    Ok(identity)
 }
 
 #[cfg(unix)]
@@ -644,7 +1002,7 @@ fn set_private_mode(file: &File) -> std::io::Result<()> {
         return Err(std::io::Error::last_os_error());
     }
     let stat = stat_file(file)?;
-    if stat.st_mode & 0o777 != 0o600 {
+    if stat.st_mode & 0o7777 != 0o600 {
         return Err(registry_security_error(
             "registry authority file did not reach mode 0600",
         ));
@@ -659,12 +1017,28 @@ fn verify_named_file(
     file: &File,
     label: &str,
 ) -> std::io::Result<()> {
-    let identity = validate_regular_file(file, label)?;
+    let identity = validate_private_file(file, label)?;
     verify_named_identity(anchor, name, identity, label)
 }
 
 #[cfg(unix)]
 fn verify_named_identity(
+    anchor: &RegistryAnchor,
+    name: &std::ffi::OsStr,
+    expected: FileIdentity,
+    label: &str,
+) -> std::io::Result<()> {
+    let actual = validate_private_stat(&stat_at(anchor, name)?, label)?;
+    if actual != expected {
+        return Err(registry_security_error(format!(
+            "{label} changed identity during the registry operation"
+        )));
+    }
+    Ok(())
+}
+
+#[cfg(unix)]
+fn verify_named_structural_identity(
     anchor: &RegistryAnchor,
     name: &std::ffi::OsStr,
     expected: FileIdentity,
@@ -771,8 +1145,11 @@ fn cleanup_temp_if_same(
         return Ok(());
     }
     let name_c = name_cstring(name)?;
-    // SAFETY: the retained dirfd and relative name are valid; identity was
-    // revalidated immediately before unlinking.
+    // SAFETY: the retained dirfd and relative name are valid. The containing
+    // directory is owned by the current user and is not group/world writable;
+    // same-UID pathname replacement is outside this file-permission boundary
+    // because that actor can already modify the 0600 authority files. The
+    // identity check still prevents unlinking an observed replacement.
     if unsafe { libc::unlinkat(anchor.parent.as_raw_fd(), name_c.as_ptr(), 0) } != 0 {
         return Err(std::io::Error::last_os_error());
     }
@@ -852,7 +1229,7 @@ mod tests {
 
     #[cfg(unix)]
     #[test]
-    fn registry_and_lock_files_are_private() {
+    fn unsafe_permissions_are_rejected_without_mutation_until_explicit_repair() {
         use std::os::unix::fs::PermissionsExt;
 
         let dir = tempfile::tempdir().unwrap();
@@ -863,10 +1240,27 @@ mod tests {
         std::fs::set_permissions(&reg_path, std::fs::Permissions::from_mode(0o644)).unwrap();
         std::fs::set_permissions(&lock_path, std::fs::Permissions::from_mode(0o644)).unwrap();
 
-        KinRegistry::default().save_to(&reg_path).unwrap();
+        let registry_before = std::fs::read(&reg_path).unwrap();
+        let lock_before = std::fs::read(&lock_path).unwrap();
+
+        let error = KinRegistry::default().save_to(&reg_path).unwrap_err();
+        assert!(error.to_string().contains("expected 0600"));
+        assert_eq!(std::fs::read(&reg_path).unwrap(), registry_before);
+        assert_eq!(std::fs::read(&lock_path).unwrap(), lock_before);
+        assert_eq!(mode(&reg_path), 0o644);
+        assert_eq!(mode(&lock_path), 0o644);
+
+        let report = inspect_registry_authority_at(&reg_path);
+        assert!(report.has_repairable_permissions());
+        assert!(!report.has_unsafe_object());
+        assert!(require_registry_authority_secure_at(&reg_path).is_err());
+
+        let repaired = repair_registry_authority_permissions_at(&reg_path).unwrap();
+        assert_eq!(repaired.len(), 2);
 
         assert_eq!(mode(&reg_path), 0o600);
         assert_eq!(mode(&lock_path), 0o600);
+        KinRegistry::default().save_to(&reg_path).unwrap();
         assert!(std::fs::read_dir(dir.path()).unwrap().all(|entry| !entry
             .unwrap()
             .file_name()
@@ -876,7 +1270,7 @@ mod tests {
 
     #[cfg(unix)]
     #[test]
-    fn loading_tightens_an_existing_registry_lock() {
+    fn loading_never_tightens_existing_permissions_implicitly() {
         use std::os::unix::fs::PermissionsExt;
 
         let dir = tempfile::tempdir().unwrap();
@@ -887,10 +1281,11 @@ mod tests {
         std::fs::set_permissions(&reg_path, std::fs::Permissions::from_mode(0o644)).unwrap();
         std::fs::set_permissions(&lock_path, std::fs::Permissions::from_mode(0o644)).unwrap();
 
-        KinRegistry::load_from(&reg_path).unwrap();
+        let error = KinRegistry::load_from(&reg_path).unwrap_err();
+        assert!(error.to_string().contains("expected 0600"));
 
-        assert_eq!(mode(&reg_path), 0o600);
-        assert_eq!(mode(&lock_path), 0o600);
+        assert_eq!(mode(&reg_path), 0o644);
+        assert_eq!(mode(&lock_path), 0o644);
     }
 
     #[test]
@@ -985,7 +1380,7 @@ mod tests {
         for directory in [&home, &kin_home, &tmp, &work] {
             std::fs::create_dir_all(directory).unwrap();
         }
-        let output = std::process::Command::new(std::env::current_exe().unwrap())
+        let mut child = std::process::Command::new(std::env::current_exe().unwrap())
             .arg("registry_security_subprocess")
             .arg("--nocapture")
             .arg("--test-threads=1")
@@ -995,8 +1390,27 @@ mod tests {
             .env("KIN_HOME", &kin_home)
             .env("KIN_REGISTRY_PATH", kin_home.join("registry.toml"))
             .env("TMPDIR", &tmp)
-            .output()
+            .stdout(std::process::Stdio::piped())
+            .stderr(std::process::Stdio::piped())
+            .spawn()
             .unwrap();
+        let deadline = std::time::Instant::now() + std::time::Duration::from_secs(5);
+        loop {
+            if child.try_wait().unwrap().is_some() {
+                break;
+            }
+            if std::time::Instant::now() >= deadline {
+                child.kill().unwrap();
+                let output = child.wait_with_output().unwrap();
+                panic!(
+                    "registry security subprocess {case} exceeded 5 seconds\nstdout:\n{}\nstderr:\n{}",
+                    String::from_utf8_lossy(&output.stdout),
+                    String::from_utf8_lossy(&output.stderr)
+                );
+            }
+            std::thread::sleep(std::time::Duration::from_millis(10));
+        }
+        let output = child.wait_with_output().unwrap();
         assert!(
             output.status.success(),
             "registry security subprocess {case} failed\nstdout:\n{}\nstderr:\n{}",
@@ -1033,6 +1447,31 @@ mod tests {
     #[test]
     fn authority_identity_checks_are_isolated() {
         run_registry_security_subprocess("identity-checks");
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn fifo_authority_paths_fail_within_a_bounded_time() {
+        run_registry_security_subprocess("fifo-paths");
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn writable_registry_parent_is_rejected() {
+        run_registry_security_subprocess("writable-parent");
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn reserved_registry_path_collisions_are_rejected() {
+        let dir = tempfile::tempdir().unwrap();
+        for filename in ["registry.lock", "registry.tmp"] {
+            let path = dir.path().join(filename);
+            let error = KinRegistry::default().save_to(&path).unwrap_err();
+            assert!(error.to_string().contains("collides"), "{error}");
+            let report = inspect_registry_authority_at(&path);
+            assert!(report.has_unsafe_object());
+        }
     }
 
     #[cfg(unix)]
@@ -1122,11 +1561,65 @@ mod tests {
                 for path in [&registry_path, &lock_path, &legacy_tmp_path] {
                     std::fs::set_permissions(path, std::fs::Permissions::from_mode(0o644)).unwrap();
                 }
+                assert!(KinRegistry::load_from(&registry_path).is_err());
+                assert_eq!(mode(&registry_path), 0o644);
+                assert_eq!(mode(&lock_path), 0o644);
+                assert_eq!(mode(&legacy_tmp_path), 0o644);
+                let repaired = repair_registry_authority_permissions_at(&registry_path).unwrap();
+                assert_eq!(repaired.len(), 3);
                 KinRegistry::load_from(&registry_path).unwrap();
                 assert_eq!(mode(&registry_path), 0o600);
                 assert_eq!(mode(&lock_path), 0o600);
                 assert_eq!(mode(&legacy_tmp_path), 0o600);
                 assert_eq!(std::fs::read(&legacy_tmp_path).unwrap(), b"legacy");
+            }
+            "fifo-paths" => {
+                let make_fifo = |path: &Path| {
+                    let path = std::ffi::CString::new(std::os::unix::ffi::OsStrExt::as_bytes(
+                        path.as_os_str(),
+                    ))
+                    .unwrap();
+                    // SAFETY: path is a valid NUL-terminated string and mode is valid.
+                    assert_eq!(unsafe { libc::mkfifo(path.as_ptr(), 0o600) }, 0);
+                };
+
+                make_fifo(&registry_path);
+                let started = std::time::Instant::now();
+                let error = KinRegistry::load_from(&registry_path).unwrap_err();
+                assert!(started.elapsed() < std::time::Duration::from_secs(1));
+                assert!(error.to_string().contains("regular file"), "{error}");
+                std::fs::remove_file(&registry_path).unwrap();
+                std::fs::remove_file(&lock_path).unwrap();
+
+                std::fs::write(&registry_path, "repos = []\n").unwrap();
+                std::fs::set_permissions(&registry_path, std::fs::Permissions::from_mode(0o600))
+                    .unwrap();
+                make_fifo(&lock_path);
+                let started = std::time::Instant::now();
+                let error = KinRegistry::load_from(&registry_path).unwrap_err();
+                assert!(started.elapsed() < std::time::Duration::from_secs(1));
+                assert!(error.to_string().contains("regular file"), "{error}");
+                std::fs::remove_file(&lock_path).unwrap();
+
+                std::fs::write(&lock_path, b"").unwrap();
+                std::fs::set_permissions(&lock_path, std::fs::Permissions::from_mode(0o600))
+                    .unwrap();
+                make_fifo(&legacy_tmp_path);
+                let started = std::time::Instant::now();
+                let error = KinRegistry::load_from(&registry_path).unwrap_err();
+                assert!(started.elapsed() < std::time::Duration::from_secs(1));
+                assert!(error.to_string().contains("regular file"), "{error}");
+            }
+            "writable-parent" => {
+                std::fs::set_permissions(&work, std::fs::Permissions::from_mode(0o777)).unwrap();
+                let error = KinRegistry::default().save_to(&registry_path).unwrap_err();
+                assert!(
+                    error.to_string().contains("group/world writable"),
+                    "{error}"
+                );
+                assert!(!registry_path.exists());
+                assert!(!lock_path.exists());
+                std::fs::set_permissions(&work, std::fs::Permissions::from_mode(0o700)).unwrap();
             }
             "failure-cleanup" => {
                 KinRegistry::default().save_to(&registry_path).unwrap();

--- a/crates/kin-core/src/registry.rs
+++ b/crates/kin-core/src/registry.rs
@@ -381,6 +381,32 @@ pub fn repair_registry_authority_permissions_at(
     #[cfg(not(unix))]
     {
         let _ = path;
+        Err(Box::new(std::io::Error::new(
+            std::io::ErrorKind::Unsupported,
+            "registry permission repair is only supported on Unix",
+        )))
+    }
+}
+
+/// Create missing Unix registry authority files without replacing existing data.
+///
+/// This is intended for fresh/upgrade installers. Existing authority must
+/// already be secure (or explicitly repaired first); existing registry bytes
+/// are never rewritten merely to create a missing companion file.
+pub fn initialize_registry_authority() -> Result<Vec<PathBuf>, Box<dyn std::error::Error>> {
+    initialize_registry_authority_at(&registry_path())
+}
+
+pub fn initialize_registry_authority_at(
+    path: &Path,
+) -> Result<Vec<PathBuf>, Box<dyn std::error::Error>> {
+    #[cfg(unix)]
+    {
+        return initialize_registry_authority_at_unix(path);
+    }
+    #[cfg(not(unix))]
+    {
+        let _ = path;
         Ok(Vec::new())
     }
 }
@@ -438,9 +464,9 @@ impl RegistryAnchor {
             })?
             .to_os_string();
 
-        if registry_name == lock_name
-            || registry_name == legacy_tmp_name
-            || lock_name == legacy_tmp_name
+        if authority_names_collide(&registry_name, &lock_name)
+            || authority_names_collide(&registry_name, &legacy_tmp_name)
+            || authority_names_collide(&lock_name, &legacy_tmp_name)
         {
             return Err(std::io::Error::new(
                 std::io::ErrorKind::InvalidInput,
@@ -476,6 +502,15 @@ impl RegistryAnchor {
             legacy_tmp_name,
         })
     }
+}
+
+#[cfg(unix)]
+fn authority_names_collide(a: &std::ffi::OsStr, b: &std::ffi::OsStr) -> bool {
+    use std::os::unix::ffi::OsStrExt;
+
+    // Conservatively reject ASCII case variants on every Unix platform so a
+    // case-insensitive filesystem cannot alias registry data with lock/temp.
+    a.as_bytes().eq_ignore_ascii_case(b.as_bytes())
 }
 
 #[cfg(unix)]
@@ -679,7 +714,40 @@ fn repair_registry_authority_permissions_at_unix(
 }
 
 #[cfg(unix)]
+fn initialize_registry_authority_at_unix(
+    path: &Path,
+) -> Result<Vec<PathBuf>, Box<dyn std::error::Error>> {
+    // This preflight is deliberately before directory or lock creation: an
+    // unsafe existing registry must not cause any companion-path mutation.
+    require_registry_authority_secure_at(path)?;
+    let anchor = prepare_anchor(path)?;
+    let lock_was_absent = match stat_at(&anchor, &anchor.lock_name) {
+        Ok(_) => false,
+        Err(err) if err.kind() == std::io::ErrorKind::NotFound => true,
+        Err(err) => return Err(Box::new(err)),
+    };
+    let lock_file = open_private_lock_at(&anchor)?;
+    lock_file.lock_exclusive()?;
+    verify_named_file(&anchor, &anchor.lock_name, &lock_file, "registry lock")?;
+    validate_legacy_tmp_at(&anchor)?;
+
+    let mut initialized = Vec::new();
+    if lock_was_absent {
+        initialized.push(path.with_extension("lock"));
+    }
+    if open_existing_regular_at(&anchor, &anchor.registry_name, "registry file")?.is_none() {
+        let contents = toml::to_string_pretty(&KinRegistry::default())?;
+        write_registry_atomically_at(&anchor, contents.as_bytes())?;
+        initialized.push(path.to_path_buf());
+    }
+    Ok(initialized)
+}
+
+#[cfg(unix)]
 fn load_from_unix(path: &Path) -> Result<KinRegistry, Box<dyn std::error::Error>> {
+    // Reject the complete authority snapshot before a missing lock can be
+    // created. Descriptor-anchored checks below then revalidate under lock.
+    require_registry_authority_secure_at(path)?;
     let anchor = match RegistryAnchor::open(path) {
         Ok(anchor) => anchor,
         Err(err) if err.kind() == std::io::ErrorKind::NotFound => {
@@ -696,6 +764,7 @@ fn load_from_unix(path: &Path) -> Result<KinRegistry, Box<dyn std::error::Error>
 
 #[cfg(unix)]
 fn save_to_unix(registry: &KinRegistry, path: &Path) -> Result<(), Box<dyn std::error::Error>> {
+    require_registry_authority_secure_at(path)?;
     let contents = toml::to_string_pretty(registry)?;
     let anchor = prepare_anchor(path)?;
     let lock_file = open_private_lock_at(&anchor)?;
@@ -709,6 +778,7 @@ fn update_at_unix<T>(
     path: &Path,
     mutate: impl FnOnce(&mut KinRegistry) -> T,
 ) -> Result<T, Box<dyn std::error::Error>> {
+    require_registry_authority_secure_at(path)?;
     let anchor = prepare_anchor(path)?;
     let lock_file = open_private_lock_at(&anchor).map_err(|err| {
         std::io::Error::new(err.kind(), format!("failed to open registry lock: {err}"))
@@ -1288,6 +1358,53 @@ mod tests {
         assert_eq!(mode(&lock_path), 0o644);
     }
 
+    #[cfg(unix)]
+    #[test]
+    fn unsafe_registry_never_creates_a_missing_companion_lock() {
+        use std::os::unix::fs::PermissionsExt;
+
+        for operation in ["load", "save", "update"] {
+            let dir = tempfile::tempdir().unwrap();
+            let reg_path = dir.path().join("registry.toml");
+            let lock_path = reg_path.with_extension("lock");
+            std::fs::write(&reg_path, "repos = []\n").unwrap();
+            std::fs::set_permissions(&reg_path, std::fs::Permissions::from_mode(0o644)).unwrap();
+
+            let result = match operation {
+                "load" => KinRegistry::load_from(&reg_path).map(|_| ()),
+                "save" => KinRegistry::default().save_to(&reg_path),
+                "update" => KinRegistry::update_at(&reg_path, |_| {}),
+                _ => unreachable!(),
+            };
+            assert!(result.is_err(), "{operation} unexpectedly trusted 0644");
+            assert!(!lock_path.exists(), "{operation} created a companion lock");
+            assert_eq!(mode(&reg_path), 0o644);
+        }
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn installer_initialization_creates_missing_authority_without_rewriting_existing_bytes() {
+        let fresh = tempfile::tempdir().unwrap();
+        let fresh_path = fresh.path().join("registry.toml");
+        let initialized = initialize_registry_authority_at(&fresh_path).unwrap();
+        assert_eq!(initialized.len(), 2);
+        assert_eq!(mode(&fresh_path), 0o600);
+        assert_eq!(mode(&fresh_path.with_extension("lock")), 0o600);
+        assert!(KinRegistry::load_from(&fresh_path).is_ok());
+
+        let upgrade = tempfile::tempdir().unwrap();
+        let upgrade_path = upgrade.path().join("registry.toml");
+        let existing = b"# retained comment\nrepos = []\n";
+        std::fs::write(&upgrade_path, existing).unwrap();
+        set_private_mode(&File::open(&upgrade_path).unwrap()).unwrap();
+        let initialized = initialize_registry_authority_at(&upgrade_path).unwrap();
+        assert_eq!(initialized, vec![upgrade_path.with_extension("lock")]);
+        assert_eq!(std::fs::read(&upgrade_path).unwrap(), existing);
+        assert_eq!(mode(&upgrade_path), 0o600);
+        assert_eq!(mode(&upgrade_path.with_extension("lock")), 0o600);
+    }
+
     #[test]
     fn locked_updates_preserve_concurrent_writers() {
         use std::sync::{Arc, Barrier};
@@ -1465,7 +1582,12 @@ mod tests {
     #[test]
     fn reserved_registry_path_collisions_are_rejected() {
         let dir = tempfile::tempdir().unwrap();
-        for filename in ["registry.lock", "registry.tmp"] {
+        for filename in [
+            "registry.lock",
+            "registry.tmp",
+            "registry.LOCK",
+            "registry.TMP",
+        ] {
             let path = dir.path().join(filename);
             let error = KinRegistry::default().save_to(&path).unwrap_err();
             assert!(error.to_string().contains("collides"), "{error}");
@@ -1537,7 +1659,7 @@ mod tests {
                 assert_eq!(std::fs::read(&victim).unwrap(), b"do not touch");
                 assert_eq!(mode(&victim), victim_mode);
                 std::fs::remove_file(&registry_path).unwrap();
-                std::fs::remove_file(&lock_path).unwrap();
+                assert!(!lock_path.exists());
 
                 std::fs::write(&registry_path, "repos = []\n").unwrap();
                 std::fs::set_permissions(&registry_path, std::fs::Permissions::from_mode(0o600))
@@ -1589,7 +1711,7 @@ mod tests {
                 assert!(started.elapsed() < std::time::Duration::from_secs(1));
                 assert!(error.to_string().contains("regular file"), "{error}");
                 std::fs::remove_file(&registry_path).unwrap();
-                std::fs::remove_file(&lock_path).unwrap();
+                assert!(!lock_path.exists());
 
                 std::fs::write(&registry_path, "repos = []\n").unwrap();
                 std::fs::set_permissions(&registry_path, std::fs::Permissions::from_mode(0o600))
@@ -1664,7 +1786,7 @@ mod tests {
                 std::fs::create_dir(&registry_path).unwrap();
                 assert!(KinRegistry::load_from(&registry_path).is_err());
                 std::fs::remove_dir(&registry_path).unwrap();
-                std::fs::remove_file(&lock_path).unwrap();
+                assert!(!lock_path.exists());
 
                 std::fs::create_dir(&lock_path).unwrap();
                 assert!(KinRegistry::default().save_to(&registry_path).is_err());

--- a/crates/kin-core/src/registry.rs
+++ b/crates/kin-core/src/registry.rs
@@ -346,15 +346,18 @@ pub fn require_registry_authority_secure() -> Result<(), Box<dyn std::error::Err
 
 pub fn require_registry_authority_secure_at(path: &Path) -> Result<(), Box<dyn std::error::Error>> {
     let mut report = inspect_registry_authority_at(path);
-    // A newly-created lock is requested at 0600 but a restrictive process
-    // umask can make its public mode 0000 for the few instructions before the
-    // creator's descriptor-anchored fchmod. Never repair or trust that state:
-    // only wait briefly for an otherwise-secure authority snapshot to converge.
+    // A newly-created lock is requested at 0600 but the process umask can make
+    // its public mode temporarily differ before the creator's descriptor-
+    // anchored fchmod. A sibling initializer can likewise observe a new parent
+    // before its descriptor-anchored chmod. Never repair or trust either state:
+    // only wait briefly and re-inspect for convergence.
     for _ in 0..50 {
         if report.is_secure() {
             return Ok(());
         }
-        if !report.is_transient_lock_creation_window() {
+        if !report.is_lock_creation_window_candidate()
+            && !report.is_parent_creation_window_candidate(path)
+        {
             break;
         }
         std::thread::sleep(std::time::Duration::from_millis(1));
@@ -379,13 +382,11 @@ pub fn require_registry_authority_secure_at(path: &Path) -> Result<(), Box<dyn s
 
 impl RegistryAuthorityReport {
     #[cfg(unix)]
-    fn is_transient_lock_creation_window(&self) -> bool {
+    fn is_lock_creation_window_candidate(&self) -> bool {
         let mut saw_lock = false;
         self.checks.iter().all(|check| match check.state {
             RegistryAuthorityState::Secure | RegistryAuthorityState::Absent => true,
-            RegistryAuthorityState::RepairablePermissions
-                if check.label == "registry lock" && check.detail.starts_with("mode 0000;") =>
-            {
+            RegistryAuthorityState::RepairablePermissions if check.label == "registry lock" => {
                 saw_lock = true;
                 true
             }
@@ -394,7 +395,29 @@ impl RegistryAuthorityReport {
     }
 
     #[cfg(not(unix))]
-    fn is_transient_lock_creation_window(&self) -> bool {
+    fn is_lock_creation_window_candidate(&self) -> bool {
+        false
+    }
+
+    #[cfg(unix)]
+    fn is_parent_creation_window_candidate(&self, path: &Path) -> bool {
+        if self.checks.len() != 1
+            || self.checks[0].label != "registry authority"
+            || self.checks[0].state != RegistryAuthorityState::Unsafe
+        {
+            return false;
+        }
+        match RegistryAnchor::open(path) {
+            Ok(_) => true,
+            Err(err) => matches!(
+                err.kind(),
+                std::io::ErrorKind::PermissionDenied | std::io::ErrorKind::NotFound
+            ),
+        }
+    }
+
+    #[cfg(not(unix))]
+    fn is_parent_creation_window_candidate(&self, _path: &Path) -> bool {
         false
     }
 }
@@ -469,6 +492,29 @@ impl RegistryAnchor {
         use std::os::unix::ffi::OsStrExt;
 
         let parent_path = normalized_parent(path);
+        let parent_c =
+            std::ffi::CString::new(parent_path.as_os_str().as_bytes()).map_err(|_| {
+                std::io::Error::new(
+                    std::io::ErrorKind::InvalidInput,
+                    "registry parent path contains a NUL byte",
+                )
+            })?;
+        // SAFETY: `parent_c` is NUL-terminated and remains alive for the call.
+        let fd = unsafe {
+            libc::open(
+                parent_c.as_ptr(),
+                libc::O_RDONLY | libc::O_DIRECTORY | libc::O_CLOEXEC | libc::O_NOFOLLOW,
+            )
+        };
+        if fd < 0 {
+            return Err(std::io::Error::last_os_error());
+        }
+        // SAFETY: `fd` was returned by `open` and ownership transfers to `File`.
+        let parent = unsafe { File::from_raw_fd(fd) };
+        Self::from_parent(path, parent)
+    }
+
+    fn from_parent(path: &Path, parent: File) -> std::io::Result<Self> {
         let registry_name = path
             .file_name()
             .filter(|name| !name.is_empty())
@@ -509,26 +555,6 @@ impl RegistryAnchor {
                 "registry path collides with its reserved .lock or .tmp authority path",
             ));
         }
-
-        let parent_c =
-            std::ffi::CString::new(parent_path.as_os_str().as_bytes()).map_err(|_| {
-                std::io::Error::new(
-                    std::io::ErrorKind::InvalidInput,
-                    "registry parent path contains a NUL byte",
-                )
-            })?;
-        // SAFETY: `parent_c` is NUL-terminated and remains alive for the call.
-        let fd = unsafe {
-            libc::open(
-                parent_c.as_ptr(),
-                libc::O_RDONLY | libc::O_DIRECTORY | libc::O_CLOEXEC | libc::O_NOFOLLOW,
-            )
-        };
-        if fd < 0 {
-            return Err(std::io::Error::last_os_error());
-        }
-        // SAFETY: `fd` was returned by `open` and ownership transfers to `File`.
-        let parent = unsafe { File::from_raw_fd(fd) };
         validate_parent(&parent)?;
 
         Ok(Self {
@@ -559,24 +585,49 @@ fn normalized_parent(path: &Path) -> PathBuf {
 
 #[cfg(unix)]
 fn prepare_anchor(path: &Path) -> Result<RegistryAnchor, Box<dyn std::error::Error>> {
-    let parent = normalized_parent(path);
-    create_private_dir_all(&parent)?;
-    Ok(RegistryAnchor::open(path)?)
+    let mut last_permission_error = None;
+    for _ in 0..50 {
+        match RegistryAnchor::open(path) {
+            Ok(anchor) => return Ok(anchor),
+            Err(err) if err.kind() == std::io::ErrorKind::NotFound => {
+                let parent = create_private_dir_all(&normalized_parent(path))?;
+                return Ok(RegistryAnchor::from_parent(path, parent)?);
+            }
+            Err(err) if err.kind() == std::io::ErrorKind::PermissionDenied => {
+                last_permission_error = Some(err);
+                std::thread::sleep(std::time::Duration::from_millis(1));
+            }
+            Err(err) => return Err(Box::new(err)),
+        }
+    }
+    Err(Box::new(last_permission_error.unwrap_or_else(|| {
+        std::io::Error::other("registry parent create race did not converge")
+    })))
 }
 
 #[cfg(unix)]
-fn create_private_dir_all(path: &Path) -> std::io::Result<()> {
-    use std::os::fd::{AsRawFd, FromRawFd};
+fn create_private_dir_all(path: &Path) -> std::io::Result<File> {
+    use std::os::fd::AsRawFd;
     use std::os::unix::ffi::OsStrExt;
 
-    match std::fs::symlink_metadata(path) {
-        Ok(_) => return Ok(()),
-        Err(err) if err.kind() == std::io::ErrorKind::NotFound => {}
-        Err(err) => return Err(err),
-    }
-
-    let mut ancestor = path.to_path_buf();
-    let mut missing = Vec::new();
+    // Always resolve the final requested component through the retained
+    // ancestor fd. If another process creates it after our caller observed
+    // ENOENT, this avoids re-resolving the mutable path or following a link.
+    let mut ancestor = path
+        .parent()
+        .filter(|parent| !parent.as_os_str().is_empty())
+        .unwrap_or_else(|| Path::new("."))
+        .to_path_buf();
+    let mut missing = vec![path
+        .file_name()
+        .filter(|name| !name.is_empty())
+        .ok_or_else(|| {
+            std::io::Error::new(
+                std::io::ErrorKind::InvalidInput,
+                "registry parent has no creatable directory component",
+            )
+        })?
+        .to_os_string()];
     loop {
         match std::fs::symlink_metadata(&ancestor) {
             Ok(_) => break,
@@ -648,20 +699,7 @@ fn create_private_dir_all(path: &Path) -> std::io::Result<()> {
             }
         }
 
-        // SAFETY: the retained parent fd/name are valid. O_NOFOLLOW prevents a
-        // raced symlink from becoming the next creation anchor.
-        let fd = unsafe {
-            libc::openat(
-                current.as_raw_fd(),
-                name_c.as_ptr(),
-                libc::O_RDONLY | libc::O_DIRECTORY | libc::O_CLOEXEC | libc::O_NOFOLLOW,
-            )
-        };
-        if fd < 0 {
-            return Err(std::io::Error::last_os_error());
-        }
-        // SAFETY: fd was returned by openat and ownership transfers to File.
-        let next = unsafe { File::from_raw_fd(fd) };
+        let next = open_directory_after_create_race(&current, &name_c)?;
         validate_parent(&next)?;
         if created && stat_file(&next)?.st_mode & 0o7777 != 0o700 {
             return Err(registry_security_error(
@@ -670,7 +708,42 @@ fn create_private_dir_all(path: &Path) -> std::io::Result<()> {
         }
         current = next;
     }
-    Ok(())
+    Ok(current)
+}
+
+#[cfg(unix)]
+fn open_directory_after_create_race(parent: &File, name: &std::ffi::CStr) -> std::io::Result<File> {
+    use std::os::fd::{AsRawFd, FromRawFd};
+
+    let mut last_error = None;
+    for _ in 0..50 {
+        // SAFETY: the retained parent fd and NUL-terminated name are valid.
+        // O_NOFOLLOW prevents a raced symlink from becoming a creation anchor.
+        let fd = unsafe {
+            libc::openat(
+                parent.as_raw_fd(),
+                name.as_ptr(),
+                libc::O_RDONLY | libc::O_DIRECTORY | libc::O_CLOEXEC | libc::O_NOFOLLOW,
+            )
+        };
+        if fd >= 0 {
+            // SAFETY: fd was returned by openat and ownership transfers to File.
+            return Ok(unsafe { File::from_raw_fd(fd) });
+        }
+        let err = std::io::Error::last_os_error();
+        if matches!(
+            err.kind(),
+            std::io::ErrorKind::PermissionDenied | std::io::ErrorKind::NotFound
+        ) {
+            last_error = Some(err);
+            std::thread::sleep(std::time::Duration::from_millis(1));
+            continue;
+        }
+        return Err(err);
+    }
+    Err(last_error.unwrap_or_else(|| {
+        std::io::Error::other("registry directory create race did not converge")
+    }))
 }
 
 #[cfg(unix)]
@@ -1525,21 +1598,29 @@ mod tests {
 
     #[cfg(unix)]
     #[test]
-    fn genuine_zero_mode_lock_is_refused_without_implicit_repair() {
+    fn genuine_non_private_lock_modes_are_refused_without_implicit_repair() {
         use std::os::unix::fs::PermissionsExt;
 
-        let dir = tempfile::tempdir().unwrap();
-        let reg_path = dir.path().join("registry.toml");
-        let lock_path = reg_path.with_extension("lock");
-        std::fs::write(&reg_path, "repos = []\n").unwrap();
-        std::fs::write(&lock_path, b"").unwrap();
-        std::fs::set_permissions(&reg_path, std::fs::Permissions::from_mode(0o600)).unwrap();
-        std::fs::set_permissions(&lock_path, std::fs::Permissions::from_mode(0o000)).unwrap();
+        for unsafe_mode in [0o000, 0o200, 0o400, 0o644] {
+            let dir = tempfile::tempdir().unwrap();
+            let reg_path = dir.path().join("registry.toml");
+            let lock_path = reg_path.with_extension("lock");
+            std::fs::write(&reg_path, "repos = []\n").unwrap();
+            std::fs::write(&lock_path, b"").unwrap();
+            std::fs::set_permissions(&reg_path, std::fs::Permissions::from_mode(0o600)).unwrap();
+            std::fs::set_permissions(&lock_path, std::fs::Permissions::from_mode(unsafe_mode))
+                .unwrap();
 
-        let error = KinRegistry::load_from(&reg_path).unwrap_err();
-        assert!(error.to_string().contains("mode 0000"), "{error}");
-        assert_eq!(mode(&lock_path), 0o000);
-        assert_eq!(std::fs::read(&reg_path).unwrap(), b"repos = []\n");
+            let error = KinRegistry::load_from(&reg_path).unwrap_err();
+            assert!(
+                error
+                    .to_string()
+                    .contains(&format!("mode {unsafe_mode:04o}")),
+                "{error}"
+            );
+            assert_eq!(mode(&lock_path), unsafe_mode);
+            assert_eq!(std::fs::read(&reg_path).unwrap(), b"repos = []\n");
+        }
     }
 
     #[cfg(unix)]
@@ -1778,6 +1859,33 @@ mod tests {
                 let previous = unsafe { libc::umask(0o777) };
                 let fresh_path = work.join("new-parent/nested/registry.toml");
                 let initialized = initialize_registry_authority_at(&fresh_path).unwrap();
+
+                let concurrent_path =
+                    std::sync::Arc::new(work.join("concurrent-parent/nested/registry.toml"));
+                let concurrent_barrier = std::sync::Arc::new(std::sync::Barrier::new(8));
+                let mut concurrent_handles = Vec::new();
+                for index in 0..8 {
+                    let path = std::sync::Arc::clone(&concurrent_path);
+                    let barrier = std::sync::Arc::clone(&concurrent_barrier);
+                    let repo_path = work.clone();
+                    concurrent_handles.push(std::thread::spawn(move || {
+                        barrier.wait();
+                        KinRegistry::update_at(&path, |registry| {
+                            registry.repos.push(RegisteredRepo {
+                                id: format!("concurrent-parent-{index}"),
+                                path: repo_path,
+                                entities: index,
+                                last_commit: "2026-07-13T00:00:00Z".to_string(),
+                                dependencies: Vec::new(),
+                            });
+                        })
+                        .unwrap();
+                    }));
+                }
+                for handle in concurrent_handles {
+                    handle.join().unwrap();
+                }
+
                 let mut handles = Vec::new();
                 for index in 0..8 {
                     let repo_path = work.clone();
@@ -1804,6 +1912,17 @@ mod tests {
                 assert_eq!(mode(&work.join("new-parent/nested")), 0o700);
                 assert_eq!(mode(&fresh_path), 0o600);
                 assert_eq!(mode(&fresh_path.with_extension("lock")), 0o600);
+                assert_eq!(mode(&work.join("concurrent-parent")), 0o700);
+                assert_eq!(mode(&work.join("concurrent-parent/nested")), 0o700);
+                assert_eq!(mode(&*concurrent_path), 0o600);
+                assert_eq!(mode(&concurrent_path.with_extension("lock")), 0o600);
+                assert_eq!(
+                    KinRegistry::load_from(&concurrent_path)
+                        .unwrap()
+                        .repos
+                        .len(),
+                    8
+                );
                 assert_eq!(mode(Path::new("registry.toml")), 0o600);
                 assert_eq!(mode(Path::new("registry.lock")), 0o600);
                 assert_eq!(

--- a/crates/kin-core/src/registry.rs
+++ b/crates/kin-core/src/registry.rs
@@ -1914,7 +1914,7 @@ mod tests {
                 assert_eq!(mode(&fresh_path.with_extension("lock")), 0o600);
                 assert_eq!(mode(&work.join("concurrent-parent")), 0o700);
                 assert_eq!(mode(&work.join("concurrent-parent/nested")), 0o700);
-                assert_eq!(mode(&*concurrent_path), 0o600);
+                assert_eq!(mode(&concurrent_path), 0o600);
                 assert_eq!(mode(&concurrent_path.with_extension("lock")), 0o600);
                 assert_eq!(
                     KinRegistry::load_from(&concurrent_path)

--- a/crates/kin-core/src/registry.rs
+++ b/crates/kin-core/src/registry.rs
@@ -9,9 +9,11 @@
 use fs2::FileExt;
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
-use std::fs::{File, OpenOptions};
+use std::fs::File;
+#[cfg(not(unix))]
+use std::fs::OpenOptions;
 #[cfg(unix)]
-use std::io::Write;
+use std::io::{Read, Write};
 use std::path::{Path, PathBuf};
 
 #[derive(Debug, Serialize, Deserialize, Default)]
@@ -41,15 +43,21 @@ impl KinRegistry {
     ///
     /// Acquires a shared (read) lock on the corresponding `.lock` file.
     pub fn load_from(path: &Path) -> Result<Self, Box<dyn std::error::Error>> {
-        if !path.exists() {
-            return Ok(Self::default());
+        #[cfg(unix)]
+        {
+            return load_from_unix(path);
         }
-        let lock_path = path.with_extension("lock");
-        let lock_file = open_private_lock_file(&lock_path)?;
-        lock_file.lock_shared()?;
-        let content = std::fs::read_to_string(path)?;
-        // Lock released on drop
-        Ok(toml::from_str(&content)?)
+        #[cfg(not(unix))]
+        {
+            if !path.exists() {
+                return Ok(Self::default());
+            }
+            let lock_path = path.with_extension("lock");
+            let lock_file = open_private_lock_file(&lock_path)?;
+            lock_file.lock_shared()?;
+            let content = std::fs::read_to_string(path)?;
+            Ok(toml::from_str(&content)?)
+        }
     }
 
     /// Save to `~/.kin/registry.toml`.
@@ -64,19 +72,66 @@ impl KinRegistry {
     /// Acquires an exclusive lock, writes atomically (tmp → rename)
     /// so concurrent readers never see a partial file.
     pub fn save_to(&self, path: &Path) -> Result<(), Box<dyn std::error::Error>> {
-        if let Some(parent) = path.parent() {
-            std::fs::create_dir_all(parent)?;
+        #[cfg(unix)]
+        {
+            return save_to_unix(self, path);
         }
-        let lock_path = path.with_extension("lock");
-        let lock_file = open_private_lock_file(&lock_path)?;
-        lock_file.lock_exclusive()?;
+        #[cfg(not(unix))]
+        {
+            if let Some(parent) = path
+                .parent()
+                .filter(|parent| !parent.as_os_str().is_empty())
+            {
+                std::fs::create_dir_all(parent)?;
+            }
+            let lock_path = path.with_extension("lock");
+            let lock_file = open_private_lock_file(&lock_path)?;
+            lock_file.lock_exclusive()?;
+            let contents = toml::to_string_pretty(self)?;
+            write_registry_atomically(path, contents.as_bytes())?;
+            Ok(())
+        }
+    }
 
-        // Atomic write: write to tmp, then rename into place.
-        let contents = toml::to_string_pretty(self)?;
-        write_registry_atomically(path, contents.as_bytes())?;
+    /// Update `~/.kin/registry.toml` under one exclusive read-modify-write lock.
+    ///
+    /// Registry writers must use this API instead of a separate `load` followed
+    /// by `save`; keeping the lock across the caller's mutation prevents one
+    /// concurrent writer from silently replacing another writer's update.
+    pub fn update<T>(mutate: impl FnOnce(&mut Self) -> T) -> Result<T, Box<dyn std::error::Error>> {
+        Self::update_at(&registry_path(), mutate)
+    }
 
-        // Lock released on drop
-        Ok(())
+    /// Update a specific registry path under one exclusive read-modify-write lock.
+    pub fn update_at<T>(
+        path: &Path,
+        mutate: impl FnOnce(&mut Self) -> T,
+    ) -> Result<T, Box<dyn std::error::Error>> {
+        #[cfg(unix)]
+        {
+            return update_at_unix(path, mutate);
+        }
+        #[cfg(not(unix))]
+        {
+            if let Some(parent) = path
+                .parent()
+                .filter(|parent| !parent.as_os_str().is_empty())
+            {
+                std::fs::create_dir_all(parent)?;
+            }
+            let lock_path = path.with_extension("lock");
+            let lock_file = open_private_lock_file(&lock_path)?;
+            lock_file.lock_exclusive()?;
+            let mut registry = if path.exists() {
+                toml::from_str(&std::fs::read_to_string(path)?)?
+            } else {
+                Self::default()
+            };
+            let result = mutate(&mut registry);
+            let contents = toml::to_string_pretty(&registry)?;
+            write_registry_atomically(path, contents.as_bytes())?;
+            Ok(result)
+        }
     }
 
     /// Register or update a repo entry.
@@ -189,81 +244,563 @@ impl KinRegistry {
     }
 }
 
-fn open_private_lock_file(path: &Path) -> Result<File, Box<dyn std::error::Error>> {
-    let mut options = OpenOptions::new();
-    options.create(true).write(true).truncate(false);
-    #[cfg(unix)]
-    {
-        use std::os::unix::fs::OpenOptionsExt;
-        options.mode(0o600);
+#[cfg(unix)]
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+struct FileIdentity {
+    device: u64,
+    inode: u64,
+}
+
+#[cfg(unix)]
+struct RegistryAnchor {
+    parent: File,
+    registry_name: std::ffi::OsString,
+    lock_name: std::ffi::OsString,
+    legacy_tmp_name: std::ffi::OsString,
+}
+
+#[cfg(unix)]
+impl RegistryAnchor {
+    fn open(path: &Path) -> std::io::Result<Self> {
+        use std::os::fd::FromRawFd;
+        use std::os::unix::ffi::OsStrExt;
+
+        let parent_path = normalized_parent(path);
+        let registry_name = path
+            .file_name()
+            .filter(|name| !name.is_empty())
+            .ok_or_else(|| {
+                std::io::Error::new(
+                    std::io::ErrorKind::InvalidInput,
+                    "registry path has no filename",
+                )
+            })?
+            .to_os_string();
+        let lock_name = path
+            .with_extension("lock")
+            .file_name()
+            .ok_or_else(|| {
+                std::io::Error::new(
+                    std::io::ErrorKind::InvalidInput,
+                    "registry lock path has no filename",
+                )
+            })?
+            .to_os_string();
+        let legacy_tmp_name = path
+            .with_extension("tmp")
+            .file_name()
+            .ok_or_else(|| {
+                std::io::Error::new(
+                    std::io::ErrorKind::InvalidInput,
+                    "legacy registry temp path has no filename",
+                )
+            })?
+            .to_os_string();
+
+        let parent_c =
+            std::ffi::CString::new(parent_path.as_os_str().as_bytes()).map_err(|_| {
+                std::io::Error::new(
+                    std::io::ErrorKind::InvalidInput,
+                    "registry parent path contains a NUL byte",
+                )
+            })?;
+        // SAFETY: `parent_c` is NUL-terminated and remains alive for the call.
+        let fd = unsafe {
+            libc::open(
+                parent_c.as_ptr(),
+                libc::O_RDONLY | libc::O_DIRECTORY | libc::O_CLOEXEC | libc::O_NOFOLLOW,
+            )
+        };
+        if fd < 0 {
+            return Err(std::io::Error::last_os_error());
+        }
+        // SAFETY: `fd` was returned by `open` and ownership transfers to `File`.
+        let parent = unsafe { File::from_raw_fd(fd) };
+        validate_parent(&parent)?;
+
+        Ok(Self {
+            parent,
+            registry_name,
+            lock_name,
+            legacy_tmp_name,
+        })
     }
-    let file = options.open(path)?;
-    #[cfg(unix)]
-    tighten_private_permissions(&file)?;
+}
+
+#[cfg(unix)]
+fn normalized_parent(path: &Path) -> PathBuf {
+    path.parent()
+        .filter(|parent| !parent.as_os_str().is_empty())
+        .unwrap_or_else(|| Path::new("."))
+        .to_path_buf()
+}
+
+#[cfg(unix)]
+fn prepare_anchor(path: &Path) -> Result<RegistryAnchor, Box<dyn std::error::Error>> {
+    let parent = normalized_parent(path);
+    std::fs::create_dir_all(&parent)?;
+    Ok(RegistryAnchor::open(path)?)
+}
+
+#[cfg(unix)]
+fn load_from_unix(path: &Path) -> Result<KinRegistry, Box<dyn std::error::Error>> {
+    let anchor = match RegistryAnchor::open(path) {
+        Ok(anchor) => anchor,
+        Err(err) if err.kind() == std::io::ErrorKind::NotFound => {
+            return Ok(KinRegistry::default());
+        }
+        Err(err) => return Err(Box::new(err)),
+    };
+    let lock_file = open_private_lock_at(&anchor)?;
+    lock_file.lock_shared()?;
+    verify_named_file(&anchor, &anchor.lock_name, &lock_file, "registry lock")?;
+    tighten_legacy_tmp_at(&anchor)?;
+    read_registry_at(&anchor)
+}
+
+#[cfg(unix)]
+fn save_to_unix(registry: &KinRegistry, path: &Path) -> Result<(), Box<dyn std::error::Error>> {
+    let contents = toml::to_string_pretty(registry)?;
+    let anchor = prepare_anchor(path)?;
+    let lock_file = open_private_lock_at(&anchor)?;
+    lock_file.lock_exclusive()?;
+    verify_named_file(&anchor, &anchor.lock_name, &lock_file, "registry lock")?;
+    save_registry_at(&anchor, contents.as_bytes())
+}
+
+#[cfg(unix)]
+fn update_at_unix<T>(
+    path: &Path,
+    mutate: impl FnOnce(&mut KinRegistry) -> T,
+) -> Result<T, Box<dyn std::error::Error>> {
+    let anchor = prepare_anchor(path)?;
+    let lock_file = open_private_lock_at(&anchor).map_err(|err| {
+        std::io::Error::new(err.kind(), format!("failed to open registry lock: {err}"))
+    })?;
+    lock_file.lock_exclusive().map_err(|err| {
+        std::io::Error::new(
+            err.kind(),
+            format!("failed to acquire registry lock: {err}"),
+        )
+    })?;
+    verify_named_file(&anchor, &anchor.lock_name, &lock_file, "registry lock").map_err(|err| {
+        std::io::Error::new(
+            err.kind(),
+            format!("failed to revalidate locked registry lock: {err}"),
+        )
+    })?;
+    tighten_legacy_tmp_at(&anchor).map_err(|err| {
+        std::io::Error::new(
+            err.kind(),
+            format!("failed to validate legacy registry temp: {err}"),
+        )
+    })?;
+    let mut registry = read_registry_at(&anchor)
+        .map_err(|err| std::io::Error::other(format!("failed to read locked registry: {err}")))?;
+    let result = mutate(&mut registry);
+    let contents = toml::to_string_pretty(&registry)?;
+    save_registry_at(&anchor, contents.as_bytes())
+        .map_err(|err| std::io::Error::other(format!("failed to save locked registry: {err}")))?;
+    Ok(result)
+}
+
+#[cfg(unix)]
+fn read_registry_at(anchor: &RegistryAnchor) -> Result<KinRegistry, Box<dyn std::error::Error>> {
+    let Some(mut file) =
+        open_existing_regular_at(anchor, &anchor.registry_name, "registry file", true)?
+    else {
+        return Ok(KinRegistry::default());
+    };
+    let identity = validate_regular_file(&file, "registry file")?;
+    let mut content = String::new();
+    file.read_to_string(&mut content)?;
+    verify_named_identity(anchor, &anchor.registry_name, identity, "registry file")?;
+    Ok(toml::from_str(&content)?)
+}
+
+#[cfg(unix)]
+fn save_registry_at(
+    anchor: &RegistryAnchor,
+    contents: &[u8],
+) -> Result<(), Box<dyn std::error::Error>> {
+    tighten_legacy_tmp_at(anchor)?;
+    let _ = open_existing_regular_at(anchor, &anchor.registry_name, "registry file", true)?;
+    write_registry_atomically_at(anchor, contents)
+}
+
+#[cfg(unix)]
+fn open_private_lock_at(anchor: &RegistryAnchor) -> std::io::Result<File> {
+    let file = match open_at(
+        anchor,
+        &anchor.lock_name,
+        libc::O_RDWR | libc::O_CREAT | libc::O_EXCL,
+        0o600,
+    ) {
+        Ok(file) => Ok(file),
+        Err(err) if err.kind() == std::io::ErrorKind::AlreadyExists => {
+            open_lock_after_create_race(anchor)
+        }
+        Err(err) => Err(err),
+    }
+    .map_err(|err| {
+        std::io::Error::new(
+            err.kind(),
+            format!("openat registry lock {:?} failed: {err}", anchor.lock_name),
+        )
+    })?;
+    validate_regular_file(&file, "registry lock").map_err(|err| {
+        std::io::Error::new(err.kind(), format!("registry lock fd invalid: {err}"))
+    })?;
+    set_private_mode(&file).map_err(|err| {
+        std::io::Error::new(err.kind(), format!("registry lock fchmod failed: {err}"))
+    })?;
+    verify_named_file(anchor, &anchor.lock_name, &file, "registry lock").map_err(|err| {
+        std::io::Error::new(err.kind(), format!("registry lock pathname invalid: {err}"))
+    })?;
     Ok(file)
 }
 
 #[cfg(unix)]
-fn tighten_private_permissions(file: &File) -> Result<(), Box<dyn std::error::Error>> {
-    use std::os::unix::fs::PermissionsExt;
+fn open_lock_after_create_race(anchor: &RegistryAnchor) -> std::io::Result<File> {
+    let mut last_error = None;
+    for _ in 0..50 {
+        match open_at(anchor, &anchor.lock_name, libc::O_RDWR, 0) {
+            Ok(file) => return Ok(file),
+            Err(err)
+                if matches!(
+                    err.kind(),
+                    std::io::ErrorKind::PermissionDenied | std::io::ErrorKind::NotFound
+                ) =>
+            {
+                last_error = Some(err);
+                std::thread::sleep(std::time::Duration::from_millis(1));
+            }
+            Err(err) => return Err(err),
+        }
+    }
+    Err(last_error
+        .unwrap_or_else(|| std::io::Error::other("registry lock create race did not converge")))
+}
 
-    let mut permissions = file.metadata()?.permissions();
-    if permissions.mode() & 0o777 != 0o600 {
-        permissions.set_mode(0o600);
-        file.set_permissions(permissions)?;
+#[cfg(unix)]
+fn open_existing_regular_at(
+    anchor: &RegistryAnchor,
+    name: &std::ffi::OsStr,
+    label: &str,
+    tighten: bool,
+) -> std::io::Result<Option<File>> {
+    let file = match open_at(anchor, name, libc::O_RDONLY, 0) {
+        Ok(file) => file,
+        Err(err) if err.kind() == std::io::ErrorKind::NotFound => return Ok(None),
+        Err(err) => return Err(err),
+    };
+    validate_regular_file(&file, label)?;
+    if tighten {
+        set_private_mode(&file)?;
+    }
+    verify_named_file(anchor, name, &file, label)?;
+    Ok(Some(file))
+}
+
+#[cfg(unix)]
+fn tighten_legacy_tmp_at(anchor: &RegistryAnchor) -> std::io::Result<()> {
+    let _ = open_existing_regular_at(
+        anchor,
+        &anchor.legacy_tmp_name,
+        "legacy registry temp file",
+        true,
+    )?;
+    Ok(())
+}
+
+#[cfg(unix)]
+fn open_at(
+    anchor: &RegistryAnchor,
+    name: &std::ffi::OsStr,
+    flags: libc::c_int,
+    mode: libc::mode_t,
+) -> std::io::Result<File> {
+    use std::os::fd::{AsRawFd, FromRawFd};
+
+    let name_c = name_cstring(name)?;
+    // SAFETY: both descriptors/strings are valid for the duration of the call.
+    let fd = unsafe {
+        libc::openat(
+            anchor.parent.as_raw_fd(),
+            name_c.as_ptr(),
+            flags | libc::O_CLOEXEC | libc::O_NOFOLLOW,
+            libc::c_uint::from(mode),
+        )
+    };
+    if fd < 0 {
+        return Err(std::io::Error::last_os_error());
+    }
+    // SAFETY: `fd` was returned by `openat` and ownership transfers to `File`.
+    Ok(unsafe { File::from_raw_fd(fd) })
+}
+
+#[cfg(unix)]
+fn name_cstring(name: &std::ffi::OsStr) -> std::io::Result<std::ffi::CString> {
+    use std::os::unix::ffi::OsStrExt;
+
+    std::ffi::CString::new(name.as_bytes()).map_err(|_| {
+        std::io::Error::new(
+            std::io::ErrorKind::InvalidInput,
+            "registry filename contains a NUL byte",
+        )
+    })
+}
+
+#[cfg(unix)]
+fn validate_parent(parent: &File) -> std::io::Result<()> {
+    let stat = stat_file(parent)?;
+    if (stat.st_mode & libc::S_IFMT) != libc::S_IFDIR {
+        return Err(registry_security_error(
+            "registry parent must be a directory",
+        ));
+    }
+    // SAFETY: `geteuid` has no preconditions.
+    if stat.st_uid != unsafe { libc::geteuid() } {
+        return Err(registry_security_error(
+            "registry parent must be owned by the current user",
+        ));
     }
     Ok(())
 }
 
+#[cfg(unix)]
+fn validate_regular_file(file: &File, label: &str) -> std::io::Result<FileIdentity> {
+    validate_regular_stat(&stat_file(file)?, label)
+}
+
+#[cfg(unix)]
+fn validate_regular_stat(stat: &libc::stat, label: &str) -> std::io::Result<FileIdentity> {
+    if (stat.st_mode & libc::S_IFMT) != libc::S_IFREG {
+        return Err(registry_security_error(format!(
+            "{label} must be a regular file"
+        )));
+    }
+    // SAFETY: `geteuid` has no preconditions.
+    if stat.st_uid != unsafe { libc::geteuid() } {
+        return Err(registry_security_error(format!(
+            "{label} must be owned by the current user"
+        )));
+    }
+    if stat.st_nlink != 1 {
+        return Err(registry_security_error(format!(
+            "{label} must have exactly one hard link (found {})",
+            stat.st_nlink
+        )));
+    }
+    Ok(FileIdentity {
+        device: stat.st_dev as u64,
+        inode: stat.st_ino as u64,
+    })
+}
+
+#[cfg(unix)]
+fn stat_file(file: &File) -> std::io::Result<libc::stat> {
+    use std::os::fd::AsRawFd;
+
+    let mut stat = std::mem::MaybeUninit::<libc::stat>::uninit();
+    // SAFETY: `stat` points to writable storage and the file descriptor is valid.
+    if unsafe { libc::fstat(file.as_raw_fd(), stat.as_mut_ptr()) } != 0 {
+        return Err(std::io::Error::last_os_error());
+    }
+    // SAFETY: successful `fstat` initialized the entire structure.
+    Ok(unsafe { stat.assume_init() })
+}
+
+#[cfg(unix)]
+fn stat_at(anchor: &RegistryAnchor, name: &std::ffi::OsStr) -> std::io::Result<libc::stat> {
+    use std::os::fd::AsRawFd;
+
+    let name_c = name_cstring(name)?;
+    let mut stat = std::mem::MaybeUninit::<libc::stat>::uninit();
+    // SAFETY: the dirfd/name are valid and `stat` points to writable storage.
+    if unsafe {
+        libc::fstatat(
+            anchor.parent.as_raw_fd(),
+            name_c.as_ptr(),
+            stat.as_mut_ptr(),
+            libc::AT_SYMLINK_NOFOLLOW,
+        )
+    } != 0
+    {
+        return Err(std::io::Error::last_os_error());
+    }
+    // SAFETY: successful `fstatat` initialized the entire structure.
+    Ok(unsafe { stat.assume_init() })
+}
+
+#[cfg(unix)]
+fn set_private_mode(file: &File) -> std::io::Result<()> {
+    use std::os::fd::AsRawFd;
+
+    // Call `fchmod` unconditionally: newly-created files must end at exactly
+    // 0600 even when the process umask removed every requested mode bit.
+    // SAFETY: the file descriptor is valid and the mode has no invalid bits.
+    if unsafe { libc::fchmod(file.as_raw_fd(), 0o600) } != 0 {
+        return Err(std::io::Error::last_os_error());
+    }
+    let stat = stat_file(file)?;
+    if stat.st_mode & 0o777 != 0o600 {
+        return Err(registry_security_error(
+            "registry authority file did not reach mode 0600",
+        ));
+    }
+    Ok(())
+}
+
+#[cfg(unix)]
+fn verify_named_file(
+    anchor: &RegistryAnchor,
+    name: &std::ffi::OsStr,
+    file: &File,
+    label: &str,
+) -> std::io::Result<()> {
+    let identity = validate_regular_file(file, label)?;
+    verify_named_identity(anchor, name, identity, label)
+}
+
+#[cfg(unix)]
+fn verify_named_identity(
+    anchor: &RegistryAnchor,
+    name: &std::ffi::OsStr,
+    expected: FileIdentity,
+    label: &str,
+) -> std::io::Result<()> {
+    let actual = validate_regular_stat(&stat_at(anchor, name)?, label)?;
+    if actual != expected {
+        return Err(registry_security_error(format!(
+            "{label} changed identity during the registry operation"
+        )));
+    }
+    Ok(())
+}
+
+#[cfg(unix)]
+fn write_registry_atomically_at(
+    anchor: &RegistryAnchor,
+    contents: &[u8],
+) -> Result<(), Box<dyn std::error::Error>> {
+    use std::os::fd::AsRawFd;
+
+    let mut tmp_name = std::ffi::OsString::from(".");
+    tmp_name.push(&anchor.registry_name);
+    tmp_name.push(format!(".tmp-{}", uuid::Uuid::new_v4()));
+
+    let mut created_identity = None;
+    let result = (|| -> Result<(), Box<dyn std::error::Error>> {
+        let mut file = open_at(
+            anchor,
+            &tmp_name,
+            libc::O_WRONLY | libc::O_CREAT | libc::O_EXCL,
+            0o600,
+        )?;
+        set_private_mode(&file)?;
+        let identity = validate_regular_file(&file, "registry transaction temp file")?;
+        created_identity = Some(identity);
+        verify_named_identity(
+            anchor,
+            &tmp_name,
+            identity,
+            "registry transaction temp file",
+        )?;
+        file.write_all(contents)?;
+        file.sync_all()?;
+
+        #[cfg(test)]
+        if std::env::var_os("REGISTRY_TEST_FAIL_AFTER_TEMP_SYNC").is_some() {
+            return Err(Box::new(std::io::Error::other(
+                "injected registry failure after temp sync",
+            )));
+        }
+
+        verify_named_identity(
+            anchor,
+            &tmp_name,
+            identity,
+            "registry transaction temp file",
+        )?;
+        let tmp_c = name_cstring(&tmp_name)?;
+        let registry_c = name_cstring(&anchor.registry_name)?;
+        // SAFETY: both names are relative to the retained valid directory fd.
+        if unsafe {
+            libc::renameat(
+                anchor.parent.as_raw_fd(),
+                tmp_c.as_ptr(),
+                anchor.parent.as_raw_fd(),
+                registry_c.as_ptr(),
+            )
+        } != 0
+        {
+            return Err(Box::new(std::io::Error::last_os_error()));
+        }
+        verify_named_identity(anchor, &anchor.registry_name, identity, "registry file")?;
+        anchor.parent.sync_all()?;
+        Ok(())
+    })();
+
+    if let Some(identity) = created_identity {
+        if result.is_err() {
+            let _ = cleanup_temp_if_same(anchor, &tmp_name, identity);
+        }
+    }
+    result
+}
+
+#[cfg(unix)]
+fn cleanup_temp_if_same(
+    anchor: &RegistryAnchor,
+    name: &std::ffi::OsStr,
+    expected: FileIdentity,
+) -> std::io::Result<()> {
+    use std::os::fd::AsRawFd;
+
+    let stat = match stat_at(anchor, name) {
+        Ok(stat) => stat,
+        Err(err) if err.kind() == std::io::ErrorKind::NotFound => return Ok(()),
+        Err(err) => return Err(err),
+    };
+    let actual = match validate_regular_stat(&stat, "registry transaction temp file") {
+        Ok(identity) => identity,
+        Err(_) => return Ok(()),
+    };
+    if actual != expected {
+        return Ok(());
+    }
+    let name_c = name_cstring(name)?;
+    // SAFETY: the retained dirfd and relative name are valid; identity was
+    // revalidated immediately before unlinking.
+    if unsafe { libc::unlinkat(anchor.parent.as_raw_fd(), name_c.as_ptr(), 0) } != 0 {
+        return Err(std::io::Error::last_os_error());
+    }
+    Ok(())
+}
+
+#[cfg(unix)]
+fn registry_security_error(message: impl Into<String>) -> std::io::Error {
+    std::io::Error::new(std::io::ErrorKind::PermissionDenied, message.into())
+}
+
+#[cfg(not(unix))]
+fn open_private_lock_file(path: &Path) -> Result<File, Box<dyn std::error::Error>> {
+    let mut options = OpenOptions::new();
+    options.create(true).write(true).truncate(false);
+    let file = options.open(path)?;
+    Ok(file)
+}
+
+#[cfg(not(unix))]
 fn write_registry_atomically(
     path: &Path,
     contents: &[u8],
 ) -> Result<(), Box<dyn std::error::Error>> {
-    #[cfg(unix)]
-    {
-        use std::os::unix::fs::OpenOptionsExt;
-
-        let parent = path.parent().ok_or_else(|| {
-            std::io::Error::new(
-                std::io::ErrorKind::InvalidInput,
-                "registry path has no parent directory",
-            )
-        })?;
-        let file_name = path.file_name().ok_or_else(|| {
-            std::io::Error::new(
-                std::io::ErrorKind::InvalidInput,
-                "registry path has no filename",
-            )
-        })?;
-        let mut tmp_name = std::ffi::OsString::from(".");
-        tmp_name.push(file_name);
-        tmp_name.push(format!(".tmp-{}", uuid::Uuid::new_v4()));
-        let tmp = parent.join(tmp_name);
-        let result = (|| -> Result<(), Box<dyn std::error::Error>> {
-            let mut file = OpenOptions::new()
-                .create_new(true)
-                .write(true)
-                .mode(0o600)
-                .open(&tmp)?;
-            file.write_all(contents)?;
-            file.sync_all()?;
-            drop(file);
-            std::fs::rename(&tmp, path)?;
-            File::open(parent)?.sync_all()?;
-            Ok(())
-        })();
-        if result.is_err() {
-            let _ = std::fs::remove_file(&tmp);
-        }
-        result
-    }
-    #[cfg(not(unix))]
-    {
-        let tmp = path.with_extension("tmp");
-        std::fs::write(&tmp, contents)?;
-        std::fs::rename(&tmp, path)?;
-        Ok(())
-    }
+    let tmp = path.with_extension("tmp");
+    std::fs::write(&tmp, contents)?;
+    std::fs::rename(&tmp, path)?;
+    Ok(())
 }
 
 /// `~/.kin/registry.toml` path (cross-platform).
@@ -347,11 +884,331 @@ mod tests {
         let lock_path = reg_path.with_extension("lock");
         std::fs::write(&reg_path, "repos = []\n").unwrap();
         std::fs::write(&lock_path, b"").unwrap();
+        std::fs::set_permissions(&reg_path, std::fs::Permissions::from_mode(0o644)).unwrap();
         std::fs::set_permissions(&lock_path, std::fs::Permissions::from_mode(0o644)).unwrap();
 
         KinRegistry::load_from(&reg_path).unwrap();
 
+        assert_eq!(mode(&reg_path), 0o600);
         assert_eq!(mode(&lock_path), 0o600);
+    }
+
+    #[test]
+    fn locked_updates_preserve_concurrent_writers() {
+        use std::sync::{Arc, Barrier};
+
+        const WRITERS: usize = 24;
+        let dir = Arc::new(tempfile::tempdir().unwrap());
+        let reg_path = Arc::new(dir.path().join("registry.toml"));
+        let barrier = Arc::new(Barrier::new(WRITERS));
+        let mut handles = Vec::new();
+
+        for index in 0..WRITERS {
+            let path = Arc::clone(&reg_path);
+            let barrier = Arc::clone(&barrier);
+            let dir_guard = Arc::clone(&dir);
+            handles.push(std::thread::spawn(move || {
+                let _dir_guard = dir_guard;
+                barrier.wait();
+                KinRegistry::update_at(&path, |registry| {
+                    registry.repos.push(RegisteredRepo {
+                        id: format!("repo-{index}"),
+                        path: PathBuf::from(format!("/repo-{index}")),
+                        entities: index,
+                        last_commit: "2026-07-13T00:00:00Z".to_string(),
+                        dependencies: Vec::new(),
+                    });
+                })
+                .map_err(|err| err.to_string())
+            }));
+        }
+        let errors: Vec<_> = handles
+            .into_iter()
+            .filter_map(|handle| handle.join().unwrap().err())
+            .collect();
+        let entries: Vec<_> = std::fs::read_dir(dir.path())
+            .unwrap()
+            .map(|entry| entry.unwrap().file_name())
+            .collect();
+        assert!(
+            errors.is_empty(),
+            "errors: {errors:?}; entries: {entries:?}"
+        );
+
+        let loaded = KinRegistry::load_from(&reg_path).unwrap();
+        let ids: std::collections::HashSet<_> =
+            loaded.repos.iter().map(|repo| repo.id.as_str()).collect();
+        assert_eq!(loaded.repos.len(), WRITERS);
+        assert_eq!(ids.len(), WRITERS);
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn identity_safe_cleanup_does_not_unlink_a_replacement() {
+        let dir = tempfile::tempdir().unwrap();
+        let reg_path = dir.path().join("registry.toml");
+        let anchor = prepare_anchor(&reg_path).unwrap();
+        let tmp_name = std::ffi::OsStr::new("candidate.tmp");
+        let original = open_at(
+            &anchor,
+            tmp_name,
+            libc::O_WRONLY | libc::O_CREAT | libc::O_EXCL,
+            0o600,
+        )
+        .unwrap();
+        set_private_mode(&original).unwrap();
+        let original_identity =
+            validate_regular_file(&original, "registry transaction temp file").unwrap();
+        drop(original);
+
+        std::fs::rename(
+            dir.path().join("candidate.tmp"),
+            dir.path().join("original.tmp"),
+        )
+        .unwrap();
+        std::fs::write(dir.path().join("candidate.tmp"), b"replacement").unwrap();
+
+        cleanup_temp_if_same(&anchor, tmp_name, original_identity).unwrap();
+        assert_eq!(
+            std::fs::read(dir.path().join("candidate.tmp")).unwrap(),
+            b"replacement"
+        );
+    }
+
+    #[cfg(unix)]
+    fn run_registry_security_subprocess(case: &str) {
+        let root = tempfile::tempdir().unwrap();
+        let home = root.path().join("home");
+        let kin_home = root.path().join("kin-home");
+        let tmp = root.path().join("tmp");
+        let work = root.path().join("work");
+        for directory in [&home, &kin_home, &tmp, &work] {
+            std::fs::create_dir_all(directory).unwrap();
+        }
+        let output = std::process::Command::new(std::env::current_exe().unwrap())
+            .arg("registry_security_subprocess")
+            .arg("--nocapture")
+            .arg("--test-threads=1")
+            .env("REGISTRY_SECURITY_TEST_CASE", case)
+            .env("REGISTRY_SECURITY_TEST_ROOT", root.path())
+            .env("HOME", &home)
+            .env("KIN_HOME", &kin_home)
+            .env("KIN_REGISTRY_PATH", kin_home.join("registry.toml"))
+            .env("TMPDIR", &tmp)
+            .output()
+            .unwrap();
+        assert!(
+            output.status.success(),
+            "registry security subprocess {case} failed\nstdout:\n{}\nstderr:\n{}",
+            String::from_utf8_lossy(&output.stdout),
+            String::from_utf8_lossy(&output.stderr)
+        );
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn restrictive_umask_and_relative_path_are_isolated() {
+        run_registry_security_subprocess("restrictive-umask-relative");
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn symlink_victims_are_isolated() {
+        run_registry_security_subprocess("symlink-victims");
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn first_load_and_legacy_temp_migrations_are_isolated() {
+        run_registry_security_subprocess("legacy-migrations");
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn failure_cleanup_is_isolated() {
+        run_registry_security_subprocess("failure-cleanup");
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn authority_identity_checks_are_isolated() {
+        run_registry_security_subprocess("identity-checks");
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn registry_security_subprocess() {
+        use std::os::unix::fs::{symlink, PermissionsExt};
+
+        let Some(case) = std::env::var_os("REGISTRY_SECURITY_TEST_CASE") else {
+            return;
+        };
+        let root = PathBuf::from(std::env::var_os("REGISTRY_SECURITY_TEST_ROOT").unwrap());
+        let work = root.join("work");
+        let registry_path = work.join("registry.toml");
+        let lock_path = work.join("registry.lock");
+        let legacy_tmp_path = work.join("registry.tmp");
+
+        match case.to_str().unwrap() {
+            "restrictive-umask-relative" => {
+                std::env::set_current_dir(&work).unwrap();
+                // SAFETY: this isolated subprocess sets the umask before spawning
+                // workers and restores it after every worker has joined.
+                let previous = unsafe { libc::umask(0o777) };
+                let mut handles = Vec::new();
+                for index in 0..8 {
+                    let repo_path = work.clone();
+                    handles.push(std::thread::spawn(move || {
+                        KinRegistry::update_at(Path::new("registry.toml"), |registry| {
+                            registry.repos.push(RegisteredRepo {
+                                id: format!("relative-{index}"),
+                                path: repo_path,
+                                entities: index,
+                                last_commit: "2026-07-13T00:00:00Z".to_string(),
+                                dependencies: Vec::new(),
+                            });
+                        })
+                        .unwrap();
+                    }));
+                }
+                for handle in handles {
+                    handle.join().unwrap();
+                }
+                // SAFETY: restore the process umask before any assertion can panic.
+                unsafe { libc::umask(previous) };
+                assert_eq!(mode(Path::new("registry.toml")), 0o600);
+                assert_eq!(mode(Path::new("registry.lock")), 0o600);
+                assert_eq!(
+                    KinRegistry::load_from(Path::new("registry.toml"))
+                        .unwrap()
+                        .repos
+                        .len(),
+                    8
+                );
+            }
+            "symlink-victims" => {
+                let victim = work.join("victim");
+                std::fs::write(&victim, b"do not touch").unwrap();
+                std::fs::set_permissions(&victim, std::fs::Permissions::from_mode(0o640)).unwrap();
+                let victim_mode = mode(&victim);
+
+                symlink(&victim, &registry_path).unwrap();
+                assert!(KinRegistry::load_from(&registry_path).is_err());
+                assert!(KinRegistry::default().save_to(&registry_path).is_err());
+                assert_eq!(std::fs::read(&victim).unwrap(), b"do not touch");
+                assert_eq!(mode(&victim), victim_mode);
+                std::fs::remove_file(&registry_path).unwrap();
+                std::fs::remove_file(&lock_path).unwrap();
+
+                std::fs::write(&registry_path, "repos = []\n").unwrap();
+                std::fs::set_permissions(&registry_path, std::fs::Permissions::from_mode(0o600))
+                    .unwrap();
+                symlink(&victim, &lock_path).unwrap();
+                assert!(KinRegistry::load_from(&registry_path).is_err());
+                assert!(KinRegistry::default().save_to(&registry_path).is_err());
+                assert_eq!(std::fs::read(&victim).unwrap(), b"do not touch");
+                assert_eq!(mode(&victim), victim_mode);
+                std::fs::remove_file(&lock_path).unwrap();
+
+                symlink(&victim, &legacy_tmp_path).unwrap();
+                assert!(KinRegistry::default().save_to(&registry_path).is_err());
+                assert_eq!(std::fs::read(&victim).unwrap(), b"do not touch");
+                assert_eq!(mode(&victim), victim_mode);
+            }
+            "legacy-migrations" => {
+                std::fs::write(&registry_path, "repos = []\n").unwrap();
+                std::fs::write(&lock_path, b"").unwrap();
+                std::fs::write(&legacy_tmp_path, b"legacy").unwrap();
+                for path in [&registry_path, &lock_path, &legacy_tmp_path] {
+                    std::fs::set_permissions(path, std::fs::Permissions::from_mode(0o644)).unwrap();
+                }
+                KinRegistry::load_from(&registry_path).unwrap();
+                assert_eq!(mode(&registry_path), 0o600);
+                assert_eq!(mode(&lock_path), 0o600);
+                assert_eq!(mode(&legacy_tmp_path), 0o600);
+                assert_eq!(std::fs::read(&legacy_tmp_path).unwrap(), b"legacy");
+            }
+            "failure-cleanup" => {
+                KinRegistry::default().save_to(&registry_path).unwrap();
+                let before = std::fs::read(&registry_path).unwrap();
+                std::env::set_var("REGISTRY_TEST_FAIL_AFTER_TEMP_SYNC", "1");
+                let mut changed = KinRegistry::default();
+                changed.repos.push(RegisteredRepo {
+                    id: "must-not-land".to_string(),
+                    path: work.clone(),
+                    entities: 1,
+                    last_commit: "2026-07-13T00:00:00Z".to_string(),
+                    dependencies: Vec::new(),
+                });
+                assert!(changed.save_to(&registry_path).is_err());
+                std::env::remove_var("REGISTRY_TEST_FAIL_AFTER_TEMP_SYNC");
+                assert_eq!(std::fs::read(&registry_path).unwrap(), before);
+                assert!(std::fs::read_dir(&work).unwrap().all(|entry| !entry
+                    .unwrap()
+                    .file_name()
+                    .to_string_lossy()
+                    .contains(".tmp-")));
+            }
+            "identity-checks" => {
+                std::fs::write(&registry_path, "repos = []\n").unwrap();
+                std::fs::set_permissions(&registry_path, std::fs::Permissions::from_mode(0o600))
+                    .unwrap();
+                let registry_link = work.join("registry-hardlink");
+                std::fs::hard_link(&registry_path, &registry_link).unwrap();
+                assert!(KinRegistry::load_from(&registry_path).is_err());
+                std::fs::remove_file(&registry_link).unwrap();
+
+                std::fs::write(&lock_path, b"").unwrap();
+                std::fs::set_permissions(&lock_path, std::fs::Permissions::from_mode(0o600))
+                    .unwrap();
+                let lock_link = work.join("lock-hardlink");
+                std::fs::hard_link(&lock_path, &lock_link).unwrap();
+                assert!(KinRegistry::load_from(&registry_path).is_err());
+                std::fs::remove_file(&lock_link).unwrap();
+
+                std::fs::remove_file(&lock_path).unwrap();
+                std::fs::remove_file(&registry_path).unwrap();
+                std::fs::create_dir(&registry_path).unwrap();
+                assert!(KinRegistry::load_from(&registry_path).is_err());
+                std::fs::remove_dir(&registry_path).unwrap();
+                std::fs::remove_file(&lock_path).unwrap();
+
+                std::fs::create_dir(&lock_path).unwrap();
+                assert!(KinRegistry::default().save_to(&registry_path).is_err());
+                std::fs::remove_dir(&lock_path).unwrap();
+
+                let real_parent = root.join("real-parent");
+                let linked_parent = root.join("linked-parent");
+                std::fs::create_dir(&real_parent).unwrap();
+                symlink(&real_parent, &linked_parent).unwrap();
+                assert!(KinRegistry::default()
+                    .save_to(&linked_parent.join("registry.toml"))
+                    .is_err());
+
+                // Wrong-owner coverage is possible only for a privileged test runner.
+                // SAFETY: `geteuid` and `chown` have no Rust aliasing requirements.
+                if unsafe { libc::geteuid() } == 0 {
+                    std::fs::write(&registry_path, "repos = []\n").unwrap();
+                    let path_c = std::ffi::CString::new(std::os::unix::ffi::OsStrExt::as_bytes(
+                        registry_path.as_os_str(),
+                    ))
+                    .unwrap();
+                    // SAFETY: `path_c` is valid and the test is running as root.
+                    assert_eq!(unsafe { libc::chown(path_c.as_ptr(), 1, u32::MAX) }, 0);
+                    assert!(KinRegistry::load_from(&registry_path).is_err());
+                    // SAFETY: restore ownership before testing the lock authority.
+                    assert_eq!(unsafe { libc::chown(path_c.as_ptr(), 0, u32::MAX) }, 0);
+                    let lock_c = std::ffi::CString::new(std::os::unix::ffi::OsStrExt::as_bytes(
+                        lock_path.as_os_str(),
+                    ))
+                    .unwrap();
+                    // SAFETY: `lock_c` is valid and the test is running as root.
+                    assert_eq!(unsafe { libc::chown(lock_c.as_ptr(), 1, u32::MAX) }, 0);
+                    assert!(KinRegistry::load_from(&registry_path).is_err());
+                }
+            }
+            unknown => panic!("unknown registry security subprocess case: {unknown}"),
+        }
     }
 
     #[test]

--- a/crates/kin-core/src/registry.rs
+++ b/crates/kin-core/src/registry.rs
@@ -345,7 +345,21 @@ pub fn require_registry_authority_secure() -> Result<(), Box<dyn std::error::Err
 }
 
 pub fn require_registry_authority_secure_at(path: &Path) -> Result<(), Box<dyn std::error::Error>> {
-    let report = inspect_registry_authority_at(path);
+    let mut report = inspect_registry_authority_at(path);
+    // A newly-created lock is requested at 0600 but a restrictive process
+    // umask can make its public mode 0000 for the few instructions before the
+    // creator's descriptor-anchored fchmod. Never repair or trust that state:
+    // only wait briefly for an otherwise-secure authority snapshot to converge.
+    for _ in 0..50 {
+        if report.is_secure() {
+            return Ok(());
+        }
+        if !report.is_transient_lock_creation_window() {
+            break;
+        }
+        std::thread::sleep(std::time::Duration::from_millis(1));
+        report = inspect_registry_authority_at(path);
+    }
     if report.is_secure() {
         return Ok(());
     }
@@ -361,6 +375,28 @@ pub fn require_registry_authority_secure_at(path: &Path) -> Result<(), Box<dyn s
             report.failure_summary()
         ),
     )))
+}
+
+impl RegistryAuthorityReport {
+    #[cfg(unix)]
+    fn is_transient_lock_creation_window(&self) -> bool {
+        let mut saw_lock = false;
+        self.checks.iter().all(|check| match check.state {
+            RegistryAuthorityState::Secure | RegistryAuthorityState::Absent => true,
+            RegistryAuthorityState::RepairablePermissions
+                if check.label == "registry lock" && check.detail.starts_with("mode 0000;") =>
+            {
+                saw_lock = true;
+                true
+            }
+            _ => false,
+        }) && saw_lock
+    }
+
+    #[cfg(not(unix))]
+    fn is_transient_lock_creation_window(&self) -> bool {
+        false
+    }
 }
 
 /// Explicitly repair mode bits on structurally safe registry-authority files.
@@ -523,13 +559,118 @@ fn normalized_parent(path: &Path) -> PathBuf {
 
 #[cfg(unix)]
 fn prepare_anchor(path: &Path) -> Result<RegistryAnchor, Box<dyn std::error::Error>> {
-    use std::os::unix::fs::DirBuilderExt;
-
     let parent = normalized_parent(path);
-    let mut builder = std::fs::DirBuilder::new();
-    builder.recursive(true).mode(0o700);
-    builder.create(&parent)?;
+    create_private_dir_all(&parent)?;
     Ok(RegistryAnchor::open(path)?)
+}
+
+#[cfg(unix)]
+fn create_private_dir_all(path: &Path) -> std::io::Result<()> {
+    use std::os::fd::{AsRawFd, FromRawFd};
+    use std::os::unix::ffi::OsStrExt;
+
+    match std::fs::symlink_metadata(path) {
+        Ok(_) => return Ok(()),
+        Err(err) if err.kind() == std::io::ErrorKind::NotFound => {}
+        Err(err) => return Err(err),
+    }
+
+    let mut ancestor = path.to_path_buf();
+    let mut missing = Vec::new();
+    loop {
+        match std::fs::symlink_metadata(&ancestor) {
+            Ok(_) => break,
+            Err(err) if err.kind() == std::io::ErrorKind::NotFound => {
+                let name = ancestor.file_name().ok_or_else(|| {
+                    std::io::Error::new(
+                        std::io::ErrorKind::InvalidInput,
+                        "registry parent has no creatable directory component",
+                    )
+                })?;
+                missing.push(name.to_os_string());
+                ancestor = ancestor
+                    .parent()
+                    .filter(|parent| !parent.as_os_str().is_empty())
+                    .unwrap_or_else(|| Path::new("."))
+                    .to_path_buf();
+            }
+            Err(err) => return Err(err),
+        }
+    }
+
+    let canonical_ancestor = ancestor.canonicalize()?;
+    let mut current = File::open(&canonical_ancestor)?;
+    validate_parent(&current).map_err(|err| {
+        std::io::Error::new(
+            err.kind(),
+            format!(
+                "refusing to create registry directories below {}: {err}",
+                canonical_ancestor.display()
+            ),
+        )
+    })?;
+
+    for name in missing.into_iter().rev() {
+        let name_c = std::ffi::CString::new(name.as_bytes()).map_err(|_| {
+            std::io::Error::new(
+                std::io::ErrorKind::InvalidInput,
+                "registry directory component contains a NUL byte",
+            )
+        })?;
+        // SAFETY: the retained parent fd and NUL-terminated component are valid.
+        let created = if unsafe { libc::mkdirat(current.as_raw_fd(), name_c.as_ptr(), 0o700) } == 0
+        {
+            true
+        } else {
+            let err = std::io::Error::last_os_error();
+            if err.kind() == std::io::ErrorKind::AlreadyExists {
+                false
+            } else {
+                return Err(err);
+            }
+        };
+
+        if created {
+            // The retained parent is current-user-owned and not writable by
+            // other users. AT_SYMLINK_NOFOLLOW keeps the chmod anchored to the
+            // directory entry this operation created even under umask 0777.
+            // SAFETY: the dirfd/name are valid and mode has no invalid bits.
+            if unsafe {
+                libc::fchmodat(
+                    current.as_raw_fd(),
+                    name_c.as_ptr(),
+                    0o700,
+                    libc::AT_SYMLINK_NOFOLLOW,
+                )
+            } != 0
+            {
+                return Err(std::io::Error::last_os_error());
+            }
+        }
+
+        // SAFETY: the retained parent fd/name are valid. O_NOFOLLOW prevents a
+        // raced symlink from becoming the next creation anchor.
+        let fd = unsafe {
+            libc::openat(
+                current.as_raw_fd(),
+                name_c.as_ptr(),
+                libc::O_RDONLY | libc::O_DIRECTORY | libc::O_CLOEXEC | libc::O_NOFOLLOW,
+            )
+        };
+        if fd < 0 {
+            return Err(std::io::Error::last_os_error());
+        }
+        // SAFETY: fd was returned by openat and ownership transfers to File.
+        let next = unsafe { File::from_raw_fd(fd) };
+        validate_parent(&next)?;
+        if created && stat_file(&next)?.st_mode & 0o7777 != 0o700 {
+            return Err(registry_security_error(
+                "new registry directory did not reach mode 0700",
+            ));
+        }
+        current = next;
+    }
+    Ok(())
 }
 
 #[cfg(unix)]
@@ -1384,6 +1525,25 @@ mod tests {
 
     #[cfg(unix)]
     #[test]
+    fn genuine_zero_mode_lock_is_refused_without_implicit_repair() {
+        use std::os::unix::fs::PermissionsExt;
+
+        let dir = tempfile::tempdir().unwrap();
+        let reg_path = dir.path().join("registry.toml");
+        let lock_path = reg_path.with_extension("lock");
+        std::fs::write(&reg_path, "repos = []\n").unwrap();
+        std::fs::write(&lock_path, b"").unwrap();
+        std::fs::set_permissions(&reg_path, std::fs::Permissions::from_mode(0o600)).unwrap();
+        std::fs::set_permissions(&lock_path, std::fs::Permissions::from_mode(0o000)).unwrap();
+
+        let error = KinRegistry::load_from(&reg_path).unwrap_err();
+        assert!(error.to_string().contains("mode 0000"), "{error}");
+        assert_eq!(mode(&lock_path), 0o000);
+        assert_eq!(std::fs::read(&reg_path).unwrap(), b"repos = []\n");
+    }
+
+    #[cfg(unix)]
+    #[test]
     fn installer_initialization_creates_missing_authority_without_rewriting_existing_bytes() {
         let fresh = tempfile::tempdir().unwrap();
         let fresh_path = fresh.path().join("registry.toml");
@@ -1616,6 +1776,8 @@ mod tests {
                 // SAFETY: this isolated subprocess sets the umask before spawning
                 // workers and restores it after every worker has joined.
                 let previous = unsafe { libc::umask(0o777) };
+                let fresh_path = work.join("new-parent/nested/registry.toml");
+                let initialized = initialize_registry_authority_at(&fresh_path).unwrap();
                 let mut handles = Vec::new();
                 for index in 0..8 {
                     let repo_path = work.clone();
@@ -1637,6 +1799,11 @@ mod tests {
                 }
                 // SAFETY: restore the process umask before any assertion can panic.
                 unsafe { libc::umask(previous) };
+                assert_eq!(initialized.len(), 2);
+                assert_eq!(mode(&work.join("new-parent")), 0o700);
+                assert_eq!(mode(&work.join("new-parent/nested")), 0o700);
+                assert_eq!(mode(&fresh_path), 0o600);
+                assert_eq!(mode(&fresh_path.with_extension("lock")), 0o600);
                 assert_eq!(mode(Path::new("registry.toml")), 0o600);
                 assert_eq!(mode(Path::new("registry.lock")), 0o600);
                 assert_eq!(
@@ -1741,6 +1908,13 @@ mod tests {
                 );
                 assert!(!registry_path.exists());
                 assert!(!lock_path.exists());
+                let nested_registry = work.join("nested/private/registry.toml");
+                let error = initialize_registry_authority_at(&nested_registry).unwrap_err();
+                assert!(
+                    error.to_string().contains("group/world writable"),
+                    "{error}"
+                );
+                assert!(!work.join("nested").exists());
                 std::fs::set_permissions(&work, std::fs::Permissions::from_mode(0o700)).unwrap();
             }
             "failure-cleanup" => {

--- a/crates/kin-core/src/registry.rs
+++ b/crates/kin-core/src/registry.rs
@@ -9,6 +9,9 @@
 use fs2::FileExt;
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
+use std::fs::{File, OpenOptions};
+#[cfg(unix)]
+use std::io::Write;
 use std::path::{Path, PathBuf};
 
 #[derive(Debug, Serialize, Deserialize, Default)]
@@ -42,11 +45,7 @@ impl KinRegistry {
             return Ok(Self::default());
         }
         let lock_path = path.with_extension("lock");
-        let lock_file = std::fs::OpenOptions::new()
-            .create(true)
-            .write(true)
-            .truncate(false)
-            .open(&lock_path)?;
+        let lock_file = open_private_lock_file(&lock_path)?;
         lock_file.lock_shared()?;
         let content = std::fs::read_to_string(path)?;
         // Lock released on drop
@@ -69,17 +68,12 @@ impl KinRegistry {
             std::fs::create_dir_all(parent)?;
         }
         let lock_path = path.with_extension("lock");
-        let lock_file = std::fs::OpenOptions::new()
-            .create(true)
-            .write(true)
-            .truncate(false)
-            .open(&lock_path)?;
+        let lock_file = open_private_lock_file(&lock_path)?;
         lock_file.lock_exclusive()?;
 
         // Atomic write: write to tmp, then rename into place.
-        let tmp = path.with_extension("tmp");
-        std::fs::write(&tmp, toml::to_string_pretty(self)?)?;
-        std::fs::rename(&tmp, path)?;
+        let contents = toml::to_string_pretty(self)?;
+        write_registry_atomically(path, contents.as_bytes())?;
 
         // Lock released on drop
         Ok(())
@@ -195,6 +189,83 @@ impl KinRegistry {
     }
 }
 
+fn open_private_lock_file(path: &Path) -> Result<File, Box<dyn std::error::Error>> {
+    let mut options = OpenOptions::new();
+    options.create(true).write(true).truncate(false);
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::OpenOptionsExt;
+        options.mode(0o600);
+    }
+    let file = options.open(path)?;
+    #[cfg(unix)]
+    tighten_private_permissions(&file)?;
+    Ok(file)
+}
+
+#[cfg(unix)]
+fn tighten_private_permissions(file: &File) -> Result<(), Box<dyn std::error::Error>> {
+    use std::os::unix::fs::PermissionsExt;
+
+    let mut permissions = file.metadata()?.permissions();
+    if permissions.mode() & 0o777 != 0o600 {
+        permissions.set_mode(0o600);
+        file.set_permissions(permissions)?;
+    }
+    Ok(())
+}
+
+fn write_registry_atomically(
+    path: &Path,
+    contents: &[u8],
+) -> Result<(), Box<dyn std::error::Error>> {
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::OpenOptionsExt;
+
+        let parent = path.parent().ok_or_else(|| {
+            std::io::Error::new(
+                std::io::ErrorKind::InvalidInput,
+                "registry path has no parent directory",
+            )
+        })?;
+        let file_name = path.file_name().ok_or_else(|| {
+            std::io::Error::new(
+                std::io::ErrorKind::InvalidInput,
+                "registry path has no filename",
+            )
+        })?;
+        let mut tmp_name = std::ffi::OsString::from(".");
+        tmp_name.push(file_name);
+        tmp_name.push(format!(".tmp-{}", uuid::Uuid::new_v4()));
+        let tmp = parent.join(tmp_name);
+        let result = (|| -> Result<(), Box<dyn std::error::Error>> {
+            let mut file = OpenOptions::new()
+                .create_new(true)
+                .write(true)
+                .mode(0o600)
+                .open(&tmp)?;
+            file.write_all(contents)?;
+            file.sync_all()?;
+            drop(file);
+            std::fs::rename(&tmp, path)?;
+            File::open(parent)?.sync_all()?;
+            Ok(())
+        })();
+        if result.is_err() {
+            let _ = std::fs::remove_file(&tmp);
+        }
+        result
+    }
+    #[cfg(not(unix))]
+    {
+        let tmp = path.with_extension("tmp");
+        std::fs::write(&tmp, contents)?;
+        std::fs::rename(&tmp, path)?;
+        Ok(())
+    }
+}
+
 /// `~/.kin/registry.toml` path (cross-platform).
 pub fn registry_path() -> PathBuf {
     if let Some(path) = std::env::var_os("KIN_REGISTRY_PATH") {
@@ -212,6 +283,13 @@ pub fn registry_path() -> PathBuf {
 mod tests {
     use super::*;
 
+    #[cfg(unix)]
+    fn mode(path: &Path) -> u32 {
+        use std::os::unix::fs::PermissionsExt;
+
+        std::fs::metadata(path).unwrap().permissions().mode() & 0o777
+    }
+
     #[test]
     fn round_trip_load_save() {
         let dir = tempfile::tempdir().unwrap();
@@ -228,6 +306,52 @@ mod tests {
         assert_eq!(loaded.repos[0].path, PathBuf::from("/tmp/my-repo"));
         assert_eq!(loaded.repos[0].entities, 42);
         assert!(!loaded.repos[0].last_commit.is_empty());
+        #[cfg(unix)]
+        {
+            assert_eq!(mode(&reg_path), 0o600);
+            assert_eq!(mode(&reg_path.with_extension("lock")), 0o600);
+        }
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn registry_and_lock_files_are_private() {
+        use std::os::unix::fs::PermissionsExt;
+
+        let dir = tempfile::tempdir().unwrap();
+        let reg_path = dir.path().join("registry.toml");
+        let lock_path = reg_path.with_extension("lock");
+        std::fs::write(&reg_path, "repos = []\n").unwrap();
+        std::fs::write(&lock_path, b"").unwrap();
+        std::fs::set_permissions(&reg_path, std::fs::Permissions::from_mode(0o644)).unwrap();
+        std::fs::set_permissions(&lock_path, std::fs::Permissions::from_mode(0o644)).unwrap();
+
+        KinRegistry::default().save_to(&reg_path).unwrap();
+
+        assert_eq!(mode(&reg_path), 0o600);
+        assert_eq!(mode(&lock_path), 0o600);
+        assert!(std::fs::read_dir(dir.path()).unwrap().all(|entry| !entry
+            .unwrap()
+            .file_name()
+            .to_string_lossy()
+            .contains(".tmp-")));
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn loading_tightens_an_existing_registry_lock() {
+        use std::os::unix::fs::PermissionsExt;
+
+        let dir = tempfile::tempdir().unwrap();
+        let reg_path = dir.path().join("registry.toml");
+        let lock_path = reg_path.with_extension("lock");
+        std::fs::write(&reg_path, "repos = []\n").unwrap();
+        std::fs::write(&lock_path, b"").unwrap();
+        std::fs::set_permissions(&lock_path, std::fs::Permissions::from_mode(0o644)).unwrap();
+
+        KinRegistry::load_from(&reg_path).unwrap();
+
+        assert_eq!(mode(&lock_path), 0o600);
     }
 
     #[test]

--- a/crates/kin-daemon/src/state.rs
+++ b/crates/kin-daemon/src/state.rs
@@ -15,7 +15,7 @@ use kin_model::{
 use kin_projection::ProjectionState;
 use kin_reconcile::Reconciler;
 use tokio::sync::RwLock;
-use tracing::{debug, info, warn};
+use tracing::{debug, error, info, warn};
 
 use crate::error::{DaemonError, Result};
 use crate::session_registry::SessionCoordinator;
@@ -1041,7 +1041,14 @@ impl DaemonState {
             }
 
             // Register sibling repos from the global registry.
-            if let Ok(registry) = kin_core::registry::KinRegistry::load() {
+            let registry = kin_core::registry::KinRegistry::load();
+            if let Err(load_error) = &registry {
+                error!(
+                    error = %load_error,
+                    "registry authority refused; sibling repos were not loaded into the spine"
+                );
+            }
+            if let Ok(registry) = registry {
                 let cwd_canonical = self
                     .layout
                     .root()

--- a/crates/kin-mcp/src/server.rs
+++ b/crates/kin-mcp/src/server.rs
@@ -274,22 +274,75 @@ fn parse_workspace_roots(value: &serde_json::Value) -> Vec<PathBuf> {
 /// `file://` URIs (decoding `%XX` escapes) and the bare absolute path some
 /// clients (e.g. Cursor) send instead. Returns `None` for remote/non-file URIs.
 fn root_uri_to_path(uri: &str) -> Option<PathBuf> {
-    if let Some(rest) = uri.strip_prefix("file://") {
-        // `file:///abs/path` -> `/abs/path`; `file://host/abs/path` -> `/abs/path`.
-        let path = match rest.as_bytes().first() {
-            Some(b'/') => rest.to_string(),
-            _ => {
-                let slash = rest.find('/')?;
-                rest[slash..].to_string()
-            }
-        };
-        return Some(PathBuf::from(percent_decode(&path)));
+    if uri
+        .get(.."file://".len())
+        .is_some_and(|scheme| scheme.eq_ignore_ascii_case("file://"))
+    {
+        let rest = &uri["file://".len()..];
+
+        // Empty authority: `file:///abs/path` or `file:///C:/Users/me/repo`.
+        if rest.starts_with('/') {
+            return Some(file_uri_path(percent_decode(rest)));
+        }
+
+        let slash = rest.find('/')?;
+        let authority = &rest[..slash];
+        let path = percent_decode(&rest[slash..]);
+
+        // `localhost` is the local machine, so only its path component matters.
+        if authority.eq_ignore_ascii_case("localhost") {
+            return Some(file_uri_path(path));
+        }
+
+        // A few Windows clients emit the non-canonical but common
+        // `file://C:/Users/...` spelling, treating the drive as an authority.
+        if is_windows_drive_authority(authority) {
+            return Some(PathBuf::from(format!("{authority}{path}")));
+        }
+
+        // A non-local file authority is a Windows UNC share. Do not reinterpret
+        // it as a local POSIX path on Unix hosts.
+        #[cfg(windows)]
+        {
+            return Some(PathBuf::from(format!(
+                r"\\{authority}{}",
+                path.replace('/', "\\")
+            )));
+        }
+        #[cfg(not(windows))]
+        {
+            return None;
+        }
     }
     // Some clients (Cursor) send a bare absolute path rather than a file URI.
-    if uri.starts_with('/') {
+    if uri.starts_with('/') || is_windows_drive_path(uri) || uri.starts_with(r"\\") {
         return Some(PathBuf::from(uri));
     }
     None
+}
+
+/// Normalize the path component of a file URI. RFC 8089 spells a Windows drive
+/// URI as `file:///C:/...`; the leading slash is URI syntax, not part of the
+/// native Windows path.
+fn file_uri_path(path: String) -> PathBuf {
+    if path.starts_with('/') && is_windows_drive_path(&path[1..]) {
+        PathBuf::from(&path[1..])
+    } else {
+        PathBuf::from(path)
+    }
+}
+
+fn is_windows_drive_path(path: &str) -> bool {
+    let bytes = path.as_bytes();
+    bytes.len() >= 3
+        && bytes[0].is_ascii_alphabetic()
+        && bytes[1] == b':'
+        && matches!(bytes[2], b'/' | b'\\')
+}
+
+fn is_windows_drive_authority(authority: &str) -> bool {
+    let bytes = authority.as_bytes();
+    bytes.len() == 2 && bytes[0].is_ascii_alphabetic() && bytes[1] == b':'
 }
 
 /// Minimal percent-decoding for `file://` URI paths (handles `%20`, etc.).
@@ -1120,11 +1173,41 @@ mod tests {
             root_uri_to_path("file:///Users/me/My%20Repo"),
             Some(PathBuf::from("/Users/me/My Repo"))
         );
+        // RFC 8089 Windows drive URIs drop the URI-only leading slash.
+        assert_eq!(
+            root_uri_to_path("file:///C:/Users/me/My%20Repo"),
+            Some(PathBuf::from("C:/Users/me/My Repo"))
+        );
+        assert_eq!(
+            root_uri_to_path("file://localhost/C:/Users/me/kin"),
+            Some(PathBuf::from("C:/Users/me/kin"))
+        );
+        // Accept the non-canonical spelling emitted by some Windows clients.
+        assert_eq!(
+            root_uri_to_path("file://C:/Users/me/kin"),
+            Some(PathBuf::from("C:/Users/me/kin"))
+        );
         // Some clients (Cursor) send a bare absolute path, not a file:// URI.
         assert_eq!(
             root_uri_to_path("/Users/me/kin"),
             Some(PathBuf::from("/Users/me/kin"))
         );
+        assert_eq!(
+            root_uri_to_path(r"C:\Users\me\kin"),
+            Some(PathBuf::from(r"C:\Users\me\kin"))
+        );
+        assert_eq!(
+            root_uri_to_path("C:/Users/me/kin"),
+            Some(PathBuf::from("C:/Users/me/kin"))
+        );
+        assert_eq!(root_uri_to_path("C:relative\\kin"), None);
+        #[cfg(windows)]
+        assert_eq!(
+            root_uri_to_path("file://server/share/kin"),
+            Some(PathBuf::from(r"\\server\share\kin"))
+        );
+        #[cfg(not(windows))]
+        assert_eq!(root_uri_to_path("file://server/share/kin"), None);
         // Non-file schemes (e.g. remote workspaces) are skipped.
         assert_eq!(root_uri_to_path("vscode-remote://host/x"), None);
         assert_eq!(root_uri_to_path("https://example.com/x"), None);

--- a/crates/kin-migrate/src/executor.rs
+++ b/crates/kin-migrate/src/executor.rs
@@ -464,7 +464,7 @@ pub fn execute_migration_persisted(plan: &MigrationPlan) -> Result<MigrationResu
         .entered();
         crate::finalize::ensure_eject_snapshot(&plan.target, &init_result.layout.root())?;
     }
-    crate::finalize::update_registry(&plan.target, entities_extracted);
+    crate::finalize::update_registry(&plan.target, entities_extracted)?;
 
     let elapsed = start.elapsed();
     Ok(MigrationResult {

--- a/crates/kin-migrate/src/finalize.rs
+++ b/crates/kin-migrate/src/finalize.rs
@@ -15,7 +15,7 @@
 use std::fs;
 use std::path::Path;
 
-use tracing::{info, warn};
+use tracing::info;
 
 use crate::error::{MigrateError, Result};
 
@@ -96,7 +96,7 @@ pub fn ensure_eject_snapshot(repo_root: &Path, kin_root: &Path) -> Result<()> {
 }
 
 /// Register the repo in `~/.kin/registry.toml` with its entity count.
-pub fn update_registry(repo_root: &Path, entity_count: usize) {
+pub fn update_registry(repo_root: &Path, entity_count: usize) -> Result<()> {
     let repo_id = repo_root
         .file_name()
         .and_then(|n| n.to_str())
@@ -105,11 +105,11 @@ pub fn update_registry(repo_root: &Path, entity_count: usize) {
     let canonical = repo_root
         .canonicalize()
         .unwrap_or_else(|_| repo_root.to_path_buf());
-    if let Err(e) = kin_core::registry::KinRegistry::update(|registry| {
+    kin_core::registry::KinRegistry::update(|registry| {
         registry.upsert(repo_id, canonical, entity_count);
-    }) {
-        warn!(error = %e, "failed to update global registry");
-    }
+    })
+    .map_err(|e| MigrateError::Other(format!("failed to update local registry authority: {e}")))?;
+    Ok(())
 }
 
 /// Best-effort trigger of the daemon LSP cold sweep.
@@ -225,6 +225,6 @@ mod tests {
     fn update_registry_does_not_panic_on_missing_home() {
         let tmp = tempfile::tempdir().unwrap();
         // Should not panic even if ~/.kin doesn't exist.
-        update_registry(tmp.path(), 42);
+        update_registry(tmp.path(), 42).unwrap();
     }
 }

--- a/crates/kin-migrate/src/finalize.rs
+++ b/crates/kin-migrate/src/finalize.rs
@@ -97,19 +97,18 @@ pub fn ensure_eject_snapshot(repo_root: &Path, kin_root: &Path) -> Result<()> {
 
 /// Register the repo in `~/.kin/registry.toml` with its entity count.
 pub fn update_registry(repo_root: &Path, entity_count: usize) {
-    if let Ok(mut registry) = kin_core::registry::KinRegistry::load() {
-        let repo_id = repo_root
-            .file_name()
-            .and_then(|n| n.to_str())
-            .unwrap_or("unknown")
-            .to_string();
-        let canonical = repo_root
-            .canonicalize()
-            .unwrap_or_else(|_| repo_root.to_path_buf());
+    let repo_id = repo_root
+        .file_name()
+        .and_then(|n| n.to_str())
+        .unwrap_or("unknown")
+        .to_string();
+    let canonical = repo_root
+        .canonicalize()
+        .unwrap_or_else(|_| repo_root.to_path_buf());
+    if let Err(e) = kin_core::registry::KinRegistry::update(|registry| {
         registry.upsert(repo_id, canonical, entity_count);
-        if let Err(e) = registry.save() {
-            warn!(error = %e, "failed to update global registry");
-        }
+    }) {
+        warn!(error = %e, "failed to update global registry");
     }
 }
 

--- a/packages/boundary-contracts/package.json
+++ b/packages/boundary-contracts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kin/boundary-contracts",
-  "version": "0.2.23",
+  "version": "0.2.24",
   "private": false,
   "description": "Shared contracts for Kin ecosystem boundaries.",
   "type": "module",

--- a/packages/kin-mcp/package.json
+++ b/packages/kin-mcp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kinlab/kin-mcp",
-  "version": "0.2.23",
+  "version": "0.2.24",
   "description": "Start Kin's MCP server, the system of record for AI-written software, through an npm-friendly wrapper.",
   "type": "module",
   "bin": {

--- a/packages/kin/package.json
+++ b/packages/kin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kinlab/kin",
-  "version": "0.2.23",
+  "version": "0.2.24",
   "description": "Canonical installer and launcher for Kin, the system of record for AI-written software. Provisions and runs the managed kin + kin-daemon release. MCP is one included mode (kin mcp start).",
   "license": "Apache-2.0",
   "type": "module",

--- a/scripts/install.ps1
+++ b/scripts/install.ps1
@@ -224,19 +224,15 @@ if (-not (Test-Path (Join-Path $TmpDir "kin-daemon.exe"))) {
     exit 1
 }
 
-# Use the downloaded binary's content-free registry-authority contract before
-# replacing an installed binary. On Windows the Unix ownership/mode portion is
-# reported as not applicable; unsafe supported states still fail closed.
-$RegistryArgs = @("registry", "authority")
-if ($env:KIN_REGISTRY_REPAIR -eq "1") {
-    $RegistryArgs += "--fix"
-}
+# Report the downloaded binary's registry-authority capability before replacing
+# an installed binary. Windows currently reports the Unix ownership/mode
+# contract as not applicable; it does not claim to repair Windows ACLs.
+$RegistryArgs = @("registry", "authority", "--json")
 $RegistryCheck = Start-Process -FilePath (Join-Path $TmpDir "kin.exe") `
     -ArgumentList $RegistryArgs -Wait -NoNewWindow -PassThru
 if ($RegistryCheck.ExitCode -ne 0) {
-    Write-Err "Unsafe local registry authority blocks installation."
-    Write-Err "No installed binary or registry authority file was replaced."
-    Write-Err "Inspect the paths above. For permission-only drift, rerun with KIN_REGISTRY_REPAIR=1."
+    Write-Err "Registry authority capability check failed."
+    Write-Err "No installed binary was replaced."
     exit 1
 }
 

--- a/scripts/install.ps1
+++ b/scripts/install.ps1
@@ -224,6 +224,22 @@ if (-not (Test-Path (Join-Path $TmpDir "kin-daemon.exe"))) {
     exit 1
 }
 
+# Use the downloaded binary's content-free registry-authority contract before
+# replacing an installed binary. On Windows the Unix ownership/mode portion is
+# reported as not applicable; unsafe supported states still fail closed.
+$RegistryArgs = @("registry", "authority")
+if ($env:KIN_REGISTRY_REPAIR -eq "1") {
+    $RegistryArgs += "--fix"
+}
+$RegistryCheck = Start-Process -FilePath (Join-Path $TmpDir "kin.exe") `
+    -ArgumentList $RegistryArgs -Wait -NoNewWindow -PassThru
+if ($RegistryCheck.ExitCode -ne 0) {
+    Write-Err "Unsafe local registry authority blocks installation."
+    Write-Err "No installed binary or registry authority file was replaced."
+    Write-Err "Inspect the paths above. For permission-only drift, rerun with KIN_REGISTRY_REPAIR=1."
+    exit 1
+}
+
 # Move binaries. kin-daemon.exe is mandatory (asserted above); kin-vfs.exe ships
 # only when the archive includes the (Unix-only) projection client.
 $HaveVfs = $false

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -12,6 +12,7 @@
 #   KIN_HOME=~/.kin       Install directory (preferred; default: ~/.kin)
 #   KIN_DIR=~/.kin        Install directory compatibility alias
 #   KIN_NO_SETUP=1        Skip interactive setup after install
+#   KIN_REGISTRY_REPAIR=1 Explicitly repair safe registry modes to 0600
 
 set -eu
 
@@ -187,6 +188,25 @@ fi
 if [ ! -f "$EXTRACT_DIR/kin-daemon" ]; then
     err "kin-daemon missing from the downloaded archive."
     err "kin status/search and the MCP server require it. Refusing a daemon-less install. Aborting."
+    exit 1
+fi
+
+# The freshly downloaded binary owns the registry-authority contract used by
+# `kin doctor` and `kin update`. Run its content-free check before replacing
+# any installed binary. Unsafe existing state is never silently chmodded or
+# overwritten; the operator must explicitly repair it and rerun the installer.
+chmod +x "$EXTRACT_DIR/kin"
+if [ "${KIN_REGISTRY_REPAIR:-}" = "1" ]; then
+    REGISTRY_AUTHORITY_STATUS=0
+    "$EXTRACT_DIR/kin" registry authority --fix || REGISTRY_AUTHORITY_STATUS=$?
+else
+    REGISTRY_AUTHORITY_STATUS=0
+    "$EXTRACT_DIR/kin" registry authority || REGISTRY_AUTHORITY_STATUS=$?
+fi
+if [ "$REGISTRY_AUTHORITY_STATUS" -ne 0 ]; then
+    err "Unsafe local registry authority blocks installation."
+    err "No installed binary or registry authority file was replaced."
+    err "Inspect the paths above. For permission-only drift, rerun with KIN_REGISTRY_REPAIR=1."
     exit 1
 fi
 

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -198,10 +198,10 @@ fi
 chmod +x "$EXTRACT_DIR/kin"
 if [ "${KIN_REGISTRY_REPAIR:-}" = "1" ]; then
     REGISTRY_AUTHORITY_STATUS=0
-    "$EXTRACT_DIR/kin" registry authority --fix || REGISTRY_AUTHORITY_STATUS=$?
+    "$EXTRACT_DIR/kin" registry authority --fix --initialize || REGISTRY_AUTHORITY_STATUS=$?
 else
     REGISTRY_AUTHORITY_STATUS=0
-    "$EXTRACT_DIR/kin" registry authority || REGISTRY_AUTHORITY_STATUS=$?
+    "$EXTRACT_DIR/kin" registry authority --initialize || REGISTRY_AUTHORITY_STATUS=$?
 fi
 if [ "$REGISTRY_AUTHORITY_STATUS" -ne 0 ]; then
     err "Unsafe local registry authority blocks installation."

--- a/scripts/test-npm-automatic-release.py
+++ b/scripts/test-npm-automatic-release.py
@@ -16,9 +16,9 @@ from pathlib import Path
 ROOT = Path(__file__).resolve().parent.parent
 SCRIPTS = ROOT / "scripts"
 PUBLISHER = SCRIPTS / "publish-npm-release.sh"
-VERSION = "0.2.23"
-OLD_VERSION = "0.2.22"
-NEWER_VERSION = "0.2.24"
+VERSION = "0.2.24"
+OLD_VERSION = "0.2.23"
+NEWER_VERSION = "0.2.25"
 REF = f"refs/tags/v{VERSION}"
 PACKAGE = "@kinlab/kin"
 OTHER_PACKAGE = "@kinlab/kin-mcp"
@@ -417,7 +417,7 @@ def test_symlinked_checkout_runs_channel_and_rollback_preflight() -> None:
     assert result.returncode == 0, result.stderr
     assert snapshot.get("channel_reads") == 1
     assert snapshot.get("rollback_checks") == 1
-    assert "latest=0.2.22" in result.stdout
+    assert "latest=0.2.23" in result.stdout
     assert "no registry mutation performed" in result.stdout
     assert not any(command[:1] == ["publish"] for command in snapshot["commands"])
     print("PASS: symlinked checkout executes channel and rollback preflight")
@@ -504,7 +504,7 @@ def test_newer_channel_during_publish_blocks_finalization() -> None:
     actual = json.loads(snapshot["state.json"])
     assert VERSION in actual["public"][PACKAGE]
     assert actual["tags"][PACKAGE]["latest"] == NEWER_VERSION
-    assert "resolves to 0.2.24" in result.stderr
+    assert "resolves to 0.2.25" in result.stderr
     assert "GitHub Latest remains blocked" in result.stderr
     assert "verify.json" in snapshot
     print("PASS: concurrent channel advancement leaves GitHub Latest blocked")

--- a/scripts/test-release-workflow-authority.py
+++ b/scripts/test-release-workflow-authority.py
@@ -17,6 +17,8 @@ RELEASE = WORKFLOWS / "release.yml"
 INSTALL_PROOF = WORKFLOWS / "install-proof.yml"
 INSTALLER_CALLBACK = WORKFLOWS / "publish-release-installers.yml"
 UPDATE_TRUST = ROOT / "docs" / "security" / "signing-and-update-trust.md"
+INSTALL_SH = ROOT / "scripts" / "install.sh"
+INSTALL_PS1 = ROOT / "scripts" / "install.ps1"
 
 
 def require(content: str, needle: str, context: str) -> None:
@@ -43,7 +45,19 @@ def main() -> None:
     ci_workflow = (WORKFLOWS / "ci.yml").read_text(encoding="utf-8")
     installer_callback = INSTALLER_CALLBACK.read_text(encoding="utf-8")
     update_trust = UPDATE_TRUST.read_text(encoding="utf-8")
+    install_sh = INSTALL_SH.read_text(encoding="utf-8")
+    install_ps1 = INSTALL_PS1.read_text(encoding="utf-8")
     docker_workflow = (WORKFLOWS / "docker.yml").read_text(encoding="utf-8")
+    for installer, command in (
+        (install_sh, '"$EXTRACT_DIR/kin" registry authority'),
+        (install_ps1, '@("registry", "authority")'),
+    ):
+        require(installer, command, "content-free installer registry-authority preflight")
+        require(
+            installer,
+            "No installed binary or registry authority file was replaced.",
+            "fail-closed installer registry-authority preflight",
+        )
     if "KIN_CI_BOT_TOKEN" in release or "bump_homebrew:" in release:
         raise AssertionError(
             "release.yml must not use a long-lived PAT or wait on cross-repo "

--- a/scripts/test-release-workflow-authority.py
+++ b/scripts/test-release-workflow-authority.py
@@ -673,7 +673,7 @@ def main() -> None:
         "always()",
         "needs.publish.result == 'success'",
         "uses: ./.github/workflows/install-proof.yml",
-        "expected_vfs_commit: 1c531216c65b734fb5e7c996094e01e030b8eec7",
+        "expected_vfs_commit: c782905f39500a7a107aba5a91e85119c77726fa",
     ):
         require(install_proof_job, policy, "mandatory public install proof")
 

--- a/scripts/test-release-workflow-authority.py
+++ b/scripts/test-release-workflow-authority.py
@@ -48,16 +48,23 @@ def main() -> None:
     install_sh = INSTALL_SH.read_text(encoding="utf-8")
     install_ps1 = INSTALL_PS1.read_text(encoding="utf-8")
     docker_workflow = (WORKFLOWS / "docker.yml").read_text(encoding="utf-8")
-    for installer, command in (
-        (install_sh, '"$EXTRACT_DIR/kin" registry authority'),
-        (install_ps1, '@("registry", "authority")'),
-    ):
-        require(installer, command, "content-free installer registry-authority preflight")
-        require(
-            installer,
-            "No installed binary or registry authority file was replaced.",
-            "fail-closed installer registry-authority preflight",
-        )
+    require(
+        install_sh,
+        '"$EXTRACT_DIR/kin" registry authority --initialize',
+        "content-free Unix installer registry-authority initialization",
+    )
+    require(
+        install_sh,
+        "No installed binary or registry authority file was replaced.",
+        "fail-closed Unix installer registry-authority preflight",
+    )
+    require(
+        install_ps1,
+        '@("registry", "authority", "--json")',
+        "honest Windows registry-authority capability report",
+    )
+    if "KIN_REGISTRY_REPAIR" in install_ps1:
+        raise AssertionError("Windows installer must not imply Unix mode repair support")
     if "KIN_CI_BOT_TOKEN" in release or "bump_homebrew:" in release:
         raise AssertionError(
             "release.yml must not use a long-lived PAT or wait on cross-repo "

--- a/scripts/test-verify-npm-release.py
+++ b/scripts/test-verify-npm-release.py
@@ -17,7 +17,7 @@ from pathlib import Path
 ROOT = Path(__file__).resolve().parent.parent
 VERIFIER = ROOT / "scripts" / "verify-npm-release.sh"
 PACKAGE = "@kinlab/kin"
-VERSION = "0.2.23"
+VERSION = "0.2.24"
 REF = f"refs/tags/v{VERSION}"
 COMMIT = "a" * 40
 INTEGRITY_BYTES = bytes([7]) * 64

--- a/scripts/test_installer_parity.py
+++ b/scripts/test_installer_parity.py
@@ -18,7 +18,7 @@ from verify_installer_parity import (
 )
 
 
-TAG = "v0.2.23"
+TAG = "v0.2.24"
 COMMIT = "a" * 40
 INSTALL = b"#!/bin/sh\necho kin\n"
 INSTALL_PS1 = b'Write-Output "Kin"\n'
@@ -65,7 +65,7 @@ class InstallerParityTests(unittest.TestCase):
 
     def test_manifest_must_bind_exact_tag(self) -> None:
         wrong = json.loads(manifest())
-        wrong["tag"] = "v0.2.22"
+        wrong["tag"] = "v0.2.23"
         with self.assertRaisesRegex(ParityError, "current.json tag"):
             self.verify(public_manifest=json.dumps(wrong).encode())
 

--- a/scripts/verify_installer_parity.py
+++ b/scripts/verify_installer_parity.py
@@ -174,7 +174,7 @@ def resolve_tag(repository: str, tag: str) -> str:
 
 def main() -> int:
     parser = argparse.ArgumentParser(description=__doc__)
-    parser.add_argument("tag", help="Exact stable release tag, for example v0.2.23")
+    parser.add_argument("tag", help="Exact stable release tag, for example v0.2.24")
     parser.add_argument("--expected-sha", help="Optional expected peeled 40-hex commit")
     parser.add_argument("--repository", default=DEFAULT_REPOSITORY)
     parser.add_argument("--base-url", default=DEFAULT_BASE_URL)


### PR DESCRIPTION
## Summary

- release MCP workspace-root binding, including native Windows drive URI/bare-path handling
- release truthful optional-VFS installer reporting and current OSS onboarding
- advance the immutable kin-vfs source pin to `c782905f39500a7a107aba5a91e85119c77726fa`; local and registry-resolved `kin-vfs-core` are both 0.1.5
- harden Unix registry authority for FIR-1481: exact 0600, regular/current-owner/single-link checks, no implicit repair, explicit permission-only repair, bounded special-file refusal, descriptor-anchored atomic updates, safe fresh-install initialization, and doctor/update/installer agreement
- close restrictive-umask and concurrent first-use races by retaining the trusted final parent descriptor through mutation, using no-follow component opens, and bounded no-mutation convergence checks
- give the non-root container runtime an owned mode-0700 `/home/kin` and assert that home contract before first-boot registry initialization
- report native Windows registry-mode authority honestly as unsupported and verify that contract in Windows CI/install proof
- bump Rust and npm release authority from 0.2.23 to 0.2.24

## Candidate authority

- base: `6a6335424bb412d2252755cf31f3d0e181bda5f5`
- exact head: `24e5eb091c91193be4fdd946fdf1d44ab9838da7`
- tag intent: `v0.2.24`
- no tag or release is claimed until exact-head hosted CI, post-merge CI, tag release, and public distribution proof all finish green

## Verification

### Exact source head `24e5eb09`

- `git diff --check`
- `actionlint .github/workflows/docker.yml`
- outside-`$HOME` `kin-dev release-check kin`: registry-only `cargo check --locked --workspace --all-targets` passed with no patches
- every external `kin-*` lock entry remained sparse-registry sourced with checksum; all eight pins matched the registry latest, including `kin-vfs-core 0.1.5`
- fresh exact-head hosted runs: CI `29446475557`, Docker `29446475534`, Daemon Smoke `29446475553`, SAST `29446475513`, DCO `29446473987`, Secret Scan `29446472792`

### Final Rust implementation head `e90de211`

- strict release allowlist clippy with `RUSTFLAGS=-D warnings`
- `RUSTFLAGS=-D warnings cargo build --all-targets --locked`
- `RUSTFLAGS=-D warnings cargo test --workspace --locked`, including doc tests
- core registry suite: 53 passed
- restrictive-umask concurrent missing-parent stress: 50/50 runs passed
- CLI registry-authority integration: 3 passed
- unsafe authority preflight proves load/save/update do not create a missing lock
- installer initialization proves both 0600 files are created while existing registry bytes are preserved
- FIFO, symlink, hard-link, non-regular, wrong-owner, unsafe-parent, reserved-path/case-alias, concurrent missing-parent, arbitrary transient lock mode, atomic update, and failure-preservation coverage passed
- two independent source reviews returned GO on the final race corrections

The `24e5eb09` delta after that full Rust gate changes only `Dockerfile` and `.github/workflows/docker.yml`; the exact-head hosted matrix reruns every release check.

## Remaining before merge/tag

- fresh exact-head GitHub checks, including the corrected container first-boot smoke
- exact post-merge CI before tagging
- public release-distribution and four-architecture Install Proof reconciliation after tagging

This PR remains a code/proof candidate only. It is not a released, production-deployed, or investor-citable v0.2.24 claim.