### PR TITLE
Enforce hosted graph authority

### DIFF
--- a/crates/kin-core/src/behavior_env.rs
+++ b/crates/kin-core/src/behavior_env.rs
@@ -44,6 +44,7 @@ pub const BEHAVIOR_ENV_VARS: &[&str] = &[
     "KIN_EMBED_CACHE_DIR",
     "KIN_EMBED_BACKEND",
     "KIN_INIT_WARM_CACHE",
+    "KIN_DAEMON_DISABLE_FILESYSTEM_RECONCILE",
     "KIN_DAEMON_LOCATE_ONLY",
     "KIN_COCHANGE_MAX_FAN_OUT",
     "EMBED_MAX_SEQ_LEN",
@@ -174,7 +175,11 @@ mod tests {
 
     #[test]
     fn resume_identity_knobs_are_reported() {
-        for name in ["KIN_DAEMON_LOCATE_ONLY", "KIN_COCHANGE_MAX_FAN_OUT"] {
+        for name in [
+            "KIN_DAEMON_DISABLE_FILESYSTEM_RECONCILE",
+            "KIN_DAEMON_LOCATE_ONLY",
+            "KIN_COCHANGE_MAX_FAN_OUT",
+        ] {
             assert!(
                 BEHAVIOR_ENV_VARS.contains(&name),
                 "daemon health must report resume-identity knob {name}"

--- a/crates/kin-core/src/env_registry.rs
+++ b/crates/kin-core/src/env_registry.rs
@@ -158,6 +158,7 @@ pub const OPERATIONAL: &[EnvVarSpec] = &[
     EnvVarSpec { name: "KIN_BYPASS_EMBEDDING_COVERAGE_CHECK", kind: Kind::Bool, default: "false", sensitivity: Sensitivity::Correctness, summary: "bypass the embedding-coverage correctness gate" },
     EnvVarSpec { name: "KIN_STRICT_BUILD_MATCH", kind: Kind::Bool, default: "false", sensitivity: Sensitivity::Correctness, summary: "require a strict historical build match when resolving a ref view" },
     EnvVarSpec { name: "KIN_ALLOW_MASS_DELETION", kind: Kind::Bool, default: "false", sensitivity: Sensitivity::Correctness, summary: "permit reconcile to apply mass deletions (data-destructive)" },
+    EnvVarSpec { name: "KIN_DAEMON_DISABLE_FILESYSTEM_RECONCILE", kind: Kind::Bool, default: "false", sensitivity: Sensitivity::Correctness, summary: "disable daemon filesystem watching and reconcile/sync ingestion so remote graph authority cannot be overwritten by a checkout" },
     EnvVarSpec { name: "KIN_WRITE_VETO", kind: Kind::OneOf(&["warn", "enforce", "off"]), default: "warn", sensitivity: Sensitivity::Correctness, summary: "write-veto mode: 'warn' (default) annotates would-be vetoes into foreign-held scopes, 'enforce' rejects them with a 409, 'off' disables" },
     EnvVarSpec { name: "KIN_DAEMON_LOCATE_ONLY", kind: Kind::Bool, default: "false", sensitivity: Sensitivity::Correctness, summary: "daemon serves locate-only from a snapshot, changing what it answers" },
     EnvVarSpec { name: "KIN_DAEMON_DISABLE_LSP", kind: Kind::Bool, default: "false", sensitivity: Sensitivity::Correctness, summary: "disable LSP enrichment in the daemon, reducing relation coverage" },
@@ -949,6 +950,7 @@ mod tests {
     fn known_hazard_vars_are_present_and_correctness_relevant() {
         for name in [
             "KIN_INIT_WARM_CACHE",
+            "KIN_DAEMON_DISABLE_FILESYSTEM_RECONCILE",
             "KIN_LOCATE_MULTIHOP_TIMEOUT_MS",
             "KIN_LOCATE_RERANK_LATENCY_BUDGET_MS",
             "KIN_LOCATE_TOTAL_TIMEOUT_SECS",

--- a/crates/kin-daemon/src/api.rs
+++ b/crates/kin-daemon/src/api.rs
@@ -98,6 +98,17 @@ pub struct HealthResponse {
     /// until restart. A true value drives `status: "attention"`.
     #[serde(default)]
     pub embed_worker_failed: bool,
+    /// Whether this daemon's storage backend lacks a durable persistence
+    /// contract for embedding/vector sidecars. This is distinct from a worker
+    /// crash: the worker is intentionally disabled and `/embed` fails closed.
+    /// A true value drives `status: "attention"`.
+    #[serde(default)]
+    pub embed_persistence_unavailable: bool,
+    /// Effective filesystem-to-graph admission policy. This reports the frozen
+    /// daemon state, including intrinsic storage-backend graph authority, not
+    /// merely whether the opt-in environment variable was present.
+    #[serde(default)]
+    pub filesystem_reconcile_disabled: bool,
     /// Monotonic authority-head marker (`.kin/kindb/head-generation`), bumped
     /// when the daemon commits a newer graph snapshot. A freshness token that
     /// lets clients and the MCP envelope express `graph_as_of` and detect stale
@@ -306,6 +317,10 @@ pub struct RepoHealthResponse {
     pub mass_deletion_blocked: bool,
     #[serde(default)]
     pub embed_worker_failed: bool,
+    #[serde(default)]
+    pub embed_persistence_unavailable: bool,
+    #[serde(default)]
+    pub filesystem_reconcile_disabled: bool,
 }
 
 /// Repo entities search response.
@@ -1347,12 +1362,14 @@ async fn health(
     let embed_worker_failed = state
         .embed_worker_failed
         .load(std::sync::atomic::Ordering::Relaxed);
+    let embed_persistence_unavailable = !state.can_persist_embed_progress_locally();
     // Surface graph-safety + derived-index health in the top-level status so an
     // operator or client polling /health sees a non-"ok" signal when the daemon
     // is withholding a suspected mass-deletion wipe OR the embedding worker has
-    // permanently stopped (embed-degraded). The graph itself stays intact and
-    // served in both cases.
-    let status = if mass_deletion_blocked || embed_worker_failed {
+    // permanently stopped (embed-degraded), OR the configured storage backend
+    // cannot durably persist vector progress. The graph itself stays intact and
+    // served in all cases.
+    let status = if mass_deletion_blocked || embed_worker_failed || embed_persistence_unavailable {
         "attention"
     } else {
         "ok"
@@ -1381,6 +1398,8 @@ async fn health(
         initialized,
         mass_deletion_blocked,
         embed_worker_failed,
+        embed_persistence_unavailable,
+        filesystem_reconcile_disabled: state.filesystem_reconcile_disabled(),
         graph_generation: DaemonState::read_generation_marker(&state.layout),
         behavior_env: kin_core::behavior_env::snapshot_from_process(),
         build: current_build_response(),
@@ -2570,6 +2589,13 @@ async fn command_commit(
     State(state): State<Arc<DaemonState>>,
     Json(request): Json<CommandCommitRequest>,
 ) -> Result<impl IntoResponse, (StatusCode, String)> {
+    if state.filesystem_reconcile_disabled() {
+        return Err(filesystem_ingest_disabled_response(
+            "/commands/commit",
+            &state.layout.working_dir().display().to_string(),
+        ));
+    }
+
     // Force a filesystem sync to guarantee the daemon has reconciled all offline changes
     // before building the commit deltas.
     let _ = crate::loop_runner::sync_filesystem_with_graph(&state).await;
@@ -3839,6 +3865,13 @@ async fn embed(
             ));
         }
 
+        if !state.can_persist_embed_progress_locally() {
+            return Err((
+                StatusCode::SERVICE_UNAVAILABLE,
+                "embedding unavailable: storage-backend graph authority has no durable vector-sidecar persistence contract; refusing a local derived-index checkpoint while graph serving remains available".to_string(),
+            ));
+        }
+
         let state_for_embed = Arc::clone(&state);
         let result = tokio::task::spawn_blocking(move || {
             let bounded_request = req.max_seconds.is_some_and(|seconds| seconds > 0);
@@ -4131,6 +4164,16 @@ async fn reconcile(
         return Err((
             StatusCode::SERVICE_UNAVAILABLE,
             "daemon not fully initialized".to_string(),
+        ));
+    }
+
+    if state.filesystem_reconcile_disabled() {
+        return Err((
+            StatusCode::CONFLICT,
+            format!(
+                "filesystem reconcile is disabled by {}; remote graph authority cannot ingest a session checkout",
+                crate::loop_runner::DISABLE_FILESYSTEM_RECONCILE_ENV
+            ),
         ));
     }
 
@@ -5750,6 +5793,8 @@ async fn repo_health(
         embed_worker_failed: state
             .embed_worker_failed
             .load(std::sync::atomic::Ordering::Relaxed),
+        embed_persistence_unavailable: !state.can_persist_embed_progress_locally(),
+        filesystem_reconcile_disabled: state.filesystem_reconcile_disabled(),
     }))
 }
 
@@ -7145,6 +7190,26 @@ fn attach_veto_warning(
     body
 }
 
+/// Build the fail-closed response used by filesystem notification endpoints
+/// when this daemon is running with graph-only authority. Keep this check ahead
+/// of write-veto and reconciler acquisition: these routes must not even begin a
+/// filesystem-to-graph attempt in this mode.
+fn filesystem_ingest_disabled_response(endpoint: &str, path: &str) -> (StatusCode, String) {
+    (
+        StatusCode::CONFLICT,
+        json!({
+            "error": "filesystem_reconcile_disabled",
+            "endpoint": endpoint,
+            "path": path,
+            "reindexed": false,
+            "mutation_applied": false,
+            "authority": "graph",
+            "configuration": crate::loop_runner::DISABLE_FILESYSTEM_RECONCILE_ENV,
+        })
+        .to_string(),
+    )
+}
+
 /// POST /vfs/file-changed — notify the daemon that a file was modified on disk.
 ///
 /// Triggers reconciliation for the specified path. Used by the VFS write-back
@@ -7153,6 +7218,13 @@ async fn vfs_file_changed(
     State(state): State<Arc<DaemonState>>,
     Json(request): Json<FileChangedRequest>,
 ) -> Result<impl IntoResponse, (StatusCode, String)> {
+    if state.filesystem_reconcile_disabled() {
+        return Err(filesystem_ingest_disabled_response(
+            "/vfs/file-changed",
+            &request.path,
+        ));
+    }
+
     let file_path = std::path::PathBuf::from(&request.path);
     tracing::info!(path = %request.path, "VFS file-changed notification received");
 
@@ -7336,6 +7408,13 @@ async fn vfs_write_notify(
     State(state): State<Arc<DaemonState>>,
     Json(request): Json<WriteNotifyRequest>,
 ) -> Result<impl IntoResponse, (StatusCode, String)> {
+    if state.filesystem_reconcile_disabled() {
+        return Err(filesystem_ingest_disabled_response(
+            "/vfs/write-notify",
+            &request.file_path,
+        ));
+    }
+
     let file_path = std::path::PathBuf::from(&request.file_path);
     tracing::info!(path = %request.file_path, "VFS write-notify received");
 
@@ -7818,9 +7897,17 @@ async fn spine_refresh_cross_repo_edges(
 }
 
 /// POST /lsp/sweep — trigger a full LSP cold sweep of all entities.
-async fn lsp_sweep(State(state): State<Arc<DaemonState>>) -> impl IntoResponse {
+async fn lsp_sweep(
+    State(state): State<Arc<DaemonState>>,
+) -> Result<impl IntoResponse, (StatusCode, String)> {
+    if state.filesystem_reconcile_disabled() {
+        return Err(filesystem_ingest_disabled_response(
+            "/lsp/sweep",
+            &state.layout.working_dir().display().to_string(),
+        ));
+    }
     state.queue_lsp_sweep();
-    Json(json!({"status": "sweep_queued"}))
+    Ok(Json(json!({"status": "sweep_queued"})))
 }
 
 /// Parse an entity kind string into an EntityKind enum value.
@@ -9167,8 +9254,130 @@ mod tests {
         assert_eq!(json.build.sha, kin_buildinfo::get().sha);
         assert_eq!(json.build.dirty, kin_buildinfo::get().dirty);
         assert!(!json.build.built_at.is_empty());
+        assert!(
+            !json.embed_persistence_unavailable,
+            "local SnapshotManager authority must retain embedding persistence"
+        );
+        assert!(
+            !json.filesystem_reconcile_disabled,
+            "local authority remains file-compatible unless explicitly disabled"
+        );
         // Additive freshness marker present; 0 before any snapshot is committed.
         assert_eq!(json.graph_generation, 0);
+    }
+
+    #[tokio::test]
+    async fn hosted_health_surfaces_embed_persistence_unavailable_attention() {
+        let dir = std::env::temp_dir().join(format!("kin-daemon-hosted-health-{}", Uuid::new_v4()));
+        let kin_dir = dir.join(".kin");
+        std::fs::create_dir_all(kin_dir.join("objects")).unwrap();
+        std::fs::create_dir_all(kin_dir.join("working")).unwrap();
+        let layout = kin_core::KinLayout::new(kin_dir);
+        kin_core::manifest::KinManifest::new()
+            .save(&layout.manifest_path())
+            .unwrap();
+        let backend_dir = dir.join("backend");
+        std::fs::create_dir_all(&backend_dir).unwrap();
+        let state = Arc::new(
+            DaemonState::open_with_backend(
+                layout,
+                Box::new(kin_db::LocalFileBackend::new(&backend_dir)),
+                "hosted-health",
+                None,
+            )
+            .unwrap(),
+        );
+
+        let response = router(state)
+            .oneshot(Request::get("/health").body(Body::empty()).unwrap())
+            .await
+            .unwrap();
+        assert_eq!(response.status(), StatusCode::OK);
+        let body = axum::body::to_bytes(response.into_body(), 4096)
+            .await
+            .unwrap();
+        let json: HealthResponse = serde_json::from_slice(&body).unwrap();
+        assert_eq!(json.status, "attention");
+        assert!(json.embed_persistence_unavailable);
+        assert!(
+            json.filesystem_reconcile_disabled,
+            "StorageBackend authority must intrinsically disable filesystem ingestion"
+        );
+        assert!(
+            !json.embed_worker_failed,
+            "unsupported persistence is a capability degradation, not a worker crash"
+        );
+    }
+
+    #[tokio::test]
+    async fn graph_only_command_commit_fails_before_filesystem_delta_computation() {
+        let state = test_state();
+        state
+            .graph
+            .upsert_entity(&test_entity("remote_authority", "src/remote.rs"))
+            .unwrap();
+        state
+            .filesystem_reconcile_disabled
+            .store(true, std::sync::atomic::Ordering::Relaxed);
+        let root_before = state.graph.compute_root_hash();
+        let snapshot_before = state.graph.to_snapshot().to_bytes().unwrap();
+        let generation_before = state
+            .snapshot_generation
+            .load(std::sync::atomic::Ordering::Relaxed);
+
+        let response = router(Arc::clone(&state))
+            .oneshot(
+                Request::post("/commands/commit")
+                    .header("content-type", "application/json")
+                    .body(Body::from(
+                        json!({ "message": "must not infer emptyDir removals" }).to_string(),
+                    ))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(response.status(), StatusCode::CONFLICT);
+        let body = axum::body::to_bytes(response.into_body(), 4096)
+            .await
+            .unwrap();
+        let json: serde_json::Value = serde_json::from_slice(&body).unwrap();
+        assert_eq!(json["error"], "filesystem_reconcile_disabled");
+        assert_eq!(json["endpoint"], "/commands/commit");
+        assert_eq!(json["mutation_applied"], false);
+        assert_eq!(state.graph.compute_root_hash(), root_before);
+        assert_eq!(
+            state.graph.to_snapshot().to_bytes().unwrap(),
+            snapshot_before
+        );
+        assert_eq!(
+            state
+                .snapshot_generation
+                .load(std::sync::atomic::Ordering::Relaxed),
+            generation_before
+        );
+    }
+
+    #[tokio::test]
+    async fn graph_only_lsp_sweep_fails_closed() {
+        let state = test_state();
+        state
+            .filesystem_reconcile_disabled
+            .store(true, std::sync::atomic::Ordering::Relaxed);
+        let root_before = state.graph.compute_root_hash();
+
+        let response = router(Arc::clone(&state))
+            .oneshot(Request::post("/lsp/sweep").body(Body::empty()).unwrap())
+            .await
+            .unwrap();
+        assert_eq!(response.status(), StatusCode::CONFLICT);
+        let body = axum::body::to_bytes(response.into_body(), 4096)
+            .await
+            .unwrap();
+        let json: serde_json::Value = serde_json::from_slice(&body).unwrap();
+        assert_eq!(json["error"], "filesystem_reconcile_disabled");
+        assert_eq!(json["endpoint"], "/lsp/sweep");
+        assert_eq!(json["mutation_applied"], false);
+        assert_eq!(state.graph.compute_root_hash(), root_before);
     }
 
     #[tokio::test]
@@ -14567,6 +14776,39 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn graph_only_write_notify_fails_before_reindex_or_graph_mutation() {
+        let state = test_state();
+        state
+            .filesystem_reconcile_disabled
+            .store(true, std::sync::atomic::Ordering::Relaxed);
+        let (_, abs) = veto_file_target(&state, "src/graph_only.rs");
+        write_disk_file(
+            &state,
+            "src/graph_only.rs",
+            "pub fn must_not_enter_graph() -> u8 { 7 }\n",
+        );
+        let root_before = state.graph.compute_root_hash();
+        let entities_before = state.graph.entity_count();
+        let version_before = state.vfs_version.load(std::sync::atomic::Ordering::Relaxed);
+
+        let (status, json) = write_notify(
+            router(Arc::clone(&state)),
+            serde_json::json!({ "file_path": abs }),
+        )
+        .await;
+
+        assert_eq!(status, StatusCode::CONFLICT);
+        assert_eq!(json["error"], "filesystem_reconcile_disabled");
+        assert_eq!(json["reindexed"], false);
+        assert_eq!(state.graph.compute_root_hash(), root_before);
+        assert_eq!(state.graph.entity_count(), entities_before);
+        assert_eq!(
+            state.vfs_version.load(std::sync::atomic::Ordering::Relaxed),
+            version_before
+        );
+    }
+
+    #[tokio::test]
     async fn write_notify_enforce_foreign_hard_intent_returns_409() {
         let _lock = VETO_ENV_LOCK.lock().await;
         let state = test_state();
@@ -14782,6 +15024,39 @@ mod tests {
             .unwrap();
         let json = serde_json::from_slice(&bytes).unwrap_or(serde_json::Value::Null);
         (status, json)
+    }
+
+    #[tokio::test]
+    async fn graph_only_file_changed_fails_before_reconcile_or_graph_mutation() {
+        let state = test_state();
+        state
+            .filesystem_reconcile_disabled
+            .store(true, std::sync::atomic::Ordering::Relaxed);
+        let (_, abs) = veto_file_target(&state, "src/graph_only_changed.rs");
+        write_disk_file(
+            &state,
+            "src/graph_only_changed.rs",
+            "pub fn must_not_reconcile() -> u8 { 9 }\n",
+        );
+        let root_before = state.graph.compute_root_hash();
+        let entities_before = state.graph.entity_count();
+        let version_before = state.vfs_version.load(std::sync::atomic::Ordering::Relaxed);
+
+        let (status, json) = file_changed(
+            router(Arc::clone(&state)),
+            serde_json::json!({ "path": abs }),
+        )
+        .await;
+
+        assert_eq!(status, StatusCode::CONFLICT);
+        assert_eq!(json["error"], "filesystem_reconcile_disabled");
+        assert_eq!(json["reindexed"], false);
+        assert_eq!(state.graph.compute_root_hash(), root_before);
+        assert_eq!(state.graph.entity_count(), entities_before);
+        assert_eq!(
+            state.vfs_version.load(std::sync::atomic::Ordering::Relaxed),
+            version_before
+        );
     }
 
     #[tokio::test]

--- a/crates/kin-daemon/src/daemon.rs
+++ b/crates/kin-daemon/src/daemon.rs
@@ -52,6 +52,10 @@ impl Default for DaemonConfig {
     }
 }
 
+fn should_enable_lsp_enrichment(config_enabled: bool, filesystem_reconcile_disabled: bool) -> bool {
+    config_enabled && !filesystem_reconcile_disabled
+}
+
 fn idle_check_interval(idle_timeout: Duration) -> Duration {
     let millis = (idle_timeout.as_millis() / 4).clamp(100, 5_000) as u64;
     Duration::from_millis(millis)
@@ -491,7 +495,10 @@ pub async fn run(mut state: DaemonState, config: DaemonConfig) -> Result<()> {
     }
 
     // Set up LSP enrichment channel before wrapping state in Arc.
-    let lsp_rx = if config.lsp_enabled {
+    let lsp_rx = if should_enable_lsp_enrichment(
+        config.lsp_enabled,
+        state.filesystem_reconcile_disabled(),
+    ) {
         let discovered = kin_lsp::discovery::discover_servers();
         if !discovered.is_empty() {
             info!(
@@ -507,6 +514,11 @@ pub async fn run(mut state: DaemonState, config: DaemonConfig) -> Result<()> {
             None
         }
     } else {
+        if config.lsp_enabled && state.filesystem_reconcile_disabled() {
+            info!(
+                "LSP discovery and enrichment disabled; filesystem-derived relations cannot mutate graph-only authority"
+            );
+        }
         None
     };
 
@@ -869,6 +881,12 @@ pub async fn run(mut state: DaemonState, config: DaemonConfig) -> Result<()> {
     let embed_pipeline_overlap = config.embed_pipeline_overlap;
     let mut embed_cancel = cancel_rx.clone();
     let embed_handle = tokio::spawn(async move {
+        if !embed_state.can_persist_embed_progress_locally() {
+            warn!(
+                "background embedding worker disabled: storage-backend graph authority has no durable vector-sidecar persistence contract; graph serving remains available"
+            );
+            return;
+        }
         // Wait for the daemon to finish its first reconciliation cycle
         // before starting embedding work — no point embedding an empty graph.
         while !embed_state
@@ -1948,9 +1966,9 @@ async fn select_with_signals(
 #[cfg(all(test, unix))]
 mod tests {
     use super::{
-        drain_pending_flush, next_embed_error_backoff, parse_duration_secs, should_flush_now,
-        watched_process_is_alive, DaemonConfig, DEFAULT_RUNTIME_SHUTDOWN_GRACE,
-        DEFAULT_SHUTDOWN_ESCALATION_GRACE,
+        drain_pending_flush, next_embed_error_backoff, parse_duration_secs,
+        should_enable_lsp_enrichment, should_flush_now, watched_process_is_alive, DaemonConfig,
+        DEFAULT_RUNTIME_SHUTDOWN_GRACE, DEFAULT_SHUTDOWN_ESCALATION_GRACE,
     };
     use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
     use std::sync::Arc;
@@ -1959,6 +1977,14 @@ mod tests {
     #[test]
     fn default_embed_batch_is_backlog_friendly() {
         assert_eq!(DaemonConfig::default().embed_batch_size, 512);
+    }
+
+    #[test]
+    fn graph_only_authority_disables_lsp_discovery_and_worker() {
+        assert!(should_enable_lsp_enrichment(true, false));
+        assert!(!should_enable_lsp_enrichment(true, true));
+        assert!(!should_enable_lsp_enrichment(false, false));
+        assert!(!should_enable_lsp_enrichment(false, true));
     }
 
     #[test]

--- a/crates/kin-daemon/src/loop_runner.rs
+++ b/crates/kin-daemon/src/loop_runner.rs
@@ -17,6 +17,42 @@ use crate::state::{
     RECON_PROCESSING,
 };
 
+pub(crate) const DISABLE_FILESYSTEM_RECONCILE_ENV: &str = "KIN_DAEMON_DISABLE_FILESYSTEM_RECONCILE";
+
+fn env_flag_enabled(value: Option<String>) -> bool {
+    value
+        .as_deref()
+        .map(str::trim)
+        .map(|value| {
+            matches!(
+                value.to_ascii_lowercase().as_str(),
+                "1" | "true" | "yes" | "on"
+            )
+        })
+        .unwrap_or(false)
+}
+
+/// Whether this daemon must treat its remote graph as the only write authority.
+///
+/// This is deliberately independent of `KIN_ALLOW_MASS_DELETION`: graph-only
+/// deployments do not scan an empty/projected checkout in the first place, so
+/// they never need to authorize destructive filesystem reconciliation.
+fn resolve_filesystem_reconcile_disabled(
+    storage_backend_graph_authority: bool,
+    environment_disabled: bool,
+) -> bool {
+    storage_backend_graph_authority || environment_disabled
+}
+
+pub(crate) fn filesystem_reconcile_disabled_at_startup(
+    storage_backend_graph_authority: bool,
+) -> bool {
+    resolve_filesystem_reconcile_disabled(
+        storage_backend_graph_authority,
+        env_flag_enabled(std::env::var(DISABLE_FILESYSTEM_RECONCILE_ENV).ok()),
+    )
+}
+
 /// Configuration for the reconciliation loop.
 #[derive(Debug, Clone)]
 pub struct LoopConfig {
@@ -64,6 +100,20 @@ pub async fn run_loop(
     config: LoopConfig,
     cancel: tokio::sync::watch::Receiver<bool>,
 ) -> Result<()> {
+    if state.filesystem_reconcile_disabled() {
+        info!(
+            env = DISABLE_FILESYSTEM_RECONCILE_ENV,
+            "filesystem watcher and reconciliation loop disabled; remote graph remains authoritative"
+        );
+        let mut cancel = cancel;
+        while !*cancel.borrow() {
+            if cancel.changed().await.is_err() {
+                break;
+            }
+        }
+        return Ok(());
+    }
+
     let working_dir = state.layout.working_dir();
     if is_bare_repository(working_dir) {
         info!(working_dir = %working_dir.display(), "working directory is a bare Git repository; reconciliation loop disabled");
@@ -436,6 +486,54 @@ mod tests {
     use std::path::PathBuf;
 
     #[test]
+    fn graph_only_flag_accepts_only_explicit_truthy_values() {
+        for value in ["1", "true", " TRUE ", "yes", "on", "ON"] {
+            assert!(env_flag_enabled(Some(value.to_string())), "{value}");
+        }
+        for value in ["", "0", "false", "off", "no", "graph-only"] {
+            assert!(!env_flag_enabled(Some(value.to_string())), "{value}");
+        }
+        assert!(!env_flag_enabled(None));
+    }
+
+    #[test]
+    fn storage_backend_graph_authority_cannot_be_reenabled_by_environment() {
+        assert!(!resolve_filesystem_reconcile_disabled(false, false));
+        assert!(resolve_filesystem_reconcile_disabled(false, true));
+        assert!(resolve_filesystem_reconcile_disabled(true, false));
+        assert!(resolve_filesystem_reconcile_disabled(true, true));
+    }
+
+    #[tokio::test]
+    async fn graph_only_mode_skips_direct_sync_and_run_loop_without_mass_delete_override() {
+        let mass_delete_before = std::env::var_os("KIN_ALLOW_MASS_DELETION");
+
+        let repo = tempfile::tempdir().unwrap();
+        std::fs::create_dir_all(repo.path().join("src")).unwrap();
+        std::fs::write(repo.path().join("src/lib.rs"), "pub fn disk_only() {}\n").unwrap();
+        let init = kin_core::init(repo.path()).unwrap();
+        let state = Arc::new(DaemonState::open(init.layout).unwrap());
+        state
+            .filesystem_reconcile_disabled
+            .store(true, std::sync::atomic::Ordering::Relaxed);
+
+        sync_filesystem_with_graph(&state).await.unwrap();
+        assert_eq!(state.graph.entity_count(), 0, "direct sync must be inert");
+
+        let (_cancel_tx, cancel_rx) = tokio::sync::watch::channel(true);
+        run_loop(Arc::clone(&state), LoopConfig::default(), cancel_rx)
+            .await
+            .unwrap();
+        assert_eq!(state.graph.entity_count(), 0, "run loop must be inert");
+        assert!(!state.is_mass_deletion_blocked());
+        assert_eq!(
+            std::env::var_os("KIN_ALLOW_MASS_DELETION"),
+            mass_delete_before,
+            "graph-only mode must not set or clear the mass-deletion escape hatch"
+        );
+    }
+
+    #[test]
     fn dedup_keeps_last_event_per_path() {
         let events = vec![
             FileEvent::Changed(PathBuf::from("/a.rs")),
@@ -628,6 +726,14 @@ fn should_block_mass_deletion(removed: u64, total_graph_files: u64, allow_overri
 
 #[tracing::instrument(skip(state))]
 pub async fn sync_filesystem_with_graph(state: &DaemonState) -> Result<()> {
+    if state.filesystem_reconcile_disabled() {
+        debug!(
+            env = DISABLE_FILESYSTEM_RECONCILE_ENV,
+            "filesystem sync skipped; remote graph remains authoritative"
+        );
+        return Ok(());
+    }
+
     let working_dir = state.layout.working_dir();
     if is_bare_repository(working_dir) {
         debug!(working_dir = %working_dir.display(), "working directory is a bare Git repository; skipping filesystem sync");

--- a/crates/kin-daemon/src/projection_wiring.rs
+++ b/crates/kin-daemon/src/projection_wiring.rs
@@ -124,6 +124,8 @@ pub async fn project_after_mcp_commit(
     ),
     McpProjectionError,
 > {
+    let filesystem_reconcile_disabled = state.filesystem_reconcile_disabled();
+
     // Build a GraphOverlay with entity_mods for every entity that has a source
     // span (placement in a working-directory file). Span-less entities are new
     // graph-only nodes with no file home yet — skip them gracefully.
@@ -178,6 +180,16 @@ pub async fn project_after_mcp_commit(
             }
             if !primed.insert(span.file.clone()) {
                 continue;
+            }
+            if filesystem_reconcile_disabled {
+                return Err(McpProjectionError {
+                    file: entity.file_origin.clone(),
+                    entity_id: entity.id,
+                    reason: format!(
+                        "cold projection cannot be primed from filesystem bytes while {} is enabled; graph commit remains authoritative and no filesystem reparse was attempted",
+                        crate::loop_runner::DISABLE_FILESYSTEM_RECONCILE_ENV
+                    ),
+                });
             }
             let path = state.layout.working_dir().join(span.file.0.as_str());
             if !path.exists() {
@@ -414,7 +426,7 @@ pub async fn project_after_mcp_commit(
     // Metadata-only edits carry no body and are skipped here: their projection is
     // byte-identical, so the LKG baseline already matches and no resync is needed.
     // -----------------------------------------------------------------------
-    if !clean_overlay.entity_bodies.is_empty() {
+    if !clean_overlay.entity_bodies.is_empty() && !filesystem_reconcile_disabled {
         let body_files: HashSet<FilePathId> = clean_overlay
             .entity_mods
             .values()
@@ -444,6 +456,11 @@ pub async fn project_after_mcp_commit(
                 }
             })?;
         }
+    } else if !clean_overlay.entity_bodies.is_empty() {
+        tracing::debug!(
+            env = crate::loop_runner::DISABLE_FILESYSTEM_RECONCILE_ENV,
+            "skipping post-projection filesystem reparse; graph remains authoritative"
+        );
     }
 
     Ok((modified_files, collision_warnings, conflicts))
@@ -796,6 +813,145 @@ mod tests {
         // reconcile sees no delta — the agent's edit is NOT clobbered.
         let mut reconciler2 = state.reconciler.write().await;
         assert_no_clobber(&mut reconciler2, &state, &file_path);
+    }
+
+    #[tokio::test]
+    async fn graph_only_projection_writes_derived_file_without_reingesting_it() {
+        let dir = tempfile::tempdir().unwrap();
+        let state = make_test_state(dir.path());
+        let file_path = dir.path().join("src/lib.rs");
+        std::fs::create_dir_all(file_path.parent().unwrap()).unwrap();
+        let original = b"pub fn foo() -> i32 { 1 }\npub fn bar() -> i32 { 2 }\n";
+        std::fs::write(&file_path, original).unwrap();
+
+        let blob_store = BlobStore::new(state.layout.objects_dir()).unwrap();
+        let mut reconciler = state.reconciler.write().await;
+        let mut overlay = GraphOverlay::default();
+        reconciler
+            .reconcile_file_change(
+                &FileEvent::Changed(file_path.clone()),
+                &blob_store,
+                state.graph.as_ref(),
+                &mut overlay,
+            )
+            .unwrap();
+        let pre_commit_entity = overlay
+            .entity_adds
+            .values()
+            .find(|entity| entity.name == "foo")
+            .cloned()
+            .unwrap();
+        let span = pre_commit_entity.span.clone().unwrap();
+        apply_overlay_to_graph(state.graph.as_ref(), &mut overlay).unwrap();
+        drop(reconciler);
+
+        let mut committed = pre_commit_entity.clone();
+        committed.fingerprint.ast_hash = Hash256::from_bytes([0xee; 32]);
+        state.graph.upsert_entity(&committed).unwrap();
+        state
+            .filesystem_reconcile_disabled
+            .store(true, std::sync::atomic::Ordering::Relaxed);
+
+        let new_body = String::from_utf8_lossy(&original[span.start_byte..span.end_byte])
+            .replace("{ 1 }", "{ 42 }")
+            .into_bytes();
+        let mut bodies = HashMap::new();
+        bodies.insert(pre_commit_entity.id, new_body);
+        let root_before = state.graph.compute_root_hash();
+
+        let (modified_files, warnings, conflicts) =
+            project_after_mcp_commit(&state, std::slice::from_ref(&pre_commit_entity), &bodies)
+                .await
+                .unwrap();
+
+        assert_eq!(modified_files.len(), 1);
+        assert!(warnings.is_empty());
+        assert!(conflicts.is_empty());
+        assert!(std::fs::read_to_string(&file_path)
+            .unwrap()
+            .contains("{ 42 }"));
+        assert_eq!(
+            state.graph.compute_root_hash(),
+            root_before,
+            "graph-only projection must not feed projected bytes back into graph authority"
+        );
+        assert_eq!(
+            state
+                .graph
+                .get_entity(&pre_commit_entity.id)
+                .unwrap()
+                .unwrap()
+                .fingerprint
+                .ast_hash,
+            Hash256::from_bytes([0xee; 32]),
+            "the graph-side commit fingerprint must remain authoritative"
+        );
+    }
+
+    #[tokio::test]
+    async fn graph_only_cold_projection_fails_without_filesystem_priming() {
+        let dir = tempfile::tempdir().unwrap();
+        let state = make_test_state(dir.path());
+        let file_path = dir.path().join("src/lib.rs");
+        std::fs::create_dir_all(file_path.parent().unwrap()).unwrap();
+        let original = b"pub fn foo() -> i32 { 1 }\npub fn bar() -> i32 { 2 }\n";
+        std::fs::write(&file_path, original).unwrap();
+
+        // Seed graph truth with a separate reconciler so the daemon projection
+        // remains cold and would have taken the compatibility prime path.
+        let blob_store = BlobStore::new(state.layout.objects_dir()).unwrap();
+        let mut discover = Reconciler::new(dir.path().to_path_buf());
+        let mut overlay = GraphOverlay::default();
+        discover
+            .reconcile_file_change(
+                &FileEvent::Changed(file_path.clone()),
+                &blob_store,
+                state.graph.as_ref(),
+                &mut overlay,
+            )
+            .unwrap();
+        let pre_commit_entity = overlay
+            .entity_adds
+            .values()
+            .find(|entity| entity.name == "foo")
+            .cloned()
+            .unwrap();
+        let span = pre_commit_entity.span.clone().unwrap();
+        apply_overlay_to_graph(state.graph.as_ref(), &mut overlay).unwrap();
+
+        let mut committed = pre_commit_entity.clone();
+        committed.fingerprint.ast_hash = Hash256::from_bytes([0xef; 32]);
+        state.graph.upsert_entity(&committed).unwrap();
+        state
+            .filesystem_reconcile_disabled
+            .store(true, std::sync::atomic::Ordering::Relaxed);
+
+        let new_body = String::from_utf8_lossy(&original[span.start_byte..span.end_byte])
+            .replace("{ 1 }", "{ 42 }")
+            .into_bytes();
+        let mut bodies = HashMap::new();
+        bodies.insert(pre_commit_entity.id, new_body);
+        let root_before = state.graph.compute_root_hash();
+
+        let error =
+            project_after_mcp_commit(&state, std::slice::from_ref(&pre_commit_entity), &bodies)
+                .await
+                .expect_err("graph-only cold projection must fail before filesystem priming");
+
+        assert!(error.reason.contains("cold projection"), "{error}");
+        assert!(
+            error
+                .reason
+                .contains(crate::loop_runner::DISABLE_FILESYSTEM_RECONCILE_ENV),
+            "{error}"
+        );
+        assert_eq!(state.graph.compute_root_hash(), root_before);
+        assert_eq!(std::fs::read(&file_path).unwrap(), original);
+        let reconciler = state.reconciler.read().await;
+        assert!(
+            reconciler.projection().get_content(&span.file).is_none(),
+            "fail-closed graph-only projection must not prime from filesystem bytes"
+        );
     }
 
     // ------------------------------------------------------------------

--- a/crates/kin-daemon/src/state.rs
+++ b/crates/kin-daemon/src/state.rs
@@ -361,6 +361,10 @@ pub struct DaemonState {
     /// `None` = legacy file-based path (via SnapshotManager).
     /// `Some` = StorageBackend (LocalFile for CLI, GCS for cloud).
     pub storage_backend: Option<Box<dyn StorageBackend>>,
+    /// Frozen startup policy for deployments whose graph backend is the only
+    /// write authority. When true, no filesystem/session/VFS compatibility
+    /// surface may reconcile bytes back into graph truth.
+    pub(crate) filesystem_reconcile_disabled: AtomicBool,
     /// Generation from the last snapshot load (for CAS on save).
     pub snapshot_generation: AtomicU64,
     /// A graph authority commit advanced, but its local generation marker and
@@ -744,6 +748,9 @@ impl DaemonState {
             is_initialized: AtomicBool::new(loaded_snapshot),
             reconciliation_status: AtomicU8::new(RECON_IDLE),
             storage_backend: None,
+            filesystem_reconcile_disabled: AtomicBool::new(
+                crate::loop_runner::filesystem_reconcile_disabled_at_startup(false),
+            ),
             snapshot_generation: AtomicU64::new(generation),
             post_commit_finalization_pending: AtomicBool::new(false),
             pending_persistence_event: Mutex::new(None),
@@ -897,6 +904,9 @@ impl DaemonState {
             is_initialized: AtomicBool::new(loaded_snapshot),
             reconciliation_status: AtomicU8::new(RECON_IDLE),
             storage_backend: Some(backend),
+            filesystem_reconcile_disabled: AtomicBool::new(
+                crate::loop_runner::filesystem_reconcile_disabled_at_startup(true),
+            ),
             snapshot_generation: AtomicU64::new(generation),
             post_commit_finalization_pending: AtomicBool::new(false),
             pending_persistence_event: Mutex::new(None),
@@ -1777,6 +1787,37 @@ impl DaemonState {
         self.save_snapshot_impl(true, None)
     }
 
+    /// Whether derived embedding progress can be committed through the local
+    /// `SnapshotManager` authority path.
+    ///
+    /// A configured `StorageBackend` owns a distinct generation cursor (GCS in
+    /// hosted deployments). Until that backend has an explicit vector-sidecar
+    /// persistence contract, writing local embed progress with its generation is
+    /// unsafe and must fail loud rather than fabricate a durable checkpoint.
+    pub(crate) fn can_persist_embed_progress_locally(&self) -> bool {
+        self.storage_backend.is_none()
+    }
+
+    /// Whether filesystem-to-graph compatibility ingestion is disabled for
+    /// this daemon. The value is captured when state opens so runtime behavior
+    /// cannot drift if the process environment later changes.
+    pub(crate) fn filesystem_reconcile_disabled(&self) -> bool {
+        self.filesystem_reconcile_disabled.load(Ordering::Relaxed)
+    }
+
+    #[cfg(any(feature = "embeddings", feature = "vector"))]
+    fn reject_remote_backend_embed_persistence(&self, operation: &str) -> Result<()> {
+        if self.can_persist_embed_progress_locally() {
+            return Ok(());
+        }
+        let generation = self.snapshot_generation.load(Ordering::SeqCst);
+        Err(DaemonError::Graph(kin_db::KinDbError::StorageError(
+            format!(
+                "{operation} skipped: storage-backend graph authority is at generation {generation}, and no backend vector-sidecar persistence contract exists; refusing to write a local SnapshotManager checkpoint against remote authority"
+            ),
+        )))
+    }
+
     fn save_snapshot_impl(&self, force_full: bool, event: Option<DaemonEvent>) -> Result<()> {
         // Serialize the whole kndb + generation-marker + kidx write sequence
         // against any other save (persist loop, idle flush, embed worker).
@@ -1929,6 +1970,7 @@ impl DaemonState {
     /// coverage.
     #[cfg(feature = "embeddings")]
     pub fn flush_embed_progress(&self) -> Result<usize> {
+        self.reject_remote_backend_embed_persistence("embed progress persistence")?;
         let _persist_guard = self
             .persist_lock
             .lock()
@@ -1979,6 +2021,7 @@ impl DaemonState {
     /// batch.
     #[cfg(feature = "vector")]
     pub fn persist_vector_sidecar(&self) -> Result<()> {
+        self.reject_remote_backend_embed_persistence("vector sidecar persistence")?;
         let _persist_guard = self
             .persist_lock
             .lock()
@@ -2532,6 +2575,9 @@ impl DaemonState {
     /// Queue changed entities for background LSP enrichment (non-blocking).
     /// No-op if LSP enrichment is not available.
     pub fn queue_lsp_enrichment(&self, request: LspEnrichmentRequest) {
+        if self.filesystem_reconcile_disabled() {
+            return;
+        }
         if let Some(ref tx) = self.lsp_enrichment_tx {
             if let Err(tokio::sync::mpsc::error::TrySendError::Full(_)) =
                 tx.try_send(LspEnrichmentMessage::Incremental(request))
@@ -2544,6 +2590,9 @@ impl DaemonState {
     /// Queue a cold sweep that enriches ALL entities in the graph via LSP.
     /// Triggered after init/migrate/reconcile. No-op if LSP enrichment is not available.
     pub fn queue_lsp_sweep(&self) {
+        if self.filesystem_reconcile_disabled() {
+            return;
+        }
         if let Some(ref tx) = self.lsp_enrichment_tx {
             if let Err(tokio::sync::mpsc::error::TrySendError::Full(_)) =
                 tx.try_send(LspEnrichmentMessage::Sweep)
@@ -2789,6 +2838,7 @@ mod tests {
             is_initialized: AtomicBool::new(false),
             reconciliation_status: AtomicU8::new(RECON_IDLE),
             storage_backend: None,
+            filesystem_reconcile_disabled: AtomicBool::new(false),
             snapshot_generation: AtomicU64::new(snapshot_generation),
             post_commit_finalization_pending: AtomicBool::new(false),
             pending_persistence_event: Mutex::new(None),
@@ -4473,6 +4523,64 @@ mod tests {
             pending >= 1,
             "the unembedded entity must remain pending (no embedder ran); got {pending}"
         );
+    }
+
+    #[cfg(feature = "embeddings")]
+    #[test]
+    fn storage_backend_embed_progress_fails_before_local_snapshot_write() {
+        use kin_db::LocalFileBackend;
+
+        let repo_dir = tempfile::tempdir().unwrap();
+        let init = kin_core::init(repo_dir.path()).unwrap();
+        let layout = init.layout;
+        let snapshot_path = layout.kindb_snapshot_path();
+        let storage = tempfile::tempdir().unwrap();
+        let state = DaemonState::open_with_backend(
+            layout,
+            Box::new(LocalFileBackend::new(storage.path())),
+            "remote-embed-authority",
+            None,
+        )
+        .unwrap();
+        state
+            .graph
+            .upsert_entity(&test_entity("embed_me", "src/lib.rs"))
+            .unwrap();
+        state
+            .save_snapshot_full()
+            .expect("seed remote authority at the local authority generation");
+        state.graph.queue_missing_for_embedding();
+
+        let local_before = kin_db::SnapshotManager::open_read_only(snapshot_path.as_path())
+            .expect("kin init creates a local authority fixture");
+        let local_generation_before = local_before.generation();
+        let local_entities_before = local_before.graph().entity_count();
+        drop(local_before);
+        assert_eq!(
+            state.snapshot_generation.load(Ordering::SeqCst),
+            local_generation_before,
+            "the fixture must align generations so an unguarded local flush would mutate"
+        );
+        let error = state
+            .flush_embed_progress()
+            .expect_err("remote authority must reject local embed checkpoints");
+        let message = error.to_string();
+        assert!(
+            message.contains("storage-backend graph authority"),
+            "{message}"
+        );
+        assert!(
+            message.contains("refusing to write a local SnapshotManager checkpoint"),
+            "{message}"
+        );
+        assert_eq!(
+            state.snapshot_generation.load(Ordering::SeqCst),
+            local_generation_before
+        );
+        let local_after = kin_db::SnapshotManager::open_read_only(snapshot_path.as_path())
+            .expect("guard must preserve local authority");
+        assert_eq!(local_after.generation(), local_generation_before);
+        assert_eq!(local_after.graph().entity_count(), local_entities_before);
     }
 
     #[test]

--- a/docs/env-vars.md
+++ b/docs/env-vars.md
@@ -3,7 +3,7 @@
 
 # Kin environment variables
 
-This is the authoritative list of supported `KIN_*` environment variables (403 total, 301 correctness-relevant), generated from the central registry in `kin-core`.
+This is the authoritative list of supported `KIN_*` environment variables (404 total, 302 correctness-relevant), generated from the central registry in `kin-core`.
 
 At CLI and daemon startup Kin validates this surface (`KIN_ENV_VALIDATION`, default `warn`):
 
@@ -78,6 +78,7 @@ Sensitivity legend: **correctness** (affects retrieval/ranking/output or data sa
 | `KIN_DAEMON_BIND_HOST` | string | *(unset)* | operational | host/interface the daemon binds its HTTP endpoint to |
 | `KIN_DAEMON_BOOTSTRAP_EXPORT_CONCURRENCY` | usize | *(unset)* | operational | concurrency for the daemon bootstrap export |
 | `KIN_DAEMON_BOOTSTRAP_TIMEOUT_SECS` | seconds>=0 | *(unset)* | operational | timeout for daemon bootstrap-as-admin |
+| `KIN_DAEMON_DISABLE_FILESYSTEM_RECONCILE` | bool | false | correctness | disable daemon filesystem watching and reconcile/sync ingestion so remote graph authority cannot be overwritten by a checkout |
 | `KIN_DAEMON_DISABLE_LSP` | bool | false | correctness | disable LSP enrichment in the daemon, reducing relation coverage |
 | `KIN_DAEMON_EMBED_BATCH_SIZE` | usize | *(unset)* | operational | embedding batch size for daemon-side embed passes |
 | `KIN_DAEMON_EXISTING_READY_TIMEOUT_SECS` | seconds>=0 | 3 | operational | readiness wait for an already-running daemon |


### PR DESCRIPTION
## Summary

- make every StorageBackend-backed daemon intrinsically graph-authoritative
- fail closed before filesystem reconcile, thin commit, VFS notification, LSP enrichment, or post-projection reparse can feed projection bytes into graph truth
- expose the effective authority mode and intentional hosted embed-persistence limitation through health

## Verification

- `cargo test -p kin-daemon`: 357 library, 3 binary, and 5 integration tests passed
- focused graph-only authority tests: 9/9 passed
- `cargo test -p kin-core`: 268/268 passed
- default and no-default-feature daemon checks passed
- formatting, env-doc consistency, and `git diff --check` passed
- independent review: no P0-P2 findings

## Rollout

Kin must merge and release first. The dependent Kin Infra change may merge only after the released daemon carries this contract; staging and production proof remain separate gates.

Not claiming: merged, released, deployed, production-verified, graph-repaired, or investor-citable.