### PR TITLE
Public-repo hygiene: comment refs, crate repository metadata, manifest posture

### DIFF
--- a/crates/kin-buildinfo/Cargo.toml
+++ b/crates/kin-buildinfo/Cargo.toml
@@ -7,6 +7,7 @@ version.workspace = true
 edition.workspace = true
 license.workspace = true
 description = "Embedded build provenance for Kin binaries"
+repository.workspace = true
 build = "build.rs"
 
 [dependencies]

--- a/crates/kin-cli/Cargo.toml
+++ b/crates/kin-cli/Cargo.toml
@@ -7,6 +7,7 @@ version.workspace = true
 edition.workspace = true
 license.workspace = true
 description = "CLI for Kin semantic VCS"
+repository.workspace = true
 
 [features]
 default = ["vector", "embeddings", "metal"]

--- a/crates/kin-cli/src/commands/bench.rs
+++ b/crates/kin-cli/src/commands/bench.rs
@@ -5,12 +5,14 @@ use std::env;
 use std::path::PathBuf;
 use std::process::{exit, Command};
 
+use kin_mcp::handlers::bench::BENCHMARK_BOUNDARY_NOTICE;
+
 /// Proxy `kin bench` to external benchmark binaries.
 ///
 /// - `kin bench prep ...` → dispatches to `kin-bench-prep`
 /// - `kin bench ...`      → dispatches to `kin-bench`
 ///
-/// Each binary is optional. If not found, install instructions are shown.
+/// Each binary is optional. If not found, its distribution boundary is shown.
 pub fn bench_proxy(args: &[String]) -> ! {
     match args.first().map(|a| a.as_str()) {
         Some("prep") => dispatch("kin-bench-prep", &args[1..]),
@@ -49,17 +51,20 @@ fn dispatch(bin_name: &str, args: &[String]) -> ! {
             }
         }
         None => {
-            eprintln!("{bin_name} is not installed.");
-            eprintln!();
-            eprintln!("Install it:");
-            eprintln!();
-            eprintln!("  cd kin-bench && cargo build --release -p {bin_name}");
-            eprintln!("  cp target/release/{bin_name} ~/.kin/bin/");
-            eprintln!();
-            eprintln!("Once installed, `kin bench` will find it automatically.");
+            eprint!("{}", missing_binary_guidance(bin_name));
             exit(1);
         }
     }
+}
+
+fn missing_binary_guidance(bin_name: &str) -> String {
+    format!(
+        "{bin_name} is not installed.\n\n\
+         {BENCHMARK_BOUNDARY_NOTICE}\n\n\
+         Authorized internal operators can place `{bin_name}` on PATH or in `~/.kin/bin/`. \
+         This command provides no public clone or install path. Treat only separately published, \
+         versioned proof artifacts as independently reproducible evidence.\n"
+    )
 }
 
 fn find_bin(name: &str) -> Option<PathBuf> {
@@ -91,4 +96,34 @@ fn find_bin(name: &str) -> Option<PathBuf> {
                 Some(PathBuf::from(p))
             }
         })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn missing_binary_guidance_preserves_private_harness_boundary() {
+        let guidance = missing_binary_guidance("kin-bench-eval");
+
+        for required in [
+            "kin-bench-eval is not installed",
+            BENCHMARK_BOUNDARY_NOTICE,
+            "Authorized internal operators",
+            "on PATH or in `~/.kin/bin/`",
+            "no public clone or install path",
+            "separately published, versioned proof artifacts",
+        ] {
+            assert!(
+                guidance.contains(required),
+                "missing boundary text: {required}"
+            );
+        }
+        for forbidden in ["github.com/", "cargo install", "cd "] {
+            assert!(
+                !guidance.contains(forbidden),
+                "public CLI exposes private install guidance: {forbidden}"
+            );
+        }
+    }
 }

--- a/crates/kin-cli/src/commands/init.rs
+++ b/crates/kin-cli/src/commands/init.rs
@@ -6496,10 +6496,10 @@ func prCheckout(cmd *cobra.Command, args []string) error {
 
     #[test]
     fn base_link_anchor_surfaces_untouched_consumer_edge_at_historical_head() {
-        // End-to-end proof of FIR-1267 Fix D: a consumer living in a file NEVER
+        // End-to-end proof that a consumer living in a file NEVER
         // touched inside a truncated import window must still yield a committed
         // inbound relation delta that ref-scoped replay surfaces at a historical
-        // head. Pre-Fix-D the window base linked against a touched-files-only
+        // head. Previously the window base linked against a touched-files-only
         // universe, so the consumer edge existed ONLY in live adjacency and the
         // genesis auto-parse change — both siblings of the historical chain — and
         // blast radius at a historical ref replayed as 0.
@@ -6639,7 +6639,7 @@ func prCheckout(cmd *cobra.Command, args []string) error {
 
     #[test]
     fn base_link_cpp_receiver_method_edge_survives_at_historical_head() {
-        // Regression guard for the FIR-1267 (c2) parity fix. A C++ receiver-method
+        // Regression guard for the incremental-linker parity fix. A C++ receiver-method
         // call `w.work()` resolves to a `Type::method` (`Widget::work`) only through
         // the linker's bare-name index. The batch resolver has always had that
         // index; the incremental linker did not, so a base-link built as a

--- a/crates/kin-cli/tests/call_shape_rename_e2e.rs
+++ b/crates/kin-cli/tests/call_shape_rename_e2e.rs
@@ -17,7 +17,7 @@
 //!
 //! Both gate channels are exercised: the inline `signature_change`/`Breaking`
 //! channel (`collect_inline_comments`) AND the SHADOW `downstream_risk` channel
-//! (`derive_shadow_policy`). FIR-1440 shipped because only the inline channel had
+//! (`derive_shadow_policy`). This gap shipped because only the inline channel had
 //! e2e coverage — the shadow gate, which is the real merge-trust verdict,
 //! re-blocked the positional-safe rename with no test to catch it.
 
@@ -207,7 +207,7 @@ fn link_and_review(
 }
 
 /// Drive the SHADOW gate (the `downstream_risk` channel) over the same real
-/// mini-graph. This is the merge-trust verdict the shipped FIR-1440 bug slipped
+/// mini-graph. This is the merge-trust verdict the shipped bug slipped
 /// through: the inline-only assertions above never exercised it. Builds a
 /// `Review` from the real diff + impact + inline comments — reproducing the
 /// exact production seam — and returns the gate verdict with the graph inputs
@@ -848,7 +848,7 @@ fn e2e_review_output_is_deterministic() {
 
 #[test]
 fn e2e_shadow_gate_positional_rename_needs_attention_not_would_block() {
-    // FIR-1440, the shipped blind spot: the inline assertions above pass for this
+    // The shipped blind spot: the inline assertions above pass for this
     // rename, but the real merge-trust verdict is the SHADOW gate. Pre-fix the
     // shadow `downstream_risk` channel re-blocked the positional-safe rename
     // (WouldBlock); post-fix it demotes to attention, matching the inline channel.
@@ -868,7 +868,7 @@ fn e2e_shadow_gate_positional_rename_needs_attention_not_would_block() {
 #[test]
 fn e2e_shadow_gate_keyword_caller_rename_would_block() {
     // A caller names the renamed parameter -> the rename strands it -> the shadow
-    // gate must still block (no over-suppression from the FIR-1440 fix).
+    // gate must still block (no over-suppression from the fix).
     let verdict = link_and_shadow_verdict(
         KEYWORD_CALLER,
         "def target(ext, args)",

--- a/crates/kin-cli/tests/history_blame_hydration.rs
+++ b/crates/kin-cli/tests/history_blame_hydration.rs
@@ -1,8 +1,8 @@
 // SPDX-License-Identifier: Apache-2.0
 // Copyright 2026 Firelock, LLC
 
-//! End-to-end proof that `history` and `blame` report ref hydration honestly
-//! (FIR-1431). Resolving either command at an unimported Git ref lazily walks
+//! End-to-end proof that `history` and `blame` report ref hydration honestly.
+//! Resolving either command at an unimported Git ref lazily walks
 //! and imports that ref's ancestry into the graph. That import must surface as
 //! a truthful `hydrated_changes` count — a cold multi-change import and a warm
 //! no-op are not the same event — instead of the old swallowed boolean. This

--- a/crates/kin-cli/tests/review_shadow_json.rs
+++ b/crates/kin-cli/tests/review_shadow_json.rs
@@ -647,7 +647,7 @@ fn setup_generated_consumer_repo(repo: &Path) -> (String, String) {
     (base, head)
 }
 
-/// FIR-1267 (687 false would_block), end-to-end: a signature change whose only
+/// End-to-end: a signature change whose only
 /// cross-file consumer is a generated single-header copy must not raise a
 /// blocking breaking finding. This exercises the same `Generated`-consumer
 /// exclusion through the full CLI + graph gate that

--- a/crates/kin-context/Cargo.toml
+++ b/crates/kin-context/Cargo.toml
@@ -7,6 +7,7 @@ version.workspace = true
 edition.workspace = true
 license.workspace = true
 description = "Token-budgeted context pack builder for Kin"
+repository.workspace = true
 
 [dependencies]
 kin-model = { workspace = true }

--- a/crates/kin-core/Cargo.toml
+++ b/crates/kin-core/Cargo.toml
@@ -7,6 +7,7 @@ version.workspace = true
 edition.workspace = true
 license.workspace = true
 description = "Shared runtime, config, and initialization for Kin"
+repository.workspace = true
 
 [lib]
 doctest = false

--- a/crates/kin-core/src/ref_view.rs
+++ b/crates/kin-core/src/ref_view.rs
@@ -2357,7 +2357,7 @@ def uri_encoder(value):\n    return value.replace(' ', '%20')\n",
         }
     }
 
-    /// FIR-1267 (687 false would_block): the historical-ref reconstruction
+    /// The historical-ref reconstruction
     /// replays persisted entities verbatim and is the only stage that
     /// re-canonicalizes their paths, so it must also re-derive `role`. A
     /// single-header amalgamated copy persisted before the `single_include/`
@@ -2402,7 +2402,7 @@ def uri_encoder(value):\n    return value.replace(' ', '%20')\n",
             EntityRole::Generated,
             "a single_include/ amalgamated copy persisted as Source must be re-derived to \
              Generated during historical-ref reconstruction so impact.rs excludes it from \
-             consumer_count (the FIR-1267 687 divergence)"
+             consumer_count"
         );
         assert_eq!(
             snapshot.entities[&real_source_id].role,

--- a/crates/kin-daemon/Cargo.toml
+++ b/crates/kin-daemon/Cargo.toml
@@ -7,6 +7,7 @@ version.workspace = true
 edition.workspace = true
 license.workspace = true
 description = "Background daemon service for Kin"
+repository.workspace = true
 
 [lib]
 doctest = false

--- a/crates/kin-daemon/src/api.rs
+++ b/crates/kin-daemon/src/api.rs
@@ -14154,7 +14154,7 @@ mod tests {
     /// The daemon's /spine endpoints serve a TRANSITIVE (2-hop) blast radius and
     /// MULTI-CONSUMER edges through the production refresh path: provider <-
     /// consumer <- downstream, plus a second consumer of provider. This is the
-    /// FIR-1149 transitive/multi-consumer gate on top of the 1-hop fixture; it
+    /// transitive/multi-consumer gate on top of the 1-hop fixture; it
     /// depends on refresh registering each repo's own entities so the next hop
     /// can resolve them.
     #[tokio::test]
@@ -15921,7 +15921,7 @@ mod tests {
         assert_eq!(result.is_error, Some(true));
     }
 
-    // FIR-1180 schema parity: the fused MCP payload IS the `LocateResult` schema
+    // Schema parity: the fused MCP payload IS the `LocateResult` schema
     // `kin locate --json` serializes — it deserializes straight back into the
     // shared type, so a consumer needs one parser across surfaces.
     #[tokio::test]
@@ -15992,7 +15992,7 @@ mod tests {
         );
     }
 
-    // FIR-1232 paging symmetry: the fused arm consumes `page_size`/`cursor` and
+    // Paging symmetry: the fused arm consumes `page_size`/`cursor` and
     // emits `total_ranked`/`page`/`next_cursor` over the graph-native entity
     // ranking, exactly like the cosine arm and `POST /locate`. The cursor is
     // stable — re-issuing it returns the identical next page from cache.
@@ -16074,7 +16074,7 @@ mod tests {
         );
     }
 
-    // FIR-1180: the fused arm's extra top-level fields survive the switch to the
+    // The fused arm's extra top-level fields survive the switch to the
     // shared schema — routing distinguishes the pipeline, and the structured
     // coverage/degradations contract rides alongside the LocateResult body.
     #[tokio::test]

--- a/crates/kin-git/Cargo.toml
+++ b/crates/kin-git/Cargo.toml
@@ -7,6 +7,7 @@ version.workspace = true
 edition.workspace = true
 license.workspace = true
 description = "Legacy Git adapter for Kin: import/export/sync"
+repository.workspace = true
 
 [dependencies]
 kin-model = { workspace = true }

--- a/crates/kin-index/Cargo.toml
+++ b/crates/kin-index/Cargo.toml
@@ -7,6 +7,7 @@ version.workspace = true
 edition.workspace = true
 license.workspace = true
 description = "Graph build and update pipeline for Kin"
+repository.workspace = true
 
 [dependencies]
 kin-model = { workspace = true }

--- a/crates/kin-index/src/fingerprint.rs
+++ b/crates/kin-index/src/fingerprint.rs
@@ -1220,9 +1220,9 @@ mod equivalence_tests {
         );
     }
 
-    // ---- Protected true positives (FIR-1306 shapes) stay non-equivalent -----
+    // ---- Protected true positives stay non-equivalent -----
 
-    /// FIR-1306 origin shape (cli b9cacbc347): adding a narrowing conjunct to a
+    /// Adding a narrowing conjunct to a
     /// predicate is a real domain change and must stay non-equivalent.
     #[test]
     fn python_added_narrowing_conjunct_is_not_equivalent() {

--- a/crates/kin-index/tests/behavior_equivalence_ingest.rs
+++ b/crates/kin-index/tests/behavior_equivalence_ingest.rs
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 // Copyright 2026 Firelock, LLC
 
-//! End-to-end ingest proof for the behavior-equivalence class (FIR-1435).
+//! End-to-end ingest proof for the behavior-equivalence class.
 //!
 //! Drives the real indexing pipeline (parse -> extract -> attach) and asserts
 //! that the graph-owned `SemanticFingerprint.equivalence_hash` is docstring-

--- a/crates/kin-index/tests/language_matrix_linker.rs
+++ b/crates/kin-index/tests/language_matrix_linker.rs
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 // Copyright 2026 Firelock, LLC
 
-//! Cross-file linker arm of the language matrix (FIR-1313).
+//! Cross-file linker arm of the language matrix.
 //!
 //! The parser adapters narrow callees to simple names; this file drives the
 //! real linker (`link_cross_file`) to prove those names resolve across files and

--- a/crates/kin-index/tests/python_call_resolution.rs
+++ b/crates/kin-index/tests/python_call_resolution.rs
@@ -138,7 +138,7 @@ fn call_confidence(relations: &[kin_model::Relation], src: EntityId, dst: Entity
 
 #[test]
 fn inherited_self_call_resolves_to_base_method_cross_file() {
-    // The FIR-1342 / django 0f169098ef shape: Command(BaseCommand) calls
+    // The Django inherited-self-call shape: Command(BaseCommand) calls
     // self.validate(), and validate is defined only on the base class in
     // another file. The edge must exist AND carry verdict-driving confidence
     // (>= 0.6, the review-side strong-consumer floor) — a weak fan-out edge

--- a/crates/kin-mcp/Cargo.toml
+++ b/crates/kin-mcp/Cargo.toml
@@ -7,6 +7,7 @@ version.workspace = true
 edition.workspace = true
 license.workspace = true
 description = "MCP server for Kin: assistant-neutral integration"
+repository.workspace = true
 
 [dependencies]
 kin-core = { workspace = true }

--- a/crates/kin-mcp/src/handlers/bench.rs
+++ b/crates/kin-mcp/src/handlers/bench.rs
@@ -8,21 +8,53 @@ use kin_model::graph::GraphStore;
 use crate::error::Result;
 use crate::types::ToolCallResult;
 
+pub const BENCHMARK_BOUNDARY_NOTICE: &str = "Kin's benchmark and proof-packaging harness is a \
+private Firelock operator surface and is not distributed with the OSS Kin release.";
+
 pub const BENCHMARK_DESC: &str = "\
-Report on Kin's benchmark results and metrics. The benchmark engine now lives in the \
-standalone `kin-bench` binary, so this tool returns pointers on how to install and run \
-it (e.g. `kin bench <subcommand>`) rather than computing metrics in-process. Reach for \
-it when you want to know where Kin's velocity/reliability/economic measurements come \
-from or how to reproduce them.";
+Describe Kin's benchmark availability and evidence boundary. The benchmark and proof-packaging \
+harness is a private Firelock operator surface and is not distributed with the OSS Kin release. \
+This tool reports that boundary rather than private metrics or install instructions. Reach for \
+it to distinguish separately published proof artifacts from unpublished internal measurements.";
 
 pub fn handle_benchmark<G: GraphStore>(
     _args: &HashMap<String, serde_json::Value>,
     _store: &G,
 ) -> Result<ToolCallResult> {
-    Ok(ToolCallResult::text(
-        "The benchmark engine has moved to the standalone `kin-bench` binary.\n\n\
-         Install it with:\n  \
-         cargo install --git https://github.com/firelock-ai/kin-bench kin-bench-cli\n\n\
-         Then run: kin bench <subcommand>",
-    ))
+    Ok(ToolCallResult::text(format!(
+        "{BENCHMARK_BOUNDARY_NOTICE}\n\n\
+         Authorized internal operators who already have the harness binaries installed can run \
+         `kin bench <subcommand>`. This public tool provides no clone or install path. Treat only \
+         separately published, versioned proof artifacts as independently reproducible evidence."
+    )))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::types::ContentBlock;
+    use kin_db::InMemoryGraph;
+
+    #[test]
+    fn benchmark_tool_preserves_private_harness_boundary() {
+        let result = handle_benchmark(&HashMap::new(), &InMemoryGraph::new()).unwrap();
+        let ContentBlock::Text { text } = &result.content[0];
+
+        for required in [
+            BENCHMARK_BOUNDARY_NOTICE,
+            "Authorized internal operators",
+            "no clone or install path",
+            "separately published, versioned proof artifacts",
+        ] {
+            assert!(text.contains(required), "missing boundary text: {required}");
+        }
+        for forbidden in ["github.com/", "cargo install", "cd "] {
+            assert!(
+                !text.contains(forbidden) && !BENCHMARK_DESC.contains(forbidden),
+                "public benchmark surface exposes private install guidance: {forbidden}"
+            );
+        }
+        assert!(BENCHMARK_DESC.contains("private Firelock operator surface"));
+        assert!(BENCHMARK_DESC.contains("not distributed with the OSS Kin release"));
+    }
 }

--- a/crates/kin-migrate/Cargo.toml
+++ b/crates/kin-migrate/Cargo.toml
@@ -7,6 +7,7 @@ version.workspace = true
 edition.workspace = true
 license.workspace = true
 description = "Git forge migration pipeline for Kin (GitHub, GitLab, Bitbucket)"
+repository.workspace = true
 
 [dependencies]
 kin-model = { workspace = true }

--- a/crates/kin-parser/Cargo.toml
+++ b/crates/kin-parser/Cargo.toml
@@ -7,6 +7,7 @@ version.workspace = true
 edition.workspace = true
 license.workspace = true
 description = "Tree-sitter parsing and language adapters for Kin"
+repository.workspace = true
 
 [dependencies]
 kin-model = { workspace = true }

--- a/crates/kin-parser/tests/fingerprint_semantics.rs
+++ b/crates/kin-parser/tests/fingerprint_semantics.rs
@@ -232,7 +232,7 @@ public:
 }
 
 // ---------------------------------------------------------------------------
-// Cosmetic-stability matrix (FIR-1313): extend the comment-only + whitespace-
+// Cosmetic-stability matrix: extend the comment-only + whitespace-
 // only invariant to every full-adapter language not covered above. Go, C++,
 // Rust, and Python are already exercised earlier in this file; the block below
 // adds TypeScript, JavaScript, Java, C, C#, Ruby, PHP, Kotlin, and Swift. All

--- a/crates/kin-parser/tests/language_matrix_calls.rs
+++ b/crates/kin-parser/tests/language_matrix_calls.rs
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 // Copyright 2026 Firelock, LLC
 
-//! Per-language call-relation matrix (FIR-1313).
+//! Per-language call-relation matrix.
 //!
 //! Three probes per language: (1) a plain same-file call emits a `Calls` edge
 //! whose `dst_name` is a simple, index-matchable identifier; (2) a method call

--- a/crates/kin-parser/tests/language_matrix_entities.rs
+++ b/crates/kin-parser/tests/language_matrix_entities.rs
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 // Copyright 2026 Firelock, LLC
 
-//! Per-language entity-extraction matrix (FIR-1313).
+//! Per-language entity-extraction matrix.
 //!
 //! For every language with a full adapter, asserts that functions, methods, and
 //! classes/types are extracted with non-empty canonical signatures, and that a

--- a/crates/kin-parser/tests/language_matrix_imports.rs
+++ b/crates/kin-parser/tests/language_matrix_imports.rs
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 // Copyright 2026 Firelock, LLC
 
-//! Per-language import/module-edge matrix (FIR-1313).
+//! Per-language import/module-edge matrix.
 //!
 //! Every language with a full adapter must turn an import/use/require/include
 //! statement into a `FileImport` the cross-file linker can key on. All 13

--- a/crates/kin-projection/Cargo.toml
+++ b/crates/kin-projection/Cargo.toml
@@ -7,6 +7,7 @@ version.workspace = true
 edition.workspace = true
 license.workspace = true
 description = "File/doc projection engine for Kin"
+repository.workspace = true
 
 [dependencies]
 kin-model = { workspace = true }

--- a/crates/kin-reconcile/Cargo.toml
+++ b/crates/kin-reconcile/Cargo.toml
@@ -7,6 +7,7 @@ version.workspace = true
 edition.workspace = true
 license.workspace = true
 description = "Kubernetes-style reconciliation loop for Kin"
+repository.workspace = true
 
 [dependencies]
 kin-model = { workspace = true }

--- a/crates/kin-registry/Cargo.toml
+++ b/crates/kin-registry/Cargo.toml
@@ -7,6 +7,7 @@ version.workspace = true
 edition.workspace = true
 license.workspace = true
 description = "Package registry for Kin: Cargo sparse protocol and multi-ecosystem support"
+repository.workspace = true
 
 [dependencies]
 kin-blobs = { workspace = true }

--- a/crates/kin-review/Cargo.toml
+++ b/crates/kin-review/Cargo.toml
@@ -7,6 +7,7 @@ version.workspace = true
 edition.workspace = true
 license.workspace = true
 description = "Semantic review engine for Kin"
+repository.workspace = true
 
 [dependencies]
 kin-model = { workspace = true }

--- a/crates/kin-review/src/impact.rs
+++ b/crates/kin-review/src/impact.rs
@@ -1047,7 +1047,7 @@ mod tests {
 
     #[test]
     fn stale_source_amalgamated_consumer_excluded_from_consumer_count_by_path() {
-        // FIR-1267 (687 false would_block): the review evaluates a graph
+        // The review evaluates a graph
         // materialized by resolve_graph_at, which replays persisted entities
         // verbatim and never reparses. A single-header amalgamated copy ingested
         // before the single_include/ rule landed replays with a stale

--- a/crates/kin-runtime/Cargo.toml
+++ b/crates/kin-runtime/Cargo.toml
@@ -7,6 +7,7 @@ version.workspace = true
 edition.workspace = true
 license.workspace = true
 description = "Workspace runs, validation, and evidence capture for Kin"
+repository.workspace = true
 
 [dependencies]
 kin-model = { workspace = true }

--- a/crates/kin-semantic-contracts/Cargo.toml
+++ b/crates/kin-semantic-contracts/Cargo.toml
@@ -7,6 +7,7 @@ version.workspace = true
 edition.workspace = true
 license.workspace = true
 description = "Semantic contract discovery and cross-language linking for Kin"
+repository.workspace = true
 
 [dependencies]
 kin-model = { workspace = true }

--- a/crates/kin-spine/Cargo.toml
+++ b/crates/kin-spine/Cargo.toml
@@ -7,6 +7,7 @@ version.workspace = true
 edition.workspace = true
 license.workspace = true
 description = "Federation spine: cross-repo metadata index and query routing"
+repository.workspace = true
 
 [lib]
 doctest = false

--- a/docs/ecosystem-manifest.json
+++ b/docs/ecosystem-manifest.json
@@ -147,12 +147,13 @@
     },
     {
       "name": "kin-bench",
-      "layer": "support",
+      "layer": "proprietary",
       "role": "proof-and-evidence",
       "dependsOn": [
         "kin",
         "kin-db"
-      ]
+      ],
+      "note": "Private benchmarking and proof-packaging harness. Kept private/trade-secret per IP strategy — not one of the open supporting repos."
     },
     {
       "name": "kin-lsp",

--- a/tests/integration/Cargo.toml
+++ b/tests/integration/Cargo.toml
@@ -7,6 +7,7 @@ version.workspace = true
 edition.workspace = true
 license.workspace = true
 description = "End-to-end acceptance tests for Kin"
+repository.workspace = true
 publish = false
 
 [dependencies]


### PR DESCRIPTION
## Summary

Public-repo hygiene across four focused changes:

1. Source-comment tracker refs — durable technical wording with internal tracker references removed; no runtime behavior change.
2. Workspace member repository metadata — every member inheriting the workspace license now also inherits the canonical repository URL.
3. Benchmark distribution boundary — the public CLI and MCP surfaces now state that the benchmark/proof-packaging harness is a private operator surface and expose no private clone or install path.
4. Ecosystem manifest posture — kin-bench is classified as proprietary/private rather than an open supporting repository.

The exact diff is 36 files, 134 additions, and 48 deletions.

## Validation

- Fresh base: main at 83156f4b0fa3e397bd628557d72b4f69b580a3f4
- Exact head: ee71a8ebbd0f7d07b8d66405bfeccb9f3921317c
- cargo fmt --all -- --check
- jq validation of docs/ecosystem-manifest.json
- cargo metadata --locked --no-deps, including canonical repository metadata for every local package
- kin-mcp benchmark boundary unit test
- kin-cli missing-binary boundary unit test
- git diff --check
- Fresh hosted CI is required before merge

A transient crates.io HTTP/2 error occurred while installing cargo-fuzz on the first parse_adapter attempt; the exact failed job was rerun without source changes and passed.