### PR TITLE
Add bot-mediated release tag workflow

### DIFF
--- a/.github/workflows/release-tag.yml
+++ b/.github/workflows/release-tag.yml
@@ -1,0 +1,272 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2026 Firelock, LLC
+
+name: Release Tag (bot-mediated)
+
+# Bot-mediated creation of a `vX.Y.Z` release tag. The repository ruleset
+# "Protect version release tags" restricts who may create `v*` tags. Instead of
+# the release captain holding the founder credential that the ruleset admits,
+# this workflow mints a short-lived installation token for the "kin-release-bot"
+# GitHub App (allowlisted in that ruleset) and creates the tag ref only after a
+# strict, fail-closed set of checks pass. Creating the ref with an App token —
+# never the default GITHUB_TOKEN — is what lets the existing tag-triggered
+# `release.yml` DAG fire.
+#
+# Every step below is fail-closed: any unmet precondition aborts before the tag
+# is created. See docs/release-bot.md for the operator runbook and the one-time
+# founder setup.
+
+on:
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: "Release tag to create (must match ^v[0-9]+.[0-9]+.[0-9]+$, e.g. v0.3.0)"
+        required: true
+        type: string
+      sha:
+        description: "40-hex commit SHA that MUST equal current origin/main HEAD"
+        required: true
+        type: string
+
+# The App installation token carries the only write capability (creating the
+# tag ref). The workflow's own GITHUB_TOKEN stays read-only: contents:read for
+# checkout and ref reads, checks:read to inspect the commit's check-runs.
+permissions:
+  contents: read
+  checks: read
+
+# Never run two tag mints at once, and never cancel one mid-flight.
+concurrency:
+  group: release-tag
+  cancel-in-progress: false
+
+jobs:
+  mint-release-tag:
+    name: Mint release tag
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - name: Guard — authorized actor and ref
+        # Only the release captain or the bot may dispatch, and only against the
+        # trusted workflow file on main. A branch dispatch of this file is
+        # refused loudly rather than silently skipped.
+        env:
+          ACTOR: ${{ github.actor }}
+          REF: ${{ github.ref }}
+          ALLOWED_ACTORS: |
+            troyjr4103
+            kin-release-bot[bot]
+        run: |
+          set -euo pipefail
+          if [ "$REF" != "refs/heads/main" ]; then
+            echo "::error::release-tag must be dispatched from main (got '$REF')"
+            exit 1
+          fi
+          authorized=0
+          while IFS= read -r allowed; do
+            [ -z "$allowed" ] && continue
+            [ "$allowed" = "$ACTOR" ] && authorized=1
+          done <<< "$ALLOWED_ACTORS"
+          if [ "$authorized" -ne 1 ]; then
+            echo "::error::actor '$ACTOR' is not authorized to mint release tags"
+            exit 1
+          fi
+          echo "authorized actor=$ACTOR ref=$REF"
+
+      - name: Validate inputs
+        # workflow_dispatch inputs cannot enforce a regex, so validate here and
+        # normalize the SHA to lowercase. Both are routed through the job
+        # environment (never interpolated into a shell) to stay injection-safe.
+        env:
+          RAW_TAG: ${{ inputs.tag }}
+          RAW_SHA: ${{ inputs.sha }}
+        run: |
+          set -euo pipefail
+          tag="$RAW_TAG"
+          sha="$(printf '%s' "$RAW_SHA" | tr '[:upper:]' '[:lower:]')"
+          if ! printf '%s' "$tag" | grep -Eq '^v[0-9]+\.[0-9]+\.[0-9]+$'; then
+            echo "::error::tag '$tag' must match ^v[0-9]+\.[0-9]+\.[0-9]+\$"
+            exit 1
+          fi
+          if ! printf '%s' "$sha" | grep -Eq '^[0-9a-f]{40}$'; then
+            echo "::error::sha '$sha' must be a 40-character lowercase hex commit SHA"
+            exit 1
+          fi
+          echo "TAG=$tag" >> "$GITHUB_ENV"
+          echo "SHA=$sha" >> "$GITHUB_ENV"
+          echo "validated tag=$tag sha=$sha"
+
+      - name: Checkout requested SHA
+        uses: actions/checkout@v7
+        with:
+          ref: ${{ env.SHA }}
+          fetch-depth: 0
+          persist-credentials: false
+
+      - name: Verify SHA is current origin/main HEAD
+        run: |
+          set -euo pipefail
+          git fetch --no-tags origin main
+          head_sha="$(git rev-parse HEAD)"
+          main_sha="$(git rev-parse FETCH_HEAD)"
+          echo "checked-out=$head_sha main=$main_sha requested=$SHA"
+          if [ "$head_sha" != "$SHA" ]; then
+            echo "::error::checked-out HEAD ($head_sha) != requested sha ($SHA)"
+            exit 1
+          fi
+          if [ "$head_sha" != "$main_sha" ]; then
+            echo "::error::sha $SHA is not current origin/main HEAD ($main_sha) — refusing"
+            exit 1
+          fi
+          echo "sha confirmed at origin/main HEAD"
+
+      - name: Verify tag version matches workspace version
+        # The version of record is [workspace.package].version in the root
+        # Cargo.toml at the requested SHA. The tag must be exactly that, v-prefixed.
+        run: |
+          set -euo pipefail
+          ws_version="$(python3 - <<'PY'
+          import tomllib
+          with open("Cargo.toml", "rb") as f:
+              data = tomllib.load(f)
+          print(data["workspace"]["package"]["version"])
+          PY
+          )"
+          expected="v${ws_version}"
+          echo "workspace.package.version=$ws_version expected_tag=$expected requested_tag=$TAG"
+          if [ "$TAG" != "$expected" ]; then
+            echo "::error::tag $TAG does not match workspace version tag $expected at $SHA"
+            exit 1
+          fi
+          echo "tag matches workspace version"
+
+      - name: Verify required checks are green
+        # Fail closed on the commit's check-runs. REQUIRED_CHECKS is the
+        # presence-required release-critical set — a sha missing any of these is
+        # refused even if nothing failed. Each must be present and green
+        # (skipped/neutral allowed — DCO is skipped on a merged HEAD). Separately,
+        # no check anywhere may be failing or still in progress; the second loop
+        # owns that present-check strictness, so this list need not mirror every
+        # CI context. It is the main branch-protection required contexts plus the
+        # Windows installer leg, which is release-critical and never optional.
+        env:
+          GH_TOKEN: ${{ github.token }}
+          REPO: ${{ github.repository }}
+          REQUIRED_CHECKS: |
+            Check & Test (ubuntu-latest)
+            Check & Test (macos-latest)
+            DCO Sign-off
+            cargo-deny
+            gitleaks (full history)
+            Windows installer + vector-free release build
+        run: |
+          set -euo pipefail
+          gh api "repos/$REPO/commits/$SHA/check-runs?per_page=100" --paginate \
+            -q '.check_runs[] | {name: .name, status: .status, conclusion: .conclusion, id: .id}' \
+            > check_runs.ndjson || { echo "::error::failed to fetch check-runs for $SHA"; exit 1; }
+          python3 - <<'PY'
+          import json, os, sys
+
+          runs = {}
+          with open("check_runs.ndjson") as handle:
+              for line in handle:
+                  line = line.strip()
+                  if not line:
+                      continue
+                  run = json.loads(line)
+                  name = run["name"]
+                  # Keep only the latest attempt per check name (highest id).
+                  if name not in runs or run["id"] > runs[name]["id"]:
+                      runs[name] = run
+
+          required = [c.strip() for c in os.environ["REQUIRED_CHECKS"].splitlines() if c.strip()]
+          acceptable = {"success", "skipped", "neutral"}
+          errors = []
+
+          if not runs:
+              errors.append("no check-runs found on sha")
+
+          for name in required:
+              run = runs.get(name)
+              if run is None:
+                  errors.append(f"missing required check: {name}")
+              elif run["status"] != "completed":
+                  errors.append(f"required check not completed: {name} (status={run['status']})")
+              elif run["conclusion"] not in acceptable:
+                  errors.append(f"required check not green: {name} (conclusion={run['conclusion']})")
+
+          for name, run in runs.items():
+              if run["status"] != "completed":
+                  errors.append(f"check still in progress: {name} (status={run['status']})")
+              elif run["conclusion"] not in acceptable:
+                  errors.append(f"check not green: {name} (conclusion={run['conclusion']})")
+
+          if errors:
+              print("::error::refusing — check verification failed:")
+              for err in errors:
+                  print(f"  - {err}")
+              sys.exit(1)
+
+          print(f"verified {len(required)} required checks green; "
+                f"{len(runs)} total checks, none failing or in progress")
+          PY
+
+      - name: Verify tag does not already exist
+        env:
+          GH_TOKEN: ${{ github.token }}
+          REPO: ${{ github.repository }}
+        run: |
+          set -euo pipefail
+          if gh api "repos/$REPO/git/ref/tags/$TAG" >/dev/null 2>&1; then
+            echo "::error::tag $TAG already exists — refusing"
+            exit 1
+          fi
+          echo "tag $TAG does not exist yet"
+
+      - name: Mint kin-release-bot installation token
+        id: app-token
+        uses: actions/create-github-app-token@v2
+        with:
+          app-id: ${{ secrets.KIN_RELEASE_BOT_APP_ID }}
+          private-key: ${{ secrets.KIN_RELEASE_BOT_PRIVATE_KEY }}
+
+      - name: Create release tag ref
+        # Created with the App token (not GITHUB_TOKEN) so the ruleset admits it
+        # AND so the tag push triggers release.yml.
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+          REPO: ${{ github.repository }}
+        run: |
+          set -euo pipefail
+          echo "creating refs/tags/$TAG -> $SHA via kin-release-bot"
+          gh api "repos/$REPO/git/refs" \
+            -f ref="refs/tags/$TAG" \
+            -f sha="$SHA" >/dev/null
+          echo "created refs/tags/$TAG"
+
+      - name: Verify tag ref and summarize
+        env:
+          GH_TOKEN: ${{ github.token }}
+          REPO: ${{ github.repository }}
+          ACTOR: ${{ github.actor }}
+        run: |
+          set -euo pipefail
+          got="$(gh api "repos/$REPO/git/ref/tags/$TAG" -q '.object.sha')"
+          echo "created ref points at: $got (expected $SHA)"
+          if [ "$got" != "$SHA" ]; then
+            echo "::error::post-verify failed: tag $TAG points at $got, not $SHA"
+            exit 1
+          fi
+          {
+            echo "## Release tag minted"
+            echo ""
+            echo "| field | value |"
+            echo "| --- | --- |"
+            echo "| tag | \`$TAG\` |"
+            echo "| sha | \`$SHA\` |"
+            echo "| actor | \`$ACTOR\` |"
+            echo "| repo | \`$REPO\` |"
+            echo ""
+            echo "Tag ref created with the kin-release-bot installation token, which triggers the fail-closed \`release.yml\` DAG."
+          } >> "$GITHUB_STEP_SUMMARY"
+          echo "release tag $TAG minted and verified at $SHA"

--- a/docs/release-bot.md
+++ b/docs/release-bot.md
@@ -1,0 +1,150 @@
+# Release tag bot
+
+`.github/workflows/release-tag.yml` lets the release captain create a `vX.Y.Z`
+release tag **without holding the founder credential**, while keeping every
+guarantee the manual tag push had. It is the front door to the existing
+fail-closed release pipeline (`.github/workflows/release.yml`), which still
+triggers on the tag push exactly as before.
+
+## Why it exists
+
+The repository ruleset **"Protect version release tags"** restricts creation of
+`v*` tags. Previously only the founder's account could push a release tag. This
+workflow moves that authority to a scoped **GitHub App** ("kin-release-bot")
+that is allowlisted in the ruleset. The captain dispatches the workflow; the
+workflow verifies the release is safe and then mints a short-lived App
+installation token to create the tag ref.
+
+The tag ref is created with the **App installation token, never the workflow's
+`GITHUB_TOKEN`**. This matters for two reasons:
+
+1. The ruleset admits the App, so the `v*` tag creation is allowed.
+2. A ref created by the default `GITHUB_TOKEN` does **not** trigger further
+   workflows (GitHub's recursion guard). A ref created by an App token **does**,
+   so `release.yml` fires normally.
+
+## What it does (fail-closed checks, in order)
+
+The single job refuses — before any tag is created — unless **all** hold:
+
+1. **Authorized actor + ref.** `github.actor` must be in the allowlist
+   (`troyjr4103`, `kin-release-bot[bot]`) and the dispatch ref must be
+   `refs/heads/main`. A branch dispatch of the workflow is refused loudly.
+2. **Well-formed inputs.** `tag` must match `^v[0-9]+\.[0-9]+\.[0-9]+$`; `sha`
+   must be a 40-character lowercase hex commit SHA. (`workflow_dispatch` cannot
+   enforce a regex, so it is validated in-job. Both are handled only through the
+   environment, never interpolated into a shell.)
+3. **SHA is current `origin/main` HEAD.** The workflow checks out the SHA, fetches
+   `origin/main`, and refuses unless the checked-out HEAD equals both the
+   requested SHA and current `origin/main`. You can only tag the reviewed tip of
+   main.
+4. **Tag matches the workspace version.** `[workspace.package].version` in the
+   root `Cargo.toml` **at that SHA** must equal the tag minus its `v`. This is
+   the same version `release.yml` later asserts against the built packages.
+5. **Required checks are green on that SHA.** Read from
+   `repos/<owner>/<repo>/commits/<sha>/check-runs`. Two independent guards run.
+   First, every context in the **presence-required release-critical set**
+   (`REQUIRED_CHECKS`) must be present and green — a SHA missing any of these is
+   refused even if nothing failed (a SHA that never ran CI is refused, not passed
+   vacuously). Second, **no** check on the SHA may be failing or still in
+   progress. `skipped`/`neutral` count as non-failing — on a merged HEAD
+   `DCO Sign-off` is `skipped` because the PR-time DCO already gated the merge.
+   The presence-required set is:
+   - `Check & Test (ubuntu-latest)`
+   - `Check & Test (macos-latest)`
+   - `DCO Sign-off`
+   - `cargo-deny`
+   - `gitleaks (full history)`
+   - `Windows installer + vector-free release build`
+
+   This is the `main` branch-protection required contexts **plus** the Windows
+   installer leg, which is release-critical and never optional. Because the
+   second guard already refuses any present check that is failing, this list need
+   not mirror every CI context — extend it only to force *presence* of a
+   release-critical check (add branch-protection additions here too).
+6. **Tag does not already exist.** Refuses if `refs/tags/<tag>` is present.
+
+Only then does it mint the App token, create `refs/tags/<tag>` at the SHA, and
+**post-verify** that the new ref points at the SHA. A run summary records the
+tag, SHA, and actor.
+
+## Captain usage
+
+One command, from a machine authenticated as an allowlisted actor:
+
+```sh
+gh workflow run release-tag.yml -f tag=v0.3.0 -f sha=<40-hex-sha>
+```
+
+Get the SHA to release (current reviewed main tip):
+
+```sh
+gh api repos/firelock-ai/kin/commits/main -q .sha
+```
+
+Watch it:
+
+```sh
+gh run list --workflow=release-tag.yml -L 1
+gh run watch <run-id>
+```
+
+On success the tag exists and `release.yml` has started. On any refusal the job
+fails at the offending step with a `::error::` line naming exactly what was
+unmet; nothing is created.
+
+## One-time founder setup
+
+These steps require the founder / org owner and gate the bot going live.
+
+1. **Create the GitHub App.** Org `firelock-ai` → Settings → Developer settings →
+   GitHub Apps → New GitHub App. Name it **`kin-release-bot`**.
+   - Repository permissions → **Contents: Read and write**. No other permissions.
+   - **Uncheck** "Active" under Webhooks (no webhook needed).
+   - "Where can this GitHub App be installed?" → **Only on this account**
+     (org-only install).
+   - Create the App. On its page, generate a **private key** (downloads a `.pem`).
+     Note the **App ID**.
+2. **Install the App on `firelock-ai/kin` only.** App → Install App → install on
+   the `firelock-ai` org, **Only select repositories → `kin`**.
+3. **Add the Actions secrets** (org-level, scoped to `kin`, or repo-level on
+   `firelock-ai/kin`):
+   - `KIN_RELEASE_BOT_APP_ID` — the App ID (numeric).
+   - `KIN_RELEASE_BOT_PRIVATE_KEY` — the full PEM contents, including the
+     `-----BEGIN...-----` / `-----END...-----` lines.
+4. **Allowlist the App in the tag ruleset.** Org/repo → Rules → Rulesets →
+   **"Protect version release tags"** → **Bypass list** → Add → the
+   `kin-release-bot` App. Without this, the App's tag creation is rejected by the
+   ruleset and the workflow fails at "Create release tag ref".
+5. **Confirm the workflow token permission.** The workflow declares
+   `permissions: contents: read` + `checks: read`. Ensure repo/org Actions
+   settings permit those read scopes on `GITHUB_TOKEN` (default). The App token,
+   not `GITHUB_TOKEN`, carries the write.
+
+### Validating the setup
+
+You cannot dry-run a real tag: a throwaway SHA will fail the "required checks"
+and "current main HEAD" gates by design. Validate the **refusal path** instead —
+dispatch with a deliberately wrong SHA and confirm the job refuses without
+creating anything:
+
+```sh
+# 40 hex chars but not main HEAD -> must refuse at the origin/main HEAD check
+gh workflow run release-tag.yml -f tag=v0.0.0 -f sha=0000000000000000000000000000000000000000
+gh run list --workflow=release-tag.yml -L 1     # expect: failure
+gh api repos/firelock-ai/kin/git/ref/tags/v0.0.0   # expect: 404 (nothing created)
+```
+
+A clean refusal with no tag created confirms the guards, token wiring, and
+permissions are correct end-to-end short of an actual release.
+
+## Recommended hardening (optional)
+
+For defense-in-depth against a modified copy of this workflow being dispatched
+from a branch (which could otherwise read the App secrets), bind
+`KIN_RELEASE_BOT_APP_ID` / `KIN_RELEASE_BOT_PRIVATE_KEY` to a GitHub
+**Environment** (e.g. `release-tag`) whose deployment branch policy allows only
+`main`, and add `environment: release-tag` to the job. The environment's
+branch policy then blocks secret access on any non-`main` dispatch, on top of
+the in-job actor/ref guard. This mirrors how `release.yml` isolates its
+publish secrets behind the protected `release` environment.


### PR DESCRIPTION
## What this does

Replaces the founder-manual `v*` tag push with a **bot-mediated** one. The release
captain can create a `vX.Y.Z` release tag without holding the founder credential,
while every guarantee of the manual path is preserved and enforced fail-closed.

- New workflow `.github/workflows/release-tag.yml` (`workflow_dispatch`, inputs
  `tag` + `sha`). A single job runs ordered, fail-closed checks and only then
  mints a short-lived **kin-release-bot** GitHub App installation token to create
  `refs/tags/<tag>`. The tag ref is created with the **App token, never
  `GITHUB_TOKEN`** — so the tag-protection ruleset admits it *and* the existing
  `release.yml` DAG triggers (the default token would suppress it).
- New doc `docs/release-bot.md` — operator runbook + one-time founder setup.

### Fail-closed checks (in order), all verified before any tag is created
1. Actor allowlist (`troyjr4103`, `kin-release-bot[bot]`) **and** dispatch ref is `main`.
2. Input shape: `tag` matches `^v[0-9]+\.[0-9]+\.[0-9]+$`, `sha` is 40-hex (routed via env, injection-safe).
3. `sha` equals current `origin/main` HEAD.
4. Tag equals `[workspace.package].version` in `Cargo.toml` at that sha.
5. Branch-protection required checks green on the sha (`Check & Test (ubuntu-latest)`,
   `Check & Test (macos-latest)`, `DCO Sign-off`, `cargo-deny`, `gitleaks (full history)`);
   nothing failing/in-progress; missing check-runs = refuse. `skipped`/`neutral` allowed
   (DCO is skipped on a merged HEAD).
6. Tag does not already exist. Then: mint token, create ref, **post-verify** ref → sha.

`permissions: contents: read` + `checks: read` at workflow level (App token carries the
write); concurrency group `release-tag` (no parallel tag runs).

### Captain usage
```
gh workflow run release-tag.yml -f tag=v0.3.0 -f sha=<40-hex-sha>
```

### One-time founder setup (see docs/release-bot.md)
1. Create GitHub App **kin-release-bot** (org `firelock-ai`): Repository → Contents:
   Read and write; no webhooks; install on this account only.
2. Install it on **`firelock-ai/kin` only**.
3. Add Actions secrets `KIN_RELEASE_BOT_APP_ID` + `KIN_RELEASE_BOT_PRIVATE_KEY` (PEM).
4. Add the App to the **"Protect version release tags"** ruleset bypass/allow list.
5. Validate the refusal path (a real dry-run isn't possible — checks would fail):
   `gh workflow run release-tag.yml -f tag=v0.0.0 -f sha=0000...0000` → expect refusal,
   no tag created.

Validation: `actionlint` clean; embedded version-parse and check-run logic unit-tested
against real HEAD data (pass) and synthetic failing/missing/empty cases (refuse).

**Setup gated on founder App creation (FIR-1538).** Draft until the App, secrets, and
ruleset bypass are in place.
