### PR TITLE
Follow MCP workspace-root changes after a repository is bound

### DIFF
--- a/crates/kin-cli/src/commands/mcp.rs
+++ b/crates/kin-cli/src/commands/mcp.rs
@@ -28,8 +28,9 @@ pub async fn start(global: bool, repo: Option<PathBuf>) -> Result<()> {
         );
     }
 
-    if let Some(repo_dir) = resolve_repo_override(repo) {
-        if let Err(err) = std::env::set_current_dir(&repo_dir) {
+    let repo_override = resolve_repo_override(repo);
+    if let Some(repo_dir) = &repo_override {
+        if let Err(err) = std::env::set_current_dir(repo_dir) {
             eprintln!(
                 "Kin MCP: --repo/KIN_MCP_REPO path {} could not be used as the working directory \
                  ({err}); continuing from the launch directory.",
@@ -39,10 +40,11 @@ pub async fn start(global: bool, repo: Option<PathBuf>) -> Result<()> {
     }
 
     let cwd = std::env::current_dir().unwrap_or_else(|_| PathBuf::from("."));
-    match bind_daemon_for_repo_dir(&cwd).await {
+    let bound_at_start = match bind_daemon_for_repo_dir(&cwd).await {
         Ok(daemon_url) => {
             eprintln!("{}", session_authority_notice());
             eprintln!("Kin MCP: forwarding graph tools to repo daemon at {daemon_url}");
+            true
         }
         Err(reason) => {
             eprintln!(
@@ -51,8 +53,9 @@ pub async fn start(global: bool, repo: Option<PathBuf>) -> Result<()> {
                  run `kin init .`, relaunch inside a Kin repository, or pass --repo <path> (or set \
                  KIN_MCP_REPO=<path>)."
             );
+            false
         }
-    }
+    };
 
     let mut config = build_mcp_start_config();
     let profile_tools: Option<&'static [&'static str]> =
@@ -80,9 +83,17 @@ pub async fn start(global: bool, repo: Option<PathBuf>) -> Result<()> {
     // reach the open repo), and again whenever the client reports that its
     // workspace changed, so a window that moves to another folder does not keep
     // being answered from the folder it left.
+    //
+    // An explicit --repo/KIN_MCP_REPO that bound successfully is an operator
+    // decision that workspace roots must not quietly overrule, so that pin never
+    // follows the client to another repository. It still refuses to answer for
+    // one: the binder reports the disagreement and the server fails loud, rather
+    // than serving the pinned repository's graph for a workspace the client
+    // moved away from.
+    let pinned_by_operator = repo_override.is_some() && bound_at_start;
     let repo_binder: Option<kin_mcp::RepoBinder> = Some(Box::new(
-        |roots: Vec<PathBuf>| -> Pin<Box<dyn Future<Output = Option<kin_mcp::BoundRepo>> + Send>> {
-            Box::pin(bind_first_kin_repo(roots))
+        move |roots: Vec<PathBuf>| -> Pin<Box<dyn Future<Output = Option<kin_mcp::BoundRepo>> + Send>> {
+            Box::pin(bind_first_kin_repo(roots, pinned_by_operator))
         },
     ));
 
@@ -105,8 +116,17 @@ pub async fn start(global: bool, repo: Option<PathBuf>) -> Result<()> {
 /// the running daemon; when they name a different one it repoints the process at
 /// it; when nothing there can be bound it returns `None`, which the stdio server
 /// turns into an explicit refusal.
-async fn bind_first_kin_repo(roots: Vec<PathBuf>) -> Option<kin_mcp::BoundRepo> {
-    bind_first_kin_repo_against(roots, bound_repo_working_dir()).await
+///
+/// `pinned_by_operator` marks a binding that came from an explicit
+/// `--repo`/`KIN_MCP_REPO`. That pin is never repointed by the client — it is a
+/// deliberate choice about which repository this server serves — so a workspace
+/// that names a different repository returns `None` and fails loud instead of
+/// following the client or, worse, answering from the pinned repository anyway.
+async fn bind_first_kin_repo(
+    roots: Vec<PathBuf>,
+    pinned_by_operator: bool,
+) -> Option<kin_mcp::BoundRepo> {
+    bind_first_kin_repo_against(roots, bound_repo_working_dir(), pinned_by_operator).await
 }
 
 /// Core of [`bind_first_kin_repo`] with the currently bound repository as an
@@ -116,6 +136,7 @@ async fn bind_first_kin_repo(roots: Vec<PathBuf>) -> Option<kin_mcp::BoundRepo> 
 async fn bind_first_kin_repo_against(
     roots: Vec<PathBuf>,
     bound_repo: Option<PathBuf>,
+    pinned_by_operator: bool,
 ) -> Option<kin_mcp::BoundRepo> {
     for root in roots {
         // Force the real upward walk. `KinLayout::discover` short-circuits to
@@ -134,6 +155,19 @@ async fn bind_first_kin_repo_against(
                 root: working_dir,
                 daemon_url,
             });
+        }
+
+        if pinned_by_operator {
+            // An explicit --repo/KIN_MCP_REPO names a different repository than
+            // the client is looking at. Following the client would overrule a
+            // deliberate operator choice; serving the pinned repository anyway
+            // would answer about a codebase the client left. Report neither.
+            eprintln!(
+                "Kin MCP: the client's workspace root {} is not the repository pinned by \
+                 --repo/KIN_MCP_REPO; refusing tool calls until the workspace and the pin agree.",
+                working_dir.display()
+            );
+            return None;
         }
 
         if bound_repo.is_some() {
@@ -384,10 +418,13 @@ mod tests {
         let repo = kin_repo_fixture();
         let repo_dir = std::fs::canonicalize(repo.path()).unwrap();
 
-        let bound =
-            bind_first_kin_repo_against(vec![repo.path().to_path_buf()], Some(repo_dir.clone()))
-                .await
-                .expect("the bound repository still being open must stay bound");
+        let bound = bind_first_kin_repo_against(
+            vec![repo.path().to_path_buf()],
+            Some(repo_dir.clone()),
+            false,
+        )
+        .await
+        .expect("the bound repository still being open must stay bound");
 
         assert_eq!(bound.root, repo_dir);
         assert_eq!(bound.daemon_url, "http://127.0.0.1:4242");
@@ -414,6 +451,7 @@ mod tests {
         let bound = bind_first_kin_repo_against(
             vec![switched_to.path().to_path_buf()],
             Some(std::fs::canonicalize(previous.path()).unwrap()),
+            false,
         )
         .await;
 
@@ -430,13 +468,62 @@ mod tests {
 
     #[tokio::test]
     #[serial]
+    async fn an_operator_pin_is_never_repointed_by_workspace_roots() {
+        // --repo/KIN_MCP_REPO is a deliberate choice about which repository this
+        // server serves. A roots change naming a different repository must
+        // neither follow the client nor keep answering from the pin: it reports
+        // failure so the stdio server refuses.
+        let _daemon_guard = EnvVarGuard::set("KIN_DAEMON_URL", "http://127.0.0.1:4242");
+        let _no_daemon_guard = EnvVarGuard::set("KIN_NO_DAEMON", "1");
+        let pinned = kin_repo_fixture();
+        let other = kin_repo_fixture();
+
+        let bound = bind_first_kin_repo_against(
+            vec![other.path().to_path_buf()],
+            Some(std::fs::canonicalize(pinned.path()).unwrap()),
+            true,
+        )
+        .await;
+
+        assert!(
+            bound.is_none(),
+            "a pinned server must report failure for a workspace it does not serve"
+        );
+        assert_eq!(
+            std::env::var("KIN_DAEMON_URL").ok().as_deref(),
+            Some("http://127.0.0.1:4242"),
+            "the operator's pin must survive a roots change it does not match"
+        );
+    }
+
+    #[tokio::test]
+    #[serial]
+    async fn an_operator_pin_still_binds_when_the_roots_name_it() {
+        let _daemon_guard = EnvVarGuard::set("KIN_DAEMON_URL", "http://127.0.0.1:4242");
+        let pinned = kin_repo_fixture();
+        let pinned_dir = std::fs::canonicalize(pinned.path()).unwrap();
+
+        let bound = bind_first_kin_repo_against(
+            vec![pinned.path().to_path_buf()],
+            Some(pinned_dir.clone()),
+            true,
+        )
+        .await
+        .expect("roots naming the pinned repository must stay bound");
+
+        assert_eq!(bound.root, pinned_dir);
+        assert_eq!(bound.daemon_url, "http://127.0.0.1:4242");
+    }
+
+    #[tokio::test]
+    #[serial]
     async fn roots_with_no_kin_repository_bind_nothing() {
         let _daemon_guard = EnvVarGuard::remove("KIN_DAEMON_URL");
         // No autostart: this test must never spawn a daemon process.
         let _no_daemon_guard = EnvVarGuard::set("KIN_NO_DAEMON", "1");
         let plain = tempfile::tempdir().unwrap();
         assert!(
-            bind_first_kin_repo_against(vec![plain.path().to_path_buf()], None)
+            bind_first_kin_repo_against(vec![plain.path().to_path_buf()], None, false)
                 .await
                 .is_none()
         );

--- a/crates/kin-cli/src/commands/mcp.rs
+++ b/crates/kin-cli/src/commands/mcp.rs
@@ -138,47 +138,52 @@ async fn bind_first_kin_repo_against(
     bound_repo: Option<PathBuf>,
     pinned_by_operator: bool,
 ) -> Option<kin_mcp::BoundRepo> {
-    for root in roots {
-        // Force the real upward walk. `KinLayout::discover` short-circuits to
-        // `<start>/.kin` whenever `KIN_DAEMON_URL` is set, so once a repository
-        // is bound it would accept any directory — including one with no `.kin/`
-        // at all — as the client's new repository.
-        let Some(layout) = kin_core::KinLayout::discover_with_daemon_url(&root, None) else {
-            continue;
-        };
-        let working_dir = canonical_path(layout.working_dir());
+    // Force the real upward walk. `KinLayout::discover` short-circuits to
+    // `<start>/.kin` whenever `KIN_DAEMON_URL` is set, so once a repository is
+    // bound it would accept any directory — including one with no `.kin/` at
+    // all — as the client's new repository.
+    let candidates: Vec<PathBuf> = roots
+        .iter()
+        .filter_map(|root| kin_core::KinLayout::discover_with_daemon_url(root, None))
+        .map(|layout| canonical_path(layout.working_dir()))
+        .collect();
+    let bound_repo_still_open = bound_repo.as_deref().is_some_and(|bound| {
+        candidates
+            .iter()
+            .any(|candidate| candidate.as_path() == bound)
+    });
 
-        if bound_repo.as_deref() == Some(working_dir.as_path()) {
-            // The client still has the bound repository open. Keep the running
-            // daemon rather than churning it on a redundant roots change.
-            return current_daemon_url().map(|daemon_url| kin_mcp::BoundRepo {
-                root: working_dir,
-                daemon_url,
-            });
-        }
+    if bound_repo_still_open {
+        // The client still has the bound repository open — anywhere in its
+        // workspace, not merely first. Keep the running daemon rather than
+        // churning it because another folder happens to sort ahead of it.
+        return bound_repo
+            .zip(current_daemon_url())
+            .map(|(root, daemon_url)| kin_mcp::BoundRepo { root, daemon_url });
+    }
 
-        if pinned_by_operator {
-            // An explicit --repo/KIN_MCP_REPO names a different repository than
-            // the client is looking at. Following the client would overrule a
-            // deliberate operator choice; serving the pinned repository anyway
-            // would answer about a codebase the client left. Report neither.
-            eprintln!(
-                "Kin MCP: the client's workspace root {} is not the repository pinned by \
-                 --repo/KIN_MCP_REPO; refusing tool calls until the workspace and the pin agree.",
-                working_dir.display()
-            );
-            return None;
-        }
+    if pinned_by_operator {
+        // An explicit --repo/KIN_MCP_REPO names a repository the client is not
+        // looking at. Following the client would overrule a deliberate operator
+        // choice; serving the pinned repository anyway would answer about a
+        // codebase the client left. Report neither, and let the server refuse.
+        eprintln!(
+            "Kin MCP: the repository pinned by --repo/KIN_MCP_REPO is not among the client's \
+             workspace roots; refusing tool calls until the workspace and the pin agree."
+        );
+        return None;
+    }
 
-        if bound_repo.is_some() {
-            // A different repository. Drop the pin so daemon resolution binds
-            // the new repo instead of returning the one being left. Deliberately
-            // not restored if the bind below fails: falling back to the previous
-            // repository is exactly the wrong-repo answer this path prevents, so
-            // failure must leave the process unbound and failing loud.
-            std::env::remove_var("KIN_DAEMON_URL");
-        }
+    if bound_repo.is_some() {
+        // The workspace moved off the bound repository. Drop the pin so daemon
+        // resolution binds the new one instead of returning the one being left.
+        // Deliberately not restored if binding fails below: falling back to the
+        // previous repository is exactly the wrong-repo answer this path
+        // prevents, so failure must leave the process unbound and failing loud.
+        std::env::remove_var("KIN_DAEMON_URL");
+    }
 
+    for working_dir in candidates {
         let Ok(url) = bind_daemon_for_repo_dir(&working_dir).await else {
             continue;
         };
@@ -464,6 +469,29 @@ mod tests {
             None,
             "the previous repository's daemon must not survive the switch"
         );
+    }
+
+    #[tokio::test]
+    #[serial]
+    async fn the_bound_repo_wins_wherever_it_sits_among_the_roots() {
+        // A second folder opened alongside the bound one is not a switch. Root
+        // order must not move a working binding.
+        let _daemon_guard = EnvVarGuard::set("KIN_DAEMON_URL", "http://127.0.0.1:4242");
+        let _no_daemon_guard = EnvVarGuard::set("KIN_NO_DAEMON", "1");
+        let other = kin_repo_fixture();
+        let bound = kin_repo_fixture();
+        let bound_dir = std::fs::canonicalize(bound.path()).unwrap();
+
+        let result = bind_first_kin_repo_against(
+            vec![other.path().to_path_buf(), bound.path().to_path_buf()],
+            Some(bound_dir.clone()),
+            false,
+        )
+        .await
+        .expect("the bound repository being open anywhere must keep the binding");
+
+        assert_eq!(result.root, bound_dir);
+        assert_eq!(result.daemon_url, "http://127.0.0.1:4242");
     }
 
     #[tokio::test]

--- a/crates/kin-cli/src/commands/mcp.rs
+++ b/crates/kin-cli/src/commands/mcp.rs
@@ -39,11 +39,10 @@ pub async fn start(global: bool, repo: Option<PathBuf>) -> Result<()> {
     }
 
     let cwd = std::env::current_dir().unwrap_or_else(|_| PathBuf::from("."));
-    let bound_at_start = match bind_daemon_for_repo_dir(&cwd).await {
+    match bind_daemon_for_repo_dir(&cwd).await {
         Ok(daemon_url) => {
             eprintln!("{}", session_authority_notice());
             eprintln!("Kin MCP: forwarding graph tools to repo daemon at {daemon_url}");
-            true
         }
         Err(reason) => {
             eprintln!(
@@ -52,9 +51,8 @@ pub async fn start(global: bool, repo: Option<PathBuf>) -> Result<()> {
                  run `kin init .`, relaunch inside a Kin repository, or pass --repo <path> (or set \
                  KIN_MCP_REPO=<path>)."
             );
-            false
         }
-    };
+    }
 
     let mut config = build_mcp_start_config();
     let profile_tools: Option<&'static [&'static str]> =
@@ -76,18 +74,17 @@ pub async fn start(global: bool, repo: Option<PathBuf>) -> Result<()> {
         );
     }
 
-    // When nothing bound from --repo/KIN_MCP_REPO/cwd, let the stdio server bind
-    // late from the MCP client's advertised workspace roots — how editors that
-    // launch MCP servers from $HOME (Cursor, Windsurf, ...) reach the open repo.
-    let repo_binder: Option<kin_mcp::RepoBinder> = if bound_at_start {
-        None
-    } else {
-        Some(Box::new(
-            |roots: Vec<PathBuf>| -> Pin<Box<dyn Future<Output = Option<String>> + Send>> {
-                Box::pin(bind_first_kin_repo(roots))
-            },
-        ))
-    };
+    // The stdio server always binds through the MCP client's advertised
+    // workspace roots: late, when nothing bound from --repo/KIN_MCP_REPO/cwd
+    // (how editors that launch MCP servers from $HOME — Cursor, Windsurf, ... —
+    // reach the open repo), and again whenever the client reports that its
+    // workspace changed, so a window that moves to another folder does not keep
+    // being answered from the folder it left.
+    let repo_binder: Option<kin_mcp::RepoBinder> = Some(Box::new(
+        |roots: Vec<PathBuf>| -> Pin<Box<dyn Future<Output = Option<kin_mcp::BoundRepo>> + Send>> {
+            Box::pin(bind_first_kin_repo(roots))
+        },
+    ));
 
     kin_mcp::run_stdio_daemon(config, repo_binder)
         .await
@@ -96,33 +93,114 @@ pub async fn start(global: bool, repo: Option<PathBuf>) -> Result<()> {
     Ok(())
 }
 
-/// Bind the repo daemon for the first workspace root that is a Kin repository.
-/// Returns the daemon URL (and sets `KIN_DAEMON_URL`) on success, or `None` when
-/// none of the client's workspace roots is a Kin repository.
-async fn bind_first_kin_repo(roots: Vec<PathBuf>) -> Option<String> {
+/// Bind — or re-bind — the repo daemon for the first workspace root that is a
+/// Kin repository. Returns the bound repository and its daemon URL (and sets
+/// `KIN_DAEMON_URL`), or `None` when none of the client's workspace roots is a
+/// Kin repository whose daemon can be resolved.
+///
+/// Re-binding is the point as much as binding: an editor that moves its window
+/// to another folder reports new roots, and a process that keeps its original
+/// binding answers every later tool call from a repository the user has left.
+/// When the roots still contain the bound repository this is a no-op that keeps
+/// the running daemon; when they name a different one it repoints the process at
+/// it; when nothing there can be bound it returns `None`, which the stdio server
+/// turns into an explicit refusal.
+async fn bind_first_kin_repo(roots: Vec<PathBuf>) -> Option<kin_mcp::BoundRepo> {
+    bind_first_kin_repo_against(roots, bound_repo_working_dir()).await
+}
+
+/// Core of [`bind_first_kin_repo`] with the currently bound repository as an
+/// explicit input rather than a read of the process working directory, so the
+/// same-repo/different-repo branch is testable without moving the cwd out from
+/// under every other test in this binary.
+async fn bind_first_kin_repo_against(
+    roots: Vec<PathBuf>,
+    bound_repo: Option<PathBuf>,
+) -> Option<kin_mcp::BoundRepo> {
     for root in roots {
-        if let Ok(url) = bind_daemon_for_repo_dir(&root).await {
-            // Point the process at the bound repo so the daemon delegate resolves
-            // the per-install loopback auth token from <root>/.kin/daemon.token,
-            // exactly as the --repo startup path does (it set_current_dir's first).
-            // Without this, tool-call forwarding sends no bearer token and the
-            // daemon replies 401 even though the repo bound correctly.
-            if let Err(err) = std::env::set_current_dir(&root) {
-                eprintln!(
-                    "Kin MCP: bound {url} but could not switch cwd to {} ({err}); \
-                     tool auth will fall back to KIN_DAEMON_AUTH_TOKEN if set.",
-                    root.display()
-                );
-            }
-            eprintln!("{}", session_authority_notice());
-            eprintln!(
-                "Kin MCP: bound repo daemon at {url} from workspace root {}",
-                root.display()
-            );
-            return Some(url);
+        // Force the real upward walk. `KinLayout::discover` short-circuits to
+        // `<start>/.kin` whenever `KIN_DAEMON_URL` is set, so once a repository
+        // is bound it would accept any directory — including one with no `.kin/`
+        // at all — as the client's new repository.
+        let Some(layout) = kin_core::KinLayout::discover_with_daemon_url(&root, None) else {
+            continue;
+        };
+        let working_dir = canonical_path(layout.working_dir());
+
+        if bound_repo.as_deref() == Some(working_dir.as_path()) {
+            // The client still has the bound repository open. Keep the running
+            // daemon rather than churning it on a redundant roots change.
+            return current_daemon_url().map(|daemon_url| kin_mcp::BoundRepo {
+                root: working_dir,
+                daemon_url,
+            });
         }
+
+        if bound_repo.is_some() {
+            // A different repository. Drop the pin so daemon resolution binds
+            // the new repo instead of returning the one being left. Deliberately
+            // not restored if the bind below fails: falling back to the previous
+            // repository is exactly the wrong-repo answer this path prevents, so
+            // failure must leave the process unbound and failing loud.
+            std::env::remove_var("KIN_DAEMON_URL");
+        }
+
+        let Ok(url) = bind_daemon_for_repo_dir(&working_dir).await else {
+            continue;
+        };
+        // Point the process at the bound repo so the daemon delegate resolves
+        // the per-install loopback auth token from <root>/.kin/daemon.token,
+        // exactly as the --repo startup path does (it set_current_dir's first).
+        // Without this, tool-call forwarding sends no bearer token and the
+        // daemon replies 401 even though the repo bound correctly.
+        if let Err(err) = std::env::set_current_dir(&working_dir) {
+            eprintln!(
+                "Kin MCP: bound {url} but could not switch cwd to {} ({err}); \
+                 tool auth will fall back to KIN_DAEMON_AUTH_TOKEN if set.",
+                working_dir.display()
+            );
+        }
+        eprintln!("{}", session_authority_notice());
+        eprintln!(
+            "Kin MCP: bound repo daemon at {url} from workspace root {}",
+            working_dir.display()
+        );
+        return Some(kin_mcp::BoundRepo {
+            root: working_dir,
+            daemon_url: url,
+        });
     }
     None
+}
+
+/// The repository this process is bound to, or `None` when it is not bound.
+///
+/// A binding exists only while a daemon URL is pinned, and the repository it
+/// serves is the one containing the process working directory: every bind path
+/// (`--repo`, `KIN_MCP_REPO`, the launch cwd, workspace roots) leaves the cwd
+/// inside the bound repository. A `KIN_DAEMON_URL` pinned from outside while the
+/// cwd is in no repository stays an explicit override — nothing to compare
+/// roots against, so roots never repoint it.
+fn bound_repo_working_dir() -> Option<PathBuf> {
+    current_daemon_url()?;
+    let cwd = std::env::current_dir().ok()?;
+    kin_core::KinLayout::discover_with_daemon_url(&cwd, None)
+        .map(|layout| canonical_path(layout.working_dir()))
+}
+
+fn current_daemon_url() -> Option<String> {
+    std::env::var("KIN_DAEMON_URL")
+        .ok()
+        .map(|url| url.trim().to_string())
+        .filter(|url| !url.is_empty())
+}
+
+/// Resolve symlinks so a client-supplied root and the process working directory
+/// compare equal when they name the same repository (`/tmp` vs `/private/tmp`
+/// on macOS, for one). Falls back to the path as given when it cannot be
+/// canonicalized.
+fn canonical_path(path: &Path) -> PathBuf {
+    std::fs::canonicalize(path).unwrap_or_else(|_| path.to_path_buf())
 }
 
 fn session_authority_notice() -> &'static str {
@@ -180,8 +258,8 @@ async fn bind_daemon_for_repo_dir(dir: &Path) -> std::result::Result<String, Str
 #[cfg(test)]
 mod tests {
     use super::{
-        bind_daemon_for_repo_dir, build_mcp_start_config, resolve_repo_override,
-        session_authority_notice, start,
+        bind_daemon_for_repo_dir, bind_first_kin_repo_against, build_mcp_start_config,
+        resolve_repo_override, session_authority_notice, start,
     };
     use serial_test::serial;
     use std::path::PathBuf;
@@ -286,6 +364,81 @@ mod tests {
         assert!(
             reason.contains("not inside a kin repository"),
             "unexpected reason: {reason}"
+        );
+    }
+
+    /// A directory that passes `KinLayout` discovery: a `.kin/` and nothing
+    /// else, so nothing here can resolve a repo id or a running daemon.
+    fn kin_repo_fixture() -> tempfile::TempDir {
+        let tmp = tempfile::tempdir().unwrap();
+        std::fs::create_dir(tmp.path().join(".kin")).unwrap();
+        tmp
+    }
+
+    #[tokio::test]
+    #[serial]
+    async fn roots_naming_the_bound_repo_keep_the_running_daemon() {
+        // A redundant roots change (same folder still open) must not tear down
+        // or re-resolve the binding.
+        let _daemon_guard = EnvVarGuard::set("KIN_DAEMON_URL", "http://127.0.0.1:4242");
+        let repo = kin_repo_fixture();
+        let repo_dir = std::fs::canonicalize(repo.path()).unwrap();
+
+        let bound =
+            bind_first_kin_repo_against(vec![repo.path().to_path_buf()], Some(repo_dir.clone()))
+                .await
+                .expect("the bound repository still being open must stay bound");
+
+        assert_eq!(bound.root, repo_dir);
+        assert_eq!(bound.daemon_url, "http://127.0.0.1:4242");
+        assert_eq!(
+            std::env::var("KIN_DAEMON_URL").ok().as_deref(),
+            Some("http://127.0.0.1:4242"),
+            "a no-op roots change must leave the pinned daemon alone"
+        );
+    }
+
+    #[tokio::test]
+    #[serial]
+    async fn switching_to_an_unresolvable_repo_never_falls_back_to_the_old_one() {
+        // The wrong-repo failure mode in miniature: the client moved to another
+        // repository whose daemon cannot be resolved. Binding must end up
+        // unbound and report failure, never silently keep serving the previous
+        // repository's daemon.
+        let _daemon_guard = EnvVarGuard::set("KIN_DAEMON_URL", "http://127.0.0.1:4242");
+        // No autostart: this test must never spawn a daemon process.
+        let _no_daemon_guard = EnvVarGuard::set("KIN_NO_DAEMON", "1");
+        let previous = kin_repo_fixture();
+        let switched_to = kin_repo_fixture();
+
+        let bound = bind_first_kin_repo_against(
+            vec![switched_to.path().to_path_buf()],
+            Some(std::fs::canonicalize(previous.path()).unwrap()),
+        )
+        .await;
+
+        assert!(
+            bound.is_none(),
+            "an unresolvable new repository must not report a successful bind"
+        );
+        assert_eq!(
+            std::env::var("KIN_DAEMON_URL").ok().as_deref(),
+            None,
+            "the previous repository's daemon must not survive the switch"
+        );
+    }
+
+    #[tokio::test]
+    #[serial]
+    async fn roots_with_no_kin_repository_bind_nothing() {
+        let _daemon_guard = EnvVarGuard::remove("KIN_DAEMON_URL");
+        // No autostart: this test must never spawn a daemon process.
+        let _no_daemon_guard = EnvVarGuard::set("KIN_NO_DAEMON", "1");
+        let plain = tempfile::tempdir().unwrap();
+        assert!(
+            bind_first_kin_repo_against(vec![plain.path().to_path_buf()], None)
+                .await
+                .is_none()
         );
     }
 

--- a/crates/kin-mcp/src/daemon_delegate.rs
+++ b/crates/kin-mcp/src/daemon_delegate.rs
@@ -30,6 +30,20 @@ static DAEMON_CLIENT: OnceLock<reqwest::Client> = OnceLock::new();
 /// a process restart.
 static DAEMON_URL_OVERRIDE: std::sync::Mutex<Option<String>> = std::sync::Mutex::new(None);
 
+/// Drop the revival-path daemon URL override.
+///
+/// The override outranks `KIN_DAEMON_URL` for every delegate call, so a process
+/// that revived a daemon for one repository keeps reaching that daemon even
+/// after `KIN_DAEMON_URL` is repointed. The stdio server clears it when the MCP
+/// client's workspace roots move it to a different repository; without that, a
+/// re-bind would repoint the environment and still forward tool calls to the
+/// repository the client left.
+pub(crate) fn clear_daemon_url_override() {
+    if let Ok(mut guard) = DAEMON_URL_OVERRIDE.lock() {
+        *guard = None;
+    }
+}
+
 /// Base URL for the daemon HTTP API.
 ///
 /// Checks the revival-path override first; falls back to the `KIN_DAEMON_URL`

--- a/crates/kin-mcp/src/lib.rs
+++ b/crates/kin-mcp/src/lib.rs
@@ -18,8 +18,8 @@ pub use envelope::{
 pub use error::{McpError, Result};
 pub use negative::NEGATIVE_KEY;
 pub use server::{
-    process_daemon_message, process_message, run_stdio, run_stdio_daemon, McpServerConfig,
-    RepoBinder, SessionAuthorityMode,
+    process_daemon_message, process_message, run_stdio, run_stdio_daemon, BoundRepo,
+    McpServerConfig, RepoBinder, SessionAuthorityMode,
 };
 pub use session::{
     AssistantSession, CoordinationEnforcementMode, CoordinationSurfaceCoverage,

--- a/crates/kin-mcp/src/server.rs
+++ b/crates/kin-mcp/src/server.rs
@@ -289,7 +289,7 @@ where
                 method,
                 client_supports_roots,
                 repo_binder.is_some(),
-                !binding.is_bound(),
+                binding.wants_workspace_roots(),
                 Instant::now(),
             ) {
                 let request = serde_json::json!({
@@ -402,6 +402,15 @@ impl RepoBindingState {
         self.daemon_url.is_some()
     }
 
+    /// Whether the server should still be reaching for workspace roots on the
+    /// ordinary triggers. A refusing server counts as needing one: it is bound
+    /// to a repository the client is not looking at, which is no more useful
+    /// than being unbound, so it keeps trying to bind rather than waiting only
+    /// for the client to announce another change.
+    fn wants_workspace_roots(&self) -> bool {
+        !self.is_bound() || self.is_mismatched()
+    }
+
     fn is_mismatched(&self) -> bool {
         self.mismatch.is_some()
     }
@@ -487,7 +496,7 @@ impl WorkspaceRootsRequestState {
         method: Option<&str>,
         client_supports_roots: bool,
         has_repo_binder: bool,
-        daemon_unbound: bool,
+        wants_binding: bool,
         now: Instant,
     ) -> bool {
         let should_begin = should_request_workspace_roots(
@@ -495,7 +504,7 @@ impl WorkspaceRootsRequestState {
             client_supports_roots,
             self.request_in_flight(now),
             has_repo_binder,
-            daemon_unbound,
+            wants_binding,
         );
         if should_begin {
             self.in_flight_since = Some(now);
@@ -511,14 +520,15 @@ impl WorkspaceRootsRequestState {
 /// A roots *change* is honored whether or not a repository is bound: it is the
 /// only signal an editor sends when its window moves to another folder, and
 /// ignoring it once bound is what leaves the server answering from the previous
-/// repository. The other triggers stay gated on an unbound daemon so a settled
-/// session does not re-ask on every `tools/list`.
+/// repository. The other triggers are gated on `wants_binding` — unbound, or
+/// bound to a repository the client has left — so a settled session does not
+/// re-ask on every `tools/list`, while a refusing one keeps trying.
 fn should_request_workspace_roots(
     method: Option<&str>,
     client_supports_roots: bool,
     request_in_flight: bool,
     has_repo_binder: bool,
-    daemon_unbound: bool,
+    wants_binding: bool,
 ) -> bool {
     if !client_supports_roots || request_in_flight || !has_repo_binder {
         return false;
@@ -526,7 +536,7 @@ fn should_request_workspace_roots(
     match method {
         Some("notifications/roots/list_changed") => true,
         Some("initialized") | Some("notifications/initialized") | Some("tools/list") => {
-            daemon_unbound
+            wants_binding
         }
         _ => false,
     }
@@ -1612,6 +1622,31 @@ mod tests {
     }
 
     #[test]
+    fn a_refusing_binding_still_wants_workspace_roots() {
+        let mut binding = RepoBindingState::default();
+        assert!(
+            binding.wants_workspace_roots(),
+            "unbound wants a repository"
+        );
+
+        binding.bind(bound_repo("/repo/a", "http://127.0.0.1:4111"));
+        assert!(
+            !binding.wants_workspace_roots(),
+            "a settled binding must not re-ask on every trigger"
+        );
+
+        binding.mark_mismatch(vec![PathBuf::from("/elsewhere")]);
+        assert!(
+            binding.wants_workspace_roots(),
+            "bound to a repository the client left is no better than unbound"
+        );
+
+        binding.bind(bound_repo("/repo/b", "http://127.0.0.1:4222"));
+        assert!(!binding.wants_workspace_roots());
+        assert!(!binding.is_mismatched(), "binding again clears the refusal");
+    }
+
+    #[test]
     fn workspace_roots_change_is_honored_after_a_repository_is_already_bound() {
         // The defect this locks down: with a daemon already bound, the roots
         // change that an editor sends when its window moves to another folder
@@ -1899,6 +1934,56 @@ mod tests {
         assert!(
             text.contains("not enabled in this MCP profile"),
             "a successful re-bind must clear the refusal and let the call through: {text}"
+        );
+    }
+
+    #[tokio::test]
+    async fn a_refusing_server_keeps_trying_to_bind_on_ordinary_triggers() {
+        // Bind A, switch to a workspace that cannot be bound, then send only a
+        // plain `tools/list`. A refusing server is no more useful than an
+        // unbound one, so it must reach for roots again instead of waiting for
+        // the client to announce another change — and a bindable answer there
+        // clears the refusal.
+        let (binder, calls) = ScriptedBinder::install(vec![
+            Some(bound_repo("/repo/a", "http://127.0.0.1:4111")),
+            None,
+            Some(bound_repo("/repo/b", "http://127.0.0.1:4222")),
+        ]);
+
+        let responses = drive_daemon_loop(
+            &[
+                initialize_with_roots_capability(),
+                serde_json::json!({"jsonrpc": "2.0", "method": "notifications/initialized"}),
+                roots_response(&["/repo/a"]),
+                serde_json::json!({"jsonrpc": "2.0", "method": "notifications/roots/list_changed"}),
+                roots_response(&["/elsewhere/not-a-kin-repo"]),
+                serde_json::json!({"jsonrpc": "2.0", "id": 2, "method": "tools/list"}),
+                roots_response(&["/repo/b"]),
+                tool_call(13, "semantic_locate"),
+            ],
+            Some(binder),
+            None,
+        )
+        .await;
+
+        assert_eq!(
+            roots_requests(&responses).len(),
+            3,
+            "a refusing server must re-request roots on an ordinary trigger: {responses:#?}"
+        );
+        assert_eq!(
+            calls.lock().unwrap().len(),
+            3,
+            "the third roots response must reach the binder"
+        );
+        let answer = responses
+            .iter()
+            .find(|value| value.get("id").and_then(|id| id.as_u64()) == Some(13))
+            .expect("the tool call must be answered");
+        let text = tool_error_text(answer);
+        assert!(
+            text.contains("not enabled in this MCP profile"),
+            "binding again must clear the refusal: {text}"
         );
     }
 

--- a/crates/kin-mcp/src/server.rs
+++ b/crates/kin-mcp/src/server.rs
@@ -177,6 +177,15 @@ const ROOTS_REQUEST_ID: &str = "kin-mcp-roots-list";
 /// the daemon to the open workspace via `repo_binder`. That is what lets Cursor,
 /// Windsurf, and other editors reach whatever repository the user has open
 /// without a hardcoded path in the MCP config.
+///
+/// The client's workspace can move afterwards, so a `roots/list_changed`
+/// notification re-requests roots whether or not a repository is bound, and the
+/// binder decides: it re-binds the process to the repository the client is now
+/// looking at, or reports that it cannot, in which case every `tools/call` is
+/// refused with a structured repo-mismatch error until a later roots change
+/// resolves it. A bound server never keeps answering from a repository the
+/// client has left — a confident answer about the wrong codebase is worse than
+/// an error.
 pub async fn run_stdio_daemon(
     config: McpServerConfig,
     repo_binder: Option<RepoBinder>,

--- a/crates/kin-mcp/src/server.rs
+++ b/crates/kin-mcp/src/server.rs
@@ -10,6 +10,7 @@ use std::collections::HashSet;
 use std::future::Future;
 use std::path::{Path, PathBuf};
 use std::pin::Pin;
+use std::time::{Duration, Instant};
 
 use crate::daemon_delegate;
 use crate::envelope::{self, Envelope};
@@ -128,16 +129,35 @@ pub async fn run_stdio<G: PersistableMcpStore + 'static>(
     Ok(())
 }
 
-/// Binds the repo daemon from the MCP client's advertised workspace roots.
+/// The repository this MCP process serves: its working directory and the URL of
+/// the daemon that owns its graph.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct BoundRepo {
+    /// Repository working directory (the parent of its `.kin/`).
+    pub root: PathBuf,
+    /// Daemon endpoint serving that repository.
+    pub daemon_url: String,
+}
+
+/// Binds — or re-binds — the repo daemon from the MCP client's advertised
+/// workspace roots.
 ///
 /// Receives the filesystem paths of the client's roots, binds the daemon for the
 /// first one that is a Kin repository (setting `KIN_DAEMON_URL` as a side
-/// effect), and returns the bound daemon URL — or `None` if none of the roots is
-/// a Kin repository. Supplied by the kin-cli MCP command; when `None`, roots
-/// binding is disabled (a repository was already bound at startup, or the client
-/// cannot serve roots).
-pub type RepoBinder =
-    Box<dyn Fn(Vec<PathBuf>) -> Pin<Box<dyn Future<Output = Option<String>> + Send>> + Send + Sync>;
+/// effect), and returns the bound repository — or `None` if none of the roots is
+/// a Kin repository whose daemon can be resolved. Supplied by the kin-cli MCP
+/// command; when `None`, roots binding is disabled (the client cannot serve
+/// roots).
+///
+/// The binder is invoked for every `roots/list` response, not only the first:
+/// an editor that moves its window to another folder announces the change, and
+/// a server that keeps its original binding answers from a repository the user
+/// has left. A `None` return while a repository is already bound is therefore
+/// meaningful — it tells the server to refuse tool calls rather than serve them
+/// from the previous repository's graph.
+pub type RepoBinder = Box<
+    dyn Fn(Vec<PathBuf>) -> Pin<Box<dyn Future<Output = Option<BoundRepo>> + Send>> + Send + Sync,
+>;
 
 /// The JSON-RPC id the server uses for its own `roots/list` request so it can
 /// recognize the matching response coming back from the client.
@@ -169,19 +189,52 @@ pub async fn run_stdio_daemon(
 
     let stdin = tokio::io::stdin();
     let mut stdout = tokio::io::stdout();
-    let reader = BufReader::new(stdin);
-    let mut reader = reader;
+    let mut reader = BufReader::new(stdin);
 
+    run_stdio_daemon_over(
+        &mut reader,
+        &mut stdout,
+        config,
+        repo_binder,
+        bound_daemon_url_from_env(),
+    )
+    .await
+}
+
+/// Transport-generic core of [`run_stdio_daemon`].
+///
+/// Split out so the binding lifecycle — the roots request, the response that
+/// completes it, the re-request after a workspace change, and the refusal that
+/// follows a change we cannot follow — is exercised over an in-memory transport
+/// instead of only over the process's real stdin/stdout.
+///
+/// `bound_daemon_url` is the daemon this process was already bound to before the
+/// loop started (from `--repo`/`KIN_MCP_REPO`/cwd), passed in rather than read
+/// from the environment so the loop's binding decisions are a function of its
+/// inputs.
+async fn run_stdio_daemon_over<R, W>(
+    reader: &mut R,
+    writer: &mut W,
+    config: McpServerConfig,
+    repo_binder: Option<RepoBinder>,
+    bound_daemon_url: Option<String>,
+) -> Result<()>
+where
+    R: AsyncBufRead + Unpin,
+    W: AsyncWrite + Unpin,
+{
     tracing::info!("kin-mcp daemon-proxy stdio server starting");
 
-    // MCP `roots` binding state. We only reach out for workspace roots when we
-    // could not bind a repository at startup and the client says it can serve
-    // them. An editor may initialize the shared MCP process before opening a
-    // workspace, so only suppress a request while one is actually in flight.
+    // MCP `roots` binding state. Before a repository is bound we reach out for
+    // workspace roots as soon as the client says it can serve them; afterwards
+    // only a roots *change* triggers another request. An editor may initialize
+    // the shared MCP process before opening a workspace, so only suppress a
+    // request while one is actually in flight.
     let mut client_supports_roots = false;
     let mut roots_request_state = WorkspaceRootsRequestState::default();
+    let mut binding = RepoBindingState::started_with(bound_daemon_url);
 
-    while let Some((message, framed)) = read_stdio_message(&mut reader).await? {
+    while let Some((message, framed)) = read_stdio_message(&mut *reader).await? {
         // Peek at the raw JSON so we can distinguish the client's requests and
         // notifications from the `roots/list` response we may have sent: a
         // response carries no `method`, which the strongly-typed
@@ -193,6 +246,18 @@ pub async fn run_stdio_daemon(
                 client_supports_roots = value.pointer("/params/capabilities/roots").is_some();
             }
 
+            // The client moved to a workspace we could not bind. Refuse every
+            // tool call until a later roots change lands on a Kin repository:
+            // answering from the repository the client left would return a
+            // confident, well-formed result about the wrong codebase.
+            if method == Some("tools/call") && binding.is_mismatched() {
+                if let Some(response) = binding.repo_mismatch_response(&value) {
+                    let response_json = serde_json::to_string(&response).map_err(McpError::Json)?;
+                    write_stdio_message(&mut *writer, &response_json, framed).await?;
+                }
+                continue;
+            }
+
             // Our own `roots/list` response returning from the client: bind the
             // daemon and swallow it (a response is never itself answered).
             if method.is_none()
@@ -200,29 +265,23 @@ pub async fn run_stdio_daemon(
             {
                 roots_request_state.complete();
                 if let Some(binder) = repo_binder.as_ref() {
-                    let roots = parse_workspace_roots(&value);
-                    if roots.is_empty() {
-                        tracing::info!(
-                            "kin-mcp: client returned no workspace roots; repository stays unbound"
-                        );
-                    } else if binder(roots).await.is_none() {
-                        tracing::info!(
-                            "kin-mcp: no Kin repository among the client's workspace roots"
-                        );
-                    }
+                    apply_workspace_roots(binder, parse_workspace_roots(&value), &mut binding)
+                        .await;
                 }
                 continue;
             }
 
-            // Once the client finishes initializing (or asks for the tool list)
-            // and we still have no bound daemon, ask it for its workspace roots.
-            // Retry after an earlier empty response, and honor the MCP roots
-            // change notification used when an editor opens or changes folders.
+            // Ask the client for its workspace roots: while nothing is bound,
+            // as soon as it finishes initializing or asks for the tool list
+            // (retrying after an earlier empty response); and whenever it
+            // reports a roots change, bound or not, because that is how an
+            // editor announces that its window moved to another folder.
             if roots_request_state.begin_if_allowed(
                 method,
                 client_supports_roots,
                 repo_binder.is_some(),
-                daemon_is_unbound(),
+                !binding.is_bound(),
+                Instant::now(),
             ) {
                 let request = serde_json::json!({
                     "jsonrpc": "2.0",
@@ -230,7 +289,7 @@ pub async fn run_stdio_daemon(
                     "method": "roots/list",
                 });
                 let request_json = serde_json::to_string(&request).map_err(McpError::Json)?;
-                write_stdio_message(&mut stdout, &request_json, framed).await?;
+                write_stdio_message(&mut *writer, &request_json, framed).await?;
                 // Fall through: `initialized` has no response, and `tools/list`
                 // is still answered normally below.
             }
@@ -238,7 +297,7 @@ pub async fn run_stdio_daemon(
 
         if let Some(response) = process_daemon_message(&message, &config).await {
             let response_json = serde_json::to_string(&response).map_err(McpError::Json)?;
-            write_stdio_message(&mut stdout, &response_json, framed).await?;
+            write_stdio_message(&mut *writer, &response_json, framed).await?;
         }
     }
 
@@ -246,21 +305,172 @@ pub async fn run_stdio_daemon(
     Ok(())
 }
 
-/// True when no repo daemon has been bound yet (`KIN_DAEMON_URL` unset/empty).
-fn daemon_is_unbound() -> bool {
-    std::env::var("KIN_DAEMON_URL")
-        .map(|value| value.trim().is_empty())
-        .unwrap_or(true)
+/// Feed a `roots/list` response through the binder and record what it means for
+/// this process: a fresh binding, an unchanged one, or a workspace the server
+/// cannot follow.
+async fn apply_workspace_roots(
+    binder: &RepoBinder,
+    roots: Vec<PathBuf>,
+    binding: &mut RepoBindingState,
+) {
+    if roots.is_empty() {
+        // No open folder is not the same as a different folder: there is no
+        // other repository for the client's calls to be about, so an existing
+        // binding is left alone rather than torn down.
+        tracing::info!("kin-mcp: client returned no workspace roots; binding is unchanged");
+        return;
+    }
+
+    let previous_url = binding.daemon_url.clone();
+    match binder(roots.clone()).await {
+        Some(bound) => {
+            if previous_url.as_deref() != Some(bound.daemon_url.as_str()) {
+                // A different daemon serves this process now. Drop the revival
+                // override, which pins delegate calls at a daemon this process
+                // started for the repository it is leaving.
+                daemon_delegate::clear_daemon_url_override();
+                tracing::info!(
+                    repo = %bound.root.display(),
+                    daemon = %bound.daemon_url,
+                    "kin-mcp: bound repo daemon from the client's workspace roots"
+                );
+            }
+            binding.bind(bound);
+        }
+        None if binding.is_bound() => {
+            tracing::warn!(
+                roots = ?roots,
+                "kin-mcp: the client's workspace roots changed to a workspace with no bindable Kin \
+                 repository; refusing tool calls instead of answering from the previous repository"
+            );
+            binding.mark_mismatch(roots);
+        }
+        None => {
+            tracing::info!("kin-mcp: no Kin repository among the client's workspace roots");
+        }
+    }
 }
+
+/// The daemon bound before the stdio loop started (`KIN_DAEMON_URL` unset or
+/// empty means nothing was bound).
+fn bound_daemon_url_from_env() -> Option<String> {
+    std::env::var("KIN_DAEMON_URL")
+        .ok()
+        .map(|value| value.trim().to_string())
+        .filter(|value| !value.is_empty())
+}
+
+/// What the stdio loop knows about which repository it serves.
+#[derive(Debug, Default)]
+struct RepoBindingState {
+    /// Daemon currently serving this process, if any.
+    daemon_url: Option<String>,
+    /// Repository that daemon serves. Unknown for a binding inherited from
+    /// startup, which arrives as a URL with no accompanying root.
+    repo_root: Option<PathBuf>,
+    /// Set when the client's workspace moved somewhere this server could not
+    /// follow. Cleared by the next successful bind.
+    mismatch: Option<WorkspaceMismatch>,
+}
+
+/// A workspace change the server could not follow: it is still bound to
+/// `bound_repo`, while the client now reports `requested_roots`.
+#[derive(Debug)]
+struct WorkspaceMismatch {
+    bound_repo: Option<PathBuf>,
+    requested_roots: Vec<PathBuf>,
+}
+
+impl RepoBindingState {
+    fn started_with(daemon_url: Option<String>) -> Self {
+        Self {
+            daemon_url,
+            ..Self::default()
+        }
+    }
+
+    fn is_bound(&self) -> bool {
+        self.daemon_url.is_some()
+    }
+
+    fn is_mismatched(&self) -> bool {
+        self.mismatch.is_some()
+    }
+
+    fn bind(&mut self, bound: BoundRepo) {
+        self.daemon_url = Some(bound.daemon_url);
+        self.repo_root = Some(bound.root);
+        self.mismatch = None;
+    }
+
+    fn mark_mismatch(&mut self, requested_roots: Vec<PathBuf>) {
+        self.mismatch = Some(WorkspaceMismatch {
+            bound_repo: self.repo_root.clone(),
+            requested_roots,
+        });
+    }
+
+    /// Structured refusal for a `tools/call` that arrived while the client's
+    /// workspace and this server's binding disagree. `None` for a malformed
+    /// call with no id, which has no response channel — the caller still drops
+    /// the call rather than forwarding it.
+    fn repo_mismatch_response(&self, request: &serde_json::Value) -> Option<JsonRpcResponse> {
+        let mismatch = self.mismatch.as_ref()?;
+        let id = request.get("id").filter(|id| !id.is_null())?.clone();
+        let tool = request
+            .pointer("/params/name")
+            .and_then(|name| name.as_str())
+            .unwrap_or("this tool");
+        let result = ToolCallResult::error(mismatch.message(tool));
+        let enveloped = envelope::finalize(result, Envelope::daemon_unreachable(), tool);
+        Some(JsonRpcResponse::success(
+            Some(id),
+            serde_json::to_value(&enveloped).unwrap_or_default(),
+        ))
+    }
+}
+
+impl WorkspaceMismatch {
+    fn message(&self, tool: &str) -> String {
+        let bound = match &self.bound_repo {
+            Some(root) => root.display().to_string(),
+            None => "the repository bound when this server started".to_string(),
+        };
+        let requested = self
+            .requested_roots
+            .iter()
+            .map(|root| root.display().to_string())
+            .collect::<Vec<_>>()
+            .join(", ");
+        format!(
+            "kin-mcp refuses '{tool}': the MCP client's workspace roots changed to [{requested}], \
+             and none of them is a Kin repository this server can bind, so Kin is still bound to \
+             {bound}. Answering would return a confident result about a repository you are no \
+             longer looking at. Run `kin init .` in the new workspace, or restart the MCP server \
+             from it (or with --repo <path> / KIN_MCP_REPO=<path>)."
+        )
+    }
+}
+
+/// How long an unanswered `roots/list` suppresses another one. A client that
+/// advertises the roots capability and then never answers would otherwise wedge
+/// binding — and, after a workspace change, the refusal state — for the life of
+/// the process.
+const ROOTS_REQUEST_TIMEOUT: Duration = Duration::from_secs(30);
 
 #[derive(Default)]
 struct WorkspaceRootsRequestState {
-    in_flight: bool,
+    in_flight_since: Option<Instant>,
 }
 
 impl WorkspaceRootsRequestState {
     fn complete(&mut self) {
-        self.in_flight = false;
+        self.in_flight_since = None;
+    }
+
+    fn request_in_flight(&self, now: Instant) -> bool {
+        self.in_flight_since
+            .is_some_and(|started| now.saturating_duration_since(started) < ROOTS_REQUEST_TIMEOUT)
     }
 
     fn begin_if_allowed(
@@ -269,16 +479,17 @@ impl WorkspaceRootsRequestState {
         client_supports_roots: bool,
         has_repo_binder: bool,
         daemon_unbound: bool,
+        now: Instant,
     ) -> bool {
         let should_begin = should_request_workspace_roots(
             method,
             client_supports_roots,
-            self.in_flight,
+            self.request_in_flight(now),
             has_repo_binder,
             daemon_unbound,
         );
         if should_begin {
-            self.in_flight = true;
+            self.in_flight_since = Some(now);
         }
         should_begin
     }
@@ -287,6 +498,12 @@ impl WorkspaceRootsRequestState {
 /// Decide whether an inbound client message should trigger a workspace-roots
 /// request. Kept separate from the stdio loop so the retry semantics remain
 /// deterministic and testable without mutating process-global daemon state.
+///
+/// A roots *change* is honored whether or not a repository is bound: it is the
+/// only signal an editor sends when its window moves to another folder, and
+/// ignoring it once bound is what leaves the server answering from the previous
+/// repository. The other triggers stay gated on an unbound daemon so a settled
+/// session does not re-ask on every `tools/list`.
 fn should_request_workspace_roots(
     method: Option<&str>,
     client_supports_roots: bool,
@@ -294,17 +511,16 @@ fn should_request_workspace_roots(
     has_repo_binder: bool,
     daemon_unbound: bool,
 ) -> bool {
-    client_supports_roots
-        && !request_in_flight
-        && has_repo_binder
-        && daemon_unbound
-        && matches!(
-            method,
-            Some("initialized")
-                | Some("notifications/initialized")
-                | Some("notifications/roots/list_changed")
-                | Some("tools/list")
-        )
+    if !client_supports_roots || request_in_flight || !has_repo_binder {
+        return false;
+    }
+    match method {
+        Some("notifications/roots/list_changed") => true,
+        Some("initialized") | Some("notifications/initialized") | Some("tools/list") => {
+            daemon_unbound
+        }
+        _ => false,
+    }
 }
 
 /// Extract filesystem paths from an MCP `roots/list` response
@@ -1330,17 +1546,39 @@ mod tests {
 
     #[test]
     fn workspace_roots_request_state_reopens_after_completion() {
+        let now = Instant::now();
         let mut state = WorkspaceRootsRequestState::default();
-        assert!(state.begin_if_allowed(Some("initialized"), true, true, true));
+        assert!(state.begin_if_allowed(Some("initialized"), true, true, true, now));
         assert!(!state.begin_if_allowed(
             Some("notifications/roots/list_changed"),
             true,
             true,
             true,
+            now,
         ));
 
         state.complete();
-        assert!(state.begin_if_allowed(Some("notifications/roots/list_changed"), true, true, true,));
+        assert!(state.begin_if_allowed(
+            Some("notifications/roots/list_changed"),
+            true,
+            true,
+            true,
+            now,
+        ));
+    }
+
+    #[test]
+    fn workspace_roots_request_retries_after_an_unanswered_request_times_out() {
+        let start = Instant::now();
+        let mut state = WorkspaceRootsRequestState::default();
+        assert!(state.begin_if_allowed(Some("initialized"), true, true, true, start));
+
+        // A client that advertises roots and never answers must not wedge
+        // binding for the life of the process.
+        let just_before = start + ROOTS_REQUEST_TIMEOUT - Duration::from_millis(1);
+        assert!(!state.begin_if_allowed(Some("tools/list"), true, true, true, just_before));
+        let after = start + ROOTS_REQUEST_TIMEOUT;
+        assert!(state.begin_if_allowed(Some("tools/list"), true, true, true, after));
     }
 
     #[test]
@@ -1362,5 +1600,369 @@ mod tests {
             true,
             true,
         ));
+    }
+
+    #[test]
+    fn workspace_roots_change_is_honored_after_a_repository_is_already_bound() {
+        // The defect this locks down: with a daemon already bound, the roots
+        // change that an editor sends when its window moves to another folder
+        // was dropped, leaving the server answering from the old repository.
+        assert!(should_request_workspace_roots(
+            Some("notifications/roots/list_changed"),
+            true,
+            false,
+            true,
+            false,
+        ));
+        // Everything else stays gated on an unbound daemon so a settled session
+        // does not re-ask on every tools/list.
+        assert!(!should_request_workspace_roots(
+            Some("notifications/initialized"),
+            true,
+            false,
+            true,
+            false,
+        ));
+        // A roots change still needs a binder and the client capability, and
+        // still never overlaps an in-flight request.
+        assert!(!should_request_workspace_roots(
+            Some("notifications/roots/list_changed"),
+            true,
+            true,
+            true,
+            false,
+        ));
+        assert!(!should_request_workspace_roots(
+            Some("notifications/roots/list_changed"),
+            true,
+            false,
+            false,
+            false,
+        ));
+        assert!(!should_request_workspace_roots(
+            Some("notifications/roots/list_changed"),
+            false,
+            false,
+            true,
+            false,
+        ));
+    }
+
+    // ── Workspace-switch integration over the real stdio loop ──────────────
+
+    /// Records every roots list the server hands the binder and replies with a
+    /// scripted outcome per call, so a test can drive a bind and then a switch.
+    struct ScriptedBinder {
+        outcomes: std::sync::Mutex<std::collections::VecDeque<Option<BoundRepo>>>,
+        calls: std::sync::Arc<std::sync::Mutex<Vec<Vec<PathBuf>>>>,
+    }
+
+    impl ScriptedBinder {
+        fn install(
+            outcomes: Vec<Option<BoundRepo>>,
+        ) -> (
+            RepoBinder,
+            std::sync::Arc<std::sync::Mutex<Vec<Vec<PathBuf>>>>,
+        ) {
+            let calls = std::sync::Arc::new(std::sync::Mutex::new(Vec::new()));
+            let scripted = std::sync::Arc::new(ScriptedBinder {
+                outcomes: std::sync::Mutex::new(outcomes.into()),
+                calls: std::sync::Arc::clone(&calls),
+            });
+            let binder: RepoBinder = Box::new(
+                move |roots: Vec<PathBuf>| -> Pin<Box<dyn Future<Output = Option<BoundRepo>> + Send>> {
+                    let scripted = std::sync::Arc::clone(&scripted);
+                    Box::pin(async move {
+                        scripted.calls.lock().unwrap().push(roots);
+                        let next = scripted.outcomes.lock().unwrap().pop_front();
+                        next.flatten()
+                    })
+                },
+            );
+            (binder, calls)
+        }
+    }
+
+    fn bound_repo(root: &str, daemon_url: &str) -> BoundRepo {
+        BoundRepo {
+            root: PathBuf::from(root),
+            daemon_url: daemon_url.to_string(),
+        }
+    }
+
+    /// Drive the daemon stdio loop over an in-memory transport with a scripted
+    /// client session, and return every message the server wrote back.
+    ///
+    /// The config carries an empty tool allow-list so a `tools/call` that is
+    /// *not* refused for a repo mismatch is answered locally by the allow-list
+    /// branch. That keeps every assertion offline and deterministic: no test
+    /// here ever reaches the daemon delegate, which on a machine with a live
+    /// `KIN_DAEMON_URL` would open a connection and could spawn a daemon.
+    async fn drive_daemon_loop(
+        client_messages: &[serde_json::Value],
+        repo_binder: Option<RepoBinder>,
+        bound_daemon_url: Option<String>,
+    ) -> Vec<serde_json::Value> {
+        let mut input = String::new();
+        for message in client_messages {
+            input.push_str(&message.to_string());
+            input.push('\n');
+        }
+        let mut reader = BufReader::new(input.as_bytes());
+        let mut written: Vec<u8> = Vec::new();
+        let config = McpServerConfig {
+            allowed_tools: Some(HashSet::new()),
+            ..McpServerConfig::default()
+        };
+
+        run_stdio_daemon_over(
+            &mut reader,
+            &mut written,
+            config,
+            repo_binder,
+            bound_daemon_url,
+        )
+        .await
+        .expect("stdio loop must drain the scripted client session");
+
+        String::from_utf8(written)
+            .expect("server output is UTF-8")
+            .lines()
+            .filter(|line| !line.trim().is_empty())
+            .map(|line| serde_json::from_str(line).expect("server output is JSON-RPC"))
+            .collect()
+    }
+
+    fn roots_response(roots: &[&str]) -> serde_json::Value {
+        serde_json::json!({
+            "jsonrpc": "2.0",
+            "id": ROOTS_REQUEST_ID,
+            "result": {
+                "roots": roots
+                    .iter()
+                    .map(|root| serde_json::json!({ "uri": format!("file://{root}") }))
+                    .collect::<Vec<_>>(),
+            },
+        })
+    }
+
+    fn initialize_with_roots_capability() -> serde_json::Value {
+        serde_json::json!({
+            "jsonrpc": "2.0",
+            "id": 1,
+            "method": "initialize",
+            "params": { "capabilities": { "roots": { "listChanged": true } } },
+        })
+    }
+
+    fn tool_call(id: u32, name: &str) -> serde_json::Value {
+        serde_json::json!({
+            "jsonrpc": "2.0",
+            "id": id,
+            "method": "tools/call",
+            "params": { "name": name, "arguments": {} },
+        })
+    }
+
+    fn roots_requests(responses: &[serde_json::Value]) -> Vec<&serde_json::Value> {
+        responses
+            .iter()
+            .filter(|value| value.get("method").and_then(|m| m.as_str()) == Some("roots/list"))
+            .collect()
+    }
+
+    fn tool_error_text(response: &serde_json::Value) -> String {
+        let result: ToolCallResult =
+            serde_json::from_value(response.get("result").cloned().expect("tool result"))
+                .expect("tool result payload");
+        assert_eq!(result.is_error, Some(true), "expected an error result");
+        match result.content.first().expect("error content block") {
+            ContentBlock::Text { text } => text.clone(),
+        }
+    }
+
+    #[tokio::test]
+    async fn roots_change_after_a_bind_rebinds_to_the_new_workspace() {
+        let (binder, calls) = ScriptedBinder::install(vec![
+            Some(bound_repo("/repo/a", "http://127.0.0.1:4111")),
+            Some(bound_repo("/repo/b", "http://127.0.0.1:4222")),
+        ]);
+
+        let responses = drive_daemon_loop(
+            &[
+                initialize_with_roots_capability(),
+                serde_json::json!({"jsonrpc": "2.0", "method": "notifications/initialized"}),
+                roots_response(&["/repo/a"]),
+                serde_json::json!({"jsonrpc": "2.0", "method": "notifications/roots/list_changed"}),
+                roots_response(&["/repo/b"]),
+            ],
+            Some(binder),
+            None,
+        )
+        .await;
+
+        // Two `roots/list` requests: the late bind, then the workspace switch.
+        // On the pre-fix server the second never leaves the process.
+        assert_eq!(
+            roots_requests(&responses).len(),
+            2,
+            "a roots change after a successful bind must re-request roots: {responses:#?}"
+        );
+        let calls = calls.lock().unwrap().clone();
+        assert_eq!(
+            calls,
+            vec![
+                vec![PathBuf::from("/repo/a")],
+                vec![PathBuf::from("/repo/b")]
+            ],
+            "the binder must be re-invoked with the client's new roots"
+        );
+    }
+
+    #[tokio::test]
+    async fn tool_calls_fail_loud_when_the_new_workspace_cannot_be_bound() {
+        // Bind repo A, then switch to a workspace with no bindable Kin repo.
+        let (binder, _calls) = ScriptedBinder::install(vec![
+            Some(bound_repo("/repo/a", "http://127.0.0.1:4111")),
+            None,
+        ]);
+
+        let responses = drive_daemon_loop(
+            &[
+                initialize_with_roots_capability(),
+                serde_json::json!({"jsonrpc": "2.0", "method": "notifications/initialized"}),
+                roots_response(&["/repo/a"]),
+                serde_json::json!({"jsonrpc": "2.0", "method": "notifications/roots/list_changed"}),
+                roots_response(&["/elsewhere/not-a-kin-repo"]),
+                tool_call(7, "semantic_locate"),
+            ],
+            Some(binder),
+            None,
+        )
+        .await;
+
+        let answer = responses
+            .iter()
+            .find(|value| value.get("id").and_then(|id| id.as_u64()) == Some(7))
+            .expect("the tool call must be answered, not dropped");
+        let text = tool_error_text(answer);
+        assert!(
+            text.contains("semantic_locate") && text.contains("/elsewhere/not-a-kin-repo"),
+            "refusal must name the tool and the workspace the client moved to: {text}"
+        );
+        assert!(
+            text.contains("/repo/a"),
+            "refusal must name the repository still bound: {text}"
+        );
+    }
+
+    #[tokio::test]
+    async fn a_bindable_workspace_switch_clears_an_earlier_refusal() {
+        // A → unbindable workspace → B: the refusal must not outlive the switch
+        // that resolves it.
+        let (binder, _calls) = ScriptedBinder::install(vec![
+            Some(bound_repo("/repo/a", "http://127.0.0.1:4111")),
+            None,
+            Some(bound_repo("/repo/b", "http://127.0.0.1:4222")),
+        ]);
+
+        let responses = drive_daemon_loop(
+            &[
+                initialize_with_roots_capability(),
+                serde_json::json!({"jsonrpc": "2.0", "method": "notifications/initialized"}),
+                roots_response(&["/repo/a"]),
+                serde_json::json!({"jsonrpc": "2.0", "method": "notifications/roots/list_changed"}),
+                roots_response(&["/elsewhere/not-a-kin-repo"]),
+                serde_json::json!({"jsonrpc": "2.0", "method": "notifications/roots/list_changed"}),
+                roots_response(&["/repo/b"]),
+                tool_call(9, "semantic_locate"),
+            ],
+            Some(binder),
+            None,
+        )
+        .await;
+
+        let answer = responses
+            .iter()
+            .find(|value| value.get("id").and_then(|id| id.as_u64()) == Some(9))
+            .expect("the tool call must be answered");
+        let text = tool_error_text(answer);
+        assert!(
+            text.contains("not enabled in this MCP profile"),
+            "a successful re-bind must clear the refusal and let the call through: {text}"
+        );
+    }
+
+    #[tokio::test]
+    async fn a_startup_bound_server_still_follows_a_workspace_switch() {
+        // The reported shape: a repository bound before the loop starts (from
+        // --repo/KIN_MCP_REPO/cwd) used to suppress roots handling entirely.
+        let (binder, calls) =
+            ScriptedBinder::install(vec![Some(bound_repo("/repo/b", "http://127.0.0.1:4222"))]);
+
+        let responses = drive_daemon_loop(
+            &[
+                initialize_with_roots_capability(),
+                serde_json::json!({"jsonrpc": "2.0", "method": "notifications/initialized"}),
+                serde_json::json!({"jsonrpc": "2.0", "id": 2, "method": "tools/list"}),
+                serde_json::json!({"jsonrpc": "2.0", "method": "notifications/roots/list_changed"}),
+                roots_response(&["/repo/b"]),
+            ],
+            Some(binder),
+            Some("http://127.0.0.1:4111".to_string()),
+        )
+        .await;
+
+        // `initialized` and `tools/list` must stay quiet for an already-bound
+        // server; only the roots change reaches out.
+        let requests = roots_requests(&responses);
+        assert_eq!(
+            requests.len(),
+            1,
+            "only the roots change may re-request roots once bound: {responses:#?}"
+        );
+        assert_eq!(
+            calls.lock().unwrap().clone(),
+            vec![vec![PathBuf::from("/repo/b")]],
+            "the switch must reach the binder even though startup already bound a repo"
+        );
+    }
+
+    #[tokio::test]
+    async fn an_empty_roots_response_leaves_an_existing_binding_alone() {
+        // No open folder is not a different folder: there is no other
+        // repository the client's calls could be about, so a binding survives
+        // and tool calls are not refused.
+        let (binder, calls) =
+            ScriptedBinder::install(vec![Some(bound_repo("/repo/a", "http://127.0.0.1:4111"))]);
+
+        let responses = drive_daemon_loop(
+            &[
+                initialize_with_roots_capability(),
+                serde_json::json!({"jsonrpc": "2.0", "method": "notifications/initialized"}),
+                roots_response(&["/repo/a"]),
+                serde_json::json!({"jsonrpc": "2.0", "method": "notifications/roots/list_changed"}),
+                roots_response(&[]),
+                tool_call(11, "semantic_locate"),
+            ],
+            Some(binder),
+            None,
+        )
+        .await;
+
+        assert_eq!(
+            calls.lock().unwrap().len(),
+            1,
+            "an empty roots list must not be handed to the binder"
+        );
+        let answer = responses
+            .iter()
+            .find(|value| value.get("id").and_then(|id| id.as_u64()) == Some(11))
+            .expect("the tool call must be answered");
+        let text = tool_error_text(answer);
+        assert!(
+            text.contains("not enabled in this MCP profile"),
+            "an empty roots list must not be treated as a workspace switch: {text}"
+        );
     }
 }


### PR DESCRIPTION
Closes FIR-1484.

## The defect

kin#364 added `notifications/roots/list_changed` to the roots-request trigger list, but two independent gates made a folder switch *after* a successful bind a silent no-op:

- `should_request_workspace_roots` required `daemon_unbound`
- `bind_daemon_for_repo_dir` early-returns the existing `KIN_DAEMON_URL`
- (and kin-cli only installed a `RepoBinder` at all when startup bound nothing)

Result: a shared client process binds repo A, the user moves the window to repo B, and every `semantic_locate`/`get_context_pack`/`trace_data_flow` for B is answered from A's graph — confident, well-formed, wrong, with no surfaced error.

## Chosen behavior: re-bind, with fail-loud as the fallback

- **Re-bind** whenever the client's new roots name a bindable Kin repository. This is what the roots mechanism is for; refusing forever would leave the feature half dead.
- **Fail loud** when they do not. The server enters a refusal state and every `tools/call` returns a structured error naming the repository still bound and the roots the client now reports. A later bindable roots change clears it.
- **A binding is stale only when the repository it serves has left the workspace.** The client's roots are resolved to repositories once, up front, and membership decides — not position. Opening a second folder alongside the bound one, or a client that lists roots in a different order, is not a switch.
- **An explicit `--repo`/`KIN_MCP_REPO` pin is never repointed by the client.** That pin exists to bind a specific repository regardless of what the launching process sees, and making the binder unconditional would otherwise have given it a behavior it never had. A pinned server does not follow roots elsewhere — but it does not answer for them either: it fails loud until the workspace and the pin agree, so neither the pin nor a wrong-repo answer wins silently.
- **A refusing server keeps trying to bind.** Being bound to a repository the client has left is no more useful than being unbound, so a refusing server also qualifies for the ordinary binding triggers and re-asks on `initialized`/`tools/list` until it can bind again. A settled binding still never re-asks.
- **Empty roots list** leaves an existing binding alone: no open folder is not a different folder, so there is no other repository the client's calls could be about. Documented at the branch, not silently assumed.

## Non-obvious mechanics this had to handle

- **The revival URL override outranks `KIN_DAEMON_URL`.** `daemon_delegate::DAEMON_URL_OVERRIDE` is set when the MCP path revives a dead daemon, and `daemon_base_url()` checks it first. A re-bind that only repointed the environment would keep forwarding tool calls to the daemon started for the repository the client left. The server now clears it when the bound daemon actually changes.
- **`KinLayout::discover` short-circuits on `KIN_DAEMON_URL`**, returning `<start>/.kin` without checking that it exists. Once a repository is bound, that would accept *any* directory as the client's new repository, so the binder forces the real upward walk via `discover_with_daemon_url(root, None)`.
- **A failed switch is not restored.** If the new repository's daemon cannot be resolved, the pin stays cleared and the process is unbound. Restoring it would put us back to serving the repository the client left — precisely the bug.
- Paths are canonicalized before comparison so a client-supplied root and the process cwd compare equal for the same repository (`/tmp` vs `/private/tmp`).

## Same-area hardening from the ticket

- `in_flight` had no timeout: a client that advertises the roots capability and never answers `roots/list` wedged binding for the life of the process. It now expires after 30s so a later trigger retries.
- `run_stdio_daemon` hardwired real stdio, leaving the integration seam untested. It is now a thin wrapper over a transport-generic core, and the bind → switch → refuse → re-bind lifecycle is driven end to end over an in-memory transport.

## Tests

Unit (drop-in against the pre-fix function, same signature):

- `workspace_roots_change_is_honored_after_a_repository_is_already_bound` — asserts `should_request_workspace_roots(Some("notifications/roots/list_changed"), true, false, true, /* daemon_unbound */ false)` is `true`. On `main` that predicate ANDs in `daemon_unbound` and returns `false`, so this test fails there. Also pins that the *other* triggers stay gated on an unbound daemon, and that a roots change still respects the capability, binder and in-flight gates.
- `workspace_roots_request_retries_after_an_unanswered_request_times_out`.
- `a_refusing_binding_still_wants_workspace_roots` — the bind → refuse → re-bind state machine.

Integration over the stdio loop (new seam):

- `roots_change_after_a_bind_rebinds_to_the_new_workspace` — two `roots/list` requests emitted, binder re-invoked with the new roots.
- `tool_calls_fail_loud_when_the_new_workspace_cannot_be_bound` — the refusal names the tool, the new roots, and the still-bound repository.
- `a_bindable_workspace_switch_clears_an_earlier_refusal`
- `a_startup_bound_server_still_follows_a_workspace_switch` — the reported shape; also pins that `initialized`/`tools/list` stay quiet once bound.
- `a_refusing_server_keeps_trying_to_bind_on_ordinary_triggers` — a plain `tools/list` while refusing re-requests roots, and a bindable answer clears the refusal.
- `an_empty_roots_response_leaves_an_existing_binding_alone`

kin-cli:

- `roots_naming_the_bound_repo_keep_the_running_daemon` — a redundant roots change does not churn the daemon.
- `the_bound_repo_wins_wherever_it_sits_among_the_roots` — root order does not move a working binding.
- `switching_to_an_unresolvable_repo_never_falls_back_to_the_old_one` — after a failed switch the process is unbound rather than still serving the old repository.
- `an_operator_pin_is_never_repointed_by_workspace_roots` / `an_operator_pin_still_binds_when_the_roots_name_it`
- `roots_with_no_kin_repository_bind_nothing`

Every test is offline: the stdio-loop tests use an empty tool allow-list so a non-refused `tools/call` is answered by the allow-list branch and never reaches the daemon delegate; the kin-cli tests set `KIN_NO_DAEMON=1` so no daemon can be spawned.

## What this does not prove

The five stdio-loop tests exercise a seam that does not exist on `main` (`run_stdio_daemon` hardwired real stdio — itself part of the ticket), so they cannot be run against `main` unmodified; they demonstrate the end-to-end consequence, and the predicate test above is the drop-in falsifier for the pre-fix behavior. No live editor was driven against a real two-repo workspace switch: the binder is exercised through a scripted stand-in, and the daemon-resolution half of a real re-bind is covered only by the CLI's no-op and failure branches.

## Out of scope

FIR-1428 (per-tool-call repo binding via tool args / client roots) is the longer-term shape and is not attempted here. This change keeps one repository per process and makes the transition between repositories honest.