### PR TITLE
Fix cross-platform install proof

### DIFF
--- a/.github/workflows/install-proof.yml
+++ b/.github/workflows/install-proof.yml
@@ -834,25 +834,6 @@ jobs:
               throw new Error(`${configPath}: Kin MCP entry is missing or malformed`);
             }
           }
-          const codexConfig = fs.readFileSync(path.join(home, ".codex", "config.toml"), "utf8");
-          const codexArgsMatch = codexConfig.match(/^args\s*=\s*(\[.*\])\s*$/m);
-          const codexArgs = codexArgsMatch ? JSON.parse(codexArgsMatch[1]) : null;
-          const codexRepo = Array.isArray(codexArgs) && codexArgs.length === 4
-            ? fs.realpathSync(codexArgs[3])
-            : null;
-          if (
-            !codexConfig.includes("[mcp_servers.kin]") ||
-            !Array.isArray(codexArgs) ||
-            codexArgs.length !== 4 ||
-            codexArgs[0] !== "mcp" ||
-            codexArgs[1] !== "start" ||
-            codexArgs[2] !== "--repo" ||
-            codexRepo !== fs.realpathSync(process.cwd()) ||
-            !codexConfig.includes("KIN_MCP_TOOL_PROFILE = \"agent-default\"")
-          ) {
-            throw new Error("Codex Kin MCP config is missing or malformed");
-          }
-
           if (runnerOs === "Windows") {
             const vectorDegradations = (locate.degradations ?? []).filter((entry) => entry.component === "vector_index");
             if (vectorDegradations.length !== 1 || vectorDegradations[0].reason !== "feature_disabled") {

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.2.28] - 2026-07-20
+
+### Fixed
+
+- Setup now accepts macOS's standard protective `everyone deny delete` home
+  ACL while continuing to reject ACLs that grant or block child-namespace
+  mutation, restoring first-run configuration and install-ledger writes on
+  Apple Silicon hosted runners.
+- Public install proof delegates Codex TOML validation to Kin's own parser and
+  health check, so Windows literal paths remain repo-bound without being
+  misparsed as JSON.
+
 ## [0.2.27] - 2026-07-20
 
 ### Fixed
@@ -689,7 +701,8 @@ Historical note: this snapshot predates the public GitHub prerelease series and 
 - Daemon mode for background file watching (`kin-daemon`)
 - 19-crate workspace architecture
 
-[unreleased]: https://github.com/firelock-ai/kin/compare/v0.2.27...HEAD
+[unreleased]: https://github.com/firelock-ai/kin/compare/v0.2.28...HEAD
+[0.2.28]: https://github.com/firelock-ai/kin/compare/v0.2.27...v0.2.28
 [0.2.27]: https://github.com/firelock-ai/kin/compare/v0.2.26...v0.2.27
 [0.2.26]: https://github.com/firelock-ai/kin/compare/v0.2.25...v0.2.26
 [0.2.25]: https://github.com/firelock-ai/kin/compare/v0.2.24...v0.2.25

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2963,14 +2963,14 @@ dependencies = [
 
 [[package]]
 name = "kin-buildinfo"
-version = "0.2.27"
+version = "0.2.28"
 dependencies = [
  "sha2 0.11.0",
 ]
 
 [[package]]
 name = "kin-cli"
-version = "0.2.27"
+version = "0.2.28"
 dependencies = [
  "age",
  "anyhow",
@@ -3041,7 +3041,7 @@ dependencies = [
 
 [[package]]
 name = "kin-context"
-version = "0.2.27"
+version = "0.2.28"
 dependencies = [
  "kin-blobs",
  "kin-db",
@@ -3057,7 +3057,7 @@ dependencies = [
 
 [[package]]
 name = "kin-core"
-version = "0.2.27"
+version = "0.2.28"
 dependencies = [
  "chrono",
  "directories 5.0.1",
@@ -3082,7 +3082,7 @@ dependencies = [
 
 [[package]]
 name = "kin-daemon"
-version = "0.2.27"
+version = "0.2.28"
 dependencies = [
  "async-stream",
  "axum",
@@ -3172,7 +3172,7 @@ dependencies = [
 
 [[package]]
 name = "kin-git"
-version = "0.2.27"
+version = "0.2.28"
 dependencies = [
  "chrono",
  "gix",
@@ -3190,7 +3190,7 @@ dependencies = [
 
 [[package]]
 name = "kin-index"
-version = "0.2.27"
+version = "0.2.28"
 dependencies = [
  "hex",
  "kin-blobs",
@@ -3238,7 +3238,7 @@ dependencies = [
 
 [[package]]
 name = "kin-integration-tests"
-version = "0.2.27"
+version = "0.2.28"
 dependencies = [
  "kin-blobs",
  "kin-cli",
@@ -3280,7 +3280,7 @@ dependencies = [
 
 [[package]]
 name = "kin-mcp"
-version = "0.2.27"
+version = "0.2.28"
 dependencies = [
  "kin-blobs",
  "kin-context",
@@ -3307,7 +3307,7 @@ dependencies = [
 
 [[package]]
 name = "kin-migrate"
-version = "0.2.27"
+version = "0.2.28"
 dependencies = [
  "chrono",
  "kin-blobs",
@@ -3349,7 +3349,7 @@ dependencies = [
 
 [[package]]
 name = "kin-parser"
-version = "0.2.27"
+version = "0.2.28"
 dependencies = [
  "kin-model",
  "pretty_assertions",
@@ -3379,7 +3379,7 @@ dependencies = [
 
 [[package]]
 name = "kin-projection"
-version = "0.2.27"
+version = "0.2.28"
 dependencies = [
  "kin-blobs",
  "kin-db",
@@ -3394,7 +3394,7 @@ dependencies = [
 
 [[package]]
 name = "kin-ranking"
-version = "0.2.27"
+version = "0.2.28"
 dependencies = [
  "kin-model",
  "serde",
@@ -3403,7 +3403,7 @@ dependencies = [
 
 [[package]]
 name = "kin-reconcile"
-version = "0.2.27"
+version = "0.2.28"
 dependencies = [
  "kin-blobs",
  "kin-db",
@@ -3423,7 +3423,7 @@ dependencies = [
 
 [[package]]
 name = "kin-registry"
-version = "0.2.27"
+version = "0.2.28"
 dependencies = [
  "axum",
  "base64 0.22.1",
@@ -3448,7 +3448,7 @@ dependencies = [
 
 [[package]]
 name = "kin-remote"
-version = "0.2.27"
+version = "0.2.28"
 dependencies = [
  "chrono",
  "kin-model",
@@ -3464,7 +3464,7 @@ dependencies = [
 
 [[package]]
 name = "kin-review"
-version = "0.2.27"
+version = "0.2.28"
 dependencies = [
  "kin-blobs",
  "kin-db",
@@ -3480,7 +3480,7 @@ dependencies = [
 
 [[package]]
 name = "kin-runtime"
-version = "0.2.27"
+version = "0.2.28"
 dependencies = [
  "chrono",
  "hex",
@@ -3512,7 +3512,7 @@ dependencies = [
 
 [[package]]
 name = "kin-semantic-contracts"
-version = "0.2.27"
+version = "0.2.28"
 dependencies = [
  "kin-db",
  "kin-model",
@@ -3527,7 +3527,7 @@ dependencies = [
 
 [[package]]
 name = "kin-spine"
-version = "0.2.27"
+version = "0.2.28"
 dependencies = [
  "chrono",
  "hashbrown 0.15.5",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,7 +27,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.2.27"
+version = "0.2.28"
 edition = "2021"
 license = "Apache-2.0"
 authors = ["Troy Fortin <troy@firelock.ai>"]

--- a/crates/kin-cli/src/commands/health.rs
+++ b/crates/kin-cli/src/commands/health.rs
@@ -837,6 +837,44 @@ fn evaluate_antigravity_binding(path: &Path, workspace: bool) -> Option<(HealthS
     }
 }
 
+fn evaluate_codex_binding_for(path: &Path, expected_repo: &Path) -> Option<(HealthStatus, String)> {
+    let content = match std::fs::read(path) {
+        Ok(content) => content,
+        Err(error) => {
+            return Some((
+                HealthStatus::Misconfigured,
+                format!(
+                    "could not read Codex MCP config {}: {error}",
+                    path.display()
+                ),
+            ));
+        }
+    };
+    match super::setup::codex_entry_has_exact_repo_binding(&content, expected_repo) {
+        Ok(true) => None,
+        Ok(false) => Some((
+            HealthStatus::Misconfigured,
+            format!(
+                "Codex Kin binding at {} does not use the exact `mcp start --repo <current-repository>` arguments for {}",
+                path.display(),
+                expected_repo.display()
+            ),
+        )),
+        Err(error) => Some((
+            HealthStatus::Misconfigured,
+            format!(
+                "Codex Kin binding at {} is invalid: {error:#}",
+                path.display()
+            ),
+        )),
+    }
+}
+
+fn evaluate_codex_binding(path: &Path) -> Option<(HealthStatus, String)> {
+    let expected_repo = current_health_repo()?;
+    evaluate_codex_binding_for(path, &expected_repo)
+}
+
 fn check_mcp_clients() -> Vec<HealthCheck> {
     let clients: Vec<McpClient> = mcp_client_config_paths()
         .into_iter()
@@ -862,6 +900,13 @@ fn check_mcp_clients() -> Vec<HealthCheck> {
             {
                 if let Some((binding_status, binding_detail)) =
                     evaluate_antigravity_binding(&client.path, client.id == "antigravity_workspace")
+                {
+                    status = binding_status;
+                    detail = binding_detail;
+                }
+            }
+            if matches!(status, HealthStatus::Healthy) && client.id == "codex" {
+                if let Some((binding_status, binding_detail)) = evaluate_codex_binding(&client.path)
                 {
                     status = binding_status;
                     detail = binding_detail;
@@ -1554,6 +1599,41 @@ mod tests {
         let (status, detail) = evaluate_mcp_client(&path);
         assert!(matches!(status, HealthStatus::Missing), "got: {detail}");
         assert!(detail.contains("mcp_servers.kin"));
+    }
+
+    #[test]
+    fn codex_health_binding_uses_the_product_toml_parser() {
+        let dir = tempfile::tempdir().unwrap();
+        let expected = dir.path().join("expected");
+        let other = dir.path().join("other");
+        std::fs::create_dir_all(expected.join(".kin")).unwrap();
+        std::fs::create_dir_all(other.join(".kin")).unwrap();
+        let expected = expected.canonicalize().unwrap();
+        let other = other.canonicalize().unwrap();
+        let path = dir.path().join("config.toml");
+        std::fs::write(
+            &path,
+            format!(
+                "[mcp_servers.kin]\ncommand = 'kin'\nargs = ['mcp', 'start', '--repo', '{}']\nenv = {{ KIN_MCP_TOOL_PROFILE = 'agent-default' }}\n",
+                expected.display()
+            ),
+        )
+        .unwrap();
+
+        assert!(evaluate_codex_binding_for(&path, &expected).is_none());
+        let (status, detail) = evaluate_codex_binding_for(&path, &other).unwrap();
+        assert!(matches!(status, HealthStatus::Misconfigured));
+        assert!(detail.contains("does not use the exact"));
+
+        std::fs::write(
+            &path,
+            format!(
+                "[mcp_servers.kin]\nargs = ['not-mcp', 'start', '--repo', '{}']\nenv = {{ KIN_MCP_TOOL_PROFILE = 'agent-default' }}\n",
+                expected.display()
+            ),
+        )
+        .unwrap();
+        assert!(evaluate_codex_binding_for(&path, &expected).is_some());
     }
 
     #[test]

--- a/crates/kin-cli/src/commands/setup.rs
+++ b/crates/kin-cli/src/commands/setup.rs
@@ -2136,6 +2136,32 @@ fn codex_repo_from_entry_bytes(content: &[u8]) -> Result<Option<PathBuf>> {
     Ok(canonical_initialized_repo(&candidate))
 }
 
+pub(crate) fn codex_entry_has_exact_repo_binding(
+    content: &[u8],
+    expected_repo: &Path,
+) -> Result<bool> {
+    let text = std::str::from_utf8(content).context("Codex MCP config is not UTF-8")?;
+    let root: toml::Value = toml::from_str(text).context("Codex MCP config is not valid TOML")?;
+    let Some(entry) = root
+        .get("mcp_servers")
+        .and_then(|servers| servers.get("kin"))
+    else {
+        return Ok(false);
+    };
+    let Some(args) = entry.get("args").and_then(toml::Value::as_array) else {
+        return Ok(false);
+    };
+    if args.len() != 4
+        || args[0].as_str() != Some("mcp")
+        || args[1].as_str() != Some("start")
+        || args[2].as_str() != Some("--repo")
+        || args[3].as_str().is_none()
+    {
+        return Ok(false);
+    }
+    Ok(codex_repo_from_entry_bytes(content)?.as_deref() == Some(expected_repo))
+}
+
 fn json_mcp_repo_from_entry_bytes(content: &[u8], client: &str) -> Result<Option<PathBuf>> {
     let root: serde_json::Value = serde_json::from_slice(content)
         .with_context(|| format!("{client} MCP config is invalid JSON"))?;
@@ -3121,9 +3147,17 @@ impl UnixConfigMetadata {
 
 #[cfg(target_os = "macos")]
 fn macos_acl_has_deny_entry(acl: &[u8]) -> Result<bool> {
+    Ok(macos_acl_entries(acl)?
+        .iter()
+        .any(|(disposition, _)| disposition == "deny"))
+}
+
+#[cfg(target_os = "macos")]
+fn macos_acl_entries(acl: &[u8]) -> Result<Vec<(String, Vec<String>)>> {
     let text = std::str::from_utf8(acl).context("managed config ACL text is not UTF-8")?;
     let mut saw_header = false;
     let mut saw_entry = false;
+    let mut entries = Vec::new();
     for line in text.lines().map(str::trim).filter(|line| !line.is_empty()) {
         if line.starts_with("!#acl") {
             if line != "!#acl 1" || saw_header || saw_entry {
@@ -3151,17 +3185,57 @@ fn macos_acl_has_deny_entry(acl: &[u8]) -> Result<bool> {
         if permissions.split(',').any(str::is_empty) {
             anyhow::bail!("managed config ACL entry contains an empty permission");
         }
-        match disposition_and_flags.split(',').next() {
-            Some("deny") => return Ok(true),
-            Some("allow") => {}
-            _ => anyhow::bail!("managed config ACL entry has an unknown disposition"),
-        }
+        let disposition = disposition_and_flags
+            .split(',')
+            .next()
+            .filter(|value| *value == "allow" || *value == "deny")
+            .context("managed config ACL entry has an unknown disposition")?;
+        entries.push((
+            disposition.to_string(),
+            permissions.split(',').map(str::to_string).collect(),
+        ));
         saw_entry = true;
     }
     if !acl.is_empty() && (!saw_header || !saw_entry) {
         anyhow::bail!("managed config ACL contains no entries");
     }
-    Ok(false)
+    Ok(entries)
+}
+
+#[cfg(target_os = "macos")]
+fn validate_macos_directory_namespace_acl(acl: &[u8], label: &str) -> Result<()> {
+    for (disposition, permissions) in macos_acl_entries(acl)? {
+        if disposition == "allow"
+            && permissions.iter().any(|permission| {
+                matches!(
+                    permission.as_str(),
+                    "write"
+                        | "append"
+                        | "add_file"
+                        | "add_subdirectory"
+                        | "delete"
+                        | "delete_child"
+                        | "writesecurity"
+                        | "chown"
+                )
+            })
+        {
+            anyhow::bail!("{label} carries extended namespace authority");
+        }
+        // A standard macOS home directory carries `everyone deny delete`.
+        // That protects the retained home entry and does not block anchored
+        // child creation, replacement, or removal. Every other deny right is
+        // rejected because it can make the transaction incomplete or
+        // platform-dependent.
+        if disposition == "deny"
+            && permissions
+                .iter()
+                .any(|permission| permission.as_str() != "delete")
+        {
+            anyhow::bail!("{label} carries a deny ACL that blocks child namespace operations");
+        }
+    }
+    Ok(())
 }
 
 #[cfg(unix)]
@@ -3209,9 +3283,7 @@ fn validate_unix_directory_namespace_metadata(
         if metadata.flags.is_some_and(|flags| flags & blocking != 0) {
             anyhow::bail!("{label} carries child-namespace-blocking BSD flags");
         }
-        if macos_acl_has_deny_entry(&metadata.acl)? {
-            anyhow::bail!("{label} carries a deny ACL that cannot be safely transacted");
-        }
+        validate_macos_directory_namespace_acl(&metadata.acl, label)?;
     }
     #[cfg(target_os = "linux")]
     if metadata
@@ -4023,6 +4095,7 @@ fn validate_kin_home_namespace(authority: &DurableConfigDirectory) -> Result<()>
             parent_path.display()
         );
     }
+    #[cfg(not(target_os = "macos"))]
     if parent_extended.grants_extended_private_access() {
         anyhow::bail!(
             "Kin-home parent carries extended namespace authority: {}",
@@ -5022,9 +5095,13 @@ fn create_config_directory_all_durable(
     if private_chain {
         let stat = rustix::fs::fstat(&parent)?;
         let extended = unix_config_metadata(&parent)?;
+        #[cfg(target_os = "macos")]
+        let grants_extended_private_access = false;
+        #[cfg(not(target_os = "macos"))]
+        let grants_extended_private_access = extended.grants_extended_private_access();
         if rustix::fs::FileType::from_raw_mode(stat.st_mode) != rustix::fs::FileType::Directory
             || (stat.st_mode as u32 & 0o022 != 0 && stat.st_mode as u32 & 0o1000 == 0)
-            || extended.grants_extended_private_access()
+            || grants_extended_private_access
         {
             anyhow::bail!(
                 "existing Kin-home ancestor permits unsafe namespace replacement: {}",
@@ -12702,6 +12779,38 @@ mod tests {
         ] {
             assert!(macos_acl_has_deny_entry(malformed).is_err());
         }
+    }
+
+    #[cfg(target_os = "macos")]
+    #[test]
+    fn macos_namespace_acl_accepts_protective_home_delete_deny_only() {
+        let standard_home =
+            b"!#acl 1\n0: ABCDEFAB-CDEF-ABCD-EFAB-CDEFABCDEFAB:everyone:deny:delete\n";
+        validate_macos_directory_namespace_acl(standard_home, "home").unwrap();
+
+        let read_only_allow =
+            b"!#acl 1\n0: ABCDEFAB-CDEF-ABCD-EFAB-CDEFABCDEFAB:everyone:allow:read\n";
+        validate_macos_directory_namespace_acl(read_only_allow, "home").unwrap();
+
+        let namespace_grant =
+            b"!#acl 1\n0: ABCDEFAB-CDEF-ABCD-EFAB-CDEFABCDEFAB:everyone:allow:add_file\n";
+        assert!(validate_macos_directory_namespace_acl(namespace_grant, "home").is_err());
+
+        let child_deny =
+            b"!#acl 1\n0: ABCDEFAB-CDEF-ABCD-EFAB-CDEFABCDEFAB:everyone:deny:delete_child\n";
+        assert!(validate_macos_directory_namespace_acl(child_deny, "home").is_err());
+    }
+
+    #[cfg(target_os = "macos")]
+    #[test]
+    fn macos_current_home_namespace_acl_is_transactable() {
+        let home = directories::BaseDirs::new()
+            .unwrap()
+            .home_dir()
+            .to_path_buf();
+        let handle = open_config_parent_nofollow(&home).unwrap();
+        let acl = macos_config_acl(&handle).unwrap();
+        validate_macos_directory_namespace_acl(&acl, "current home").unwrap();
     }
 
     #[cfg(target_os = "macos")]

--- a/packages/boundary-contracts/package.json
+++ b/packages/boundary-contracts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kin/boundary-contracts",
-  "version": "0.2.27",
+  "version": "0.2.28",
   "private": false,
   "description": "Shared contracts for Kin ecosystem boundaries.",
   "type": "module",

--- a/packages/kin-mcp/package.json
+++ b/packages/kin-mcp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kinlab/kin-mcp",
-  "version": "0.2.27",
+  "version": "0.2.28",
   "description": "Start Kin's MCP server, the system of record for AI-written software, through an npm-friendly wrapper.",
   "type": "module",
   "bin": {

--- a/packages/kin/package.json
+++ b/packages/kin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kinlab/kin",
-  "version": "0.2.27",
+  "version": "0.2.28",
   "description": "Canonical installer and launcher for Kin, the system of record for AI-written software. Provisions and runs the managed kin + kin-daemon release. MCP is one included mode (kin mcp start).",
   "license": "Apache-2.0",
   "type": "module",

--- a/scripts/test-release-workflow-authority.py
+++ b/scripts/test-release-workflow-authority.py
@@ -19,6 +19,7 @@ INSTALLER_CALLBACK = WORKFLOWS / "publish-release-installers.yml"
 UPDATE_TRUST = ROOT / "docs" / "security" / "signing-and-update-trust.md"
 INSTALL_SH = ROOT / "scripts" / "install.sh"
 INSTALL_PS1 = ROOT / "scripts" / "install.ps1"
+HEALTH = ROOT / "crates" / "kin-cli" / "src" / "commands" / "health.rs"
 
 
 def require(content: str, needle: str, context: str) -> None:
@@ -47,6 +48,7 @@ def main() -> None:
     update_trust = UPDATE_TRUST.read_text(encoding="utf-8")
     install_sh = INSTALL_SH.read_text(encoding="utf-8")
     install_ps1 = INSTALL_PS1.read_text(encoding="utf-8")
+    health = HEALTH.read_text(encoding="utf-8")
     docker_workflow = (WORKFLOWS / "docker.yml").read_text(encoding="utf-8")
     require(
         install_sh,
@@ -134,12 +136,25 @@ def main() -> None:
         "manifest.schema_version === 2",
         "aggregate release-provenance schema accepted by install proof",
     )
-    for policy in (
-        "codexArgs.length !== 4",
-        'codexArgs[2] !== "--repo"',
-        "codexRepo !== fs.realpathSync(process.cwd())",
-    ):
-        require(install_proof, policy, "repo-bound Codex MCP install proof")
+    require(
+        install_proof,
+        '["mcp_client_codex", "healthy"]',
+        "repo-bound Codex MCP install proof",
+    )
+    require(
+        health,
+        "evaluate_codex_binding(&client.path)",
+        "product-owned Codex MCP binding validation",
+    )
+    require(
+        health,
+        "super::setup::codex_entry_has_exact_repo_binding(&content, expected_repo)",
+        "shared TOML parser for Codex MCP binding validation",
+    )
+    if "JSON.parse(codexArgsMatch[1])" in install_proof:
+        raise AssertionError(
+            "install proof must not parse TOML as JSON; the product health check owns Codex binding validation"
+        )
 
     for policy in (
         "Graph-backed VFS projection proof",


### PR DESCRIPTION
## Summary
- accept macOS standard protective home ACLs while preserving namespace safety checks
- validate Codex TOML through Kin health instead of parsing TOML as JSON in the workflow
- stage coherent v0.2.28 release metadata

## Verification
- cargo fmt -- --check
- exact CI clippy allowlist with RUSTFLAGS=-D warnings
- cargo build --all-targets --locked
- cargo test --locked (full workspace)
- cargo test --locked -p kin-cli
- python3 scripts/test-release-workflow-authority.py
- actionlint .github/workflows/install-proof.yml
- node scripts/release-intent.mjs --json

## Release posture
This fixes the two independent v0.2.27 public-install failures. It does not claim a stable release until the protected release and five-platform public install proof pass.