### PR TITLE
Restore artifact-only ref hydration for retrieval paths

### DIFF
--- a/crates/kin-cli/src/commands/ref_lookup.rs
+++ b/crates/kin-cli/src/commands/ref_lookup.rs
@@ -1004,9 +1004,7 @@ mod tests {
     /// unavailable so these tests skip the same way the others do.
     fn single_commit_repo_for_hydration() -> Option<(InMemoryGraph, kin_core::KinLayout, String)> {
         let repo = tempfile::tempdir().unwrap();
-        if git_ok(repo.path(), &["init", "-q"]).is_none() {
-            return None;
-        }
+        git_ok(repo.path(), &["init", "-q"])?;
         assert!(git_ok(repo.path(), &["config", "user.email", "test@kin.dev"]).is_some());
         assert!(git_ok(repo.path(), &["config", "user.name", "Kin Test"]).is_some());
         std::fs::write(

--- a/crates/kin-cli/src/commands/ref_lookup.rs
+++ b/crates/kin-cli/src/commands/ref_lookup.rs
@@ -114,12 +114,44 @@ where
     }
 }
 
+/// How much semantic work a lazy Git-ref hydration performs on the ancestry it
+/// imports. Both depths import the same commits and the same artifact deltas;
+/// they differ only in whether the per-commit semantic replay runs.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum HydrationDepth {
+    /// Replay per-commit entity and relation deltas across the whole imported
+    /// ancestry.
+    ///
+    /// Required by every caller that reads semantic truth *at* the ref rather
+    /// than a tree state derived from it: `history` and `blame` resolve the
+    /// target entity through `resolve_graph_at`, which replays exactly these
+    /// deltas, and `review` diffs them between two refs.
+    Semantic,
+    /// Import artifact deltas only, skipping the per-commit semantic replay.
+    ///
+    /// Retrieval does not read those deltas. `kin_core::build_graph_at_ref*`
+    /// takes the ref's file tree from the replayed *artifact* deltas (or from
+    /// the Git tree directly) and rebuilds the scoped entity set by re-parsing
+    /// that tree through `IndexPipeline`, so scope-for-retrieval and
+    /// `locate --ref` get the same answer either way. Co-change mining also
+    /// reads artifact deltas only.
+    ///
+    /// The replay it skips re-parses and re-links every ancestor commit — the
+    /// "Hydrating History: [n/26747]" pass, minutes of work on a deep
+    /// base_commit — which is pure cost on these two paths.
+    ArtifactOnly,
+}
+
 pub fn resolve_ref_importing_git_if_needed(
     graph: &kin_db::InMemoryGraph,
     layout: &kin_core::KinLayout,
     reference: Option<&str>,
 ) -> Result<SemanticChangeId> {
-    Ok(resolve_ref_importing_git_if_needed_with_report_inner(graph, layout, reference)?.head)
+    Ok(
+        prepare_ref_importing_git_if_needed(graph, layout, reference, HydrationDepth::Semantic)
+            .into_result()?
+            .head,
+    )
 }
 
 pub fn resolve_ref_importing_git_if_needed_for_locate(
@@ -127,7 +159,11 @@ pub fn resolve_ref_importing_git_if_needed_for_locate(
     layout: &kin_core::KinLayout,
     reference: Option<&str>,
 ) -> Result<SemanticChangeId> {
-    Ok(resolve_ref_importing_git_if_needed_with_report_inner(graph, layout, reference)?.head)
+    Ok(
+        prepare_ref_importing_git_if_needed(graph, layout, reference, HydrationDepth::ArtifactOnly)
+            .into_result()?
+            .head,
+    )
 }
 
 pub fn resolve_ref_importing_git_if_needed_with_report(
@@ -135,7 +171,8 @@ pub fn resolve_ref_importing_git_if_needed_with_report(
     layout: &kin_core::KinLayout,
     reference: Option<&str>,
 ) -> Result<ResolvedRef> {
-    prepare_ref_importing_git_if_needed_with_report(graph, layout, reference).into_result()
+    prepare_ref_importing_git_if_needed(graph, layout, reference, HydrationDepth::Semantic)
+        .into_result()
 }
 
 pub fn resolve_ref_importing_git_if_needed_for_locate_with_report(
@@ -143,21 +180,23 @@ pub fn resolve_ref_importing_git_if_needed_for_locate_with_report(
     layout: &kin_core::KinLayout,
     reference: Option<&str>,
 ) -> Result<ResolvedRef> {
-    resolve_ref_importing_git_if_needed_with_report_inner(graph, layout, reference)
-}
-
-fn resolve_ref_importing_git_if_needed_with_report_inner(
-    graph: &kin_db::InMemoryGraph,
-    layout: &kin_core::KinLayout,
-    reference: Option<&str>,
-) -> Result<ResolvedRef> {
-    prepare_ref_importing_git_if_needed_with_report(graph, layout, reference).into_result()
+    prepare_ref_importing_git_if_needed(graph, layout, reference, HydrationDepth::ArtifactOnly)
+        .into_result()
 }
 
 pub fn prepare_ref_importing_git_if_needed_with_report(
     graph: &kin_db::InMemoryGraph,
     layout: &kin_core::KinLayout,
     reference: Option<&str>,
+) -> PreparedRefResolution {
+    prepare_ref_importing_git_if_needed(graph, layout, reference, HydrationDepth::Semantic)
+}
+
+fn prepare_ref_importing_git_if_needed(
+    graph: &kin_db::InMemoryGraph,
+    layout: &kin_core::KinLayout,
+    reference: Option<&str>,
+    depth: HydrationDepth,
 ) -> PreparedRefResolution {
     match resolve_ref(graph, layout, reference) {
         Ok(head) => PreparedRefResolution {
@@ -177,7 +216,7 @@ pub fn prepare_ref_importing_git_if_needed_with_report(
                     hydrated_changes: 0,
                 };
             };
-            match hydrate_imported_git_ref(graph, layout, git_oid) {
+            match hydrate_imported_git_ref(graph, layout, git_oid, depth) {
                 Ok(hydrated_changes) => PreparedRefResolution {
                     // Preserve a relative-hop error until the graph owner has
                     // acknowledged the successful ancestry insertion.
@@ -516,20 +555,99 @@ pub fn git_ref_requires_hydration(graph: &kin_db::InMemoryGraph, reference: &str
 /// no import ran). Callers report this count directly rather than collapsing
 /// it to a boolean, so a cold multi-thousand-change import is never described
 /// the same way as a no-op.
+///
+/// `depth` selects whether the imported ancestry also gets its per-commit
+/// semantic replay; see [`HydrationDepth`] for which callers need it.
 fn hydrate_imported_git_ref(
     graph: &kin_db::InMemoryGraph,
     layout: &kin_core::KinLayout,
     git_oid: &str,
+    depth: HydrationDepth,
 ) -> Result<usize> {
-    hydrate_imported_git_ref_with(graph, layout, git_oid, |imported, blob_store, kin_root| {
-        crate::commands::init::enrich_imported_changes_with_semantics_checkpointed(
-            imported,
-            blob_store,
-            kin_root,
-            kin_core::build_genesis_change().id,
-        )
-        .map(|_| ())
-    })
+    match depth {
+        HydrationDepth::Semantic => {
+            hydrate_imported_git_ref_with(graph, layout, git_oid, replay_imported_semantics)
+        }
+        HydrationDepth::ArtifactOnly => {
+            hydrate_imported_git_ref_with(graph, layout, git_oid, skip_imported_semantics)
+        }
+    }
+}
+
+/// [`HydrationDepth::Semantic`] replay: reconstruct per-commit entity and
+/// relation deltas across the imported ancestry, resuming from and writing
+/// hydration checkpoints.
+fn replay_imported_semantics(
+    imported: &mut [kin_git::ImportedChange],
+    blob_store: &kin_blobs::BlobStore,
+    kin_root: &std::path::Path,
+) -> Result<()> {
+    crate::commands::init::enrich_imported_changes_with_semantics_checkpointed(
+        imported,
+        blob_store,
+        kin_root,
+        kin_core::build_genesis_change().id,
+    )
+    .map(|_| ())
+}
+
+/// [`HydrationDepth::ArtifactOnly`] replay: none. The imported changes keep the
+/// artifact deltas the Git import produced, which is what the ref view and
+/// co-change mining read.
+fn skip_imported_semantics(
+    _imported: &mut [kin_git::ImportedChange],
+    _blob_store: &kin_blobs::BlobStore,
+    _kin_root: &std::path::Path,
+) -> Result<()> {
+    Ok(())
+}
+
+/// Reject an imported window before any of it is written to the graph unless
+/// every change lands on an already-known parent.
+///
+/// A change is admitted when each of its parents is the import's boundary root
+/// (canonical genesis), a change already present in `graph`, or a change
+/// admitted earlier in this same pass. Because admission is evaluated in the
+/// order kin-git emits — a parent-first Kahn traversal — that single rule
+/// rejects a parentless change, a parent outside the imported window, and a
+/// parent cycle alike: no member of a cycle can ever be admitted first.
+///
+/// This guards the graph write itself, so it holds for every hydration depth.
+/// The semantic replay performs its own richer validation before it mutates
+/// deltas; this check is what keeps an artifact-only import, which runs no
+/// replay, from inserting an ancestry the graph cannot resolve.
+fn admit_imported_changes_for_insert(
+    graph: &kin_db::InMemoryGraph,
+    imported: &[kin_git::ImportedChange],
+    boundary_root: SemanticChangeId,
+) -> Result<()> {
+    let mut admitted = std::collections::HashSet::with_capacity(imported.len());
+    for imported_change in imported {
+        let change = &imported_change.change;
+        if change.parents.is_empty() {
+            bail!(
+                "imported change {} has no parent; Git roots must reference canonical genesis {}",
+                change.id,
+                boundary_root
+            );
+        }
+        for parent in &change.parents {
+            if *parent == boundary_root
+                || admitted.contains(parent)
+                || graph.get_change(parent)?.is_some()
+            {
+                continue;
+            }
+            bail!(
+                "imported change {} names parent {} that is neither canonical genesis {}, already in the graph, nor an earlier change in the imported window",
+                change.id,
+                parent,
+                boundary_root
+            );
+        }
+        admitted.insert(change.id);
+    }
+    Ok(())
 }
 
 fn hydrate_imported_git_ref_with<F>(
@@ -567,6 +685,8 @@ where
             git_oid
         )
     })?;
+
+    admit_imported_changes_for_insert(graph, &imported, genesis_id)?;
 
     let mut inserted = 0usize;
     for imported_change in &imported {
@@ -876,6 +996,213 @@ mod tests {
         assert!(
             !layout.root().join("checkpoints/history-hydration").exists(),
             "lazy parent preflight must precede checkpoint-store creation"
+        );
+    }
+
+    /// A one-commit Git repo with a real source file, initialized for Kin, plus
+    /// an empty graph and the commit's oid. Returns `None` when Git is
+    /// unavailable so these tests skip the same way the others do.
+    fn single_commit_repo_for_hydration() -> Option<(InMemoryGraph, kin_core::KinLayout, String)> {
+        let repo = tempfile::tempdir().unwrap();
+        if git_ok(repo.path(), &["init", "-q"]).is_none() {
+            return None;
+        }
+        assert!(git_ok(repo.path(), &["config", "user.email", "test@kin.dev"]).is_some());
+        assert!(git_ok(repo.path(), &["config", "user.name", "Kin Test"]).is_some());
+        std::fs::write(
+            repo.path().join("lib.rs"),
+            "pub fn answer() -> i32 {\n    42\n}\n",
+        )
+        .unwrap();
+        assert!(git_ok(repo.path(), &["add", "lib.rs"]).is_some());
+        assert!(git_ok(repo.path(), &["commit", "-q", "-m", "initial"]).is_some());
+        let git_oid = git_ok(repo.path(), &["rev-parse", "HEAD"]).unwrap();
+        let layout = kin_core::init(repo.path()).unwrap().layout;
+        // Keep the repo alive for the test process lifetime; the layout and the
+        // blob store both keep reading from it after this function returns.
+        let _kept = repo.keep();
+        Some((InMemoryGraph::new(), layout, git_oid))
+    }
+
+    fn hydrated_tip_change(graph: &InMemoryGraph, git_oid: &str) -> kin_model::SemanticChange {
+        let imported_id = kin_git::semantic_change_id_from_git_oid_hex(git_oid).unwrap();
+        graph
+            .get_change(&imported_id)
+            .unwrap()
+            .expect("hydration must insert the requested commit")
+    }
+
+    /// The perf contract: an artifact-only hydration imports the same commits
+    /// and the same artifact deltas but runs no per-commit semantic replay, so
+    /// it writes no entity deltas and never opens a hydration checkpoint store.
+    /// The semantic hydration does replay.
+    #[test]
+    fn artifact_only_hydration_skips_the_semantic_replay_that_full_hydration_runs() {
+        let Some((semantic_graph, semantic_layout, semantic_oid)) =
+            single_commit_repo_for_hydration()
+        else {
+            return;
+        };
+        let Some((artifact_graph, artifact_layout, artifact_oid)) =
+            single_commit_repo_for_hydration()
+        else {
+            return;
+        };
+
+        let semantic_inserted = hydrate_imported_git_ref(
+            &semantic_graph,
+            &semantic_layout,
+            &semantic_oid,
+            HydrationDepth::Semantic,
+        )
+        .unwrap();
+        let artifact_inserted = hydrate_imported_git_ref(
+            &artifact_graph,
+            &artifact_layout,
+            &artifact_oid,
+            HydrationDepth::ArtifactOnly,
+        )
+        .unwrap();
+
+        assert!(semantic_inserted > 0);
+        assert_eq!(
+            artifact_inserted, semantic_inserted,
+            "both depths must import the same ancestry; only the replay differs"
+        );
+
+        let semantic_change = hydrated_tip_change(&semantic_graph, &semantic_oid);
+        let artifact_change = hydrated_tip_change(&artifact_graph, &artifact_oid);
+
+        assert!(
+            !semantic_change.entity_deltas.is_empty(),
+            "semantic hydration must replay per-commit entity deltas"
+        );
+        assert!(
+            artifact_change.entity_deltas.is_empty(),
+            "artifact-only hydration must not run the per-commit semantic replay"
+        );
+        assert!(
+            !artifact_change.artifact_deltas.is_empty(),
+            "artifact-only hydration must still import artifact deltas: the ref view and co-change mining read them"
+        );
+        assert!(
+            !artifact_layout
+                .root()
+                .join("checkpoints/history-hydration")
+                .exists(),
+            "artifact-only hydration must not open a hydration checkpoint store"
+        );
+    }
+
+    /// The regression this guards: the four public entry points must stay
+    /// distinct. `_for_locate*` resolves at artifact-only depth for scope and
+    /// `locate --ref`; the plain variants stay semantic for `history`, `blame`,
+    /// and `review`, which read the deltas the replay produces.
+    #[test]
+    fn locate_entry_points_resolve_at_artifact_only_depth_and_others_stay_semantic() {
+        let Some((locate_graph, locate_layout, locate_oid)) = single_commit_repo_for_hydration()
+        else {
+            return;
+        };
+        let Some((locate_report_graph, locate_report_layout, locate_report_oid)) =
+            single_commit_repo_for_hydration()
+        else {
+            return;
+        };
+        let Some((standard_graph, standard_layout, standard_oid)) =
+            single_commit_repo_for_hydration()
+        else {
+            return;
+        };
+        let Some((prepared_graph, prepared_layout, prepared_oid)) =
+            single_commit_repo_for_hydration()
+        else {
+            return;
+        };
+
+        resolve_ref_importing_git_if_needed_for_locate(
+            &locate_graph,
+            &locate_layout,
+            Some(&locate_oid),
+        )
+        .unwrap();
+        let locate_report = resolve_ref_importing_git_if_needed_for_locate_with_report(
+            &locate_report_graph,
+            &locate_report_layout,
+            Some(&locate_report_oid),
+        )
+        .unwrap();
+        let standard_report = resolve_ref_importing_git_if_needed_with_report(
+            &standard_graph,
+            &standard_layout,
+            Some(&standard_oid),
+        )
+        .unwrap();
+        let prepared = prepare_ref_importing_git_if_needed_with_report(
+            &prepared_graph,
+            &prepared_layout,
+            Some(&prepared_oid),
+        );
+
+        assert!(locate_report.hydrated_changes > 0);
+        assert!(standard_report.hydrated_changes > 0);
+        assert!(prepared.hydrated_changes > 0);
+        prepared.into_result().unwrap();
+
+        for (graph, oid, label) in [
+            (&locate_graph, &locate_oid, "resolve_..._for_locate"),
+            (
+                &locate_report_graph,
+                &locate_report_oid,
+                "resolve_..._for_locate_with_report",
+            ),
+        ] {
+            assert!(
+                hydrated_tip_change(graph, oid).entity_deltas.is_empty(),
+                "{label} must hydrate at artifact-only depth; otherwise it runs the deep per-commit replay whose deltas scope and locate --ref never read"
+            );
+        }
+
+        for (graph, oid, label) in [
+            (&standard_graph, &standard_oid, "resolve_..._with_report"),
+            (&prepared_graph, &prepared_oid, "prepare_..._with_report"),
+        ] {
+            assert!(
+                !hydrated_tip_change(graph, oid).entity_deltas.is_empty(),
+                "{label} must keep full semantic hydration; history, blame, and review read these deltas"
+            );
+        }
+    }
+
+    /// Graph-integrity parity: the artifact-only path runs no semantic replay,
+    /// so the replay's own preflight cannot be what protects it. A corrupt
+    /// imported window must still be refused before anything is written.
+    #[test]
+    fn artifact_only_hydration_still_refuses_a_dangling_parent_before_graph_write() {
+        let Some((graph, layout, git_oid)) = single_commit_repo_for_hydration() else {
+            return;
+        };
+        let imported_id = kin_git::semantic_change_id_from_git_oid_hex(&git_oid).unwrap();
+        let dangling = SemanticChangeId::from_hash(kin_model::Hash256::from_bytes([0xee; 32]));
+
+        let error = hydrate_imported_git_ref_with(
+            &graph,
+            &layout,
+            &git_oid,
+            |imported, blob_store, kin_root| {
+                imported[0].change.parents = vec![dangling];
+                skip_imported_semantics(imported, blob_store, kin_root)
+            },
+        )
+        .unwrap_err();
+
+        assert!(
+            error.to_string().contains("names parent"),
+            "artifact-only hydration lost its parent-admission guard: {error:#}"
+        );
+        assert!(
+            graph.get_change(&imported_id).unwrap().is_none(),
+            "a refused imported window must leave the graph untouched"
         );
     }
 

--- a/crates/kin-daemon/src/api.rs
+++ b/crates/kin-daemon/src/api.rs
@@ -1624,14 +1624,17 @@ async fn set_scope(
     let scope_task = tokio::task::spawn_blocking(
         move || -> std::result::Result<_, (StatusCode, String)> {
             let _hydration_gate = hydration_gate;
-            // Resolve the ref to a SemanticChangeId using the LOCATE resolve mode
-            // (enrich_semantics=false). Scope-for-retrieval only needs the
-            // base_commit's tree state; the full per-commit semantic-delta enrichment
-            // of its entire ancestry ("Hydrating History: [n/26747]") re-parses and
-            // re-links every ancestor commit — ~10 min on a deep base_commit — and the
-            // session-scope locate path never reads those deltas (it ranks the scoped
-            // entity set with HEAD vectors via `vector_source`). The /locate ref path
-            // already uses this lighter mode.
+            // Resolve the ref through the locate entry point, which hydrates a
+            // not-yet-imported Git ancestry at artifact-only depth. Scope-for-
+            // retrieval only needs the base_commit's tree state: build_graph_at_ref
+            // below takes the file tree from the imported artifact deltas (or from
+            // the Git tree) and rebuilds the scoped entity set by re-parsing it.
+            // The per-commit semantic replay that depth skips ("Hydrating History:
+            // [n/26747]") re-parses and re-links every ancestor commit — ~10 min on
+            // a deep base_commit — and nothing on this path reads the deltas it
+            // produces; the scoped entity set is ranked with HEAD vectors via
+            // `vector_source`. Callers that do read those deltas — history, blame,
+            // review — resolve through the semantic entry points instead.
             let resolved =
             kin_cli::commands::ref_lookup::resolve_ref_importing_git_if_needed_for_locate_with_report(
                 state_clone.graph.as_ref(),


### PR DESCRIPTION
## The stale claim

`crates/kin-daemon/src/api.rs:1626-1634`, verbatim on `main`:

> Resolve the ref to a SemanticChangeId using the LOCATE resolve mode
> (enrich_semantics=false). Scope-for-retrieval only needs the
> base_commit's tree state; the full per-commit semantic-delta enrichment
> of its entire ancestry ("Hydrating History: [n/26747]") re-parses and
> re-links every ancestor commit — ~10 min on a deep base_commit — and the
> session-scope locate path never reads those deltas (it ranks the scoped
> entity set with HEAD vectors via `vector_source`). **The /locate ref path
> already uses this lighter mode.**

There is no lighter mode. On `main` all four entry points in
`crates/kin-cli/src/commands/ref_lookup.rs` — `resolve_ref_importing_git_if_needed`
(:117), `..._for_locate` (:125), `..._with_report` (:133),
`..._for_locate_with_report` (:141) — have byte-identical bodies. Every one
funnels through `:180 hydrate_imported_git_ref` → `:519`, which
unconditionally passes the full enricher
`enrich_imported_changes_with_semantics_checkpointed`. The parameterized
`hydrate_imported_git_ref_with` (:535) receives a different closure only under
`#[cfg(test)]`.

## How it got that way

`269a9644` (2026-06-05, *perf(daemon): set_scope uses locate-mode resolve
(enrich=false)*) added a real `enrich_semantics: bool`, with the `_for_locate`
variants passing `false`, and pointed `set_scope` at the locate variant.

`a27f5d63` (2026-07-10, *Harden history hydration checkpoints*, PR #305,
Linear FIR-1373) deleted the bool, made enrichment unconditional, and collapsed
the four entry points into aliases. That was collateral, not a decision: #305 is
checkpoint resume, topology-safe bounded history windows, and fail-closed
checkpoint reuse. Its refactor replaced the bool with an injectable closure for
the new test seams and pointed every caller at the full closure. The api.rs
comment was left describing the deleted behavior.

Consequence: the deep-base_commit hydration is back on
`POST /session/{id}/scope` and `/locate --ref`.

## Why artifact-only depth is correct for those two paths

Verified against the code, not the 06-05 commit message:

- `build_graph_at_ref_with_repo_inner` (`kin-core/src/ref_view.rs:78`) takes the
  ref's file tree from the replayed **artifact** deltas (kin-db:
  `resolve_file_tree_at_replays_artifact_deltas_for_target_head`) or from the Git
  tree directly, never from entity deltas.
- `rebuild_entity_source_file_layouts` (`ref_view.rs:1046`) re-parses every
  `EntitySource` file in that tree through `IndexPipeline` whenever the replayed
  entity set for the file is empty, so the scoped entity set is reconstructed
  from tree state.
- Co-change is unaffected: `changed_files_from_change`
  (`kin-git/src/cochange.rs:145`) reads `artifact_deltas`.

The callers that *do* read the replayed deltas — `history` and `blame` resolve
their target through `resolve_graph_at`, `review` diffs deltas between refs —
stay on the semantic depth.

## Behavior for non-locate callers

**Not behavior-affecting.** `prepare_ref_importing_git_if_needed_with_report`
keeps its signature and now explicitly requests `HydrationDepth::Semantic`, so
its four production callers — `review.rs:399,418`, `history.rs:98`,
`blame.rs:96`, `api.rs:12463` — resolve exactly as before. Only
`..._for_locate` and `..._for_locate_with_report` change depth, and their only
production callers are `api.rs:1636` (`set_scope`) and `api.rs:3465`
(`/locate --ref`).

## The guard this PR adds, and why it is not optional

Skipping the replay also skips the *only* runtime validation the imported window
ever received. `validate_imported_parent_closure`
(`kin-cli/src/commands/init.rs:1742`) — duplicate ids, parentless changes,
dangling parents, boundary-root collision, cycles in the parent DAG — is private
and called from exactly one place: the top of the enrichment body
(`init.rs:2034`). The similar assertion at `kin-git/src/import.rs:1787` is inside
a `#[test]`. So "locate passes an enricher that does not enrich" would also mean
"locate stops validating the DAG it is about to insert and persist" — and the
daemon does persist it (`save_snapshot()` on `hydrated_git_history`).

### The trade this makes, stated so it is not "simplified" away

The artifact-only path **skips** exactly one thing: the per-commit semantic
replay that reconstructs entity and relation deltas across the ancestry. It must
still **do** parent-closure validation of the window it is about to insert and
persist.

Those two were fused only by accident of implementation — the validation lived
inside the enrichment function. Separating them is the whole point of this PR, and
re-fusing them is the failure mode to guard against: a future change that drops
`admit_imported_changes_for_insert` "because the enricher already validates" would
be correct for the semantic path and silently wrong for the artifact-only one,
which runs no enricher at all. That is the trade — a naive restore of the 06-05
parameterization buys back the performance by paying with graph integrity, and it
looks like a clean win in the diff.

### Why the guard is not a second copy of the validator

The alternative was to duplicate `validate_imported_parent_closure` into
`ref_lookup.rs`. That was rejected: duplicating a hardened invariant into a second
location is **the exact two-places-one-updated failure mode that produced this
ticket** — the api.rs comment and the ref_lookup.rs code drifted apart for five
weeks precisely because one was updated and the other was not. Shipping that as
the fix for this ticket would be self-defeating. A single validator reachable from
both paths beats two copies that drift; where that is not available, a guard at
the write boundary — which is a different question, asked in a different place —
beats a copy of the same question asked twice.

Rather than duplicate that validator, this PR guards the graph write where the
write happens. `admit_imported_changes_for_insert` admits a change only when each
parent is canonical genesis, already present in the graph, or admitted earlier in
the same window. `import_git_history_to_commit_with_blobs` → `import_full` emits
parent-first (`order_selected_oids_parent_first`, tested by
`assert_import_order_is_parent_first`), so that one rule rejects parentless
changes, out-of-window parents, and parent cycles alike — no member of a cycle can
be admitted first. It runs at every depth and is strictly more permissive than
the replay's preflight for windows whose parents are already in the graph, so it
cannot newly reject anything the semantic path accepts today.

## Known boundary this restores along with the perf win — not silent, not fixed here

Artifact-only hydration persists. `set_scope` and `/locate --ref` call
`save_snapshot()` when `hydrated_git_history` is set, so the artifact-only
ancestry becomes part of the durable graph. A later semantic caller does not
upgrade it: `prepare_ref_importing_git_if_needed` only hydrates when
`resolve_ref` *fails*, and once the tip change exists `resolve_ref` succeeds, so
enrichment never runs for that ref again.

Concretely: `locate --ref git:<oid>` on a not-yet-imported commit, then
`kin history <entity> --ref git:<oid>` on the same commit, yields
`No entity matching '<entity>' found` — a misleading error rather than the real
history. `review` at such a ref would diff empty delta sets.

This is the behavior `269a9644` originally shipped and it was live 06-05 →
07-10; it is not new, and it is orthogonal to the entry-point regression this PR
fixes. It is also exactly co-located with the perf win: refs inside the window
`kin init` already imported are enriched and never re-hydrate, so both the
saving and the hazard apply to the same first-touch-of-a-deep-ref case.

It is deliberately **not** fixed here. Detecting "present but artifact-only" from
the change alone is unreliable — a commit that only reflows whitespace in a
source file legitimately produces zero entity deltas — so a cheap heuristic would
fail loud on valid refs. The durable fix is to record the depth a tip was
hydrated at and have a semantic caller either upgrade it or report the graph gap,
which is daemon/hydration-owner work rather than a change to these entry points.
Recommend tracking it as its own issue.

## Fatal vs. warn on enrichment failure — assessed, deliberately unchanged

`a27f5d63` also flipped enrichment failure from `warn!` + continue to
`.with_context(…)?` at `ref_lookup.rs:564-569`. **Keeping it fatal.** Fatal on a
query path is right here because the path is not a query: it mutates and persists
the authoritative graph. Warn-and-continue durably persists an artifact-only
ancestry that `history`, `blame`, and `review` then read as semantic truth with
no signal that anything was lost — the "hide the graph gap" pattern the runtime
standard forbids. It would also defeat the fail-closed checkpoint refusal that
`a27f5d63` existed to add: a `REFUSED hydration checkpoint` is precisely the case
where continuing persists unverified history. Client-input errors stay separately
classified as `RefResolutionError`, so this does not turn bad refs into 500s.

Note the contrast with this PR: artifact-only history is now produced
deliberately, only for callers that do not read the deltas, instead of
accidentally for everyone on enrichment failure.

## Tests

Three added, all in `ref_lookup.rs`:

- `artifact_only_hydration_skips_the_semantic_replay_that_full_hydration_runs` —
  both depths insert the same commits; the semantic tip carries entity deltas,
  the artifact-only tip carries none while keeping its artifact deltas and never
  opening a checkpoint store.
- `locate_entry_points_resolve_at_artifact_only_depth_and_others_stay_semantic` —
  binds each of the four public entry points to its depth.
- `artifact_only_hydration_still_refuses_a_dangling_parent_before_graph_write` —
  a corrupt window is refused with no replay running and no graph write.

**Fail-on-`main` demonstrated in CI, not asserted.** The regression assertion
was expressed against `main`'s unmodified entry points and run through CI on a
throwaway draft (#383, since closed and its branch deleted). On `main`
(`32b592d2`), `Check & Test (ubuntu-latest)` job `88680007150` reports:

```
test commands::ref_lookup::tests::locate_ref_hydration_must_not_run_the_full_semantic_replay ... FAILED
panicked at crates/kin-cli/src/commands/ref_lookup.rs:914:9:
the locate entry point must hydrate at artifact-only depth, but it produced 1 entity deltas
test result: FAILED. 1043 passed; 1 failed
```

That is the regression, measured. On this branch the equivalent assertions pass;
the third test could not run on `main` at all (`skip_imported_semantics` does not
exist there), and it exists to catch a naive restore that drops the guard.

## Verification boundary

Validated through GitHub CI only. No local `cargo build`/`check`/`test`, no
daemon run, and no benchmark was executed: a citable benchmark cohort holds this
machine. `rustfmt --check` clean on both files.

All checks green on this branch, including the three new tests, and including
`locate_ref_resolves_head_and_out_of_window_commits_after_truncated_init` — the
existing end-to-end test that runs `kin locate --ref git:<out-of-window-sha>`
against a truncated init, which is precisely the path this PR changes.

No perf number is claimed here. The ~10 min figure is quoted from `269a9644`
and was not re-measured; what is demonstrated is that the replay no longer runs
on these two paths, not how much wall-clock that saves on any given repo.
