### PR TITLE
Enforce atomic multi-agent coordination

### DIFF
--- a/crates/kin-cli/src/commands/bench_meta.rs
+++ b/crates/kin-cli/src/commands/bench_meta.rs
@@ -31,6 +31,10 @@ pub(crate) struct BenchMeta {
 pub struct CoordinationMeta {
     pub schema: String,
     pub effective_mode: String,
+    #[serde(default)]
+    pub effective_mode_source: String,
+    #[serde(default)]
+    pub daemon_runtime_attested: bool,
     pub default_mode: String,
     pub hard_rejection_active: bool,
     pub capability_evaluation_active: bool,
@@ -43,6 +47,14 @@ pub struct CoordinationMeta {
     pub durable_event_schema: String,
     pub durable_event_store: String,
     pub durable_event_fsync_before_broadcast: bool,
+    #[serde(default)]
+    pub durable_event_mutation_fail_closed: bool,
+    #[serde(default)]
+    pub durable_event_lifecycle_complete: bool,
+    #[serde(default)]
+    pub durable_event_reservation_prefix: String,
+    #[serde(default)]
+    pub durable_event_requires_terminal_pair: bool,
     pub durable_event_families: Vec<String>,
     pub contract_scope_claim_eligible: bool,
     pub all_write_surfaces_claim_eligible: bool,
@@ -215,19 +227,39 @@ pub(crate) fn build_meta() -> Result<BenchMeta> {
 }
 
 pub fn coordination_meta() -> CoordinationMeta {
-    coordination_meta_for_mode(kin_mcp::CoordinationEnforcementMode::from_env())
+    coordination_meta_with_source(
+        kin_mcp::CoordinationEnforcementMode::from_env(),
+        "process_env",
+        false,
+    )
 }
 
 pub fn coordination_meta_for_mode(mode: kin_mcp::CoordinationEnforcementMode) -> CoordinationMeta {
+    coordination_meta_with_source(mode, "explicit_mode", false)
+}
+
+pub fn coordination_meta_for_daemon_mode(
+    mode: kin_mcp::CoordinationEnforcementMode,
+) -> CoordinationMeta {
+    coordination_meta_with_source(mode, "daemon_startup_snapshot", true)
+}
+
+fn coordination_meta_with_source(
+    mode: kin_mcp::CoordinationEnforcementMode,
+    source: &str,
+    daemon_runtime_attested: bool,
+) -> CoordinationMeta {
     CoordinationMeta {
         schema: "kin.coordination-enforcement.v1".to_string(),
         effective_mode: mode.as_str().to_string(),
+        effective_mode_source: source.to_string(),
+        daemon_runtime_attested,
         default_mode: "warn".to_string(),
         hard_rejection_active: mode.is_enforcing(),
         capability_evaluation_active: mode.evaluates(),
         capability_fail_closed_active: mode.is_enforcing(),
         intent_registration_linearized: true,
-        max_concurrent_intents_enforced: true,
+        max_concurrent_intents_enforced: mode.is_enforcing(),
         hard_intent_capabilities_checked: vec!["can_write".to_string()],
         transaction_capabilities_covered: vec!["can_write".to_string(), "can_commit".to_string()],
         surfaces: CoordinationSurfaceMeta {
@@ -243,6 +275,10 @@ pub fn coordination_meta_for_mode(mode: kin_mcp::CoordinationEnforcementMode) ->
         durable_event_schema: "kin.coordination-event.v1".to_string(),
         durable_event_store: ".kin/coordination_events.jsonl".to_string(),
         durable_event_fsync_before_broadcast: true,
+        durable_event_mutation_fail_closed: true,
+        durable_event_lifecycle_complete: true,
+        durable_event_reservation_prefix: "pending:".to_string(),
+        durable_event_requires_terminal_pair: true,
         durable_event_families: vec![
             "intent_registration".to_string(),
             "intent_release".to_string(),

--- a/crates/kin-cli/src/commands/bench_meta.rs
+++ b/crates/kin-cli/src/commands/bench_meta.rs
@@ -20,10 +20,44 @@ pub(crate) struct BenchMeta {
     vector_index_metadata_version: Option<u32>,
     feature_flags: Vec<&'static str>,
     embeddings: EmbeddingMeta,
+    coordination: CoordinationMeta,
     kin_commit: &'static str,
     kin_dirty: bool,
     kin_source_known: bool,
     dependency_provenance: &'static str,
+}
+
+#[derive(Debug, Clone, Serialize, serde::Deserialize)]
+pub struct CoordinationMeta {
+    pub schema: String,
+    pub effective_mode: String,
+    pub default_mode: String,
+    pub hard_rejection_active: bool,
+    pub capability_evaluation_active: bool,
+    pub capability_fail_closed_active: bool,
+    pub intent_registration_linearized: bool,
+    pub max_concurrent_intents_enforced: bool,
+    pub hard_intent_capabilities_checked: Vec<String>,
+    pub transaction_capabilities_covered: Vec<String>,
+    pub surfaces: CoordinationSurfaceMeta,
+    pub durable_event_schema: String,
+    pub durable_event_store: String,
+    pub durable_event_fsync_before_broadcast: bool,
+    pub durable_event_families: Vec<String>,
+    pub contract_scope_claim_eligible: bool,
+    pub all_write_surfaces_claim_eligible: bool,
+}
+
+#[derive(Debug, Clone, Serialize, serde::Deserialize)]
+pub struct CoordinationSurfaceMeta {
+    pub vfs_agent_write_entity: bool,
+    pub vfs_agent_write_artifact: bool,
+    pub mcp_transaction_entity: bool,
+    pub mcp_transaction_artifact: bool,
+    pub mcp_relation_endpoint_entities: bool,
+    pub contract: bool,
+    pub direct_filesystem_write: bool,
+    pub non_transaction_graph_mutation_tools: bool,
 }
 
 #[derive(Debug, Clone, Serialize)]
@@ -133,6 +167,14 @@ pub async fn run(json: bool, prepared_state: bool) -> Result<()> {
             println!("vector_index_metadata_version: disabled");
         }
         println!("feature_flags: {}", meta.feature_flags.join(","));
+        println!(
+            "coordination_enforcement_mode: {}",
+            meta.coordination.effective_mode
+        );
+        println!(
+            "coordination_contract_scope_claim_eligible: {}",
+            meta.coordination.contract_scope_claim_eligible
+        );
         println!("kin_commit: {}", meta.kin_commit);
         println!("kin_dirty: {}", meta.kin_dirty);
         println!("kin_source_known: {}", meta.kin_source_known);
@@ -164,11 +206,51 @@ pub(crate) fn build_meta() -> Result<BenchMeta> {
         vector_index_metadata_version: vector_index_metadata_version(),
         feature_flags: feature_flags(),
         embeddings: embedding_meta(),
+        coordination: coordination_meta(),
         kin_commit: build.sha,
         kin_dirty: build.dirty,
         kin_source_known: build.source_known,
         dependency_provenance: build.dependency_provenance,
     })
+}
+
+pub fn coordination_meta() -> CoordinationMeta {
+    coordination_meta_for_mode(kin_mcp::CoordinationEnforcementMode::from_env())
+}
+
+pub fn coordination_meta_for_mode(mode: kin_mcp::CoordinationEnforcementMode) -> CoordinationMeta {
+    CoordinationMeta {
+        schema: "kin.coordination-enforcement.v1".to_string(),
+        effective_mode: mode.as_str().to_string(),
+        default_mode: "warn".to_string(),
+        hard_rejection_active: mode.is_enforcing(),
+        capability_evaluation_active: mode.evaluates(),
+        capability_fail_closed_active: mode.is_enforcing(),
+        intent_registration_linearized: true,
+        max_concurrent_intents_enforced: true,
+        hard_intent_capabilities_checked: vec!["can_write".to_string()],
+        transaction_capabilities_covered: vec!["can_write".to_string(), "can_commit".to_string()],
+        surfaces: CoordinationSurfaceMeta {
+            vfs_agent_write_entity: true,
+            vfs_agent_write_artifact: true,
+            mcp_transaction_entity: true,
+            mcp_transaction_artifact: true,
+            mcp_relation_endpoint_entities: true,
+            contract: false,
+            direct_filesystem_write: false,
+            non_transaction_graph_mutation_tools: false,
+        },
+        durable_event_schema: "kin.coordination-event.v1".to_string(),
+        durable_event_store: ".kin/coordination_events.jsonl".to_string(),
+        durable_event_fsync_before_broadcast: true,
+        durable_event_families: vec![
+            "intent_registration".to_string(),
+            "intent_release".to_string(),
+            "transaction_outcome".to_string(),
+        ],
+        contract_scope_claim_eligible: false,
+        all_write_surfaces_claim_eligible: false,
+    }
 }
 
 /// Whether the Metal embedding backend is *actually* compiled into this binary.

--- a/crates/kin-cli/tests/bench_meta_json.rs
+++ b/crates/kin-cli/tests/bench_meta_json.rs
@@ -41,12 +41,17 @@ fn bench_meta_json_reports_cache_key_dimensions() {
         Some("off" | "warn" | "enforce")
     ));
     assert_eq!(coordination["default_mode"], "warn");
+    assert_eq!(coordination["effective_mode_source"], "process_env");
+    assert_eq!(coordination["daemon_runtime_attested"], false);
     assert_eq!(
         coordination["hard_rejection_active"],
         coordination["effective_mode"] == "enforce"
     );
     assert_eq!(coordination["intent_registration_linearized"], true);
-    assert_eq!(coordination["max_concurrent_intents_enforced"], true);
+    assert_eq!(
+        coordination["max_concurrent_intents_enforced"],
+        coordination["effective_mode"] == "enforce"
+    );
     assert_eq!(coordination["contract_scope_claim_eligible"], false);
     assert_eq!(coordination["all_write_surfaces_claim_eligible"], false);
     assert_eq!(coordination["surfaces"]["mcp_transaction_entity"], true);
@@ -56,6 +61,10 @@ fn bench_meta_json_reports_cache_key_dimensions() {
         "kin.coordination-event.v1"
     );
     assert_eq!(coordination["durable_event_fsync_before_broadcast"], true);
+    assert_eq!(coordination["durable_event_mutation_fail_closed"], true);
+    assert_eq!(coordination["durable_event_lifecycle_complete"], true);
+    assert_eq!(coordination["durable_event_reservation_prefix"], "pending:");
+    assert_eq!(coordination["durable_event_requires_terminal_pair"], true);
 
     let embeddings = payload["embeddings"]
         .as_object()

--- a/crates/kin-cli/tests/bench_meta_json.rs
+++ b/crates/kin-cli/tests/bench_meta_json.rs
@@ -32,6 +32,31 @@ fn bench_meta_json_reports_cache_key_dimensions() {
     assert!(payload["kin_commit"].is_string());
     assert!(payload["kin_dirty"].is_boolean());
 
+    let coordination = payload["coordination"]
+        .as_object()
+        .expect("coordination attestation object");
+    assert_eq!(coordination["schema"], "kin.coordination-enforcement.v1");
+    assert!(matches!(
+        coordination["effective_mode"].as_str(),
+        Some("off" | "warn" | "enforce")
+    ));
+    assert_eq!(coordination["default_mode"], "warn");
+    assert_eq!(
+        coordination["hard_rejection_active"],
+        coordination["effective_mode"] == "enforce"
+    );
+    assert_eq!(coordination["intent_registration_linearized"], true);
+    assert_eq!(coordination["max_concurrent_intents_enforced"], true);
+    assert_eq!(coordination["contract_scope_claim_eligible"], false);
+    assert_eq!(coordination["all_write_surfaces_claim_eligible"], false);
+    assert_eq!(coordination["surfaces"]["mcp_transaction_entity"], true);
+    assert_eq!(coordination["surfaces"]["contract"], false);
+    assert_eq!(
+        coordination["durable_event_schema"],
+        "kin.coordination-event.v1"
+    );
+    assert_eq!(coordination["durable_event_fsync_before_broadcast"], true);
+
     let embeddings = payload["embeddings"]
         .as_object()
         .expect("embeddings object");

--- a/crates/kin-daemon/src/api.rs
+++ b/crates/kin-daemon/src/api.rs
@@ -9,8 +9,9 @@ use std::sync::{Arc, OnceLock};
 use std::time::{Duration, Instant};
 
 use crate::state::{
-    CachedLocateRanking, CachedSemanticPage, DaemonEvent, DaemonState, ProjectionChangedSet,
-    RequestGraphAuthority, VfsTreeCacheKey, VfsTreeSnapshot, LOCATE_RANKING_CACHE_CAP,
+    CachedLocateRanking, CachedSemanticPage, CoordinationEventDraft, DaemonEvent, DaemonState,
+    ProjectionChangedSet, RequestGraphAuthority, VfsTreeCacheKey, VfsTreeSnapshot,
+    LOCATE_RANKING_CACHE_CAP,
 };
 
 use axum::extract::{Path, Query, State};
@@ -123,6 +124,14 @@ pub struct HealthResponse {
     /// `kin_core::behavior_env`.
     #[serde(default)]
     pub behavior_env: kin_core::behavior_env::BehaviorEnv,
+    /// Effective coordination mode and exact surface/capability coverage for
+    /// operator and benchmark attestation.
+    #[serde(default = "kin_cli::commands::bench_meta::coordination_meta")]
+    pub coordination: kin_cli::commands::bench_meta::CoordinationMeta,
+    /// Must remain zero for a coordination-event stream to be eligible as a
+    /// complete citable measurement source during this daemon lifetime.
+    #[serde(default)]
+    pub coordination_event_persist_failures: u64,
     pub build: BuildResponse,
 }
 
@@ -247,6 +256,12 @@ struct RegisterIntentResponse {
     status: String,
     conflicts: Vec<IntentSummary>,
     downstream_warnings: Vec<IntentSummary>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    active_intents: Option<usize>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    max_concurrent_intents: Option<usize>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    required_capability: Option<String>,
 }
 
 #[derive(Debug, Serialize, Deserialize)]
@@ -1402,6 +1417,12 @@ async fn health(
         filesystem_reconcile_disabled: state.filesystem_reconcile_disabled(),
         graph_generation: DaemonState::read_generation_marker(&state.layout),
         behavior_env: kin_core::behavior_env::snapshot_from_process(),
+        coordination: kin_cli::commands::bench_meta::coordination_meta_for_mode(
+            state.coordination_mode(),
+        ),
+        coordination_event_persist_failures: state
+            .coordination_event_persist_failures
+            .load(std::sync::atomic::Ordering::Relaxed),
         build: current_build_response(),
     }))
 }
@@ -2904,6 +2925,7 @@ async fn end_session(
     Path(session_id): Path<String>,
     State(state): State<Arc<DaemonState>>,
 ) -> Result<impl IntoResponse, (StatusCode, String)> {
+    let _coordination = state.coordination_gate.lock().await;
     let session_id = parse_session_id(&session_id)?;
     let session = state
         .coordinator
@@ -2915,10 +2937,27 @@ async fn end_session(
                 format!("session not found: {session_id}"),
             )
         })?;
+    let intents = state
+        .coordinator
+        .list_intents(&session_id)
+        .map_err(internal_error)?;
     state
         .coordinator
         .deregister_session(&session_id)
         .map_err(internal_error)?;
+    for intent in intents {
+        state.record_coordination_event(CoordinationEventDraft {
+            event: "intent_release",
+            outcome: "session_ended".to_string(),
+            session_id: Some(session_id.to_string()),
+            intent_id: Some(intent.intent_id.to_string()),
+            intent_ids: vec![intent.intent_id.to_string()],
+            transaction_id: None,
+            scopes: intent.scopes.iter().map(format_scope).collect(),
+            enforcement_mode: state.coordination_mode().as_str().to_string(),
+            blocking_intent_ids: Vec::new(),
+        });
+    }
 
     Ok(Json(SessionEndResponse {
         session_id: session.session_id.to_string(),
@@ -2952,6 +2991,7 @@ async fn clear_session_intents(
     Path(session_id): Path<String>,
     State(state): State<Arc<DaemonState>>,
 ) -> Result<impl IntoResponse, (StatusCode, String)> {
+    let _coordination = state.coordination_gate.lock().await;
     let session_id = parse_session_id(&session_id)?;
     let intents = state
         .coordinator
@@ -2963,6 +3003,17 @@ async fn clear_session_intents(
             .coordinator
             .release_intent(&session_id, &intent.intent_id)
             .map_err(internal_error)?;
+        state.record_coordination_event(CoordinationEventDraft {
+            event: "intent_release",
+            outcome: "cleared".to_string(),
+            session_id: Some(session_id.to_string()),
+            intent_id: Some(intent.intent_id.to_string()),
+            intent_ids: vec![intent.intent_id.to_string()],
+            transaction_id: None,
+            scopes: intent.scopes.iter().map(format_scope).collect(),
+            enforcement_mode: state.coordination_mode().as_str().to_string(),
+            blocking_intent_ids: Vec::new(),
+        });
     }
 
     Ok(Json(ClearedIntentsResponse {
@@ -2988,6 +3039,10 @@ async fn register_intent(
     State(state): State<Arc<DaemonState>>,
     Json(request): Json<RegisterIntentRequest>,
 ) -> Result<impl IntoResponse, (StatusCode, String)> {
+    // Serialize the full check+register decision with transaction preflight and
+    // apply. This daemon gate complements the coordinator's own linearization
+    // lock and closes the cross-surface HTTP race.
+    let _coordination = state.coordination_gate.lock().await;
     let mut scope_values = request.scopes;
     if scope_values.is_empty() {
         if request.scope.trim().is_empty() {
@@ -3002,6 +3057,7 @@ async fn register_intent(
         .iter()
         .map(|scope| parse_scope(scope))
         .collect::<Result<Vec<_>, _>>()?;
+    let scope_labels = scopes.iter().map(format_scope).collect::<Vec<_>>();
     let lock_type = parse_lock_type(&request.lock_type)?;
     let session_id = resolve_or_create_session(&state, request.session_id.as_deref())?;
     let result = state
@@ -3019,28 +3075,95 @@ async fn register_intent(
         )
         .map_err(internal_error)?;
 
-    let response = match result {
+    let (response, outcome, blocking_intent_ids) = match result {
         crate::session_registry::IntentRegistrationResult::Registered {
             intent_id,
             downstream_warnings,
-        } => RegisterIntentResponse {
-            intent_id: intent_id.to_string(),
-            session_id: session_id.to_string(),
-            status: "registered".to_string(),
-            conflicts: Vec::new(),
-            downstream_warnings,
-        },
+        } => (
+            RegisterIntentResponse {
+                intent_id: intent_id.to_string(),
+                session_id: session_id.to_string(),
+                status: "registered".to_string(),
+                conflicts: Vec::new(),
+                downstream_warnings,
+                active_intents: None,
+                max_concurrent_intents: None,
+                required_capability: None,
+            },
+            "registered".to_string(),
+            Vec::new(),
+        ),
         crate::session_registry::IntentRegistrationResult::Blocked {
             intent_id,
             conflicts,
-        } => RegisterIntentResponse {
-            intent_id: intent_id.to_string(),
-            session_id: session_id.to_string(),
-            status: "blocked".to_string(),
-            conflicts,
-            downstream_warnings: Vec::new(),
-        },
+        } => {
+            let blocking = conflicts
+                .iter()
+                .map(|conflict| conflict.intent_id.to_string())
+                .collect();
+            (
+                RegisterIntentResponse {
+                    intent_id: intent_id.to_string(),
+                    session_id: session_id.to_string(),
+                    status: "blocked".to_string(),
+                    conflicts,
+                    downstream_warnings: Vec::new(),
+                    active_intents: None,
+                    max_concurrent_intents: None,
+                    required_capability: None,
+                },
+                "blocked".to_string(),
+                blocking,
+            )
+        }
+        crate::session_registry::IntentRegistrationResult::LimitExceeded {
+            intent_id,
+            active,
+            limit,
+        } => (
+            RegisterIntentResponse {
+                intent_id: intent_id.to_string(),
+                session_id: session_id.to_string(),
+                status: "limit_exceeded".to_string(),
+                conflicts: Vec::new(),
+                downstream_warnings: Vec::new(),
+                active_intents: Some(active),
+                max_concurrent_intents: Some(limit),
+                required_capability: None,
+            },
+            "limit_exceeded".to_string(),
+            Vec::new(),
+        ),
+        crate::session_registry::IntentRegistrationResult::CapabilityDenied {
+            intent_id,
+            capability,
+        } => (
+            RegisterIntentResponse {
+                intent_id: intent_id.to_string(),
+                session_id: session_id.to_string(),
+                status: "capability_denied".to_string(),
+                conflicts: Vec::new(),
+                downstream_warnings: Vec::new(),
+                active_intents: None,
+                max_concurrent_intents: None,
+                required_capability: Some(capability.to_string()),
+            },
+            "capability_denied".to_string(),
+            Vec::new(),
+        ),
     };
+
+    state.record_coordination_event(CoordinationEventDraft {
+        event: "intent_registration",
+        outcome,
+        session_id: Some(session_id.to_string()),
+        intent_id: Some(response.intent_id.clone()),
+        intent_ids: vec![response.intent_id.clone()],
+        transaction_id: None,
+        scopes: scope_labels,
+        enforcement_mode: state.coordination_mode().as_str().to_string(),
+        blocking_intent_ids,
+    });
 
     Ok(Json(response))
 }
@@ -3050,6 +3173,7 @@ async fn release_intent(
     Path(intent_id): Path<String>,
     State(state): State<Arc<DaemonState>>,
 ) -> Result<impl IntoResponse, (StatusCode, String)> {
+    let _coordination = state.coordination_gate.lock().await;
     let intent_id = parse_intent_id(&intent_id)?;
     let intent = state
         .graph
@@ -3066,6 +3190,17 @@ async fn release_intent(
         .coordinator
         .release_intent(&intent.session_id, &intent_id)
         .map_err(internal_error)?;
+    state.record_coordination_event(CoordinationEventDraft {
+        event: "intent_release",
+        outcome: "released".to_string(),
+        session_id: Some(intent.session_id.to_string()),
+        intent_id: Some(intent_id.to_string()),
+        intent_ids: vec![intent_id.to_string()],
+        transaction_id: None,
+        scopes: intent.scopes.iter().map(format_scope).collect(),
+        enforcement_mode: state.coordination_mode().as_str().to_string(),
+        blocking_intent_ids: Vec::new(),
+    });
     Ok(StatusCode::NO_CONTENT)
 }
 
@@ -4388,6 +4523,7 @@ fn mcp_session_registry_snapshot(
     let sessions = state.coordinator.list_sessions().map_err(internal_error)?;
     let intents = state.graph.list_all_intents().map_err(internal_error)?;
     let registry = kin_mcp::SessionRegistry::new();
+    registry.set_coordination_mode(state.coordination_mode());
     registry.replace_agent_sessions_and_intents(sessions, intents);
     // Restore in-flight transactions so a registry built fresh for this request
     // sees what earlier requests staged; sessions/intents persist via the graph,
@@ -4478,6 +4614,83 @@ fn collect_pre_commit_entities(
         }
     }
     (entities, supplied_bodies)
+}
+
+fn transaction_coordination_context(
+    state: &DaemonState,
+    sessions: &kin_mcp::SessionRegistry,
+    arguments: &HashMap<String, serde_json::Value>,
+) -> (
+    Option<String>,
+    Option<String>,
+    Vec<IntentScope>,
+    Vec<String>,
+) {
+    let transaction_id = arguments
+        .get("transaction_id")
+        .and_then(serde_json::Value::as_str)
+        .map(str::to_string);
+    let Some(transaction) = transaction_id
+        .as_deref()
+        .and_then(|id| sessions.get_transaction(id))
+    else {
+        return (None, transaction_id, Vec::new(), Vec::new());
+    };
+
+    let mut touched = Vec::new();
+    let mut push = |scope: IntentScope| {
+        if !touched.contains(&scope) {
+            touched.push(scope);
+        }
+    };
+    let mut operations = transaction.staged_operations;
+    if let Some(inline) = arguments.get("operations") {
+        if let Ok(mut parsed) =
+            serde_json::from_value::<Vec<kin_mcp::McpMutationOperation>>(inline.clone())
+        {
+            operations.append(&mut parsed);
+        }
+    }
+    for operation in &operations {
+        match operation.payload.as_ref() {
+            Some(kin_mcp::McpMutationPayload::Entity(entity)) => {
+                push(IntentScope::Entity(entity.id));
+                if let Some(file) = entity.file_origin.clone() {
+                    push(IntentScope::Artifact(file));
+                }
+                let mut existing = state.graph.get_entity(&entity.id).ok().flatten();
+                if existing.is_none() {
+                    existing = state
+                        .graph
+                        .query_entities(&kin_model::EntityFilter {
+                            name_pattern: Some(entity.name.clone()),
+                            kinds: Some(vec![entity.kind]),
+                            ..Default::default()
+                        })
+                        .ok()
+                        .and_then(|mut matches| matches.pop());
+                }
+                if let Some(existing) = existing {
+                    push(IntentScope::Entity(existing.id));
+                    if let Some(file) = existing.file_origin {
+                        push(IntentScope::Artifact(file));
+                    }
+                }
+            }
+            Some(kin_mcp::McpMutationPayload::Relation { from, to, .. }) => {
+                push(IntentScope::Entity(*from));
+                push(IntentScope::Entity(*to));
+            }
+            Some(kin_mcp::McpMutationPayload::Blob(_)) | None => {}
+        }
+    }
+    let labels = touched.iter().map(format_scope).collect();
+    (
+        Some(transaction.session_id),
+        transaction_id,
+        touched,
+        labels,
+    )
 }
 
 /// The transaction id a terminal transaction tool (commit/abort) acted on, used
@@ -5584,7 +5797,45 @@ async fn mcp_tools_call(
         )));
     }
 
+    // Serialize the full daemon transaction lifecycle and other graph-mutating
+    // MCP tools. Commit holds this gate from final intent/capability preflight
+    // through graph application and projection; intent registration uses it
+    // too, closing transaction-state races and keeping touched-scope derivation
+    // stable until apply. Non-transaction mutators are sequenced here but remain
+    // explicitly unattested for intent-veto coverage in bench-meta.
+    let _coordination_guard = if mcp_tool_is_transaction(&request.name) || mutates {
+        Some(state.coordination_gate.lock().await)
+    } else {
+        None
+    };
+
     let sessions = mcp_session_registry_snapshot(&state)?;
+    let (transaction_session_id, transaction_id, transaction_scopes, transaction_scope_labels) =
+        if request.name == "kin_transaction_commit" {
+            transaction_coordination_context(&state, &sessions, &request.arguments)
+        } else {
+            (None, None, Vec::new(), Vec::new())
+        };
+    let transaction_preflight = transaction_session_id.as_deref().map(|session_id| {
+        sessions.evaluate_transaction_write(session_id, transaction_scopes.clone())
+    });
+    let transaction_intent_ids = transaction_session_id
+        .as_deref()
+        .and_then(|session_id| uuid::Uuid::parse_str(session_id).ok().map(SessionId))
+        .map(|session_id| {
+            sessions
+                .list_intents_for_session(&session_id)
+                .into_iter()
+                .filter(|intent| {
+                    intent
+                        .scopes
+                        .iter()
+                        .any(|scope| transaction_scopes.contains(scope))
+                })
+                .map(|intent| intent.intent_id.to_string())
+                .collect::<Vec<_>>()
+        })
+        .unwrap_or_default();
 
     // Snapshot entity state before the commit so we can project the
     // mutations into working-directory files after the graph is updated.
@@ -5620,6 +5871,33 @@ async fn mcp_tools_call(
                 forget_mcp_transaction(&state, &tx_id);
             }
         }
+    }
+
+    if request.name == "kin_transaction_commit" && result.is_error == Some(true) {
+        state.record_coordination_event(CoordinationEventDraft {
+            event: "transaction_outcome",
+            outcome: "rejected_before_graph_apply".to_string(),
+            session_id: transaction_session_id.clone(),
+            intent_id: None,
+            intent_ids: transaction_intent_ids.clone(),
+            transaction_id: transaction_id.clone(),
+            scopes: transaction_scope_labels.clone(),
+            enforcement_mode: transaction_preflight
+                .as_ref()
+                .map(|preflight| preflight.mode.as_str())
+                .unwrap_or_else(|| state.coordination_mode().as_str())
+                .to_string(),
+            blocking_intent_ids: transaction_preflight
+                .as_ref()
+                .map(|preflight| {
+                    preflight
+                        .blocking_intents
+                        .iter()
+                        .map(|intent| intent.intent_id.to_string())
+                        .collect()
+                })
+                .unwrap_or_default(),
+        });
     }
 
     if mutates && result.is_error != Some(true) {
@@ -5658,6 +5936,21 @@ async fn mcp_tools_call(
             .await
             {
                 Err(proj_err) => {
+                    state.record_coordination_event(CoordinationEventDraft {
+                        event: "transaction_outcome",
+                        outcome: "projection_failed_after_graph_apply".to_string(),
+                        session_id: transaction_session_id.clone(),
+                        intent_id: None,
+                        intent_ids: transaction_intent_ids.clone(),
+                        transaction_id: transaction_id.clone(),
+                        scopes: transaction_scope_labels.clone(),
+                        enforcement_mode: transaction_preflight
+                            .as_ref()
+                            .map(|preflight| preflight.mode.as_str())
+                            .unwrap_or("warn")
+                            .to_string(),
+                        blocking_intent_ids: Vec::new(),
+                    });
                     return Ok(Json(kin_mcp::ToolCallResult::error(format!(
                         "graph commit succeeded but file projection failed — agent intent is \
                          preserved in the graph; retry projection or inspect the source file. \
@@ -5680,6 +5973,21 @@ async fn mcp_tools_call(
                             )
                         })
                         .collect();
+                    state.record_coordination_event(CoordinationEventDraft {
+                        event: "transaction_outcome",
+                        outcome: "projection_conflict_after_graph_apply".to_string(),
+                        session_id: transaction_session_id.clone(),
+                        intent_id: None,
+                        intent_ids: transaction_intent_ids.clone(),
+                        transaction_id: transaction_id.clone(),
+                        scopes: transaction_scope_labels.clone(),
+                        enforcement_mode: transaction_preflight
+                            .as_ref()
+                            .map(|preflight| preflight.mode.as_str())
+                            .unwrap_or("warn")
+                            .to_string(),
+                        blocking_intent_ids: Vec::new(),
+                    });
                     return Ok(Json(kin_mcp::ToolCallResult::error(format!(
                         "graph commit succeeded but {n} entity/entities had concurrent file \
                          edits — those entities were NOT projected (human edits preserved). \
@@ -5696,6 +6004,30 @@ async fn mcp_tools_call(
         // response so a commit reports what it did instead of an opaque
         // "committed". `ops_applied`/`empty` already rode in from the handler.
         result = enrich_commit_result(result, &new_root_hash, &modified_files, &collision_warnings);
+        state.record_coordination_event(CoordinationEventDraft {
+            event: "transaction_outcome",
+            outcome: "committed".to_string(),
+            session_id: transaction_session_id,
+            intent_id: None,
+            intent_ids: transaction_intent_ids,
+            transaction_id,
+            scopes: transaction_scope_labels,
+            enforcement_mode: transaction_preflight
+                .as_ref()
+                .map(|preflight| preflight.mode.as_str())
+                .unwrap_or("warn")
+                .to_string(),
+            blocking_intent_ids: transaction_preflight
+                .as_ref()
+                .map(|preflight| {
+                    preflight
+                        .blocking_intents
+                        .iter()
+                        .map(|intent| intent.intent_id.to_string())
+                        .collect()
+                })
+                .unwrap_or_default(),
+        });
     }
 
     Ok(Json(result))
@@ -7225,6 +7557,9 @@ async fn vfs_file_changed(
         ));
     }
 
+    // One ordering with intent registration and transaction commits: no hard
+    // intent can appear after this path's precheck but before graph apply.
+    let _coordination = state.coordination_gate.lock().await;
     let file_path = std::path::PathBuf::from(&request.path);
     tracing::info!(path = %request.path, "VFS file-changed notification received");
 
@@ -7415,6 +7750,7 @@ async fn vfs_write_notify(
         ));
     }
 
+    let _coordination = state.coordination_gate.lock().await;
     let file_path = std::path::PathBuf::from(&request.file_path);
     tracing::info!(path = %request.file_path, "VFS write-notify received");
 
@@ -7575,7 +7911,7 @@ async fn vfs_write_notify(
 /// GET /vfs/subscribe — SSE stream for real-time invalidation events.
 ///
 /// Subscribers receive DaemonEvent messages (EntityChanged, TreeChanged,
-/// OverlayUpdated, GraphRootChanged) as they happen. The VFS daemon uses
+/// OverlayUpdated, GraphRootChanged, Coordination) as they happen. The VFS daemon uses
 /// these to invalidate its cache; the spine uses them to update its metadata index.
 ///
 /// Protocol: Server-Sent Events (text/event-stream). Each event is a JSON
@@ -7969,7 +8305,10 @@ fn resolve_or_create_session(
             SessionTransport::Cli,
             None,
             state.layout.working_dir().to_path_buf(),
-            SessionCapabilities::default(),
+            SessionCapabilities {
+                can_write: true,
+                ..SessionCapabilities::default()
+            },
         )
         .map_err(internal_error)
 }
@@ -9264,6 +9603,11 @@ mod tests {
         );
         // Additive freshness marker present; 0 before any snapshot is committed.
         assert_eq!(json.graph_generation, 0);
+        assert_eq!(json.coordination.schema, "kin.coordination-enforcement.v1");
+        assert!(json.coordination.surfaces.mcp_transaction_entity);
+        assert!(!json.coordination.surfaces.contract);
+        assert!(!json.coordination.contract_scope_claim_eligible);
+        assert_eq!(json.coordination_event_persist_failures, 0);
     }
 
     #[tokio::test]
@@ -9875,6 +10219,221 @@ mod tests {
             before + 1,
             "committed entity must land in the canonical graph"
         );
+    }
+
+    #[tokio::test]
+    async fn mcp_transaction_enforce_rejects_before_graph_apply_and_records_event() {
+        let state = test_state();
+        *state
+            .coordination_mode
+            .write()
+            .unwrap_or_else(std::sync::PoisonError::into_inner) =
+            kin_mcp::CoordinationEnforcementMode::Enforce;
+        state
+            .is_initialized
+            .store(true, std::sync::atomic::Ordering::Relaxed);
+
+        let capabilities = SessionCapabilities {
+            can_write: true,
+            can_commit: true,
+            ..SessionCapabilities::default()
+        };
+        let owner = state
+            .coordinator
+            .register_session(
+                "claude-code",
+                "owner",
+                SessionTransport::Mcp,
+                None,
+                state.layout.working_dir().to_path_buf(),
+                capabilities.clone(),
+            )
+            .unwrap();
+        let caller = state
+            .coordinator
+            .register_session(
+                "codex",
+                "caller",
+                SessionTransport::Mcp,
+                None,
+                state.layout.working_dir().to_path_buf(),
+                capabilities,
+            )
+            .unwrap();
+        let entity = test_entity("blocked_fn", "src/lib.rs");
+        let registration = state
+            .coordinator
+            .register_intent(
+                &owner,
+                vec![IntentScope::Entity(entity.id)],
+                LockType::Hard,
+                "exclusive edit",
+                None,
+            )
+            .unwrap();
+        assert!(matches!(
+            registration,
+            crate::session_registry::IntentRegistrationResult::Registered { .. }
+        ));
+        let before = state.graph.entity_count();
+
+        let begin = mcp_call(
+            router(Arc::clone(&state)),
+            "kin_transaction_begin",
+            serde_json::json!({
+                "session_id": caller.to_string(),
+                "scope": "file:src/lib.rs"
+            }),
+        )
+        .await;
+        let begin_json: serde_json::Value = serde_json::from_str(&mcp_result_text(&begin)).unwrap();
+        let tx_id = begin_json["transaction_id"].as_str().unwrap().to_string();
+        let stage = mcp_call(
+            router(Arc::clone(&state)),
+            "kin_transaction_stage",
+            serde_json::json!({
+                "transaction_id": tx_id,
+                "operations": [{
+                    "verb": "create",
+                    "target": "",
+                    "payload": { "Entity": entity },
+                    "description": "must be vetoed"
+                }]
+            }),
+        )
+        .await;
+        assert_ne!(stage.is_error, Some(true));
+
+        let commit = mcp_call(
+            router(Arc::clone(&state)),
+            "kin_transaction_commit",
+            serde_json::json!({ "transaction_id": tx_id }),
+        )
+        .await;
+        assert_eq!(commit.is_error, Some(true));
+        assert!(mcp_result_text(&commit).contains("before graph apply"));
+        assert_eq!(
+            state.graph.entity_count(),
+            before,
+            "rejected transaction must not mutate graph truth"
+        );
+
+        let records = std::fs::read_to_string(state.coordination_events.path()).unwrap();
+        let last: crate::state::CoordinationEventEnvelope =
+            serde_json::from_str(records.lines().last().unwrap()).unwrap();
+        assert_eq!(last.event, "transaction_outcome");
+        assert_eq!(last.outcome, "rejected_before_graph_apply");
+        assert_eq!(last.transaction_id.as_deref(), Some(tx_id.as_str()));
+        assert_eq!(last.session_id, Some(caller.to_string()));
+        assert_eq!(last.enforcement_mode, "enforce");
+        assert_eq!(last.blocking_intent_ids.len(), 1);
+    }
+
+    #[tokio::test]
+    async fn mcp_transaction_preflight_covers_name_kind_upsert_resolution() {
+        let state = test_state();
+        *state
+            .coordination_mode
+            .write()
+            .unwrap_or_else(std::sync::PoisonError::into_inner) =
+            kin_mcp::CoordinationEnforcementMode::Enforce;
+        state
+            .is_initialized
+            .store(true, std::sync::atomic::Ordering::Relaxed);
+
+        let capabilities = SessionCapabilities {
+            can_write: true,
+            can_commit: true,
+            ..SessionCapabilities::default()
+        };
+        let owner = state
+            .coordinator
+            .register_session(
+                "claude-code",
+                "owner",
+                SessionTransport::Mcp,
+                None,
+                state.layout.working_dir().to_path_buf(),
+                capabilities.clone(),
+            )
+            .unwrap();
+        let caller = state
+            .coordinator
+            .register_session(
+                "codex",
+                "caller",
+                SessionTransport::Mcp,
+                None,
+                state.layout.working_dir().to_path_buf(),
+                capabilities,
+            )
+            .unwrap();
+
+        let existing = test_entity("resolved_by_name", "src/protected.py");
+        state.graph.upsert_entity(&existing).unwrap();
+        assert!(matches!(
+            state
+                .coordinator
+                .register_intent(
+                    &owner,
+                    vec![IntentScope::Entity(existing.id)],
+                    LockType::Hard,
+                    "protect existing entity",
+                    None,
+                )
+                .unwrap(),
+            crate::session_registry::IntentRegistrationResult::Registered { .. }
+        ));
+
+        // The commit path resolves an unknown payload id by name+kind. The
+        // preflight must mirror that resolution or a caller could bypass an
+        // intent on `existing.id` by submitting a fresh id with the same name.
+        let mut alias_payload = existing.clone();
+        alias_payload.id = EntityId::new();
+        alias_payload.signature = "def resolved_by_name(changed)".to_string();
+        let alias_id = alias_payload.id;
+        let begin = mcp_call(
+            router(Arc::clone(&state)),
+            "kin_transaction_begin",
+            json!({ "session_id": caller.to_string(), "scope": "entity" }),
+        )
+        .await;
+        let begin_json: serde_json::Value = serde_json::from_str(&mcp_result_text(&begin)).unwrap();
+        let tx_id = begin_json["transaction_id"].as_str().unwrap().to_string();
+        let stage = mcp_call(
+            router(Arc::clone(&state)),
+            "kin_transaction_stage",
+            json!({
+                "transaction_id": tx_id,
+                "operations": [{
+                    "verb": "upsert",
+                    "target": "",
+                    "payload": { "Entity": alias_payload },
+                    "description": "attempt id-alias bypass"
+                }]
+            }),
+        )
+        .await;
+        assert_ne!(stage.is_error, Some(true));
+
+        let commit = mcp_call(
+            router(Arc::clone(&state)),
+            "kin_transaction_commit",
+            json!({ "transaction_id": tx_id }),
+        )
+        .await;
+        assert_eq!(commit.is_error, Some(true));
+        assert!(mcp_result_text(&commit).contains(&existing.id.to_string()));
+        assert_eq!(
+            state
+                .graph
+                .get_entity(&existing.id)
+                .unwrap()
+                .unwrap()
+                .signature,
+            existing.signature
+        );
+        assert!(state.graph.get_entity(&alias_id).unwrap().is_none());
     }
 
     #[test]
@@ -11625,7 +12184,10 @@ mod tests {
                 SessionTransport::Cli,
                 None,
                 state.layout.working_dir().to_path_buf(),
-                SessionCapabilities::default(),
+                SessionCapabilities {
+                    can_write: true,
+                    ..SessionCapabilities::default()
+                },
             )
             .unwrap();
         let entity_id = EntityId::new();
@@ -11698,6 +12260,62 @@ mod tests {
         let registered: RegisterIntentResponse = serde_json::from_slice(&body).unwrap();
         assert_eq!(registered.status, "registered");
         assert!(!registered.session_id.is_empty());
+
+        let records = std::fs::read_to_string(state.coordination_events.path()).unwrap();
+        let registered_event: crate::state::CoordinationEventEnvelope =
+            serde_json::from_str(records.lines().last().unwrap()).unwrap();
+        assert_eq!(registered_event.event, "intent_registration");
+        assert_eq!(registered_event.outcome, "registered");
+        assert_eq!(
+            registered_event.intent_id.as_deref(),
+            Some(registered.intent_id.as_str())
+        );
+        assert_eq!(registered_event.kin_version, kin_buildinfo::version());
+
+        let contender = state
+            .coordinator
+            .register_session(
+                "claude-code",
+                "contender",
+                SessionTransport::Mcp,
+                None,
+                state.layout.working_dir().to_path_buf(),
+                SessionCapabilities {
+                    can_write: true,
+                    ..SessionCapabilities::default()
+                },
+            )
+            .unwrap();
+        let blocked = app
+            .clone()
+            .oneshot(
+                Request::post("/intent/register")
+                    .header("content-type", "application/json")
+                    .body(Body::from(
+                        json!({
+                            "session_id": contender.to_string(),
+                            "scope": "file:src/lib.rs",
+                            "lock_type": "hard",
+                            "task_description": "conflicting edit"
+                        })
+                        .to_string(),
+                    ))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(blocked.status(), StatusCode::OK);
+        let blocked_body = axum::body::to_bytes(blocked.into_body(), 4096)
+            .await
+            .unwrap();
+        let blocked: RegisterIntentResponse = serde_json::from_slice(&blocked_body).unwrap();
+        assert_eq!(blocked.status, "blocked");
+        assert_eq!(blocked.conflicts.len(), 1);
+        let records = std::fs::read_to_string(state.coordination_events.path()).unwrap();
+        let blocked_event: crate::state::CoordinationEventEnvelope =
+            serde_json::from_str(records.lines().last().unwrap()).unwrap();
+        assert_eq!(blocked_event.outcome, "blocked");
+        assert_eq!(blocked_event.blocking_intent_ids.len(), 1);
 
         let traffic = app
             .clone()
@@ -14752,7 +15370,10 @@ mod tests {
                 SessionTransport::Mcp,
                 None,
                 state.layout.working_dir().to_path_buf(),
-                SessionCapabilities::default(),
+                SessionCapabilities {
+                    can_write: true,
+                    ..SessionCapabilities::default()
+                },
             )
             .unwrap()
     }

--- a/crates/kin-daemon/src/api.rs
+++ b/crates/kin-daemon/src/api.rs
@@ -126,12 +126,12 @@ pub struct HealthResponse {
     pub behavior_env: kin_core::behavior_env::BehaviorEnv,
     /// Effective coordination mode and exact surface/capability coverage for
     /// operator and benchmark attestation.
-    #[serde(default = "kin_cli::commands::bench_meta::coordination_meta")]
-    pub coordination: kin_cli::commands::bench_meta::CoordinationMeta,
+    #[serde(default)]
+    pub coordination: Option<kin_cli::commands::bench_meta::CoordinationMeta>,
     /// Must remain zero for a coordination-event stream to be eligible as a
     /// complete citable measurement source during this daemon lifetime.
     #[serde(default)]
-    pub coordination_event_persist_failures: u64,
+    pub coordination_event_persist_failures: Option<u64>,
     pub build: BuildResponse,
 }
 
@@ -256,6 +256,8 @@ struct RegisterIntentResponse {
     status: String,
     conflicts: Vec<IntentSummary>,
     downstream_warnings: Vec<IntentSummary>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    coordination_warnings: Vec<String>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     active_intents: Option<usize>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
@@ -1202,8 +1204,8 @@ async fn inject_loopback_host_in_tests(
     next.run(request).await
 }
 
-/// Extract an optional session ID from the `X-Kin-Session` header or
-/// `?session_id=` query parameter. Header takes precedence.
+/// Extract an optional caller session ID from the authoritative
+/// `X-Kin-Session` request header.
 fn extract_session_id_from_headers(
     headers: &axum::http::HeaderMap,
 ) -> Result<Option<SessionId>, (StatusCode, String)> {
@@ -1378,13 +1380,20 @@ async fn health(
         .embed_worker_failed
         .load(std::sync::atomic::Ordering::Relaxed);
     let embed_persistence_unavailable = !state.can_persist_embed_progress_locally();
+    let coordination_event_persist_failures = state
+        .coordination_event_persist_failures
+        .load(std::sync::atomic::Ordering::Relaxed);
     // Surface graph-safety + derived-index health in the top-level status so an
     // operator or client polling /health sees a non-"ok" signal when the daemon
     // is withholding a suspected mass-deletion wipe OR the embedding worker has
     // permanently stopped (embed-degraded), OR the configured storage backend
-    // cannot durably persist vector progress. The graph itself stays intact and
-    // served in all cases.
-    let status = if mass_deletion_blocked || embed_worker_failed || embed_persistence_unavailable {
+    // cannot durably persist vector progress, OR coordination evidence could not
+    // be persisted. The graph itself stays intact and served in all cases.
+    let status = if mass_deletion_blocked
+        || embed_worker_failed
+        || embed_persistence_unavailable
+        || coordination_event_persist_failures > 0
+    {
         "attention"
     } else {
         "ok"
@@ -1417,12 +1426,12 @@ async fn health(
         filesystem_reconcile_disabled: state.filesystem_reconcile_disabled(),
         graph_generation: DaemonState::read_generation_marker(&state.layout),
         behavior_env: kin_core::behavior_env::snapshot_from_process(),
-        coordination: kin_cli::commands::bench_meta::coordination_meta_for_mode(
-            state.coordination_mode(),
+        coordination: Some(
+            kin_cli::commands::bench_meta::coordination_meta_for_daemon_mode(
+                state.coordination_mode(),
+            ),
         ),
-        coordination_event_persist_failures: state
-            .coordination_event_persist_failures
-            .load(std::sync::atomic::Ordering::Relaxed),
+        coordination_event_persist_failures: Some(coordination_event_persist_failures),
         build: current_build_response(),
     }))
 }
@@ -2941,12 +2950,9 @@ async fn end_session(
         .coordinator
         .list_intents(&session_id)
         .map_err(internal_error)?;
-    state
-        .coordinator
-        .deregister_session(&session_id)
-        .map_err(internal_error)?;
-    for intent in intents {
-        state.record_coordination_event(CoordinationEventDraft {
+    let event_drafts: Vec<_> = intents
+        .iter()
+        .map(|intent| CoordinationEventDraft {
             event: "intent_release",
             outcome: "session_ended".to_string(),
             session_id: Some(session_id.to_string()),
@@ -2956,7 +2962,19 @@ async fn end_session(
             scopes: intent.scopes.iter().map(format_scope).collect(),
             enforcement_mode: state.coordination_mode().as_str().to_string(),
             blocking_intent_ids: Vec::new(),
-        });
+        })
+        .collect();
+    for draft in &event_drafts {
+        persist_coordination_reservation(&state, draft.clone())?;
+    }
+    if let Err(error) = state.coordinator.deregister_session(&session_id) {
+        state.mark_coordination_evidence_incomplete(format!(
+            "session end failed after intent-release reservations: {error}"
+        ));
+        return Err(internal_error(error));
+    }
+    for draft in event_drafts {
+        persist_coordination_event(&state, draft)?;
     }
 
     Ok(Json(SessionEndResponse {
@@ -2998,12 +3016,9 @@ async fn clear_session_intents(
         .list_intents(&session_id)
         .map_err(internal_error)?;
 
-    for intent in &intents {
-        state
-            .coordinator
-            .release_intent(&session_id, &intent.intent_id)
-            .map_err(internal_error)?;
-        state.record_coordination_event(CoordinationEventDraft {
+    let event_drafts: Vec<_> = intents
+        .iter()
+        .map(|intent| CoordinationEventDraft {
             event: "intent_release",
             outcome: "cleared".to_string(),
             session_id: Some(session_id.to_string()),
@@ -3013,7 +3028,25 @@ async fn clear_session_intents(
             scopes: intent.scopes.iter().map(format_scope).collect(),
             enforcement_mode: state.coordination_mode().as_str().to_string(),
             blocking_intent_ids: Vec::new(),
-        });
+        })
+        .collect();
+    for draft in &event_drafts {
+        persist_coordination_reservation(&state, draft.clone())?;
+    }
+
+    for intent in &intents {
+        if let Err(error) = state
+            .coordinator
+            .release_intent(&session_id, &intent.intent_id)
+        {
+            state.mark_coordination_evidence_incomplete(format!(
+                "intent clear failed after release reservations: {error}"
+            ));
+            return Err(internal_error(error));
+        }
+    }
+    for draft in event_drafts {
+        persist_coordination_event(&state, draft)?;
     }
 
     Ok(Json(ClearedIntentsResponse {
@@ -3025,7 +3058,20 @@ async fn clear_session_intents(
 async fn list_intents(
     State(state): State<Arc<DaemonState>>,
 ) -> Result<impl IntoResponse, (StatusCode, String)> {
-    let intents = state.graph.list_all_intents().map_err(internal_error)?;
+    let now = kin_model::Timestamp::now();
+    let mut intents: Vec<_> = state
+        .graph
+        .list_all_intents()
+        .map_err(internal_error)?
+        .into_iter()
+        .filter(|intent| {
+            intent
+                .expires_at
+                .as_ref()
+                .is_none_or(|expires_at| expires_at >= &now)
+        })
+        .collect();
+    intents.sort_by_key(|intent| intent.intent_id.to_string());
     Ok(Json(
         intents
             .into_iter()
@@ -3060,25 +3106,46 @@ async fn register_intent(
     let scope_labels = scopes.iter().map(format_scope).collect::<Vec<_>>();
     let lock_type = parse_lock_type(&request.lock_type)?;
     let session_id = resolve_or_create_session(&state, request.session_id.as_deref())?;
-    let result = state
-        .coordinator
-        .register_intent(
-            &session_id,
-            scopes,
-            lock_type,
-            &request.task_description,
-            request
-                .expires_at
-                .as_deref()
-                .map(parse_timestamp)
-                .transpose()?,
-        )
-        .map_err(internal_error)?;
+    persist_coordination_reservation(
+        &state,
+        CoordinationEventDraft {
+            event: "intent_registration",
+            outcome: "registration".to_string(),
+            session_id: Some(session_id.to_string()),
+            intent_id: None,
+            intent_ids: Vec::new(),
+            transaction_id: None,
+            scopes: scope_labels.clone(),
+            enforcement_mode: state.coordination_mode().as_str().to_string(),
+            blocking_intent_ids: Vec::new(),
+        },
+    )?;
+    let result = match state.coordinator.register_intent_with_mode(
+        &session_id,
+        scopes,
+        lock_type,
+        &request.task_description,
+        request
+            .expires_at
+            .as_deref()
+            .map(parse_timestamp)
+            .transpose()?,
+        state.coordination_mode(),
+    ) {
+        Ok(result) => result,
+        Err(error) => {
+            state.mark_coordination_evidence_incomplete(format!(
+                "intent registration failed after durable reservation: {error}"
+            ));
+            return Err(internal_error(error));
+        }
+    };
 
     let (response, outcome, blocking_intent_ids) = match result {
         crate::session_registry::IntentRegistrationResult::Registered {
             intent_id,
             downstream_warnings,
+            policy_warnings,
         } => (
             RegisterIntentResponse {
                 intent_id: intent_id.to_string(),
@@ -3086,6 +3153,7 @@ async fn register_intent(
                 status: "registered".to_string(),
                 conflicts: Vec::new(),
                 downstream_warnings,
+                coordination_warnings: policy_warnings,
                 active_intents: None,
                 max_concurrent_intents: None,
                 required_capability: None,
@@ -3108,6 +3176,7 @@ async fn register_intent(
                     status: "blocked".to_string(),
                     conflicts,
                     downstream_warnings: Vec::new(),
+                    coordination_warnings: Vec::new(),
                     active_intents: None,
                     max_concurrent_intents: None,
                     required_capability: None,
@@ -3127,6 +3196,7 @@ async fn register_intent(
                 status: "limit_exceeded".to_string(),
                 conflicts: Vec::new(),
                 downstream_warnings: Vec::new(),
+                coordination_warnings: Vec::new(),
                 active_intents: Some(active),
                 max_concurrent_intents: Some(limit),
                 required_capability: None,
@@ -3144,6 +3214,7 @@ async fn register_intent(
                 status: "capability_denied".to_string(),
                 conflicts: Vec::new(),
                 downstream_warnings: Vec::new(),
+                coordination_warnings: Vec::new(),
                 active_intents: None,
                 max_concurrent_intents: None,
                 required_capability: Some(capability.to_string()),
@@ -3153,17 +3224,21 @@ async fn register_intent(
         ),
     };
 
-    state.record_coordination_event(CoordinationEventDraft {
-        event: "intent_registration",
-        outcome,
-        session_id: Some(session_id.to_string()),
-        intent_id: Some(response.intent_id.clone()),
-        intent_ids: vec![response.intent_id.clone()],
-        transaction_id: None,
-        scopes: scope_labels,
-        enforcement_mode: state.coordination_mode().as_str().to_string(),
-        blocking_intent_ids,
-    });
+    let persisted_intent_id = (response.status == "registered").then(|| response.intent_id.clone());
+    persist_coordination_event(
+        &state,
+        CoordinationEventDraft {
+            event: "intent_registration",
+            outcome,
+            session_id: Some(session_id.to_string()),
+            intent_id: persisted_intent_id.clone(),
+            intent_ids: persisted_intent_id.into_iter().collect(),
+            transaction_id: None,
+            scopes: scope_labels,
+            enforcement_mode: state.coordination_mode().as_str().to_string(),
+            blocking_intent_ids,
+        },
+    )?;
 
     Ok(Json(response))
 }
@@ -3186,11 +3261,7 @@ async fn release_intent(
             )
         })?;
 
-    state
-        .coordinator
-        .release_intent(&intent.session_id, &intent_id)
-        .map_err(internal_error)?;
-    state.record_coordination_event(CoordinationEventDraft {
+    let event_draft = CoordinationEventDraft {
         event: "intent_release",
         outcome: "released".to_string(),
         session_id: Some(intent.session_id.to_string()),
@@ -3200,7 +3271,18 @@ async fn release_intent(
         scopes: intent.scopes.iter().map(format_scope).collect(),
         enforcement_mode: state.coordination_mode().as_str().to_string(),
         blocking_intent_ids: Vec::new(),
-    });
+    };
+    persist_coordination_reservation(&state, event_draft.clone())?;
+    if let Err(error) = state
+        .coordinator
+        .release_intent(&intent.session_id, &intent_id)
+    {
+        state.mark_coordination_evidence_incomplete(format!(
+            "intent release failed after durable reservation: {error}"
+        ));
+        return Err(internal_error(error));
+    }
+    persist_coordination_event(&state, event_draft)?;
     Ok(StatusCode::NO_CONTENT)
 }
 
@@ -4521,7 +4603,20 @@ fn mcp_session_registry_snapshot(
     state: &DaemonState,
 ) -> Result<kin_mcp::SessionRegistry, (StatusCode, String)> {
     let sessions = state.coordinator.list_sessions().map_err(internal_error)?;
-    let intents = state.graph.list_all_intents().map_err(internal_error)?;
+    let now = kin_model::Timestamp::now();
+    let mut intents: Vec<_> = state
+        .graph
+        .list_all_intents()
+        .map_err(internal_error)?
+        .into_iter()
+        .filter(|intent| {
+            intent
+                .expires_at
+                .as_ref()
+                .is_none_or(|expires_at| expires_at >= &now)
+        })
+        .collect();
+    intents.sort_by_key(|intent| intent.intent_id.to_string());
     let registry = kin_mcp::SessionRegistry::new();
     registry.set_coordination_mode(state.coordination_mode());
     registry.replace_agent_sessions_and_intents(sessions, intents);
@@ -5810,15 +5905,78 @@ async fn mcp_tools_call(
     };
 
     let sessions = mcp_session_registry_snapshot(&state)?;
+    if mcp_tool_is_transaction(&request.name) && state.coordination_mode().is_enforcing() {
+        if let Some(declared_session) = request
+            .arguments
+            .get("session_id")
+            .and_then(serde_json::Value::as_str)
+        {
+            let declared_id = Uuid::parse_str(declared_session).ok().map(SessionId);
+            if declared_id.is_none() || session_id != declared_id {
+                return Ok(Json(kin_mcp::ToolCallResult::error(format!(
+                    "coordination enforcement rejected {}: body session_id is not bound to X-Kin-Session",
+                    request.name
+                ))));
+            }
+        }
+    }
+    if mcp_tool_is_transaction(&request.name) && request.name != "kin_transaction_commit" {
+        let owner = if request.name == "kin_transaction_begin" {
+            request
+                .arguments
+                .get("session_id")
+                .and_then(serde_json::Value::as_str)
+                .map(str::to_string)
+        } else {
+            request
+                .arguments
+                .get("transaction_id")
+                .and_then(serde_json::Value::as_str)
+                .and_then(|transaction_id| sessions.get_transaction(transaction_id))
+                .map(|transaction| transaction.session_id)
+        };
+        if state.coordination_mode().is_enforcing() {
+            let Some(owner) = owner else {
+                return Ok(Json(kin_mcp::ToolCallResult::error(format!(
+                    "coordination enforcement rejected {}: transaction owner could not be resolved",
+                    request.name
+                ))));
+            };
+            let owner_id = Uuid::parse_str(&owner).ok().map(SessionId);
+            if owner_id.is_none() || session_id != owner_id {
+                return Ok(Json(kin_mcp::ToolCallResult::error(format!(
+                    "coordination enforcement rejected {}: X-Kin-Session does not own transaction session {owner}",
+                    request.name
+                ))));
+            }
+        }
+    }
     let (transaction_session_id, transaction_id, transaction_scopes, transaction_scope_labels) =
         if request.name == "kin_transaction_commit" {
             transaction_coordination_context(&state, &sessions, &request.arguments)
         } else {
             (None, None, Vec::new(), Vec::new())
         };
-    let transaction_preflight = transaction_session_id.as_deref().map(|session_id| {
+    let mut transaction_preflight = transaction_session_id.as_deref().map(|session_id| {
         sessions.evaluate_transaction_write(session_id, transaction_scopes.clone())
     });
+    if request.name == "kin_transaction_commit" {
+        if let Some(preflight) = transaction_preflight.as_mut() {
+            let owner = Uuid::parse_str(&preflight.session_id).ok().map(SessionId);
+            if session_id != owner {
+                preflight.capability_violations.push(match session_id {
+                    Some(actual) => format!(
+                        "X-Kin-Session {actual} does not own transaction session {}",
+                        preflight.session_id
+                    ),
+                    None => "transaction commit has no X-Kin-Session caller identity".to_string(),
+                });
+                if preflight.mode.is_enforcing() {
+                    preflight.allowed = false;
+                }
+            }
+        }
+    }
     let transaction_intent_ids = transaction_session_id
         .as_deref()
         .and_then(|session_id| uuid::Uuid::parse_str(session_id).ok().map(SessionId))
@@ -5847,17 +6005,62 @@ async fn mcp_tools_call(
         (vec![], HashMap::new())
     };
 
-    let mut result = match kin_mcp::handlers::handle_tool_call(
-        &request.name,
-        &request.arguments,
-        graph.as_ref(),
-        &sessions,
-        kin_mcp::SessionAuthorityMode::OfflineFallback,
-    )
-    .await
+    if request.name == "kin_transaction_commit" && transaction_id.is_some() {
+        persist_coordination_reservation(
+            &state,
+            CoordinationEventDraft {
+                event: "transaction_outcome",
+                outcome: "commit".to_string(),
+                session_id: transaction_session_id.clone(),
+                intent_id: None,
+                intent_ids: transaction_intent_ids.clone(),
+                transaction_id: transaction_id.clone(),
+                scopes: transaction_scope_labels.clone(),
+                enforcement_mode: transaction_preflight
+                    .as_ref()
+                    .map(|preflight| preflight.mode.as_str())
+                    .unwrap_or_else(|| state.coordination_mode().as_str())
+                    .to_string(),
+                blocking_intent_ids: transaction_preflight
+                    .as_ref()
+                    .map(|preflight| {
+                        preflight
+                            .blocking_intents
+                            .iter()
+                            .map(|intent| intent.intent_id.to_string())
+                            .collect()
+                    })
+                    .unwrap_or_default(),
+            },
+        )?;
+    }
+
+    let mut result = if transaction_preflight
+        .as_ref()
+        .is_some_and(|preflight| !preflight.allowed)
     {
-        Ok(result) => result,
-        Err(error) => kin_mcp::ToolCallResult::error(error.to_string()),
+        let evidence = serde_json::to_string(
+            transaction_preflight
+                .as_ref()
+                .expect("checked preflight must exist"),
+        )
+        .map_err(internal_error)?;
+        kin_mcp::ToolCallResult::error(format!(
+            "coordination enforcement rejected transaction before graph apply: {evidence}"
+        ))
+    } else {
+        match kin_mcp::handlers::handle_tool_call(
+            &request.name,
+            &request.arguments,
+            graph.as_ref(),
+            &sessions,
+            kin_mcp::SessionAuthorityMode::OfflineFallback,
+        )
+        .await
+        {
+            Ok(result) => result,
+            Err(error) => kin_mcp::ToolCallResult::error(error.to_string()),
+        }
     };
 
     // Persist transaction state mutated by this call so the next HTTP request
@@ -5874,30 +6077,42 @@ async fn mcp_tools_call(
     }
 
     if request.name == "kin_transaction_commit" && result.is_error == Some(true) {
-        state.record_coordination_event(CoordinationEventDraft {
-            event: "transaction_outcome",
-            outcome: "rejected_before_graph_apply".to_string(),
-            session_id: transaction_session_id.clone(),
-            intent_id: None,
-            intent_ids: transaction_intent_ids.clone(),
-            transaction_id: transaction_id.clone(),
-            scopes: transaction_scope_labels.clone(),
-            enforcement_mode: transaction_preflight
-                .as_ref()
-                .map(|preflight| preflight.mode.as_str())
-                .unwrap_or_else(|| state.coordination_mode().as_str())
+        let coordination_rejected = transaction_preflight
+            .as_ref()
+            .is_some_and(|preflight| !preflight.allowed);
+        persist_coordination_event(
+            &state,
+            CoordinationEventDraft {
+                event: "transaction_outcome",
+                outcome: if coordination_rejected {
+                    "coordination_rejected_before_graph_apply"
+                } else {
+                    "commit_failed_before_graph_apply"
+                }
                 .to_string(),
-            blocking_intent_ids: transaction_preflight
-                .as_ref()
-                .map(|preflight| {
-                    preflight
-                        .blocking_intents
-                        .iter()
-                        .map(|intent| intent.intent_id.to_string())
-                        .collect()
-                })
-                .unwrap_or_default(),
-        });
+                session_id: transaction_session_id.clone(),
+                intent_id: None,
+                intent_ids: transaction_intent_ids.clone(),
+                transaction_id: transaction_id.clone(),
+                scopes: transaction_scope_labels.clone(),
+                enforcement_mode: transaction_preflight
+                    .as_ref()
+                    .map(|preflight| preflight.mode.as_str())
+                    .unwrap_or_else(|| state.coordination_mode().as_str())
+                    .to_string(),
+                blocking_intent_ids: coordination_rejected
+                    .then_some(transaction_preflight.as_ref())
+                    .flatten()
+                    .map(|preflight| {
+                        preflight
+                            .blocking_intents
+                            .iter()
+                            .map(|intent| intent.intent_id.to_string())
+                            .collect()
+                    })
+                    .unwrap_or_default(),
+            },
+        )?;
     }
 
     if mutates && result.is_error != Some(true) {
@@ -5936,21 +6151,24 @@ async fn mcp_tools_call(
             .await
             {
                 Err(proj_err) => {
-                    state.record_coordination_event(CoordinationEventDraft {
-                        event: "transaction_outcome",
-                        outcome: "projection_failed_after_graph_apply".to_string(),
-                        session_id: transaction_session_id.clone(),
-                        intent_id: None,
-                        intent_ids: transaction_intent_ids.clone(),
-                        transaction_id: transaction_id.clone(),
-                        scopes: transaction_scope_labels.clone(),
-                        enforcement_mode: transaction_preflight
-                            .as_ref()
-                            .map(|preflight| preflight.mode.as_str())
-                            .unwrap_or("warn")
-                            .to_string(),
-                        blocking_intent_ids: Vec::new(),
-                    });
+                    persist_coordination_event(
+                        &state,
+                        CoordinationEventDraft {
+                            event: "transaction_outcome",
+                            outcome: "projection_failed_after_graph_apply".to_string(),
+                            session_id: transaction_session_id.clone(),
+                            intent_id: None,
+                            intent_ids: transaction_intent_ids.clone(),
+                            transaction_id: transaction_id.clone(),
+                            scopes: transaction_scope_labels.clone(),
+                            enforcement_mode: transaction_preflight
+                                .as_ref()
+                                .map(|preflight| preflight.mode.as_str())
+                                .unwrap_or_else(|| state.coordination_mode().as_str())
+                                .to_string(),
+                            blocking_intent_ids: Vec::new(),
+                        },
+                    )?;
                     return Ok(Json(kin_mcp::ToolCallResult::error(format!(
                         "graph commit succeeded but file projection failed — agent intent is \
                          preserved in the graph; retry projection or inspect the source file. \
@@ -5973,21 +6191,24 @@ async fn mcp_tools_call(
                             )
                         })
                         .collect();
-                    state.record_coordination_event(CoordinationEventDraft {
-                        event: "transaction_outcome",
-                        outcome: "projection_conflict_after_graph_apply".to_string(),
-                        session_id: transaction_session_id.clone(),
-                        intent_id: None,
-                        intent_ids: transaction_intent_ids.clone(),
-                        transaction_id: transaction_id.clone(),
-                        scopes: transaction_scope_labels.clone(),
-                        enforcement_mode: transaction_preflight
-                            .as_ref()
-                            .map(|preflight| preflight.mode.as_str())
-                            .unwrap_or("warn")
-                            .to_string(),
-                        blocking_intent_ids: Vec::new(),
-                    });
+                    persist_coordination_event(
+                        &state,
+                        CoordinationEventDraft {
+                            event: "transaction_outcome",
+                            outcome: "projection_conflict_after_graph_apply".to_string(),
+                            session_id: transaction_session_id.clone(),
+                            intent_id: None,
+                            intent_ids: transaction_intent_ids.clone(),
+                            transaction_id: transaction_id.clone(),
+                            scopes: transaction_scope_labels.clone(),
+                            enforcement_mode: transaction_preflight
+                                .as_ref()
+                                .map(|preflight| preflight.mode.as_str())
+                                .unwrap_or_else(|| state.coordination_mode().as_str())
+                                .to_string(),
+                            blocking_intent_ids: Vec::new(),
+                        },
+                    )?;
                     return Ok(Json(kin_mcp::ToolCallResult::error(format!(
                         "graph commit succeeded but {n} entity/entities had concurrent file \
                          edits — those entities were NOT projected (human edits preserved). \
@@ -6004,30 +6225,33 @@ async fn mcp_tools_call(
         // response so a commit reports what it did instead of an opaque
         // "committed". `ops_applied`/`empty` already rode in from the handler.
         result = enrich_commit_result(result, &new_root_hash, &modified_files, &collision_warnings);
-        state.record_coordination_event(CoordinationEventDraft {
-            event: "transaction_outcome",
-            outcome: "committed".to_string(),
-            session_id: transaction_session_id,
-            intent_id: None,
-            intent_ids: transaction_intent_ids,
-            transaction_id,
-            scopes: transaction_scope_labels,
-            enforcement_mode: transaction_preflight
-                .as_ref()
-                .map(|preflight| preflight.mode.as_str())
-                .unwrap_or("warn")
-                .to_string(),
-            blocking_intent_ids: transaction_preflight
-                .as_ref()
-                .map(|preflight| {
-                    preflight
-                        .blocking_intents
-                        .iter()
-                        .map(|intent| intent.intent_id.to_string())
-                        .collect()
-                })
-                .unwrap_or_default(),
-        });
+        persist_coordination_event(
+            &state,
+            CoordinationEventDraft {
+                event: "transaction_outcome",
+                outcome: "committed".to_string(),
+                session_id: transaction_session_id,
+                intent_id: None,
+                intent_ids: transaction_intent_ids,
+                transaction_id,
+                scopes: transaction_scope_labels,
+                enforcement_mode: transaction_preflight
+                    .as_ref()
+                    .map(|preflight| preflight.mode.as_str())
+                    .unwrap_or_else(|| state.coordination_mode().as_str())
+                    .to_string(),
+                blocking_intent_ids: transaction_preflight
+                    .as_ref()
+                    .map(|preflight| {
+                        preflight
+                            .blocking_intents
+                            .iter()
+                            .map(|intent| intent.intent_id.to_string())
+                            .collect()
+                    })
+                    .unwrap_or_default(),
+            },
+        )?;
     }
 
     Ok(Json(result))
@@ -7380,17 +7604,31 @@ async fn write_veto_precheck(
     file_path: &FsPath,
     display_path: &str,
     caller: Option<SessionId>,
+    capability_warnings: &[String],
 ) -> std::result::Result<Option<serde_json::Value>, (StatusCode, String)> {
-    let mode = crate::write_veto::WriteVetoMode::from_env();
+    let mode = crate::write_veto::WriteVetoMode::from(state.coordination_mode());
     if mode.is_off() {
         return Ok(None);
     }
     // Cheap short-circuit: with no active intents a write can collide with
     // nothing, so warn-by-default costs nothing on the common single-agent path
     // (no per-file entity query, no scope build).
-    let intents = state.graph.list_all_intents().map_err(internal_error)?;
+    let now = kin_model::Timestamp::now();
+    let mut intents: Vec<_> = state
+        .graph
+        .list_all_intents()
+        .map_err(internal_error)?
+        .into_iter()
+        .filter(|intent| {
+            intent
+                .expires_at
+                .as_ref()
+                .is_none_or(|expires_at| expires_at >= &now)
+        })
+        .collect();
+    intents.sort_by_key(|intent| intent.intent_id.to_string());
     if intents.is_empty() {
-        return Ok(None);
+        return Ok(vfs_capability_warning(capability_warnings));
     }
     let file_id = kin_index::normalize_file_path_id(file_path, state.layout.working_dir());
     let filter = kin_model::EntityFilter {
@@ -7447,12 +7685,75 @@ async fn write_veto_precheck(
                 "write-veto[warn]: write would be rejected under KIN_WRITE_VETO=enforce"
             );
         }
-        return Ok(Some(crate::write_veto::veto_warning_annotation(
-            display_path,
-            &blocking,
-        )));
+        let mut annotation = crate::write_veto::veto_warning_annotation(display_path, &blocking);
+        if !capability_warnings.is_empty() {
+            if let Some(object) = annotation.as_object_mut() {
+                object.insert(
+                    "capability_violations".to_string(),
+                    serde_json::json!(capability_warnings),
+                );
+            }
+        }
+        return Ok(Some(annotation));
     }
-    Ok(None)
+    Ok(vfs_capability_warning(capability_warnings))
+}
+
+fn vfs_capability_warning(violations: &[String]) -> Option<serde_json::Value> {
+    (!violations.is_empty()).then(|| {
+        serde_json::json!({
+            "would_block": true,
+            "conflict_type": "CapabilityDenied",
+            "capability_violations": violations,
+            "message": "VFS write would be rejected in enforce mode because caller identity or can_write capability is invalid",
+        })
+    })
+}
+
+fn resolve_vfs_write_caller(
+    state: &DaemonState,
+    header_session: Option<SessionId>,
+    body_session: Option<SessionId>,
+) -> std::result::Result<(Option<SessionId>, Vec<String>), (StatusCode, String)> {
+    let mode = state.coordination_mode();
+    if !mode.evaluates() {
+        return Ok((header_session.or(body_session), Vec::new()));
+    }
+
+    let mut violations = Vec::new();
+    if header_session.is_none() && body_session.is_some() {
+        violations.push("body session_id is not bound to X-Kin-Session".to_string());
+    }
+    if let (Some(header), Some(body)) = (header_session, body_session) {
+        if header != body {
+            violations.push("body session_id does not match X-Kin-Session".to_string());
+        }
+    }
+    let caller = header_session.or(body_session);
+    match caller {
+        Some(session_id) => match state
+            .coordinator
+            .get_session(&session_id)
+            .map_err(internal_error)?
+        {
+            Some(session) if session.capabilities.can_write => {}
+            Some(_) => violations.push("can_write=false".to_string()),
+            None => violations.push("VFS caller is not an active rich agent session".to_string()),
+        },
+        None => violations.push("VFS write has no attributed agent session".to_string()),
+    }
+
+    if mode.is_enforcing() && !violations.is_empty() {
+        return Err((
+            StatusCode::FORBIDDEN,
+            serde_json::json!({
+                "error": "coordination_capability_denied",
+                "capability_violations": violations,
+            })
+            .to_string(),
+        ));
+    }
+    Ok((caller, violations))
 }
 
 /// How a reconcile-detected hard collision maps under the active write-veto
@@ -7475,8 +7776,8 @@ enum CollisionVeto {
 fn write_veto_collision_response(
     err: &kin_reconcile::ReconcileError,
     display_path: &str,
+    mode: crate::write_veto::WriteVetoMode,
 ) -> CollisionVeto {
-    let mode = crate::write_veto::WriteVetoMode::from_env();
     if mode.is_off() {
         return CollisionVeto::Ignore;
     }
@@ -7547,6 +7848,7 @@ fn filesystem_ingest_disabled_response(endpoint: &str, path: &str) -> (StatusCod
 /// Triggers reconciliation for the specified path. Used by the VFS write-back
 /// flow to inform the daemon that projected content has been written through.
 async fn vfs_file_changed(
+    headers: axum::http::HeaderMap,
     State(state): State<Arc<DaemonState>>,
     Json(request): Json<FileChangedRequest>,
 ) -> Result<impl IntoResponse, (StatusCode, String)> {
@@ -7566,12 +7868,22 @@ async fn vfs_file_changed(
     // Rung-3 write veto (KIN_WRITE_VETO=enforce): the general-purpose sibling of
     // /vfs/write-notify must gate too, else enforce is trivially bypassable by
     // choosing this endpoint. Off by default (byte-identical).
-    let caller = request
+    let header_session = extract_session_id_from_headers(&headers)?;
+    let body_session = request
         .session_id
         .as_ref()
-        .and_then(|s| s.parse::<Uuid>().ok())
-        .map(SessionId);
-    let veto_warning = write_veto_precheck(&state, &file_path, &request.path, caller).await?;
+        .map(|session_id| parse_session_id(session_id))
+        .transpose()?;
+    let (caller, capability_warnings) =
+        resolve_vfs_write_caller(&state, header_session, body_session)?;
+    let veto_warning = write_veto_precheck(
+        &state,
+        &file_path,
+        &request.path,
+        caller,
+        &capability_warnings,
+    )
+    .await?;
 
     let event = kin_index::FileEvent::Changed(file_path);
 
@@ -7592,11 +7904,9 @@ async fn vfs_file_changed(
     // Temporarily adopt the caller's session so the reconciler's own collision
     // check excludes the caller's intents (parity with /vfs/write-notify); the
     // write-veto precheck above applies the same own-write exclusion.
-    let prev_session_id = if let Some(ref sid) = request.session_id {
+    let prev_session_id = if let Some(session_id) = caller {
         let prev = reconciler.session_id().copied();
-        if let Ok(parsed) = sid.parse::<Uuid>() {
-            reconciler.set_session_id(SessionId(parsed));
-        }
+        reconciler.set_session_id(session_id);
         prev
     } else {
         None
@@ -7610,7 +7920,7 @@ async fn vfs_file_changed(
         edit_hint.as_ref(),
     );
 
-    if request.session_id.is_some() {
+    if caller.is_some() {
         match prev_session_id {
             Some(prev) => reconciler.set_session_id(prev),
             None => reconciler.clear_session_id(),
@@ -7660,7 +7970,7 @@ async fn vfs_file_changed(
                             file_path: Some(request.path.clone()),
                             // Truthful attribution: the originating session the
                             // VFS write-back request carried (None if anonymous).
-                            session_id: request.session_id.clone(),
+                            session_id: caller.map(|session_id| session_id.to_string()),
                         });
                     }
                     for id in modified {
@@ -7670,7 +7980,7 @@ async fn vfs_file_changed(
                             file_path: Some(request.path.clone()),
                             // Truthful attribution: the originating session the
                             // VFS write-back request carried (None if anonymous).
-                            session_id: request.session_id.clone(),
+                            session_id: caller.map(|session_id| session_id.to_string()),
                         });
                     }
                     for id in removed {
@@ -7680,7 +7990,7 @@ async fn vfs_file_changed(
                             file_path: Some(request.path.clone()),
                             // Truthful attribution: the originating session the
                             // VFS write-back request carried (None if anonymous).
-                            session_id: request.session_id.clone(),
+                            session_id: caller.map(|session_id| session_id.to_string()),
                         });
                     }
                     (added.len(), modified.len(), removed.len())
@@ -7713,7 +8023,11 @@ async fn vfs_file_changed(
             drop(reconciler);
             // Under enforce, surface a hard collision detected during reconcile
             // as a pre-write 409; under warn, annotate the soft notification.
-            let warning = match write_veto_collision_response(&e, &request.path) {
+            let warning = match write_veto_collision_response(
+                &e,
+                &request.path,
+                crate::write_veto::WriteVetoMode::from(state.coordination_mode()),
+            ) {
                 CollisionVeto::Block(body) => {
                     return Err((StatusCode::CONFLICT, body.to_string()));
                 }
@@ -7740,6 +8054,7 @@ async fn vfs_file_changed(
 /// `/vfs/file-changed` (which is general-purpose), this endpoint is
 /// optimized for the shim hot-path: minimal request body, fast response.
 async fn vfs_write_notify(
+    headers: axum::http::HeaderMap,
     State(state): State<Arc<DaemonState>>,
     Json(request): Json<WriteNotifyRequest>,
 ) -> Result<impl IntoResponse, (StatusCode, String)> {
@@ -7757,12 +8072,22 @@ async fn vfs_write_notify(
     // Rung-3 write veto (KIN_WRITE_VETO=enforce): reject a write whose existing
     // entity/artifact scopes are held under another session's hard intent
     // before the reconciler touches the overlay. Off by default (byte-identical).
-    let caller = request
+    let header_session = extract_session_id_from_headers(&headers)?;
+    let body_session = request
         .session_id
         .as_ref()
-        .and_then(|s| s.parse::<Uuid>().ok())
-        .map(SessionId);
-    let veto_warning = write_veto_precheck(&state, &file_path, &request.file_path, caller).await?;
+        .map(|session_id| parse_session_id(session_id))
+        .transpose()?;
+    let (caller, capability_warnings) =
+        resolve_vfs_write_caller(&state, header_session, body_session)?;
+    let veto_warning = write_veto_precheck(
+        &state,
+        &file_path,
+        &request.file_path,
+        caller,
+        &capability_warnings,
+    )
+    .await?;
 
     let event = kin_index::FileEvent::Changed(file_path);
 
@@ -7771,11 +8096,9 @@ async fn vfs_write_notify(
 
     // If the caller supplies a session_id, temporarily set it on the
     // reconciler so check_scopes() excludes the caller's own intents.
-    let prev_session_id = if let Some(ref sid) = request.session_id {
+    let prev_session_id = if let Some(session_id) = caller {
         let prev = reconciler.session_id().copied();
-        if let Ok(parsed) = sid.parse::<Uuid>() {
-            reconciler.set_session_id(SessionId(parsed));
-        }
+        reconciler.set_session_id(session_id);
         prev
     } else {
         None
@@ -7791,7 +8114,7 @@ async fn vfs_write_notify(
 
     // Always restore the previous session_id so caller identity doesn't
     // leak into future reconciles through the shared reconciler.
-    if request.session_id.is_some() {
+    if caller.is_some() {
         match prev_session_id {
             Some(prev) => reconciler.set_session_id(prev),
             None => reconciler.clear_session_id(),
@@ -7888,7 +8211,11 @@ async fn vfs_write_notify(
             // Under enforce, surface a hard collision detected during reconcile
             // (e.g. a brand-new entity the precheck cannot see) as a pre-write
             // 409; under warn, annotate the soft notification below.
-            let warning = match write_veto_collision_response(&e, &request.file_path) {
+            let warning = match write_veto_collision_response(
+                &e,
+                &request.file_path,
+                crate::write_veto::WriteVetoMode::from(state.coordination_mode()),
+            ) {
                 CollisionVeto::Block(body) => {
                     return Err((StatusCode::CONFLICT, body.to_string()));
                 }
@@ -8305,10 +8632,7 @@ fn resolve_or_create_session(
             SessionTransport::Cli,
             None,
             state.layout.working_dir().to_path_buf(),
-            SessionCapabilities {
-                can_write: true,
-                ..SessionCapabilities::default()
-            },
+            SessionCapabilities::default(),
         )
         .map_err(internal_error)
 }
@@ -8385,12 +8709,32 @@ fn parse_uuid(value: &str, kind: &str) -> Result<Uuid, (StatusCode, String)> {
     })
 }
 
-fn format_scope(scope: &IntentScope) -> String {
+pub(crate) fn format_scope(scope: &IntentScope) -> String {
     match scope {
         IntentScope::Entity(id) => format!("entity:{id}"),
         IntentScope::Contract(id) => format!("contract:{id}"),
         IntentScope::Artifact(id) => format!("file:{id}"),
     }
+}
+
+fn persist_coordination_event(
+    state: &DaemonState,
+    draft: CoordinationEventDraft,
+) -> Result<crate::state::CoordinationEventEnvelope, (StatusCode, String)> {
+    state.record_coordination_event(draft).map_err(|error| {
+        (
+            StatusCode::INSUFFICIENT_STORAGE,
+            format!("coordination event persistence failed; action is not claim-eligible: {error}"),
+        )
+    })
+}
+
+fn persist_coordination_reservation(
+    state: &DaemonState,
+    mut draft: CoordinationEventDraft,
+) -> Result<crate::state::CoordinationEventEnvelope, (StatusCode, String)> {
+    draft.outcome = format!("pending:{}", draft.outcome);
+    persist_coordination_event(state, draft)
 }
 
 fn primary_repo_id(state: &DaemonState) -> String {
@@ -9603,11 +9947,24 @@ mod tests {
         );
         // Additive freshness marker present; 0 before any snapshot is committed.
         assert_eq!(json.graph_generation, 0);
-        assert_eq!(json.coordination.schema, "kin.coordination-enforcement.v1");
-        assert!(json.coordination.surfaces.mcp_transaction_entity);
-        assert!(!json.coordination.surfaces.contract);
-        assert!(!json.coordination.contract_scope_claim_eligible);
-        assert_eq!(json.coordination_event_persist_failures, 0);
+        let coordination = json
+            .coordination
+            .expect("new daemon must attest coordination");
+        assert_eq!(coordination.schema, "kin.coordination-enforcement.v1");
+        assert!(coordination.surfaces.mcp_transaction_entity);
+        assert!(!coordination.surfaces.contract);
+        assert!(!coordination.contract_scope_claim_eligible);
+        assert_eq!(json.coordination_event_persist_failures, Some(0));
+
+        let mut legacy: serde_json::Value = serde_json::from_slice(&body).unwrap();
+        legacy.as_object_mut().unwrap().remove("coordination");
+        legacy
+            .as_object_mut()
+            .unwrap()
+            .remove("coordination_event_persist_failures");
+        let legacy: HealthResponse = serde_json::from_value(legacy).unwrap();
+        assert!(legacy.coordination.is_none());
+        assert!(legacy.coordination_event_persist_failures.is_none());
     }
 
     #[tokio::test]
@@ -10079,6 +10436,31 @@ mod tests {
         serde_json::from_slice(&body).unwrap()
     }
 
+    async fn mcp_call_as(
+        router: axum::Router,
+        name: &str,
+        arguments: serde_json::Value,
+        session_id: SessionId,
+    ) -> kin_mcp::ToolCallResult {
+        let response = router
+            .oneshot(
+                Request::post("/mcp/tools/call")
+                    .header("content-type", "application/json")
+                    .header("X-Kin-Session", session_id.to_string())
+                    .body(Body::from(
+                        serde_json::json!({ "name": name, "arguments": arguments }).to_string(),
+                    ))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(response.status(), StatusCode::OK);
+        let body = axum::body::to_bytes(response.into_body(), 64 * 1024)
+            .await
+            .unwrap();
+        serde_json::from_slice(&body).unwrap()
+    }
+
     fn mcp_result_text(result: &kin_mcp::ToolCallResult) -> String {
         match result.content.first().unwrap() {
             kin_mcp::ContentBlock::Text { text } => text.clone(),
@@ -10277,18 +10659,19 @@ mod tests {
         ));
         let before = state.graph.entity_count();
 
-        let begin = mcp_call(
+        let begin = mcp_call_as(
             router(Arc::clone(&state)),
             "kin_transaction_begin",
             serde_json::json!({
                 "session_id": caller.to_string(),
                 "scope": "file:src/lib.rs"
             }),
+            caller,
         )
         .await;
         let begin_json: serde_json::Value = serde_json::from_str(&mcp_result_text(&begin)).unwrap();
         let tx_id = begin_json["transaction_id"].as_str().unwrap().to_string();
-        let stage = mcp_call(
+        let stage = mcp_call_as(
             router(Arc::clone(&state)),
             "kin_transaction_stage",
             serde_json::json!({
@@ -10300,14 +10683,16 @@ mod tests {
                     "description": "must be vetoed"
                 }]
             }),
+            caller,
         )
         .await;
         assert_ne!(stage.is_error, Some(true));
 
-        let commit = mcp_call(
+        let commit = mcp_call_as(
             router(Arc::clone(&state)),
             "kin_transaction_commit",
             serde_json::json!({ "transaction_id": tx_id }),
+            caller,
         )
         .await;
         assert_eq!(commit.is_error, Some(true));
@@ -10322,11 +10707,161 @@ mod tests {
         let last: crate::state::CoordinationEventEnvelope =
             serde_json::from_str(records.lines().last().unwrap()).unwrap();
         assert_eq!(last.event, "transaction_outcome");
-        assert_eq!(last.outcome, "rejected_before_graph_apply");
+        assert_eq!(last.outcome, "coordination_rejected_before_graph_apply");
         assert_eq!(last.transaction_id.as_deref(), Some(tx_id.as_str()));
         assert_eq!(last.session_id, Some(caller.to_string()));
         assert_eq!(last.enforcement_mode, "enforce");
         assert_eq!(last.blocking_intent_ids.len(), 1);
+    }
+
+    #[tokio::test]
+    async fn mcp_transaction_enforce_binds_commit_to_header_session() {
+        let state = test_state();
+        state
+            .is_initialized
+            .store(true, std::sync::atomic::Ordering::Relaxed);
+        *state
+            .coordination_mode
+            .write()
+            .unwrap_or_else(std::sync::PoisonError::into_inner) =
+            kin_mcp::CoordinationEnforcementMode::Enforce;
+        let writable = SessionCapabilities {
+            can_write: true,
+            can_commit: true,
+            ..SessionCapabilities::default()
+        };
+        let owner = state
+            .coordinator
+            .register_session(
+                "owner",
+                "owner",
+                SessionTransport::Mcp,
+                None,
+                state.layout.working_dir().to_path_buf(),
+                writable,
+            )
+            .unwrap();
+        let caller = state
+            .coordinator
+            .register_session(
+                "caller",
+                "caller",
+                SessionTransport::Mcp,
+                None,
+                state.layout.working_dir().to_path_buf(),
+                SessionCapabilities::default(),
+            )
+            .unwrap();
+        let entity = test_entity("identity_guard", "src/lib.rs");
+        let before = state.graph.entity_count();
+        let missing_identity_begin = mcp_call(
+            router(Arc::clone(&state)),
+            "kin_transaction_begin",
+            serde_json::json!({
+                "session_id": owner.to_string(),
+                "scope": "file:src/lib.rs"
+            }),
+        )
+        .await;
+        assert_eq!(missing_identity_begin.is_error, Some(true));
+        assert!(mcp_result_text(&missing_identity_begin).contains("body session_id"));
+
+        let begin = mcp_call_as(
+            router(Arc::clone(&state)),
+            "kin_transaction_begin",
+            serde_json::json!({
+                "session_id": owner.to_string(),
+                "scope": "file:src/lib.rs"
+            }),
+            owner,
+        )
+        .await;
+        let begin_json: serde_json::Value = serde_json::from_str(&mcp_result_text(&begin)).unwrap();
+        let transaction_id = begin_json["transaction_id"].as_str().unwrap().to_string();
+        let rejected_stage = mcp_call_as(
+            router(Arc::clone(&state)),
+            "kin_transaction_stage",
+            serde_json::json!({
+                "transaction_id": transaction_id,
+                "operations": [{
+                    "verb": "create",
+                    "target": "",
+                    "payload": { "Entity": entity.clone() },
+                    "description": "must not borrow owner identity"
+                }]
+            }),
+            caller,
+        )
+        .await;
+        assert_eq!(rejected_stage.is_error, Some(true));
+        assert!(mcp_result_text(&rejected_stage).contains("does not own"));
+
+        let body_mismatch_stage = mcp_call_as(
+            router(Arc::clone(&state)),
+            "kin_transaction_stage",
+            serde_json::json!({
+                "transaction_id": transaction_id,
+                "session_id": caller.to_string(),
+                "operations": [{
+                    "verb": "create",
+                    "target": "",
+                    "payload": { "Entity": entity.clone() },
+                    "description": "body identity must match the authenticated header"
+                }]
+            }),
+            owner,
+        )
+        .await;
+        assert_eq!(body_mismatch_stage.is_error, Some(true));
+        assert!(mcp_result_text(&body_mismatch_stage).contains("body session_id"));
+
+        let stage = mcp_call_as(
+            router(Arc::clone(&state)),
+            "kin_transaction_stage",
+            serde_json::json!({
+                "transaction_id": transaction_id,
+                "operations": [{
+                    "verb": "create",
+                    "target": "",
+                    "payload": { "Entity": entity },
+                    "description": "must not borrow owner identity"
+                }]
+            }),
+            owner,
+        )
+        .await;
+        assert_ne!(stage.is_error, Some(true));
+        let commit = mcp_call_as(
+            router(Arc::clone(&state)),
+            "kin_transaction_commit",
+            serde_json::json!({ "transaction_id": transaction_id }),
+            caller,
+        )
+        .await;
+        assert_eq!(commit.is_error, Some(true));
+        assert!(mcp_result_text(&commit).contains("does not own transaction session"));
+        assert_eq!(state.graph.entity_count(), before);
+    }
+
+    #[tokio::test]
+    async fn mcp_generic_commit_failure_is_not_labeled_coordination_rejection() {
+        let state = test_state();
+        state
+            .is_initialized
+            .store(true, std::sync::atomic::Ordering::Relaxed);
+        let missing = EntityId::new().to_string();
+        let commit = mcp_call(
+            router(Arc::clone(&state)),
+            "kin_transaction_commit",
+            serde_json::json!({ "transaction_id": missing }),
+        )
+        .await;
+        assert_eq!(commit.is_error, Some(true));
+        let records = std::fs::read_to_string(state.coordination_events.path()).unwrap();
+        let last: crate::state::CoordinationEventEnvelope =
+            serde_json::from_str(records.lines().last().unwrap()).unwrap();
+        assert_eq!(last.outcome, "commit_failed_before_graph_apply");
+        assert!(last.blocking_intent_ids.is_empty());
     }
 
     #[tokio::test]
@@ -10392,15 +10927,16 @@ mod tests {
         alias_payload.id = EntityId::new();
         alias_payload.signature = "def resolved_by_name(changed)".to_string();
         let alias_id = alias_payload.id;
-        let begin = mcp_call(
+        let begin = mcp_call_as(
             router(Arc::clone(&state)),
             "kin_transaction_begin",
             json!({ "session_id": caller.to_string(), "scope": "entity" }),
+            caller,
         )
         .await;
         let begin_json: serde_json::Value = serde_json::from_str(&mcp_result_text(&begin)).unwrap();
         let tx_id = begin_json["transaction_id"].as_str().unwrap().to_string();
-        let stage = mcp_call(
+        let stage = mcp_call_as(
             router(Arc::clone(&state)),
             "kin_transaction_stage",
             json!({
@@ -10412,14 +10948,16 @@ mod tests {
                     "description": "attempt id-alias bypass"
                 }]
             }),
+            caller,
         )
         .await;
         assert_ne!(stage.is_error, Some(true));
 
-        let commit = mcp_call(
+        let commit = mcp_call_as(
             router(Arc::clone(&state)),
             "kin_transaction_commit",
             json!({ "transaction_id": tx_id }),
+            caller,
         )
         .await;
         assert_eq!(commit.is_error, Some(true));
@@ -12260,6 +12798,10 @@ mod tests {
         let registered: RegisterIntentResponse = serde_json::from_slice(&body).unwrap();
         assert_eq!(registered.status, "registered");
         assert!(!registered.session_id.is_empty());
+        assert!(registered
+            .coordination_warnings
+            .iter()
+            .any(|warning| warning.contains("can_write")));
 
         let records = std::fs::read_to_string(state.coordination_events.path()).unwrap();
         let registered_event: crate::state::CoordinationEventEnvelope =
@@ -12586,6 +13128,89 @@ mod tests {
         assert_eq!(json.status, "registered");
         assert!(!json.session_id.is_empty());
         assert!(!json.intent_id.is_empty());
+    }
+
+    #[tokio::test]
+    async fn register_intent_enforce_does_not_mint_writable_implicit_session() {
+        let state = test_state();
+        *state
+            .coordination_mode
+            .write()
+            .unwrap_or_else(std::sync::PoisonError::into_inner) =
+            kin_mcp::CoordinationEnforcementMode::Enforce;
+        let response = router(Arc::clone(&state))
+            .oneshot(
+                Request::post("/intent/register")
+                    .header("content-type", "application/json")
+                    .body(Body::from(
+                        serde_json::json!({
+                            "scope": "file:src/main.rs",
+                            "lock_type": "hard",
+                            "task_description": "must require declared write capability"
+                        })
+                        .to_string(),
+                    ))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(response.status(), StatusCode::OK);
+        let body = axum::body::to_bytes(response.into_body(), 4096)
+            .await
+            .unwrap();
+        let payload: RegisterIntentResponse = serde_json::from_slice(&body).unwrap();
+        assert_eq!(payload.status, "capability_denied");
+        assert!(state.graph.list_all_intents().unwrap().is_empty());
+        let records = std::fs::read_to_string(state.coordination_events.path()).unwrap();
+        let final_event: crate::state::CoordinationEventEnvelope =
+            serde_json::from_str(records.lines().last().unwrap()).unwrap();
+        assert!(final_event.intent_id.is_none());
+        assert!(final_event.intent_ids.is_empty());
+    }
+
+    #[tokio::test]
+    async fn register_intent_fails_before_mutation_when_event_reservation_fails() {
+        let state = test_state();
+        let session_id = state
+            .coordinator
+            .register_session(
+                "test",
+                "event-failure",
+                SessionTransport::Cli,
+                None,
+                state.layout.working_dir().to_path_buf(),
+                SessionCapabilities::default(),
+            )
+            .unwrap();
+        let event_path = state.coordination_events.path().to_path_buf();
+        std::fs::remove_file(&event_path).unwrap();
+        std::fs::create_dir(&event_path).unwrap();
+
+        let response = router(Arc::clone(&state))
+            .oneshot(
+                Request::post("/intent/register")
+                    .header("content-type", "application/json")
+                    .body(Body::from(
+                        serde_json::json!({
+                            "session_id": session_id.to_string(),
+                            "scope": "file:src/main.rs",
+                            "lock_type": "soft",
+                            "task_description": "must not land without evidence"
+                        })
+                        .to_string(),
+                    ))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(response.status(), StatusCode::INSUFFICIENT_STORAGE);
+        assert!(state.graph.list_all_intents().unwrap().is_empty());
+        assert_eq!(
+            state
+                .coordination_event_persist_failures
+                .load(std::sync::atomic::Ordering::Relaxed),
+            1
+        );
     }
 
     #[tokio::test]
@@ -14680,6 +15305,24 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn health_surfaces_coordination_event_failure_attention() {
+        let state = test_state();
+        state
+            .coordination_event_persist_failures
+            .store(1, std::sync::atomic::Ordering::Relaxed);
+        let response = router(state)
+            .oneshot(Request::get("/health").body(Body::empty()).unwrap())
+            .await
+            .unwrap();
+        let body = axum::body::to_bytes(response.into_body(), 4096)
+            .await
+            .unwrap();
+        let json: HealthResponse = serde_json::from_slice(&body).unwrap();
+        assert_eq!(json.status, "attention");
+        assert_eq!(json.coordination_event_persist_failures, Some(1));
+    }
+
+    #[tokio::test]
     async fn command_exec_requires_capability_optin() {
         // Default install (no KIN_DAEMON_ALLOW_EXEC) must refuse shell exec even
         // for an initialized daemon — being initialized is not sufficient.
@@ -15379,13 +16022,13 @@ mod tests {
     }
 
     async fn write_notify(app: Router, body: serde_json::Value) -> (StatusCode, serde_json::Value) {
+        let mut request =
+            Request::post("/vfs/write-notify").header("content-type", "application/json");
+        if let Some(session_id) = body.get("session_id").and_then(serde_json::Value::as_str) {
+            request = request.header("X-Kin-Session", session_id);
+        }
         let resp = app
-            .oneshot(
-                Request::post("/vfs/write-notify")
-                    .header("content-type", "application/json")
-                    .body(Body::from(body.to_string()))
-                    .unwrap(),
-            )
+            .oneshot(request.body(Body::from(body.to_string())).unwrap())
             .await
             .unwrap();
         let status = resp.status();
@@ -15450,8 +16093,17 @@ mod tests {
 
         let _env = EnvVarGuard("KIN_WRITE_VETO");
         std::env::set_var("KIN_WRITE_VETO", "enforce");
-        let (status, json) =
-            write_notify(router(state), serde_json::json!({ "file_path": abs })).await;
+        *state
+            .coordination_mode
+            .write()
+            .unwrap_or_else(std::sync::PoisonError::into_inner) =
+            kin_mcp::CoordinationEnforcementMode::Enforce;
+        let caller = register_foreign_session(&state, "caller");
+        let (status, json) = write_notify(
+            router(state),
+            serde_json::json!({ "file_path": abs, "session_id": caller.to_string() }),
+        )
+        .await;
 
         assert_eq!(status, StatusCode::CONFLICT);
         assert_eq!(json["error"], "write_veto");
@@ -15590,6 +16242,11 @@ mod tests {
 
         let _env = EnvVarGuard("KIN_WRITE_VETO");
         std::env::set_var("KIN_WRITE_VETO", "enforce");
+        *state
+            .coordination_mode
+            .write()
+            .unwrap_or_else(std::sync::PoisonError::into_inner) =
+            kin_mcp::CoordinationEnforcementMode::Enforce;
         let (status, json) = write_notify(
             router(state),
             serde_json::json!({ "file_path": abs, "session_id": caller.to_string() }),
@@ -15622,21 +16279,84 @@ mod tests {
 
         let _env = EnvVarGuard("KIN_WRITE_VETO");
         std::env::set_var("KIN_WRITE_VETO", "enforce");
-        let (status, json) =
-            write_notify(router(state), serde_json::json!({ "file_path": abs })).await;
+        *state
+            .coordination_mode
+            .write()
+            .unwrap_or_else(std::sync::PoisonError::into_inner) =
+            kin_mcp::CoordinationEnforcementMode::Enforce;
+        let caller = register_foreign_session(&state, "caller");
+        let (status, json) = write_notify(
+            router(state),
+            serde_json::json!({ "file_path": abs, "session_id": caller.to_string() }),
+        )
+        .await;
 
         assert_eq!(status, StatusCode::OK);
         assert_eq!(json["reindexed"], true);
     }
 
-    async fn file_changed(app: Router, body: serde_json::Value) -> (StatusCode, serde_json::Value) {
-        let resp = app
+    #[tokio::test]
+    async fn write_notify_enforce_rejects_read_only_and_mismatched_callers() {
+        let _lock = VETO_ENV_LOCK.lock().await;
+        let state = test_state();
+        *state
+            .coordination_mode
+            .write()
+            .unwrap_or_else(std::sync::PoisonError::into_inner) =
+            kin_mcp::CoordinationEnforcementMode::Enforce;
+        let (_, abs) = veto_file_target(&state, "src/lib.py");
+        let read_only = state
+            .coordinator
+            .register_session(
+                "read-only",
+                "reader",
+                SessionTransport::Mcp,
+                None,
+                state.layout.working_dir().to_path_buf(),
+                SessionCapabilities::default(),
+            )
+            .unwrap();
+        let (status, json) = write_notify(
+            router(Arc::clone(&state)),
+            serde_json::json!({ "file_path": abs, "session_id": read_only.to_string() }),
+        )
+        .await;
+        assert_eq!(status, StatusCode::FORBIDDEN);
+        assert!(json["capability_violations"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .any(|value| value == "can_write=false"));
+
+        let first = register_foreign_session(&state, "first");
+        let second = register_foreign_session(&state, "second");
+        let response = router(state)
             .oneshot(
-                Request::post("/vfs/file-changed")
+                Request::post("/vfs/write-notify")
                     .header("content-type", "application/json")
-                    .body(Body::from(body.to_string()))
+                    .header("X-Kin-Session", first.to_string())
+                    .body(Body::from(
+                        serde_json::json!({
+                            "file_path": abs,
+                            "session_id": second.to_string()
+                        })
+                        .to_string(),
+                    ))
                     .unwrap(),
             )
+            .await
+            .unwrap();
+        assert_eq!(response.status(), StatusCode::FORBIDDEN);
+    }
+
+    async fn file_changed(app: Router, body: serde_json::Value) -> (StatusCode, serde_json::Value) {
+        let mut request =
+            Request::post("/vfs/file-changed").header("content-type", "application/json");
+        if let Some(session_id) = body.get("session_id").and_then(serde_json::Value::as_str) {
+            request = request.header("X-Kin-Session", session_id);
+        }
+        let resp = app
+            .oneshot(request.body(Body::from(body.to_string())).unwrap())
             .await
             .unwrap();
         let status = resp.status();
@@ -15701,7 +16421,17 @@ mod tests {
 
         let _env = EnvVarGuard("KIN_WRITE_VETO");
         std::env::set_var("KIN_WRITE_VETO", "enforce");
-        let (status, json) = file_changed(router(state), serde_json::json!({ "path": abs })).await;
+        *state
+            .coordination_mode
+            .write()
+            .unwrap_or_else(std::sync::PoisonError::into_inner) =
+            kin_mcp::CoordinationEnforcementMode::Enforce;
+        let caller = register_foreign_session(&state, "caller");
+        let (status, json) = file_changed(
+            router(state),
+            serde_json::json!({ "path": abs, "session_id": caller.to_string() }),
+        )
+        .await;
 
         assert_eq!(status, StatusCode::CONFLICT);
         assert_eq!(json["error"], "write_veto");
@@ -15794,6 +16524,11 @@ mod tests {
 
         let _env = EnvVarGuard("KIN_WRITE_VETO");
         std::env::set_var("KIN_WRITE_VETO", "enforce");
+        *state
+            .coordination_mode
+            .write()
+            .unwrap_or_else(std::sync::PoisonError::into_inner) =
+            kin_mcp::CoordinationEnforcementMode::Enforce;
         let (status, json) = file_changed(
             router(state),
             serde_json::json!({ "path": abs, "session_id": caller.to_string() }),

--- a/crates/kin-daemon/src/daemon.rs
+++ b/crates/kin-daemon/src/daemon.rs
@@ -743,9 +743,59 @@ pub async fn run(mut state: DaemonState, config: DaemonConfig) -> Result<()> {
             if *sweep_cancel.borrow() {
                 break;
             }
-            match sweep_state.coordinator.sweep_stale_sessions() {
-                Ok(_) => {}
+            let _coordination = sweep_state.coordination_gate.lock().await;
+            let mode = sweep_state.coordination_mode().as_str().to_string();
+            match sweep_state
+                .coordinator
+                .sweep_stale_sessions_with_reservation(|session, intents| {
+                    for intent in intents {
+                        sweep_state.record_coordination_event(
+                            crate::state::CoordinationEventDraft {
+                                event: "intent_release",
+                                outcome: "pending:session_reaped".to_string(),
+                                session_id: Some(session.session_id.to_string()),
+                                intent_id: Some(intent.intent_id.to_string()),
+                                intent_ids: vec![intent.intent_id.to_string()],
+                                transaction_id: None,
+                                scopes: intent
+                                    .scopes
+                                    .iter()
+                                    .map(crate::api::format_scope)
+                                    .collect(),
+                                enforcement_mode: mode.clone(),
+                                blocking_intent_ids: Vec::new(),
+                            },
+                        )?;
+                    }
+                    Ok(())
+                }) {
+                Ok(reaped) => {
+                    for (session, intents) in reaped {
+                        for intent in intents {
+                            let _ = sweep_state.record_coordination_event(
+                                crate::state::CoordinationEventDraft {
+                                    event: "intent_release",
+                                    outcome: "session_reaped".to_string(),
+                                    session_id: Some(session.session_id.to_string()),
+                                    intent_id: Some(intent.intent_id.to_string()),
+                                    intent_ids: vec![intent.intent_id.to_string()],
+                                    transaction_id: None,
+                                    scopes: intent
+                                        .scopes
+                                        .iter()
+                                        .map(crate::api::format_scope)
+                                        .collect(),
+                                    enforcement_mode: mode.clone(),
+                                    blocking_intent_ids: Vec::new(),
+                                },
+                            );
+                        }
+                    }
+                }
                 Err(e) => {
+                    sweep_state.mark_coordination_evidence_incomplete(format!(
+                        "stale-session sweep failed after reservation may have been written: {e}"
+                    ));
                     error!(error = %e, "session sweeper error");
                 }
             }

--- a/crates/kin-daemon/src/lib.rs
+++ b/crates/kin-daemon/src/lib.rs
@@ -38,9 +38,10 @@
 //! Rung-3 of the write path. The agent-write apply paths (`POST /vfs/write-notify`,
 //! `POST /vfs/file-changed`, and MCP `kin_transaction_commit`) evaluate whether
 //! a write touches a scope held under another session's hard intent and, by
-//! default, surface the collision without blocking. Intent registration and
-//! transaction apply share a coordinator gate, so enforce mode cannot race a
-//! hard-intent registration between preflight and graph apply.
+//! default, surface the collision without blocking. Intent registration,
+//! automatic expiry/orphan sweeps, and transaction apply share the same gates,
+//! so enforce mode cannot race lifecycle cleanup against preflight and graph
+//! apply.
 //!
 //! - Default (unset): **warn**. The write still proceeds — a colliding write is
 //!   declined by the reconciler's own check and reported as a soft notification —
@@ -49,7 +50,8 @@
 //!   collision it would hit under enforce.
 //! - `KIN_WRITE_VETO=enforce`: the write is rejected *before* it is folded into
 //!   the graph with a structured `409 Conflict` (`error: "write_veto"`) naming
-//!   the blocking intent(s).
+//!   the blocking intent(s). Missing, mismatched, unknown, or read-only VFS
+//!   caller identity is rejected first with `403 Forbidden`.
 //! - `KIN_WRITE_VETO=off`: the veto never evaluates and never annotates or
 //!   rejects. MCP transaction responses still carry the additive coordination
 //!   coverage attestation with `evaluated:false`.
@@ -101,9 +103,10 @@
 //!   scopes and non-transaction graph-mutating MCP tools are explicitly not
 //!   claim-eligible yet. Each terminal outcome is submitted to
 //!   `.kin/coordination_events.jsonl` with sequence, repo/session/intent,
-//!   effective mode, and release attribution; a successful append is fsynced
-//!   before live broadcast, and persistence failures are logged without a
-//!   misleading broadcast.
+//!   effective mode, and release attribution. A write-ahead reservation is
+//!   fsynced before mutation, the terminal event is fsynced before live
+//!   broadcast, and any persistence failure makes health `attention` and the
+//!   stream ineligible rather than reporting a misleading success.
 
 pub mod api;
 pub mod commit_deltas;

--- a/crates/kin-daemon/src/lib.rs
+++ b/crates/kin-daemon/src/lib.rs
@@ -36,9 +36,11 @@
 //! # Write veto (`KIN_WRITE_VETO`)
 //!
 //! Rung-3 of the write path. The agent-write apply paths (`POST /vfs/write-notify`,
-//! `POST /vfs/file-changed`) evaluate whether a write touches a scope held under
-//! another session's hard intent and, by default, surface the collision without
-//! blocking.
+//! `POST /vfs/file-changed`, and MCP `kin_transaction_commit`) evaluate whether
+//! a write touches a scope held under another session's hard intent and, by
+//! default, surface the collision without blocking. Intent registration and
+//! transaction apply share a coordinator gate, so enforce mode cannot race a
+//! hard-intent registration between preflight and graph apply.
 //!
 //! - Default (unset): **warn**. The write still proceeds — a colliding write is
 //!   declined by the reconciler's own check and reported as a soft notification —
@@ -48,13 +50,14 @@
 //! - `KIN_WRITE_VETO=enforce`: the write is rejected *before* it is folded into
 //!   the graph with a structured `409 Conflict` (`error: "write_veto"`) naming
 //!   the blocking intent(s).
-//! - `KIN_WRITE_VETO=off` (`0`/`false`/`disabled`/`none`): the veto never
-//!   evaluates; the apply path is byte-identical to pre-veto behavior (no
-//!   annotation).
+//! - `KIN_WRITE_VETO=off`: the veto never evaluates and never annotates or
+//!   rejects. MCP transaction responses still carry the additive coordination
+//!   coverage attestation with `evaluated:false`.
 //!
 //! What rung-3 enforces today is exactly **entity/artifact scope containment
 //! versus other sessions' hard intents** — the only "contract" expressible with
-//! current intent data. A session is never blocked by its own intent, and soft
+//! current intent data. MCP relation mutations cover their endpoint entities.
+//! A session is never blocked by its own intent, and soft
 //! intents stay advisory. Content-hash and semantic-contract (e.g.
 //! [`IntentScope::Contract`](kin_model::session::IntentScope)) vetoes are future
 //! work: no contract-content data exists at the apply boundary, and file writes
@@ -91,9 +94,16 @@
 //!   metadata, not entity truth; ungated.
 //! - `PUT /graph/branches/{name}/head`, `DELETE /graph/branches/{name}`: branch
 //!   ref operations; ungated.
-//! - `POST /mcp/tools/call` (`mcp_tools_call`): MCP write transactions — out of
-//!   this crate's veto scope (kin-mcp lane), with its own stage/commit
-//!   validation.
+//! - `POST /mcp/tools/call` (`kin_transaction_commit`): **write-veto** before
+//!   `apply_transaction_delta`, plus `can_write`/`can_commit` capability checks.
+//!   Enforce mode fails closed for an unknown/non-rich session. Exact entity,
+//!   entity-file artifact, and relation-endpoint scopes are covered; contract
+//!   scopes and non-transaction graph-mutating MCP tools are explicitly not
+//!   claim-eligible yet. Each terminal outcome is submitted to
+//!   `.kin/coordination_events.jsonl` with sequence, repo/session/intent,
+//!   effective mode, and release attribution; a successful append is fsynced
+//!   before live broadcast, and persistence failures are logged without a
+//!   misleading broadcast.
 
 pub mod api;
 pub mod commit_deltas;

--- a/crates/kin-daemon/src/loop_runner.rs
+++ b/crates/kin-daemon/src/loop_runner.rs
@@ -169,10 +169,56 @@ pub async fn run_loop(
             break;
         }
 
-        // Sweep expired intents so stale leases don't block work.
-        if let Ok(reaped) = state.coordinator.sweep_expired_intents() {
-            if reaped > 0 {
-                debug!(reaped, "swept expired intents");
+        // Sweep under the same cross-surface gate used by registration and
+        // graph apply, then record every automatic release durably.
+        {
+            let _coordination = state.coordination_gate.lock().await;
+            let mode = state.coordination_mode().as_str().to_string();
+            match state
+                .coordinator
+                .sweep_expired_intents_with_reservation(|intent| {
+                    state
+                        .record_coordination_event(crate::state::CoordinationEventDraft {
+                            event: "intent_release",
+                            outcome: "pending:expired".to_string(),
+                            session_id: Some(intent.session_id.to_string()),
+                            intent_id: Some(intent.intent_id.to_string()),
+                            intent_ids: vec![intent.intent_id.to_string()],
+                            transaction_id: None,
+                            scopes: intent.scopes.iter().map(crate::api::format_scope).collect(),
+                            enforcement_mode: mode.clone(),
+                            blocking_intent_ids: Vec::new(),
+                        })
+                        .map(|_| ())
+                }) {
+                Ok(reaped) => {
+                    for intent in &reaped {
+                        let _ =
+                            state.record_coordination_event(crate::state::CoordinationEventDraft {
+                                event: "intent_release",
+                                outcome: "expired".to_string(),
+                                session_id: Some(intent.session_id.to_string()),
+                                intent_id: Some(intent.intent_id.to_string()),
+                                intent_ids: vec![intent.intent_id.to_string()],
+                                transaction_id: None,
+                                scopes: intent
+                                    .scopes
+                                    .iter()
+                                    .map(crate::api::format_scope)
+                                    .collect(),
+                                enforcement_mode: mode.clone(),
+                                blocking_intent_ids: Vec::new(),
+                            });
+                    }
+                    if !reaped.is_empty() {
+                        debug!(reaped = reaped.len(), "swept expired intents");
+                    }
+                }
+                Err(error) => {
+                    state.mark_coordination_evidence_incomplete(format!(
+                        "expired-intent sweep failed after reservation may have been written: {error}"
+                    ));
+                }
             }
         }
 

--- a/crates/kin-daemon/src/session_registry.rs
+++ b/crates/kin-daemon/src/session_registry.rs
@@ -2,7 +2,7 @@
 // Copyright 2026 Firelock, LLC
 
 use std::path::PathBuf;
-use std::sync::Arc;
+use std::sync::{Arc, Mutex};
 use std::time::Duration;
 
 use tracing::{debug, info, warn};
@@ -30,6 +30,19 @@ pub enum IntentRegistrationResult {
         intent_id: IntentId,
         conflicts: Vec<IntentSummary>,
     },
+    /// Registration rejected because the session has reached the concurrency
+    /// limit it declared at session start.
+    LimitExceeded {
+        intent_id: IntentId,
+        active: usize,
+        limit: usize,
+    },
+    /// A hard intent can block other writers, so only a session that declared
+    /// write capability may register one.
+    CapabilityDenied {
+        intent_id: IntentId,
+        capability: &'static str,
+    },
 }
 
 /// Traffic check result for a set of scopes.
@@ -48,6 +61,12 @@ pub struct TrafficCheck {
 /// higher-level lifecycle operations described in PLAN_P2.md Section 4.7.
 pub struct SessionCoordinator {
     graph: Arc<kin_db::InMemoryGraph>,
+    /// Linearization point for session/intent lifecycle mutations. `kin-db`'s
+    /// public `SessionStore` API exposes individual CRUD calls, so the
+    /// conflict-check + limit-check + insert sequence must be serialized here
+    /// at the owning coordinator boundary rather than performed as racy reads
+    /// followed by a later write.
+    arbitration: Mutex<()>,
     /// Heartbeat interval used for stale-session detection.
     heartbeat_interval: Duration,
 }
@@ -57,6 +76,7 @@ impl SessionCoordinator {
     pub fn new(graph: Arc<kin_db::InMemoryGraph>) -> Self {
         Self {
             graph,
+            arbitration: Mutex::new(()),
             heartbeat_interval: Duration::from_secs(30),
         }
     }
@@ -65,6 +85,7 @@ impl SessionCoordinator {
     pub fn with_heartbeat_interval(graph: Arc<kin_db::InMemoryGraph>, interval: Duration) -> Self {
         Self {
             graph,
+            arbitration: Mutex::new(()),
             heartbeat_interval: interval,
         }
     }
@@ -135,6 +156,10 @@ impl SessionCoordinator {
 
     /// Deregister a session and clean up all its intents.
     pub fn deregister_session(&self, session_id: &SessionId) -> Result<()> {
+        let _arbitration = self
+            .arbitration
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
         for intent in self.list_intents(session_id)? {
             self.graph
                 .delete_intent(&intent.intent_id)
@@ -179,12 +204,21 @@ impl SessionCoordinator {
         task_description: &str,
         expires_at: Option<Timestamp>,
     ) -> Result<IntentRegistrationResult> {
+        // This guard is the linearization point for the whole arbitration
+        // decision. Concurrent hard registrations cannot both observe an
+        // empty conflict set, and a release/deregister cannot race the session
+        // limit check.
+        let _arbitration = self
+            .arbitration
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
+
         // 1. Validate session exists.
         let session = self
             .graph
             .get_session(session_id)
             .map_err(DaemonError::from)?;
-        let _session = session.ok_or_else(|| {
+        let session = session.ok_or_else(|| {
             DaemonError::Graph(kin_db::KinDbError::NotFound(format!(
                 "session not found: {}",
                 session_id
@@ -193,6 +227,27 @@ impl SessionCoordinator {
 
         let intent_id = IntentId::new();
         let now = Timestamp::now();
+
+        if lock_type == LockType::Hard && !session.capabilities.can_write {
+            return Ok(IntentRegistrationResult::CapabilityDenied {
+                intent_id,
+                capability: "can_write",
+            });
+        }
+
+        let active = self
+            .graph
+            .list_intents_for_session(session_id)
+            .map_err(DaemonError::from)?
+            .len();
+        let limit = session.capabilities.max_concurrent_intents;
+        if active >= limit {
+            return Ok(IntentRegistrationResult::LimitExceeded {
+                intent_id,
+                active,
+                limit,
+            });
+        }
 
         // 2. Check for hard collisions on all scope types.
         let mut all_conflicts = Vec::new();
@@ -204,6 +259,11 @@ impl SessionCoordinator {
                         .hard_collisions_for_entity(entity_id, &intent_id)
                         .map_err(DaemonError::from)?;
                     for collision in &collisions {
+                        // A session's own intent is not a collision: own-write
+                        // exclusion is the invariant used by every apply path.
+                        if collision.session_id == *session_id {
+                            continue;
+                        }
                         let col_session = self
                             .graph
                             .get_session(&collision.session_id)
@@ -328,6 +388,10 @@ impl SessionCoordinator {
 
     /// Release (delete) an intent.
     pub fn release_intent(&self, session_id: &SessionId, intent_id: &IntentId) -> Result<()> {
+        let _arbitration = self
+            .arbitration
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
         // Verify the intent belongs to this session.
         let intent = self
             .graph
@@ -785,6 +849,21 @@ mod tests {
         SessionCoordinator::new(graph)
     }
 
+    fn write_capabilities() -> SessionCapabilities {
+        SessionCapabilities {
+            can_write: true,
+            ..SessionCapabilities::default()
+        }
+    }
+
+    fn write_capabilities_with_limit(limit: usize) -> SessionCapabilities {
+        SessionCapabilities {
+            can_write: true,
+            max_concurrent_intents: limit,
+            ..SessionCapabilities::default()
+        }
+    }
+
     #[test]
     fn register_and_get_session() {
         let coord = make_coordinator();
@@ -922,7 +1001,7 @@ mod tests {
                 SessionTransport::Mcp,
                 None,
                 PathBuf::from("/"),
-                SessionCapabilities::default(),
+                write_capabilities(),
             )
             .unwrap();
         let s2 = coord
@@ -932,7 +1011,7 @@ mod tests {
                 SessionTransport::Cli,
                 None,
                 PathBuf::from("/"),
-                SessionCapabilities::default(),
+                write_capabilities(),
             )
             .unwrap();
 
@@ -1050,7 +1129,7 @@ mod tests {
                 SessionTransport::Mcp,
                 None,
                 PathBuf::from("/"),
-                SessionCapabilities::default(),
+                write_capabilities(),
             )
             .unwrap();
 
@@ -1103,7 +1182,7 @@ mod tests {
                 SessionTransport::Mcp,
                 None,
                 PathBuf::from("/"),
-                SessionCapabilities::default(),
+                write_capabilities(),
             )
             .unwrap();
         let s2 = coord
@@ -1113,7 +1192,7 @@ mod tests {
                 SessionTransport::Cli,
                 None,
                 PathBuf::from("/"),
-                SessionCapabilities::default(),
+                write_capabilities(),
             )
             .unwrap();
 
@@ -1154,7 +1233,7 @@ mod tests {
                 SessionTransport::Mcp,
                 None,
                 PathBuf::from("/"),
-                SessionCapabilities::default(),
+                write_capabilities(),
             )
             .unwrap();
         let s2 = coord
@@ -1164,7 +1243,7 @@ mod tests {
                 SessionTransport::Cli,
                 None,
                 PathBuf::from("/"),
-                SessionCapabilities::default(),
+                write_capabilities(),
             )
             .unwrap();
 
@@ -1207,7 +1286,7 @@ mod tests {
                 SessionTransport::Mcp,
                 None,
                 PathBuf::from("/"),
-                SessionCapabilities::default(),
+                write_capabilities_with_limit(3),
             )
             .unwrap();
 
@@ -1358,7 +1437,7 @@ mod tests {
                 SessionTransport::Mcp,
                 None,
                 PathBuf::from("/"),
-                SessionCapabilities::default(),
+                write_capabilities(),
             )
             .unwrap();
         coord
@@ -1403,7 +1482,7 @@ mod tests {
                 SessionTransport::Mcp,
                 None,
                 PathBuf::from("/"),
-                SessionCapabilities::default(),
+                write_capabilities(),
             )
             .unwrap();
         let s2 = coord
@@ -1413,7 +1492,7 @@ mod tests {
                 SessionTransport::Cli,
                 None,
                 PathBuf::from("/"),
-                SessionCapabilities::default(),
+                write_capabilities(),
             )
             .unwrap();
 
@@ -1455,7 +1534,10 @@ mod tests {
                 SessionTransport::Mcp,
                 None,
                 PathBuf::from("/"),
-                SessionCapabilities::default(),
+                SessionCapabilities {
+                    max_concurrent_intents: 5,
+                    ..SessionCapabilities::default()
+                },
             )
             .unwrap();
 
@@ -1480,6 +1562,135 @@ mod tests {
     }
 
     #[test]
+    fn max_concurrent_intents_is_enforced_at_registration_boundary() {
+        let coord = make_coordinator();
+        let sid = coord
+            .register_session(
+                "codex",
+                "bounded",
+                SessionTransport::Mcp,
+                None,
+                PathBuf::from("/"),
+                write_capabilities_with_limit(1),
+            )
+            .unwrap();
+
+        let first = coord
+            .register_intent(
+                &sid,
+                vec![IntentScope::Entity(EntityId::new())],
+                LockType::Hard,
+                "first",
+                None,
+            )
+            .unwrap();
+        assert!(matches!(first, IntentRegistrationResult::Registered { .. }));
+
+        let second = coord
+            .register_intent(
+                &sid,
+                vec![IntentScope::Entity(EntityId::new())],
+                LockType::Hard,
+                "second",
+                None,
+            )
+            .unwrap();
+        assert!(matches!(
+            second,
+            IntentRegistrationResult::LimitExceeded {
+                active: 1,
+                limit: 1,
+                ..
+            }
+        ));
+        assert_eq!(coord.list_intents(&sid).unwrap().len(), 1);
+    }
+
+    #[test]
+    fn hard_intent_requires_session_write_capability() {
+        let coord = make_coordinator();
+        let sid = coord
+            .register_session(
+                "read-only-agent",
+                "reader",
+                SessionTransport::Mcp,
+                None,
+                PathBuf::from("/"),
+                SessionCapabilities::default(),
+            )
+            .unwrap();
+
+        let result = coord
+            .register_intent(
+                &sid,
+                vec![IntentScope::Entity(EntityId::new())],
+                LockType::Hard,
+                "must not block writers",
+                None,
+            )
+            .unwrap();
+        assert!(matches!(
+            result,
+            IntentRegistrationResult::CapabilityDenied {
+                capability: "can_write",
+                ..
+            }
+        ));
+        assert!(coord.list_intents(&sid).unwrap().is_empty());
+    }
+
+    #[test]
+    fn concurrent_hard_registration_has_one_linearizable_winner() {
+        use std::sync::{Arc, Barrier};
+
+        let coord = Arc::new(make_coordinator());
+        let entity = make_test_entity(&coord);
+        let sessions = ["one", "two"].map(|name| {
+            coord
+                .register_session(
+                    "codex",
+                    name,
+                    SessionTransport::Mcp,
+                    None,
+                    PathBuf::from("/"),
+                    write_capabilities(),
+                )
+                .unwrap()
+        });
+        let barrier = Arc::new(Barrier::new(2));
+
+        let handles = sessions.map(|session_id| {
+            let coord = Arc::clone(&coord);
+            let barrier = Arc::clone(&barrier);
+            std::thread::spawn(move || {
+                barrier.wait();
+                coord
+                    .register_intent(
+                        &session_id,
+                        vec![IntentScope::Entity(entity)],
+                        LockType::Hard,
+                        "racing registration",
+                        None,
+                    )
+                    .unwrap()
+            })
+        });
+        let outcomes = handles.map(|handle| handle.join().unwrap());
+        let registered = outcomes
+            .iter()
+            .filter(|result| matches!(result, IntentRegistrationResult::Registered { .. }))
+            .count();
+        let blocked = outcomes
+            .iter()
+            .filter(|result| matches!(result, IntentRegistrationResult::Blocked { .. }))
+            .count();
+
+        assert_eq!(registered, 1);
+        assert_eq!(blocked, 1);
+        assert_eq!(coord.graph.list_all_intents().unwrap().len(), 1);
+    }
+
+    #[test]
     fn soft_lock_does_not_block_hard_lock_from_other_session() {
         let coord = make_coordinator();
         let entity = make_test_entity(&coord);
@@ -1491,7 +1702,7 @@ mod tests {
                 SessionTransport::Mcp,
                 None,
                 PathBuf::from("/"),
-                SessionCapabilities::default(),
+                write_capabilities(),
             )
             .unwrap();
         let s2 = coord
@@ -1501,7 +1712,7 @@ mod tests {
                 SessionTransport::Cli,
                 None,
                 PathBuf::from("/"),
-                SessionCapabilities::default(),
+                write_capabilities(),
             )
             .unwrap();
 
@@ -1652,7 +1863,7 @@ mod tests {
                 SessionTransport::Mcp,
                 None,
                 PathBuf::from("/"),
-                SessionCapabilities::default(),
+                write_capabilities(),
             )
             .unwrap();
 

--- a/crates/kin-daemon/src/session_registry.rs
+++ b/crates/kin-daemon/src/session_registry.rs
@@ -24,6 +24,7 @@ pub enum IntentRegistrationResult {
     Registered {
         intent_id: IntentId,
         downstream_warnings: Vec<IntentSummary>,
+        policy_warnings: Vec<String>,
     },
     /// Registration blocked by a hard collision.
     Blocked {
@@ -204,6 +205,29 @@ impl SessionCoordinator {
         task_description: &str,
         expires_at: Option<Timestamp>,
     ) -> Result<IntentRegistrationResult> {
+        self.register_intent_with_mode(
+            session_id,
+            scopes,
+            lock_type,
+            task_description,
+            expires_at,
+            kin_mcp::CoordinationEnforcementMode::from_env(),
+        )
+    }
+
+    /// Register an intent under an explicit coordination mode. The daemon uses
+    /// its startup-captured mode so an in-flight request cannot observe a
+    /// process-environment change; the compatibility wrapper above remains for
+    /// in-process callers.
+    pub fn register_intent_with_mode(
+        &self,
+        session_id: &SessionId,
+        scopes: Vec<IntentScope>,
+        lock_type: LockType,
+        task_description: &str,
+        expires_at: Option<Timestamp>,
+        mode: kin_mcp::CoordinationEnforcementMode,
+    ) -> Result<IntentRegistrationResult> {
         // This guard is the linearization point for the whole arbitration
         // decision. Concurrent hard registrations cannot both observe an
         // empty conflict set, and a release/deregister cannot race the session
@@ -228,25 +252,49 @@ impl SessionCoordinator {
         let intent_id = IntentId::new();
         let now = Timestamp::now();
 
+        let mut policy_warnings = Vec::new();
         if lock_type == LockType::Hard && !session.capabilities.can_write {
-            return Ok(IntentRegistrationResult::CapabilityDenied {
-                intent_id,
-                capability: "can_write",
-            });
+            if mode.is_enforcing() {
+                return Ok(IntentRegistrationResult::CapabilityDenied {
+                    intent_id,
+                    capability: "can_write",
+                });
+            }
+            if mode.evaluates() {
+                policy_warnings.push(
+                    "hard intent requires can_write=true; registration would be denied in enforce mode"
+                        .to_string(),
+                );
+            }
         }
 
+        let now_for_expiry = Timestamp::now();
         let active = self
             .graph
             .list_intents_for_session(session_id)
             .map_err(DaemonError::from)?
-            .len();
+            .into_iter()
+            .filter(|intent| {
+                intent
+                    .expires_at
+                    .as_ref()
+                    .is_none_or(|expires_at| expires_at >= &now_for_expiry)
+            })
+            .count();
         let limit = session.capabilities.max_concurrent_intents;
         if active >= limit {
-            return Ok(IntentRegistrationResult::LimitExceeded {
-                intent_id,
-                active,
-                limit,
-            });
+            if mode.is_enforcing() {
+                return Ok(IntentRegistrationResult::LimitExceeded {
+                    intent_id,
+                    active,
+                    limit,
+                });
+            }
+            if mode.evaluates() {
+                policy_warnings.push(format!(
+                    "active intent count {active} reached max_concurrent_intents={limit}; registration would be denied in enforce mode"
+                ));
+            }
         }
 
         // 2. Check for hard collisions on all scope types.
@@ -259,6 +307,13 @@ impl SessionCoordinator {
                         .hard_collisions_for_entity(entity_id, &intent_id)
                         .map_err(DaemonError::from)?;
                     for collision in &collisions {
+                        if collision
+                            .expires_at
+                            .as_ref()
+                            .is_some_and(|expires_at| expires_at < &now)
+                        {
+                            continue;
+                        }
                         // A session's own intent is not a collision: own-write
                         // exclusion is the invariant used by every apply path.
                         if collision.session_id == *session_id {
@@ -289,6 +344,8 @@ impl SessionCoordinator {
         }
 
         // If registering a hard lock and there are hard collisions, block.
+        all_conflicts.sort_by_key(|conflict| conflict.intent_id.to_string());
+        all_conflicts.dedup_by_key(|conflict| conflict.intent_id);
         if lock_type == LockType::Hard && !all_conflicts.is_empty() {
             return Ok(IntentRegistrationResult::Blocked {
                 intent_id,
@@ -383,6 +440,7 @@ impl SessionCoordinator {
         Ok(IntentRegistrationResult::Registered {
             intent_id,
             downstream_warnings,
+            policy_warnings,
         })
     }
 
@@ -529,9 +587,12 @@ impl SessionCoordinator {
 
     /// List all intents for a given session.
     pub fn list_intents(&self, session_id: &SessionId) -> Result<Vec<Intent>> {
-        self.graph
+        let mut intents = self
+            .graph
             .list_intents_for_session(session_id)
-            .map_err(DaemonError::from)
+            .map_err(DaemonError::from)?;
+        intents.sort_by_key(|intent| intent.intent_id.to_string());
+        Ok(intents)
     }
 
     /// Sweep expired intents from the graph.
@@ -540,31 +601,52 @@ impl SessionCoordinator {
     /// number of intents reaped. Call this periodically (e.g. from the
     /// reconcile loop tick) to prevent stale leases from blocking work.
     pub fn sweep_expired_intents(&self) -> Result<usize> {
+        Ok(self.sweep_expired_intents_detailed()?.len())
+    }
+
+    /// Sweep expired intents and return the removed records so the daemon can
+    /// emit a complete durable lifecycle event for each release.
+    pub fn sweep_expired_intents_detailed(&self) -> Result<Vec<Intent>> {
+        self.sweep_expired_intents_with_reservation(|_| Ok(()))
+    }
+
+    pub fn sweep_expired_intents_with_reservation<F>(&self, mut reserve: F) -> Result<Vec<Intent>>
+    where
+        F: FnMut(&Intent) -> std::io::Result<()>,
+    {
+        let _arbitration = self
+            .arbitration
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
         let now = Timestamp::now();
-        let all_intents = self.graph.list_all_intents().map_err(DaemonError::from)?;
-        let mut reaped = 0;
+        let mut all_intents = self.graph.list_all_intents().map_err(DaemonError::from)?;
+        all_intents.sort_by_key(|intent| intent.intent_id.to_string());
+        let mut reaped = Vec::new();
 
         for intent in &all_intents {
             if let Some(ref expires_at) = intent.expires_at {
                 if expires_at < &now {
+                    reserve(intent)?;
                     if let Err(e) = self.graph.delete_intent(&intent.intent_id) {
                         warn!(
                             intent_id = %intent.intent_id,
                             error = %e,
                             "failed to reap expired intent"
                         );
+                        return Err(DaemonError::from(e));
                     } else {
                         info!(
                             intent_id = %intent.intent_id,
                             session_id = %intent.session_id,
                             "reaped expired intent"
                         );
-                        reaped += 1;
+                        reaped.push(intent.clone());
                     }
                 }
             }
         }
 
+        reaped.sort_by_key(|intent| intent.intent_id.to_string());
         Ok(reaped)
     }
 
@@ -582,8 +664,16 @@ impl SessionCoordinator {
     ) -> Result<Vec<IntentSummary>> {
         let all_intents = self.graph.list_all_intents().map_err(DaemonError::from)?;
         let mut conflicts = Vec::new();
+        let now = Timestamp::now();
 
         for intent in &all_intents {
+            if intent
+                .expires_at
+                .as_ref()
+                .is_some_and(|expires_at| expires_at < &now)
+            {
+                continue;
+            }
             if &intent.session_id == caller_session {
                 continue;
             }
@@ -722,10 +812,31 @@ impl SessionCoordinator {
     ///
     /// Returns the number of sessions reaped.
     pub fn sweep_stale_sessions(&self) -> Result<usize> {
-        let sessions = self.graph.list_sessions().map_err(DaemonError::from)?;
+        Ok(self.sweep_stale_sessions_detailed()?.len())
+    }
+
+    /// Sweep stale sessions, deleting their intents before the session and
+    /// returning the removed records for durable lifecycle logging.
+    pub fn sweep_stale_sessions_detailed(&self) -> Result<Vec<(AgentSession, Vec<Intent>)>> {
+        self.sweep_stale_sessions_with_reservation(|_, _| Ok(()))
+    }
+
+    pub fn sweep_stale_sessions_with_reservation<F>(
+        &self,
+        mut reserve: F,
+    ) -> Result<Vec<(AgentSession, Vec<Intent>)>>
+    where
+        F: FnMut(&AgentSession, &[Intent]) -> std::io::Result<()>,
+    {
+        let _arbitration = self
+            .arbitration
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
+        let mut sessions = self.graph.list_sessions().map_err(DaemonError::from)?;
+        sessions.sort_by_key(|session| session.session_id.to_string());
         let now = Timestamp::now();
         let stale_threshold = self.heartbeat_interval * 2;
-        let mut reaped = 0;
+        let mut reaped = Vec::new();
 
         for session in &sessions {
             let mut is_stale = false;
@@ -771,6 +882,17 @@ impl SessionCoordinator {
             }
 
             if is_stale {
+                let mut intents = self
+                    .graph
+                    .list_intents_for_session(&session.session_id)
+                    .map_err(DaemonError::from)?;
+                intents.sort_by_key(|intent| intent.intent_id.to_string());
+                reserve(session, &intents)?;
+                for intent in &intents {
+                    self.graph
+                        .delete_intent(&intent.intent_id)
+                        .map_err(DaemonError::from)?;
+                }
                 self.graph
                     .delete_session(&session.session_id)
                     .map_err(DaemonError::from)?;
@@ -779,12 +901,12 @@ impl SessionCoordinator {
                     vendor = %session.vendor,
                     "reaped stale agent session"
                 );
-                reaped += 1;
+                reaped.push((session.clone(), intents));
             }
         }
 
-        if reaped > 0 {
-            info!(reaped, "orphan sweep complete");
+        if !reaped.is_empty() {
+            info!(reaped = reaped.len(), "orphan sweep complete");
         }
 
         Ok(reaped)
@@ -1576,23 +1698,25 @@ mod tests {
             .unwrap();
 
         let first = coord
-            .register_intent(
+            .register_intent_with_mode(
                 &sid,
                 vec![IntentScope::Entity(EntityId::new())],
                 LockType::Hard,
                 "first",
                 None,
+                kin_mcp::CoordinationEnforcementMode::Enforce,
             )
             .unwrap();
         assert!(matches!(first, IntentRegistrationResult::Registered { .. }));
 
         let second = coord
-            .register_intent(
+            .register_intent_with_mode(
                 &sid,
                 vec![IntentScope::Entity(EntityId::new())],
                 LockType::Hard,
                 "second",
                 None,
+                kin_mcp::CoordinationEnforcementMode::Enforce,
             )
             .unwrap();
         assert!(matches!(
@@ -1621,12 +1745,13 @@ mod tests {
             .unwrap();
 
         let result = coord
-            .register_intent(
+            .register_intent_with_mode(
                 &sid,
                 vec![IntentScope::Entity(EntityId::new())],
                 LockType::Hard,
                 "must not block writers",
                 None,
+                kin_mcp::CoordinationEnforcementMode::Enforce,
             )
             .unwrap();
         assert!(matches!(
@@ -1899,14 +2024,27 @@ mod tests {
                 SessionTransport::Mcp,
                 Some(999_999_999),
                 PathBuf::from("/"),
-                SessionCapabilities::default(),
+                write_capabilities(),
             )
             .unwrap();
 
-        let reaped = coord.sweep_stale_sessions().unwrap();
+        let lock = coord
+            .register_intent(
+                &sid,
+                vec![IntentScope::Entity(EntityId::new())],
+                LockType::Hard,
+                "non-expiring orphan candidate",
+                None,
+            )
+            .unwrap();
+        assert!(matches!(lock, IntentRegistrationResult::Registered { .. }));
+
+        let reaped = coord.sweep_stale_sessions_detailed().unwrap();
         // On macOS, kill -0 on invalid PID fails, marking it stale
-        assert_eq!(reaped, 1);
+        assert_eq!(reaped.len(), 1);
+        assert_eq!(reaped[0].1.len(), 1);
         assert!(coord.get_session(&sid).unwrap().is_none());
+        assert!(coord.list_intents(&sid).unwrap().is_empty());
     }
 
     #[test]

--- a/crates/kin-daemon/src/state.rs
+++ b/crates/kin-daemon/src/state.rs
@@ -182,7 +182,7 @@ impl CoordinationEventLog {
                 .open(&path)?
                 .sync_data()?;
             if let Some(parent) = path.parent() {
-                std::fs::File::open(parent)?.sync_all()?;
+                sync_directory_metadata(parent)?;
             }
         }
 
@@ -320,7 +320,7 @@ impl CoordinationEventLog {
             file.sync_data()?;
             if !path_existed {
                 if let Some(parent) = self.path.parent() {
-                    std::fs::File::open(parent)?.sync_all()?;
+                    sync_directory_metadata(parent)?;
                 }
             }
             Ok(())
@@ -345,11 +345,17 @@ impl CoordinationEventLog {
     fn persist_failure_count(&self, count: u64) {
         let temp = self.failure_marker.with_extension("failed.tmp");
         let result = (|| -> std::io::Result<()> {
-            std::fs::write(&temp, format!("{count}\n"))?;
-            std::fs::File::open(&temp)?.sync_data()?;
+            let mut file = std::fs::OpenOptions::new()
+                .write(true)
+                .create(true)
+                .truncate(true)
+                .open(&temp)?;
+            file.write_all(format!("{count}\n").as_bytes())?;
+            file.sync_data()?;
+            drop(file);
             std::fs::rename(&temp, &self.failure_marker)?;
             if let Some(parent) = self.failure_marker.parent() {
-                std::fs::File::open(parent)?.sync_all()?;
+                sync_directory_metadata(parent)?;
             }
             Ok(())
         })();

--- a/crates/kin-daemon/src/state.rs
+++ b/crates/kin-daemon/src/state.rs
@@ -2,6 +2,7 @@
 // Copyright 2026 Firelock, LLC
 
 use std::collections::{HashMap, HashSet};
+use std::io::Write;
 use std::sync::atomic::{AtomicBool, AtomicU32, AtomicU64, AtomicU8, Ordering};
 use std::sync::{Arc, Mutex};
 use std::time::{Duration, Instant};
@@ -112,6 +113,128 @@ pub(crate) fn write_persisted_mcp_transactions(
     }
 }
 
+/// One append-only, release-attributed coordination event. This is the durable
+/// collector boundary used by citable multi-agent metrics; every record names
+/// its exact enforcement mode and scopes instead of implying unsupported
+/// contract coverage.
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
+pub struct CoordinationEventEnvelope {
+    pub schema: String,
+    pub sequence: u64,
+    pub timestamp: String,
+    pub event: String,
+    pub outcome: String,
+    pub repo_id: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub session_id: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub intent_id: Option<String>,
+    #[serde(default)]
+    pub intent_ids: Vec<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub transaction_id: Option<String>,
+    #[serde(default)]
+    pub scopes: Vec<String>,
+    pub enforcement_mode: String,
+    #[serde(default)]
+    pub blocking_intent_ids: Vec<String>,
+    pub kin_version: String,
+    pub kin_commit: String,
+    pub kin_dirty: bool,
+}
+
+#[derive(Debug, Clone)]
+pub struct CoordinationEventDraft {
+    pub event: &'static str,
+    pub outcome: String,
+    pub session_id: Option<String>,
+    pub intent_id: Option<String>,
+    pub intent_ids: Vec<String>,
+    pub transaction_id: Option<String>,
+    pub scopes: Vec<String>,
+    pub enforcement_mode: String,
+    pub blocking_intent_ids: Vec<String>,
+}
+
+/// Append-only JSONL writer with a monotonic sequence recovered from disk on
+/// daemon restart. Appends are serialized and `sync_data` is called before an
+/// event is broadcast, so live consumers never observe an event the durable
+/// collector failed to record.
+pub struct CoordinationEventLog {
+    path: std::path::PathBuf,
+    repo_id: String,
+    next_sequence: Mutex<u64>,
+}
+
+impl CoordinationEventLog {
+    pub fn open(layout: &KinLayout, repo_id: &str) -> Self {
+        let path = layout.root().join("coordination_events.jsonl");
+        let next_sequence = std::fs::read_to_string(&path)
+            .ok()
+            .and_then(|contents| {
+                contents.lines().rev().find_map(|line| {
+                    serde_json::from_str::<serde_json::Value>(line)
+                        .ok()
+                        .and_then(|value| value.get("sequence")?.as_u64())
+                })
+            })
+            .unwrap_or(0)
+            .saturating_add(1);
+        Self {
+            path,
+            repo_id: repo_id.to_string(),
+            next_sequence: Mutex::new(next_sequence),
+        }
+    }
+
+    pub fn append(
+        &self,
+        draft: CoordinationEventDraft,
+    ) -> std::io::Result<CoordinationEventEnvelope> {
+        let mut next = self
+            .next_sequence
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
+        let build = kin_buildinfo::get();
+        let envelope = CoordinationEventEnvelope {
+            schema: "kin.coordination-event.v1".to_string(),
+            sequence: *next,
+            timestamp: kin_model::Timestamp::now().to_string(),
+            event: draft.event.to_string(),
+            outcome: draft.outcome,
+            repo_id: self.repo_id.clone(),
+            session_id: draft.session_id,
+            intent_id: draft.intent_id,
+            intent_ids: draft.intent_ids,
+            transaction_id: draft.transaction_id,
+            scopes: draft.scopes,
+            enforcement_mode: draft.enforcement_mode,
+            blocking_intent_ids: draft.blocking_intent_ids,
+            kin_version: kin_buildinfo::version().to_string(),
+            kin_commit: build.sha.to_string(),
+            kin_dirty: build.dirty,
+        };
+        let mut bytes = serde_json::to_vec(&envelope).map_err(std::io::Error::other)?;
+        bytes.push(b'\n');
+        if let Some(parent) = self.path.parent() {
+            std::fs::create_dir_all(parent)?;
+        }
+        let mut file = std::fs::OpenOptions::new()
+            .create(true)
+            .append(true)
+            .open(&self.path)?;
+        file.write_all(&bytes)?;
+        file.sync_data()?;
+        *next = next.saturating_add(1);
+        Ok(envelope)
+    }
+
+    #[cfg(test)]
+    pub(crate) fn path(&self) -> &std::path::Path {
+        &self.path
+    }
+}
+
 /// SSE invalidation events pushed to subscribers (VFS daemon, spine, KinLab).
 #[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
 #[serde(tag = "type")]
@@ -141,6 +264,8 @@ pub enum DaemonEvent {
         old_root_hash: Option<String>,
         new_root_hash: String,
     },
+    /// Durable coordination lifecycle event, appended before broadcast.
+    Coordination { event: CoordinationEventEnvelope },
 }
 
 /// Authority owning the graph selected for a daemon request.
@@ -351,6 +476,18 @@ pub struct DaemonState {
     pub projection: RwLock<ProjectionState>,
     /// Session and intent coordinator (Phase 7).
     pub coordinator: SessionCoordinator,
+    /// Serializes daemon intent lifecycle mutations with MCP transaction
+    /// preflight+apply so those two authority paths have one ordering.
+    pub coordination_gate: tokio::sync::Mutex<()>,
+    /// Mode captured when the daemon state is created. Requests use this
+    /// stable value instead of re-reading process-global environment mid-run.
+    pub coordination_mode: std::sync::RwLock<kin_mcp::CoordinationEnforcementMode>,
+    /// Durable, release-attributed coordination event collector.
+    pub coordination_events: CoordinationEventLog,
+    /// Runtime completeness signal for the durable collector. Citable runs
+    /// must require zero; an append failure never masquerades as a recorded
+    /// event merely because the product action itself completed.
+    pub coordination_event_persist_failures: AtomicU64,
     /// When the daemon was started (for uptime reporting).
     pub started_at: Instant,
     /// Whether the daemon has been initialized (snapshot loaded or first reconciliation done).
@@ -562,6 +699,33 @@ pub(crate) fn graph_collapse_is_wipe(current: u64, baseline: u64) -> bool {
 }
 
 impl DaemonState {
+    pub fn coordination_mode(&self) -> kin_mcp::CoordinationEnforcementMode {
+        *self
+            .coordination_mode
+            .read()
+            .unwrap_or_else(std::sync::PoisonError::into_inner)
+    }
+
+    pub(crate) fn record_coordination_event(
+        &self,
+        draft: CoordinationEventDraft,
+    ) -> Option<CoordinationEventEnvelope> {
+        match self.coordination_events.append(draft) {
+            Ok(event) => {
+                self.emit_event(DaemonEvent::Coordination {
+                    event: event.clone(),
+                });
+                Some(event)
+            }
+            Err(error) => {
+                self.coordination_event_persist_failures
+                    .fetch_add(1, Ordering::Relaxed);
+                warn!(error = %error, "failed to persist coordination event; event not broadcast");
+                None
+            }
+        }
+    }
+
     /// Load a persisted vector-index sidecar into a graph that was NOT built
     /// through `SnapshotManager` (the storage-backend path uses
     /// `InMemoryGraph::from_snapshot_with_text_index`, which does not load the
@@ -736,6 +900,7 @@ impl DaemonState {
         // from the on-disk snapshot. Read before `graph` is moved into the state.
         let loaded_entity_count = graph.entity_count();
 
+        let coordination_events = CoordinationEventLog::open(&layout, &cached_repo_id);
         let mut state = Self {
             layout,
             graph,
@@ -744,6 +909,12 @@ impl DaemonState {
             reconciler: RwLock::new(reconciler),
             projection: RwLock::new(ProjectionState::new()),
             coordinator,
+            coordination_gate: tokio::sync::Mutex::new(()),
+            coordination_mode: std::sync::RwLock::new(
+                kin_mcp::CoordinationEnforcementMode::from_env(),
+            ),
+            coordination_events,
+            coordination_event_persist_failures: AtomicU64::new(0),
             started_at: Instant::now(),
             is_initialized: AtomicBool::new(loaded_snapshot),
             reconciliation_status: AtomicU8::new(RECON_IDLE),
@@ -892,6 +1063,7 @@ impl DaemonState {
         // the backend snapshot).
         let loaded_entity_count = graph.entity_count();
 
+        let coordination_events = CoordinationEventLog::open(&layout, repo_id);
         let mut state = Self {
             layout,
             graph: Arc::clone(&graph),
@@ -900,6 +1072,12 @@ impl DaemonState {
             reconciler: RwLock::new(reconciler),
             projection: RwLock::new(ProjectionState::new()),
             coordinator,
+            coordination_gate: tokio::sync::Mutex::new(()),
+            coordination_mode: std::sync::RwLock::new(
+                kin_mcp::CoordinationEnforcementMode::from_env(),
+            ),
+            coordination_events,
+            coordination_event_persist_failures: AtomicU64::new(0),
             started_at: Instant::now(),
             is_initialized: AtomicBool::new(loaded_snapshot),
             reconciliation_status: AtomicU8::new(RECON_IDLE),
@@ -2825,6 +3003,7 @@ mod tests {
         };
         let coordinator = SessionCoordinator::new(Arc::clone(&graph));
         let loaded_entity_count = graph.entity_count();
+        let coordination_events = CoordinationEventLog::open(&layout, "test-repo");
 
         DaemonState {
             layout,
@@ -2834,6 +3013,12 @@ mod tests {
             reconciler: RwLock::new(Reconciler::new(working_dir.to_path_buf())),
             projection: RwLock::new(ProjectionState::new()),
             coordinator,
+            coordination_gate: tokio::sync::Mutex::new(()),
+            coordination_mode: std::sync::RwLock::new(
+                kin_mcp::CoordinationEnforcementMode::from_env(),
+            ),
+            coordination_events,
+            coordination_event_persist_failures: AtomicU64::new(0),
             started_at: Instant::now(),
             is_initialized: AtomicBool::new(false),
             reconciliation_status: AtomicU8::new(RECON_IDLE),
@@ -2921,6 +3106,55 @@ mod tests {
         let v = serde_json::to_value(&event).unwrap();
         assert_eq!(v["type"], json!("EntityChanged"));
         assert_eq!(v["session_id"], json!("mission-ctl-7"));
+    }
+
+    #[test]
+    fn coordination_event_log_is_durable_and_sequence_resumes() {
+        let dir = tempfile::tempdir().unwrap();
+        let layout = KinLayout::new(dir.path().join(".kin"));
+        std::fs::create_dir_all(layout.root()).unwrap();
+        let log = CoordinationEventLog::open(&layout, "test-repo");
+        let first = log
+            .append(CoordinationEventDraft {
+                event: "intent_registration",
+                outcome: "registered".to_string(),
+                session_id: Some("session-1".to_string()),
+                intent_id: Some("intent-1".to_string()),
+                intent_ids: vec!["intent-1".to_string()],
+                transaction_id: None,
+                scopes: vec!["entity:e1".to_string()],
+                enforcement_mode: "warn".to_string(),
+                blocking_intent_ids: vec![],
+            })
+            .unwrap();
+        assert_eq!(first.sequence, 1);
+        assert_eq!(first.schema, "kin.coordination-event.v1");
+
+        let reopened = CoordinationEventLog::open(&layout, "test-repo");
+        let second = reopened
+            .append(CoordinationEventDraft {
+                event: "transaction_outcome",
+                outcome: "committed".to_string(),
+                session_id: Some("session-1".to_string()),
+                intent_id: None,
+                intent_ids: Vec::new(),
+                transaction_id: Some("tx-1".to_string()),
+                scopes: vec!["artifact:src/lib.rs".to_string()],
+                enforcement_mode: "enforce".to_string(),
+                blocking_intent_ids: vec![],
+            })
+            .unwrap();
+        assert_eq!(second.sequence, 2);
+
+        let lines = std::fs::read_to_string(reopened.path()).unwrap();
+        let records: Vec<CoordinationEventEnvelope> = lines
+            .lines()
+            .map(|line| serde_json::from_str(line).unwrap())
+            .collect();
+        assert_eq!(records.len(), 2);
+        assert_eq!(records[1].repo_id, "test-repo");
+        assert_eq!(records[1].transaction_id.as_deref(), Some("tx-1"));
+        assert!(!records[1].kin_commit.is_empty());
     }
 
     #[test]

--- a/crates/kin-daemon/src/state.rs
+++ b/crates/kin-daemon/src/state.rs
@@ -162,40 +162,130 @@ pub struct CoordinationEventDraft {
 /// collector failed to record.
 pub struct CoordinationEventLog {
     path: std::path::PathBuf,
+    failure_marker: std::path::PathBuf,
     repo_id: String,
     next_sequence: Mutex<u64>,
+    poisoned: AtomicBool,
 }
 
 impl CoordinationEventLog {
-    pub fn open(layout: &KinLayout, repo_id: &str) -> Self {
+    pub fn open(layout: &KinLayout, repo_id: &str) -> std::io::Result<Self> {
         let path = layout.root().join("coordination_events.jsonl");
-        let next_sequence = std::fs::read_to_string(&path)
-            .ok()
-            .and_then(|contents| {
-                contents.lines().rev().find_map(|line| {
-                    serde_json::from_str::<serde_json::Value>(line)
-                        .ok()
-                        .and_then(|value| value.get("sequence")?.as_u64())
-                })
-            })
-            .unwrap_or(0)
-            .saturating_add(1);
-        Self {
+        let failure_marker = layout.root().join("coordination_events.failed");
+        if let Some(parent) = path.parent() {
+            std::fs::create_dir_all(parent)?;
+        }
+        if !path.exists() {
+            std::fs::OpenOptions::new()
+                .write(true)
+                .create_new(true)
+                .open(&path)?
+                .sync_data()?;
+            if let Some(parent) = path.parent() {
+                std::fs::File::open(parent)?.sync_all()?;
+            }
+        }
+
+        let mut bytes = match std::fs::read(&path) {
+            Ok(bytes) => bytes,
+            Err(error) if error.kind() == std::io::ErrorKind::NotFound => Vec::new(),
+            Err(error) => return Err(error),
+        };
+        let mut repaired_tail = false;
+        if !bytes.is_empty() && !bytes.ends_with(b"\n") {
+            let repaired_len = bytes
+                .iter()
+                .rposition(|byte| *byte == b'\n')
+                .map_or(0, |index| index + 1);
+            let file = std::fs::OpenOptions::new().write(true).open(&path)?;
+            file.set_len(repaired_len as u64)?;
+            file.sync_data()?;
+            bytes.truncate(repaired_len);
+            repaired_tail = true;
+        }
+
+        let mut previous_sequence = None;
+        let mut pending_reservations: HashMap<String, usize> = HashMap::new();
+        for line in bytes
+            .split(|byte| *byte == b'\n')
+            .filter(|line| !line.is_empty())
+        {
+            let event: CoordinationEventEnvelope =
+                serde_json::from_slice(line).map_err(|error| {
+                    std::io::Error::new(
+                        std::io::ErrorKind::InvalidData,
+                        format!("invalid coordination event JSONL record: {error}"),
+                    )
+                })?;
+            if previous_sequence.is_some_and(|previous| event.sequence <= previous) {
+                return Err(std::io::Error::new(
+                    std::io::ErrorKind::InvalidData,
+                    format!(
+                        "coordination event sequence is not strictly increasing: {}",
+                        event.sequence
+                    ),
+                ));
+            }
+            let reservation_key = serde_json::to_string(&(
+                &event.event,
+                &event.session_id,
+                &event.transaction_id,
+                &event.scopes,
+            ))
+            .map_err(std::io::Error::other)?;
+            if event.outcome.starts_with("pending:") {
+                *pending_reservations.entry(reservation_key).or_default() += 1;
+            } else if let Some(count) = pending_reservations.get_mut(&reservation_key) {
+                *count -= 1;
+                if *count == 0 {
+                    pending_reservations.remove(&reservation_key);
+                }
+            }
+            previous_sequence = Some(event.sequence);
+        }
+        let next_sequence = previous_sequence.unwrap_or(0).saturating_add(1);
+        let log = Self {
             path,
+            failure_marker,
             repo_id: repo_id.to_string(),
             next_sequence: Mutex::new(next_sequence),
+            poisoned: AtomicBool::new(false),
+        };
+        if repaired_tail || !pending_reservations.is_empty() {
+            let failures = log.persisted_failure_count().max(1);
+            log.persist_failure_count(failures);
         }
+        Ok(log)
     }
 
     pub fn append(
         &self,
         draft: CoordinationEventDraft,
     ) -> std::io::Result<CoordinationEventEnvelope> {
+        if self.poisoned.load(Ordering::Acquire) {
+            return Err(std::io::Error::other(
+                "coordination event log is poisoned after a prior append failure",
+            ));
+        }
         let mut next = self
             .next_sequence
             .lock()
             .unwrap_or_else(std::sync::PoisonError::into_inner);
+        if self.poisoned.load(Ordering::Acquire) {
+            return Err(std::io::Error::other(
+                "coordination event log is poisoned after a prior append failure",
+            ));
+        }
         let build = kin_buildinfo::get();
+        let mut intent_ids = draft.intent_ids;
+        intent_ids.sort();
+        intent_ids.dedup();
+        let mut scopes = draft.scopes;
+        scopes.sort();
+        scopes.dedup();
+        let mut blocking_intent_ids = draft.blocking_intent_ids;
+        blocking_intent_ids.sort();
+        blocking_intent_ids.dedup();
         let envelope = CoordinationEventEnvelope {
             schema: "kin.coordination-event.v1".to_string(),
             sequence: *next,
@@ -205,11 +295,11 @@ impl CoordinationEventLog {
             repo_id: self.repo_id.clone(),
             session_id: draft.session_id,
             intent_id: draft.intent_id,
-            intent_ids: draft.intent_ids,
+            intent_ids,
             transaction_id: draft.transaction_id,
-            scopes: draft.scopes,
+            scopes,
             enforcement_mode: draft.enforcement_mode,
-            blocking_intent_ids: draft.blocking_intent_ids,
+            blocking_intent_ids,
             kin_version: kin_buildinfo::version().to_string(),
             kin_commit: build.sha.to_string(),
             kin_dirty: build.dirty,
@@ -219,14 +309,54 @@ impl CoordinationEventLog {
         if let Some(parent) = self.path.parent() {
             std::fs::create_dir_all(parent)?;
         }
+        let path_existed = self.path.exists();
+        let original_len = std::fs::metadata(&self.path).map_or(0, |metadata| metadata.len());
         let mut file = std::fs::OpenOptions::new()
             .create(true)
             .append(true)
             .open(&self.path)?;
-        file.write_all(&bytes)?;
-        file.sync_data()?;
+        let persist_result = (|| -> std::io::Result<()> {
+            file.write_all(&bytes)?;
+            file.sync_data()?;
+            if !path_existed {
+                if let Some(parent) = self.path.parent() {
+                    std::fs::File::open(parent)?.sync_all()?;
+                }
+            }
+            Ok(())
+        })();
+        if let Err(error) = persist_result {
+            self.poisoned.store(true, Ordering::Release);
+            let _ = file.set_len(original_len);
+            let _ = file.sync_data();
+            return Err(error);
+        }
         *next = next.saturating_add(1);
         Ok(envelope)
+    }
+
+    pub fn persisted_failure_count(&self) -> u64 {
+        std::fs::read_to_string(&self.failure_marker)
+            .ok()
+            .and_then(|value| value.trim().parse().ok())
+            .unwrap_or(0)
+    }
+
+    fn persist_failure_count(&self, count: u64) {
+        let temp = self.failure_marker.with_extension("failed.tmp");
+        let result = (|| -> std::io::Result<()> {
+            std::fs::write(&temp, format!("{count}\n"))?;
+            std::fs::File::open(&temp)?.sync_data()?;
+            std::fs::rename(&temp, &self.failure_marker)?;
+            if let Some(parent) = self.failure_marker.parent() {
+                std::fs::File::open(parent)?.sync_all()?;
+            }
+            Ok(())
+        })();
+        if let Err(error) = result {
+            warn!(error = %error, "failed to persist coordination event failure marker");
+            let _ = std::fs::remove_file(temp);
+        }
     }
 
     #[cfg(test)]
@@ -709,21 +839,31 @@ impl DaemonState {
     pub(crate) fn record_coordination_event(
         &self,
         draft: CoordinationEventDraft,
-    ) -> Option<CoordinationEventEnvelope> {
+    ) -> std::io::Result<CoordinationEventEnvelope> {
         match self.coordination_events.append(draft) {
             Ok(event) => {
                 self.emit_event(DaemonEvent::Coordination {
                     event: event.clone(),
                 });
-                Some(event)
+                Ok(event)
             }
             Err(error) => {
-                self.coordination_event_persist_failures
-                    .fetch_add(1, Ordering::Relaxed);
-                warn!(error = %error, "failed to persist coordination event; event not broadcast");
-                None
+                self.mark_coordination_evidence_incomplete(&error);
+                Err(error)
             }
         }
+    }
+
+    /// Permanently disqualify the current coordination evidence stream after
+    /// a reserved mutation cannot be paired with a trustworthy terminal event.
+    /// The marker survives daemon restart and is surfaced by `/health`.
+    pub(crate) fn mark_coordination_evidence_incomplete(&self, reason: impl std::fmt::Display) {
+        let count = self
+            .coordination_event_persist_failures
+            .fetch_add(1, Ordering::Relaxed)
+            .saturating_add(1);
+        self.coordination_events.persist_failure_count(count);
+        warn!(reason = %reason, "coordination evidence is incomplete; stream is not claim-eligible");
     }
 
     /// Load a persisted vector-index sidecar into a graph that was NOT built
@@ -900,7 +1040,8 @@ impl DaemonState {
         // from the on-disk snapshot. Read before `graph` is moved into the state.
         let loaded_entity_count = graph.entity_count();
 
-        let coordination_events = CoordinationEventLog::open(&layout, &cached_repo_id);
+        let coordination_events = CoordinationEventLog::open(&layout, &cached_repo_id)?;
+        let coordination_event_persist_failures = coordination_events.persisted_failure_count();
         let mut state = Self {
             layout,
             graph,
@@ -914,7 +1055,9 @@ impl DaemonState {
                 kin_mcp::CoordinationEnforcementMode::from_env(),
             ),
             coordination_events,
-            coordination_event_persist_failures: AtomicU64::new(0),
+            coordination_event_persist_failures: AtomicU64::new(
+                coordination_event_persist_failures,
+            ),
             started_at: Instant::now(),
             is_initialized: AtomicBool::new(loaded_snapshot),
             reconciliation_status: AtomicU8::new(RECON_IDLE),
@@ -1063,7 +1206,8 @@ impl DaemonState {
         // the backend snapshot).
         let loaded_entity_count = graph.entity_count();
 
-        let coordination_events = CoordinationEventLog::open(&layout, repo_id);
+        let coordination_events = CoordinationEventLog::open(&layout, repo_id)?;
+        let coordination_event_persist_failures = coordination_events.persisted_failure_count();
         let mut state = Self {
             layout,
             graph: Arc::clone(&graph),
@@ -1077,7 +1221,9 @@ impl DaemonState {
                 kin_mcp::CoordinationEnforcementMode::from_env(),
             ),
             coordination_events,
-            coordination_event_persist_failures: AtomicU64::new(0),
+            coordination_event_persist_failures: AtomicU64::new(
+                coordination_event_persist_failures,
+            ),
             started_at: Instant::now(),
             is_initialized: AtomicBool::new(loaded_snapshot),
             reconciliation_status: AtomicU8::new(RECON_IDLE),
@@ -3003,7 +3149,8 @@ mod tests {
         };
         let coordinator = SessionCoordinator::new(Arc::clone(&graph));
         let loaded_entity_count = graph.entity_count();
-        let coordination_events = CoordinationEventLog::open(&layout, "test-repo");
+        let coordination_events =
+            CoordinationEventLog::open(&layout, "test-repo").expect("open coordination log");
 
         DaemonState {
             layout,
@@ -3113,7 +3260,7 @@ mod tests {
         let dir = tempfile::tempdir().unwrap();
         let layout = KinLayout::new(dir.path().join(".kin"));
         std::fs::create_dir_all(layout.root()).unwrap();
-        let log = CoordinationEventLog::open(&layout, "test-repo");
+        let log = CoordinationEventLog::open(&layout, "test-repo").expect("open coordination log");
         let first = log
             .append(CoordinationEventDraft {
                 event: "intent_registration",
@@ -3130,7 +3277,8 @@ mod tests {
         assert_eq!(first.sequence, 1);
         assert_eq!(first.schema, "kin.coordination-event.v1");
 
-        let reopened = CoordinationEventLog::open(&layout, "test-repo");
+        let reopened =
+            CoordinationEventLog::open(&layout, "test-repo").expect("reopen coordination log");
         let second = reopened
             .append(CoordinationEventDraft {
                 event: "transaction_outcome",
@@ -3155,6 +3303,110 @@ mod tests {
         assert_eq!(records[1].repo_id, "test-repo");
         assert_eq!(records[1].transaction_id.as_deref(), Some("tx-1"));
         assert!(!records[1].kin_commit.is_empty());
+    }
+
+    #[test]
+    fn coordination_event_log_repairs_partial_tail_and_marks_stream_ineligible() {
+        let dir = tempfile::tempdir().unwrap();
+        let layout = KinLayout::new(dir.path().join(".kin"));
+        let log = CoordinationEventLog::open(&layout, "test-repo").unwrap();
+        log.append(CoordinationEventDraft {
+            event: "intent_registration",
+            outcome: "registered".to_string(),
+            session_id: Some("session-1".to_string()),
+            intent_id: Some("intent-1".to_string()),
+            intent_ids: vec!["intent-1".to_string()],
+            transaction_id: None,
+            scopes: vec!["entity:e1".to_string()],
+            enforcement_mode: "warn".to_string(),
+            blocking_intent_ids: Vec::new(),
+        })
+        .unwrap();
+        let mut file = std::fs::OpenOptions::new()
+            .append(true)
+            .open(log.path())
+            .unwrap();
+        file.write_all(b"{\"schema\":\"partial").unwrap();
+        file.sync_data().unwrap();
+        drop(file);
+
+        let reopened = CoordinationEventLog::open(&layout, "test-repo").unwrap();
+        assert_eq!(reopened.persisted_failure_count(), 1);
+        let next = reopened
+            .append(CoordinationEventDraft {
+                event: "transaction_outcome",
+                outcome: "committed".to_string(),
+                session_id: Some("session-1".to_string()),
+                intent_id: None,
+                intent_ids: Vec::new(),
+                transaction_id: Some("tx-1".to_string()),
+                scopes: vec!["entity:e1".to_string()],
+                enforcement_mode: "warn".to_string(),
+                blocking_intent_ids: Vec::new(),
+            })
+            .unwrap();
+        assert_eq!(next.sequence, 2);
+        let records = std::fs::read_to_string(reopened.path()).unwrap();
+        assert_eq!(records.lines().count(), 2);
+        assert!(records
+            .lines()
+            .all(|line| serde_json::from_str::<CoordinationEventEnvelope>(line).is_ok()));
+    }
+
+    #[test]
+    fn coordination_event_log_marks_unresolved_reservation_after_restart() {
+        let dir = tempfile::tempdir().unwrap();
+        let layout = KinLayout::new(dir.path().join(".kin"));
+        let log = CoordinationEventLog::open(&layout, "test-repo").unwrap();
+        log.append(CoordinationEventDraft {
+            event: "intent_release",
+            outcome: "pending:released".to_string(),
+            session_id: Some("session-1".to_string()),
+            intent_id: Some("intent-1".to_string()),
+            intent_ids: vec!["intent-1".to_string()],
+            transaction_id: None,
+            scopes: vec!["entity:e1".to_string()],
+            enforcement_mode: "enforce".to_string(),
+            blocking_intent_ids: Vec::new(),
+        })
+        .unwrap();
+        drop(log);
+
+        let reopened = CoordinationEventLog::open(&layout, "test-repo").unwrap();
+        assert_eq!(reopened.persisted_failure_count(), 1);
+    }
+
+    #[test]
+    fn coordination_event_log_rejects_duplicate_sequences() {
+        let dir = tempfile::tempdir().unwrap();
+        let layout = KinLayout::new(dir.path().join(".kin"));
+        let log = CoordinationEventLog::open(&layout, "test-repo").unwrap();
+        log.append(CoordinationEventDraft {
+            event: "transaction_outcome",
+            outcome: "committed".to_string(),
+            session_id: Some("session-1".to_string()),
+            intent_id: None,
+            intent_ids: Vec::new(),
+            transaction_id: Some("tx-1".to_string()),
+            scopes: vec!["entity:e1".to_string()],
+            enforcement_mode: "enforce".to_string(),
+            blocking_intent_ids: Vec::new(),
+        })
+        .unwrap();
+        let existing = std::fs::read(log.path()).unwrap();
+        let mut file = std::fs::OpenOptions::new()
+            .append(true)
+            .open(log.path())
+            .unwrap();
+        file.write_all(&existing).unwrap();
+        file.sync_data().unwrap();
+        drop(file);
+        drop(log);
+
+        let error = CoordinationEventLog::open(&layout, "test-repo")
+            .err()
+            .expect("duplicate sequence must fail closed");
+        assert_eq!(error.kind(), std::io::ErrorKind::InvalidData);
     }
 
     #[test]

--- a/crates/kin-daemon/src/write_veto.rs
+++ b/crates/kin-daemon/src/write_veto.rs
@@ -105,6 +105,16 @@ impl WriteVetoMode {
     }
 }
 
+impl From<kin_mcp::CoordinationEnforcementMode> for WriteVetoMode {
+    fn from(mode: kin_mcp::CoordinationEnforcementMode) -> Self {
+        match mode {
+            kin_mcp::CoordinationEnforcementMode::Off => Self::Off,
+            kin_mcp::CoordinationEnforcementMode::Warn => Self::Warn,
+            kin_mcp::CoordinationEnforcementMode::Enforce => Self::Enforce,
+        }
+    }
+}
+
 /// Outcome of [`evaluate_write_veto`].
 #[derive(Debug, Clone)]
 pub enum WriteVetoDecision {

--- a/crates/kin-daemon/src/write_veto.rs
+++ b/crates/kin-daemon/src/write_veto.rs
@@ -95,6 +95,14 @@ impl WriteVetoMode {
     pub fn evaluates(self) -> bool {
         !self.is_off()
     }
+
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::Off => "off",
+            Self::Warn => "warn",
+            Self::Enforce => "enforce",
+        }
+    }
 }
 
 /// Outcome of [`evaluate_write_veto`].

--- a/crates/kin-mcp/src/handlers/mod.rs
+++ b/crates/kin-mcp/src/handlers/mod.rs
@@ -1122,7 +1122,10 @@ mod tests {
             SessionTransport::Cli,
             None,
             PathBuf::from("/tmp"),
-            SessionCapabilities::default(),
+            SessionCapabilities {
+                can_write: true,
+                ..SessionCapabilities::default()
+            },
         );
         let session_id_str = session.session_id.to_string();
 

--- a/crates/kin-mcp/src/handlers/sessions.rs
+++ b/crates/kin-mcp/src/handlers/sessions.rs
@@ -299,7 +299,10 @@ pub async fn handle_register_intent(
         task_description,
         expires_at,
     ) {
-        crate::session::IntentRegistrationAttempt::Registered(intent) => {
+        crate::session::IntentRegistrationAttempt::Registered {
+            intent,
+            policy_warnings,
+        } => {
             let result = serde_json::json!({
                 "intent_id": intent.intent_id.to_string(),
                 "session_id": intent.session_id.to_string(),
@@ -308,6 +311,7 @@ pub async fn handle_register_intent(
                 "task_description": intent.task_description,
                 "registered_at": intent.registered_at,
                 "status": "registered",
+                "coordination_warnings": policy_warnings,
             });
             let json =
                 serde_json::to_string_pretty(&result).map_err(crate::error::McpError::Json)?;

--- a/crates/kin-mcp/src/handlers/sessions.rs
+++ b/crates/kin-mcp/src/handlers/sessions.rs
@@ -292,8 +292,14 @@ pub async fn handle_register_intent(
         }
     }
 
-    match sessions.register_intent(session_id, scopes, lock_type, task_description, expires_at) {
-        Some(intent) => {
+    match sessions.register_intent_checked(
+        session_id,
+        scopes,
+        lock_type,
+        task_description,
+        expires_at,
+    ) {
+        crate::session::IntentRegistrationAttempt::Registered(intent) => {
             let result = serde_json::json!({
                 "intent_id": intent.intent_id.to_string(),
                 "session_id": intent.session_id.to_string(),
@@ -307,10 +313,56 @@ pub async fn handle_register_intent(
                 serde_json::to_string_pretty(&result).map_err(crate::error::McpError::Json)?;
             Ok(ToolCallResult::text(json))
         }
-        None => Ok(ToolCallResult::error(format!(
-            "Session not found: {}. Start a session with kin_session_start first.",
-            id_str
-        ))),
+        crate::session::IntentRegistrationAttempt::Blocked {
+            intent_id,
+            conflicts,
+        } => {
+            let result = serde_json::json!({
+                "intent_id": intent_id.to_string(),
+                "session_id": session_id.to_string(),
+                "status": "blocked",
+                "conflicts": conflicts,
+            });
+            let json =
+                serde_json::to_string_pretty(&result).map_err(crate::error::McpError::Json)?;
+            Ok(ToolCallResult::text(json))
+        }
+        crate::session::IntentRegistrationAttempt::LimitExceeded {
+            intent_id,
+            active,
+            limit,
+        } => {
+            let result = serde_json::json!({
+                "intent_id": intent_id.to_string(),
+                "session_id": session_id.to_string(),
+                "status": "limit_exceeded",
+                "active_intents": active,
+                "max_concurrent_intents": limit,
+            });
+            let json =
+                serde_json::to_string_pretty(&result).map_err(crate::error::McpError::Json)?;
+            Ok(ToolCallResult::text(json))
+        }
+        crate::session::IntentRegistrationAttempt::CapabilityDenied {
+            intent_id,
+            capability,
+        } => {
+            let result = serde_json::json!({
+                "intent_id": intent_id.to_string(),
+                "session_id": session_id.to_string(),
+                "status": "capability_denied",
+                "required_capability": capability,
+            });
+            let json =
+                serde_json::to_string_pretty(&result).map_err(crate::error::McpError::Json)?;
+            Ok(ToolCallResult::text(json))
+        }
+        crate::session::IntentRegistrationAttempt::SessionNotFound => {
+            Ok(ToolCallResult::error(format!(
+                "Session not found: {}. Start a session with kin_session_start first.",
+                id_str
+            )))
+        }
     }
 }
 
@@ -448,6 +500,7 @@ pub async fn handle_transaction_begin(
         }
     }
 
+    let _coordination_apply = sessions.lock_coordination_apply();
     match sessions.begin_transaction(&session_id, &scope) {
         Ok(tx) => {
             let result = serde_json::json!({
@@ -505,6 +558,7 @@ pub async fn handle_transaction_stage(
         }
     }
 
+    let _coordination_apply = sessions.lock_coordination_apply();
     match sessions.stage_transaction(&transaction_id, operations) {
         Ok(tx) => {
             let result = serde_json::json!({
@@ -542,6 +596,7 @@ pub async fn handle_transaction_validate(
         }
     }
 
+    let _coordination_apply = sessions.lock_coordination_apply();
     match sessions.validate_transaction(&transaction_id) {
         Ok(tx) => {
             let result = serde_json::json!({
@@ -563,7 +618,62 @@ returns status, ops_applied (entity+relation deltas applied), empty (true for a 
 no-op commit), new_root_hash (graph Merkle root after the commit), modified_files \
 (working-directory files the projection wrote — entity-body edits reach disk here), \
 collision_warnings, and conflicts (entities skipped due to a concurrent file edit; a \
-non-empty set is surfaced as an error instead).";
+non-empty set is surfaced as an error instead). Before graph application, exact entity/artifact \
+intent conflicts and session write/commit capabilities are attested; enforce mode rejects \
+before graph truth changes. Contract-scope coverage remains explicitly false until touched \
+contracts can be derived from the semantic delta.";
+
+fn push_scope_once(scopes: &mut Vec<kin_model::IntentScope>, scope: kin_model::IntentScope) {
+    if !scopes.contains(&scope) {
+        scopes.push(scope);
+    }
+}
+
+/// Derive only the scopes the transaction payload can prove it touches. Entity
+/// ids and their old/new file origins are exact. Relation mutations cover both
+/// endpoint entities. Contract scopes are intentionally absent: the current
+/// delta carries no touched-contract derivation, so claiming them would be a
+/// false enforcement guarantee.
+fn transaction_touched_scopes<G: GraphStore>(
+    store: &G,
+    operations: &[McpMutationOperation],
+) -> Vec<kin_model::IntentScope> {
+    let mut scopes = Vec::new();
+    for operation in operations {
+        match operation.payload.as_ref() {
+            Some(McpMutationPayload::Entity(entity)) => {
+                push_scope_once(&mut scopes, kin_model::IntentScope::Entity(entity.id));
+                if let Some(file) = entity.file_origin.clone() {
+                    push_scope_once(&mut scopes, kin_model::IntentScope::Artifact(file));
+                }
+                let mut existing = store.get_entity(&entity.id).ok().flatten();
+                if existing.is_none() {
+                    let filter = kin_model::EntityFilter {
+                        name_pattern: Some(entity.name.clone()),
+                        kinds: Some(vec![entity.kind]),
+                        ..Default::default()
+                    };
+                    existing = store
+                        .query_entities(&filter)
+                        .ok()
+                        .and_then(|mut matches| matches.pop());
+                }
+                if let Some(existing) = existing {
+                    push_scope_once(&mut scopes, kin_model::IntentScope::Entity(existing.id));
+                    if let Some(file) = existing.file_origin {
+                        push_scope_once(&mut scopes, kin_model::IntentScope::Artifact(file));
+                    }
+                }
+            }
+            Some(McpMutationPayload::Relation { from, to, .. }) => {
+                push_scope_once(&mut scopes, kin_model::IntentScope::Entity(*from));
+                push_scope_once(&mut scopes, kin_model::IntentScope::Entity(*to));
+            }
+            Some(McpMutationPayload::Blob(_)) | None => {}
+        }
+    }
+    scopes
+}
 
 pub async fn handle_transaction_commit<G: GraphStore>(
     args: &HashMap<String, serde_json::Value>,
@@ -596,6 +706,11 @@ pub async fn handle_transaction_commit<G: GraphStore>(
             Err(err) => return Ok(ToolCallResult::error(err)),
         }
     }
+
+    // Serialize the entire local/offline transaction transition, final
+    // preflight, graph apply, and terminal state change with intent mutation
+    // and the other transaction lifecycle handlers.
+    let _coordination_apply = sessions.lock_coordination_apply();
 
     if let Some(ops) = inline_ops {
         match sessions.stage_transaction(&transaction_id, ops) {
@@ -634,6 +749,19 @@ pub async fn handle_transaction_commit<G: GraphStore>(
             transaction_id,
             uncommittable.len(),
             uncommittable.join("\n  - ")
+        )));
+    }
+
+    // Load-bearing ordering: run coordination enforcement against the fully
+    // staged operation set before constructing or applying any graph delta.
+    // A denied transaction remains active and graph truth is unchanged.
+    let touched_scopes = transaction_touched_scopes(store, &tx.staged_operations);
+    let coordination = sessions.evaluate_transaction_write(&tx.session_id, touched_scopes);
+    if !coordination.allowed {
+        let evidence =
+            serde_json::to_string(&coordination).map_err(crate::error::McpError::Json)?;
+        return Ok(ToolCallResult::error(format!(
+            "coordination enforcement rejected transaction {transaction_id} before graph apply: {evidence}"
         )));
     }
 
@@ -773,6 +901,7 @@ pub async fn handle_transaction_commit<G: GraphStore>(
         "status": "committed",
         "ops_applied": ops_applied,
         "empty": ops_applied == 0,
+        "coordination": coordination,
     });
     let json = serde_json::to_string_pretty(&result).map_err(crate::error::McpError::Json)?;
     Ok(ToolCallResult::text(json))
@@ -799,6 +928,7 @@ pub async fn handle_transaction_abort(
         }
     }
 
+    let _coordination_apply = sessions.lock_coordination_apply();
     match sessions.abort_transaction(&transaction_id) {
         Ok(tx) => {
             let result = serde_json::json!({

--- a/crates/kin-mcp/src/lib.rs
+++ b/crates/kin-mcp/src/lib.rs
@@ -22,7 +22,9 @@ pub use server::{
     RepoBinder, SessionAuthorityMode,
 };
 pub use session::{
-    AssistantSession, McpMutationOperation, McpMutationPayload, McpTransaction, SessionRegistry,
+    AssistantSession, CoordinationEnforcementMode, CoordinationSurfaceCoverage,
+    CoordinationWritePreflight, IntentRegistrationAttempt, McpMutationOperation,
+    McpMutationPayload, McpTransaction, SessionRegistry,
 };
 pub use tools::{
     agent_default_tool_names, benchmark_tool_names, context_bench_tool_names, tool_definitions,

--- a/crates/kin-mcp/src/session.rs
+++ b/crates/kin-mcp/src/session.rs
@@ -60,6 +60,105 @@ pub struct McpTransaction {
     pub staged_operations: Vec<McpMutationOperation>,
 }
 
+/// Linearized outcome of an in-process intent registration attempt.
+#[derive(Debug, Clone)]
+pub enum IntentRegistrationAttempt {
+    Registered(Intent),
+    Blocked {
+        intent_id: IntentId,
+        conflicts: Vec<IntentSummary>,
+    },
+    LimitExceeded {
+        intent_id: IntentId,
+        active: usize,
+        limit: usize,
+    },
+    CapabilityDenied {
+        intent_id: IntentId,
+        capability: &'static str,
+    },
+    SessionNotFound,
+}
+
+/// Effective coordination enforcement mode shared by transaction preflight
+/// and proof/build attestation. Warn remains the default; only explicit
+/// `enforce` may reject a write.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum CoordinationEnforcementMode {
+    Off,
+    Warn,
+    Enforce,
+}
+
+impl CoordinationEnforcementMode {
+    pub fn from_env() -> Self {
+        Self::parse(std::env::var("KIN_WRITE_VETO").ok().as_deref())
+    }
+
+    pub fn parse(raw: Option<&str>) -> Self {
+        match raw.map(str::trim) {
+            Some(value) if value.eq_ignore_ascii_case("enforce") => Self::Enforce,
+            Some(value) if value.eq_ignore_ascii_case("off") => Self::Off,
+            _ => Self::Warn,
+        }
+    }
+
+    pub fn is_enforcing(self) -> bool {
+        matches!(self, Self::Enforce)
+    }
+
+    pub fn evaluates(self) -> bool {
+        !matches!(self, Self::Off)
+    }
+
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::Off => "off",
+            Self::Warn => "warn",
+            Self::Enforce => "enforce",
+        }
+    }
+}
+
+/// Honest surface attestation for MCP transaction coordination. Contract
+/// scopes stay explicitly ineligible until a transaction can derive a touched
+/// contract from the actual semantic delta.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct CoordinationSurfaceCoverage {
+    pub entity_scopes: bool,
+    pub artifact_scopes_from_entity_origin: bool,
+    pub relation_endpoint_entities: bool,
+    pub contract_scopes: bool,
+    pub direct_filesystem_writes: bool,
+}
+
+impl Default for CoordinationSurfaceCoverage {
+    fn default() -> Self {
+        Self {
+            entity_scopes: true,
+            artifact_scopes_from_entity_origin: true,
+            relation_endpoint_entities: true,
+            contract_scopes: false,
+            direct_filesystem_writes: false,
+        }
+    }
+}
+
+/// Result of checking a transaction immediately before graph application.
+#[derive(Debug, Clone, Serialize)]
+pub struct CoordinationWritePreflight {
+    pub schema: &'static str,
+    pub mode: CoordinationEnforcementMode,
+    pub evaluated: bool,
+    pub allowed: bool,
+    pub session_id: String,
+    pub touched_scopes: Vec<IntentScope>,
+    pub blocking_intents: Vec<IntentSummary>,
+    pub capability_violations: Vec<String>,
+    pub coverage: CoordinationSurfaceCoverage,
+}
+
 /// The mutation verbs the transaction commit path understands, listed for
 /// actionable error messages.
 const KNOWN_MUTATION_VERBS: &str = "create/add/upsert/insert, update/modify, or delete/remove";
@@ -201,6 +300,15 @@ pub struct SessionRegistry {
     intents: Mutex<HashMap<IntentId, Intent>>,
     /// Active transactions keyed by TransactionId.
     transactions: Mutex<HashMap<String, McpTransaction>>,
+    /// Linearization point for rich-session and intent lifecycle mutations.
+    /// The maps stay separate for low-impact compatibility, but registration's
+    /// session lookup + concurrency check + conflict check + insert is one
+    /// indivisible coordinator operation under this gate.
+    intent_registration_gate: Mutex<()>,
+    /// Daemon-owned mode snapshot. `None` keeps standalone/offline MCP behavior
+    /// environment-driven; the daemon sets this explicitly so a request cannot
+    /// observe a process-global env change mid-run.
+    coordination_mode: Mutex<Option<CoordinationEnforcementMode>>,
 }
 
 impl SessionRegistry {
@@ -210,6 +318,8 @@ impl SessionRegistry {
             agent_sessions: Mutex::new(HashMap::new()),
             intents: Mutex::new(HashMap::new()),
             transactions: Mutex::new(HashMap::new()),
+            intent_registration_gate: Mutex::new(()),
+            coordination_mode: Mutex::new(None),
         }
     }
 
@@ -274,6 +384,10 @@ impl SessionRegistry {
         cwd: PathBuf,
         capabilities: SessionCapabilities,
     ) -> AgentSession {
+        let _gate = self
+            .intent_registration_gate
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
         let now = Timestamp::now();
         let session = AgentSession {
             session_id: SessionId::new(),
@@ -310,6 +424,10 @@ impl SessionRegistry {
 
     /// End an agent session and release all its intents.
     pub fn end_agent_session(&self, session_id: &SessionId) -> Option<AgentSession> {
+        let _gate = self
+            .intent_registration_gate
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
         let session = self
             .agent_sessions
             .lock()
@@ -354,6 +472,10 @@ impl SessionRegistry {
         agent_sessions: Vec<AgentSession>,
         intents: Vec<Intent>,
     ) {
+        let _gate = self
+            .intent_registration_gate
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
         let mut sessions_map = self
             .agent_sessions
             .lock()
@@ -373,7 +495,22 @@ impl SessionRegistry {
 
     // ── Intent API ──
 
-    /// Register a new intent. Returns the created Intent.
+    pub fn set_coordination_mode(&self, mode: CoordinationEnforcementMode) {
+        *self
+            .coordination_mode
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner) = Some(mode);
+    }
+
+    pub(crate) fn lock_coordination_apply(&self) -> std::sync::MutexGuard<'_, ()> {
+        self.intent_registration_gate
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner)
+    }
+
+    /// Backward-compatible registration API. Callers that need to distinguish
+    /// conflict, capability, and concurrency-limit rejection should use
+    /// [`Self::register_intent_checked`].
     pub fn register_intent(
         &self,
         session_id: SessionId,
@@ -382,15 +519,42 @@ impl SessionRegistry {
         task_description: String,
         expires_at: Option<Timestamp>,
     ) -> Option<Intent> {
-        // Verify session exists.
-        let sessions = self
+        match self.register_intent_checked(
+            session_id,
+            scopes,
+            lock_type,
+            task_description,
+            expires_at,
+        ) {
+            IntentRegistrationAttempt::Registered(intent) => Some(intent),
+            _ => None,
+        }
+    }
+
+    /// Register a new intent as one linearized arbitration operation and
+    /// preserve the exact rejection reason.
+    pub fn register_intent_checked(
+        &self,
+        session_id: SessionId,
+        scopes: Vec<IntentScope>,
+        lock_type: LockType,
+        task_description: String,
+        expires_at: Option<Timestamp>,
+    ) -> IntentRegistrationAttempt {
+        let _gate = self
+            .intent_registration_gate
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
+
+        let session = self
             .agent_sessions
             .lock()
-            .expect("agent_sessions lock poisoned");
-        if !sessions.contains_key(&session_id) {
-            return None;
-        }
-        drop(sessions);
+            .unwrap_or_else(std::sync::PoisonError::into_inner)
+            .get(&session_id)
+            .cloned();
+        let Some(session) = session else {
+            return IntentRegistrationAttempt::SessionNotFound;
+        };
 
         let now = Timestamp::now();
         let intent = Intent {
@@ -403,15 +567,76 @@ impl SessionRegistry {
             expires_at,
         };
         let id = intent.intent_id;
-        self.intents
+        let mut intents = self
+            .intents
             .lock()
-            .expect("intents lock poisoned")
-            .insert(id, intent.clone());
-        Some(intent)
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
+
+        if lock_type == LockType::Hard && !session.capabilities.can_write {
+            return IntentRegistrationAttempt::CapabilityDenied {
+                intent_id: id,
+                capability: "can_write",
+            };
+        }
+
+        let active = intents
+            .values()
+            .filter(|active| active.session_id == session_id)
+            .count();
+        let limit = session.capabilities.max_concurrent_intents;
+        if active >= limit {
+            return IntentRegistrationAttempt::LimitExceeded {
+                intent_id: id,
+                active,
+                limit,
+            };
+        }
+
+        if lock_type == LockType::Hard {
+            let sessions = self
+                .agent_sessions
+                .lock()
+                .unwrap_or_else(std::sync::PoisonError::into_inner);
+            let conflicts: Vec<IntentSummary> = intents
+                .values()
+                .filter(|active| {
+                    active.session_id != session_id
+                        && active.lock_type == LockType::Hard
+                        && active
+                            .scopes
+                            .iter()
+                            .any(|scope| intent.scopes.contains(scope))
+                })
+                .map(|active| IntentSummary {
+                    intent_id: active.intent_id,
+                    session_id: active.session_id,
+                    vendor: sessions
+                        .get(&active.session_id)
+                        .map(|owner| owner.vendor.clone())
+                        .unwrap_or_else(|| "unknown".to_string()),
+                    task_description: active.task_description.clone(),
+                    lock_type: active.lock_type,
+                    registered_at: active.registered_at.clone(),
+                })
+                .collect();
+            if !conflicts.is_empty() {
+                return IntentRegistrationAttempt::Blocked {
+                    intent_id: id,
+                    conflicts,
+                };
+            }
+        }
+
+        intents.insert(id, intent.clone());
+        IntentRegistrationAttempt::Registered(intent)
     }
 
     /// Release a specific intent. Returns it if it existed.
     pub fn release_intent(&self, session_id: &SessionId, intent_id: &IntentId) -> Option<Intent> {
+        let _gate = self
+            .intent_registration_gate
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
         let mut intents = self.intents.lock().expect("intents lock poisoned");
         if let Some(intent) = intents.get(intent_id) {
             if intent.session_id == *session_id {
@@ -430,6 +655,105 @@ impl SessionRegistry {
             .filter(|i| i.session_id == *session_id)
             .cloned()
             .collect()
+    }
+
+    /// Evaluate exact-scope intent conflicts and declared write capabilities
+    /// immediately before a transaction delta is applied. In enforce mode an
+    /// unknown/non-rich session fails closed; warn mode records the same
+    /// violations while preserving the historical proceed behavior.
+    pub fn evaluate_transaction_write(
+        &self,
+        session_id: &str,
+        touched_scopes: Vec<IntentScope>,
+    ) -> CoordinationWritePreflight {
+        let mode = self
+            .coordination_mode
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner)
+            .unwrap_or_else(CoordinationEnforcementMode::from_env);
+        self.evaluate_transaction_write_with_mode(session_id, touched_scopes, mode)
+    }
+
+    pub fn evaluate_transaction_write_with_mode(
+        &self,
+        session_id: &str,
+        touched_scopes: Vec<IntentScope>,
+        mode: CoordinationEnforcementMode,
+    ) -> CoordinationWritePreflight {
+        if !mode.evaluates() {
+            return CoordinationWritePreflight {
+                schema: "kin.coordination-preflight.v1",
+                mode,
+                evaluated: false,
+                allowed: true,
+                session_id: session_id.to_string(),
+                touched_scopes,
+                blocking_intents: Vec::new(),
+                capability_violations: Vec::new(),
+                coverage: CoordinationSurfaceCoverage::default(),
+            };
+        }
+
+        let parsed_session = uuid::Uuid::parse_str(session_id).ok().map(SessionId);
+        let session = parsed_session.and_then(|id| self.get_agent_session(&id));
+        let mut capability_violations = Vec::new();
+
+        match session.as_ref() {
+            Some(session) => {
+                if !session.capabilities.can_write {
+                    capability_violations.push("can_write=false".to_string());
+                }
+                if !session.capabilities.can_commit {
+                    capability_violations.push("can_commit=false".to_string());
+                }
+            }
+            None => capability_violations
+                .push("transaction session is not an active rich agent session".to_string()),
+        }
+
+        let intents = self
+            .intents
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
+        let sessions = self
+            .agent_sessions
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
+        let blocking_intents: Vec<IntentSummary> = intents
+            .values()
+            .filter(|intent| {
+                Some(intent.session_id) != parsed_session
+                    && intent.lock_type == LockType::Hard
+                    && intent
+                        .scopes
+                        .iter()
+                        .any(|scope| touched_scopes.contains(scope))
+            })
+            .map(|intent| IntentSummary {
+                intent_id: intent.intent_id,
+                session_id: intent.session_id,
+                vendor: sessions
+                    .get(&intent.session_id)
+                    .map(|owner| owner.vendor.clone())
+                    .unwrap_or_else(|| "unknown".to_string()),
+                task_description: intent.task_description.clone(),
+                lock_type: intent.lock_type,
+                registered_at: intent.registered_at.clone(),
+            })
+            .collect();
+
+        let violates_policy = !blocking_intents.is_empty() || !capability_violations.is_empty();
+        CoordinationWritePreflight {
+            schema: "kin.coordination-preflight.v1",
+            mode,
+            evaluated: true,
+            allowed: !mode.is_enforcing() || !violates_policy,
+            session_id: session_id.to_string(),
+            touched_scopes,
+            blocking_intents,
+            capability_violations,
+            coverage: CoordinationSurfaceCoverage::default(),
+        }
     }
 
     /// Check traffic for the given scopes. Returns a TrafficReport per scope.
@@ -746,15 +1070,16 @@ mod tests {
             SessionCapabilities::default(),
         );
 
-        let intent = registry
-            .register_intent(
-                session.session_id,
-                vec![IntentScope::Entity(EntityId::new())],
-                LockType::Soft,
-                "testing".into(),
-                None,
-            )
-            .unwrap();
+        let intent = match registry.register_intent_checked(
+            session.session_id,
+            vec![IntentScope::Entity(EntityId::new())],
+            LockType::Soft,
+            "testing".into(),
+            None,
+        ) {
+            IntentRegistrationAttempt::Registered(intent) => intent,
+            other => panic!("expected registered intent, got {other:?}"),
+        };
 
         assert_eq!(
             registry.list_intents_for_session(&session.session_id).len(),
@@ -809,14 +1134,182 @@ mod tests {
         let registry = SessionRegistry::new();
         let fake_session = SessionId::new();
 
-        let result = registry.register_intent(
+        let result = registry.register_intent_checked(
             fake_session,
             vec![IntentScope::Entity(EntityId::new())],
             LockType::Soft,
             "test".into(),
             None,
         );
-        assert!(result.is_none());
+        assert!(matches!(result, IntentRegistrationAttempt::SessionNotFound));
+    }
+
+    #[test]
+    fn intent_registration_enforces_limit_and_foreign_hard_conflict() {
+        let registry = SessionRegistry::new();
+        let capabilities = SessionCapabilities {
+            can_write: true,
+            can_commit: true,
+            max_concurrent_intents: 1,
+            ..SessionCapabilities::default()
+        };
+        let first = registry.start_agent_session(
+            "codex",
+            "first",
+            SessionTransport::Mcp,
+            None,
+            PathBuf::from("/tmp"),
+            capabilities.clone(),
+        );
+        let second = registry.start_agent_session(
+            "claude-code",
+            "second",
+            SessionTransport::Mcp,
+            None,
+            PathBuf::from("/tmp"),
+            capabilities,
+        );
+        let entity = EntityId::new();
+
+        let registered = registry.register_intent_checked(
+            first.session_id,
+            vec![IntentScope::Entity(entity)],
+            LockType::Hard,
+            "first write".into(),
+            None,
+        );
+        assert!(matches!(
+            registered,
+            IntentRegistrationAttempt::Registered(_)
+        ));
+
+        let limited = registry.register_intent_checked(
+            first.session_id,
+            vec![IntentScope::Entity(EntityId::new())],
+            LockType::Hard,
+            "second write".into(),
+            None,
+        );
+        assert!(matches!(
+            limited,
+            IntentRegistrationAttempt::LimitExceeded {
+                active: 1,
+                limit: 1,
+                ..
+            }
+        ));
+
+        let blocked = registry.register_intent_checked(
+            second.session_id,
+            vec![IntentScope::Entity(entity)],
+            LockType::Hard,
+            "conflicting write".into(),
+            None,
+        );
+        assert!(matches!(blocked, IntentRegistrationAttempt::Blocked { .. }));
+    }
+
+    #[test]
+    fn hard_intent_requires_declared_write_capability() {
+        let registry = SessionRegistry::new();
+        let session = registry.start_agent_session(
+            "read-only-agent",
+            "reader",
+            SessionTransport::Mcp,
+            None,
+            PathBuf::from("/tmp"),
+            SessionCapabilities::default(),
+        );
+        let result = registry.register_intent_checked(
+            session.session_id,
+            vec![IntentScope::Entity(EntityId::new())],
+            LockType::Hard,
+            "must not block writers".into(),
+            None,
+        );
+        assert!(matches!(
+            result,
+            IntentRegistrationAttempt::CapabilityDenied {
+                capability: "can_write",
+                ..
+            }
+        ));
+        assert!(registry
+            .list_intents_for_session(&session.session_id)
+            .is_empty());
+    }
+
+    #[test]
+    fn transaction_preflight_enforce_fails_closed_before_apply() {
+        let registry = SessionRegistry::new();
+        let capabilities = SessionCapabilities {
+            can_write: true,
+            can_commit: true,
+            ..SessionCapabilities::default()
+        };
+        let owner = registry.start_agent_session(
+            "claude-code",
+            "owner",
+            SessionTransport::Mcp,
+            None,
+            PathBuf::from("/tmp"),
+            capabilities.clone(),
+        );
+        let caller = registry.start_agent_session(
+            "codex",
+            "caller",
+            SessionTransport::Mcp,
+            None,
+            PathBuf::from("/tmp"),
+            capabilities,
+        );
+        let entity = EntityId::new();
+        assert!(matches!(
+            registry.register_intent_checked(
+                owner.session_id,
+                vec![IntentScope::Entity(entity)],
+                LockType::Hard,
+                "owner write".into(),
+                None,
+            ),
+            IntentRegistrationAttempt::Registered(_)
+        ));
+
+        let denied = registry.evaluate_transaction_write_with_mode(
+            &caller.session_id.to_string(),
+            vec![IntentScope::Entity(entity)],
+            CoordinationEnforcementMode::Enforce,
+        );
+        assert!(!denied.allowed);
+        assert_eq!(denied.blocking_intents.len(), 1);
+        assert!(denied.capability_violations.is_empty());
+        assert!(!denied.coverage.contract_scopes);
+
+        let warned = registry.evaluate_transaction_write_with_mode(
+            &caller.session_id.to_string(),
+            vec![IntentScope::Entity(entity)],
+            CoordinationEnforcementMode::Warn,
+        );
+        assert!(warned.allowed);
+        assert_eq!(warned.blocking_intents.len(), 1);
+
+        let off = registry.evaluate_transaction_write_with_mode(
+            "legacy-session",
+            vec![IntentScope::Entity(entity)],
+            CoordinationEnforcementMode::Off,
+        );
+        assert!(off.allowed);
+        assert!(!off.evaluated);
+        assert!(off.blocking_intents.is_empty());
+        assert!(off.capability_violations.is_empty());
+
+        let unknown = registry.evaluate_transaction_write_with_mode(
+            "legacy-session",
+            vec![IntentScope::Entity(EntityId::new())],
+            CoordinationEnforcementMode::Enforce,
+        );
+        assert!(!unknown.allowed);
+        assert!(!unknown.capability_violations.is_empty());
     }
 
     #[test]
@@ -828,18 +1321,22 @@ mod tests {
             SessionTransport::Mcp,
             None,
             PathBuf::from("/tmp"),
-            SessionCapabilities::default(),
+            SessionCapabilities {
+                can_write: true,
+                ..SessionCapabilities::default()
+            },
         );
 
-        let intent = registry
-            .register_intent(
-                session.session_id,
-                vec![IntentScope::Entity(EntityId::new())],
-                LockType::Hard,
-                "editing".into(),
-                None,
-            )
-            .unwrap();
+        let intent = match registry.register_intent_checked(
+            session.session_id,
+            vec![IntentScope::Entity(EntityId::new())],
+            LockType::Hard,
+            "editing".into(),
+            None,
+        ) {
+            IntentRegistrationAttempt::Registered(intent) => intent,
+            other => panic!("expected registered intent, got {other:?}"),
+        };
 
         // Wrong session cannot release.
         let other_session = SessionId::new();
@@ -894,7 +1391,10 @@ mod tests {
             SessionTransport::Mcp,
             None,
             PathBuf::from("/tmp"),
-            SessionCapabilities::default(),
+            SessionCapabilities {
+                can_write: true,
+                ..SessionCapabilities::default()
+            },
         );
 
         let entity_id = EntityId::new();

--- a/crates/kin-mcp/src/session.rs
+++ b/crates/kin-mcp/src/session.rs
@@ -63,7 +63,10 @@ pub struct McpTransaction {
 /// Linearized outcome of an in-process intent registration attempt.
 #[derive(Debug, Clone)]
 pub enum IntentRegistrationAttempt {
-    Registered(Intent),
+    Registered {
+        intent: Intent,
+        policy_warnings: Vec<String>,
+    },
     Blocked {
         intent_id: IntentId,
         conflicts: Vec<IntentSummary>,
@@ -526,7 +529,7 @@ impl SessionRegistry {
             task_description,
             expires_at,
         ) {
-            IntentRegistrationAttempt::Registered(intent) => Some(intent),
+            IntentRegistrationAttempt::Registered { intent, .. } => Some(intent),
             _ => None,
         }
     }
@@ -572,24 +575,53 @@ impl SessionRegistry {
             .lock()
             .unwrap_or_else(std::sync::PoisonError::into_inner);
 
+        let mode = self
+            .coordination_mode
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner)
+            .unwrap_or_else(CoordinationEnforcementMode::from_env);
+        let mut policy_warnings = Vec::new();
+
         if lock_type == LockType::Hard && !session.capabilities.can_write {
-            return IntentRegistrationAttempt::CapabilityDenied {
-                intent_id: id,
-                capability: "can_write",
-            };
+            if mode.is_enforcing() {
+                return IntentRegistrationAttempt::CapabilityDenied {
+                    intent_id: id,
+                    capability: "can_write",
+                };
+            }
+            if mode.evaluates() {
+                policy_warnings.push(
+                    "hard intent requires can_write=true; registration would be denied in enforce mode"
+                        .to_string(),
+                );
+            }
         }
 
+        let now = Timestamp::now();
         let active = intents
             .values()
-            .filter(|active| active.session_id == session_id)
+            .filter(|active| {
+                active.session_id == session_id
+                    && active
+                        .expires_at
+                        .as_ref()
+                        .is_none_or(|expires_at| expires_at >= &now)
+            })
             .count();
         let limit = session.capabilities.max_concurrent_intents;
         if active >= limit {
-            return IntentRegistrationAttempt::LimitExceeded {
-                intent_id: id,
-                active,
-                limit,
-            };
+            if mode.is_enforcing() {
+                return IntentRegistrationAttempt::LimitExceeded {
+                    intent_id: id,
+                    active,
+                    limit,
+                };
+            }
+            if mode.evaluates() {
+                policy_warnings.push(format!(
+                    "active intent count {active} reached max_concurrent_intents={limit}; registration would be denied in enforce mode"
+                ));
+            }
         }
 
         if lock_type == LockType::Hard {
@@ -597,10 +629,14 @@ impl SessionRegistry {
                 .agent_sessions
                 .lock()
                 .unwrap_or_else(std::sync::PoisonError::into_inner);
-            let conflicts: Vec<IntentSummary> = intents
+            let mut conflicts: Vec<IntentSummary> = intents
                 .values()
                 .filter(|active| {
-                    active.session_id != session_id
+                    active
+                        .expires_at
+                        .as_ref()
+                        .is_none_or(|expires_at| expires_at >= &now)
+                        && active.session_id != session_id
                         && active.lock_type == LockType::Hard
                         && active
                             .scopes
@@ -619,6 +655,7 @@ impl SessionRegistry {
                     registered_at: active.registered_at.clone(),
                 })
                 .collect();
+            conflicts.sort_by_key(|conflict| conflict.intent_id.to_string());
             if !conflicts.is_empty() {
                 return IntentRegistrationAttempt::Blocked {
                     intent_id: id,
@@ -628,7 +665,10 @@ impl SessionRegistry {
         }
 
         intents.insert(id, intent.clone());
-        IntentRegistrationAttempt::Registered(intent)
+        IntentRegistrationAttempt::Registered {
+            intent,
+            policy_warnings,
+        }
     }
 
     /// Release a specific intent. Returns it if it existed.
@@ -646,15 +686,18 @@ impl SessionRegistry {
         None
     }
 
-    /// List all intents for a given session.
+    /// List all intents for a given session in deterministic ID order.
     pub fn list_intents_for_session(&self, session_id: &SessionId) -> Vec<Intent> {
-        self.intents
+        let mut intents: Vec<_> = self
+            .intents
             .lock()
             .expect("intents lock poisoned")
             .values()
             .filter(|i| i.session_id == *session_id)
             .cloned()
-            .collect()
+            .collect();
+        intents.sort_by_key(|intent| intent.intent_id.to_string());
+        intents
     }
 
     /// Evaluate exact-scope intent conflicts and declared write capabilities
@@ -719,10 +762,15 @@ impl SessionRegistry {
             .agent_sessions
             .lock()
             .unwrap_or_else(std::sync::PoisonError::into_inner);
-        let blocking_intents: Vec<IntentSummary> = intents
+        let now = Timestamp::now();
+        let mut blocking_intents: Vec<IntentSummary> = intents
             .values()
             .filter(|intent| {
-                Some(intent.session_id) != parsed_session
+                intent
+                    .expires_at
+                    .as_ref()
+                    .is_none_or(|expires_at| expires_at >= &now)
+                    && Some(intent.session_id) != parsed_session
                     && intent.lock_type == LockType::Hard
                     && intent
                         .scopes
@@ -741,6 +789,7 @@ impl SessionRegistry {
                 registered_at: intent.registered_at.clone(),
             })
             .collect();
+        blocking_intents.sort_by_key(|intent| intent.intent_id.to_string());
 
         let violates_policy = !blocking_intents.is_empty() || !capability_violations.is_empty();
         CoordinationWritePreflight {
@@ -1077,7 +1126,7 @@ mod tests {
             "testing".into(),
             None,
         ) {
-            IntentRegistrationAttempt::Registered(intent) => intent,
+            IntentRegistrationAttempt::Registered { intent, .. } => intent,
             other => panic!("expected registered intent, got {other:?}"),
         };
 
@@ -1147,6 +1196,7 @@ mod tests {
     #[test]
     fn intent_registration_enforces_limit_and_foreign_hard_conflict() {
         let registry = SessionRegistry::new();
+        registry.set_coordination_mode(CoordinationEnforcementMode::Enforce);
         let capabilities = SessionCapabilities {
             can_write: true,
             can_commit: true,
@@ -1180,7 +1230,7 @@ mod tests {
         );
         assert!(matches!(
             registered,
-            IntentRegistrationAttempt::Registered(_)
+            IntentRegistrationAttempt::Registered { .. }
         ));
 
         let limited = registry.register_intent_checked(
@@ -1212,6 +1262,7 @@ mod tests {
     #[test]
     fn hard_intent_requires_declared_write_capability() {
         let registry = SessionRegistry::new();
+        registry.set_coordination_mode(CoordinationEnforcementMode::Enforce);
         let session = registry.start_agent_session(
             "read-only-agent",
             "reader",
@@ -1237,6 +1288,51 @@ mod tests {
         assert!(registry
             .list_intents_for_session(&session.session_id)
             .is_empty());
+    }
+
+    #[test]
+    fn warn_and_off_modes_preserve_registration_compatibility() {
+        let registry = SessionRegistry::new();
+        let session = registry.start_agent_session(
+            "read-only-agent",
+            "reader",
+            SessionTransport::Mcp,
+            None,
+            PathBuf::from("/tmp"),
+            SessionCapabilities::default(),
+        );
+
+        registry.set_coordination_mode(CoordinationEnforcementMode::Warn);
+        let warned = registry.register_intent_checked(
+            session.session_id,
+            vec![IntentScope::Entity(EntityId::new())],
+            LockType::Hard,
+            "warn compatibility".into(),
+            None,
+        );
+        match warned {
+            IntentRegistrationAttempt::Registered {
+                policy_warnings, ..
+            } => assert!(policy_warnings
+                .iter()
+                .any(|warning| warning.contains("can_write"))),
+            other => panic!("warn mode should register with evidence, got {other:?}"),
+        }
+
+        registry.set_coordination_mode(CoordinationEnforcementMode::Off);
+        let off = registry.register_intent_checked(
+            session.session_id,
+            vec![IntentScope::Entity(EntityId::new())],
+            LockType::Hard,
+            "off compatibility".into(),
+            None,
+        );
+        match off {
+            IntentRegistrationAttempt::Registered {
+                policy_warnings, ..
+            } => assert!(policy_warnings.is_empty()),
+            other => panic!("off mode should register without evaluation, got {other:?}"),
+        }
     }
 
     #[test]
@@ -1272,7 +1368,7 @@ mod tests {
                 "owner write".into(),
                 None,
             ),
-            IntentRegistrationAttempt::Registered(_)
+            IntentRegistrationAttempt::Registered { .. }
         ));
 
         let denied = registry.evaluate_transaction_write_with_mode(
@@ -1334,7 +1430,7 @@ mod tests {
             "editing".into(),
             None,
         ) {
-            IntentRegistrationAttempt::Registered(intent) => intent,
+            IntentRegistrationAttempt::Registered { intent, .. } => intent,
             other => panic!("expected registered intent, got {other:?}"),
         };
 

--- a/crates/kin-mcp/src/tools.rs
+++ b/crates/kin-mcp/src/tools.rs
@@ -479,6 +479,7 @@ pub fn tool_definitions() -> ToolsListResult {
                     "type": "object",
                     "properties": {
                         "transaction_id": { "type": "string", "description": "Transaction UUID" },
+                        "session_id": { "type": "string", "description": "Optional owning session UUID mirror; when present in enforce mode it must match the authenticated caller and transaction owner" },
                         "operations": {
                             "type": "array",
                             "description": "Array of mutation operations to stage",
@@ -510,7 +511,8 @@ pub fn tool_definitions() -> ToolsListResult {
                 input_schema: serde_json::json!({
                     "type": "object",
                     "properties": {
-                        "transaction_id": { "type": "string", "description": "Transaction UUID" }
+                        "transaction_id": { "type": "string", "description": "Transaction UUID" },
+                        "session_id": { "type": "string", "description": "Optional owning session UUID mirror; when present in enforce mode it must match the authenticated caller and transaction owner" }
                     },
                     "required": ["transaction_id"]
                 }),
@@ -522,6 +524,7 @@ pub fn tool_definitions() -> ToolsListResult {
                     "type": "object",
                     "properties": {
                         "transaction_id": { "type": "string", "description": "Transaction UUID" },
+                        "session_id": { "type": "string", "description": "Optional owning session UUID mirror; when present in enforce mode it must match the authenticated caller and transaction owner" },
                         "operations": {
                             "type": "array",
                             "description": "Optional array of mutation operations to stage immediately before committing (solves stage+commit HTTP persistence gaps)",
@@ -553,7 +556,8 @@ pub fn tool_definitions() -> ToolsListResult {
                 input_schema: serde_json::json!({
                     "type": "object",
                     "properties": {
-                        "transaction_id": { "type": "string", "description": "Transaction UUID" }
+                        "transaction_id": { "type": "string", "description": "Transaction UUID" },
+                        "session_id": { "type": "string", "description": "Optional owning session UUID mirror; when present in enforce mode it must match the authenticated caller and transaction owner" }
                     },
                     "required": ["transaction_id"]
                 }),

--- a/tests/integration/src/concurrency_enforcement.rs
+++ b/tests/integration/src/concurrency_enforcement.rs
@@ -12,6 +12,7 @@
 
 use std::path::PathBuf;
 
+use kin_daemon::session_registry::IntentRegistrationResult;
 use kin_daemon::traffic_adapter::CoordinatorTrafficChecker;
 use kin_daemon::SessionCoordinator;
 use kin_model::session::{IntentScope, LockType, SessionCapabilities, SessionTransport};
@@ -20,6 +21,13 @@ use kin_reconcile::collision::{CollisionCheck, TrafficChecker};
 use kin_reconcile::{ReconcileError, Reconciler};
 
 use crate::helpers::{init_kin_repo, make_entity};
+
+fn writable_capabilities() -> SessionCapabilities {
+    SessionCapabilities {
+        can_write: true,
+        ..SessionCapabilities::default()
+    }
+}
 
 // -----------------------------------------------------------------------
 // 1. CoordinatorTrafficChecker blocks hard-locked scope
@@ -37,7 +45,7 @@ fn coordinator_checker_blocks_hard_locked_scope() {
             SessionTransport::Mcp,
             None,
             PathBuf::from("/project"),
-            SessionCapabilities::default(),
+            writable_capabilities(),
         )
         .unwrap();
 
@@ -55,7 +63,7 @@ fn coordinator_checker_blocks_hard_locked_scope() {
     let entity_id = EntityId::new();
 
     // Session 1 takes a hard lock on the entity.
-    coord
+    let registration = coord
         .register_intent(
             &s1,
             vec![IntentScope::Entity(entity_id)],
@@ -64,6 +72,10 @@ fn coordinator_checker_blocks_hard_locked_scope() {
             None,
         )
         .unwrap();
+    assert!(matches!(
+        registration,
+        IntentRegistrationResult::Registered { .. }
+    ));
 
     // Session 2 tries to check traffic on the same scope.
     let checker = CoordinatorTrafficChecker::new(graph.clone());
@@ -99,7 +111,7 @@ fn coordinator_checker_allows_disjoint_scopes() {
             SessionTransport::Mcp,
             None,
             PathBuf::from("/project"),
-            SessionCapabilities::default(),
+            writable_capabilities(),
         )
         .unwrap();
 
@@ -107,7 +119,7 @@ fn coordinator_checker_allows_disjoint_scopes() {
     let entity_b = EntityId::new();
 
     // Session 1 hard-locks entity A.
-    coord
+    let registration = coord
         .register_intent(
             &s1,
             vec![IntentScope::Entity(entity_a)],
@@ -116,6 +128,10 @@ fn coordinator_checker_allows_disjoint_scopes() {
             None,
         )
         .unwrap();
+    assert!(matches!(
+        registration,
+        IntentRegistrationResult::Registered { .. }
+    ));
 
     // Check traffic on entity B — should be clear.
     let checker = CoordinatorTrafficChecker::new(graph.clone());
@@ -147,14 +163,14 @@ fn coordinator_checker_allows_own_session() {
             SessionTransport::Mcp,
             None,
             PathBuf::from("/project"),
-            SessionCapabilities::default(),
+            writable_capabilities(),
         )
         .unwrap();
 
     let entity_id = EntityId::new();
 
     // Session 1 hard-locks the entity.
-    coord
+    let registration = coord
         .register_intent(
             &s1,
             vec![IntentScope::Entity(entity_id)],
@@ -163,6 +179,10 @@ fn coordinator_checker_allows_own_session() {
             None,
         )
         .unwrap();
+    assert!(matches!(
+        registration,
+        IntentRegistrationResult::Registered { .. }
+    ));
 
     // Session 1 checks traffic on the same entity — should NOT be blocked.
     let checker = CoordinatorTrafficChecker::new(graph.clone());
@@ -200,7 +220,7 @@ fn coordinator_checker_warns_on_soft_lease() {
     let entity_id = EntityId::new();
 
     // Session 1 takes a soft lock on the entity.
-    coord
+    let registration = coord
         .register_intent(
             &s1,
             vec![IntentScope::Entity(entity_id)],
@@ -209,6 +229,10 @@ fn coordinator_checker_warns_on_soft_lease() {
             None,
         )
         .unwrap();
+    assert!(matches!(
+        registration,
+        IntentRegistrationResult::Registered { .. }
+    ));
 
     // Another session checks traffic — should get warnings, not blocked.
     let checker = CoordinatorTrafficChecker::new(graph.clone());
@@ -243,7 +267,7 @@ fn reconciler_with_coordinator_checker_blocks_hard_lock() {
             SessionTransport::Mcp,
             None,
             PathBuf::from("/project"),
-            SessionCapabilities::default(),
+            writable_capabilities(),
         )
         .unwrap();
 
@@ -251,7 +275,7 @@ fn reconciler_with_coordinator_checker_blocks_hard_lock() {
     let entity_id = entity.id;
 
     // Session 1 hard-locks the entity.
-    coord
+    let registration = coord
         .register_intent(
             &s1,
             vec![IntentScope::Entity(entity_id)],
@@ -260,6 +284,10 @@ fn reconciler_with_coordinator_checker_blocks_hard_lock() {
             None,
         )
         .unwrap();
+    assert!(matches!(
+        registration,
+        IntentRegistrationResult::Registered { .. }
+    ));
 
     // Set up reconciler with the coordinator-backed traffic checker.
     let checker = CoordinatorTrafficChecker::new(graph.clone());

--- a/tests/integration/src/p7_acceptance.rs
+++ b/tests/integration/src/p7_acceptance.rs
@@ -14,6 +14,13 @@ use kin_reconcile::{CollisionCheck, ReconcileError, Reconciler, TrafficChecker};
 
 use crate::helpers::*;
 
+fn writable_capabilities() -> SessionCapabilities {
+    SessionCapabilities {
+        can_write: true,
+        ..SessionCapabilities::default()
+    }
+}
+
 // -----------------------------------------------------------------------
 // 8. Session lifecycle: register -> heartbeat -> verify active -> end -> gone
 // -----------------------------------------------------------------------
@@ -78,7 +85,7 @@ fn intent_hard_collision_blocks_second_agent() {
             SessionTransport::Mcp,
             None,
             PathBuf::from("/project"),
-            SessionCapabilities::default(),
+            writable_capabilities(),
         )
         .unwrap();
 
@@ -89,7 +96,7 @@ fn intent_hard_collision_blocks_second_agent() {
             SessionTransport::Cli,
             None,
             PathBuf::from("/project"),
-            SessionCapabilities::default(),
+            writable_capabilities(),
         )
         .unwrap();
 
@@ -571,7 +578,7 @@ fn contract_scope_collision() {
             SessionTransport::Mcp,
             None,
             PathBuf::from("/project"),
-            SessionCapabilities::default(),
+            writable_capabilities(),
         )
         .unwrap();
 
@@ -582,7 +589,7 @@ fn contract_scope_collision() {
             SessionTransport::Cli,
             None,
             PathBuf::from("/project"),
-            SessionCapabilities::default(),
+            writable_capabilities(),
         )
         .unwrap();
 
@@ -641,7 +648,7 @@ fn artifact_scope_collision() {
             SessionTransport::Mcp,
             None,
             PathBuf::from("/project"),
-            SessionCapabilities::default(),
+            writable_capabilities(),
         )
         .unwrap();
 
@@ -652,7 +659,7 @@ fn artifact_scope_collision() {
             SessionTransport::Cli,
             None,
             PathBuf::from("/project"),
-            SessionCapabilities::default(),
+            writable_capabilities(),
         )
         .unwrap();
 


### PR DESCRIPTION
## Summary
- add durable, deterministic coordination evidence across intent, MCP transaction, and VFS write boundaries
- preserve off/warn compatibility while making enforce mode fail closed on capabilities, limits, identity, and conflicts
- distinguish coordination rejection from generic pre-apply commit failures
- expose optional daemon-side health attestation without fabricating legacy coverage
- ignore expired intents and keep enforcement mode consistent in evidence

## Verification
- focused `cargo test -p kin-daemon coordination --locked`
- focused `cargo test -p kin-mcp coordination --locked`
- `cargo fmt -- --check`
- zero-file-search, runtime-boundary, and private-coupling guards
- CI-equivalent clippy allowlist with `-D warnings`
- `cargo build --all-targets --locked`
- `cargo test --locked`

Supersedes stale draft #289 and fixes all five blocking review findings on current `main`.