### PR TITLE
Bump kin-lsp to 0.2.3

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3265,9 +3265,9 @@ dependencies = [
 
 [[package]]
 name = "kin-lsp"
-version = "0.2.2"
+version = "0.2.3"
 source = "sparse+https://kinlab.ai/registry/cargo/"
-checksum = "b6f4d495f89be0c1538ae99be3855fca0469c0c68be5522aac1caa04f02e0f51"
+checksum = "18c12c2c4ceea690f0a587d58a7b6d1ad8a177f2fbe2a79fc990dd680b2b0d8c"
 dependencies = [
  "kin-model",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -139,7 +139,7 @@ kin-daemon = { path = "crates/kin-daemon" }
 kin-mcp = { path = "crates/kin-mcp" }
 kin-spine = { path = "crates/kin-spine" }
 kin-registry = { path = "crates/kin-registry" }
-kin-lsp = { version = "0.2.2", registry = "kin" }
+kin-lsp = { version = "0.2.3", registry = "kin" }
 # Cross-platform base: NO "metal" here. `[workspace.dependencies]` entries cannot be
 # `[target.'cfg(...)']`-gated, so listing "metal" here forces the macOS-only kin-infer/metal
 # backend on every target (incl. Linux, where it cannot compile). Metal is re-enabled


### PR DESCRIPTION
Closes the final release-clean freshness warning before v0.2.25.

- require the already-published `kin-lsp` 0.2.3
- update only the locked version and published registry checksum
- preserve every other dependency pin

Verification:
- registry metadata and checksum verified directly for 0.2.3
- patch-off `cargo metadata --locked` outside `$HOME`
- patch-off `cargo check --locked -p kin-cli --no-default-features` outside `$HOME`

This PR does not tag or publish v0.2.25.