### PR TITLE
Make the Zero File-Search guards see the whole file

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -297,10 +297,6 @@ jobs:
           trap 'rm -rf "$poisoned"' EXIT
           cp -a crates scripts "$poisoned/"
 
-          probe='fn workspace_source_path_exists(p: &str, root: &std::path::Path) -> bool {
-              root.join(p).is_file()
-          }'
-
           fail_expected() {
             local label="$1" want="$2"; shift 2
             local out rc=0
@@ -315,19 +311,16 @@ jobs:
             echo "  ok: $label"
           }
 
-          echo "[1/3] reintroduced existence probe in an answer module"
-          printf '%s\n' "$probe" > "$poisoned/crates/kin-cli/src/commands/locate.rs"
-          fail_expected "shell guard" "locate.rs" bash "$poisoned/scripts/zero_file_search_guard.sh" "$poisoned"
-          fail_expected "python guard" "locate.rs" python3 "$poisoned/scripts/verify-zero-file-search.py" "$poisoned"
+          # [1/2] Every answer module, poisoned at several sites including
+          # end-of-file, against both guards. This step used to plant one probe
+          # in one module, at the top of a file it had truncated to three lines.
+          # That proved the guards worked at that spot and nowhere else, and it
+          # passed for as long as a comment-tracking desync left the last third
+          # of the largest answer module unscanned.
+          echo "[1/2] every answer module, every probe site, both guards"
+          python3 scripts/falsify-zero-file-search.py "$poisoned"
 
-          echo "[2/3] new raw read inside a pinned-exemption module"
-          cp -a crates/kin-cli/src/commands/locate.rs "$poisoned/crates/kin-cli/src/commands/locate.rs"
-          printf '\nfn leak(p: &str) -> String {\n    std::fs::read_to_string(p).unwrap()\n}\n' \
-            >> "$poisoned/crates/kin-cli/src/commands/deps.rs"
-          fail_expected "python guard" "deps.rs" python3 "$poisoned/scripts/verify-zero-file-search.py" "$poisoned"
-
-          echo "[3/3] allowlist entry naming a path that no longer exists"
-          cp -a crates/kin-cli/src/commands/deps.rs "$poisoned/crates/kin-cli/src/commands/deps.rs"
+          echo "[2/2] allowlist entry naming a path that no longer exists"
           python3 - "$poisoned/scripts/zero-file-search-allowlist.json" <<'PY'
           import json, sys
           path = sys.argv[1]

--- a/scripts/falsify-zero-file-search.py
+++ b/scripts/falsify-zero-file-search.py
@@ -1,0 +1,202 @@
+#!/usr/bin/env python3
+"""Falsify the Zero File-Search guards against a poisoned tree.
+
+A guard that has never been shown to fail proves nothing. A guard shown to
+fail at ONE location proves only that it works at that location: it cannot
+distinguish "the guard enforces" from "the guard enforces here". That
+distinction is not academic. A desync in the checker's comment and brace
+tracking once left roughly a third of the largest answer module unscanned,
+and a single-point falsification passed the whole time, because the probe
+was planted inside the region that still worked.
+
+So this poisons every module the guard claims to enforce, at several points
+each including end-of-file, and requires the guard to fail and to name the
+offending file every time.
+
+The enforced-module list is read from the guard itself rather than restated
+here. A module added to the guard's coverage is falsified automatically, and
+this harness cannot quietly fall behind what the guard claims to cover.
+
+Usage: falsify-zero-file-search.py <tree_root>
+"""
+import importlib.util
+import json
+import os
+import subprocess
+import sys
+
+POISON = "fn __falsification_probe(p: &str) -> String { std::fs::read_to_string(p).unwrap() }"
+CMD_DIR = "crates/kin-cli/src/commands"
+
+
+def load_guard(root):
+    path = os.path.join(root, "scripts", "verify-zero-file-search.py")
+    spec = importlib.util.spec_from_file_location("zfs_guard", path)
+    module = importlib.util.module_from_spec(spec)
+    argv = sys.argv
+    sys.argv = ["verify-zero-file-search.py", root]
+    try:
+        spec.loader.exec_module(module)
+    except SystemExit:
+        # The guard runs main() on import and exits; we only want its constants.
+        pass
+    finally:
+        sys.argv = argv
+    return module
+
+
+def whole_file_exempt(root):
+    """Files the allowlist exempts entirely, which the guard therefore never
+    scans. Excluding them here is correct, but it must be visible: an
+    exemption that silently cancels a module's enforcement is exactly the kind
+    of gap this harness exists to surface."""
+    path = os.path.join(root, "scripts", "zero-file-search-allowlist.json")
+    with open(path, "r", encoding="utf-8") as f:
+        data = json.load(f)
+    return {e["file"] for e in data.get("allowlist", []) if not e.get("allow_match")}
+
+
+def production_end(lines):
+    """Index of the first column-0 `#[cfg(test)]`, or len(lines).
+
+    Deliberately a plain textual marker rather than the guard's own lexer. If
+    this harness chose its probe sites using the parser it is testing, a
+    parser that mistakenly believes it is inside a test module would steer
+    every probe into the region it still scans, and the bug would hide from
+    the check built to catch it.
+    """
+    for i, line in enumerate(lines):
+        if line.startswith("#[cfg(test)]"):
+            return i
+    return len(lines)
+
+
+def probe_sites(lines):
+    """(label, insert-after index) pairs spanning the production region."""
+    end = production_end(lines)
+    sites = [("eof", len(lines))]
+    if end >= 8:
+        for label, idx in (("quarter", end // 4), ("half", end // 2), ("last-prod", end - 1)):
+            # Snap back to a blank line so the probe cannot land inside a
+            # multi-line string or a block comment, where the guard is right
+            # to ignore it.
+            j = idx
+            while j > 0 and lines[j].strip():
+                j -= 1
+            sites.append((label, j if j > 0 else idx))
+    return sites
+
+
+def shell_guard_modules(root):
+    """The answer modules the shell guard lists, read from the script itself.
+
+    Read rather than restated for the same reason as the Python list: a
+    harness that keeps its own copy of what it is supposed to cover will
+    eventually cover something else.
+    """
+    path = os.path.join(root, "scripts", "zero_file_search_guard.sh")
+    modules, collecting = set(), False
+    with open(path, "r", encoding="utf-8") as f:
+        for line in f:
+            if line.startswith("authority_files=("):
+                collecting = True
+                continue
+            if collecting:
+                if line.strip() == ")":
+                    break
+                entry = line.strip().strip('"')
+                if entry.startswith("$cmd_dir/"):
+                    modules.add(entry.split("/")[-1])
+    return modules
+
+
+def run(cmd):
+    result = subprocess.run(cmd, capture_output=True, text=True)
+    return result.returncode, result.stdout + result.stderr
+
+
+def main():
+    if len(sys.argv) != 2:
+        print(__doc__)
+        return 2
+    root = os.path.abspath(sys.argv[1])
+    guard = load_guard(root)
+    exempt = whole_file_exempt(root)
+    shell_modules = shell_guard_modules(root)
+
+    enforced, skipped = [], []
+    cmd_dir = os.path.join(root, CMD_DIR)
+    for name in sorted(os.listdir(cmd_dir)):
+        if name not in guard.QUERY_COMMANDS and name not in shell_modules:
+            continue
+        rel = f"{CMD_DIR}/{name}"
+        python_scans = name in guard.QUERY_COMMANDS and rel not in exempt
+        shell_scans = name in shell_modules
+        if python_scans or shell_scans:
+            enforced.append((rel, python_scans, shell_scans))
+        else:
+            skipped.append(rel)
+
+    if skipped:
+        print("Not falsifiable — the allowlist exempts these answer modules entirely,")
+        print("so the guard never scans them despite their being listed as query commands:")
+        for rel in skipped:
+            print(f"  - {rel}")
+        print()
+
+    if not enforced:
+        print("::error::no enforced answer modules to falsify")
+        return 1
+
+    py_guard = os.path.join(root, "scripts", "verify-zero-file-search.py")
+    sh_guard = os.path.join(root, "scripts", "zero_file_search_guard.sh")
+
+    print(f"Falsifying {len(enforced)} answer modules at up to 4 sites each")
+    print("  py = Python checker, sh = shell guard, - = module not in that guard's scope\n")
+    failures = []
+    for rel, python_scans, shell_scans in enforced:
+        path = os.path.join(root, rel)
+        with open(path, "r", encoding="utf-8") as f:
+            original = f.read()
+        lines = original.split("\n")
+        marks = []
+        try:
+            for label, idx in probe_sites(lines):
+                poisoned = lines[:idx] + [POISON] + lines[idx:]
+                with open(path, "w", encoding="utf-8") as f:
+                    f.write("\n".join(poisoned))
+                cell = []
+                for tag, scans, cmd in (
+                    ("py", python_scans, [sys.executable, py_guard, root]),
+                    ("sh", shell_scans, ["bash", sh_guard, root]),
+                ):
+                    if not scans:
+                        cell.append("-")
+                        continue
+                    code, out = run(cmd)
+                    if code == 0:
+                        failures.append(f"{rel} @ {label}: {tag} guard PASSED on a poisoned tree")
+                        cell.append("BLIND")
+                    elif os.path.basename(rel) not in out:
+                        failures.append(f"{rel} @ {label}: {tag} guard failed but never named the file")
+                        cell.append("UNNAMED")
+                    else:
+                        cell.append("ok")
+                marks.append(f"{label}=py:{cell[0]}/sh:{cell[1]}")
+        finally:
+            with open(path, "w", encoding="utf-8") as f:
+                f.write(original)
+        print(f"  {os.path.basename(rel):24} {'  '.join(marks)}")
+
+    if failures:
+        print()
+        for f in failures:
+            print(f"::error::falsification failed — {f}")
+        return 1
+
+    print("\nEvery enforced answer module fails its guards when poisoned, at every site.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/verify-zero-file-search.py
+++ b/scripts/verify-zero-file-search.py
@@ -178,7 +178,12 @@ QUERY_COMMANDS = {
     "overview.rs",
     # health reports on the local install and graph state. Environment probes
     # here are a diagnostic boundary, but repo-content reads would not be.
-    "health.rs"
+    "health.rs",
+    # `kin mcp` is how agents reach Kin. It is a launcher today and carries no
+    # filesystem primitive at all, which is exactly why it belongs here: the
+    # agent-facing entry point should never become the one answer surface that
+    # nothing was watching.
+    "mcp.rs"
 }
 
 # Query/answer authority handlers that live inside an otherwise IO-boundary
@@ -276,6 +281,132 @@ def find_fn_body_ranges(lines, fn_names):
     return ranges
 
 
+class LexState:
+    """Carries lexical context across line boundaries.
+
+    Block comments, string literals and raw strings all span lines in Rust, so
+    a line cannot be classified in isolation.
+    """
+
+    __slots__ = ("block_depth", "string", "raw_hashes")
+
+    def __init__(self):
+        self.block_depth = 0
+        self.string = None
+        self.raw_hashes = 0
+
+
+# `r"`, `r#"`, `br##"`, `b"` -- the raw and byte string openers.
+RAW_OPEN = re.compile(r'(b?)r(#*)"|b"')
+IDENT_CHAR = re.compile(r"[A-Za-z0-9_]")
+
+
+def split_code(line, st):
+    """Split one line into (structure, code), advancing the lexer state.
+
+    `structure` is the line with comments removed AND every literal's contents
+    blanked out. Brace depth and keyword detection read this, so a `{` inside a
+    string, or the word `mod tests` inside one, cannot move the parser.
+
+    `code` is the line with comments removed but literals intact. The violation
+    patterns read this, because some of them legitimately match literal text --
+    `Command::new("git")` is only recognisable with the string still in place.
+
+    Splitting the two is the whole point: structure tracking must ignore
+    literals, and pattern matching must not.
+    """
+    structure = []
+    code = []
+    i, n = 0, len(line)
+
+    while i < n:
+        ch = line[i]
+
+        if st.block_depth > 0:
+            # Rust block comments nest, so `/*` inside one opens another level.
+            if line.startswith("/*", i):
+                st.block_depth += 1
+                i += 2
+            elif line.startswith("*/", i):
+                st.block_depth -= 1
+                i += 2
+            else:
+                i += 1
+            continue
+
+        if st.string == "raw":
+            if ch == '"' and line[i + 1 : i + 1 + st.raw_hashes] == "#" * st.raw_hashes:
+                code.append(line[i : i + 1 + st.raw_hashes])
+                i += 1 + st.raw_hashes
+                st.string = None
+            else:
+                code.append(ch)
+                i += 1
+            continue
+
+        if st.string == "normal":
+            if ch == "\\":
+                code.append(line[i : i + 2])
+                i += 2
+            elif ch == '"':
+                code.append(ch)
+                i += 1
+                st.string = None
+            else:
+                code.append(ch)
+                i += 1
+            continue
+
+        if line.startswith("//", i):
+            break
+
+        if line.startswith("/*", i):
+            st.block_depth = 1
+            i += 2
+            continue
+
+        # A raw or byte string opener, but only where it starts a token --
+        # otherwise the `r` ending an identifier would be mistaken for one.
+        if ch in "rb" and not (i and IDENT_CHAR.match(line[i - 1])):
+            m = RAW_OPEN.match(line, i)
+            if m:
+                code.append(m.group(0))
+                st.string = "raw" if "r" in m.group(0) else "normal"
+                st.raw_hashes = len(m.group(2) or "")
+                i = m.end()
+                continue
+
+        if ch == '"':
+            code.append(ch)
+            st.string = "normal"
+            i += 1
+            continue
+
+        if ch == "'":
+            # A char literal, or a lifetime. `'a'` is a literal; `'static` is
+            # not, and consuming it as one would swallow the rest of the line.
+            if line.startswith("\\", i + 1):
+                j = i + 2
+                while j < n and line[j] != "'":
+                    j += 1
+                code.append(line[i : j + 1])
+                i = j + 1
+            elif i + 2 < n and line[i + 2] == "'":
+                code.append(line[i : i + 3])
+                i += 3
+            else:
+                structure.append(ch)
+                code.append(ch)
+                i += 1
+            continue
+
+        structure.append(ch)
+        code.append(ch)
+        i += 1
+
+    return "".join(structure), "".join(code)
+
+
 def scan_file(filepath, rel_path, query_fn_names=None, allowed_matches=None):
     violations = []
 
@@ -288,30 +419,19 @@ def scan_file(filepath, rel_path, query_fn_names=None, allowed_matches=None):
         find_fn_body_ranges(lines, query_fn_names) if query_fn_names else None
     )
 
-    in_block_comment = False
+    lex = LexState()
     in_test_module = False
     brace_depth = 0
     test_module_brace_depth = -1
 
     for idx, line in enumerate(lines, 1):
-        stripped = line.strip()
-
-        # Track block comments
-        if "/*" in stripped:
-            in_block_comment = True
-        if in_block_comment:
-            if "*/" in stripped:
-                in_block_comment = False
-            continue
-
-        # Ignore single line comments
-        if stripped.startswith("//"):
-            continue
-
-        # Remove trailing comments
-        if "//" in line:
-            line = line.split("//")[0]
-            stripped = line.strip()
+        # Comments and literals are removed lexically rather than by substring
+        # search. A `//` or `/*` inside a string literal used to truncate the
+        # line or latch block-comment mode on to EOF, desynchronising brace
+        # depth so the scanner believed it had entered `mod tests` and quietly
+        # stopped enforcing for the rest of the file.
+        structure, line = split_code(line, lex)
+        stripped = structure.strip()
 
         # Track test module to ignore test code inside source files
         if "mod tests" in stripped or "#[cfg(test)]" in stripped:

--- a/scripts/zero_file_search_guard.sh
+++ b/scripts/zero_file_search_guard.sh
@@ -58,22 +58,39 @@ allow_for() {
   esac
 }
 
-# Line number of the inline `#[cfg(test)]` test module (scan stops before it, so
-# test-only filesystem IO is never mistaken for an answer-path leak). Prints the
-# past-the-end line when a file has no such module.
-test_module_line() {
+# First and last line of the inline `#[cfg(test)]` test module, so test-only
+# filesystem IO is never mistaken for an answer-path leak. Prints a span past
+# the end of the file when there is no such module.
+#
+# The span is bounded at both ends deliberately. Skipping from the test module
+# to end-of-file instead left everything after it unscanned — in the largest
+# answer module that was a third of the file, and a raw read appended at the
+# end passed the guard untouched. Production code after a test module is
+# unusual but perfectly legal, and "unusual" is precisely where a leak survives.
+test_module_span() {
   # A `#[cfg(test)]` attribute attaches to the next real item; intervening
   # lines are only other attributes, comments, or blanks. The test module is
   # the first `#[cfg(test)]` whose next real item is a `mod` (a `#[cfg(test)]`
   # on a plain `fn` is a test helper amid production code and is not a boundary).
+  # The module ends at the first `}` in column zero at or after it. Counting
+  # braces instead would need to know which ones sit inside a string or a
+  # comment, and a scanner that guesses at that desynchronises and silently
+  # swallows the rest of the file. `cargo fmt --check` runs in the same job, so
+  # a top-level item's closing brace is reliably unindented.
+  #
+  # If no such line exists the span runs to end of file, which is the old
+  # blind behaviour — but scripts/falsify-zero-file-search.py plants a probe at
+  # end of file in every listed module, so that case fails CI rather than
+  # quietly disabling the guard.
   awk '
-    /^[[:space:]]*#\[cfg\(test\)\]/ { cfg=NR; watching=1; next }
-    watching {
+    !found && /^[[:space:]]*#\[cfg\(test\)\]/ { cfg=NR; watching=1; next }
+    watching && !found {
       if ($0 ~ /^[[:space:]]*(#|\/\/|$)/) next
-      if ($0 ~ /^[[:space:]]*mod /) { print cfg; found=1; exit }
-      watching=0
+      if ($0 ~ /^[[:space:]]*mod /) { found=1; start=cfg }
+      else { watching=0; next }
     }
-    END { if (!found) print NR + 1 }
+    found && NR > start && /^\}[[:space:]]*$/ { print start, NR; done=1; exit }
+    END { if (!done) print (found ? start : NR + 1), NR + 1 }
   ' "$1"
 }
 
@@ -83,11 +100,13 @@ for rel in "${authority_files[@]}"; do
   [[ -f "$file" ]] || continue
   base="$(basename "$rel")"
   allow="$(allow_for "$base")"
-  boundary="$(test_module_line "$file")"
+  read -r test_start test_end <<<"$(test_module_span "$file")"
 
-  # Non-test region only, with line numbers preserved from the original file.
-  region="$(head -n "$((boundary - 1))" "$file")"
-  hits="$(printf '%s\n' "$region" | grep -nE "$deny_re" || true)"
+  # Everything outside the test module, before it and after it alike, with the
+  # original line numbers preserved.
+  region="$(awk -v s="$test_start" -v e="$test_end" \
+    'NR < s || NR > e { print NR ":" $0 }' "$file")"
+  hits="$(printf '%s\n' "$region" | grep -E "$deny_re" || true)"
   [[ -n "$hits" ]] || continue
   if [[ -n "$allow" ]]; then
     hits="$(printf '%s\n' "$hits" | grep -vF "$allow" || true)"


### PR DESCRIPTION
A raw `std::fs::read_to_string` appended to the end of `locate.rs` passed **both** guards. The rule's most important answer module could be violated in its last third and nothing would say so.

Reproduced on a clean tree at `origin/main` before changing anything, and again against the fixed guards.

## Two unrelated causes, one symptom

**The Python checker tracked comments and braces by substring search.** Two ordinary lines of production code were enough:

| file | trigger | effect |
|---|---|---|
| `locate.rs` | a `//` inside a string literal | line truncated there, trailing `{` dropped, brace depth desynced permanently |
| `rename.rs:544` | `\|\| trimmed.starts_with("/*")` | block-comment mode latched on, no closing delimiter ever arrives |

Once depth desynced, the scanner believed it had entered `mod tests` and stopped enforcing to end of file.

Replaced with a lexer that knows where literals begin and end — raw and byte strings, escapes, nested block comments, and the char-versus-lifetime ambiguity (`'a'` is a literal, `'static` is not, and consuming it as one swallows the line).

The split matters: **structure tracking** reads the line with literal contents blanked, so a `{` or the words `mod tests` inside a string cannot move the parser; **pattern matching** still reads them intact, because some patterns must match literal text — `Command::new("git")` is unrecognisable otherwise.

**The shell guard had a different bug with the same symptom**: it stopped at the test module and never resumed, leaving everything after it invisible. Now the skipped span is bounded at both ends. Its end is the first unindented `}` rather than a brace count — counting braces without knowing which sit inside literals is the same bug in a second language, and `cargo fmt --check` runs in this same job, so a top-level closing brace is reliably at column 0.

## Coverage

| module | newly enforced | removed from enforcement |
|---|---|---|
| `locate.rs` | 1,445 lines | 0 |
| `rename.rs` | 168 lines | 0 |

Strictly additive — nothing that was scanned before is skipped now. Both newly-covered regions are clean, which is the re-scan the ticket asked for.

**A correction to the ticket's framing.** It reads as though ~7,456 lines of `locate.rs` had lost coverage. They had not: the real `mod tests` genuinely is that long and is legitimately skipped by both the old and new scanners. The actual lost enforcement was the 1,445 scattered lines above, plus the entire region past end-of-file where an appended leak lands. Smaller than stated, and in a more dangerous place.

`mcp.rs` is now scanned too. It carries no filesystem primitive at all today, which is exactly the point — the surface agents reach Kin through should not be the one answer path nobody was watching.

## The falsification step was the real defect

It planted one probe at the top of a file it had **first truncated to three lines** (`>` not `>>`). That proves the guards work at that spot and nowhere else, and it passed for as long as the blind region existed.

`scripts/falsify-zero-file-search.py` replaces it: every module either guard claims to cover, four sites each including end-of-file, both guards, each required to fail **and to name the file**.

Two properties that make it more than a bigger loop:

- **It reads its module list from the guards themselves.** Add a module to `QUERY_COMMANDS` or `authority_files` and it is falsified automatically; the harness cannot fall behind what the guards claim.
- **It picks probe sites without using the parser under test.** Sites come from a plain column-0 `#[cfg(test)]` marker. Had it used the guard's own lexer, a lexer wrongly believing it was inside a test module would have steered every probe into the region it still scanned — the bug hiding from the check built to catch it.

Verified in both directions:

```
against the fixed guards:     all 19 modules, all sites, both guards -> caught
against the previous checker: locate.rs @ eof        -> BLIND
                              rename.rs @ eof        -> BLIND
                              rename.rs @ last-prod  -> BLIND   (a third site the ticket did not enumerate)
```

## One gap this surfaced, deliberately not fixed here

`health.rs` is listed in `QUERY_COMMANDS` but carries a **whole-file** allowlist exemption, so the guard never scans it — it cannot be falsified at any site. Two policy surfaces disagree and the checker silently resolves it in favour of skipping.

Converting it to a pinned `allow_match` means deciding which of its install-diagnostic probes are justified. That is a policy judgement, not a checker bug, so the harness now **prints it as an explicit exclusion on every run** rather than my quietly changing it. It needs its own ticket.

## Verification

Both guards pass on a clean tree; the full CI falsification sequence was run locally end to end. No cargo build or test was run — a citable cohort holds this machine.