### PR TITLE
Close the zero-file-search guard's coverage gaps

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -279,8 +279,70 @@ jobs:
       - name: Check formatting
         run: cargo fmt -- --check
 
+      # Two guards, two jobs. The Python checker walks every crate and carries
+      # the owned, dated, existence-validated allowlist. The shell guard is a
+      # dependency-free check on the ten core answer modules and is the one the
+      # kin-cli unit test drives. Both run, and the third step falsifies them —
+      # a guard that has never been shown to fail proves nothing.
       - name: Check Zero File-Search Invariant
         run: python3 scripts/verify-zero-file-search.py
+
+      - name: Check Zero File-Search Invariant (answer modules)
+        run: bash scripts/zero_file_search_guard.sh
+
+      - name: Falsify Zero File-Search guards
+        run: |
+          set -euo pipefail
+          poisoned="$(mktemp -d)"
+          trap 'rm -rf "$poisoned"' EXIT
+          cp -a crates scripts "$poisoned/"
+
+          probe='fn workspace_source_path_exists(p: &str, root: &std::path::Path) -> bool {
+              root.join(p).is_file()
+          }'
+
+          fail_expected() {
+            local label="$1" want="$2"; shift 2
+            local out rc=0
+            out="$("$@" 2>&1)" || rc=$?
+            if [[ $rc -eq 0 ]]; then
+              echo "::error::falsification failed — $label did not fail"; echo "$out"; exit 1
+            fi
+            if ! grep -qF "$want" <<<"$out"; then
+              echo "::error::falsification failed — $label failed but never named '$want'"
+              echo "$out"; exit 1
+            fi
+            echo "  ok: $label"
+          }
+
+          echo "[1/3] reintroduced existence probe in an answer module"
+          printf '%s\n' "$probe" > "$poisoned/crates/kin-cli/src/commands/locate.rs"
+          fail_expected "shell guard" "locate.rs" bash "$poisoned/scripts/zero_file_search_guard.sh" "$poisoned"
+          fail_expected "python guard" "locate.rs" python3 "$poisoned/scripts/verify-zero-file-search.py" "$poisoned"
+
+          echo "[2/3] new raw read inside a pinned-exemption module"
+          cp -a crates/kin-cli/src/commands/locate.rs "$poisoned/crates/kin-cli/src/commands/locate.rs"
+          printf '\nfn leak(p: &str) -> String {\n    std::fs::read_to_string(p).unwrap()\n}\n' \
+            >> "$poisoned/crates/kin-cli/src/commands/deps.rs"
+          fail_expected "python guard" "deps.rs" python3 "$poisoned/scripts/verify-zero-file-search.py" "$poisoned"
+
+          echo "[3/3] allowlist entry naming a path that no longer exists"
+          cp -a crates/kin-cli/src/commands/deps.rs "$poisoned/crates/kin-cli/src/commands/deps.rs"
+          python3 - "$poisoned/scripts/zero-file-search-allowlist.json" <<'PY'
+          import json, sys
+          path = sys.argv[1]
+          data = json.load(open(path))
+          data["allowlist"].append({
+              "file": "crates/kin-core/src/text_refs.rs",
+              "reason": "resurrected stale exemption",
+              "owner": "ci-falsification",
+              "expiration": "2026-12-31",
+          })
+          json.dump(data, open(path, "w"))
+          PY
+          fail_expected "python guard" "text_refs.rs" python3 "$poisoned/scripts/verify-zero-file-search.py" "$poisoned"
+
+          echo "Zero File-Search guards are falsifiable: every probe was caught."
 
       # TEMPORARY debt allow-list — burn down per crates/kin-cli/docs/kin-cli-clippy-triage.md
       # + release-ops task; no additions without lead sign-off.

--- a/scripts/verify-zero-file-search.py
+++ b/scripts/verify-zero-file-search.py
@@ -1,4 +1,18 @@
 #!/usr/bin/env python3
+"""Zero File-Search Authority guard.
+
+Kin answers locate/search/context/trace/review/xref/rename queries from
+graph-owned truth, never by consulting raw filesystem contents. This guard
+fails when a raw filesystem read, existence, or traversal primitive appears in
+an answer path outside the justified allowlist.
+
+Usage: verify-zero-file-search.py [repo_root]
+
+The optional repo_root selects the tree to scan (default: the repo containing
+this script). The allowlist always travels with the script — it is the policy,
+not a property of the tree under test — which lets CI point the guard at a
+deliberately poisoned copy and assert that it fails.
+"""
 import os
 import sys
 import json
@@ -7,7 +21,7 @@ from datetime import date
 
 # Resolve paths relative to kin repo root
 SCRIPT_DIR = os.path.dirname(os.path.abspath(__file__))
-KIN_ROOT = os.path.dirname(SCRIPT_DIR)
+KIN_ROOT = os.path.abspath(sys.argv[1]) if len(sys.argv) > 1 else os.path.dirname(SCRIPT_DIR)
 ALLOWLIST_PATH = os.path.join(SCRIPT_DIR, "zero-file-search-allowlist.json")
 
 # Every allowlist entry must carry these so each exemption has an accountable
@@ -16,11 +30,21 @@ REQUIRED_FIELDS = ("file", "reason", "owner", "expiration")
 
 
 def load_allowlist():
-    """Load and validate the allowlist, returning the set of exempt files.
+    """Load and validate the allowlist, returning {file: allowed_matches}.
 
-    Each entry must declare file, reason, owner, and an ISO `expiration` date.
-    Missing fields, malformed dates, and past-due exemptions fail the guard so
-    exemptions cannot silently accumulate or outlive their justification.
+    Each entry must declare file, reason, owner, and an ISO `expiration` date,
+    and must name a path that actually exists. Missing fields, malformed dates,
+    past-due exemptions, and entries for deleted files all fail the guard, so
+    exemptions cannot silently accumulate, outlive their justification, or sit
+    dormant waiting to auto-exempt a file that gets recreated under the same
+    path.
+
+    `allow_match` is optional. When present it lists exact substrings that are
+    exempt within that file, mirroring `allow_for` in
+    scripts/zero_file_search_guard.sh: the exemption is pinned to the known
+    lines, so a new or different filesystem primitive in the same file still
+    trips the guard. When absent the whole file is exempt, which is only
+    appropriate for files that are an IO boundary end to end.
     """
     try:
         with open(ALLOWLIST_PATH, "r", encoding="utf-8") as f:
@@ -31,7 +55,7 @@ def load_allowlist():
 
     entries = data.get("allowlist", [])
     errors = []
-    files = set()
+    files = {}
     today = date.today()
 
     for i, item in enumerate(entries):
@@ -42,7 +66,28 @@ def load_allowlist():
                 f"field(s): {', '.join(missing)}"
             )
             continue
-        files.add(item["file"])
+
+        if not os.path.exists(os.path.join(KIN_ROOT, item["file"])):
+            errors.append(
+                f"  entry {item['file']} names a path that does not exist "
+                f"(owner: {item['owner']}) — remove the stale exemption; leaving "
+                f"it would silently exempt any file later recreated at that path"
+            )
+            continue
+
+        matches = item.get("allow_match")
+        if matches is not None and (
+            not isinstance(matches, list)
+            or not matches
+            or not all(isinstance(m, str) and m for m in matches)
+        ):
+            errors.append(
+                f"  entry {item['file']} has an invalid allow_match "
+                f"(want a non-empty list of non-empty strings)"
+            )
+            continue
+        files[item["file"]] = set(matches) if matches else None
+
         try:
             exp_date = date.fromisoformat(item["expiration"])
         except ValueError:
@@ -116,7 +161,24 @@ QUERY_COMMANDS = {
     # scanning it keeps that authority path free of any raw source-tree walk.
     "refs.rs",
     # Context-pack assembly is an answer authority, not an IO boundary.
-    "context.rs"
+    "context.rs",
+    # rename derives its edit plan — the answer — from the graph's entity and
+    # reference relations, so it is an authority path even though applying the
+    # plan later writes files.
+    "rename.rs",
+    # deps answers a cross-repo dependency query. Whether it may answer it from
+    # manifests instead of the spine is an open decision; scanning it keeps the
+    # question visible instead of silent.
+    "deps.rs",
+    # Read-only analyses that answer from graph relations, history, and health
+    # records. None of them should need the working tree to produce an answer.
+    "blame.rs",
+    "impact.rs",
+    "dead_code.rs",
+    "overview.rs",
+    # health reports on the local install and graph state. Environment probes
+    # here are a diagnostic boundary, but repo-content reads would not be.
+    "health.rs"
 }
 
 # Query/answer authority handlers that live inside an otherwise IO-boundary
@@ -158,11 +220,28 @@ def is_test_file(rel_path):
     return False
 
 
-# Patterns to scan
+# Patterns to scan.
+#
+# The first group is the raw filesystem read / existence / traversal primitive
+# set shared with scripts/zero_file_search_guard.sh. Answering a semantic query
+# by probing the working tree is the violation the rule exists to stop, and it
+# does not require the `std::fs::` prefix to happen: `path.exists()`,
+# `File::open`, a bare `read_dir(`, or a `WalkDir` traversal all read the tree
+# just as directly. Writes and directory creation stay out of the deny set —
+# materialization is a projection boundary, not answer-by-search.
 PATTERNS = [
+    (re.compile(r'\.is_file\(\)'), "filesystem existence probe (is_file)"),
+    (re.compile(r'\.is_dir\(\)'), "filesystem existence probe (is_dir)"),
+    (re.compile(r'\.exists\(\)'), "filesystem existence probe (exists)"),
+    (re.compile(r'\.canonicalize\(\)'), "filesystem path resolution (canonicalize)"),
+    (re.compile(r'\bsymlink_metadata\b'), "filesystem metadata probe"),
+    (re.compile(r'\bread_link\b'), "filesystem symlink read"),
+    (re.compile(r'\bFile::open\b'), "raw file handle open"),
+    (re.compile(r'\bread_dir\('), "directory traversal (read_dir)"),
+    (re.compile(r'\bWalkDir\b|\bwalkdir::'), "directory traversal (walkdir)"),
+    (re.compile(r'\bglob::glob\b'), "filesystem glob"),
     (re.compile(r'\bstd::fs::[a-zA-Z0-9_]+'), "std::fs API usage"),
-    (re.compile(r'\bfs::(read|read_to_string|read_dir|write|copy|create_dir|create_dir_all|remove_file|remove_dir|remove_dir_all)\b'), "fs API usage"),
-    (re.compile(r'\bwalkdir::WalkDir\b'), "walkdir usage"),
+    (re.compile(r'(?<![_a-z])fs::(read|read_to_string|read_dir|metadata|write|copy|create_dir|create_dir_all|remove_file|remove_dir|remove_dir_all)\b'), "fs API usage"),
     (re.compile(r'Command::new\("git"\).*?"grep"'), "git grep subprocess usage")
 ]
 
@@ -197,7 +276,7 @@ def find_fn_body_ranges(lines, fn_names):
     return ranges
 
 
-def scan_file(filepath, rel_path, query_fn_names=None):
+def scan_file(filepath, rel_path, query_fn_names=None, allowed_matches=None):
     violations = []
 
     with open(filepath, "r", encoding="utf-8") as f:
@@ -259,10 +338,18 @@ def scan_file(filepath, rel_path, query_fn_names=None):
         ):
             continue
 
-        # Scan for patterns
-        for pattern, desc in PATTERNS:
-            if pattern.search(line):
-                violations.append((idx, line.strip(), desc))
+        # Lines pinned by an `allow_match` exemption are a justified IO
+        # boundary. Anything else in the same file still trips the guard.
+        if allowed_matches and any(m in line for m in allowed_matches):
+            continue
+
+        # Scan for patterns. A line can match several primitives at once
+        # (`std::fs::read_dir` is both an fs call and a traversal); report the
+        # line once with every primitive it tripped, so the violation count
+        # tracks offending lines rather than pattern hits.
+        descs = [desc for pattern, desc in PATTERNS if pattern.search(line)]
+        if descs:
+            violations.append((idx, line.strip(), ", ".join(dict.fromkeys(descs))))
 
     return violations
 
@@ -285,17 +372,21 @@ def main():
             filepath = os.path.join(root, file)
             rel_path = os.path.relpath(filepath, KIN_ROOT)
 
-            # Allowed files are exempt regardless of where they live.
+            # Whole-file exemptions (an `allow_match`-less entry) skip the scan
+            # entirely; pinned exemptions still scan, minus their named lines.
+            allowed_matches = None
             if rel_path in allowlist:
-                continue
+                allowed_matches = allowlist[rel_path]
+                if allowed_matches is None:
+                    continue
 
             # Query handlers inside boundary crates are scanned function-scoped;
             # they bypass the boundary skip so their answer paths are covered.
             query_fns = DAEMON_QUERY_HANDLERS.get(rel_path)
-            if query_fns is None and is_test_file(rel_path):
+            if query_fns is None and allowed_matches is None and is_test_file(rel_path):
                 continue
 
-            violations = scan_file(filepath, rel_path, query_fns)
+            violations = scan_file(filepath, rel_path, query_fns, allowed_matches)
             if violations:
                 print(f"\n[VIOLATION] {rel_path} contains forbidden filesystem access:")
                 for line_num, content, desc in violations:

--- a/scripts/zero-file-search-allowlist.json
+++ b/scripts/zero-file-search-allowlist.json
@@ -85,18 +85,87 @@
       "expiration": "2026-12-31"
     },
     {
-      "file": "crates/kin-core/src/text_refs.rs",
-      "reason": "TRANSITIONAL: Direct filesystem read for text references. Needs migration to graph-derived source.",
-      "owner": "kin-core",
-      "status": "transitional",
-      "removal_target": "Replace direct text-reference reads with graph-derived source projection.",
-      "expiration": "2026-09-30"
-    },
-    {
       "file": "crates/kin-cli/src/retrieval_profile.rs",
       "reason": "Config/capability IO: probes the local model cache directory for reranker availability; never reads repo content and is not a semantic answer path",
       "owner": "kin-cli",
       "expiration": "2026-12-31"
+    },
+    {
+      "file": "crates/kin-cli/src/commands/locate.rs",
+      "reason": "Telemetry consent boundary: the only filesystem touch in the locate authority path is the presence of the consent marker, which gates telemetry and never contributes to the ranked answer. Pinned so any other filesystem primitive in this module fails the guard",
+      "owner": "kin-cli",
+      "expiration": "2026-12-31",
+      "allow_match": [
+        "consent_marker_path"
+      ]
+    },
+    {
+      "file": "crates/kin-cli/src/commands/health.rs",
+      "reason": "Config/diagnostic IO: kin health reports on the local installation, so the environment is its subject, not a source of semantic answers. Every probe targets the install — daemon binary, VFS shim header, shell hook and rc, AI-client MCP config files, editor extensions dir, pending session runs. It must never read repo content to answer a semantic query",
+      "owner": "kin-cli",
+      "expiration": "2026-12-31"
+    },
+    {
+      "file": "crates/kin-cli/src/commands/rename.rs",
+      "reason": "PENDING FOUNDER DECISION: the rename plan's file SET is graph-derived, but its edit COORDINATES are not. read_repo_file reads the raw working tree and find_token_occurrences lexically scans those bytes to produce every line/col in the plan, so a tree that has drifted from graph truth yields silently wrong or zero edits with no gap report. A graph-native path already exists (graph.rs get_file_hash -> BlobStore, which bails loud on miss). Not fixed here: routing rename through it is a behavior change owned by another lane. Pinned to the single known read so any additional filesystem access in this module fails the guard",
+      "owner": "kin-cli",
+      "expiration": "2026-09-30",
+      "allow_match": [
+        "std::fs::read_to_string(path)"
+      ]
+    },
+    {
+      "file": "crates/kin-cli/src/commands/deps.rs",
+      "reason": "PENDING FOUNDER DECISION: kin deps answers a cross-repo dependency query by scraping Cargo.toml/package.json and line-scanning for 'git =' entries; the graph is never consulted. xref.rs routes users here on a graph miss, so a compliant command's gap path hands off to this one. Not fixed here: making deps graph-backed, or reclassifying it as an ingestion-boundary command that is not an authority path, is a product decision. Pinned to the known manifest reads so any additional filesystem access in this module fails the guard",
+      "owner": "kin-cli",
+      "expiration": "2026-09-30",
+      "allow_match": [
+        "std::fs::read_to_string(&cargo_path)",
+        "crates_dir.is_dir()",
+        "std::fs::read_dir(&crates_dir)",
+        "member_cargo.is_file()",
+        "std::fs::read_to_string(&member_cargo)",
+        "pkg_path.is_file()",
+        "std::fs::read_to_string(&pkg_path)"
+      ]
+    },
+    {
+      "file": "crates/kin-mcp/src/handlers/common.rs",
+      "reason": "Layout discovery boundary: candidate_source_roots only probes KIN_SOURCE_ROOT and the cwd for a .kin layout so the BlobStore can be located. Entity bodies are still fetched by graph-recorded hash and re-digested before use, and a miss reports graph-miss rather than falling back to the working tree",
+      "owner": "kin-mcp",
+      "expiration": "2026-12-31",
+      "allow_match": [
+        "if root.is_dir()",
+        "cwd.is_dir()"
+      ]
+    },
+    {
+      "file": "crates/kin-git/src/import.rs",
+      "reason": "Git ingestion boundary: open_repo probes for a .git directory to distinguish a worktree from a bare repo before handing the path to gix. Explicit input boundary for building graph truth, not a semantic answer",
+      "owner": "kin-git",
+      "expiration": "2026-12-31",
+      "allow_match": [
+        "dot_git.is_dir()"
+      ]
+    },
+    {
+      "file": "crates/kin-git/src/export.rs",
+      "reason": "Git export boundary: probes the output path's git layout to decide open-vs-init before materializing graph truth as git objects. Explicit output boundary, not a semantic answer",
+      "owner": "kin-git",
+      "expiration": "2026-12-31",
+      "allow_match": [
+        "dot_git.is_dir()",
+        "output_path.join(\".git\").exists()"
+      ]
+    },
+    {
+      "file": "crates/kin-git/src/cochange.rs",
+      "reason": "Git ingestion boundary: open_repo probes the .git layout before mining commit history into graph relations. Co-change relations are read back from the graph, never from this traversal",
+      "owner": "kin-git",
+      "expiration": "2026-12-31",
+      "allow_match": [
+        "dot_git.is_dir()"
+      ]
     }
   ]
 }

--- a/scripts/zero_file_search_guard.sh
+++ b/scripts/zero_file_search_guard.sh
@@ -10,6 +10,18 @@
 # task-input boundary. Filesystem writes and directory creation are
 # materialization, not answer-by-search, and are intentionally not denied.
 #
+# This is the narrow half of a two-guard pair, both run by CI:
+#
+#   scripts/verify-zero-file-search.py   walks every crate, shares this deny
+#                                        set, and carries the owned, dated,
+#                                        existence-validated allowlist
+#   scripts/zero_file_search_guard.sh    this file — a dependency-free check on
+#                                        the core answer modules, driven by the
+#                                        kin-cli unit test as well as by CI
+#
+# Keep the deny sets in step. Coverage beyond these modules belongs in the
+# Python checker rather than being duplicated here.
+#
 # Usage: zero_file_search_guard.sh [repo_root]
 # Exit: 0 when the answer paths are graph-clean, 1 on the first violation.
 set -euo pipefail


### PR DESCRIPTION
The Zero File-Search Authority rule is structurally honored on the surfaces that matter — but the guard proving it was weaker than it looked. This closes the four coverage defects and reports what widening the guard actually surfaced.

## Defect 1 — CI ran the weaker of the two checkers

`.github/workflows/ci.yml:283` ran **only** `scripts/verify-zero-file-search.py`. `scripts/zero_file_search_guard.sh` carried the stricter deny set (`.exists()`, `.canonicalize()`, `File::open`, `WalkDir`, `read_dir(`, `glob::glob`) and **was invoked by nothing** in CI. The Python patterns (`:161-166`) missed all of those unless prefixed `std::fs::`.

**Changed — both, and argued:** the strict deny set is now shared by both guards, and both run as named CI steps.

Merging rather than choosing, because the two guards have genuinely different strengths. The Python checker walks all 93 scanned files across 11 crates and owns the dated, accountable allowlist; putting the strict primitives there widens strictness across the *whole* surface, not just ten files. The shell guard is dependency-free, is what the `kin-cli` unit test drives, and its per-file exact-substring allowance model is *tighter* than a whole-file exemption. Deleting either would have lost something. Its header now states the division of labor so the deny sets stay in step and coverage is not duplicated into it.

## Defect 2 — unscanned command modules

`QUERY_COMMANDS` (`:107-121`) omitted `rename.rs`; `is_test_file` (`:141-155`) left `deps.rs`, `blame.rs`, `impact.rs`, `dead_code.rs`, `health.rs`, `overview.rs` unscanned. All seven are now scanned.

## Defect 3 — the allowlist could resurrect a deleted exemption

`scripts/zero-file-search-allowlist.json:88` exempted `crates/kin-core/src/text_refs.rs` — deleted by `118e11c3`, the very commit that removed it for being an answer-authority scan. `load_allowlist` validated expiry but not existence, so re-creating that file would have been silently auto-exempt.

`load_allowlist` now **fails when an allowlisted path does not exist**, and the stale entry is removed. The allowlist also gains an optional `allow_match` field — a list of exact substrings exempt within a file, mirroring `allow_for` in the shell guard. An exemption pins to its known lines, so a *new or different* filesystem primitive in the same file still trips the guard. Whole-file exemptions remain available but are now the exception rather than the only option — which is why the 22,871-line `locate.rs` gets a one-substring pin instead of a blanket pass.

## Defect 4 — kin-mcp handlers

Correction to the premise, and it matters: `crates/kin-mcp/src/handlers/*` **was** being walked — all 8 handler files plus 9 more kin-mcp files were in the scan set. The gap was the *pattern set*, not the file walk: with only `std::fs::`-prefixed patterns, a bare `.is_dir()` was invisible. Under the strict deny set the handlers are genuinely covered, and it immediately surfaced a real hit (below).

## Defect 5 — the guards were never shown to fail in CI

The `kin-cli` unit test falsifies the shell guard against a poisoned tree. Nothing falsified the Python checker. Both guards now take an optional `repo_root` argument, and a **`Falsify Zero File-Search guards`** CI step poisons a scratch copy and requires each guard to both fail *and name the offending file* — so a guard that fails for the wrong reason cannot pass as proof:

1. reintroduced `is_file()` probe in an answer module → both guards must fail naming `locate.rs`
2. a new raw read inside a pinned-exemption module → Python must fail naming `deps.rs` (proves `allow_match` does not blanket-exempt)
3. an allowlist entry naming a deleted path → Python must fail naming `text_refs.rs` (proves the existence check)

Verified locally by extracting the step's script straight out of the parsed YAML and executing it; all three probes are caught, and both guards pass on the clean tree.

## Newly surfaced violations and their disposition

Widening coverage surfaced **8 files / 33 offending lines**. Every one was triaged individually; none was silenced with a blanket entry.

### Genuine authority-path violations — named, pinned, expiring `2026-09-30`, founder decision pending

| File | Lines | Finding |
|---|---|---|
| `commands/rename.rs` | `456` | The plan's file SET is graph-derived, but its edit COORDINATES are not. `read_repo_file` → `std::fs::read_to_string(source_dir(layout).join(rel_path))`, then `find_token_occurrences` lexically scans those bytes to produce every line/col in the plan. A drifted tree yields silently wrong or zero edits with no gap report. A graph-native path already exists (`graph.rs` `get_file_hash` → BlobStore, bails loud on miss) and is not taken. |
| `commands/deps.rs` | `116,122,123,126,127,177,181` | Answers a cross-repo dependency query by scraping `Cargo.toml`/`package.json` and line-scanning for `git =`. The graph is never consulted. `xref.rs:127` routes users here on a graph miss, so a compliant command's gap path hands off to this one. |

Both are pinned to their known lines, so any *additional* filesystem access in either module fails CI immediately. Neither Rust file was touched.

### Ingestion / boundary IO — justified, pinned, `2026-12-31`

| File | Lines | Disposition |
|---|---|---|
| `kin-git/src/import.rs` | `22` | `open_repo` probes `.git` to distinguish worktree from bare repo before handing the path to `gix`. Explicit input boundary. |
| `kin-git/src/export.rs` | `95,113` | Same probe, plus open-vs-init on the output path. Explicit output boundary. |
| `kin-git/src/cochange.rs` | `53` | Same probe before mining commit history into graph relations; co-change relations are read back from the graph. |
| `kin-mcp/src/handlers/common.rs` | `987,993` | `candidate_source_roots` probes `KIN_SOURCE_ROOT`/cwd for a `.kin` layout so the BlobStore can be located. Bodies are still fetched by graph-recorded hash and **re-digested before use**; a miss reports `graph-miss` rather than falling back to the tree. Layout discovery, not content read. |
| `commands/locate.rs` | `1307` | Telemetry consent-marker presence; never contributes to the ranked answer. Already the shell guard's sole `allow_for` allowance — the two guards now agree. |
| `commands/health.rs` | 20 lines | Config/diagnostic IO. `kin health` reports on the local *installation*, so the environment is its subject. Every probe targets the install: daemon binary, VFS shim header, shell hook + rc, AI-client MCP config files, editor extensions dir, pending session runs. Zero repo-content reads. Whole-file, with the boundary condition stated in the reason. |

### Clean under the widened guard

`blame.rs`, `impact.rs`, `dead_code.rs`, `overview.rs` — four newly scanned analysis commands, **zero violations** under the full strict deny set. They answer from graph truth today.

## Scope

**No `.rs` file was modified.** This PR changes only `scripts/verify-zero-file-search.py`, `scripts/zero_file_search_guard.sh`, `scripts/zero-file-search-allowlist.json`, and `.github/workflows/ci.yml`. Deciding `rename.rs` and `deps.rs` on their merits — routing rename's span reads through the existing BlobStore path, and making deps graph-backed or explicitly reclassifying it — is left to the founder and the lane that owns those files. The exemptions expire `2026-09-30`, so the decision cannot be deferred silently.

No local `cargo` build/check/test was run: a citable benchmark cohort is on this machine. Both guards are pure Python/bash and were run directly. The existing `kin-cli` unit test that drives the shell guard is unaffected — the guard's behavior is unchanged, only its header comment.
