### PR TITLE
Correct feature-space dimension in kin-ranking module docs

### DIFF
--- a/crates/kin-ranking/src/features.rs
+++ b/crates/kin-ranking/src/features.rs
@@ -3,7 +3,7 @@
 
 //! Feature vector definitions for the learning-to-rank pipeline.
 //!
-//! [`LocateFeatureVector`] captures the 33-dimensional feature space used by
+//! [`LocateFeatureVector`] captures the 32-dimensional feature space used by
 //! [`crate::ltr::GradientBoostedRanker`] to rerank locate-pipeline candidates.
 
 use serde::{Deserialize, Serialize};


### PR DESCRIPTION
Module documentation described a 33-dimensional feature space; `FEATURE_COUNT` is 32 and the compile-time `NAMES` array pins that width.

`cargo test -p kin-ranking`: 104 passed, 0 failed. Comment-only change.