### PR TITLE
Align public capability counts with source truth

### DIFF
--- a/crates/kin-parser/src/lib.rs
+++ b/crates/kin-parser/src/lib.rs
@@ -4,7 +4,8 @@
 //! Tree-sitter parsing and language adapters for Kin.
 //!
 //! This crate provides the `LanguageAdapter` trait and built-in adapters
-//! for TypeScript, JavaScript, Python, Go, Java, Rust, C, C++, C#, Ruby, and PHP.
+//! for TypeScript, JavaScript, Python, Go, Java, Rust, C, C++, C#, Ruby, PHP, Swift,
+//! Kotlin, and HCL/Terraform.
 
 pub const PARSER_SCHEMA_EPOCH: &str = "parser-schema-2026-03-29-v1";
 

--- a/docs/mcp-tools.md
+++ b/docs/mcp-tools.md
@@ -1,6 +1,6 @@
 # Model Context Protocol (MCP) Tool Surface Reference
 
-The Kin MCP server exposes 60 semantic tools to AI assistants (Claude, Cursor, Gemini,
+The Kin MCP server exposes 62 semantic tools to AI assistants (Claude, Cursor, Gemini,
 Codex, etc.). These tools bridge the gap between traditional file-first navigation and
 Kin's graph-first semantic substrate: instead of issuing raw shell commands or reading raw
 files, an assistant interacts with the codebase through entity-level primitives.


### PR DESCRIPTION
## Summary

- align the public MCP reference with the v0.2.27 tool registry
- list all 14 built-in parser adapters in the crate documentation
- keep OSS and investor capability claims at source-enforced values

## Verification

- `cargo test -p kin-mcp expected_tool_count --locked`
- `cargo test -p kin-parser registry_has_all_languages --locked`
- `cargo fmt -- --check`
- `git diff --check`

The source tests assert 62 MCP tools and 14 parser adapters; this PR corrects stale public documentation only.