### PR TITLE
Fix graph validation authority checks

### DIFF
--- a/crates/kin-cli/src/commands/graph.rs
+++ b/crates/kin-cli/src/commands/graph.rs
@@ -369,9 +369,22 @@ fn build_graph_validate_response(
     graph: &kin_db::InMemoryGraph,
 ) -> Result<GraphCommandResponse> {
     let health = inspect_graph(layout, graph)?;
-    let stats = graph.graph_stats();
 
-    let entities = graph.list_all_entities()?;
+    // Validation needs the complete relation table, including corrupt edges
+    // whose source and destination are both absent. Entity-rooted traversal
+    // cannot discover those edges. A live snapshot is a coherent, graph-owned
+    // view of both tables; relation IDs are still deduplicated defensively
+    // below before endpoint accounting.
+    let snapshot = graph.to_snapshot();
+    let entities: Vec<_> = snapshot
+        .entities
+        .into_iter()
+        .map(|(_id, entity)| entity)
+        .collect();
+    let relations = snapshot
+        .relations
+        .into_iter()
+        .map(|(_id, relation)| relation);
     let mut issues = Vec::new();
 
     // Check for duplicate entities (same name + file + kind + byte position).
@@ -415,27 +428,39 @@ fn build_graph_validate_response(
         ));
     }
 
-    // Check relation integrity (src/dst entity IDs exist)
+    // Check relation integrity (src/dst entity IDs exist). Cross-repo Calls and
+    // References intentionally point at a deterministic external placeholder
+    // that is absent from this repo's entity set. The linker marks that exact
+    // contract with a non-empty import source and external_import_reference
+    // evidence; every other missing endpoint remains a validation failure.
     let entity_ids: std::collections::HashSet<_> = entities.iter().map(|e| e.id).collect();
-    let mut broken_relations = 0usize;
-    for e in &entities {
-        for rel in graph.get_all_relations_for_entity(&e.id)? {
-            if let kin_model::GraphNodeId::Entity(id) = rel.src {
-                if !entity_ids.contains(&id) {
-                    broken_relations += 1;
-                }
+    let mut seen_relation_ids = HashSet::new();
+    let mut broken_relation_endpoints = 0usize;
+    for rel in relations {
+        if !seen_relation_ids.insert(rel.id) {
+            continue;
+        }
+        if let kin_model::GraphNodeId::Entity(id) = rel.src {
+            if !entity_ids.contains(&id) {
+                broken_relation_endpoints += 1;
             }
-            if let kin_model::GraphNodeId::Entity(id) = rel.dst {
-                if !entity_ids.contains(&id) {
-                    broken_relations += 1;
-                }
+        }
+        if let kin_model::GraphNodeId::Entity(id) = rel.dst {
+            if !entity_ids.contains(&id) && !kin_index::is_external_import_placeholder(&rel) {
+                broken_relation_endpoints += 1;
             }
         }
     }
-    if broken_relations > 0 {
+    let inspected_relation_count = seen_relation_ids.len();
+    if broken_relation_endpoints > 0 {
+        let (endpoint_label, verb) = if broken_relation_endpoints == 1 {
+            ("relation endpoint", "references")
+        } else {
+            ("relation endpoints", "reference")
+        };
         issues.push(format!(
-            "{} relations reference non-existent entities",
-            broken_relations
+            "{} {} {} non-existent entities",
+            broken_relation_endpoints, endpoint_label, verb
         ));
     }
 
@@ -444,10 +469,16 @@ fn build_graph_validate_response(
     let mut lines = Vec::new();
     lines.push("=== Graph Validation ===".to_string());
     lines.push(String::new());
+    let relation_label = if inspected_relation_count == 1 {
+        "relation"
+    } else {
+        "relations"
+    };
     lines.push(format!(
-        "Checked {} entities, {} relations",
+        "Checked {} entities, {} {}",
         entities.len(),
-        stats.total_relations
+        inspected_relation_count,
+        relation_label
     ));
 
     if issues.is_empty() {
@@ -845,8 +876,9 @@ mod tests {
     use super::*;
     use kin_model::{
         ArtifactDelta, ArtifactDeltaKind, AuthorId, Branch, BranchName, ChangeStore, Entity,
-        EntityMetadata, FingerprintAlgorithm, Hash256, LanguageId, SemanticChange,
-        SemanticChangeId, SemanticFingerprint, SourceSpan, Timestamp, Visibility,
+        EntityMetadata, FingerprintAlgorithm, GraphNodeId, Hash256, LanguageId, Relation,
+        RelationId, RelationOrigin, SemanticChange, SemanticChangeId, SemanticFingerprint,
+        SourceSpan, Timestamp, Visibility,
     };
     use std::fs;
 
@@ -893,6 +925,148 @@ mod tests {
             created_in: None,
             superseded_by: None,
         }
+    }
+
+    fn test_relation(kind: RelationKind, src: EntityId, dst: EntityId) -> Relation {
+        Relation {
+            id: RelationId::new(),
+            kind,
+            src: GraphNodeId::Entity(src),
+            dst: GraphNodeId::Entity(dst),
+            confidence: 1.0,
+            origin: RelationOrigin::Parsed,
+            created_in: None,
+            import_source: None,
+            evidence: Vec::new(),
+        }
+    }
+
+    fn external_placeholder_relation(kind: RelationKind) -> (Entity, Relation) {
+        let mut caller = test_entity("run_task");
+        let file_id = FilePathId::new("src/app.rs");
+        caller.file_origin = Some(file_id.clone());
+        caller.span = Some(SourceSpan {
+            file: file_id,
+            start_byte: 0,
+            end_byte: 10,
+            start_line: 1,
+            start_col: 0,
+            end_line: 1,
+            end_col: 10,
+        });
+        let relations = kin_index::link_cross_file(&[kin_index::FileParseData {
+            file_path: "src/app.rs".to_string(),
+            entities: vec![caller.clone()],
+            relations: vec![kin_parser::ExtractedRelation {
+                call_shape: None,
+                kind,
+                src_name: caller.name.clone(),
+                dst_name: "InMemoryGraph".to_string(),
+                import_source: Some("kin_db".to_string()),
+            }],
+            imports: Vec::new(),
+        }]);
+        assert_eq!(relations.len(), 1);
+        let relation = relations.into_iter().next().unwrap();
+        assert!(kin_index::is_external_import_placeholder(&relation));
+        // The validator fixture has no source file; remove file metadata after
+        // the real linker has used it so this test isolates relation integrity
+        // rather than also triggering the orphaned-entity check.
+        caller.file_origin = None;
+        caller.span = None;
+        (caller, relation)
+    }
+
+    fn graph_validation_fixture() -> (
+        tempfile::TempDir,
+        kin_core::KinLayout,
+        kin_db::InMemoryGraph,
+    ) {
+        let temp = tempfile::tempdir().unwrap();
+        let kin_root = temp.path().join(".kin");
+        fs::create_dir_all(&kin_root).unwrap();
+        (
+            temp,
+            kin_core::KinLayout::new(kin_root),
+            kin_db::InMemoryGraph::new(),
+        )
+    }
+
+    #[test]
+    fn graph_validate_accepts_external_import_placeholder_destination() {
+        let (_temp, layout, graph) = graph_validation_fixture();
+        let (caller, relation) = external_placeholder_relation(RelationKind::Calls);
+        graph.upsert_entity(&caller).unwrap();
+        graph.upsert_relation(&relation).unwrap();
+
+        let response = build_graph_validate_response(&layout, &graph).unwrap();
+
+        assert!(response.error.is_none(), "{:?}", response.lines);
+        assert!(response
+            .lines
+            .iter()
+            .any(|line| line == "✓ All checks passed."));
+    }
+
+    #[test]
+    fn graph_validate_rejects_unmarked_dangling_destination() {
+        let (_temp, layout, graph) = graph_validation_fixture();
+        let caller = test_entity("run_task");
+        graph.upsert_entity(&caller).unwrap();
+        graph
+            .upsert_relation(&test_relation(
+                RelationKind::Calls,
+                caller.id,
+                EntityId::new(),
+            ))
+            .unwrap();
+
+        let response = build_graph_validate_response(&layout, &graph).unwrap();
+
+        assert!(response.error.is_some(), "{:?}", response.lines);
+        assert!(response
+            .lines
+            .iter()
+            .any(|line| line == "✗ 1 relation endpoint references non-existent entities"));
+    }
+
+    #[test]
+    fn graph_validate_rejects_relation_with_both_endpoints_absent() {
+        let (_temp, layout, graph) = graph_validation_fixture();
+        graph
+            .upsert_relation(&test_relation(
+                RelationKind::References,
+                EntityId::new(),
+                EntityId::new(),
+            ))
+            .unwrap();
+
+        let response = build_graph_validate_response(&layout, &graph).unwrap();
+
+        assert!(response.error.is_some(), "{:?}", response.lines);
+        assert!(response
+            .lines
+            .iter()
+            .any(|line| line == "Checked 0 entities, 1 relation"));
+        assert!(response
+            .lines
+            .iter()
+            .any(|line| line == "✗ 2 relation endpoints reference non-existent entities"));
+    }
+
+    #[test]
+    fn graph_validate_rejects_missing_source_on_canonical_external_placeholder() {
+        let (_temp, layout, graph) = graph_validation_fixture();
+        let (_caller, relation) = external_placeholder_relation(RelationKind::References);
+        graph.upsert_relation(&relation).unwrap();
+
+        let response = build_graph_validate_response(&layout, &graph).unwrap();
+
+        assert!(response.error.is_some(), "{:?}", response.lines);
+        assert!(response
+            .lines
+            .iter()
+            .any(|line| line == "✗ 1 relation endpoint references non-existent entities"));
     }
 
     #[test]

--- a/crates/kin-cli/src/commands/graph.rs
+++ b/crates/kin-cli/src/commands/graph.rs
@@ -376,15 +376,8 @@ fn build_graph_validate_response(
     // view of both tables; relation IDs are still deduplicated defensively
     // below before endpoint accounting.
     let snapshot = graph.to_snapshot();
-    let entities: Vec<_> = snapshot
-        .entities
-        .into_iter()
-        .map(|(_id, entity)| entity)
-        .collect();
-    let relations = snapshot
-        .relations
-        .into_iter()
-        .map(|(_id, relation)| relation);
+    let entities: Vec<_> = snapshot.entities.into_values().collect();
+    let relations = snapshot.relations.into_values();
     let mut issues = Vec::new();
 
     // Check for duplicate entities (same name + file + kind + byte position).

--- a/crates/kin-index/src/lib.rs
+++ b/crates/kin-index/src/lib.rs
@@ -37,6 +37,7 @@ pub use linker::{
     CALL_SHAPE_PARSE_COVERAGE_FULL_V1, CALL_SHAPE_PARSE_COVERAGE_INCOMPLETE_V1,
     INCREMENTAL_LINKER_CHECKPOINT_VERSION, KIN_INDEX_CRATE_VERSION,
 };
+pub use linker::{is_external_import_placeholder, EXTERNAL_IMPORT_REFERENCE_RULE};
 pub use overlay::{apply_file_removal, apply_to_graph, ApplyResult};
 pub use pipeline::{
     classify_file_role, entity_semantics_changed, normalize_file_path_id, IndexPipeline,

--- a/crates/kin-index/src/linker.rs
+++ b/crates/kin-index/src/linker.rs
@@ -2529,6 +2529,63 @@ const EXTERNAL_REFERENCE_CONFIDENCE: f32 = 0.2;
 /// derived id can never collide with a locally indexed entity.
 const EXTERNAL_REFERENCE_KIND_TAG: &str = "ExternalReference";
 
+/// Linker evidence rule that identifies an intentional cross-repo placeholder
+/// destination. Consumers may accept a missing destination only when a
+/// Calls/References relation also has a non-empty import source and this rule.
+pub const EXTERNAL_IMPORT_REFERENCE_RULE: &str = "external_import_reference";
+
+/// Returns whether a relation exactly matches the linker's external-import
+/// placeholder contract. This does not inspect graph membership; callers must
+/// separately establish that the destination is absent from the local entity
+/// set. `created_in` is deliberately not part of this predicate because commit
+/// provenance may stamp it after the linker produces the relation.
+pub fn is_external_import_placeholder(relation: &Relation) -> bool {
+    if !matches!(
+        relation.kind,
+        RelationKind::Calls | RelationKind::References
+    ) || relation.origin != RelationOrigin::Inferred
+        || relation.confidence.to_bits() != EXTERNAL_REFERENCE_CONFIDENCE.to_bits()
+    {
+        return false;
+    }
+
+    let Some(src) = relation.src.as_entity() else {
+        return false;
+    };
+    let Some(dst) = relation.dst.as_entity() else {
+        return false;
+    };
+    let Some(import_source) = relation.import_source.as_deref() else {
+        return false;
+    };
+    if import_source.is_empty() || import_source != import_source.trim() {
+        return false;
+    }
+
+    let [evidence] = relation.evidence.as_slice() else {
+        return false;
+    };
+    let Some(symbol) = evidence.token.as_deref() else {
+        return false;
+    };
+    if symbol.is_empty() || symbol != symbol.trim() {
+        return false;
+    }
+    if evidence.parser_rule.as_deref() != Some(EXTERNAL_IMPORT_REFERENCE_RULE)
+        || evidence.source_path.as_deref() != Some(import_source)
+        || evidence.source_span.is_some()
+        || evidence.resolved_path.is_some()
+        || evidence.call_shape.is_some()
+        || evidence.occurrence_count == 0
+    {
+        return false;
+    }
+
+    let expected_dst =
+        EntityId::from_content(import_source, symbol, EXTERNAL_REFERENCE_KIND_TAG, 0);
+    dst == expected_dst && relation.id == stable_relation_id(&src, &expected_dst, &relation.kind)
+}
+
 /// Emit a cross-repo reference edge for a Calls/References relation that could
 /// not be resolved to any local entity but carries a parser-provided import
 /// source from a module that lives outside this repo.
@@ -2585,7 +2642,7 @@ where
         import_source: Some(import_source.to_string()),
         evidence: vec![RelationEvidence {
             token: Some(symbol.to_string()),
-            parser_rule: Some("external_import_reference".to_string()),
+            parser_rule: Some(EXTERNAL_IMPORT_REFERENCE_RULE.to_string()),
             source_path: Some(import_source.to_string()),
             ..RelationEvidence::default()
         }],
@@ -6263,6 +6320,24 @@ void f();
         assert_eq!(result[0].dst, GraphNodeId::Entity(e2.id));
     }
 
+    fn external_reference_fixture(kind: RelationKind) -> (Entity, Relation) {
+        let caller = make_entity("run_task", "src/app.rs");
+        let mut result = link_cross_file(&[FileParseData {
+            file_path: "src/app.rs".to_string(),
+            entities: vec![caller.clone()],
+            relations: vec![ExtractedRelation {
+                call_shape: None,
+                kind,
+                src_name: "run_task".to_string(),
+                dst_name: "InMemoryGraph".to_string(),
+                import_source: Some("kin_db".to_string()),
+            }],
+            imports: vec![],
+        }]);
+        assert_eq!(result.len(), 1, "one cross-repo reference edge expected");
+        (caller, result.pop().unwrap())
+    }
+
     #[test]
     fn external_reference_carries_symbol_and_import_source() {
         // A call to a symbol that lives in another repo: the target is absent
@@ -6270,36 +6345,123 @@ void f();
         // was imported from. The linker must preserve it as a cross-repo edge
         // carrying the lexical symbol (evidence.token) and the module hint
         // (import_source) — exactly what the spine resolver keys on.
-        let caller = make_entity("run_task", "src/app.rs");
-
-        let files = vec![FileParseData {
-            file_path: "src/app.rs".to_string(),
-            entities: vec![caller.clone()],
-            relations: vec![ExtractedRelation {
-                call_shape: None,
-                kind: RelationKind::Calls,
-                src_name: "run_task".to_string(),
-                dst_name: "InMemoryGraph".to_string(),
-                import_source: Some("kin_db".to_string()),
-            }],
-            imports: vec![],
-        }];
-
-        let result = link_cross_file(&files);
-        assert_eq!(result.len(), 1, "one cross-repo reference edge expected");
-        let edge = &result[0];
+        let (caller, edge) = external_reference_fixture(RelationKind::Calls);
         assert_eq!(edge.kind, RelationKind::Calls);
         assert_eq!(edge.src, GraphNodeId::Entity(caller.id));
         // The destination is an external placeholder, never a local entity.
         assert_ne!(edge.dst, GraphNodeId::Entity(caller.id));
         assert_eq!(edge.import_source.as_deref(), Some("kin_db"));
         assert_eq!(edge.origin, RelationOrigin::Inferred);
+        assert!(is_external_import_placeholder(&edge));
+        assert!(edge.evidence.iter().any(|evidence| {
+            evidence.parser_rule.as_deref() == Some(EXTERNAL_IMPORT_REFERENCE_RULE)
+        }));
         let token = edge
             .evidence
             .iter()
             .find_map(|ev| ev.token.as_deref())
             .expect("evidence token present");
         assert_eq!(token, "InMemoryGraph");
+    }
+
+    #[test]
+    fn external_import_placeholder_contract_rejects_mutations() {
+        let (_caller, canonical) = external_reference_fixture(RelationKind::Calls);
+        assert!(is_external_import_placeholder(&canonical));
+        let rejects = |relation: &Relation, mutation: &str| {
+            assert!(
+                !is_external_import_placeholder(relation),
+                "accepted non-canonical mutation: {mutation}"
+            );
+        };
+
+        let mut relation = canonical.clone();
+        relation.dst = GraphNodeId::Entity(EntityId::new());
+        rejects(&relation, "arbitrary destination");
+
+        let mut relation = canonical.clone();
+        relation.src = GraphNodeId::Entity(EntityId::new());
+        rejects(&relation, "arbitrary source");
+
+        let mut relation = canonical.clone();
+        relation.id = RelationId::new();
+        rejects(&relation, "arbitrary relation id");
+
+        let mut relation = canonical.clone();
+        relation.evidence[0].token = None;
+        rejects(&relation, "missing symbol token");
+
+        let mut relation = canonical.clone();
+        relation.evidence[0].token = Some("  ".to_string());
+        rejects(&relation, "blank symbol token");
+
+        let mut relation = canonical.clone();
+        relation.evidence[0].token = Some(" InMemoryGraph".to_string());
+        rejects(&relation, "untrimmed symbol token");
+
+        let mut relation = canonical.clone();
+        relation.evidence[0].source_path = Some("kin_model".to_string());
+        rejects(&relation, "source path mismatch");
+
+        let mut relation = canonical.clone();
+        relation.origin = RelationOrigin::Parsed;
+        rejects(&relation, "wrong origin");
+
+        let mut relation = canonical.clone();
+        relation.confidence = 0.3;
+        rejects(&relation, "wrong confidence");
+
+        let mut relation = canonical.clone();
+        relation.import_source = Some(" kin_db".to_string());
+        rejects(&relation, "untrimmed import source");
+
+        let mut relation = canonical.clone();
+        relation.import_source = None;
+        rejects(&relation, "missing import source");
+
+        let mut relation = canonical.clone();
+        relation.import_source = Some("  ".to_string());
+        rejects(&relation, "blank import source");
+
+        let mut relation = canonical.clone();
+        relation.evidence[0].source_path = None;
+        rejects(&relation, "missing evidence source path");
+
+        let mut relation = canonical.clone();
+        relation.evidence[0].parser_rule = Some("call_expression".to_string());
+        rejects(&relation, "wrong parser rule");
+
+        let mut relation = canonical.clone();
+        relation.kind = RelationKind::Imports;
+        rejects(&relation, "wrong relation kind");
+
+        let mut relation = canonical.clone();
+        relation.evidence[0].resolved_path = Some("src/lib.rs".to_string());
+        rejects(&relation, "resolved local path");
+
+        let mut relation = canonical.clone();
+        relation.evidence[0].source_span = Some(SourceSpan {
+            file: FilePathId::new("src/app.rs"),
+            start_byte: 0,
+            end_byte: 1,
+            start_line: 1,
+            start_col: 1,
+            end_line: 1,
+            end_col: 2,
+        });
+        rejects(&relation, "unexpected source span");
+
+        let mut relation = canonical.clone();
+        relation.evidence[0].call_shape = Some(kin_model::CallArgShape::default());
+        rejects(&relation, "unexpected call shape");
+
+        let mut relation = canonical.clone();
+        relation.evidence[0].occurrence_count = 0;
+        rejects(&relation, "zero evidence occurrences");
+
+        let mut relation = canonical;
+        relation.evidence.push(RelationEvidence::default());
+        rejects(&relation, "extra evidence record");
     }
 
     #[test]
@@ -6349,6 +6511,13 @@ void f();
                 ExtractedRelation {
                     call_shape: None,
                     kind: RelationKind::Calls,
+                    src_name: "run_task".to_string(),
+                    dst_name: "InMemoryGraph".to_string(),
+                    import_source: Some("kin_db".to_string()),
+                },
+                ExtractedRelation {
+                    call_shape: None,
+                    kind: RelationKind::Calls,
                     src_name: "run_again".to_string(),
                     dst_name: "InMemoryGraph".to_string(),
                     import_source: Some("kin_db".to_string()),
@@ -6363,6 +6532,13 @@ void f();
         let dst_a = first[0].dst;
         let dst_b = first[1].dst;
         assert_eq!(dst_a, dst_b, "same symbol/source → same external target id");
+        let repeated = first
+            .iter()
+            .find(|relation| relation.src == GraphNodeId::Entity(caller.id))
+            .unwrap();
+        assert_eq!(repeated.evidence.len(), 1);
+        assert_eq!(repeated.evidence[0].occurrence_count, 2);
+        assert!(is_external_import_placeholder(repeated));
 
         let second = link_cross_file(&[build(vec![caller, other])]);
         assert_eq!(second.len(), 2);


### PR DESCRIPTION
## Summary
- validate the complete coherent graph relation snapshot, including relations whose two endpoints are missing
- exempt only canonical external-import placeholder destinations using the producer contract
- report relation and missing-endpoint counts from the inspected snapshot

## Verification
- cargo test -p kin-index external_ (7 passed)
- cargo test -p kin-cli graph_validate (4 passed)
- cargo test -p kin-cli commands::graph::tests:: (14 passed)
- cargo fmt --all -- --check
- git diff --check
- independent review: no P0-P2 findings

## Claims not being made
- This does not repair or rebuild any canonical graph.
- This does not merge or release the change.