### PR TITLE
Add deterministic ranked graph impact

### DIFF
--- a/crates/kin-cli/src/commands/impact.rs
+++ b/crates/kin-cli/src/commands/impact.rs
@@ -5,6 +5,8 @@ use anyhow::{Context, Result};
 use kin_model::{EntityFilter, EntityId, EntityStore};
 use serde::{Deserialize, Serialize};
 
+pub const IMPACT_RESPONSE_SCHEMA_VERSION: &str = "kin-impact-response-v1";
+
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct ImpactRequest {
     pub entity: String,
@@ -30,14 +32,17 @@ pub struct ImpactRequest {
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct ImpactResponse {
     pub lines: Vec<String>,
+    #[serde(default)]
     pub schema_version: String,
+    #[serde(default)]
     pub resolution: String,
+    #[serde(default)]
     pub query: ImpactQuery,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub ranked: Option<kin_review::RankedImpactReport>,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
 pub struct ImpactQuery {
     pub entity: String,
     pub file: Option<String>,
@@ -69,7 +74,15 @@ pub async fn run(
     )
     .await?;
     if json {
+        if response.schema_version.is_empty() {
+            anyhow::bail!(
+                "the running daemon does not support structured ranked impact; restart it with the current Kin build"
+            );
+        }
         println!("{}", serde_json::to_string_pretty(&response)?);
+        if response.resolution != "resolved" {
+            anyhow::bail!("impact resolution failed: {}", response.resolution);
+        }
     } else {
         for line in response.lines {
             println!("{line}");
@@ -117,7 +130,7 @@ pub async fn build_impact_response(
     if matches.is_empty() {
         return Ok(ImpactResponse {
             lines: impact_not_found_guidance(&request.entity),
-            schema_version: kin_review::RANKED_IMPACT_SCHEMA_VERSION.to_string(),
+            schema_version: IMPACT_RESPONSE_SCHEMA_VERSION.to_string(),
             resolution: "not_found".to_string(),
             query,
             ranked: None,
@@ -131,7 +144,7 @@ pub async fn build_impact_response(
                 request.entity,
                 matches.len()
             )],
-            schema_version: kin_review::RANKED_IMPACT_SCHEMA_VERSION.to_string(),
+            schema_version: IMPACT_RESPONSE_SCHEMA_VERSION.to_string(),
             resolution: "ambiguous".to_string(),
             query,
             ranked: None,
@@ -164,13 +177,17 @@ pub async fn build_impact_response(
         }
     }
 
-    let ranked = kin_review::rank_impact(graph, &target.id, request.depth)?;
+    let ranked = if request.require_unique {
+        Some(kin_review::rank_impact(graph, &target.id, request.depth)?)
+    } else {
+        None
+    };
     Ok(ImpactResponse {
         lines,
-        schema_version: kin_review::RANKED_IMPACT_SCHEMA_VERSION.to_string(),
+        schema_version: IMPACT_RESPONSE_SCHEMA_VERSION.to_string(),
         resolution: "resolved".to_string(),
         query,
-        ranked: Some(ranked),
+        ranked,
     })
 }
 
@@ -178,18 +195,21 @@ fn resolve_entities(
     graph: &kin_db::InMemoryGraph,
     request: &ImpactRequest,
 ) -> Result<Vec<kin_model::Entity>> {
-    if let Ok(uuid) = uuid::Uuid::parse_str(&request.entity) {
-        return Ok(graph.get_entity(&EntityId(uuid))?.into_iter().collect());
-    }
-
-    let filter = EntityFilter {
-        name_pattern: Some(request.entity.clone()),
-        ..Default::default()
+    let mut matches = if let Ok(uuid) = uuid::Uuid::parse_str(&request.entity) {
+        graph.get_entity(&EntityId(uuid))?.into_iter().collect()
+    } else {
+        let filter = EntityFilter {
+            name_pattern: Some(request.entity.clone()),
+            ..Default::default()
+        };
+        let mut matches = graph.query_entities(&filter)?;
+        // The human surface preserves Kin's broad name matching. Structured
+        // callers explicitly opt into exact, fail-closed identity resolution.
+        if request.require_unique {
+            matches.retain(|entity| entity.name == request.entity);
+        }
+        matches
     };
-    let mut matches = graph.query_entities(&filter)?;
-    // EntityFilter name matching is intentionally broad for search. Impact
-    // identity resolution is exact and fail-closed.
-    matches.retain(|entity| entity.name == request.entity);
     if let Some(file) = request.file.as_deref() {
         matches.retain(|entity| kin_review::StableEntityIdentity::from_entity(entity).file == file);
     }
@@ -223,7 +243,7 @@ fn impact_not_found_guidance(entity: &str) -> Vec<String> {
 
 #[cfg(test)]
 mod tests {
-    use super::{build_impact_response, impact_not_found_guidance, ImpactRequest};
+    use super::{build_impact_response, impact_not_found_guidance, ImpactRequest, ImpactResponse};
     use kin_model::{
         Entity, EntityId, EntityKind, EntityMetadata, EntityRole, EntityStore, FilePathId,
         FingerprintAlgorithm, GraphNodeId, Hash256, LanguageId, Relation, RelationId, RelationKind,
@@ -273,6 +293,71 @@ mod tests {
             joined.contains("kin xref"),
             "notes cross-repo path: {joined}"
         );
+    }
+
+    #[test]
+    fn legacy_daemon_response_deserializes_without_structured_fields() {
+        let response: ImpactResponse =
+            serde_json::from_value(serde_json::json!({ "lines": ["legacy"] })).unwrap();
+        assert_eq!(response.lines, vec!["legacy"]);
+        assert!(response.schema_version.is_empty());
+        assert!(response.resolution.is_empty());
+        assert_eq!(response.query.match_count, 0);
+        assert!(response.ranked.is_none());
+    }
+
+    #[tokio::test]
+    async fn legacy_human_resolution_preserves_broad_name_matching_and_skips_ranked_work() {
+        let graph = kin_db::InMemoryGraph::new();
+        graph
+            .upsert_entity(&entity("changed", "src/lib.rs"))
+            .unwrap();
+        let dir = tempfile::tempdir().unwrap();
+        let layout = kin_core::KinLayout::new(dir.path().join(".kin"));
+        let response = build_impact_response(
+            &layout,
+            &graph,
+            &ImpactRequest {
+                entity: "CHANGED".to_string(),
+                depth: 3,
+                file: None,
+                kind: None,
+                signature: None,
+                require_unique: false,
+            },
+        )
+        .await
+        .unwrap();
+
+        assert_eq!(response.resolution, "resolved");
+        assert!(response.ranked.is_none());
+    }
+
+    #[tokio::test]
+    async fn uuid_resolution_still_enforces_identity_qualifiers() {
+        let graph = kin_db::InMemoryGraph::new();
+        let target = entity("changed", "src/lib.rs");
+        let target_id = target.id;
+        graph.upsert_entity(&target).unwrap();
+        let dir = tempfile::tempdir().unwrap();
+        let layout = kin_core::KinLayout::new(dir.path().join(".kin"));
+        let response = build_impact_response(
+            &layout,
+            &graph,
+            &ImpactRequest {
+                entity: target_id.to_string(),
+                depth: 3,
+                file: Some("src/other.rs".to_string()),
+                kind: None,
+                signature: None,
+                require_unique: true,
+            },
+        )
+        .await
+        .unwrap();
+
+        assert_eq!(response.resolution, "not_found");
+        assert!(response.ranked.is_none());
     }
 
     #[tokio::test]

--- a/crates/kin-cli/src/commands/impact.rs
+++ b/crates/kin-cli/src/commands/impact.rs
@@ -2,27 +2,78 @@
 // Copyright 2026 Firelock, LLC
 
 use anyhow::{Context, Result};
-use kin_model::EntityFilter;
-use kin_model::EntityStore;
+use kin_model::{EntityFilter, EntityId, EntityStore};
 use serde::{Deserialize, Serialize};
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct ImpactRequest {
     pub entity: String,
     pub depth: u32,
+    /// Optional stable-identity file qualifier. This is line-independent and
+    /// lets automation fail closed instead of choosing an arbitrary same-name
+    /// declaration.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub file: Option<String>,
+    /// Optional stable-identity entity-kind qualifier (serde snake_case name).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub kind: Option<String>,
+    /// Optional whitespace-normalized declaration signature. Required to
+    /// distinguish same-name/same-file overloads on structured callers.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub signature: Option<String>,
+    /// Refuse an ambiguous name match. Structured benchmark clients set this;
+    /// the legacy human surface retains its deterministic first-match display.
+    #[serde(default)]
+    pub require_unique: bool,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct ImpactResponse {
     pub lines: Vec<String>,
+    pub schema_version: String,
+    pub resolution: String,
+    pub query: ImpactQuery,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub ranked: Option<kin_review::RankedImpactReport>,
 }
 
-pub async fn run(entity: String, depth: u32) -> Result<()> {
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ImpactQuery {
+    pub entity: String,
+    pub file: Option<String>,
+    pub kind: Option<String>,
+    pub signature: Option<String>,
+    pub match_count: usize,
+}
+
+pub async fn run(
+    entity: String,
+    depth: u32,
+    file: Option<String>,
+    kind: Option<String>,
+    signature: Option<String>,
+    json: bool,
+) -> Result<()> {
     let layout = kin_core::KinLayout::discover(&std::env::current_dir()?)
         .ok_or_else(|| anyhow::anyhow!("not a Kin repository (no .kin/ found)"))?;
-    let response = run_daemon_impact(&layout, &ImpactRequest { entity, depth }).await?;
-    for line in response.lines {
-        println!("{line}");
+    let response = run_daemon_impact(
+        &layout,
+        &ImpactRequest {
+            entity,
+            depth,
+            file,
+            kind,
+            signature,
+            require_unique: json,
+        },
+    )
+    .await?;
+    if json {
+        println!("{}", serde_json::to_string_pretty(&response)?);
+    } else {
+        for line in response.lines {
+            println!("{line}");
+        }
     }
     Ok(())
 }
@@ -48,16 +99,42 @@ pub async fn build_impact_response(
     graph: &kin_db::InMemoryGraph,
     request: &ImpactRequest,
 ) -> Result<ImpactResponse> {
-    // Find the entity by name
-    let filter = EntityFilter {
-        name_pattern: Some(request.entity.clone()),
-        ..Default::default()
+    let mut matches = resolve_entities(graph, request)?;
+    matches.sort_by(|left, right| {
+        kin_review::StableEntityIdentity::from_entity(left)
+            .cmp(&kin_review::StableEntityIdentity::from_entity(right))
+            .then_with(|| left.id.cmp(&right.id))
+    });
+
+    let query = ImpactQuery {
+        entity: request.entity.clone(),
+        file: request.file.clone(),
+        kind: request.kind.clone(),
+        signature: request.signature.clone(),
+        match_count: matches.len(),
     };
-    let matches = graph.query_entities(&filter)?;
 
     if matches.is_empty() {
         return Ok(ImpactResponse {
             lines: impact_not_found_guidance(&request.entity),
+            schema_version: kin_review::RANKED_IMPACT_SCHEMA_VERSION.to_string(),
+            resolution: "not_found".to_string(),
+            query,
+            ranked: None,
+        });
+    }
+
+    if request.require_unique && matches.len() != 1 {
+        return Ok(ImpactResponse {
+            lines: vec![format!(
+                "Entity query '{}' is ambiguous ({} matches); add --file, --kind, and --signature qualifiers.",
+                request.entity,
+                matches.len()
+            )],
+            schema_version: kin_review::RANKED_IMPACT_SCHEMA_VERSION.to_string(),
+            resolution: "ambiguous".to_string(),
+            query,
+            ranked: None,
         });
     }
 
@@ -66,6 +143,12 @@ pub async fn build_impact_response(
         format!("Impact analysis for '{}' ({:?}):", target.name, target.kind),
         format!("  Depth: {}", request.depth),
     ];
+    if matches.len() > 1 {
+        lines.push(format!(
+            "  Note: {} matches; showing the deterministic first match. Use --json with --file/--kind/--signature for fail-closed resolution.",
+            matches.len()
+        ));
+    }
 
     // 1. Local Impact
     let local_impacted = graph.get_downstream_impact(&target.id, request.depth)?;
@@ -81,7 +164,45 @@ pub async fn build_impact_response(
         }
     }
 
-    Ok(ImpactResponse { lines })
+    let ranked = kin_review::rank_impact(graph, &target.id, request.depth)?;
+    Ok(ImpactResponse {
+        lines,
+        schema_version: kin_review::RANKED_IMPACT_SCHEMA_VERSION.to_string(),
+        resolution: "resolved".to_string(),
+        query,
+        ranked: Some(ranked),
+    })
+}
+
+fn resolve_entities(
+    graph: &kin_db::InMemoryGraph,
+    request: &ImpactRequest,
+) -> Result<Vec<kin_model::Entity>> {
+    if let Ok(uuid) = uuid::Uuid::parse_str(&request.entity) {
+        return Ok(graph.get_entity(&EntityId(uuid))?.into_iter().collect());
+    }
+
+    let filter = EntityFilter {
+        name_pattern: Some(request.entity.clone()),
+        ..Default::default()
+    };
+    let mut matches = graph.query_entities(&filter)?;
+    // EntityFilter name matching is intentionally broad for search. Impact
+    // identity resolution is exact and fail-closed.
+    matches.retain(|entity| entity.name == request.entity);
+    if let Some(file) = request.file.as_deref() {
+        matches.retain(|entity| kin_review::StableEntityIdentity::from_entity(entity).file == file);
+    }
+    if let Some(kind) = request.kind.as_deref() {
+        matches.retain(|entity| kin_review::StableEntityIdentity::from_entity(entity).kind == kind);
+    }
+    if let Some(signature) = request.signature.as_deref() {
+        let normalized = signature.split_whitespace().collect::<Vec<_>>().join(" ");
+        matches.retain(|entity| {
+            kin_review::StableEntityIdentity::from_entity(entity).signature == normalized
+        });
+    }
+    Ok(matches)
 }
 
 /// Actionable guidance when `kin impact <symbol>` can't resolve the symbol in
@@ -102,7 +223,39 @@ fn impact_not_found_guidance(entity: &str) -> Vec<String> {
 
 #[cfg(test)]
 mod tests {
-    use super::impact_not_found_guidance;
+    use super::{build_impact_response, impact_not_found_guidance, ImpactRequest};
+    use kin_model::{
+        Entity, EntityId, EntityKind, EntityMetadata, EntityRole, EntityStore, FilePathId,
+        FingerprintAlgorithm, GraphNodeId, Hash256, LanguageId, Relation, RelationId, RelationKind,
+        RelationOrigin, SemanticFingerprint, Visibility,
+    };
+
+    fn entity(name: &str, file: &str) -> Entity {
+        Entity {
+            id: EntityId::from_content(file, name, "function", 1),
+            kind: EntityKind::Function,
+            name: name.to_string(),
+            language: LanguageId::Rust,
+            fingerprint: SemanticFingerprint {
+                algorithm: FingerprintAlgorithm::V1TreeSitter,
+                ast_hash: Hash256::from_bytes([0; 32]),
+                signature_hash: Hash256::from_bytes([0; 32]),
+                behavior_hash: Hash256::from_bytes([0; 32]),
+                equivalence_hash: Hash256::from_bytes([0; 32]),
+                stability_score: 1.0,
+            },
+            file_origin: Some(FilePathId::new(file)),
+            span: None,
+            signature: format!("fn {name}()"),
+            visibility: Visibility::Public,
+            role: EntityRole::Source,
+            doc_summary: None,
+            metadata: EntityMetadata::default(),
+            lineage_parent: None,
+            created_in: None,
+            superseded_by: None,
+        }
+    }
 
     #[test]
     fn impact_not_found_guidance_keeps_signal_and_offers_next_steps() {
@@ -119,6 +272,118 @@ mod tests {
         assert!(
             joined.contains("kin xref"),
             "notes cross-repo path: {joined}"
+        );
+    }
+
+    #[tokio::test]
+    async fn json_response_exposes_ranked_graph_path_without_replacing_legacy_lines() {
+        let graph = kin_db::InMemoryGraph::new();
+        let target = entity("changed", "src/lib.rs");
+        let caller = entity("caller", "src/caller.rs");
+        graph.upsert_entity(&target).unwrap();
+        graph.upsert_entity(&caller).unwrap();
+        graph
+            .upsert_relation(&Relation {
+                id: RelationId::from_content(
+                    &caller.id.to_string(),
+                    &target.id.to_string(),
+                    "calls",
+                ),
+                kind: RelationKind::Calls,
+                src: GraphNodeId::Entity(caller.id),
+                dst: GraphNodeId::Entity(target.id),
+                confidence: 1.0,
+                origin: RelationOrigin::Parsed,
+                created_in: None,
+                import_source: None,
+                evidence: Vec::new(),
+            })
+            .unwrap();
+        let dir = tempfile::tempdir().unwrap();
+        let layout = kin_core::KinLayout::new(dir.path().join(".kin"));
+        let response = build_impact_response(
+            &layout,
+            &graph,
+            &ImpactRequest {
+                entity: "changed".to_string(),
+                depth: 3,
+                file: Some("src/lib.rs".to_string()),
+                kind: Some("function".to_string()),
+                signature: Some("fn changed()".to_string()),
+                require_unique: true,
+            },
+        )
+        .await
+        .unwrap();
+
+        assert_eq!(response.resolution, "resolved");
+        assert!(response.lines[0].contains("Impact analysis"));
+        let ranked = response.ranked.expect("ranked impact report");
+        assert_eq!(ranked.candidates.len(), 1);
+        assert_eq!(ranked.candidates[0].identity.name, "caller");
+        assert_eq!(ranked.candidates[0].path.len(), 1);
+        assert!(ranked
+            .score_semantics
+            .contains("not a calibrated probability"));
+    }
+
+    #[tokio::test]
+    async fn structured_resolution_fails_closed_on_ambiguous_name() {
+        let graph = kin_db::InMemoryGraph::new();
+        graph.upsert_entity(&entity("same", "src/a.rs")).unwrap();
+        graph.upsert_entity(&entity("same", "src/b.rs")).unwrap();
+        let dir = tempfile::tempdir().unwrap();
+        let layout = kin_core::KinLayout::new(dir.path().join(".kin"));
+        let response = build_impact_response(
+            &layout,
+            &graph,
+            &ImpactRequest {
+                entity: "same".to_string(),
+                depth: 3,
+                file: None,
+                kind: None,
+                signature: None,
+                require_unique: true,
+            },
+        )
+        .await
+        .unwrap();
+        assert_eq!(response.resolution, "ambiguous");
+        assert_eq!(response.query.match_count, 2);
+        assert!(response.ranked.is_none());
+    }
+
+    #[tokio::test]
+    async fn signature_qualifier_resolves_same_file_same_name_overload() {
+        let graph = kin_db::InMemoryGraph::new();
+        let mut first = entity("handle", "src/handlers.rs");
+        first.signature = "fn handle(value: u32)".to_string();
+        let mut second = entity("handle", "src/handlers.rs");
+        second.id = EntityId::from_content("src/handlers.rs", "handle", "function", 20);
+        second.signature = "fn handle(value: String)".to_string();
+        graph.upsert_entity(&first).unwrap();
+        graph.upsert_entity(&second).unwrap();
+        let dir = tempfile::tempdir().unwrap();
+        let layout = kin_core::KinLayout::new(dir.path().join(".kin"));
+        let response = build_impact_response(
+            &layout,
+            &graph,
+            &ImpactRequest {
+                entity: "handle".to_string(),
+                depth: 3,
+                file: Some("src/handlers.rs".to_string()),
+                kind: Some("function".to_string()),
+                signature: Some("fn   handle(value: String)".to_string()),
+                require_unique: true,
+            },
+        )
+        .await
+        .unwrap();
+        assert_eq!(response.resolution, "resolved");
+        assert_eq!(response.query.match_count, 1);
+        assert_eq!(
+            response.ranked.unwrap().root_identity.signature,
+            "fn handle(value: String)"
         );
     }
 }

--- a/crates/kin-cli/src/main.rs
+++ b/crates/kin-cli/src/main.rs
@@ -124,6 +124,18 @@ enum Command {
         /// Maximum depth
         #[arg(short, long, default_value = "3")]
         depth: u32,
+        /// Exact repo-relative file qualifier for stable identity resolution
+        #[arg(long)]
+        file: Option<String>,
+        /// Exact entity-kind qualifier (for example: function or method)
+        #[arg(long)]
+        kind: Option<String>,
+        /// Whitespace-normalized declaration signature for overload resolution
+        #[arg(long)]
+        signature: Option<String>,
+        /// Emit the ranked graph-evidence report as JSON; ambiguous identities fail closed
+        #[arg(long, default_value_t = false)]
+        json: bool,
     },
     /// Build a context pack for an entity
     Context {
@@ -2022,7 +2034,14 @@ fn main() -> Result<()> {
                     yes,
                     force,
                 } => commands::eject::run(revert_files, yes || force).await,
-                Command::Impact { entity, depth } => commands::impact::run(entity, depth).await,
+                Command::Impact {
+                    entity,
+                    depth,
+                    file,
+                    kind,
+                    signature,
+                    json,
+                } => commands::impact::run(entity, depth, file, kind, signature, json).await,
                 Command::Context {
                     entity,
                     budget,

--- a/crates/kin-cli/tests/prepared_state_json.rs
+++ b/crates/kin-cli/tests/prepared_state_json.rs
@@ -149,20 +149,26 @@ fn parse_json_output(output: &Output, context: &str) -> Value {
     serde_json::from_slice(&output.stdout).expect("stdout should be valid json")
 }
 
+fn kin(repo: &Path, kin_home: &Path) -> Command {
+    let mut command = Command::new(env!("CARGO_BIN_EXE_kin"));
+    command.current_dir(repo).env("KIN_HOME", kin_home);
+    command
+}
+
 #[test]
 fn prepared_state_publish_and_materialize_preserve_indexed_state() {
     let root = tempdir().expect("temp root");
     let repo1 = root.path().join("repo1");
     let repo2 = root.path().join("repo2");
     let prepared_dir = root.path().join("prepared");
+    let kin_home = root.path().join("kin-home");
     let remote = "https://example.com/acme/prepared-state.git";
 
     init_seed_repo(&repo1, remote);
     clone_same_repo_identity(&repo1, &repo2, remote);
 
-    let init = Command::new(env!("CARGO_BIN_EXE_kin"))
+    let init = kin(&repo1, &kin_home)
         .args(["init", "--json", "."])
-        .current_dir(&repo1)
         .output()
         .expect("run kin init");
     let init_payload = parse_json_output(&init, "kin init --json");
@@ -170,7 +176,7 @@ fn prepared_state_publish_and_materialize_preserve_indexed_state() {
 
     seed_local_vectors(&repo1.join(".kin/kindb/graph.kndb"));
 
-    let publish = Command::new(env!("CARGO_BIN_EXE_kin"))
+    let publish = kin(&repo1, &kin_home)
         .args([
             "prepared-state",
             "publish",
@@ -178,7 +184,6 @@ fn prepared_state_publish_and_materialize_preserve_indexed_state() {
             "--target",
             prepared_dir.to_str().expect("prepared dir"),
         ])
-        .current_dir(&repo1)
         .output()
         .expect("run kin prepared-state publish");
     let publish_payload = parse_json_output(&publish, "kin prepared-state publish --json");
@@ -186,7 +191,7 @@ fn prepared_state_publish_and_materialize_preserve_indexed_state() {
     assert_eq!(publish_payload["text_index_present"], true);
     assert_eq!(publish_payload["vector_index_present"], true);
 
-    let materialize = Command::new(env!("CARGO_BIN_EXE_kin"))
+    let materialize = kin(&repo2, &kin_home)
         .args([
             "prepared-state",
             "materialize",
@@ -194,7 +199,6 @@ fn prepared_state_publish_and_materialize_preserve_indexed_state() {
             "--source",
             prepared_dir.to_str().expect("prepared dir"),
         ])
-        .current_dir(&repo2)
         .output()
         .expect("run kin prepared-state materialize");
     let materialize_payload =
@@ -209,13 +213,12 @@ fn prepared_state_publish_and_materialize_preserve_indexed_state() {
         publish_payload["cache_key"]
     );
 
-    let support = Command::new(env!("CARGO_BIN_EXE_kin"))
+    let support = kin(&repo2, &kin_home)
         .args(["support", "--json"])
         .env("KIN_DAEMON_BIN", common::fresh_daemon_bin())
         .env("KIN_DAEMON_DISABLE_LSP", "1")
         .env("KIN_DAEMON_IDLE_TIMEOUT_SECS", "1")
         .env("KIN_DAEMON_READY_TIMEOUT_SECS", "30")
-        .current_dir(&repo2)
         .output()
         .expect("run kin support --json");
     let support_payload = parse_json_output(&support, "kin support --json");
@@ -281,21 +284,21 @@ fn prepared_state_materialize_rejects_repo_state_mismatch() {
     let repo1 = root.path().join("repo1");
     let repo2 = root.path().join("repo2");
     let prepared_dir = root.path().join("prepared");
+    let kin_home = root.path().join("kin-home");
     let remote = "https://example.com/acme/prepared-state.git";
 
     init_seed_repo(&repo1, remote);
     clone_same_repo_identity(&repo1, &repo2, remote);
 
-    let init = Command::new(env!("CARGO_BIN_EXE_kin"))
+    let init = kin(&repo1, &kin_home)
         .args(["init", "--json", "."])
-        .current_dir(&repo1)
         .output()
         .expect("run kin init");
     let _ = parse_json_output(&init, "kin init --json");
 
     seed_local_vectors(&repo1.join(".kin/kindb/graph.kndb"));
 
-    let publish = Command::new(env!("CARGO_BIN_EXE_kin"))
+    let publish = kin(&repo1, &kin_home)
         .args([
             "prepared-state",
             "publish",
@@ -303,7 +306,6 @@ fn prepared_state_materialize_rejects_repo_state_mismatch() {
             "--target",
             prepared_dir.to_str().expect("prepared dir"),
         ])
-        .current_dir(&repo1)
         .output()
         .expect("run kin prepared-state publish");
     let _ = parse_json_output(&publish, "kin prepared-state publish --json");
@@ -312,7 +314,7 @@ fn prepared_state_materialize_rejects_repo_state_mismatch() {
     git(&repo2, &["config", "user.name", "Kin"]);
     git(&repo2, &["commit", "--allow-empty", "-m", "drift"]);
 
-    let materialize = Command::new(env!("CARGO_BIN_EXE_kin"))
+    let materialize = kin(&repo2, &kin_home)
         .args([
             "prepared-state",
             "materialize",
@@ -320,7 +322,6 @@ fn prepared_state_materialize_rejects_repo_state_mismatch() {
             "--source",
             prepared_dir.to_str().expect("prepared dir"),
         ])
-        .current_dir(&repo2)
         .output()
         .expect("run kin prepared-state materialize");
     assert!(

--- a/crates/kin-cli/tests/prepared_state_json.rs
+++ b/crates/kin-cli/tests/prepared_state_json.rs
@@ -151,7 +151,13 @@ fn parse_json_output(output: &Output, context: &str) -> Value {
 
 fn kin(repo: &Path, kin_home: &Path) -> Command {
     let mut command = Command::new(env!("CARGO_BIN_EXE_kin"));
-    command.current_dir(repo).env("KIN_HOME", kin_home);
+    command
+        .current_dir(repo)
+        .env("KIN_HOME", kin_home)
+        .env("KIN_REGISTRY_PATH", kin_home.join("registry.toml"))
+        .env_remove("KIN_DAEMON_URL")
+        .env_remove("KIN_SUPERVISOR_URL")
+        .env_remove("KIN_SESSION_ID");
     command
 }
 
@@ -236,8 +242,8 @@ fn prepared_state_publish_and_materialize_preserve_indexed_state() {
     );
     assert_eq!(support_payload["pending_embedding_count"], 0);
 
-    let artifact_dir = Path::new("/tmp/workstreamA-prepared-state-ownership-proof");
-    fs::create_dir_all(artifact_dir).expect("create proof artifact dir");
+    let artifact_dir = root.path().join("proof-artifact");
+    fs::create_dir_all(&artifact_dir).expect("create proof artifact dir");
     fs::write(
         artifact_dir.join("publish.json"),
         serde_json::to_string_pretty(&publish_payload).expect("serialize publish payload"),

--- a/crates/kin-review/src/lib.rs
+++ b/crates/kin-review/src/lib.rs
@@ -8,6 +8,7 @@ pub mod format;
 pub mod gate;
 pub mod impact;
 pub mod inline;
+pub mod ranked_impact;
 pub mod ref_graph;
 pub mod release_gate;
 pub mod revert_history;
@@ -32,6 +33,11 @@ pub use impact::{analyze_impact, analyze_impact_at, EntityImpact, ImpactGraph, I
 pub use inline::{
     collect_inline_comments, group_by_file, InlineComment, InlineCommentKind,
     CONSUMER_FANOUT_THRESHOLD,
+};
+pub use ranked_impact::{
+    rank_impact, rank_impact_at, CandidateLocation, ImpactBucket, PriorityScoreComponents,
+    RankedImpactCandidate, RankedImpactReport, RelationPathStep, StableEntityIdentity,
+    PRIORITY_SCORE_FORMULA, RANKED_IMPACT_SCHEMA_VERSION,
 };
 pub use ref_graph::GraphAtRef;
 pub use release_gate::{

--- a/crates/kin-review/src/ranked_impact.rs
+++ b/crates/kin-review/src/ranked_impact.rs
@@ -293,9 +293,11 @@ fn candidate_is_better(
     candidate: &RankedImpactCandidate,
     existing: &RankedImpactCandidate,
 ) -> bool {
-    candidate.priority_score > existing.priority_score
-        || (candidate.priority_score == existing.priority_score
-            && (candidate.hop, candidate.entity_id) < (existing.hop, existing.entity_id))
+    candidate.hop < existing.hop
+        || (candidate.hop == existing.hop
+            && (candidate.priority_score > existing.priority_score
+                || (candidate.priority_score == existing.priority_score
+                    && candidate.entity_id < existing.entity_id)))
 }
 
 fn relation_sort_key(relation: &Relation) -> (String, String, String) {
@@ -363,7 +365,7 @@ fn score_components(
         bucket_points: bucket.points(),
         relation_points: relation_points(relation.kind),
         hop_points,
-        confidence_points: (confidence_basis_points(relation.confidence) + 50) / 100,
+        confidence_points: (relation.confidence.clamp(0.0, 1.0) * 100.0).round() as u32,
         source_evidence_points: if relation
             .evidence
             .iter()
@@ -664,8 +666,8 @@ mod tests {
         let root = entity("root", "src/root.rs", 1);
         let caller = entity("caller", "src/caller.rs", 1);
         let mut relation = edge(&caller, &root, RelationKind::Calls, false);
-        relation.confidence = 0.805;
+        relation.confidence = 0.8049;
         let components = score_components(ImpactBucket::RuntimeCaller, &relation, 1);
-        assert_eq!(components.confidence_points, 81);
+        assert_eq!(components.confidence_points, 80);
     }
 }

--- a/crates/kin-review/src/ranked_impact.rs
+++ b/crates/kin-review/src/ranked_impact.rs
@@ -31,6 +31,8 @@ pub const PRIORITY_SCORE_FORMULA: &str = "bucket_points + relation_points + max(
 /// to compare candidates across re-indexes and distinguish overloads.
 /// `EntityId` includes the declaration's start line, so it is included in the
 /// report as snapshot provenance but is not the candidate's durable identity.
+/// Stable identity is not necessarily unique within one snapshot: conditional
+/// declarations may have identical signatures in the same file.
 #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
 pub struct StableEntityIdentity {
     pub file: String,
@@ -187,7 +189,8 @@ pub fn rank_impact_at<I: ImpactGraph>(
     // The first route at a hop is canonical because each frontier's inbound
     // relations are sorted. A shorter route always dominates deeper traversal.
     let mut shallowest_hop: HashMap<EntityId, u32> = HashMap::from([(*root, 0)]);
-    let mut candidates: BTreeMap<StableEntityIdentity, RankedImpactCandidate> = BTreeMap::new();
+    let mut candidates: BTreeMap<(StableEntityIdentity, EntityId), RankedImpactCandidate> =
+        BTreeMap::new();
 
     while let Some(frontier) = queue.pop_front() {
         if frontier.hop >= bounded_depth {
@@ -215,6 +218,7 @@ pub fn rank_impact_at<I: ImpactGraph>(
             };
             let hop = frontier.hop + 1;
             let candidate_identity = StableEntityIdentity::from_entity(&candidate_entity);
+            let candidate_key = (candidate_identity.clone(), candidate_id);
             let step = RelationPathStep {
                 relation_id: relation.id,
                 relation_kind: relation.kind,
@@ -244,10 +248,10 @@ pub fn rank_impact_at<I: ImpactGraph>(
                 path: path.clone(),
             };
 
-            match candidates.get(&candidate_identity) {
+            match candidates.get(&candidate_key) {
                 Some(existing) if !candidate_is_better(&ranked, existing) => {}
                 _ => {
-                    candidates.insert(candidate_identity, ranked);
+                    candidates.insert(candidate_key, ranked);
                 }
             }
 
@@ -315,6 +319,7 @@ fn is_impact_relation(kind: RelationKind) -> bool {
             | RelationKind::Implements
             | RelationKind::Overrides
             | RelationKind::Calls
+            | RelationKind::Spawns
             | RelationKind::Instantiates
             | RelationKind::References
             | RelationKind::UsesMacro
@@ -343,9 +348,10 @@ fn impact_bucket(entity: &Entity, relation: RelationKind) -> ImpactBucket {
     } else {
         match relation {
             RelationKind::ConsumesContract => ImpactBucket::ContractConsumer,
-            RelationKind::Calls | RelationKind::Instantiates | RelationKind::SendsMessage => {
-                ImpactBucket::RuntimeCaller
-            }
+            RelationKind::Calls
+            | RelationKind::Spawns
+            | RelationKind::Instantiates
+            | RelationKind::SendsMessage => ImpactBucket::RuntimeCaller,
             RelationKind::Extends
             | RelationKind::Implements
             | RelationKind::Overrides
@@ -381,7 +387,7 @@ fn score_components(
 fn relation_points(kind: RelationKind) -> u32 {
     match kind {
         RelationKind::ConsumesContract => 120,
-        RelationKind::Calls => 110,
+        RelationKind::Calls | RelationKind::Spawns => 110,
         RelationKind::Extends | RelationKind::Implements | RelationKind::Overrides => 105,
         RelationKind::Instantiates | RelationKind::References | RelationKind::UsesType => 90,
         RelationKind::SubscribesTo | RelationKind::SendsMessage => 80,
@@ -662,6 +668,39 @@ mod tests {
     }
 
     #[test]
+    fn identical_conditional_declarations_remain_distinct_candidates() {
+        let root = entity("root", "src/root.rs", 1);
+        let first = entity("platform", "src/platform.rs", 10);
+        let second = entity("platform", "src/platform.rs", 30);
+        assert_eq!(
+            StableEntityIdentity::from_entity(&first),
+            StableEntityIdentity::from_entity(&second)
+        );
+
+        let mut graph = Graph::default();
+        for value in [&root, &first, &second] {
+            graph.entities.insert(value.id, value.clone());
+        }
+        graph.relations.insert(
+            root.id,
+            vec![
+                edge(&first, &root, RelationKind::Calls, true),
+                edge(&second, &root, RelationKind::Calls, true),
+            ],
+        );
+
+        let report = rank_impact_at(&graph, &root.id, 1).unwrap();
+        assert_eq!(report.candidates.len(), 2);
+        let ids: Vec<_> = report
+            .candidates
+            .iter()
+            .map(|candidate| candidate.entity_id)
+            .collect();
+        assert!(ids.contains(&first.id));
+        assert!(ids.contains(&second.id));
+    }
+
+    #[test]
     fn confidence_points_match_the_documented_rounding_formula() {
         let root = entity("root", "src/root.rs", 1);
         let caller = entity("caller", "src/caller.rs", 1);
@@ -669,5 +708,28 @@ mod tests {
         relation.confidence = 0.8049;
         let components = score_components(ImpactBucket::RuntimeCaller, &relation, 1);
         assert_eq!(components.confidence_points, 80);
+    }
+
+    #[test]
+    fn spawned_runtime_caller_is_ranked_with_direct_path_evidence() {
+        let root = entity("worker", "src/worker.rs", 10);
+        let caller = entity("launch", "src/launch.rs", 20);
+        let mut graph = Graph::default();
+        for value in [&root, &caller] {
+            graph.entities.insert(value.id, value.clone());
+        }
+        graph.relations.insert(
+            root.id,
+            vec![edge(&caller, &root, RelationKind::Spawns, true)],
+        );
+
+        let report = rank_impact_at(&graph, &root.id, 1).unwrap();
+        let candidate = report.candidates.first().expect("spawn caller");
+        assert_eq!(candidate.identity.name, "launch");
+        assert_eq!(candidate.bucket, ImpactBucket::RuntimeCaller);
+        assert_eq!(candidate.relation, RelationKind::Spawns);
+        assert_eq!(candidate.score_components.relation_points, 110);
+        assert_eq!(candidate.path[0].relation_kind, RelationKind::Spawns);
+        assert!(candidate.path[0].evidence[0].source_span.is_some());
     }
 }

--- a/crates/kin-review/src/ranked_impact.rs
+++ b/crates/kin-review/src/ranked_impact.rs
@@ -1,0 +1,671 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Firelock, LLC
+
+//! Deterministic, evidence-preserving ranking over Kin's graph-native impact walk.
+//!
+//! The score is an inspection-priority heuristic, not a calibrated probability.
+//! Every point is attributable to a graph relation, its path length, confidence,
+//! and captured source evidence. The existing [`crate::impact::ImpactReport`]
+//! remains the compatibility surface for review policy; this module is additive.
+
+use std::collections::{BTreeMap, HashMap, VecDeque};
+
+use kin_model::entity::{Entity, EntityRole};
+use kin_model::graph::GraphStore;
+use kin_model::ids::{EntityId, RelationId};
+use kin_model::relation::{GraphNodeId, Relation, RelationEvidence, RelationKind};
+use serde::{Deserialize, Serialize};
+
+use crate::error::ReviewError;
+use crate::impact::{ImpactGraph, LiveGraph};
+
+pub const RANKED_IMPACT_SCHEMA_VERSION: &str = "kin.ranked-impact.v1";
+
+/// Exact integer formula used for [`RankedImpactCandidate::priority_score`].
+///
+/// The components are intentionally exposed in each result. A consumer must
+/// never relabel this score as likelihood, risk probability, or calibration.
+pub const PRIORITY_SCORE_FORMULA: &str = "bucket_points + relation_points + max(0, 240 - 60 * (hop - 1)) + round(100 * clamp(relation_confidence, 0, 1)) + (25 if the relation carries a source span else 0)";
+
+/// Line-independent `(file, name, kind, normalized signature)` identity used
+/// to compare candidates across re-indexes and distinguish overloads.
+/// `EntityId` includes the declaration's start line, so it is included in the
+/// report as snapshot provenance but is not the candidate's durable identity.
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+pub struct StableEntityIdentity {
+    pub file: String,
+    pub name: String,
+    pub kind: String,
+    /// Whitespace-normalized declaration signature. This distinguishes
+    /// overloads without depending on a declaration's line number.
+    pub signature: String,
+}
+
+impl StableEntityIdentity {
+    pub fn from_entity(entity: &Entity) -> Self {
+        Self {
+            file: entity_file(entity).unwrap_or_default(),
+            name: entity.name.clone(),
+            kind: entity_kind_name(entity),
+            signature: normalized_signature(entity),
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum ImpactBucket {
+    ContractConsumer,
+    RuntimeCaller,
+    TypeDependent,
+    Dependent,
+    Test,
+    Derived,
+}
+
+impl ImpactBucket {
+    pub fn points(self) -> u32 {
+        match self {
+            Self::ContractConsumer => 500,
+            Self::RuntimeCaller => 450,
+            Self::TypeDependent => 400,
+            Self::Dependent => 350,
+            Self::Test => 250,
+            Self::Derived => 100,
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct CandidateLocation {
+    pub file: String,
+    pub start_line: Option<u32>,
+    pub end_line: Option<u32>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct RelationPathStep {
+    pub relation_id: RelationId,
+    pub relation_kind: RelationKind,
+    pub from_entity_id: EntityId,
+    pub from_identity: StableEntityIdentity,
+    pub to_entity_id: EntityId,
+    pub to_identity: StableEntityIdentity,
+    pub confidence_basis_points: u32,
+    /// Parser/linker evidence copied from the graph edge. Source spans, rules,
+    /// tokens, and resolved paths remain machine-checkable in the output.
+    pub evidence: Vec<RelationEvidence>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct PriorityScoreComponents {
+    pub bucket_points: u32,
+    pub relation_points: u32,
+    pub hop_points: u32,
+    pub confidence_points: u32,
+    pub source_evidence_points: u32,
+}
+
+impl PriorityScoreComponents {
+    pub fn total(&self) -> u32 {
+        self.bucket_points
+            + self.relation_points
+            + self.hop_points
+            + self.confidence_points
+            + self.source_evidence_points
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct RankedImpactCandidate {
+    /// Snapshot-local graph id. Use `identity` to compare across snapshots.
+    pub entity_id: EntityId,
+    pub identity: StableEntityIdentity,
+    pub location: CandidateLocation,
+    pub bucket: ImpactBucket,
+    /// Relation joining this candidate to the next entity toward the root.
+    pub relation: RelationKind,
+    pub hop: u32,
+    /// Inspection-priority points. This is not a calibrated probability.
+    pub priority_score: u32,
+    pub score_components: PriorityScoreComponents,
+    /// Root-near to candidate-far graph path, preserving every edge's evidence.
+    pub path: Vec<RelationPathStep>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct RankedImpactReport {
+    pub schema_version: String,
+    pub root_entity_id: EntityId,
+    pub root_identity: StableEntityIdentity,
+    pub max_depth: u32,
+    pub score_semantics: String,
+    pub score_formula: String,
+    pub candidates: Vec<RankedImpactCandidate>,
+}
+
+/// Rank graph-native downstream impact from a live graph store.
+pub fn rank_impact<G: GraphStore>(
+    store: &G,
+    root: &EntityId,
+    max_depth: u32,
+) -> Result<RankedImpactReport, ReviewError> {
+    rank_impact_at(&LiveGraph(store), root, max_depth)
+}
+
+/// Rank graph-native downstream impact from an explicitly scoped graph view.
+///
+/// Traversal follows inbound entity relations only: a candidate points to the
+/// entity it consumes. Outbound dependencies of the changed entity are not
+/// downstream impact. Relation iteration and final ranking have explicit
+/// stable tie-breaks, so storage/hash-map order cannot affect the result.
+pub fn rank_impact_at<I: ImpactGraph>(
+    graph: &I,
+    root: &EntityId,
+    max_depth: u32,
+) -> Result<RankedImpactReport, ReviewError> {
+    let root_entity = graph
+        .get_entity(root)?
+        .ok_or(ReviewError::EntityNotFound(*root))?;
+    let root_identity = StableEntityIdentity::from_entity(&root_entity);
+    let bounded_depth = max_depth.min(8);
+
+    #[derive(Clone)]
+    struct Frontier {
+        entity_id: EntityId,
+        entity: Entity,
+        hop: u32,
+        path: Vec<RelationPathStep>,
+    }
+
+    let mut queue = VecDeque::from([Frontier {
+        entity_id: *root,
+        entity: root_entity,
+        hop: 0,
+        path: Vec::new(),
+    }]);
+    // The first route at a hop is canonical because each frontier's inbound
+    // relations are sorted. A shorter route always dominates deeper traversal.
+    let mut shallowest_hop: HashMap<EntityId, u32> = HashMap::from([(*root, 0)]);
+    let mut candidates: BTreeMap<StableEntityIdentity, RankedImpactCandidate> = BTreeMap::new();
+
+    while let Some(frontier) = queue.pop_front() {
+        if frontier.hop >= bounded_depth {
+            continue;
+        }
+        let mut relations = graph.get_all_relations_for_entity(&frontier.entity_id)?;
+        relations.retain(|relation| is_impact_relation(relation.kind));
+        relations.sort_by_key(relation_sort_key);
+
+        for relation in relations {
+            if relation.dst != GraphNodeId::Entity(frontier.entity_id) {
+                continue;
+            }
+            let Some(candidate_id) = relation.src.as_entity() else {
+                continue;
+            };
+            if frontier.path.iter().any(|step| {
+                step.to_entity_id == candidate_id || step.from_entity_id == candidate_id
+            }) || candidate_id == *root
+            {
+                continue;
+            }
+            let Some(candidate_entity) = graph.get_entity(&candidate_id)? else {
+                continue;
+            };
+            let hop = frontier.hop + 1;
+            let candidate_identity = StableEntityIdentity::from_entity(&candidate_entity);
+            let step = RelationPathStep {
+                relation_id: relation.id,
+                relation_kind: relation.kind,
+                from_entity_id: candidate_id,
+                from_identity: candidate_identity.clone(),
+                to_entity_id: frontier.entity_id,
+                to_identity: StableEntityIdentity::from_entity(&frontier.entity),
+                confidence_basis_points: confidence_basis_points(relation.confidence),
+                evidence: relation.evidence.clone(),
+            };
+            let mut path = frontier.path.clone();
+            // Traversal discovers root-near edges first, so append preserves the
+            // root-near -> candidate-far order promised by the wire contract.
+            path.push(step);
+
+            let bucket = impact_bucket(&candidate_entity, relation.kind);
+            let components = score_components(bucket, &relation, hop);
+            let ranked = RankedImpactCandidate {
+                entity_id: candidate_id,
+                identity: candidate_identity.clone(),
+                location: candidate_location(&candidate_entity),
+                bucket,
+                relation: relation.kind,
+                hop,
+                priority_score: components.total(),
+                score_components: components,
+                path: path.clone(),
+            };
+
+            match candidates.get(&candidate_identity) {
+                Some(existing) if !candidate_is_better(&ranked, existing) => {}
+                _ => {
+                    candidates.insert(candidate_identity, ranked);
+                }
+            }
+
+            let should_expand = match shallowest_hop.get(&candidate_id) {
+                Some(previous) => hop < *previous,
+                None => true,
+            };
+            if should_expand && hop < bounded_depth {
+                shallowest_hop.insert(candidate_id, hop);
+                queue.push_back(Frontier {
+                    entity_id: candidate_id,
+                    entity: candidate_entity,
+                    hop,
+                    path,
+                });
+            }
+        }
+    }
+
+    let mut candidates: Vec<_> = candidates.into_values().collect();
+    candidates.sort_by(|left, right| {
+        right
+            .priority_score
+            .cmp(&left.priority_score)
+            .then_with(|| left.hop.cmp(&right.hop))
+            .then_with(|| left.identity.cmp(&right.identity))
+            .then_with(|| left.entity_id.cmp(&right.entity_id))
+    });
+
+    Ok(RankedImpactReport {
+        schema_version: RANKED_IMPACT_SCHEMA_VERSION.to_string(),
+        root_entity_id: *root,
+        root_identity,
+        max_depth: bounded_depth,
+        score_semantics: "deterministic inspection-priority points; not a calibrated probability"
+            .to_string(),
+        score_formula: PRIORITY_SCORE_FORMULA.to_string(),
+        candidates,
+    })
+}
+
+fn candidate_is_better(
+    candidate: &RankedImpactCandidate,
+    existing: &RankedImpactCandidate,
+) -> bool {
+    candidate.priority_score > existing.priority_score
+        || (candidate.priority_score == existing.priority_score
+            && (candidate.hop, candidate.entity_id) < (existing.hop, existing.entity_id))
+}
+
+fn relation_sort_key(relation: &Relation) -> (String, String, String) {
+    (
+        relation.src.to_string(),
+        relation_kind_name(relation.kind),
+        relation.id.to_string(),
+    )
+}
+
+fn is_impact_relation(kind: RelationKind) -> bool {
+    matches!(
+        kind,
+        RelationKind::Extends
+            | RelationKind::Implements
+            | RelationKind::Overrides
+            | RelationKind::Calls
+            | RelationKind::Instantiates
+            | RelationKind::References
+            | RelationKind::UsesMacro
+            | RelationKind::UsesType
+            | RelationKind::Imports
+            | RelationKind::Includes
+            | RelationKind::DependsOn
+            | RelationKind::ConsumesContract
+            | RelationKind::SubscribesTo
+            | RelationKind::SendsMessage
+            | RelationKind::Tests
+            | RelationKind::Covers
+            | RelationKind::DerivedFrom
+    )
+}
+
+fn impact_bucket(entity: &Entity, relation: RelationKind) -> ImpactBucket {
+    if matches!(entity.role, EntityRole::Generated | EntityRole::Vendored)
+        || relation == RelationKind::DerivedFrom
+    {
+        ImpactBucket::Derived
+    } else if entity.role == EntityRole::Test
+        || matches!(relation, RelationKind::Tests | RelationKind::Covers)
+    {
+        ImpactBucket::Test
+    } else {
+        match relation {
+            RelationKind::ConsumesContract => ImpactBucket::ContractConsumer,
+            RelationKind::Calls | RelationKind::Instantiates | RelationKind::SendsMessage => {
+                ImpactBucket::RuntimeCaller
+            }
+            RelationKind::Extends
+            | RelationKind::Implements
+            | RelationKind::Overrides
+            | RelationKind::UsesType => ImpactBucket::TypeDependent,
+            _ => ImpactBucket::Dependent,
+        }
+    }
+}
+
+fn score_components(
+    bucket: ImpactBucket,
+    relation: &Relation,
+    hop: u32,
+) -> PriorityScoreComponents {
+    let hop_points = 240u32.saturating_sub(60u32.saturating_mul(hop.saturating_sub(1)));
+    PriorityScoreComponents {
+        bucket_points: bucket.points(),
+        relation_points: relation_points(relation.kind),
+        hop_points,
+        confidence_points: (confidence_basis_points(relation.confidence) + 50) / 100,
+        source_evidence_points: if relation
+            .evidence
+            .iter()
+            .any(|evidence| evidence.source_span.is_some())
+        {
+            25
+        } else {
+            0
+        },
+    }
+}
+
+fn relation_points(kind: RelationKind) -> u32 {
+    match kind {
+        RelationKind::ConsumesContract => 120,
+        RelationKind::Calls => 110,
+        RelationKind::Extends | RelationKind::Implements | RelationKind::Overrides => 105,
+        RelationKind::Instantiates | RelationKind::References | RelationKind::UsesType => 90,
+        RelationKind::SubscribesTo | RelationKind::SendsMessage => 80,
+        RelationKind::Imports | RelationKind::Includes | RelationKind::DependsOn => 70,
+        RelationKind::Tests | RelationKind::Covers => 50,
+        RelationKind::UsesMacro | RelationKind::DerivedFrom => 40,
+        _ => 0,
+    }
+}
+
+fn confidence_basis_points(confidence: f32) -> u32 {
+    (confidence.clamp(0.0, 1.0) * 10_000.0).round() as u32
+}
+
+fn candidate_location(entity: &Entity) -> CandidateLocation {
+    CandidateLocation {
+        file: entity_file(entity).unwrap_or_default(),
+        start_line: entity.span.as_ref().map(|span| span.start_line),
+        end_line: entity.span.as_ref().map(|span| span.end_line),
+    }
+}
+
+fn entity_file(entity: &Entity) -> Option<String> {
+    entity
+        .span
+        .as_ref()
+        .map(|span| span.file.to_string())
+        .or_else(|| entity.file_origin.as_ref().map(ToString::to_string))
+}
+
+fn entity_kind_name(entity: &Entity) -> String {
+    serde_json::to_value(entity.kind)
+        .ok()
+        .and_then(|value| value.as_str().map(ToOwned::to_owned))
+        .unwrap_or_else(|| format!("{:?}", entity.kind).to_ascii_lowercase())
+}
+
+fn normalized_signature(entity: &Entity) -> String {
+    let normalized = entity
+        .signature
+        .split_whitespace()
+        .collect::<Vec<_>>()
+        .join(" ");
+    if normalized.is_empty() {
+        format!("signature_hash:{}", entity.fingerprint.signature_hash)
+    } else {
+        normalized
+    }
+}
+
+fn relation_kind_name(kind: RelationKind) -> String {
+    serde_json::to_value(kind)
+        .ok()
+        .and_then(|value| value.as_str().map(ToOwned::to_owned))
+        .unwrap_or_else(|| format!("{kind:?}"))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::collections::HashMap;
+
+    use kin_model::entity::{
+        EntityKind, EntityMetadata, FingerprintAlgorithm, SemanticFingerprint, SourceSpan,
+        Visibility,
+    };
+    use kin_model::ids::{FilePathId, Hash256, LanguageId, SemanticChangeId};
+    use kin_model::provenance::{Actor, ActorId, Approval, AuditEvent};
+    use kin_model::relation::{RelationEvidence, RelationOrigin};
+    use kin_model::work::{Annotation, WorkItem, WorkScope};
+
+    #[derive(Default)]
+    struct Graph {
+        entities: HashMap<EntityId, Entity>,
+        relations: HashMap<EntityId, Vec<Relation>>,
+    }
+
+    impl ImpactGraph for Graph {
+        fn get_entity(&self, id: &EntityId) -> Result<Option<Entity>, ReviewError> {
+            Ok(self.entities.get(id).cloned())
+        }
+        fn get_relations(
+            &self,
+            _id: &EntityId,
+            _kinds: &[RelationKind],
+        ) -> Result<Vec<Relation>, ReviewError> {
+            Ok(Vec::new())
+        }
+        fn get_all_relations_for_entity(
+            &self,
+            id: &EntityId,
+        ) -> Result<Vec<Relation>, ReviewError> {
+            Ok(self.relations.get(id).cloned().unwrap_or_default())
+        }
+        fn get_downstream_impact(
+            &self,
+            _id: &EntityId,
+            _max_depth: u32,
+        ) -> Result<Vec<Entity>, ReviewError> {
+            Ok(Vec::new())
+        }
+        fn get_work_for_scope(&self, _scope: &WorkScope) -> Result<Vec<WorkItem>, ReviewError> {
+            Ok(Vec::new())
+        }
+        fn get_annotations_for_scope(
+            &self,
+            _scope: &WorkScope,
+        ) -> Result<Vec<Annotation>, ReviewError> {
+            Ok(Vec::new())
+        }
+        fn get_approvals_for_change(
+            &self,
+            _id: &SemanticChangeId,
+        ) -> Result<Vec<Approval>, ReviewError> {
+            Ok(Vec::new())
+        }
+        fn query_audit_events(
+            &self,
+            _actor_id: Option<&ActorId>,
+            _limit: usize,
+        ) -> Result<Vec<AuditEvent>, ReviewError> {
+            Ok(Vec::new())
+        }
+        fn get_actor(&self, _id: &ActorId) -> Result<Option<Actor>, ReviewError> {
+            Ok(None)
+        }
+    }
+
+    fn entity(name: &str, file: &str, line: u32) -> Entity {
+        Entity {
+            id: EntityId::from_content(file, name, "function", line),
+            kind: EntityKind::Function,
+            name: name.to_string(),
+            language: LanguageId::Rust,
+            fingerprint: SemanticFingerprint {
+                algorithm: FingerprintAlgorithm::V1TreeSitter,
+                ast_hash: Hash256::from_bytes([0; 32]),
+                signature_hash: Hash256::from_bytes([0; 32]),
+                behavior_hash: Hash256::from_bytes([0; 32]),
+                equivalence_hash: Hash256::from_bytes([0; 32]),
+                stability_score: 1.0,
+            },
+            file_origin: Some(FilePathId::new(file)),
+            span: Some(SourceSpan {
+                file: FilePathId::new(file),
+                start_byte: 0,
+                end_byte: 8,
+                start_line: line,
+                start_col: 0,
+                end_line: line + 1,
+                end_col: 0,
+            }),
+            signature: format!("fn {name}()"),
+            visibility: Visibility::Public,
+            role: EntityRole::Source,
+            doc_summary: None,
+            metadata: EntityMetadata::default(),
+            lineage_parent: None,
+            created_in: None,
+            superseded_by: None,
+        }
+    }
+
+    fn edge(src: &Entity, dst: &Entity, kind: RelationKind, with_span: bool) -> Relation {
+        Relation {
+            id: RelationId::from_content(
+                &src.id.to_string(),
+                &dst.id.to_string(),
+                &format!("{kind:?}"),
+            ),
+            kind,
+            src: GraphNodeId::Entity(src.id),
+            dst: GraphNodeId::Entity(dst.id),
+            confidence: 0.8,
+            origin: RelationOrigin::Parsed,
+            created_in: None,
+            import_source: None,
+            evidence: vec![RelationEvidence {
+                source_span: with_span.then(|| src.span.clone().unwrap()),
+                parser_rule: Some("test-rule".to_string()),
+                ..RelationEvidence::default()
+            }],
+        }
+    }
+
+    fn graph_in_order(reverse: bool) -> (Graph, EntityId) {
+        let root = entity("changed", "src/lib.rs", 10);
+        let direct = entity("direct", "src/direct.rs", 20);
+        let transitive = entity("transitive", "src/transitive.rs", 30);
+        let contract = entity("contract", "src/contract.rs", 40);
+        let mut graph = Graph::default();
+        for item in [&root, &direct, &transitive, &contract] {
+            graph.entities.insert(item.id, item.clone());
+        }
+        let mut inbound = vec![
+            edge(&direct, &root, RelationKind::Calls, true),
+            edge(&contract, &root, RelationKind::ConsumesContract, false),
+        ];
+        if reverse {
+            inbound.reverse();
+        }
+        graph.relations.insert(root.id, inbound);
+        graph.relations.insert(
+            direct.id,
+            vec![edge(&transitive, &direct, RelationKind::References, true)],
+        );
+        (graph, root.id)
+    }
+
+    #[test]
+    fn ranking_is_deterministic_across_relation_storage_order() {
+        let (a, root) = graph_in_order(false);
+        let (b, _) = graph_in_order(true);
+        let left = serde_json::to_vec(&rank_impact_at(&a, &root, 3).unwrap()).unwrap();
+        let right = serde_json::to_vec(&rank_impact_at(&b, &root, 3).unwrap()).unwrap();
+        assert_eq!(left, right);
+    }
+
+    #[test]
+    fn ranked_candidate_carries_complete_two_hop_path_evidence() {
+        let (graph, root) = graph_in_order(false);
+        let report = rank_impact_at(&graph, &root, 3).unwrap();
+        let candidate = report
+            .candidates
+            .iter()
+            .find(|candidate| candidate.identity.name == "transitive")
+            .expect("transitive candidate");
+        assert_eq!(candidate.hop, 2);
+        assert_eq!(candidate.path.len(), 2);
+        assert_eq!(candidate.path[0].to_identity.name, "changed");
+        assert_eq!(candidate.path[0].from_identity.name, "direct");
+        assert_eq!(candidate.path[1].to_identity.name, "direct");
+        assert_eq!(candidate.path[1].from_identity.name, "transitive");
+        assert!(candidate.path[1].evidence[0].source_span.is_some());
+        assert!(report
+            .score_semantics
+            .contains("not a calibrated probability"));
+    }
+
+    #[test]
+    fn stable_identity_ignores_line_and_snapshot_entity_id() {
+        let first = entity("same", "src/same.rs", 10);
+        let second = entity("same", "src/same.rs", 90);
+        assert_ne!(first.id, second.id);
+        assert_eq!(
+            StableEntityIdentity::from_entity(&first),
+            StableEntityIdentity::from_entity(&second)
+        );
+    }
+
+    #[test]
+    fn same_name_same_file_overloads_remain_distinct_candidates() {
+        let root = entity("root", "src/root.rs", 1);
+        let mut first = entity("handle", "src/handlers.rs", 10);
+        first.signature = "fn handle(value: u32)".to_string();
+        let mut second = entity("handle", "src/handlers.rs", 30);
+        second.signature = "fn   handle(value: String)".to_string();
+        let mut graph = Graph::default();
+        for value in [&root, &first, &second] {
+            graph.entities.insert(value.id, value.clone());
+        }
+        graph.relations.insert(
+            root.id,
+            vec![
+                edge(&first, &root, RelationKind::Calls, true),
+                edge(&second, &root, RelationKind::Calls, true),
+            ],
+        );
+        let report = rank_impact_at(&graph, &root.id, 1).unwrap();
+        assert_eq!(report.candidates.len(), 2);
+        let signatures: Vec<_> = report
+            .candidates
+            .iter()
+            .map(|candidate| candidate.identity.signature.as_str())
+            .collect();
+        assert!(signatures.contains(&"fn handle(value: u32)"));
+        assert!(signatures.contains(&"fn handle(value: String)"));
+    }
+
+    #[test]
+    fn confidence_points_match_the_documented_rounding_formula() {
+        let root = entity("root", "src/root.rs", 1);
+        let caller = entity("caller", "src/caller.rs", 1);
+        let mut relation = edge(&caller, &root, RelationKind::Calls, false);
+        relation.confidence = 0.805;
+        let components = score_components(ImpactBucket::RuntimeCaller, &relation, 1);
+        assert_eq!(components.confidence_points, 81);
+    }
+}


### PR DESCRIPTION
## Summary
- add deterministic, evidence-preserving ranked impact output for structured callers
- keep human resolution broad and avoid ranked traversal unless requested
- preserve CLI compatibility with older daemon payloads while failing closed for unsupported structured output
- enforce qualifiers for UUID resolution and minimum-distance hop semantics

## Verification
- focused `cargo test -p kin-review ranked_impact --locked`
- focused `cargo test -p kin-cli impact --locked`
- `cargo fmt -- --check`
- zero-file-search, runtime-boundary, and private-coupling guards
- CI-equivalent clippy allowlist with `-D warnings`
- `cargo build --all-targets --locked`
- `cargo test --locked`

Supersedes stale draft #288 and resolves its independent review findings on current `main`.