### PR TITLE
Bump open to 5.4.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4221,9 +4221,9 @@ checksum = "c08d65885ee38876c4f86fa503fb49d7b507c2b62552df7c70b2fce627e06381"
 
 [[package]]
 name = "open"
-version = "5.3.6"
+version = "5.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cd8d3b65c44123a56e0133d2cd06ce4361bd3ca99d41198b2f25e3c3db9b8b4a"
+checksum = "a0b3d059e795d52b8a72fef45658620edd4d9c359b338564aa14391ffa511ed5"
 dependencies = [
  "is-wsl",
  "libc",


### PR DESCRIPTION
Replaces #360 on the post-graph-authority mainline. The original Dependabot branch conflicted after the serialized merge wave, and merging main into that old branch made the repository DCO range include unsigned GitHub merge commits. This replacement is a single signed lockfile update generated from current main.

Verification:
- cargo metadata --locked --no-deps --format-version 1
- git diff --check

Signed-off-by: Troy Fortin <troy@firelock.ai>