### PR TITLE
Report the gap an artifact-only ref hydration leaves

### DIFF
--- a/crates/kin-cli/src/commands/hydration_depth.rs
+++ b/crates/kin-cli/src/commands/hydration_depth.rs
@@ -1,0 +1,229 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Firelock, LLC
+
+//! Durable record of how deeply a lazy Git-ref hydration imported history.
+//!
+//! Both hydration depths import the same commits and the same artifact deltas.
+//! Only the deeper one replays per-commit entity and relation deltas, and
+//! nothing in the graph distinguishes the two afterwards: a change with no
+//! semantic deltas is exactly what a whitespace-only commit produces at either
+//! depth. Depth therefore has to be *recorded* when the import runs — inferring
+//! it later from "present but empty" would refuse valid refs to catch invalid
+//! ones.
+//!
+//! This module is the persistence boundary for that record, kept out of the
+//! ref-lookup answer path for the same reason the hydration checkpoint store is
+//! kept out of it: reading and writing Kin's own state is an IO boundary, and an
+//! answer path must not hold one. Nothing here reads repository source content,
+//! and no query is ever answered from these files — they only report which
+//! recorded history a graph-backed answer cannot be produced for.
+
+use anyhow::{bail, Context, Result};
+use kin_model::SemanticChangeId;
+use serde::{Deserialize, Serialize};
+use std::collections::HashSet;
+use std::path::{Path, PathBuf};
+
+const RECORD_SCHEMA: &str = "kin.ref-hydration-depth.v1";
+const RECORD_DEPTH: &str = "artifact-only";
+
+/// One hydration that inserted history into the graph with no semantic replay
+/// behind it.
+pub(crate) struct ArtifactOnlyHydration {
+    /// The Git commit whose ancestry the hydration imported. Carried as the
+    /// operator-facing name of the import that produced the gap.
+    pub(crate) tip: String,
+    /// Every change the hydration inserted unreplayed. The whole ancestry is
+    /// recorded, not just the tip: `history --ref <tip>~2` reads an ancestor's
+    /// deltas, and that ancestor is exactly as unreplayed as the tip is.
+    pub(crate) changes: Vec<SemanticChangeId>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+struct StoredRecord {
+    schema: String,
+    depth: String,
+    tip: String,
+    changes: Vec<String>,
+}
+
+/// `.kin/kindb/hydration-depth/` — one record per artifact-only hydration.
+///
+/// Deliberately inside the KinDB directory rather than beside it: the records
+/// describe the depth of the history held in `graph.kndb`, so they are
+/// discarded with the snapshot they describe. A record that outlived its graph
+/// would claim a gap in history the graph no longer holds.
+fn records_dir(layout: &kin_core::KinLayout) -> PathBuf {
+    layout.kindb_dir().join("hydration-depth")
+}
+
+fn write_record_atomically(path: &Path, record: &StoredRecord) -> Result<()> {
+    use std::io::Write;
+
+    let json = serde_json::to_vec_pretty(record)
+        .with_context(|| format!("serialize hydration-depth record {}", path.display()))?;
+    let temp_path = path.with_extension(format!("json.{}.tmp", std::process::id()));
+    {
+        let mut file = std::fs::File::create(&temp_path)
+            .with_context(|| format!("create hydration-depth record {}", temp_path.display()))?;
+        file.write_all(&json)
+            .with_context(|| format!("write hydration-depth record {}", temp_path.display()))?;
+        // Durable before it is visible: this record is what stops a later
+        // semantic caller from answering out of an unreplayed ancestry, so it
+        // has to survive the same crash the graph write it guards survives.
+        file.sync_all()
+            .with_context(|| format!("flush hydration-depth record {}", temp_path.display()))?;
+    }
+    std::fs::rename(&temp_path, path).with_context(|| {
+        format!(
+            "publish hydration-depth record {} as {}",
+            temp_path.display(),
+            path.display()
+        )
+    })
+}
+
+fn read_stored_records(layout: &kin_core::KinLayout) -> Result<Vec<(PathBuf, StoredRecord)>> {
+    let dir = records_dir(layout);
+    let entries = match std::fs::read_dir(&dir) {
+        Ok(entries) => entries,
+        Err(err) if err.kind() == std::io::ErrorKind::NotFound => return Ok(Vec::new()),
+        Err(err) => {
+            return Err(err)
+                .with_context(|| format!("read hydration-depth records in {}", dir.display()))
+        }
+    };
+
+    let mut paths = Vec::new();
+    for entry in entries {
+        let entry =
+            entry.with_context(|| format!("read hydration-depth records in {}", dir.display()))?;
+        let path = entry.path();
+        if path.extension().and_then(|extension| extension.to_str()) == Some("json") {
+            paths.push(path);
+        }
+    }
+    // Directory order is not stable across platforms; reading in sorted order
+    // keeps repeated calls reporting the same gap first.
+    paths.sort();
+
+    let mut records = Vec::new();
+    for path in paths {
+        let bytes = std::fs::read(&path)
+            .with_context(|| format!("read hydration-depth record {}", path.display()))?;
+        let record: StoredRecord = serde_json::from_slice(&bytes)
+            .with_context(|| format!("parse hydration-depth record {}", path.display()))?;
+        // Unreadable or unrecognized state is reported, never assumed away: it
+        // means the depth of the history in this graph cannot be established.
+        if record.schema != RECORD_SCHEMA || record.depth != RECORD_DEPTH {
+            bail!(
+                "hydration-depth record {} declares unsupported schema '{}' depth '{}'",
+                path.display(),
+                record.schema,
+                record.depth
+            );
+        }
+        records.push((path, record));
+    }
+    Ok(records)
+}
+
+fn parse_recorded_change(record: &StoredRecord, change: &str) -> Result<SemanticChangeId> {
+    crate::commands::ref_lookup::parse_change_id(change).with_context(|| {
+        format!(
+            "hydration-depth record for Git commit {} names unparseable change '{}'",
+            record.tip, change
+        )
+    })
+}
+
+/// Every artifact-only hydration this repository has recorded.
+pub(crate) fn artifact_only_hydrations(
+    layout: &kin_core::KinLayout,
+) -> Result<Vec<ArtifactOnlyHydration>> {
+    let mut hydrations = Vec::new();
+    for (_, record) in read_stored_records(layout)? {
+        let mut changes = Vec::with_capacity(record.changes.len());
+        for change in &record.changes {
+            changes.push(parse_recorded_change(&record, change)?);
+        }
+        hydrations.push(ArtifactOnlyHydration {
+            tip: record.tip.clone(),
+            changes,
+        });
+    }
+    Ok(hydrations)
+}
+
+/// Every change recorded as imported without its semantic replay, whether or
+/// not a graph still holds it.
+///
+/// The hydration owner uses this to find history it can upgrade. Readers must
+/// additionally confirm the graph still holds what a record describes.
+pub(crate) fn recorded_change_ids(
+    layout: &kin_core::KinLayout,
+) -> Result<HashSet<SemanticChangeId>> {
+    let mut recorded = HashSet::new();
+    for hydration in artifact_only_hydrations(layout)? {
+        recorded.extend(hydration.changes);
+    }
+    Ok(recorded)
+}
+
+/// Record that `changes` were inserted for `git_oid`'s ancestry unreplayed.
+///
+/// Written before the graph write, never after. A record without the matching
+/// graph state is inert — every reader confirms presence in the graph before
+/// treating a recorded change as a gap — whereas graph state without its record
+/// is exactly the silent wrong answer this exists to prevent.
+pub(crate) fn record_artifact_only(
+    layout: &kin_core::KinLayout,
+    tip: SemanticChangeId,
+    git_oid: &str,
+    changes: &[SemanticChangeId],
+) -> Result<()> {
+    if changes.is_empty() {
+        return Ok(());
+    }
+    let dir = records_dir(layout);
+    std::fs::create_dir_all(&dir)
+        .with_context(|| format!("create hydration-depth directory {}", dir.display()))?;
+    let record = StoredRecord {
+        schema: RECORD_SCHEMA.to_string(),
+        depth: RECORD_DEPTH.to_string(),
+        tip: git_oid.to_string(),
+        changes: changes.iter().map(ToString::to_string).collect(),
+    };
+    // Named by the tip's change id, which is hex by construction. The Git oid
+    // it was derived from arrives as caller text and never becomes a path
+    // component.
+    write_record_atomically(&dir.join(format!("{tip}.json")), &record)
+}
+
+/// Drop `changes` from every record: they now carry semantic deltas, so nothing
+/// about them is a gap any more. A record left describing nothing is removed.
+pub(crate) fn forget_replayed(
+    layout: &kin_core::KinLayout,
+    changes: &[SemanticChangeId],
+) -> Result<()> {
+    if changes.is_empty() {
+        return Ok(());
+    }
+    let replayed: HashSet<String> = changes.iter().map(ToString::to_string).collect();
+    for (path, mut record) in read_stored_records(layout)? {
+        let before = record.changes.len();
+        record.changes.retain(|change| !replayed.contains(change));
+        if record.changes.len() == before {
+            continue;
+        }
+        if record.changes.is_empty() {
+            std::fs::remove_file(&path).with_context(|| {
+                format!("remove satisfied hydration-depth record {}", path.display())
+            })?;
+        } else {
+            write_record_atomically(&path, &record)?;
+        }
+    }
+    Ok(())
+}

--- a/crates/kin-cli/src/commands/init.rs
+++ b/crates/kin-cli/src/commands/init.rs
@@ -910,6 +910,109 @@ fn repair_legacy_git_import_history(
     })
 }
 
+/// True when `existing` is `canonical` as an artifact-only import would have
+/// stored it: every graph-defining field identical, and the two semantic delta
+/// lists — the only thing the skipped per-commit replay produces — empty.
+///
+/// Exact, not heuristic. A commit that genuinely replays to no semantic deltas
+/// (a whitespace-only edit, say) has an empty `canonical` too, so `existing`
+/// already equals it and nothing here matches or rewrites it.
+fn artifact_only_import_remnant_matches(
+    existing: &SemanticChange,
+    canonical: &SemanticChange,
+) -> bool {
+    if !existing.entity_deltas.is_empty() || !existing.relation_deltas.is_empty() {
+        return false;
+    }
+    if canonical.entity_deltas.is_empty() && canonical.relation_deltas.is_empty() {
+        return false;
+    }
+    let Ok(mut expected) = serde_json::to_value(canonical) else {
+        return false;
+    };
+    let Some(object) = expected.as_object_mut() else {
+        return false;
+    };
+    object.insert(
+        "entity_deltas".to_string(),
+        serde_json::Value::Array(Vec::new()),
+    );
+    object.insert(
+        "relation_deltas".to_string(),
+        serde_json::Value::Array(Vec::new()),
+    );
+    matches!(serde_json::to_value(existing), Ok(actual) if actual == expected)
+}
+
+/// Replace history that a lazy ref hydration imported at artifact-only depth
+/// with the semantically replayed changes this import just produced.
+///
+/// This is the upgrade half of hydration-depth ownership, and it has to happen
+/// here. kin-db's `create_change` cannot re-publish an id that is already in the
+/// graph, so a change imported without its semantic replay stays that way until
+/// an owner that can rewrite the snapshot replaces it — which `kin init` is, and
+/// a ref lookup holding only `&InMemoryGraph` is not.
+///
+/// Two independent facts must agree before anything is rewritten: the id is
+/// recorded as artifact-only hydrated, and the stored change still has the exact
+/// shape such an import leaves behind. History that merely differs from this
+/// import (a parser-semantics change, say) is left alone for the existing
+/// deterministic-collision refusal to report.
+fn upgrade_artifact_only_imported_history(
+    manager: &kin_db::SnapshotManager,
+    layout: &kin_core::KinLayout,
+    boundary_root: SemanticChangeId,
+    canonical_imported: &[kin_git::ImportedChange],
+) -> Result<usize> {
+    if canonical_imported.is_empty() {
+        return Ok(0);
+    }
+    let recorded = crate::commands::hydration_depth::recorded_change_ids(layout)
+        .context("read recorded artifact-only hydration depth before importing Git history")?;
+    if recorded.is_empty() {
+        return Ok(0);
+    }
+
+    let graph = manager.graph();
+    let mut snapshot = graph.to_snapshot();
+    let mut upgraded = Vec::new();
+    for canonical in canonical_imported {
+        if !recorded.contains(&canonical.change.id) {
+            continue;
+        }
+        let Some(existing) = snapshot.changes.get(&canonical.change.id) else {
+            continue;
+        };
+        if artifact_only_import_remnant_matches(existing, &canonical.change) {
+            upgraded.push(canonical.change.id);
+        }
+    }
+    if upgraded.is_empty() {
+        return Ok(0);
+    }
+
+    for canonical in canonical_imported {
+        if upgraded.contains(&canonical.change.id) {
+            snapshot
+                .changes
+                .insert(canonical.change.id, canonical.change.clone());
+        }
+    }
+    validate_repaired_change_history(&snapshot.changes, &snapshot.branches, boundary_root)?;
+    rebuild_history_derived_indexes(&mut snapshot);
+    let upgraded_graph =
+        kin_db::InMemoryGraph::from_snapshot_with_text_index(snapshot, layout.text_index_dir());
+    manager.swap(upgraded_graph);
+    manager
+        .save()
+        .context("persist artifact-only history upgraded to semantic depth")?;
+    // Only after the upgraded history is durable: the records are what keeps a
+    // semantic caller from reading through the gap, so they outlive every
+    // failure that could leave the old history in place.
+    crate::commands::hydration_depth::forget_replayed(layout, &upgraded)?;
+    Ok(upgraded.len())
+}
+
 pub async fn run(
     path: Option<String>,
     json: bool,
@@ -1263,6 +1366,26 @@ pub async fn run(
                         // caller's Arc so exact-once collision checks target
                         // the repaired graph rather than the retired view.
                         graph = snap.graph();
+                    }
+
+                    let upgraded_changes = upgrade_artifact_only_imported_history(
+                        &snap,
+                        &layout,
+                        history_boundary_root,
+                        &imported,
+                    )?;
+                    if upgraded_changes > 0 {
+                        warn!(
+                            upgraded_changes,
+                            "upgraded artifact-only hydrated history to semantic depth"
+                        );
+                        graph = snap.graph();
+                        if !json {
+                            println!(
+                                "  Upgraded {} lazily hydrated commit(s) from artifact-only to semantic depth.",
+                                upgraded_changes
+                            );
+                        }
                     }
 
                     let mut last_id = None;
@@ -9768,6 +9891,152 @@ func prCheckout(cmd *cobra.Command, args []string) error {
         assert_eq!(
             local_graph.list_opaque_artifacts().unwrap()[0].file_id,
             opaque.file_id
+        );
+    }
+
+    /// One change in the shape a lazy artifact-only ref hydration leaves in the
+    /// graph, plus the semantically replayed copy of it a later Git import
+    /// produces.
+    fn artifact_only_remnant_pair(
+        parents: Vec<SemanticChangeId>,
+        branch_name: &kin_model::BranchName,
+    ) -> (SemanticChange, SemanticChange) {
+        let change_id = SemanticChangeId::from_hash(Hash256::from_bytes([0x33; 32]));
+        let entity = test_entity("answer", "src/lib.rs");
+        let remnant = SemanticChange {
+            id: change_id,
+            parents,
+            timestamp: Timestamp::now(),
+            author: AuthorId::new("test"),
+            message: "kin import: git commit".to_string(),
+            entity_deltas: vec![],
+            relation_deltas: vec![],
+            artifact_deltas: vec![],
+            projected_files: vec![],
+            spec_link: None,
+            evidence: vec![],
+            risk_summary: None,
+            authored_on: Some(branch_name.clone()),
+        };
+        let replayed = SemanticChange {
+            entity_deltas: vec![EntityDelta::Added(entity)],
+            ..remnant.clone()
+        };
+        (remnant, replayed)
+    }
+
+    /// The upgrade half of hydration-depth ownership: history a lazy ref
+    /// hydration left without its semantic replay is replaced by the replayed
+    /// import, and the record that made semantic callers report a gap is
+    /// retired with it.
+    #[test]
+    fn init_upgrades_recorded_artifact_only_history_to_semantic_depth() {
+        let dir = tempfile::tempdir().unwrap();
+        let layout = kin_core::init(dir.path()).unwrap().layout;
+        let snap = open_snapshot_with_retry(layout.kindb_snapshot_path());
+        let genesis = kin_core::build_genesis_change();
+        let branch_name = kin_model::BranchName::new("main");
+        let (remnant, replayed) = artifact_only_remnant_pair(vec![genesis.id], &branch_name);
+
+        let graph = snap.graph();
+        if graph.get_change(&genesis.id).unwrap().is_none() {
+            graph.create_change(&genesis).unwrap();
+        }
+        graph.create_change(&remnant).unwrap();
+        crate::commands::hydration_depth::record_artifact_only(
+            &layout,
+            remnant.id,
+            "0123456789abcdef0123456789abcdef01234567",
+            &[remnant.id],
+        )
+        .unwrap();
+
+        let imported = vec![kin_git::ImportedChange {
+            change: replayed.clone(),
+            git_oid: "0123456789abcdef0123456789abcdef01234567".to_string(),
+        }];
+        let upgraded =
+            upgrade_artifact_only_imported_history(&snap, &layout, genesis.id, &imported).unwrap();
+
+        assert_eq!(upgraded, 1);
+        let stored = snap.graph().get_change(&remnant.id).unwrap().unwrap();
+        assert_eq!(
+            stored.entity_deltas.len(),
+            1,
+            "the upgraded change must carry the replayed semantics"
+        );
+        assert!(
+            crate::commands::hydration_depth::recorded_change_ids(&layout)
+                .unwrap()
+                .is_empty(),
+            "upgraded history must stop being reported as a gap"
+        );
+    }
+
+    /// The upgrade needs both facts. History that merely differs from this
+    /// import — a parser-semantics change, say — is not an artifact-only
+    /// remnant and is left for the deterministic-collision refusal to report,
+    /// and history nobody recorded as artifact-only hydrated is never rewritten
+    /// on shape alone.
+    #[test]
+    fn init_upgrade_requires_both_the_record_and_the_remnant_shape() {
+        let dir = tempfile::tempdir().unwrap();
+        let layout = kin_core::init(dir.path()).unwrap().layout;
+        let snap = open_snapshot_with_retry(layout.kindb_snapshot_path());
+        let genesis = kin_core::build_genesis_change();
+        let branch_name = kin_model::BranchName::new("main");
+        let (remnant, replayed) = artifact_only_remnant_pair(vec![genesis.id], &branch_name);
+
+        let graph = snap.graph();
+        if graph.get_change(&genesis.id).unwrap().is_none() {
+            graph.create_change(&genesis).unwrap();
+        }
+        graph.create_change(&remnant).unwrap();
+
+        let imported = vec![kin_git::ImportedChange {
+            change: replayed.clone(),
+            git_oid: "0123456789abcdef0123456789abcdef01234567".to_string(),
+        }];
+        assert_eq!(
+            upgrade_artifact_only_imported_history(&snap, &layout, genesis.id, &imported).unwrap(),
+            0,
+            "an unrecorded change must not be rewritten on shape alone"
+        );
+
+        crate::commands::hydration_depth::record_artifact_only(
+            &layout,
+            remnant.id,
+            "0123456789abcdef0123456789abcdef01234567",
+            &[remnant.id],
+        )
+        .unwrap();
+        let diverged = vec![kin_git::ImportedChange {
+            change: SemanticChange {
+                message: "a different commit message".to_string(),
+                ..replayed.clone()
+            },
+            git_oid: "0123456789abcdef0123456789abcdef01234567".to_string(),
+        }];
+        assert_eq!(
+            upgrade_artifact_only_imported_history(&snap, &layout, genesis.id, &diverged).unwrap(),
+            0,
+            "history that differs beyond the skipped replay must not be rewritten"
+        );
+    }
+
+    /// A commit that genuinely replays to no semantic deltas — a whitespace-only
+    /// edit — is stored identically at either depth, so it is never mistaken for
+    /// an unreplayed remnant. This is why depth is recorded rather than inferred
+    /// from "present but empty".
+    #[test]
+    fn a_commit_with_no_semantic_deltas_is_not_an_artifact_only_remnant() {
+        let branch_name = kin_model::BranchName::new("main");
+        let (remnant, replayed) = artifact_only_remnant_pair(vec![], &branch_name);
+
+        assert!(artifact_only_import_remnant_matches(&remnant, &replayed));
+        assert!(
+            !artifact_only_import_remnant_matches(&remnant, &remnant),
+            "an import that replays to nothing leaves the stored change unchanged"
         );
     }
 

--- a/crates/kin-cli/src/commands/mod.rs
+++ b/crates/kin-cli/src/commands/mod.rs
@@ -35,6 +35,7 @@ pub mod graph_recover;
 pub mod graph_viz;
 pub mod health;
 pub mod history;
+pub(crate) mod hydration_depth;
 pub mod impact;
 pub mod import;
 pub mod init;

--- a/crates/kin-cli/src/commands/ref_lookup.rs
+++ b/crates/kin-cli/src/commands/ref_lookup.rs
@@ -4,6 +4,7 @@
 use anyhow::{anyhow, bail, Context, Result};
 use kin_model::{BranchName, ChangeStore, Entity, EntityFilter, GraphStore};
 use kin_model::{Hash256, SemanticChangeId};
+use std::collections::HashSet;
 
 /// A reference did not resolve to a semantic change — unknown ref syntax, a
 /// ref that legitimately does not exist, or a relative-ref hop (`^N`/`~N`)
@@ -45,6 +46,54 @@ fn ref_error(reference: impl Into<String>, reason: impl Into<String>) -> anyhow:
 pub fn is_ref_resolution_error(err: &anyhow::Error) -> bool {
     err.chain()
         .any(|cause| cause.downcast_ref::<RefResolutionError>().is_some())
+}
+
+/// A ref that resolves, but whose ancestry is in the graph without the
+/// per-commit semantic deltas that `history`, `blame`, and `review` read.
+///
+/// This is a graph gap, not bad client input: the ref names real, present
+/// history. Reporting it is what keeps an unhydrated negative distinguishable
+/// from a real one — the alternative is a confident, well-formed empty answer
+/// that a caller cannot tell apart from "this entity genuinely has no history
+/// at this ref".
+#[derive(Debug)]
+pub struct HydrationDepthGapError {
+    reference: String,
+    change: SemanticChangeId,
+    tip: String,
+}
+
+impl std::fmt::Display for HydrationDepthGapError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(
+            f,
+            "ref '{}' resolves to change {}, which this repository imported at artifact-only depth while hydrating Git commit {}: its per-commit entity and relation deltas were never replayed, so semantic history at this ref would read as empty rather than as an answer. Re-import semantic history with `kin init --git-history full` to upgrade it.",
+            self.reference, self.change, self.tip
+        )
+    }
+}
+
+impl std::error::Error for HydrationDepthGapError {}
+
+/// True when `err` is, or wraps via added context, a
+/// [`HydrationDepthGapError`]. Kept separate from
+/// [`is_ref_resolution_error`] so a transport owner can report a graph gap
+/// distinctly from a client-input error without matching on message text.
+pub fn is_hydration_depth_gap_error(err: &anyhow::Error) -> bool {
+    err.chain()
+        .any(|cause| cause.downcast_ref::<HydrationDepthGapError>().is_some())
+}
+
+fn hydration_depth_gap_error(
+    reference: Option<&str>,
+    change: SemanticChangeId,
+    tip: impl Into<String>,
+) -> anyhow::Error {
+    anyhow::Error::new(HydrationDepthGapError {
+        reference: reference.unwrap_or("HEAD").to_string(),
+        change,
+        tip: tip.into(),
+    })
 }
 
 pub(crate) fn parse_change_id(input: &str) -> Result<SemanticChangeId> {
@@ -142,6 +191,45 @@ enum HydrationDepth {
     ArtifactOnly,
 }
 
+/// The first candidate this graph is holding exactly as some artifact-only
+/// hydration left it.
+///
+/// Two facts have to agree, and neither decides alone.
+///
+/// The record is necessary: no property of a stored change identifies an
+/// unreplayed import, because a whitespace-only commit replays to no semantic
+/// deltas either. Treating "present but empty" as unhydrated would refuse refs
+/// that are perfectly answerable.
+///
+/// The graph is confirmatory, and only ever narrows what the record claims. A
+/// record describes a hydration, not a graph: hydration into an ephemeral
+/// session graph records and then discards its growth, and a later import can
+/// insert the same change *with* its replay. So a recorded change is a gap only
+/// while this graph still holds it in the shape the record describes.
+fn first_live_artifact_only_gap(
+    graph: &kin_db::InMemoryGraph,
+    layout: &kin_core::KinLayout,
+    candidates: &HashSet<SemanticChangeId>,
+) -> Result<Option<(SemanticChangeId, String)>> {
+    if candidates.is_empty() {
+        return Ok(None);
+    }
+    for hydration in crate::commands::hydration_depth::artifact_only_hydrations(layout)? {
+        for change_id in &hydration.changes {
+            if !candidates.contains(change_id) {
+                continue;
+            }
+            let Some(change) = graph.get_change(change_id)? else {
+                continue;
+            };
+            if change.entity_deltas.is_empty() && change.relation_deltas.is_empty() {
+                return Ok(Some((*change_id, hydration.tip.clone())));
+            }
+        }
+    }
+    Ok(None)
+}
+
 pub fn resolve_ref_importing_git_if_needed(
     graph: &kin_db::InMemoryGraph,
     layout: &kin_core::KinLayout,
@@ -199,8 +287,14 @@ fn prepare_ref_importing_git_if_needed(
     depth: HydrationDepth,
 ) -> PreparedRefResolution {
     match resolve_ref(graph, layout, reference) {
+        // A ref that already resolves never re-enters hydration, so this is the
+        // only place a semantic caller can learn that the history it is about to
+        // read was imported without its semantic replay. Answering here is what
+        // the old code did, and what made an unhydrated ancestry indistinguishable
+        // from an entity that genuinely has no history at this ref.
         Ok(head) => PreparedRefResolution {
-            resolution: Ok(head),
+            resolution: semantic_depth_is_available(graph, layout, reference, depth, head)
+                .map(|()| head),
             hydrated_changes: 0,
         },
         Err(original_err) => {
@@ -229,6 +323,28 @@ fn prepare_ref_importing_git_if_needed(
                 },
             }
         }
+    }
+}
+
+/// Confirm the resolved ref can answer at the depth the caller resolves for.
+///
+/// Retrieval reads the ref's tree state and is complete at artifact-only depth,
+/// so it never consults the records. `history`, `blame`, and `review` read the
+/// per-commit deltas the artifact-only import skipped, and get the gap reported
+/// instead of an empty answer.
+fn semantic_depth_is_available(
+    graph: &kin_db::InMemoryGraph,
+    layout: &kin_core::KinLayout,
+    reference: Option<&str>,
+    depth: HydrationDepth,
+    head: SemanticChangeId,
+) -> Result<()> {
+    if depth == HydrationDepth::ArtifactOnly {
+        return Ok(());
+    }
+    match first_live_artifact_only_gap(graph, layout, &HashSet::from([head]))? {
+        Some((change, tip)) => Err(hydration_depth_gap_error(reference, change, tip)),
+        None => Ok(()),
     }
 }
 
@@ -566,10 +682,10 @@ fn hydrate_imported_git_ref(
 ) -> Result<usize> {
     match depth {
         HydrationDepth::Semantic => {
-            hydrate_imported_git_ref_with(graph, layout, git_oid, replay_imported_semantics)
+            hydrate_imported_git_ref_with(graph, layout, git_oid, depth, replay_imported_semantics)
         }
         HydrationDepth::ArtifactOnly => {
-            hydrate_imported_git_ref_with(graph, layout, git_oid, skip_imported_semantics)
+            hydrate_imported_git_ref_with(graph, layout, git_oid, depth, skip_imported_semantics)
         }
     }
 }
@@ -654,6 +770,7 @@ fn hydrate_imported_git_ref_with<F>(
     graph: &kin_db::InMemoryGraph,
     layout: &kin_core::KinLayout,
     git_oid: &str,
+    depth: HydrationDepth,
     enrich_semantics: F,
 ) -> Result<usize>
 where
@@ -679,6 +796,31 @@ where
     )
     .with_context(|| format!("hydrate imported Git commit '{}'", git_oid))?;
 
+    // Split the window before any replay or graph write. kin-db's
+    // `create_change` is an insertion primitive, not an upsert, so a change
+    // already in the graph keeps whatever depth it was imported at and the
+    // enriched copy this pass would produce for it is discarded.
+    let mut absent = Vec::with_capacity(imported.len());
+    let mut present = HashSet::new();
+    for imported_change in &imported {
+        let change_id = imported_change.change.id;
+        if graph.get_change(&change_id)?.is_some() {
+            present.insert(change_id);
+        } else {
+            absent.push(change_id);
+        }
+    }
+
+    // Semantics for the already-present part of this ancestry cannot be
+    // published from here, so completing the import would leave history reading
+    // silently through an unreplayed prefix. Report the gap instead — before the
+    // replay this would waste, and before anything is written.
+    if depth == HydrationDepth::Semantic {
+        if let Some((change, tip)) = first_live_artifact_only_gap(graph, layout, &present)? {
+            return Err(hydration_depth_gap_error(Some(git_oid), change, tip));
+        }
+    }
+
     enrich_semantics(&mut imported, &blob_store, layout.root()).with_context(|| {
         format!(
             "semantically hydrate imported Git history for ref '{}'",
@@ -688,9 +830,26 @@ where
 
     admit_imported_changes_for_insert(graph, &imported, genesis_id)?;
 
+    match depth {
+        HydrationDepth::Semantic => {
+            // Everything this pass is about to insert carries replayed deltas,
+            // so no earlier record still describes it.
+            crate::commands::hydration_depth::forget_replayed(layout, &absent)?;
+        }
+        HydrationDepth::ArtifactOnly => {
+            crate::commands::hydration_depth::record_artifact_only(
+                layout,
+                imported_change_id,
+                git_oid,
+                &absent,
+            )?;
+        }
+    }
+
+    let mut pending: HashSet<SemanticChangeId> = absent.iter().copied().collect();
     let mut inserted = 0usize;
     for imported_change in &imported {
-        if graph.get_change(&imported_change.change.id)?.is_none() {
+        if pending.remove(&imported_change.change.id) {
             graph.create_change(&imported_change.change)?;
             inserted += 1;
         }
@@ -861,6 +1020,7 @@ mod tests {
             &first_graph,
             &layout,
             &git_oid,
+            HydrationDepth::Semantic,
             |imported, blob_store, kin_root| {
                 let stats =
                     crate::commands::init::enrich_imported_changes_with_semantics_test_checkpoint(
@@ -885,6 +1045,7 @@ mod tests {
             &second_graph,
             &layout,
             &git_oid,
+            HydrationDepth::Semantic,
             |imported, blob_store, kin_root| {
                 let stats =
                     crate::commands::init::enrich_imported_changes_with_semantics_test_checkpoint(
@@ -923,6 +1084,7 @@ mod tests {
             &refused_graph,
             &layout,
             &git_oid,
+            HydrationDepth::Semantic,
             |imported, blob_store, kin_root| {
                 crate::commands::init::enrich_imported_changes_with_semantics_test_checkpoint(
                     imported,
@@ -973,6 +1135,7 @@ mod tests {
             &graph,
             &layout,
             &git_oid,
+            HydrationDepth::Semantic,
             |imported, blob_store, kin_root| {
                 imported[0].change.parents = vec![dangling];
                 crate::commands::init::enrich_imported_changes_with_semantics_test_checkpoint(
@@ -1020,6 +1183,182 @@ mod tests {
         // blob store both keep reading from it after this function returns.
         let _kept = repo.keep();
         Some((InMemoryGraph::new(), layout, git_oid))
+    }
+
+    /// A two-commit Git repo initialized for Kin, plus an empty graph and both
+    /// commits' oids, oldest first. Returns `None` when Git is unavailable.
+    fn two_commit_repo_for_hydration(
+    ) -> Option<(InMemoryGraph, kin_core::KinLayout, String, String)> {
+        let repo = tempfile::tempdir().unwrap();
+        git_ok(repo.path(), &["init", "-q"])?;
+        assert!(git_ok(repo.path(), &["config", "user.email", "test@kin.dev"]).is_some());
+        assert!(git_ok(repo.path(), &["config", "user.name", "Kin Test"]).is_some());
+        std::fs::write(
+            repo.path().join("lib.rs"),
+            "pub fn answer() -> i32 {\n    42\n}\n",
+        )
+        .unwrap();
+        assert!(git_ok(repo.path(), &["add", "lib.rs"]).is_some());
+        assert!(git_ok(repo.path(), &["commit", "-q", "-m", "initial"]).is_some());
+        let base_oid = git_ok(repo.path(), &["rev-parse", "HEAD"]).unwrap();
+        std::fs::write(
+            repo.path().join("lib.rs"),
+            "pub fn answer() -> i32 {\n    43\n}\n\npub fn extra() -> i32 {\n    1\n}\n",
+        )
+        .unwrap();
+        assert!(git_ok(repo.path(), &["add", "lib.rs"]).is_some());
+        assert!(git_ok(repo.path(), &["commit", "-q", "-m", "follow-up"]).is_some());
+        let head_oid = git_ok(repo.path(), &["rev-parse", "HEAD"]).unwrap();
+        let layout = kin_core::init(repo.path()).unwrap().layout;
+        let _kept = repo.keep();
+        Some((InMemoryGraph::new(), layout, base_oid, head_oid))
+    }
+
+    /// The reported defect: `locate --ref` hydrates at artifact-only depth and
+    /// persists it, and nothing upgrades it, so a later `history`/`blame`/
+    /// `review` at the same ref used to resolve successfully into an ancestry
+    /// with no semantic deltas and report an empty answer that is
+    /// indistinguishable from a real negative.
+    #[test]
+    fn a_semantic_caller_reports_the_gap_a_persisted_artifact_only_hydration_left() {
+        let Some((graph, layout, git_oid)) = single_commit_repo_for_hydration() else {
+            return;
+        };
+
+        resolve_ref_importing_git_if_needed_for_locate(&graph, &layout, Some(&git_oid)).unwrap();
+        assert!(
+            hydrated_tip_change(&graph, &git_oid)
+                .entity_deltas
+                .is_empty(),
+            "fixture must leave the artifact-only history the semantic caller then meets"
+        );
+
+        let error =
+            prepare_ref_importing_git_if_needed_with_report(&graph, &layout, Some(&git_oid))
+                .into_result()
+                .expect_err("a semantic caller must not answer out of artifact-only history");
+        assert!(
+            is_hydration_depth_gap_error(&error),
+            "the gap must be reported as its own failure, not as a bad ref: {error:#}"
+        );
+        assert!(
+            !is_ref_resolution_error(&error),
+            "a present, valid ref is not client-input error: {error:#}"
+        );
+        assert!(
+            format!("{error:#}").contains(&git_oid),
+            "the report must name the import that produced the gap: {error:#}"
+        );
+    }
+
+    /// Retrieval reads the ref's tree state, not the per-commit deltas, so it
+    /// stays answerable at artifact-only depth. Refusing here would trade the
+    /// silent wrong answer for a wrong refusal on the path the depth exists for.
+    #[test]
+    fn recorded_artifact_only_depth_never_refuses_the_retrieval_path() {
+        let Some((graph, layout, git_oid)) = single_commit_repo_for_hydration() else {
+            return;
+        };
+
+        resolve_ref_importing_git_if_needed_for_locate(&graph, &layout, Some(&git_oid)).unwrap();
+        let repeat = resolve_ref_importing_git_if_needed_for_locate_with_report(
+            &graph,
+            &layout,
+            Some(&git_oid),
+        )
+        .expect("locate must keep answering at the depth it hydrated");
+        assert_eq!(repeat.hydrated_changes, 0);
+    }
+
+    /// A record is evidence that some hydration ran at artifact-only depth —
+    /// never that this graph is still holding the result. Daemon session graphs
+    /// hydrate and then discard the growth by design, so a record whose changes
+    /// are absent here must not refuse anything.
+    #[test]
+    fn a_record_whose_changes_this_graph_never_received_refuses_nothing() {
+        let Some((discarded_graph, layout, git_oid)) = single_commit_repo_for_hydration() else {
+            return;
+        };
+
+        resolve_ref_importing_git_if_needed_for_locate(&discarded_graph, &layout, Some(&git_oid))
+            .unwrap();
+        assert!(
+            !crate::commands::hydration_depth::recorded_change_ids(&layout)
+                .unwrap()
+                .is_empty(),
+            "fixture must leave a record behind"
+        );
+
+        let fresh_graph = InMemoryGraph::new();
+        let resolved =
+            resolve_ref_importing_git_if_needed_with_report(&fresh_graph, &layout, Some(&git_oid))
+                .expect("a record without matching graph state must not block hydration");
+        assert!(resolved.hydrated_changes > 0);
+        assert!(
+            !hydrated_tip_change(&fresh_graph, &git_oid)
+                .entity_deltas
+                .is_empty(),
+            "the semantic entry point must still replay"
+        );
+        assert!(
+            crate::commands::hydration_depth::recorded_change_ids(&layout)
+                .unwrap()
+                .is_empty(),
+            "history replayed at semantic depth is no longer a recorded gap"
+        );
+    }
+
+    /// A record describes a hydration, not a graph. A later import can insert
+    /// the same change with its replay — a re-`init` after the graph was
+    /// rebuilt, say — and history that this graph did replay must answer
+    /// normally no matter what an older record still names.
+    #[test]
+    fn a_recorded_change_this_graph_replayed_is_not_reported_as_a_gap() {
+        let Some((graph, layout, git_oid)) = single_commit_repo_for_hydration() else {
+            return;
+        };
+
+        resolve_ref_importing_git_if_needed_with_report(&graph, &layout, Some(&git_oid))
+            .expect("semantic hydration replays the ancestry it imports");
+        let tip = kin_git::semantic_change_id_from_git_oid_hex(&git_oid).unwrap();
+        crate::commands::hydration_depth::record_artifact_only(&layout, tip, &git_oid, &[tip])
+            .unwrap();
+
+        prepare_ref_importing_git_if_needed_with_report(&graph, &layout, Some(&git_oid))
+            .into_result()
+            .expect("replayed history must answer, whatever an older record names");
+    }
+
+    /// The descendant case. Hydrating a child ref imports its whole ancestry,
+    /// but kin-db cannot re-publish the ancestors already sitting in the graph
+    /// at artifact-only depth, so their replayed copies are dropped. Completing
+    /// that import would answer through an unreplayed prefix; it is refused
+    /// before anything is written instead.
+    #[test]
+    fn semantic_hydration_refuses_an_ancestry_it_cannot_replay_before_writing_it() {
+        let Some((graph, layout, base_oid, head_oid)) = two_commit_repo_for_hydration() else {
+            return;
+        };
+        let head_id = kin_git::semantic_change_id_from_git_oid_hex(&head_oid).unwrap();
+
+        resolve_ref_importing_git_if_needed_for_locate(&graph, &layout, Some(&base_oid)).unwrap();
+        assert!(
+            graph.get_change(&head_id).unwrap().is_none(),
+            "fixture must leave the descendant unimported"
+        );
+
+        let error =
+            prepare_ref_importing_git_if_needed_with_report(&graph, &layout, Some(&head_oid))
+                .into_result()
+                .expect_err("an unreplayable prefix must be reported, not imported over");
+        assert!(
+            is_hydration_depth_gap_error(&error),
+            "expected a hydration-depth gap: {error:#}"
+        );
+        assert!(
+            graph.get_change(&head_id).unwrap().is_none(),
+            "the refusal must precede the graph write"
+        );
     }
 
     fn hydrated_tip_change(graph: &InMemoryGraph, git_oid: &str) -> kin_model::SemanticChange {
@@ -1187,6 +1526,7 @@ mod tests {
             &graph,
             &layout,
             &git_oid,
+            HydrationDepth::ArtifactOnly,
             |imported, blob_store, kin_root| {
                 imported[0].change.parents = vec![dangling];
                 skip_imported_semantics(imported, blob_store, kin_root)


### PR DESCRIPTION
FIR-1506.

## The defect

`kin locate --ref git:<oid>` hydrates at `HydrationDepth::ArtifactOnly` and **persists** it. Nothing upgraded it afterwards: `prepare_ref_importing_git_if_needed` only hydrates when `resolve_ref` *fails*, and once the tip exists `resolve_ref` succeeds forever. A later `kin history <entity> --ref git:<oid>` therefore resolved successfully into an ancestry whose per-commit entity and relation deltas were never replayed, and reported `No entity matching '<entity>' found` — confident, well-formed, and indistinguishable from a real negative. `review` diffed empty delta sets the same way.

This is durable, not per-process. Both daemon locate sites hydrate artifact-only into `state.graph` and then call `save_snapshot()`, so the unreplayed ancestry survives daemon restarts.

There was also **no in-product recovery**. Warm `kin init` over a window containing such changes aborts outright with `REFUSED deterministic init change <id>: existing graph payload differs`, because `create_deterministic_change_once` compares full payloads and an artifact-only change differs from canonical by construction. That second consequence was unfiled; it is fixed here too.

## Two facts must agree, and the second one only narrows

**The record is necessary.** No property of a stored change identifies an unreplayed import, because a whitespace-only commit to a source file replays to zero semantic deltas as well. Treating "present but empty" as unhydrated would refuse refs that are perfectly answerable — the cheap heuristic the FIR-1501 lane considered and rejected. Depth is therefore *recorded* when the import runs.

**The graph is confirmatory, and can never trigger a refusal on its own.** A record describes a *hydration*, not a *graph*. Daemon session-scope hydration is ephemeral by design — it records, then discards the growth — and a later import can insert the very same change **with** its replay (a re-`init` after the graph was rebuilt). So a recorded change is a gap only while this graph still holds it in the shape the record describes.

This is the distinction that keeps the check from collapsing into the rejected heuristic: the second condition is a **narrowing** of what the positive record already claims, not an additional trigger. There is no input for which the graph state alone produces a refusal — a change with no record is never refused, however empty it looks.

## What the change does

**Records depth per hydration** — `.kin/kindb/hydration-depth/`, one schema-versioned record per artifact-only hydration, atomic write + fsync + rename. A record names **every** change the hydration inserted unreplayed, not just the tip: `history --ref <tip>~2` reads an ancestor's deltas, and that ancestor is exactly as unreplayed as the tip.

**Semantic callers report the gap** in the two places it can be met:

1. the ref already resolves to a recorded change this graph still holds unreplayed;
2. a semantic hydration's imported ancestry contains recorded unreplayed changes that are **already present** — kin-db's `create_change` cannot re-publish them, so their freshly replayed copies would be dropped and history would read through an unreplayed prefix. Reported before the replay it would waste and before any graph write.

Retrieval is untouched. It resolves at artifact-only depth, reads the ref's tree state rather than the deltas, and never consults the records.

## Behaviour changes

**1. Calls that previously returned a wrong empty answer now fail loudly.** A flow that scopes via `locate --ref git:<oid>` and then runs `review`/`history`/`blame` at that same ref used to diff empty delta sets; it now reports the gap. Any flow that breaks under this was already broken, silently — the refusal makes it legible. (The pinned merge-trust harness is unaffected: its flow is `kin init` → `kin embed` → `kin review shadow`, all semantic entry points, so no artifact-only record is ever created.)

**2. `kin init` rewrites stored history in place.** When a Git import re-produces a change that is recorded as artifact-only hydrated, init replaces the stored change with the replayed one via snapshot rewrite → `validate_repaired_change_history` → `rebuild_history_derived_indexes` → `SnapshotManager::swap` → `save`, then retires the record. This is the same machinery init already uses to repair the legacy Git-import defect.

**The gate, spelled out:** a change is rewritten only when *both* (a) its id appears in a persisted artifact-only hydration record, and (b) the stored change is identical to the freshly imported canonical change once the canonical's `entity_deltas` and `relation_deltas` are emptied — i.e. it differs from canonical in nothing except the two lists the skipped replay produces. History that differs for any other reason (a parser-semantics change, say) fails both halves and is left to the existing deterministic-collision refusal. A commit that genuinely replays to no semantic deltas has an empty canonical too, so stored already equals canonical and nothing matches or is touched.

The upgrade lives in `init` rather than at query time because kin-db's `create_change` is an insertion primitive, not an upsert — re-inserting an id already in the graph appends to every parent's reverse-child vector and replays entity revisions. Replacing a stored change requires a snapshot rewrite, which `init` owns and a ref lookup holding only `&InMemoryGraph` does not.

## Transitional debt: the record is a file, and should not stay one

Hydration depth is state about graph-owned truth and belongs **in** that truth. It lives in a sidecar file only because `kin-db` is registry-pinned at 0.2.39 and cannot be given a place to hold it without a publish. The umbrella thesis is that filesystem surfaces are derived views over graph truth, and a sidecar consulted for an authority decision runs against that grain. Read this as migration debt with a clear retirement path — depth becomes a graph-native property of an imported change, and both the store and its reader disappear — not as the steady-state design.

The store is confined to `commands/hydration_depth.rs` rather than living in `ref_lookup.rs`, which is in the zero-file-search checker's `QUERY_COMMANDS` set: a `std::fs` call there fails CI, correctly. This mirrors the split `init` already uses for its hydration checkpoint store. All four repo guards were run locally and pass (`verify-zero-file-search.py`, `zero_file_search_guard.sh`, `check_runtime_boundaries.sh`, `check_private_repo_coupling.sh`).

## Falsification

Throwaway draft #390 carried one assertion on unmodified `main` (4998a4bc) and nothing else. Result: **`1046 passed; 1 failed`**, the single failure being the probe:

> `a semantic caller resolved into history with no replayed entity deltas: history, blame, and review answer empty here`

Failing jobs: [ubuntu](https://github.com/firelock-ai/kin/actions/runs/29850963976/job/88703428132), [macos](https://github.com/firelock-ai/kin/actions/runs/29850963976/job/88703428145). The probe asserted `hydrated_changes == 0` and **passed that assertion first**, which proves the mechanism rather than describing it: the tip is present, so nothing re-hydrates and nothing upgrades the depth. On this PR the same suite is `1054 passed; 0 failed`.

Eight tests cover: the reported sequence reports the gap; retrieval still answers at artifact-only depth; a record whose changes this graph never received refuses nothing; a recorded change this graph replayed is not a gap (the narrowing condition); the descendant case refuses before the graph write; the init upgrade needs both facts; and a commit that replays to nothing is never mistaken for a remnant.

## Interaction with #384

`/history`, `/blame` and `/review`-shadow now run their hydration inside `spawn_blocking`. Checked deliberately rather than assumed: the gap error **never crosses as a `JoinError`**. `prepare_*_request` returns `Ok(prepared)` with the error carried as data inside `PreparedRefResolution`, so it rides across the boundary inside `T`; `prepare_on_blocking_pool`'s `T: Send + 'static` bound is what admits it, and that is compile-enforced. Classification and rendering happen after the boundary, on the async side, exactly as before #384.

## Boundaries

`crates/kin-daemon/src/api.rs` is untouched. The daemon surfaces the gap through its existing generic path, so on `history`/`blame` the client gets the full report as the response body; `review` wraps with `.with_context(...)` and the daemon formats with `{}`, so there the explanation is one `{:#}` away. `is_hydration_depth_gap_error` is exposed alongside `is_ref_resolution_error` so the api.rs owner can classify and render a graph gap distinctly from client input without matching on message text.
