### PR TITLE
Harden exact-source release authority for Kin 0.3.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -137,6 +137,7 @@ jobs:
         shell: bash
         run: |
           set -euo pipefail
+          export RUST_BACKTRACE=1
           cargo test --locked --target x86_64-pc-windows-msvc \
             -p kin-registry --lib
           cargo test --locked --target x86_64-pc-windows-msvc \
@@ -149,6 +150,11 @@ jobs:
             -maxdepth 1 -type f -name 'kin_cli-*.exe' -print -quit)
           test -n "$test_binary"
           "$test_binary" windows --test-threads=1
+          cargo test --locked --target x86_64-pc-windows-msvc \
+            -p kin-core --lib current_branch_write_replaces_existing_head -- \
+            --test-threads=1
+          cargo test --locked --target x86_64-pc-windows-msvc \
+            -p kin-core --lib branch_transaction -- --test-threads=1
 
       - name: Build Windows release binaries without vector features
         shell: bash

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,60 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.3.0] - 2026-07-22
+
+This release makes exact source state part of Kin's graph authority and tightens
+the release boundary around that state.
+
+### Added
+
+- Exact source archives preserve regular files, executable files, symbolic-link
+  target bytes, and truncated Git-history parent boundaries. Git export and
+  supported-platform checkout can reconstruct that graph-owned tree without
+  consulting raw files; platforms without safe symbolic-link publication reject
+  those checkout entries during preflight rather than partially materializing.
+- Semantic change IDs bind the complete normalized entity, relation, and
+  artifact payload. An existing ID with a different payload is rejected instead
+  of being treated as the same immutable change.
+
+### Changed
+
+- Branch-head mutation is now an API v2 operation. Clients must send
+  `{ "head": "<change-id>", "expected_head": "<current-change-id>" }` to
+  `PUT /v2/graph/branches/{name}/head`; the former v1 mutation endpoint returns
+  `410 Gone` instead of accepting an update without compare-and-swap.
+- Native semantic changes now derive their ID from the complete immutable
+  record (all parents, timestamp, author, message, deltas, provenance, risk,
+  and authored branch). Independent deltas remain order-canonical, while
+  overlapping replay targets bind their order because replay is order-sensitive.
+- Checkout preflights the complete graph-resolved source tree and its blobs
+  before mutating the projection. Release commits are graph-only markers whose
+  proof and approval policy is evaluated against the marker's immutable source
+  parent on both the initial request and every exact identical retry. Because
+  verification runs do not yet bind an immutable source change, source-bound
+  coverage is 0% for every non-empty source and strict proof fails closed; the
+  approval option requires known-human approval for every reachable non-root
+  change.
+- The external graph boundary now resolves exactly `kin-model` 0.4.0,
+  `kin-lsp` 0.4.0, and `kin-db` 0.3.1; local workspace crates and all three npm
+  release manifests advance together to 0.3.0.
+
+### Fixed
+
+- Daemon graph commits and branch-head updates enforce compare-and-swap against
+  the live branch head, reject stale or malformed release requests before graph
+  mutation, and keep exact identical retries idempotent.
+- CLI release admission and the MCP graph-only advisory use the same immutable
+  source coverage semantics and full reachable-history approval policy. Missing
+  referenced changes fail closed. The MCP result is explicitly advisory because
+  only daemon admission verifies source-object availability and the final CAS.
+- Session workspace paths are contained: session workspace path traversal and
+  symlinked session workspaces are rejected so a session cannot resolve or
+  operate outside its workspace root.
+- Git export updates each ref under a lock-first compare-and-swap using Git's
+  atomic ref update, so a concurrent writer cannot lose or overwrite a ref
+  update during export.
+
 ## [0.2.28] - 2026-07-20
 
 ### Fixed
@@ -701,7 +755,8 @@ Historical note: this snapshot predates the public GitHub prerelease series and 
 - Daemon mode for background file watching (`kin-daemon`)
 - 19-crate workspace architecture
 
-[unreleased]: https://github.com/firelock-ai/kin/compare/v0.2.28...HEAD
+[unreleased]: https://github.com/firelock-ai/kin/compare/v0.3.0...HEAD
+[0.3.0]: https://github.com/firelock-ai/kin/compare/v0.2.28...v0.3.0
 [0.2.28]: https://github.com/firelock-ai/kin/compare/v0.2.27...v0.2.28
 [0.2.27]: https://github.com/firelock-ai/kin/compare/v0.2.26...v0.2.27
 [0.2.26]: https://github.com/firelock-ai/kin/compare/v0.2.25...v0.2.26

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -141,7 +141,7 @@ version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -152,7 +152,7 @@ checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -433,7 +433,7 @@ dependencies = [
  "cap-primitives",
  "cap-std",
  "io-lifetimes 3.0.1",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -450,7 +450,7 @@ dependencies = [
  "maybe-owned",
  "rustix",
  "rustix-linux-procfs",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
  "winx",
 ]
 
@@ -1115,7 +1115,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users 0.5.2",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -1224,7 +1224,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -1893,7 +1893,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "19753d40da53d0ec41604750eeb969097a90fb2d7f7992730d904541c04e2c19"
 dependencies = [
  "bstr",
- "hashbrown 0.17.1",
+ "hashbrown 0.16.1",
 ]
 
 [[package]]
@@ -3044,14 +3044,14 @@ dependencies = [
 
 [[package]]
 name = "kin-buildinfo"
-version = "0.2.28"
+version = "0.3.0"
 dependencies = [
  "sha2 0.11.0",
 ]
 
 [[package]]
 name = "kin-cli"
-version = "0.2.28"
+version = "0.3.0"
 dependencies = [
  "age",
  "anyhow",
@@ -3125,7 +3125,7 @@ dependencies = [
 
 [[package]]
 name = "kin-context"
-version = "0.2.28"
+version = "0.3.0"
 dependencies = [
  "kin-blobs",
  "kin-db",
@@ -3141,8 +3141,10 @@ dependencies = [
 
 [[package]]
 name = "kin-core"
-version = "0.2.28"
+version = "0.3.0"
 dependencies = [
+ "cap-fs-ext",
+ "cap-std",
  "chrono",
  "directories 5.0.1",
  "fs2",
@@ -3154,6 +3156,7 @@ dependencies = [
  "kin-parser",
  "libc",
  "pretty_assertions",
+ "rustix",
  "serde",
  "serde_json",
  "sha2 0.11.0",
@@ -3161,12 +3164,14 @@ dependencies = [
  "thiserror 2.0.18",
  "toml 1.1.2+spec-1.1.0",
  "tracing",
+ "unicode-normalization",
  "uuid",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
 name = "kin-daemon"
-version = "0.2.28"
+version = "0.3.0"
 dependencies = [
  "async-stream",
  "axum",
@@ -3176,6 +3181,7 @@ dependencies = [
  "fs2",
  "gix",
  "hex",
+ "http-body",
  "kin-blobs",
  "kin-buildinfo",
  "kin-cli",
@@ -3191,6 +3197,7 @@ dependencies = [
  "kin-projection",
  "kin-reconcile",
  "kin-registry",
+ "kin-review",
  "kin-spine",
  "libc",
  "mimalloc",
@@ -3216,9 +3223,9 @@ dependencies = [
 
 [[package]]
 name = "kin-db"
-version = "0.2.39"
+version = "0.3.1"
 source = "sparse+https://kinlab.ai/registry/cargo/"
-checksum = "e70759792c8a050ac85ff72acfd0b0d563cddd8aba8a3e1876f9fd683ede25a1"
+checksum = "80bfc3d362b3e928051e80fca41293f239a38bb5a46c384ff5c39343fc6b6d8d"
 dependencies = [
  "bincode",
  "bytes",
@@ -3257,7 +3264,7 @@ dependencies = [
 
 [[package]]
 name = "kin-git"
-version = "0.2.28"
+version = "0.3.0"
 dependencies = [
  "chrono",
  "gix",
@@ -3275,7 +3282,7 @@ dependencies = [
 
 [[package]]
 name = "kin-index"
-version = "0.2.28"
+version = "0.3.0"
 dependencies = [
  "hex",
  "kin-blobs",
@@ -3299,9 +3306,9 @@ dependencies = [
 
 [[package]]
 name = "kin-infer"
-version = "0.2.40"
+version = "0.2.41"
 source = "sparse+https://kinlab.ai/registry/cargo/"
-checksum = "97fd7176da2b74e8e261285856d812f917b35a7e13eab7c2589e1868652f94a1"
+checksum = "073c47139ed0850d8f3ae2d1f11c63ffc10f3bc24e6a09c9e2d77a134ab416b1"
 dependencies = [
  "block",
  "half",
@@ -3323,7 +3330,7 @@ dependencies = [
 
 [[package]]
 name = "kin-integration-tests"
-version = "0.2.28"
+version = "0.3.0"
 dependencies = [
  "kin-blobs",
  "kin-cli",
@@ -3350,9 +3357,9 @@ dependencies = [
 
 [[package]]
 name = "kin-lsp"
-version = "0.2.3"
+version = "0.4.0"
 source = "sparse+https://kinlab.ai/registry/cargo/"
-checksum = "18c12c2c4ceea690f0a587d58a7b6d1ad8a177f2fbe2a79fc990dd680b2b0d8c"
+checksum = "eac57c8501983212e1923efdf64c76ad5e61dce24dd62d714cb1b15f71b2ce54"
 dependencies = [
  "kin-model",
  "serde",
@@ -3365,7 +3372,7 @@ dependencies = [
 
 [[package]]
 name = "kin-mcp"
-version = "0.2.28"
+version = "0.3.0"
 dependencies = [
  "kin-blobs",
  "kin-context",
@@ -3392,7 +3399,7 @@ dependencies = [
 
 [[package]]
 name = "kin-migrate"
-version = "0.2.28"
+version = "0.3.0"
 dependencies = [
  "chrono",
  "kin-blobs",
@@ -3416,9 +3423,9 @@ dependencies = [
 
 [[package]]
 name = "kin-model"
-version = "0.2.5"
+version = "0.4.0"
 source = "sparse+https://kinlab.ai/registry/cargo/"
-checksum = "f0fb9f21abc67a9f9c1374e6d8f304ca496fba96d98586fa3a8ff0ca2d5a91bd"
+checksum = "56123029e2cc463a2acc85d00bb4ae2146db7c5088097cadcc92a60d6d1a1b03"
 dependencies = [
  "chrono",
  "hex",
@@ -3434,7 +3441,7 @@ dependencies = [
 
 [[package]]
 name = "kin-parser"
-version = "0.2.28"
+version = "0.3.0"
 dependencies = [
  "kin-model",
  "pretty_assertions",
@@ -3464,7 +3471,7 @@ dependencies = [
 
 [[package]]
 name = "kin-projection"
-version = "0.2.28"
+version = "0.3.0"
 dependencies = [
  "kin-blobs",
  "kin-db",
@@ -3479,7 +3486,7 @@ dependencies = [
 
 [[package]]
 name = "kin-ranking"
-version = "0.2.28"
+version = "0.3.0"
 dependencies = [
  "kin-model",
  "serde",
@@ -3488,7 +3495,7 @@ dependencies = [
 
 [[package]]
 name = "kin-reconcile"
-version = "0.2.28"
+version = "0.3.0"
 dependencies = [
  "kin-blobs",
  "kin-db",
@@ -3508,7 +3515,7 @@ dependencies = [
 
 [[package]]
 name = "kin-registry"
-version = "0.2.28"
+version = "0.3.0"
 dependencies = [
  "async-stream",
  "axum",
@@ -3541,7 +3548,7 @@ dependencies = [
 
 [[package]]
 name = "kin-remote"
-version = "0.2.28"
+version = "0.3.0"
 dependencies = [
  "chrono",
  "kin-model",
@@ -3557,7 +3564,7 @@ dependencies = [
 
 [[package]]
 name = "kin-review"
-version = "0.2.28"
+version = "0.3.0"
 dependencies = [
  "kin-blobs",
  "kin-db",
@@ -3573,7 +3580,7 @@ dependencies = [
 
 [[package]]
 name = "kin-runtime"
-version = "0.2.28"
+version = "0.3.0"
 dependencies = [
  "chrono",
  "hex",
@@ -3605,7 +3612,7 @@ dependencies = [
 
 [[package]]
 name = "kin-semantic-contracts"
-version = "0.2.28"
+version = "0.3.0"
 dependencies = [
  "kin-db",
  "kin-model",
@@ -3620,7 +3627,7 @@ dependencies = [
 
 [[package]]
 name = "kin-spine"
-version = "0.2.28"
+version = "0.3.0"
 dependencies = [
  "chrono",
  "hashbrown 0.15.5",
@@ -3641,9 +3648,9 @@ dependencies = [
 
 [[package]]
 name = "kin-vector"
-version = "0.1.6"
+version = "0.1.7"
 source = "sparse+https://kinlab.ai/registry/cargo/"
-checksum = "4a0675c99c00faf3fd2a8cb71f73513677daef4fb35b2eb7d300da07f4990550"
+checksum = "59643af64209511b0721f919f4bd4e0defe08c4e8e48055eb291953b4519b582"
 dependencies = [
  "fs2",
  "hashbrown 0.15.5",
@@ -4026,7 +4033,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -4925,7 +4932,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -4994,7 +5001,7 @@ dependencies = [
  "security-framework 3.7.0",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -5438,7 +5445,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "52d1cfed4120b4d927bf7c0f86d2087a4a7d6027c906d9f9d525a80573b9be51"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -5571,7 +5578,7 @@ dependencies = [
  "getrandom 0.4.3",
  "once_cell",
  "rustix",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -6504,7 +6511,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,7 +27,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.2.28"
+version = "0.3.0"
 edition = "2021"
 license = "Apache-2.0"
 authors = ["Troy Fortin <troy@firelock.ai>"]
@@ -118,7 +118,7 @@ pretty_assertions = "1"
 serial_test = "3"
 
 # Internal crates
-kin-model = { version = "0.2.5", registry = "kin" }
+kin-model = { version = "=0.4.0", registry = "kin" }
 kin-blobs = { version = "0.1.1", registry = "kin" }
 kin-core = { path = "crates/kin-core" }
 kin-parser = { path = "crates/kin-parser" }
@@ -139,13 +139,13 @@ kin-daemon = { path = "crates/kin-daemon" }
 kin-mcp = { path = "crates/kin-mcp" }
 kin-spine = { path = "crates/kin-spine" }
 kin-registry = { path = "crates/kin-registry" }
-kin-lsp = { version = "0.2.3", registry = "kin" }
+kin-lsp = { version = "0.4.0", registry = "kin" }
 # Cross-platform base: NO "metal" here. `[workspace.dependencies]` entries cannot be
 # `[target.'cfg(...)']`-gated, so listing "metal" here forces the macOS-only kin-infer/metal
 # backend on every target (incl. Linux, where it cannot compile). Metal is re-enabled
 # additively on macOS via a `[target.'cfg(target_os = "macos")'.dependencies]` block in the
 # binary/runtime crates (kin-cli, kin-daemon). Feature unification makes that additive.
-kin-db = { version = "0.2.39", registry = "kin", default-features = false }
+kin-db = { version = "0.3.1", registry = "kin", default-features = false }
 kin-vfs-core = { version = "0.1.5", registry = "kin" }
 
 [profile.release]

--- a/crates/kin-cli/Cargo.toml
+++ b/crates/kin-cli/Cargo.toml
@@ -86,7 +86,7 @@ toml = { workspace = true }
 toml_edit = "0.25"
 tempfile = { workspace = true }
 unicode-normalization = "0.1"
-kin-spine = { version = "0.2.0", path = "../kin-spine" }
+kin-spine = { version = "0.3.0", path = "../kin-spine" }
 
 [dev-dependencies]
 pretty_assertions = { workspace = true }

--- a/crates/kin-cli/src/backend.rs
+++ b/crates/kin-cli/src/backend.rs
@@ -341,6 +341,7 @@ pub async fn require_daemon_update_head(
     layout: &kin_core::KinLayout,
     branch_name: &str,
     head_id: &str,
+    expected_head_id: &str,
 ) -> anyhow::Result<()> {
     let daemon_url = crate::daemon_client::resolve_daemon_url_if_running_async(layout)
         .await
@@ -351,11 +352,12 @@ pub async fn require_daemon_update_head(
 
     let payload = serde_json::json!({
         "head": head_id,
+        "expected_head": expected_head_id,
     });
 
     let resp = with_daemon_auth(
         client.put(format!(
-            "{}/v1/graph/branches/{}/head",
+            "{}/v2/graph/branches/{}/head",
             daemon_url.trim_end_matches('/'),
             branch_name
         )),
@@ -411,6 +413,215 @@ pub async fn require_daemon_commit(
         anyhow::bail!("daemon commit rejected for branch {branch_name}: HTTP {status}: {body}");
     }
     Ok(())
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum DaemonReleaseFailureKind {
+    /// The daemon returned a non-retryable client/policy response, so the
+    /// request did not become release authority.
+    Definitive,
+    /// A transport error, timeout, or exhausted 5xx response leaves the caller
+    /// unable to know whether the daemon committed before the response failed.
+    Uncertain,
+}
+
+#[derive(Debug)]
+pub struct DaemonReleaseCommitError {
+    pub kind: DaemonReleaseFailureKind,
+    /// The daemon serialized this exact change against graph authority and
+    /// explicitly proved it was not materialized before returning a stale-head
+    /// rejection. A durable recovery journal may be abandoned instead of
+    /// wedging every later release.
+    pub safe_to_abandon: bool,
+    message: String,
+}
+
+impl std::fmt::Display for DaemonReleaseCommitError {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        formatter.write_str(&self.message)
+    }
+}
+
+impl std::error::Error for DaemonReleaseCommitError {}
+
+fn release_finalization_timeout() -> Duration {
+    // A release request performs a full authority snapshot and durable
+    // generation-marker finalization before responding. Ten seconds was a
+    // normal mutation timeout, not a realistic finalization budget.
+    Duration::from_secs(120)
+}
+
+async fn send_serialized_release_request(
+    layout: &kin_core::KinLayout,
+    daemon_url: &str,
+    serialized_payload: &[u8],
+    branch_name: &str,
+    timeout: Duration,
+    max_attempts: usize,
+    initial_backoff: Duration,
+) -> Result<(), DaemonReleaseCommitError> {
+    let expected_change_id = serde_json::from_slice::<serde_json::Value>(serialized_payload)
+        .ok()
+        .and_then(|request| request.pointer("/change/id")?.as_str().map(str::to_owned));
+    let client = reqwest::Client::builder()
+        .timeout(timeout)
+        .connect_timeout(Duration::from_secs(2))
+        .build()
+        .map_err(|error| DaemonReleaseCommitError {
+            kind: DaemonReleaseFailureKind::Uncertain,
+            safe_to_abandon: false,
+            message: format!("build daemon release client: {error}"),
+        })?;
+    let endpoint = format!("{}/v1/graph/commit", daemon_url.trim_end_matches('/'));
+    let attempts = max_attempts.max(1);
+    let mut backoff = initial_backoff;
+    let mut last_uncertain = String::new();
+    let mut saw_uncertain = false;
+
+    for attempt in 0..attempts {
+        let response = with_daemon_auth(
+            client
+                .post(&endpoint)
+                .header(reqwest::header::CONTENT_TYPE, "application/json")
+                // Clone the already-serialized bytes. Retries must never
+                // regenerate the change, timestamp, ID, or JSON request.
+                .body(serialized_payload.to_vec()),
+            layout,
+        )
+        .send()
+        .await;
+
+        match response {
+            Ok(response) if response.status().is_success() => return Ok(()),
+            Ok(response)
+                if response.status().is_server_error()
+                    || response.status() == reqwest::StatusCode::REQUEST_TIMEOUT =>
+            {
+                let status = response.status();
+                let body = response.text().await.unwrap_or_default();
+                last_uncertain = format!("HTTP {status}: {body}");
+                saw_uncertain = true;
+            }
+            Ok(response) => {
+                let status = response.status();
+                let body = response.text().await.unwrap_or_default();
+                let kind = if saw_uncertain {
+                    // A later rejection can describe the exact retry (for
+                    // example, a stale-head 409) without proving that an
+                    // earlier timed-out/5xx attempt was not committed. Keep
+                    // the durable request journal until an exact retry
+                    // succeeds.
+                    DaemonReleaseFailureKind::Uncertain
+                } else {
+                    DaemonReleaseFailureKind::Definitive
+                };
+                return Err(DaemonReleaseCommitError {
+                    kind,
+                    safe_to_abandon: !saw_uncertain
+                        && expected_change_id.as_deref().is_some_and(|change_id| {
+                            stale_release_rejection_proves_change_absent(&body, change_id)
+                        }),
+                    message: if saw_uncertain {
+                        format!(
+                            "daemon release outcome remains uncertain for branch {branch_name}: an earlier exact-payload attempt had an uncertain outcome, then a retry was rejected with HTTP {status}: {body}"
+                        )
+                    } else {
+                        format!(
+                            "daemon release rejected for branch {branch_name}: HTTP {status}: {body}"
+                        )
+                    },
+                });
+            }
+            Err(error) => {
+                last_uncertain = format!("transport/finalization error: {error}");
+                saw_uncertain = true;
+            }
+        }
+
+        if attempt + 1 < attempts {
+            tokio::time::sleep(backoff).await;
+            backoff = backoff.saturating_mul(2).min(Duration::from_secs(2));
+        }
+    }
+
+    Err(DaemonReleaseCommitError {
+        kind: DaemonReleaseFailureKind::Uncertain,
+        safe_to_abandon: false,
+        message: format!(
+            "daemon release outcome is uncertain for branch {branch_name} after {attempts} exact-payload attempt(s): {last_uncertain}"
+        ),
+    })
+}
+
+/// POST an already-serialized release request and retry transport, timeout,
+/// and 5xx outcomes with those exact bytes. The caller persists the payload
+/// before calling so an exhausted uncertain result can be resumed by a later
+/// process without manufacturing another marker.
+pub async fn require_daemon_release_commit(
+    layout: &kin_core::KinLayout,
+    serialized_payload: &[u8],
+    branch_name: &str,
+) -> Result<(), DaemonReleaseCommitError> {
+    let daemon_url = crate::daemon_client::resolve_daemon_url(layout)
+        .await
+        .map_err(|error| DaemonReleaseCommitError {
+            kind: DaemonReleaseFailureKind::Uncertain,
+            safe_to_abandon: false,
+            message: format!("start or resolve Kin daemon for pending semantic release: {error:#}"),
+        })?
+        .ok_or_else(|| DaemonReleaseCommitError {
+            kind: DaemonReleaseFailureKind::Uncertain,
+            safe_to_abandon: false,
+            message: "Kin daemon is disabled; exact semantic release request remains pending"
+                .to_string(),
+        })?;
+    send_serialized_release_request(
+        layout,
+        &daemon_url,
+        serialized_payload,
+        branch_name,
+        release_finalization_timeout(),
+        3,
+        Duration::from_millis(100),
+    )
+    .await
+}
+
+fn stale_release_rejection_proves_change_absent(body: &str, expected_change_id: &str) -> bool {
+    let Ok(body) = serde_json::from_str::<serde_json::Value>(body) else {
+        return false;
+    };
+    body.get("error").and_then(serde_json::Value::as_str) == Some("stale_branch_head")
+        && body
+            .get("mutation_applied")
+            .and_then(serde_json::Value::as_bool)
+            == Some(false)
+        && body
+            .get("change_materialized")
+            .and_then(serde_json::Value::as_bool)
+            == Some(false)
+        && body.get("change_id").and_then(serde_json::Value::as_str) == Some(expected_change_id)
+}
+
+/// Build the canonical daemon request bytes once. These bytes are persisted
+/// and reused verbatim for every recovery attempt.
+pub fn serialize_daemon_release_request(
+    change: &kin_model::SemanticChange,
+    branch_name: &str,
+    force: bool,
+    require_proof: bool,
+    require_approval: bool,
+) -> anyhow::Result<Vec<u8>> {
+    serde_json::to_vec(&serde_json::json!({
+        "change": change,
+        "branch_name": branch_name,
+        "release_policy": {
+            "force": force,
+            "require_proof": require_proof,
+            "require_approval": require_approval,
+        },
+    }))
+    .map_err(Into::into)
 }
 
 #[derive(Default, serde::Serialize)]
@@ -569,12 +780,243 @@ pub async fn get_spine_xref(
 
 #[cfg(test)]
 mod tests {
+    use super::{send_serialized_release_request, stale_release_rejection_proves_change_absent};
+    use std::collections::HashSet;
+    use std::sync::atomic::{AtomicUsize, Ordering};
+    use std::sync::{Arc, Mutex};
+    use std::time::Duration;
+
+    use axum::body::Bytes;
+    use axum::extract::State;
+    use axum::http::StatusCode;
+    use axum::routing::post;
+    use axum::Router;
     use kin_model::EntityStore;
     use kin_model::WorkStore;
     use kin_model::{
         Entity, EntityId, EntityKind, EntityMetadata, EntityRole, FilePathId, FingerprintAlgorithm,
         Hash256, LanguageId, RetrievalKey, SemanticFingerprint, Visibility,
     };
+
+    #[derive(Clone, Default)]
+    struct ReleaseRetryServerState {
+        attempts: Arc<AtomicUsize>,
+        received: Arc<Mutex<Vec<Vec<u8>>>>,
+        markers: Arc<Mutex<HashSet<String>>>,
+        head: Arc<Mutex<Option<String>>>,
+        first_response: Arc<Mutex<Option<StatusCode>>>,
+        first_delay: Arc<Mutex<Option<Duration>>>,
+        later_response: Arc<Mutex<Option<StatusCode>>>,
+    }
+
+    async fn release_retry_handler(
+        State(state): State<ReleaseRetryServerState>,
+        body: Bytes,
+    ) -> StatusCode {
+        state.received.lock().unwrap().push(body.to_vec());
+        let request: serde_json::Value = serde_json::from_slice(&body).unwrap();
+        let change_id = request["change"]["id"].as_str().unwrap().to_string();
+        state.markers.lock().unwrap().insert(change_id.clone());
+        *state.head.lock().unwrap() = Some(change_id);
+
+        if state.attempts.fetch_add(1, Ordering::SeqCst) == 0 {
+            let delay = *state.first_delay.lock().unwrap();
+            if let Some(delay) = delay {
+                tokio::time::sleep(delay).await;
+            }
+            return state
+                .first_response
+                .lock()
+                .unwrap()
+                .unwrap_or(StatusCode::OK);
+        }
+        state
+            .later_response
+            .lock()
+            .unwrap()
+            .unwrap_or(StatusCode::OK)
+    }
+
+    async fn release_retry_server(
+        state: ReleaseRetryServerState,
+    ) -> (String, tokio::task::JoinHandle<()>) {
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let address = listener.local_addr().unwrap();
+        let app = Router::new()
+            .route("/v1/graph/commit", post(release_retry_handler))
+            .with_state(state);
+        let task = tokio::spawn(async move {
+            axum::serve(listener, app).await.unwrap();
+        });
+        (format!("http://{address}"), task)
+    }
+
+    fn serialized_release_fixture() -> Vec<u8> {
+        serde_json::to_vec(&serde_json::json!({
+            "change": {
+                "id": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+                "parents": ["bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"],
+                "author": "kin-release",
+                "message": "release: v0.3.0",
+            },
+            "branch_name": "main",
+            "release_policy": {
+                "force": true,
+                "require_proof": false,
+                "require_approval": false,
+            }
+        }))
+        .unwrap()
+    }
+
+    #[test]
+    fn only_identity_bound_stale_rejection_proves_pending_change_absent() {
+        let expected = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa";
+        let exact = serde_json::json!({
+            "error": "stale_branch_head",
+            "mutation_applied": false,
+            "change_materialized": false,
+            "change_id": expected,
+        })
+        .to_string();
+        assert!(stale_release_rejection_proves_change_absent(
+            &exact, expected
+        ));
+
+        for body in [
+            serde_json::json!({
+                "error": "stale_branch_head",
+                "mutation_applied": false,
+                "change_materialized": false,
+                "change_id": "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+            })
+            .to_string(),
+            serde_json::json!({
+                "error": "stale_branch_head",
+                "mutation_applied": false,
+                "change_materialized": true,
+                "change_id": expected,
+            })
+            .to_string(),
+            serde_json::json!({
+                "error": "stale_branch_head",
+                "mutation_applied": false,
+                "change_id": expected,
+            })
+            .to_string(),
+            serde_json::json!({
+                "error": "release_policy_failed",
+                "mutation_applied": false,
+                "change_materialized": false,
+                "change_id": expected,
+            })
+            .to_string(),
+            "not-json".to_string(),
+        ] {
+            assert!(!stale_release_rejection_proves_change_absent(
+                &body, expected
+            ));
+        }
+    }
+
+    #[tokio::test]
+    async fn release_5xx_retry_reuses_identical_serialized_bytes() {
+        let repo = tempfile::tempdir().unwrap();
+        let layout = kin_core::init(repo.path()).unwrap().layout;
+        let state = ReleaseRetryServerState::default();
+        *state.first_response.lock().unwrap() = Some(StatusCode::INTERNAL_SERVER_ERROR);
+        let (url, server) = release_retry_server(state.clone()).await;
+        let payload = serialized_release_fixture();
+
+        send_serialized_release_request(
+            &layout,
+            &url,
+            &payload,
+            "main",
+            Duration::from_secs(1),
+            3,
+            Duration::from_millis(1),
+        )
+        .await
+        .unwrap();
+        server.abort();
+
+        let received = state.received.lock().unwrap();
+        assert_eq!(received.len(), 2);
+        assert!(received.iter().all(|request| request == &payload));
+    }
+
+    #[tokio::test]
+    async fn release_timeout_retry_keeps_exactly_one_marker_and_head() {
+        let repo = tempfile::tempdir().unwrap();
+        let layout = kin_core::init(repo.path()).unwrap().layout;
+        let state = ReleaseRetryServerState::default();
+        *state.first_delay.lock().unwrap() = Some(Duration::from_millis(80));
+        let (url, server) = release_retry_server(state.clone()).await;
+        let payload = serialized_release_fixture();
+
+        send_serialized_release_request(
+            &layout,
+            &url,
+            &payload,
+            "main",
+            Duration::from_millis(20),
+            3,
+            Duration::from_millis(1),
+        )
+        .await
+        .unwrap();
+        server.abort();
+
+        let received = state.received.lock().unwrap();
+        assert_eq!(received.len(), 2);
+        assert!(received.iter().all(|request| request == &payload));
+        let markers = state.markers.lock().unwrap();
+        assert_eq!(
+            markers.len(),
+            1,
+            "timeout retry manufactured a second marker"
+        );
+        assert_eq!(
+            state.head.lock().unwrap().as_deref(),
+            markers.iter().next().map(String::as_str)
+        );
+    }
+
+    #[tokio::test]
+    async fn release_retry_rejection_after_timeout_remains_uncertain() {
+        let repo = tempfile::tempdir().unwrap();
+        let layout = kin_core::init(repo.path()).unwrap().layout;
+        let state = ReleaseRetryServerState::default();
+        *state.first_delay.lock().unwrap() = Some(Duration::from_millis(80));
+        *state.later_response.lock().unwrap() = Some(StatusCode::CONFLICT);
+        let (url, server) = release_retry_server(state.clone()).await;
+        let payload = serialized_release_fixture();
+
+        let error = send_serialized_release_request(
+            &layout,
+            &url,
+            &payload,
+            "main",
+            Duration::from_millis(20),
+            2,
+            Duration::from_millis(1),
+        )
+        .await
+        .unwrap_err();
+        server.abort();
+
+        assert_eq!(error.kind, super::DaemonReleaseFailureKind::Uncertain);
+        let received = state.received.lock().unwrap();
+        assert_eq!(received.len(), 2);
+        assert!(received.iter().all(|request| request == &payload));
+        let markers = state.markers.lock().unwrap();
+        assert_eq!(markers.len(), 1);
+        assert_eq!(
+            state.head.lock().unwrap().as_deref(),
+            markers.iter().next().map(String::as_str)
+        );
+    }
 
     fn test_entity(name: &str) -> Entity {
         Entity {

--- a/crates/kin-cli/src/commands/branch.rs
+++ b/crates/kin-cli/src/commands/branch.rs
@@ -146,6 +146,35 @@ fn branch_switch(
     graph: &kin_db::InMemoryGraph,
     name: &str,
 ) -> Result<BranchResponse> {
+    branch_switch_with_pre_mutation_hook(layout, graph, name, || {})
+}
+
+fn branch_switch_with_pre_mutation_hook(
+    layout: &kin_core::KinLayout,
+    graph: &kin_db::InMemoryGraph,
+    name: &str,
+    after_read_only_preflight: impl FnOnce(),
+) -> Result<BranchResponse> {
+    branch_switch_with_hooks(
+        layout,
+        graph,
+        name,
+        after_read_only_preflight,
+        |_layout, _branch| Ok(()),
+    )
+}
+
+fn branch_switch_with_hooks(
+    layout: &kin_core::KinLayout,
+    graph: &kin_db::InMemoryGraph,
+    name: &str,
+    after_read_only_preflight: impl FnOnce(),
+    before_head_commit: impl FnOnce(&kin_core::KinLayout, &BranchName) -> Result<()>,
+) -> Result<BranchResponse> {
+    let previous_name = kin_core::read_current_branch(layout)?;
+    let previous_branch = graph
+        .get_branch(&previous_name)?
+        .ok_or_else(|| anyhow::anyhow!("current branch '{}' not found in graph", previous_name))?;
     let branch = graph.get_branch(&BranchName::new(name))?;
     let Some(branch) = branch else {
         anyhow::bail!("branch '{}' not found", name);
@@ -153,11 +182,38 @@ fn branch_switch(
 
     let blob_store = kin_blobs::BlobStore::new(layout.objects_dir())
         .map_err(|e| anyhow::anyhow!("failed to open blob store: {}", e))?;
-    let genesis = kin_core::build_genesis_change();
-    let files_written =
-        kin_core::checkout_branch(graph, &blob_store, layout, &genesis.id, &branch.head)?;
-
-    kin_core::write_current_branch(layout, &BranchName::new(name))?;
+    let files_written = kin_core::tree::checkout_branch_between_heads_transactional_with_hooks(
+        graph,
+        &blob_store,
+        layout,
+        &previous_name.to_string(),
+        &previous_branch.head,
+        &branch.name.to_string(),
+        &branch.head,
+        after_read_only_preflight,
+        || {
+            let current_target = graph
+                .get_branch(&branch.name)
+                .map_err(|error| kin_core::KinError::Graph(error.to_string()))?
+                .ok_or_else(|| {
+                    kin_core::KinError::Graph(format!(
+                        "branch '{}' disappeared during switch",
+                        branch.name
+                    ))
+                })?;
+            if current_target.head != branch.head {
+                return Err(kin_core::KinError::Graph(format!(
+                    "branch '{}' advanced from {} to {} during switch; current branch marker was not changed",
+                    branch.name, branch.head, current_target.head
+                )));
+            }
+            before_head_commit(layout, &branch.name).map_err(|error| {
+                kin_core::KinError::Other(format!(
+                    "validate branch authority before HEAD publication: {error:#}"
+                ))
+            })
+        },
+    )?;
     let mut lines = vec![format!(
         "Switched to branch '{}' at {}",
         branch.name, branch.head
@@ -176,4 +232,543 @@ fn parse_change_id(s: &str) -> Result<SemanticChangeId> {
     let hash = Hash256::from_hex(s)
         .map_err(|_| anyhow::anyhow!("invalid change ID (expected 64 hex chars): {}", s))?;
     Ok(SemanticChangeId::from_hash(hash))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use kin_model::{ArtifactDelta, ArtifactDeltaKind, AuthorId, SemanticChange, Timestamp};
+
+    fn source_change(
+        id_byte: u8,
+        parent: SemanticChangeId,
+        artifact_deltas: Vec<ArtifactDelta>,
+    ) -> SemanticChange {
+        SemanticChange {
+            id: SemanticChangeId::from_hash(Hash256::from_bytes([id_byte; 32])),
+            parents: vec![parent],
+            timestamp: Timestamp::now(),
+            author: AuthorId::new("branch-switch-test"),
+            message: format!("branch switch fixture {id_byte}"),
+            entity_deltas: vec![],
+            relation_deltas: vec![],
+            artifact_deltas,
+            projected_files: vec![],
+            spec_link: None,
+            evidence: vec![],
+            risk_summary: None,
+            authored_on: None,
+        }
+    }
+
+    #[cfg(any(unix, windows))]
+    #[test]
+    fn branch_switch_removes_only_old_tracked_paths() {
+        let repo = tempfile::tempdir().unwrap();
+        let layout = kin_core::init(repo.path()).unwrap().layout;
+        let graph = kin_db::InMemoryGraph::new();
+        let genesis = kin_core::build_genesis_change();
+        graph.create_change(&genesis).unwrap();
+        let blob_store = kin_blobs::BlobStore::new(layout.objects_dir()).unwrap();
+
+        let shared_blob = blob_store.write(b"shared on main\n").unwrap();
+        let shared_hash = Hash256::from_bytes(shared_blob.0);
+        let main_change = source_change(
+            0x61,
+            genesis.id,
+            vec![ArtifactDelta {
+                file_id: kin_model::FilePathId::new("src/shared.rs"),
+                kind: ArtifactDeltaKind::AddedRegularFile,
+                old_hash: None,
+                new_hash: Some(shared_hash),
+            }],
+        );
+        graph.create_change(&main_change).unwrap();
+
+        let stale_blob = blob_store.write(b"feature only\n").unwrap();
+        let stale_hash = Hash256::from_bytes(stale_blob.0);
+        let feature_change = source_change(
+            0x62,
+            main_change.id,
+            vec![ArtifactDelta {
+                file_id: kin_model::FilePathId::new("src/feature_only.rs"),
+                kind: ArtifactDeltaKind::AddedRegularFile,
+                old_hash: None,
+                new_hash: Some(stale_hash),
+            }],
+        );
+        graph.create_change(&feature_change).unwrap();
+        graph
+            .create_branch(&Branch {
+                name: BranchName::new("main"),
+                head: main_change.id,
+            })
+            .unwrap();
+        graph
+            .create_branch(&Branch {
+                name: BranchName::new("feature"),
+                head: feature_change.id,
+            })
+            .unwrap();
+        kin_core::write_current_branch(&layout, &BranchName::new("feature")).unwrap();
+
+        std::fs::create_dir_all(repo.path().join("src")).unwrap();
+        std::fs::write(layout.root().join("preserve-control"), b"preserve kin\n").unwrap();
+        std::fs::write(repo.path().join("src/shared.rs"), b"shared on main\n").unwrap();
+        std::fs::write(repo.path().join("src/feature_only.rs"), b"feature only\n").unwrap();
+        std::fs::write(repo.path().join("notes.txt"), b"untracked user bytes\n").unwrap();
+        std::fs::create_dir_all(repo.path().join(".git")).unwrap();
+        std::fs::write(repo.path().join(".git/config"), b"preserve git\n").unwrap();
+        std::fs::create_dir_all(repo.path().join(".kin-session")).unwrap();
+        std::fs::write(
+            repo.path().join(".kin-session/base.json"),
+            b"preserve session\n",
+        )
+        .unwrap();
+        std::fs::create_dir_all(repo.path().join("target/debug")).unwrap();
+        std::fs::write(repo.path().join("target/debug/cache"), b"preserve build\n").unwrap();
+
+        branch_switch(&layout, &graph, "main").unwrap();
+
+        assert_eq!(
+            std::fs::read(repo.path().join("src/shared.rs")).unwrap(),
+            b"shared on main\n"
+        );
+        assert!(!repo.path().join("src/feature_only.rs").exists());
+        assert_eq!(
+            std::fs::read(repo.path().join("notes.txt")).unwrap(),
+            b"untracked user bytes\n"
+        );
+        assert!(layout.root().join("preserve-control").exists());
+        assert!(repo.path().join(".git/config").exists());
+        assert!(repo.path().join(".kin-session/base.json").exists());
+        assert!(repo.path().join("target/debug/cache").exists());
+        assert_eq!(
+            kin_core::read_current_branch(&layout).unwrap(),
+            BranchName::new("main")
+        );
+    }
+
+    #[cfg(any(unix, windows))]
+    #[test]
+    fn branch_switch_refuses_modified_tracked_overwrite_without_partial_mutation() {
+        let repo = tempfile::tempdir().unwrap();
+        let layout = kin_core::init(repo.path()).unwrap().layout;
+        let graph = kin_db::InMemoryGraph::new();
+        let genesis = kin_core::build_genesis_change();
+        graph.create_change(&genesis).unwrap();
+        let blob_store = kin_blobs::BlobStore::new(layout.objects_dir()).unwrap();
+
+        let main_blob = blob_store.write(b"shared on main\n").unwrap();
+        let main_hash = Hash256::from_bytes(main_blob.0);
+        let main_change = source_change(
+            0x63,
+            genesis.id,
+            vec![ArtifactDelta {
+                file_id: kin_model::FilePathId::new("src/shared.rs"),
+                kind: ArtifactDeltaKind::AddedRegularFile,
+                old_hash: None,
+                new_hash: Some(main_hash),
+            }],
+        );
+        graph.create_change(&main_change).unwrap();
+
+        let feature_blob = blob_store.write(b"shared on feature\n").unwrap();
+        let feature_hash = Hash256::from_bytes(feature_blob.0);
+        let stale_blob = blob_store.write(b"feature only\n").unwrap();
+        let stale_hash = Hash256::from_bytes(stale_blob.0);
+        let feature_change = source_change(
+            0x64,
+            main_change.id,
+            vec![
+                ArtifactDelta {
+                    file_id: kin_model::FilePathId::new("src/shared.rs"),
+                    kind: ArtifactDeltaKind::ModifiedRegularFile,
+                    old_hash: Some(main_hash),
+                    new_hash: Some(feature_hash),
+                },
+                ArtifactDelta {
+                    file_id: kin_model::FilePathId::new("src/feature_only.rs"),
+                    kind: ArtifactDeltaKind::AddedRegularFile,
+                    old_hash: None,
+                    new_hash: Some(stale_hash),
+                },
+            ],
+        );
+        graph.create_change(&feature_change).unwrap();
+        graph
+            .create_branch(&Branch {
+                name: BranchName::new("main"),
+                head: main_change.id,
+            })
+            .unwrap();
+        graph
+            .create_branch(&Branch {
+                name: BranchName::new("feature"),
+                head: feature_change.id,
+            })
+            .unwrap();
+        kin_core::write_current_branch(&layout, &BranchName::new("feature")).unwrap();
+
+        std::fs::create_dir_all(repo.path().join("src")).unwrap();
+        std::fs::write(repo.path().join("src/shared.rs"), b"user-edited feature\n").unwrap();
+        std::fs::write(repo.path().join("src/feature_only.rs"), b"feature only\n").unwrap();
+
+        let error = branch_switch(&layout, &graph, "main").unwrap_err();
+
+        assert!(error
+            .to_string()
+            .contains("differs from current branch source"));
+        assert_eq!(
+            std::fs::read(repo.path().join("src/shared.rs")).unwrap(),
+            b"user-edited feature\n"
+        );
+        assert_eq!(
+            std::fs::read(repo.path().join("src/feature_only.rs")).unwrap(),
+            b"feature only\n"
+        );
+        assert_eq!(
+            kin_core::read_current_branch(&layout).unwrap(),
+            BranchName::new("feature")
+        );
+    }
+
+    #[cfg(any(unix, windows))]
+    #[test]
+    fn branch_switch_refuses_modified_tracked_removal_without_partial_mutation() {
+        let repo = tempfile::tempdir().unwrap();
+        let layout = kin_core::init(repo.path()).unwrap().layout;
+        let graph = kin_db::InMemoryGraph::new();
+        let genesis = kin_core::build_genesis_change();
+        graph.create_change(&genesis).unwrap();
+        let blob_store = kin_blobs::BlobStore::new(layout.objects_dir()).unwrap();
+
+        let main_blob = blob_store.write(b"shared on main\n").unwrap();
+        let main_hash = Hash256::from_bytes(main_blob.0);
+        let main_change = source_change(
+            0x65,
+            genesis.id,
+            vec![ArtifactDelta {
+                file_id: kin_model::FilePathId::new("src/shared.rs"),
+                kind: ArtifactDeltaKind::AddedRegularFile,
+                old_hash: None,
+                new_hash: Some(main_hash),
+            }],
+        );
+        graph.create_change(&main_change).unwrap();
+
+        let feature_shared_blob = blob_store.write(b"shared on feature\n").unwrap();
+        let feature_shared_hash = Hash256::from_bytes(feature_shared_blob.0);
+        let removed_blob = blob_store.write(b"feature removable\n").unwrap();
+        let removed_hash = Hash256::from_bytes(removed_blob.0);
+        let feature_change = source_change(
+            0x66,
+            main_change.id,
+            vec![
+                ArtifactDelta {
+                    file_id: kin_model::FilePathId::new("src/shared.rs"),
+                    kind: ArtifactDeltaKind::ModifiedRegularFile,
+                    old_hash: Some(main_hash),
+                    new_hash: Some(feature_shared_hash),
+                },
+                ArtifactDelta {
+                    file_id: kin_model::FilePathId::new("src/remove_on_main.rs"),
+                    kind: ArtifactDeltaKind::AddedRegularFile,
+                    old_hash: None,
+                    new_hash: Some(removed_hash),
+                },
+            ],
+        );
+        graph.create_change(&feature_change).unwrap();
+        graph
+            .create_branch(&Branch {
+                name: BranchName::new("main"),
+                head: main_change.id,
+            })
+            .unwrap();
+        graph
+            .create_branch(&Branch {
+                name: BranchName::new("feature"),
+                head: feature_change.id,
+            })
+            .unwrap();
+        kin_core::write_current_branch(&layout, &BranchName::new("feature")).unwrap();
+
+        std::fs::create_dir_all(repo.path().join("src")).unwrap();
+        std::fs::write(repo.path().join("src/shared.rs"), b"shared on feature\n").unwrap();
+        std::fs::write(
+            repo.path().join("src/remove_on_main.rs"),
+            b"user-edited removable\n",
+        )
+        .unwrap();
+
+        let error = branch_switch(&layout, &graph, "main").unwrap_err();
+
+        assert!(error
+            .to_string()
+            .contains("differs from current branch source"));
+        assert_eq!(
+            std::fs::read(repo.path().join("src/shared.rs")).unwrap(),
+            b"shared on feature\n"
+        );
+        assert_eq!(
+            std::fs::read(repo.path().join("src/remove_on_main.rs")).unwrap(),
+            b"user-edited removable\n"
+        );
+        assert_eq!(
+            kin_core::read_current_branch(&layout).unwrap(),
+            BranchName::new("feature")
+        );
+    }
+
+    #[cfg(any(unix, windows))]
+    #[test]
+    fn branch_switch_revalidates_post_preflight_editor_replacement_before_head() {
+        let repo = tempfile::tempdir().unwrap();
+        let layout = kin_core::init(repo.path()).unwrap().layout;
+        let graph = kin_db::InMemoryGraph::new();
+        let genesis = kin_core::build_genesis_change();
+        graph.create_change(&genesis).unwrap();
+        let blob_store = kin_blobs::BlobStore::new(layout.objects_dir()).unwrap();
+
+        let main_hash = Hash256::from_bytes(blob_store.write(b"main bytes\n").unwrap().0);
+        let main = source_change(
+            0x67,
+            genesis.id,
+            vec![ArtifactDelta {
+                file_id: kin_model::FilePathId::new("src/shared.rs"),
+                kind: ArtifactDeltaKind::AddedRegularFile,
+                old_hash: None,
+                new_hash: Some(main_hash),
+            }],
+        );
+        graph.create_change(&main).unwrap();
+        let feature_hash = Hash256::from_bytes(blob_store.write(b"feature bytes\n").unwrap().0);
+        let feature = source_change(
+            0x68,
+            main.id,
+            vec![ArtifactDelta {
+                file_id: kin_model::FilePathId::new("src/shared.rs"),
+                kind: ArtifactDeltaKind::ModifiedRegularFile,
+                old_hash: Some(main_hash),
+                new_hash: Some(feature_hash),
+            }],
+        );
+        graph.create_change(&feature).unwrap();
+        graph
+            .create_branch(&Branch {
+                name: BranchName::new("main"),
+                head: main.id,
+            })
+            .unwrap();
+        graph
+            .create_branch(&Branch {
+                name: BranchName::new("feature"),
+                head: feature.id,
+            })
+            .unwrap();
+        kin_core::write_current_branch(&layout, &BranchName::new("feature")).unwrap();
+        std::fs::create_dir_all(repo.path().join("src")).unwrap();
+        let path = repo.path().join("src/shared.rs");
+        std::fs::write(&path, b"feature bytes\n").unwrap();
+
+        let error = branch_switch_with_pre_mutation_hook(&layout, &graph, "main", || {
+            let replacement = repo.path().join("src/editor.tmp");
+            std::fs::write(&replacement, b"editor bytes\n").unwrap();
+            std::fs::remove_file(&path).unwrap();
+            std::fs::rename(replacement, &path).unwrap();
+        })
+        .unwrap_err();
+
+        assert!(error
+            .to_string()
+            .contains("differs from current branch source"));
+        assert_eq!(std::fs::read(&path).unwrap(), b"editor bytes\n");
+        assert_eq!(
+            kin_core::read_current_branch(&layout).unwrap(),
+            BranchName::new("feature")
+        );
+    }
+
+    #[cfg(any(unix, windows))]
+    #[test]
+    fn branch_switch_revalidates_target_head_before_writing_current_branch() {
+        let repo = tempfile::tempdir().unwrap();
+        let layout = kin_core::init(repo.path()).unwrap().layout;
+        let graph = kin_db::InMemoryGraph::new();
+        let genesis = kin_core::build_genesis_change();
+        graph.create_change(&genesis).unwrap();
+        let blob_store = kin_blobs::BlobStore::new(layout.objects_dir()).unwrap();
+
+        let main_hash = Hash256::from_bytes(blob_store.write(b"main bytes\n").unwrap().0);
+        let main = source_change(
+            0x69,
+            genesis.id,
+            vec![ArtifactDelta {
+                file_id: kin_model::FilePathId::new("src/shared.rs"),
+                kind: ArtifactDeltaKind::AddedRegularFile,
+                old_hash: None,
+                new_hash: Some(main_hash),
+            }],
+        );
+        graph.create_change(&main).unwrap();
+        let feature_hash = Hash256::from_bytes(blob_store.write(b"feature bytes\n").unwrap().0);
+        let feature = source_change(
+            0x6a,
+            main.id,
+            vec![ArtifactDelta {
+                file_id: kin_model::FilePathId::new("src/shared.rs"),
+                kind: ArtifactDeltaKind::ModifiedRegularFile,
+                old_hash: Some(main_hash),
+                new_hash: Some(feature_hash),
+            }],
+        );
+        graph.create_change(&feature).unwrap();
+        let advanced_hash = Hash256::from_bytes(blob_store.write(b"advanced bytes\n").unwrap().0);
+        let advanced = source_change(
+            0x6b,
+            feature.id,
+            vec![ArtifactDelta {
+                file_id: kin_model::FilePathId::new("src/shared.rs"),
+                kind: ArtifactDeltaKind::ModifiedRegularFile,
+                old_hash: Some(feature_hash),
+                new_hash: Some(advanced_hash),
+            }],
+        );
+        graph.create_change(&advanced).unwrap();
+        graph
+            .create_branch(&Branch {
+                name: BranchName::new("main"),
+                head: main.id,
+            })
+            .unwrap();
+        graph
+            .create_branch(&Branch {
+                name: BranchName::new("feature"),
+                head: feature.id,
+            })
+            .unwrap();
+        kin_core::write_current_branch(&layout, &BranchName::new("main")).unwrap();
+        std::fs::create_dir_all(repo.path().join("src")).unwrap();
+        std::fs::write(repo.path().join("src/shared.rs"), b"main bytes\n").unwrap();
+
+        let error = branch_switch_with_pre_mutation_hook(&layout, &graph, "feature", || {
+            graph
+                .update_branch_head(&BranchName::new("feature"), &advanced.id)
+                .unwrap();
+        })
+        .unwrap_err();
+
+        assert!(format!("{error:#}").contains("advanced"));
+        assert_eq!(
+            kin_core::read_current_branch(&layout).unwrap(),
+            BranchName::new("main")
+        );
+        assert_eq!(
+            graph
+                .get_branch(&BranchName::new("feature"))
+                .unwrap()
+                .unwrap()
+                .head,
+            advanced.id
+        );
+        assert_eq!(
+            graph
+                .get_branch(&BranchName::new("main"))
+                .unwrap()
+                .unwrap()
+                .head,
+            main.id
+        );
+        assert_eq!(
+            std::fs::read(repo.path().join("src/shared.rs")).unwrap(),
+            b"main bytes\n"
+        );
+    }
+
+    #[cfg(any(unix, windows))]
+    #[test]
+    fn branch_switch_head_write_failure_restores_prior_tree_head_and_graph() {
+        let repo = tempfile::tempdir().unwrap();
+        let layout = kin_core::init(repo.path()).unwrap().layout;
+        let graph = kin_db::InMemoryGraph::new();
+        let genesis = kin_core::build_genesis_change();
+        graph.create_change(&genesis).unwrap();
+        let blob_store = kin_blobs::BlobStore::new(layout.objects_dir()).unwrap();
+
+        let main_hash = Hash256::from_bytes(blob_store.write(b"main bytes\n").unwrap().0);
+        let main = source_change(
+            0x6c,
+            genesis.id,
+            vec![ArtifactDelta {
+                file_id: kin_model::FilePathId::new("src/shared.rs"),
+                kind: ArtifactDeltaKind::AddedRegularFile,
+                old_hash: None,
+                new_hash: Some(main_hash),
+            }],
+        );
+        graph.create_change(&main).unwrap();
+        let feature_hash = Hash256::from_bytes(blob_store.write(b"feature bytes\n").unwrap().0);
+        let feature = source_change(
+            0x6d,
+            main.id,
+            vec![ArtifactDelta {
+                file_id: kin_model::FilePathId::new("src/shared.rs"),
+                kind: ArtifactDeltaKind::ModifiedRegularFile,
+                old_hash: Some(main_hash),
+                new_hash: Some(feature_hash),
+            }],
+        );
+        graph.create_change(&feature).unwrap();
+        graph
+            .create_branch(&Branch {
+                name: BranchName::new("main"),
+                head: main.id,
+            })
+            .unwrap();
+        graph
+            .create_branch(&Branch {
+                name: BranchName::new("feature"),
+                head: feature.id,
+            })
+            .unwrap();
+        kin_core::write_current_branch(&layout, &BranchName::new("main")).unwrap();
+        std::fs::create_dir_all(repo.path().join("src")).unwrap();
+        std::fs::write(repo.path().join("src/shared.rs"), b"main bytes\n").unwrap();
+
+        let error = branch_switch_with_hooks(
+            &layout,
+            &graph,
+            "feature",
+            || {},
+            |_layout, _branch| anyhow::bail!("injected HEAD write failure"),
+        )
+        .unwrap_err();
+
+        assert!(format!("{error:#}").contains("injected HEAD write failure"));
+        assert_eq!(
+            kin_core::read_current_branch(&layout).unwrap(),
+            BranchName::new("main")
+        );
+        assert_eq!(
+            std::fs::read(repo.path().join("src/shared.rs")).unwrap(),
+            b"main bytes\n"
+        );
+        assert_eq!(
+            graph
+                .get_branch(&BranchName::new("main"))
+                .unwrap()
+                .unwrap()
+                .head,
+            main.id
+        );
+        assert_eq!(
+            graph
+                .get_branch(&BranchName::new("feature"))
+                .unwrap()
+                .unwrap()
+                .head,
+            feature.id
+        );
+    }
 }

--- a/crates/kin-cli/src/commands/checkout.rs
+++ b/crates/kin-cli/src/commands/checkout.rs
@@ -1,8 +1,13 @@
 // SPDX-License-Identifier: Apache-2.0
 // Copyright 2026 Firelock, LLC
 
+use std::collections::HashMap;
+
 use anyhow::{Context, Result};
-use kin_model::{ChangeStore, FilePathId, Hash256, SemanticChangeId};
+use kin_model::{
+    ChangeStore, FilePathId, Hash256, ResolvedSourceEntry, SemanticChangeId, SourceEntryKind,
+    SourceTreeResolution,
+};
 use serde::{Deserialize, Serialize};
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -55,8 +60,6 @@ pub fn execute_checkout_request(
     let blob_store = kin_blobs::BlobStore::new(layout.objects_dir())
         .map_err(|e| anyhow::anyhow!("failed to open blob store: {}", e))?;
 
-    let genesis = kin_core::build_genesis_change();
-
     let target_head = match &request.change_id {
         Some(id) => {
             let hash = Hash256::from_hex(id).map_err(|_| {
@@ -79,41 +82,24 @@ pub fn execute_checkout_request(
         }
     };
 
-    let tree = kin_core::build_file_tree(graph, &genesis.id, &target_head)
-        .map_err(|e| anyhow::anyhow!("failed to build file tree: {}", e))?;
+    let tree = resolve_exact_checkout_tree(graph, &target_head)?;
 
     let normalized = normalize_checkout_path(&request.path);
 
     if normalized == "." || normalized == "*" || normalized.is_empty() {
         // Checkout the entire tree!
         // 1. Write/restore all files in the tree
-        for (file_id, blob_hash) in &tree {
-            let blob_key = kin_blobs::Hash256(*blob_hash.as_bytes());
-            let content = blob_store
-                .read(&blob_key)
-                .map_err(|e| anyhow::anyhow!("failed to read blob for '{}': {}", file_id.0, e))?;
+        let entries = load_and_validate_checkout_entries(&blob_store, tree.iter())?;
 
-            let dest = layout.working_dir().join(&file_id.0);
-            if let Some(parent) = dest.parent() {
-                std::fs::create_dir_all(parent).map_err(|e| {
-                    anyhow::anyhow!("failed to create directory {}: {}", parent.display(), e)
-                })?;
-            }
-            std::fs::write(&dest, &content)
-                .map_err(|e| anyhow::anyhow!("failed to write {}: {}", dest.display(), e))?;
-        }
-
-        // 2. Clean up any files in the working directory that are NOT in the tree
         let source_root = layout.working_dir();
-        let mut files_to_delete = Vec::new();
-        collect_non_tree_files(source_root, source_root, &tree, &mut files_to_delete)?;
-
-        for file_path in files_to_delete {
-            let _ = std::fs::remove_file(file_path);
-        }
-
-        // Clean up empty directories
-        clean_empty_dirs(source_root, source_root)?;
+        kin_core::replace_source_tree(
+            source_root,
+            entries
+                .iter()
+                .map(|entry| (&entry.file_id, entry.kind, entry.content.as_slice())),
+            should_skip_checkout_clean,
+        )
+        .map_err(|error| anyhow::anyhow!("failed to materialize exact source tree: {error}"))?;
 
         return Ok(CheckoutResponse {
             lines: vec![format!("Checked out all files from change {}", target_head)],
@@ -122,28 +108,28 @@ pub fn execute_checkout_request(
 
     let file_id = FilePathId(normalized.to_string());
 
-    let blob_hash = tree.get(&file_id).ok_or_else(|| {
+    let source = tree.get(&file_id).ok_or_else(|| {
         anyhow::anyhow!(
             "file '{}' not found in the semantic tree at change {}",
             normalized,
             target_head
         )
     })?;
-
-    let blob_key = kin_blobs::Hash256(*blob_hash.as_bytes());
-    let content = blob_store
-        .read(&blob_key)
-        .map_err(|e| anyhow::anyhow!("failed to read blob for '{}': {}", normalized, e))?;
-
-    let dest = layout.working_dir().join(normalized);
-    if let Some(parent) = dest.parent() {
-        std::fs::create_dir_all(parent).map_err(|e| {
-            anyhow::anyhow!("failed to create directory {}: {}", parent.display(), e)
-        })?;
-    }
-
-    std::fs::write(&dest, &content)
-        .map_err(|e| anyhow::anyhow!("failed to write {}: {}", dest.display(), e))?;
+    let prepared = load_and_validate_checkout_entries(&blob_store, [(&file_id, source)])?;
+    let entry = prepared
+        .first()
+        .expect("single-file checkout preflight returns one entry");
+    kin_core::materialize_source_tree(
+        layout.working_dir(),
+        [(&entry.file_id, entry.kind, entry.content.as_slice())],
+    )
+    .map_err(|error| {
+        anyhow::anyhow!(
+            "failed to materialize exact source '{}': {}",
+            normalized,
+            error
+        )
+    })?;
 
     Ok(CheckoutResponse {
         lines: vec![format!(
@@ -153,92 +139,66 @@ pub fn execute_checkout_request(
     })
 }
 
-fn collect_non_tree_files(
-    root: &std::path::Path,
-    current: &std::path::Path,
-    tree: &std::collections::HashMap<FilePathId, Hash256>,
-    files_to_delete: &mut Vec<std::path::PathBuf>,
-) -> Result<()> {
-    let entries = match std::fs::read_dir(current) {
-        Ok(e) => e,
-        Err(_) => return Ok(()),
-    };
+struct PreparedCheckoutEntry {
+    file_id: FilePathId,
+    kind: SourceEntryKind,
+    content: Vec<u8>,
+}
 
-    for entry in entries {
-        let entry = entry?;
-        let path = entry.path();
-        let rel = path.strip_prefix(root)?;
-        let rel_str = rel.to_string_lossy().to_string();
+/// Resolve and verify every graph-owned source object before checkout mutates
+/// the working tree. `BlobStore::read` performs the SHA-256 verification bound
+/// to the requested content address; the tree validator then checks the whole
+/// path set, entry kinds, UTF-8 link payloads, and link targets without IO.
+fn load_and_validate_checkout_entries<'a>(
+    blob_store: &kin_blobs::BlobStore,
+    entries: impl IntoIterator<Item = (&'a FilePathId, &'a ResolvedSourceEntry)>,
+) -> Result<Vec<PreparedCheckoutEntry>> {
+    let mut entries: Vec<_> = entries.into_iter().collect();
+    entries.sort_by(|left, right| left.0 .0.cmp(&right.0 .0));
 
-        if should_skip_checkout_clean(rel) {
-            continue;
-        }
+    let mut prepared = Vec::with_capacity(entries.len());
+    for (file_id, source) in entries {
+        let blob_key = kin_blobs::Hash256(*source.hash.as_bytes());
+        let content = blob_store.read(&blob_key).map_err(|error| {
+            anyhow::anyhow!("failed to read blob for '{}': {}", file_id.0, error)
+        })?;
+        prepared.push(PreparedCheckoutEntry {
+            file_id: file_id.clone(),
+            kind: source.kind,
+            content,
+        });
+    }
+    kin_core::validate_source_tree(
+        prepared
+            .iter()
+            .map(|entry| (&entry.file_id, entry.kind, entry.content.as_slice())),
+    )?;
+    Ok(prepared)
+}
 
-        let ft = entry.file_type()?;
-        if ft.is_dir() {
-            collect_non_tree_files(root, &path, tree, files_to_delete)?;
-        } else if ft.is_file() {
-            let file_id = FilePathId(rel_str);
-            if !tree.contains_key(&file_id) {
-                files_to_delete.push(path);
-            }
+fn resolve_exact_checkout_tree(
+    graph: &kin_db::InMemoryGraph,
+    target_head: &SemanticChangeId,
+) -> Result<HashMap<FilePathId, ResolvedSourceEntry>> {
+    match graph.resolve_source_tree_at(target_head)? {
+        SourceTreeResolution::Exact { entries } => Ok(entries),
+        SourceTreeResolution::Incomplete { gaps } => {
+            let gaps = gaps
+                .iter()
+                .map(|gap| format!("{}@{}:{:?}", gap.file_id, gap.change_id, gap.reason))
+                .collect::<Vec<_>>()
+                .join(", ");
+            Err(anyhow::anyhow!(
+                "checkout requires exact source history at {}, but found unresolved gaps: {}",
+                target_head,
+                gaps
+            ))
         }
     }
-    Ok(())
 }
 
 fn should_skip_checkout_clean(rel: &std::path::Path) -> bool {
-    const SKIP_DIRS: &[&str] = &[
-        ".kin",
-        ".git",
-        "node_modules",
-        "target",
-        "__pycache__",
-        ".next",
-        "dist",
-        "build",
-        "vendor",
-    ];
-
-    rel.components().any(|component| {
-        if let std::path::Component::Normal(name) = component {
-            SKIP_DIRS
-                .iter()
-                .any(|skip| name == std::ffi::OsStr::new(skip))
-        } else {
-            false
-        }
-    })
-}
-
-fn clean_empty_dirs(root: &std::path::Path, current: &std::path::Path) -> Result<bool> {
-    let entries = match std::fs::read_dir(current) {
-        Ok(e) => e,
-        Err(_) => return Ok(false),
-    };
-
-    let mut is_empty = true;
-    for entry in entries {
-        let entry = entry?;
-        let path = entry.path();
-        let ft = entry.file_type()?;
-        if ft.is_dir() {
-            let rel = path.strip_prefix(root)?;
-            if should_skip_checkout_clean(rel) {
-                is_empty = false;
-                continue;
-            }
-            let child_empty = clean_empty_dirs(root, &path)?;
-            if child_empty {
-                let _ = std::fs::remove_dir(&path);
-            } else {
-                is_empty = false;
-            }
-        } else {
-            is_empty = false;
-        }
-    }
-    Ok(is_empty)
+    kin_core::should_preserve_checkout_path(rel)
 }
 
 fn normalize_checkout_path(path: &str) -> &str {
@@ -248,6 +208,7 @@ fn normalize_checkout_path(path: &str) -> &str {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use kin_model::{ArtifactDelta, ArtifactDeltaKind, AuthorId, SemanticChange, Timestamp};
 
     #[test]
     fn normalizes_relative_path_prefix() {
@@ -280,6 +241,9 @@ mod tests {
             ".git/config"
         )));
         assert!(should_skip_checkout_clean(std::path::Path::new(
+            "nested/.KIN-SESSION/base.json"
+        )));
+        assert!(should_skip_checkout_clean(std::path::Path::new(
             "target/debug/app"
         )));
         assert!(should_skip_checkout_clean(std::path::Path::new(
@@ -293,47 +257,208 @@ mod tests {
         )));
     }
 
+    #[cfg(unix)]
     #[test]
-    fn collect_non_tree_files_ignores_tracked_and_skip_dirs() {
+    fn full_tree_projection_ignores_tracked_and_skip_dirs() {
         let temp = tempfile::tempdir().unwrap();
         let root = temp.path();
         std::fs::create_dir_all(root.join("src")).unwrap();
         std::fs::create_dir_all(root.join(".kin")).unwrap();
+        std::fs::create_dir_all(root.join(".kin-session")).unwrap();
         std::fs::create_dir_all(root.join("target/debug")).unwrap();
         std::fs::write(root.join("src/lib.rs"), "tracked").unwrap();
         std::fs::write(root.join("src/old.rs"), "delete").unwrap();
         std::fs::write(root.join(".kin/state"), "keep").unwrap();
+        std::fs::write(root.join(".kin-session/base.json"), "keep").unwrap();
         std::fs::write(root.join("target/debug/app"), "keep").unwrap();
 
-        let mut tree = std::collections::HashMap::new();
-        tree.insert(
-            FilePathId("src/lib.rs".to_string()),
-            Hash256::from_bytes([0; 32]),
-        );
+        let tracked = FilePathId("src/lib.rs".to_string());
+        kin_core::replace_source_tree(
+            root,
+            [(
+                &tracked,
+                SourceEntryKind::File { executable: false },
+                b"new".as_slice(),
+            )],
+            should_skip_checkout_clean,
+        )
+        .unwrap();
 
-        let mut files = Vec::new();
-        collect_non_tree_files(root, root, &tree, &mut files).unwrap();
-        let rels: Vec<_> = files
-            .iter()
-            .map(|path| path.strip_prefix(root).unwrap().to_path_buf())
-            .collect();
-
-        assert_eq!(rels, vec![std::path::PathBuf::from("src/old.rs")]);
+        assert_eq!(std::fs::read(root.join("src/lib.rs")).unwrap(), b"new");
+        assert!(!root.join("src/old.rs").exists());
+        assert!(root.join(".kin/state").exists());
+        assert!(root.join(".kin-session/base.json").exists());
+        assert!(root.join("target/debug/app").exists());
     }
 
+    #[cfg(unix)]
     #[test]
-    fn clean_empty_dirs_removes_only_untracked_empty_dirs() {
+    fn full_tree_projection_leaves_blocking_ancestor_for_tree_preparation() {
+        let temp = tempfile::tempdir().unwrap();
+        let root = temp.path();
+        std::fs::write(root.join("a-parent"), "blocking file").unwrap();
+        std::fs::write(root.join("untracked.txt"), "delete").unwrap();
+
+        let tracked = FilePathId("a-parent/child.txt".to_string());
+        kin_core::replace_source_tree(
+            root,
+            [(
+                &tracked,
+                SourceEntryKind::File { executable: false },
+                b"child".as_slice(),
+            )],
+            should_skip_checkout_clean,
+        )
+        .unwrap();
+
+        assert_eq!(
+            std::fs::read(root.join("a-parent/child.txt")).unwrap(),
+            b"child"
+        );
+        assert!(!root.join("untracked.txt").exists());
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn full_tree_projection_removes_only_untracked_empty_dirs() {
         let temp = tempfile::tempdir().unwrap();
         let root = temp.path();
         std::fs::create_dir_all(root.join("src/empty/nested")).unwrap();
         std::fs::create_dir_all(root.join(".kin/empty")).unwrap();
         std::fs::create_dir_all(root.join("crates/app/target")).unwrap();
 
-        let root_empty = clean_empty_dirs(root, root).unwrap();
+        let tracked = FilePathId("tracked.txt".to_string());
+        kin_core::replace_source_tree(
+            root,
+            [(
+                &tracked,
+                SourceEntryKind::File { executable: false },
+                b"tracked".as_slice(),
+            )],
+            should_skip_checkout_clean,
+        )
+        .unwrap();
 
-        assert!(!root_empty);
         assert!(!root.join("src/empty").exists());
         assert!(root.join(".kin/empty").exists());
         assert!(root.join("crates/app/target").exists());
+    }
+
+    #[test]
+    fn late_missing_blob_preserves_destructive_transition_tree() {
+        let temp = tempfile::tempdir().unwrap();
+        let layout = kin_core::KinLayout::new(temp.path().join(".kin"));
+        let blob_store = kin_blobs::BlobStore::new(layout.objects_dir()).unwrap();
+        let valid_hash = blob_store.write(b"new child\n").unwrap();
+        let missing_hash = Hash256::from_bytes([0xf1; 32]);
+        let change = SemanticChange {
+            id: SemanticChangeId::from_hash(Hash256::from_bytes([0xa1; 32])),
+            parents: vec![],
+            timestamp: Timestamp::now(),
+            author: AuthorId::new("checkout-test"),
+            message: "exact checkout fixture".to_string(),
+            entity_deltas: vec![],
+            relation_deltas: vec![],
+            artifact_deltas: vec![
+                ArtifactDelta {
+                    file_id: FilePathId("a-parent/child.txt".to_string()),
+                    kind: ArtifactDeltaKind::AddedRegularFile,
+                    old_hash: None,
+                    new_hash: Some(valid_hash),
+                },
+                ArtifactDelta {
+                    file_id: FilePathId("z-missing.txt".to_string()),
+                    kind: ArtifactDeltaKind::AddedRegularFile,
+                    old_hash: None,
+                    new_hash: Some(missing_hash),
+                },
+            ],
+            projected_files: vec![],
+            spec_link: None,
+            evidence: vec![],
+            risk_summary: None,
+            authored_on: None,
+        };
+        let graph = kin_db::InMemoryGraph::new();
+        graph.create_change(&change).unwrap();
+
+        std::fs::write(temp.path().join("a-parent"), b"old file stays\n").unwrap();
+        std::fs::write(temp.path().join("sentinel"), b"untouched\n").unwrap();
+
+        let error = execute_checkout_request(
+            &layout,
+            &graph,
+            &CheckoutRequest {
+                path: ".".to_string(),
+                change_id: Some(change.id.to_string()),
+            },
+        )
+        .expect_err("all blobs must verify before a file-to-directory transition");
+
+        assert!(error.to_string().contains("z-missing.txt"));
+        let metadata = std::fs::symlink_metadata(temp.path().join("a-parent")).unwrap();
+        assert!(
+            metadata.is_file(),
+            "the blocking file shape must be preserved"
+        );
+        assert_eq!(
+            std::fs::read(temp.path().join("a-parent")).unwrap(),
+            b"old file stays\n"
+        );
+        assert_eq!(
+            std::fs::read(temp.path().join("sentinel")).unwrap(),
+            b"untouched\n"
+        );
+        assert!(!temp.path().join("a-parent/child.txt").exists());
+    }
+
+    #[test]
+    fn checkout_replaces_blocking_ancestor_without_redeleting_new_directory() {
+        let temp = tempfile::tempdir().unwrap();
+        let layout = kin_core::KinLayout::new(temp.path().join(".kin"));
+        let blob_store = kin_blobs::BlobStore::new(layout.objects_dir()).unwrap();
+        let child_hash = blob_store.write(b"new child\n").unwrap();
+        let change = SemanticChange {
+            id: SemanticChangeId::from_hash(Hash256::from_bytes([0xa2; 32])),
+            parents: vec![],
+            timestamp: Timestamp::now(),
+            author: AuthorId::new("checkout-test"),
+            message: "blocking ancestor fixture".to_string(),
+            entity_deltas: vec![],
+            relation_deltas: vec![],
+            artifact_deltas: vec![ArtifactDelta {
+                file_id: FilePathId("a-parent/child.txt".to_string()),
+                kind: ArtifactDeltaKind::AddedRegularFile,
+                old_hash: None,
+                new_hash: Some(child_hash),
+            }],
+            projected_files: vec![],
+            spec_link: None,
+            evidence: vec![],
+            risk_summary: None,
+            authored_on: None,
+        };
+        let graph = kin_db::InMemoryGraph::new();
+        graph.create_change(&change).unwrap();
+
+        std::fs::write(temp.path().join("a-parent"), b"old blocking file\n").unwrap();
+        std::fs::write(temp.path().join("untracked.txt"), b"remove me\n").unwrap();
+
+        execute_checkout_request(
+            &layout,
+            &graph,
+            &CheckoutRequest {
+                path: ".".to_string(),
+                change_id: Some(change.id.to_string()),
+            },
+        )
+        .expect("blocking ancestor should be replaced by the tracked tree");
+
+        assert!(temp.path().join("a-parent").is_dir());
+        assert_eq!(
+            std::fs::read(temp.path().join("a-parent/child.txt")).unwrap(),
+            b"new child\n"
+        );
+        assert!(!temp.path().join("untracked.txt").exists());
     }
 }

--- a/crates/kin-cli/src/commands/commit.rs
+++ b/crates/kin-cli/src/commands/commit.rs
@@ -479,11 +479,8 @@ async fn run_local_commit_pipeline_for_tests(
     let write_start = Instant::now();
 
     // Build the semantic change
-    let content_id =
-        kin_core::content_identity_from_deltas(&entity_deltas, &relation_deltas, &artifact_deltas);
-    let change_id = kin_core::compute_change_id(&message, &parent_id, &content_id);
-    let change = SemanticChange {
-        id: change_id,
+    let mut change = SemanticChange {
+        id: kin_model::SemanticChangeId::from_hash(kin_model::Hash256::from_bytes([0; 32])),
         parents: vec![parent_id],
         timestamp: Timestamp::now(),
         author: AuthorId::new(kin_core::whoami()),
@@ -497,6 +494,8 @@ async fn run_local_commit_pipeline_for_tests(
         risk_summary: None,
         authored_on: Some(branch_name.clone()),
     };
+    change.id = kin_core::compute_semantic_change_id(&change)?;
+    let change_id = change.id;
 
     let details = Some(format!(
         "branch={}; entities={}; relations={}; files={}",

--- a/crates/kin-cli/src/commands/init.rs
+++ b/crates/kin-cli/src/commands/init.rs
@@ -8,10 +8,11 @@ use kin_model::ChangeStore;
 use kin_model::EntityStore;
 use kin_model::VerificationStore;
 use kin_model::{
-    ArtifactId, AuthorId, Entity, EntityDelta, EntityFilter, EntityId, FileLayout, FilePathId,
-    GraphNodeId, Hash256, OpaqueArtifact, ParseCompleteness, Relation, RelationDelta, RelationId,
-    RelationKind, RelationOrigin, SemanticChange, SemanticChangeId, ShallowTrackedFile,
-    SourceRegion, StructuredArtifact, TestCase, TestId, TestKind, TestRunner, Timestamp, WorkScope,
+    ArtifactDeltaKind, ArtifactId, AuthorId, Entity, EntityDelta, EntityFilter, EntityId,
+    FileLayout, FilePathId, GraphNodeId, Hash256, OpaqueArtifact, ParseCompleteness, Relation,
+    RelationDelta, RelationId, RelationKind, RelationOrigin, ResolvedSourceEntry, SemanticChange,
+    SemanticChangeId, ShallowTrackedFile, SourceEntryKind, SourceRegion, SourceTreeResolution,
+    StructuredArtifact, TestCase, TestId, TestKind, TestRunner, Timestamp, WorkScope,
 };
 use kin_projection::build_layout;
 use rayon::prelude::*;
@@ -248,6 +249,14 @@ struct IndexableFile {
     classification: FileClassification,
 }
 
+#[derive(Debug, Clone)]
+struct ExactInitSourceEntry {
+    abs_path: PathBuf,
+    rel_path: String,
+    hash: [u8; 32],
+    kind: kin_model::SourceEntryKind,
+}
+
 #[derive(Debug, Clone, Copy, Default, Serialize)]
 struct InitIndexSummary {
     total_entity_count: usize,
@@ -287,10 +296,9 @@ struct WarmCacheDeltaResult {
     queued_artifacts: Vec<ArtifactId>,
 }
 
-/// Take an independent copy-based snapshot of the working tree before `kin init`
-/// mutates it.  We always use `fs::copy()` rather than hardlinks because
-/// hardlinks share inodes — modifying the original file after init would
-/// silently corrupt the snapshot.
+/// Take an independent snapshot of the working tree before `kin init` mutates
+/// it. Regular files are copied rather than hardlinked; symbolic links are
+/// recreated with their exact target bytes.
 /// Take snapshot BEFORE kin init creates .kin/.
 /// We snapshot to a temp dir, then move it into .kin/snapshot/ after init succeeds.
 ///
@@ -375,10 +383,8 @@ fn walk_and_snapshot(
     file_count: &mut u64,
     total_bytes: &mut u64,
 ) -> Result<()> {
-    let entries = match fs::read_dir(current) {
-        Ok(e) => e,
-        Err(_) => return Ok(()), // skip unreadable dirs
-    };
+    let entries = fs::read_dir(current)
+        .with_context(|| format!("read source directory {}", current.display()))?;
 
     for entry in entries {
         let entry = entry?;
@@ -406,8 +412,25 @@ fn walk_and_snapshot(
 
             *total_bytes += entry.metadata()?.len();
             *file_count += 1;
+        } else if ft.is_symlink() {
+            #[cfg(not(unix))]
+            anyhow::bail!(
+                "kin init cannot preserve symbolic link {} on this platform",
+                rel.display()
+            );
+            #[cfg(unix)]
+            {
+                let dest = snapshot_dir.join(rel);
+                if let Some(parent) = dest.parent() {
+                    fs::create_dir_all(parent)?;
+                }
+                let target = fs::read_link(&path)?;
+                std::os::unix::fs::symlink(&target, &dest)?;
+                *total_bytes += target.as_os_str().len() as u64;
+                *file_count += 1;
+            }
         }
-        // Skip symlinks / other special types.
+        // Skip other special types.
     }
 
     Ok(())
@@ -566,6 +589,53 @@ fn stable_change_payload_without_parents_matches(
     }
 
     matches!((payload(left), payload(right)), (Some(left), Some(right)) if left == right)
+        || legacy_git_source_mode_upgrade_matches(left, right, true)
+}
+
+/// Prove that an existing Git-derived change differs from the freshly
+/// imported canonical record only because pre-0.3 history lacked exact source
+/// entry kinds. Git OID-derived change IDs intentionally remain stable, so
+/// this narrow matcher authorizes an in-place history migration instead of
+/// treating the exact-mode payload upgrade as an unrelated ID collision.
+fn legacy_git_source_mode_upgrade_matches(
+    existing: &SemanticChange,
+    canonical: &SemanticChange,
+    ignore_parents: bool,
+) -> bool {
+    if existing.id != canonical.id
+        || existing.artifact_deltas.len() != canonical.artifact_deltas.len()
+    {
+        return false;
+    }
+    let mut normalized = existing.clone();
+    if ignore_parents {
+        normalized.parents = canonical.parents.clone();
+    }
+    let mut upgraded_any = false;
+    for (old, exact) in normalized
+        .artifact_deltas
+        .iter_mut()
+        .zip(&canonical.artifact_deltas)
+    {
+        let compatible_legacy_kind = match old.kind {
+            ArtifactDeltaKind::Added => {
+                exact.kind.is_added() && exact.kind.source_entry_kind().is_some()
+            }
+            ArtifactDeltaKind::Modified => {
+                exact.kind.is_modified() && exact.kind.source_entry_kind().is_some()
+            }
+            _ => false,
+        };
+        if compatible_legacy_kind {
+            old.kind = exact.kind;
+            upgraded_any = true;
+        }
+    }
+    upgraded_any
+        && matches!(
+            (serde_json::to_value(&normalized), serde_json::to_value(canonical)),
+            (Ok(normalized), Ok(canonical)) if normalized == canonical
+        )
 }
 
 /// Publish a deterministic init/import change exactly once.
@@ -728,6 +798,88 @@ fn candidate_parent_path_reaches(
     false
 }
 
+fn legacy_window_parent_shape_matches(
+    existing: &[SemanticChangeId],
+    canonical: &[SemanticChangeId],
+    boundary_root: SemanticChangeId,
+    anchor_ids: &HashMap<SemanticChangeId, SemanticChangeId>,
+) -> bool {
+    fn push_unique(output: &mut Vec<SemanticChangeId>, parent: SemanticChangeId) {
+        if !output.contains(&parent) {
+            output.push(parent);
+        }
+    }
+
+    if existing == canonical || canonical.is_empty() {
+        return false;
+    }
+
+    // The oldest record from the earliest truncated importer collapsed every
+    // missing Git parent to the Kin boundary root, deduplicating merges.
+    let mut collapsed = Vec::with_capacity(canonical.len());
+    for parent in canonical {
+        let replacement = if existing.contains(parent) {
+            *parent
+        } else {
+            boundary_root
+        };
+        push_unique(&mut collapsed, replacement);
+    }
+    if existing == collapsed {
+        return true;
+    }
+
+    // The later exact-tree truncated importer replaced each omitted Git
+    // parent with its deterministic base-link change. Recompute only those
+    // IDs from canonical Git OIDs; arbitrary parent substitutions stay
+    // unrecognized and are never rewritten.
+    let mut anchored = Vec::with_capacity(canonical.len());
+    for parent in canonical {
+        let replacement = if existing.contains(parent) {
+            *parent
+        } else if let Some(anchor) = anchor_ids.get(parent) {
+            *anchor
+        } else {
+            return false;
+        };
+        push_unique(&mut anchored, replacement);
+    }
+    existing == anchored
+}
+
+/// Recognize the reverse transition: an existing commit already has its real
+/// Git parents (from a wider/older window), while the newly bounded import has
+/// replaced one or more now-omitted parents with deterministic base links.
+/// Keeping the already-materialized real-parent payload makes Git-OID-derived
+/// change IDs stable as a 50-commit window slides or after `full -> recent`.
+fn existing_parent_shape_matches_anchored_window(
+    existing: &[SemanticChangeId],
+    canonical: &[SemanticChangeId],
+    anchor_targets: &HashMap<SemanticChangeId, SemanticChangeId>,
+) -> bool {
+    fn push_unique(output: &mut Vec<SemanticChangeId>, parent: SemanticChangeId) {
+        if !output.contains(&parent) {
+            output.push(parent);
+        }
+    }
+
+    if existing == canonical || canonical.is_empty() {
+        return false;
+    }
+    let mut expanded = Vec::with_capacity(canonical.len());
+    let mut expanded_anchor = false;
+    for parent in canonical {
+        let resolved = if let Some(target) = anchor_targets.get(parent) {
+            expanded_anchor = true;
+            *target
+        } else {
+            *parent
+        };
+        push_unique(&mut expanded, resolved);
+    }
+    expanded_anchor && existing == expanded
+}
+
 fn candidate_reverse_index_needs_rebuild(
     snapshot: &kin_db::GraphSnapshot,
     candidate_ids: &HashSet<SemanticChangeId>,
@@ -802,7 +954,44 @@ struct LegacyImportRepairOutcome {
     rebuilt_derived_indexes: bool,
 }
 
-/// Repair only the two provable legacy Git-import defects.
+fn upgrade_legacy_git_import_source_modes(
+    manager: &kin_db::SnapshotManager,
+    layout: &kin_core::KinLayout,
+    boundary_root: SemanticChangeId,
+    canonical_imported: &[kin_git::ImportedChange],
+) -> Result<usize> {
+    if canonical_imported.is_empty() {
+        return Ok(0);
+    }
+    let mut snapshot = manager.graph().to_snapshot();
+    let mut upgraded = 0_usize;
+    for canonical in canonical_imported {
+        let Some(existing) = snapshot.changes.get(&canonical.change.id) else {
+            continue;
+        };
+        if legacy_git_source_mode_upgrade_matches(existing, &canonical.change, false) {
+            snapshot
+                .changes
+                .insert(canonical.change.id, canonical.change.clone());
+            upgraded += 1;
+        }
+    }
+    if upgraded == 0 {
+        return Ok(0);
+    }
+
+    validate_repaired_change_history(&snapshot.changes, &snapshot.branches, boundary_root)?;
+    rebuild_history_derived_indexes(&mut snapshot);
+    let upgraded_graph =
+        kin_db::InMemoryGraph::from_snapshot_with_text_index(snapshot, layout.text_index_dir());
+    manager.swap(upgraded_graph);
+    manager
+        .save()
+        .context("persist exact-source mode upgrade for Git-derived history")?;
+    Ok(upgraded)
+}
+
+/// Repair only provable legacy Git-import defects.
 ///
 /// Old warm init passed the current imported head as the import boundary. The
 /// resulting persisted cycle is recognizable only after a fresh canonical Git
@@ -810,14 +999,19 @@ struct LegacyImportRepairOutcome {
 /// canonical genesis to one imported descendant, and that descendant's stored
 /// parent path closes the cycle. Separately, boundary-correct releases still
 /// reinserted deterministic imported ids and could duplicate reverse edges and
-/// revision generations. Both cases rebuild the derived indexes from immutable
-/// change truth. Any unrelated self-edge/cycle remains after the narrowly
-/// proven substitution and is refused by full-DAG validation.
+/// revision generations. Pre-0.3 `recent` imports also substituted the Kin
+/// boundary or a deterministic base-link for omitted Git parents, changing the
+/// immutable payload of the same Git-OID-derived change when a later `full`
+/// import widened the window. That exact substitution is migrated back to the
+/// canonical Git parent and the newly reachable canonical ancestors are
+/// installed in the same snapshot transaction. All cases rebuild derived
+/// indexes from immutable change truth. Any unrelated parent mismatch or cycle
+/// remains after the narrowly proven substitutions and is refused.
 fn repair_legacy_git_import_history(
     manager: &kin_db::SnapshotManager,
     layout: &kin_core::KinLayout,
     boundary_root: SemanticChangeId,
-    canonical_imported: &[kin_git::ImportedChange],
+    canonical_imported: &mut [kin_git::ImportedChange],
 ) -> Result<LegacyImportRepairOutcome> {
     if canonical_imported.is_empty() {
         return Ok(LegacyImportRepairOutcome::default());
@@ -828,9 +1022,27 @@ fn repair_legacy_git_import_history(
         .iter()
         .map(|entry| entry.change.id)
         .collect();
+    let anchor_ids: HashMap<_, _> = canonical_imported
+        .iter()
+        .map(|entry| {
+            kin_git::base_link_change_id_from_git_oid_hex(&entry.git_oid)
+                .map(|anchor| (entry.change.id, anchor))
+        })
+        .collect::<std::result::Result<_, _>>()?;
+    let mut anchor_targets = HashMap::new();
+    for entry in canonical_imported.iter() {
+        let anchor = kin_git::base_link_change_id_from_git_oid_hex(&entry.git_oid)?;
+        if entry.change.id == anchor {
+            anchor_targets.insert(
+                anchor,
+                kin_git::semantic_change_id_from_git_oid_hex(&entry.git_oid)?,
+            );
+        }
+    }
     let mut mismatches = Vec::<(SemanticChangeId, SemanticChangeId)>::new();
+    let mut window_mismatches = HashSet::new();
     let mut unrecognized_payload_or_parent = false;
-    for canonical in canonical_imported {
+    for canonical in canonical_imported.iter_mut() {
         let Some(existing) = snapshot.changes.get(&canonical.change.id) else {
             continue;
         };
@@ -839,6 +1051,35 @@ fn repair_legacy_git_import_history(
             continue;
         }
         if existing.parents == canonical.change.parents {
+            continue;
+        }
+        if existing_parent_shape_matches_anchored_window(
+            &existing.parents,
+            &canonical.change.parents,
+            &anchor_targets,
+        ) {
+            if existing
+                .parents
+                .iter()
+                .all(|parent| *parent == boundary_root || snapshot.changes.contains_key(parent))
+            {
+                // The wider parent chain is already graph authority. Normalize
+                // this bounded import back to that immutable payload before
+                // exact-once insertion, instead of downgrading the same ID to
+                // a window-relative anchor parent.
+                canonical.change.parents = existing.parents.clone();
+                continue;
+            }
+            unrecognized_payload_or_parent = true;
+            continue;
+        }
+        if legacy_window_parent_shape_matches(
+            &existing.parents,
+            &canonical.change.parents,
+            boundary_root,
+            &anchor_ids,
+        ) {
+            window_mismatches.insert(canonical.change.id);
             continue;
         }
         let matching_targets: Vec<_> = candidate_ids
@@ -872,16 +1113,39 @@ fn repair_legacy_git_import_history(
             )
         });
 
+    let window_shape_proven = !window_mismatches.is_empty() && !unrecognized_payload_or_parent;
     let mut corrected_changes = 0usize;
+    if window_shape_proven {
+        for canonical in canonical_imported.iter() {
+            if window_mismatches.contains(&canonical.change.id) {
+                snapshot
+                    .changes
+                    .insert(canonical.change.id, canonical.change.clone());
+                corrected_changes += 1;
+            }
+        }
+    }
     if legacy_shape_proven {
         let mismatch_ids: HashSet<_> = mismatches.iter().map(|(id, _)| *id).collect();
-        for canonical in canonical_imported {
+        for canonical in canonical_imported.iter() {
             if mismatch_ids.contains(&canonical.change.id) {
                 snapshot
                     .changes
                     .insert(canonical.change.id, canonical.change.clone());
                 corrected_changes += 1;
             }
+        }
+    }
+
+    if window_shape_proven {
+        // A corrected boundary now points at ancestors the old bounded window
+        // never stored. Install the already-enriched canonical records before
+        // validating or publishing the migrated snapshot.
+        for canonical in canonical_imported.iter() {
+            snapshot
+                .changes
+                .entry(canonical.change.id)
+                .or_insert_with(|| canonical.change.clone());
         }
     }
 
@@ -1114,12 +1378,36 @@ pub async fn run(
     let all_files = collect_source_files(&tmp_snapshot)?;
     phase!("collect_source_files");
 
+    let exact_source_entries = collect_exact_init_source_entries(&tmp_snapshot, &all_files)?;
+    phase!("collect_exact_source_entries");
+
+    // Persist exact bytes while the frozen snapshot still lives at its
+    // temporary path. `move_snapshot_into_place` renames that directory, so
+    // deferring this backfill until after the move makes every retained
+    // `abs_path` stale (most visibly for symlinks, which parsing skips).
+    for entry in &exact_source_entries {
+        let blob_hash = kin_blobs::Hash256::from_bytes(entry.hash);
+        if !blob_store.exists(&blob_hash).unwrap_or(false) {
+            let (content, observed_kind) = read_exact_init_source(&entry.abs_path)?;
+            if observed_kind != entry.kind || kin_blobs::digest_bytes(&content) != entry.hash {
+                anyhow::bail!(
+                    "frozen init source changed while building graph authority: {}",
+                    entry.rel_path
+                );
+            }
+            blob_store
+                .write(&content)
+                .with_context(|| format!("store exact init source {}", entry.rel_path))?;
+        }
+    }
+    phase!("persist_exact_source_entries");
+
     let indexable_files = collect_indexable_files(&tmp_snapshot, &all_files)?;
     phase!("collect_indexable_files");
     let (entity_source_input_count, shallow_source_input_count) =
         count_supported_source_inputs(&indexable_files);
 
-    let init_summary = if !all_files.is_empty() {
+    let init_summary = if !all_files.is_empty() || is_warm {
         if is_warm {
             // NATIVE WARM CACHE: Run the diff directly against the existing graph!
             let graph = snap.graph();
@@ -1193,41 +1481,33 @@ pub async fn run(
 
     let mut graph = snap.graph();
     let branch_name = kin_core::read_current_branch(&layout)?;
-    if !all_files.is_empty() {
+    if !all_files.is_empty() || is_warm {
         // Build a semantic change for the initial parse.
         // Include artifact_deltas for every file so that the VFS tree
         // (built from the change DAG) knows which files exist.
         let change_id = compute_init_change_id(
             &auto_parse_parent_id,
             &compute_artifact_fingerprint(
-                indexable_files
+                exact_source_entries
                     .iter()
-                    .map(|f| (f.rel_path.as_str(), &f.hash)),
+                    .map(|entry| (entry.rel_path.as_str(), &entry.hash, entry.kind)),
             ),
         );
 
-        // Ensure every tracked file has its blob in the store.
-        // The warm-cache path may skip unchanged files, leaving blobs missing.
-        // Read from the working directory (not snapshot) as a fallback.
-        for f in &indexable_files {
-            let blob_hash = kin_blobs::Hash256::from_bytes(f.hash);
-            if !blob_store.exists(&blob_hash).unwrap_or(false) {
-                let work_path = dir.join(&f.rel_path);
-                if let Ok(content) = fs::read(&work_path) {
-                    let _ = blob_store.write(&content);
-                }
+        let artifact_deltas = match graph.resolve_source_tree_at(&auto_parse_parent_id)? {
+            SourceTreeResolution::Exact { entries } => {
+                build_exact_init_artifact_deltas(entries, &exact_source_entries)
             }
-        }
-
-        let artifact_deltas: Vec<_> = indexable_files
-            .iter()
-            .map(|f| kin_model::ArtifactDelta {
-                file_id: FilePathId::new(&f.rel_path),
-                kind: kin_model::ArtifactDeltaKind::Added,
-                old_hash: None,
-                new_hash: Some(kin_model::Hash256::from_bytes(f.hash)),
-            })
-            .collect();
+            SourceTreeResolution::Incomplete { gaps } => {
+                warn!(
+                    gap_count = gaps.len(),
+                    parent = %auto_parse_parent_id,
+                    "repairing incomplete legacy source history from the frozen init snapshot"
+                );
+                let parent_file_tree = graph.resolve_file_tree_at(&auto_parse_parent_id)?;
+                build_exact_init_repair_deltas(parent_file_tree, &exact_source_entries)
+            }
+        };
         let mut all_entities = graph.list_all_entities()?;
         // `list_all_entities` is backed by a hash map. Canonicalize its order
         // before it becomes a deterministic init change payload so a repeated
@@ -1312,6 +1592,7 @@ pub async fn run(
                 Some(&blob_store),
             ) {
                 Ok(mut imported) if !imported.is_empty() => {
+                    let imported_git_commit_count = imported.len();
                     // Anchor the (possibly truncated) history at a full base
                     // universe so ref-scoped blast at historical refs sees
                     // committed inbound edges across files untouched inside
@@ -1328,13 +1609,11 @@ pub async fn run(
                             debug!(base_link = %base_id, "anchored imported history at base-link change");
                         }
                         Ok(None) => {}
-                        Err(err) => {
-                            warn!(
-                                error = %err,
-                                mode = %git_history,
-                                "failed to anchor imported Git history at a base-link change; continuing without base-universe anchoring"
-                            );
-                        }
+                        Err(err) => return Err(err).with_context(|| {
+                            format!(
+                                "anchor imported Git history at its exact base universe ({git_history})"
+                            )
+                        }),
                     }
 
                     // Historical semantic truth is an authority path. A
@@ -1355,7 +1634,7 @@ pub async fn run(
                         &snap,
                         &layout,
                         history_boundary_root,
-                        &imported,
+                        &mut imported,
                     )?;
                     if repair.rebuilt_derived_indexes {
                         warn!(
@@ -1365,6 +1644,20 @@ pub async fn run(
                         // `SnapshotManager::swap` is RCU-style. Refresh the
                         // caller's Arc so exact-once collision checks target
                         // the repaired graph rather than the retired view.
+                        graph = snap.graph();
+                    }
+
+                    let upgraded_source_modes = upgrade_legacy_git_import_source_modes(
+                        &snap,
+                        &layout,
+                        history_boundary_root,
+                        &imported,
+                    )?;
+                    if upgraded_source_modes > 0 {
+                        warn!(
+                            upgraded_changes = upgraded_source_modes,
+                            "upgraded Git-derived history to exact source entry modes"
+                        );
                         graph = snap.graph();
                     }
 
@@ -1408,7 +1701,7 @@ pub async fn run(
                         };
                         println!(
                             "  Imported {} {mode_label} Git commit(s) as semantic history.",
-                            imported.len()
+                            imported_git_commit_count
                         );
                     }
                 }
@@ -1821,22 +2114,20 @@ impl Clone for ImportedCommitSemanticState {
     }
 }
 
-/// Deterministic topological order over the first-parent forest.
+/// Deterministic topological order over the complete imported parent DAG.
 ///
-/// `first_parent_index[c]` is the slice index of commit `c`'s first git parent
-/// when that parent is itself in the imported set (`None` for a root or a parent
-/// below the import horizon). Each commit has at most one in-set first parent,
-/// so "process a commit after its first parent" is a forest constraint; Kahn's
-/// algorithm seeded and drained in ascending index order yields a stable order
-/// in which every commit follows its first parent, staying as close as possible
-/// to the input order. An (impossible for Git) cycle is rejected instead of
-/// manufacturing an order that would replay a child before its baseline.
-fn first_parent_topological_order(first_parent_index: &[Option<usize>]) -> Result<Vec<usize>> {
-    let n = first_parent_index.len();
+/// Every in-set parent must be processed before its child. This is stricter
+/// than the first-parent ordering required to compute a Git commit's target
+/// tree: merge-delta rebasing also resolves the runtime all-parent baseline, so
+/// every secondary parent must already be present in the scratch change store.
+/// Kahn's algorithm is seeded and drained in ascending input-index order to keep
+/// the result byte-stable and as close as possible to the importer order.
+fn full_parent_topological_order(parent_indices: &[Vec<usize>]) -> Result<Vec<usize>> {
+    let n = parent_indices.len();
     let mut children: Vec<Vec<usize>> = vec![Vec::new(); n];
     let mut indegree = vec![0usize; n];
-    for (child, parent) in first_parent_index.iter().enumerate() {
-        if let Some(parent) = *parent {
+    for (child, parents) in parent_indices.iter().enumerate() {
+        for &parent in parents {
             children[parent].push(child);
             indegree[child] += 1;
         }
@@ -1856,7 +2147,7 @@ fn first_parent_topological_order(first_parent_index: &[Option<usize>]) -> Resul
     }
     if order.len() != n {
         return Err(anyhow!(
-            "historical hydration invariant violated: imported first-parent graph contains a cycle"
+            "historical hydration invariant violated: imported parent DAG contains a cycle"
         ));
     }
     Ok(order)
@@ -1882,6 +2173,7 @@ fn validate_imported_parent_closure(
         }
     }
     for imported_change in imported {
+        let mut unique_parents = HashSet::with_capacity(imported_change.change.parents.len());
         if imported_change.change.parents.is_empty() {
             return Err(anyhow!(
                 "historical hydration invariant violated: imported change {} has no parent; Git roots must reference canonical genesis {}",
@@ -1890,6 +2182,13 @@ fn validate_imported_parent_closure(
             ));
         }
         for parent in &imported_change.change.parents {
+            if !unique_parents.insert(*parent) {
+                return Err(anyhow!(
+                    "historical hydration invariant violated: imported change {} repeats parent {}",
+                    imported_change.change.id,
+                    parent
+                ));
+            }
             if *parent != boundary_root && !imported_ids.contains(parent) {
                 return Err(anyhow!(
                     "historical hydration invariant violated: imported change {} has dangling parent {} (expected imported history or canonical genesis {})",
@@ -2180,6 +2479,22 @@ fn enrich_imported_changes_with_semantics_with_checkpoints_and_boundary_root(
             })
         })
         .collect();
+    let all_parent_indices: Vec<Vec<usize>> = imported
+        .iter()
+        .map(|imported_change| {
+            imported_change
+                .change
+                .parents
+                .iter()
+                .filter(|parent| **parent != boundary_root)
+                .map(|parent| {
+                    *index_by_change_id
+                        .get(parent)
+                        .expect("validated imported parent must be present")
+                })
+                .collect()
+        })
+        .collect();
 
     // Count how many in-set commits fork from each commit as their first parent,
     // so a commit's snapshot is retained only while children still need it. This
@@ -2194,7 +2509,7 @@ fn enrich_imported_changes_with_semantics_with_checkpoints_and_boundary_root(
     // store lock or creates any store paths. Git cannot contain a commit
     // cycle, so accepting one here would only turn corrupt input into a later
     // missing-snapshot failure with partial hydration side effects.
-    let order = first_parent_topological_order(&first_parent_index)?;
+    let order = full_parent_topological_order(&all_parent_indices)?;
     let mut snapshots = HashMap::<SemanticChangeId, ImportedCommitSemanticState>::new();
     let mut resumed_from = 0usize;
     let mut checkpoint_session = if let Some(config) = checkpoint_config {
@@ -2262,6 +2577,14 @@ fn enrich_imported_changes_with_semantics_with_checkpoints_and_boundary_root(
             mut relations_by_dst,
             linker: mut incremental_linker,
         } = baseline;
+        let mut merge_runtime_baseline = if imported[i].change.parents.len() > 1 {
+            Some(ImportedRuntimeSemanticState {
+                entities: imported_target_entities(&current_files)?,
+                relations: current_relations.clone(),
+            })
+        } else {
+            None
+        };
 
         let mut entity_deltas = Vec::new();
         let mut relation_deltas = Vec::new();
@@ -2613,6 +2936,26 @@ fn enrich_imported_changes_with_semantics_with_checkpoints_and_boundary_root(
             RelationDelta::Added(relation) => relation.id.0,
             RelationDelta::Removed(relation_id) => relation_id.0,
         });
+
+        // Artifact deltas describe the merge target against its first parent,
+        // while runtime DAG replay reaches a merge by replaying every parent.
+        // Rebase the computed target onto that actual all-parent baseline so a
+        // secondary-parent-only entity or relation cannot leak through merely
+        // because the merge's first-parent target deleted it.
+        if let Some(all_parent_baseline) = merge_runtime_baseline.as_mut() {
+            replay_imported_secondary_parents(
+                all_parent_baseline,
+                imported,
+                &index_by_change_id,
+                boundary_root,
+                &imported[i].change.parents,
+            )?;
+            (entity_deltas, relation_deltas) = rebase_imported_merge_semantic_deltas(
+                all_parent_baseline,
+                &current_files,
+                &current_relations,
+            )?;
+        }
         imported[i].change.entity_deltas = entity_deltas;
         imported[i].change.relation_deltas = relation_deltas;
 
@@ -3034,6 +3377,234 @@ fn imported_relations_equivalent(old: &Relation, new: &Relation) -> bool {
         && old.import_source == new.import_source
         && old.evidence == new.evidence
         && (old.confidence - new.confidence).abs() < f32::EPSILON
+}
+
+fn imported_entities_exactly_equivalent(old: &Entity, new: &Entity) -> bool {
+    old.id == new.id
+        && old.kind == new.kind
+        && old.name == new.name
+        && old.language == new.language
+        && old.fingerprint.algorithm == new.fingerprint.algorithm
+        && old.fingerprint.ast_hash == new.fingerprint.ast_hash
+        && old.fingerprint.signature_hash == new.fingerprint.signature_hash
+        && old.fingerprint.behavior_hash == new.fingerprint.behavior_hash
+        && old.fingerprint.equivalence_hash == new.fingerprint.equivalence_hash
+        && old.fingerprint.stability_score.to_bits() == new.fingerprint.stability_score.to_bits()
+        && old.file_origin == new.file_origin
+        && old.span == new.span
+        && old.signature == new.signature
+        && old.visibility == new.visibility
+        && old.role == new.role
+        && old.doc_summary == new.doc_summary
+        && old.metadata.extra == new.metadata.extra
+        && old.lineage_parent == new.lineage_parent
+        && old.created_in == new.created_in
+        && old.superseded_by == new.superseded_by
+}
+
+fn imported_relations_exactly_equivalent(old: &Relation, new: &Relation) -> bool {
+    old.id == new.id
+        && old.kind == new.kind
+        && old.src == new.src
+        && old.dst == new.dst
+        && old.confidence.to_bits() == new.confidence.to_bits()
+        && old.origin == new.origin
+        && old.created_in == new.created_in
+        && old.import_source == new.import_source
+        && old.evidence == new.evidence
+}
+
+fn imported_target_entities(
+    files: &HashMap<String, ImportedSemanticFileState>,
+) -> Result<HashMap<EntityId, Entity>> {
+    let mut entities = HashMap::new();
+    for file in files.values() {
+        for entity in &file.entities {
+            if entities.insert(entity.id, entity.clone()).is_some() {
+                return Err(anyhow!(
+                    "historical hydration invariant violated: entity {} occurs in more than one imported file state",
+                    entity.id
+                ));
+            }
+        }
+    }
+    Ok(entities)
+}
+
+struct ImportedRuntimeSemanticState {
+    entities: HashMap<EntityId, Entity>,
+    relations: HashMap<RelationId, Relation>,
+}
+
+fn imported_relation_mentions_entity(relation: &Relation, entity_id: EntityId) -> bool {
+    relation.src.as_entity() == Some(entity_id) || relation.dst.as_entity() == Some(entity_id)
+}
+
+/// Apply only the live entity/relation portion of runtime graph replay. This is
+/// deliberately kept field-for-field aligned with `kin_model`'s authoritative
+/// `replay_graph_state`; revisions, tombstones, and artifacts do not affect the
+/// live semantic diff produced by history hydration.
+fn apply_imported_change_to_runtime_state(
+    state: &mut ImportedRuntimeSemanticState,
+    change: &SemanticChange,
+) {
+    for delta in &change.entity_deltas {
+        match delta {
+            EntityDelta::Added(entity) => {
+                state.entities.insert(entity.id, entity.clone());
+            }
+            EntityDelta::Modified { new, .. } => {
+                state.entities.insert(new.id, new.clone());
+            }
+            EntityDelta::Removed(entity_id) => {
+                state.entities.remove(entity_id);
+                state
+                    .relations
+                    .retain(|_, relation| !imported_relation_mentions_entity(relation, *entity_id));
+            }
+        }
+    }
+    for delta in &change.relation_deltas {
+        match delta {
+            RelationDelta::Added(relation) => {
+                state.relations.insert(relation.id, relation.clone());
+            }
+            RelationDelta::Removed(relation_id) => {
+                state.relations.remove(relation_id);
+            }
+        }
+    }
+}
+
+/// Starting from the already-resolved first-parent state, replay exactly the
+/// changes runtime DFS contributes from each later parent. Shared ancestry is
+/// marked visited but never replayed twice. Unlike `resolve_graph_at` per merge,
+/// this traverses only change IDs through shared history and applies semantic
+/// payloads only for secondary-parent-unique changes, avoiding repeated full
+/// graph/revision reconstruction and its high-RSS quadratic behavior.
+fn replay_imported_secondary_parents(
+    state: &mut ImportedRuntimeSemanticState,
+    imported: &[kin_git::ImportedChange],
+    index_by_change_id: &HashMap<SemanticChangeId, usize>,
+    boundary_root: SemanticChangeId,
+    parents: &[SemanticChangeId],
+) -> Result<()> {
+    let Some(first_parent) = parents.first().copied() else {
+        return Err(anyhow!(
+            "historical hydration invariant violated: merge has no first parent"
+        ));
+    };
+
+    let mut visited = HashSet::new();
+    visited.insert(boundary_root);
+
+    // The supplied state already includes the complete first-parent history;
+    // mark that ancestry visited without replaying its semantic payloads.
+    let mut mark_stack = vec![first_parent];
+    while let Some(change_id) = mark_stack.pop() {
+        if !visited.insert(change_id) {
+            continue;
+        }
+        let imported_index = *index_by_change_id.get(&change_id).ok_or_else(|| {
+            anyhow!(
+                "historical hydration invariant violated: runtime replay cannot find imported ancestor {}",
+                change_id
+            )
+        })?;
+        mark_stack.extend(imported[imported_index].change.parents.iter().copied());
+    }
+
+    enum ReplayFrame {
+        Visit(SemanticChangeId),
+        Emit(usize),
+    }
+
+    // Match `collect_changes_topologically`: visit parents left-to-right,
+    // emit each change after its parents, and skip every ID already reached by
+    // an earlier direct parent.
+    for secondary_parent in parents.iter().skip(1).copied() {
+        let mut stack = vec![ReplayFrame::Visit(secondary_parent)];
+        while let Some(frame) = stack.pop() {
+            match frame {
+                ReplayFrame::Visit(change_id) => {
+                    if !visited.insert(change_id) {
+                        continue;
+                    }
+                    let imported_index =
+                        *index_by_change_id.get(&change_id).ok_or_else(|| {
+                            anyhow!(
+                                "historical hydration invariant violated: runtime replay cannot find imported ancestor {}",
+                                change_id
+                            )
+                        })?;
+                    stack.push(ReplayFrame::Emit(imported_index));
+                    for parent in imported[imported_index].change.parents.iter().rev() {
+                        stack.push(ReplayFrame::Visit(*parent));
+                    }
+                }
+                ReplayFrame::Emit(imported_index) => {
+                    apply_imported_change_to_runtime_state(state, &imported[imported_index].change);
+                }
+            }
+        }
+    }
+
+    Ok(())
+}
+
+/// Build the semantic delta that transforms runtime's all-parent merge state
+/// into the target Git tree parsed against the commit's first parent.
+fn rebase_imported_merge_semantic_deltas(
+    all_parent_baseline: &ImportedRuntimeSemanticState,
+    target_files: &HashMap<String, ImportedSemanticFileState>,
+    target_relations: &HashMap<RelationId, Relation>,
+) -> Result<(Vec<EntityDelta>, Vec<RelationDelta>)> {
+    let target_entities = imported_target_entities(target_files)?;
+    let mut entity_ids = BTreeSet::new();
+    entity_ids.extend(all_parent_baseline.entities.keys().copied());
+    entity_ids.extend(target_entities.keys().copied());
+
+    let mut entity_deltas = Vec::new();
+    for entity_id in entity_ids {
+        match (
+            all_parent_baseline.entities.get(&entity_id),
+            target_entities.get(&entity_id),
+        ) {
+            (Some(old), Some(new)) if !imported_entities_exactly_equivalent(old, new) => {
+                entity_deltas.push(EntityDelta::Modified {
+                    old: old.clone(),
+                    new: new.clone(),
+                });
+            }
+            (Some(_), None) => entity_deltas.push(EntityDelta::Removed(entity_id)),
+            (None, Some(new)) => entity_deltas.push(EntityDelta::Added(new.clone())),
+            _ => {}
+        }
+    }
+
+    let mut relation_ids = HashSet::new();
+    relation_ids.extend(all_parent_baseline.relations.keys().copied());
+    relation_ids.extend(target_relations.keys().copied());
+    let mut relation_ids: Vec<_> = relation_ids.into_iter().collect();
+    relation_ids.sort_by_key(|relation_id| relation_id.0);
+
+    let mut relation_deltas = Vec::new();
+    for relation_id in relation_ids {
+        match (
+            all_parent_baseline.relations.get(&relation_id),
+            target_relations.get(&relation_id),
+        ) {
+            (Some(old), Some(new)) if !imported_relations_exactly_equivalent(old, new) => {
+                relation_deltas.push(RelationDelta::Removed(relation_id));
+                relation_deltas.push(RelationDelta::Added(new.clone()));
+            }
+            (Some(_), None) => relation_deltas.push(RelationDelta::Removed(relation_id)),
+            (None, Some(new)) => relation_deltas.push(RelationDelta::Added(new.clone())),
+            _ => {}
+        }
+    }
+
+    Ok((entity_deltas, relation_deltas))
 }
 
 pub(crate) fn entity_fingerprint_changed(old: &Entity, new: &Entity) -> bool {
@@ -3743,6 +4314,13 @@ fn collect_indexable_files(
         Ok(all_files
             .par_iter()
             .filter_map(|file_path| {
+                if fs::symlink_metadata(file_path)
+                    .ok()?
+                    .file_type()
+                    .is_symlink()
+                {
+                    return None;
+                }
                 let source = fs::read(file_path).ok()?;
                 let classification = FileClassifier::classify(file_path);
                 Some(IndexableFile {
@@ -3760,6 +4338,182 @@ fn collect_indexable_files(
     })?;
 
     Ok(files)
+}
+
+fn read_exact_init_source(path: &Path) -> Result<(Vec<u8>, kin_model::SourceEntryKind)> {
+    let metadata = fs::symlink_metadata(path)
+        .with_context(|| format!("inspect exact init source {}", path.display()))?;
+    if metadata.file_type().is_symlink() {
+        let target = fs::read_link(path)
+            .with_context(|| format!("read symbolic link {}", path.display()))?;
+        let target = target.to_str().ok_or_else(|| {
+            anyhow!(
+                "symbolic link target is not valid UTF-8: {}",
+                path.display()
+            )
+        })?;
+        return Ok((
+            target.as_bytes().to_vec(),
+            kin_model::SourceEntryKind::Symlink,
+        ));
+    }
+    if !metadata.is_file() {
+        anyhow::bail!("unsupported source entry type: {}", path.display());
+    }
+    #[cfg(unix)]
+    let executable = {
+        use std::os::unix::fs::PermissionsExt;
+        metadata.permissions().mode() & 0o111 != 0
+    };
+    #[cfg(not(unix))]
+    let executable = false;
+    Ok((
+        fs::read(path).with_context(|| format!("read exact init source {}", path.display()))?,
+        kin_model::SourceEntryKind::File { executable },
+    ))
+}
+
+fn collect_exact_init_source_entries(
+    source_root: &Path,
+    all_files: &[PathBuf],
+) -> Result<Vec<ExactInitSourceEntry>> {
+    all_files
+        .iter()
+        .map(|path| {
+            let rel_path = path
+                .strip_prefix(source_root)
+                .unwrap_or(path)
+                .to_str()
+                .ok_or_else(|| anyhow!("source path is not valid UTF-8: {}", path.display()))?
+                .replace(std::path::MAIN_SEPARATOR, "/");
+            let (bytes, kind) = read_exact_init_source(path)?;
+            Ok(ExactInitSourceEntry {
+                abs_path: path.clone(),
+                rel_path,
+                hash: kin_blobs::digest_bytes(&bytes),
+                kind,
+            })
+        })
+        .collect()
+}
+
+fn added_exact_init_kind(kind: SourceEntryKind) -> kin_model::ArtifactDeltaKind {
+    match kind {
+        SourceEntryKind::File { executable: false } => {
+            kin_model::ArtifactDeltaKind::AddedRegularFile
+        }
+        SourceEntryKind::File { executable: true } => {
+            kin_model::ArtifactDeltaKind::AddedExecutableFile
+        }
+        SourceEntryKind::Symlink => kin_model::ArtifactDeltaKind::AddedSymlink,
+    }
+}
+
+fn modified_exact_init_kind(kind: SourceEntryKind) -> kin_model::ArtifactDeltaKind {
+    match kind {
+        SourceEntryKind::File { executable: false } => {
+            kin_model::ArtifactDeltaKind::ModifiedRegularFile
+        }
+        SourceEntryKind::File { executable: true } => {
+            kin_model::ArtifactDeltaKind::ModifiedExecutableFile
+        }
+        SourceEntryKind::Symlink => kin_model::ArtifactDeltaKind::ModifiedSymlink,
+    }
+}
+
+/// Diff the frozen source snapshot against the exact parent tree. Warm init
+/// must record removals as well as additions/mode changes, including deletion
+/// of the final source file, or graph-owned source history keeps ghost files.
+fn build_exact_init_artifact_deltas(
+    parent: HashMap<FilePathId, ResolvedSourceEntry>,
+    current: &[ExactInitSourceEntry],
+) -> Vec<kin_model::ArtifactDelta> {
+    let current: BTreeMap<&str, &ExactInitSourceEntry> = current
+        .iter()
+        .map(|entry| (entry.rel_path.as_str(), entry))
+        .collect();
+    let parent: BTreeMap<String, ResolvedSourceEntry> = parent
+        .into_iter()
+        .map(|(path, entry)| (path.0, entry))
+        .collect();
+    let mut deltas = Vec::new();
+
+    for (path, old) in &parent {
+        if !current.contains_key(path.as_str()) {
+            deltas.push(kin_model::ArtifactDelta {
+                file_id: FilePathId::new(path),
+                kind: kin_model::ArtifactDeltaKind::Removed,
+                old_hash: Some(old.hash),
+                new_hash: None,
+            });
+        }
+    }
+    for (path, entry) in current {
+        let new_hash = Hash256::from_bytes(entry.hash);
+        match parent.get(path) {
+            Some(old) if old.hash == new_hash && old.kind == entry.kind => {}
+            Some(old) => deltas.push(kin_model::ArtifactDelta {
+                file_id: FilePathId::new(path),
+                kind: modified_exact_init_kind(entry.kind),
+                old_hash: Some(old.hash),
+                new_hash: Some(new_hash),
+            }),
+            None => deltas.push(kin_model::ArtifactDelta {
+                file_id: FilePathId::new(path),
+                kind: added_exact_init_kind(entry.kind),
+                old_hash: None,
+                new_hash: Some(new_hash),
+            }),
+        }
+    }
+    deltas.sort_by(|left, right| left.file_id.0.cmp(&right.file_id.0));
+    deltas
+}
+
+/// Repair an incomplete legacy source parent by restating the entire current
+/// tree with exact entry kinds and explicitly removing every parent path that
+/// no longer exists. Replaying this correction clears both legacy-mode gaps on
+/// retained paths and gaps for deleted paths, without consulting the live
+/// filesystem as an authority source.
+fn build_exact_init_repair_deltas(
+    parent: HashMap<FilePathId, Hash256>,
+    current: &[ExactInitSourceEntry],
+) -> Vec<kin_model::ArtifactDelta> {
+    let current: BTreeMap<&str, &ExactInitSourceEntry> = current
+        .iter()
+        .map(|entry| (entry.rel_path.as_str(), entry))
+        .collect();
+    let parent: BTreeMap<String, Hash256> = parent
+        .into_iter()
+        .map(|(path, hash)| (path.0, hash))
+        .collect();
+    let mut deltas = Vec::new();
+
+    for (path, old_hash) in &parent {
+        if !current.contains_key(path.as_str()) {
+            deltas.push(kin_model::ArtifactDelta {
+                file_id: FilePathId::new(path),
+                kind: kin_model::ArtifactDeltaKind::Removed,
+                old_hash: Some(*old_hash),
+                new_hash: None,
+            });
+        }
+    }
+    for (path, entry) in current {
+        let old_hash = parent.get(path).copied();
+        deltas.push(kin_model::ArtifactDelta {
+            file_id: FilePathId::new(path),
+            kind: if old_hash.is_some() {
+                modified_exact_init_kind(entry.kind)
+            } else {
+                added_exact_init_kind(entry.kind)
+            },
+            old_hash,
+            new_hash: Some(Hash256::from_bytes(entry.hash)),
+        });
+    }
+    deltas.sort_by(|left, right| left.file_id.0.cmp(&right.file_id.0));
+    deltas
 }
 
 fn try_warm_init_from_cache(
@@ -4975,6 +5729,21 @@ fn copy_dir_recursive(src: &Path, dst: &Path) -> Result<()> {
         let file_type = entry.file_type()?;
         if file_type.is_dir() {
             copy_dir_recursive(&src_path, &dst_path)?;
+        } else if file_type.is_symlink() {
+            if let Some(parent) = dst_path.parent() {
+                fs::create_dir_all(parent)?;
+            }
+            let target = fs::read_link(&src_path)?;
+            #[cfg(unix)]
+            std::os::unix::fs::symlink(&target, &dst_path)?;
+            #[cfg(windows)]
+            {
+                if src_path.is_dir() {
+                    std::os::windows::fs::symlink_dir(&target, &dst_path)?;
+                } else {
+                    std::os::windows::fs::symlink_file(&target, &dst_path)?;
+                }
+            }
         } else if file_type.is_file() {
             if let Some(parent) = dst_path.parent() {
                 fs::create_dir_all(parent)?;
@@ -5003,23 +5772,22 @@ fn source_file_sort_key(root: &Path, path: &Path) -> String {
 }
 
 fn collect_source_files_recursive(root: &Path, dir: &Path, files: &mut Vec<PathBuf>) -> Result<()> {
-    let entries = match fs::read_dir(dir) {
-        Ok(e) => e,
-        Err(_) => return Ok(()),
-    };
+    let entries = fs::read_dir(dir)
+        .with_context(|| format!("read frozen source directory {}", dir.display()))?;
 
     for entry in entries {
         let entry = entry?;
         let path = entry.path();
         let name = entry.file_name();
         let name_str = name.to_string_lossy();
+        let file_type = entry.file_type()?;
 
-        if path.is_dir() {
+        if file_type.is_dir() {
             if kin_index::should_skip_dir(name_str.as_ref()) {
                 continue;
             }
             collect_source_files_recursive(root, &path, files)?;
-        } else if path.is_file() {
+        } else if file_type.is_file() || file_type.is_symlink() {
             // A git *worktree* root carries `.git` as a FILE (a `gitdir:` pointer
             // holding a machine-absolute path), not a directory. Apply the same
             // VCS/internal skip to file entries so that pointer file — and any
@@ -5096,20 +5864,25 @@ fn ensure_graph_surface_materialized(
     Ok(())
 }
 
-/// Deterministic digest of the (path, content-hash) set, independent of
-/// wall-clock time, machine path, and walk order. The path length prefix keeps
-/// the digest unambiguous across path boundaries.
+/// Deterministic digest of the (path, content-hash, source-kind) set,
+/// independent of wall-clock time, machine path, and walk order. The path
+/// length prefix keeps the digest unambiguous across path boundaries.
 fn compute_artifact_fingerprint<'a>(
-    entries: impl IntoIterator<Item = (&'a str, &'a [u8; 32])>,
+    entries: impl IntoIterator<Item = (&'a str, &'a [u8; 32], kin_model::SourceEntryKind)>,
 ) -> [u8; 32] {
-    let mut entries: Vec<(&str, &[u8; 32])> = entries.into_iter().collect();
-    entries.sort_unstable();
+    let mut entries: Vec<_> = entries.into_iter().collect();
+    entries.sort_unstable_by(|left, right| left.0.cmp(right.0));
     let mut hasher = Sha256::new();
-    hasher.update(b"kin-init-artifacts-v1:");
-    for (path, hash) in entries {
+    hasher.update(b"kin-init-artifacts-v2:");
+    for (path, hash, kind) in entries {
         hasher.update((path.len() as u64).to_le_bytes());
         hasher.update(path.as_bytes());
         hasher.update(hash);
+        hasher.update([match kind {
+            kin_model::SourceEntryKind::File { executable: false } => 0,
+            kin_model::SourceEntryKind::File { executable: true } => 1,
+            kin_model::SourceEntryKind::Symlink => 2,
+        }]);
     }
     let result = hasher.finalize();
     let mut bytes = [0u8; 32];
@@ -5222,6 +5995,35 @@ mod tests {
             &original,
             &retried,
             DeterministicChangeProvenance::Regenerated,
+        ));
+    }
+
+    #[test]
+    fn git_history_mode_upgrade_accepts_only_the_proven_exact_kind_change() {
+        let root = kin_core::build_genesis_change();
+        let mut exact = root.clone();
+        exact.id = SemanticChangeId::from_hash(Hash256::from_bytes([0x91; 32]));
+        exact.parents = vec![root.id];
+        exact.message = "imported git commit".to_string();
+        exact.artifact_deltas = vec![kin_model::ArtifactDelta {
+            file_id: FilePathId::new("src/lib.rs"),
+            kind: ArtifactDeltaKind::AddedRegularFile,
+            old_hash: None,
+            new_hash: Some(Hash256::from_bytes([0x22; 32])),
+        }];
+        let mut legacy = exact.clone();
+        legacy.artifact_deltas[0].kind = ArtifactDeltaKind::Added;
+
+        assert!(legacy_git_source_mode_upgrade_matches(
+            &legacy, &exact, false
+        ));
+
+        let mut changed_bytes = exact.clone();
+        changed_bytes.artifact_deltas[0].new_hash = Some(Hash256::from_bytes([0x23; 32]));
+        assert!(!legacy_git_source_mode_upgrade_matches(
+            &legacy,
+            &changed_bytes,
+            false
         ));
     }
 
@@ -5354,6 +6156,250 @@ mod tests {
         let full = git_history_import_options("full").unwrap();
         assert_eq!(full.max_commits, 0);
         assert!(!full.shallow);
+
+        assert_eq!(
+            recent.max_commits, 50,
+            "recent must bound both co-change mining and semantic history import"
+        );
+    }
+
+    #[test]
+    fn legacy_window_parent_matcher_accepts_only_exact_boundary_substitutions() {
+        let boundary = SemanticChangeId::from_hash(Hash256::from_bytes([0x10; 32]));
+        let parent_a = SemanticChangeId::from_hash(Hash256::from_bytes([0x11; 32]));
+        let parent_b = SemanticChangeId::from_hash(Hash256::from_bytes([0x12; 32]));
+        let anchor_a = SemanticChangeId::from_hash(Hash256::from_bytes([0x13; 32]));
+        let anchor_b = SemanticChangeId::from_hash(Hash256::from_bytes([0x14; 32]));
+        let unrelated = SemanticChangeId::from_hash(Hash256::from_bytes([0x15; 32]));
+        let anchors = HashMap::from([(parent_a, anchor_a), (parent_b, anchor_b)]);
+
+        assert!(legacy_window_parent_shape_matches(
+            &[boundary],
+            &[parent_a, parent_b],
+            boundary,
+            &anchors,
+        ));
+        assert!(legacy_window_parent_shape_matches(
+            &[anchor_a, anchor_b],
+            &[parent_a, parent_b],
+            boundary,
+            &anchors,
+        ));
+        assert!(legacy_window_parent_shape_matches(
+            &[parent_a, anchor_b],
+            &[parent_a, parent_b],
+            boundary,
+            &anchors,
+        ));
+        assert!(!legacy_window_parent_shape_matches(
+            &[unrelated],
+            &[parent_a],
+            boundary,
+            &anchors,
+        ));
+    }
+
+    #[test]
+    fn legacy_recent_parent_is_migrated_with_missing_canonical_ancestor_atomically() {
+        let repo = tempfile::tempdir().unwrap();
+        let layout = kin_core::init(repo.path()).unwrap().layout;
+        let manager = kin_db::SnapshotManager::new(layout.kindb_snapshot_path());
+        let graph = manager.graph();
+        let genesis = kin_core::build_genesis_change();
+        graph.create_change(&genesis).unwrap();
+
+        let parent_oid = "1111111111111111111111111111111111111111";
+        let child_oid = "2222222222222222222222222222222222222222";
+        let parent_id = kin_git::semantic_change_id_from_git_oid_hex(parent_oid).unwrap();
+        let child_id = kin_git::semantic_change_id_from_git_oid_hex(child_oid).unwrap();
+        let anchor_id = kin_git::base_link_change_id_from_git_oid_hex(parent_oid).unwrap();
+        let parent = SemanticChange {
+            id: parent_id,
+            parents: vec![genesis.id],
+            timestamp: Timestamp::now(),
+            author: AuthorId::new("git-parent"),
+            message: "parent".to_string(),
+            entity_deltas: vec![],
+            relation_deltas: vec![],
+            artifact_deltas: vec![],
+            projected_files: vec![],
+            spec_link: None,
+            evidence: vec![],
+            risk_summary: None,
+            authored_on: Some(kin_model::BranchName::new("main")),
+        };
+        let child = SemanticChange {
+            id: child_id,
+            parents: vec![parent_id],
+            timestamp: Timestamp::now(),
+            author: AuthorId::new("git-child"),
+            message: "child".to_string(),
+            entity_deltas: vec![],
+            relation_deltas: vec![],
+            artifact_deltas: vec![],
+            projected_files: vec![],
+            spec_link: None,
+            evidence: vec![],
+            risk_summary: None,
+            authored_on: Some(kin_model::BranchName::new("main")),
+        };
+        let mut legacy_child = child.clone();
+        legacy_child.parents = vec![anchor_id];
+        let anchor = SemanticChange {
+            id: anchor_id,
+            parents: vec![genesis.id],
+            timestamp: Timestamp::now(),
+            author: AuthorId::new("git-anchor"),
+            message: history_checkpoint::BASE_LINK_MESSAGE.to_string(),
+            entity_deltas: vec![],
+            relation_deltas: vec![],
+            artifact_deltas: vec![],
+            projected_files: vec![],
+            spec_link: None,
+            evidence: vec![],
+            risk_summary: None,
+            authored_on: Some(kin_model::BranchName::new("main")),
+        };
+        graph.create_change(&anchor).unwrap();
+        graph.create_change(&legacy_child).unwrap();
+        graph
+            .create_branch(&kin_model::Branch {
+                name: kin_model::BranchName::new("main"),
+                head: child_id,
+            })
+            .unwrap();
+        manager.save().unwrap();
+        drop(graph);
+
+        let mut canonical = vec![
+            kin_git::ImportedChange {
+                change: parent.clone(),
+                git_oid: parent_oid.to_string(),
+            },
+            kin_git::ImportedChange {
+                change: child.clone(),
+                git_oid: child_oid.to_string(),
+            },
+        ];
+        let outcome =
+            repair_legacy_git_import_history(&manager, &layout, genesis.id, &mut canonical)
+                .unwrap();
+
+        assert_eq!(outcome.corrected_changes, 1);
+        assert!(outcome.rebuilt_derived_indexes);
+        let repaired = manager.graph().to_snapshot();
+        assert_eq!(repaired.changes[&child_id].parents, vec![parent_id]);
+        assert_eq!(repaired.changes[&parent_id].parents, vec![genesis.id]);
+        assert_eq!(
+            repaired
+                .change_children
+                .get(&parent_id)
+                .into_iter()
+                .flatten()
+                .filter(|id| **id == child_id)
+                .count(),
+            1
+        );
+    }
+
+    #[test]
+    fn bounded_window_preserves_existing_real_parent_payload() {
+        let repo = tempfile::tempdir().unwrap();
+        let layout = kin_core::init(repo.path()).unwrap().layout;
+        let manager = kin_db::SnapshotManager::new(layout.kindb_snapshot_path());
+        let graph = manager.graph();
+        let genesis = kin_core::build_genesis_change();
+        graph.create_change(&genesis).unwrap();
+
+        let parent_oid = "3333333333333333333333333333333333333333";
+        let child_oid = "4444444444444444444444444444444444444444";
+        let parent_id = kin_git::semantic_change_id_from_git_oid_hex(parent_oid).unwrap();
+        let child_id = kin_git::semantic_change_id_from_git_oid_hex(child_oid).unwrap();
+        let anchor_id = kin_git::base_link_change_id_from_git_oid_hex(parent_oid).unwrap();
+        let parent = SemanticChange {
+            id: parent_id,
+            parents: vec![genesis.id],
+            timestamp: Timestamp::now(),
+            author: AuthorId::new("git-parent"),
+            message: "parent".to_string(),
+            entity_deltas: vec![],
+            relation_deltas: vec![],
+            artifact_deltas: vec![],
+            projected_files: vec![],
+            spec_link: None,
+            evidence: vec![],
+            risk_summary: None,
+            authored_on: Some(kin_model::BranchName::new("main")),
+        };
+        let child = SemanticChange {
+            id: child_id,
+            parents: vec![parent_id],
+            timestamp: Timestamp::now(),
+            author: AuthorId::new("git-child"),
+            message: "child".to_string(),
+            entity_deltas: vec![],
+            relation_deltas: vec![],
+            artifact_deltas: vec![],
+            projected_files: vec![],
+            spec_link: None,
+            evidence: vec![],
+            risk_summary: None,
+            authored_on: Some(kin_model::BranchName::new("main")),
+        };
+        graph.create_change(&parent).unwrap();
+        graph.create_change(&child).unwrap();
+        graph
+            .create_branch(&kin_model::Branch {
+                name: kin_model::BranchName::new("main"),
+                head: child_id,
+            })
+            .unwrap();
+        manager.save().unwrap();
+        drop(graph);
+
+        let anchor = SemanticChange {
+            id: anchor_id,
+            parents: vec![genesis.id],
+            timestamp: parent.timestamp,
+            author: parent.author.clone(),
+            message: history_checkpoint::BASE_LINK_MESSAGE.to_string(),
+            entity_deltas: vec![],
+            relation_deltas: vec![],
+            artifact_deltas: vec![],
+            projected_files: vec![],
+            spec_link: None,
+            evidence: vec![],
+            risk_summary: None,
+            authored_on: Some(kin_model::BranchName::new("main")),
+        };
+        let mut bounded_child = child.clone();
+        bounded_child.parents = vec![anchor_id];
+        let mut bounded = vec![
+            kin_git::ImportedChange {
+                change: anchor,
+                git_oid: parent_oid.to_string(),
+            },
+            kin_git::ImportedChange {
+                change: bounded_child,
+                git_oid: child_oid.to_string(),
+            },
+        ];
+
+        let outcome =
+            repair_legacy_git_import_history(&manager, &layout, genesis.id, &mut bounded).unwrap();
+
+        assert_eq!(outcome, LegacyImportRepairOutcome::default());
+        assert_eq!(
+            bounded[1].change.parents,
+            vec![parent_id],
+            "a sliding/full-to-recent window must retain the existing immutable Git payload"
+        );
+        create_deterministic_change_once(
+            manager.graph().as_ref(),
+            &bounded[1].change,
+            DeterministicChangeProvenance::Stable,
+        )
+        .expect("normalized bounded import must not collide with the existing Git-derived ID");
     }
 
     #[test]
@@ -5361,7 +6407,9 @@ mod tests {
         let parent = SemanticChangeId::from_hash(Hash256::from_bytes([0x11; 32]));
         let a: [u8; 32] = [0xaa; 32];
         let b: [u8; 32] = [0xbb; 32];
-        let fingerprint = compute_artifact_fingerprint([("src/a.rs", &a), ("src/b.rs", &b)]);
+        let regular = kin_model::SourceEntryKind::File { executable: false };
+        let fingerprint =
+            compute_artifact_fingerprint([("src/a.rs", &a, regular), ("src/b.rs", &b, regular)]);
 
         let id1 = compute_init_change_id(&parent, &fingerprint);
         let id2 = compute_init_change_id(&parent, &fingerprint);
@@ -5373,13 +6421,15 @@ mod tests {
 
         assert_eq!(
             fingerprint,
-            compute_artifact_fingerprint([("src/b.rs", &b), ("src/a.rs", &a)]),
+            compute_artifact_fingerprint([("src/b.rs", &b, regular), ("src/a.rs", &a, regular)]),
             "fingerprint must be independent of walk order"
         );
 
         let c: [u8; 32] = [0xcc; 32];
-        let id3 =
-            compute_init_change_id(&parent, &compute_artifact_fingerprint([("src/a.rs", &c)]));
+        let id3 = compute_init_change_id(
+            &parent,
+            &compute_artifact_fingerprint([("src/a.rs", &c, regular)]),
+        );
         assert_ne!(
             id1.to_string(),
             id3.to_string(),
@@ -6391,6 +7441,555 @@ func prCheckout(cmd *cobra.Command, args []string) error {
                 .any(|delta| matches!(delta, EntityDelta::Removed(id) if *id == f_id)),
             "branch B must not report a phantom Removed for `f`, got {b_deltas:?}"
         );
+    }
+
+    fn merge_rebase_fixture(blob_store: &kin_blobs::BlobStore) -> Vec<kin_git::ImportedChange> {
+        let tools = blob_store.write(b"def helper():\n    return 1\n").unwrap();
+        let app_root = blob_store.write(b"def run():\n    return 1\n").unwrap();
+        let app_first_parent = blob_store.write(b"def run():\n    return 2\n").unwrap();
+        let app_secondary_parent = blob_store
+            .write(b"from tools import helper\n\ndef run():\n    return helper()\n")
+            .unwrap();
+        let secondary_only = blob_store
+            .write(b"def secondary_only():\n    return 'secondary'\n")
+            .unwrap();
+
+        let root = imported_change(
+            [0x81; 32],
+            [0; 32],
+            "root",
+            vec![
+                artifact_delta(
+                    "tools.py",
+                    kin_model::ArtifactDeltaKind::AddedRegularFile,
+                    None,
+                    Some(Hash256::from_bytes(tools.0)),
+                ),
+                artifact_delta(
+                    "app.py",
+                    kin_model::ArtifactDeltaKind::AddedRegularFile,
+                    None,
+                    Some(Hash256::from_bytes(app_root.0)),
+                ),
+            ],
+        );
+        let first_parent = imported_change(
+            [0x82; 32],
+            [0x81; 32],
+            "first parent",
+            vec![artifact_delta(
+                "app.py",
+                kin_model::ArtifactDeltaKind::ModifiedRegularFile,
+                Some(Hash256::from_bytes(app_root.0)),
+                Some(Hash256::from_bytes(app_first_parent.0)),
+            )],
+        );
+        let secondary_parent = imported_change(
+            [0x83; 32],
+            [0x81; 32],
+            "secondary parent",
+            vec![
+                artifact_delta(
+                    "app.py",
+                    kin_model::ArtifactDeltaKind::ModifiedRegularFile,
+                    Some(Hash256::from_bytes(app_root.0)),
+                    Some(Hash256::from_bytes(app_secondary_parent.0)),
+                ),
+                artifact_delta(
+                    "secondary.py",
+                    kin_model::ArtifactDeltaKind::AddedRegularFile,
+                    None,
+                    Some(Hash256::from_bytes(secondary_only.0)),
+                ),
+            ],
+        );
+        let mut merge = imported_change(
+            [0x84; 32],
+            [0x82; 32],
+            "merge choosing first-parent tree",
+            vec![
+                artifact_delta(
+                    "app.py",
+                    kin_model::ArtifactDeltaKind::ModifiedRegularFile,
+                    Some(Hash256::from_bytes(app_secondary_parent.0)),
+                    Some(Hash256::from_bytes(app_first_parent.0)),
+                ),
+                artifact_delta(
+                    "secondary.py",
+                    kin_model::ArtifactDeltaKind::Removed,
+                    Some(Hash256::from_bytes(secondary_only.0)),
+                    None,
+                ),
+            ],
+        );
+        merge.change.parents = vec![first_parent.change.id, secondary_parent.change.id];
+
+        vec![root, first_parent, secondary_parent, merge]
+    }
+
+    fn resolve_imported_semantics(
+        imported: &[kin_git::ImportedChange],
+        head: SemanticChangeId,
+    ) -> kin_model::graph::ResolvedGraphState {
+        let graph = kin_db::InMemoryGraph::new();
+        graph
+            .create_change(&kin_core::build_genesis_change())
+            .unwrap();
+        for imported_change in imported {
+            graph.create_change(&imported_change.change).unwrap();
+        }
+        graph.resolve_graph_at(&head).unwrap()
+    }
+
+    fn assert_imported_semantics_exact(
+        expected: &kin_model::graph::ResolvedGraphState,
+        actual: &kin_model::graph::ResolvedGraphState,
+    ) {
+        assert_eq!(expected.entities.len(), actual.entities.len());
+        for (entity_id, expected_entity) in &expected.entities {
+            let actual_entity = actual
+                .entities
+                .get(entity_id)
+                .unwrap_or_else(|| panic!("missing entity {entity_id}"));
+            assert!(
+                imported_entities_exactly_equivalent(expected_entity, actual_entity),
+                "entity {entity_id} differs: expected {expected_entity:#?}, actual {actual_entity:#?}"
+            );
+        }
+        assert_eq!(expected.relations.len(), actual.relations.len());
+        for (relation_id, expected_relation) in &expected.relations {
+            let actual_relation = actual
+                .relations
+                .get(relation_id)
+                .unwrap_or_else(|| panic!("missing relation {relation_id}"));
+            assert!(
+                imported_relations_exactly_equivalent(expected_relation, actual_relation),
+                "relation {relation_id} differs: expected {expected_relation:#?}, actual {actual_relation:#?}"
+            );
+        }
+        assert_eq!(expected.file_tree, actual.file_tree);
+    }
+
+    fn identity_neutral_semantic_shape(
+        state: &kin_model::graph::ResolvedGraphState,
+    ) -> (Vec<String>, Vec<String>) {
+        let normalized_ids: HashMap<_, _> = state
+            .entities
+            .values()
+            .map(|entity| {
+                let file = entity
+                    .file_origin
+                    .as_ref()
+                    .map(|file| file.0.as_str())
+                    .unwrap_or("");
+                let start_line = entity
+                    .span
+                    .as_ref()
+                    .map(|span| span.start_line)
+                    .unwrap_or(0);
+                (
+                    entity.id,
+                    EntityId::from_content(
+                        file,
+                        &entity.name,
+                        &format!("{:?}", entity.kind),
+                        start_line,
+                    ),
+                )
+            })
+            .collect();
+
+        let mut entities = state
+            .entities
+            .values()
+            .cloned()
+            .map(|mut entity| {
+                entity.id = normalized_ids[&entity.id];
+                entity.lineage_parent = entity
+                    .lineage_parent
+                    .and_then(|id| normalized_ids.get(&id).copied());
+                entity.superseded_by = entity
+                    .superseded_by
+                    .and_then(|id| normalized_ids.get(&id).copied());
+                canonical_json(&entity)
+            })
+            .collect::<Vec<_>>();
+        entities.sort();
+
+        let normalize_node = |node: GraphNodeId| match node {
+            GraphNodeId::Entity(id) => {
+                GraphNodeId::Entity(normalized_ids.get(&id).copied().unwrap_or(id))
+            }
+            other => other,
+        };
+        let mut relations = state
+            .relations
+            .values()
+            .cloned()
+            .map(|mut relation| {
+                relation.src = normalize_node(relation.src);
+                relation.dst = normalize_node(relation.dst);
+                relation.id = RelationId::from_content(
+                    &relation.src.to_string(),
+                    &relation.dst.to_string(),
+                    &format!("{:?}", relation.kind),
+                );
+                canonical_json(&relation)
+            })
+            .collect::<Vec<_>>();
+        relations.sort();
+        (entities, relations)
+    }
+
+    fn assert_secondary_parent_replay_matches_authoritative_model(
+        imported: &[kin_git::ImportedChange],
+        merge_id: SemanticChangeId,
+    ) {
+        let merge = imported
+            .iter()
+            .find(|entry| entry.change.id == merge_id)
+            .unwrap();
+        let first_parent = merge.change.parents[0];
+        let first_parent_state = resolve_imported_semantics(imported, first_parent);
+        let mut lightweight = ImportedRuntimeSemanticState {
+            entities: first_parent_state.entities,
+            relations: first_parent_state.relations,
+        };
+        let index_by_change_id: HashMap<_, _> = imported
+            .iter()
+            .enumerate()
+            .map(|(index, entry)| (entry.change.id, index))
+            .collect();
+        replay_imported_secondary_parents(
+            &mut lightweight,
+            imported,
+            &index_by_change_id,
+            kin_core::build_genesis_change().id,
+            &merge.change.parents,
+        )
+        .unwrap();
+
+        let graph = kin_db::InMemoryGraph::new();
+        graph
+            .create_change(&kin_core::build_genesis_change())
+            .unwrap();
+        for imported_change in imported {
+            graph.create_change(&imported_change.change).unwrap();
+        }
+        let mut probe = merge.change.clone();
+        probe.id = SemanticChangeId::from_hash(Hash256::from_bytes([0xf9; 32]));
+        probe.entity_deltas.clear();
+        probe.relation_deltas.clear();
+        probe.artifact_deltas.clear();
+        graph.create_change(&probe).unwrap();
+        let authoritative = graph.resolve_graph_at(&probe.id).unwrap();
+
+        assert_eq!(lightweight.entities.len(), authoritative.entities.len());
+        for (entity_id, expected) in &authoritative.entities {
+            let actual = lightweight
+                .entities
+                .get(entity_id)
+                .unwrap_or_else(|| panic!("lightweight replay missed entity {entity_id}"));
+            assert!(imported_entities_exactly_equivalent(expected, actual));
+        }
+        assert_eq!(lightweight.relations.len(), authoritative.relations.len());
+        for (relation_id, expected) in &authoritative.relations {
+            let actual = lightweight
+                .relations
+                .get(relation_id)
+                .unwrap_or_else(|| panic!("lightweight replay missed relation {relation_id}"));
+            assert!(imported_relations_exactly_equivalent(expected, actual));
+        }
+    }
+
+    #[test]
+    fn enrich_imported_merge_rebases_runtime_union_to_first_parent_target() {
+        let dir = tempfile::tempdir().unwrap();
+        let blob_store = kin_blobs::BlobStore::new(dir.path().join("objects")).unwrap();
+        let fixture = merge_rebase_fixture(&blob_store);
+        let first_parent_id = fixture[1].change.id;
+        let merge_id = fixture[3].change.id;
+
+        // Put the merge before both of its parents in input order. A
+        // first-parent-only scheduler can process it after parent A but before
+        // secondary parent B; complete-DAG ordering must wait for both.
+        let mut imported = vec![
+            fixture[0].clone(),
+            fixture[3].clone(),
+            fixture[1].clone(),
+            fixture[2].clone(),
+        ];
+        enrich_imported_changes_with_semantics(&mut imported, &blob_store).unwrap();
+        assert_secondary_parent_replay_matches_authoritative_model(&imported, merge_id);
+
+        let expected = resolve_imported_semantics(&imported, first_parent_id);
+        let actual = resolve_imported_semantics(&imported, merge_id);
+        assert_imported_semantics_exact(&expected, &actual);
+
+        let merge = imported
+            .iter()
+            .find(|entry| entry.change.id == merge_id)
+            .unwrap();
+        assert!(
+            merge
+                .change
+                .entity_deltas
+                .iter()
+                .any(|delta| matches!(delta, EntityDelta::Removed(_))),
+            "merge must explicitly remove secondary-parent-only semantic state"
+        );
+        assert!(
+            merge
+                .change
+                .relation_deltas
+                .iter()
+                .any(|delta| matches!(delta, RelationDelta::Removed(_))),
+            "merge must explicitly remove secondary-parent-only relations"
+        );
+    }
+
+    #[test]
+    fn enrich_imported_octopus_merge_removes_every_unselected_parent_state() {
+        let dir = tempfile::tempdir().unwrap();
+        let blob_store = kin_blobs::BlobStore::new(dir.path().join("objects")).unwrap();
+        let mut fixture = merge_rebase_fixture(&blob_store);
+        let first_parent_id = fixture[1].change.id;
+        let tertiary_blob = blob_store
+            .write(b"def tertiary_only():\n    return 'tertiary'\n")
+            .unwrap();
+        let tertiary = imported_change(
+            [0x85; 32],
+            [0x81; 32],
+            "tertiary parent",
+            vec![artifact_delta(
+                "tertiary.py",
+                kin_model::ArtifactDeltaKind::AddedRegularFile,
+                None,
+                Some(Hash256::from_bytes(tertiary_blob.0)),
+            )],
+        );
+        let mut merge = fixture.pop().unwrap();
+        merge.change.parents.push(tertiary.change.id);
+        merge.change.artifact_deltas.push(artifact_delta(
+            "tertiary.py",
+            kin_model::ArtifactDeltaKind::Removed,
+            Some(Hash256::from_bytes(tertiary_blob.0)),
+            None,
+        ));
+        let merge_id = merge.change.id;
+
+        // Keep the octopus merge ahead of all three parent records in the
+        // slice; complete-DAG scheduling still has to delay it until each arm
+        // has been enriched for the exact secondary-parent replay.
+        let mut imported = vec![
+            fixture[0].clone(),
+            merge,
+            fixture[1].clone(),
+            fixture[2].clone(),
+            tertiary,
+        ];
+        enrich_imported_changes_with_semantics(&mut imported, &blob_store).unwrap();
+        assert_secondary_parent_replay_matches_authoritative_model(&imported, merge_id);
+
+        let expected = resolve_imported_semantics(&imported, first_parent_id);
+        let actual = resolve_imported_semantics(&imported, merge_id);
+        assert_imported_semantics_exact(&expected, &actual);
+        assert!(actual
+            .entities
+            .values()
+            .all(|entity| !matches!(entity.name.as_str(), "secondary_only" | "tertiary_only")));
+    }
+
+    #[test]
+    fn secondary_parent_replay_prunes_relation_when_removed_entity_is_already_absent() {
+        let removed = test_entity("removed", "removed.py");
+        let peer = test_entity("peer", "peer.py");
+        let relation = test_relation(RelationKind::Calls, peer.id, removed.id);
+
+        // First-parent runtime state contains a dangling cross-branch relation
+        // but not the referenced entity. The secondary parent removes that
+        // absent entity. Authoritative replay still prunes every relation that
+        // mentions the ID; conditioning pruning on `entities.remove()` would
+        // leak this edge through the merge baseline.
+        let mut first_parent = imported_change(
+            [0xa1; 32],
+            [0; 32],
+            "first parent adds cross-branch relation",
+            Vec::new(),
+        );
+        first_parent.change.relation_deltas = vec![RelationDelta::Added(relation)];
+        let mut secondary_parent = imported_change(
+            [0xa2; 32],
+            [0; 32],
+            "secondary parent removes absent entity",
+            Vec::new(),
+        );
+        secondary_parent.change.entity_deltas = vec![EntityDelta::Removed(removed.id)];
+        let mut merge = imported_change([0xa3; 32], [0xa1; 32], "merge", Vec::new());
+        merge.change.parents = vec![first_parent.change.id, secondary_parent.change.id];
+        let merge_id = merge.change.id;
+        let imported = vec![first_parent, secondary_parent, merge];
+
+        assert_secondary_parent_replay_matches_authoritative_model(&imported, merge_id);
+    }
+
+    #[test]
+    fn imported_merge_target_can_select_secondary_state_and_add_novel_content() {
+        let dir = tempfile::tempdir().unwrap();
+        let blob_store = kin_blobs::BlobStore::new(dir.path().join("objects")).unwrap();
+        let mut imported = merge_rebase_fixture(&blob_store);
+        let tools_hash = imported[0]
+            .change
+            .artifact_deltas
+            .iter()
+            .find(|delta| delta.file_id.0 == "tools.py")
+            .and_then(|delta| delta.new_hash)
+            .unwrap();
+        let app_first_parent_hash = imported[1].change.artifact_deltas[0].new_hash.unwrap();
+        let app_secondary_hash = imported[2]
+            .change
+            .artifact_deltas
+            .iter()
+            .find(|delta| delta.file_id.0 == "app.py")
+            .and_then(|delta| delta.new_hash)
+            .unwrap();
+        let secondary_hash = imported[2]
+            .change
+            .artifact_deltas
+            .iter()
+            .find(|delta| delta.file_id.0 == "secondary.py")
+            .and_then(|delta| delta.new_hash)
+            .unwrap();
+        let novel_hash = Hash256::from_bytes(
+            blob_store
+                .write(b"def novel_at_merge():\n    return 'novel'\n")
+                .unwrap()
+                .0,
+        );
+
+        let merge = imported.last_mut().unwrap();
+        let app_delta = merge
+            .change
+            .artifact_deltas
+            .iter_mut()
+            .find(|delta| delta.file_id.0 == "app.py")
+            .unwrap();
+        app_delta.old_hash = Some(app_first_parent_hash);
+        app_delta.new_hash = Some(app_secondary_hash);
+        let secondary_delta = merge
+            .change
+            .artifact_deltas
+            .iter_mut()
+            .find(|delta| delta.file_id.0 == "secondary.py")
+            .unwrap();
+        secondary_delta.kind = kin_model::ArtifactDeltaKind::ModifiedRegularFile;
+        secondary_delta.new_hash = Some(secondary_hash);
+        merge.change.artifact_deltas.push(artifact_delta(
+            "novel.py",
+            kin_model::ArtifactDeltaKind::AddedRegularFile,
+            None,
+            Some(novel_hash),
+        ));
+        let merge_id = merge.change.id;
+
+        enrich_imported_changes_with_semantics(&mut imported, &blob_store).unwrap();
+        assert_secondary_parent_replay_matches_authoritative_model(&imported, merge_id);
+
+        // Hydrate the exact selected merge tree independently as a single
+        // root. This oracle proves the merge is not hardwired to reset to its
+        // first parent: it keeps secondary-parent app/edge state and adds a
+        // path that exists in neither parent.
+        let mut oracle = vec![imported_change(
+            [0xb1; 32],
+            [0; 32],
+            "independent exact merge target",
+            vec![
+                artifact_delta(
+                    "tools.py",
+                    kin_model::ArtifactDeltaKind::AddedRegularFile,
+                    None,
+                    Some(tools_hash),
+                ),
+                artifact_delta(
+                    "app.py",
+                    kin_model::ArtifactDeltaKind::AddedRegularFile,
+                    None,
+                    Some(app_secondary_hash),
+                ),
+                artifact_delta(
+                    "secondary.py",
+                    kin_model::ArtifactDeltaKind::AddedRegularFile,
+                    None,
+                    Some(secondary_hash),
+                ),
+                artifact_delta(
+                    "novel.py",
+                    kin_model::ArtifactDeltaKind::AddedRegularFile,
+                    None,
+                    Some(novel_hash),
+                ),
+            ],
+        )];
+        enrich_imported_changes_with_semantics(&mut oracle, &blob_store).unwrap();
+
+        let expected = resolve_imported_semantics(&oracle, oracle[0].change.id);
+        let actual = resolve_imported_semantics(&imported, merge_id);
+        assert_eq!(
+            identity_neutral_semantic_shape(&expected),
+            identity_neutral_semantic_shape(&actual),
+            "selected merge tree must match an independently hydrated exact-tree oracle after neutralizing expected lineage-preserving IDs"
+        );
+        assert_eq!(expected.file_tree, actual.file_tree);
+        assert!(actual
+            .entities
+            .values()
+            .any(|entity| entity.name == "novel_at_merge"));
+        assert!(!actual.relations.is_empty());
+    }
+
+    #[test]
+    fn checkpoint_resume_seeds_all_parent_merge_rebase_prefix() {
+        let dir = tempfile::tempdir().unwrap();
+        let blob_store = kin_blobs::BlobStore::new(dir.path().join("objects")).unwrap();
+        let fixture = merge_rebase_fixture(&blob_store);
+        let first_parent_id = fixture[1].change.id;
+        let merge_id = fixture[3].change.id;
+        let config = HydrationCheckpointConfig::clean_for_test(
+            &dir.path().join("kin"),
+            "merge-rebase-clean-sha",
+            1,
+            16 * 1024 * 1024,
+        );
+
+        let mut oracle = fixture.clone();
+        enrich_imported_changes_with_semantics_inner(&mut oracle, &blob_store, true).unwrap();
+
+        let mut prefix = fixture[..2].to_vec();
+        enrich_imported_changes_with_semantics_with_checkpoints(
+            &mut prefix,
+            &blob_store,
+            true,
+            Some(config.clone()),
+        )
+        .unwrap();
+
+        let mut resumed = fixture;
+        let stats = enrich_imported_changes_with_semantics_with_checkpoints(
+            &mut resumed,
+            &blob_store,
+            true,
+            Some(config),
+        )
+        .unwrap();
+        assert_eq!(
+            stats.resumed_from, 1,
+            "resume must fall back to the newest frontier retaining root state for both branches"
+        );
+        assert_same_hydration_deltas(&oracle, &resumed);
+
+        let expected = resolve_imported_semantics(&resumed, first_parent_id);
+        let actual = resolve_imported_semantics(&resumed, merge_id);
+        assert_imported_semantics_exact(&expected, &actual);
     }
 
     /// Minimal git repo bootstrap for history-import tests. Returns false when
@@ -8548,6 +10147,104 @@ func prCheckout(cmd *cobra.Command, args []string) error {
         assert!(snapshot.join("manifest.json").exists());
     }
 
+    #[cfg(unix)]
+    #[test]
+    fn snapshot_and_exact_init_entries_preserve_modes_and_symlink_targets() {
+        use std::os::unix::fs::{symlink, PermissionsExt};
+
+        let dir = tempfile::tempdir().unwrap();
+        let root = dir.path();
+        fs::create_dir_all(root.join("bin")).unwrap();
+        fs::write(root.join("plain.txt"), b"plain\n").unwrap();
+        fs::write(root.join("bin/run"), b"#!/bin/sh\n").unwrap();
+        let mut permissions = fs::metadata(root.join("bin/run")).unwrap().permissions();
+        permissions.set_mode(0o755);
+        fs::set_permissions(root.join("bin/run"), permissions).unwrap();
+        symlink("plain.txt", root.join("current")).unwrap();
+
+        let (snapshot, manifest) = snapshot_repo(root, false).unwrap();
+        assert_eq!(manifest["file_count"], 3);
+        assert_eq!(
+            fs::read_link(snapshot.join("current")).unwrap(),
+            Path::new("plain.txt")
+        );
+        assert_ne!(
+            fs::metadata(snapshot.join("bin/run"))
+                .unwrap()
+                .permissions()
+                .mode()
+                & 0o111,
+            0
+        );
+
+        let all_files = collect_source_files(&snapshot).unwrap();
+        let exact = collect_exact_init_source_entries(&snapshot, &all_files).unwrap();
+        let kinds: BTreeMap<_, _> = exact
+            .iter()
+            .map(|entry| (entry.rel_path.as_str(), entry.kind))
+            .collect();
+        assert_eq!(
+            kinds.get("plain.txt"),
+            Some(&kin_model::SourceEntryKind::File { executable: false })
+        );
+        assert_eq!(
+            kinds.get("bin/run"),
+            Some(&kin_model::SourceEntryKind::File { executable: true })
+        );
+        assert_eq!(
+            kinds.get("current"),
+            Some(&kin_model::SourceEntryKind::Symlink)
+        );
+        let link = exact
+            .iter()
+            .find(|entry| entry.rel_path == "current")
+            .unwrap();
+        let (target, _) = read_exact_init_source(&link.abs_path).unwrap();
+        assert_eq!(target, b"plain.txt");
+    }
+
+    #[test]
+    fn exact_init_repair_restates_retained_paths_and_removes_deleted_gaps() {
+        let retained_hash = Hash256::from_bytes([0x11; 32]);
+        let deleted_hash = Hash256::from_bytes([0x22; 32]);
+        let added_hash = [0x33; 32];
+        let parent = HashMap::from([
+            (FilePathId::new("legacy.sh"), retained_hash),
+            (FilePathId::new("deleted.txt"), deleted_hash),
+        ]);
+        let current = vec![
+            ExactInitSourceEntry {
+                abs_path: PathBuf::from("legacy.sh"),
+                rel_path: "legacy.sh".to_string(),
+                hash: *retained_hash.as_bytes(),
+                kind: SourceEntryKind::File { executable: true },
+            },
+            ExactInitSourceEntry {
+                abs_path: PathBuf::from("new-link"),
+                rel_path: "new-link".to_string(),
+                hash: added_hash,
+                kind: SourceEntryKind::Symlink,
+            },
+        ];
+
+        let deltas = build_exact_init_repair_deltas(parent, &current);
+        assert_eq!(deltas.len(), 3);
+        assert_eq!(deltas[0].file_id, FilePathId::new("deleted.txt"));
+        assert_eq!(deltas[0].kind, kin_model::ArtifactDeltaKind::Removed);
+        assert_eq!(deltas[0].old_hash, Some(deleted_hash));
+        assert_eq!(deltas[1].file_id, FilePathId::new("legacy.sh"));
+        assert_eq!(
+            deltas[1].kind,
+            kin_model::ArtifactDeltaKind::ModifiedExecutableFile
+        );
+        assert_eq!(deltas[1].old_hash, Some(retained_hash));
+        assert_eq!(deltas[1].new_hash, Some(retained_hash));
+        assert_eq!(deltas[2].file_id, FilePathId::new("new-link"));
+        assert_eq!(deltas[2].kind, kin_model::ArtifactDeltaKind::AddedSymlink);
+        assert_eq!(deltas[2].old_hash, None);
+        assert_eq!(deltas[2].new_hash, Some(Hash256::from_bytes(added_hash)));
+    }
+
     #[test]
     fn manifest_has_correct_file_count() {
         let dir = tempfile::tempdir().unwrap();
@@ -8908,18 +10605,46 @@ func prCheckout(cmd *cobra.Command, args []string) error {
         // deterministic Git id. Reuse the already-persisted semantic deltas;
         // the old replay also treated that wrong boundary as external, so the
         // only authoritative record difference is the generated parent edge.
+        let ids: Vec<_> = legacy.iter().map(|entry| entry.change.id).collect();
+        let id_set: HashSet<_> = ids.iter().copied().collect();
+        let mut snapshot = graph.to_snapshot();
         for imported in &legacy {
-            let mut old_release_record = graph
-                .get_change(&imported.change.id)
-                .unwrap()
+            let old_release_record = snapshot
+                .changes
+                .get_mut(&imported.change.id)
                 .expect("fresh init must already contain every imported Git id");
             old_release_record.parents = imported.change.parents.clone();
-            graph.create_change(&old_release_record).unwrap();
+
+            // Reproduce the append-only derived-index side effects of the old
+            // duplicate-ID insertion implementation. The current kin-db
+            // correctly rejects that public operation, so a legacy fixture
+            // must install the already-persisted corrupt shape directly.
+            for parent in &old_release_record.parents {
+                snapshot
+                    .change_children
+                    .entry(*parent)
+                    .or_default()
+                    .push(old_release_record.id);
+            }
         }
-        let ids: Vec<_> = legacy.iter().map(|entry| entry.change.id).collect();
-        graph
-            .update_branch_head(&branch, ids.last().unwrap())
-            .unwrap();
+        for revisions in snapshot.entity_revisions.values_mut() {
+            let duplicates = revisions
+                .iter()
+                .filter(|revision| id_set.contains(&revision.introduced_by))
+                .cloned()
+                .collect::<Vec<_>>();
+            revisions.extend(duplicates);
+        }
+        snapshot
+            .branches
+            .get_mut(&branch)
+            .expect("fixture branch must exist")
+            .head = *ids.last().unwrap();
+        drop(graph);
+        snap.swap(kin_db::InMemoryGraph::from_snapshot_with_text_index(
+            snapshot,
+            layout.text_index_dir(),
+        ));
         snap.save().unwrap();
         ids
     }
@@ -9133,18 +10858,43 @@ func prCheckout(cmd *cobra.Command, args []string) error {
         .await
         .unwrap();
 
-        // Reproduce the pre-fix warm-init corruption under kin-db 0.2.31:
-        // overwriting the deterministic Git change with a self-parent appends
-        // both a stale reverse edge and duplicate revision generations.
+        // Reproduce the pre-fix warm-init corruption under kin-db 0.2.31.
+        // Current kin-db rejects duplicate-ID insertion, so install the exact
+        // already-persisted legacy shape through the snapshot boundary.
         let layout = kin_core::KinLayout::new(repo_dir.path().join(".kin"));
         {
             let snap = open_snapshot_with_retry(layout.kindb_snapshot_path());
             let graph = snap.graph();
-            let mut malformed = graph.get_change(&git_change).unwrap().unwrap();
-            malformed.parents = vec![git_change];
-            graph.create_change(&malformed).unwrap();
+            let mut snapshot = graph.to_snapshot();
+            snapshot
+                .changes
+                .get_mut(&git_change)
+                .expect("imported change must exist")
+                .parents = vec![git_change];
+            snapshot
+                .change_children
+                .entry(git_change)
+                .or_default()
+                .push(git_change);
+            for revisions in snapshot.entity_revisions.values_mut() {
+                let duplicates = revisions
+                    .iter()
+                    .filter(|revision| revision.introduced_by == git_change)
+                    .cloned()
+                    .collect::<Vec<_>>();
+                revisions.extend(duplicates);
+            }
             let branch = kin_core::read_current_branch(&layout).unwrap();
-            graph.update_branch_head(&branch, &git_change).unwrap();
+            snapshot
+                .branches
+                .get_mut(&branch)
+                .expect("fixture branch must exist")
+                .head = git_change;
+            drop(graph);
+            snap.swap(kin_db::InMemoryGraph::from_snapshot_with_text_index(
+                snapshot,
+                layout.text_index_dir(),
+            ));
             snap.save().unwrap();
         }
 
@@ -9450,13 +11200,30 @@ func prCheckout(cmd *cobra.Command, args []string) error {
                 .filter(|change| change.message != "kin init: auto-parse")
                 .map(|change| change.id)
                 .collect();
-            for _ in 0..2 {
-                for id in &ids {
-                    graph
-                        .create_change(&graph.get_change(id).unwrap().unwrap())
-                        .unwrap();
+            let id_set: HashSet<_> = ids.iter().copied().collect();
+            let mut snapshot = graph.to_snapshot();
+            for id in &ids {
+                for parent in snapshot.changes[id].parents.clone() {
+                    snapshot
+                        .change_children
+                        .entry(parent)
+                        .or_default()
+                        .push(*id);
                 }
             }
+            for revisions in snapshot.entity_revisions.values_mut() {
+                let duplicates = revisions
+                    .iter()
+                    .filter(|revision| id_set.contains(&revision.introduced_by))
+                    .cloned()
+                    .collect::<Vec<_>>();
+                revisions.extend(duplicates);
+            }
+            drop(graph);
+            snap.swap(kin_db::InMemoryGraph::from_snapshot_with_text_index(
+                snapshot,
+                layout.text_index_dir(),
+            ));
             snap.save().unwrap();
             ids
         };

--- a/crates/kin-cli/src/commands/merge.rs
+++ b/crates/kin-cli/src/commands/merge.rs
@@ -55,6 +55,7 @@ pub async fn run(branch: String, strategy: String) -> Result<()> {
             &layout,
             &current_name.to_string(),
             &current.head.to_string(),
+            &current.head.to_string(),
         )
         .await?;
     }
@@ -106,7 +107,7 @@ pub async fn run(branch: String, strategy: String) -> Result<()> {
                 &source.head,
                 &[],
                 &format!("Merge unrelated '{}' into '{}'", branch, current.name),
-            );
+            )?;
             crate::backend::require_daemon_commit(&layout, &merge, &current.name.to_string())
                 .await?;
             println!("  Merge commit: {}", merge.id);
@@ -159,6 +160,7 @@ pub async fn run(branch: String, strategy: String) -> Result<()> {
                 &layout,
                 &current.name.to_string(),
                 &source.head.to_string(),
+                &current.head.to_string(),
             )
             .await?;
             println!("  Fast-forward: '{}' -> {}", current.name, source.head);
@@ -169,7 +171,7 @@ pub async fn run(branch: String, strategy: String) -> Result<()> {
                 &source.head,
                 &theirs,
                 &format!("Merge '{}' into '{}'", branch, current.name),
-            );
+            )?;
             crate::backend::require_daemon_commit(&layout, &merge, &current.name.to_string())
                 .await?;
             println!("  Merge commit: {}", merge.id);
@@ -199,6 +201,7 @@ pub async fn run(branch: String, strategy: String) -> Result<()> {
                     &layout,
                     &current.name.to_string(),
                     &source.head.to_string(),
+                    &current.head.to_string(),
                 )
                 .await?;
                 println!("  Fast-forward: '{}' -> {}", current.name, source.head);
@@ -208,7 +211,7 @@ pub async fn run(branch: String, strategy: String) -> Result<()> {
                     &source.head,
                     &theirs,
                     &format!("Merge '{}' into '{}' (auto-resolved)", branch, current.name),
-                );
+                )?;
                 crate::backend::require_daemon_commit(&layout, &merge, &current.name.to_string())
                     .await?;
                 println!("  Merge commit: {}", merge.id);
@@ -360,17 +363,7 @@ fn build_merge_change(
     theirs_head: &SemanticChangeId,
     their_changes: &[SemanticChange],
     message: &str,
-) -> SemanticChange {
-    use sha2::Digest;
-    let mut hasher = sha2::Sha256::new();
-    hasher.update(b"kin-merge-v1:");
-    hasher.update(ours_head.0.as_bytes());
-    hasher.update(theirs_head.0.as_bytes());
-    let result = hasher.finalize();
-    let mut bytes = [0u8; 32];
-    bytes.copy_from_slice(&result);
-    let id = SemanticChangeId::from_hash(Hash256::from_bytes(bytes));
-
+) -> Result<SemanticChange> {
     // Collect all deltas from their side
     let entity_deltas: Vec<_> = their_changes
         .iter()
@@ -385,8 +378,8 @@ fn build_merge_change(
         .flat_map(|c| c.artifact_deltas.clone())
         .collect();
 
-    SemanticChange {
-        id,
+    let mut change = SemanticChange {
+        id: SemanticChangeId::from_hash(Hash256::from_bytes([0; 32])),
         parents: vec![*ours_head, *theirs_head],
         timestamp: Timestamp::now(),
         author: AuthorId::new("kin-merge"),
@@ -399,5 +392,30 @@ fn build_merge_change(
         evidence: vec![],
         risk_summary: None,
         authored_on: None,
+    };
+    change.id = kin_core::compute_semantic_change_id(&change)?;
+    Ok(change)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn merge_identity_binds_complete_constructed_payload() {
+        let ours = SemanticChangeId::from_hash(Hash256::from_bytes([0x11; 32]));
+        let theirs = SemanticChangeId::from_hash(Hash256::from_bytes([0x22; 32]));
+        let merge = build_merge_change(&ours, &theirs, &[], "merge feature").unwrap();
+        assert_eq!(
+            merge.id,
+            kin_core::compute_semantic_change_id(&merge).unwrap()
+        );
+
+        let mut changed = merge.clone();
+        changed.message = "different merge payload".to_string();
+        assert_ne!(
+            merge.id,
+            kin_core::compute_semantic_change_id(&changed).unwrap()
+        );
     }
 }

--- a/crates/kin-cli/src/commands/ref_lookup.rs
+++ b/crates/kin-cli/src/commands/ref_lookup.rs
@@ -846,6 +846,16 @@ where
         }
     }
 
+    // The canonical genesis ID is the admitted boundary for every imported Git
+    // root, but a request-scoped or freshly constructed graph may not have had
+    // repository bootstrap applied. Graph replay requires every reachable
+    // parent record, so materialize the deterministic boundary before
+    // inserting children instead of leaving an accepted but unresolvable
+    // ancestry.
+    if graph.get_change(&genesis_id)?.is_none() {
+        graph.create_change(&kin_core::build_genesis_change())?;
+    }
+
     let mut pending: HashSet<SemanticChangeId> = absent.iter().copied().collect();
     let mut inserted = 0usize;
     for imported_change in &imported {

--- a/crates/kin-cli/src/commands/release.rs
+++ b/crates/kin-cli/src/commands/release.rs
@@ -1,12 +1,1028 @@
 // SPDX-License-Identifier: Apache-2.0
 // Copyright 2026 Firelock, LLC
 
-use anyhow::Result;
+use std::collections::HashMap;
+use std::fs::{self, File, OpenOptions};
+use std::io::{Read, Write};
+use std::path::{Path, PathBuf};
+
+use anyhow::{Context, Result};
+use fs2::FileExt;
 use kin_model::{
-    ArtifactDeltaKind, AuthorId, ChangeStore, EntityDelta, EntityStore, GraphStore, Hash256,
-    RelationDelta, SemanticChange, SemanticChangeId, Timestamp, VerificationStore, Visibility,
-    WorkId, WorkStore,
+    ArtifactDelta, ArtifactDeltaKind, AuthorId, ChangeStore, EntityDelta, EntityStore, FilePathId,
+    GraphStore, Hash256, RelationDelta, ResolvedSourceEntry, SemanticChange, SemanticChangeId,
+    SourceEntryKind, SourceTreeResolution, Timestamp, Visibility, WorkId, WorkStore,
 };
+
+const PENDING_RELEASE_SCHEMA: u32 = 1;
+const MAX_PENDING_RELEASE_BYTES: u64 = 4 * 1024 * 1024;
+
+#[derive(Debug, Clone, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
+struct PendingRelease {
+    schema: u32,
+    tag: String,
+    branch_name: String,
+    change_id: String,
+    /// The complete `/graph/commit` body. Keeping it as one string preserves
+    /// exact request bytes across retries and later CLI process invocations.
+    request_json: String,
+}
+
+impl PendingRelease {
+    fn new(
+        tag: String,
+        branch_name: String,
+        change_id: SemanticChangeId,
+        request_bytes: Vec<u8>,
+    ) -> Result<Self> {
+        let request_json = String::from_utf8(request_bytes)
+            .context("serialized daemon release request was not UTF-8 JSON")?;
+        let pending = Self {
+            schema: PENDING_RELEASE_SCHEMA,
+            tag,
+            branch_name,
+            change_id: change_id.to_string(),
+            request_json,
+        };
+        pending.validate()?;
+        Ok(pending)
+    }
+
+    fn validate(&self) -> Result<()> {
+        if self.schema != PENDING_RELEASE_SCHEMA {
+            anyhow::bail!(
+                "unsupported pending release schema {} (expected {})",
+                self.schema,
+                PENDING_RELEASE_SCHEMA
+            );
+        }
+        if u64::try_from(self.request_json.len()).unwrap_or(u64::MAX) > MAX_PENDING_RELEASE_BYTES {
+            anyhow::bail!("pending release request exceeds the 4 MiB safety limit");
+        }
+        let request: serde_json::Value = serde_json::from_str(&self.request_json)
+            .context("pending release request is not valid JSON")?;
+        let request_branch = request
+            .get("branch_name")
+            .and_then(serde_json::Value::as_str)
+            .context("pending release request has no branch_name")?;
+        let request_change: SemanticChange = serde_json::from_value(
+            request
+                .get("change")
+                .cloned()
+                .context("pending release request has no change")?,
+        )
+        .context("pending release request has an invalid semantic change")?;
+        if request_branch != self.branch_name || request_change.id.to_string() != self.change_id {
+            anyhow::bail!("pending release envelope does not match its serialized daemon request");
+        }
+        let expected_message_prefix = format!("release: {} (", self.tag);
+        if request_change.author.to_string() != "kin-release"
+            || !request_change.message.starts_with(&expected_message_prefix)
+            || request_change.parents.len() != 1
+            || request_change.authored_on.as_ref().map(ToString::to_string)
+                != Some(self.branch_name.clone())
+        {
+            anyhow::bail!("pending release payload is not a one-parent Kin release marker");
+        }
+        let policy = request
+            .get("release_policy")
+            .and_then(serde_json::Value::as_object)
+            .context("pending release payload has no daemon release policy")?;
+        if ["force", "require_proof", "require_approval"]
+            .iter()
+            .any(|field| {
+                policy
+                    .get(*field)
+                    .and_then(serde_json::Value::as_bool)
+                    .is_none()
+            })
+        {
+            anyhow::bail!("pending release payload has an invalid daemon release policy");
+        }
+        Ok(())
+    }
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+struct ReleaseFileIdentity {
+    #[cfg(unix)]
+    device: u64,
+    #[cfg(unix)]
+    inode: u64,
+    #[cfg(windows)]
+    volume_serial: u64,
+    #[cfg(windows)]
+    file_id: [u8; 16],
+}
+
+#[derive(Debug)]
+struct LoadedPendingRelease {
+    pending: PendingRelease,
+    file: File,
+    identity: ReleaseFileIdentity,
+}
+
+impl std::ops::Deref for LoadedPendingRelease {
+    type Target = PendingRelease;
+
+    fn deref(&self) -> &Self::Target {
+        &self.pending
+    }
+}
+
+#[cfg(unix)]
+fn release_file_identity(file: &File) -> std::io::Result<ReleaseFileIdentity> {
+    use std::os::unix::fs::MetadataExt;
+    let metadata = file.metadata()?;
+    if !metadata.is_file() {
+        return Err(std::io::Error::other(
+            "release control object is not a regular file",
+        ));
+    }
+    Ok(ReleaseFileIdentity {
+        device: metadata.dev(),
+        inode: metadata.ino(),
+    })
+}
+
+#[cfg(windows)]
+fn release_file_identity(file: &File) -> std::io::Result<ReleaseFileIdentity> {
+    use std::os::windows::io::AsRawHandle;
+    use windows_sys::Win32::Storage::FileSystem::{
+        FileAttributeTagInfo, FileIdInfo, GetFileInformationByHandleEx, FILE_ATTRIBUTE_DIRECTORY,
+        FILE_ATTRIBUTE_REPARSE_POINT, FILE_ATTRIBUTE_TAG_INFO, FILE_ID_INFO,
+    };
+
+    let handle = file.as_raw_handle().cast();
+    let mut attributes: FILE_ATTRIBUTE_TAG_INFO = unsafe { std::mem::zeroed() };
+    if unsafe {
+        GetFileInformationByHandleEx(
+            handle,
+            FileAttributeTagInfo,
+            (&raw mut attributes).cast(),
+            std::mem::size_of::<FILE_ATTRIBUTE_TAG_INFO>() as u32,
+        )
+    } == 0
+    {
+        return Err(std::io::Error::last_os_error());
+    }
+    if attributes.FileAttributes & (FILE_ATTRIBUTE_DIRECTORY | FILE_ATTRIBUTE_REPARSE_POINT) != 0 {
+        return Err(std::io::Error::other(
+            "release control object is a directory or reparse point",
+        ));
+    }
+    let mut info: FILE_ID_INFO = unsafe { std::mem::zeroed() };
+    if unsafe {
+        GetFileInformationByHandleEx(
+            handle,
+            FileIdInfo,
+            (&raw mut info).cast(),
+            std::mem::size_of::<FILE_ID_INFO>() as u32,
+        )
+    } == 0
+    {
+        return Err(std::io::Error::last_os_error());
+    }
+    let identity = ReleaseFileIdentity {
+        volume_serial: info.VolumeSerialNumber,
+        file_id: info.FileId.Identifier,
+    };
+    if identity.volume_serial == 0 || identity.file_id.iter().all(|byte| *byte == 0) {
+        return Err(std::io::Error::new(
+            std::io::ErrorKind::InvalidData,
+            "release control object has a zero Windows FILE_ID_128 identity",
+        ));
+    }
+    Ok(identity)
+}
+
+#[cfg(windows)]
+fn open_windows_release_file(
+    path: &Path,
+    desired_access: u32,
+    creation_disposition: u32,
+) -> std::io::Result<File> {
+    use std::os::windows::ffi::OsStrExt;
+    use std::os::windows::io::FromRawHandle;
+    use windows_sys::Win32::Foundation::INVALID_HANDLE_VALUE;
+    use windows_sys::Win32::Storage::FileSystem::{
+        CreateFileW, FILE_ATTRIBUTE_NORMAL, FILE_FLAG_OPEN_REPARSE_POINT, FILE_SHARE_DELETE,
+        FILE_SHARE_READ, FILE_SHARE_WRITE,
+    };
+
+    let mut wide = path.as_os_str().encode_wide().collect::<Vec<_>>();
+    wide.push(0);
+    let handle = unsafe {
+        CreateFileW(
+            wide.as_ptr(),
+            desired_access,
+            FILE_SHARE_READ | FILE_SHARE_WRITE | FILE_SHARE_DELETE,
+            std::ptr::null(),
+            creation_disposition,
+            FILE_ATTRIBUTE_NORMAL | FILE_FLAG_OPEN_REPARSE_POINT,
+            std::ptr::null_mut(),
+        )
+    };
+    if handle == INVALID_HANDLE_VALUE {
+        return Err(std::io::Error::last_os_error());
+    }
+    let file = unsafe { File::from_raw_handle(handle.cast()) };
+    release_file_identity(&file)?;
+    Ok(file)
+}
+
+#[cfg(windows)]
+fn open_windows_release_directory(path: &Path) -> std::io::Result<File> {
+    use std::os::windows::ffi::OsStrExt;
+    use std::os::windows::io::FromRawHandle;
+    use windows_sys::Win32::Foundation::{GENERIC_READ, INVALID_HANDLE_VALUE};
+    use windows_sys::Win32::Storage::FileSystem::{
+        CreateFileW, FileAttributeTagInfo, GetFileInformationByHandleEx, FILE_ATTRIBUTE_DIRECTORY,
+        FILE_ATTRIBUTE_REPARSE_POINT, FILE_ATTRIBUTE_TAG_INFO, FILE_FLAG_BACKUP_SEMANTICS,
+        FILE_FLAG_OPEN_REPARSE_POINT, FILE_SHARE_DELETE, FILE_SHARE_READ, FILE_SHARE_WRITE,
+        OPEN_EXISTING,
+    };
+
+    let mut wide = path.as_os_str().encode_wide().collect::<Vec<_>>();
+    wide.push(0);
+    let handle = unsafe {
+        CreateFileW(
+            wide.as_ptr(),
+            GENERIC_READ,
+            FILE_SHARE_READ | FILE_SHARE_WRITE | FILE_SHARE_DELETE,
+            std::ptr::null(),
+            OPEN_EXISTING,
+            FILE_FLAG_BACKUP_SEMANTICS | FILE_FLAG_OPEN_REPARSE_POINT,
+            std::ptr::null_mut(),
+        )
+    };
+    if handle == INVALID_HANDLE_VALUE {
+        return Err(std::io::Error::last_os_error());
+    }
+    let directory = unsafe { File::from_raw_handle(handle.cast()) };
+    let mut attributes: FILE_ATTRIBUTE_TAG_INFO = unsafe { std::mem::zeroed() };
+    if unsafe {
+        GetFileInformationByHandleEx(
+            handle,
+            FileAttributeTagInfo,
+            (&raw mut attributes).cast(),
+            std::mem::size_of::<FILE_ATTRIBUTE_TAG_INFO>() as u32,
+        )
+    } == 0
+    {
+        return Err(std::io::Error::last_os_error());
+    }
+    if attributes.FileAttributes & FILE_ATTRIBUTE_DIRECTORY == 0
+        || attributes.FileAttributes & FILE_ATTRIBUTE_REPARSE_POINT != 0
+    {
+        return Err(std::io::Error::other(
+            "release state parent is not an exact non-reparse directory",
+        ));
+    }
+    Ok(directory)
+}
+
+#[cfg(windows)]
+fn rename_windows_release_handle(
+    source: &File,
+    destination_parent: &File,
+    destination_name: &std::ffi::OsStr,
+) -> std::io::Result<()> {
+    use std::os::windows::ffi::OsStrExt;
+    use std::os::windows::io::AsRawHandle;
+    use windows_sys::Win32::Storage::FileSystem::{
+        FileRenameInfoEx, SetFileInformationByHandle, FILE_RENAME_INFO,
+    };
+
+    let wide = destination_name.encode_wide().collect::<Vec<_>>();
+    if wide.is_empty() || wide.contains(&0) {
+        return Err(std::io::Error::new(
+            std::io::ErrorKind::InvalidInput,
+            "pending release tombstone has an invalid Windows name",
+        ));
+    }
+    let name_bytes = wide
+        .len()
+        .checked_mul(std::mem::size_of::<u16>())
+        .ok_or_else(|| std::io::Error::other("pending release tombstone length overflow"))?;
+    let buffer_bytes = std::mem::offset_of!(FILE_RENAME_INFO, FileName)
+        .checked_add(name_bytes)
+        .and_then(|bytes| bytes.checked_add(std::mem::size_of::<u16>()))
+        .ok_or_else(|| std::io::Error::other("pending release rename buffer overflow"))?;
+    let mut storage = vec![0_usize; buffer_bytes.div_ceil(std::mem::size_of::<usize>())];
+    let info = storage.as_mut_ptr().cast::<FILE_RENAME_INFO>();
+    unsafe {
+        (*info).Anonymous.Flags = 0;
+        (*info).RootDirectory = destination_parent.as_raw_handle().cast();
+        (*info).FileNameLength = u32::try_from(name_bytes)
+            .map_err(|_| std::io::Error::other("pending release tombstone name is too long"))?;
+        std::ptr::copy_nonoverlapping(
+            wide.as_ptr(),
+            std::ptr::addr_of_mut!((*info).FileName).cast::<u16>(),
+            wide.len(),
+        );
+        *std::ptr::addr_of_mut!((*info).FileName)
+            .cast::<u16>()
+            .add(wide.len()) = 0;
+    }
+    if unsafe {
+        SetFileInformationByHandle(
+            source.as_raw_handle().cast(),
+            FileRenameInfoEx,
+            info.cast(),
+            u32::try_from(buffer_bytes)
+                .map_err(|_| std::io::Error::other("pending release rename buffer is too large"))?,
+        )
+    } == 0
+    {
+        return Err(std::io::Error::last_os_error());
+    }
+    Ok(())
+}
+
+#[cfg(windows)]
+fn delete_windows_release_handle(source: &File) -> std::io::Result<()> {
+    use std::os::windows::io::AsRawHandle;
+    use windows_sys::Win32::Storage::FileSystem::{
+        FileDispositionInfo, SetFileInformationByHandle, FILE_DISPOSITION_INFO,
+    };
+
+    let disposition = FILE_DISPOSITION_INFO { DeleteFile: true };
+    if unsafe {
+        SetFileInformationByHandle(
+            source.as_raw_handle().cast(),
+            FileDispositionInfo,
+            (&raw const disposition).cast(),
+            std::mem::size_of::<FILE_DISPOSITION_INFO>() as u32,
+        )
+    } == 0
+    {
+        return Err(std::io::Error::last_os_error());
+    }
+    Ok(())
+}
+
+#[derive(Debug)]
+struct ReleaseTransactionLock {
+    file: File,
+    path: PathBuf,
+    identity: ReleaseFileIdentity,
+}
+
+impl ReleaseTransactionLock {
+    fn acquire(layout: &kin_core::KinLayout) -> Result<Self> {
+        let path = layout.pending_release_lock_path();
+        #[cfg(unix)]
+        let file = {
+            if fs::symlink_metadata(&path).is_ok_and(|metadata| metadata.file_type().is_symlink()) {
+                anyhow::bail!(
+                    "pending release lock must not be a symlink: {}",
+                    path.display()
+                );
+            }
+            let mut options = OpenOptions::new();
+            options.read(true).write(true).create(true);
+            use std::os::unix::fs::OpenOptionsExt;
+            options
+                .mode(0o600)
+                .custom_flags(libc::O_NOFOLLOW | libc::O_CLOEXEC);
+            options
+                .open(&path)
+                .with_context(|| format!("open pending release lock {}", path.display()))?
+        };
+        #[cfg(windows)]
+        let file = {
+            use windows_sys::Win32::Foundation::{GENERIC_READ, GENERIC_WRITE};
+            use windows_sys::Win32::Storage::FileSystem::OPEN_ALWAYS;
+            open_windows_release_file(&path, GENERIC_READ | GENERIC_WRITE, OPEN_ALWAYS)
+                .with_context(|| format!("open pending release lock {}", path.display()))?
+        };
+        #[cfg(not(any(unix, windows)))]
+        let file = OpenOptions::new()
+            .read(true)
+            .write(true)
+            .create(true)
+            .open(&path)
+            .with_context(|| format!("open pending release lock {}", path.display()))?;
+        let identity = release_file_identity(&file)
+            .with_context(|| format!("validate pending release lock {}", path.display()))?;
+        file.try_lock_exclusive().with_context(|| {
+            format!(
+                "another Kin release or recovery is active for {}",
+                layout.working_dir().display()
+            )
+        })?;
+
+        #[cfg(unix)]
+        let named = {
+            let mut options = OpenOptions::new();
+            options.read(true);
+            use std::os::unix::fs::OpenOptionsExt;
+            options.custom_flags(libc::O_NOFOLLOW | libc::O_CLOEXEC);
+            options.open(&path)
+        };
+        #[cfg(windows)]
+        let named = {
+            use windows_sys::Win32::Foundation::GENERIC_READ;
+            use windows_sys::Win32::Storage::FileSystem::OPEN_EXISTING;
+            open_windows_release_file(&path, GENERIC_READ, OPEN_EXISTING)
+        };
+        #[cfg(not(any(unix, windows)))]
+        let named = File::open(&path);
+        let named = named.with_context(|| {
+            format!(
+                "revalidate pending release lock attachment {}",
+                path.display()
+            )
+        })?;
+        if release_file_identity(&named)? != identity {
+            anyhow::bail!(
+                "pending release lock {} changed identity while acquiring",
+                path.display()
+            );
+        }
+        recover_pending_release_tombstones(layout)?;
+        Ok(Self {
+            file,
+            path,
+            identity,
+        })
+    }
+
+    /// Prove that the name every cooperating release process opens still
+    /// refers to the kernel-locked object. A pathname lock can otherwise be
+    /// renamed and replaced after acquisition, allowing another process to
+    /// lock the substitute and enter the same release transaction.
+    fn revalidate(&self) -> Result<()> {
+        #[cfg(unix)]
+        let named = {
+            let mut options = OpenOptions::new();
+            options.read(true);
+            use std::os::unix::fs::OpenOptionsExt;
+            options.custom_flags(libc::O_NOFOLLOW | libc::O_CLOEXEC);
+            options.open(&self.path)
+        };
+        #[cfg(windows)]
+        let named = {
+            use windows_sys::Win32::Foundation::GENERIC_READ;
+            use windows_sys::Win32::Storage::FileSystem::OPEN_EXISTING;
+            open_windows_release_file(&self.path, GENERIC_READ, OPEN_EXISTING)
+        };
+        #[cfg(not(any(unix, windows)))]
+        let named = File::open(&self.path);
+        let named = named.with_context(|| {
+            format!(
+                "revalidate pending release lock attachment {}",
+                self.path.display()
+            )
+        })?;
+        if release_file_identity(&named)? != self.identity {
+            anyhow::bail!(
+                "pending release lock {} was replaced while held; refusing release state mutation",
+                self.path.display()
+            );
+        }
+        Ok(())
+    }
+}
+
+impl Drop for ReleaseTransactionLock {
+    fn drop(&mut self) {
+        let _ = FileExt::unlock(&self.file);
+    }
+}
+
+fn sync_directory(path: &Path) -> Result<()> {
+    #[cfg(unix)]
+    File::open(path)
+        .and_then(|directory| directory.sync_all())
+        .with_context(|| format!("sync release state directory {}", path.display()))?;
+    #[cfg(not(unix))]
+    let _ = path;
+    Ok(())
+}
+
+#[cfg(test)]
+fn persist_pending_release(layout: &kin_core::KinLayout, pending: &PendingRelease) -> Result<()> {
+    persist_pending_release_with_before_publish(layout, pending, || Ok(()))
+}
+
+fn persist_pending_release_with_before_publish<F>(
+    layout: &kin_core::KinLayout,
+    pending: &PendingRelease,
+    before_publish: F,
+) -> Result<()>
+where
+    F: FnOnce() -> Result<()>,
+{
+    pending.validate()?;
+    let path = layout.pending_release_path();
+    match fs::symlink_metadata(&path) {
+        Ok(_) => {
+            anyhow::bail!(
+                "pending release state already exists and must be recovered first: {}",
+                path.display()
+            );
+        }
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => {}
+        Err(error) => {
+            return Err(error)
+                .with_context(|| format!("inspect pending release state {}", path.display()));
+        }
+    }
+    let bytes = serde_json::to_vec_pretty(pending)?;
+    if u64::try_from(bytes.len()).unwrap_or(u64::MAX) > MAX_PENDING_RELEASE_BYTES {
+        anyhow::bail!("pending release state exceeds the 4 MiB safety limit");
+    }
+    let temporary = layout
+        .root()
+        .join(format!(".pending-release-{}.tmp", uuid::Uuid::new_v4()));
+    let mut options = OpenOptions::new();
+    options.write(true).create_new(true);
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::OpenOptionsExt;
+        options
+            .mode(0o600)
+            .custom_flags(libc::O_NOFOLLOW | libc::O_CLOEXEC);
+    }
+    let mut file = options
+        .open(&temporary)
+        .with_context(|| format!("create pending release state {}", temporary.display()))?;
+    let write_result = (|| -> Result<()> {
+        file.write_all(&bytes)?;
+        file.sync_all()?;
+        Ok(())
+    })();
+    if let Err(error) = write_result {
+        drop(file);
+        let _ = fs::remove_file(&temporary);
+        return Err(error)
+            .with_context(|| format!("write pending release state {}", temporary.display()));
+    }
+
+    let result = (|| -> Result<()> {
+        before_publish()?;
+        // The journal is published by creating a second link to the fully
+        // synced temporary inode. Unlike rename on Unix, hard_link never
+        // replaces a destination created by a racing process.
+        fs::hard_link(&temporary, &path).with_context(|| {
+            format!(
+                "publish pending release state without overwriting {} -> {}",
+                temporary.display(),
+                path.display()
+            )
+        })?;
+        file.sync_all()
+            .with_context(|| format!("sync published pending release state {}", path.display()))?;
+        sync_directory(layout.root())?;
+        fs::remove_file(&temporary).with_context(|| {
+            format!(
+                "remove published pending release temporary file {}",
+                temporary.display()
+            )
+        })?;
+        sync_directory(layout.root())?;
+        Ok(())
+    })();
+    drop(file);
+    if result.is_err() {
+        let _ = fs::remove_file(&temporary);
+    }
+    result
+}
+
+fn load_pending_release(layout: &kin_core::KinLayout) -> Result<Option<LoadedPendingRelease>> {
+    let path = layout.pending_release_path();
+    load_pending_release_path(&path)
+}
+
+fn load_pending_release_path(path: &Path) -> Result<Option<LoadedPendingRelease>> {
+    #[cfg(unix)]
+    let mut file = {
+        if fs::symlink_metadata(path).is_ok_and(|metadata| metadata.file_type().is_symlink()) {
+            anyhow::bail!(
+                "pending release state must not be a symlink: {}",
+                path.display()
+            );
+        }
+        let mut options = OpenOptions::new();
+        options.read(true);
+        use std::os::unix::fs::OpenOptionsExt;
+        options.custom_flags(libc::O_NOFOLLOW | libc::O_CLOEXEC);
+        match options.open(path) {
+            Ok(file) => file,
+            Err(error) if error.kind() == std::io::ErrorKind::NotFound => return Ok(None),
+            Err(error) => return Err(error).with_context(|| format!("open {}", path.display())),
+        }
+    };
+    #[cfg(windows)]
+    let mut file = {
+        use windows_sys::Win32::Foundation::GENERIC_READ;
+        use windows_sys::Win32::Storage::FileSystem::{DELETE, OPEN_EXISTING};
+        match open_windows_release_file(path, GENERIC_READ | DELETE, OPEN_EXISTING) {
+            Ok(file) => file,
+            Err(error) if error.kind() == std::io::ErrorKind::NotFound => return Ok(None),
+            Err(error) => return Err(error).with_context(|| format!("open {}", path.display())),
+        }
+    };
+    #[cfg(not(any(unix, windows)))]
+    let mut file = match File::open(path) {
+        Ok(file) => file,
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => return Ok(None),
+        Err(error) => return Err(error).with_context(|| format!("open {}", path.display())),
+    };
+    let identity = release_file_identity(&file)
+        .with_context(|| format!("validate pending release state {}", path.display()))?;
+    let metadata = file.metadata()?;
+    if metadata.len() > MAX_PENDING_RELEASE_BYTES {
+        anyhow::bail!("pending release state exceeds the 4 MiB safety limit");
+    }
+    let mut bytes = Vec::new();
+    Read::by_ref(&mut file)
+        .take(MAX_PENDING_RELEASE_BYTES + 1)
+        .read_to_end(&mut bytes)
+        .with_context(|| format!("read {}", path.display()))?;
+    if u64::try_from(bytes.len()).unwrap_or(u64::MAX) > MAX_PENDING_RELEASE_BYTES {
+        anyhow::bail!("pending release state exceeds the 4 MiB safety limit");
+    }
+    let pending: PendingRelease =
+        serde_json::from_slice(&bytes).with_context(|| format!("decode {}", path.display()))?;
+    pending.validate()?;
+    Ok(Some(LoadedPendingRelease {
+        pending,
+        file,
+        identity,
+    }))
+}
+
+#[cfg(test)]
+fn clear_pending_release(layout: &kin_core::KinLayout, expected_change_id: &str) -> Result<()> {
+    clear_pending_release_with_before_move(layout, expected_change_id, || Ok(()))
+}
+
+fn clear_pending_release_with_before_move<F>(
+    layout: &kin_core::KinLayout,
+    expected_change_id: &str,
+    before_move: F,
+) -> Result<()>
+where
+    F: FnOnce() -> Result<()>,
+{
+    let Some(loaded) = load_pending_release(layout)? else {
+        return Ok(());
+    };
+    if loaded.change_id != expected_change_id {
+        anyhow::bail!(
+            "refusing to clear pending release {} while finalizing {}",
+            loaded.change_id,
+            expected_change_id
+        );
+    }
+    if release_file_identity(&loaded.file)? != loaded.identity {
+        anyhow::bail!("pending release handle changed identity before cleanup");
+    }
+    before_move()?;
+
+    #[cfg(not(windows))]
+    let pending_path = layout.pending_release_path();
+    let tombstone_name = format!(".pending-release-delete-{}.tmp", uuid::Uuid::new_v4());
+    let tombstone_path = layout.root().join(&tombstone_name);
+
+    #[cfg(unix)]
+    {
+        let parent = rustix::fs::open(
+            layout.root(),
+            rustix::fs::OFlags::RDONLY
+                | rustix::fs::OFlags::DIRECTORY
+                | rustix::fs::OFlags::NOFOLLOW
+                | rustix::fs::OFlags::CLOEXEC,
+            rustix::fs::Mode::empty(),
+        )
+        .map(std::fs::File::from)
+        .with_context(|| format!("open release state directory {}", layout.root().display()))?;
+        let pending_name = pending_path
+            .file_name()
+            .context("pending release path has no file name")?;
+        rustix::fs::renameat_with(
+            &parent,
+            pending_name,
+            &parent,
+            std::ffi::OsStr::new(&tombstone_name),
+            rustix::fs::RenameFlags::NOREPLACE,
+        )
+        .with_context(|| {
+            format!(
+                "move pending release into private tombstone {}",
+                tombstone_path.display()
+            )
+        })?;
+        rustix::fs::fsync(&parent)
+            .with_context(|| format!("sync release state directory {}", layout.root().display()))?;
+    }
+    #[cfg(windows)]
+    let windows_parent = {
+        let parent = open_windows_release_directory(layout.root())
+            .with_context(|| format!("open release state directory {}", layout.root().display()))?;
+        rename_windows_release_handle(&loaded.file, &parent, std::ffi::OsStr::new(&tombstone_name))
+            .with_context(|| {
+                format!(
+                    "move exact pending release handle into private tombstone {}",
+                    tombstone_path.display()
+                )
+            })?;
+        parent
+    };
+    #[cfg(not(any(unix, windows)))]
+    fs::rename(&pending_path, &tombstone_path)?;
+
+    #[cfg(unix)]
+    let moved = {
+        let mut options = OpenOptions::new();
+        options.read(true);
+        use std::os::unix::fs::OpenOptionsExt;
+        options.custom_flags(libc::O_NOFOLLOW | libc::O_CLOEXEC);
+        options.open(&tombstone_path)
+    };
+    #[cfg(windows)]
+    let moved = {
+        use windows_sys::Win32::Foundation::GENERIC_READ;
+        use windows_sys::Win32::Storage::FileSystem::{DELETE, OPEN_EXISTING};
+        open_windows_release_file(&tombstone_path, GENERIC_READ | DELETE, OPEN_EXISTING)
+    };
+    #[cfg(not(any(unix, windows)))]
+    let moved = File::open(&tombstone_path);
+    let moved = moved.with_context(|| {
+        format!(
+            "reopen pending release tombstone {}",
+            tombstone_path.display()
+        )
+    })?;
+    let moved_identity = release_file_identity(&moved)?;
+    if moved_identity != loaded.identity {
+        #[cfg(unix)]
+        {
+            let parent = rustix::fs::open(
+                layout.root(),
+                rustix::fs::OFlags::RDONLY
+                    | rustix::fs::OFlags::DIRECTORY
+                    | rustix::fs::OFlags::NOFOLLOW
+                    | rustix::fs::OFlags::CLOEXEC,
+                rustix::fs::Mode::empty(),
+            )
+            .map(std::fs::File::from)?;
+            let pending_name = pending_path
+                .file_name()
+                .context("pending release path has no file name")?;
+            let _ = rustix::fs::renameat_with(
+                &parent,
+                std::ffi::OsStr::new(&tombstone_name),
+                &parent,
+                pending_name,
+                rustix::fs::RenameFlags::NOREPLACE,
+            );
+            let _ = rustix::fs::fsync(&parent);
+        }
+        anyhow::bail!(
+            "pending release changed identity before tombstoning; no unverified object was deleted"
+        );
+    }
+
+    #[cfg(unix)]
+    fs::remove_file(&tombstone_path).with_context(|| {
+        format!(
+            "unlink identity-verified pending release tombstone {}",
+            tombstone_path.display()
+        )
+    })?;
+    #[cfg(windows)]
+    {
+        delete_windows_release_handle(&loaded.file).with_context(|| {
+            format!(
+                "delete identity-bound pending release tombstone {}",
+                tombstone_path.display()
+            )
+        })?;
+        drop(windows_parent);
+    }
+    #[cfg(not(any(unix, windows)))]
+    fs::remove_file(&tombstone_path)?;
+    sync_directory(layout.root())
+}
+
+fn recover_pending_release_tombstones(layout: &kin_core::KinLayout) -> Result<()> {
+    let mut tombstones = fs::read_dir(layout.root())?
+        .filter_map(std::result::Result::ok)
+        .filter_map(|entry| {
+            let name = entry.file_name();
+            name.to_str()
+                .is_some_and(|name| {
+                    name.starts_with(".pending-release-delete-") && name.ends_with(".tmp")
+                })
+                .then(|| entry.path())
+        })
+        .collect::<Vec<_>>();
+    tombstones.sort();
+    for path in tombstones {
+        let loaded = load_pending_release_path(&path)?.ok_or_else(|| {
+            anyhow::anyhow!(
+                "pending release tombstone disappeared during recovery: {}",
+                path.display()
+            )
+        })?;
+        if release_file_identity(&loaded.file)? != loaded.identity {
+            anyhow::bail!(
+                "pending release tombstone changed identity during recovery: {}",
+                path.display()
+            );
+        }
+        #[cfg(unix)]
+        fs::remove_file(&path).with_context(|| {
+            format!(
+                "remove identity-verified pending release tombstone {}",
+                path.display()
+            )
+        })?;
+        #[cfg(windows)]
+        delete_windows_release_handle(&loaded.file).with_context(|| {
+            format!(
+                "remove identity-bound pending release tombstone {}",
+                path.display()
+            )
+        })?;
+        #[cfg(not(any(unix, windows)))]
+        fs::remove_file(&path)?;
+    }
+    sync_directory(layout.root())
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum PendingReleaseAttempt {
+    First,
+    Recovery,
+}
+
+fn clear_pending_after_failure(
+    attempt: PendingReleaseAttempt,
+    kind: crate::backend::DaemonReleaseFailureKind,
+    safe_to_abandon: bool,
+) -> bool {
+    // A first-attempt definitive rejection never became authority. A recovered
+    // journal is cleared only when the daemon's serialized stale-head response
+    // proved this exact change absent; ordinary policy/auth failures cannot
+    // reconcile an earlier uncertain attempt and retain the journal.
+    kind == crate::backend::DaemonReleaseFailureKind::Definitive
+        && (attempt == PendingReleaseAttempt::First || safe_to_abandon)
+}
+
+async fn send_pending_release(
+    layout: &kin_core::KinLayout,
+    pending: &PendingRelease,
+    attempt: PendingReleaseAttempt,
+    transaction: &ReleaseTransactionLock,
+) -> Result<()> {
+    transaction.revalidate()?;
+    match crate::backend::require_daemon_release_commit(
+        layout,
+        pending.request_json.as_bytes(),
+        &pending.branch_name,
+    )
+    .await
+    {
+        Ok(()) => clear_pending_release_with_before_move(layout, &pending.change_id, || {
+            transaction.revalidate()
+        }),
+        Err(error) => {
+            if clear_pending_after_failure(attempt, error.kind, error.safe_to_abandon) {
+                clear_pending_release_with_before_move(layout, &pending.change_id, || {
+                    transaction.revalidate()
+                })
+                .with_context(|| {
+                    format!(
+                        "daemon definitively rejected release, but pending state cleanup failed: {error}"
+                    )
+                })?;
+                return Err(anyhow::Error::new(error).context(format!(
+                    "release request {} was definitively not applied; its pending journal was cleared safely and a later invocation may build a new marker",
+                    pending.change_id
+                )));
+            }
+            Err(anyhow::Error::new(error).context(format!(
+                "release request {} remains recoverable at {}",
+                pending.change_id,
+                layout.pending_release_path().display()
+            )))
+        }
+    }
+}
+
+fn added_artifact_kind(kind: SourceEntryKind) -> ArtifactDeltaKind {
+    match kind {
+        SourceEntryKind::File { executable: false } => ArtifactDeltaKind::AddedRegularFile,
+        SourceEntryKind::File { executable: true } => ArtifactDeltaKind::AddedExecutableFile,
+        SourceEntryKind::Symlink => ArtifactDeltaKind::AddedSymlink,
+    }
+}
+
+fn modified_artifact_kind(kind: SourceEntryKind) -> ArtifactDeltaKind {
+    match kind {
+        SourceEntryKind::File { executable: false } => ArtifactDeltaKind::ModifiedRegularFile,
+        SourceEntryKind::File { executable: true } => ArtifactDeltaKind::ModifiedExecutableFile,
+        SourceEntryKind::Symlink => ArtifactDeltaKind::ModifiedSymlink,
+    }
+}
+
+fn require_exact_source_tree<G: GraphStore>(
+    graph: &G,
+    head: &SemanticChangeId,
+) -> Result<HashMap<FilePathId, ResolvedSourceEntry>> {
+    match graph.resolve_source_tree_at(head)? {
+        SourceTreeResolution::Exact { entries } => Ok(entries),
+        SourceTreeResolution::Incomplete { gaps } => {
+            let gaps = gaps
+                .iter()
+                .map(|gap| format!("{}@{}:{:?}", gap.file_id, gap.change_id, gap.reason))
+                .collect::<Vec<_>>()
+                .join(", ");
+            anyhow::bail!(
+                "rollback requires exact source history at {head}, but found unresolved gaps: {gaps}"
+            )
+        }
+    }
+}
+
+fn exact_source_tree_correction(
+    current: &HashMap<FilePathId, ResolvedSourceEntry>,
+    desired: &HashMap<FilePathId, ResolvedSourceEntry>,
+) -> Vec<ArtifactDelta> {
+    let mut deltas = Vec::new();
+    for (path, old) in current {
+        if !desired.contains_key(path) {
+            deltas.push(ArtifactDelta {
+                file_id: path.clone(),
+                kind: ArtifactDeltaKind::Removed,
+                old_hash: Some(old.hash),
+                new_hash: None,
+            });
+        }
+    }
+    for (path, new) in desired {
+        match current.get(path) {
+            Some(old) if old == new => {}
+            Some(old) => deltas.push(ArtifactDelta {
+                file_id: path.clone(),
+                kind: modified_artifact_kind(new.kind),
+                old_hash: Some(old.hash),
+                new_hash: Some(new.hash),
+            }),
+            None => deltas.push(ArtifactDelta {
+                file_id: path.clone(),
+                kind: added_artifact_kind(new.kind),
+                old_hash: None,
+                new_hash: Some(new.hash),
+            }),
+        }
+    }
+    deltas.sort_by(|left, right| left.file_id.0.cmp(&right.file_id.0));
+    deltas
+}
+
+fn prior_exact_source_entry<G: GraphStore>(
+    graph: &G,
+    change: &SemanticChange,
+    delta: &ArtifactDelta,
+) -> Result<ResolvedSourceEntry> {
+    let old_hash = delta.old_hash.ok_or_else(|| {
+        anyhow::anyhow!(
+            "cannot exactly reverse source delta for {} in {}: old content hash is missing",
+            delta.file_id,
+            change.id
+        )
+    })?;
+    let mut candidates = Vec::new();
+    for parent in &change.parents {
+        if let Some(entry) = require_exact_source_tree(graph, parent)?.get(&delta.file_id) {
+            if entry.hash == old_hash && !candidates.contains(entry) {
+                candidates.push(*entry);
+            }
+        }
+    }
+    match candidates.as_slice() {
+        [entry] => Ok(*entry),
+        [] => anyhow::bail!(
+            "cannot exactly reverse source delta for {} in {}: no parent carries old hash {}",
+            delta.file_id,
+            change.id,
+            old_hash
+        ),
+        _ => anyhow::bail!(
+            "cannot exactly reverse source delta for {} in {}: parent history gives ambiguous entry kinds for old hash {}",
+            delta.file_id,
+            change.id,
+            old_hash
+        ),
+    }
+}
 
 /// Semver bump level.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
@@ -137,10 +1153,41 @@ pub struct ReleaseOptions {
 /// Gating checks:
 ///   - Coverage ratio < 0.5 warns and requires `--force` to proceed
 ///   - `--require-proof`: blocks if any entity in the change lacks linked passing tests
-///   - `--require-approval`: blocks if unapproved agent changes exist
+///   - `--require-approval`: blocks if any non-root change lacks human approval
 pub async fn release_with_options(tag: String, opts: ReleaseOptions) -> Result<()> {
     let layout = kin_core::KinLayout::discover(&std::env::current_dir()?)
         .ok_or_else(|| anyhow::anyhow!("not a Kin repository (no .kin/ found)"))?;
+    // Hold one repo-scoped lock across recovery, advisory preflight, marker
+    // construction, and publication. A concurrent CLI must not observe an
+    // uncertain request and manufacture a second marker from a newer head.
+    let release_transaction = ReleaseTransactionLock::acquire(&layout)?;
+    release_transaction.revalidate()?;
+    if let Some(pending) = load_pending_release(&layout)? {
+        let requested_tag_is_pending = pending.tag == tag;
+        eprintln!(
+            "Recovering pending release '{}' with exact change {} before creating any new marker.",
+            pending.tag, pending.change_id
+        );
+        send_pending_release(
+            &layout,
+            &pending,
+            PendingReleaseAttempt::Recovery,
+            &release_transaction,
+        )
+        .await?;
+        println!(
+            "Recovered durable release '{}' on branch '{}'.",
+            pending.tag, pending.branch_name
+        );
+        println!("  Change: {}", pending.change_id);
+        if requested_tag_is_pending {
+            return Ok(());
+        }
+    }
+    if tag.trim().is_empty() || tag != tag.trim() || tag.chars().any(char::is_control) {
+        anyhow::bail!("release tag must be non-empty, trimmed, and contain no control characters");
+    }
+
     let snap =
         crate::backend::open_snapshot_explicit_admin_read_only(&layout, "kin release").await?;
     let graph = &*snap.graph();
@@ -150,19 +1197,23 @@ pub async fn release_with_options(tag: String, opts: ReleaseOptions) -> Result<(
         .get_branch(&branch_name)?
         .ok_or_else(|| anyhow::anyhow!("branch '{}' not found", branch_name))?;
 
-    let entities = graph.list_all_entities()?;
+    // Release policy and marker metadata must describe the immutable branch
+    // parent, never ambient graph overlays that are not reachable from it.
+    let source_state = graph.resolve_graph_at(&branch.head)?;
+    let source_entities = source_state.entities;
 
     // Gating: coverage ratio check
-    let summary = graph.get_coverage_summary()?;
+    let summary =
+        kin_review::source_bound_release_proof_coverage_for_entities(source_entities.values());
     if summary.coverage_ratio < 0.5 {
         if opts.force {
             eprintln!(
-                "Warning: coverage ratio {:.1}% is below 50% threshold, proceeding with --force.",
+                "Warning: immutable source-bound proof coverage {:.1}% is below 50%; proceeding with --force.",
                 summary.coverage_ratio * 100.0
             );
         } else {
             anyhow::bail!(
-                "Release blocked: coverage ratio {:.1}% is below 50% threshold. Use --force to override.",
+                "Release blocked: immutable source-bound proof coverage {:.1}% is below 50%. Verification runs are not yet bound to a source change; use --force to override the coverage gate.",
                 summary.coverage_ratio * 100.0
             );
         }
@@ -173,18 +1224,24 @@ pub async fn release_with_options(tag: String, opts: ReleaseOptions) -> Result<(
         let missing_names: Vec<String> = summary
             .missing_proof
             .iter()
-            .filter_map(|eid| graph.get_entity(eid).ok().flatten().map(|e| e.name))
+            .map(|eid| {
+                source_entities
+                    .get(eid)
+                    .cloned()
+                    .map(|entity| entity.name)
+                    .unwrap_or_else(|| eid.to_string())
+            })
             .collect();
         anyhow::bail!(
-            "Release blocked: {} entity(ies) lack linked passing tests: {}",
-            missing_names.len(),
+            "Release blocked: {} entity(ies) lack immutable source-bound passing proof: {}",
+            summary.missing_proof.len(),
             missing_names.join(", ")
         );
     }
 
-    // Gating: --require-approval (check recent changes for unapproved agent changes)
+    // Gating: --require-approval (every reachable non-root change needs a human approval)
     if opts.require_approval {
-        let unapproved = kin_review::unapproved_agent_changes(graph, &branch.head, 50)?;
+        let unapproved = kin_review::unapproved_changes(graph, &branch.head, usize::MAX)?;
         if !unapproved.is_empty() {
             let detail = unapproved
                 .iter()
@@ -192,7 +1249,7 @@ pub async fn release_with_options(tag: String, opts: ReleaseOptions) -> Result<(
                 .collect::<Vec<_>>()
                 .join(", ");
             anyhow::bail!(
-                "Release blocked: {} unapproved agent change(s): {}",
+                "Release blocked: {} non-root change(s) lack human approval: {}",
                 unapproved.len(),
                 detail
             );
@@ -200,23 +1257,16 @@ pub async fn release_with_options(tag: String, opts: ReleaseOptions) -> Result<(
     }
 
     // Build a release change — empty deltas, just a marker with entity count snapshot
-    let change_id = {
-        use sha2::{Digest, Sha256};
-        let mut hasher = Sha256::new();
-        hasher.update(format!("release:{}:{}", tag, branch.head).as_bytes());
-        hasher.update(chrono::Utc::now().to_rfc3339().as_bytes());
-        let result = hasher.finalize();
-        let mut bytes = [0u8; 32];
-        bytes.copy_from_slice(&result);
-        SemanticChangeId::from_hash(Hash256::from_bytes(bytes))
-    };
-
-    let release_change = SemanticChange {
-        id: change_id,
+    let mut release_change = SemanticChange {
+        id: SemanticChangeId::from_hash(Hash256::from_bytes([0; 32])),
         parents: vec![branch.head],
         timestamp: Timestamp::now(),
         author: AuthorId::new("kin-release"),
-        message: format!("release: {} ({} entities snapshot)", tag, entities.len()),
+        message: format!(
+            "release: {} ({} entities snapshot)",
+            tag,
+            source_entities.len()
+        ),
         entity_deltas: Vec::new(),
         relation_deltas: Vec::new(),
         artifact_deltas: Vec::new(),
@@ -226,14 +1276,39 @@ pub async fn release_with_options(tag: String, opts: ReleaseOptions) -> Result<(
         risk_summary: None,
         authored_on: Some(branch_name.clone()),
     };
+    release_change.id = kin_core::compute_semantic_change_id(&release_change)?;
+    let change_id = release_change.id;
 
-    crate::backend::require_daemon_commit(&layout, &release_change, &branch_name.to_string())
-        .await?;
+    let request_bytes = crate::backend::serialize_daemon_release_request(
+        &release_change,
+        &branch_name.to_string(),
+        opts.force,
+        opts.require_proof,
+        opts.require_approval,
+    )?;
+    let pending = PendingRelease::new(
+        tag.clone(),
+        branch_name.to_string(),
+        change_id,
+        request_bytes,
+    )?;
+    // Persist before the first byte can reach the daemon. Any timeout, 5xx, or
+    // client death after this point is resumed with this exact payload.
+    persist_pending_release_with_before_publish(&layout, &pending, || {
+        release_transaction.revalidate()
+    })?;
+    send_pending_release(
+        &layout,
+        &pending,
+        PendingReleaseAttempt::First,
+        &release_transaction,
+    )
+    .await?;
     println!("Daemon accepted release change.");
 
     println!("Release '{}' created on branch '{}'.", tag, branch_name);
     println!("  Change: {}", change_id);
-    println!("  Entities: {}", entities.len());
+    println!("  Entities: {}", source_entities.len());
     println!("  Parent: {}", branch.head);
 
     Ok(())
@@ -298,7 +1373,8 @@ pub async fn rollback_with_options(change_id_str: String, feature: Option<String
         // Reverse in topological order (newest first — already in HEAD-first order)
         let mut reversed_entity_deltas = Vec::new();
         let mut reversed_relation_deltas = Vec::new();
-        let mut reversed_artifact_deltas = Vec::new();
+        let current_source_tree = require_exact_source_tree(graph, &branch.head)?;
+        let mut desired_source_tree = current_source_tree.clone();
 
         for change in &feature_changes {
             println!("  reverting: {} - {}", change.id, change.message);
@@ -327,41 +1403,37 @@ pub async fn rollback_with_options(change_id_str: String, feature: Option<String
                 reversed_relation_deltas.push(reversed);
             }
             for delta in &change.artifact_deltas {
-                let reversed_kind = match delta.kind {
-                    ArtifactDeltaKind::Added => ArtifactDeltaKind::Removed,
-                    ArtifactDeltaKind::Removed => ArtifactDeltaKind::Added,
-                    ArtifactDeltaKind::Modified => ArtifactDeltaKind::Modified,
-                };
-                reversed_artifact_deltas.push(kin_model::ArtifactDelta {
-                    file_id: delta.file_id.clone(),
-                    kind: reversed_kind,
-                    old_hash: delta.new_hash,
-                    new_hash: delta.old_hash,
-                });
+                if delta.kind.is_added() {
+                    desired_source_tree.remove(&delta.file_id);
+                } else if delta.kind.is_removed() || delta.kind.is_modified() {
+                    desired_source_tree.insert(
+                        delta.file_id.clone(),
+                        prior_exact_source_entry(graph, change, delta)?,
+                    );
+                } else {
+                    anyhow::bail!(
+                        "cannot reverse unsupported source delta {:?} for {} in {}",
+                        delta.kind,
+                        delta.file_id,
+                        change.id
+                    );
+                }
             }
         }
+        let reversed_artifact_deltas =
+            exact_source_tree_correction(&current_source_tree, &desired_source_tree);
 
-        let rollback_change_id = {
-            use sha2::{Digest, Sha256};
-            let mut hasher = Sha256::new();
-            hasher.update(format!("feature-rollback:{}:{}", work_id_str, branch.head).as_bytes());
-            hasher.update(chrono::Utc::now().to_rfc3339().as_bytes());
-            let result = hasher.finalize();
-            let mut bytes = [0u8; 32];
-            bytes.copy_from_slice(&result);
-            SemanticChangeId::from_hash(Hash256::from_bytes(bytes))
-        };
-
-        let rollback_change = SemanticChange {
-            id: rollback_change_id,
+        let rollback_message = format!(
+            "rollback: revert feature '{}' ({} change(s))",
+            work_item.title,
+            feature_changes.len()
+        );
+        let mut rollback_change = SemanticChange {
+            id: SemanticChangeId::from_hash(Hash256::from_bytes([0; 32])),
             parents: vec![branch.head],
             timestamp: Timestamp::now(),
             author: AuthorId::new("kin-rollback"),
-            message: format!(
-                "rollback: revert feature '{}' ({} change(s))",
-                work_item.title,
-                feature_changes.len()
-            ),
+            message: rollback_message,
             entity_deltas: reversed_entity_deltas,
             relation_deltas: reversed_relation_deltas,
             artifact_deltas: reversed_artifact_deltas,
@@ -371,6 +1443,8 @@ pub async fn rollback_with_options(change_id_str: String, feature: Option<String
             risk_summary: None,
             authored_on: Some(branch_name.clone()),
         };
+        rollback_change.id = kin_core::compute_semantic_change_id(&rollback_change)?;
+        let rollback_change_id = rollback_change.id;
 
         for delta in &rollback_change.entity_deltas {
             match delta {
@@ -433,7 +1507,10 @@ pub async fn rollback_with_options(change_id_str: String, feature: Option<String
     // Build reversed deltas: walk changes in reverse, invert each delta
     let mut reversed_entity_deltas = Vec::new();
     let mut reversed_relation_deltas = Vec::new();
-    let mut reversed_artifact_deltas = Vec::new();
+    let current_source_tree = require_exact_source_tree(graph, &branch.head)?;
+    let target_source_tree = require_exact_source_tree(graph, &target_id)?;
+    let reversed_artifact_deltas =
+        exact_source_tree_correction(&current_source_tree, &target_source_tree);
 
     for change in changes_to_reverse.iter().rev() {
         for delta in &change.entity_deltas {
@@ -468,44 +1545,20 @@ pub async fn rollback_with_options(change_id_str: String, feature: Option<String
             };
             reversed_relation_deltas.push(reversed);
         }
-
-        for delta in &change.artifact_deltas {
-            let reversed_kind = match delta.kind {
-                ArtifactDeltaKind::Added => ArtifactDeltaKind::Removed,
-                ArtifactDeltaKind::Removed => ArtifactDeltaKind::Added,
-                ArtifactDeltaKind::Modified => ArtifactDeltaKind::Modified,
-            };
-            reversed_artifact_deltas.push(kin_model::ArtifactDelta {
-                file_id: delta.file_id.clone(),
-                kind: reversed_kind,
-                old_hash: delta.new_hash,
-                new_hash: delta.old_hash,
-            });
-        }
     }
 
     // Create the rollback change
-    let rollback_change_id = {
-        use sha2::{Digest, Sha256};
-        let mut hasher = Sha256::new();
-        hasher.update(format!("rollback:{}:{}", change_id_str, branch.head).as_bytes());
-        hasher.update(chrono::Utc::now().to_rfc3339().as_bytes());
-        let result = hasher.finalize();
-        let mut bytes = [0u8; 32];
-        bytes.copy_from_slice(&result);
-        SemanticChangeId::from_hash(Hash256::from_bytes(bytes))
-    };
-
-    let rollback_change = SemanticChange {
-        id: rollback_change_id,
+    let rollback_message = format!(
+        "rollback: revert {} change(s) to {}",
+        changes_to_reverse.len(),
+        &change_id_str[..change_id_str.len().min(12)]
+    );
+    let mut rollback_change = SemanticChange {
+        id: SemanticChangeId::from_hash(Hash256::from_bytes([0; 32])),
         parents: vec![branch.head],
         timestamp: Timestamp::now(),
         author: AuthorId::new("kin-rollback"),
-        message: format!(
-            "rollback: revert {} change(s) to {}",
-            changes_to_reverse.len(),
-            &change_id_str[..change_id_str.len().min(12)]
-        ),
+        message: rollback_message,
         entity_deltas: reversed_entity_deltas,
         relation_deltas: reversed_relation_deltas,
         artifact_deltas: reversed_artifact_deltas,
@@ -515,6 +1568,8 @@ pub async fn rollback_with_options(change_id_str: String, feature: Option<String
         risk_summary: None,
         authored_on: Some(branch_name.clone()),
     };
+    rollback_change.id = kin_core::compute_semantic_change_id(&rollback_change)?;
+    let rollback_change_id = rollback_change.id;
 
     // Apply reversed entity deltas to the graph
     for delta in &rollback_change.entity_deltas {
@@ -596,6 +1651,241 @@ fn collect_changes_from_head<G: GraphStore>(
 mod tests {
     use super::*;
 
+    fn pending_release_fixture() -> (SemanticChange, Vec<u8>) {
+        let parent = SemanticChangeId::from_hash(Hash256::from_bytes([0x31; 32]));
+        let change = SemanticChange {
+            id: SemanticChangeId::from_hash(Hash256::from_bytes([0x32; 32])),
+            parents: vec![parent],
+            timestamp: Timestamp::now(),
+            author: AuthorId::new("kin-release"),
+            message: "release: v0.3.0 (1 entities snapshot)".to_string(),
+            entity_deltas: vec![],
+            relation_deltas: vec![],
+            artifact_deltas: vec![],
+            projected_files: vec![],
+            spec_link: None,
+            evidence: vec![],
+            risk_summary: None,
+            authored_on: Some(kin_model::BranchName::new("main")),
+        };
+        let request =
+            crate::backend::serialize_daemon_release_request(&change, "main", true, true, true)
+                .unwrap();
+        (change, request)
+    }
+
+    #[test]
+    fn pending_release_roundtrip_preserves_exact_request_bytes() {
+        let repo = tempfile::tempdir().unwrap();
+        let layout = kin_core::init(repo.path()).unwrap().layout;
+        let (change, request) = pending_release_fixture();
+        let pending = PendingRelease::new(
+            "v0.3.0".to_string(),
+            "main".to_string(),
+            change.id,
+            request.clone(),
+        )
+        .unwrap();
+
+        persist_pending_release(&layout, &pending).unwrap();
+        let recovered = load_pending_release(&layout).unwrap().unwrap();
+        assert_eq!(recovered.pending, pending);
+        assert_eq!(recovered.request_json.as_bytes(), request);
+        clear_pending_release(&layout, &change.id.to_string()).unwrap();
+        assert!(load_pending_release(&layout).unwrap().is_none());
+    }
+
+    #[test]
+    fn pending_release_rejects_envelope_payload_mismatch() {
+        let (change, request) = pending_release_fixture();
+        let mut pending =
+            PendingRelease::new("v0.3.0".to_string(), "main".to_string(), change.id, request)
+                .unwrap();
+        pending.change_id =
+            SemanticChangeId::from_hash(Hash256::from_bytes([0x33; 32])).to_string();
+        assert!(pending.validate().is_err());
+    }
+
+    #[test]
+    fn pending_release_publish_never_overwrites_raced_state() {
+        let repo = tempfile::tempdir().unwrap();
+        let layout = kin_core::init(repo.path()).unwrap().layout;
+        let (change, request) = pending_release_fixture();
+        let pending =
+            PendingRelease::new("v0.3.0".to_string(), "main".to_string(), change.id, request)
+                .unwrap();
+        let raced_bytes = b"raced pending state";
+
+        let error = persist_pending_release_with_before_publish(&layout, &pending, || {
+            fs::write(layout.pending_release_path(), raced_bytes)?;
+            Ok(())
+        })
+        .unwrap_err();
+
+        assert!(format!("{error:#}").contains("without overwriting"));
+        assert_eq!(
+            fs::read(layout.pending_release_path()).unwrap(),
+            raced_bytes
+        );
+        assert_eq!(
+            fs::read_dir(layout.root())
+                .unwrap()
+                .filter_map(Result::ok)
+                .filter(|entry| {
+                    entry
+                        .file_name()
+                        .to_string_lossy()
+                        .starts_with(".pending-release-")
+                })
+                .count(),
+            0,
+            "failed no-clobber publication left a temporary journal"
+        );
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn pending_release_cleanup_never_unlinks_an_aba_substitute() {
+        let repo = tempfile::tempdir().unwrap();
+        let layout = kin_core::init(repo.path()).unwrap().layout;
+        let (change, request) = pending_release_fixture();
+        let pending =
+            PendingRelease::new("v0.3.0".to_string(), "main".to_string(), change.id, request)
+                .unwrap();
+        persist_pending_release(&layout, &pending).unwrap();
+        let displaced = layout.root().join("displaced-pending-release.json");
+        let substitute = b"unrelated substitute bytes";
+
+        let error = clear_pending_release_with_before_move(&layout, &change.id.to_string(), || {
+            fs::rename(layout.pending_release_path(), &displaced)?;
+            fs::write(layout.pending_release_path(), substitute)?;
+            Ok(())
+        })
+        .unwrap_err();
+
+        assert!(error.to_string().contains("changed identity"));
+        assert_eq!(fs::read(layout.pending_release_path()).unwrap(), substitute);
+        assert_eq!(
+            serde_json::from_slice::<PendingRelease>(&fs::read(displaced).unwrap()).unwrap(),
+            pending
+        );
+        assert_eq!(
+            fs::read_dir(layout.root())
+                .unwrap()
+                .filter_map(Result::ok)
+                .filter(|entry| entry
+                    .file_name()
+                    .to_string_lossy()
+                    .starts_with(".pending-release-delete-"))
+                .count(),
+            0
+        );
+    }
+
+    #[test]
+    fn release_lock_recovers_identity_bound_cleanup_tombstone() {
+        let repo = tempfile::tempdir().unwrap();
+        let layout = kin_core::init(repo.path()).unwrap().layout;
+        let (change, request) = pending_release_fixture();
+        let pending =
+            PendingRelease::new("v0.3.0".to_string(), "main".to_string(), change.id, request)
+                .unwrap();
+        persist_pending_release(&layout, &pending).unwrap();
+        let tombstone = layout
+            .root()
+            .join(".pending-release-delete-crash-recovery.tmp");
+        fs::rename(layout.pending_release_path(), &tombstone).unwrap();
+
+        let lock = ReleaseTransactionLock::acquire(&layout).unwrap();
+
+        assert!(!tombstone.exists());
+        assert!(!layout.pending_release_path().exists());
+        drop(lock);
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn release_lock_refuses_mutation_after_path_replacement() {
+        let repo = tempfile::tempdir().unwrap();
+        let layout = kin_core::init(repo.path()).unwrap().layout;
+        let lock = ReleaseTransactionLock::acquire(&layout).unwrap();
+        let displaced = layout.root().join("displaced-release.lock");
+        fs::rename(layout.pending_release_lock_path(), &displaced).unwrap();
+        fs::write(layout.pending_release_lock_path(), b"substitute lock").unwrap();
+
+        let error = lock.revalidate().unwrap_err();
+
+        assert!(format!("{error:#}").contains("replaced while held"));
+        assert!(
+            displaced.exists(),
+            "the actually locked inode must be retained"
+        );
+        assert_eq!(
+            fs::read(layout.pending_release_lock_path()).unwrap(),
+            b"substitute lock"
+        );
+    }
+
+    #[cfg(windows)]
+    #[test]
+    fn windows_pending_release_open_rejects_reparse_point() {
+        use std::os::windows::fs::symlink_file;
+
+        let repo = tempfile::tempdir().unwrap();
+        let layout = kin_core::init(repo.path()).unwrap().layout;
+        let target = layout.root().join("pending-target.json");
+        fs::write(&target, b"not authority").unwrap();
+        symlink_file(&target, layout.pending_release_path()).unwrap();
+
+        let error = load_pending_release(&layout).unwrap_err();
+
+        assert!(format!("{error:#}").contains("reparse"));
+        assert_eq!(fs::read(&target).unwrap(), b"not authority");
+    }
+
+    #[cfg(windows)]
+    #[test]
+    fn windows_release_lock_rejects_reparse_point() {
+        use std::os::windows::fs::symlink_file;
+
+        let repo = tempfile::tempdir().unwrap();
+        let layout = kin_core::init(repo.path()).unwrap().layout;
+        let target = layout.root().join("lock-target");
+        fs::write(&target, b"not a lock").unwrap();
+        let lock_path = layout.pending_release_lock_path();
+        let _ = fs::remove_file(&lock_path);
+        symlink_file(&target, &lock_path).unwrap();
+
+        let error = ReleaseTransactionLock::acquire(&layout).unwrap_err();
+
+        assert!(format!("{error:#}").contains("reparse"));
+        assert_eq!(fs::read(&target).unwrap(), b"not a lock");
+    }
+
+    #[test]
+    fn recovered_pending_release_clears_only_after_exact_absence_proof() {
+        assert!(!clear_pending_after_failure(
+            PendingReleaseAttempt::Recovery,
+            crate::backend::DaemonReleaseFailureKind::Definitive,
+            false,
+        ));
+        assert!(clear_pending_after_failure(
+            PendingReleaseAttempt::Recovery,
+            crate::backend::DaemonReleaseFailureKind::Definitive,
+            true,
+        ));
+        assert!(!clear_pending_after_failure(
+            PendingReleaseAttempt::Recovery,
+            crate::backend::DaemonReleaseFailureKind::Uncertain,
+            true,
+        ));
+        assert!(clear_pending_after_failure(
+            PendingReleaseAttempt::First,
+            crate::backend::DaemonReleaseFailureKind::Definitive,
+            false,
+        ));
+    }
+
     #[test]
     fn semver_bump_ordering() {
         assert!(SemverBump::Patch < SemverBump::Minor);
@@ -609,5 +1899,56 @@ mod tests {
         assert_eq!(format!("{}", SemverBump::Patch), "patch");
         assert_eq!(format!("{}", SemverBump::Minor), "minor");
         assert_eq!(format!("{}", SemverBump::Major), "major");
+    }
+
+    #[test]
+    fn exact_source_tree_correction_preserves_modes_additions_and_removals() {
+        let first_hash = Hash256::from_bytes([1; 32]);
+        let removed_hash = Hash256::from_bytes([2; 32]);
+        let added_hash = Hash256::from_bytes([3; 32]);
+        let current = HashMap::from([
+            (
+                FilePathId::new("bin/kin"),
+                ResolvedSourceEntry {
+                    hash: first_hash,
+                    kind: SourceEntryKind::File { executable: false },
+                },
+            ),
+            (
+                FilePathId::new("old-link"),
+                ResolvedSourceEntry {
+                    hash: removed_hash,
+                    kind: SourceEntryKind::Symlink,
+                },
+            ),
+        ]);
+        let desired = HashMap::from([
+            (
+                FilePathId::new("bin/kin"),
+                ResolvedSourceEntry {
+                    hash: first_hash,
+                    kind: SourceEntryKind::File { executable: true },
+                },
+            ),
+            (
+                FilePathId::new("current"),
+                ResolvedSourceEntry {
+                    hash: added_hash,
+                    kind: SourceEntryKind::Symlink,
+                },
+            ),
+        ]);
+
+        let deltas = exact_source_tree_correction(&current, &desired);
+        assert_eq!(deltas.len(), 3);
+        assert_eq!(deltas[0].file_id, FilePathId::new("bin/kin"));
+        assert_eq!(deltas[0].kind, ArtifactDeltaKind::ModifiedExecutableFile);
+        assert_eq!(deltas[0].old_hash, Some(first_hash));
+        assert_eq!(deltas[0].new_hash, Some(first_hash));
+        assert_eq!(deltas[1].file_id, FilePathId::new("current"));
+        assert_eq!(deltas[1].kind, ArtifactDeltaKind::AddedSymlink);
+        assert_eq!(deltas[2].file_id, FilePathId::new("old-link"));
+        assert_eq!(deltas[2].kind, ArtifactDeltaKind::Removed);
+        assert_eq!(deltas[2].old_hash, Some(removed_hash));
     }
 }

--- a/crates/kin-cli/src/main.rs
+++ b/crates/kin-cli/src/main.rs
@@ -681,7 +681,7 @@ enum Command {
         /// Block release if entities lack linked passing tests
         #[arg(long)]
         require_proof: bool,
-        /// Block release if unapproved agent changes exist
+        /// Require known-human approval for every reachable non-root change
         #[arg(long)]
         require_approval: bool,
         /// Force release even with low coverage
@@ -1907,7 +1907,7 @@ enum ReleaseAction {
         /// Block release if entities lack linked passing tests
         #[arg(long)]
         require_proof: bool,
-        /// Block release if unapproved agent changes exist
+        /// Require known-human approval for every reachable non-root change
         #[arg(long)]
         require_approval: bool,
         /// Force release even with low coverage

--- a/crates/kin-core/Cargo.toml
+++ b/crates/kin-core/Cargo.toml
@@ -29,9 +29,21 @@ sha2 = { workspace = true }
 gix = { workspace = true }
 directories = "5"
 fs2 = { workspace = true }
+unicode-normalization = "=0.1.25"
+
+[target.'cfg(any(unix, windows))'.dependencies]
+cap-std = "=4.0.2"
 
 [target.'cfg(unix)'.dependencies]
 libc = "0.2"
+rustix = { workspace = true }
+
+[target.'cfg(windows)'.dependencies]
+cap-fs-ext = "=4.0.2"
+windows-sys = { version = "0.61", features = [
+    "Win32_Foundation",
+    "Win32_Storage_FileSystem",
+] }
 
 [dev-dependencies]
 tempfile = { workspace = true }

--- a/crates/kin-core/src/diff.rs
+++ b/crates/kin-core/src/diff.rs
@@ -6,98 +6,277 @@
 //! Shared utilities for building semantic changes, computing change IDs,
 //! and resolving author identity.
 
-use kin_model::{ArtifactDelta, EntityDelta, Hash256, RelationDelta, SemanticChangeId};
+use std::collections::HashSet;
+
+use kin_model::{
+    ArtifactDelta, Entity, EntityDelta, Hash256, Relation, RelationDelta, SemanticChange,
+    SemanticChangeId,
+};
+use serde::Serialize;
 use sha2::{Digest, Sha256};
 
-/// Compute a content-addressed change ID from message + parent + content identity.
+use crate::{KinError, Result};
+
+/// Compute the immutable identity of a complete native semantic change.
 ///
-/// Deterministic: identical inputs always produce the same ID.  Wall-clock time
-/// must NOT be mixed into the hash — use `content_identity_from_deltas` to derive
-/// a stable content fingerprint and pass it as `content_identity`.
-pub fn compute_change_id(
-    message: &str,
-    parent: &SemanticChangeId,
-    content_identity: &[u8],
-) -> SemanticChangeId {
+/// The existing `id` field is excluded to avoid a self-reference; every other
+/// serialized field participates, including all parents, author, timestamp,
+/// message, deltas, provenance links, risk, and authored branch. Native change
+/// constructors must use this after assembling the final payload so daemon
+/// exact-retry equality and ID authority describe the same bytes.
+pub fn compute_semantic_change_id(change: &SemanticChange) -> Result<SemanticChangeId> {
+    // Reuse delta validation so non-finite semantic scores cannot enter a
+    // canonical JSON identity through this higher-level path.
+    let _ = content_identity_from_deltas(
+        &change.entity_deltas,
+        &change.relation_deltas,
+        &change.artifact_deltas,
+    )?;
+
+    let mut payload = serde_json::to_value(change)?;
+    let fields = payload.as_object_mut().ok_or_else(|| {
+        KinError::Other("semantic change identity payload is not an object".to_string())
+    })?;
+    if fields.remove("id").is_none() {
+        return Err(KinError::Other(
+            "semantic change identity payload has no id field".to_string(),
+        ));
+    }
+    let mut canonical = Vec::new();
+    append_canonical_json(&mut canonical, &payload)?;
+
     let mut hasher = Sha256::new();
-    hasher.update(b"kin-change-v2:");
-    hasher.update(message.as_bytes());
-    hasher.update(b":");
-    hasher.update(parent.0.as_bytes());
-    hasher.update(b":");
-    hasher.update(content_identity);
+    hasher.update(b"kin-semantic-change-v3\0");
+    append_len_prefixed_hash_field(&mut hasher, &canonical)?;
     let result = hasher.finalize();
     let mut bytes = [0u8; 32];
     bytes.copy_from_slice(&result);
-    SemanticChangeId::from_hash(Hash256::from_bytes(bytes))
+    Ok(SemanticChangeId::from_hash(Hash256::from_bytes(bytes)))
 }
 
-/// Derive a deterministic content fingerprint from the three delta slices.
+/// Derive a deterministic content fingerprint from the complete delta payloads.
 ///
-/// IDs within each slice are sorted before hashing so insertion order does not
-/// affect the result.  Two preps of the same logical tree will produce the same
-/// fingerprint; a different tree (different entity/relation/artifact set) will
-/// produce a different one.
+/// Canonical encodings of independent deltas are sorted before hashing so their
+/// insertion order does not affect the result. If deltas overlap a replay
+/// target, their order is retained because graph replay is order-sensitive.
+/// Every field of every delta participates, including entity
+/// bodies/fingerprints, relation evidence/confidence, and artifact kind plus
+/// old/new hashes. This is deliberately not an ID-only projection: two
+/// immutable `SemanticChange` records must never receive the same ID merely
+/// because they touch the same graph IDs or file paths.
 pub fn content_identity_from_deltas(
     entity_deltas: &[EntityDelta],
     relation_deltas: &[RelationDelta],
     artifact_deltas: &[ArtifactDelta],
-) -> [u8; 32] {
-    // EntityIds are content-addressed UUIDs — sort their 16-byte representations.
-    let mut entity_ids: Vec<[u8; 16]> = entity_deltas
-        .iter()
-        .map(|d| match d {
-            EntityDelta::Added(e) => *e.id.0.as_bytes(),
-            EntityDelta::Modified { new, .. } => *new.id.0.as_bytes(),
-            EntityDelta::Removed(id) => *id.0.as_bytes(),
-        })
-        .collect();
-    entity_ids.sort_unstable();
-
-    // RelationIds are also content-addressed UUIDs.
-    let mut relation_ids: Vec<[u8; 16]> = relation_deltas
-        .iter()
-        .map(|d| match d {
-            RelationDelta::Added(r) => *r.id.0.as_bytes(),
-            RelationDelta::Removed(id) => *id.0.as_bytes(),
-        })
-        .collect();
-    relation_ids.sort_unstable();
-
-    // Artifact key = file-path bytes + NUL separator + new-hash bytes (if present).
-    // Fixed-length hash after the separator prevents ambiguity.
-    let mut artifact_keys: Vec<Vec<u8>> = artifact_deltas
-        .iter()
-        .map(|d| {
-            let mut k = Vec::new();
-            k.extend_from_slice(d.file_id.0.as_bytes());
-            k.push(0u8);
-            if let Some(h) = d.new_hash {
-                k.extend_from_slice(h.as_bytes());
+) -> Result<[u8; 32]> {
+    for delta in entity_deltas {
+        match delta {
+            EntityDelta::Added(entity) => validate_entity_numbers(entity)?,
+            EntityDelta::Modified { old, new } => {
+                validate_entity_numbers(old)?;
+                validate_entity_numbers(new)?;
             }
-            k
-        })
-        .collect();
-    artifact_keys.sort_unstable();
+            EntityDelta::Removed(_) => {}
+        }
+    }
+    for delta in relation_deltas {
+        if let RelationDelta::Added(relation) = delta {
+            validate_relation_numbers(relation)?;
+        }
+    }
+
+    let entity_payloads = replay_equivalent_payloads(
+        entity_deltas,
+        entity_deltas_have_overlapping_targets(entity_deltas),
+    )?;
+    let relation_payloads = replay_equivalent_payloads(
+        relation_deltas,
+        relation_deltas_have_overlapping_targets(relation_deltas),
+    )?;
+    let artifact_payloads = replay_equivalent_payloads(
+        artifact_deltas,
+        artifact_deltas_have_overlapping_targets(artifact_deltas),
+    )?;
 
     let mut hasher = Sha256::new();
-    hasher.update(b"kin-content-v1:");
-    for id in &entity_ids {
-        hasher.update(id);
-    }
-    hasher.update(b"|");
-    for id in &relation_ids {
-        hasher.update(id);
-    }
-    hasher.update(b"|");
-    for key in &artifact_keys {
-        hasher.update(key);
-        hasher.update(b"\x00");
-    }
+    hasher.update(b"kin-content-v2\0");
+    append_payload_slice(&mut hasher, b"entities", &entity_payloads)?;
+    append_payload_slice(&mut hasher, b"relations", &relation_payloads)?;
+    append_payload_slice(&mut hasher, b"artifacts", &artifact_payloads)?;
     let result = hasher.finalize();
     let mut bytes = [0u8; 32];
     bytes.copy_from_slice(&result);
-    bytes
+    Ok(bytes)
+}
+
+fn entity_deltas_have_overlapping_targets(entity_deltas: &[EntityDelta]) -> bool {
+    let mut entity_targets = HashSet::with_capacity(entity_deltas.len());
+    for delta in entity_deltas {
+        match delta {
+            EntityDelta::Added(entity) => {
+                if !entity_targets.insert(entity.id) {
+                    return true;
+                }
+            }
+            EntityDelta::Modified { old, new } => {
+                if !entity_targets.insert(old.id)
+                    || (new.id != old.id && !entity_targets.insert(new.id))
+                {
+                    return true;
+                }
+            }
+            EntityDelta::Removed(id) => {
+                if !entity_targets.insert(*id) {
+                    return true;
+                }
+            }
+        }
+    }
+    false
+}
+
+fn relation_deltas_have_overlapping_targets(relation_deltas: &[RelationDelta]) -> bool {
+    let mut relation_targets = HashSet::with_capacity(relation_deltas.len());
+    for delta in relation_deltas {
+        let target = match delta {
+            RelationDelta::Added(relation) => relation.id,
+            RelationDelta::Removed(id) => *id,
+        };
+        if !relation_targets.insert(target) {
+            return true;
+        }
+    }
+    false
+}
+
+fn artifact_deltas_have_overlapping_targets(artifact_deltas: &[ArtifactDelta]) -> bool {
+    let mut artifact_targets = HashSet::with_capacity(artifact_deltas.len());
+    for delta in artifact_deltas {
+        if !artifact_targets.insert(delta.file_id.clone()) {
+            return true;
+        }
+    }
+    false
+}
+
+fn validate_entity_numbers(entity: &Entity) -> Result<()> {
+    if !entity.fingerprint.stability_score.is_finite() {
+        return Err(KinError::Other(format!(
+            "entity {} has a non-finite fingerprint stability score",
+            entity.id
+        )));
+    }
+    Ok(())
+}
+
+fn validate_relation_numbers(relation: &Relation) -> Result<()> {
+    if !relation.confidence.is_finite() {
+        return Err(KinError::Other(format!(
+            "relation {} has a non-finite confidence score",
+            relation.id
+        )));
+    }
+    Ok(())
+}
+
+fn canonical_payloads<T: Serialize>(values: &[T]) -> Result<Vec<Vec<u8>>> {
+    values
+        .iter()
+        .map(|value| {
+            let value = serde_json::to_value(value)?;
+            let mut encoded = Vec::new();
+            append_canonical_json(&mut encoded, &value)?;
+            Ok(encoded)
+        })
+        .collect()
+}
+
+fn replay_equivalent_payloads<T: Serialize>(
+    values: &[T],
+    order_matters: bool,
+) -> Result<Vec<Vec<u8>>> {
+    let mut payloads = canonical_payloads(values)?;
+    if !order_matters {
+        payloads.sort_unstable();
+    }
+    Ok(payloads)
+}
+
+fn append_payload_slice(hasher: &mut Sha256, label: &[u8], payloads: &[Vec<u8>]) -> Result<()> {
+    append_len_prefixed_hash_field(hasher, label)?;
+    hasher.update(
+        u64::try_from(payloads.len())
+            .map_err(|_| KinError::Other("change delta count exceeds u64".to_string()))?
+            .to_le_bytes(),
+    );
+    for payload in payloads {
+        append_len_prefixed_hash_field(hasher, payload)?;
+    }
+    Ok(())
+}
+
+fn append_len_prefixed_hash_field(hasher: &mut Sha256, value: &[u8]) -> Result<()> {
+    hasher.update(
+        u64::try_from(value.len())
+            .map_err(|_| KinError::Other("canonical change field exceeds u64".to_string()))?
+            .to_le_bytes(),
+    );
+    hasher.update(value);
+    Ok(())
+}
+
+fn append_canonical_json(output: &mut Vec<u8>, value: &serde_json::Value) -> Result<()> {
+    match value {
+        serde_json::Value::Null => output.push(0),
+        serde_json::Value::Bool(value) => {
+            output.push(1);
+            output.push(u8::from(*value));
+        }
+        serde_json::Value::Number(value) => {
+            output.push(2);
+            append_len_prefixed_vec_field(output, value.to_string().as_bytes())?;
+        }
+        serde_json::Value::String(value) => {
+            output.push(3);
+            append_len_prefixed_vec_field(output, value.as_bytes())?;
+        }
+        serde_json::Value::Array(values) => {
+            output.push(4);
+            output.extend_from_slice(
+                &u64::try_from(values.len())
+                    .map_err(|_| KinError::Other("canonical array exceeds u64".to_string()))?
+                    .to_le_bytes(),
+            );
+            for value in values {
+                append_canonical_json(output, value)?;
+            }
+        }
+        serde_json::Value::Object(values) => {
+            output.push(5);
+            output.extend_from_slice(
+                &u64::try_from(values.len())
+                    .map_err(|_| KinError::Other("canonical object exceeds u64".to_string()))?
+                    .to_le_bytes(),
+            );
+            let mut values: Vec<_> = values.iter().collect();
+            values.sort_by(|left, right| left.0.cmp(right.0));
+            for (key, value) in values {
+                append_len_prefixed_vec_field(output, key.as_bytes())?;
+                append_canonical_json(output, value)?;
+            }
+        }
+    }
+    Ok(())
+}
+
+fn append_len_prefixed_vec_field(output: &mut Vec<u8>, value: &[u8]) -> Result<()> {
+    output.extend_from_slice(
+        &u64::try_from(value.len())
+            .map_err(|_| KinError::Other("canonical value exceeds u64".to_string()))?
+            .to_le_bytes(),
+    );
+    output.extend_from_slice(value);
+    Ok(())
 }
 
 /// Get a human-readable author name from environment variables.
@@ -112,48 +291,176 @@ pub fn whoami() -> String {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use kin_model::{
+        relation::GraphNodeId, ArtifactDeltaKind, AuthorId, BranchName, EntityId, EntityKind,
+        EntityMetadata, EntityRole, FilePathId, FingerprintAlgorithm, LanguageId, RelationId,
+        RelationKind, RelationOrigin, SemanticFingerprint, Visibility,
+    };
 
-    #[test]
-    fn compute_change_id_is_deterministic() {
-        let parent = SemanticChangeId::from_hash(Hash256::from_bytes([0xaa; 32]));
-        let content = [0u8; 32];
-        let id1 = compute_change_id("test", &parent, &content);
-        let id2 = compute_change_id("test", &parent, &content);
-        assert_eq!(id1, id2);
+    fn test_entity(id: EntityId, name: &str) -> Entity {
+        Entity {
+            id,
+            kind: EntityKind::Function,
+            name: name.to_string(),
+            language: LanguageId::Rust,
+            fingerprint: SemanticFingerprint {
+                algorithm: FingerprintAlgorithm::V1TreeSitter,
+                ast_hash: Hash256::from_bytes([1; 32]),
+                signature_hash: Hash256::from_bytes([2; 32]),
+                behavior_hash: Hash256::from_bytes([3; 32]),
+                equivalence_hash: Hash256::from_bytes([4; 32]),
+                stability_score: 1.0,
+            },
+            file_origin: Some(FilePathId::new("src/lib.rs")),
+            span: None,
+            signature: format!("fn {name}()"),
+            visibility: Visibility::Private,
+            role: EntityRole::Source,
+            doc_summary: None,
+            metadata: EntityMetadata::default(),
+            lineage_parent: None,
+            created_in: None,
+            superseded_by: None,
+        }
     }
 
     #[test]
-    fn compute_change_id_differs_on_content() {
-        let parent = SemanticChangeId::from_hash(Hash256::from_bytes([0xaa; 32]));
-        let id1 = compute_change_id("test", &parent, &[0u8; 32]);
-        let id2 = compute_change_id("test", &parent, &[1u8; 32]);
-        assert_ne!(id1, id2);
-    }
+    fn complete_change_identity_binds_provenance_but_excludes_existing_id() {
+        let mut original = crate::build_genesis_change();
+        original.author = AuthorId::new("agent-a");
+        original.authored_on = Some(BranchName::new("main"));
+        let original_id = compute_semantic_change_id(&original).unwrap();
 
-    #[test]
-    fn compute_change_id_differs_on_message() {
-        let parent = SemanticChangeId::from_hash(Hash256::from_bytes([0xaa; 32]));
-        let content = [0u8; 32];
-        let id1 = compute_change_id("foo", &parent, &content);
-        let id2 = compute_change_id("bar", &parent, &content);
-        assert_ne!(id1, id2);
-    }
+        let mut different_author = original.clone();
+        different_author.author = AuthorId::new("agent-b");
+        assert_ne!(
+            original_id,
+            compute_semantic_change_id(&different_author).unwrap()
+        );
 
-    #[test]
-    fn compute_change_id_differs_on_parent() {
-        let parent1 = SemanticChangeId::from_hash(Hash256::from_bytes([0xaa; 32]));
-        let parent2 = SemanticChangeId::from_hash(Hash256::from_bytes([0xbb; 32]));
-        let content = [0u8; 32];
-        let id1 = compute_change_id("test", &parent1, &content);
-        let id2 = compute_change_id("test", &parent2, &content);
-        assert_ne!(id1, id2);
+        let mut different_branch = original.clone();
+        different_branch.authored_on = Some(BranchName::new("feature"));
+        assert_ne!(
+            original_id,
+            compute_semantic_change_id(&different_branch).unwrap()
+        );
+
+        original.id = SemanticChangeId::from_hash(Hash256::from_bytes([0x55; 32]));
+        assert_eq!(original_id, compute_semantic_change_id(&original).unwrap());
     }
 
     #[test]
     fn content_identity_empty_deltas_is_deterministic() {
-        let h1 = content_identity_from_deltas(&[], &[], &[]);
-        let h2 = content_identity_from_deltas(&[], &[], &[]);
+        let h1 = content_identity_from_deltas(&[], &[], &[]).unwrap();
+        let h2 = content_identity_from_deltas(&[], &[], &[]).unwrap();
         assert_eq!(h1, h2);
+    }
+
+    #[test]
+    fn content_identity_binds_complete_artifact_delta_and_ignores_slice_order() {
+        let regular = ArtifactDelta {
+            file_id: FilePathId::new("bin/kin"),
+            kind: ArtifactDeltaKind::ModifiedRegularFile,
+            old_hash: Some(Hash256::from_bytes([1; 32])),
+            new_hash: Some(Hash256::from_bytes([2; 32])),
+        };
+        let executable = ArtifactDelta {
+            kind: ArtifactDeltaKind::ModifiedExecutableFile,
+            ..regular.clone()
+        };
+        let different_old = ArtifactDelta {
+            old_hash: Some(Hash256::from_bytes([3; 32])),
+            ..regular.clone()
+        };
+
+        let regular_id =
+            content_identity_from_deltas(&[], &[], std::slice::from_ref(&regular)).unwrap();
+        let executable_id =
+            content_identity_from_deltas(&[], &[], std::slice::from_ref(&executable)).unwrap();
+        let different_old_id =
+            content_identity_from_deltas(&[], &[], std::slice::from_ref(&different_old)).unwrap();
+        assert_ne!(regular_id, executable_id);
+        assert_ne!(regular_id, different_old_id);
+
+        let ordered_executable = ArtifactDelta {
+            file_id: FilePathId::new("bin/kin-exec"),
+            ..executable
+        };
+        let ordered_different_old = ArtifactDelta {
+            file_id: FilePathId::new("bin/kin-old"),
+            ..different_old
+        };
+        let first = content_identity_from_deltas(
+            &[],
+            &[],
+            &[
+                regular.clone(),
+                ordered_executable.clone(),
+                ordered_different_old.clone(),
+            ],
+        )
+        .unwrap();
+        let reordered = content_identity_from_deltas(
+            &[],
+            &[],
+            &[ordered_different_old, regular, ordered_executable],
+        )
+        .unwrap();
+        assert_eq!(first, reordered);
+    }
+
+    #[test]
+    fn content_identity_binds_order_for_duplicate_artifact_targets() {
+        let first = ArtifactDelta {
+            file_id: FilePathId::new("src/lib.rs"),
+            kind: ArtifactDeltaKind::ModifiedRegularFile,
+            old_hash: Some(Hash256::from_bytes([1; 32])),
+            new_hash: Some(Hash256::from_bytes([2; 32])),
+        };
+        let second = ArtifactDelta {
+            new_hash: Some(Hash256::from_bytes([3; 32])),
+            ..first.clone()
+        };
+
+        let forward =
+            content_identity_from_deltas(&[], &[], &[first.clone(), second.clone()]).unwrap();
+        let reversed = content_identity_from_deltas(&[], &[], &[second, first]).unwrap();
+        assert_ne!(forward, reversed);
+    }
+
+    #[test]
+    fn content_identity_binds_order_for_cross_linked_entity_modifications() {
+        let a = test_entity(EntityId::new(), "a");
+        let b = test_entity(EntityId::new(), "b");
+        let c = test_entity(EntityId::new(), "c");
+        let a_to_b = EntityDelta::Modified {
+            old: a,
+            new: b.clone(),
+        };
+        let b_to_c = EntityDelta::Modified { old: b, new: c };
+
+        let forward =
+            content_identity_from_deltas(&[a_to_b.clone(), b_to_c.clone()], &[], &[]).unwrap();
+        let reversed = content_identity_from_deltas(&[b_to_c, a_to_b], &[], &[]).unwrap();
+        assert_ne!(forward, reversed);
+    }
+
+    #[test]
+    fn content_identity_rejects_non_finite_semantic_scores() {
+        let relation = Relation {
+            id: RelationId::new(),
+            kind: RelationKind::Calls,
+            src: GraphNodeId::Entity(EntityId::new()),
+            dst: GraphNodeId::Entity(EntityId::new()),
+            confidence: f32::NAN,
+            origin: RelationOrigin::Parsed,
+            created_in: None,
+            import_source: None,
+            evidence: vec![],
+        };
+        let error =
+            content_identity_from_deltas(&[], &[RelationDelta::Added(relation)], &[]).unwrap_err();
+        assert!(error.to_string().contains("non-finite confidence"));
     }
 
     #[test]

--- a/crates/kin-core/src/layout.rs
+++ b/crates/kin-core/src/layout.rs
@@ -315,6 +315,20 @@ impl KinLayout {
         self.root.join("merge_state.json")
     }
 
+    /// `.kin/pending-release.json` — exact serialized daemon release request
+    /// retained until the daemon reports durable success or definitive
+    /// rejection. This lets a later CLI process resume an uncertain timeout or
+    /// transport failure without constructing a second release marker.
+    pub fn pending_release_path(&self) -> PathBuf {
+        self.root.join("pending-release.json")
+    }
+
+    /// `.kin/pending-release.lock` — cross-process serialization for release
+    /// recovery, policy preflight, and marker construction.
+    pub fn pending_release_lock_path(&self) -> PathBuf {
+        self.root.join("pending-release.lock")
+    }
+
     /// All directories that must exist inside `.kin/`.
     ///
     pub fn all_dirs(&self) -> Vec<PathBuf> {

--- a/crates/kin-core/src/lib.rs
+++ b/crates/kin-core/src/lib.rs
@@ -45,9 +45,14 @@ pub use layout::KinLayout;
 pub use manifest::KinManifest;
 pub use resolver::{ImportResolver, PythonResolver, SymbolTable, TypeScriptResolver};
 pub use sync_state::SyncStateStore;
-pub use tree::{build_file_tree, checkout_branch};
+pub use tree::{
+    build_file_tree, checkout_branch, materialize_source_entry, materialize_source_tree,
+    prepare_source_tree, reconcile_source_tree, replace_source_tree, should_preserve_checkout_path,
+    validate_portable_source_paths, validate_portable_source_symlink, validate_source_entry,
+    validate_source_paths, validate_source_tree,
+};
 
-pub use diff::{compute_change_id, content_identity_from_deltas, whoami};
+pub use diff::{compute_semantic_change_id, content_identity_from_deltas, whoami};
 pub use disambiguation::{fallback_leaf_trace_matches, query_trace_matches};
 pub use ranking::{
     normalize_symbol_hint, normalize_trace_name, qualifier_hint_from_query, select_best_match,
@@ -87,12 +92,114 @@ pub fn read_current_branch(layout: &KinLayout) -> Result<BranchName> {
 
 /// Write the current branch name to `.kin/HEAD`.
 pub fn write_current_branch(layout: &KinLayout, name: &BranchName) -> Result<()> {
-    std::fs::write(layout.head_path(), name.to_string())
-        .map_err(|e| KinError::io(layout.head_path(), e))
+    use std::io::Write;
+
+    let temporary = layout
+        .root()
+        .join(format!(".HEAD-{}.tmp", uuid::Uuid::new_v4()));
+    let mut options = std::fs::OpenOptions::new();
+    options.write(true).create_new(true);
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::OpenOptionsExt;
+        options
+            .mode(0o600)
+            .custom_flags(libc::O_NOFOLLOW | libc::O_CLOEXEC);
+    }
+    let mut file = options
+        .open(&temporary)
+        .map_err(|error| KinError::io(&temporary, error))?;
+    let write_result = file
+        .write_all(name.to_string().as_bytes())
+        .and_then(|()| file.sync_all())
+        .map_err(|error| KinError::io(&temporary, error));
+    if let Err(error) = write_result {
+        drop(file);
+        let _ = std::fs::remove_file(&temporary);
+        return Err(error);
+    }
+    #[cfg(windows)]
+    let replace_result = replace_current_branch_windows(&temporary, &layout.head_path());
+    #[cfg(not(windows))]
+    let replace_result = std::fs::rename(&temporary, layout.head_path());
+    if let Err(error) = replace_result {
+        drop(file);
+        let _ = std::fs::remove_file(&temporary);
+        return Err(KinError::io(layout.head_path(), error));
+    }
+    file.sync_all()
+        .map_err(|error| KinError::io(layout.head_path(), error))?;
+    drop(file);
+    #[cfg(unix)]
+    {
+        let directory = std::fs::File::open(layout.root())
+            .map_err(|error| KinError::io(layout.root(), error))?;
+        directory
+            .sync_all()
+            .map_err(|error| KinError::io(layout.root(), error))?;
+    }
+    Ok(())
+}
+
+/// Replace `.kin/HEAD` atomically on Windows even when the destination exists.
+/// `std::fs::rename` maps to a non-replacing move there, so every checkout after
+/// the first otherwise fails with `AlreadyExists`. `MoveFileExW` preserves the
+/// same-volume atomic name switch and asks the OS to flush the rename metadata.
+#[cfg(windows)]
+fn replace_current_branch_windows(
+    source: &std::path::Path,
+    target: &std::path::Path,
+) -> std::io::Result<()> {
+    use std::os::windows::ffi::OsStrExt;
+    use windows_sys::Win32::Storage::FileSystem::{
+        MoveFileExW, MOVEFILE_REPLACE_EXISTING, MOVEFILE_WRITE_THROUGH,
+    };
+
+    let mut source_wide = source.as_os_str().encode_wide().collect::<Vec<_>>();
+    source_wide.push(0);
+    let mut target_wide = target.as_os_str().encode_wide().collect::<Vec<_>>();
+    target_wide.push(0);
+    if unsafe {
+        MoveFileExW(
+            source_wide.as_ptr(),
+            target_wide.as_ptr(),
+            MOVEFILE_REPLACE_EXISTING | MOVEFILE_WRITE_THROUGH,
+        )
+    } == 0
+    {
+        return Err(std::io::Error::last_os_error());
+    }
+    Ok(())
 }
 
 /// Read the raw bytes of a blob from the layout's objects directory by its hash.
 pub fn read_blob_from_layout(layout: &KinLayout, hash: &kin_model::Hash256) -> Option<Vec<u8>> {
     let store = kin_blobs::BlobStore::new(layout.objects_dir()).ok()?;
     store.read(hash).ok()
+}
+
+#[cfg(test)]
+mod current_branch_tests {
+    use super::*;
+
+    #[test]
+    fn current_branch_write_replaces_existing_head() {
+        let root = tempfile::tempdir().unwrap();
+        let layout = KinLayout::new(root.path().join(".kin"));
+        std::fs::create_dir_all(layout.root()).unwrap();
+        std::fs::write(layout.head_path(), b"main").unwrap();
+
+        write_current_branch(&layout, &BranchName::new("feature")).unwrap();
+        write_current_branch(&layout, &BranchName::new("release")).unwrap();
+
+        assert_eq!(read_current_branch(&layout).unwrap().to_string(), "release");
+        assert_eq!(
+            std::fs::read_dir(layout.root())
+                .unwrap()
+                .filter_map(std::result::Result::ok)
+                .filter(|entry| entry.file_name().to_string_lossy().starts_with(".HEAD-"))
+                .count(),
+            0
+        );
+    }
 }

--- a/crates/kin-core/src/tree.rs
+++ b/crates/kin-core/src/tree.rs
@@ -2,10 +2,43 @@
 // Copyright 2026 Firelock, LLC
 
 use std::collections::HashMap;
+#[cfg(any(unix, windows))]
+use std::collections::HashSet;
+#[cfg(any(unix, windows))]
+use std::ffi::OsString;
+#[cfg(any(unix, windows))]
+use std::io::{Read, Write};
+use std::path::Path;
+#[cfg(any(unix, windows))]
+use std::path::PathBuf;
 
-use kin_model::{ArtifactDeltaKind, FilePathId, GraphStore, Hash256, SemanticChangeId};
+use kin_model::{
+    FilePathId, GraphStore, Hash256, SemanticChangeId, SourceEntryKind, SourceTreeResolution,
+};
 
 use crate::{KinError, KinLayout, Result};
+
+#[cfg(any(unix, windows))]
+use fs2::FileExt as _;
+
+#[cfg(any(unix, windows))]
+const RECONCILIATION_CONTROL_DIRECTORY: &str = "reconciliation";
+#[cfg(any(unix, windows))]
+const RECONCILIATION_AUTHORITY_FILE: &str = "authority.key";
+#[cfg(any(unix, windows))]
+const RECONCILIATION_MANIFEST_FILE: &str = "manifest.json";
+#[cfg(any(unix, windows))]
+const RECONCILIATION_PROJECTION_LOCK_FILE: &str = "projection.lock";
+#[cfg(any(unix, windows))]
+const RECONCILIATION_MANIFEST_SCHEMA: u32 = 2;
+#[cfg(any(unix, windows))]
+const RECONCILIATION_ACTION_FILE_PREFIX: &str = "action-";
+#[cfg(any(unix, windows))]
+const MAX_RECONCILIATION_ACTIONS: usize = 100_000;
+#[cfg(any(unix, windows))]
+const MAX_RECONCILIATION_ACTION_RECORD_BYTES: u64 = 256 * 1024;
+#[cfg(any(unix, windows))]
+const MAX_RECONCILIATION_ACTION_LOG_BYTES: u64 = 64 * 1024 * 1024;
 
 /// Walk the SemanticChange DAG from genesis to branch_head and build
 /// the current file tree: Map<FilePathId, Hash256>.
@@ -17,19 +50,13 @@ pub fn build_file_tree<G: GraphStore>(
     let changes = graph
         .get_changes_since(genesis_id, branch_head)
         .map_err(|e| KinError::Graph(format!("{}", e)))?;
-
-    let mut tree: HashMap<FilePathId, Hash256> = HashMap::new();
+    let mut tree = HashMap::new();
     for change in &changes {
         for delta in &change.artifact_deltas {
-            match delta.kind {
-                ArtifactDeltaKind::Added | ArtifactDeltaKind::Modified => {
-                    if let Some(hash) = delta.new_hash {
-                        tree.insert(delta.file_id.clone(), hash);
-                    }
-                }
-                ArtifactDeltaKind::Removed => {
-                    tree.remove(&delta.file_id);
-                }
+            if delta.kind.is_removed() {
+                tree.remove(&delta.file_id);
+            } else if let Some(hash) = delta.new_hash {
+                tree.insert(delta.file_id.clone(), hash);
             }
         }
     }
@@ -43,34 +70,7390 @@ pub fn checkout_branch<G: GraphStore>(
     graph: &G,
     blob_store: &kin_blobs::BlobStore,
     layout: &KinLayout,
-    genesis_id: &SemanticChangeId,
+    _genesis_id: &SemanticChangeId,
     branch_head: &SemanticChangeId,
+) -> Result<usize> {
+    checkout_branch_with_pre_mutation_hook(
+        graph,
+        blob_store,
+        layout,
+        _genesis_id,
+        branch_head,
+        || {},
+    )
+}
+
+/// Test seam for deterministically exercising a working-copy edit that lands
+/// after reconciliation's first read-only preflight but before mutation.
+/// Production callers use [`checkout_branch`], which supplies a no-op hook.
+#[doc(hidden)]
+pub fn checkout_branch_with_pre_mutation_hook<G: GraphStore>(
+    graph: &G,
+    blob_store: &kin_blobs::BlobStore,
+    layout: &KinLayout,
+    _genesis_id: &SemanticChangeId,
+    branch_head: &SemanticChangeId,
+    after_read_only_preflight: impl FnOnce(),
 ) -> Result<usize> {
     // VFS projects files from the graph — no physical checkout needed.
     // Kept for backward compatibility with repos that don't have VFS yet.
     // Once VFS is universal, this entire function can be removed.
 
-    let tree = build_file_tree(graph, genesis_id, branch_head)?;
-    let work_dir = layout.working_dir();
-    let mut count = 0;
+    let current_branch_name = crate::read_current_branch(layout)?;
+    let current_branch = graph
+        .get_branch(&current_branch_name)
+        .map_err(|error| KinError::Graph(error.to_string()))?
+        .ok_or_else(|| {
+            KinError::Graph(format!(
+                "current branch {current_branch_name:?} is absent from graph authority"
+            ))
+        })?;
+    checkout_branch_between_heads_with_pre_mutation_hook(
+        graph,
+        blob_store,
+        layout,
+        &current_branch.head,
+        branch_head,
+        after_read_only_preflight,
+    )
+}
 
-    for (file_id, hash) in &tree {
-        // Convert kin_model::Hash256 to kin_blobs::Hash256
-        let blob_hash = kin_blobs::Hash256(*hash.as_bytes());
-        match blob_store.read(&blob_hash) {
-            Ok(content) => {
-                let path = work_dir.join(&file_id.0);
-                if let Some(parent) = path.parent() {
-                    std::fs::create_dir_all(parent).map_err(|e| KinError::io(parent, e))?;
+/// Reconcile the projection between two explicit, exact graph heads.
+///
+/// Branch switching uses this to compensate a successfully published target
+/// tree when a later branch-head recheck or HEAD update fails. The current
+/// branch marker cannot supply the `previous_head` in that path because it
+/// intentionally still names the old branch.
+#[doc(hidden)]
+pub fn checkout_branch_between_heads<G: GraphStore>(
+    graph: &G,
+    blob_store: &kin_blobs::BlobStore,
+    layout: &KinLayout,
+    previous_head: &SemanticChangeId,
+    branch_head: &SemanticChangeId,
+) -> Result<usize> {
+    checkout_branch_between_heads_with_pre_mutation_hook(
+        graph,
+        blob_store,
+        layout,
+        previous_head,
+        branch_head,
+        || {},
+    )
+}
+
+fn checkout_branch_between_heads_with_pre_mutation_hook<G: GraphStore>(
+    graph: &G,
+    blob_store: &kin_blobs::BlobStore,
+    layout: &KinLayout,
+    previous_head: &SemanticChangeId,
+    branch_head: &SemanticChangeId,
+    after_read_only_preflight: impl FnOnce(),
+) -> Result<usize> {
+    let previous_tree = resolve_exact_source_tree(graph, previous_head)?;
+    let tree = resolve_exact_source_tree(graph, branch_head)?;
+    let work_dir = layout.working_dir();
+    let previous_prepared = load_source_tree_blobs(blob_store, previous_tree)?;
+    let prepared = load_source_tree_blobs(blob_store, tree)?;
+
+    // A checkout may require destructive file/directory transitions. Resolve
+    // and verify every content object and every path/link shape before any of
+    // those transitions begin, so a late corrupt or missing blob cannot leave
+    // a partially projected working tree.
+    reconcile_source_tree_with_pre_mutation_hook(
+        work_dir,
+        previous_prepared
+            .iter()
+            .map(|(file_id, kind, content)| (file_id, *kind, content.as_slice())),
+        prepared
+            .iter()
+            .map(|(file_id, kind, content)| (file_id, *kind, content.as_slice())),
+        should_preserve_checkout_path,
+        after_read_only_preflight,
+    )?;
+
+    Ok(prepared.len())
+}
+
+/// Publish a branch projection and its `.kin/HEAD` transition as one
+/// crash-recoverable transaction. `before_head_commit` runs after all target
+/// bytes are durable while the repository projection lock and rollback journal
+/// are still retained. It must recheck graph authority; the transaction then
+/// writes the target HEAD through its retained `.kin` capability.
+#[doc(hidden)]
+#[allow(clippy::too_many_arguments)]
+pub fn checkout_branch_between_heads_transactional_with_hooks<G: GraphStore>(
+    graph: &G,
+    blob_store: &kin_blobs::BlobStore,
+    layout: &KinLayout,
+    previous_branch: &str,
+    previous_head: &SemanticChangeId,
+    target_branch: &str,
+    target_head: &SemanticChangeId,
+    after_read_only_preflight: impl FnOnce(),
+    before_head_commit: impl FnOnce() -> Result<()>,
+) -> Result<usize> {
+    let previous_tree = resolve_exact_source_tree(graph, previous_head)?;
+    let target_tree = resolve_exact_source_tree(graph, target_head)?;
+    let previous_prepared = load_source_tree_blobs(blob_store, previous_tree)?;
+    let prepared = load_source_tree_blobs(blob_store, target_tree)?;
+    let previous_entries = validated_source_entries(
+        previous_prepared
+            .iter()
+            .map(|(file_id, kind, content)| (file_id, *kind, content.as_slice())),
+    )?;
+    let entries = validated_source_entries(
+        prepared
+            .iter()
+            .map(|(file_id, kind, content)| (file_id, *kind, content.as_slice())),
+    )?;
+    let transition = BranchProjectionTransition {
+        previous_branch: previous_branch.to_string(),
+        previous_head: *previous_head,
+        target_branch: target_branch.to_string(),
+        target_head: *target_head,
+    };
+    project_reconciled_source_tree(
+        layout.working_dir(),
+        &previous_entries,
+        &entries,
+        &should_preserve_checkout_path,
+        after_read_only_preflight,
+        || {},
+        Some(transition),
+        before_head_commit,
+    )?;
+    Ok(prepared.len())
+}
+
+fn load_source_tree_blobs(
+    blob_store: &kin_blobs::BlobStore,
+    tree: HashMap<FilePathId, kin_model::ResolvedSourceEntry>,
+) -> Result<Vec<(FilePathId, SourceEntryKind, Vec<u8>)>> {
+    let mut entries: Vec<_> = tree.into_iter().collect();
+    entries.sort_by(|left, right| left.0 .0.cmp(&right.0 .0));
+    entries
+        .into_iter()
+        .map(|(file_id, source)| {
+            // Convert kin_model::Hash256 to kin_blobs::Hash256.
+            let blob_hash = kin_blobs::Hash256(*source.hash.as_bytes());
+            let content = blob_store.read(&blob_hash)?;
+            Ok((file_id, source.kind, content))
+        })
+        .collect()
+}
+
+fn resolve_exact_source_tree<G: GraphStore>(
+    graph: &G,
+    head: &SemanticChangeId,
+) -> Result<HashMap<FilePathId, kin_model::ResolvedSourceEntry>> {
+    match graph
+        .resolve_source_tree_at(head)
+        .map_err(|error| KinError::Graph(error.to_string()))?
+    {
+        SourceTreeResolution::Exact { entries } => Ok(entries),
+        SourceTreeResolution::Incomplete { gaps } => {
+            let gaps = gaps
+                .iter()
+                .map(|gap| format!("{}@{}:{:?}", gap.file_id, gap.change_id, gap.reason))
+                .collect::<Vec<_>>()
+                .join(", ");
+            Err(KinError::Graph(format!(
+                "checkout requires exact source history at {head}, but found unresolved gaps: {gaps}"
+            )))
+        }
+    }
+}
+
+/// Preserve control-plane and generated dependency/build directories during
+/// exact tree cleanup. This policy is shared by full checkout and branch
+/// switching so neither path treats generated state as graph-owned source.
+pub fn should_preserve_checkout_path(relative: &Path) -> bool {
+    const PRESERVED_COMPONENTS: &[&str] = &[
+        ".kin",
+        ".kin-session",
+        ".git",
+        "node_modules",
+        "target",
+        "__pycache__",
+        ".next",
+        "dist",
+        "build",
+        "vendor",
+    ];
+
+    relative.components().any(|component| {
+        if let std::path::Component::Normal(name) = component {
+            name.to_str().is_some_and(|name| {
+                PRESERVED_COMPONENTS
+                    .iter()
+                    .any(|preserved| name.eq_ignore_ascii_case(preserved))
+            })
+        } else {
+            false
+        }
+    })
+}
+
+/// Materialize one graph-owned exact source entry beneath `root`.
+///
+/// Paths and link targets are validated before mutation. Supported-platform
+/// writes are anchored to directory capabilities and use no-follow traversal
+/// plus atomic replacement, so neither a pre-existing link nor a concurrent
+/// rename can redirect bytes outside the projection root.
+pub fn materialize_source_entry(
+    root: &Path,
+    file_id: &FilePathId,
+    kind: SourceEntryKind,
+    content: &[u8],
+) -> Result<()> {
+    materialize_source_tree(root, [(file_id, kind, content)]).map(|_| ())
+}
+
+/// Materialize a complete graph-owned source tree under one retained root
+/// capability.
+///
+/// Validation finishes before the root is opened, and every preparation and
+/// replacement operation after that is relative to the same directory handle.
+/// A concurrent rename or symlink swap therefore cannot redirect a later
+/// entry to a different ambient path.
+pub fn materialize_source_tree<'a>(
+    root: &Path,
+    entries: impl IntoIterator<Item = (&'a FilePathId, SourceEntryKind, &'a [u8])>,
+) -> Result<usize> {
+    let entries = validated_source_entries(entries)?;
+    project_validated_source_tree(root, &entries, None, || {})
+}
+
+/// Replace a working tree from exact graph-owned source under one retained
+/// root capability, removing non-tree files except paths selected by
+/// `should_preserve`.
+///
+/// Cleanup discovery is part of the read-only preflight. Cleanup, transition
+/// preparation, materialization, and empty-directory removal then all use the
+/// same retained capability rather than ambient pathnames.
+pub fn replace_source_tree<'a>(
+    root: &Path,
+    entries: impl IntoIterator<Item = (&'a FilePathId, SourceEntryKind, &'a [u8])>,
+    should_preserve: impl Fn(&Path) -> bool,
+) -> Result<usize> {
+    let entries = validated_source_entries(entries)?;
+    project_validated_source_tree(root, &entries, Some(&should_preserve), || {})
+}
+
+/// Reconcile one exact graph-owned tree to another without deleting unrelated
+/// working-copy files.
+///
+/// Only paths tracked by `previous_entries` and absent from `entries` are
+/// eligible for deletion. A prior tracked path that would be replaced or
+/// removed must still match its exact current-branch kind and content; local
+/// edits fail the whole read-only preflight. New target paths fail closed when
+/// an unrelated working-copy object occupies the destination or blocks an
+/// ancestor.
+pub fn reconcile_source_tree<'a, 'b>(
+    root: &Path,
+    previous_entries: impl IntoIterator<Item = (&'b FilePathId, SourceEntryKind, &'b [u8])>,
+    entries: impl IntoIterator<Item = (&'a FilePathId, SourceEntryKind, &'a [u8])>,
+    should_preserve: impl Fn(&Path) -> bool,
+) -> Result<usize> {
+    reconcile_source_tree_with_pre_mutation_hook(
+        root,
+        previous_entries,
+        entries,
+        should_preserve,
+        || {},
+    )
+}
+
+#[doc(hidden)]
+pub fn reconcile_source_tree_with_pre_mutation_hook<'a, 'b>(
+    root: &Path,
+    previous_entries: impl IntoIterator<Item = (&'b FilePathId, SourceEntryKind, &'b [u8])>,
+    entries: impl IntoIterator<Item = (&'a FilePathId, SourceEntryKind, &'a [u8])>,
+    should_preserve: impl Fn(&Path) -> bool,
+    after_read_only_preflight: impl FnOnce(),
+) -> Result<usize> {
+    reconcile_source_tree_with_mutation_hooks(
+        root,
+        previous_entries,
+        entries,
+        should_preserve,
+        after_read_only_preflight,
+        || {},
+    )
+}
+
+/// Test seam for a namespace replacement that lands after the second
+/// byte/kind/identity validation but before any tracked object is displaced.
+#[doc(hidden)]
+pub fn reconcile_source_tree_with_mutation_hooks<'a, 'b>(
+    root: &Path,
+    previous_entries: impl IntoIterator<Item = (&'b FilePathId, SourceEntryKind, &'b [u8])>,
+    entries: impl IntoIterator<Item = (&'a FilePathId, SourceEntryKind, &'a [u8])>,
+    should_preserve: impl Fn(&Path) -> bool,
+    after_read_only_preflight: impl FnOnce(),
+    after_identity_revalidation: impl FnOnce(),
+) -> Result<usize> {
+    let entries = validated_source_entries(entries)?;
+    let previous_entries = validated_source_entries(previous_entries)?;
+    project_reconciled_source_tree(
+        root,
+        &previous_entries,
+        &entries,
+        &should_preserve,
+        after_read_only_preflight,
+        after_identity_revalidation,
+        None,
+        || Ok(()),
+    )
+}
+
+#[derive(Clone, Copy)]
+struct ValidatedSourceEntry<'a> {
+    file_id: &'a FilePathId,
+    kind: SourceEntryKind,
+    content: &'a [u8],
+}
+
+#[cfg(test)]
+std::thread_local! {
+    static INJECT_PUBLICATION_FAILURE_AFTER: std::cell::Cell<Option<usize>> = const { std::cell::Cell::new(None) };
+}
+
+#[cfg(test)]
+fn inject_next_publication_failure() {
+    inject_publication_failure_after(0);
+}
+
+#[cfg(test)]
+fn inject_publication_failure_after(successful_publications: usize) {
+    INJECT_PUBLICATION_FAILURE_AFTER.set(Some(successful_publications));
+}
+
+#[cfg(test)]
+fn fail_publication_if_injected() -> Result<()> {
+    INJECT_PUBLICATION_FAILURE_AFTER.with(|remaining| match remaining.get() {
+        None => Ok(()),
+        Some(0) => {
+            remaining.set(None);
+            Err(KinError::Other(
+                "injected exact-source publication failure".to_string(),
+            ))
+        }
+        Some(count) => {
+            remaining.set(Some(count - 1));
+            Ok(())
+        }
+    })
+}
+
+#[cfg(not(test))]
+fn fail_publication_if_injected() -> Result<()> {
+    Ok(())
+}
+
+fn validated_source_entries<'a>(
+    entries: impl IntoIterator<Item = (&'a FilePathId, SourceEntryKind, &'a [u8])>,
+) -> Result<Vec<ValidatedSourceEntry<'a>>> {
+    let mut entries: Vec<_> = entries
+        .into_iter()
+        .map(|(file_id, kind, content)| ValidatedSourceEntry {
+            file_id,
+            kind,
+            content,
+        })
+        .collect();
+    entries.sort_by(|left, right| left.file_id.0.cmp(&right.file_id.0));
+    validate_source_tree(
+        entries
+            .iter()
+            .map(|entry| (entry.file_id, entry.kind, entry.content)),
+    )?;
+    Ok(entries)
+}
+
+/// Validate an exact-source entry without touching the projection root.
+///
+/// Checkout callers use this during their global preflight so unsafe paths,
+/// unsupported entry encodings, and escaping symbolic-link targets all fail
+/// before any file/directory transition is applied.
+pub fn validate_source_entry(
+    file_id: &FilePathId,
+    kind: SourceEntryKind,
+    content: &[u8],
+) -> Result<()> {
+    validate_source_entry_components(file_id, kind, content).map(|_| ())
+}
+
+fn validate_source_entry_components<'a>(
+    file_id: &'a FilePathId,
+    kind: SourceEntryKind,
+    content: &[u8],
+) -> Result<Vec<&'a str>> {
+    let components = validate_source_path(&file_id.0)?;
+
+    if kind == SourceEntryKind::Symlink {
+        let target = std::str::from_utf8(content).map_err(|_| {
+            KinError::Other(format!(
+                "symbolic link target is not valid UTF-8 for {}",
+                file_id.0
+            ))
+        })?;
+        validate_source_symlink_target(&components, target)?;
+
+        #[cfg(not(unix))]
+        return Err(KinError::Other(
+            "safe exact symbolic-link checkout is unsupported on this platform".to_string(),
+        ));
+    }
+    Ok(components)
+}
+
+/// Validate a complete exact-source tree without mutating the filesystem.
+///
+/// In addition to validating every entry kind and symbolic-link target, this
+/// rejects path-prefix conflicts such as `a` and `a/b` before callers remove a
+/// blocking file or directory.
+pub fn validate_source_tree<'a>(
+    entries: impl IntoIterator<Item = (&'a FilePathId, SourceEntryKind, &'a [u8])>,
+) -> Result<()> {
+    let entries: Vec<_> = entries.into_iter().collect();
+    validate_source_paths(entries.iter().map(|(file_id, _, _)| *file_id))?;
+    for (file_id, kind, content) in entries {
+        validate_source_entry(file_id, kind, content)?;
+    }
+    Ok(())
+}
+
+/// Validate a complete exact-source path set without retaining source bytes.
+///
+/// Authority preflights that read blobs from a remote store use this before
+/// validating each entry one at a time. Keeping path-shape validation separate
+/// from byte validation prevents a repository-sized second copy of the source
+/// tree from accumulating in memory merely to detect path-prefix conflicts.
+pub fn validate_source_paths<'a>(file_ids: impl IntoIterator<Item = &'a FilePathId>) -> Result<()> {
+    validate_source_path_set(file_ids)
+}
+
+/// Validate paths for a portable exact-source artifact regardless of the host
+/// running the validator. This applies the conservative Windows component
+/// rules plus Unicode normalization/case alias detection used by default
+/// Windows and macOS filesystems, so an archive accepted on Linux cannot
+/// collapse or overwrite entries when extracted elsewhere.
+pub fn validate_portable_source_paths<'a>(paths: impl IntoIterator<Item = &'a str>) -> Result<()> {
+    let mut paths: Vec<_> = paths
+        .into_iter()
+        .map(|path| (portable_source_path_comparison_key(path), path))
+        .collect();
+    paths.sort_unstable_by(|left, right| left.0.cmp(&right.0));
+    for (_, path) in &paths {
+        validate_portable_source_path(path)?;
+    }
+    for pair in paths.windows(2) {
+        if pair[1].0 == pair[0].0
+            || pair[1]
+                .0
+                .strip_prefix(&pair[0].0)
+                .is_some_and(|suffix| suffix.starts_with('/'))
+        {
+            return Err(KinError::Other(format!(
+                "conflicting graph-owned source paths {:?} and {:?}",
+                pair[0].1, pair[1].1
+            )));
+        }
+    }
+    Ok(())
+}
+
+/// Validate one portable relative symlink using the same cross-platform path
+/// rules as [`validate_portable_source_paths`].
+pub fn validate_portable_source_symlink(path: &str, target: &str) -> Result<()> {
+    let components = validate_portable_source_path(path)?;
+    validate_source_symlink_target_with_windows_rules(&components, target, true)
+}
+
+/// Validate a complete exact-source path set and remove only filesystem
+/// objects whose shape blocks materialization (file-as-parent or
+/// directory-as-file).
+pub fn prepare_source_tree<'a>(
+    root: &Path,
+    file_ids: impl IntoIterator<Item = &'a FilePathId>,
+) -> Result<()> {
+    let file_ids: Vec<_> = file_ids.into_iter().collect();
+    validate_source_paths(file_ids.iter().copied())?;
+
+    #[cfg(any(unix, windows))]
+    {
+        let projection = ProjectionRoot::open(root)?;
+        return projection.prepare(&file_ids);
+    }
+
+    #[cfg(not(any(unix, windows)))]
+    {
+        let _ = root;
+        Err(unsupported_safe_projection_error())
+    }
+}
+
+fn validate_source_path_set<'a>(file_ids: impl IntoIterator<Item = &'a FilePathId>) -> Result<()> {
+    let mut paths: Vec<_> = file_ids
+        .into_iter()
+        .map(|file_id| {
+            let path = file_id.0.as_str();
+            (projection_path_comparison_key(path), path)
+        })
+        .collect();
+    paths.sort_unstable_by(|left, right| left.0.cmp(&right.0));
+    for (_, path) in &paths {
+        validate_source_path(path)?;
+    }
+    for pair in paths.windows(2) {
+        if pair[1].0 == pair[0].0
+            || pair[1]
+                .0
+                .strip_prefix(&pair[0].0)
+                .is_some_and(|suffix| suffix.starts_with('/'))
+        {
+            return Err(KinError::Other(format!(
+                "conflicting graph-owned source paths {:?} and {:?}",
+                pair[0].1, pair[1].1
+            )));
+        }
+    }
+    Ok(())
+}
+
+fn projection_path_comparison_key(path: &str) -> String {
+    #[cfg(any(windows, target_os = "macos"))]
+    {
+        // Windows and the default macOS filesystem are case-insensitive, and
+        // macOS also aliases canonically equivalent Unicode spellings. Build a
+        // conservative per-component key using canonical decomposition and
+        // Unicode case expansion so those trees fail before any transition is
+        // applied. Upper-then-lower also catches folds such as sharp-s and the
+        // Greek final sigma that lowercase alone does not collapse.
+        return path
+            .split('/')
+            .map(projection_component_comparison_key)
+            .collect::<Vec<_>>()
+            .join("/");
+    }
+    #[cfg(not(any(windows, target_os = "macos")))]
+    path.to_string()
+}
+
+fn portable_source_path_comparison_key(path: &str) -> String {
+    path.split('/')
+        .map(projection_component_comparison_key)
+        .collect::<Vec<_>>()
+        .join("/")
+}
+
+fn projection_component_comparison_key(component: &str) -> String {
+    use unicode_normalization::UnicodeNormalization;
+
+    component
+        .nfd()
+        .flat_map(char::to_uppercase)
+        .flat_map(char::to_lowercase)
+        .nfd()
+        .collect()
+}
+
+fn project_validated_source_tree(
+    root: &Path,
+    entries: &[ValidatedSourceEntry<'_>],
+    should_preserve: Option<&dyn Fn(&Path) -> bool>,
+    after_read_only_preflight: impl FnOnce(),
+) -> Result<usize> {
+    #[cfg(any(unix, windows))]
+    {
+        let projection = ProjectionRoot::open(root)?;
+        let tracked = TrackedPathClassifier::new(entries.iter().map(|entry| entry.file_id));
+        let plan = projection.plan_full_replacement(&tracked, should_preserve)?;
+
+        // Tests use this boundary to deterministically swap ambient pathnames
+        // after validation and cleanup discovery. All later work must remain
+        // anchored to `projection.root`.
+        after_read_only_preflight();
+
+        projection.apply_full_replacement(entries, plan)?;
+        return Ok(entries.len());
+    }
+
+    #[cfg(not(any(unix, windows)))]
+    {
+        let _ = (root, entries, should_preserve, after_read_only_preflight);
+        Err(unsupported_safe_projection_error())
+    }
+}
+
+fn project_reconciled_source_tree(
+    root: &Path,
+    previous_entries: &[ValidatedSourceEntry<'_>],
+    entries: &[ValidatedSourceEntry<'_>],
+    should_preserve: &dyn Fn(&Path) -> bool,
+    after_read_only_preflight: impl FnOnce(),
+    after_identity_revalidation: impl FnOnce(),
+    branch_transition: Option<BranchProjectionTransition>,
+    before_head_commit: impl FnOnce() -> Result<()>,
+) -> Result<usize> {
+    #[cfg(any(unix, windows))]
+    {
+        let projection = ProjectionRoot::open(root)?;
+        let previous =
+            TrackedPathClassifier::new(previous_entries.iter().map(|entry| entry.file_id));
+        let target = TrackedPathClassifier::new(entries.iter().map(|entry| entry.file_id));
+        let target_by_path: HashMap<_, _> = entries
+            .iter()
+            .map(|entry| (entry.file_id.0.as_str(), entry))
+            .collect();
+        let previous_by_path: HashMap<_, _> = previous_entries
+            .iter()
+            .map(|entry| (entry.file_id.0.as_str(), entry))
+            .collect();
+        let affected_previous: Vec<_> = previous_entries
+            .iter()
+            .filter(|previous_entry| {
+                target_by_path
+                    .get(previous_entry.file_id.0.as_str())
+                    .is_none_or(|target_entry| !source_entries_match(previous_entry, target_entry))
+            })
+            .collect();
+        let mut removed_file_ids: Vec<_> = previous_entries
+            .iter()
+            .map(|entry| entry.file_id)
+            .filter(|file_id| target.relation(Path::new(&file_id.0)) != TrackedPathRelation::Exact)
+            .collect();
+        removed_file_ids.sort_unstable_by(|left, right| left.0.cmp(&right.0));
+        let removed = TrackedPathClassifier::new(removed_file_ids.iter().copied());
+        let entries_to_materialize: Vec<_> = entries
+            .iter()
+            .copied()
+            .filter(|target_entry| {
+                previous_by_path
+                    .get(target_entry.file_id.0.as_str())
+                    .is_none_or(|previous_entry| {
+                        !source_entries_match(previous_entry, target_entry)
+                    })
+            })
+            .collect();
+
+        // This is one read-only preflight boundary: first prove that every old
+        // path the switch would mutate is still byte/kind-exact, then validate
+        // every target collision. No deletion or replacement occurs until all
+        // local-edit and untracked-path conflicts have been rejected.
+        let previous_identities =
+            projection.validate_tracked_entries_unchanged(&affected_previous)?;
+        projection.validate_reconciliation_targets(&entries_to_materialize, &previous, &removed)?;
+
+        let files_to_delete: Vec<_> = removed_file_ids
+            .iter()
+            .map(|file_id| PathBuf::from(&file_id.0))
+            .collect();
+
+        // A generated-directory name is preservation policy only for
+        // unrelated occupants. When the previous graph owns every leaf under
+        // a directory and the target graph owns the directory path as a file,
+        // remove that now-empty graph-owned directory explicitly so names such
+        // as target/vendor/dist/build/node_modules can transition exactly.
+        let replacement_roots: Vec<_> = entries_to_materialize
+            .iter()
+            .filter_map(|entry| {
+                let relative = Path::new(&entry.file_id.0);
+                (previous.relation(relative) == TrackedPathRelation::Ancestor
+                    && removed.relation(relative) == TrackedPathRelation::Ancestor)
+                    .then(|| relative.to_path_buf())
+            })
+            .collect();
+        let mut directories_to_replace = HashSet::new();
+        for removed_path in &files_to_delete {
+            for replacement_root in &replacement_roots {
+                if !removed_path.starts_with(replacement_root) {
+                    continue;
                 }
-                std::fs::write(&path, &content).map_err(|e| KinError::io(&path, e))?;
-                count += 1;
+                let mut directory = removed_path.parent();
+                while let Some(relative) = directory {
+                    if !relative.starts_with(replacement_root) {
+                        break;
+                    }
+                    directories_to_replace.insert(relative.to_path_buf());
+                    if relative == replacement_root {
+                        break;
+                    }
+                    directory = relative.parent();
+                }
             }
-            Err(_) => {
-                tracing::warn!(file = %file_id, "blob not found in store, skipping");
+        }
+        let mut directories_to_replace: Vec<_> = directories_to_replace.into_iter().collect();
+        directories_to_replace.sort_by(|left, right| {
+            right
+                .components()
+                .count()
+                .cmp(&left.components().count())
+                .then_with(|| left.cmp(right))
+        });
+
+        let replacement_directory_set: HashSet<_> =
+            directories_to_replace.iter().cloned().collect();
+        let mut cleanup_directories = HashSet::new();
+        for removed_path in &files_to_delete {
+            let mut directory = removed_path.parent();
+            while let Some(relative) = directory {
+                if relative.as_os_str().is_empty() {
+                    break;
+                }
+                if !should_preserve(relative)
+                    && removed.relation(relative) == TrackedPathRelation::Ancestor
+                    && !replacement_directory_set.contains(relative)
+                {
+                    cleanup_directories.insert(relative.to_path_buf());
+                }
+                directory = relative.parent();
+            }
+        }
+        let mut cleanup_directories: Vec<_> = cleanup_directories.into_iter().collect();
+        cleanup_directories.sort_by(|left, right| {
+            right
+                .components()
+                .count()
+                .cmp(&left.components().count())
+                .then_with(|| left.cmp(right))
+        });
+
+        let mut directory_identities = HashMap::new();
+        for relative in directories_to_replace.iter().chain(&cleanup_directories) {
+            let identity = projection
+                .relative_directory_identity(relative)?
+                .ok_or_else(|| {
+                    KinError::Other(format!(
+                        "graph-owned directory {} disappeared during exact-source preflight",
+                        projection.display_root.join(relative).display()
+                    ))
+                })?;
+            directory_identities.insert(relative.clone(), identity);
+        }
+
+        after_read_only_preflight();
+        projection
+            .revalidate_tracked_entries_unchanged(&affected_previous, &previous_identities)?;
+        for (relative, expected_identity) in &directory_identities {
+            let actual = projection.relative_directory_identity(relative)?;
+            if actual != Some(*expected_identity) {
+                return Err(KinError::Other(format!(
+                    "graph-owned directory {} changed identity after exact-source preflight",
+                    projection.display_root.join(relative).display()
+                )));
+            }
+        }
+
+        let file_ids: Vec<_> = entries_to_materialize
+            .iter()
+            .map(|entry| entry.file_id)
+            .collect();
+
+        // Stage every target object before the first destructive namespace
+        // operation. The transaction directory is retained until either all
+        // publications succeed or every displaced old object is restored.
+        let mut transaction =
+            projection.create_reconciliation_transaction_with_transition(branch_transition)?;
+        let staged = match projection
+            .stage_reconciliation_entries(&transaction.directory, &entries_to_materialize)
+        {
+            Ok(staged) => staged,
+            Err(error) => {
+                return match projection.cleanup_reconciliation_transaction(transaction) {
+                    Ok(()) => Err(error),
+                    Err(cleanup_error) => Err(KinError::Other(format!(
+                        "{error}; staged exact-source cleanup also failed: {cleanup_error}"
+                    ))),
+                };
+            }
+        };
+
+        // Tests exercise the final namespace race here. Every later removal is
+        // a compare-and-swap: the named object is first moved into the retained
+        // transaction, then its exact preflight identity/kind/content is
+        // verified before any replacement can publish.
+        after_identity_revalidation();
+
+        let mut created_directories = Vec::new();
+        let mut removed_directories = Vec::new();
+
+        let mutation_result: Result<()> = (|| {
+            for (name_index, (entry, identity)) in affected_previous
+                .iter()
+                .zip(&previous_identities)
+                .enumerate()
+            {
+                projection.displace_previous_entry(
+                    &mut transaction,
+                    **entry,
+                    *identity,
+                    name_index,
+                )?;
+            }
+
+            for relative in &directories_to_replace {
+                removed_directories.push(projection.back_up_planned_empty_directory(
+                    &mut transaction,
+                    relative,
+                    directory_identities[relative],
+                    removed_directories.len(),
+                )?);
+            }
+
+            projection.prepare_without_replacement_transactional(
+                &mut transaction,
+                &file_ids,
+                &mut created_directories,
+            )?;
+            for staged_entry in &staged {
+                projection.publish_staged_entry(&mut transaction, staged_entry)?;
+            }
+
+            for relative in &cleanup_directories {
+                if projection.relative_directory_is_empty(relative)? {
+                    removed_directories.push(projection.back_up_planned_empty_directory(
+                        &mut transaction,
+                        relative,
+                        directory_identities[relative],
+                        removed_directories.len(),
+                    )?);
+                }
+            }
+            Ok(())
+        })();
+
+        if let Err(error) = mutation_result {
+            let rollback = projection.rollback_reconciliation_manifest(&transaction);
+            return match rollback {
+                Ok(()) => match projection.cleanup_reconciliation_transaction(transaction) {
+                    Ok(()) => Err(error),
+                    Err(cleanup_error) => Err(KinError::Other(format!(
+                        "{error}; exact-source rollback succeeded but transaction cleanup failed: {cleanup_error}"
+                    ))),
+                },
+                Err(rollback_error) => Err(KinError::Other(format!(
+                    "{error}; {rollback_error}; retained recovery transaction at {}",
+                    projection
+                        .reconciliation_control_path()
+                        .join(&transaction.name)
+                        .display()
+                ))),
+            };
+        }
+
+        let head_commit = before_head_commit().and_then(|()| {
+            projection.revalidate_projection_lock()?;
+            if let Some(transition) = &transaction.manifest.branch_transition {
+                projection.write_branch_marker_capability(&transition.target_branch)?;
+            }
+            Ok(())
+        });
+        if let Err(error) = head_commit {
+            let rollback = projection.rollback_reconciliation_manifest(&transaction);
+            return match rollback {
+                Ok(()) => match projection.cleanup_reconciliation_transaction(transaction) {
+                    Ok(()) => Err(error),
+                    Err(cleanup_error) => Err(KinError::Other(format!(
+                        "{error}; finalized branch rollback succeeded but transaction cleanup failed: {cleanup_error}"
+                    ))),
+                },
+                Err(rollback_error) => Err(KinError::Other(format!(
+                    "{error}; {rollback_error}; retained recovery transaction at {}",
+                    projection
+                        .reconciliation_control_path()
+                        .join(&transaction.name)
+                        .display()
+                ))),
+            };
+        }
+
+        if transaction.manifest.branch_transition.is_some() {
+            transaction.manifest.state = ReconciliationTransactionState::Committed;
+            if let Err(error) = projection.persist_reconciliation_manifest(&transaction) {
+                // The durable descriptor is still pending. Restore the
+                // in-memory phase before using the same recovery path so HEAD
+                // and projected bytes return to the prior authority.
+                transaction.manifest.state = ReconciliationTransactionState::Pending;
+                let rollback = projection.rollback_reconciliation_manifest(&transaction);
+                return match rollback {
+                    Ok(()) => match projection.cleanup_reconciliation_transaction(transaction) {
+                        Ok(()) => Err(error),
+                        Err(cleanup_error) => Err(KinError::Other(format!(
+                            "{error}; branch commit-marker rollback succeeded but transaction cleanup failed: {cleanup_error}"
+                        ))),
+                    },
+                    Err(rollback_error) => Err(KinError::Other(format!(
+                        "{error}; {rollback_error}; retained recovery transaction at {}",
+                        projection
+                            .reconciliation_control_path()
+                            .join(&transaction.name)
+                            .display()
+                    ))),
+                };
+            }
+        }
+
+        projection.cleanup_reconciliation_transaction(transaction)?;
+        return Ok(entries_to_materialize.len());
+    }
+
+    #[cfg(not(any(unix, windows)))]
+    {
+        let _ = (
+            root,
+            previous_entries,
+            entries,
+            should_preserve,
+            after_read_only_preflight,
+            after_identity_revalidation,
+        );
+        Err(unsupported_safe_projection_error())
+    }
+}
+
+fn source_entries_match(left: &ValidatedSourceEntry<'_>, right: &ValidatedSourceEntry<'_>) -> bool {
+    left.kind == right.kind && left.content == right.content
+}
+
+#[cfg(not(any(unix, windows)))]
+fn unsupported_safe_projection_error() -> KinError {
+    KinError::Other(
+        "safe exact source checkout is unsupported on this platform because retained no-follow directory capabilities are unavailable"
+            .to_string(),
+    )
+}
+
+#[cfg(any(unix, windows))]
+struct ProjectionRoot {
+    root: cap_std::fs::Dir,
+    kin_control: cap_std::fs::Dir,
+    control: cap_std::fs::Dir,
+    projection_lock: std::fs::File,
+    projection_lock_identity: TrackedEntryIdentity,
+    display_root: PathBuf,
+    kin_control_identity: TrackedEntryIdentity,
+    control_identity: TrackedEntryIdentity,
+    authority_key: [u8; 32],
+}
+
+#[cfg(any(unix, windows))]
+#[derive(Clone, Copy, Debug, Eq, PartialEq, serde::Deserialize, serde::Serialize)]
+struct TrackedEntryIdentity {
+    #[cfg(unix)]
+    device: u64,
+    #[cfg(unix)]
+    inode: u64,
+    #[cfg(windows)]
+    volume_serial: u64,
+    #[cfg(windows)]
+    file_id: [u8; 16],
+}
+
+#[cfg(any(unix, windows))]
+#[derive(Clone, Copy)]
+struct StagedReconciliationEntry<'a> {
+    entry: ValidatedSourceEntry<'a>,
+    name_index: usize,
+    identity: TrackedEntryIdentity,
+    state: TrackedObjectState,
+}
+
+#[cfg(any(unix, windows))]
+struct ReconciliationTransaction {
+    name: OsString,
+    directory: cap_std::fs::Dir,
+    identity: TrackedEntryIdentity,
+    manifest: ReconciliationManifest,
+    action_log_bytes: u64,
+    action_tail_authentication: Vec<u8>,
+}
+
+#[cfg(any(unix, windows))]
+#[derive(Clone, Copy, Debug, Eq, PartialEq, serde::Deserialize, serde::Serialize)]
+enum ExistingObjectKind {
+    File,
+    Symlink,
+}
+
+#[cfg(any(unix, windows))]
+#[derive(Clone, Copy, Debug, Eq, PartialEq, serde::Deserialize, serde::Serialize)]
+struct TrackedObjectState {
+    content_sha256: [u8; 32],
+    /// Unix permission bits. Windows exact-source projection binds bytes and
+    /// FILE_ID_128, but sets this to zero because Win32 ACLs are not a stable
+    /// mode scalar and are outside the current projection transaction model.
+    mode: u32,
+}
+
+#[cfg(any(unix, windows))]
+#[derive(Clone, Debug, serde::Deserialize, serde::Serialize)]
+struct ReconciliationManifest {
+    schema: u32,
+    transaction_id: String,
+    root_identity: TrackedEntryIdentity,
+    kin_control_identity: TrackedEntryIdentity,
+    control_identity: TrackedEntryIdentity,
+    transaction_identity: TrackedEntryIdentity,
+    state: ReconciliationTransactionState,
+    branch_transition: Option<BranchProjectionTransition>,
+    actions: Vec<ReconciliationRecoveryAction>,
+}
+
+#[cfg(any(unix, windows))]
+#[derive(Clone, Copy, Debug, Eq, PartialEq, serde::Deserialize, serde::Serialize)]
+#[serde(rename_all = "snake_case")]
+enum ReconciliationTransactionState {
+    Pending,
+    Committed,
+}
+
+#[cfg(any(unix, windows))]
+#[derive(Clone, Debug, Eq, PartialEq, serde::Deserialize, serde::Serialize)]
+struct BranchProjectionTransition {
+    previous_branch: String,
+    previous_head: SemanticChangeId,
+    target_branch: String,
+    target_head: SemanticChangeId,
+}
+
+#[cfg(any(unix, windows))]
+#[derive(Clone, Debug, serde::Deserialize, serde::Serialize)]
+struct AuthenticatedReconciliationManifest {
+    manifest: ReconciliationManifest,
+    authentication: Vec<u8>,
+}
+
+#[cfg(any(unix, windows))]
+#[derive(Clone, Debug, serde::Deserialize, serde::Serialize)]
+struct AuthenticatedReconciliationAction {
+    sequence: u64,
+    previous_authentication: Vec<u8>,
+    action: ReconciliationRecoveryAction,
+    authentication: Vec<u8>,
+}
+
+#[cfg(any(unix, windows))]
+#[derive(Clone, Debug, serde::Deserialize, serde::Serialize)]
+#[serde(tag = "operation", rename_all = "snake_case")]
+enum ReconciliationRecoveryAction {
+    BackupObject {
+        relative: PathBuf,
+        kind: ExistingObjectKind,
+        identity: TrackedEntryIdentity,
+        state: TrackedObjectState,
+        slot: String,
+    },
+    BackupDirectory {
+        relative: PathBuf,
+        identity: TrackedEntryIdentity,
+        slot: String,
+    },
+    PublishObject {
+        relative: PathBuf,
+        kind: ExistingObjectKind,
+        identity: TrackedEntryIdentity,
+        state: TrackedObjectState,
+        slot: String,
+    },
+    PublishDirectory {
+        relative: PathBuf,
+        identity: TrackedEntryIdentity,
+        slot: String,
+    },
+}
+
+#[cfg(any(unix, windows))]
+#[derive(Clone, Debug)]
+struct PlannedExistingObject {
+    relative: PathBuf,
+    kind: ExistingObjectKind,
+    identity: TrackedEntryIdentity,
+    state: TrackedObjectState,
+}
+
+#[cfg(any(unix, windows))]
+struct BackedUpDirectory {
+    _directory: cap_std::fs::Dir,
+}
+
+#[cfg(any(unix, windows))]
+struct PublishedDirectory {
+    #[cfg(all(test, unix))]
+    relative: PathBuf,
+    #[cfg(all(test, unix))]
+    identity: TrackedEntryIdentity,
+    #[cfg(all(test, unix))]
+    name_index: usize,
+    directory: cap_std::fs::Dir,
+}
+
+#[cfg(any(unix, windows))]
+struct FullReplacementPlan {
+    objects: Vec<PlannedExistingObject>,
+    directories: Vec<(PathBuf, TrackedEntryIdentity)>,
+}
+
+#[cfg(any(unix, windows))]
+#[derive(Clone, Copy)]
+struct NamedEntryLocation<'a> {
+    parent: &'a cap_std::fs::Dir,
+    name: &'a std::ffi::OsStr,
+}
+
+#[cfg(unix)]
+fn tracked_entry_identity(metadata: &cap_std::fs::Metadata) -> TrackedEntryIdentity {
+    use cap_std::fs::MetadataExt;
+
+    TrackedEntryIdentity {
+        device: metadata.dev(),
+        inode: metadata.ino(),
+    }
+}
+
+#[cfg(unix)]
+fn tracked_open_file_identity(metadata: &std::fs::Metadata) -> TrackedEntryIdentity {
+    use std::os::unix::fs::MetadataExt;
+
+    TrackedEntryIdentity {
+        device: metadata.dev(),
+        inode: metadata.ino(),
+    }
+}
+
+#[cfg(windows)]
+fn tracked_open_file_identity(file: &cap_std::fs::File) -> std::io::Result<TrackedEntryIdentity> {
+    use std::os::windows::io::AsRawHandle;
+
+    tracked_windows_handle_identity(file.as_raw_handle().cast())
+}
+
+#[cfg(unix)]
+fn tracked_open_file_identity_for_std(
+    file: &std::fs::File,
+) -> std::io::Result<TrackedEntryIdentity> {
+    file.metadata()
+        .map(|metadata| tracked_open_file_identity(&metadata))
+}
+
+#[cfg(unix)]
+fn tracked_cap_file_identity(file: &cap_std::fs::File) -> std::io::Result<TrackedEntryIdentity> {
+    file.metadata()
+        .map(|metadata| tracked_entry_identity(&metadata))
+}
+
+#[cfg(windows)]
+fn tracked_cap_file_identity(file: &cap_std::fs::File) -> std::io::Result<TrackedEntryIdentity> {
+    tracked_open_file_identity(file)
+}
+
+#[cfg(windows)]
+fn tracked_open_file_identity_for_std(
+    file: &std::fs::File,
+) -> std::io::Result<TrackedEntryIdentity> {
+    use std::os::windows::io::AsRawHandle;
+
+    tracked_windows_handle_identity(file.as_raw_handle().cast())
+}
+
+#[cfg(unix)]
+fn tracked_open_directory_identity(
+    directory: &cap_std::fs::Dir,
+) -> std::io::Result<TrackedEntryIdentity> {
+    directory
+        .dir_metadata()
+        .map(|metadata| tracked_entry_identity(&metadata))
+}
+
+#[cfg(windows)]
+fn tracked_open_directory_identity(
+    directory: &cap_std::fs::Dir,
+) -> std::io::Result<TrackedEntryIdentity> {
+    use std::os::windows::io::AsRawHandle;
+
+    tracked_windows_handle_identity(directory.as_raw_handle().cast())
+}
+
+#[cfg(windows)]
+fn tracked_windows_handle_identity(
+    handle: windows_sys::Win32::Foundation::HANDLE,
+) -> std::io::Result<TrackedEntryIdentity> {
+    use windows_sys::Win32::Storage::FileSystem::{
+        FileIdInfo, GetFileInformationByHandleEx, FILE_ID_INFO,
+    };
+
+    // FILE_ID_INFO is the Windows namespace authority for modern filesystems.
+    // The legacy 64-bit file index exposed by metadata can alias on ReFS, so it
+    // must never authorize a destructive exact-source transition.
+    let mut info: FILE_ID_INFO = unsafe { std::mem::zeroed() };
+    let inspected = unsafe {
+        GetFileInformationByHandleEx(
+            handle,
+            FileIdInfo,
+            (&raw mut info).cast(),
+            std::mem::size_of::<FILE_ID_INFO>() as u32,
+        )
+    };
+    if inspected == 0 {
+        return Err(std::io::Error::last_os_error());
+    }
+    let identity = TrackedEntryIdentity {
+        volume_serial: info.VolumeSerialNumber,
+        file_id: info.FileId.Identifier,
+    };
+    if identity.volume_serial == 0 || identity.file_id.iter().all(|byte| *byte == 0) {
+        return Err(std::io::Error::new(
+            std::io::ErrorKind::InvalidData,
+            "Windows exact-source object returned a zero volume or FILE_ID_128 identity",
+        ));
+    }
+    Ok(identity)
+}
+
+#[cfg(any(unix, windows))]
+fn reconciliation_hmac(key: &[u8; 32], message: &[u8]) -> [u8; 32] {
+    use sha2::{Digest, Sha256};
+
+    const BLOCK_BYTES: usize = 64;
+    let mut inner_key = [0x36_u8; BLOCK_BYTES];
+    let mut outer_key = [0x5c_u8; BLOCK_BYTES];
+    for (index, byte) in key.iter().enumerate() {
+        inner_key[index] ^= byte;
+        outer_key[index] ^= byte;
+    }
+    let mut inner = Sha256::new();
+    inner.update(inner_key);
+    inner.update(message);
+    let inner_digest = inner.finalize();
+    let mut outer = Sha256::new();
+    outer.update(outer_key);
+    outer.update(inner_digest);
+    outer.finalize().into()
+}
+
+#[cfg(any(unix, windows))]
+fn sync_directory_capability(directory: &cap_std::fs::Dir, display: &Path) -> Result<()> {
+    #[cfg(unix)]
+    rustix::fs::fsync(directory)
+        .map_err(|error| KinError::io(display, std::io::Error::from(error)))?;
+    #[cfg(windows)]
+    {
+        // Win32 has no supported equivalent of fsync for a directory handle;
+        // FlushFileBuffers requires GENERIC_WRITE and applies to file data, not
+        // directory namespace entries. The file contents and recovery manifest
+        // are flushed through their retained file handles before any rename.
+        let _ = (directory, display);
+    }
+    Ok(())
+}
+
+#[cfg(any(unix, windows))]
+fn sync_namespace_parents(
+    source: &cap_std::fs::Dir,
+    source_display: &Path,
+    destination: &cap_std::fs::Dir,
+    destination_display: &Path,
+) -> Result<()> {
+    sync_directory_capability(source, source_display)?;
+    if tracked_open_directory_identity(source)
+        .map_err(|error| KinError::io(source_display, error))?
+        != tracked_open_directory_identity(destination)
+            .map_err(|error| KinError::io(destination_display, error))?
+    {
+        sync_directory_capability(destination, destination_display)?;
+    }
+    Ok(())
+}
+
+#[cfg(any(unix, windows))]
+fn open_or_create_private_directory(
+    parent: &cap_std::fs::Dir,
+    name: &std::ffi::OsStr,
+    display: &Path,
+) -> Result<cap_std::fs::Dir> {
+    for _ in 0..8 {
+        // Open the control-plane directory read-only. This handle is held for the
+        // projection's lifetime and never deletes its own directory (children are
+        // removed through their own per-child handles), so it must not request
+        // DELETE access. On Windows a peer that already holds this directory open
+        // without FILE_SHARE_DELETE — for example the graph store's snapshot/index
+        // under `.kin` — denies any DELETE-access open regardless of the sharing we
+        // offer; POSIX imposes no such bilateral constraint. Directory removal uses
+        // `open_directory_nofollow_for_removal` at the point of deletion instead.
+        match open_directory_nofollow(parent, name) {
+            Ok(directory) => {
+                #[cfg(unix)]
+                rustix::fs::fchmod(&directory, rustix::fs::Mode::from_raw_mode(0o700))
+                    .map_err(|error| KinError::io(display, error.into()))?;
+                return Ok(directory);
+            }
+            Err(error) if error.kind() == std::io::ErrorKind::NotFound => {
+                match parent.create_dir(name) {
+                    Ok(()) => {
+                        sync_directory_capability(parent, display.parent().unwrap_or(display))?
+                    }
+                    Err(error) if error.kind() == std::io::ErrorKind::AlreadyExists => {}
+                    Err(error) => return Err(KinError::io(display, error)),
+                }
+            }
+            Err(error) => return Err(KinError::io(display, error)),
+        }
+    }
+    Err(KinError::Other(format!(
+        "control-plane directory {} changed repeatedly during exact-source initialization",
+        display.display()
+    )))
+}
+
+#[cfg(unix)]
+fn open_reconciliation_control_file(
+    parent: &cap_std::fs::Dir,
+    name: &std::ffi::OsStr,
+) -> std::io::Result<cap_std::fs::File> {
+    rustix::fs::openat(
+        parent,
+        name,
+        rustix::fs::OFlags::RDONLY | rustix::fs::OFlags::NOFOLLOW | rustix::fs::OFlags::CLOEXEC,
+        rustix::fs::Mode::empty(),
+    )
+    .map(std::fs::File::from)
+    .map(cap_std::fs::File::from_std)
+    .map_err(Into::into)
+}
+
+#[cfg(windows)]
+fn open_reconciliation_control_file(
+    parent: &cap_std::fs::Dir,
+    name: &std::ffi::OsStr,
+) -> std::io::Result<cap_std::fs::File> {
+    use cap_fs_ext::{FollowSymlinks, OpenOptionsFollowExt};
+    let mut options = cap_std::fs::OpenOptions::new();
+    options.read(true).follow(FollowSymlinks::No);
+    parent.open_with(name, &options)
+}
+
+#[cfg(any(unix, windows))]
+fn load_or_create_reconciliation_authority_key(
+    control: &cap_std::fs::Dir,
+    display_control: &Path,
+) -> Result<[u8; 32]> {
+    for _ in 0..8 {
+        match open_reconciliation_control_file(
+            control,
+            std::ffi::OsStr::new(RECONCILIATION_AUTHORITY_FILE),
+        ) {
+            Ok(mut file) => {
+                let metadata = file.metadata().map_err(|error| {
+                    KinError::io(display_control.join(RECONCILIATION_AUTHORITY_FILE), error)
+                })?;
+                if !metadata.is_file() || metadata.len() != 32 {
+                    return Err(KinError::Other(format!(
+                        "reconciliation authority {} is not an exact 32-byte regular file",
+                        display_control
+                            .join(RECONCILIATION_AUTHORITY_FILE)
+                            .display()
+                    )));
+                }
+                let mut key = [0_u8; 32];
+                file.read_exact(&mut key).map_err(|error| {
+                    KinError::io(display_control.join(RECONCILIATION_AUTHORITY_FILE), error)
+                })?;
+                return Ok(key);
+            }
+            Err(error) if error.kind() == std::io::ErrorKind::NotFound => {
+                let mut key = [0_u8; 32];
+                key[..16].copy_from_slice(uuid::Uuid::new_v4().as_bytes());
+                key[16..].copy_from_slice(uuid::Uuid::new_v4().as_bytes());
+                let temporary = OsString::from(format!(".authority-{}.tmp", uuid::Uuid::new_v4()));
+                let mut options = cap_std::fs::OpenOptions::new();
+                options.write(true).create_new(true);
+                match control.open_with(&temporary, &options) {
+                    Ok(mut file) => {
+                        #[cfg(unix)]
+                        rustix::fs::fchmod(&file, rustix::fs::Mode::from_raw_mode(0o600)).map_err(
+                            |error| KinError::io(display_control.join(&temporary), error.into()),
+                        )?;
+                        file.write_all(&key)
+                            .and_then(|()| file.sync_all())
+                            .map_err(|error| {
+                                KinError::io(display_control.join(&temporary), error)
+                            })?;
+                        let publication =
+                            control.hard_link(&temporary, control, RECONCILIATION_AUTHORITY_FILE);
+                        match publication {
+                            Ok(()) => {
+                                file.sync_all().map_err(|error| {
+                                    KinError::io(
+                                        display_control.join(RECONCILIATION_AUTHORITY_FILE),
+                                        error,
+                                    )
+                                })?;
+                                drop(file);
+                                sync_directory_capability(control, display_control)?;
+                                control.remove_file(&temporary).map_err(|error| {
+                                    KinError::io(display_control.join(&temporary), error)
+                                })?;
+                                sync_directory_capability(control, display_control)?;
+                                return Ok(key);
+                            }
+                            Err(error)
+                                if matches!(
+                                    error.kind(),
+                                    std::io::ErrorKind::AlreadyExists
+                                        | std::io::ErrorKind::PermissionDenied
+                                ) =>
+                            {
+                                drop(file);
+                                let _ = control.remove_file(&temporary);
+                                continue;
+                            }
+                            Err(error) => {
+                                drop(file);
+                                let _ = control.remove_file(&temporary);
+                                return Err(KinError::io(
+                                    display_control.join(RECONCILIATION_AUTHORITY_FILE),
+                                    error,
+                                ));
+                            }
+                        }
+                    }
+                    Err(error) if error.kind() == std::io::ErrorKind::AlreadyExists => continue,
+                    Err(error) => {
+                        return Err(KinError::io(
+                            display_control.join(RECONCILIATION_AUTHORITY_FILE),
+                            error,
+                        ));
+                    }
+                }
+            }
+            Err(error) => {
+                return Err(KinError::io(
+                    display_control.join(RECONCILIATION_AUTHORITY_FILE),
+                    error,
+                ));
+            }
+        }
+    }
+    Err(KinError::Other(format!(
+        "reconciliation authority {} changed repeatedly during initialization",
+        display_control
+            .join(RECONCILIATION_AUTHORITY_FILE)
+            .display()
+    )))
+}
+
+#[cfg(any(unix, windows))]
+fn acquire_reconciliation_projection_lock(
+    control: &cap_std::fs::Dir,
+    display_control: &Path,
+) -> Result<(std::fs::File, TrackedEntryIdentity)> {
+    let name = std::ffi::OsStr::new(RECONCILIATION_PROJECTION_LOCK_FILE);
+    #[cfg(unix)]
+    let file = rustix::fs::openat(
+        control,
+        name,
+        rustix::fs::OFlags::RDWR
+            | rustix::fs::OFlags::CREATE
+            | rustix::fs::OFlags::NOFOLLOW
+            | rustix::fs::OFlags::CLOEXEC,
+        rustix::fs::Mode::from_raw_mode(0o600),
+    )
+    .map(std::fs::File::from)
+    .map_err(|error| {
+        KinError::io(
+            display_control.join(RECONCILIATION_PROJECTION_LOCK_FILE),
+            error.into(),
+        )
+    })?;
+    #[cfg(windows)]
+    let file = {
+        use cap_fs_ext::{FollowSymlinks, OpenOptionsFollowExt};
+        let mut options = cap_std::fs::OpenOptions::new();
+        options
+            .read(true)
+            .write(true)
+            .create(true)
+            .follow(FollowSymlinks::No);
+        control
+            .open_with(name, &options)
+            .map(cap_std::fs::File::into_std)
+            .map_err(|error| {
+                KinError::io(
+                    display_control.join(RECONCILIATION_PROJECTION_LOCK_FILE),
+                    error,
+                )
+            })?
+    };
+    let metadata = file.metadata().map_err(|error| {
+        KinError::io(
+            display_control.join(RECONCILIATION_PROJECTION_LOCK_FILE),
+            error,
+        )
+    })?;
+    if !metadata.is_file() {
+        return Err(KinError::Other(format!(
+            "projection lock {} is not a regular file",
+            display_control
+                .join(RECONCILIATION_PROJECTION_LOCK_FILE)
+                .display()
+        )));
+    }
+    let identity = tracked_open_file_identity_for_std(&file).map_err(|error| {
+        KinError::io(
+            display_control.join(RECONCILIATION_PROJECTION_LOCK_FILE),
+            error,
+        )
+    })?;
+    file.try_lock_exclusive().map_err(|error| {
+        KinError::io(
+            display_control.join(RECONCILIATION_PROJECTION_LOCK_FILE),
+            std::io::Error::new(
+                error.kind(),
+                format!("another exact-source projection is active: {error}"),
+            ),
+        )
+    })?;
+
+    let named = open_reconciliation_control_file(control, name).map_err(|error| {
+        KinError::io(
+            display_control.join(RECONCILIATION_PROJECTION_LOCK_FILE),
+            error,
+        )
+    })?;
+    let named_identity = tracked_cap_file_identity(&named).map_err(|error| {
+        KinError::io(
+            display_control.join(RECONCILIATION_PROJECTION_LOCK_FILE),
+            error,
+        )
+    })?;
+    if named_identity != identity {
+        return Err(KinError::Other(format!(
+            "projection lock {} changed identity while acquiring",
+            display_control
+                .join(RECONCILIATION_PROJECTION_LOCK_FILE)
+                .display()
+        )));
+    }
+    Ok((file, identity))
+}
+
+#[cfg(any(unix, windows))]
+impl ProjectionRoot {
+    fn open(root: &Path) -> Result<Self> {
+        #[cfg(unix)]
+        let capability = {
+            let root_fd = rustix::fs::open(
+                root,
+                rustix::fs::OFlags::RDONLY
+                    | rustix::fs::OFlags::DIRECTORY
+                    | rustix::fs::OFlags::NOFOLLOW
+                    | rustix::fs::OFlags::CLOEXEC,
+                rustix::fs::Mode::empty(),
+            )
+            .map(std::fs::File::from)
+            .map_err(|error| KinError::io(root, std::io::Error::from(error)))?;
+            cap_std::fs::Dir::from_std_file(root_fd)
+        };
+        #[cfg(windows)]
+        let capability =
+            open_windows_projection_root(root).map_err(|error| KinError::io(root, error))?;
+        let kin_control = open_or_create_private_directory(
+            &capability,
+            std::ffi::OsStr::new(".kin"),
+            &root.join(".kin"),
+        )?;
+        let kin_control_identity = tracked_open_directory_identity(&kin_control)
+            .map_err(|error| KinError::io(root.join(".kin"), error))?;
+        let control = open_or_create_private_directory(
+            &kin_control,
+            std::ffi::OsStr::new(RECONCILIATION_CONTROL_DIRECTORY),
+            &root.join(".kin").join(RECONCILIATION_CONTROL_DIRECTORY),
+        )?;
+        let control_identity = tracked_open_directory_identity(&control).map_err(|error| {
+            KinError::io(
+                root.join(".kin").join(RECONCILIATION_CONTROL_DIRECTORY),
+                error,
+            )
+        })?;
+        let display_control = root.join(".kin").join(RECONCILIATION_CONTROL_DIRECTORY);
+        let (projection_lock, projection_lock_identity) =
+            acquire_reconciliation_projection_lock(&control, &display_control)?;
+        let authority_key =
+            load_or_create_reconciliation_authority_key(&control, &display_control)?;
+        let projection = Self {
+            root: capability,
+            kin_control,
+            control,
+            projection_lock,
+            projection_lock_identity,
+            display_root: root.to_path_buf(),
+            kin_control_identity,
+            control_identity,
+            authority_key,
+        };
+        projection.recover_reconciliation_transactions()?;
+        Ok(projection)
+    }
+
+    fn create_reconciliation_transaction(&self) -> Result<ReconciliationTransaction> {
+        self.create_reconciliation_transaction_with_transition(None)
+    }
+
+    fn create_reconciliation_transaction_with_transition(
+        &self,
+        branch_transition: Option<BranchProjectionTransition>,
+    ) -> Result<ReconciliationTransaction> {
+        self.revalidate_projection_lock()?;
+        for _ in 0..8 {
+            let id = uuid::Uuid::new_v4().to_string();
+            let name = OsString::from(format!("tx-{id}"));
+            match self.control.create_dir(&name) {
+                Ok(()) => {
+                    let directory = open_directory_nofollow_for_removal(&self.control, &name)
+                        .map_err(|error| {
+                            KinError::io(self.reconciliation_control_path().join(&name), error)
+                        })?;
+                    #[cfg(unix)]
+                    rustix::fs::fchmod(&directory, rustix::fs::Mode::from_raw_mode(0o700))
+                        .map_err(|error| {
+                            KinError::io(
+                                self.reconciliation_control_path().join(&name),
+                                error.into(),
+                            )
+                        })?;
+                    let identity =
+                        tracked_open_directory_identity(&directory).map_err(|error| {
+                            KinError::io(self.reconciliation_control_path().join(&name), error)
+                        })?;
+                    sync_directory_capability(&self.control, &self.reconciliation_control_path())?;
+                    let root_identity = tracked_open_directory_identity(&self.root)
+                        .map_err(|error| KinError::io(&self.display_root, error))?;
+                    let mut transaction = ReconciliationTransaction {
+                        name,
+                        directory,
+                        identity,
+                        manifest: ReconciliationManifest {
+                            schema: RECONCILIATION_MANIFEST_SCHEMA,
+                            transaction_id: id,
+                            root_identity,
+                            kin_control_identity: self.kin_control_identity,
+                            control_identity: self.control_identity,
+                            transaction_identity: identity,
+                            state: ReconciliationTransactionState::Pending,
+                            branch_transition: branch_transition.clone(),
+                            actions: Vec::new(),
+                        },
+                        action_log_bytes: 0,
+                        action_tail_authentication: Vec::new(),
+                    };
+                    if let Err(error) = self.persist_reconciliation_manifest(&transaction) {
+                        let cleanup = self.cleanup_reconciliation_transaction(transaction);
+                        return match cleanup {
+                            Ok(()) => Err(error),
+                            Err(cleanup_error) => Err(KinError::Other(format!(
+                                "{error}; empty reconciliation transaction cleanup also failed: {cleanup_error}"
+                            ))),
+                        };
+                    }
+                    // Keep the value mutable at its construction boundary so
+                    // every later namespace intent can be journaled in-place.
+                    transaction.manifest.actions.reserve(16);
+                    return Ok(transaction);
+                }
+                Err(error) if error.kind() == std::io::ErrorKind::AlreadyExists => continue,
+                Err(error) => {
+                    return Err(KinError::io(
+                        self.reconciliation_control_path().join(&name),
+                        error,
+                    ));
+                }
+            }
+        }
+        Err(KinError::Other(
+            "could not allocate a unique exact-source reconciliation transaction".to_string(),
+        ))
+    }
+
+    fn cleanup_reconciliation_transaction(
+        &self,
+        transaction: ReconciliationTransaction,
+    ) -> Result<()> {
+        let display = self.reconciliation_control_path().join(&transaction.name);
+        let actual = tracked_open_directory_identity(&transaction.directory)
+            .map_err(|error| KinError::io(&display, error))?;
+        if actual != transaction.identity {
+            return Err(KinError::Other(format!(
+                "exact-source transaction capability identity changed for {}",
+                display.display()
+            )));
+        }
+        #[cfg(unix)]
+        transaction
+            .directory
+            .remove_open_dir_all()
+            .map_err(|error| KinError::io(display, error))?;
+        #[cfg(windows)]
+        {
+            self.remove_windows_directory_contents(
+                &transaction.directory,
+                Path::new(&transaction.name),
+            )?;
+            mark_windows_directory_for_deletion(transaction.directory)
+                .map_err(|error| KinError::io(display, error))?;
+        }
+        sync_directory_capability(&self.control, &self.reconciliation_control_path())?;
+        Ok(())
+    }
+
+    fn reconciliation_control_path(&self) -> PathBuf {
+        self.display_root
+            .join(".kin")
+            .join(RECONCILIATION_CONTROL_DIRECTORY)
+    }
+
+    fn revalidate_projection_lock(&self) -> Result<()> {
+        // Read-only identity check, not a removal: requesting DELETE access on
+        // `.kin` here would be vetoed on Windows by the graph store's live handle
+        // opened without FILE_SHARE_DELETE (the same bilateral collision as the
+        // use-path open).
+        let named_kin = open_directory_nofollow(&self.root, std::ffi::OsStr::new(".kin"))
+            .map_err(|error| KinError::io(self.display_root.join(".kin"), error))?;
+        if tracked_open_directory_identity(&named_kin)
+            .map_err(|error| KinError::io(self.display_root.join(".kin"), error))?
+            != self.kin_control_identity
+        {
+            return Err(KinError::Other(format!(
+                "repository control directory {} was replaced while the projection lock was held",
+                self.display_root.join(".kin").display()
+            )));
+        }
+        // Read-only identity check, matching the `.kin` open above: `.kin/control`
+        // is projection-owned and does not collide today, but narrowing it now
+        // closes the gratuitous-DELETE-access class rather than only the instance.
+        let named_control = open_directory_nofollow(
+            &self.kin_control,
+            std::ffi::OsStr::new(RECONCILIATION_CONTROL_DIRECTORY),
+        )
+        .map_err(|error| KinError::io(self.reconciliation_control_path(), error))?;
+        if tracked_open_directory_identity(&named_control)
+            .map_err(|error| KinError::io(self.reconciliation_control_path(), error))?
+            != self.control_identity
+        {
+            return Err(KinError::Other(format!(
+                "reconciliation control directory {} was replaced while the projection lock was held",
+                self.reconciliation_control_path().display()
+            )));
+        }
+        let display = self
+            .reconciliation_control_path()
+            .join(RECONCILIATION_PROJECTION_LOCK_FILE);
+        let held_identity = tracked_open_file_identity_for_std(&self.projection_lock)
+            .map_err(|error| KinError::io(&display, error))?;
+        if held_identity != self.projection_lock_identity {
+            return Err(KinError::Other(format!(
+                "projection lock capability changed identity for {}",
+                display.display()
+            )));
+        }
+        let named = open_reconciliation_control_file(
+            &self.control,
+            std::ffi::OsStr::new(RECONCILIATION_PROJECTION_LOCK_FILE),
+        )
+        .map_err(|error| KinError::io(&display, error))?;
+        if tracked_cap_file_identity(&named).map_err(|error| KinError::io(&display, error))?
+            != self.projection_lock_identity
+        {
+            return Err(KinError::Other(format!(
+                "projection lock {} was replaced while held; refusing namespace mutation",
+                display.display()
+            )));
+        }
+        Ok(())
+    }
+
+    fn read_branch_marker_capability(&self) -> Result<String> {
+        let display = self.display_root.join(".kin/HEAD");
+        let file =
+            open_reconciliation_control_file(&self.kin_control, std::ffi::OsStr::new("HEAD"))
+                .map_err(|error| KinError::io(&display, error))?;
+        let metadata = file
+            .metadata()
+            .map_err(|error| KinError::io(&display, error))?;
+        if !metadata.is_file() || metadata.len() > 4096 {
+            return Err(KinError::Other(format!(
+                "branch marker {} is not a bounded regular file",
+                display.display()
+            )));
+        }
+        let mut bytes = Vec::new();
+        file.take(4097)
+            .read_to_end(&mut bytes)
+            .map_err(|error| KinError::io(&display, error))?;
+        if bytes.len() > 4096 {
+            return Err(KinError::Other(format!(
+                "branch marker {} exceeds 4096 bytes",
+                display.display()
+            )));
+        }
+        let marker = std::str::from_utf8(&bytes).map_err(|error| {
+            KinError::Other(format!(
+                "branch marker {} is not UTF-8: {error}",
+                display.display()
+            ))
+        })?;
+        let marker = marker.trim();
+        if marker.is_empty() {
+            return Err(KinError::Other(format!(
+                "branch marker {} is empty",
+                display.display()
+            )));
+        }
+        Ok(marker.to_string())
+    }
+
+    fn write_branch_marker_capability(&self, branch: &str) -> Result<()> {
+        if branch.trim().is_empty()
+            || branch != branch.trim()
+            || branch.len() > 4096
+            || branch.chars().any(char::is_control)
+        {
+            return Err(KinError::Other(
+                "refusing to write an invalid branch marker during recovery".to_string(),
+            ));
+        }
+        let temporary = OsString::from(format!(".HEAD-{}.tmp", uuid::Uuid::new_v4()));
+        let display = self.display_root.join(".kin/HEAD");
+        let mut options = cap_std::fs::OpenOptions::new();
+        options.write(true).create_new(true);
+        #[cfg(windows)]
+        {
+            use cap_std::fs::OpenOptionsExt;
+            use windows_sys::Win32::Foundation::{GENERIC_READ, GENERIC_WRITE};
+            use windows_sys::Win32::Storage::FileSystem::{
+                DELETE, FILE_SHARE_DELETE, FILE_SHARE_READ, FILE_SHARE_WRITE,
+            };
+
+            options
+                .access_mode(GENERIC_READ | GENERIC_WRITE | DELETE)
+                .share_mode(FILE_SHARE_READ | FILE_SHARE_WRITE | FILE_SHARE_DELETE);
+        }
+        let mut file = self
+            .kin_control
+            .open_with(&temporary, &options)
+            .map_err(|error| KinError::io(&display, error))?;
+        #[cfg(unix)]
+        rustix::fs::fchmod(&file, rustix::fs::Mode::from_raw_mode(0o600))
+            .map_err(|error| KinError::io(&display, error.into()))?;
+        if let Err(error) = file
+            .write_all(branch.as_bytes())
+            .and_then(|()| file.sync_all())
+            .map_err(|error| KinError::io(&display, error))
+        {
+            drop(file);
+            let _ = self.kin_control.remove_file(&temporary);
+            return Err(error);
+        }
+        #[cfg(unix)]
+        let rename_result =
+            self.kin_control
+                .rename(&temporary, &self.kin_control, std::ffi::OsStr::new("HEAD"));
+        #[cfg(windows)]
+        let rename_result = replace_windows_file_handle_exact(
+            &file,
+            &self.kin_control,
+            std::ffi::OsStr::new("HEAD"),
+            true,
+        );
+        if let Err(error) = rename_result {
+            drop(file);
+            let _ = self.kin_control.remove_file(&temporary);
+            return Err(KinError::io(&display, error));
+        }
+        file.sync_all()
+            .map_err(|error| KinError::io(&display, error))?;
+        drop(file);
+        sync_directory_capability(&self.kin_control, &self.display_root.join(".kin"))
+    }
+
+    fn recover_pending_branch_transition(
+        &self,
+        transition: &BranchProjectionTransition,
+    ) -> Result<()> {
+        let current = self.read_branch_marker_capability()?;
+        if current == transition.previous_branch {
+            return Ok(());
+        }
+        if current != transition.target_branch {
+            return Err(KinError::Other(format!(
+                "branch-switch recovery refused to overwrite HEAD '{}': expected '{}' or '{}'",
+                current, transition.previous_branch, transition.target_branch
+            )));
+        }
+        self.write_branch_marker_capability(&transition.previous_branch)
+    }
+
+    fn validate_committed_branch_transition(
+        &self,
+        transition: &BranchProjectionTransition,
+    ) -> Result<()> {
+        let current = self.read_branch_marker_capability()?;
+        if current == transition.target_branch {
+            Ok(())
+        } else {
+            Err(KinError::Other(format!(
+                "committed branch-switch transaction expected HEAD '{}', found '{}'; refusing cleanup",
+                transition.target_branch, current
+            )))
+        }
+    }
+
+    fn authenticate_reconciliation_manifest(
+        &self,
+        manifest: &ReconciliationManifest,
+    ) -> Result<Vec<u8>> {
+        let encoded = serde_json::to_vec(manifest)
+            .map_err(|error| KinError::Other(format!("encode reconciliation manifest: {error}")))?;
+        Ok(reconciliation_hmac(&self.authority_key, &encoded).to_vec())
+    }
+
+    fn persist_reconciliation_manifest(
+        &self,
+        transaction: &ReconciliationTransaction,
+    ) -> Result<()> {
+        let mut descriptor = transaction.manifest.clone();
+        // Recovery actions live in the append-only authenticated WAL. Keeping
+        // the fixed descriptor action-free makes every phase update bounded,
+        // independent of repository size.
+        descriptor.actions.clear();
+        let authenticated = AuthenticatedReconciliationManifest {
+            authentication: self.authenticate_reconciliation_manifest(&descriptor)?,
+            manifest: descriptor,
+        };
+        let bytes = serde_json::to_vec(&authenticated).map_err(|error| {
+            KinError::Other(format!(
+                "encode authenticated reconciliation manifest: {error}"
+            ))
+        })?;
+        let temporary = OsString::from(format!(".manifest-{}.tmp", uuid::Uuid::new_v4()));
+        let display = self
+            .reconciliation_control_path()
+            .join(&transaction.name)
+            .join(RECONCILIATION_MANIFEST_FILE);
+        // Every step below reports the same manifest path; on Windows the control
+        // renames all funnel through one handle helper, so tag each operation so CI
+        // failure output identifies which step failed rather than only the path. Unix
+        // keeps the bare path so existing error-path expectations are unchanged.
+        #[cfg(windows)]
+        let step = |name: &str| -> PathBuf {
+            let mut raw = display.as_os_str().to_os_string();
+            raw.push(" [");
+            raw.push(name);
+            raw.push("]");
+            PathBuf::from(raw)
+        };
+        #[cfg(not(windows))]
+        let step = |_name: &str| -> PathBuf { display.clone() };
+        let mut options = cap_std::fs::OpenOptions::new();
+        options.write(true).create_new(true);
+        #[cfg(windows)]
+        {
+            use cap_std::fs::OpenOptionsExt;
+            use windows_sys::Win32::Foundation::{GENERIC_READ, GENERIC_WRITE};
+            use windows_sys::Win32::Storage::FileSystem::{
+                DELETE, FILE_SHARE_DELETE, FILE_SHARE_READ, FILE_SHARE_WRITE,
+            };
+
+            options
+                .access_mode(GENERIC_READ | GENERIC_WRITE | DELETE)
+                .share_mode(FILE_SHARE_READ | FILE_SHARE_WRITE | FILE_SHARE_DELETE);
+        }
+        let mut file = transaction
+            .directory
+            .open_with(&temporary, &options)
+            .map_err(|error| KinError::io(step("create-temp"), error))?;
+        #[cfg(unix)]
+        rustix::fs::fchmod(&file, rustix::fs::Mode::from_raw_mode(0o600))
+            .map_err(|error| KinError::io(&display, error.into()))?;
+        let write_result = file
+            .write_all(&bytes)
+            .and_then(|()| file.sync_all())
+            .map_err(|error| KinError::io(step("write-temp"), error));
+        if let Err(error) = write_result {
+            drop(file);
+            let _ = transaction.directory.remove_file(&temporary);
+            return Err(error);
+        }
+        #[cfg(unix)]
+        let publish = transaction.directory.rename(
+            &temporary,
+            &transaction.directory,
+            std::ffi::OsStr::new(RECONCILIATION_MANIFEST_FILE),
+        );
+        #[cfg(windows)]
+        let publish = replace_windows_file_handle_exact(
+            &file,
+            &transaction.directory,
+            std::ffi::OsStr::new(RECONCILIATION_MANIFEST_FILE),
+            true,
+        );
+        if let Err(error) = publish {
+            drop(file);
+            let _ = transaction.directory.remove_file(&temporary);
+            return Err(KinError::io(step("publish-rename"), error));
+        }
+        file.sync_all()
+            .map_err(|error| KinError::io(step("sync-final"), error))?;
+        drop(file);
+        sync_directory_capability(&transaction.directory, &display)?;
+        Ok(())
+    }
+
+    fn record_reconciliation_action(
+        &self,
+        transaction: &mut ReconciliationTransaction,
+        action: ReconciliationRecoveryAction,
+    ) -> Result<()> {
+        if transaction.manifest.actions.len() >= MAX_RECONCILIATION_ACTIONS {
+            return Err(KinError::Other(format!(
+                "exact-source reconciliation exceeds the bounded {}-action recovery log",
+                MAX_RECONCILIATION_ACTIONS
+            )));
+        }
+        let sequence = u64::try_from(transaction.manifest.actions.len()).map_err(|_| {
+            KinError::Other("exact-source recovery action sequence overflow".to_string())
+        })?;
+        let previous_authentication = transaction.action_tail_authentication.clone();
+        let authentication =
+            self.authenticate_reconciliation_action(sequence, &previous_authentication, &action)?;
+        let record = AuthenticatedReconciliationAction {
+            sequence,
+            previous_authentication,
+            action: action.clone(),
+            authentication: authentication.clone(),
+        };
+        let bytes = serde_json::to_vec(&record).map_err(|error| {
+            KinError::Other(format!(
+                "encode authenticated reconciliation action: {error}"
+            ))
+        })?;
+        let record_bytes = u64::try_from(bytes.len()).unwrap_or(u64::MAX);
+        if record_bytes > MAX_RECONCILIATION_ACTION_RECORD_BYTES
+            || transaction.action_log_bytes.saturating_add(record_bytes)
+                > MAX_RECONCILIATION_ACTION_LOG_BYTES
+        {
+            return Err(KinError::Other(format!(
+                "exact-source reconciliation action log exceeds its bounded {} MiB recovery limit",
+                MAX_RECONCILIATION_ACTION_LOG_BYTES / (1024 * 1024)
+            )));
+        }
+
+        let name = format!("{RECONCILIATION_ACTION_FILE_PREFIX}{sequence:020}.json");
+        let temporary = OsString::from(format!(".action-{}.tmp", uuid::Uuid::new_v4()));
+        let display = self
+            .reconciliation_control_path()
+            .join(&transaction.name)
+            .join(&name);
+        let mut options = cap_std::fs::OpenOptions::new();
+        options.write(true).create_new(true);
+        let mut file = transaction
+            .directory
+            .open_with(&temporary, &options)
+            .map_err(|error| KinError::io(&display, error))?;
+        #[cfg(unix)]
+        rustix::fs::fchmod(&file, rustix::fs::Mode::from_raw_mode(0o600))
+            .map_err(|error| KinError::io(&display, error.into()))?;
+        if let Err(error) = file
+            .write_all(&bytes)
+            .and_then(|()| file.sync_all())
+            .map_err(|error| KinError::io(&display, error))
+        {
+            drop(file);
+            let _ = transaction.directory.remove_file(&temporary);
+            return Err(error);
+        }
+        if let Err(error) = transaction
+            .directory
+            .hard_link(&temporary, &transaction.directory, &name)
+            .map_err(|error| KinError::io(&display, error))
+        {
+            drop(file);
+            let _ = transaction.directory.remove_file(&temporary);
+            return Err(error);
+        }
+        file.sync_all()
+            .map_err(|error| KinError::io(&display, error))?;
+        sync_directory_capability(&transaction.directory, &display)?;
+        transaction
+            .directory
+            .remove_file(&temporary)
+            .map_err(|error| KinError::io(&display, error))?;
+        sync_directory_capability(&transaction.directory, &display)?;
+
+        transaction.manifest.actions.push(action);
+        transaction.action_log_bytes += record_bytes;
+        transaction.action_tail_authentication = authentication;
+        Ok(())
+    }
+
+    fn authenticate_reconciliation_action(
+        &self,
+        sequence: u64,
+        previous_authentication: &[u8],
+        action: &ReconciliationRecoveryAction,
+    ) -> Result<Vec<u8>> {
+        let encoded =
+            serde_json::to_vec(&(sequence, previous_authentication, action)).map_err(|error| {
+                KinError::Other(format!("encode reconciliation action payload: {error}"))
+            })?;
+        Ok(reconciliation_hmac(&self.authority_key, &encoded).to_vec())
+    }
+
+    fn load_reconciliation_manifest(
+        &self,
+        transaction_name: &std::ffi::OsStr,
+        directory: &cap_std::fs::Dir,
+    ) -> Result<Option<ReconciliationManifest>> {
+        let display = self
+            .reconciliation_control_path()
+            .join(transaction_name)
+            .join(RECONCILIATION_MANIFEST_FILE);
+        let file = match open_reconciliation_control_file(
+            directory,
+            std::ffi::OsStr::new(RECONCILIATION_MANIFEST_FILE),
+        ) {
+            Ok(file) => file,
+            Err(error) if error.kind() == std::io::ErrorKind::NotFound => return Ok(None),
+            Err(error) => return Err(KinError::io(&display, error)),
+        };
+        let metadata = file
+            .metadata()
+            .map_err(|error| KinError::io(&display, error))?;
+        if !metadata.is_file() || metadata.len() > 4 * 1024 * 1024 {
+            return Err(KinError::Other(format!(
+                "reconciliation manifest {} is not a bounded regular file",
+                display.display()
+            )));
+        }
+        let mut bytes = Vec::new();
+        file.take(4 * 1024 * 1024 + 1)
+            .read_to_end(&mut bytes)
+            .map_err(|error| KinError::io(&display, error))?;
+        if bytes.len() > 4 * 1024 * 1024 {
+            return Err(KinError::Other(format!(
+                "reconciliation manifest {} exceeds 4 MiB",
+                display.display()
+            )));
+        }
+        let authenticated: AuthenticatedReconciliationManifest = serde_json::from_slice(&bytes)
+            .map_err(|error| {
+                KinError::Other(format!(
+                    "decode reconciliation manifest {}: {error}",
+                    display.display()
+                ))
+            })?;
+        let encoded = serde_json::to_vec(&authenticated.manifest)
+            .map_err(|error| KinError::Other(format!("encode reconciliation manifest: {error}")))?;
+        let expected = reconciliation_hmac(&self.authority_key, &encoded);
+        let authentication_valid = authenticated.authentication.len() == expected.len()
+            && authenticated
+                .authentication
+                .iter()
+                .zip(expected)
+                .fold(0_u8, |difference, (actual, expected)| {
+                    difference | (*actual ^ expected)
+                })
+                == 0;
+        if !authentication_valid {
+            return Err(KinError::Other(format!(
+                "reconciliation manifest {} failed authentication",
+                display.display()
+            )));
+        }
+        Ok(Some(authenticated.manifest))
+    }
+
+    fn load_reconciliation_actions(
+        &self,
+        transaction_name: &std::ffi::OsStr,
+        directory: &cap_std::fs::Dir,
+    ) -> Result<(Vec<ReconciliationRecoveryAction>, u64, Vec<u8>)> {
+        let mut names = Vec::new();
+        for entry in directory.entries().map_err(|error| {
+            KinError::io(
+                self.reconciliation_control_path().join(transaction_name),
+                error,
+            )
+        })? {
+            let entry = entry.map_err(|error| {
+                KinError::io(
+                    self.reconciliation_control_path().join(transaction_name),
+                    error,
+                )
+            })?;
+            let name = entry.file_name();
+            if name.to_str().is_some_and(|name| {
+                name.starts_with(RECONCILIATION_ACTION_FILE_PREFIX) && name.ends_with(".json")
+            }) {
+                names.push(name);
+            }
+        }
+        names.sort();
+        if names.len() > MAX_RECONCILIATION_ACTIONS {
+            return Err(KinError::Other(format!(
+                "reconciliation transaction {} exceeds the bounded action count",
+                self.reconciliation_control_path()
+                    .join(transaction_name)
+                    .display()
+            )));
+        }
+
+        let mut actions = Vec::with_capacity(names.len());
+        let mut total_bytes = 0_u64;
+        let mut tail = Vec::new();
+        for (index, name) in names.into_iter().enumerate() {
+            let expected_name = format!("{RECONCILIATION_ACTION_FILE_PREFIX}{index:020}.json");
+            if name != std::ffi::OsStr::new(&expected_name) {
+                return Err(KinError::Other(format!(
+                    "reconciliation action log {} is not contiguous at sequence {}",
+                    self.reconciliation_control_path()
+                        .join(transaction_name)
+                        .display(),
+                    index
+                )));
+            }
+            let display = self
+                .reconciliation_control_path()
+                .join(transaction_name)
+                .join(&name);
+            let file = open_reconciliation_control_file(directory, &name)
+                .map_err(|error| KinError::io(&display, error))?;
+            let metadata = file
+                .metadata()
+                .map_err(|error| KinError::io(&display, error))?;
+            if !metadata.is_file() || metadata.len() > MAX_RECONCILIATION_ACTION_RECORD_BYTES {
+                return Err(KinError::Other(format!(
+                    "reconciliation action {} is not a bounded regular file",
+                    display.display()
+                )));
+            }
+            total_bytes = total_bytes.saturating_add(metadata.len());
+            if total_bytes > MAX_RECONCILIATION_ACTION_LOG_BYTES {
+                return Err(KinError::Other(format!(
+                    "reconciliation action log {} exceeds {} MiB",
+                    self.reconciliation_control_path()
+                        .join(transaction_name)
+                        .display(),
+                    MAX_RECONCILIATION_ACTION_LOG_BYTES / (1024 * 1024)
+                )));
+            }
+            let mut bytes = Vec::new();
+            file.take(MAX_RECONCILIATION_ACTION_RECORD_BYTES + 1)
+                .read_to_end(&mut bytes)
+                .map_err(|error| KinError::io(&display, error))?;
+            if u64::try_from(bytes.len()).unwrap_or(u64::MAX)
+                > MAX_RECONCILIATION_ACTION_RECORD_BYTES
+            {
+                return Err(KinError::Other(format!(
+                    "reconciliation action {} exceeds its record bound",
+                    display.display()
+                )));
+            }
+            let record: AuthenticatedReconciliationAction = serde_json::from_slice(&bytes)
+                .map_err(|error| {
+                    KinError::Other(format!(
+                        "decode reconciliation action {}: {error}",
+                        display.display()
+                    ))
+                })?;
+            if record.sequence != index as u64 || record.previous_authentication != tail {
+                return Err(KinError::Other(format!(
+                    "reconciliation action {} broke the authenticated sequence chain",
+                    display.display()
+                )));
+            }
+            let expected = self.authenticate_reconciliation_action(
+                record.sequence,
+                &record.previous_authentication,
+                &record.action,
+            )?;
+            let authentication_valid = record.authentication.len() == expected.len()
+                && record
+                    .authentication
+                    .iter()
+                    .zip(&expected)
+                    .fold(0_u8, |difference, (actual, expected)| {
+                        difference | (*actual ^ *expected)
+                    })
+                    == 0;
+            if !authentication_valid {
+                return Err(KinError::Other(format!(
+                    "reconciliation action {} failed authentication",
+                    display.display()
+                )));
+            }
+            tail = record.authentication;
+            actions.push(record.action);
+        }
+        Ok((actions, total_bytes, tail))
+    }
+
+    fn recover_reconciliation_transactions(&self) -> Result<()> {
+        self.revalidate_projection_lock()?;
+        let root_identity = tracked_open_directory_identity(&self.root)
+            .map_err(|error| KinError::io(&self.display_root, error))?;
+        let mut transactions = Vec::new();
+        let entries = self
+            .control
+            .entries()
+            .map_err(|error| KinError::io(self.reconciliation_control_path(), error))?;
+        for entry in entries {
+            let entry =
+                entry.map_err(|error| KinError::io(self.reconciliation_control_path(), error))?;
+            let name = entry.file_name();
+            let Some(name_text) = name.to_str() else {
+                continue;
+            };
+            if !name_text.starts_with("tx-") {
+                continue;
+            }
+            transactions.push(name);
+        }
+        transactions.sort();
+
+        for name in transactions {
+            let directory =
+                open_directory_nofollow_for_removal(&self.control, &name).map_err(|error| {
+                    KinError::io(self.reconciliation_control_path().join(&name), error)
+                })?;
+            let identity = tracked_open_directory_identity(&directory).map_err(|error| {
+                KinError::io(self.reconciliation_control_path().join(&name), error)
+            })?;
+            let manifest = match self.load_reconciliation_manifest(&name, &directory)? {
+                Some(manifest) => manifest,
+                None => {
+                    let transaction = ReconciliationTransaction {
+                        name,
+                        directory,
+                        identity,
+                        manifest: ReconciliationManifest {
+                            schema: RECONCILIATION_MANIFEST_SCHEMA,
+                            transaction_id: String::new(),
+                            root_identity,
+                            kin_control_identity: self.kin_control_identity,
+                            control_identity: self.control_identity,
+                            transaction_identity: identity,
+                            state: ReconciliationTransactionState::Pending,
+                            branch_transition: None,
+                            actions: Vec::new(),
+                        },
+                        action_log_bytes: 0,
+                        action_tail_authentication: Vec::new(),
+                    };
+                    self.cleanup_reconciliation_transaction(transaction)?;
+                    continue;
+                }
+            };
+            let expected_name = format!("tx-{}", manifest.transaction_id);
+            if manifest.schema != RECONCILIATION_MANIFEST_SCHEMA
+                || name != std::ffi::OsStr::new(&expected_name)
+                || manifest.root_identity != root_identity
+                || manifest.kin_control_identity != self.kin_control_identity
+                || manifest.control_identity != self.control_identity
+                || manifest.transaction_identity != identity
+            {
+                return Err(KinError::Other(format!(
+                    "reconciliation transaction {} has an invalid identity-bound descriptor",
+                    self.reconciliation_control_path().join(&name).display()
+                )));
+            }
+            if !manifest.actions.is_empty() {
+                return Err(KinError::Other(format!(
+                    "reconciliation transaction {} embedded actions in its fixed descriptor",
+                    self.reconciliation_control_path().join(&name).display()
+                )));
+            }
+            if manifest.state == ReconciliationTransactionState::Committed {
+                if let Some(transition) = &manifest.branch_transition {
+                    self.validate_committed_branch_transition(transition)?;
+                }
+                let transaction = ReconciliationTransaction {
+                    name,
+                    directory,
+                    identity,
+                    manifest,
+                    action_log_bytes: 0,
+                    action_tail_authentication: Vec::new(),
+                };
+                self.cleanup_reconciliation_transaction(transaction)?;
+                continue;
+            }
+            let (actions, action_log_bytes, action_tail_authentication) =
+                self.load_reconciliation_actions(&name, &directory)?;
+            let mut manifest = manifest;
+            manifest.actions = actions;
+            let transaction = ReconciliationTransaction {
+                name,
+                directory,
+                identity,
+                manifest,
+                action_log_bytes,
+                action_tail_authentication,
+            };
+            self.rollback_reconciliation_manifest(&transaction)?;
+            self.cleanup_reconciliation_transaction(transaction)?;
+        }
+        Ok(())
+    }
+
+    fn rollback_reconciliation_manifest(
+        &self,
+        transaction: &ReconciliationTransaction,
+    ) -> Result<()> {
+        let mut failures = Vec::new();
+
+        for (index, action) in transaction.manifest.actions.iter().enumerate().rev() {
+            if let ReconciliationRecoveryAction::PublishObject {
+                relative,
+                kind,
+                identity,
+                state,
+                slot,
+            } = action
+            {
+                if let Err(error) = self.recover_published_object(
+                    transaction,
+                    relative,
+                    *kind,
+                    *identity,
+                    *state,
+                    slot,
+                    index,
+                ) {
+                    failures.push(error.to_string());
+                }
+            }
+        }
+
+        let mut published_directories: Vec<_> = transaction
+            .manifest
+            .actions
+            .iter()
+            .enumerate()
+            .filter_map(|(index, action)| match action {
+                ReconciliationRecoveryAction::PublishDirectory {
+                    relative,
+                    identity,
+                    slot,
+                } => Some((index, relative, identity, slot)),
+                _ => None,
+            })
+            .collect();
+        published_directories.sort_by(|left, right| {
+            right
+                .1
+                .components()
+                .count()
+                .cmp(&left.1.components().count())
+                .then_with(|| left.1.cmp(right.1))
+        });
+        for (index, relative, identity, slot) in published_directories {
+            if let Err(error) =
+                self.recover_published_directory(transaction, relative, *identity, slot, index)
+            {
+                failures.push(error.to_string());
+            }
+        }
+
+        let mut backed_directories: Vec<_> = transaction
+            .manifest
+            .actions
+            .iter()
+            .filter_map(|action| match action {
+                ReconciliationRecoveryAction::BackupDirectory {
+                    relative,
+                    identity,
+                    slot,
+                } => Some((relative, identity, slot)),
+                _ => None,
+            })
+            .collect();
+        backed_directories.sort_by(|left, right| {
+            left.0
+                .components()
+                .count()
+                .cmp(&right.0.components().count())
+                .then_with(|| left.0.cmp(right.0))
+        });
+        for (relative, identity, slot) in backed_directories {
+            if let Err(error) =
+                self.recover_backed_directory(transaction, relative, *identity, slot)
+            {
+                failures.push(error.to_string());
+            }
+        }
+
+        let mut backed_objects: Vec<_> = transaction
+            .manifest
+            .actions
+            .iter()
+            .filter_map(|action| match action {
+                ReconciliationRecoveryAction::BackupObject {
+                    relative,
+                    kind,
+                    identity,
+                    state,
+                    slot,
+                } => Some((relative, kind, identity, state, slot)),
+                _ => None,
+            })
+            .collect();
+        backed_objects.sort_by(|left, right| {
+            left.0
+                .components()
+                .count()
+                .cmp(&right.0.components().count())
+                .then_with(|| left.0.cmp(right.0))
+        });
+        for (relative, kind, identity, state, slot) in backed_objects {
+            if let Err(error) =
+                self.recover_backed_object(transaction, relative, *kind, *identity, *state, slot)
+            {
+                failures.push(error.to_string());
+            }
+        }
+
+        if let Some(transition) = &transaction.manifest.branch_transition {
+            if let Err(error) = self.recover_pending_branch_transition(transition) {
+                failures.push(error.to_string());
+            }
+        }
+
+        if failures.is_empty() {
+            Ok(())
+        } else {
+            Err(KinError::Other(format!(
+                "exact-source startup recovery failed for {}: {}",
+                self.reconciliation_control_path()
+                    .join(&transaction.name)
+                    .display(),
+                failures.join("; ")
+            )))
+        }
+    }
+
+    fn optional_existing_object_inspection(
+        &self,
+        parent: &cap_std::fs::Dir,
+        name: &std::ffi::OsStr,
+        kind: ExistingObjectKind,
+        display: &Path,
+    ) -> Result<Option<(TrackedEntryIdentity, TrackedObjectState)>> {
+        match parent.symlink_metadata(name) {
+            Ok(_) => self
+                .inspect_named_existing_object(parent, name, kind, display)
+                .map(Some),
+            Err(error) if error.kind() == std::io::ErrorKind::NotFound => Ok(None),
+            Err(error) => Err(KinError::io(display, error)),
+        }
+    }
+
+    fn require_recovery_object_state(
+        &self,
+        actual: Option<(TrackedEntryIdentity, TrackedObjectState)>,
+        expected_identity: TrackedEntryIdentity,
+        expected_state: TrackedObjectState,
+        display: &Path,
+        location: &str,
+    ) -> Result<bool> {
+        match actual {
+            Some((identity, state)) if identity == expected_identity && state == expected_state => {
+                Ok(true)
+            }
+            Some((identity, state)) if identity == expected_identity => Err(KinError::Other(
+                format!(
+                    "exact-source recovery refused to overwrite {}: the identity-bound {} changed content or mode after the crash (expected {:?}, found {:?})",
+                    display.display(),
+                    location,
+                    expected_state,
+                    state
+                ),
+            )),
+            _ => Ok(false),
+        }
+    }
+
+    fn optional_directory_identity(
+        &self,
+        parent: &cap_std::fs::Dir,
+        name: &std::ffi::OsStr,
+        display: &Path,
+    ) -> Result<Option<TrackedEntryIdentity>> {
+        match parent.symlink_metadata(name) {
+            Err(error) if error.kind() == std::io::ErrorKind::NotFound => Ok(None),
+            Err(error) => Err(KinError::io(display, error)),
+            Ok(metadata) if metadata.is_dir() && !metadata_is_reparse(&metadata) => {
+                // Read-only identity probe: the handle only reads its directory
+                // identity and is dropped, so it must not request DELETE access.
+                let directory = open_directory_nofollow(parent, name)
+                    .map_err(|error| KinError::io(display, error))?;
+                tracked_open_directory_identity(&directory)
+                    .map(Some)
+                    .map_err(|error| KinError::io(display, error))
+            }
+            Ok(_) => Err(KinError::Other(format!(
+                "exact-source recovery path {} changed into a non-directory",
+                display.display()
+            ))),
+        }
+    }
+
+    fn recover_published_object(
+        &self,
+        transaction: &ReconciliationTransaction,
+        relative: &Path,
+        kind: ExistingObjectKind,
+        identity: TrackedEntryIdentity,
+        state: TrackedObjectState,
+        slot: &str,
+        action_index: usize,
+    ) -> Result<()> {
+        let path = relative
+            .to_str()
+            .ok_or_else(|| KinError::Other(format!("recovery path is not UTF-8: {relative:?}")))?;
+        let components = validate_source_path(path)?;
+        let parent = self.open_existing_parent(&components)?;
+        let source_name = std::ffi::OsStr::new(components[components.len() - 1]);
+        let display = self.display_root.join(relative);
+        let root =
+            self.optional_existing_object_inspection(&parent, source_name, kind, &display)?;
+        if self.require_recovery_object_state(
+            root,
+            identity,
+            state,
+            &display,
+            "published object",
+        )? {
+            let discard = format!("recovery-discard-object-{action_index}");
+            self.move_existing_object_exact(
+                NamedEntryLocation {
+                    parent: &parent,
+                    name: source_name,
+                },
+                NamedEntryLocation {
+                    parent: &transaction.directory,
+                    name: std::ffi::OsStr::new(&discard),
+                },
+                kind,
+                identity,
+                state,
+                &display,
+            )?;
+            return Ok(());
+        }
+        let staged = self.optional_existing_object_inspection(
+            &transaction.directory,
+            std::ffi::OsStr::new(slot),
+            kind,
+            &display,
+        )?;
+        let discard = format!("recovery-discard-object-{action_index}");
+        let discarded = self.optional_existing_object_inspection(
+            &transaction.directory,
+            std::ffi::OsStr::new(&discard),
+            kind,
+            &display,
+        )?;
+        if self.require_recovery_object_state(staged, identity, state, &display, "staged object")?
+            || self.require_recovery_object_state(
+                discarded,
+                identity,
+                state,
+                &display,
+                "discarded object",
+            )?
+        {
+            return Ok(());
+        }
+        Err(KinError::Other(format!(
+            "published exact-source object {} is not recoverably attached to its root or transaction",
+            display.display()
+        )))
+    }
+
+    fn recover_published_directory(
+        &self,
+        transaction: &ReconciliationTransaction,
+        relative: &Path,
+        identity: TrackedEntryIdentity,
+        slot: &str,
+        action_index: usize,
+    ) -> Result<()> {
+        let path = relative
+            .to_str()
+            .ok_or_else(|| KinError::Other(format!("recovery path is not UTF-8: {relative:?}")))?;
+        let components = validate_source_path(path)?;
+        let parent = self.open_existing_parent(&components)?;
+        let source_name = std::ffi::OsStr::new(components[components.len() - 1]);
+        let display = self.display_root.join(relative);
+        if self.optional_directory_identity(&parent, source_name, &display)? == Some(identity) {
+            let directory = open_directory_nofollow_for_removal(&parent, source_name)
+                .map_err(|error| KinError::io(&display, error))?;
+            let discard = OsString::from(format!("recovery-discard-directory-{action_index}"));
+            self.move_open_directory_exact(
+                NamedEntryLocation {
+                    parent: &parent,
+                    name: source_name,
+                },
+                NamedEntryLocation {
+                    parent: &transaction.directory,
+                    name: &discard,
+                },
+                &directory,
+                identity,
+                &display,
+            )?;
+            return Ok(());
+        }
+        let staged = self.optional_directory_identity(
+            &transaction.directory,
+            std::ffi::OsStr::new(slot),
+            &display,
+        )?;
+        let discard = OsString::from(format!("recovery-discard-directory-{action_index}"));
+        let discarded =
+            self.optional_directory_identity(&transaction.directory, &discard, &display)?;
+        if staged == Some(identity) || discarded == Some(identity) {
+            return Ok(());
+        }
+        Err(KinError::Other(format!(
+            "published exact-source directory {} is not recoverably attached to its root or transaction",
+            display.display()
+        )))
+    }
+
+    fn recover_backed_directory(
+        &self,
+        transaction: &ReconciliationTransaction,
+        relative: &Path,
+        identity: TrackedEntryIdentity,
+        slot: &str,
+    ) -> Result<()> {
+        let path = relative
+            .to_str()
+            .ok_or_else(|| KinError::Other(format!("recovery path is not UTF-8: {relative:?}")))?;
+        let components = validate_source_path(path)?;
+        let parent = self.open_existing_parent(&components)?;
+        let destination_name = std::ffi::OsStr::new(components[components.len() - 1]);
+        let display = self.display_root.join(relative);
+        if self.optional_directory_identity(&parent, destination_name, &display)? == Some(identity)
+        {
+            return Ok(());
+        }
+        if self.optional_directory_identity(
+            &transaction.directory,
+            std::ffi::OsStr::new(slot),
+            &display,
+        )? != Some(identity)
+        {
+            return Err(KinError::Other(format!(
+                "backed-up exact-source directory {} is missing from its authenticated transaction slot",
+                display.display()
+            )));
+        }
+        let directory =
+            open_directory_nofollow_for_removal(&transaction.directory, std::ffi::OsStr::new(slot))
+                .map_err(|error| KinError::io(&display, error))?;
+        self.move_open_directory_exact(
+            NamedEntryLocation {
+                parent: &transaction.directory,
+                name: std::ffi::OsStr::new(slot),
+            },
+            NamedEntryLocation {
+                parent: &parent,
+                name: destination_name,
+            },
+            &directory,
+            identity,
+            &display,
+        )
+    }
+
+    fn recover_backed_object(
+        &self,
+        transaction: &ReconciliationTransaction,
+        relative: &Path,
+        kind: ExistingObjectKind,
+        identity: TrackedEntryIdentity,
+        state: TrackedObjectState,
+        slot: &str,
+    ) -> Result<()> {
+        let path = relative
+            .to_str()
+            .ok_or_else(|| KinError::Other(format!("recovery path is not UTF-8: {relative:?}")))?;
+        let components = validate_source_path(path)?;
+        let parent = self.open_existing_parent(&components)?;
+        let destination_name = std::ffi::OsStr::new(components[components.len() - 1]);
+        let display = self.display_root.join(relative);
+        let root =
+            self.optional_existing_object_inspection(&parent, destination_name, kind, &display)?;
+        if self.require_recovery_object_state(root, identity, state, &display, "restored object")? {
+            return Ok(());
+        }
+        let staged = self.optional_existing_object_inspection(
+            &transaction.directory,
+            std::ffi::OsStr::new(slot),
+            kind,
+            &display,
+        )?;
+        if !self.require_recovery_object_state(
+            staged,
+            identity,
+            state,
+            &display,
+            "backed-up object",
+        )? {
+            return Err(KinError::Other(format!(
+                "backed-up exact-source object {} is missing from its authenticated transaction slot",
+                display.display()
+            )));
+        }
+        self.move_existing_object_exact(
+            NamedEntryLocation {
+                parent: &transaction.directory,
+                name: std::ffi::OsStr::new(slot),
+            },
+            NamedEntryLocation {
+                parent: &parent,
+                name: destination_name,
+            },
+            kind,
+            identity,
+            state,
+            &display,
+        )
+    }
+
+    fn plan_full_replacement(
+        &self,
+        tracked: &TrackedPathClassifier,
+        should_preserve: Option<&dyn Fn(&Path) -> bool>,
+    ) -> Result<FullReplacementPlan> {
+        let mut plan = FullReplacementPlan {
+            objects: Vec::new(),
+            directories: Vec::new(),
+        };
+        self.plan_full_replacement_from(
+            &self.root,
+            Path::new(""),
+            tracked,
+            should_preserve,
+            false,
+            &mut plan,
+        )?;
+        plan.objects.sort_by(|left, right| {
+            right
+                .relative
+                .components()
+                .count()
+                .cmp(&left.relative.components().count())
+                .then_with(|| left.relative.cmp(&right.relative))
+        });
+        plan.directories.sort_by(|left, right| {
+            right
+                .0
+                .components()
+                .count()
+                .cmp(&left.0.components().count())
+                .then_with(|| left.0.cmp(&right.0))
+        });
+        Ok(plan)
+    }
+
+    fn plan_full_replacement_from(
+        &self,
+        current: &cap_std::fs::Dir,
+        relative_directory: &Path,
+        tracked: &TrackedPathClassifier,
+        should_preserve: Option<&dyn Fn(&Path) -> bool>,
+        force_remove: bool,
+        plan: &mut FullReplacementPlan,
+    ) -> Result<bool> {
+        let entries = current
+            .entries()
+            .map_err(|error| KinError::io(self.display_root.join(relative_directory), error))?;
+        let mut all_children_removed = true;
+        for entry in entries {
+            let entry = entry
+                .map_err(|error| KinError::io(self.display_root.join(relative_directory), error))?;
+            let name = entry.file_name();
+            let relative = relative_directory.join(&name);
+            if relative_directory.as_os_str().is_empty()
+                && name
+                    .to_str()
+                    .is_some_and(|component| component.eq_ignore_ascii_case(".kin"))
+            {
+                all_children_removed = false;
+                continue;
+            }
+            let relation = tracked.relation(&relative);
+            let preserved_unrelated = relation == TrackedPathRelation::Unrelated
+                && should_preserve.is_some_and(|preserve| preserve(&relative));
+            let cleanup_unrelated = relation == TrackedPathRelation::Unrelated
+                && should_preserve.is_some()
+                && !preserved_unrelated;
+            let metadata = current
+                .symlink_metadata(&name)
+                .map_err(|error| KinError::io(self.display_root.join(&relative), error))?;
+
+            if metadata.is_dir() && !metadata_is_reparse(&metadata) {
+                if preserved_unrelated && !force_remove {
+                    all_children_removed = false;
+                    continue;
+                }
+                if relation == TrackedPathRelation::Unrelated && !cleanup_unrelated && !force_remove
+                {
+                    all_children_removed = false;
+                    continue;
+                }
+                let directory =
+                    self.open_existing_directory_for_removal(current, &name, &relative)?;
+                let identity = tracked_open_directory_identity(&directory)
+                    .map_err(|error| KinError::io(self.display_root.join(&relative), error))?;
+                let remove_entire_directory = force_remove
+                    || matches!(
+                        relation,
+                        TrackedPathRelation::Exact | TrackedPathRelation::Descendant
+                    );
+                let children_removed = self.plan_full_replacement_from(
+                    &directory,
+                    &relative,
+                    tracked,
+                    should_preserve,
+                    remove_entire_directory,
+                    plan,
+                )?;
+                let remove_directory = remove_entire_directory
+                    || (cleanup_unrelated && children_removed)
+                    || (force_remove && children_removed);
+                if remove_directory {
+                    plan.directories.push((relative, identity));
+                } else {
+                    all_children_removed = false;
+                }
+                continue;
+            }
+
+            let remove_object =
+                force_remove || relation != TrackedPathRelation::Unrelated || cleanup_unrelated;
+            if !remove_object || (preserved_unrelated && !force_remove) {
+                all_children_removed = false;
+                continue;
+            }
+            let kind = if metadata_is_reparse(&metadata) {
+                ExistingObjectKind::Symlink
+            } else if metadata.is_file() {
+                ExistingObjectKind::File
+            } else {
+                return Err(KinError::Other(format!(
+                    "working-copy object {} has an unsupported kind for atomic exact-source replacement",
+                    self.display_root.join(&relative).display()
+                )));
+            };
+            let (identity, state) = self.inspect_named_existing_object(
+                current,
+                &name,
+                kind,
+                &self.display_root.join(&relative),
+            )?;
+            plan.objects.push(PlannedExistingObject {
+                relative,
+                kind,
+                identity,
+                state,
+            });
+        }
+        Ok(all_children_removed)
+    }
+
+    fn apply_full_replacement(
+        &self,
+        entries: &[ValidatedSourceEntry<'_>],
+        plan: FullReplacementPlan,
+    ) -> Result<()> {
+        let mut transaction = self.create_reconciliation_transaction()?;
+        let staged = match self.stage_reconciliation_entries(&transaction.directory, entries) {
+            Ok(staged) => staged,
+            Err(error) => {
+                return match self.cleanup_reconciliation_transaction(transaction) {
+                    Ok(()) => Err(error),
+                    Err(cleanup_error) => Err(KinError::Other(format!(
+                        "{error}; staged full-tree cleanup also failed: {cleanup_error}"
+                    ))),
+                };
+            }
+        };
+
+        let mut backed_directories = Vec::with_capacity(plan.directories.len());
+        let mut created_directories = Vec::new();
+        let mut next_object_backup = plan.objects.len();
+        let file_ids: Vec<_> = entries.iter().map(|entry| entry.file_id).collect();
+        let mutation_result: Result<()> = (|| {
+            for (name_index, object) in plan.objects.iter().enumerate() {
+                self.back_up_existing_object(&mut transaction, object, name_index)?;
+            }
+            for (relative, expected_identity) in &plan.directories {
+                let backup = self.back_up_planned_empty_directory(
+                    &mut transaction,
+                    relative,
+                    *expected_identity,
+                    backed_directories.len(),
+                )?;
+                backed_directories.push(backup);
+            }
+            self.prepare_full_replacement_transactional(
+                &mut transaction,
+                &file_ids,
+                &mut created_directories,
+                &mut next_object_backup,
+                &mut backed_directories,
+            )?;
+            for staged_entry in &staged {
+                self.publish_staged_entry(&mut transaction, staged_entry)?;
+            }
+            Ok(())
+        })();
+
+        if let Err(error) = mutation_result {
+            let rollback = self.rollback_reconciliation_manifest(&transaction);
+            return match rollback {
+                Ok(()) => match self.cleanup_reconciliation_transaction(transaction) {
+                    Ok(()) => Err(error),
+                    Err(cleanup_error) => Err(KinError::Other(format!(
+                        "{error}; full-tree rollback succeeded but transaction cleanup failed: {cleanup_error}"
+                    ))),
+                },
+                Err(rollback_error) => Err(KinError::Other(format!(
+                    "{error}; {rollback_error}; retained recovery transaction at {}",
+                    self.reconciliation_control_path()
+                        .join(&transaction.name)
+                        .display()
+                ))),
+            };
+        }
+
+        self.cleanup_reconciliation_transaction(transaction)
+    }
+
+    fn stage_reconciliation_entries<'a>(
+        &self,
+        transaction: &cap_std::fs::Dir,
+        entries: &[ValidatedSourceEntry<'a>],
+    ) -> Result<Vec<StagedReconciliationEntry<'a>>> {
+        let mut staged = Vec::with_capacity(entries.len());
+        for (name_index, entry) in entries.iter().copied().enumerate() {
+            let name = format!("stage-{name_index}");
+            let identity = self.stage_reconciliation_entry(transaction, &name, &entry)?;
+            let kind = match entry.kind {
+                SourceEntryKind::File { .. } => ExistingObjectKind::File,
+                SourceEntryKind::Symlink => ExistingObjectKind::Symlink,
+            };
+            let (inspected_identity, state) = self.inspect_named_existing_object(
+                transaction,
+                std::ffi::OsStr::new(&name),
+                kind,
+                &self.display_root.join(&entry.file_id.0),
+            )?;
+            if inspected_identity != identity {
+                return Err(KinError::Other(format!(
+                    "staged exact-source object {} changed identity before journaling",
+                    self.display_root.join(&entry.file_id.0).display()
+                )));
+            }
+            staged.push(StagedReconciliationEntry {
+                entry,
+                name_index,
+                identity,
+                state,
+            });
+        }
+        #[cfg(unix)]
+        rustix::fs::fsync(transaction)
+            .map_err(|error| KinError::io(&self.display_root, error.into()))?;
+        Ok(staged)
+    }
+
+    #[cfg(unix)]
+    fn stage_reconciliation_entry(
+        &self,
+        transaction: &cap_std::fs::Dir,
+        name: &str,
+        entry: &ValidatedSourceEntry<'_>,
+    ) -> Result<TrackedEntryIdentity> {
+        let display = self.display_root.join(&entry.file_id.0);
+        match entry.kind {
+            SourceEntryKind::File { executable } => {
+                let fd = rustix::fs::openat(
+                    transaction,
+                    name,
+                    rustix::fs::OFlags::RDWR
+                        | rustix::fs::OFlags::CREATE
+                        | rustix::fs::OFlags::EXCL
+                        | rustix::fs::OFlags::NOFOLLOW
+                        | rustix::fs::OFlags::CLOEXEC,
+                    rustix::fs::Mode::from_raw_mode(0o600),
+                )
+                .map_err(|error| KinError::io(&display, error.into()))?;
+                let mut file = std::fs::File::from(fd);
+                file.write_all(entry.content)
+                    .map_err(|error| KinError::io(&display, error))?;
+                rustix::fs::fchmod(
+                    &file,
+                    rustix::fs::Mode::from_raw_mode(if executable { 0o755 } else { 0o644 }),
+                )
+                .map_err(|error| KinError::io(&display, error.into()))?;
+                file.sync_all()
+                    .map_err(|error| KinError::io(&display, error))?;
+                let metadata = file
+                    .metadata()
+                    .map_err(|error| KinError::io(&display, error))?;
+                Ok(tracked_open_file_identity(&metadata))
+            }
+            SourceEntryKind::Symlink => {
+                let target =
+                    std::str::from_utf8(entry.content).expect("validated UTF-8 symlink target");
+                rustix::fs::symlinkat(target, transaction, name)
+                    .map_err(|error| KinError::io(&display, error.into()))?;
+                let metadata = transaction
+                    .symlink_metadata(name)
+                    .map_err(|error| KinError::io(&display, error))?;
+                Ok(tracked_entry_identity(&metadata))
             }
         }
     }
 
-    Ok(count)
+    #[cfg(windows)]
+    fn stage_reconciliation_entry(
+        &self,
+        transaction: &cap_std::fs::Dir,
+        name: &str,
+        entry: &ValidatedSourceEntry<'_>,
+    ) -> Result<TrackedEntryIdentity> {
+        use cap_fs_ext::{FollowSymlinks, OpenOptionsFollowExt};
+        use cap_std::fs::OpenOptionsExt;
+        use windows_sys::Win32::Foundation::{GENERIC_READ, GENERIC_WRITE};
+        use windows_sys::Win32::Storage::FileSystem::DELETE;
+
+        if entry.kind == SourceEntryKind::Symlink {
+            return Err(KinError::Other(
+                "safe exact symbolic-link checkout is unsupported on Windows".to_string(),
+            ));
+        }
+        let display = self.display_root.join(&entry.file_id.0);
+        let mut options = cap_std::fs::OpenOptions::new();
+        options
+            .read(true)
+            .write(true)
+            .create_new(true)
+            .access_mode(GENERIC_READ | GENERIC_WRITE | DELETE)
+            .follow(FollowSymlinks::No);
+        let mut file = transaction
+            .open_with(name, &options)
+            .map_err(|error| KinError::io(&display, error))?;
+        file.write_all(entry.content)
+            .map_err(|error| KinError::io(&display, error))?;
+        file.sync_all()
+            .map_err(|error| KinError::io(&display, error))?;
+        tracked_open_file_identity(&file).map_err(|error| KinError::io(&display, error))
+    }
+
+    fn prepare(&self, file_ids: &[&FilePathId]) -> Result<()> {
+        let mut paths: Vec<_> = file_ids
+            .iter()
+            .map(|file_id| validate_source_path(&file_id.0))
+            .collect::<Result<_>>()?;
+        paths.sort_unstable();
+
+        for components in &paths {
+            let mut parent = self.clone_root()?;
+            for component in &components[..components.len() - 1] {
+                parent = self.open_or_create_directory(&parent, component)?;
+            }
+        }
+
+        // A graph-owned file or link cannot be atomically renamed over a
+        // directory. Remove only those leaf directories, relative to held
+        // parent capabilities, before staging replacements.
+        for components in paths {
+            let parent = self.open_existing_parent(&components)?;
+            let name = components[components.len() - 1];
+            match parent.symlink_metadata(name) {
+                Ok(metadata) if metadata.is_dir() && !metadata_is_reparse(&metadata) => {
+                    self.remove_directory_tree(
+                        &parent,
+                        std::ffi::OsStr::new(name),
+                        Path::new(&components.join("/")),
+                    )?;
+                }
+                Ok(_) => {}
+                Err(error) if error.kind() == std::io::ErrorKind::NotFound => {}
+                Err(error) => {
+                    return Err(KinError::io(self.display_path(&components), error));
+                }
+            }
+        }
+        Ok(())
+    }
+
+    fn prepare_without_replacement_transactional(
+        &self,
+        transaction: &mut ReconciliationTransaction,
+        file_ids: &[&FilePathId],
+        created_directories: &mut Vec<PublishedDirectory>,
+    ) -> Result<()> {
+        let mut paths: Vec<_> = file_ids
+            .iter()
+            .map(|file_id| validate_source_path(&file_id.0))
+            .collect::<Result<_>>()?;
+        paths.sort_unstable();
+        for components in &paths {
+            let mut parent = self.clone_root()?;
+            let mut relative = PathBuf::new();
+            for component in &components[..components.len() - 1] {
+                relative.push(component);
+                parent = loop {
+                    match open_directory_nofollow(&parent, std::ffi::OsStr::new(component)) {
+                        Ok(directory) => break directory,
+                        Err(_) => match parent.symlink_metadata(component) {
+                            Err(error) if error.kind() == std::io::ErrorKind::NotFound => {
+                                let published = self.stage_and_publish_directory(
+                                    transaction,
+                                    &parent,
+                                    std::ffi::OsStr::new(component),
+                                    &relative,
+                                    created_directories.len(),
+                                )?;
+                                let directory =
+                                    published.directory.try_clone().map_err(|error| {
+                                        KinError::io(self.display_root.join(&relative), error)
+                                    })?;
+                                created_directories.push(published);
+                                break directory;
+                            }
+                            Ok(metadata)
+                                if metadata.is_dir() && !metadata_is_reparse(&metadata) =>
+                            {
+                                continue;
+                            }
+                            Ok(_) => {
+                                return Err(KinError::Other(format!(
+                                    "working-copy path {} changed into an untracked blocker during exact branch reconciliation",
+                                    self.display_root.join(&relative).display()
+                                )));
+                            }
+                            Err(error) => {
+                                return Err(KinError::io(self.display_root.join(&relative), error));
+                            }
+                        },
+                    }
+                };
+            }
+        }
+
+        for components in paths {
+            let parent = self.open_existing_parent(&components)?;
+            let name = components[components.len() - 1];
+            match parent.symlink_metadata(name) {
+                Ok(metadata) if metadata.is_dir() && !metadata_is_reparse(&metadata) => {
+                    return Err(KinError::Other(format!(
+                        "working-copy directory {} conflicts with an exact branch file",
+                        self.display_path(&components).display()
+                    )));
+                }
+                Ok(_) => {}
+                Err(error) if error.kind() == std::io::ErrorKind::NotFound => {}
+                Err(error) => return Err(KinError::io(self.display_path(&components), error)),
+            }
+        }
+        Ok(())
+    }
+
+    fn prepare_full_replacement_transactional(
+        &self,
+        transaction: &mut ReconciliationTransaction,
+        file_ids: &[&FilePathId],
+        created_directories: &mut Vec<PublishedDirectory>,
+        next_object_backup: &mut usize,
+        backed_directories: &mut Vec<BackedUpDirectory>,
+    ) -> Result<()> {
+        let mut paths: Vec<_> = file_ids
+            .iter()
+            .map(|file_id| validate_source_path(&file_id.0))
+            .collect::<Result<_>>()?;
+        paths.sort_unstable();
+        for components in &paths {
+            let mut parent = self.clone_root()?;
+            let mut relative = PathBuf::new();
+            for component in &components[..components.len() - 1] {
+                relative.push(component);
+                parent = loop {
+                    match open_directory_nofollow(&parent, std::ffi::OsStr::new(component)) {
+                        Ok(directory) => break directory,
+                        Err(_) => match parent.symlink_metadata(component) {
+                            Err(error) if error.kind() == std::io::ErrorKind::NotFound => {
+                                let published = self.stage_and_publish_directory(
+                                    transaction,
+                                    &parent,
+                                    std::ffi::OsStr::new(component),
+                                    &relative,
+                                    created_directories.len(),
+                                )?;
+                                let directory =
+                                    published.directory.try_clone().map_err(|error| {
+                                        KinError::io(self.display_root.join(&relative), error)
+                                    })?;
+                                created_directories.push(published);
+                                break directory;
+                            }
+                            Ok(metadata)
+                                if metadata.is_dir() && !metadata_is_reparse(&metadata) =>
+                            {
+                                continue;
+                            }
+                            Ok(metadata) => {
+                                let kind = if metadata_is_reparse(&metadata) {
+                                    ExistingObjectKind::Symlink
+                                } else if metadata.is_file() {
+                                    ExistingObjectKind::File
+                                } else {
+                                    return Err(KinError::Other(format!(
+                                        "working-copy object {} has an unsupported kind for atomic exact-source replacement",
+                                        self.display_root.join(&relative).display()
+                                    )));
+                                };
+                                let (identity, state) = self.inspect_named_existing_object(
+                                    &parent,
+                                    std::ffi::OsStr::new(component),
+                                    kind,
+                                    &self.display_root.join(&relative),
+                                )?;
+                                let object = PlannedExistingObject {
+                                    relative: relative.clone(),
+                                    kind,
+                                    identity,
+                                    state,
+                                };
+                                self.back_up_existing_object(
+                                    transaction,
+                                    &object,
+                                    *next_object_backup,
+                                )?;
+                                *next_object_backup += 1;
+                            }
+                            Err(error) => {
+                                return Err(KinError::io(self.display_root.join(&relative), error));
+                            }
+                        },
+                    }
+                };
+            }
+        }
+
+        for components in paths {
+            let parent = self.open_existing_parent(&components)?;
+            let name = components[components.len() - 1];
+            let relative = PathBuf::from(components.join("/"));
+            match parent.symlink_metadata(name) {
+                Ok(metadata) if metadata.is_dir() && !metadata_is_reparse(&metadata) => {
+                    backed_directories.push(self.back_up_directory(
+                        transaction,
+                        &relative,
+                        backed_directories.len(),
+                        false,
+                        None,
+                    )?);
+                }
+                Ok(_) => {}
+                Err(error) if error.kind() == std::io::ErrorKind::NotFound => {}
+                Err(error) => return Err(KinError::io(self.display_path(&components), error)),
+            }
+        }
+        Ok(())
+    }
+
+    fn validate_reconciliation_targets(
+        &self,
+        entries: &[ValidatedSourceEntry<'_>],
+        previous: &TrackedPathClassifier,
+        removed: &TrackedPathClassifier,
+    ) -> Result<()> {
+        for entry in entries {
+            let components = validate_source_path(&entry.file_id.0)?;
+            let mut parent = self.clone_root()?;
+            let mut relative = PathBuf::new();
+            let mut ancestor_missing_or_authorized = false;
+
+            for component in &components[..components.len() - 1] {
+                relative.push(component);
+                match parent.symlink_metadata(component) {
+                    Ok(metadata) if metadata.is_dir() && !metadata_is_reparse(&metadata) => {
+                        parent = self.open_existing_directory(
+                            &parent,
+                            std::ffi::OsStr::new(component),
+                            &relative,
+                        )?;
+                    }
+                    Ok(_) if removed.relation(&relative) == TrackedPathRelation::Exact => {
+                        ancestor_missing_or_authorized = true;
+                        break;
+                    }
+                    Ok(_) => {
+                        return Err(KinError::Other(format!(
+                            "untracked working-copy path {} blocks exact branch target {}",
+                            self.display_root.join(&relative).display(),
+                            entry.file_id.0
+                        )));
+                    }
+                    Err(error) if error.kind() == std::io::ErrorKind::NotFound => {
+                        ancestor_missing_or_authorized = true;
+                        break;
+                    }
+                    Err(error) => {
+                        return Err(KinError::io(self.display_root.join(&relative), error));
+                    }
+                }
+            }
+
+            if ancestor_missing_or_authorized {
+                continue;
+            }
+
+            relative.push(components[components.len() - 1]);
+            match parent.symlink_metadata(components[components.len() - 1]) {
+                Ok(metadata) if metadata.is_dir() && !metadata_is_reparse(&metadata) => {
+                    if previous.relation(&relative) != TrackedPathRelation::Ancestor
+                        || removed.relation(&relative) != TrackedPathRelation::Ancestor
+                    {
+                        return Err(KinError::Other(format!(
+                            "untracked working-copy directory {} conflicts with exact branch target {}",
+                            self.display_root.join(&relative).display(),
+                            entry.file_id.0
+                        )));
+                    }
+                    let directory = self.open_existing_directory(
+                        &parent,
+                        std::ffi::OsStr::new(components[components.len() - 1]),
+                        &relative,
+                    )?;
+                    self.validate_removable_directory_contents(&directory, &relative, removed)?;
+                }
+                Ok(_) if previous.relation(&relative) == TrackedPathRelation::Exact => {}
+                Ok(_) => {
+                    return Err(KinError::Other(format!(
+                        "untracked working-copy path {} conflicts with exact branch target {}",
+                        self.display_root.join(&relative).display(),
+                        entry.file_id.0
+                    )));
+                }
+                Err(error) if error.kind() == std::io::ErrorKind::NotFound => {}
+                Err(error) => {
+                    return Err(KinError::io(self.display_root.join(&relative), error));
+                }
+            }
+        }
+        Ok(())
+    }
+
+    fn validate_removable_directory_contents(
+        &self,
+        directory: &cap_std::fs::Dir,
+        relative_directory: &Path,
+        removed: &TrackedPathClassifier,
+    ) -> Result<()> {
+        let entries = directory
+            .entries()
+            .map_err(|error| KinError::io(self.display_root.join(relative_directory), error))?;
+        for entry in entries {
+            let entry = entry
+                .map_err(|error| KinError::io(self.display_root.join(relative_directory), error))?;
+            let name = entry.file_name();
+            let relative = relative_directory.join(&name);
+            let metadata = directory
+                .symlink_metadata(&name)
+                .map_err(|error| KinError::io(self.display_root.join(&relative), error))?;
+            if metadata.is_dir() && !metadata_is_reparse(&metadata) {
+                if removed.relation(&relative) != TrackedPathRelation::Ancestor {
+                    return Err(KinError::Other(format!(
+                        "untracked working-copy directory {} blocks exact branch reconciliation",
+                        self.display_root.join(&relative).display()
+                    )));
+                }
+                let child = self.open_existing_directory(directory, &name, &relative)?;
+                self.validate_removable_directory_contents(&child, &relative, removed)?;
+            } else if removed.relation(&relative) != TrackedPathRelation::Exact {
+                return Err(KinError::Other(format!(
+                    "untracked working-copy path {} blocks exact branch reconciliation",
+                    self.display_root.join(&relative).display()
+                )));
+            }
+        }
+        Ok(())
+    }
+
+    fn validate_tracked_entries_unchanged(
+        &self,
+        entries: &[&ValidatedSourceEntry<'_>],
+    ) -> Result<Vec<TrackedEntryIdentity>> {
+        entries
+            .iter()
+            .map(|entry| self.validate_tracked_entry_unchanged(entry))
+            .collect()
+    }
+
+    fn revalidate_tracked_entries_unchanged(
+        &self,
+        entries: &[&ValidatedSourceEntry<'_>],
+        expected_identities: &[TrackedEntryIdentity],
+    ) -> Result<()> {
+        if entries.len() != expected_identities.len() {
+            return Err(KinError::Other(
+                "exact branch reconciliation identity preflight is inconsistent".to_string(),
+            ));
+        }
+        for (entry, expected_identity) in entries.iter().zip(expected_identities) {
+            let actual_identity = self.validate_tracked_entry_unchanged(entry)?;
+            if actual_identity != *expected_identity {
+                return Err(KinError::Other(format!(
+                    "tracked working-copy path {} changed object identity after exact branch preflight; reconciliation refused",
+                    self.display_root.join(&entry.file_id.0).display()
+                )));
+            }
+        }
+        Ok(())
+    }
+
+    fn validate_named_source_entry(
+        &self,
+        parent: &cap_std::fs::Dir,
+        name: &std::ffi::OsStr,
+        entry: &ValidatedSourceEntry<'_>,
+        display: &Path,
+    ) -> Result<TrackedEntryIdentity> {
+        match entry.kind {
+            SourceEntryKind::File { executable } => {
+                #[cfg(unix)]
+                let mut file = rustix::fs::openat(
+                    parent,
+                    name,
+                    rustix::fs::OFlags::RDONLY
+                        | rustix::fs::OFlags::NOFOLLOW
+                        | rustix::fs::OFlags::CLOEXEC,
+                    rustix::fs::Mode::empty(),
+                )
+                .map(std::fs::File::from)
+                .map_err(|error| KinError::io(display, error.into()))?;
+                #[cfg(windows)]
+                let mut file = {
+                    use cap_fs_ext::{FollowSymlinks, OpenOptionsFollowExt};
+
+                    let mut options = cap_std::fs::OpenOptions::new();
+                    options.read(true).follow(FollowSymlinks::No);
+                    parent
+                        .open_with(name, &options)
+                        .map_err(|error| KinError::io(display, error))?
+                };
+                let metadata = file
+                    .metadata()
+                    .map_err(|error| KinError::io(display, error))?;
+                if !metadata.is_file() {
+                    return Err(KinError::Other(format!(
+                        "exact-source object {} changed kind",
+                        display.display()
+                    )));
+                }
+                #[cfg(windows)]
+                if metadata_is_reparse(&metadata) {
+                    return Err(KinError::Other(format!(
+                        "exact-source object {} became a reparse point",
+                        display.display()
+                    )));
+                }
+                #[cfg(unix)]
+                {
+                    use std::os::unix::fs::PermissionsExt;
+
+                    if (metadata.permissions().mode() & 0o111 != 0) != executable {
+                        return Err(KinError::Other(format!(
+                            "exact-source object {} changed executable mode",
+                            display.display()
+                        )));
+                    }
+                }
+                #[cfg(windows)]
+                let _ = executable;
+                if !reader_matches_bytes(&mut file, entry.content)
+                    .map_err(|error| KinError::io(display, error))?
+                {
+                    return Err(KinError::Other(format!(
+                        "exact-source object {} changed content",
+                        display.display()
+                    )));
+                }
+                #[cfg(unix)]
+                {
+                    Ok(tracked_open_file_identity(&metadata))
+                }
+                #[cfg(windows)]
+                {
+                    tracked_open_file_identity(&file).map_err(|error| KinError::io(display, error))
+                }
+            }
+            SourceEntryKind::Symlink => {
+                #[cfg(unix)]
+                {
+                    let metadata = parent
+                        .symlink_metadata(name)
+                        .map_err(|error| KinError::io(display, error))?;
+                    if !metadata_is_reparse(&metadata) {
+                        return Err(KinError::Other(format!(
+                            "exact-source object {} changed kind",
+                            display.display()
+                        )));
+                    }
+                    let target = rustix::fs::readlinkat(parent, name, Vec::new())
+                        .map_err(|error| KinError::io(display, error.into()))?;
+                    if target.as_bytes() != entry.content {
+                        return Err(KinError::Other(format!(
+                            "exact-source symbolic link {} changed target",
+                            display.display()
+                        )));
+                    }
+                    Ok(tracked_entry_identity(&metadata))
+                }
+                #[cfg(windows)]
+                {
+                    Err(KinError::Other(
+                        "safe exact symbolic-link checkout is unsupported on Windows".to_string(),
+                    ))
+                }
+            }
+        }
+    }
+
+    #[cfg(unix)]
+    fn move_named_entry_noreplace(
+        &self,
+        source_parent: &cap_std::fs::Dir,
+        source_name: &std::ffi::OsStr,
+        destination_parent: &cap_std::fs::Dir,
+        destination_name: &std::ffi::OsStr,
+    ) -> std::io::Result<()> {
+        rustix::fs::renameat_with(
+            source_parent,
+            source_name,
+            destination_parent,
+            destination_name,
+            rustix::fs::RenameFlags::NOREPLACE,
+        )
+        .map_err(Into::into)
+    }
+
+    #[cfg(windows)]
+    fn move_named_entry_noreplace(
+        &self,
+        source_parent: &cap_std::fs::Dir,
+        source_name: &std::ffi::OsStr,
+        destination_parent: &cap_std::fs::Dir,
+        destination_name: &std::ffi::OsStr,
+    ) -> std::io::Result<()> {
+        use cap_fs_ext::{FollowSymlinks, OpenOptionsFollowExt};
+        use cap_std::fs::OpenOptionsExt;
+        use windows_sys::Win32::Foundation::GENERIC_READ;
+        use windows_sys::Win32::Storage::FileSystem::{
+            DELETE, FILE_SHARE_DELETE, FILE_SHARE_READ, FILE_SHARE_WRITE,
+        };
+
+        let mut options = cap_std::fs::OpenOptions::new();
+        options
+            .access_mode(GENERIC_READ | DELETE)
+            .share_mode(FILE_SHARE_READ | FILE_SHARE_WRITE | FILE_SHARE_DELETE)
+            .follow(FollowSymlinks::No);
+        let source = source_parent.open_with(source_name, &options)?;
+        let metadata = source.metadata()?;
+        if metadata_is_reparse(&metadata) || !metadata.is_file() {
+            return Err(std::io::Error::other(
+                "exact-source displacement target changed kind",
+            ));
+        }
+        replace_windows_file_handle_exact(&source, destination_parent, destination_name, false)
+    }
+
+    #[cfg(unix)]
+    fn locate_open_directory(
+        &self,
+        directory: &cap_std::fs::Dir,
+        expected_identity: TrackedEntryIdentity,
+        display: &Path,
+    ) -> Result<(cap_std::fs::Dir, OsString)> {
+        let parent_fd = rustix::fs::openat(
+            directory,
+            std::path::Component::ParentDir.as_os_str(),
+            rustix::fs::OFlags::RDONLY
+                | rustix::fs::OFlags::DIRECTORY
+                | rustix::fs::OFlags::NOFOLLOW
+                | rustix::fs::OFlags::CLOEXEC,
+            rustix::fs::Mode::empty(),
+        )
+        .map(std::fs::File::from)
+        .map_err(|error| KinError::io(display, error.into()))?;
+        let parent = cap_std::fs::Dir::from_std_file(parent_fd);
+        let entries = parent
+            .entries()
+            .map_err(|error| KinError::io(display, error))?;
+        for entry in entries {
+            let entry = entry.map_err(|error| KinError::io(display, error))?;
+            let name = entry.file_name();
+            let metadata = match parent.symlink_metadata(&name) {
+                Ok(metadata) => metadata,
+                Err(error) if error.kind() == std::io::ErrorKind::NotFound => continue,
+                Err(error) => return Err(KinError::io(display, error)),
+            };
+            if metadata.is_dir()
+                && !metadata_is_reparse(&metadata)
+                && tracked_entry_identity(&metadata) == expected_identity
+            {
+                return Ok((parent, name));
+            }
+        }
+        Err(KinError::Other(format!(
+            "retained exact-source directory {} is no longer linked from its actual parent",
+            display.display()
+        )))
+    }
+
+    fn move_open_directory_exact(
+        &self,
+        source: NamedEntryLocation<'_>,
+        destination: NamedEntryLocation<'_>,
+        directory: &cap_std::fs::Dir,
+        expected_identity: TrackedEntryIdentity,
+        display: &Path,
+    ) -> Result<()> {
+        #[cfg(unix)]
+        let _ = source;
+        let retained_identity = tracked_open_directory_identity(directory)
+            .map_err(|error| KinError::io(display, error))?;
+        if retained_identity != expected_identity {
+            return Err(KinError::Other(format!(
+                "retained exact-source directory identity changed for {}",
+                display.display()
+            )));
+        }
+
+        #[cfg(unix)]
+        let (restore_parent, restore_name) =
+            self.locate_open_directory(directory, expected_identity, display)?;
+        #[cfg(windows)]
+        let (restore_parent, restore_name) = (
+            source
+                .parent
+                .try_clone()
+                .map_err(|error| KinError::io(display, error))?,
+            source.name.to_os_string(),
+        );
+
+        #[cfg(unix)]
+        rustix::fs::renameat_with(
+            &restore_parent,
+            &restore_name,
+            destination.parent,
+            destination.name,
+            rustix::fs::RenameFlags::NOREPLACE,
+        )
+        .map_err(|error| KinError::io(display, error.into()))?;
+        #[cfg(windows)]
+        replace_windows_directory_handle_exact(
+            directory,
+            destination.parent,
+            destination.name,
+            false,
+        )
+        .map_err(|error| KinError::io(display, error))?;
+        sync_namespace_parents(&restore_parent, display, destination.parent, display)?;
+
+        let destination_validation = (|| {
+            // Read-only identity check: `named` only reads its identity for the
+            // comparison below and is dropped, so DELETE access is unnecessary.
+            let named = open_directory_nofollow(destination.parent, destination.name)
+                .map_err(|error| KinError::io(display, error))?;
+            let actual = tracked_open_directory_identity(&named)
+                .map_err(|error| KinError::io(display, error))?;
+            if actual != expected_identity {
+                return Err(KinError::Other(format!(
+                    "exact-source directory destination {} changed identity during publication",
+                    display.display()
+                )));
+            }
+            Ok(())
+        })();
+        if let Err(error) = destination_validation {
+            #[cfg(unix)]
+            let restoration = self
+                .locate_open_directory(directory, expected_identity, display)
+                .and_then(|(actual_parent, actual_name)| {
+                    rustix::fs::renameat_with(
+                        &actual_parent,
+                        &actual_name,
+                        &restore_parent,
+                        &restore_name,
+                        rustix::fs::RenameFlags::NOREPLACE,
+                    )
+                    .map_err(|restore_error| KinError::io(display, restore_error.into()))?;
+                    sync_namespace_parents(&actual_parent, display, &restore_parent, display)
+                });
+            #[cfg(windows)]
+            let restoration = replace_windows_directory_handle_exact(
+                directory,
+                &restore_parent,
+                &restore_name,
+                false,
+            )
+            .map_err(|restore_error| KinError::io(display, restore_error))
+            .and_then(|()| {
+                sync_namespace_parents(destination.parent, display, &restore_parent, display)
+            });
+            return match restoration {
+                Ok(()) => Err(error),
+                Err(restore_error) => Err(KinError::Other(format!(
+                    "{error}; exact-source directory restoration also failed for {}: {restore_error}",
+                    display.display()
+                ))),
+            };
+        }
+        Ok(())
+    }
+
+    fn stage_and_publish_directory(
+        &self,
+        transaction: &mut ReconciliationTransaction,
+        destination_parent: &cap_std::fs::Dir,
+        destination_name: &std::ffi::OsStr,
+        relative: &Path,
+        name_index: usize,
+    ) -> Result<PublishedDirectory> {
+        let stage_name = OsString::from(format!("created-dir-{name_index}"));
+        transaction
+            .directory
+            .create_dir(&stage_name)
+            .map_err(|error| KinError::io(self.display_root.join(relative), error))?;
+        let directory = self.open_existing_directory_for_removal(
+            &transaction.directory,
+            &stage_name,
+            Path::new(&stage_name),
+        )?;
+        let identity = tracked_open_directory_identity(&directory)
+            .map_err(|error| KinError::io(self.display_root.join(relative), error))?;
+        self.record_reconciliation_action(
+            transaction,
+            ReconciliationRecoveryAction::PublishDirectory {
+                relative: relative.to_path_buf(),
+                identity,
+                slot: stage_name.to_string_lossy().into_owned(),
+            },
+        )?;
+        let publication = self.move_open_directory_exact(
+            NamedEntryLocation {
+                parent: &transaction.directory,
+                name: &stage_name,
+            },
+            NamedEntryLocation {
+                parent: destination_parent,
+                name: destination_name,
+            },
+            &directory,
+            identity,
+            &self.display_root.join(relative),
+        );
+        publication?;
+        Ok(PublishedDirectory {
+            #[cfg(all(test, unix))]
+            relative: relative.to_path_buf(),
+            #[cfg(all(test, unix))]
+            identity,
+            #[cfg(all(test, unix))]
+            name_index,
+            directory,
+        })
+    }
+
+    fn relative_directory_is_empty(&self, relative: &Path) -> Result<bool> {
+        let path = relative.to_str().ok_or_else(|| {
+            KinError::Other(format!("graph-owned path is not UTF-8: {relative:?}"))
+        })?;
+        let components = validate_source_path(path)?;
+        let parent = self.open_existing_parent(&components)?;
+        let name = std::ffi::OsStr::new(components[components.len() - 1]);
+        let metadata = match parent.symlink_metadata(name) {
+            Ok(metadata) => metadata,
+            Err(error) if error.kind() == std::io::ErrorKind::NotFound => return Ok(false),
+            Err(error) => return Err(KinError::io(self.display_root.join(relative), error)),
+        };
+        if !metadata.is_dir() || metadata_is_reparse(&metadata) {
+            return Ok(false);
+        }
+        let directory = self.open_existing_directory_for_removal(&parent, name, relative)?;
+        self.open_directory_is_empty(&directory, relative)
+    }
+
+    fn relative_directory_identity(&self, relative: &Path) -> Result<Option<TrackedEntryIdentity>> {
+        let path = relative.to_str().ok_or_else(|| {
+            KinError::Other(format!("graph-owned path is not UTF-8: {relative:?}"))
+        })?;
+        let components = validate_source_path(path)?;
+        let parent = self.open_existing_parent(&components)?;
+        let name = std::ffi::OsStr::new(components[components.len() - 1]);
+        let metadata = match parent.symlink_metadata(name) {
+            Ok(metadata) => metadata,
+            Err(error) if error.kind() == std::io::ErrorKind::NotFound => return Ok(None),
+            Err(error) => return Err(KinError::io(self.display_root.join(relative), error)),
+        };
+        if !metadata.is_dir() || metadata_is_reparse(&metadata) {
+            return Ok(None);
+        }
+        let directory = self.open_existing_directory_for_removal(&parent, name, relative)?;
+        tracked_open_directory_identity(&directory)
+            .map(Some)
+            .map_err(|error| KinError::io(self.display_root.join(relative), error))
+    }
+
+    fn open_directory_is_empty(
+        &self,
+        directory: &cap_std::fs::Dir,
+        relative: &Path,
+    ) -> Result<bool> {
+        let mut entries = directory
+            .entries()
+            .map_err(|error| KinError::io(self.display_root.join(relative), error))?;
+        match entries.next() {
+            None => Ok(true),
+            Some(Ok(_)) => Ok(false),
+            Some(Err(error)) => Err(KinError::io(self.display_root.join(relative), error)),
+        }
+    }
+
+    fn back_up_planned_empty_directory(
+        &self,
+        transaction: &mut ReconciliationTransaction,
+        relative: &Path,
+        expected_identity: TrackedEntryIdentity,
+        name_index: usize,
+    ) -> Result<BackedUpDirectory> {
+        self.back_up_directory(
+            transaction,
+            relative,
+            name_index,
+            true,
+            Some(expected_identity),
+        )
+    }
+
+    fn back_up_directory(
+        &self,
+        transaction: &mut ReconciliationTransaction,
+        relative: &Path,
+        name_index: usize,
+        require_empty: bool,
+        expected_identity: Option<TrackedEntryIdentity>,
+    ) -> Result<BackedUpDirectory> {
+        let path = relative.to_str().ok_or_else(|| {
+            KinError::Other(format!("graph-owned path is not UTF-8: {relative:?}"))
+        })?;
+        let components = validate_source_path(path)?;
+        let parent = self.open_existing_parent(&components)?;
+        let source_name = std::ffi::OsStr::new(components[components.len() - 1]);
+        let directory = self.open_existing_directory_for_removal(&parent, source_name, relative)?;
+        if require_empty && !self.open_directory_is_empty(&directory, relative)? {
+            return Err(KinError::Other(format!(
+                "graph-owned directory transition target {} was not empty at displacement",
+                self.display_root.join(relative).display()
+            )));
+        }
+        let identity = tracked_open_directory_identity(&directory)
+            .map_err(|error| KinError::io(self.display_root.join(relative), error))?;
+        if expected_identity.is_some_and(|expected| expected != identity) {
+            return Err(KinError::Other(format!(
+                "working-copy directory {} changed identity after exact-source preflight",
+                self.display_root.join(relative).display()
+            )));
+        }
+        let backup_name = OsString::from(format!("directory-backup-{name_index}"));
+        self.record_reconciliation_action(
+            transaction,
+            ReconciliationRecoveryAction::BackupDirectory {
+                relative: relative.to_path_buf(),
+                identity,
+                slot: backup_name.to_string_lossy().into_owned(),
+            },
+        )?;
+        self.move_open_directory_exact(
+            NamedEntryLocation {
+                parent: &parent,
+                name: source_name,
+            },
+            NamedEntryLocation {
+                parent: &transaction.directory,
+                name: &backup_name,
+            },
+            &directory,
+            identity,
+            &self.display_root.join(relative),
+        )?;
+        if require_empty && !self.open_directory_is_empty(&directory, relative)? {
+            let restoration = self.move_open_directory_exact(
+                NamedEntryLocation {
+                    parent: &transaction.directory,
+                    name: &backup_name,
+                },
+                NamedEntryLocation {
+                    parent: &parent,
+                    name: source_name,
+                },
+                &directory,
+                identity,
+                &self.display_root.join(relative),
+            );
+            return match restoration {
+                Ok(()) => Err(KinError::Other(format!(
+                    "graph-owned directory {} changed contents during exact displacement",
+                    self.display_root.join(relative).display()
+                ))),
+                Err(restore_error) => Err(KinError::Other(format!(
+                    "graph-owned directory {} changed contents during exact displacement; restoration failed: {restore_error}",
+                    self.display_root.join(relative).display()
+                ))),
+            };
+        }
+        Ok(BackedUpDirectory {
+            _directory: directory,
+        })
+    }
+
+    fn move_named_entry_exact(
+        &self,
+        source: NamedEntryLocation<'_>,
+        destination: NamedEntryLocation<'_>,
+        entry: &ValidatedSourceEntry<'_>,
+        expected_identity: TrackedEntryIdentity,
+        expected_state: TrackedObjectState,
+        display: &Path,
+    ) -> Result<()> {
+        let kind = match entry.kind {
+            SourceEntryKind::File { .. } => ExistingObjectKind::File,
+            SourceEntryKind::Symlink => ExistingObjectKind::Symlink,
+        };
+        let (inspected_identity, inspected_state) =
+            self.inspect_named_existing_object(source.parent, source.name, kind, display)?;
+        if inspected_identity != expected_identity || inspected_state != expected_state {
+            return Err(KinError::Other(format!(
+                "tracked working-copy path {} changed object identity, content, or mode before exact displacement; reconciliation refused",
+                display.display()
+            )));
+        }
+        self.move_named_entry_noreplace(
+            source.parent,
+            source.name,
+            destination.parent,
+            destination.name,
+        )
+        .map_err(|error| KinError::io(display, error))?;
+        sync_namespace_parents(source.parent, display, destination.parent, display)?;
+
+        let validation = self
+            .validate_named_source_entry(destination.parent, destination.name, entry, display)
+            .and_then(|actual_identity| {
+                let (_, actual_state) = self.inspect_named_existing_object(
+                    destination.parent,
+                    destination.name,
+                    kind,
+                    display,
+                )?;
+                if actual_identity != expected_identity || actual_state != expected_state {
+                    Err(KinError::Other(format!(
+                        "tracked working-copy path {} changed object identity, content, or mode during exact displacement; reconciliation refused",
+                        display.display()
+                    )))
+                } else {
+                    Ok(())
+                }
+            });
+        if let Err(error) = validation {
+            let restored = self.move_named_entry_noreplace(
+                destination.parent,
+                destination.name,
+                source.parent,
+                source.name,
+            );
+            return match restored.and_then(|()| {
+                sync_namespace_parents(destination.parent, display, source.parent, display)
+                    .map_err(|error| std::io::Error::other(error.to_string()))
+            }) {
+                Ok(()) => Err(error),
+                Err(restore_error) => Err(KinError::Other(format!(
+                    "{error}; exact-source namespace restoration also failed for {}: {restore_error}",
+                    display.display()
+                ))),
+            };
+        }
+        Ok(())
+    }
+
+    fn inspect_named_existing_object(
+        &self,
+        parent: &cap_std::fs::Dir,
+        name: &std::ffi::OsStr,
+        expected_kind: ExistingObjectKind,
+        display: &Path,
+    ) -> Result<(TrackedEntryIdentity, TrackedObjectState)> {
+        fn hash_reader(mut reader: impl Read) -> std::io::Result<[u8; 32]> {
+            use sha2::{Digest, Sha256};
+
+            let mut hasher = Sha256::new();
+            let mut buffer = [0_u8; 64 * 1024];
+            loop {
+                let read = reader.read(&mut buffer)?;
+                if read == 0 {
+                    break;
+                }
+                hasher.update(&buffer[..read]);
+            }
+            Ok(hasher.finalize().into())
+        }
+
+        fn hash_bytes(bytes: &[u8]) -> [u8; 32] {
+            use sha2::{Digest, Sha256};
+
+            Sha256::digest(bytes).into()
+        }
+
+        #[cfg(unix)]
+        {
+            let metadata = parent
+                .symlink_metadata(name)
+                .map_err(|error| KinError::io(display, error))?;
+            let actual_kind = if metadata_is_reparse(&metadata) {
+                ExistingObjectKind::Symlink
+            } else if metadata.is_file() {
+                ExistingObjectKind::File
+            } else {
+                return Err(KinError::Other(format!(
+                    "working-copy object {} changed into an unsupported kind",
+                    display.display()
+                )));
+            };
+            if actual_kind != expected_kind {
+                return Err(KinError::Other(format!(
+                    "working-copy object {} changed kind after exact-source preflight",
+                    display.display()
+                )));
+            }
+            match actual_kind {
+                ExistingObjectKind::File => {
+                    use std::os::unix::fs::MetadataExt;
+
+                    let file = rustix::fs::openat(
+                        parent,
+                        name,
+                        rustix::fs::OFlags::RDONLY
+                            | rustix::fs::OFlags::NOFOLLOW
+                            | rustix::fs::OFlags::CLOEXEC,
+                        rustix::fs::Mode::empty(),
+                    )
+                    .map(std::fs::File::from)
+                    .map_err(|error| KinError::io(display, error.into()))?;
+                    let opened = file
+                        .metadata()
+                        .map_err(|error| KinError::io(display, error))?;
+                    let identity = tracked_open_file_identity(&opened);
+                    let state = TrackedObjectState {
+                        content_sha256: hash_reader(file)
+                            .map_err(|error| KinError::io(display, error))?,
+                        mode: opened.mode() & 0o7777,
+                    };
+                    Ok((identity, state))
+                }
+                ExistingObjectKind::Symlink => {
+                    use cap_std::fs::MetadataExt;
+
+                    let target = rustix::fs::readlinkat(parent, name, Vec::new())
+                        .map_err(|error| KinError::io(display, error.into()))?;
+                    let after = parent
+                        .symlink_metadata(name)
+                        .map_err(|error| KinError::io(display, error))?;
+                    let before_identity = tracked_entry_identity(&metadata);
+                    let after_identity = tracked_entry_identity(&after);
+                    if before_identity != after_identity || !metadata_is_reparse(&after) {
+                        return Err(KinError::Other(format!(
+                            "working-copy symbolic link {} changed while inspecting recovery state",
+                            display.display()
+                        )));
+                    }
+                    Ok((
+                        after_identity,
+                        TrackedObjectState {
+                            content_sha256: hash_bytes(target.as_bytes()),
+                            mode: after.mode() & 0o7777,
+                        },
+                    ))
+                }
+            }
+        }
+        #[cfg(windows)]
+        {
+            let mut file = self.open_windows_existing_object(parent, name, display)?;
+            let metadata = file
+                .metadata()
+                .map_err(|error| KinError::io(display, error))?;
+            let actual_kind = if metadata_is_reparse(&metadata) {
+                ExistingObjectKind::Symlink
+            } else if metadata.is_file() {
+                ExistingObjectKind::File
+            } else {
+                return Err(KinError::Other(format!(
+                    "working-copy object {} changed into an unsupported kind",
+                    display.display()
+                )));
+            };
+            if actual_kind != expected_kind {
+                return Err(KinError::Other(format!(
+                    "working-copy object {} changed kind after exact-source preflight",
+                    display.display()
+                )));
+            }
+            let identity =
+                tracked_open_file_identity(&file).map_err(|error| KinError::io(display, error))?;
+            let content_sha256 = match actual_kind {
+                ExistingObjectKind::File => {
+                    hash_reader(&mut file).map_err(|error| KinError::io(display, error))?
+                }
+                ExistingObjectKind::Symlink => {
+                    use std::os::windows::ffi::OsStrExt;
+
+                    let target = parent
+                        .read_link(name)
+                        .map_err(|error| KinError::io(display, error))?;
+                    let wide = target
+                        .as_os_str()
+                        .encode_wide()
+                        .flat_map(u16::to_le_bytes)
+                        .collect::<Vec<_>>();
+                    hash_bytes(&wide)
+                }
+            };
+            Ok((
+                identity,
+                TrackedObjectState {
+                    content_sha256,
+                    mode: 0,
+                },
+            ))
+        }
+    }
+
+    #[cfg(windows)]
+    fn open_windows_existing_object(
+        &self,
+        parent: &cap_std::fs::Dir,
+        name: &std::ffi::OsStr,
+        display: &Path,
+    ) -> Result<cap_std::fs::File> {
+        use cap_fs_ext::{FollowSymlinks, OpenOptionsFollowExt};
+        use cap_std::fs::OpenOptionsExt;
+        use windows_sys::Win32::Foundation::GENERIC_READ;
+        use windows_sys::Win32::Storage::FileSystem::{
+            DELETE, FILE_SHARE_DELETE, FILE_SHARE_READ, FILE_SHARE_WRITE,
+        };
+
+        let mut options = cap_std::fs::OpenOptions::new();
+        options
+            .access_mode(GENERIC_READ | DELETE)
+            .share_mode(FILE_SHARE_READ | FILE_SHARE_WRITE | FILE_SHARE_DELETE)
+            .follow(FollowSymlinks::No);
+        parent
+            .open_with(name, &options)
+            .map_err(|error| KinError::io(display, error))
+    }
+
+    fn move_existing_object_exact(
+        &self,
+        source: NamedEntryLocation<'_>,
+        destination: NamedEntryLocation<'_>,
+        kind: ExistingObjectKind,
+        expected_identity: TrackedEntryIdentity,
+        expected_state: TrackedObjectState,
+        display: &Path,
+    ) -> Result<()> {
+        let (actual_identity, actual_state) =
+            self.inspect_named_existing_object(source.parent, source.name, kind, display)?;
+        if actual_identity != expected_identity {
+            return Err(KinError::Other(format!(
+                "working-copy object {} changed identity after exact-source preflight",
+                display.display()
+            )));
+        }
+        if actual_state != expected_state {
+            return Err(KinError::Other(format!(
+                "working-copy object {} changed content or mode after exact-source preflight",
+                display.display()
+            )));
+        }
+
+        #[cfg(unix)]
+        rustix::fs::renameat_with(
+            source.parent,
+            source.name,
+            destination.parent,
+            destination.name,
+            rustix::fs::RenameFlags::NOREPLACE,
+        )
+        .map_err(|error| KinError::io(display, error.into()))?;
+        #[cfg(windows)]
+        let retained = self.open_windows_existing_object(source.parent, source.name, display)?;
+        #[cfg(windows)]
+        {
+            let retained_identity = tracked_open_file_identity(&retained)
+                .map_err(|error| KinError::io(display, error))?;
+            if retained_identity != expected_identity {
+                return Err(KinError::Other(format!(
+                    "working-copy object {} changed identity while opening for exact displacement",
+                    display.display()
+                )));
+            }
+            replace_windows_file_handle_exact(
+                &retained,
+                destination.parent,
+                destination.name,
+                false,
+            )
+            .map_err(|error| KinError::io(display, error))?;
+        }
+        sync_namespace_parents(source.parent, display, destination.parent, display)?;
+
+        let validation = self
+            .inspect_named_existing_object(destination.parent, destination.name, kind, display)
+            .and_then(|(actual_identity, actual_state)| {
+                if actual_identity == expected_identity && actual_state == expected_state {
+                    Ok(())
+                } else {
+                    Err(KinError::Other(format!(
+                        "working-copy object {} changed identity, content, or mode during exact displacement",
+                        display.display()
+                    )))
+                }
+            });
+        if let Err(error) = validation {
+            #[cfg(unix)]
+            let restoration = rustix::fs::renameat_with(
+                destination.parent,
+                destination.name,
+                source.parent,
+                source.name,
+                rustix::fs::RenameFlags::NOREPLACE,
+            )
+            .map_err(|restore_error| KinError::io(display, restore_error.into()))
+            .and_then(|()| {
+                sync_namespace_parents(destination.parent, display, source.parent, display)
+            });
+            #[cfg(windows)]
+            let restoration =
+                replace_windows_file_handle_exact(&retained, source.parent, source.name, false)
+                    .map_err(|restore_error| KinError::io(display, restore_error))
+                    .and_then(|()| {
+                        sync_namespace_parents(destination.parent, display, source.parent, display)
+                    });
+            return match restoration {
+                Ok(()) => Err(error),
+                Err(restore_error) => Err(KinError::Other(format!(
+                    "{error}; exact-source object restoration also failed for {}: {restore_error}",
+                    display.display()
+                ))),
+            };
+        }
+        Ok(())
+    }
+
+    fn back_up_existing_object(
+        &self,
+        transaction: &mut ReconciliationTransaction,
+        object: &PlannedExistingObject,
+        name_index: usize,
+    ) -> Result<()> {
+        let path = object.relative.to_str().ok_or_else(|| {
+            KinError::Other(format!(
+                "working-copy path is not UTF-8: {:?}",
+                object.relative
+            ))
+        })?;
+        let components = validate_source_path(path)?;
+        let parent = self.open_existing_parent(&components)?;
+        let source_name = std::ffi::OsStr::new(components[components.len() - 1]);
+        let backup_name = OsString::from(format!("existing-backup-{name_index}"));
+        self.record_reconciliation_action(
+            transaction,
+            ReconciliationRecoveryAction::BackupObject {
+                relative: object.relative.clone(),
+                kind: object.kind,
+                identity: object.identity,
+                state: object.state,
+                slot: backup_name.to_string_lossy().into_owned(),
+            },
+        )?;
+        self.move_existing_object_exact(
+            NamedEntryLocation {
+                parent: &parent,
+                name: source_name,
+            },
+            NamedEntryLocation {
+                parent: &transaction.directory,
+                name: &backup_name,
+            },
+            object.kind,
+            object.identity,
+            object.state,
+            &self.display_root.join(&object.relative),
+        )
+    }
+
+    fn displace_previous_entry<'a>(
+        &self,
+        transaction: &mut ReconciliationTransaction,
+        entry: ValidatedSourceEntry<'a>,
+        expected_identity: TrackedEntryIdentity,
+        name_index: usize,
+    ) -> Result<()> {
+        let components = validate_source_path(&entry.file_id.0)?;
+        let parent = self.open_existing_parent(&components)?;
+        let source_name = std::ffi::OsStr::new(components[components.len() - 1]);
+        let backup_name = format!("backup-{name_index}");
+        let display = self.display_path(&components);
+        let kind = match entry.kind {
+            SourceEntryKind::File { .. } => ExistingObjectKind::File,
+            SourceEntryKind::Symlink => ExistingObjectKind::Symlink,
+        };
+        let (actual_identity, state) =
+            self.inspect_named_existing_object(&parent, source_name, kind, &display)?;
+        if actual_identity != expected_identity {
+            return Err(KinError::Other(format!(
+                "tracked working-copy path {} changed object identity before exact displacement",
+                display.display()
+            )));
+        }
+        self.record_reconciliation_action(
+            transaction,
+            ReconciliationRecoveryAction::BackupObject {
+                relative: PathBuf::from(&entry.file_id.0),
+                kind,
+                identity: expected_identity,
+                state,
+                slot: backup_name.clone(),
+            },
+        )?;
+        self.move_named_entry_exact(
+            NamedEntryLocation {
+                parent: &parent,
+                name: source_name,
+            },
+            NamedEntryLocation {
+                parent: &transaction.directory,
+                name: std::ffi::OsStr::new(&backup_name),
+            },
+            &entry,
+            expected_identity,
+            state,
+            &display,
+        )
+    }
+
+    fn publish_staged_entry(
+        &self,
+        transaction: &mut ReconciliationTransaction,
+        staged: &StagedReconciliationEntry<'_>,
+    ) -> Result<()> {
+        let components = validate_source_path(&staged.entry.file_id.0)?;
+        let parent = self.open_existing_parent(&components)?;
+        let destination_name = std::ffi::OsStr::new(components[components.len() - 1]);
+        let stage_name = format!("stage-{}", staged.name_index);
+        let display = self.display_path(&components);
+        let kind = match staged.entry.kind {
+            SourceEntryKind::File { .. } => ExistingObjectKind::File,
+            SourceEntryKind::Symlink => ExistingObjectKind::Symlink,
+        };
+        self.record_reconciliation_action(
+            transaction,
+            ReconciliationRecoveryAction::PublishObject {
+                relative: PathBuf::from(&staged.entry.file_id.0),
+                kind,
+                identity: staged.identity,
+                state: staged.state,
+                slot: stage_name.clone(),
+            },
+        )?;
+        fail_publication_if_injected()?;
+        self.move_named_entry_exact(
+            NamedEntryLocation {
+                parent: &transaction.directory,
+                name: std::ffi::OsStr::new(&stage_name),
+            },
+            NamedEntryLocation {
+                parent: &parent,
+                name: destination_name,
+            },
+            &staged.entry,
+            staged.identity,
+            staged.state,
+            &display,
+        )
+    }
+
+    #[cfg(all(test, unix))]
+    fn move_published_directory_back(
+        &self,
+        transaction: &cap_std::fs::Dir,
+        published: &PublishedDirectory,
+    ) -> Result<()> {
+        let path = published.relative.to_str().ok_or_else(|| {
+            KinError::Other(format!(
+                "graph-owned path is not UTF-8: {:?}",
+                published.relative
+            ))
+        })?;
+        let components = validate_source_path(path)?;
+        let parent = self.open_existing_parent(&components)?;
+        let source_name = std::ffi::OsStr::new(components[components.len() - 1]);
+        let discard_name = OsString::from(format!("discard-created-dir-{}", published.name_index));
+        self.move_open_directory_exact(
+            NamedEntryLocation {
+                parent: &parent,
+                name: source_name,
+            },
+            NamedEntryLocation {
+                parent: transaction,
+                name: &discard_name,
+            },
+            &published.directory,
+            published.identity,
+            &self.display_root.join(&published.relative),
+        )
+    }
+
+    fn validate_tracked_entry_unchanged(
+        &self,
+        entry: &ValidatedSourceEntry<'_>,
+    ) -> Result<TrackedEntryIdentity> {
+        let components =
+            validate_source_entry_components(entry.file_id, entry.kind, entry.content)?;
+        let display = self.display_path(&components);
+        let conflict = |reason: &str| {
+            KinError::Other(format!(
+                "tracked working-copy path {} differs from current branch source ({reason}); exact branch reconciliation refused",
+                display.display()
+            ))
+        };
+        let mut parent = self.clone_root()?;
+        let mut relative = PathBuf::new();
+        for component in &components[..components.len() - 1] {
+            relative.push(component);
+            let metadata = match parent.symlink_metadata(component) {
+                Ok(metadata) => metadata,
+                Err(error) if error.kind() == std::io::ErrorKind::NotFound => {
+                    return Err(conflict("a parent directory is missing"));
+                }
+                Err(error) => {
+                    return Err(KinError::io(self.display_root.join(&relative), error));
+                }
+            };
+            if !metadata.is_dir() || metadata_is_reparse(&metadata) {
+                return Err(conflict("a parent path is not the expected directory"));
+            }
+            parent =
+                self.open_existing_directory(&parent, std::ffi::OsStr::new(component), &relative)?;
+        }
+
+        let name = components[components.len() - 1];
+        let metadata = match parent.symlink_metadata(name) {
+            Ok(metadata) => metadata,
+            Err(error) if error.kind() == std::io::ErrorKind::NotFound => {
+                return Err(conflict("the tracked path is missing"));
+            }
+            Err(error) => return Err(KinError::io(&display, error)),
+        };
+        let identity = match entry.kind {
+            SourceEntryKind::File { executable } => {
+                if !metadata.is_file() || metadata_is_reparse(&metadata) {
+                    return Err(conflict("the tracked path kind changed"));
+                }
+                #[cfg(windows)]
+                let _ = executable;
+                #[cfg(unix)]
+                {
+                    use cap_std::fs::PermissionsExt;
+
+                    let actual_executable = metadata.permissions().mode() & 0o111 != 0;
+                    if actual_executable != executable {
+                        return Err(conflict("the executable bit changed"));
+                    }
+                }
+
+                #[cfg(unix)]
+                let mut file = rustix::fs::openat(
+                    &parent,
+                    name,
+                    rustix::fs::OFlags::RDONLY
+                        | rustix::fs::OFlags::NOFOLLOW
+                        | rustix::fs::OFlags::CLOEXEC,
+                    rustix::fs::Mode::empty(),
+                )
+                .map(std::fs::File::from)
+                .map_err(|error| KinError::io(&display, error.into()))?;
+                #[cfg(windows)]
+                let mut file = {
+                    use cap_fs_ext::{FollowSymlinks, OpenOptionsFollowExt};
+
+                    let mut options = cap_std::fs::OpenOptions::new();
+                    options.read(true).follow(FollowSymlinks::No);
+                    parent
+                        .open_with(name, &options)
+                        .map_err(|error| KinError::io(&display, error))?
+                };
+                let opened_metadata = file
+                    .metadata()
+                    .map_err(|error| KinError::io(&display, error))?;
+                if !opened_metadata.is_file() {
+                    return Err(conflict("the tracked path kind changed while opening"));
+                }
+                #[cfg(windows)]
+                if metadata_is_reparse(&opened_metadata) {
+                    return Err(conflict("the tracked path kind changed while opening"));
+                }
+                if !reader_matches_bytes(&mut file, entry.content)
+                    .map_err(|error| KinError::io(&display, error))?
+                {
+                    return Err(conflict("the file content changed"));
+                }
+                #[cfg(unix)]
+                {
+                    tracked_open_file_identity(&opened_metadata)
+                }
+                #[cfg(windows)]
+                {
+                    tracked_open_file_identity(&file)
+                        .map_err(|error| KinError::io(&display, error))?
+                }
+            }
+            SourceEntryKind::Symlink => {
+                #[cfg(windows)]
+                return Err(KinError::Other(
+                    "safe exact symbolic-link checkout is unsupported on Windows".to_string(),
+                ));
+                #[cfg(unix)]
+                {
+                    if !metadata_is_reparse(&metadata) {
+                        return Err(conflict("the tracked path kind changed"));
+                    }
+                    let target = parent
+                        .read_link(name)
+                        .map_err(|error| KinError::io(&display, error))?;
+                    if target.to_str().map(str::as_bytes) != Some(entry.content) {
+                        return Err(conflict("the symbolic-link target changed"));
+                    }
+                    tracked_entry_identity(&metadata)
+                }
+            }
+        };
+        Ok(identity)
+    }
+
+    fn open_existing_parent(&self, components: &[&str]) -> Result<cap_std::fs::Dir> {
+        let mut parent = self.clone_root()?;
+        let mut relative = PathBuf::new();
+        for component in &components[..components.len() - 1] {
+            relative.push(component);
+            parent =
+                self.open_existing_directory(&parent, std::ffi::OsStr::new(*component), &relative)?;
+        }
+        Ok(parent)
+    }
+
+    fn open_or_create_directory(
+        &self,
+        parent: &cap_std::fs::Dir,
+        component: &str,
+    ) -> Result<cap_std::fs::Dir> {
+        for _ in 0..8 {
+            if let Ok(directory) = open_directory_nofollow(parent, std::ffi::OsStr::new(component))
+            {
+                return Ok(directory);
+            }
+            match parent.symlink_metadata(component) {
+                Err(error) if error.kind() == std::io::ErrorKind::NotFound => {
+                    match create_capability_directory(parent, std::ffi::OsStr::new(component)) {
+                        Ok(()) => continue,
+                        Err(error) if error.kind() == std::io::ErrorKind::AlreadyExists => continue,
+                        Err(error) => {
+                            return Err(KinError::io(self.display_root.join(component), error));
+                        }
+                    }
+                }
+                Ok(metadata) if metadata.is_dir() && !metadata_is_reparse(&metadata) => {
+                    return open_directory_nofollow(parent, std::ffi::OsStr::new(component))
+                        .map_err(|error| KinError::io(self.display_root.join(component), error));
+                }
+                Ok(_) => {
+                    match remove_capability_file_or_symlink(parent, std::ffi::OsStr::new(component))
+                    {
+                        Ok(()) => continue,
+                        Err(error) if error.kind() == std::io::ErrorKind::NotFound => continue,
+                        Err(error) => {
+                            return Err(KinError::io(self.display_root.join(component), error));
+                        }
+                    }
+                }
+                Err(error) => {
+                    return Err(KinError::io(self.display_root.join(component), error));
+                }
+            }
+        }
+        Err(KinError::Other(format!(
+            "projection parent changed repeatedly during checkout: {}",
+            self.display_root.join(component).display()
+        )))
+    }
+
+    fn open_existing_directory(
+        &self,
+        parent: &cap_std::fs::Dir,
+        component: &std::ffi::OsStr,
+        relative: &Path,
+    ) -> Result<cap_std::fs::Dir> {
+        open_directory_nofollow(parent, component)
+            .map_err(|error| KinError::io(self.display_root.join(relative), error))
+    }
+
+    fn open_existing_directory_for_removal(
+        &self,
+        parent: &cap_std::fs::Dir,
+        component: &std::ffi::OsStr,
+        relative: &Path,
+    ) -> Result<cap_std::fs::Dir> {
+        open_directory_nofollow_for_removal(parent, component)
+            .map_err(|error| KinError::io(self.display_root.join(relative), error))
+    }
+
+    fn remove_directory_tree(
+        &self,
+        parent: &cap_std::fs::Dir,
+        name: &std::ffi::OsStr,
+        relative: &Path,
+    ) -> Result<()> {
+        #[cfg(unix)]
+        {
+            // cap-std 4.0.2's Unix implementation performs a no-follow stat,
+            // opens the directory no-follow, then recursively removes through
+            // held child directory descriptors.
+            parent
+                .remove_dir_all(name)
+                .map_err(|error| KinError::io(self.display_root.join(relative), error))?;
+        }
+        #[cfg(windows)]
+        {
+            let directory = self.open_existing_directory_for_removal(parent, name, relative)?;
+            self.remove_windows_directory_contents(&directory, relative)?;
+            mark_windows_directory_for_deletion(directory)
+                .map_err(|error| KinError::io(self.display_root.join(relative), error))?;
+        }
+        Ok(())
+    }
+
+    #[cfg(windows)]
+    fn remove_windows_directory_contents(
+        &self,
+        directory: &cap_std::fs::Dir,
+        relative: &Path,
+    ) -> Result<()> {
+        let entries = directory
+            .entries()
+            .map_err(|error| KinError::io(self.display_root.join(relative), error))?;
+        for entry in entries {
+            let entry =
+                entry.map_err(|error| KinError::io(self.display_root.join(relative), error))?;
+            let name = entry.file_name();
+            let child_relative = relative.join(&name);
+            let metadata = directory
+                .symlink_metadata(&name)
+                .map_err(|error| KinError::io(self.display_root.join(&child_relative), error))?;
+            if metadata.is_dir() && !metadata_is_reparse(&metadata) {
+                let child =
+                    self.open_existing_directory_for_removal(directory, &name, &child_relative)?;
+                self.remove_windows_directory_contents(&child, &child_relative)?;
+                mark_windows_directory_for_deletion(child).map_err(|error| {
+                    KinError::io(self.display_root.join(&child_relative), error)
+                })?;
+            } else {
+                remove_capability_file_or_symlink(directory, &name).map_err(|error| {
+                    KinError::io(self.display_root.join(&child_relative), error)
+                })?;
+            }
+        }
+        Ok(())
+    }
+
+    fn clone_root(&self) -> Result<cap_std::fs::Dir> {
+        self.root
+            .try_clone()
+            .map_err(|error| KinError::io(&self.display_root, error))
+    }
+
+    fn display_path(&self, components: &[&str]) -> PathBuf {
+        self.display_root.join(components.join("/"))
+    }
+}
+
+#[cfg(unix)]
+fn open_directory_nofollow(
+    parent: &cap_std::fs::Dir,
+    component: &std::ffi::OsStr,
+) -> std::io::Result<cap_std::fs::Dir> {
+    rustix::fs::openat(
+        parent,
+        component,
+        rustix::fs::OFlags::RDONLY
+            | rustix::fs::OFlags::DIRECTORY
+            | rustix::fs::OFlags::NOFOLLOW
+            | rustix::fs::OFlags::CLOEXEC,
+        rustix::fs::Mode::empty(),
+    )
+    .map(|fd| cap_std::fs::Dir::from_std_file(fd.into()))
+    .map_err(Into::into)
+}
+
+#[cfg(any(unix, windows))]
+fn reader_matches_bytes(reader: &mut impl Read, expected: &[u8]) -> std::io::Result<bool> {
+    let mut offset = 0;
+    let mut buffer = [0_u8; 16 * 1024];
+    loop {
+        let read = reader.read(&mut buffer)?;
+        if read == 0 {
+            return Ok(offset == expected.len());
+        }
+        let Some(end) = offset.checked_add(read) else {
+            return Ok(false);
+        };
+        if end > expected.len() || buffer[..read] != expected[offset..end] {
+            return Ok(false);
+        }
+        offset = end;
+    }
+}
+
+#[cfg(unix)]
+fn open_directory_nofollow_for_removal(
+    parent: &cap_std::fs::Dir,
+    component: &std::ffi::OsStr,
+) -> std::io::Result<cap_std::fs::Dir> {
+    open_directory_nofollow(parent, component)
+}
+
+#[cfg(unix)]
+fn create_capability_directory(
+    parent: &cap_std::fs::Dir,
+    component: &std::ffi::OsStr,
+) -> std::io::Result<()> {
+    rustix::fs::mkdirat(parent, component, rustix::fs::Mode::from_raw_mode(0o755))
+        .map_err(Into::into)
+}
+
+#[cfg(unix)]
+fn remove_capability_file_or_symlink(
+    parent: &cap_std::fs::Dir,
+    component: &std::ffi::OsStr,
+) -> std::io::Result<()> {
+    rustix::fs::unlinkat(parent, component, rustix::fs::AtFlags::empty()).map_err(Into::into)
+}
+
+#[cfg(unix)]
+fn metadata_is_reparse(metadata: &cap_std::fs::Metadata) -> bool {
+    metadata.file_type().is_symlink()
+}
+
+#[cfg(windows)]
+fn open_directory_nofollow(
+    parent: &cap_std::fs::Dir,
+    component: &std::ffi::OsStr,
+) -> std::io::Result<cap_std::fs::Dir> {
+    use cap_fs_ext::{FollowSymlinks, OpenOptionsFollowExt, OpenOptionsMaybeDirExt};
+    use cap_std::fs::OpenOptionsExt;
+    use windows_sys::Win32::Storage::FileSystem::{
+        FILE_SHARE_DELETE, FILE_SHARE_READ, FILE_SHARE_WRITE,
+    };
+
+    let mut options = cap_std::fs::OpenOptions::new();
+    // cap-std opens directories without FILE_SHARE_DELETE, which collides on
+    // Windows with a peer that holds a concurrent handle under `.kin` (for
+    // example the graph store's own snapshot/index). Share read/write/delete so
+    // the projection can open a control-plane directory alongside those handles;
+    // POSIX permits this implicitly.
+    options
+        .read(true)
+        .share_mode(FILE_SHARE_READ | FILE_SHARE_WRITE | FILE_SHARE_DELETE)
+        .follow(FollowSymlinks::No)
+        .maybe_dir(true);
+    let file = parent.open_with(component, &options)?;
+    let metadata = file.metadata()?;
+    if metadata_is_reparse(&metadata) || !metadata.is_dir() {
+        return Err(std::io::Error::other(format!(
+            "projection directory component is a reparse point or non-directory: {}",
+            component.to_string_lossy()
+        )));
+    }
+    Ok(cap_std::fs::Dir::from_std_file(file.into_std()))
+}
+
+#[cfg(windows)]
+fn open_directory_nofollow_for_removal(
+    parent: &cap_std::fs::Dir,
+    component: &std::ffi::OsStr,
+) -> std::io::Result<cap_std::fs::Dir> {
+    use cap_fs_ext::{FollowSymlinks, OpenOptionsFollowExt, OpenOptionsMaybeDirExt};
+    use cap_std::fs::OpenOptionsExt;
+    use windows_sys::Win32::Foundation::GENERIC_READ;
+    use windows_sys::Win32::Storage::FileSystem::{
+        DELETE, FILE_SHARE_DELETE, FILE_SHARE_READ, FILE_SHARE_WRITE,
+    };
+
+    let mut options = cap_std::fs::OpenOptions::new();
+    // Request DELETE access to remove the directory, and share read/write/delete
+    // so the open does not collide on Windows with a peer holding a concurrent
+    // handle under `.kin`. cap-std's directory default omits FILE_SHARE_DELETE,
+    // which raises a sharing violation here even though POSIX allows the same
+    // unlink-while-open pattern.
+    options
+        .access_mode(GENERIC_READ | DELETE)
+        .share_mode(FILE_SHARE_READ | FILE_SHARE_WRITE | FILE_SHARE_DELETE)
+        .follow(FollowSymlinks::No)
+        .maybe_dir(true);
+    let file = parent.open_with(component, &options)?;
+    let metadata = file.metadata()?;
+    if metadata_is_reparse(&metadata) || !metadata.is_dir() {
+        return Err(std::io::Error::other(format!(
+            "projection removal target is a reparse point or non-directory: {}",
+            component.to_string_lossy()
+        )));
+    }
+    Ok(cap_std::fs::Dir::from_std_file(file.into_std()))
+}
+
+#[cfg(windows)]
+fn create_capability_directory(
+    parent: &cap_std::fs::Dir,
+    component: &std::ffi::OsStr,
+) -> std::io::Result<()> {
+    parent.create_dir(component)
+}
+
+#[cfg(windows)]
+fn remove_capability_file_or_symlink(
+    parent: &cap_std::fs::Dir,
+    component: &std::ffi::OsStr,
+) -> std::io::Result<()> {
+    use cap_fs_ext::DirExt;
+
+    parent.remove_file_or_symlink(component)
+}
+
+#[cfg(windows)]
+fn metadata_is_reparse(metadata: &cap_std::fs::Metadata) -> bool {
+    use windows_sys::Win32::Storage::FileSystem::FILE_ATTRIBUTE_REPARSE_POINT;
+
+    cap_fs_ext::OsMetadataExt::file_attributes(metadata) & FILE_ATTRIBUTE_REPARSE_POINT != 0
+}
+
+#[cfg(windows)]
+fn replace_windows_file_handle_exact(
+    source: &cap_std::fs::File,
+    destination_parent: &cap_std::fs::Dir,
+    destination_name: &std::ffi::OsStr,
+    replace_existing: bool,
+) -> std::io::Result<()> {
+    use std::os::windows::io::AsRawHandle;
+
+    replace_windows_handle_exact(
+        source.as_raw_handle().cast(),
+        destination_parent,
+        destination_name,
+        replace_existing,
+    )
+}
+
+#[cfg(windows)]
+fn replace_windows_directory_handle_exact(
+    source: &cap_std::fs::Dir,
+    destination_parent: &cap_std::fs::Dir,
+    destination_name: &std::ffi::OsStr,
+    replace_existing: bool,
+) -> std::io::Result<()> {
+    use std::os::windows::io::AsRawHandle;
+
+    replace_windows_handle_exact(
+        source.as_raw_handle().cast(),
+        destination_parent,
+        destination_name,
+        replace_existing,
+    )
+}
+
+/// Resolve an open directory/file handle to its fully-qualified verbatim `\\?\`
+/// final path. Grows the buffer until `GetFinalPathNameByHandleW` reports the
+/// full length, mirroring the proven managed-config resolution idiom.
+#[cfg(windows)]
+fn read_windows_final_path(
+    handle: windows_sys::Win32::Foundation::HANDLE,
+) -> std::io::Result<Vec<u16>> {
+    use windows_sys::Win32::Storage::FileSystem::{
+        GetFinalPathNameByHandleW, FILE_NAME_NORMALIZED, VOLUME_NAME_DOS,
+    };
+
+    let flags = FILE_NAME_NORMALIZED | VOLUME_NAME_DOS;
+    let mut capacity = 256_usize;
+    loop {
+        let mut buffer = vec![0_u16; capacity];
+        let length = u32::try_from(buffer.len()).map_err(|_| {
+            std::io::Error::new(
+                std::io::ErrorKind::InvalidInput,
+                "exact-source destination path buffer exceeds the Windows length limit",
+            )
+        })?;
+        let written =
+            unsafe { GetFinalPathNameByHandleW(handle, buffer.as_mut_ptr(), length, flags) };
+        if written == 0 {
+            return Err(std::io::Error::last_os_error());
+        }
+        let written = written as usize;
+        if written >= buffer.len() {
+            // The buffer was too small; the return value is the required length
+            // including the terminating NUL. Grow past it and retry.
+            capacity = written.checked_add(1).ok_or_else(|| {
+                std::io::Error::new(
+                    std::io::ErrorKind::InvalidInput,
+                    "exact-source destination path length overflow",
+                )
+            })?;
+            continue;
+        }
+        buffer.truncate(written);
+        return Ok(buffer);
+    }
+}
+
+#[cfg(windows)]
+fn replace_windows_handle_exact(
+    source: windows_sys::Win32::Foundation::HANDLE,
+    destination_parent: &cap_std::fs::Dir,
+    destination_name: &std::ffi::OsStr,
+    replace_existing: bool,
+) -> std::io::Result<()> {
+    use std::os::windows::ffi::OsStrExt;
+    use std::os::windows::io::AsRawHandle;
+    use windows_sys::Win32::Storage::FileSystem::{
+        FileRenameInfo, SetFileInformationByHandle, FILE_RENAME_INFO,
+    };
+
+    let mut components = Path::new(destination_name).components();
+    if !matches!(components.next(), Some(std::path::Component::Normal(name)) if name == destination_name)
+        || components.next().is_some()
+    {
+        return Err(std::io::Error::new(
+            std::io::ErrorKind::InvalidInput,
+            "exact-source destination must be one normal path component",
+        ));
+    }
+    let name_wide = destination_name.encode_wide().collect::<Vec<_>>();
+    if name_wide.is_empty() || name_wide.contains(&0) {
+        return Err(std::io::Error::new(
+            std::io::ErrorKind::InvalidInput,
+            "exact-source destination is empty or contains an interior NUL",
+        ));
+    }
+    // SetFileInformationByHandle's FileRenameInfo requires RootDirectory to be NULL
+    // and FileName to carry the fully-qualified destination; passing a directory
+    // handle in RootDirectory is rejected with ERROR_INVALID_PARAMETER (only the NT
+    // NtSetInformationFile path honors a relative name against a root handle).
+    // Resolve the parent's verbatim `\\?\` final path from its handle and append the
+    // validated single-component leaf.
+    //
+    // A full-path destination is re-resolved from the volume root, so unlike a
+    // parent-handle-relative rename it does not by itself pin the destination against
+    // an ancestor swap. Callers bound that window: control renames hold the projection
+    // lock, working-copy displacement re-validates post-rename identity/state and rolls
+    // back on mismatch, and new destinations pass replace_existing = false so a raced
+    // destination fails closed rather than being overwritten.
+    let mut destination_wide = read_windows_final_path(destination_parent.as_raw_handle().cast())?;
+    destination_wide.push(u16::from(b'\\'));
+    destination_wide.extend_from_slice(&name_wide);
+    let name_bytes = destination_wide
+        .len()
+        .checked_mul(std::mem::size_of::<u16>())
+        .ok_or_else(|| {
+            std::io::Error::new(
+                std::io::ErrorKind::InvalidInput,
+                "exact-source destination length overflow",
+            )
+        })?;
+    let buffer_bytes = std::mem::offset_of!(FILE_RENAME_INFO, FileName)
+        .checked_add(name_bytes)
+        .and_then(|bytes| bytes.checked_add(std::mem::size_of::<u16>()))
+        .ok_or_else(|| {
+            std::io::Error::new(
+                std::io::ErrorKind::InvalidInput,
+                "exact-source rename buffer length overflow",
+            )
+        })?;
+    let file_name_length = u32::try_from(name_bytes).map_err(|_| {
+        std::io::Error::new(
+            std::io::ErrorKind::InvalidInput,
+            "exact-source destination exceeds the Windows length limit",
+        )
+    })?;
+    let buffer_length = u32::try_from(buffer_bytes).map_err(|_| {
+        std::io::Error::new(
+            std::io::ErrorKind::InvalidInput,
+            "exact-source rename buffer exceeds the Windows length limit",
+        )
+    })?;
+    let mut storage = vec![0_usize; buffer_bytes.div_ceil(std::mem::size_of::<usize>())];
+    let info = storage.as_mut_ptr().cast::<FILE_RENAME_INFO>();
+    unsafe {
+        // FileRenameInfo reads this union field as ReplaceIfExists: a nonzero low
+        // byte replaces an existing destination. New branch-only paths pass 0 so a
+        // raced untracked destination fails closed rather than being overwritten;
+        // previously-tracked paths pass 1 to replace. FileRenameInfo (not the Ex
+        // class) is used because FileRenameInfoEx raises ERROR_INVALID_PARAMETER
+        // where its POSIX-semantics extension is unavailable, and no POSIX flag is
+        // needed here.
+        (*info).Anonymous.Flags = u32::from(replace_existing);
+        (*info).RootDirectory = std::ptr::null_mut();
+        (*info).FileNameLength = file_name_length;
+        std::ptr::copy_nonoverlapping(
+            destination_wide.as_ptr(),
+            std::ptr::addr_of_mut!((*info).FileName).cast::<u16>(),
+            destination_wide.len(),
+        );
+        *std::ptr::addr_of_mut!((*info).FileName)
+            .cast::<u16>()
+            .add(destination_wide.len()) = 0;
+    }
+    if unsafe { SetFileInformationByHandle(source, FileRenameInfo, info.cast(), buffer_length) }
+        == 0
+    {
+        return Err(std::io::Error::last_os_error());
+    }
+    Ok(())
+}
+
+#[cfg(windows)]
+fn mark_windows_directory_for_deletion(directory: cap_std::fs::Dir) -> std::io::Result<()> {
+    use std::os::windows::io::AsRawHandle;
+
+    let directory = directory.into_std_file();
+    mark_windows_handle_for_deletion(directory.as_raw_handle().cast())?;
+    drop(directory);
+    Ok(())
+}
+
+#[cfg(windows)]
+fn mark_windows_handle_for_deletion(
+    handle: windows_sys::Win32::Foundation::HANDLE,
+) -> std::io::Result<()> {
+    use windows_sys::Win32::Storage::FileSystem::{
+        FileDispositionInfo, SetFileInformationByHandle, FILE_DISPOSITION_INFO,
+    };
+
+    let disposition = FILE_DISPOSITION_INFO { DeleteFile: true };
+    let removed = unsafe {
+        SetFileInformationByHandle(
+            handle,
+            FileDispositionInfo,
+            (&disposition as *const FILE_DISPOSITION_INFO).cast(),
+            std::mem::size_of::<FILE_DISPOSITION_INFO>() as u32,
+        )
+    };
+    if removed == 0 {
+        return Err(std::io::Error::last_os_error());
+    }
+    Ok(())
+}
+
+#[cfg(windows)]
+fn open_windows_projection_root(root: &Path) -> std::io::Result<cap_std::fs::Dir> {
+    let absolute = if root.is_absolute() {
+        root.to_path_buf()
+    } else {
+        std::env::current_dir()?.join(root)
+    };
+    if absolute
+        .components()
+        .any(|component| matches!(component, std::path::Component::ParentDir))
+    {
+        return Err(std::io::Error::new(
+            std::io::ErrorKind::InvalidInput,
+            "projection root may not contain parent traversal",
+        ));
+    }
+    let ambient_root = absolute
+        .ancestors()
+        .last()
+        .filter(|ancestor| !ancestor.as_os_str().is_empty())
+        .ok_or_else(|| {
+            std::io::Error::new(
+                std::io::ErrorKind::InvalidInput,
+                "projection root has no filesystem root",
+            )
+        })?;
+    let relative = absolute.strip_prefix(ambient_root).map_err(|_| {
+        std::io::Error::new(
+            std::io::ErrorKind::InvalidInput,
+            "projection root is not beneath its filesystem root",
+        )
+    })?;
+    if relative
+        .components()
+        .any(|component| !matches!(component, std::path::Component::Normal(_)))
+    {
+        return Err(std::io::Error::new(
+            std::io::ErrorKind::InvalidInput,
+            "projection root contains an unsupported component",
+        ));
+    }
+
+    let mut current =
+        cap_std::fs::Dir::open_ambient_dir(ambient_root, cap_std::ambient_authority())?;
+    for component in relative.components() {
+        let std::path::Component::Normal(name) = component else {
+            unreachable!("projection root was validated as normal components")
+        };
+        current = open_directory_nofollow(&current, name)?;
+    }
+    Ok(current)
+}
+
+#[cfg(any(unix, windows))]
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+enum TrackedPathRelation {
+    Exact,
+    Ancestor,
+    Descendant,
+    Unrelated,
+}
+
+#[cfg(any(unix, windows))]
+struct TrackedPathClassifier {
+    /// Complete graph-owned leaf keys.
+    exact: HashSet<Vec<OsString>>,
+    /// Strict prefixes of graph-owned leaves. A filesystem directory whose key
+    /// is in this set must be traversed because it contains a tracked leaf.
+    ancestors: HashSet<Vec<OsString>>,
+}
+
+#[cfg(any(unix, windows))]
+impl TrackedPathClassifier {
+    fn new<'a>(tracked: impl IntoIterator<Item = &'a FilePathId>) -> Self {
+        let mut exact = HashSet::new();
+        let mut ancestors = HashSet::new();
+        for file_id in tracked {
+            let key = projection_path_key(Path::new(&file_id.0));
+            for prefix_len in 1..key.len() {
+                ancestors.insert(key[..prefix_len].to_vec());
+            }
+            exact.insert(key);
+        }
+        Self { exact, ancestors }
+    }
+
+    fn relation(&self, relative: &Path) -> TrackedPathRelation {
+        self.relation_with_probe_count(relative).0
+    }
+
+    /// Classify one filesystem path with a number of hash probes bounded by
+    /// path depth, independent of the number of graph-owned files. Returning
+    /// the probe count keeps the complexity contract directly testable without
+    /// a timing-sensitive benchmark.
+    fn relation_with_probe_count(&self, relative: &Path) -> (TrackedPathRelation, usize) {
+        let key = projection_path_key(relative);
+        let mut probes = 1;
+        if self.exact.contains(key.as_slice()) {
+            return (TrackedPathRelation::Exact, probes);
+        }
+        probes += 1;
+        if self.ancestors.contains(key.as_slice()) {
+            return (TrackedPathRelation::Ancestor, probes);
+        }
+        for prefix_len in 1..key.len() {
+            probes += 1;
+            if self.exact.contains(&key[..prefix_len]) {
+                return (TrackedPathRelation::Descendant, probes);
+            }
+        }
+        (TrackedPathRelation::Unrelated, probes)
+    }
+}
+
+#[cfg(any(unix, windows))]
+fn projection_path_key(path: &Path) -> Vec<OsString> {
+    path.components()
+        .map(|component| match component {
+            std::path::Component::Normal(component) => {
+                #[cfg(any(windows, target_os = "macos"))]
+                if let Some(component) = component.to_str() {
+                    return OsString::from(projection_component_comparison_key(component));
+                }
+                component.to_os_string()
+            }
+            other => other.as_os_str().to_os_string(),
+        })
+        .collect()
+}
+
+fn is_reserved_source_component(component: &str) -> bool {
+    if component.eq_ignore_ascii_case(".git")
+        || component.eq_ignore_ascii_case(".kin")
+        || component.eq_ignore_ascii_case(".kin-session")
+    {
+        return true;
+    }
+
+    let key = projection_component_comparison_key(component);
+    matches!(key.as_str(), ".git" | ".kin" | ".kin-session")
+}
+
+fn validate_portable_source_path(path: &str) -> Result<Vec<&str>> {
+    if path.is_empty()
+        || path.len() > 4096
+        || path.starts_with('/')
+        || path.ends_with('/')
+        || path.contains(['\0', '\\'])
+    {
+        return Err(KinError::Other(format!(
+            "unsafe graph-owned source path {path:?}"
+        )));
+    }
+    let components: Vec<_> = path.split('/').collect();
+    if components.iter().any(|component| {
+        component.is_empty()
+            || component.len() > 255
+            || matches!(*component, "." | "..")
+            || is_reserved_source_component(component)
+            || !is_safe_windows_source_component(component)
+    }) {
+        return Err(KinError::Other(format!(
+            "unsafe graph-owned source path {path:?}"
+        )));
+    }
+    Ok(components)
+}
+
+fn validate_source_path(path: &str) -> Result<Vec<&str>> {
+    if path.is_empty()
+        || path.len() > 4096
+        || path.starts_with('/')
+        || path.ends_with('/')
+        || path.contains(['\0', '\\'])
+    {
+        return Err(KinError::Other(format!(
+            "unsafe graph-owned source path {path:?}"
+        )));
+    }
+    let components: Vec<_> = path.split('/').collect();
+    if components.iter().any(|component| {
+        component.is_empty()
+            || component.len() > 255
+            || matches!(*component, "." | "..")
+            || is_reserved_source_component(component)
+            || cfg!(windows) && !is_safe_windows_source_component(component)
+    }) {
+        return Err(KinError::Other(format!(
+            "unsafe graph-owned source path {path:?}"
+        )));
+    }
+    Ok(components)
+}
+
+fn is_safe_windows_source_component(component: &str) -> bool {
+    if component.encode_utf16().count() > 255
+        || component.ends_with(['.', ' '])
+        || component.chars().any(|character| {
+            character <= '\u{1f}' || matches!(character, '<' | '>' | ':' | '"' | '|' | '?' | '*')
+        })
+    {
+        return false;
+    }
+
+    // Mirror cap-primitives' Windows open guard: take the file prefix before
+    // the first non-leading dot, trim trailing whitespace from that prefix,
+    // then apply Unicode uppercase. A looser check can pass global preflight
+    // and fail only after destructive tree preparation has begun.
+    let bytes = component.as_bytes();
+    let stem_end = bytes
+        .get(1..)
+        .and_then(|tail| tail.iter().position(|byte| *byte == b'.'))
+        .map_or(bytes.len(), |index| index + 1);
+    let stem = component[..stem_end].trim_end().to_uppercase();
+    if matches!(
+        stem.as_str(),
+        "CON"
+            | "PRN"
+            | "AUX"
+            | "NUL"
+            | "CONIN$"
+            | "CONOUT$"
+            | "COM0"
+            | "COM1"
+            | "COM2"
+            | "COM3"
+            | "COM4"
+            | "COM5"
+            | "COM6"
+            | "COM7"
+            | "COM8"
+            | "COM9"
+            | "COM¹"
+            | "COM²"
+            | "COM³"
+            | "LPT0"
+            | "LPT1"
+            | "LPT2"
+            | "LPT3"
+            | "LPT4"
+            | "LPT5"
+            | "LPT6"
+            | "LPT7"
+            | "LPT8"
+            | "LPT9"
+            | "LPT¹"
+            | "LPT²"
+            | "LPT³"
+    ) {
+        return false;
+    }
+    true
+}
+
+fn validate_source_symlink_target(path: &[&str], target: &str) -> Result<()> {
+    validate_source_symlink_target_with_windows_rules(path, target, cfg!(windows))
+}
+
+fn validate_source_symlink_target_with_windows_rules(
+    path: &[&str],
+    target: &str,
+    enforce_windows_components: bool,
+) -> Result<()> {
+    if target.is_empty()
+        || target.len() > 4096
+        || target.starts_with('/')
+        || target.contains(['\0', '\\'])
+    {
+        return Err(KinError::Other(format!(
+            "source symlink has unsafe target {target:?}"
+        )));
+    }
+    let mut resolved: Vec<&str> = path[..path.len().saturating_sub(1)].to_vec();
+    for component in target.split('/') {
+        match component {
+            "" => {
+                return Err(KinError::Other(format!(
+                    "source symlink has unsafe target {target:?}"
+                )))
+            }
+            "." => {}
+            ".." => {
+                if resolved.pop().is_none() {
+                    return Err(KinError::Other(format!(
+                        "source symlink target escapes projection root: {target:?}"
+                    )));
+                }
+            }
+            component if is_reserved_source_component(component) => {
+                return Err(KinError::Other(format!(
+                    "source symlink targets reserved control-plane path {target:?}"
+                )))
+            }
+            component
+                if component.len() > 255
+                    || enforce_windows_components
+                        && !is_safe_windows_source_component(component) =>
+            {
+                return Err(KinError::Other(format!(
+                    "source symlink has unmaterializable target component {component:?}"
+                )))
+            }
+            component => resolved.push(component),
+        }
+    }
+    if resolved
+        .iter()
+        .any(|component| is_reserved_source_component(component))
+    {
+        return Err(KinError::Other(format!(
+            "source symlink targets reserved control-plane path {target:?}"
+        )));
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn regular() -> SourceEntryKind {
+        SourceEntryKind::File { executable: false }
+    }
+
+    #[test]
+    fn materialization_rejects_unsafe_source_paths() {
+        let root = tempfile::tempdir().unwrap();
+        for path in [
+            "",
+            "/absolute",
+            "../escape",
+            "src/../escape",
+            ".kin/config",
+            ".KIN/config",
+            ".git/config",
+            ".GiT/config",
+            ".kin-session/base.json",
+            "src/.KIN-SESSION/base.json",
+            "src\\escape",
+        ] {
+            let result = materialize_source_entry(
+                root.path(),
+                &FilePathId(path.to_string()),
+                regular(),
+                b"blocked",
+            );
+            assert!(result.is_err(), "unsafe path was accepted: {path:?}");
+        }
+    }
+
+    #[test]
+    fn unicode_case_aliases_cannot_target_reserved_control_plane_paths() {
+        for component in [".g\u{131}t", ".\u{212a}in", ".\u{212a}in-session"] {
+            assert!(
+                is_reserved_source_component(component),
+                "Unicode alias of a reserved component was accepted: {component:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn portable_source_paths_reject_windows_names_and_cross_platform_aliases() {
+        for path in [
+            "NUL",
+            "src/COM1.rs",
+            "src/trailing.",
+            "src/alternate:stream",
+        ] {
+            assert!(
+                validate_portable_source_paths(std::iter::once(path)).is_err(),
+                "unportable path was accepted: {path:?}"
+            );
+        }
+        for paths in [
+            ["src/Foo.rs", "src/foo.rs"],
+            ["src/caf\u{e9}.rs", "src/cafe\u{301}.rs"],
+        ] {
+            assert!(
+                validate_portable_source_paths(paths).is_err(),
+                "cross-platform aliases were accepted: {paths:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn windows_source_component_validation_rejects_aliasing_names() {
+        for component in [
+            "CON",
+            "con.txt",
+            "PRN",
+            "AUX.log",
+            "NUL",
+            "NUL .log",
+            "COM0",
+            "COM0.rs",
+            "COM1.rs",
+            "COM1 .txt",
+            "com9",
+            "COM¹",
+            "com².rs",
+            "COM³ .txt",
+            "LPT0",
+            "LPT1",
+            "lpt9.txt",
+            "LPT¹",
+            "lpt².rs",
+            "LPT³ .txt",
+            "CONIN$",
+            "CONOUT$",
+            "alternate:stream",
+            "trailing.",
+            "trailing ",
+            "wild*card",
+            "question?mark",
+        ] {
+            assert!(
+                !is_safe_windows_source_component(component),
+                "unsafe Windows component was accepted: {component:?}"
+            );
+        }
+        for component in [
+            "console.rs",
+            "com10",
+            "lpt10",
+            "normal.name",
+            "space inside",
+        ] {
+            assert!(
+                is_safe_windows_source_component(component),
+                "ordinary Windows component was rejected: {component:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn windows_symlink_target_components_reject_unmaterializable_names() {
+        let link_path = ["dir", "link"];
+        let overlong = "x".repeat(256);
+        for target in [
+            "CON/file".to_string(),
+            "nested/aux.txt".to_string(),
+            "alternate:stream".to_string(),
+            "trailing.".to_string(),
+            "wild*card".to_string(),
+            overlong,
+        ] {
+            let error =
+                validate_source_symlink_target_with_windows_rules(&link_path, &target, true)
+                    .expect_err("Windows-invalid link target component must fail preflight");
+            assert!(
+                error
+                    .to_string()
+                    .contains("unmaterializable target component"),
+                "unexpected error for {target:?}: {error}"
+            );
+        }
+
+        validate_source_symlink_target_with_windows_rules(
+            &link_path,
+            "../ordinary/target.rs",
+            true,
+        )
+        .expect("ordinary relative target should remain valid");
+    }
+
+    #[cfg(windows)]
+    #[test]
+    fn windows_symlink_entry_validates_target_before_reporting_unsupported_publication() {
+        let error = validate_source_entry(
+            &FilePathId("dir/link".to_string()),
+            SourceEntryKind::Symlink,
+            b"CON/file",
+        )
+        .expect_err("Windows-invalid target must fail before publication");
+
+        assert!(error
+            .to_string()
+            .contains("unmaterializable target component"));
+    }
+
+    #[test]
+    fn materialization_rejects_escaping_or_reserved_symlink_targets() {
+        let root = tempfile::tempdir().unwrap();
+        for target in [
+            "../../escape",
+            "/absolute",
+            ".kin/config",
+            "../.git/config",
+            "../.kin-session/base.json",
+        ] {
+            let result = materialize_source_entry(
+                root.path(),
+                &FilePathId("dir/link".to_string()),
+                SourceEntryKind::Symlink,
+                target.as_bytes(),
+            );
+            assert!(
+                result.is_err(),
+                "unsafe link target was accepted: {target:?}"
+            );
+        }
+    }
+
+    #[cfg(any(unix, windows))]
+    #[test]
+    fn reserved_control_plane_path_fails_before_destructive_transition() {
+        let root = tempfile::tempdir().unwrap();
+        std::fs::write(root.path().join("a-parent"), b"old complete bytes").unwrap();
+        let transition = FilePathId("a-parent/child.txt".to_string());
+        let reserved = FilePathId("z/.KIN-SESSION/base.json".to_string());
+
+        let error = replace_source_tree(
+            root.path(),
+            [
+                (&transition, regular(), b"new child".as_slice()),
+                (&reserved, regular(), b"forbidden".as_slice()),
+            ],
+            |_| false,
+        )
+        .unwrap_err();
+
+        assert!(error.to_string().contains("unsafe graph-owned source path"));
+        assert_eq!(
+            std::fs::read(root.path().join("a-parent")).unwrap(),
+            b"old complete bytes"
+        );
+        assert!(!root.path().join("a-parent/child.txt").exists());
+        assert!(!root.path().join("z").exists());
+    }
+
+    #[cfg(any(unix, windows))]
+    #[test]
+    fn overlong_component_fails_before_destructive_transition() {
+        let root = tempfile::tempdir().unwrap();
+        std::fs::write(root.path().join("a-parent"), b"old complete bytes").unwrap();
+        let transition = FilePathId("a-parent/child.txt".to_string());
+        let overlong = FilePathId(format!("z/{}", "x".repeat(256)));
+
+        let error = replace_source_tree(
+            root.path(),
+            [
+                (&transition, regular(), b"new child".as_slice()),
+                (&overlong, regular(), b"forbidden".as_slice()),
+            ],
+            |_| false,
+        )
+        .unwrap_err();
+
+        assert!(error.to_string().contains("unsafe graph-owned source path"));
+        assert_eq!(
+            std::fs::read(root.path().join("a-parent")).unwrap(),
+            b"old complete bytes"
+        );
+        assert!(!root.path().join("a-parent/child.txt").exists());
+        assert!(!root.path().join("z").exists());
+    }
+
+    #[cfg(any(unix, windows))]
+    #[test]
+    fn targeted_reconciliation_rejects_untracked_collision_before_removal() {
+        let root = tempfile::tempdir().unwrap();
+        std::fs::write(root.path().join("old-tracked.rs"), b"old tracked bytes").unwrap();
+        std::fs::write(root.path().join("new-target.rs"), b"untracked user bytes").unwrap();
+        let old = FilePathId("old-tracked.rs".to_string());
+        let target = FilePathId("new-target.rs".to_string());
+
+        let error = reconcile_source_tree(
+            root.path(),
+            [(&old, regular(), b"old tracked bytes".as_slice())],
+            [(&target, regular(), b"target bytes".as_slice())],
+            should_preserve_checkout_path,
+        )
+        .unwrap_err();
+
+        assert!(error.to_string().contains("untracked working-copy path"));
+        assert_eq!(
+            std::fs::read(root.path().join("old-tracked.rs")).unwrap(),
+            b"old tracked bytes"
+        );
+        assert_eq!(
+            std::fs::read(root.path().join("new-target.rs")).unwrap(),
+            b"untracked user bytes"
+        );
+    }
+
+    #[cfg(any(unix, windows))]
+    #[test]
+    fn targeted_reconciliation_removes_clean_tracked_generated_path_only() {
+        let root = tempfile::tempdir().unwrap();
+        std::fs::create_dir_all(root.path().join("target/debug")).unwrap();
+        std::fs::write(root.path().join("target/tracked.bin"), b"graph-owned bytes").unwrap();
+        std::fs::write(
+            root.path().join("target/debug/untracked-cache"),
+            b"generated bytes",
+        )
+        .unwrap();
+        let old = FilePathId("target/tracked.bin".to_string());
+
+        reconcile_source_tree(
+            root.path(),
+            [(&old, regular(), b"graph-owned bytes".as_slice())],
+            std::iter::empty::<(&FilePathId, SourceEntryKind, &[u8])>(),
+            should_preserve_checkout_path,
+        )
+        .unwrap();
+
+        assert!(!root.path().join("target/tracked.bin").exists());
+        assert_eq!(
+            std::fs::read(root.path().join("target/debug/untracked-cache")).unwrap(),
+            b"generated bytes"
+        );
+    }
+
+    #[cfg(any(unix, windows))]
+    #[test]
+    fn graph_owned_generated_directory_can_transition_to_file() {
+        for generated in ["target", "vendor", "dist", "build", "node_modules"] {
+            let root = tempfile::tempdir().unwrap();
+            std::fs::create_dir_all(root.path().join(generated).join("nested/deeper")).unwrap();
+            std::fs::write(
+                root.path()
+                    .join(generated)
+                    .join("nested/deeper/tracked.old"),
+                b"old graph bytes",
+            )
+            .unwrap();
+            std::fs::create_dir_all(root.path().join(".next/cache")).unwrap();
+            std::fs::write(root.path().join(".next/cache/untracked"), b"cache bytes").unwrap();
+            let old = FilePathId(format!("{generated}/nested/deeper/tracked.old"));
+            let target = FilePathId(generated.to_string());
+
+            reconcile_source_tree(
+                root.path(),
+                [(&old, regular(), b"old graph bytes".as_slice())],
+                [(&target, regular(), b"new graph file".as_slice())],
+                should_preserve_checkout_path,
+            )
+            .unwrap();
+
+            assert_eq!(
+                std::fs::read(root.path().join(generated)).unwrap(),
+                b"new graph file",
+                "graph-owned {generated} directory must transition to a file"
+            );
+            assert_eq!(
+                std::fs::read(root.path().join(".next/cache/untracked")).unwrap(),
+                b"cache bytes",
+                "unrelated generated content must survive {generated} transition"
+            );
+        }
+    }
+
+    #[cfg(any(unix, windows))]
+    #[test]
+    fn generated_directory_transition_rejects_unrelated_child_before_mutation() {
+        let root = tempfile::tempdir().unwrap();
+        std::fs::create_dir_all(root.path().join("target")).unwrap();
+        std::fs::write(root.path().join("target/tracked.old"), b"old graph bytes").unwrap();
+        std::fs::write(root.path().join("target/editor-cache"), b"editor bytes").unwrap();
+        let old = FilePathId("target/tracked.old".to_string());
+        let target = FilePathId("target".to_string());
+
+        let error = reconcile_source_tree(
+            root.path(),
+            [(&old, regular(), b"old graph bytes".as_slice())],
+            [(&target, regular(), b"new graph file".as_slice())],
+            should_preserve_checkout_path,
+        )
+        .unwrap_err();
+
+        assert!(error.to_string().contains("untracked working-copy path"));
+        assert_eq!(
+            std::fs::read(root.path().join("target/tracked.old")).unwrap(),
+            b"old graph bytes"
+        );
+        assert_eq!(
+            std::fs::read(root.path().join("target/editor-cache")).unwrap(),
+            b"editor bytes"
+        );
+        assert!(root.path().join("target").is_dir());
+    }
+
+    #[cfg(any(unix, windows))]
+    #[test]
+    fn post_preflight_editor_replacement_blocks_overwrite_and_preserves_bytes() {
+        let root = tempfile::tempdir().unwrap();
+        std::fs::create_dir_all(root.path().join("src")).unwrap();
+        let path = root.path().join("src/owned.rs");
+        std::fs::write(&path, b"old graph bytes").unwrap();
+        let owned = FilePathId("src/owned.rs".to_string());
+
+        let error = reconcile_source_tree_with_pre_mutation_hook(
+            root.path(),
+            [(&owned, regular(), b"old graph bytes".as_slice())],
+            [(&owned, regular(), b"new branch bytes".as_slice())],
+            should_preserve_checkout_path,
+            || {
+                let replacement = root.path().join("src/editor.tmp");
+                std::fs::write(&replacement, b"editor bytes").unwrap();
+                std::fs::remove_file(&path).unwrap();
+                std::fs::rename(replacement, &path).unwrap();
+            },
+        )
+        .unwrap_err();
+
+        assert!(error
+            .to_string()
+            .contains("differs from current branch source"));
+        assert_eq!(std::fs::read(&path).unwrap(), b"editor bytes");
+    }
+
+    #[cfg(any(unix, windows))]
+    #[test]
+    fn post_preflight_editor_replacement_blocks_removal_and_preserves_bytes() {
+        let root = tempfile::tempdir().unwrap();
+        std::fs::create_dir_all(root.path().join("src")).unwrap();
+        let path = root.path().join("src/removed.rs");
+        std::fs::write(&path, b"old graph bytes").unwrap();
+        let removed = FilePathId("src/removed.rs".to_string());
+
+        let error = reconcile_source_tree_with_pre_mutation_hook(
+            root.path(),
+            [(&removed, regular(), b"old graph bytes".as_slice())],
+            std::iter::empty::<(&FilePathId, SourceEntryKind, &[u8])>(),
+            should_preserve_checkout_path,
+            || {
+                let replacement = root.path().join("src/editor.tmp");
+                std::fs::write(&replacement, b"editor bytes").unwrap();
+                std::fs::remove_file(&path).unwrap();
+                std::fs::rename(replacement, &path).unwrap();
+            },
+        )
+        .unwrap_err();
+
+        assert!(error
+            .to_string()
+            .contains("differs from current branch source"));
+        assert_eq!(std::fs::read(&path).unwrap(), b"editor bytes");
+    }
+
+    #[cfg(any(unix, windows))]
+    #[test]
+    fn projection_root_kernel_lock_serializes_cross_process_authority() {
+        let root = tempfile::tempdir().unwrap();
+        let first = ProjectionRoot::open(root.path()).unwrap();
+
+        let error = match ProjectionRoot::open(root.path()) {
+            Ok(_) => panic!("a second projection authority entered while the lock was held"),
+            Err(error) => error,
+        };
+        assert!(
+            error
+                .to_string()
+                .contains("another exact-source projection is active"),
+            "unexpected lock refusal: {error}"
+        );
+
+        drop(first);
+        ProjectionRoot::open(root.path())
+            .expect("dropping the retained capability must release the kernel lock");
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn post_preflight_control_directory_replacement_blocks_tree_mutation() {
+        let root = tempfile::tempdir().unwrap();
+        let path = root.path().join("owned.rs");
+        std::fs::write(&path, b"old graph bytes").unwrap();
+        let owned = FilePathId("owned.rs".to_string());
+
+        let error = reconcile_source_tree_with_pre_mutation_hook(
+            root.path(),
+            [(&owned, regular(), b"old graph bytes".as_slice())],
+            [(&owned, regular(), b"new graph bytes".as_slice())],
+            should_preserve_checkout_path,
+            || {
+                std::fs::rename(root.path().join(".kin"), root.path().join(".kin-detached"))
+                    .unwrap();
+                std::fs::create_dir(root.path().join(".kin")).unwrap();
+                std::fs::write(root.path().join(".kin/HEAD"), b"replacement").unwrap();
+            },
+        )
+        .unwrap_err();
+
+        assert!(error.to_string().contains("repository control directory"));
+        assert_eq!(std::fs::read(&path).unwrap(), b"old graph bytes");
+        assert_eq!(
+            std::fs::read(root.path().join(".kin/HEAD")).unwrap(),
+            b"replacement"
+        );
+    }
+
+    #[cfg(any(unix, windows))]
+    #[test]
+    fn post_preflight_same_bytes_replacement_blocks_mutation_by_identity() {
+        let root = tempfile::tempdir().unwrap();
+        std::fs::create_dir_all(root.path().join("src")).unwrap();
+        let path = root.path().join("src/owned.rs");
+        std::fs::write(&path, b"old graph bytes").unwrap();
+        let owned = FilePathId("src/owned.rs".to_string());
+
+        let error = reconcile_source_tree_with_pre_mutation_hook(
+            root.path(),
+            [(&owned, regular(), b"old graph bytes".as_slice())],
+            [(&owned, regular(), b"new branch bytes".as_slice())],
+            should_preserve_checkout_path,
+            || {
+                let replacement = root.path().join("src/editor.tmp");
+                std::fs::write(&replacement, b"old graph bytes").unwrap();
+                std::fs::remove_file(&path).unwrap();
+                std::fs::rename(replacement, &path).unwrap();
+            },
+        )
+        .unwrap_err();
+
+        assert!(error.to_string().contains("changed object identity"));
+        assert_eq!(std::fs::read(&path).unwrap(), b"old graph bytes");
+    }
+
+    #[cfg(any(unix, windows))]
+    #[test]
+    fn post_identity_validation_replacement_is_restored_without_mutation() {
+        let root = tempfile::tempdir().unwrap();
+        std::fs::create_dir_all(root.path().join("src")).unwrap();
+        let path = root.path().join("src/owned.rs");
+        std::fs::write(&path, b"old graph bytes").unwrap();
+        let owned = FilePathId("src/owned.rs".to_string());
+
+        let error = reconcile_source_tree_with_mutation_hooks(
+            root.path(),
+            [(&owned, regular(), b"old graph bytes".as_slice())],
+            [(&owned, regular(), b"new branch bytes".as_slice())],
+            should_preserve_checkout_path,
+            || {},
+            || {
+                let replacement = root.path().join("src/editor.tmp");
+                std::fs::write(&replacement, b"old graph bytes").unwrap();
+                std::fs::remove_file(&path).unwrap();
+                std::fs::rename(replacement, &path).unwrap();
+            },
+        )
+        .unwrap_err();
+
+        assert!(error
+            .to_string()
+            .contains("changed object identity before exact displacement"));
+        assert_eq!(std::fs::read(&path).unwrap(), b"old graph bytes");
+        assert!(std::fs::read_dir(root.path()).unwrap().all(|entry| !entry
+            .unwrap()
+            .file_name()
+            .to_string_lossy()
+            .starts_with(".kin-reconcile-")));
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn directory_identity_swap_is_rejected_even_when_leaf_identity_matches() {
+        let root = tempfile::tempdir().unwrap();
+        std::fs::create_dir(root.path().join("pkg")).unwrap();
+        std::fs::write(root.path().join("pkg/lib.rs"), b"old graph bytes").unwrap();
+        let previous = FilePathId("pkg/lib.rs".to_string());
+        let target = FilePathId("pkg".to_string());
+
+        let error = reconcile_source_tree_with_pre_mutation_hook(
+            root.path(),
+            [(&previous, regular(), b"old graph bytes".as_slice())],
+            [(&target, regular(), b"new graph file".as_slice())],
+            should_preserve_checkout_path,
+            || {
+                std::fs::rename(root.path().join("pkg"), root.path().join("true-pkg")).unwrap();
+                std::fs::create_dir(root.path().join("pkg")).unwrap();
+                std::fs::hard_link(
+                    root.path().join("true-pkg/lib.rs"),
+                    root.path().join("pkg/lib.rs"),
+                )
+                .unwrap();
+            },
+        )
+        .unwrap_err();
+
+        assert!(error.to_string().contains("directory"));
+        assert!(error.to_string().contains("changed identity"));
+        assert_eq!(
+            std::fs::read(root.path().join("true-pkg/lib.rs")).unwrap(),
+            b"old graph bytes"
+        );
+        assert_eq!(
+            std::fs::read(root.path().join("pkg/lib.rs")).unwrap(),
+            b"old graph bytes"
+        );
+    }
+
+    #[cfg(any(unix, windows))]
+    #[test]
+    fn generated_directory_publication_failure_restores_previous_tree() {
+        for generated in ["target", "vendor", "dist", "build", "node_modules"] {
+            let root = tempfile::tempdir().unwrap();
+            let previous_path = root
+                .path()
+                .join(generated)
+                .join("nested/deeper/tracked.old");
+            std::fs::create_dir_all(previous_path.parent().unwrap()).unwrap();
+            std::fs::write(&previous_path, b"old graph bytes").unwrap();
+            let previous = FilePathId(format!("{generated}/nested/deeper/tracked.old"));
+            let target = FilePathId(generated.to_string());
+
+            inject_next_publication_failure();
+            let error = reconcile_source_tree(
+                root.path(),
+                [(&previous, regular(), b"old graph bytes".as_slice())],
+                [(&target, regular(), b"new graph file".as_slice())],
+                should_preserve_checkout_path,
+            )
+            .unwrap_err();
+
+            assert!(error
+                .to_string()
+                .contains("injected exact-source publication failure"));
+            assert_eq!(std::fs::read(&previous_path).unwrap(), b"old graph bytes");
+            assert!(root.path().join(generated).is_dir());
+            assert!(std::fs::read_dir(root.path()).unwrap().all(|entry| !entry
+                .unwrap()
+                .file_name()
+                .to_string_lossy()
+                .starts_with(".kin-reconcile-")));
+        }
+    }
+
+    #[cfg(any(unix, windows))]
+    #[test]
+    fn partial_publication_failure_rolls_back_every_published_entry() {
+        let root = tempfile::tempdir().unwrap();
+        let first_path = root.path().join("first.txt");
+        let second_path = root.path().join("second.txt");
+        std::fs::write(&first_path, b"old first bytes").unwrap();
+        std::fs::write(&second_path, b"old second bytes").unwrap();
+        let first = FilePathId("first.txt".to_string());
+        let second = FilePathId("second.txt".to_string());
+
+        inject_publication_failure_after(1);
+        let error = reconcile_source_tree(
+            root.path(),
+            [
+                (&first, regular(), b"old first bytes".as_slice()),
+                (&second, regular(), b"old second bytes".as_slice()),
+            ],
+            [
+                (&first, regular(), b"new first bytes".as_slice()),
+                (&second, regular(), b"new second bytes".as_slice()),
+            ],
+            should_preserve_checkout_path,
+        )
+        .unwrap_err();
+
+        assert!(error
+            .to_string()
+            .contains("injected exact-source publication failure"));
+        assert_eq!(std::fs::read(&first_path).unwrap(), b"old first bytes");
+        assert_eq!(std::fs::read(&second_path).unwrap(), b"old second bytes");
+        assert!(std::fs::read_dir(root.path()).unwrap().all(|entry| !entry
+            .unwrap()
+            .file_name()
+            .to_string_lossy()
+            .starts_with(".kin-reconcile-")));
+    }
+
+    #[cfg(any(unix, windows))]
+    #[test]
+    fn full_tree_partial_publication_failure_restores_exact_prior_tree() {
+        let root = tempfile::tempdir().unwrap();
+        std::fs::write(root.path().join("first.txt"), b"old first bytes").unwrap();
+        std::fs::write(root.path().join("second.txt"), b"old second bytes").unwrap();
+        std::fs::create_dir_all(root.path().join("untracked/nested")).unwrap();
+        std::fs::write(
+            root.path().join("untracked/nested/sentinel.txt"),
+            b"untracked prior bytes",
+        )
+        .unwrap();
+        let first = FilePathId("first.txt".to_string());
+        let second = FilePathId("second.txt".to_string());
+
+        inject_publication_failure_after(1);
+        let error = replace_source_tree(
+            root.path(),
+            [
+                (&first, regular(), b"new first bytes".as_slice()),
+                (&second, regular(), b"new second bytes".as_slice()),
+            ],
+            |_| false,
+        )
+        .unwrap_err();
+
+        assert!(error
+            .to_string()
+            .contains("injected exact-source publication failure"));
+        assert_eq!(
+            std::fs::read(root.path().join("first.txt")).unwrap(),
+            b"old first bytes"
+        );
+        assert_eq!(
+            std::fs::read(root.path().join("second.txt")).unwrap(),
+            b"old second bytes"
+        );
+        assert_eq!(
+            std::fs::read(root.path().join("untracked/nested/sentinel.txt")).unwrap(),
+            b"untracked prior bytes"
+        );
+        assert!(std::fs::read_dir(root.path()).unwrap().all(|entry| !entry
+            .unwrap()
+            .file_name()
+            .to_string_lossy()
+            .starts_with(".kin-reconcile-")));
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn retained_transaction_cleanup_ignores_ambient_name_substitution() {
+        let root = tempfile::tempdir().unwrap();
+        let projection = ProjectionRoot::open(root.path()).unwrap();
+        let transaction = projection.create_reconciliation_transaction().unwrap();
+        let transaction_path = projection
+            .reconciliation_control_path()
+            .join(&transaction.name);
+        std::fs::write(
+            transaction_path.join("true-backup"),
+            b"true transaction bytes",
+        )
+        .unwrap();
+        let renamed_transaction = projection
+            .reconciliation_control_path()
+            .join("renamed-true-transaction");
+        std::fs::rename(&transaction_path, &renamed_transaction).unwrap();
+        let substitute = transaction_path;
+        std::fs::create_dir(&substitute).unwrap();
+        std::fs::write(substitute.join("attacker-sentinel"), b"must survive").unwrap();
+
+        projection
+            .cleanup_reconciliation_transaction(transaction)
+            .unwrap();
+
+        assert!(!renamed_transaction.exists());
+        assert_eq!(
+            std::fs::read(substitute.join("attacker-sentinel")).unwrap(),
+            b"must survive"
+        );
+    }
+
+    #[cfg(any(unix, windows))]
+    #[test]
+    fn startup_recovers_identity_bound_full_tree_backup_transaction() {
+        let root = tempfile::tempdir().unwrap();
+        let prior = root.path().join("prior.txt");
+        std::fs::write(&prior, b"exact prior bytes").unwrap();
+        let projection = ProjectionRoot::open(root.path()).unwrap();
+        let (identity, state) = projection
+            .inspect_named_existing_object(
+                &projection.root,
+                std::ffi::OsStr::new("prior.txt"),
+                ExistingObjectKind::File,
+                &prior,
+            )
+            .unwrap();
+        let mut transaction = projection.create_reconciliation_transaction().unwrap();
+        projection
+            .back_up_existing_object(
+                &mut transaction,
+                &PlannedExistingObject {
+                    relative: PathBuf::from("prior.txt"),
+                    kind: ExistingObjectKind::File,
+                    identity,
+                    state,
+                },
+                0,
+            )
+            .unwrap();
+        let transaction_path = projection
+            .reconciliation_control_path()
+            .join(&transaction.name);
+        assert!(!prior.exists());
+        assert!(transaction_path.exists());
+        drop(transaction);
+        drop(projection);
+
+        let reopened = ProjectionRoot::open(root.path()).unwrap();
+
+        assert_eq!(std::fs::read(&prior).unwrap(), b"exact prior bytes");
+        assert!(!transaction_path.exists());
+        drop(reopened);
+    }
+
+    #[cfg(any(unix, windows))]
+    #[test]
+    fn startup_rolls_back_crash_after_exact_target_publication() {
+        let root = tempfile::tempdir().unwrap();
+        let prior = root.path().join("owned.txt");
+        std::fs::write(&prior, b"exact prior bytes").unwrap();
+        let file_id = FilePathId("owned.txt".to_string());
+        let entry = ValidatedSourceEntry {
+            file_id: &file_id,
+            kind: regular(),
+            content: b"published target bytes",
+        };
+        let projection = ProjectionRoot::open(root.path()).unwrap();
+        let (identity, state) = projection
+            .inspect_named_existing_object(
+                &projection.root,
+                std::ffi::OsStr::new("owned.txt"),
+                ExistingObjectKind::File,
+                &prior,
+            )
+            .unwrap();
+        let mut transaction = projection.create_reconciliation_transaction().unwrap();
+        let staged = projection
+            .stage_reconciliation_entries(&transaction.directory, &[entry])
+            .unwrap();
+        projection
+            .back_up_existing_object(
+                &mut transaction,
+                &PlannedExistingObject {
+                    relative: PathBuf::from("owned.txt"),
+                    kind: ExistingObjectKind::File,
+                    identity,
+                    state,
+                },
+                0,
+            )
+            .unwrap();
+        projection
+            .publish_staged_entry(&mut transaction, &staged[0])
+            .unwrap();
+        let transaction_path = projection
+            .reconciliation_control_path()
+            .join(&transaction.name);
+        assert_eq!(std::fs::read(&prior).unwrap(), b"published target bytes");
+        drop(transaction);
+        drop(projection);
+
+        ProjectionRoot::open(root.path()).unwrap();
+
+        assert_eq!(std::fs::read(&prior).unwrap(), b"exact prior bytes");
+        assert!(!transaction_path.exists());
+    }
+
+    #[cfg(any(unix, windows))]
+    #[test]
+    fn startup_recovery_preserves_same_identity_post_crash_content_edit() {
+        let root = tempfile::tempdir().unwrap();
+        let path = root.path().join("owned.txt");
+        std::fs::write(&path, b"prior bytes").unwrap();
+        let file_id = FilePathId("owned.txt".to_string());
+        let entry = ValidatedSourceEntry {
+            file_id: &file_id,
+            kind: regular(),
+            content: b"published bytes",
+        };
+        let projection = ProjectionRoot::open(root.path()).unwrap();
+        let (identity, state) = projection
+            .inspect_named_existing_object(
+                &projection.root,
+                std::ffi::OsStr::new("owned.txt"),
+                ExistingObjectKind::File,
+                &path,
+            )
+            .unwrap();
+        let mut transaction = projection.create_reconciliation_transaction().unwrap();
+        let staged = projection
+            .stage_reconciliation_entries(&transaction.directory, &[entry])
+            .unwrap();
+        projection
+            .back_up_existing_object(
+                &mut transaction,
+                &PlannedExistingObject {
+                    relative: PathBuf::from("owned.txt"),
+                    kind: ExistingObjectKind::File,
+                    identity,
+                    state,
+                },
+                0,
+            )
+            .unwrap();
+        projection
+            .publish_staged_entry(&mut transaction, &staged[0])
+            .unwrap();
+        let transaction_path = projection
+            .reconciliation_control_path()
+            .join(&transaction.name);
+        drop(transaction);
+        drop(projection);
+
+        // `write` truncates the existing published inode in place. Identity-
+        // only recovery would delete this editor write and restore the backup.
+        std::fs::write(&path, b"editor bytes after crash").unwrap();
+        let error = match ProjectionRoot::open(root.path()) {
+            Ok(_) => panic!("same-inode post-crash edit was overwritten by recovery"),
+            Err(error) => error,
+        };
+
+        assert!(error.to_string().contains("changed content or mode"));
+        assert_eq!(std::fs::read(&path).unwrap(), b"editor bytes after crash");
+        assert!(
+            transaction_path.exists(),
+            "failed-closed recovery must retain the authenticated transaction"
+        );
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn startup_recovery_preserves_same_identity_post_crash_mode_edit() {
+        use std::os::unix::fs::PermissionsExt;
+
+        let root = tempfile::tempdir().unwrap();
+        let path = root.path().join("owned.sh");
+        std::fs::write(&path, b"prior bytes").unwrap();
+        let file_id = FilePathId("owned.sh".to_string());
+        let entry = ValidatedSourceEntry {
+            file_id: &file_id,
+            kind: regular(),
+            content: b"published bytes",
+        };
+        let projection = ProjectionRoot::open(root.path()).unwrap();
+        let (identity, state) = projection
+            .inspect_named_existing_object(
+                &projection.root,
+                std::ffi::OsStr::new("owned.sh"),
+                ExistingObjectKind::File,
+                &path,
+            )
+            .unwrap();
+        let mut transaction = projection.create_reconciliation_transaction().unwrap();
+        let staged = projection
+            .stage_reconciliation_entries(&transaction.directory, &[entry])
+            .unwrap();
+        projection
+            .back_up_existing_object(
+                &mut transaction,
+                &PlannedExistingObject {
+                    relative: PathBuf::from("owned.sh"),
+                    kind: ExistingObjectKind::File,
+                    identity,
+                    state,
+                },
+                0,
+            )
+            .unwrap();
+        projection
+            .publish_staged_entry(&mut transaction, &staged[0])
+            .unwrap();
+        drop(transaction);
+        drop(projection);
+
+        std::fs::set_permissions(&path, std::fs::Permissions::from_mode(0o600)).unwrap();
+        let error = match ProjectionRoot::open(root.path()) {
+            Ok(_) => panic!("same-inode post-crash mode edit was overwritten by recovery"),
+            Err(error) => error,
+        };
+
+        assert!(error.to_string().contains("changed content or mode"));
+        assert_eq!(
+            std::fs::metadata(&path).unwrap().permissions().mode() & 0o7777,
+            0o600
+        );
+    }
+
+    #[cfg(any(unix, windows))]
+    #[test]
+    fn pending_branch_transaction_recovers_tree_and_head_together() {
+        let root = tempfile::tempdir().unwrap();
+        let layout = crate::init(root.path()).unwrap().layout;
+        let path = root.path().join("owned.txt");
+        std::fs::write(&path, b"main bytes").unwrap();
+        let file_id = FilePathId("owned.txt".to_string());
+        let entry = ValidatedSourceEntry {
+            file_id: &file_id,
+            kind: regular(),
+            content: b"feature bytes",
+        };
+        let transition = BranchProjectionTransition {
+            previous_branch: "main".to_string(),
+            previous_head: SemanticChangeId::from_hash(Hash256::from_bytes([0x11; 32])),
+            target_branch: "feature".to_string(),
+            target_head: SemanticChangeId::from_hash(Hash256::from_bytes([0x12; 32])),
+        };
+        let projection = ProjectionRoot::open(root.path()).unwrap();
+        let (identity, state) = projection
+            .inspect_named_existing_object(
+                &projection.root,
+                std::ffi::OsStr::new("owned.txt"),
+                ExistingObjectKind::File,
+                &path,
+            )
+            .unwrap();
+        let mut transaction = projection
+            .create_reconciliation_transaction_with_transition(Some(transition))
+            .unwrap();
+        let staged = projection
+            .stage_reconciliation_entries(&transaction.directory, &[entry])
+            .unwrap();
+        projection
+            .back_up_existing_object(
+                &mut transaction,
+                &PlannedExistingObject {
+                    relative: PathBuf::from("owned.txt"),
+                    kind: ExistingObjectKind::File,
+                    identity,
+                    state,
+                },
+                0,
+            )
+            .unwrap();
+        projection
+            .publish_staged_entry(&mut transaction, &staged[0])
+            .unwrap();
+        projection
+            .write_branch_marker_capability("feature")
+            .unwrap();
+        let transaction_path = projection
+            .reconciliation_control_path()
+            .join(&transaction.name);
+        drop(transaction);
+        drop(projection);
+
+        ProjectionRoot::open(root.path()).unwrap();
+
+        assert_eq!(std::fs::read(&path).unwrap(), b"main bytes");
+        assert_eq!(
+            crate::read_current_branch(&layout).unwrap().to_string(),
+            "main"
+        );
+        assert!(!transaction_path.exists());
+    }
+
+    #[cfg(any(unix, windows))]
+    #[test]
+    fn committed_branch_transaction_keeps_tree_and_head_during_cleanup_recovery() {
+        let root = tempfile::tempdir().unwrap();
+        let layout = crate::init(root.path()).unwrap().layout;
+        let path = root.path().join("owned.txt");
+        std::fs::write(&path, b"main bytes").unwrap();
+        let file_id = FilePathId("owned.txt".to_string());
+        let entry = ValidatedSourceEntry {
+            file_id: &file_id,
+            kind: regular(),
+            content: b"feature bytes",
+        };
+        let transition = BranchProjectionTransition {
+            previous_branch: "main".to_string(),
+            previous_head: SemanticChangeId::from_hash(Hash256::from_bytes([0x21; 32])),
+            target_branch: "feature".to_string(),
+            target_head: SemanticChangeId::from_hash(Hash256::from_bytes([0x22; 32])),
+        };
+        let projection = ProjectionRoot::open(root.path()).unwrap();
+        let (identity, state) = projection
+            .inspect_named_existing_object(
+                &projection.root,
+                std::ffi::OsStr::new("owned.txt"),
+                ExistingObjectKind::File,
+                &path,
+            )
+            .unwrap();
+        let mut transaction = projection
+            .create_reconciliation_transaction_with_transition(Some(transition))
+            .unwrap();
+        let staged = projection
+            .stage_reconciliation_entries(&transaction.directory, &[entry])
+            .unwrap();
+        projection
+            .back_up_existing_object(
+                &mut transaction,
+                &PlannedExistingObject {
+                    relative: PathBuf::from("owned.txt"),
+                    kind: ExistingObjectKind::File,
+                    identity,
+                    state,
+                },
+                0,
+            )
+            .unwrap();
+        projection
+            .publish_staged_entry(&mut transaction, &staged[0])
+            .unwrap();
+        projection
+            .write_branch_marker_capability("feature")
+            .unwrap();
+        transaction.manifest.state = ReconciliationTransactionState::Committed;
+        projection
+            .persist_reconciliation_manifest(&transaction)
+            .unwrap();
+        let transaction_path = projection
+            .reconciliation_control_path()
+            .join(&transaction.name);
+        drop(transaction);
+        drop(projection);
+
+        ProjectionRoot::open(root.path()).unwrap();
+
+        assert_eq!(std::fs::read(&path).unwrap(), b"feature bytes");
+        assert_eq!(
+            crate::read_current_branch(&layout).unwrap().to_string(),
+            "feature"
+        );
+        assert!(!transaction_path.exists());
+    }
+
+    #[cfg(any(unix, windows))]
+    #[test]
+    fn recovery_actions_are_bounded_authenticated_wal_records() {
+        let root = tempfile::tempdir().unwrap();
+        let projection = ProjectionRoot::open(root.path()).unwrap();
+        let mut transaction = projection.create_reconciliation_transaction().unwrap();
+        let transaction_path = projection
+            .reconciliation_control_path()
+            .join(&transaction.name);
+        let manifest_path = transaction_path.join(RECONCILIATION_MANIFEST_FILE);
+        let manifest_before = std::fs::read(&manifest_path).unwrap();
+        let identity = tracked_open_directory_identity(&projection.root).unwrap();
+
+        for index in 0..32 {
+            projection
+                .record_reconciliation_action(
+                    &mut transaction,
+                    ReconciliationRecoveryAction::PublishDirectory {
+                        relative: PathBuf::from(format!("unused-{index}")),
+                        identity,
+                        slot: format!("unused-slot-{index}"),
+                    },
+                )
+                .unwrap();
+        }
+
+        assert_eq!(
+            std::fs::read(&manifest_path).unwrap(),
+            manifest_before,
+            "action growth must never rewrite the fixed transaction descriptor"
+        );
+        assert_eq!(transaction.manifest.actions.len(), 32);
+        assert!(transaction.action_log_bytes < MAX_RECONCILIATION_ACTION_LOG_BYTES);
+        assert_eq!(
+            std::fs::read_dir(&transaction_path)
+                .unwrap()
+                .filter_map(std::result::Result::ok)
+                .filter(|entry| entry
+                    .file_name()
+                    .to_string_lossy()
+                    .starts_with(RECONCILIATION_ACTION_FILE_PREFIX))
+                .count(),
+            32
+        );
+        projection
+            .cleanup_reconciliation_transaction(transaction)
+            .unwrap();
+    }
+
+    #[cfg(any(unix, windows))]
+    #[test]
+    fn startup_rejects_tampered_recovery_action_without_mutation() {
+        let root = tempfile::tempdir().unwrap();
+        std::fs::write(root.path().join("sentinel.txt"), b"must survive").unwrap();
+        let projection = ProjectionRoot::open(root.path()).unwrap();
+        let mut transaction = projection.create_reconciliation_transaction().unwrap();
+        let identity = tracked_open_directory_identity(&projection.root).unwrap();
+        projection
+            .record_reconciliation_action(
+                &mut transaction,
+                ReconciliationRecoveryAction::PublishDirectory {
+                    relative: PathBuf::from("unused"),
+                    identity,
+                    slot: "unused-slot".to_string(),
+                },
+            )
+            .unwrap();
+        let action_path = projection
+            .reconciliation_control_path()
+            .join(&transaction.name)
+            .join(format!("{RECONCILIATION_ACTION_FILE_PREFIX}{:020}.json", 0));
+        let mut action: AuthenticatedReconciliationAction =
+            serde_json::from_slice(&std::fs::read(&action_path).unwrap()).unwrap();
+        action.authentication[0] ^= 1;
+        std::fs::write(&action_path, serde_json::to_vec(&action).unwrap()).unwrap();
+        drop(transaction);
+        drop(projection);
+
+        let error = match ProjectionRoot::open(root.path()) {
+            Ok(_) => panic!("tampered recovery action unexpectedly recovered"),
+            Err(error) => error,
+        };
+
+        assert!(error.to_string().contains("failed authentication"));
+        assert_eq!(
+            std::fs::read(root.path().join("sentinel.txt")).unwrap(),
+            b"must survive"
+        );
+    }
+
+    #[cfg(any(unix, windows))]
+    #[test]
+    fn startup_rejects_tampered_recovery_manifest_without_mutation() {
+        let root = tempfile::tempdir().unwrap();
+        std::fs::write(root.path().join("sentinel.txt"), b"must survive").unwrap();
+        let projection = ProjectionRoot::open(root.path()).unwrap();
+        let transaction = projection.create_reconciliation_transaction().unwrap();
+        let manifest_path = projection
+            .reconciliation_control_path()
+            .join(&transaction.name)
+            .join(RECONCILIATION_MANIFEST_FILE);
+        let mut manifest: AuthenticatedReconciliationManifest =
+            serde_json::from_slice(&std::fs::read(&manifest_path).unwrap()).unwrap();
+        manifest.authentication[0] ^= 1;
+        std::fs::write(&manifest_path, serde_json::to_vec(&manifest).unwrap()).unwrap();
+        drop(transaction);
+        drop(projection);
+
+        let error = match ProjectionRoot::open(root.path()) {
+            Ok(_) => panic!("tampered manifest unexpectedly recovered"),
+            Err(error) => error,
+        };
+
+        assert!(error.to_string().contains("failed authentication"));
+        assert_eq!(
+            std::fs::read(root.path().join("sentinel.txt")).unwrap(),
+            b"must survive"
+        );
+    }
+
+    #[cfg(any(unix, windows))]
+    #[test]
+    fn startup_cleans_pre_manifest_transaction_residue() {
+        let root = tempfile::tempdir().unwrap();
+        let projection = ProjectionRoot::open(root.path()).unwrap();
+        let residue = projection
+            .reconciliation_control_path()
+            .join(format!("tx-{}", uuid::Uuid::new_v4()));
+        std::fs::create_dir(&residue).unwrap();
+        std::fs::write(residue.join("staged-only"), b"no root mutation").unwrap();
+        drop(projection);
+
+        ProjectionRoot::open(root.path()).unwrap();
+
+        assert!(!residue.exists());
+    }
+
+    #[cfg(any(unix, windows))]
+    #[test]
+    fn graph_path_that_looks_like_legacy_transaction_name_is_materialized() {
+        let root = tempfile::tempdir().unwrap();
+        let target = FilePathId(".kin-reconcile-user.tmp".to_string());
+
+        replace_source_tree(
+            root.path(),
+            [(&target, regular(), b"graph-owned bytes".as_slice())],
+            |_| false,
+        )
+        .unwrap();
+
+        assert_eq!(
+            std::fs::read(root.path().join(".kin-reconcile-user.tmp")).unwrap(),
+            b"graph-owned bytes"
+        );
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn directory_rollback_moves_retained_object_not_substitute() {
+        let root = tempfile::tempdir().unwrap();
+        let projection = ProjectionRoot::open(root.path()).unwrap();
+        let mut transaction = projection.create_reconciliation_transaction().unwrap();
+        let published = projection
+            .stage_and_publish_directory(
+                &mut transaction,
+                &projection.root,
+                std::ffi::OsStr::new("created"),
+                Path::new("created"),
+                0,
+            )
+            .unwrap();
+        let renamed_true_directory = root.path().join("renamed-true-created");
+        std::fs::rename(root.path().join("created"), &renamed_true_directory).unwrap();
+        std::fs::create_dir(root.path().join("created")).unwrap();
+        std::fs::write(
+            root.path().join("created/attacker-sentinel"),
+            b"must survive",
+        )
+        .unwrap();
+
+        projection
+            .move_published_directory_back(&transaction.directory, &published)
+            .unwrap();
+
+        assert!(!renamed_true_directory.exists());
+        assert_eq!(
+            std::fs::read(root.path().join("created/attacker-sentinel")).unwrap(),
+            b"must survive"
+        );
+        projection
+            .cleanup_reconciliation_transaction(transaction)
+            .unwrap();
+        assert_eq!(
+            std::fs::read(root.path().join("created/attacker-sentinel")).unwrap(),
+            b"must survive"
+        );
+    }
+
+    #[cfg(windows)]
+    #[test]
+    fn windows_reserved_component_fails_before_destructive_transition() {
+        for unsafe_component in ["COM0.rs", "LPT¹.txt", "COM1 .txt", "NUL .log"] {
+            let root = tempfile::tempdir().unwrap();
+            std::fs::write(root.path().join("a-parent"), b"old complete bytes").unwrap();
+            let transition = FilePathId("a-parent/child.txt".to_string());
+            let reserved = FilePathId(format!("z/{unsafe_component}"));
+
+            let error = replace_source_tree(
+                root.path(),
+                [
+                    (&transition, regular(), b"new child".as_slice()),
+                    (&reserved, regular(), b"forbidden".as_slice()),
+                ],
+                |_| false,
+            )
+            .unwrap_err();
+
+            assert!(error.to_string().contains("unsafe graph-owned source path"));
+            assert_eq!(
+                std::fs::read(root.path().join("a-parent")).unwrap(),
+                b"old complete bytes"
+            );
+            assert!(!root.path().join("a-parent/child.txt").exists());
+            assert!(!root.path().join("z").exists());
+        }
+    }
+
+    #[cfg(any(unix, windows))]
+    #[test]
+    fn injected_publication_failure_preserves_existing_complete_destination() {
+        let root = tempfile::tempdir().unwrap();
+        let destination = root.path().join("owned.txt");
+        std::fs::write(&destination, b"old complete bytes").unwrap();
+        let file_id = FilePathId("owned.txt".to_string());
+
+        inject_next_publication_failure();
+        let error =
+            materialize_source_entry(root.path(), &file_id, regular(), b"new bytes").unwrap_err();
+
+        assert!(error
+            .to_string()
+            .contains("injected exact-source publication failure"));
+        assert_eq!(std::fs::read(&destination).unwrap(), b"old complete bytes");
+        assert!(
+            std::fs::read_dir(root.path()).unwrap().all(|entry| !entry
+                .unwrap()
+                .file_name()
+                .to_string_lossy()
+                .starts_with(".kin-checkout-")),
+            "a failed exact-source publication must clean only its staged object"
+        );
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn materialization_preserves_regular_executable_and_symlink_kinds() {
+        use std::os::unix::fs::PermissionsExt;
+
+        let root = tempfile::tempdir().unwrap();
+        materialize_source_entry(
+            root.path(),
+            &FilePathId("README.md".to_string()),
+            regular(),
+            b"read me\n",
+        )
+        .unwrap();
+        materialize_source_entry(
+            root.path(),
+            &FilePathId("bin/tool".to_string()),
+            SourceEntryKind::File { executable: true },
+            b"#!/bin/sh\n",
+        )
+        .unwrap();
+        materialize_source_entry(
+            root.path(),
+            &FilePathId("bin/readme".to_string()),
+            SourceEntryKind::Symlink,
+            b"../README.md",
+        )
+        .unwrap();
+
+        assert_eq!(
+            std::fs::read(root.path().join("README.md")).unwrap(),
+            b"read me\n"
+        );
+        assert_eq!(
+            std::fs::metadata(root.path().join("README.md"))
+                .unwrap()
+                .permissions()
+                .mode()
+                & 0o777,
+            0o644
+        );
+        assert_eq!(
+            std::fs::metadata(root.path().join("bin/tool"))
+                .unwrap()
+                .permissions()
+                .mode()
+                & 0o777,
+            0o755
+        );
+        assert_eq!(
+            std::fs::read_link(root.path().join("bin/readme")).unwrap(),
+            Path::new("../README.md")
+        );
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn materialization_replaces_a_parent_symlink_without_following_it() {
+        use std::os::unix::fs::symlink;
+
+        let root = tempfile::tempdir().unwrap();
+        let outside = tempfile::tempdir().unwrap();
+        symlink(outside.path(), root.path().join("redirect")).unwrap();
+
+        materialize_source_entry(
+            root.path(),
+            &FilePathId("redirect/owned".to_string()),
+            regular(),
+            b"must remain inside",
+        )
+        .unwrap();
+
+        assert!(!outside.path().join("owned").exists());
+        assert_eq!(
+            std::fs::read(root.path().join("redirect/owned")).unwrap(),
+            b"must remain inside"
+        );
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn materialization_replaces_a_destination_symlink_without_touching_its_target() {
+        use std::os::unix::fs::symlink;
+
+        let root = tempfile::tempdir().unwrap();
+        let outside = tempfile::tempdir().unwrap();
+        let outside_file = outside.path().join("sentinel");
+        std::fs::write(&outside_file, b"outside").unwrap();
+        symlink(&outside_file, root.path().join("victim")).unwrap();
+
+        materialize_source_entry(
+            root.path(),
+            &FilePathId("victim".to_string()),
+            regular(),
+            b"inside",
+        )
+        .unwrap();
+
+        assert_eq!(std::fs::read(&outside_file).unwrap(), b"outside");
+        assert_eq!(
+            std::fs::read(root.path().join("victim")).unwrap(),
+            b"inside"
+        );
+        assert!(!std::fs::symlink_metadata(root.path().join("victim"))
+            .unwrap()
+            .file_type()
+            .is_symlink());
+    }
+
+    #[test]
+    fn source_tree_preparation_rejects_file_directory_prefix_conflicts() {
+        let root = tempfile::tempdir().unwrap();
+        let paths = [
+            FilePathId("same".to_string()),
+            FilePathId("same/child".to_string()),
+        ];
+
+        let error = prepare_source_tree(root.path(), paths.iter()).unwrap_err();
+        assert!(error
+            .to_string()
+            .contains("conflicting graph-owned source paths"));
+
+        let duplicate = [
+            FilePathId("duplicate".to_string()),
+            FilePathId("duplicate".to_string()),
+        ];
+        let error = prepare_source_tree(root.path(), duplicate.iter()).unwrap_err();
+        assert!(error
+            .to_string()
+            .contains("conflicting graph-owned source paths"));
+
+        #[cfg(any(windows, target_os = "macos"))]
+        {
+            let aliases = [
+                FilePathId("src/Owned.rs".to_string()),
+                FilePathId("SRC/owned.rs".to_string()),
+            ];
+            let error = prepare_source_tree(root.path(), aliases.iter()).unwrap_err();
+            assert!(error
+                .to_string()
+                .contains("conflicting graph-owned source paths"));
+        }
+    }
+
+    #[cfg(any(windows, target_os = "macos"))]
+    #[test]
+    fn source_tree_preparation_rejects_unicode_aliases() {
+        let root = tempfile::tempdir().unwrap();
+        for aliases in [
+            ["src/caf\u{e9}.rs", "src/cafe\u{301}.rs"],
+            ["src/\u{dc}ber.rs", "src/\u{fc}ber.rs"],
+        ] {
+            let paths = aliases.map(|path| FilePathId(path.to_string()));
+            let error = prepare_source_tree(root.path(), paths.iter()).unwrap_err();
+            assert!(
+                error
+                    .to_string()
+                    .contains("conflicting graph-owned source paths"),
+                "Unicode aliases were not rejected: {aliases:?}"
+            );
+        }
+    }
+
+    #[cfg(any(windows, target_os = "macos"))]
+    #[test]
+    fn full_tree_cleanup_preserves_unicode_aliases_of_tracked_destinations() {
+        for (ambient, tracked_path) in [
+            ("src/caf\u{e9}.rs", "src/cafe\u{301}.rs"),
+            ("src/\u{dc}ber.rs", "src/\u{fc}ber.rs"),
+        ] {
+            let root = tempfile::tempdir().unwrap();
+            std::fs::create_dir(root.path().join("src")).unwrap();
+            std::fs::write(root.path().join(ambient), b"old bytes").unwrap();
+            std::fs::write(root.path().join("untracked.txt"), b"remove me").unwrap();
+            let tracked_id = FilePathId(tracked_path.to_string());
+
+            replace_source_tree(
+                root.path(),
+                [(&tracked_id, regular(), b"new complete bytes".as_slice())],
+                |_| false,
+            )
+            .unwrap();
+
+            // The Unicode alias of the tracked path is recognized as the tracked
+            // destination and materialized, not deleted as a stale untracked file.
+            assert_eq!(
+                std::fs::read(root.path().join(tracked_path)).unwrap(),
+                b"new complete bytes",
+                "cleanup did not preserve the Unicode alias of tracked path {tracked_path:?}"
+            );
+            // A genuinely untracked file is still swept.
+            assert!(
+                !root.path().join("untracked.txt").exists(),
+                "cleanup left an untracked file for tracked path {tracked_path:?}"
+            );
+        }
+    }
+
+    #[cfg(any(unix, windows))]
+    #[test]
+    fn tracked_cleanup_classification_is_bounded_by_path_depth() {
+        let tracked: Vec<_> = (0..20_000)
+            .map(|index| FilePathId(format!("src/generated/{index}/owned.rs")))
+            .collect();
+        let classifier = TrackedPathClassifier::new(tracked.iter());
+
+        let (relation, probes) =
+            classifier.relation_with_probe_count(Path::new("src/unrelated/leaf.rs"));
+        assert_eq!(relation, TrackedPathRelation::Unrelated);
+        assert!(
+            probes <= 5,
+            "classification used {probes} probes for a four-component path"
+        );
+
+        let (relation, probes) =
+            classifier.relation_with_probe_count(Path::new("src/generated/19999/owned.rs/cache"));
+        assert_eq!(relation, TrackedPathRelation::Descendant);
+        assert!(
+            probes <= 6,
+            "descendant classification used {probes} probes for a five-component path"
+        );
+    }
+
+    #[cfg(any(windows, target_os = "macos"))]
+    #[test]
+    fn full_tree_cleanup_never_deletes_a_case_aliased_tracked_destination() {
+        let root = tempfile::tempdir().unwrap();
+        std::fs::create_dir(root.path().join("SRC")).unwrap();
+        std::fs::write(root.path().join("SRC/Owned.rs"), b"old bytes").unwrap();
+        std::fs::write(root.path().join("untracked.txt"), b"remove me").unwrap();
+        let file_id = FilePathId("src/owned.rs".to_string());
+
+        replace_source_tree(
+            root.path(),
+            [(&file_id, regular(), b"new complete bytes".as_slice())],
+            |_| false,
+        )
+        .unwrap();
+
+        assert_eq!(
+            std::fs::read(root.path().join("src/owned.rs")).unwrap(),
+            b"new complete bytes"
+        );
+        assert!(!root.path().join("untracked.txt").exists());
+    }
+
+    #[cfg(any(unix, windows))]
+    #[test]
+    fn source_tree_preparation_handles_both_file_directory_transitions() {
+        let root = tempfile::tempdir().unwrap();
+        std::fs::write(root.path().join("file_to_dir"), b"old file").unwrap();
+        std::fs::create_dir(root.path().join("dir_to_file")).unwrap();
+        std::fs::write(root.path().join("dir_to_file/old"), b"old child").unwrap();
+        let paths = [
+            FilePathId("file_to_dir/new".to_string()),
+            FilePathId("dir_to_file".to_string()),
+        ];
+
+        prepare_source_tree(root.path(), paths.iter()).unwrap();
+        materialize_source_entry(root.path(), &paths[0], regular(), b"new child").unwrap();
+        materialize_source_entry(root.path(), &paths[1], regular(), b"new file").unwrap();
+
+        assert_eq!(
+            std::fs::read(root.path().join("file_to_dir/new")).unwrap(),
+            b"new child"
+        );
+        assert_eq!(
+            std::fs::read(root.path().join("dir_to_file")).unwrap(),
+            b"new file"
+        );
+    }
+
+    #[cfg(any(unix, windows))]
+    #[test]
+    fn full_tree_cleanup_does_not_retain_children_of_a_replaced_directory() {
+        let root = tempfile::tempdir().unwrap();
+        std::fs::create_dir(root.path().join("dir_to_file")).unwrap();
+        std::fs::write(root.path().join("dir_to_file/old"), b"old child").unwrap();
+        let file_id = FilePathId("dir_to_file".to_string());
+
+        replace_source_tree(
+            root.path(),
+            [(&file_id, regular(), b"new file".as_slice())],
+            |_| false,
+        )
+        .unwrap();
+
+        assert_eq!(
+            std::fs::read(root.path().join("dir_to_file")).unwrap(),
+            b"new file"
+        );
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn retained_root_capability_survives_ambient_root_swap_at_preflight_barrier() {
+        use std::os::unix::fs::symlink;
+        use std::sync::{Arc, Barrier};
+
+        let sandbox = tempfile::tempdir().unwrap();
+        let root = sandbox.path().join("root");
+        let moved_root = sandbox.path().join("moved-root");
+        let outside = sandbox.path().join("outside");
+        std::fs::create_dir(&root).unwrap();
+        std::fs::create_dir(&outside).unwrap();
+        std::fs::write(root.join("old.txt"), b"remove me").unwrap();
+        std::fs::write(outside.join("sentinel"), b"outside").unwrap();
+
+        let ready = Arc::new(Barrier::new(2));
+        let resume = Arc::new(Barrier::new(2));
+        std::thread::scope(|scope| {
+            let ready_worker = Arc::clone(&ready);
+            let resume_worker = Arc::clone(&resume);
+            let root_worker = root.clone();
+            scope.spawn(move || {
+                let file_id = FilePathId("owned.txt".to_string());
+                let entries =
+                    validated_source_entries([(&file_id, regular(), b"inside".as_slice())])
+                        .unwrap();
+                project_validated_source_tree(&root_worker, &entries, Some(&|_| false), || {
+                    ready_worker.wait();
+                    resume_worker.wait();
+                })
+                .unwrap();
+            });
+
+            ready.wait();
+            std::fs::rename(&root, &moved_root).unwrap();
+            symlink(&outside, &root).unwrap();
+            resume.wait();
+        });
+
+        assert_eq!(std::fs::read(outside.join("sentinel")).unwrap(), b"outside");
+        assert!(!outside.join("owned.txt").exists());
+        assert_eq!(
+            std::fs::read(moved_root.join("owned.txt")).unwrap(),
+            b"inside"
+        );
+        assert!(!moved_root.join("old.txt").exists());
+    }
+
+    #[cfg(windows)]
+    #[test]
+    fn retained_root_capability_blocks_ambient_root_swap_at_preflight_barrier() {
+        use std::sync::{Arc, Barrier};
+
+        let sandbox = tempfile::tempdir().unwrap();
+        let root = sandbox.path().join("root");
+        let moved_root = sandbox.path().join("moved-root");
+        std::fs::create_dir(&root).unwrap();
+        std::fs::write(root.join("old.txt"), b"remove me").unwrap();
+
+        let ready = Arc::new(Barrier::new(2));
+        let resume = Arc::new(Barrier::new(2));
+        std::thread::scope(|scope| {
+            let ready_worker = Arc::clone(&ready);
+            let resume_worker = Arc::clone(&resume);
+            let root_worker = root.clone();
+            let worker = scope.spawn(move || {
+                let file_id = FilePathId("owned.txt".to_string());
+                let entries =
+                    validated_source_entries([(&file_id, regular(), b"inside".as_slice())])
+                        .unwrap();
+                project_validated_source_tree(&root_worker, &entries, Some(&|_| false), || {
+                    ready_worker.wait();
+                    resume_worker.wait();
+                })
+            });
+
+            ready.wait();
+            assert!(
+                std::fs::rename(&root, &moved_root).is_err(),
+                "a retained Windows directory capability must block root replacement"
+            );
+            resume.wait();
+            worker.join().unwrap().unwrap();
+        });
+
+        assert_eq!(std::fs::read(root.join("owned.txt")).unwrap(), b"inside");
+        assert!(!root.join("old.txt").exists());
+        assert!(!moved_root.exists());
+    }
+
+    #[cfg(windows)]
+    #[test]
+    fn materialization_replaces_descendant_junction_without_following_it() {
+        let sandbox = tempfile::tempdir().unwrap();
+        let root = sandbox.path().join("root");
+        let outside = sandbox.path().join("outside");
+        std::fs::create_dir(&root).unwrap();
+        std::fs::create_dir(&outside).unwrap();
+        std::fs::write(outside.join("artifact"), b"outside").unwrap();
+
+        let junction = root.join("junction");
+        let output = std::process::Command::new("cmd")
+            .args(["/C", "mklink", "/J"])
+            .arg(&junction)
+            .arg(&outside)
+            .output()
+            .unwrap();
+        assert!(
+            output.status.success(),
+            "failed to create test junction: {}{}",
+            String::from_utf8_lossy(&output.stdout),
+            String::from_utf8_lossy(&output.stderr)
+        );
+
+        materialize_source_entry(
+            &root,
+            &FilePathId("junction/artifact".to_string()),
+            regular(),
+            b"inside",
+        )
+        .unwrap();
+
+        assert_eq!(std::fs::read(outside.join("artifact")).unwrap(), b"outside");
+        assert_eq!(std::fs::read(junction.join("artifact")).unwrap(), b"inside");
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn nested_parent_symlink_swap_at_preflight_barrier_cannot_escape() {
+        use std::os::unix::fs::symlink;
+        use std::sync::{Arc, Barrier};
+
+        let sandbox = tempfile::tempdir().unwrap();
+        let root = sandbox.path().join("root");
+        let outside = sandbox.path().join("outside");
+        std::fs::create_dir_all(root.join("a/b")).unwrap();
+        std::fs::create_dir(&outside).unwrap();
+        std::fs::write(outside.join("sentinel"), b"outside").unwrap();
+
+        let ready = Arc::new(Barrier::new(2));
+        let resume = Arc::new(Barrier::new(2));
+        std::thread::scope(|scope| {
+            let ready_worker = Arc::clone(&ready);
+            let resume_worker = Arc::clone(&resume);
+            let root_worker = root.clone();
+            scope.spawn(move || {
+                let file_id = FilePathId("a/b/file".to_string());
+                let entries =
+                    validated_source_entries([(&file_id, regular(), b"inside".as_slice())])
+                        .unwrap();
+                project_validated_source_tree(&root_worker, &entries, None, || {
+                    ready_worker.wait();
+                    resume_worker.wait();
+                })
+                .unwrap();
+            });
+
+            ready.wait();
+            std::fs::remove_dir_all(root.join("a")).unwrap();
+            symlink(&outside, root.join("a")).unwrap();
+            resume.wait();
+        });
+
+        assert_eq!(std::fs::read(outside.join("sentinel")).unwrap(), b"outside");
+        assert!(!outside.join("b/file").exists());
+        assert_eq!(std::fs::read(root.join("a/b/file")).unwrap(), b"inside");
+        assert!(!std::fs::symlink_metadata(root.join("a"))
+            .unwrap()
+            .file_type()
+            .is_symlink());
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn nested_cleanup_parent_swap_fails_without_touching_symlink_target() {
+        use std::os::unix::fs::symlink;
+        use std::sync::{Arc, Barrier};
+
+        let sandbox = tempfile::tempdir().unwrap();
+        let root = sandbox.path().join("root");
+        let outside = sandbox.path().join("outside");
+        std::fs::create_dir_all(root.join("a")).unwrap();
+        std::fs::create_dir(&outside).unwrap();
+        std::fs::write(root.join("a/delete.txt"), b"inside old tree").unwrap();
+        std::fs::write(outside.join("delete.txt"), b"outside sentinel").unwrap();
+
+        let ready = Arc::new(Barrier::new(2));
+        let resume = Arc::new(Barrier::new(2));
+        let result = std::thread::scope(|scope| {
+            let ready_worker = Arc::clone(&ready);
+            let resume_worker = Arc::clone(&resume);
+            let root_worker = root.clone();
+            let handle = scope.spawn(move || {
+                let file_id = FilePathId("tracked.txt".to_string());
+                let entries =
+                    validated_source_entries([(&file_id, regular(), b"tracked".as_slice())])
+                        .unwrap();
+                project_validated_source_tree(&root_worker, &entries, Some(&|_| false), || {
+                    ready_worker.wait();
+                    resume_worker.wait();
+                })
+            });
+
+            ready.wait();
+            std::fs::remove_dir_all(root.join("a")).unwrap();
+            symlink(&outside, root.join("a")).unwrap();
+            resume.wait();
+            handle.join().unwrap()
+        });
+
+        assert!(result.is_err(), "a swapped cleanup parent must fail closed");
+        assert_eq!(
+            std::fs::read(outside.join("delete.txt")).unwrap(),
+            b"outside sentinel"
+        );
+    }
 }

--- a/crates/kin-daemon/Cargo.toml
+++ b/crates/kin-daemon/Cargo.toml
@@ -40,6 +40,7 @@ kin-lsp = { workspace = true }
 kin-cli = { workspace = true }
 kin-buildinfo = { workspace = true }
 kin-mcp = { workspace = true }
+kin-review = { workspace = true }
 gix = { workspace = true }
 axum = { workspace = true }
 tokio = { workspace = true }
@@ -74,6 +75,7 @@ kin-infer = { version = ">=0.2.1", registry = "kin", features = ["metal"] }
 [dev-dependencies]
 base64 = "0.22"
 kin-git = { workspace = true }
+http-body = "1"
 tempfile = { workspace = true }
 pretty_assertions = { workspace = true }
 serial_test = { workspace = true }

--- a/crates/kin-daemon/src/api.rs
+++ b/crates/kin-daemon/src/api.rs
@@ -15,7 +15,7 @@ use crate::state::{
 };
 
 use axum::extract::{Path, Query, State};
-use axum::http::{header, HeaderValue, StatusCode};
+use axum::http::{header, HeaderMap, HeaderName, HeaderValue, StatusCode};
 use axum::middleware::{self, Next};
 use axum::response::{IntoResponse, Response};
 use axum::routing::{delete, get, post, put};
@@ -23,16 +23,64 @@ use axum::{Json, Router};
 use kin_model::session::{Intent, IntentScope, IntentSummary, LockType};
 use kin_model::{
     Branch, BranchName, ChangeStore, ContractId, EntityId, EntityStore, FileLayout, FilePathId,
-    GraphNodeId, IntentId, ProvenanceStore, SessionCapabilities, SessionId, SessionStore,
-    SessionTransport, WorkStore,
+    GraphNodeId, IntentId, ProvenanceStore, ResolvedSourceEntry, SessionCapabilities, SessionId,
+    SessionStore, SessionTransport, SourceEntryKind, SourceTreeResolution, WorkStore,
 };
 use serde::{Deserialize, Serialize};
 use serde_json::json;
+use sha2::{Digest, Sha256};
 use socket2::{Domain, Protocol, Socket, Type};
 use tracing::info;
 use uuid::Uuid;
 
 static BOOTSTRAP_EXPORTS: OnceLock<Arc<tokio::sync::Semaphore>> = OnceLock::new();
+static EXACT_SOURCE_ARCHIVE_EXPORTS: OnceLock<Arc<tokio::sync::Semaphore>> = OnceLock::new();
+
+fn exact_source_archive_exports() -> Arc<tokio::sync::Semaphore> {
+    Arc::clone(
+        EXACT_SOURCE_ARCHIVE_EXPORTS.get_or_init(|| Arc::new(tokio::sync::Semaphore::new(1))),
+    )
+}
+
+fn hold_exact_source_archive_permit<T, E>(
+    permit: tokio::sync::OwnedSemaphorePermit,
+    work: impl FnOnce() -> Result<T, E>,
+) -> Result<(T, tokio::sync::OwnedSemaphorePermit), E> {
+    let output = work()?;
+    Ok((output, permit))
+}
+
+/// Own the archive bytes and their memory-admission permit together. `Bytes`
+/// retains this owner across response-body and hyper socket-buffer clones, so
+/// admission cannot reopen while any copy still keeps the allocation alive.
+struct ExactSourceArchiveAllocation {
+    archive: Vec<u8>,
+    _permit: tokio::sync::OwnedSemaphorePermit,
+}
+
+impl ExactSourceArchiveAllocation {
+    fn new(archive: Vec<u8>, permit: tokio::sync::OwnedSemaphorePermit) -> Self {
+        Self {
+            archive,
+            _permit: permit,
+        }
+    }
+}
+
+impl AsRef<[u8]> for ExactSourceArchiveAllocation {
+    fn as_ref(&self) -> &[u8] {
+        &self.archive
+    }
+}
+
+fn exact_source_archive_body(
+    archive: Vec<u8>,
+    permit: tokio::sync::OwnedSemaphorePermit,
+) -> axum::body::Body {
+    axum::body::Body::from(axum::body::Bytes::from_owner(
+        ExactSourceArchiveAllocation::new(archive, permit),
+    ))
+}
 
 /// Acquire a `std::sync::Mutex`, recovering the guard if the lock was poisoned
 /// by a panic in a prior holder.
@@ -527,12 +575,157 @@ pub struct DaemonCommitRequest {
     pub audit_event: Option<kin_model::provenance::AuditEvent>,
     #[serde(default)]
     pub session_id: Option<String>,
+    #[serde(default)]
+    pub release_policy: Option<DaemonReleasePolicy>,
+}
+
+#[derive(Debug, Deserialize)]
+pub struct DaemonReleasePolicy {
+    #[serde(default)]
+    pub force: bool,
+    #[serde(default)]
+    pub require_proof: bool,
+    #[serde(default)]
+    pub require_approval: bool,
+}
+
+fn release_policy_failure(gate: &str, fields: serde_json::Value) -> (StatusCode, String) {
+    let mut body = serde_json::json!({
+        "error": "release_policy_failed",
+        "gate": gate,
+        "mutation_applied": false,
+    });
+    if let (Some(body), Some(fields)) = (body.as_object_mut(), fields.as_object()) {
+        body.extend(fields.clone());
+    }
+    (StatusCode::CONFLICT, body.to_string())
+}
+
+fn canonical_release_entity_count(message: &str) -> Option<usize> {
+    let (tag, snapshot) = message
+        .strip_prefix("release: ")
+        .and_then(|message| message.rsplit_once(" ("))?;
+    let entity_count = snapshot.strip_suffix(" entities snapshot)")?;
+    if tag.trim().is_empty() || tag != tag.trim() || tag.chars().any(char::is_control) {
+        return None;
+    }
+    entity_count.parse::<usize>().ok()
+}
+
+fn release_change_reachable_from(
+    graph: &kin_db::InMemoryGraph,
+    target: &kin_model::SemanticChangeId,
+    head: &kin_model::SemanticChangeId,
+) -> Result<bool, (StatusCode, String)> {
+    let mut pending = vec![*head];
+    let mut visited = HashSet::new();
+    while let Some(change_id) = pending.pop() {
+        if change_id == *target {
+            return Ok(true);
+        }
+        if !visited.insert(change_id) {
+            continue;
+        }
+        let change = graph
+            .get_change(&change_id)
+            .map_err(internal_error)?
+            .ok_or_else(|| {
+                (
+                    StatusCode::INTERNAL_SERVER_ERROR,
+                    format!("branch history at {head} references missing change {change_id}"),
+                )
+            })?;
+        pending.extend(change.parents);
+    }
+    Ok(false)
+}
+
+/// Enforce daemon release policy against the immutable source authority named
+/// by the release marker's sole parent.
+///
+/// The live graph can contain overlays, later branch heads, and verification
+/// runs created after this source state. Rebuilding a historical evidence graph
+/// keeps entity/coverage/approval decisions anchored to `source_head`. Because
+/// VerificationRun does not yet carry an immutable source-change or manifest
+/// binding, `release_evidence_graph_at` intentionally admits no current run as
+/// proof; strict proof therefore fails closed whenever the historical head has
+/// entities.
+fn enforce_daemon_release_policy(
+    graph: &kin_db::InMemoryGraph,
+    source_head: &kin_model::SemanticChangeId,
+    marker_entity_count: usize,
+    policy: &DaemonReleasePolicy,
+) -> Result<(), (StatusCode, String)> {
+    let frozen_snapshot = graph.to_snapshot();
+    let frozen_root = kin_db::compute_graph_root_hash(&frozen_snapshot);
+    let frozen_graph = kin_db::InMemoryGraph::from_snapshot_without_text_index_with_root_hash(
+        frozen_snapshot.clone(),
+        frozen_root,
+    );
+    let (evidence_graph, _) =
+        release_evidence_graph_at(&frozen_graph, &frozen_snapshot, source_head)?;
+    let source_entity_count = evidence_graph
+        .list_all_entities()
+        .map_err(internal_error)?
+        .len();
+    if marker_entity_count != source_entity_count {
+        return Err((
+            StatusCode::BAD_REQUEST,
+            serde_json::json!({
+                "error": "invalid_release_snapshot_count",
+                "mutation_applied": false,
+                "marker_entity_count": marker_entity_count,
+                "source_entity_count": source_entity_count,
+                "source_head": source_head.to_string(),
+                "message": "release marker entity count does not match its immutable source",
+            })
+            .to_string(),
+        ));
+    }
+    let coverage =
+        kin_review::source_bound_release_proof_coverage(&evidence_graph).map_err(internal_error)?;
+
+    if coverage.coverage_ratio < 0.5 && !policy.force {
+        return Err(release_policy_failure(
+            "coverage",
+            serde_json::json!({
+                "coverage_ratio": coverage.coverage_ratio,
+                "source_head": source_head.to_string(),
+                "message": "immutable source-bound release coverage is below the 50% threshold",
+            }),
+        ));
+    }
+    if policy.require_proof && !coverage.missing_proof.is_empty() {
+        return Err(release_policy_failure(
+            "proof",
+            serde_json::json!({
+                "missing_proof": coverage.missing_proof.iter().map(ToString::to_string).collect::<Vec<_>>(),
+                "source_head": source_head.to_string(),
+                "message": "release contains entities without immutable source-bound passing proof; current verification runs do not carry source authority",
+            }),
+        ));
+    }
+    if policy.require_approval {
+        let unapproved = kin_review::unapproved_changes(&evidence_graph, source_head, usize::MAX)
+            .map_err(internal_error)?;
+        if !unapproved.is_empty() {
+            return Err(release_policy_failure(
+                "approval",
+                serde_json::json!({
+                    "unapproved_changes": unapproved.iter().map(|change| change.change_id.to_string()).collect::<Vec<_>>(),
+                    "source_head": source_head.to_string(),
+                    "message": "release contains non-root changes without human approval reachable from its immutable parent",
+                }),
+            ));
+        }
+    }
+    Ok(())
 }
 
 /// The current API version number, returned in the `X-Kin-API-Version` header.
-pub const API_VERSION: &str = "1";
+pub const API_VERSION: &str = "2";
 
-/// Axum middleware that adds `X-Kin-API-Version: 1` to every response.
+/// Axum middleware that adds the current `X-Kin-API-Version` to every response.
 async fn api_version_header(
     request: axum::http::Request<axum::body::Body>,
     next: Next,
@@ -755,7 +948,13 @@ fn auth_error(status: StatusCode, message: &str) -> Response {
 }
 
 /// Build the core route set (without state or middleware).
-fn api_routes() -> Router<Arc<DaemonState>> {
+fn api_routes(retire_v1_branch_head_update: bool) -> Router<Arc<DaemonState>> {
+    let branch_head_update: axum::routing::MethodRouter<Arc<DaemonState>> =
+        if retire_v1_branch_head_update {
+            put(graph_update_branch_head_v1_retired)
+        } else {
+            put(graph_update_branch_head)
+        };
     Router::new()
         .route("/health", get(health))
         .route("/readiness", get(readiness))
@@ -826,7 +1025,7 @@ fn api_routes() -> Router<Arc<DaemonState>> {
             get(graph_list_branches).post(graph_create_branch),
         )
         .route("/graph/branches/{name}", delete(graph_delete_branch))
-        .route("/graph/branches/{name}/head", put(graph_update_branch_head))
+        .route("/graph/branches/{name}/head", branch_head_update)
         .route("/mcp/tools/call", post(mcp_tools_call))
         // Multi-repo endpoints — list and query lazily-loaded repo graphs
         .route("/repos", get(list_repos))
@@ -836,6 +1035,14 @@ fn api_routes() -> Router<Arc<DaemonState>> {
         .route("/repos/{repo_id}/refs", get(repo_refs))
         .route("/repos/{repo_id}/history", get(repo_history))
         .route("/repos/{repo_id}/compare", get(repo_compare))
+        .route(
+            "/repos/{repo_id}/archive/tar/{source_change_id}",
+            get(repo_exact_source_tar_gz),
+        )
+        .route(
+            "/repos/{repo_id}/release/evidence/{source_change_id}",
+            get(repo_release_evidence),
+        )
         // Provenance endpoints — Merkle DAG proof lineage
         .route(
             "/repos/{repo_id}/provenance/entity/{entity_id}",
@@ -1077,14 +1284,17 @@ fn npm_registry_auth_error(status: StatusCode, message: &str) -> Response {
 
 /// Build the axum router with all daemon API routes.
 ///
-/// Routes are served at both `/` (backward compat) and `/v1/` prefixes.
-/// All responses include the `X-Kin-API-Version: 1` header.
+/// Routes are served at `/`, `/v2/`, and the legacy `/v1/` read-compatibility
+/// prefix. The unsafe v1 branch-head mutation is explicitly retired instead
+/// of silently accepting the v2 CAS contract. All responses identify the
+/// effective API contract in the `X-Kin-API-Version` header.
 pub fn router(state: Arc<DaemonState>) -> Router {
     router_with_auth(state, None)
 }
 
 fn router_with_auth(state: Arc<DaemonState>, auth_token: Option<String>) -> Router {
-    let routes = api_routes();
+    let routes = api_routes(false);
+    let legacy_v1_routes = api_routes(true);
     let activity_state = Arc::clone(&state);
 
     // Package registry — all ecosystems share the same packages dir and manifest store
@@ -1155,7 +1365,8 @@ fn router_with_auth(state: Arc<DaemonState>, auth_token: Option<String>) -> Rout
     // `validate_host_and_origin`) still apply to EVERYTHING, registry included.
     let daemon_routes = Router::new()
         .merge(routes.clone())
-        .nest("/v1", routes)
+        .nest("/v1", legacy_v1_routes)
+        .nest("/v2", routes)
         .layer(middleware::from_fn_with_state(
             DaemonAuthState { auth_token },
             daemon_auth,
@@ -2060,7 +2271,186 @@ async fn graph_commit(
 ) -> Result<impl IntoResponse, (StatusCode, String)> {
     use kin_model::{EntityDelta, RelationDelta};
 
+    // Serialize caller-supplied history publication so the same-ID check and
+    // insertion are one authority operation. `create_change` is an overwrite
+    // primitive internally, so the API must enforce immutable IDs itself.
+    let _mutation_guard = state.coordination_gate.lock().await;
     let graph = &*state.graph;
+    let live_branch = graph
+        .get_branch(&request.branch_name)
+        .map_err(internal_error)?;
+    let change_already_exists = match graph
+        .get_change(&request.change.id)
+        .map_err(internal_error)?
+    {
+        Some(existing) => {
+            let existing = serde_json::to_value(&existing).map_err(internal_error)?;
+            let incoming = serde_json::to_value(&request.change).map_err(internal_error)?;
+            if existing != incoming {
+                return Err((
+                    StatusCode::CONFLICT,
+                    serde_json::json!({
+                        "error": "semantic_change_id_collision",
+                        "change_id": request.change.id.to_string(),
+                        "mutation_applied": false,
+                        "message": "semantic change ID already exists with a different immutable payload",
+                    })
+                    .to_string(),
+                ));
+            }
+            true
+        }
+        None => false,
+    };
+
+    let release_author = request.change.author.to_string() == "kin-release";
+    let release_message_signal = request.change.message.starts_with("release: ");
+    let release_entity_count = canonical_release_entity_count(&request.change.message);
+    let release_marker = release_author && release_entity_count.is_some();
+    if release_author != release_message_signal
+        || (release_message_signal && release_entity_count.is_none())
+    {
+        return Err((
+            StatusCode::BAD_REQUEST,
+            serde_json::json!({
+                "error": "invalid_release_marker",
+                "mutation_applied": false,
+                "message": "release markers must use both the canonical kin-release author and release: message prefix",
+            })
+            .to_string(),
+        ));
+    }
+    let release_shape_is_empty = request.change.parents.len() == 1
+        && request.change.entity_deltas.is_empty()
+        && request.change.relation_deltas.is_empty()
+        && request.change.artifact_deltas.is_empty()
+        && request.change.projected_files.is_empty()
+        && request.shallow_files.is_empty()
+        && request.shallow_clears.is_empty()
+        && request.audit_event.is_none()
+        && request.change.authored_on.as_ref() == Some(&request.branch_name);
+
+    if release_marker && request.release_policy.is_none() {
+        return Err((
+            StatusCode::BAD_REQUEST,
+            serde_json::json!({
+                "error": "release_policy_required",
+                "mutation_applied": false,
+                "message": "release changes must carry daemon-enforced release policy",
+            })
+            .to_string(),
+        ));
+    }
+
+    if request.release_policy.is_some() {
+        if live_branch.is_none() {
+            return Err((
+                StatusCode::CONFLICT,
+                serde_json::json!({
+                    "error": "release_branch_missing",
+                    "branch": request.branch_name.to_string(),
+                    "change_id": request.change.id.to_string(),
+                    "change_materialized": change_already_exists,
+                    "mutation_applied": false,
+                    "message": "release requires an existing branch authority",
+                })
+                .to_string(),
+            ));
+        }
+        if !release_marker || !release_shape_is_empty {
+            return Err((
+                StatusCode::BAD_REQUEST,
+                serde_json::json!({
+                    "error": "invalid_release_change_shape",
+                    "mutation_applied": false,
+                    "message": "release commits must be empty-delta marker changes with exactly one live parent",
+                })
+                .to_string(),
+            ));
+        }
+    }
+
+    let exact_release_retry = release_marker
+        && release_shape_is_empty
+        && request.release_policy.is_some()
+        && change_already_exists
+        && match &live_branch {
+            Some(branch) => release_change_reachable_from(graph, &request.change.id, &branch.head)?,
+            None => false,
+        };
+
+    // Compare-and-swap the caller's observed parent against the live branch
+    // while holding the same gate used for the eventual head mutation. Merge
+    // commits may carry additional parents, but their first parent is the
+    // target branch authority they were constructed against. An exact release
+    // recovery is the only exception: its branch already points at the marker
+    // or at a descendant that retained the marker. Policy is still evaluated
+    // against the marker's immutable parent.
+    if !exact_release_retry {
+        if let Some(branch) = &live_branch {
+            let expected_head = request.change.parents.first().copied();
+            if expected_head != Some(branch.head) {
+                return Err((
+                    StatusCode::CONFLICT,
+                    serde_json::json!({
+                        "error": "stale_branch_head",
+                        "branch": request.branch_name.to_string(),
+                        "expected_head": expected_head.map(|head| head.to_string()),
+                        "actual_head": branch.head.to_string(),
+                        "change_id": request.change.id.to_string(),
+                        "change_materialized": change_already_exists,
+                        "mutation_applied": false,
+                        "message": "semantic change parent does not match the current branch head",
+                    })
+                    .to_string(),
+                ));
+            }
+        }
+    }
+
+    if let Some(policy) = &request.release_policy {
+        // Both first publication and an identical recovery retry evaluate the
+        // same immutable parent. Never substitute the live branch head here:
+        // on retry it is the release marker itself, while ambient overlays can
+        // otherwise add or remove entities without changing history.
+        enforce_daemon_release_policy(
+            graph,
+            &request.change.parents[0],
+            release_entity_count.expect("validated release policy has a canonical marker"),
+            policy,
+        )?;
+        state
+            .preflight_exact_source_tree(graph, &request.change.parents[0])
+            .map_err(|error| {
+                (
+                    StatusCode::FAILED_DEPENDENCY,
+                    serde_json::json!({
+                        "error": "release_source_not_exact",
+                        "source_head": request.change.parents[0].to_string(),
+                        "mutation_applied": false,
+                        "message": error.to_string(),
+                    })
+                    .to_string(),
+                )
+            })?;
+    }
+
+    // An identical retry already reachable from the branch must not reapply
+    // graph mutations. This also reconciles a durable journal after later
+    // branch progress: the marker remains release authority even though it is
+    // no longer the tip. General commits still fail closed on stale parents.
+    if exact_release_retry {
+        state
+            .retry_snapshot_authority_with_event(DaemonEvent::GraphRootChanged {
+                old_root_hash: None,
+                new_root_hash: live_branch
+                    .as_ref()
+                    .map(|branch| branch.head.to_string())
+                    .unwrap_or_else(|| request.change.id.to_string()),
+            })
+            .map_err(internal_error)?;
+        return Ok(Json(serde_json::json!({"status": "ok"})));
+    }
 
     // --- Lease enforcement gate ---
     // Collect the entity scopes touched by this commit and check for hard
@@ -2121,6 +2511,16 @@ async fn graph_commit(
         }
     }
 
+    // Release admission already validated the marker parent's complete exact
+    // tree above. The marker has no artifact deltas, so resolving it produces
+    // that identical tree; reading every source object again here only doubles
+    // release latency and peak backend traffic without adding authority.
+    if request.release_policy.is_none() {
+        state
+            .preflight_exact_source_change(graph, &request.change)
+            .map_err(internal_error)?;
+    }
+
     let graph_mutation = state.begin_graph_authority_mutation();
     for delta in &request.change.entity_deltas {
         match delta {
@@ -2155,14 +2555,12 @@ async fn graph_commit(
         graph.upsert_shallow_file(sf).map_err(internal_error)?;
     }
 
-    graph
-        .create_change(&request.change)
-        .map_err(internal_error)?;
-    if graph
-        .get_branch(&request.branch_name)
-        .map_err(internal_error)?
-        .is_some()
-    {
+    if !change_already_exists {
+        graph
+            .create_change(&request.change)
+            .map_err(internal_error)?;
+    }
+    if live_branch.is_some() {
         graph
             .update_branch_head(&request.branch_name, &request.change.id)
             .map_err(internal_error)?;
@@ -2182,11 +2580,12 @@ async fn graph_commit(
     // Broadcast root hash change and compact the delta journal at the commit boundary.
     state.bump_version();
     drop(graph_mutation);
-    state.save_snapshot_full().map_err(internal_error)?;
-    state.emit_event(DaemonEvent::GraphRootChanged {
-        old_root_hash: None,
-        new_root_hash: request.change.id.to_string(),
-    });
+    state
+        .save_snapshot_full_with_event(DaemonEvent::GraphRootChanged {
+            old_root_hash: None,
+            new_root_hash: request.change.id.to_string(),
+        })
+        .map_err(internal_error)?;
 
     Ok(Json(serde_json::json!({"status": "ok"})))
 }
@@ -2739,6 +3138,14 @@ async fn command_branch(
         ));
     }
 
+    let requires_authority_gate =
+        !matches!(&request, kin_cli::commands::branch::BranchRequest::List);
+    let _coordination = if requires_authority_gate {
+        Some(state.coordination_gate.lock().await)
+    } else {
+        None
+    };
+
     let response = kin_cli::commands::branch::execute_branch_request(
         &state.layout,
         state.graph.as_ref(),
@@ -2771,6 +3178,7 @@ async fn command_checkout(
         ));
     }
 
+    let _coordination = state.coordination_gate.lock().await;
     let session_id = extract_session_id_from_headers(&headers)?;
     let graph = resolve_session_graph(&state, session_id.as_ref()).await;
 
@@ -2919,7 +3327,13 @@ async fn command_commit(
 
     // Force a filesystem sync to guarantee the daemon has reconciled all offline changes
     // before building the commit deltas.
-    let _ = crate::loop_runner::sync_filesystem_with_graph(&state).await;
+    crate::loop_runner::sync_filesystem_with_graph(&state)
+        .await
+        .map_err(internal_error)?;
+
+    // Serialize the branch read, change construction, and head publication
+    // with `/graph/commit` release CAS operations.
+    let _coordination = state.coordination_gate.lock().await;
 
     let graph = &*state.graph;
 
@@ -3036,10 +3450,8 @@ async fn command_commit(
     }
 
     // Create the semantic change.
-    let content_id =
-        kin_core::content_identity_from_deltas(&entity_deltas, &relation_deltas, &artifact_deltas);
-    let change = kin_model::SemanticChange {
-        id: kin_core::compute_change_id(&request.message, &branch.head, &content_id),
+    let mut change = kin_model::SemanticChange {
+        id: kin_model::SemanticChangeId::from_hash(kin_model::Hash256::from_bytes([0; 32])),
         parents: vec![branch.head],
         author: kin_model::AuthorId::new(kin_core::whoami()),
         message: request.message,
@@ -3053,8 +3465,17 @@ async fn command_commit(
         risk_summary: None,
         authored_on: None,
     };
+    change.id = kin_core::compute_semantic_change_id(&change).map_err(internal_error)?;
 
     let change_id = change.id;
+
+    // `/commands/commit` constructs the change in-process, but it publishes
+    // through the same immutable graph authority as `/graph/commit`. Keep the
+    // exact-source gate identical across both entry points and run it before
+    // any change or branch mutation.
+    state
+        .preflight_exact_source_change(graph, &change)
+        .map_err(internal_error)?;
 
     graph.create_change(&change).map_err(internal_error)?;
     graph
@@ -3139,10 +3560,31 @@ async fn graph_create_branch(
 
     use kin_model::{Branch, BranchName, Hash256, SemanticChangeId};
 
+    let _coordination = state.coordination_gate.lock().await;
+
     let head_hash = Hash256::from_hex(&request.head).map_err(bad_request)?;
+    let head = SemanticChangeId::from_hash(head_hash);
+    if state
+        .graph
+        .get_change(&head)
+        .map_err(internal_error)?
+        .is_none()
+    {
+        return Err((
+            StatusCode::NOT_FOUND,
+            serde_json::json!({
+                "error": "branch_head_not_found",
+                "branch": request.name,
+                "head": head.to_string(),
+                "mutation_applied": false,
+                "message": "branch head must name an existing semantic change",
+            })
+            .to_string(),
+        ));
+    }
     let branch = Branch {
         name: BranchName::new(&request.name),
-        head: SemanticChangeId::from_hash(head_hash),
+        head,
     };
 
     state.graph.create_branch(&branch).map_err(internal_error)?;
@@ -3169,6 +3611,7 @@ async fn graph_delete_branch(
     }
 
     use kin_model::BranchName;
+    let _coordination = state.coordination_gate.lock().await;
     state
         .graph
         .delete_branch(&BranchName::new(&name))
@@ -3181,6 +3624,19 @@ async fn graph_delete_branch(
 #[derive(Debug, Deserialize)]
 struct UpdateBranchHeadRequest {
     head: String,
+    expected_head: String,
+}
+
+async fn graph_update_branch_head_v1_retired(Path(name): Path<String>) -> impl IntoResponse {
+    (
+        StatusCode::GONE,
+        Json(serde_json::json!({
+            "error": "v1_branch_head_update_retired",
+            "branch": name,
+            "mutation_applied": false,
+            "message": "PUT branch head moved to /v2 and requires expected_head for atomic fast-forward CAS",
+        })),
+    )
 }
 
 async fn graph_update_branch_head(
@@ -3201,13 +3657,69 @@ async fn graph_update_branch_head(
     use kin_model::{BranchName, Hash256, SemanticChangeId};
 
     let head_hash = Hash256::from_hex(&request.head).map_err(bad_request)?;
+    let expected_head_hash = Hash256::from_hex(&request.expected_head).map_err(bad_request)?;
+    let branch_name = BranchName::new(&name);
+    let expected_head = SemanticChangeId::from_hash(expected_head_hash);
+    let _coordination = state.coordination_gate.lock().await;
+    let branch = state
+        .graph
+        .get_branch(&branch_name)
+        .map_err(internal_error)?
+        .ok_or_else(|| (StatusCode::NOT_FOUND, format!("branch '{name}' not found")))?;
+    if branch.head != expected_head {
+        return Err((
+            StatusCode::CONFLICT,
+            serde_json::json!({
+                "error": "stale_branch_head",
+                "branch": name,
+                "expected_head": expected_head.to_string(),
+                "actual_head": branch.head.to_string(),
+                "mutation_applied": false,
+                "message": "branch head changed before update",
+            })
+            .to_string(),
+        ));
+    }
+
+    let new_head = SemanticChangeId::from_hash(head_hash);
+    if state
+        .graph
+        .get_change(&new_head)
+        .map_err(internal_error)?
+        .is_none()
+    {
+        return Err((
+            StatusCode::NOT_FOUND,
+            serde_json::json!({
+                "error": "branch_head_not_found",
+                "branch": name,
+                "head": new_head.to_string(),
+                "mutation_applied": false,
+                "message": "branch head must name an existing semantic change",
+            })
+            .to_string(),
+        ));
+    }
+    let ancestry = kin_review::ref_graph::collect_ancestry(state.graph.as_ref(), &new_head)
+        .map_err(internal_error)?;
+    if !ancestry.contains(&expected_head) {
+        return Err((
+            StatusCode::CONFLICT,
+            serde_json::json!({
+                "error": "non_fast_forward_branch_update",
+                "branch": name,
+                "expected_head": expected_head.to_string(),
+                "new_head": new_head.to_string(),
+                "mutation_applied": false,
+                "message": "branch updates must advance to a descendant of the current head",
+            })
+            .to_string(),
+        ));
+    }
 
     state
         .graph
-        .update_branch_head(
-            &BranchName::new(&name),
-            &SemanticChangeId::from_hash(head_hash),
-        )
+        .update_branch_head(&branch_name, &new_head)
         .map_err(internal_error)?;
 
     // Broadcast root hash change. bump_version() marks dirty for background persistence.
@@ -4681,6 +5193,11 @@ async fn verify_run(
             "daemon not fully initialized".to_string(),
         ));
     }
+
+    // Release authorization reads verification coverage while holding this
+    // same gate. Keep a verification run's graph writes and durable snapshot
+    // indivisible with respect to that decision.
+    let _coordination = state.coordination_gate.lock().await;
 
     let state_for_verify = Arc::clone(&state);
     let response = tokio::task::spawn_blocking(move || {
@@ -7587,8 +8104,6 @@ fn build_vfs_tree_snapshot(
     state: &DaemonState,
     key: VfsTreeCacheKey,
 ) -> Result<VfsTreeSnapshot, (StatusCode, String)> {
-    use kin_model::ArtifactDeltaKind;
-
     let Some(head_id) = key.head.clone() else {
         return Ok(VfsTreeSnapshot {
             key,
@@ -7607,17 +8122,14 @@ fn build_vfs_tree_snapshot(
     for change in &changes {
         let epoch_secs = change.timestamp.0.timestamp() as u64;
         for delta in &change.artifact_deltas {
-            match delta.kind {
-                ArtifactDeltaKind::Added | ArtifactDeltaKind::Modified => {
-                    if let Some(hash) = delta.new_hash {
-                        files.insert(delta.file_id.clone(), hash);
-                    }
-                    timestamps.insert(delta.file_id.clone(), epoch_secs);
+            if delta.kind.is_removed() {
+                files.remove(&delta.file_id);
+                timestamps.remove(&delta.file_id);
+            } else {
+                if let Some(hash) = delta.new_hash {
+                    files.insert(delta.file_id.clone(), hash);
                 }
-                ArtifactDeltaKind::Removed => {
-                    files.remove(&delta.file_id);
-                    timestamps.remove(&delta.file_id);
-                }
+                timestamps.insert(delta.file_id.clone(), epoch_secs);
             }
         }
     }
@@ -9150,6 +9662,972 @@ fn primary_repo_id(state: &DaemonState) -> String {
 }
 
 /// Derive a short repo name from the daemon's working directory.
+const EXACT_SOURCE_MAX_ENTRIES: usize = 100_000;
+const EXACT_SOURCE_MAX_EXPANDED_BYTES: u64 = 256 * 1024 * 1024;
+const EXACT_SOURCE_MAX_ARCHIVE_BYTES: usize = 128 * 1024 * 1024;
+const EXACT_SOURCE_ROOT: &str = "kin-source";
+
+fn try_acquire_exact_source_archive_slot(
+    semaphore: Arc<tokio::sync::Semaphore>,
+) -> Result<tokio::sync::OwnedSemaphorePermit, (StatusCode, String)> {
+    semaphore.try_acquire_owned().map_err(|_| {
+        (
+            StatusCode::TOO_MANY_REQUESTS,
+            "an exact source archive or release-evidence job is already running; retry after it completes"
+                .to_string(),
+        )
+    })
+}
+
+#[derive(Debug)]
+struct ExactSourceArchiveLimitExceeded;
+
+impl std::fmt::Display for ExactSourceArchiveLimitExceeded {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        formatter.write_str("exact source archive exceeds the compressed byte limit")
+    }
+}
+
+impl std::error::Error for ExactSourceArchiveLimitExceeded {}
+
+/// A `Vec<u8>` writer that enforces the compressed archive limit before an
+/// allocation or write can cross it. Checking only after `GzEncoder::finish`
+/// would allow a low-compressibility source tree to allocate more than the
+/// advertised ceiling first.
+struct BoundedArchiveWriter {
+    bytes: Vec<u8>,
+    limit: usize,
+}
+
+impl BoundedArchiveWriter {
+    fn new(limit: usize) -> Self {
+        Self {
+            bytes: Vec::new(),
+            limit,
+        }
+    }
+
+    fn into_inner(self) -> Vec<u8> {
+        self.bytes
+    }
+}
+
+impl Write for BoundedArchiveWriter {
+    fn write(&mut self, buffer: &[u8]) -> std::io::Result<usize> {
+        let remaining = self.limit.saturating_sub(self.bytes.len());
+        if buffer.len() > remaining {
+            return Err(std::io::Error::new(
+                std::io::ErrorKind::Other,
+                ExactSourceArchiveLimitExceeded,
+            ));
+        }
+        self.bytes.extend_from_slice(buffer);
+        Ok(buffer.len())
+    }
+
+    fn flush(&mut self) -> std::io::Result<()> {
+        Ok(())
+    }
+}
+
+fn exact_source_archive_write_error(context: &str, error: std::io::Error) -> (StatusCode, String) {
+    if error
+        .get_ref()
+        .is_some_and(|source| source.is::<ExactSourceArchiveLimitExceeded>())
+        || error
+            .to_string()
+            .contains("exact source archive exceeds the compressed byte limit")
+    {
+        return (
+            StatusCode::PAYLOAD_TOO_LARGE,
+            "exact source archive exceeds the compressed byte limit".to_string(),
+        );
+    }
+    (
+        StatusCode::INTERNAL_SERVER_ERROR,
+        format!("{context}: {error}"),
+    )
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) enum ExactSourceEntry {
+    File {
+        path: String,
+        data: Arc<[u8]>,
+        executable: bool,
+    },
+    Symlink {
+        path: String,
+        target: Arc<str>,
+    },
+}
+
+impl ExactSourceEntry {
+    fn path(&self) -> &str {
+        match self {
+            Self::File { path, .. } | Self::Symlink { path, .. } => path,
+        }
+    }
+}
+
+fn parse_exact_source_change_id(
+    source_change_id: &str,
+) -> Result<kin_model::SemanticChangeId, (StatusCode, String)> {
+    if source_change_id.len() != 64
+        || !source_change_id
+            .bytes()
+            .all(|byte| byte.is_ascii_hexdigit())
+    {
+        return Err((
+            StatusCode::BAD_REQUEST,
+            "source_change_id must be a canonical 64-character hexadecimal semantic change ID"
+                .to_string(),
+        ));
+    }
+    let decoded = hex::decode(source_change_id).map_err(|error| {
+        (
+            StatusCode::BAD_REQUEST,
+            format!("invalid source_change_id: {error}"),
+        )
+    })?;
+    let bytes: [u8; 32] = decoded.try_into().map_err(|_| {
+        (
+            StatusCode::BAD_REQUEST,
+            "source_change_id must decode to 32 bytes".to_string(),
+        )
+    })?;
+    Ok(kin_model::SemanticChangeId::from_hash(
+        kin_model::Hash256::from_bytes(bytes),
+    ))
+}
+
+fn resolve_exact_source_tree(
+    graph: &kin_db::InMemoryGraph,
+    requested_change: &kin_model::SemanticChangeId,
+) -> Result<HashMap<FilePathId, ResolvedSourceEntry>, (StatusCode, String)> {
+    match graph
+        .resolve_source_tree_at(requested_change)
+        .map_err(internal_error)?
+    {
+        SourceTreeResolution::Exact { entries } => Ok(entries),
+        SourceTreeResolution::Incomplete { gaps } => {
+            let gap_summary = gaps
+                .iter()
+                .map(|gap| format!("{}@{}:{:?}", gap.file_id, gap.change_id, gap.reason))
+                .collect::<Vec<_>>()
+                .join(", ");
+            Err((
+                StatusCode::FAILED_DEPENDENCY,
+                format!(
+                    "exact source history is incomplete for {requested_change}: {gap_summary}; no fallback was attempted"
+                ),
+            ))
+        }
+    }
+}
+
+fn validate_exact_source_path(path: &str) -> Result<(), (StatusCode, String)> {
+    kin_core::validate_portable_source_paths(std::iter::once(path)).map_err(|error| {
+        (
+            StatusCode::INTERNAL_SERVER_ERROR,
+            format!("graph contains an unsafe exact-source path {path:?}: {error}"),
+        )
+    })
+}
+
+fn validate_exact_source_symlink(path: &str, target: &str) -> Result<(), (StatusCode, String)> {
+    kin_core::validate_portable_source_symlink(path, target).map_err(|error| {
+        (
+            StatusCode::INTERNAL_SERVER_ERROR,
+            format!("exact-source symlink {path:?} has an unsafe target {target:?}: {error}"),
+        )
+    })
+}
+
+fn canonical_exact_source_manifest(
+    entries: &[ExactSourceEntry],
+) -> Result<Vec<u8>, (StatusCode, String)> {
+    kin_core::validate_portable_source_paths(entries.iter().map(ExactSourceEntry::path)).map_err(
+        |error| {
+            (
+                StatusCode::INTERNAL_SERVER_ERROR,
+                format!("graph contains conflicting or unportable exact-source paths: {error}"),
+            )
+        },
+    )?;
+    let all_paths: HashSet<&str> = entries.iter().map(ExactSourceEntry::path).collect();
+    let mut ordered: Vec<&ExactSourceEntry> = entries.iter().collect();
+    ordered.sort_by(|left, right| left.path().cmp(right.path()));
+    let mut manifest = Vec::new();
+    manifest.extend_from_slice(b"kin-exact-source-manifest-v2\0");
+    manifest.extend_from_slice(
+        &u64::try_from(ordered.len())
+            .map_err(|_| {
+                (
+                    StatusCode::PAYLOAD_TOO_LARGE,
+                    "exact source manifest entry count exceeds u64".to_string(),
+                )
+            })?
+            .to_le_bytes(),
+    );
+    let mut previous_path: Option<&str> = None;
+    for entry in ordered {
+        let path = entry.path();
+        validate_exact_source_path(path)?;
+        if let ExactSourceEntry::Symlink { target, .. } = entry {
+            validate_exact_source_symlink(path, target.as_ref())?;
+        }
+        if previous_path == Some(path) {
+            return Err((
+                StatusCode::INTERNAL_SERVER_ERROR,
+                format!("graph contains duplicate exact-source path {path:?}"),
+            ));
+        }
+        for (index, byte) in path.bytes().enumerate() {
+            if byte == b'/' && all_paths.contains(&path[..index]) {
+                return Err((
+                    StatusCode::INTERNAL_SERVER_ERROR,
+                    format!(
+                        "graph contains conflicting exact-source paths {:?} and {path:?}",
+                        &path[..index]
+                    ),
+                ));
+            }
+        }
+        previous_path = Some(path);
+        append_exact_source_manifest_field(&mut manifest, path.as_bytes())?;
+        match entry {
+            ExactSourceEntry::File {
+                data, executable, ..
+            } => {
+                manifest.push(0);
+                manifest.push(u8::from(*executable));
+                manifest.extend_from_slice(&Sha256::digest(data.as_ref()));
+            }
+            ExactSourceEntry::Symlink { target, .. } => {
+                manifest.push(1);
+                append_exact_source_manifest_field(&mut manifest, target.as_bytes())?;
+            }
+        }
+    }
+    Ok(manifest)
+}
+
+fn append_exact_source_manifest_field(
+    manifest: &mut Vec<u8>,
+    value: &[u8],
+) -> Result<(), (StatusCode, String)> {
+    let len = u64::try_from(value.len()).map_err(|_| {
+        (
+            StatusCode::PAYLOAD_TOO_LARGE,
+            "exact source manifest field length exceeds u64".to_string(),
+        )
+    })?;
+    manifest.extend_from_slice(&len.to_le_bytes());
+    manifest.extend_from_slice(value);
+    Ok(())
+}
+
+fn build_exact_source_tar_gz(
+    mut entries: Vec<ExactSourceEntry>,
+) -> Result<(Vec<u8>, String), (StatusCode, String)> {
+    entries.sort_by(|left, right| left.path().cmp(right.path()));
+    let archive_entry_count = entries.len().checked_add(1).ok_or_else(|| {
+        (
+            StatusCode::PAYLOAD_TOO_LARGE,
+            "exact source archive entry count overflow".to_string(),
+        )
+    })?;
+    if archive_entry_count > EXACT_SOURCE_MAX_ENTRIES {
+        return Err((
+            StatusCode::PAYLOAD_TOO_LARGE,
+            "exact source tree exceeds the archive entry limit".to_string(),
+        ));
+    }
+    let expanded_bytes = entries.iter().try_fold(0_u64, |total, entry| {
+        let len = match entry {
+            ExactSourceEntry::File { data, .. } => data.len(),
+            ExactSourceEntry::Symlink { target, .. } => target.len(),
+        };
+        total.checked_add(u64::try_from(len).unwrap_or(u64::MAX))
+    });
+    if expanded_bytes.is_none_or(|bytes| bytes > EXACT_SOURCE_MAX_EXPANDED_BYTES) {
+        return Err((
+            StatusCode::PAYLOAD_TOO_LARGE,
+            "exact source tree exceeds the expanded byte limit".to_string(),
+        ));
+    }
+
+    let manifest = canonical_exact_source_manifest(&entries)?;
+    let manifest_hash = hex::encode(Sha256::digest(&manifest));
+    let gzip = flate2::GzBuilder::new().mtime(0).write(
+        BoundedArchiveWriter::new(EXACT_SOURCE_MAX_ARCHIVE_BYTES),
+        flate2::Compression::fast(),
+    );
+    let mut archive = tar::Builder::new(gzip);
+    archive.mode(tar::HeaderMode::Deterministic);
+
+    let mut root_header = tar::Header::new_gnu();
+    root_header.set_uid(0);
+    root_header.set_gid(0);
+    root_header.set_mtime(0);
+    root_header.set_entry_type(tar::EntryType::Directory);
+    root_header.set_mode(0o755);
+    root_header.set_size(0);
+    root_header.set_cksum();
+    archive
+        .append_data(
+            &mut root_header,
+            format!("{EXACT_SOURCE_ROOT}/"),
+            std::io::empty(),
+        )
+        .map_err(|error| {
+            exact_source_archive_write_error("exact source tar root write failed", error)
+        })?;
+
+    for entry in &entries {
+        let archive_path = format!("{EXACT_SOURCE_ROOT}/{}", entry.path());
+        let mut header = tar::Header::new_gnu();
+        header.set_uid(0);
+        header.set_gid(0);
+        header.set_mtime(0);
+        match entry {
+            ExactSourceEntry::File {
+                data, executable, ..
+            } => {
+                header.set_entry_type(tar::EntryType::Regular);
+                header.set_mode(if *executable { 0o755 } else { 0o644 });
+                header.set_size(data.len() as u64);
+                header.set_cksum();
+                archive
+                    .append_data(&mut header, &archive_path, data.as_ref())
+                    .map_err(|error| {
+                        exact_source_archive_write_error("exact source tar write failed", error)
+                    })?;
+            }
+            ExactSourceEntry::Symlink { target, .. } => {
+                header.set_entry_type(tar::EntryType::Symlink);
+                header.set_mode(0o777);
+                header.set_size(0);
+                header.set_link_name(target.as_ref()).map_err(|error| {
+                    (
+                        StatusCode::INTERNAL_SERVER_ERROR,
+                        format!("exact source tar link write failed: {error}"),
+                    )
+                })?;
+                header.set_cksum();
+                archive
+                    .append_data(&mut header, &archive_path, std::io::empty())
+                    .map_err(|error| {
+                        exact_source_archive_write_error("exact source tar write failed", error)
+                    })?;
+            }
+        }
+    }
+
+    let gzip = archive.into_inner().map_err(|error| {
+        exact_source_archive_write_error("exact source tar finish failed", error)
+    })?;
+    let bytes = gzip
+        .finish()
+        .map_err(|error| {
+            exact_source_archive_write_error("exact source gzip finish failed", error)
+        })?
+        .into_inner();
+    Ok((bytes, manifest_hash))
+}
+
+fn load_exact_source_entries(
+    state: &DaemonState,
+    repo_id: &str,
+    tree: std::collections::HashMap<FilePathId, ResolvedSourceEntry>,
+) -> Result<Vec<ExactSourceEntry>, (StatusCode, String)> {
+    let backend = state.storage_backend.as_ref().ok_or_else(|| {
+        (
+            StatusCode::SERVICE_UNAVAILABLE,
+            "exact source export requires immutable backend source storage".to_string(),
+        )
+    })?;
+    load_exact_source_entries_with(tree, |file_id, digest, remaining_bytes| {
+        backend
+            .load_source_blob_bounded(repo_id, digest, remaining_bytes)
+            .map_err(|error| {
+                let status = if matches!(
+                    &error,
+                    kin_db::KinDbError::SourceBlobReadLimitExceeded { .. }
+                ) {
+                    StatusCode::PAYLOAD_TOO_LARGE
+                } else {
+                    StatusCode::INTERNAL_SERVER_ERROR
+                };
+                (
+                    status,
+                    format!(
+                        "immutable source blob load failed for {} at {}: {error}",
+                        file_id.0,
+                        hex::encode(digest)
+                    ),
+                )
+            })
+    })
+}
+
+fn load_exact_source_entries_with(
+    tree: std::collections::HashMap<FilePathId, ResolvedSourceEntry>,
+    mut load_blob: impl FnMut(
+        &FilePathId,
+        [u8; 32],
+        u64,
+    ) -> Result<Option<Vec<u8>>, (StatusCode, String)>,
+) -> Result<Vec<ExactSourceEntry>, (StatusCode, String)> {
+    let mut files: Vec<_> = tree.into_iter().collect();
+    files.sort_by(|left, right| left.0 .0.cmp(&right.0 .0));
+    let archive_entry_count = files.len().checked_add(1).ok_or_else(|| {
+        (
+            StatusCode::PAYLOAD_TOO_LARGE,
+            "exact source archive entry count overflow".to_string(),
+        )
+    })?;
+    if archive_entry_count > EXACT_SOURCE_MAX_ENTRIES {
+        return Err((
+            StatusCode::PAYLOAD_TOO_LARGE,
+            "exact source tree exceeds the archive entry limit".to_string(),
+        ));
+    }
+    kin_core::validate_portable_source_paths(files.iter().map(|(file_id, _)| file_id.0.as_str()))
+        .map_err(|error| {
+        (
+            StatusCode::INTERNAL_SERVER_ERROR,
+            format!("graph contains conflicting or unportable exact-source paths: {error}"),
+        )
+    })?;
+    files.sort_by(|left, right| {
+        left.1
+            .hash
+            .as_bytes()
+            .cmp(right.1.hash.as_bytes())
+            .then_with(|| left.0 .0.cmp(&right.0 .0))
+    });
+    let mut entries = Vec::with_capacity(files.len());
+    let mut expanded_bytes = 0_u64;
+    let mut remaining_load_bytes = EXACT_SOURCE_MAX_EXPANDED_BYTES as u64;
+    let mut start = 0;
+    while start < files.len() {
+        let source_hash = files[start].1.hash;
+        let mut end = start + 1;
+        while end < files.len() && files[end].1.hash == source_hash {
+            end += 1;
+        }
+        let digest = *source_hash.as_bytes();
+        let data: Arc<[u8]> = load_blob(&files[start].0, digest, remaining_load_bytes)?
+            .ok_or_else(|| {
+                (
+                    StatusCode::FAILED_DEPENDENCY,
+                    format!(
+                        "exact source bytes are unavailable for {} at {}; no fallback was attempted",
+                        files[start].0 .0,
+                        hex::encode(digest)
+                    ),
+                )
+            })?
+            .into();
+        let loaded_bytes = u64::try_from(data.len()).map_err(|_| {
+            (
+                StatusCode::PAYLOAD_TOO_LARGE,
+                "exact source blob length does not fit the allocation limit".to_string(),
+            )
+        })?;
+        remaining_load_bytes = remaining_load_bytes
+            .checked_sub(loaded_bytes)
+            .ok_or_else(|| {
+                (
+                    StatusCode::PAYLOAD_TOO_LARGE,
+                    "exact source tree exceeds the source allocation limit".to_string(),
+                )
+            })?;
+        let logical_group_bytes = u64::try_from(data.len())
+            .unwrap_or(u64::MAX)
+            .checked_mul(u64::try_from(end - start).unwrap_or(u64::MAX))
+            .ok_or_else(|| {
+                (
+                    StatusCode::PAYLOAD_TOO_LARGE,
+                    "exact source tree expanded byte count overflow".to_string(),
+                )
+            })?;
+        expanded_bytes = expanded_bytes
+            .checked_add(logical_group_bytes)
+            .ok_or_else(|| {
+                (
+                    StatusCode::PAYLOAD_TOO_LARGE,
+                    "exact source tree expanded byte count overflow".to_string(),
+                )
+            })?;
+        if expanded_bytes > EXACT_SOURCE_MAX_EXPANDED_BYTES {
+            return Err((
+                StatusCode::PAYLOAD_TOO_LARGE,
+                "exact source tree exceeds the expanded byte limit".to_string(),
+            ));
+        }
+        let actual: [u8; 32] = Sha256::digest(data.as_ref()).into();
+        if actual != digest {
+            return Err((
+                StatusCode::INTERNAL_SERVER_ERROR,
+                format!(
+                    "immutable source blob digest mismatch for {}: requested {}, found {}",
+                    files[start].0 .0,
+                    hex::encode(digest),
+                    hex::encode(actual)
+                ),
+            ));
+        }
+        let mut symlink_target: Option<Arc<str>> = None;
+        for (file_id, source) in &files[start..end] {
+            match source.kind {
+                SourceEntryKind::File { executable } => entries.push(ExactSourceEntry::File {
+                    path: file_id.0.clone(),
+                    data: Arc::clone(&data),
+                    executable,
+                }),
+                SourceEntryKind::Symlink => {
+                    let target = if let Some(target) = &symlink_target {
+                        Arc::clone(target)
+                    } else {
+                        let target = std::str::from_utf8(data.as_ref())
+                            .map(Arc::<str>::from)
+                            .map_err(|_| {
+                                (
+                                    StatusCode::INTERNAL_SERVER_ERROR,
+                                    format!(
+                                        "exact-source symlink target bytes are not UTF-8 for {} at {}",
+                                        file_id.0,
+                                        hex::encode(digest)
+                                    ),
+                                )
+                            })?;
+                        symlink_target = Some(Arc::clone(&target));
+                        target
+                    };
+                    validate_exact_source_symlink(&file_id.0, target.as_ref())?;
+                    entries.push(ExactSourceEntry::Symlink {
+                        path: file_id.0.clone(),
+                        target,
+                    });
+                }
+            }
+        }
+        start = end;
+    }
+    Ok(entries)
+}
+
+/// GET /repos/{repo_id}/archive/tar/{source_change_id} — export one exact
+/// semantic change from graph-owned history and immutable backend source bytes.
+async fn repo_exact_source_tar_gz(
+    Path((repo_id, source_change_id)): Path<(String, String)>,
+    State(state): State<Arc<DaemonState>>,
+) -> Result<impl IntoResponse, (StatusCode, String)> {
+    // The current backend API returns whole blobs and the HTTP response is a
+    // complete in-memory archive. Serialize this bounded path until backend
+    // streaming lands so concurrent requests cannot multiply peak RSS.
+    let archive_permit = try_acquire_exact_source_archive_slot(exact_source_archive_exports())?;
+    let requested_change = parse_exact_source_change_id(&source_change_id)?;
+    let graph = state
+        .get_repo_graph(&repo_id)
+        .await
+        .map_err(internal_error)?;
+    if graph
+        .get_change(&requested_change)
+        .map_err(internal_error)?
+        .is_none()
+    {
+        return Err((
+            StatusCode::NOT_FOUND,
+            format!("semantic change {requested_change} was not found in repo {repo_id}"),
+        ));
+    }
+
+    let tree = resolve_exact_source_tree(graph.as_ref(), &requested_change)?;
+    let state_for_archive = Arc::clone(&state);
+    let repo_for_archive = repo_id.clone();
+    let ((archive, manifest_hash), archive_permit) = tokio::task::spawn_blocking(move || {
+        hold_exact_source_archive_permit(archive_permit, || {
+            let entries = load_exact_source_entries(&state_for_archive, &repo_for_archive, tree)?;
+            build_exact_source_tar_gz(entries)
+        })
+    })
+    .await
+    .map_err(|error| {
+        (
+            StatusCode::INTERNAL_SERVER_ERROR,
+            format!("exact source archive worker failed: {error}"),
+        )
+    })??;
+
+    let canonical_change = requested_change.to_string();
+    let mut headers = HeaderMap::new();
+    headers.insert(
+        header::CONTENT_TYPE,
+        HeaderValue::from_static("application/gzip"),
+    );
+    headers.insert(
+        header::CONTENT_DISPOSITION,
+        HeaderValue::from_str(&format!(
+            "attachment; filename=\"kin-source-{canonical_change}.tar.gz\""
+        ))
+        .map_err(|error| {
+            (
+                StatusCode::INTERNAL_SERVER_ERROR,
+                format!("exact source response filename is invalid: {error}"),
+            )
+        })?,
+    );
+    headers.insert(
+        header::CACHE_CONTROL,
+        HeaderValue::from_static("private, immutable, max-age=31536000"),
+    );
+    headers.insert(
+        HeaderName::from_static("x-kin-source-change-id"),
+        HeaderValue::from_str(&canonical_change).map_err(|error| {
+            (
+                StatusCode::INTERNAL_SERVER_ERROR,
+                format!("exact source change response header is invalid: {error}"),
+            )
+        })?,
+    );
+    headers.insert(
+        HeaderName::from_static("x-kin-source-manifest-sha256"),
+        HeaderValue::from_str(&manifest_hash).map_err(|error| {
+            (
+                StatusCode::INTERNAL_SERVER_ERROR,
+                format!("exact source manifest response header is invalid: {error}"),
+            )
+        })?,
+    );
+    let body = exact_source_archive_body(archive, archive_permit);
+    Ok((headers, body))
+}
+
+#[derive(Debug, Serialize, Deserialize, PartialEq)]
+struct RepoReleaseCheckEvidence {
+    pass: bool,
+    blockers: Vec<String>,
+}
+
+#[derive(Debug, Serialize, Deserialize, PartialEq)]
+struct RepoCoverageEvidence {
+    total_entities: usize,
+    covered_entities: usize,
+    coverage_ratio: f64,
+    missing_proof_count: usize,
+}
+
+#[derive(Debug, Serialize, Deserialize, PartialEq)]
+struct RepoSecurityEvidence {
+    finding_count: usize,
+}
+
+#[derive(Debug, Serialize, Deserialize, PartialEq)]
+struct RepoReleaseEvidenceResponse {
+    source_change_id: String,
+    authority_anchor: String,
+    source_manifest_sha256: String,
+    release_check: RepoReleaseCheckEvidence,
+    coverage: RepoCoverageEvidence,
+    security: RepoSecurityEvidence,
+}
+
+fn reachable_change_ids(
+    snapshot: &kin_db::GraphSnapshot,
+    head: &kin_model::SemanticChangeId,
+) -> Result<HashSet<kin_model::SemanticChangeId>, (StatusCode, String)> {
+    let mut reachable = HashSet::new();
+    let mut pending = vec![*head];
+    while let Some(change_id) = pending.pop() {
+        if !reachable.insert(change_id) {
+            continue;
+        }
+        let change = snapshot.changes.get(&change_id).ok_or_else(|| {
+            (
+                StatusCode::INTERNAL_SERVER_ERROR,
+                format!("graph history for {head} references missing semantic change {change_id}"),
+            )
+        })?;
+        pending.extend(change.parents.iter().copied());
+    }
+    Ok(reachable)
+}
+
+fn release_evidence_graph_at(
+    frozen_graph: &kin_db::InMemoryGraph,
+    frozen_snapshot: &kin_db::GraphSnapshot,
+    head: &kin_model::SemanticChangeId,
+) -> Result<(kin_db::InMemoryGraph, [u8; 32]), (StatusCode, String)> {
+    let reachable = reachable_change_ids(frozen_snapshot, head)?;
+    let resolved = frozen_graph
+        .resolve_graph_at(head)
+        .map_err(internal_error)?;
+    let mut snapshot = kin_db::GraphSnapshot::empty();
+    snapshot.entities = resolved.entities;
+    snapshot.relations = resolved.relations;
+    snapshot.entity_revisions = resolved.entity_revisions;
+    snapshot.entity_tombstones = resolved.entity_tombstones;
+    snapshot.relation_tombstones = resolved.relation_tombstones;
+    snapshot.file_hashes = resolved
+        .file_tree
+        .into_iter()
+        .map(|(file_id, hash)| (file_id.0, *hash.as_bytes()))
+        .collect();
+
+    for change_id in &reachable {
+        let change = frozen_snapshot.changes.get(change_id).ok_or_else(|| {
+            (
+                StatusCode::INTERNAL_SERVER_ERROR,
+                format!("reachable semantic change {change_id} disappeared from frozen history"),
+            )
+        })?;
+        snapshot.changes.insert(*change_id, change.clone());
+        for parent in &change.parents {
+            if reachable.contains(parent) {
+                snapshot
+                    .change_children
+                    .entry(*parent)
+                    .or_default()
+                    .push(*change_id);
+            }
+        }
+    }
+    for children in snapshot.change_children.values_mut() {
+        children.sort_by_key(ToString::to_string);
+        children.dedup();
+    }
+    let evidence_branch = BranchName::new("release-evidence");
+    snapshot.branches.insert(
+        evidence_branch.clone(),
+        Branch {
+            name: evidence_branch,
+            head: *head,
+        },
+    );
+
+    // Verification runs, test cases, assertions, contracts, mock hints, and
+    // coverage mappings currently have no immutable source-change/manifest
+    // binding. Grafting their current values into a historical graph lets
+    // later tests change an older release's proof, security findings, graph
+    // root, and authority anchor. Fail closed: retain only relations already
+    // reconstructed by `resolve_graph_at(head)` from source-bound history and
+    // admit no current structural verification metadata until the model binds
+    // it to immutable source authority.
+
+    snapshot.actors = frozen_snapshot.actors.clone();
+    snapshot.approvals = frozen_snapshot
+        .approvals
+        .iter()
+        .filter(|approval| reachable.contains(&approval.change_id))
+        .cloned()
+        .collect();
+
+    let graph_root = kin_db::compute_graph_root_hash(&snapshot);
+    Ok((
+        kin_db::InMemoryGraph::from_snapshot_without_text_index_with_root_hash(
+            snapshot, graph_root,
+        ),
+        graph_root,
+    ))
+}
+
+fn append_anchor_field(hasher: &mut Sha256, value: &[u8]) {
+    hasher.update(u64::try_from(value.len()).unwrap_or(u64::MAX).to_le_bytes());
+    hasher.update(value);
+}
+
+fn release_evidence_anchor(
+    repo_id: &str,
+    source_change_id: &str,
+    source_manifest_hash: &str,
+    graph_root: [u8; 32],
+    release_check: &RepoReleaseCheckEvidence,
+    coverage: &RepoCoverageEvidence,
+    security: &RepoSecurityEvidence,
+) -> String {
+    let mut hasher = Sha256::new();
+    hasher.update(b"kin-release-evidence-v1\0");
+    append_anchor_field(&mut hasher, repo_id.as_bytes());
+    append_anchor_field(&mut hasher, source_change_id.as_bytes());
+    append_anchor_field(&mut hasher, source_manifest_hash.as_bytes());
+    append_anchor_field(&mut hasher, &graph_root);
+    hasher.update([u8::from(release_check.pass)]);
+    for blocker in &release_check.blockers {
+        append_anchor_field(&mut hasher, blocker.as_bytes());
+    }
+    hasher.update(
+        u64::try_from(coverage.total_entities)
+            .unwrap_or(u64::MAX)
+            .to_le_bytes(),
+    );
+    hasher.update(
+        u64::try_from(coverage.covered_entities)
+            .unwrap_or(u64::MAX)
+            .to_le_bytes(),
+    );
+    hasher.update(coverage.coverage_ratio.to_bits().to_le_bytes());
+    hasher.update(
+        u64::try_from(coverage.missing_proof_count)
+            .unwrap_or(u64::MAX)
+            .to_le_bytes(),
+    );
+    hasher.update(
+        u64::try_from(security.finding_count)
+            .unwrap_or(u64::MAX)
+            .to_le_bytes(),
+    );
+    hex::encode(hasher.finalize())
+}
+
+fn build_repo_release_evidence(
+    state: &DaemonState,
+    repo_id: &str,
+    source_change_id: kin_model::SemanticChangeId,
+    frozen_snapshot: kin_db::GraphSnapshot,
+) -> Result<RepoReleaseEvidenceResponse, (StatusCode, String)> {
+    let frozen_root = kin_db::compute_graph_root_hash(&frozen_snapshot);
+    let frozen_graph = kin_db::InMemoryGraph::from_snapshot_without_text_index_with_root_hash(
+        frozen_snapshot.clone(),
+        frozen_root,
+    );
+    if frozen_graph
+        .get_change(&source_change_id)
+        .map_err(internal_error)?
+        .is_none()
+    {
+        return Err((
+            StatusCode::NOT_FOUND,
+            format!("semantic change {source_change_id} was not found in repo {repo_id}"),
+        ));
+    }
+
+    let source_tree = resolve_exact_source_tree(&frozen_graph, &source_change_id)?;
+    let source_entries = load_exact_source_entries(state, repo_id, source_tree)?;
+    let source_manifest = canonical_exact_source_manifest(&source_entries)?;
+    let source_manifest_hash = hex::encode(Sha256::digest(&source_manifest));
+
+    let (evidence_graph, evidence_root) =
+        release_evidence_graph_at(&frozen_graph, &frozen_snapshot, &source_change_id)?;
+    let coverage_summary = kin_review::source_bound_release_proof_coverage(&evidence_graph)
+        .map_err(|error| {
+            (
+                StatusCode::INTERNAL_SERVER_ERROR,
+                format!("source-bound release proof scan failed: {error}"),
+            )
+        })?;
+    let mut unapproved =
+        kin_review::unapproved_changes(&evidence_graph, &source_change_id, usize::MAX).map_err(
+            |error| {
+                (
+                    StatusCode::INTERNAL_SERVER_ERROR,
+                    format!("source-bound release approval scan failed: {error}"),
+                )
+            },
+        )?;
+    unapproved.sort_by_key(|change| change.change_id.to_string());
+
+    let mut blockers = Vec::new();
+    if !coverage_summary.missing_proof.is_empty() {
+        blockers.push(format!(
+            "{} entities missing test proof",
+            coverage_summary.missing_proof.len()
+        ));
+    }
+    if !unapproved.is_empty() {
+        let detail = unapproved
+            .iter()
+            .map(|change| format!("{} ({})", change.change_id, change.author))
+            .collect::<Vec<_>>()
+            .join(", ");
+        blockers.push(format!(
+            "{} non-root change(s) lack human approval: {detail}",
+            unapproved.len()
+        ));
+    }
+    let release_check = RepoReleaseCheckEvidence {
+        pass: blockers.is_empty(),
+        blockers,
+    };
+    let coverage = RepoCoverageEvidence {
+        total_entities: coverage_summary.total_entities,
+        covered_entities: coverage_summary.covered_entities,
+        coverage_ratio: coverage_summary.coverage_ratio,
+        missing_proof_count: coverage_summary.missing_proof.len(),
+    };
+    let security = RepoSecurityEvidence {
+        finding_count: kin_review::security_findings(&evidence_graph, true)
+            .map_err(|error| {
+                (
+                    StatusCode::INTERNAL_SERVER_ERROR,
+                    format!("source-bound security scan failed: {error}"),
+                )
+            })?
+            .len(),
+    };
+    let canonical_change = source_change_id.to_string();
+    let authority_anchor = release_evidence_anchor(
+        repo_id,
+        &canonical_change,
+        &source_manifest_hash,
+        evidence_root,
+        &release_check,
+        &coverage,
+        &security,
+    );
+
+    Ok(RepoReleaseEvidenceResponse {
+        source_change_id: canonical_change,
+        authority_anchor,
+        source_manifest_sha256: source_manifest_hash,
+        release_check,
+        coverage,
+        security,
+    })
+}
+
+/// GET /repos/{repo_id}/release/evidence/{source_change_id} — compute Kin's
+/// release, proof-coverage, and security gates against one immutable source
+/// change. The exact source manifest and historical graph root are bound into
+/// the returned authority anchor.
+async fn repo_release_evidence(
+    Path((repo_id, source_change_id)): Path<(String, String)>,
+    State(state): State<Arc<DaemonState>>,
+) -> Result<Json<RepoReleaseEvidenceResponse>, (StatusCode, String)> {
+    // Evidence computes the same exact-source manifest as archive export and
+    // currently reads whole backend blobs. Share the process-wide singleton so
+    // an evidence request cannot multiply archive export's bounded peak RSS.
+    let archive_permit = try_acquire_exact_source_archive_slot(exact_source_archive_exports())?;
+    let requested_change = parse_exact_source_change_id(&source_change_id)?;
+    let graph = state
+        .get_repo_graph(&repo_id)
+        .await
+        .map_err(internal_error)?;
+    let frozen_snapshot = graph.to_snapshot();
+    let state_for_evidence = Arc::clone(&state);
+    let repo_for_evidence = repo_id.clone();
+    let evidence = tokio::task::spawn_blocking(move || {
+        let _archive_permit = archive_permit;
+        build_repo_release_evidence(
+            &state_for_evidence,
+            &repo_for_evidence,
+            requested_change,
+            frozen_snapshot,
+        )
+    })
+    .await
+    .map_err(|error| {
+        (
+            StatusCode::INTERNAL_SERVER_ERROR,
+            format!("source-bound release evidence worker failed: {error}"),
+        )
+    })??;
+    Ok(Json(evidence))
+}
+
 fn repo_name(state: &DaemonState) -> String {
     primary_repo_id(state)
 }
@@ -9546,6 +11024,891 @@ mod tests {
     use super::*;
     use axum::body::Body;
     use axum::http::Request;
+
+    #[test]
+    fn bounded_archive_writer_rejects_before_crossing_limit() {
+        let mut writer = BoundedArchiveWriter::new(4);
+        writer.write_all(b"abc").unwrap();
+        let error = writer.write_all(b"de").unwrap_err();
+        assert!(error
+            .get_ref()
+            .is_some_and(|source| source.is::<ExactSourceArchiveLimitExceeded>()));
+        assert_eq!(writer.into_inner(), b"abc");
+    }
+
+    #[tokio::test]
+    async fn exact_source_archive_generation_is_single_flight_for_response_lifetime() {
+        let semaphore = Arc::new(tokio::sync::Semaphore::new(1));
+        let permit = try_acquire_exact_source_archive_slot(Arc::clone(&semaphore)).unwrap();
+        let mut body = exact_source_archive_body(vec![0_u8; 16], permit);
+        let error = try_acquire_exact_source_archive_slot(Arc::clone(&semaphore)).unwrap_err();
+        assert_eq!(error.0, StatusCode::TOO_MANY_REQUESTS);
+
+        // Hyper can drop an exhausted Body as soon as it has polled the data
+        // frame, while retaining the Bytes in its socket/write buffer. The
+        // frame owner—not merely the Body—must therefore keep admission.
+        let frame = std::future::poll_fn(|cx| {
+            http_body::Body::poll_frame(std::pin::Pin::new(&mut body), cx)
+        })
+        .await
+        .unwrap()
+        .unwrap();
+        let data = frame.into_data().unwrap();
+        drop(body);
+        let error = try_acquire_exact_source_archive_slot(Arc::clone(&semaphore)).unwrap_err();
+        assert_eq!(error.0, StatusCode::TOO_MANY_REQUESTS);
+        drop(data);
+        assert!(try_acquire_exact_source_archive_slot(semaphore).is_ok());
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn cancelled_archive_request_cannot_release_a_running_worker_permit() {
+        let semaphore = Arc::new(tokio::sync::Semaphore::new(1));
+        let permit = try_acquire_exact_source_archive_slot(Arc::clone(&semaphore)).unwrap();
+        let (started_tx, started_rx) = tokio::sync::oneshot::channel();
+        let (resume_tx, resume_rx) = tokio::sync::oneshot::channel();
+        let (done_tx, done_rx) = tokio::sync::oneshot::channel();
+        let worker = tokio::task::spawn_blocking(move || {
+            let result = hold_exact_source_archive_permit(permit, || {
+                started_tx.send(()).unwrap();
+                resume_rx.blocking_recv().unwrap();
+                Ok::<_, ()>(())
+            });
+            drop(result);
+            done_tx.send(()).unwrap();
+        });
+        started_rx.await.unwrap();
+
+        // Dropping a request's JoinHandle does not abort spawn_blocking. The
+        // worker, not the request future, must therefore retain admission.
+        drop(worker);
+        let error = try_acquire_exact_source_archive_slot(Arc::clone(&semaphore)).unwrap_err();
+        assert_eq!(error.0, StatusCode::TOO_MANY_REQUESTS);
+
+        resume_tx.send(()).unwrap();
+        done_rx.await.unwrap();
+        assert!(try_acquire_exact_source_archive_slot(semaphore).is_ok());
+    }
+
+    #[test]
+    fn archive_and_evidence_use_the_same_process_wide_memory_slot() {
+        assert!(Arc::ptr_eq(
+            &exact_source_archive_exports(),
+            &exact_source_archive_exports()
+        ));
+    }
+
+    #[test]
+    fn exact_source_loader_fetches_and_retains_one_allocation_per_content_hash() {
+        let bytes = b"shared archive payload\n";
+        let digest: [u8; 32] = Sha256::digest(bytes).into();
+        let hash = Hash256::from_bytes(digest);
+        let tree = HashMap::from([
+            (
+                FilePathId::new("src/first.rs"),
+                ResolvedSourceEntry {
+                    hash,
+                    kind: SourceEntryKind::File { executable: false },
+                },
+            ),
+            (
+                FilePathId::new("src/second.rs"),
+                ResolvedSourceEntry {
+                    hash,
+                    kind: SourceEntryKind::File { executable: true },
+                },
+            ),
+        ]);
+        let mut loads = 0;
+        let entries = load_exact_source_entries_with(tree, |_, requested, max_bytes| {
+            loads += 1;
+            assert_eq!(requested, digest);
+            assert_eq!(max_bytes, EXACT_SOURCE_MAX_EXPANDED_BYTES as u64);
+            Ok(Some(bytes.to_vec()))
+        })
+        .unwrap();
+
+        assert_eq!(loads, 1);
+        let ExactSourceEntry::File { data: first, .. } = &entries[0] else {
+            panic!("expected regular source entry")
+        };
+        let ExactSourceEntry::File { data: second, .. } = &entries[1] else {
+            panic!("expected regular source entry")
+        };
+        assert!(Arc::ptr_eq(first, second));
+    }
+
+    #[test]
+    fn exact_source_loader_reduces_the_backend_limit_before_each_distinct_allocation() {
+        let first = b"first immutable payload\n";
+        let second = b"second immutable payload with a different length\n";
+        let first_digest: [u8; 32] = Sha256::digest(first).into();
+        let second_digest: [u8; 32] = Sha256::digest(second).into();
+        let tree = HashMap::from([
+            (
+                FilePathId::new("src/first.rs"),
+                ResolvedSourceEntry {
+                    hash: Hash256::from_bytes(first_digest),
+                    kind: SourceEntryKind::File { executable: false },
+                },
+            ),
+            (
+                FilePathId::new("src/second.rs"),
+                ResolvedSourceEntry {
+                    hash: Hash256::from_bytes(second_digest),
+                    kind: SourceEntryKind::File { executable: false },
+                },
+            ),
+        ]);
+        let mut expected = [
+            (first_digest, first.as_slice()),
+            (second_digest, second.as_slice()),
+        ];
+        expected.sort_by_key(|(digest, _)| *digest);
+        let mut observed = Vec::new();
+
+        load_exact_source_entries_with(tree, |_, requested, max_bytes| {
+            observed.push((requested, max_bytes));
+            let bytes = expected
+                .iter()
+                .find_map(|(digest, bytes)| (*digest == requested).then_some(*bytes))
+                .expect("the loader must request a tree-owned digest");
+            Ok(Some(bytes.to_vec()))
+        })
+        .unwrap();
+
+        assert_eq!(observed.len(), 2);
+        assert_eq!(observed[0].0, expected[0].0);
+        assert_eq!(observed[0].1, EXACT_SOURCE_MAX_EXPANDED_BYTES as u64);
+        assert_eq!(observed[1].0, expected[1].0);
+        assert_eq!(
+            observed[1].1,
+            EXACT_SOURCE_MAX_EXPANDED_BYTES as u64 - expected[0].1.len() as u64
+        );
+    }
+
+    #[test]
+    fn historical_release_evidence_omits_unbound_later_verification_runs() {
+        use kin_model::VerificationStore;
+
+        let graph = kin_db::InMemoryGraph::new();
+        let root = kin_core::build_genesis_change();
+        graph.create_change(&root).unwrap();
+        let entity = test_entity("source_bound", "src/lib.rs");
+        let mut source_change = root.clone();
+        source_change.id = SemanticChangeId::from_hash(Hash256::from_bytes([0x85; 32]));
+        source_change.parents = vec![root.id];
+        source_change.message = "historical source".to_string();
+        source_change.entity_deltas = vec![kin_model::EntityDelta::Added(entity.clone())];
+        graph.create_change(&source_change).unwrap();
+        graph.upsert_entity(&entity).unwrap();
+
+        let run = kin_model::VerificationRun {
+            run_id: kin_model::VerificationRunId::new(),
+            test_ids: vec![],
+            status: kin_model::VerificationStatus::Passing,
+            runner: kin_model::TestRunner::Cargo,
+            started_at: Timestamp::now(),
+            finished_at: Some(Timestamp::now()),
+            duration_ms: Some(1),
+            evidence_blob: None,
+            exit_code: Some(0),
+        };
+        graph.create_verification_run(&run).unwrap();
+        graph
+            .link_run_proves_entity(&run.run_id, &entity.id)
+            .unwrap();
+        assert_eq!(
+            kin_review::passing_proof_coverage(&graph)
+                .unwrap()
+                .covered_entities,
+            1,
+            "the current unbound run is a false-green without historical filtering"
+        );
+
+        let snapshot = graph.to_snapshot();
+        let (historical, _) =
+            release_evidence_graph_at(&graph, &snapshot, &source_change.id).unwrap();
+        let coverage = kin_review::passing_proof_coverage(&historical).unwrap();
+        assert_eq!(coverage.total_entities, 1);
+        assert_eq!(coverage.covered_entities, 0);
+        assert_eq!(coverage.missing_proof, vec![entity.id]);
+    }
+
+    #[test]
+    fn later_unbound_tests_cannot_rewrite_historical_security_or_anchor() {
+        use kin_model::{EntityStore, VerificationStore};
+
+        let graph = kin_db::InMemoryGraph::new();
+        let root = kin_core::build_genesis_change();
+        graph.create_change(&root).unwrap();
+        let mut entity = test_entity("historical_endpoint", "src/api.rs");
+        entity.kind = EntityKind::ApiEndpoint;
+        let mut source_change = root.clone();
+        source_change.id = SemanticChangeId::from_hash(Hash256::from_bytes([0x86; 32]));
+        source_change.parents = vec![root.id];
+        source_change.message = "historical endpoint source".to_string();
+        source_change.entity_deltas = vec![kin_model::EntityDelta::Added(entity.clone())];
+        graph.create_change(&source_change).unwrap();
+        graph.upsert_entity(&entity).unwrap();
+
+        let before_snapshot = graph.to_snapshot();
+        let (before_graph, before_root) =
+            release_evidence_graph_at(&graph, &before_snapshot, &source_change.id).unwrap();
+        let before_security_count = kin_review::security_findings(&before_graph, true)
+            .unwrap()
+            .len();
+        assert!(before_security_count > 0);
+
+        let release_check = RepoReleaseCheckEvidence {
+            pass: false,
+            blockers: vec!["fixed historical blocker".to_string()],
+        };
+        let coverage = RepoCoverageEvidence {
+            total_entities: 1,
+            covered_entities: 0,
+            coverage_ratio: 0.0,
+            missing_proof_count: 1,
+        };
+        let before_security = RepoSecurityEvidence {
+            finding_count: before_security_count,
+        };
+        let before_anchor = release_evidence_anchor(
+            "repo",
+            &source_change.id.to_string(),
+            "fixed-manifest",
+            before_root,
+            &release_check,
+            &coverage,
+            &before_security,
+        );
+
+        let test = kin_model::TestCase {
+            test_id: kin_model::TestId::new(),
+            name: "later_endpoint_test".to_string(),
+            language: "rust".to_string(),
+            kind: kin_model::TestKind::Unit,
+            scopes: vec![kin_model::WorkScope::Entity(entity.id)],
+            runner: kin_model::TestRunner::Cargo,
+            file_origin: Some(FilePathId::new("tests/later.rs")),
+        };
+        graph.create_test_case(&test).unwrap();
+        graph
+            .create_assertion(&kin_model::Assertion {
+                assertion_id: kin_model::AssertionId::new(),
+                summary: "later assertion".to_string(),
+                expected_behavior: "later behavior".to_string(),
+                target_scope: kin_model::WorkScope::Entity(entity.id),
+            })
+            .unwrap();
+        graph
+            .create_contract(&kin_model::Contract {
+                id: EntityId::new(),
+                kind: kin_model::ContractKind::OpenApi,
+                name: "later contract".to_string(),
+                schema_hash: Hash256::from_bytes([0x87; 32]),
+                producers: vec![entity.id],
+                consumers: vec![],
+                version: None,
+            })
+            .unwrap();
+        graph
+            .create_mock_hint(&kin_model::MockHint {
+                hint_id: kin_model::MockHintId::new(),
+                test_id: test.test_id,
+                dependency_scope: kin_model::WorkScope::Entity(entity.id),
+                strategy: kin_model::MockStrategy::Stub,
+            })
+            .unwrap();
+        graph
+            .upsert_relation(&kin_model::Relation {
+                id: kin_model::RelationId::new(),
+                kind: RelationKind::Tests,
+                // The release scanner's entity relation API currently admits
+                // only entity-to-entity edges. This uncommitted overlay edge
+                // has the exact shape that the former historical graft copied
+                // and that can false-green `untested-api`.
+                src: GraphNodeId::Entity(entity.id),
+                dst: GraphNodeId::Entity(entity.id),
+                confidence: 1.0,
+                origin: kin_model::RelationOrigin::Inferred,
+                created_in: None,
+                import_source: None,
+                evidence: vec![],
+            })
+            .unwrap();
+        assert!(
+            kin_review::security_findings(&graph, true).unwrap().len() < before_security_count,
+            "the later unbound Tests relation must demonstrate the false-green current graph"
+        );
+
+        let mut after_snapshot = graph.to_snapshot();
+        after_snapshot
+            .test_covers_entity
+            .push((test.test_id, entity.id));
+        assert!(!after_snapshot.test_cases.is_empty());
+        assert!(!after_snapshot.assertions.is_empty());
+        assert!(!after_snapshot.contracts.is_empty());
+        assert!(!after_snapshot.mock_hints.is_empty());
+        assert!(!after_snapshot.test_covers_entity.is_empty());
+        assert!(after_snapshot
+            .relations
+            .values()
+            .any(|relation| matches!(relation.kind, RelationKind::Tests | RelationKind::Covers)));
+
+        let after_snapshot_root = kin_db::compute_graph_root_hash(&after_snapshot);
+        let after_frozen = kin_db::InMemoryGraph::from_snapshot_without_text_index_with_root_hash(
+            after_snapshot.clone(),
+            after_snapshot_root,
+        );
+        let (after_graph, after_root) =
+            release_evidence_graph_at(&after_frozen, &after_snapshot, &source_change.id).unwrap();
+        let historical_snapshot = after_graph.to_snapshot();
+        assert!(historical_snapshot.test_cases.is_empty());
+        assert!(historical_snapshot.assertions.is_empty());
+        assert!(historical_snapshot.contracts.is_empty());
+        assert!(historical_snapshot.mock_hints.is_empty());
+        assert!(historical_snapshot.test_covers_entity.is_empty());
+        assert!(!historical_snapshot
+            .relations
+            .values()
+            .any(|relation| matches!(relation.kind, RelationKind::Tests | RelationKind::Covers)));
+
+        let after_security_count = kin_review::security_findings(&after_graph, true)
+            .unwrap()
+            .len();
+        let after_security = RepoSecurityEvidence {
+            finding_count: after_security_count,
+        };
+        let after_anchor = release_evidence_anchor(
+            "repo",
+            &source_change.id.to_string(),
+            "fixed-manifest",
+            after_root,
+            &release_check,
+            &coverage,
+            &after_security,
+        );
+
+        assert_eq!(after_security_count, before_security_count);
+        assert_eq!(after_root, before_root);
+        assert_eq!(after_anchor, before_anchor);
+    }
+
+    #[test]
+    fn exact_source_archive_is_deterministic_mode_faithful_and_manifest_bound() {
+        use std::io::Read;
+
+        let entries = vec![
+            ExactSourceEntry::File {
+                path: "README.md".to_string(),
+                data: b"Kin\n".to_vec().into(),
+                executable: false,
+            },
+            ExactSourceEntry::Symlink {
+                path: "current".to_string(),
+                target: "bin/run".to_string().into(),
+            },
+            ExactSourceEntry::File {
+                path: "bin/run".to_string(),
+                data: b"#!/bin/sh\n".to_vec().into(),
+                executable: true,
+            },
+        ];
+        let (first, first_manifest_hash) = build_exact_source_tar_gz(entries.clone()).unwrap();
+        let (second, second_manifest_hash) = build_exact_source_tar_gz(entries.clone()).unwrap();
+        assert_eq!(first, second);
+        assert_eq!(first_manifest_hash, second_manifest_hash);
+
+        let manifest = canonical_exact_source_manifest(&entries).unwrap();
+        assert_eq!(first_manifest_hash, hex::encode(Sha256::digest(&manifest)));
+
+        let decoder = flate2::read::GzDecoder::new(first.as_slice());
+        let mut archive = tar::Archive::new(decoder);
+        let mut observed = Vec::new();
+        for entry in archive.entries().unwrap() {
+            let mut entry = entry.unwrap();
+            let path = entry.path().unwrap().to_string_lossy().into_owned();
+            let kind = entry.header().entry_type();
+            let mode = entry.header().mode().unwrap();
+            let link = entry
+                .link_name()
+                .unwrap()
+                .map(|target| target.to_string_lossy().into_owned());
+            let mut data = Vec::new();
+            entry.read_to_end(&mut data).unwrap();
+            observed.push((path, kind, mode, link, data));
+        }
+
+        assert_eq!(observed.len(), 4);
+        assert_eq!(observed[0].0, "kin-source/");
+        assert!(observed[0].1.is_dir());
+        assert_eq!(observed[1].0, "kin-source/README.md");
+        assert!(observed[1].1.is_file());
+        assert_eq!(observed[1].2, 0o644);
+        assert_eq!(observed[1].4, b"Kin\n");
+        assert_eq!(observed[2].0, "kin-source/bin/run");
+        assert!(observed[2].1.is_file());
+        assert_eq!(observed[2].2, 0o755);
+        assert_eq!(observed[2].4, b"#!/bin/sh\n");
+        assert_eq!(observed[3].0, "kin-source/current");
+        assert!(observed[3].1.is_symlink());
+        assert_eq!(observed[3].2, 0o777);
+        assert_eq!(observed[3].3.as_deref(), Some("bin/run"));
+
+        let mut mutated = entries;
+        if let ExactSourceEntry::File { data, .. } = &mut mutated[0] {
+            Arc::make_mut(data)[0] = b'!';
+        }
+        let (_, mutated_manifest_hash) = build_exact_source_tar_gz(mutated).unwrap();
+        assert_ne!(first_manifest_hash, mutated_manifest_hash);
+    }
+
+    #[test]
+    fn exact_source_manifest_is_order_independent_and_rejects_conflicts() {
+        let first = ExactSourceEntry::File {
+            path: "z.txt".to_string(),
+            data: b"z".to_vec().into(),
+            executable: false,
+        };
+        let second = ExactSourceEntry::File {
+            path: "a.txt".to_string(),
+            data: b"a".to_vec().into(),
+            executable: false,
+        };
+        assert_eq!(
+            canonical_exact_source_manifest(&[first.clone(), second.clone()]).unwrap(),
+            canonical_exact_source_manifest(&[second, first]).unwrap()
+        );
+
+        let conflict = canonical_exact_source_manifest(&[
+            ExactSourceEntry::File {
+                path: "src".to_string(),
+                data: Vec::new().into(),
+                executable: false,
+            },
+            ExactSourceEntry::File {
+                path: "src/lib.rs".to_string(),
+                data: Vec::new().into(),
+                executable: false,
+            },
+        ])
+        .unwrap_err();
+        assert_eq!(conflict.0, StatusCode::INTERNAL_SERVER_ERROR);
+        assert!(conflict.1.contains("conflicting"));
+    }
+
+    #[test]
+    fn exact_source_manifest_rejects_cross_platform_path_aliases() {
+        for (first, second) in [
+            ("src/Foo.rs", "src/foo.rs"),
+            ("src/caf\u{e9}.rs", "src/cafe\u{301}.rs"),
+        ] {
+            let error = canonical_exact_source_manifest(&[
+                ExactSourceEntry::File {
+                    path: first.to_string(),
+                    data: b"first".to_vec().into(),
+                    executable: false,
+                },
+                ExactSourceEntry::File {
+                    path: second.to_string(),
+                    data: b"second".to_vec().into(),
+                    executable: false,
+                },
+            ])
+            .expect_err("portable archives must reject paths that alias on Windows or macOS");
+            assert_eq!(error.0, StatusCode::INTERNAL_SERVER_ERROR);
+            assert!(error.1.contains("conflicting or unportable"));
+        }
+    }
+
+    #[test]
+    fn exact_source_manifest_rejects_newline_bearing_fields_for_portability() {
+        for entries in [
+            vec![ExactSourceEntry::Symlink {
+                path: "line\nbreak".to_string(),
+                target: "ordinary".to_string().into(),
+            }],
+            vec![ExactSourceEntry::Symlink {
+                path: "link".to_string(),
+                target: "line\nbreak".to_string().into(),
+            }],
+        ] {
+            let error = canonical_exact_source_manifest(&entries)
+                .expect_err("portable archives must reject control characters");
+            assert_eq!(error.0, StatusCode::INTERNAL_SERVER_ERROR);
+        }
+    }
+
+    #[test]
+    fn exact_source_paths_and_symlinks_fail_closed() {
+        for path in [
+            "",
+            "/etc/passwd",
+            "../secret",
+            "src\\lib.rs",
+            ".git/config",
+            ".GiT/config",
+            ".kin/config.toml",
+            ".KIN/config.toml",
+            "nested/.kin/graph.kndb",
+            "nested/.KiN/graph.kndb",
+            ".kin-session/base.json",
+            ".KIN-SESSION/base.json",
+            "nested/.kin-session/base.json",
+            "nested/.KiN-SeSsIoN/base.json",
+            "NUL",
+            "src/COM1.rs",
+            "src/trailing.",
+            "src/trailing ",
+            "src/alternate:stream",
+        ] {
+            assert!(
+                validate_exact_source_path(path).is_err(),
+                "accepted {path:?}"
+            );
+        }
+        assert!(validate_exact_source_symlink("dir/link", "../../secret").is_err());
+        assert!(validate_exact_source_symlink("link", "/etc/passwd").is_err());
+        assert!(validate_exact_source_symlink("dir/link", "../.kin-session/base.json").is_err());
+        assert!(validate_exact_source_symlink("dir/link", "../.KiN-SeSsIoN/base.json").is_err());
+        assert!(validate_exact_source_symlink("dir/link", "../README.md").is_ok());
+    }
+
+    fn exact_source_backend_state(repo_id: &str) -> Arc<DaemonState> {
+        install_test_registry_override();
+        let directory =
+            std::env::temp_dir().join(format!("kin-daemon-exact-source-{}", uuid::Uuid::new_v4()));
+        let kin_dir = directory.join(".kin");
+        std::fs::create_dir_all(kin_dir.join("objects")).unwrap();
+        std::fs::create_dir_all(kin_dir.join("working")).unwrap();
+        let layout = kin_core::KinLayout::new(kin_dir);
+        kin_core::manifest::KinManifest::new()
+            .save(&layout.manifest_path())
+            .unwrap();
+        let backend = directory.join("backend");
+        std::fs::create_dir_all(&backend).unwrap();
+        Arc::new(
+            DaemonState::open_with_backend(
+                layout,
+                Box::new(kin_db::LocalFileBackend::new(backend)),
+                repo_id,
+                None,
+            )
+            .unwrap(),
+        )
+    }
+
+    fn exact_source_delta(
+        state: &DaemonState,
+        path: &str,
+        kind: ArtifactDeltaKind,
+        old_hash: Option<Hash256>,
+        data: &[u8],
+    ) -> ArtifactDelta {
+        let blob_hash = state.blobs.write(data).unwrap();
+        ArtifactDelta {
+            file_id: FilePathId::new(path),
+            kind,
+            old_hash,
+            new_hash: Some(blob_hash),
+        }
+    }
+
+    fn install_two_change_exact_source_history(
+        state: &DaemonState,
+    ) -> (SemanticChangeId, SemanticChangeId) {
+        let branch_name = BranchName::new("main");
+        let old_readme = state.blobs.write(b"old source\n").unwrap();
+        let first_entity = test_entity("first_source_entity", "src/first.rs");
+        state.graph.upsert_entity(&first_entity).unwrap();
+        let first = SemanticChange {
+            id: SemanticChangeId::from_hash(Hash256::from_bytes([81; 32])),
+            parents: vec![],
+            timestamp: Timestamp::now(),
+            author: AuthorId::new("human-test"),
+            message: "first exact source".to_string(),
+            entity_deltas: vec![EntityDelta::Added(first_entity)],
+            relation_deltas: vec![],
+            artifact_deltas: vec![
+                ArtifactDelta {
+                    file_id: FilePathId::new("README.md"),
+                    kind: ArtifactDeltaKind::AddedRegularFile,
+                    old_hash: None,
+                    new_hash: Some(old_readme),
+                },
+                exact_source_delta(
+                    state,
+                    "bin/run",
+                    ArtifactDeltaKind::AddedExecutableFile,
+                    None,
+                    b"#!/bin/sh\necho old\n",
+                ),
+                exact_source_delta(
+                    state,
+                    "current",
+                    ArtifactDeltaKind::AddedSymlink,
+                    None,
+                    b"bin/run",
+                ),
+            ],
+            projected_files: vec![],
+            spec_link: None,
+            evidence: vec![],
+            risk_summary: None,
+            authored_on: Some(branch_name.clone()),
+        };
+        state.graph.create_change(&first).unwrap();
+        state
+            .graph
+            .create_branch(&Branch {
+                name: branch_name.clone(),
+                head: first.id,
+            })
+            .unwrap();
+
+        let second_entity = test_entity("second_source_entity", "src/second.rs");
+        state.graph.upsert_entity(&second_entity).unwrap();
+        let second = SemanticChange {
+            id: SemanticChangeId::from_hash(Hash256::from_bytes([82; 32])),
+            parents: vec![first.id],
+            timestamp: Timestamp::now(),
+            author: AuthorId::new("human-test"),
+            message: "newer exact source".to_string(),
+            entity_deltas: vec![EntityDelta::Added(second_entity)],
+            relation_deltas: vec![],
+            artifact_deltas: vec![exact_source_delta(
+                state,
+                "README.md",
+                ArtifactDeltaKind::ModifiedRegularFile,
+                Some(old_readme),
+                b"new source\n",
+            )],
+            projected_files: vec![],
+            spec_link: None,
+            evidence: vec![],
+            risk_summary: None,
+            authored_on: Some(branch_name.clone()),
+        };
+        state.graph.create_change(&second).unwrap();
+        state
+            .graph
+            .update_branch_head(&branch_name, &second.id)
+            .unwrap();
+        state.save_snapshot_full().unwrap();
+        (first.id, second.id)
+    }
+
+    async fn exact_source_get(
+        app: Router,
+        path: String,
+        authenticated: bool,
+    ) -> axum::response::Response {
+        let mut request = Request::get(path);
+        if authenticated {
+            request = request.header(header::AUTHORIZATION, "Bearer exact-source-token");
+        }
+        app.oneshot(request.body(Body::empty()).unwrap())
+            .await
+            .unwrap()
+    }
+
+    fn read_exact_source_tar_entry(
+        archive: &[u8],
+        wanted: &str,
+    ) -> (u32, bool, Option<String>, Vec<u8>) {
+        use std::io::Read;
+
+        let decoder = flate2::read::GzDecoder::new(archive);
+        let mut archive = tar::Archive::new(decoder);
+        for entry in archive.entries().unwrap() {
+            let mut entry = entry.unwrap();
+            if entry.path().unwrap().as_ref() != FsPath::new(wanted) {
+                continue;
+            }
+            let mode = entry.header().mode().unwrap();
+            let is_symlink = entry.header().entry_type().is_symlink();
+            let link = entry
+                .link_name()
+                .unwrap()
+                .map(|target| target.to_string_lossy().into_owned());
+            let mut data = Vec::new();
+            entry.read_to_end(&mut data).unwrap();
+            return (mode, is_symlink, link, data);
+        }
+        panic!("archive entry {wanted:?} was not found")
+    }
+
+    #[tokio::test]
+    #[serial_test::serial]
+    async fn exact_source_routes_are_authenticated_historical_and_file_independent() {
+        let repo_id = "exact-route-repo";
+        let state = exact_source_backend_state(repo_id);
+        let (old_change, new_change) = install_two_change_exact_source_history(&state);
+        let app = router_with_auth(Arc::clone(&state), Some("exact-source-token".to_string()));
+        let old_path = format!("/repos/{repo_id}/archive/tar/{old_change}");
+
+        let rejected = exact_source_get(app.clone(), old_path.clone(), false).await;
+        assert_eq!(rejected.status(), StatusCode::UNAUTHORIZED);
+
+        let old_response = exact_source_get(app.clone(), old_path.clone(), true).await;
+        assert_eq!(old_response.status(), StatusCode::OK);
+        assert_eq!(
+            old_response.headers()["x-kin-source-change-id"],
+            old_change.to_string()
+        );
+        let old_manifest = old_response.headers()["x-kin-source-manifest-sha256"].clone();
+        let old_archive_frame = axum::body::to_bytes(old_response.into_body(), 1024 * 1024)
+            .await
+            .unwrap();
+        // Tower's in-process transport hands the server-owned Bytes directly
+        // to the test client. Copy into client-owned storage and release that
+        // server allocation, matching a real network write completing.
+        let old_archive = old_archive_frame.to_vec();
+        drop(old_archive_frame);
+        assert_eq!(
+            read_exact_source_tar_entry(&old_archive, "kin-source/README.md"),
+            (0o644, false, None, b"old source\n".to_vec())
+        );
+        assert_eq!(
+            read_exact_source_tar_entry(&old_archive, "kin-source/bin/run"),
+            (0o755, false, None, b"#!/bin/sh\necho old\n".to_vec())
+        );
+        assert_eq!(
+            read_exact_source_tar_entry(&old_archive, "kin-source/current"),
+            (0o777, true, Some("bin/run".to_string()), Vec::new())
+        );
+
+        // A newer branch head and a decoy working-tree file cannot change the
+        // bytes returned for the explicitly requested historical source ID.
+        std::fs::write(state.layout.working_dir().join("README.md"), b"raw decoy\n").unwrap();
+        let repeated = exact_source_get(app.clone(), old_path, true).await;
+        assert_eq!(repeated.status(), StatusCode::OK);
+        assert_eq!(
+            repeated.headers()["x-kin-source-manifest-sha256"],
+            old_manifest
+        );
+        let repeated_archive_frame = axum::body::to_bytes(repeated.into_body(), 1024 * 1024)
+            .await
+            .unwrap();
+        let repeated_archive = repeated_archive_frame.to_vec();
+        drop(repeated_archive_frame);
+        assert_eq!(old_archive, repeated_archive);
+
+        let new_response = exact_source_get(
+            app.clone(),
+            format!("/repos/{repo_id}/archive/tar/{new_change}"),
+            true,
+        )
+        .await;
+        assert_eq!(new_response.status(), StatusCode::OK);
+        let new_manifest = new_response.headers()["x-kin-source-manifest-sha256"].clone();
+        assert_ne!(old_manifest, new_manifest);
+        let new_archive_frame = axum::body::to_bytes(new_response.into_body(), 1024 * 1024)
+            .await
+            .unwrap();
+        let new_archive = new_archive_frame.to_vec();
+        drop(new_archive_frame);
+        assert_eq!(
+            read_exact_source_tar_entry(&new_archive, "kin-source/README.md").3,
+            b"new source\n"
+        );
+
+        let old_evidence = exact_source_get(
+            app.clone(),
+            format!("/repos/{repo_id}/release/evidence/{old_change}"),
+            true,
+        )
+        .await;
+        assert_eq!(old_evidence.status(), StatusCode::OK);
+        let old_evidence: RepoReleaseEvidenceResponse = serde_json::from_slice(
+            &axum::body::to_bytes(old_evidence.into_body(), 64 * 1024)
+                .await
+                .unwrap(),
+        )
+        .unwrap();
+        let new_evidence = exact_source_get(
+            app,
+            format!("/repos/{repo_id}/release/evidence/{new_change}"),
+            true,
+        )
+        .await;
+        assert_eq!(new_evidence.status(), StatusCode::OK);
+        let new_evidence: RepoReleaseEvidenceResponse = serde_json::from_slice(
+            &axum::body::to_bytes(new_evidence.into_body(), 64 * 1024)
+                .await
+                .unwrap(),
+        )
+        .unwrap();
+
+        assert_eq!(old_evidence.source_change_id, old_change.to_string());
+        assert_eq!(new_evidence.source_change_id, new_change.to_string());
+        assert_eq!(old_evidence.coverage.total_entities, 1);
+        assert_eq!(new_evidence.coverage.total_entities, 2);
+        assert_eq!(old_evidence.coverage.missing_proof_count, 1);
+        assert_eq!(new_evidence.coverage.missing_proof_count, 2);
+        assert_ne!(old_evidence.authority_anchor, new_evidence.authority_anchor);
+        assert_eq!(
+            old_evidence.source_manifest_sha256,
+            old_manifest.to_str().unwrap()
+        );
+        assert_eq!(
+            new_evidence.source_manifest_sha256,
+            new_manifest.to_str().unwrap()
+        );
+    }
+
+    #[tokio::test]
+    #[serial_test::serial]
+    async fn exact_source_archive_fails_closed_on_legacy_mode_gap() {
+        let repo_id = "legacy-source-gap";
+        let state = exact_source_backend_state(repo_id);
+        let content = state.blobs.write(b"local compatibility bytes\n").unwrap();
+        let change = SemanticChange {
+            id: SemanticChangeId::from_hash(Hash256::from_bytes([83; 32])),
+            parents: vec![],
+            timestamp: Timestamp::now(),
+            author: AuthorId::new("human-test"),
+            message: "legacy source".to_string(),
+            entity_deltas: vec![],
+            relation_deltas: vec![],
+            artifact_deltas: vec![ArtifactDelta {
+                file_id: FilePathId::new("legacy.txt"),
+                kind: ArtifactDeltaKind::Added,
+                old_hash: None,
+                new_hash: Some(content),
+            }],
+            projected_files: vec![],
+            spec_link: None,
+            evidence: vec![],
+            risk_summary: None,
+            authored_on: None,
+        };
+        state.graph.create_change(&change).unwrap();
+        state.save_snapshot_full().unwrap();
+        std::fs::write(
+            state.layout.working_dir().join("legacy.txt"),
+            b"filesystem fallback must not be served\n",
+        )
+        .unwrap();
+
+        let response = exact_source_get(
+            router_with_auth(state, Some("exact-source-token".to_string())),
+            format!("/repos/{repo_id}/archive/tar/{}", change.id),
+            true,
+        )
+        .await;
+        assert_eq!(response.status(), StatusCode::FAILED_DEPENDENCY);
+        let body = String::from_utf8(
+            axum::body::to_bytes(response.into_body(), 16 * 1024)
+                .await
+                .unwrap()
+                .to_vec(),
+        )
+        .unwrap();
+        assert!(body.contains("exact source history is incomplete"));
+        assert!(body.contains("no fallback was attempted"));
+    }
 
     /// Dispatching the prepare must leave the async worker schedulable.
     ///
@@ -10123,12 +12486,13 @@ mod tests {
     }
     use axum::routing::get as axum_get;
     use kin_model::{
-        AgentSession, AnnotationFilter, ArtifactDelta, ArtifactDeltaKind, AuthorId, Branch,
-        BranchName, Entity, EntityDelta, EntityId, EntityKind, EntityRole, FilePathId,
-        FingerprintAlgorithm, Hash256, IdentityRef, ImportSection, IntentScope, LanguageId,
-        Priority, SemanticChange, SemanticChangeId, SemanticFingerprint, SourceRegion, SourceSpan,
-        TestCase, TestKind, TestRunner, Timestamp, Visibility, WorkItem, WorkKind, WorkScope,
-        WorkStatus, WorkStore,
+        Actor, ActorId, ActorKind, AgentSession, AnnotationFilter, Approval, ApprovalDecision,
+        ApprovalId, ArtifactDelta, ArtifactDeltaKind, AuditEventId, AuthorId, Branch, BranchName,
+        Entity, EntityDelta, EntityId, EntityKind, EntityRole, FilePathId, FingerprintAlgorithm,
+        Hash256, IdentityRef, ImportSection, IntentScope, LanguageId, Priority, RelationKind,
+        SemanticChange, SemanticChangeId, SemanticFingerprint, SourceRegion, SourceSpan, TestCase,
+        TestKind, TestRunner, Timestamp, Visibility, WorkItem, WorkKind, WorkScope, WorkStatus,
+        WorkStore,
     };
     use kin_model::{ReviewStore, VerificationStore};
     use kin_registry::Ecosystem;
@@ -10203,6 +12567,14 @@ mod tests {
     /// Create a real Git commit outside graph truth. A ref query against the
     /// returned oid must therefore take the daemon's cold hydration path.
     fn setup_daemon_hydration_fixture(state: &DaemonState) -> String {
+        // `is_initialized = true` means the canonical Kin boundary root is
+        // already durable in production. Keep the synthetic daemon fixture
+        // faithful to that invariant so strict temporal traversal does not
+        // mistake its intentionally bare test graph for a valid repository.
+        let genesis = kin_core::build_genesis_change();
+        if state.graph.get_change(&genesis.id).unwrap().is_none() {
+            state.graph.create_change(&genesis).unwrap();
+        }
         let repo = state.layout.working_dir();
         std::fs::create_dir_all(repo.join("src")).unwrap();
         std::fs::write(
@@ -10351,6 +12723,198 @@ mod tests {
             })
             .unwrap();
         kin_core::write_current_branch(&state.layout, &branch_name).unwrap();
+    }
+
+    fn install_release_test_branch(state: &Arc<DaemonState>) -> SemanticChangeId {
+        let genesis = kin_core::build_genesis_change();
+        state.graph.create_change(&genesis).unwrap();
+        state
+            .graph
+            .create_branch(&Branch {
+                name: BranchName::new("main"),
+                head: genesis.id,
+            })
+            .unwrap();
+        genesis.id
+    }
+
+    fn install_release_entity_head(
+        state: &Arc<DaemonState>,
+        entity: &Entity,
+        id_byte: u8,
+    ) -> SemanticChange {
+        let genesis = kin_core::build_genesis_change();
+        state.graph.create_change(&genesis).unwrap();
+        let change = SemanticChange {
+            id: SemanticChangeId::from_hash(Hash256::from_bytes([id_byte; 32])),
+            parents: vec![genesis.id],
+            timestamp: Timestamp::now(),
+            author: AuthorId::new("agent-test"),
+            message: "add release entity".to_string(),
+            entity_deltas: vec![EntityDelta::Added(entity.clone())],
+            relation_deltas: vec![],
+            artifact_deltas: vec![],
+            projected_files: vec![],
+            spec_link: None,
+            evidence: vec![],
+            risk_summary: None,
+            authored_on: Some(BranchName::new("main")),
+        };
+        state.graph.upsert_entity(entity).unwrap();
+        state.graph.create_change(&change).unwrap();
+        state
+            .graph
+            .create_branch(&Branch {
+                name: BranchName::new("main"),
+                head: change.id,
+            })
+            .unwrap();
+        change
+    }
+
+    fn release_test_change(parent: SemanticChangeId, id_byte: u8) -> SemanticChange {
+        release_test_change_with_count(parent, id_byte, 0)
+    }
+
+    fn release_test_change_with_count(
+        parent: SemanticChangeId,
+        id_byte: u8,
+        entity_count: usize,
+    ) -> SemanticChange {
+        SemanticChange {
+            id: SemanticChangeId::from_hash(Hash256::from_bytes([id_byte; 32])),
+            parents: vec![parent],
+            timestamp: Timestamp::now(),
+            author: AuthorId::new("kin-release"),
+            message: format!("release: test ({entity_count} entities snapshot)"),
+            entity_deltas: vec![],
+            relation_deltas: vec![],
+            artifact_deltas: vec![],
+            projected_files: vec![],
+            spec_link: None,
+            evidence: vec![],
+            risk_summary: None,
+            authored_on: Some(BranchName::new("main")),
+        }
+    }
+
+    fn release_test_payload(change: &SemanticChange) -> serde_json::Value {
+        serde_json::json!({
+            "change": change,
+            "branch_name": "main",
+            "release_policy": {
+                "force": true,
+                "require_proof": false,
+                "require_approval": false,
+            },
+        })
+    }
+
+    fn exact_source_test_change(
+        parent: SemanticChangeId,
+        id_byte: u8,
+        file_id: &str,
+        kind: ArtifactDeltaKind,
+        hash: Hash256,
+    ) -> SemanticChange {
+        SemanticChange {
+            id: SemanticChangeId::from_hash(Hash256::from_bytes([id_byte; 32])),
+            parents: vec![parent],
+            timestamp: Timestamp::now(),
+            author: AuthorId::new("exact-source-api-test"),
+            message: "exact source API fixture".to_string(),
+            entity_deltas: vec![],
+            relation_deltas: vec![],
+            artifact_deltas: vec![ArtifactDelta {
+                file_id: FilePathId::new(file_id),
+                kind,
+                old_hash: None,
+                new_hash: Some(hash),
+            }],
+            projected_files: vec![FilePathId::new(file_id)],
+            spec_link: None,
+            evidence: vec![],
+            risk_summary: None,
+            authored_on: Some(BranchName::new("main")),
+        }
+    }
+
+    fn install_source_test_head(state: &Arc<DaemonState>, change: &SemanticChange) {
+        state.graph.create_change(change).unwrap();
+        state
+            .graph
+            .update_branch_head(&BranchName::new("main"), &change.id)
+            .unwrap();
+    }
+
+    fn api_local_object_path(state: &DaemonState, hash: Hash256) -> PathBuf {
+        let encoded = hash.to_string();
+        state
+            .layout
+            .objects_dir()
+            .join(&encoded[..2])
+            .join(&encoded[2..])
+    }
+
+    fn install_exact_checkout_branches(
+        state: &Arc<DaemonState>,
+    ) -> (SemanticChange, SemanticChange) {
+        let genesis = kin_core::build_genesis_change();
+        state.graph.create_change(&genesis).unwrap();
+        let main_blob = state.blobs.write(b"main checkout bytes\n").unwrap();
+        let main = exact_source_test_change(
+            genesis.id,
+            0xbc,
+            "src/shared.rs",
+            ArtifactDeltaKind::AddedRegularFile,
+            Hash256::from_bytes(main_blob.0),
+        );
+        state.graph.create_change(&main).unwrap();
+        state
+            .graph
+            .create_branch(&Branch {
+                name: BranchName::new("main"),
+                head: main.id,
+            })
+            .unwrap();
+
+        let feature_blob = state.blobs.write(b"feature checkout bytes\n").unwrap();
+        let feature = SemanticChange {
+            id: SemanticChangeId::from_hash(Hash256::from_bytes([0xbd; 32])),
+            parents: vec![main.id],
+            timestamp: Timestamp::now(),
+            author: AuthorId::new("exact-checkout-api-test"),
+            message: "feature checkout fixture".to_string(),
+            entity_deltas: vec![],
+            relation_deltas: vec![],
+            artifact_deltas: vec![ArtifactDelta {
+                file_id: FilePathId::new("src/shared.rs"),
+                kind: ArtifactDeltaKind::ModifiedRegularFile,
+                old_hash: main.artifact_deltas[0].new_hash,
+                new_hash: Some(Hash256::from_bytes(feature_blob.0)),
+            }],
+            projected_files: vec![FilePathId::new("src/shared.rs")],
+            spec_link: None,
+            evidence: vec![],
+            risk_summary: None,
+            authored_on: Some(BranchName::new("feature")),
+        };
+        state.graph.create_change(&feature).unwrap();
+        state
+            .graph
+            .create_branch(&Branch {
+                name: BranchName::new("feature"),
+                head: feature.id,
+            })
+            .unwrap();
+        kin_core::write_current_branch(&state.layout, &BranchName::new("main")).unwrap();
+        std::fs::create_dir_all(state.layout.working_dir().join("src")).unwrap();
+        std::fs::write(
+            state.layout.working_dir().join("src/shared.rs"),
+            b"main checkout bytes\n",
+        )
+        .unwrap();
+        (main, feature)
     }
 
     fn advance_branch_with_file(
@@ -10637,6 +13201,1190 @@ mod tests {
         assert_eq!(refs.branch_name.as_deref(), Some("main"));
         assert_eq!(refs.head_ref.as_deref(), Some(change_id_string.as_str()));
         assert_eq!(state.graph.entity_count(), 1);
+    }
+
+    #[tokio::test]
+    async fn graph_commit_rejects_same_id_with_different_payload_before_mutation() {
+        let state = test_state();
+        let mut existing = kin_core::build_genesis_change();
+        existing.id = SemanticChangeId::from_hash(Hash256::from_bytes([0x84; 32]));
+        existing.message = "immutable original".to_string();
+        state.graph.create_change(&existing).unwrap();
+
+        let entity = test_entity("must_not_land", "src/lib.rs");
+        let mut conflicting = existing.clone();
+        conflicting.message = "conflicting replacement".to_string();
+        conflicting.entity_deltas = vec![kin_model::EntityDelta::Added(entity)];
+        let payload = serde_json::json!({
+            "change": conflicting,
+            "branch_name": "main",
+        });
+
+        let response = router(Arc::clone(&state))
+            .oneshot(
+                Request::post("/graph/commit")
+                    .header("content-type", "application/json")
+                    .body(Body::from(payload.to_string()))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(response.status(), StatusCode::CONFLICT);
+        assert_eq!(state.graph.entity_count(), 0);
+        assert_eq!(
+            state
+                .graph
+                .get_change(&existing.id)
+                .unwrap()
+                .unwrap()
+                .message,
+            "immutable original"
+        );
+    }
+
+    #[tokio::test]
+    async fn graph_commit_stale_parent_returns_409_before_any_mutation() {
+        let state = test_state();
+        let live_head = install_release_test_branch(&state);
+        let entity = test_entity("must_not_land", "src/stale.rs");
+        let candidate_id = SemanticChangeId::from_hash(Hash256::from_bytes([0x91; 32]));
+        let candidate = SemanticChange {
+            id: candidate_id,
+            parents: vec![SemanticChangeId::from_hash(Hash256::from_bytes([0x90; 32]))],
+            timestamp: Timestamp::now(),
+            author: AuthorId::new("tester"),
+            message: "stale candidate".to_string(),
+            entity_deltas: vec![EntityDelta::Added(entity)],
+            relation_deltas: vec![],
+            artifact_deltas: vec![],
+            projected_files: vec![],
+            spec_link: None,
+            evidence: vec![],
+            risk_summary: None,
+            authored_on: Some(BranchName::new("main")),
+        };
+        let root_before = state.graph.compute_root_hash();
+        let generation_before = state
+            .snapshot_generation
+            .load(std::sync::atomic::Ordering::SeqCst);
+
+        let response = router(Arc::clone(&state))
+            .oneshot(
+                Request::post("/graph/commit")
+                    .header("content-type", "application/json")
+                    .body(Body::from(
+                        json!({ "change": candidate, "branch_name": "main" }).to_string(),
+                    ))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(response.status(), StatusCode::CONFLICT);
+        let body = axum::body::to_bytes(response.into_body(), 4096)
+            .await
+            .unwrap();
+        let json: serde_json::Value = serde_json::from_slice(&body).unwrap();
+        assert_eq!(json["error"], "stale_branch_head");
+        assert_eq!(json["mutation_applied"], false);
+        assert_eq!(json["change_materialized"], false);
+        assert_eq!(json["actual_head"], live_head.to_string());
+        assert!(state.graph.get_change(&candidate_id).unwrap().is_none());
+        assert_eq!(state.graph.entity_count(), 0);
+        assert_eq!(state.graph.compute_root_hash(), root_before);
+        assert_eq!(
+            state
+                .snapshot_generation
+                .load(std::sync::atomic::Ordering::SeqCst),
+            generation_before
+        );
+
+        // The same stale response is not absence proof when the immutable
+        // change already exists but is detached from this branch.
+        state.graph.create_change(&candidate).unwrap();
+        let response = router(Arc::clone(&state))
+            .oneshot(
+                Request::post("/graph/commit")
+                    .header("content-type", "application/json")
+                    .body(Body::from(
+                        json!({ "change": candidate, "branch_name": "main" }).to_string(),
+                    ))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(response.status(), StatusCode::CONFLICT);
+        let body = axum::body::to_bytes(response.into_body(), 4096)
+            .await
+            .unwrap();
+        let json: serde_json::Value = serde_json::from_slice(&body).unwrap();
+        assert_eq!(json["error"], "stale_branch_head");
+        assert_eq!(json["mutation_applied"], false);
+        assert_eq!(json["change_materialized"], true);
+    }
+
+    #[tokio::test]
+    async fn graph_commit_local_exact_source_preflight_is_atomic_and_accepts_valid_cas() {
+        let valid_state = test_state();
+        let valid_parent = install_release_test_branch(&valid_state);
+        let valid_blob = valid_state.blobs.write(b"verified source\n").unwrap();
+        let valid_change = exact_source_test_change(
+            valid_parent,
+            0xb0,
+            "src/lib.rs",
+            ArtifactDeltaKind::AddedRegularFile,
+            Hash256::from_bytes(valid_blob.0),
+        );
+        let valid_response = router(Arc::clone(&valid_state))
+            .oneshot(
+                Request::post("/graph/commit")
+                    .header("content-type", "application/json")
+                    .body(Body::from(
+                        json!({ "change": valid_change, "branch_name": "main" }).to_string(),
+                    ))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(valid_response.status(), StatusCode::OK);
+        assert!(valid_state
+            .graph
+            .get_change(&valid_change.id)
+            .unwrap()
+            .is_some());
+        assert_eq!(
+            valid_state
+                .graph
+                .get_branch(&BranchName::new("main"))
+                .unwrap()
+                .unwrap()
+                .head,
+            valid_change.id
+        );
+
+        for case in ["missing", "corrupt", "unsafe_path", "unsafe_symlink"] {
+            let state = test_state();
+            let parent = install_release_test_branch(&state);
+            let (file_id, kind, hash) = match case {
+                "missing" => (
+                    "src/missing.rs",
+                    ArtifactDeltaKind::AddedRegularFile,
+                    Hash256::from_bytes(kin_blobs::digest_bytes(b"missing source")),
+                ),
+                "corrupt" => {
+                    let blob = state.blobs.write(b"expected source").unwrap();
+                    let hash = Hash256::from_bytes(blob.0);
+                    std::fs::write(api_local_object_path(&state, hash), b"corrupt source").unwrap();
+                    ("src/corrupt.rs", ArtifactDeltaKind::AddedRegularFile, hash)
+                }
+                "unsafe_path" => {
+                    let blob = state.blobs.write(b"control overwrite").unwrap();
+                    (
+                        ".kin/authority",
+                        ArtifactDeltaKind::AddedRegularFile,
+                        Hash256::from_bytes(blob.0),
+                    )
+                }
+                "unsafe_symlink" => {
+                    let blob = state.blobs.write(b"../../outside").unwrap();
+                    (
+                        "src/escape",
+                        ArtifactDeltaKind::AddedSymlink,
+                        Hash256::from_bytes(blob.0),
+                    )
+                }
+                _ => unreachable!(),
+            };
+            let change = exact_source_test_change(parent, 0xb1, file_id, kind, hash);
+            let root_before = state.graph.compute_root_hash();
+            let generation_before = state
+                .snapshot_generation
+                .load(std::sync::atomic::Ordering::SeqCst);
+
+            let response = router(Arc::clone(&state))
+                .oneshot(
+                    Request::post("/graph/commit")
+                        .header("content-type", "application/json")
+                        .body(Body::from(
+                            json!({ "change": change, "branch_name": "main" }).to_string(),
+                        ))
+                        .unwrap(),
+                )
+                .await
+                .unwrap();
+
+            assert_eq!(
+                response.status(),
+                StatusCode::INTERNAL_SERVER_ERROR,
+                "{case} must fail exact-source admission"
+            );
+            let body = axum::body::to_bytes(response.into_body(), 16 * 1024)
+                .await
+                .unwrap();
+            assert!(
+                String::from_utf8_lossy(&body).contains("exact source"),
+                "unexpected {case} response: {}",
+                String::from_utf8_lossy(&body)
+            );
+            assert!(state.graph.get_change(&change.id).unwrap().is_none());
+            assert_eq!(
+                state
+                    .graph
+                    .get_branch(&BranchName::new("main"))
+                    .unwrap()
+                    .unwrap()
+                    .head,
+                parent
+            );
+            assert_eq!(state.graph.compute_root_hash(), root_before);
+            assert_eq!(
+                state
+                    .snapshot_generation
+                    .load(std::sync::atomic::Ordering::SeqCst),
+                generation_before
+            );
+        }
+    }
+
+    #[tokio::test]
+    async fn release_admission_rejects_nonexact_or_unmaterializable_source_tree_atomically() {
+        for case in [
+            "legacy_mode",
+            "missing",
+            "corrupt",
+            "unsafe_path",
+            "unsafe_symlink",
+        ] {
+            let state = test_state();
+            let parent = install_release_test_branch(&state);
+            let (file_id, kind, hash) = match case {
+                "legacy_mode" => (
+                    "src/legacy.rs",
+                    ArtifactDeltaKind::Added,
+                    Hash256::from_bytes(kin_blobs::digest_bytes(b"legacy source")),
+                ),
+                "missing" => (
+                    "src/missing.rs",
+                    ArtifactDeltaKind::AddedRegularFile,
+                    Hash256::from_bytes(kin_blobs::digest_bytes(b"missing source")),
+                ),
+                "corrupt" => {
+                    let blob = state.blobs.write(b"expected release source").unwrap();
+                    let hash = Hash256::from_bytes(blob.0);
+                    std::fs::write(api_local_object_path(&state, hash), b"corrupt source").unwrap();
+                    ("src/corrupt.rs", ArtifactDeltaKind::AddedRegularFile, hash)
+                }
+                "unsafe_path" => {
+                    let blob = state.blobs.write(b"control overwrite").unwrap();
+                    (
+                        ".kin/release",
+                        ArtifactDeltaKind::AddedRegularFile,
+                        Hash256::from_bytes(blob.0),
+                    )
+                }
+                "unsafe_symlink" => {
+                    let blob = state.blobs.write(b"../../outside").unwrap();
+                    (
+                        "src/escape",
+                        ArtifactDeltaKind::AddedSymlink,
+                        Hash256::from_bytes(blob.0),
+                    )
+                }
+                _ => unreachable!(),
+            };
+            let source = exact_source_test_change(parent, 0xb2, file_id, kind, hash);
+            install_source_test_head(&state, &source);
+            let release = release_test_change(source.id, 0xb3);
+            let root_before = state.graph.compute_root_hash();
+            let generation_before = state
+                .snapshot_generation
+                .load(std::sync::atomic::Ordering::SeqCst);
+
+            let response = router(Arc::clone(&state))
+                .oneshot(
+                    Request::post("/graph/commit")
+                        .header("content-type", "application/json")
+                        .body(Body::from(release_test_payload(&release).to_string()))
+                        .unwrap(),
+                )
+                .await
+                .unwrap();
+
+            assert_eq!(
+                response.status(),
+                StatusCode::FAILED_DEPENDENCY,
+                "{case} release source must fail closed"
+            );
+            let body = axum::body::to_bytes(response.into_body(), 16 * 1024)
+                .await
+                .unwrap();
+            let body: serde_json::Value = serde_json::from_slice(&body).unwrap();
+            assert_eq!(body["error"], "release_source_not_exact");
+            assert_eq!(body["source_head"], source.id.to_string());
+            assert_eq!(body["mutation_applied"], false);
+            assert!(state.graph.get_change(&release.id).unwrap().is_none());
+            assert_eq!(
+                state
+                    .graph
+                    .get_branch(&BranchName::new("main"))
+                    .unwrap()
+                    .unwrap()
+                    .head,
+                source.id
+            );
+            assert_eq!(state.graph.compute_root_hash(), root_before);
+            assert_eq!(
+                state
+                    .snapshot_generation
+                    .load(std::sync::atomic::Ordering::SeqCst),
+                generation_before
+            );
+        }
+    }
+
+    #[tokio::test]
+    async fn release_admission_accepts_materializable_exact_local_source_tree() {
+        let state = test_state();
+        let parent = install_release_test_branch(&state);
+        let blob = state.blobs.write(b"release exact source\n").unwrap();
+        let source = exact_source_test_change(
+            parent,
+            0xb4,
+            "src/release.rs",
+            ArtifactDeltaKind::AddedRegularFile,
+            Hash256::from_bytes(blob.0),
+        );
+        install_source_test_head(&state, &source);
+        let release = release_test_change(source.id, 0xb5);
+
+        let response = router(Arc::clone(&state))
+            .oneshot(
+                Request::post("/graph/commit")
+                    .header("content-type", "application/json")
+                    .body(Body::from(release_test_payload(&release).to_string()))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(response.status(), StatusCode::OK);
+        assert!(state.graph.get_change(&release.id).unwrap().is_some());
+        assert_eq!(
+            state
+                .graph
+                .get_branch(&BranchName::new("main"))
+                .unwrap()
+                .unwrap()
+                .head,
+            release.id
+        );
+    }
+
+    #[tokio::test]
+    async fn release_admission_rejects_noncanonical_one_sided_markers() {
+        for case in ["author_only", "message_only"] {
+            let state = test_state();
+            let parent = install_release_test_branch(&state);
+            let mut candidate = release_test_change(parent, 0xb8);
+            match case {
+                "author_only" => candidate.message = "ordinary commit".to_string(),
+                "message_only" => candidate.author = AuthorId::new("ordinary-author"),
+                _ => unreachable!(),
+            }
+            let root_before = state.graph.compute_root_hash();
+
+            let response = router(Arc::clone(&state))
+                .oneshot(
+                    Request::post("/graph/commit")
+                        .header("content-type", "application/json")
+                        .body(Body::from(
+                            json!({ "change": candidate, "branch_name": "main" }).to_string(),
+                        ))
+                        .unwrap(),
+                )
+                .await
+                .unwrap();
+
+            assert_eq!(response.status(), StatusCode::BAD_REQUEST, "{case}");
+            let body = axum::body::to_bytes(response.into_body(), 4096)
+                .await
+                .unwrap();
+            let body: serde_json::Value = serde_json::from_slice(&body).unwrap();
+            assert_eq!(body["error"], "invalid_release_marker", "{case}");
+            assert_eq!(body["mutation_applied"], false, "{case}");
+            assert!(state.graph.get_change(&candidate.id).unwrap().is_none());
+            assert_eq!(state.graph.compute_root_hash(), root_before);
+        }
+    }
+
+    #[tokio::test]
+    async fn release_admission_rejects_marker_count_not_bound_to_source() {
+        let state = test_state();
+        let parent = install_release_test_branch(&state);
+        let mut candidate = release_test_change(parent, 0xb9);
+        candidate.message = "release: test (1 entities snapshot)".to_string();
+        let root_before = state.graph.compute_root_hash();
+
+        let response = router(Arc::clone(&state))
+            .oneshot(
+                Request::post("/graph/commit")
+                    .header("content-type", "application/json")
+                    .body(Body::from(release_test_payload(&candidate).to_string()))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(response.status(), StatusCode::BAD_REQUEST);
+        let body = axum::body::to_bytes(response.into_body(), 4096)
+            .await
+            .unwrap();
+        let body: serde_json::Value = serde_json::from_slice(&body).unwrap();
+        assert_eq!(body["error"], "invalid_release_snapshot_count");
+        assert_eq!(body["marker_entity_count"], 1);
+        assert_eq!(body["source_entity_count"], 0);
+        assert_eq!(body["mutation_applied"], false);
+        assert!(state.graph.get_change(&candidate.id).unwrap().is_none());
+        assert_eq!(state.graph.compute_root_hash(), root_before);
+    }
+
+    #[tokio::test]
+    async fn release_admission_rejects_exact_file_directory_collision() {
+        let state = test_state();
+        let parent = install_release_test_branch(&state);
+        let file_hash = Hash256::from_bytes(state.blobs.write(b"file bytes").unwrap().0);
+        let child_hash = Hash256::from_bytes(state.blobs.write(b"child bytes").unwrap().0);
+        let mut source = exact_source_test_change(
+            parent,
+            0xb6,
+            "pkg",
+            ArtifactDeltaKind::AddedRegularFile,
+            file_hash,
+        );
+        source.artifact_deltas.push(ArtifactDelta {
+            file_id: FilePathId::new("pkg/lib.rs"),
+            kind: ArtifactDeltaKind::AddedRegularFile,
+            old_hash: None,
+            new_hash: Some(child_hash),
+        });
+        install_source_test_head(&state, &source);
+        let release = release_test_change(source.id, 0xb7);
+        let root_before = state.graph.compute_root_hash();
+        let generation_before = state
+            .snapshot_generation
+            .load(std::sync::atomic::Ordering::SeqCst);
+
+        let response = router(Arc::clone(&state))
+            .oneshot(
+                Request::post("/graph/commit")
+                    .header("content-type", "application/json")
+                    .body(Body::from(release_test_payload(&release).to_string()))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(response.status(), StatusCode::FAILED_DEPENDENCY);
+        assert!(state.graph.get_change(&release.id).unwrap().is_none());
+        assert_eq!(
+            state
+                .graph
+                .get_branch(&BranchName::new("main"))
+                .unwrap()
+                .unwrap()
+                .head,
+            source.id
+        );
+        assert_eq!(state.graph.compute_root_hash(), root_before);
+        assert_eq!(
+            state
+                .snapshot_generation
+                .load(std::sync::atomic::Ordering::SeqCst),
+            generation_before
+        );
+    }
+
+    #[tokio::test]
+    async fn queued_release_observes_competing_head_and_returns_409() {
+        let state = test_state();
+        let original_head = install_release_test_branch(&state);
+        let release = release_test_change(original_head, 0x92);
+        let release_id = release.id;
+        let payload = release_test_payload(&release);
+
+        let guard = state.coordination_gate.lock().await;
+        let app = router(Arc::clone(&state));
+        let request = tokio::spawn(async move {
+            app.oneshot(
+                Request::post("/graph/commit")
+                    .header("content-type", "application/json")
+                    .body(Body::from(payload.to_string()))
+                    .unwrap(),
+            )
+            .await
+            .unwrap()
+        });
+        tokio::task::yield_now().await;
+
+        let mut competing = kin_core::build_genesis_change();
+        competing.id = SemanticChangeId::from_hash(Hash256::from_bytes([0x93; 32]));
+        competing.parents = vec![original_head];
+        competing.message = "competing branch advance".to_string();
+        state.graph.create_change(&competing).unwrap();
+        state
+            .graph
+            .update_branch_head(&BranchName::new("main"), &competing.id)
+            .unwrap();
+        drop(guard);
+
+        let response = request.await.unwrap();
+        assert_eq!(response.status(), StatusCode::CONFLICT);
+        let body = axum::body::to_bytes(response.into_body(), 4096)
+            .await
+            .unwrap();
+        let json: serde_json::Value = serde_json::from_slice(&body).unwrap();
+        assert_eq!(json["error"], "stale_branch_head");
+        assert_eq!(json["actual_head"], competing.id.to_string());
+        assert!(state.graph.get_change(&release_id).unwrap().is_none());
+        assert_eq!(
+            state
+                .graph
+                .get_branch(&BranchName::new("main"))
+                .unwrap()
+                .unwrap()
+                .head,
+            competing.id
+        );
+    }
+
+    #[tokio::test]
+    async fn live_overlay_deletion_cannot_make_strict_release_green() {
+        let state = test_state();
+        let entity = test_entity("historical_entity", "src/live.rs");
+        let source = install_release_entity_head(&state, &entity, 0x93);
+        let release = release_test_change_with_count(source.id, 0x94, 1);
+        let release_id = release.id;
+        let payload = json!({
+            "change": release,
+            "branch_name": "main",
+            "release_policy": {
+                "force": true,
+                "require_proof": true,
+                "require_approval": false,
+            },
+        });
+
+        let guard = state.coordination_gate.lock().await;
+        let app = router(Arc::clone(&state));
+        let request = tokio::spawn(async move {
+            app.oneshot(
+                Request::post("/graph/commit")
+                    .header("content-type", "application/json")
+                    .body(Body::from(payload.to_string()))
+                    .unwrap(),
+            )
+            .await
+            .unwrap()
+        });
+        tokio::task::yield_now().await;
+
+        // This ambient/live deletion is not a semantic change and therefore
+        // cannot alter policy for the immutable release parent.
+        state.graph.remove_entity(&entity.id).unwrap();
+        drop(guard);
+
+        let response = request.await.unwrap();
+        assert_eq!(response.status(), StatusCode::CONFLICT);
+        let body = axum::body::to_bytes(response.into_body(), 4096)
+            .await
+            .unwrap();
+        let json: serde_json::Value = serde_json::from_slice(&body).unwrap();
+        assert_eq!(json["error"], "release_policy_failed");
+        assert_eq!(json["gate"], "proof");
+        assert_eq!(json["source_head"], source.id.to_string());
+        assert_eq!(
+            json["missing_proof"],
+            serde_json::json!([entity.id.to_string()])
+        );
+        assert!(state.graph.get_change(&release_id).unwrap().is_none());
+        assert_eq!(
+            state
+                .graph
+                .get_branch(&BranchName::new("main"))
+                .unwrap()
+                .unwrap()
+                .head,
+            source.id
+        );
+    }
+
+    #[tokio::test]
+    async fn changed_stable_id_entity_cannot_reuse_an_unbound_old_run() {
+        let state = test_state();
+        let old = test_entity("stable_entity", "src/stable.rs");
+        let first = install_release_entity_head(&state, &old, 0xa0);
+
+        let old_run = kin_model::VerificationRun {
+            run_id: kin_model::VerificationRunId::new(),
+            test_ids: vec![],
+            status: kin_model::VerificationStatus::Passing,
+            runner: kin_model::TestRunner::Cargo,
+            started_at: Timestamp::now(),
+            finished_at: Some(Timestamp::now()),
+            duration_ms: Some(1),
+            evidence_blob: None,
+            exit_code: Some(0),
+        };
+        state.graph.create_verification_run(&old_run).unwrap();
+        state
+            .graph
+            .link_run_proves_entity(&old_run.run_id, &old.id)
+            .unwrap();
+
+        let mut changed = old.clone();
+        changed.signature = "def stable_entity(required)".to_string();
+        changed.fingerprint.signature_hash = Hash256::from_bytes([0x44; 32]);
+        let second = SemanticChange {
+            id: SemanticChangeId::from_hash(Hash256::from_bytes([0xa1; 32])),
+            parents: vec![first.id],
+            timestamp: Timestamp::now(),
+            author: AuthorId::new("agent-test"),
+            message: "change stable entity".to_string(),
+            entity_deltas: vec![EntityDelta::Modified {
+                old: old.clone(),
+                new: changed.clone(),
+            }],
+            relation_deltas: vec![],
+            artifact_deltas: vec![],
+            projected_files: vec![],
+            spec_link: None,
+            evidence: vec![],
+            risk_summary: None,
+            authored_on: Some(BranchName::new("main")),
+        };
+        state.graph.upsert_entity(&changed).unwrap();
+        state.graph.create_change(&second).unwrap();
+        state
+            .graph
+            .update_branch_head(&BranchName::new("main"), &second.id)
+            .unwrap();
+
+        let release = release_test_change_with_count(second.id, 0xa2, 1);
+        let response = router(Arc::clone(&state))
+            .oneshot(
+                Request::post("/graph/commit")
+                    .header("content-type", "application/json")
+                    .body(Body::from(
+                        json!({
+                            "change": release,
+                            "branch_name": "main",
+                            "release_policy": {
+                                "force": true,
+                                "require_proof": true,
+                                "require_approval": false,
+                            },
+                        })
+                        .to_string(),
+                    ))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(response.status(), StatusCode::CONFLICT);
+        let body = axum::body::to_bytes(response.into_body(), 4096)
+            .await
+            .unwrap();
+        let json: serde_json::Value = serde_json::from_slice(&body).unwrap();
+        assert_eq!(json["gate"], "proof");
+        assert_eq!(json["source_head"], second.id.to_string());
+        assert_eq!(
+            json["missing_proof"],
+            serde_json::json!([changed.id.to_string()])
+        );
+    }
+
+    #[test]
+    fn release_approval_scope_keeps_reachable_and_rejects_unrelated_approvals() {
+        let state = test_state();
+        let entity = test_entity("approved_entity", "src/approved.rs");
+        let source = install_release_entity_head(&state, &entity, 0xa3);
+        let root = source.parents[0];
+        let approver = ActorId::from_hash(Hash256::from_bytes([0xa4; 32]));
+        state
+            .graph
+            .create_actor(&Actor {
+                actor_id: approver,
+                kind: ActorKind::Human,
+                display_name: "release reviewer".to_string(),
+                external_refs: vec![],
+            })
+            .unwrap();
+
+        let mut unrelated = kin_core::build_genesis_change();
+        unrelated.id = SemanticChangeId::from_hash(Hash256::from_bytes([0xa5; 32]));
+        unrelated.parents = vec![root];
+        unrelated.author = AuthorId::new("agent-unrelated");
+        unrelated.message = "unrelated change".to_string();
+        state.graph.create_change(&unrelated).unwrap();
+        state
+            .graph
+            .create_approval(&Approval {
+                approval_id: ApprovalId::new(),
+                change_id: unrelated.id,
+                approver,
+                decision: ApprovalDecision::Approved,
+                reason: "not authority for the release source".to_string(),
+                timestamp: Timestamp::now(),
+            })
+            .unwrap();
+
+        let policy = DaemonReleasePolicy {
+            force: true,
+            require_proof: false,
+            require_approval: true,
+        };
+        let error = enforce_daemon_release_policy(&state.graph, &source.id, 1, &policy)
+            .expect_err("an unrelated approval must not authorize the source history");
+        assert_eq!(error.0, StatusCode::CONFLICT);
+        let body: serde_json::Value = serde_json::from_str(&error.1).unwrap();
+        assert_eq!(body["gate"], "approval");
+        assert_eq!(body["unapproved_changes"], json!([source.id.to_string()]));
+
+        state
+            .graph
+            .create_approval(&Approval {
+                approval_id: ApprovalId::new(),
+                change_id: source.id,
+                approver,
+                decision: ApprovalDecision::Approved,
+                reason: "reviewed immutable release source".to_string(),
+                timestamp: Timestamp::now(),
+            })
+            .unwrap();
+        enforce_daemon_release_policy(&state.graph, &source.id, 1, &policy)
+            .expect("the reachable human approval must satisfy the gate");
+    }
+
+    #[tokio::test]
+    async fn strict_release_retry_rechecks_parent_without_generation_or_event() {
+        let state = test_state();
+        let entity = test_entity("strict_retry", "src/retry.rs");
+        let source = install_release_entity_head(&state, &entity, 0xa6);
+        let release = release_test_change_with_count(source.id, 0xa7, 1);
+        let app = router(Arc::clone(&state));
+
+        let first = app
+            .clone()
+            .oneshot(
+                Request::post("/graph/commit")
+                    .header("content-type", "application/json")
+                    .body(Body::from(release_test_payload(&release).to_string()))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(first.status(), StatusCode::OK);
+        let generation = state
+            .snapshot_generation
+            .load(std::sync::atomic::Ordering::SeqCst);
+        let mut events = state.event_tx.subscribe();
+
+        let strict_retry = app
+            .oneshot(
+                Request::post("/graph/commit")
+                    .header("content-type", "application/json")
+                    .body(Body::from(
+                        json!({
+                            "change": release,
+                            "branch_name": "main",
+                            "release_policy": {
+                                "force": true,
+                                "require_proof": true,
+                                "require_approval": false,
+                            },
+                        })
+                        .to_string(),
+                    ))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(strict_retry.status(), StatusCode::CONFLICT);
+        assert_eq!(
+            state
+                .snapshot_generation
+                .load(std::sync::atomic::Ordering::SeqCst),
+            generation,
+            "failed policy retry must not create a generation"
+        );
+        assert_eq!(
+            state
+                .graph
+                .get_branch(&BranchName::new("main"))
+                .unwrap()
+                .unwrap()
+                .head,
+            release.id
+        );
+        assert!(matches!(
+            events.try_recv(),
+            Err(tokio::sync::broadcast::error::TryRecvError::Empty)
+        ));
+    }
+
+    #[tokio::test]
+    async fn exact_release_retry_is_idempotent() {
+        let state = test_state();
+        let head = install_release_test_branch(&state);
+        let release = release_test_change(head, 0x95);
+        let payload = release_test_payload(&release);
+        let app = router(Arc::clone(&state));
+
+        let mut committed_generation = None;
+
+        for _ in 0..2 {
+            let response = app
+                .clone()
+                .oneshot(
+                    Request::post("/graph/commit")
+                        .header("content-type", "application/json")
+                        .body(Body::from(payload.to_string()))
+                        .unwrap(),
+                )
+                .await
+                .unwrap();
+            assert_eq!(response.status(), StatusCode::OK);
+            let generation = state
+                .snapshot_generation
+                .load(std::sync::atomic::Ordering::SeqCst);
+            if let Some(committed_generation) = committed_generation {
+                assert_eq!(
+                    generation, committed_generation,
+                    "an already-finalized retry must not create another authority generation"
+                );
+            } else {
+                committed_generation = Some(generation);
+            }
+        }
+        assert_eq!(
+            state
+                .graph
+                .get_branch(&BranchName::new("main"))
+                .unwrap()
+                .unwrap()
+                .head,
+            release.id
+        );
+        let release_markers = state
+            .graph
+            .to_snapshot()
+            .changes
+            .values()
+            .filter(|change| change.author.to_string() == "kin-release")
+            .count();
+        assert_eq!(release_markers, 1, "retry created a second release marker");
+    }
+
+    #[tokio::test]
+    async fn exact_release_retry_reconciles_after_branch_advances() {
+        let state = test_state();
+        let head = install_release_test_branch(&state);
+        let release = release_test_change(head, 0x96);
+        let payload = release_test_payload(&release);
+        let app = router(Arc::clone(&state));
+
+        let first = app
+            .clone()
+            .oneshot(
+                Request::post("/graph/commit")
+                    .header("content-type", "application/json")
+                    .body(Body::from(payload.to_string()))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(first.status(), StatusCode::OK);
+
+        let descendant = SemanticChange {
+            id: SemanticChangeId::from_hash(Hash256::from_bytes([0x97; 32])),
+            parents: vec![release.id],
+            timestamp: Timestamp::now(),
+            author: AuthorId::new("later-human"),
+            message: "advance after release".to_string(),
+            entity_deltas: vec![],
+            relation_deltas: vec![],
+            artifact_deltas: vec![],
+            projected_files: vec![],
+            spec_link: None,
+            evidence: vec![],
+            risk_summary: None,
+            authored_on: Some(BranchName::new("main")),
+        };
+        state.graph.create_change(&descendant).unwrap();
+        state
+            .graph
+            .update_branch_head(&BranchName::new("main"), &descendant.id)
+            .unwrap();
+
+        let retry = app
+            .oneshot(
+                Request::post("/graph/commit")
+                    .header("content-type", "application/json")
+                    .body(Body::from(payload.to_string()))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(retry.status(), StatusCode::OK);
+        assert_eq!(
+            state
+                .graph
+                .get_branch(&BranchName::new("main"))
+                .unwrap()
+                .unwrap()
+                .head,
+            descendant.id,
+            "reconciling an older release marker must not rewind the branch"
+        );
+    }
+
+    #[tokio::test]
+    async fn graph_commit_retry_persists_after_pre_authority_save_failure() {
+        let state = test_state();
+        let head = install_release_test_branch(&state);
+        let release = release_test_change(head, 0x9a);
+        let payload = release_test_payload(&release);
+        let app = router(Arc::clone(&state));
+        let mut events = state.event_tx.subscribe();
+        state.fail_next_snapshot_save_for_test();
+
+        let first = app
+            .clone()
+            .oneshot(
+                Request::post("/graph/commit")
+                    .header("content-type", "application/json")
+                    .body(Body::from(payload.to_string()))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(first.status(), StatusCode::INTERNAL_SERVER_ERROR);
+        let body = axum::body::to_bytes(first.into_body(), 4096).await.unwrap();
+        assert!(
+            String::from_utf8_lossy(&body).contains("injected pre-authority snapshot save failure")
+        );
+        assert_eq!(
+            state
+                .graph
+                .get_branch(&BranchName::new("main"))
+                .unwrap()
+                .unwrap()
+                .head,
+            release.id,
+            "the failed request has already advanced in-memory authority"
+        );
+        assert!(state.graph.has_unpersisted_changes());
+        assert!(matches!(
+            events.try_recv(),
+            Err(tokio::sync::broadcast::error::TryRecvError::Empty)
+        ));
+
+        let retry = app
+            .oneshot(
+                Request::post("/graph/commit")
+                    .header("content-type", "application/json")
+                    .body(Body::from(payload.to_string()))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(retry.status(), StatusCode::OK);
+        assert!(!state.graph.has_unpersisted_changes());
+
+        let snapshot =
+            kin_db::SnapshotManager::open_read_only(state.layout.kindb_snapshot_path()).unwrap();
+        assert!(snapshot.graph().get_change(&release.id).unwrap().is_some());
+        assert_eq!(
+            snapshot
+                .graph()
+                .get_branch(&BranchName::new("main"))
+                .unwrap()
+                .unwrap()
+                .head,
+            release.id
+        );
+        match events.try_recv().expect("the durable retry must emit once") {
+            DaemonEvent::GraphRootChanged { new_root_hash, .. } => {
+                assert_eq!(new_root_hash, release.id.to_string())
+            }
+            other => panic!("retry emitted the wrong event: {other:?}"),
+        }
+        assert!(matches!(
+            events.try_recv(),
+            Err(tokio::sync::broadcast::error::TryRecvError::Empty)
+        ));
+    }
+
+    #[tokio::test]
+    async fn graph_commit_retry_finalizes_committed_generation_without_recommit() {
+        let state = test_state();
+        let head = install_release_test_branch(&state);
+        let release = release_test_change(head, 0x9b);
+        let payload = release_test_payload(&release);
+        let app = router(Arc::clone(&state));
+        let mut events = state.event_tx.subscribe();
+        state.fail_next_finalization_for_test();
+
+        let first = app
+            .clone()
+            .oneshot(
+                Request::post("/graph/commit")
+                    .header("content-type", "application/json")
+                    .body(Body::from(payload.to_string()))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(first.status(), StatusCode::INTERNAL_SERVER_ERROR);
+        let committed_generation = state
+            .snapshot_generation
+            .load(std::sync::atomic::Ordering::SeqCst);
+        assert!(committed_generation > kin_db::GENERATION_INIT);
+        assert_eq!(DaemonState::read_generation_marker(&state.layout), 0);
+        assert!(!state.graph.has_unpersisted_changes());
+        assert!(matches!(
+            events.try_recv(),
+            Err(tokio::sync::broadcast::error::TryRecvError::Empty)
+        ));
+
+        let retry = app
+            .oneshot(
+                Request::post("/graph/commit")
+                    .header("content-type", "application/json")
+                    .body(Body::from(payload.to_string()))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(retry.status(), StatusCode::OK);
+        assert_eq!(
+            state
+                .snapshot_generation
+                .load(std::sync::atomic::Ordering::SeqCst),
+            committed_generation,
+            "finalization retry must not recommit graph authority"
+        );
+        assert_eq!(
+            DaemonState::read_generation_marker(&state.layout),
+            committed_generation
+        );
+        match events
+            .try_recv()
+            .expect("finalization retry must release the queued event")
+        {
+            DaemonEvent::GraphRootChanged { new_root_hash, .. } => {
+                assert_eq!(new_root_hash, release.id.to_string())
+            }
+            other => panic!("finalization retry emitted the wrong event: {other:?}"),
+        }
+        assert!(matches!(
+            events.try_recv(),
+            Err(tokio::sync::broadcast::error::TryRecvError::Empty)
+        ));
+    }
+
+    #[tokio::test]
+    async fn identical_non_release_retry_with_missing_audit_effect_fails_closed() {
+        let state = test_state();
+        let head = install_release_test_branch(&state);
+        let mut change = kin_core::build_genesis_change();
+        change.id = SemanticChangeId::from_hash(Hash256::from_bytes([0x9c; 32]));
+        change.parents = vec![head];
+        change.author = AuthorId::new("non-release-client");
+        change.message = "ordinary commit with audit".to_string();
+        change.authored_on = Some(BranchName::new("main"));
+        state.graph.create_change(&change).unwrap();
+        state
+            .graph
+            .update_branch_head(&BranchName::new("main"), &change.id)
+            .unwrap();
+
+        let audit = kin_model::provenance::AuditEvent {
+            event_id: AuditEventId::new(),
+            actor_id: ActorId::new(),
+            action: "ordinary_commit".to_string(),
+            target_scope: None,
+            timestamp: Timestamp::now(),
+            details: Some("must not be silently skipped".to_string()),
+        };
+        let response = router(Arc::clone(&state))
+            .oneshot(
+                Request::post("/graph/commit")
+                    .header("content-type", "application/json")
+                    .body(Body::from(
+                        json!({
+                            "change": change,
+                            "branch_name": "main",
+                            "audit_event": audit,
+                        })
+                        .to_string(),
+                    ))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(response.status(), StatusCode::CONFLICT);
+        let body = axum::body::to_bytes(response.into_body(), 4096)
+            .await
+            .unwrap();
+        let json: serde_json::Value = serde_json::from_slice(&body).unwrap();
+        assert_eq!(json["error"], "stale_branch_head");
+        assert_eq!(json["mutation_applied"], false);
+        assert!(state.graph.query_audit_events(None, 10).unwrap().is_empty());
+        assert!(state.graph.has_unpersisted_changes());
+        assert_eq!(
+            state
+                .snapshot_generation
+                .load(std::sync::atomic::Ordering::SeqCst),
+            kin_db::GENERATION_INIT,
+            "the retry must not persist a head missing its requested audit effect"
+        );
+    }
+
+    #[tokio::test]
+    async fn release_policy_rejects_nonempty_change_before_mutation() {
+        let state = test_state();
+        let head = install_release_test_branch(&state);
+        let entity = test_entity("must_not_release", "src/release.rs");
+        let entity_id = entity.id;
+        let mut release = release_test_change(head, 0x96);
+        release.entity_deltas.push(EntityDelta::Added(entity));
+        let release_id = release.id;
+
+        let response = router(Arc::clone(&state))
+            .oneshot(
+                Request::post("/graph/commit")
+                    .header("content-type", "application/json")
+                    .body(Body::from(release_test_payload(&release).to_string()))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(response.status(), StatusCode::BAD_REQUEST);
+        assert!(state.graph.get_change(&release_id).unwrap().is_none());
+        assert!(state.graph.get_entity(&entity_id).unwrap().is_none());
+        assert_eq!(
+            state
+                .graph
+                .get_branch(&BranchName::new("main"))
+                .unwrap()
+                .unwrap()
+                .head,
+            head
+        );
     }
 
     #[tokio::test]
@@ -11944,6 +15692,391 @@ mod tests {
             .get_branch(&BranchName::new("feature"))
             .unwrap()
             .is_some());
+    }
+
+    #[tokio::test]
+    async fn graph_branch_mutations_reject_unknown_heads_without_authority_changes() {
+        let state = test_state();
+        let genesis = kin_core::build_genesis_change();
+        state.graph.create_change(&genesis).unwrap();
+        state
+            .graph
+            .create_branch(&Branch {
+                name: BranchName::new("main"),
+                head: genesis.id,
+            })
+            .unwrap();
+        state
+            .is_initialized
+            .store(true, std::sync::atomic::Ordering::Relaxed);
+        let missing = SemanticChangeId::from_hash(Hash256::from_bytes([0xbe; 32]));
+        let stale = SemanticChangeId::from_hash(Hash256::from_bytes([0xbf; 32]));
+        let root_before = state.graph.compute_root_hash();
+        let generation_before = state
+            .snapshot_generation
+            .load(std::sync::atomic::Ordering::SeqCst);
+        let app = router(Arc::clone(&state));
+
+        let create = app
+            .clone()
+            .oneshot(
+                Request::post("/graph/branches")
+                    .header("content-type", "application/json")
+                    .body(Body::from(
+                        json!({ "name": "unknown", "head": missing.to_string() }).to_string(),
+                    ))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(create.status(), StatusCode::NOT_FOUND);
+        let body = axum::body::to_bytes(create.into_body(), 4096)
+            .await
+            .unwrap();
+        let body: serde_json::Value = serde_json::from_slice(&body).unwrap();
+        assert_eq!(body["error"], "branch_head_not_found");
+        assert_eq!(body["mutation_applied"], false);
+        assert!(state
+            .graph
+            .get_branch(&BranchName::new("unknown"))
+            .unwrap()
+            .is_none());
+
+        let update = app
+            .clone()
+            .oneshot(
+                Request::put("/graph/branches/main/head")
+                    .header("content-type", "application/json")
+                    .body(Body::from(
+                        json!({
+                            "head": missing.to_string(),
+                            "expected_head": genesis.id.to_string(),
+                        })
+                        .to_string(),
+                    ))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(update.status(), StatusCode::NOT_FOUND);
+        let body = axum::body::to_bytes(update.into_body(), 4096)
+            .await
+            .unwrap();
+        let body: serde_json::Value = serde_json::from_slice(&body).unwrap();
+        assert_eq!(body["error"], "branch_head_not_found");
+        assert_eq!(body["mutation_applied"], false);
+
+        let stale_update = app
+            .oneshot(
+                Request::put("/graph/branches/main/head")
+                    .header("content-type", "application/json")
+                    .body(Body::from(
+                        json!({
+                            "head": missing.to_string(),
+                            "expected_head": stale.to_string(),
+                        })
+                        .to_string(),
+                    ))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(stale_update.status(), StatusCode::CONFLICT);
+        let body = axum::body::to_bytes(stale_update.into_body(), 4096)
+            .await
+            .unwrap();
+        let body: serde_json::Value = serde_json::from_slice(&body).unwrap();
+        assert_eq!(body["error"], "stale_branch_head");
+        assert_eq!(body["mutation_applied"], false);
+
+        assert_eq!(
+            state
+                .graph
+                .get_branch(&BranchName::new("main"))
+                .unwrap()
+                .unwrap()
+                .head,
+            genesis.id
+        );
+        assert_eq!(state.graph.compute_root_hash(), root_before);
+        assert_eq!(
+            state
+                .snapshot_generation
+                .load(std::sync::atomic::Ordering::SeqCst),
+            generation_before
+        );
+    }
+
+    #[tokio::test]
+    async fn graph_branch_head_update_rejects_backward_and_sideways_moves() {
+        let state = test_state();
+        let genesis = kin_core::build_genesis_change();
+        let mut child = genesis.clone();
+        child.id = SemanticChangeId::from_hash(Hash256::from_bytes([0xc1; 32]));
+        child.parents = vec![genesis.id];
+        child.message = "child".to_string();
+        let mut sibling = child.clone();
+        sibling.id = SemanticChangeId::from_hash(Hash256::from_bytes([0xc2; 32]));
+        sibling.message = "sibling".to_string();
+        state.graph.create_change(&genesis).unwrap();
+        state.graph.create_change(&child).unwrap();
+        state.graph.create_change(&sibling).unwrap();
+        state
+            .graph
+            .create_branch(&Branch {
+                name: BranchName::new("main"),
+                head: genesis.id,
+            })
+            .unwrap();
+        state
+            .is_initialized
+            .store(true, std::sync::atomic::Ordering::Relaxed);
+        let app = router(Arc::clone(&state));
+
+        let forward = app
+            .clone()
+            .oneshot(
+                Request::put("/graph/branches/main/head")
+                    .header("content-type", "application/json")
+                    .body(Body::from(
+                        json!({
+                            "head": child.id.to_string(),
+                            "expected_head": genesis.id.to_string(),
+                        })
+                        .to_string(),
+                    ))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(forward.status(), StatusCode::OK);
+
+        for rejected in [genesis.id, sibling.id] {
+            let response = app
+                .clone()
+                .oneshot(
+                    Request::put("/graph/branches/main/head")
+                        .header("content-type", "application/json")
+                        .body(Body::from(
+                            json!({
+                                "head": rejected.to_string(),
+                                "expected_head": child.id.to_string(),
+                            })
+                            .to_string(),
+                        ))
+                        .unwrap(),
+                )
+                .await
+                .unwrap();
+            assert_eq!(response.status(), StatusCode::CONFLICT);
+            let body = axum::body::to_bytes(response.into_body(), 4096)
+                .await
+                .unwrap();
+            let body: serde_json::Value = serde_json::from_slice(&body).unwrap();
+            assert_eq!(body["error"], "non_fast_forward_branch_update");
+            assert_eq!(body["mutation_applied"], false);
+        }
+        assert_eq!(
+            state
+                .graph
+                .get_branch(&BranchName::new("main"))
+                .unwrap()
+                .unwrap()
+                .head,
+            child.id
+        );
+    }
+
+    #[tokio::test]
+    async fn v1_branch_head_mutation_is_explicitly_retired() {
+        let response = router(test_state())
+            .oneshot(
+                Request::put("/v1/graph/branches/main/head")
+                    .header("content-type", "application/json")
+                    .body(Body::from(json!({ "head": "legacy" }).to_string()))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(response.status(), StatusCode::GONE);
+        assert_eq!(response.headers()["X-Kin-API-Version"], API_VERSION);
+        let body = axum::body::to_bytes(response.into_body(), 4096)
+            .await
+            .unwrap();
+        let body: serde_json::Value = serde_json::from_slice(&body).unwrap();
+        assert_eq!(body["error"], "v1_branch_head_update_retired");
+        assert_eq!(body["mutation_applied"], false);
+    }
+
+    #[tokio::test]
+    async fn checkout_requests_are_serialized_by_the_authority_gate() {
+        let state = test_state();
+        let (main, feature) = install_exact_checkout_branches(&state);
+        state
+            .is_initialized
+            .store(true, std::sync::atomic::Ordering::Relaxed);
+        let guard = state.coordination_gate.lock().await;
+        let app = router(Arc::clone(&state));
+        let mut first = tokio::spawn({
+            let app = app.clone();
+            async move {
+                app.oneshot(
+                    Request::post("/commands/checkout")
+                        .header("content-type", "application/json")
+                        .body(Body::from(
+                            json!({
+                                "path": "src/shared.rs",
+                                "change_id": feature.id.to_string(),
+                            })
+                            .to_string(),
+                        ))
+                        .unwrap(),
+                )
+                .await
+                .unwrap()
+            }
+        });
+        assert!(
+            tokio::time::timeout(Duration::from_millis(50), &mut first)
+                .await
+                .is_err(),
+            "first checkout must wait for the authority gate"
+        );
+        let mut second = tokio::spawn(async move {
+            app.oneshot(
+                Request::post("/commands/checkout")
+                    .header("content-type", "application/json")
+                    .body(Body::from(
+                        json!({
+                            "path": "src/shared.rs",
+                            "change_id": main.id.to_string(),
+                        })
+                        .to_string(),
+                    ))
+                    .unwrap(),
+            )
+            .await
+            .unwrap()
+        });
+        assert!(
+            tokio::time::timeout(Duration::from_millis(50), &mut second)
+                .await
+                .is_err(),
+            "second checkout must queue behind the same authority gate"
+        );
+        assert_eq!(
+            std::fs::read(state.layout.working_dir().join("src/shared.rs")).unwrap(),
+            b"main checkout bytes\n"
+        );
+
+        drop(guard);
+        assert_eq!(first.await.unwrap().status(), StatusCode::OK);
+        assert_eq!(second.await.unwrap().status(), StatusCode::OK);
+        assert_eq!(
+            std::fs::read(state.layout.working_dir().join("src/shared.rs")).unwrap(),
+            b"main checkout bytes\n",
+            "FIFO checkout A/B must leave the second target fully materialized"
+        );
+    }
+
+    #[tokio::test]
+    async fn branch_switch_and_head_update_wait_for_the_authority_gate() {
+        let state = test_state();
+        let (_main, feature) = install_exact_checkout_branches(&state);
+        state
+            .is_initialized
+            .store(true, std::sync::atomic::Ordering::Relaxed);
+        let advanced = SemanticChange {
+            id: SemanticChangeId::from_hash(Hash256::from_bytes([0xc0; 32])),
+            parents: vec![feature.id],
+            timestamp: Timestamp::now(),
+            author: AuthorId::new("branch-gate-test"),
+            message: "advance feature after switch barrier".to_string(),
+            entity_deltas: vec![],
+            relation_deltas: vec![],
+            artifact_deltas: vec![],
+            projected_files: vec![],
+            spec_link: None,
+            evidence: vec![],
+            risk_summary: None,
+            authored_on: Some(BranchName::new("feature")),
+        };
+        state.graph.create_change(&advanced).unwrap();
+        let guard = state.coordination_gate.lock().await;
+        let app = router(Arc::clone(&state));
+        let mut switch = tokio::spawn({
+            let app = app.clone();
+            async move {
+                app.oneshot(
+                    Request::post("/commands/branch")
+                        .header("content-type", "application/json")
+                        .body(Body::from(
+                            json!({ "command": "switch", "name": "feature" }).to_string(),
+                        ))
+                        .unwrap(),
+                )
+                .await
+                .unwrap()
+            }
+        });
+        assert!(
+            tokio::time::timeout(Duration::from_millis(50), &mut switch)
+                .await
+                .is_err(),
+            "branch switch must wait for the authority gate"
+        );
+        let mut update = tokio::spawn(async move {
+            app.oneshot(
+                Request::put("/graph/branches/feature/head")
+                    .header("content-type", "application/json")
+                    .body(Body::from(
+                        json!({
+                            "head": advanced.id.to_string(),
+                            "expected_head": feature.id.to_string(),
+                        })
+                        .to_string(),
+                    ))
+                    .unwrap(),
+            )
+            .await
+            .unwrap()
+        });
+        assert!(
+            tokio::time::timeout(Duration::from_millis(50), &mut update)
+                .await
+                .is_err(),
+            "branch head update must wait for the same authority gate"
+        );
+        assert_eq!(
+            kin_core::read_current_branch(&state.layout).unwrap(),
+            BranchName::new("main")
+        );
+        assert_eq!(
+            state
+                .graph
+                .get_branch(&BranchName::new("feature"))
+                .unwrap()
+                .unwrap()
+                .head,
+            feature.id
+        );
+
+        drop(guard);
+        assert_eq!(switch.await.unwrap().status(), StatusCode::OK);
+        assert_eq!(update.await.unwrap().status(), StatusCode::OK);
+        assert_eq!(
+            kin_core::read_current_branch(&state.layout).unwrap(),
+            BranchName::new("feature")
+        );
+        assert_eq!(
+            state
+                .graph
+                .get_branch(&BranchName::new("feature"))
+                .unwrap()
+                .unwrap()
+                .head,
+            advanced.id
+        );
     }
 
     #[tokio::test]
@@ -15749,7 +19882,10 @@ mod tests {
             .oneshot(Request::get("/health").body(Body::empty()).unwrap())
             .await
             .unwrap();
-        assert_eq!(response.headers().get("X-Kin-API-Version").unwrap(), "1");
+        assert_eq!(
+            response.headers().get("X-Kin-API-Version").unwrap(),
+            API_VERSION
+        );
     }
 
     #[tokio::test]
@@ -15761,7 +19897,10 @@ mod tests {
             .await
             .unwrap();
         assert_eq!(response.status(), StatusCode::OK);
-        assert_eq!(response.headers().get("X-Kin-API-Version").unwrap(), "1");
+        assert_eq!(
+            response.headers().get("X-Kin-API-Version").unwrap(),
+            API_VERSION
+        );
     }
 
     #[tokio::test]
@@ -15862,7 +20001,7 @@ mod tests {
             .await
             .unwrap();
         assert_eq!(accepted.status(), StatusCode::OK);
-        assert_eq!(accepted.headers()["X-Kin-API-Version"], "1");
+        assert_eq!(accepted.headers()["X-Kin-API-Version"], API_VERSION);
     }
 
     #[tokio::test]

--- a/crates/kin-daemon/src/commit_deltas.rs
+++ b/crates/kin-daemon/src/commit_deltas.rs
@@ -29,6 +29,7 @@ use kin_db::InMemoryGraph;
 use kin_model::{
     relation::GraphNodeId, ArtifactDelta, ArtifactDeltaKind, ChangeStore, Entity, EntityDelta,
     EntityId, EntityStore, FilePathId, Hash256, RelationDelta, RelationId, SemanticChangeId,
+    SourceEntryKind,
 };
 
 use crate::error::{DaemonError, Result};
@@ -38,6 +39,30 @@ pub struct CommitDeltas {
     pub entity_deltas: Vec<EntityDelta>,
     pub relation_deltas: Vec<RelationDelta>,
     pub artifact_deltas: Vec<ArtifactDelta>,
+}
+
+#[derive(Debug, Clone, Copy)]
+struct CommittedSourceEntry {
+    hash: Hash256,
+    /// `None` identifies pre-0.3 mode-unknown history. An unchanged working
+    /// entry then emits an exact modification to backfill its mode.
+    kind: Option<SourceEntryKind>,
+}
+
+fn added_artifact_kind(kind: SourceEntryKind) -> ArtifactDeltaKind {
+    match kind {
+        SourceEntryKind::File { executable: false } => ArtifactDeltaKind::AddedRegularFile,
+        SourceEntryKind::File { executable: true } => ArtifactDeltaKind::AddedExecutableFile,
+        SourceEntryKind::Symlink => ArtifactDeltaKind::AddedSymlink,
+    }
+}
+
+fn modified_artifact_kind(kind: SourceEntryKind) -> ArtifactDeltaKind {
+    match kind {
+        SourceEntryKind::File { executable: false } => ArtifactDeltaKind::ModifiedRegularFile,
+        SourceEntryKind::File { executable: true } => ArtifactDeltaKind::ModifiedExecutableFile,
+        SourceEntryKind::Symlink => ArtifactDeltaKind::ModifiedSymlink,
+    }
 }
 
 /// Compute commit deltas by diffing current graph state against the
@@ -59,8 +84,8 @@ pub fn compute_deltas_vs_last_commit(
 
     // entity_id → Entity (state at last commit)
     let mut committed_entities: HashMap<EntityId, Entity> = HashMap::new();
-    // file_id → content_hash (state at last commit)
-    let mut committed_files: HashMap<FilePathId, Hash256> = HashMap::new();
+    // file_id → content hash + exact source kind (state at last commit)
+    let mut committed_files: HashMap<FilePathId, CommittedSourceEntry> = HashMap::new();
     // relation IDs present at last commit
     let mut committed_relation_ids: HashSet<RelationId> = HashSet::new();
 
@@ -79,15 +104,16 @@ pub fn compute_deltas_vs_last_commit(
             }
         }
         for delta in &change.artifact_deltas {
-            match delta.kind {
-                ArtifactDeltaKind::Added | ArtifactDeltaKind::Modified => {
-                    if let Some(hash) = delta.new_hash {
-                        committed_files.insert(delta.file_id.clone(), hash);
-                    }
-                }
-                ArtifactDeltaKind::Removed => {
-                    committed_files.remove(&delta.file_id);
-                }
+            if delta.kind.is_removed() {
+                committed_files.remove(&delta.file_id);
+            } else if let Some(hash) = delta.new_hash {
+                committed_files.insert(
+                    delta.file_id.clone(),
+                    CommittedSourceEntry {
+                        hash,
+                        kind: delta.kind.source_entry_kind(),
+                    },
+                );
             }
         }
         for delta in &change.relation_deltas {
@@ -139,15 +165,16 @@ pub fn compute_deltas_vs_last_commit(
     let mut current_relation_ids: HashSet<RelationId> = HashSet::new();
 
     for entity in &current_entities {
-        if let Ok(relations) = graph.get_all_relations_for_entity(&entity.id) {
-            for rel in relations {
-                // Only track outgoing relations to avoid double-counting.
-                if rel.src == GraphNodeId::Entity(entity.id)
-                    && current_relation_ids.insert(rel.id)
-                    && !committed_relation_ids.contains(&rel.id)
-                {
-                    relation_deltas.push(RelationDelta::Added(rel));
-                }
+        let relations = graph
+            .get_all_relations_for_entity(&entity.id)
+            .map_err(DaemonError::Graph)?;
+        for rel in relations {
+            // Only track outgoing relations to avoid double-counting.
+            if rel.src == GraphNodeId::Entity(entity.id)
+                && current_relation_ids.insert(rel.id)
+                && !committed_relation_ids.contains(&rel.id)
+            {
+                relation_deltas.push(RelationDelta::Added(rel));
             }
         }
     }
@@ -169,55 +196,87 @@ pub fn compute_deltas_vs_last_commit(
     })
 }
 
-/// Compare working-directory files against the committed file tree, producing
-/// `Added`, `Modified`, and `Removed` artifact deltas.
-///
-/// Each file is content-hashed and stored in the blob store (idempotent).
-/// Files whose hash matches the committed hash are unchanged and produce no delta.
+/// Compare working-directory source entries against the committed tree,
+/// producing mode-faithful artifact deltas. A mode-only change and an exact
+/// backfill over legacy mode-unknown history both produce a modification.
 fn compute_artifact_deltas(
     layout: &kin_core::KinLayout,
     blobs: &kin_blobs::BlobStore,
-    committed_files: HashMap<FilePathId, Hash256>,
+    committed_files: HashMap<FilePathId, CommittedSourceEntry>,
 ) -> Result<Vec<ArtifactDelta>> {
     let source_root = kin_core::source_dir(layout);
     let mut artifact_deltas = Vec::new();
     let mut current_file_ids: HashSet<FilePathId> = HashSet::new();
 
-    for abs_path in collect_tracked_files(&source_root) {
+    for abs_path in collect_tracked_files(&source_root)? {
         let rel = match abs_path.strip_prefix(&source_root) {
-            Ok(r) => r.to_string_lossy().to_string(),
-            Err(_) => continue,
+            Ok(path) => path.to_str().ok_or_else(|| {
+                DaemonError::Io(std::io::Error::new(
+                    std::io::ErrorKind::InvalidData,
+                    format!("source path is not valid UTF-8: {}", path.display()),
+                ))
+            })?,
+            Err(error) => {
+                return Err(DaemonError::Io(std::io::Error::other(format!(
+                    "tracked source path {} escaped source root {}: {error}",
+                    abs_path.display(),
+                    source_root.display()
+                ))))
+            }
         };
-        let file_id = FilePathId::new(&rel);
+        let file_id = FilePathId::new(rel);
         current_file_ids.insert(file_id.clone());
 
-        let content = match std::fs::read(&abs_path) {
-            Ok(c) => c,
-            Err(_) => continue,
+        let metadata = std::fs::symlink_metadata(&abs_path).map_err(DaemonError::Io)?;
+        let (content, source_kind) = if metadata.file_type().is_symlink() {
+            let target = std::fs::read_link(&abs_path).map_err(DaemonError::Io)?;
+            let target = target.to_str().ok_or_else(|| {
+                DaemonError::Io(std::io::Error::new(
+                    std::io::ErrorKind::InvalidData,
+                    format!(
+                        "symbolic link target is not valid UTF-8: {}",
+                        abs_path.display()
+                    ),
+                ))
+            })?;
+            (target.as_bytes().to_vec(), SourceEntryKind::Symlink)
+        } else if metadata.is_file() {
+            #[cfg(unix)]
+            let executable = {
+                use std::os::unix::fs::PermissionsExt;
+                metadata.permissions().mode() & 0o111 != 0
+            };
+            #[cfg(not(unix))]
+            let executable = false;
+            (
+                std::fs::read(&abs_path).map_err(DaemonError::Io)?,
+                SourceEntryKind::File { executable },
+            )
+        } else {
+            continue;
         };
 
-        // Store blob (idempotent — noop if already present).
-        let blob_digest = blobs
-            .write(&content)
-            .unwrap_or_else(|_| kin_blobs::digest(&content));
+        // A graph delta must never name bytes that failed to enter the local
+        // object store: the backend persistence path relies on this object.
+        let blob_digest = blobs.write(&content).map_err(DaemonError::from)?;
         let new_hash = Hash256::from_bytes(blob_digest.0);
 
-        match committed_files.get(&file_id) {
+        match committed_files.get(&file_id).copied() {
             None => {
-                // File not in last commit → Added
                 artifact_deltas.push(ArtifactDelta {
                     file_id,
-                    kind: ArtifactDeltaKind::Added,
+                    kind: added_artifact_kind(source_kind),
                     old_hash: None,
                     new_hash: Some(new_hash),
                 });
             }
-            Some(&committed_hash) if committed_hash != new_hash => {
-                // File in last commit but content changed → Modified
+            Some(committed)
+                if committed.hash != new_hash || committed.kind != Some(source_kind) =>
+            {
                 artifact_deltas.push(ArtifactDelta {
                     file_id,
-                    kind: ArtifactDeltaKind::Modified,
-                    old_hash: Some(committed_hash),
+                    kind: modified_artifact_kind(source_kind),
+                    old_hash: Some(committed.hash),
                     new_hash: Some(new_hash),
                 });
             }
@@ -226,12 +285,12 @@ fn compute_artifact_deltas(
     }
 
     // Files in committed tree but missing from working directory → Removed
-    for (file_id, committed_hash) in &committed_files {
+    for (file_id, committed) in &committed_files {
         if !current_file_ids.contains(file_id) {
             artifact_deltas.push(ArtifactDelta {
                 file_id: file_id.clone(),
                 kind: ArtifactDeltaKind::Removed,
-                old_hash: Some(*committed_hash),
+                old_hash: Some(committed.hash),
                 new_hash: None,
             });
         }
@@ -243,29 +302,42 @@ fn compute_artifact_deltas(
 /// Recursively collect all tracked (non-skip) files under `root`.
 /// Uses `kin_index::should_skip_dir` for directory filtering, mirroring
 /// the same skip rules applied by the reconcile loop.
-fn collect_tracked_files(root: &std::path::Path) -> Vec<std::path::PathBuf> {
+fn collect_tracked_files(root: &std::path::Path) -> Result<Vec<std::path::PathBuf>> {
     let mut files = Vec::new();
-    collect_tracked_files_recursive(root, &mut files);
-    files
+    collect_tracked_files_recursive(root, &mut files)?;
+    files.sort();
+    Ok(files)
 }
 
-fn collect_tracked_files_recursive(dir: &std::path::Path, files: &mut Vec<std::path::PathBuf>) {
-    let Ok(entries) = std::fs::read_dir(dir) else {
-        return;
-    };
-    for entry in entries.flatten() {
+fn collect_tracked_files_recursive(
+    dir: &std::path::Path,
+    files: &mut Vec<std::path::PathBuf>,
+) -> Result<()> {
+    let entries = std::fs::read_dir(dir).map_err(DaemonError::Io)?;
+    for entry in entries {
+        let entry = entry.map_err(DaemonError::Io)?;
         let path = entry.path();
         let name = entry.file_name();
-        let name_str = name.to_string_lossy();
-        if path.is_dir() {
-            if kin_index::should_skip_dir(name_str.as_ref()) {
+        let name_str = name.to_str().ok_or_else(|| {
+            DaemonError::Io(std::io::Error::new(
+                std::io::ErrorKind::InvalidData,
+                format!(
+                    "source path component is not valid UTF-8: {}",
+                    path.display()
+                ),
+            ))
+        })?;
+        let file_type = entry.file_type().map_err(DaemonError::Io)?;
+        if file_type.is_dir() {
+            if kin_index::should_skip_dir(name_str) {
                 continue;
             }
-            collect_tracked_files_recursive(&path, files);
-        } else if path.is_file() {
+            collect_tracked_files_recursive(&path, files)?;
+        } else if file_type.is_file() || file_type.is_symlink() {
             files.push(path);
         }
     }
+    Ok(())
 }
 
 #[cfg(test)]
@@ -279,6 +351,13 @@ mod tests {
         ArtifactDeltaKind, AuthorId, EntityKind, EntityMetadata, FingerprintAlgorithm, LanguageId,
         SemanticFingerprint, Timestamp, Visibility,
     };
+
+    #[test]
+    fn tracked_file_scan_fails_loud_when_root_is_missing() {
+        let temp = tempfile::tempdir().unwrap();
+        let missing = temp.path().join("missing");
+        assert!(collect_tracked_files(&missing).is_err());
+    }
 
     fn make_entity(name: &str, file_path: &str, ast_hash: [u8; 32]) -> kin_model::entity::Entity {
         kin_model::entity::Entity {
@@ -316,14 +395,8 @@ mod tests {
         parent: &SemanticChangeId,
         branch: &str,
     ) -> SemanticChangeId {
-        let content_id = kin_core::content_identity_from_deltas(
-            &entity_deltas,
-            &relation_deltas,
-            &artifact_deltas,
-        );
-        let change_id = kin_core::compute_change_id("test commit", parent, &content_id);
-        let change = kin_model::SemanticChange {
-            id: change_id,
+        let mut change = kin_model::SemanticChange {
+            id: SemanticChangeId::from_hash(Hash256::from_bytes([0; 32])),
             parents: vec![*parent],
             author: AuthorId::new("test".to_string()),
             message: "test commit".to_string(),
@@ -337,6 +410,8 @@ mod tests {
             risk_summary: None,
             authored_on: None,
         };
+        change.id = kin_core::compute_semantic_change_id(&change).unwrap();
+        let change_id = change.id;
         graph.create_change(&change).expect("create_change");
         graph
             .update_branch_head(&kin_model::BranchName::new(branch), &change_id)
@@ -551,7 +626,7 @@ mod tests {
         let added = deltas
             .artifact_deltas
             .iter()
-            .filter(|d| d.kind == ArtifactDeltaKind::Added)
+            .filter(|d| d.kind == ArtifactDeltaKind::AddedRegularFile)
             .count();
         assert!(added >= 1, "at least one Added artifact delta expected");
     }
@@ -589,7 +664,7 @@ mod tests {
             vec![],
             vec![ArtifactDelta {
                 file_id: file_id.clone(),
-                kind: ArtifactDeltaKind::Added,
+                kind: ArtifactDeltaKind::AddedRegularFile,
                 old_hash: None,
                 new_hash: Some(old_hash),
             }],
@@ -605,7 +680,7 @@ mod tests {
         let modified: Vec<_> = deltas
             .artifact_deltas
             .iter()
-            .filter(|d| d.kind == ArtifactDeltaKind::Modified && d.file_id == file_id)
+            .filter(|d| d.kind == ArtifactDeltaKind::ModifiedRegularFile && d.file_id == file_id)
             .collect();
         assert!(
             !modified.is_empty(),
@@ -647,7 +722,7 @@ mod tests {
             vec![],
             vec![ArtifactDelta {
                 file_id: file_id.clone(),
-                kind: ArtifactDeltaKind::Added,
+                kind: ArtifactDeltaKind::AddedRegularFile,
                 old_hash: None,
                 new_hash: Some(committed_hash),
             }],
@@ -667,6 +742,138 @@ mod tests {
             !removed.is_empty(),
             "deleted file must produce a Removed artifact delta"
         );
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn artifact_deltas_preserve_modes_symlinks_and_mode_only_changes() {
+        use std::os::unix::fs::{symlink, PermissionsExt};
+
+        let tmp = tempfile::tempdir().unwrap();
+        let init = kin_core::init(tmp.path()).unwrap();
+        let layout = init.layout;
+        let graph = Arc::new(kin_db::InMemoryGraph::new());
+        let blobs = BlobStore::new(layout.objects_dir()).unwrap();
+        let genesis = kin_core::build_genesis_change();
+        graph.create_change(&genesis).unwrap();
+        graph
+            .create_branch(&kin_model::Branch {
+                name: kin_model::BranchName::new("main"),
+                head: genesis.id,
+            })
+            .unwrap();
+
+        let source = kin_core::source_dir(&layout);
+        std::fs::create_dir_all(source.join("bin")).unwrap();
+        let regular = source.join("plain.txt");
+        let executable = source.join("bin/run");
+        std::fs::write(&regular, b"plain\n").unwrap();
+        std::fs::write(&executable, b"#!/bin/sh\n").unwrap();
+        let mut permissions = std::fs::metadata(&executable).unwrap().permissions();
+        permissions.set_mode(0o755);
+        std::fs::set_permissions(&executable, permissions).unwrap();
+        symlink("plain.txt", source.join("current")).unwrap();
+
+        let initial = compute_deltas_vs_last_commit(&graph, &blobs, &layout, &genesis.id).unwrap();
+        let kinds: std::collections::BTreeMap<_, _> = initial
+            .artifact_deltas
+            .iter()
+            .map(|delta| (delta.file_id.0.as_str(), delta.kind))
+            .collect();
+        assert_eq!(
+            kinds.get("plain.txt"),
+            Some(&ArtifactDeltaKind::AddedRegularFile)
+        );
+        assert_eq!(
+            kinds.get("bin/run"),
+            Some(&ArtifactDeltaKind::AddedExecutableFile)
+        );
+        assert_eq!(kinds.get("current"), Some(&ArtifactDeltaKind::AddedSymlink));
+        let link = initial
+            .artifact_deltas
+            .iter()
+            .find(|delta| delta.file_id.0 == "current")
+            .unwrap();
+        assert_eq!(
+            blobs
+                .read(&kin_blobs::Hash256(link.new_hash.unwrap().0))
+                .unwrap(),
+            b"plain.txt"
+        );
+
+        let head = record_commit(
+            &graph,
+            vec![],
+            vec![],
+            initial.artifact_deltas,
+            &genesis.id,
+            "main",
+        );
+        let plain_hash = blobs.write(b"plain\n").unwrap();
+        let mut permissions = std::fs::metadata(&regular).unwrap().permissions();
+        permissions.set_mode(0o755);
+        std::fs::set_permissions(&regular, permissions).unwrap();
+
+        let mode_only = compute_deltas_vs_last_commit(&graph, &blobs, &layout, &head).unwrap();
+        assert_eq!(mode_only.artifact_deltas.len(), 1);
+        assert_eq!(
+            mode_only.artifact_deltas[0].kind,
+            ArtifactDeltaKind::ModifiedExecutableFile
+        );
+        assert_eq!(mode_only.artifact_deltas[0].file_id.0, "plain.txt");
+        assert_eq!(
+            mode_only.artifact_deltas[0].old_hash,
+            Some(Hash256::from_bytes(plain_hash.0))
+        );
+        assert_eq!(
+            mode_only.artifact_deltas[0].old_hash,
+            mode_only.artifact_deltas[0].new_hash
+        );
+    }
+
+    #[test]
+    fn unchanged_legacy_file_emits_exact_mode_backfill() {
+        let tmp = tempfile::tempdir().unwrap();
+        let init = kin_core::init(tmp.path()).unwrap();
+        let layout = init.layout;
+        let graph = Arc::new(kin_db::InMemoryGraph::new());
+        let blobs = BlobStore::new(layout.objects_dir()).unwrap();
+        let genesis = kin_core::build_genesis_change();
+        graph.create_change(&genesis).unwrap();
+        graph
+            .create_branch(&kin_model::Branch {
+                name: kin_model::BranchName::new("main"),
+                head: genesis.id,
+            })
+            .unwrap();
+
+        let source = kin_core::source_dir(&layout);
+        std::fs::create_dir_all(&source).unwrap();
+        let content = b"legacy bytes\n";
+        std::fs::write(source.join("legacy.txt"), content).unwrap();
+        let hash = Hash256::from_bytes(blobs.write(content).unwrap().0);
+        let head = record_commit(
+            &graph,
+            vec![],
+            vec![],
+            vec![ArtifactDelta {
+                file_id: FilePathId::new("legacy.txt"),
+                kind: ArtifactDeltaKind::Added,
+                old_hash: None,
+                new_hash: Some(hash),
+            }],
+            &genesis.id,
+            "main",
+        );
+
+        let backfill = compute_deltas_vs_last_commit(&graph, &blobs, &layout, &head).unwrap();
+        assert_eq!(backfill.artifact_deltas.len(), 1);
+        assert_eq!(
+            backfill.artifact_deltas[0].kind,
+            ArtifactDeltaKind::ModifiedRegularFile
+        );
+        assert_eq!(backfill.artifact_deltas[0].old_hash, Some(hash));
+        assert_eq!(backfill.artifact_deltas[0].new_hash, Some(hash));
     }
 
     // ── End-to-end: zero deltas after recording current state ─────────────
@@ -711,7 +918,7 @@ mod tests {
             vec![],
             vec![ArtifactDelta {
                 file_id,
-                kind: ArtifactDeltaKind::Added,
+                kind: ArtifactDeltaKind::AddedRegularFile,
                 old_hash: None,
                 new_hash: Some(hash),
             }],

--- a/crates/kin-daemon/src/lib.rs
+++ b/crates/kin-daemon/src/lib.rs
@@ -94,8 +94,11 @@
 //!   scoped reconcile mutates a session-private graph isolated from HEAD.
 //! - `POST /graph/mutations` (`graph_mutations`): work-item / annotation / audit
 //!   metadata, not entity truth; ungated.
-//! - `PUT /graph/branches/{name}/head`, `DELETE /graph/branches/{name}`: branch
-//!   ref operations; ungated.
+//! - `PUT /v2/graph/branches/{name}/head`: compare-and-swap against the live
+//!   head plus ancestry validation; stale, sideways, and backward moves fail
+//!   before mutation. The v1 mutation route is retired with `410 Gone`.
+//!   `DELETE /graph/branches/{name}` remains a ref-management operation outside
+//!   the entity write-veto policy.
 //! - `POST /mcp/tools/call` (`kin_transaction_commit`): **write-veto** before
 //!   `apply_transaction_delta`, plus `can_write`/`can_commit` capability checks.
 //!   Enforce mode fails closed for an unknown/non-rich session. Exact entity,

--- a/crates/kin-daemon/src/state.rs
+++ b/crates/kin-daemon/src/state.rs
@@ -11,7 +11,8 @@ use kin_blobs::BlobStore;
 use kin_core::KinLayout;
 use kin_db::StorageBackend;
 use kin_model::{
-    EntityId, EntityStore, FilePathId, GraphOverlay, Hash256, SemanticChangeId, WorkingCopy,
+    ChangeStore, EntityId, EntityStore, FilePathId, GraphOverlay, Hash256, SemanticChange,
+    SemanticChangeId, SourceEntryKind, SourceTreeResolution, WorkingCopy,
 };
 use kin_projection::ProjectionState;
 use kin_reconcile::Reconciler;
@@ -20,6 +21,92 @@ use tracing::{debug, error, info, warn};
 
 use crate::error::{DaemonError, Result};
 use crate::session_registry::SessionCoordinator;
+
+/// Read-only overlay used to resolve the complete source tree an incoming
+/// change would create without first inserting that change into graph
+/// authority. The default `ChangeStore` replay then applies the same
+/// topological and merge-parent semantics as a committed change.
+struct ProspectiveChangeStore<'a> {
+    graph: &'a kin_db::InMemoryGraph,
+    incoming: &'a SemanticChange,
+}
+
+impl ChangeStore for ProspectiveChangeStore<'_> {
+    type Error = kin_db::KinDbError;
+
+    fn get_entity_history(
+        &self,
+        id: &EntityId,
+    ) -> std::result::Result<Vec<SemanticChange>, Self::Error> {
+        self.graph.get_entity_history(id)
+    }
+
+    fn find_merge_bases(
+        &self,
+        a: &SemanticChangeId,
+        b: &SemanticChangeId,
+    ) -> std::result::Result<Vec<SemanticChangeId>, Self::Error> {
+        self.graph.find_merge_bases(a, b)
+    }
+
+    fn create_change(&self, _change: &SemanticChange) -> std::result::Result<(), Self::Error> {
+        Err(kin_db::KinDbError::StorageError(
+            "prospective exact-source replay is read-only".to_string(),
+        ))
+    }
+
+    fn get_change(
+        &self,
+        id: &SemanticChangeId,
+    ) -> std::result::Result<Option<SemanticChange>, Self::Error> {
+        if *id == self.incoming.id {
+            Ok(Some(self.incoming.clone()))
+        } else {
+            self.graph.get_change(id)
+        }
+    }
+
+    fn get_changes_since(
+        &self,
+        base: &SemanticChangeId,
+        head: &SemanticChangeId,
+    ) -> std::result::Result<Vec<SemanticChange>, Self::Error> {
+        self.graph.get_changes_since(base, head)
+    }
+
+    fn get_branch(
+        &self,
+        name: &kin_model::BranchName,
+    ) -> std::result::Result<Option<kin_model::Branch>, Self::Error> {
+        self.graph.get_branch(name)
+    }
+
+    fn create_branch(&self, _branch: &kin_model::Branch) -> std::result::Result<(), Self::Error> {
+        Err(kin_db::KinDbError::StorageError(
+            "prospective exact-source replay is read-only".to_string(),
+        ))
+    }
+
+    fn update_branch_head(
+        &self,
+        _name: &kin_model::BranchName,
+        _new_head: &SemanticChangeId,
+    ) -> std::result::Result<(), Self::Error> {
+        Err(kin_db::KinDbError::StorageError(
+            "prospective exact-source replay is read-only".to_string(),
+        ))
+    }
+
+    fn delete_branch(&self, _name: &kin_model::BranchName) -> std::result::Result<(), Self::Error> {
+        Err(kin_db::KinDbError::StorageError(
+            "prospective exact-source replay is read-only".to_string(),
+        ))
+    }
+
+    fn list_branches(&self) -> std::result::Result<Vec<kin_model::Branch>, Self::Error> {
+        self.graph.list_branches()
+    }
+}
 
 /// Reconciliation loop status values.
 pub const RECON_IDLE: u8 = 0;
@@ -612,6 +699,74 @@ impl Drop for GraphPersistenceAttempt<'_> {
     }
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum SnapshotSaveMode {
+    Incremental,
+    Full,
+    /// Recover an earlier request whose graph mutation is already visible in
+    /// memory. Persist a full snapshot only when authority is still pending;
+    /// otherwise finish an already-committed generation without advancing it.
+    Retry,
+}
+
+fn exact_source_storage_error(message: impl Into<String>) -> DaemonError {
+    DaemonError::Graph(kin_db::KinDbError::StorageError(message.into()))
+}
+
+fn exact_source_objects<'a>(
+    changes: impl IntoIterator<Item = &'a SemanticChange>,
+) -> Result<Vec<(Hash256, FilePathId, SemanticChangeId, SourceEntryKind)>> {
+    let mut objects = Vec::new();
+    for change in changes {
+        for delta in &change.artifact_deltas {
+            if delta.kind.is_removed() {
+                continue;
+            }
+            let Some(kind) = delta.kind.source_entry_kind() else {
+                // Legacy mode-unknown history stays an explicit exact-tree gap;
+                // this object preflight must not normalize it into a mode.
+                continue;
+            };
+            let hash = delta.new_hash.ok_or_else(|| {
+                exact_source_storage_error(format!(
+                    "exact source delta for {} in change {} has no content identity",
+                    delta.file_id, change.id
+                ))
+            })?;
+            objects.push((hash, delta.file_id.clone(), change.id, kind));
+        }
+    }
+    objects.sort_by(|left, right| {
+        left.0
+            .as_bytes()
+            .cmp(right.0.as_bytes())
+            .then_with(|| left.1 .0.cmp(&right.1 .0))
+            .then_with(|| left.2 .0.as_bytes().cmp(right.2 .0.as_bytes()))
+    });
+    Ok(objects)
+}
+
+fn validate_exact_source_bytes(
+    file_id: &FilePathId,
+    kind: SourceEntryKind,
+    expected: Hash256,
+    data: &[u8],
+    authority: &str,
+) -> Result<()> {
+    let actual = kin_blobs::digest_bytes(data);
+    if actual != *expected.as_bytes() {
+        return Err(exact_source_storage_error(format!(
+            "{authority} exact source bytes for {file_id} do not match {expected}: found {}",
+            hex::encode(actual)
+        )));
+    }
+    kin_core::validate_source_entry(file_id, kind, data).map_err(|error| {
+        exact_source_storage_error(format!(
+            "{authority} exact source entry {file_id} at {expected} is not materializable: {error}"
+        ))
+    })
+}
+
 #[cfg(test)]
 #[derive(Debug, Clone)]
 pub(crate) struct VfsTreeBuildTestHook {
@@ -708,6 +863,8 @@ pub struct DaemonState {
     pending_persistence_event: Mutex<Option<DaemonEvent>>,
     #[cfg(test)]
     finalization_fail_once: AtomicBool,
+    #[cfg(test)]
+    snapshot_save_fail_once: AtomicBool,
     /// Monotonically increasing version counter for VFS cache invalidation.
     /// Incremented on every graph mutation (reconcile, commit, overlay update).
     /// Unlike entity_count, this never decreases on deletions.
@@ -1226,6 +1383,8 @@ impl DaemonState {
             pending_persistence_event: Mutex::new(None),
             #[cfg(test)]
             finalization_fail_once: AtomicBool::new(false),
+            #[cfg(test)]
+            snapshot_save_fail_once: AtomicBool::new(false),
             vfs_version: AtomicU64::new(persisted_vfs_version),
             vfs_tree_cache: std::sync::RwLock::new(None),
             vfs_tree_build_lock: tokio::sync::Mutex::new(()),
@@ -1394,6 +1553,8 @@ impl DaemonState {
             pending_persistence_event: Mutex::new(None),
             #[cfg(test)]
             finalization_fail_once: AtomicBool::new(false),
+            #[cfg(test)]
+            snapshot_save_fail_once: AtomicBool::new(false),
             vfs_version: AtomicU64::new(persisted_vfs_version),
             vfs_tree_cache: std::sync::RwLock::new(None),
             vfs_tree_build_lock: tokio::sync::Mutex::new(()),
@@ -2672,6 +2833,11 @@ impl DaemonState {
     }
 
     #[cfg(test)]
+    pub(crate) fn fail_next_snapshot_save_for_test(&self) {
+        self.snapshot_save_fail_once.store(true, Ordering::SeqCst);
+    }
+
+    #[cfg(test)]
     pub(crate) fn persistence_event_is_queued_for_test(&self) -> bool {
         self.pending_persistence_event
             .lock()
@@ -2693,7 +2859,7 @@ impl DaemonState {
     /// `.kin/kindb/head-generation` so CLI and MCP processes can detect
     /// when their loaded snapshot is stale (P2-2.7).
     pub fn save_snapshot(&self) -> Result<()> {
-        self.save_snapshot_impl(false, None)
+        self.save_snapshot_impl(SnapshotSaveMode::Incremental, None)
     }
 
     /// Save graph authority and publish `event` only after the generation that
@@ -2701,11 +2867,24 @@ impl DaemonState {
     /// holding `persist_lock`, so an older in-flight generation cannot consume
     /// this event before the caller's batch is detached and committed.
     pub(crate) fn save_snapshot_with_event(&self, event: DaemonEvent) -> Result<()> {
-        self.save_snapshot_impl(false, Some(event))
+        self.save_snapshot_impl(SnapshotSaveMode::Incremental, Some(event))
     }
 
     pub fn save_snapshot_full(&self) -> Result<()> {
-        self.save_snapshot_impl(true, None)
+        self.save_snapshot_impl(SnapshotSaveMode::Full, None)
+    }
+
+    pub(crate) fn save_snapshot_full_with_event(&self, event: DaemonEvent) -> Result<()> {
+        self.save_snapshot_impl(SnapshotSaveMode::Full, Some(event))
+    }
+
+    /// Complete persistence for a request whose identical graph change and
+    /// branch head are already visible in memory. A failure before the prior
+    /// authority commit leaves graph deltas pending and therefore requires a
+    /// full snapshot. A failure after the authority commit leaves only local
+    /// finalization pending and must not create a second generation.
+    pub(crate) fn retry_snapshot_authority_with_event(&self, event: DaemonEvent) -> Result<()> {
+        self.save_snapshot_impl(SnapshotSaveMode::Retry, Some(event))
     }
 
     /// Whether derived embedding progress can be committed through the local
@@ -2717,6 +2896,240 @@ impl DaemonState {
     /// unsafe and must fail loud rather than fabricate a durable checkpoint.
     pub(crate) fn can_persist_embed_progress_locally(&self) -> bool {
         self.storage_backend.is_none()
+    }
+
+    /// Persist every exact-mode source object referenced by `changes` before
+    /// the graph authority that names those objects is committed.
+    ///
+    /// Legacy mode-unknown deltas remain explicit graph gaps and are skipped;
+    /// exact deltas fail closed when neither the local content-addressed store
+    /// nor the backend already has the named bytes. Durable source objects may
+    /// safely precede a failed graph CAS because they are immutable and
+    /// content-addressed, while committing the graph first would create an
+    /// irreparable authority gap.
+    fn persist_exact_source_objects<'a>(
+        &self,
+        backend: &dyn StorageBackend,
+        repo_id: &str,
+        changes: impl IntoIterator<Item = &'a SemanticChange>,
+    ) -> Result<()> {
+        let objects = exact_source_objects(changes)?;
+        // Reject path aliases/prefix conflicts before reading or publishing
+        // any source object. This metadata-only pass borrows paths from the
+        // object list and therefore does not duplicate repository bytes.
+        {
+            let mut paths = objects
+                .iter()
+                .map(|(_, file_id, change_id, _)| (*change_id, file_id))
+                .collect::<Vec<_>>();
+            paths.sort_by(|left, right| {
+                left.0
+                     .0
+                    .as_bytes()
+                    .cmp(right.0 .0.as_bytes())
+                    .then_with(|| left.1 .0.cmp(&right.1 .0))
+            });
+            let mut start = 0;
+            while start < paths.len() {
+                let change_id = paths[start].0;
+                let mut end = start + 1;
+                while end < paths.len() && paths[end].0 == change_id {
+                    end += 1;
+                }
+                kin_core::validate_source_paths(
+                    paths[start..end].iter().map(|(_, file_id)| *file_id),
+                )
+                .map_err(|error| {
+                    exact_source_storage_error(format!(
+                        "exact source change {change_id} is not materializable: {error}"
+                    ))
+                })?;
+                start = end;
+            }
+        }
+
+        let mut start = 0;
+        while start < objects.len() {
+            let hash = objects[start].0;
+            let mut end = start + 1;
+            while end < objects.len() && objects[end].0 == hash {
+                end += 1;
+            }
+            let digest = *hash.as_bytes();
+            match self.blobs.read(&kin_blobs::Hash256(digest)) {
+                Ok(data) => {
+                    for (_, file_id, _, kind) in &objects[start..end] {
+                        validate_exact_source_bytes(file_id, *kind, hash, &data, "local")?;
+                    }
+                    backend
+                        .save_source_blob(repo_id, digest, &data)
+                        .map_err(DaemonError::from)?;
+                }
+                Err(local_error) => match backend
+                    .load_source_blob(repo_id, digest)
+                    .map_err(DaemonError::from)?
+                {
+                    Some(data) => {
+                        for (_, file_id, _, kind) in &objects[start..end] {
+                            validate_exact_source_bytes(file_id, *kind, hash, &data, "backend")?;
+                        }
+                        let (_, first_file_id, first_change_id, _) = &objects[start];
+                        warn!(
+                            repo_id,
+                            file = %first_file_id,
+                            change = %first_change_id,
+                            hash = %hash,
+                            references = end - start,
+                            error = %local_error,
+                            "local source object unavailable; retained verified backend authority"
+                        );
+                    }
+                    None => {
+                        let (_, file_id, change_id, _) = &objects[start];
+                        return Err(DaemonError::Graph(kin_db::KinDbError::StorageError(
+                            format!(
+                                "exact source bytes for {} in change {} at {} are absent from both local and backend authority: {local_error}",
+                                file_id, change_id, hash
+                            ),
+                        )));
+                    }
+                },
+            };
+            start = end;
+        }
+        Ok(())
+    }
+
+    /// Preflight one incoming semantic change before mutating the live graph.
+    /// Hosted graph commits do not share the caller's local object directory;
+    /// an exact change whose bytes are unavailable must therefore fail before
+    /// its entities, relations, change record, or branch head become visible.
+    pub(crate) fn preflight_exact_source_change(
+        &self,
+        graph: &kin_db::InMemoryGraph,
+        change: &SemanticChange,
+    ) -> Result<()> {
+        if let Some(backend) = &self.storage_backend {
+            self.persist_exact_source_objects(
+                backend.as_ref(),
+                self.cached_repo_id.as_str(),
+                std::iter::once(change),
+            )?;
+        }
+
+        let prospective = ProspectiveChangeStore {
+            graph,
+            incoming: change,
+        };
+        let entries = match prospective
+            .resolve_source_tree_at(&change.id)
+            .map_err(DaemonError::from)?
+        {
+            SourceTreeResolution::Exact { entries } => entries,
+            SourceTreeResolution::Incomplete { gaps } => {
+                let gaps = gaps
+                    .iter()
+                    .map(|gap| format!("{}@{}:{:?}", gap.file_id, gap.change_id, gap.reason))
+                    .collect::<Vec<_>>()
+                    .join(", ");
+                return Err(exact_source_storage_error(format!(
+                    "incoming source history at {} is not exact: {gaps}",
+                    change.id
+                )));
+            }
+        };
+        self.preflight_materializable_source_entries(entries, "incoming exact")
+    }
+
+    fn preflight_materializable_source_entries(
+        &self,
+        entries: HashMap<FilePathId, kin_model::ResolvedSourceEntry>,
+        purpose: &str,
+    ) -> Result<()> {
+        let mut entries: Vec<_> = entries.into_iter().collect();
+        entries.sort_by(|left, right| left.0 .0.cmp(&right.0 .0));
+        kin_core::validate_source_paths(entries.iter().map(|(file_id, _)| file_id)).map_err(
+            |error| {
+                exact_source_storage_error(format!(
+                    "{purpose} source tree is not materializable: {error}"
+                ))
+            },
+        )?;
+        entries.sort_by(|left, right| {
+            left.1
+                .hash
+                .as_bytes()
+                .cmp(right.1.hash.as_bytes())
+                .then_with(|| left.0 .0.cmp(&right.0 .0))
+        });
+        let mut start = 0;
+        while start < entries.len() {
+            let source_hash = entries[start].1.hash;
+            let mut end = start + 1;
+            while end < entries.len() && entries[end].1.hash == source_hash {
+                end += 1;
+            }
+            let digest = *source_hash.as_bytes();
+            let (data, authority) = if let Some(backend) = &self.storage_backend {
+                let data = backend
+                    .load_source_blob(self.cached_repo_id.as_str(), digest)
+                    .map_err(DaemonError::from)?
+                    .ok_or_else(|| {
+                        exact_source_storage_error(format!(
+                            "{purpose} source bytes for {} at {} are absent from backend authority",
+                            entries[start].0, source_hash
+                        ))
+                    })?;
+                (data, "backend")
+            } else {
+                let data = self
+                    .blobs
+                    .read(&kin_blobs::Hash256(digest))
+                    .map_err(|error| {
+                        exact_source_storage_error(format!(
+                            "{purpose} source bytes for {} at {} are absent or corrupt in local authority: {error}",
+                            entries[start].0, source_hash
+                        ))
+                    })?;
+                (data, "local")
+            };
+            for (file_id, source) in &entries[start..end] {
+                validate_exact_source_bytes(file_id, source.kind, source.hash, &data, authority)?;
+            }
+            start = end;
+        }
+        Ok(())
+    }
+
+    /// Prove that the exact source tree at `head` is both complete and fully
+    /// materializable from the daemon's immutable source authority.
+    ///
+    /// Release admission calls this while holding the same coordination gate
+    /// as marker/head mutation. Backend-backed daemons use backend objects only
+    /// (the hosted immutable authority); local daemons use their verified CAS.
+    pub(crate) fn preflight_exact_source_tree(
+        &self,
+        graph: &kin_db::InMemoryGraph,
+        head: &SemanticChangeId,
+    ) -> Result<()> {
+        let entries = match graph
+            .resolve_source_tree_at(head)
+            .map_err(DaemonError::from)?
+        {
+            SourceTreeResolution::Exact { entries } => entries,
+            SourceTreeResolution::Incomplete { gaps } => {
+                let gaps = gaps
+                    .iter()
+                    .map(|gap| format!("{}@{}:{:?}", gap.file_id, gap.change_id, gap.reason))
+                    .collect::<Vec<_>>()
+                    .join(", ");
+                return Err(exact_source_storage_error(format!(
+                    "release source history at {head} is not exact: {gaps}"
+                )));
+            }
+        };
+
+        self.preflight_materializable_source_entries(entries, &format!("release source at {head}"))
     }
 
     /// Whether filesystem-to-graph compatibility ingestion is disabled for
@@ -2739,7 +3152,7 @@ impl DaemonState {
         )))
     }
 
-    fn save_snapshot_impl(&self, force_full: bool, event: Option<DaemonEvent>) -> Result<()> {
+    fn save_snapshot_impl(&self, mode: SnapshotSaveMode, event: Option<DaemonEvent>) -> Result<()> {
         // Serialize the whole kndb + generation-marker + kidx write sequence
         // against any other save (persist loop, idle flush, embed worker).
         // Without this, two concurrent saves race on the shared tmp paths and
@@ -2750,9 +3163,25 @@ impl DaemonState {
             .lock()
             .map_err(|_| DaemonError::Io(std::io::Error::other("persist lock poisoned")))?;
 
+        let has_unpersisted_changes = self.graph.has_unpersisted_changes();
+        let finalization_pending = self.post_commit_finalization_pending.load(Ordering::SeqCst);
+        if mode == SnapshotSaveMode::Retry && !has_unpersisted_changes && !finalization_pending {
+            return Ok(());
+        }
+
         if let Some(event) = event {
             self.queue_persistence_event(event);
         }
+
+        #[cfg(test)]
+        if self.snapshot_save_fail_once.swap(false, Ordering::SeqCst) {
+            return Err(DaemonError::Io(std::io::Error::other(
+                "injected pre-authority snapshot save failure",
+            )));
+        }
+
+        let force_full = mode == SnapshotSaveMode::Full
+            || (mode == SnapshotSaveMode::Retry && has_unpersisted_changes);
 
         let repo_id = self.cached_repo_id.as_str();
         let expected_gen = self.snapshot_generation.load(Ordering::SeqCst);
@@ -2770,6 +3199,13 @@ impl DaemonState {
                     .map_err(DaemonError::from)?;
                 let persistence_attempt =
                     GraphPersistenceAttempt::new(self.graph.as_ref(), persistence_epoch);
+                let detached_snapshot =
+                    kin_db::GraphSnapshot::from_bytes(&bytes).map_err(DaemonError::from)?;
+                self.persist_exact_source_objects(
+                    backend.as_ref(),
+                    repo_id,
+                    detached_snapshot.changes.values(),
+                )?;
                 // Keep every fallible derived-index operation before the
                 // authority commit. If it fails, the RAII attempt forces a full
                 // retry and the backend generation remains unchanged.
@@ -2805,6 +3241,16 @@ impl DaemonState {
             {
                 let persistence_attempt =
                     GraphPersistenceAttempt::new(self.graph.as_ref(), persistence_epoch);
+                self.persist_exact_source_objects(
+                    backend.as_ref(),
+                    repo_id,
+                    delta
+                        .changes
+                        .added
+                        .iter()
+                        .chain(delta.changes.modified.iter())
+                        .map(|(_, change)| change),
+                )?;
                 let bytes = delta.to_bytes().map_err(DaemonError::from)?;
                 // A text-index failure must precede the durable delta commit.
                 // The index is derived and root-stamped; the authority write is
@@ -3590,6 +4036,9 @@ mod tests {
         fail_cleanup: AtomicBool,
         delta_block: Option<DeltaSaveBlock>,
         recovery_loads: Option<Arc<AtomicU64>>,
+        source_loads: Option<Arc<AtomicU64>>,
+        source_saves: Option<Arc<AtomicU64>>,
+        source_override: Option<Vec<u8>>,
     }
 
     struct DeltaSaveBlock {
@@ -3605,6 +4054,9 @@ mod tests {
                 fail_cleanup: AtomicBool::new(fail_cleanup),
                 delta_block: None,
                 recovery_loads: None,
+                source_loads: None,
+                source_saves: None,
+                source_override: None,
             }
         }
 
@@ -3622,6 +4074,9 @@ mod tests {
                     block_once: AtomicBool::new(true),
                 }),
                 recovery_loads: None,
+                source_loads: None,
+                source_saves: None,
+                source_override: None,
             }
         }
 
@@ -3631,6 +4086,37 @@ mod tests {
                 fail_cleanup: AtomicBool::new(false),
                 delta_block: None,
                 recovery_loads: Some(recovery_loads),
+                source_loads: None,
+                source_saves: None,
+                source_override: None,
+            }
+        }
+
+        fn counting_source(
+            path: &std::path::Path,
+            source_loads: Arc<AtomicU64>,
+            source_saves: Arc<AtomicU64>,
+        ) -> Self {
+            Self {
+                inner: kin_db::LocalFileBackend::new(path),
+                fail_cleanup: AtomicBool::new(false),
+                delta_block: None,
+                recovery_loads: None,
+                source_loads: Some(source_loads),
+                source_saves: Some(source_saves),
+                source_override: None,
+            }
+        }
+
+        fn corrupt_source(path: &std::path::Path, bytes: Vec<u8>) -> Self {
+            Self {
+                inner: kin_db::LocalFileBackend::new(path),
+                fail_cleanup: AtomicBool::new(false),
+                delta_block: None,
+                recovery_loads: None,
+                source_loads: None,
+                source_saves: None,
+                source_override: Some(bytes),
             }
         }
     }
@@ -3646,6 +4132,32 @@ mod tests {
         ) -> std::result::Result<Option<(Vec<u8>, kin_db::Generation)>, kin_db::KinDbError>
         {
             self.inner.load_snapshot(repo_id)
+        }
+
+        fn save_source_blob(
+            &self,
+            repo_id: &str,
+            digest: [u8; 32],
+            data: &[u8],
+        ) -> std::result::Result<(), kin_db::KinDbError> {
+            if let Some(saves) = &self.source_saves {
+                saves.fetch_add(1, Ordering::SeqCst);
+            }
+            self.inner.save_source_blob(repo_id, digest, data)
+        }
+
+        fn load_source_blob(
+            &self,
+            repo_id: &str,
+            digest: [u8; 32],
+        ) -> std::result::Result<Option<Vec<u8>>, kin_db::KinDbError> {
+            if let Some(loads) = &self.source_loads {
+                loads.fetch_add(1, Ordering::SeqCst);
+            }
+            if let Some(bytes) = &self.source_override {
+                return Ok(Some(bytes.clone()));
+            }
+            self.inner.load_source_blob(repo_id, digest)
         }
 
         fn load_snapshot_authority(
@@ -3748,6 +4260,39 @@ mod tests {
         }
     }
 
+    fn exact_source_change(
+        id_byte: u8,
+        file_id: &str,
+        kind: kin_model::ArtifactDeltaKind,
+        hash: Hash256,
+    ) -> kin_model::SemanticChange {
+        kin_model::SemanticChange {
+            id: kin_model::SemanticChangeId::from_hash(Hash256::from_bytes([id_byte; 32])),
+            parents: vec![],
+            author: kin_model::AuthorId::new("exact-source-preflight-test"),
+            message: "exact source preflight fixture".to_string(),
+            timestamp: kin_model::Timestamp::now(),
+            entity_deltas: vec![],
+            relation_deltas: vec![],
+            artifact_deltas: vec![kin_model::ArtifactDelta {
+                file_id: FilePathId::new(file_id),
+                kind,
+                old_hash: None,
+                new_hash: Some(hash),
+            }],
+            projected_files: vec![],
+            spec_link: None,
+            evidence: vec![],
+            risk_summary: None,
+            authored_on: None,
+        }
+    }
+
+    fn local_object_path(layout: &KinLayout, hash: Hash256) -> std::path::PathBuf {
+        let encoded = hash.to_string();
+        layout.objects_dir().join(&encoded[..2]).join(&encoded[2..])
+    }
+
     fn test_state(layout: KinLayout, working_dir: &std::path::Path) -> DaemonState {
         let snapshot_generation =
             if kin_db::SnapshotManager::local_authority_exists(layout.kindb_snapshot_path()) {
@@ -3796,6 +4341,8 @@ mod tests {
             pending_persistence_event: Mutex::new(None),
             #[cfg(test)]
             finalization_fail_once: AtomicBool::new(false),
+            #[cfg(test)]
+            snapshot_save_fail_once: AtomicBool::new(false),
             vfs_version: AtomicU64::new(0),
             vfs_tree_cache: std::sync::RwLock::new(None),
             vfs_tree_build_lock: tokio::sync::Mutex::new(()),
@@ -4968,6 +5515,550 @@ mod tests {
         assert!(names.contains("base_entity"));
         assert!(names.contains("first_delta_entity"));
         assert!(names.contains("second_delta_entity"));
+    }
+
+    #[test]
+    fn storage_backend_persists_exact_source_objects_before_full_and_delta_authority() {
+        use kin_db::{LocalFileBackend, StorageBackend};
+        use kin_model::{
+            ArtifactDelta, ArtifactDeltaKind, AuthorId, Branch, BranchName, ChangeStore,
+            SemanticChange, SemanticChangeId, Timestamp,
+        };
+
+        let repo_dir = tempfile::tempdir().unwrap();
+        let init = kin_core::init(repo_dir.path()).unwrap();
+        let layout = init.layout;
+        let storage = tempfile::tempdir().unwrap();
+        let repo_id = "exact-source-restart";
+        let branch_name = BranchName::new("main");
+
+        let state = DaemonState::open_with_backend(
+            layout.clone(),
+            Box::new(LocalFileBackend::new(storage.path())),
+            repo_id,
+            None,
+        )
+        .unwrap();
+        let executable = b"#!/bin/sh\necho kin\n";
+        let executable_hash = state.blobs.write(executable).unwrap();
+        let executable_hash = Hash256::from_bytes(executable_hash.0);
+        let first = SemanticChange {
+            id: SemanticChangeId::from_hash(Hash256::from_bytes([31; 32])),
+            parents: vec![],
+            author: AuthorId::new("tester"),
+            message: "add executable".to_string(),
+            timestamp: Timestamp::now(),
+            entity_deltas: vec![],
+            relation_deltas: vec![],
+            artifact_deltas: vec![ArtifactDelta {
+                file_id: FilePathId("bin/kin".to_string()),
+                kind: ArtifactDeltaKind::AddedExecutableFile,
+                old_hash: None,
+                new_hash: Some(executable_hash),
+            }],
+            projected_files: vec![],
+            spec_link: None,
+            evidence: vec![],
+            risk_summary: None,
+            authored_on: None,
+        };
+        state.graph.create_change(&first).unwrap();
+        state
+            .graph
+            .create_branch(&Branch {
+                name: branch_name.clone(),
+                head: first.id,
+            })
+            .unwrap();
+        state.save_snapshot_full().unwrap();
+        assert_eq!(state.snapshot_generation.load(Ordering::SeqCst), 1);
+        assert_eq!(
+            LocalFileBackend::new(storage.path())
+                .load_source_blob(repo_id, *executable_hash.as_bytes())
+                .unwrap()
+                .as_deref(),
+            Some(executable.as_slice())
+        );
+        drop(state);
+
+        let reopened = DaemonState::open_with_backend(
+            layout.clone(),
+            Box::new(LocalFileBackend::new(storage.path())),
+            repo_id,
+            None,
+        )
+        .unwrap();
+        let target = b"bin/kin";
+        let target_hash = reopened.blobs.write(target).unwrap();
+        let target_hash = Hash256::from_bytes(target_hash.0);
+        let second = SemanticChange {
+            id: SemanticChangeId::from_hash(Hash256::from_bytes([32; 32])),
+            parents: vec![first.id],
+            author: AuthorId::new("tester"),
+            message: "add symlink".to_string(),
+            timestamp: Timestamp::now(),
+            entity_deltas: vec![],
+            relation_deltas: vec![],
+            artifact_deltas: vec![ArtifactDelta {
+                file_id: FilePathId("current".to_string()),
+                kind: ArtifactDeltaKind::AddedSymlink,
+                old_hash: None,
+                new_hash: Some(target_hash),
+            }],
+            projected_files: vec![],
+            spec_link: None,
+            evidence: vec![],
+            risk_summary: None,
+            authored_on: None,
+        };
+        reopened.graph.create_change(&second).unwrap();
+        reopened
+            .graph
+            .update_branch_head(&branch_name, &second.id)
+            .unwrap();
+        reopened.save_snapshot().unwrap();
+        assert_eq!(reopened.snapshot_generation.load(Ordering::SeqCst), 2);
+        assert_eq!(
+            LocalFileBackend::new(storage.path())
+                .load_source_blob(repo_id, *target_hash.as_bytes())
+                .unwrap()
+                .as_deref(),
+            Some(target.as_slice())
+        );
+        drop(reopened);
+
+        let reopened = DaemonState::open_with_backend(
+            layout,
+            Box::new(LocalFileBackend::new(storage.path())),
+            repo_id,
+            None,
+        )
+        .unwrap();
+        let exact = reopened.graph.resolve_source_tree_at(&second.id).unwrap();
+        let kin_model::SourceTreeResolution::Exact { entries } = exact else {
+            panic!("persisted exact source history reopened as incomplete")
+        };
+        assert_eq!(
+            entries[&FilePathId("bin/kin".to_string())].kind,
+            kin_model::SourceEntryKind::File { executable: true }
+        );
+        assert_eq!(
+            entries[&FilePathId("current".to_string())].kind,
+            kin_model::SourceEntryKind::Symlink
+        );
+    }
+
+    #[test]
+    fn exact_source_persistence_and_preflight_load_each_content_hash_once() {
+        use kin_db::StorageBackend;
+        use kin_model::{
+            ArtifactDelta, ArtifactDeltaKind, AuthorId, ChangeStore, SemanticChange,
+            SemanticChangeId, Timestamp,
+        };
+
+        let repo_dir = tempfile::tempdir().unwrap();
+        let init = kin_core::init(repo_dir.path()).unwrap();
+        let storage = tempfile::tempdir().unwrap();
+        let repo_id = "deduplicated-exact-source";
+        let source_loads = Arc::new(AtomicU64::new(0));
+        let source_saves = Arc::new(AtomicU64::new(0));
+        let backend = CleanupFailOnceBackend::counting_source(
+            storage.path(),
+            Arc::clone(&source_loads),
+            Arc::clone(&source_saves),
+        );
+        let bytes = b"shared exact source bytes\n";
+        let digest = kin_blobs::digest_bytes(bytes);
+        backend
+            .inner
+            .save_source_blob(repo_id, digest, bytes)
+            .unwrap();
+        let hash = Hash256::from_bytes(digest);
+        let change = SemanticChange {
+            id: SemanticChangeId::from_hash(Hash256::from_bytes([0x93; 32])),
+            parents: vec![],
+            author: AuthorId::new("tester"),
+            message: "reuse one immutable source object".to_string(),
+            timestamp: Timestamp::now(),
+            entity_deltas: vec![],
+            relation_deltas: vec![],
+            artifact_deltas: vec![
+                ArtifactDelta {
+                    file_id: FilePathId("src/first.rs".to_string()),
+                    kind: ArtifactDeltaKind::AddedRegularFile,
+                    old_hash: None,
+                    new_hash: Some(hash),
+                },
+                ArtifactDelta {
+                    file_id: FilePathId("src/second.rs".to_string()),
+                    kind: ArtifactDeltaKind::AddedRegularFile,
+                    old_hash: None,
+                    new_hash: Some(hash),
+                },
+            ],
+            projected_files: vec![],
+            spec_link: None,
+            evidence: vec![],
+            risk_summary: None,
+            authored_on: None,
+        };
+        let state =
+            DaemonState::open_with_backend(init.layout, Box::new(backend), repo_id, None).unwrap();
+        state.graph.create_change(&change).unwrap();
+
+        source_loads.store(0, Ordering::SeqCst);
+        source_saves.store(0, Ordering::SeqCst);
+        state
+            .persist_exact_source_objects(
+                state.storage_backend.as_deref().unwrap(),
+                repo_id,
+                std::iter::once(&change),
+            )
+            .unwrap();
+        assert_eq!(source_loads.load(Ordering::SeqCst), 1);
+        assert_eq!(source_saves.load(Ordering::SeqCst), 0);
+
+        source_loads.store(0, Ordering::SeqCst);
+        state
+            .preflight_exact_source_tree(&state.graph, &change.id)
+            .unwrap();
+        assert_eq!(source_loads.load(Ordering::SeqCst), 1);
+
+        state.blobs.write(bytes).unwrap();
+        source_loads.store(0, Ordering::SeqCst);
+        source_saves.store(0, Ordering::SeqCst);
+        state
+            .persist_exact_source_objects(
+                state.storage_backend.as_deref().unwrap(),
+                repo_id,
+                std::iter::once(&change),
+            )
+            .unwrap();
+        assert_eq!(source_loads.load(Ordering::SeqCst), 0);
+        assert_eq!(source_saves.load(Ordering::SeqCst), 1);
+    }
+
+    #[test]
+    fn storage_backend_rejects_exact_graph_authority_when_source_bytes_are_missing() {
+        use kin_db::{LocalFileBackend, StorageBackend};
+        use kin_model::{
+            ArtifactDelta, ArtifactDeltaKind, AuthorId, ChangeStore, SemanticChange,
+            SemanticChangeId, Timestamp,
+        };
+
+        let repo_dir = tempfile::tempdir().unwrap();
+        let init = kin_core::init(repo_dir.path()).unwrap();
+        let storage = tempfile::tempdir().unwrap();
+        let repo_id = "missing-exact-source";
+        let state = DaemonState::open_with_backend(
+            init.layout,
+            Box::new(LocalFileBackend::new(storage.path())),
+            repo_id,
+            None,
+        )
+        .unwrap();
+        let missing_hash = Hash256::from_bytes([99; 32]);
+        state
+            .graph
+            .create_change(&SemanticChange {
+                id: SemanticChangeId::from_hash(Hash256::from_bytes([33; 32])),
+                parents: vec![],
+                author: AuthorId::new("tester"),
+                message: "missing source".to_string(),
+                timestamp: Timestamp::now(),
+                entity_deltas: vec![],
+                relation_deltas: vec![],
+                artifact_deltas: vec![ArtifactDelta {
+                    file_id: FilePathId("src/lib.rs".to_string()),
+                    kind: ArtifactDeltaKind::AddedRegularFile,
+                    old_hash: None,
+                    new_hash: Some(missing_hash),
+                }],
+                projected_files: vec![],
+                spec_link: None,
+                evidence: vec![],
+                risk_summary: None,
+                authored_on: None,
+            })
+            .unwrap();
+
+        let error = state
+            .save_snapshot_full()
+            .expect_err("graph authority must not name unavailable exact source bytes");
+        assert!(error
+            .to_string()
+            .contains("absent from both local and backend authority"));
+        assert_eq!(state.snapshot_generation.load(Ordering::SeqCst), 0);
+        assert!(LocalFileBackend::new(storage.path())
+            .load_snapshot(repo_id)
+            .unwrap()
+            .is_none());
+    }
+
+    #[test]
+    fn corrupt_backend_exact_source_preflight_preserves_graph_and_generation() {
+        use kin_db::{LocalFileBackend, StorageBackend};
+        use kin_model::{
+            ArtifactDelta, ArtifactDeltaKind, AuthorId, ChangeStore, SemanticChange,
+            SemanticChangeId, Timestamp,
+        };
+
+        let repo_dir = tempfile::tempdir().unwrap();
+        let init = kin_core::init(repo_dir.path()).unwrap();
+        let storage = tempfile::tempdir().unwrap();
+        let repo_id = "corrupt-exact-source";
+        let state = DaemonState::open_with_backend(
+            init.layout,
+            Box::new(CleanupFailOnceBackend::corrupt_source(
+                storage.path(),
+                b"wrong backend bytes".to_vec(),
+            )),
+            repo_id,
+            None,
+        )
+        .unwrap();
+        let expected_hash =
+            Hash256::from_bytes(kin_blobs::digest_bytes(b"expected exact source bytes"));
+        let change = SemanticChange {
+            id: SemanticChangeId::from_hash(Hash256::from_bytes([34; 32])),
+            parents: vec![],
+            author: AuthorId::new("tester"),
+            message: "corrupt backend source".to_string(),
+            timestamp: Timestamp::now(),
+            entity_deltas: vec![],
+            relation_deltas: vec![],
+            artifact_deltas: vec![ArtifactDelta {
+                file_id: FilePathId("src/lib.rs".to_string()),
+                kind: ArtifactDeltaKind::AddedRegularFile,
+                old_hash: None,
+                new_hash: Some(expected_hash),
+            }],
+            projected_files: vec![],
+            spec_link: None,
+            evidence: vec![],
+            risk_summary: None,
+            authored_on: None,
+        };
+
+        let error = state
+            .preflight_exact_source_change(&state.graph, &change)
+            .expect_err("backend bytes with the wrong digest must fail before graph mutation");
+        assert!(error.to_string().contains("do not match"));
+        assert!(state.graph.get_change(&change.id).unwrap().is_none());
+        assert_eq!(state.snapshot_generation.load(Ordering::SeqCst), 0);
+        assert!(LocalFileBackend::new(storage.path())
+            .load_snapshot(repo_id)
+            .unwrap()
+            .is_none());
+    }
+
+    #[test]
+    fn local_exact_source_preflight_accepts_verified_cas_bytes() {
+        let repo_dir = tempfile::tempdir().unwrap();
+        let init = kin_core::init(repo_dir.path()).unwrap();
+        let state = test_state(init.layout, repo_dir.path());
+        let bytes = b"verified local source\n";
+        let blob_hash = state.blobs.write(bytes).unwrap();
+        let hash = Hash256::from_bytes(blob_hash.0);
+        let change = exact_source_change(
+            35,
+            "src/lib.rs",
+            kin_model::ArtifactDeltaKind::AddedRegularFile,
+            hash,
+        );
+
+        state
+            .preflight_exact_source_change(&state.graph, &change)
+            .expect("verified local CAS bytes must satisfy exact-source preflight");
+    }
+
+    #[test]
+    fn local_exact_source_preflight_rejects_missing_and_corrupt_bytes_without_mutation() {
+        for corrupt in [false, true] {
+            let repo_dir = tempfile::tempdir().unwrap();
+            let init = kin_core::init(repo_dir.path()).unwrap();
+            let state = test_state(init.layout, repo_dir.path());
+            let expected = b"expected local source\n";
+            let hash = if corrupt {
+                let blob_hash = state.blobs.write(expected).unwrap();
+                let hash = Hash256::from_bytes(blob_hash.0);
+                std::fs::write(local_object_path(&state.layout, hash), b"corrupt bytes").unwrap();
+                hash
+            } else {
+                Hash256::from_bytes(kin_blobs::digest_bytes(expected))
+            };
+            let change = exact_source_change(
+                if corrupt { 36 } else { 37 },
+                "src/lib.rs",
+                kin_model::ArtifactDeltaKind::AddedRegularFile,
+                hash,
+            );
+            let root_before = state.graph.compute_root_hash();
+            let generation_before = state.snapshot_generation.load(Ordering::SeqCst);
+
+            let error = state
+                .preflight_exact_source_change(&state.graph, &change)
+                .expect_err("unavailable local CAS authority must fail closed");
+
+            assert!(error.to_string().contains("absent or corrupt"));
+            assert!(state.graph.get_change(&change.id).unwrap().is_none());
+            assert_eq!(state.graph.compute_root_hash(), root_before);
+            assert_eq!(
+                state.snapshot_generation.load(Ordering::SeqCst),
+                generation_before
+            );
+        }
+    }
+
+    #[test]
+    fn local_exact_source_preflight_rejects_unmaterializable_path_and_symlink() {
+        let cases = [
+            (
+                ".kin/authority",
+                kin_model::ArtifactDeltaKind::AddedRegularFile,
+                b"must not enter control state".as_slice(),
+            ),
+            (
+                "src/escape",
+                kin_model::ArtifactDeltaKind::AddedSymlink,
+                b"../../outside".as_slice(),
+            ),
+        ];
+
+        for (index, (file_id, kind, bytes)) in cases.into_iter().enumerate() {
+            let repo_dir = tempfile::tempdir().unwrap();
+            let init = kin_core::init(repo_dir.path()).unwrap();
+            let state = test_state(init.layout, repo_dir.path());
+            let blob_hash = state.blobs.write(bytes).unwrap();
+            let change = exact_source_change(
+                38 + index as u8,
+                file_id,
+                kind,
+                Hash256::from_bytes(blob_hash.0),
+            );
+            let root_before = state.graph.compute_root_hash();
+            let generation_before = state.snapshot_generation.load(Ordering::SeqCst);
+
+            let error = state
+                .preflight_exact_source_change(&state.graph, &change)
+                .expect_err("unsafe exact-source entries must fail before graph mutation");
+
+            assert!(error.to_string().contains("not materializable"));
+            assert!(state.graph.get_change(&change.id).unwrap().is_none());
+            assert_eq!(state.graph.compute_root_hash(), root_before);
+            assert_eq!(
+                state.snapshot_generation.load(Ordering::SeqCst),
+                generation_before
+            );
+        }
+    }
+
+    #[test]
+    fn local_exact_source_preflight_rejects_file_directory_collision() {
+        let repo_dir = tempfile::tempdir().unwrap();
+        let init = kin_core::init(repo_dir.path()).unwrap();
+        let state = test_state(init.layout, repo_dir.path());
+        let file_hash = Hash256::from_bytes(state.blobs.write(b"file bytes").unwrap().0);
+        let child_hash = Hash256::from_bytes(state.blobs.write(b"child bytes").unwrap().0);
+        let mut change = exact_source_change(
+            40,
+            "pkg",
+            kin_model::ArtifactDeltaKind::AddedRegularFile,
+            file_hash,
+        );
+        change.artifact_deltas.push(kin_model::ArtifactDelta {
+            file_id: FilePathId::new("pkg/lib.rs"),
+            kind: kin_model::ArtifactDeltaKind::AddedRegularFile,
+            old_hash: None,
+            new_hash: Some(child_hash),
+        });
+        let root_before = state.graph.compute_root_hash();
+        let generation_before = state.snapshot_generation.load(Ordering::SeqCst);
+
+        let error = state
+            .preflight_exact_source_change(&state.graph, &change)
+            .expect_err("a file and its descendant cannot form one materializable tree");
+
+        assert!(error.to_string().contains("not materializable"));
+        assert!(state.graph.get_change(&change.id).unwrap().is_none());
+        assert_eq!(state.graph.compute_root_hash(), root_before);
+        assert_eq!(
+            state.snapshot_generation.load(Ordering::SeqCst),
+            generation_before
+        );
+    }
+
+    #[test]
+    fn local_exact_source_preflight_rejects_parent_delta_tree_collision() {
+        let repo_dir = tempfile::tempdir().unwrap();
+        let init = kin_core::init(repo_dir.path()).unwrap();
+        let state = test_state(init.layout, repo_dir.path());
+        let child_hash = Hash256::from_bytes(state.blobs.write(b"parent child bytes").unwrap().0);
+        let parent = exact_source_change(
+            41,
+            "pkg/lib.rs",
+            kin_model::ArtifactDeltaKind::AddedRegularFile,
+            child_hash,
+        );
+        state.graph.create_change(&parent).unwrap();
+
+        let file_hash = Hash256::from_bytes(state.blobs.write(b"incoming file bytes").unwrap().0);
+        let mut incoming = exact_source_change(
+            42,
+            "pkg",
+            kin_model::ArtifactDeltaKind::AddedRegularFile,
+            file_hash,
+        );
+        incoming.parents = vec![parent.id];
+        let root_before = state.graph.compute_root_hash();
+
+        let error = state
+            .preflight_exact_source_change(&state.graph, &incoming)
+            .expect_err("the complete parent plus delta tree must be materializable");
+
+        assert!(error.to_string().contains("not materializable"));
+        assert!(state.graph.get_change(&incoming.id).unwrap().is_none());
+        assert_eq!(state.graph.compute_root_hash(), root_before);
+    }
+
+    #[test]
+    fn local_exact_source_preflight_rejects_merge_parent_tree_collision() {
+        let repo_dir = tempfile::tempdir().unwrap();
+        let init = kin_core::init(repo_dir.path()).unwrap();
+        let state = test_state(init.layout, repo_dir.path());
+        let child_hash = Hash256::from_bytes(state.blobs.write(b"left child bytes").unwrap().0);
+        let left = exact_source_change(
+            43,
+            "pkg/lib.rs",
+            kin_model::ArtifactDeltaKind::AddedRegularFile,
+            child_hash,
+        );
+        let file_hash = Hash256::from_bytes(state.blobs.write(b"right file bytes").unwrap().0);
+        let right = exact_source_change(
+            44,
+            "pkg",
+            kin_model::ArtifactDeltaKind::AddedRegularFile,
+            file_hash,
+        );
+        state.graph.create_change(&left).unwrap();
+        state.graph.create_change(&right).unwrap();
+
+        let mut merge = exact_source_change(
+            45,
+            "merge-marker.txt",
+            kin_model::ArtifactDeltaKind::AddedRegularFile,
+            Hash256::from_bytes(state.blobs.write(b"merge marker").unwrap().0),
+        );
+        merge.parents = vec![left.id, right.id];
+        let root_before = state.graph.compute_root_hash();
+
+        let error = state
+            .preflight_exact_source_change(&state.graph, &merge)
+            .expect_err("all merge parents must participate in prospective tree validation");
+
+        assert!(error.to_string().contains("not materializable"));
+        assert!(state.graph.get_change(&merge.id).unwrap().is_none());
+        assert_eq!(state.graph.compute_root_hash(), root_before);
     }
 
     #[test]

--- a/crates/kin-daemon/tests/chaos_recovery.rs
+++ b/crates/kin-daemon/tests/chaos_recovery.rs
@@ -168,6 +168,7 @@ async fn wait_for_path_removed(path: &Path, what: &str, timeout: Duration) {
 async fn create_branch(repo_root: &Path, port: u16, name: &str) {
     let client = reqwest::Client::new();
     let url = format!("http://127.0.0.1:{port}/graph/branches");
+    let genesis = kin_core::build_genesis_change().id.to_string();
     let deadline = Instant::now() + Duration::from_secs(30);
     let mut backoff = Duration::from_millis(50);
 
@@ -183,7 +184,7 @@ async fn create_branch(repo_root: &Path, port: u16, name: &str) {
             .filter(|token| !token.is_empty());
         let mut request = client.post(&url).json(&serde_json::json!({
             "name": name,
-            "head": "0000000000000000000000000000000000000000000000000000000000000001"
+            "head": genesis
         }));
         if let Some(token) = token {
             request = request.bearer_auth(token);

--- a/crates/kin-git/src/cochange.rs
+++ b/crates/kin-git/src/cochange.rs
@@ -14,7 +14,9 @@ use sha2::{Digest, Sha256};
 
 use crate::error::{GitError, Result};
 use crate::genesis::is_genesis_change;
-use crate::import::{commit_file_deltas, select_history_oids_from_head};
+use crate::import::{
+    commit_file_deltas, select_bounded_history_oids_from_head, select_history_oids_from_head,
+};
 
 const MAX_ENTITIES_PER_FILE: usize = 8;
 
@@ -92,19 +94,20 @@ where
         }
         Err(err) => return Err(GitError::Git(err.to_string())),
     };
-    let walk = repo
-        .rev_walk([head_id])
-        .sorting(gix::revision::walk::Sorting::ByCommitTime(
-            Default::default(),
-        ))
-        .all()
-        .map_err(|e| GitError::Git(e.to_string()))?;
-
-    // Phase 1: collect the full walk, then select the same deterministic,
-    // HEAD-rooted ancestry window used by semantic-history import. This keeps
-    // co-change evidence aligned with the commits present in recent history.
-    let oids: Vec<gix::ObjectId> = {
+    // Phase 1: select the same deterministic, HEAD-rooted ancestry window used
+    // by semantic-history import. Bounded mode expands directly from HEAD so a
+    // 50-commit request never scans or retains the full repository history.
+    let oids: Vec<gix::ObjectId> = if max_commits > 0 {
+        select_bounded_history_oids_from_head(&repo, head_id, max_commits)?
+    } else {
         let _span = tracing::info_span!("kin.git.cochange.collect_oids").entered();
+        let walk = repo
+            .rev_walk([head_id])
+            .sorting(gix::revision::walk::Sorting::ByCommitTime(
+                Default::default(),
+            ))
+            .all()
+            .map_err(|e| GitError::Git(e.to_string()))?;
         let timed: Vec<(i64, gix::ObjectId)> = walk
             .map(|r| {
                 r.map(|info| (info.commit_time.unwrap_or(0), info.id().detach()))
@@ -453,6 +456,10 @@ mod tests {
                     .output();
                 let _ = Command::new("git")
                     .args(["config", "user.name", "Test"])
+                    .current_dir(dir)
+                    .output();
+                let _ = Command::new("git")
+                    .args(["config", "core.hooksPath", ".git/no-hooks"])
                     .current_dir(dir)
                     .output();
                 true

--- a/crates/kin-git/src/export.rs
+++ b/crates/kin-git/src/export.rs
@@ -9,8 +9,8 @@ use std::time::Duration;
 use gix::objs::tree::{Entry, EntryKind, EntryMode};
 use gix::objs::{Commit, Tree};
 use kin_blobs::BlobStore;
-use kin_model::{ArtifactDeltaKind, BranchName, GraphStore, SemanticChange, SemanticChangeId};
-use tracing::{debug, info, warn};
+use kin_model::{BranchName, GraphStore, SemanticChange, SemanticChangeId, SourceEntryKind};
+use tracing::{debug, info};
 
 use crate::error::{GitError, Result};
 use crate::genesis::is_genesis_change;
@@ -126,8 +126,11 @@ pub fn export_changes(
 
     let mut commits_exported = 0usize;
     let commits_skipped = 0usize;
-    // Track the cumulative file state across all changes for tree building.
-    let mut file_state: BTreeMap<String, Vec<u8>> = BTreeMap::new();
+    // Track one immutable file state per semantic change. A single cumulative
+    // map contaminates sibling branches: exporting sibling B after sibling A
+    // would incorrectly include A-only files in B's Git tree.
+    let mut file_states: HashMap<SemanticChangeId, BTreeMap<String, SourceFileState>> =
+        HashMap::new();
     let mut last_commit_id: Option<gix::ObjectId> = existing_head;
 
     for change in changes {
@@ -137,8 +140,18 @@ pub fn export_changes(
             continue;
         }
 
-        // Apply artifact deltas to our file state.
-        apply_artifact_deltas(change, blob_store, &mut file_state);
+        // Reconstruct this change from its own parent states. Parent order is
+        // deterministic; later parents fill/replace paths before the change's
+        // own deltas apply. Exact imported merges carry a full correction.
+        let mut file_state = BTreeMap::new();
+        for parent in &change.parents {
+            if let Some(parent_state) = file_states.get(parent) {
+                for (path, source) in parent_state {
+                    file_state.insert(path.clone(), source.clone());
+                }
+            }
+        }
+        apply_artifact_deltas(change, blob_store, &mut file_state)?;
 
         // Build the Git tree from the current file state.
         let tree_id = build_tree(&git_repo, &file_state)?;
@@ -158,6 +171,7 @@ pub fn export_changes(
         );
 
         change_to_commit.insert(change.id, commit_id);
+        file_states.insert(change.id, file_state);
         last_commit_id = Some(commit_id);
         commits_exported += 1;
     }
@@ -188,32 +202,36 @@ pub fn export_changes(
 fn apply_artifact_deltas(
     change: &SemanticChange,
     blob_store: &BlobStore,
-    file_state: &mut BTreeMap<String, Vec<u8>>,
-) {
+    file_state: &mut BTreeMap<String, SourceFileState>,
+) -> Result<()> {
     for delta in &change.artifact_deltas {
-        match delta.kind {
-            ArtifactDeltaKind::Removed => {
-                file_state.remove(&delta.file_id.0);
-            }
-            ArtifactDeltaKind::Added | ArtifactDeltaKind::Modified => {
-                if let Some(hash) = &delta.new_hash {
-                    match blob_store.read(&kin_blobs::Hash256(hash.0)) {
-                        Ok(content) => {
-                            file_state.insert(delta.file_id.0.clone(), content);
-                        }
-                        Err(e) => {
-                            warn!(
-                                hash = %hash,
-                                file = %delta.file_id,
-                                error = %e,
-                                "blob not found for artifact delta, skipping"
-                            );
-                        }
-                    }
-                }
-            }
+        if delta.kind.is_removed() {
+            file_state.remove(&delta.file_id.0);
+            continue;
         }
+        let kind = delta.kind.source_entry_kind().ok_or_else(|| {
+            GitError::Other(format!(
+                "cannot export legacy mode-unknown artifact delta for {} in change {}; exact source mode backfill is required",
+                delta.file_id, change.id
+            ))
+        })?;
+        let hash = delta.new_hash.ok_or_else(|| {
+            GitError::Other(format!(
+                "cannot export artifact delta for {} in change {} without an exact content identity",
+                delta.file_id, change.id
+            ))
+        })?;
+        let content = blob_store
+            .read(&kin_blobs::Hash256(hash.0))
+            .map_err(|error| {
+                GitError::Other(format!(
+                    "cannot export exact source blob {} for {} in change {}: {error}",
+                    hash, delta.file_id, change.id
+                ))
+            })?;
+        file_state.insert(delta.file_id.0.clone(), SourceFileState { content, kind });
     }
+    Ok(())
 }
 
 /// Build a Git tree object from a flat map of file paths to contents.
@@ -221,7 +239,7 @@ fn apply_artifact_deltas(
 /// Handles nested directory structures by creating intermediate tree objects.
 fn build_tree(
     repo: &gix::Repository,
-    file_state: &BTreeMap<String, Vec<u8>>,
+    file_state: &BTreeMap<String, SourceFileState>,
 ) -> Result<gix::ObjectId> {
     if file_state.is_empty() {
         // Return the well-known empty tree hash.
@@ -233,17 +251,20 @@ fn build_tree(
     let mut dir_entries: BTreeMap<String, Vec<(String, DirEntry)>> = BTreeMap::new();
 
     // First pass: write all blobs and record them with their directory.
-    for (path, content) in file_state {
+    for (path, source) in file_state {
         let blob_id = repo
-            .write_blob(content)
+            .write_blob(&source.content)
             .map_err(|e| GitError::Git(e.to_string()))?
             .detach();
 
         let (dir, filename) = split_path(path);
-        dir_entries
-            .entry(dir)
-            .or_default()
-            .push((filename, DirEntry::Blob(blob_id)));
+        dir_entries.entry(dir).or_default().push((
+            filename,
+            DirEntry::Source {
+                id: blob_id,
+                kind: source.kind,
+            },
+        ));
     }
 
     // Build trees bottom-up: process deepest directories first.
@@ -298,9 +319,15 @@ fn build_tree(
         if let Some(file_entries) = dir_entries.get(dir) {
             for (name, entry) in file_entries {
                 match entry {
-                    DirEntry::Blob(id) => {
+                    DirEntry::Source { id, kind } => {
                         entries.push(Entry {
-                            mode: EntryMode::from(EntryKind::Blob),
+                            mode: EntryMode::from(match kind {
+                                SourceEntryKind::File { executable: false } => EntryKind::Blob,
+                                SourceEntryKind::File { executable: true } => {
+                                    EntryKind::BlobExecutable
+                                }
+                                SourceEntryKind::Symlink => EntryKind::Link,
+                            }),
                             filename: name.clone().into(),
                             oid: *id,
                         });
@@ -340,9 +367,18 @@ fn build_tree(
         .ok_or_else(|| GitError::Other("failed to build root tree".to_string()))
 }
 
+#[derive(Debug, Clone)]
+struct SourceFileState {
+    content: Vec<u8>,
+    kind: SourceEntryKind,
+}
+
 #[derive(Debug)]
 enum DirEntry {
-    Blob(gix::ObjectId),
+    Source {
+        id: gix::ObjectId,
+        kind: SourceEntryKind,
+    },
 }
 
 /// Split a path into (directory, filename).
@@ -1483,6 +1519,21 @@ mod tests {
         object.data.clone()
     }
 
+    fn entry_kind_from_commit(
+        repo_path: &Path,
+        commit_oid: gix::ObjectId,
+        path: &str,
+    ) -> EntryKind {
+        let repo = gix::open(repo_path).unwrap();
+        let commit = repo.find_commit(commit_oid).unwrap();
+        let tree = commit.tree().unwrap();
+        tree.lookup_entry_by_path(path)
+            .unwrap()
+            .expect("entry not found")
+            .mode()
+            .kind()
+    }
+
     // -- Tests --
 
     #[test]
@@ -1525,7 +1576,7 @@ mod tests {
             "add greeting",
             vec![make_delta(
                 "hello.txt",
-                ArtifactDeltaKind::Added,
+                ArtifactDeltaKind::AddedRegularFile,
                 Some(hash),
             )],
         );
@@ -1558,6 +1609,102 @@ mod tests {
     }
 
     #[test]
+    fn export_preserves_regular_executable_and_symlink_modes() {
+        let tmp = tempfile::tempdir().unwrap();
+        let blob_store = make_blob_store(tmp.path());
+        let genesis = make_genesis();
+        let regular_hash = store_blob(&blob_store, b"plain\n");
+        let executable_hash = store_blob(&blob_store, b"#!/bin/sh\necho exact\n");
+        let symlink_hash = store_blob(&blob_store, b"plain.txt");
+        let change = make_change(
+            1,
+            vec![genesis.id],
+            "add exact source modes",
+            vec![
+                make_delta(
+                    "plain.txt",
+                    ArtifactDeltaKind::AddedRegularFile,
+                    Some(regular_hash),
+                ),
+                make_delta(
+                    "run.sh",
+                    ArtifactDeltaKind::AddedExecutableFile,
+                    Some(executable_hash),
+                ),
+                make_delta(
+                    "plain-link",
+                    ArtifactDeltaKind::AddedSymlink,
+                    Some(symlink_hash),
+                ),
+            ],
+        );
+        let branch_name = BranchName::new("main");
+        let graph = MockGraph::with_branch_and_changes("main", change.id, vec![genesis, change]);
+        let git_path = tmp.path().join("repo.git");
+        export_to_git(
+            &graph,
+            &blob_store,
+            make_genesis().id,
+            &branch_name,
+            &git_path,
+        )
+        .unwrap();
+
+        let repo = gix::open(&git_path).unwrap();
+        let head = repo
+            .find_reference("refs/heads/main")
+            .unwrap()
+            .id()
+            .detach();
+        assert_eq!(
+            entry_kind_from_commit(&git_path, head, "plain.txt"),
+            EntryKind::Blob
+        );
+        assert_eq!(
+            entry_kind_from_commit(&git_path, head, "run.sh"),
+            EntryKind::BlobExecutable
+        );
+        assert_eq!(
+            entry_kind_from_commit(&git_path, head, "plain-link"),
+            EntryKind::Link
+        );
+        assert_eq!(
+            read_file_from_commit(&git_path, head, "plain-link"),
+            b"plain.txt"
+        );
+    }
+
+    #[test]
+    fn export_rejects_legacy_mode_unknown_deltas() {
+        let tmp = tempfile::tempdir().unwrap();
+        let blob_store = make_blob_store(tmp.path());
+        let genesis = make_genesis();
+        let hash = store_blob(&blob_store, b"legacy\n");
+        let change = make_change(
+            1,
+            vec![genesis.id],
+            "legacy source",
+            vec![make_delta(
+                "legacy.txt",
+                ArtifactDeltaKind::Added,
+                Some(hash),
+            )],
+        );
+        let branch_name = BranchName::new("main");
+        let graph =
+            MockGraph::with_branch_and_changes("main", change.id, vec![genesis.clone(), change]);
+        let error = export_to_git(
+            &graph,
+            &blob_store,
+            genesis.id,
+            &branch_name,
+            &tmp.path().join("repo.git"),
+        )
+        .expect_err("legacy mode-unknown history must not be normalized during export");
+        assert!(error.to_string().contains("mode-unknown"));
+    }
+
+    #[test]
     fn export_multi_change_chain() {
         let tmp = tempfile::tempdir().unwrap();
         let blob_store = make_blob_store(tmp.path());
@@ -1570,7 +1717,7 @@ mod tests {
             "initial file",
             vec![make_delta(
                 "file.txt",
-                ArtifactDeltaKind::Added,
+                ArtifactDeltaKind::AddedRegularFile,
                 Some(hash1),
             )],
         );
@@ -1582,7 +1729,7 @@ mod tests {
             "update file",
             vec![make_delta(
                 "file.txt",
-                ArtifactDeltaKind::Modified,
+                ArtifactDeltaKind::ModifiedRegularFile,
                 Some(hash2),
             )],
         );
@@ -1594,7 +1741,7 @@ mod tests {
             "add another file",
             vec![make_delta(
                 "src/lib.rs",
-                ArtifactDeltaKind::Added,
+                ArtifactDeltaKind::AddedRegularFile,
                 Some(hash3),
             )],
         );
@@ -1659,7 +1806,7 @@ mod tests {
             "feature work",
             vec![make_delta(
                 "feature.rs",
-                ArtifactDeltaKind::Added,
+                ArtifactDeltaKind::AddedRegularFile,
                 Some(hash),
             )],
         );
@@ -1964,7 +2111,7 @@ mod tests {
             "first commit",
             vec![make_delta(
                 "file.txt",
-                ArtifactDeltaKind::Added,
+                ArtifactDeltaKind::AddedRegularFile,
                 Some(hash1),
             )],
         );
@@ -1987,7 +2134,7 @@ mod tests {
             "second commit",
             vec![make_delta(
                 "file.txt",
-                ArtifactDeltaKind::Modified,
+                ArtifactDeltaKind::ModifiedRegularFile,
                 Some(hash2),
             )],
         );
@@ -2031,7 +2178,11 @@ mod tests {
             1,
             vec![genesis.id],
             "add file",
-            vec![make_delta("temp.txt", ArtifactDeltaKind::Added, Some(hash))],
+            vec![make_delta(
+                "temp.txt",
+                ArtifactDeltaKind::AddedRegularFile,
+                Some(hash),
+            )],
         );
 
         let change2 = make_change(
@@ -2084,9 +2235,21 @@ mod tests {
             vec![genesis.id],
             "add nested files",
             vec![
-                make_delta("src/lib/mod.rs", ArtifactDeltaKind::Added, Some(hash1)),
-                make_delta("src/main.rs", ArtifactDeltaKind::Added, Some(hash2)),
-                make_delta("README.md", ArtifactDeltaKind::Added, Some(hash3)),
+                make_delta(
+                    "src/lib/mod.rs",
+                    ArtifactDeltaKind::AddedRegularFile,
+                    Some(hash1),
+                ),
+                make_delta(
+                    "src/main.rs",
+                    ArtifactDeltaKind::AddedRegularFile,
+                    Some(hash2),
+                ),
+                make_delta(
+                    "README.md",
+                    ArtifactDeltaKind::AddedRegularFile,
+                    Some(hash3),
+                ),
             ],
         );
 

--- a/crates/kin-git/src/import.rs
+++ b/crates/kin-git/src/import.rs
@@ -9,13 +9,36 @@ use chrono::TimeZone;
 use kin_blobs::BlobStore;
 use kin_model::{
     ArtifactDelta, ArtifactDeltaKind, AuthorId, BranchName, FilePathId, Hash256, SemanticChange,
-    SemanticChangeId, Timestamp,
+    SemanticChangeId, SourceEntryKind, Timestamp,
 };
 use rayon::prelude::*;
 use sha2::{Digest, Sha256};
 use tracing::{debug, info};
 
 use crate::error::{GitError, Result};
+
+const MAX_BASE_LINK_ANCHORS: usize = 64;
+const MAX_BASE_LINK_TREE_ENTRIES: usize = 100_000;
+const MAX_BASE_LINK_EXPANDED_BYTES: u64 = 256 * 1024 * 1024;
+
+fn enforce_base_link_budget(anchors: usize, entries: usize, expanded_bytes: u64) -> Result<()> {
+    if anchors > MAX_BASE_LINK_ANCHORS {
+        return Err(GitError::Other(format!(
+            "truncated Git history requires {anchors} boundary anchors; limit is {MAX_BASE_LINK_ANCHORS}"
+        )));
+    }
+    if entries > MAX_BASE_LINK_TREE_ENTRIES {
+        return Err(GitError::Other(format!(
+            "truncated Git history boundary contains {entries} source entries; limit is {MAX_BASE_LINK_TREE_ENTRIES}"
+        )));
+    }
+    if expanded_bytes > MAX_BASE_LINK_EXPANDED_BYTES {
+        return Err(GitError::Other(format!(
+            "truncated Git history boundary contains {expanded_bytes} source bytes; limit is {MAX_BASE_LINK_EXPANDED_BYTES}"
+        )));
+    }
+    Ok(())
+}
 
 fn open_repo(path: &Path) -> std::result::Result<gix::Repository, gix::open::Error> {
     let dot_git = path.join(".git");
@@ -26,11 +49,22 @@ fn open_repo(path: &Path) -> std::result::Result<gix::Repository, gix::open::Err
     }
 }
 
+fn shallow_boundary_ids(repo: &gix::Repository) -> Result<HashSet<gix::ObjectId>> {
+    let commits = repo
+        .shallow_commits()
+        .map_err(|error| GitError::Git(format!("read shallow boundary: {error}")))?;
+    Ok(commits
+        .as_ref()
+        .map(|commits| commits.iter().copied().collect())
+        .unwrap_or_default())
+}
+
 #[derive(Debug, Clone)]
 pub(crate) struct CommitFileDelta {
     pub path: String,
     pub old_blob_id: Option<gix::ObjectId>,
     pub new_blob_id: Option<gix::ObjectId>,
+    pub new_entry_kind: Option<SourceEntryKind>,
 }
 
 /// Options for importing Git history into Kin.
@@ -68,6 +102,18 @@ fn change_id_from_git_oid(oid: &gix::ObjectId) -> SemanticChangeId {
     let mut bytes = [0u8; 32];
     bytes.copy_from_slice(&result);
     SemanticChangeId::from_hash(Hash256::from_bytes(bytes))
+}
+
+fn timestamp_from_git_seconds(seconds: i64, oid: &gix::ObjectId) -> Result<Timestamp> {
+    chrono::Utc
+        .timestamp_opt(seconds, 0)
+        .single()
+        .map(Timestamp::from)
+        .ok_or_else(|| {
+            GitError::Git(format!(
+                "Git commit {oid} has author timestamp {seconds} outside Kin's supported range"
+            ))
+        })
 }
 
 /// Compute the deterministic imported SemanticChangeId for a Git commit hash.
@@ -408,6 +454,59 @@ pub(crate) fn select_history_oids_from_head(
     Ok(selected)
 }
 
+/// Select a deterministic HEAD-rooted history window without first walking or
+/// retaining the repository's full reachable history. Only selected commits
+/// and their immediate frontier parents are inspected.
+pub(crate) fn select_bounded_history_oids_from_head(
+    repo: &gix::Repository,
+    head_id: gix::ObjectId,
+    max_commits: usize,
+) -> Result<Vec<gix::ObjectId>> {
+    debug_assert!(max_commits > 0);
+    let commit_time = |oid: gix::ObjectId| -> Result<i64> {
+        repo.find_commit(oid)
+            .map_err(|error| GitError::CommitNotFound(format!("{oid}: {error}")))?
+            .time()
+            .map(|time| time.seconds)
+            .map_err(|error| GitError::Git(error.to_string()))
+    };
+    let shallow_boundaries = shallow_boundary_ids(repo)?;
+    let mut frontier = BTreeSet::from([(Reverse(commit_time(head_id)?), head_id)]);
+    let mut selected = Vec::with_capacity(max_commits);
+    let mut selected_set = HashSet::new();
+
+    while selected.len() < max_commits {
+        let Some(candidate) = frontier.iter().next().copied() else {
+            break;
+        };
+        frontier.remove(&candidate);
+        let oid = candidate.1;
+        if !selected_set.insert(oid) {
+            continue;
+        }
+        selected.push(oid);
+        if selected.len() == max_commits {
+            break;
+        }
+        if shallow_boundaries.contains(&oid) {
+            continue;
+        }
+
+        let commit = repo
+            .find_commit(oid)
+            .map_err(|error| GitError::CommitNotFound(format!("{oid}: {error}")))?;
+        for parent in commit.parent_ids().map(|parent| parent.detach()) {
+            if selected_set.contains(&parent)
+                || frontier.iter().any(|(_, candidate)| *candidate == parent)
+            {
+                continue;
+            }
+            frontier.insert((Reverse(commit_time(parent)?), parent));
+        }
+    }
+    Ok(selected)
+}
+
 /// Full history import: walk commits in deterministic topological order.
 fn import_full(
     repo: &gix::Repository,
@@ -424,24 +523,23 @@ fn import_full(
     )
     .entered();
 
-    // Walk commits by commit time (approximates parent-before-child order).
-    let walk = repo
-        .rev_walk([head_id])
-        .sorting(gix::revision::walk::Sorting::ByCommitTime(
-            Default::default(),
-        ))
-        .all()
-        .map_err(|e| GitError::Git(e.to_string()))?;
-
-    // Phase 1: collect every commit as (commit time, oid), then select a
-    // deterministic ancestry-connected window by expanding from HEAD. A raw
-    // `ByCommitTime` walk leaves equal-timestamp commits in a process-dependent
-    // order, while global oid truncation can drop HEAD or disconnect the chosen
-    // set. Selection order is not emission order: once the set is fixed, a
-    // deterministic Kahn pass below emits every selected parent before its
-    // selected children, using oid order only among simultaneously ready nodes.
-    let oids: Vec<gix::ObjectId> = {
+    // Phase 1: bounded mode expands a deterministic ancestry-connected window
+    // directly from HEAD; unlimited mode collects the complete walk. Selection
+    // order is not emission order: once the set is fixed, a deterministic Kahn
+    // pass emits every selected parent before its selected children, using oid
+    // order only among simultaneously ready nodes.
+    let oids: Vec<gix::ObjectId> = if max_commits > 0 {
+        let selected = select_bounded_history_oids_from_head(repo, head_id, max_commits)?;
+        order_selected_oids_parent_first(repo, selected)?
+    } else {
         let _span = tracing::info_span!("kin.git.import_full.collect_oids").entered();
+        let walk = repo
+            .rev_walk([head_id])
+            .sorting(gix::revision::walk::Sorting::ByCommitTime(
+                Default::default(),
+            ))
+            .all()
+            .map_err(|e| GitError::Git(e.to_string()))?;
         let timed: Vec<(i64, gix::ObjectId)> = walk
             .map(|r| {
                 r.map(|info| (info.commit_time.unwrap_or(0), info.id().detach()))
@@ -451,6 +549,7 @@ fn import_full(
         let selected = select_history_oids_from_head(repo, head_id, timed, max_commits)?;
         order_selected_oids_parent_first(repo, selected)?
     };
+    let shallow_boundaries = shallow_boundary_ids(repo)?;
 
     // Phase 2: map each commit to an ImportedChange in parallel. Each commit's
     // mapping is independent (deterministic change_id from its OID, parents from
@@ -493,7 +592,7 @@ fn import_full(
                         .map_err(|e| GitError::Git(e.to_string()))?,
                 }
                 .into_commit();
-                let is_root = commit.parent_ids().count() == 0;
+                let is_root = commit.parent_ids().count() == 0 || shallow_boundaries.contains(oid);
                 let change = commit_to_change(&local, &commit, genesis_id, is_root, blob_store)?;
                 let oid_str = oid.to_string();
                 debug!(git_oid = %oid_str, kin_id = %change.id, parents = change.parents.len(), "imported commit");
@@ -542,13 +641,14 @@ fn import_full_serial(
         .collect::<Result<Vec<_>>>()?;
     let selected = select_history_oids_from_head(repo, head_id, timed, max_commits)?;
     let oids = order_selected_oids_parent_first(repo, selected)?;
+    let shallow_boundaries = shallow_boundary_ids(repo)?;
 
     for oid in &oids {
         let commit = repo
             .find_object(*oid)
             .map_err(|e| GitError::Git(e.to_string()))?
             .into_commit();
-        let is_root = commit.parent_ids().count() == 0;
+        let is_root = commit.parent_ids().count() == 0 || shallow_boundaries.contains(oid);
         let change = commit_to_change(repo, &commit, genesis_id, is_root, blob_store)?;
         changes.push(ImportedChange {
             change,
@@ -636,11 +736,7 @@ fn commit_to_change(
     let git_time = author_sig
         .time()
         .map_err(|e| GitError::Git(e.to_string()))?;
-    let dt = chrono::Utc
-        .timestamp_opt(git_time.seconds, 0)
-        .single()
-        .unwrap_or_else(chrono::Utc::now);
-    let timestamp = Timestamp::from(dt);
+    let timestamp = timestamp_from_git_seconds(git_time.seconds, &oid)?;
 
     // Extract commit message.
     let message = commit
@@ -648,11 +744,18 @@ fn commit_to_change(
         .map_err(|e| GitError::Git(e.to_string()))?
         .to_string();
 
-    // Compute artifact deltas by examining the commit's tree.
-    // For a full import, we'd diff against parent trees. For now, we record
-    // file paths from the tree as artifact deltas (the indexing pipeline
-    // will later enrich these with entity extraction).
-    let artifact_deltas = extract_artifact_deltas(repo, commit, blob_store)?;
+    // A synthetic import root (shallow import or a real Git root) must carry
+    // the complete tree. A merge must also carry a full correction relative
+    // to the union of all direct-parent trees: semantic history replays the
+    // complete DAG, while a Git merge diff against only its first parent can
+    // otherwise leak second-parent content that the merge did not select.
+    let artifact_deltas = if is_root {
+        extract_full_tree_artifact_deltas(repo, commit, blob_store)?
+    } else if commit.parent_ids().count() > 1 {
+        extract_merge_artifact_deltas(repo, commit, blob_store)?
+    } else {
+        extract_artifact_deltas(repo, commit, blob_store)?
+    };
 
     let authored_on = if is_root {
         Some(BranchName::new("main"))
@@ -681,6 +784,46 @@ fn commit_to_change(
 ///
 /// For root commits (no parents), all files in the tree are "Added".
 /// For non-root commits, we diff against the first parent's tree.
+fn source_entry_kind(mode: gix::objs::tree::EntryMode) -> Result<Option<SourceEntryKind>> {
+    use gix::objs::tree::EntryKind;
+
+    match mode.kind() {
+        EntryKind::Blob => Ok(Some(SourceEntryKind::File { executable: false })),
+        EntryKind::BlobExecutable => Ok(Some(SourceEntryKind::File { executable: true })),
+        EntryKind::Link => Ok(Some(SourceEntryKind::Symlink)),
+        EntryKind::Tree => Ok(None),
+        EntryKind::Commit => Err(GitError::Other(
+            "exact Git import does not yet support gitlink/submodule entries; import refused rather than silently omitting source state"
+                .to_string(),
+        )),
+    }
+}
+
+fn utf8_git_path(path: &[u8]) -> Result<String> {
+    std::str::from_utf8(path).map(str::to_owned).map_err(|_| {
+        GitError::Other(
+            "exact Git import encountered a non-UTF-8 path; import refused rather than recording a lossy source identity"
+                .to_string(),
+        )
+    })
+}
+
+fn added_artifact_kind(kind: SourceEntryKind) -> ArtifactDeltaKind {
+    match kind {
+        SourceEntryKind::File { executable: false } => ArtifactDeltaKind::AddedRegularFile,
+        SourceEntryKind::File { executable: true } => ArtifactDeltaKind::AddedExecutableFile,
+        SourceEntryKind::Symlink => ArtifactDeltaKind::AddedSymlink,
+    }
+}
+
+fn modified_artifact_kind(kind: SourceEntryKind) -> ArtifactDeltaKind {
+    match kind {
+        SourceEntryKind::File { executable: false } => ArtifactDeltaKind::ModifiedRegularFile,
+        SourceEntryKind::File { executable: true } => ArtifactDeltaKind::ModifiedExecutableFile,
+        SourceEntryKind::Symlink => ArtifactDeltaKind::ModifiedSymlink,
+    }
+}
+
 fn extract_artifact_deltas(
     repo: &gix::Repository,
     commit: &gix::Commit<'_>,
@@ -688,11 +831,11 @@ fn extract_artifact_deltas(
 ) -> Result<Vec<ArtifactDelta>> {
     let mut deltas = Vec::new();
     for delta in commit_file_deltas(repo, commit)? {
-        let kind = match (delta.old_blob_id, delta.new_blob_id) {
-            (None, Some(_)) => ArtifactDeltaKind::Added,
-            (Some(_), None) => ArtifactDeltaKind::Removed,
-            (Some(_), Some(_)) => ArtifactDeltaKind::Modified,
-            (None, None) => continue,
+        let kind = match (delta.old_blob_id, delta.new_blob_id, delta.new_entry_kind) {
+            (None, Some(_), Some(entry_kind)) => added_artifact_kind(entry_kind),
+            (Some(_), None, None) => ArtifactDeltaKind::Removed,
+            (Some(_), Some(_), Some(entry_kind)) => modified_artifact_kind(entry_kind),
+            _ => continue,
         };
 
         let old_hash = match delta.old_blob_id {
@@ -712,6 +855,91 @@ fn extract_artifact_deltas(
         });
     }
 
+    Ok(deltas)
+}
+
+fn extract_full_tree_artifact_deltas(
+    repo: &gix::Repository,
+    commit: &gix::Commit<'_>,
+    blob_store: Option<&BlobStore>,
+) -> Result<Vec<ArtifactDelta>> {
+    let tree = commit
+        .tree()
+        .map_err(|error| GitError::Git(error.to_string()))?;
+    full_tree_blob_entries(repo, &tree)?
+        .into_iter()
+        .map(|(path, blob_id, kind)| {
+            Ok(ArtifactDelta {
+                file_id: FilePathId::new(path),
+                kind: added_artifact_kind(kind),
+                old_hash: None,
+                new_hash: Some(blob_hash(repo, blob_id, blob_store)?),
+            })
+        })
+        .collect()
+}
+
+/// Encode a merge as a complete correction over the union of its direct
+/// parent trees. This makes the semantic DAG replay converge on the exact Git
+/// merge tree regardless of sibling topological order.
+fn extract_merge_artifact_deltas(
+    repo: &gix::Repository,
+    commit: &gix::Commit<'_>,
+    blob_store: Option<&BlobStore>,
+) -> Result<Vec<ArtifactDelta>> {
+    let current_tree = commit
+        .tree()
+        .map_err(|error| GitError::Git(error.to_string()))?;
+    let current: BTreeMap<String, (gix::ObjectId, SourceEntryKind)> =
+        full_tree_blob_entries(repo, &current_tree)?
+            .into_iter()
+            .map(|(path, id, kind)| (path, (id, kind)))
+            .collect();
+
+    // Parent order is Git-authoritative. Keep the first occurrence of a path
+    // only to provide deterministic old_hash metadata; replay correctness is
+    // supplied by the complete remove/upsert correction below.
+    let mut parent_union: BTreeMap<String, (gix::ObjectId, SourceEntryKind)> = BTreeMap::new();
+    for parent_id in commit.parent_ids() {
+        let parent = repo
+            .find_commit(parent_id.detach())
+            .map_err(|error| GitError::Git(error.to_string()))?;
+        let parent_tree = parent
+            .tree()
+            .map_err(|error| GitError::Git(error.to_string()))?;
+        for (path, id, kind) in full_tree_blob_entries(repo, &parent_tree)? {
+            parent_union.entry(path).or_insert((id, kind));
+        }
+    }
+
+    let mut deltas = Vec::with_capacity(current.len() + parent_union.len());
+    for (path, (old_id, _)) in &parent_union {
+        if !current.contains_key(path) {
+            deltas.push(ArtifactDelta {
+                file_id: FilePathId::new(path),
+                kind: ArtifactDeltaKind::Removed,
+                old_hash: Some(blob_hash(repo, *old_id, blob_store)?),
+                new_hash: None,
+            });
+        }
+    }
+    for (path, (new_id, new_kind)) in current {
+        let old_hash = parent_union
+            .get(&path)
+            .map(|(old_id, _)| blob_hash(repo, *old_id, blob_store))
+            .transpose()?;
+        deltas.push(ArtifactDelta {
+            file_id: FilePathId::new(path),
+            kind: if old_hash.is_some() {
+                modified_artifact_kind(new_kind)
+            } else {
+                added_artifact_kind(new_kind)
+            },
+            old_hash,
+            new_hash: Some(blob_hash(repo, new_id, blob_store)?),
+        });
+    }
+    deltas.sort_by(|left, right| left.file_id.0.cmp(&right.file_id.0));
     Ok(deltas)
 }
 
@@ -743,33 +971,51 @@ pub(crate) fn commit_file_deltas(
                 entry_mode,
                 id,
                 ..
-            } if entry_mode.is_blob() => deltas.push(CommitFileDelta {
-                path: location.to_string(),
-                old_blob_id: None,
-                new_blob_id: Some(id),
-            }),
+            } => {
+                let path = utf8_git_path(location.as_ref())?;
+                if let Some(new_entry_kind) = source_entry_kind(entry_mode)? {
+                    deltas.push(CommitFileDelta {
+                        path,
+                        old_blob_id: None,
+                        new_blob_id: Some(id),
+                        new_entry_kind: Some(new_entry_kind),
+                    });
+                }
+            }
             gix::object::tree::diff::ChangeDetached::Deletion {
                 location,
                 entry_mode,
                 id,
                 ..
-            } if entry_mode.is_blob() => deltas.push(CommitFileDelta {
-                path: location.to_string(),
-                old_blob_id: Some(id),
-                new_blob_id: None,
-            }),
+            } => {
+                let path = utf8_git_path(location.as_ref())?;
+                if source_entry_kind(entry_mode)?.is_some() {
+                    deltas.push(CommitFileDelta {
+                        path,
+                        old_blob_id: Some(id),
+                        new_blob_id: None,
+                        new_entry_kind: None,
+                    });
+                }
+            }
             gix::object::tree::diff::ChangeDetached::Modification {
                 location,
                 previous_entry_mode,
                 previous_id,
                 entry_mode,
                 id,
-            } if previous_entry_mode.is_blob() || entry_mode.is_blob() => {
-                deltas.push(CommitFileDelta {
-                    path: location.to_string(),
-                    old_blob_id: Some(previous_id),
-                    new_blob_id: Some(id),
-                })
+            } => {
+                let path = utf8_git_path(location.as_ref())?;
+                let old_entry_kind = source_entry_kind(previous_entry_mode)?;
+                let new_entry_kind = source_entry_kind(entry_mode)?;
+                if old_entry_kind.is_some() || new_entry_kind.is_some() {
+                    deltas.push(CommitFileDelta {
+                        path,
+                        old_blob_id: old_entry_kind.map(|_| previous_id),
+                        new_blob_id: new_entry_kind.map(|_| id),
+                        new_entry_kind,
+                    });
+                }
             }
             _ => {}
         }
@@ -809,7 +1055,18 @@ fn base_link_change_id_from_git_oid(oid: &gix::ObjectId) -> SemanticChangeId {
     SemanticChangeId::from_hash(Hash256::from_bytes(bytes))
 }
 
-/// Enumerate every blob in a tree as `(path, blob_oid)`, sorted by path.
+/// Recompute the deterministic synthetic base-link ID used by pre-0.3
+/// truncated imports. This is exposed only so an owning graph migration can
+/// recognize and replace that exact historical parent substitution when it
+/// widens the import to canonical full ancestry.
+pub fn base_link_change_id_from_git_oid_hex(oid: &str) -> Result<SemanticChangeId> {
+    let oid = gix::ObjectId::from_hex(oid.as_bytes())
+        .map_err(|error| GitError::Git(format!("invalid git oid '{oid}': {error}")))?;
+    Ok(base_link_change_id_from_git_oid(&oid))
+}
+
+/// Enumerate every source entry in a tree as `(path, blob_oid, kind)`, sorted
+/// by path.
 ///
 /// Implemented as a diff of the tree against the empty tree (`None`), which
 /// yields one Addition per blob — the same machinery `commit_file_deltas` uses
@@ -818,7 +1075,7 @@ fn base_link_change_id_from_git_oid(oid: &gix::ObjectId) -> SemanticChangeId {
 fn full_tree_blob_entries(
     repo: &gix::Repository,
     tree: &gix::Tree<'_>,
-) -> Result<Vec<(String, gix::ObjectId)>> {
+) -> Result<Vec<(String, gix::ObjectId, SourceEntryKind)>> {
     let options = gix::diff::Options::default().with_rewrites(None);
     let changes = repo
         .diff_tree_to_tree(None, Some(tree), Some(options))
@@ -833,8 +1090,9 @@ fn full_tree_blob_entries(
             ..
         } = change
         {
-            if entry_mode.is_blob() {
-                entries.push((location.to_string(), id));
+            let path = utf8_git_path(location.as_ref())?;
+            if let Some(kind) = source_entry_kind(entry_mode)? {
+                entries.push((path, id, kind));
             }
         }
     }
@@ -842,8 +1100,73 @@ fn full_tree_blob_entries(
     Ok(entries)
 }
 
-/// Anchor a (possibly truncated) imported history at a synthetic "base-link"
-/// change carrying the FULL file universe present at the import window's base.
+/// Enumerate at most `max_entries` source entries without first materializing
+/// the complete tree diff. This is used at the truncated-history boundary,
+/// where an adversarial or unexpectedly large parent tree must fail before its
+/// full path set is retained in memory.
+fn bounded_full_tree_blob_entries(
+    repo: &gix::Repository,
+    tree: &gix::Tree<'_>,
+    max_entries: usize,
+) -> Result<Vec<(String, gix::ObjectId, SourceEntryKind)>> {
+    let empty_tree = repo.empty_tree();
+    let mut changes = empty_tree
+        .changes()
+        .map_err(|error| GitError::Git(error.to_string()))?;
+    changes.options(|options| {
+        options.track_rewrites(None);
+    });
+
+    let mut entries = Vec::with_capacity(max_entries.min(4_096));
+    let mut callback_error = None;
+    let mut over_limit = false;
+    let traversal_result = changes.for_each_to_obtain_tree(tree, |change| {
+        if let gix::object::tree::diff::Change::Addition {
+            location,
+            entry_mode,
+            id,
+            ..
+        } = change
+        {
+            let path = match utf8_git_path(location) {
+                Ok(path) => path,
+                Err(error) => {
+                    callback_error = Some(error);
+                    return Ok::<_, std::convert::Infallible>(std::ops::ControlFlow::Break(()));
+                }
+            };
+            let kind = match source_entry_kind(entry_mode) {
+                Ok(Some(kind)) => kind,
+                Ok(None) => return Ok(std::ops::ControlFlow::Continue(())),
+                Err(error) => {
+                    callback_error = Some(error);
+                    return Ok(std::ops::ControlFlow::Break(()));
+                }
+            };
+            if entries.len() == max_entries {
+                over_limit = true;
+                return Ok(std::ops::ControlFlow::Break(()));
+            }
+            entries.push((path, id.detach(), kind));
+        }
+        Ok(std::ops::ControlFlow::Continue(()))
+    });
+
+    if let Some(error) = callback_error {
+        return Err(error);
+    }
+    if over_limit {
+        return Err(GitError::Other(format!(
+            "truncated Git history boundary exceeds the remaining source-entry budget of {max_entries}"
+        )));
+    }
+    traversal_result.map_err(|error| GitError::Git(error.to_string()))?;
+    entries.sort_by(|left, right| left.0.cmp(&right.0));
+    Ok(entries)
+}
+
+/// Anchor every omitted parent edge in a truncated import at a synthetic
+/// "base-link" change carrying that parent's FULL file universe.
 ///
 /// # Why
 ///
@@ -862,29 +1185,27 @@ fn full_tree_blob_entries(
 ///
 /// # What
 ///
-/// This walks the complete Git tree at the window base's first parent — the
-/// state the window was built on — and inserts one root change carrying every
-/// base file as an Addition (`parents = [genesis_id]`), then re-points the
-/// window base's dangling first parent from `genesis_id` to this change. The
-/// subsequent semantic-enrichment pass (in `kin-cli`) then parses and links the
-/// whole base universe into the base-link change exactly as it does a true root
-/// commit, and forks each windowed commit's baseline from it,
-/// so every imported head inherits the base-era inbound edges and each commit's
-/// delta only records what it actually changed.
+/// This walks the actual Git parents of every imported commit. For each distinct
+/// parent omitted by the history window it inserts one root change carrying
+/// every file in that parent's tree as an Addition (`parents = [genesis_id]`),
+/// then rebuilds the child's parent list in original Git order with the
+/// corresponding base-link id. Sharing one anchor for repeated edges to the
+/// same omitted commit preserves diamond provenance. It also avoids collapsing
+/// two omitted merge parents into one genesis edge, which loses the independent
+/// parent trees needed to replay a merge exactly.
 ///
 /// `changes` must be oldest-first, as returned by `import_git_history_*`.
 ///
-/// Returns the inserted base-link change id, or `None` when no anchoring is
-/// needed: an empty import, or a full import whose oldest commit is a true Git
-/// root (its own artifact deltas already carry the entire tree).
+/// Returns the first inserted base-link change id in deterministic Git-OID
+/// order, or `None` when no anchoring is needed. A linear window has exactly
+/// one anchor, preserving the original API behavior; a truncated merge may
+/// prepend several anchors.
 ///
 /// # Determinism
 ///
-/// The window base is found by a first-parent walk from the newest change (a
-/// pure function of the already-deterministic imported DAG). The base id is a
-/// hash of the base commit's parent OID. The base-link's artifact deltas are
-/// built in sorted-path order with content-addressed blob hashes, and its
-/// author/timestamp come from Git commit content, never wall-clock. The output
+/// Base ids are hashes of omitted parent OIDs. Anchors are emitted in OID order,
+/// artifact deltas in path order, and author/timestamp come from Git commit
+/// content, never wall-clock. Parent order continues to match Git. The output
 /// is therefore byte-identical across runs for identical history + window.
 pub fn anchor_imported_history_at_base_link(
     repo_path: &Path,
@@ -896,133 +1217,207 @@ pub fn anchor_imported_history_at_base_link(
         return Ok(None);
     }
 
-    // Map change id -> slice position so the first-parent walk stays in-set.
-    let index_by_id: HashMap<SemanticChangeId, usize> = changes
+    let repo = open_repo(repo_path).map_err(|e| GitError::Git(e.to_string()))?;
+    let shallow_boundaries = shallow_boundary_ids(&repo)?;
+    let imported_ids: HashSet<SemanticChangeId> =
+        changes.iter().map(|entry| entry.change.id).collect();
+    let mut git_parent_oids = Vec::with_capacity(changes.len());
+    let mut omitted_parents = BTreeSet::new();
+
+    // `close_truncated_history_dag` intentionally makes the public raw import
+    // self-contained by collapsing missing parents to genesis. Recover the
+    // authoritative edge identities from each Git commit before anchoring so
+    // no merge-parent provenance is lost at that compatibility boundary.
+    for imported in changes.iter() {
+        let oid = gix::ObjectId::from_hex(imported.git_oid.as_bytes())
+            .map_err(|e| GitError::Git(format!("invalid git oid '{}': {}", imported.git_oid, e)))?;
+        let commit = repo
+            .find_commit(oid)
+            .map_err(|e| GitError::CommitNotFound(format!("{oid}: {e}")))?;
+        let mut parents = Vec::new();
+        if !shallow_boundaries.contains(&oid) {
+            for parent in commit.parent_ids() {
+                if parents.len() == MAX_BASE_LINK_ANCHORS {
+                    return Err(GitError::Other(format!(
+                        "Git commit {oid} has more than {MAX_BASE_LINK_ANCHORS} direct parents; refusing an unbounded truncated-history boundary"
+                    )));
+                }
+                let parent = parent.detach();
+                if !imported_ids.contains(&change_id_from_git_oid(&parent))
+                    && omitted_parents.insert(parent)
+                {
+                    // Enforce as the set grows so an adversarial octopus commit
+                    // cannot be fully retained before the boundary is rejected.
+                    enforce_base_link_budget(omitted_parents.len(), 0, 0)?;
+                }
+                parents.push(parent);
+            }
+        }
+        git_parent_oids.push(parents);
+    }
+
+    if omitted_parents.is_empty() {
+        return Ok(None);
+    }
+    let anchor_ids: BTreeMap<gix::ObjectId, SemanticChangeId> = omitted_parents
         .iter()
-        .enumerate()
-        .map(|(i, ic)| (ic.change.id, i))
+        .map(|oid| (*oid, base_link_change_id_from_git_oid(oid)))
         .collect();
 
-    // Window base = the oldest commit reachable from the import head (the newest
-    // change, last in oldest-first order) by following the FIRST parent while it
-    // stays inside the imported set. `close_truncated_history_dag` has already
-    // re-pointed the base's out-of-window first parent to `genesis_id`, so the
-    // walk halts there (or at a true root, whose first parent is also genesis).
-    let mut cursor = changes.len() - 1;
-    loop {
-        match changes[cursor].change.parents.first().copied() {
-            Some(pid) if pid != genesis_id => match index_by_id.get(&pid) {
-                Some(&next) => cursor = next,
-                // Dangling parent (should not occur post-close): treat as base.
-                None => break,
-            },
-            // First parent is genesis (re-pointed horizon or true root) or none.
-            _ => break,
+    // Compute every replacement parent vector without mutating caller-owned
+    // history. Anchor construction below is fallible (missing/corrupt Git
+    // objects and blob persistence can fail), so publication must be atomic:
+    // either every anchor and edge is ready, or `changes` stays byte-identical.
+    let replacement_parents: Vec<Vec<SemanticChangeId>> = git_parent_oids
+        .iter()
+        .map(|parents| {
+            if parents.is_empty() {
+                vec![genesis_id]
+            } else {
+                parents
+                    .iter()
+                    .map(|parent| {
+                        let imported_id = change_id_from_git_oid(parent);
+                        if imported_ids.contains(&imported_id) {
+                            imported_id
+                        } else {
+                            anchor_ids[parent]
+                        }
+                    })
+                    .collect()
+            }
+        })
+        .collect();
+
+    let mut anchors = Vec::with_capacity(anchor_ids.len());
+    let mut aggregate_entries = 0_usize;
+    let mut aggregate_expanded_bytes = 0_u64;
+    let mut blob_cache = HashMap::<gix::ObjectId, (Hash256, u64)>::new();
+    for (parent_oid, base_id) in &anchor_ids {
+        let parent_commit = repo
+            .find_commit(*parent_oid)
+            .map_err(|e| GitError::CommitNotFound(format!("{parent_oid}: {e}")))?;
+        let parent_tree = parent_commit
+            .tree()
+            .map_err(|e| GitError::Git(e.to_string()))?;
+
+        // Full parent universe as Added artifact deltas, in stable path order.
+        // Materialize every blob so exact checkout/archive consumers have the
+        // bytes corresponding to the graph-owned content identities.
+        let remaining_entries = MAX_BASE_LINK_TREE_ENTRIES
+            .checked_sub(aggregate_entries)
+            .ok_or_else(|| GitError::Other("base-link entry count exceeds limit".to_string()))?;
+        let entries = bounded_full_tree_blob_entries(&repo, &parent_tree, remaining_entries)?;
+        aggregate_entries = aggregate_entries
+            .checked_add(entries.len())
+            .ok_or_else(|| GitError::Other("base-link entry count overflow".to_string()))?;
+        enforce_base_link_budget(
+            anchor_ids.len(),
+            aggregate_entries,
+            aggregate_expanded_bytes,
+        )?;
+        let mut artifact_deltas = Vec::with_capacity(entries.len());
+        for (path, blob_id, entry_kind) in entries {
+            let (new_hash, byte_len) = if let Some(cached) = blob_cache.get(&blob_id) {
+                *cached
+            } else {
+                let header = repo
+                    .find_header(blob_id)
+                    .map_err(|error| GitError::Git(error.to_string()))?;
+                if header.kind() != gix::objs::Kind::Blob {
+                    return Err(GitError::Git(format!(
+                        "source entry {path:?} points to non-blob Git object {blob_id} ({:?})",
+                        header.kind()
+                    )));
+                }
+                let byte_len = header.size();
+                let prospective_bytes =
+                    aggregate_expanded_bytes
+                        .checked_add(byte_len)
+                        .ok_or_else(|| {
+                            GitError::Other("base-link source byte count overflow".into())
+                        })?;
+                enforce_base_link_budget(anchor_ids.len(), aggregate_entries, prospective_bytes)?;
+
+                let mut blob = repo
+                    .find_blob(blob_id)
+                    .map_err(|error| GitError::Git(error.to_string()))?;
+                let content = blob.take_data();
+                let loaded_len = u64::try_from(content.len()).unwrap_or(u64::MAX);
+                if loaded_len != byte_len {
+                    return Err(GitError::Git(format!(
+                        "Git blob {blob_id} changed size while loading: header={byte_len}, loaded={loaded_len}"
+                    )));
+                }
+                let hash = Hash256::from_bytes(kin_blobs::digest(&content).0);
+                if let Some(store) = blob_store {
+                    store.write(&content)?;
+                }
+                blob_cache.insert(blob_id, (hash, byte_len));
+                (hash, byte_len)
+            };
+            aggregate_expanded_bytes = aggregate_expanded_bytes
+                .checked_add(byte_len)
+                .ok_or_else(|| GitError::Other("base-link source byte count overflow".into()))?;
+            enforce_base_link_budget(
+                anchor_ids.len(),
+                aggregate_entries,
+                aggregate_expanded_bytes,
+            )?;
+            artifact_deltas.push(ArtifactDelta {
+                file_id: FilePathId::new(path),
+                kind: added_artifact_kind(entry_kind),
+                old_hash: None,
+                new_hash: Some(new_hash),
+            });
         }
-    }
-    let window_base_idx = cursor;
 
-    let repo = open_repo(repo_path).map_err(|e| GitError::Git(e.to_string()))?;
+        let author_sig = parent_commit
+            .author()
+            .map_err(|e| GitError::Git(e.to_string()))?;
+        let author = AuthorId::new(format!("{} <{}>", author_sig.name, author_sig.email));
+        let git_time = author_sig
+            .time()
+            .map_err(|e| GitError::Git(e.to_string()))?;
+        let timestamp = timestamp_from_git_seconds(git_time.seconds, parent_oid)?;
 
-    let base_git_oid = gix::ObjectId::from_hex(changes[window_base_idx].git_oid.as_bytes())
-        .map_err(|e| {
-            GitError::Git(format!(
-                "invalid git oid '{}': {}",
-                changes[window_base_idx].git_oid, e
-            ))
-        })?;
-    let base_commit = repo
-        .find_commit(base_git_oid)
-        .map_err(|e| GitError::CommitNotFound(format!("{base_git_oid}: {e}")))?;
-
-    // The state the window was built on is the base commit's FIRST parent tree.
-    // No first parent means this is a true Git root: a full import whose own
-    // deltas already carry the whole tree, so there is nothing to anchor.
-    let parent_oid = match base_commit.parent_ids().next() {
-        Some(pid) => pid.detach(),
-        None => return Ok(None),
-    };
-    let parent_commit = repo
-        .find_commit(parent_oid)
-        .map_err(|e| GitError::CommitNotFound(format!("{parent_oid}: {e}")))?;
-    let parent_tree = parent_commit
-        .tree()
-        .map_err(|e| GitError::Git(e.to_string()))?;
-
-    // Full base universe as Added artifact deltas, in stable path order. Blobs
-    // are materialized into the store so the semantic pass can read and parse
-    // them (mirrors how imported commits materialize their changed blobs).
-    let entries = full_tree_blob_entries(&repo, &parent_tree)?;
-    let mut artifact_deltas = Vec::with_capacity(entries.len());
-    for (path, blob_id) in entries {
-        let new_hash = blob_hash(&repo, blob_id, blob_store)?;
-        artifact_deltas.push(ArtifactDelta {
-            file_id: FilePathId::new(path),
-            kind: ArtifactDeltaKind::Added,
-            old_hash: None,
-            new_hash: Some(new_hash),
+        anchors.push(ImportedChange {
+            change: SemanticChange {
+                id: *base_id,
+                parents: vec![genesis_id],
+                timestamp,
+                author,
+                // Preserve the original linear-anchor payload for existing
+                // deterministic IDs while extending it to every boundary edge.
+                message: "kin import: base-link (window base universe)".to_string(),
+                entity_deltas: vec![],
+                relation_deltas: vec![],
+                artifact_deltas,
+                projected_files: vec![],
+                spec_link: None,
+                evidence: vec![],
+                risk_summary: None,
+                authored_on: Some(BranchName::new("main")),
+            },
+            git_oid: parent_oid.to_string(),
         });
     }
 
-    // Author/timestamp come from the base parent commit so the synthetic change
-    // is a pure function of Git content (no wall-clock), matching how
-    // `commit_to_change` derives them for every real imported commit.
-    let author_sig = parent_commit
-        .author()
-        .map_err(|e| GitError::Git(e.to_string()))?;
-    let author = AuthorId::new(format!("{} <{}>", author_sig.name, author_sig.email));
-    let git_time = author_sig
-        .time()
-        .map_err(|e| GitError::Git(e.to_string()))?;
-    let timestamp = Timestamp::from(
-        chrono::Utc
-            .timestamp_opt(git_time.seconds, 0)
-            .single()
-            .unwrap_or_else(chrono::Utc::now),
-    );
-
-    let base_id = base_link_change_id_from_git_oid(&parent_oid);
-    let base_change = SemanticChange {
-        id: base_id,
-        parents: vec![genesis_id],
-        timestamp,
-        author,
-        message: "kin import: base-link (window base universe)".to_string(),
-        entity_deltas: vec![],   // populated by the semantic enrichment pass
-        relation_deltas: vec![], // populated by the semantic enrichment pass
-        artifact_deltas,
-        projected_files: vec![],
-        spec_link: None,
-        evidence: vec![],
-        risk_summary: None,
-        authored_on: Some(BranchName::new("main")),
-    };
-
-    // Re-point the window base's first parent from genesis to the base-link so
-    // every head's first-parent ancestry now flows through the base universe.
-    if let Some(first) = changes[window_base_idx].change.parents.first_mut() {
-        if *first == genesis_id {
-            *first = base_id;
-        }
+    let first_anchor = anchors.first().map(|anchor| anchor.change.id);
+    for (imported, parents) in changes.iter_mut().zip(replacement_parents) {
+        imported.change.parents = parents;
     }
-
-    // Prepend: created before its child, and processed first by the topological
-    // enrichment pass (its own parent, genesis, is out of the imported set).
-    changes.insert(
-        0,
-        ImportedChange {
-            change: base_change,
-            git_oid: parent_oid.to_string(),
-        },
-    );
-
-    Ok(Some(base_id))
+    // All roots precede every imported child. OID sorting above makes the
+    // multi-anchor prefix deterministic without disturbing Git parent order.
+    changes.splice(0..0, anchors);
+    Ok(first_anchor)
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
-    use std::process::Command;
+    use std::io::Write as _;
+    use std::process::{Command, Stdio};
 
     #[test]
     fn test_open_repo_resolves_git_suffix_directories() {
@@ -1053,6 +1448,10 @@ mod tests {
                     .args(["config", "gc.auto", "0"])
                     .current_dir(dir)
                     .output();
+                let _ = Command::new("git")
+                    .args(["config", "core.hooksPath", ".git/no-hooks"])
+                    .current_dir(dir)
+                    .output();
                 true
             }
             _ => false,
@@ -1068,12 +1467,147 @@ mod tests {
     }
 
     #[test]
+    fn truncated_history_boundary_budget_fails_closed_at_each_dimension() {
+        assert!(enforce_base_link_budget(
+            MAX_BASE_LINK_ANCHORS,
+            MAX_BASE_LINK_TREE_ENTRIES,
+            MAX_BASE_LINK_EXPANDED_BYTES,
+        )
+        .is_ok());
+        for error in [
+            enforce_base_link_budget(MAX_BASE_LINK_ANCHORS + 1, 0, 0).unwrap_err(),
+            enforce_base_link_budget(1, MAX_BASE_LINK_TREE_ENTRIES + 1, 0).unwrap_err(),
+            enforce_base_link_budget(1, 1, MAX_BASE_LINK_EXPANDED_BYTES + 1).unwrap_err(),
+        ] {
+            assert!(error.to_string().contains("limit"));
+        }
+    }
+
+    #[test]
+    fn bounded_tree_enumeration_stops_at_entry_budget() {
+        let dir = tempfile::tempdir().unwrap();
+        if !init_git_repo(dir.path()) {
+            eprintln!("git not available, skipping bounded tree test");
+            return;
+        }
+        std::fs::write(dir.path().join("a.txt"), b"a\n").unwrap();
+        std::fs::write(dir.path().join("b.txt"), b"b\n").unwrap();
+        assert!(Command::new("git")
+            .args(["add", "a.txt", "b.txt"])
+            .current_dir(dir.path())
+            .status()
+            .unwrap()
+            .success());
+        assert!(Command::new("git")
+            .args(["commit", "-m", "two files"])
+            .current_dir(dir.path())
+            .status()
+            .unwrap()
+            .success());
+
+        let repo = open_repo(dir.path()).unwrap();
+        let tree = repo.head_commit().unwrap().tree().unwrap();
+        assert_eq!(
+            bounded_full_tree_blob_entries(&repo, &tree, 2)
+                .unwrap()
+                .len(),
+            2
+        );
+        let error = bounded_full_tree_blob_entries(&repo, &tree, 1).unwrap_err();
+        assert!(
+            error
+                .to_string()
+                .contains("remaining source-entry budget of 1"),
+            "unexpected error: {error}"
+        );
+    }
+
+    #[test]
     fn different_oids_produce_different_ids() {
         let oid1 = gix::ObjectId::from_hex(b"aabbccddee00112233445566778899aabbccddee").unwrap();
         let oid2 = gix::ObjectId::from_hex(b"00112233445566778899aabbccddeeff00112233").unwrap();
         let id1 = change_id_from_git_oid(&oid1);
         let id2 = change_id_from_git_oid(&oid2);
         assert_ne!(id1, id2);
+    }
+
+    #[test]
+    fn git_import_rejects_out_of_range_author_timestamp() {
+        let dir = tempfile::tempdir().unwrap();
+        if !init_git_repo(dir.path()) {
+            eprintln!("git not available, skipping invalid timestamp test");
+            return;
+        }
+
+        std::fs::write(dir.path().join("owned.txt"), "owned\n").unwrap();
+        let add = Command::new("git")
+            .args(["add", "owned.txt"])
+            .current_dir(dir.path())
+            .output()
+            .unwrap();
+        assert!(add.status.success());
+        let tree = Command::new("git")
+            .args(["write-tree"])
+            .current_dir(dir.path())
+            .output()
+            .unwrap();
+        assert!(tree.status.success());
+        let tree_oid = String::from_utf8(tree.stdout).unwrap();
+        let raw_commit = format!(
+            "tree {}\nauthor Test <test@test.com> {} +0000\ncommitter Test <test@test.com> {} +0000\n\nout of range\n",
+            tree_oid.trim(),
+            i64::MAX,
+            i64::MAX
+        );
+        let mut hash = Command::new("git")
+            .args(["hash-object", "-t", "commit", "-w", "--stdin"])
+            .current_dir(dir.path())
+            .stdin(Stdio::piped())
+            .stdout(Stdio::piped())
+            .stderr(Stdio::piped())
+            .spawn()
+            .unwrap();
+        hash.stdin
+            .take()
+            .unwrap()
+            .write_all(raw_commit.as_bytes())
+            .unwrap();
+        let hash = hash.wait_with_output().unwrap();
+        assert!(
+            hash.status.success(),
+            "git rejected raw commit fixture: {}",
+            String::from_utf8_lossy(&hash.stderr)
+        );
+        let commit_oid = String::from_utf8(hash.stdout).unwrap();
+        let update = Command::new("git")
+            .args(["update-ref", "HEAD", commit_oid.trim()])
+            .current_dir(dir.path())
+            .output()
+            .unwrap();
+        assert!(update.status.success());
+
+        let genesis_id = SemanticChangeId::from_hash(Hash256::from_bytes([0x24; 32]));
+        let first = import_git_history(
+            dir.path(),
+            genesis_id,
+            &ImportOptions {
+                shallow: true,
+                ..Default::default()
+            },
+        )
+        .unwrap_err();
+        let second = import_git_history(
+            dir.path(),
+            genesis_id,
+            &ImportOptions {
+                shallow: true,
+                ..Default::default()
+            },
+        )
+        .unwrap_err();
+
+        assert!(first.to_string().contains("outside Kin's supported range"));
+        assert_eq!(first.to_string(), second.to_string());
     }
 
     #[test]
@@ -1128,6 +1662,191 @@ mod tests {
         assert_eq!(stored, content);
     }
 
+    #[cfg(unix)]
+    #[test]
+    fn import_preserves_regular_executable_symlink_and_mode_only_changes() {
+        use std::os::unix::fs::{symlink, PermissionsExt};
+
+        let dir = tempfile::tempdir().unwrap();
+        if !init_git_repo(dir.path()) {
+            eprintln!("git not available, skipping source mode import test");
+            return;
+        }
+
+        let regular_path = dir.path().join("plain.txt");
+        let executable_path = dir.path().join("run.sh");
+        std::fs::write(&regular_path, b"plain\n").unwrap();
+        std::fs::write(&executable_path, b"#!/bin/sh\necho exact\n").unwrap();
+        let mut executable_permissions = std::fs::metadata(&executable_path).unwrap().permissions();
+        executable_permissions.set_mode(0o755);
+        std::fs::set_permissions(&executable_path, executable_permissions).unwrap();
+        symlink("plain.txt", dir.path().join("plain-link")).unwrap();
+        let initial = Command::new("git")
+            .args(["add", "."])
+            .current_dir(dir.path())
+            .status()
+            .unwrap();
+        assert!(initial.success());
+        let initial = Command::new("git")
+            .args(["commit", "-m", "exact source modes"])
+            .current_dir(dir.path())
+            .status()
+            .unwrap();
+        assert!(initial.success());
+
+        let mut regular_permissions = std::fs::metadata(&regular_path).unwrap().permissions();
+        regular_permissions.set_mode(0o755);
+        std::fs::set_permissions(&regular_path, regular_permissions).unwrap();
+        let mode_change = Command::new("git")
+            .args(["add", "plain.txt"])
+            .current_dir(dir.path())
+            .status()
+            .unwrap();
+        assert!(mode_change.success());
+        let mode_change = Command::new("git")
+            .args(["commit", "-m", "make plain executable"])
+            .current_dir(dir.path())
+            .status()
+            .unwrap();
+        assert!(mode_change.success());
+
+        let blob_store = BlobStore::new(dir.path().join("kin-blobs")).unwrap();
+        let genesis_id = SemanticChangeId::from_hash(Hash256::from_bytes([0x12; 32]));
+        let imported = import_git_history_with_blobs(
+            dir.path(),
+            genesis_id,
+            &ImportOptions::default(),
+            Some(&blob_store),
+        )
+        .expect("git import should preserve source modes");
+        assert_eq!(imported.len(), 2);
+
+        let initial_kinds: std::collections::BTreeMap<_, _> = imported[0]
+            .change
+            .artifact_deltas
+            .iter()
+            .map(|delta| (delta.file_id.0.as_str(), delta.kind))
+            .collect();
+        assert_eq!(
+            initial_kinds.get("plain.txt"),
+            Some(&ArtifactDeltaKind::AddedRegularFile)
+        );
+        assert_eq!(
+            initial_kinds.get("run.sh"),
+            Some(&ArtifactDeltaKind::AddedExecutableFile)
+        );
+        assert_eq!(
+            initial_kinds.get("plain-link"),
+            Some(&ArtifactDeltaKind::AddedSymlink)
+        );
+        let link_delta = imported[0]
+            .change
+            .artifact_deltas
+            .iter()
+            .find(|delta| delta.file_id.0 == "plain-link")
+            .unwrap();
+        let link_target = blob_store
+            .read(&kin_blobs::Hash256(link_delta.new_hash.unwrap().0))
+            .unwrap();
+        assert_eq!(link_target, b"plain.txt");
+
+        assert_eq!(imported[1].change.artifact_deltas.len(), 1);
+        let mode_delta = &imported[1].change.artifact_deltas[0];
+        assert_eq!(mode_delta.file_id.0, "plain.txt");
+        assert_eq!(mode_delta.kind, ArtifactDeltaKind::ModifiedExecutableFile);
+        assert_eq!(mode_delta.old_hash, mode_delta.new_hash);
+    }
+
+    #[test]
+    fn exact_import_rejects_gitlinks_instead_of_omitting_them() {
+        let dir = tempfile::tempdir().unwrap();
+        if !init_git_repo(dir.path()) {
+            eprintln!("git not available, skipping gitlink rejection test");
+            return;
+        }
+
+        std::fs::write(dir.path().join("seed.txt"), "seed\n").unwrap();
+        assert!(Command::new("git")
+            .args(["add", "seed.txt"])
+            .current_dir(dir.path())
+            .status()
+            .unwrap()
+            .success());
+        assert!(Command::new("git")
+            .args(["commit", "-m", "seed"])
+            .current_dir(dir.path())
+            .status()
+            .unwrap()
+            .success());
+        let head = Command::new("git")
+            .args(["rev-parse", "HEAD"])
+            .current_dir(dir.path())
+            .output()
+            .unwrap();
+        assert!(head.status.success());
+        let head = String::from_utf8(head.stdout).unwrap();
+        let cache_info = format!("160000,{},vendor/sub", head.trim());
+        assert!(Command::new("git")
+            .args(["update-index", "--add", "--cacheinfo", &cache_info])
+            .current_dir(dir.path())
+            .status()
+            .unwrap()
+            .success());
+        assert!(Command::new("git")
+            .args(["commit", "-m", "add gitlink"])
+            .current_dir(dir.path())
+            .status()
+            .unwrap()
+            .success());
+
+        let genesis_id = SemanticChangeId::from_hash(Hash256::from_bytes([0x13; 32]));
+        let error = import_git_history(dir.path(), genesis_id, &ImportOptions::default())
+            .expect_err("an exact import must not silently omit gitlinks");
+        assert!(error.to_string().contains("gitlink/submodule"));
+    }
+
+    #[test]
+    fn exact_import_path_decoder_rejects_non_utf8_bytes() {
+        let error = utf8_git_path(b"invalid-\xff.rs")
+            .expect_err("an exact import must not record a lossy path identity");
+        assert!(error.to_string().contains("non-UTF-8 path"));
+    }
+
+    // Linux filesystems accept arbitrary non-NUL path bytes. macOS's filesystem
+    // APIs reject this fixture at creation time, so the end-to-end repository
+    // case belongs on Linux while the decoder unit test above runs everywhere.
+    #[cfg(target_os = "linux")]
+    #[test]
+    fn exact_import_rejects_non_utf8_paths_instead_of_lossy_identity() {
+        use std::os::unix::ffi::OsStringExt;
+
+        let dir = tempfile::tempdir().unwrap();
+        if !init_git_repo(dir.path()) {
+            eprintln!("git not available, skipping non-UTF-8 path rejection test");
+            return;
+        }
+
+        let name = std::ffi::OsString::from_vec(b"invalid-\xff.rs".to_vec());
+        std::fs::write(dir.path().join(name), "fn invalid() {}\n").unwrap();
+        assert!(Command::new("git")
+            .args(["add", "-A"])
+            .current_dir(dir.path())
+            .status()
+            .unwrap()
+            .success());
+        assert!(Command::new("git")
+            .args(["commit", "-m", "non utf8 path"])
+            .current_dir(dir.path())
+            .status()
+            .unwrap()
+            .success());
+
+        let genesis_id = SemanticChangeId::from_hash(Hash256::from_bytes([0x14; 32]));
+        let error = import_git_history(dir.path(), genesis_id, &ImportOptions::default())
+            .expect_err("an exact import must not record a lossy path identity");
+        assert!(error.to_string().contains("non-UTF-8 path"));
+    }
+
     #[test]
     fn import_tracks_only_changed_files_for_non_root_commits() {
         let dir = tempfile::tempdir().unwrap();
@@ -1174,7 +1893,10 @@ mod tests {
 
         assert_eq!(
             paths,
-            vec![("alpha.txt".to_string(), ArtifactDeltaKind::Modified)]
+            vec![(
+                "alpha.txt".to_string(),
+                ArtifactDeltaKind::ModifiedRegularFile,
+            )]
         );
     }
 
@@ -1265,8 +1987,8 @@ mod tests {
         assert_eq!(
             base_paths,
             vec![
-                ("alpha.txt".to_string(), ArtifactDeltaKind::Added),
-                ("beta.txt".to_string(), ArtifactDeltaKind::Added),
+                ("alpha.txt".to_string(), ArtifactDeltaKind::AddedRegularFile,),
+                ("beta.txt".to_string(), ArtifactDeltaKind::AddedRegularFile,),
             ],
             "base-link must carry the full base universe as sorted Additions"
         );
@@ -1333,6 +2055,76 @@ mod tests {
             before,
             "no synthetic change should be added"
         );
+    }
+
+    #[test]
+    fn anchor_base_link_failure_leaves_imported_history_unchanged() {
+        let dir = tempfile::tempdir().unwrap();
+        if !init_git_repo(dir.path()) {
+            eprintln!("git not available, skipping base-link atomic failure test");
+            return;
+        }
+
+        for (index, contents) in ["one\n", "two\n"].into_iter().enumerate() {
+            std::fs::write(dir.path().join("alpha.txt"), contents).unwrap();
+            let _ = Command::new("git")
+                .args(["add", "alpha.txt"])
+                .current_dir(dir.path())
+                .output();
+            let stamp = format!("{} +0000", 1_000_000_000 + index as i64);
+            let output = Command::new("git")
+                .args(["commit", "-m", &format!("c{}", index + 1)])
+                .env("GIT_AUTHOR_DATE", &stamp)
+                .env("GIT_COMMITTER_DATE", &stamp)
+                .current_dir(dir.path())
+                .output()
+                .unwrap();
+            assert!(output.status.success());
+        }
+
+        let genesis_id = SemanticChangeId::from_hash(Hash256::from_bytes([0x45; 32]));
+        let mut imported = import_git_history(
+            dir.path(),
+            genesis_id,
+            &ImportOptions {
+                max_commits: 1,
+                ..Default::default()
+            },
+        )
+        .expect("truncated import should succeed before object corruption");
+        let before: Vec<_> = imported
+            .iter()
+            .map(|entry| (entry.git_oid.clone(), format!("{:?}", entry.change)))
+            .collect();
+
+        let parent_oid = Command::new("git")
+            .args(["rev-parse", "HEAD^"])
+            .current_dir(dir.path())
+            .output()
+            .unwrap();
+        assert!(parent_oid.status.success());
+        let parent_oid = String::from_utf8(parent_oid.stdout).unwrap();
+        let parent_oid = parent_oid.trim();
+        let parent_object = dir
+            .path()
+            .join(".git/objects")
+            .join(&parent_oid[..2])
+            .join(&parent_oid[2..]);
+        std::fs::remove_file(&parent_object).expect("fixture parent commit must be loose");
+
+        let error =
+            anchor_imported_history_at_base_link(dir.path(), &mut imported, genesis_id, None)
+                .expect_err("missing boundary parent object must fail anchoring");
+        assert!(
+            error.to_string().contains(parent_oid),
+            "error must identify the missing parent: {error}"
+        );
+
+        let after: Vec<_> = imported
+            .iter()
+            .map(|entry| (entry.git_oid.clone(), format!("{:?}", entry.change)))
+            .collect();
+        assert_eq!(after, before, "failed anchoring must not reparent history");
     }
 
     #[test]
@@ -1517,6 +2309,57 @@ mod tests {
         Some(dir)
     }
 
+    fn build_truncated_merge_correction_repo() -> Option<tempfile::TempDir> {
+        let dir = tempfile::tempdir().unwrap();
+        if !init_git_repo(dir.path()) {
+            return None;
+        }
+        let _ = Command::new("git")
+            .args(["config", "core.hooksPath", "/dev/null"])
+            .current_dir(dir.path())
+            .output();
+        let fixed_date = "1112911993 +0000";
+
+        run_dated_git(
+            dir.path(),
+            &["symbolic-ref", "HEAD", "refs/heads/main"],
+            fixed_date,
+        );
+        std::fs::write(
+            dir.path().join("gone.txt"),
+            "retained only by second parent\n",
+        )
+        .unwrap();
+        std::fs::write(dir.path().join("conflict.txt"), "base\n").unwrap();
+        std::fs::write(dir.path().join("mode.sh"), "#!/bin/sh\necho stable\n").unwrap();
+        run_dated_git(dir.path(), &["add", "."], fixed_date);
+        run_dated_git(dir.path(), &["commit", "-m", "base"], fixed_date);
+
+        run_dated_git(dir.path(), &["switch", "-c", "feature"], fixed_date);
+        std::fs::write(dir.path().join("conflict.txt"), "feature content\n").unwrap();
+        std::fs::write(dir.path().join("feature-only.txt"), "feature\n").unwrap();
+        run_dated_git(dir.path(), &["add", "."], fixed_date);
+        run_dated_git(dir.path(), &["commit", "-m", "feature"], fixed_date);
+
+        run_dated_git(dir.path(), &["switch", "main"], fixed_date);
+        std::fs::remove_file(dir.path().join("gone.txt")).unwrap();
+        std::fs::write(dir.path().join("conflict.txt"), "main content\n").unwrap();
+        run_dated_git(dir.path(), &["add", "-A"], fixed_date);
+        run_dated_git(
+            dir.path(),
+            &["update-index", "--chmod=+x", "mode.sh"],
+            fixed_date,
+        );
+        run_dated_git(dir.path(), &["commit", "-m", "main"], fixed_date);
+        run_dated_git(
+            dir.path(),
+            &["merge", "--no-ff", "-X", "ours", "feature", "-m", "merge"],
+            fixed_date,
+        );
+
+        Some(dir)
+    }
+
     fn assert_import_order_is_parent_first(changes: &[ImportedChange]) {
         let positions: HashMap<SemanticChangeId, usize> = changes
             .iter()
@@ -1671,6 +2514,206 @@ mod tests {
             bounded_head.parents.contains(&genesis_id),
             "the omitted merge parent must close at the history boundary"
         );
+    }
+
+    #[test]
+    fn truncated_merge_anchors_every_boundary_parent_and_replays_exact_archive() {
+        use kin_model::{ChangeStore, SourceTreeResolution};
+
+        let Some(dir) = build_equal_timestamp_merge_repo() else {
+            eprintln!("git not available, skipping merge-boundary anchor test");
+            return;
+        };
+        let repo = open_repo(dir.path()).expect("open repo");
+        let head_id = repo
+            .head_ref()
+            .expect("head_ref")
+            .expect("non-empty repo")
+            .id()
+            .detach();
+        let genesis_id = SemanticChangeId::from_hash(Hash256::from_bytes([0x68; 32]));
+        let blob_store = BlobStore::new(dir.path().join("boundary-blobs")).unwrap();
+
+        // Keep only the merge. Both sides of the root -> {main, feature} ->
+        // merge diamond cross the truncation boundary independently.
+        let mut imported = import_full(&repo, head_id, genesis_id, 1, Some(&blob_store))
+            .expect("bounded merge import");
+        assert_eq!(imported.len(), 1);
+        assert_eq!(imported[0].change.parents, vec![genesis_id]);
+
+        anchor_imported_history_at_base_link(
+            dir.path(),
+            &mut imported,
+            genesis_id,
+            Some(&blob_store),
+        )
+        .expect("anchor every omitted merge parent")
+        .expect("truncated merge must create boundary anchors");
+
+        assert_eq!(
+            imported.len(),
+            3,
+            "two full-tree roots must precede the one imported merge"
+        );
+        let merge = imported.last().expect("merge remains the imported head");
+        assert_eq!(merge.change.parents.len(), 2);
+        assert!(merge
+            .change
+            .parents
+            .iter()
+            .all(|parent| *parent != genesis_id));
+
+        // Parent order and identity remain the original Git provenance, rather
+        // than two boundary edges collapsing into one anonymous genesis edge.
+        let anchor_oid_by_id: HashMap<_, _> = imported[..2]
+            .iter()
+            .map(|anchor| (anchor.change.id, anchor.git_oid.clone()))
+            .collect();
+        let git_merge = repo.find_commit(head_id).expect("find merge commit");
+        let expected_parent_oids: Vec<_> = git_merge
+            .parent_ids()
+            .map(|parent| parent.to_string())
+            .collect();
+        let replay_parent_oids: Vec<_> = merge
+            .change
+            .parents
+            .iter()
+            .map(|parent| anchor_oid_by_id[parent].clone())
+            .collect();
+        assert_eq!(replay_parent_oids, expected_parent_oids);
+
+        // Each synthetic boundary node is independently exact and carries its
+        // omitted parent's complete tree, not merely files touched in-window.
+        for anchor in &imported[..2] {
+            assert_eq!(anchor.change.parents, vec![genesis_id]);
+            let parent_oid = gix::ObjectId::from_hex(anchor.git_oid.as_bytes()).unwrap();
+            let parent_tree = repo.find_commit(parent_oid).unwrap().tree().unwrap();
+            let expected_paths: Vec<_> = full_tree_blob_entries(&repo, &parent_tree)
+                .unwrap()
+                .into_iter()
+                .map(|(path, _, kind)| (path, added_artifact_kind(kind)))
+                .collect();
+            let anchor_paths: Vec<_> = anchor
+                .change
+                .artifact_deltas
+                .iter()
+                .map(|delta| (delta.file_id.0.clone(), delta.kind))
+                .collect();
+            assert_eq!(anchor_paths, expected_paths);
+        }
+
+        let graph = kin_db::InMemoryGraph::new();
+        let genesis = bare_change(genesis_id, vec![]).change;
+        graph.create_change(&genesis).unwrap();
+        for change in &imported {
+            graph.create_change(&change.change).unwrap();
+        }
+        let SourceTreeResolution::Exact { entries } =
+            graph.resolve_source_tree_at(&merge.change.id).unwrap()
+        else {
+            panic!("anchored truncated merge must resolve to an exact source tree")
+        };
+
+        // Compare an archive-shaped manifest (path, mode, bytes) against the
+        // authoritative Git merge tree. This proves both graph identities and
+        // persisted object bytes are sufficient to reproduce the exact archive.
+        let head_tree = git_merge.tree().unwrap();
+        let expected_entries = full_tree_blob_entries(&repo, &head_tree).unwrap();
+        let mut expected_archive = Vec::new();
+        for (path, blob_oid, kind) in expected_entries {
+            let bytes = repo.find_blob(blob_oid).unwrap().take_data();
+            expected_archive.push((path, kind, bytes));
+        }
+        let mut replay_archive = Vec::new();
+        let mut resolved: Vec<_> = entries.into_iter().collect();
+        resolved.sort_by(|left, right| left.0 .0.cmp(&right.0 .0));
+        for (path, entry) in resolved {
+            let bytes = blob_store
+                .read(&kin_blobs::Hash256(*entry.hash.as_bytes()))
+                .unwrap();
+            replay_archive.push((path.0, entry.kind, bytes));
+        }
+        assert_eq!(replay_archive, expected_archive);
+    }
+
+    #[test]
+    fn truncated_merge_correction_preserves_deletion_content_and_mode_choices() {
+        use kin_model::{ChangeStore, SourceTreeResolution};
+
+        let Some(dir) = build_truncated_merge_correction_repo() else {
+            eprintln!("git not available, skipping merge-correction test");
+            return;
+        };
+        let repo = open_repo(dir.path()).expect("open repo");
+        let head_id = repo
+            .head_ref()
+            .expect("head_ref")
+            .expect("non-empty repo")
+            .id()
+            .detach();
+        let genesis_id = SemanticChangeId::from_hash(Hash256::from_bytes([0x69; 32]));
+        let blob_store = BlobStore::new(dir.path().join("correction-blobs")).unwrap();
+
+        let mut imported = import_full(&repo, head_id, genesis_id, 1, Some(&blob_store))
+            .expect("bounded merge import");
+        anchor_imported_history_at_base_link(
+            dir.path(),
+            &mut imported,
+            genesis_id,
+            Some(&blob_store),
+        )
+        .expect("anchor omitted merge parents")
+        .expect("truncated merge must create anchors");
+
+        let merge = imported.last().expect("merge remains imported head");
+        let by_path: HashMap<_, _> = merge
+            .change
+            .artifact_deltas
+            .iter()
+            .map(|delta| (delta.file_id.0.as_str(), delta.kind))
+            .collect();
+        assert_eq!(by_path["gone.txt"], ArtifactDeltaKind::Removed);
+        assert_eq!(
+            by_path["conflict.txt"],
+            ArtifactDeltaKind::ModifiedRegularFile
+        );
+        assert_eq!(
+            by_path["mode.sh"],
+            ArtifactDeltaKind::ModifiedExecutableFile
+        );
+
+        let graph = kin_db::InMemoryGraph::new();
+        graph
+            .create_change(&bare_change(genesis_id, vec![]).change)
+            .unwrap();
+        for change in &imported {
+            graph.create_change(&change.change).unwrap();
+        }
+        let SourceTreeResolution::Exact { entries } =
+            graph.resolve_source_tree_at(&merge.change.id).unwrap()
+        else {
+            panic!("truncated merge correction must resolve exactly")
+        };
+
+        let git_merge = repo.find_commit(head_id).unwrap();
+        let expected_entries = full_tree_blob_entries(&repo, &git_merge.tree().unwrap()).unwrap();
+        let mut expected_archive = Vec::new();
+        for (path, blob_oid, kind) in expected_entries {
+            expected_archive.push((path, kind, repo.find_blob(blob_oid).unwrap().take_data()));
+        }
+        let mut replay_archive = Vec::new();
+        let mut resolved: Vec<_> = entries.into_iter().collect();
+        resolved.sort_by(|left, right| left.0 .0.cmp(&right.0 .0));
+        for (path, entry) in resolved {
+            replay_archive.push((
+                path.0,
+                entry.kind,
+                blob_store
+                    .read(&kin_blobs::Hash256(*entry.hash.as_bytes()))
+                    .unwrap(),
+            ));
+        }
+        assert_eq!(replay_archive, expected_archive);
     }
 
     /// A SemanticChange carrying only an id and parents — enough to exercise the
@@ -1922,6 +2965,77 @@ mod tests {
             .env("GIT_COMMITTER_DATE", &date)
             .current_dir(repo)
             .output();
+    }
+
+    #[test]
+    fn shallow_boundary_is_a_full_tree_semantic_root_without_missing_parent_anchors() {
+        let source = tempfile::tempdir().unwrap();
+        if !init_git_repo(source.path()) {
+            eprintln!("git not available, skipping shallow-boundary test");
+            return;
+        }
+        commit_file(source.path(), "a.txt", "one\n", "one", "1000000000");
+        commit_file(source.path(), "b.txt", "two\n", "two", "1000000100");
+        commit_file(source.path(), "a.txt", "three\n", "three", "1000000200");
+
+        let clone_parent = tempfile::tempdir().unwrap();
+        let shallow = clone_parent.path().join("shallow");
+        let clone = Command::new("git")
+            .args([
+                "clone",
+                "--depth",
+                "1",
+                &format!("file://{}", source.path().display()),
+                shallow.to_str().unwrap(),
+            ])
+            .output()
+            .unwrap();
+        assert!(
+            clone.status.success(),
+            "shallow clone failed: {}",
+            String::from_utf8_lossy(&clone.stderr)
+        );
+
+        let genesis = SemanticChangeId::from_hash(Hash256::from_bytes([0xa7; 32]));
+        let recent_store = BlobStore::new(clone_parent.path().join("recent-objects")).unwrap();
+        let full_store = BlobStore::new(clone_parent.path().join("full-objects")).unwrap();
+        let mut recent = import_git_history_with_blobs(
+            &shallow,
+            genesis,
+            &ImportOptions {
+                max_commits: 50,
+                ..Default::default()
+            },
+            Some(&recent_store),
+        )
+        .unwrap();
+        let mut full = import_git_history_with_blobs(
+            &shallow,
+            genesis,
+            &ImportOptions::default(),
+            Some(&full_store),
+        )
+        .unwrap();
+
+        assert_eq!(recent.len(), 1);
+        assert_eq!(format!("{recent:?}"), format!("{full:?}"));
+        assert_eq!(recent[0].change.parents, vec![genesis]);
+        assert_eq!(recent[0].change.artifact_deltas.len(), 2);
+        assert_eq!(
+            anchor_imported_history_at_base_link(
+                &shallow,
+                &mut recent,
+                genesis,
+                Some(&recent_store),
+            )
+            .unwrap(),
+            None
+        );
+        assert_eq!(
+            anchor_imported_history_at_base_link(&shallow, &mut full, genesis, Some(&full_store),)
+                .unwrap(),
+            None
+        );
     }
 
     #[test]

--- a/crates/kin-git/src/lib.rs
+++ b/crates/kin-git/src/lib.rs
@@ -21,7 +21,8 @@ pub use error::{GitError, Result};
 pub use export::{export_changes, export_to_git, ExportOptions, ExportResult};
 pub use genesis::is_genesis_change;
 pub use import::{
-    anchor_imported_history_at_base_link, expand_git_commit_prefix, import_git_history,
-    import_git_history_to_commit_with_blobs, import_git_history_with_blobs, is_ancestor_commit,
-    semantic_change_id_from_git_oid_hex, GitOidPrefixExpansion, ImportOptions, ImportedChange,
+    anchor_imported_history_at_base_link, base_link_change_id_from_git_oid_hex,
+    expand_git_commit_prefix, import_git_history, import_git_history_to_commit_with_blobs,
+    import_git_history_with_blobs, is_ancestor_commit, semantic_change_id_from_git_oid_hex,
+    GitOidPrefixExpansion, ImportOptions, ImportedChange,
 };

--- a/crates/kin-mcp/src/handlers/mod.rs
+++ b/crates/kin-mcp/src/handlers/mod.rs
@@ -160,6 +160,7 @@ mod tests {
         file_hashes: HashMap<FilePathId, Hash256>,
         branches: Vec<Branch>,
         changes_by_id: HashMap<SemanticChangeId, SemanticChange>,
+        actors_by_id: HashMap<kin_model::provenance::ActorId, kin_model::provenance::Actor>,
         approvals_by_change: HashMap<SemanticChangeId, Vec<kin_model::provenance::Approval>>,
     }
 
@@ -849,14 +850,14 @@ mod tests {
         }
         fn get_actor(
             &self,
-            _: &kin_model::provenance::ActorId,
+            id: &kin_model::provenance::ActorId,
         ) -> std::result::Result<Option<kin_model::provenance::Actor>, Self::Error> {
-            Ok(None)
+            Ok(self.actors_by_id.get(id).cloned())
         }
         fn list_actors(
             &self,
         ) -> std::result::Result<Vec<kin_model::provenance::Actor>, Self::Error> {
-            Ok(vec![])
+            Ok(self.actors_by_id.values().cloned().collect())
         }
         fn create_delegation(
             &self,
@@ -2760,6 +2761,25 @@ mod tests {
         }
     }
 
+    fn gov_approver_id() -> kin_model::provenance::ActorId {
+        kin_model::provenance::ActorId::from_hash(Hash256::from_bytes([0xa5; 32]))
+    }
+
+    fn register_gov_human_approver(store: &mut EmptyStore) {
+        let actor = kin_model::provenance::Actor {
+            actor_id: gov_approver_id(),
+            kind: kin_model::provenance::ActorKind::Human,
+            display_name: "reviewer".into(),
+            external_refs: vec![],
+        };
+        store.actors_by_id.insert(actor.actor_id, actor);
+    }
+
+    fn add_gov_root(store: &mut EmptyStore) {
+        let root = gov_change(0, None, "kin");
+        store.changes_by_id.insert(root.id, root);
+    }
+
     fn gov_approval(
         change: &SemanticChange,
         decision: kin_model::provenance::ApprovalDecision,
@@ -2767,7 +2787,7 @@ mod tests {
         kin_model::provenance::Approval {
             approval_id: kin_model::provenance::ApprovalId::new(),
             change_id: change.id,
-            approver: kin_model::provenance::ActorId::new(),
+            approver: gov_approver_id(),
             decision,
             reason: "test".into(),
             timestamp: kin_model::timestamp::Timestamp::now(),
@@ -2804,13 +2824,11 @@ mod tests {
         }
     }
 
-    async fn call_release_check(store: &EmptyStore, require_approval: bool) -> serde_json::Value {
+    async fn call_release_check_with_args(
+        store: &EmptyStore,
+        args: HashMap<String, serde_json::Value>,
+    ) -> serde_json::Value {
         let sessions = SessionRegistry::new();
-        let mut args = HashMap::new();
-        args.insert(
-            "require_approval".into(),
-            serde_json::json!(require_approval),
-        );
         let result = handle_tool_call(
             "kin_release_check",
             &args,
@@ -2826,12 +2844,109 @@ mod tests {
         serde_json::from_str(&text).unwrap()
     }
 
+    async fn call_release_check(store: &EmptyStore, require_approval: bool) -> serde_json::Value {
+        call_release_check_with_args(
+            store,
+            HashMap::from([(
+                "require_approval".into(),
+                serde_json::json!(require_approval),
+            )]),
+        )
+        .await
+    }
+
     #[tokio::test]
-    async fn release_check_require_approval_passes_with_no_branches() {
-        // No branches => nothing to walk => approval gate cannot find blockers.
+    async fn release_check_force_overrides_baseline_but_not_strict_source_proof() {
+        let mut store = EmptyStore::default();
+        let entity = gov_entity("unbound", EntityKind::Function, Visibility::Public);
+        store.entities_by_id.insert(entity.id, entity.clone());
+        let mut root = gov_change(0, None, "kin");
+        root.entity_deltas = vec![kin_model::EntityDelta::Added(entity)];
+        store.changes_by_id.insert(root.id, root.clone());
+        store.branches.push(Branch {
+            name: BranchName::new("main"),
+            head: root.id,
+        });
+
+        let baseline = call_release_check_with_args(&store, HashMap::new()).await;
+        assert_eq!(baseline["pass"], false);
+        assert_eq!(baseline["coverage"]["missing_proof_count"], 1);
+
+        let forced = call_release_check_with_args(
+            &store,
+            HashMap::from([("force".into(), serde_json::json!(true))]),
+        )
+        .await;
+        assert_eq!(forced["pass"], true);
+
+        let strict = call_release_check_with_args(
+            &store,
+            HashMap::from([
+                ("force".into(), serde_json::json!(true)),
+                ("require_proof".into(), serde_json::json!(true)),
+            ]),
+        )
+        .await;
+        assert_eq!(strict["pass"], false);
+        assert!(strict["blockers"][0]
+            .as_str()
+            .unwrap()
+            .contains("immutable source-bound"));
+    }
+
+    #[tokio::test]
+    async fn release_check_binds_source_count_and_branch_cas_not_ambient_entities() {
+        let mut store = EmptyStore::default();
+        let source_entity = gov_entity("source", EntityKind::Function, Visibility::Public);
+        let ambient_entity = gov_entity("ambient", EntityKind::Function, Visibility::Public);
+        store
+            .entities_by_id
+            .insert(source_entity.id, source_entity.clone());
+        store
+            .entities_by_id
+            .insert(ambient_entity.id, ambient_entity);
+
+        let mut source = gov_change(0, None, "kin");
+        source.entity_deltas = vec![kin_model::EntityDelta::Added(source_entity)];
+        let advanced = gov_change(1, Some(0), "human");
+        store.changes_by_id.insert(source.id, source.clone());
+        store.changes_by_id.insert(advanced.id, advanced.clone());
+        store.branches.push(Branch {
+            name: BranchName::new("main"),
+            head: advanced.id,
+        });
+
+        let response = call_release_check_with_args(
+            &store,
+            HashMap::from([
+                ("force".into(), serde_json::json!(true)),
+                (
+                    "source_change_id".into(),
+                    serde_json::json!(source.id.to_string()),
+                ),
+                ("expected_entity_count".into(), serde_json::json!(2)),
+            ]),
+        )
+        .await;
+
+        assert_eq!(response["pass"], false);
+        assert_eq!(response["source_entity_count"], 1);
+        let blockers = response["blockers"].as_array().unwrap();
+        assert!(blockers
+            .iter()
+            .any(|blocker| blocker.as_str().unwrap().contains("branch main moved")));
+        assert!(blockers.iter().any(|blocker| blocker
+            .as_str()
+            .unwrap()
+            .contains("expected entity count 2")));
+    }
+
+    #[tokio::test]
+    async fn release_check_requires_source_authority_when_no_branch_exists() {
         let store = EmptyStore::default();
-        let response = call_release_check(&store, true).await;
-        assert_eq!(response["pass"], true);
+        let error = verification::handle_release_check(&HashMap::new(), &store).unwrap_err();
+        assert!(matches!(error, crate::error::McpError::InvalidParams(_)));
+        assert!(error.to_string().contains("requires branch"));
     }
 
     #[tokio::test]
@@ -2839,7 +2954,8 @@ mod tests {
         // The false-green this fix targets: an agent change with NO approval must
         // fail the gate. (Previously it passed because any audit event sufficed.)
         let mut store = EmptyStore::default();
-        let head = gov_change(1, None, "claude-agent");
+        add_gov_root(&mut store);
+        let head = gov_change(1, Some(0), "claude-agent");
         store.changes_by_id.insert(head.id, head.clone());
         store.branches.push(Branch {
             name: BranchName::new("main"),
@@ -2852,15 +2968,17 @@ mod tests {
         assert!(
             blockers
                 .iter()
-                .any(|b| b.as_str().unwrap().contains("unapproved agent change")),
-            "blocker list must name the unapproved agent change: {blockers:?}"
+                .any(|b| b.as_str().unwrap().contains("lack human approval")),
+            "blocker list must name the unapproved non-root change: {blockers:?}"
         );
     }
 
     #[tokio::test]
     async fn release_check_passes_when_agent_change_approved() {
         let mut store = EmptyStore::default();
-        let head = gov_change(1, None, "claude-agent");
+        add_gov_root(&mut store);
+        register_gov_human_approver(&mut store);
+        let head = gov_change(1, Some(0), "claude-agent");
         store.changes_by_id.insert(head.id, head.clone());
         store.approvals_by_change.insert(
             head.id,
@@ -2883,7 +3001,9 @@ mod tests {
         // c1 (agent, approved) <- c2 (agent, unapproved, HEAD): the later
         // unapproved mutation must block even though an earlier change is approved.
         let mut store = EmptyStore::default();
-        let c1 = gov_change(1, None, "agent-a");
+        add_gov_root(&mut store);
+        register_gov_human_approver(&mut store);
+        let c1 = gov_change(1, Some(0), "agent-a");
         let c2 = gov_change(2, Some(1), "agent-a");
         store.changes_by_id.insert(c1.id, c1.clone());
         store.changes_by_id.insert(c2.id, c2.clone());
@@ -2915,9 +3035,10 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn release_check_human_change_does_not_block() {
+    async fn release_check_display_name_cannot_bypass_approval() {
         let mut store = EmptyStore::default();
-        let head = gov_change(1, None, "alice");
+        add_gov_root(&mut store);
+        let head = gov_change(1, Some(0), "alice");
         store.changes_by_id.insert(head.id, head.clone());
         store.branches.push(Branch {
             name: BranchName::new("main"),
@@ -2925,14 +3046,18 @@ mod tests {
         });
 
         let response = call_release_check(&store, true).await;
-        assert_eq!(response["pass"], true, "human-authored change is not gated");
+        assert_eq!(
+            response["pass"], false,
+            "an unauthenticated author display name must not bypass approval"
+        );
     }
 
     #[tokio::test]
     async fn release_check_approval_disabled_skips_gate() {
         // With require_approval=false, an unapproved agent change must NOT block.
         let mut store = EmptyStore::default();
-        let head = gov_change(1, None, "claude-agent");
+        add_gov_root(&mut store);
+        let head = gov_change(1, Some(0), "claude-agent");
         store.changes_by_id.insert(head.id, head.clone());
         store.branches.push(Branch {
             name: BranchName::new("main"),
@@ -3004,8 +3129,9 @@ mod tests {
         // so the sort is what makes the output stable. Two identical-state calls
         // must produce byte-identical blockers.
         let mut store = EmptyStore::default();
-        let c_a = gov_change(0xAA, None, "agent-a");
-        let c_b = gov_change(0xBB, None, "agent-b");
+        add_gov_root(&mut store);
+        let c_a = gov_change(0xAA, Some(0), "agent-a");
+        let c_b = gov_change(0xBB, Some(0), "agent-b");
         store.changes_by_id.insert(c_a.id, c_a.clone());
         store.changes_by_id.insert(c_b.id, c_b.clone());
         store.branches.push(Branch {

--- a/crates/kin-mcp/src/handlers/verification.rs
+++ b/crates/kin-mcp/src/handlers/verification.rs
@@ -59,12 +59,14 @@ pub fn handle_verify_entity<G: GraphStore>(
 pub const COVERAGE_SUMMARY_DESC: &str = "\
 Get repo-wide test coverage at a glance: total entities, how many are covered, the \
 coverage ratio, and the list of entities still missing test proof. Reach for it to \
-assess overall test health, find what's untested, or feed a release/quality gate. It's \
+assess current test health or find what's untested. Verification runs are not yet \
+bound to immutable source changes, so this advisory live view does not authorize a release. It's \
 the whole-repo counterpart to kin_verify_entity (one entity) and underlies \
 kin_release_check's proof requirement.";
 
 pub fn handle_coverage_summary<G: GraphStore>(store: &G) -> Result<ToolCallResult> {
-    let coverage = store.get_coverage_summary().map_err(McpError::graph)?;
+    let coverage = kin_review::passing_proof_coverage(store)
+        .map_err(|error| McpError::Review(error.to_string()))?;
 
     let result = serde_json::json!({
         "total_entities": coverage.total_entities,
@@ -126,80 +128,195 @@ pub fn handle_security_scan<G: GraphStore>(
 }
 
 pub const RELEASE_CHECK_DESC: &str = "\
-Run a pre-release gate and get a pass/fail verdict with the specific blockers. Toggle \
-the policy you want enforced: require_proof fails when entities are missing test proof; \
-require_approval fails when any agent-authored change in recent history lacks a recorded \
-approval (the same gate as `kin release --require-approval`). Returns whether the release \
-would pass plus a list of what's blocking it and the current coverage figures. Reach for \
-it as the final go/no-go check before cutting a release, consolidating coverage and \
-approval gates into one answer.";
+Run a graph-only pre-release advisory against one named branch and immutable source change. \
+force overrides only the baseline coverage threshold; require_proof fails closed for every \
+non-empty source because verification runs do not yet carry immutable source authority; \
+require_approval requires human approval for every reachable non-root change. The result \
+binds its source, rechecks the branch-head/source match before returning, and checks exact \
+graph history, source-tree completeness, and the optional expected entity count. It is not \
+daemon admission: object availability and the final mutation CAS are enforced only by \
+`kin release`.";
+
+fn release_optional_bool(
+    args: &HashMap<String, serde_json::Value>,
+    key: &str,
+    default: bool,
+) -> Result<bool> {
+    match args.get(key) {
+        None => Ok(default),
+        Some(value) => value
+            .as_bool()
+            .ok_or_else(|| McpError::InvalidParams(format!("{key} must be a boolean"))),
+    }
+}
+
+fn release_optional_string(
+    args: &HashMap<String, serde_json::Value>,
+    key: &str,
+) -> Result<Option<String>> {
+    match args.get(key) {
+        None => Ok(None),
+        Some(value) => value
+            .as_str()
+            .map(|value| Some(value.to_string()))
+            .ok_or_else(|| McpError::InvalidParams(format!("{key} must be a string"))),
+    }
+}
+
+fn release_optional_entity_count(
+    args: &HashMap<String, serde_json::Value>,
+) -> Result<Option<usize>> {
+    match args.get("expected_entity_count") {
+        None => Ok(None),
+        Some(value) => {
+            let count = value.as_u64().ok_or_else(|| {
+                McpError::InvalidParams(
+                    "expected_entity_count must be a non-negative integer".to_string(),
+                )
+            })?;
+            usize::try_from(count)
+                .map(Some)
+                .map_err(|_| McpError::InvalidParams("expected_entity_count exceeds usize".into()))
+        }
+    }
+}
 
 pub fn handle_release_check<G: GraphStore>(
     args: &HashMap<String, serde_json::Value>,
     store: &G,
 ) -> Result<ToolCallResult> {
-    let require_proof = get_optional_bool(args, "require_proof", false);
-    let require_approval = get_optional_bool(args, "require_approval", false);
+    let require_proof = release_optional_bool(args, "require_proof", false)?;
+    let require_approval = release_optional_bool(args, "require_approval", false)?;
+    let force = release_optional_bool(args, "force", false)?;
+    let requested_branch = release_optional_string(args, "branch")?;
+    let requested_source = release_optional_string(args, "source_change_id")?
+        .map(|value| parse_change_id(&value))
+        .transpose()?;
+    let expected_entity_count = release_optional_entity_count(args)?;
 
-    let coverage = store.get_coverage_summary().map_err(McpError::graph)?;
+    let mut branches = store.list_branches().map_err(McpError::graph)?;
+    branches.sort_by(|left, right| left.name.0.cmp(&right.name.0));
+    let branch = if let Some(name) = requested_branch {
+        store
+            .get_branch(&kin_model::BranchName::new(&name))
+            .map_err(McpError::graph)?
+            .ok_or_else(|| McpError::InvalidParams(format!("branch not found: {name}")))?
+    } else if let Some(main) = branches.iter().find(|branch| branch.name.0 == "main") {
+        main.clone()
+    } else if let [only] = branches.as_slice() {
+        only.clone()
+    } else {
+        return Err(McpError::InvalidParams(
+            "kin_release_check requires branch when graph truth has zero or multiple branches"
+                .to_string(),
+        ));
+    };
+    let source_head = requested_source.unwrap_or(branch.head);
+    store
+        .get_change(&source_head)
+        .map_err(McpError::graph)?
+        .ok_or_else(|| {
+            McpError::Review(format!(
+                "release source change {source_head} is not materialized"
+            ))
+        })?;
+    let source_state = store
+        .resolve_graph_at(&source_head)
+        .map_err(|error| McpError::Review(error.to_string()))?;
+    let coverage = kin_review::source_bound_release_proof_coverage_for_entities(
+        source_state.entities.values(),
+    );
 
-    let mut pass = true;
     let mut blockers: Vec<String> = Vec::new();
 
-    if require_proof && !coverage.missing_proof.is_empty() {
-        pass = false;
+    if let Some(expected) = expected_entity_count {
+        if expected != source_state.entities.len() {
+            blockers.push(format!(
+                "expected entity count {expected} does not match immutable source count {}",
+                source_state.entities.len()
+            ));
+        }
+    }
+
+    match store
+        .resolve_source_tree_at(&source_head)
+        .map_err(McpError::graph)?
+    {
+        kin_model::SourceTreeResolution::Exact { .. } => {}
+        kin_model::SourceTreeResolution::Incomplete { gaps } => blockers.push(format!(
+            "immutable source tree is incomplete at {source_head}: {} gap(s)",
+            gaps.len()
+        )),
+    }
+
+    if coverage.coverage_ratio < 0.5 && !force {
         blockers.push(format!(
-            "{} entities missing test proof",
+            "immutable source-bound proof coverage {:.1}% is below 50%",
+            coverage.coverage_ratio * 100.0
+        ));
+    }
+
+    if require_proof && !coverage.missing_proof.is_empty() {
+        blockers.push(format!(
+            "{} entities missing immutable source-bound test proof",
             coverage.missing_proof.len()
         ));
     }
 
     if require_approval {
-        // Match `kin release --require-approval`: walk change history from each
-        // branch head and block on any agent-authored change that lacks a
-        // recorded `Approved` approval. The store has no working-tree HEAD file,
-        // so heads are resolved from the branch graph (graph truth). A branch is
-        // walked over its first-parent linear history.
-        let branches = store.list_branches().map_err(McpError::graph)?;
-        let mut seen: std::collections::HashSet<kin_model::SemanticChangeId> =
-            std::collections::HashSet::new();
-        let mut unapproved: Vec<kin_review::UnapprovedAgentChange> = Vec::new();
-        for branch in &branches {
-            for change in kin_review::unapproved_agent_changes(store, &branch.head, 50)
-                .map_err(|e| McpError::Review(e.to_string()))?
-            {
-                if seen.insert(change.change_id) {
-                    unapproved.push(change);
-                }
-            }
-        }
-        // Total-order the blockers by change id so the emitted list is byte-stable
-        // across identical-state runs regardless of branch iteration order — agents
-        // diffing gate output must not see phantom reorderings.
+        let mut unapproved = kin_review::unapproved_changes(store, &source_head, usize::MAX)
+            .map_err(|error| McpError::Review(error.to_string()))?;
         unapproved.sort_by(|a, b| a.change_id.to_string().cmp(&b.change_id.to_string()));
         if !unapproved.is_empty() {
-            pass = false;
             let detail = unapproved
                 .iter()
                 .map(|c| format!("{} ({})", c.change_id, c.author))
                 .collect::<Vec<_>>()
                 .join(", ");
             blockers.push(format!(
-                "{} unapproved agent change(s): {}",
+                "{} non-root change(s) lack human approval: {}",
                 unapproved.len(),
                 detail
             ));
         }
     }
 
+    // This tool is advisory and cannot hold the daemon's mutation gate, but it
+    // must at least detect a branch move that happened while the source checks
+    // above were running. Publication still performs the authoritative CAS.
+    let final_branch = store.get_branch(&branch.name).map_err(McpError::graph)?;
+    let final_branch_head = final_branch.as_ref().map(|branch| branch.head);
+    match final_branch_head {
+        Some(head) if head == source_head => {}
+        Some(head) => blockers.push(format!(
+            "branch {} moved: expected source {}, current head {}",
+            branch.name, source_head, head
+        )),
+        None => blockers.push(format!(
+            "branch {} disappeared while checking source {}",
+            branch.name, source_head
+        )),
+    }
+
     let result = serde_json::json!({
-        "pass": pass,
+        "pass": blockers.is_empty(),
         "blockers": blockers,
+        "branch": branch.name.to_string(),
+        "branch_head": final_branch_head.map(|head| head.to_string()),
+        "source_change_id": source_head.to_string(),
+        "source_entity_count": source_state.entities.len(),
         "coverage": {
             "total_entities": coverage.total_entities,
             "covered_entities": coverage.covered_entities,
             "coverage_ratio": coverage.coverage_ratio,
             "missing_proof_count": coverage.missing_proof.len(),
+        },
+        "authority": "advisory_graph_only",
+        "daemon_admission_required": true,
+        "proof_authority": if source_state.entities.is_empty() {
+            "empty_source_vacuous"
+        } else {
+            "strict_source_bound_proof_unavailable"
         }
     });
 
@@ -235,4 +352,54 @@ pub fn handle_contract_check<G: GraphStore>(
 
     let json = serde_json::to_string_pretty(&result).map_err(McpError::Json)?;
     Ok(ToolCallResult::text(json))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use kin_model::{Branch, BranchName, ChangeStore, Hash256, SemanticChangeId};
+
+    #[test]
+    fn release_check_fails_closed_for_dangling_branch_head() {
+        let store = kin_db::InMemoryGraph::new();
+        let missing = SemanticChangeId::from_hash(Hash256::from_bytes([0xd9; 32]));
+        store
+            .create_branch(&Branch {
+                name: BranchName::new("main"),
+                head: missing,
+            })
+            .unwrap();
+        let args = HashMap::from([("require_approval".to_string(), serde_json::json!(true))]);
+
+        let error = handle_release_check(&args, &store)
+            .expect_err("MCP release gate must not pass a missing graph head");
+
+        assert!(matches!(error, McpError::Review(_)));
+        assert!(error.to_string().contains(&missing.to_string()));
+        assert!(error.to_string().contains("not materialized"));
+    }
+
+    #[test]
+    fn release_check_rejects_present_parameters_with_wrong_json_types() {
+        let store = kin_db::InMemoryGraph::new();
+        let cases = [
+            ("branch", serde_json::json!(false)),
+            ("source_change_id", serde_json::json!([])),
+            ("expected_entity_count", serde_json::json!("1")),
+            ("force", serde_json::json!("false")),
+            ("require_proof", serde_json::json!(1)),
+            ("require_approval", serde_json::Value::Null),
+        ];
+
+        for (key, value) in cases {
+            let args = HashMap::from([(key.to_string(), value)]);
+            let error = handle_release_check(&args, &store)
+                .expect_err("present release parameters must not silently default on bad types");
+            assert!(matches!(error, McpError::InvalidParams(_)));
+            assert!(
+                error.to_string().contains(key),
+                "wrong-type error must name {key}: {error}"
+            );
+        }
+    }
 }

--- a/crates/kin-mcp/src/tools.rs
+++ b/crates/kin-mcp/src/tools.rs
@@ -759,8 +759,12 @@ pub fn tool_definitions() -> ToolsListResult {
                 input_schema: serde_json::json!({
                     "type": "object",
                     "properties": {
-                        "require_proof": { "type": "boolean", "description": "Require all entities to have test proof", "default": false },
-                        "require_approval": { "type": "boolean", "description": "Require approval on the latest change", "default": false }
+                        "branch": { "type": "string", "description": "Branch authority to evaluate; may be omitted only when main exists or graph truth has exactly one branch" },
+                        "source_change_id": { "type": "string", "description": "Optional observed branch head; a moved branch fails the advisory CAS check" },
+                        "expected_entity_count": { "type": "integer", "minimum": 0, "description": "Optional release-marker count to validate against the immutable source" },
+                        "force": { "type": "boolean", "description": "Override only the baseline 50% immutable source-bound proof coverage threshold", "default": false },
+                        "require_proof": { "type": "boolean", "description": "Require every entity to have immutable source-bound passing proof", "default": false },
+                        "require_approval": { "type": "boolean", "description": "Require a known human approval for every reachable non-root change", "default": false }
                     }
                 }),
             },

--- a/crates/kin-review/src/lib.rs
+++ b/crates/kin-review/src/lib.rs
@@ -41,8 +41,10 @@ pub use ranked_impact::{
 };
 pub use ref_graph::GraphAtRef;
 pub use release_gate::{
-    entities_touched_by_change, security_findings, unapproved_agent_changes, SecurityFinding,
-    SecurityFindingCounts, SecuritySeverity, UnapprovedAgentChange,
+    entities_touched_by_change, passing_proof_coverage, security_findings,
+    source_bound_release_proof_coverage, source_bound_release_proof_coverage_for_entities,
+    unapproved_agent_changes, unapproved_changes, SecurityFinding, SecurityFindingCounts,
+    SecuritySeverity, UnapprovedAgentChange, UnapprovedChange,
 };
 pub use review::{Review, SemanticReview};
 pub use risk::assess_risk;

--- a/crates/kin-review/src/release_gate.rs
+++ b/crates/kin-review/src/release_gate.rs
@@ -13,59 +13,171 @@ use kin_model::change::EntityDelta;
 use kin_model::entity::{EntityKind, Visibility};
 use kin_model::graph::GraphStore;
 use kin_model::ids::{EntityId, SemanticChangeId};
-use kin_model::provenance::ApprovalDecision;
+use kin_model::provenance::{ActorKind, ApprovalDecision};
 use kin_model::relation::{GraphNodeId, RelationKind};
+use kin_model::verification::{CoverageSummary, VerificationStatus};
 
 use crate::error::ReviewError;
 
-/// An unapproved change authored by an agent, found while walking history.
+/// A non-root change without a recorded human approval, found while walking history.
 #[derive(Debug, Clone, PartialEq, Eq)]
-pub struct UnapprovedAgentChange {
+pub struct UnapprovedChange {
     pub change_id: SemanticChangeId,
     pub author: String,
 }
 
-/// Walk change history from `head` and collect changes authored by an agent
-/// that lack a recorded `Approved` approval.
+/// Walk change history from `head` and collect non-root changes that lack a
+/// recorded approval by a known human actor.
 ///
-/// Matches the `kin release --require-approval` gate: a change blocks the
-/// release when its author identifier contains "agent" and no approval with
-/// decision `Approved` is recorded for it. The walk follows first parents
-/// (linear history) for up to `limit` changes.
-pub fn unapproved_agent_changes<G: GraphStore>(
+/// `SemanticChange.author` is an unauthenticated display string and supported
+/// daemon commits commonly populate it with the OS username even when an agent
+/// authored the change. It therefore cannot safely decide whether approval is
+/// required. The release gate fails closed for every non-root change and only
+/// accepts an `Approved` decision whose approver resolves to `ActorKind::Human`.
+pub fn unapproved_changes<G: GraphStore>(
     store: &G,
     head: &SemanticChangeId,
     limit: usize,
-) -> Result<Vec<UnapprovedAgentChange>, ReviewError> {
+) -> Result<Vec<UnapprovedChange>, ReviewError> {
     let mut unapproved = Vec::new();
-    let mut current = *head;
+    let mut pending = vec![*head];
+    let mut visited = std::collections::HashSet::new();
 
     for _ in 0..limit {
-        let change = match store.get_change(&current).map_err(ReviewError::graph)? {
-            Some(change) => change,
-            None => break,
+        let Some(current) = pending.pop() else {
+            break;
         };
+        if !visited.insert(current) {
+            continue;
+        }
+        let change = store
+            .get_change(&current)
+            .map_err(ReviewError::graph)?
+            .ok_or(ReviewError::RefStateUnavailable {
+                at: *head,
+                missing: current,
+            })?;
 
-        let approvals = store
+        let mut is_approved = false;
+        for approval in store
             .get_approvals_for_change(&change.id)
-            .map_err(ReviewError::graph)?;
-        let is_approved = approvals
-            .iter()
-            .any(|a| a.decision == ApprovalDecision::Approved);
-        if !is_approved && change.author.0.contains("agent") {
-            unapproved.push(UnapprovedAgentChange {
+            .map_err(ReviewError::graph)?
+        {
+            if approval.decision != ApprovalDecision::Approved {
+                continue;
+            }
+            if store
+                .get_actor(&approval.approver)
+                .map_err(ReviewError::graph)?
+                .is_some_and(|actor| actor.kind == ActorKind::Human)
+            {
+                is_approved = true;
+                break;
+            }
+        }
+        if !change.parents.is_empty() && !is_approved {
+            unapproved.push(UnapprovedChange {
                 change_id: change.id,
                 author: change.author.0.clone(),
             });
         }
 
-        match change.parents.first() {
-            Some(parent) => current = *parent,
-            None => break,
+        for parent in change.parents.iter().rev() {
+            if !visited.contains(parent) {
+                pending.push(*parent);
+            }
         }
     }
 
+    unapproved.sort_by_key(|change| change.change_id.to_string());
     Ok(unapproved)
+}
+
+// Compatibility aliases for downstream crates compiled against the pre-0.3
+// symbol names. The policy has always been conservative at this boundary: it
+// applies to every non-root change, regardless of the unauthenticated author
+// display string.
+pub use unapproved_changes as unapproved_agent_changes;
+pub use UnapprovedChange as UnapprovedAgentChange;
+
+/// Compute current, advisory proof coverage for a graph.
+///
+/// Structural `Test -> Covers -> Entity` links describe intended coverage,
+/// but do not prove that a test ran or passed. Release proof therefore counts
+/// an entity only when at least one persisted `VerificationRun` linked through
+/// `run_proves_entity` has status `Passing`.
+pub fn passing_proof_coverage<G: GraphStore>(store: &G) -> Result<CoverageSummary, ReviewError> {
+    let mut entities = store.list_all_entities().map_err(ReviewError::graph)?;
+    entities.sort_by_key(|entity| entity.id.to_string());
+
+    let mut covered_entities = 0_usize;
+    let mut missing_proof = Vec::new();
+    for entity in &entities {
+        let has_passing_run = store
+            .list_runs_proving_entity(&entity.id)
+            .map_err(ReviewError::graph)?
+            .iter()
+            .any(|run| run.status == VerificationStatus::Passing);
+        if has_passing_run {
+            covered_entities += 1;
+        } else {
+            missing_proof.push(entity.id);
+        }
+    }
+
+    let total_entities = entities.len();
+    let coverage_ratio = if total_entities == 0 {
+        0.0
+    } else {
+        covered_entities as f64 / total_entities as f64
+    };
+    Ok(CoverageSummary {
+        total_entities,
+        covered_entities,
+        coverage_ratio,
+        missing_proof,
+    })
+}
+
+/// Compute proof coverage admissible for an immutable release source.
+///
+/// `VerificationRun` currently has no source-change or source-manifest field,
+/// so a passing run in live graph state cannot prove an older immutable source
+/// and must not authorize publication. Until that binding exists, release
+/// admission fails closed by reporting every source entity as missing proof.
+/// The empty source is vacuously covered.
+pub fn source_bound_release_proof_coverage<G: GraphStore>(
+    store: &G,
+) -> Result<CoverageSummary, ReviewError> {
+    let mut entities = store.list_all_entities().map_err(ReviewError::graph)?;
+    entities.sort_by_key(|entity| entity.id.to_string());
+    Ok(source_bound_release_proof_coverage_for_entities(
+        entities.iter(),
+    ))
+}
+
+/// Compute fail-closed release coverage for an already-resolved immutable
+/// source state.
+///
+/// Callers use this after resolving a specific branch head or change, so
+/// ambient graph overlays cannot change the release count. Verification runs
+/// do not yet carry an immutable source binding; every entity in a non-empty
+/// source therefore remains missing and coverage is exactly 0%.
+pub fn source_bound_release_proof_coverage_for_entities<'a>(
+    entities: impl IntoIterator<Item = &'a kin_model::Entity>,
+) -> CoverageSummary {
+    let mut missing_proof = entities
+        .into_iter()
+        .map(|entity| entity.id)
+        .collect::<Vec<_>>();
+    missing_proof.sort_by_key(ToString::to_string);
+    let total_entities = missing_proof.len();
+    CoverageSummary {
+        total_entities,
+        covered_entities: 0,
+        coverage_ratio: if total_entities == 0 { 1.0 } else { 0.0 },
+        missing_proof,
+    }
 }
 
 /// Severity of a security finding, ordered low → high.
@@ -312,9 +424,9 @@ mod tests {
     use kin_model::entity::{
         Entity, EntityMetadata, EntityRole, FingerprintAlgorithm, SemanticFingerprint,
     };
-    use kin_model::graph::{ChangeStore, EntityStore, ProvenanceStore};
+    use kin_model::graph::{ChangeStore, EntityStore, ProvenanceStore, VerificationStore};
     use kin_model::ids::{AuthorId, Hash256, LanguageId, RelationId};
-    use kin_model::provenance::{ActorId, Approval, ApprovalId};
+    use kin_model::provenance::{Actor, ActorId, Approval, ApprovalId};
     use kin_model::relation::{Relation, RelationOrigin};
     use kin_model::timestamp::Timestamp;
 
@@ -371,11 +483,26 @@ mod tests {
         Approval {
             approval_id: ApprovalId::new(),
             change_id: change.id,
-            approver: ActorId::new(),
+            approver: ActorId::from_hash(Hash256::from_bytes([0xa5; 32])),
             decision,
             reason: "test".into(),
             timestamp: Timestamp::now(),
         }
+    }
+
+    fn register_approver(store: &InMemoryGraph, kind: ActorKind) {
+        store
+            .create_actor(&Actor {
+                actor_id: ActorId::from_hash(Hash256::from_bytes([0xa5; 32])),
+                kind,
+                display_name: "reviewer".into(),
+                external_refs: vec![],
+            })
+            .unwrap();
+    }
+
+    fn add_root(store: &InMemoryGraph) {
+        store.create_change(&change(0, None, "kin")).unwrap();
     }
 
     fn calls(src: &Entity, dst: &Entity) -> Relation {
@@ -397,7 +524,8 @@ mod tests {
     #[test]
     fn agent_change_without_approval_is_flagged() {
         let store = InMemoryGraph::new();
-        let c = change(1, None, "claude-agent");
+        add_root(&store);
+        let c = change(1, Some(0), "claude-agent");
         store.create_change(&c).unwrap();
 
         let found = unapproved_agent_changes(&store, &c.id, 50).unwrap();
@@ -409,7 +537,9 @@ mod tests {
     #[test]
     fn agent_change_with_approval_is_not_flagged() {
         let store = InMemoryGraph::new();
-        let c = change(1, None, "claude-agent");
+        add_root(&store);
+        register_approver(&store, ActorKind::Human);
+        let c = change(1, Some(0), "claude-agent");
         store.create_change(&c).unwrap();
         store
             .create_approval(&approval(&c, ApprovalDecision::Approved))
@@ -420,20 +550,37 @@ mod tests {
     }
 
     #[test]
-    fn human_change_without_approval_is_not_flagged() {
+    fn display_name_cannot_bypass_required_approval() {
         let store = InMemoryGraph::new();
-        let c = change(1, None, "alice");
+        add_root(&store);
+        let c = change(1, Some(0), "alice");
         store.create_change(&c).unwrap();
 
         let found = unapproved_agent_changes(&store, &c.id, 50).unwrap();
-        assert!(found.is_empty(), "non-agent author is never gated");
+        assert_eq!(found.len(), 1, "display text must not bypass the gate");
+    }
+
+    #[test]
+    fn assistant_approval_does_not_satisfy_human_gate() {
+        let store = InMemoryGraph::new();
+        add_root(&store);
+        register_approver(&store, ActorKind::Assistant);
+        let c = change(1, Some(0), "alice");
+        store.create_change(&c).unwrap();
+        store
+            .create_approval(&approval(&c, ApprovalDecision::Approved))
+            .unwrap();
+
+        let found = unapproved_agent_changes(&store, &c.id, 50).unwrap();
+        assert_eq!(found.len(), 1);
     }
 
     #[test]
     fn rejected_and_conditional_do_not_satisfy_approval() {
         for decision in [ApprovalDecision::Rejected, ApprovalDecision::Conditional] {
             let store = InMemoryGraph::new();
-            let c = change(1, None, "agent-x");
+            add_root(&store);
+            let c = change(1, Some(0), "agent-x");
             store.create_change(&c).unwrap();
             store.create_approval(&approval(&c, decision)).unwrap();
 
@@ -452,6 +599,7 @@ mod tests {
         // The new unapproved mutation must block even though an earlier change
         // was approved — this is the audit-events-exist-but-latest-unapproved case.
         let store = InMemoryGraph::new();
+        register_approver(&store, ActorKind::Human);
         let c1 = change(1, None, "agent-a");
         let c2 = change(2, Some(1), "agent-a");
         store.create_change(&c1).unwrap();
@@ -488,10 +636,45 @@ mod tests {
     }
 
     #[test]
-    fn missing_head_change_yields_no_blockers() {
+    fn missing_head_change_fails_closed() {
         let store = InMemoryGraph::new();
-        let found = unapproved_agent_changes(&store, &change_id(9), 50).unwrap();
-        assert!(found.is_empty());
+        let head = change_id(9);
+        let error = unapproved_agent_changes(&store, &head, 50).unwrap_err();
+        assert!(matches!(
+            error,
+            ReviewError::RefStateUnavailable { at, missing }
+                if at == head && missing == head
+        ));
+    }
+
+    #[test]
+    fn unbound_passing_run_is_advisory_but_never_release_authority() {
+        let store = InMemoryGraph::new();
+        let source = entity("source", EntityKind::Function, Visibility::Public);
+        store.upsert_entity(&source).unwrap();
+        let run = kin_model::VerificationRun {
+            run_id: kin_model::VerificationRunId::new(),
+            test_ids: vec![],
+            status: VerificationStatus::Passing,
+            runner: kin_model::TestRunner::Cargo,
+            started_at: Timestamp::now(),
+            finished_at: Some(Timestamp::now()),
+            duration_ms: Some(1),
+            evidence_blob: None,
+            exit_code: Some(0),
+        };
+        store.create_verification_run(&run).unwrap();
+        store
+            .link_run_proves_entity(&run.run_id, &source.id)
+            .unwrap();
+
+        assert_eq!(passing_proof_coverage(&store).unwrap().covered_entities, 1);
+        let release = source_bound_release_proof_coverage(&store).unwrap();
+        assert_eq!(release.covered_entities, 0);
+        assert_eq!(release.missing_proof, vec![source.id]);
+
+        let empty = source_bound_release_proof_coverage(&InMemoryGraph::new()).unwrap();
+        assert_eq!(empty.coverage_ratio, 1.0);
     }
 
     // ── security_findings ───────────────────────────────────────────────────

--- a/docs/mcp-tools.md
+++ b/docs/mcp-tools.md
@@ -119,7 +119,7 @@ can run `kin mcp start` with the same `agent-default` profile), see
 - **`kin_verify_entity`**: Inspect the test coverage recorded for an entity — which tests are linked to it and whether it is covered (optionally filtered by runner).
 - **`kin_coverage_summary`**: Report repo-wide test coverage — total entities, how many are covered, the ratio, and what's still untested.
 - **`kin_security_scan`**: Run a graph-based security/quality scan that returns findings with severity (today it surfaces dead/unreachable code; `propagate=true` also computes each finding's downstream impact).
-- **`kin_release_check`**: Run a pre-release gate returning a pass/fail verdict with blockers (toggle `require_proof` / `require_approval`).
+- **`kin_release_check`**: Run a graph-only advisory against a named branch and immutable source change. It checks exact history/tree completeness and an optional source entity count; `require_approval` covers every reachable non-root change, while `require_proof` currently fails closed for every non-empty source because verification runs are not yet source-bound. Final object availability and mutation CAS remain daemon `kin release` authority.
 - **`kin_contract_check`**: Check whether a specific behavioral contract has backing tests (which tests cover it, and whether it is covered).
 - **`kin_provenance_query`**: Answer who-changed-and-whether-approved for an entity — its change count, latest change, recorded approvals, and recent audit events.
 

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -148,7 +148,8 @@ agent/runtime surfaces beside it.
 
 *Flags:*
 - `--git-history <off|recent|full>`: how much Git history to import into the graph on init
-  (default: `recent`).
+  (default: `recent`, a deterministic HEAD-connected window of at most 50 commits;
+  `full` imports complete reachable ancestry).
 - `--force`: initialize even if a `.git/` directory is already present.
 - `--no-lsp`: skip LSP enrichment (faster, tree-sitter-only init).
 

--- a/packages/boundary-contracts/package.json
+++ b/packages/boundary-contracts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kin/boundary-contracts",
-  "version": "0.2.28",
+  "version": "0.3.0",
   "private": false,
   "description": "Shared contracts for Kin ecosystem boundaries.",
   "type": "module",

--- a/packages/kin-mcp/package.json
+++ b/packages/kin-mcp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kinlab/kin-mcp",
-  "version": "0.2.28",
+  "version": "0.3.0",
   "description": "Start Kin's MCP server, the system of record for AI-written software, through an npm-friendly wrapper.",
   "type": "module",
   "bin": {

--- a/packages/kin/package.json
+++ b/packages/kin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kinlab/kin",
-  "version": "0.2.28",
+  "version": "0.3.0",
   "description": "Canonical installer and launcher for Kin, the system of record for AI-written software. Provisions and runs the managed kin + kin-daemon release. MCP is one included mode (kin mcp start).",
   "license": "Apache-2.0",
   "type": "module",

--- a/tests/integration/src/p3_acceptance.rs
+++ b/tests/integration/src/p3_acceptance.rs
@@ -153,7 +153,7 @@ fn branch_switch_reprojects_working_directory() {
     let mut change_main = make_change(genesis_id, vec![entity_main], "add main_fn");
     change_main.artifact_deltas.push(ArtifactDelta {
         file_id: FilePathId::new("src/lib.rs"),
-        kind: ArtifactDeltaKind::Added,
+        kind: ArtifactDeltaKind::AddedRegularFile,
         old_hash: None,
         new_hash: Some(main_hash),
     });
@@ -178,7 +178,7 @@ fn branch_switch_reprojects_working_directory() {
     let mut change_feature = make_change(change_main.id, vec![entity_feature], "add feature_fn");
     change_feature.artifact_deltas.push(ArtifactDelta {
         file_id: FilePathId::new("src/feature.rs"),
-        kind: ArtifactDeltaKind::Added,
+        kind: ArtifactDeltaKind::AddedRegularFile,
         old_hash: None,
         new_hash: Some(feature_hash),
     });
@@ -189,7 +189,7 @@ fn branch_switch_reprojects_working_directory() {
 
     // Checkout main: working dir should have src/lib.rs only.
     let main_branch = graph.get_branch(&BranchName::new("main")).unwrap().unwrap();
-    let files_written = kin_core::checkout_branch(
+    let files_written = kin_core::tree::checkout_branch_between_heads(
         graph.as_ref(),
         &blob_store,
         &layout,
@@ -207,11 +207,11 @@ fn branch_switch_reprojects_working_directory() {
         .get_branch(&BranchName::new("feature"))
         .unwrap()
         .unwrap();
-    let files_written = kin_core::checkout_branch(
+    let files_written = kin_core::tree::checkout_branch_between_heads(
         graph.as_ref(),
         &blob_store,
         &layout,
-        &genesis_id,
+        &main_branch.head,
         &feature.head,
     )
     .unwrap();
@@ -624,7 +624,7 @@ fn git_export_import_round_trip() {
     let mut change = make_change(genesis_id, vec![entity], "add round_trip function");
     change.artifact_deltas.push(ArtifactDelta {
         file_id: FilePathId::new("src/lib.rs"),
-        kind: ArtifactDeltaKind::Added,
+        kind: ArtifactDeltaKind::AddedRegularFile,
         old_hash: None,
         new_hash: Some(content_hash),
     });

--- a/tests/integration/src/v1_acceptance.rs
+++ b/tests/integration/src/v1_acceptance.rs
@@ -366,7 +366,7 @@ fn git_export_creates_commits() {
     let mut change = make_change(genesis_id, vec![entity], "add exported function");
     change.artifact_deltas.push(kin_model::ArtifactDelta {
         file_id: kin_model::FilePathId::new("src/lib.rs"),
-        kind: kin_model::ArtifactDeltaKind::Added,
+        kind: kin_model::ArtifactDeltaKind::AddedRegularFile,
         old_hash: None,
         new_hash: Some(content_hash),
     });


### PR DESCRIPTION
## Summary

- make graph-owned exact source bytes and full semantic change identity authoritative across commit, import, checkout, diff, archive, and release paths
- fail closed on missing or conflicting historical source instead of repairing from current files or Git fallbacks
- harden materialization against reserved control paths, case aliases, file-directory transitions, and scan I/O ambiguity
- bind release decisions to exact historical evidence and require recorded human approvals for reachable non-root changes
- add bounded, single-flight archive handling and move the workspace to the published kin-model 0.4.0 and kin-lsp 0.4.0 contracts
- prepare the breaking Kin workspace version as 0.3.0 against kin-db 0.3.0

## Verification

At `4bc3205e6f3d1d79b6311d82a1e94ce9247bb819` in the DEV-LOCAL lane:

- `kin-cli --lib`: 1081 passed
- `kin-daemon --lib`: 398 passed
- `kin-core --lib`: 277 passed
- `kin-review --lib`: 226 passed
- `kin-git --lib`: 45 passed, 2 intentional ignores
- `cargo check -p kin-daemon`: passed
- `cargo fmt --all -- --check`: passed
- `git diff --check`: passed

## Release boundary

This PR is intentionally draft and its current verification is non-citable because kin-db 0.3.0 is not yet published; the local lockfile used an unpublished exact-head path resolution and remains uncommitted. After kin-db 0.3.0 publishes, regenerate `Cargo.lock` registry-only, run the release-clean gate outside the home directory, complete independent review and hosted CI, then merge in queue order.

Historical verification runs without immutable source/run binding remain excluded from proof. Human approval records are required, but actor identity is not yet cryptographically authenticated. Archive processing is bounded and single-flight but still buffered.