### PR TITLE
Answer rename and deps from graph-owned truth (FIR-1504)

### DIFF
--- a/crates/kin-cli/src/commands/deps.rs
+++ b/crates/kin-cli/src/commands/deps.rs
@@ -2,11 +2,15 @@
 // Copyright 2026 Firelock, LLC
 
 use anyhow::Result;
-use kin_core::registry::KinRegistry;
+use kin_core::registry::{KinRegistry, RegisteredRepo};
 use std::collections::{BTreeMap, HashSet};
-use std::path::Path;
 
 /// Show cross-repo dependencies across all registered Kin repositories.
+///
+/// The answer is projected from the dependency records ingestion wrote for each
+/// repo, not re-derived by parsing manifests at query time. A repo that carries
+/// no records reports that gap rather than having it filled in from whatever
+/// manifests happen to be on disk.
 pub async fn run() -> Result<()> {
     let registry =
         KinRegistry::load().map_err(|e| anyhow::anyhow!("failed to load registry: {}", e))?;
@@ -17,21 +21,20 @@ pub async fn run() -> Result<()> {
         return Ok(());
     }
 
-    // Build a set of known repo IDs for matching
     let known_ids: HashSet<String> = registry.repos.iter().map(|r| r.id.clone()).collect();
 
-    // Detect typed deps for each repo
     let mut repo_deps: BTreeMap<String, Vec<(String, DepType)>> = BTreeMap::new();
     for repo in &registry.repos {
-        let deps = detect_dependencies_for_repo(&repo.path, &known_ids);
-        repo_deps.insert(repo.id.clone(), deps);
+        repo_deps.insert(repo.id.clone(), dependencies_for_repo(repo, &known_ids));
     }
 
     println!("Cross-repo dependencies:\n");
+    let mut unrecorded = Vec::new();
     for (id, deps) in &repo_deps {
         println!("  {}", id);
         if deps.is_empty() {
-            println!("    (no cross-repo dependencies)");
+            println!("    (no cross-repo dependencies recorded)");
+            unrecorded.push(id.clone());
         } else {
             for (name, dep_type) in deps {
                 println!("    -> {} ({})", name, dep_type);
@@ -40,46 +43,68 @@ pub async fn run() -> Result<()> {
         println!();
     }
 
+    if !unrecorded.is_empty() {
+        println!(
+            "note: dependencies are recorded when a repo is registered or re-indexed. If a repo above should have dependencies, re-run `kin init` in it to refresh its records: {}",
+            unrecorded.join(", ")
+        );
+    }
+
     Ok(())
 }
 
-/// Detect deps for a single repo path returning (dep_name, dep_type) pairs.
-pub fn detect_dependencies_for_repo(
-    repo_path: &Path,
+/// Project a registered repo's recorded cross-repo dependencies.
+///
+/// [`RegisteredRepo::dependencies`] is written by the registry at ingestion, so
+/// this is a read of recorded truth. Only dependencies that ingestion resolved
+/// to a repo still present in `known_ids` are reported, so the listing never
+/// names a provider the registry no longer knows.
+pub fn dependencies_for_repo(
+    repo: &RegisteredRepo,
     known_ids: &HashSet<String>,
 ) -> Vec<(String, DepType)> {
-    let mut deps = Vec::new();
+    let mut deps: Vec<(String, DepType)> = repo
+        .dependencies
+        .iter()
+        .filter_map(|dep| {
+            let provider = dep.provider_repo.as_ref()?;
+            known_ids
+                .contains(provider)
+                .then(|| (provider.clone(), DepType::from_source(&dep.source)))
+        })
+        .collect();
 
-    // Cargo git deps
-    let cargo_deps = detect_cargo_git_deps(repo_path);
-    for dep_name in cargo_deps {
-        if let Some(matched) = match_to_known_repo(&dep_name, known_ids) {
-            if !deps.iter().any(|(n, _)| n == &matched) {
-                deps.push((matched, DepType::CargoGit));
-            }
-        }
-    }
-
-    // npm workspace deps
-    let npm_deps = detect_npm_workspace_deps(repo_path);
-    for dep_name in &npm_deps {
-        if let Some(matched) = match_to_known_repo(dep_name, known_ids) {
-            if !deps.iter().any(|(n, _)| n == &matched) {
-                deps.push((matched, DepType::NpmWorkspace));
-            }
-            continue;
-        }
-        // Try scoped npm packages like @kinlab/contracts
-        if let Some(_matched) = match_scoped_npm_to_repo(dep_name, known_ids) {
-            if !deps.iter().any(|(n, _)| n == dep_name) {
-                deps.push((dep_name.clone(), DepType::NpmWorkspace));
-            }
-        }
-    }
-
-    deps.sort_by(|a, b| a.0.cmp(&b.0));
-    deps.dedup_by(|a, b| a.0 == b.0);
+    deps.sort();
+    deps.dedup();
     deps
+}
+
+/// Recorded dependencies for the repo registered at `repo_path`.
+///
+/// Kept for callers that hold a path rather than the registry record; prefer
+/// [`dependencies_for_repo`] when the record is already in hand, since this
+/// re-reads the registry to find it.
+pub fn detect_dependencies_for_repo(
+    repo_path: &std::path::Path,
+    known_ids: &HashSet<String>,
+) -> Vec<(String, DepType)> {
+    let registry = match KinRegistry::load() {
+        Ok(registry) => registry,
+        Err(error) => {
+            tracing::warn!(
+                path = %repo_path.display(),
+                error = %error.to_string(),
+                "registry unreadable; reporting no recorded dependencies"
+            );
+            return Vec::new();
+        }
+    };
+    registry
+        .repos
+        .iter()
+        .find(|repo| repo.path.as_path() == repo_path)
+        .map(|repo| dependencies_for_repo(repo, known_ids))
+        .unwrap_or_default()
 }
 
 /// Format deps as a short suffix string for registry display, e.g. "-> kin-db, kin-vfs-core"
@@ -92,148 +117,150 @@ pub fn format_deps_short(deps: &[(String, DepType)]) -> String {
     }
 }
 
-#[derive(Debug, Clone, PartialEq)]
-pub enum DepType {
-    CargoGit,
-    NpmWorkspace,
+/// Where ingestion observed a dependency.
+///
+/// Carries the recorded source verbatim so the projection reports what was
+/// actually captured rather than collapsing every dependency into one of a
+/// couple of guessed manifest kinds.
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord)]
+pub struct DepType(String);
+
+impl DepType {
+    fn from_source(source: &str) -> Self {
+        Self(source.to_string())
+    }
 }
 
 impl std::fmt::Display for DepType {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        match self {
-            DepType::CargoGit => write!(f, "cargo: git dep"),
-            DepType::NpmWorkspace => write!(f, "npm: workspace"),
-        }
+        let label = match self.0.as_str() {
+            "cargo" => "cargo manifest",
+            "npm" => "npm manifest",
+            "go" => "go module",
+            "protocol" => "protocol import",
+            "dockerfile" => "dockerfile",
+            "compose" => "docker compose",
+            "ci" => "ci workflow",
+            "subprocess" => "runtime subprocess",
+            "http" => "http api",
+            other => other,
+        };
+        write!(f, "{label}")
     }
 }
 
-/// Parse Cargo.toml files in the repo and find dependencies with `git = "..."`.
-fn detect_cargo_git_deps(repo_path: &Path) -> Vec<String> {
-    let mut deps = Vec::new();
+#[cfg(test)]
+mod tests {
+    use super::{dependencies_for_repo, DepType};
+    use kin_core::dependencies::RepoDependency;
+    use kin_core::registry::RegisteredRepo;
+    use std::collections::HashSet;
 
-    // Check root Cargo.toml
-    let cargo_path = repo_path.join("Cargo.toml");
-    if let Ok(content) = std::fs::read_to_string(&cargo_path) {
-        collect_cargo_external_deps(&content, &mut deps);
-    }
-
-    // Check workspace member Cargo.toml files
-    let crates_dir = repo_path.join("crates");
-    if crates_dir.is_dir() {
-        if let Ok(entries) = std::fs::read_dir(&crates_dir) {
-            for entry in entries.flatten() {
-                let member_cargo = entry.path().join("Cargo.toml");
-                if member_cargo.is_file() {
-                    if let Ok(content) = std::fs::read_to_string(&member_cargo) {
-                        collect_cargo_external_deps(&content, &mut deps);
-                    }
-                }
-            }
+    fn repo(path: std::path::PathBuf, dependencies: Vec<RepoDependency>) -> RegisteredRepo {
+        RegisteredRepo {
+            id: "kin".to_string(),
+            path,
+            entities: 0,
+            last_commit: "2026-01-01T00:00:00Z".to_string(),
+            dependencies,
         }
     }
 
-    deps.sort();
-    deps.dedup();
-    deps
-}
-
-/// Extract dependency names that use `git = "..."` (cross-repo deps).
-fn collect_cargo_external_deps(content: &str, deps: &mut Vec<String>) {
-    let mut in_deps_section = false;
-
-    for line in content.lines() {
-        let trimmed = line.trim();
-
-        // Track section headers
-        if trimmed.starts_with('[') {
-            in_deps_section = trimmed.starts_with("[dependencies")
-                || trimmed.starts_with("[dev-dependencies")
-                || trimmed.starts_with("[build-dependencies")
-                || trimmed.starts_with("[workspace.dependencies");
-            continue;
-        }
-
-        if !in_deps_section {
-            continue;
-        }
-
-        // Check for inline git deps: `name = { git = "..." }`
-        if trimmed.contains("git =") || trimmed.contains("git=") {
-            if let Some(dep_name) = trimmed.split('=').next() {
-                let name = dep_name.trim().trim_matches('"');
-                if !name.is_empty() && !name.contains(' ') {
-                    deps.push(name.to_string());
-                }
-            }
-        }
-    }
-}
-
-/// Detect npm workspace / linked dependencies from package.json.
-fn detect_npm_workspace_deps(repo_path: &Path) -> Vec<String> {
-    let mut deps = Vec::new();
-
-    let pkg_path = repo_path.join("package.json");
-    if !pkg_path.is_file() {
-        return deps;
-    }
-
-    let content = match std::fs::read_to_string(&pkg_path) {
-        Ok(c) => c,
-        Err(_) => return deps,
-    };
-
-    let json: serde_json::Value = match serde_json::from_str(&content) {
-        Ok(v) => v,
-        Err(_) => return deps,
-    };
-
-    // Check dependencies, devDependencies for workspace: references
-    for section in ["dependencies", "devDependencies"] {
-        if let Some(obj) = json.get(section).and_then(|v| v.as_object()) {
-            for (name, version) in obj {
-                let ver_str = version.as_str().unwrap_or("");
-                if ver_str.starts_with("workspace:")
-                    || ver_str.starts_with("link:")
-                    || ver_str.starts_with("file:")
-                {
-                    deps.push(name.clone());
-                }
-            }
+    fn dep(name: &str, provider: &str, source: &str) -> RepoDependency {
+        RepoDependency {
+            name: name.to_string(),
+            provider_repo: Some(provider.to_string()),
+            source: source.to_string(),
         }
     }
 
-    deps
-}
+    /// `kin deps` answers from the dependency records ingestion wrote, so a
+    /// manifest sitting in the working tree cannot steer the answer. The
+    /// manifest here contradicts the records on purpose: anything that re-derives
+    /// the answer by parsing it reports kin-vfs and fails.
+    #[test]
+    fn deps_project_recorded_truth_not_the_manifest_on_disk() {
+        let dir = tempfile::tempdir().unwrap();
+        std::fs::write(
+            dir.path().join("Cargo.toml"),
+            "[dependencies]\nkin-vfs = { git = \"git@example.invalid:kin-vfs.git\" }\n",
+        )
+        .unwrap();
 
-/// Try to match a dependency name to a known registered repo ID.
-fn match_to_known_repo(dep_name: &str, known_ids: &HashSet<String>) -> Option<String> {
-    // Exact match
-    if known_ids.contains(dep_name) {
-        return Some(dep_name.to_string());
+        let repo = repo(
+            dir.path().to_path_buf(),
+            vec![dep("kin-db", "kin-db", "cargo")],
+        );
+        let known: HashSet<String> = ["kin-db", "kin-vfs"]
+            .iter()
+            .map(|s| s.to_string())
+            .collect();
+
+        assert_eq!(
+            dependencies_for_repo(&repo, &known),
+            vec![("kin-db".to_string(), DepType("cargo".to_string()))],
+        );
     }
 
-    // Try matching crate name to repo (e.g., "kin-vfs-core" crate from "kin-vfs" repo)
-    for id in known_ids {
-        if dep_name.starts_with(id.as_str()) {
-            let rest = &dep_name[id.len()..];
-            if rest.is_empty() || rest.starts_with('-') {
-                return Some(id.clone());
-            }
+    /// A repo with no recorded dependencies reports none — the gap is surfaced
+    /// rather than filled in from the manifests lying next to it.
+    #[test]
+    fn deps_report_the_gap_rather_than_scraping_manifests() {
+        let dir = tempfile::tempdir().unwrap();
+        std::fs::write(
+            dir.path().join("Cargo.toml"),
+            "[dependencies]\nkin-db = { git = \"git@example.invalid:kin-db.git\" }\n",
+        )
+        .unwrap();
+        std::fs::write(
+            dir.path().join("package.json"),
+            "{\"dependencies\":{\"@kinlab/contracts\":\"workspace:*\"}}",
+        )
+        .unwrap();
+
+        let repo = repo(dir.path().to_path_buf(), Vec::new());
+        let known: HashSet<String> = ["kin-db", "kinlab"].iter().map(|s| s.to_string()).collect();
+
+        assert!(dependencies_for_repo(&repo, &known).is_empty());
+    }
+
+    /// A recorded provider the registry no longer knows is dropped rather than
+    /// listed as a live cross-repo edge.
+    #[test]
+    fn deps_drop_providers_the_registry_no_longer_knows() {
+        let dir = tempfile::tempdir().unwrap();
+        let repo = repo(
+            dir.path().to_path_buf(),
+            vec![
+                dep("kin-db", "kin-db", "cargo"),
+                dep("retired-crate", "retired-repo", "cargo"),
+            ],
+        );
+        let known: HashSet<String> = ["kin-db"].iter().map(|s| s.to_string()).collect();
+
+        assert_eq!(
+            dependencies_for_repo(&repo, &known),
+            vec![("kin-db".to_string(), DepType("cargo".to_string()))],
+        );
+    }
+
+    /// Every recorded source family renders with a label, including ones the
+    /// retired two-variant enum could not express.
+    #[test]
+    fn dep_type_labels_every_recorded_source() {
+        for (source, label) in [
+            ("cargo", "cargo manifest"),
+            ("npm", "npm manifest"),
+            ("go", "go module"),
+            ("protocol", "protocol import"),
+            ("dockerfile", "dockerfile"),
+            ("compose", "docker compose"),
+            ("ci", "ci workflow"),
+            ("subprocess", "runtime subprocess"),
+            ("http", "http api"),
+        ] {
+            assert_eq!(DepType::from_source(source).to_string(), label);
         }
+        assert_eq!(DepType::from_source("future").to_string(), "future");
     }
-
-    None
-}
-
-/// Try to match a scoped npm package like `@kinlab/contracts` to a known repo.
-fn match_scoped_npm_to_repo(dep_name: &str, known_ids: &HashSet<String>) -> Option<String> {
-    if let Some(scoped) = dep_name.strip_prefix('@') {
-        if let Some(scope) = scoped.split('/').next() {
-            if known_ids.contains(scope) {
-                return Some(scope.to_string());
-            }
-        }
-    }
-    None
 }

--- a/crates/kin-cli/src/commands/rename.rs
+++ b/crates/kin-cli/src/commands/rename.rs
@@ -3,10 +3,10 @@
 
 use anyhow::{Context, Result};
 use kin_model::{
-    Entity, EntityFilter, EntityId, GraphNodeId, GraphStore, RelationKind, SourceSpan,
+    Entity, EntityFilter, EntityId, FilePathId, GraphNodeId, GraphStore, RelationKind, SourceSpan,
 };
 use serde::{Deserialize, Serialize};
-use std::collections::{BTreeSet, HashSet};
+use std::collections::{BTreeSet, HashMap, HashSet};
 use std::path::{Path, PathBuf};
 
 #[derive(Serialize)]
@@ -189,10 +189,19 @@ fn build_rename_plan(
 
     let mut edits = Vec::new();
     let mut seen = HashSet::new();
+    let mut reader = GraphSourceReader::new(layout, graph)?;
+    // Gaps are collected in a sorted set so a plan reports the same warnings in
+    // the same order regardless of relation iteration order.
+    let mut reference_gaps = BTreeSet::new();
 
     if let (Some(file_origin), Some(span)) = (&target.file_origin, &target.span) {
+        // A gap on the declaration file is fatal: without graph-owned bytes for
+        // it there is no trustworthy anchor for any edit, and emitting a plan
+        // built from whatever the working tree happens to hold is exactly the
+        // silent-miscoordinate failure this path must not have.
         add_first_span_edit(
             layout,
+            &mut reader,
             &file_origin.0,
             span.start_byte,
             span.end_byte,
@@ -201,7 +210,14 @@ fn build_rename_plan(
             "declaration".to_string(),
             &mut edits,
             &mut seen,
-        )?;
+        )
+        .map_err(|GraphContentGap(reason)| {
+            anyhow::anyhow!(
+                "graph gap: cannot anchor the rename of '{}' because graph truth cannot supply the contents of its declaration file '{}': {reason}. Rename coordinates are measured against graph-owned bytes, never the working tree — re-ingest the repo so the file's content is recorded in graph truth",
+                target.name,
+                file_origin.0
+            )
+        })?;
     } else {
         warnings.push(
             "target entity has no stable file/span; declaration edit could not be anchored"
@@ -221,8 +237,12 @@ fn build_rename_plan(
         if let Some(source_id) = rel.src.as_entity() {
             if let Some(source) = graph.get_entity(&source_id)? {
                 if let (Some(file_origin), Some(span)) = (&source.file_origin, &source.span) {
-                    add_span_edits(
+                    // A gap on a referencing file leaves the plan incomplete
+                    // rather than unusable, so it is reported as a named
+                    // warning. It is never backfilled from the working tree.
+                    if let Err(GraphContentGap(reason)) = add_span_edits(
                         layout,
+                        &mut reader,
                         &file_origin.0,
                         span.start_byte,
                         span.end_byte,
@@ -231,11 +251,18 @@ fn build_rename_plan(
                         relation_reason(&[rel.kind]),
                         &mut edits,
                         &mut seen,
-                    )?;
+                    ) {
+                        reference_gaps.insert(format!(
+                            "graph gap: references in '{}' were not planned because graph truth cannot supply its contents: {reason}",
+                            file_origin.0
+                        ));
+                    }
                 }
             }
         }
     }
+
+    warnings.extend(reference_gaps);
 
     edits.sort_by(|left, right| {
         left.file
@@ -249,7 +276,7 @@ fn build_rename_plan(
             .push("no semantically anchored occurrences were found for this symbol".to_string());
     } else {
         warnings.push(
-            "plan is token-boundary based inside semantically selected declarations and reference files; review the workspace diff after applying"
+            "coordinates are token-boundary matches measured against graph-owned file content inside semantically selected declaration and reference spans; a working tree that has drifted from graph truth must be reconciled before the plan is applied"
                 .to_string(),
         );
     }
@@ -358,8 +385,9 @@ fn resolve_target(
     Ok(matches.into_iter().next())
 }
 
-fn add_span_edits(
+fn add_span_edits<G: GraphStore>(
     layout: &kin_core::KinLayout,
+    reader: &mut GraphSourceReader<'_, G>,
     rel_path: &str,
     start_byte: usize,
     end_byte: usize,
@@ -368,9 +396,12 @@ fn add_span_edits(
     reason: String,
     edits: &mut Vec<RenameEditJson>,
     seen: &mut HashSet<String>,
-) -> Result<()> {
-    let content = read_repo_file(layout, rel_path)?;
-    for occurrence in find_token_occurrences(&content, old_name, Some((start_byte, end_byte))) {
+) -> Result<(), GraphContentGap> {
+    let occurrences = {
+        let content = reader.content(rel_path)?;
+        find_token_occurrences(content, old_name, Some((start_byte, end_byte)))
+    };
+    for occurrence in occurrences {
         push_edit(
             layout,
             rel_path,
@@ -388,8 +419,9 @@ fn add_span_edits(
     Ok(())
 }
 
-fn add_first_span_edit(
+fn add_first_span_edit<G: GraphStore>(
     layout: &kin_core::KinLayout,
+    reader: &mut GraphSourceReader<'_, G>,
     rel_path: &str,
     start_byte: usize,
     end_byte: usize,
@@ -398,13 +430,14 @@ fn add_first_span_edit(
     reason: String,
     edits: &mut Vec<RenameEditJson>,
     seen: &mut HashSet<String>,
-) -> Result<()> {
-    let content = read_repo_file(layout, rel_path)?;
-    if let Some(occurrence) =
-        find_token_occurrences(&content, old_name, Some((start_byte, end_byte)))
+) -> Result<(), GraphContentGap> {
+    let occurrence = {
+        let content = reader.content(rel_path)?;
+        find_token_occurrences(content, old_name, Some((start_byte, end_byte)))
             .into_iter()
             .next()
-    {
+    };
+    if let Some(occurrence) = occurrence {
         push_edit(
             layout,
             rel_path,
@@ -451,9 +484,100 @@ fn push_edit(
     });
 }
 
-fn read_repo_file(layout: &kin_core::KinLayout, rel_path: &str) -> Result<String> {
-    let path = kin_core::source_dir(layout).join(rel_path);
-    Ok(std::fs::read_to_string(path)?)
+/// A file the graph cannot supply, carrying the reason it could not.
+///
+/// Kept distinct from a plan-level error so a gap in one referencing file is
+/// reported in the plan's warnings while a gap on the declaration file, which
+/// no plan can be anchored without, fails the command outright.
+struct GraphContentGap(String);
+
+/// Supplies the file bytes a rename plan's coordinates are measured against,
+/// resolved from graph-owned truth alone.
+///
+/// Rename is a mutation-planning authority path: every line and column it emits
+/// becomes an edit. Measuring them against the working tree makes a tree that
+/// has drifted from the graph — an un-ingested edit, a stale checkout, a
+/// partially reconciled projection — silently yield coordinates that point at
+/// the wrong bytes. So content is addressed by the hash the graph recorded for
+/// the file and read from the content-addressed blob store, which verifies the
+/// bytes against that address on read. A file the graph cannot supply is
+/// reported as a gap; it is never filled in from disk.
+struct GraphSourceReader<'a, G: GraphStore> {
+    layout: &'a kin_core::KinLayout,
+    graph: &'a G,
+    blobs: kin_blobs::BlobStore,
+    contents: HashMap<String, Result<String, String>>,
+}
+
+impl<'a, G: GraphStore> GraphSourceReader<'a, G> {
+    fn new(layout: &'a kin_core::KinLayout, graph: &'a G) -> Result<Self> {
+        Ok(Self {
+            layout,
+            graph,
+            blobs: kin_blobs::BlobStore::new(layout.objects_dir()).context(
+                "graph blob store is unavailable; rename cannot read graph-owned source",
+            )?,
+            contents: HashMap::new(),
+        })
+    }
+
+    /// Graph-recorded content of `rel_path`, or the gap that prevents it.
+    fn content(&mut self, rel_path: &str) -> Result<&str, GraphContentGap> {
+        if !self.contents.contains_key(rel_path) {
+            let resolved = self.resolve(rel_path).map_err(|err| err.to_string());
+            self.contents.insert(rel_path.to_string(), resolved);
+        }
+        match &self.contents[rel_path] {
+            Ok(content) => Ok(content.as_str()),
+            Err(reason) => Err(GraphContentGap(reason.clone())),
+        }
+    }
+
+    fn resolve(&self, rel_path: &str) -> Result<String> {
+        let file_id = FilePathId::new(rel_path);
+        let hash = self.recorded_hash(&file_id)?;
+        let blob_hash = kin_blobs::Hash256(*hash.as_bytes());
+        let bytes = self.blobs.read(&blob_hash).with_context(|| {
+            format!("graph blob for file '{rel_path}' is unavailable (hash {blob_hash})")
+        })?;
+        String::from_utf8(bytes).with_context(|| {
+            format!("graph-owned content for file '{rel_path}' is not valid UTF-8")
+        })
+    }
+
+    /// The content hash graph truth records for `file_id`, preferring the
+    /// graph's file-layout store and falling back to the file tree at the
+    /// current branch head. Both are graph reads; neither consults the tree.
+    fn recorded_hash(&self, file_id: &FilePathId) -> Result<kin_model::Hash256> {
+        if let Some(hash) = self.graph.get_file_hash(file_id)? {
+            return Ok(hash);
+        }
+
+        let branch_name = kin_core::read_current_branch(self.layout)?;
+        let branch = match self.graph.get_branch(&branch_name)? {
+            Some(branch) => branch,
+            None => self
+                .graph
+                .list_branches()?
+                .into_iter()
+                .next()
+                .ok_or_else(|| {
+                    anyhow::anyhow!(
+                        "graph records no content hash for file '{}' and no branch is available to resolve one",
+                        file_id.0
+                    )
+                })?,
+        };
+        let genesis = kin_core::build_genesis_change();
+        let tree = kin_core::build_file_tree(self.graph, &genesis.id, &branch.head)?;
+        tree.get(file_id).copied().ok_or_else(|| {
+            anyhow::anyhow!(
+                "file '{}' is not in the graph file tree at branch '{}'",
+                file_id.0,
+                branch.name
+            )
+        })
+    }
 }
 
 #[derive(Clone, Copy)]
@@ -708,6 +832,144 @@ fn unique_file_count(edits: &[RenameEditJson]) -> usize {
 #[cfg(test)]
 mod tests {
     use super::{build_rename_response, RenameRequest};
+    use kin_db::InMemoryGraph;
+    use kin_model::{
+        ArtifactDelta, ArtifactDeltaKind, AuthorId, Branch, BranchName, ChangeStore, Entity,
+        EntityId, EntityKind, EntityMetadata, EntityRole, EntityStore, FilePathId,
+        FingerprintAlgorithm, GraphNodeId, Hash256, LanguageId, Relation, RelationId, RelationKind,
+        RelationOrigin, SemanticChange, SemanticChangeId, SemanticFingerprint, SourceSpan,
+        Timestamp, Visibility,
+    };
+
+    struct Fixture {
+        _temp: tempfile::TempDir,
+        repo: std::path::PathBuf,
+        layout: kin_core::KinLayout,
+        graph: InMemoryGraph,
+    }
+
+    /// Build a repo whose graph owns the content of `graph_files`.
+    ///
+    /// Each file's bytes are written to the content-addressed blob store and
+    /// recorded on a change, which is exactly how ingestion establishes the
+    /// content a rename plan's coordinates must be measured against.
+    fn fixture(graph_files: &[(&str, &str)]) -> Fixture {
+        let temp = tempfile::tempdir().unwrap();
+        let repo = temp.path().to_path_buf();
+        let kin_root = repo.join(".kin");
+        std::fs::create_dir_all(kin_root.join("objects")).unwrap();
+        let layout = kin_core::KinLayout::new(kin_root);
+        let graph = InMemoryGraph::new();
+
+        let genesis = kin_core::build_genesis_change();
+        graph.create_change(&genesis).unwrap();
+
+        let blobs = kin_blobs::BlobStore::new(layout.objects_dir()).unwrap();
+        let mut artifact_deltas = Vec::new();
+        let mut projected_files = Vec::new();
+        for (path, content) in graph_files {
+            let hash = blobs.write(content.as_bytes()).unwrap();
+            let file_id = FilePathId::new(*path);
+            artifact_deltas.push(ArtifactDelta {
+                file_id: file_id.clone(),
+                kind: ArtifactDeltaKind::Added,
+                old_hash: None,
+                new_hash: Some(Hash256::from_bytes(hash.0)),
+            });
+            projected_files.push(file_id);
+        }
+
+        let branch_name = BranchName::new("main");
+        let change_id = SemanticChangeId::from_hash(Hash256::from_bytes([0x42; 32]));
+        graph
+            .create_change(&SemanticChange {
+                id: change_id,
+                parents: vec![genesis.id],
+                timestamp: Timestamp::now(),
+                author: AuthorId::new("test"),
+                message: "seed graph-owned source".to_string(),
+                entity_deltas: vec![],
+                relation_deltas: vec![],
+                artifact_deltas,
+                projected_files,
+                spec_link: None,
+                evidence: vec![],
+                risk_summary: None,
+                authored_on: Some(branch_name.clone()),
+            })
+            .unwrap();
+        graph
+            .create_branch(&Branch {
+                name: branch_name.clone(),
+                head: change_id,
+            })
+            .unwrap();
+        kin_core::write_current_branch(&layout, &branch_name).unwrap();
+
+        Fixture {
+            _temp: temp,
+            repo,
+            layout,
+            graph,
+        }
+    }
+
+    fn entity(name: &str, file: &str, span: SourceSpan) -> Entity {
+        Entity {
+            id: EntityId::new(),
+            kind: EntityKind::Function,
+            name: name.to_string(),
+            language: LanguageId::Rust,
+            fingerprint: SemanticFingerprint {
+                algorithm: FingerprintAlgorithm::V1TreeSitter,
+                ast_hash: Hash256::from_bytes([0; 32]),
+                signature_hash: Hash256::from_bytes([0; 32]),
+                behavior_hash: Hash256::from_bytes([0; 32]),
+                equivalence_hash: Hash256::from_bytes([0; 32]),
+                stability_score: 1.0,
+            },
+            file_origin: Some(FilePathId::new(file)),
+            span: Some(span),
+            signature: name.to_string(),
+            visibility: Visibility::Public,
+            role: EntityRole::Source,
+            doc_summary: None,
+            metadata: EntityMetadata::default(),
+            lineage_parent: None,
+            created_in: None,
+            superseded_by: None,
+        }
+    }
+
+    fn span(file: &str, content: &str, start_line: u32) -> SourceSpan {
+        SourceSpan {
+            file: FilePathId::new(file),
+            start_byte: 0,
+            end_byte: content.len(),
+            start_line,
+            start_col: 0,
+            end_line: start_line + content.lines().count() as u32,
+            end_col: 0,
+        }
+    }
+
+    fn rename_json(fixture: &Fixture, symbol: &str) -> String {
+        build_rename_response(
+            &fixture.layout,
+            &fixture.graph,
+            &RenameRequest {
+                symbol: symbol.to_string(),
+                new_name: "renamed_symbol".to_string(),
+                file: None,
+                line: None,
+                column: None,
+                json: true,
+            },
+        )
+        .unwrap()
+        .json
+        .expect("rename plan json")
+    }
 
     /// A `kin rename` plan may only anchor edits on graph-owned truth: the
     /// declaration span and graph relation edges. A caller that lives in the
@@ -716,66 +978,102 @@ mod tests {
     /// tree.
     #[test]
     fn rename_plan_edits_come_from_graph_not_source_tree_scan() {
-        use kin_db::InMemoryGraph;
-        use kin_model::{
-            Entity, EntityId, EntityKind, EntityMetadata, EntityRole, EntityStore, FilePathId,
-            FingerprintAlgorithm, Hash256, LanguageId, SemanticFingerprint, SourceSpan, Visibility,
-        };
-
-        let dir = tempfile::tempdir().unwrap();
-        let repo = dir.path();
-        std::fs::create_dir_all(repo.join(".kin")).unwrap();
-        let layout = kin_core::KinLayout::new(repo.join(".kin"));
-
         let decl_src = "fn probe_symbol() -> i32 { 0 }\n";
-        std::fs::write(repo.join("decl.rs"), decl_src).unwrap();
+        let caller_src = "pub fn linked() -> i32 { probe_symbol() }\n";
+        let fixture = fixture(&[("decl.rs", decl_src), ("caller.rs", caller_src)]);
+
         // A caller present only in the working tree, never linked into the graph.
         // The retired scan would have planned edits here off the `use` import.
         std::fs::write(
-            repo.join("disk_only_caller.rs"),
+            fixture.repo.join("disk_only_caller.rs"),
             "use crate::decl::probe_symbol;\npub fn disk_only() -> i32 { probe_symbol() }\n",
         )
         .unwrap();
 
-        let target = Entity {
-            id: EntityId::new(),
-            kind: EntityKind::Function,
-            name: "probe_symbol".to_string(),
-            language: LanguageId::Rust,
-            fingerprint: SemanticFingerprint {
-                algorithm: FingerprintAlgorithm::V1TreeSitter,
-                ast_hash: Hash256::from_bytes([0; 32]),
-                signature_hash: Hash256::from_bytes([0; 32]),
-                behavior_hash: Hash256::from_bytes([0; 32]),
-                equivalence_hash: kin_model::Hash256::from_bytes([0; 32]),
-                stability_score: 1.0,
-            },
-            file_origin: Some(FilePathId::new("decl.rs")),
-            span: Some(SourceSpan {
-                file: FilePathId::new("decl.rs"),
-                start_byte: 0,
-                end_byte: decl_src.len(),
-                start_line: 1,
-                start_col: 0,
-                end_line: 1,
-                end_col: decl_src.len() as u32,
-            }),
-            signature: "probe_symbol".to_string(),
-            visibility: Visibility::Public,
-            role: EntityRole::Source,
-            doc_summary: None,
-            metadata: EntityMetadata::default(),
-            lineage_parent: None,
-            created_in: None,
-            superseded_by: None,
-        };
+        let target = entity("probe_symbol", "decl.rs", span("decl.rs", decl_src, 1));
+        let caller = entity("linked", "caller.rs", span("caller.rs", caller_src, 1));
+        fixture.graph.upsert_entity(&target).unwrap();
+        fixture.graph.upsert_entity(&caller).unwrap();
+        fixture
+            .graph
+            .upsert_relation(&Relation {
+                id: RelationId::new(),
+                kind: RelationKind::Calls,
+                src: GraphNodeId::Entity(caller.id),
+                dst: GraphNodeId::Entity(target.id),
+                confidence: 1.0,
+                origin: RelationOrigin::Parsed,
+                created_in: None,
+                import_source: None,
+                evidence: Vec::new(),
+            })
+            .unwrap();
 
-        let graph = InMemoryGraph::new();
-        graph.upsert_entity(&target).unwrap();
+        let json = rename_json(&fixture, "probe_symbol");
 
-        let response = build_rename_response(
-            &layout,
-            &graph,
+        // The graph-anchored declaration edit is present...
+        assert!(
+            json.contains("\"reason\":\"declaration\""),
+            "graph-anchored declaration edit must be present: {json}"
+        );
+        // ...so is the edit for the caller the graph links in...
+        assert!(
+            json.contains("caller.rs"),
+            "graph-linked caller must receive an edit: {json}"
+        );
+        // ...and no edit is planned for the working-tree-only caller.
+        assert!(
+            !json.contains("disk_only_caller.rs"),
+            "rename must not plan edits discovered by scanning the raw source tree: {json}"
+        );
+    }
+
+    /// The coordinates in a rename plan are the edit. They must be measured
+    /// against the bytes graph truth records for a file, never against whatever
+    /// the working tree currently holds — a tree that has drifted from the graph
+    /// otherwise yields a plan whose line/column numbers point at the wrong
+    /// bytes, silently, on a mutation-planning path.
+    #[test]
+    fn rename_plan_coordinates_come_from_graph_content_not_the_working_tree() {
+        let graph_src = "fn probe_symbol() -> i32 { 0 }\n";
+        let fixture = fixture(&[("decl.rs", graph_src)]);
+
+        // The working tree has drifted: same declaration, three lines lower.
+        // Reading it would place the declaration edit on line 4.
+        std::fs::write(fixture.repo.join("decl.rs"), format!("\n\n\n{graph_src}")).unwrap();
+
+        let target = entity("probe_symbol", "decl.rs", span("decl.rs", graph_src, 1));
+        fixture.graph.upsert_entity(&target).unwrap();
+
+        let json = rename_json(&fixture, "probe_symbol");
+
+        assert!(
+            json.contains("\"startLine\":1"),
+            "declaration edit must be anchored on graph-owned content (line 1): {json}"
+        );
+        assert!(
+            !json.contains("\"startLine\":4"),
+            "declaration edit must not be anchored on the drifted working tree (line 4): {json}"
+        );
+    }
+
+    /// When graph truth cannot supply the declaration file's content there is no
+    /// trustworthy anchor for any edit. The command must say so rather than
+    /// quietly measuring coordinates against the working tree.
+    #[test]
+    fn rename_reports_the_graph_gap_instead_of_reading_the_working_tree() {
+        let decl_src = "fn probe_symbol() -> i32 { 0 }\n";
+        // Nothing is seeded into graph-owned content for decl.rs...
+        let fixture = fixture(&[("unrelated.rs", "fn other() {}\n")]);
+        // ...even though the working tree has a perfectly readable copy.
+        std::fs::write(fixture.repo.join("decl.rs"), decl_src).unwrap();
+
+        let target = entity("probe_symbol", "decl.rs", span("decl.rs", decl_src, 1));
+        fixture.graph.upsert_entity(&target).unwrap();
+
+        let err = build_rename_response(
+            &fixture.layout,
+            &fixture.graph,
             &RenameRequest {
                 symbol: "probe_symbol".to_string(),
                 new_name: "renamed_symbol".to_string(),
@@ -785,18 +1083,10 @@ mod tests {
                 json: true,
             },
         )
-        .unwrap();
-        let json = response.json.expect("rename plan json");
+        .expect_err("a graph gap on the declaration file must fail loud");
+        let err = format!("{err:#}");
 
-        // The graph-anchored declaration edit is present...
-        assert!(
-            json.contains("\"reason\":\"declaration\""),
-            "graph-anchored declaration edit must be present: {json}"
-        );
-        // ...and no edit is planned for the working-tree-only caller.
-        assert!(
-            !json.contains("disk_only_caller.rs"),
-            "rename must not plan edits discovered by scanning the raw source tree: {json}"
-        );
+        assert!(err.contains("graph gap"), "{err}");
+        assert!(err.contains("decl.rs"), "{err}");
     }
 }

--- a/scripts/zero-file-search-allowlist.json
+++ b/scripts/zero-file-search-allowlist.json
@@ -106,30 +106,6 @@
       "expiration": "2026-12-31"
     },
     {
-      "file": "crates/kin-cli/src/commands/rename.rs",
-      "reason": "PENDING FOUNDER DECISION: the rename plan's file SET is graph-derived, but its edit COORDINATES are not. read_repo_file reads the raw working tree and find_token_occurrences lexically scans those bytes to produce every line/col in the plan, so a tree that has drifted from graph truth yields silently wrong or zero edits with no gap report. A graph-native path already exists (graph.rs get_file_hash -> BlobStore, which bails loud on miss). Not fixed here: routing rename through it is a behavior change owned by another lane. Pinned to the single known read so any additional filesystem access in this module fails the guard",
-      "owner": "kin-cli",
-      "expiration": "2026-09-30",
-      "allow_match": [
-        "std::fs::read_to_string(path)"
-      ]
-    },
-    {
-      "file": "crates/kin-cli/src/commands/deps.rs",
-      "reason": "PENDING FOUNDER DECISION: kin deps answers a cross-repo dependency query by scraping Cargo.toml/package.json and line-scanning for 'git =' entries; the graph is never consulted. xref.rs routes users here on a graph miss, so a compliant command's gap path hands off to this one. Not fixed here: making deps graph-backed, or reclassifying it as an ingestion-boundary command that is not an authority path, is a product decision. Pinned to the known manifest reads so any additional filesystem access in this module fails the guard",
-      "owner": "kin-cli",
-      "expiration": "2026-09-30",
-      "allow_match": [
-        "std::fs::read_to_string(&cargo_path)",
-        "crates_dir.is_dir()",
-        "std::fs::read_dir(&crates_dir)",
-        "member_cargo.is_file()",
-        "std::fs::read_to_string(&member_cargo)",
-        "pkg_path.is_file()",
-        "std::fs::read_to_string(&pkg_path)"
-      ]
-    },
-    {
       "file": "crates/kin-mcp/src/handlers/common.rs",
       "reason": "Layout discovery boundary: candidate_source_roots only probes KIN_SOURCE_ROOT and the cwd for a .kin layout so the BlobStore can be located. Entity bodies are still fetched by graph-recorded hash and re-digested before use, and a miss reports graph-miss rather than falling back to the working tree",
       "owner": "kin-mcp",


### PR DESCRIPTION
Closes the two genuine Zero File-Search authority-path violations that the widened guard in #380 surfaced. Both were behind explicit allowlist entries; both entries are removed here.

## 1. `rename.rs` — coordinates came from the working tree

`read_repo_file` read the raw source root and `find_token_occurrences` lexed those bytes to produce every line and column in the plan. The file *set* was graph-derived, so the plan looked graph-backed — but its *coordinates* were not. On a mutation-planning path a tree that has drifted from graph truth then yields silently wrong or missing edits.

Coordinates are now measured against the bytes graph truth records for a file: the content hash from the graph's file-layout store (falling back to the file tree at the current branch head) addresses a read from the content-addressed blob store, which verifies the bytes against that address on read. This is the same graph-native path `kin graph source` already uses.

Gap handling is explicit, never a disk fallback:
- declaration file unavailable → the command fails with a `graph gap:` error naming the file, because no edit can be anchored without it;
- referencing file unavailable → a named warning in the plan, so an incomplete plan says which file it could not cover.

## 2. `deps.rs` — manifests re-scraped at query time

`kin deps` parsed `Cargo.toml`/`package.json` and line-matched `git =` entries. That structure is already recorded at ingestion: `KinRegistry::upsert_with_remote` stores resolved `RepoDependency` records per repo (via `kin-core/src/dependencies.rs`, which the guard already classifies as an ingestion boundary). `deps` now projects those records.

Consequences, stated plainly:
- coverage improves — the records carry all nine recorded source families (cargo, npm, go, protocol, dockerfile, compose, ci, subprocess, http) and come from a real TOML parse, where the scrape recognized only cargo-git and npm-workspace deps from a line match;
- freshness changes — the answer is now what ingestion recorded, so a repo registered before a sibling repo existed reports no edge until it is re-registered. The old scrape re-derived at query time and so looked fresher. The output prints an explicit note naming every repo with no records rather than papering the gap over by re-deriving.

Known limitation of the store, stated rather than hidden: `RegisteredRepo.dependencies` cannot distinguish "none detected" from "never detected". An empty record set means only that ingestion wrote no dependency rows for that repo — it does not prove the repo has no cross-repo dependencies. The note in the output says which repos are in that state and how to refresh them; it does not claim to know which of the two cases applies.

## Falsification

Each test fails before the change and passes after:
- `rename_plan_coordinates_come_from_graph_content_not_the_working_tree` — graph content puts the declaration on line 1, the drifted working tree puts it on line 4; the plan must say 1.
- `rename_reports_the_graph_gap_instead_of_reading_the_working_tree` — no graph-owned content for the declaration file, but a perfectly readable copy on disk; the command must fail loud rather than read it.
- `rename_plan_edits_come_from_graph_not_source_tree_scan` — extended to assert a graph-linked caller *does* get an edit while a working-tree-only caller does not.
- `deps_project_recorded_truth_not_the_manifest_on_disk` — the on-disk manifest names `kin-vfs`, the records name `kin-db`; the answer must be `kin-db`.
- `deps_report_the_gap_rather_than_scraping_manifests`, `deps_drop_providers_the_registry_no_longer_knows`, `dep_type_labels_every_recorded_source`.

## Not fixed here

Reference-site coordinates still come from a token-boundary match inside the graph-recorded span rather than from a per-occurrence graph record. `kin_model::RelationEvidence.source_span` exists but `kin-index/src/linker.rs` never populates it — every construction site is `..RelationEvidence::default()`. Populating it is a parser/linker change outside this change's scope.
