### PR TITLE
Narrow release-bot tokens to the kin repository

### DIFF
--- a/.github/workflows/release-tag.yml
+++ b/.github/workflows/release-tag.yml
@@ -196,6 +196,9 @@ jobs:
                   errors.append(f"required check not green: {name} (conclusion={run['conclusion']})")
 
           for name, run in runs.items():
+              # Self-exclude this workflow's own job ("Mint release tag") — a gate must not read its own refusals as evidence.
+              if name == "Mint release tag":
+                  continue
               if run["status"] != "completed":
                   errors.append(f"check still in progress: {name} (status={run['status']})")
               elif run["conclusion"] not in acceptable:
@@ -229,6 +232,12 @@ jobs:
         with:
           app-id: ${{ secrets.KIN_RELEASE_BOT_APP_ID }}
           private-key: ${{ secrets.KIN_RELEASE_BOT_PRIVATE_KEY }}
+          # kin-release-bot is installed org-wide, so scope every minted token to
+          # the kin repository alone. owner + repositories narrows the installation
+          # token to just these repos; setting owner without repositories would
+          # instead widen it to every repo the org-wide install can reach.
+          owner: firelock-ai
+          repositories: kin
 
       - name: Create release tag ref
         # Created with the App token (not GITHUB_TOKEN) so the ruleset admits it

--- a/docs/release-bot.md
+++ b/docs/release-bot.md
@@ -47,8 +47,12 @@ The single job refuses — before any tag is created — unless **all** hold:
    (`REQUIRED_CHECKS`) must be present and green — a SHA missing any of these is
    refused even if nothing failed (a SHA that never ran CI is refused, not passed
    vacuously). Second, **no** check on the SHA may be failing or still in
-   progress. `skipped`/`neutral` count as non-failing — on a merged HEAD
-   `DCO Sign-off` is `skipped` because the PR-time DCO already gated the merge.
+   progress. The workflow's own `Mint release tag` check-run is self-excluded
+   from this second guard — a refused dispatch is recorded as a failed
+   `Mint release tag` check-run on the target SHA, and a gate must not read its
+   own refusals as evidence. `skipped`/`neutral` count as non-failing — on a
+   merged HEAD `DCO Sign-off` is `skipped` because the PR-time DCO already gated
+   the merge.
    The presence-required set is:
    - `Check & Test (ubuntu-latest)`
    - `Check & Test (macos-latest)`
@@ -105,8 +109,10 @@ These steps require the founder / org owner and gate the bot going live.
      (org-only install).
    - Create the App. On its page, generate a **private key** (downloads a `.pem`).
      Note the **App ID**.
-2. **Install the App on `firelock-ai/kin` only.** App → Install App → install on
-   the `firelock-ai` org, **Only select repositories → `kin`**.
+2. **Install the App.** App → Install App → install on the `firelock-ai` org.
+   Scoping the install to **Only select repositories → `kin`** is the tightest
+   posture, but the App is currently installed **org-wide** (founder decision) —
+   see "Install scope and token narrowing" below for why that is still safe.
 3. **Add the Actions secrets** (org-level, scoped to `kin`, or repo-level on
    `firelock-ai/kin`):
    - `KIN_RELEASE_BOT_APP_ID` — the App ID (numeric).
@@ -120,6 +126,20 @@ These steps require the founder / org owner and gate the bot going live.
    `permissions: contents: read` + `checks: read`. Ensure repo/org Actions
    settings permit those read scopes on `GITHUB_TOKEN` (default). The App token,
    not `GITHUB_TOKEN`, carries the write.
+
+### Install scope and token narrowing
+
+The `kin-release-bot` App is installed **org-wide** across `firelock-ai` (founder
+decision), so the App itself can reach every repository in the org. The workflow
+does not depend on a repo-scoped install: the "Mint kin-release-bot installation
+token" step passes `owner: firelock-ai` + `repositories: kin` to
+`actions/create-github-app-token`, which narrows every minted installation token
+to the `kin` repository alone — so a compromised or misused run can only write to
+`kin`, never a sibling repo. Extending bot-mediated tagging to another repo is a
+deliberate act: replicate this workflow and its secrets in that repo and widen or
+duplicate the `repositories:` narrowing to name the new repo explicitly — never
+drop the `owner`/`repositories` inputs, since without them a single token would
+span every repository the org-wide install can reach.
 
 ### Validating the setup
 


### PR DESCRIPTION
The `kin-release-bot` GitHub App is now installed **org-wide** across `firelock-ai` (founder decision), so any installation token it mints could otherwise reach every repository in the org. This change narrows the blast radius back to intent: the `release-tag.yml` workflow now passes `owner: firelock-ai` + `repositories: kin` to `actions/create-github-app-token`, scoping every minted token to the `kin` repository alone, so a compromised or misused run can only write to `kin` and never a sibling repo. `docs/release-bot.md` is updated to record the org-wide install and this per-mint narrowing, and to note that extending bot-mediated tagging to another repo must be a deliberate act — replicate the workflow and its secrets there and widen or duplicate the `repositories:` narrowing — never by dropping the `owner`/`repositories` inputs.

It also fixes a self-blocking flaw in the checks-verification gate exposed during live validation. The second guard ("no check on the SHA may be failing or in progress") iterated **every** check-run on the target SHA — including the workflow's own `Mint release tag` job. A refused dispatch is itself recorded as a failed `Mint release tag` check-run on the main HEAD it ran against, so the gate would then read its own prior refusals (and its in-progress current run, which sits on that same SHA) as evidence and refuse every future mint on that SHA. The fix self-excludes the `Mint release tag` check-run by exact name from that second guard only; the presence-required set is unchanged, and every other check still gates.
