### PR TITLE
ci: bound Cargo disk usage

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -232,6 +232,14 @@ jobs:
     name: Check & Test
     runs-on: ${{ matrix.os }}
     timeout-minutes: 60
+    # The all-features clippy/build/test sequence can otherwise retain more
+    # than a hosted runner's available disk in incremental objects and debug
+    # symbols. Keep validation semantics identical while bounding the target
+    # directory so tests still have space for their temporary fixtures.
+    env:
+      CARGO_INCREMENTAL: "0"
+      CARGO_PROFILE_DEV_DEBUG: "0"
+      CARGO_PROFILE_TEST_DEBUG: "0"
     strategy:
       matrix:
         os: [ubuntu-latest, macos-latest]


### PR DESCRIPTION
## Summary

Bound Cargo target growth in the hosted Ubuntu/macOS check matrix by disabling incremental artifacts and debug information for dev/test profiles. Validation semantics remain unchanged.

## Why

The current-main postmerge run and ranked-impact PR both exhausted the hosted runner filesystem (`Os { code: 28, kind: StorageFull }`) while creating temporary fixtures in updater tests. This change leaves disk headroom for those tests rather than weakening or skipping them.

## Validation

- `actionlint .github/workflows/ci.yml`
- `startup_authority_requires_the_exact_executing_object_and_rechecks_its_bytes`
- `stale_doctor_after_a_newer_install_fails_before_download_or_write`

Both exact previously failing tests pass with the bounded target configuration. Full hosted Ubuntu/macOS/Windows, coverage, daemon, Docker, security, and install checks remain required before merge.