### PR TITLE
Consume kin-db authority recovery fix

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -135,7 +135,7 @@ version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -146,7 +146,7 @@ checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -1067,7 +1067,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users 0.5.2",
- "windows-sys 0.59.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -1176,7 +1176,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.59.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -3131,9 +3131,9 @@ dependencies = [
 
 [[package]]
 name = "kin-db"
-version = "0.2.38"
+version = "0.2.39"
 source = "sparse+https://kinlab.ai/registry/cargo/"
-checksum = "6fa139ef291c5436b6fac9d1bf4aeeb2c07e9171562654bec0dd5a819d82f14d"
+checksum = "e70759792c8a050ac85ff72acfd0b0d563cddd8aba8a3e1876f9fd683ede25a1"
 dependencies = [
  "bincode",
  "bytes",
@@ -3927,7 +3927,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -4422,7 +4422,7 @@ dependencies = [
  "once_cell",
  "socket2",
  "tracing",
- "windows-sys 0.59.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -4826,7 +4826,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.59.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -4885,7 +4885,7 @@ dependencies = [
  "security-framework 3.7.0",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.59.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -5329,7 +5329,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "52d1cfed4120b4d927bf7c0f86d2087a4a7d6027c906d9f9d525a80573b9be51"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -5462,7 +5462,7 @@ dependencies = [
  "getrandom 0.4.3",
  "once_cell",
  "rustix",
- "windows-sys 0.59.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -6395,7 +6395,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.48.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -145,7 +145,7 @@ kin-lsp = { version = "0.2.3", registry = "kin" }
 # backend on every target (incl. Linux, where it cannot compile). Metal is re-enabled
 # additively on macOS via a `[target.'cfg(target_os = "macos")'.dependencies]` block in the
 # binary/runtime crates (kin-cli, kin-daemon). Feature unification makes that additive.
-kin-db = { version = "0.2.38", registry = "kin", default-features = false }
+kin-db = { version = "0.2.39", registry = "kin", default-features = false }
 kin-vfs-core = { version = "0.1.5", registry = "kin" }
 
 [profile.release]


### PR DESCRIPTION
## Summary

- consume published kin-db 0.2.39 from the Kin registry
- preserve registry source and checksum authority in Cargo.lock
- unblock content-addressed legacy authority recovery for the KinLab graph

## Verification

- cargo fmt -- --check
- python3 scripts/verify-zero-file-search.py
- CI-equivalent cargo clippy allowlist with RUSTFLAGS=-D warnings
- scripts/check_runtime_boundaries.sh
- scripts/check_private_repo_coupling.sh
- cargo build --all-targets --locked
- cargo test --locked
- cargo build --release --locked -p kin-cli -p kin-daemon
- exact published kin-db 0.2.39 archive recovery rehearsal: generation 6 to 7, root unchanged at 9488966da0758dc6eae999b38afc0bbf86abd243304ea6ddf45e6b31fdff77fa, 5,391 entities, 14,300 authoritative relations, workspace_source_files_read=false
- matching release daemon reopened the recovered graph; graph status reported 5,391 entities and 443 files

## Scope

This is the minimal downstream dependency wave for firelock-ai/kin-db#110. It does not claim the final v0.2.25 release or investor proof until this exact head passes hosted gates, registry-only release-check, sealed proof, and live KinLab recovery.
