### PR TITLE
Fix Codex install proof contract

### DIFF
--- a/.github/workflows/install-proof.yml
+++ b/.github/workflows/install-proof.yml
@@ -835,7 +835,21 @@ jobs:
             }
           }
           const codexConfig = fs.readFileSync(path.join(home, ".codex", "config.toml"), "utf8");
-          if (!codexConfig.includes("[mcp_servers.kin]") || !codexConfig.includes('args = ["mcp", "start"]') || !codexConfig.includes("KIN_MCP_TOOL_PROFILE = \"agent-default\"")) {
+          const codexArgsMatch = codexConfig.match(/^args\s*=\s*(\[.*\])\s*$/m);
+          const codexArgs = codexArgsMatch ? JSON.parse(codexArgsMatch[1]) : null;
+          const codexRepo = Array.isArray(codexArgs) && codexArgs.length === 4
+            ? fs.realpathSync(codexArgs[3])
+            : null;
+          if (
+            !codexConfig.includes("[mcp_servers.kin]") ||
+            !Array.isArray(codexArgs) ||
+            codexArgs.length !== 4 ||
+            codexArgs[0] !== "mcp" ||
+            codexArgs[1] !== "start" ||
+            codexArgs[2] !== "--repo" ||
+            codexRepo !== fs.realpathSync(process.cwd()) ||
+            !codexConfig.includes("KIN_MCP_TOOL_PROFILE = \"agent-default\"")
+          ) {
             throw new Error("Codex Kin MCP config is missing or malformed");
           }
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.2.27] - 2026-07-20
+
+### Fixed
+
+- Public install proof now validates Codex's repo-bound MCP configuration,
+  including the canonical `--repo` target, instead of rejecting the stronger
+  binding as though it were the legacy unbound argument list.
+
 ## [0.2.26] - 2026-07-20
 
 ### Fixed
@@ -681,7 +689,8 @@ Historical note: this snapshot predates the public GitHub prerelease series and 
 - Daemon mode for background file watching (`kin-daemon`)
 - 19-crate workspace architecture
 
-[unreleased]: https://github.com/firelock-ai/kin/compare/v0.2.26...HEAD
+[unreleased]: https://github.com/firelock-ai/kin/compare/v0.2.27...HEAD
+[0.2.27]: https://github.com/firelock-ai/kin/compare/v0.2.26...v0.2.27
 [0.2.26]: https://github.com/firelock-ai/kin/compare/v0.2.25...v0.2.26
 [0.2.25]: https://github.com/firelock-ai/kin/compare/v0.2.24...v0.2.25
 [0.2.24]: https://github.com/firelock-ai/kin/compare/v0.2.23...v0.2.24

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2963,14 +2963,14 @@ dependencies = [
 
 [[package]]
 name = "kin-buildinfo"
-version = "0.2.26"
+version = "0.2.27"
 dependencies = [
  "sha2 0.11.0",
 ]
 
 [[package]]
 name = "kin-cli"
-version = "0.2.26"
+version = "0.2.27"
 dependencies = [
  "age",
  "anyhow",
@@ -3041,7 +3041,7 @@ dependencies = [
 
 [[package]]
 name = "kin-context"
-version = "0.2.26"
+version = "0.2.27"
 dependencies = [
  "kin-blobs",
  "kin-db",
@@ -3057,7 +3057,7 @@ dependencies = [
 
 [[package]]
 name = "kin-core"
-version = "0.2.26"
+version = "0.2.27"
 dependencies = [
  "chrono",
  "directories 5.0.1",
@@ -3082,7 +3082,7 @@ dependencies = [
 
 [[package]]
 name = "kin-daemon"
-version = "0.2.26"
+version = "0.2.27"
 dependencies = [
  "async-stream",
  "axum",
@@ -3172,7 +3172,7 @@ dependencies = [
 
 [[package]]
 name = "kin-git"
-version = "0.2.26"
+version = "0.2.27"
 dependencies = [
  "chrono",
  "gix",
@@ -3190,7 +3190,7 @@ dependencies = [
 
 [[package]]
 name = "kin-index"
-version = "0.2.26"
+version = "0.2.27"
 dependencies = [
  "hex",
  "kin-blobs",
@@ -3238,7 +3238,7 @@ dependencies = [
 
 [[package]]
 name = "kin-integration-tests"
-version = "0.2.26"
+version = "0.2.27"
 dependencies = [
  "kin-blobs",
  "kin-cli",
@@ -3280,7 +3280,7 @@ dependencies = [
 
 [[package]]
 name = "kin-mcp"
-version = "0.2.26"
+version = "0.2.27"
 dependencies = [
  "kin-blobs",
  "kin-context",
@@ -3307,7 +3307,7 @@ dependencies = [
 
 [[package]]
 name = "kin-migrate"
-version = "0.2.26"
+version = "0.2.27"
 dependencies = [
  "chrono",
  "kin-blobs",
@@ -3349,7 +3349,7 @@ dependencies = [
 
 [[package]]
 name = "kin-parser"
-version = "0.2.26"
+version = "0.2.27"
 dependencies = [
  "kin-model",
  "pretty_assertions",
@@ -3379,7 +3379,7 @@ dependencies = [
 
 [[package]]
 name = "kin-projection"
-version = "0.2.26"
+version = "0.2.27"
 dependencies = [
  "kin-blobs",
  "kin-db",
@@ -3394,7 +3394,7 @@ dependencies = [
 
 [[package]]
 name = "kin-ranking"
-version = "0.2.26"
+version = "0.2.27"
 dependencies = [
  "kin-model",
  "serde",
@@ -3403,7 +3403,7 @@ dependencies = [
 
 [[package]]
 name = "kin-reconcile"
-version = "0.2.26"
+version = "0.2.27"
 dependencies = [
  "kin-blobs",
  "kin-db",
@@ -3423,7 +3423,7 @@ dependencies = [
 
 [[package]]
 name = "kin-registry"
-version = "0.2.26"
+version = "0.2.27"
 dependencies = [
  "axum",
  "base64 0.22.1",
@@ -3448,7 +3448,7 @@ dependencies = [
 
 [[package]]
 name = "kin-remote"
-version = "0.2.26"
+version = "0.2.27"
 dependencies = [
  "chrono",
  "kin-model",
@@ -3464,7 +3464,7 @@ dependencies = [
 
 [[package]]
 name = "kin-review"
-version = "0.2.26"
+version = "0.2.27"
 dependencies = [
  "kin-blobs",
  "kin-db",
@@ -3480,7 +3480,7 @@ dependencies = [
 
 [[package]]
 name = "kin-runtime"
-version = "0.2.26"
+version = "0.2.27"
 dependencies = [
  "chrono",
  "hex",
@@ -3512,7 +3512,7 @@ dependencies = [
 
 [[package]]
 name = "kin-semantic-contracts"
-version = "0.2.26"
+version = "0.2.27"
 dependencies = [
  "kin-db",
  "kin-model",
@@ -3527,7 +3527,7 @@ dependencies = [
 
 [[package]]
 name = "kin-spine"
-version = "0.2.26"
+version = "0.2.27"
 dependencies = [
  "chrono",
  "hashbrown 0.15.5",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,7 +27,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.2.26"
+version = "0.2.27"
 edition = "2021"
 license = "Apache-2.0"
 authors = ["Troy Fortin <troy@firelock.ai>"]

--- a/packages/boundary-contracts/package.json
+++ b/packages/boundary-contracts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kin/boundary-contracts",
-  "version": "0.2.26",
+  "version": "0.2.27",
   "private": false,
   "description": "Shared contracts for Kin ecosystem boundaries.",
   "type": "module",

--- a/packages/kin-mcp/package.json
+++ b/packages/kin-mcp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kinlab/kin-mcp",
-  "version": "0.2.26",
+  "version": "0.2.27",
   "description": "Start Kin's MCP server, the system of record for AI-written software, through an npm-friendly wrapper.",
   "type": "module",
   "bin": {

--- a/packages/kin/package.json
+++ b/packages/kin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kinlab/kin",
-  "version": "0.2.26",
+  "version": "0.2.27",
   "description": "Canonical installer and launcher for Kin, the system of record for AI-written software. Provisions and runs the managed kin + kin-daemon release. MCP is one included mode (kin mcp start).",
   "license": "Apache-2.0",
   "type": "module",

--- a/scripts/test-release-workflow-authority.py
+++ b/scripts/test-release-workflow-authority.py
@@ -134,6 +134,12 @@ def main() -> None:
         "manifest.schema_version === 2",
         "aggregate release-provenance schema accepted by install proof",
     )
+    for policy in (
+        "codexArgs.length !== 4",
+        'codexArgs[2] !== "--repo"',
+        "codexRepo !== fs.realpathSync(process.cwd())",
+    ):
+        require(install_proof, policy, "repo-bound Codex MCP install proof")
 
     for policy in (
         "Graph-backed VFS projection proof",


### PR DESCRIPTION
## Summary
- validate the repo-bound Codex MCP argument tuple in public install proof
- require the configured canonical repository to match the first-run proof repository
- stage the immutable-tag hotfix as v0.2.27

## Verification
- cargo fmt -- --check
- zero-file-search, runtime-boundary, private-coupling, installer, Homebrew, npm release-policy checks
- npm tests and lints for both launchers and boundary contracts
- cargo clippy --all-targets --all-features with the CI allowlist
- cargo build --all-targets --locked
- cargo test --locked (including 1,038 kin-cli tests)