### PR TITLE
Fix MCP cross-repo reference decoding

### DIFF
--- a/crates/kin-cli/src/backend.rs
+++ b/crates/kin-cli/src/backend.rs
@@ -557,7 +557,7 @@ pub async fn get_spine_xref(
     match classify_spine_probe(true, status) {
         SpineProbe::Healthy => {
             let bytes = resp?.bytes().await?;
-            let body = ::kin_spine::SpineXrefResponse::from_slice(&bytes)?;
+            let body = ::kin_spine::SpineXrefResponse::from_slice_for(&bytes, repo_id, entity_id)?;
             Ok(SpineQuery::Found(body.edges))
         }
         SpineProbe::Unavailable(reason) => Ok(SpineQuery::Unavailable(reason)),

--- a/crates/kin-cli/src/backend.rs
+++ b/crates/kin-cli/src/backend.rs
@@ -556,9 +556,9 @@ pub async fn get_spine_xref(
 
     match classify_spine_probe(true, status) {
         SpineProbe::Healthy => {
-            let body: serde_json::Value = resp?.json().await?;
-            let edges = serde_json::from_value(body["edges"].clone())?;
-            Ok(SpineQuery::Found(edges))
+            let bytes = resp?.bytes().await?;
+            let body = ::kin_spine::SpineXrefResponse::from_slice(&bytes)?;
+            Ok(SpineQuery::Found(body.edges))
         }
         SpineProbe::Unavailable(reason) => Ok(SpineQuery::Unavailable(reason)),
         SpineProbe::NotConfigured => Ok(SpineQuery::Unavailable(

--- a/crates/kin-cli/src/backend.rs
+++ b/crates/kin-cli/src/backend.rs
@@ -532,7 +532,7 @@ pub async fn get_spine_xref(
     layout: &kin_core::KinLayout,
     repo_id: &str,
     entity_id: &kin_model::EntityId,
-) -> anyhow::Result<::kin_spine::SpineQuery<Vec<::kin_spine::CrossRepoEdge>>> {
+) -> anyhow::Result<::kin_spine::SpineQuery<::kin_spine::SpineXrefResponse>> {
     use ::kin_spine::{classify_spine_probe, SpineProbe, SpineQuery};
 
     let Some(daemon_url) = crate::daemon_client::resolve_daemon_url(layout).await? else {
@@ -558,7 +558,7 @@ pub async fn get_spine_xref(
         SpineProbe::Healthy => {
             let bytes = resp?.bytes().await?;
             let body = ::kin_spine::SpineXrefResponse::from_slice_for(&bytes, repo_id, entity_id)?;
-            Ok(SpineQuery::Found(body.edges))
+            Ok(SpineQuery::Found(body))
         }
         SpineProbe::Unavailable(reason) => Ok(SpineQuery::Unavailable(reason)),
         SpineProbe::NotConfigured => Ok(SpineQuery::Unavailable(

--- a/crates/kin-cli/src/commands/setup.rs
+++ b/crates/kin-cli/src/commands/setup.rs
@@ -12917,6 +12917,7 @@ mod tests {
 
     #[cfg(target_os = "macos")]
     #[test]
+    #[serial]
     fn macos_current_home_namespace_acl_is_transactable() {
         let home = directories::BaseDirs::new()
             .unwrap()

--- a/crates/kin-cli/src/commands/xref.rs
+++ b/crates/kin-cli/src/commands/xref.rs
@@ -70,38 +70,61 @@ pub async fn build_xref_response(
     let repo_id = crate::commands::remote::resolve_repo_id(layout)?;
 
     match crate::backend::get_spine_xref(layout, &repo_id, &target.id).await {
-        Ok(::kin_spine::SpineQuery::Found(edges)) if !edges.is_empty() => {
-            lines.push(format!("  Found {} cross-repo edges:", edges.len()));
-            for edge in edges {
-                lines.push(format!(
-                    "    - Impact: [{}] {} depends on us ([{}] {}) (conf: {:.2})",
-                    edge.src_repo, edge.src_entity, edge.dst_repo, edge.dst_entity, edge.confidence
-                ));
-            }
-        }
-        // Healthy spine, genuinely no edges — an explicit, trustworthy empty.
-        Ok(::kin_spine::SpineQuery::Found(_)) => {
-            lines.push("  No cross-repo references found in the spine.".to_string());
-        }
-        // Spine configured but unreachable/disabled (e.g. HTTP 503) — say so
-        // instead of implying an empty result.
-        Ok(::kin_spine::SpineQuery::Unavailable(reason)) => {
-            lines.push(format!(
-                "  Cross-repo spine unavailable ({reason}) — this is not the same as 'no references found'."
-            ));
-        }
-        // No daemon endpoint configured in this context.
-        Ok(::kin_spine::SpineQuery::NotConfigured) => {
-            lines.push(
-                "  Cross-repo spine not configured (no daemon endpoint available).".to_string(),
-            );
-        }
+        Ok(query) => lines.extend(spine_xref_lines(query, &repo_id, &target.id)),
         Err(e) => {
             lines.push(format!("  Failed to query spine: {}", e));
         }
     }
 
     Ok(XrefResponse { lines })
+}
+
+fn spine_xref_lines(
+    query: ::kin_spine::SpineQuery<::kin_spine::SpineXrefResponse>,
+    repo_id: &str,
+    entity_id: &kin_model::EntityId,
+) -> Vec<String> {
+    match query {
+        ::kin_spine::SpineQuery::Found(response) => {
+            let authority_complete = response.authority_complete_for(repo_id, entity_id);
+            let mut lines = Vec::new();
+            if response.edges.is_empty() {
+                if authority_complete {
+                    lines.push("  No cross-repo references found in the spine.".to_string());
+                } else {
+                    lines.push(
+                        "  The spine returned no cross-repo edges, but its authority is incomplete — this is not the same as 'no references found'."
+                            .to_string(),
+                    );
+                }
+                return lines;
+            }
+
+            lines.push(format!(
+                "  Found {} cross-repo edges:",
+                response.edges.len()
+            ));
+            for edge in response.edges {
+                lines.push(format!(
+                    "    - Impact: [{}] {} depends on us ([{}] {}) (conf: {:.2})",
+                    edge.src_repo, edge.src_entity, edge.dst_repo, edge.dst_entity, edge.confidence
+                ));
+            }
+            if !authority_complete {
+                lines.push(
+                    "  Warning: these are partial results; the spine authority is incomplete and may omit additional references."
+                        .to_string(),
+                );
+            }
+            lines
+        }
+        ::kin_spine::SpineQuery::Unavailable(reason) => vec![format!(
+            "  Cross-repo spine unavailable ({reason}) — this is not the same as 'no references found'."
+        )],
+        ::kin_spine::SpineQuery::NotConfigured => vec![
+            "  Cross-repo spine not configured (no daemon endpoint available).".to_string(),
+        ],
+    }
 }
 
 /// Actionable guidance when `kin xref <symbol>` can't resolve the symbol in the
@@ -131,7 +154,8 @@ fn xref_not_found_guidance(entity: &str) -> Vec<String> {
 
 #[cfg(test)]
 mod tests {
-    use super::xref_not_found_guidance;
+    use super::{spine_xref_lines, xref_not_found_guidance};
+    use kin_model::EntityId;
 
     #[test]
     fn xref_not_found_guidance_keeps_signal_and_explains_anchor_model() {
@@ -150,6 +174,49 @@ mod tests {
         assert!(
             joined.contains("kin import") || joined.contains("kin deps"),
             "should give an actionable next step: {joined}"
+        );
+    }
+
+    #[test]
+    fn incomplete_empty_xref_never_claims_no_references() {
+        let entity_id = EntityId::new();
+        let response = kin_spine::SpineXrefResponse::new(Vec::new(), Vec::new());
+        let lines = spine_xref_lines(
+            kin_spine::SpineQuery::Found(response),
+            "provider",
+            &entity_id,
+        );
+        let joined = lines.join("\n");
+        assert!(!joined.contains("No cross-repo references found"));
+        assert!(joined.contains("authority is incomplete"));
+        assert!(joined.contains("not the same as 'no references found'"));
+    }
+
+    #[test]
+    fn complete_empty_xref_is_the_only_trustworthy_no_references_control() {
+        let entity_id = EntityId::new();
+        let encoded = serde_json::to_vec(&serde_json::json!({
+            "version": kin_spine::SPINE_PAYLOAD_VERSION,
+            "edges": [],
+            "authority_anchor": {
+                "repo_id": "provider",
+                "entity_id": entity_id,
+            },
+            "authority_complete": true,
+            "authority_revision": format!("sha256:{}", "a".repeat(64)),
+            "authority_roots": { "provider": "provider-root" },
+        }))
+        .unwrap();
+        let response =
+            kin_spine::SpineXrefResponse::from_slice_for(&encoded, "provider", &entity_id).unwrap();
+        let lines = spine_xref_lines(
+            kin_spine::SpineQuery::Found(response),
+            "provider",
+            &entity_id,
+        );
+        assert_eq!(
+            lines,
+            vec!["  No cross-repo references found in the spine."]
         );
     }
 }

--- a/crates/kin-cli/src/commands/xref.rs
+++ b/crates/kin-cli/src/commands/xref.rs
@@ -15,6 +15,11 @@ pub struct XrefRequest {
 pub struct XrefResponse {
     #[serde(default)]
     pub lines: Vec<String>,
+    /// Exact daemon/spine payload behind the human rendering. Keeping it in
+    /// the CLI RPC response prevents typed clients from losing incomplete
+    /// authority, revision, roots, and anchor information at this boundary.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub spine: Option<::kin_spine::SpineXrefResponse>,
 }
 
 pub async fn run(entity: String) -> Result<()> {
@@ -58,6 +63,7 @@ pub async fn build_xref_response(
     if matches.is_empty() {
         return Ok(XrefResponse {
             lines: xref_not_found_guidance(&request.entity),
+            spine: None,
         });
     }
 
@@ -69,18 +75,24 @@ pub async fn build_xref_response(
 
     let repo_id = crate::commands::remote::resolve_repo_id(layout)?;
 
+    let mut spine = None;
     match crate::backend::get_spine_xref(layout, &repo_id, &target.id).await {
-        Ok(query) => lines.extend(spine_xref_lines(query, &repo_id, &target.id)),
+        Ok(query) => {
+            lines.extend(spine_xref_lines(&query, &repo_id, &target.id));
+            if let ::kin_spine::SpineQuery::Found(response) = query {
+                spine = Some(response);
+            }
+        }
         Err(e) => {
             lines.push(format!("  Failed to query spine: {}", e));
         }
     }
 
-    Ok(XrefResponse { lines })
+    Ok(XrefResponse { lines, spine })
 }
 
 fn spine_xref_lines(
-    query: ::kin_spine::SpineQuery<::kin_spine::SpineXrefResponse>,
+    query: &::kin_spine::SpineQuery<::kin_spine::SpineXrefResponse>,
     repo_id: &str,
     entity_id: &kin_model::EntityId,
 ) -> Vec<String> {
@@ -104,7 +116,7 @@ fn spine_xref_lines(
                 "  Found {} cross-repo edges:",
                 response.edges.len()
             ));
-            for edge in response.edges {
+            for edge in &response.edges {
                 lines.push(format!(
                     "    - Impact: [{}] {} depends on us ([{}] {}) (conf: {:.2})",
                     edge.src_repo, edge.src_entity, edge.dst_repo, edge.dst_entity, edge.confidence
@@ -154,7 +166,7 @@ fn xref_not_found_guidance(entity: &str) -> Vec<String> {
 
 #[cfg(test)]
 mod tests {
-    use super::{spine_xref_lines, xref_not_found_guidance};
+    use super::{spine_xref_lines, xref_not_found_guidance, XrefResponse};
     use kin_model::EntityId;
 
     #[test]
@@ -181,11 +193,8 @@ mod tests {
     fn incomplete_empty_xref_never_claims_no_references() {
         let entity_id = EntityId::new();
         let response = kin_spine::SpineXrefResponse::new(Vec::new(), Vec::new());
-        let lines = spine_xref_lines(
-            kin_spine::SpineQuery::Found(response),
-            "provider",
-            &entity_id,
-        );
+        let query = kin_spine::SpineQuery::Found(response);
+        let lines = spine_xref_lines(&query, "provider", &entity_id);
         let joined = lines.join("\n");
         assert!(!joined.contains("No cross-repo references found"));
         assert!(joined.contains("authority is incomplete"));
@@ -209,14 +218,25 @@ mod tests {
         .unwrap();
         let response =
             kin_spine::SpineXrefResponse::from_slice_for(&encoded, "provider", &entity_id).unwrap();
-        let lines = spine_xref_lines(
-            kin_spine::SpineQuery::Found(response),
-            "provider",
-            &entity_id,
-        );
+        let query = kin_spine::SpineQuery::Found(response);
+        let lines = spine_xref_lines(&query, "provider", &entity_id);
         assert_eq!(
             lines,
             vec!["  No cross-repo references found in the spine."]
         );
+    }
+
+    #[test]
+    fn xref_rpc_response_preserves_incomplete_spine_authority() {
+        let response = XrefResponse {
+            lines: vec!["partial".to_string()],
+            spine: Some(kin_spine::SpineXrefResponse::new(Vec::new(), Vec::new())),
+        };
+        let encoded = serde_json::to_vec(&response).unwrap();
+        let decoded: XrefResponse = serde_json::from_slice(&encoded).unwrap();
+        let spine = decoded.spine.expect("typed spine payload must survive RPC");
+        assert!(!spine.authority_complete);
+        assert!(spine.authority_revision.is_none());
+        assert!(spine.authority_roots.is_empty());
     }
 }

--- a/crates/kin-cli/src/commands/xref.rs
+++ b/crates/kin-cli/src/commands/xref.rs
@@ -49,9 +49,11 @@ async fn run_daemon_xref(
 }
 
 pub async fn build_xref_response(
-    layout: &kin_core::KinLayout,
     graph: &kin_db::InMemoryGraph,
     request: &XrefRequest,
+    repo_id: &str,
+    graph_root: &str,
+    spine_backend: Option<&dyn kin_spine::SpineBackend>,
 ) -> Result<XrefResponse> {
     // Find the entity by name
     let filter = EntityFilter {
@@ -73,19 +75,23 @@ pub async fn build_xref_response(
         target.name
     )];
 
-    let repo_id = crate::commands::remote::resolve_repo_id(layout)?;
-
     let mut spine = None;
-    match crate::backend::get_spine_xref(layout, &repo_id, &target.id).await {
-        Ok(query) => {
-            lines.extend(spine_xref_lines(&query, &repo_id, &target.id));
-            if let ::kin_spine::SpineQuery::Found(response) = query {
-                spine = Some(response);
+    let query = match spine_backend {
+        Some(backend) => {
+            let response = backend.cross_repo_xref_response(repo_id, &target.id);
+            if response.authority_root_matches(repo_id, graph_root) {
+                ::kin_spine::SpineQuery::Found(response)
+            } else {
+                ::kin_spine::SpineQuery::Unavailable(format!(
+                    "spine root mismatch for repository {repo_id}: live/session graph root {graph_root} is not the registered spine root"
+                ))
             }
         }
-        Err(e) => {
-            lines.push(format!("  Failed to query spine: {}", e));
-        }
+        None => ::kin_spine::SpineQuery::NotConfigured,
+    };
+    lines.extend(spine_xref_lines(&query, repo_id, &target.id));
+    if let ::kin_spine::SpineQuery::Found(response) = query {
+        spine = Some(response);
     }
 
     Ok(XrefResponse { lines, spine })
@@ -166,8 +172,60 @@ fn xref_not_found_guidance(entity: &str) -> Vec<String> {
 
 #[cfg(test)]
 mod tests {
-    use super::{spine_xref_lines, xref_not_found_guidance, XrefResponse};
-    use kin_model::EntityId;
+    use super::{
+        build_xref_response, spine_xref_lines, xref_not_found_guidance, XrefRequest, XrefResponse,
+    };
+    use kin_model::entity::{
+        Entity, EntityKind, EntityMetadata, EntityRole, FingerprintAlgorithm, SemanticFingerprint,
+        Visibility,
+    };
+    use kin_model::graph::EntityStore as _;
+    use kin_model::{EntityId, FilePathId, Hash256, LanguageId};
+    use kin_spine::SpineBackend as _;
+
+    fn entity(name: &str) -> Entity {
+        Entity {
+            id: EntityId::new(),
+            kind: EntityKind::Function,
+            name: name.to_string(),
+            language: LanguageId::Rust,
+            fingerprint: SemanticFingerprint {
+                algorithm: FingerprintAlgorithm::V1TreeSitter,
+                ast_hash: Hash256::from_bytes([1; 32]),
+                signature_hash: Hash256::from_bytes([2; 32]),
+                behavior_hash: Hash256::from_bytes([3; 32]),
+                equivalence_hash: Hash256::from_bytes([4; 32]),
+                stability_score: 1.0,
+            },
+            file_origin: Some(FilePathId::new("src/lib.rs")),
+            span: None,
+            signature: format!("fn {name}()"),
+            visibility: Visibility::Public,
+            role: EntityRole::Source,
+            doc_summary: None,
+            metadata: EntityMetadata::default(),
+            lineage_parent: None,
+            created_in: None,
+            superseded_by: None,
+        }
+    }
+
+    fn entry(repo_id: &str, entity: &Entity) -> kin_spine::EntityEntry {
+        kin_spine::EntityEntry {
+            repo_id: repo_id.to_string(),
+            entity_id: entity.id,
+            name: entity.name.clone(),
+            kind: entity.kind,
+            signature: entity.signature.clone(),
+            fingerprint: entity.fingerprint.clone(),
+            file_path: entity.file_origin.as_ref().map(|path| path.0.clone()),
+            role: Some(entity.role),
+        }
+    }
+
+    fn graph_root(graph: &kin_db::InMemoryGraph) -> String {
+        hex::encode(graph.compute_root_hash())
+    }
 
     #[test]
     fn xref_not_found_guidance_keeps_signal_and_explains_anchor_model() {
@@ -238,5 +296,42 @@ mod tests {
         assert!(!spine.authority_complete);
         assert!(spine.authority_revision.is_none());
         assert!(spine.authority_roots.is_empty());
+    }
+
+    #[tokio::test]
+    async fn daemon_xref_uses_explicit_cached_repo_binding() {
+        let graph = kin_db::InMemoryGraph::new();
+        let target = entity("target");
+        graph.upsert_entity(&target).unwrap();
+        let root = graph_root(&graph);
+        let spine = kin_spine::InMemorySpineBackend::new();
+        spine.register_repo("daemon-X", vec![entry("daemon-X", &target)], &root);
+        spine.register_repo("manifest-Y", Vec::new(), "manifest-root");
+        let repos = vec!["daemon-X".to_string(), "manifest-Y".to_string()];
+        for repo in &repos {
+            spine.refresh_cross_repo_edges(repo, &[], &[], &repos);
+        }
+
+        let response = build_xref_response(
+            &graph,
+            &XrefRequest {
+                entity: "target".to_string(),
+            },
+            "daemon-X",
+            &root,
+            Some(&spine),
+        )
+        .await
+        .unwrap();
+        let payload = response.spine.expect("typed spine response");
+        assert_eq!(
+            payload
+                .authority_anchor
+                .as_ref()
+                .expect("explicit anchor")
+                .repo_id,
+            "daemon-X"
+        );
+        assert!(payload.authority_complete_for("daemon-X", &target.id));
     }
 }

--- a/crates/kin-daemon/src/api.rs
+++ b/crates/kin-daemon/src/api.rs
@@ -8515,10 +8515,21 @@ async fn spine_xref(
 
     let entity_id = parse_entity_id_hex(&params.entity)?;
     let edges = spine.cross_repo_edges_for(&params.repo, &entity_id);
+    let entity_keys = edges
+        .iter()
+        .flat_map(|edge| {
+            [
+                (edge.src_repo.clone(), edge.src_entity),
+                (edge.dst_repo.clone(), edge.dst_entity),
+            ]
+        })
+        .collect::<std::collections::BTreeSet<_>>();
+    let entities = entity_keys
+        .into_iter()
+        .filter_map(|(repo_id, entity_id)| spine.lookup_by_id(&repo_id, &entity_id))
+        .collect();
 
-    Ok(Json(
-        json!({ "version": kin_spine::SPINE_PAYLOAD_VERSION, "edges": edges }),
-    ))
+    Ok(Json(kin_spine::SpineXrefResponse::new(edges, entities)))
 }
 
 /// `GET /v1/spine/edges` — one atomic graph-authoritative cross-repo snapshot.
@@ -14565,13 +14576,13 @@ mod tests {
             kin_spine::SpineQuery::Found(body) => body,
             other => panic!("MCP fetch_spine_xref expected Found, got {other:?}"),
         };
-        let mcp_xref_to_provider = mcp_xref["edges"]
-            .as_array()
-            .map(|edges| edges.iter().any(|e| e["dst_repo"] == "provider"))
-            .unwrap_or(false);
+        let mcp_xref_to_provider = mcp_xref
+            .edges
+            .iter()
+            .any(|edge| edge.dst_repo == "provider");
         assert!(
             mcp_xref_to_provider,
-            "MCP fetch_spine_xref must resolve consumer->provider: {mcp_xref}"
+            "MCP fetch_spine_xref must resolve consumer->provider: {mcp_xref:?}"
         );
 
         let mcp_impact = match fetch_spine_impact_typed("provider", &do_work_id, 5).await {
@@ -14596,6 +14607,36 @@ mod tests {
             "daemon, CLI, and MCP must all resolve the same consumer->provider xref"
         );
 
+        // The agent-facing MCP handler must project that real incoming edge as
+        // a useful external caller. This pins the complete contract, including
+        // edge direction and the metadata sidecar, rather than merely proving
+        // that the transport returned some JSON.
+        let mut provider_entity = test_entity("do_work", "src/lib.rs");
+        provider_entity.id = do_work_id;
+        let local_graph = kin_db::InMemoryGraph::new();
+        local_graph.upsert_entity(&provider_entity).unwrap();
+        std::env::set_var("KIN_REPO_ID", "provider");
+        let args = HashMap::from([(
+            "entity_id".to_string(),
+            serde_json::json!(do_work_id.to_string()),
+        )]);
+        let result = kin_mcp::handlers::entities::handle_find_references(&args, &local_graph)
+            .await
+            .unwrap();
+        let kin_mcp::types::ContentBlock::Text { text } = result
+            .content
+            .first()
+            .expect("find_references text response");
+        let body: serde_json::Value = serde_json::from_str(text).unwrap();
+        assert_eq!(body["cross_repo"]["status"], "available");
+        assert_eq!(body["cross_repo"]["reference_count"], 1);
+        assert!(body["references"].as_array().is_some_and(|references| {
+            references.iter().any(|reference| {
+                reference["name"] == "run_task" && reference["file_path"] == "[consumer] src/app.rs"
+            })
+        }));
+
+        std::env::remove_var("KIN_REPO_ID");
         std::env::remove_var("KIN_DAEMON_URL");
         server.abort();
     }
@@ -14666,6 +14707,55 @@ mod tests {
             other => panic!("MCP impact must be Unavailable on 503, got {other:?}"),
         }
 
+        std::env::remove_var("KIN_DAEMON_URL");
+        server.abort();
+    }
+
+    #[tokio::test]
+    #[serial_test::serial]
+    async fn mcp_find_references_reports_legacy_xref_payload_as_unavailable() {
+        async fn legacy_xref() -> Json<serde_json::Value> {
+            Json(serde_json::json!({
+                "version": kin_spine::SPINE_PAYLOAD_VERSION,
+                "edges": [{
+                    "repo_id": "consumer",
+                    "from_name": "run_task",
+                    "to_repo_id": "provider",
+                    "kind": "calls",
+                }],
+            }))
+        }
+
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let addr = listener.local_addr().unwrap();
+        let server = tokio::spawn(async move {
+            let _ = axum::serve(listener, Router::new().fallback(legacy_xref)).await;
+        });
+        std::env::set_var("KIN_DAEMON_URL", format!("http://{addr}"));
+        std::env::set_var("KIN_REPO_ID", "provider");
+
+        let target = test_entity("do_work", "src/lib.rs");
+        let graph = kin_db::InMemoryGraph::new();
+        graph.upsert_entity(&target).unwrap();
+        let args = HashMap::from([(
+            "entity_id".to_string(),
+            serde_json::json!(target.id.to_string()),
+        )]);
+        let result = kin_mcp::handlers::entities::handle_find_references(&args, &graph)
+            .await
+            .unwrap();
+        let kin_mcp::types::ContentBlock::Text { text } = result
+            .content
+            .first()
+            .expect("find_references text response");
+        let body: serde_json::Value = serde_json::from_str(text).unwrap();
+        assert_eq!(body["cross_repo"]["status"], "unavailable");
+        assert!(body["cross_repo"]["reason"]
+            .as_str()
+            .is_some_and(|reason| reason.contains("malformed spine xref response")));
+        assert_eq!(body["total_upstream"], 0);
+
+        std::env::remove_var("KIN_REPO_ID");
         std::env::remove_var("KIN_DAEMON_URL");
         server.abort();
     }

--- a/crates/kin-daemon/src/api.rs
+++ b/crates/kin-daemon/src/api.rs
@@ -6124,15 +6124,27 @@ async fn mcp_tools_call(
             "coordination enforcement rejected transaction before graph apply: {evidence}"
         ))
     } else {
-        match kin_mcp::handlers::handle_tool_call(
-            &request.name,
-            &request.arguments,
-            graph.as_ref(),
-            &sessions,
-            kin_mcp::SessionAuthorityMode::OfflineFallback,
-        )
-        .await
-        {
+        let handled = if request.name == "find_references" {
+            kin_mcp::handlers::entities::handle_find_references_with_authority(
+                &request.arguments,
+                graph.as_ref(),
+                kin_mcp::handlers::entities::FindReferencesAuthority {
+                    repo_id: &state.cached_repo_id,
+                    spine: state.ensure_spine(),
+                },
+            )
+            .await
+        } else {
+            kin_mcp::handlers::handle_tool_call(
+                &request.name,
+                &request.arguments,
+                graph.as_ref(),
+                &sessions,
+                kin_mcp::SessionAuthorityMode::OfflineFallback,
+            )
+            .await
+        };
+        match handled {
             Ok(result) => result,
             Err(error) => kin_mcp::ToolCallResult::error(error.to_string()),
         }
@@ -9838,6 +9850,10 @@ mod tests {
     }
 
     fn test_state() -> Arc<DaemonState> {
+        test_state_with_repo_id(None)
+    }
+
+    fn test_state_with_repo_id(repo_id: Option<&str>) -> Arc<DaemonState> {
         install_test_registry_override();
         let dir = std::env::temp_dir().join(format!("kin-daemon-test-state-{}", Uuid::new_v4()));
         std::fs::create_dir_all(&dir).unwrap();
@@ -9848,7 +9864,10 @@ mod tests {
         kin_core::manifest::KinManifest::new()
             .save(&layout.manifest_path())
             .unwrap();
-        Arc::new(DaemonState::open(layout).unwrap())
+        Arc::new(match repo_id {
+            Some(repo_id) => DaemonState::open_for_test(layout, repo_id).unwrap(),
+            None => DaemonState::open(layout).unwrap(),
+        })
     }
 
     fn run_hydration_fixture_git(repo: &FsPath, args: &[&str]) -> String {
@@ -14478,7 +14497,9 @@ mod tests {
         let state = test_state();
         let spine = state.ensure_spine().expect("spine enabled in test");
         // Register two repos' metadata so the pass has a non-empty repo set to
-        // iterate over (their graphs are unavailable without a backend).
+        // iterate over (their graphs are unavailable without a backend). The
+        // daemon's own repo is also registered and remains loadable from its
+        // in-process graph.
         spine.register_repo("kin", vec![], "");
         spine.register_repo("kin-db", vec![], "");
         let app = router(state);
@@ -14507,9 +14528,10 @@ mod tests {
             body.get("crossRepoEdges").is_some(),
             "response must carry crossRepoEdges, got {body}"
         );
-        // No backend → no repo graph loadable → nothing refreshed, but a clean
-        // 200 rather than a hard failure.
-        assert_eq!(body["reposRefreshed"], serde_json::json!(0));
+        // No backend means the two foreign repo graphs are unavailable, while
+        // the daemon's own cached repo identity refreshes from its in-process
+        // graph. The partial pass still answers cleanly rather than failing.
+        assert_eq!(body["reposRefreshed"], serde_json::json!(1));
     }
 
     /// One gate proving the cross-repo blast radius is consistent across every
@@ -14557,7 +14579,16 @@ mod tests {
             .expect("run_task entity present")
             .id;
 
-        let state = test_state();
+        // Pin the daemon's canonical graph identity without mutating process
+        // environment shared by concurrently executing tests.
+        let state = test_state_with_repo_id(Some("provider"));
+        assert_eq!(state.cached_repo_id, "provider");
+        let mut provider_entity = test_entity("do_work", "src/lib.rs");
+        provider_entity.id = do_work_id;
+        state.graph.upsert_entity(&provider_entity).unwrap();
+        state
+            .is_initialized
+            .store(true, std::sync::atomic::Ordering::Relaxed);
         let layout = state.layout.clone();
         {
             let spine = state.ensure_spine().expect("spine enabled in test");
@@ -14648,10 +14679,10 @@ mod tests {
             .await
             .expect("CLI get_spine_xref call")
         {
-            kin_spine::SpineQuery::Found(edges) => edges,
+            kin_spine::SpineQuery::Found(response) => response,
             other => panic!("CLI get_spine_xref expected Found, got {other:?}"),
         };
-        let cli_xref_to_provider = cli_xref.iter().any(|e| e.dst_repo == "provider");
+        let cli_xref_to_provider = cli_xref.edges.iter().any(|e| e.dst_repo == "provider");
         assert!(
             cli_xref_to_provider,
             "kin xref CLI must resolve consumer->provider: {cli_xref:?}"
@@ -14707,22 +14738,25 @@ mod tests {
             "daemon, CLI, and MCP must all resolve the same consumer->provider xref"
         );
 
-        // The agent-facing MCP handler must project that real incoming edge as
-        // a useful external caller. This pins the complete contract, including
-        // edge direction and the metadata sidecar, rather than merely proving
-        // that the transport returned some JSON.
-        let mut provider_entity = test_entity("do_work", "src/lib.rs");
-        provider_entity.id = do_work_id;
-        let local_graph = kin_db::InMemoryGraph::new();
-        local_graph.upsert_entity(&provider_entity).unwrap();
-        std::env::set_var("KIN_REPO_ID", "provider");
-        let args = HashMap::from([(
-            "entity_id".to_string(),
-            serde_json::json!(do_work_id.to_string()),
-        )]);
-        let result = kin_mcp::handlers::entities::handle_find_references(&args, &local_graph)
+        // The agent-facing production route must project that real incoming
+        // edge without looping back through KIN_DAEMON_URL. A foreign request
+        // argument must not override DaemonState's repo binding.
+        std::env::remove_var("KIN_DAEMON_URL");
+        let result: kin_mcp::ToolCallResult = http
+            .post(format!("{base}/mcp/tools/call"))
+            .json(&serde_json::json!({
+                "name": "find_references",
+                "arguments": {
+                    "entity_id": do_work_id.to_string(),
+                    "repo_id": "request-controlled",
+                },
+            }))
+            .send()
             .await
-            .unwrap();
+            .expect("daemon MCP find_references request")
+            .json()
+            .await
+            .expect("daemon MCP find_references response");
         let kin_mcp::types::ContentBlock::Text { text } = result
             .content
             .first()
@@ -14731,6 +14765,10 @@ mod tests {
         assert_eq!(body["cross_repo"]["status"], "available");
         assert_eq!(body["cross_repo"]["reference_count"], 1);
         assert_eq!(body["cross_repo"]["authority_complete"], true);
+        assert_eq!(
+            body["cross_repo"]["authority_anchor"]["repo_id"],
+            "provider"
+        );
         assert!(body["cross_repo"]["authority_revision"]
             .as_str()
             .is_some_and(|revision| revision.starts_with("sha256:")));
@@ -14744,7 +14782,6 @@ mod tests {
             })
         }));
 
-        std::env::remove_var("KIN_REPO_ID");
         std::env::remove_var("KIN_DAEMON_URL");
         server.abort();
     }

--- a/crates/kin-daemon/src/api.rs
+++ b/crates/kin-daemon/src/api.rs
@@ -8514,22 +8514,13 @@ async fn spine_xref(
     })?;
 
     let entity_id = parse_entity_id_hex(&params.entity)?;
-    let edges = spine.cross_repo_edges_for(&params.repo, &entity_id);
-    let entity_keys = edges
-        .iter()
-        .flat_map(|edge| {
-            [
-                (edge.src_repo.clone(), edge.src_entity),
-                (edge.dst_repo.clone(), edge.dst_entity),
-            ]
-        })
-        .collect::<std::collections::BTreeSet<_>>();
-    let entities = entity_keys
-        .into_iter()
-        .filter_map(|(repo_id, entity_id)| spine.lookup_by_id(&repo_id, &entity_id))
-        .collect();
+    let snapshot = spine.cross_repo_edges_snapshot();
 
-    Ok(Json(kin_spine::SpineXrefResponse::new(edges, entities)))
+    Ok(Json(kin_spine::SpineXrefResponse::from_snapshot(
+        snapshot,
+        &params.repo,
+        &entity_id,
+    )))
 }
 
 /// `GET /v1/spine/edges` — one atomic graph-authoritative cross-repo snapshot.
@@ -14007,6 +13998,16 @@ mod tests {
             serde_json::json!(kin_spine::SPINE_PAYLOAD_VERSION),
             "/spine/xref payload must carry the spine wire-format version"
         );
+        assert_eq!(xbody["authority_complete"], true);
+        assert!(xbody["authority_revision"]
+            .as_str()
+            .is_some_and(|revision| revision.starts_with("sha256:") && revision.len() == 71));
+        assert_eq!(xbody["authority_roots"]["consumer"], "consumer-root");
+        assert_eq!(xbody["authority_roots"]["provider"], "provider-root");
+        assert!(xbody["entities"].as_array().is_some_and(|entities| {
+            entities.iter().any(|entity| entity["name"] == "run_task")
+                && entities.iter().any(|entity| entity["name"] == "do_work")
+        }));
 
         let snapshot = app
             .clone()
@@ -14065,6 +14066,85 @@ mod tests {
             serde_json::json!(kin_spine::SPINE_PAYLOAD_VERSION),
             "/spine/impact payload must carry the spine wire-format version"
         );
+    }
+
+    #[tokio::test]
+    async fn spine_xref_fails_closed_while_topology_is_dirty_then_exposes_complete_watermark() {
+        let consumer_id = EntityId::new();
+        let provider_id = EntityId::new();
+        let state = test_state();
+        let spine = state.ensure_spine().expect("spine enabled in test");
+        spine.register_repo(
+            "consumer",
+            vec![spine_test_entry_with_id(
+                "consumer",
+                consumer_id,
+                "run_task",
+            )],
+            "consumer-root",
+        );
+        spine.register_repo(
+            "provider",
+            vec![spine_test_entry_with_id("provider", provider_id, "do_work")],
+            "provider-root",
+        );
+        spine.add_cross_repo_edge(kin_spine::CrossRepoEdge {
+            src_repo: "consumer".to_string(),
+            src_entity: consumer_id,
+            dst_repo: "provider".to_string(),
+            dst_entity: provider_id,
+            confidence: 0.9,
+        });
+
+        let app = router(state.clone());
+        let read_xref = |app: Router| async move {
+            let response = app
+                .oneshot(
+                    Request::get(format!(
+                        "/spine/xref?repo=provider&entity={}",
+                        provider_id.0
+                    ))
+                    .body(Body::empty())
+                    .unwrap(),
+                )
+                .await
+                .unwrap();
+            assert_eq!(response.status(), StatusCode::OK);
+            serde_json::from_slice::<serde_json::Value>(
+                &axum::body::to_bytes(response.into_body(), 65536)
+                    .await
+                    .unwrap(),
+            )
+            .unwrap()
+        };
+
+        let dirty = read_xref(app.clone()).await;
+        assert_eq!(dirty["authority_complete"], false);
+        assert!(dirty["authority_revision"]
+            .as_str()
+            .is_some_and(|revision| revision.starts_with("sha256:")));
+        assert_eq!(dirty["authority_roots"]["provider"], "provider-root");
+        assert_eq!(dirty["edges"].as_array().map(Vec::len), Some(1));
+        assert_eq!(dirty["entities"].as_array().map(Vec::len), Some(2));
+
+        let mut repos = state
+            .ensure_spine()
+            .expect("spine enabled in test")
+            .registered_repo_ids()
+            .into_iter()
+            .collect::<Vec<_>>();
+        repos.sort();
+        for repo in &repos {
+            state
+                .ensure_spine()
+                .expect("spine enabled in test")
+                .refresh_cross_repo_edges(repo, &[], &[], &repos);
+        }
+        let complete = read_xref(app).await;
+        assert_eq!(complete["authority_complete"], true);
+        assert_eq!(complete["authority_roots"], dirty["authority_roots"]);
+        assert_ne!(complete["authority_revision"], dirty["authority_revision"]);
+        assert!(complete["edges"].as_array().is_some_and(Vec::is_empty));
     }
 
     #[tokio::test]
@@ -14476,13 +14556,28 @@ mod tests {
         let layout = state.layout.clone();
         {
             let spine = state.ensure_spine().expect("spine enabled in test");
-            spine.register_repo("provider", vec![provider_entry], "");
-            spine.refresh_cross_repo_edges(
+            spine.register_repo("provider", vec![provider_entry], "provider-root");
+            spine.register_repo(
                 "consumer",
-                &consumer_entities,
-                &consumer_relations,
-                &["provider".to_string()],
+                consumer_entities
+                    .iter()
+                    .map(|entity| spine_test_entry("consumer", entity))
+                    .collect(),
+                "consumer-root",
             );
+            let mut registry = spine.registered_repo_ids().into_iter().collect::<Vec<_>>();
+            registry.sort();
+            for repo in &registry {
+                match repo.as_str() {
+                    "consumer" => spine.refresh_cross_repo_edges(
+                        repo,
+                        &consumer_entities,
+                        &consumer_relations,
+                        &registry,
+                    ),
+                    _ => spine.refresh_cross_repo_edges(repo, &[], &[], &registry),
+                }
+            }
             assert!(
                 spine.edge_count() >= 1,
                 "fixture must materialize a cross-repo edge (parse -> link -> spine)"
@@ -14630,6 +14725,14 @@ mod tests {
         let body: serde_json::Value = serde_json::from_str(text).unwrap();
         assert_eq!(body["cross_repo"]["status"], "available");
         assert_eq!(body["cross_repo"]["reference_count"], 1);
+        assert_eq!(body["cross_repo"]["authority_complete"], true);
+        assert!(body["cross_repo"]["authority_revision"]
+            .as_str()
+            .is_some_and(|revision| revision.starts_with("sha256:")));
+        assert_eq!(
+            body["cross_repo"]["authority_roots"]["provider"],
+            "provider-root"
+        );
         assert!(body["references"].as_array().is_some_and(|references| {
             references.iter().any(|reference| {
                 reference["name"] == "run_task" && reference["file_path"] == "[consumer] src/app.rs"
@@ -14758,6 +14861,110 @@ mod tests {
         std::env::remove_var("KIN_REPO_ID");
         std::env::remove_var("KIN_DAEMON_URL");
         server.abort();
+    }
+
+    #[tokio::test]
+    #[serial_test::serial]
+    async fn mcp_find_references_treats_legacy_unwatermarked_xref_as_inconclusive() {
+        async fn legacy_xref() -> Json<serde_json::Value> {
+            Json(serde_json::json!({
+                "version": kin_spine::SPINE_PAYLOAD_VERSION,
+                "edges": [],
+            }))
+        }
+
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let addr = listener.local_addr().unwrap();
+        let server = tokio::spawn(async move {
+            let _ = axum::serve(listener, Router::new().fallback(legacy_xref)).await;
+        });
+        std::env::set_var("KIN_DAEMON_URL", format!("http://{addr}"));
+        std::env::set_var("KIN_REPO_ID", "provider");
+
+        let target = test_entity("do_work", "src/lib.rs");
+        let graph = kin_db::InMemoryGraph::new();
+        graph.upsert_entity(&target).unwrap();
+        let args = HashMap::from([(
+            "entity_id".to_string(),
+            serde_json::json!(target.id.to_string()),
+        )]);
+        let result = kin_mcp::handlers::entities::handle_find_references(&args, &graph)
+            .await
+            .unwrap();
+        let result = kin_mcp::finalize_with_envelope(
+            result,
+            kin_mcp::Envelope::daemon().with_health(&serde_json::json!({
+                "initialized": true,
+                "graph_loaded": true,
+                "graph_generation": 12,
+            })),
+            "find_references",
+        );
+        let kin_mcp::types::ContentBlock::Text { text } = result
+            .content
+            .first()
+            .expect("find_references text response");
+        let body: serde_json::Value = serde_json::from_str(text).unwrap();
+        assert_eq!(body["cross_repo"]["status"], "available");
+        assert_eq!(body["cross_repo"]["authority_complete"], false);
+        assert_eq!(
+            body["cross_repo"]["authority_revision"],
+            serde_json::Value::Null
+        );
+        assert_eq!(body["negative"]["safe_to_conclude_absent"], false);
+        assert!(body["negative"]["trust_reason"]
+            .as_str()
+            .is_some_and(|reason| reason.contains("cross_repo_authority_incomplete")));
+
+        std::env::remove_var("KIN_REPO_ID");
+        std::env::remove_var("KIN_DAEMON_URL");
+        server.abort();
+    }
+
+    #[tokio::test]
+    #[serial_test::serial]
+    async fn mcp_find_references_requires_nonblank_repo_binding() {
+        let target = test_entity("do_work", "src/lib.rs");
+        let graph = kin_db::InMemoryGraph::new();
+        graph.upsert_entity(&target).unwrap();
+        let args = HashMap::from([(
+            "entity_id".to_string(),
+            serde_json::json!(target.id.to_string()),
+        )]);
+
+        for repo_id in [None, Some("   ")] {
+            match repo_id {
+                Some(value) => std::env::set_var("KIN_REPO_ID", value),
+                None => std::env::remove_var("KIN_REPO_ID"),
+            }
+            let result = kin_mcp::handlers::entities::handle_find_references(&args, &graph)
+                .await
+                .unwrap();
+            let result = kin_mcp::finalize_with_envelope(
+                result,
+                kin_mcp::Envelope::daemon().with_health(&serde_json::json!({
+                    "initialized": true,
+                    "graph_loaded": true,
+                    "graph_generation": 12,
+                })),
+                "find_references",
+            );
+            let kin_mcp::types::ContentBlock::Text { text } = result
+                .content
+                .first()
+                .expect("find_references text response");
+            let body: serde_json::Value = serde_json::from_str(text).unwrap();
+            assert_eq!(body["cross_repo"]["status"], "unavailable");
+            assert!(body["cross_repo"]["reason"]
+                .as_str()
+                .is_some_and(|reason| reason.contains("KIN_REPO_ID is missing or blank")));
+            assert_eq!(body["negative"]["safe_to_conclude_absent"], false);
+            assert!(body["negative"]["trust_reason"]
+                .as_str()
+                .is_some_and(|reason| reason.contains("cross_repo_unavailable")));
+        }
+
+        std::env::remove_var("KIN_REPO_ID");
     }
 
     // -----------------------------------------------------------------------

--- a/crates/kin-daemon/src/api.rs
+++ b/crates/kin-daemon/src/api.rs
@@ -13999,6 +13999,11 @@ mod tests {
             "/spine/xref payload must carry the spine wire-format version"
         );
         assert_eq!(xbody["authority_complete"], true);
+        assert_eq!(xbody["authority_anchor"]["repo_id"], "consumer");
+        assert_eq!(
+            xbody["authority_anchor"]["entity_id"],
+            serde_json::json!(run_task_id)
+        );
         assert!(xbody["authority_revision"]
             .as_str()
             .is_some_and(|revision| revision.starts_with("sha256:") && revision.len() == 71));
@@ -14865,7 +14870,7 @@ mod tests {
 
     #[tokio::test]
     #[serial_test::serial]
-    async fn mcp_find_references_treats_legacy_unwatermarked_xref_as_inconclusive() {
+    async fn mcp_find_references_rejects_unanchored_xref_as_inconclusive() {
         async fn legacy_xref() -> Json<serde_json::Value> {
             Json(serde_json::json!({
                 "version": kin_spine::SPINE_PAYLOAD_VERSION,
@@ -14905,16 +14910,14 @@ mod tests {
             .first()
             .expect("find_references text response");
         let body: serde_json::Value = serde_json::from_str(text).unwrap();
-        assert_eq!(body["cross_repo"]["status"], "available");
-        assert_eq!(body["cross_repo"]["authority_complete"], false);
-        assert_eq!(
-            body["cross_repo"]["authority_revision"],
-            serde_json::Value::Null
-        );
+        assert_eq!(body["cross_repo"]["status"], "unavailable");
+        assert!(body["cross_repo"]["reason"]
+            .as_str()
+            .is_some_and(|reason| reason.contains("xref response anchor does not match")));
         assert_eq!(body["negative"]["safe_to_conclude_absent"], false);
         assert!(body["negative"]["trust_reason"]
             .as_str()
-            .is_some_and(|reason| reason.contains("cross_repo_authority_incomplete")));
+            .is_some_and(|reason| reason.contains("cross_repo_unavailable")));
 
         std::env::remove_var("KIN_REPO_ID");
         std::env::remove_var("KIN_DAEMON_URL");

--- a/crates/kin-daemon/src/api.rs
+++ b/crates/kin-daemon/src/api.rs
@@ -1233,6 +1233,247 @@ async fn resolve_session_graph(
     state.graph_for_request(session_id).await
 }
 
+const XREF_STABLE_READ_ATTEMPTS: usize = 3;
+
+/// One optimistic, point-in-time graph authority used by xref-style reads.
+///
+/// Both authorities are detached through one entity/relation snapshot so the
+/// handler's multi-call read cannot straddle a mutation. HEAD additionally
+/// pairs the snapshot's semantic root with the daemon's monotonic mutation
+/// version. Session-scope graphs do not participate in that HEAD version, so
+/// their selected graph pointer and exact live root are revalidated instead.
+struct XrefGraphReadAttempt {
+    graph: Arc<kin_db::InMemoryGraph>,
+    root: String,
+    head_version: Option<u64>,
+    mutation_epoch: u64,
+}
+
+fn prepare_xref_graph_read(
+    state: &DaemonState,
+    selected_graph: &Arc<kin_db::InMemoryGraph>,
+    authority: RequestGraphAuthority,
+) -> Option<XrefGraphReadAttempt> {
+    let mutation_epoch = state.stable_graph_authority_epoch()?;
+    match authority {
+        RequestGraphAuthority::Head => {
+            let version_before = state.vfs_version.load(std::sync::atomic::Ordering::SeqCst);
+            // Query a detached entity/relation domain even for HEAD. The
+            // version is published at the end of a graph mutation, so merely
+            // stamping the live graph would still allow several handler reads
+            // to observe different intermediate lock-points before that bump.
+            let snapshot = selected_graph.to_snapshot();
+            let root_hash = kin_db::compute_graph_root_hash(&snapshot);
+            let root = hex::encode(root_hash);
+            let live_root = hex::encode(selected_graph.compute_root_hash());
+            let version_after = state.vfs_version.load(std::sync::atomic::Ordering::SeqCst);
+            (version_before == version_after
+                && root == live_root
+                && state.graph_authority_epoch_is_current(mutation_epoch))
+            .then(|| XrefGraphReadAttempt {
+                graph: Arc::new(
+                    kin_db::InMemoryGraph::from_snapshot_without_text_index_with_root_hash(
+                        snapshot, root_hash,
+                    ),
+                ),
+                root,
+                head_version: Some(version_after),
+                mutation_epoch,
+            })
+        }
+        RequestGraphAuthority::SessionScope => {
+            // `to_snapshot` clones the entity/relation store under one graph
+            // read lock. Build the query graph from that detached state so a
+            // private ref-hydration cannot interleave the handler's entity and
+            // relation reads. A live-root check below still rejects a snapshot
+            // that was already superseded before the attempt began.
+            let snapshot = selected_graph.to_snapshot();
+            let root_hash = kin_db::compute_graph_root_hash(&snapshot);
+            let root = hex::encode(root_hash);
+            if root != hex::encode(selected_graph.compute_root_hash()) {
+                return None;
+            }
+            if !state.graph_authority_epoch_is_current(mutation_epoch) {
+                return None;
+            }
+            Some(XrefGraphReadAttempt {
+                graph: Arc::new(
+                    kin_db::InMemoryGraph::from_snapshot_without_text_index_with_root_hash(
+                        snapshot, root_hash,
+                    ),
+                ),
+                root,
+                head_version: None,
+                mutation_epoch,
+            })
+        }
+    }
+}
+
+async fn xref_graph_read_is_still_current(
+    state: &DaemonState,
+    session_id: Option<&SessionId>,
+    selected_graph: &Arc<kin_db::InMemoryGraph>,
+    authority: RequestGraphAuthority,
+    attempt: &XrefGraphReadAttempt,
+) -> bool {
+    if !state.graph_authority_epoch_is_current(attempt.mutation_epoch) {
+        return false;
+    }
+    match authority {
+        RequestGraphAuthority::Head => {
+            let Some(expected_version) = attempt.head_version else {
+                return false;
+            };
+            let version_before = state.vfs_version.load(std::sync::atomic::Ordering::SeqCst);
+            if version_before != expected_version {
+                return false;
+            }
+            let root_after = hex::encode(selected_graph.compute_root_hash());
+            let version_after = state.vfs_version.load(std::sync::atomic::Ordering::SeqCst);
+            version_after == expected_version
+                && root_after == attempt.root
+                && state.graph_authority_epoch_is_current(attempt.mutation_epoch)
+        }
+        RequestGraphAuthority::SessionScope => {
+            if hex::encode(selected_graph.compute_root_hash()) != attempt.root
+                || !state
+                    .ref_hydration_authority_is_current(session_id, selected_graph, authority)
+                    .await
+            {
+                return false;
+            }
+            state.graph_authority_epoch_is_current(attempt.mutation_epoch)
+        }
+    }
+}
+
+async fn command_xref_with_stable_authority<F>(
+    state: &DaemonState,
+    session_id: Option<&SessionId>,
+    selected_graph: Arc<kin_db::InMemoryGraph>,
+    authority: RequestGraphAuthority,
+    request: &kin_cli::commands::xref::XrefRequest,
+    mut after_root: F,
+) -> Result<kin_cli::commands::xref::XrefResponse, (StatusCode, String)>
+where
+    F: FnMut(usize),
+{
+    // Initialize once outside the stamped interval: lazy spine hydration and
+    // registration can be expensive, but it is not part of the graph read.
+    let spine = state.ensure_spine();
+    for attempt_number in 0..XREF_STABLE_READ_ATTEMPTS {
+        let Some(attempt) = prepare_xref_graph_read(state, &selected_graph, authority) else {
+            continue;
+        };
+        after_root(attempt_number);
+        let response = kin_cli::commands::xref::build_xref_response(
+            attempt.graph.as_ref(),
+            request,
+            &state.cached_repo_id,
+            &attempt.root,
+            spine,
+        )
+        .await;
+        if xref_graph_read_is_still_current(state, session_id, &selected_graph, authority, &attempt)
+            .await
+        {
+            return response.map_err(internal_error);
+        }
+        tracing::warn!(
+            attempt = attempt_number + 1,
+            "graph authority changed during command xref; retrying"
+        );
+    }
+    Err((
+        StatusCode::SERVICE_UNAVAILABLE,
+        "graph authority changed repeatedly during command xref; retry".to_string(),
+    ))
+}
+
+async fn mcp_find_references_with_stable_authority<F>(
+    state: &DaemonState,
+    session_id: Option<&SessionId>,
+    selected_graph: Arc<kin_db::InMemoryGraph>,
+    authority: RequestGraphAuthority,
+    arguments: &HashMap<String, serde_json::Value>,
+    mut after_root: F,
+) -> kin_mcp::Result<kin_mcp::ToolCallResult>
+where
+    F: FnMut(usize),
+{
+    let spine = state.ensure_spine();
+    for attempt_number in 0..XREF_STABLE_READ_ATTEMPTS {
+        let Some(attempt) = prepare_xref_graph_read(state, &selected_graph, authority) else {
+            continue;
+        };
+        after_root(attempt_number);
+        let result = kin_mcp::handlers::entities::handle_find_references_with_authority(
+            arguments,
+            attempt.graph.as_ref(),
+            kin_mcp::handlers::entities::FindReferencesAuthority {
+                repo_id: &state.cached_repo_id,
+                graph_root: &attempt.root,
+                spine,
+            },
+        )
+        .await;
+        if xref_graph_read_is_still_current(state, session_id, &selected_graph, authority, &attempt)
+            .await
+        {
+            return result;
+        }
+        tracing::warn!(
+            attempt = attempt_number + 1,
+            "graph authority changed during MCP find_references; retrying"
+        );
+    }
+    Err(kin_mcp::McpError::Other(
+        "graph authority changed repeatedly during find_references; retry".to_string(),
+    ))
+}
+
+async fn mcp_bulk_check_references_with_stable_authority<F>(
+    state: &DaemonState,
+    session_id: Option<&SessionId>,
+    selected_graph: Arc<kin_db::InMemoryGraph>,
+    authority: RequestGraphAuthority,
+    arguments: &HashMap<String, serde_json::Value>,
+    mut after_root: F,
+) -> kin_mcp::Result<kin_mcp::ToolCallResult>
+where
+    F: FnMut(usize),
+{
+    let spine = state.ensure_spine();
+    for attempt_number in 0..XREF_STABLE_READ_ATTEMPTS {
+        let Some(attempt) = prepare_xref_graph_read(state, &selected_graph, authority) else {
+            continue;
+        };
+        after_root(attempt_number);
+        let result = kin_mcp::handlers::entities::handle_bulk_check_references_with_authority(
+            arguments,
+            attempt.graph.as_ref(),
+            kin_mcp::handlers::entities::FindReferencesAuthority {
+                repo_id: &state.cached_repo_id,
+                graph_root: &attempt.root,
+                spine,
+            },
+        );
+        if xref_graph_read_is_still_current(state, session_id, &selected_graph, authority, &attempt)
+            .await
+        {
+            return result;
+        }
+        tracing::warn!(
+            attempt = attempt_number + 1,
+            "graph authority changed during MCP bulk_check_references; retrying"
+        );
+    }
+    Err(kin_mcp::McpError::Other(
+        "graph authority changed repeatedly during bulk_check_references; retry".to_string(),
+    ))
+}
+
 /// Resolve the graph together with the authority that owns ref hydration.
 ///
 /// A request may wait a long time for the serialized hydration gate. Resolve
@@ -1652,9 +1893,13 @@ async fn set_scope(
     } else {
         None
     };
+    let graph_mutation = hydration_gate
+        .as_ref()
+        .map(|_| state.begin_graph_authority_mutation());
     let scope_task = tokio::task::spawn_blocking(
         move || -> std::result::Result<_, (StatusCode, String)> {
             let _hydration_gate = hydration_gate;
+            let _graph_mutation = graph_mutation;
             // Resolve the ref through the locate entry point, which hydrates a
             // not-yet-imported Git ancestry at artifact-only depth. Scope-for-
             // retrieval only needs the base_commit's tree state: build_graph_at_ref
@@ -1873,6 +2118,7 @@ async fn graph_commit(
         }
     }
 
+    let graph_mutation = state.begin_graph_authority_mutation();
     for delta in &request.change.entity_deltas {
         match delta {
             EntityDelta::Added(e) => {
@@ -1932,6 +2178,7 @@ async fn graph_commit(
 
     // Broadcast root hash change and compact the delta journal at the commit boundary.
     state.bump_version();
+    drop(graph_mutation);
     state.save_snapshot_full().map_err(internal_error)?;
     state.emit_event(DaemonEvent::GraphRootChanged {
         old_root_hash: None,
@@ -2343,11 +2590,18 @@ async fn command_xref(
     }
 
     let session_id = extract_session_id_from_headers(&headers)?;
-    let graph = resolve_session_graph(&state, session_id.as_ref()).await;
-    let response =
-        kin_cli::commands::xref::build_xref_response(&state.layout, graph.as_ref(), &request)
-            .await
-            .map_err(internal_error)?;
+    let (graph, authority) = state
+        .graph_for_request_with_authority(session_id.as_ref())
+        .await;
+    let response = command_xref_with_stable_authority(
+        &state,
+        session_id.as_ref(),
+        graph,
+        authority,
+        &request,
+        |_| {},
+    )
+    .await?;
     Ok(Json(response))
 }
 
@@ -3496,6 +3750,9 @@ async fn locate(
         } else {
             None
         };
+        let _graph_mutation = _hydration_gate
+            .as_ref()
+            .map(|_| state.begin_graph_authority_mutation());
         let resolved = kin_cli::commands::ref_lookup::resolve_ref_importing_git_if_needed_for_locate_with_report(
             state.graph.as_ref(),
             &state.layout,
@@ -3935,6 +4192,9 @@ async fn review(
                 let references = [base.as_str(), head.as_str()];
                 resolve_ref_hydration_graph(&state, session_id.as_ref(), &references).await
             };
+            let graph_mutation = hydration_gate
+                .as_ref()
+                .map(|_| state.begin_graph_authority_mutation());
             // Shadow review resolves both refs at full semantic depth, so the
             // same synchronous multi-minute replay applies. Blocking pool, gate
             // round-trips out for the drop below.
@@ -3972,6 +4232,7 @@ async fn review(
                 "review",
                 "review-hydration",
             )?;
+            drop(graph_mutation);
             drop(hydration_gate);
 
             let response =
@@ -4264,6 +4525,9 @@ async fn blame(
     let reference = req.reference.as_deref();
     let (graph, authority, hydration_gate) =
         resolve_ref_hydration_graph(&state, session_id.as_ref(), reference.as_slice()).await;
+    let graph_mutation = hydration_gate
+        .as_ref()
+        .map(|_| state.begin_graph_authority_mutation());
     // Preparing resolves the ref, which hydrates a not-yet-imported ancestry at
     // full semantic depth — minutes of synchronous replay. Run it on the
     // blocking pool so it cannot park an async worker; the gate comes back out
@@ -4299,6 +4563,7 @@ async fn blame(
         "blame",
         "blame-hydration",
     )?;
+    drop(graph_mutation);
     drop(hydration_gate);
 
     let response =
@@ -4336,6 +4601,9 @@ async fn history(
     let reference = req.reference.as_deref();
     let (graph, authority, hydration_gate) =
         resolve_ref_hydration_graph(&state, session_id.as_ref(), reference.as_slice()).await;
+    let graph_mutation = hydration_gate
+        .as_ref()
+        .map(|_| state.begin_graph_authority_mutation());
     // Same reasoning as blame: full-depth semantic hydration is synchronous and
     // minutes long, so it runs on the blocking pool and the gate round-trips.
     let (prepared, hydration_gate) = {
@@ -4369,6 +4637,7 @@ async fn history(
         "history",
         "history-hydration",
     )?;
+    drop(graph_mutation);
     drop(hydration_gate);
 
     let response =
@@ -4381,6 +4650,18 @@ async fn history(
                 }
             })?;
     Ok(Json(response))
+}
+
+/// Hold graph authority unstable for one logical writer transaction.
+///
+/// The guard deliberately spans durable acknowledgement as well as in-memory
+/// mutations so xref readers cannot certify an intermediate batch or a graph
+/// state whose generation has not yet been persisted.
+fn with_graph_authority_mutation<T>(state: &DaemonState, operation: impl FnOnce() -> T) -> T {
+    let mutation = state.begin_graph_authority_mutation();
+    let result = operation();
+    drop(mutation);
+    result
 }
 
 /// POST /verify/run — execute and persist a verification run in daemon state.
@@ -4400,18 +4681,20 @@ async fn verify_run(
 
     let state_for_verify = Arc::clone(&state);
     let response = tokio::task::spawn_blocking(move || {
-        let response = kin_cli::commands::verify::execute_verify_run(
-            &state_for_verify.layout,
-            state_for_verify.graph.as_ref(),
-            &req,
-        )
-        .map_err(|error| error.to_string())?;
-        state_for_verify.bump_version();
-        state_for_verify
-            .save_snapshot()
+        with_graph_authority_mutation(state_for_verify.as_ref(), || {
+            let response = kin_cli::commands::verify::execute_verify_run(
+                &state_for_verify.layout,
+                state_for_verify.graph.as_ref(),
+                &req,
+            )
             .map_err(|error| error.to_string())?;
-        state_for_verify.mark_clean();
-        Ok::<_, String>(response)
+            state_for_verify.bump_version();
+            state_for_verify
+                .save_snapshot()
+                .map_err(|error| error.to_string())?;
+            state_for_verify.mark_clean();
+            Ok::<_, String>(response)
+        })
     })
     .await
     .map_err(internal_error)?
@@ -4492,32 +4775,36 @@ async fn reconcile(
             }
         };
         tokio::task::spawn_blocking(move || {
-            kin_cli::commands::reconcile::execute_reconcile_session_dir_scoped(
-                &state_for_reconcile.layout,
-                scoped_graph.as_ref(),
-                &req.session_dir,
-            )
-            .map_err(|error| error.to_string())
+            with_graph_authority_mutation(state_for_reconcile.as_ref(), || {
+                kin_cli::commands::reconcile::execute_reconcile_session_dir_scoped(
+                    &state_for_reconcile.layout,
+                    scoped_graph.as_ref(),
+                    &req.session_dir,
+                )
+                .map_err(|error| error.to_string())
+            })
         })
         .await
         .map_err(internal_error)?
         .map_err(internal_error)?
     } else {
         tokio::task::spawn_blocking(move || {
-            kin_cli::commands::reconcile::execute_reconcile_session_dir_with_persist(
-                &state_for_reconcile.layout,
-                state_for_reconcile.graph.as_ref(),
-                &req.session_dir,
-                || {
-                    state_for_reconcile.bump_version();
-                    state_for_reconcile.save_snapshot().map_err(|error| {
-                        std::io::Error::new(std::io::ErrorKind::Other, error.to_string())
-                    })?;
-                    state_for_reconcile.mark_clean();
-                    Ok(())
-                },
-            )
-            .map_err(|error| error.to_string())
+            with_graph_authority_mutation(state_for_reconcile.as_ref(), || {
+                kin_cli::commands::reconcile::execute_reconcile_session_dir_with_persist(
+                    &state_for_reconcile.layout,
+                    state_for_reconcile.graph.as_ref(),
+                    &req.session_dir,
+                    || {
+                        state_for_reconcile.bump_version();
+                        state_for_reconcile.save_snapshot().map_err(|error| {
+                            std::io::Error::new(std::io::ErrorKind::Other, error.to_string())
+                        })?;
+                        state_for_reconcile.mark_clean();
+                        Ok(())
+                    },
+                )
+                .map_err(|error| error.to_string())
+            })
         })
         .await
         .map_err(internal_error)?
@@ -5745,10 +6032,12 @@ async fn mcp_tools_call(
 
     let session_id = extract_session_id_from_headers(&headers)?;
     let mutates = mcp_tool_mutates_graph(&request.name);
-    let graph = if mutates {
-        Arc::clone(&state.graph)
+    let (graph, graph_authority) = if mutates {
+        (Arc::clone(&state.graph), RequestGraphAuthority::Head)
     } else {
-        resolve_session_graph(&state, session_id.as_ref()).await
+        state
+            .graph_for_request_with_authority(session_id.as_ref())
+            .await
     };
 
     if matches!(
@@ -6110,6 +6399,7 @@ async fn mcp_tools_call(
         )?;
     }
 
+    let graph_mutation = mutates.then(|| state.begin_graph_authority_mutation());
     let mut result = if transaction_preflight
         .as_ref()
         .is_some_and(|preflight| !preflight.allowed)
@@ -6125,13 +6415,23 @@ async fn mcp_tools_call(
         ))
     } else {
         let handled = if request.name == "find_references" {
-            kin_mcp::handlers::entities::handle_find_references_with_authority(
+            mcp_find_references_with_stable_authority(
+                &state,
+                session_id.as_ref(),
+                Arc::clone(&graph),
+                graph_authority,
                 &request.arguments,
-                graph.as_ref(),
-                kin_mcp::handlers::entities::FindReferencesAuthority {
-                    repo_id: &state.cached_repo_id,
-                    spine: state.ensure_spine(),
-                },
+                |_| {},
+            )
+            .await
+        } else if request.name == "bulk_check_references" {
+            mcp_bulk_check_references_with_stable_authority(
+                &state,
+                session_id.as_ref(),
+                Arc::clone(&graph),
+                graph_authority,
+                &request.arguments,
+                |_| {},
             )
             .await
         } else {
@@ -6341,6 +6641,7 @@ async fn mcp_tools_call(
         )?;
     }
 
+    drop(graph_mutation);
     Ok(Json(result))
 }
 
@@ -7987,6 +8288,7 @@ async fn vfs_file_changed(
 
     let mut reconciler = state.reconciler.write().await;
     let mut wc = state.working_copy.write().await;
+    let graph_mutation = state.begin_graph_authority_mutation();
 
     // Temporarily adopt the caller's session so the reconciler's own collision
     // check excludes the caller's intents (parity with /vfs/write-notify); the
@@ -8089,6 +8391,9 @@ async fn vfs_file_changed(
             // VFS reads serve updated FileLayouts.
             if !projection_changed.is_empty() {
                 state.bump_version(); // marks dirty for background persistence
+            }
+            drop(graph_mutation);
+            if !projection_changed.is_empty() {
                 if let Err(e) = state.refresh_projection(&projection_changed).await {
                     tracing::warn!(error = %e, "failed to refresh projection after write-back");
                 }
@@ -8180,6 +8485,7 @@ async fn vfs_write_notify(
 
     let mut reconciler = state.reconciler.write().await;
     let mut wc = state.working_copy.write().await;
+    let graph_mutation = state.begin_graph_authority_mutation();
 
     // If the caller supplies a session_id, temporarily set it on the
     // reconciler so check_scopes() excludes the caller's own intents.
@@ -8279,6 +8585,9 @@ async fn vfs_write_notify(
 
             if !projection_changed.is_empty() {
                 state.bump_version(); // marks dirty for background persistence
+            }
+            drop(graph_mutation);
+            if !projection_changed.is_empty() {
                 if let Err(e) = state.refresh_projection(&projection_changed).await {
                     tracing::warn!(error = %e, "failed to refresh projection after write-notify");
                 }
@@ -8526,13 +8835,9 @@ async fn spine_xref(
     })?;
 
     let entity_id = parse_entity_id_hex(&params.entity)?;
-    let snapshot = spine.cross_repo_edges_snapshot();
-
-    Ok(Json(kin_spine::SpineXrefResponse::from_snapshot(
-        snapshot,
-        &params.repo,
-        &entity_id,
-    )))
+    Ok(Json(
+        spine.cross_repo_xref_response(&params.repo, &entity_id),
+    ))
 }
 
 /// `GET /v1/spine/edges` — one atomic graph-authoritative cross-repo snapshot.
@@ -9836,7 +10141,9 @@ mod tests {
                 .join(format!("kin-daemon-test-registry-{}", uuid::Uuid::new_v4()));
             std::fs::create_dir_all(&root).unwrap();
             let path = root.join("registry.toml");
-            std::fs::write(&path, "repos = []\n").unwrap();
+            kin_core::registry::KinRegistry { repos: Vec::new() }
+                .save_to(&path)
+                .unwrap();
             path
         });
 
@@ -14500,9 +14807,18 @@ mod tests {
         // iterate over (their graphs are unavailable without a backend). The
         // daemon's own repo is also registered and remains loadable from its
         // in-process graph.
-        spine.register_repo("kin", vec![], "");
-        spine.register_repo("kin-db", vec![], "");
-        let app = router(state);
+        spine.register_repo("kin", vec![], "kin-root");
+        spine.register_repo("kin-db", vec![], "kin-db-root");
+        let mut repos = spine.registered_repo_ids().into_iter().collect::<Vec<_>>();
+        repos.sort();
+        for repo in &repos {
+            spine.refresh_cross_repo_edges(repo, &[], &[], &repos);
+        }
+        assert!(
+            spine.cross_repo_edges_snapshot().complete,
+            "fixture starts complete so skipped loads test invalidation"
+        );
+        let app = router(Arc::clone(&state));
 
         let response = app
             .oneshot(
@@ -14528,10 +14844,19 @@ mod tests {
             body.get("crossRepoEdges").is_some(),
             "response must carry crossRepoEdges, got {body}"
         );
-        // No backend means the two foreign repo graphs are unavailable, while
-        // the daemon's own cached repo identity refreshes from its in-process
-        // graph. The partial pass still answers cleanly rather than failing.
-        assert_eq!(body["reposRefreshed"], serde_json::json!(1));
+        // No backend means the two foreign repo graphs are unavailable. The
+        // two-phase pass must not certify a partial registry by refreshing only
+        // the daemon's in-process repo, so zero repos are reported refreshed
+        // and the prior complete watermark remains revoked.
+        assert_eq!(body["reposRefreshed"], serde_json::json!(0));
+        assert!(
+            !state
+                .ensure_spine()
+                .expect("spine remains enabled")
+                .cross_repo_edges_snapshot()
+                .complete,
+            "skipped registered repos must revoke the old complete watermark"
+        );
     }
 
     /// One gate proving the cross-repo blast radius is consistent across every
@@ -14590,9 +14915,10 @@ mod tests {
             .is_initialized
             .store(true, std::sync::atomic::Ordering::Relaxed);
         let layout = state.layout.clone();
+        let provider_root = hex::encode(state.graph.compute_root_hash());
         {
             let spine = state.ensure_spine().expect("spine enabled in test");
-            spine.register_repo("provider", vec![provider_entry], "provider-root");
+            spine.register_repo("provider", vec![provider_entry], &provider_root);
             spine.register_repo(
                 "consumer",
                 consumer_entities
@@ -14774,7 +15100,7 @@ mod tests {
             .is_some_and(|revision| revision.starts_with("sha256:")));
         assert_eq!(
             body["cross_repo"]["authority_roots"]["provider"],
-            "provider-root"
+            provider_root
         );
         assert!(body["references"].as_array().is_some_and(|references| {
             references.iter().any(|reference| {
@@ -14784,6 +15110,315 @@ mod tests {
 
         std::env::remove_var("KIN_DAEMON_URL");
         server.abort();
+    }
+
+    #[tokio::test]
+    async fn daemon_mcp_bulk_reachability_uses_exact_federated_authority() {
+        let state = test_state_with_repo_id(Some("provider"));
+        let target = test_entity("target", "src/lib.rs");
+        let source = test_entity("caller", "src/app.rs");
+        state.graph.upsert_entity(&target).unwrap();
+        state
+            .is_initialized
+            .store(true, std::sync::atomic::Ordering::Relaxed);
+
+        let spine = state.ensure_spine().expect("spine enabled in test");
+        let provider_root = hex::encode(state.graph.compute_root_hash());
+        assert_eq!(
+            spine.root_hash("provider").as_deref(),
+            Some(provider_root.as_str())
+        );
+        spine.register_repo(
+            "consumer",
+            vec![spine_test_entry("consumer", &source)],
+            "consumer-root",
+        );
+        let mut repos = spine.registered_repo_ids().into_iter().collect::<Vec<_>>();
+        repos.sort();
+        for repo in &repos {
+            spine.refresh_cross_repo_edges(repo, &[], &[], &repos);
+        }
+        spine.add_cross_repo_edge(kin_spine::CrossRepoEdge {
+            src_repo: "consumer".to_string(),
+            src_entity: source.id,
+            dst_repo: "provider".to_string(),
+            dst_entity: target.id,
+            confidence: 0.9,
+        });
+
+        let result = mcp_call(
+            router(Arc::clone(&state)),
+            "bulk_check_references",
+            serde_json::json!({
+                "entity_ids": [target.id.to_string()],
+                "relation_kind": "Any",
+            }),
+        )
+        .await;
+        let result = kin_mcp::finalize_with_envelope(
+            result,
+            kin_mcp::Envelope::daemon().with_health(&serde_json::json!({
+                "initialized": true,
+                "graph_loaded": true,
+                "graph_generation": 12,
+            })),
+            "bulk_check_references",
+        );
+        let body: serde_json::Value = serde_json::from_str(&mcp_result_text(&result)).unwrap();
+        assert_eq!(body["results"][0]["has_references"], true);
+        assert_eq!(body["results"][0]["federated_reference_count"], 1);
+        assert_eq!(body["cross_repo"]["authority_complete"], true);
+        assert_eq!(
+            body["cross_repo"]["authority_roots"]["provider"],
+            provider_root
+        );
+        assert_eq!(body["negative"]["safe_to_conclude_absent"], true);
+    }
+
+    #[tokio::test]
+    async fn xref_reads_retry_when_head_mutates_between_root_and_read_even_after_aba() {
+        let state = test_state_with_repo_id(Some("provider"));
+        let target = test_entity("target", "src/lib.rs");
+        state.graph.upsert_entity(&target).unwrap();
+        let stable_root = state.graph.compute_root_hash();
+        let stable_root_hex = hex::encode(stable_root);
+
+        // Initialize a complete spine at the same semantic root. Every hook
+        // below inserts and removes a transient entity after the root stamp,
+        // returning the graph to this exact root. Root-only validation would
+        // accept the first attempt; the monotonic HEAD version must force one
+        // retry while each handler reads its detached snapshot.
+        let spine = state.ensure_spine().expect("spine enabled in test");
+        assert_eq!(
+            spine.root_hash("provider").as_deref(),
+            Some(stable_root_hex.as_str())
+        );
+        assert!(
+            spine.cross_repo_edges_snapshot().complete,
+            "stable primary initialization must publish complete local spine authority"
+        );
+
+        let command_attempts = Arc::new(std::sync::atomic::AtomicUsize::new(0));
+        let command_hook_state = Arc::clone(&state);
+        let command_hook_attempts = Arc::clone(&command_attempts);
+        let command_transient = test_entity("command_transient", "src/transient.rs");
+        let command = command_xref_with_stable_authority(
+            &state,
+            None,
+            Arc::clone(&state.graph),
+            RequestGraphAuthority::Head,
+            &kin_cli::commands::xref::XrefRequest {
+                entity: target.name.clone(),
+            },
+            move |attempt| {
+                command_hook_attempts.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+                if attempt == 0 {
+                    command_hook_state
+                        .graph
+                        .upsert_entity(&command_transient)
+                        .unwrap();
+                    command_hook_state
+                        .graph
+                        .remove_entity(&command_transient.id)
+                        .unwrap();
+                    command_hook_state.bump_version();
+                }
+            },
+        )
+        .await
+        .expect("command xref retries onto stable authority");
+        assert_eq!(
+            command_attempts.load(std::sync::atomic::Ordering::SeqCst),
+            2
+        );
+        assert_eq!(state.graph.compute_root_hash(), stable_root);
+        assert!(command
+            .spine
+            .as_ref()
+            .is_some_and(|body| body.authority_complete_for("provider", &target.id)));
+
+        let arguments = serde_json::from_value::<HashMap<String, serde_json::Value>>(json!({
+            "entity_id": target.id.to_string(),
+        }))
+        .unwrap();
+        let find_attempts = Arc::new(std::sync::atomic::AtomicUsize::new(0));
+        let find_hook_state = Arc::clone(&state);
+        let find_hook_attempts = Arc::clone(&find_attempts);
+        let find_transient = test_entity("find_transient", "src/transient.rs");
+        let find = mcp_find_references_with_stable_authority(
+            &state,
+            None,
+            Arc::clone(&state.graph),
+            RequestGraphAuthority::Head,
+            &arguments,
+            move |attempt| {
+                find_hook_attempts.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+                if attempt == 0 {
+                    find_hook_state
+                        .graph
+                        .upsert_entity(&find_transient)
+                        .unwrap();
+                    find_hook_state
+                        .graph
+                        .remove_entity(&find_transient.id)
+                        .unwrap();
+                    find_hook_state.bump_version();
+                }
+            },
+        )
+        .await
+        .expect("find_references retries onto stable authority");
+        assert_eq!(find_attempts.load(std::sync::atomic::Ordering::SeqCst), 2);
+        let find_body: serde_json::Value = serde_json::from_str(&mcp_result_text(&find)).unwrap();
+        assert_eq!(find_body["cross_repo"]["status"], "available");
+        assert_eq!(find_body["cross_repo"]["authority_complete"], true);
+
+        let arguments = serde_json::from_value::<HashMap<String, serde_json::Value>>(json!({
+            "entity_ids": [target.id.to_string()],
+            "relation_kind": "Any",
+        }))
+        .unwrap();
+        let bulk_attempts = Arc::new(std::sync::atomic::AtomicUsize::new(0));
+        let bulk_hook_state = Arc::clone(&state);
+        let bulk_hook_attempts = Arc::clone(&bulk_attempts);
+        let bulk_transient = test_entity("bulk_transient", "src/transient.rs");
+        let bulk = mcp_bulk_check_references_with_stable_authority(
+            &state,
+            None,
+            Arc::clone(&state.graph),
+            RequestGraphAuthority::Head,
+            &arguments,
+            move |attempt| {
+                bulk_hook_attempts.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+                if attempt == 0 {
+                    bulk_hook_state
+                        .graph
+                        .upsert_entity(&bulk_transient)
+                        .unwrap();
+                    bulk_hook_state
+                        .graph
+                        .remove_entity(&bulk_transient.id)
+                        .unwrap();
+                    bulk_hook_state.bump_version();
+                }
+            },
+        )
+        .await
+        .expect("bulk_check_references retries onto stable authority");
+        assert_eq!(bulk_attempts.load(std::sync::atomic::Ordering::SeqCst), 2);
+        let bulk_body: serde_json::Value = serde_json::from_str(&mcp_result_text(&bulk)).unwrap();
+        assert_eq!(bulk_body["cross_repo"]["status"], "available");
+        assert_eq!(bulk_body["cross_repo"]["authority_complete"], true);
+        assert_eq!(state.graph.compute_root_hash(), stable_root);
+    }
+
+    #[test]
+    fn mutation_wrapper_blocks_xref_during_stalled_head_and_session_batches() {
+        let state = test_state_with_repo_id(Some("provider"));
+        let head_target = test_entity("head_target", "src/head.rs");
+        state.graph.upsert_entity(&head_target).unwrap();
+
+        let head_started = Arc::new(std::sync::Barrier::new(2));
+        let head_release = Arc::new(std::sync::Barrier::new(2));
+        let head_state = Arc::clone(&state);
+        let head_started_worker = Arc::clone(&head_started);
+        let head_release_worker = Arc::clone(&head_release);
+        let head_writer = std::thread::spawn(move || {
+            with_graph_authority_mutation(head_state.as_ref(), || {
+                let transient = test_entity("head_mid_batch", "src/transient.rs");
+                head_state.graph.upsert_entity(&transient).unwrap();
+                head_started_worker.wait();
+                head_release_worker.wait();
+                head_state.graph.remove_entity(&transient.id).unwrap();
+                head_state.bump_version();
+            });
+        });
+
+        head_started.wait();
+        assert!(
+            prepare_xref_graph_read(&state, &state.graph, RequestGraphAuthority::Head).is_none(),
+            "HEAD must not detach an intermediate graph while a writer is stalled"
+        );
+        head_release.wait();
+        head_writer.join().unwrap();
+        assert!(
+            prepare_xref_graph_read(&state, &state.graph, RequestGraphAuthority::Head).is_some()
+        );
+
+        let scoped_graph = Arc::new(kin_db::InMemoryGraph::new());
+        let scoped_target = test_entity("scoped_target", "src/scoped.rs");
+        scoped_graph.upsert_entity(&scoped_target).unwrap();
+        let scope_started = Arc::new(std::sync::Barrier::new(2));
+        let scope_release = Arc::new(std::sync::Barrier::new(2));
+        let scope_state = Arc::clone(&state);
+        let scope_graph_worker = Arc::clone(&scoped_graph);
+        let scope_started_worker = Arc::clone(&scope_started);
+        let scope_release_worker = Arc::clone(&scope_release);
+        let scope_writer = std::thread::spawn(move || {
+            with_graph_authority_mutation(scope_state.as_ref(), || {
+                let transient = test_entity("scope_mid_batch", "src/transient.rs");
+                scope_graph_worker.upsert_entity(&transient).unwrap();
+                scope_started_worker.wait();
+                scope_release_worker.wait();
+                scope_graph_worker.remove_entity(&transient.id).unwrap();
+            });
+        });
+
+        scope_started.wait();
+        assert!(
+            prepare_xref_graph_read(&state, &scoped_graph, RequestGraphAuthority::SessionScope,)
+                .is_none(),
+            "session scope must not detach an intermediate hydration graph"
+        );
+        scope_release.wait();
+        scope_writer.join().unwrap();
+        assert!(prepare_xref_graph_read(
+            &state,
+            &scoped_graph,
+            RequestGraphAuthority::SessionScope,
+        )
+        .is_some());
+    }
+
+    #[tokio::test]
+    async fn scoped_xref_fails_closed_when_selected_scope_is_replaced_mid_read() {
+        let state = test_state_with_repo_id(Some("provider"));
+        let scoped_graph = Arc::new(kin_db::InMemoryGraph::new());
+        let target = test_entity("historical_target", "src/lib.rs");
+        scoped_graph.upsert_entity(&target).unwrap();
+        let session_id = SessionId::new();
+        state
+            .set_session_scope(
+                &session_id,
+                "git:historical".to_string(),
+                kin_model::SemanticChangeId::from_hash(kin_model::Hash256::from_bytes([7; 32])),
+                Arc::clone(&scoped_graph),
+            )
+            .await;
+
+        let hook_state = Arc::clone(&state);
+        let error = command_xref_with_stable_authority(
+            &state,
+            Some(&session_id),
+            scoped_graph,
+            RequestGraphAuthority::SessionScope,
+            &kin_cli::commands::xref::XrefRequest {
+                entity: target.name,
+            },
+            move |attempt| {
+                if attempt == 0 {
+                    hook_state
+                        .session_scopes
+                        .try_write()
+                        .expect("xref does not hold the session scope lock")
+                        .remove(&session_id);
+                }
+            },
+        )
+        .await
+        .expect_err("an orphaned session graph must never be certified");
+        assert_eq!(error.0, StatusCode::SERVICE_UNAVAILABLE);
+        assert!(error.1.contains("changed repeatedly"));
     }
 
     /// Fail-loud contract: when a spine endpoint IS configured but the daemon

--- a/crates/kin-daemon/src/bin/kin-daemon.rs
+++ b/crates/kin-daemon/src/bin/kin-daemon.rs
@@ -157,10 +157,7 @@ fn create_state(
     repo_id: &str,
 ) -> std::result::Result<DaemonState, Box<dyn std::error::Error>> {
     match storage {
-        StorageMode::Local => {
-            let _ = repo_id;
-            Ok(DaemonState::open(layout)?)
-        }
+        StorageMode::Local => Ok(DaemonState::open_with_repo_id(layout, Some(repo_id))?),
         #[cfg(feature = "gcs")]
         StorageMode::Gcs => {
             let allowed_repo_ids = parse_allowed_repo_ids();

--- a/crates/kin-daemon/src/daemon.rs
+++ b/crates/kin-daemon/src/daemon.rs
@@ -414,6 +414,21 @@ async fn run_idle_monitor(
     }
 }
 
+fn install_lsp_relations(state: &DaemonState, relations: &[kin_model::Relation]) -> usize {
+    if relations.is_empty() {
+        return 0;
+    }
+
+    use kin_model::EntityStore;
+    let graph_mutation = state.begin_graph_authority_mutation();
+    for relation in relations {
+        let _ = state.graph.upsert_relation(relation);
+    }
+    state.bump_version();
+    drop(graph_mutation);
+    relations.len()
+}
+
 /// Enrich a single entity with all available LSP relation types (calls, overrides,
 /// uses-type, references). Each query is capped at 5 seconds. Returns the total
 /// number of relations upserted into the graph.
@@ -422,9 +437,8 @@ async fn enrich_single_entity(
     entity_ref: &kin_lsp::EntityRef,
     index: &kin_lsp::EntityIndex,
     root: &std::path::Path,
-    graph: &kin_db::InMemoryGraph,
+    state: &DaemonState,
 ) -> usize {
-    use kin_model::EntityStore;
     let timeout = std::time::Duration::from_secs(5);
     let mut count = 0;
 
@@ -436,10 +450,7 @@ async fn enrich_single_entity(
     .await
     {
         Ok(Ok(relations)) => {
-            for r in &relations {
-                let _ = graph.upsert_relation(r);
-            }
-            count += relations.len();
+            count += install_lsp_relations(state, &relations);
         }
         Ok(Err(e)) => {
             debug!(entity = %entity_ref.name, error = %e, "LSP calls enrichment failed");
@@ -456,10 +467,7 @@ async fn enrich_single_entity(
     )
     .await
     {
-        for r in &relations {
-            let _ = graph.upsert_relation(r);
-        }
-        count += relations.len();
+        count += install_lsp_relations(state, &relations);
     }
 
     // UsesType
@@ -469,10 +477,7 @@ async fn enrich_single_entity(
     )
     .await
     {
-        for r in &relations {
-            let _ = graph.upsert_relation(r);
-        }
-        count += relations.len();
+        count += install_lsp_relations(state, &relations);
     }
 
     // References
@@ -482,10 +487,7 @@ async fn enrich_single_entity(
     )
     .await
     {
-        for r in &relations {
-            let _ = graph.upsert_relation(r);
-        }
-        count += relations.len();
+        count += install_lsp_relations(state, &relations);
     }
 
     count
@@ -1564,11 +1566,7 @@ pub async fn run(mut state: DaemonState, config: DaemonConfig) -> Result<()> {
                         for entity_ref in &file_entities {
                             info!(entity = %entity_ref.name, "querying LSP for entity");
                             total_relations += enrich_single_entity(
-                                server,
-                                entity_ref,
-                                &index,
-                                &lsp_root,
-                                &lsp_state.graph,
+                                server, entity_ref, &index, &lsp_root, &lsp_state,
                             )
                             .await;
                         }
@@ -1772,20 +1770,14 @@ pub async fn run(mut state: DaemonState, config: DaemonConfig) -> Result<()> {
                             .await
                             .unwrap_or_default();
 
-                            let mut file_relations = file_result.relations.len();
-                            for rel in &file_result.relations {
-                                let _ = lsp_state.graph.upsert_relation(rel);
-                            }
+                            let mut file_relations =
+                                install_lsp_relations(&lsp_state, &file_result.relations);
 
                             // Also run per-entity call hierarchy for Calls relations
                             // (definition approach gives References, call hierarchy gives Calls).
                             for entity_ref in &file_entity_refs {
                                 file_relations += enrich_single_entity(
-                                    server,
-                                    entity_ref,
-                                    &index,
-                                    &lsp_root,
-                                    &lsp_state.graph,
+                                    server, entity_ref, &index, &lsp_root, &lsp_state,
                                 )
                                 .await;
                             }

--- a/crates/kin-daemon/src/loop_runner.rs
+++ b/crates/kin-daemon/src/loop_runner.rs
@@ -282,6 +282,7 @@ pub async fn run_loop(
         let mut projection_changed = ProjectionChangedSet::default();
 
         let mut lsp_changed: Vec<(PathBuf, Vec<kin_model::EntityId>)> = Vec::new();
+        let graph_mutation = state.begin_graph_authority_mutation();
 
         for event in &batch {
             match reconciler.reconcile_file_change(
@@ -425,6 +426,7 @@ pub async fn run_loop(
                 }
             }
         }
+        drop(graph_mutation);
 
         // Drop write locks before rebuilding projection (it takes its own locks).
         drop(working_copy);
@@ -908,6 +910,7 @@ pub async fn sync_filesystem_with_graph(state: &DaemonState) -> Result<()> {
     let mut working_copy = state.working_copy.write().await;
     let mut graph_changed = false;
     let mut projection_changed = ProjectionChangedSet::default();
+    let graph_mutation = state.begin_graph_authority_mutation();
 
     for event in events {
         match reconciler.reconcile_file_change(
@@ -974,6 +977,10 @@ pub async fn sync_filesystem_with_graph(state: &DaemonState) -> Result<()> {
     if graph_changed {
         state.mark_dirty();
         state.bump_version();
+    }
+    drop(graph_mutation);
+
+    if graph_changed {
         let projection_result = if projection_changed.is_empty() {
             state.rebuild_projection().await
         } else {

--- a/crates/kin-daemon/src/state.rs
+++ b/crates/kin-daemon/src/state.rs
@@ -943,6 +943,18 @@ impl DaemonState {
 
     /// Open an existing .kin/ directory and create daemon state.
     pub fn open(layout: KinLayout) -> Result<Self> {
+        let explicit_repo_id = std::env::var("KIN_REPO_ID")
+            .ok()
+            .or_else(|| std::env::var("KIN_PRIMARY_REPO_ID").ok());
+        Self::open_with_repo_id(layout, explicit_repo_id.as_deref())
+    }
+
+    #[cfg(test)]
+    pub(crate) fn open_for_test(layout: KinLayout, repo_id: &str) -> Result<Self> {
+        Self::open_with_repo_id(layout, Some(repo_id))
+    }
+
+    fn open_with_repo_id(layout: KinLayout, explicit_repo_id: Option<&str>) -> Result<Self> {
         // Up-front compatibility gate. A repo created by a pre-0.2 kin carries
         // an on-disk graph/index that this build's post-load embed/readiness
         // path cannot serve. Without this gate the daemon loads the snapshot,
@@ -1037,9 +1049,11 @@ impl DaemonState {
         // don't see a reset after daemon restart.
         let persisted_vfs_version = Self::load_persisted_vfs_version(&layout);
 
-        let explicit_repo_id = std::env::var("KIN_REPO_ID").ok();
+        // Resolve the daemon's repository identity once. KIN_PRIMARY_REPO_ID is
+        // retained as the multi-repo compatibility alias, but it feeds the same
+        // cached authority used by graph, MCP, and spine paths.
         let cached_repo_id =
-            kin_core::manifest::resolve_repo_id(&layout, explicit_repo_id.as_deref())
+            kin_core::manifest::resolve_repo_id(&layout, explicit_repo_id)
                 .map_err(DaemonError::from)?;
 
         // Baseline for the shutdown anti-wipe guard: the entity count loaded
@@ -1358,14 +1372,11 @@ impl DaemonState {
                 Vec::new();
 
             // Register the primary (this daemon's) repo.
-            let default_repo = self
-                .layout
-                .working_dir()
-                .file_name()
-                .and_then(|n| n.to_str())
-                .unwrap_or("default");
-            let repo_id_str = std::env::var("KIN_PRIMARY_REPO_ID").unwrap_or_else(|_| default_repo.to_string());
-            let repo_id = repo_id_str.as_str();
+            // This graph's repository identity was resolved once when the
+            // daemon opened. Reuse that binding for spine registration so MCP,
+            // graph, and spine authority cannot diverge through a later ambient
+            // environment change.
+            let repo_id = self.cached_repo_id.as_str();
 
             if let Ok(entities) = self.graph.list_all_entities() {
                 let entries = Self::entities_to_spine_entries(repo_id, &entities);

--- a/crates/kin-daemon/src/state.rs
+++ b/crates/kin-daemon/src/state.rs
@@ -1052,9 +1052,8 @@ impl DaemonState {
         // Resolve the daemon's repository identity once. KIN_PRIMARY_REPO_ID is
         // retained as the multi-repo compatibility alias, but it feeds the same
         // cached authority used by graph, MCP, and spine paths.
-        let cached_repo_id =
-            kin_core::manifest::resolve_repo_id(&layout, explicit_repo_id)
-                .map_err(DaemonError::from)?;
+        let cached_repo_id = kin_core::manifest::resolve_repo_id(&layout, explicit_repo_id)
+            .map_err(DaemonError::from)?;
 
         // Baseline for the shutdown anti-wipe guard: the entity count loaded
         // from the on-disk snapshot. Read before `graph` is moved into the state.

--- a/crates/kin-daemon/src/state.rs
+++ b/crates/kin-daemon/src/state.rs
@@ -1,9 +1,9 @@
 // SPDX-License-Identifier: Apache-2.0
 // Copyright 2026 Firelock, LLC
 
-use std::collections::{HashMap, HashSet};
+use std::collections::{BTreeMap, HashMap, HashSet};
 use std::io::Write;
-use std::sync::atomic::{AtomicBool, AtomicU32, AtomicU64, AtomicU8, Ordering};
+use std::sync::atomic::{AtomicBool, AtomicU32, AtomicU64, AtomicU8, AtomicUsize, Ordering};
 use std::sync::{Arc, Mutex};
 use std::time::{Duration, Instant};
 
@@ -507,6 +507,26 @@ impl TemporalScope {
     }
 }
 
+/// Maximum attempts to capture one repo's entity/relation authority without
+/// straddling a graph mutation.
+const SPINE_GRAPH_CAPTURE_ATTEMPTS: usize = 3;
+
+/// One internally coherent repo domain prepared for spine publication.
+///
+/// Entities, relations, entries, and `root_hash` are all derived from the same
+/// detached graph snapshot. `graph_authority_epoch` is populated only for this
+/// daemon's mutable primary graph; storage-loaded siblings are immutable cache
+/// entries and are validated by exact live-root agreement instead.
+struct SpineGraphCapture {
+    repo_id: String,
+    graph: Arc<kin_db::InMemoryGraph>,
+    graph_authority_epoch: Option<u64>,
+    root_hash: String,
+    entries: Vec<kin_spine::EntityEntry>,
+    entities: Vec<kin_model::Entity>,
+    relations: Vec<kin_model::Relation>,
+}
+
 /// Outcome of ingesting one repo's graph into the spine from durable storage.
 ///
 /// Returned by [`DaemonState::ingest_repo_into_spine`] and surfaced by the
@@ -599,6 +619,39 @@ pub(crate) struct VfsTreeBuildTestHook {
     pub resume: Arc<std::sync::Barrier>,
 }
 
+#[derive(Default)]
+struct GraphAuthorityClock {
+    /// Serializes writer publication with the one-time spine visibility edge.
+    /// Held only while a writer announces itself or initialization performs its
+    /// final authority check and publishes OnceLock.
+    publication_gate: Mutex<()>,
+    active_writers: AtomicUsize,
+    epoch: AtomicU64,
+}
+
+/// Marks one entity/relation mutation batch as in flight.
+///
+/// Writers publish both edges of the batch through a shared clock. Xref readers
+/// accept a detached snapshot only when no writer is active and this epoch is
+/// unchanged through their final authority validation. A writer count (rather
+/// than an odd/even bit) keeps overlapping background and request mutations
+/// fail-closed until the last batch finishes.
+pub(crate) struct GraphAuthorityMutationGuard {
+    clock: Arc<GraphAuthorityClock>,
+}
+
+impl Drop for GraphAuthorityMutationGuard {
+    fn drop(&mut self) {
+        self.clock.epoch.fetch_add(1, Ordering::SeqCst);
+        self.clock
+            .active_writers
+            .fetch_update(Ordering::SeqCst, Ordering::SeqCst, |active| {
+                active.checked_sub(1)
+            })
+            .expect("graph authority writer count underflow");
+    }
+}
+
 /// Shared daemon state. All mutable state is behind RwLock for
 /// concurrent access from the reconciliation loop and API handlers.
 pub struct DaemonState {
@@ -615,6 +668,10 @@ pub struct DaemonState {
     /// Serializes daemon intent lifecycle mutations with MCP transaction
     /// preflight+apply so those two authority paths have one ordering.
     pub coordination_gate: tokio::sync::Mutex<()>,
+    /// Shared entity/relation mutation clock. Every authority writer brackets
+    /// its complete batch so detached xref reads cannot certify an intermediate
+    /// graph state before the writer publishes its normal version/root update.
+    graph_authority_clock: Arc<GraphAuthorityClock>,
     /// Mode captured when the daemon state is created. Requests use this
     /// stable value instead of re-reading process-global environment mid-run.
     pub coordination_mode: std::sync::RwLock<kin_mcp::CoordinationEnforcementMode>,
@@ -684,6 +741,10 @@ pub struct DaemonState {
     /// - `InMemorySpineBackend`: local dev / single daemon (default)
     /// - `FirestoreSpineBackend`: cloud / stateless daemon pool (when GOOGLE_CLOUD_PROJECT is set)
     pub spine: std::sync::OnceLock<Arc<dyn kin_spine::SpineBackend>>,
+    /// Serializes hosted repo registration and all-repo edge refresh passes.
+    /// The backend independently keeps a pass-wide incomplete lease; this gate
+    /// prevents daemon request paths from racing that lease with a new ingest.
+    spine_refresh_gate: tokio::sync::Mutex<()>,
     /// Maps repo_id to a lazily-loaded graph. Graphs are loaded from the
     /// storage backend on first access. Only active when `storage_backend`
     /// is `Some` (cloud / multi-repo mode).
@@ -835,6 +896,78 @@ pub(crate) fn graph_collapse_is_wipe(current: u64, baseline: u64) -> bool {
 }
 
 impl DaemonState {
+    /// Begin one entity/relation authority mutation batch.
+    ///
+    /// The first epoch edge is published before callers touch the graph; the
+    /// guard publishes the closing edge only after their version/root update.
+    pub(crate) fn begin_graph_authority_mutation(&self) -> GraphAuthorityMutationGuard {
+        let _publication = self
+            .graph_authority_clock
+            .publication_gate
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
+        self.graph_authority_clock
+            .active_writers
+            .fetch_update(Ordering::SeqCst, Ordering::SeqCst, |active| {
+                active.checked_add(1)
+            })
+            .expect("graph authority writer count exhausted");
+        self.graph_authority_clock
+            .epoch
+            .fetch_add(1, Ordering::SeqCst);
+        // If initialization already crossed its visibility edge, revoke spine
+        // completeness before the caller can mutate graph truth. If the spine
+        // is not published yet, the same publication gate forces initialization
+        // to observe this writer/epoch before it can expose the prepared backend.
+        if let Some(spine) = self.spine.get() {
+            spine.invalidate_cross_repo_edges(&self.cached_repo_id);
+        }
+        GraphAuthorityMutationGuard {
+            clock: Arc::clone(&self.graph_authority_clock),
+        }
+    }
+
+    /// Return a stable graph-authority epoch only when no mutation batch spans
+    /// the sample. The second writer-count read closes the begin/read race.
+    pub(crate) fn stable_graph_authority_epoch(&self) -> Option<u64> {
+        if self
+            .graph_authority_clock
+            .active_writers
+            .load(Ordering::SeqCst)
+            != 0
+        {
+            return None;
+        }
+        let epoch = self.graph_authority_clock.epoch.load(Ordering::SeqCst);
+        (self
+            .graph_authority_clock
+            .active_writers
+            .load(Ordering::SeqCst)
+            == 0)
+            .then_some(epoch)
+    }
+
+    /// Revalidate a reader's epoch, including the fast writer that can begin
+    /// and finish between two active-writer samples.
+    pub(crate) fn graph_authority_epoch_is_current(&self, expected: u64) -> bool {
+        if self
+            .graph_authority_clock
+            .active_writers
+            .load(Ordering::SeqCst)
+            != 0
+        {
+            return false;
+        }
+        let epoch = self.graph_authority_clock.epoch.load(Ordering::SeqCst);
+        epoch == expected
+            && self
+                .graph_authority_clock
+                .active_writers
+                .load(Ordering::SeqCst)
+                == 0
+            && self.graph_authority_clock.epoch.load(Ordering::SeqCst) == expected
+    }
+
     pub fn coordination_mode(&self) -> kin_mcp::CoordinationEnforcementMode {
         *self
             .coordination_mode
@@ -1073,6 +1206,7 @@ impl DaemonState {
             projection: RwLock::new(ProjectionState::new()),
             coordinator,
             coordination_gate: tokio::sync::Mutex::new(()),
+            graph_authority_clock: Arc::new(GraphAuthorityClock::default()),
             coordination_mode: std::sync::RwLock::new(
                 kin_mcp::CoordinationEnforcementMode::from_env(),
             ),
@@ -1103,6 +1237,7 @@ impl DaemonState {
             session_overlays: RwLock::new(std::collections::HashMap::new()),
             session_scopes: RwLock::new(HashMap::new()),
             spine: std::sync::OnceLock::new(),
+            spine_refresh_gate: tokio::sync::Mutex::new(()),
             repo_graphs: RwLock::new(HashMap::new()),
             allowed_repo_ids: None,
             dirty: AtomicBool::new(false),
@@ -1239,6 +1374,7 @@ impl DaemonState {
             projection: RwLock::new(ProjectionState::new()),
             coordinator,
             coordination_gate: tokio::sync::Mutex::new(()),
+            graph_authority_clock: Arc::new(GraphAuthorityClock::default()),
             coordination_mode: std::sync::RwLock::new(
                 kin_mcp::CoordinationEnforcementMode::from_env(),
             ),
@@ -1269,6 +1405,7 @@ impl DaemonState {
             session_overlays: RwLock::new(std::collections::HashMap::new()),
             session_scopes: RwLock::new(HashMap::new()),
             spine: std::sync::OnceLock::new(),
+            spine_refresh_gate: tokio::sync::Mutex::new(()),
             repo_graphs: RwLock::new(HashMap::new()), // populated below
             allowed_repo_ids,
             dirty: AtomicBool::new(false),
@@ -1345,7 +1482,8 @@ impl DaemonState {
     }
 
     /// Lazily initialize the spine and return a reference to it.
-    /// Returns `None` if spine is disabled via `KIN_DISABLE_SPINE`.
+    /// Returns `None` if spine is disabled or if the mutable primary graph could
+    /// not be captured stably yet; the latter leaves OnceLock empty for retry.
     pub fn ensure_spine(&self) -> Option<&dyn kin_spine::SpineBackend> {
         if Self::spine_disabled() {
             return None;
@@ -1354,6 +1492,97 @@ impl DaemonState {
             self.initialize_spine_lazy();
         }
         self.spine.get().map(|s| s.as_ref())
+    }
+
+    fn spine_capture_is_current(&self, capture: &SpineGraphCapture) -> bool {
+        if capture
+            .graph_authority_epoch
+            .is_some_and(|epoch| !self.graph_authority_epoch_is_current(epoch))
+        {
+            return false;
+        }
+        if hex::encode(capture.graph.compute_root_hash()) != capture.root_hash {
+            return false;
+        }
+        capture
+            .graph_authority_epoch
+            .is_none_or(|epoch| self.graph_authority_epoch_is_current(epoch))
+    }
+
+    fn capture_spine_repo(
+        &self,
+        repo_id: &str,
+        graph: Arc<kin_db::InMemoryGraph>,
+    ) -> std::result::Result<SpineGraphCapture, String> {
+        self.capture_spine_repo_with_hook(repo_id, graph, |_| {})
+    }
+
+    /// Capture one exact entity/relation/root domain, retrying when a writer
+    /// overlaps the detached snapshot. The hook is a deterministic race seam
+    /// used by regression tests; production callers pass the no-op wrapper.
+    fn capture_spine_repo_with_hook<F>(
+        &self,
+        repo_id: &str,
+        graph: Arc<kin_db::InMemoryGraph>,
+        mut after_snapshot: F,
+    ) -> std::result::Result<SpineGraphCapture, String>
+    where
+        F: FnMut(usize),
+    {
+        let mutable_primary = Arc::ptr_eq(&graph, &self.graph);
+        let mut last_reason = "graph authority did not stabilize".to_string();
+
+        for attempt in 0..SPINE_GRAPH_CAPTURE_ATTEMPTS {
+            let graph_authority_epoch = if mutable_primary {
+                let Some(epoch) = self.stable_graph_authority_epoch() else {
+                    last_reason = "primary graph has an active authority writer".to_string();
+                    continue;
+                };
+                Some(epoch)
+            } else {
+                None
+            };
+
+            let snapshot = graph.to_snapshot();
+            let root_hash = hex::encode(kin_db::compute_graph_root_hash(&snapshot));
+            let entity_ids = snapshot.entities.keys().copied().collect::<HashSet<_>>();
+            let mut entities = snapshot.entities.into_values().collect::<Vec<_>>();
+            entities.sort_by_key(|entity| entity.id);
+            let mut relations = snapshot
+                .relations
+                .into_values()
+                .filter(|relation| {
+                    matches!(
+                        relation.kind,
+                        kin_model::RelationKind::Calls | kin_model::RelationKind::References
+                    ) && relation
+                        .src
+                        .as_entity()
+                        .is_some_and(|source| entity_ids.contains(&source))
+                })
+                .collect::<Vec<_>>();
+            relations.sort_by_key(|relation| relation.id.to_string());
+            let entries = Self::entities_to_spine_entries(repo_id, &entities);
+            let capture = SpineGraphCapture {
+                repo_id: repo_id.to_string(),
+                graph: Arc::clone(&graph),
+                graph_authority_epoch,
+                root_hash,
+                entries,
+                entities,
+                relations,
+            };
+
+            after_snapshot(attempt);
+            if self.spine_capture_is_current(&capture) {
+                return Ok(capture);
+            }
+            last_reason = "graph changed while its detached spine domain was captured".to_string();
+        }
+
+        Err(format!(
+            "could not capture stable spine authority for repo {repo_id} after {SPINE_GRAPH_CAPTURE_ATTEMPTS} attempts: {last_reason}"
+        ))
     }
 
     /// Lazily initialize the spine from the loaded graph and global registry.
@@ -1365,43 +1594,46 @@ impl DaemonState {
     ///   reads from local cache). This enables the stateless daemon pool.
     /// - Otherwise: uses `InMemorySpineBackend` (current behavior, no external deps).
     fn initialize_spine_lazy(&self) {
-        let _ = self.spine.get_or_init(|| {
-            let backend: Arc<dyn kin_spine::SpineBackend> = self.create_spine_backend();
+        self.initialize_spine_lazy_with_publication_hook(|| {});
+    }
 
-            // Per-repo (id, entities, relations) captured during registration and
-            // replayed into cross-repo edge resolution once every repo is indexed.
-            let mut repo_relations: Vec<(String, Vec<kin_model::Entity>, Vec<kin_model::Relation>)> =
-                Vec::new();
+    /// Prepare and publish the lazy spine behind the graph-authority visibility
+    /// handshake. The hook is a deterministic seam for the final-validation to
+    /// publication race regression; production callers use the no-op wrapper.
+    fn initialize_spine_lazy_with_publication_hook<F>(&self, mut before_publication: F)
+    where
+        F: FnMut(),
+    {
+        if self.spine.get().is_some() {
+            return;
+        }
 
-            // Register the primary (this daemon's) repo.
-            // This graph's repository identity was resolved once when the
-            // daemon opened. Reuse that binding for spine registration so MCP,
-            // graph, and spine authority cannot diverge through a later ambient
-            // environment change.
-            let repo_id = self.cached_repo_id.as_str();
-
-            if let Ok(entities) = self.graph.list_all_entities() {
-                let entries = Self::entities_to_spine_entries(repo_id, &entities);
-                let root_hash = hex::encode(self.graph.compute_root_hash());
-                backend.register_repo(repo_id, entries, &root_hash);
-                info!(
-                    repo_id,
-                    entities = entities.len(),
-                    "registered primary repo in spine"
+        // Capture the mutable primary before constructing or publishing the
+        // OnceLock value. A busy writer therefore leaves the spine uninitialized
+        // and the next request retries instead of permanently caching an empty
+        // or mismatched backend.
+        let primary_repo_id = self.cached_repo_id.as_str();
+        let primary = match self.capture_spine_repo(primary_repo_id, Arc::clone(&self.graph)) {
+            Ok(capture) => capture,
+            Err(capture_error) => {
+                warn!(
+                    repo_id = primary_repo_id,
+                    error = %capture_error,
+                    "spine initialization deferred until primary graph authority is stable"
                 );
-                let relations = Self::collect_spine_relations(self.graph.as_ref(), &entities);
-                repo_relations.push((repo_id.to_string(), entities, relations));
+                return;
             }
+        };
+        let mut captures = vec![primary];
+        let mut authority_incomplete = false;
 
-            // Register sibling repos from the global registry.
-            let registry = kin_core::registry::KinRegistry::load();
-            if let Err(load_error) = &registry {
-                error!(
-                    error = %load_error,
-                    "registry authority refused; sibling repos were not loaded into the spine"
-                );
-            }
-            if let Ok(registry) = registry {
+        // Capture sibling repos from the global registry. Persisted sibling
+        // graphs are immutable cache inputs, but they still go through one
+        // detached snapshot and exact live-root validation. A bad sibling is
+        // omitted as advisory data and prevents this initialization from ever
+        // claiming complete authority.
+        match kin_core::registry::KinRegistry::load() {
+            Ok(registry) => {
                 let cwd_canonical = self
                     .layout
                     .root()
@@ -1413,10 +1645,9 @@ impl DaemonState {
                         .path
                         .canonicalize()
                         .unwrap_or_else(|_| repo.path.clone());
-                    if repo_canonical == cwd_canonical
-                        || cwd_canonical.starts_with(&repo_canonical)
+                    if repo_canonical == cwd_canonical || cwd_canonical.starts_with(&repo_canonical)
                     {
-                        continue; // skip primary
+                        continue;
                     }
 
                     let kndb_path = repo.path.join(".kin").join("kindb").join("graph.kndb");
@@ -1426,45 +1657,154 @@ impl DaemonState {
 
                     let kndb_clone = kndb_path.clone();
                     let sibling_id = repo.id.clone();
-                    let handle = std::thread::Builder::new()
+                    let loaded = std::thread::Builder::new()
                         .name(format!("spine-load-{}", repo.id))
-                        .spawn(move || -> Option<kin_db::InMemoryGraph> {
-                            let snap = kin_db::SnapshotManager::open(&kndb_clone).ok()?;
-                            let arc = snap.graph();
-                            drop(snap);
-                            std::sync::Arc::try_unwrap(arc).ok()
-                        });
+                        .spawn(move || -> Option<Arc<kin_db::InMemoryGraph>> {
+                            let snapshot = kin_db::SnapshotManager::open(&kndb_clone).ok()?;
+                            Some(snapshot.graph())
+                        })
+                        .ok()
+                        .and_then(|handle| handle.join().ok())
+                        .flatten();
 
-                    if let Ok(h) = handle {
-                        if let Ok(Some(sibling_graph)) = h.join() {
-                            if let Ok(entities) = sibling_graph.list_all_entities() {
-                                let entries =
-                                    Self::entities_to_spine_entries(&sibling_id, &entities);
-                                let count = entries.len();
-                                backend.register_repo(&sibling_id, entries, "");
-                                info!(repo_id = %sibling_id, entities = count, "registered sibling in spine");
-                                let relations =
-                                    Self::collect_spine_relations(&sibling_graph, &entities);
-                                repo_relations.push((sibling_id.clone(), entities, relations));
-                            }
+                    let Some(sibling_graph) = loaded else {
+                        authority_incomplete = true;
+                        warn!(
+                            repo_id = %sibling_id,
+                            path = %kndb_path.display(),
+                            "sibling graph could not be loaded; spine authority will remain incomplete"
+                        );
+                        continue;
+                    };
+                    match self.capture_spine_repo(&sibling_id, sibling_graph) {
+                        Ok(capture) => captures.push(capture),
+                        Err(capture_error) => {
+                            authority_incomplete = true;
+                            warn!(
+                                repo_id = %sibling_id,
+                                error = %capture_error,
+                                "sibling graph capture failed; spine authority will remain incomplete"
+                            );
                         }
                     }
                 }
             }
-
-            // With every reachable repo indexed, resolve unresolved imports into
-            // cross-repo reference edges so federated impact/xref can traverse them.
-            let registry_ids: Vec<String> = backend.registered_repo_ids().into_iter().collect();
-            for (rid, entities, relations) in &repo_relations {
-                backend.refresh_cross_repo_edges(rid, entities, relations, &registry_ids);
+            Err(load_error) => {
+                authority_incomplete = true;
+                error!(
+                    error = %load_error,
+                    "registry authority refused; spine authority will remain incomplete"
+                );
             }
+        }
 
-            info!(
-                cross_repo_edges = backend.edge_count(),
-                "spine index initialized"
+        // A captured graph may advance while a later sibling is loading. Never
+        // publish a backend containing a stale capture; leave OnceLock empty so
+        // the next request can retry the whole authority set.
+        if captures
+            .iter()
+            .any(|capture| !self.spine_capture_is_current(capture))
+        {
+            warn!("spine initialization deferred because a captured graph advanced");
+            return;
+        }
+        if self.spine.get().is_some() {
+            return;
+        }
+
+        let backend: Arc<dyn kin_spine::SpineBackend> = self.create_spine_backend();
+        for capture in &mut captures {
+            let entity_count = capture.entries.len();
+            backend.register_repo(
+                &capture.repo_id,
+                std::mem::take(&mut capture.entries),
+                &capture.root_hash,
             );
-            backend
-        });
+            info!(
+                repo_id = %capture.repo_id,
+                entities = entity_count,
+                root_hash = %capture.root_hash,
+                "registered exact graph snapshot in spine"
+            );
+        }
+
+        let registry_ids = backend
+            .registered_repo_ids()
+            .into_iter()
+            .collect::<Vec<_>>();
+        for capture in &captures {
+            backend.refresh_cross_repo_edges(
+                &capture.repo_id,
+                &capture.entities,
+                &capture.relations,
+                &registry_ids,
+            );
+        }
+
+        if captures
+            .iter()
+            .any(|capture| !self.spine_capture_is_current(capture))
+        {
+            for repo_id in backend.registered_repo_ids() {
+                backend.invalidate_cross_repo_edges(&repo_id);
+            }
+            warn!(
+                "spine initialization discarded because a captured graph advanced during publication"
+            );
+            return;
+        }
+
+        let captured_repo_ids = captures
+            .iter()
+            .map(|capture| capture.repo_id.clone())
+            .collect::<HashSet<_>>();
+        let registered_repo_ids = backend.registered_repo_ids();
+        if registered_repo_ids != captured_repo_ids {
+            authority_incomplete = true;
+            warn!(
+                captured = captured_repo_ids.len(),
+                registered = registered_repo_ids.len(),
+                "spine contains durable advisory repos without a current graph capture"
+            );
+        }
+        if authority_incomplete {
+            for repo_id in &registered_repo_ids {
+                backend.invalidate_cross_repo_edges(repo_id);
+            }
+        }
+
+        // A writer announcing itself after the preparation checks but before
+        // OnceLock publication used to leave a stale backend visibly complete:
+        // the writer could not invalidate a value that was not published yet.
+        // Serialize that visibility edge with writer announcement, then repeat
+        // the authority check while the gate prevents a new writer from
+        // starting. The next writer can only proceed after publication and will
+        // invalidate the visible primary repo before touching graph truth.
+        before_publication();
+        let _publication = self
+            .graph_authority_clock
+            .publication_gate
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
+        if captures
+            .iter()
+            .any(|capture| !self.spine_capture_is_current(capture))
+        {
+            for repo_id in backend.registered_repo_ids() {
+                backend.invalidate_cross_repo_edges(&repo_id);
+            }
+            warn!(
+                "spine initialization discarded because graph authority advanced before visibility"
+            );
+            return;
+        }
+
+        info!(
+            cross_repo_edges = backend.edge_count(),
+            capture_set_complete = !authority_incomplete,
+            "spine index initialized"
+        );
+        let _ = self.spine.get_or_init(move || backend);
     }
 
     /// Create the appropriate spine backend based on environment.
@@ -1489,28 +1829,6 @@ impl DaemonState {
 
         info!("using in-memory spine backend (local dev mode)");
         Arc::new(kin_spine::InMemorySpineBackend::new())
-    }
-
-    /// Collect the entity-level reference edges the spine uses to resolve
-    /// cross-repo imports. Only `Calls`/`References` edges carry the
-    /// `import_source` the cross-repo resolver keys on, so the scan is limited
-    /// to those kinds. Edges are read per source entity (outgoing only), so each
-    /// relation is yielded exactly once.
-    fn collect_spine_relations(
-        graph: &kin_db::InMemoryGraph,
-        entities: &[kin_model::Entity],
-    ) -> Vec<kin_model::Relation> {
-        let kinds = [
-            kin_model::RelationKind::Calls,
-            kin_model::RelationKind::References,
-        ];
-        let mut relations = Vec::new();
-        for entity in entities {
-            if let Ok(rels) = graph.get_relations(&entity.id, &kinds) {
-                relations.extend(rels);
-            }
-        }
-        relations
     }
 
     /// Project a repo's graph entities into the metadata-only `EntityEntry`
@@ -1560,45 +1878,88 @@ impl DaemonState {
         repo_id: &str,
         refresh_cross_repo_edges: bool,
     ) -> Result<SpineIngestOutcome> {
+        self.ingest_repo_into_spine_with_capture_hook(repo_id, refresh_cross_repo_edges, |_| {})
+            .await
+    }
+
+    async fn ingest_repo_into_spine_with_capture_hook<F>(
+        &self,
+        repo_id: &str,
+        refresh_cross_repo_edges: bool,
+        capture_hook: F,
+    ) -> Result<SpineIngestOutcome>
+    where
+        F: FnMut(usize),
+    {
         let Some(spine) = self.ensure_spine() else {
+            let reason = if Self::spine_disabled() {
+                "spine disabled via KIN_DISABLE_SPINE"
+            } else {
+                "spine initialization could not capture stable primary graph authority; retry"
+            };
             return Err(DaemonError::Graph(kin_db::KinDbError::StorageError(
-                "spine disabled via KIN_DISABLE_SPINE".to_string(),
+                reason.to_string(),
             )));
         };
+        let _spine_refresh = self.spine_refresh_gate.lock().await;
 
         // Load the repo's graph from durable storage (GCS in cloud). This is the
         // blob-store read boundary that replaces the local-disk `.kndb` lookup.
         let graph = self.get_repo_graph(repo_id).await?;
-
-        let entities = graph
-            .list_all_entities()
-            .map_err(|e| DaemonError::Graph(kin_db::KinDbError::StorageError(e.to_string())))?;
-
-        let entries = Self::entities_to_spine_entries(repo_id, &entities);
-        let entity_count = entries.len();
-        let root_hash = hex::encode(graph.compute_root_hash());
+        let mut capture = match self.capture_spine_repo_with_hook(repo_id, graph, capture_hook) {
+            Ok(capture) => capture,
+            Err(capture_error) => {
+                spine.invalidate_cross_repo_edges(repo_id);
+                return Err(DaemonError::Graph(kin_db::KinDbError::StorageError(
+                    capture_error,
+                )));
+            }
+        };
+        let entity_count = capture.entries.len();
+        let relation_count = capture.relations.len();
+        let root_hash = capture.root_hash.clone();
 
         // Write-through: register this repo's metadata into the spine store so a
         // freshly started (stateless) pod can hydrate it and resolve against it.
-        spine.register_repo(repo_id, entries, &root_hash);
-
-        let relations = Self::collect_spine_relations(graph.as_ref(), &entities);
-        let relation_count = relations.len();
+        spine.register_repo(repo_id, std::mem::take(&mut capture.entries), &root_hash);
+        if !self.spine_capture_is_current(&capture) {
+            spine.invalidate_cross_repo_edges(repo_id);
+            return Err(DaemonError::Graph(kin_db::KinDbError::StorageError(
+                format!("repo {repo_id} graph authority changed during spine registration; retry"),
+            )));
+        }
 
         // Count the relations the resolver can actually bind into cross-repo
         // edges, against the spine's current registered-repo set. This is the
         // honest "can this materialize edges" signal the control plane gates on
         // — it is derived from graph truth, never a heuristic.
         let registry_ids: Vec<String> = spine.registered_repo_ids().into_iter().collect();
-        let resolvable_relations =
-            kin_spine::collect_unresolved_imports(&entities, &relations, repo_id, &registry_ids)
-                .len();
+        let resolvable_relations = kin_spine::collect_unresolved_imports(
+            &capture.entities,
+            &capture.relations,
+            repo_id,
+            &registry_ids,
+        )
+        .len();
 
         if refresh_cross_repo_edges {
             // Re-resolve this repo's imports now that the sibling metadata is in
             // the spine, materializing (and write-through persisting) the
             // cross-repo edges that back `/spine/xref`.
-            spine.refresh_cross_repo_edges(repo_id, &entities, &relations, &registry_ids);
+            spine.refresh_cross_repo_edges(
+                repo_id,
+                &capture.entities,
+                &capture.relations,
+                &registry_ids,
+            );
+            if !self.spine_capture_is_current(&capture) {
+                spine.invalidate_cross_repo_edges(repo_id);
+                return Err(DaemonError::Graph(kin_db::KinDbError::StorageError(
+                    format!(
+                        "repo {repo_id} graph authority changed during cross-repo refresh; retry"
+                    ),
+                )));
+            }
         }
 
         info!(
@@ -1632,21 +1993,52 @@ impl DaemonState {
     /// existing edges are removed and re-materialized.
     pub async fn refresh_all_cross_repo_edges(&self) -> Result<SpineRefreshOutcome> {
         let Some(spine) = self.ensure_spine() else {
+            let reason = if Self::spine_disabled() {
+                "spine disabled via KIN_DISABLE_SPINE"
+            } else {
+                "spine initialization could not capture stable primary graph authority; retry"
+            };
             return Err(DaemonError::Graph(kin_db::KinDbError::StorageError(
-                "spine disabled via KIN_DISABLE_SPINE".to_string(),
+                reason.to_string(),
             )));
         };
+        let _spine_refresh = self.spine_refresh_gate.lock().await;
 
         // Resolve against the full registered-repo set, sorted for a
         // deterministic pass order.
         let mut registry_ids: Vec<String> = spine.registered_repo_ids().into_iter().collect();
         registry_ids.sort();
 
-        let mut repos_refreshed = 0usize;
+        // Invalidate the whole pass up front. A graph-load or stable-capture
+        // failure therefore leaves the shared topology explicitly incomplete
+        // instead of serving the previous complete watermark after a skipped
+        // repo.
         for repo_id in &registry_ids {
-            // Load this repo's graph from durable storage (cached after the first
-            // load). Skip a repo this pod cannot load rather than aborting the
-            // whole pass — the others still refresh.
+            spine.invalidate_cross_repo_edges(repo_id);
+        }
+        let Some(graph_authority_epoch) = self.stable_graph_authority_epoch() else {
+            warn!("cross-repo refresh remains incomplete while graph authority is mutating");
+            return Ok(SpineRefreshOutcome {
+                repos_refreshed: 0,
+                cross_repo_edges: spine.edge_count(),
+            });
+        };
+
+        struct PreparedSpineRepo {
+            repo_id: String,
+            graph: Arc<kin_db::InMemoryGraph>,
+            root_hash: String,
+            entries: Vec<kin_spine::EntityEntry>,
+            entities: Vec<kin_model::Entity>,
+            relations: Vec<kin_model::Relation>,
+        }
+
+        // Phase 1: capture each entity/relation domain through one detached
+        // graph snapshot. Computing the registered root from that same snapshot
+        // prevents per-entity reads from straddling a reconcile. No spine state
+        // is updated unless every repo in the pass has a stable capture.
+        let mut prepared = Vec::with_capacity(registry_ids.len());
+        for repo_id in &registry_ids {
             let graph = match self.get_repo_graph(repo_id).await {
                 Ok(graph) => graph,
                 Err(e) => {
@@ -1654,17 +2046,197 @@ impl DaemonState {
                     continue;
                 }
             };
-            let entities = match graph.list_all_entities() {
-                Ok(entities) => entities,
-                Err(e) => {
-                    warn!(repo_id, error = %e, "skipping cross-repo refresh: entity listing failed");
-                    continue;
-                }
-            };
-            let relations = Self::collect_spine_relations(graph.as_ref(), &entities);
-            spine.refresh_cross_repo_edges(repo_id, &entities, &relations, &registry_ids);
-            repos_refreshed += 1;
+
+            let snapshot = graph.to_snapshot();
+            let root_hash = hex::encode(kin_db::compute_graph_root_hash(&snapshot));
+            let live_root = hex::encode(graph.compute_root_hash());
+            if root_hash != live_root {
+                warn!(
+                    repo_id,
+                    snapshot_root = %root_hash,
+                    live_root = %live_root,
+                    "skipping cross-repo refresh: graph changed while its detached state was captured"
+                );
+                continue;
+            }
+
+            let entity_ids = snapshot.entities.keys().copied().collect::<HashSet<_>>();
+            let mut entities = snapshot.entities.into_values().collect::<Vec<_>>();
+            entities.sort_by_key(|entity| entity.id);
+            let mut relations = snapshot
+                .relations
+                .into_values()
+                .filter(|relation| {
+                    matches!(
+                        relation.kind,
+                        kin_model::RelationKind::Calls | kin_model::RelationKind::References
+                    ) && relation
+                        .src
+                        .as_entity()
+                        .is_some_and(|source| entity_ids.contains(&source))
+                })
+                .collect::<Vec<_>>();
+            relations.sort_by_key(|relation| relation.id.to_string());
+            let entries = Self::entities_to_spine_entries(repo_id, &entities);
+            prepared.push(PreparedSpineRepo {
+                repo_id: repo_id.clone(),
+                graph,
+                root_hash,
+                entries,
+                entities,
+                relations,
+            });
         }
+
+        if prepared.len() != registry_ids.len() {
+            warn!(
+                prepared = prepared.len(),
+                expected = registry_ids.len(),
+                "cross-repo refresh remains incomplete because not every registered repo had a stable graph capture"
+            );
+            return Ok(SpineRefreshOutcome {
+                repos_refreshed: 0,
+                cross_repo_edges: spine.edge_count(),
+            });
+        }
+
+        // A graph may have changed while a later repo was loading. Revalidate
+        // the full captured set before exposing any of its roots or entries.
+        if !self.graph_authority_epoch_is_current(graph_authority_epoch)
+            || prepared
+                .iter()
+                .any(|repo| hex::encode(repo.graph.compute_root_hash()) != repo.root_hash)
+        {
+            warn!(
+                "cross-repo refresh remains incomplete because a graph changed before registration"
+            );
+            return Ok(SpineRefreshOutcome {
+                repos_refreshed: 0,
+                cross_repo_edges: spine.edge_count(),
+            });
+        }
+
+        // Phase 2a: publish every repo's entries and exact captured root before
+        // resolving any source. Each registration dirties the shared topology;
+        // only the following all-source pass may clear it again.
+        for repo in &mut prepared {
+            spine.register_repo(
+                &repo.repo_id,
+                std::mem::take(&mut repo.entries),
+                &repo.root_hash,
+            );
+        }
+
+        if !self.graph_authority_epoch_is_current(graph_authority_epoch)
+            || prepared
+                .iter()
+                .any(|repo| hex::encode(repo.graph.compute_root_hash()) != repo.root_hash)
+        {
+            for repo_id in &registry_ids {
+                spine.invalidate_cross_repo_edges(repo_id);
+            }
+            warn!(
+                "cross-repo refresh remains incomplete because a graph changed during registration"
+            );
+            return Ok(SpineRefreshOutcome {
+                repos_refreshed: 0,
+                cross_repo_edges: spine.edge_count(),
+            });
+        }
+
+        let authority_roots = prepared
+            .iter()
+            .map(|repo| (repo.repo_id.clone(), repo.root_hash.clone()))
+            .collect::<BTreeMap<_, _>>();
+        let Some(pass_token) = spine.begin_cross_repo_refresh_pass(&authority_roots) else {
+            warn!(
+                "cross-repo refresh remains incomplete because another pass or authority change won the lease"
+            );
+            return Ok(SpineRefreshOutcome {
+                repos_refreshed: 0,
+                cross_repo_edges: spine.edge_count(),
+            });
+        };
+
+        struct SpineRefreshLease<'a> {
+            spine: &'a dyn kin_spine::SpineBackend,
+            token: u64,
+            authority_roots: &'a BTreeMap<String, String>,
+            finished: bool,
+        }
+
+        impl SpineRefreshLease<'_> {
+            fn finish(mut self, success: bool) -> bool {
+                let committed = self.spine.finish_cross_repo_refresh_pass(
+                    self.token,
+                    self.authority_roots,
+                    success,
+                );
+                self.finished = true;
+                committed
+            }
+        }
+
+        impl Drop for SpineRefreshLease<'_> {
+            fn drop(&mut self) {
+                if !self.finished {
+                    let _ = self.spine.finish_cross_repo_refresh_pass(
+                        self.token,
+                        self.authority_roots,
+                        false,
+                    );
+                }
+            }
+        }
+
+        let pass = SpineRefreshLease {
+            spine,
+            token: pass_token,
+            authority_roots: &authority_roots,
+            finished: false,
+        };
+
+        // Phase 2b: now every resolver sees one coherent current registry.
+        for repo in &prepared {
+            spine.refresh_cross_repo_edges(
+                &repo.repo_id,
+                &repo.entities,
+                &repo.relations,
+                &registry_ids,
+            );
+        }
+
+        let registry_unchanged =
+            spine.registered_repo_ids() == registry_ids.iter().cloned().collect::<HashSet<_>>();
+        let roots_unchanged = prepared
+            .iter()
+            .all(|repo| hex::encode(repo.graph.compute_root_hash()) == repo.root_hash);
+        let spine_roots_unchanged = authority_roots
+            .iter()
+            .all(|(repo_id, root)| spine.root_hash(repo_id).as_ref() == Some(root));
+        let graph_authority_unchanged =
+            self.graph_authority_epoch_is_current(graph_authority_epoch);
+        let pass_committed = pass.finish(
+            registry_unchanged
+                && roots_unchanged
+                && spine_roots_unchanged
+                && graph_authority_unchanged,
+        );
+        if !pass_committed {
+            warn!(
+                registry_unchanged,
+                roots_unchanged,
+                spine_roots_unchanged,
+                graph_authority_unchanged,
+                "cross-repo refresh completed against unstable authority; leaving every repo incomplete"
+            );
+            return Ok(SpineRefreshOutcome {
+                repos_refreshed: 0,
+                cross_repo_edges: spine.edge_count(),
+            });
+        }
+
+        let repos_refreshed = prepared.len();
 
         info!(
             repos_refreshed,
@@ -1709,6 +2281,14 @@ impl DaemonState {
         }
     }
 
+    fn cache_loaded_repo_graph(
+        graphs: &mut HashMap<String, Arc<kin_db::InMemoryGraph>>,
+        repo_id: &str,
+        loaded: Arc<kin_db::InMemoryGraph>,
+    ) -> Arc<kin_db::InMemoryGraph> {
+        Arc::clone(graphs.entry(repo_id.to_string()).or_insert(loaded))
+    }
+
     /// Get or lazy-load a repo's graph from the storage backend.
     ///
     /// Returns the cached graph if already loaded, otherwise loads from
@@ -1733,10 +2313,8 @@ impl DaemonState {
         let graph = self.load_repo_graph(repo_id)?;
         let mut graphs = self.repo_graphs.write().await;
         // Double-check: another task may have loaded it while we were loading.
-        graphs
-            .entry(repo_id.to_string())
-            .or_insert_with(|| Arc::clone(&graph));
-        Ok(graph)
+        // Return that task's cached winner, not this task's losing generation.
+        Ok(Self::cache_loaded_repo_graph(&mut graphs, repo_id, graph))
     }
 
     /// List repo IDs that are currently loaded in the multi-repo cache.
@@ -2985,6 +3563,28 @@ mod tests {
             .expect("directory metadata sync must not reject a valid host directory");
     }
 
+    #[test]
+    fn concurrent_repo_graph_load_returns_the_cached_winner() {
+        let winner = Arc::new(kin_db::InMemoryGraph::new());
+        let winner_entity = test_entity("winner", "src/winner.rs");
+        winner.upsert_entity(&winner_entity).unwrap();
+
+        let losing_load = Arc::new(kin_db::InMemoryGraph::new());
+        let losing_entity = test_entity("loser", "src/loser.rs");
+        losing_load.upsert_entity(&losing_entity).unwrap();
+
+        // Deterministically model two slow-path loads that both missed the
+        // read cache: the first task has acquired the write lock and installed
+        // its generation before the second task reaches the entry operation.
+        let mut graphs = HashMap::new();
+        graphs.insert("shared".to_string(), Arc::clone(&winner));
+        let returned = DaemonState::cache_loaded_repo_graph(&mut graphs, "shared", losing_load);
+
+        assert!(Arc::ptr_eq(&returned, &winner));
+        assert!(returned.get_entity(&winner_entity.id).unwrap().is_some());
+        assert!(returned.get_entity(&losing_entity.id).unwrap().is_none());
+    }
+
     struct CleanupFailOnceBackend {
         inner: kin_db::LocalFileBackend,
         fail_cleanup: AtomicBool,
@@ -3180,6 +3780,7 @@ mod tests {
             projection: RwLock::new(ProjectionState::new()),
             coordinator,
             coordination_gate: tokio::sync::Mutex::new(()),
+            graph_authority_clock: Arc::new(GraphAuthorityClock::default()),
             coordination_mode: std::sync::RwLock::new(
                 kin_mcp::CoordinationEnforcementMode::from_env(),
             ),
@@ -3206,6 +3807,7 @@ mod tests {
             session_overlays: RwLock::new(std::collections::HashMap::new()),
             session_scopes: RwLock::new(HashMap::new()),
             spine: std::sync::OnceLock::new(),
+            spine_refresh_gate: tokio::sync::Mutex::new(()),
             repo_graphs: RwLock::new(HashMap::new()),
             allowed_repo_ids: None,
             dirty: AtomicBool::new(false),
@@ -3565,6 +4167,197 @@ mod tests {
     }
 
     #[test]
+    fn spine_capture_retries_after_primary_mutates_between_snapshot_and_validation() {
+        use kin_model::{GraphNodeId, Relation, RelationId, RelationKind, RelationOrigin};
+
+        let repo_dir = tempfile::tempdir().unwrap();
+        let init = kin_core::init(repo_dir.path()).unwrap();
+        let state = Arc::new(test_state(init.layout, repo_dir.path()));
+        let original = test_entity("original", "src/original.rs");
+        state.graph.upsert_entity(&original).unwrap();
+        let old_root = hex::encode(state.graph.compute_root_hash());
+
+        let captured = Arc::new(std::sync::Barrier::new(2));
+        let resume = Arc::new(std::sync::Barrier::new(2));
+        let worker_state = Arc::clone(&state);
+        let worker_graph = Arc::clone(&state.graph);
+        let worker_captured = Arc::clone(&captured);
+        let worker_resume = Arc::clone(&resume);
+        let worker = std::thread::spawn(move || {
+            worker_state.capture_spine_repo_with_hook("test-repo", worker_graph, move |attempt| {
+                if attempt == 0 {
+                    worker_captured.wait();
+                    worker_resume.wait();
+                }
+            })
+        });
+
+        captured.wait();
+        let raced = test_entity("raced", "src/raced.rs");
+        let raced_relation = Relation {
+            id: RelationId::new(),
+            kind: RelationKind::Calls,
+            src: GraphNodeId::Entity(original.id),
+            dst: GraphNodeId::Entity(raced.id),
+            confidence: 1.0,
+            origin: RelationOrigin::Parsed,
+            created_in: None,
+            import_source: None,
+            evidence: Vec::new(),
+        };
+        let mutation = state.begin_graph_authority_mutation();
+        state.graph.upsert_entity(&raced).unwrap();
+        state.graph.upsert_relation(&raced_relation).unwrap();
+        drop(mutation);
+        resume.wait();
+
+        let capture = worker
+            .join()
+            .unwrap()
+            .expect("capture retries onto stable primary authority");
+        let current_root = hex::encode(state.graph.compute_root_hash());
+        assert_ne!(old_root, current_root);
+        assert_eq!(capture.root_hash, current_root);
+        assert!(capture
+            .entries
+            .iter()
+            .any(|entry| entry.entity_id == raced.id));
+        assert!(capture
+            .relations
+            .iter()
+            .any(|relation| relation.id == raced_relation.id));
+        assert_eq!(capture.entries.len(), capture.entities.len());
+    }
+
+    #[test]
+    #[serial_test::serial]
+    fn spine_initialization_retries_after_busy_primary_authority() {
+        let repo_dir = tempfile::tempdir().unwrap();
+        let init = kin_core::init(repo_dir.path()).unwrap();
+        let state = test_state(init.layout, repo_dir.path());
+        let entity = test_entity("stable_after_writer", "src/lib.rs");
+        state.graph.upsert_entity(&entity).unwrap();
+
+        let registry_dir = tempfile::tempdir().unwrap();
+        let registry_path = registry_dir.path().join("registry.toml");
+        kin_core::registry::KinRegistry { repos: Vec::new() }
+            .save_to(&registry_path)
+            .unwrap();
+        let prev_registry = std::env::var_os("KIN_REGISTRY_PATH");
+        let prev_disable = std::env::var_os("KIN_DISABLE_SPINE");
+        std::env::set_var("KIN_REGISTRY_PATH", &registry_path);
+        std::env::remove_var("KIN_DISABLE_SPINE");
+
+        let writer = state.begin_graph_authority_mutation();
+        let deferred = state.ensure_spine().is_none();
+        let once_lock_unpublished = state.spine.get().is_none();
+        drop(writer);
+        let expected_root = hex::encode(state.graph.compute_root_hash());
+        let (retried, registered_root, registered_entity) = match state.ensure_spine() {
+            Some(spine) => (
+                true,
+                spine.root_hash("test-repo"),
+                spine.lookup_by_id("test-repo", &entity.id).is_some(),
+            ),
+            None => (false, None, false),
+        };
+
+        match prev_registry {
+            Some(value) => std::env::set_var("KIN_REGISTRY_PATH", value),
+            None => std::env::remove_var("KIN_REGISTRY_PATH"),
+        }
+        match prev_disable {
+            Some(value) => std::env::set_var("KIN_DISABLE_SPINE", value),
+            None => std::env::remove_var("KIN_DISABLE_SPINE"),
+        }
+
+        assert!(deferred, "an active writer must defer spine initialization");
+        assert!(
+            once_lock_unpublished,
+            "a failed primary capture must not permanently publish OnceLock"
+        );
+        assert!(retried, "the next request must retry initialization");
+        assert_eq!(registered_root.as_deref(), Some(expected_root.as_str()));
+        assert!(registered_entity);
+    }
+
+    #[test]
+    #[serial_test::serial]
+    fn spine_initialization_revalidates_at_the_publication_edge() {
+        let repo_dir = tempfile::tempdir().unwrap();
+        let init = kin_core::init(repo_dir.path()).unwrap();
+        let state = Arc::new(test_state(init.layout, repo_dir.path()));
+        let original = test_entity("before_publication", "src/original.rs");
+        state.graph.upsert_entity(&original).unwrap();
+
+        let registry_dir = tempfile::tempdir().unwrap();
+        let registry_path = registry_dir.path().join("registry.toml");
+        kin_core::registry::KinRegistry { repos: Vec::new() }
+            .save_to(&registry_path)
+            .unwrap();
+        let prev_registry = std::env::var_os("KIN_REGISTRY_PATH");
+        let prev_disable = std::env::var_os("KIN_DISABLE_SPINE");
+        std::env::set_var("KIN_REGISTRY_PATH", &registry_path);
+        std::env::remove_var("KIN_DISABLE_SPINE");
+
+        let prepared = Arc::new(std::sync::Barrier::new(2));
+        let resume = Arc::new(std::sync::Barrier::new(2));
+        let worker_state = Arc::clone(&state);
+        let worker_prepared = Arc::clone(&prepared);
+        let worker_resume = Arc::clone(&resume);
+        let worker = std::thread::spawn(move || {
+            worker_state.initialize_spine_lazy_with_publication_hook(|| {
+                worker_prepared.wait();
+                worker_resume.wait();
+            });
+        });
+
+        // Advance graph authority after the prepared backend's ordinary final
+        // validation but before it can cross the OnceLock visibility edge.
+        prepared.wait();
+        let raced = test_entity("at_publication", "src/raced.rs");
+        let mutation = state.begin_graph_authority_mutation();
+        state.graph.upsert_entity(&raced).unwrap();
+        drop(mutation);
+        resume.wait();
+        worker.join().unwrap();
+
+        let stale_backend_unpublished = state.spine.get().is_none();
+        let expected_root = hex::encode(state.graph.compute_root_hash());
+        let (retried, registered_root, raced_entity) = match state.ensure_spine() {
+            Some(spine) => (
+                true,
+                spine.root_hash("test-repo"),
+                spine.lookup_by_id("test-repo", &raced.id).is_some(),
+            ),
+            None => (false, None, false),
+        };
+
+        match prev_registry {
+            Some(value) => std::env::set_var("KIN_REGISTRY_PATH", value),
+            None => std::env::remove_var("KIN_REGISTRY_PATH"),
+        }
+        match prev_disable {
+            Some(value) => std::env::set_var("KIN_DISABLE_SPINE", value),
+            None => std::env::remove_var("KIN_DISABLE_SPINE"),
+        }
+
+        assert!(
+            stale_backend_unpublished,
+            "a graph advance before OnceLock publication must discard the prepared backend"
+        );
+        assert!(
+            retried,
+            "the next request must rebuild from current authority"
+        );
+        assert_eq!(registered_root.as_deref(), Some(expected_root.as_str()));
+        assert!(
+            raced_entity,
+            "the rebuilt backend must include raced authority"
+        );
+    }
+
+    #[test]
     #[serial_test::serial]
     fn spine_init_materializes_cross_repo_edges() {
         use kin_db::{InMemoryGraph, SnapshotManager};
@@ -3587,6 +4380,7 @@ mod tests {
         sibling_graph
             .batch_upsert_entities(&[test_entity(imported_symbol, "src/lib.rs")])
             .unwrap();
+        let expected_sibling_root = hex::encode(sibling_graph.compute_root_hash());
         SnapshotManager::save_graph(sibling_init.layout.kindb_snapshot_path(), &sibling_graph)
             .unwrap();
 
@@ -3639,9 +4433,13 @@ mod tests {
         std::env::set_var("KIN_REGISTRY_PATH", &registry_path);
         std::env::remove_var("KIN_DISABLE_SPINE");
 
-        let (repo_count, edge_count) = {
+        let (repo_count, edge_count, sibling_root) = {
             let spine = state.ensure_spine().expect("spine must be enabled");
-            (spine.repo_count(), spine.edge_count())
+            (
+                spine.repo_count(),
+                spine.edge_count(),
+                spine.root_hash(sibling_id),
+            )
         };
 
         // Restore the process-global env before asserting so a failure can never
@@ -3661,6 +4459,11 @@ mod tests {
         assert!(
             edge_count > 0,
             "cross-repo edges must materialize after spine init (got {edge_count})"
+        );
+        assert_eq!(
+            sibling_root.as_deref(),
+            Some(expected_sibling_root.as_str()),
+            "sibling registration must carry its exact nonempty snapshot root"
         );
     }
 
@@ -3775,10 +4578,17 @@ mod tests {
             .ingest_repo_into_spine(sibling_id, false)
             .await
             .expect("sibling ingest from storage");
+        let ingest_race_entity = test_entity("ingest_race", "src/ingest_race.rs");
         let primary_outcome = state
-            .ingest_repo_into_spine(primary_id, true)
+            .ingest_repo_into_spine_with_capture_hook(primary_id, true, |attempt| {
+                if attempt == 0 {
+                    let mutation = state.begin_graph_authority_mutation();
+                    state.graph.upsert_entity(&ingest_race_entity).unwrap();
+                    drop(mutation);
+                }
+            })
             .await
-            .expect("primary ingest + cross-repo edge refresh");
+            .expect("primary ingest retries onto stable capture + cross-repo edge refresh");
 
         // Restore env before asserting so a failure cannot leak the override.
         if let Some(v) = prev_disable {
@@ -3800,12 +4610,23 @@ mod tests {
             primary_outcome.resolvable_relations, 1,
             "the primary's cross-repo call must be classified resolvable"
         );
+        assert_eq!(
+            primary_outcome.root_hash,
+            hex::encode(state.graph.compute_root_hash()),
+            "ingest must never publish the pre-race entity set under the post-race root"
+        );
 
         let spine = state.spine().expect("spine initialized by ingest");
         assert!(
             spine.repo_count() >= 2,
             "primary and sibling must both be registered (got {})",
             spine.repo_count()
+        );
+        assert!(
+            spine
+                .lookup_by_id(primary_id, &ingest_race_entity.id)
+                .is_some(),
+            "ingest retry must register the entity added between capture and validation"
         );
 
         // ── The contract the demo needs: non-empty cross-repo xref ────────
@@ -3837,6 +4658,38 @@ mod tests {
         assert!(
             impact.repos_involved.contains(&primary_id.to_string()),
             "changing the sibling entity must impact the primary repo across the boundary"
+        );
+
+        // Regression: the primary graph can advance after its explicit ingest
+        // but before the orchestrator's all-repo refresh. The refresh must
+        // re-register current entries and R1 before resolving; certifying the
+        // captured R1 topology under the old ingested R0 root is unsound.
+        let ingested_root = spine
+            .root_hash(primary_id)
+            .expect("primary ingest registered a root");
+        let post_ingest_entity = test_entity("post_ingest", "src/new.rs");
+        state.graph.upsert_entity(&post_ingest_entity).unwrap();
+        let current_root = hex::encode(state.graph.compute_root_hash());
+        assert_ne!(current_root, ingested_root);
+
+        let refreshed = state
+            .refresh_all_cross_repo_edges()
+            .await
+            .expect("all-repo refresh after graph mutation");
+        assert_eq!(refreshed.repos_refreshed, 2);
+        assert_eq!(
+            spine.root_hash(primary_id).as_deref(),
+            Some(current_root.as_str())
+        );
+        assert!(
+            spine
+                .lookup_by_id(primary_id, &post_ingest_entity.id)
+                .is_some(),
+            "phase 2 must publish current R1 entries before resolving any source"
+        );
+        assert!(
+            spine.cross_repo_edges_snapshot().complete,
+            "a stable two-phase pass over both repos should certify completeness"
         );
     }
 

--- a/crates/kin-daemon/src/state.rs
+++ b/crates/kin-daemon/src/state.rs
@@ -954,7 +954,10 @@ impl DaemonState {
         Self::open_with_repo_id(layout, Some(repo_id))
     }
 
-    fn open_with_repo_id(layout: KinLayout, explicit_repo_id: Option<&str>) -> Result<Self> {
+    /// Open local daemon state with a repository identity already resolved by
+    /// the process entrypoint. This keeps CLI flags and manifest-derived
+    /// authority from being discarded in favor of an unrelated ambient value.
+    pub fn open_with_repo_id(layout: KinLayout, explicit_repo_id: Option<&str>) -> Result<Self> {
         // Up-front compatibility gate. A repo created by a pre-0.2 kin carries
         // an on-disk graph/index that this build's post-load embed/readiness
         // path cannot serve. Without this gate the daemon loads the snapshot,
@@ -3905,6 +3908,15 @@ mod tests {
         let repo_dir = tempfile::tempdir().unwrap();
         let init = kin_core::init(repo_dir.path()).unwrap();
         DaemonState::open(init.layout).expect("current-version repo must open");
+    }
+
+    #[test]
+    fn open_with_repo_id_preserves_entrypoint_authority() {
+        let repo_dir = tempfile::tempdir().unwrap();
+        let init = kin_core::init(repo_dir.path()).unwrap();
+        let state = DaemonState::open_with_repo_id(init.layout, Some("entrypoint-repo"))
+            .expect("an entrypoint-resolved repository id must open");
+        assert_eq!(state.cached_repo_id, "entrypoint-repo");
     }
 
     #[cfg(feature = "vector")]

--- a/crates/kin-mcp/src/handlers/common.rs
+++ b/crates/kin-mcp/src/handlers/common.rs
@@ -201,7 +201,7 @@ pub async fn fetch_spine_impact_typed(
 pub async fn fetch_spine_xref(
     repo_id: &str,
     entity_id: &EntityId,
-) -> SpineQuery<serde_json::Value> {
+) -> SpineQuery<kin_spine::SpineXrefResponse> {
     let Ok(daemon_url) = daemon_url_from_env() else {
         return SpineQuery::NotConfigured;
     };
@@ -226,9 +226,12 @@ pub async fn fetch_spine_xref(
     };
 
     match classify_spine_probe(true, Some(resp.status().as_u16())) {
-        SpineProbe::Healthy => match resp.json::<serde_json::Value>().await {
-            Ok(body) => SpineQuery::Found(body),
-            Err(e) => SpineQuery::Unavailable(format!("malformed spine response: {e}")),
+        SpineProbe::Healthy => match resp.bytes().await {
+            Ok(bytes) => match kin_spine::SpineXrefResponse::from_slice(&bytes) {
+                Ok(body) => SpineQuery::Found(body),
+                Err(e) => SpineQuery::Unavailable(e.to_string()),
+            },
+            Err(e) => SpineQuery::Unavailable(format!("failed to read spine response: {e}")),
         },
         SpineProbe::Unavailable(reason) => SpineQuery::Unavailable(reason),
         SpineProbe::NotConfigured => {

--- a/crates/kin-mcp/src/handlers/common.rs
+++ b/crates/kin-mcp/src/handlers/common.rs
@@ -227,10 +227,12 @@ pub async fn fetch_spine_xref(
 
     match classify_spine_probe(true, Some(resp.status().as_u16())) {
         SpineProbe::Healthy => match resp.bytes().await {
-            Ok(bytes) => match kin_spine::SpineXrefResponse::from_slice(&bytes) {
-                Ok(body) => SpineQuery::Found(body),
-                Err(e) => SpineQuery::Unavailable(e.to_string()),
-            },
+            Ok(bytes) => {
+                match kin_spine::SpineXrefResponse::from_slice_for(&bytes, repo_id, entity_id) {
+                    Ok(body) => SpineQuery::Found(body),
+                    Err(e) => SpineQuery::Unavailable(e.to_string()),
+                }
+            }
             Err(e) => SpineQuery::Unavailable(format!("failed to read spine response: {e}")),
         },
         SpineProbe::Unavailable(reason) => SpineQuery::Unavailable(reason),

--- a/crates/kin-mcp/src/handlers/entities.rs
+++ b/crates/kin-mcp/src/handlers/entities.rs
@@ -761,16 +761,9 @@ fn append_spine_reference_rows(
     rows: &mut Vec<ReferenceRow>,
     repo_id: &str,
     target_id: &kin_model::EntityId,
-    relation_kinds: &[RelationKind],
+    _relation_kinds: &[RelationKind],
     response: &kin_spine::SpineXrefResponse,
 ) -> usize {
-    // CrossRepoEdge does not encode a source relation kind. Treat it as the
-    // generic cross-repo reference it is, and do not leak it into a calls-only
-    // or imports-only filtered response.
-    if !relation_kinds.contains(&RelationKind::References) {
-        return 0;
-    }
-
     let before = rows.len();
     for edge in &response.edges {
         if edge.dst_repo != repo_id || edge.dst_entity != *target_id || edge.src_repo == repo_id {
@@ -803,6 +796,12 @@ fn append_spine_reference_rows(
             relation_kinds: vec![RelationKind::References],
         });
     }
+
+    // CrossRepoEdge does not encode whether the dependency originated as a
+    // call, import, or other reference. Keep the generic row even for a narrow
+    // filter: dropping it would let a calls-only/imports-only empty response
+    // certify absence despite a real external dependent. The row's explicit
+    // `references` kind tells clients that the exact subtype is unavailable.
     rows.len() - before
 }
 
@@ -865,13 +864,13 @@ pub async fn handle_find_references<G: GraphStore>(
                     &relation_kinds,
                     &body,
                 );
-                let authority_complete =
-                    body.authority_complete && body.authority_roots.contains_key(&repo_id);
+                let authority_complete = body.authority_complete_for(&repo_id, &target.id);
                 serde_json::json!({
                     "status": "available",
                     "payload_version": body.version(),
                     "reference_count": reference_count,
                     "authority_complete": authority_complete,
+                    "authority_anchor": body.authority_anchor,
                     "authority_revision": body.authority_revision,
                     "authority_roots": body.authority_roots,
                 })
@@ -2215,10 +2214,10 @@ mod tests {
     }
 
     #[test]
-    fn spine_xrefs_respect_direction_and_relation_filter() {
+    fn spine_xrefs_respect_direction_and_preserve_untyped_filtered_dependencies() {
         let target = make_entity("do_work", "src/lib.rs");
         let other = EntityId::new();
-        let response = kin_spine::SpineXrefResponse::new(
+        let outgoing_response = kin_spine::SpineXrefResponse::new(
             vec![kin_spine::CrossRepoEdge {
                 src_repo: "provider".to_string(),
                 src_entity: target.id,
@@ -2236,21 +2235,43 @@ mod tests {
                 "provider",
                 &target.id,
                 &[RelationKind::References],
-                &response,
-            ),
-            0
-        );
-        assert_eq!(
-            append_spine_reference_rows(
-                &mut rows,
-                "consumer",
-                &other,
-                &[RelationKind::Calls],
-                &response,
+                &outgoing_response,
             ),
             0
         );
         assert!(rows.is_empty());
+
+        let source = make_entity("run_task", "src/app.rs");
+        let incoming_response = kin_spine::SpineXrefResponse::new(
+            vec![kin_spine::CrossRepoEdge {
+                src_repo: "consumer".to_string(),
+                src_entity: source.id,
+                dst_repo: "provider".to_string(),
+                dst_entity: target.id,
+                confidence: 0.9,
+            }],
+            Vec::new(),
+        );
+        assert!(!incoming_response.authority_complete_for("provider", &target.id));
+
+        for filter in [RelationKind::Calls, RelationKind::Imports] {
+            let mut filtered_rows = Vec::new();
+            assert_eq!(
+                append_spine_reference_rows(
+                    &mut filtered_rows,
+                    "provider",
+                    &target.id,
+                    &[filter],
+                    &incoming_response,
+                ),
+                1,
+                "a generic federated dependency must survive the {filter:?} filter"
+            );
+            assert_eq!(
+                filtered_rows[0].relation_kinds,
+                vec![RelationKind::References]
+            );
+        }
     }
 
     #[test]

--- a/crates/kin-mcp/src/handlers/entities.rs
+++ b/crates/kin-mcp/src/handlers/entities.rs
@@ -762,8 +762,11 @@ fn cross_repo_repo_id() -> std::result::Result<String, String> {
 /// The daemon constructs this from its resolved repository identity and its
 /// in-process spine. Neither value comes from MCP request arguments or ambient
 /// process configuration, so a caller cannot redirect the authority query.
+#[derive(Clone, Copy)]
 pub struct FindReferencesAuthority<'a> {
     pub repo_id: &'a str,
+    /// Exact root of the concrete live/session graph serving this request.
+    pub graph_root: &'a str,
     pub spine: Option<&'a dyn kin_spine::SpineBackend>,
 }
 
@@ -772,14 +775,12 @@ enum FindReferencesAuthoritySource<'a> {
     Daemon(FindReferencesAuthority<'a>),
 }
 
-fn append_spine_reference_rows(
-    rows: &mut Vec<ReferenceRow>,
+fn spine_reference_rows(
     repo_id: &str,
     target_id: &kin_model::EntityId,
-    _relation_kinds: &[RelationKind],
     response: &kin_spine::SpineXrefResponse,
-) -> usize {
-    let before = rows.len();
+) -> Vec<ReferenceRow> {
+    let mut rows = Vec::new();
     for edge in &response.edges {
         if edge.dst_repo != repo_id || edge.dst_entity != *target_id || edge.src_repo == repo_id {
             continue;
@@ -808,16 +809,58 @@ fn append_spine_reference_rows(
             start_line: None,
             signature: source.map(|entity| entity.signature.clone()),
             snippet: None,
-            relation_kinds: vec![RelationKind::References],
+            // CrossRepoEdge proves a dependency but does not retain whether
+            // the source relation was Calls/Imports/References.
+            relation_kinds: Vec::new(),
         });
     }
 
-    // CrossRepoEdge does not encode whether the dependency originated as a
-    // call, import, or other reference. Keep the generic row even for a narrow
-    // filter: dropping it would let a calls-only/imports-only empty response
-    // certify absence despite a real external dependent. The row's explicit
-    // `references` kind tells clients that the exact subtype is unavailable.
-    rows.len() - before
+    rows
+}
+
+fn reference_filter_covers_unknown_subtypes(relation_kinds: &[RelationKind]) -> bool {
+    let defaults = default_reference_kinds();
+    relation_kinds.len() == defaults.len()
+        && defaults.iter().all(|kind| relation_kinds.contains(kind))
+}
+
+fn reference_row_json(row: ReferenceRow) -> serde_json::Value {
+    serde_json::json!({
+        "entity_id": row.entity_id,
+        "name": row.name,
+        "kind": row.kind,
+        "file_path": row.file_path,
+        "start_line": row.start_line,
+        "signature": row.signature,
+        "snippet": row.snippet,
+        "relation_kinds": row
+            .relation_kinds
+            .into_iter()
+            .map(relation_kind_name)
+            .collect::<Vec<_>>(),
+    })
+}
+
+fn daemon_spine_xref(
+    authority: FindReferencesAuthority<'_>,
+    target_id: &kin_model::EntityId,
+) -> std::result::Result<(String, kin_spine::SpineQuery<kin_spine::SpineXrefResponse>), String> {
+    let repo_id = normalize_cross_repo_repo_id(Some(authority.repo_id))?;
+    let query = match authority.spine {
+        Some(spine) => {
+            let body = spine.cross_repo_xref_response(&repo_id, target_id);
+            if body.authority_root_matches(&repo_id, authority.graph_root) {
+                kin_spine::SpineQuery::Found(body)
+            } else {
+                kin_spine::SpineQuery::Unavailable(format!(
+                    "spine root mismatch for repository {repo_id}: live/session graph root {} is not the registered spine root",
+                    authority.graph_root
+                ))
+            }
+        }
+        None => kin_spine::SpineQuery::NotConfigured,
+    };
+    Ok((repo_id, query))
 }
 
 pub async fn handle_find_references<G: GraphStore>(
@@ -902,19 +945,7 @@ async fn handle_find_references_with_authority_source<G: GraphStore>(
             Err(reason) => Err(reason),
         },
         FindReferencesAuthoritySource::Daemon(authority) => {
-            normalize_cross_repo_repo_id(Some(authority.repo_id)).map(|repo_id| {
-                let query = match authority.spine {
-                    Some(spine) => {
-                        kin_spine::SpineQuery::Found(kin_spine::SpineXrefResponse::from_snapshot(
-                            spine.cross_repo_edges_snapshot(),
-                            &repo_id,
-                            &target.id,
-                        ))
-                    }
-                    None => kin_spine::SpineQuery::NotConfigured,
-                };
-                (repo_id, query)
-            })
+            daemon_spine_xref(authority, &target.id)
         }
     };
     let cross_repo = match cross_repo_query {
@@ -927,18 +958,28 @@ async fn handle_find_references_with_authority_source<G: GraphStore>(
         }
         Ok((repo_id, query)) => match query {
             kin_spine::SpineQuery::Found(body) => {
-                let reference_count = append_spine_reference_rows(
-                    &mut rows,
-                    &repo_id,
-                    &target.id,
-                    &relation_kinds,
-                    &body,
-                );
+                let federated_rows = spine_reference_rows(&repo_id, &target.id, &body);
+                let relation_subtype_complete =
+                    reference_filter_covers_unknown_subtypes(&relation_kinds)
+                        || federated_rows.is_empty();
+                let reference_count = if relation_subtype_complete {
+                    rows.extend(federated_rows.iter().cloned());
+                    federated_rows.len()
+                } else {
+                    0
+                };
+                let federated_references = federated_rows
+                    .into_iter()
+                    .map(reference_row_json)
+                    .collect::<Vec<_>>();
                 let authority_complete = body.authority_complete_for(&repo_id, &target.id);
                 serde_json::json!({
                     "status": "available",
                     "payload_version": body.version(),
                     "reference_count": reference_count,
+                    "federated_reference_count": federated_references.len(),
+                    "federated_references": federated_references,
+                    "relation_subtype_complete": relation_subtype_complete,
                     "authority_complete": authority_complete,
                     "authority_anchor": body.authority_anchor,
                     "authority_revision": body.authority_revision,
@@ -967,27 +1008,9 @@ async fn handle_find_references_with_authority_source<G: GraphStore>(
             .then_with(|| left.name.cmp(&right.name))
     });
 
-    let references = rows
-        .into_iter()
-        .map(|row| {
-            serde_json::json!({
-                // `entity_id` is the keystone: it lets the agent drill this
-                // reference straight to the caller's body
-                // (`get_entity_source`/`get_context_pack`) with no name
-                // re-resolution and no filesystem fallback. `snippet` carries the
-                // caller's bounded body inline so the common drill needs no
-                // second round-trip.
-                "entity_id": row.entity_id,
-                "name": row.name,
-                "kind": row.kind,
-                "file_path": row.file_path,
-                "start_line": row.start_line,
-                "signature": row.signature,
-                "snippet": row.snippet,
-                "relation_kinds": row.relation_kinds.into_iter().map(relation_kind_name).collect::<Vec<_>>(),
-            })
-        })
-        .collect::<Vec<_>>();
+    // `entity_id` remains the local drill-through keystone. Federated rows use
+    // repo-qualified paths and carry no local entity id.
+    let references = rows.into_iter().map(reference_row_json).collect::<Vec<_>>();
 
     let result = serde_json::json!({
         "focal_entity": {
@@ -1015,6 +1038,11 @@ async fn handle_find_references_with_authority_source<G: GraphStore>(
 ///
 /// Returns one row per requested entity_id with `has_references`, `reference_count`,
 /// and (in non-compact mode) the matching relation kinds and entity metadata.
+/// Unknown entities or authority gaps carry `has_references: null` and
+/// `verdict_complete: false`; they are never counted as unreferenced. A numeric
+/// total is emitted only with `reference_count_complete: true`; otherwise
+/// `known_reference_count` is the explicit lower bound and `reference_count`
+/// is null.
 /// Designed for reachability / dead-code / count-callers workloads where calling
 /// `find_references` per entity blows up token budgets.
 pub const BULK_CHECK_REFERENCES_DESC: &str = "\
@@ -1032,11 +1060,32 @@ list of callers, find_references is the right tool; for finding dead code from a
 concept rather than a known ID set, find_dead_code_seeded combines the search and the \
 classification. Each `has_references:false` row is qualified by the response's additive \
 `negative` object — consult `safe_to_conclude_absent` before treating a false verdict as \
-\"safe to delete\", since an incomplete or stale index can report a false negative.";
+\"safe to delete\". Unknown entities, stale authority, and unclassified federated relation \
+subtypes return `has_references:null` with `verdict_complete:false`, never a false verdict. \
+When total count authority is incomplete, `reference_count` is null and \
+`known_reference_count` is only a lower bound.";
 
 pub fn handle_bulk_check_references<G: GraphStore>(
     args: &HashMap<String, serde_json::Value>,
     store: &G,
+) -> Result<ToolCallResult> {
+    handle_bulk_check_references_with_authority_source(args, store, None)
+}
+
+/// Serve the batched reachability tool from the same exact daemon graph/spine
+/// authority as `find_references`.
+pub fn handle_bulk_check_references_with_authority<G: GraphStore>(
+    args: &HashMap<String, serde_json::Value>,
+    store: &G,
+    authority: FindReferencesAuthority<'_>,
+) -> Result<ToolCallResult> {
+    handle_bulk_check_references_with_authority_source(args, store, Some(authority))
+}
+
+fn handle_bulk_check_references_with_authority_source<G: GraphStore>(
+    args: &HashMap<String, serde_json::Value>,
+    store: &G,
+    authority: Option<FindReferencesAuthority<'_>>,
 ) -> Result<ToolCallResult> {
     const MAX_BULK_ENTITIES: usize = 200;
 
@@ -1066,8 +1115,17 @@ pub fn handle_bulk_check_references<G: GraphStore>(
     let compact = get_optional_bool(args, "compact", true);
 
     let allowed: std::collections::HashSet<RelationKind> = relation_kinds.iter().copied().collect();
+    let relation_subtype_complete = reference_filter_covers_unknown_subtypes(&relation_kinds);
     let mut results = Vec::with_capacity(entity_ids_raw.len());
-    let mut with_references = 0usize;
+    let mut cross_repo_checked = 0usize;
+    let mut cross_repo_authority_complete = true;
+    let mut cross_repo_revision = None;
+    let mut cross_repo_roots = serde_json::Map::new();
+    let mut cross_repo_watermark_initialized = false;
+    let mut cross_repo_watermark_complete = true;
+    let mut cross_repo_unavailable = None;
+    let mut federated_reference_count = 0usize;
+    let mut saw_unknown_federated_subtype = false;
 
     for raw_id in &entity_ids_raw {
         let entity_id = match parse_entity_id(raw_id) {
@@ -1076,10 +1134,14 @@ pub fn handle_bulk_check_references<G: GraphStore>(
                 let mut row = serde_json::json!({
                     "entity_id": raw_id,
                     "error": "invalid entity_id (not a UUID)",
+                    "has_references": null,
+                    "reference_count": null,
+                    "known_reference_count": null,
+                    "reference_count_complete": false,
+                    "verdict_complete": false,
                 });
                 if !compact {
-                    row["has_references"] = serde_json::json!(false);
-                    row["reference_count"] = serde_json::json!(0);
+                    row["federated_reference_count"] = serde_json::Value::Null;
                 }
                 results.push(row);
                 continue;
@@ -1091,14 +1153,18 @@ pub fn handle_bulk_check_references<G: GraphStore>(
             let mut row = serde_json::json!({
                 "entity_id": raw_id,
                 "error": "entity not found",
-                "has_references": false,
-                "reference_count": 0,
+                "has_references": null,
+                "reference_count": null,
+                "known_reference_count": null,
+                "reference_count_complete": false,
+                "verdict_complete": false,
             });
             if !compact {
                 row["name"] = serde_json::Value::Null;
                 row["kind"] = serde_json::Value::Null;
                 row["file_path"] = serde_json::Value::Null;
                 row["matched_kinds"] = serde_json::json!([]);
+                row["federated_reference_count"] = serde_json::Value::Null;
             }
             results.push(row);
             continue;
@@ -1128,39 +1194,193 @@ pub fn handle_bulk_check_references<G: GraphStore>(
             }
         }
 
-        let has_references = reference_count > 0;
-        if has_references {
-            with_references += 1;
+        let mut entity_federated_reference_count = 0usize;
+        // Local-only execution may prove a positive, but it has no authority
+        // to classify a zero or numeric count as the cross-repo total.
+        let mut entity_cross_repo_authority_complete = false;
+        if let Some(authority) = authority {
+            match daemon_spine_xref(authority, &entity_id) {
+                Ok((repo_id, kin_spine::SpineQuery::Found(body))) => {
+                    cross_repo_checked += 1;
+                    entity_cross_repo_authority_complete =
+                        body.authority_complete_for(&repo_id, &entity_id);
+                    cross_repo_authority_complete &= entity_cross_repo_authority_complete;
+                    let body_roots = body
+                        .authority_roots
+                        .iter()
+                        .map(|(repo, root)| (repo.clone(), serde_json::Value::String(root.clone())))
+                        .collect::<serde_json::Map<_, _>>();
+                    if !cross_repo_watermark_initialized {
+                        cross_repo_revision = body.authority_revision.clone();
+                        cross_repo_roots = body_roots;
+                        cross_repo_watermark_initialized = true;
+                    } else if body.authority_revision != cross_repo_revision
+                        || body_roots != cross_repo_roots
+                    {
+                        // A topology mutation raced this batch. Known positives
+                        // remain useful, but no false row spans one atomic
+                        // authority watermark, so the batch cannot certify
+                        // absence.
+                        cross_repo_authority_complete = false;
+                        cross_repo_watermark_complete = false;
+                    }
+                    entity_federated_reference_count = body
+                        .edges
+                        .iter()
+                        .filter(|edge| {
+                            edge.dst_repo == repo_id
+                                && edge.dst_entity == entity_id
+                                && edge.src_repo != repo_id
+                        })
+                        .count();
+                    federated_reference_count += entity_federated_reference_count;
+                    if relation_subtype_complete && entity_federated_reference_count > 0 {
+                        reference_count += entity_federated_reference_count;
+                    }
+                }
+                Ok((_, kin_spine::SpineQuery::Unavailable(reason))) => {
+                    cross_repo_unavailable.get_or_insert(reason);
+                    cross_repo_authority_complete = false;
+                }
+                Ok((_, kin_spine::SpineQuery::NotConfigured)) => {
+                    cross_repo_unavailable
+                        .get_or_insert_with(|| "cross-repo spine is not configured".to_string());
+                    cross_repo_authority_complete = false;
+                }
+                Err(reason) => {
+                    cross_repo_unavailable.get_or_insert(reason);
+                    cross_repo_authority_complete = false;
+                }
+            }
         }
 
+        let known_positive = reference_count > 0;
+        let federated_count_incomplete =
+            !relation_subtype_complete && entity_federated_reference_count > 0;
+        saw_unknown_federated_subtype |= federated_count_incomplete;
+        let federated_subtype_unknown = federated_count_incomplete && !known_positive;
+        let reference_count_complete =
+            entity_cross_repo_authority_complete && !federated_count_incomplete;
+        let has_references = if known_positive {
+            Some(true)
+        } else if reference_count_complete {
+            Some(false)
+        } else {
+            None
+        };
+        let verdict_complete = has_references.is_some();
+        let reported_reference_count = reference_count_complete.then_some(reference_count);
+        let verdict_reason = if federated_subtype_unknown {
+            Some("federated relation subtype unavailable")
+        } else if !entity_cross_repo_authority_complete && !known_positive {
+            Some("cross-repo authority incomplete")
+        } else {
+            None
+        };
+
         if compact {
-            results.push(serde_json::json!({
+            let mut row = serde_json::json!({
                 "entity_id": entity_id,
                 "has_references": has_references,
-                "reference_count": reference_count,
-            }));
+                "reference_count": reported_reference_count,
+                "known_reference_count": reference_count,
+                "reference_count_complete": reference_count_complete,
+                "federated_reference_count": entity_federated_reference_count,
+                "verdict_complete": verdict_complete,
+            });
+            if let Some(reason) = verdict_reason {
+                row["verdict_reason"] = serde_json::json!(reason);
+            }
+            results.push(row);
         } else {
             matched_kinds.sort_by_key(|kind| relation_kind_rank(kind));
-            results.push(serde_json::json!({
+            let mut row = serde_json::json!({
                 "entity_id": entity_id,
                 "name": entity.name,
                 "kind": format!("{:?}", entity.kind),
                 "file_path": entity.file_origin.as_ref().map(|p| p.to_string()),
                 "has_references": has_references,
-                "reference_count": reference_count,
+                "reference_count": reported_reference_count,
+                "known_reference_count": reference_count,
+                "reference_count_complete": reference_count_complete,
+                "federated_reference_count": entity_federated_reference_count,
+                "verdict_complete": verdict_complete,
                 "matched_kinds": matched_kinds
                     .into_iter()
                     .map(relation_kind_name)
                     .collect::<Vec<_>>(),
-            }));
+            });
+            if let Some(reason) = verdict_reason {
+                row["verdict_reason"] = serde_json::json!(reason);
+            }
+            results.push(row);
+        }
+    }
+
+    // If the topology watermark changed between rows, every negative row in
+    // this batch becomes inconclusive. Preserve known positives, but never
+    // leave a boolean `false` that spans two authority revisions.
+    if !cross_repo_watermark_complete {
+        for row in &mut results {
+            if row
+                .get("has_references")
+                .and_then(serde_json::Value::as_bool)
+                == Some(false)
+            {
+                row["has_references"] = serde_json::Value::Null;
+                row["verdict_complete"] = serde_json::json!(false);
+                row["verdict_reason"] =
+                    serde_json::json!("cross-repo authority changed during batch");
+            }
+            if row.get("error").is_none() {
+                row["reference_count"] = serde_json::Value::Null;
+                row["reference_count_complete"] = serde_json::json!(false);
+            }
         }
     }
 
     let total_checked = entity_ids_raw.len();
-    let result = serde_json::json!({
+    let classified_count = results
+        .iter()
+        .filter(|row| {
+            row.get("has_references")
+                .is_some_and(serde_json::Value::is_boolean)
+        })
+        .count();
+    let error_count = results
+        .iter()
+        .filter(|row| row.get("error").is_some())
+        .count();
+    let with_references = results
+        .iter()
+        .filter(|row| {
+            row.get("has_references")
+                .and_then(serde_json::Value::as_bool)
+                == Some(true)
+        })
+        .count();
+    let without_references = results
+        .iter()
+        .filter(|row| {
+            row.get("has_references")
+                .and_then(serde_json::Value::as_bool)
+                == Some(false)
+        })
+        .count();
+    let incomplete_verdict_count = total_checked
+        .saturating_sub(classified_count)
+        .saturating_sub(error_count);
+    let verdicts_complete =
+        classified_count == total_checked && error_count == 0 && cross_repo_watermark_complete;
+    let relation_subtype_verdicts_complete =
+        relation_subtype_complete || !saw_unknown_federated_subtype;
+    let mut result = serde_json::json!({
         "total_checked": total_checked,
+        "classified_count": classified_count,
+        "error_count": error_count,
+        "incomplete_verdict_count": incomplete_verdict_count,
         "with_references": with_references,
-        "without_references": total_checked - with_references,
+        "without_references": without_references,
         "relation_kinds": relation_kinds
             .iter()
             .copied()
@@ -1169,6 +1389,28 @@ pub fn handle_bulk_check_references<G: GraphStore>(
         "compact": compact,
         "results": results,
     });
+
+    if authority.is_some() {
+        result["cross_repo"] = if let Some(reason) = cross_repo_unavailable {
+            serde_json::json!({
+                "status": "unavailable",
+                "reason": reason,
+                "checked_entities": cross_repo_checked,
+                "relation_subtype_complete": false,
+            })
+        } else {
+            serde_json::json!({
+                "status": "available",
+                "checked_entities": cross_repo_checked,
+                "authority_complete": cross_repo_authority_complete && verdicts_complete,
+                "authority_revision": cross_repo_revision,
+                "authority_roots": cross_repo_roots,
+                "federated_reference_count": federated_reference_count,
+                "relation_subtype_complete": relation_subtype_verdicts_complete,
+                "verdicts_complete": verdicts_complete,
+            })
+        };
+    }
 
     let json = serde_json::to_string_pretty(&result).map_err(McpError::Json)?;
     Ok(ToolCallResult::text(json))
@@ -2156,6 +2398,7 @@ mod tests {
     use kin_model::graph::EntityStore as _;
     use kin_model::ids::{EntityId, FilePathId, Hash256, LanguageId, RelationId};
     use kin_model::relation::{GraphNodeId, Relation, RelationKind, RelationOrigin};
+    use kin_spine::SpineBackend as _;
 
     fn make_entity(name: &str, file: &str) -> Entity {
         Entity {
@@ -2196,6 +2439,35 @@ mod tests {
             import_source: None,
             evidence: Vec::new(),
         }
+    }
+
+    fn graph_root(graph: &InMemoryGraph) -> String {
+        graph
+            .compute_root_hash()
+            .iter()
+            .map(|byte| format!("{byte:02x}"))
+            .collect()
+    }
+
+    fn spine_entry(repo_id: &str, entity: &Entity) -> kin_spine::EntityEntry {
+        kin_spine::EntityEntry {
+            repo_id: repo_id.to_string(),
+            entity_id: entity.id,
+            name: entity.name.clone(),
+            kind: entity.kind,
+            signature: entity.signature.clone(),
+            fingerprint: entity.fingerprint.clone(),
+            file_path: entity.file_origin.as_ref().map(|path| path.0.clone()),
+            role: Some(entity.role),
+        }
+    }
+
+    fn structurally_ready_envelope() -> crate::Envelope {
+        crate::Envelope::daemon().with_health(&serde_json::json!({
+            "initialized": true,
+            "graph_loaded": true,
+            "graph_generation": 12,
+        }))
     }
 
     fn parsed_response(result: &ToolCallResult) -> serde_json::Value {
@@ -2264,27 +2536,18 @@ mod tests {
                 role: Some(source.role),
             }],
         );
-        let mut rows = Vec::new();
+        let rows = spine_reference_rows("provider", &target.id, &response);
 
-        let appended = append_spine_reference_rows(
-            &mut rows,
-            "provider",
-            &target.id,
-            &[RelationKind::References],
-            &response,
-        );
-
-        assert_eq!(appended, 1);
         assert_eq!(rows.len(), 1);
         assert_eq!(rows[0].name, "run_task");
         assert_eq!(rows[0].kind.as_deref(), Some("Function"));
         assert_eq!(rows[0].file_path.as_deref(), Some("[consumer] src/app.rs"));
         assert_eq!(rows[0].signature.as_deref(), Some("fn run_task()"));
-        assert_eq!(rows[0].relation_kinds, vec![RelationKind::References]);
+        assert!(rows[0].relation_kinds.is_empty());
     }
 
     #[test]
-    fn spine_xrefs_respect_direction_and_preserve_untyped_filtered_dependencies() {
+    fn spine_xrefs_respect_direction_and_keep_subtype_unknown() {
         let target = make_entity("do_work", "src/lib.rs");
         let other = EntityId::new();
         let outgoing_response = kin_spine::SpineXrefResponse::new(
@@ -2297,18 +2560,7 @@ mod tests {
             }],
             Vec::new(),
         );
-        let mut rows = Vec::new();
-
-        assert_eq!(
-            append_spine_reference_rows(
-                &mut rows,
-                "provider",
-                &target.id,
-                &[RelationKind::References],
-                &outgoing_response,
-            ),
-            0
-        );
+        let rows = spine_reference_rows("provider", &target.id, &outgoing_response);
         assert!(rows.is_empty());
 
         let source = make_entity("run_task", "src/app.rs");
@@ -2324,24 +2576,9 @@ mod tests {
         );
         assert!(!incoming_response.authority_complete_for("provider", &target.id));
 
-        for filter in [RelationKind::Calls, RelationKind::Imports] {
-            let mut filtered_rows = Vec::new();
-            assert_eq!(
-                append_spine_reference_rows(
-                    &mut filtered_rows,
-                    "provider",
-                    &target.id,
-                    &[filter],
-                    &incoming_response,
-                ),
-                1,
-                "a generic federated dependency must survive the {filter:?} filter"
-            );
-            assert_eq!(
-                filtered_rows[0].relation_kinds,
-                vec![RelationKind::References]
-            );
-        }
+        let incoming = spine_reference_rows("provider", &target.id, &incoming_response);
+        assert_eq!(incoming.len(), 1);
+        assert!(incoming[0].relation_kinds.is_empty());
     }
 
     #[test]
@@ -2542,8 +2779,11 @@ mod tests {
         let compact = handle_bulk_check_references(&args, &store).unwrap();
         let body = parsed_response(&compact);
         assert_eq!(body["total_checked"], 2);
+        assert_eq!(body["classified_count"], 1);
+        assert_eq!(body["error_count"], 0);
+        assert_eq!(body["incomplete_verdict_count"], 1);
         assert_eq!(body["with_references"], 1);
-        assert_eq!(body["without_references"], 1);
+        assert_eq!(body["without_references"], 0);
         assert_eq!(body["compact"], true);
         let rows = body["results"].as_array().unwrap();
         assert_eq!(rows.len(), 2);
@@ -2552,7 +2792,10 @@ mod tests {
             .find(|r| r["entity_id"] == serde_json::json!(live_id))
             .unwrap();
         assert_eq!(live_row["has_references"], true);
-        assert_eq!(live_row["reference_count"], 2);
+        assert!(live_row["reference_count"].is_null());
+        assert_eq!(live_row["known_reference_count"], 2);
+        assert_eq!(live_row["reference_count_complete"], false);
+        assert_eq!(live_row["verdict_complete"], true);
         assert!(
             live_row.get("name").is_none(),
             "compact mode must omit name"
@@ -2561,8 +2804,18 @@ mod tests {
             .iter()
             .find(|r| r["entity_id"] == serde_json::json!(dead_id))
             .unwrap();
-        assert_eq!(dead_row["has_references"], false);
-        assert_eq!(dead_row["reference_count"], 0);
+        assert!(
+            dead_row["has_references"].is_null(),
+            "a local-only zero is not a total reachability verdict"
+        );
+        assert!(dead_row["reference_count"].is_null());
+        assert_eq!(dead_row["known_reference_count"], 0);
+        assert_eq!(dead_row["reference_count_complete"], false);
+        assert_eq!(dead_row["verdict_complete"], false);
+        assert_eq!(
+            dead_row["verdict_reason"],
+            "cross-repo authority incomplete"
+        );
 
         args.insert("compact".to_string(), serde_json::json!(false));
         let verbose = handle_bulk_check_references(&args, &store).unwrap();
@@ -2604,13 +2857,23 @@ mod tests {
         args.insert("relation_kind".to_string(), serde_json::json!("Calls"));
         let calls_resp = parsed_response(&handle_bulk_check_references(&args, &store).unwrap());
         assert_eq!(calls_resp["with_references"], 0);
-        assert_eq!(calls_resp["results"][0]["reference_count"], 0);
+        assert_eq!(calls_resp["without_references"], 0);
+        assert!(calls_resp["results"][0]["has_references"].is_null());
+        assert!(calls_resp["results"][0]["reference_count"].is_null());
+        assert_eq!(calls_resp["results"][0]["known_reference_count"], 0);
+        assert_eq!(calls_resp["results"][0]["reference_count_complete"], false);
 
         // Asking for Imports — should match.
         args.insert("relation_kind".to_string(), serde_json::json!("Imports"));
         let imports_resp = parsed_response(&handle_bulk_check_references(&args, &store).unwrap());
         assert_eq!(imports_resp["with_references"], 1);
-        assert_eq!(imports_resp["results"][0]["reference_count"], 1);
+        assert_eq!(imports_resp["results"][0]["has_references"], true);
+        assert!(imports_resp["results"][0]["reference_count"].is_null());
+        assert_eq!(imports_resp["results"][0]["known_reference_count"], 1);
+        assert_eq!(
+            imports_resp["results"][0]["reference_count_complete"],
+            false
+        );
     }
 
     #[test]
@@ -2636,6 +2899,21 @@ mod tests {
         assert_eq!(rows.len(), 2);
         assert_eq!(rows[0]["error"], "invalid entity_id (not a UUID)");
         assert_eq!(rows[1]["error"], "entity not found");
+        assert_eq!(resp["classified_count"], 0);
+        assert_eq!(resp["error_count"], 2);
+        assert_eq!(resp["incomplete_verdict_count"], 0);
+        assert_eq!(resp["with_references"], 0);
+        assert_eq!(resp["without_references"], 0);
+        for row in rows {
+            assert!(
+                row["has_references"].is_null(),
+                "an invalid or missing entity is not a false reachability verdict: {row}"
+            );
+            assert!(row["reference_count"].is_null());
+            assert!(row["known_reference_count"].is_null());
+            assert_eq!(row["reference_count_complete"], false);
+            assert_eq!(row["verdict_complete"], false);
+        }
     }
 
     #[tokio::test]
@@ -2689,6 +2967,287 @@ mod tests {
         let body = parsed_response(&handle_find_references(&args, &store).await.unwrap());
         assert_eq!(body["total_upstream"], 0);
         assert!(body["references"].as_array().unwrap().is_empty());
+    }
+
+    #[tokio::test]
+    async fn daemon_find_references_requires_exact_live_graph_root() {
+        let graph = InMemoryGraph::new();
+        let target = make_entity("target", "src/lib.rs");
+        graph.upsert_entity(&target).unwrap();
+        let registered_root = graph_root(&graph);
+
+        let spine = kin_spine::InMemorySpineBackend::new();
+        spine.register_repo(
+            "provider",
+            vec![spine_entry("provider", &target)],
+            &registered_root,
+        );
+        spine.refresh_cross_repo_edges("provider", &[], &[], &["provider".to_string()]);
+
+        let args = HashMap::from([(
+            "entity_id".to_string(),
+            serde_json::json!(target.id.to_string()),
+        )]);
+        let matching = handle_find_references_with_authority(
+            &args,
+            &graph,
+            FindReferencesAuthority {
+                repo_id: "provider",
+                graph_root: &registered_root,
+                spine: Some(&spine),
+            },
+        )
+        .await
+        .unwrap();
+        let matching = crate::finalize_with_envelope(
+            matching,
+            structurally_ready_envelope(),
+            "find_references",
+        );
+        let matching = parsed_response(&matching);
+        assert_eq!(matching["cross_repo"]["authority_complete"], true);
+        assert_eq!(matching["negative"]["safe_to_conclude_absent"], true);
+
+        graph
+            .upsert_entity(&make_entity("session_only", "src/session.rs"))
+            .unwrap();
+        let live_root = graph_root(&graph);
+        assert_ne!(live_root, registered_root);
+        let mismatched = handle_find_references_with_authority(
+            &args,
+            &graph,
+            FindReferencesAuthority {
+                repo_id: "provider",
+                graph_root: &live_root,
+                spine: Some(&spine),
+            },
+        )
+        .await
+        .unwrap();
+        let mismatched = crate::finalize_with_envelope(
+            mismatched,
+            structurally_ready_envelope(),
+            "find_references",
+        );
+        let mismatched = parsed_response(&mismatched);
+        assert_eq!(mismatched["cross_repo"]["status"], "unavailable");
+        assert!(mismatched["cross_repo"]["reason"]
+            .as_str()
+            .is_some_and(|reason| reason.contains("root mismatch")));
+        assert_eq!(mismatched["negative"]["safe_to_conclude_absent"], false);
+        assert!(mismatched["references"].as_array().unwrap().is_empty());
+    }
+
+    #[tokio::test]
+    async fn filtered_find_references_keeps_unknown_federated_subtype_advisory() {
+        let graph = InMemoryGraph::new();
+        let target = make_entity("target", "src/lib.rs");
+        let source = make_entity("caller", "src/app.rs");
+        graph.upsert_entity(&target).unwrap();
+        let provider_root = graph_root(&graph);
+
+        let spine = kin_spine::InMemorySpineBackend::new();
+        spine.register_repo(
+            "provider",
+            vec![spine_entry("provider", &target)],
+            &provider_root,
+        );
+        spine.register_repo(
+            "consumer",
+            vec![spine_entry("consumer", &source)],
+            "consumer-root",
+        );
+        let repos = vec!["consumer".to_string(), "provider".to_string()];
+        for repo in &repos {
+            spine.refresh_cross_repo_edges(repo, &[], &[], &repos);
+        }
+        spine.add_cross_repo_edge(kin_spine::CrossRepoEdge {
+            src_repo: "consumer".to_string(),
+            src_entity: source.id,
+            dst_repo: "provider".to_string(),
+            dst_entity: target.id,
+            confidence: 0.9,
+        });
+
+        let args = HashMap::from([
+            (
+                "entity_id".to_string(),
+                serde_json::json!(target.id.to_string()),
+            ),
+            ("relation_kinds".to_string(), serde_json::json!(["calls"])),
+        ]);
+        let filtered = handle_find_references_with_authority(
+            &args,
+            &graph,
+            FindReferencesAuthority {
+                repo_id: "provider",
+                graph_root: &provider_root,
+                spine: Some(&spine),
+            },
+        )
+        .await
+        .unwrap();
+        let filtered = crate::finalize_with_envelope(
+            filtered,
+            structurally_ready_envelope(),
+            "find_references",
+        );
+        let filtered = parsed_response(&filtered);
+        assert_eq!(filtered["total_upstream"], 0);
+        assert!(filtered["references"].as_array().unwrap().is_empty());
+        assert_eq!(filtered["cross_repo"]["federated_reference_count"], 1);
+        assert_eq!(filtered["cross_repo"]["relation_subtype_complete"], false);
+        assert_eq!(filtered["negative"]["safe_to_conclude_absent"], false);
+
+        let default_args = HashMap::from([(
+            "entity_id".to_string(),
+            serde_json::json!(target.id.to_string()),
+        )]);
+        let unfiltered = parsed_response(
+            &handle_find_references_with_authority(
+                &default_args,
+                &graph,
+                FindReferencesAuthority {
+                    repo_id: "provider",
+                    graph_root: &provider_root,
+                    spine: Some(&spine),
+                },
+            )
+            .await
+            .unwrap(),
+        );
+        assert_eq!(unfiltered["total_upstream"], 1);
+        assert_eq!(unfiltered["references"][0]["name"], "caller");
+    }
+
+    #[tokio::test]
+    async fn filtered_find_references_certifies_complete_federated_zero() {
+        let graph = InMemoryGraph::new();
+        let target = make_entity("target", "src/lib.rs");
+        graph.upsert_entity(&target).unwrap();
+        let provider_root = graph_root(&graph);
+
+        let spine = kin_spine::InMemorySpineBackend::new();
+        spine.register_repo(
+            "provider",
+            vec![spine_entry("provider", &target)],
+            &provider_root,
+        );
+        spine.refresh_cross_repo_edges("provider", &[], &[], &["provider".to_string()]);
+
+        let args = HashMap::from([
+            (
+                "entity_id".to_string(),
+                serde_json::json!(target.id.to_string()),
+            ),
+            ("relation_kinds".to_string(), serde_json::json!(["calls"])),
+        ]);
+        let result = handle_find_references_with_authority(
+            &args,
+            &graph,
+            FindReferencesAuthority {
+                repo_id: "provider",
+                graph_root: &provider_root,
+                spine: Some(&spine),
+            },
+        )
+        .await
+        .unwrap();
+        let result =
+            crate::finalize_with_envelope(result, structurally_ready_envelope(), "find_references");
+        let result = parsed_response(&result);
+
+        assert!(result["references"].as_array().unwrap().is_empty());
+        assert_eq!(result["cross_repo"]["authority_complete"], true);
+        assert_eq!(
+            result["cross_repo"]["relation_subtype_complete"], true,
+            "a complete empty incoming edge set excludes every unknown subtype"
+        );
+        assert_eq!(result["negative"]["safe_to_conclude_absent"], true);
+    }
+
+    #[test]
+    fn daemon_bulk_reachability_includes_complete_federated_edges() {
+        let graph = InMemoryGraph::new();
+        let target = make_entity("target", "src/lib.rs");
+        let source = make_entity("caller", "src/app.rs");
+        graph.upsert_entity(&target).unwrap();
+        let provider_root = graph_root(&graph);
+
+        let spine = kin_spine::InMemorySpineBackend::new();
+        spine.register_repo(
+            "provider",
+            vec![spine_entry("provider", &target)],
+            &provider_root,
+        );
+        spine.register_repo(
+            "consumer",
+            vec![spine_entry("consumer", &source)],
+            "consumer-root",
+        );
+        let repos = vec!["consumer".to_string(), "provider".to_string()];
+        for repo in &repos {
+            spine.refresh_cross_repo_edges(repo, &[], &[], &repos);
+        }
+        spine.add_cross_repo_edge(kin_spine::CrossRepoEdge {
+            src_repo: "consumer".to_string(),
+            src_entity: source.id,
+            dst_repo: "provider".to_string(),
+            dst_entity: target.id,
+            confidence: 0.9,
+        });
+
+        let mut args = HashMap::from([(
+            "entity_ids".to_string(),
+            serde_json::json!([target.id.to_string()]),
+        )]);
+        let authority = FindReferencesAuthority {
+            repo_id: "provider",
+            graph_root: &provider_root,
+            spine: Some(&spine),
+        };
+        let any = handle_bulk_check_references_with_authority(&args, &graph, authority).unwrap();
+        let any = crate::finalize_with_envelope(
+            any,
+            structurally_ready_envelope(),
+            "bulk_check_references",
+        );
+        let any = parsed_response(&any);
+        assert_eq!(any["results"][0]["has_references"], true);
+        assert_eq!(any["results"][0]["reference_count"], 1);
+        assert_eq!(any["results"][0]["known_reference_count"], 1);
+        assert_eq!(any["results"][0]["reference_count_complete"], true);
+        assert_eq!(any["results"][0]["federated_reference_count"], 1);
+        assert_eq!(any["cross_repo"]["authority_complete"], true);
+        assert_eq!(any["negative"]["safe_to_conclude_absent"], true);
+
+        args.insert("relation_kind".to_string(), serde_json::json!("Calls"));
+        let calls = handle_bulk_check_references_with_authority(&args, &graph, authority).unwrap();
+        let calls = crate::finalize_with_envelope(
+            calls,
+            structurally_ready_envelope(),
+            "bulk_check_references",
+        );
+        let calls = parsed_response(&calls);
+        assert!(
+            calls["results"][0]["has_references"].is_null(),
+            "an untyped federated edge cannot be classified as Calls=false"
+        );
+        assert!(calls["results"][0]["reference_count"].is_null());
+        assert_eq!(calls["results"][0]["known_reference_count"], 0);
+        assert_eq!(calls["results"][0]["reference_count_complete"], false);
+        assert_eq!(calls["results"][0]["federated_reference_count"], 1);
+        assert_eq!(calls["results"][0]["verdict_complete"], false);
+        assert_eq!(
+            calls["results"][0]["verdict_reason"],
+            "federated relation subtype unavailable"
+        );
+        assert_eq!(calls["classified_count"], 0);
+        assert_eq!(calls["incomplete_verdict_count"], 1);
+        assert_eq!(calls["without_references"], 0);
+        assert_eq!(calls["cross_repo"]["relation_subtype_complete"], false);
+        assert_eq!(calls["cross_repo"]["verdicts_complete"], false);
+        assert_eq!(calls["negative"]["safe_to_conclude_absent"], false);
     }
 
     #[test]

--- a/crates/kin-mcp/src/handlers/entities.rs
+++ b/crates/kin-mcp/src/handlers/entities.rs
@@ -757,6 +757,21 @@ fn cross_repo_repo_id() -> std::result::Result<String, String> {
     }
 }
 
+/// Daemon-owned cross-repository authority for `find_references`.
+///
+/// The daemon constructs this from its resolved repository identity and its
+/// in-process spine. Neither value comes from MCP request arguments or ambient
+/// process configuration, so a caller cannot redirect the authority query.
+pub struct FindReferencesAuthority<'a> {
+    pub repo_id: &'a str,
+    pub spine: Option<&'a dyn kin_spine::SpineBackend>,
+}
+
+enum FindReferencesAuthoritySource<'a> {
+    Environment,
+    Daemon(FindReferencesAuthority<'a>),
+}
+
 fn append_spine_reference_rows(
     rows: &mut Vec<ReferenceRow>,
     repo_id: &str,
@@ -809,6 +824,37 @@ pub async fn handle_find_references<G: GraphStore>(
     args: &HashMap<String, serde_json::Value>,
     store: &G,
 ) -> Result<ToolCallResult> {
+    handle_find_references_with_authority_source(
+        args,
+        store,
+        FindReferencesAuthoritySource::Environment,
+    )
+    .await
+}
+
+/// Serve `find_references` from daemon-owned repository and spine authority.
+///
+/// This avoids an HTTP loop back into the same daemon and, more importantly,
+/// prevents `KIN_REPO_ID`, `KIN_DAEMON_URL`, or request fields from changing
+/// which repository graph the answer is bound to.
+pub async fn handle_find_references_with_authority<G: GraphStore>(
+    args: &HashMap<String, serde_json::Value>,
+    store: &G,
+    authority: FindReferencesAuthority<'_>,
+) -> Result<ToolCallResult> {
+    handle_find_references_with_authority_source(
+        args,
+        store,
+        FindReferencesAuthoritySource::Daemon(authority),
+    )
+    .await
+}
+
+async fn handle_find_references_with_authority_source<G: GraphStore>(
+    args: &HashMap<String, serde_json::Value>,
+    store: &G,
+    authority_source: FindReferencesAuthoritySource<'_>,
+) -> Result<ToolCallResult> {
     let relation_kinds = if let Some(raw_kinds) = get_optional_string_array(args, "relation_kinds")
     {
         if raw_kinds.is_empty() {
@@ -847,7 +893,31 @@ pub async fn handle_find_references<G: GraphStore>(
 
     let mut rows = collect_graph_reference_rows(store, &target.id, &relation_kinds)?;
     // ── Federated Xrefs via Spine ─────────────────────────────────────
-    let cross_repo = match cross_repo_repo_id() {
+    let cross_repo_query = match authority_source {
+        FindReferencesAuthoritySource::Environment => match cross_repo_repo_id() {
+            Ok(repo_id) => {
+                let query = fetch_spine_xref(&repo_id, &target.id).await;
+                Ok((repo_id, query))
+            }
+            Err(reason) => Err(reason),
+        },
+        FindReferencesAuthoritySource::Daemon(authority) => {
+            normalize_cross_repo_repo_id(Some(authority.repo_id)).map(|repo_id| {
+                let query = match authority.spine {
+                    Some(spine) => {
+                        kin_spine::SpineQuery::Found(kin_spine::SpineXrefResponse::from_snapshot(
+                            spine.cross_repo_edges_snapshot(),
+                            &repo_id,
+                            &target.id,
+                        ))
+                    }
+                    None => kin_spine::SpineQuery::NotConfigured,
+                };
+                (repo_id, query)
+            })
+        }
+    };
+    let cross_repo = match cross_repo_query {
         Err(reason) => {
             tracing::warn!(reason = %reason, "cross-repo repository binding unavailable for references enrichment");
             serde_json::json!({
@@ -855,7 +925,7 @@ pub async fn handle_find_references<G: GraphStore>(
                 "reason": reason,
             })
         }
-        Ok(repo_id) => match fetch_spine_xref(&repo_id, &target.id).await {
+        Ok((repo_id, query)) => match query {
             kin_spine::SpineQuery::Found(body) => {
                 let reference_count = append_spine_reference_rows(
                     &mut rows,

--- a/crates/kin-mcp/src/handlers/entities.rs
+++ b/crates/kin-mcp/src/handlers/entities.rs
@@ -736,6 +736,55 @@ flag says whether \"nothing depends on this\" is authoritative (daemon-owned gra
 complete coverage, no degraded signals) or merely \"not indexed yet\" — consult it \
 before treating the entity as safe to delete.";
 
+fn append_spine_reference_rows(
+    rows: &mut Vec<ReferenceRow>,
+    repo_id: &str,
+    target_id: &kin_model::EntityId,
+    relation_kinds: &[RelationKind],
+    response: &kin_spine::SpineXrefResponse,
+) -> usize {
+    // CrossRepoEdge does not encode a source relation kind. Treat it as the
+    // generic cross-repo reference it is, and do not leak it into a calls-only
+    // or imports-only filtered response.
+    if !relation_kinds.contains(&RelationKind::References) {
+        return 0;
+    }
+
+    let before = rows.len();
+    for edge in &response.edges {
+        if edge.dst_repo != repo_id || edge.dst_entity != *target_id || edge.src_repo == repo_id {
+            continue;
+        }
+
+        let source = response
+            .entities
+            .iter()
+            .find(|entity| entity.repo_id == edge.src_repo && entity.entity_id == edge.src_entity);
+        let name = source
+            .map(|entity| entity.name.clone())
+            .unwrap_or_else(|| edge.src_entity.to_string());
+        let file_path = source
+            .and_then(|entity| entity.file_path.as_deref())
+            .map(|path| format!("[{}] {path}", edge.src_repo))
+            .unwrap_or_else(|| format!("[{}] {}", edge.src_repo, edge.src_entity));
+
+        rows.push(ReferenceRow {
+            // The source ID belongs to another repo's graph authority. Returning
+            // it as a local drill-through ID would resolve against the wrong
+            // graph, so the repo-qualified path remains the navigation anchor.
+            entity_id: None,
+            name,
+            kind: source.map(|entity| format!("{:?}", entity.kind)),
+            file_path: Some(file_path),
+            start_line: None,
+            signature: source.map(|entity| entity.signature.clone()),
+            snippet: None,
+            relation_kinds: vec![RelationKind::References],
+        });
+    }
+    rows.len() - before
+}
+
 pub async fn handle_find_references<G: GraphStore>(
     args: &HashMap<String, serde_json::Value>,
     store: &G,
@@ -777,48 +826,43 @@ pub async fn handle_find_references<G: GraphStore>(
     };
 
     let mut rows = collect_graph_reference_rows(store, &target.id, &relation_kinds)?;
-    rows.sort_by(|left, right| {
-        left.file_path
-            .cmp(&right.file_path)
-            .then_with(|| left.name.cmp(&right.name))
-    });
-
     // ── Federated Xrefs via Spine ─────────────────────────────────────
     let repo_id = std::env::var("KIN_REPO_ID").unwrap_or_else(|_| "unknown".into());
-    match fetch_spine_xref(&repo_id, &target.id).await {
+    let cross_repo = match fetch_spine_xref(&repo_id, &target.id).await {
         kin_spine::SpineQuery::Found(body) => {
-            if let Some(edges) = body.get("edges").and_then(|v| v.as_array()) {
-                for edge in edges {
-                    if edge["to_repo_id"] == repo_id && edge["repo_id"] != repo_id {
-                        // This is an external caller pointing at us.
-                        rows.push(ReferenceRow {
-                            // Federated xref: the caller lives in another repo, so
-                            // there is no local entity id or graph-owned body here.
-                            entity_id: None,
-                            name: edge["from_name"].as_str().unwrap_or("unknown").to_string(),
-                            kind: edge["kind"].as_str().map(|s| s.to_string()),
-                            file_path: Some(format!(
-                                "[{}] {}",
-                                edge["repo_id"].as_str().unwrap_or("?"),
-                                edge["from_name"].as_str().unwrap_or("?")
-                            )),
-                            start_line: None,
-                            signature: None,
-                            snippet: None,
-                            relation_kinds: vec![RelationKind::References], // Spine edges are generic xrefs
-                        });
-                    }
-                }
-            }
+            let reference_count = append_spine_reference_rows(
+                &mut rows,
+                &repo_id,
+                &target.id,
+                &relation_kinds,
+                &body,
+            );
+            serde_json::json!({
+                "status": "available",
+                "payload_version": body.version(),
+                "reference_count": reference_count,
+            })
         }
         // Spine configured but unreachable: surface as a warning rather than
         // silently dropping cross-repo references (which would read as "none").
         kin_spine::SpineQuery::Unavailable(reason) => {
             tracing::warn!(reason = %reason, "cross-repo spine unavailable for references enrichment");
+            serde_json::json!({
+                "status": "unavailable",
+                "reason": reason,
+            })
         }
         // Local-only (no spine configured): quiet — cross-repo refs don't apply.
-        kin_spine::SpineQuery::NotConfigured => {}
-    }
+        kin_spine::SpineQuery::NotConfigured => serde_json::json!({
+            "status": "not_configured",
+        }),
+    };
+
+    rows.sort_by(|left, right| {
+        left.file_path
+            .cmp(&right.file_path)
+            .then_with(|| left.name.cmp(&right.name))
+    });
 
     let references = rows
         .into_iter()
@@ -857,6 +901,7 @@ pub async fn handle_find_references<G: GraphStore>(
             .collect::<Vec<_>>(),
         "total_upstream": references.len(),
         "references": references,
+        "cross_repo": cross_repo,
     });
 
     let json = serde_json::to_string_pretty(&result).map_err(McpError::Json)?;
@@ -2079,6 +2124,87 @@ mod tests {
             max_lines_per_body: crate::handlers::common::DEFAULT_SOURCE_MAX_LINES,
             max_bytes_per_body: crate::handlers::common::DEFAULT_SOURCE_MAX_BYTES,
         }
+    }
+
+    #[test]
+    fn spine_xrefs_append_typed_external_callers() {
+        let source = make_entity("run_task", "src/app.rs");
+        let target = make_entity("do_work", "src/lib.rs");
+        let response = kin_spine::SpineXrefResponse::new(
+            vec![kin_spine::CrossRepoEdge {
+                src_repo: "consumer".to_string(),
+                src_entity: source.id,
+                dst_repo: "provider".to_string(),
+                dst_entity: target.id,
+                confidence: 0.9,
+            }],
+            vec![kin_spine::EntityEntry {
+                repo_id: "consumer".to_string(),
+                entity_id: source.id,
+                name: source.name.clone(),
+                kind: source.kind,
+                signature: source.signature.clone(),
+                fingerprint: source.fingerprint.clone(),
+                file_path: source.file_origin.as_ref().map(|path| path.0.clone()),
+                role: Some(source.role),
+            }],
+        );
+        let mut rows = Vec::new();
+
+        let appended = append_spine_reference_rows(
+            &mut rows,
+            "provider",
+            &target.id,
+            &[RelationKind::References],
+            &response,
+        );
+
+        assert_eq!(appended, 1);
+        assert_eq!(rows.len(), 1);
+        assert_eq!(rows[0].name, "run_task");
+        assert_eq!(rows[0].kind.as_deref(), Some("Function"));
+        assert_eq!(rows[0].file_path.as_deref(), Some("[consumer] src/app.rs"));
+        assert_eq!(rows[0].signature.as_deref(), Some("fn run_task()"));
+        assert_eq!(rows[0].relation_kinds, vec![RelationKind::References]);
+    }
+
+    #[test]
+    fn spine_xrefs_respect_direction_and_relation_filter() {
+        let target = make_entity("do_work", "src/lib.rs");
+        let other = EntityId::new();
+        let response = kin_spine::SpineXrefResponse::new(
+            vec![kin_spine::CrossRepoEdge {
+                src_repo: "provider".to_string(),
+                src_entity: target.id,
+                dst_repo: "consumer".to_string(),
+                dst_entity: other,
+                confidence: 0.9,
+            }],
+            Vec::new(),
+        );
+        let mut rows = Vec::new();
+
+        assert_eq!(
+            append_spine_reference_rows(
+                &mut rows,
+                "provider",
+                &target.id,
+                &[RelationKind::References],
+                &response,
+            ),
+            0
+        );
+        assert_eq!(
+            append_spine_reference_rows(
+                &mut rows,
+                "consumer",
+                &other,
+                &[RelationKind::Calls],
+                &response,
+            ),
+            0
+        );
+        assert!(rows.is_empty());
     }
 
     #[test]

--- a/crates/kin-mcp/src/handlers/entities.rs
+++ b/crates/kin-mcp/src/handlers/entities.rs
@@ -736,6 +736,27 @@ flag says whether \"nothing depends on this\" is authoritative (daemon-owned gra
 complete coverage, no degraded signals) or merely \"not indexed yet\" — consult it \
 before treating the entity as safe to delete.";
 
+fn normalize_cross_repo_repo_id(raw: Option<&str>) -> std::result::Result<String, String> {
+    raw.map(str::trim)
+        .filter(|value| !value.is_empty())
+        .map(str::to_owned)
+        .ok_or_else(|| {
+            "KIN_REPO_ID is missing or blank; cross-repo authority cannot bind this graph to a repository"
+                .to_string()
+        })
+}
+
+fn cross_repo_repo_id() -> std::result::Result<String, String> {
+    match std::env::var("KIN_REPO_ID") {
+        Ok(value) => normalize_cross_repo_repo_id(Some(&value)),
+        Err(std::env::VarError::NotPresent) => normalize_cross_repo_repo_id(None),
+        Err(std::env::VarError::NotUnicode(_)) => Err(
+            "KIN_REPO_ID is not valid Unicode; cross-repo authority cannot bind this graph to a repository"
+                .to_string(),
+        ),
+    }
+}
+
 fn append_spine_reference_rows(
     rows: &mut Vec<ReferenceRow>,
     repo_id: &str,
@@ -827,35 +848,48 @@ pub async fn handle_find_references<G: GraphStore>(
 
     let mut rows = collect_graph_reference_rows(store, &target.id, &relation_kinds)?;
     // ── Federated Xrefs via Spine ─────────────────────────────────────
-    let repo_id = std::env::var("KIN_REPO_ID").unwrap_or_else(|_| "unknown".into());
-    let cross_repo = match fetch_spine_xref(&repo_id, &target.id).await {
-        kin_spine::SpineQuery::Found(body) => {
-            let reference_count = append_spine_reference_rows(
-                &mut rows,
-                &repo_id,
-                &target.id,
-                &relation_kinds,
-                &body,
-            );
-            serde_json::json!({
-                "status": "available",
-                "payload_version": body.version(),
-                "reference_count": reference_count,
-            })
-        }
-        // Spine configured but unreachable: surface as a warning rather than
-        // silently dropping cross-repo references (which would read as "none").
-        kin_spine::SpineQuery::Unavailable(reason) => {
-            tracing::warn!(reason = %reason, "cross-repo spine unavailable for references enrichment");
+    let cross_repo = match cross_repo_repo_id() {
+        Err(reason) => {
+            tracing::warn!(reason = %reason, "cross-repo repository binding unavailable for references enrichment");
             serde_json::json!({
                 "status": "unavailable",
                 "reason": reason,
             })
         }
-        // Local-only (no spine configured): quiet — cross-repo refs don't apply.
-        kin_spine::SpineQuery::NotConfigured => serde_json::json!({
-            "status": "not_configured",
-        }),
+        Ok(repo_id) => match fetch_spine_xref(&repo_id, &target.id).await {
+            kin_spine::SpineQuery::Found(body) => {
+                let reference_count = append_spine_reference_rows(
+                    &mut rows,
+                    &repo_id,
+                    &target.id,
+                    &relation_kinds,
+                    &body,
+                );
+                let authority_complete =
+                    body.authority_complete && body.authority_roots.contains_key(&repo_id);
+                serde_json::json!({
+                    "status": "available",
+                    "payload_version": body.version(),
+                    "reference_count": reference_count,
+                    "authority_complete": authority_complete,
+                    "authority_revision": body.authority_revision,
+                    "authority_roots": body.authority_roots,
+                })
+            }
+            // Spine configured but unreachable: surface as a warning rather than
+            // silently dropping cross-repo references (which would read as "none").
+            kin_spine::SpineQuery::Unavailable(reason) => {
+                tracing::warn!(reason = %reason, "cross-repo spine unavailable for references enrichment");
+                serde_json::json!({
+                    "status": "unavailable",
+                    "reason": reason,
+                })
+            }
+            // Local-only (no spine configured): quiet — cross-repo refs don't apply.
+            kin_spine::SpineQuery::NotConfigured => serde_json::json!({
+                "status": "not_configured",
+            }),
+        },
     };
 
     rows.sort_by(|left, right| {
@@ -2124,6 +2158,18 @@ mod tests {
             max_lines_per_body: crate::handlers::common::DEFAULT_SOURCE_MAX_LINES,
             max_bytes_per_body: crate::handlers::common::DEFAULT_SOURCE_MAX_BYTES,
         }
+    }
+
+    #[test]
+    fn cross_repo_binding_rejects_missing_or_blank_repo_id() {
+        for raw in [None, Some(""), Some("   "), Some("\t\n")] {
+            let reason = normalize_cross_repo_repo_id(raw).unwrap_err();
+            assert!(reason.contains("KIN_REPO_ID is missing or blank"));
+        }
+        assert_eq!(
+            normalize_cross_repo_repo_id(Some("  provider  ")).unwrap(),
+            "provider"
+        );
     }
 
     #[test]

--- a/crates/kin-mcp/src/negative.rs
+++ b/crates/kin-mcp/src/negative.rs
@@ -222,6 +222,19 @@ fn focal_entity_is_method(payload: &Value) -> bool {
         .is_some_and(|kind| kind.eq_ignore_ascii_case("method"))
 }
 
+fn cross_repo_references_unavailable(payload: &Value) -> Option<&str> {
+    let cross_repo = payload.get("cross_repo")?;
+    if cross_repo.get("status").and_then(Value::as_str) != Some("unavailable") {
+        return None;
+    }
+    Some(
+        cross_repo
+            .get("reason")
+            .and_then(Value::as_str)
+            .unwrap_or("the cross-repo spine could not answer"),
+    )
+}
+
 /// Build a confidence-qualified negative for `tool`'s `payload`, enriched from
 /// `envelope`, or `None` when the tool is not negative-capable or it returned a
 /// non-empty result (and is not an `always`-qualify tool).
@@ -235,7 +248,8 @@ pub fn negative_for(tool: &str, payload: &Value, envelope: &Envelope) -> Option<
         return None;
     }
 
-    let (mut trustworthy, mut trust_reason) = envelope.negative_trust(spec.class);
+    let (mut trustworthy, trust_reason) = envelope.negative_trust(spec.class);
+    let mut trust_reason = trust_reason.to_string();
 
     // Receiver-method calls (`x.method()`) are resolved by bare name in
     // the linker while method entities are keyed by their qualified name, so a
@@ -248,7 +262,19 @@ pub fn negative_for(tool: &str, payload: &Value, envelope: &Envelope) -> Option<
         trustworthy = false;
         trust_reason = "method_call_resolution_incomplete: receiver-method calls are \
              linked by bare name and may be unresolved, so an empty result is not an \
-             authoritative absence for a method";
+             authoritative absence for a method"
+            .to_string();
+    }
+
+    // A healthy local graph is not enough to certify "no references" when the
+    // configured cross-repo authority failed or returned an invalid payload.
+    // Keep the local rows, but make the negative verdict explicitly
+    // inconclusive so agents cannot read the gap as safe-to-delete proof.
+    if tool == "find_references" {
+        if let Some(reason) = cross_repo_references_unavailable(payload) {
+            trustworthy = false;
+            trust_reason = format!("cross_repo_unavailable: {reason}");
+        }
     }
 
     let interpretation = if spec.always {
@@ -509,6 +535,30 @@ mod tests {
             .unwrap()
             .contains("degraded"));
         assert_eq!(negative["degraded_signals"], json!(["embed_worker_failed"]));
+    }
+
+    #[test]
+    fn find_references_cross_repo_gap_is_inconclusive_despite_loaded_graph() {
+        let payload = json!({
+            "focal_entity": { "kind": "function", "name": "do_work" },
+            "references": [],
+            "cross_repo": {
+                "status": "unavailable",
+                "reason": "malformed spine xref response: missing field `src_repo`",
+            },
+        });
+        let negative = negative_for("find_references", &payload, &structural_ready_envelope())
+            .expect("empty references yields a negative");
+        assert_eq!(negative["safe_to_conclude_absent"], json!(false));
+        assert_eq!(negative["trust"], json!("inconclusive"));
+        assert!(negative["trust_reason"]
+            .as_str()
+            .unwrap()
+            .contains("cross_repo_unavailable"));
+        assert!(negative["advice"]
+            .as_str()
+            .unwrap()
+            .contains("NOT authoritative"));
     }
 
     #[test]

--- a/crates/kin-mcp/src/negative.rs
+++ b/crates/kin-mcp/src/negative.rs
@@ -265,11 +265,79 @@ fn cross_repo_references_gap(payload: &Value) -> Option<String> {
             let anchor_is_bound = anchor_repo
                 .is_some_and(|repo_id| roots.is_some_and(|roots| roots.contains_key(repo_id)))
                 && anchor_entity == focal_entity;
-            if authority_complete && revision.is_some() && anchor_is_bound {
+            let relation_subtype_complete = cross_repo
+                .get("relation_subtype_complete")
+                .and_then(Value::as_bool)
+                != Some(false);
+            if authority_complete
+                && revision.is_some()
+                && anchor_is_bound
+                && relation_subtype_complete
+            {
                 None
             } else {
                 Some(format!(
-                    "cross_repo_authority_incomplete: spine topology is incomplete at revision {}",
+                    "cross_repo_authority_incomplete: spine topology or requested relation subtype is incomplete at revision {}",
+                    revision.unwrap_or("unwatermarked")
+                ))
+            }
+        }
+        Some("not_configured") => {
+            Some("cross_repo_not_configured: cross-repo authority did not answer".to_string())
+        }
+        Some(status) => Some(format!(
+            "cross_repo_authority_unknown: unrecognized cross-repo authority status '{status}'"
+        )),
+        None => {
+            Some("cross_repo_authority_missing: cross-repo authority status is missing".to_string())
+        }
+    }
+}
+
+fn cross_repo_bulk_gap(payload: &Value) -> Option<String> {
+    let Some(cross_repo) = payload.get("cross_repo") else {
+        return Some(
+            "cross_repo_authority_missing: bulk reachability did not report cross-repo authority"
+                .to_string(),
+        );
+    };
+    match cross_repo.get("status").and_then(Value::as_str) {
+        Some("unavailable") => Some(format!(
+            "cross_repo_unavailable: {}",
+            cross_repo
+                .get("reason")
+                .and_then(Value::as_str)
+                .unwrap_or("the cross-repo spine could not answer")
+        )),
+        Some("available") => {
+            let authority_complete = cross_repo
+                .get("authority_complete")
+                .and_then(Value::as_bool)
+                == Some(true);
+            let revision = cross_repo
+                .get("authority_revision")
+                .and_then(Value::as_str)
+                .filter(|revision| !revision.is_empty());
+            let roots_complete = cross_repo
+                .get("authority_roots")
+                .and_then(Value::as_object)
+                .is_some_and(|roots| !roots.is_empty());
+            let subtype_complete = cross_repo
+                .get("relation_subtype_complete")
+                .and_then(Value::as_bool)
+                == Some(true);
+            let verdicts_complete =
+                cross_repo.get("verdicts_complete").and_then(Value::as_bool) == Some(true);
+            if authority_complete
+                && revision.is_some()
+                && roots_complete
+                && subtype_complete
+                && verdicts_complete
+            {
+                None
+            } else {
+                Some(format!(
+                    "cross_repo_authority_incomplete: bulk topology or requested relation subtype is incomplete at revision {}",
                     revision.unwrap_or("unwatermarked")
                 ))
             }
@@ -323,6 +391,13 @@ pub fn negative_for(tool: &str, payload: &Value, envelope: &Envelope) -> Option<
     // inconclusive so agents cannot read the gap as safe-to-delete proof.
     if tool == "find_references" {
         if let Some(reason) = cross_repo_references_gap(payload) {
+            trustworthy = false;
+            trust_reason = reason;
+        }
+    }
+
+    if tool == "bulk_check_references" {
+        if let Some(reason) = cross_repo_bulk_gap(payload) {
             trustworthy = false;
             trust_reason = reason;
         }

--- a/crates/kin-mcp/src/negative.rs
+++ b/crates/kin-mcp/src/negative.rs
@@ -222,17 +222,40 @@ fn focal_entity_is_method(payload: &Value) -> bool {
         .is_some_and(|kind| kind.eq_ignore_ascii_case("method"))
 }
 
-fn cross_repo_references_unavailable(payload: &Value) -> Option<&str> {
+fn cross_repo_references_gap(payload: &Value) -> Option<String> {
     let cross_repo = payload.get("cross_repo")?;
-    if cross_repo.get("status").and_then(Value::as_str) != Some("unavailable") {
-        return None;
+    match cross_repo.get("status").and_then(Value::as_str) {
+        Some("unavailable") => {
+            let reason = cross_repo
+                .get("reason")
+                .and_then(Value::as_str)
+                .unwrap_or("the cross-repo spine could not answer");
+            Some(format!("cross_repo_unavailable: {reason}"))
+        }
+        Some("available") => {
+            let authority_complete = cross_repo
+                .get("authority_complete")
+                .and_then(Value::as_bool)
+                == Some(true);
+            let revision = cross_repo
+                .get("authority_revision")
+                .and_then(Value::as_str)
+                .filter(|revision| !revision.is_empty());
+            let roots_are_present = cross_repo
+                .get("authority_roots")
+                .and_then(Value::as_object)
+                .is_some_and(|roots| !roots.is_empty());
+            if authority_complete && revision.is_some() && roots_are_present {
+                None
+            } else {
+                Some(format!(
+                    "cross_repo_authority_incomplete: spine topology is incomplete at revision {}",
+                    revision.unwrap_or("unwatermarked")
+                ))
+            }
+        }
+        _ => None,
     }
-    Some(
-        cross_repo
-            .get("reason")
-            .and_then(Value::as_str)
-            .unwrap_or("the cross-repo spine could not answer"),
-    )
 }
 
 /// Build a confidence-qualified negative for `tool`'s `payload`, enriched from
@@ -271,9 +294,9 @@ pub fn negative_for(tool: &str, payload: &Value, envelope: &Envelope) -> Option<
     // Keep the local rows, but make the negative verdict explicitly
     // inconclusive so agents cannot read the gap as safe-to-delete proof.
     if tool == "find_references" {
-        if let Some(reason) = cross_repo_references_unavailable(payload) {
+        if let Some(reason) = cross_repo_references_gap(payload) {
             trustworthy = false;
-            trust_reason = format!("cross_repo_unavailable: {reason}");
+            trust_reason = reason;
         }
     }
 
@@ -559,6 +582,73 @@ mod tests {
             .as_str()
             .unwrap()
             .contains("NOT authoritative"));
+    }
+
+    #[test]
+    fn find_references_incomplete_cross_repo_authority_is_inconclusive() {
+        let payload = json!({
+            "focal_entity": { "kind": "function", "name": "do_work" },
+            "references": [],
+            "cross_repo": {
+                "status": "available",
+                "authority_complete": false,
+                "authority_revision": "sha256:dirty",
+                "authority_roots": { "provider": "provider-root" },
+            },
+        });
+        let negative = negative_for("find_references", &payload, &structural_ready_envelope())
+            .expect("empty references yields a negative");
+        assert_eq!(negative["safe_to_conclude_absent"], json!(false));
+        assert_eq!(negative["trust"], json!("inconclusive"));
+        assert!(negative["trust_reason"]
+            .as_str()
+            .unwrap()
+            .contains("cross_repo_authority_incomplete"));
+        assert!(negative["trust_reason"]
+            .as_str()
+            .unwrap()
+            .contains("sha256:dirty"));
+    }
+
+    #[test]
+    fn find_references_legacy_unwatermarked_cross_repo_is_inconclusive() {
+        let payload = json!({
+            "focal_entity": { "kind": "function", "name": "do_work" },
+            "references": [],
+            "cross_repo": {
+                "status": "available",
+                "payload_version": 1,
+                "reference_count": 0,
+            },
+        });
+        let negative = negative_for("find_references", &payload, &structural_ready_envelope())
+            .expect("empty references yields a negative");
+        assert_eq!(negative["safe_to_conclude_absent"], json!(false));
+        assert!(negative["trust_reason"]
+            .as_str()
+            .unwrap()
+            .contains("unwatermarked"));
+    }
+
+    #[test]
+    fn find_references_complete_cross_repo_authority_remains_authoritative() {
+        let payload = json!({
+            "focal_entity": { "kind": "function", "name": "do_work" },
+            "references": [],
+            "cross_repo": {
+                "status": "available",
+                "authority_complete": true,
+                "authority_revision": "sha256:complete",
+                "authority_roots": {
+                    "consumer": "consumer-root",
+                    "provider": "provider-root",
+                },
+            },
+        });
+        let negative = negative_for("find_references", &payload, &structural_ready_envelope())
+            .expect("empty references yields a negative");
+        assert_eq!(negative["safe_to_conclude_absent"], json!(true));
+        assert_eq!(negative["trust"], json!("authoritative"));
     }
 
     #[test]

--- a/crates/kin-mcp/src/negative.rs
+++ b/crates/kin-mcp/src/negative.rs
@@ -223,7 +223,12 @@ fn focal_entity_is_method(payload: &Value) -> bool {
 }
 
 fn cross_repo_references_gap(payload: &Value) -> Option<String> {
-    let cross_repo = payload.get("cross_repo")?;
+    let Some(cross_repo) = payload.get("cross_repo") else {
+        return Some(
+            "cross_repo_authority_missing: find_references did not report cross-repo authority"
+                .to_string(),
+        );
+    };
     match cross_repo.get("status").and_then(Value::as_str) {
         Some("unavailable") => {
             let reason = cross_repo
@@ -241,11 +246,26 @@ fn cross_repo_references_gap(payload: &Value) -> Option<String> {
                 .get("authority_revision")
                 .and_then(Value::as_str)
                 .filter(|revision| !revision.is_empty());
-            let roots_are_present = cross_repo
-                .get("authority_roots")
-                .and_then(Value::as_object)
-                .is_some_and(|roots| !roots.is_empty());
-            if authority_complete && revision.is_some() && roots_are_present {
+            let roots = cross_repo.get("authority_roots").and_then(Value::as_object);
+            let anchor = cross_repo
+                .get("authority_anchor")
+                .and_then(Value::as_object);
+            let anchor_repo = anchor
+                .and_then(|anchor| anchor.get("repo_id"))
+                .and_then(Value::as_str)
+                .filter(|repo_id| !repo_id.is_empty());
+            let anchor_entity = anchor
+                .and_then(|anchor| anchor.get("entity_id"))
+                .and_then(Value::as_str)
+                .filter(|entity_id| !entity_id.is_empty());
+            let focal_entity = payload
+                .get("focal_entity")
+                .and_then(|focal| focal.get("id"))
+                .and_then(Value::as_str);
+            let anchor_is_bound = anchor_repo
+                .is_some_and(|repo_id| roots.is_some_and(|roots| roots.contains_key(repo_id)))
+                && anchor_entity == focal_entity;
+            if authority_complete && revision.is_some() && anchor_is_bound {
                 None
             } else {
                 Some(format!(
@@ -254,7 +274,15 @@ fn cross_repo_references_gap(payload: &Value) -> Option<String> {
                 ))
             }
         }
-        _ => None,
+        Some("not_configured") => {
+            Some("cross_repo_not_configured: cross-repo authority did not answer".to_string())
+        }
+        Some(status) => Some(format!(
+            "cross_repo_authority_unknown: unrecognized cross-repo authority status '{status}'"
+        )),
+        None => {
+            Some("cross_repo_authority_missing: cross-repo authority status is missing".to_string())
+        }
     }
 }
 
@@ -370,6 +398,28 @@ mod tests {
         }))
     }
 
+    fn authoritative_empty_references(kind: &str) -> Value {
+        json!({
+            "focal_entity": {
+                "id": "00000000-0000-0000-0000-000000000001",
+                "kind": kind,
+                "name": "do_work",
+            },
+            "total_upstream": 0,
+            "references": [],
+            "cross_repo": {
+                "status": "available",
+                "authority_complete": true,
+                "authority_anchor": {
+                    "repo_id": "provider",
+                    "entity_id": "00000000-0000-0000-0000-000000000001",
+                },
+                "authority_revision": "sha256:complete",
+                "authority_roots": { "provider": "provider-root" },
+            },
+        })
+    }
+
     #[test]
     fn non_retrieval_tool_gets_no_negative() {
         let payload = json!({ "ok": true });
@@ -469,7 +519,7 @@ mod tests {
         // The headline structural lift: an empty find_references is authoritative
         // on an initialized + loaded graph even with NO embedding coverage —
         // structural tools read typed relations, not embeddings.
-        let payload = json!({ "total_upstream": 0, "references": [] });
+        let payload = authoritative_empty_references("function");
         let negative = negative_for("find_references", &payload, &structural_ready_envelope())
             .expect("empty references yields a negative");
         assert_eq!(negative["kind"], json!("no_references"));
@@ -495,10 +545,7 @@ mod tests {
         // (method entities are keyed by qualified name; calls arrive bare), so an
         // empty find_references for a method must NOT be certified authoritative
         // ("safe to delete") even on a healthy, loaded graph.
-        let payload = json!({
-            "focal_entity": { "kind": "method", "name": "Foo::bar" },
-            "references": []
-        });
+        let payload = authoritative_empty_references("method");
         let negative = negative_for("find_references", &payload, &structural_ready_envelope())
             .expect("empty references yields a negative");
         assert_eq!(negative["safe_to_conclude_absent"], json!(false));
@@ -513,10 +560,7 @@ mod tests {
     fn find_references_on_function_stays_authoritative() {
         // The gate is method-specific: a free function's incoming call edges
         // resolve, so its empty find_references remains an authoritative absence.
-        let payload = json!({
-            "focal_entity": { "kind": "function", "name": "free_fn" },
-            "references": []
-        });
+        let payload = authoritative_empty_references("function");
         let negative =
             negative_for("find_references", &payload, &structural_ready_envelope()).unwrap();
         assert_eq!(negative["safe_to_conclude_absent"], json!(true));
@@ -532,7 +576,7 @@ mod tests {
             "reconciliation_status": "reconciling",
             "graph_loaded": true,
         }));
-        let payload = json!({ "references": [] });
+        let payload = authoritative_empty_references("function");
         let negative = negative_for("find_references", &payload, &env).unwrap();
         assert_eq!(negative["safe_to_conclude_absent"], json!(false));
         assert!(negative["trust_reason"]
@@ -550,7 +594,7 @@ mod tests {
             embed_worker_failed: Some(true),
             ..Degraded::default()
         };
-        let payload = json!({ "references": [] });
+        let payload = authoritative_empty_references("function");
         let negative = negative_for("find_references", &payload, &env).unwrap();
         assert_eq!(negative["safe_to_conclude_absent"], json!(false));
         assert!(negative["trust_reason"]
@@ -634,23 +678,45 @@ mod tests {
 
     #[test]
     fn find_references_complete_cross_repo_authority_remains_authoritative() {
-        let payload = json!({
-            "focal_entity": { "kind": "function", "name": "do_work" },
-            "references": [],
-            "cross_repo": {
-                "status": "available",
-                "authority_complete": true,
-                "authority_revision": "sha256:complete",
-                "authority_roots": {
-                    "consumer": "consumer-root",
-                    "provider": "provider-root",
-                },
-            },
-        });
+        let payload = authoritative_empty_references("function");
         let negative = negative_for("find_references", &payload, &structural_ready_envelope())
             .expect("empty references yields a negative");
         assert_eq!(negative["safe_to_conclude_absent"], json!(true));
         assert_eq!(negative["trust"], json!("authoritative"));
+    }
+
+    #[test]
+    fn find_references_missing_or_unknown_cross_repo_authority_is_inconclusive() {
+        for (cross_repo, expected_reason) in [
+            (None, "cross_repo_authority_missing"),
+            (
+                Some(json!({ "status": "not_configured" })),
+                "cross_repo_not_configured",
+            ),
+            (
+                Some(json!({ "status": "mystery" })),
+                "cross_repo_authority_unknown",
+            ),
+            (Some(json!({})), "cross_repo_authority_missing"),
+        ] {
+            let mut payload = json!({
+                "focal_entity": {
+                    "id": "00000000-0000-0000-0000-000000000001",
+                    "kind": "function",
+                    "name": "do_work",
+                },
+                "references": [],
+            });
+            if let Some(cross_repo) = cross_repo {
+                payload["cross_repo"] = cross_repo;
+            }
+            let negative =
+                negative_for("find_references", &payload, &structural_ready_envelope()).unwrap();
+            assert_eq!(negative["safe_to_conclude_absent"], json!(false));
+            assert!(negative["trust_reason"]
+                .as_str()
+                .is_some_and(|reason| reason.contains(expected_reason)));
+        }
     }
 
     #[test]

--- a/crates/kin-mcp/src/negative.rs
+++ b/crates/kin-mcp/src/negative.rs
@@ -564,6 +564,7 @@ mod tests {
     fn find_references_cross_repo_gap_is_inconclusive_despite_loaded_graph() {
         let payload = json!({
             "focal_entity": { "kind": "function", "name": "do_work" },
+            "relation_kinds": ["calls"],
             "references": [],
             "cross_repo": {
                 "status": "unavailable",
@@ -588,6 +589,7 @@ mod tests {
     fn find_references_incomplete_cross_repo_authority_is_inconclusive() {
         let payload = json!({
             "focal_entity": { "kind": "function", "name": "do_work" },
+            "relation_kinds": ["imports"],
             "references": [],
             "cross_repo": {
                 "status": "available",

--- a/crates/kin-spine/src/backend.rs
+++ b/crates/kin-spine/src/backend.rs
@@ -8,12 +8,14 @@
 //! - `FirestoreSpineBackend`: Firestore REST API (cloud, stateless daemon pool)
 //! - `CachedSpineBackend<B>`: LRU cache wrapper for any backend
 
-use std::collections::HashSet;
+use std::collections::{BTreeMap, HashSet};
 
 use kin_model::{Entity, EntityId, EntityKind, Relation, SemanticFingerprint};
 
 use crate::federation::{self, FederatedImpact};
-use crate::index::{CrossRepoEdge, CrossRepoEdgesSnapshot, EntityEntry, SpineIndex};
+use crate::index::{
+    CrossRepoEdge, CrossRepoEdgesSnapshot, EntityEntry, SpineIndex, SpineXrefResponse,
+};
 
 /// Error type for spine backend operations.
 #[derive(Debug, thiserror::Error)]
@@ -66,6 +68,15 @@ pub trait SpineBackend: Send + Sync {
         CrossRepoEdgesSnapshot::default()
     }
 
+    /// Atomically project xrefs for one repository/entity anchor.
+    ///
+    /// The compatibility default remains fail-closed because the default bulk
+    /// snapshot is incomplete. Built-in backends override this with a bounded
+    /// incident-edge projection that does not clone the organization graph.
+    fn cross_repo_xref_response(&self, repo_id: &str, entity_id: &EntityId) -> SpineXrefResponse {
+        SpineXrefResponse::from_snapshot(self.cross_repo_edges_snapshot(), repo_id, entity_id)
+    }
+
     /// Add a cross-repo edge.
     fn add_cross_repo_edge(&self, edge: CrossRepoEdge);
 
@@ -92,6 +103,27 @@ pub trait SpineBackend: Send + Sync {
         relations: &[Relation],
         registry_repo_ids: &[String],
     );
+
+    /// Fail closed after a refresh/load failure while preserving last-known
+    /// positive edges for advisory use. This is required rather than a no-op
+    /// default so a backend cannot advertise complete snapshots while silently
+    /// ignoring a failed refresh.
+    fn invalidate_cross_repo_edges(&self, repo_id: &str);
+
+    /// Acquire one all-repo refresh lease against an exact registered root set.
+    /// While active, per-source refreshes cannot advertise completeness.
+    fn begin_cross_repo_refresh_pass(
+        &self,
+        authority_roots: &BTreeMap<String, String>,
+    ) -> Option<u64>;
+
+    /// Atomically publish (or abort) the all-repo pass after final validation.
+    fn finish_cross_repo_refresh_pass(
+        &self,
+        token: u64,
+        authority_roots: &BTreeMap<String, String>,
+        success: bool,
+    ) -> bool;
 
     /// Compute federated impact by BFS through cross-repo edges.
     fn federated_impact(
@@ -156,6 +188,10 @@ impl SpineBackend for InMemorySpineBackend {
         self.index.cross_repo_edges_snapshot()
     }
 
+    fn cross_repo_xref_response(&self, repo_id: &str, entity_id: &EntityId) -> SpineXrefResponse {
+        self.index.cross_repo_xref_response(repo_id, entity_id)
+    }
+
     fn add_cross_repo_edge(&self, edge: CrossRepoEdge) {
         self.index.add_cross_repo_edge(edge);
     }
@@ -189,6 +225,27 @@ impl SpineBackend for InMemorySpineBackend {
     ) {
         self.index
             .refresh_cross_repo_edges(repo_id, entities, relations, registry_repo_ids);
+    }
+
+    fn invalidate_cross_repo_edges(&self, repo_id: &str) {
+        self.index.invalidate_cross_repo_edges(repo_id);
+    }
+
+    fn begin_cross_repo_refresh_pass(
+        &self,
+        authority_roots: &BTreeMap<String, String>,
+    ) -> Option<u64> {
+        self.index.begin_cross_repo_refresh_pass(authority_roots)
+    }
+
+    fn finish_cross_repo_refresh_pass(
+        &self,
+        token: u64,
+        authority_roots: &BTreeMap<String, String>,
+        success: bool,
+    ) -> bool {
+        self.index
+            .finish_cross_repo_refresh_pass(token, authority_roots, success)
     }
 
     fn federated_impact(
@@ -251,6 +308,21 @@ mod tests {
         }
 
         fn refresh_cross_repo_edges(&self, _: &str, _: &[Entity], _: &[Relation], _: &[String]) {}
+
+        fn invalidate_cross_repo_edges(&self, _: &str) {}
+
+        fn begin_cross_repo_refresh_pass(&self, _: &BTreeMap<String, String>) -> Option<u64> {
+            None
+        }
+
+        fn finish_cross_repo_refresh_pass(
+            &self,
+            _: u64,
+            _: &BTreeMap<String, String>,
+            _: bool,
+        ) -> bool {
+            false
+        }
 
         fn federated_impact(&self, _: &str, _: &EntityId, _: u32) -> FederatedImpact {
             panic!("not used by compatibility test")

--- a/crates/kin-spine/src/firestore.rs
+++ b/crates/kin-spine/src/firestore.rs
@@ -28,7 +28,7 @@
 //! the authoritative copy used to rebuild the cache; the sibling fields stay
 //! human-readable for the Firestore console and back the by-repo delete queries.
 
-use std::collections::HashSet;
+use std::collections::{BTreeMap, HashSet};
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::Arc;
 
@@ -109,12 +109,10 @@ impl FirestoreSpineBackend {
             self.cache
                 .register_repo(&repo.repo_id, repo.entries, &repo.root_hash);
         }
-        let mut edge_count = 0;
-        for edge in edges {
-            if self.cache.index().add_cross_repo_edge(edge) {
-                edge_count += 1;
-            }
-        }
+        // Hydration is a bulk install, not a stream of authority publications.
+        // Rebuild the global incident projection/revision once after all rows
+        // are resident; doing it once per edge is O(E^2 log E).
+        let edge_count = self.cache.index().add_cross_repo_edges(edges);
 
         self.hydrated.store(true, Ordering::Release);
         info!(
@@ -179,9 +177,23 @@ impl SpineBackend for FirestoreSpineBackend {
     }
 
     fn cross_repo_edges_snapshot(&self) -> CrossRepoEdgesSnapshot {
-        // Hydration is cache warm-start only. Completeness comes exclusively
-        // from the cache's graph-authoritative dirty/epoch/endpoint checks.
-        self.cache.cross_repo_edges_snapshot()
+        // Durable rows and this pod's graph refreshes are useful advisory
+        // positives, but neither can prove that every other pod observed the
+        // same registered roots. Keep completeness fail-closed until the
+        // durable backend owns a shared pass/root CAS.
+        let mut snapshot = self.cache.cross_repo_edges_snapshot();
+        snapshot.complete = false;
+        snapshot
+    }
+
+    fn cross_repo_xref_response(
+        &self,
+        repo_id: &str,
+        entity_id: &EntityId,
+    ) -> crate::SpineXrefResponse {
+        let mut response = self.cache.cross_repo_xref_response(repo_id, entity_id);
+        response.authority_complete = false;
+        response
     }
 
     fn add_cross_repo_edge(&self, edge: CrossRepoEdge) {
@@ -238,6 +250,32 @@ impl SpineBackend for FirestoreSpineBackend {
                 error!(error = %e, "failed to write refreshed edge to store");
             }
         }
+    }
+
+    fn invalidate_cross_repo_edges(&self, repo_id: &str) {
+        self.cache.invalidate_cross_repo_edges(repo_id);
+    }
+
+    fn begin_cross_repo_refresh_pass(
+        &self,
+        authority_roots: &BTreeMap<String, String>,
+    ) -> Option<u64> {
+        self.cache.begin_cross_repo_refresh_pass(authority_roots)
+    }
+
+    fn finish_cross_repo_refresh_pass(
+        &self,
+        token: u64,
+        authority_roots: &BTreeMap<String, String>,
+        _success: bool,
+    ) -> bool {
+        // Clear this pod's lease while deliberately retaining its dirty set.
+        // A successful local pass cannot be published as globally complete
+        // without a shared durable epoch/root compare-and-swap.
+        let _ = self
+            .cache
+            .finish_cross_repo_refresh_pass(token, authority_roots, false);
+        false
     }
 
     fn federated_impact(
@@ -822,7 +860,7 @@ mod tests {
     }
 
     #[test]
-    fn valid_hydration_stays_incomplete_until_graph_authoritative_full_refresh() {
+    fn valid_hydration_and_pod_local_refresh_remain_advisory() {
         let store = Arc::new(FakeSpineStore::default());
         let writer = FirestoreSpineBackend::with_store(store.clone());
         let provider = test_entry("provider", "provide", EntityKind::Function);
@@ -871,14 +909,20 @@ mod tests {
         );
 
         let snapshot = reader.cross_repo_edges_snapshot();
-        assert!(snapshot.complete);
+        assert!(
+            !snapshot.complete,
+            "a pod-local refresh cannot certify shared durable authority"
+        );
         assert_eq!(snapshot.repos, vec!["consumer", "provider"]);
         assert_eq!(snapshot.edges.len(), 1);
         assert!(snapshot.revision.starts_with("sha256:"));
+        let xref = reader.cross_repo_xref_response("provider", &provider.entity_id);
+        assert_eq!(xref.edges.len(), 1, "known positives remain advisory");
+        assert!(!xref.authority_complete);
     }
 
     #[test]
-    fn torn_hydration_stays_incomplete_until_authoritative_refresh_removes_orphan() {
+    fn torn_hydration_remains_incomplete_after_pod_local_rebuild() {
         let store = Arc::new(FakeSpineStore::default());
         let writer = FirestoreSpineBackend::with_store(store.clone());
         let provider = test_entry("provider", "provide", EntityKind::Function);
@@ -910,7 +954,10 @@ mod tests {
             reader.refresh_cross_repo_edges(repo, &[], &[], &registry);
         }
         let rebuilt = reader.cross_repo_edges_snapshot();
-        assert!(rebuilt.complete);
+        assert!(
+            !rebuilt.complete,
+            "a local rebuild cannot establish shared-store completeness"
+        );
         assert!(
             rebuilt.edges.is_empty(),
             "authoritative refresh removes torn edge"
@@ -918,7 +965,7 @@ mod tests {
     }
 
     #[test]
-    fn failed_hydration_does_not_block_later_authoritative_rebuild() {
+    fn failed_hydration_and_local_rebuild_remain_incomplete() {
         let store = Arc::new(FakeSpineStore::default());
         let writer = FirestoreSpineBackend::with_store(store.clone());
         let alpha = test_entry("alpha", "alpha", EntityKind::Function);
@@ -936,9 +983,70 @@ mod tests {
             reader.refresh_cross_repo_edges(repo, &[], &[], &registry);
         }
         assert!(
-            reader.cross_repo_edges_snapshot().complete,
-            "hydration status must not veto a complete graph-authoritative rebuild"
+            !reader.cross_repo_edges_snapshot().complete,
+            "shared-store authority needs a durable pass/root CAS even after local recovery"
         );
+    }
+
+    #[test]
+    fn stale_pod_cannot_certify_shared_store_completeness() {
+        let store = Arc::new(FakeSpineStore::default());
+        let stale_pod = FirestoreSpineBackend::with_store(store.clone());
+        let provider = test_entry("provider", "provide", EntityKind::Function);
+        let consumer = test_entry("consumer", "consume", EntityKind::Function);
+        stale_pod.register_repo("provider", vec![provider.clone()], "provider-root-v1");
+        stale_pod.register_repo("consumer", vec![consumer.clone()], "consumer-root");
+        stale_pod.add_cross_repo_edge(CrossRepoEdge {
+            src_repo: "consumer".to_string(),
+            src_entity: consumer.entity_id,
+            dst_repo: "provider".to_string(),
+            dst_entity: provider.entity_id,
+            confidence: 0.95,
+        });
+
+        let fresh_pod = FirestoreSpineBackend::with_store(store.clone());
+        fresh_pod.hydrate().expect("hydrate shared durable rows");
+        fresh_pod.register_repo(
+            "provider",
+            vec![test_entry("provider", "provide_v2", EntityKind::Function)],
+            "provider-root-v2",
+        );
+
+        let stale_roots = BTreeMap::from([
+            ("consumer".to_string(), "consumer-root".to_string()),
+            ("provider".to_string(), "provider-root-v1".to_string()),
+        ]);
+        let token = stale_pod
+            .begin_cross_repo_refresh_pass(&stale_roots)
+            .expect("stale pod can only acquire its local lease");
+        assert!(
+            !stale_pod.finish_cross_repo_refresh_pass(token, &stale_roots, true),
+            "a local pass must never publish shared durable completeness"
+        );
+
+        let durable_provider = store
+            .load_repos()
+            .unwrap()
+            .into_iter()
+            .find(|repo| repo.repo_id == "provider")
+            .expect("provider remains in shared store");
+        assert_eq!(durable_provider.root_hash, "provider-root-v2");
+        assert_eq!(
+            stale_pod.root_hash("provider").as_deref(),
+            Some("provider-root-v1"),
+            "the first pod is demonstrably stale"
+        );
+
+        let snapshot = stale_pod.cross_repo_edges_snapshot();
+        assert!(!snapshot.complete);
+        let xref = stale_pod.cross_repo_xref_response("provider", &provider.entity_id);
+        assert_eq!(xref.edges.len(), 1, "stale known positives stay advisory");
+        assert!(!xref.authority_complete);
+
+        let retry_token = stale_pod
+            .begin_cross_repo_refresh_pass(&stale_roots)
+            .expect("failed publication still clears the pod-local lease");
+        assert!(!stale_pod.finish_cross_repo_refresh_pass(retry_token, &stale_roots, false));
     }
 
     #[test]

--- a/crates/kin-spine/src/index.rs
+++ b/crates/kin-spine/src/index.rs
@@ -65,6 +65,17 @@ pub struct CrossRepoEdge {
     pub confidence: f32,
 }
 
+/// The exact repository/entity pair for which an xref response was projected.
+///
+/// Xref payloads may legitimately be empty, so clients cannot infer this anchor
+/// from the returned edges. Echoing it prevents a stale or mis-keyed response
+/// from certifying absence for a different entity in the same repository.
+#[derive(Debug, Clone, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
+pub struct SpineXrefAuthorityAnchor {
+    pub repo_id: RepoId,
+    pub entity_id: EntityId,
+}
+
 /// Versioned wire response for `GET /v1/spine/xref`.
 ///
 /// `edges` remains the canonical topology payload. `entities` is an additive,
@@ -79,6 +90,8 @@ pub struct SpineXrefResponse {
     pub edges: Vec<CrossRepoEdge>,
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub entities: Vec<EntityEntry>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub authority_anchor: Option<SpineXrefAuthorityAnchor>,
     #[serde(default)]
     pub authority_complete: bool,
     #[serde(default, skip_serializing_if = "Option::is_none")]
@@ -98,6 +111,7 @@ impl SpineXrefResponse {
             version: crate::SPINE_PAYLOAD_VERSION,
             edges,
             entities,
+            authority_anchor: None,
             authority_complete: false,
             authority_revision: None,
             authority_roots: BTreeMap::new(),
@@ -149,6 +163,10 @@ impl SpineXrefResponse {
             version: crate::SPINE_PAYLOAD_VERSION,
             edges,
             entities,
+            authority_anchor: Some(SpineXrefAuthorityAnchor {
+                repo_id: repo_id.to_string(),
+                entity_id: *entity_id,
+            }),
             authority_complete: complete
                 && roots.contains_key(repo_id)
                 && covered_entities
@@ -161,6 +179,19 @@ impl SpineXrefResponse {
 
     pub fn version(&self) -> u32 {
         self.version
+    }
+
+    /// Whether this payload can certify an answer for the requested anchor.
+    ///
+    /// This is intentionally stricter than the wire-level boolean so callers
+    /// cannot accidentally ignore the response's query binding.
+    pub fn authority_complete_for(&self, repo_id: &str, entity_id: &EntityId) -> bool {
+        self.authority_complete
+            && self
+                .authority_anchor
+                .as_ref()
+                .is_some_and(|anchor| anchor.repo_id == repo_id && anchor.entity_id == *entity_id)
+            && self.authority_roots.contains_key(repo_id)
     }
 
     /// Decode and version-check an xref response as one shared contract.
@@ -177,6 +208,11 @@ impl SpineXrefResponse {
             });
         }
         if response.authority_complete {
+            let valid_anchor = response.authority_anchor.as_ref().is_some_and(|anchor| {
+                !anchor.repo_id.is_empty()
+                    && anchor.repo_id.trim() == anchor.repo_id
+                    && response.authority_roots.contains_key(&anchor.repo_id)
+            });
             let valid_revision = response
                 .authority_revision
                 .as_deref()
@@ -197,13 +233,48 @@ impl SpineXrefResponse {
                 response.authority_roots.contains_key(&edge.src_repo)
                     && response.authority_roots.contains_key(&edge.dst_repo)
             });
-            if !valid_revision || !valid_roots || !endpoints_are_watermarked {
+            if !valid_anchor || !valid_revision || !valid_roots || !endpoints_are_watermarked {
                 return Err(SpineXrefDecodeError::InvalidAuthority(
-                    "complete xref authority requires a canonical revision, non-empty roots, and watermarked edge endpoints"
+                    "complete xref authority requires a query anchor, canonical revision, non-empty roots, and watermarked edge endpoints"
                         .to_string(),
                 ));
             }
         }
+        Ok(response)
+    }
+
+    /// Decode an xref response and bind it to the request that produced it.
+    ///
+    /// Every transport consumer should use this method. Even an incomplete
+    /// response must echo the requested anchor: without it an empty body could
+    /// belong to a different cache key. Returned edges must all be incident to
+    /// that same anchor, otherwise the payload is internally inconsistent.
+    pub fn from_slice_for(
+        bytes: &[u8],
+        repo_id: &str,
+        entity_id: &EntityId,
+    ) -> Result<Self, SpineXrefDecodeError> {
+        let response = Self::from_slice(bytes)?;
+        let anchor_matches = response
+            .authority_anchor
+            .as_ref()
+            .is_some_and(|anchor| anchor.repo_id == repo_id && anchor.entity_id == *entity_id);
+        if !anchor_matches {
+            return Err(SpineXrefDecodeError::InvalidAuthority(format!(
+                "xref response anchor does not match requested repository/entity {repo_id}/{entity_id}"
+            )));
+        }
+
+        let edges_are_incident = response.edges.iter().all(|edge| {
+            (edge.src_repo == repo_id && edge.src_entity == *entity_id)
+                || (edge.dst_repo == repo_id && edge.dst_entity == *entity_id)
+        });
+        if !edges_are_incident {
+            return Err(SpineXrefDecodeError::InvalidAuthority(format!(
+                "xref response contains an edge unrelated to requested repository/entity {repo_id}/{entity_id}"
+            )));
+        }
+
         Ok(response)
     }
 }
@@ -808,6 +879,7 @@ mod tests {
         assert_eq!(decoded.entities.len(), 1);
         assert_eq!(decoded.entities[0].name, "run_task");
         assert!(!decoded.authority_complete);
+        assert!(decoded.authority_anchor.is_none());
         assert!(decoded.authority_revision.is_none());
         assert!(decoded.authority_roots.is_empty());
     }
@@ -832,8 +904,13 @@ mod tests {
         assert_eq!(decoded.edges.len(), 1);
         assert!(decoded.entities.is_empty());
         assert!(!decoded.authority_complete);
+        assert!(decoded.authority_anchor.is_none());
         assert!(decoded.authority_revision.is_none());
         assert!(decoded.authority_roots.is_empty());
+        assert!(matches!(
+            SpineXrefResponse::from_slice_for(&bytes, "provider", &dst),
+            Err(SpineXrefDecodeError::InvalidAuthority(_))
+        ));
     }
 
     #[test]
@@ -868,13 +945,22 @@ mod tests {
             .is_some_and(|revision| revision.starts_with("sha256:")));
         assert_eq!(response.authority_roots["consumer"], "consumer-root");
         assert_eq!(response.authority_roots["provider"], "provider-root");
+        assert_eq!(
+            response.authority_anchor,
+            Some(SpineXrefAuthorityAnchor {
+                repo_id: "provider".to_string(),
+                entity_id: dst,
+            })
+        );
+        assert!(response.authority_complete_for("provider", &dst));
+        assert!(!response.authority_complete_for("provider", &no_refs));
         assert_eq!(response.edges.len(), 1);
         assert_eq!(response.entities.len(), 2);
         assert_eq!(response.entities[0].repo_id, "consumer");
         assert_eq!(response.entities[1].repo_id, "provider");
 
-        let decoded =
-            SpineXrefResponse::from_slice(&serde_json::to_vec(&response).unwrap()).unwrap();
+        let response_bytes = serde_json::to_vec(&response).unwrap();
+        let decoded = SpineXrefResponse::from_slice_for(&response_bytes, "provider", &dst).unwrap();
         assert!(decoded.authority_complete);
         assert_eq!(decoded.authority_revision, response.authority_revision);
 
@@ -889,6 +975,11 @@ mod tests {
         );
         assert!(covered_empty.authority_complete);
         assert!(covered_empty.edges.is_empty());
+        let covered_empty_bytes = serde_json::to_vec(&covered_empty).unwrap();
+        assert!(matches!(
+            SpineXrefResponse::from_slice_for(&covered_empty_bytes, "provider", &dst),
+            Err(SpineXrefDecodeError::InvalidAuthority(_))
+        ));
 
         let unknown_entity = SpineXrefResponse::from_snapshot(
             index.cross_repo_edges_snapshot(),
@@ -896,6 +987,33 @@ mod tests {
             &EntityId::new(),
         );
         assert!(!unknown_entity.authority_complete);
+    }
+
+    #[test]
+    fn xref_bound_decode_rejects_non_incident_edges() {
+        let requested = EntityId::new();
+        let unrelated_src = EntityId::new();
+        let unrelated_dst = EntityId::new();
+        let mut response = SpineXrefResponse::new(
+            vec![CrossRepoEdge {
+                src_repo: "consumer".to_string(),
+                src_entity: unrelated_src,
+                dst_repo: "provider".to_string(),
+                dst_entity: unrelated_dst,
+                confidence: 0.9,
+            }],
+            Vec::new(),
+        );
+        response.authority_anchor = Some(SpineXrefAuthorityAnchor {
+            repo_id: "provider".to_string(),
+            entity_id: requested,
+        });
+
+        let bytes = serde_json::to_vec(&response).unwrap();
+        assert!(matches!(
+            SpineXrefResponse::from_slice_for(&bytes, "provider", &requested),
+            Err(SpineXrefDecodeError::InvalidAuthority(_))
+        ));
     }
 
     #[test]

--- a/crates/kin-spine/src/index.rs
+++ b/crates/kin-spine/src/index.rs
@@ -7,7 +7,7 @@
 //! registered repos. Provides name-based resolution with fingerprint
 //! disambiguation for common names like Config, Error, init.
 
-use std::collections::{BTreeMap, HashSet};
+use std::collections::{BTreeMap, BTreeSet, HashSet};
 
 use hashbrown::HashMap;
 use kin_model::{Entity, EntityId, EntityKind, EntityRole, Relation, SemanticFingerprint};
@@ -34,6 +34,25 @@ pub struct EntityEntry {
     pub role: Option<EntityRole>,
 }
 
+impl PartialEq for EntityEntry {
+    fn eq(&self, other: &Self) -> bool {
+        self.repo_id == other.repo_id
+            && self.entity_id == other.entity_id
+            && self.name == other.name
+            && self.kind == other.kind
+            && self.signature == other.signature
+            && self.fingerprint.algorithm == other.fingerprint.algorithm
+            && self.fingerprint.ast_hash == other.fingerprint.ast_hash
+            && self.fingerprint.signature_hash == other.fingerprint.signature_hash
+            && self.fingerprint.behavior_hash == other.fingerprint.behavior_hash
+            && self.fingerprint.equivalence_hash == other.fingerprint.equivalence_hash
+            && self.fingerprint.stability_score.to_bits()
+                == other.fingerprint.stability_score.to_bits()
+            && self.file_path == other.file_path
+            && self.role == other.role
+    }
+}
+
 /// Cross-repo edge linking two entities across repo boundaries.
 #[derive(Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize)]
 pub struct CrossRepoEdge {
@@ -50,22 +69,93 @@ pub struct CrossRepoEdge {
 ///
 /// `edges` remains the canonical topology payload. `entities` is an additive,
 /// metadata-only sidecar that lets clients render useful cross-repo references
-/// without inventing field names or reading another repository's files. Older
-/// version-1 daemons omitted the sidecar, so it defaults to empty on decode.
+/// without inventing field names or reading another repository's files.
+/// `authority_*` carries the exact graph-authority watermark against which the
+/// topology was answered. Older version-1 daemons omitted the additive sidecar
+/// and authority fields, so they decode conservatively as incomplete.
 #[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
 pub struct SpineXrefResponse {
     version: u32,
     pub edges: Vec<CrossRepoEdge>,
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub entities: Vec<EntityEntry>,
+    #[serde(default)]
+    pub authority_complete: bool,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub authority_revision: Option<String>,
+    #[serde(default, skip_serializing_if = "BTreeMap::is_empty")]
+    pub authority_roots: BTreeMap<RepoId, String>,
 }
 
 impl SpineXrefResponse {
+    /// Construct an unwatermarked response.
+    ///
+    /// This remains available for patch-compatible callers that only have an
+    /// edge collection, but it deliberately cannot certify an empty result.
+    /// Production daemon routes should use [`Self::from_snapshot`].
     pub fn new(edges: Vec<CrossRepoEdge>, entities: Vec<EntityEntry>) -> Self {
         Self {
             version: crate::SPINE_PAYLOAD_VERSION,
             edges,
             entities,
+            authority_complete: false,
+            authority_revision: None,
+            authority_roots: BTreeMap::new(),
+        }
+    }
+
+    /// Project one entity's xrefs from a single atomic authority snapshot.
+    ///
+    /// Both topology and the metadata sidecar come from the same spine read.
+    /// Completeness also requires that the requested repository belongs to the
+    /// snapshot's root watermark; a typo or stale binding must not certify an
+    /// empty result against some unrelated repository universe.
+    pub fn from_snapshot(
+        snapshot: CrossRepoEdgesSnapshot,
+        repo_id: &str,
+        entity_id: &EntityId,
+    ) -> Self {
+        let CrossRepoEdgesSnapshot {
+            complete,
+            revision,
+            roots,
+            edges,
+            entities,
+            covered_entities,
+            ..
+        } = snapshot;
+        let edges = edges
+            .into_iter()
+            .filter(|edge| {
+                (edge.src_repo == repo_id && edge.src_entity == *entity_id)
+                    || (edge.dst_repo == repo_id && edge.dst_entity == *entity_id)
+            })
+            .collect::<Vec<_>>();
+        let entity_keys = edges
+            .iter()
+            .flat_map(|edge| {
+                [
+                    (edge.src_repo.clone(), edge.src_entity),
+                    (edge.dst_repo.clone(), edge.dst_entity),
+                ]
+            })
+            .collect::<std::collections::BTreeSet<_>>();
+        let entities = entities
+            .into_iter()
+            .filter(|entity| entity_keys.contains(&(entity.repo_id.clone(), entity.entity_id)))
+            .collect();
+
+        Self {
+            version: crate::SPINE_PAYLOAD_VERSION,
+            edges,
+            entities,
+            authority_complete: complete
+                && roots.contains_key(repo_id)
+                && covered_entities
+                    .get(repo_id)
+                    .is_some_and(|entities| entities.contains(entity_id)),
+            authority_revision: Some(revision),
+            authority_roots: roots,
         }
     }
 
@@ -86,6 +176,34 @@ impl SpineXrefResponse {
                 supported: crate::SPINE_PAYLOAD_VERSION,
             });
         }
+        if response.authority_complete {
+            let valid_revision = response
+                .authority_revision
+                .as_deref()
+                .is_some_and(|revision| {
+                    revision.len() == 71
+                        && revision.strip_prefix("sha256:").is_some_and(|digest| {
+                            digest.bytes().all(|byte| byte.is_ascii_hexdigit())
+                        })
+                });
+            let valid_roots = !response.authority_roots.is_empty()
+                && response.authority_roots.iter().all(|(repo, root)| {
+                    !repo.is_empty()
+                        && repo.trim() == repo
+                        && !root.is_empty()
+                        && root.trim() == root
+                });
+            let endpoints_are_watermarked = response.edges.iter().all(|edge| {
+                response.authority_roots.contains_key(&edge.src_repo)
+                    && response.authority_roots.contains_key(&edge.dst_repo)
+            });
+            if !valid_revision || !valid_roots || !endpoints_are_watermarked {
+                return Err(SpineXrefDecodeError::InvalidAuthority(
+                    "complete xref authority requires a canonical revision, non-empty roots, and watermarked edge endpoints"
+                        .to_string(),
+                ));
+            }
+        }
         Ok(response)
     }
 }
@@ -96,6 +214,8 @@ pub enum SpineXrefDecodeError {
     Malformed(#[from] serde_json::Error),
     #[error("unsupported spine xref response version {actual}; supported version is {supported}")]
     UnsupportedVersion { actual: u32, supported: u32 },
+    #[error("invalid spine xref authority: {0}")]
+    InvalidAuthority(String),
 }
 
 /// One atomic, graph-authoritative view of every cross-repo edge in the spine.
@@ -112,6 +232,16 @@ pub struct CrossRepoEdgesSnapshot {
     pub repos: Vec<RepoId>,
     pub roots: BTreeMap<RepoId, String>,
     pub edges: Vec<CrossRepoEdge>,
+    /// Metadata for the returned edge endpoints, captured under the same lock.
+    /// This is an internal authority sidecar; the bulk edge route intentionally
+    /// projects only topology and watermarks onto its public wire response.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub entities: Vec<EntityEntry>,
+    /// Entity IDs covered by the same registered root snapshot. Kept off the
+    /// serialized bulk payload; xref projection uses it to ensure the queried
+    /// anchor itself belongs to the watermarked graph before certifying absence.
+    #[serde(skip)]
+    covered_entities: BTreeMap<RepoId, BTreeSet<EntityId>>,
 }
 
 impl Default for CrossRepoEdgesSnapshot {
@@ -124,6 +254,8 @@ impl Default for CrossRepoEdgesSnapshot {
             repos: Vec::new(),
             roots,
             edges,
+            entities: Vec::new(),
+            covered_entities: BTreeMap::new(),
         }
     }
 }
@@ -335,7 +467,7 @@ impl SpineIndex {
     /// authority serialize to identical bytes. No projection or filesystem
     /// surface participates in this read.
     pub fn cross_repo_edges_snapshot(&self) -> CrossRepoEdgesSnapshot {
-        let (complete, roots, mut edges) = {
+        let (complete, roots, mut edges, mut entities, covered_entities) = {
             let inner = self.inner.read();
             let roots = inner
                 .root_hashes
@@ -352,6 +484,24 @@ impl SpineIndex {
                         .by_id
                         .contains_key(&(edge.dst_repo.clone(), edge.dst_entity))
             });
+            let entities = inner
+                .cross_repo_edges
+                .iter()
+                .flat_map(|edge| {
+                    [
+                        (edge.src_repo.clone(), edge.src_entity),
+                        (edge.dst_repo.clone(), edge.dst_entity),
+                    ]
+                })
+                .filter_map(|key| inner.by_id.get(&key).cloned())
+                .collect::<Vec<_>>();
+            let mut covered_entities = BTreeMap::<RepoId, BTreeSet<EntityId>>::new();
+            for (repo_id, entity_id) in inner.by_id.keys() {
+                covered_entities
+                    .entry(repo_id.clone())
+                    .or_default()
+                    .insert(*entity_id);
+            }
             (
                 inner.active_edge_refreshes == 0
                     && inner.dirty_edge_repos.is_empty()
@@ -362,11 +512,21 @@ impl SpineIndex {
                     && edge_authority_is_closed,
                 roots,
                 inner.cross_repo_edges.clone(),
+                entities,
+                covered_entities,
             )
         };
 
         edges.sort_by(cross_repo_edge_order);
         edges.dedup_by(|a, b| cross_repo_edge_identity_order(a, b).is_eq());
+        entities.sort_by(|left, right| {
+            left.repo_id
+                .cmp(&right.repo_id)
+                .then_with(|| left.entity_id.cmp(&right.entity_id))
+        });
+        entities.dedup_by(|left, right| {
+            left.repo_id == right.repo_id && left.entity_id == right.entity_id
+        });
 
         let repos = roots.keys().cloned().collect::<Vec<_>>();
         let revision = cross_repo_snapshot_revision(&roots, &edges);
@@ -376,6 +536,8 @@ impl SpineIndex {
             repos,
             roots,
             edges,
+            entities,
+            covered_entities,
         }
     }
 
@@ -645,10 +807,13 @@ mod tests {
         assert_eq!(decoded.edges[0].src_repo, "consumer");
         assert_eq!(decoded.entities.len(), 1);
         assert_eq!(decoded.entities[0].name, "run_task");
+        assert!(!decoded.authority_complete);
+        assert!(decoded.authority_revision.is_none());
+        assert!(decoded.authority_roots.is_empty());
     }
 
     #[test]
-    fn xref_wire_response_accepts_version_one_without_metadata_sidecar() {
+    fn xref_wire_response_accepts_legacy_version_one_as_incomplete() {
         let src = EntityId::new();
         let dst = EntityId::new();
         let bytes = serde_json::to_vec(&serde_json::json!({
@@ -666,6 +831,71 @@ mod tests {
         let decoded = SpineXrefResponse::from_slice(&bytes).unwrap();
         assert_eq!(decoded.edges.len(), 1);
         assert!(decoded.entities.is_empty());
+        assert!(!decoded.authority_complete);
+        assert!(decoded.authority_revision.is_none());
+        assert!(decoded.authority_roots.is_empty());
+    }
+
+    #[test]
+    fn xref_wire_response_projects_complete_atomic_snapshot() {
+        let src = EntityId::new();
+        let dst = EntityId::new();
+        let no_refs = EntityId::new();
+        let consumer = test_entry_with_id("consumer", src, "run_task");
+        let provider = test_entry_with_id("provider", dst, "do_work");
+        let unused = test_entry_with_id("provider", no_refs, "unused");
+        let index = SpineIndex::new();
+        index.register_repo("consumer", vec![consumer], "consumer-root");
+        index.register_repo("provider", vec![provider, unused], "provider-root");
+        let repos = vec!["consumer".to_string(), "provider".to_string()];
+        for repo in &repos {
+            index.refresh_cross_repo_edges(repo, &[], &[], &repos);
+        }
+        index.add_cross_repo_edge(CrossRepoEdge {
+            src_repo: "consumer".to_string(),
+            src_entity: src,
+            dst_repo: "provider".to_string(),
+            dst_entity: dst,
+            confidence: 0.9,
+        });
+
+        let response =
+            SpineXrefResponse::from_snapshot(index.cross_repo_edges_snapshot(), "provider", &dst);
+        assert!(response.authority_complete);
+        assert!(response
+            .authority_revision
+            .as_deref()
+            .is_some_and(|revision| revision.starts_with("sha256:")));
+        assert_eq!(response.authority_roots["consumer"], "consumer-root");
+        assert_eq!(response.authority_roots["provider"], "provider-root");
+        assert_eq!(response.edges.len(), 1);
+        assert_eq!(response.entities.len(), 2);
+        assert_eq!(response.entities[0].repo_id, "consumer");
+        assert_eq!(response.entities[1].repo_id, "provider");
+
+        let decoded =
+            SpineXrefResponse::from_slice(&serde_json::to_vec(&response).unwrap()).unwrap();
+        assert!(decoded.authority_complete);
+        assert_eq!(decoded.authority_revision, response.authority_revision);
+
+        let wrong_repo =
+            SpineXrefResponse::from_snapshot(index.cross_repo_edges_snapshot(), "unknown", &dst);
+        assert!(!wrong_repo.authority_complete);
+
+        let covered_empty = SpineXrefResponse::from_snapshot(
+            index.cross_repo_edges_snapshot(),
+            "provider",
+            &no_refs,
+        );
+        assert!(covered_empty.authority_complete);
+        assert!(covered_empty.edges.is_empty());
+
+        let unknown_entity = SpineXrefResponse::from_snapshot(
+            index.cross_repo_edges_snapshot(),
+            "provider",
+            &EntityId::new(),
+        );
+        assert!(!unknown_entity.authority_complete);
     }
 
     #[test]
@@ -693,6 +923,17 @@ mod tests {
         assert!(matches!(
             SpineXrefResponse::from_slice(&unsupported),
             Err(SpineXrefDecodeError::UnsupportedVersion { .. })
+        ));
+
+        let unwatermarked_complete = serde_json::to_vec(&serde_json::json!({
+            "version": crate::SPINE_PAYLOAD_VERSION,
+            "edges": [],
+            "authority_complete": true,
+        }))
+        .unwrap();
+        assert!(matches!(
+            SpineXrefResponse::from_slice(&unwatermarked_complete),
+            Err(SpineXrefDecodeError::InvalidAuthority(_))
         ));
     }
 

--- a/crates/kin-spine/src/index.rs
+++ b/crates/kin-spine/src/index.rs
@@ -194,6 +194,15 @@ impl SpineXrefResponse {
             && self.authority_roots.contains_key(repo_id)
     }
 
+    /// Whether the response's primary-repo watermark is the exact graph root
+    /// held by the caller. A complete spine rooted at an older live/session
+    /// graph is stale authority, including for positive rows.
+    pub fn authority_root_matches(&self, repo_id: &str, expected_root: &str) -> bool {
+        self.authority_roots
+            .get(repo_id)
+            .is_some_and(|root| root == expected_root)
+    }
+
     /// Decode and version-check an xref response as one shared contract.
     ///
     /// Callers must not index ad-hoc JSON fields: required topology fields and
@@ -245,21 +254,25 @@ impl SpineXrefResponse {
 
     /// Decode an xref response and bind it to the request that produced it.
     ///
-    /// Every transport consumer should use this method. Even an incomplete
-    /// response must echo the requested anchor: without it an empty body could
-    /// belong to a different cache key. Returned edges must all be incident to
-    /// that same anchor, otherwise the payload is internally inconsistent.
+    /// Every transport consumer should use this method. Empty responses must
+    /// echo the requested anchor; the sole compatibility exception is a
+    /// pre-authority v1 payload with non-empty typed edges, which is accepted
+    /// only when every edge is incident to the requested anchor and is forced
+    /// incomplete. Any unrelated edge is internally inconsistent.
     pub fn from_slice_for(
         bytes: &[u8],
         repo_id: &str,
         entity_id: &EntityId,
     ) -> Result<Self, SpineXrefDecodeError> {
-        let response = Self::from_slice(bytes)?;
+        let mut response = Self::from_slice(bytes)?;
         let anchor_matches = response
             .authority_anchor
             .as_ref()
             .is_some_and(|anchor| anchor.repo_id == repo_id && anchor.entity_id == *entity_id);
-        if !anchor_matches {
+        let legacy_incident_positive = response.authority_anchor.is_none()
+            && !response.edges.is_empty()
+            && !response.authority_complete;
+        if !anchor_matches && !legacy_incident_positive {
             return Err(SpineXrefDecodeError::InvalidAuthority(format!(
                 "xref response anchor does not match requested repository/entity {repo_id}/{entity_id}"
             )));
@@ -273,6 +286,13 @@ impl SpineXrefResponse {
             return Err(SpineXrefDecodeError::InvalidAuthority(format!(
                 "xref response contains an edge unrelated to requested repository/entity {repo_id}/{entity_id}"
             )));
+        }
+
+        // Pre-authority v1 payloads can still carry a useful typed positive.
+        // Preserve only non-empty incident edges and force them incomplete;
+        // an unanchored empty can never certify which query it answered.
+        if legacy_incident_positive {
+            response.authority_complete = false;
         }
 
         Ok(response)
@@ -354,6 +374,17 @@ struct SpineInner {
     /// Cross-repo edges (precomputed from import analysis).
     cross_repo_edges: Vec<CrossRepoEdge>,
 
+    /// Incident-edge index for bounded single-anchor xref reads. The full edge
+    /// vector remains the canonical bulk topology, while this projection lets
+    /// one entity query avoid cloning or scanning the entire organization.
+    cross_repo_edges_by_anchor: HashMap<(RepoId, EntityId), Vec<CrossRepoEdge>>,
+
+    /// Cached validation/revision metadata maintained on the write path. Xref
+    /// reads use these values under the same read lock as the incident-edge
+    /// projection, so certifying one anchor never requires a global edge scan.
+    edge_authority_is_closed: bool,
+    authority_revision: String,
+
     /// Graph root hash per repo (for cache coherence).
     root_hashes: HashMap<RepoId, String>,
 
@@ -369,6 +400,12 @@ struct SpineInner {
     /// Number of edge refreshes currently replacing a repo's outgoing set.
     /// A snapshot taken while this is non-zero is atomic but not complete.
     active_edge_refreshes: usize,
+
+    /// Epoch of the one all-repo refresh pass currently in flight. Per-source
+    /// refreshes may install topology during this lease, but they cannot clear
+    /// dirty authority or expose completeness; only the pass-wide final CAS can
+    /// publish the captured root set atomically.
+    active_full_refresh_epoch: Option<u64>,
 }
 
 struct EdgeRefreshGuard<'a> {
@@ -387,7 +424,10 @@ impl EdgeRefreshGuard<'_> {
 impl Drop for EdgeRefreshGuard<'_> {
     fn drop(&mut self) {
         let mut inner = self.index.inner.write();
-        if self.succeeded && inner.authority_epoch == self.authority_epoch {
+        if self.succeeded
+            && inner.authority_epoch == self.authority_epoch
+            && inner.active_full_refresh_epoch.is_none()
+        {
             inner.dirty_edge_repos.remove(&self.repo_id);
         }
         inner.active_edge_refreshes = inner
@@ -410,10 +450,14 @@ impl SpineIndex {
                 by_name: HashMap::new(),
                 by_id: HashMap::new(),
                 cross_repo_edges: Vec::new(),
+                cross_repo_edges_by_anchor: HashMap::new(),
+                edge_authority_is_closed: true,
+                authority_revision: cross_repo_snapshot_revision(&BTreeMap::new(), &[]),
                 root_hashes: HashMap::new(),
                 dirty_edge_repos: HashSet::new(),
                 authority_epoch: 0,
                 active_edge_refreshes: 0,
+                active_full_refresh_epoch: None,
             }),
             edge_refresh_serialization: Mutex::new(()),
         }
@@ -459,6 +503,62 @@ impl SpineIndex {
         // resolution. Adding or changing one target therefore invalidates every
         // registered source, not just the repo whose metadata changed.
         inner.dirty_edge_repos = inner.root_hashes.keys().cloned().collect();
+        Self::recompute_cross_repo_metadata(inner);
+    }
+
+    /// Rebuild the bounded xref projection and global authority metadata after
+    /// a topology/root mutation. This deliberately runs on the write path;
+    /// read-side single-anchor queries stay proportional to repo roots plus the
+    /// queried entity's incident edges.
+    fn recompute_cross_repo_metadata(inner: &mut SpineInner) {
+        let mut by_anchor = HashMap::<(RepoId, EntityId), Vec<CrossRepoEdge>>::new();
+        let mut closed = true;
+        for edge in &inner.cross_repo_edges {
+            closed &= inner.root_hashes.contains_key(&edge.src_repo)
+                && inner.root_hashes.contains_key(&edge.dst_repo)
+                && inner
+                    .by_id
+                    .contains_key(&(edge.src_repo.clone(), edge.src_entity))
+                && inner
+                    .by_id
+                    .contains_key(&(edge.dst_repo.clone(), edge.dst_entity));
+            by_anchor
+                .entry((edge.src_repo.clone(), edge.src_entity))
+                .or_default()
+                .push(edge.clone());
+            by_anchor
+                .entry((edge.dst_repo.clone(), edge.dst_entity))
+                .or_default()
+                .push(edge.clone());
+        }
+        for edges in by_anchor.values_mut() {
+            edges.sort_by(cross_repo_edge_order);
+            edges.dedup_by(|left, right| cross_repo_edge_identity_order(left, right).is_eq());
+        }
+
+        let roots = inner
+            .root_hashes
+            .iter()
+            .map(|(repo, root)| (repo.clone(), root.clone()))
+            .collect::<BTreeMap<_, _>>();
+        let mut canonical_edges = inner.cross_repo_edges.clone();
+        canonical_edges.sort_by(cross_repo_edge_order);
+        canonical_edges.dedup_by(|left, right| cross_repo_edge_identity_order(left, right).is_eq());
+
+        inner.cross_repo_edges_by_anchor = by_anchor;
+        inner.edge_authority_is_closed = closed;
+        inner.authority_revision = cross_repo_snapshot_revision(&roots, &canonical_edges);
+    }
+
+    fn authority_complete(inner: &SpineInner, roots: &BTreeMap<RepoId, String>) -> bool {
+        inner.active_edge_refreshes == 0
+            && inner.active_full_refresh_epoch.is_none()
+            && inner.dirty_edge_repos.is_empty()
+            && !roots.is_empty()
+            && roots
+                .values()
+                .all(|root| !root.is_empty() && root.trim() == root)
+            && inner.edge_authority_is_closed
     }
 
     /// Resolve an entity by name and kind across all repos.
@@ -538,23 +638,13 @@ impl SpineIndex {
     /// authority serialize to identical bytes. No projection or filesystem
     /// surface participates in this read.
     pub fn cross_repo_edges_snapshot(&self) -> CrossRepoEdgesSnapshot {
-        let (complete, roots, mut edges, mut entities, covered_entities) = {
+        let (complete, revision, roots, mut edges, mut entities, covered_entities) = {
             let inner = self.inner.read();
             let roots = inner
                 .root_hashes
                 .iter()
                 .map(|(repo, root)| (repo.clone(), root.clone()))
                 .collect::<BTreeMap<_, _>>();
-            let edge_authority_is_closed = inner.cross_repo_edges.iter().all(|edge| {
-                inner.root_hashes.contains_key(&edge.src_repo)
-                    && inner.root_hashes.contains_key(&edge.dst_repo)
-                    && inner
-                        .by_id
-                        .contains_key(&(edge.src_repo.clone(), edge.src_entity))
-                    && inner
-                        .by_id
-                        .contains_key(&(edge.dst_repo.clone(), edge.dst_entity))
-            });
             let entities = inner
                 .cross_repo_edges
                 .iter()
@@ -574,13 +664,8 @@ impl SpineIndex {
                     .insert(*entity_id);
             }
             (
-                inner.active_edge_refreshes == 0
-                    && inner.dirty_edge_repos.is_empty()
-                    && !roots.is_empty()
-                    && roots
-                        .values()
-                        .all(|root| !root.is_empty() && root.trim() == root)
-                    && edge_authority_is_closed,
+                Self::authority_complete(&inner, &roots),
+                inner.authority_revision.clone(),
                 roots,
                 inner.cross_repo_edges.clone(),
                 entities,
@@ -600,7 +685,6 @@ impl SpineIndex {
         });
 
         let repos = roots.keys().cloned().collect::<Vec<_>>();
-        let revision = cross_repo_snapshot_revision(&roots, &edges);
         CrossRepoEdgesSnapshot {
             complete,
             revision,
@@ -612,6 +696,57 @@ impl SpineIndex {
         }
     }
 
+    /// Atomically project one entity's xref response without cloning/scanning
+    /// the global edge and entity collections. Roots, completeness, incident
+    /// edges, endpoint metadata, and direct anchor coverage all come from one
+    /// read-lock acquisition.
+    pub fn cross_repo_xref_response(
+        &self,
+        repo_id: &str,
+        entity_id: &EntityId,
+    ) -> SpineXrefResponse {
+        let inner = self.inner.read();
+        let roots = inner
+            .root_hashes
+            .iter()
+            .map(|(repo, root)| (repo.clone(), root.clone()))
+            .collect::<BTreeMap<_, _>>();
+        let edges = inner
+            .cross_repo_edges_by_anchor
+            .get(&(repo_id.to_string(), *entity_id))
+            .cloned()
+            .unwrap_or_default();
+        let endpoint_keys = edges
+            .iter()
+            .flat_map(|edge| {
+                [
+                    (edge.src_repo.clone(), edge.src_entity),
+                    (edge.dst_repo.clone(), edge.dst_entity),
+                ]
+            })
+            .collect::<BTreeSet<_>>();
+        let entities = endpoint_keys
+            .into_iter()
+            .filter_map(|key| inner.by_id.get(&key).cloned())
+            .collect();
+        let anchor_covered = inner.by_id.contains_key(&(repo_id.to_string(), *entity_id));
+
+        SpineXrefResponse {
+            version: crate::SPINE_PAYLOAD_VERSION,
+            edges,
+            entities,
+            authority_anchor: Some(SpineXrefAuthorityAnchor {
+                repo_id: repo_id.to_string(),
+                entity_id: *entity_id,
+            }),
+            authority_complete: Self::authority_complete(&inner, &roots)
+                && roots.contains_key(repo_id)
+                && anchor_covered,
+            authority_revision: Some(inner.authority_revision.clone()),
+            authority_roots: roots,
+        }
+    }
+
     /// Add a cross-repo edge to the index.
     ///
     /// Returns `false` when the candidate does not cross a repository
@@ -619,12 +754,108 @@ impl SpineIndex {
     /// resolver bug or stale durable row from making an intra-repo reference
     /// look like hosted cross-repo proof.
     pub fn add_cross_repo_edge(&self, edge: CrossRepoEdge) -> bool {
-        if edge.src_repo == edge.dst_repo {
+        self.add_cross_repo_edges(std::iter::once(edge)) == 1
+    }
+
+    /// Install a batch of cross-repo edges with one metadata rebuild.
+    ///
+    /// Durable-cache hydration can contain thousands of rows. Recomputing the
+    /// global anchor projection and canonical revision after every row turns
+    /// that linear load into O(E^2 log E). This path validates every candidate
+    /// but defers the projection/revision rebuild until the full batch is in
+    /// memory. Incremental callers can continue using `add_cross_repo_edge`.
+    pub fn add_cross_repo_edges<I>(&self, edges: I) -> usize
+    where
+        I: IntoIterator<Item = CrossRepoEdge>,
+    {
+        let mut inner = self.inner.write();
+        let mut accepted = 0usize;
+        for edge in edges {
+            if edge.src_repo == edge.dst_repo {
+                continue;
+            }
+            inner.cross_repo_edges.push(edge);
+            accepted += 1;
+        }
+        if accepted == 0 {
+            return 0;
+        }
+        Self::recompute_cross_repo_metadata(&mut inner);
+        accepted
+    }
+
+    /// Mark one source repo's cross-repo materialization stale without
+    /// discarding its last known positive edges. The authority epoch bump also
+    /// prevents an older in-flight refresh from clearing this invalidation.
+    pub fn invalidate_cross_repo_edges(&self, repo_id: &str) {
+        let mut inner = self.inner.write();
+        inner.dirty_edge_repos.insert(repo_id.to_string());
+        inner.authority_epoch = inner
+            .authority_epoch
+            .checked_add(1)
+            .expect("spine authority epoch exhausted");
+    }
+
+    /// Start the one pass-wide cross-repo refresh lease.
+    ///
+    /// Returns `None` when another full pass is already active or the caller's
+    /// captured root set no longer matches registered spine authority. Either
+    /// failure leaves all registered sources dirty and therefore incomplete.
+    pub fn begin_cross_repo_refresh_pass(
+        &self,
+        authority_roots: &BTreeMap<RepoId, String>,
+    ) -> Option<u64> {
+        let mut inner = self.inner.write();
+        let registered_roots = inner
+            .root_hashes
+            .iter()
+            .map(|(repo, root)| (repo.clone(), root.clone()))
+            .collect::<BTreeMap<_, _>>();
+        if inner.active_full_refresh_epoch.is_some() || registered_roots != *authority_roots {
+            inner.dirty_edge_repos = inner.root_hashes.keys().cloned().collect();
+            return None;
+        }
+
+        inner.authority_epoch = inner
+            .authority_epoch
+            .checked_add(1)
+            .expect("spine authority epoch exhausted");
+        let token = inner.authority_epoch;
+        inner.active_full_refresh_epoch = Some(token);
+        inner.dirty_edge_repos = authority_roots.keys().cloned().collect();
+        Some(token)
+    }
+
+    /// Finish a full refresh and publish completeness with one authority CAS.
+    ///
+    /// The dirty set and pass lease are cleared under the same write lock only
+    /// when no registration/invalidation advanced the epoch and the registered
+    /// repo/root map still exactly equals the caller's captured authority.
+    pub fn finish_cross_repo_refresh_pass(
+        &self,
+        token: u64,
+        authority_roots: &BTreeMap<RepoId, String>,
+        success: bool,
+    ) -> bool {
+        let mut inner = self.inner.write();
+        if inner.active_full_refresh_epoch != Some(token) {
             return false;
         }
-        let mut inner = self.inner.write();
-        inner.cross_repo_edges.push(edge);
-        true
+
+        let registered_roots = inner
+            .root_hashes
+            .iter()
+            .map(|(repo, root)| (repo.clone(), root.clone()))
+            .collect::<BTreeMap<_, _>>();
+        let committed = success
+            && inner.authority_epoch == token
+            && registered_roots == *authority_roots
+            && inner.active_edge_refreshes == 0;
+        if committed {
+            inner.dirty_edge_repos.clear();
+        }
+        inner.active_full_refresh_epoch = None;
+        committed
     }
 
     /// Look up an entity by (repo_id, entity_id).
@@ -713,6 +944,7 @@ impl SpineIndex {
         let mut inner = self.inner.write();
         inner.cross_repo_edges.retain(|e| e.src_repo != repo_id);
         inner.cross_repo_edges.extend(replacement);
+        Self::recompute_cross_repo_metadata(&mut inner);
         drop(inner);
         refresh.mark_succeeded();
     }
@@ -907,8 +1139,18 @@ mod tests {
         assert!(decoded.authority_anchor.is_none());
         assert!(decoded.authority_revision.is_none());
         assert!(decoded.authority_roots.is_empty());
+        let bound = SpineXrefResponse::from_slice_for(&bytes, "provider", &dst).unwrap();
+        assert_eq!(bound.edges.len(), 1);
+        assert!(!bound.authority_complete);
+        assert!(bound.authority_anchor.is_none());
+
+        let empty_unanchored = serde_json::to_vec(&serde_json::json!({
+            "version": crate::SPINE_PAYLOAD_VERSION,
+            "edges": [],
+        }))
+        .unwrap();
         assert!(matches!(
-            SpineXrefResponse::from_slice_for(&bytes, "provider", &dst),
+            SpineXrefResponse::from_slice_for(&empty_unanchored, "provider", &dst),
             Err(SpineXrefDecodeError::InvalidAuthority(_))
         ));
     }
@@ -936,8 +1178,7 @@ mod tests {
             confidence: 0.9,
         });
 
-        let response =
-            SpineXrefResponse::from_snapshot(index.cross_repo_edges_snapshot(), "provider", &dst);
+        let response = index.cross_repo_xref_response("provider", &dst);
         assert!(response.authority_complete);
         assert!(response
             .authority_revision
@@ -964,15 +1205,10 @@ mod tests {
         assert!(decoded.authority_complete);
         assert_eq!(decoded.authority_revision, response.authority_revision);
 
-        let wrong_repo =
-            SpineXrefResponse::from_snapshot(index.cross_repo_edges_snapshot(), "unknown", &dst);
+        let wrong_repo = index.cross_repo_xref_response("unknown", &dst);
         assert!(!wrong_repo.authority_complete);
 
-        let covered_empty = SpineXrefResponse::from_snapshot(
-            index.cross_repo_edges_snapshot(),
-            "provider",
-            &no_refs,
-        );
+        let covered_empty = index.cross_repo_xref_response("provider", &no_refs);
         assert!(covered_empty.authority_complete);
         assert!(covered_empty.edges.is_empty());
         let covered_empty_bytes = serde_json::to_vec(&covered_empty).unwrap();
@@ -981,12 +1217,57 @@ mod tests {
             Err(SpineXrefDecodeError::InvalidAuthority(_))
         ));
 
-        let unknown_entity = SpineXrefResponse::from_snapshot(
-            index.cross_repo_edges_snapshot(),
-            "provider",
-            &EntityId::new(),
-        );
+        let unknown_entity = index.cross_repo_xref_response("provider", &EntityId::new());
         assert!(!unknown_entity.authority_complete);
+    }
+
+    #[test]
+    fn anchor_xref_projection_excludes_unrelated_topology() {
+        let index = SpineIndex::new();
+        let target = EntityId::new();
+        let caller = EntityId::new();
+        let unrelated_target = EntityId::new();
+        let unrelated_caller = EntityId::new();
+        index.register_repo(
+            "provider",
+            vec![
+                test_entry_with_id("provider", target, "target"),
+                test_entry_with_id("provider", unrelated_target, "other_target"),
+            ],
+            "provider-root",
+        );
+        index.register_repo(
+            "consumer",
+            vec![
+                test_entry_with_id("consumer", caller, "caller"),
+                test_entry_with_id("consumer", unrelated_caller, "other_caller"),
+            ],
+            "consumer-root",
+        );
+        let repos = vec!["consumer".to_string(), "provider".to_string()];
+        for repo in &repos {
+            index.refresh_cross_repo_edges(repo, &[], &[], &repos);
+        }
+        for (src_entity, dst_entity) in [(caller, target), (unrelated_caller, unrelated_target)] {
+            index.add_cross_repo_edge(CrossRepoEdge {
+                src_repo: "consumer".to_string(),
+                src_entity,
+                dst_repo: "provider".to_string(),
+                dst_entity,
+                confidence: 0.9,
+            });
+        }
+
+        let response = index.cross_repo_xref_response("provider", &target);
+        assert!(response.authority_complete);
+        assert_eq!(response.edges.len(), 1);
+        assert_eq!(response.edges[0].src_entity, caller);
+        assert_eq!(response.entities.len(), 2);
+        assert!(response
+            .entities
+            .iter()
+            .all(|entity| entity.entity_id != unrelated_caller
+                && entity.entity_id != unrelated_target));
     }
 
     #[test]
@@ -1201,6 +1482,47 @@ mod tests {
     }
 
     #[test]
+    fn bulk_edge_install_filters_invalid_rows_and_builds_anchor_projection() {
+        let index = SpineIndex::new();
+        let caller = test_entry("repo-a", "caller", EntityKind::Function);
+        let callee = test_entry("repo-b", "callee", EntityKind::Function);
+        index.register_repo("repo-a", vec![caller.clone()], "hash-a");
+        index.register_repo("repo-b", vec![callee.clone()], "hash-b");
+        let repos = vec!["repo-a".to_string(), "repo-b".to_string()];
+        for repo in &repos {
+            index.refresh_cross_repo_edges(repo, &[], &[], &repos);
+        }
+
+        let accepted = index.add_cross_repo_edges([
+            CrossRepoEdge {
+                src_repo: "repo-a".to_string(),
+                src_entity: caller.entity_id,
+                dst_repo: "repo-b".to_string(),
+                dst_entity: callee.entity_id,
+                confidence: 0.95,
+            },
+            CrossRepoEdge {
+                src_repo: "repo-a".to_string(),
+                src_entity: caller.entity_id,
+                dst_repo: "repo-a".to_string(),
+                dst_entity: caller.entity_id,
+                confidence: 0.5,
+            },
+        ]);
+
+        assert_eq!(accepted, 1);
+        assert_eq!(index.edge_count(), 1);
+        let response = index.cross_repo_xref_response("repo-b", &callee.entity_id);
+        assert_eq!(response.edges.len(), 1);
+        assert_eq!(response.edges[0].src_entity, caller.entity_id);
+        assert!(response.authority_complete_for("repo-b", &callee.entity_id));
+        assert!(response
+            .authority_revision
+            .as_deref()
+            .is_some_and(|revision| revision.starts_with("sha256:")));
+    }
+
+    #[test]
     fn rejects_intra_repo_edges_at_the_index_boundary() {
         let index = SpineIndex::new();
         let caller = test_entry("repo-a", "caller", EntityKind::Function);
@@ -1358,6 +1680,101 @@ mod tests {
             index.cross_repo_edges_snapshot().complete,
             "the snapshot becomes complete only after every dirty repo refreshes"
         );
+    }
+
+    #[test]
+    fn all_repo_pass_stays_incomplete_through_the_final_validation_window() {
+        let index = SpineIndex::new();
+        let repos = vec!["alpha".to_string(), "beta".to_string()];
+        index.register_repo("alpha", vec![], "root-a");
+        index.register_repo("beta", vec![], "root-b");
+        for repo in &repos {
+            index.refresh_cross_repo_edges(repo, &[], &[], &repos);
+        }
+        assert!(index.cross_repo_edges_snapshot().complete);
+
+        let roots = BTreeMap::from([
+            ("alpha".to_string(), "root-a".to_string()),
+            ("beta".to_string(), "root-b".to_string()),
+        ]);
+        let token = index
+            .begin_cross_repo_refresh_pass(&roots)
+            .expect("first full pass owns the lease");
+        assert!(
+            index.begin_cross_repo_refresh_pass(&roots).is_none(),
+            "a concurrent full pass must not overlap the active lease"
+        );
+
+        for repo in &repos {
+            index.refresh_cross_repo_edges(repo, &[], &[], &repos);
+        }
+        assert!(
+            !index.cross_repo_edges_snapshot().complete,
+            "the last source install must not expose completeness before final validation"
+        );
+
+        assert!(index.finish_cross_repo_refresh_pass(token, &roots, true));
+        assert!(index.cross_repo_edges_snapshot().complete);
+    }
+
+    #[test]
+    fn all_repo_pass_cannot_commit_after_concurrent_authority_change() {
+        let index = SpineIndex::new();
+        let repos = vec!["alpha".to_string(), "beta".to_string()];
+        index.register_repo("alpha", vec![], "root-a");
+        index.register_repo("beta", vec![], "root-b");
+        for repo in &repos {
+            index.refresh_cross_repo_edges(repo, &[], &[], &repos);
+        }
+
+        let roots = BTreeMap::from([
+            ("alpha".to_string(), "root-a".to_string()),
+            ("beta".to_string(), "root-b".to_string()),
+        ]);
+        let token = index.begin_cross_repo_refresh_pass(&roots).unwrap();
+        for repo in &repos {
+            index.refresh_cross_repo_edges(repo, &[], &[], &repos);
+        }
+        index.register_repo("beta", vec![], "root-b-next");
+
+        assert!(!index.finish_cross_repo_refresh_pass(token, &roots, true));
+        assert!(
+            !index.cross_repo_edges_snapshot().complete,
+            "a newer root registration must win the pass epoch CAS"
+        );
+    }
+
+    #[test]
+    fn explicit_refresh_invalidation_preserves_edges_but_revokes_completeness() {
+        let index = SpineIndex::new();
+        let source = test_entry("consumer", "caller", EntityKind::Function);
+        let target = test_entry("provider", "target", EntityKind::Function);
+        index.register_repo("consumer", vec![source.clone()], "consumer-root");
+        index.register_repo("provider", vec![target.clone()], "provider-root");
+        let repos = vec!["consumer".to_string(), "provider".to_string()];
+        for repo in &repos {
+            index.refresh_cross_repo_edges(repo, &[], &[], &repos);
+        }
+        index.add_cross_repo_edge(CrossRepoEdge {
+            src_repo: "consumer".to_string(),
+            src_entity: source.entity_id,
+            dst_repo: "provider".to_string(),
+            dst_entity: target.entity_id,
+            confidence: 0.9,
+        });
+        assert!(index.cross_repo_edges_snapshot().complete);
+
+        index.invalidate_cross_repo_edges("consumer");
+        let invalidated = index.cross_repo_xref_response("provider", &target.entity_id);
+        assert!(!invalidated.authority_complete);
+        assert_eq!(
+            invalidated.edges.len(),
+            1,
+            "known positives remain advisory"
+        );
+
+        index.refresh_cross_repo_edges("consumer", &[], &[], &repos);
+        assert!(index.cross_repo_edges_snapshot().complete);
     }
 
     #[test]

--- a/crates/kin-spine/src/index.rs
+++ b/crates/kin-spine/src/index.rs
@@ -46,6 +46,58 @@ pub struct CrossRepoEdge {
     pub confidence: f32,
 }
 
+/// Versioned wire response for `GET /v1/spine/xref`.
+///
+/// `edges` remains the canonical topology payload. `entities` is an additive,
+/// metadata-only sidecar that lets clients render useful cross-repo references
+/// without inventing field names or reading another repository's files. Older
+/// version-1 daemons omitted the sidecar, so it defaults to empty on decode.
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
+pub struct SpineXrefResponse {
+    version: u32,
+    pub edges: Vec<CrossRepoEdge>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub entities: Vec<EntityEntry>,
+}
+
+impl SpineXrefResponse {
+    pub fn new(edges: Vec<CrossRepoEdge>, entities: Vec<EntityEntry>) -> Self {
+        Self {
+            version: crate::SPINE_PAYLOAD_VERSION,
+            edges,
+            entities,
+        }
+    }
+
+    pub fn version(&self) -> u32 {
+        self.version
+    }
+
+    /// Decode and version-check an xref response as one shared contract.
+    ///
+    /// Callers must not index ad-hoc JSON fields: required topology fields and
+    /// entity IDs are validated by Serde, while an unsupported version fails
+    /// explicitly instead of degrading to an empty cross-repo result.
+    pub fn from_slice(bytes: &[u8]) -> Result<Self, SpineXrefDecodeError> {
+        let response: Self = serde_json::from_slice(bytes)?;
+        if response.version != crate::SPINE_PAYLOAD_VERSION {
+            return Err(SpineXrefDecodeError::UnsupportedVersion {
+                actual: response.version,
+                supported: crate::SPINE_PAYLOAD_VERSION,
+            });
+        }
+        Ok(response)
+    }
+}
+
+#[derive(Debug, thiserror::Error)]
+pub enum SpineXrefDecodeError {
+    #[error("malformed spine xref response: {0}")]
+    Malformed(#[from] serde_json::Error),
+    #[error("unsupported spine xref response version {actual}; supported version is {supported}")]
+    UnsupportedVersion { actual: u32, supported: u32 },
+}
+
 /// One atomic, graph-authoritative view of every cross-repo edge in the spine.
 ///
 /// `roots` is the graph-root watermark for the exact registered repo set and
@@ -569,6 +621,79 @@ mod tests {
         let mut entry = test_entry(repo, name, EntityKind::Function);
         entry.entity_id = id;
         entry
+    }
+
+    #[test]
+    fn xref_wire_response_round_trips_typed_edges_and_metadata() {
+        let src = EntityId::new();
+        let dst = EntityId::new();
+        let response = SpineXrefResponse::new(
+            vec![CrossRepoEdge {
+                src_repo: "consumer".to_string(),
+                src_entity: src,
+                dst_repo: "provider".to_string(),
+                dst_entity: dst,
+                confidence: 0.9,
+            }],
+            vec![test_entry_with_id("consumer", src, "run_task")],
+        );
+
+        let bytes = serde_json::to_vec(&response).unwrap();
+        let decoded = SpineXrefResponse::from_slice(&bytes).unwrap();
+        assert_eq!(decoded.version(), crate::SPINE_PAYLOAD_VERSION);
+        assert_eq!(decoded.edges.len(), 1);
+        assert_eq!(decoded.edges[0].src_repo, "consumer");
+        assert_eq!(decoded.entities.len(), 1);
+        assert_eq!(decoded.entities[0].name, "run_task");
+    }
+
+    #[test]
+    fn xref_wire_response_accepts_version_one_without_metadata_sidecar() {
+        let src = EntityId::new();
+        let dst = EntityId::new();
+        let bytes = serde_json::to_vec(&serde_json::json!({
+            "version": crate::SPINE_PAYLOAD_VERSION,
+            "edges": [{
+                "src_repo": "consumer",
+                "src_entity": src,
+                "dst_repo": "provider",
+                "dst_entity": dst,
+                "confidence": 0.9,
+            }],
+        }))
+        .unwrap();
+
+        let decoded = SpineXrefResponse::from_slice(&bytes).unwrap();
+        assert_eq!(decoded.edges.len(), 1);
+        assert!(decoded.entities.is_empty());
+    }
+
+    #[test]
+    fn xref_wire_response_rejects_legacy_field_names_and_versions() {
+        let legacy = serde_json::to_vec(&serde_json::json!({
+            "version": crate::SPINE_PAYLOAD_VERSION,
+            "edges": [{
+                "repo_id": "consumer",
+                "from_name": "run_task",
+                "to_repo_id": "provider",
+                "kind": "calls",
+            }],
+        }))
+        .unwrap();
+        assert!(matches!(
+            SpineXrefResponse::from_slice(&legacy),
+            Err(SpineXrefDecodeError::Malformed(_))
+        ));
+
+        let unsupported = serde_json::to_vec(&serde_json::json!({
+            "version": crate::SPINE_PAYLOAD_VERSION + 1,
+            "edges": [],
+        }))
+        .unwrap();
+        assert!(matches!(
+            SpineXrefResponse::from_slice(&unsupported),
+            Err(SpineXrefDecodeError::UnsupportedVersion { .. })
+        ));
     }
 
     fn test_entity(id: EntityId, name: &str) -> Entity {

--- a/crates/kin-spine/src/lib.rs
+++ b/crates/kin-spine/src/lib.rs
@@ -30,7 +30,10 @@ pub use federation::{federated_impact, FederatedEdge, FederatedImpact, Federated
 pub use firestore::FirestoreSpineBackend;
 #[cfg(feature = "firestore")]
 pub use firestore::FirestoreStore;
-pub use index::{CrossRepoEdge, CrossRepoEdgesSnapshot, EntityEntry, SpineIndex};
+pub use index::{
+    CrossRepoEdge, CrossRepoEdgesSnapshot, EntityEntry, SpineIndex, SpineXrefDecodeError,
+    SpineXrefResponse,
+};
 pub use query::{classify_spine_probe, SpineProbe, SpineQuery};
 pub use routing::{RepoEndpoint, RoutingTable};
 pub use store::{LoadedRepo, SpineStore};

--- a/crates/kin-spine/src/lib.rs
+++ b/crates/kin-spine/src/lib.rs
@@ -31,8 +31,8 @@ pub use firestore::FirestoreSpineBackend;
 #[cfg(feature = "firestore")]
 pub use firestore::FirestoreStore;
 pub use index::{
-    CrossRepoEdge, CrossRepoEdgesSnapshot, EntityEntry, SpineIndex, SpineXrefDecodeError,
-    SpineXrefResponse,
+    CrossRepoEdge, CrossRepoEdgesSnapshot, EntityEntry, SpineIndex, SpineXrefAuthorityAnchor,
+    SpineXrefDecodeError, SpineXrefResponse,
 };
 pub use query::{classify_spine_probe, SpineProbe, SpineQuery};
 pub use routing::{RepoEndpoint, RoutingTable};


### PR DESCRIPTION
## Summary

- replace ad-hoc MCP xref JSON parsing with the shared, version-checked SpineXrefResponse contract
- attach graph-owned entity metadata and exact repo authority to daemon, CLI, and MCP xref responses
- capture entities, relations, entries, and roots from one detached graph snapshot and fail closed across graph mutation or refresh races
- make spine initialization retryable, serialize the final OnceLock publication edge with writer announcement, and keep hosted Firestore topology advisory until shared authority is complete
- keep empty-reference negatives inconclusive whenever cross-repo authority, revision, roots, or requested relation subtype is incomplete

## Exact review and integration

- independently reviewed dirty diff: SHA-256 507f3538d50b7301fbb54e0569cd29da94f51ecb23103fcebc7b7bd64095124f; no P0-P2 findings
- integrated current green main a1468027 into exact head 0ea980aea6dc30171c5c1bd63913d44fa53f9b2c

## Verification on integrated head

- cargo test -p kin-spine --locked: 69 unit + 19 integration passed
- cargo test -p kin-mcp --locked: 215 passed
- cargo test -p kin-daemon --locked: 398 library + 3 binary + 3 chaos + 1 compatibility + 1 port passed
- CI-equivalent RUSTFLAGS=-D warnings cargo clippy --all-targets --all-features with the committed 45-lint allowlist
- RUSTFLAGS=-D warnings cargo build --all-targets --locked
- cargo fmt --all -- --check and git diff --check
- python3 scripts/verify-zero-file-search.py .
- bash scripts/check_runtime_boundaries.sh
- bash scripts/check_private_repo_coupling.sh

## Compatibility boundary

A v1 daemon that omits the new metadata sidecar remains accepted as incomplete advisory data. Malformed legacy keys and future unsupported payload versions become an explicit unavailable gap. Bundled daemon and MCP should be upgraded together; older MCP builds retain their prior parser behavior.

## Claims not being made

This PR does not itself publish Kin 0.3.0 or certify the investor proof cohort. Those gates remain downstream of merge, registry-only release verification, public artifact verification, and the fresh 0.3.0 seal.