### PR TITLE
Fix install proof schema and stage v0.2.26

### DIFF
--- a/.github/workflows/install-proof.yml
+++ b/.github/workflows/install-proof.yml
@@ -232,7 +232,7 @@ jobs:
             "release provenance checksum does not match its public sidecar");
 
           const manifest = JSON.parse(fs.readFileSync("release-provenance.json", "utf8"));
-          fail(manifest.schema_version === 1, "release provenance schema is unsupported");
+          fail(manifest.schema_version === 2, "release provenance schema is unsupported");
           fail(manifest.release_tag === process.env.EXPECTED_TAG,
             "release provenance tag does not match the installed release");
           fail(manifest.kin?.commit === process.env.EXPECTED_COMMIT,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.2.26] - 2026-07-20
+
+### Fixed
+
+- Public install proof now accepts the aggregate release-provenance schema
+  emitted by the protected publisher, restoring the fail-closed promotion path
+  for stable GitHub, npm, container, Homebrew, and installer releases.
+
 ## [0.2.25] - 2026-07-19
 
 This patch strengthens graph authority across local, hosted, and recovery paths,
@@ -673,7 +681,8 @@ Historical note: this snapshot predates the public GitHub prerelease series and 
 - Daemon mode for background file watching (`kin-daemon`)
 - 19-crate workspace architecture
 
-[unreleased]: https://github.com/firelock-ai/kin/compare/v0.2.25...HEAD
+[unreleased]: https://github.com/firelock-ai/kin/compare/v0.2.26...HEAD
+[0.2.26]: https://github.com/firelock-ai/kin/compare/v0.2.25...v0.2.26
 [0.2.25]: https://github.com/firelock-ai/kin/compare/v0.2.24...v0.2.25
 [0.2.24]: https://github.com/firelock-ai/kin/compare/v0.2.23...v0.2.24
 [0.2.23]: https://github.com/firelock-ai/kin/compare/v0.2.22...v0.2.23

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2963,14 +2963,14 @@ dependencies = [
 
 [[package]]
 name = "kin-buildinfo"
-version = "0.2.25"
+version = "0.2.26"
 dependencies = [
  "sha2 0.11.0",
 ]
 
 [[package]]
 name = "kin-cli"
-version = "0.2.25"
+version = "0.2.26"
 dependencies = [
  "age",
  "anyhow",
@@ -3041,7 +3041,7 @@ dependencies = [
 
 [[package]]
 name = "kin-context"
-version = "0.2.25"
+version = "0.2.26"
 dependencies = [
  "kin-blobs",
  "kin-db",
@@ -3057,7 +3057,7 @@ dependencies = [
 
 [[package]]
 name = "kin-core"
-version = "0.2.25"
+version = "0.2.26"
 dependencies = [
  "chrono",
  "directories 5.0.1",
@@ -3082,7 +3082,7 @@ dependencies = [
 
 [[package]]
 name = "kin-daemon"
-version = "0.2.25"
+version = "0.2.26"
 dependencies = [
  "async-stream",
  "axum",
@@ -3172,7 +3172,7 @@ dependencies = [
 
 [[package]]
 name = "kin-git"
-version = "0.2.25"
+version = "0.2.26"
 dependencies = [
  "chrono",
  "gix",
@@ -3190,7 +3190,7 @@ dependencies = [
 
 [[package]]
 name = "kin-index"
-version = "0.2.25"
+version = "0.2.26"
 dependencies = [
  "hex",
  "kin-blobs",
@@ -3238,7 +3238,7 @@ dependencies = [
 
 [[package]]
 name = "kin-integration-tests"
-version = "0.2.25"
+version = "0.2.26"
 dependencies = [
  "kin-blobs",
  "kin-cli",
@@ -3280,7 +3280,7 @@ dependencies = [
 
 [[package]]
 name = "kin-mcp"
-version = "0.2.25"
+version = "0.2.26"
 dependencies = [
  "kin-blobs",
  "kin-context",
@@ -3307,7 +3307,7 @@ dependencies = [
 
 [[package]]
 name = "kin-migrate"
-version = "0.2.25"
+version = "0.2.26"
 dependencies = [
  "chrono",
  "kin-blobs",
@@ -3349,7 +3349,7 @@ dependencies = [
 
 [[package]]
 name = "kin-parser"
-version = "0.2.25"
+version = "0.2.26"
 dependencies = [
  "kin-model",
  "pretty_assertions",
@@ -3379,7 +3379,7 @@ dependencies = [
 
 [[package]]
 name = "kin-projection"
-version = "0.2.25"
+version = "0.2.26"
 dependencies = [
  "kin-blobs",
  "kin-db",
@@ -3394,7 +3394,7 @@ dependencies = [
 
 [[package]]
 name = "kin-ranking"
-version = "0.2.25"
+version = "0.2.26"
 dependencies = [
  "kin-model",
  "serde",
@@ -3403,7 +3403,7 @@ dependencies = [
 
 [[package]]
 name = "kin-reconcile"
-version = "0.2.25"
+version = "0.2.26"
 dependencies = [
  "kin-blobs",
  "kin-db",
@@ -3423,7 +3423,7 @@ dependencies = [
 
 [[package]]
 name = "kin-registry"
-version = "0.2.25"
+version = "0.2.26"
 dependencies = [
  "axum",
  "base64 0.22.1",
@@ -3448,7 +3448,7 @@ dependencies = [
 
 [[package]]
 name = "kin-remote"
-version = "0.2.25"
+version = "0.2.26"
 dependencies = [
  "chrono",
  "kin-model",
@@ -3464,7 +3464,7 @@ dependencies = [
 
 [[package]]
 name = "kin-review"
-version = "0.2.25"
+version = "0.2.26"
 dependencies = [
  "kin-blobs",
  "kin-db",
@@ -3480,7 +3480,7 @@ dependencies = [
 
 [[package]]
 name = "kin-runtime"
-version = "0.2.25"
+version = "0.2.26"
 dependencies = [
  "chrono",
  "hex",
@@ -3512,7 +3512,7 @@ dependencies = [
 
 [[package]]
 name = "kin-semantic-contracts"
-version = "0.2.25"
+version = "0.2.26"
 dependencies = [
  "kin-db",
  "kin-model",
@@ -3527,7 +3527,7 @@ dependencies = [
 
 [[package]]
 name = "kin-spine"
-version = "0.2.25"
+version = "0.2.26"
 dependencies = [
  "chrono",
  "hashbrown 0.15.5",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,7 +27,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.2.25"
+version = "0.2.26"
 edition = "2021"
 license = "Apache-2.0"
 authors = ["Troy Fortin <troy@firelock.ai>"]

--- a/crates/kin-cli/src/commands/graph_recover.rs
+++ b/crates/kin-cli/src/commands/graph_recover.rs
@@ -175,6 +175,18 @@ struct RepoPaths {
     recovery_lock: PathBuf,
 }
 
+struct RecoveryLock(File);
+
+impl Drop for RecoveryLock {
+    fn drop(&mut self) {
+        // Closing the parent's descriptor is not sufficient if a concurrent
+        // fork inherited the open file description before exec. Explicitly
+        // unlock so an unrelated child cannot extend the recovery critical
+        // section after this guard leaves scope.
+        let _ = FileExt::unlock(&self.0);
+    }
+}
+
 struct ManifestPlan {
     repo_id: String,
     existing: bool,
@@ -1060,7 +1072,7 @@ fn read_generation_file(path: &Path, role: &str) -> Result<u64> {
         .with_context(|| format!("invalid generation in {role} {}", path.display()))
 }
 
-fn acquire_recovery_lock(path: &Path) -> Result<File> {
+fn acquire_recovery_lock(path: &Path) -> Result<RecoveryLock> {
     if let Ok(metadata) = fs::symlink_metadata(path) {
         if !metadata.file_type().is_file() || metadata.file_type().is_symlink() {
             bail!("recovery lock {} is not a regular file", path.display());
@@ -1078,7 +1090,7 @@ fn acquire_recovery_lock(path: &Path) -> Result<File> {
         .with_context(|| format!("failed to open recovery lock {}", path.display()))?;
     file.try_lock_exclusive()
         .with_context(|| format!("another graph authority recovery holds {}", path.display()))?;
-    Ok(file)
+    Ok(RecoveryLock(file))
 }
 
 fn verify_kindb_unlocked(snapshot: &Path) -> Result<()> {
@@ -1641,6 +1653,21 @@ mod tests {
             .to_string()
             .contains("--confirm-quiesced"));
         assert!(!authority_path(&fixture.snapshot).exists());
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn recovery_guard_unlocks_a_duplicated_open_file_description() {
+        let temp = tempfile::tempdir().unwrap();
+        let path = temp.path().join("graph.kndb.recovery.lock");
+        let guard = acquire_recovery_lock(&path).unwrap();
+        let inherited = guard.0.try_clone().unwrap();
+
+        drop(guard);
+        let reacquired = acquire_recovery_lock(&path).unwrap();
+
+        drop(reacquired);
+        drop(inherited);
     }
 
     #[cfg(unix)]

--- a/packages/boundary-contracts/package.json
+++ b/packages/boundary-contracts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kin/boundary-contracts",
-  "version": "0.2.25",
+  "version": "0.2.26",
   "private": false,
   "description": "Shared contracts for Kin ecosystem boundaries.",
   "type": "module",

--- a/packages/kin-mcp/package.json
+++ b/packages/kin-mcp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kinlab/kin-mcp",
-  "version": "0.2.25",
+  "version": "0.2.26",
   "description": "Start Kin's MCP server, the system of record for AI-written software, through an npm-friendly wrapper.",
   "type": "module",
   "bin": {

--- a/packages/kin/package.json
+++ b/packages/kin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kinlab/kin",
-  "version": "0.2.25",
+  "version": "0.2.26",
   "description": "Canonical installer and launcher for Kin, the system of record for AI-written software. Provisions and runs the managed kin + kin-daemon release. MCP is one included mode (kin mcp start).",
   "license": "Apache-2.0",
   "type": "module",

--- a/scripts/test-release-workflow-authority.py
+++ b/scripts/test-release-workflow-authority.py
@@ -129,6 +129,11 @@ def main() -> None:
         "non-healthy checks: ${nonHealthyChecks(report)}",
     ):
         require(install_proof, policy, "actionable install-proof health failure")
+    require(
+        install_proof,
+        "manifest.schema_version === 2",
+        "aggregate release-provenance schema accepted by install proof",
+    )
 
     for policy in (
         "Graph-backed VFS projection proof",


### PR DESCRIPTION
## Summary
- accept the aggregate release provenance schema actually emitted by the protected release workflow
- pin that cross-workflow schema contract in the release-authority policy test
- explicitly release the graph-recovery lock when its guard leaves scope, including when a duplicate open file description was inherited before exec
- stage v0.2.26 coherently across Cargo, npm manifests, lockfile, and changelog because the failed v0.2.25 tag is immutable

## Failure evidence
The v0.2.25 quarantined public install proof downloaded, checksum-verified, installed, and ran the correct binaries on all five OS targets, then every target failed with `release provenance schema is unsupported`. The publisher emits aggregate `release-provenance.json` schema 2, while the reusable install proof still required schema 1.

The first hotfix exact-head full suite then exposed one macOS recovery-lock race after 1,036 passing tests: the idempotent retry found the recovery lock still held after a preceding retry. A duplicated descriptor can retain the lock after the parent descriptor closes; the guard now explicitly unlocks and a deterministic duplicated-open-description regression test covers that behavior.

## Verification
- `cargo fmt --all -- --check`
- `cargo check --workspace --all-targets --locked`
- `cargo metadata --locked --no-deps --format-version 1`
- exact recovery lock regression and idempotent retry tests
- `python3 scripts/test-release-workflow-authority.py`
- `actionlint .github/workflows/install-proof.yml .github/workflows/release.yml`
- Ruby YAML parse of both workflows
- release-intent reports v0.2.26 coherent and ready to tag
- `git diff --check`

v0.2.25 remains a non-latest quarantined prerelease. After this PR passes exact-head gates and merges, v0.2.26 will be the next stable release candidate.