### PR TITLE
Classify the MCP repository-selection canonicalize as a boundary

### DIFF
--- a/scripts/zero-file-search-allowlist.json
+++ b/scripts/zero-file-search-allowlist.json
@@ -100,6 +100,15 @@
       ]
     },
     {
+      "file": "crates/kin-cli/src/commands/mcp.rs",
+      "reason": "Repository selection boundary: resolves symlinks on a repository root so a client-supplied workspace root and the process working directory compare equal when they name the same repo (/tmp against /private/tmp on macOS, tempdirs under /var/folders in fixtures). It decides which repository to bind, before a binding exists and before any graph is consulted, so it precedes the answer path rather than serving it: no file contents are read and no query result derives from it. The error case falls back to the path as given rather than treating failure as absence, so it is not an existence probe. Pinned to the whole expression, so a bare canonicalize that did read failure as a signal, or any other filesystem primitive in this module, still fails the guard",
+      "owner": "kin-cli",
+      "expiration": "2026-12-31",
+      "allow_match": [
+        "std::fs::canonicalize(path).unwrap_or_else(|_| path.to_path_buf())"
+      ]
+    },
+    {
       "file": "crates/kin-cli/src/commands/health.rs",
       "reason": "Config/diagnostic IO: kin health reports on the local installation, so the environment is its subject, not a source of semantic answers. Every probe targets the install — daemon binary, VFS shim header, shell hook and rc, AI-client MCP config files, editor extensions dir, pending session runs. It must never read repo content to answer a semantic query",
       "owner": "kin-cli",


### PR DESCRIPTION
`main` is red. Fixes it forward.

```
[VIOLATION] crates/kin-cli/src/commands/mcp.rs
  Line 242: std::fs::canonicalize(path).unwrap_or_else(|_| path.to_path_buf())
```

MCP re-bind (#388) added the `canonicalize`; #391 added `mcp.rs` to the scanned set. Both were green alone and neither could see the other.

## I agree it is a boundary, and here is what I checked

I read both call sites rather than taking the description. `canonical_path` is applied at `mcp.rs:148` and `mcp.rs:227`, in each case to `layout.working_dir()` — a repository root — and the result is used only to compare a client-supplied workspace root against the process working directory.

| test | result |
|---|---|
| does it read file contents? | no — resolves a path through symlinks, returns a `PathBuf` |
| does any query answer derive from it? | no — it selects *which repository to bind*, before a binding exists and before any graph is consulted |
| is it an existence probe? | **no** — `unwrap_or_else(\|_\| path.to_path_buf())` discards the error and falls back to the path as given |

That third row is the load-bearing one. `canonicalize` is in the deny set precisely because it *can* serve as an existence probe — it fails when a path is absent. Here the failure is structurally discarded, so it cannot carry that signal.

Under the umbrella rule this precedes the answer path rather than serving it, so it is a boundary. Removing `mcp.rs` from the scanned set would be the wrong fix — it would restore the exact blind spot the module was added to close.

## The exemption is pinned to the whole expression, on purpose

```json
"allow_match": ["std::fs::canonicalize(path).unwrap_or_else(|_| path.to_path_buf())"]
```

Not the file, not the function, not `canonicalize`. Pinning the entire expression means the *boundary* use is classified while the *probe* use of the same function is still caught.

Falsified rather than asserted — four poisons appended to `mcp.rs`:

| poison | result |
|---|---|
| a different fs primitive (`read_to_string`) | caught |
| **a bare `canonicalize` using failure as a signal** | **caught** |
| an existence probe (`.exists()`) | caught |
| directory traversal (`read_dir`) | caught |

The second row is the one that matters: the same function, exempt in one form and caught in the other.

## Pinning also keeps mcp.rs enforced

A whole-file entry would have dropped `mcp.rs` out of enforcement entirely. Confirmed it did not — the falsification harness still lists it among the enforced modules and poisons it at all four sites:

```
mcp.rs   eof=py:ok  quarter=py:ok  half=py:ok  last-prod=py:ok
```

It did **not** join `health.rs` in the harness's "not falsifiable" list. That list is the standing record of modules an allowlist entry has silently removed from enforcement, and this change deliberately does not lengthen it.

## Verification

Both guards pass on this branch; the falsification harness passes with `mcp.rs` still enforced. No cargo run — a citable cohort holds the machine. Only `scripts/zero-file-search-allowlist.json` changes; #386 has landed so there is no collision.