### PR TITLE
Fix clean-install capability proof and Windows Codex binding for 0.3.1

### DIFF
--- a/.github/workflows/install-proof.yml
+++ b/.github/workflows/install-proof.yml
@@ -784,12 +784,30 @@ jobs:
           ]);
 
           for (const [path, report] of reports) {
-            if (report.healthy !== true) {
+            const checks = new Map(report.checks.map((check) => [check.id, check]));
+            // This capability capture runs before `kin embed`, so the daemon
+            // graph still has embeddings pending. Under graph-authoritative
+            // health that is semantic_query_readiness=stale, an intentional
+            // authority gate that flips the aggregate report.healthy to false.
+            // Accept that single transient pre-embed reason here — the
+            // post-embed embedded-health capture below still requires
+            // healthy=true with readiness=healthy — while keeping every other
+            // unhealthy reason fatal: any missing/misconfigured check, or any
+            // other check that is neither healthy nor unsupported, still fails.
+            const onlyPendingEmbeddingsBlocks =
+              runnerOs !== "Windows" &&
+              checks.get("semantic_query_readiness")?.status === "stale" &&
+              report.checks.every(
+                (check) =>
+                  check.id === "semantic_query_readiness" ||
+                  check.status === "healthy" ||
+                  check.status === "unsupported"
+              );
+            if (report.healthy !== true && !onlyPendingEmbeddingsBlocks) {
               throw new Error(
                 `${path}: overall healthy=${report.healthy}; non-healthy checks: ${nonHealthyChecks(report)}`
               );
             }
-            const checks = new Map(report.checks.map((check) => [check.id, check]));
             for (const [id, expected] of required) {
               const actual = checks.get(id)?.status;
               if (actual !== expected) {

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.3.1] - 2026-07-22
+
+### Fixed
+
+- Install-proof gate fixed for graph-authoritative health semantics (pre-embed
+  readiness staleness is expected); Windows Codex MCP binding health check now
+  compares canonical repository identity, fixing a false "misconfigured" on
+  extended-length paths. No other changes.
+
 ## [0.3.0] - 2026-07-22
 
 This release makes exact source state part of Kin's graph authority and tightens
@@ -755,7 +764,8 @@ Historical note: this snapshot predates the public GitHub prerelease series and 
 - Daemon mode for background file watching (`kin-daemon`)
 - 19-crate workspace architecture
 
-[unreleased]: https://github.com/firelock-ai/kin/compare/v0.3.0...HEAD
+[unreleased]: https://github.com/firelock-ai/kin/compare/v0.3.1...HEAD
+[0.3.1]: https://github.com/firelock-ai/kin/compare/v0.3.0...v0.3.1
 [0.3.0]: https://github.com/firelock-ai/kin/compare/v0.2.28...v0.3.0
 [0.2.28]: https://github.com/firelock-ai/kin/compare/v0.2.27...v0.2.28
 [0.2.27]: https://github.com/firelock-ai/kin/compare/v0.2.26...v0.2.27

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3044,14 +3044,14 @@ dependencies = [
 
 [[package]]
 name = "kin-buildinfo"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "sha2 0.11.0",
 ]
 
 [[package]]
 name = "kin-cli"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "age",
  "anyhow",
@@ -3125,7 +3125,7 @@ dependencies = [
 
 [[package]]
 name = "kin-context"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "kin-blobs",
  "kin-db",
@@ -3141,7 +3141,7 @@ dependencies = [
 
 [[package]]
 name = "kin-core"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "cap-fs-ext",
  "cap-std",
@@ -3171,7 +3171,7 @@ dependencies = [
 
 [[package]]
 name = "kin-daemon"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "async-stream",
  "axum",
@@ -3264,7 +3264,7 @@ dependencies = [
 
 [[package]]
 name = "kin-git"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "chrono",
  "gix",
@@ -3282,7 +3282,7 @@ dependencies = [
 
 [[package]]
 name = "kin-index"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "hex",
  "kin-blobs",
@@ -3330,7 +3330,7 @@ dependencies = [
 
 [[package]]
 name = "kin-integration-tests"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "kin-blobs",
  "kin-cli",
@@ -3372,7 +3372,7 @@ dependencies = [
 
 [[package]]
 name = "kin-mcp"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "kin-blobs",
  "kin-context",
@@ -3399,7 +3399,7 @@ dependencies = [
 
 [[package]]
 name = "kin-migrate"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "chrono",
  "kin-blobs",
@@ -3441,7 +3441,7 @@ dependencies = [
 
 [[package]]
 name = "kin-parser"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "kin-model",
  "pretty_assertions",
@@ -3471,7 +3471,7 @@ dependencies = [
 
 [[package]]
 name = "kin-projection"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "kin-blobs",
  "kin-db",
@@ -3486,7 +3486,7 @@ dependencies = [
 
 [[package]]
 name = "kin-ranking"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "kin-model",
  "serde",
@@ -3495,7 +3495,7 @@ dependencies = [
 
 [[package]]
 name = "kin-reconcile"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "kin-blobs",
  "kin-db",
@@ -3515,7 +3515,7 @@ dependencies = [
 
 [[package]]
 name = "kin-registry"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "async-stream",
  "axum",
@@ -3548,7 +3548,7 @@ dependencies = [
 
 [[package]]
 name = "kin-remote"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "chrono",
  "kin-model",
@@ -3564,7 +3564,7 @@ dependencies = [
 
 [[package]]
 name = "kin-review"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "kin-blobs",
  "kin-db",
@@ -3580,7 +3580,7 @@ dependencies = [
 
 [[package]]
 name = "kin-runtime"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "chrono",
  "hex",
@@ -3612,7 +3612,7 @@ dependencies = [
 
 [[package]]
 name = "kin-semantic-contracts"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "kin-db",
  "kin-model",
@@ -3627,7 +3627,7 @@ dependencies = [
 
 [[package]]
 name = "kin-spine"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "chrono",
  "hashbrown 0.15.5",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,7 +27,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.3.0"
+version = "0.3.1"
 edition = "2021"
 license = "Apache-2.0"
 authors = ["Troy Fortin <troy@firelock.ai>"]

--- a/crates/kin-cli/Cargo.toml
+++ b/crates/kin-cli/Cargo.toml
@@ -86,7 +86,7 @@ toml = { workspace = true }
 toml_edit = "0.25"
 tempfile = { workspace = true }
 unicode-normalization = "0.1"
-kin-spine = { version = "0.3.0", path = "../kin-spine" }
+kin-spine = { version = "0.3.1", path = "../kin-spine" }
 
 [dev-dependencies]
 pretty_assertions = { workspace = true }

--- a/crates/kin-cli/src/commands/setup.rs
+++ b/crates/kin-cli/src/commands/setup.rs
@@ -2159,7 +2159,19 @@ pub(crate) fn codex_entry_has_exact_repo_binding(
     {
         return Ok(false);
     }
-    Ok(codex_repo_from_entry_bytes(content)?.as_deref() == Some(expected_repo))
+    // `configure_codex` writes the *canonicalized* working directory, and the
+    // parsed `--repo` path is normalized through `canonical_initialized_repo`.
+    // The expected repository is supplied by the health surface via
+    // `current_health_repo`, which does not canonicalize, so normalize it the
+    // same way before comparing. Otherwise a correctly written binding is
+    // rejected wherever a raw path differs from its canonical form — notably
+    // Windows `\\?\` verbatim prefixes and symlinked home directories. Compare
+    // canonical repository identity, not raw path strings.
+    let actual = codex_repo_from_entry_bytes(content)?;
+    Ok(match canonical_initialized_repo(expected_repo) {
+        Some(expected) => actual == Some(expected),
+        None => false,
+    })
 }
 
 fn json_mcp_repo_from_entry_bytes(content: &[u8], client: &str) -> Result<Option<PathBuf>> {
@@ -12785,6 +12797,46 @@ mod tests {
             .expect("relative --repo must resolve from the entry cwd");
 
         assert_eq!(resolved, repo_a);
+    }
+
+    #[test]
+    fn codex_binding_matches_expected_repo_regardless_of_path_form() {
+        // Regression: `configure_codex` writes the canonicalized repository
+        // path, but the health surface supplies the expected repo via
+        // `current_health_repo`, which does not canonicalize. Comparing the two
+        // by raw path equality wrongly reports a correct binding as
+        // misconfigured wherever the raw path differs from its canonical form —
+        // this is what failed every Windows install-proof leg (the `\\?\`
+        // verbatim prefix that `canonicalize` adds) while Unix passed. The
+        // comparison must normalize both sides to canonical repository identity.
+        let dir = tempfile::tempdir().unwrap();
+        let repo = dir.path().join("repo");
+        fs::create_dir_all(repo.join(".kin")).unwrap();
+        let canonical = repo.canonicalize().unwrap();
+
+        // Exactly what `configure_codex` writes: an absolute, canonicalized
+        // `--repo` path.
+        let content = format!(
+            "[mcp_servers.kin]\ncommand = \"/managed/kin\"\nargs = [\"mcp\", \"start\", \"--repo\", {:?}]\n",
+            canonical.to_string_lossy()
+        );
+
+        // The same repository named through a non-canonical but equivalent
+        // path, standing in for the Windows `\\?\`/symlink divergence.
+        let non_canonical = canonical.join("..").join(canonical.file_name().unwrap());
+        assert_ne!(non_canonical, canonical);
+        assert!(
+            codex_entry_has_exact_repo_binding(content.as_bytes(), &non_canonical).unwrap(),
+            "a canonically written binding must match its repository named through a non-canonical path"
+        );
+
+        // A genuinely different repository must still be refused.
+        let other = dir.path().join("other");
+        fs::create_dir_all(other.join(".kin")).unwrap();
+        assert!(
+            !codex_entry_has_exact_repo_binding(content.as_bytes(), &other).unwrap(),
+            "a binding for one repository must not satisfy a different repository"
+        );
     }
 
     #[test]

--- a/packages/boundary-contracts/package.json
+++ b/packages/boundary-contracts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kin/boundary-contracts",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "private": false,
   "description": "Shared contracts for Kin ecosystem boundaries.",
   "type": "module",

--- a/packages/kin-mcp/package.json
+++ b/packages/kin-mcp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kinlab/kin-mcp",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "description": "Start Kin's MCP server, the system of record for AI-written software, through an npm-friendly wrapper.",
   "type": "module",
   "bin": {

--- a/packages/kin/package.json
+++ b/packages/kin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kinlab/kin",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "description": "Canonical installer and launcher for Kin, the system of record for AI-written software. Provisions and runs the managed kin + kin-daemon release. MCP is one included mode (kin mcp start).",
   "license": "Apache-2.0",
   "type": "module",


### PR DESCRIPTION
## Summary

The v0.3.0 public install proof (`.github/workflows/install-proof.yml`, run via release.yml's "Public Install Proof") fails closed at the **Validate installed capability proof** gate on all platforms, from **two independent regressions** in the 0.2.28 → 0.3.0 window. Both are fixed here on one branch.

## Unix legs (ubuntu x2, macOS x2) — proof-sequencing (no binary change)

Semantic health became graph-authoritative in 0.3.0 (`c48775ac`) and gained a readiness authority gate (`daf93410`). A fresh **post-`kin setup`, pre-`kin embed`** capture (`kin-health.json`, install-proof.yml:403) honestly reports `semantic_query_readiness=stale` — the daemon graph still has embeddings pending (`0/5 indexed` in the failing run) — which now aggregates to overall `healthy=false`. The proof's pre-embed capture asserted `report.healthy === true` while *also* explicitly tolerating `readiness=stale` at the same point — an internal contradiction under the stricter semantics.

**Fix:** accept `healthy=false` at that one capture only when a stale `semantic_query_readiness` is the *sole* blocker (every other check `healthy` or `unsupported`); any missing/misconfigured check, any other stale check, and the strict post-embed capture stay fully enforced. The published v0.3.0 artifacts are correct for these legs.

## Windows leg — product regression

`configure_codex` writes the **canonicalized** repo path into `~/.codex/config.toml`, but `c48775ac` stopped `current_health_repo()` from canonicalizing. On Windows `std::fs::canonicalize` adds the `\\?\` verbatim prefix, so the Codex `--repo` binding check compared `\\?\D:\...` (written) against raw `D:\...` (expected) and reported a correct binding as `misconfigured` — a hard failure that flips overall health. Unix is unaffected (canonicalize is effectively a string no-op there).

**Fix:** `codex_entry_has_exact_repo_binding` now normalizes `expected_repo` through the same `canonical_initialized_repo` used for the written `--repo` path, comparing canonical repository identity instead of raw path strings. Guard-safe (setup.rs is not a Zero File-Search authority file). Includes a regression test that fails without the fix.

## Release — v0.3.1

The Windows fix ships in the `kin` binary, so the published v0.3.0 bytes can never pass the corrected proof — v0.3.1 is the only path. This PR bumps the workspace version and all three npm release manifests (`@kinlab/kin`, `@kinlab/kin-mcp`, `@kin/boundary-contracts`) 0.3.0 → 0.3.1, re-locks `Cargo.lock` patch-off (external kin registry sources + checksums preserved), and adds a CHANGELOG `[0.3.1]` entry. The release-tag gate reads `[workspace.package].version` and will see `0.3.1` → tag `v0.3.1`. `kin-db` (0.3.1) / `kin-model` / `kin-lsp` (0.4.0) external pins are unchanged.

## Verification (local, macOS)

- `cargo test -p kin-cli` codex/mcp: 9 passed; the new regression test is confirmed to **fail without the fix**.
- `cargo fmt --check` clean; `cargo clippy --all-targets --all-features` (CI debt allow-list, `-Dwarnings`) clean.
- Zero File-Search guard (bash + python) pass.
- Unix fix validated against the **real failing-run** `kin-health.json`/`kin-doctor.json`: reproduces the failure under the old gate, passes under the new gate, and still rejects tampered reports (missing/misconfigured checks, a second stale blocker).
- `cargo metadata --locked` clean (lock ↔ manifest consistent); `Cargo.lock` diff is version-only (20 workspace entries), no source/checksum changes.
- npm package tests pass (`packages/kin`, `packages/kin-mcp`); release-tag version gate simulated → `v0.3.1`.

## Known follow-up (not a release blocker)

The Antigravity binding check consumes the same non-canonical `current_health_repo()` and shares the identical latent Windows path-form bug, but Antigravity isn't configured on the proof runners so it isn't exercised. Recommend a follow-up to normalize there too (or restore canonicalization in `current_health_repo` via the setup helper, which fixes both surfaces at the root).
