### PR TITLE
fix(registry): secure OCI writes and keep Cargo reads authoritative

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -138,6 +138,10 @@ jobs:
         run: |
           set -euo pipefail
           cargo test --locked --target x86_64-pc-windows-msvc \
+            -p kin-registry --lib
+          cargo test --locked --target x86_64-pc-windows-msvc \
+            -p kin-core --lib registry::tests
+          cargo test --locked --target x86_64-pc-windows-msvc \
             -p kin-cli --no-default-features --no-run
           test_binary=$(find target/x86_64-pc-windows-msvc/debug/deps \
             -maxdepth 1 -type f -name 'kin_cli-*.exe' -print -quit)

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -91,6 +91,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "683d7910e743518b0e34f1186f92494becacb047c7b6bf616c96772180fef923"
 
 [[package]]
+name = "ambient-authority"
+version = "0.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e9d4ee0d472d1cd2e28c97dfa124b3d8d992e10eb0a035f33f5d12e3a177ba3b"
+
+[[package]]
 name = "android_system_properties"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -417,6 +423,48 @@ name = "bytes"
 version = "1.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8ae3f5d315924270530207e2a68396c3cc547f6dca3fbdca317cfb1a51edb593"
+
+[[package]]
+name = "cap-fs-ext"
+version = "4.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d78e5a3368ae89b7cb68186411452b4b9fac8b41be9c19bf3f47c2d2c8e36e6b"
+dependencies = [
+ "cap-primitives",
+ "cap-std",
+ "io-lifetimes 3.0.1",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "cap-primitives"
+version = "4.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cdadbd7c002d3a484b35243669abdae85a0ebaded5a61117169dc3400f9a7ff0"
+dependencies = [
+ "ambient-authority",
+ "fs-set-times",
+ "io-extras",
+ "io-lifetimes 3.0.1",
+ "ipnet",
+ "maybe-owned",
+ "rustix",
+ "rustix-linux-procfs",
+ "windows-sys 0.61.2",
+ "winx",
+]
+
+[[package]]
+name = "cap-std"
+version = "4.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7281235d6e96d3544ca18bba9049be92f4190f8d923e3caef1b5f66cfa752608"
+dependencies = [
+ "cap-primitives",
+ "io-extras",
+ "io-lifetimes 3.0.1",
+ "rustix",
+]
 
 [[package]]
 name = "castaway"
@@ -1339,6 +1387,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cb4cb245038516f5f85277875cdaa4f7d2c9a0fa0468de06ed190163b1581fcf"
 dependencies = [
  "percent-encoding",
+]
+
+[[package]]
+name = "fs-set-times"
+version = "0.20.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "94e7099f6313ecacbe1256e8ff9d617b75d1bcb16a6fddef94866d225a01a14a"
+dependencies = [
+ "io-lifetimes 2.0.4",
+ "rustix",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -2763,6 +2822,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "io-extras"
+version = "0.19.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "20fd6de4ccfcc187e38bc21cfa543cb5a302cb86a8b114eb7f0bf0dc9f8ac00f"
+dependencies = [
+ "io-lifetimes 3.0.1",
+ "windows-sys 0.60.2",
+]
+
+[[package]]
+name = "io-lifetimes"
+version = "2.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "06432fb54d3be7964ecd3649233cddf80db2832f47fec34c01f65b3d9d774983"
+
+[[package]]
+name = "io-lifetimes"
+version = "3.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2f0fb0570afe1fed943c5c3d4102d5358592d8625fda6a0007fdbe65a92fba96"
+
+[[package]]
 name = "io_tee"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3429,6 +3510,8 @@ dependencies = [
  "async-stream",
  "axum",
  "base64 0.22.1",
+ "cap-fs-ext",
+ "cap-std",
  "chrono",
  "flate2",
  "fs2",
@@ -3753,6 +3836,12 @@ dependencies = [
  "quote",
  "syn",
 ]
+
+[[package]]
+name = "maybe-owned"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4facc753ae494aeb6e3c22f839b158aebd4f9270f55cd3c79906c45476c47ab4"
 
 [[package]]
 name = "memchr"
@@ -4834,6 +4923,16 @@ dependencies = [
  "libc",
  "linux-raw-sys",
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "rustix-linux-procfs"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2fc84bf7e9aa16c4f2c758f27412dc9841341e16aa682d9c7ac308fe3ee12056"
+dependencies = [
+ "once_cell",
+ "rustix",
 ]
 
 [[package]]
@@ -6766,6 +6865,16 @@ name = "winsafe"
 version = "0.0.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d135d17ab770252ad95e9a872d365cf3090e3be864a34ab46f48555993efc904"
+
+[[package]]
+name = "winx"
+version = "0.36.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f3fd376f71958b862e7afb20cfe5a22830e1963462f3a17f49d82a6c1d1f42d"
+dependencies = [
+ "bitflags 2.13.0",
+ "windows-sys 0.59.0",
+]
 
 [[package]]
 name = "wit-bindgen"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3436,6 +3436,7 @@ dependencies = [
  "hex",
  "kin-blobs",
  "kin-model",
+ "libc",
  "percent-encoding",
  "semver",
  "serde",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3425,10 +3425,12 @@ dependencies = [
 name = "kin-registry"
 version = "0.2.28"
 dependencies = [
+ "async-stream",
  "axum",
  "base64 0.22.1",
  "chrono",
  "flate2",
+ "futures-util",
  "hex",
  "kin-blobs",
  "kin-model",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3433,6 +3433,7 @@ dependencies = [
  "kin-blobs",
  "kin-model",
  "percent-encoding",
+ "semver",
  "serde",
  "serde_json",
  "sha1 0.11.0",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3086,6 +3086,7 @@ version = "0.2.28"
 dependencies = [
  "async-stream",
  "axum",
+ "base64 0.22.1",
  "chrono",
  "flate2",
  "fs2",
@@ -3430,6 +3431,7 @@ dependencies = [
  "base64 0.22.1",
  "chrono",
  "flate2",
+ "fs2",
  "futures-util",
  "hex",
  "kin-blobs",
@@ -3447,6 +3449,7 @@ dependencies = [
  "toml 1.1.2+spec-1.1.0",
  "tower",
  "tracing",
+ "url",
 ]
 
 [[package]]

--- a/crates/kin-core/src/env_registry.rs
+++ b/crates/kin-core/src/env_registry.rs
@@ -187,6 +187,7 @@ pub const OPERATIONAL: &[EnvVarSpec] = &[
     EnvVarSpec { name: "KIN_DAEMON_AUTH_TOKEN", kind: Kind::Secret, default: "", sensitivity: Sensitivity::Secret, summary: "bearer token for authenticated daemon requests" },
     EnvVarSpec { name: "KIN_SUPERVISOR_AUTH_TOKEN", kind: Kind::Secret, default: "", sensitivity: Sensitivity::Secret, summary: "bearer token for authenticated supervisor requests" },
     EnvVarSpec { name: "KIN_REGISTRY_CARGO_TOKEN", kind: Kind::Secret, default: "", sensitivity: Sensitivity::Secret, summary: "cargo registry auth token for publish" },
+    EnvVarSpec { name: "KIN_REGISTRY_OCI_WRITE_TOKEN", kind: Kind::Secret, default: "", sensitivity: Sensitivity::Secret, summary: "OCI registry auth token for mutations" },
 
     // ---- daemon lifecycle / networking ---------------------------------------
     EnvVarSpec { name: "KIN_DAEMON_URL", kind: Kind::Url, default: "", sensitivity: Sensitivity::Operational, summary: "explicit daemon endpoint URL (skip local discovery)" },

--- a/crates/kin-core/src/registry.rs
+++ b/crates/kin-core/src/registry.rs
@@ -26,7 +26,7 @@ struct RegistryProcessGates {
 #[derive(Clone, Debug, Eq, Hash, PartialEq)]
 struct RegistryProcessKey {
     parent: FileIdentity,
-    registry_name: std::ffi::OsString,
+    lock_authority_name: Vec<u8>,
 }
 
 #[cfg(unix)]
@@ -60,8 +60,8 @@ impl Drop for RegistryProcessGuard {
 /// unlink a sibling thread's just-opened registry descriptor (`st_nlink == 0`).
 /// Different registry authorities remain independent; the durable lock file
 /// remains the cross-process authority. Keying on the opened parent identity
-/// collapses prefix aliases such as `/tmp` and `/private/tmp` that lexical path
-/// normalization cannot recognize as one directory.
+/// plus the collision-normalized lock name collapses both prefix aliases such
+/// as `/tmp` and `/private/tmp` and case aliases on default macOS filesystems.
 #[cfg(unix)]
 fn lock_registry_process(path: &Path) -> std::io::Result<RegistryProcessGuard> {
     let anchor = prepare_anchor(path).map_err(|error| {
@@ -73,7 +73,7 @@ fn lock_registry_process(path: &Path) -> std::io::Result<RegistryProcessGuard> {
             device: parent_stat.st_dev as u64,
             inode: parent_stat.st_ino as u64,
         },
-        registry_name: anchor.registry_name,
+        lock_authority_name: collision_normalized_authority_name(&anchor.lock_name),
     };
     let (state, changed) = REGISTRY_PROCESS_GATES.get_or_init(|| {
         (
@@ -650,6 +650,13 @@ fn authority_names_collide(a: &std::ffi::OsStr, b: &std::ffi::OsStr) -> bool {
     // Conservatively reject ASCII case variants on every Unix platform so a
     // case-insensitive filesystem cannot alias registry data with lock/temp.
     a.as_bytes().eq_ignore_ascii_case(b.as_bytes())
+}
+
+#[cfg(unix)]
+fn collision_normalized_authority_name(name: &std::ffi::OsStr) -> Vec<u8> {
+    use std::os::unix::ffi::OsStrExt;
+
+    name.as_bytes().iter().map(u8::to_ascii_lowercase).collect()
 }
 
 #[cfg(unix)]
@@ -1808,6 +1815,90 @@ mod tests {
             .recv_timeout(std::time::Duration::from_secs(1))
             .unwrap();
         contender.join().unwrap();
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn process_gate_collapses_case_aliases_of_the_named_lock_authority() {
+        let root = tempfile::tempdir().unwrap();
+        let lowercase = root.path().join("registry.toml");
+        let uppercase = root.path().join("REGISTRY.TOML");
+
+        let first = lock_registry_process(&lowercase).unwrap();
+        let (attempted_tx, attempted_rx) = std::sync::mpsc::channel();
+        let (acquired_tx, acquired_rx) = std::sync::mpsc::channel();
+        let contender = std::thread::spawn(move || {
+            attempted_tx.send(()).unwrap();
+            let _guard = lock_registry_process(&uppercase).unwrap();
+            acquired_tx.send(()).unwrap();
+        });
+
+        attempted_rx
+            .recv_timeout(std::time::Duration::from_secs(1))
+            .unwrap();
+        assert!(matches!(
+            acquired_rx.recv_timeout(std::time::Duration::from_millis(50)),
+            Err(std::sync::mpsc::RecvTimeoutError::Timeout)
+        ));
+        drop(first);
+        acquired_rx
+            .recv_timeout(std::time::Duration::from_secs(1))
+            .unwrap();
+        contender.join().unwrap();
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn case_alias_updates_preserve_both_writers_on_case_insensitive_filesystems() {
+        use std::sync::{Arc, Barrier};
+
+        let root = tempfile::tempdir().unwrap();
+        let lowercase = root.path().join("registry.toml");
+        let uppercase = root.path().join("REGISTRY.TOML");
+        KinRegistry::default().save_to(&lowercase).unwrap();
+        let Ok(lower_file) = File::open(&lowercase) else {
+            return;
+        };
+        let Ok(upper_file) = File::open(&uppercase) else {
+            return;
+        };
+        let lower_stat = stat_file(&lower_file).unwrap();
+        let upper_stat = stat_file(&upper_file).unwrap();
+        if lower_stat.st_dev != upper_stat.st_dev || lower_stat.st_ino != upper_stat.st_ino {
+            return;
+        }
+
+        let barrier = Arc::new(Barrier::new(2));
+        let writers = [(lowercase.clone(), "lower"), (uppercase, "upper")]
+            .into_iter()
+            .map(|(path, id)| {
+                let barrier = barrier.clone();
+                std::thread::spawn(move || {
+                    barrier.wait();
+                    KinRegistry::update_at(&path, |registry| {
+                        registry.repos.push(RegisteredRepo {
+                            id: id.to_string(),
+                            path: PathBuf::from(format!("/{id}")),
+                            entities: 1,
+                            last_commit: "now".to_string(),
+                            dependencies: Vec::new(),
+                        });
+                    })
+                    .unwrap();
+                })
+            })
+            .collect::<Vec<_>>();
+        for writer in writers {
+            writer.join().unwrap();
+        }
+
+        let registry = KinRegistry::load_from(&lowercase).unwrap();
+        let ids = registry
+            .repos
+            .iter()
+            .map(|repo| repo.id.as_str())
+            .collect::<std::collections::HashSet<_>>();
+        assert_eq!(ids, std::collections::HashSet::from(["lower", "upper"]));
     }
 
     #[test]

--- a/crates/kin-core/src/registry.rs
+++ b/crates/kin-core/src/registry.rs
@@ -16,6 +16,86 @@ use std::fs::OpenOptions;
 use std::io::{Read, Write};
 use std::path::{Path, PathBuf};
 
+#[cfg(unix)]
+#[derive(Default)]
+struct RegistryProcessGates {
+    active: std::collections::HashSet<PathBuf>,
+}
+
+#[cfg(unix)]
+static REGISTRY_PROCESS_GATES: std::sync::OnceLock<(
+    std::sync::Mutex<RegistryProcessGates>,
+    std::sync::Condvar,
+)> = std::sync::OnceLock::new();
+
+#[cfg(unix)]
+struct RegistryProcessGuard {
+    key: PathBuf,
+}
+
+#[cfg(unix)]
+impl Drop for RegistryProcessGuard {
+    fn drop(&mut self) {
+        let (state, changed) = REGISTRY_PROCESS_GATES
+            .get()
+            .expect("registry process gate was initialized before guard creation");
+        let mut state = state
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
+        state.active.remove(&self.key);
+        changed.notify_all();
+    }
+}
+
+/// `flock` semantics for separately-opened descriptors differ across Unix
+/// kernels when contenders are threads in one process. Keep a path-keyed local
+/// gate around the preflight + OS-lock transaction so an atomic rename cannot
+/// unlink a sibling thread's just-opened registry descriptor (`st_nlink == 0`).
+/// Different registry authorities remain independent; the durable lock file
+/// remains the cross-process authority.
+#[cfg(unix)]
+fn lock_registry_process(path: &Path) -> std::io::Result<RegistryProcessGuard> {
+    let key = lexical_absolute_path(path)?;
+    let (state, changed) = REGISTRY_PROCESS_GATES.get_or_init(|| {
+        (
+            std::sync::Mutex::new(RegistryProcessGates::default()),
+            std::sync::Condvar::new(),
+        )
+    });
+    let mut state = state
+        .lock()
+        .unwrap_or_else(std::sync::PoisonError::into_inner);
+    while state.active.contains(&key) {
+        state = changed
+            .wait(state)
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
+    }
+    state.active.insert(key.clone());
+    Ok(RegistryProcessGuard { key })
+}
+
+#[cfg(unix)]
+fn lexical_absolute_path(path: &Path) -> std::io::Result<PathBuf> {
+    let absolute = if path.is_absolute() {
+        path.to_path_buf()
+    } else {
+        std::env::current_dir()?.join(path)
+    };
+    let mut normalized = PathBuf::new();
+    for component in absolute.components() {
+        match component {
+            std::path::Component::RootDir => normalized.push(Path::new("/")),
+            std::path::Component::CurDir => {}
+            std::path::Component::ParentDir => {
+                normalized.pop();
+            }
+            std::path::Component::Normal(part) => normalized.push(part),
+            std::path::Component::Prefix(_) => unreachable!("Unix paths have no prefix"),
+        }
+    }
+    Ok(normalized)
+}
+
 /// Read-only classification of one local registry-authority path.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, serde::Serialize)]
 #[serde(rename_all = "snake_case")]
@@ -878,6 +958,7 @@ fn inspect_named_authority(
 fn repair_registry_authority_permissions_at_unix(
     path: &Path,
 ) -> Result<Vec<PathBuf>, Box<dyn std::error::Error>> {
+    let _process_guard = lock_registry_process(path)?;
     let anchor = match RegistryAnchor::open(path) {
         Ok(anchor) => anchor,
         Err(err) if err.kind() == std::io::ErrorKind::NotFound => return Ok(Vec::new()),
@@ -931,6 +1012,7 @@ fn repair_registry_authority_permissions_at_unix(
 fn initialize_registry_authority_at_unix(
     path: &Path,
 ) -> Result<Vec<PathBuf>, Box<dyn std::error::Error>> {
+    let _process_guard = lock_registry_process(path)?;
     // This preflight is deliberately before directory or lock creation: an
     // unsafe existing registry must not cause any companion-path mutation.
     require_registry_authority_secure_at(path)?;
@@ -959,6 +1041,7 @@ fn initialize_registry_authority_at_unix(
 
 #[cfg(unix)]
 fn load_from_unix(path: &Path) -> Result<KinRegistry, Box<dyn std::error::Error>> {
+    let _process_guard = lock_registry_process(path)?;
     // Reject the complete authority snapshot before a missing lock can be
     // created. Descriptor-anchored checks below then revalidate under lock.
     require_registry_authority_secure_at(path)?;
@@ -978,6 +1061,7 @@ fn load_from_unix(path: &Path) -> Result<KinRegistry, Box<dyn std::error::Error>
 
 #[cfg(unix)]
 fn save_to_unix(registry: &KinRegistry, path: &Path) -> Result<(), Box<dyn std::error::Error>> {
+    let _process_guard = lock_registry_process(path)?;
     require_registry_authority_secure_at(path)?;
     let contents = toml::to_string_pretty(registry)?;
     let anchor = prepare_anchor(path)?;
@@ -992,6 +1076,7 @@ fn update_at_unix<T>(
     path: &Path,
     mutate: impl FnOnce(&mut KinRegistry) -> T,
 ) -> Result<T, Box<dyn std::error::Error>> {
+    let _process_guard = lock_registry_process(path)?;
     require_registry_authority_secure_at(path)?;
     let anchor = prepare_anchor(path)?;
     let lock_file = open_private_lock_at(&anchor).map_err(|err| {
@@ -1644,6 +1729,51 @@ mod tests {
         assert_eq!(std::fs::read(&upgrade_path).unwrap(), existing);
         assert_eq!(mode(&upgrade_path), 0o600);
         assert_eq!(mode(&upgrade_path.with_extension("lock")), 0o600);
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn process_gate_keeps_same_registry_rename_outside_open_descriptor_window() {
+        let dir = tempfile::tempdir().unwrap();
+        let registry = dir.path().join("registry.toml");
+        let replacement = dir.path().join("replacement.toml");
+        let unrelated = dir.path().join("other-registry.toml");
+        std::fs::write(&registry, b"repos = []\n").unwrap();
+        std::fs::write(&replacement, b"repos = []\n").unwrap();
+
+        let guard = lock_registry_process(&registry).unwrap();
+        let opened_before_rename = File::open(&registry).unwrap();
+        assert_eq!(stat_file(&opened_before_rename).unwrap().st_nlink, 1);
+
+        // The key is path-scoped: an unrelated authority remains available.
+        drop(lock_registry_process(&unrelated).unwrap());
+
+        let (attempted_tx, attempted_rx) = std::sync::mpsc::channel();
+        let (renamed_tx, renamed_rx) = std::sync::mpsc::channel();
+        let registry_for_thread = registry.clone();
+        let replacement_for_thread = replacement.clone();
+        let writer = std::thread::spawn(move || {
+            attempted_tx.send(()).unwrap();
+            let _guard = lock_registry_process(&registry_for_thread).unwrap();
+            std::fs::rename(replacement_for_thread, registry_for_thread).unwrap();
+            renamed_tx.send(()).unwrap();
+        });
+
+        attempted_rx
+            .recv_timeout(std::time::Duration::from_secs(1))
+            .unwrap();
+        assert!(matches!(
+            renamed_rx.recv_timeout(std::time::Duration::from_millis(50)),
+            Err(std::sync::mpsc::RecvTimeoutError::Timeout)
+        ));
+        assert_eq!(stat_file(&opened_before_rename).unwrap().st_nlink, 1);
+
+        drop(guard);
+        renamed_rx
+            .recv_timeout(std::time::Duration::from_secs(1))
+            .unwrap();
+        writer.join().unwrap();
+        assert_eq!(stat_file(&opened_before_rename).unwrap().st_nlink, 0);
     }
 
     #[test]

--- a/crates/kin-core/src/registry.rs
+++ b/crates/kin-core/src/registry.rs
@@ -19,7 +19,14 @@ use std::path::{Path, PathBuf};
 #[cfg(unix)]
 #[derive(Default)]
 struct RegistryProcessGates {
-    active: std::collections::HashSet<PathBuf>,
+    active: std::collections::HashSet<RegistryProcessKey>,
+}
+
+#[cfg(unix)]
+#[derive(Clone, Debug, Eq, Hash, PartialEq)]
+struct RegistryProcessKey {
+    parent: FileIdentity,
+    registry_name: std::ffi::OsString,
 }
 
 #[cfg(unix)]
@@ -30,7 +37,7 @@ static REGISTRY_PROCESS_GATES: std::sync::OnceLock<(
 
 #[cfg(unix)]
 struct RegistryProcessGuard {
-    key: PathBuf,
+    key: RegistryProcessKey,
 }
 
 #[cfg(unix)]
@@ -52,10 +59,22 @@ impl Drop for RegistryProcessGuard {
 /// gate around the preflight + OS-lock transaction so an atomic rename cannot
 /// unlink a sibling thread's just-opened registry descriptor (`st_nlink == 0`).
 /// Different registry authorities remain independent; the durable lock file
-/// remains the cross-process authority.
+/// remains the cross-process authority. Keying on the opened parent identity
+/// collapses prefix aliases such as `/tmp` and `/private/tmp` that lexical path
+/// normalization cannot recognize as one directory.
 #[cfg(unix)]
 fn lock_registry_process(path: &Path) -> std::io::Result<RegistryProcessGuard> {
-    let key = lexical_absolute_path(path)?;
+    let anchor = prepare_anchor(path).map_err(|error| {
+        std::io::Error::other(format!("failed to anchor registry process lock: {error}"))
+    })?;
+    let parent_stat = stat_file(&anchor.parent)?;
+    let key = RegistryProcessKey {
+        parent: FileIdentity {
+            device: parent_stat.st_dev as u64,
+            inode: parent_stat.st_ino as u64,
+        },
+        registry_name: anchor.registry_name,
+    };
     let (state, changed) = REGISTRY_PROCESS_GATES.get_or_init(|| {
         (
             std::sync::Mutex::new(RegistryProcessGates::default()),
@@ -72,28 +91,6 @@ fn lock_registry_process(path: &Path) -> std::io::Result<RegistryProcessGuard> {
     }
     state.active.insert(key.clone());
     Ok(RegistryProcessGuard { key })
-}
-
-#[cfg(unix)]
-fn lexical_absolute_path(path: &Path) -> std::io::Result<PathBuf> {
-    let absolute = if path.is_absolute() {
-        path.to_path_buf()
-    } else {
-        std::env::current_dir()?.join(path)
-    };
-    let mut normalized = PathBuf::new();
-    for component in absolute.components() {
-        match component {
-            std::path::Component::RootDir => normalized.push(Path::new("/")),
-            std::path::Component::CurDir => {}
-            std::path::Component::ParentDir => {
-                normalized.pop();
-            }
-            std::path::Component::Normal(part) => normalized.push(part),
-            std::path::Component::Prefix(_) => unreachable!("Unix paths have no prefix"),
-        }
-    }
-    Ok(normalized)
 }
 
 /// Read-only classification of one local registry-authority path.
@@ -551,7 +548,7 @@ pub fn initialize_registry_authority_at(
 }
 
 #[cfg(unix)]
-#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+#[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
 struct FileIdentity {
     device: u64,
     inode: u64,
@@ -1309,7 +1306,7 @@ fn validate_regular_stat(stat: &libc::stat, label: &str) -> std::io::Result<File
     }
     Ok(FileIdentity {
         device: stat.st_dev as u64,
-        inode: stat.st_ino as u64,
+        inode: stat.st_ino,
     })
 }
 
@@ -1774,6 +1771,43 @@ mod tests {
             .unwrap();
         writer.join().unwrap();
         assert_eq!(stat_file(&opened_before_rename).unwrap().st_nlink, 0);
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn process_gate_collapses_symlinked_prefix_aliases_by_parent_identity() {
+        use std::os::unix::fs::symlink;
+
+        let root = tempfile::tempdir().unwrap();
+        let real_root = root.path().join("real");
+        let nested = real_root.join("nested");
+        std::fs::create_dir_all(&nested).unwrap();
+        let alias_root = root.path().join("alias");
+        symlink(&real_root, &alias_root).unwrap();
+        let real_registry = nested.join("registry.toml");
+        let aliased_registry = alias_root.join("nested").join("registry.toml");
+
+        let first = lock_registry_process(&real_registry).unwrap();
+        let (attempted_tx, attempted_rx) = std::sync::mpsc::channel();
+        let (acquired_tx, acquired_rx) = std::sync::mpsc::channel();
+        let contender = std::thread::spawn(move || {
+            attempted_tx.send(()).unwrap();
+            let _guard = lock_registry_process(&aliased_registry).unwrap();
+            acquired_tx.send(()).unwrap();
+        });
+
+        attempted_rx
+            .recv_timeout(std::time::Duration::from_secs(1))
+            .unwrap();
+        assert!(matches!(
+            acquired_rx.recv_timeout(std::time::Duration::from_millis(50)),
+            Err(std::sync::mpsc::RecvTimeoutError::Timeout)
+        ));
+        drop(first);
+        acquired_rx
+            .recv_timeout(std::time::Duration::from_secs(1))
+            .unwrap();
+        contender.join().unwrap();
     }
 
     #[test]

--- a/crates/kin-core/src/registry.rs
+++ b/crates/kin-core/src/registry.rs
@@ -623,6 +623,8 @@ impl RegistryAnchor {
             })?
             .to_os_string();
 
+        validate_authority_filename(&registry_name)?;
+
         if authority_names_collide(&registry_name, &lock_name)
             || authority_names_collide(&registry_name, &legacy_tmp_name)
             || authority_names_collide(&lock_name, &legacy_tmp_name)
@@ -650,6 +652,25 @@ fn authority_names_collide(a: &std::ffi::OsStr, b: &std::ffi::OsStr) -> bool {
     // Conservatively reject ASCII case variants on every Unix platform so a
     // case-insensitive filesystem cannot alias registry data with lock/temp.
     a.as_bytes().eq_ignore_ascii_case(b.as_bytes())
+}
+
+#[cfg(unix)]
+fn validate_authority_filename(name: &std::ffi::OsStr) -> std::io::Result<()> {
+    use std::os::unix::ffi::OsStrExt;
+
+    // Filesystems such as default macOS APFS apply Unicode normalization and
+    // case folding that cannot be reproduced from raw OsStr bytes. In
+    // particular, `registry.locK` aliases `registry.lock`, despite the two
+    // names being neither byte-equal nor ASCII-case-equal. Restrict only the
+    // authority filename (parent paths remain fully Unicode-capable) so the
+    // data, lock, and reserved temp names can never alias unexpectedly.
+    if !name.as_bytes().is_ascii() {
+        return Err(std::io::Error::new(
+            std::io::ErrorKind::InvalidInput,
+            "registry authority filename must be ASCII to avoid filesystem case-fold aliases",
+        ));
+    }
+    Ok(())
 }
 
 #[cfg(unix)]
@@ -1598,6 +1619,18 @@ mod tests {
             assert_eq!(mode(&reg_path), 0o600);
             assert_eq!(mode(&reg_path.with_extension("lock")), 0o600);
         }
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn unicode_case_fold_cannot_alias_registry_and_lock_authorities() {
+        let dir = tempfile::tempdir().unwrap();
+        let reg_path = dir.path().join("registry.locK");
+
+        let error = KinRegistry::default().save_to(&reg_path).unwrap_err();
+
+        assert!(error.to_string().contains("filename must be ASCII"));
+        assert!(std::fs::read_dir(dir.path()).unwrap().next().is_none());
     }
 
     #[cfg(unix)]

--- a/crates/kin-daemon/Cargo.toml
+++ b/crates/kin-daemon/Cargo.toml
@@ -71,6 +71,7 @@ kin-db = { workspace = true, features = ["metal", "accelerate"] }
 kin-infer = { version = ">=0.2.1", registry = "kin", features = ["metal"] }
 
 [dev-dependencies]
+base64 = "0.22"
 kin-git = { workspace = true }
 tempfile = { workspace = true }
 pretty_assertions = { workspace = true }

--- a/crates/kin-daemon/src/api.rs
+++ b/crates/kin-daemon/src/api.rs
@@ -1103,12 +1103,12 @@ fn router_with_auth(state: Arc<DaemonState>, auth_token: Option<String>) -> Rout
         .map(|token| token.trim().to_string())
         .filter(|token| !token.is_empty());
     let cargo_routes =
-        kin_registry::cargo::cargo_routes(Arc::new(kin_registry::cargo::CargoRegistryState {
-            manifest_store: kin_registry::ManifestStore::new(state.layout.root()),
-            blobs_dir: crates_dir,
-            base_url: base_url.clone(),
-            publish_token: registry_write_token.clone(),
-        }));
+        kin_registry::cargo::cargo_routes(Arc::new(kin_registry::cargo::CargoRegistryState::new(
+            kin_registry::ManifestStore::new(state.layout.root()),
+            crates_dir,
+            base_url.clone(),
+            registry_write_token.clone(),
+        )));
 
     let npm_routes = npm_registry_routes(
         &state,

--- a/crates/kin-daemon/src/api.rs
+++ b/crates/kin-daemon/src/api.rs
@@ -1093,12 +1093,11 @@ fn router_with_auth(state: Arc<DaemonState>, auth_token: Option<String>) -> Rout
     let base_url = std::env::var("KIN_REGISTRY_BASE_URL")
         .unwrap_or_else(|_| "http://localhost:4219".to_string());
 
-    // Cargo and OCI reuse the existing registry write-token contract from
-    // KIN_REGISTRY_CARGO_TOKEN; reads stay open. A None token fails closed, so
-    // an unset/empty env var never silently exposes either write surface.
+    // Cargo and OCI have independent write credentials. Reads stay open, while
+    // an unset/empty token fails its own write surface closed.
     let crates_dir = packages_dir.join("crates");
     std::fs::create_dir_all(&crates_dir).ok();
-    let registry_write_token = std::env::var("KIN_REGISTRY_CARGO_TOKEN")
+    let cargo_write_token = std::env::var("KIN_REGISTRY_CARGO_TOKEN")
         .ok()
         .map(|token| token.trim().to_string())
         .filter(|token| !token.is_empty());
@@ -1107,7 +1106,7 @@ fn router_with_auth(state: Arc<DaemonState>, auth_token: Option<String>) -> Rout
             kin_registry::ManifestStore::new(state.layout.root()),
             crates_dir,
             base_url.clone(),
-            registry_write_token.clone(),
+            cargo_write_token,
         )));
 
     let npm_routes = npm_registry_routes(
@@ -1120,8 +1119,12 @@ fn router_with_auth(state: Arc<DaemonState>, auth_token: Option<String>) -> Rout
     // OCI container registry
     let oci_dir = packages_dir.join("oci");
     std::fs::create_dir_all(&oci_dir).ok();
+    let oci_write_token = std::env::var("KIN_REGISTRY_OCI_WRITE_TOKEN")
+        .ok()
+        .map(|token| token.trim().to_string())
+        .filter(|token| !token.is_empty());
     let oci_routes = kin_registry::oci::oci_routes(Arc::new(
-        kin_registry::oci::OciRegistryState::new(oci_dir, registry_write_token),
+        kin_registry::oci::OciRegistryState::new(oci_dir, oci_write_token),
     ));
 
     // Go module proxy
@@ -1133,7 +1136,8 @@ fn router_with_auth(state: Arc<DaemonState>, auth_token: Option<String>) -> Rout
     }));
 
     // The package registries (cargo/npm/oci/go) are PUBLIC services with their
-    // own per-write gates (cargo + OCI: `KIN_REGISTRY_CARGO_TOKEN`; npm:
+    // own per-write gates (Cargo: `KIN_REGISTRY_CARGO_TOKEN`; OCI:
+    // `KIN_REGISTRY_OCI_WRITE_TOKEN`; npm:
     // `KIN_REGISTRY_NPM_AUTH_URL` introspection); their reads stay open. The
     // daemon API is a PROTECTED control surface. So `daemon_auth` is scoped to
     // ONLY the daemon routes — applied as an inner `.layer()` on the daemon
@@ -15090,10 +15094,12 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn oci_writes_require_registry_token_while_pulls_stay_public() {
+    async fn oci_writes_require_their_own_token_while_pulls_stay_public() {
         let _lock = REGISTRY_ENV_LOCK.lock().await;
 
-        std::env::remove_var("KIN_REGISTRY_CARGO_TOKEN");
+        std::env::remove_var("KIN_REGISTRY_OCI_WRITE_TOKEN");
+        let _cargo_env = RegistryEnvGuard("KIN_REGISTRY_CARGO_TOKEN");
+        std::env::set_var("KIN_REGISTRY_CARGO_TOKEN", "cargo-secret");
         let disabled = router_with_auth(test_state(), Some("daemon-token".to_string()))
             .oneshot(
                 Request::post("/v2/demo/blobs/uploads/")
@@ -15105,9 +15111,22 @@ mod tests {
             .unwrap();
         assert_eq!(disabled.status(), StatusCode::SERVICE_UNAVAILABLE);
 
-        let _env = RegistryEnvGuard("KIN_REGISTRY_CARGO_TOKEN");
-        std::env::set_var("KIN_REGISTRY_CARGO_TOKEN", "registry-secret");
+        let _oci_env = RegistryEnvGuard("KIN_REGISTRY_OCI_WRITE_TOKEN");
+        std::env::set_var("KIN_REGISTRY_OCI_WRITE_TOKEN", "registry-secret");
         let app = router_with_auth(test_state(), Some("daemon-token".to_string()));
+
+        // The Cargo credential is deliberately not accepted on the OCI scope.
+        let cargo_token_rejected = app
+            .clone()
+            .oneshot(
+                Request::post("/v2/demo/blobs/uploads/")
+                    .header("authorization", "Bearer cargo-secret")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(cargo_token_rejected.status(), StatusCode::UNAUTHORIZED);
         let unauthorized = app
             .clone()
             .oneshot(

--- a/crates/kin-daemon/src/api.rs
+++ b/crates/kin-daemon/src/api.rs
@@ -14962,6 +14962,22 @@ mod tests {
         builder.into_inner().unwrap().finish().unwrap()
     }
 
+    fn build_valid_npm_tarball() -> Vec<u8> {
+        use flate2::{write::GzEncoder, Compression};
+
+        let contents = b"module.exports = 'kin';\n";
+        let encoder = GzEncoder::new(Vec::new(), Compression::default());
+        let mut builder = tar::Builder::new(encoder);
+        let mut header = tar::Header::new_gnu();
+        header.set_size(contents.len() as u64);
+        header.set_mode(0o644);
+        header.set_cksum();
+        builder
+            .append_data(&mut header, "package/index.js", contents.as_slice())
+            .unwrap();
+        builder.into_inner().unwrap().finish().unwrap()
+    }
+
     #[tokio::test]
     async fn registry_routes_public_even_with_daemon_auth_token() {
         // With a daemon auth token configured, the cargo registry's read routes
@@ -15222,7 +15238,42 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn npm_registry_writes_fail_closed_without_auth_configuration() {
+        let state = test_state();
+        let app = npm_registry_routes(
+            &state,
+            &test_packages_dir(&state),
+            "https://kinlab.ai",
+            None,
+        );
+
+        let read = app
+            .clone()
+            .oneshot(
+                Request::get("/registry/npm/@kin%2Fboundary-contracts")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(read.status(), StatusCode::NOT_FOUND);
+
+        let write = app
+            .oneshot(
+                Request::put("/registry/npm/@kin%2Fboundary-contracts")
+                    .header(header::CONTENT_TYPE, "application/json")
+                    .body(Body::from("{}"))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(write.status(), StatusCode::SERVICE_UNAVAILABLE);
+    }
+
+    #[tokio::test]
     async fn npm_publish_records_authenticated_publisher() {
+        use base64::{engine::general_purpose::STANDARD, Engine as _};
+
         let state = test_state();
         let (auth_url, auth_server) = spawn_registry_auth_server(
             StatusCode::OK,
@@ -15250,6 +15301,7 @@ mod tests {
             })),
         );
 
+        let tarball = build_valid_npm_tarball();
         let publish_payload = serde_json::json!({
             "_id": "@kin/boundary-contracts",
             "name": "@kin/boundary-contracts",
@@ -15263,8 +15315,8 @@ mod tests {
             "_attachments": {
                 "@kin/boundary-contracts-0.1.0.tgz": {
                     "content_type": "application/octet-stream",
-                    "data": "ZmFrZS10YXJiYWxs",
-                    "length": 12
+                    "data": STANDARD.encode(&tarball),
+                    "length": tarball.len()
                 }
             }
         });

--- a/crates/kin-daemon/src/api.rs
+++ b/crates/kin-daemon/src/api.rs
@@ -930,11 +930,11 @@ fn npm_registry_routes(
     let npm_dir = packages_dir.join("npm");
     std::fs::create_dir_all(&npm_dir).ok();
 
-    let router = kin_registry::npm::npm_routes(Arc::new(kin_registry::npm::NpmRegistryState {
-        manifest_store: kin_registry::ManifestStore::new(state.layout.root()),
-        blobs_dir: npm_dir,
-        base_url: base_url.to_string(),
-    }));
+    let router = kin_registry::npm::npm_routes(Arc::new(kin_registry::npm::NpmRegistryState::new(
+        kin_registry::ManifestStore::new(state.layout.root()),
+        npm_dir,
+        base_url.to_string(),
+    )));
 
     match auth_state {
         Some(auth_state) => router.route_layer(middleware::from_fn_with_state(

--- a/crates/kin-daemon/src/api.rs
+++ b/crates/kin-daemon/src/api.rs
@@ -1130,10 +1130,10 @@ fn router_with_auth(state: Arc<DaemonState>, auth_token: Option<String>) -> Rout
     // Go module proxy
     let go_dir = packages_dir.join("go");
     std::fs::create_dir_all(&go_dir).ok();
-    let go_routes = kin_registry::go::go_routes(Arc::new(kin_registry::go::GoProxyState {
-        manifest_store: kin_registry::ManifestStore::new(state.layout.root()),
-        blobs_dir: go_dir,
-    }));
+    let go_routes = kin_registry::go::go_routes(Arc::new(kin_registry::go::GoProxyState::new(
+        kin_registry::ManifestStore::new(state.layout.root()),
+        go_dir,
+    )));
 
     // The package registries (cargo/npm/oci/go) are PUBLIC services with their
     // own per-write gates (Cargo: `KIN_REGISTRY_CARGO_TOKEN`; OCI:

--- a/crates/kin-daemon/src/api.rs
+++ b/crates/kin-daemon/src/api.rs
@@ -1093,20 +1093,21 @@ fn router_with_auth(state: Arc<DaemonState>, auth_token: Option<String>) -> Rout
     let base_url = std::env::var("KIN_REGISTRY_BASE_URL")
         .unwrap_or_else(|_| "http://localhost:4219".to_string());
 
-    // Cargo registry. The publish (write) path is gated on a shared secret from
-    // KIN_REGISTRY_CARGO_TOKEN; reads stay open. A None token fails closed
-    // (publishing disabled), so an unset/empty env var never falls open.
+    // Cargo and OCI reuse the existing registry write-token contract from
+    // KIN_REGISTRY_CARGO_TOKEN; reads stay open. A None token fails closed, so
+    // an unset/empty env var never silently exposes either write surface.
     let crates_dir = packages_dir.join("crates");
     std::fs::create_dir_all(&crates_dir).ok();
-    let cargo_publish_token = std::env::var("KIN_REGISTRY_CARGO_TOKEN")
+    let registry_write_token = std::env::var("KIN_REGISTRY_CARGO_TOKEN")
         .ok()
-        .filter(|s| !s.is_empty());
+        .map(|token| token.trim().to_string())
+        .filter(|token| !token.is_empty());
     let cargo_routes =
         kin_registry::cargo::cargo_routes(Arc::new(kin_registry::cargo::CargoRegistryState {
             manifest_store: kin_registry::ManifestStore::new(state.layout.root()),
             blobs_dir: crates_dir,
             base_url: base_url.clone(),
-            publish_token: cargo_publish_token,
+            publish_token: registry_write_token.clone(),
         }));
 
     let npm_routes = npm_registry_routes(
@@ -1119,11 +1120,9 @@ fn router_with_auth(state: Arc<DaemonState>, auth_token: Option<String>) -> Rout
     // OCI container registry
     let oci_dir = packages_dir.join("oci");
     std::fs::create_dir_all(&oci_dir).ok();
-    let oci_routes = kin_registry::oci::oci_routes(Arc::new(kin_registry::oci::OciRegistryState {
-        blobs_dir: oci_dir,
-        manifests: Default::default(),
-        uploads: Default::default(),
-    }));
+    let oci_routes = kin_registry::oci::oci_routes(Arc::new(
+        kin_registry::oci::OciRegistryState::new(oci_dir, registry_write_token),
+    ));
 
     // Go module proxy
     let go_dir = packages_dir.join("go");
@@ -1134,7 +1133,7 @@ fn router_with_auth(state: Arc<DaemonState>, auth_token: Option<String>) -> Rout
     }));
 
     // The package registries (cargo/npm/oci/go) are PUBLIC services with their
-    // own per-write gates (cargo: `KIN_REGISTRY_CARGO_TOKEN`; npm:
+    // own per-write gates (cargo + OCI: `KIN_REGISTRY_CARGO_TOKEN`; npm:
     // `KIN_REGISTRY_NPM_AUTH_URL` introspection); their reads stay open. The
     // daemon API is a PROTECTED control surface. So `daemon_auth` is scoped to
     // ONLY the daemon routes — applied as an inner `.layer()` on the daemon
@@ -15088,6 +15087,55 @@ mod tests {
             .await
             .unwrap();
         assert_eq!(ok.status(), StatusCode::OK);
+    }
+
+    #[tokio::test]
+    async fn oci_writes_require_registry_token_while_pulls_stay_public() {
+        let _lock = REGISTRY_ENV_LOCK.lock().await;
+
+        std::env::remove_var("KIN_REGISTRY_CARGO_TOKEN");
+        let disabled = router_with_auth(test_state(), Some("daemon-token".to_string()))
+            .oneshot(
+                Request::post("/v2/demo/blobs/uploads/")
+                    .header("authorization", "Bearer anything")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(disabled.status(), StatusCode::SERVICE_UNAVAILABLE);
+
+        let _env = RegistryEnvGuard("KIN_REGISTRY_CARGO_TOKEN");
+        std::env::set_var("KIN_REGISTRY_CARGO_TOKEN", "registry-secret");
+        let app = router_with_auth(test_state(), Some("daemon-token".to_string()));
+        let unauthorized = app
+            .clone()
+            .oneshot(
+                Request::post("/v2/demo/blobs/uploads/")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(unauthorized.status(), StatusCode::UNAUTHORIZED);
+
+        let accepted = app
+            .clone()
+            .oneshot(
+                Request::post("/v2/demo/blobs/uploads/")
+                    .header("authorization", "Bearer registry-secret")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(accepted.status(), StatusCode::ACCEPTED);
+
+        let public = app
+            .oneshot(Request::get("/v2/").body(Body::empty()).unwrap())
+            .await
+            .unwrap();
+        assert_eq!(public.status(), StatusCode::OK);
     }
 
     fn test_packages_dir(state: &Arc<DaemonState>) -> std::path::PathBuf {

--- a/crates/kin-registry/Cargo.toml
+++ b/crates/kin-registry/Cargo.toml
@@ -32,10 +32,10 @@ tempfile = { workspace = true }
 async-stream = "0.3"
 fs2 = { workspace = true }
 url = "2"
+futures-util = "0.3"
 
 [target.'cfg(unix)'.dependencies]
 libc = "0.2"
 
 [dev-dependencies]
 tower = { workspace = true }
-futures-util = "0.3"

--- a/crates/kin-registry/Cargo.toml
+++ b/crates/kin-registry/Cargo.toml
@@ -37,5 +37,9 @@ futures-util = "0.3"
 [target.'cfg(unix)'.dependencies]
 libc = "0.2"
 
+[target.'cfg(not(unix))'.dependencies]
+cap-std = "4.0.2"
+cap-fs-ext = "4.0.2"
+
 [dev-dependencies]
 tower = { workspace = true }

--- a/crates/kin-registry/Cargo.toml
+++ b/crates/kin-registry/Cargo.toml
@@ -33,6 +33,9 @@ async-stream = "0.3"
 fs2 = { workspace = true }
 url = "2"
 
+[target.'cfg(unix)'.dependencies]
+libc = "0.2"
+
 [dev-dependencies]
 tower = { workspace = true }
 futures-util = "0.3"

--- a/crates/kin-registry/Cargo.toml
+++ b/crates/kin-registry/Cargo.toml
@@ -30,6 +30,8 @@ percent-encoding = "2.3"
 sha1 = "0.11"
 tempfile = { workspace = true }
 async-stream = "0.3"
+fs2 = { workspace = true }
+url = "2"
 
 [dev-dependencies]
 tower = { workspace = true }

--- a/crates/kin-registry/Cargo.toml
+++ b/crates/kin-registry/Cargo.toml
@@ -24,6 +24,7 @@ tokio = { workspace = true }
 tar = { workspace = true }
 flate2 = { workspace = true }
 toml = { workspace = true }
+semver = { workspace = true }
 base64 = "0.22"
 percent-encoding = "2.3"
 sha1 = "0.11"

--- a/crates/kin-registry/Cargo.toml
+++ b/crates/kin-registry/Cargo.toml
@@ -28,7 +28,7 @@ semver = { workspace = true }
 base64 = "0.22"
 percent-encoding = "2.3"
 sha1 = "0.11"
+tempfile = { workspace = true }
 
 [dev-dependencies]
-tempfile = { workspace = true }
 tower = { workspace = true }

--- a/crates/kin-registry/Cargo.toml
+++ b/crates/kin-registry/Cargo.toml
@@ -29,6 +29,8 @@ base64 = "0.22"
 percent-encoding = "2.3"
 sha1 = "0.11"
 tempfile = { workspace = true }
+async-stream = "0.3"
 
 [dev-dependencies]
 tower = { workspace = true }
+futures-util = "0.3"

--- a/crates/kin-registry/PUBLISHING.md
+++ b/crates/kin-registry/PUBLISHING.md
@@ -3,17 +3,20 @@ SPDX-License-Identifier: Apache-2.0
 Copyright 2026 Firelock, LLC
 -->
 
-# Publishing to the Kin Cargo Registry
+# Publishing to the Kin Cargo and OCI Registries
 
-The Kin daemon serves a Cargo sparse registry (the `kin-registry` crate, mounted
-by `kin-daemon`). As of the registry-auth change, **publishing requires
-authentication; reads remain open.**
+The Kin daemon serves Cargo and OCI registries (the `kin-registry` crate,
+mounted by `kin-daemon`). **Publishing and other mutations require
+authentication; reads remain open.** Both adapters currently reuse the same
+registry write token so there is one fail-closed deployment contract.
 
 - Read endpoints — `config.json`, the sparse index, and `dl/{name}/{version}`
   downloads — never check a token, so `cargo` can fetch dependencies without
   credentials.
 - The write endpoint — `POST /registry/cargo/api/v1/crates/publish` — requires a
   bearer token that matches the daemon's configured secret.
+- OCI `POST`, `PUT`, and `DELETE` routes require that same bearer token; OCI
+  `GET` and `HEAD` routes remain public for pulls and discovery.
 
 ## Daemon configuration (fail-closed)
 
@@ -23,12 +26,13 @@ The daemon reads its publish secret from the environment variable:
 KIN_REGISTRY_CARGO_TOKEN=<secret>
 ```
 
-This populates `CargoRegistryState.publish_token`. The behavior is **fail-closed**:
+This populates `CargoRegistryState.publish_token` and
+`OciRegistryState.write_token`. The behavior is **fail-closed**:
 
-- If `KIN_REGISTRY_CARGO_TOKEN` is **unset or empty**, `publish_token` is `None`
-  and **every publish request is rejected**. A misconfigured deployment cannot
-  silently fall open — but it also means publishing is fully disabled until the
-  variable is set.
+- If `KIN_REGISTRY_CARGO_TOKEN` is **unset or empty**, **every Cargo publish and
+  OCI mutation is rejected**. A misconfigured deployment cannot silently fall
+  open — but it also means publishing is fully disabled until the variable is
+  set.
 - If it is set, a publish request is accepted only when its
   `Authorization: Bearer <token>` header carries the exact same value.
 
@@ -101,7 +105,7 @@ the now-fail-closed registry (surfaced as a non-2xx HTTP error).
 
 | Side | Variable | Effect when unset |
 | --- | --- | --- |
-| Daemon | `KIN_REGISTRY_CARGO_TOKEN` | Publishing disabled (fail-closed); reads still work |
+| Daemon | `KIN_REGISTRY_CARGO_TOKEN` | Cargo and OCI mutations disabled (fail-closed); reads still work |
 | `kin publish` | `KINLAB_CARGO_TOKEN`, else `KIN_REGISTRY_CARGO_TOKEN` | Warns; publish rejected by registry |
 | `publish-kinlab-crates.sh` | `KINLAB_CARGO_TOKEN` (or `KINLAB_TOKEN`) | No header; publish rejected by registry |
 

--- a/crates/kin-registry/PUBLISHING.md
+++ b/crates/kin-registry/PUBLISHING.md
@@ -7,48 +7,46 @@ Copyright 2026 Firelock, LLC
 
 The Kin daemon serves Cargo and OCI registries (the `kin-registry` crate,
 mounted by `kin-daemon`). **Publishing and other mutations require
-authentication; reads remain open.** Both adapters currently reuse the same
-registry write token so there is one fail-closed deployment contract.
+authentication; reads remain open.** Cargo and OCI use separate write
+credentials so one ecosystem's publisher cannot mutate the other.
 
 - Read endpoints — `config.json`, the sparse index, and `dl/{name}/{version}`
   downloads — never check a token, so `cargo` can fetch dependencies without
   credentials.
 - The write endpoint — `POST /registry/cargo/api/v1/crates/publish` — requires a
   bearer token that matches the daemon's configured secret.
-- OCI `POST`, `PUT`, and `DELETE` routes require that same bearer token; OCI
+- OCI `POST`, `PUT`, and `DELETE` routes require the OCI bearer token; OCI
   `GET` and `HEAD` routes remain public for pulls and discovery.
 
 ## Daemon configuration (fail-closed)
 
-The daemon reads its publish secret from the environment variable:
+The daemon reads independent publish secrets from the environment variables:
 
 ```
 KIN_REGISTRY_CARGO_TOKEN=<secret>
+KIN_REGISTRY_OCI_WRITE_TOKEN=<different-secret>
 ```
 
-This populates `CargoRegistryState.publish_token` and
-`OciRegistryState.write_token`. The behavior is **fail-closed**:
+These populate `CargoRegistryState.publish_token` and
+`OciRegistryState.write_token`, respectively. The behavior is **fail-closed**:
 
-- If `KIN_REGISTRY_CARGO_TOKEN` is **unset or empty**, **every Cargo publish and
-  OCI mutation is rejected**. A misconfigured deployment cannot silently fall
-  open — but it also means publishing is fully disabled until the variable is
-  set.
+- If either variable is **unset or empty**, that ecosystem's mutations are
+  rejected. A misconfigured deployment cannot silently fall open.
 - If it is set, a publish request is accepted only when its
   `Authorization: Bearer <token>` header carries the exact same value.
+- The Cargo credential never authorizes an OCI mutation (or vice versa).
 
 ### Production deployment action required
 
-The production GKE deployment does **not** currently set this variable:
+The production GKE deployment must set both variables:
 
 - project: `kin-ecosystem`
 - namespace: `kin`
 - deployment: `kin-daemon`
 
-Because the registry now fails closed, **publishing is disabled in production
-until `KIN_REGISTRY_CARGO_TOKEN` is added to the `kin-daemon` deployment and the
-daemon is redeployed.** Add the secret (e.g. as a Kubernetes Secret referenced
-via `env`/`envFrom`) and roll the deployment before expecting any publish to
-succeed.
+Because each registry fails closed, its writes are disabled until the matching
+secret is added to the `kin-daemon` deployment and the daemon is redeployed.
+Use distinct Kubernetes Secret keys for Cargo and OCI.
 
 > Ephemeral store note: the registry's blob/manifest store is currently backed by
 > the daemon pod's ephemeral `emptyDir`. A pod restart loses published crates, so
@@ -63,8 +61,9 @@ Every publisher sends:
 Authorization: Bearer <token>
 ```
 
-The publisher's token **must equal** the daemon's `KIN_REGISTRY_CARGO_TOKEN`.
-There are two supported publishing paths, both of which send this header.
+Cargo publishers must match the daemon's `KIN_REGISTRY_CARGO_TOKEN`. OCI clients
+must instead match `KIN_REGISTRY_OCI_WRITE_TOKEN`. There are two supported Cargo
+publishing paths, both of which send this header.
 
 ### 1. `kin publish` CLI
 
@@ -105,9 +104,9 @@ the now-fail-closed registry (surfaced as a non-2xx HTTP error).
 
 | Side | Variable | Effect when unset |
 | --- | --- | --- |
-| Daemon | `KIN_REGISTRY_CARGO_TOKEN` | Cargo and OCI mutations disabled (fail-closed); reads still work |
+| Daemon | `KIN_REGISTRY_CARGO_TOKEN` | Cargo mutations disabled (fail-closed); reads still work |
+| Daemon | `KIN_REGISTRY_OCI_WRITE_TOKEN` | OCI mutations disabled (fail-closed); reads still work |
 | `kin publish` | `KINLAB_CARGO_TOKEN`, else `KIN_REGISTRY_CARGO_TOKEN` | Warns; publish rejected by registry |
 | `publish-kinlab-crates.sh` | `KINLAB_CARGO_TOKEN` (or `KINLAB_TOKEN`) | No header; publish rejected by registry |
 
-The sender's token and the daemon's `KIN_REGISTRY_CARGO_TOKEN` must be identical
-for a publish to succeed.
+The sender's token must match the credential for the ecosystem it is mutating.

--- a/crates/kin-registry/src/atomic_file.rs
+++ b/crates/kin-registry/src/atomic_file.rs
@@ -7,10 +7,17 @@
 //! rewritten. Stage bytes in the destination directory, durably flush them,
 //! and only then replace the destination with one atomic rename.
 
+#[cfg(all(not(unix), windows))]
+use cap_fs_ext::OsMetadataExt as CapabilityOsMetadataExt;
+#[cfg(not(unix))]
+use cap_fs_ext::{
+    FollowSymlinks, MetadataExt as CapabilityMetadataExt, OpenOptionsFollowExt,
+    OpenOptionsMaybeDirExt,
+};
+#[cfg(not(unix))]
+use cap_std::fs::{Dir as CapabilityDir, OpenOptions as CapabilityOpenOptions};
 use std::ffi::OsString;
 use std::fs::File;
-#[cfg(not(unix))]
-use std::fs::OpenOptions;
 use std::io::{self, Read, Write};
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
@@ -25,14 +32,12 @@ pub(crate) enum AuthorityKey {
         name: OsString,
     },
     #[cfg(not(unix))]
-    Path(PathBuf),
+    Capability { device: u64, inode: u64 },
 }
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub(crate) struct ArtifactIdentity {
-    #[cfg(unix)]
     pub(crate) device: u64,
-    #[cfg(unix)]
     pub(crate) inode: u64,
     pub(crate) len: u64,
 }
@@ -43,8 +48,9 @@ pub(crate) struct ArtifactIdentity {
 /// Unix operations walk only relative, normal components from the retained
 /// directory descriptor with `openat(2)` and `O_NOFOLLOW`. Renaming or
 /// replacing the configured pathname therefore cannot redirect a live
-/// registry. Platforms without descriptor-relative filesystem APIs keep the
-/// canonical path and reject reparse points before each operation.
+/// registry. Windows operations retain a capability directory and resolve
+/// every descendant component from held handles without following reparse
+/// points.
 #[derive(Clone)]
 pub(crate) struct AuthorityRoot {
     path: PathBuf,
@@ -55,7 +61,7 @@ enum AuthorityRootInner {
     #[cfg(unix)]
     Unix(File),
     #[cfg(not(unix))]
-    Path,
+    Capability(CapabilityDir),
     Failed {
         kind: io::ErrorKind,
         message: String,
@@ -89,15 +95,17 @@ impl AuthorityRoot {
     }
 
     fn try_new(path: &Path) -> io::Result<Self> {
-        let path = pin_authority_root(path)?;
-        ensure_directory_durable(&path)?;
         #[cfg(unix)]
-        let inner = AuthorityRootInner::Unix(open_or_create_directory(&path)?.file);
+        let path = pin_authority_root(path)?;
         #[cfg(not(unix))]
+        let path = absolute_capability_authority_path(path)?;
+        #[cfg(unix)]
         let inner = {
-            reject_reparse_components(&path)?;
-            AuthorityRootInner::Path
+            ensure_directory_durable(&path)?;
+            AuthorityRootInner::Unix(open_or_create_directory(&path)?.file)
         };
+        #[cfg(not(unix))]
+        let inner = AuthorityRootInner::Capability(open_or_create_capability_directory(&path)?);
         Ok(Self {
             path,
             inner: Arc::new(inner),
@@ -116,7 +124,7 @@ impl AuthorityRoot {
             #[cfg(unix)]
             AuthorityRootInner::Unix(_) => None,
             #[cfg(not(unix))]
-            AuthorityRootInner::Path => None,
+            AuthorityRootInner::Capability(_) => None,
         }
     }
 
@@ -139,6 +147,16 @@ impl AuthorityRoot {
     fn unix_root(&self) -> io::Result<&File> {
         match self.inner.as_ref() {
             AuthorityRootInner::Unix(file) => Ok(file),
+            AuthorityRootInner::Failed { kind, message } => {
+                Err(io::Error::new(*kind, message.clone()))
+            }
+        }
+    }
+
+    #[cfg(not(unix))]
+    fn capability_root(&self) -> io::Result<&CapabilityDir> {
+        match self.inner.as_ref() {
+            AuthorityRootInner::Capability(directory) => Ok(directory),
             AuthorityRootInner::Failed { kind, message } => {
                 Err(io::Error::new(*kind, message.clone()))
             }
@@ -178,6 +196,34 @@ impl AuthorityRoot {
         Ok((self.directory(parent, create)?, name))
     }
 
+    #[cfg(not(unix))]
+    fn capability_directory(&self, relative: &Path, create: bool) -> io::Result<CapabilityDir> {
+        Self::validate_relative(relative, true)?;
+        let mut current = self.capability_root()?.try_clone()?;
+        for component in relative.components() {
+            let std::path::Component::Normal(name) = component else {
+                unreachable!("relative path was validated")
+            };
+            current = open_capability_child_directory(&current, name, create)?;
+        }
+        Ok(current)
+    }
+
+    #[cfg(not(unix))]
+    fn capability_parent_and_name(
+        &self,
+        relative: &Path,
+        create: bool,
+    ) -> io::Result<(CapabilityDir, OsString)> {
+        Self::validate_relative(relative, false)?;
+        let parent = relative.parent().unwrap_or_else(|| Path::new(""));
+        let name = relative
+            .file_name()
+            .expect("validated non-empty relative path")
+            .to_os_string();
+        Ok((self.capability_directory(parent, create)?, name))
+    }
+
     pub(crate) fn ensure_directory(&self, relative: &Path) -> io::Result<()> {
         if let Some(error) = self.initialization_error() {
             return Err(error);
@@ -190,10 +236,8 @@ impl AuthorityRoot {
         }
         #[cfg(not(unix))]
         {
-            let path = self.path.join(relative);
-            ensure_directory_durable(&path)?;
-            reject_reparse_components(&self.path)?;
-            reject_reparse_components(&path)
+            let _ = self.capability_directory(relative, true)?;
+            Ok(())
         }
     }
 
@@ -213,10 +257,10 @@ impl AuthorityRoot {
         }
         #[cfg(not(unix))]
         {
-            reject_reparse_components(&self.path)?;
-            let path = self.path.join(relative);
-            reject_reparse_or_non_file(&path, "registry artifact")?;
-            std::fs::read(path)
+            let mut file = self.open_read(relative)?;
+            let mut bytes = Vec::new();
+            file.read_to_end(&mut bytes)?;
+            Ok(bytes)
         }
     }
 
@@ -234,10 +278,10 @@ impl AuthorityRoot {
         }
         #[cfg(not(unix))]
         {
-            reject_reparse_components(&self.path)?;
-            let path = self.path.join(relative);
-            reject_reparse_or_non_file(&path, "registry artifact")?;
-            File::open(path)
+            let (parent, name) = self.capability_parent_and_name(relative, false)?;
+            let mut options = CapabilityOpenOptions::new();
+            options.read(true).follow(FollowSymlinks::No);
+            open_capability_regular_file(&parent, &name, &options, "registry artifact")
         }
     }
 
@@ -255,10 +299,10 @@ impl AuthorityRoot {
         }
         #[cfg(not(unix))]
         {
-            reject_reparse_components(&self.path)?;
-            let path = self.path.join(relative);
-            reject_reparse_or_non_file(&path, "registry upload data")?;
-            OpenOptions::new().append(true).open(path)
+            let (parent, name) = self.capability_parent_and_name(relative, false)?;
+            let mut options = CapabilityOpenOptions::new();
+            options.append(true).follow(FollowSymlinks::No);
+            open_capability_regular_file(&parent, &name, &options, "registry upload data")
         }
     }
 
@@ -276,10 +320,10 @@ impl AuthorityRoot {
         }
         #[cfg(not(unix))]
         {
-            reject_reparse_components(&self.path)?;
-            let path = self.path.join(relative);
-            reject_reparse_or_non_file(&path, "registry artifact")?;
-            OpenOptions::new().write(true).open(path)
+            let (parent, name) = self.capability_parent_and_name(relative, false)?;
+            let mut options = CapabilityOpenOptions::new();
+            options.write(true).follow(FollowSymlinks::No);
+            open_capability_regular_file(&parent, &name, &options, "registry artifact")
         }
     }
 
@@ -300,7 +344,10 @@ impl AuthorityRoot {
         }
         #[cfg(not(unix))]
         {
+            let identity = validate_capability_regular_file_from_std(&file, "registry artifact")?;
             Ok(ArtifactIdentity {
+                device: identity.device,
+                inode: identity.inode,
                 len: file.metadata()?.len(),
             })
         }
@@ -355,8 +402,8 @@ impl AuthorityRoot {
         }
         #[cfg(not(unix))]
         {
-            reject_reparse_components(&self.path)?;
-            std::fs::read_dir(self.path.join(relative))?
+            self.capability_directory(relative, false)?
+                .entries()?
                 .map(|entry| entry.map(|entry| entry.file_name()))
                 .collect()
         }
@@ -374,9 +421,8 @@ impl AuthorityRoot {
         }
         #[cfg(not(unix))]
         {
-            reject_reparse_components(&self.path)?;
-            write(&self.path.join(relative), bytes)?;
-            reject_reparse_components(&self.path)
+            let (parent, destination_name) = self.capability_parent_and_name(relative, true)?;
+            write_capability_at(&parent, &destination_name, bytes, |_| Ok(()))
         }
     }
 
@@ -405,10 +451,9 @@ impl AuthorityRoot {
         }
         #[cfg(not(unix))]
         {
-            reject_reparse_components(&self.path)?;
-            let path = self.path.join(relative);
-            match reject_reparse_or_non_file(&path, "registry artifact") {
-                Ok(()) => std::fs::remove_file(path),
+            let (parent, name) = self.capability_parent_and_name(relative, false)?;
+            match validate_capability_named_regular_file(&parent, &name, "registry artifact") {
+                Ok(_) => parent.remove_file(&name),
                 Err(error) if error.kind() == io::ErrorKind::NotFound => Ok(()),
                 Err(error) => Err(error),
             }
@@ -449,11 +494,20 @@ impl AuthorityRoot {
         }
         #[cfg(not(unix))]
         {
-            reject_reparse_components(&self.path)?;
-            let from = self.path.join(from);
-            let to = self.path.join(to);
-            reject_reparse_or_non_file(&from, "registry artifact")?;
-            std::fs::rename(from, to)
+            let (from_parent, from_name) = self.capability_parent_and_name(from, false)?;
+            let (to_parent, to_name) = self.capability_parent_and_name(to, true)?;
+            validate_capability_named_regular_file(&from_parent, &from_name, "registry artifact")?;
+            match to_parent.symlink_metadata(&to_name) {
+                Ok(_) => {
+                    return Err(io::Error::new(
+                        io::ErrorKind::AlreadyExists,
+                        "registry destination already exists",
+                    ));
+                }
+                Err(error) if error.kind() == io::ErrorKind::NotFound => {}
+                Err(error) => return Err(error),
+            }
+            from_parent.rename(&from_name, &to_parent, &to_name)
         }
     }
 
@@ -469,7 +523,8 @@ impl AuthorityRoot {
         }
         #[cfg(not(unix))]
         {
-            open_lock_file(&self.path.join(relative))
+            let (parent, name) = self.capability_parent_and_name(relative, true)?;
+            open_capability_lock_file(parent, name)
         }
     }
 }
@@ -481,6 +536,7 @@ impl AuthorityRoot {
 /// (a system alias for `/private/var`) without permitting storage operations
 /// to follow symlinks in package-controlled descendants. Missing descendants
 /// are appended only after the nearest existing ancestor is canonicalized.
+#[cfg(unix)]
 pub(crate) fn pin_authority_root(path: &Path) -> io::Result<PathBuf> {
     let mut cursor = path;
     let mut missing = Vec::<OsString>::new();
@@ -522,7 +578,9 @@ pub(crate) struct AnchoredLockFile {
     #[cfg(unix)]
     name: OsString,
     #[cfg(not(unix))]
-    path: PathBuf,
+    capability_parent: CapabilityDir,
+    #[cfg(not(unix))]
+    capability_name: OsString,
 }
 
 impl AnchoredLockFile {
@@ -547,12 +605,346 @@ impl AnchoredLockFile {
         }
         #[cfg(not(unix))]
         {
-            reject_reparse_or_non_file(&self.path, "registry transaction lock")
+            let opened =
+                validate_capability_regular_file_from_std(&self.file, "registry transaction lock")?;
+            let named = validate_capability_named_regular_file(
+                &self.capability_parent,
+                &self.capability_name,
+                "registry transaction lock",
+            )?;
+            if opened != named {
+                return Err(io::Error::other(
+                    "registry transaction lock changed identity during acquisition",
+                ));
+            }
+            Ok(())
         }
     }
 }
 
-#[cfg(any(test, not(unix)))]
+#[cfg(not(unix))]
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+struct CapabilityFileIdentity {
+    device: u64,
+    inode: u64,
+}
+
+#[cfg(not(unix))]
+fn capability_metadata_is_reparse(metadata: &cap_std::fs::Metadata) -> bool {
+    #[cfg(windows)]
+    {
+        CapabilityOsMetadataExt::file_attributes(metadata) & 0x400 != 0
+    }
+    #[cfg(not(windows))]
+    {
+        metadata.file_type().is_symlink()
+    }
+}
+
+#[cfg(not(unix))]
+fn validate_capability_regular_file(
+    file: &cap_std::fs::File,
+    label: &str,
+) -> io::Result<CapabilityFileIdentity> {
+    let metadata = file.metadata()?;
+    if capability_metadata_is_reparse(&metadata)
+        || !metadata.is_file()
+        || CapabilityMetadataExt::nlink(&metadata) != 1
+    {
+        return Err(io::Error::other(format!(
+            "{label} is not a single-link regular-file authority"
+        )));
+    }
+    Ok(CapabilityFileIdentity {
+        device: CapabilityMetadataExt::dev(&metadata),
+        inode: CapabilityMetadataExt::ino(&metadata),
+    })
+}
+
+#[cfg(not(unix))]
+fn validate_capability_regular_file_from_std(
+    file: &File,
+    label: &str,
+) -> io::Result<CapabilityFileIdentity> {
+    let file = cap_std::fs::File::from_std(file.try_clone()?);
+    validate_capability_regular_file(&file, label)
+}
+
+#[cfg(not(unix))]
+fn open_capability_regular_file(
+    parent: &CapabilityDir,
+    name: &std::ffi::OsStr,
+    options: &CapabilityOpenOptions,
+    label: &str,
+) -> io::Result<File> {
+    let file = parent.open_with(name, options)?;
+    validate_capability_regular_file(&file, label)?;
+    Ok(file.into_std())
+}
+
+#[cfg(not(unix))]
+fn validate_capability_named_regular_file(
+    parent: &CapabilityDir,
+    name: &std::ffi::OsStr,
+    label: &str,
+) -> io::Result<CapabilityFileIdentity> {
+    let mut options = CapabilityOpenOptions::new();
+    options.read(true).follow(FollowSymlinks::No);
+    let file = parent.open_with(name, &options)?;
+    validate_capability_regular_file(&file, label)
+}
+
+#[cfg(not(unix))]
+fn open_capability_child_directory(
+    parent: &CapabilityDir,
+    name: &std::ffi::OsStr,
+    create: bool,
+) -> io::Result<CapabilityDir> {
+    let open = || {
+        let mut options = CapabilityOpenOptions::new();
+        options
+            .read(true)
+            .follow(FollowSymlinks::No)
+            .maybe_dir(true);
+        let file = parent.open_with(name, &options)?;
+        let metadata = file.metadata()?;
+        if capability_metadata_is_reparse(&metadata) || !metadata.is_dir() {
+            return Err(io::Error::other(format!(
+                "registry directory component is a reparse point or non-directory: {}",
+                name.to_string_lossy()
+            )));
+        }
+        Ok(CapabilityDir::from_std_file(file.into_std()))
+    };
+
+    match open() {
+        Ok(directory) => Ok(directory),
+        Err(error) if create && error.kind() == io::ErrorKind::NotFound => {
+            match parent.create_dir(name) {
+                Ok(()) => {}
+                Err(error) if error.kind() == io::ErrorKind::AlreadyExists => {}
+                Err(error) => return Err(error),
+            }
+            open()
+        }
+        Err(error) => Err(error),
+    }
+}
+
+#[cfg(not(unix))]
+fn capability_ambient_root_and_relative(path: &Path) -> io::Result<(PathBuf, PathBuf)> {
+    if !path.is_absolute() {
+        return Err(io::Error::new(
+            io::ErrorKind::InvalidInput,
+            "registry capability authority must be absolute",
+        ));
+    }
+    let root = path
+        .ancestors()
+        .last()
+        .filter(|root| !root.as_os_str().is_empty())
+        .ok_or_else(|| {
+            io::Error::new(
+                io::ErrorKind::InvalidInput,
+                "registry capability authority has no filesystem root",
+            )
+        })?;
+    let relative = path.strip_prefix(root).map_err(|_| {
+        io::Error::new(
+            io::ErrorKind::InvalidInput,
+            "registry capability authority is not beneath its filesystem root",
+        )
+    })?;
+    if relative
+        .components()
+        .any(|component| !matches!(component, std::path::Component::Normal(_)))
+    {
+        return Err(io::Error::new(
+            io::ErrorKind::InvalidInput,
+            "registry capability authority contains an unsupported component",
+        ));
+    }
+    Ok((root.to_path_buf(), relative.to_path_buf()))
+}
+
+#[cfg(not(unix))]
+fn absolute_capability_authority_path(path: &Path) -> io::Result<PathBuf> {
+    let path = if path.is_absolute() {
+        path.to_path_buf()
+    } else {
+        std::env::current_dir()?.join(path)
+    };
+    if path
+        .components()
+        .any(|component| matches!(component, std::path::Component::ParentDir))
+    {
+        return Err(io::Error::new(
+            io::ErrorKind::InvalidInput,
+            "registry capability authority may not contain parent traversal",
+        ));
+    }
+    Ok(path)
+}
+
+#[cfg(not(unix))]
+fn open_or_create_capability_directory(path: &Path) -> io::Result<CapabilityDir> {
+    let (ambient_root, relative) = capability_ambient_root_and_relative(path)?;
+    let mut current = CapabilityDir::open_ambient_dir(&ambient_root, cap_std::ambient_authority())?;
+    for component in relative.components() {
+        let std::path::Component::Normal(name) = component else {
+            unreachable!("capability-relative path was built from normal components")
+        };
+        current = open_capability_child_directory(&current, name, true)?;
+    }
+    Ok(current)
+}
+
+#[cfg(all(test, not(unix)))]
+fn ambient_parent_and_name(path: &Path) -> io::Result<(PathBuf, OsString)> {
+    let parent = path.parent().ok_or_else(|| {
+        io::Error::new(
+            io::ErrorKind::InvalidInput,
+            "registry authority path has no parent directory",
+        )
+    })?;
+    let name = path
+        .file_name()
+        .filter(|name| !name.is_empty())
+        .ok_or_else(|| {
+            io::Error::new(
+                io::ErrorKind::InvalidInput,
+                "registry authority path has no filename",
+            )
+        })?
+        .to_os_string();
+    Ok((absolute_capability_authority_path(parent)?, name))
+}
+
+#[cfg(not(unix))]
+fn open_capability_lock_file(
+    parent: CapabilityDir,
+    name: OsString,
+) -> io::Result<AnchoredLockFile> {
+    let mut options = CapabilityOpenOptions::new();
+    options
+        .read(true)
+        .write(true)
+        .create(true)
+        .follow(FollowSymlinks::No);
+    let file = parent.open_with(&name, &options)?;
+    let identity = validate_capability_regular_file(&file, "registry transaction lock")?;
+    let key = AuthorityKey::Capability {
+        device: identity.device,
+        inode: identity.inode,
+    };
+    Ok(AnchoredLockFile {
+        file: file.into_std(),
+        key,
+        capability_parent: parent,
+        capability_name: name,
+    })
+}
+
+#[cfg(not(unix))]
+fn create_capability_staged_file(
+    parent: &CapabilityDir,
+) -> io::Result<(cap_std::fs::File, OsString)> {
+    use std::sync::atomic::{AtomicU64, Ordering};
+    use std::time::{SystemTime, UNIX_EPOCH};
+
+    static NEXT_STAGE: AtomicU64 = AtomicU64::new(0);
+    for _ in 0..100 {
+        let nonce = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .unwrap_or_default()
+            .as_nanos();
+        let sequence = NEXT_STAGE.fetch_add(1, Ordering::Relaxed);
+        let name = OsString::from(format!(
+            ".kin-registry-stage-{}-{nonce}-{sequence}",
+            std::process::id()
+        ));
+        let mut options = CapabilityOpenOptions::new();
+        options
+            .write(true)
+            .create_new(true)
+            .follow(FollowSymlinks::No);
+        match parent.open_with(&name, &options) {
+            Ok(file) => return Ok((file, name)),
+            Err(error) if error.kind() == io::ErrorKind::AlreadyExists => continue,
+            Err(error) => return Err(error),
+        }
+    }
+    Err(io::Error::new(
+        io::ErrorKind::AlreadyExists,
+        "could not allocate a unique registry staging file",
+    ))
+}
+
+#[cfg(not(unix))]
+fn write_capability_at<F>(
+    parent: &CapabilityDir,
+    destination_name: &std::ffi::OsStr,
+    bytes: &[u8],
+    pre_commit: F,
+) -> io::Result<()>
+where
+    F: FnOnce(&Path) -> io::Result<()>,
+{
+    let (mut staged, staged_name) = create_capability_staged_file(parent)?;
+    let staged_identity = validate_capability_regular_file(&staged, "registry staged artifact")?;
+    let result = (|| {
+        staged.write_all(bytes)?;
+        staged.flush()?;
+        staged.sync_all()?;
+        pre_commit(Path::new(&staged_name))?;
+        let named = validate_capability_named_regular_file(
+            parent,
+            &staged_name,
+            "registry staged artifact",
+        )?;
+        if named != staged_identity {
+            return Err(io::Error::other(
+                "registry staged artifact changed identity during publication",
+            ));
+        }
+        match parent.symlink_metadata(destination_name) {
+            Ok(_) => {
+                validate_capability_named_regular_file(
+                    parent,
+                    destination_name,
+                    "existing registry destination",
+                )?;
+            }
+            Err(error) if error.kind() == io::ErrorKind::NotFound => {}
+            Err(error) => return Err(error),
+        }
+        parent.rename(&staged_name, parent, destination_name)?;
+        let published = validate_capability_named_regular_file(
+            parent,
+            destination_name,
+            "published registry artifact",
+        )?;
+        if published != staged_identity {
+            return Err(io::Error::other(
+                "published registry artifact changed identity during publication",
+            ));
+        }
+        // cap-std makes the rename capability-relative and atomic, but Windows
+        // has no portable directory-fsync primitive. Flush the published file;
+        // directory-entry crash durability remains bounded by the platform.
+        staged.sync_all()
+    })();
+
+    if result.is_err()
+        && validate_capability_named_regular_file(parent, &staged_name, "registry staged artifact")
+            .is_ok_and(|actual| actual == staged_identity)
+    {
+        let _ = parent.remove_file(&staged_name);
+    }
+    result
+}
+
+#[cfg(test)]
 pub(crate) fn open_lock_file(path: &Path) -> io::Result<AnchoredLockFile> {
     #[cfg(unix)]
     {
@@ -561,27 +953,9 @@ pub(crate) fn open_lock_file(path: &Path) -> io::Result<AnchoredLockFile> {
     }
     #[cfg(not(unix))]
     {
-        let parent = path.parent().ok_or_else(|| {
-            io::Error::new(
-                io::ErrorKind::InvalidInput,
-                "registry transaction lock has no parent directory",
-            )
-        })?;
-        ensure_directory_durable(parent)?;
-        reject_reparse_components(parent)?;
-        let file = OpenOptions::new()
-            .read(true)
-            .write(true)
-            .create(true)
-            .truncate(false)
-            .open(path)?;
-        reject_reparse_or_non_file(path, "registry transaction lock")?;
-        let key = AuthorityKey::Path(path.canonicalize()?);
-        Ok(AnchoredLockFile {
-            file,
-            key,
-            path: path.to_path_buf(),
-        })
+        let (parent_path, name) = ambient_parent_and_name(path)?;
+        let parent = open_or_create_capability_directory(&parent_path)?;
+        open_capability_lock_file(parent, name)
     }
 }
 
@@ -620,7 +994,7 @@ fn open_lock_file_in(parent: File, name: OsString) -> io::Result<AnchoredLockFil
     })
 }
 
-#[cfg(any(test, not(unix)))]
+#[cfg(test)]
 pub(crate) fn write(path: &Path, bytes: &[u8]) -> io::Result<()> {
     write_with_pre_commit(path, bytes, |_| Ok(()))
 }
@@ -712,31 +1086,16 @@ fn write_at(parent: &File, destination_name: &std::ffi::OsStr, bytes: &[u8]) -> 
     result
 }
 
-#[cfg(not(unix))]
+#[cfg(all(test, not(unix)))]
 fn write_with_pre_commit_impl<F>(path: &Path, bytes: &[u8], pre_commit: F) -> io::Result<()>
 where
     F: FnOnce(&Path) -> io::Result<()>,
 {
-    let parent = path.parent().ok_or_else(|| {
-        io::Error::new(
-            io::ErrorKind::InvalidInput,
-            "atomic registry destination has no parent directory",
-        )
-    })?;
-    ensure_directory_durable(parent)?;
-    reject_reparse_components(parent)?;
-
-    let mut staged = tempfile::NamedTempFile::new_in(parent)?;
-    staged.write_all(bytes)?;
-    staged.flush()?;
-    staged.as_file().sync_all()?;
-    pre_commit(staged.path())?;
-    reject_reparse_components(parent)?;
-
-    let published = staged.persist(path).map_err(|error| error.error)?;
-    published.sync_all()?;
-    sync_parent(parent)?;
-    Ok(())
+    let (parent_path, destination_name) = ambient_parent_and_name(path)?;
+    let parent = open_or_create_capability_directory(&parent_path)?;
+    write_capability_at(&parent, &destination_name, bytes, |staged_name| {
+        pre_commit(&parent_path.join(staged_name))
+    })
 }
 
 /// Create a directory chain and durably publish each newly-created component.
@@ -746,6 +1105,7 @@ where
 /// from its parent even though the response was already acknowledged. Build
 /// missing components from the first existing ancestor downward and fsync the
 /// parent after every directory entry becomes visible.
+#[cfg(any(unix, test))]
 pub(crate) fn ensure_directory_durable(path: &Path) -> io::Result<()> {
     #[cfg(unix)]
     {
@@ -754,58 +1114,7 @@ pub(crate) fn ensure_directory_durable(path: &Path) -> io::Result<()> {
     }
     #[cfg(not(unix))]
     {
-        let mut cursor = path.to_path_buf();
-        let mut missing: Vec<PathBuf> = Vec::new();
-
-        loop {
-            match std::fs::symlink_metadata(&cursor) {
-                Ok(metadata) if metadata.is_dir() && !metadata_is_reparse(&metadata) => break,
-                Ok(_) => {
-                    return Err(io::Error::new(
-                        io::ErrorKind::AlreadyExists,
-                        format!(
-                            "registry directory path is not a directory: {}",
-                            cursor.display()
-                        ),
-                    ));
-                }
-                Err(error) if error.kind() == io::ErrorKind::NotFound => {
-                    missing.push(cursor.clone());
-                    cursor = cursor
-                        .parent()
-                        .ok_or_else(|| {
-                            io::Error::new(
-                                io::ErrorKind::InvalidInput,
-                                "registry directory has no existing ancestor",
-                            )
-                        })?
-                        .to_path_buf();
-                }
-                Err(error) => return Err(error),
-            }
-        }
-
-        for directory in missing.into_iter().rev() {
-            match std::fs::create_dir(&directory) {
-                Ok(()) => {}
-                Err(error) if error.kind() == io::ErrorKind::AlreadyExists => {
-                    let metadata = std::fs::symlink_metadata(&directory)?;
-                    if !metadata.is_dir() || metadata_is_reparse(&metadata) {
-                        return Err(io::Error::new(
-                            io::ErrorKind::AlreadyExists,
-                            format!(
-                                "registry directory path raced with a non-directory: {}",
-                                directory.display()
-                            ),
-                        ));
-                    }
-                }
-                Err(error) => return Err(error),
-            }
-            if let Some(parent) = directory.parent() {
-                sync_parent(parent)?;
-            }
-        }
+        let _ = open_or_create_capability_directory(path)?;
         Ok(())
     }
 }
@@ -1115,67 +1424,12 @@ fn name_cstring(name: &std::ffi::OsStr) -> io::Result<std::ffi::CString> {
     })
 }
 
-#[cfg(not(unix))]
-fn metadata_is_reparse(metadata: &std::fs::Metadata) -> bool {
-    #[cfg(windows)]
-    {
-        use std::os::windows::fs::MetadataExt;
-        return metadata.file_attributes() & 0x400 != 0;
-    }
-    #[cfg(not(windows))]
-    {
-        metadata.file_type().is_symlink()
-    }
-}
-
-#[cfg(not(unix))]
-fn reject_reparse_or_non_file(path: &Path, label: &str) -> io::Result<()> {
-    let metadata = std::fs::symlink_metadata(path)?;
-    if metadata_is_reparse(&metadata) || !metadata.is_file() {
-        return Err(io::Error::other(format!(
-            "{label} is a reparse point or non-file authority"
-        )));
-    }
-    Ok(())
-}
-
-#[cfg(not(unix))]
-fn reject_reparse_components(path: &Path) -> io::Result<()> {
-    let mut current = PathBuf::new();
-    for component in path.components() {
-        current.push(component.as_os_str());
-        let metadata = std::fs::symlink_metadata(&current)?;
-        if metadata_is_reparse(&metadata) || !metadata.is_dir() {
-            return Err(io::Error::other(format!(
-                "registry directory component is a reparse point or non-directory: {}",
-                current.display()
-            )));
-        }
-    }
-    Ok(())
-}
-
 #[cfg(test)]
 pub(crate) fn write_with_pre_commit<F>(path: &Path, bytes: &[u8], pre_commit: F) -> io::Result<()>
 where
     F: FnOnce(&Path) -> io::Result<()>,
 {
     write_with_pre_commit_impl(path, bytes, pre_commit)
-}
-
-#[cfg(all(not(test), not(unix)))]
-fn write_with_pre_commit<F>(path: &Path, bytes: &[u8], pre_commit: F) -> io::Result<()>
-where
-    F: FnOnce(&Path) -> io::Result<()>,
-{
-    write_with_pre_commit_impl(path, bytes, pre_commit)
-}
-
-#[cfg(not(unix))]
-fn sync_parent(_parent: &Path) -> io::Result<()> {
-    // The published file itself is flushed above. Opening directories for a
-    // portable metadata fsync is not supported by std on non-Unix platforms.
-    Ok(())
 }
 
 #[cfg(test)]
@@ -1245,6 +1499,21 @@ mod tests {
         assert_eq!(std::fs::read(destination).unwrap(), b"complete-manifest\n");
     }
 
+    #[test]
+    fn same_length_replacement_changes_artifact_identity() {
+        let root = tempfile::tempdir().unwrap();
+        let authority = AuthorityRoot::new(&root.path().join("authority"));
+        let relative = Path::new("nested/artifact");
+        authority.write(relative, b"first").unwrap();
+        let before = authority.identity(relative).unwrap();
+
+        authority.write(relative, b"other").unwrap();
+        let after = authority.identity(relative).unwrap();
+
+        assert_eq!(before.len, after.len);
+        assert_ne!((before.device, before.inode), (after.device, after.inode));
+    }
+
     #[cfg(unix)]
     #[test]
     fn write_rejects_symlinked_directory_components_and_destinations() {
@@ -1269,5 +1538,57 @@ mod tests {
             .unwrap()
             .file_type()
             .is_symlink());
+    }
+
+    #[cfg(windows)]
+    #[test]
+    fn live_capability_authority_blocks_root_replacement() {
+        let root = tempfile::tempdir().unwrap();
+        let authority_path = root.path().join("authority");
+        let authority = AuthorityRoot::new(&authority_path);
+        authority
+            .write(Path::new("nested/artifact"), b"pinned")
+            .unwrap();
+
+        let displaced = root.path().join("displaced");
+        assert!(std::fs::rename(&authority_path, &displaced).is_err());
+        assert_eq!(
+            authority.read(Path::new("nested/artifact")).unwrap(),
+            b"pinned"
+        );
+
+        drop(authority);
+        std::fs::rename(&authority_path, &displaced).unwrap();
+    }
+
+    #[cfg(windows)]
+    #[test]
+    fn capability_authority_rejects_descendant_junctions() {
+        let root = tempfile::tempdir().unwrap();
+        let authority_path = root.path().join("authority");
+        let authority = AuthorityRoot::new(&authority_path);
+        let outside = root.path().join("outside");
+        std::fs::create_dir(&outside).unwrap();
+        std::fs::write(outside.join("artifact"), b"outside").unwrap();
+
+        let junction = authority_path.join("junction");
+        let output = std::process::Command::new("cmd")
+            .args(["/C", "mklink", "/J"])
+            .arg(&junction)
+            .arg(&outside)
+            .output()
+            .unwrap();
+        assert!(
+            output.status.success(),
+            "failed to create test junction: {}{}",
+            String::from_utf8_lossy(&output.stdout),
+            String::from_utf8_lossy(&output.stderr)
+        );
+
+        assert!(authority.read(Path::new("junction/artifact")).is_err());
+        assert!(authority
+            .write(Path::new("junction/artifact"), b"redirected")
+            .is_err());
+        assert_eq!(std::fs::read(outside.join("artifact")).unwrap(), b"outside");
     }
 }

--- a/crates/kin-registry/src/atomic_file.rs
+++ b/crates/kin-registry/src/atomic_file.rs
@@ -1,0 +1,119 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Firelock, LLC
+
+//! Crash-safe publication of registry artifacts.
+//!
+//! Registry readers must never observe a destination while it is being
+//! rewritten. Stage bytes in the destination directory, durably flush them,
+//! and only then replace the destination with one atomic rename.
+
+use std::io::{self, Write};
+use std::path::Path;
+
+pub(crate) fn write(path: &Path, bytes: &[u8]) -> io::Result<()> {
+    write_with_pre_commit(path, bytes, |_| Ok(()))
+}
+
+fn write_with_pre_commit_impl<F>(path: &Path, bytes: &[u8], pre_commit: F) -> io::Result<()>
+where
+    F: FnOnce(&Path) -> io::Result<()>,
+{
+    let parent = path.parent().ok_or_else(|| {
+        io::Error::new(
+            io::ErrorKind::InvalidInput,
+            "atomic registry destination has no parent directory",
+        )
+    })?;
+    std::fs::create_dir_all(parent)?;
+
+    // tempfile::NamedTempFile::persist performs an atomic, replacing rename on
+    // Unix and Windows. Because the stage lives in `parent`, the rename cannot
+    // cross filesystems. PersistError retains and cleans the stage on failure.
+    let mut staged = tempfile::NamedTempFile::new_in(parent)?;
+    staged.write_all(bytes)?;
+    staged.flush()?;
+    staged.as_file().sync_all()?;
+    pre_commit(staged.path())?;
+
+    let published = staged.persist(path).map_err(|error| error.error)?;
+    published.sync_all()?;
+    sync_parent(parent)?;
+    Ok(())
+}
+
+#[cfg(test)]
+pub(crate) fn write_with_pre_commit<F>(path: &Path, bytes: &[u8], pre_commit: F) -> io::Result<()>
+where
+    F: FnOnce(&Path) -> io::Result<()>,
+{
+    write_with_pre_commit_impl(path, bytes, pre_commit)
+}
+
+#[cfg(not(test))]
+fn write_with_pre_commit<F>(path: &Path, bytes: &[u8], pre_commit: F) -> io::Result<()>
+where
+    F: FnOnce(&Path) -> io::Result<()>,
+{
+    write_with_pre_commit_impl(path, bytes, pre_commit)
+}
+
+#[cfg(unix)]
+fn sync_parent(parent: &Path) -> io::Result<()> {
+    std::fs::File::open(parent)?.sync_all()
+}
+
+#[cfg(not(unix))]
+fn sync_parent(_parent: &Path) -> io::Result<()> {
+    // The published file itself is flushed above. Opening directories for a
+    // portable metadata fsync is not supported by std on non-Unix platforms.
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn failed_pre_commit_preserves_destination_and_cleans_stage() {
+        let root = tempfile::tempdir().unwrap();
+        let destination = root.path().join("artifact");
+        std::fs::write(&destination, b"old-complete-bytes").unwrap();
+
+        let error = write_with_pre_commit(&destination, b"replacement", |_| {
+            Err(io::Error::other("injected pre-rename failure"))
+        })
+        .unwrap_err();
+
+        assert_eq!(error.kind(), io::ErrorKind::Other);
+        assert_eq!(std::fs::read(&destination).unwrap(), b"old-complete-bytes");
+        assert_eq!(std::fs::read_dir(root.path()).unwrap().count(), 1);
+    }
+
+    #[test]
+    fn successful_write_atomically_replaces_destination() {
+        let root = tempfile::tempdir().unwrap();
+        let destination = root.path().join("artifact");
+        std::fs::write(&destination, b"old").unwrap();
+
+        write(&destination, b"new-complete-bytes").unwrap();
+
+        assert_eq!(std::fs::read(&destination).unwrap(), b"new-complete-bytes");
+        assert_eq!(std::fs::read_dir(root.path()).unwrap().count(), 1);
+    }
+
+    #[test]
+    fn fully_staged_bytes_are_not_visible_at_the_destination_before_commit() {
+        let root = tempfile::tempdir().unwrap();
+        let destination = root.path().join("artifact");
+        std::fs::write(&destination, b"old-complete-bytes").unwrap();
+
+        write_with_pre_commit(&destination, b"new-complete-bytes", |stage| {
+            assert_eq!(std::fs::read(&destination)?, b"old-complete-bytes");
+            assert_eq!(std::fs::read(stage)?, b"new-complete-bytes");
+            Ok(())
+        })
+        .unwrap();
+
+        assert_eq!(std::fs::read(&destination).unwrap(), b"new-complete-bytes");
+    }
+}

--- a/crates/kin-registry/src/atomic_file.rs
+++ b/crates/kin-registry/src/atomic_file.rs
@@ -7,13 +7,223 @@
 //! rewritten. Stage bytes in the destination directory, durably flush them,
 //! and only then replace the destination with one atomic rename.
 
+use std::ffi::OsString;
+use std::fs::File;
+#[cfg(not(unix))]
+use std::fs::OpenOptions;
 use std::io::{self, Write};
 use std::path::{Path, PathBuf};
+
+/// Stable in-process identity for one named authority inside a pinned parent.
+#[derive(Clone, Debug, Eq, Hash, PartialEq)]
+pub(crate) enum AuthorityKey {
+    #[cfg(unix)]
+    Unix {
+        parent_device: u64,
+        parent_inode: u64,
+        name: OsString,
+    },
+    #[cfg(not(unix))]
+    Path(PathBuf),
+}
+
+/// Resolve the configured authority root once, then retain the resulting
+/// absolute path for every later descriptor-anchored operation.
+///
+/// This deliberately permits an operator-selected root such as macOS `/var`
+/// (a system alias for `/private/var`) without permitting storage operations
+/// to follow symlinks in package-controlled descendants. Missing descendants
+/// are appended only after the nearest existing ancestor is canonicalized.
+pub(crate) fn pin_authority_root(path: &Path) -> io::Result<PathBuf> {
+    let mut cursor = path;
+    let mut missing = Vec::<OsString>::new();
+
+    loop {
+        match cursor.canonicalize() {
+            Ok(mut pinned) => {
+                for component in missing.into_iter().rev() {
+                    pinned.push(component);
+                }
+                return Ok(pinned);
+            }
+            Err(error) if error.kind() == io::ErrorKind::NotFound => {
+                let name = cursor.file_name().ok_or_else(|| {
+                    io::Error::new(
+                        io::ErrorKind::InvalidInput,
+                        "registry authority root has no existing ancestor",
+                    )
+                })?;
+                missing.push(name.to_os_string());
+                cursor = cursor.parent().ok_or_else(|| {
+                    io::Error::new(
+                        io::ErrorKind::InvalidInput,
+                        "registry authority root has no existing ancestor",
+                    )
+                })?;
+            }
+            Err(error) => return Err(error),
+        }
+    }
+}
+
+/// A lock file opened without following the final path component.
+pub(crate) struct AnchoredLockFile {
+    pub(crate) file: File,
+    key: AuthorityKey,
+    #[cfg(unix)]
+    parent: File,
+    #[cfg(unix)]
+    name: OsString,
+    #[cfg(not(unix))]
+    path: PathBuf,
+}
+
+impl AnchoredLockFile {
+    pub(crate) fn authority_key(&self) -> AuthorityKey {
+        self.key.clone()
+    }
+
+    pub(crate) fn verify_named(&self) -> io::Result<()> {
+        #[cfg(unix)]
+        {
+            let opened = validate_regular_file(&self.file, "registry transaction lock")?;
+            let named = validate_regular_stat(
+                &stat_at(&self.parent, &self.name)?,
+                "registry transaction lock",
+            )?;
+            if opened != named {
+                return Err(io::Error::other(
+                    "registry transaction lock changed identity during acquisition",
+                ));
+            }
+            Ok(())
+        }
+        #[cfg(not(unix))]
+        {
+            reject_reparse_or_non_file(&self.path, "registry transaction lock")
+        }
+    }
+}
+
+pub(crate) fn open_lock_file(path: &Path) -> io::Result<AnchoredLockFile> {
+    #[cfg(unix)]
+    {
+        let (parent, name) = anchor_named_path(path)?;
+        let file = match open_file_at(
+            &parent.file,
+            &name,
+            libc::O_RDWR | libc::O_CREAT | libc::O_EXCL,
+            0o600,
+        ) {
+            Ok(file) => file,
+            Err(error) if error.kind() == io::ErrorKind::AlreadyExists => {
+                open_file_at(&parent.file, &name, libc::O_RDWR, 0o600)?
+            }
+            Err(error) => return Err(error),
+        };
+        let opened = validate_regular_file(&file, "registry transaction lock")?;
+        let named =
+            validate_regular_stat(&stat_at(&parent.file, &name)?, "registry transaction lock")?;
+        if opened != named {
+            return Err(io::Error::other(
+                "registry transaction lock changed identity while opening",
+            ));
+        }
+        let parent_stat = stat_file(&parent.file)?;
+        let key = AuthorityKey::Unix {
+            parent_device: parent_stat.st_dev as u64,
+            parent_inode: parent_stat.st_ino as u64,
+            name: name.clone(),
+        };
+        Ok(AnchoredLockFile {
+            file,
+            key,
+            parent: parent.file,
+            name,
+        })
+    }
+    #[cfg(not(unix))]
+    {
+        let parent = path.parent().ok_or_else(|| {
+            io::Error::new(
+                io::ErrorKind::InvalidInput,
+                "registry transaction lock has no parent directory",
+            )
+        })?;
+        ensure_directory_durable(parent)?;
+        reject_reparse_components(parent)?;
+        let file = OpenOptions::new()
+            .read(true)
+            .write(true)
+            .create(true)
+            .truncate(false)
+            .open(path)?;
+        reject_reparse_or_non_file(path, "registry transaction lock")?;
+        let key = AuthorityKey::Path(path.canonicalize()?);
+        Ok(AnchoredLockFile {
+            file,
+            key,
+            path: path.to_path_buf(),
+        })
+    }
+}
 
 pub(crate) fn write(path: &Path, bytes: &[u8]) -> io::Result<()> {
     write_with_pre_commit(path, bytes, |_| Ok(()))
 }
 
+#[cfg(unix)]
+fn write_with_pre_commit_impl<F>(path: &Path, bytes: &[u8], pre_commit: F) -> io::Result<()>
+where
+    F: FnOnce(&Path) -> io::Result<()>,
+{
+    let parent = path.parent().ok_or_else(|| {
+        io::Error::new(
+            io::ErrorKind::InvalidInput,
+            "atomic registry destination has no parent directory",
+        )
+    })?;
+    let (anchor, destination_name) = anchor_named_path(path)?;
+    let (mut staged, staged_name) = create_staged_file(&anchor.file)?;
+    let staged_identity = validate_regular_file(&staged, "registry staged artifact")?;
+    let staged_path = parent.join(&staged_name);
+
+    let result = (|| {
+        staged.write_all(bytes)?;
+        staged.flush()?;
+        staged.sync_all()?;
+        pre_commit(&staged_path)?;
+        verify_named_identity(
+            &anchor.file,
+            &staged_name,
+            staged_identity,
+            "registry staged artifact",
+        )?;
+        match stat_at(&anchor.file, &destination_name) {
+            Ok(stat) => {
+                validate_regular_stat(&stat, "existing registry destination")?;
+            }
+            Err(error) if error.kind() == io::ErrorKind::NotFound => {}
+            Err(error) => return Err(error),
+        }
+        rename_at(&anchor.file, &staged_name, &anchor.file, &destination_name)?;
+        verify_named_identity(
+            &anchor.file,
+            &destination_name,
+            staged_identity,
+            "published registry artifact",
+        )?;
+        anchor.file.sync_all()?;
+        Ok(())
+    })();
+
+    if result.is_err() {
+        let _ = unlink_if_same(&anchor.file, &staged_name, staged_identity);
+    }
+    result
+}
+
+#[cfg(not(unix))]
 fn write_with_pre_commit_impl<F>(path: &Path, bytes: &[u8], pre_commit: F) -> io::Result<()>
 where
     F: FnOnce(&Path) -> io::Result<()>,
@@ -25,15 +235,14 @@ where
         )
     })?;
     ensure_directory_durable(parent)?;
+    reject_reparse_components(parent)?;
 
-    // tempfile::NamedTempFile::persist performs an atomic, replacing rename on
-    // Unix and Windows. Because the stage lives in `parent`, the rename cannot
-    // cross filesystems. PersistError retains and cleans the stage on failure.
     let mut staged = tempfile::NamedTempFile::new_in(parent)?;
     staged.write_all(bytes)?;
     staged.flush()?;
     staged.as_file().sync_all()?;
     pre_commit(staged.path())?;
+    reject_reparse_components(parent)?;
 
     let published = staged.persist(path).map_err(|error| error.error)?;
     published.sync_all()?;
@@ -49,55 +258,409 @@ where
 /// missing components from the first existing ancestor downward and fsync the
 /// parent after every directory entry becomes visible.
 pub(crate) fn ensure_directory_durable(path: &Path) -> io::Result<()> {
-    let mut cursor = path.to_path_buf();
-    let mut missing: Vec<PathBuf> = Vec::new();
-
-    loop {
-        match std::fs::metadata(&cursor) {
-            Ok(metadata) if metadata.is_dir() => break,
-            Ok(_) => {
-                return Err(io::Error::new(
-                    io::ErrorKind::AlreadyExists,
-                    format!(
-                        "registry directory path is not a directory: {}",
-                        cursor.display()
-                    ),
-                ));
-            }
-            Err(error) if error.kind() == io::ErrorKind::NotFound => {
-                missing.push(cursor.clone());
-                cursor = cursor
-                    .parent()
-                    .ok_or_else(|| {
-                        io::Error::new(
-                            io::ErrorKind::InvalidInput,
-                            "registry directory has no existing ancestor",
-                        )
-                    })?
-                    .to_path_buf();
-            }
-            Err(error) => return Err(error),
-        }
+    #[cfg(unix)]
+    {
+        let _ = open_or_create_directory(path)?;
+        Ok(())
     }
+    #[cfg(not(unix))]
+    {
+        let mut cursor = path.to_path_buf();
+        let mut missing: Vec<PathBuf> = Vec::new();
 
-    for directory in missing.into_iter().rev() {
-        match std::fs::create_dir(&directory) {
-            Ok(()) => {}
-            Err(error) if error.kind() == io::ErrorKind::AlreadyExists => {
-                if !std::fs::metadata(&directory)?.is_dir() {
+        loop {
+            match std::fs::symlink_metadata(&cursor) {
+                Ok(metadata) if metadata.is_dir() && !metadata_is_reparse(&metadata) => break,
+                Ok(_) => {
                     return Err(io::Error::new(
                         io::ErrorKind::AlreadyExists,
                         format!(
-                            "registry directory path raced with a non-directory: {}",
-                            directory.display()
+                            "registry directory path is not a directory: {}",
+                            cursor.display()
                         ),
                     ));
                 }
+                Err(error) if error.kind() == io::ErrorKind::NotFound => {
+                    missing.push(cursor.clone());
+                    cursor = cursor
+                        .parent()
+                        .ok_or_else(|| {
+                            io::Error::new(
+                                io::ErrorKind::InvalidInput,
+                                "registry directory has no existing ancestor",
+                            )
+                        })?
+                        .to_path_buf();
+                }
+                Err(error) => return Err(error),
+            }
+        }
+
+        for directory in missing.into_iter().rev() {
+            match std::fs::create_dir(&directory) {
+                Ok(()) => {}
+                Err(error) if error.kind() == io::ErrorKind::AlreadyExists => {
+                    let metadata = std::fs::symlink_metadata(&directory)?;
+                    if !metadata.is_dir() || metadata_is_reparse(&metadata) {
+                        return Err(io::Error::new(
+                            io::ErrorKind::AlreadyExists,
+                            format!(
+                                "registry directory path raced with a non-directory: {}",
+                                directory.display()
+                            ),
+                        ));
+                    }
+                }
+                Err(error) => return Err(error),
+            }
+            if let Some(parent) = directory.parent() {
+                sync_parent(parent)?;
+            }
+        }
+        Ok(())
+    }
+}
+
+#[cfg(unix)]
+struct DirectoryAnchor {
+    file: File,
+}
+
+#[cfg(unix)]
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+struct FileIdentity {
+    device: u64,
+    inode: u64,
+}
+
+#[cfg(unix)]
+fn anchor_named_path(path: &Path) -> io::Result<(DirectoryAnchor, OsString)> {
+    let parent = path.parent().ok_or_else(|| {
+        io::Error::new(
+            io::ErrorKind::InvalidInput,
+            "registry authority path has no parent directory",
+        )
+    })?;
+    let name = path
+        .file_name()
+        .filter(|name| !name.is_empty())
+        .ok_or_else(|| {
+            io::Error::new(
+                io::ErrorKind::InvalidInput,
+                "registry authority path has no filename",
+            )
+        })?
+        .to_os_string();
+    Ok((open_or_create_directory(parent)?, name))
+}
+
+#[cfg(unix)]
+fn open_or_create_directory(path: &Path) -> io::Result<DirectoryAnchor> {
+    use std::os::fd::FromRawFd;
+
+    let start = if path.is_absolute() {
+        Path::new("/")
+    } else {
+        Path::new(".")
+    };
+    let start_c = name_cstring(start.as_os_str())?;
+    // SAFETY: the path is NUL-terminated and flags request a directory descriptor.
+    let fd = unsafe {
+        libc::open(
+            start_c.as_ptr(),
+            libc::O_RDONLY | libc::O_DIRECTORY | libc::O_CLOEXEC | libc::O_NOFOLLOW,
+        )
+    };
+    if fd < 0 {
+        return Err(io::Error::last_os_error());
+    }
+    // SAFETY: ownership of the successful descriptor transfers to File.
+    let mut current = unsafe { File::from_raw_fd(fd) };
+
+    for component in path.components() {
+        let name = match component {
+            std::path::Component::RootDir | std::path::Component::CurDir => continue,
+            std::path::Component::Normal(name) => name,
+            std::path::Component::ParentDir => {
+                return Err(io::Error::new(
+                    io::ErrorKind::InvalidInput,
+                    "registry directory paths may not contain parent traversal",
+                ));
+            }
+            std::path::Component::Prefix(_) => {
+                return Err(io::Error::new(
+                    io::ErrorKind::InvalidInput,
+                    "unsupported registry directory prefix",
+                ));
+            }
+        };
+        let next = match open_directory_at(&current, name) {
+            Ok(next) => next,
+            Err(error) if error.kind() == io::ErrorKind::NotFound => {
+                mkdir_at(&current, name)?;
+                current.sync_all()?;
+                open_directory_at(&current, name)?
             }
             Err(error) => return Err(error),
+        };
+        current = next;
+    }
+    Ok(DirectoryAnchor { file: current })
+}
+
+#[cfg(unix)]
+fn open_directory_at(parent: &File, name: &std::ffi::OsStr) -> io::Result<File> {
+    use std::os::fd::{AsRawFd, FromRawFd};
+
+    let name = name_cstring(name)?;
+    // SAFETY: parent is a live directory descriptor and name is NUL-terminated.
+    let fd = unsafe {
+        libc::openat(
+            parent.as_raw_fd(),
+            name.as_ptr(),
+            libc::O_RDONLY | libc::O_DIRECTORY | libc::O_CLOEXEC | libc::O_NOFOLLOW,
+        )
+    };
+    if fd < 0 {
+        return Err(io::Error::last_os_error());
+    }
+    // SAFETY: ownership of the successful descriptor transfers to File.
+    Ok(unsafe { File::from_raw_fd(fd) })
+}
+
+#[cfg(unix)]
+fn mkdir_at(parent: &File, name: &std::ffi::OsStr) -> io::Result<()> {
+    use std::os::fd::AsRawFd;
+
+    let name = name_cstring(name)?;
+    // SAFETY: parent is a live directory descriptor and name is NUL-terminated.
+    let result = unsafe { libc::mkdirat(parent.as_raw_fd(), name.as_ptr(), 0o755) };
+    if result == 0 {
+        return Ok(());
+    }
+    let error = io::Error::last_os_error();
+    if error.kind() == io::ErrorKind::AlreadyExists {
+        return Ok(());
+    }
+    Err(error)
+}
+
+#[cfg(unix)]
+fn open_file_at(parent: &File, name: &std::ffi::OsStr, flags: i32, mode: u32) -> io::Result<File> {
+    use std::os::fd::{AsRawFd, FromRawFd};
+
+    let name = name_cstring(name)?;
+    // SAFETY: parent is live, name is NUL-terminated, and ownership of a successful fd
+    // transfers immediately to File.
+    let fd = unsafe {
+        libc::openat(
+            parent.as_raw_fd(),
+            name.as_ptr(),
+            flags | libc::O_CLOEXEC | libc::O_NOFOLLOW,
+            mode as libc::c_uint,
+        )
+    };
+    if fd < 0 {
+        return Err(io::Error::last_os_error());
+    }
+    Ok(unsafe { File::from_raw_fd(fd) })
+}
+
+#[cfg(unix)]
+fn create_staged_file(parent: &File) -> io::Result<(File, OsString)> {
+    use std::sync::atomic::{AtomicU64, Ordering};
+    use std::time::{SystemTime, UNIX_EPOCH};
+
+    static NEXT_STAGE: AtomicU64 = AtomicU64::new(0);
+    for _ in 0..100 {
+        let nonce = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .unwrap_or_default()
+            .as_nanos();
+        let sequence = NEXT_STAGE.fetch_add(1, Ordering::Relaxed);
+        let name = OsString::from(format!(
+            ".kin-registry-stage-{}-{nonce}-{sequence}",
+            std::process::id()
+        ));
+        match open_file_at(
+            parent,
+            &name,
+            libc::O_WRONLY | libc::O_CREAT | libc::O_EXCL,
+            0o600,
+        ) {
+            Ok(file) => return Ok((file, name)),
+            Err(error) if error.kind() == io::ErrorKind::AlreadyExists => continue,
+            Err(error) => return Err(error),
         }
-        if let Some(parent) = directory.parent() {
-            sync_parent(parent)?;
+    }
+    Err(io::Error::new(
+        io::ErrorKind::AlreadyExists,
+        "could not allocate a unique registry staging file",
+    ))
+}
+
+#[cfg(unix)]
+fn rename_at(
+    old_parent: &File,
+    old_name: &std::ffi::OsStr,
+    new_parent: &File,
+    new_name: &std::ffi::OsStr,
+) -> io::Result<()> {
+    use std::os::fd::AsRawFd;
+
+    let old_name = name_cstring(old_name)?;
+    let new_name = name_cstring(new_name)?;
+    // SAFETY: both descriptors and relative NUL-terminated names remain valid.
+    if unsafe {
+        libc::renameat(
+            old_parent.as_raw_fd(),
+            old_name.as_ptr(),
+            new_parent.as_raw_fd(),
+            new_name.as_ptr(),
+        )
+    } != 0
+    {
+        return Err(io::Error::last_os_error());
+    }
+    Ok(())
+}
+
+#[cfg(unix)]
+fn unlink_if_same(parent: &File, name: &std::ffi::OsStr, expected: FileIdentity) -> io::Result<()> {
+    use std::os::fd::AsRawFd;
+
+    let actual = match stat_at(parent, name) {
+        Ok(stat) => validate_regular_stat(&stat, "registry staged artifact")?,
+        Err(error) if error.kind() == io::ErrorKind::NotFound => return Ok(()),
+        Err(error) => return Err(error),
+    };
+    if actual != expected {
+        return Ok(());
+    }
+    let name = name_cstring(name)?;
+    // SAFETY: parent is live and name is a relative NUL-terminated component.
+    if unsafe { libc::unlinkat(parent.as_raw_fd(), name.as_ptr(), 0) } != 0 {
+        return Err(io::Error::last_os_error());
+    }
+    Ok(())
+}
+
+#[cfg(unix)]
+fn verify_named_identity(
+    parent: &File,
+    name: &std::ffi::OsStr,
+    expected: FileIdentity,
+    label: &str,
+) -> io::Result<()> {
+    let actual = validate_regular_stat(&stat_at(parent, name)?, label)?;
+    if actual != expected {
+        return Err(io::Error::other(format!(
+            "{label} changed identity during publication"
+        )));
+    }
+    Ok(())
+}
+
+#[cfg(unix)]
+fn stat_file(file: &File) -> io::Result<libc::stat> {
+    use std::os::fd::AsRawFd;
+
+    let mut stat = std::mem::MaybeUninit::<libc::stat>::uninit();
+    // SAFETY: stat points to writable storage and the descriptor is live.
+    if unsafe { libc::fstat(file.as_raw_fd(), stat.as_mut_ptr()) } != 0 {
+        return Err(io::Error::last_os_error());
+    }
+    // SAFETY: successful fstat initialized the structure.
+    Ok(unsafe { stat.assume_init() })
+}
+
+#[cfg(unix)]
+fn stat_at(parent: &File, name: &std::ffi::OsStr) -> io::Result<libc::stat> {
+    use std::os::fd::AsRawFd;
+
+    let name = name_cstring(name)?;
+    let mut stat = std::mem::MaybeUninit::<libc::stat>::uninit();
+    // SAFETY: stat points to writable storage and the descriptor/name are valid.
+    if unsafe {
+        libc::fstatat(
+            parent.as_raw_fd(),
+            name.as_ptr(),
+            stat.as_mut_ptr(),
+            libc::AT_SYMLINK_NOFOLLOW,
+        )
+    } != 0
+    {
+        return Err(io::Error::last_os_error());
+    }
+    // SAFETY: successful fstatat initialized the structure.
+    Ok(unsafe { stat.assume_init() })
+}
+
+#[cfg(unix)]
+fn validate_regular_file(file: &File, label: &str) -> io::Result<FileIdentity> {
+    validate_regular_stat(&stat_file(file)?, label)
+}
+
+#[cfg(unix)]
+fn validate_regular_stat(stat: &libc::stat, label: &str) -> io::Result<FileIdentity> {
+    if stat.st_mode & libc::S_IFMT != libc::S_IFREG || stat.st_nlink != 1 {
+        return Err(io::Error::other(format!(
+            "{label} is not a single-link regular file"
+        )));
+    }
+    Ok(FileIdentity {
+        device: stat.st_dev as u64,
+        inode: stat.st_ino,
+    })
+}
+
+#[cfg(unix)]
+fn name_cstring(name: &std::ffi::OsStr) -> io::Result<std::ffi::CString> {
+    use std::os::unix::ffi::OsStrExt;
+
+    std::ffi::CString::new(name.as_bytes()).map_err(|_| {
+        io::Error::new(
+            io::ErrorKind::InvalidInput,
+            "registry authority path contains a NUL byte",
+        )
+    })
+}
+
+#[cfg(not(unix))]
+fn metadata_is_reparse(metadata: &std::fs::Metadata) -> bool {
+    #[cfg(windows)]
+    {
+        use std::os::windows::fs::MetadataExt;
+        return metadata.file_attributes() & 0x400 != 0;
+    }
+    #[cfg(not(windows))]
+    {
+        metadata.file_type().is_symlink()
+    }
+}
+
+#[cfg(not(unix))]
+fn reject_reparse_or_non_file(path: &Path, label: &str) -> io::Result<()> {
+    let metadata = std::fs::symlink_metadata(path)?;
+    if metadata_is_reparse(&metadata) || !metadata.is_file() {
+        return Err(io::Error::other(format!(
+            "{label} is a reparse point or non-file authority"
+        )));
+    }
+    Ok(())
+}
+
+#[cfg(not(unix))]
+fn reject_reparse_components(path: &Path) -> io::Result<()> {
+    let mut current = PathBuf::new();
+    for component in path.components() {
+        current.push(component.as_os_str());
+        let metadata = std::fs::symlink_metadata(&current)?;
+        if metadata_is_reparse(&metadata) || !metadata.is_dir() {
+            return Err(io::Error::other(format!(
+                "registry directory component is a reparse point or non-directory: {}",
+                current.display()
+            )));
         }
     }
     Ok(())
@@ -119,11 +682,6 @@ where
     write_with_pre_commit_impl(path, bytes, pre_commit)
 }
 
-#[cfg(unix)]
-fn sync_parent(parent: &Path) -> io::Result<()> {
-    std::fs::File::open(parent)?.sync_all()
-}
-
 #[cfg(not(unix))]
 fn sync_parent(_parent: &Path) -> io::Result<()> {
     // The published file itself is flushed above. Opening directories for a
@@ -138,7 +696,8 @@ mod tests {
     #[test]
     fn failed_pre_commit_preserves_destination_and_cleans_stage() {
         let root = tempfile::tempdir().unwrap();
-        let destination = root.path().join("artifact");
+        let root_path = root.path().canonicalize().unwrap();
+        let destination = root_path.join("artifact");
         std::fs::write(&destination, b"old-complete-bytes").unwrap();
 
         let error = write_with_pre_commit(&destination, b"replacement", |_| {
@@ -148,25 +707,26 @@ mod tests {
 
         assert_eq!(error.kind(), io::ErrorKind::Other);
         assert_eq!(std::fs::read(&destination).unwrap(), b"old-complete-bytes");
-        assert_eq!(std::fs::read_dir(root.path()).unwrap().count(), 1);
+        assert_eq!(std::fs::read_dir(root_path).unwrap().count(), 1);
     }
 
     #[test]
     fn successful_write_atomically_replaces_destination() {
         let root = tempfile::tempdir().unwrap();
-        let destination = root.path().join("artifact");
+        let root_path = root.path().canonicalize().unwrap();
+        let destination = root_path.join("artifact");
         std::fs::write(&destination, b"old").unwrap();
 
         write(&destination, b"new-complete-bytes").unwrap();
 
         assert_eq!(std::fs::read(&destination).unwrap(), b"new-complete-bytes");
-        assert_eq!(std::fs::read_dir(root.path()).unwrap().count(), 1);
+        assert_eq!(std::fs::read_dir(root_path).unwrap().count(), 1);
     }
 
     #[test]
     fn fully_staged_bytes_are_not_visible_at_the_destination_before_commit() {
         let root = tempfile::tempdir().unwrap();
-        let destination = root.path().join("artifact");
+        let destination = root.path().canonicalize().unwrap().join("artifact");
         std::fs::write(&destination, b"old-complete-bytes").unwrap();
 
         write_with_pre_commit(&destination, b"new-complete-bytes", |stage| {
@@ -184,6 +744,8 @@ mod tests {
         let root = tempfile::tempdir().unwrap();
         let destination = root
             .path()
+            .canonicalize()
+            .unwrap()
             .join("packages")
             .join("manifests")
             .join("cargo")
@@ -192,5 +754,31 @@ mod tests {
         write(&destination, b"complete-manifest\n").unwrap();
 
         assert_eq!(std::fs::read(destination).unwrap(), b"complete-manifest\n");
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn write_rejects_symlinked_directory_components_and_destinations() {
+        use std::os::unix::fs::symlink;
+
+        let root = tempfile::tempdir().unwrap();
+        let root_path = root.path().canonicalize().unwrap();
+        let real = root_path.join("real");
+        std::fs::create_dir(&real).unwrap();
+        let alias = root_path.join("alias");
+        symlink(&real, &alias).unwrap();
+        assert!(write(&alias.join("artifact"), b"blocked").is_err());
+        assert!(!real.join("artifact").exists());
+
+        let outside = root_path.join("outside");
+        std::fs::write(&outside, b"outside").unwrap();
+        let destination = real.join("artifact");
+        symlink(&outside, &destination).unwrap();
+        assert!(write(&destination, b"replacement").is_err());
+        assert_eq!(std::fs::read(&outside).unwrap(), b"outside");
+        assert!(std::fs::symlink_metadata(&destination)
+            .unwrap()
+            .file_type()
+            .is_symlink());
     }
 }

--- a/crates/kin-registry/src/atomic_file.rs
+++ b/crates/kin-registry/src/atomic_file.rs
@@ -8,7 +8,7 @@
 //! and only then replace the destination with one atomic rename.
 
 use std::io::{self, Write};
-use std::path::Path;
+use std::path::{Path, PathBuf};
 
 pub(crate) fn write(path: &Path, bytes: &[u8]) -> io::Result<()> {
     write_with_pre_commit(path, bytes, |_| Ok(()))
@@ -24,7 +24,7 @@ where
             "atomic registry destination has no parent directory",
         )
     })?;
-    std::fs::create_dir_all(parent)?;
+    ensure_directory_durable(parent)?;
 
     // tempfile::NamedTempFile::persist performs an atomic, replacing rename on
     // Unix and Windows. Because the stage lives in `parent`, the rename cannot
@@ -38,6 +38,68 @@ where
     let published = staged.persist(path).map_err(|error| error.error)?;
     published.sync_all()?;
     sync_parent(parent)?;
+    Ok(())
+}
+
+/// Create a directory chain and durably publish each newly-created component.
+///
+/// Syncing only the final file and its immediate parent is insufficient on a
+/// first write: after a power loss, the new parent directory itself can vanish
+/// from its parent even though the response was already acknowledged. Build
+/// missing components from the first existing ancestor downward and fsync the
+/// parent after every directory entry becomes visible.
+pub(crate) fn ensure_directory_durable(path: &Path) -> io::Result<()> {
+    let mut cursor = path.to_path_buf();
+    let mut missing: Vec<PathBuf> = Vec::new();
+
+    loop {
+        match std::fs::metadata(&cursor) {
+            Ok(metadata) if metadata.is_dir() => break,
+            Ok(_) => {
+                return Err(io::Error::new(
+                    io::ErrorKind::AlreadyExists,
+                    format!(
+                        "registry directory path is not a directory: {}",
+                        cursor.display()
+                    ),
+                ));
+            }
+            Err(error) if error.kind() == io::ErrorKind::NotFound => {
+                missing.push(cursor.clone());
+                cursor = cursor
+                    .parent()
+                    .ok_or_else(|| {
+                        io::Error::new(
+                            io::ErrorKind::InvalidInput,
+                            "registry directory has no existing ancestor",
+                        )
+                    })?
+                    .to_path_buf();
+            }
+            Err(error) => return Err(error),
+        }
+    }
+
+    for directory in missing.into_iter().rev() {
+        match std::fs::create_dir(&directory) {
+            Ok(()) => {}
+            Err(error) if error.kind() == io::ErrorKind::AlreadyExists => {
+                if !std::fs::metadata(&directory)?.is_dir() {
+                    return Err(io::Error::new(
+                        io::ErrorKind::AlreadyExists,
+                        format!(
+                            "registry directory path raced with a non-directory: {}",
+                            directory.display()
+                        ),
+                    ));
+                }
+            }
+            Err(error) => return Err(error),
+        }
+        if let Some(parent) = directory.parent() {
+            sync_parent(parent)?;
+        }
+    }
     Ok(())
 }
 
@@ -115,5 +177,20 @@ mod tests {
         .unwrap();
 
         assert_eq!(std::fs::read(&destination).unwrap(), b"new-complete-bytes");
+    }
+
+    #[test]
+    fn first_write_durably_creates_nested_parent_chain() {
+        let root = tempfile::tempdir().unwrap();
+        let destination = root
+            .path()
+            .join("packages")
+            .join("manifests")
+            .join("cargo")
+            .join("demo");
+
+        write(&destination, b"complete-manifest\n").unwrap();
+
+        assert_eq!(std::fs::read(destination).unwrap(), b"complete-manifest\n");
     }
 }

--- a/crates/kin-registry/src/atomic_file.rs
+++ b/crates/kin-registry/src/atomic_file.rs
@@ -19,6 +19,8 @@ use cap_std::fs::{Dir as CapabilityDir, OpenOptions as CapabilityOpenOptions};
 use std::ffi::OsString;
 use std::fs::File;
 use std::io::{self, Read, Write};
+#[cfg(not(unix))]
+use std::io::{Seek, SeekFrom};
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
 
@@ -301,12 +303,16 @@ impl AuthorityRoot {
         {
             let (parent, name) = self.capability_parent_and_name(relative, false)?;
             let mut options = CapabilityOpenOptions::new();
-            // Windows requires generic write access for `set_len`, which the
-            // upload rollback path uses after a rejected or cancelled append.
-            // Append-only access is sufficient on Unix but cannot truncate a
-            // Windows handle back to the durable metadata offset.
-            options.write(true).append(true).follow(FollowSymlinks::No);
-            open_capability_regular_file(&parent, &name, &options, "registry upload data")
+            // cap-std intentionally maps append mode to FILE_APPEND_DATA on
+            // Windows, which cannot truncate after a rejected upload. Open
+            // with full write access and position the one transaction-owned
+            // handle at EOF instead; the upload transaction serializes all
+            // writers for this artifact.
+            options.write(true).follow(FollowSymlinks::No);
+            let mut file =
+                open_capability_regular_file(&parent, &name, &options, "registry upload data")?;
+            file.seek(SeekFrom::End(0))?;
+            Ok(file)
         }
     }
 
@@ -1527,6 +1533,8 @@ mod tests {
 
         let mut file = authority.open_append(relative).unwrap();
         file.write_all(b"-uncommitted").unwrap();
+        file.sync_all().unwrap();
+        assert_eq!(authority.read(relative).unwrap(), b"durable-uncommitted");
         file.set_len(b"durable".len() as u64).unwrap();
         file.sync_all().unwrap();
         drop(file);

--- a/crates/kin-registry/src/atomic_file.rs
+++ b/crates/kin-registry/src/atomic_file.rs
@@ -11,8 +11,9 @@ use std::ffi::OsString;
 use std::fs::File;
 #[cfg(not(unix))]
 use std::fs::OpenOptions;
-use std::io::{self, Write};
+use std::io::{self, Read, Write};
 use std::path::{Path, PathBuf};
+use std::sync::Arc;
 
 /// Stable in-process identity for one named authority inside a pinned parent.
 #[derive(Clone, Debug, Eq, Hash, PartialEq)]
@@ -25,6 +26,452 @@ pub(crate) enum AuthorityKey {
     },
     #[cfg(not(unix))]
     Path(PathBuf),
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub(crate) struct ArtifactIdentity {
+    #[cfg(unix)]
+    pub(crate) device: u64,
+    #[cfg(unix)]
+    pub(crate) inode: u64,
+    pub(crate) len: u64,
+}
+
+/// A registry storage root whose identity remains authoritative for the
+/// lifetime of the adapter.
+///
+/// Unix operations walk only relative, normal components from the retained
+/// directory descriptor with `openat(2)` and `O_NOFOLLOW`. Renaming or
+/// replacing the configured pathname therefore cannot redirect a live
+/// registry. Platforms without descriptor-relative filesystem APIs keep the
+/// canonical path and reject reparse points before each operation.
+#[derive(Clone)]
+pub(crate) struct AuthorityRoot {
+    path: PathBuf,
+    inner: Arc<AuthorityRootInner>,
+}
+
+enum AuthorityRootInner {
+    #[cfg(unix)]
+    Unix(File),
+    #[cfg(not(unix))]
+    Path,
+    Failed {
+        kind: io::ErrorKind,
+        message: String,
+    },
+}
+
+impl std::fmt::Debug for AuthorityRoot {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        formatter
+            .debug_struct("AuthorityRoot")
+            .field("path", &self.path)
+            .finish_non_exhaustive()
+    }
+}
+
+impl AuthorityRoot {
+    /// Pin and create a configured root. Construction stays infallible for the
+    /// existing public state constructors, but any initialization failure is
+    /// retained and makes every later storage operation fail closed.
+    pub(crate) fn new(path: &Path) -> Self {
+        match Self::try_new(path) {
+            Ok(root) => root,
+            Err(error) => Self {
+                path: path.to_path_buf(),
+                inner: Arc::new(AuthorityRootInner::Failed {
+                    kind: error.kind(),
+                    message: error.to_string(),
+                }),
+            },
+        }
+    }
+
+    fn try_new(path: &Path) -> io::Result<Self> {
+        let path = pin_authority_root(path)?;
+        ensure_directory_durable(&path)?;
+        #[cfg(unix)]
+        let inner = AuthorityRootInner::Unix(open_or_create_directory(&path)?.file);
+        #[cfg(not(unix))]
+        let inner = {
+            reject_reparse_components(&path)?;
+            AuthorityRootInner::Path
+        };
+        Ok(Self {
+            path,
+            inner: Arc::new(inner),
+        })
+    }
+
+    pub(crate) fn path(&self) -> &Path {
+        &self.path
+    }
+
+    fn initialization_error(&self) -> Option<io::Error> {
+        match self.inner.as_ref() {
+            AuthorityRootInner::Failed { kind, message } => {
+                Some(io::Error::new(*kind, message.clone()))
+            }
+            #[cfg(unix)]
+            AuthorityRootInner::Unix(_) => None,
+            #[cfg(not(unix))]
+            AuthorityRootInner::Path => None,
+        }
+    }
+
+    fn validate_relative(relative: &Path, allow_empty: bool) -> io::Result<()> {
+        if relative.is_absolute()
+            || relative
+                .components()
+                .any(|component| !matches!(component, std::path::Component::Normal(_)))
+            || (!allow_empty && relative.as_os_str().is_empty())
+        {
+            return Err(io::Error::new(
+                io::ErrorKind::InvalidInput,
+                "registry authority paths must contain only relative normal components",
+            ));
+        }
+        Ok(())
+    }
+
+    #[cfg(unix)]
+    fn unix_root(&self) -> io::Result<&File> {
+        match self.inner.as_ref() {
+            AuthorityRootInner::Unix(file) => Ok(file),
+            AuthorityRootInner::Failed { kind, message } => {
+                Err(io::Error::new(*kind, message.clone()))
+            }
+        }
+    }
+
+    #[cfg(unix)]
+    fn directory(&self, relative: &Path, create: bool) -> io::Result<File> {
+        Self::validate_relative(relative, true)?;
+        let mut current = self.unix_root()?.try_clone()?;
+        for component in relative.components() {
+            let std::path::Component::Normal(name) = component else {
+                unreachable!("relative path was validated")
+            };
+            let next = match open_directory_at(&current, name) {
+                Ok(next) => next,
+                Err(error) if create && error.kind() == io::ErrorKind::NotFound => {
+                    mkdir_at(&current, name)?;
+                    current.sync_all()?;
+                    open_directory_at(&current, name)?
+                }
+                Err(error) => return Err(error),
+            };
+            current = next;
+        }
+        Ok(current)
+    }
+
+    #[cfg(unix)]
+    fn parent_and_name(&self, relative: &Path, create: bool) -> io::Result<(File, OsString)> {
+        Self::validate_relative(relative, false)?;
+        let parent = relative.parent().unwrap_or_else(|| Path::new(""));
+        let name = relative
+            .file_name()
+            .expect("validated non-empty relative path")
+            .to_os_string();
+        Ok((self.directory(parent, create)?, name))
+    }
+
+    pub(crate) fn ensure_directory(&self, relative: &Path) -> io::Result<()> {
+        if let Some(error) = self.initialization_error() {
+            return Err(error);
+        }
+        Self::validate_relative(relative, true)?;
+        #[cfg(unix)]
+        {
+            let _ = self.directory(relative, true)?;
+            Ok(())
+        }
+        #[cfg(not(unix))]
+        {
+            let path = self.path.join(relative);
+            ensure_directory_durable(&path)?;
+            reject_reparse_components(&self.path)?;
+            reject_reparse_components(&path)
+        }
+    }
+
+    pub(crate) fn read(&self, relative: &Path) -> io::Result<Vec<u8>> {
+        if let Some(error) = self.initialization_error() {
+            return Err(error);
+        }
+        Self::validate_relative(relative, false)?;
+        #[cfg(unix)]
+        {
+            let (parent, name) = self.parent_and_name(relative, false)?;
+            let mut file = open_file_at(&parent, &name, libc::O_RDONLY, 0)?;
+            validate_regular_file(&file, "registry artifact")?;
+            let mut bytes = Vec::new();
+            file.read_to_end(&mut bytes)?;
+            Ok(bytes)
+        }
+        #[cfg(not(unix))]
+        {
+            reject_reparse_components(&self.path)?;
+            let path = self.path.join(relative);
+            reject_reparse_or_non_file(&path, "registry artifact")?;
+            std::fs::read(path)
+        }
+    }
+
+    pub(crate) fn open_read(&self, relative: &Path) -> io::Result<File> {
+        if let Some(error) = self.initialization_error() {
+            return Err(error);
+        }
+        Self::validate_relative(relative, false)?;
+        #[cfg(unix)]
+        {
+            let (parent, name) = self.parent_and_name(relative, false)?;
+            let file = open_file_at(&parent, &name, libc::O_RDONLY, 0)?;
+            validate_regular_file(&file, "registry artifact")?;
+            Ok(file)
+        }
+        #[cfg(not(unix))]
+        {
+            reject_reparse_components(&self.path)?;
+            let path = self.path.join(relative);
+            reject_reparse_or_non_file(&path, "registry artifact")?;
+            File::open(path)
+        }
+    }
+
+    pub(crate) fn open_append(&self, relative: &Path) -> io::Result<File> {
+        if let Some(error) = self.initialization_error() {
+            return Err(error);
+        }
+        Self::validate_relative(relative, false)?;
+        #[cfg(unix)]
+        {
+            let (parent, name) = self.parent_and_name(relative, false)?;
+            let file = open_file_at(&parent, &name, libc::O_WRONLY | libc::O_APPEND, 0)?;
+            validate_regular_file(&file, "registry upload data")?;
+            Ok(file)
+        }
+        #[cfg(not(unix))]
+        {
+            reject_reparse_components(&self.path)?;
+            let path = self.path.join(relative);
+            reject_reparse_or_non_file(&path, "registry upload data")?;
+            OpenOptions::new().append(true).open(path)
+        }
+    }
+
+    pub(crate) fn open_write(&self, relative: &Path) -> io::Result<File> {
+        if let Some(error) = self.initialization_error() {
+            return Err(error);
+        }
+        Self::validate_relative(relative, false)?;
+        #[cfg(unix)]
+        {
+            let (parent, name) = self.parent_and_name(relative, false)?;
+            let file = open_file_at(&parent, &name, libc::O_WRONLY, 0)?;
+            validate_regular_file(&file, "registry artifact")?;
+            Ok(file)
+        }
+        #[cfg(not(unix))]
+        {
+            reject_reparse_components(&self.path)?;
+            let path = self.path.join(relative);
+            reject_reparse_or_non_file(&path, "registry artifact")?;
+            OpenOptions::new().write(true).open(path)
+        }
+    }
+
+    pub(crate) fn metadata(&self, relative: &Path) -> io::Result<std::fs::Metadata> {
+        self.open_read(relative)?.metadata()
+    }
+
+    pub(crate) fn identity(&self, relative: &Path) -> io::Result<ArtifactIdentity> {
+        let file = self.open_read(relative)?;
+        #[cfg(unix)]
+        {
+            let stat = stat_file(&file)?;
+            Ok(ArtifactIdentity {
+                device: stat.st_dev as u64,
+                inode: stat.st_ino as u64,
+                len: stat.st_size as u64,
+            })
+        }
+        #[cfg(not(unix))]
+        {
+            Ok(ArtifactIdentity {
+                len: file.metadata()?.len(),
+            })
+        }
+    }
+
+    pub(crate) fn read_dir_names(&self, relative: &Path) -> io::Result<Vec<OsString>> {
+        if let Some(error) = self.initialization_error() {
+            return Err(error);
+        }
+        Self::validate_relative(relative, true)?;
+        #[cfg(unix)]
+        {
+            use std::os::fd::{FromRawFd, IntoRawFd};
+            use std::os::unix::ffi::OsStrExt;
+
+            let directory = self.directory(relative, false)?;
+            let descriptor = directory.into_raw_fd();
+            let stream = unsafe { libc::fdopendir(descriptor) };
+            if stream.is_null() {
+                let error = io::Error::last_os_error();
+                // SAFETY: fdopendir failed without taking ownership of the descriptor.
+                drop(unsafe { File::from_raw_fd(descriptor) });
+                return Err(error);
+            }
+            struct DirectoryStream(*mut libc::DIR);
+            impl Drop for DirectoryStream {
+                fn drop(&mut self) {
+                    // SAFETY: fdopendir returned this live stream exactly once.
+                    unsafe { libc::closedir(self.0) };
+                }
+            }
+            let stream = DirectoryStream(stream);
+            let mut names = Vec::new();
+            loop {
+                // SAFETY: the stream remains live and is accessed by one thread.
+                let entry = unsafe { libc::readdir(stream.0) };
+                if entry.is_null() {
+                    break;
+                }
+                // SAFETY: d_name is NUL-terminated for the lifetime of this entry.
+                let bytes = unsafe {
+                    std::ffi::CStr::from_ptr((*entry).d_name.as_ptr())
+                        .to_bytes()
+                        .to_vec()
+                };
+                if bytes == b"." || bytes == b".." {
+                    continue;
+                }
+                names.push(std::ffi::OsStr::from_bytes(&bytes).to_os_string());
+            }
+            Ok(names)
+        }
+        #[cfg(not(unix))]
+        {
+            reject_reparse_components(&self.path)?;
+            std::fs::read_dir(self.path.join(relative))?
+                .map(|entry| entry.map(|entry| entry.file_name()))
+                .collect()
+        }
+    }
+
+    pub(crate) fn write(&self, relative: &Path, bytes: &[u8]) -> io::Result<()> {
+        if let Some(error) = self.initialization_error() {
+            return Err(error);
+        }
+        Self::validate_relative(relative, false)?;
+        #[cfg(unix)]
+        {
+            let (parent, destination_name) = self.parent_and_name(relative, true)?;
+            write_at(&parent, &destination_name, bytes)
+        }
+        #[cfg(not(unix))]
+        {
+            reject_reparse_components(&self.path)?;
+            write(&self.path.join(relative), bytes)?;
+            reject_reparse_components(&self.path)
+        }
+    }
+
+    pub(crate) fn remove_file(&self, relative: &Path) -> io::Result<()> {
+        if let Some(error) = self.initialization_error() {
+            return Err(error);
+        }
+        Self::validate_relative(relative, false)?;
+        #[cfg(unix)]
+        {
+            use std::os::fd::AsRawFd;
+            let (parent, name) = self.parent_and_name(relative, false)?;
+            match stat_at(&parent, &name) {
+                Ok(stat) => {
+                    validate_regular_stat(&stat, "registry artifact")?;
+                }
+                Err(error) if error.kind() == io::ErrorKind::NotFound => return Ok(()),
+                Err(error) => return Err(error),
+            }
+            let name = name_cstring(&name)?;
+            // SAFETY: the retained parent descriptor and relative name are valid.
+            if unsafe { libc::unlinkat(parent.as_raw_fd(), name.as_ptr(), 0) } != 0 {
+                return Err(io::Error::last_os_error());
+            }
+            parent.sync_all()
+        }
+        #[cfg(not(unix))]
+        {
+            reject_reparse_components(&self.path)?;
+            let path = self.path.join(relative);
+            match reject_reparse_or_non_file(&path, "registry artifact") {
+                Ok(()) => std::fs::remove_file(path),
+                Err(error) if error.kind() == io::ErrorKind::NotFound => Ok(()),
+                Err(error) => Err(error),
+            }
+        }
+    }
+
+    pub(crate) fn rename(&self, from: &Path, to: &Path) -> io::Result<()> {
+        if let Some(error) = self.initialization_error() {
+            return Err(error);
+        }
+        Self::validate_relative(from, false)?;
+        Self::validate_relative(to, false)?;
+        #[cfg(unix)]
+        {
+            let (from_parent, from_name) = self.parent_and_name(from, false)?;
+            let (to_parent, to_name) = self.parent_and_name(to, true)?;
+            validate_regular_stat(&stat_at(&from_parent, &from_name)?, "registry artifact")?;
+            match stat_at(&to_parent, &to_name) {
+                Ok(_) => {
+                    return Err(io::Error::new(
+                        io::ErrorKind::AlreadyExists,
+                        "registry destination already exists",
+                    ))
+                }
+                Err(error) if error.kind() == io::ErrorKind::NotFound => {}
+                Err(error) => return Err(error),
+            }
+            rename_at(&from_parent, &from_name, &to_parent, &to_name)?;
+            to_parent.sync_all()?;
+            let from_identity = stat_file(&from_parent)?;
+            let to_identity = stat_file(&to_parent)?;
+            if from_identity.st_dev != to_identity.st_dev
+                || from_identity.st_ino != to_identity.st_ino
+            {
+                from_parent.sync_all()?;
+            }
+            Ok(())
+        }
+        #[cfg(not(unix))]
+        {
+            reject_reparse_components(&self.path)?;
+            let from = self.path.join(from);
+            let to = self.path.join(to);
+            reject_reparse_or_non_file(&from, "registry artifact")?;
+            std::fs::rename(from, to)
+        }
+    }
+
+    pub(crate) fn open_lock_file(&self, relative: &Path) -> io::Result<AnchoredLockFile> {
+        if let Some(error) = self.initialization_error() {
+            return Err(error);
+        }
+        Self::validate_relative(relative, false)?;
+        #[cfg(unix)]
+        {
+            let (parent, name) = self.parent_and_name(relative, true)?;
+            open_lock_file_in(parent, name)
+        }
+        #[cfg(not(unix))]
+        {
+            open_lock_file(&self.path.join(relative))
+        }
+    }
 }
 
 /// Resolve the configured authority root once, then retain the resulting
@@ -105,42 +552,12 @@ impl AnchoredLockFile {
     }
 }
 
+#[cfg(any(test, not(unix)))]
 pub(crate) fn open_lock_file(path: &Path) -> io::Result<AnchoredLockFile> {
     #[cfg(unix)]
     {
         let (parent, name) = anchor_named_path(path)?;
-        let file = match open_file_at(
-            &parent.file,
-            &name,
-            libc::O_RDWR | libc::O_CREAT | libc::O_EXCL,
-            0o600,
-        ) {
-            Ok(file) => file,
-            Err(error) if error.kind() == io::ErrorKind::AlreadyExists => {
-                open_file_at(&parent.file, &name, libc::O_RDWR, 0o600)?
-            }
-            Err(error) => return Err(error),
-        };
-        let opened = validate_regular_file(&file, "registry transaction lock")?;
-        let named =
-            validate_regular_stat(&stat_at(&parent.file, &name)?, "registry transaction lock")?;
-        if opened != named {
-            return Err(io::Error::other(
-                "registry transaction lock changed identity while opening",
-            ));
-        }
-        let parent_stat = stat_file(&parent.file)?;
-        let key = AuthorityKey::Unix {
-            parent_device: parent_stat.st_dev as u64,
-            parent_inode: parent_stat.st_ino as u64,
-            name: name.clone(),
-        };
-        Ok(AnchoredLockFile {
-            file,
-            key,
-            parent: parent.file,
-            name,
-        })
+        open_lock_file_in(parent.file, name)
     }
     #[cfg(not(unix))]
     {
@@ -168,11 +585,47 @@ pub(crate) fn open_lock_file(path: &Path) -> io::Result<AnchoredLockFile> {
     }
 }
 
+#[cfg(unix)]
+fn open_lock_file_in(parent: File, name: OsString) -> io::Result<AnchoredLockFile> {
+    let file = match open_file_at(
+        &parent,
+        &name,
+        libc::O_RDWR | libc::O_CREAT | libc::O_EXCL,
+        0o600,
+    ) {
+        Ok(file) => file,
+        Err(error) if error.kind() == io::ErrorKind::AlreadyExists => {
+            open_file_at(&parent, &name, libc::O_RDWR, 0o600)?
+        }
+        Err(error) => return Err(error),
+    };
+    let opened = validate_regular_file(&file, "registry transaction lock")?;
+    let named = validate_regular_stat(&stat_at(&parent, &name)?, "registry transaction lock")?;
+    if opened != named {
+        return Err(io::Error::other(
+            "registry transaction lock changed identity while opening",
+        ));
+    }
+    let parent_stat = stat_file(&parent)?;
+    let key = AuthorityKey::Unix {
+        parent_device: parent_stat.st_dev as u64,
+        parent_inode: parent_stat.st_ino as u64,
+        name: name.clone(),
+    };
+    Ok(AnchoredLockFile {
+        file,
+        key,
+        parent,
+        name,
+    })
+}
+
+#[cfg(any(test, not(unix)))]
 pub(crate) fn write(path: &Path, bytes: &[u8]) -> io::Result<()> {
     write_with_pre_commit(path, bytes, |_| Ok(()))
 }
 
-#[cfg(unix)]
+#[cfg(all(test, unix))]
 fn write_with_pre_commit_impl<F>(path: &Path, bytes: &[u8], pre_commit: F) -> io::Result<()>
 where
     F: FnOnce(&Path) -> io::Result<()>,
@@ -219,6 +672,42 @@ where
 
     if result.is_err() {
         let _ = unlink_if_same(&anchor.file, &staged_name, staged_identity);
+    }
+    result
+}
+
+#[cfg(unix)]
+fn write_at(parent: &File, destination_name: &std::ffi::OsStr, bytes: &[u8]) -> io::Result<()> {
+    let (mut staged, staged_name) = create_staged_file(parent)?;
+    let staged_identity = validate_regular_file(&staged, "registry staged artifact")?;
+    let result = (|| {
+        staged.write_all(bytes)?;
+        staged.flush()?;
+        staged.sync_all()?;
+        verify_named_identity(
+            parent,
+            &staged_name,
+            staged_identity,
+            "registry staged artifact",
+        )?;
+        match stat_at(parent, destination_name) {
+            Ok(stat) => {
+                validate_regular_stat(&stat, "existing registry destination")?;
+            }
+            Err(error) if error.kind() == io::ErrorKind::NotFound => {}
+            Err(error) => return Err(error),
+        }
+        rename_at(parent, &staged_name, parent, destination_name)?;
+        verify_named_identity(
+            parent,
+            destination_name,
+            staged_identity,
+            "published registry artifact",
+        )?;
+        parent.sync_all()
+    })();
+    if result.is_err() {
+        let _ = unlink_if_same(parent, &staged_name, staged_identity);
     }
     result
 }
@@ -333,7 +822,7 @@ struct FileIdentity {
     inode: u64,
 }
 
-#[cfg(unix)]
+#[cfg(all(test, unix))]
 fn anchor_named_path(path: &Path) -> io::Result<(DirectoryAnchor, OsString)> {
     let parent = path.parent().ok_or_else(|| {
         io::Error::new(
@@ -674,7 +1163,7 @@ where
     write_with_pre_commit_impl(path, bytes, pre_commit)
 }
 
-#[cfg(not(test))]
+#[cfg(all(not(test), not(unix)))]
 fn write_with_pre_commit<F>(path: &Path, bytes: &[u8], pre_commit: F) -> io::Result<()>
 where
     F: FnOnce(&Path) -> io::Result<()>,

--- a/crates/kin-registry/src/atomic_file.rs
+++ b/crates/kin-registry/src/atomic_file.rs
@@ -301,7 +301,11 @@ impl AuthorityRoot {
         {
             let (parent, name) = self.capability_parent_and_name(relative, false)?;
             let mut options = CapabilityOpenOptions::new();
-            options.append(true).follow(FollowSymlinks::No);
+            // Windows requires generic write access for `set_len`, which the
+            // upload rollback path uses after a rejected or cancelled append.
+            // Append-only access is sufficient on Unix but cannot truncate a
+            // Windows handle back to the durable metadata offset.
+            options.write(true).append(true).follow(FollowSymlinks::No);
             open_capability_regular_file(&parent, &name, &options, "registry upload data")
         }
     }
@@ -1512,6 +1516,22 @@ mod tests {
 
         assert_eq!(before.len, after.len);
         assert_ne!((before.device, before.inode), (after.device, after.inode));
+    }
+
+    #[test]
+    fn append_handle_can_rollback_to_the_durable_offset() {
+        let root = tempfile::tempdir().unwrap();
+        let authority = AuthorityRoot::new(&root.path().join("authority"));
+        let relative = Path::new("uploads/session.data");
+        authority.write(relative, b"durable").unwrap();
+
+        let mut file = authority.open_append(relative).unwrap();
+        file.write_all(b"-uncommitted").unwrap();
+        file.set_len(b"durable".len() as u64).unwrap();
+        file.sync_all().unwrap();
+        drop(file);
+
+        assert_eq!(authority.read(relative).unwrap(), b"durable");
     }
 
     #[cfg(unix)]

--- a/crates/kin-registry/src/cargo.rs
+++ b/crates/kin-registry/src/cargo.rs
@@ -85,13 +85,14 @@ async fn index_lookup(
     // Extract the package name (last path segment)
     let name = params.last().map(|(_, v)| v.as_str()).unwrap_or("");
 
-    let mut versions = match state.manifest_store.get_versions(Ecosystem::Cargo, name) {
+    // The manifest is the sparse index authority. Metadata extraction belongs
+    // to authenticated publish/ingest; a GET must never rebuild or mutate the
+    // index from ambient crate files.
+    let versions = match state.manifest_store.get_versions(Ecosystem::Cargo, name) {
         Ok(v) if v.is_empty() => return StatusCode::NOT_FOUND.into_response(),
         Ok(v) => v,
         Err(_) => return StatusCode::NOT_FOUND.into_response(),
     };
-
-    backfill_cargo_metadata_from_crate(&state, &mut versions);
 
     // Cargo expects newline-delimited JSON, one entry per version
     let mut body = String::new();
@@ -680,57 +681,6 @@ fn extract_crate_metadata(crate_bytes: &[u8], name: &str, version: &str) -> serd
     metadata
 }
 
-fn backfill_cargo_metadata_from_crate(state: &CargoRegistryState, versions: &mut [PackageVersion]) {
-    let mut changed = false;
-
-    for version in versions.iter_mut() {
-        let crate_path = state
-            .blobs_dir
-            .join(format!("{}-{}.crate", version.id.name, version.version));
-        let Ok(crate_bytes) = std::fs::read(&crate_path) else {
-            continue;
-        };
-        let extracted = extract_crate_metadata(&crate_bytes, &version.id.name, &version.version);
-        let merged = merge_cargo_metadata(&version.metadata, &extracted);
-        if merged != version.metadata {
-            version.metadata = merged;
-            changed = true;
-        }
-    }
-
-    if changed {
-        if let Some(first) = versions.first() {
-            let _ = state.manifest_store.replace_versions(&first.id, versions);
-        }
-    }
-}
-
-fn merge_cargo_metadata(
-    existing: &serde_json::Value,
-    extracted: &serde_json::Value,
-) -> serde_json::Value {
-    let Some(extracted_obj) = extracted.as_object() else {
-        return existing.clone();
-    };
-
-    let mut merged = existing.clone();
-    if !merged.is_object() {
-        merged = serde_json::json!({});
-    }
-
-    let Some(merged_obj) = merged.as_object_mut() else {
-        return existing.clone();
-    };
-
-    for key in ["features", "deps"] {
-        if let Some(value) = extracted_obj.get(key) {
-            merged_obj.insert(key.to_string(), value.clone());
-        }
-    }
-
-    merged
-}
-
 /// Cargo index entry format (one per version, newline-delimited JSON)
 #[derive(Serialize)]
 struct CargoIndexEntry {
@@ -825,7 +775,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn sparse_index_backfills_missing_dependency_metadata_from_crate_blob() {
+    async fn sparse_index_is_a_manifest_only_read_and_never_repairs_from_blob_bytes() {
         let (_root, state) = registry_state();
         std::fs::create_dir_all(&state.blobs_dir).unwrap();
 
@@ -865,6 +815,11 @@ kin-blobs = { version = "0.1.0", registry = "kin", features = ["schema"] }
             })
             .unwrap();
 
+        let manifest_before = state
+            .manifest_store
+            .get_versions(Ecosystem::Cargo, "kin-infer")
+            .unwrap();
+
         let response = cargo_routes(state.clone())
             .oneshot(
                 Request::builder()
@@ -882,22 +837,83 @@ kin-blobs = { version = "0.1.0", registry = "kin", features = ["schema"] }
         let line = String::from_utf8(body.to_vec()).unwrap();
         let index_entry: serde_json::Value = serde_json::from_str(line.trim()).unwrap();
         let deps = index_entry["deps"].as_array().unwrap();
+        assert!(deps.is_empty());
 
-        let serde_dep = deps.iter().find(|dep| dep["name"] == "serde").unwrap();
-        assert_eq!(serde_dep["registry"], CRATES_IO_INDEX_URL);
-
-        let ndarray_dep = deps.iter().find(|dep| dep["name"] == "ndarray").unwrap();
-        assert_eq!(ndarray_dep["registry"], CRATES_IO_INDEX_URL);
-
-        let kin_dep = deps.iter().find(|dep| dep["name"] == "kin-blobs").unwrap();
-        assert!(kin_dep["registry"].is_null());
-
-        let versions = state
+        let manifest_after = state
             .manifest_store
             .get_versions(Ecosystem::Cargo, "kin-infer")
             .unwrap();
-        let deps = versions[0].metadata["deps"].as_array().unwrap();
-        assert_eq!(deps.len(), 3);
+        assert_eq!(manifest_after.len(), manifest_before.len());
+        assert_eq!(manifest_after[0].version, manifest_before[0].version);
+        assert_eq!(manifest_after[0].metadata, manifest_before[0].metadata);
+    }
+
+    #[tokio::test]
+    async fn concurrent_sparse_reads_cannot_erase_a_published_version() {
+        let (_root, state) = registry_state_with_token(Some("s3cret"));
+        std::fs::create_dir_all(&state.blobs_dir).unwrap();
+        let first_body = build_test_crate(
+            "demo",
+            "0.1.0",
+            "[package]\nname = \"demo\"\nversion = \"0.1.0\"\n\n[dependencies]\nserde = \"1\"\n",
+        );
+        std::fs::write(state.blobs_dir.join("demo-0.1.0.crate"), &first_body).unwrap();
+        state
+            .manifest_store
+            .add_version(&PackageVersion {
+                id: PackageId {
+                    ecosystem: Ecosystem::Cargo,
+                    scope: None,
+                    name: "demo".to_string(),
+                },
+                version: "0.1.0".to_string(),
+                blob_hash: "hash".to_string(),
+                blob_size: first_body.len() as u64,
+                checksum: "checksum".to_string(),
+                metadata: serde_json::json!({}),
+                published_at: Utc::now(),
+                published_by: "legacy-test".to_string(),
+                yanked: false,
+            })
+            .unwrap();
+
+        let reads = async {
+            for _ in 0..64 {
+                let response = cargo_routes(state.clone())
+                    .oneshot(
+                        Request::get("/registry/cargo/de/mo/demo")
+                            .body(Body::empty())
+                            .unwrap(),
+                    )
+                    .await
+                    .unwrap();
+                assert_eq!(response.status(), StatusCode::OK);
+                tokio::task::yield_now().await;
+            }
+        };
+        let publish_second = publish(
+            state.clone(),
+            "demo",
+            "0.2.0",
+            Some("s3cret"),
+            valid_crate("demo", "0.2.0"),
+        );
+
+        let (_, status) = tokio::join!(reads, publish_second);
+        assert_eq!(status, StatusCode::OK);
+
+        let versions = state
+            .manifest_store
+            .get_versions(Ecosystem::Cargo, "demo")
+            .unwrap();
+        assert_eq!(
+            versions
+                .iter()
+                .map(|version| version.version.as_str())
+                .collect::<Vec<_>>(),
+            vec!["0.1.0", "0.2.0"]
+        );
+        assert_eq!(versions[0].metadata, serde_json::json!({}));
     }
 
     /// Build a valid `.crate` blob for a simple `[package]` manifest.

--- a/crates/kin-registry/src/cargo.rs
+++ b/crates/kin-registry/src/cargo.rs
@@ -33,6 +33,7 @@ use crate::{Ecosystem, ManifestStore, PackageId, PackageVersion};
 pub struct CargoRegistryState {
     pub manifest_store: ManifestStore,
     pub blobs_dir: std::path::PathBuf,
+    blobs_authority: crate::atomic_file::AuthorityRoot,
     pub base_url: String,
     /// Shared secret required to authorize `publish` requests (the write path).
     ///
@@ -52,6 +53,8 @@ pub struct CargoRegistryState {
     publish_gate: RwLock<()>,
     #[cfg(test)]
     fail_next_blob_commit: std::sync::atomic::AtomicBool,
+    #[cfg(test)]
+    delay_next_blob_commit_ms: std::sync::atomic::AtomicU64,
 }
 
 impl CargoRegistryState {
@@ -61,10 +64,12 @@ impl CargoRegistryState {
         base_url: String,
         publish_token: Option<String>,
     ) -> Self {
-        let blobs_dir = crate::atomic_file::pin_authority_root(&blobs_dir).unwrap_or(blobs_dir);
+        let blobs_authority = crate::atomic_file::AuthorityRoot::new(&blobs_dir);
+        let blobs_dir = blobs_authority.path().to_path_buf();
         Self {
             manifest_store,
             blobs_dir,
+            blobs_authority,
             base_url,
             publish_token: publish_token
                 .map(|token| token.trim().to_string())
@@ -72,6 +77,8 @@ impl CargoRegistryState {
             publish_gate: RwLock::new(()),
             #[cfg(test)]
             fail_next_blob_commit: std::sync::atomic::AtomicBool::new(false),
+            #[cfg(test)]
+            delay_next_blob_commit_ms: std::sync::atomic::AtomicU64::new(0),
         }
     }
 }
@@ -212,13 +219,18 @@ async fn index_lookup(
     }
 
     let _read_guard = state.publish_gate.read().await;
-    let transaction = match state
-        .manifest_store
-        .read_transaction_async(Ecosystem::Cargo)
-        .await
+    let read_state = Arc::clone(&state);
+    let read_name = name.to_string();
+    let versions = match tokio::task::spawn_blocking(move || {
+        read_state
+            .manifest_store
+            .read_transaction(Ecosystem::Cargo)?
+            .get_versions(&read_name)
+    })
+    .await
     {
-        Ok(transaction) => transaction,
-        Err(error) => {
+        Ok(Ok(versions)) => versions,
+        Ok(Err(error)) => {
             return (
                 StatusCode::INTERNAL_SERVER_ERROR,
                 Json(serde_json::json!({
@@ -227,24 +239,22 @@ async fn index_lookup(
             )
                 .into_response();
         }
-    };
-
-    // The manifest is the sparse index authority. Metadata extraction belongs
-    // to authenticated publish/ingest; a GET must never rebuild or mutate the
-    // index from ambient crate files.
-    let versions = match transaction.get_versions(name) {
-        Ok(v) if v.is_empty() => return StatusCode::NOT_FOUND.into_response(),
-        Ok(v) => v,
         Err(error) => {
             return (
                 StatusCode::INTERNAL_SERVER_ERROR,
                 Json(serde_json::json!({
-                    "error": format!("Cargo index manifest is unreadable: {error}")
+                    "error": format!("Cargo index storage task failed: {error}")
                 })),
             )
                 .into_response();
         }
     };
+    // The manifest is the sparse index authority. Metadata extraction belongs
+    // to authenticated publish/ingest; a GET must never rebuild or mutate the
+    // index from ambient crate files.
+    if versions.is_empty() {
+        return StatusCode::NOT_FOUND.into_response();
+    }
 
     // Cargo expects newline-delimited JSON, one entry per version
     let mut body = String::new();
@@ -291,36 +301,41 @@ async fn download_crate(
         return bad_coordinate(message);
     }
     let _read_guard = state.publish_gate.read().await;
-    let transaction = match state
-        .manifest_store
-        .read_transaction_async(Ecosystem::Cargo)
-        .await
-    {
-        Ok(transaction) => transaction,
+    let relative = match crate_path.strip_prefix(&state.blobs_dir) {
+        Ok(relative) => relative.to_path_buf(),
         Err(_) => return StatusCode::INTERNAL_SERVER_ERROR.into_response(),
     };
-    let versions = match transaction.get_versions(&name) {
-        Ok(v) => v,
-        Err(_) => return StatusCode::NOT_FOUND.into_response(),
-    };
-
-    let pkg_version = match versions.iter().find(|v| v.version == version) {
-        Some(v) => v,
-        None => return StatusCode::NOT_FOUND.into_response(),
-    };
-
-    // Read the .crate file from blob store
-    match std::fs::read(&crate_path) {
-        Ok(bytes) => (
+    let read_state = Arc::clone(&state);
+    let read_name = name.clone();
+    let read_version = version.clone();
+    let result = tokio::task::spawn_blocking(move || {
+        let transaction = read_state
+            .manifest_store
+            .read_transaction(Ecosystem::Cargo)?;
+        let versions = transaction.get_versions(&read_name)?;
+        let Some(pkg_version) = versions.iter().find(|item| item.version == read_version) else {
+            return Ok::<_, crate::RegistryError>(None);
+        };
+        let bytes = match read_state.blobs_authority.read(&relative) {
+            Ok(bytes) => bytes,
+            Err(error) if error.kind() == std::io::ErrorKind::NotFound => return Ok(None),
+            Err(error) => return Err(error.into()),
+        };
+        Ok(Some((bytes, pkg_version.checksum.clone())))
+    })
+    .await;
+    match result {
+        Ok(Ok(Some((bytes, checksum)))) => (
             StatusCode::OK,
             [
                 ("content-type", "application/x-tar"),
-                ("etag", &format!("\"{}\"", pkg_version.checksum)),
+                ("etag", &format!("\"{checksum}\"")),
             ],
             bytes,
         )
             .into_response(),
-        Err(_) => StatusCode::NOT_FOUND.into_response(),
+        Ok(Ok(None)) => StatusCode::NOT_FOUND.into_response(),
+        Ok(Err(_)) | Err(_) => StatusCode::INTERNAL_SERVER_ERROR.into_response(),
     }
 }
 
@@ -471,11 +486,6 @@ async fn publish_crate(
     // Compute SHA-256 checksum of the .crate bytes
     let checksum = hex::encode(Sha256::digest(&body));
 
-    let crate_path = match cargo_blob_path(&state.blobs_dir, &params.name, &params.version) {
-        Ok(path) => path,
-        Err(message) => return bad_coordinate(message),
-    };
-
     // Parse metadata before entering the short storage critical section. The
     // write side serializes the subsequent manifest check + blob write +
     // manifest append against every other publish in this registry. Readers
@@ -501,79 +511,34 @@ async fn publish_crate(
         }
     };
     let _write_guard = state.publish_gate.write().await;
-    let transaction = match state
-        .manifest_store
-        .write_transaction_async(Ecosystem::Cargo)
-        .await
-    {
-        Ok(transaction) => transaction,
-        Err(error) => {
-            return (
-                StatusCode::INTERNAL_SERVER_ERROR,
-                Json(serde_json::json!({
-                    "error": format!("failed to lock Cargo registry storage: {error}")
-                })),
-            )
-                .into_response();
-        }
-    };
+    let commit_state = Arc::clone(&state);
+    let commit_name = params.name.clone();
+    let commit_version = params.version.clone();
+    let commit_checksum = checksum.clone();
+    let commit_body = body.to_vec();
+    let outcome = tokio::task::spawn_blocking(move || {
+        commit_crate(
+            &commit_state,
+            &commit_name,
+            &commit_version,
+            &commit_checksum,
+            metadata,
+            &commit_body,
+        )
+    })
+    .await;
 
-    let existing_versions = match transaction.get_versions(&params.name) {
-        Ok(versions) => versions,
-        Err(e) => {
-            return (
-                StatusCode::INTERNAL_SERVER_ERROR,
-                Json(serde_json::json!({ "error": format!("{e}") })),
-            )
-                .into_response();
-        }
-    };
-
-    if let Some((existing_index, existing)) = existing_versions
-        .iter()
-        .enumerate()
-        .find(|(_, version)| version.version == params.version)
-    {
-        if existing.checksum != checksum {
-            return (
-                StatusCode::CONFLICT,
-                Json(serde_json::json!({
-                    "error": format!(
-                        "version {} of crate {} already exists with a different checksum",
-                        params.version, params.name
-                    )
-                })),
-            )
-                .into_response();
-        }
-
-        if let Err(e) = write_crate_blob(&state, &crate_path, &body) {
-            return (
-                StatusCode::INTERNAL_SERVER_ERROR,
-                Json(serde_json::json!({ "error": format!("failed to write crate file: {e}") })),
-            )
-                .into_response();
-        }
-
-        // An identical immutable artifact is also the safe recovery path for
-        // manifests written before Cargo dependency metadata became
-        // authoritative. Replace only metadata derived from the same bytes;
-        // preserve publication identity and timestamps.
-        if existing.metadata != metadata {
-            let mut repaired = existing_versions.clone();
-            repaired[existing_index].metadata = metadata.clone();
-            if let Err(error) = transaction.replace_versions(&existing.id, &repaired) {
-                return (
-                    StatusCode::INTERNAL_SERVER_ERROR,
-                    Json(serde_json::json!({
-                        "error": format!("failed to repair Cargo index metadata: {error}")
-                    })),
-                )
-                    .into_response();
-            }
-        }
-
-        return (
+    match outcome {
+        Ok(Ok(CargoCommitOutcome::Published)) => (
+            StatusCode::OK,
+            Json(serde_json::json!({
+                "name": params.name,
+                "version": params.version,
+                "checksum": checksum,
+            })),
+        )
+            .into_response(),
+        Ok(Ok(CargoCommitOutcome::AlreadyPublished)) => (
             StatusCode::OK,
             Json(serde_json::json!({
                 "name": params.name,
@@ -582,60 +547,111 @@ async fn publish_crate(
                 "already_published": true,
             })),
         )
-            .into_response();
-    }
-
-    if let Err(e) = write_crate_blob(&state, &crate_path, &body) {
-        return (
-            StatusCode::INTERNAL_SERVER_ERROR,
-            Json(serde_json::json!({ "error": format!("failed to write crate file: {e}") })),
+            .into_response(),
+        Ok(Err(CargoCommitError::Conflict(message))) => (
+            StatusCode::CONFLICT,
+            Json(serde_json::json!({ "error": message })),
         )
-            .into_response();
+            .into_response(),
+        Ok(Err(CargoCommitError::Storage(message))) => (
+            StatusCode::INTERNAL_SERVER_ERROR,
+            Json(serde_json::json!({ "error": message })),
+        )
+            .into_response(),
+        Err(error) => (
+            StatusCode::INTERNAL_SERVER_ERROR,
+            Json(serde_json::json!({
+                "error": format!("Cargo publication task failed: {error}")
+            })),
+        )
+            .into_response(),
+    }
+}
+
+enum CargoCommitOutcome {
+    Published,
+    AlreadyPublished,
+}
+
+enum CargoCommitError {
+    Conflict(String),
+    Storage(String),
+}
+
+fn commit_crate(
+    state: &CargoRegistryState,
+    name: &str,
+    version: &str,
+    checksum: &str,
+    metadata: serde_json::Value,
+    body: &[u8],
+) -> Result<CargoCommitOutcome, CargoCommitError> {
+    let transaction = state
+        .manifest_store
+        .write_transaction(Ecosystem::Cargo)
+        .map_err(|error| {
+            CargoCommitError::Storage(format!("failed to lock Cargo registry storage: {error}"))
+        })?;
+    let existing_versions = transaction
+        .get_versions(name)
+        .map_err(|error| CargoCommitError::Storage(error.to_string()))?;
+    let crate_path =
+        cargo_blob_path(&state.blobs_dir, name, version).map_err(CargoCommitError::Storage)?;
+
+    if let Some((existing_index, existing)) = existing_versions
+        .iter()
+        .enumerate()
+        .find(|(_, candidate)| candidate.version == version)
+    {
+        if existing.checksum != checksum {
+            return Err(CargoCommitError::Conflict(format!(
+                "version {version} of crate {name} already exists with a different checksum"
+            )));
+        }
+        write_crate_blob(state, &crate_path, body).map_err(|error| {
+            CargoCommitError::Storage(format!("failed to write crate file: {error}"))
+        })?;
+        if existing.metadata != metadata {
+            let mut repaired = existing_versions.clone();
+            repaired[existing_index].metadata = metadata;
+            transaction
+                .replace_versions(&existing.id, &repaired)
+                .map_err(|error| {
+                    CargoCommitError::Storage(format!(
+                        "failed to repair Cargo index metadata: {error}"
+                    ))
+                })?;
+        }
+        return Ok(CargoCommitOutcome::AlreadyPublished);
     }
 
-    // Register the version in the manifest store
-    let pkg_version = PackageVersion {
+    write_crate_blob(state, &crate_path, body).map_err(|error| {
+        CargoCommitError::Storage(format!("failed to write crate file: {error}"))
+    })?;
+    let package_version = PackageVersion {
         id: PackageId {
             ecosystem: Ecosystem::Cargo,
             scope: None,
-            name: params.name.clone(),
+            name: name.to_string(),
         },
-        version: params.version.clone(),
-        blob_hash: checksum.clone(),
+        version: version.to_string(),
+        blob_hash: checksum.to_string(),
         blob_size: body.len() as u64,
-        checksum: checksum.clone(),
+        checksum: checksum.to_string(),
         metadata,
         published_at: Utc::now(),
         published_by: "anonymous".to_string(),
         yanked: false,
     };
-
-    match transaction.add_version(&pkg_version) {
-        Ok(()) => (
-            StatusCode::OK,
-            Json(serde_json::json!({
-                "name": params.name,
-                "version": params.version,
-                "checksum": checksum,
-            })),
-        )
-            .into_response(),
-        Err(crate::RegistryError::VersionExists(_, _)) => (
-            StatusCode::CONFLICT,
-            Json(serde_json::json!({
-                "error": format!(
-                    "version {} of crate {} already exists and cannot be overwritten",
-                    params.version, params.name
-                )
-            })),
-        )
-            .into_response(),
-        Err(e) => (
-            StatusCode::INTERNAL_SERVER_ERROR,
-            Json(serde_json::json!({ "error": format!("{e}") })),
-        )
-            .into_response(),
-    }
+    transaction
+        .add_version(&package_version)
+        .map_err(|error| match error {
+            crate::RegistryError::VersionExists(_, _) => CargoCommitError::Conflict(format!(
+                "version {version} of crate {name} already exists and cannot be overwritten"
+            )),
+            error => CargoCommitError::Storage(error.to_string()),
+        })?;
+    Ok(CargoCommitOutcome::Published)
 }
 
 fn write_crate_blob(
@@ -651,6 +667,16 @@ fn write_crate_blob(
     }
 
     #[cfg(test)]
+    {
+        let delay = state
+            .delay_next_blob_commit_ms
+            .swap(0, std::sync::atomic::Ordering::SeqCst);
+        if delay > 0 {
+            std::thread::sleep(std::time::Duration::from_millis(delay));
+        }
+    }
+
+    #[cfg(test)]
     if state
         .fail_next_blob_commit
         .swap(false, std::sync::atomic::Ordering::SeqCst)
@@ -662,7 +688,13 @@ fn write_crate_blob(
         });
     }
 
-    crate::atomic_file::write(crate_path, body)
+    let relative = crate_path.strip_prefix(&state.blobs_dir).map_err(|_| {
+        std::io::Error::new(
+            std::io::ErrorKind::InvalidInput,
+            "crate blob path escaped the configured blob directory",
+        )
+    })?;
+    state.blobs_authority.write(relative, body)
 }
 
 /// Parse and verify the one authoritative Cargo.toml under bounded archive
@@ -672,11 +704,11 @@ fn parse_crate_manifest(
     name: &str,
     version: &str,
 ) -> Result<toml::Value, String> {
-    use flate2::read::GzDecoder;
+    use flate2::bufread::GzDecoder;
     use std::io::Read;
 
     let expected_manifest = format!("{}-{}/Cargo.toml", name, version);
-    let gz = GzDecoder::new(crate_bytes);
+    let gz = GzDecoder::new(std::io::BufReader::new(crate_bytes));
     let mut archive = tar::Archive::new(gz);
 
     let entries = archive
@@ -733,6 +765,14 @@ fn parse_crate_manifest(
                 ));
             }
         }
+    }
+
+    let mut decoder = archive.into_inner();
+    std::io::copy(&mut decoder, &mut std::io::sink())
+        .map_err(|error| format!("crate gzip stream is truncated: {error}"))?;
+    let compressed = decoder.into_inner();
+    if !compressed.buffer().is_empty() || !compressed.get_ref().is_empty() {
+        return Err("crate contains trailing data or more than one gzip member".to_string());
     }
 
     if !manifest_seen {
@@ -1080,6 +1120,7 @@ mod tests {
     use super::*;
     use axum::body::Body;
     use axum::http::{Request, StatusCode};
+    use std::time::Duration;
     use tower::ServiceExt;
 
     fn registry_state() -> (tempfile::TempDir, Arc<CargoRegistryState>) {
@@ -1575,6 +1616,30 @@ kin-blobs = { version = "0.1.0", registry = "kin", features = ["schema"] }
         assert_eq!(versions[0].version, "0.1.0");
     }
 
+    #[tokio::test(flavor = "current_thread")]
+    async fn delayed_durable_commit_does_not_block_the_async_worker() {
+        let (_root, state) = registry_state_with_token(Some("s3cret"));
+        state
+            .delay_next_blob_commit_ms
+            .store(200, std::sync::atomic::Ordering::SeqCst);
+        let publisher = tokio::spawn(publish(
+            state,
+            "demo",
+            "1.0.0",
+            Some("s3cret"),
+            valid_crate("demo", "1.0.0"),
+        ));
+
+        tokio::time::timeout(Duration::from_millis(75), async {
+            for _ in 0..3 {
+                tokio::time::sleep(Duration::from_millis(10)).await;
+            }
+        })
+        .await
+        .expect("Tokio heartbeat stalled behind the durable registry commit");
+        assert_eq!(publisher.await.unwrap(), StatusCode::OK);
+    }
+
     #[tokio::test]
     async fn republishing_existing_version_is_idempotent_for_same_checksum() {
         // (d) Re-publishing the same version with identical bytes repairs the
@@ -1991,6 +2056,53 @@ private = { version = "1", registry = "corp" }
         let body = encoder.finish().unwrap();
         let error = parse_crate_manifest(&body, "demo", "1.0.0").unwrap_err();
         assert!(error.contains("more than one authoritative"), "{error}");
+    }
+
+    #[tokio::test]
+    async fn publish_rejects_a_second_gzip_member_without_mutating_storage() {
+        let (_root, state) = registry_state_with_token(Some("s3cret"));
+        let mut body = valid_crate("demo", "1.0.0");
+        body.extend_from_slice(&valid_crate("demo", "1.0.0"));
+
+        let status = publish(state.clone(), "demo", "1.0.0", Some("s3cret"), body).await;
+
+        assert_eq!(status, StatusCode::BAD_REQUEST);
+        assert!(state
+            .manifest_store
+            .get_versions(Ecosystem::Cargo, "demo")
+            .unwrap()
+            .is_empty());
+        assert!(!state.blobs_dir.join("demo-1.0.0.crate").exists());
+    }
+
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn live_cargo_state_cannot_be_redirected_by_root_replacement() {
+        let (root, state) = registry_state_with_token(Some("s3cret"));
+        let original_blobs = root.path().join("cargo-retained");
+        std::fs::rename(&state.blobs_dir, &original_blobs).unwrap();
+        std::fs::create_dir(&state.blobs_dir).unwrap();
+
+        let manifest_path = root.path().join(".kin/packages/manifests");
+        let original_manifests = root.path().join("manifests-retained");
+        std::fs::rename(&manifest_path, &original_manifests).unwrap();
+        std::fs::create_dir(&manifest_path).unwrap();
+
+        assert_eq!(
+            publish(
+                state,
+                "demo",
+                "1.0.0",
+                Some("s3cret"),
+                valid_crate("demo", "1.0.0"),
+            )
+            .await,
+            StatusCode::OK
+        );
+        assert!(original_blobs.join("demo-1.0.0.crate").is_file());
+        assert!(!root.path().join("cargo/demo-1.0.0.crate").exists());
+        assert!(original_manifests.join("cargo/demo").is_file());
+        assert!(!manifest_path.join("cargo/demo").exists());
     }
 
     #[tokio::test]

--- a/crates/kin-registry/src/cargo.rs
+++ b/crates/kin-registry/src/cargo.rs
@@ -25,6 +25,7 @@ use sha2::{Digest, Sha256};
 use std::path::{Path as FsPath, PathBuf};
 use std::sync::Arc;
 use tokio::sync::RwLock;
+use url::Url;
 
 use crate::{Ecosystem, ManifestStore, PackageId, PackageVersion};
 
@@ -78,6 +79,9 @@ const CRATES_IO_INDEX_URL: &str = "https://github.com/rust-lang/crates.io-index"
 
 /// Maximum accepted `.crate` upload size (50 MiB), matching crates.io's cap.
 const MAX_CRATE_SIZE: usize = 50 * 1024 * 1024;
+const MAX_CRATE_ARCHIVE_ENTRIES: usize = 4096;
+const MAX_CRATE_ARCHIVE_SCAN_SIZE: u64 = 256 * 1024 * 1024;
+const MAX_CRATE_MANIFEST_SIZE: u64 = 1024 * 1024;
 const MAX_CRATE_NAME_LEN: usize = 64;
 
 /// Validate a Cargo registry package name before it can reach either the blob
@@ -207,11 +211,23 @@ async fn index_lookup(
     }
 
     let _read_guard = state.publish_gate.read().await;
+    let transaction = match state.manifest_store.read_transaction(Ecosystem::Cargo) {
+        Ok(transaction) => transaction,
+        Err(error) => {
+            return (
+                StatusCode::INTERNAL_SERVER_ERROR,
+                Json(serde_json::json!({
+                    "error": format!("Cargo index storage lock failed: {error}")
+                })),
+            )
+                .into_response();
+        }
+    };
 
     // The manifest is the sparse index authority. Metadata extraction belongs
     // to authenticated publish/ingest; a GET must never rebuild or mutate the
     // index from ambient crate files.
-    let versions = match state.manifest_store.get_versions(Ecosystem::Cargo, name) {
+    let versions = match transaction.get_versions(name) {
         Ok(v) if v.is_empty() => return StatusCode::NOT_FOUND.into_response(),
         Ok(v) => v,
         Err(error) => {
@@ -270,7 +286,11 @@ async fn download_crate(
         return bad_coordinate(message);
     }
     let _read_guard = state.publish_gate.read().await;
-    let versions = match state.manifest_store.get_versions(Ecosystem::Cargo, &name) {
+    let transaction = match state.manifest_store.read_transaction(Ecosystem::Cargo) {
+        Ok(transaction) => transaction,
+        Err(_) => return StatusCode::INTERNAL_SERVER_ERROR.into_response(),
+    };
+    let versions = match transaction.get_versions(&name) {
         Ok(v) => v,
         Err(_) => return StatusCode::NOT_FOUND.into_response(),
     };
@@ -424,17 +444,20 @@ async fn publish_crate(
             .into_response();
     }
 
-    // Verify the uploaded bytes are a valid gzip-tar whose embedded Cargo.toml
-    // declares a `[package]` name/version matching the query params. This
-    // prevents publishing arbitrary/garbage bytes or claiming a coordinate that
-    // disagrees with the crate's own manifest.
-    if let Err(message) = verify_crate_coordinates(&body, &params.name, &params.version) {
-        return (
-            StatusCode::BAD_REQUEST,
-            Json(serde_json::json!({ "error": message })),
-        )
-            .into_response();
-    }
+    // Parse the archive exactly once under explicit decompression, entry, and
+    // Cargo.toml budgets. Coordinate verification and sparse-index extraction
+    // consume the same parsed manifest so an authorized gzip bomb cannot make
+    // the daemon walk an unbounded archive twice.
+    let crate_manifest = match parse_crate_manifest(&body, &params.name, &params.version) {
+        Ok(manifest) => manifest,
+        Err(message) => {
+            return (
+                StatusCode::BAD_REQUEST,
+                Json(serde_json::json!({ "error": message })),
+            )
+                .into_response();
+        }
+    };
 
     // Compute SHA-256 checksum of the .crate bytes
     let checksum = hex::encode(Sha256::digest(&body));
@@ -448,7 +471,17 @@ async fn publish_crate(
     // write side serializes the subsequent manifest check + blob write +
     // manifest append against every other publish in this registry. Readers
     // hold the read side across their corresponding manifest/blob reads.
-    let metadata = match extract_crate_metadata(&body, &params.name, &params.version) {
+    let configured_index = match configured_sparse_index_url(&state.base_url) {
+        Ok(index) => index,
+        Err(message) => {
+            return (
+                StatusCode::INTERNAL_SERVER_ERROR,
+                Json(serde_json::json!({ "error": message })),
+            )
+                .into_response();
+        }
+    };
+    let metadata = match extract_crate_metadata(&crate_manifest, &configured_index) {
         Ok(metadata) => metadata,
         Err(message) => {
             return (
@@ -459,11 +492,20 @@ async fn publish_crate(
         }
     };
     let _write_guard = state.publish_gate.write().await;
+    let transaction = match state.manifest_store.write_transaction(Ecosystem::Cargo) {
+        Ok(transaction) => transaction,
+        Err(error) => {
+            return (
+                StatusCode::INTERNAL_SERVER_ERROR,
+                Json(serde_json::json!({
+                    "error": format!("failed to lock Cargo registry storage: {error}")
+                })),
+            )
+                .into_response();
+        }
+    };
 
-    let existing_versions = match state
-        .manifest_store
-        .get_versions(Ecosystem::Cargo, &params.name)
-    {
+    let existing_versions = match transaction.get_versions(&params.name) {
         Ok(versions) => versions,
         Err(e) => {
             return (
@@ -474,9 +516,10 @@ async fn publish_crate(
         }
     };
 
-    if let Some(existing) = existing_versions
+    if let Some((existing_index, existing)) = existing_versions
         .iter()
-        .find(|version| version.version == params.version)
+        .enumerate()
+        .find(|(_, version)| version.version == params.version)
     {
         if existing.checksum != checksum {
             return (
@@ -497,6 +540,24 @@ async fn publish_crate(
                 Json(serde_json::json!({ "error": format!("failed to write crate file: {e}") })),
             )
                 .into_response();
+        }
+
+        // An identical immutable artifact is also the safe recovery path for
+        // manifests written before Cargo dependency metadata became
+        // authoritative. Replace only metadata derived from the same bytes;
+        // preserve publication identity and timestamps.
+        if existing.metadata != metadata {
+            let mut repaired = existing_versions.clone();
+            repaired[existing_index].metadata = metadata.clone();
+            if let Err(error) = transaction.replace_versions(&existing.id, &repaired) {
+                return (
+                    StatusCode::INTERNAL_SERVER_ERROR,
+                    Json(serde_json::json!({
+                        "error": format!("failed to repair Cargo index metadata: {error}")
+                    })),
+                )
+                    .into_response();
+            }
         }
 
         return (
@@ -536,7 +597,7 @@ async fn publish_crate(
         yanked: false,
     };
 
-    match state.manifest_store.add_version(&pkg_version) {
+    match transaction.add_version(&pkg_version) {
         Ok(()) => (
             StatusCode::OK,
             Json(serde_json::json!({
@@ -591,15 +652,13 @@ fn write_crate_blob(
     crate::atomic_file::write(crate_path, body)
 }
 
-/// Verify an uploaded `.crate` blob is a well-formed gzip-tar whose embedded
-/// manifest matches the published coordinates.
-///
-/// `.crate` files are gzipped tarballs that must contain
-/// `{name}-{version}/Cargo.toml`; the manifest's `[package] name` and `version`
-/// must equal `name`/`version`. Returns `Err(message)` describing the first
-/// problem found (bad gzip/tar, missing manifest, unparseable TOML, or a
-/// name/version mismatch) so the caller can surface a `400`.
-fn verify_crate_coordinates(crate_bytes: &[u8], name: &str, version: &str) -> Result<(), String> {
+/// Parse and verify the one authoritative Cargo.toml under bounded archive
+/// traversal. The returned value is reused for sparse-index extraction.
+fn parse_crate_manifest(
+    crate_bytes: &[u8],
+    name: &str,
+    version: &str,
+) -> Result<toml::Value, String> {
     use flate2::read::GzDecoder;
     use std::io::Read;
 
@@ -612,25 +671,52 @@ fn verify_crate_coordinates(crate_bytes: &[u8], name: &str, version: &str) -> Re
         .map_err(|e| format!("crate is not a valid gzip-tar archive: {e}"))?;
 
     let mut cargo_toml_content = String::new();
-    let mut found_manifest = false;
-    for entry in entries {
+    let mut scanned_size = 0u64;
+    for (index, entry) in entries.enumerate() {
+        if index >= MAX_CRATE_ARCHIVE_ENTRIES {
+            return Err(format!(
+                "crate archive exceeds the {MAX_CRATE_ARCHIVE_ENTRIES} entry scan limit"
+            ));
+        }
         // A malformed tar stream surfaces here (e.g. truncated/non-gzip body).
-        let mut entry = entry.map_err(|e| format!("crate is not a valid gzip-tar archive: {e}"))?;
+        let entry = entry.map_err(|e| format!("crate is not a valid gzip-tar archive: {e}"))?;
+        let entry_size = entry
+            .header()
+            .size()
+            .map_err(|error| format!("crate contains an invalid entry size: {error}"))?;
+        scanned_size = scanned_size
+            .checked_add(entry_size)
+            .ok_or_else(|| "crate archive scan size overflowed".to_string())?;
+        if scanned_size > MAX_CRATE_ARCHIVE_SCAN_SIZE {
+            return Err(format!(
+                "crate archive exceeds the {MAX_CRATE_ARCHIVE_SCAN_SIZE} byte scan limit"
+            ));
+        }
         let is_manifest = entry
             .path()
             .ok()
             .map(|path| path.to_str() == Some(&expected_manifest))
             .unwrap_or(false);
         if is_manifest {
+            if entry_size > MAX_CRATE_MANIFEST_SIZE {
+                return Err(format!(
+                    "crate Cargo.toml exceeds the {MAX_CRATE_MANIFEST_SIZE} byte limit"
+                ));
+            }
             entry
+                .take(MAX_CRATE_MANIFEST_SIZE + 1)
                 .read_to_string(&mut cargo_toml_content)
                 .map_err(|e| format!("failed to read {expected_manifest} from crate: {e}"))?;
-            found_manifest = true;
+            if cargo_toml_content.len() as u64 > MAX_CRATE_MANIFEST_SIZE {
+                return Err(format!(
+                    "crate Cargo.toml exceeds the {MAX_CRATE_MANIFEST_SIZE} byte limit"
+                ));
+            }
             break;
         }
     }
 
-    if !found_manifest {
+    if cargo_toml_content.is_empty() {
         return Err(format!("crate does not contain {expected_manifest}"));
     }
 
@@ -662,54 +748,44 @@ fn verify_crate_coordinates(crate_bytes: &[u8], name: &str, version: &str) -> Re
         ));
     }
 
-    Ok(())
+    Ok(toml_value)
 }
 
-/// Extract features and dependencies from a .crate tarball.
-///
-/// .crate files are gzipped tarballs containing `{name}-{version}/Cargo.toml`.
-/// We parse this to extract features (for feature resolution) and dependencies
-/// (for the sparse index).
+fn normalize_registry_index_url(value: &str) -> Result<String, String> {
+    let (prefix, raw) = match value.strip_prefix("sparse+") {
+        Some(raw) => ("sparse+", raw),
+        None => ("", value),
+    };
+    let mut parsed = Url::parse(raw)
+        .map_err(|error| format!("registry index URL {value:?} is invalid: {error}"))?;
+    if !matches!(parsed.scheme(), "http" | "https")
+        || !parsed.username().is_empty()
+        || parsed.password().is_some()
+        || parsed.query().is_some()
+        || parsed.fragment().is_some()
+    {
+        return Err(format!(
+            "registry index URL {value:?} must be an http(s) URL without credentials, query, or fragment"
+        ));
+    }
+    let normalized_path = format!("{}/", parsed.path().trim_end_matches('/'));
+    parsed.set_path(&normalized_path);
+    Ok(format!("{prefix}{parsed}"))
+}
+
+fn configured_sparse_index_url(base_url: &str) -> Result<String, String> {
+    normalize_registry_index_url(&format!(
+        "sparse+{}/registry/cargo/",
+        base_url.trim_end_matches('/')
+    ))
+    .map_err(|error| format!("configured Cargo registry base URL is invalid: {error}"))
+}
+
+/// Extract features and dependencies from the already verified Cargo.toml.
 fn extract_crate_metadata(
-    crate_bytes: &[u8],
-    name: &str,
-    version: &str,
+    toml_value: &toml::Value,
+    configured_index: &str,
 ) -> Result<serde_json::Value, String> {
-    use flate2::read::GzDecoder;
-    use std::io::Read;
-
-    let expected_manifest = format!("{}-{}/Cargo.toml", name, version);
-    let gz = GzDecoder::new(crate_bytes);
-    let mut archive = tar::Archive::new(gz);
-
-    let mut cargo_toml_content = String::new();
-    let entries = archive
-        .entries()
-        .map_err(|error| format!("crate is not a valid gzip-tar archive: {error}"))?;
-    for entry in entries {
-        let mut entry =
-            entry.map_err(|error| format!("crate is not a valid gzip-tar archive: {error}"))?;
-        let path = entry
-            .path()
-            .map_err(|error| format!("crate contains an invalid path: {error}"))?;
-        if path.to_str() == Some(&expected_manifest) {
-            entry
-                .read_to_string(&mut cargo_toml_content)
-                .map_err(|error| format!("failed to read {expected_manifest}: {error}"))?;
-            break;
-        }
-    }
-
-    if cargo_toml_content.is_empty() {
-        return Err(format!("crate does not contain {expected_manifest}"));
-    }
-
-    // Parse Cargo.toml to extract features and deps. This metadata is the
-    // sparse-index authority, so an extraction failure must never be recorded
-    // as an authoritative empty dependency list.
-    let toml_value: toml::Value = toml::from_str(&cargo_toml_content)
-        .map_err(|error| format!("crate {expected_manifest} is not valid TOML: {error}"))?;
-
     let mut metadata = serde_json::json!({
         "cargo_index_format": 1,
         "features": {},
@@ -732,7 +808,8 @@ fn extract_crate_metadata(
         dep_value: &toml::Value,
         target: Option<&str>,
         kind: &str,
-    ) -> Option<serde_json::Value> {
+        configured_index: &str,
+    ) -> Result<Option<serde_json::Value>, String> {
         let (req, optional, default_features, dep_features, registry, package) = match dep_value {
             toml::Value::String(version_str) => (
                 version_str.clone(),
@@ -745,7 +822,7 @@ fn extract_crate_metadata(
             toml::Value::Table(t) => {
                 // Skip path-only deps without a version (workspace-internal deps)
                 if t.get("path").is_some() && t.get("version").is_none() {
-                    return None;
+                    return Ok(None);
                 }
                 let req = t
                     .get("version")
@@ -773,15 +850,18 @@ fn extract_crate_metadata(
                     match reg {
                         "" | "crates-io" => Some(CRATES_IO_INDEX_URL.to_string()),
                         "kin" => None,
-                        other => Some(other.to_string()),
+                        other => {
+                            return Err(format!(
+                                "dependency {dep_name:?} uses unresolved named registry {other:?}"
+                            ));
+                        }
                     }
                 } else if let Some(idx) = t.get("registry-index").and_then(|v| v.as_str()) {
-                    // registry-index contains the full index URL; if it points
-                    // to this registry (kinlab.ai), treat it as the kin registry.
-                    if idx.contains("kinlab.ai") {
+                    let normalized = normalize_registry_index_url(idx)?;
+                    if normalized == configured_index {
                         None
                     } else {
-                        Some(idx.to_string())
+                        Some(normalized)
                     }
                 } else {
                     Some(CRATES_IO_INDEX_URL.to_string())
@@ -789,10 +869,10 @@ fn extract_crate_metadata(
                 let package = t.get("package").and_then(|v| v.as_str()).map(String::from);
                 (req, optional, default_features, features, registry, package)
             }
-            _ => return None,
+            _ => return Ok(None),
         };
 
-        Some(serde_json::json!({
+        Ok(Some(serde_json::json!({
             "name": dep_name,
             "req": req,
             "features": dep_features,
@@ -802,13 +882,15 @@ fn extract_crate_metadata(
             "kind": kind,
             "registry": registry,
             "package": package,
-        }))
+        })))
     }
 
     // [dependencies]
     if let Some(dep_table) = toml_value.get("dependencies").and_then(|d| d.as_table()) {
         for (dep_name, dep_value) in dep_table {
-            if let Some(entry) = extract_dep_entry(dep_name, dep_value, None, "normal") {
+            if let Some(entry) =
+                extract_dep_entry(dep_name, dep_value, None, "normal", configured_index)?
+            {
                 deps.push(entry);
             }
         }
@@ -820,7 +902,9 @@ fn extract_crate_metadata(
         .and_then(|d| d.as_table())
     {
         for (dep_name, dep_value) in dep_table {
-            if let Some(entry) = extract_dep_entry(dep_name, dep_value, None, "dev") {
+            if let Some(entry) =
+                extract_dep_entry(dep_name, dep_value, None, "dev", configured_index)?
+            {
                 deps.push(entry);
             }
         }
@@ -832,7 +916,9 @@ fn extract_crate_metadata(
         .and_then(|d| d.as_table())
     {
         for (dep_name, dep_value) in dep_table {
-            if let Some(entry) = extract_dep_entry(dep_name, dep_value, None, "build") {
+            if let Some(entry) =
+                extract_dep_entry(dep_name, dep_value, None, "build", configured_index)?
+            {
                 deps.push(entry);
             }
         }
@@ -843,9 +929,13 @@ fn extract_crate_metadata(
         for (target_spec, target_value) in target_table {
             if let Some(target_deps) = target_value.get("dependencies").and_then(|d| d.as_table()) {
                 for (dep_name, dep_value) in target_deps {
-                    if let Some(entry) =
-                        extract_dep_entry(dep_name, dep_value, Some(target_spec), "normal")
-                    {
+                    if let Some(entry) = extract_dep_entry(
+                        dep_name,
+                        dep_value,
+                        Some(target_spec),
+                        "normal",
+                        configured_index,
+                    )? {
                         deps.push(entry);
                     }
                 }
@@ -855,9 +945,13 @@ fn extract_crate_metadata(
                 .and_then(|d| d.as_table())
             {
                 for (dep_name, dep_value) in target_deps {
-                    if let Some(entry) =
-                        extract_dep_entry(dep_name, dep_value, Some(target_spec), "dev")
-                    {
+                    if let Some(entry) = extract_dep_entry(
+                        dep_name,
+                        dep_value,
+                        Some(target_spec),
+                        "dev",
+                        configured_index,
+                    )? {
                         deps.push(entry);
                     }
                 }
@@ -867,9 +961,13 @@ fn extract_crate_metadata(
                 .and_then(|d| d.as_table())
             {
                 for (dep_name, dep_value) in target_deps {
-                    if let Some(entry) =
-                        extract_dep_entry(dep_name, dep_value, Some(target_spec), "build")
-                    {
+                    if let Some(entry) = extract_dep_entry(
+                        dep_name,
+                        dep_value,
+                        Some(target_spec),
+                        "build",
+                        configured_index,
+                    )? {
                         deps.push(entry);
                     }
                 }
@@ -1099,7 +1197,11 @@ kin-blobs = { version = "0.1.0", registry = "kin", features = ["schema"] }
                 blob_hash: "hash".to_string(),
                 blob_size: first_body.len() as u64,
                 checksum: "checksum".to_string(),
-                metadata: extract_crate_metadata(&first_body, "demo", "0.1.0").unwrap(),
+                metadata: extract_crate_metadata(
+                    &parse_crate_manifest(&first_body, "demo", "0.1.0").unwrap(),
+                    &configured_sparse_index_url(&state.base_url).unwrap(),
+                )
+                .unwrap(),
                 published_at: Utc::now(),
                 published_by: "legacy-test".to_string(),
                 yanked: false,
@@ -1663,6 +1765,167 @@ kin-blobs = { version = "0.1.0", registry = "kin", features = ["schema"] }
             .await
             .unwrap();
         assert_eq!(downloaded.as_ref(), committed_body.as_slice());
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+    async fn independent_states_preserve_concurrent_versions_and_matching_blobs() {
+        let root = tempfile::tempdir().unwrap();
+        let kin_dir = root.path().join(".kin");
+        let blobs_dir = root.path().join("cargo");
+        std::fs::create_dir_all(&kin_dir).unwrap();
+        let make_state = || {
+            Arc::new(CargoRegistryState::new(
+                ManifestStore::new(&kin_dir),
+                blobs_dir.clone(),
+                "https://kinlab.ai".to_string(),
+                Some("s3cret".to_string()),
+            ))
+        };
+        let first_state = make_state();
+        let second_state = make_state();
+        let first_body = valid_crate("demo", "1.0.0");
+        let second_body = valid_crate("demo", "2.0.0");
+        let start = Arc::new(tokio::sync::Barrier::new(3));
+
+        let first = {
+            let start = start.clone();
+            let body = first_body.clone();
+            tokio::spawn(async move {
+                start.wait().await;
+                publish(first_state, "demo", "1.0.0", Some("s3cret"), body).await
+            })
+        };
+        let second = {
+            let start = start.clone();
+            let body = second_body.clone();
+            tokio::spawn(async move {
+                start.wait().await;
+                publish(second_state, "demo", "2.0.0", Some("s3cret"), body).await
+            })
+        };
+        start.wait().await;
+        assert_eq!(first.await.unwrap(), StatusCode::OK);
+        assert_eq!(second.await.unwrap(), StatusCode::OK);
+
+        let versions = ManifestStore::new(&kin_dir)
+            .get_versions(Ecosystem::Cargo, "demo")
+            .unwrap();
+        assert_eq!(versions.len(), 2);
+        for (version, expected) in [("1.0.0", first_body), ("2.0.0", second_body)] {
+            let entry = versions
+                .iter()
+                .find(|candidate| candidate.version == version)
+                .unwrap();
+            let stored = std::fs::read(blobs_dir.join(format!("demo-{version}.crate"))).unwrap();
+            assert_eq!(stored, expected);
+            assert_eq!(entry.checksum, hex::encode(Sha256::digest(&stored)));
+        }
+    }
+
+    #[tokio::test]
+    async fn identical_republish_repairs_legacy_metadata_without_changing_identity() {
+        let (_root, state) = registry_state_with_token(Some("s3cret"));
+        let body = build_test_crate(
+            "demo",
+            "1.0.0",
+            "[package]\nname = \"demo\"\nversion = \"1.0.0\"\n\n[dependencies]\nserde = \"1\"\n",
+        );
+        assert_eq!(
+            publish(state.clone(), "demo", "1.0.0", Some("s3cret"), body.clone(),).await,
+            StatusCode::OK
+        );
+        let mut legacy = state
+            .manifest_store
+            .get_versions(Ecosystem::Cargo, "demo")
+            .unwrap();
+        let published_at = legacy[0].published_at;
+        let published_by = legacy[0].published_by.clone();
+        legacy[0].metadata = serde_json::json!({});
+        state
+            .manifest_store
+            .replace_versions(&legacy[0].id, &legacy)
+            .unwrap();
+
+        assert_eq!(
+            publish(state.clone(), "demo", "1.0.0", Some("s3cret"), body).await,
+            StatusCode::OK
+        );
+        let repaired = state
+            .manifest_store
+            .get_versions(Ecosystem::Cargo, "demo")
+            .unwrap();
+        assert_eq!(repaired.len(), 1);
+        assert_eq!(repaired[0].published_at, published_at);
+        assert_eq!(repaired[0].published_by, published_by);
+        assert_eq!(repaired[0].metadata["cargo_index_format"], 1);
+        assert_eq!(repaired[0].metadata["deps"][0]["name"], "serde");
+    }
+
+    #[test]
+    fn dependency_registry_urls_are_classified_by_exact_normalized_authority() {
+        let configured = configured_sparse_index_url("https://kinlab.ai").unwrap();
+        let manifest: toml::Value = toml::from_str(
+            r#"
+[package]
+name = "demo"
+version = "1.0.0"
+
+[dependencies]
+local = { version = "1", registry-index = "sparse+https://kinlab.ai/registry/cargo" }
+attacker = { version = "1", registry-index = "sparse+https://kinlab.ai.evil/registry/cargo" }
+"#,
+        )
+        .unwrap();
+        let metadata = extract_crate_metadata(&manifest, &configured).unwrap();
+        let deps = metadata["deps"].as_array().unwrap();
+        assert_eq!(deps[0]["name"], "attacker");
+        assert_eq!(
+            deps[0]["registry"],
+            "sparse+https://kinlab.ai.evil/registry/cargo/"
+        );
+        assert_eq!(deps[1]["name"], "local");
+        assert!(deps[1]["registry"].is_null());
+
+        let unresolved: toml::Value = toml::from_str(
+            r#"
+[package]
+name = "demo"
+version = "1.0.0"
+[dependencies]
+private = { version = "1", registry = "corp" }
+"#,
+        )
+        .unwrap();
+        assert!(extract_crate_metadata(&unresolved, &configured).is_err());
+    }
+
+    #[test]
+    fn crate_archive_budgets_reject_declared_bombs_before_decompression() {
+        use flate2::{write::GzEncoder, Compression};
+        use std::io::Write;
+
+        let archive_with_declared_entry = |path: &str, size: u64| {
+            let mut header = tar::Header::new_gnu();
+            header.set_path(path).unwrap();
+            header.set_size(size);
+            header.set_mode(0o644);
+            header.set_cksum();
+            let mut encoder = GzEncoder::new(Vec::new(), Compression::default());
+            encoder.write_all(header.as_bytes()).unwrap();
+            encoder.finish().unwrap()
+        };
+        let oversized_manifest =
+            archive_with_declared_entry("demo-1.0.0/Cargo.toml", MAX_CRATE_MANIFEST_SIZE + 1);
+        let error = parse_crate_manifest(&oversized_manifest, "demo", "1.0.0").unwrap_err();
+        assert!(
+            error.contains("Cargo.toml") && error.contains("limit"),
+            "{error}"
+        );
+
+        let oversized_scan =
+            archive_with_declared_entry("demo-1.0.0/padding", MAX_CRATE_ARCHIVE_SCAN_SIZE + 1);
+        let error = parse_crate_manifest(&oversized_scan, "demo", "1.0.0").unwrap_err();
+        assert!(error.contains("scan limit"), "{error}");
     }
 
     #[tokio::test]

--- a/crates/kin-registry/src/cargo.rs
+++ b/crates/kin-registry/src/cargo.rs
@@ -49,6 +49,8 @@ pub struct CargoRegistryState {
     /// their full manifest/blob read, so they cannot observe a half-published
     /// coordinate.
     publish_gate: RwLock<()>,
+    #[cfg(test)]
+    fail_next_blob_commit: std::sync::atomic::AtomicBool,
 }
 
 impl CargoRegistryState {
@@ -66,6 +68,8 @@ impl CargoRegistryState {
                 .map(|token| token.trim().to_string())
                 .filter(|token| !token.is_empty()),
             publish_gate: RwLock::new(()),
+            #[cfg(test)]
+            fail_next_blob_commit: std::sync::atomic::AtomicBool::new(false),
         }
     }
 }
@@ -447,7 +451,7 @@ async fn publish_crate(
                 .into_response();
         }
 
-        if let Err(e) = write_crate_blob(&state.blobs_dir, &crate_path, &body) {
+        if let Err(e) = write_crate_blob(&state, &crate_path, &body) {
             return (
                 StatusCode::INTERNAL_SERVER_ERROR,
                 Json(serde_json::json!({ "error": format!("failed to write crate file: {e}") })),
@@ -467,7 +471,7 @@ async fn publish_crate(
             .into_response();
     }
 
-    if let Err(e) = write_crate_blob(&state.blobs_dir, &crate_path, &body) {
+    if let Err(e) = write_crate_blob(&state, &crate_path, &body) {
         return (
             StatusCode::INTERNAL_SERVER_ERROR,
             Json(serde_json::json!({ "error": format!("failed to write crate file: {e}") })),
@@ -521,18 +525,30 @@ async fn publish_crate(
 }
 
 fn write_crate_blob(
-    blobs_dir: &std::path::Path,
+    state: &CargoRegistryState,
     crate_path: &std::path::Path,
     body: &[u8],
 ) -> std::io::Result<()> {
-    if crate_path.parent() != Some(blobs_dir) {
+    if crate_path.parent() != Some(state.blobs_dir.as_path()) {
         return Err(std::io::Error::new(
             std::io::ErrorKind::InvalidInput,
             "crate blob path escaped the configured blob directory",
         ));
     }
-    std::fs::create_dir_all(blobs_dir)?;
-    std::fs::write(crate_path, body)
+
+    #[cfg(test)]
+    if state
+        .fail_next_blob_commit
+        .swap(false, std::sync::atomic::Ordering::SeqCst)
+    {
+        return crate::atomic_file::write_with_pre_commit(crate_path, body, |_| {
+            Err(std::io::Error::other(
+                "injected failure before atomic crate commit",
+            ))
+        });
+    }
+
+    crate::atomic_file::write(crate_path, body)
 }
 
 /// Verify an uploaded `.crate` blob is a well-formed gzip-tar whose embedded
@@ -1359,6 +1375,52 @@ kin-blobs = { version = "0.1.0", registry = "kin", features = ["schema"] }
             .get_versions(Ecosystem::Cargo, "demo")
             .unwrap();
         assert_eq!(versions.len(), 1);
+    }
+
+    #[tokio::test]
+    async fn failed_idempotent_repair_preserves_the_existing_blob_until_atomic_commit() {
+        let (_root, state) = registry_state_with_token(Some("s3cret"));
+        let body = valid_crate("demo", "0.1.0");
+        assert_eq!(
+            publish(state.clone(), "demo", "0.1.0", Some("s3cret"), body.clone(),).await,
+            StatusCode::OK
+        );
+
+        let blob_path = state.blobs_dir.join("demo-0.1.0.crate");
+        let prior_bytes = b"preexisting-corrupt-but-complete-bytes";
+        std::fs::write(&blob_path, prior_bytes).unwrap();
+        let manifest_before = state
+            .manifest_store
+            .get_versions(Ecosystem::Cargo, "demo")
+            .unwrap();
+
+        // Fail after the replacement is fully staged and fsynced but before
+        // the atomic rename. The indexed coordinate and old blob must remain
+        // exactly as they were; no temporary file may be exposed or leaked.
+        state
+            .fail_next_blob_commit
+            .store(true, std::sync::atomic::Ordering::SeqCst);
+        let failed = publish(state.clone(), "demo", "0.1.0", Some("s3cret"), body.clone()).await;
+        assert_eq!(failed, StatusCode::INTERNAL_SERVER_ERROR);
+        assert_eq!(std::fs::read(&blob_path).unwrap(), prior_bytes);
+        assert_eq!(std::fs::read_dir(&state.blobs_dir).unwrap().count(), 1);
+
+        let manifest_after_failure = state
+            .manifest_store
+            .get_versions(Ecosystem::Cargo, "demo")
+            .unwrap();
+        assert_eq!(manifest_after_failure.len(), manifest_before.len());
+        assert_eq!(
+            manifest_after_failure[0].checksum,
+            manifest_before[0].checksum
+        );
+
+        assert_eq!(
+            publish(state.clone(), "demo", "0.1.0", Some("s3cret"), body.clone(),).await,
+            StatusCode::OK
+        );
+        assert_eq!(std::fs::read(&blob_path).unwrap(), body);
+        assert_eq!(std::fs::read_dir(&state.blobs_dir).unwrap().count(), 1);
     }
 
     #[tokio::test]

--- a/crates/kin-registry/src/cargo.rs
+++ b/crates/kin-registry/src/cargo.rs
@@ -11,8 +11,10 @@
 //! - GET /registry/cargo/dl/{name}/{version} -- download .crate file
 
 use axum::{
-    extract::{Path, Query, State},
-    http::StatusCode,
+    body::{Body, Bytes},
+    extract::{DefaultBodyLimit, Path, Query, State},
+    http::{header, Request, StatusCode},
+    middleware::{self, Next},
     response::{IntoResponse, Json, Response},
     routing::{get, post},
     Router,
@@ -22,6 +24,7 @@ use serde::{Deserialize, Serialize};
 use sha2::{Digest, Sha256};
 use std::path::{Path as FsPath, PathBuf};
 use std::sync::Arc;
+use tokio::sync::RwLock;
 
 use crate::{Ecosystem, ManifestStore, PackageId, PackageVersion};
 
@@ -39,6 +42,32 @@ pub struct CargoRegistryState {
     /// Fail-closed: when this is `None` (env unset/empty) every publish request
     /// is rejected, so a misconfigured deployment cannot silently fall open.
     pub publish_token: Option<String>,
+    /// Serializes the manifest/blob commit while allowing coherent readers.
+    ///
+    /// Publish handlers take the write side before inspecting or mutating
+    /// storage. Sparse-index and download handlers take the read side across
+    /// their full manifest/blob read, so they cannot observe a half-published
+    /// coordinate.
+    publish_gate: RwLock<()>,
+}
+
+impl CargoRegistryState {
+    pub fn new(
+        manifest_store: ManifestStore,
+        blobs_dir: PathBuf,
+        base_url: String,
+        publish_token: Option<String>,
+    ) -> Self {
+        Self {
+            manifest_store,
+            blobs_dir,
+            base_url,
+            publish_token: publish_token
+                .map(|token| token.trim().to_string())
+                .filter(|token| !token.is_empty()),
+            publish_gate: RwLock::new(()),
+        }
+    }
 }
 
 const CRATES_IO_INDEX_URL: &str = "https://github.com/rust-lang/crates.io-index";
@@ -115,7 +144,7 @@ fn bad_coordinate(message: String) -> Response {
 
 /// Create axum router for Cargo registry endpoints
 pub fn cargo_routes(state: Arc<CargoRegistryState>) -> Router {
-    Router::new()
+    let public = Router::new()
         .route("/registry/cargo/config.json", get(config_json))
         .route("/registry/cargo/dl/{name}/{version}", get(download_crate))
         // Cargo sparse index: 1-char names under /1/, 2-char under /2/,
@@ -126,9 +155,22 @@ pub fn cargo_routes(state: Arc<CargoRegistryState>) -> Router {
         .route(
             "/registry/cargo/{prefix1}/{prefix2}/{name}",
             get(index_lookup),
+        );
+
+    // Authentication executes before the Bytes extractor can poll or buffer
+    // the body. The explicit route limit raises Axum's much smaller default to
+    // the registry's documented 50 MiB cap while still bounding chunked bodies.
+    let writes = Router::new()
+        .route(
+            "/registry/cargo/api/v1/crates/publish",
+            post(publish_crate).layer(DefaultBodyLimit::max(MAX_CRATE_SIZE)),
         )
-        .route("/registry/cargo/api/v1/crates/publish", post(publish_crate))
-        .with_state(state)
+        .route_layer(middleware::from_fn_with_state(
+            Arc::clone(&state),
+            authorize_cargo_publish,
+        ));
+
+    Router::new().merge(public).merge(writes).with_state(state)
 }
 
 /// GET /registry/cargo/config.json
@@ -155,6 +197,8 @@ async fn index_lookup(
     if let Err(message) = validate_cargo_manifest_path(&state.manifest_store, name) {
         return bad_coordinate(message);
     }
+
+    let _read_guard = state.publish_gate.read().await;
 
     // The manifest is the sparse index authority. Metadata extraction belongs
     // to authenticated publish/ingest; a GET must never rebuild or mutate the
@@ -190,6 +234,7 @@ async fn download_crate(
     if let Err(message) = validate_cargo_manifest_path(&state.manifest_store, &name) {
         return bad_coordinate(message);
     }
+    let _read_guard = state.publish_gate.read().await;
     let versions = match state.manifest_store.get_versions(Ecosystem::Cargo, &name) {
         Ok(v) => v,
         Err(_) => return StatusCode::NOT_FOUND.into_response(),
@@ -239,48 +284,58 @@ fn constant_time_eq(a: &[u8], b: &[u8]) -> bool {
     diff == 0
 }
 
-/// Authorize a publish request against the configured shared secret.
-///
-/// Fail-closed contract:
-/// - `publish_token == None` (env unset/empty) -> `503`, publishing disabled.
-/// - token configured but `Authorization` header missing/malformed/mismatched
-///   -> `401`.
-///
-/// On success returns `None`; otherwise returns the rejection response.
-fn authorize_publish(
-    state: &CargoRegistryState,
-    headers: &axum::http::HeaderMap,
-) -> Option<Response> {
+/// Authenticate Cargo writes before any body extractor runs.
+async fn authorize_cargo_publish(
+    State(state): State<Arc<CargoRegistryState>>,
+    request: Request<Body>,
+    next: Next,
+) -> Response {
     let Some(expected) = state.publish_token.as_deref() else {
-        return Some(
-            (
-                StatusCode::SERVICE_UNAVAILABLE,
-                Json(serde_json::json!({
-                    "error": "registry publishing is disabled: no token configured"
-                })),
-            )
-                .into_response(),
-        );
+        return (
+            StatusCode::SERVICE_UNAVAILABLE,
+            Json(serde_json::json!({
+                "error": "registry publishing is disabled: no token configured"
+            })),
+        )
+            .into_response();
     };
 
-    let provided = headers
-        .get(axum::http::header::AUTHORIZATION)
+    let provided = request
+        .headers()
+        .get(header::AUTHORIZATION)
         .and_then(|value| value.to_str().ok())
         .and_then(|value| value.strip_prefix("Bearer "))
-        .map(str::trim);
+        .map(str::trim)
+        .filter(|token| !token.is_empty());
 
-    match provided {
-        Some(token) if constant_time_eq(token.as_bytes(), expected.as_bytes()) => None,
-        _ => Some(
-            (
-                StatusCode::UNAUTHORIZED,
-                Json(serde_json::json!({
-                    "error": "invalid or missing publish token"
-                })),
-            )
-                .into_response(),
-        ),
+    if !provided.is_some_and(|token| constant_time_eq(token.as_bytes(), expected.as_bytes())) {
+        return (
+            StatusCode::UNAUTHORIZED,
+            Json(serde_json::json!({
+                "error": "invalid or missing publish token"
+            })),
+        )
+            .into_response();
     }
+
+    // Reject a declared oversize body without polling it. DefaultBodyLimit on
+    // the route remains authoritative for chunked/missing/forged lengths.
+    let declared = request
+        .headers()
+        .get(header::CONTENT_LENGTH)
+        .and_then(|value| value.to_str().ok())
+        .and_then(|value| value.parse::<u64>().ok());
+    if declared.is_some_and(|length| length > MAX_CRATE_SIZE as u64) {
+        return (
+            StatusCode::PAYLOAD_TOO_LARGE,
+            Json(serde_json::json!({
+                "error": format!("crate body exceeds the {MAX_CRATE_SIZE} byte limit")
+            })),
+        )
+            .into_response();
+    }
+
+    next.run(request).await
 }
 
 /// POST /registry/cargo/api/v1/crates/publish
@@ -302,15 +357,8 @@ fn authorize_publish(
 async fn publish_crate(
     State(state): State<Arc<CargoRegistryState>>,
     Query(params): Query<PublishParams>,
-    headers: axum::http::HeaderMap,
-    body: axum::body::Bytes,
+    body: Bytes,
 ) -> Response {
-    // Auth gate runs first so unauthorized callers learn nothing about the
-    // request body or registry contents.
-    if let Some(rejection) = authorize_publish(&state, &headers) {
-        return rejection;
-    }
-
     if let Err(message) = validate_cargo_coordinates(&params.name, &params.version) {
         return bad_coordinate(message);
     }
@@ -360,6 +408,13 @@ async fn publish_crate(
         Ok(path) => path,
         Err(message) => return bad_coordinate(message),
     };
+
+    // Parse metadata before entering the short storage critical section. The
+    // write side serializes the subsequent manifest check + blob write +
+    // manifest append against every other publish in this registry. Readers
+    // hold the read side across their corresponding manifest/blob reads.
+    let metadata = extract_crate_metadata(&body, &params.name, &params.version);
+    let _write_guard = state.publish_gate.write().await;
 
     let existing_versions = match state
         .manifest_store
@@ -419,9 +474,6 @@ async fn publish_crate(
         )
             .into_response();
     }
-
-    // Extract features and deps from the .crate tarball's Cargo.toml
-    let metadata = extract_crate_metadata(&body, &params.name, &params.version);
 
     // Register the version in the manifest store
     let pkg_version = PackageVersion {
@@ -829,12 +881,12 @@ mod tests {
     ) -> (tempfile::TempDir, Arc<CargoRegistryState>) {
         let root = tempfile::tempdir().unwrap();
         std::fs::create_dir_all(root.path().join(".kin")).unwrap();
-        let state = Arc::new(CargoRegistryState {
-            manifest_store: ManifestStore::new(&root.path().join(".kin")),
-            blobs_dir: root.path().join("cargo"),
-            base_url: "https://kinlab.ai".to_string(),
-            publish_token: publish_token.map(String::from),
-        });
+        let state = Arc::new(CargoRegistryState::new(
+            ManifestStore::new(&root.path().join(".kin")),
+            root.path().join("cargo"),
+            "https://kinlab.ai".to_string(),
+            publish_token.map(String::from),
+        ));
         (root, state)
     }
 
@@ -1095,6 +1147,43 @@ kin-blobs = { version = "0.1.0", registry = "kin", features = ["schema"] }
         build_test_crate(name, version, &cargo_toml)
     }
 
+    fn valid_crate_with_padding(name: &str, version: &str, padding_len: usize) -> Vec<u8> {
+        use flate2::{write::GzEncoder, Compression};
+
+        let encoder = GzEncoder::new(Vec::new(), Compression::none());
+        let mut builder = tar::Builder::new(encoder);
+        let cargo_toml =
+            format!("[package]\nname = \"{name}\"\nversion = \"{version}\"\nedition = \"2021\"\n");
+
+        let mut manifest_header = tar::Header::new_gnu();
+        manifest_header.set_size(cargo_toml.len() as u64);
+        manifest_header.set_mode(0o644);
+        manifest_header.set_cksum();
+        builder
+            .append_data(
+                &mut manifest_header,
+                format!("{name}-{version}/Cargo.toml"),
+                cargo_toml.as_bytes(),
+            )
+            .unwrap();
+
+        let padding = vec![b'x'; padding_len];
+        let mut padding_header = tar::Header::new_gnu();
+        padding_header.set_size(padding.len() as u64);
+        padding_header.set_mode(0o644);
+        padding_header.set_cksum();
+        builder
+            .append_data(
+                &mut padding_header,
+                format!("{name}-{version}/payload.bin"),
+                padding.as_slice(),
+            )
+            .unwrap();
+
+        let encoder = builder.into_inner().unwrap();
+        encoder.finish().unwrap()
+    }
+
     /// Build a `POST .../publish` request with the given query, optional Bearer
     /// token, and raw body bytes.
     fn publish_request(
@@ -1164,6 +1253,64 @@ kin-blobs = { version = "0.1.0", registry = "kin", features = ["schema"] }
         )
         .await;
         assert_eq!(wrong, StatusCode::UNAUTHORIZED);
+    }
+
+    #[tokio::test]
+    async fn auth_precedes_extraction_and_the_50_mib_limit_bounds_chunked_bodies() {
+        let (_root, state) = registry_state_with_token(Some("s3cret"));
+
+        // No Content-Length: the body extractor's explicit DefaultBodyLimit is
+        // the only size authority. Invalid auth must still win before that
+        // extractor polls or buffers the oversized body.
+        let unauthorized = cargo_routes(state.clone())
+            .oneshot(publish_request(
+                "demo",
+                "0.1.0",
+                Some("wrong"),
+                vec![b'x'; MAX_CRATE_SIZE + 1],
+            ))
+            .await
+            .unwrap();
+        assert_eq!(unauthorized.status(), StatusCode::UNAUTHORIZED);
+        drop(unauthorized);
+
+        let oversized = cargo_routes(state)
+            .oneshot(publish_request(
+                "demo",
+                "0.1.0",
+                Some("s3cret"),
+                vec![b'x'; MAX_CRATE_SIZE + 1],
+            ))
+            .await
+            .unwrap();
+        assert_eq!(oversized.status(), StatusCode::PAYLOAD_TOO_LARGE);
+    }
+
+    #[tokio::test]
+    async fn declared_oversize_publish_is_rejected_without_reading_the_body() {
+        let (_root, state) = registry_state_with_token(Some("s3cret"));
+        let response = cargo_routes(state)
+            .oneshot(
+                Request::post("/registry/cargo/api/v1/crates/publish?name=demo&version=0.1.0")
+                    .header("authorization", "Bearer s3cret")
+                    .header(header::CONTENT_LENGTH, MAX_CRATE_SIZE + 1)
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(response.status(), StatusCode::PAYLOAD_TOO_LARGE);
+    }
+
+    #[tokio::test]
+    async fn publish_above_axum_default_but_below_registry_limit_succeeds() {
+        let (_root, state) = registry_state_with_token(Some("s3cret"));
+        let body = valid_crate_with_padding("demo", "0.1.0", 3 * 1024 * 1024);
+        assert!(body.len() > 2 * 1024 * 1024);
+        assert!(body.len() < MAX_CRATE_SIZE);
+
+        let status = publish(state, "demo", "0.1.0", Some("s3cret"), body).await;
+        assert_eq!(status, StatusCode::OK);
     }
 
     #[tokio::test]
@@ -1243,6 +1390,114 @@ kin-blobs = { version = "0.1.0", registry = "kin", features = ["schema"] }
 
         let blob_path = state.blobs_dir.join("demo-0.1.0.crate");
         assert_eq!(std::fs::read(blob_path).unwrap(), original);
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+    async fn concurrent_conflicting_publishes_commit_exactly_one_matching_artifact() {
+        let (_root, state) = registry_state_with_token(Some("s3cret"));
+        let first = build_test_crate(
+            "demo",
+            "0.1.0",
+            "[package]\nname = \"demo\"\nversion = \"0.1.0\"\nedition = \"2021\"\ndescription = \"first\"\n",
+        );
+        let second = build_test_crate(
+            "demo",
+            "0.1.0",
+            "[package]\nname = \"demo\"\nversion = \"0.1.0\"\nedition = \"2021\"\ndescription = \"second\"\n",
+        );
+        let first_checksum = hex::encode(Sha256::digest(&first));
+        let second_checksum = hex::encode(Sha256::digest(&second));
+        assert_ne!(first_checksum, second_checksum);
+
+        let start = Arc::new(tokio::sync::Barrier::new(3));
+        let first_task = {
+            let state = state.clone();
+            let start = start.clone();
+            let body = first.clone();
+            tokio::spawn(async move {
+                start.wait().await;
+                publish(state, "demo", "0.1.0", Some("s3cret"), body).await
+            })
+        };
+        let second_task = {
+            let state = state.clone();
+            let start = start.clone();
+            let body = second.clone();
+            tokio::spawn(async move {
+                start.wait().await;
+                publish(state, "demo", "0.1.0", Some("s3cret"), body).await
+            })
+        };
+        start.wait().await;
+
+        let statuses = [first_task.await.unwrap(), second_task.await.unwrap()];
+        assert_eq!(
+            statuses
+                .iter()
+                .filter(|status| **status == StatusCode::OK)
+                .count(),
+            1
+        );
+        assert_eq!(
+            statuses
+                .iter()
+                .filter(|status| **status == StatusCode::CONFLICT)
+                .count(),
+            1
+        );
+
+        let versions = state
+            .manifest_store
+            .get_versions(Ecosystem::Cargo, "demo")
+            .unwrap();
+        assert_eq!(versions.len(), 1);
+        let committed_checksum = &versions[0].checksum;
+        assert!(
+            committed_checksum == &first_checksum || committed_checksum == &second_checksum,
+            "unexpected committed checksum {committed_checksum}"
+        );
+
+        let blob_path = state.blobs_dir.join("demo-0.1.0.crate");
+        let stored = std::fs::read(&blob_path).unwrap();
+        assert_eq!(hex::encode(Sha256::digest(&stored)), *committed_checksum);
+        let committed_body = if committed_checksum == &first_checksum {
+            &first
+        } else {
+            &second
+        };
+        assert_eq!(&stored, committed_body);
+
+        let index_response = cargo_routes(state.clone())
+            .oneshot(
+                Request::get("/registry/cargo/de/mo/demo")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(index_response.status(), StatusCode::OK);
+        let index_body = axum::body::to_bytes(index_response.into_body(), usize::MAX)
+            .await
+            .unwrap();
+        let lines = String::from_utf8(index_body.to_vec()).unwrap();
+        let entries = lines.lines().collect::<Vec<_>>();
+        assert_eq!(entries.len(), 1);
+        let entry: serde_json::Value = serde_json::from_str(entries[0]).unwrap();
+        assert_eq!(entry["cksum"].as_str(), Some(committed_checksum.as_str()));
+
+        let download_response = cargo_routes(state)
+            .oneshot(
+                Request::get("/registry/cargo/dl/demo/0.1.0")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(download_response.status(), StatusCode::OK);
+        let downloaded = axum::body::to_bytes(download_response.into_body(), MAX_CRATE_SIZE)
+            .await
+            .unwrap();
+        assert_eq!(downloaded.as_ref(), committed_body.as_slice());
     }
 
     #[tokio::test]

--- a/crates/kin-registry/src/cargo.rs
+++ b/crates/kin-registry/src/cargo.rs
@@ -89,6 +89,8 @@ const CRATES_IO_INDEX_URL: &str = "https://github.com/rust-lang/crates.io-index"
 const MAX_CRATE_SIZE: usize = 50 * 1024 * 1024;
 const MAX_CRATE_ARCHIVE_ENTRIES: usize = 4096;
 const MAX_CRATE_ARCHIVE_SCAN_SIZE: u64 = 256 * 1024 * 1024;
+const MAX_CRATE_ARCHIVE_DECOMPRESSED_SIZE: u64 =
+    MAX_CRATE_ARCHIVE_SCAN_SIZE + (MAX_CRATE_ARCHIVE_ENTRIES as u64 * 1024) + 1024;
 const MAX_CRATE_MANIFEST_SIZE: u64 = 1024 * 1024;
 const MAX_CRATE_NAME_LEN: usize = 64;
 
@@ -472,12 +474,28 @@ async fn publish_crate(
     // Cargo.toml budgets. Coordinate verification and sparse-index extraction
     // consume the same parsed manifest so an authorized gzip bomb cannot make
     // the daemon walk an unbounded archive twice.
-    let crate_manifest = match parse_crate_manifest(&body, &params.name, &params.version) {
-        Ok(manifest) => manifest,
-        Err(message) => {
+    let parse_body = body.clone();
+    let parse_name = params.name.clone();
+    let parse_version = params.version.clone();
+    let crate_manifest = match tokio::task::spawn_blocking(move || {
+        parse_crate_manifest(&parse_body, &parse_name, &parse_version)
+    })
+    .await
+    {
+        Ok(Ok(manifest)) => manifest,
+        Ok(Err(message)) => {
             return (
                 StatusCode::BAD_REQUEST,
                 Json(serde_json::json!({ "error": message })),
+            )
+                .into_response();
+        }
+        Err(error) => {
+            return (
+                StatusCode::INTERNAL_SERVER_ERROR,
+                Json(serde_json::json!({
+                    "error": format!("crate validation task failed: {error}"),
+                })),
             )
                 .into_response();
         }
@@ -704,12 +722,27 @@ fn parse_crate_manifest(
     name: &str,
     version: &str,
 ) -> Result<toml::Value, String> {
+    parse_crate_manifest_with_limit(
+        crate_bytes,
+        name,
+        version,
+        MAX_CRATE_ARCHIVE_DECOMPRESSED_SIZE,
+    )
+}
+
+fn parse_crate_manifest_with_limit(
+    crate_bytes: &[u8],
+    name: &str,
+    version: &str,
+    decompressed_limit: u64,
+) -> Result<toml::Value, String> {
     use flate2::bufread::GzDecoder;
     use std::io::Read;
 
     let expected_manifest = format!("{}-{}/Cargo.toml", name, version);
     let gz = GzDecoder::new(std::io::BufReader::new(crate_bytes));
-    let mut archive = tar::Archive::new(gz);
+    let limited = gz.take(decompressed_limit.saturating_add(1));
+    let mut archive = tar::Archive::new(limited);
 
     let entries = archive
         .entries()
@@ -767,9 +800,15 @@ fn parse_crate_manifest(
         }
     }
 
-    let mut decoder = archive.into_inner();
-    std::io::copy(&mut decoder, &mut std::io::sink())
+    let mut limited = archive.into_inner();
+    std::io::copy(&mut limited, &mut std::io::sink())
         .map_err(|error| format!("crate gzip stream is truncated: {error}"))?;
+    if limited.limit() == 0 {
+        return Err(format!(
+            "crate archive exceeds the {decompressed_limit} byte decompressed limit"
+        ));
+    }
+    let decoder = limited.into_inner();
     let compressed = decoder.into_inner();
     if !compressed.buffer().is_empty() || !compressed.get_ref().is_empty() {
         return Err("crate contains trailing data or more than one gzip member".to_string());
@@ -2034,6 +2073,33 @@ private = { version = "1", registry = "corp" }
         let manifest_first_bomb = encoder.finish().unwrap();
         let error = parse_crate_manifest(&manifest_first_bomb, "demo", "1.0.0").unwrap_err();
         assert!(error.contains("scan limit"), "{error}");
+    }
+
+    #[test]
+    fn crate_archive_bounds_bytes_after_the_tar_end_marker() {
+        use flate2::{write::GzEncoder, Compression};
+        use std::io::Write;
+
+        let manifest = b"[package]\nname = \"demo\"\nversion = \"1.0.0\"\n";
+        let mut builder = tar::Builder::new(Vec::new());
+        let mut header = tar::Header::new_gnu();
+        header.set_size(manifest.len() as u64);
+        header.set_mode(0o644);
+        header.set_cksum();
+        builder
+            .append_data(&mut header, "demo-1.0.0/Cargo.toml", manifest.as_slice())
+            .unwrap();
+        builder.finish().unwrap();
+        let mut uncompressed = builder.into_inner().unwrap();
+        let decompressed_limit = uncompressed.len() as u64 + 64;
+        uncompressed.resize(uncompressed.len() + 4096, 0);
+
+        let mut encoder = GzEncoder::new(Vec::new(), Compression::default());
+        encoder.write_all(&uncompressed).unwrap();
+        let body = encoder.finish().unwrap();
+        let error = parse_crate_manifest_with_limit(&body, "demo", "1.0.0", decompressed_limit)
+            .unwrap_err();
+        assert!(error.contains("decompressed limit"), "{error}");
     }
 
     #[test]

--- a/crates/kin-registry/src/cargo.rs
+++ b/crates/kin-registry/src/cargo.rs
@@ -20,6 +20,7 @@ use axum::{
 use chrono::Utc;
 use serde::{Deserialize, Serialize};
 use sha2::{Digest, Sha256};
+use std::path::{Path as FsPath, PathBuf};
 use std::sync::Arc;
 
 use crate::{Ecosystem, ManifestStore, PackageId, PackageVersion};
@@ -44,6 +45,73 @@ const CRATES_IO_INDEX_URL: &str = "https://github.com/rust-lang/crates.io-index"
 
 /// Maximum accepted `.crate` upload size (50 MiB), matching crates.io's cap.
 const MAX_CRATE_SIZE: usize = 50 * 1024 * 1024;
+const MAX_CRATE_NAME_LEN: usize = 64;
+
+/// Validate a Cargo registry package name before it can reach either the blob
+/// path or the manifest store. This is deliberately at least as strict as the
+/// crates.io publish boundary: an ASCII letter first, then only ASCII letters,
+/// digits, `-`, or `_`, with a 64-byte maximum.
+fn validate_cargo_name(name: &str) -> Result<(), String> {
+    if name.is_empty() || name.len() > MAX_CRATE_NAME_LEN {
+        return Err(format!(
+            "crate name must contain 1 to {MAX_CRATE_NAME_LEN} ASCII characters"
+        ));
+    }
+    let mut bytes = name.bytes();
+    if !bytes.next().is_some_and(|byte| byte.is_ascii_alphabetic())
+        || !bytes.all(|byte| byte.is_ascii_alphanumeric() || matches!(byte, b'-' | b'_'))
+    {
+        return Err(
+            "crate name must start with an ASCII letter and contain only ASCII letters, digits, '-' or '_'"
+                .to_string(),
+        );
+    }
+    Ok(())
+}
+
+fn validate_cargo_version(version: &str) -> Result<(), String> {
+    semver::Version::parse(version)
+        .map(|_| ())
+        .map_err(|error| format!("crate version must be valid SemVer: {error}"))
+}
+
+fn validate_cargo_coordinates(name: &str, version: &str) -> Result<(), String> {
+    validate_cargo_name(name)?;
+    validate_cargo_version(version)
+}
+
+fn validate_cargo_manifest_path(store: &ManifestStore, name: &str) -> Result<(), String> {
+    validate_cargo_name(name)?;
+    let id = PackageId {
+        ecosystem: Ecosystem::Cargo,
+        scope: None,
+        name: name.to_string(),
+    };
+    store
+        .manifest_path_is_direct_child(&id)
+        .then_some(())
+        .ok_or_else(|| "crate manifest path escaped the Cargo manifest directory".to_string())
+}
+
+/// Build the only Cargo blob path shape accepted by this adapter. Coordinate
+/// validation forbids separators and dot components; the parent equality check
+/// is a second, structural containment proof that fails before any IO.
+fn cargo_blob_path(blobs_dir: &FsPath, name: &str, version: &str) -> Result<PathBuf, String> {
+    validate_cargo_coordinates(name, version)?;
+    let path = blobs_dir.join(format!("{name}-{version}.crate"));
+    if path.parent() != Some(blobs_dir) {
+        return Err("crate blob path escaped the configured blob directory".to_string());
+    }
+    Ok(path)
+}
+
+fn bad_coordinate(message: String) -> Response {
+    (
+        StatusCode::BAD_REQUEST,
+        Json(serde_json::json!({ "error": message })),
+    )
+        .into_response()
+}
 
 /// Create axum router for Cargo registry endpoints
 pub fn cargo_routes(state: Arc<CargoRegistryState>) -> Router {
@@ -84,6 +152,9 @@ async fn index_lookup(
 ) -> Response {
     // Extract the package name (last path segment)
     let name = params.last().map(|(_, v)| v.as_str()).unwrap_or("");
+    if let Err(message) = validate_cargo_manifest_path(&state.manifest_store, name) {
+        return bad_coordinate(message);
+    }
 
     // The manifest is the sparse index authority. Metadata extraction belongs
     // to authenticated publish/ingest; a GET must never rebuild or mutate the
@@ -112,6 +183,13 @@ async fn download_crate(
     State(state): State<Arc<CargoRegistryState>>,
     Path((name, version)): Path<(String, String)>,
 ) -> Response {
+    let crate_path = match cargo_blob_path(&state.blobs_dir, &name, &version) {
+        Ok(path) => path,
+        Err(message) => return bad_coordinate(message),
+    };
+    if let Err(message) = validate_cargo_manifest_path(&state.manifest_store, &name) {
+        return bad_coordinate(message);
+    }
     let versions = match state.manifest_store.get_versions(Ecosystem::Cargo, &name) {
         Ok(v) => v,
         Err(_) => return StatusCode::NOT_FOUND.into_response(),
@@ -123,7 +201,6 @@ async fn download_crate(
     };
 
     // Read the .crate file from blob store
-    let crate_path = state.blobs_dir.join(format!("{}-{}.crate", name, version));
     match std::fs::read(&crate_path) {
         Ok(bytes) => (
             StatusCode::OK,
@@ -234,12 +311,11 @@ async fn publish_crate(
         return rejection;
     }
 
-    if params.name.is_empty() || params.version.is_empty() {
-        return (
-            StatusCode::BAD_REQUEST,
-            Json(serde_json::json!({ "error": "name and version are required" })),
-        )
-            .into_response();
+    if let Err(message) = validate_cargo_coordinates(&params.name, &params.version) {
+        return bad_coordinate(message);
+    }
+    if let Err(message) = validate_cargo_manifest_path(&state.manifest_store, &params.name) {
+        return bad_coordinate(message);
     }
 
     // Reject an empty upload before touching the filesystem.
@@ -280,9 +356,10 @@ async fn publish_crate(
     // Compute SHA-256 checksum of the .crate bytes
     let checksum = hex::encode(Sha256::digest(&body));
 
-    let crate_path = state
-        .blobs_dir
-        .join(format!("{}-{}.crate", params.name, params.version));
+    let crate_path = match cargo_blob_path(&state.blobs_dir, &params.name, &params.version) {
+        Ok(path) => path,
+        Err(message) => return bad_coordinate(message),
+    };
 
     let existing_versions = match state
         .manifest_store
@@ -396,6 +473,12 @@ fn write_crate_blob(
     crate_path: &std::path::Path,
     body: &[u8],
 ) -> std::io::Result<()> {
+    if crate_path.parent() != Some(blobs_dir) {
+        return Err(std::io::Error::new(
+            std::io::ErrorKind::InvalidInput,
+            "crate blob path escaped the configured blob directory",
+        ));
+    }
     std::fs::create_dir_all(blobs_dir)?;
     std::fs::write(crate_path, body)
 }
@@ -848,7 +931,7 @@ kin-blobs = { version = "0.1.0", registry = "kin", features = ["schema"] }
         assert_eq!(manifest_after[0].metadata, manifest_before[0].metadata);
     }
 
-    #[tokio::test]
+    #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
     async fn concurrent_sparse_reads_cannot_erase_a_published_version() {
         let (_root, state) = registry_state_with_token(Some("s3cret"));
         std::fs::create_dir_all(&state.blobs_dir).unwrap();
@@ -877,30 +960,49 @@ kin-blobs = { version = "0.1.0", registry = "kin", features = ["schema"] }
             })
             .unwrap();
 
-        let reads = async {
-            for _ in 0..64 {
-                let response = cargo_routes(state.clone())
-                    .oneshot(
-                        Request::get("/registry/cargo/de/mo/demo")
-                            .body(Body::empty())
-                            .unwrap(),
-                    )
-                    .await
-                    .unwrap();
-                assert_eq!(response.status(), StatusCode::OK);
-                tokio::task::yield_now().await;
-            }
-        };
-        let publish_second = publish(
-            state.clone(),
-            "demo",
-            "0.2.0",
-            Some("s3cret"),
-            valid_crate("demo", "0.2.0"),
-        );
+        let reader_count = 8;
+        let start = Arc::new(tokio::sync::Barrier::new(reader_count + 2));
+        let mut readers = tokio::task::JoinSet::new();
+        for _ in 0..reader_count {
+            let state = state.clone();
+            let start = start.clone();
+            readers.spawn(async move {
+                start.wait().await;
+                for _ in 0..32 {
+                    let response = cargo_routes(state.clone())
+                        .oneshot(
+                            Request::get("/registry/cargo/de/mo/demo")
+                                .body(Body::empty())
+                                .unwrap(),
+                        )
+                        .await
+                        .unwrap();
+                    assert_eq!(response.status(), StatusCode::OK);
+                    tokio::task::yield_now().await;
+                }
+            });
+        }
 
-        let (_, status) = tokio::join!(reads, publish_second);
+        let publish_state = state.clone();
+        let publish_start = start.clone();
+        let publisher = tokio::spawn(async move {
+            publish_start.wait().await;
+            publish(
+                publish_state,
+                "demo",
+                "0.2.0",
+                Some("s3cret"),
+                valid_crate("demo", "0.2.0"),
+            )
+            .await
+        });
+        start.wait().await;
+
+        let status = publisher.await.unwrap();
         assert_eq!(status, StatusCode::OK);
+        while let Some(result) = readers.join_next().await {
+            result.unwrap();
+        }
 
         let versions = state
             .manifest_store
@@ -914,6 +1016,76 @@ kin-blobs = { version = "0.1.0", registry = "kin", features = ["schema"] }
             vec!["0.1.0", "0.2.0"]
         );
         assert_eq!(versions[0].metadata, serde_json::json!({}));
+    }
+
+    #[test]
+    fn cargo_coordinates_are_semver_valid_and_paths_stay_contained() {
+        let root = tempfile::tempdir().unwrap();
+        let blobs = root.path().join("cargo");
+        let manifests = ManifestStore::new(&root.path().join(".kin"));
+        std::fs::create_dir_all(&blobs).unwrap();
+
+        for (name, version) in [("demo", "0.1.0"), ("kin_registry", "1.2.3-alpha.1+build.9")] {
+            let path = cargo_blob_path(&blobs, name, version).unwrap();
+            assert_eq!(path.parent(), Some(blobs.as_path()));
+            validate_cargo_manifest_path(&manifests, name).unwrap();
+        }
+
+        for name in [
+            "",
+            ".",
+            "..",
+            "../outside",
+            "demo/outside",
+            "demo%2foutside",
+            "-demo",
+        ] {
+            assert!(validate_cargo_name(name).is_err(), "accepted {name:?}");
+        }
+        for version in ["", ".", "..", "../1.0.0", "1", "1.0", "01.0.0"] {
+            assert!(
+                validate_cargo_version(version).is_err(),
+                "accepted {version:?}"
+            );
+        }
+    }
+
+    #[tokio::test]
+    async fn traversal_coordinates_never_touch_blob_or_manifest_paths() {
+        let (root, state) = registry_state_with_token(Some("s3cret"));
+        let sentinel = root.path().join("outside");
+        std::fs::write(&sentinel, b"unchanged").unwrap();
+
+        for uri in [
+            "/registry/cargo/api/v1/crates/publish?name=..%2Foutside&version=0.1.0",
+            "/registry/cargo/api/v1/crates/publish?name=demo&version=..%2Foutside",
+        ] {
+            let response = cargo_routes(state.clone())
+                .oneshot(
+                    Request::post(uri)
+                        .header("authorization", "Bearer s3cret")
+                        .body(Body::from(b"not consulted".as_slice()))
+                        .unwrap(),
+                )
+                .await
+                .unwrap();
+            assert_eq!(response.status(), StatusCode::BAD_REQUEST);
+        }
+
+        let sparse = cargo_routes(state.clone())
+            .oneshot(
+                Request::get("/registry/cargo/1/%2e%2e")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_ne!(sparse.status(), StatusCode::OK);
+
+        assert_eq!(std::fs::read(&sentinel).unwrap(), b"unchanged");
+        assert!(!root.path().join("outside-0.1.0.crate").exists());
+        assert!(!state.blobs_dir.join("outside.crate").exists());
+        assert!(!root.path().join(".kin/packages/manifests/outside").exists());
     }
 
     /// Build a valid `.crate` blob for a simple `[package]` manifest.

--- a/crates/kin-registry/src/cargo.rs
+++ b/crates/kin-registry/src/cargo.rs
@@ -61,6 +61,7 @@ impl CargoRegistryState {
         base_url: String,
         publish_token: Option<String>,
     ) -> Self {
+        let blobs_dir = crate::atomic_file::pin_authority_root(&blobs_dir).unwrap_or(blobs_dir);
         Self {
             manifest_store,
             blobs_dir,
@@ -211,7 +212,11 @@ async fn index_lookup(
     }
 
     let _read_guard = state.publish_gate.read().await;
-    let transaction = match state.manifest_store.read_transaction(Ecosystem::Cargo) {
+    let transaction = match state
+        .manifest_store
+        .read_transaction_async(Ecosystem::Cargo)
+        .await
+    {
         Ok(transaction) => transaction,
         Err(error) => {
             return (
@@ -286,7 +291,11 @@ async fn download_crate(
         return bad_coordinate(message);
     }
     let _read_guard = state.publish_gate.read().await;
-    let transaction = match state.manifest_store.read_transaction(Ecosystem::Cargo) {
+    let transaction = match state
+        .manifest_store
+        .read_transaction_async(Ecosystem::Cargo)
+        .await
+    {
         Ok(transaction) => transaction,
         Err(_) => return StatusCode::INTERNAL_SERVER_ERROR.into_response(),
     };
@@ -492,7 +501,11 @@ async fn publish_crate(
         }
     };
     let _write_guard = state.publish_gate.write().await;
-    let transaction = match state.manifest_store.write_transaction(Ecosystem::Cargo) {
+    let transaction = match state
+        .manifest_store
+        .write_transaction_async(Ecosystem::Cargo)
+        .await
+    {
         Ok(transaction) => transaction,
         Err(error) => {
             return (
@@ -671,6 +684,7 @@ fn parse_crate_manifest(
         .map_err(|e| format!("crate is not a valid gzip-tar archive: {e}"))?;
 
     let mut cargo_toml_content = String::new();
+    let mut manifest_seen = false;
     let mut scanned_size = 0u64;
     for (index, entry) in entries.enumerate() {
         if index >= MAX_CRATE_ARCHIVE_ENTRIES {
@@ -698,6 +712,12 @@ fn parse_crate_manifest(
             .map(|path| path.to_str() == Some(&expected_manifest))
             .unwrap_or(false);
         if is_manifest {
+            if manifest_seen {
+                return Err(format!(
+                    "crate contains more than one authoritative {expected_manifest}"
+                ));
+            }
+            manifest_seen = true;
             if entry_size > MAX_CRATE_MANIFEST_SIZE {
                 return Err(format!(
                     "crate Cargo.toml exceeds the {MAX_CRATE_MANIFEST_SIZE} byte limit"
@@ -712,11 +732,10 @@ fn parse_crate_manifest(
                     "crate Cargo.toml exceeds the {MAX_CRATE_MANIFEST_SIZE} byte limit"
                 ));
             }
-            break;
         }
     }
 
-    if cargo_toml_content.is_empty() {
+    if !manifest_seen {
         return Err(format!("crate does not contain {expected_manifest}"));
     }
 
@@ -1926,6 +1945,52 @@ private = { version = "1", registry = "corp" }
             archive_with_declared_entry("demo-1.0.0/padding", MAX_CRATE_ARCHIVE_SCAN_SIZE + 1);
         let error = parse_crate_manifest(&oversized_scan, "demo", "1.0.0").unwrap_err();
         assert!(error.contains("scan limit"), "{error}");
+
+        let manifest = b"[package]\nname = \"demo\"\nversion = \"1.0.0\"\n";
+        let mut uncompressed = Vec::new();
+        let mut manifest_header = tar::Header::new_gnu();
+        manifest_header.set_path("demo-1.0.0/Cargo.toml").unwrap();
+        manifest_header.set_size(manifest.len() as u64);
+        manifest_header.set_mode(0o644);
+        manifest_header.set_cksum();
+        uncompressed.extend_from_slice(manifest_header.as_bytes());
+        uncompressed.extend_from_slice(manifest);
+        uncompressed.resize(uncompressed.len().next_multiple_of(512), 0);
+        let mut trailing_header = tar::Header::new_gnu();
+        trailing_header
+            .set_path("demo-1.0.0/trailing-bomb")
+            .unwrap();
+        trailing_header.set_size(MAX_CRATE_ARCHIVE_SCAN_SIZE + 1);
+        trailing_header.set_mode(0o644);
+        trailing_header.set_cksum();
+        uncompressed.extend_from_slice(trailing_header.as_bytes());
+        let mut encoder = GzEncoder::new(Vec::new(), Compression::default());
+        encoder.write_all(&uncompressed).unwrap();
+        let manifest_first_bomb = encoder.finish().unwrap();
+        let error = parse_crate_manifest(&manifest_first_bomb, "demo", "1.0.0").unwrap_err();
+        assert!(error.contains("scan limit"), "{error}");
+    }
+
+    #[test]
+    fn crate_archive_rejects_duplicate_authoritative_manifests() {
+        use flate2::{write::GzEncoder, Compression};
+
+        let manifest = b"[package]\nname = \"demo\"\nversion = \"1.0.0\"\n";
+        let encoder = GzEncoder::new(Vec::new(), Compression::default());
+        let mut builder = tar::Builder::new(encoder);
+        for _ in 0..2 {
+            let mut header = tar::Header::new_gnu();
+            header.set_size(manifest.len() as u64);
+            header.set_mode(0o644);
+            header.set_cksum();
+            builder
+                .append_data(&mut header, "demo-1.0.0/Cargo.toml", manifest.as_slice())
+                .unwrap();
+        }
+        let encoder = builder.into_inner().unwrap();
+        let body = encoder.finish().unwrap();
+        let error = parse_crate_manifest(&body, "demo", "1.0.0").unwrap_err();
+        assert!(error.contains("more than one authoritative"), "{error}");
     }
 
     #[tokio::test]

--- a/crates/kin-registry/src/cargo.rs
+++ b/crates/kin-registry/src/cargo.rs
@@ -82,8 +82,10 @@ const MAX_CRATE_NAME_LEN: usize = 64;
 
 /// Validate a Cargo registry package name before it can reach either the blob
 /// path or the manifest store. This is deliberately at least as strict as the
-/// crates.io publish boundary: an ASCII letter first, then only ASCII letters,
-/// digits, `-`, or `_`, with a 64-byte maximum.
+/// crates.io publish boundary: a lowercase ASCII letter first, then only
+/// lowercase ASCII letters, digits, `-`, or `_`, with a 64-byte maximum.
+/// Rejecting uppercase avoids creating an index coordinate that Cargo later
+/// lowercases and therefore cannot resolve on a case-sensitive filesystem.
 fn validate_cargo_name(name: &str) -> Result<(), String> {
     if name.is_empty() || name.len() > MAX_CRATE_NAME_LEN {
         return Err(format!(
@@ -91,11 +93,13 @@ fn validate_cargo_name(name: &str) -> Result<(), String> {
         ));
     }
     let mut bytes = name.bytes();
-    if !bytes.next().is_some_and(|byte| byte.is_ascii_alphabetic())
-        || !bytes.all(|byte| byte.is_ascii_alphanumeric() || matches!(byte, b'-' | b'_'))
+    if !bytes.next().is_some_and(|byte| byte.is_ascii_lowercase())
+        || !bytes.all(|byte| {
+            byte.is_ascii_lowercase() || byte.is_ascii_digit() || matches!(byte, b'-' | b'_')
+        })
     {
         return Err(
-            "crate name must start with an ASCII letter and contain only ASCII letters, digits, '-' or '_'"
+            "crate name must start with a lowercase ASCII letter and contain only lowercase ASCII letters, digits, '-' or '_'"
                 .to_string(),
         );
     }
@@ -210,17 +214,44 @@ async fn index_lookup(
     let versions = match state.manifest_store.get_versions(Ecosystem::Cargo, name) {
         Ok(v) if v.is_empty() => return StatusCode::NOT_FOUND.into_response(),
         Ok(v) => v,
-        Err(_) => return StatusCode::NOT_FOUND.into_response(),
+        Err(error) => {
+            return (
+                StatusCode::INTERNAL_SERVER_ERROR,
+                Json(serde_json::json!({
+                    "error": format!("Cargo index manifest is unreadable: {error}")
+                })),
+            )
+                .into_response();
+        }
     };
 
     // Cargo expects newline-delimited JSON, one entry per version
     let mut body = String::new();
     for v in &versions {
-        let entry = CargoIndexEntry::from_version(v);
-        if let Ok(line) = serde_json::to_string(&entry) {
-            body.push_str(&line);
-            body.push('\n');
-        }
+        let entry = match CargoIndexEntry::try_from_version(v) {
+            Ok(entry) => entry,
+            Err(error) => {
+                return (
+                    StatusCode::INTERNAL_SERVER_ERROR,
+                    Json(serde_json::json!({ "error": error })),
+                )
+                    .into_response();
+            }
+        };
+        let line = match serde_json::to_string(&entry) {
+            Ok(line) => line,
+            Err(error) => {
+                return (
+                    StatusCode::INTERNAL_SERVER_ERROR,
+                    Json(serde_json::json!({
+                        "error": format!("failed to encode Cargo index entry: {error}")
+                    })),
+                )
+                    .into_response();
+            }
+        };
+        body.push_str(&line);
+        body.push('\n');
     }
 
     (StatusCode::OK, [("content-type", "text/plain")], body).into_response()
@@ -417,7 +448,16 @@ async fn publish_crate(
     // write side serializes the subsequent manifest check + blob write +
     // manifest append against every other publish in this registry. Readers
     // hold the read side across their corresponding manifest/blob reads.
-    let metadata = extract_crate_metadata(&body, &params.name, &params.version);
+    let metadata = match extract_crate_metadata(&body, &params.name, &params.version) {
+        Ok(metadata) => metadata,
+        Err(message) => {
+            return (
+                StatusCode::BAD_REQUEST,
+                Json(serde_json::json!({ "error": message })),
+            )
+                .into_response();
+        }
+    };
     let _write_guard = state.publish_gate.write().await;
 
     let existing_versions = match state
@@ -630,7 +670,11 @@ fn verify_crate_coordinates(crate_bytes: &[u8], name: &str, version: &str) -> Re
 /// .crate files are gzipped tarballs containing `{name}-{version}/Cargo.toml`.
 /// We parse this to extract features (for feature resolution) and dependencies
 /// (for the sparse index).
-fn extract_crate_metadata(crate_bytes: &[u8], name: &str, version: &str) -> serde_json::Value {
+fn extract_crate_metadata(
+    crate_bytes: &[u8],
+    name: &str,
+    version: &str,
+) -> Result<serde_json::Value, String> {
     use flate2::read::GzDecoder;
     use std::io::Read;
 
@@ -639,30 +683,38 @@ fn extract_crate_metadata(crate_bytes: &[u8], name: &str, version: &str) -> serd
     let mut archive = tar::Archive::new(gz);
 
     let mut cargo_toml_content = String::new();
-    if let Ok(entries) = archive.entries() {
-        for entry in entries.flatten() {
-            if let Ok(path) = entry.path() {
-                if path.to_str() == Some(&expected_manifest) {
-                    let mut entry = entry;
-                    if entry.read_to_string(&mut cargo_toml_content).is_ok() {
-                        break;
-                    }
-                }
-            }
+    let entries = archive
+        .entries()
+        .map_err(|error| format!("crate is not a valid gzip-tar archive: {error}"))?;
+    for entry in entries {
+        let mut entry =
+            entry.map_err(|error| format!("crate is not a valid gzip-tar archive: {error}"))?;
+        let path = entry
+            .path()
+            .map_err(|error| format!("crate contains an invalid path: {error}"))?;
+        if path.to_str() == Some(&expected_manifest) {
+            entry
+                .read_to_string(&mut cargo_toml_content)
+                .map_err(|error| format!("failed to read {expected_manifest}: {error}"))?;
+            break;
         }
     }
 
     if cargo_toml_content.is_empty() {
-        return serde_json::json!({});
+        return Err(format!("crate does not contain {expected_manifest}"));
     }
 
-    // Parse Cargo.toml to extract features and deps
-    let toml_value: toml::Value = match toml::from_str(&cargo_toml_content) {
-        Ok(v) => v,
-        Err(_) => return serde_json::json!({}),
-    };
+    // Parse Cargo.toml to extract features and deps. This metadata is the
+    // sparse-index authority, so an extraction failure must never be recorded
+    // as an authoritative empty dependency list.
+    let toml_value: toml::Value = toml::from_str(&cargo_toml_content)
+        .map_err(|error| format!("crate {expected_manifest} is not valid TOML: {error}"))?;
 
-    let mut metadata = serde_json::json!({});
+    let mut metadata = serde_json::json!({
+        "cargo_index_format": 1,
+        "features": {},
+        "deps": [],
+    });
 
     // Extract [features]
     if let Some(features) = toml_value.get("features") {
@@ -825,11 +877,9 @@ fn extract_crate_metadata(crate_bytes: &[u8], name: &str, version: &str) -> serd
         }
     }
 
-    if !deps.is_empty() {
-        metadata["deps"] = serde_json::Value::Array(deps);
-    }
+    metadata["deps"] = serde_json::Value::Array(deps);
 
-    metadata
+    Ok(metadata)
 }
 
 /// Cargo index entry format (one per version, newline-delimited JSON)
@@ -857,27 +907,54 @@ struct CargoIndexDep {
 }
 
 impl CargoIndexEntry {
-    fn from_version(v: &PackageVersion) -> Self {
-        // Extract deps from metadata if present
+    fn try_from_version(v: &PackageVersion) -> Result<Self, String> {
+        if v.metadata
+            .get("cargo_index_format")
+            .and_then(|value| value.as_u64())
+            != Some(1)
+        {
+            return Err(format!(
+                "Cargo index metadata for {}@{} is legacy or incomplete; re-publish or migrate the manifest before serving it",
+                v.id.name, v.version
+            ));
+        }
         let deps = v
             .metadata
             .get("deps")
-            .and_then(|d| serde_json::from_value::<Vec<CargoIndexDep>>(d.clone()).ok())
-            .unwrap_or_default();
+            .ok_or_else(|| {
+                format!(
+                    "Cargo index metadata for {}@{} has no dependency authority",
+                    v.id.name, v.version
+                )
+            })
+            .and_then(|deps| {
+                serde_json::from_value::<Vec<CargoIndexDep>>(deps.clone()).map_err(|error| {
+                    format!(
+                        "Cargo index metadata for {}@{} has invalid dependencies: {error}",
+                        v.id.name, v.version
+                    )
+                })
+            })?;
         let features = v
             .metadata
             .get("features")
             .cloned()
-            .unwrap_or_else(|| serde_json::json!({}));
+            .filter(serde_json::Value::is_object)
+            .ok_or_else(|| {
+                format!(
+                    "Cargo index metadata for {}@{} has invalid features",
+                    v.id.name, v.version
+                )
+            })?;
 
-        Self {
+        Ok(Self {
             name: v.id.name.clone(),
             vers: v.version.clone(),
             deps,
             cksum: v.checksum.clone(),
             features,
             yanked: v.yanked,
-        }
+        })
     }
 }
 
@@ -926,7 +1003,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn sparse_index_is_a_manifest_only_read_and_never_repairs_from_blob_bytes() {
+    async fn sparse_index_fails_loud_on_legacy_metadata_and_never_repairs_from_blob_bytes() {
         let (_root, state) = registry_state();
         std::fs::create_dir_all(&state.blobs_dir).unwrap();
 
@@ -980,15 +1057,16 @@ kin-blobs = { version = "0.1.0", registry = "kin", features = ["schema"] }
             )
             .await
             .unwrap();
-        assert_eq!(response.status(), StatusCode::OK);
+        assert_eq!(response.status(), StatusCode::INTERNAL_SERVER_ERROR);
 
         let body = axum::body::to_bytes(response.into_body(), usize::MAX)
             .await
             .unwrap();
-        let line = String::from_utf8(body.to_vec()).unwrap();
-        let index_entry: serde_json::Value = serde_json::from_str(line.trim()).unwrap();
-        let deps = index_entry["deps"].as_array().unwrap();
-        assert!(deps.is_empty());
+        let error: serde_json::Value = serde_json::from_slice(&body).unwrap();
+        assert!(error["error"]
+            .as_str()
+            .unwrap()
+            .contains("legacy or incomplete"));
 
         let manifest_after = state
             .manifest_store
@@ -1021,7 +1099,7 @@ kin-blobs = { version = "0.1.0", registry = "kin", features = ["schema"] }
                 blob_hash: "hash".to_string(),
                 blob_size: first_body.len() as u64,
                 checksum: "checksum".to_string(),
-                metadata: serde_json::json!({}),
+                metadata: extract_crate_metadata(&first_body, "demo", "0.1.0").unwrap(),
                 published_at: Utc::now(),
                 published_by: "legacy-test".to_string(),
                 yanked: false,
@@ -1083,7 +1161,7 @@ kin-blobs = { version = "0.1.0", registry = "kin", features = ["schema"] }
                 .collect::<Vec<_>>(),
             vec!["0.1.0", "0.2.0"]
         );
-        assert_eq!(versions[0].metadata, serde_json::json!({}));
+        assert_eq!(versions[0].metadata["cargo_index_format"].as_u64(), Some(1));
     }
 
     #[test]
@@ -1103,6 +1181,7 @@ kin-blobs = { version = "0.1.0", registry = "kin", features = ["schema"] }
             "",
             ".",
             "..",
+            "Demo",
             "../outside",
             "demo/outside",
             "demo%2foutside",
@@ -1116,6 +1195,30 @@ kin-blobs = { version = "0.1.0", registry = "kin", features = ["schema"] }
                 "accepted {version:?}"
             );
         }
+    }
+
+    #[tokio::test]
+    async fn uppercase_publish_is_rejected_before_case_sensitive_index_divergence() {
+        let (_root, state) = registry_state_with_token(Some("s3cret"));
+        let rejected = publish(
+            state.clone(),
+            "Demo",
+            "0.1.0",
+            Some("s3cret"),
+            valid_crate("Demo", "0.1.0"),
+        )
+        .await;
+        assert_eq!(rejected, StatusCode::BAD_REQUEST);
+
+        let lowercase_lookup = cargo_routes(state)
+            .oneshot(
+                Request::get("/registry/cargo/de/mo/demo")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(lowercase_lookup.status(), StatusCode::NOT_FOUND);
     }
 
     #[tokio::test]

--- a/crates/kin-registry/src/go.rs
+++ b/crates/kin-registry/src/go.rs
@@ -18,6 +18,7 @@ use axum::{
     routing::get,
     Router,
 };
+use std::path::{Path as FsPath, PathBuf};
 use std::sync::Arc;
 
 use crate::{Ecosystem, ManifestStore};
@@ -26,6 +27,49 @@ use crate::{Ecosystem, ManifestStore};
 pub struct GoProxyState {
     pub manifest_store: ManifestStore,
     pub blobs_dir: std::path::PathBuf,
+}
+
+const MAX_GO_MODULE_LEN: usize = 255;
+const MAX_GO_VERSION_LEN: usize = 128;
+
+fn valid_go_module(module: &str) -> bool {
+    if module.is_empty() || module.len() > MAX_GO_MODULE_LEN {
+        return false;
+    }
+    let bytes = module.as_bytes();
+    bytes
+        .first()
+        .is_some_and(|byte| byte.is_ascii_alphanumeric())
+        && bytes
+            .last()
+            .is_some_and(|byte| byte.is_ascii_alphanumeric())
+        && bytes
+            .iter()
+            .all(|byte| byte.is_ascii_alphanumeric() || matches!(byte, b'.' | b'-' | b'_' | b'!'))
+        && module != "."
+        && module != ".."
+}
+
+fn valid_go_version(version: &str) -> bool {
+    if version.is_empty() || version.len() > MAX_GO_VERSION_LEN || !version.starts_with('v') {
+        return false;
+    }
+    version
+        .bytes()
+        .all(|byte| byte.is_ascii_alphanumeric() || matches!(byte, b'.' | b'-' | b'+' | b'!'))
+        && !version.contains("..")
+}
+
+fn go_zip_path(blobs_dir: &FsPath, module: &str, version: &str) -> Option<PathBuf> {
+    if !valid_go_module(module) || !valid_go_version(version) {
+        return None;
+    }
+    let path = blobs_dir.join(format!("{module}-{version}.zip"));
+    (path.parent() == Some(blobs_dir)).then_some(path)
+}
+
+fn invalid_coordinate() -> Response {
+    (StatusCode::BAD_REQUEST, "invalid Go module coordinate").into_response()
 }
 
 /// Create axum router for Go module proxy endpoints
@@ -44,10 +88,16 @@ async fn version_dispatch(
     state: State<Arc<GoProxyState>>,
     Path((module, version_file)): Path<(String, String)>,
 ) -> Response {
+    if !valid_go_module(&module) {
+        return invalid_coordinate();
+    }
     let (version, ext) = match version_file.rsplit_once('.') {
         Some((v, e)) => (v.to_string(), e),
         None => return StatusCode::NOT_FOUND.into_response(),
     };
+    if !valid_go_version(&version) {
+        return invalid_coordinate();
+    }
     match ext {
         "info" => version_info_inner(state, &module, &version).await,
         "mod" => version_mod_inner(state, &module, &version).await,
@@ -61,6 +111,9 @@ async fn list_versions(
     State(state): State<Arc<GoProxyState>>,
     Path(module): Path<String>,
 ) -> Response {
+    if !valid_go_module(&module) {
+        return invalid_coordinate();
+    }
     let versions = match state.manifest_store.get_versions(Ecosystem::Go, &module) {
         Ok(v) => v,
         Err(_) => return StatusCode::NOT_FOUND.into_response(),
@@ -125,11 +178,105 @@ async fn version_zip_inner(
     module: &str,
     version: &str,
 ) -> Response {
-    let zip_path = state
-        .blobs_dir
-        .join(format!("{}-{}.zip", module.replace('/', "_"), version));
+    let Some(zip_path) = go_zip_path(&state.blobs_dir, module, version) else {
+        return invalid_coordinate();
+    };
     match std::fs::read(&zip_path) {
         Ok(bytes) => (StatusCode::OK, [("content-type", "application/zip")], bytes).into_response(),
         Err(_) => StatusCode::NOT_FOUND.into_response(),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use axum::{body::Body, http::Request};
+    use tower::ServiceExt;
+
+    fn state() -> (tempfile::TempDir, Arc<GoProxyState>) {
+        let root = tempfile::tempdir().unwrap();
+        let kin_dir = root.path().join(".kin");
+        let blobs_dir = root.path().join("go");
+        std::fs::create_dir_all(&kin_dir).unwrap();
+        std::fs::create_dir_all(&blobs_dir).unwrap();
+        (
+            root,
+            Arc::new(GoProxyState {
+                manifest_store: ManifestStore::new(&kin_dir),
+                blobs_dir,
+            }),
+        )
+    }
+
+    #[test]
+    fn zip_path_rejects_traversal_and_remains_a_direct_child() {
+        let root = tempfile::tempdir().unwrap();
+        let blobs = root.path().join("go");
+        std::fs::create_dir_all(&blobs).unwrap();
+
+        let valid = go_zip_path(&blobs, "example.com", "v1.2.3").unwrap();
+        assert_eq!(valid, blobs.join("example.com-v1.2.3.zip"));
+        assert_eq!(valid.parent(), Some(blobs.as_path()));
+
+        for (module, version) in [
+            ("..", "v1.2.3"),
+            ("../outside", "v1.2.3"),
+            ("example.com", "../../outside"),
+            ("example.com", "v1.2.3/../../outside"),
+            ("example.com", "v1.2.3\\outside"),
+            ("example.com", "v1..2"),
+        ] {
+            assert!(
+                go_zip_path(&blobs, module, version).is_none(),
+                "accepted {module:?}@{version:?}"
+            );
+        }
+    }
+
+    #[tokio::test]
+    async fn catch_all_version_route_cannot_read_outside_the_blob_directory() {
+        let (root, state) = state();
+        let sentinel = root.path().join("outside.zip");
+        std::fs::write(&sentinel, b"must-not-be-served").unwrap();
+
+        for uri in [
+            "/registry/go/example.com/@v/..%2F..%2Foutside.zip",
+            "/registry/go/example.com/@v/v1.2.3%5C..%5Coutside.zip",
+            "/registry/go/%2e%2e/@v/v1.2.3.zip",
+        ] {
+            let response = go_routes(state.clone())
+                .oneshot(Request::get(uri).body(Body::empty()).unwrap())
+                .await
+                .unwrap();
+            assert_ne!(response.status(), StatusCode::OK, "served {uri}");
+        }
+
+        assert_eq!(std::fs::read(sentinel).unwrap(), b"must-not-be-served");
+        assert!(std::fs::read_dir(&state.blobs_dir)
+            .unwrap()
+            .next()
+            .is_none());
+    }
+
+    #[tokio::test]
+    async fn validated_go_zip_reads_remain_public() {
+        let (_root, state) = state();
+        let bytes = b"valid-public-module-zip";
+        let path = go_zip_path(&state.blobs_dir, "example.com", "v1.2.3").unwrap();
+        std::fs::write(path, bytes).unwrap();
+
+        let response = go_routes(state)
+            .oneshot(
+                Request::get("/registry/go/example.com/@v/v1.2.3.zip")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(response.status(), StatusCode::OK);
+        let observed = axum::body::to_bytes(response.into_body(), 1024)
+            .await
+            .unwrap();
+        assert_eq!(observed.as_ref(), bytes);
     }
 }

--- a/crates/kin-registry/src/go.rs
+++ b/crates/kin-registry/src/go.rs
@@ -18,6 +18,7 @@ use axum::{
     routing::get,
     Router,
 };
+use sha2::{Digest, Sha256};
 use std::path::{Path as FsPath, PathBuf};
 use std::sync::Arc;
 
@@ -36,18 +37,21 @@ fn valid_go_module(module: &str) -> bool {
     if module.is_empty() || module.len() > MAX_GO_MODULE_LEN {
         return false;
     }
-    let bytes = module.as_bytes();
-    bytes
-        .first()
-        .is_some_and(|byte| byte.is_ascii_alphanumeric())
-        && bytes
-            .last()
-            .is_some_and(|byte| byte.is_ascii_alphanumeric())
-        && bytes
-            .iter()
-            .all(|byte| byte.is_ascii_alphanumeric() || matches!(byte, b'.' | b'-' | b'_' | b'!'))
-        && module != "."
-        && module != ".."
+    module.split('/').all(|segment| {
+        let bytes = segment.as_bytes();
+        !segment.is_empty()
+            && segment != "."
+            && segment != ".."
+            && bytes
+                .first()
+                .is_some_and(|byte| byte.is_ascii_alphanumeric())
+            && bytes
+                .last()
+                .is_some_and(|byte| byte.is_ascii_alphanumeric())
+            && bytes.iter().all(|byte| {
+                byte.is_ascii_alphanumeric() || matches!(byte, b'.' | b'-' | b'_' | b'!')
+            })
+    })
 }
 
 fn valid_go_version(version: &str) -> bool {
@@ -64,7 +68,12 @@ fn go_zip_path(blobs_dir: &FsPath, module: &str, version: &str) -> Option<PathBu
     if !valid_go_module(module) || !valid_go_version(version) {
         return None;
     }
-    let path = blobs_dir.join(format!("{module}-{version}.zip"));
+    // Module paths contain `/`; hash the validated logical coordinate into one
+    // fixed filename rather than projecting caller-controlled segments onto
+    // the host filesystem.
+    let coordinate = format!("{module}\0{version}");
+    let key = hex::encode(Sha256::digest(coordinate.as_bytes()));
+    let path = blobs_dir.join(format!("module_{key}.zip"));
     (path.parent() == Some(blobs_dir)).then_some(path)
 }
 
@@ -75,46 +84,39 @@ fn invalid_coordinate() -> Response {
 /// Create axum router for Go module proxy endpoints
 pub fn go_routes(state: Arc<GoProxyState>) -> Router {
     Router::new()
-        .route("/registry/go/{module}/@v/list", get(list_versions))
-        .route(
-            "/registry/go/{module}/@v/{*version_file}",
-            get(version_dispatch),
-        )
+        .route("/registry/go/{*path}", get(dispatch))
         .with_state(state)
 }
 
-/// Dispatch /registry/go/{module}/@v/{version}.{ext} to the correct handler
-async fn version_dispatch(
-    state: State<Arc<GoProxyState>>,
-    Path((module, version_file)): Path<(String, String)>,
-) -> Response {
-    if !valid_go_module(&module) {
+/// Parse the fixed `/@v/` protocol marker from the right so normal multi-segment
+/// module paths remain one validated logical coordinate.
+async fn dispatch(State(state): State<Arc<GoProxyState>>, Path(path): Path<String>) -> Response {
+    let Some((module, version_file)) = path.rsplit_once("/@v/") else {
+        return StatusCode::NOT_FOUND.into_response();
+    };
+    if !valid_go_module(module) {
         return invalid_coordinate();
     }
+    if version_file == "list" {
+        return list_versions_inner(&state, module);
+    }
     let (version, ext) = match version_file.rsplit_once('.') {
-        Some((v, e)) => (v.to_string(), e),
+        Some((v, e)) => (v, e),
         None => return StatusCode::NOT_FOUND.into_response(),
     };
-    if !valid_go_version(&version) {
+    if !valid_go_version(version) {
         return invalid_coordinate();
     }
     match ext {
-        "info" => version_info_inner(state, &module, &version).await,
-        "mod" => version_mod_inner(state, &module, &version).await,
-        "zip" => version_zip_inner(state, &module, &version).await,
+        "info" => version_info_inner(&state, module, version),
+        "mod" => version_mod_inner(&state, module, version),
+        "zip" => version_zip_inner(&state, module, version),
         _ => StatusCode::NOT_FOUND.into_response(),
     }
 }
 
-/// GET /registry/go/{module}/@v/list -- list all available versions (plain text, one per line)
-async fn list_versions(
-    State(state): State<Arc<GoProxyState>>,
-    Path(module): Path<String>,
-) -> Response {
-    if !valid_go_module(&module) {
-        return invalid_coordinate();
-    }
-    let versions = match state.manifest_store.get_versions(Ecosystem::Go, &module) {
+fn list_versions_inner(state: &GoProxyState, module: &str) -> Response {
+    let versions = match state.manifest_store.get_versions(Ecosystem::Go, module) {
         Ok(v) => v,
         Err(_) => return StatusCode::NOT_FOUND.into_response(),
     };
@@ -126,11 +128,7 @@ async fn list_versions(
     (StatusCode::OK, [("content-type", "text/plain")], body).into_response()
 }
 
-async fn version_info_inner(
-    State(state): State<Arc<GoProxyState>>,
-    module: &str,
-    version: &str,
-) -> Response {
+fn version_info_inner(state: &GoProxyState, module: &str, version: &str) -> Response {
     let versions = match state.manifest_store.get_versions(Ecosystem::Go, module) {
         Ok(v) => v,
         Err(_) => return StatusCode::NOT_FOUND.into_response(),
@@ -145,11 +143,7 @@ async fn version_info_inner(
     }
 }
 
-async fn version_mod_inner(
-    State(state): State<Arc<GoProxyState>>,
-    module: &str,
-    version: &str,
-) -> Response {
+fn version_mod_inner(state: &GoProxyState, module: &str, version: &str) -> Response {
     let versions = match state.manifest_store.get_versions(Ecosystem::Go, module) {
         Ok(v) => v,
         Err(_) => return StatusCode::NOT_FOUND.into_response(),
@@ -173,11 +167,7 @@ async fn version_mod_inner(
     }
 }
 
-async fn version_zip_inner(
-    State(state): State<Arc<GoProxyState>>,
-    module: &str,
-    version: &str,
-) -> Response {
+fn version_zip_inner(state: &GoProxyState, module: &str, version: &str) -> Response {
     let Some(zip_path) = go_zip_path(&state.blobs_dir, module, version) else {
         return invalid_coordinate();
     };
@@ -214,9 +204,9 @@ mod tests {
         let blobs = root.path().join("go");
         std::fs::create_dir_all(&blobs).unwrap();
 
-        let valid = go_zip_path(&blobs, "example.com", "v1.2.3").unwrap();
-        assert_eq!(valid, blobs.join("example.com-v1.2.3.zip"));
+        let valid = go_zip_path(&blobs, "example.com/team/module", "v1.2.3").unwrap();
         assert_eq!(valid.parent(), Some(blobs.as_path()));
+        assert_eq!(valid.file_name().unwrap().to_string_lossy().len(), 75);
 
         for (module, version) in [
             ("..", "v1.2.3"),
@@ -262,12 +252,13 @@ mod tests {
     async fn validated_go_zip_reads_remain_public() {
         let (_root, state) = state();
         let bytes = b"valid-public-module-zip";
-        let path = go_zip_path(&state.blobs_dir, "example.com", "v1.2.3").unwrap();
+        let module = "github.com/firelock-ai/kin";
+        let path = go_zip_path(&state.blobs_dir, module, "v1.2.3").unwrap();
         std::fs::write(path, bytes).unwrap();
 
         let response = go_routes(state)
             .oneshot(
-                Request::get("/registry/go/example.com/@v/v1.2.3.zip")
+                Request::get("/registry/go/github.com/firelock-ai/kin/@v/v1.2.3.zip")
                     .body(Body::empty())
                     .unwrap(),
             )
@@ -278,5 +269,43 @@ mod tests {
             .await
             .unwrap();
         assert_eq!(observed.as_ref(), bytes);
+    }
+
+    #[tokio::test]
+    async fn standard_multisegment_module_path_lists_versions() {
+        let (_root, state) = state();
+        let module = "github.com/firelock-ai/kin";
+        state
+            .manifest_store
+            .add_version(&crate::PackageVersion {
+                id: crate::PackageId {
+                    ecosystem: Ecosystem::Go,
+                    scope: None,
+                    name: module.to_string(),
+                },
+                version: "v1.2.3".to_string(),
+                blob_hash: "hash".to_string(),
+                blob_size: 0,
+                checksum: "checksum".to_string(),
+                metadata: serde_json::json!({}),
+                published_at: chrono::Utc::now(),
+                published_by: "test".to_string(),
+                yanked: false,
+            })
+            .unwrap();
+
+        let response = go_routes(state)
+            .oneshot(
+                Request::get("/registry/go/github.com/firelock-ai/kin/@v/list")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(response.status(), StatusCode::OK);
+        let observed = axum::body::to_bytes(response.into_body(), 1024)
+            .await
+            .unwrap();
+        assert_eq!(observed.as_ref(), b"v1.2.3");
     }
 }

--- a/crates/kin-registry/src/go.rs
+++ b/crates/kin-registry/src/go.rs
@@ -19,15 +19,30 @@ use axum::{
     Router,
 };
 use sha2::{Digest, Sha256};
-use std::path::{Path as FsPath, PathBuf};
+#[cfg(test)]
+use std::path::Path as FsPath;
+use std::path::PathBuf;
 use std::sync::Arc;
 
-use crate::{Ecosystem, ManifestStore};
+use crate::{atomic_file::AuthorityRoot, Ecosystem, ManifestStore, PackageVersion, RegistryError};
 
 /// Shared state for the Go module proxy routes
 pub struct GoProxyState {
     pub manifest_store: ManifestStore,
     pub blobs_dir: std::path::PathBuf,
+    blobs_authority: AuthorityRoot,
+}
+
+impl GoProxyState {
+    pub fn new(manifest_store: ManifestStore, blobs_dir: PathBuf) -> Self {
+        let blobs_authority = AuthorityRoot::new(&blobs_dir);
+        let blobs_dir = blobs_authority.path().to_path_buf();
+        Self {
+            manifest_store,
+            blobs_dir,
+            blobs_authority,
+        }
+    }
 }
 
 const MAX_GO_MODULE_LEN: usize = 255;
@@ -64,7 +79,12 @@ fn valid_go_version(version: &str) -> bool {
         && !version.contains("..")
 }
 
+#[cfg(test)]
 fn go_zip_path(blobs_dir: &FsPath, module: &str, version: &str) -> Option<PathBuf> {
+    go_zip_relative(module, version).map(|relative| blobs_dir.join(relative))
+}
+
+fn go_zip_relative(module: &str, version: &str) -> Option<PathBuf> {
     if !valid_go_module(module) || !valid_go_version(version) {
         return None;
     }
@@ -73,8 +93,7 @@ fn go_zip_path(blobs_dir: &FsPath, module: &str, version: &str) -> Option<PathBu
     // the host filesystem.
     let coordinate = format!("{module}\0{version}");
     let key = hex::encode(Sha256::digest(coordinate.as_bytes()));
-    let path = blobs_dir.join(format!("module_{key}.zip"));
-    (path.parent() == Some(blobs_dir)).then_some(path)
+    Some(PathBuf::from(format!("module_{key}.zip")))
 }
 
 fn invalid_coordinate() -> Response {
@@ -98,7 +117,7 @@ async fn dispatch(State(state): State<Arc<GoProxyState>>, Path(path): Path<Strin
         return invalid_coordinate();
     }
     if version_file == "list" {
-        return list_versions_inner(&state, module);
+        return list_versions_inner(&state, module).await;
     }
     let (version, ext) = match version_file.rsplit_once('.') {
         Some((v, e)) => (v, e),
@@ -108,15 +127,35 @@ async fn dispatch(State(state): State<Arc<GoProxyState>>, Path(path): Path<Strin
         return invalid_coordinate();
     }
     match ext {
-        "info" => version_info_inner(&state, module, version),
-        "mod" => version_mod_inner(&state, module, version),
-        "zip" => version_zip_inner(&state, module, version),
+        "info" => version_info_inner(&state, module, version).await,
+        "mod" => version_mod_inner(&state, module, version).await,
+        "zip" => version_zip_inner(&state, module, version).await,
         _ => StatusCode::NOT_FOUND.into_response(),
     }
 }
 
-fn list_versions_inner(state: &GoProxyState, module: &str) -> Response {
-    let versions = match state.manifest_store.get_versions(Ecosystem::Go, module) {
+async fn read_go_versions(
+    state: &Arc<GoProxyState>,
+    module: &str,
+) -> Result<Vec<PackageVersion>, RegistryError> {
+    let state = Arc::clone(state);
+    let module = module.to_string();
+    tokio::task::spawn_blocking(move || {
+        state
+            .manifest_store
+            .read_transaction(Ecosystem::Go)?
+            .get_versions(&module)
+    })
+    .await
+    .map_err(|error| {
+        RegistryError::Storage(std::io::Error::other(format!(
+            "Go manifest storage task failed: {error}"
+        )))
+    })?
+}
+
+async fn list_versions_inner(state: &Arc<GoProxyState>, module: &str) -> Response {
+    let versions = match read_go_versions(state, module).await {
         Ok(v) => v,
         Err(_) => return StatusCode::NOT_FOUND.into_response(),
     };
@@ -128,8 +167,8 @@ fn list_versions_inner(state: &GoProxyState, module: &str) -> Response {
     (StatusCode::OK, [("content-type", "text/plain")], body).into_response()
 }
 
-fn version_info_inner(state: &GoProxyState, module: &str, version: &str) -> Response {
-    let versions = match state.manifest_store.get_versions(Ecosystem::Go, module) {
+async fn version_info_inner(state: &Arc<GoProxyState>, module: &str, version: &str) -> Response {
+    let versions = match read_go_versions(state, module).await {
         Ok(v) => v,
         Err(_) => return StatusCode::NOT_FOUND.into_response(),
     };
@@ -143,8 +182,8 @@ fn version_info_inner(state: &GoProxyState, module: &str, version: &str) -> Resp
     }
 }
 
-fn version_mod_inner(state: &GoProxyState, module: &str, version: &str) -> Response {
-    let versions = match state.manifest_store.get_versions(Ecosystem::Go, module) {
+async fn version_mod_inner(state: &Arc<GoProxyState>, module: &str, version: &str) -> Response {
+    let versions = match read_go_versions(state, module).await {
         Ok(v) => v,
         Err(_) => return StatusCode::NOT_FOUND.into_response(),
     };
@@ -167,13 +206,17 @@ fn version_mod_inner(state: &GoProxyState, module: &str, version: &str) -> Respo
     }
 }
 
-fn version_zip_inner(state: &GoProxyState, module: &str, version: &str) -> Response {
-    let Some(zip_path) = go_zip_path(&state.blobs_dir, module, version) else {
+async fn version_zip_inner(state: &Arc<GoProxyState>, module: &str, version: &str) -> Response {
+    let Some(zip_relative) = go_zip_relative(module, version) else {
         return invalid_coordinate();
     };
-    match std::fs::read(&zip_path) {
-        Ok(bytes) => (StatusCode::OK, [("content-type", "application/zip")], bytes).into_response(),
-        Err(_) => StatusCode::NOT_FOUND.into_response(),
+    let authority = state.blobs_authority.clone();
+    let bytes = tokio::task::spawn_blocking(move || authority.read(&zip_relative)).await;
+    match bytes {
+        Ok(Ok(bytes)) => {
+            (StatusCode::OK, [("content-type", "application/zip")], bytes).into_response()
+        }
+        Ok(Err(_)) | Err(_) => StatusCode::NOT_FOUND.into_response(),
     }
 }
 
@@ -191,10 +234,7 @@ mod tests {
         std::fs::create_dir_all(&blobs_dir).unwrap();
         (
             root,
-            Arc::new(GoProxyState {
-                manifest_store: ManifestStore::new(&kin_dir),
-                blobs_dir,
-            }),
+            Arc::new(GoProxyState::new(ManifestStore::new(&kin_dir), blobs_dir)),
         )
     }
 
@@ -269,6 +309,39 @@ mod tests {
             .await
             .unwrap();
         assert_eq!(observed.as_ref(), bytes);
+    }
+
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn live_state_keeps_the_pinned_blob_authority_after_root_replacement() {
+        let (root, state) = state();
+        let module = "github.com/firelock-ai/kin";
+        let version = "v1.2.3";
+        let zip_path = go_zip_path(&state.blobs_dir, module, version).unwrap();
+        std::fs::write(&zip_path, b"pinned-authority-bytes").unwrap();
+
+        let displaced = root.path().join("go-original");
+        std::fs::rename(&state.blobs_dir, &displaced).unwrap();
+        std::fs::create_dir(&state.blobs_dir).unwrap();
+        std::fs::write(
+            go_zip_path(&state.blobs_dir, module, version).unwrap(),
+            b"replacement-path-bytes",
+        )
+        .unwrap();
+
+        let response = go_routes(state)
+            .oneshot(
+                Request::get("/registry/go/github.com/firelock-ai/kin/@v/v1.2.3.zip")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(response.status(), StatusCode::OK);
+        let observed = axum::body::to_bytes(response.into_body(), 1024)
+            .await
+            .unwrap();
+        assert_eq!(observed.as_ref(), b"pinned-authority-bytes");
     }
 
     #[tokio::test]

--- a/crates/kin-registry/src/lib.rs
+++ b/crates/kin-registry/src/lib.rs
@@ -125,7 +125,11 @@ impl ManifestStore {
         Ok(versions)
     }
 
-    /// Add a new version (appends to the manifest file)
+    /// Add a new version with a crash-durable whole-file replacement.
+    ///
+    /// Callers that can publish concurrently must serialize the read/modify/
+    /// write transaction. Replacing the complete newline-delimited manifest
+    /// keeps readers from ever observing a torn append after a crash.
     pub fn add_version(&self, version: &PackageVersion) -> Result<(), RegistryError> {
         let canonical_name = version.id.canonical_name();
 
@@ -138,19 +142,9 @@ impl ManifestStore {
             ));
         }
 
-        let path = self.manifest_path(&version.id);
-        if let Some(parent) = path.parent() {
-            std::fs::create_dir_all(parent)?;
-        }
-
-        use std::io::Write;
-        let mut file = std::fs::OpenOptions::new()
-            .create(true)
-            .append(true)
-            .open(&path)?;
-        let line = serde_json::to_string(version)?;
-        writeln!(file, "{}", line)?;
-        Ok(())
+        let mut replacement = existing;
+        replacement.push(version.clone());
+        self.replace_versions(&version.id, &replacement)
     }
 
     /// Rewrite the full version list for a package.
@@ -164,16 +158,27 @@ impl ManifestStore {
             std::fs::create_dir_all(parent)?;
         }
 
-        use std::io::Write;
-        let mut file = std::fs::OpenOptions::new()
-            .create(true)
-            .write(true)
-            .truncate(true)
-            .open(&path)?;
-        for version in versions {
-            let line = serde_json::to_string(version)?;
-            writeln!(file, "{}", line)?;
+        let contents = serialize_versions(versions)?;
+        atomic_file::write(&path, &contents)?;
+        Ok(())
+    }
+
+    #[cfg(test)]
+    fn replace_versions_with_pre_commit<F>(
+        &self,
+        id: &PackageId,
+        versions: &[PackageVersion],
+        pre_commit: F,
+    ) -> Result<(), RegistryError>
+    where
+        F: FnOnce(&std::path::Path) -> std::io::Result<()>,
+    {
+        let path = self.manifest_path(id);
+        if let Some(parent) = path.parent() {
+            std::fs::create_dir_all(parent)?;
         }
+        let contents = serialize_versions(versions)?;
+        atomic_file::write_with_pre_commit(&path, &contents, pre_commit)?;
         Ok(())
     }
 
@@ -211,7 +216,73 @@ impl ManifestStore {
     }
 }
 
+fn serialize_versions(versions: &[PackageVersion]) -> Result<Vec<u8>, RegistryError> {
+    let mut contents = Vec::new();
+    for version in versions {
+        let line = serde_json::to_string(version)?;
+        contents.extend_from_slice(line.as_bytes());
+        contents.push(b'\n');
+    }
+    Ok(contents)
+}
+
 pub mod cargo;
 pub mod go;
 pub mod npm;
 pub mod oci;
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn cargo_version(version: &str) -> PackageVersion {
+        PackageVersion {
+            id: PackageId {
+                ecosystem: Ecosystem::Cargo,
+                scope: None,
+                name: "demo".to_string(),
+            },
+            version: version.to_string(),
+            blob_hash: format!("hash-{version}"),
+            blob_size: 1,
+            checksum: format!("checksum-{version}"),
+            metadata: serde_json::json!({
+                "cargo_index_format": 1,
+                "features": {},
+                "deps": [],
+            }),
+            published_at: Utc::now(),
+            published_by: "test".to_string(),
+            yanked: false,
+        }
+    }
+
+    #[test]
+    fn failed_cargo_manifest_commit_preserves_prior_authority_and_cleans_stage() {
+        let root = tempfile::tempdir().unwrap();
+        let store = ManifestStore::new(root.path());
+        let first = cargo_version("0.1.0");
+        let second = cargo_version("0.2.0");
+        store.add_version(&first).unwrap();
+        let path = store.manifest_path(&first.id);
+        let original = std::fs::read(&path).unwrap();
+
+        let error = store
+            .replace_versions_with_pre_commit(&first.id, &[first.clone(), second], |_| {
+                Err(std::io::Error::other("injected before manifest rename"))
+            })
+            .unwrap_err();
+        assert!(error
+            .to_string()
+            .contains("injected before manifest rename"));
+        assert_eq!(std::fs::read(&path).unwrap(), original);
+        assert_eq!(
+            store.get_versions(Ecosystem::Cargo, "demo").unwrap().len(),
+            1
+        );
+        assert_eq!(
+            std::fs::read_dir(path.parent().unwrap()).unwrap().count(),
+            1
+        );
+    }
+}

--- a/crates/kin-registry/src/lib.rs
+++ b/crates/kin-registry/src/lib.rs
@@ -120,7 +120,9 @@ pub(crate) struct ManifestWriteTransaction<'a> {
 
 impl ManifestStore {
     pub fn new(kin_dir: &std::path::Path) -> Self {
-        let manifests_dir = kin_dir.join("packages").join("manifests");
+        let pinned_kin_dir =
+            atomic_file::pin_authority_root(kin_dir).unwrap_or_else(|_| kin_dir.to_path_buf());
+        let manifests_dir = pinned_kin_dir.join("packages").join("manifests");
         let _ = atomic_file::ensure_directory_durable(&manifests_dir);
         Self { manifests_dir }
     }
@@ -142,6 +144,37 @@ impl ManifestStore {
         ecosystem: Ecosystem,
     ) -> Result<ManifestWriteTransaction<'_>, RegistryError> {
         let lock = storage_lock::StorageLock::exclusive(&self.transaction_lock_path(ecosystem))?;
+        Ok(ManifestWriteTransaction {
+            store: self,
+            ecosystem,
+            _lock: lock,
+        })
+    }
+
+    /// Async handler boundary for the same shared transaction lock. The OS
+    /// lock and in-process condition wait run on Tokio's bounded blocking pool
+    /// so a stalled peer process cannot occupy an API worker thread.
+    pub(crate) async fn read_transaction_async(
+        &self,
+        ecosystem: Ecosystem,
+    ) -> Result<ManifestReadTransaction<'_>, RegistryError> {
+        let lock =
+            storage_lock::StorageLock::shared_async(&self.transaction_lock_path(ecosystem)).await?;
+        Ok(ManifestReadTransaction {
+            store: self,
+            ecosystem,
+            _lock: lock,
+        })
+    }
+
+    /// Async handler boundary for the exclusive publication transaction.
+    pub(crate) async fn write_transaction_async(
+        &self,
+        ecosystem: Ecosystem,
+    ) -> Result<ManifestWriteTransaction<'_>, RegistryError> {
+        let lock =
+            storage_lock::StorageLock::exclusive_async(&self.transaction_lock_path(ecosystem))
+                .await?;
         Ok(ManifestWriteTransaction {
             store: self,
             ecosystem,

--- a/crates/kin-registry/src/lib.rs
+++ b/crates/kin-registry/src/lib.rs
@@ -11,6 +11,8 @@
 use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
 
+mod atomic_file;
+
 /// Package ecosystem identifier
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "lowercase")]

--- a/crates/kin-registry/src/lib.rs
+++ b/crates/kin-registry/src/lib.rs
@@ -12,6 +12,7 @@ use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
 
 mod atomic_file;
+mod storage_lock;
 
 /// Package ecosystem identifier
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
@@ -90,6 +91,8 @@ pub enum RegistryError {
     Storage(#[from] std::io::Error),
     #[error("serialization error: {0}")]
     Serialization(#[from] serde_json::Error),
+    #[error("invalid registry operation: {0}")]
+    InvalidOperation(String),
 }
 
 /// In-memory manifest store backed by a JSON file in the .kin directory.
@@ -98,11 +101,52 @@ pub struct ManifestStore {
     manifests_dir: std::path::PathBuf,
 }
 
+/// Shared-lock view of one ecosystem's durable manifest authority.
+pub(crate) struct ManifestReadTransaction<'a> {
+    store: &'a ManifestStore,
+    ecosystem: Ecosystem,
+    _lock: storage_lock::StorageLock,
+}
+
+/// Exclusive-lock view used for blob + manifest publication transactions.
+///
+/// Protocol adapters must keep this value alive from their immutable-version
+/// preflight through blob publication and the final manifest replacement.
+pub(crate) struct ManifestWriteTransaction<'a> {
+    store: &'a ManifestStore,
+    ecosystem: Ecosystem,
+    _lock: storage_lock::StorageLock,
+}
+
 impl ManifestStore {
     pub fn new(kin_dir: &std::path::Path) -> Self {
         let manifests_dir = kin_dir.join("packages").join("manifests");
-        std::fs::create_dir_all(&manifests_dir).ok();
+        let _ = atomic_file::ensure_directory_durable(&manifests_dir);
         Self { manifests_dir }
+    }
+
+    pub(crate) fn read_transaction(
+        &self,
+        ecosystem: Ecosystem,
+    ) -> Result<ManifestReadTransaction<'_>, RegistryError> {
+        let lock = storage_lock::StorageLock::shared(&self.transaction_lock_path(ecosystem))?;
+        Ok(ManifestReadTransaction {
+            store: self,
+            ecosystem,
+            _lock: lock,
+        })
+    }
+
+    pub(crate) fn write_transaction(
+        &self,
+        ecosystem: Ecosystem,
+    ) -> Result<ManifestWriteTransaction<'_>, RegistryError> {
+        let lock = storage_lock::StorageLock::exclusive(&self.transaction_lock_path(ecosystem))?;
+        Ok(ManifestWriteTransaction {
+            store: self,
+            ecosystem,
+            _lock: lock,
+        })
     }
 
     /// Get all versions of a package
@@ -111,7 +155,20 @@ impl ManifestStore {
         ecosystem: Ecosystem,
         package: &str,
     ) -> Result<Vec<PackageVersion>, RegistryError> {
+        self.read_transaction(ecosystem)?.get_versions(package)
+    }
+
+    fn get_versions_unlocked(
+        &self,
+        ecosystem: Ecosystem,
+        package: &str,
+    ) -> Result<Vec<PackageVersion>, RegistryError> {
         let id = PackageId::from_registry_name(ecosystem, package);
+        if !self.manifest_path_is_contained(&id) {
+            return Err(RegistryError::InvalidOperation(
+                "package manifest path escaped its ecosystem directory".to_string(),
+            ));
+        }
         let path = self.manifest_path(&id);
         if !path.exists() {
             return Ok(vec![]);
@@ -131,20 +188,8 @@ impl ManifestStore {
     /// write transaction. Replacing the complete newline-delimited manifest
     /// keeps readers from ever observing a torn append after a crash.
     pub fn add_version(&self, version: &PackageVersion) -> Result<(), RegistryError> {
-        let canonical_name = version.id.canonical_name();
-
-        // Check for duplicate
-        let existing = self.get_versions(version.id.ecosystem, &canonical_name)?;
-        if existing.iter().any(|v| v.version == version.version) {
-            return Err(RegistryError::VersionExists(
-                canonical_name,
-                version.version.clone(),
-            ));
-        }
-
-        let mut replacement = existing;
-        replacement.push(version.clone());
-        self.replace_versions(&version.id, &replacement)
+        self.write_transaction(version.id.ecosystem)?
+            .add_version(version)
     }
 
     /// Rewrite the full version list for a package.
@@ -153,9 +198,23 @@ impl ManifestStore {
         id: &PackageId,
         versions: &[PackageVersion],
     ) -> Result<(), RegistryError> {
+        self.write_transaction(id.ecosystem)?
+            .replace_versions(id, versions)
+    }
+
+    fn replace_versions_unlocked(
+        &self,
+        id: &PackageId,
+        versions: &[PackageVersion],
+    ) -> Result<(), RegistryError> {
+        if !self.manifest_path_is_contained(id) {
+            return Err(RegistryError::InvalidOperation(
+                "package manifest path escaped its ecosystem directory".to_string(),
+            ));
+        }
         let path = self.manifest_path(id);
         if let Some(parent) = path.parent() {
-            std::fs::create_dir_all(parent)?;
+            atomic_file::ensure_directory_durable(parent)?;
         }
 
         let contents = serialize_versions(versions)?;
@@ -175,7 +234,7 @@ impl ManifestStore {
     {
         let path = self.manifest_path(id);
         if let Some(parent) = path.parent() {
-            std::fs::create_dir_all(parent)?;
+            atomic_file::ensure_directory_durable(parent)?;
         }
         let contents = serialize_versions(versions)?;
         atomic_file::write_with_pre_commit(&path, &contents, pre_commit)?;
@@ -186,15 +245,37 @@ impl ManifestStore {
     /// its ecosystem directory. Protocol adapters use this after validating a
     /// caller-controlled package name and before any manifest IO.
     pub(crate) fn manifest_path_is_direct_child(&self, id: &PackageId) -> bool {
-        let mut components = std::path::Path::new(&id.name).components();
-        let is_one_normal_segment = matches!(
-            components.next(),
-            Some(std::path::Component::Normal(segment)) if segment == std::ffi::OsStr::new(&id.name)
-        ) && components.next().is_none();
+        let is_one_normal_segment = is_one_normal_path_segment(&id.name);
         let base = self.ecosystem_manifests_dir(id.ecosystem);
         id.scope.is_none()
             && is_one_normal_segment
             && self.manifest_path(id).parent() == Some(base.as_path())
+    }
+
+    fn manifest_path_is_contained(&self, id: &PackageId) -> bool {
+        let base = self.ecosystem_manifests_dir(id.ecosystem);
+        let shape_is_valid = match id.ecosystem {
+            Ecosystem::Npm => match id.scope.as_deref() {
+                Some(scope) if !scope.is_empty() && is_one_normal_path_segment(scope) => {
+                    is_one_normal_path_segment(&id.name)
+                }
+                Some(_) => false,
+                None => is_one_normal_path_segment(&id.name),
+            },
+            // Go module names are intentionally multi-segment. Validate every
+            // segment lexically before projecting the logical coordinate to
+            // the manifest hierarchy.
+            Ecosystem::Go => id.scope.is_none() && is_safe_relative_path(&id.name),
+            Ecosystem::Cargo | Ecosystem::Oci | Ecosystem::Raw => {
+                id.scope.is_none() && is_one_normal_path_segment(&id.name)
+            }
+        };
+        if !shape_is_valid {
+            return false;
+        }
+
+        let path = self.manifest_path(id);
+        path != base && path.starts_with(&base)
     }
 
     fn ecosystem_manifests_dir(&self, ecosystem: Ecosystem) -> std::path::PathBuf {
@@ -207,12 +288,84 @@ impl ManifestStore {
         })
     }
 
+    fn transaction_lock_path(&self, ecosystem: Ecosystem) -> std::path::PathBuf {
+        let name = match ecosystem {
+            Ecosystem::Cargo => "cargo.lock",
+            Ecosystem::Npm => "npm.lock",
+            Ecosystem::Oci => "oci.lock",
+            Ecosystem::Go => "go.lock",
+            Ecosystem::Raw => "raw.lock",
+        };
+        self.manifests_dir.join(".transactions").join(name)
+    }
+
     fn manifest_path(&self, id: &PackageId) -> std::path::PathBuf {
         let base = self.ecosystem_manifests_dir(id.ecosystem);
         match &id.scope {
             Some(scope) if !scope.is_empty() => base.join(format!("@{scope}")).join(&id.name),
             _ => base.join(&id.name),
         }
+    }
+}
+
+fn is_one_normal_path_segment(value: &str) -> bool {
+    let mut components = std::path::Path::new(value).components();
+    matches!(
+        components.next(),
+        Some(std::path::Component::Normal(segment)) if segment == std::ffi::OsStr::new(value)
+    ) && components.next().is_none()
+}
+
+fn is_safe_relative_path(value: &str) -> bool {
+    !value.is_empty()
+        && value
+            .split('/')
+            .all(|segment| !segment.is_empty() && is_one_normal_path_segment(segment))
+}
+
+impl ManifestReadTransaction<'_> {
+    pub(crate) fn get_versions(&self, package: &str) -> Result<Vec<PackageVersion>, RegistryError> {
+        self.store.get_versions_unlocked(self.ecosystem, package)
+    }
+}
+
+impl ManifestWriteTransaction<'_> {
+    pub(crate) fn get_versions(&self, package: &str) -> Result<Vec<PackageVersion>, RegistryError> {
+        self.store.get_versions_unlocked(self.ecosystem, package)
+    }
+
+    pub(crate) fn add_version(&self, version: &PackageVersion) -> Result<(), RegistryError> {
+        if version.id.ecosystem != self.ecosystem {
+            return Err(RegistryError::InvalidOperation(
+                "manifest transaction ecosystem does not match package".to_string(),
+            ));
+        }
+        let canonical_name = version.id.canonical_name();
+        let mut existing = self.get_versions(&canonical_name)?;
+        if existing
+            .iter()
+            .any(|candidate| candidate.version == version.version)
+        {
+            return Err(RegistryError::VersionExists(
+                canonical_name,
+                version.version.clone(),
+            ));
+        }
+        existing.push(version.clone());
+        self.store.replace_versions_unlocked(&version.id, &existing)
+    }
+
+    pub(crate) fn replace_versions(
+        &self,
+        id: &PackageId,
+        versions: &[PackageVersion],
+    ) -> Result<(), RegistryError> {
+        if id.ecosystem != self.ecosystem {
+            return Err(RegistryError::InvalidOperation(
+                "manifest transaction ecosystem does not match package".to_string(),
+            ));
+        }
+        self.store.replace_versions_unlocked(id, versions)
     }
 }
 

--- a/crates/kin-registry/src/lib.rs
+++ b/crates/kin-registry/src/lib.rs
@@ -97,8 +97,10 @@ pub enum RegistryError {
 
 /// In-memory manifest store backed by a JSON file in the .kin directory.
 /// At scale, this would use kin-db entities, but for MVP a simple file works.
+#[derive(Clone)]
 pub struct ManifestStore {
     manifests_dir: std::path::PathBuf,
+    authority: atomic_file::AuthorityRoot,
 }
 
 /// Shared-lock view of one ecosystem's durable manifest authority.
@@ -120,18 +122,23 @@ pub(crate) struct ManifestWriteTransaction<'a> {
 
 impl ManifestStore {
     pub fn new(kin_dir: &std::path::Path) -> Self {
-        let pinned_kin_dir =
-            atomic_file::pin_authority_root(kin_dir).unwrap_or_else(|_| kin_dir.to_path_buf());
-        let manifests_dir = pinned_kin_dir.join("packages").join("manifests");
-        let _ = atomic_file::ensure_directory_durable(&manifests_dir);
-        Self { manifests_dir }
+        let configured = kin_dir.join("packages").join("manifests");
+        let authority = atomic_file::AuthorityRoot::new(&configured);
+        let manifests_dir = authority.path().to_path_buf();
+        Self {
+            manifests_dir,
+            authority,
+        }
     }
 
     pub(crate) fn read_transaction(
         &self,
         ecosystem: Ecosystem,
     ) -> Result<ManifestReadTransaction<'_>, RegistryError> {
-        let lock = storage_lock::StorageLock::shared(&self.transaction_lock_path(ecosystem))?;
+        let lock = storage_lock::StorageLock::shared_at(
+            &self.authority,
+            &self.transaction_lock_relative(ecosystem),
+        )?;
         Ok(ManifestReadTransaction {
             store: self,
             ecosystem,
@@ -143,38 +150,10 @@ impl ManifestStore {
         &self,
         ecosystem: Ecosystem,
     ) -> Result<ManifestWriteTransaction<'_>, RegistryError> {
-        let lock = storage_lock::StorageLock::exclusive(&self.transaction_lock_path(ecosystem))?;
-        Ok(ManifestWriteTransaction {
-            store: self,
-            ecosystem,
-            _lock: lock,
-        })
-    }
-
-    /// Async handler boundary for the same shared transaction lock. The OS
-    /// lock and in-process condition wait run on Tokio's bounded blocking pool
-    /// so a stalled peer process cannot occupy an API worker thread.
-    pub(crate) async fn read_transaction_async(
-        &self,
-        ecosystem: Ecosystem,
-    ) -> Result<ManifestReadTransaction<'_>, RegistryError> {
-        let lock =
-            storage_lock::StorageLock::shared_async(&self.transaction_lock_path(ecosystem)).await?;
-        Ok(ManifestReadTransaction {
-            store: self,
-            ecosystem,
-            _lock: lock,
-        })
-    }
-
-    /// Async handler boundary for the exclusive publication transaction.
-    pub(crate) async fn write_transaction_async(
-        &self,
-        ecosystem: Ecosystem,
-    ) -> Result<ManifestWriteTransaction<'_>, RegistryError> {
-        let lock =
-            storage_lock::StorageLock::exclusive_async(&self.transaction_lock_path(ecosystem))
-                .await?;
+        let lock = storage_lock::StorageLock::exclusive_at(
+            &self.authority,
+            &self.transaction_lock_relative(ecosystem),
+        )?;
         Ok(ManifestWriteTransaction {
             store: self,
             ecosystem,
@@ -202,11 +181,16 @@ impl ManifestStore {
                 "package manifest path escaped its ecosystem directory".to_string(),
             ));
         }
-        let path = self.manifest_path(&id);
-        if !path.exists() {
-            return Ok(vec![]);
-        }
-        let content = std::fs::read_to_string(&path)?;
+        let relative = self.manifest_relative_path(&id);
+        let content = match self.authority.read(&relative) {
+            Ok(content) => String::from_utf8(content).map_err(|error| {
+                RegistryError::InvalidOperation(format!(
+                    "package manifest is not valid UTF-8: {error}"
+                ))
+            })?,
+            Err(error) if error.kind() == std::io::ErrorKind::NotFound => return Ok(vec![]),
+            Err(error) => return Err(error.into()),
+        };
         let versions: Vec<PackageVersion> = content
             .lines()
             .filter(|l| !l.trim().is_empty())
@@ -245,13 +229,9 @@ impl ManifestStore {
                 "package manifest path escaped its ecosystem directory".to_string(),
             ));
         }
-        let path = self.manifest_path(id);
-        if let Some(parent) = path.parent() {
-            atomic_file::ensure_directory_durable(parent)?;
-        }
-
+        let relative = self.manifest_relative_path(id);
         let contents = serialize_versions(versions)?;
-        atomic_file::write(&path, &contents)?;
+        self.authority.write(&relative, &contents)?;
         Ok(())
     }
 
@@ -321,7 +301,7 @@ impl ManifestStore {
         })
     }
 
-    fn transaction_lock_path(&self, ecosystem: Ecosystem) -> std::path::PathBuf {
+    fn transaction_lock_relative(&self, ecosystem: Ecosystem) -> std::path::PathBuf {
         let name = match ecosystem {
             Ecosystem::Cargo => "cargo.lock",
             Ecosystem::Npm => "npm.lock",
@@ -329,7 +309,23 @@ impl ManifestStore {
             Ecosystem::Go => "go.lock",
             Ecosystem::Raw => "raw.lock",
         };
-        self.manifests_dir.join(".transactions").join(name)
+        std::path::PathBuf::from(".transactions").join(name)
+    }
+
+    fn manifest_relative_path(&self, id: &PackageId) -> std::path::PathBuf {
+        let ecosystem = match id.ecosystem {
+            Ecosystem::Cargo => "cargo",
+            Ecosystem::Npm => "npm",
+            Ecosystem::Oci => "oci",
+            Ecosystem::Go => "go",
+            Ecosystem::Raw => "raw",
+        };
+        match &id.scope {
+            Some(scope) if !scope.is_empty() => std::path::PathBuf::from(ecosystem)
+                .join(format!("@{scope}"))
+                .join(&id.name),
+            _ => std::path::PathBuf::from(ecosystem).join(&id.name),
+        }
     }
 
     fn manifest_path(&self, id: &PackageId) -> std::path::PathBuf {

--- a/crates/kin-registry/src/lib.rs
+++ b/crates/kin-registry/src/lib.rs
@@ -175,15 +175,33 @@ impl ManifestStore {
         Ok(())
     }
 
-    fn manifest_path(&self, id: &PackageId) -> std::path::PathBuf {
-        let eco_str = match id.ecosystem {
+    /// Prove that an unscoped package manifest resolves to one direct child of
+    /// its ecosystem directory. Protocol adapters use this after validating a
+    /// caller-controlled package name and before any manifest IO.
+    pub(crate) fn manifest_path_is_direct_child(&self, id: &PackageId) -> bool {
+        let mut components = std::path::Path::new(&id.name).components();
+        let is_one_normal_segment = matches!(
+            components.next(),
+            Some(std::path::Component::Normal(segment)) if segment == std::ffi::OsStr::new(&id.name)
+        ) && components.next().is_none();
+        let base = self.ecosystem_manifests_dir(id.ecosystem);
+        id.scope.is_none()
+            && is_one_normal_segment
+            && self.manifest_path(id).parent() == Some(base.as_path())
+    }
+
+    fn ecosystem_manifests_dir(&self, ecosystem: Ecosystem) -> std::path::PathBuf {
+        self.manifests_dir.join(match ecosystem {
             Ecosystem::Cargo => "cargo",
             Ecosystem::Npm => "npm",
             Ecosystem::Oci => "oci",
             Ecosystem::Go => "go",
             Ecosystem::Raw => "raw",
-        };
-        let base = self.manifests_dir.join(eco_str);
+        })
+    }
+
+    fn manifest_path(&self, id: &PackageId) -> std::path::PathBuf {
+        let base = self.ecosystem_manifests_dir(id.ecosystem);
         match &id.scope {
             Some(scope) if !scope.is_empty() => base.join(format!("@{scope}")).join(&id.name),
             _ => base.join(&id.name),

--- a/crates/kin-registry/src/npm.rs
+++ b/crates/kin-registry/src/npm.rs
@@ -10,9 +10,10 @@
 //! - PUT /registry/npm/{package}
 
 use axum::{
-    body::Bytes,
-    extract::{DefaultBodyLimit, Extension, OriginalUri, State},
-    http::{StatusCode, Uri},
+    body::{Body, Bytes},
+    extract::{DefaultBodyLimit, Extension, OriginalUri, Request, State},
+    http::{header, Method, StatusCode, Uri},
+    middleware::{self, Next},
     response::{IntoResponse, Json, Response},
     routing::get,
     Router,
@@ -43,6 +44,21 @@ pub struct NpmRegistryState {
     pub base_url: String,
 }
 
+impl NpmRegistryState {
+    pub fn new(
+        manifest_store: ManifestStore,
+        blobs_dir: std::path::PathBuf,
+        base_url: String,
+    ) -> Self {
+        let blobs_dir = crate::atomic_file::pin_authority_root(&blobs_dir).unwrap_or(blobs_dir);
+        Self {
+            manifest_store,
+            blobs_dir,
+            base_url,
+        }
+    }
+}
+
 /// Authenticated caller metadata injected by the daemon-side registry auth
 /// middleware when KinLab token enforcement is enabled.
 #[derive(Clone, Debug, Default, serde::Deserialize, serde::Serialize)]
@@ -68,7 +84,45 @@ pub fn npm_routes(state: Arc<NpmRegistryState>) -> Router {
     Router::new()
         .route("/registry/npm/{*path}", get(handle_get).put(handle_put))
         .layer(DefaultBodyLimit::max(MAX_NPM_PUBLISH_BODY_SIZE))
+        .route_layer(middleware::from_fn(authorize_npm_publish))
         .with_state(state)
+}
+
+/// Refuse writes without the daemon-injected identity before Axum polls the
+/// request body. This keeps a disabled or unauthenticated registry from
+/// buffering the 140 MiB publish envelope merely to return a 503.
+async fn authorize_npm_publish(request: Request<Body>, next: Next) -> Response {
+    if request.method() != Method::PUT {
+        return next.run(request).await;
+    }
+    if request
+        .extensions()
+        .get::<RegistryAccessIdentity>()
+        .is_none()
+    {
+        return (
+            StatusCode::SERVICE_UNAVAILABLE,
+            Json(serde_json::json!({
+                "error": "npm publishing is disabled: no authenticated registry identity",
+            })),
+        )
+            .into_response();
+    }
+    let declared = request
+        .headers()
+        .get(header::CONTENT_LENGTH)
+        .and_then(|value| value.to_str().ok())
+        .and_then(|value| value.parse::<u64>().ok());
+    if declared.is_some_and(|length| length > MAX_NPM_PUBLISH_BODY_SIZE as u64) {
+        return (
+            StatusCode::PAYLOAD_TOO_LARGE,
+            Json(serde_json::json!({
+                "error": "npm publish body exceeds the configured size limit",
+            })),
+        )
+            .into_response();
+    }
+    next.run(request).await
 }
 
 async fn handle_get(
@@ -85,19 +139,19 @@ async fn handle_get(
             if validate_npm_package(&package).is_err() {
                 return invalid_npm_coordinate();
             }
-            package_metadata(&state, &package)
+            package_metadata(&state, &package).await
         }
         ParsedRoute::VersionMetadata { package, version } => {
             if validate_npm_package(&package).is_err() || !valid_npm_version(&version) {
                 return invalid_npm_coordinate();
             }
-            version_metadata(&state, &package, &version)
+            version_metadata(&state, &package, &version).await
         }
         ParsedRoute::Tarball { package, tarball } => {
             if validate_npm_package(&package).is_err() || !valid_npm_tarball_name(&tarball) {
                 return invalid_npm_coordinate();
             }
-            download_tarball(&state, &package, &tarball)
+            download_tarball(&state, &package, &tarball).await
         }
     }
 }
@@ -135,7 +189,7 @@ async fn handle_put(
         return invalid_npm_coordinate();
     }
 
-    publish_package(&state, &package, identity, body)
+    publish_package(&state, &package, identity, body).await
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -288,8 +342,16 @@ fn invalid_npm_coordinate() -> Response {
         .into_response()
 }
 
-fn package_metadata(state: &NpmRegistryState, package: &str) -> Response {
-    let versions = match state.manifest_store.get_versions(Ecosystem::Npm, package) {
+async fn package_metadata(state: &NpmRegistryState, package: &str) -> Response {
+    let transaction = match state
+        .manifest_store
+        .read_transaction_async(Ecosystem::Npm)
+        .await
+    {
+        Ok(transaction) => transaction,
+        Err(_) => return StatusCode::NOT_FOUND.into_response(),
+    };
+    let versions = match transaction.get_versions(package) {
         Ok(v) if v.is_empty() => return StatusCode::NOT_FOUND.into_response(),
         Ok(v) => v,
         Err(_) => return StatusCode::NOT_FOUND.into_response(),
@@ -376,8 +438,16 @@ fn package_metadata(state: &NpmRegistryState, package: &str) -> Response {
     Json(response).into_response()
 }
 
-fn version_metadata(state: &NpmRegistryState, package: &str, version: &str) -> Response {
-    let versions = match state.manifest_store.get_versions(Ecosystem::Npm, package) {
+async fn version_metadata(state: &NpmRegistryState, package: &str, version: &str) -> Response {
+    let transaction = match state
+        .manifest_store
+        .read_transaction_async(Ecosystem::Npm)
+        .await
+    {
+        Ok(transaction) => transaction,
+        Err(_) => return StatusCode::NOT_FOUND.into_response(),
+    };
+    let versions = match transaction.get_versions(package) {
         Ok(v) => v,
         Err(_) => return StatusCode::NOT_FOUND.into_response(),
     };
@@ -391,8 +461,12 @@ fn version_metadata(state: &NpmRegistryState, package: &str, version: &str) -> R
     }
 }
 
-fn download_tarball(state: &NpmRegistryState, package: &str, tarball: &str) -> Response {
-    let transaction = match state.manifest_store.read_transaction(Ecosystem::Npm) {
+async fn download_tarball(state: &NpmRegistryState, package: &str, tarball: &str) -> Response {
+    let transaction = match state
+        .manifest_store
+        .read_transaction_async(Ecosystem::Npm)
+        .await
+    {
         Ok(transaction) => transaction,
         Err(_) => return StatusCode::INTERNAL_SERVER_ERROR.into_response(),
     };
@@ -464,7 +538,7 @@ struct NpmAttachment {
     length: Option<u64>,
 }
 
-fn publish_package(
+async fn publish_package(
     state: &NpmRegistryState,
     package: &str,
     identity: RegistryAccessIdentity,
@@ -620,7 +694,11 @@ fn publish_package(
                     .into_response();
             }
         };
-    let transaction = match state.manifest_store.write_transaction(Ecosystem::Npm) {
+    let transaction = match state
+        .manifest_store
+        .write_transaction_async(Ecosystem::Npm)
+        .await
+    {
         Ok(transaction) => transaction,
         Err(error) => {
             return (
@@ -984,11 +1062,11 @@ mod tests {
     fn registry_state() -> (tempfile::TempDir, Arc<NpmRegistryState>) {
         let root = tempfile::tempdir().unwrap();
         std::fs::create_dir_all(root.path().join(".kin")).unwrap();
-        let state = Arc::new(NpmRegistryState {
-            manifest_store: ManifestStore::new(&root.path().join(".kin")),
-            blobs_dir: root.path().join("npm"),
-            base_url: "https://kinlab.ai".to_string(),
-        });
+        let state = Arc::new(NpmRegistryState::new(
+            ManifestStore::new(&root.path().join(".kin")),
+            root.path().join("npm"),
+            "https://kinlab.ai".to_string(),
+        ));
         (root, state)
     }
 
@@ -1241,6 +1319,28 @@ mod tests {
         assert_eq!(response.status(), StatusCode::SERVICE_UNAVAILABLE);
     }
 
+    #[tokio::test]
+    async fn unauthenticated_publish_is_rejected_without_polling_the_body() {
+        use std::task::Poll;
+
+        let (_root, state) = registry_state();
+        let body = Body::from_stream(futures_util::stream::poll_fn(
+            |_| -> Poll<Option<Result<Bytes, std::io::Error>>> {
+                panic!("unauthenticated npm request body was polled")
+            },
+        ));
+        let response = npm_routes(state)
+            .oneshot(
+                Request::put("/registry/npm/demo")
+                    .header("content-type", "application/json")
+                    .body(body)
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(response.status(), StatusCode::SERVICE_UNAVAILABLE);
+    }
+
     #[test]
     fn stored_tarball_metadata_cannot_redirect_reads_outside_the_blob_root() {
         let root = tempfile::tempdir().unwrap();
@@ -1293,11 +1393,11 @@ mod tests {
         let blobs_dir = root.path().join("npm");
         std::fs::create_dir_all(&kin_dir).unwrap();
         let make_state = || {
-            Arc::new(NpmRegistryState {
-                manifest_store: ManifestStore::new(&kin_dir),
-                blobs_dir: blobs_dir.clone(),
-                base_url: "https://kinlab.ai".to_string(),
-            })
+            Arc::new(NpmRegistryState::new(
+                ManifestStore::new(&kin_dir),
+                blobs_dir.clone(),
+                "https://kinlab.ai".to_string(),
+            ))
         };
         let first_state = make_state();
         let second_state = make_state();

--- a/crates/kin-registry/src/npm.rs
+++ b/crates/kin-registry/src/npm.rs
@@ -11,7 +11,7 @@
 
 use axum::{
     body::Bytes,
-    extract::{Extension, OriginalUri, State},
+    extract::{DefaultBodyLimit, Extension, OriginalUri, State},
     http::{StatusCode, Uri},
     response::{IntoResponse, Json, Response},
     routing::get,
@@ -24,11 +24,17 @@ use serde::Deserialize;
 use serde_json::{Map, Value};
 use sha1::Sha1;
 use sha2::{Digest, Sha512};
-use std::{collections::BTreeMap, sync::Arc};
+use std::{collections::BTreeMap, path::Path as FsPath, sync::Arc};
 
 use crate::{Ecosystem, ManifestStore, PackageId, PackageVersion, RegistryError};
 
 const INTERNAL_REGISTRY_KEY: &str = "_kin_registry";
+const MAX_NPM_PACKAGE_LEN: usize = 214;
+const MAX_NPM_VERSION_LEN: usize = 128;
+const MAX_NPM_TARBALL_SIZE: usize = 100 * 1024 * 1024;
+const MAX_NPM_PUBLISH_BODY_SIZE: usize = 140 * 1024 * 1024;
+const MAX_NPM_ARCHIVE_ENTRIES: u64 = 100_000;
+const MAX_NPM_UNPACKED_SIZE: u64 = 1024 * 1024 * 1024;
 
 /// Shared state for the npm registry routes
 pub struct NpmRegistryState {
@@ -61,6 +67,7 @@ pub struct RegistryAccessIdentity {
 pub fn npm_routes(state: Arc<NpmRegistryState>) -> Router {
     Router::new()
         .route("/registry/npm/{*path}", get(handle_get).put(handle_put))
+        .layer(DefaultBodyLimit::max(MAX_NPM_PUBLISH_BODY_SIZE))
         .with_state(state)
 }
 
@@ -74,11 +81,24 @@ async fn handle_get(
     };
 
     match route {
-        ParsedRoute::PackageMetadata { package } => package_metadata(&state, &package),
+        ParsedRoute::PackageMetadata { package } => {
+            if validate_npm_package(&package).is_err() {
+                return invalid_npm_coordinate();
+            }
+            package_metadata(&state, &package)
+        }
         ParsedRoute::VersionMetadata { package, version } => {
+            if validate_npm_package(&package).is_err() || !valid_npm_version(&version) {
+                return invalid_npm_coordinate();
+            }
             version_metadata(&state, &package, &version)
         }
-        ParsedRoute::Tarball { package, tarball } => download_tarball(&state, &package, &tarball),
+        ParsedRoute::Tarball { package, tarball } => {
+            if validate_npm_package(&package).is_err() || !valid_npm_tarball_name(&tarball) {
+                return invalid_npm_coordinate();
+            }
+            download_tarball(&state, &package, &tarball)
+        }
     }
 }
 
@@ -98,12 +118,24 @@ async fn handle_put(
         _ => return StatusCode::METHOD_NOT_ALLOWED.into_response(),
     };
 
-    publish_package(
-        &state,
-        &package,
-        identity.map(|extension| extension.0),
-        body,
-    )
+    let identity = match identity {
+        Some(Extension(identity)) => identity,
+        None => {
+            return (
+                StatusCode::SERVICE_UNAVAILABLE,
+                Json(serde_json::json!({
+                    "error": "npm publishing is disabled: no authenticated registry identity",
+                })),
+            )
+                .into_response();
+        }
+    };
+
+    if validate_npm_package(&package).is_err() {
+        return invalid_npm_coordinate();
+    }
+
+    publish_package(&state, &package, identity, body)
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -188,6 +220,72 @@ fn decode_package_path(raw: &str) -> Option<String> {
         return None;
     }
     Some(decoded)
+}
+
+fn valid_npm_name_segment(segment: &str) -> bool {
+    if segment.is_empty() || segment == "." || segment == ".." {
+        return false;
+    }
+    let bytes = segment.as_bytes();
+    bytes
+        .first()
+        .is_some_and(|byte| byte.is_ascii_lowercase() || byte.is_ascii_digit())
+        && bytes
+            .last()
+            .is_some_and(|byte| byte.is_ascii_lowercase() || byte.is_ascii_digit())
+        && bytes.iter().all(|byte| {
+            byte.is_ascii_lowercase() || byte.is_ascii_digit() || matches!(byte, b'-' | b'_' | b'.')
+        })
+}
+
+fn validate_npm_package(package: &str) -> Result<PackageId, String> {
+    if package.is_empty() || package.len() > MAX_NPM_PACKAGE_LEN {
+        return Err("npm package name is empty or too long".to_string());
+    }
+    if let Some(scoped) = package.strip_prefix('@') {
+        let Some((scope, name)) = scoped.split_once('/') else {
+            return Err("scoped npm package must contain one scope and one name".to_string());
+        };
+        if name.contains('/') || !valid_npm_name_segment(scope) || !valid_npm_name_segment(name) {
+            return Err("scoped npm package contains an invalid segment".to_string());
+        }
+        return Ok(PackageId {
+            ecosystem: Ecosystem::Npm,
+            scope: Some(scope.to_string()),
+            name: name.to_string(),
+        });
+    }
+    if package.contains('/') || !valid_npm_name_segment(package) {
+        return Err("npm package contains an invalid segment".to_string());
+    }
+    Ok(PackageId {
+        ecosystem: Ecosystem::Npm,
+        scope: None,
+        name: package.to_string(),
+    })
+}
+
+fn valid_npm_version(version: &str) -> bool {
+    !version.is_empty()
+        && version.len() <= MAX_NPM_VERSION_LEN
+        && semver::Version::parse(version).is_ok()
+}
+
+fn valid_npm_tarball_name(tarball: &str) -> bool {
+    !tarball.is_empty()
+        && tarball.len() <= MAX_NPM_PACKAGE_LEN + MAX_NPM_VERSION_LEN + 5
+        && tarball.bytes().all(|byte| {
+            byte.is_ascii_lowercase() || byte.is_ascii_digit() || matches!(byte, b'-' | b'_' | b'.')
+        })
+        && !tarball.contains("..")
+}
+
+fn invalid_npm_coordinate() -> Response {
+    (
+        StatusCode::BAD_REQUEST,
+        Json(serde_json::json!({ "error": "invalid npm package coordinate" })),
+    )
+        .into_response()
 }
 
 fn package_metadata(state: &NpmRegistryState, package: &str) -> Response {
@@ -294,7 +392,11 @@ fn version_metadata(state: &NpmRegistryState, package: &str, version: &str) -> R
 }
 
 fn download_tarball(state: &NpmRegistryState, package: &str, tarball: &str) -> Response {
-    let versions = match state.manifest_store.get_versions(Ecosystem::Npm, package) {
+    let transaction = match state.manifest_store.read_transaction(Ecosystem::Npm) {
+        Ok(transaction) => transaction,
+        Err(_) => return StatusCode::INTERNAL_SERVER_ERROR.into_response(),
+    };
+    let versions = match transaction.get_versions(package) {
         Ok(v) => v,
         Err(_) => return StatusCode::NOT_FOUND.into_response(),
     };
@@ -313,7 +415,11 @@ fn download_tarball(state: &NpmRegistryState, package: &str, tarball: &str) -> R
         None => return StatusCode::NOT_FOUND.into_response(),
     };
 
-    let tarball_path = state.blobs_dir.join(&metadata.blob_rel_path);
+    let tarball_path =
+        match stored_npm_blob_path(&state.blobs_dir, package, &pkg_version.version, &metadata) {
+            Some(path) => path,
+            None => return StatusCode::INTERNAL_SERVER_ERROR.into_response(),
+        };
     match std::fs::read(&tarball_path) {
         Ok(bytes) => (
             StatusCode::OK,
@@ -361,7 +467,7 @@ struct NpmAttachment {
 fn publish_package(
     state: &NpmRegistryState,
     package: &str,
-    identity: Option<RegistryAccessIdentity>,
+    identity: RegistryAccessIdentity,
     body: Bytes,
 ) -> Response {
     let publish_request: NpmPublishRequest = match serde_json::from_slice(&body) {
@@ -387,6 +493,15 @@ fn publish_package(
             .into_response();
     }
 
+    if publish_request.versions.len() != 1 {
+        return (
+            StatusCode::BAD_REQUEST,
+            Json(serde_json::json!({
+                "error": "npm publish payload must contain exactly one version",
+            })),
+        )
+            .into_response();
+    }
     let (version, mut version_document) = match publish_request.versions.into_iter().next() {
         Some((version, Value::Object(document))) => (version, Value::Object(document)),
         Some(_) => {
@@ -409,27 +524,26 @@ fn publish_package(
         }
     };
 
-    let existing = match state.manifest_store.get_versions(Ecosystem::Npm, package) {
-        Ok(existing) => existing,
-        Err(error) => {
-            return (
-                StatusCode::INTERNAL_SERVER_ERROR,
-                Json(serde_json::json!({ "error": format!("{error}") })),
-            )
-                .into_response();
-        }
-    };
-    if existing.iter().any(|entry| entry.version == version) {
+    if !valid_npm_version(&version) {
+        return invalid_npm_coordinate();
+    }
+    if version_document.get("name").and_then(Value::as_str) != Some(package)
+        || version_document.get("version").and_then(Value::as_str) != Some(version.as_str())
+    {
         return (
-            StatusCode::CONFLICT,
+            StatusCode::BAD_REQUEST,
             Json(serde_json::json!({
-                "error": format!("version already exists: {package}@{version}"),
+                "error": "npm version document does not match the published coordinate",
             })),
         )
             .into_response();
     }
 
-    let package_id = PackageId::from_registry_name(Ecosystem::Npm, package);
+    let package_id = match validate_npm_package(package) {
+        Ok(package_id) => package_id,
+        Err(_) => return invalid_npm_coordinate(),
+    };
+
     let tarball_filename = tarball_filename(&package_id, &version);
 
     let attachment = match select_attachment(&publish_request.attachments, &package_id, &version) {
@@ -457,6 +571,15 @@ fn publish_package(
                 .into_response();
         }
     };
+    if tarball_bytes.is_empty() || tarball_bytes.len() > MAX_NPM_TARBALL_SIZE {
+        return (
+            StatusCode::PAYLOAD_TOO_LARGE,
+            Json(serde_json::json!({
+                "error": "npm tarball is empty or exceeds the configured size limit",
+            })),
+        )
+            .into_response();
+    }
 
     if let Some(expected_length) = attachment.length {
         if expected_length != tarball_bytes.len() as u64 {
@@ -473,36 +596,60 @@ fn publish_package(
     let shasum = hex::encode(Sha1::digest(&tarball_bytes));
     let blob_hash = hex::encode(sha2::Sha256::digest(&tarball_bytes));
     let integrity = format!("sha512-{}", STANDARD.encode(Sha512::digest(&tarball_bytes)));
-    let (file_count, unpacked_size) = tarball_stats(&tarball_bytes);
-
-    let package_dir = match tarball_dir(&package_id) {
-        Some(dir) => dir,
-        None => {
+    let (file_count, unpacked_size) = match tarball_stats(&tarball_bytes) {
+        Ok(stats) => stats,
+        Err(error) => {
             return (
                 StatusCode::BAD_REQUEST,
-                Json(serde_json::json!({
-                    "error": "invalid npm package name",
-                })),
+                Json(serde_json::json!({ "error": error })),
             )
                 .into_response();
         }
     };
-    let tarball_rel_path = package_dir.join(&tarball_filename);
-    let tarball_path = state.blobs_dir.join(&tarball_rel_path);
 
-    if let Some(parent) = tarball_path.parent() {
-        if let Err(error) = std::fs::create_dir_all(parent) {
+    let (tarball_rel_path, tarball_path) =
+        match npm_blob_path(&state.blobs_dir, &package_id, &version) {
+            Some(paths) => paths,
+            None => {
+                return (
+                    StatusCode::BAD_REQUEST,
+                    Json(serde_json::json!({
+                        "error": "invalid npm package name",
+                    })),
+                )
+                    .into_response();
+            }
+        };
+    let transaction = match state.manifest_store.write_transaction(Ecosystem::Npm) {
+        Ok(transaction) => transaction,
+        Err(error) => {
             return (
                 StatusCode::INTERNAL_SERVER_ERROR,
-                Json(serde_json::json!({
-                    "error": format!("failed to create npm blob directory: {error}"),
-                })),
+                Json(serde_json::json!({ "error": format!("{error}") })),
             )
                 .into_response();
         }
+    };
+    let existing = match transaction.get_versions(package) {
+        Ok(existing) => existing,
+        Err(error) => {
+            return (
+                StatusCode::INTERNAL_SERVER_ERROR,
+                Json(serde_json::json!({ "error": format!("{error}") })),
+            )
+                .into_response();
+        }
+    };
+    if existing.iter().any(|entry| entry.version == version) {
+        return (
+            StatusCode::CONFLICT,
+            Json(serde_json::json!({
+                "error": format!("version already exists: {package}@{version}"),
+            })),
+        )
+            .into_response();
     }
-
-    if let Err(error) = std::fs::write(&tarball_path, &tarball_bytes) {
+    if let Err(error) = crate::atomic_file::write(&tarball_path, &tarball_bytes) {
         return (
             StatusCode::INTERNAL_SERVER_ERROR,
             Json(serde_json::json!({
@@ -561,10 +708,7 @@ fn publish_package(
         );
     }
 
-    let published_by = identity
-        .as_ref()
-        .map(|caller| caller.email.clone())
-        .unwrap_or_else(|| "anonymous".to_string());
+    let published_by = identity.email;
 
     let package_version = PackageVersion {
         id: package_id,
@@ -578,7 +722,7 @@ fn publish_package(
         yanked: false,
     };
 
-    match state.manifest_store.add_version(&package_version) {
+    match transaction.add_version(&package_version) {
         Ok(()) => (
             StatusCode::CREATED,
             Json(serde_json::json!({
@@ -648,6 +792,48 @@ fn tarball_dir(package_id: &PackageId) -> Option<std::path::PathBuf> {
     Some(path)
 }
 
+fn npm_blob_path(
+    blobs_dir: &FsPath,
+    package_id: &PackageId,
+    version: &str,
+) -> Option<(std::path::PathBuf, std::path::PathBuf)> {
+    let validated = validate_npm_package(&package_id.canonical_name()).ok()?;
+    if package_id.ecosystem != Ecosystem::Npm
+        || !valid_npm_version(version)
+        || validated.scope != package_id.scope
+        || validated.name != package_id.name
+    {
+        return None;
+    }
+    let directory = tarball_dir(package_id)?;
+    let relative = directory.join(tarball_filename(package_id, version));
+    if relative
+        .components()
+        .any(|component| !matches!(component, std::path::Component::Normal(_)))
+    {
+        return None;
+    }
+    let package_directory = blobs_dir.join(&directory);
+    let path = blobs_dir.join(&relative);
+    (path.parent() == Some(package_directory.as_path())).then_some((relative, path))
+}
+
+fn stored_npm_blob_path(
+    blobs_dir: &FsPath,
+    package: &str,
+    version: &str,
+    metadata: &ParsedRegistryMetadata,
+) -> Option<std::path::PathBuf> {
+    let package_id = validate_npm_package(package).ok()?;
+    let (expected_relative, expected_path) = npm_blob_path(blobs_dir, &package_id, version)?;
+    if metadata.tarball_filename != tarball_filename(&package_id, version)
+        || FsPath::new(&metadata.blob_rel_path) != expected_relative
+    {
+        return None;
+    }
+    Some(expected_path)
+}
+
 fn npm_version_document(
     state: &NpmRegistryState,
     package: &str,
@@ -698,7 +884,7 @@ fn format_npm_time(timestamp: chrono::DateTime<Utc>) -> String {
     timestamp.to_rfc3339_opts(SecondsFormat::Millis, true)
 }
 
-fn tarball_stats(tarball_bytes: &[u8]) -> (u64, u64) {
+fn tarball_stats(tarball_bytes: &[u8]) -> Result<(u64, u64), String> {
     use flate2::read::GzDecoder;
 
     let gz = GzDecoder::new(tarball_bytes);
@@ -706,14 +892,35 @@ fn tarball_stats(tarball_bytes: &[u8]) -> (u64, u64) {
     let mut file_count = 0u64;
     let mut unpacked_size = 0u64;
 
-    if let Ok(entries) = archive.entries() {
-        for entry in entries.flatten() {
-            file_count += 1;
-            unpacked_size += entry.header().size().unwrap_or(0);
+    let entries = archive
+        .entries()
+        .map_err(|error| format!("npm attachment is not a valid gzip-tar archive: {error}"))?;
+    for entry in entries {
+        let entry = entry
+            .map_err(|error| format!("npm attachment is not a valid gzip-tar archive: {error}"))?;
+        file_count = file_count
+            .checked_add(1)
+            .ok_or_else(|| "npm archive entry count overflowed".to_string())?;
+        if file_count > MAX_NPM_ARCHIVE_ENTRIES {
+            return Err(format!(
+                "npm archive exceeds the {MAX_NPM_ARCHIVE_ENTRIES} entry limit"
+            ));
+        }
+        let size = entry
+            .header()
+            .size()
+            .map_err(|error| format!("npm archive entry has an invalid size: {error}"))?;
+        unpacked_size = unpacked_size
+            .checked_add(size)
+            .ok_or_else(|| "npm archive unpacked size overflowed".to_string())?;
+        if unpacked_size > MAX_NPM_UNPACKED_SIZE {
+            return Err(format!(
+                "npm archive exceeds the {MAX_NPM_UNPACKED_SIZE} byte unpacked limit"
+            ));
         }
     }
 
-    (file_count, unpacked_size)
+    Ok((file_count, unpacked_size))
 }
 
 #[derive(Debug, Clone)]
@@ -774,13 +981,64 @@ mod tests {
     use axum::http::{Method, Request, StatusCode};
     use tower::ServiceExt;
 
-    fn registry_state() -> Arc<NpmRegistryState> {
+    fn registry_state() -> (tempfile::TempDir, Arc<NpmRegistryState>) {
         let root = tempfile::tempdir().unwrap();
         std::fs::create_dir_all(root.path().join(".kin")).unwrap();
-        Arc::new(NpmRegistryState {
+        let state = Arc::new(NpmRegistryState {
             manifest_store: ManifestStore::new(&root.path().join(".kin")),
             blobs_dir: root.path().join("npm"),
             base_url: "https://kinlab.ai".to_string(),
+        });
+        (root, state)
+    }
+
+    fn publish_identity() -> RegistryAccessIdentity {
+        RegistryAccessIdentity {
+            email: "builder@firelock.ai".to_string(),
+            display_name: "Builder".to_string(),
+            user_id: "user_123".to_string(),
+            actor_kind: "human".to_string(),
+            org_ids: vec![],
+            scopes: vec!["packages:write".to_string()],
+            credential_type: Some("pat".to_string()),
+        }
+    }
+
+    fn build_test_tarball(marker: &str) -> Vec<u8> {
+        use flate2::{write::GzEncoder, Compression};
+
+        let encoder = GzEncoder::new(Vec::new(), Compression::default());
+        let mut builder = tar::Builder::new(encoder);
+        let contents = format!("module.exports = {marker:?};\n");
+        let mut header = tar::Header::new_gnu();
+        header.set_size(contents.len() as u64);
+        header.set_mode(0o644);
+        header.set_cksum();
+        builder
+            .append_data(&mut header, "package/index.js", contents.as_bytes())
+            .unwrap();
+        builder.into_inner().unwrap().finish().unwrap()
+    }
+
+    fn publish_payload(package: &str, version: &str, tarball: &[u8]) -> Value {
+        let attachment = format!("{package}-{version}.tgz");
+        serde_json::json!({
+            "_id": package,
+            "name": package,
+            "dist-tags": { "latest": version },
+            "versions": {
+                version: {
+                    "name": package,
+                    "version": version,
+                }
+            },
+            "_attachments": {
+                attachment: {
+                    "content_type": "application/octet-stream",
+                    "data": STANDARD.encode(tarball),
+                    "length": tarball.len(),
+                }
+            }
         })
     }
 
@@ -816,8 +1074,9 @@ mod tests {
 
     #[tokio::test]
     async fn publishes_and_reads_back_scoped_package_metadata() {
-        let state = registry_state();
+        let (_root, state) = registry_state();
         let app = npm_routes(state.clone());
+        let tarball_bytes = build_test_tarball("boundary-contracts");
         let payload = serde_json::json!({
             "_id": "@kin/boundary-contracts",
             "name": "@kin/boundary-contracts",
@@ -836,8 +1095,8 @@ mod tests {
             "_attachments": {
                 "@kin/boundary-contracts-0.1.0.tgz": {
                     "content_type": "application/octet-stream",
-                    "data": STANDARD.encode(b"fake-tarball"),
-                    "length": 12
+                    "data": STANDARD.encode(&tarball_bytes),
+                    "length": tarball_bytes.len()
                 }
             }
         });
@@ -848,15 +1107,7 @@ mod tests {
                 Request::builder()
                     .method(Method::PUT)
                     .uri("/registry/npm/@kin%2Fboundary-contracts")
-                    .extension(RegistryAccessIdentity {
-                        email: "builder@firelock.ai".to_string(),
-                        display_name: "Builder".to_string(),
-                        user_id: "user_123".to_string(),
-                        actor_kind: "human".to_string(),
-                        org_ids: vec![],
-                        scopes: vec!["packages:write".to_string()],
-                        credential_type: Some("pat".to_string()),
-                    })
+                    .extension(publish_identity())
                     .header("content-type", "application/json")
                     .body(Body::from(payload.to_string()))
                     .unwrap(),
@@ -923,8 +1174,9 @@ mod tests {
 
     #[tokio::test]
     async fn rejects_immutable_version_republish() {
-        let state = registry_state();
+        let (_root, state) = registry_state();
         let app = npm_routes(state);
+        let tarball_bytes = build_test_tarball("immutable");
         let payload = serde_json::json!({
             "_id": "@kin/boundary-contracts",
             "name": "@kin/boundary-contracts",
@@ -938,8 +1190,8 @@ mod tests {
             "_attachments": {
                 "@kin/boundary-contracts-0.1.0.tgz": {
                     "content_type": "application/octet-stream",
-                    "data": STANDARD.encode(b"fake-tarball"),
-                    "length": 12
+                    "data": STANDARD.encode(&tarball_bytes),
+                    "length": tarball_bytes.len()
                 }
             }
         });
@@ -950,6 +1202,7 @@ mod tests {
                 Request::builder()
                     .method(Method::PUT)
                     .uri("/registry/npm/@kin%2Fboundary-contracts")
+                    .extension(publish_identity())
                     .header("content-type", "application/json")
                     .body(Body::from(payload.to_string()))
                     .unwrap(),
@@ -963,6 +1216,7 @@ mod tests {
                 Request::builder()
                     .method(Method::PUT)
                     .uri("/registry/npm/@kin%2Fboundary-contracts")
+                    .extension(publish_identity())
                     .header("content-type", "application/json")
                     .body(Body::from(payload.to_string()))
                     .unwrap(),
@@ -970,5 +1224,125 @@ mod tests {
             .await
             .unwrap();
         assert_eq!(second.status(), StatusCode::CONFLICT);
+    }
+
+    #[tokio::test]
+    async fn publishing_fails_closed_without_an_authenticated_identity() {
+        let (_root, state) = registry_state();
+        let response = npm_routes(state)
+            .oneshot(
+                Request::put("/registry/npm/demo")
+                    .header("content-type", "application/json")
+                    .body(Body::from("{}"))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(response.status(), StatusCode::SERVICE_UNAVAILABLE);
+    }
+
+    #[test]
+    fn stored_tarball_metadata_cannot_redirect_reads_outside_the_blob_root() {
+        let root = tempfile::tempdir().unwrap();
+        let metadata = ParsedRegistryMetadata {
+            tarball_filename: "demo-1.0.0.tgz".to_string(),
+            blob_rel_path: "../outside".to_string(),
+            content_type: None,
+            shasum: "checksum".to_string(),
+            integrity: "integrity".to_string(),
+            file_count: 0,
+            unpacked_size: 0,
+            dist_tags: None,
+            readme: None,
+        };
+        assert!(stored_npm_blob_path(root.path(), "demo", "1.0.0", &metadata).is_none());
+        for invalid in [
+            "../demo",
+            "@scope/../demo",
+            "@../demo",
+            "demo/../../outside",
+        ] {
+            assert!(
+                validate_npm_package(invalid).is_err(),
+                "accepted {invalid:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn archive_stats_reject_invalid_and_declared_oversize_tarballs() {
+        assert!(tarball_stats(b"not-a-tarball").is_err());
+
+        use flate2::{write::GzEncoder, Compression};
+        use std::io::Write;
+        let mut header = tar::Header::new_gnu();
+        header.set_size(MAX_NPM_UNPACKED_SIZE + 1);
+        header.set_mode(0o644);
+        header.set_cksum();
+        let mut encoder = GzEncoder::new(Vec::new(), Compression::default());
+        encoder.write_all(header.as_bytes()).unwrap();
+        let declared_oversize = encoder.finish().unwrap();
+        let error = tarball_stats(&declared_oversize).unwrap_err();
+        assert!(error.contains("unpacked limit"), "{error}");
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+    async fn independent_states_preserve_concurrent_versions_and_matching_blobs() {
+        let root = tempfile::tempdir().unwrap();
+        let kin_dir = root.path().join(".kin");
+        let blobs_dir = root.path().join("npm");
+        std::fs::create_dir_all(&kin_dir).unwrap();
+        let make_state = || {
+            Arc::new(NpmRegistryState {
+                manifest_store: ManifestStore::new(&kin_dir),
+                blobs_dir: blobs_dir.clone(),
+                base_url: "https://kinlab.ai".to_string(),
+            })
+        };
+        let first_state = make_state();
+        let second_state = make_state();
+        let first_tarball = build_test_tarball("first");
+        let second_tarball = build_test_tarball("second");
+        let start = Arc::new(tokio::sync::Barrier::new(3));
+
+        let publish = |state: Arc<NpmRegistryState>,
+                       version: &'static str,
+                       tarball: Vec<u8>,
+                       start: Arc<tokio::sync::Barrier>| {
+            tokio::spawn(async move {
+                let payload = publish_payload("demo", version, &tarball);
+                start.wait().await;
+                npm_routes(state)
+                    .oneshot(
+                        Request::put("/registry/npm/demo")
+                            .extension(publish_identity())
+                            .header("content-type", "application/json")
+                            .body(Body::from(payload.to_string()))
+                            .unwrap(),
+                    )
+                    .await
+                    .unwrap()
+                    .status()
+            })
+        };
+        let first = publish(first_state, "1.0.0", first_tarball.clone(), start.clone());
+        let second = publish(second_state, "2.0.0", second_tarball.clone(), start.clone());
+        start.wait().await;
+        assert_eq!(first.await.unwrap(), StatusCode::CREATED);
+        assert_eq!(second.await.unwrap(), StatusCode::CREATED);
+
+        let versions = ManifestStore::new(&kin_dir)
+            .get_versions(Ecosystem::Npm, "demo")
+            .unwrap();
+        assert_eq!(versions.len(), 2);
+        for (version, expected) in [("1.0.0", first_tarball), ("2.0.0", second_tarball)] {
+            let entry = versions
+                .iter()
+                .find(|candidate| candidate.version == version)
+                .unwrap();
+            let metadata = registry_metadata(entry).unwrap();
+            let path = stored_npm_blob_path(&blobs_dir, "demo", version, &metadata).unwrap();
+            assert_eq!(std::fs::read(path).unwrap(), expected);
+        }
     }
 }

--- a/crates/kin-registry/src/npm.rs
+++ b/crates/kin-registry/src/npm.rs
@@ -41,6 +41,7 @@ const MAX_NPM_UNPACKED_SIZE: u64 = 1024 * 1024 * 1024;
 pub struct NpmRegistryState {
     pub manifest_store: ManifestStore,
     pub blobs_dir: std::path::PathBuf,
+    blobs_authority: crate::atomic_file::AuthorityRoot,
     pub base_url: String,
 }
 
@@ -50,10 +51,12 @@ impl NpmRegistryState {
         blobs_dir: std::path::PathBuf,
         base_url: String,
     ) -> Self {
-        let blobs_dir = crate::atomic_file::pin_authority_root(&blobs_dir).unwrap_or(blobs_dir);
+        let blobs_authority = crate::atomic_file::AuthorityRoot::new(&blobs_dir);
+        let blobs_dir = blobs_authority.path().to_path_buf();
         Self {
             manifest_store,
             blobs_dir,
+            blobs_authority,
             base_url,
         }
     }
@@ -189,7 +192,7 @@ async fn handle_put(
         return invalid_npm_coordinate();
     }
 
-    publish_package(&state, &package, identity, body).await
+    publish_package(state, &package, identity, body).await
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -328,10 +331,11 @@ fn valid_npm_version(version: &str) -> bool {
 fn valid_npm_tarball_name(tarball: &str) -> bool {
     !tarball.is_empty()
         && tarball.len() <= MAX_NPM_PACKAGE_LEN + MAX_NPM_VERSION_LEN + 5
-        && tarball.bytes().all(|byte| {
-            byte.is_ascii_lowercase() || byte.is_ascii_digit() || matches!(byte, b'-' | b'_' | b'.')
-        })
-        && !tarball.contains("..")
+        && tarball != "."
+        && tarball != ".."
+        && !tarball
+            .bytes()
+            .any(|byte| byte.is_ascii_control() || matches!(byte, b'/' | b'\\' | 0))
 }
 
 fn invalid_npm_coordinate() -> Response {
@@ -342,16 +346,28 @@ fn invalid_npm_coordinate() -> Response {
         .into_response()
 }
 
-async fn package_metadata(state: &NpmRegistryState, package: &str) -> Response {
-    let transaction = match state
-        .manifest_store
-        .read_transaction_async(Ecosystem::Npm)
-        .await
-    {
-        Ok(transaction) => transaction,
-        Err(_) => return StatusCode::NOT_FOUND.into_response(),
-    };
-    let versions = match transaction.get_versions(package) {
+async fn read_npm_versions(
+    state: &Arc<NpmRegistryState>,
+    package: &str,
+) -> Result<Vec<PackageVersion>, RegistryError> {
+    let state = Arc::clone(state);
+    let package = package.to_string();
+    tokio::task::spawn_blocking(move || {
+        state
+            .manifest_store
+            .read_transaction(Ecosystem::Npm)?
+            .get_versions(&package)
+    })
+    .await
+    .map_err(|error| {
+        RegistryError::Storage(std::io::Error::other(format!(
+            "npm storage task failed: {error}"
+        )))
+    })?
+}
+
+async fn package_metadata(state: &Arc<NpmRegistryState>, package: &str) -> Response {
+    let versions = match read_npm_versions(state, package).await {
         Ok(v) if v.is_empty() => return StatusCode::NOT_FOUND.into_response(),
         Ok(v) => v,
         Err(_) => return StatusCode::NOT_FOUND.into_response(),
@@ -438,16 +454,8 @@ async fn package_metadata(state: &NpmRegistryState, package: &str) -> Response {
     Json(response).into_response()
 }
 
-async fn version_metadata(state: &NpmRegistryState, package: &str, version: &str) -> Response {
-    let transaction = match state
-        .manifest_store
-        .read_transaction_async(Ecosystem::Npm)
-        .await
-    {
-        Ok(transaction) => transaction,
-        Err(_) => return StatusCode::NOT_FOUND.into_response(),
-    };
-    let versions = match transaction.get_versions(package) {
+async fn version_metadata(state: &Arc<NpmRegistryState>, package: &str, version: &str) -> Response {
+    let versions = match read_npm_versions(state, package).await {
         Ok(v) => v,
         Err(_) => return StatusCode::NOT_FOUND.into_response(),
     };
@@ -461,56 +469,64 @@ async fn version_metadata(state: &NpmRegistryState, package: &str, version: &str
     }
 }
 
-async fn download_tarball(state: &NpmRegistryState, package: &str, tarball: &str) -> Response {
-    let transaction = match state
-        .manifest_store
-        .read_transaction_async(Ecosystem::Npm)
-        .await
-    {
-        Ok(transaction) => transaction,
-        Err(_) => return StatusCode::INTERNAL_SERVER_ERROR.into_response(),
-    };
-    let versions = match transaction.get_versions(package) {
-        Ok(v) => v,
-        Err(_) => return StatusCode::NOT_FOUND.into_response(),
-    };
-
-    let pkg_version = match versions.iter().find(|version| {
-        registry_metadata(version)
-            .map(|meta| meta.tarball_filename == tarball)
-            .unwrap_or(false)
-    }) {
-        Some(version) => version,
-        None => return StatusCode::NOT_FOUND.into_response(),
-    };
-
-    let metadata = match registry_metadata(pkg_version) {
-        Some(metadata) => metadata,
-        None => return StatusCode::NOT_FOUND.into_response(),
-    };
-
-    let tarball_path =
-        match stored_npm_blob_path(&state.blobs_dir, package, &pkg_version.version, &metadata) {
-            Some(path) => path,
-            None => return StatusCode::INTERNAL_SERVER_ERROR.into_response(),
+async fn download_tarball(state: &Arc<NpmRegistryState>, package: &str, tarball: &str) -> Response {
+    let read_state = Arc::clone(state);
+    let package = package.to_string();
+    let tarball = tarball.to_string();
+    let result = tokio::task::spawn_blocking(move || {
+        let transaction = read_state.manifest_store.read_transaction(Ecosystem::Npm)?;
+        let versions = transaction.get_versions(&package)?;
+        let Some(pkg_version) = versions.iter().find(|candidate| {
+            registry_metadata(candidate)
+                .is_some_and(|metadata| metadata.tarball_filename == tarball)
+        }) else {
+            return Ok::<_, RegistryError>(None);
         };
-    match std::fs::read(&tarball_path) {
-        Ok(bytes) => (
+        let Some(metadata) = registry_metadata(pkg_version) else {
+            return Ok(None);
+        };
+        let Some(path) = stored_npm_blob_path(
+            &read_state.blobs_dir,
+            &package,
+            &pkg_version.version,
+            &metadata,
+        ) else {
+            return Err(RegistryError::InvalidOperation(
+                "stored npm blob path failed validation".to_string(),
+            ));
+        };
+        let relative = path.strip_prefix(&read_state.blobs_dir).map_err(|_| {
+            RegistryError::InvalidOperation("stored npm blob escaped authority".to_string())
+        })?;
+        let bytes = match read_state.blobs_authority.read(relative) {
+            Ok(bytes) => bytes,
+            Err(error) if error.kind() == std::io::ErrorKind::NotFound => return Ok(None),
+            Err(error) => return Err(error.into()),
+        };
+        Ok(Some((
+            bytes,
+            pkg_version.checksum.clone(),
+            metadata.content_type,
+        )))
+    })
+    .await;
+    match result {
+        Ok(Ok(Some((bytes, checksum, content_type)))) => (
             StatusCode::OK,
             [
                 (
                     "content-type",
-                    metadata
-                        .content_type
+                    content_type
                         .as_deref()
                         .unwrap_or("application/octet-stream"),
                 ),
-                ("etag", &format!("\"{}\"", pkg_version.checksum)),
+                ("etag", &format!("\"{checksum}\"")),
             ],
             bytes,
         )
             .into_response(),
-        Err(_) => StatusCode::NOT_FOUND.into_response(),
+        Ok(Ok(None)) => StatusCode::NOT_FOUND.into_response(),
+        Ok(Err(_)) | Err(_) => StatusCode::INTERNAL_SERVER_ERROR.into_response(),
     }
 }
 
@@ -539,7 +555,7 @@ struct NpmAttachment {
 }
 
 async fn publish_package(
-    state: &NpmRegistryState,
+    state: Arc<NpmRegistryState>,
     package: &str,
     identity: RegistryAccessIdentity,
     body: Bytes,
@@ -694,49 +710,6 @@ async fn publish_package(
                     .into_response();
             }
         };
-    let transaction = match state
-        .manifest_store
-        .write_transaction_async(Ecosystem::Npm)
-        .await
-    {
-        Ok(transaction) => transaction,
-        Err(error) => {
-            return (
-                StatusCode::INTERNAL_SERVER_ERROR,
-                Json(serde_json::json!({ "error": format!("{error}") })),
-            )
-                .into_response();
-        }
-    };
-    let existing = match transaction.get_versions(package) {
-        Ok(existing) => existing,
-        Err(error) => {
-            return (
-                StatusCode::INTERNAL_SERVER_ERROR,
-                Json(serde_json::json!({ "error": format!("{error}") })),
-            )
-                .into_response();
-        }
-    };
-    if existing.iter().any(|entry| entry.version == version) {
-        return (
-            StatusCode::CONFLICT,
-            Json(serde_json::json!({
-                "error": format!("version already exists: {package}@{version}"),
-            })),
-        )
-            .into_response();
-    }
-    if let Err(error) = crate::atomic_file::write(&tarball_path, &tarball_bytes) {
-        return (
-            StatusCode::INTERNAL_SERVER_ERROR,
-            Json(serde_json::json!({
-                "error": format!("failed to store npm tarball: {error}"),
-            })),
-        )
-            .into_response();
-    }
-
     let mut registry_metadata = Map::new();
     registry_metadata.insert(
         "tarball_filename".to_string(),
@@ -800,8 +773,37 @@ async fn publish_package(
         yanked: false,
     };
 
-    match transaction.add_version(&package_version) {
-        Ok(()) => (
+    let relative = match tarball_path.strip_prefix(&state.blobs_dir) {
+        Ok(relative) if relative == tarball_rel_path => relative.to_path_buf(),
+        _ => {
+            return (
+                StatusCode::INTERNAL_SERVER_ERROR,
+                Json(serde_json::json!({ "error": "npm blob escaped storage authority" })),
+            )
+                .into_response();
+        }
+    };
+    let commit_state = Arc::clone(&state);
+    let commit_package = package.to_string();
+    let commit_version = version.clone();
+    let commit_bytes = tarball_bytes;
+    let result = tokio::task::spawn_blocking(move || {
+        let transaction = commit_state
+            .manifest_store
+            .write_transaction(Ecosystem::Npm)?;
+        let existing = transaction.get_versions(&commit_package)?;
+        if existing.iter().any(|entry| entry.version == commit_version) {
+            return Err(RegistryError::VersionExists(commit_package, commit_version));
+        }
+        commit_state
+            .blobs_authority
+            .write(&relative, &commit_bytes)
+            .map_err(RegistryError::Storage)?;
+        transaction.add_version(&package_version)
+    })
+    .await;
+    match result {
+        Ok(Ok(())) => (
             StatusCode::CREATED,
             Json(serde_json::json!({
                 "ok": "created",
@@ -811,16 +813,23 @@ async fn publish_package(
             })),
         )
             .into_response(),
-        Err(RegistryError::VersionExists(name, version)) => (
+        Ok(Err(RegistryError::VersionExists(name, version))) => (
             StatusCode::CONFLICT,
             Json(serde_json::json!({
                 "error": format!("version already exists: {name}@{version}"),
             })),
         )
             .into_response(),
-        Err(error) => (
+        Ok(Err(error)) => (
             StatusCode::INTERNAL_SERVER_ERROR,
             Json(serde_json::json!({ "error": format!("{error}") })),
+        )
+            .into_response(),
+        Err(error) => (
+            StatusCode::INTERNAL_SERVER_ERROR,
+            Json(serde_json::json!({
+                "error": format!("npm publication task failed: {error}")
+            })),
         )
             .into_response(),
     }
@@ -963,9 +972,8 @@ fn format_npm_time(timestamp: chrono::DateTime<Utc>) -> String {
 }
 
 fn tarball_stats(tarball_bytes: &[u8]) -> Result<(u64, u64), String> {
-    use flate2::read::GzDecoder;
-
-    let gz = GzDecoder::new(tarball_bytes);
+    use flate2::bufread::GzDecoder;
+    let gz = GzDecoder::new(std::io::BufReader::new(tarball_bytes));
     let mut archive = tar::Archive::new(gz);
     let mut file_count = 0u64;
     let mut unpacked_size = 0u64;
@@ -996,6 +1004,16 @@ fn tarball_stats(tarball_bytes: &[u8]) -> Result<(u64, u64), String> {
                 "npm archive exceeds the {MAX_NPM_UNPACKED_SIZE} byte unpacked limit"
             ));
         }
+    }
+
+    let mut decoder = archive.into_inner();
+    std::io::copy(&mut decoder, &mut std::io::sink())
+        .map_err(|error| format!("npm attachment gzip stream is truncated: {error}"))?;
+    let compressed = decoder.into_inner();
+    if !compressed.buffer().is_empty() || !compressed.get_ref().is_empty() {
+        return Err(
+            "npm attachment contains trailing data or more than one gzip member".to_string(),
+        );
     }
 
     Ok((file_count, unpacked_size))
@@ -1384,6 +1402,86 @@ mod tests {
         let declared_oversize = encoder.finish().unwrap();
         let error = tarball_stats(&declared_oversize).unwrap_err();
         assert!(error.contains("unpacked limit"), "{error}");
+    }
+
+    #[test]
+    fn archive_stats_rejects_a_second_gzip_member() {
+        let mut tarball = build_test_tarball("first");
+        tarball.extend_from_slice(&build_test_tarball("second"));
+        assert!(tarball_stats(&tarball)
+            .unwrap_err()
+            .contains("more than one gzip member"));
+    }
+
+    #[tokio::test]
+    async fn every_accepted_semver_tarball_is_retrievable() {
+        let (_root, state) = registry_state();
+        let app = npm_routes(state);
+        for version in ["1.0.0+build.1", "1.0.1-RC.1"] {
+            let tarball = build_test_tarball(version);
+            let payload = publish_payload("demo", version, &tarball);
+            let published = app
+                .clone()
+                .oneshot(
+                    Request::put("/registry/npm/demo")
+                        .extension(publish_identity())
+                        .header(header::CONTENT_TYPE, "application/json")
+                        .body(Body::from(serde_json::to_vec(&payload).unwrap()))
+                        .unwrap(),
+                )
+                .await
+                .unwrap();
+            assert_eq!(published.status(), StatusCode::CREATED, "{version}");
+
+            let downloaded = app
+                .clone()
+                .oneshot(
+                    Request::get(format!("/registry/npm/demo/-/demo-{version}.tgz"))
+                        .body(Body::empty())
+                        .unwrap(),
+                )
+                .await
+                .unwrap();
+            assert_eq!(downloaded.status(), StatusCode::OK, "{version}");
+            assert_eq!(
+                axum::body::to_bytes(downloaded.into_body(), MAX_NPM_TARBALL_SIZE)
+                    .await
+                    .unwrap()
+                    .as_ref(),
+                tarball.as_slice()
+            );
+        }
+    }
+
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn live_npm_state_cannot_be_redirected_by_root_replacement() {
+        let (root, state) = registry_state();
+        let original_blobs = root.path().join("npm-retained");
+        std::fs::rename(&state.blobs_dir, &original_blobs).unwrap();
+        std::fs::create_dir(&state.blobs_dir).unwrap();
+        let manifest_path = root.path().join(".kin/packages/manifests");
+        let original_manifests = root.path().join("manifests-retained");
+        std::fs::rename(&manifest_path, &original_manifests).unwrap();
+        std::fs::create_dir(&manifest_path).unwrap();
+
+        let tarball = build_test_tarball("retained");
+        let payload = publish_payload("demo", "1.0.0", &tarball);
+        let response = npm_routes(state)
+            .oneshot(
+                Request::put("/registry/npm/demo")
+                    .extension(publish_identity())
+                    .header(header::CONTENT_TYPE, "application/json")
+                    .body(Body::from(serde_json::to_vec(&payload).unwrap()))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(response.status(), StatusCode::CREATED);
+        assert!(original_blobs.join("demo/demo-1.0.0.tgz").is_file());
+        assert!(!root.path().join("npm/demo/demo-1.0.0.tgz").exists());
+        assert!(original_manifests.join("npm/demo").is_file());
+        assert!(!manifest_path.join("npm/demo").exists());
     }
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 4)]

--- a/crates/kin-registry/src/npm.rs
+++ b/crates/kin-registry/src/npm.rs
@@ -36,6 +36,9 @@ const MAX_NPM_TARBALL_SIZE: usize = 100 * 1024 * 1024;
 const MAX_NPM_PUBLISH_BODY_SIZE: usize = 140 * 1024 * 1024;
 const MAX_NPM_ARCHIVE_ENTRIES: u64 = 100_000;
 const MAX_NPM_UNPACKED_SIZE: u64 = 1024 * 1024 * 1024;
+const MAX_NPM_ARCHIVE_DECOMPRESSED_SIZE: u64 =
+    MAX_NPM_UNPACKED_SIZE + (MAX_NPM_ARCHIVE_ENTRIES * 1024) + 1024;
+const NPM_MAX_SAFE_INTEGER: u64 = 9_007_199_254_740_991;
 
 /// Shared state for the npm registry routes
 pub struct NpmRegistryState {
@@ -323,9 +326,15 @@ fn validate_npm_package(package: &str) -> Result<PackageId, String> {
 }
 
 fn valid_npm_version(version: &str) -> bool {
-    !version.is_empty()
-        && version.len() <= MAX_NPM_VERSION_LEN
-        && semver::Version::parse(version).is_ok()
+    if version.is_empty() || version.len() > MAX_NPM_VERSION_LEN {
+        return false;
+    }
+    let Ok(version) = semver::Version::parse(version) else {
+        return false;
+    };
+    version.major <= NPM_MAX_SAFE_INTEGER
+        && version.minor <= NPM_MAX_SAFE_INTEGER
+        && version.patch <= NPM_MAX_SAFE_INTEGER
 }
 
 fn valid_npm_tarball_name(tarball: &str) -> bool {
@@ -683,19 +692,41 @@ async fn publish_package(
         }
     }
 
-    let shasum = hex::encode(Sha1::digest(&tarball_bytes));
-    let blob_hash = hex::encode(sha2::Sha256::digest(&tarball_bytes));
-    let integrity = format!("sha512-{}", STANDARD.encode(Sha512::digest(&tarball_bytes)));
-    let (file_count, unpacked_size) = match tarball_stats(&tarball_bytes) {
-        Ok(stats) => stats,
-        Err(error) => {
-            return (
-                StatusCode::BAD_REQUEST,
-                Json(serde_json::json!({ "error": error })),
-            )
-                .into_response();
-        }
-    };
+    let parsed_tarball = tokio::task::spawn_blocking(move || {
+        let shasum = hex::encode(Sha1::digest(&tarball_bytes));
+        let blob_hash = hex::encode(sha2::Sha256::digest(&tarball_bytes));
+        let integrity = format!("sha512-{}", STANDARD.encode(Sha512::digest(&tarball_bytes)));
+        let (file_count, unpacked_size) = tarball_stats(&tarball_bytes)?;
+        Ok::<_, String>((
+            tarball_bytes,
+            shasum,
+            blob_hash,
+            integrity,
+            file_count,
+            unpacked_size,
+        ))
+    })
+    .await;
+    let (tarball_bytes, shasum, blob_hash, integrity, file_count, unpacked_size) =
+        match parsed_tarball {
+            Ok(Ok(parsed)) => parsed,
+            Ok(Err(error)) => {
+                return (
+                    StatusCode::BAD_REQUEST,
+                    Json(serde_json::json!({ "error": error })),
+                )
+                    .into_response();
+            }
+            Err(error) => {
+                return (
+                    StatusCode::INTERNAL_SERVER_ERROR,
+                    Json(serde_json::json!({
+                        "error": format!("npm attachment validation task failed: {error}"),
+                    })),
+                )
+                    .into_response();
+            }
+        };
 
     let (tarball_rel_path, tarball_path) =
         match npm_blob_path(&state.blobs_dir, &package_id, &version) {
@@ -972,9 +1003,19 @@ fn format_npm_time(timestamp: chrono::DateTime<Utc>) -> String {
 }
 
 fn tarball_stats(tarball_bytes: &[u8]) -> Result<(u64, u64), String> {
+    tarball_stats_with_limit(tarball_bytes, MAX_NPM_ARCHIVE_DECOMPRESSED_SIZE)
+}
+
+fn tarball_stats_with_limit(
+    tarball_bytes: &[u8],
+    decompressed_limit: u64,
+) -> Result<(u64, u64), String> {
     use flate2::bufread::GzDecoder;
+    use std::io::Read;
+
     let gz = GzDecoder::new(std::io::BufReader::new(tarball_bytes));
-    let mut archive = tar::Archive::new(gz);
+    let limited = gz.take(decompressed_limit.saturating_add(1));
+    let mut archive = tar::Archive::new(limited);
     let mut file_count = 0u64;
     let mut unpacked_size = 0u64;
 
@@ -1006,9 +1047,15 @@ fn tarball_stats(tarball_bytes: &[u8]) -> Result<(u64, u64), String> {
         }
     }
 
-    let mut decoder = archive.into_inner();
-    std::io::copy(&mut decoder, &mut std::io::sink())
+    let mut limited = archive.into_inner();
+    std::io::copy(&mut limited, &mut std::io::sink())
         .map_err(|error| format!("npm attachment gzip stream is truncated: {error}"))?;
+    if limited.limit() == 0 {
+        return Err(format!(
+            "npm archive exceeds the {decompressed_limit} byte decompressed limit"
+        ));
+    }
+    let decoder = limited.into_inner();
     let compressed = decoder.into_inner();
     if !compressed.buffer().is_empty() || !compressed.get_ref().is_empty() {
         return Err(
@@ -1411,6 +1458,46 @@ mod tests {
         assert!(tarball_stats(&tarball)
             .unwrap_err()
             .contains("more than one gzip member"));
+    }
+
+    #[test]
+    fn archive_stats_bounds_bytes_after_the_tar_end_marker() {
+        use flate2::{write::GzEncoder, Compression};
+        use std::io::Write;
+
+        let mut builder = tar::Builder::new(Vec::new());
+        let contents = b"package";
+        let mut header = tar::Header::new_gnu();
+        header.set_size(contents.len() as u64);
+        header.set_mode(0o644);
+        header.set_cksum();
+        builder
+            .append_data(&mut header, "package/index.js", contents.as_slice())
+            .unwrap();
+        builder.finish().unwrap();
+        let mut uncompressed = builder.into_inner().unwrap();
+        let decompressed_limit = uncompressed.len() as u64 + 64;
+        uncompressed.resize(uncompressed.len() + 4096, 0);
+
+        let mut encoder = GzEncoder::new(Vec::new(), Compression::default());
+        encoder.write_all(&uncompressed).unwrap();
+        let tarball = encoder.finish().unwrap();
+        let error = tarball_stats_with_limit(&tarball, decompressed_limit).unwrap_err();
+        assert!(error.contains("decompressed limit"), "{error}");
+    }
+
+    #[test]
+    fn npm_versions_match_node_safe_integer_limits() {
+        assert!(valid_npm_version(
+            "9007199254740991.9007199254740991.9007199254740991"
+        ));
+        for version in [
+            "9007199254740992.0.0",
+            "0.9007199254740992.0",
+            "0.0.9007199254740992",
+        ] {
+            assert!(!valid_npm_version(version), "accepted {version}");
+        }
     }
 
     #[tokio::test]

--- a/crates/kin-registry/src/oci.rs
+++ b/crates/kin-registry/src/oci.rs
@@ -23,8 +23,11 @@ use axum::{
 };
 use sha2::{Digest, Sha256};
 use std::collections::HashMap;
+use std::path::{Path as FsPath, PathBuf};
 use std::sync::Arc;
 use tokio::sync::RwLock;
+
+const SHA256_HEX_LEN: usize = 64;
 
 /// Shared state for the OCI registry routes
 pub struct OciRegistryState {
@@ -59,7 +62,9 @@ async fn check_blob(
     State(state): State<Arc<OciRegistryState>>,
     Path((_name, digest)): Path<(String, String)>,
 ) -> Response {
-    let blob_path = state.blobs_dir.join(digest.replace(':', "_"));
+    let Some(blob_path) = blob_path_for_digest(&state.blobs_dir, &digest) else {
+        return StatusCode::BAD_REQUEST.into_response();
+    };
     if blob_path.exists() {
         let size = std::fs::metadata(&blob_path).map(|m| m.len()).unwrap_or(0);
         (
@@ -80,7 +85,9 @@ async fn get_blob(
     State(state): State<Arc<OciRegistryState>>,
     Path((_name, digest)): Path<(String, String)>,
 ) -> Response {
-    let blob_path = state.blobs_dir.join(digest.replace(':', "_"));
+    let Some(blob_path) = blob_path_for_digest(&state.blobs_dir, &digest) else {
+        return StatusCode::BAD_REQUEST.into_response();
+    };
     match std::fs::read(&blob_path) {
         Ok(bytes) => (
             StatusCode::OK,
@@ -139,7 +146,8 @@ async fn complete_upload(
     data.extend_from_slice(&body);
 
     let digest = format!("sha256:{}", sha2_hex(&data));
-    let blob_path = state.blobs_dir.join(digest.replace(':', "_"));
+    let blob_path = blob_path_for_digest(&state.blobs_dir, &digest)
+        .expect("internally generated sha256 digest must be valid");
 
     if let Err(e) = std::fs::write(&blob_path, &data) {
         return (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()).into_response();
@@ -203,4 +211,132 @@ async fn delete_manifest(
 fn sha2_hex(data: &[u8]) -> String {
     let hash = Sha256::digest(data);
     hex::encode(hash)
+}
+
+/// Map a canonical SHA-256 digest to its on-disk blob filename.
+///
+/// The caller-controlled digest is never joined directly. Only a fixed prefix
+/// plus 64 lowercase hexadecimal bytes can reach the filesystem, so path
+/// separators, dot components, alternate algorithms, and encoded traversal
+/// payloads are rejected before any filesystem operation.
+fn blob_path_for_digest(blobs_dir: &FsPath, digest: &str) -> Option<PathBuf> {
+    let encoded = digest.strip_prefix("sha256:")?;
+    if encoded.len() != SHA256_HEX_LEN
+        || !encoded
+            .bytes()
+            .all(|byte| matches!(byte, b'0'..=b'9' | b'a'..=b'f'))
+    {
+        return None;
+    }
+
+    Some(blobs_dir.join(format!("sha256_{encoded}")))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use axum::body::Body;
+    use axum::http::Request;
+    use tower::ServiceExt;
+
+    fn registry_state() -> (tempfile::TempDir, Arc<OciRegistryState>) {
+        let root = tempfile::tempdir().unwrap();
+        let blobs_dir = root.path().join("oci");
+        std::fs::create_dir_all(&blobs_dir).unwrap();
+        let state = Arc::new(OciRegistryState {
+            blobs_dir,
+            manifests: Default::default(),
+            uploads: Default::default(),
+        });
+        (root, state)
+    }
+
+    #[test]
+    fn blob_path_accepts_only_canonical_sha256_digests() {
+        let root = std::path::Path::new("/registry/blobs");
+        let digest = format!("sha256:{}", "a".repeat(SHA256_HEX_LEN));
+        assert_eq!(
+            blob_path_for_digest(root, &digest),
+            Some(root.join(format!("sha256_{}", "a".repeat(SHA256_HEX_LEN))))
+        );
+
+        for invalid in [
+            "sha256:../outside",
+            "sha256:%2e%2e%2foutside",
+            "sha256:ABCDEF",
+            "sha512:abcdef",
+            "sha256:",
+        ] {
+            assert_eq!(blob_path_for_digest(root, invalid), None, "{invalid}");
+        }
+        assert_eq!(
+            blob_path_for_digest(root, &format!("sha256:{}", "a".repeat(63))),
+            None
+        );
+        assert_eq!(
+            blob_path_for_digest(root, &format!("sha256:{}", "a".repeat(65))),
+            None
+        );
+    }
+
+    #[tokio::test]
+    async fn public_blob_reads_accept_valid_digests_without_authorization() {
+        let (_root, state) = registry_state();
+        let bytes = b"public oci blob";
+        let digest = format!("sha256:{}", sha2_hex(bytes));
+        let blob_path = blob_path_for_digest(&state.blobs_dir, &digest).unwrap();
+        std::fs::write(blob_path, bytes).unwrap();
+
+        let response = oci_routes(state)
+            .oneshot(
+                Request::get(format!("/v2/demo/blobs/{digest}"))
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(response.status(), StatusCode::OK);
+        assert_eq!(response.headers()["docker-content-digest"], digest.as_str());
+        let body = axum::body::to_bytes(response.into_body(), usize::MAX)
+            .await
+            .unwrap();
+        assert_eq!(&body[..], bytes);
+    }
+
+    #[tokio::test]
+    async fn blob_routes_reject_noncanonical_digest_paths() {
+        let (_root, state) = registry_state();
+        let outside = state.blobs_dir.parent().unwrap().join("outside");
+        std::fs::write(&outside, b"must not be served").unwrap();
+
+        for method in ["GET", "HEAD"] {
+            let noncanonical = format!("/v2/demo/blobs/sha256:{}", "A".repeat(SHA256_HEX_LEN));
+            let response = oci_routes(state.clone())
+                .oneshot(
+                    Request::builder()
+                        .method(method)
+                        .uri(noncanonical)
+                        .body(Body::empty())
+                        .unwrap(),
+                )
+                .await
+                .unwrap();
+            assert_eq!(response.status(), StatusCode::BAD_REQUEST);
+
+            let response = oci_routes(state.clone())
+                .oneshot(
+                    Request::builder()
+                        .method(method)
+                        .uri("/v2/demo/blobs/sha256:..%2Foutside")
+                        .body(Body::empty())
+                        .unwrap(),
+                )
+                .await
+                .unwrap();
+
+            assert_ne!(response.status(), StatusCode::OK);
+        }
+        assert_eq!(std::fs::read(outside).unwrap(), b"must not be served");
+    }
 }

--- a/crates/kin-registry/src/oci.rs
+++ b/crates/kin-registry/src/oci.rs
@@ -435,7 +435,8 @@ fn read_metadata_file(path: &FsPath) -> Result<OciMetadata, String> {
 /// lock orders this snapshot against publishers in other daemon processes.
 async fn metadata_snapshot(state: &OciRegistryState) -> Result<OciMetadata, String> {
     let mut cache = state.metadata.write().await;
-    let _storage_lock = crate::storage_lock::StorageLock::shared(&state.metadata_lock_path)
+    let _storage_lock = crate::storage_lock::StorageLock::shared_async(&state.metadata_lock_path)
+        .await
         .map_err(|error| format!("failed to lock OCI metadata for reading: {error}"))?;
     let fresh = read_metadata_file(&state.metadata_path)?;
     *cache = fresh.clone();
@@ -455,7 +456,8 @@ async fn begin_metadata_write(
     String,
 > {
     let cache = state.metadata.write().await;
-    let storage_lock = crate::storage_lock::StorageLock::exclusive(&state.metadata_lock_path)
+    let storage_lock = crate::storage_lock::StorageLock::exclusive_async(&state.metadata_lock_path)
+        .await
         .map_err(|error| format!("failed to lock OCI metadata for writing: {error}"))?;
     let fresh = read_metadata_file(&state.metadata_path)?;
     Ok((cache, storage_lock, fresh))
@@ -567,7 +569,8 @@ async fn begin_upload_write(
     state: &OciRegistryState,
 ) -> Result<UploadWriteTransaction<'_>, String> {
     let local = state.upload_gate.lock().await;
-    let storage = crate::storage_lock::StorageLock::exclusive(&state.uploads_lock_path)
+    let storage = crate::storage_lock::StorageLock::exclusive_async(&state.uploads_lock_path)
+        .await
         .map_err(|error| format!("failed to lock OCI uploads: {error}"))?;
     crate::atomic_file::ensure_directory_durable(&state.uploads_dir)
         .map_err(|error| format!("failed to create OCI upload storage: {error}"))?;

--- a/crates/kin-registry/src/oci.rs
+++ b/crates/kin-registry/src/oci.rs
@@ -20,11 +20,11 @@ use serde::{Deserialize, Serialize};
 use sha2::{Digest, Sha256};
 use std::collections::{BTreeSet, HashMap};
 use std::path::{Path as FsPath, PathBuf};
-use std::sync::atomic::{AtomicU64, Ordering};
-use std::sync::Arc;
+use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
+use std::sync::{Arc, Mutex as StdMutex};
 use std::time::{Duration, SystemTime};
-use tokio::io::{AsyncReadExt, AsyncWriteExt};
-use tokio::sync::{Mutex, MutexGuard, RwLock, RwLockWriteGuard};
+use tokio::io::AsyncReadExt;
+use tokio::sync::{Mutex, OwnedMutexGuard, RwLock};
 
 const SHA256_HEX_LEN: usize = 64;
 const UPLOAD_ID_HEX_LEN: usize = 32;
@@ -106,6 +106,7 @@ struct ImageDescriptor {
     size: u64,
 }
 
+#[derive(Debug)]
 struct ManifestValidationError {
     status: StatusCode,
     code: &'static str,
@@ -151,14 +152,16 @@ pub struct OciRegistryState {
     authority: crate::atomic_file::AuthorityRoot,
     #[cfg(test)]
     metadata_path: PathBuf,
-    metadata: RwLock<OciMetadata>,
+    metadata: Arc<RwLock<OciMetadata>>,
     /// Serializes this process before the shared storage lock is acquired.
-    upload_gate: Mutex<()>,
+    upload_gate: Arc<Mutex<()>>,
     max_active_upload_bytes: u64,
     /// OCI-specific secret for writes. `None` disables every mutation.
     write_token: Option<String>,
     #[cfg(test)]
     manifest_validation_hook: std::sync::Mutex<Option<Arc<ManifestValidationHook>>>,
+    #[cfg(test)]
+    upload_rollback_hook: std::sync::Mutex<Option<Arc<UploadRollbackHook>>>,
 }
 
 #[cfg(test)]
@@ -166,6 +169,18 @@ struct ManifestValidationHook {
     started: tokio::sync::Notify,
     release: tokio::sync::Notify,
 }
+
+#[cfg(test)]
+struct UploadRollbackHook {
+    started: tokio::sync::Notify,
+    release: tokio::sync::Notify,
+}
+
+#[cfg(test)]
+type UploadRollbackHookRef = Option<Arc<UploadRollbackHook>>;
+#[cfg(not(test))]
+#[derive(Clone, Copy)]
+struct UploadRollbackHookRef;
 
 #[derive(Clone)]
 struct OciDiskState {
@@ -190,14 +205,16 @@ impl OciRegistryState {
             authority,
             #[cfg(test)]
             metadata_path,
-            metadata: RwLock::new(metadata),
-            upload_gate: Mutex::new(()),
+            metadata: Arc::new(RwLock::new(metadata)),
+            upload_gate: Arc::new(Mutex::new(())),
             max_active_upload_bytes: MAX_TOTAL_ACTIVE_UPLOAD_BYTES,
             write_token: write_token
                 .map(|token| token.trim().to_string())
                 .filter(|token| !token.is_empty()),
             #[cfg(test)]
             manifest_validation_hook: std::sync::Mutex::new(None),
+            #[cfg(test)]
+            upload_rollback_hook: std::sync::Mutex::new(None),
         }
     }
 
@@ -206,6 +223,17 @@ impl OciRegistryState {
             authority: self.authority.clone(),
             blobs_dir: self.blobs_dir.clone(),
             max_active_upload_bytes: self.max_active_upload_bytes,
+        }
+    }
+
+    fn upload_rollback_hook(&self) -> UploadRollbackHookRef {
+        #[cfg(test)]
+        {
+            self.upload_rollback_hook.lock().unwrap().clone()
+        }
+        #[cfg(not(test))]
+        {
+            UploadRollbackHookRef
         }
     }
 }
@@ -511,70 +539,83 @@ fn read_metadata_authority(
 /// same-process readers from racing a local publisher while the shared file
 /// lock orders this snapshot against publishers in other daemon processes.
 async fn metadata_snapshot(state: &OciRegistryState) -> Result<OciMetadata, String> {
-    let mut cache = state.metadata.write().await;
+    let cache = state.metadata.clone().write_owned().await;
     let authority = state.authority.clone();
-    let fresh = tokio::task::spawn_blocking(move || {
+    tokio::task::spawn_blocking(move || {
+        let mut cache = cache;
         let _storage_lock =
             crate::storage_lock::StorageLock::shared_at(&authority, FsPath::new(".metadata.lock"))
                 .map_err(|error| format!("failed to lock OCI metadata for reading: {error}"))?;
-        read_metadata_authority(&authority)
+        let fresh = read_metadata_authority(&authority)?;
+        *cache = fresh.clone();
+        Ok(fresh)
     })
     .await
-    .map_err(|error| format!("OCI metadata read task failed: {error}"))??;
-    *cache = fresh.clone();
-    Ok(fresh)
+    .map_err(|error| format!("OCI metadata read task failed: {error}"))?
 }
 
-/// Begin a cross-process read/modify/write transaction from the latest durable
-/// metadata. Callers must keep both returned guards alive through persistence.
-async fn begin_metadata_write(
+#[derive(Debug)]
+enum MetadataWriteError {
+    Storage(String),
+    Validation(ManifestValidationError),
+    NotFound,
+}
+
+impl MetadataWriteError {
+    fn response(self) -> Response {
+        match self {
+            Self::Storage(error) => metadata_authority_error(&error),
+            Self::Validation(error) => error.response(),
+            Self::NotFound => StatusCode::NOT_FOUND.into_response(),
+        }
+    }
+}
+
+/// Run a cross-process read/modify/write transaction from the latest durable
+/// metadata. The owned local guard and storage lock live in the blocking
+/// closure so cancellation of the async caller cannot expose a half-finished
+/// mutation to another request or process.
+async fn metadata_write_transaction<T, F>(
     state: &OciRegistryState,
-) -> Result<
-    (
-        RwLockWriteGuard<'_, OciMetadata>,
-        crate::storage_lock::StorageLock,
-        OciMetadata,
-    ),
-    String,
-> {
-    let cache = state.metadata.write().await;
-    let storage_lock = crate::storage_lock::StorageLock::exclusive_at_async(
-        state.authority.clone(),
-        PathBuf::from(".metadata.lock"),
-    )
-    .await
-    .map_err(|error| format!("failed to lock OCI metadata for writing: {error}"))?;
-    let authority = state.authority.clone();
-    let fresh = tokio::task::spawn_blocking(move || read_metadata_authority(&authority))
-        .await
-        .map_err(|error| format!("OCI metadata read task failed: {error}"))??;
-    Ok((cache, storage_lock, fresh))
-}
-
-#[cfg(test)]
-fn persist_metadata(state: &OciRegistryState, metadata: &OciMetadata) -> Result<(), String> {
-    let bytes = serde_json::to_vec(metadata)
-        .map_err(|error| format!("failed to encode OCI metadata: {error}"))?;
-    state
-        .authority
-        .write(FsPath::new("metadata.json"), &bytes)
-        .map_err(|error| format!("failed to persist OCI metadata: {error}"))
-}
-
-async fn persist_metadata_async(
-    state: &OciRegistryState,
-    metadata: &OciMetadata,
-) -> Result<(), String> {
-    let bytes = serde_json::to_vec(metadata)
-        .map_err(|error| format!("failed to encode OCI metadata: {error}"))?;
+    operation: F,
+) -> Result<T, MetadataWriteError>
+where
+    T: Send + 'static,
+    F: FnOnce(
+            &crate::atomic_file::AuthorityRoot,
+            &mut OciMetadata,
+        ) -> Result<T, MetadataWriteError>
+        + Send
+        + 'static,
+{
+    let cache = state.metadata.clone().write_owned().await;
     let authority = state.authority.clone();
     tokio::task::spawn_blocking(move || {
+        let mut cache = cache;
+        let _storage_lock = crate::storage_lock::StorageLock::exclusive_at(
+            &authority,
+            FsPath::new(".metadata.lock"),
+        )
+        .map_err(|error| {
+            MetadataWriteError::Storage(format!("failed to lock OCI metadata for writing: {error}"))
+        })?;
+        let mut fresh = read_metadata_authority(&authority).map_err(MetadataWriteError::Storage)?;
+        let output = operation(&authority, &mut fresh)?;
+        let bytes = serde_json::to_vec(&fresh).map_err(|error| {
+            MetadataWriteError::Storage(format!("failed to encode OCI metadata: {error}"))
+        })?;
         authority
             .write(FsPath::new("metadata.json"), &bytes)
-            .map_err(|error| format!("failed to persist OCI metadata: {error}"))
+            .map_err(|error| {
+                MetadataWriteError::Storage(format!("failed to persist OCI metadata: {error}"))
+            })?;
+        *cache = fresh;
+        Ok(output)
     })
     .await
-    .map_err(|error| format!("OCI metadata persistence task failed: {error}"))?
+    .map_err(|error| {
+        MetadataWriteError::Storage(format!("OCI metadata transaction task failed: {error}"))
+    })?
 }
 
 /// HEAD /v2/{name}/blobs/{digest} -- check if blob exists.
@@ -658,8 +699,8 @@ async fn get_blob_inner(
     response
 }
 
-struct UploadWriteTransaction<'a> {
-    _local: MutexGuard<'a, ()>,
+struct UploadWriteTransaction {
+    _local: OwnedMutexGuard<()>,
     _storage: crate::storage_lock::StorageLock,
 }
 
@@ -672,35 +713,44 @@ enum UploadAppendError {
 
 async fn begin_upload_write(
     state: &OciRegistryState,
-) -> Result<UploadWriteTransaction<'_>, String> {
-    let local = state.upload_gate.lock().await;
+) -> Result<Arc<UploadWriteTransaction>, String> {
+    let local = state.upload_gate.clone().lock_owned().await;
     let storage = crate::storage_lock::StorageLock::exclusive_at_async(
         state.authority.clone(),
         PathBuf::from(".uploads.lock"),
     )
     .await
     .map_err(|error| format!("failed to lock OCI uploads: {error}"))?;
-    run_upload_disk(state, |disk| {
+    let transaction = Arc::new(UploadWriteTransaction {
+        _local: local,
+        _storage: storage,
+    });
+    run_upload_disk(state, &transaction, |disk| {
         disk.authority
             .ensure_directory(FsPath::new("uploads"))
             .map_err(|error| format!("failed to create OCI upload storage: {error}"))
     })
     .await?;
-    Ok(UploadWriteTransaction {
-        _local: local,
-        _storage: storage,
-    })
+    Ok(transaction)
 }
 
-async fn run_upload_disk<T, F>(state: &OciRegistryState, operation: F) -> Result<T, String>
+async fn run_upload_disk<T, F>(
+    state: &OciRegistryState,
+    transaction: &Arc<UploadWriteTransaction>,
+    operation: F,
+) -> Result<T, String>
 where
     T: Send + 'static,
     F: FnOnce(OciDiskState) -> Result<T, String> + Send + 'static,
 {
     let disk = state.disk_state();
-    tokio::task::spawn_blocking(move || operation(disk))
-        .await
-        .map_err(|error| format!("OCI upload storage task failed: {error}"))?
+    let transaction = Arc::clone(transaction);
+    tokio::task::spawn_blocking(move || {
+        let _transaction = transaction;
+        operation(disk)
+    })
+    .await
+    .map_err(|error| format!("OCI upload storage task failed: {error}"))?
 }
 
 #[cfg(test)]
@@ -920,44 +970,222 @@ fn prune_and_measure_uploads_disk(state: &OciDiskState) -> Result<(usize, u64), 
     Ok((active_count, active_bytes))
 }
 
-async fn rollback_staged_file(file: &mut tokio::fs::File, size: u64) -> Result<(), String> {
-    file.set_len(size)
+#[derive(Default)]
+struct AppendOperationCompletion {
+    done: AtomicBool,
+    notify: tokio::sync::Notify,
+}
+
+impl AppendOperationCompletion {
+    fn finish(&self) {
+        self.done.store(true, Ordering::Release);
+        self.notify.notify_waiters();
+    }
+
+    async fn wait(&self) {
+        loop {
+            let notified = self.notify.notified();
+            if self.done.load(Ordering::Acquire) {
+                return;
+            }
+            notified.await;
+        }
+    }
+}
+
+/// Owns recovery for bytes appended beyond a session's durable metadata
+/// offset. Every blocking file/session operation is tracked before it is
+/// spawned. If the request future is dropped, recovery waits for that exact
+/// operation, then either observes a successful session commit or truncates
+/// and syncs the staged file before releasing the upload transaction.
+struct UploadAppendGuard {
+    file: Arc<StdMutex<std::fs::File>>,
+    transaction: Option<Arc<UploadWriteTransaction>>,
+    original_size: u64,
+    in_flight: Option<Arc<AppendOperationCompletion>>,
+    committed: Arc<AtomicBool>,
+    armed: bool,
+    #[cfg(test)]
+    rollback_hook: UploadRollbackHookRef,
+}
+
+impl UploadAppendGuard {
+    fn new(
+        file: std::fs::File,
+        transaction: Arc<UploadWriteTransaction>,
+        original_size: u64,
+        _rollback_hook: UploadRollbackHookRef,
+    ) -> Self {
+        Self {
+            file: Arc::new(StdMutex::new(file)),
+            transaction: Some(transaction),
+            original_size,
+            in_flight: None,
+            committed: Arc::new(AtomicBool::new(false)),
+            armed: true,
+            #[cfg(test)]
+            rollback_hook: _rollback_hook,
+        }
+    }
+
+    async fn run_tracked_operation<F>(
+        &mut self,
+        marks_session_commit: bool,
+        operation: F,
+    ) -> Result<(), String>
+    where
+        F: FnOnce() -> Result<(), String> + Send + 'static,
+    {
+        let completion = Arc::new(AppendOperationCompletion::default());
+        self.in_flight = Some(Arc::clone(&completion));
+        let transaction = Arc::clone(
+            self.transaction
+                .as_ref()
+                .expect("armed upload append guard retains its transaction"),
+        );
+        let committed = Arc::clone(&self.committed);
+        let completion_for_task = Arc::clone(&completion);
+        let (result_tx, result_rx) = tokio::sync::oneshot::channel();
+        tokio::spawn(async move {
+            let result = tokio::task::spawn_blocking(move || {
+                let _transaction = transaction;
+                operation()
+            })
+            .await
+            .map_err(|error| format!("OCI upload storage task failed: {error}"))
+            .and_then(|result| result);
+            if marks_session_commit && result.is_ok() {
+                committed.store(true, Ordering::Release);
+            }
+            completion_for_task.finish();
+            let _ = result_tx.send(result);
+        });
+
+        let result = result_rx
+            .await
+            .map_err(|_| "OCI upload storage task ended without a result".to_string())?;
+        self.in_flight = None;
+        result
+    }
+
+    async fn run_file_operation<F>(&mut self, operation: F) -> Result<(), String>
+    where
+        F: FnOnce(&mut std::fs::File) -> Result<(), String> + Send + 'static,
+    {
+        let file = Arc::clone(&self.file);
+        self.run_tracked_operation(false, move || {
+            let mut file = file
+                .lock()
+                .map_err(|_| "OCI upload file lock was poisoned".to_string())?;
+            operation(&mut file)
+        })
         .await
-        .map_err(|error| format!("failed to roll back OCI upload data: {error}"))?;
-    file.sync_all()
-        .await
-        .map_err(|error| format!("failed to sync rolled-back OCI upload data: {error}"))
+    }
+
+    async fn rollback(&mut self) -> Result<(), String> {
+        let original_size = self.original_size;
+        let result = self
+            .run_file_operation(move |file| {
+                file.set_len(original_size)
+                    .map_err(|error| format!("failed to roll back OCI upload data: {error}"))?;
+                file.sync_all()
+                    .map_err(|error| format!("failed to sync rolled-back OCI upload data: {error}"))
+            })
+            .await;
+        if result.is_ok() {
+            self.armed = false;
+        }
+        result
+    }
+
+    fn commit(mut self) {
+        debug_assert!(self.committed.load(Ordering::Acquire));
+        self.armed = false;
+    }
+}
+
+impl Drop for UploadAppendGuard {
+    fn drop(&mut self) {
+        if !self.armed {
+            return;
+        }
+        let Some(transaction) = self.transaction.take() else {
+            return;
+        };
+        let file = Arc::clone(&self.file);
+        let in_flight = self.in_flight.take();
+        let committed = Arc::clone(&self.committed);
+        let original_size = self.original_size;
+        #[cfg(test)]
+        let rollback_hook = self.rollback_hook.take();
+
+        let Ok(runtime) = tokio::runtime::Handle::try_current() else {
+            tracing::error!(
+                original_size,
+                "cannot schedule OCI upload cancellation rollback outside a Tokio runtime"
+            );
+            return;
+        };
+        runtime.spawn(async move {
+            if let Some(in_flight) = in_flight {
+                in_flight.wait().await;
+            }
+            if committed.load(Ordering::Acquire) {
+                return;
+            }
+            #[cfg(test)]
+            if let Some(hook) = rollback_hook {
+                hook.started.notify_one();
+                hook.release.notified().await;
+            }
+            let rollback = tokio::task::spawn_blocking(move || {
+                let _transaction = transaction;
+                let file = file
+                    .lock()
+                    .map_err(|_| "OCI upload file lock was poisoned".to_string())?;
+                file.set_len(original_size)
+                    .map_err(|error| format!("failed to roll back OCI upload data: {error}"))?;
+                file.sync_all()
+                    .map_err(|error| format!("failed to sync rolled-back OCI upload data: {error}"))
+            })
+            .await
+            .map_err(|error| format!("OCI upload rollback task failed: {error}"))
+            .and_then(|result| result);
+            if let Err(error) = rollback {
+                tracing::error!(%error, original_size, "failed to recover cancelled OCI upload");
+            }
+        });
+    }
 }
 
 async fn append_upload_body(
     authority: &crate::atomic_file::AuthorityRoot,
+    transaction: &Arc<UploadWriteTransaction>,
     relative: &FsPath,
     original_size: u64,
     aggregate_remaining: u64,
     declared_length: Option<u64>,
     body: Body,
     mut hasher: Option<&mut Sha256>,
-) -> Result<u64, UploadAppendError> {
+    rollback_hook: UploadRollbackHookRef,
+) -> Result<(u64, UploadAppendGuard), UploadAppendError> {
     let session_remaining = (MAX_OCI_BLOB_SIZE as u64).saturating_sub(original_size);
     let allowed = session_remaining.min(aggregate_remaining);
     if declared_length.is_some_and(|length| length > allowed) {
         return Err(UploadAppendError::Limit);
     }
-    let mut file = authority
-        .open_append(relative)
-        .map(tokio::fs::File::from_std)
-        .map_err(|error| {
-            UploadAppendError::Storage(format!("failed to open OCI upload data: {error}"))
-        })?;
+    let file = authority.open_append(relative).map_err(|error| {
+        UploadAppendError::Storage(format!("failed to open OCI upload data: {error}"))
+    })?;
+    let mut guard =
+        UploadAppendGuard::new(file, Arc::clone(transaction), original_size, rollback_hook);
     let mut written = 0u64;
     let mut stream = body.into_data_stream();
     while let Some(chunk) = stream.next().await {
         let chunk = match chunk {
             Ok(chunk) => chunk,
             Err(error) => {
-                rollback_staged_file(&mut file, original_size)
-                    .await
-                    .map_err(UploadAppendError::Storage)?;
+                guard.rollback().await.map_err(UploadAppendError::Storage)?;
                 return Err(UploadAppendError::Body(format!(
                     "failed to read OCI upload body: {error}"
                 )));
@@ -968,41 +1196,38 @@ async fn append_upload_body(
             .checked_add(chunk_len)
             .is_none_or(|total| total > allowed)
         {
-            rollback_staged_file(&mut file, original_size)
-                .await
-                .map_err(UploadAppendError::Storage)?;
+            guard.rollback().await.map_err(UploadAppendError::Storage)?;
             return Err(UploadAppendError::Limit);
         }
-        if let Err(error) = file.write_all(&chunk).await {
-            rollback_staged_file(&mut file, original_size)
-                .await
-                .map_err(UploadAppendError::Storage)?;
-            return Err(UploadAppendError::Storage(format!(
-                "failed to append OCI upload data: {error}"
-            )));
+        let chunk_for_write = chunk.clone();
+        if let Err(error) = guard
+            .run_file_operation(move |file| {
+                std::io::Write::write_all(file, &chunk_for_write)
+                    .map_err(|error| format!("failed to append OCI upload data: {error}"))
+            })
+            .await
+        {
+            guard.rollback().await.map_err(UploadAppendError::Storage)?;
+            return Err(UploadAppendError::Storage(error));
         }
         if let Some(hasher) = hasher.as_deref_mut() {
             hasher.update(&chunk);
         }
         written += chunk_len;
     }
-    if let Err(error) = file.flush().await {
-        rollback_staged_file(&mut file, original_size)
-            .await
-            .map_err(UploadAppendError::Storage)?;
-        return Err(UploadAppendError::Storage(format!(
-            "failed to flush OCI upload data: {error}"
-        )));
+    if let Err(error) = guard
+        .run_file_operation(|file| {
+            std::io::Write::flush(file)
+                .map_err(|error| format!("failed to flush OCI upload data: {error}"))?;
+            file.sync_all()
+                .map_err(|error| format!("failed to sync OCI upload data: {error}"))
+        })
+        .await
+    {
+        guard.rollback().await.map_err(UploadAppendError::Storage)?;
+        return Err(UploadAppendError::Storage(error));
     }
-    if let Err(error) = file.sync_all().await {
-        rollback_staged_file(&mut file, original_size)
-            .await
-            .map_err(UploadAppendError::Storage)?;
-        return Err(UploadAppendError::Storage(format!(
-            "failed to sync OCI upload data: {error}"
-        )));
-    }
-    Ok(written)
+    Ok((written, guard))
 }
 
 async fn hash_upload_file(
@@ -1110,7 +1335,7 @@ async fn initiate_upload_inner(state: &OciRegistryState, name: &str) -> Response
     if let Err(error) = metadata_snapshot(state).await {
         return metadata_authority_error(&error);
     }
-    let _transaction = match begin_upload_write(state).await {
+    let transaction = match begin_upload_write(state).await {
         Ok(transaction) => transaction,
         Err(error) => return metadata_authority_error(&error),
     };
@@ -1119,7 +1344,7 @@ async fn initiate_upload_inner(state: &OciRegistryState, name: &str) -> Response
         Err(error) => return metadata_authority_error(&error),
     };
     let repository = name.to_string();
-    let upload_id = match run_upload_disk(state, move |disk| {
+    let upload_id = match run_upload_disk(state, &transaction, move |disk| {
         let (active_count, active_bytes) = prune_and_measure_uploads_disk(&disk)?;
         if active_count >= MAX_ACTIVE_UPLOADS || active_bytes >= disk.max_active_upload_bytes {
             return Ok(None);
@@ -1178,12 +1403,12 @@ async fn upload_status_inner(state: &OciRegistryState, name: &str, id: &str) -> 
             Some(&location),
         );
     }
-    let _transaction = match begin_upload_write(state).await {
+    let transaction = match begin_upload_write(state).await {
         Ok(transaction) => transaction,
         Err(error) => return metadata_authority_error(&error),
     };
     let id_owned = id.to_string();
-    let upload = run_upload_disk(state, move |disk| {
+    let upload = run_upload_disk(state, &transaction, move |disk| {
         prune_and_measure_uploads_disk(&disk)?;
         read_upload_session_disk(&disk, &id_owned)
     })
@@ -1212,13 +1437,13 @@ async fn cancel_upload_inner(state: &OciRegistryState, name: &str, id: &str) -> 
             Some(&location),
         );
     }
-    let _transaction = match begin_upload_write(state).await {
+    let transaction = match begin_upload_write(state).await {
         Ok(transaction) => transaction,
         Err(error) => return metadata_authority_error(&error),
     };
     let id_owned = id.to_string();
     let repository = name.to_string();
-    let cancelled = run_upload_disk(state, move |disk| {
+    let cancelled = run_upload_disk(state, &transaction, move |disk| {
         prune_and_measure_uploads_disk(&disk)?;
         match read_upload_session_disk(&disk, &id_owned)? {
             Some(upload) if upload.repository == repository => {
@@ -1258,12 +1483,12 @@ async fn patch_upload_inner(
             Some(&location),
         );
     }
-    let _transaction = match begin_upload_write(state).await {
+    let transaction = match begin_upload_write(state).await {
         Ok(transaction) => transaction,
         Err(error) => return metadata_authority_error(&error),
     };
     let id_owned = id.to_string();
-    let measured = run_upload_disk(state, move |disk| {
+    let measured = run_upload_disk(state, &transaction, move |disk| {
         let (_, active_bytes) = prune_and_measure_uploads_disk(&disk)?;
         Ok((active_bytes, read_upload_session_disk(&disk, &id_owned)?))
     })
@@ -1329,14 +1554,16 @@ async fn patch_upload_inner(
     };
     let data_relative = upload_data_relative(id).expect("validated upload identifier");
     let aggregate_remaining = state.max_active_upload_bytes.saturating_sub(active_bytes);
-    let appended = match append_upload_body(
+    let (appended, mut append_guard) = match append_upload_body(
         &state.authority,
+        &transaction,
         &data_relative,
         upload.size,
         aggregate_remaining,
         declared_length,
         body,
         None,
+        state.upload_rollback_hook(),
     )
     .await
     {
@@ -1344,18 +1571,8 @@ async fn patch_upload_inner(
         Err(error) => return upload_error(error, &location),
     };
     if expected_range_length.is_some_and(|expected| expected != appended) {
-        match state.authority.open_write(&data_relative) {
-            Ok(file) => {
-                let mut file = tokio::fs::File::from_std(file);
-                if let Err(error) = rollback_staged_file(&mut file, upload.size).await {
-                    return metadata_authority_error(&error);
-                }
-            }
-            Err(error) => {
-                return metadata_authority_error(&format!(
-                    "failed to reopen OCI upload after Content-Range mismatch: {error}"
-                ));
-            }
+        if let Err(error) = append_guard.rollback().await {
+            return metadata_authority_error(&error);
         }
         return oci_error(
             StatusCode::RANGE_NOT_SATISFIABLE,
@@ -1364,35 +1581,25 @@ async fn patch_upload_inner(
             Some(&location),
         );
     }
-    let previous_size = upload.size;
     upload.size += appended;
     upload.updated_at_unix_secs = updated_at;
     let persisted = {
+        let disk = state.disk_state();
         let id = id.to_string();
         let upload = upload.clone();
-        run_upload_disk(state, move |disk| {
-            persist_upload_session_disk(&disk, &id, &upload)
-        })
-        .await
+        append_guard
+            .run_tracked_operation(true, move || {
+                persist_upload_session_disk(&disk, &id, &upload)
+            })
+            .await
     };
     if let Err(error) = persisted {
-        match state.authority.open_write(&data_relative) {
-            Ok(file) => {
-                let mut file = tokio::fs::File::from_std(file);
-                if let Err(rollback_error) = rollback_staged_file(&mut file, previous_size).await {
-                    return metadata_authority_error(&format!(
-                        "{error}; additionally {rollback_error}"
-                    ));
-                }
-            }
-            Err(rollback_error) => {
-                return metadata_authority_error(&format!(
-                    "{error}; failed to reopen OCI upload for rollback: {rollback_error}"
-                ));
-            }
+        if let Err(rollback_error) = append_guard.rollback().await {
+            return metadata_authority_error(&format!("{error}; additionally {rollback_error}"));
         }
         return metadata_authority_error(&error);
     }
+    append_guard.commit();
     upload_progress_response(StatusCode::ACCEPTED, name, id, upload.size)
 }
 
@@ -1426,12 +1633,12 @@ async fn complete_upload_inner(
             Some(&location),
         );
     }
-    let _upload_transaction = match begin_upload_write(state).await {
+    let upload_transaction = match begin_upload_write(state).await {
         Ok(transaction) => transaction,
         Err(error) => return metadata_authority_error(&error),
     };
     let id_owned = id.to_string();
-    let measured = run_upload_disk(state, move |disk| {
+    let measured = run_upload_disk(state, &upload_transaction, move |disk| {
         let (_, active_bytes) = prune_and_measure_uploads_disk(&disk)?;
         Ok((active_bytes, read_upload_session_disk(&disk, &id_owned)?))
     })
@@ -1499,6 +1706,14 @@ async fn complete_upload_inner(
                 Some(&location),
             );
         }
+        if expected_range_length.is_some() {
+            return oci_error(
+                StatusCode::RANGE_NOT_SATISFIABLE,
+                "BLOB_UPLOAD_INVALID",
+                "a finalizing upload cannot be resumed with a non-empty Content-Range",
+                Some(&location),
+            );
+        }
         let mut stream = body.into_data_stream();
         if stream.next().await.is_some() {
             return oci_error(
@@ -1506,6 +1721,28 @@ async fn complete_upload_inner(
                 "BLOB_UPLOAD_INVALID",
                 "a finalizing upload can only be resumed with an empty body",
                 Some(&location),
+            );
+        }
+        let durable_relative = match state.authority.metadata(&data_relative) {
+            Ok(_) => data_relative.clone(),
+            Err(error) if error.kind() == std::io::ErrorKind::NotFound => {
+                blob_relative_for_digest(finalizing_digest)
+                    .expect("durable finalization digest is canonical")
+            }
+            Err(error) => {
+                return metadata_authority_error(&format!(
+                    "failed to inspect durable OCI upload data: {error}"
+                ));
+            }
+        };
+        let observed =
+            match hash_upload_file(&state.authority, &durable_relative, upload.size).await {
+                Ok(hasher) => format!("sha256:{}", hex::encode(hasher.finalize())),
+                Err(error) => return metadata_authority_error(&error),
+            };
+        if observed != finalizing_digest {
+            return metadata_authority_error(
+                "the durable finalizing OCI upload does not match its expected digest",
             );
         }
         finalizing_digest.to_string()
@@ -1521,14 +1758,16 @@ async fn complete_upload_inner(
         };
         let aggregate_remaining = state.max_active_upload_bytes.saturating_sub(active_bytes);
         let original_size = upload.size;
-        let appended = match append_upload_body(
+        let (appended, mut append_guard) = match append_upload_body(
             &state.authority,
+            &upload_transaction,
             &data_relative,
             original_size,
             aggregate_remaining,
             declared_length,
             body,
             Some(&mut hasher),
+            state.upload_rollback_hook(),
         )
         .await
         {
@@ -1536,18 +1775,8 @@ async fn complete_upload_inner(
             Err(error) => return upload_error(error, &location),
         };
         if expected_range_length.is_some_and(|expected| expected != appended) {
-            match state.authority.open_write(&data_relative) {
-                Ok(file) => {
-                    let mut file = tokio::fs::File::from_std(file);
-                    if let Err(error) = rollback_staged_file(&mut file, original_size).await {
-                        return metadata_authority_error(&error);
-                    }
-                }
-                Err(error) => {
-                    return metadata_authority_error(&format!(
-                        "failed to reopen OCI upload after final Content-Range mismatch: {error}"
-                    ));
-                }
+            if let Err(error) = append_guard.rollback().await {
+                return metadata_authority_error(&error);
             }
             return oci_error(
                 StatusCode::RANGE_NOT_SATISFIABLE,
@@ -1558,18 +1787,8 @@ async fn complete_upload_inner(
         }
         let computed_digest = format!("sha256:{}", hex::encode(hasher.finalize()));
         if expected_digest != computed_digest {
-            match state.authority.open_write(&data_relative) {
-                Ok(file) => {
-                    let mut file = tokio::fs::File::from_std(file);
-                    if let Err(error) = rollback_staged_file(&mut file, original_size).await {
-                        return metadata_authority_error(&error);
-                    }
-                }
-                Err(error) => {
-                    return metadata_authority_error(&format!(
-                        "failed to reopen OCI upload for digest-mismatch rollback: {error}"
-                    ));
-                }
+            if let Err(error) = append_guard.rollback().await {
+                return metadata_authority_error(&error);
             }
             return digest_invalid(
                 "provided digest does not match uploaded content",
@@ -1580,33 +1799,24 @@ async fn complete_upload_inner(
         upload.updated_at_unix_secs = updated_at;
         upload.expected_digest = Some(computed_digest.clone());
         let persisted = {
+            let disk = state.disk_state();
             let id = id.to_string();
             let upload = upload.clone();
-            run_upload_disk(state, move |disk| {
-                persist_upload_session_disk(&disk, &id, &upload)
-            })
-            .await
+            append_guard
+                .run_tracked_operation(true, move || {
+                    persist_upload_session_disk(&disk, &id, &upload)
+                })
+                .await
         };
         if let Err(error) = persisted {
-            match state.authority.open_write(&data_relative) {
-                Ok(file) => {
-                    let mut file = tokio::fs::File::from_std(file);
-                    if let Err(rollback_error) =
-                        rollback_staged_file(&mut file, original_size).await
-                    {
-                        return metadata_authority_error(&format!(
-                            "{error}; additionally {rollback_error}"
-                        ));
-                    }
-                }
-                Err(rollback_error) => {
-                    return metadata_authority_error(&format!(
-                        "{error}; failed to reopen OCI upload for rollback: {rollback_error}"
-                    ));
-                }
+            if let Err(rollback_error) = append_guard.rollback().await {
+                return metadata_authority_error(&format!(
+                    "{error}; additionally {rollback_error}"
+                ));
             }
             return metadata_authority_error(&error);
         }
+        append_guard.commit();
         computed_digest
     };
 
@@ -1637,7 +1847,7 @@ async fn complete_upload_inner(
         } else {
             let staged = data_relative.clone();
             let destination = blob_relative.clone();
-            if let Err(error) = run_upload_disk(state, move |disk| {
+            if let Err(error) = run_upload_disk(state, &upload_transaction, move |disk| {
                 publish_staged_upload(&disk.authority, &staged, &destination)
                     .map_err(|error| format!("failed to atomically publish OCI blob: {error}"))
             })
@@ -1668,30 +1878,27 @@ async fn complete_upload_inner(
         }
     }
 
-    let (mut metadata_guard, storage_lock, mut replacement) =
-        match begin_metadata_write(state).await {
-            Ok(transaction) => transaction,
-            Err(error) => return metadata_authority_error(&error),
-        };
-    replacement
-        .repositories
-        .entry(name.to_string())
-        .or_default()
-        .blobs
-        .insert(computed_digest.clone());
-    if let Err(error) = persist_metadata_async(state, &replacement).await {
-        return oci_error(
-            StatusCode::INTERNAL_SERVER_ERROR,
-            "UNKNOWN",
-            &error,
-            Some(&location),
-        );
+    let repository_name = name.to_string();
+    let digest_for_metadata = computed_digest.clone();
+    let upload_transaction_for_metadata = Arc::clone(&upload_transaction);
+    if let Err(error) = metadata_write_transaction(state, move |_authority, replacement| {
+        replacement
+            .repositories
+            .entry(repository_name)
+            .or_default()
+            .blobs
+            .insert(digest_for_metadata);
+        // Returning the guard clone keeps the upload transaction alive through
+        // the helper's subsequent metadata persistence when the caller is
+        // cancelled while awaiting this blocking transaction.
+        Ok(upload_transaction_for_metadata)
+    })
+    .await
+    {
+        return error.response();
     }
-    *metadata_guard = replacement;
-    drop(storage_lock);
-    drop(metadata_guard);
     let id_to_remove = id.to_string();
-    if let Err(error) = run_upload_disk(state, move |disk| {
+    if let Err(error) = run_upload_disk(state, &upload_transaction, move |disk| {
         remove_upload_session_disk(&disk, &id_to_remove)
     })
     .await
@@ -2060,7 +2267,7 @@ async fn validate_manifest_references(
 }
 
 fn revalidate_manifest_references(
-    state: &OciRegistryState,
+    authority: &crate::atomic_file::AuthorityRoot,
     metadata: &OciMetadata,
     repository_name: &str,
     validated: &[ValidatedManifestReference],
@@ -2082,7 +2289,7 @@ fn revalidate_manifest_references(
         }
         let path = manifest_reference_path(reference.kind, &reference.digest)
             .expect("validated manifest digest remains canonical");
-        if state.authority.identity(&path).ok() != Some(reference.identity) {
+        if authority.identity(&path).ok() != Some(reference.identity) {
             return Err(ManifestValidationError {
                 status: StatusCode::CONFLICT,
                 code: "MANIFEST_INVALID",
@@ -2147,57 +2354,34 @@ async fn put_manifest_inner(
         Ok(validated) => validated,
         Err(error) => return error.response(),
     };
-    let (mut metadata_guard, storage_lock, mut replacement) =
-        match begin_metadata_write(state).await {
-            Ok(transaction) => transaction,
-            Err(error) => return metadata_authority_error(&error),
-        };
-    if let Err(error) = revalidate_manifest_references(state, &replacement, name, &validated) {
-        return error.response();
-    }
-    let descriptor = ManifestDescriptor {
-        digest: digest.clone(),
-        media_type: canonical_media_type.to_string(),
-    };
-    let repository = replacement
-        .repositories
-        .entry(name.to_string())
-        .or_default();
-    repository
-        .manifests
-        .insert(reference.to_string(), descriptor.clone());
-    repository.manifests.insert(digest.clone(), descriptor);
-    let metadata_bytes = match serde_json::to_vec(&replacement) {
-        Ok(bytes) => bytes,
-        Err(error) => {
-            return oci_error(
-                StatusCode::INTERNAL_SERVER_ERROR,
-                "UNKNOWN",
-                &format!("failed to encode OCI metadata: {error}"),
-                None,
-            );
-        }
-    };
-    let authority = state.authority.clone();
+    let repository_name = name.to_string();
+    let manifest_reference = reference.to_string();
+    let media_type = canonical_media_type.to_string();
+    let digest_for_transaction = digest.clone();
     let body = body.to_vec();
-    let persist = tokio::task::spawn_blocking(move || {
-        authority
-            .write(&manifest_path, &body)
-            .map_err(|error| format!("failed to persist OCI manifest: {error}"))?;
-        authority
-            .write(FsPath::new("metadata.json"), &metadata_bytes)
-            .map_err(|error| format!("failed to persist OCI metadata: {error}"))
+    let transaction = metadata_write_transaction(state, move |authority, replacement| {
+        revalidate_manifest_references(authority, replacement, &repository_name, &validated)
+            .map_err(MetadataWriteError::Validation)?;
+        let descriptor = ManifestDescriptor {
+            digest: digest_for_transaction.clone(),
+            media_type,
+        };
+        let repository = replacement.repositories.entry(repository_name).or_default();
+        repository
+            .manifests
+            .insert(manifest_reference, descriptor.clone());
+        repository
+            .manifests
+            .insert(digest_for_transaction, descriptor);
+        authority.write(&manifest_path, &body).map_err(|error| {
+            MetadataWriteError::Storage(format!("failed to persist OCI manifest: {error}"))
+        })?;
+        Ok(())
     })
     .await;
-    if let Err(error) = persist
-        .map_err(|error| format!("OCI manifest persistence task failed: {error}"))
-        .and_then(|result| result)
-    {
-        return oci_error(StatusCode::INTERNAL_SERVER_ERROR, "UNKNOWN", &error, None);
+    if let Err(error) = transaction {
+        return error.response();
     }
-    *metadata_guard = replacement;
-    drop(storage_lock);
-    drop(metadata_guard);
 
     let mut response = StatusCode::CREATED.into_response();
     insert_header(
@@ -2223,29 +2407,32 @@ async fn delete_manifest_inner(state: &OciRegistryState, name: &str, reference: 
             None,
         );
     }
-    let (mut metadata_guard, storage_lock, mut replacement) =
-        match begin_metadata_write(state).await {
-            Ok(transaction) => transaction,
-            Err(error) => return metadata_authority_error(&error),
-        };
-    let Some(repository) = replacement.repositories.get_mut(name) else {
-        return StatusCode::NOT_FOUND.into_response();
-    };
-    let Some(descriptor) = repository.manifests.get(reference).cloned() else {
-        return StatusCode::NOT_FOUND.into_response();
-    };
-    if sha256_hex(reference).is_some() {
-        repository
+    let repository_name = name.to_string();
+    let manifest_reference = reference.to_string();
+    let digest_reference = sha256_hex(reference).is_some();
+    let transaction = metadata_write_transaction(state, move |_authority, replacement| {
+        let repository = replacement
+            .repositories
+            .get_mut(&repository_name)
+            .ok_or(MetadataWriteError::NotFound)?;
+        let descriptor = repository
             .manifests
-            .retain(|_, candidate| candidate.digest != descriptor.digest);
-    } else {
-        repository.manifests.remove(reference);
+            .get(&manifest_reference)
+            .cloned()
+            .ok_or(MetadataWriteError::NotFound)?;
+        if digest_reference {
+            repository
+                .manifests
+                .retain(|_, candidate| candidate.digest != descriptor.digest);
+        } else {
+            repository.manifests.remove(&manifest_reference);
+        }
+        Ok(())
+    })
+    .await;
+    if let Err(error) = transaction {
+        return error.response();
     }
-    if let Err(error) = persist_metadata_async(state, &replacement).await {
-        return oci_error(StatusCode::INTERNAL_SERVER_ERROR, "UNKNOWN", &error, None);
-    }
-    *metadata_guard = replacement;
-    drop(storage_lock);
     StatusCode::ACCEPTED.into_response()
 }
 
@@ -2414,18 +2601,24 @@ mod tests {
 
     async fn seed_blob(state: &OciRegistryState, repository: &str, bytes: &[u8]) -> String {
         let digest = format!("sha256:{}", sha2_hex(bytes));
-        let blob_path = blob_path_for_digest(&state.blobs_dir, &digest).unwrap();
-        let (mut guard, storage_lock, mut replacement) = begin_metadata_write(state).await.unwrap();
-        crate::atomic_file::write(&blob_path, bytes).unwrap();
-        replacement
-            .repositories
-            .entry(repository.to_string())
-            .or_default()
-            .blobs
-            .insert(digest.clone());
-        persist_metadata(state, &replacement).unwrap();
-        *guard = replacement;
-        drop(storage_lock);
+        let blob_relative = blob_relative_for_digest(&digest).unwrap();
+        let repository = repository.to_string();
+        let bytes = bytes.to_vec();
+        let digest_for_transaction = digest.clone();
+        metadata_write_transaction(state, move |authority, replacement| {
+            authority.write(&blob_relative, &bytes).map_err(|error| {
+                MetadataWriteError::Storage(format!("failed to seed OCI blob: {error}"))
+            })?;
+            replacement
+                .repositories
+                .entry(repository)
+                .or_default()
+                .blobs
+                .insert(digest_for_transaction);
+            Ok(())
+        })
+        .await
+        .unwrap();
         digest
     }
 
@@ -2502,6 +2695,29 @@ mod tests {
         prune_and_measure_uploads(state).unwrap().0
     }
 
+    async fn mark_upload_finalizing(
+        state: Arc<OciRegistryState>,
+        location: &str,
+        bytes: &[u8],
+    ) -> String {
+        let patched = oci_routes(state.clone())
+            .oneshot(authenticated_request(
+                "PATCH",
+                location,
+                Body::from(bytes.to_vec()),
+            ))
+            .await
+            .unwrap();
+        assert_eq!(patched.status(), StatusCode::ACCEPTED);
+        let digest = format!("sha256:{}", sha2_hex(bytes));
+        let id = upload_id_from_location(location);
+        let _transaction = begin_upload_write(&state).await.unwrap();
+        let mut upload = read_upload_session(&state, id).unwrap().unwrap();
+        upload.expected_digest = Some(digest.clone());
+        persist_upload_session(&state, id, &upload).unwrap();
+        digest
+    }
+
     fn upload_id_from_location(location: &str) -> &str {
         location.rsplit('/').next().unwrap()
     }
@@ -2532,6 +2748,213 @@ mod tests {
             blob_path_for_digest(root, &format!("sha256:{}", "a".repeat(65))),
             None
         );
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn cancelled_metadata_mutation_retains_local_and_storage_locks() {
+        let (_root, state) = registry_state_with_token(Some("registry-secret"));
+        let (started_tx, started_rx) = tokio::sync::oneshot::channel();
+        let (release_tx, release_rx) = std::sync::mpsc::channel();
+        let first_state = state.clone();
+        let first = tokio::spawn(async move {
+            metadata_write_transaction(&first_state, move |_authority, metadata| {
+                let _ = started_tx.send(());
+                release_rx
+                    .recv_timeout(Duration::from_secs(5))
+                    .map_err(|error| {
+                        MetadataWriteError::Storage(format!(
+                            "metadata cancellation test barrier failed: {error}"
+                        ))
+                    })?;
+                metadata
+                    .repositories
+                    .entry("first".to_string())
+                    .or_default();
+                Ok(())
+            })
+            .await
+        });
+        started_rx.await.unwrap();
+        first.abort();
+        assert!(first.await.unwrap_err().is_cancelled());
+        assert!(state.metadata.try_write().is_err());
+
+        let peer = Arc::new(OciRegistryState::new(
+            state.blobs_dir.clone(),
+            Some("registry-secret".to_string()),
+        ));
+        let peer_state = peer.clone();
+        let mut peer_write = tokio::spawn(async move {
+            metadata_write_transaction(&peer_state, move |_authority, metadata| {
+                metadata
+                    .repositories
+                    .entry("second".to_string())
+                    .or_default();
+                Ok(())
+            })
+            .await
+        });
+        assert!(
+            tokio::time::timeout(Duration::from_millis(100), &mut peer_write)
+                .await
+                .is_err()
+        );
+
+        release_tx.send(()).unwrap();
+        tokio::time::timeout(Duration::from_secs(2), peer_write)
+            .await
+            .unwrap()
+            .unwrap()
+            .unwrap();
+        let durable = read_metadata_authority(&state.authority).unwrap();
+        assert!(durable.repositories.contains_key("first"));
+        assert!(durable.repositories.contains_key("second"));
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn cancelled_upload_disk_mutation_retains_local_and_storage_locks() {
+        let (_root, state) = registry_state_with_token(Some("registry-secret"));
+        let (started_tx, started_rx) = tokio::sync::oneshot::channel();
+        let (release_tx, release_rx) = std::sync::mpsc::channel();
+        let first_state = state.clone();
+        let first = tokio::spawn(async move {
+            let transaction = begin_upload_write(&first_state).await?;
+            run_upload_disk(&first_state, &transaction, move |disk| {
+                let _ = started_tx.send(());
+                release_rx
+                    .recv_timeout(Duration::from_secs(5))
+                    .map_err(|error| format!("upload cancellation test barrier failed: {error}"))?;
+                disk.authority
+                    .write(FsPath::new("uploads/cancellation-marker"), b"complete")
+                    .map_err(|error| format!("failed to write cancellation marker: {error}"))
+            })
+            .await
+        });
+        started_rx.await.unwrap();
+        first.abort();
+        assert!(first.await.unwrap_err().is_cancelled());
+        assert!(state.upload_gate.try_lock().is_err());
+
+        let peer = Arc::new(OciRegistryState::new(
+            state.blobs_dir.clone(),
+            Some("registry-secret".to_string()),
+        ));
+        let peer_state = peer.clone();
+        let mut peer_write =
+            tokio::spawn(async move { begin_upload_write(&peer_state).await.map(drop) });
+        assert!(
+            tokio::time::timeout(Duration::from_millis(100), &mut peer_write)
+                .await
+                .is_err()
+        );
+
+        release_tx.send(()).unwrap();
+        tokio::time::timeout(Duration::from_secs(2), peer_write)
+            .await
+            .unwrap()
+            .unwrap()
+            .unwrap();
+        assert_eq!(
+            state
+                .authority
+                .read(FsPath::new("uploads/cancellation-marker"))
+                .unwrap(),
+            b"complete"
+        );
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn cancelled_patch_stream_rolls_back_before_peer_mutation() {
+        let (_root, state) = registry_state_with_token(Some("registry-secret"));
+        let location = initiate(state.clone()).await;
+        let id = upload_id_from_location(&location).to_string();
+        let rollback_hook = Arc::new(UploadRollbackHook {
+            started: tokio::sync::Notify::new(),
+            release: tokio::sync::Notify::new(),
+        });
+        *state.upload_rollback_hook.lock().unwrap() = Some(Arc::clone(&rollback_hook));
+        let (first_chunk_tx, first_chunk_rx) = tokio::sync::oneshot::channel();
+        let chunks = async_stream::stream! {
+            yield Ok::<Bytes, std::io::Error>(Bytes::from_static(b"partial"));
+            // The stream is polled for its next item only after append_upload_body
+            // has written the first chunk, so this is a deterministic cancellation
+            // point with an uncommitted tail on disk.
+            let _ = first_chunk_tx.send(());
+            std::future::pending::<()>().await;
+        };
+
+        let first_app = oci_routes(state.clone());
+        let first_location = location.clone();
+        let first = tokio::spawn(async move {
+            first_app
+                .oneshot(
+                    Request::patch(&first_location)
+                        .header(header::AUTHORIZATION, "Bearer registry-secret")
+                        .body(Body::from_stream(chunks))
+                        .unwrap(),
+                )
+                .await
+        });
+        first_chunk_rx.await.unwrap();
+        first.abort();
+        assert!(first.await.unwrap_err().is_cancelled());
+        tokio::time::timeout(Duration::from_secs(2), rollback_hook.started.notified())
+            .await
+            .unwrap();
+        assert!(state.upload_gate.try_lock().is_err());
+        assert_eq!(
+            state
+                .authority
+                .read(&upload_data_relative(&id).unwrap())
+                .unwrap(),
+            b"partial"
+        );
+        let durable_before_rollback: PendingUpload = serde_json::from_slice(
+            &state
+                .authority
+                .read(&upload_metadata_relative(&id).unwrap())
+                .unwrap(),
+        )
+        .unwrap();
+        assert_eq!(durable_before_rollback.size, 0);
+        *state.upload_rollback_hook.lock().unwrap() = None;
+
+        let second_app = oci_routes(state.clone());
+        let second_location = location.clone();
+        let mut second = tokio::spawn(async move {
+            second_app
+                .oneshot(
+                    Request::patch(&second_location)
+                        .header(header::AUTHORIZATION, "Bearer registry-secret")
+                        .header(header::CONTENT_RANGE, "0-0")
+                        .body(Body::from("!"))
+                        .unwrap(),
+                )
+                .await
+                .unwrap()
+        });
+        assert!(
+            tokio::time::timeout(Duration::from_millis(100), &mut second)
+                .await
+                .is_err(),
+            "a competing PATCH escaped while the cancelled stream was still mutating storage"
+        );
+
+        rollback_hook.release.notify_one();
+        let response = tokio::time::timeout(Duration::from_secs(2), second)
+            .await
+            .unwrap()
+            .unwrap();
+        assert_eq!(response.status(), StatusCode::ACCEPTED);
+        assert_eq!(response.headers()[header::RANGE], "0-0");
+        assert_eq!(
+            state
+                .authority
+                .read(&upload_data_relative(&id).unwrap())
+                .unwrap(),
+            b"!"
+        );
+        assert_eq!(read_upload_session(&state, &id).unwrap().unwrap().size, 1);
     }
 
     #[tokio::test]
@@ -2915,6 +3338,83 @@ mod tests {
             .await
             .unwrap();
         assert_eq!(accepted.status(), StatusCode::CREATED);
+    }
+
+    #[tokio::test]
+    async fn resumed_finalization_rejects_same_length_staged_data_tampering() {
+        let (_root, state) = registry_state_with_token(Some("registry-secret"));
+        let location = initiate(state.clone()).await;
+        let trusted = b"trusted";
+        let digest = mark_upload_finalizing(state.clone(), &location, trusted).await;
+        let id = upload_id_from_location(&location);
+        let tampered = b"forged!";
+        assert_eq!(trusted.len(), tampered.len());
+        state
+            .authority
+            .write(&upload_data_relative(id).unwrap(), tampered)
+            .unwrap();
+
+        let rejected = oci_routes(state.clone())
+            .oneshot(authenticated_request(
+                "PUT",
+                &format!("{location}?digest={digest}"),
+                Body::empty(),
+            ))
+            .await
+            .unwrap();
+        assert_eq!(rejected.status(), StatusCode::INTERNAL_SERVER_ERROR);
+        assert_eq!(error_code(rejected).await, "UNKNOWN");
+        assert!(read_upload_session(&state, id).unwrap().is_some());
+        assert!(state
+            .authority
+            .metadata(&blob_relative_for_digest(&digest).unwrap())
+            .is_err());
+        assert!(!metadata_snapshot(&state)
+            .await
+            .unwrap()
+            .repositories
+            .get("demo")
+            .is_some_and(|repository| repository.blobs.contains(&digest)));
+    }
+
+    #[tokio::test]
+    async fn empty_resumed_finalization_rejects_nonzero_content_range() {
+        let (_root, state) = registry_state_with_token(Some("registry-secret"));
+        let location = initiate(state.clone()).await;
+        let bytes = b"durable";
+        let digest = mark_upload_finalizing(state.clone(), &location, bytes).await;
+        let id = upload_id_from_location(&location);
+
+        let rejected = oci_routes(state.clone())
+            .oneshot(
+                Request::put(format!("{location}?digest={digest}"))
+                    .header(header::AUTHORIZATION, "Bearer registry-secret")
+                    .header(
+                        header::CONTENT_RANGE,
+                        format!("{}-{}", bytes.len(), bytes.len()),
+                    )
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(rejected.status(), StatusCode::RANGE_NOT_SATISFIABLE);
+        assert_eq!(error_code(rejected).await, "BLOB_UPLOAD_INVALID");
+        assert_eq!(
+            state
+                .authority
+                .read(&upload_data_relative(id).unwrap())
+                .unwrap(),
+            bytes
+        );
+        assert_eq!(
+            read_upload_session(&state, id)
+                .unwrap()
+                .unwrap()
+                .expected_digest
+                .as_deref(),
+            Some(digest.as_str())
+        );
     }
 
     #[cfg(unix)]

--- a/crates/kin-registry/src/oci.rs
+++ b/crates/kin-registry/src/oci.rs
@@ -3,97 +3,264 @@
 
 //! OCI Distribution Specification adapter.
 //!
-//! Implements core OCI distribution endpoints:
-//! - GET  /v2/ -- version check
-//! - HEAD /v2/{name}/blobs/{digest} -- check blob existence
-//! - GET  /v2/{name}/blobs/{digest} -- pull blob
-//! - POST /v2/{name}/blobs/uploads/ -- initiate upload
-//! - PUT  /v2/{name}/blobs/uploads/{id} -- complete upload
-//! - GET  /v2/{name}/manifests/{reference} -- pull manifest
-//! - PUT  /v2/{name}/manifests/{reference} -- push manifest
-//! - DELETE /v2/{name}/manifests/{reference} -- delete manifest
+//! Pulls are intentionally public. Every mutating route is protected by the
+//! registry write token and fails closed when no token is configured.
 
 use axum::{
-    body::Bytes,
-    extract::{Path, State},
-    http::{header, StatusCode},
-    response::{IntoResponse, Response},
+    body::{Body, Bytes},
+    extract::{DefaultBodyLimit, Path, Query, State},
+    http::{header, HeaderMap, HeaderValue, Method, Request, StatusCode},
+    middleware::{self, Next},
+    response::{IntoResponse, Json, Response},
     routing::{get, head, post, put},
     Router,
 };
+use serde::Deserialize;
 use sha2::{Digest, Sha256};
 use std::collections::HashMap;
 use std::path::{Path as FsPath, PathBuf};
+use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::Arc;
+use std::time::{Duration, Instant, SystemTime};
 use tokio::sync::RwLock;
 
 const SHA256_HEX_LEN: usize = 64;
+const UPLOAD_ID_HEX_LEN: usize = 32;
+const MAX_REPOSITORY_NAME_LEN: usize = 255;
+const MAX_MANIFEST_REFERENCE_LEN: usize = 128;
+const MAX_OCI_BLOB_SIZE: usize = 512 * 1024 * 1024;
+const MAX_OCI_MANIFEST_SIZE: usize = 4 * 1024 * 1024;
+const MAX_ACTIVE_UPLOADS: usize = 1024;
+const UPLOAD_TTL: Duration = Duration::from_secs(15 * 60);
 
-/// Shared state for the OCI registry routes
-pub struct OciRegistryState {
-    pub blobs_dir: std::path::PathBuf,
-    /// reference -> manifest bytes
-    pub manifests: RwLock<HashMap<String, Vec<u8>>>,
-    /// upload ID -> partial data
-    pub uploads: RwLock<HashMap<String, Vec<u8>>>,
+static UPLOAD_SEQUENCE: AtomicU64 = AtomicU64::new(0);
+
+struct PendingUpload {
+    repository: String,
+    created_at: Instant,
+    data: Vec<u8>,
 }
 
-/// Create axum router for OCI distribution endpoints
+/// Shared state for the OCI registry routes.
+pub struct OciRegistryState {
+    blobs_dir: PathBuf,
+    /// (repository, reference) -> manifest bytes
+    manifests: RwLock<HashMap<(String, String), Vec<u8>>>,
+    /// upload ID -> bounded, expiring partial data
+    uploads: RwLock<HashMap<String, PendingUpload>>,
+    /// Shared secret for OCI writes. `None` disables every mutation.
+    write_token: Option<String>,
+}
+
+impl OciRegistryState {
+    pub fn new(blobs_dir: PathBuf, write_token: Option<String>) -> Self {
+        Self {
+            blobs_dir,
+            manifests: RwLock::new(HashMap::new()),
+            uploads: RwLock::new(HashMap::new()),
+            write_token: write_token
+                .map(|token| token.trim().to_string())
+                .filter(|token| !token.is_empty()),
+        }
+    }
+}
+
+/// Create axum router for OCI distribution endpoints.
 pub fn oci_routes(state: Arc<OciRegistryState>) -> Router {
-    Router::new()
+    let public = Router::new()
         .route("/v2/", get(version_check))
         .route("/v2/{name}/blobs/{digest}", head(check_blob).get(get_blob))
+        .route("/v2/{name}/manifests/{reference}", get(get_manifest));
+
+    // The auth middleware executes before body extraction, so an unauthorized
+    // caller cannot make the handlers buffer an upload. Axum's body limits also
+    // cap chunked requests for which Content-Length cannot be trusted.
+    let writes = Router::new()
         .route("/v2/{name}/blobs/uploads/", post(initiate_upload))
-        .route("/v2/{name}/blobs/uploads/{id}", put(complete_upload))
+        .route(
+            "/v2/{name}/blobs/uploads/{id}",
+            put(complete_upload).layer(DefaultBodyLimit::max(MAX_OCI_BLOB_SIZE)),
+        )
         .route(
             "/v2/{name}/manifests/{reference}",
-            get(get_manifest).put(put_manifest).delete(delete_manifest),
+            put(put_manifest)
+                .delete(delete_manifest)
+                .layer(DefaultBodyLimit::max(MAX_OCI_MANIFEST_SIZE)),
         )
-        .with_state(state)
+        .route_layer(middleware::from_fn_with_state(
+            Arc::clone(&state),
+            authorize_oci_write,
+        ));
+
+    Router::new().merge(public).merge(writes).with_state(state)
 }
 
-/// GET /v2/ -- OCI version check (returns 200 OK)
+fn constant_time_eq(a: &[u8], b: &[u8]) -> bool {
+    if a.len() != b.len() {
+        return false;
+    }
+    let mut diff = 0u8;
+    for (left, right) in a.iter().zip(b.iter()) {
+        diff |= left ^ right;
+    }
+    diff == 0
+}
+
+async fn authorize_oci_write(
+    State(state): State<Arc<OciRegistryState>>,
+    request: Request<Body>,
+    next: Next,
+) -> Response {
+    let Some(expected) = state.write_token.as_deref() else {
+        return oci_error(
+            StatusCode::SERVICE_UNAVAILABLE,
+            "DENIED",
+            "OCI registry writes are disabled: no registry token is configured",
+            None,
+        );
+    };
+
+    let provided = bearer_token(request.headers());
+    if !provided.is_some_and(|token| constant_time_eq(token.as_bytes(), expected.as_bytes())) {
+        let mut response = oci_error(
+            StatusCode::UNAUTHORIZED,
+            "UNAUTHORIZED",
+            "authentication required for OCI registry writes",
+            None,
+        );
+        response.headers_mut().insert(
+            header::WWW_AUTHENTICATE,
+            HeaderValue::from_static("Bearer realm=\"kin OCI registry\""),
+        );
+        return response;
+    }
+
+    if let Some(limit) = oci_write_body_limit(request.method(), request.uri().path()) {
+        let declared = request
+            .headers()
+            .get(header::CONTENT_LENGTH)
+            .and_then(|value| value.to_str().ok())
+            .and_then(|value| value.parse::<u64>().ok());
+        if declared.is_some_and(|length| length > limit as u64) {
+            return oci_error(
+                StatusCode::PAYLOAD_TOO_LARGE,
+                "SIZE_INVALID",
+                "request body exceeds the configured OCI limit",
+                Some(request.uri().path()),
+            );
+        }
+    }
+
+    next.run(request).await
+}
+
+fn oci_write_body_limit(method: &Method, path: &str) -> Option<usize> {
+    if method == Method::PUT && path.contains("/blobs/uploads/") {
+        Some(MAX_OCI_BLOB_SIZE)
+    } else if method == Method::PUT && path.contains("/manifests/") {
+        Some(MAX_OCI_MANIFEST_SIZE)
+    } else {
+        None
+    }
+}
+
+fn bearer_token(headers: &HeaderMap) -> Option<&str> {
+    headers
+        .get(header::AUTHORIZATION)?
+        .to_str()
+        .ok()?
+        .strip_prefix("Bearer ")
+        .map(str::trim)
+        .filter(|token| !token.is_empty())
+}
+
+fn oci_error(status: StatusCode, code: &str, message: &str, location: Option<&str>) -> Response {
+    let mut response = (
+        status,
+        Json(serde_json::json!({
+            "errors": [{
+                "code": code,
+                "message": message,
+            }]
+        })),
+    )
+        .into_response();
+    if let Some(location) = location {
+        insert_header(response.headers_mut(), header::LOCATION, location);
+    }
+    response
+}
+
+fn insert_header(headers: &mut HeaderMap, name: header::HeaderName, value: &str) {
+    if let Ok(value) = HeaderValue::from_str(value) {
+        headers.insert(name, value);
+    }
+}
+
+/// GET /v2/ -- OCI version check (returns 200 OK).
 async fn version_check() -> impl IntoResponse {
     StatusCode::OK
 }
 
-/// HEAD /v2/{name}/blobs/{digest} -- check if blob exists
+/// HEAD /v2/{name}/blobs/{digest} -- check if blob exists.
 async fn check_blob(
     State(state): State<Arc<OciRegistryState>>,
-    Path((_name, digest)): Path<(String, String)>,
+    Path((name, digest)): Path<(String, String)>,
 ) -> Response {
+    if !valid_repository_name(&name) {
+        return oci_error(
+            StatusCode::BAD_REQUEST,
+            "NAME_INVALID",
+            "invalid OCI repository name",
+            None,
+        );
+    }
     let Some(blob_path) = blob_path_for_digest(&state.blobs_dir, &digest) else {
-        return StatusCode::BAD_REQUEST.into_response();
+        return digest_invalid("invalid non-canonical blob digest", None);
     };
-    if blob_path.exists() {
-        let size = std::fs::metadata(&blob_path).map(|m| m.len()).unwrap_or(0);
-        (
-            StatusCode::OK,
-            [
-                ("docker-content-digest", digest.as_str()),
-                ("content-length", &size.to_string()),
-            ],
-        )
-            .into_response()
+    if blob_path.is_file() {
+        let size = std::fs::metadata(&blob_path)
+            .map(|metadata| metadata.len())
+            .unwrap_or(0);
+        let mut response = StatusCode::OK.into_response();
+        insert_header(
+            response.headers_mut(),
+            header::HeaderName::from_static("docker-content-digest"),
+            &digest,
+        );
+        insert_header(
+            response.headers_mut(),
+            header::CONTENT_LENGTH,
+            &size.to_string(),
+        );
+        response
     } else {
         StatusCode::NOT_FOUND.into_response()
     }
 }
 
-/// GET /v2/{name}/blobs/{digest} -- pull a blob by digest
+/// GET /v2/{name}/blobs/{digest} -- pull a blob by digest.
 async fn get_blob(
     State(state): State<Arc<OciRegistryState>>,
-    Path((_name, digest)): Path<(String, String)>,
+    Path((name, digest)): Path<(String, String)>,
 ) -> Response {
+    if !valid_repository_name(&name) {
+        return oci_error(
+            StatusCode::BAD_REQUEST,
+            "NAME_INVALID",
+            "invalid OCI repository name",
+            None,
+        );
+    }
     let Some(blob_path) = blob_path_for_digest(&state.blobs_dir, &digest) else {
-        return StatusCode::BAD_REQUEST.into_response();
+        return digest_invalid("invalid non-canonical blob digest", None);
     };
     match std::fs::read(&blob_path) {
         Ok(bytes) => (
             StatusCode::OK,
             [
                 (header::CONTENT_TYPE.as_str(), "application/octet-stream"),
-                ("docker-content-digest", &digest),
+                ("docker-content-digest", digest.as_str()),
             ],
             bytes,
         )
@@ -102,71 +269,177 @@ async fn get_blob(
     }
 }
 
-/// POST /v2/{name}/blobs/uploads/ -- initiate a blob upload
+/// POST /v2/{name}/blobs/uploads/ -- initiate a blob upload.
 async fn initiate_upload(
     State(state): State<Arc<OciRegistryState>>,
     Path(name): Path<String>,
 ) -> Response {
-    // Generate a unique upload ID without uuid crate
-    let upload_id = {
-        use std::time::SystemTime;
-        let nanos = SystemTime::now()
-            .duration_since(SystemTime::UNIX_EPOCH)
-            .unwrap_or_default()
-            .as_nanos();
-        let hash = Sha256::digest(format!("{}-{}", name, nanos).as_bytes());
-        hex::encode(&hash[..16])
-    };
-
-    state
-        .uploads
-        .write()
-        .await
-        .insert(upload_id.clone(), Vec::new());
-
-    (
-        StatusCode::ACCEPTED,
-        [(
-            "location",
-            format!("/v2/{}/blobs/uploads/{}", name, upload_id).as_str(),
-        )],
-    )
-        .into_response()
-}
-
-/// PUT /v2/{name}/blobs/uploads/{id} -- complete a blob upload
-async fn complete_upload(
-    State(state): State<Arc<OciRegistryState>>,
-    Path((_name, id)): Path<(String, String)>,
-    body: Bytes,
-) -> Response {
-    // Merge any existing upload data with final chunk
-    let mut uploads = state.uploads.write().await;
-    let mut data = uploads.remove(&id).unwrap_or_default();
-    data.extend_from_slice(&body);
-
-    let digest = format!("sha256:{}", sha2_hex(&data));
-    let blob_path = blob_path_for_digest(&state.blobs_dir, &digest)
-        .expect("internally generated sha256 digest must be valid");
-
-    if let Err(e) = std::fs::write(&blob_path, &data) {
-        return (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()).into_response();
+    if !valid_repository_name(&name) {
+        return oci_error(
+            StatusCode::BAD_REQUEST,
+            "NAME_INVALID",
+            "invalid OCI repository name",
+            None,
+        );
     }
 
-    (
-        StatusCode::CREATED,
-        [("docker-content-digest", digest.as_str())],
-    )
-        .into_response()
+    let upload_id = new_upload_id(&name);
+    let mut uploads = state.uploads.write().await;
+    prune_expired_uploads(&mut uploads);
+    if uploads.len() >= MAX_ACTIVE_UPLOADS {
+        return oci_error(
+            StatusCode::TOO_MANY_REQUESTS,
+            "TOOMANYREQUESTS",
+            "too many active OCI uploads",
+            None,
+        );
+    }
+    uploads.insert(
+        upload_id.clone(),
+        PendingUpload {
+            repository: name.clone(),
+            created_at: Instant::now(),
+            data: Vec::new(),
+        },
+    );
+    drop(uploads);
+
+    let location = upload_location(&name, &upload_id);
+    let mut response = StatusCode::ACCEPTED.into_response();
+    insert_header(response.headers_mut(), header::LOCATION, &location);
+    response
 }
 
-/// GET /v2/{name}/manifests/{reference} -- pull a manifest
+#[derive(Debug, Default, Deserialize)]
+struct CompleteUploadQuery {
+    digest: Option<String>,
+}
+
+/// PUT /v2/{name}/blobs/uploads/{id}?digest=sha256:... -- complete upload.
+async fn complete_upload(
+    State(state): State<Arc<OciRegistryState>>,
+    Path((name, id)): Path<(String, String)>,
+    Query(query): Query<CompleteUploadQuery>,
+    body: Bytes,
+) -> Response {
+    let location = upload_location(&name, &id);
+    if !valid_repository_name(&name) || !valid_upload_id(&id) {
+        return oci_error(
+            StatusCode::BAD_REQUEST,
+            "BLOB_UPLOAD_INVALID",
+            "invalid OCI upload coordinate",
+            Some(&location),
+        );
+    }
+    let Some(expected_digest) = query.digest.as_deref() else {
+        return digest_invalid(
+            "completion requires a digest query parameter",
+            Some(&location),
+        );
+    };
+    if sha256_hex(expected_digest).is_none() {
+        return digest_invalid(
+            "completion digest must be canonical lowercase sha256",
+            Some(&location),
+        );
+    }
+
+    let mut uploads = state.uploads.write().await;
+    let Some(pending) = uploads.get(&id) else {
+        return oci_error(
+            StatusCode::NOT_FOUND,
+            "BLOB_UPLOAD_UNKNOWN",
+            "blob upload is unknown or expired",
+            Some(&location),
+        );
+    };
+    if pending.repository != name || pending.created_at.elapsed() >= UPLOAD_TTL {
+        uploads.remove(&id);
+        return oci_error(
+            StatusCode::NOT_FOUND,
+            "BLOB_UPLOAD_UNKNOWN",
+            "blob upload is unknown or expired",
+            Some(&location),
+        );
+    }
+    let Some(completed_size) = pending.data.len().checked_add(body.len()) else {
+        return oci_error(
+            StatusCode::PAYLOAD_TOO_LARGE,
+            "BLOB_UPLOAD_INVALID",
+            "blob upload exceeds the configured size limit",
+            Some(&location),
+        );
+    };
+    if completed_size > MAX_OCI_BLOB_SIZE {
+        return oci_error(
+            StatusCode::PAYLOAD_TOO_LARGE,
+            "BLOB_UPLOAD_INVALID",
+            "blob upload exceeds the configured size limit",
+            Some(&location),
+        );
+    }
+
+    let mut hasher = Sha256::new();
+    hasher.update(&pending.data);
+    hasher.update(&body);
+    let computed_digest = format!("sha256:{}", hex::encode(hasher.finalize()));
+    if expected_digest != computed_digest {
+        return digest_invalid(
+            "provided digest does not match uploaded content",
+            Some(&location),
+        );
+    }
+
+    let mut pending = uploads
+        .remove(&id)
+        .expect("upload remained present while write lock was held");
+    drop(uploads);
+    let partial_len = pending.data.len();
+    pending.data.extend_from_slice(&body);
+
+    let blob_path = blob_path_for_digest(&state.blobs_dir, &computed_digest)
+        .expect("computed sha256 digest is canonical");
+    let write_result = std::fs::create_dir_all(&state.blobs_dir)
+        .and_then(|()| std::fs::write(&blob_path, &pending.data));
+    if let Err(error) = write_result {
+        // Preserve the pre-completion upload state so the same final request
+        // can be retried after the storage failure without duplicating bytes.
+        pending.data.truncate(partial_len);
+        state.uploads.write().await.insert(id, pending);
+        return oci_error(
+            StatusCode::INTERNAL_SERVER_ERROR,
+            "UNKNOWN",
+            &format!("failed to persist OCI blob: {error}"),
+            Some(&location),
+        );
+    }
+
+    let blob_location = format!("/v2/{name}/blobs/{computed_digest}");
+    let mut response = StatusCode::CREATED.into_response();
+    insert_header(
+        response.headers_mut(),
+        header::HeaderName::from_static("docker-content-digest"),
+        &computed_digest,
+    );
+    insert_header(response.headers_mut(), header::LOCATION, &blob_location);
+    response
+}
+
+/// GET /v2/{name}/manifests/{reference} -- pull a manifest.
 async fn get_manifest(
     State(state): State<Arc<OciRegistryState>>,
-    Path((_name, reference)): Path<(String, String)>,
+    Path((name, reference)): Path<(String, String)>,
 ) -> Response {
+    if !valid_repository_name(&name) || !valid_manifest_reference(&reference) {
+        return oci_error(
+            StatusCode::BAD_REQUEST,
+            "MANIFEST_INVALID",
+            "invalid OCI manifest coordinate",
+            None,
+        );
+    }
     let manifests = state.manifests.read().await;
-    match manifests.get(&reference) {
+    match manifests.get(&(name, reference)) {
         Some(bytes) => (
             StatusCode::OK,
             [(
@@ -180,37 +453,137 @@ async fn get_manifest(
     }
 }
 
-/// PUT /v2/{name}/manifests/{reference} -- push a manifest
+/// PUT /v2/{name}/manifests/{reference} -- push a manifest.
 async fn put_manifest(
     State(state): State<Arc<OciRegistryState>>,
-    Path((_name, reference)): Path<(String, String)>,
+    Path((name, reference)): Path<(String, String)>,
     body: Bytes,
 ) -> Response {
+    if !valid_repository_name(&name) || !valid_manifest_reference(&reference) {
+        return oci_error(
+            StatusCode::BAD_REQUEST,
+            "MANIFEST_INVALID",
+            "invalid OCI manifest coordinate",
+            None,
+        );
+    }
+    if body.is_empty() || body.len() > MAX_OCI_MANIFEST_SIZE {
+        return oci_error(
+            if body.len() > MAX_OCI_MANIFEST_SIZE {
+                StatusCode::PAYLOAD_TOO_LARGE
+            } else {
+                StatusCode::BAD_REQUEST
+            },
+            "MANIFEST_INVALID",
+            "manifest body is empty or exceeds the configured size limit",
+            None,
+        );
+    }
+
     let digest = format!("sha256:{}", sha2_hex(&body));
     let mut manifests = state.manifests.write().await;
-    manifests.insert(reference, body.to_vec());
-    manifests.insert(digest.clone(), body.to_vec());
-    (
-        StatusCode::CREATED,
-        [("docker-content-digest", digest.as_str())],
-    )
-        .into_response()
+    manifests.insert((name.clone(), reference), body.to_vec());
+    manifests.insert((name.clone(), digest.clone()), body.to_vec());
+    drop(manifests);
+
+    let mut response = StatusCode::CREATED.into_response();
+    insert_header(
+        response.headers_mut(),
+        header::HeaderName::from_static("docker-content-digest"),
+        &digest,
+    );
+    insert_header(
+        response.headers_mut(),
+        header::LOCATION,
+        &format!("/v2/{name}/manifests/{digest}"),
+    );
+    response
 }
 
-/// DELETE /v2/{name}/manifests/{reference} -- delete a manifest
+/// DELETE /v2/{name}/manifests/{reference} -- delete a manifest.
 async fn delete_manifest(
     State(state): State<Arc<OciRegistryState>>,
-    Path((_name, reference)): Path<(String, String)>,
+    Path((name, reference)): Path<(String, String)>,
 ) -> Response {
-    let mut manifests = state.manifests.write().await;
-    manifests.remove(&reference);
+    if !valid_repository_name(&name) || !valid_manifest_reference(&reference) {
+        return oci_error(
+            StatusCode::BAD_REQUEST,
+            "MANIFEST_INVALID",
+            "invalid OCI manifest coordinate",
+            None,
+        );
+    }
+    state.manifests.write().await.remove(&(name, reference));
     StatusCode::ACCEPTED.into_response()
 }
 
-/// Compute SHA-256 hex digest of data
+fn new_upload_id(name: &str) -> String {
+    let nanos = SystemTime::now()
+        .duration_since(SystemTime::UNIX_EPOCH)
+        .unwrap_or_default()
+        .as_nanos();
+    let sequence = UPLOAD_SEQUENCE.fetch_add(1, Ordering::Relaxed);
+    let hash = Sha256::digest(format!("{name}-{nanos}-{sequence}").as_bytes());
+    hex::encode(&hash[..UPLOAD_ID_HEX_LEN / 2])
+}
+
+fn upload_location(name: &str, id: &str) -> String {
+    format!("/v2/{name}/blobs/uploads/{id}")
+}
+
+fn valid_upload_id(id: &str) -> bool {
+    id.len() == UPLOAD_ID_HEX_LEN && id.bytes().all(is_lower_hex)
+}
+
+fn prune_expired_uploads(uploads: &mut HashMap<String, PendingUpload>) {
+    uploads.retain(|_, pending| pending.created_at.elapsed() < UPLOAD_TTL);
+}
+
+fn valid_repository_name(name: &str) -> bool {
+    if name.is_empty() || name.len() > MAX_REPOSITORY_NAME_LEN {
+        return false;
+    }
+    let bytes = name.as_bytes();
+    bytes
+        .first()
+        .is_some_and(|byte| byte.is_ascii_lowercase() || byte.is_ascii_digit())
+        && bytes
+            .last()
+            .is_some_and(|byte| byte.is_ascii_lowercase() || byte.is_ascii_digit())
+        && bytes.iter().all(|byte| {
+            byte.is_ascii_lowercase() || byte.is_ascii_digit() || matches!(byte, b'.' | b'_' | b'-')
+        })
+}
+
+fn valid_manifest_reference(reference: &str) -> bool {
+    if reference.starts_with("sha256:") {
+        return sha256_hex(reference).is_some();
+    }
+    if reference.is_empty() || reference.len() > MAX_MANIFEST_REFERENCE_LEN {
+        return false;
+    }
+    let bytes = reference.as_bytes();
+    bytes
+        .first()
+        .is_some_and(|byte| byte.is_ascii_alphanumeric() || *byte == b'_')
+        && bytes
+            .iter()
+            .all(|byte| byte.is_ascii_alphanumeric() || matches!(byte, b'_' | b'.' | b'-'))
+}
+
+/// Compute SHA-256 hex digest of data.
 fn sha2_hex(data: &[u8]) -> String {
-    let hash = Sha256::digest(data);
-    hex::encode(hash)
+    hex::encode(Sha256::digest(data))
+}
+
+fn is_lower_hex(byte: u8) -> bool {
+    matches!(byte, b'0'..=b'9' | b'a'..=b'f')
+}
+
+fn sha256_hex(digest: &str) -> Option<&str> {
+    let encoded = digest.strip_prefix("sha256:")?;
+    (encoded.len() == SHA256_HEX_LEN && encoded.as_bytes().iter().all(|byte| is_lower_hex(*byte)))
+        .then_some(encoded)
 }
 
 /// Map a canonical SHA-256 digest to its on-disk blob filename.
@@ -220,40 +593,74 @@ fn sha2_hex(data: &[u8]) -> String {
 /// separators, dot components, alternate algorithms, and encoded traversal
 /// payloads are rejected before any filesystem operation.
 fn blob_path_for_digest(blobs_dir: &FsPath, digest: &str) -> Option<PathBuf> {
-    let encoded = digest.strip_prefix("sha256:")?;
-    if encoded.len() != SHA256_HEX_LEN
-        || !encoded
-            .bytes()
-            .all(|byte| matches!(byte, b'0'..=b'9' | b'a'..=b'f'))
-    {
-        return None;
-    }
+    let encoded = sha256_hex(digest)?;
+    let path = blobs_dir.join(format!("sha256_{encoded}"));
+    (path.parent() == Some(blobs_dir)).then_some(path)
+}
 
-    Some(blobs_dir.join(format!("sha256_{encoded}")))
+fn digest_invalid(message: &str, location: Option<&str>) -> Response {
+    oci_error(StatusCode::BAD_REQUEST, "DIGEST_INVALID", message, location)
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
-    use axum::body::Body;
-    use axum::http::Request;
+    use axum::body::to_bytes;
     use tower::ServiceExt;
 
-    fn registry_state() -> (tempfile::TempDir, Arc<OciRegistryState>) {
+    fn registry_state_with_token(
+        write_token: Option<&str>,
+    ) -> (tempfile::TempDir, Arc<OciRegistryState>) {
         let root = tempfile::tempdir().unwrap();
         let blobs_dir = root.path().join("oci");
         std::fs::create_dir_all(&blobs_dir).unwrap();
-        let state = Arc::new(OciRegistryState {
-            blobs_dir,
-            manifests: Default::default(),
-            uploads: Default::default(),
-        });
-        (root, state)
+        (
+            root,
+            Arc::new(OciRegistryState::new(
+                blobs_dir,
+                write_token.map(String::from),
+            )),
+        )
+    }
+
+    fn registry_state() -> (tempfile::TempDir, Arc<OciRegistryState>) {
+        registry_state_with_token(None)
+    }
+
+    fn authenticated_request(method: &str, uri: &str, body: Body) -> Request<Body> {
+        Request::builder()
+            .method(method)
+            .uri(uri)
+            .header(header::AUTHORIZATION, "Bearer registry-secret")
+            .body(body)
+            .unwrap()
+    }
+
+    async fn initiate(state: Arc<OciRegistryState>) -> String {
+        let response = oci_routes(state)
+            .oneshot(authenticated_request(
+                "POST",
+                "/v2/demo/blobs/uploads/",
+                Body::empty(),
+            ))
+            .await
+            .unwrap();
+        assert_eq!(response.status(), StatusCode::ACCEPTED);
+        response.headers()[header::LOCATION]
+            .to_str()
+            .unwrap()
+            .to_string()
+    }
+
+    async fn error_code(response: Response) -> String {
+        let body = to_bytes(response.into_body(), 1024 * 1024).await.unwrap();
+        let json: serde_json::Value = serde_json::from_slice(&body).unwrap();
+        json["errors"][0]["code"].as_str().unwrap().to_string()
     }
 
     #[test]
     fn blob_path_accepts_only_canonical_sha256_digests() {
-        let root = std::path::Path::new("/registry/blobs");
+        let root = FsPath::new("/registry/blobs");
         let digest = format!("sha256:{}", "a".repeat(SHA256_HEX_LEN));
         assert_eq!(
             blob_path_for_digest(root, &digest),
@@ -281,7 +688,7 @@ mod tests {
 
     #[tokio::test]
     async fn public_blob_reads_accept_valid_digests_without_authorization() {
-        let (_root, state) = registry_state();
+        let (_root, state) = registry_state_with_token(Some("registry-secret"));
         let bytes = b"public oci blob";
         let digest = format!("sha256:{}", sha2_hex(bytes));
         let blob_path = blob_path_for_digest(&state.blobs_dir, &digest).unwrap();
@@ -298,9 +705,7 @@ mod tests {
 
         assert_eq!(response.status(), StatusCode::OK);
         assert_eq!(response.headers()["docker-content-digest"], digest.as_str());
-        let body = axum::body::to_bytes(response.into_body(), usize::MAX)
-            .await
-            .unwrap();
+        let body = to_bytes(response.into_body(), usize::MAX).await.unwrap();
         assert_eq!(&body[..], bytes);
     }
 
@@ -334,9 +739,154 @@ mod tests {
                 )
                 .await
                 .unwrap();
-
             assert_ne!(response.status(), StatusCode::OK);
         }
         assert_eq!(std::fs::read(outside).unwrap(), b"must not be served");
+    }
+
+    #[tokio::test]
+    async fn writes_fail_closed_but_reads_remain_public() {
+        let (_root, disabled_state) = registry_state();
+        let disabled = oci_routes(disabled_state)
+            .oneshot(
+                Request::post("/v2/demo/blobs/uploads/")
+                    .header(header::AUTHORIZATION, "Bearer anything")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(disabled.status(), StatusCode::SERVICE_UNAVAILABLE);
+
+        let (_root, state) = registry_state_with_token(Some("registry-secret"));
+        for token in [None, Some("wrong")] {
+            let mut builder = Request::post("/v2/demo/blobs/uploads/");
+            if let Some(token) = token {
+                builder = builder.header(header::AUTHORIZATION, format!("Bearer {token}"));
+            }
+            let response = oci_routes(state.clone())
+                .oneshot(builder.body(Body::empty()).unwrap())
+                .await
+                .unwrap();
+            assert_eq!(response.status(), StatusCode::UNAUTHORIZED);
+            assert!(response.headers().contains_key(header::WWW_AUTHENTICATE));
+        }
+
+        let accepted = oci_routes(state.clone())
+            .oneshot(authenticated_request(
+                "POST",
+                "/v2/demo/blobs/uploads/",
+                Body::empty(),
+            ))
+            .await
+            .unwrap();
+        assert_eq!(accepted.status(), StatusCode::ACCEPTED);
+
+        let public = oci_routes(state)
+            .oneshot(Request::get("/v2/").body(Body::empty()).unwrap())
+            .await
+            .unwrap();
+        assert_eq!(public.status(), StatusCode::OK);
+    }
+
+    #[tokio::test]
+    async fn completion_requires_matching_canonical_digest_and_preserves_upload_on_error() {
+        let (_root, state) = registry_state_with_token(Some("registry-secret"));
+        let location = initiate(state.clone()).await;
+        let body = b"verified OCI layer";
+        let digest = format!("sha256:{}", sha2_hex(body));
+
+        for uri in [
+            location.clone(),
+            format!("{location}?digest=sha256:{}", "0".repeat(SHA256_HEX_LEN)),
+            format!("{location}?digest={}", digest.to_ascii_uppercase()),
+        ] {
+            let response = oci_routes(state.clone())
+                .oneshot(authenticated_request(
+                    "PUT",
+                    &uri,
+                    Body::from(body.as_slice()),
+                ))
+                .await
+                .unwrap();
+            assert_eq!(response.status(), StatusCode::BAD_REQUEST);
+            assert_eq!(response.headers()[header::LOCATION], location.as_str());
+            assert_eq!(error_code(response).await, "DIGEST_INVALID");
+            assert_eq!(state.uploads.read().await.len(), 1);
+        }
+
+        let success = oci_routes(state.clone())
+            .oneshot(authenticated_request(
+                "PUT",
+                &format!("{location}?digest={digest}"),
+                Body::from(body.as_slice()),
+            ))
+            .await
+            .unwrap();
+        assert_eq!(success.status(), StatusCode::CREATED);
+        assert_eq!(success.headers()["docker-content-digest"], digest.as_str());
+        assert!(state.uploads.read().await.is_empty());
+        let blob_path = blob_path_for_digest(&state.blobs_dir, &digest).unwrap();
+        assert_eq!(std::fs::read(blob_path).unwrap(), body);
+    }
+
+    #[tokio::test]
+    async fn expired_upload_is_removed_and_cannot_be_completed() {
+        let (_root, state) = registry_state_with_token(Some("registry-secret"));
+        let id = "a".repeat(UPLOAD_ID_HEX_LEN);
+        state.uploads.write().await.insert(
+            id.clone(),
+            PendingUpload {
+                repository: "demo".to_string(),
+                created_at: Instant::now() - UPLOAD_TTL - Duration::from_secs(1),
+                data: Vec::new(),
+            },
+        );
+        let body = b"expired";
+        let digest = format!("sha256:{}", sha2_hex(body));
+        let location = upload_location("demo", &id);
+        let response = oci_routes(state.clone())
+            .oneshot(authenticated_request(
+                "PUT",
+                &format!("{location}?digest={digest}"),
+                Body::from(body.as_slice()),
+            ))
+            .await
+            .unwrap();
+        assert_eq!(response.status(), StatusCode::NOT_FOUND);
+        assert_eq!(error_code(response).await, "BLOB_UPLOAD_UNKNOWN");
+        assert!(state.uploads.read().await.is_empty());
+    }
+
+    #[tokio::test]
+    async fn manifest_body_is_bounded_before_handler_buffering() {
+        let (_root, state) = registry_state_with_token(Some("registry-secret"));
+        let response = oci_routes(state)
+            .oneshot(authenticated_request(
+                "PUT",
+                "/v2/demo/manifests/latest",
+                Body::from(vec![b'x'; MAX_OCI_MANIFEST_SIZE + 1]),
+            ))
+            .await
+            .unwrap();
+        assert_eq!(response.status(), StatusCode::PAYLOAD_TOO_LARGE);
+    }
+
+    #[tokio::test]
+    async fn blob_body_is_bounded_before_handler_buffering() {
+        let (_root, state) = registry_state_with_token(Some("registry-secret"));
+        let location = initiate(state.clone()).await;
+        let digest = format!("sha256:{}", sha2_hex(b""));
+        let response = oci_routes(state)
+            .oneshot(
+                Request::put(format!("{location}?digest={digest}"))
+                    .header(header::AUTHORIZATION, "Bearer registry-secret")
+                    .header(header::CONTENT_LENGTH, MAX_OCI_BLOB_SIZE + 1)
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(response.status(), StatusCode::PAYLOAD_TOO_LARGE);
     }
 }

--- a/crates/kin-registry/src/oci.rs
+++ b/crates/kin-registry/src/oci.rs
@@ -15,15 +15,16 @@ use axum::{
     routing::{any, get},
     Router,
 };
+use futures_util::StreamExt;
 use serde::{Deserialize, Serialize};
 use sha2::{Digest, Sha256};
 use std::collections::{BTreeSet, HashMap};
 use std::path::{Path as FsPath, PathBuf};
 use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::Arc;
-use std::time::{Duration, Instant, SystemTime};
-use tokio::io::AsyncReadExt;
-use tokio::sync::{RwLock, RwLockWriteGuard};
+use std::time::{Duration, SystemTime};
+use tokio::io::{AsyncReadExt, AsyncWriteExt};
+use tokio::sync::{Mutex, MutexGuard, RwLock, RwLockWriteGuard};
 
 const SHA256_HEX_LEN: usize = 64;
 const UPLOAD_ID_HEX_LEN: usize = 32;
@@ -32,17 +33,56 @@ const MAX_MANIFEST_REFERENCE_LEN: usize = 128;
 const MAX_OCI_BLOB_SIZE: usize = 512 * 1024 * 1024;
 const MAX_OCI_MANIFEST_SIZE: usize = 4 * 1024 * 1024;
 const MAX_ACTIVE_UPLOADS: usize = 1024;
+const MAX_TOTAL_ACTIVE_UPLOAD_BYTES: u64 = 2 * 1024 * 1024 * 1024;
 const UPLOAD_TTL: Duration = Duration::from_secs(15 * 60);
 const OCI_METADATA_VERSION: u32 = 1;
+const OCI_UPLOAD_METADATA_VERSION: u32 = 1;
 const BLOB_STREAM_CHUNK_SIZE: usize = 64 * 1024;
 const DEFAULT_MANIFEST_MEDIA_TYPE: &str = "application/vnd.oci.image.manifest.v1+json";
+const DOCKER_MANIFEST_MEDIA_TYPE: &str = "application/vnd.docker.distribution.manifest.v2+json";
+const MAX_MANIFEST_LAYERS: usize = 4096;
 
 static UPLOAD_SEQUENCE: AtomicU64 = AtomicU64::new(0);
 
+#[derive(Clone, Debug, Deserialize, Serialize)]
 struct PendingUpload {
+    version: u32,
     repository: String,
-    created_at: Instant,
-    data: Vec<u8>,
+    created_at_unix_secs: u64,
+    updated_at_unix_secs: u64,
+    size: u64,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    expected_digest: Option<String>,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct ImageManifest {
+    schema_version: u32,
+    #[serde(default)]
+    media_type: Option<String>,
+    config: ImageDescriptor,
+    layers: Vec<ImageDescriptor>,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct ImageDescriptor {
+    media_type: String,
+    digest: String,
+    size: u64,
+}
+
+struct ManifestValidationError {
+    status: StatusCode,
+    code: &'static str,
+    message: String,
+}
+
+impl ManifestValidationError {
+    fn response(self) -> Response {
+        oci_error(self.status, self.code, &self.message, None)
+    }
 }
 
 #[derive(Clone, Debug, Deserialize, Serialize)]
@@ -78,16 +118,26 @@ pub struct OciRegistryState {
     metadata_path: PathBuf,
     metadata_lock_path: PathBuf,
     metadata: RwLock<OciMetadata>,
-    /// upload ID -> bounded, expiring partial data
-    uploads: RwLock<HashMap<String, PendingUpload>>,
+    uploads_dir: PathBuf,
+    uploads_lock_path: PathBuf,
+    /// Serializes this process before the shared storage lock is acquired.
+    upload_gate: Mutex<()>,
+    max_active_upload_bytes: u64,
     /// OCI-specific secret for writes. `None` disables every mutation.
     write_token: Option<String>,
 }
 
 impl OciRegistryState {
     pub fn new(blobs_dir: PathBuf, write_token: Option<String>) -> Self {
+        // Pin the storage identity once. macOS temporary paths commonly enter
+        // through `/var` while descriptor-anchored storage resolves them under
+        // `/private/var`; a canonical root keeps every later no-follow boundary
+        // and cross-process lock keyed to the same directory.
+        let blobs_dir = std::fs::canonicalize(&blobs_dir).unwrap_or(blobs_dir);
         let metadata_path = blobs_dir.join("metadata.json");
         let metadata_lock_path = blobs_dir.join(".metadata.lock");
+        let uploads_dir = blobs_dir.join("uploads");
+        let uploads_lock_path = blobs_dir.join(".uploads.lock");
         // This cache is only an in-process observation surface. Every request
         // reloads durable authority under a storage-scoped advisory lock, so a
         // corrupt file or another daemon's publication can never be hidden by
@@ -98,7 +148,10 @@ impl OciRegistryState {
             metadata_path,
             metadata_lock_path,
             metadata: RwLock::new(metadata),
-            uploads: RwLock::new(HashMap::new()),
+            uploads_dir,
+            uploads_lock_path,
+            upload_gate: Mutex::new(()),
+            max_active_upload_bytes: MAX_TOTAL_ACTIVE_UPLOAD_BYTES,
             write_token: write_token
                 .map(|token| token.trim().to_string())
                 .filter(|token| !token.is_empty()),
@@ -143,7 +196,7 @@ async fn authorize_oci_write(
     }
     if !matches!(
         *request.method(),
-        Method::POST | Method::PUT | Method::DELETE
+        Method::POST | Method::PUT | Method::PATCH | Method::DELETE
     ) {
         return next.run(request).await;
     }
@@ -191,7 +244,7 @@ async fn authorize_oci_write(
 }
 
 fn oci_write_body_limit(method: &Method, path: &str) -> Option<usize> {
-    if method == Method::PUT && path.contains("/blobs/uploads/") {
+    if matches!(*method, Method::PUT | Method::PATCH) && path.contains("/blobs/uploads/") {
         Some(MAX_OCI_BLOB_SIZE)
     } else if method == Method::PUT && path.contains("/manifests/") {
         Some(MAX_OCI_MANIFEST_SIZE)
@@ -252,19 +305,45 @@ async fn dispatch(
     }
 
     if let Some((repository, upload_id)) = path.rsplit_once("/blobs/uploads/") {
-        if method == Method::PUT {
-            let digest = request
-                .uri()
-                .query()
-                .and_then(|query| query_parameter(query, "digest"));
-            let body = match read_bounded_body(request.into_body(), MAX_OCI_BLOB_SIZE).await {
-                Ok(body) => body,
-                Err(response) => return response,
-            };
-            return complete_upload_inner(&state, repository, upload_id, digest.as_deref(), body)
-                .await;
-        }
-        return StatusCode::METHOD_NOT_ALLOWED.into_response();
+        let declared_length = request
+            .headers()
+            .get(header::CONTENT_LENGTH)
+            .and_then(|value| value.to_str().ok())
+            .and_then(|value| value.parse::<u64>().ok());
+        let content_range = request
+            .headers()
+            .get(header::CONTENT_RANGE)
+            .and_then(|value| value.to_str().ok())
+            .map(str::to_string);
+        return match method {
+            Method::PATCH => {
+                patch_upload_inner(
+                    &state,
+                    repository,
+                    upload_id,
+                    content_range.as_deref(),
+                    declared_length,
+                    request.into_body(),
+                )
+                .await
+            }
+            Method::PUT => {
+                let digest = request
+                    .uri()
+                    .query()
+                    .and_then(|query| query_parameter(query, "digest"));
+                complete_upload_inner(
+                    &state,
+                    repository,
+                    upload_id,
+                    digest.as_deref(),
+                    declared_length,
+                    request.into_body(),
+                )
+                .await
+            }
+            _ => StatusCode::METHOD_NOT_ALLOWED.into_response(),
+        };
     }
 
     if let Some((repository, digest)) = path.rsplit_once("/blobs/") {
@@ -418,6 +497,12 @@ async fn get_blob_inner(
     if !is_member {
         return StatusCode::NOT_FOUND.into_response();
     }
+    if !std::fs::symlink_metadata(&blob_path)
+        .ok()
+        .is_some_and(|metadata| metadata.file_type().is_file())
+    {
+        return StatusCode::NOT_FOUND.into_response();
+    }
     let file = match tokio::fs::File::open(&blob_path).await {
         Ok(file) => file,
         Err(_) => return StatusCode::NOT_FOUND.into_response(),
@@ -466,6 +551,423 @@ async fn get_blob_inner(
     response
 }
 
+struct UploadWriteTransaction<'a> {
+    _local: MutexGuard<'a, ()>,
+    _storage: crate::storage_lock::StorageLock,
+}
+
+#[derive(Debug)]
+enum UploadAppendError {
+    Limit,
+    Body(String),
+    Storage(String),
+}
+
+async fn begin_upload_write(
+    state: &OciRegistryState,
+) -> Result<UploadWriteTransaction<'_>, String> {
+    let local = state.upload_gate.lock().await;
+    let storage = crate::storage_lock::StorageLock::exclusive(&state.uploads_lock_path)
+        .map_err(|error| format!("failed to lock OCI uploads: {error}"))?;
+    crate::atomic_file::ensure_directory_durable(&state.uploads_dir)
+        .map_err(|error| format!("failed to create OCI upload storage: {error}"))?;
+    Ok(UploadWriteTransaction {
+        _local: local,
+        _storage: storage,
+    })
+}
+
+fn upload_metadata_path(state: &OciRegistryState, id: &str) -> Option<PathBuf> {
+    valid_upload_id(id).then(|| state.uploads_dir.join(format!("{id}.json")))
+}
+
+fn upload_data_path(state: &OciRegistryState, id: &str) -> Option<PathBuf> {
+    valid_upload_id(id).then(|| state.uploads_dir.join(format!("{id}.data")))
+}
+
+fn now_unix_secs() -> Result<u64, String> {
+    SystemTime::now()
+        .duration_since(SystemTime::UNIX_EPOCH)
+        .map(|duration| duration.as_secs())
+        .map_err(|error| format!("system clock is before the Unix epoch: {error}"))
+}
+
+fn read_upload_session(
+    state: &OciRegistryState,
+    id: &str,
+) -> Result<Option<PendingUpload>, String> {
+    let metadata_path = upload_metadata_path(state, id)
+        .ok_or_else(|| "invalid OCI upload identifier".to_string())?;
+    let bytes = match std::fs::read(&metadata_path) {
+        Ok(bytes) => bytes,
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => return Ok(None),
+        Err(error) => return Err(format!("failed to read OCI upload metadata: {error}")),
+    };
+    let upload = serde_json::from_slice::<PendingUpload>(&bytes)
+        .map_err(|error| format!("failed to decode OCI upload metadata: {error}"))?;
+    if upload.version != OCI_UPLOAD_METADATA_VERSION
+        || !valid_repository_name(&upload.repository)
+        || upload.created_at_unix_secs > upload.updated_at_unix_secs
+        || upload.size > MAX_OCI_BLOB_SIZE as u64
+        || upload
+            .expected_digest
+            .as_deref()
+            .is_some_and(|digest| sha256_hex(digest).is_none())
+    {
+        return Err("OCI upload metadata failed validation".to_string());
+    }
+    let data_path = upload_data_path(state, id).expect("validated upload identifier");
+    match std::fs::symlink_metadata(&data_path) {
+        Ok(metadata) if metadata.file_type().is_file() && metadata.len() == upload.size => {}
+        Ok(metadata) if metadata.file_type().is_file() && metadata.len() > upload.size => {
+            // The durable metadata offset is the commit point. Bytes beyond it
+            // can only be an interrupted PATCH/final PUT and are safe to drop.
+            let file = std::fs::OpenOptions::new()
+                .write(true)
+                .open(&data_path)
+                .map_err(|error| format!("failed to reopen interrupted OCI upload: {error}"))?;
+            file.set_len(upload.size)
+                .map_err(|error| format!("failed to roll back interrupted OCI upload: {error}"))?;
+            file.sync_all()
+                .map_err(|error| format!("failed to sync interrupted OCI upload: {error}"))?;
+        }
+        Ok(_) => return Err("OCI upload staged data does not match its metadata".to_string()),
+        Err(error)
+            if error.kind() == std::io::ErrorKind::NotFound
+                && upload.expected_digest.as_ref().is_some_and(|digest| {
+                    blob_path_for_digest(&state.blobs_dir, digest)
+                        .and_then(|path| std::fs::symlink_metadata(path).ok())
+                        .is_some_and(|metadata| {
+                            metadata.file_type().is_file() && metadata.len() == upload.size
+                        })
+                }) => {}
+        Err(error) => return Err(format!("failed to inspect OCI upload data: {error}")),
+    }
+    Ok(Some(upload))
+}
+
+fn persist_upload_session(
+    state: &OciRegistryState,
+    id: &str,
+    upload: &PendingUpload,
+) -> Result<(), String> {
+    let metadata_path = upload_metadata_path(state, id)
+        .ok_or_else(|| "invalid OCI upload identifier".to_string())?;
+    let bytes = serde_json::to_vec(upload)
+        .map_err(|error| format!("failed to encode OCI upload metadata: {error}"))?;
+    crate::atomic_file::write(&metadata_path, &bytes)
+        .map_err(|error| format!("failed to persist OCI upload metadata: {error}"))
+}
+
+fn remove_upload_session(state: &OciRegistryState, id: &str) -> Result<(), String> {
+    for path in [
+        upload_metadata_path(state, id)
+            .ok_or_else(|| "invalid OCI upload identifier".to_string())?,
+        upload_data_path(state, id).ok_or_else(|| "invalid OCI upload identifier".to_string())?,
+    ] {
+        match std::fs::remove_file(&path) {
+            Ok(()) => {}
+            Err(error) if error.kind() == std::io::ErrorKind::NotFound => {}
+            Err(error) => {
+                return Err(format!(
+                    "failed to remove OCI upload state {}: {error}",
+                    path.display()
+                ));
+            }
+        }
+    }
+    Ok(())
+}
+
+/// Prune expired durable sessions and return (active count, aggregate bytes).
+/// The caller holds the shared-storage upload lock, so all daemon processes
+/// enforce the same count and byte budget.
+fn prune_and_measure_uploads(state: &OciRegistryState) -> Result<(usize, u64), String> {
+    let now = now_unix_secs()?;
+    let mut active_ids = BTreeSet::new();
+    let mut active_count = 0usize;
+    let mut active_bytes = 0u64;
+    for entry in std::fs::read_dir(&state.uploads_dir)
+        .map_err(|error| format!("failed to enumerate OCI uploads: {error}"))?
+    {
+        let entry = entry.map_err(|error| format!("failed to enumerate OCI uploads: {error}"))?;
+        let file_name = entry.file_name();
+        let Some(file_name) = file_name.to_str() else {
+            return Err("OCI upload storage contains a non-UTF-8 entry".to_string());
+        };
+        let Some(id) = file_name.strip_suffix(".json") else {
+            continue;
+        };
+        if !valid_upload_id(id) {
+            return Err(format!(
+                "OCI upload storage contains invalid metadata entry {file_name}"
+            ));
+        }
+        let Some(upload) = read_upload_session(state, id)? else {
+            continue;
+        };
+        if now.saturating_sub(upload.updated_at_unix_secs) >= UPLOAD_TTL.as_secs() {
+            remove_upload_session(state, id)?;
+            continue;
+        }
+        active_count = active_count
+            .checked_add(1)
+            .ok_or_else(|| "OCI upload count overflowed".to_string())?;
+        active_bytes = active_bytes
+            .checked_add(upload.size)
+            .ok_or_else(|| "OCI upload byte count overflowed".to_string())?;
+        if active_bytes > state.max_active_upload_bytes {
+            return Err("durable OCI uploads exceed the configured aggregate limit".to_string());
+        }
+        active_ids.insert(id.to_string());
+    }
+
+    // A crash between the empty data write and metadata publication can leave
+    // an unowned stage. Remove only canonical unowned stages; every unexpected
+    // entry fails closed instead of being omitted from the aggregate budget.
+    for entry in std::fs::read_dir(&state.uploads_dir)
+        .map_err(|error| format!("failed to enumerate OCI upload data: {error}"))?
+    {
+        let entry =
+            entry.map_err(|error| format!("failed to enumerate OCI upload data: {error}"))?;
+        let file_name = entry.file_name();
+        let Some(file_name) = file_name.to_str() else {
+            return Err("OCI upload storage contains a non-UTF-8 entry".to_string());
+        };
+        if let Some(id) = file_name.strip_suffix(".json") {
+            if !valid_upload_id(id) {
+                return Err(format!(
+                    "OCI upload storage contains invalid metadata entry {file_name}"
+                ));
+            }
+            continue;
+        }
+        if let Some(id) = file_name.strip_suffix(".data") {
+            if !valid_upload_id(id) {
+                return Err(format!(
+                    "OCI upload storage contains invalid data entry {file_name}"
+                ));
+            }
+            if !active_ids.contains(id) {
+                std::fs::remove_file(entry.path()).map_err(|error| {
+                    format!("failed to prune orphaned OCI upload data: {error}")
+                })?;
+            }
+            continue;
+        }
+        return Err(format!(
+            "OCI upload storage contains unexpected entry {file_name}"
+        ));
+    }
+    Ok((active_count, active_bytes))
+}
+
+async fn rollback_staged_file(file: &mut tokio::fs::File, size: u64) -> Result<(), String> {
+    file.set_len(size)
+        .await
+        .map_err(|error| format!("failed to roll back OCI upload data: {error}"))?;
+    file.sync_all()
+        .await
+        .map_err(|error| format!("failed to sync rolled-back OCI upload data: {error}"))
+}
+
+async fn append_upload_body(
+    path: &FsPath,
+    original_size: u64,
+    aggregate_remaining: u64,
+    declared_length: Option<u64>,
+    body: Body,
+    mut hasher: Option<&mut Sha256>,
+) -> Result<u64, UploadAppendError> {
+    let session_remaining = (MAX_OCI_BLOB_SIZE as u64).saturating_sub(original_size);
+    let allowed = session_remaining.min(aggregate_remaining);
+    if declared_length.is_some_and(|length| length > allowed) {
+        return Err(UploadAppendError::Limit);
+    }
+    let mut file = tokio::fs::OpenOptions::new()
+        .append(true)
+        .open(path)
+        .await
+        .map_err(|error| {
+            UploadAppendError::Storage(format!("failed to open OCI upload data: {error}"))
+        })?;
+    let mut written = 0u64;
+    let mut stream = body.into_data_stream();
+    while let Some(chunk) = stream.next().await {
+        let chunk = match chunk {
+            Ok(chunk) => chunk,
+            Err(error) => {
+                rollback_staged_file(&mut file, original_size)
+                    .await
+                    .map_err(UploadAppendError::Storage)?;
+                return Err(UploadAppendError::Body(format!(
+                    "failed to read OCI upload body: {error}"
+                )));
+            }
+        };
+        let chunk_len = u64::try_from(chunk.len()).map_err(|_| UploadAppendError::Limit)?;
+        if written
+            .checked_add(chunk_len)
+            .is_none_or(|total| total > allowed)
+        {
+            rollback_staged_file(&mut file, original_size)
+                .await
+                .map_err(UploadAppendError::Storage)?;
+            return Err(UploadAppendError::Limit);
+        }
+        if let Err(error) = file.write_all(&chunk).await {
+            rollback_staged_file(&mut file, original_size)
+                .await
+                .map_err(UploadAppendError::Storage)?;
+            return Err(UploadAppendError::Storage(format!(
+                "failed to append OCI upload data: {error}"
+            )));
+        }
+        if let Some(hasher) = hasher.as_deref_mut() {
+            hasher.update(&chunk);
+        }
+        written += chunk_len;
+    }
+    if let Err(error) = file.flush().await {
+        rollback_staged_file(&mut file, original_size)
+            .await
+            .map_err(UploadAppendError::Storage)?;
+        return Err(UploadAppendError::Storage(format!(
+            "failed to flush OCI upload data: {error}"
+        )));
+    }
+    if let Err(error) = file.sync_all().await {
+        rollback_staged_file(&mut file, original_size)
+            .await
+            .map_err(UploadAppendError::Storage)?;
+        return Err(UploadAppendError::Storage(format!(
+            "failed to sync OCI upload data: {error}"
+        )));
+    }
+    Ok(written)
+}
+
+async fn hash_upload_file(path: &FsPath, expected_size: u64) -> Result<Sha256, String> {
+    let mut file = tokio::fs::File::open(path)
+        .await
+        .map_err(|error| format!("failed to open OCI upload data for hashing: {error}"))?;
+    let mut hasher = Sha256::new();
+    let mut observed_size = 0u64;
+    let mut buffer = vec![0u8; BLOB_STREAM_CHUNK_SIZE];
+    loop {
+        let read = file
+            .read(&mut buffer)
+            .await
+            .map_err(|error| format!("failed to hash OCI upload data: {error}"))?;
+        if read == 0 {
+            break;
+        }
+        observed_size = observed_size
+            .checked_add(read as u64)
+            .ok_or_else(|| "OCI upload size overflowed while hashing".to_string())?;
+        if observed_size > expected_size || observed_size > MAX_OCI_BLOB_SIZE as u64 {
+            return Err("OCI upload data exceeded its durable size".to_string());
+        }
+        hasher.update(&buffer[..read]);
+    }
+    if observed_size != expected_size {
+        return Err("OCI upload data did not match its durable size".to_string());
+    }
+    Ok(hasher)
+}
+
+fn publish_staged_upload(staged: &FsPath, destination: &FsPath) -> std::io::Result<()> {
+    let staged_parent = staged.parent().ok_or_else(|| {
+        std::io::Error::new(
+            std::io::ErrorKind::InvalidInput,
+            "OCI upload stage has no parent directory",
+        )
+    })?;
+    let destination_parent = destination.parent().ok_or_else(|| {
+        std::io::Error::new(
+            std::io::ErrorKind::InvalidInput,
+            "OCI blob destination has no parent directory",
+        )
+    })?;
+    match std::fs::symlink_metadata(destination) {
+        Ok(_) => {
+            return Err(std::io::Error::new(
+                std::io::ErrorKind::AlreadyExists,
+                "OCI blob destination already exists",
+            ));
+        }
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => {}
+        Err(error) => return Err(error),
+    }
+    std::fs::rename(staged, destination)?;
+    sync_oci_directory(destination_parent)?;
+    if staged_parent != destination_parent {
+        sync_oci_directory(staged_parent)?;
+    }
+    Ok(())
+}
+
+#[cfg(unix)]
+fn sync_oci_directory(path: &FsPath) -> std::io::Result<()> {
+    std::fs::File::open(path)?.sync_all()
+}
+
+#[cfg(not(unix))]
+fn sync_oci_directory(_path: &FsPath) -> std::io::Result<()> {
+    Ok(())
+}
+
+fn upload_progress_response(status: StatusCode, name: &str, id: &str, size: u64) -> Response {
+    let mut response = status.into_response();
+    insert_header(
+        response.headers_mut(),
+        header::LOCATION,
+        &upload_location(name, id),
+    );
+    insert_header(
+        response.headers_mut(),
+        header::HeaderName::from_static("docker-upload-uuid"),
+        id,
+    );
+    insert_header(
+        response.headers_mut(),
+        header::RANGE,
+        &format!("0-{}", size.saturating_sub(1)),
+    );
+    response
+}
+
+fn parse_content_range(value: &str) -> Option<(u64, u64)> {
+    let value = value.strip_prefix("bytes ").unwrap_or(value);
+    let (start, end) = value.split_once('-')?;
+    let start = start.parse::<u64>().ok()?;
+    let end = end.parse::<u64>().ok()?;
+    (end >= start).then_some((start, end))
+}
+
+fn upload_error(error: UploadAppendError, location: &str) -> Response {
+    match error {
+        UploadAppendError::Limit => oci_error(
+            StatusCode::PAYLOAD_TOO_LARGE,
+            "BLOB_UPLOAD_INVALID",
+            "blob upload exceeds the configured per-upload or aggregate size limit",
+            Some(location),
+        ),
+        UploadAppendError::Body(message) => oci_error(
+            StatusCode::BAD_REQUEST,
+            "BLOB_UPLOAD_INVALID",
+            &message,
+            Some(location),
+        ),
+        UploadAppendError::Storage(message) => oci_error(
+            StatusCode::INTERNAL_SERVER_ERROR,
+            "UNKNOWN",
+            &message,
+            Some(location),
+        ),
+    }
+}
+
 async fn initiate_upload_inner(state: &OciRegistryState, name: &str) -> Response {
     if !valid_repository_name(name) {
         return oci_error(
@@ -478,11 +980,15 @@ async fn initiate_upload_inner(state: &OciRegistryState, name: &str) -> Response
     if let Err(error) = metadata_snapshot(state).await {
         return metadata_authority_error(&error);
     }
-
-    let upload_id = new_upload_id(name);
-    let mut uploads = state.uploads.write().await;
-    prune_expired_uploads(&mut uploads);
-    if uploads.len() >= MAX_ACTIVE_UPLOADS {
+    let _transaction = match begin_upload_write(state).await {
+        Ok(transaction) => transaction,
+        Err(error) => return metadata_authority_error(&error),
+    };
+    let (active_count, active_bytes) = match prune_and_measure_uploads(state) {
+        Ok(measured) => measured,
+        Err(error) => return metadata_authority_error(&error),
+    };
+    if active_count >= MAX_ACTIVE_UPLOADS || active_bytes >= state.max_active_upload_bytes {
         return oci_error(
             StatusCode::TOO_MANY_REQUESTS,
             "TOOMANYREQUESTS",
@@ -490,20 +996,184 @@ async fn initiate_upload_inner(state: &OciRegistryState, name: &str) -> Response
             None,
         );
     }
-    uploads.insert(
-        upload_id.clone(),
-        PendingUpload {
-            repository: name.to_string(),
-            created_at: Instant::now(),
-            data: Vec::new(),
-        },
-    );
-    drop(uploads);
 
-    let location = upload_location(name, &upload_id);
-    let mut response = StatusCode::ACCEPTED.into_response();
-    insert_header(response.headers_mut(), header::LOCATION, &location);
-    response
+    let now = match now_unix_secs() {
+        Ok(now) => now,
+        Err(error) => return metadata_authority_error(&error),
+    };
+    let upload_id = loop {
+        let candidate = new_upload_id(name);
+        let metadata_exists =
+            upload_metadata_path(state, &candidate).is_some_and(|path| path.exists());
+        let data_exists = upload_data_path(state, &candidate).is_some_and(|path| path.exists());
+        if !metadata_exists && !data_exists {
+            break candidate;
+        }
+    };
+    let data_path = upload_data_path(state, &upload_id).expect("generated upload identifier");
+    if let Err(error) = crate::atomic_file::write(&data_path, &[]) {
+        return metadata_authority_error(&format!("failed to create OCI upload data: {error}"));
+    }
+    let upload = PendingUpload {
+        version: OCI_UPLOAD_METADATA_VERSION,
+        repository: name.to_string(),
+        created_at_unix_secs: now,
+        updated_at_unix_secs: now,
+        size: 0,
+        expected_digest: None,
+    };
+    if let Err(error) = persist_upload_session(state, &upload_id, &upload) {
+        let _ = std::fs::remove_file(data_path);
+        return metadata_authority_error(&error);
+    }
+    upload_progress_response(StatusCode::ACCEPTED, name, &upload_id, 0)
+}
+
+async fn patch_upload_inner(
+    state: &OciRegistryState,
+    name: &str,
+    id: &str,
+    content_range: Option<&str>,
+    declared_length: Option<u64>,
+    body: Body,
+) -> Response {
+    let location = upload_location(name, id);
+    if !valid_repository_name(name) || !valid_upload_id(id) {
+        return oci_error(
+            StatusCode::BAD_REQUEST,
+            "BLOB_UPLOAD_INVALID",
+            "invalid OCI upload coordinate",
+            Some(&location),
+        );
+    }
+    let _transaction = match begin_upload_write(state).await {
+        Ok(transaction) => transaction,
+        Err(error) => return metadata_authority_error(&error),
+    };
+    let (_, active_bytes) = match prune_and_measure_uploads(state) {
+        Ok(measured) => measured,
+        Err(error) => return metadata_authority_error(&error),
+    };
+    let mut upload = match read_upload_session(state, id) {
+        Ok(Some(upload)) if upload.repository == name => upload,
+        Ok(Some(_)) | Ok(None) => {
+            return oci_error(
+                StatusCode::NOT_FOUND,
+                "BLOB_UPLOAD_UNKNOWN",
+                "blob upload is unknown or expired",
+                Some(&location),
+            );
+        }
+        Err(error) => return metadata_authority_error(&error),
+    };
+    if upload.expected_digest.is_some() {
+        return oci_error(
+            StatusCode::CONFLICT,
+            "BLOB_UPLOAD_INVALID",
+            "blob upload is already being finalized",
+            Some(&location),
+        );
+    }
+    let expected_range_length = if let Some(value) = content_range {
+        let Some((start, end)) = parse_content_range(value) else {
+            return oci_error(
+                StatusCode::RANGE_NOT_SATISFIABLE,
+                "BLOB_UPLOAD_INVALID",
+                "Content-Range is invalid",
+                Some(&location),
+            );
+        };
+        let Some(length) = end
+            .checked_sub(start)
+            .and_then(|length| length.checked_add(1))
+        else {
+            return oci_error(
+                StatusCode::RANGE_NOT_SATISFIABLE,
+                "BLOB_UPLOAD_INVALID",
+                "Content-Range is invalid",
+                Some(&location),
+            );
+        };
+        if start != upload.size || declared_length.is_some_and(|declared| declared != length) {
+            return oci_error(
+                StatusCode::RANGE_NOT_SATISFIABLE,
+                "BLOB_UPLOAD_INVALID",
+                "Content-Range does not match the persisted upload offset and body length",
+                Some(&location),
+            );
+        }
+        Some(length)
+    } else {
+        None
+    };
+    let updated_at = match now_unix_secs() {
+        Ok(now) => now,
+        Err(error) => return metadata_authority_error(&error),
+    };
+    let data_path = upload_data_path(state, id).expect("validated upload identifier");
+    let aggregate_remaining = state.max_active_upload_bytes.saturating_sub(active_bytes);
+    let appended = match append_upload_body(
+        &data_path,
+        upload.size,
+        aggregate_remaining,
+        declared_length,
+        body,
+        None,
+    )
+    .await
+    {
+        Ok(appended) => appended,
+        Err(error) => return upload_error(error, &location),
+    };
+    if expected_range_length.is_some_and(|expected| expected != appended) {
+        match tokio::fs::OpenOptions::new()
+            .write(true)
+            .open(&data_path)
+            .await
+        {
+            Ok(mut file) => {
+                if let Err(error) = rollback_staged_file(&mut file, upload.size).await {
+                    return metadata_authority_error(&error);
+                }
+            }
+            Err(error) => {
+                return metadata_authority_error(&format!(
+                    "failed to reopen OCI upload after Content-Range mismatch: {error}"
+                ));
+            }
+        }
+        return oci_error(
+            StatusCode::RANGE_NOT_SATISFIABLE,
+            "BLOB_UPLOAD_INVALID",
+            "Content-Range length does not match the streamed body",
+            Some(&location),
+        );
+    }
+    let previous_size = upload.size;
+    upload.size += appended;
+    upload.updated_at_unix_secs = updated_at;
+    if let Err(error) = persist_upload_session(state, id, &upload) {
+        match tokio::fs::OpenOptions::new()
+            .write(true)
+            .open(&data_path)
+            .await
+        {
+            Ok(mut file) => {
+                if let Err(rollback_error) = rollback_staged_file(&mut file, previous_size).await {
+                    return metadata_authority_error(&format!(
+                        "{error}; additionally {rollback_error}"
+                    ));
+                }
+            }
+            Err(rollback_error) => {
+                return metadata_authority_error(&format!(
+                    "{error}; failed to reopen OCI upload for rollback: {rollback_error}"
+                ));
+            }
+        }
+        return metadata_authority_error(&error);
+    }
+    upload_progress_response(StatusCode::ACCEPTED, name, id, upload.size)
 }
 
 async fn complete_upload_inner(
@@ -511,7 +1181,8 @@ async fn complete_upload_inner(
     name: &str,
     id: &str,
     expected_digest: Option<&str>,
-    body: Bytes,
+    declared_length: Option<u64>,
+    body: Body,
 ) -> Response {
     let location = upload_location(name, id);
     if !valid_repository_name(name) || !valid_upload_id(id) {
@@ -534,98 +1205,188 @@ async fn complete_upload_inner(
             Some(&location),
         );
     }
-    if let Err(error) = metadata_snapshot(state).await {
-        return metadata_authority_error(&error);
-    }
-
-    let mut uploads = state.uploads.write().await;
-    let Some(pending) = uploads.get(id) else {
-        return oci_error(
-            StatusCode::NOT_FOUND,
-            "BLOB_UPLOAD_UNKNOWN",
-            "blob upload is unknown or expired",
-            Some(&location),
-        );
+    let _upload_transaction = match begin_upload_write(state).await {
+        Ok(transaction) => transaction,
+        Err(error) => return metadata_authority_error(&error),
     };
-    if pending.repository != name || pending.created_at.elapsed() >= UPLOAD_TTL {
-        uploads.remove(id);
-        return oci_error(
-            StatusCode::NOT_FOUND,
-            "BLOB_UPLOAD_UNKNOWN",
-            "blob upload is unknown or expired",
-            Some(&location),
-        );
-    }
-    let Some(completed_size) = pending.data.len().checked_add(body.len()) else {
-        return oci_error(
-            StatusCode::PAYLOAD_TOO_LARGE,
-            "BLOB_UPLOAD_INVALID",
-            "blob upload exceeds the configured size limit",
-            Some(&location),
-        );
+    let (_, active_bytes) = match prune_and_measure_uploads(state) {
+        Ok(measured) => measured,
+        Err(error) => return metadata_authority_error(&error),
     };
-    if completed_size > MAX_OCI_BLOB_SIZE {
-        return oci_error(
-            StatusCode::PAYLOAD_TOO_LARGE,
-            "BLOB_UPLOAD_INVALID",
-            "blob upload exceeds the configured size limit",
-            Some(&location),
-        );
-    }
-
-    let mut hasher = Sha256::new();
-    hasher.update(&pending.data);
-    hasher.update(&body);
-    let computed_digest = format!("sha256:{}", hex::encode(hasher.finalize()));
-    if expected_digest != computed_digest {
-        return digest_invalid(
-            "provided digest does not match uploaded content",
-            Some(&location),
-        );
-    }
-
-    let mut pending = uploads
-        .remove(id)
-        .expect("upload remained present while write lock was held");
-    drop(uploads);
-    let partial_len = pending.data.len();
-    pending.data.extend_from_slice(&body);
+    let mut upload = match read_upload_session(state, id) {
+        Ok(Some(upload)) if upload.repository == name => upload,
+        Ok(Some(_)) | Ok(None) => {
+            return oci_error(
+                StatusCode::NOT_FOUND,
+                "BLOB_UPLOAD_UNKNOWN",
+                "blob upload is unknown or expired",
+                Some(&location),
+            );
+        }
+        Err(error) => return metadata_authority_error(&error),
+    };
+    let data_path = upload_data_path(state, id).expect("validated upload identifier");
+    let computed_digest = if let Some(finalizing_digest) = upload.expected_digest.as_deref() {
+        if finalizing_digest != expected_digest {
+            return digest_invalid(
+                "completion digest differs from the durable finalization digest",
+                Some(&location),
+            );
+        }
+        if declared_length.is_some_and(|length| length != 0) {
+            return oci_error(
+                StatusCode::CONFLICT,
+                "BLOB_UPLOAD_INVALID",
+                "a finalizing upload can only be resumed with an empty body",
+                Some(&location),
+            );
+        }
+        let mut stream = body.into_data_stream();
+        if stream.next().await.is_some() {
+            return oci_error(
+                StatusCode::CONFLICT,
+                "BLOB_UPLOAD_INVALID",
+                "a finalizing upload can only be resumed with an empty body",
+                Some(&location),
+            );
+        }
+        finalizing_digest.to_string()
+    } else {
+        let updated_at = match now_unix_secs() {
+            Ok(now) => now,
+            Err(error) => return metadata_authority_error(&error),
+        };
+        let mut hasher = match hash_upload_file(&data_path, upload.size).await {
+            Ok(hasher) => hasher,
+            Err(error) => return metadata_authority_error(&error),
+        };
+        let aggregate_remaining = state.max_active_upload_bytes.saturating_sub(active_bytes);
+        let original_size = upload.size;
+        let appended = match append_upload_body(
+            &data_path,
+            original_size,
+            aggregate_remaining,
+            declared_length,
+            body,
+            Some(&mut hasher),
+        )
+        .await
+        {
+            Ok(appended) => appended,
+            Err(error) => return upload_error(error, &location),
+        };
+        let computed_digest = format!("sha256:{}", hex::encode(hasher.finalize()));
+        if expected_digest != computed_digest {
+            match tokio::fs::OpenOptions::new()
+                .write(true)
+                .open(&data_path)
+                .await
+            {
+                Ok(mut file) => {
+                    if let Err(error) = rollback_staged_file(&mut file, original_size).await {
+                        return metadata_authority_error(&error);
+                    }
+                }
+                Err(error) => {
+                    return metadata_authority_error(&format!(
+                        "failed to reopen OCI upload for digest-mismatch rollback: {error}"
+                    ));
+                }
+            }
+            return digest_invalid(
+                "provided digest does not match uploaded content",
+                Some(&location),
+            );
+        }
+        upload.size += appended;
+        upload.updated_at_unix_secs = updated_at;
+        upload.expected_digest = Some(computed_digest.clone());
+        if let Err(error) = persist_upload_session(state, id, &upload) {
+            match tokio::fs::OpenOptions::new()
+                .write(true)
+                .open(&data_path)
+                .await
+            {
+                Ok(mut file) => {
+                    if let Err(rollback_error) =
+                        rollback_staged_file(&mut file, original_size).await
+                    {
+                        return metadata_authority_error(&format!(
+                            "{error}; additionally {rollback_error}"
+                        ));
+                    }
+                }
+                Err(rollback_error) => {
+                    return metadata_authority_error(&format!(
+                        "{error}; failed to reopen OCI upload for rollback: {rollback_error}"
+                    ));
+                }
+            }
+            return metadata_authority_error(&error);
+        }
+        computed_digest
+    };
 
     let blob_path = blob_path_for_digest(&state.blobs_dir, &computed_digest)
         .expect("computed sha256 digest is canonical");
+    let data_present = std::fs::symlink_metadata(&data_path)
+        .ok()
+        .is_some_and(|metadata| metadata.file_type().is_file());
+    let blob_metadata = match std::fs::symlink_metadata(&blob_path) {
+        Ok(metadata) if metadata.file_type().is_file() => Some(metadata),
+        Ok(_) => {
+            return metadata_authority_error(
+                "an OCI blob digest path exists but is not a regular file",
+            );
+        }
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => None,
+        Err(error) => {
+            return metadata_authority_error(&format!(
+                "failed to inspect OCI blob digest path: {error}"
+            ));
+        }
+    };
+    if data_present {
+        if blob_metadata.is_some() {
+            let existing = match hash_upload_file(&blob_path, upload.size).await {
+                Ok(hasher) => format!("sha256:{}", hex::encode(hasher.finalize())),
+                Err(error) => return metadata_authority_error(&error),
+            };
+            if existing != computed_digest {
+                return metadata_authority_error(
+                    "an OCI blob digest path already contains different content",
+                );
+            }
+        } else if let Err(error) = publish_staged_upload(&data_path, &blob_path) {
+            return oci_error(
+                StatusCode::INTERNAL_SERVER_ERROR,
+                "UNKNOWN",
+                &format!("failed to atomically publish OCI blob: {error}"),
+                Some(&location),
+            );
+        }
+    } else {
+        if blob_metadata.is_none() {
+            return metadata_authority_error(
+                "durable OCI upload data disappeared before publication",
+            );
+        }
+        let existing = match hash_upload_file(&blob_path, upload.size).await {
+            Ok(hasher) => format!("sha256:{}", hex::encode(hasher.finalize())),
+            Err(error) => return metadata_authority_error(&error),
+        };
+        if existing != computed_digest {
+            return metadata_authority_error(
+                "the durable finalizing OCI blob does not match its expected digest",
+            );
+        }
+    }
+
     let (mut metadata_guard, storage_lock, mut replacement) =
         match begin_metadata_write(state).await {
             Ok(transaction) => transaction,
-            Err(error) => {
-                pending.data.truncate(partial_len);
-                state.uploads.write().await.insert(id.to_string(), pending);
-                return metadata_authority_error(&error);
-            }
+            Err(error) => return metadata_authority_error(&error),
         };
-    // Stage beside the digest path, fsync the complete bytes, and atomically
-    // rename them into place. Public GET/HEAD requests therefore see either no
-    // blob (or the prior complete blob) or the complete replacement, never a
-    // partially written digest object.
-    let write_result = crate::atomic_file::write(&blob_path, &pending.data);
-    if let Err(error) = write_result {
-        // Preserve the pre-completion upload state so the same final request
-        // can be retried after the storage failure without duplicating bytes.
-        drop(storage_lock);
-        drop(metadata_guard);
-        pending.data.truncate(partial_len);
-        state.uploads.write().await.insert(id.to_string(), pending);
-        return oci_error(
-            StatusCode::INTERNAL_SERVER_ERROR,
-            "UNKNOWN",
-            &format!("failed to persist OCI blob: {error}"),
-            Some(&location),
-        );
-    }
-
-    // The content-addressed object is global, but public availability is scoped
-    // to the repository that completed the upload. Persist membership before
-    // acknowledging the write; an orphaned content file after a crash is safe
-    // because reads consult this durable authority first.
     replacement
         .repositories
         .entry(name.to_string())
@@ -633,10 +1394,6 @@ async fn complete_upload_inner(
         .blobs
         .insert(computed_digest.clone());
     if let Err(error) = persist_metadata(state, &replacement) {
-        drop(storage_lock);
-        drop(metadata_guard);
-        pending.data.truncate(partial_len);
-        state.uploads.write().await.insert(id.to_string(), pending);
         return oci_error(
             StatusCode::INTERNAL_SERVER_ERROR,
             "UNKNOWN",
@@ -647,6 +1404,9 @@ async fn complete_upload_inner(
     *metadata_guard = replacement;
     drop(storage_lock);
     drop(metadata_guard);
+    if let Err(error) = remove_upload_session(state, id) {
+        tracing::warn!(upload_id = id, error = %error, "published OCI blob but could not remove completed upload state");
+    }
 
     let blob_location = format!("/v2/{name}/blobs/{computed_digest}");
     let mut response = StatusCode::CREATED.into_response();
@@ -725,6 +1485,119 @@ async fn get_manifest_inner(
     response
 }
 
+fn supported_manifest_media_type(value: &str) -> Option<&str> {
+    let media_type = value.split(';').next()?.trim();
+    matches!(
+        media_type,
+        DEFAULT_MANIFEST_MEDIA_TYPE | DOCKER_MANIFEST_MEDIA_TYPE
+    )
+    .then_some(media_type)
+}
+
+fn parse_image_manifest(
+    media_type: &str,
+    body: &[u8],
+) -> Result<ImageManifest, ManifestValidationError> {
+    let Some(request_media_type) = supported_manifest_media_type(media_type) else {
+        return Err(ManifestValidationError {
+            status: StatusCode::BAD_REQUEST,
+            code: "MANIFEST_INVALID",
+            message: "unsupported OCI manifest Content-Type".to_string(),
+        });
+    };
+    let manifest =
+        serde_json::from_slice::<ImageManifest>(body).map_err(|error| ManifestValidationError {
+            status: StatusCode::BAD_REQUEST,
+            code: "MANIFEST_INVALID",
+            message: format!("manifest is not a supported OCI/Docker image manifest: {error}"),
+        })?;
+    if manifest.schema_version != 2
+        || manifest.layers.len() > MAX_MANIFEST_LAYERS
+        || manifest
+            .media_type
+            .as_deref()
+            .is_some_and(|body_media_type| body_media_type != request_media_type)
+    {
+        return Err(ManifestValidationError {
+            status: StatusCode::BAD_REQUEST,
+            code: "MANIFEST_INVALID",
+            message: "manifest schema, media type, or layer count is unsupported".to_string(),
+        });
+    }
+    for descriptor in std::iter::once(&manifest.config).chain(manifest.layers.iter()) {
+        if descriptor.media_type.is_empty()
+            || descriptor.media_type.len() > 255
+            || !descriptor
+                .media_type
+                .bytes()
+                .all(|byte| byte.is_ascii_graphic())
+            || sha256_hex(&descriptor.digest).is_none()
+            || descriptor.size > MAX_OCI_BLOB_SIZE as u64
+        {
+            return Err(ManifestValidationError {
+                status: StatusCode::BAD_REQUEST,
+                code: "MANIFEST_INVALID",
+                message: "manifest contains an invalid config or layer descriptor".to_string(),
+            });
+        }
+    }
+    Ok(manifest)
+}
+
+async fn validate_manifest_blobs(
+    state: &OciRegistryState,
+    metadata: &OciMetadata,
+    repository_name: &str,
+    manifest: &ImageManifest,
+) -> Result<(), ManifestValidationError> {
+    let repository = metadata.repositories.get(repository_name);
+    let mut verified = BTreeSet::new();
+    for descriptor in std::iter::once(&manifest.config).chain(manifest.layers.iter()) {
+        let is_member =
+            repository.is_some_and(|repository| repository.blobs.contains(&descriptor.digest));
+        let Some(blob_path) = blob_path_for_digest(&state.blobs_dir, &descriptor.digest) else {
+            return Err(ManifestValidationError {
+                status: StatusCode::BAD_REQUEST,
+                code: "MANIFEST_INVALID",
+                message: "manifest contains an invalid blob digest".to_string(),
+            });
+        };
+        let file_is_exact = std::fs::symlink_metadata(&blob_path)
+            .ok()
+            .is_some_and(|metadata| {
+                metadata.file_type().is_file() && metadata.len() == descriptor.size
+            });
+        if !is_member || !file_is_exact {
+            return Err(ManifestValidationError {
+                status: StatusCode::NOT_FOUND,
+                code: "MANIFEST_BLOB_UNKNOWN",
+                message: format!("manifest references unavailable blob {}", descriptor.digest),
+            });
+        }
+        if verified.insert(descriptor.digest.clone()) {
+            let observed = hash_upload_file(&blob_path, descriptor.size)
+                .await
+                .map_err(|error| ManifestValidationError {
+                    status: StatusCode::INTERNAL_SERVER_ERROR,
+                    code: "UNKNOWN",
+                    message: error,
+                })?;
+            let observed = format!("sha256:{}", hex::encode(observed.finalize()));
+            if observed != descriptor.digest {
+                return Err(ManifestValidationError {
+                    status: StatusCode::NOT_FOUND,
+                    code: "MANIFEST_BLOB_UNKNOWN",
+                    message: format!(
+                        "manifest references blob {} whose content is not trustworthy",
+                        descriptor.digest
+                    ),
+                });
+            }
+        }
+    }
+    Ok(())
+}
+
 /// PUT /v2/{name}/manifests/{reference} -- push a manifest.
 async fn put_manifest_inner(
     state: &OciRegistryState,
@@ -753,19 +1626,12 @@ async fn put_manifest_inner(
             None,
         );
     }
-    if media_type.is_empty()
-        || media_type.len() > 255
-        || !media_type
-            .bytes()
-            .all(|byte| byte.is_ascii_graphic() || byte == b' ')
-    {
-        return oci_error(
-            StatusCode::BAD_REQUEST,
-            "MANIFEST_INVALID",
-            "manifest Content-Type is invalid",
-            None,
-        );
-    }
+    let manifest = match parse_image_manifest(media_type, &body) {
+        Ok(manifest) => manifest,
+        Err(error) => return error.response(),
+    };
+    let canonical_media_type = supported_manifest_media_type(media_type)
+        .expect("manifest parsing already validated the media type");
 
     let digest = format!("sha256:{}", sha2_hex(&body));
     if reference.starts_with("sha256:") && reference != digest {
@@ -781,6 +1647,9 @@ async fn put_manifest_inner(
             Ok(transaction) => transaction,
             Err(error) => return metadata_authority_error(&error),
         };
+    if let Err(error) = validate_manifest_blobs(state, &replacement, name, &manifest).await {
+        return error.response();
+    }
     if let Err(error) = crate::atomic_file::write(&manifest_path, &body) {
         return oci_error(
             StatusCode::INTERNAL_SERVER_ERROR,
@@ -791,7 +1660,7 @@ async fn put_manifest_inner(
     }
     let descriptor = ManifestDescriptor {
         digest: digest.clone(),
-        media_type: media_type.to_string(),
+        media_type: canonical_media_type.to_string(),
     };
     let repository = replacement
         .repositories
@@ -874,10 +1743,6 @@ fn upload_location(name: &str, id: &str) -> String {
 
 fn valid_upload_id(id: &str) -> bool {
     id.len() == UPLOAD_ID_HEX_LEN && id.bytes().all(is_lower_hex)
-}
-
-fn prune_expired_uploads(uploads: &mut HashMap<String, PendingUpload>) {
-    uploads.retain(|_, pending| pending.created_at.elapsed() < UPLOAD_TTL);
 }
 
 fn valid_repository_name(name: &str) -> bool {
@@ -1051,6 +1916,64 @@ mod tests {
         .await;
         assert_eq!(response.status(), StatusCode::CREATED);
         format!("sha256:{}", sha2_hex(bytes))
+    }
+
+    fn image_manifest_body(
+        media_type: &str,
+        config_digest: &str,
+        config_size: usize,
+        layer_digest: &str,
+        layer_size: usize,
+        marker: &str,
+    ) -> Vec<u8> {
+        serde_json::to_vec(&serde_json::json!({
+            "schemaVersion": 2,
+            "mediaType": media_type,
+            "config": {
+                "mediaType": "application/vnd.oci.image.config.v1+json",
+                "digest": config_digest,
+                "size": config_size,
+            },
+            "layers": [{
+                "mediaType": "application/vnd.oci.image.layer.v1.tar+gzip",
+                "digest": layer_digest,
+                "size": layer_size,
+            }],
+            "annotations": { "dev.kin.test-marker": marker },
+        }))
+        .unwrap()
+    }
+
+    async fn seed_valid_manifest(
+        state: &OciRegistryState,
+        repository: &str,
+        reference: &str,
+        media_type: &str,
+        marker: &str,
+    ) -> (String, Vec<u8>) {
+        let config = format!("config-{marker}").into_bytes();
+        let layer = format!("layer-{marker}").into_bytes();
+        let config_digest = seed_blob(state, repository, &config).await;
+        let layer_digest = seed_blob(state, repository, &layer).await;
+        let body = image_manifest_body(
+            media_type,
+            &config_digest,
+            config.len(),
+            &layer_digest,
+            layer.len(),
+            marker,
+        );
+        let digest = seed_manifest(state, repository, reference, media_type, &body).await;
+        (digest, body)
+    }
+
+    async fn durable_upload_count(state: &OciRegistryState) -> usize {
+        let _transaction = begin_upload_write(state).await.unwrap();
+        prune_and_measure_uploads(state).unwrap().0
+    }
+
+    fn upload_id_from_location(location: &str) -> &str {
+        location.rsplit('/').next().unwrap()
     }
 
     #[test]
@@ -1253,14 +2176,13 @@ mod tests {
 
     #[tokio::test]
     async fn shared_manifest_url_keeps_get_public_but_rejects_unauthenticated_mutations() {
-        let original = br#"{"schemaVersion":2,"marker":"original"}"#.to_vec();
         let (_root, state) = registry_state_with_token(Some("registry-secret"));
-        let digest = seed_manifest(
+        let (digest, original) = seed_valid_manifest(
             &state,
             "demo",
             "latest",
             DEFAULT_MANIFEST_MEDIA_TYPE,
-            &original,
+            "original",
         )
         .await;
 
@@ -1301,12 +2223,12 @@ mod tests {
         }
 
         let (_root, disabled) = registry_state_with_token(None);
-        let disabled_digest = seed_manifest(
+        let (disabled_digest, _disabled_body) = seed_valid_manifest(
             &disabled,
             "demo",
             "latest",
             DEFAULT_MANIFEST_MEDIA_TYPE,
-            &original,
+            "disabled-original",
         )
         .await;
         for request in [
@@ -1354,7 +2276,7 @@ mod tests {
             assert_eq!(response.status(), StatusCode::BAD_REQUEST);
             assert_eq!(response.headers()[header::LOCATION], location.as_str());
             assert_eq!(error_code(response).await, "DIGEST_INVALID");
-            assert_eq!(state.uploads.read().await.len(), 1);
+            assert_eq!(durable_upload_count(&state).await, 1);
         }
 
         let success = oci_routes(state.clone())
@@ -1367,7 +2289,7 @@ mod tests {
             .unwrap();
         assert_eq!(success.status(), StatusCode::CREATED);
         assert_eq!(success.headers()["docker-content-digest"], digest.as_str());
-        assert!(state.uploads.read().await.is_empty());
+        assert_eq!(durable_upload_count(&state).await, 0);
         let blob_path = blob_path_for_digest(&state.blobs_dir, &digest).unwrap();
         assert_eq!(std::fs::read(blob_path).unwrap(), body);
     }
@@ -1392,9 +2314,10 @@ mod tests {
             .await
             .unwrap();
         assert_eq!(failed.status(), StatusCode::INTERNAL_SERVER_ERROR);
-        assert_eq!(state.uploads.read().await.len(), 1);
+        assert_eq!(durable_upload_count(&state).await, 1);
         assert!(blob_path.is_dir());
-        assert_eq!(std::fs::read_dir(&state.blobs_dir).unwrap().count(), 2);
+        let id = upload_id_from_location(&location);
+        assert!(upload_data_path(&state, id).unwrap().is_file());
 
         // The retained upload can be retried after the storage fault clears.
         std::fs::remove_dir(&blob_path).unwrap();
@@ -1402,14 +2325,13 @@ mod tests {
             .oneshot(authenticated_request(
                 "PUT",
                 &format!("{location}?digest={digest}"),
-                Body::from(body.as_slice()),
+                Body::empty(),
             ))
             .await
             .unwrap();
         assert_eq!(retried.status(), StatusCode::CREATED);
-        assert!(state.uploads.read().await.is_empty());
+        assert_eq!(durable_upload_count(&state).await, 0);
         assert_eq!(std::fs::read(&blob_path).unwrap(), body);
-        assert_eq!(std::fs::read_dir(&state.blobs_dir).unwrap().count(), 3);
     }
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
@@ -1483,33 +2405,45 @@ mod tests {
         reader.await.unwrap();
         let blob_path = blob_path_for_digest(&state.blobs_dir, &digest).unwrap();
         assert_eq!(std::fs::read(blob_path).unwrap(), body);
-        assert_eq!(std::fs::read_dir(&state.blobs_dir).unwrap().count(), 3);
     }
 
     #[tokio::test]
     async fn manifest_digest_reference_must_equal_the_uploaded_body_digest() {
         let (_root, state) = registry_state_with_token(Some("registry-secret"));
-        let body = br#"{"schemaVersion":2}"#;
-        let computed = format!("sha256:{}", sha2_hex(body));
+        let config = b"digest-test-config";
+        let layer = b"digest-test-layer";
+        let config_digest = seed_blob(&state, "demo", config).await;
+        let layer_digest = seed_blob(&state, "demo", layer).await;
+        let body = image_manifest_body(
+            DEFAULT_MANIFEST_MEDIA_TYPE,
+            &config_digest,
+            config.len(),
+            &layer_digest,
+            layer.len(),
+            "digest-reference",
+        );
+        let computed = format!("sha256:{}", sha2_hex(&body));
         let mismatched = format!("sha256:{}", "0".repeat(SHA256_HEX_LEN));
 
         let rejected = oci_routes(state.clone())
             .oneshot(authenticated_request(
                 "PUT",
                 &format!("/v2/demo/manifests/{mismatched}"),
-                Body::from(body.as_slice()),
+                Body::from(body.clone()),
             ))
             .await
             .unwrap();
         assert_eq!(rejected.status(), StatusCode::BAD_REQUEST);
         assert_eq!(error_code(rejected).await, "DIGEST_INVALID");
-        assert!(state.metadata.read().await.repositories.is_empty());
+        assert!(state.metadata.read().await.repositories["demo"]
+            .manifests
+            .is_empty());
 
         let accepted = oci_routes(state.clone())
             .oneshot(authenticated_request(
                 "PUT",
                 &format!("/v2/demo/manifests/{computed}"),
-                Body::from(body.as_slice()),
+                Body::from(body.clone()),
             ))
             .await
             .unwrap();
@@ -1528,9 +2462,20 @@ mod tests {
     async fn manifest_metadata_survives_restart_and_digest_delete_revokes_every_reference() {
         let (root, state) = registry_state_with_token(Some("registry-secret"));
         let repository = "firelock-ai/kin";
-        let body = br#"{"schemaVersion":2,"mediaType":"application/vnd.docker.distribution.manifest.v2+json"}"#;
-        let digest = format!("sha256:{}", sha2_hex(body));
         let media_type = "application/vnd.docker.distribution.manifest.v2+json";
+        let config = b"docker-config";
+        let layer = b"docker-layer";
+        let config_digest = seed_blob(&state, repository, config).await;
+        let layer_digest = seed_blob(&state, repository, layer).await;
+        let body = image_manifest_body(
+            media_type,
+            &config_digest,
+            config.len(),
+            &layer_digest,
+            layer.len(),
+            "restart",
+        );
+        let digest = format!("sha256:{}", sha2_hex(&body));
 
         for tag in ["latest", "stable"] {
             let response = oci_routes(state.clone())
@@ -1538,7 +2483,7 @@ mod tests {
                     Request::put(format!("/v2/{repository}/manifests/{tag}"))
                         .header(header::AUTHORIZATION, "Bearer registry-secret")
                         .header(header::CONTENT_TYPE, media_type)
-                        .body(Body::from(body.as_slice()))
+                        .body(Body::from(body.clone()))
                         .unwrap(),
                 )
                 .await
@@ -1627,12 +2572,36 @@ mod tests {
             blobs_dir,
             Some("registry-secret".to_string()),
         ));
+        let first_config = b"first-config";
+        let first_layer = b"first-layer";
+        let first_config_digest = seed_blob(&first, "team/first", first_config).await;
+        let first_layer_digest = seed_blob(&first, "team/first", first_layer).await;
+        let first_body = image_manifest_body(
+            DEFAULT_MANIFEST_MEDIA_TYPE,
+            &first_config_digest,
+            first_config.len(),
+            &first_layer_digest,
+            first_layer.len(),
+            "first",
+        );
+        let second_config = b"second-config";
+        let second_layer = b"second-layer";
+        let second_config_digest = seed_blob(&second, "team/second", second_config).await;
+        let second_layer_digest = seed_blob(&second, "team/second", second_layer).await;
+        let second_body = image_manifest_body(
+            DEFAULT_MANIFEST_MEDIA_TYPE,
+            &second_config_digest,
+            second_config.len(),
+            &second_layer_digest,
+            second_layer.len(),
+            "second",
+        );
         let start = Arc::new(tokio::sync::Barrier::new(3));
 
         let publish = |state: Arc<OciRegistryState>,
                        repository: &'static str,
                        tag: &'static str,
-                       marker: &'static str,
+                       body: Vec<u8>,
                        start: Arc<tokio::sync::Barrier>| {
             tokio::spawn(async move {
                 start.wait().await;
@@ -1641,7 +2610,7 @@ mod tests {
                     repository,
                     tag,
                     DEFAULT_MANIFEST_MEDIA_TYPE,
-                    Bytes::from(format!(r#"{{"schemaVersion":2,"marker":"{marker}"}}"#)),
+                    Bytes::from(body),
                 )
                 .await
                 .status()
@@ -1651,14 +2620,14 @@ mod tests {
             first.clone(),
             "team/first",
             "stable",
-            "first",
+            first_body,
             start.clone(),
         );
         let right = publish(
             second.clone(),
             "team/second",
             "latest",
-            "second",
+            second_body,
             start.clone(),
         );
         start.wait().await;
@@ -1721,17 +2690,283 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn authenticated_patch_upload_survives_restart_and_final_put() {
+        let (root, state) = registry_state_with_token(Some("registry-secret"));
+        let location = initiate(state.clone()).await;
+
+        let unauthorized = oci_routes(state.clone())
+            .oneshot(
+                Request::patch(&location)
+                    .body(Body::from("ignored"))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(unauthorized.status(), StatusCode::UNAUTHORIZED);
+
+        let chunks = futures_util::stream::iter([
+            Ok::<Bytes, std::io::Error>(Bytes::from_static(b"he")),
+            Ok::<Bytes, std::io::Error>(Bytes::from_static(b"llo")),
+        ]);
+        let first = oci_routes(state.clone())
+            .oneshot(
+                Request::patch(&location)
+                    .header(header::AUTHORIZATION, "Bearer registry-secret")
+                    .header(header::CONTENT_RANGE, "bytes 0-4")
+                    .body(Body::from_stream(chunks))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(first.status(), StatusCode::ACCEPTED);
+        assert_eq!(first.headers()[header::RANGE], "0-4");
+        assert_eq!(durable_upload_count(&state).await, 1);
+
+        let restarted = Arc::new(OciRegistryState::new(
+            root.path().join("oci"),
+            Some("registry-secret".to_string()),
+        ));
+        let mismatched_range = oci_routes(restarted.clone())
+            .oneshot(
+                Request::patch(&location)
+                    .header(header::AUTHORIZATION, "Bearer registry-secret")
+                    .header(header::CONTENT_RANGE, "5-20")
+                    .body(Body::from(" world"))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(mismatched_range.status(), StatusCode::RANGE_NOT_SATISFIABLE);
+        let second = oci_routes(restarted.clone())
+            .oneshot(
+                Request::patch(&location)
+                    .header(header::AUTHORIZATION, "Bearer registry-secret")
+                    .header(header::CONTENT_RANGE, "5-10")
+                    .body(Body::from(" world"))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(second.status(), StatusCode::ACCEPTED);
+        assert_eq!(second.headers()[header::RANGE], "0-10");
+
+        let complete_body = b"hello world";
+        let digest = format!("sha256:{}", sha2_hex(complete_body));
+        let completed = oci_routes(restarted.clone())
+            .oneshot(authenticated_request(
+                "PUT",
+                &format!("{location}?digest={digest}"),
+                Body::empty(),
+            ))
+            .await
+            .unwrap();
+        assert_eq!(completed.status(), StatusCode::CREATED);
+        assert_eq!(completed.headers()["docker-content-digest"], digest);
+        assert_eq!(durable_upload_count(&restarted).await, 0);
+        assert_eq!(
+            std::fs::read(blob_path_for_digest(&restarted.blobs_dir, &digest).unwrap()).unwrap(),
+            complete_body
+        );
+    }
+
+    #[tokio::test]
+    async fn restart_discards_uncommitted_stream_bytes_at_the_durable_offset() {
+        let (root, state) = registry_state_with_token(Some("registry-secret"));
+        let location = initiate(state).await;
+        let id = upload_id_from_location(&location);
+        std::fs::write(
+            root.path().join(format!("oci/uploads/{id}.data")),
+            b"interrupted-request-bytes",
+        )
+        .unwrap();
+
+        let restarted = Arc::new(OciRegistryState::new(
+            root.path().join("oci"),
+            Some("registry-secret".to_string()),
+        ));
+        let patched = oci_routes(restarted.clone())
+            .oneshot(
+                Request::patch(&location)
+                    .header(header::AUTHORIZATION, "Bearer registry-secret")
+                    .header(header::CONTENT_RANGE, "0-4")
+                    .body(Body::from("fresh"))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(patched.status(), StatusCode::ACCEPTED);
+        assert_eq!(patched.headers()[header::RANGE], "0-4");
+        assert_eq!(
+            std::fs::read(upload_data_path(&restarted, id).unwrap()).unwrap(),
+            b"fresh"
+        );
+    }
+
+    #[tokio::test]
+    async fn durable_uploads_share_a_cross_process_aggregate_byte_cap() {
+        let root = tempfile::tempdir().unwrap();
+        let blobs_dir = root.path().join("oci");
+        std::fs::create_dir_all(&blobs_dir).unwrap();
+        let mut state = OciRegistryState::new(blobs_dir, Some("registry-secret".to_string()));
+        state.max_active_upload_bytes = 512;
+        let state = Arc::new(state);
+        {
+            let _transaction = begin_upload_write(&state).await.unwrap();
+            let now = now_unix_secs().unwrap();
+            for sequence in 1u128..=4 {
+                let id = format!("{sequence:032x}");
+                let data_path = upload_data_path(&state, &id).unwrap();
+                let file = std::fs::File::create(data_path).unwrap();
+                file.set_len(128).unwrap();
+                persist_upload_session(
+                    &state,
+                    &id,
+                    &PendingUpload {
+                        version: OCI_UPLOAD_METADATA_VERSION,
+                        repository: "demo".to_string(),
+                        created_at_unix_secs: now,
+                        updated_at_unix_secs: now,
+                        size: 128,
+                        expected_digest: None,
+                    },
+                )
+                .unwrap();
+            }
+            assert_eq!(
+                prune_and_measure_uploads(&state).unwrap(),
+                (4, state.max_active_upload_bytes)
+            );
+        }
+
+        let rejected = oci_routes(state)
+            .oneshot(authenticated_request(
+                "POST",
+                "/v2/demo/blobs/uploads/",
+                Body::empty(),
+            ))
+            .await
+            .unwrap();
+        assert_eq!(rejected.status(), StatusCode::TOO_MANY_REQUESTS);
+        assert_eq!(error_code(rejected).await, "TOOMANYREQUESTS");
+    }
+
+    #[tokio::test]
+    async fn manifest_publication_requires_supported_json_and_all_referenced_blobs() {
+        let (_root, state) = registry_state_with_token(Some("registry-secret"));
+        let config = b"manifest-config";
+        let layer = b"manifest-layer";
+        let config_digest = format!("sha256:{}", sha2_hex(config));
+        let layer_digest = format!("sha256:{}", sha2_hex(layer));
+        let body = image_manifest_body(
+            DEFAULT_MANIFEST_MEDIA_TYPE,
+            &config_digest,
+            config.len(),
+            &layer_digest,
+            layer.len(),
+            "validation",
+        );
+
+        let malformed = oci_routes(state.clone())
+            .oneshot(authenticated_request(
+                "PUT",
+                "/v2/demo/manifests/malformed",
+                Body::from("not-json"),
+            ))
+            .await
+            .unwrap();
+        assert_eq!(malformed.status(), StatusCode::BAD_REQUEST);
+        assert_eq!(error_code(malformed).await, "MANIFEST_INVALID");
+
+        let unsupported = oci_routes(state.clone())
+            .oneshot(
+                Request::put("/v2/demo/manifests/index")
+                    .header(header::AUTHORIZATION, "Bearer registry-secret")
+                    .header(
+                        header::CONTENT_TYPE,
+                        "application/vnd.oci.image.index.v1+json",
+                    )
+                    .body(Body::from(body.clone()))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(unsupported.status(), StatusCode::BAD_REQUEST);
+        assert_eq!(error_code(unsupported).await, "MANIFEST_INVALID");
+
+        let missing = oci_routes(state.clone())
+            .oneshot(authenticated_request(
+                "PUT",
+                "/v2/demo/manifests/latest",
+                Body::from(body.clone()),
+            ))
+            .await
+            .unwrap();
+        assert_eq!(missing.status(), StatusCode::NOT_FOUND);
+        assert_eq!(error_code(missing).await, "MANIFEST_BLOB_UNKNOWN");
+
+        assert_eq!(seed_blob(&state, "demo", config).await, config_digest);
+        let missing_layer = oci_routes(state.clone())
+            .oneshot(authenticated_request(
+                "PUT",
+                "/v2/demo/manifests/latest",
+                Body::from(body.clone()),
+            ))
+            .await
+            .unwrap();
+        assert_eq!(missing_layer.status(), StatusCode::NOT_FOUND);
+        assert_eq!(error_code(missing_layer).await, "MANIFEST_BLOB_UNKNOWN");
+
+        assert_eq!(seed_blob(&state, "demo", layer).await, layer_digest);
+        let layer_path = blob_path_for_digest(&state.blobs_dir, &layer_digest).unwrap();
+        std::fs::write(&layer_path, vec![b'x'; layer.len()]).unwrap();
+        let corrupt_layer = oci_routes(state.clone())
+            .oneshot(authenticated_request(
+                "PUT",
+                "/v2/demo/manifests/latest",
+                Body::from(body.clone()),
+            ))
+            .await
+            .unwrap();
+        assert_eq!(corrupt_layer.status(), StatusCode::NOT_FOUND);
+        assert_eq!(error_code(corrupt_layer).await, "MANIFEST_BLOB_UNKNOWN");
+
+        assert_eq!(seed_blob(&state, "demo", layer).await, layer_digest);
+        let accepted = oci_routes(state.clone())
+            .oneshot(authenticated_request(
+                "PUT",
+                "/v2/demo/manifests/latest",
+                Body::from(body),
+            ))
+            .await
+            .unwrap();
+        assert_eq!(accepted.status(), StatusCode::CREATED);
+        assert!(state.metadata.read().await.repositories["demo"]
+            .manifests
+            .contains_key("latest"));
+    }
+
+    #[tokio::test]
     async fn expired_upload_is_removed_and_cannot_be_completed() {
         let (_root, state) = registry_state_with_token(Some("registry-secret"));
         let id = "a".repeat(UPLOAD_ID_HEX_LEN);
-        state.uploads.write().await.insert(
-            id.clone(),
-            PendingUpload {
-                repository: "demo".to_string(),
-                created_at: Instant::now() - UPLOAD_TTL - Duration::from_secs(1),
-                data: Vec::new(),
-            },
-        );
+        {
+            let _transaction = begin_upload_write(&state).await.unwrap();
+            let expired_at = now_unix_secs().unwrap() - UPLOAD_TTL.as_secs() - 1;
+            crate::atomic_file::write(&upload_data_path(&state, &id).unwrap(), &[]).unwrap();
+            persist_upload_session(
+                &state,
+                &id,
+                &PendingUpload {
+                    version: OCI_UPLOAD_METADATA_VERSION,
+                    repository: "demo".to_string(),
+                    created_at_unix_secs: expired_at,
+                    updated_at_unix_secs: expired_at,
+                    size: 0,
+                    expected_digest: None,
+                },
+            )
+            .unwrap();
+        }
         let body = b"expired";
         let digest = format!("sha256:{}", sha2_hex(body));
         let location = upload_location("demo", &id);
@@ -1745,7 +2980,9 @@ mod tests {
             .unwrap();
         assert_eq!(response.status(), StatusCode::NOT_FOUND);
         assert_eq!(error_code(response).await, "BLOB_UPLOAD_UNKNOWN");
-        assert!(state.uploads.read().await.is_empty());
+        assert_eq!(durable_upload_count(&state).await, 0);
+        assert!(!upload_metadata_path(&state, &id).unwrap().exists());
+        assert!(!upload_data_path(&state, &id).unwrap().exists());
     }
 
     #[tokio::test]

--- a/crates/kin-registry/src/oci.rs
+++ b/crates/kin-registry/src/oci.rs
@@ -399,8 +399,11 @@ async fn complete_upload(
 
     let blob_path = blob_path_for_digest(&state.blobs_dir, &computed_digest)
         .expect("computed sha256 digest is canonical");
-    let write_result = std::fs::create_dir_all(&state.blobs_dir)
-        .and_then(|()| std::fs::write(&blob_path, &pending.data));
+    // Stage beside the digest path, fsync the complete bytes, and atomically
+    // rename them into place. Public GET/HEAD requests therefore see either no
+    // blob (or the prior complete blob) or the complete replacement, never a
+    // partially written digest object.
+    let write_result = crate::atomic_file::write(&blob_path, &pending.data);
     if let Err(error) = write_result {
         // Preserve the pre-completion upload state so the same final request
         // can be retried after the storage failure without duplicating bytes.
@@ -481,6 +484,12 @@ async fn put_manifest(
     }
 
     let digest = format!("sha256:{}", sha2_hex(&body));
+    if reference.starts_with("sha256:") && reference != digest {
+        return digest_invalid(
+            "manifest digest reference does not match uploaded content",
+            None,
+        );
+    }
     let mut manifests = state.manifests.write().await;
     manifests.insert((name.clone(), reference), body.to_vec());
     manifests.insert((name.clone(), digest.clone()), body.to_vec());
@@ -790,6 +799,82 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn shared_manifest_url_keeps_get_public_but_rejects_unauthenticated_mutations() {
+        let original = br#"{"schemaVersion":2,"marker":"original"}"#.to_vec();
+        let coordinate = ("demo".to_string(), "latest".to_string());
+
+        let (_root, state) = registry_state_with_token(Some("registry-secret"));
+        state
+            .manifests
+            .write()
+            .await
+            .insert(coordinate.clone(), original.clone());
+
+        let public_get = oci_routes(state.clone())
+            .oneshot(
+                Request::get("/v2/demo/manifests/latest")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(public_get.status(), StatusCode::OK);
+        assert_eq!(
+            to_bytes(public_get.into_body(), MAX_OCI_MANIFEST_SIZE)
+                .await
+                .unwrap()
+                .as_ref(),
+            original.as_slice()
+        );
+
+        for request in [
+            Request::put("/v2/demo/manifests/latest")
+                .body(Body::from(
+                    br#"{"schemaVersion":2,"marker":"forged"}"#.as_slice(),
+                ))
+                .unwrap(),
+            Request::delete("/v2/demo/manifests/latest")
+                .body(Body::empty())
+                .unwrap(),
+        ] {
+            let rejected = oci_routes(state.clone()).oneshot(request).await.unwrap();
+            assert_eq!(rejected.status(), StatusCode::UNAUTHORIZED);
+            assert_eq!(error_code(rejected).await, "UNAUTHORIZED");
+            assert_eq!(
+                state.manifests.read().await.get(&coordinate),
+                Some(&original)
+            );
+        }
+
+        let (_root, disabled) = registry_state_with_token(None);
+        disabled
+            .manifests
+            .write()
+            .await
+            .insert(coordinate.clone(), original.clone());
+        for request in [
+            Request::put("/v2/demo/manifests/latest")
+                .header(header::AUTHORIZATION, "Bearer registry-secret")
+                .body(Body::from(
+                    br#"{"schemaVersion":2,"marker":"forged"}"#.as_slice(),
+                ))
+                .unwrap(),
+            Request::delete("/v2/demo/manifests/latest")
+                .header(header::AUTHORIZATION, "Bearer registry-secret")
+                .body(Body::empty())
+                .unwrap(),
+        ] {
+            let rejected = oci_routes(disabled.clone()).oneshot(request).await.unwrap();
+            assert_eq!(rejected.status(), StatusCode::SERVICE_UNAVAILABLE);
+            assert_eq!(error_code(rejected).await, "DENIED");
+            assert_eq!(
+                disabled.manifests.read().await.get(&coordinate),
+                Some(&original)
+            );
+        }
+    }
+
+    #[tokio::test]
     async fn completion_requires_matching_canonical_digest_and_preserves_upload_on_error() {
         let (_root, state) = registry_state_with_token(Some("registry-secret"));
         let location = initiate(state.clone()).await;
@@ -828,6 +913,160 @@ mod tests {
         assert!(state.uploads.read().await.is_empty());
         let blob_path = blob_path_for_digest(&state.blobs_dir, &digest).unwrap();
         assert_eq!(std::fs::read(blob_path).unwrap(), body);
+    }
+
+    #[tokio::test]
+    async fn failed_blob_commit_preserves_upload_and_leaves_no_partial_file() {
+        let (_root, state) = registry_state_with_token(Some("registry-secret"));
+        let location = initiate(state.clone()).await;
+        let body = b"complete bytes that must publish atomically";
+        let digest = format!("sha256:{}", sha2_hex(body));
+        let blob_path = blob_path_for_digest(&state.blobs_dir, &digest).unwrap();
+
+        // A directory at the final digest coordinate forces the atomic rename
+        // to fail after the temporary file has been fully written and synced.
+        std::fs::create_dir(&blob_path).unwrap();
+        let failed = oci_routes(state.clone())
+            .oneshot(authenticated_request(
+                "PUT",
+                &format!("{location}?digest={digest}"),
+                Body::from(body.as_slice()),
+            ))
+            .await
+            .unwrap();
+        assert_eq!(failed.status(), StatusCode::INTERNAL_SERVER_ERROR);
+        assert_eq!(state.uploads.read().await.len(), 1);
+        assert!(blob_path.is_dir());
+        assert_eq!(std::fs::read_dir(&state.blobs_dir).unwrap().count(), 1);
+
+        // The retained upload can be retried after the storage fault clears.
+        std::fs::remove_dir(&blob_path).unwrap();
+        let retried = oci_routes(state.clone())
+            .oneshot(authenticated_request(
+                "PUT",
+                &format!("{location}?digest={digest}"),
+                Body::from(body.as_slice()),
+            ))
+            .await
+            .unwrap();
+        assert_eq!(retried.status(), StatusCode::CREATED);
+        assert!(state.uploads.read().await.is_empty());
+        assert_eq!(std::fs::read(&blob_path).unwrap(), body);
+        assert_eq!(std::fs::read_dir(&state.blobs_dir).unwrap().count(), 1);
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+    async fn concurrent_blob_reads_observe_only_absent_or_complete_bytes() {
+        let (_root, state) = registry_state_with_token(Some("registry-secret"));
+        let location = initiate(state.clone()).await;
+        let body = vec![b'x'; 8 * 1024 * 1024];
+        let digest = format!("sha256:{}", sha2_hex(&body));
+        let start = Arc::new(tokio::sync::Barrier::new(3));
+        let finished = Arc::new(std::sync::atomic::AtomicBool::new(false));
+
+        let writer = {
+            let state = state.clone();
+            let start = start.clone();
+            let body = body.clone();
+            let digest = digest.clone();
+            let finished = finished.clone();
+            tokio::spawn(async move {
+                start.wait().await;
+                let response = oci_routes(state)
+                    .oneshot(authenticated_request(
+                        "PUT",
+                        &format!("{location}?digest={digest}"),
+                        Body::from(body),
+                    ))
+                    .await
+                    .unwrap();
+                finished.store(true, Ordering::Release);
+                response.status()
+            })
+        };
+        let reader = {
+            let state = state.clone();
+            let start = start.clone();
+            let body = body.clone();
+            let digest = digest.clone();
+            let finished = finished.clone();
+            tokio::spawn(async move {
+                start.wait().await;
+                let mut reads = 0usize;
+                loop {
+                    let response = oci_routes(state.clone())
+                        .oneshot(
+                            Request::get(format!("/v2/demo/blobs/{digest}"))
+                                .body(Body::empty())
+                                .unwrap(),
+                        )
+                        .await
+                        .unwrap();
+                    match response.status() {
+                        StatusCode::NOT_FOUND => {}
+                        StatusCode::OK => {
+                            let observed = to_bytes(response.into_body(), MAX_OCI_BLOB_SIZE)
+                                .await
+                                .unwrap();
+                            assert_eq!(observed.as_ref(), body.as_slice());
+                        }
+                        status => panic!("unexpected concurrent read status {status}"),
+                    }
+                    reads += 1;
+                    if finished.load(Ordering::Acquire) && reads >= 4 {
+                        break;
+                    }
+                    tokio::task::yield_now().await;
+                }
+            })
+        };
+        start.wait().await;
+
+        assert_eq!(writer.await.unwrap(), StatusCode::CREATED);
+        reader.await.unwrap();
+        let blob_path = blob_path_for_digest(&state.blobs_dir, &digest).unwrap();
+        assert_eq!(std::fs::read(blob_path).unwrap(), body);
+        assert_eq!(std::fs::read_dir(&state.blobs_dir).unwrap().count(), 1);
+    }
+
+    #[tokio::test]
+    async fn manifest_digest_reference_must_equal_the_uploaded_body_digest() {
+        let (_root, state) = registry_state_with_token(Some("registry-secret"));
+        let body = br#"{"schemaVersion":2}"#;
+        let computed = format!("sha256:{}", sha2_hex(body));
+        let mismatched = format!("sha256:{}", "0".repeat(SHA256_HEX_LEN));
+
+        let rejected = oci_routes(state.clone())
+            .oneshot(authenticated_request(
+                "PUT",
+                &format!("/v2/demo/manifests/{mismatched}"),
+                Body::from(body.as_slice()),
+            ))
+            .await
+            .unwrap();
+        assert_eq!(rejected.status(), StatusCode::BAD_REQUEST);
+        assert_eq!(error_code(rejected).await, "DIGEST_INVALID");
+        assert!(state.manifests.read().await.is_empty());
+
+        let accepted = oci_routes(state.clone())
+            .oneshot(authenticated_request(
+                "PUT",
+                &format!("/v2/demo/manifests/{computed}"),
+                Body::from(body.as_slice()),
+            ))
+            .await
+            .unwrap();
+        assert_eq!(accepted.status(), StatusCode::CREATED);
+        assert_eq!(state.manifests.read().await.len(), 1);
+        assert_eq!(
+            state
+                .manifests
+                .read()
+                .await
+                .get(&("demo".to_string(), computed))
+                .map(Vec::as_slice),
+            Some(body.as_slice())
+        );
     }
 
     #[tokio::test]

--- a/crates/kin-registry/src/oci.rs
+++ b/crates/kin-registry/src/oci.rs
@@ -40,7 +40,11 @@ const OCI_UPLOAD_METADATA_VERSION: u32 = 1;
 const BLOB_STREAM_CHUNK_SIZE: usize = 64 * 1024;
 const DEFAULT_MANIFEST_MEDIA_TYPE: &str = "application/vnd.oci.image.manifest.v1+json";
 const DOCKER_MANIFEST_MEDIA_TYPE: &str = "application/vnd.docker.distribution.manifest.v2+json";
-const MAX_MANIFEST_LAYERS: usize = 4096;
+const OCI_INDEX_MEDIA_TYPE: &str = "application/vnd.oci.image.index.v1+json";
+const DOCKER_MANIFEST_LIST_MEDIA_TYPE: &str =
+    "application/vnd.docker.distribution.manifest.list.v2+json";
+const MAX_MANIFEST_DESCRIPTORS: usize = 4096;
+const MAX_MANIFEST_VALIDATION_BYTES: u64 = 2 * 1024 * 1024 * 1024;
 
 static UPLOAD_SEQUENCE: AtomicU64 = AtomicU64::new(0);
 
@@ -63,6 +67,35 @@ struct ImageManifest {
     media_type: Option<String>,
     config: ImageDescriptor,
     layers: Vec<ImageDescriptor>,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct ImageIndex {
+    schema_version: u32,
+    #[serde(default)]
+    media_type: Option<String>,
+    manifests: Vec<ImageDescriptor>,
+}
+
+#[derive(Debug)]
+enum ParsedManifest {
+    Image(ImageManifest),
+    Index(ImageIndex),
+}
+
+#[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
+enum ManifestReferenceKind {
+    Blob,
+    Manifest,
+}
+
+#[derive(Clone, Debug)]
+struct ValidatedManifestReference {
+    kind: ManifestReferenceKind,
+    digest: String,
+    media_type: String,
+    identity: crate::atomic_file::ArtifactIdentity,
 }
 
 #[derive(Debug, Deserialize)]
@@ -115,46 +148,64 @@ impl Default for OciMetadata {
 /// Shared state for the OCI registry routes.
 pub struct OciRegistryState {
     blobs_dir: PathBuf,
+    authority: crate::atomic_file::AuthorityRoot,
+    #[cfg(test)]
     metadata_path: PathBuf,
-    metadata_lock_path: PathBuf,
     metadata: RwLock<OciMetadata>,
-    uploads_dir: PathBuf,
-    uploads_lock_path: PathBuf,
     /// Serializes this process before the shared storage lock is acquired.
     upload_gate: Mutex<()>,
     max_active_upload_bytes: u64,
     /// OCI-specific secret for writes. `None` disables every mutation.
     write_token: Option<String>,
+    #[cfg(test)]
+    manifest_validation_hook: std::sync::Mutex<Option<Arc<ManifestValidationHook>>>,
+}
+
+#[cfg(test)]
+struct ManifestValidationHook {
+    started: tokio::sync::Notify,
+    release: tokio::sync::Notify,
+}
+
+#[derive(Clone)]
+struct OciDiskState {
+    authority: crate::atomic_file::AuthorityRoot,
+    blobs_dir: PathBuf,
+    max_active_upload_bytes: u64,
 }
 
 impl OciRegistryState {
     pub fn new(blobs_dir: PathBuf, write_token: Option<String>) -> Self {
-        // Pin the storage identity once. macOS temporary paths commonly enter
-        // through `/var` while descriptor-anchored storage resolves them under
-        // `/private/var`; a canonical root keeps every later no-follow boundary
-        // and cross-process lock keyed to the same directory.
-        let blobs_dir = std::fs::canonicalize(&blobs_dir).unwrap_or(blobs_dir);
+        let authority = crate::atomic_file::AuthorityRoot::new(&blobs_dir);
+        let blobs_dir = authority.path().to_path_buf();
+        #[cfg(test)]
         let metadata_path = blobs_dir.join("metadata.json");
-        let metadata_lock_path = blobs_dir.join(".metadata.lock");
-        let uploads_dir = blobs_dir.join("uploads");
-        let uploads_lock_path = blobs_dir.join(".uploads.lock");
         // This cache is only an in-process observation surface. Every request
         // reloads durable authority under a storage-scoped advisory lock, so a
         // corrupt file or another daemon's publication can never be hidden by
         // startup state.
-        let metadata = read_metadata_file(&metadata_path).unwrap_or_default();
+        let metadata = read_metadata_authority(&authority).unwrap_or_default();
         Self {
             blobs_dir,
+            authority,
+            #[cfg(test)]
             metadata_path,
-            metadata_lock_path,
             metadata: RwLock::new(metadata),
-            uploads_dir,
-            uploads_lock_path,
             upload_gate: Mutex::new(()),
             max_active_upload_bytes: MAX_TOTAL_ACTIVE_UPLOAD_BYTES,
             write_token: write_token
                 .map(|token| token.trim().to_string())
                 .filter(|token| !token.is_empty()),
+            #[cfg(test)]
+            manifest_validation_hook: std::sync::Mutex::new(None),
+        }
+    }
+
+    fn disk_state(&self) -> OciDiskState {
+        OciDiskState {
+            authority: self.authority.clone(),
+            blobs_dir: self.blobs_dir.clone(),
+            max_active_upload_bytes: self.max_active_upload_bytes,
         }
     }
 }
@@ -337,11 +388,14 @@ async fn dispatch(
                     repository,
                     upload_id,
                     digest.as_deref(),
+                    content_range.as_deref(),
                     declared_length,
                     request.into_body(),
                 )
                 .await
             }
+            Method::GET => upload_status_inner(&state, repository, upload_id).await,
+            Method::DELETE => cancel_upload_inner(&state, repository, upload_id).await,
             _ => StatusCode::METHOD_NOT_ALLOWED.into_response(),
         };
     }
@@ -412,6 +466,7 @@ fn metadata_authority_error(error: &str) -> Response {
     )
 }
 
+#[cfg(test)]
 fn read_metadata_file(path: &FsPath) -> Result<OciMetadata, String> {
     match std::fs::read(path) {
         Ok(bytes) => {
@@ -430,15 +485,42 @@ fn read_metadata_file(path: &FsPath) -> Result<OciMetadata, String> {
     }
 }
 
+fn decode_metadata(bytes: &[u8]) -> Result<OciMetadata, String> {
+    let metadata = serde_json::from_slice::<OciMetadata>(bytes)
+        .map_err(|error| format!("cannot decode OCI metadata: {error}"))?;
+    if metadata.version != OCI_METADATA_VERSION {
+        return Err(format!(
+            "unsupported OCI metadata version {} (expected {OCI_METADATA_VERSION})",
+            metadata.version
+        ));
+    }
+    Ok(metadata)
+}
+
+fn read_metadata_authority(
+    authority: &crate::atomic_file::AuthorityRoot,
+) -> Result<OciMetadata, String> {
+    match authority.read(FsPath::new("metadata.json")) {
+        Ok(bytes) => decode_metadata(&bytes),
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => Ok(OciMetadata::default()),
+        Err(error) => Err(format!("cannot read OCI metadata: {error}")),
+    }
+}
+
 /// Reload the durable authority for every read. The local write guard prevents
 /// same-process readers from racing a local publisher while the shared file
 /// lock orders this snapshot against publishers in other daemon processes.
 async fn metadata_snapshot(state: &OciRegistryState) -> Result<OciMetadata, String> {
     let mut cache = state.metadata.write().await;
-    let _storage_lock = crate::storage_lock::StorageLock::shared_async(&state.metadata_lock_path)
-        .await
-        .map_err(|error| format!("failed to lock OCI metadata for reading: {error}"))?;
-    let fresh = read_metadata_file(&state.metadata_path)?;
+    let authority = state.authority.clone();
+    let fresh = tokio::task::spawn_blocking(move || {
+        let _storage_lock =
+            crate::storage_lock::StorageLock::shared_at(&authority, FsPath::new(".metadata.lock"))
+                .map_err(|error| format!("failed to lock OCI metadata for reading: {error}"))?;
+        read_metadata_authority(&authority)
+    })
+    .await
+    .map_err(|error| format!("OCI metadata read task failed: {error}"))??;
     *cache = fresh.clone();
     Ok(fresh)
 }
@@ -456,18 +538,43 @@ async fn begin_metadata_write(
     String,
 > {
     let cache = state.metadata.write().await;
-    let storage_lock = crate::storage_lock::StorageLock::exclusive_async(&state.metadata_lock_path)
+    let storage_lock = crate::storage_lock::StorageLock::exclusive_at_async(
+        state.authority.clone(),
+        PathBuf::from(".metadata.lock"),
+    )
+    .await
+    .map_err(|error| format!("failed to lock OCI metadata for writing: {error}"))?;
+    let authority = state.authority.clone();
+    let fresh = tokio::task::spawn_blocking(move || read_metadata_authority(&authority))
         .await
-        .map_err(|error| format!("failed to lock OCI metadata for writing: {error}"))?;
-    let fresh = read_metadata_file(&state.metadata_path)?;
+        .map_err(|error| format!("OCI metadata read task failed: {error}"))??;
     Ok((cache, storage_lock, fresh))
 }
 
+#[cfg(test)]
 fn persist_metadata(state: &OciRegistryState, metadata: &OciMetadata) -> Result<(), String> {
     let bytes = serde_json::to_vec(metadata)
         .map_err(|error| format!("failed to encode OCI metadata: {error}"))?;
-    crate::atomic_file::write(&state.metadata_path, &bytes)
+    state
+        .authority
+        .write(FsPath::new("metadata.json"), &bytes)
         .map_err(|error| format!("failed to persist OCI metadata: {error}"))
+}
+
+async fn persist_metadata_async(
+    state: &OciRegistryState,
+    metadata: &OciMetadata,
+) -> Result<(), String> {
+    let bytes = serde_json::to_vec(metadata)
+        .map_err(|error| format!("failed to encode OCI metadata: {error}"))?;
+    let authority = state.authority.clone();
+    tokio::task::spawn_blocking(move || {
+        authority
+            .write(FsPath::new("metadata.json"), &bytes)
+            .map_err(|error| format!("failed to persist OCI metadata: {error}"))
+    })
+    .await
+    .map_err(|error| format!("OCI metadata persistence task failed: {error}"))?
 }
 
 /// HEAD /v2/{name}/blobs/{digest} -- check if blob exists.
@@ -499,14 +606,12 @@ async fn get_blob_inner(
     if !is_member {
         return StatusCode::NOT_FOUND.into_response();
     }
-    if !std::fs::symlink_metadata(&blob_path)
-        .ok()
-        .is_some_and(|metadata| metadata.file_type().is_file())
-    {
-        return StatusCode::NOT_FOUND.into_response();
-    }
-    let file = match tokio::fs::File::open(&blob_path).await {
-        Ok(file) => file,
+    let relative = match blob_path.strip_prefix(&state.blobs_dir) {
+        Ok(relative) => relative.to_path_buf(),
+        Err(_) => return StatusCode::INTERNAL_SERVER_ERROR.into_response(),
+    };
+    let file = match state.authority.open_read(&relative) {
+        Ok(file) => tokio::fs::File::from_std(file),
         Err(_) => return StatusCode::NOT_FOUND.into_response(),
     };
     let size = match file.metadata().await {
@@ -569,23 +674,51 @@ async fn begin_upload_write(
     state: &OciRegistryState,
 ) -> Result<UploadWriteTransaction<'_>, String> {
     let local = state.upload_gate.lock().await;
-    let storage = crate::storage_lock::StorageLock::exclusive_async(&state.uploads_lock_path)
-        .await
-        .map_err(|error| format!("failed to lock OCI uploads: {error}"))?;
-    crate::atomic_file::ensure_directory_durable(&state.uploads_dir)
-        .map_err(|error| format!("failed to create OCI upload storage: {error}"))?;
+    let storage = crate::storage_lock::StorageLock::exclusive_at_async(
+        state.authority.clone(),
+        PathBuf::from(".uploads.lock"),
+    )
+    .await
+    .map_err(|error| format!("failed to lock OCI uploads: {error}"))?;
+    run_upload_disk(state, |disk| {
+        disk.authority
+            .ensure_directory(FsPath::new("uploads"))
+            .map_err(|error| format!("failed to create OCI upload storage: {error}"))
+    })
+    .await?;
     Ok(UploadWriteTransaction {
         _local: local,
         _storage: storage,
     })
 }
 
-fn upload_metadata_path(state: &OciRegistryState, id: &str) -> Option<PathBuf> {
-    valid_upload_id(id).then(|| state.uploads_dir.join(format!("{id}.json")))
+async fn run_upload_disk<T, F>(state: &OciRegistryState, operation: F) -> Result<T, String>
+where
+    T: Send + 'static,
+    F: FnOnce(OciDiskState) -> Result<T, String> + Send + 'static,
+{
+    let disk = state.disk_state();
+    tokio::task::spawn_blocking(move || operation(disk))
+        .await
+        .map_err(|error| format!("OCI upload storage task failed: {error}"))?
 }
 
+#[cfg(test)]
+fn upload_metadata_path(state: &OciRegistryState, id: &str) -> Option<PathBuf> {
+    upload_metadata_relative(id).map(|relative| state.blobs_dir.join(relative))
+}
+
+#[cfg(test)]
 fn upload_data_path(state: &OciRegistryState, id: &str) -> Option<PathBuf> {
-    valid_upload_id(id).then(|| state.uploads_dir.join(format!("{id}.data")))
+    upload_data_relative(id).map(|relative| state.blobs_dir.join(relative))
+}
+
+fn upload_metadata_relative(id: &str) -> Option<PathBuf> {
+    valid_upload_id(id).then(|| PathBuf::from("uploads").join(format!("{id}.json")))
+}
+
+fn upload_data_relative(id: &str) -> Option<PathBuf> {
+    valid_upload_id(id).then(|| PathBuf::from("uploads").join(format!("{id}.data")))
 }
 
 fn now_unix_secs() -> Result<u64, String> {
@@ -595,13 +728,21 @@ fn now_unix_secs() -> Result<u64, String> {
         .map_err(|error| format!("system clock is before the Unix epoch: {error}"))
 }
 
+#[cfg(test)]
 fn read_upload_session(
     state: &OciRegistryState,
     id: &str,
 ) -> Result<Option<PendingUpload>, String> {
-    let metadata_path = upload_metadata_path(state, id)
-        .ok_or_else(|| "invalid OCI upload identifier".to_string())?;
-    let bytes = match std::fs::read(&metadata_path) {
+    read_upload_session_disk(&state.disk_state(), id)
+}
+
+fn read_upload_session_disk(
+    state: &OciDiskState,
+    id: &str,
+) -> Result<Option<PendingUpload>, String> {
+    let metadata_relative =
+        upload_metadata_relative(id).ok_or_else(|| "invalid OCI upload identifier".to_string())?;
+    let bytes = match state.authority.read(&metadata_relative) {
         Ok(bytes) => bytes,
         Err(error) if error.kind() == std::io::ErrorKind::NotFound => return Ok(None),
         Err(error) => return Err(format!("failed to read OCI upload metadata: {error}")),
@@ -619,15 +760,15 @@ fn read_upload_session(
     {
         return Err("OCI upload metadata failed validation".to_string());
     }
-    let data_path = upload_data_path(state, id).expect("validated upload identifier");
-    match std::fs::symlink_metadata(&data_path) {
-        Ok(metadata) if metadata.file_type().is_file() && metadata.len() == upload.size => {}
-        Ok(metadata) if metadata.file_type().is_file() && metadata.len() > upload.size => {
+    let data_relative = upload_data_relative(id).expect("validated upload identifier");
+    match state.authority.metadata(&data_relative) {
+        Ok(metadata) if metadata.len() == upload.size => {}
+        Ok(metadata) if metadata.len() > upload.size => {
             // The durable metadata offset is the commit point. Bytes beyond it
             // can only be an interrupted PATCH/final PUT and are safe to drop.
-            let file = std::fs::OpenOptions::new()
-                .write(true)
-                .open(&data_path)
+            let file = state
+                .authority
+                .open_write(&data_relative)
                 .map_err(|error| format!("failed to reopen interrupted OCI upload: {error}"))?;
             file.set_len(upload.size)
                 .map_err(|error| format!("failed to roll back interrupted OCI upload: {error}"))?;
@@ -638,43 +779,50 @@ fn read_upload_session(
         Err(error)
             if error.kind() == std::io::ErrorKind::NotFound
                 && upload.expected_digest.as_ref().is_some_and(|digest| {
-                    blob_path_for_digest(&state.blobs_dir, digest)
-                        .and_then(|path| std::fs::symlink_metadata(path).ok())
-                        .is_some_and(|metadata| {
-                            metadata.file_type().is_file() && metadata.len() == upload.size
-                        })
+                    blob_relative_for_digest(digest)
+                        .and_then(|path| state.authority.metadata(&path).ok())
+                        .is_some_and(|metadata| metadata.len() == upload.size)
                 }) => {}
         Err(error) => return Err(format!("failed to inspect OCI upload data: {error}")),
     }
     Ok(Some(upload))
 }
 
+#[cfg(test)]
 fn persist_upload_session(
     state: &OciRegistryState,
     id: &str,
     upload: &PendingUpload,
 ) -> Result<(), String> {
-    let metadata_path = upload_metadata_path(state, id)
-        .ok_or_else(|| "invalid OCI upload identifier".to_string())?;
+    persist_upload_session_disk(&state.disk_state(), id, upload)
+}
+
+fn persist_upload_session_disk(
+    state: &OciDiskState,
+    id: &str,
+    upload: &PendingUpload,
+) -> Result<(), String> {
+    let metadata_path =
+        upload_metadata_relative(id).ok_or_else(|| "invalid OCI upload identifier".to_string())?;
     let bytes = serde_json::to_vec(upload)
         .map_err(|error| format!("failed to encode OCI upload metadata: {error}"))?;
-    crate::atomic_file::write(&metadata_path, &bytes)
+    state
+        .authority
+        .write(&metadata_path, &bytes)
         .map_err(|error| format!("failed to persist OCI upload metadata: {error}"))
 }
 
-fn remove_upload_session(state: &OciRegistryState, id: &str) -> Result<(), String> {
+fn remove_upload_session_disk(state: &OciDiskState, id: &str) -> Result<(), String> {
     for path in [
-        upload_metadata_path(state, id)
-            .ok_or_else(|| "invalid OCI upload identifier".to_string())?,
-        upload_data_path(state, id).ok_or_else(|| "invalid OCI upload identifier".to_string())?,
+        upload_metadata_relative(id).ok_or_else(|| "invalid OCI upload identifier".to_string())?,
+        upload_data_relative(id).ok_or_else(|| "invalid OCI upload identifier".to_string())?,
     ] {
-        match std::fs::remove_file(&path) {
+        match state.authority.remove_file(&path) {
             Ok(()) => {}
-            Err(error) if error.kind() == std::io::ErrorKind::NotFound => {}
             Err(error) => {
                 return Err(format!(
                     "failed to remove OCI upload state {}: {error}",
-                    path.display()
+                    state.blobs_dir.join(&path).display()
                 ));
             }
         }
@@ -685,16 +833,21 @@ fn remove_upload_session(state: &OciRegistryState, id: &str) -> Result<(), Strin
 /// Prune expired durable sessions and return (active count, aggregate bytes).
 /// The caller holds the shared-storage upload lock, so all daemon processes
 /// enforce the same count and byte budget.
+#[cfg(test)]
 fn prune_and_measure_uploads(state: &OciRegistryState) -> Result<(usize, u64), String> {
+    prune_and_measure_uploads_disk(&state.disk_state())
+}
+
+fn prune_and_measure_uploads_disk(state: &OciDiskState) -> Result<(usize, u64), String> {
     let now = now_unix_secs()?;
     let mut active_ids = BTreeSet::new();
     let mut active_count = 0usize;
     let mut active_bytes = 0u64;
-    for entry in std::fs::read_dir(&state.uploads_dir)
+    for file_name in state
+        .authority
+        .read_dir_names(FsPath::new("uploads"))
         .map_err(|error| format!("failed to enumerate OCI uploads: {error}"))?
     {
-        let entry = entry.map_err(|error| format!("failed to enumerate OCI uploads: {error}"))?;
-        let file_name = entry.file_name();
         let Some(file_name) = file_name.to_str() else {
             return Err("OCI upload storage contains a non-UTF-8 entry".to_string());
         };
@@ -706,11 +859,11 @@ fn prune_and_measure_uploads(state: &OciRegistryState) -> Result<(usize, u64), S
                 "OCI upload storage contains invalid metadata entry {file_name}"
             ));
         }
-        let Some(upload) = read_upload_session(state, id)? else {
+        let Some(upload) = read_upload_session_disk(state, id)? else {
             continue;
         };
         if now.saturating_sub(upload.updated_at_unix_secs) >= UPLOAD_TTL.as_secs() {
-            remove_upload_session(state, id)?;
+            remove_upload_session_disk(state, id)?;
             continue;
         }
         active_count = active_count
@@ -728,12 +881,11 @@ fn prune_and_measure_uploads(state: &OciRegistryState) -> Result<(usize, u64), S
     // A crash between the empty data write and metadata publication can leave
     // an unowned stage. Remove only canonical unowned stages; every unexpected
     // entry fails closed instead of being omitted from the aggregate budget.
-    for entry in std::fs::read_dir(&state.uploads_dir)
+    for file_name in state
+        .authority
+        .read_dir_names(FsPath::new("uploads"))
         .map_err(|error| format!("failed to enumerate OCI upload data: {error}"))?
     {
-        let entry =
-            entry.map_err(|error| format!("failed to enumerate OCI upload data: {error}"))?;
-        let file_name = entry.file_name();
         let Some(file_name) = file_name.to_str() else {
             return Err("OCI upload storage contains a non-UTF-8 entry".to_string());
         };
@@ -752,9 +904,12 @@ fn prune_and_measure_uploads(state: &OciRegistryState) -> Result<(usize, u64), S
                 ));
             }
             if !active_ids.contains(id) {
-                std::fs::remove_file(entry.path()).map_err(|error| {
-                    format!("failed to prune orphaned OCI upload data: {error}")
-                })?;
+                state
+                    .authority
+                    .remove_file(&PathBuf::from("uploads").join(file_name))
+                    .map_err(|error| {
+                        format!("failed to prune orphaned OCI upload data: {error}")
+                    })?;
             }
             continue;
         }
@@ -775,7 +930,8 @@ async fn rollback_staged_file(file: &mut tokio::fs::File, size: u64) -> Result<(
 }
 
 async fn append_upload_body(
-    path: &FsPath,
+    authority: &crate::atomic_file::AuthorityRoot,
+    relative: &FsPath,
     original_size: u64,
     aggregate_remaining: u64,
     declared_length: Option<u64>,
@@ -787,10 +943,9 @@ async fn append_upload_body(
     if declared_length.is_some_and(|length| length > allowed) {
         return Err(UploadAppendError::Limit);
     }
-    let mut file = tokio::fs::OpenOptions::new()
-        .append(true)
-        .open(path)
-        .await
+    let mut file = authority
+        .open_append(relative)
+        .map(tokio::fs::File::from_std)
         .map_err(|error| {
             UploadAppendError::Storage(format!("failed to open OCI upload data: {error}"))
         })?;
@@ -850,9 +1005,14 @@ async fn append_upload_body(
     Ok(written)
 }
 
-async fn hash_upload_file(path: &FsPath, expected_size: u64) -> Result<Sha256, String> {
-    let mut file = tokio::fs::File::open(path)
-        .await
+async fn hash_upload_file(
+    authority: &crate::atomic_file::AuthorityRoot,
+    relative: &FsPath,
+    expected_size: u64,
+) -> Result<Sha256, String> {
+    let mut file = authority
+        .open_read(relative)
+        .map(tokio::fs::File::from_std)
         .map_err(|error| format!("failed to open OCI upload data for hashing: {error}"))?;
     let mut hasher = Sha256::new();
     let mut observed_size = 0u64;
@@ -879,45 +1039,12 @@ async fn hash_upload_file(path: &FsPath, expected_size: u64) -> Result<Sha256, S
     Ok(hasher)
 }
 
-fn publish_staged_upload(staged: &FsPath, destination: &FsPath) -> std::io::Result<()> {
-    let staged_parent = staged.parent().ok_or_else(|| {
-        std::io::Error::new(
-            std::io::ErrorKind::InvalidInput,
-            "OCI upload stage has no parent directory",
-        )
-    })?;
-    let destination_parent = destination.parent().ok_or_else(|| {
-        std::io::Error::new(
-            std::io::ErrorKind::InvalidInput,
-            "OCI blob destination has no parent directory",
-        )
-    })?;
-    match std::fs::symlink_metadata(destination) {
-        Ok(_) => {
-            return Err(std::io::Error::new(
-                std::io::ErrorKind::AlreadyExists,
-                "OCI blob destination already exists",
-            ));
-        }
-        Err(error) if error.kind() == std::io::ErrorKind::NotFound => {}
-        Err(error) => return Err(error),
-    }
-    std::fs::rename(staged, destination)?;
-    sync_oci_directory(destination_parent)?;
-    if staged_parent != destination_parent {
-        sync_oci_directory(staged_parent)?;
-    }
-    Ok(())
-}
-
-#[cfg(unix)]
-fn sync_oci_directory(path: &FsPath) -> std::io::Result<()> {
-    std::fs::File::open(path)?.sync_all()
-}
-
-#[cfg(not(unix))]
-fn sync_oci_directory(_path: &FsPath) -> std::io::Result<()> {
-    Ok(())
+fn publish_staged_upload(
+    authority: &crate::atomic_file::AuthorityRoot,
+    staged: &FsPath,
+    destination: &FsPath,
+) -> std::io::Result<()> {
+    authority.rename(staged, destination)
 }
 
 fn upload_progress_response(status: StatusCode, name: &str, id: &str, size: u64) -> Response {
@@ -987,49 +1114,131 @@ async fn initiate_upload_inner(state: &OciRegistryState, name: &str) -> Response
         Ok(transaction) => transaction,
         Err(error) => return metadata_authority_error(&error),
     };
-    let (active_count, active_bytes) = match prune_and_measure_uploads(state) {
-        Ok(measured) => measured,
-        Err(error) => return metadata_authority_error(&error),
-    };
-    if active_count >= MAX_ACTIVE_UPLOADS || active_bytes >= state.max_active_upload_bytes {
-        return oci_error(
-            StatusCode::TOO_MANY_REQUESTS,
-            "TOOMANYREQUESTS",
-            "too many active OCI uploads",
-            None,
-        );
-    }
-
     let now = match now_unix_secs() {
         Ok(now) => now,
         Err(error) => return metadata_authority_error(&error),
     };
-    let upload_id = loop {
-        let candidate = new_upload_id(name);
-        let metadata_exists =
-            upload_metadata_path(state, &candidate).is_some_and(|path| path.exists());
-        let data_exists = upload_data_path(state, &candidate).is_some_and(|path| path.exists());
-        if !metadata_exists && !data_exists {
-            break candidate;
+    let repository = name.to_string();
+    let upload_id = match run_upload_disk(state, move |disk| {
+        let (active_count, active_bytes) = prune_and_measure_uploads_disk(&disk)?;
+        if active_count >= MAX_ACTIVE_UPLOADS || active_bytes >= disk.max_active_upload_bytes {
+            return Ok(None);
         }
+        let upload_id = loop {
+            let candidate = new_upload_id(&repository);
+            let metadata_exists = upload_metadata_relative(&candidate)
+                .is_some_and(|path| disk.authority.metadata(&path).is_ok());
+            let data_exists = upload_data_relative(&candidate)
+                .is_some_and(|path| disk.authority.metadata(&path).is_ok());
+            if !metadata_exists && !data_exists {
+                break candidate;
+            }
+        };
+        let data_path = upload_data_relative(&upload_id).expect("generated upload identifier");
+        disk.authority
+            .write(&data_path, &[])
+            .map_err(|error| format!("failed to create OCI upload data: {error}"))?;
+        let upload = PendingUpload {
+            version: OCI_UPLOAD_METADATA_VERSION,
+            repository,
+            created_at_unix_secs: now,
+            updated_at_unix_secs: now,
+            size: 0,
+            expected_digest: None,
+        };
+        if let Err(error) = persist_upload_session_disk(&disk, &upload_id, &upload) {
+            let _ = disk.authority.remove_file(&data_path);
+            return Err(error);
+        }
+        Ok(Some(upload_id))
+    })
+    .await
+    {
+        Ok(Some(upload_id)) => upload_id,
+        Ok(None) => {
+            return oci_error(
+                StatusCode::TOO_MANY_REQUESTS,
+                "TOOMANYREQUESTS",
+                "too many active OCI uploads",
+                None,
+            );
+        }
+        Err(error) => return metadata_authority_error(&error),
     };
-    let data_path = upload_data_path(state, &upload_id).expect("generated upload identifier");
-    if let Err(error) = crate::atomic_file::write(&data_path, &[]) {
-        return metadata_authority_error(&format!("failed to create OCI upload data: {error}"));
-    }
-    let upload = PendingUpload {
-        version: OCI_UPLOAD_METADATA_VERSION,
-        repository: name.to_string(),
-        created_at_unix_secs: now,
-        updated_at_unix_secs: now,
-        size: 0,
-        expected_digest: None,
-    };
-    if let Err(error) = persist_upload_session(state, &upload_id, &upload) {
-        let _ = std::fs::remove_file(data_path);
-        return metadata_authority_error(&error);
-    }
     upload_progress_response(StatusCode::ACCEPTED, name, &upload_id, 0)
+}
+
+async fn upload_status_inner(state: &OciRegistryState, name: &str, id: &str) -> Response {
+    let location = upload_location(name, id);
+    if !valid_repository_name(name) || !valid_upload_id(id) {
+        return oci_error(
+            StatusCode::BAD_REQUEST,
+            "BLOB_UPLOAD_INVALID",
+            "invalid OCI upload coordinate",
+            Some(&location),
+        );
+    }
+    let _transaction = match begin_upload_write(state).await {
+        Ok(transaction) => transaction,
+        Err(error) => return metadata_authority_error(&error),
+    };
+    let id_owned = id.to_string();
+    let upload = run_upload_disk(state, move |disk| {
+        prune_and_measure_uploads_disk(&disk)?;
+        read_upload_session_disk(&disk, &id_owned)
+    })
+    .await;
+    match upload {
+        Ok(Some(upload)) if upload.repository == name => {
+            upload_progress_response(StatusCode::NO_CONTENT, name, id, upload.size)
+        }
+        Ok(Some(_)) | Ok(None) => oci_error(
+            StatusCode::NOT_FOUND,
+            "BLOB_UPLOAD_UNKNOWN",
+            "blob upload is unknown or expired",
+            Some(&location),
+        ),
+        Err(error) => metadata_authority_error(&error),
+    }
+}
+
+async fn cancel_upload_inner(state: &OciRegistryState, name: &str, id: &str) -> Response {
+    let location = upload_location(name, id);
+    if !valid_repository_name(name) || !valid_upload_id(id) {
+        return oci_error(
+            StatusCode::BAD_REQUEST,
+            "BLOB_UPLOAD_INVALID",
+            "invalid OCI upload coordinate",
+            Some(&location),
+        );
+    }
+    let _transaction = match begin_upload_write(state).await {
+        Ok(transaction) => transaction,
+        Err(error) => return metadata_authority_error(&error),
+    };
+    let id_owned = id.to_string();
+    let repository = name.to_string();
+    let cancelled = run_upload_disk(state, move |disk| {
+        prune_and_measure_uploads_disk(&disk)?;
+        match read_upload_session_disk(&disk, &id_owned)? {
+            Some(upload) if upload.repository == repository => {
+                remove_upload_session_disk(&disk, &id_owned)?;
+                Ok(true)
+            }
+            Some(_) | None => Ok(false),
+        }
+    })
+    .await;
+    match cancelled {
+        Ok(true) => StatusCode::NO_CONTENT.into_response(),
+        Ok(false) => oci_error(
+            StatusCode::NOT_FOUND,
+            "BLOB_UPLOAD_UNKNOWN",
+            "blob upload is unknown or expired",
+            Some(&location),
+        ),
+        Err(error) => metadata_authority_error(&error),
+    }
 }
 
 async fn patch_upload_inner(
@@ -1053,13 +1262,19 @@ async fn patch_upload_inner(
         Ok(transaction) => transaction,
         Err(error) => return metadata_authority_error(&error),
     };
-    let (_, active_bytes) = match prune_and_measure_uploads(state) {
+    let id_owned = id.to_string();
+    let measured = run_upload_disk(state, move |disk| {
+        let (_, active_bytes) = prune_and_measure_uploads_disk(&disk)?;
+        Ok((active_bytes, read_upload_session_disk(&disk, &id_owned)?))
+    })
+    .await;
+    let (active_bytes, upload) = match measured {
         Ok(measured) => measured,
         Err(error) => return metadata_authority_error(&error),
     };
-    let mut upload = match read_upload_session(state, id) {
-        Ok(Some(upload)) if upload.repository == name => upload,
-        Ok(Some(_)) | Ok(None) => {
+    let mut upload = match upload {
+        Some(upload) if upload.repository == name => upload,
+        Some(_) | None => {
             return oci_error(
                 StatusCode::NOT_FOUND,
                 "BLOB_UPLOAD_UNKNOWN",
@@ -1067,7 +1282,6 @@ async fn patch_upload_inner(
                 Some(&location),
             );
         }
-        Err(error) => return metadata_authority_error(&error),
     };
     if upload.expected_digest.is_some() {
         return oci_error(
@@ -1113,10 +1327,11 @@ async fn patch_upload_inner(
         Ok(now) => now,
         Err(error) => return metadata_authority_error(&error),
     };
-    let data_path = upload_data_path(state, id).expect("validated upload identifier");
+    let data_relative = upload_data_relative(id).expect("validated upload identifier");
     let aggregate_remaining = state.max_active_upload_bytes.saturating_sub(active_bytes);
     let appended = match append_upload_body(
-        &data_path,
+        &state.authority,
+        &data_relative,
         upload.size,
         aggregate_remaining,
         declared_length,
@@ -1129,12 +1344,9 @@ async fn patch_upload_inner(
         Err(error) => return upload_error(error, &location),
     };
     if expected_range_length.is_some_and(|expected| expected != appended) {
-        match tokio::fs::OpenOptions::new()
-            .write(true)
-            .open(&data_path)
-            .await
-        {
-            Ok(mut file) => {
+        match state.authority.open_write(&data_relative) {
+            Ok(file) => {
+                let mut file = tokio::fs::File::from_std(file);
                 if let Err(error) = rollback_staged_file(&mut file, upload.size).await {
                     return metadata_authority_error(&error);
                 }
@@ -1155,13 +1367,18 @@ async fn patch_upload_inner(
     let previous_size = upload.size;
     upload.size += appended;
     upload.updated_at_unix_secs = updated_at;
-    if let Err(error) = persist_upload_session(state, id, &upload) {
-        match tokio::fs::OpenOptions::new()
-            .write(true)
-            .open(&data_path)
-            .await
-        {
-            Ok(mut file) => {
+    let persisted = {
+        let id = id.to_string();
+        let upload = upload.clone();
+        run_upload_disk(state, move |disk| {
+            persist_upload_session_disk(&disk, &id, &upload)
+        })
+        .await
+    };
+    if let Err(error) = persisted {
+        match state.authority.open_write(&data_relative) {
+            Ok(file) => {
+                let mut file = tokio::fs::File::from_std(file);
                 if let Err(rollback_error) = rollback_staged_file(&mut file, previous_size).await {
                     return metadata_authority_error(&format!(
                         "{error}; additionally {rollback_error}"
@@ -1184,6 +1401,7 @@ async fn complete_upload_inner(
     name: &str,
     id: &str,
     expected_digest: Option<&str>,
+    content_range: Option<&str>,
     declared_length: Option<u64>,
     body: Body,
 ) -> Response {
@@ -1212,13 +1430,19 @@ async fn complete_upload_inner(
         Ok(transaction) => transaction,
         Err(error) => return metadata_authority_error(&error),
     };
-    let (_, active_bytes) = match prune_and_measure_uploads(state) {
+    let id_owned = id.to_string();
+    let measured = run_upload_disk(state, move |disk| {
+        let (_, active_bytes) = prune_and_measure_uploads_disk(&disk)?;
+        Ok((active_bytes, read_upload_session_disk(&disk, &id_owned)?))
+    })
+    .await;
+    let (active_bytes, upload) = match measured {
         Ok(measured) => measured,
         Err(error) => return metadata_authority_error(&error),
     };
-    let mut upload = match read_upload_session(state, id) {
-        Ok(Some(upload)) if upload.repository == name => upload,
-        Ok(Some(_)) | Ok(None) => {
+    let mut upload = match upload {
+        Some(upload) if upload.repository == name => upload,
+        Some(_) | None => {
             return oci_error(
                 StatusCode::NOT_FOUND,
                 "BLOB_UPLOAD_UNKNOWN",
@@ -1226,9 +1450,40 @@ async fn complete_upload_inner(
                 Some(&location),
             );
         }
-        Err(error) => return metadata_authority_error(&error),
     };
-    let data_path = upload_data_path(state, id).expect("validated upload identifier");
+    let expected_range_length = if let Some(value) = content_range {
+        let Some((start, end)) = parse_content_range(value) else {
+            return oci_error(
+                StatusCode::RANGE_NOT_SATISFIABLE,
+                "BLOB_UPLOAD_INVALID",
+                "Content-Range is invalid",
+                Some(&location),
+            );
+        };
+        let Some(length) = end
+            .checked_sub(start)
+            .and_then(|length| length.checked_add(1))
+        else {
+            return oci_error(
+                StatusCode::RANGE_NOT_SATISFIABLE,
+                "BLOB_UPLOAD_INVALID",
+                "Content-Range is invalid",
+                Some(&location),
+            );
+        };
+        if start != upload.size || declared_length.is_some_and(|declared| declared != length) {
+            return oci_error(
+                StatusCode::RANGE_NOT_SATISFIABLE,
+                "BLOB_UPLOAD_INVALID",
+                "Content-Range does not match the persisted upload offset and body length",
+                Some(&location),
+            );
+        }
+        Some(length)
+    } else {
+        None
+    };
+    let data_relative = upload_data_relative(id).expect("validated upload identifier");
     let computed_digest = if let Some(finalizing_digest) = upload.expected_digest.as_deref() {
         if finalizing_digest != expected_digest {
             return digest_invalid(
@@ -1259,14 +1514,16 @@ async fn complete_upload_inner(
             Ok(now) => now,
             Err(error) => return metadata_authority_error(&error),
         };
-        let mut hasher = match hash_upload_file(&data_path, upload.size).await {
+        let mut hasher = match hash_upload_file(&state.authority, &data_relative, upload.size).await
+        {
             Ok(hasher) => hasher,
             Err(error) => return metadata_authority_error(&error),
         };
         let aggregate_remaining = state.max_active_upload_bytes.saturating_sub(active_bytes);
         let original_size = upload.size;
         let appended = match append_upload_body(
-            &data_path,
+            &state.authority,
+            &data_relative,
             original_size,
             aggregate_remaining,
             declared_length,
@@ -1278,14 +1535,32 @@ async fn complete_upload_inner(
             Ok(appended) => appended,
             Err(error) => return upload_error(error, &location),
         };
+        if expected_range_length.is_some_and(|expected| expected != appended) {
+            match state.authority.open_write(&data_relative) {
+                Ok(file) => {
+                    let mut file = tokio::fs::File::from_std(file);
+                    if let Err(error) = rollback_staged_file(&mut file, original_size).await {
+                        return metadata_authority_error(&error);
+                    }
+                }
+                Err(error) => {
+                    return metadata_authority_error(&format!(
+                        "failed to reopen OCI upload after final Content-Range mismatch: {error}"
+                    ));
+                }
+            }
+            return oci_error(
+                StatusCode::RANGE_NOT_SATISFIABLE,
+                "BLOB_UPLOAD_INVALID",
+                "Content-Range length does not match the streamed body",
+                Some(&location),
+            );
+        }
         let computed_digest = format!("sha256:{}", hex::encode(hasher.finalize()));
         if expected_digest != computed_digest {
-            match tokio::fs::OpenOptions::new()
-                .write(true)
-                .open(&data_path)
-                .await
-            {
-                Ok(mut file) => {
+            match state.authority.open_write(&data_relative) {
+                Ok(file) => {
+                    let mut file = tokio::fs::File::from_std(file);
                     if let Err(error) = rollback_staged_file(&mut file, original_size).await {
                         return metadata_authority_error(&error);
                     }
@@ -1304,13 +1579,18 @@ async fn complete_upload_inner(
         upload.size += appended;
         upload.updated_at_unix_secs = updated_at;
         upload.expected_digest = Some(computed_digest.clone());
-        if let Err(error) = persist_upload_session(state, id, &upload) {
-            match tokio::fs::OpenOptions::new()
-                .write(true)
-                .open(&data_path)
-                .await
-            {
-                Ok(mut file) => {
+        let persisted = {
+            let id = id.to_string();
+            let upload = upload.clone();
+            run_upload_disk(state, move |disk| {
+                persist_upload_session_disk(&disk, &id, &upload)
+            })
+            .await
+        };
+        if let Err(error) = persisted {
+            match state.authority.open_write(&data_relative) {
+                Ok(file) => {
+                    let mut file = tokio::fs::File::from_std(file);
                     if let Err(rollback_error) =
                         rollback_staged_file(&mut file, original_size).await
                     {
@@ -1330,18 +1610,11 @@ async fn complete_upload_inner(
         computed_digest
     };
 
-    let blob_path = blob_path_for_digest(&state.blobs_dir, &computed_digest)
-        .expect("computed sha256 digest is canonical");
-    let data_present = std::fs::symlink_metadata(&data_path)
-        .ok()
-        .is_some_and(|metadata| metadata.file_type().is_file());
-    let blob_metadata = match std::fs::symlink_metadata(&blob_path) {
-        Ok(metadata) if metadata.file_type().is_file() => Some(metadata),
-        Ok(_) => {
-            return metadata_authority_error(
-                "an OCI blob digest path exists but is not a regular file",
-            );
-        }
+    let blob_relative =
+        blob_relative_for_digest(&computed_digest).expect("computed sha256 digest is canonical");
+    let data_present = state.authority.metadata(&data_relative).is_ok();
+    let blob_metadata = match state.authority.metadata(&blob_relative) {
+        Ok(metadata) => Some(metadata),
         Err(error) if error.kind() == std::io::ErrorKind::NotFound => None,
         Err(error) => {
             return metadata_authority_error(&format!(
@@ -1351,22 +1624,32 @@ async fn complete_upload_inner(
     };
     if data_present {
         if blob_metadata.is_some() {
-            let existing = match hash_upload_file(&blob_path, upload.size).await {
-                Ok(hasher) => format!("sha256:{}", hex::encode(hasher.finalize())),
-                Err(error) => return metadata_authority_error(&error),
-            };
+            let existing =
+                match hash_upload_file(&state.authority, &blob_relative, upload.size).await {
+                    Ok(hasher) => format!("sha256:{}", hex::encode(hasher.finalize())),
+                    Err(error) => return metadata_authority_error(&error),
+                };
             if existing != computed_digest {
                 return metadata_authority_error(
                     "an OCI blob digest path already contains different content",
                 );
             }
-        } else if let Err(error) = publish_staged_upload(&data_path, &blob_path) {
-            return oci_error(
-                StatusCode::INTERNAL_SERVER_ERROR,
-                "UNKNOWN",
-                &format!("failed to atomically publish OCI blob: {error}"),
-                Some(&location),
-            );
+        } else {
+            let staged = data_relative.clone();
+            let destination = blob_relative.clone();
+            if let Err(error) = run_upload_disk(state, move |disk| {
+                publish_staged_upload(&disk.authority, &staged, &destination)
+                    .map_err(|error| format!("failed to atomically publish OCI blob: {error}"))
+            })
+            .await
+            {
+                return oci_error(
+                    StatusCode::INTERNAL_SERVER_ERROR,
+                    "UNKNOWN",
+                    &error,
+                    Some(&location),
+                );
+            }
         }
     } else {
         if blob_metadata.is_none() {
@@ -1374,7 +1657,7 @@ async fn complete_upload_inner(
                 "durable OCI upload data disappeared before publication",
             );
         }
-        let existing = match hash_upload_file(&blob_path, upload.size).await {
+        let existing = match hash_upload_file(&state.authority, &blob_relative, upload.size).await {
             Ok(hasher) => format!("sha256:{}", hex::encode(hasher.finalize())),
             Err(error) => return metadata_authority_error(&error),
         };
@@ -1396,7 +1679,7 @@ async fn complete_upload_inner(
         .or_default()
         .blobs
         .insert(computed_digest.clone());
-    if let Err(error) = persist_metadata(state, &replacement) {
+    if let Err(error) = persist_metadata_async(state, &replacement).await {
         return oci_error(
             StatusCode::INTERNAL_SERVER_ERROR,
             "UNKNOWN",
@@ -1407,7 +1690,12 @@ async fn complete_upload_inner(
     *metadata_guard = replacement;
     drop(storage_lock);
     drop(metadata_guard);
-    if let Err(error) = remove_upload_session(state, id) {
+    let id_to_remove = id.to_string();
+    if let Err(error) = run_upload_disk(state, move |disk| {
+        remove_upload_session_disk(&disk, &id_to_remove)
+    })
+    .await
+    {
         tracing::warn!(upload_id = id, error = %error, "published OCI blob but could not remove completed upload state");
     }
 
@@ -1448,7 +1736,7 @@ async fn get_manifest_inner(
     let Some(descriptor) = descriptor else {
         return StatusCode::NOT_FOUND.into_response();
     };
-    let Some(path) = manifest_path_for_digest(&state.blobs_dir, &descriptor.digest) else {
+    let Some(path) = manifest_relative_for_digest(&descriptor.digest) else {
         return oci_error(
             StatusCode::INTERNAL_SERVER_ERROR,
             "UNKNOWN",
@@ -1456,8 +1744,8 @@ async fn get_manifest_inner(
             None,
         );
     };
-    let bytes = match tokio::fs::read(path).await {
-        Ok(bytes) => bytes,
+    let mut file = match state.authority.open_read(&path) {
+        Ok(file) => tokio::fs::File::from_std(file),
         Err(error) => {
             return oci_error(
                 StatusCode::INTERNAL_SERVER_ERROR,
@@ -1467,6 +1755,15 @@ async fn get_manifest_inner(
             );
         }
     };
+    let mut bytes = Vec::new();
+    if let Err(error) = file.read_to_end(&mut bytes).await {
+        return oci_error(
+            StatusCode::INTERNAL_SERVER_ERROR,
+            "UNKNOWN",
+            &format!("stored OCI manifest is unavailable: {error}"),
+            None,
+        );
+    }
     let length = bytes.len();
     let body = if head_only { Vec::new() } else { bytes };
     let mut response = (StatusCode::OK, body).into_response();
@@ -1492,15 +1789,24 @@ fn supported_manifest_media_type(value: &str) -> Option<&str> {
     let media_type = value.split(';').next()?.trim();
     matches!(
         media_type,
-        DEFAULT_MANIFEST_MEDIA_TYPE | DOCKER_MANIFEST_MEDIA_TYPE
+        DEFAULT_MANIFEST_MEDIA_TYPE
+            | DOCKER_MANIFEST_MEDIA_TYPE
+            | OCI_INDEX_MEDIA_TYPE
+            | DOCKER_MANIFEST_LIST_MEDIA_TYPE
     )
     .then_some(media_type)
 }
 
-fn parse_image_manifest(
+fn valid_descriptor_media_type(media_type: &str) -> bool {
+    !media_type.is_empty()
+        && media_type.len() <= 255
+        && media_type.bytes().all(|byte| byte.is_ascii_graphic())
+}
+
+fn parse_manifest(
     media_type: &str,
     body: &[u8],
-) -> Result<ImageManifest, ManifestValidationError> {
+) -> Result<ParsedManifest, ManifestValidationError> {
     let Some(request_media_type) = supported_manifest_media_type(media_type) else {
         return Err(ManifestValidationError {
             status: StatusCode::BAD_REQUEST,
@@ -1508,94 +1814,282 @@ fn parse_image_manifest(
             message: "unsupported OCI manifest Content-Type".to_string(),
         });
     };
-    let manifest =
-        serde_json::from_slice::<ImageManifest>(body).map_err(|error| ManifestValidationError {
-            status: StatusCode::BAD_REQUEST,
-            code: "MANIFEST_INVALID",
-            message: format!("manifest is not a supported OCI/Docker image manifest: {error}"),
+    let invalid = |message: String| ManifestValidationError {
+        status: StatusCode::BAD_REQUEST,
+        code: "MANIFEST_INVALID",
+        message,
+    };
+    if matches!(
+        request_media_type,
+        OCI_INDEX_MEDIA_TYPE | DOCKER_MANIFEST_LIST_MEDIA_TYPE
+    ) {
+        let index = serde_json::from_slice::<ImageIndex>(body).map_err(|error| {
+            invalid(format!(
+                "manifest is not a supported OCI/Docker image index: {error}"
+            ))
         })?;
+        if index.schema_version != 2
+            || index.manifests.len() > MAX_MANIFEST_DESCRIPTORS
+            || index
+                .media_type
+                .as_deref()
+                .is_some_and(|body_media_type| body_media_type != request_media_type)
+        {
+            return Err(ManifestValidationError {
+                status: StatusCode::BAD_REQUEST,
+                code: "MANIFEST_INVALID",
+                message: "manifest index schema, media type, or descriptor count is unsupported"
+                    .to_string(),
+            });
+        }
+        for descriptor in &index.manifests {
+            if !valid_descriptor_media_type(&descriptor.media_type)
+                || supported_manifest_media_type(&descriptor.media_type).is_none()
+                || sha256_hex(&descriptor.digest).is_none()
+                || descriptor.size > MAX_OCI_MANIFEST_SIZE as u64
+            {
+                return Err(invalid(
+                    "manifest index contains an invalid manifest descriptor".to_string(),
+                ));
+            }
+        }
+        return Ok(ParsedManifest::Index(index));
+    }
+
+    let manifest = serde_json::from_slice::<ImageManifest>(body).map_err(|error| {
+        invalid(format!(
+            "manifest is not a supported OCI/Docker image manifest: {error}"
+        ))
+    })?;
     if manifest.schema_version != 2
-        || manifest.layers.len() > MAX_MANIFEST_LAYERS
+        || manifest.layers.len().saturating_add(1) > MAX_MANIFEST_DESCRIPTORS
         || manifest
             .media_type
             .as_deref()
             .is_some_and(|body_media_type| body_media_type != request_media_type)
     {
-        return Err(ManifestValidationError {
-            status: StatusCode::BAD_REQUEST,
-            code: "MANIFEST_INVALID",
-            message: "manifest schema, media type, or layer count is unsupported".to_string(),
-        });
+        return Err(invalid(
+            "manifest schema, media type, or descriptor count is unsupported".to_string(),
+        ));
     }
     for descriptor in std::iter::once(&manifest.config).chain(manifest.layers.iter()) {
-        if descriptor.media_type.is_empty()
-            || descriptor.media_type.len() > 255
-            || !descriptor
-                .media_type
-                .bytes()
-                .all(|byte| byte.is_ascii_graphic())
+        if !valid_descriptor_media_type(&descriptor.media_type)
             || sha256_hex(&descriptor.digest).is_none()
             || descriptor.size > MAX_OCI_BLOB_SIZE as u64
         {
-            return Err(ManifestValidationError {
-                status: StatusCode::BAD_REQUEST,
-                code: "MANIFEST_INVALID",
-                message: "manifest contains an invalid config or layer descriptor".to_string(),
-            });
+            return Err(invalid(
+                "manifest contains an invalid config or layer descriptor".to_string(),
+            ));
         }
     }
-    Ok(manifest)
+    Ok(ParsedManifest::Image(manifest))
 }
 
-async fn validate_manifest_blobs(
+fn manifest_references(
+    manifest: &ParsedManifest,
+) -> Vec<(ManifestReferenceKind, &ImageDescriptor)> {
+    match manifest {
+        ParsedManifest::Image(manifest) => {
+            std::iter::once((ManifestReferenceKind::Blob, &manifest.config))
+                .chain(
+                    manifest
+                        .layers
+                        .iter()
+                        .map(|descriptor| (ManifestReferenceKind::Blob, descriptor)),
+                )
+                .collect()
+        }
+        ParsedManifest::Index(index) => index
+            .manifests
+            .iter()
+            .map(|descriptor| (ManifestReferenceKind::Manifest, descriptor))
+            .collect(),
+    }
+}
+
+fn manifest_reference_is_member(
+    metadata: &OciMetadata,
+    repository_name: &str,
+    kind: ManifestReferenceKind,
+    digest: &str,
+    media_type: &str,
+) -> bool {
+    let Some(repository) = metadata.repositories.get(repository_name) else {
+        return false;
+    };
+    match kind {
+        ManifestReferenceKind::Blob => repository.blobs.contains(digest),
+        ManifestReferenceKind::Manifest => {
+            repository.manifests.get(digest).is_some_and(|descriptor| {
+                descriptor.digest == digest && descriptor.media_type == media_type
+            })
+        }
+    }
+}
+
+fn manifest_reference_path(kind: ManifestReferenceKind, digest: &str) -> Option<PathBuf> {
+    match kind {
+        ManifestReferenceKind::Blob => blob_relative_for_digest(digest),
+        ManifestReferenceKind::Manifest => manifest_relative_for_digest(digest),
+    }
+}
+
+async fn validate_manifest_references(
     state: &OciRegistryState,
     metadata: &OciMetadata,
     repository_name: &str,
-    manifest: &ImageManifest,
-) -> Result<(), ManifestValidationError> {
-    let repository = metadata.repositories.get(repository_name);
-    let mut verified = BTreeSet::new();
-    for descriptor in std::iter::once(&manifest.config).chain(manifest.layers.iter()) {
-        let is_member =
-            repository.is_some_and(|repository| repository.blobs.contains(&descriptor.digest));
-        let Some(blob_path) = blob_path_for_digest(&state.blobs_dir, &descriptor.digest) else {
-            return Err(ManifestValidationError {
-                status: StatusCode::BAD_REQUEST,
-                code: "MANIFEST_INVALID",
-                message: "manifest contains an invalid blob digest".to_string(),
-            });
-        };
-        let file_is_exact = std::fs::symlink_metadata(&blob_path)
-            .ok()
-            .is_some_and(|metadata| {
-                metadata.file_type().is_file() && metadata.len() == descriptor.size
-            });
-        if !is_member || !file_is_exact {
+    manifest: &ParsedManifest,
+) -> Result<Vec<ValidatedManifestReference>, ManifestValidationError> {
+    let references = manifest_references(manifest);
+    if references.len() > MAX_MANIFEST_DESCRIPTORS {
+        return Err(ManifestValidationError {
+            status: StatusCode::BAD_REQUEST,
+            code: "MANIFEST_INVALID",
+            message: "manifest descriptor count exceeds the validation limit".to_string(),
+        });
+    }
+    let mut unique = HashMap::<(ManifestReferenceKind, String), (u64, String)>::new();
+    let mut work_bytes = 0u64;
+    for (kind, descriptor) in references {
+        if !manifest_reference_is_member(
+            metadata,
+            repository_name,
+            kind,
+            &descriptor.digest,
+            &descriptor.media_type,
+        ) {
             return Err(ManifestValidationError {
                 status: StatusCode::NOT_FOUND,
                 code: "MANIFEST_BLOB_UNKNOWN",
-                message: format!("manifest references unavailable blob {}", descriptor.digest),
+                message: format!(
+                    "manifest references unavailable descriptor {}",
+                    descriptor.digest
+                ),
             });
         }
-        if verified.insert(descriptor.digest.clone()) {
-            let observed = hash_upload_file(&blob_path, descriptor.size)
-                .await
-                .map_err(|error| ManifestValidationError {
-                    status: StatusCode::INTERNAL_SERVER_ERROR,
-                    code: "UNKNOWN",
-                    message: error,
-                })?;
-            let observed = format!("sha256:{}", hex::encode(observed.finalize()));
-            if observed != descriptor.digest {
+        let key = (kind, descriptor.digest.clone());
+        if let Some((size, media_type)) = unique.get(&key) {
+            if *size != descriptor.size || media_type != &descriptor.media_type {
                 return Err(ManifestValidationError {
-                    status: StatusCode::NOT_FOUND,
-                    code: "MANIFEST_BLOB_UNKNOWN",
-                    message: format!(
-                        "manifest references blob {} whose content is not trustworthy",
-                        descriptor.digest
-                    ),
+                    status: StatusCode::BAD_REQUEST,
+                    code: "MANIFEST_INVALID",
+                    message: "manifest repeats a digest with conflicting descriptor metadata"
+                        .to_string(),
                 });
             }
+            continue;
+        }
+        work_bytes =
+            work_bytes
+                .checked_add(descriptor.size)
+                .ok_or_else(|| ManifestValidationError {
+                    status: StatusCode::BAD_REQUEST,
+                    code: "MANIFEST_INVALID",
+                    message: "manifest validation byte count overflowed".to_string(),
+                })?;
+        if work_bytes > MAX_MANIFEST_VALIDATION_BYTES {
+            return Err(ManifestValidationError {
+                status: StatusCode::BAD_REQUEST,
+                code: "MANIFEST_INVALID",
+                message: "manifest referenced bytes exceed the validation work limit".to_string(),
+            });
+        }
+        unique.insert(key, (descriptor.size, descriptor.media_type.clone()));
+    }
+
+    let mut validated = Vec::with_capacity(unique.len());
+    #[cfg(test)]
+    let validation_hook = state
+        .manifest_validation_hook
+        .lock()
+        .unwrap_or_else(std::sync::PoisonError::into_inner)
+        .clone();
+    #[cfg(test)]
+    if let Some(hook) = validation_hook {
+        hook.started.notify_one();
+        hook.release.notified().await;
+    }
+    for ((kind, digest), (size, media_type)) in unique {
+        let Some(path) = manifest_reference_path(kind, &digest) else {
+            return Err(ManifestValidationError {
+                status: StatusCode::BAD_REQUEST,
+                code: "MANIFEST_INVALID",
+                message: "manifest contains an invalid descriptor digest".to_string(),
+            });
+        };
+        let identity = state
+            .authority
+            .identity(&path)
+            .map_err(|_| ManifestValidationError {
+                status: StatusCode::NOT_FOUND,
+                code: "MANIFEST_BLOB_UNKNOWN",
+                message: format!("manifest references unavailable descriptor {digest}"),
+            })?;
+        if identity.len != size {
+            return Err(ManifestValidationError {
+                status: StatusCode::NOT_FOUND,
+                code: "MANIFEST_BLOB_UNKNOWN",
+                message: format!("manifest descriptor {digest} has an unexpected size"),
+            });
+        }
+        let observed = hash_upload_file(&state.authority, &path, size)
+            .await
+            .map_err(|error| ManifestValidationError {
+                status: StatusCode::INTERNAL_SERVER_ERROR,
+                code: "UNKNOWN",
+                message: error,
+            })?;
+        let observed = format!("sha256:{}", hex::encode(observed.finalize()));
+        if observed != digest {
+            return Err(ManifestValidationError {
+                status: StatusCode::NOT_FOUND,
+                code: "MANIFEST_BLOB_UNKNOWN",
+                message: format!(
+                    "manifest references descriptor {digest} whose content is not trustworthy"
+                ),
+            });
+        }
+        validated.push(ValidatedManifestReference {
+            kind,
+            digest,
+            media_type,
+            identity,
+        });
+    }
+    Ok(validated)
+}
+
+fn revalidate_manifest_references(
+    state: &OciRegistryState,
+    metadata: &OciMetadata,
+    repository_name: &str,
+    validated: &[ValidatedManifestReference],
+) -> Result<(), ManifestValidationError> {
+    for reference in validated {
+        if !manifest_reference_is_member(
+            metadata,
+            repository_name,
+            reference.kind,
+            &reference.digest,
+            &reference.media_type,
+        ) {
+            return Err(ManifestValidationError {
+                status: StatusCode::CONFLICT,
+                code: "MANIFEST_INVALID",
+                message: "manifest references changed during validation; retry publication"
+                    .to_string(),
+            });
+        }
+        let path = manifest_reference_path(reference.kind, &reference.digest)
+            .expect("validated manifest digest remains canonical");
+        if state.authority.identity(&path).ok() != Some(reference.identity) {
+            return Err(ManifestValidationError {
+                status: StatusCode::CONFLICT,
+                code: "MANIFEST_INVALID",
+                message:
+                    "manifest descriptor identity changed during validation; retry publication"
+                        .to_string(),
+            });
         }
     }
     Ok(())
@@ -1629,7 +2123,7 @@ async fn put_manifest_inner(
             None,
         );
     }
-    let manifest = match parse_image_manifest(media_type, &body) {
+    let manifest = match parse_manifest(media_type, &body) {
         Ok(manifest) => manifest,
         Err(error) => return error.response(),
     };
@@ -1643,23 +2137,23 @@ async fn put_manifest_inner(
             None,
         );
     }
-    let manifest_path = manifest_path_for_digest(&state.blobs_dir, &digest)
-        .expect("computed manifest digest is canonical");
+    let manifest_path =
+        manifest_relative_for_digest(&digest).expect("computed manifest digest is canonical");
+    let snapshot = match metadata_snapshot(state).await {
+        Ok(snapshot) => snapshot,
+        Err(error) => return metadata_authority_error(&error),
+    };
+    let validated = match validate_manifest_references(state, &snapshot, name, &manifest).await {
+        Ok(validated) => validated,
+        Err(error) => return error.response(),
+    };
     let (mut metadata_guard, storage_lock, mut replacement) =
         match begin_metadata_write(state).await {
             Ok(transaction) => transaction,
             Err(error) => return metadata_authority_error(&error),
         };
-    if let Err(error) = validate_manifest_blobs(state, &replacement, name, &manifest).await {
+    if let Err(error) = revalidate_manifest_references(state, &replacement, name, &validated) {
         return error.response();
-    }
-    if let Err(error) = crate::atomic_file::write(&manifest_path, &body) {
-        return oci_error(
-            StatusCode::INTERNAL_SERVER_ERROR,
-            "UNKNOWN",
-            &format!("failed to persist OCI manifest: {error}"),
-            None,
-        );
     }
     let descriptor = ManifestDescriptor {
         digest: digest.clone(),
@@ -1673,7 +2167,32 @@ async fn put_manifest_inner(
         .manifests
         .insert(reference.to_string(), descriptor.clone());
     repository.manifests.insert(digest.clone(), descriptor);
-    if let Err(error) = persist_metadata(state, &replacement) {
+    let metadata_bytes = match serde_json::to_vec(&replacement) {
+        Ok(bytes) => bytes,
+        Err(error) => {
+            return oci_error(
+                StatusCode::INTERNAL_SERVER_ERROR,
+                "UNKNOWN",
+                &format!("failed to encode OCI metadata: {error}"),
+                None,
+            );
+        }
+    };
+    let authority = state.authority.clone();
+    let body = body.to_vec();
+    let persist = tokio::task::spawn_blocking(move || {
+        authority
+            .write(&manifest_path, &body)
+            .map_err(|error| format!("failed to persist OCI manifest: {error}"))?;
+        authority
+            .write(FsPath::new("metadata.json"), &metadata_bytes)
+            .map_err(|error| format!("failed to persist OCI metadata: {error}"))
+    })
+    .await;
+    if let Err(error) = persist
+        .map_err(|error| format!("OCI manifest persistence task failed: {error}"))
+        .and_then(|result| result)
+    {
         return oci_error(StatusCode::INTERNAL_SERVER_ERROR, "UNKNOWN", &error, None);
     }
     *metadata_guard = replacement;
@@ -1722,7 +2241,7 @@ async fn delete_manifest_inner(state: &OciRegistryState, name: &str, reference: 
     } else {
         repository.manifests.remove(reference);
     }
-    if let Err(error) = persist_metadata(state, &replacement) {
+    if let Err(error) = persist_metadata_async(state, &replacement).await {
         return oci_error(StatusCode::INTERNAL_SERVER_ERROR, "UNKNOWN", &error, None);
     }
     *metadata_guard = replacement;
@@ -1809,15 +2328,23 @@ fn sha256_hex(digest: &str) -> Option<&str> {
 /// separators, dot components, alternate algorithms, and encoded traversal
 /// payloads are rejected before any filesystem operation.
 fn blob_path_for_digest(blobs_dir: &FsPath, digest: &str) -> Option<PathBuf> {
-    let encoded = sha256_hex(digest)?;
-    let path = blobs_dir.join(format!("sha256_{encoded}"));
+    let path = blobs_dir.join(blob_relative_for_digest(digest)?);
     (path.parent() == Some(blobs_dir)).then_some(path)
 }
 
-fn manifest_path_for_digest(blobs_dir: &FsPath, digest: &str) -> Option<PathBuf> {
+fn blob_relative_for_digest(digest: &str) -> Option<PathBuf> {
     let encoded = sha256_hex(digest)?;
-    let manifests_dir = blobs_dir.join("manifests");
-    Some(manifests_dir.join(format!("sha256_{encoded}")))
+    Some(PathBuf::from(format!("sha256_{encoded}")))
+}
+
+#[cfg(test)]
+fn manifest_path_for_digest(blobs_dir: &FsPath, digest: &str) -> Option<PathBuf> {
+    Some(blobs_dir.join(manifest_relative_for_digest(digest)?))
+}
+
+fn manifest_relative_for_digest(digest: &str) -> Option<PathBuf> {
+    let encoded = sha256_hex(digest)?;
+    Some(PathBuf::from("manifests").join(format!("sha256_{encoded}")))
 }
 
 fn digest_invalid(message: &str, location: Option<&str>) -> Response {
@@ -2295,6 +2822,130 @@ mod tests {
         assert_eq!(durable_upload_count(&state).await, 0);
         let blob_path = blob_path_for_digest(&state.blobs_dir, &digest).unwrap();
         assert_eq!(std::fs::read(blob_path).unwrap(), body);
+    }
+
+    #[tokio::test]
+    async fn upload_status_and_authenticated_cancel_reclaim_durable_quota() {
+        let root = tempfile::tempdir().unwrap();
+        let blobs_dir = root.path().join("oci");
+        std::fs::create_dir_all(&blobs_dir).unwrap();
+        let mut configured = OciRegistryState::new(blobs_dir, Some("registry-secret".to_string()));
+        configured.max_active_upload_bytes = 3;
+        let state = Arc::new(configured);
+        let location = initiate(state.clone()).await;
+        let id = upload_id_from_location(&location).to_string();
+
+        let patched = oci_routes(state.clone())
+            .oneshot(authenticated_request("PATCH", &location, Body::from("abc")))
+            .await
+            .unwrap();
+        assert_eq!(patched.status(), StatusCode::ACCEPTED);
+
+        let status = oci_routes(state.clone())
+            .oneshot(Request::get(&location).body(Body::empty()).unwrap())
+            .await
+            .unwrap();
+        assert_eq!(status.status(), StatusCode::NO_CONTENT);
+        assert_eq!(status.headers()[header::RANGE], "0-2");
+        assert_eq!(status.headers()["docker-upload-uuid"], id);
+
+        let unauthenticated = oci_routes(state.clone())
+            .oneshot(Request::delete(&location).body(Body::empty()).unwrap())
+            .await
+            .unwrap();
+        assert_eq!(unauthenticated.status(), StatusCode::UNAUTHORIZED);
+        let cancelled = oci_routes(state.clone())
+            .oneshot(authenticated_request("DELETE", &location, Body::empty()))
+            .await
+            .unwrap();
+        assert_eq!(cancelled.status(), StatusCode::NO_CONTENT);
+        assert_eq!(durable_upload_count(&state).await, 0);
+
+        let replacement = initiate(state).await;
+        assert_ne!(replacement, location);
+    }
+
+    #[tokio::test]
+    async fn final_put_rejects_stale_content_range_without_mutating_upload() {
+        let (_root, state) = registry_state_with_token(Some("registry-secret"));
+        let location = initiate(state.clone()).await;
+        let patched = oci_routes(state.clone())
+            .oneshot(
+                Request::patch(&location)
+                    .header(header::AUTHORIZATION, "Bearer registry-secret")
+                    .header(header::CONTENT_RANGE, "0-4")
+                    .body(Body::from("hello"))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(patched.status(), StatusCode::ACCEPTED);
+
+        let complete = b"helloworld";
+        let digest = format!("sha256:{}", sha2_hex(complete));
+        let rejected = oci_routes(state.clone())
+            .oneshot(
+                Request::put(format!("{location}?digest={digest}"))
+                    .header(header::AUTHORIZATION, "Bearer registry-secret")
+                    .header(header::CONTENT_RANGE, "0-4")
+                    .body(Body::from("world"))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(rejected.status(), StatusCode::RANGE_NOT_SATISFIABLE);
+        let id = upload_id_from_location(&location);
+        assert_eq!(
+            state
+                .authority
+                .read(&upload_data_relative(id).unwrap())
+                .unwrap(),
+            b"hello"
+        );
+        assert_eq!(read_upload_session(&state, id).unwrap().unwrap().size, 5);
+
+        let accepted = oci_routes(state.clone())
+            .oneshot(
+                Request::put(format!("{location}?digest={digest}"))
+                    .header(header::AUTHORIZATION, "Bearer registry-secret")
+                    .header(header::CONTENT_RANGE, "5-9")
+                    .body(Body::from("world"))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(accepted.status(), StatusCode::CREATED);
+    }
+
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn live_oci_state_cannot_be_redirected_by_root_replacement() {
+        let (root, state) = registry_state_with_token(Some("registry-secret"));
+        let original = root.path().join("oci-retained");
+        std::fs::rename(&state.blobs_dir, &original).unwrap();
+        std::fs::create_dir(&state.blobs_dir).unwrap();
+
+        let location = initiate(state.clone()).await;
+        let body = b"retained-root-blob";
+        let digest = format!("sha256:{}", sha2_hex(body));
+        let completed = oci_routes(state)
+            .oneshot(authenticated_request(
+                "PUT",
+                &format!("{location}?digest={digest}"),
+                Body::from(body.as_slice()),
+            ))
+            .await
+            .unwrap();
+        assert_eq!(completed.status(), StatusCode::CREATED);
+        assert_eq!(
+            std::fs::read(original.join(blob_relative_for_digest(&digest).unwrap())).unwrap(),
+            body
+        );
+        assert!(!root
+            .path()
+            .join("oci")
+            .join(blob_relative_for_digest(&digest).unwrap())
+            .exists());
     }
 
     #[tokio::test]
@@ -2946,6 +3597,158 @@ mod tests {
         assert!(state.metadata.read().await.repositories["demo"]
             .manifests
             .contains_key("latest"));
+    }
+
+    #[tokio::test]
+    async fn oci_indexes_and_docker_manifest_lists_validate_and_round_trip() {
+        let (_root, state) = registry_state_with_token(Some("registry-secret"));
+        for (sequence, (index_media_type, child_media_type)) in [
+            (OCI_INDEX_MEDIA_TYPE, DEFAULT_MANIFEST_MEDIA_TYPE),
+            (DOCKER_MANIFEST_LIST_MEDIA_TYPE, DOCKER_MANIFEST_MEDIA_TYPE),
+        ]
+        .into_iter()
+        .enumerate()
+        {
+            let child_tag = format!("child-{sequence}");
+            let (child_digest, child_body) =
+                seed_valid_manifest(&state, "demo", &child_tag, child_media_type, &child_tag).await;
+            let index_body = serde_json::to_vec(&serde_json::json!({
+                "schemaVersion": 2,
+                "mediaType": index_media_type,
+                "manifests": [{
+                    "mediaType": child_media_type,
+                    "digest": child_digest,
+                    "size": child_body.len(),
+                    "platform": { "architecture": "arm64", "os": "linux" }
+                }]
+            }))
+            .unwrap();
+            let tag = format!("multi-{sequence}");
+            let published = oci_routes(state.clone())
+                .oneshot(
+                    Request::put(format!("/v2/demo/manifests/{tag}"))
+                        .header(header::AUTHORIZATION, "Bearer registry-secret")
+                        .header(header::CONTENT_TYPE, index_media_type)
+                        .body(Body::from(index_body.clone()))
+                        .unwrap(),
+                )
+                .await
+                .unwrap();
+            assert_eq!(
+                published.status(),
+                StatusCode::CREATED,
+                "{index_media_type}"
+            );
+
+            let fetched = oci_routes(state.clone())
+                .oneshot(
+                    Request::get(format!("/v2/demo/manifests/{tag}"))
+                        .body(Body::empty())
+                        .unwrap(),
+                )
+                .await
+                .unwrap();
+            assert_eq!(fetched.status(), StatusCode::OK);
+            assert_eq!(fetched.headers()[header::CONTENT_TYPE], index_media_type);
+            assert_eq!(
+                to_bytes(fetched.into_body(), MAX_OCI_MANIFEST_SIZE)
+                    .await
+                    .unwrap()
+                    .as_ref(),
+                index_body.as_slice()
+            );
+        }
+
+        let missing_digest = format!("sha256:{}", "0".repeat(SHA256_HEX_LEN));
+        let missing = serde_json::to_vec(&serde_json::json!({
+            "schemaVersion": 2,
+            "mediaType": OCI_INDEX_MEDIA_TYPE,
+            "manifests": [{
+                "mediaType": DEFAULT_MANIFEST_MEDIA_TYPE,
+                "digest": missing_digest,
+                "size": 1,
+            }]
+        }))
+        .unwrap();
+        let rejected = oci_routes(state)
+            .oneshot(
+                Request::put("/v2/demo/manifests/missing-child")
+                    .header(header::AUTHORIZATION, "Bearer registry-secret")
+                    .header(header::CONTENT_TYPE, OCI_INDEX_MEDIA_TYPE)
+                    .body(Body::from(missing))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(rejected.status(), StatusCode::NOT_FOUND);
+        assert_eq!(error_code(rejected).await, "MANIFEST_BLOB_UNKNOWN");
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn manifest_reference_validation_does_not_hold_the_metadata_write_lock() {
+        let (_root, state) = registry_state_with_token(Some("registry-secret"));
+        seed_valid_manifest(
+            &state,
+            "demo",
+            "stable",
+            DEFAULT_MANIFEST_MEDIA_TYPE,
+            "stable",
+        )
+        .await;
+        let config = b"new-config";
+        let layer = b"new-layer";
+        let config_digest = seed_blob(&state, "demo", config).await;
+        let layer_digest = seed_blob(&state, "demo", layer).await;
+        let body = image_manifest_body(
+            DEFAULT_MANIFEST_MEDIA_TYPE,
+            &config_digest,
+            config.len(),
+            &layer_digest,
+            layer.len(),
+            "new",
+        );
+        let hook = Arc::new(ManifestValidationHook {
+            started: tokio::sync::Notify::new(),
+            release: tokio::sync::Notify::new(),
+        });
+        *state
+            .manifest_validation_hook
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner) = Some(hook.clone());
+
+        let publisher = {
+            let state = state.clone();
+            tokio::spawn(async move {
+                oci_routes(state)
+                    .oneshot(
+                        Request::put("/v2/demo/manifests/new")
+                            .header(header::AUTHORIZATION, "Bearer registry-secret")
+                            .header(header::CONTENT_TYPE, DEFAULT_MANIFEST_MEDIA_TYPE)
+                            .body(Body::from(body))
+                            .unwrap(),
+                    )
+                    .await
+                    .unwrap()
+                    .status()
+            })
+        };
+        tokio::time::timeout(Duration::from_secs(1), hook.started.notified())
+            .await
+            .unwrap();
+        let public_read = tokio::time::timeout(
+            Duration::from_secs(1),
+            oci_routes(state.clone()).oneshot(
+                Request::get("/v2/demo/manifests/stable")
+                    .body(Body::empty())
+                    .unwrap(),
+            ),
+        )
+        .await
+        .unwrap()
+        .unwrap();
+        assert_eq!(public_read.status(), StatusCode::OK);
+        hook.release.notify_one();
+        assert_eq!(publisher.await.unwrap(), StatusCode::CREATED);
     }
 
     #[tokio::test]

--- a/crates/kin-registry/src/oci.rs
+++ b/crates/kin-registry/src/oci.rs
@@ -7,21 +7,22 @@
 //! registry write token and fails closed when no token is configured.
 
 use axum::{
-    body::{Body, Bytes},
-    extract::{DefaultBodyLimit, Path, Query, State},
+    body::{to_bytes, Body, Bytes},
+    extract::{Path, State},
     http::{header, HeaderMap, HeaderValue, Method, Request, StatusCode},
     middleware::{self, Next},
     response::{IntoResponse, Json, Response},
-    routing::{get, head, post, put},
+    routing::{any, get},
     Router,
 };
-use serde::Deserialize;
+use serde::{Deserialize, Serialize};
 use sha2::{Digest, Sha256};
-use std::collections::HashMap;
+use std::collections::{BTreeSet, HashMap};
 use std::path::{Path as FsPath, PathBuf};
 use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::Arc;
 use std::time::{Duration, Instant, SystemTime};
+use tokio::io::AsyncReadExt;
 use tokio::sync::RwLock;
 
 const SHA256_HEX_LEN: usize = 64;
@@ -32,6 +33,9 @@ const MAX_OCI_BLOB_SIZE: usize = 512 * 1024 * 1024;
 const MAX_OCI_MANIFEST_SIZE: usize = 4 * 1024 * 1024;
 const MAX_ACTIVE_UPLOADS: usize = 1024;
 const UPLOAD_TTL: Duration = Duration::from_secs(15 * 60);
+const OCI_METADATA_VERSION: u32 = 1;
+const BLOB_STREAM_CHUNK_SIZE: usize = 64 * 1024;
+const DEFAULT_MANIFEST_MEDIA_TYPE: &str = "application/vnd.oci.image.manifest.v1+json";
 
 static UPLOAD_SEQUENCE: AtomicU64 = AtomicU64::new(0);
 
@@ -41,22 +45,77 @@ struct PendingUpload {
     data: Vec<u8>,
 }
 
+#[derive(Clone, Debug, Deserialize, Serialize)]
+struct ManifestDescriptor {
+    digest: String,
+    media_type: String,
+}
+
+#[derive(Clone, Debug, Default, Deserialize, Serialize)]
+struct RepositoryMetadata {
+    blobs: BTreeSet<String>,
+    manifests: HashMap<String, ManifestDescriptor>,
+}
+
+#[derive(Clone, Debug, Deserialize, Serialize)]
+struct OciMetadata {
+    version: u32,
+    repositories: HashMap<String, RepositoryMetadata>,
+}
+
+impl Default for OciMetadata {
+    fn default() -> Self {
+        Self {
+            version: OCI_METADATA_VERSION,
+            repositories: HashMap::new(),
+        }
+    }
+}
+
 /// Shared state for the OCI registry routes.
 pub struct OciRegistryState {
     blobs_dir: PathBuf,
-    /// (repository, reference) -> manifest bytes
-    manifests: RwLock<HashMap<(String, String), Vec<u8>>>,
+    metadata_path: PathBuf,
+    metadata: RwLock<OciMetadata>,
+    /// A malformed durable index is an authority failure, never an empty registry.
+    load_error: Option<String>,
     /// upload ID -> bounded, expiring partial data
     uploads: RwLock<HashMap<String, PendingUpload>>,
-    /// Shared secret for OCI writes. `None` disables every mutation.
+    /// OCI-specific secret for writes. `None` disables every mutation.
     write_token: Option<String>,
 }
 
 impl OciRegistryState {
     pub fn new(blobs_dir: PathBuf, write_token: Option<String>) -> Self {
+        let metadata_path = blobs_dir.join("metadata.json");
+        let (metadata, load_error) = match std::fs::read(&metadata_path) {
+            Ok(bytes) => match serde_json::from_slice::<OciMetadata>(&bytes) {
+                Ok(metadata) if metadata.version == OCI_METADATA_VERSION => (metadata, None),
+                Ok(metadata) => (
+                    OciMetadata::default(),
+                    Some(format!(
+                        "unsupported OCI metadata version {} (expected {OCI_METADATA_VERSION})",
+                        metadata.version
+                    )),
+                ),
+                Err(error) => (
+                    OciMetadata::default(),
+                    Some(format!("cannot decode OCI metadata: {error}")),
+                ),
+            },
+            Err(error) if error.kind() == std::io::ErrorKind::NotFound => {
+                (OciMetadata::default(), None)
+            }
+            Err(error) => (
+                OciMetadata::default(),
+                Some(format!("cannot read OCI metadata: {error}")),
+            ),
+        };
         Self {
             blobs_dir,
-            manifests: RwLock::new(HashMap::new()),
+            metadata_path,
+            metadata: RwLock::new(metadata),
+            load_error,
             uploads: RwLock::new(HashMap::new()),
             write_token: write_token
                 .map(|token| token.trim().to_string())
@@ -67,32 +126,18 @@ impl OciRegistryState {
 
 /// Create axum router for OCI distribution endpoints.
 pub fn oci_routes(state: Arc<OciRegistryState>) -> Router {
-    let public = Router::new()
+    Router::new()
         .route("/v2/", get(version_check))
-        .route("/v2/{name}/blobs/{digest}", head(check_blob).get(get_blob))
-        .route("/v2/{name}/manifests/{reference}", get(get_manifest));
-
-    // The auth middleware executes before body extraction, so an unauthorized
-    // caller cannot make the handlers buffer an upload. Axum's body limits also
-    // cap chunked requests for which Content-Length cannot be trusted.
-    let writes = Router::new()
-        .route("/v2/{name}/blobs/uploads/", post(initiate_upload))
-        .route(
-            "/v2/{name}/blobs/uploads/{id}",
-            put(complete_upload).layer(DefaultBodyLimit::max(MAX_OCI_BLOB_SIZE)),
-        )
-        .route(
-            "/v2/{name}/manifests/{reference}",
-            put(put_manifest)
-                .delete(delete_manifest)
-                .layer(DefaultBodyLimit::max(MAX_OCI_MANIFEST_SIZE)),
-        )
+        // A final wildcard is required because OCI repository names commonly
+        // contain namespace slashes (for example `firelock-ai/kin`). The
+        // dispatcher parses fixed protocol markers from the right and validates
+        // every repository segment before any storage access.
+        .route("/v2/{*path}", any(dispatch))
         .route_layer(middleware::from_fn_with_state(
             Arc::clone(&state),
             authorize_oci_write,
-        ));
-
-    Router::new().merge(public).merge(writes).with_state(state)
+        ))
+        .with_state(state)
 }
 
 fn constant_time_eq(a: &[u8], b: &[u8]) -> bool {
@@ -111,11 +156,20 @@ async fn authorize_oci_write(
     request: Request<Body>,
     next: Next,
 ) -> Response {
+    if matches!(*request.method(), Method::GET | Method::HEAD) {
+        return next.run(request).await;
+    }
+    if !matches!(
+        *request.method(),
+        Method::POST | Method::PUT | Method::DELETE
+    ) {
+        return next.run(request).await;
+    }
     let Some(expected) = state.write_token.as_deref() else {
         return oci_error(
             StatusCode::SERVICE_UNAVAILABLE,
             "DENIED",
-            "OCI registry writes are disabled: no registry token is configured",
+            "OCI registry writes are disabled: no OCI write token is configured",
             None,
         );
     };
@@ -202,79 +256,194 @@ async fn version_check() -> impl IntoResponse {
     StatusCode::OK
 }
 
-/// HEAD /v2/{name}/blobs/{digest} -- check if blob exists.
-async fn check_blob(
+async fn dispatch(
     State(state): State<Arc<OciRegistryState>>,
-    Path((name, digest)): Path<(String, String)>,
+    Path(path): Path<String>,
+    request: Request<Body>,
 ) -> Response {
-    if !valid_repository_name(&name) {
-        return oci_error(
-            StatusCode::BAD_REQUEST,
-            "NAME_INVALID",
-            "invalid OCI repository name",
-            None,
-        );
+    let method = request.method().clone();
+
+    if method == Method::POST {
+        if let Some(repository) = path.strip_suffix("/blobs/uploads/") {
+            return initiate_upload_inner(&state, repository).await;
+        }
     }
-    let Some(blob_path) = blob_path_for_digest(&state.blobs_dir, &digest) else {
-        return digest_invalid("invalid non-canonical blob digest", None);
-    };
-    if blob_path.is_file() {
-        let size = std::fs::metadata(&blob_path)
-            .map(|metadata| metadata.len())
-            .unwrap_or(0);
-        let mut response = StatusCode::OK.into_response();
-        insert_header(
-            response.headers_mut(),
-            header::HeaderName::from_static("docker-content-digest"),
-            &digest,
-        );
-        insert_header(
-            response.headers_mut(),
-            header::CONTENT_LENGTH,
-            &size.to_string(),
-        );
-        response
-    } else {
-        StatusCode::NOT_FOUND.into_response()
+
+    if let Some((repository, upload_id)) = path.rsplit_once("/blobs/uploads/") {
+        if method == Method::PUT {
+            let digest = request
+                .uri()
+                .query()
+                .and_then(|query| query_parameter(query, "digest"));
+            let body = match read_bounded_body(request.into_body(), MAX_OCI_BLOB_SIZE).await {
+                Ok(body) => body,
+                Err(response) => return response,
+            };
+            return complete_upload_inner(&state, repository, upload_id, digest.as_deref(), body)
+                .await;
+        }
+        return StatusCode::METHOD_NOT_ALLOWED.into_response();
     }
+
+    if let Some((repository, digest)) = path.rsplit_once("/blobs/") {
+        return match method {
+            Method::GET => get_blob_inner(&state, repository, digest, false).await,
+            Method::HEAD => get_blob_inner(&state, repository, digest, true).await,
+            _ => StatusCode::METHOD_NOT_ALLOWED.into_response(),
+        };
+    }
+
+    if let Some((repository, reference)) = path.rsplit_once("/manifests/") {
+        return match method {
+            Method::GET => get_manifest_inner(&state, repository, reference, false).await,
+            Method::HEAD => get_manifest_inner(&state, repository, reference, true).await,
+            Method::PUT => {
+                let media_type = request
+                    .headers()
+                    .get(header::CONTENT_TYPE)
+                    .and_then(|value| value.to_str().ok())
+                    .unwrap_or(DEFAULT_MANIFEST_MEDIA_TYPE)
+                    .to_string();
+                let body = match read_bounded_body(request.into_body(), MAX_OCI_MANIFEST_SIZE).await
+                {
+                    Ok(body) => body,
+                    Err(response) => return response,
+                };
+                put_manifest_inner(&state, repository, reference, &media_type, body).await
+            }
+            Method::DELETE => delete_manifest_inner(&state, repository, reference).await,
+            _ => StatusCode::METHOD_NOT_ALLOWED.into_response(),
+        };
+    }
+
+    StatusCode::NOT_FOUND.into_response()
 }
 
-/// GET /v2/{name}/blobs/{digest} -- pull a blob by digest.
-async fn get_blob(
-    State(state): State<Arc<OciRegistryState>>,
-    Path((name, digest)): Path<(String, String)>,
-) -> Response {
-    if !valid_repository_name(&name) {
-        return oci_error(
-            StatusCode::BAD_REQUEST,
-            "NAME_INVALID",
-            "invalid OCI repository name",
+async fn read_bounded_body(body: Body, limit: usize) -> Result<Bytes, Response> {
+    to_bytes(body, limit).await.map_err(|_| {
+        oci_error(
+            StatusCode::PAYLOAD_TOO_LARGE,
+            "SIZE_INVALID",
+            "request body exceeds the configured OCI limit",
             None,
-        );
-    }
-    let Some(blob_path) = blob_path_for_digest(&state.blobs_dir, &digest) else {
-        return digest_invalid("invalid non-canonical blob digest", None);
-    };
-    match std::fs::read(&blob_path) {
-        Ok(bytes) => (
-            StatusCode::OK,
-            [
-                (header::CONTENT_TYPE.as_str(), "application/octet-stream"),
-                ("docker-content-digest", digest.as_str()),
-            ],
-            bytes,
         )
-            .into_response(),
-        Err(_) => StatusCode::NOT_FOUND.into_response(),
-    }
+    })
 }
 
-/// POST /v2/{name}/blobs/uploads/ -- initiate a blob upload.
-async fn initiate_upload(
-    State(state): State<Arc<OciRegistryState>>,
-    Path(name): Path<String>,
+fn query_parameter(query: &str, wanted: &str) -> Option<String> {
+    query.split('&').find_map(|pair| {
+        let (key, value) = pair.split_once('=')?;
+        (key == wanted).then(|| {
+            percent_encoding::percent_decode_str(value)
+                .decode_utf8()
+                .ok()
+                .map(|value| value.into_owned())
+        })?
+    })
+}
+
+fn metadata_error(state: &OciRegistryState) -> Option<Response> {
+    state.load_error.as_ref().map(|error| {
+        oci_error(
+            StatusCode::INTERNAL_SERVER_ERROR,
+            "UNKNOWN",
+            &format!("OCI metadata authority is unavailable: {error}"),
+            None,
+        )
+    })
+}
+
+fn persist_metadata(state: &OciRegistryState, metadata: &OciMetadata) -> Result<(), String> {
+    let bytes = serde_json::to_vec(metadata)
+        .map_err(|error| format!("failed to encode OCI metadata: {error}"))?;
+    crate::atomic_file::write(&state.metadata_path, &bytes)
+        .map_err(|error| format!("failed to persist OCI metadata: {error}"))
+}
+
+/// HEAD /v2/{name}/blobs/{digest} -- check if blob exists.
+async fn get_blob_inner(
+    state: &OciRegistryState,
+    name: &str,
+    digest: &str,
+    head_only: bool,
 ) -> Response {
-    if !valid_repository_name(&name) {
+    if let Some(error) = metadata_error(state) {
+        return error;
+    }
+    if !valid_repository_name(name) {
+        return oci_error(
+            StatusCode::BAD_REQUEST,
+            "NAME_INVALID",
+            "invalid OCI repository name",
+            None,
+        );
+    }
+    let Some(blob_path) = blob_path_for_digest(&state.blobs_dir, digest) else {
+        return digest_invalid("invalid non-canonical blob digest", None);
+    };
+    let is_member = state
+        .metadata
+        .read()
+        .await
+        .repositories
+        .get(name)
+        .is_some_and(|repository| repository.blobs.contains(digest));
+    if !is_member {
+        return StatusCode::NOT_FOUND.into_response();
+    }
+    let file = match tokio::fs::File::open(&blob_path).await {
+        Ok(file) => file,
+        Err(_) => return StatusCode::NOT_FOUND.into_response(),
+    };
+    let size = match file.metadata().await {
+        Ok(metadata) => metadata.len(),
+        Err(_) => return StatusCode::NOT_FOUND.into_response(),
+    };
+    let body = if head_only {
+        Body::empty()
+    } else {
+        let stream = async_stream::stream! {
+            let mut file = file;
+            let mut buffer = vec![0u8; BLOB_STREAM_CHUNK_SIZE];
+            loop {
+                match file.read(&mut buffer).await {
+                    Ok(0) => break,
+                    Ok(read) => {
+                        yield Ok::<Bytes, std::io::Error>(Bytes::copy_from_slice(&buffer[..read]));
+                    }
+                    Err(error) => {
+                        yield Err::<Bytes, std::io::Error>(error);
+                        break;
+                    }
+                }
+            }
+        };
+        Body::from_stream(stream)
+    };
+    let mut response = (StatusCode::OK, body).into_response();
+    insert_header(
+        response.headers_mut(),
+        header::CONTENT_TYPE,
+        "application/octet-stream",
+    );
+    insert_header(
+        response.headers_mut(),
+        header::HeaderName::from_static("docker-content-digest"),
+        digest,
+    );
+    insert_header(
+        response.headers_mut(),
+        header::CONTENT_LENGTH,
+        &size.to_string(),
+    );
+    response
+}
+
+async fn initiate_upload_inner(state: &OciRegistryState, name: &str) -> Response {
+    if let Some(error) = metadata_error(state) {
+        return error;
+    }
+    if !valid_repository_name(name) {
         return oci_error(
             StatusCode::BAD_REQUEST,
             "NAME_INVALID",
@@ -283,7 +452,7 @@ async fn initiate_upload(
         );
     }
 
-    let upload_id = new_upload_id(&name);
+    let upload_id = new_upload_id(name);
     let mut uploads = state.uploads.write().await;
     prune_expired_uploads(&mut uploads);
     if uploads.len() >= MAX_ACTIVE_UPLOADS {
@@ -297,33 +466,31 @@ async fn initiate_upload(
     uploads.insert(
         upload_id.clone(),
         PendingUpload {
-            repository: name.clone(),
+            repository: name.to_string(),
             created_at: Instant::now(),
             data: Vec::new(),
         },
     );
     drop(uploads);
 
-    let location = upload_location(&name, &upload_id);
+    let location = upload_location(name, &upload_id);
     let mut response = StatusCode::ACCEPTED.into_response();
     insert_header(response.headers_mut(), header::LOCATION, &location);
     response
 }
 
-#[derive(Debug, Default, Deserialize)]
-struct CompleteUploadQuery {
-    digest: Option<String>,
-}
-
-/// PUT /v2/{name}/blobs/uploads/{id}?digest=sha256:... -- complete upload.
-async fn complete_upload(
-    State(state): State<Arc<OciRegistryState>>,
-    Path((name, id)): Path<(String, String)>,
-    Query(query): Query<CompleteUploadQuery>,
+async fn complete_upload_inner(
+    state: &OciRegistryState,
+    name: &str,
+    id: &str,
+    expected_digest: Option<&str>,
     body: Bytes,
 ) -> Response {
-    let location = upload_location(&name, &id);
-    if !valid_repository_name(&name) || !valid_upload_id(&id) {
+    if let Some(error) = metadata_error(state) {
+        return error;
+    }
+    let location = upload_location(name, id);
+    if !valid_repository_name(name) || !valid_upload_id(id) {
         return oci_error(
             StatusCode::BAD_REQUEST,
             "BLOB_UPLOAD_INVALID",
@@ -331,7 +498,7 @@ async fn complete_upload(
             Some(&location),
         );
     }
-    let Some(expected_digest) = query.digest.as_deref() else {
+    let Some(expected_digest) = expected_digest else {
         return digest_invalid(
             "completion requires a digest query parameter",
             Some(&location),
@@ -345,7 +512,7 @@ async fn complete_upload(
     }
 
     let mut uploads = state.uploads.write().await;
-    let Some(pending) = uploads.get(&id) else {
+    let Some(pending) = uploads.get(id) else {
         return oci_error(
             StatusCode::NOT_FOUND,
             "BLOB_UPLOAD_UNKNOWN",
@@ -354,7 +521,7 @@ async fn complete_upload(
         );
     };
     if pending.repository != name || pending.created_at.elapsed() >= UPLOAD_TTL {
-        uploads.remove(&id);
+        uploads.remove(id);
         return oci_error(
             StatusCode::NOT_FOUND,
             "BLOB_UPLOAD_UNKNOWN",
@@ -391,7 +558,7 @@ async fn complete_upload(
     }
 
     let mut pending = uploads
-        .remove(&id)
+        .remove(id)
         .expect("upload remained present while write lock was held");
     drop(uploads);
     let partial_len = pending.data.len();
@@ -408,7 +575,7 @@ async fn complete_upload(
         // Preserve the pre-completion upload state so the same final request
         // can be retried after the storage failure without duplicating bytes.
         pending.data.truncate(partial_len);
-        state.uploads.write().await.insert(id, pending);
+        state.uploads.write().await.insert(id.to_string(), pending);
         return oci_error(
             StatusCode::INTERNAL_SERVER_ERROR,
             "UNKNOWN",
@@ -416,6 +583,31 @@ async fn complete_upload(
             Some(&location),
         );
     }
+
+    // The content-addressed object is global, but public availability is scoped
+    // to the repository that completed the upload. Persist membership before
+    // acknowledging the write; an orphaned content file after a crash is safe
+    // because reads consult this durable authority first.
+    let mut metadata_guard = state.metadata.write().await;
+    let mut replacement = metadata_guard.clone();
+    replacement
+        .repositories
+        .entry(name.to_string())
+        .or_default()
+        .blobs
+        .insert(computed_digest.clone());
+    if let Err(error) = persist_metadata(state, &replacement) {
+        pending.data.truncate(partial_len);
+        state.uploads.write().await.insert(id.to_string(), pending);
+        return oci_error(
+            StatusCode::INTERNAL_SERVER_ERROR,
+            "UNKNOWN",
+            &error,
+            Some(&location),
+        );
+    }
+    *metadata_guard = replacement;
+    drop(metadata_guard);
 
     let blob_location = format!("/v2/{name}/blobs/{computed_digest}");
     let mut response = StatusCode::CREATED.into_response();
@@ -428,12 +620,16 @@ async fn complete_upload(
     response
 }
 
-/// GET /v2/{name}/manifests/{reference} -- pull a manifest.
-async fn get_manifest(
-    State(state): State<Arc<OciRegistryState>>,
-    Path((name, reference)): Path<(String, String)>,
+async fn get_manifest_inner(
+    state: &OciRegistryState,
+    name: &str,
+    reference: &str,
+    head_only: bool,
 ) -> Response {
-    if !valid_repository_name(&name) || !valid_manifest_reference(&reference) {
+    if let Some(error) = metadata_error(state) {
+        return error;
+    }
+    if !valid_repository_name(name) || !valid_manifest_reference(reference) {
         return oci_error(
             StatusCode::BAD_REQUEST,
             "MANIFEST_INVALID",
@@ -441,28 +637,69 @@ async fn get_manifest(
             None,
         );
     }
-    let manifests = state.manifests.read().await;
-    match manifests.get(&(name, reference)) {
-        Some(bytes) => (
-            StatusCode::OK,
-            [(
-                header::CONTENT_TYPE.as_str(),
-                "application/vnd.oci.image.manifest.v1+json",
-            )],
-            bytes.clone(),
-        )
-            .into_response(),
-        None => StatusCode::NOT_FOUND.into_response(),
-    }
+    let descriptor = state
+        .metadata
+        .read()
+        .await
+        .repositories
+        .get(name)
+        .and_then(|repository| repository.manifests.get(reference))
+        .cloned();
+    let Some(descriptor) = descriptor else {
+        return StatusCode::NOT_FOUND.into_response();
+    };
+    let Some(path) = manifest_path_for_digest(&state.blobs_dir, &descriptor.digest) else {
+        return oci_error(
+            StatusCode::INTERNAL_SERVER_ERROR,
+            "UNKNOWN",
+            "stored OCI manifest digest is invalid",
+            None,
+        );
+    };
+    let bytes = match tokio::fs::read(path).await {
+        Ok(bytes) => bytes,
+        Err(error) => {
+            return oci_error(
+                StatusCode::INTERNAL_SERVER_ERROR,
+                "UNKNOWN",
+                &format!("stored OCI manifest is unavailable: {error}"),
+                None,
+            );
+        }
+    };
+    let length = bytes.len();
+    let body = if head_only { Vec::new() } else { bytes };
+    let mut response = (StatusCode::OK, body).into_response();
+    insert_header(
+        response.headers_mut(),
+        header::CONTENT_TYPE,
+        &descriptor.media_type,
+    );
+    insert_header(
+        response.headers_mut(),
+        header::HeaderName::from_static("docker-content-digest"),
+        &descriptor.digest,
+    );
+    insert_header(
+        response.headers_mut(),
+        header::CONTENT_LENGTH,
+        &length.to_string(),
+    );
+    response
 }
 
 /// PUT /v2/{name}/manifests/{reference} -- push a manifest.
-async fn put_manifest(
-    State(state): State<Arc<OciRegistryState>>,
-    Path((name, reference)): Path<(String, String)>,
+async fn put_manifest_inner(
+    state: &OciRegistryState,
+    name: &str,
+    reference: &str,
+    media_type: &str,
     body: Bytes,
 ) -> Response {
-    if !valid_repository_name(&name) || !valid_manifest_reference(&reference) {
+    if let Some(error) = metadata_error(state) {
+        return error;
+    }
+    if !valid_repository_name(name) || !valid_manifest_reference(reference) {
         return oci_error(
             StatusCode::BAD_REQUEST,
             "MANIFEST_INVALID",
@@ -482,6 +719,19 @@ async fn put_manifest(
             None,
         );
     }
+    if media_type.is_empty()
+        || media_type.len() > 255
+        || !media_type
+            .bytes()
+            .all(|byte| byte.is_ascii_graphic() || byte == b' ')
+    {
+        return oci_error(
+            StatusCode::BAD_REQUEST,
+            "MANIFEST_INVALID",
+            "manifest Content-Type is invalid",
+            None,
+        );
+    }
 
     let digest = format!("sha256:{}", sha2_hex(&body));
     if reference.starts_with("sha256:") && reference != digest {
@@ -490,10 +740,35 @@ async fn put_manifest(
             None,
         );
     }
-    let mut manifests = state.manifests.write().await;
-    manifests.insert((name.clone(), reference), body.to_vec());
-    manifests.insert((name.clone(), digest.clone()), body.to_vec());
-    drop(manifests);
+    let manifest_path = manifest_path_for_digest(&state.blobs_dir, &digest)
+        .expect("computed manifest digest is canonical");
+    if let Err(error) = crate::atomic_file::write(&manifest_path, &body) {
+        return oci_error(
+            StatusCode::INTERNAL_SERVER_ERROR,
+            "UNKNOWN",
+            &format!("failed to persist OCI manifest: {error}"),
+            None,
+        );
+    }
+    let descriptor = ManifestDescriptor {
+        digest: digest.clone(),
+        media_type: media_type.to_string(),
+    };
+    let mut metadata_guard = state.metadata.write().await;
+    let mut replacement = metadata_guard.clone();
+    let repository = replacement
+        .repositories
+        .entry(name.to_string())
+        .or_default();
+    repository
+        .manifests
+        .insert(reference.to_string(), descriptor.clone());
+    repository.manifests.insert(digest.clone(), descriptor);
+    if let Err(error) = persist_metadata(state, &replacement) {
+        return oci_error(StatusCode::INTERNAL_SERVER_ERROR, "UNKNOWN", &error, None);
+    }
+    *metadata_guard = replacement;
+    drop(metadata_guard);
 
     let mut response = StatusCode::CREATED.into_response();
     insert_header(
@@ -510,11 +785,11 @@ async fn put_manifest(
 }
 
 /// DELETE /v2/{name}/manifests/{reference} -- delete a manifest.
-async fn delete_manifest(
-    State(state): State<Arc<OciRegistryState>>,
-    Path((name, reference)): Path<(String, String)>,
-) -> Response {
-    if !valid_repository_name(&name) || !valid_manifest_reference(&reference) {
+async fn delete_manifest_inner(state: &OciRegistryState, name: &str, reference: &str) -> Response {
+    if let Some(error) = metadata_error(state) {
+        return error;
+    }
+    if !valid_repository_name(name) || !valid_manifest_reference(reference) {
         return oci_error(
             StatusCode::BAD_REQUEST,
             "MANIFEST_INVALID",
@@ -522,7 +797,25 @@ async fn delete_manifest(
             None,
         );
     }
-    state.manifests.write().await.remove(&(name, reference));
+    let mut metadata_guard = state.metadata.write().await;
+    let mut replacement = metadata_guard.clone();
+    let Some(repository) = replacement.repositories.get_mut(name) else {
+        return StatusCode::NOT_FOUND.into_response();
+    };
+    let Some(descriptor) = repository.manifests.get(reference).cloned() else {
+        return StatusCode::NOT_FOUND.into_response();
+    };
+    if sha256_hex(reference).is_some() {
+        repository
+            .manifests
+            .retain(|_, candidate| candidate.digest != descriptor.digest);
+    } else {
+        repository.manifests.remove(reference);
+    }
+    if let Err(error) = persist_metadata(state, &replacement) {
+        return oci_error(StatusCode::INTERNAL_SERVER_ERROR, "UNKNOWN", &error, None);
+    }
+    *metadata_guard = replacement;
     StatusCode::ACCEPTED.into_response()
 }
 
@@ -552,16 +845,23 @@ fn valid_repository_name(name: &str) -> bool {
     if name.is_empty() || name.len() > MAX_REPOSITORY_NAME_LEN {
         return false;
     }
-    let bytes = name.as_bytes();
-    bytes
-        .first()
-        .is_some_and(|byte| byte.is_ascii_lowercase() || byte.is_ascii_digit())
-        && bytes
-            .last()
-            .is_some_and(|byte| byte.is_ascii_lowercase() || byte.is_ascii_digit())
-        && bytes.iter().all(|byte| {
-            byte.is_ascii_lowercase() || byte.is_ascii_digit() || matches!(byte, b'.' | b'_' | b'-')
-        })
+    name.split('/').all(|segment| {
+        let bytes = segment.as_bytes();
+        !segment.is_empty()
+            && segment != "."
+            && segment != ".."
+            && bytes
+                .first()
+                .is_some_and(|byte| byte.is_ascii_lowercase() || byte.is_ascii_digit())
+            && bytes
+                .last()
+                .is_some_and(|byte| byte.is_ascii_lowercase() || byte.is_ascii_digit())
+            && bytes.iter().all(|byte| {
+                byte.is_ascii_lowercase()
+                    || byte.is_ascii_digit()
+                    || matches!(byte, b'.' | b'_' | b'-')
+            })
+    })
 }
 
 fn valid_manifest_reference(reference: &str) -> bool {
@@ -607,6 +907,12 @@ fn blob_path_for_digest(blobs_dir: &FsPath, digest: &str) -> Option<PathBuf> {
     (path.parent() == Some(blobs_dir)).then_some(path)
 }
 
+fn manifest_path_for_digest(blobs_dir: &FsPath, digest: &str) -> Option<PathBuf> {
+    let encoded = sha256_hex(digest)?;
+    let manifests_dir = blobs_dir.join("manifests");
+    Some(manifests_dir.join(format!("sha256_{encoded}")))
+}
+
 fn digest_invalid(message: &str, location: Option<&str>) -> Response {
     oci_error(StatusCode::BAD_REQUEST, "DIGEST_INVALID", message, location)
 }
@@ -615,6 +921,7 @@ fn digest_invalid(message: &str, location: Option<&str>) -> Response {
 mod tests {
     use super::*;
     use axum::body::to_bytes;
+    use futures_util::StreamExt;
     use tower::ServiceExt;
 
     fn registry_state_with_token(
@@ -646,10 +953,14 @@ mod tests {
     }
 
     async fn initiate(state: Arc<OciRegistryState>) -> String {
+        initiate_repository(state, "demo").await
+    }
+
+    async fn initiate_repository(state: Arc<OciRegistryState>, repository: &str) -> String {
         let response = oci_routes(state)
             .oneshot(authenticated_request(
                 "POST",
-                "/v2/demo/blobs/uploads/",
+                &format!("/v2/{repository}/blobs/uploads/"),
                 Body::empty(),
             ))
             .await
@@ -665,6 +976,42 @@ mod tests {
         let body = to_bytes(response.into_body(), 1024 * 1024).await.unwrap();
         let json: serde_json::Value = serde_json::from_slice(&body).unwrap();
         json["errors"][0]["code"].as_str().unwrap().to_string()
+    }
+
+    async fn seed_blob(state: &OciRegistryState, repository: &str, bytes: &[u8]) -> String {
+        let digest = format!("sha256:{}", sha2_hex(bytes));
+        let blob_path = blob_path_for_digest(&state.blobs_dir, &digest).unwrap();
+        crate::atomic_file::write(&blob_path, bytes).unwrap();
+        let mut guard = state.metadata.write().await;
+        let mut replacement = guard.clone();
+        replacement
+            .repositories
+            .entry(repository.to_string())
+            .or_default()
+            .blobs
+            .insert(digest.clone());
+        persist_metadata(state, &replacement).unwrap();
+        *guard = replacement;
+        digest
+    }
+
+    async fn seed_manifest(
+        state: &OciRegistryState,
+        repository: &str,
+        reference: &str,
+        media_type: &str,
+        bytes: &[u8],
+    ) -> String {
+        let response = put_manifest_inner(
+            state,
+            repository,
+            reference,
+            media_type,
+            Bytes::copy_from_slice(bytes),
+        )
+        .await;
+        assert_eq!(response.status(), StatusCode::CREATED);
+        format!("sha256:{}", sha2_hex(bytes))
     }
 
     #[test]
@@ -699,9 +1046,7 @@ mod tests {
     async fn public_blob_reads_accept_valid_digests_without_authorization() {
         let (_root, state) = registry_state_with_token(Some("registry-secret"));
         let bytes = b"public oci blob";
-        let digest = format!("sha256:{}", sha2_hex(bytes));
-        let blob_path = blob_path_for_digest(&state.blobs_dir, &digest).unwrap();
-        std::fs::write(blob_path, bytes).unwrap();
+        let digest = seed_blob(&state, "demo", bytes).await;
 
         let response = oci_routes(state)
             .oneshot(
@@ -716,6 +1061,75 @@ mod tests {
         assert_eq!(response.headers()["docker-content-digest"], digest.as_str());
         let body = to_bytes(response.into_body(), usize::MAX).await.unwrap();
         assert_eq!(&body[..], bytes);
+    }
+
+    #[tokio::test]
+    async fn namespaced_repository_routes_are_safe_and_blob_membership_isolated() {
+        let (_root, state) = registry_state_with_token(Some("registry-secret"));
+        let repository = "firelock-ai/platform/kin";
+        let body = b"repository-scoped layer";
+        let digest = format!("sha256:{}", sha2_hex(body));
+        let location = initiate_repository(state.clone(), repository).await;
+        assert!(location.starts_with(&format!("/v2/{repository}/blobs/uploads/")));
+
+        let completed = oci_routes(state.clone())
+            .oneshot(authenticated_request(
+                "PUT",
+                &format!("{location}?digest={digest}"),
+                Body::from(body.as_slice()),
+            ))
+            .await
+            .unwrap();
+        assert_eq!(completed.status(), StatusCode::CREATED);
+
+        let own_read = oci_routes(state.clone())
+            .oneshot(
+                Request::get(format!("/v2/{repository}/blobs/{digest}"))
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(own_read.status(), StatusCode::OK);
+        assert_eq!(
+            to_bytes(own_read.into_body(), 1024).await.unwrap().as_ref(),
+            body
+        );
+
+        // The global content object exists, but another repository cannot use
+        // its digest as an ambient capability.
+        assert!(blob_path_for_digest(&state.blobs_dir, &digest)
+            .unwrap()
+            .is_file());
+        let cross_repository = oci_routes(state)
+            .oneshot(
+                Request::get(format!("/v2/other/team/blobs/{digest}"))
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(cross_repository.status(), StatusCode::NOT_FOUND);
+    }
+
+    #[tokio::test]
+    async fn public_blob_get_streams_bounded_chunks() {
+        let (_root, state) = registry_state_with_token(Some("registry-secret"));
+        let body = vec![b'x'; BLOB_STREAM_CHUNK_SIZE * 4 + 17];
+        let digest = seed_blob(&state, "demo", &body).await;
+        let response = oci_routes(state)
+            .oneshot(
+                Request::get(format!("/v2/demo/blobs/{digest}"))
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(response.status(), StatusCode::OK);
+        let mut stream = response.into_body().into_data_stream();
+        let first = stream.next().await.unwrap().unwrap();
+        assert!(first.len() <= BLOB_STREAM_CHUNK_SIZE);
+        assert!(first.len() < body.len());
     }
 
     #[tokio::test]
@@ -801,14 +1215,15 @@ mod tests {
     #[tokio::test]
     async fn shared_manifest_url_keeps_get_public_but_rejects_unauthenticated_mutations() {
         let original = br#"{"schemaVersion":2,"marker":"original"}"#.to_vec();
-        let coordinate = ("demo".to_string(), "latest".to_string());
-
         let (_root, state) = registry_state_with_token(Some("registry-secret"));
-        state
-            .manifests
-            .write()
-            .await
-            .insert(coordinate.clone(), original.clone());
+        let digest = seed_manifest(
+            &state,
+            "demo",
+            "latest",
+            DEFAULT_MANIFEST_MEDIA_TYPE,
+            &original,
+        )
+        .await;
 
         let public_get = oci_routes(state.clone())
             .oneshot(
@@ -841,17 +1256,20 @@ mod tests {
             assert_eq!(rejected.status(), StatusCode::UNAUTHORIZED);
             assert_eq!(error_code(rejected).await, "UNAUTHORIZED");
             assert_eq!(
-                state.manifests.read().await.get(&coordinate),
-                Some(&original)
+                state.metadata.read().await.repositories["demo"].manifests["latest"].digest,
+                digest
             );
         }
 
         let (_root, disabled) = registry_state_with_token(None);
-        disabled
-            .manifests
-            .write()
-            .await
-            .insert(coordinate.clone(), original.clone());
+        let disabled_digest = seed_manifest(
+            &disabled,
+            "demo",
+            "latest",
+            DEFAULT_MANIFEST_MEDIA_TYPE,
+            &original,
+        )
+        .await;
         for request in [
             Request::put("/v2/demo/manifests/latest")
                 .header(header::AUTHORIZATION, "Bearer registry-secret")
@@ -868,8 +1286,8 @@ mod tests {
             assert_eq!(rejected.status(), StatusCode::SERVICE_UNAVAILABLE);
             assert_eq!(error_code(rejected).await, "DENIED");
             assert_eq!(
-                disabled.manifests.read().await.get(&coordinate),
-                Some(&original)
+                disabled.metadata.read().await.repositories["demo"].manifests["latest"].digest,
+                disabled_digest
             );
         }
     }
@@ -952,7 +1370,7 @@ mod tests {
         assert_eq!(retried.status(), StatusCode::CREATED);
         assert!(state.uploads.read().await.is_empty());
         assert_eq!(std::fs::read(&blob_path).unwrap(), body);
-        assert_eq!(std::fs::read_dir(&state.blobs_dir).unwrap().count(), 1);
+        assert_eq!(std::fs::read_dir(&state.blobs_dir).unwrap().count(), 2);
     }
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
@@ -1026,7 +1444,7 @@ mod tests {
         reader.await.unwrap();
         let blob_path = blob_path_for_digest(&state.blobs_dir, &digest).unwrap();
         assert_eq!(std::fs::read(blob_path).unwrap(), body);
-        assert_eq!(std::fs::read_dir(&state.blobs_dir).unwrap().count(), 1);
+        assert_eq!(std::fs::read_dir(&state.blobs_dir).unwrap().count(), 2);
     }
 
     #[tokio::test]
@@ -1046,7 +1464,7 @@ mod tests {
             .unwrap();
         assert_eq!(rejected.status(), StatusCode::BAD_REQUEST);
         assert_eq!(error_code(rejected).await, "DIGEST_INVALID");
-        assert!(state.manifests.read().await.is_empty());
+        assert!(state.metadata.read().await.repositories.is_empty());
 
         let accepted = oci_routes(state.clone())
             .oneshot(authenticated_request(
@@ -1057,16 +1475,130 @@ mod tests {
             .await
             .unwrap();
         assert_eq!(accepted.status(), StatusCode::CREATED);
-        assert_eq!(state.manifests.read().await.len(), 1);
         assert_eq!(
-            state
+            state.metadata.read().await.repositories["demo"]
                 .manifests
-                .read()
-                .await
-                .get(&("demo".to_string(), computed))
-                .map(Vec::as_slice),
-            Some(body.as_slice())
+                .len(),
+            1
         );
+        let manifest_path = manifest_path_for_digest(&state.blobs_dir, &computed).unwrap();
+        assert_eq!(std::fs::read(manifest_path).unwrap(), body);
+    }
+
+    #[tokio::test]
+    async fn manifest_metadata_survives_restart_and_digest_delete_revokes_every_reference() {
+        let (root, state) = registry_state_with_token(Some("registry-secret"));
+        let repository = "firelock-ai/kin";
+        let body = br#"{"schemaVersion":2,"mediaType":"application/vnd.docker.distribution.manifest.v2+json"}"#;
+        let digest = format!("sha256:{}", sha2_hex(body));
+        let media_type = "application/vnd.docker.distribution.manifest.v2+json";
+
+        for tag in ["latest", "stable"] {
+            let response = oci_routes(state.clone())
+                .oneshot(
+                    Request::put(format!("/v2/{repository}/manifests/{tag}"))
+                        .header(header::AUTHORIZATION, "Bearer registry-secret")
+                        .header(header::CONTENT_TYPE, media_type)
+                        .body(Body::from(body.as_slice()))
+                        .unwrap(),
+                )
+                .await
+                .unwrap();
+            assert_eq!(response.status(), StatusCode::CREATED);
+            assert_eq!(response.headers()["docker-content-digest"], digest);
+        }
+
+        let restarted = Arc::new(OciRegistryState::new(
+            root.path().join("oci"),
+            Some("registry-secret".to_string()),
+        ));
+        for method in [Method::GET, Method::HEAD] {
+            let response = oci_routes(restarted.clone())
+                .oneshot(
+                    Request::builder()
+                        .method(method.clone())
+                        .uri(format!("/v2/{repository}/manifests/latest"))
+                        .body(Body::empty())
+                        .unwrap(),
+                )
+                .await
+                .unwrap();
+            assert_eq!(response.status(), StatusCode::OK);
+            assert_eq!(response.headers()[header::CONTENT_TYPE], media_type);
+            assert_eq!(response.headers()["docker-content-digest"], digest);
+            let observed = to_bytes(response.into_body(), MAX_OCI_MANIFEST_SIZE)
+                .await
+                .unwrap();
+            if method == Method::GET {
+                assert_eq!(observed.as_ref(), body);
+            } else {
+                assert!(observed.is_empty());
+            }
+        }
+
+        let deleted = oci_routes(restarted.clone())
+            .oneshot(authenticated_request(
+                "DELETE",
+                &format!("/v2/{repository}/manifests/{digest}"),
+                Body::empty(),
+            ))
+            .await
+            .unwrap();
+        assert_eq!(deleted.status(), StatusCode::ACCEPTED);
+        for reference in ["latest", "stable", digest.as_str()] {
+            let response = oci_routes(restarted.clone())
+                .oneshot(
+                    Request::get(format!("/v2/{repository}/manifests/{reference}"))
+                        .body(Body::empty())
+                        .unwrap(),
+                )
+                .await
+                .unwrap();
+            assert_eq!(response.status(), StatusCode::NOT_FOUND, "{reference}");
+        }
+
+        let after_delete_restart = Arc::new(OciRegistryState::new(
+            root.path().join("oci"),
+            Some("registry-secret".to_string()),
+        ));
+        let absent = oci_routes(after_delete_restart)
+            .oneshot(
+                Request::get(format!("/v2/{repository}/manifests/latest"))
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(absent.status(), StatusCode::NOT_FOUND);
+    }
+
+    #[tokio::test]
+    async fn corrupt_durable_metadata_fails_loud_instead_of_appearing_empty() {
+        let (root, _state) = registry_state_with_token(Some("registry-secret"));
+        std::fs::write(root.path().join("oci/metadata.json"), b"not-json").unwrap();
+        let corrupt = Arc::new(OciRegistryState::new(
+            root.path().join("oci"),
+            Some("registry-secret".to_string()),
+        ));
+        let digest = format!("sha256:{}", "0".repeat(SHA256_HEX_LEN));
+        let read = oci_routes(corrupt.clone())
+            .oneshot(
+                Request::get(format!("/v2/demo/blobs/{digest}"))
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(read.status(), StatusCode::INTERNAL_SERVER_ERROR);
+        let write = oci_routes(corrupt)
+            .oneshot(authenticated_request(
+                "POST",
+                "/v2/demo/blobs/uploads/",
+                Body::empty(),
+            ))
+            .await
+            .unwrap();
+        assert_eq!(write.status(), StatusCode::INTERNAL_SERVER_ERROR);
     }
 
     #[tokio::test]

--- a/crates/kin-registry/src/oci.rs
+++ b/crates/kin-registry/src/oci.rs
@@ -23,7 +23,7 @@ use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::Arc;
 use std::time::{Duration, Instant, SystemTime};
 use tokio::io::AsyncReadExt;
-use tokio::sync::RwLock;
+use tokio::sync::{RwLock, RwLockWriteGuard};
 
 const SHA256_HEX_LEN: usize = 64;
 const UPLOAD_ID_HEX_LEN: usize = 32;
@@ -76,9 +76,8 @@ impl Default for OciMetadata {
 pub struct OciRegistryState {
     blobs_dir: PathBuf,
     metadata_path: PathBuf,
+    metadata_lock_path: PathBuf,
     metadata: RwLock<OciMetadata>,
-    /// A malformed durable index is an authority failure, never an empty registry.
-    load_error: Option<String>,
     /// upload ID -> bounded, expiring partial data
     uploads: RwLock<HashMap<String, PendingUpload>>,
     /// OCI-specific secret for writes. `None` disables every mutation.
@@ -88,34 +87,17 @@ pub struct OciRegistryState {
 impl OciRegistryState {
     pub fn new(blobs_dir: PathBuf, write_token: Option<String>) -> Self {
         let metadata_path = blobs_dir.join("metadata.json");
-        let (metadata, load_error) = match std::fs::read(&metadata_path) {
-            Ok(bytes) => match serde_json::from_slice::<OciMetadata>(&bytes) {
-                Ok(metadata) if metadata.version == OCI_METADATA_VERSION => (metadata, None),
-                Ok(metadata) => (
-                    OciMetadata::default(),
-                    Some(format!(
-                        "unsupported OCI metadata version {} (expected {OCI_METADATA_VERSION})",
-                        metadata.version
-                    )),
-                ),
-                Err(error) => (
-                    OciMetadata::default(),
-                    Some(format!("cannot decode OCI metadata: {error}")),
-                ),
-            },
-            Err(error) if error.kind() == std::io::ErrorKind::NotFound => {
-                (OciMetadata::default(), None)
-            }
-            Err(error) => (
-                OciMetadata::default(),
-                Some(format!("cannot read OCI metadata: {error}")),
-            ),
-        };
+        let metadata_lock_path = blobs_dir.join(".metadata.lock");
+        // This cache is only an in-process observation surface. Every request
+        // reloads durable authority under a storage-scoped advisory lock, so a
+        // corrupt file or another daemon's publication can never be hidden by
+        // startup state.
+        let metadata = read_metadata_file(&metadata_path).unwrap_or_default();
         Self {
             blobs_dir,
             metadata_path,
+            metadata_lock_path,
             metadata: RwLock::new(metadata),
-            load_error,
             uploads: RwLock::new(HashMap::new()),
             write_token: write_token
                 .map(|token| token.trim().to_string())
@@ -342,15 +324,62 @@ fn query_parameter(query: &str, wanted: &str) -> Option<String> {
     })
 }
 
-fn metadata_error(state: &OciRegistryState) -> Option<Response> {
-    state.load_error.as_ref().map(|error| {
-        oci_error(
-            StatusCode::INTERNAL_SERVER_ERROR,
-            "UNKNOWN",
-            &format!("OCI metadata authority is unavailable: {error}"),
-            None,
-        )
-    })
+fn metadata_authority_error(error: &str) -> Response {
+    oci_error(
+        StatusCode::INTERNAL_SERVER_ERROR,
+        "UNKNOWN",
+        &format!("OCI metadata authority is unavailable: {error}"),
+        None,
+    )
+}
+
+fn read_metadata_file(path: &FsPath) -> Result<OciMetadata, String> {
+    match std::fs::read(path) {
+        Ok(bytes) => {
+            let metadata = serde_json::from_slice::<OciMetadata>(&bytes)
+                .map_err(|error| format!("cannot decode OCI metadata: {error}"))?;
+            if metadata.version != OCI_METADATA_VERSION {
+                return Err(format!(
+                    "unsupported OCI metadata version {} (expected {OCI_METADATA_VERSION})",
+                    metadata.version
+                ));
+            }
+            Ok(metadata)
+        }
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => Ok(OciMetadata::default()),
+        Err(error) => Err(format!("cannot read OCI metadata: {error}")),
+    }
+}
+
+/// Reload the durable authority for every read. The local write guard prevents
+/// same-process readers from racing a local publisher while the shared file
+/// lock orders this snapshot against publishers in other daemon processes.
+async fn metadata_snapshot(state: &OciRegistryState) -> Result<OciMetadata, String> {
+    let mut cache = state.metadata.write().await;
+    let _storage_lock = crate::storage_lock::StorageLock::shared(&state.metadata_lock_path)
+        .map_err(|error| format!("failed to lock OCI metadata for reading: {error}"))?;
+    let fresh = read_metadata_file(&state.metadata_path)?;
+    *cache = fresh.clone();
+    Ok(fresh)
+}
+
+/// Begin a cross-process read/modify/write transaction from the latest durable
+/// metadata. Callers must keep both returned guards alive through persistence.
+async fn begin_metadata_write(
+    state: &OciRegistryState,
+) -> Result<
+    (
+        RwLockWriteGuard<'_, OciMetadata>,
+        crate::storage_lock::StorageLock,
+        OciMetadata,
+    ),
+    String,
+> {
+    let cache = state.metadata.write().await;
+    let storage_lock = crate::storage_lock::StorageLock::exclusive(&state.metadata_lock_path)
+        .map_err(|error| format!("failed to lock OCI metadata for writing: {error}"))?;
+    let fresh = read_metadata_file(&state.metadata_path)?;
+    Ok((cache, storage_lock, fresh))
 }
 
 fn persist_metadata(state: &OciRegistryState, metadata: &OciMetadata) -> Result<(), String> {
@@ -367,9 +396,6 @@ async fn get_blob_inner(
     digest: &str,
     head_only: bool,
 ) -> Response {
-    if let Some(error) = metadata_error(state) {
-        return error;
-    }
     if !valid_repository_name(name) {
         return oci_error(
             StatusCode::BAD_REQUEST,
@@ -381,10 +407,11 @@ async fn get_blob_inner(
     let Some(blob_path) = blob_path_for_digest(&state.blobs_dir, digest) else {
         return digest_invalid("invalid non-canonical blob digest", None);
     };
-    let is_member = state
-        .metadata
-        .read()
-        .await
+    let metadata = match metadata_snapshot(state).await {
+        Ok(metadata) => metadata,
+        Err(error) => return metadata_authority_error(&error),
+    };
+    let is_member = metadata
         .repositories
         .get(name)
         .is_some_and(|repository| repository.blobs.contains(digest));
@@ -440,9 +467,6 @@ async fn get_blob_inner(
 }
 
 async fn initiate_upload_inner(state: &OciRegistryState, name: &str) -> Response {
-    if let Some(error) = metadata_error(state) {
-        return error;
-    }
     if !valid_repository_name(name) {
         return oci_error(
             StatusCode::BAD_REQUEST,
@@ -450,6 +474,9 @@ async fn initiate_upload_inner(state: &OciRegistryState, name: &str) -> Response
             "invalid OCI repository name",
             None,
         );
+    }
+    if let Err(error) = metadata_snapshot(state).await {
+        return metadata_authority_error(&error);
     }
 
     let upload_id = new_upload_id(name);
@@ -486,9 +513,6 @@ async fn complete_upload_inner(
     expected_digest: Option<&str>,
     body: Bytes,
 ) -> Response {
-    if let Some(error) = metadata_error(state) {
-        return error;
-    }
     let location = upload_location(name, id);
     if !valid_repository_name(name) || !valid_upload_id(id) {
         return oci_error(
@@ -509,6 +533,9 @@ async fn complete_upload_inner(
             "completion digest must be canonical lowercase sha256",
             Some(&location),
         );
+    }
+    if let Err(error) = metadata_snapshot(state).await {
+        return metadata_authority_error(&error);
     }
 
     let mut uploads = state.uploads.write().await;
@@ -566,6 +593,15 @@ async fn complete_upload_inner(
 
     let blob_path = blob_path_for_digest(&state.blobs_dir, &computed_digest)
         .expect("computed sha256 digest is canonical");
+    let (mut metadata_guard, storage_lock, mut replacement) =
+        match begin_metadata_write(state).await {
+            Ok(transaction) => transaction,
+            Err(error) => {
+                pending.data.truncate(partial_len);
+                state.uploads.write().await.insert(id.to_string(), pending);
+                return metadata_authority_error(&error);
+            }
+        };
     // Stage beside the digest path, fsync the complete bytes, and atomically
     // rename them into place. Public GET/HEAD requests therefore see either no
     // blob (or the prior complete blob) or the complete replacement, never a
@@ -574,6 +610,8 @@ async fn complete_upload_inner(
     if let Err(error) = write_result {
         // Preserve the pre-completion upload state so the same final request
         // can be retried after the storage failure without duplicating bytes.
+        drop(storage_lock);
+        drop(metadata_guard);
         pending.data.truncate(partial_len);
         state.uploads.write().await.insert(id.to_string(), pending);
         return oci_error(
@@ -588,8 +626,6 @@ async fn complete_upload_inner(
     // to the repository that completed the upload. Persist membership before
     // acknowledging the write; an orphaned content file after a crash is safe
     // because reads consult this durable authority first.
-    let mut metadata_guard = state.metadata.write().await;
-    let mut replacement = metadata_guard.clone();
     replacement
         .repositories
         .entry(name.to_string())
@@ -597,6 +633,8 @@ async fn complete_upload_inner(
         .blobs
         .insert(computed_digest.clone());
     if let Err(error) = persist_metadata(state, &replacement) {
+        drop(storage_lock);
+        drop(metadata_guard);
         pending.data.truncate(partial_len);
         state.uploads.write().await.insert(id.to_string(), pending);
         return oci_error(
@@ -607,6 +645,7 @@ async fn complete_upload_inner(
         );
     }
     *metadata_guard = replacement;
+    drop(storage_lock);
     drop(metadata_guard);
 
     let blob_location = format!("/v2/{name}/blobs/{computed_digest}");
@@ -626,9 +665,6 @@ async fn get_manifest_inner(
     reference: &str,
     head_only: bool,
 ) -> Response {
-    if let Some(error) = metadata_error(state) {
-        return error;
-    }
     if !valid_repository_name(name) || !valid_manifest_reference(reference) {
         return oci_error(
             StatusCode::BAD_REQUEST,
@@ -637,10 +673,11 @@ async fn get_manifest_inner(
             None,
         );
     }
-    let descriptor = state
-        .metadata
-        .read()
-        .await
+    let metadata = match metadata_snapshot(state).await {
+        Ok(metadata) => metadata,
+        Err(error) => return metadata_authority_error(&error),
+    };
+    let descriptor = metadata
         .repositories
         .get(name)
         .and_then(|repository| repository.manifests.get(reference))
@@ -696,9 +733,6 @@ async fn put_manifest_inner(
     media_type: &str,
     body: Bytes,
 ) -> Response {
-    if let Some(error) = metadata_error(state) {
-        return error;
-    }
     if !valid_repository_name(name) || !valid_manifest_reference(reference) {
         return oci_error(
             StatusCode::BAD_REQUEST,
@@ -742,6 +776,11 @@ async fn put_manifest_inner(
     }
     let manifest_path = manifest_path_for_digest(&state.blobs_dir, &digest)
         .expect("computed manifest digest is canonical");
+    let (mut metadata_guard, storage_lock, mut replacement) =
+        match begin_metadata_write(state).await {
+            Ok(transaction) => transaction,
+            Err(error) => return metadata_authority_error(&error),
+        };
     if let Err(error) = crate::atomic_file::write(&manifest_path, &body) {
         return oci_error(
             StatusCode::INTERNAL_SERVER_ERROR,
@@ -754,8 +793,6 @@ async fn put_manifest_inner(
         digest: digest.clone(),
         media_type: media_type.to_string(),
     };
-    let mut metadata_guard = state.metadata.write().await;
-    let mut replacement = metadata_guard.clone();
     let repository = replacement
         .repositories
         .entry(name.to_string())
@@ -768,6 +805,7 @@ async fn put_manifest_inner(
         return oci_error(StatusCode::INTERNAL_SERVER_ERROR, "UNKNOWN", &error, None);
     }
     *metadata_guard = replacement;
+    drop(storage_lock);
     drop(metadata_guard);
 
     let mut response = StatusCode::CREATED.into_response();
@@ -786,9 +824,6 @@ async fn put_manifest_inner(
 
 /// DELETE /v2/{name}/manifests/{reference} -- delete a manifest.
 async fn delete_manifest_inner(state: &OciRegistryState, name: &str, reference: &str) -> Response {
-    if let Some(error) = metadata_error(state) {
-        return error;
-    }
     if !valid_repository_name(name) || !valid_manifest_reference(reference) {
         return oci_error(
             StatusCode::BAD_REQUEST,
@@ -797,8 +832,11 @@ async fn delete_manifest_inner(state: &OciRegistryState, name: &str, reference: 
             None,
         );
     }
-    let mut metadata_guard = state.metadata.write().await;
-    let mut replacement = metadata_guard.clone();
+    let (mut metadata_guard, storage_lock, mut replacement) =
+        match begin_metadata_write(state).await {
+            Ok(transaction) => transaction,
+            Err(error) => return metadata_authority_error(&error),
+        };
     let Some(repository) = replacement.repositories.get_mut(name) else {
         return StatusCode::NOT_FOUND.into_response();
     };
@@ -816,6 +854,7 @@ async fn delete_manifest_inner(state: &OciRegistryState, name: &str, reference: 
         return oci_error(StatusCode::INTERNAL_SERVER_ERROR, "UNKNOWN", &error, None);
     }
     *metadata_guard = replacement;
+    drop(storage_lock);
     StatusCode::ACCEPTED.into_response()
 }
 
@@ -981,9 +1020,8 @@ mod tests {
     async fn seed_blob(state: &OciRegistryState, repository: &str, bytes: &[u8]) -> String {
         let digest = format!("sha256:{}", sha2_hex(bytes));
         let blob_path = blob_path_for_digest(&state.blobs_dir, &digest).unwrap();
+        let (mut guard, storage_lock, mut replacement) = begin_metadata_write(state).await.unwrap();
         crate::atomic_file::write(&blob_path, bytes).unwrap();
-        let mut guard = state.metadata.write().await;
-        let mut replacement = guard.clone();
         replacement
             .repositories
             .entry(repository.to_string())
@@ -992,6 +1030,7 @@ mod tests {
             .insert(digest.clone());
         persist_metadata(state, &replacement).unwrap();
         *guard = replacement;
+        drop(storage_lock);
         digest
     }
 
@@ -1355,7 +1394,7 @@ mod tests {
         assert_eq!(failed.status(), StatusCode::INTERNAL_SERVER_ERROR);
         assert_eq!(state.uploads.read().await.len(), 1);
         assert!(blob_path.is_dir());
-        assert_eq!(std::fs::read_dir(&state.blobs_dir).unwrap().count(), 1);
+        assert_eq!(std::fs::read_dir(&state.blobs_dir).unwrap().count(), 2);
 
         // The retained upload can be retried after the storage fault clears.
         std::fs::remove_dir(&blob_path).unwrap();
@@ -1370,7 +1409,7 @@ mod tests {
         assert_eq!(retried.status(), StatusCode::CREATED);
         assert!(state.uploads.read().await.is_empty());
         assert_eq!(std::fs::read(&blob_path).unwrap(), body);
-        assert_eq!(std::fs::read_dir(&state.blobs_dir).unwrap().count(), 2);
+        assert_eq!(std::fs::read_dir(&state.blobs_dir).unwrap().count(), 3);
     }
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
@@ -1444,7 +1483,7 @@ mod tests {
         reader.await.unwrap();
         let blob_path = blob_path_for_digest(&state.blobs_dir, &digest).unwrap();
         assert_eq!(std::fs::read(blob_path).unwrap(), body);
-        assert_eq!(std::fs::read_dir(&state.blobs_dir).unwrap().count(), 2);
+        assert_eq!(std::fs::read_dir(&state.blobs_dir).unwrap().count(), 3);
     }
 
     #[tokio::test]
@@ -1570,6 +1609,86 @@ mod tests {
             .await
             .unwrap();
         assert_eq!(absent.status(), StatusCode::NOT_FOUND);
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+    async fn independent_states_merge_writes_and_observe_fresh_durable_metadata() {
+        let root = tempfile::tempdir().unwrap();
+        let blobs_dir = root.path().join("oci");
+        std::fs::create_dir_all(&blobs_dir).unwrap();
+        // Both long-lived states start from the same empty snapshot. A
+        // startup-cached implementation would let the second publication
+        // erase the first.
+        let first = Arc::new(OciRegistryState::new(
+            blobs_dir.clone(),
+            Some("registry-secret".to_string()),
+        ));
+        let second = Arc::new(OciRegistryState::new(
+            blobs_dir,
+            Some("registry-secret".to_string()),
+        ));
+        let start = Arc::new(tokio::sync::Barrier::new(3));
+
+        let publish = |state: Arc<OciRegistryState>,
+                       repository: &'static str,
+                       tag: &'static str,
+                       marker: &'static str,
+                       start: Arc<tokio::sync::Barrier>| {
+            tokio::spawn(async move {
+                start.wait().await;
+                put_manifest_inner(
+                    &state,
+                    repository,
+                    tag,
+                    DEFAULT_MANIFEST_MEDIA_TYPE,
+                    Bytes::from(format!(r#"{{"schemaVersion":2,"marker":"{marker}"}}"#)),
+                )
+                .await
+                .status()
+            })
+        };
+        let left = publish(
+            first.clone(),
+            "team/first",
+            "stable",
+            "first",
+            start.clone(),
+        );
+        let right = publish(
+            second.clone(),
+            "team/second",
+            "latest",
+            "second",
+            start.clone(),
+        );
+        start.wait().await;
+        assert_eq!(left.await.unwrap(), StatusCode::CREATED);
+        assert_eq!(right.await.unwrap(), StatusCode::CREATED);
+
+        let durable = read_metadata_file(&first.metadata_path).unwrap();
+        assert!(durable.repositories.contains_key("team/first"));
+        assert!(durable.repositories.contains_key("team/second"));
+
+        // Each pre-existing process must see the other process's publication
+        // without a restart.
+        let observed_by_first = oci_routes(first)
+            .oneshot(
+                Request::get("/v2/team/second/manifests/latest")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(observed_by_first.status(), StatusCode::OK);
+        let observed_by_second = oci_routes(second)
+            .oneshot(
+                Request::get("/v2/team/first/manifests/stable")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(observed_by_second.status(), StatusCode::OK);
     }
 
     #[tokio::test]

--- a/crates/kin-registry/src/storage_lock.rs
+++ b/crates/kin-registry/src/storage_lock.rs
@@ -106,31 +106,43 @@ pub(crate) struct StorageLock {
 }
 
 impl StorageLock {
-    pub(crate) fn shared(path: &Path) -> io::Result<Self> {
-        Self::acquire(path, false)
-    }
-
+    #[cfg(test)]
     pub(crate) fn exclusive(path: &Path) -> io::Result<Self> {
         Self::acquire(path, true)
     }
 
-    pub(crate) async fn shared_async(path: &Path) -> io::Result<Self> {
-        Self::acquire_async(path, false).await
+    pub(crate) fn shared_at(
+        root: &crate::atomic_file::AuthorityRoot,
+        relative: &Path,
+    ) -> io::Result<Self> {
+        Self::acquire_file(root.open_lock_file(relative)?, false)
     }
 
-    pub(crate) async fn exclusive_async(path: &Path) -> io::Result<Self> {
-        Self::acquire_async(path, true).await
+    pub(crate) fn exclusive_at(
+        root: &crate::atomic_file::AuthorityRoot,
+        relative: &Path,
+    ) -> io::Result<Self> {
+        Self::acquire_file(root.open_lock_file(relative)?, true)
     }
 
-    async fn acquire_async(path: &Path, exclusive: bool) -> io::Result<Self> {
-        let path = PathBuf::from(path);
-        tokio::task::spawn_blocking(move || Self::acquire(&path, exclusive))
+    pub(crate) async fn exclusive_at_async(
+        root: crate::atomic_file::AuthorityRoot,
+        relative: PathBuf,
+    ) -> io::Result<Self> {
+        tokio::task::spawn_blocking(move || Self::exclusive_at(&root, &relative))
             .await
             .map_err(|error| io::Error::other(format!("registry lock task failed: {error}")))?
     }
 
+    #[cfg(test)]
     fn acquire(path: &Path, exclusive: bool) -> io::Result<Self> {
-        let file = crate::atomic_file::open_lock_file(path)?;
+        Self::acquire_file(crate::atomic_file::open_lock_file(path)?, exclusive)
+    }
+
+    fn acquire_file(
+        file: crate::atomic_file::AnchoredLockFile,
+        exclusive: bool,
+    ) -> io::Result<Self> {
         let process_guard = ProcessGuard::acquire(file.authority_key(), exclusive)?;
         if exclusive {
             FileExt::lock_exclusive(&file.file)?;

--- a/crates/kin-registry/src/storage_lock.rs
+++ b/crates/kin-registry/src/storage_lock.rs
@@ -1,0 +1,56 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Firelock, LLC
+
+//! Cross-process advisory locks for registry storage transactions.
+//!
+//! Tokio locks only coordinate handlers inside one daemon. Registry roots can
+//! also be mounted by multiple daemon processes during rollout or recovery, so
+//! every read/modify/write authority boundary needs a lock whose identity is
+//! the shared storage path itself.
+
+use fs2::FileExt;
+use std::fs::{File, OpenOptions};
+use std::io;
+use std::path::Path;
+
+pub(crate) struct StorageLock {
+    file: File,
+}
+
+impl StorageLock {
+    pub(crate) fn shared(path: &Path) -> io::Result<Self> {
+        Self::acquire(path, false)
+    }
+
+    pub(crate) fn exclusive(path: &Path) -> io::Result<Self> {
+        Self::acquire(path, true)
+    }
+
+    fn acquire(path: &Path, exclusive: bool) -> io::Result<Self> {
+        let parent = path.parent().ok_or_else(|| {
+            io::Error::new(
+                io::ErrorKind::InvalidInput,
+                "registry transaction lock has no parent directory",
+            )
+        })?;
+        crate::atomic_file::ensure_directory_durable(parent)?;
+        let file = OpenOptions::new()
+            .read(true)
+            .write(true)
+            .create(true)
+            .truncate(false)
+            .open(path)?;
+        if exclusive {
+            FileExt::lock_exclusive(&file)?;
+        } else {
+            FileExt::lock_shared(&file)?;
+        }
+        Ok(Self { file })
+    }
+}
+
+impl Drop for StorageLock {
+    fn drop(&mut self) {
+        let _ = FileExt::unlock(&self.file);
+    }
+}

--- a/crates/kin-registry/src/storage_lock.rs
+++ b/crates/kin-registry/src/storage_lock.rs
@@ -9,12 +9,100 @@
 //! the shared storage path itself.
 
 use fs2::FileExt;
-use std::fs::{File, OpenOptions};
+use std::collections::HashMap;
 use std::io;
-use std::path::Path;
+use std::path::{Path, PathBuf};
+use std::sync::{Arc, Condvar, Mutex, OnceLock, Weak};
+
+#[derive(Default)]
+struct GateState {
+    readers: usize,
+    writer: bool,
+    waiting_writers: usize,
+}
+
+#[derive(Default)]
+struct ProcessGate {
+    state: Mutex<GateState>,
+    changed: Condvar,
+}
+
+struct ProcessGuard {
+    gate: Arc<ProcessGate>,
+    exclusive: bool,
+}
+
+impl ProcessGuard {
+    fn acquire(key: crate::atomic_file::AuthorityKey, exclusive: bool) -> io::Result<Self> {
+        static GATES: OnceLock<
+            Mutex<HashMap<crate::atomic_file::AuthorityKey, Weak<ProcessGate>>>,
+        > = OnceLock::new();
+
+        let gate = {
+            let mut gates = GATES
+                .get_or_init(|| Mutex::new(HashMap::new()))
+                .lock()
+                .map_err(|_| io::Error::other("registry process-lock map is poisoned"))?;
+            gates.retain(|_, gate| gate.strong_count() > 0);
+            match gates.get(&key).and_then(Weak::upgrade) {
+                Some(gate) => gate,
+                None => {
+                    let gate = Arc::new(ProcessGate::default());
+                    gates.insert(key, Arc::downgrade(&gate));
+                    gate
+                }
+            }
+        };
+
+        let mut state = gate
+            .state
+            .lock()
+            .map_err(|_| io::Error::other("registry process lock is poisoned"))?;
+        if exclusive {
+            state.waiting_writers += 1;
+            while state.writer || state.readers > 0 {
+                state = gate
+                    .changed
+                    .wait(state)
+                    .map_err(|_| io::Error::other("registry process lock is poisoned"))?;
+            }
+            state.waiting_writers -= 1;
+            state.writer = true;
+        } else {
+            // Give a queued writer priority so a continuous stream of public reads cannot
+            // starve package publication forever.
+            while state.writer || state.waiting_writers > 0 {
+                state = gate
+                    .changed
+                    .wait(state)
+                    .map_err(|_| io::Error::other("registry process lock is poisoned"))?;
+            }
+            state.readers += 1;
+        }
+        drop(state);
+        Ok(Self { gate, exclusive })
+    }
+}
+
+impl Drop for ProcessGuard {
+    fn drop(&mut self) {
+        let mut state = self
+            .gate
+            .state
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
+        if self.exclusive {
+            state.writer = false;
+        } else {
+            state.readers = state.readers.saturating_sub(1);
+        }
+        self.gate.changed.notify_all();
+    }
+}
 
 pub(crate) struct StorageLock {
-    file: File,
+    file: crate::atomic_file::AnchoredLockFile,
+    _process_guard: ProcessGuard,
 }
 
 impl StorageLock {
@@ -26,31 +114,93 @@ impl StorageLock {
         Self::acquire(path, true)
     }
 
+    pub(crate) async fn shared_async(path: &Path) -> io::Result<Self> {
+        Self::acquire_async(path, false).await
+    }
+
+    pub(crate) async fn exclusive_async(path: &Path) -> io::Result<Self> {
+        Self::acquire_async(path, true).await
+    }
+
+    async fn acquire_async(path: &Path, exclusive: bool) -> io::Result<Self> {
+        let path = PathBuf::from(path);
+        tokio::task::spawn_blocking(move || Self::acquire(&path, exclusive))
+            .await
+            .map_err(|error| io::Error::other(format!("registry lock task failed: {error}")))?
+    }
+
     fn acquire(path: &Path, exclusive: bool) -> io::Result<Self> {
-        let parent = path.parent().ok_or_else(|| {
-            io::Error::new(
-                io::ErrorKind::InvalidInput,
-                "registry transaction lock has no parent directory",
-            )
-        })?;
-        crate::atomic_file::ensure_directory_durable(parent)?;
-        let file = OpenOptions::new()
-            .read(true)
-            .write(true)
-            .create(true)
-            .truncate(false)
-            .open(path)?;
+        let file = crate::atomic_file::open_lock_file(path)?;
+        let process_guard = ProcessGuard::acquire(file.authority_key(), exclusive)?;
         if exclusive {
-            FileExt::lock_exclusive(&file)?;
+            FileExt::lock_exclusive(&file.file)?;
         } else {
-            FileExt::lock_shared(&file)?;
+            FileExt::lock_shared(&file.file)?;
         }
-        Ok(Self { file })
+        file.verify_named()?;
+        Ok(Self {
+            file,
+            _process_guard: process_guard,
+        })
     }
 }
 
 impl Drop for StorageLock {
     fn drop(&mut self) {
-        let _ = FileExt::unlock(&self.file);
+        let _ = FileExt::unlock(&self.file.file);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::sync::mpsc;
+    use std::time::Duration;
+
+    #[test]
+    fn same_process_exclusive_locks_are_serialized_by_authority_identity() {
+        let root = tempfile::tempdir().unwrap();
+        let path = root.path().canonicalize().unwrap().join("registry.lock");
+        let first = StorageLock::exclusive(&path).unwrap();
+        let (attempted_tx, attempted_rx) = mpsc::channel();
+        let (acquired_tx, acquired_rx) = mpsc::channel();
+        let contender_path = path.clone();
+        let contender = std::thread::spawn(move || {
+            attempted_tx.send(()).unwrap();
+            let _lock = StorageLock::exclusive(&contender_path).unwrap();
+            acquired_tx.send(()).unwrap();
+        });
+
+        attempted_rx.recv_timeout(Duration::from_secs(1)).unwrap();
+        assert!(matches!(
+            acquired_rx.recv_timeout(Duration::from_millis(50)),
+            Err(mpsc::RecvTimeoutError::Timeout)
+        ));
+        drop(first);
+        acquired_rx.recv_timeout(Duration::from_secs(1)).unwrap();
+        contender.join().unwrap();
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn symlinked_parent_aliases_share_one_process_gate() {
+        use std::os::unix::fs::symlink;
+
+        let root = tempfile::tempdir().unwrap();
+        let root_path = root.path().canonicalize().unwrap();
+        let real = root_path.join("real");
+        let alias = root_path.join("alias");
+        std::fs::create_dir(&real).unwrap();
+        symlink(&real, &alias).unwrap();
+
+        // Registry storage rejects symlink traversal instead of assigning a second lock
+        // identity to the same underlying authority.
+        let error = StorageLock::exclusive(&alias.join("registry.lock"))
+            .err()
+            .expect("symlinked registry parent must be rejected");
+        assert!(matches!(
+            error.raw_os_error(),
+            Some(code) if code == libc::ELOOP || code == libc::ENOTDIR
+        ));
     }
 }

--- a/docs/env-vars.md
+++ b/docs/env-vars.md
@@ -3,7 +3,7 @@
 
 # Kin environment variables
 
-This is the authoritative list of supported `KIN_*` environment variables (404 total, 302 correctness-relevant), generated from the central registry in `kin-core`.
+This is the authoritative list of supported `KIN_*` environment variables (405 total, 302 correctness-relevant), generated from the central registry in `kin-core`.
 
 At CLI and daemon startup Kin validates this surface (`KIN_ENV_VALIDATION`, default `warn`):
 
@@ -123,6 +123,7 @@ Sensitivity legend: **correctness** (affects retrieval/ranking/output or data sa
 | `KIN_REGISTRY_BASE_URL` | url | *(unset)* | operational | kin registry base URL (alternate key) |
 | `KIN_REGISTRY_CARGO_TOKEN` | secret | *(unset)* | secret | cargo registry auth token for publish |
 | `KIN_REGISTRY_NPM_AUTH_URL` | url | *(unset)* | operational | npm auth URL for the registry |
+| `KIN_REGISTRY_OCI_WRITE_TOKEN` | secret | *(unset)* | secret | OCI registry auth token for mutations |
 | `KIN_REGISTRY_PATH` | path | *(unset)* | operational | local registry path override |
 | `KIN_REGISTRY_URL` | url | *(unset)* | operational | kin registry base URL |
 


### PR DESCRIPTION
## What

- Keep OCI `GET`/`HEAD` pulls public while making every `POST`/`PUT`/`DELETE` mutation fail closed behind a dedicated `KIN_REGISTRY_OCI_WRITE_TOKEN` credential. The Cargo token is intentionally invalid for OCI writes.
- Support slash-delimited OCI repository namespaces and Go module paths without projecting caller-controlled segments into artifact filenames.
- Require canonical OCI digests, verify uploaded and resumed content, preserve exact manifest media types, return `Docker-Content-Digest` on manifest/blob reads, and make digest deletion revoke every tag/reference for that manifest.
- Persist OCI manifest references and repository-scoped blob membership in a versioned, atomically replaced metadata authority that survives restart and fails loud if unreadable.
- Stream public OCI blobs in bounded 64 KiB chunks instead of loading objects up to 512 MiB into memory.
- Keep Cargo sparse-index reads manifest-only, reject uppercase publish coordinates, and fail loud on legacy/incomplete index metadata rather than manufacturing `deps: []`.
- Replace Cargo manifest appends/truncation with crash-durable whole-file publication and serialize publication/rollback across cancellation boundaries.
- Retain a capability-opened registry authority root on non-Unix platforms, descend without following links, and key transactions by stable artifact identity rather than caller path spelling.

## Why

Closes the release-blocking OCI authentication, path containment, metadata durability, and Cargo index authority gaps.

The prior adapter shared Cargo credentials with OCI, did not durably preserve OCI reference/membership authority, only handled one-segment repository/module names, could serve a global blob through an unrelated repository, buffered large public pulls, and could silently turn incomplete Cargo manifest metadata into an authoritative empty dependency set. Pathname-only authority on Windows also allowed aliasing or root replacement to escape the intended registry root.

## Auth and durability contract

- Cargo writes use only `KIN_REGISTRY_CARGO_TOKEN`.
- OCI writes use only `KIN_REGISTRY_OCI_WRITE_TOKEN`.
- Either missing/empty credential disables only its corresponding write surface; reads remain public.
- Cargo and OCI authoritative metadata is published through the shared same-directory atomic writer. Bytes are fully staged and flushed before rename; Unix additionally syncs the published file and parent directory.
- The retained non-Unix capability root is opened from the volume root, rejects link/reparse traversal, and remains the authority for descendant reads, writes, locks, renames, and cleanup.
- OCI content written before a metadata commit is an inaccessible orphan, never ambient read authority. Blob GET/HEAD requires durable membership in the requested repository.

## Testing

- [x] `cargo test -p kin-registry` — 88 passed
- [x] `cargo test -p kin-core` — 273 passed
- [x] native `cargo check -p kin-daemon`
- [x] OCI restart, digest-deletion, repository-membership, resumed-finalization, and cancellation/rollback regressions
- [x] Cargo gzip post-EOA, manifest-authority, same-length replacement, and transaction-identity regressions
- [x] Windows root-replacement, junction rejection, case-alias, and capability-root regressions
- [x] `cargo check --target x86_64-pc-windows-msvc -p kin-registry --all-targets`
- [x] `cargo clippy --target x86_64-pc-windows-msvc -p kin-registry --all-targets -- -D warnings`
- [x] exact CI `cargo clippy --all-targets --all-features` allowlist with `RUSTFLAGS=-D warnings`
- [x] `cargo deny check`, `cargo fmt --all -- --check`, and `git diff --check`
- [x] fresh hosted CI, including actual Windows execution, for exact head `9d871e5ff4e1f58647fcbad9b9604955aa8860b0`

## Not claiming

This PR is not merged, released, deployed, proof-run, sealed, production-verified, or investor-citable. The exact head must complete fresh hosted CI, including Windows execution, followed by queue-authorized merge and post-merge verification.

