### PR TITLE
docs: align tagline with proves-the-change positioning

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Kin
 
-> **AI writes code. Kin proves it safe to ship.**
+> **AI writes code. Kin proves the change.**
 >
 > The **system of record for AI-written software**.
 


### PR DESCRIPTION
Aligns the repo tagline with the founder-ratified positioning already live on kinlab.ai.

New verb line: "AI writes code. Kin proves the change."

This replaces the prior verb line ("proves it safe to ship" / "records what it means"). The category noun ("the system of record for AI-written software") is unchanged and already correct. Docs/marketing copy only: a single tagline line in README.md. No code, workflow, or dependency changes.