### PR TITLE
Record submodule pointers and split importer strictness by caller

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3044,14 +3044,14 @@ dependencies = [
 
 [[package]]
 name = "kin-buildinfo"
-version = "0.3.1"
+version = "0.3.2"
 dependencies = [
  "sha2 0.11.0",
 ]
 
 [[package]]
 name = "kin-cli"
-version = "0.3.1"
+version = "0.3.2"
 dependencies = [
  "age",
  "anyhow",
@@ -3125,7 +3125,7 @@ dependencies = [
 
 [[package]]
 name = "kin-context"
-version = "0.3.1"
+version = "0.3.2"
 dependencies = [
  "kin-blobs",
  "kin-db",
@@ -3141,7 +3141,7 @@ dependencies = [
 
 [[package]]
 name = "kin-core"
-version = "0.3.1"
+version = "0.3.2"
 dependencies = [
  "cap-fs-ext",
  "cap-std",
@@ -3171,7 +3171,7 @@ dependencies = [
 
 [[package]]
 name = "kin-daemon"
-version = "0.3.1"
+version = "0.3.2"
 dependencies = [
  "async-stream",
  "axum",
@@ -3264,7 +3264,7 @@ dependencies = [
 
 [[package]]
 name = "kin-git"
-version = "0.3.1"
+version = "0.3.2"
 dependencies = [
  "chrono",
  "gix",
@@ -3282,7 +3282,7 @@ dependencies = [
 
 [[package]]
 name = "kin-index"
-version = "0.3.1"
+version = "0.3.2"
 dependencies = [
  "hex",
  "kin-blobs",
@@ -3330,7 +3330,7 @@ dependencies = [
 
 [[package]]
 name = "kin-integration-tests"
-version = "0.3.1"
+version = "0.3.2"
 dependencies = [
  "kin-blobs",
  "kin-cli",
@@ -3372,7 +3372,7 @@ dependencies = [
 
 [[package]]
 name = "kin-mcp"
-version = "0.3.1"
+version = "0.3.2"
 dependencies = [
  "kin-blobs",
  "kin-context",
@@ -3399,7 +3399,7 @@ dependencies = [
 
 [[package]]
 name = "kin-migrate"
-version = "0.3.1"
+version = "0.3.2"
 dependencies = [
  "chrono",
  "kin-blobs",
@@ -3441,7 +3441,7 @@ dependencies = [
 
 [[package]]
 name = "kin-parser"
-version = "0.3.1"
+version = "0.3.2"
 dependencies = [
  "kin-model",
  "pretty_assertions",
@@ -3471,7 +3471,7 @@ dependencies = [
 
 [[package]]
 name = "kin-projection"
-version = "0.3.1"
+version = "0.3.2"
 dependencies = [
  "kin-blobs",
  "kin-db",
@@ -3486,7 +3486,7 @@ dependencies = [
 
 [[package]]
 name = "kin-ranking"
-version = "0.3.1"
+version = "0.3.2"
 dependencies = [
  "kin-model",
  "serde",
@@ -3495,7 +3495,7 @@ dependencies = [
 
 [[package]]
 name = "kin-reconcile"
-version = "0.3.1"
+version = "0.3.2"
 dependencies = [
  "kin-blobs",
  "kin-db",
@@ -3515,7 +3515,7 @@ dependencies = [
 
 [[package]]
 name = "kin-registry"
-version = "0.3.1"
+version = "0.3.2"
 dependencies = [
  "async-stream",
  "axum",
@@ -3548,7 +3548,7 @@ dependencies = [
 
 [[package]]
 name = "kin-remote"
-version = "0.3.1"
+version = "0.3.2"
 dependencies = [
  "chrono",
  "kin-model",
@@ -3564,7 +3564,7 @@ dependencies = [
 
 [[package]]
 name = "kin-review"
-version = "0.3.1"
+version = "0.3.2"
 dependencies = [
  "kin-blobs",
  "kin-db",
@@ -3580,7 +3580,7 @@ dependencies = [
 
 [[package]]
 name = "kin-runtime"
-version = "0.3.1"
+version = "0.3.2"
 dependencies = [
  "chrono",
  "hex",
@@ -3612,7 +3612,7 @@ dependencies = [
 
 [[package]]
 name = "kin-semantic-contracts"
-version = "0.3.1"
+version = "0.3.2"
 dependencies = [
  "kin-db",
  "kin-model",
@@ -3627,7 +3627,7 @@ dependencies = [
 
 [[package]]
 name = "kin-spine"
-version = "0.3.1"
+version = "0.3.2"
 dependencies = [
  "chrono",
  "hashbrown 0.15.5",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,7 +27,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.3.1"
+version = "0.3.2"
 edition = "2021"
 license = "Apache-2.0"
 authors = ["Troy Fortin <troy@firelock.ai>"]

--- a/crates/kin-cli/src/commands/init.rs
+++ b/crates/kin-cli/src/commands/init.rs
@@ -1625,6 +1625,10 @@ pub async fn run(
                         &blob_store,
                         layout.root(),
                         history_boundary_root,
+                        // Certification: `kin init` builds the authoritative
+                        // repo graph and must reject a hydration invariant
+                        // rather than silently degrade it.
+                        false,
                     )
                     .with_context(|| {
                         format!("enrich imported Git history with semantic deltas ({git_history})")
@@ -2319,7 +2323,7 @@ fn enrich_imported_changes_with_semantics_and_genesis(
     genesis_id: SemanticChangeId,
 ) -> Result<()> {
     enrich_imported_changes_with_semantics_with_checkpoints_and_boundary_root(
-        imported, blob_store, true, None, genesis_id,
+        imported, blob_store, true, None, genesis_id, false,
     )
     .map(|_| ())
 }
@@ -2344,6 +2348,7 @@ pub(crate) fn enrich_imported_changes_with_semantics_checkpointed(
     blob_store: &kin_blobs::BlobStore,
     kin_root: &Path,
     boundary_root: SemanticChangeId,
+    tolerant: bool,
 ) -> Result<HydrationReplayStats> {
     let config = HydrationCheckpointConfig::production(kin_root);
     let stats = enrich_imported_changes_with_semantics_with_checkpoints_and_boundary_root(
@@ -2352,6 +2357,7 @@ pub(crate) fn enrich_imported_changes_with_semantics_checkpointed(
         true,
         Some(config),
         boundary_root,
+        tolerant,
     )?;
     debug!(
         resumed_from = stats.resumed_from,
@@ -2389,6 +2395,7 @@ pub(crate) fn enrich_imported_changes_with_semantics_test_checkpoint(
             16 * 1024 * 1024,
         )),
         boundary_root,
+        false,
     )
 }
 
@@ -2423,6 +2430,7 @@ fn enrich_imported_changes_with_semantics_with_checkpoints(
         parse_memo_enabled,
         checkpoint_config,
         kin_core::build_genesis_change().id,
+        false,
     )
 }
 
@@ -2432,6 +2440,7 @@ fn enrich_imported_changes_with_semantics_with_checkpoints_and_boundary_root(
     parse_memo_enabled: bool,
     checkpoint_config: Option<HydrationCheckpointConfig>,
     boundary_root: SemanticChangeId,
+    tolerant: bool,
 ) -> Result<HydrationReplayStats> {
     // Profiling timers (accumulated across every commit in the pass).
     let mut total_blob_read_time = std::time::Duration::ZERO;
@@ -2579,7 +2588,7 @@ fn enrich_imported_changes_with_semantics_with_checkpoints_and_boundary_root(
         } = baseline;
         let mut merge_runtime_baseline = if imported[i].change.parents.len() > 1 {
             Some(ImportedRuntimeSemanticState {
-                entities: imported_target_entities(&current_files)?,
+                entities: imported_target_entities(&current_files, tolerant)?,
                 relations: current_relations.clone(),
             })
         } else {
@@ -2954,6 +2963,7 @@ fn enrich_imported_changes_with_semantics_with_checkpoints_and_boundary_root(
                 all_parent_baseline,
                 &current_files,
                 &current_relations,
+                tolerant,
             )?;
         }
         imported[i].change.entity_deltas = entity_deltas;
@@ -3416,15 +3426,43 @@ fn imported_relations_exactly_equivalent(old: &Relation, new: &Relation) -> bool
 
 fn imported_target_entities(
     files: &HashMap<String, ImportedSemanticFileState>,
+    tolerant: bool,
 ) -> Result<HashMap<EntityId, Entity>> {
-    let mut entities = HashMap::new();
-    for file in files.values() {
+    let mut entities: HashMap<EntityId, Entity> = HashMap::new();
+    // Deterministic file order so the tolerant conflict resolution below is
+    // stable across runs (the map iterates in an unspecified order); reproducible
+    // hydration is required for a citable review.
+    let mut ordered: Vec<(&String, &ImportedSemanticFileState)> = files.iter().collect();
+    ordered.sort_by(|left, right| left.0.cmp(right.0));
+    for (_path, file) in ordered {
         for entity in &file.entities {
-            if entities.insert(entity.id, entity.clone()).is_some() {
-                return Err(anyhow!(
-                    "historical hydration invariant violated: entity {} occurs in more than one imported file state",
-                    entity.id
-                ));
+            match entities.get(&entity.id) {
+                // A content-addressed entity is not owned by one file: an
+                // identical definition projected into more than one file (a
+                // header and an amalgamated single-include copy, a vendored
+                // duplicate) resolves to the same entity id. Identical
+                // projections are the same entity, not a collision.
+                Some(existing) if imported_entities_exactly_equivalent(existing, entity) => {}
+                // Same id, diverging content: an entity-id derivation collision.
+                // Certification (strict) rejects it. Lazy-ref reads (review /
+                // history / blame) over arbitrary repos keep the first by
+                // deterministic file order and continue rather than failing the
+                // read on ancestry the caller is not certifying.
+                Some(_) if tolerant => {
+                    tracing::debug!(
+                        entity = %entity.id,
+                        "tolerant hydration: keeping first of diverging entity projections"
+                    );
+                }
+                Some(_) => {
+                    return Err(anyhow!(
+                        "historical hydration invariant violated: entity {} occurs with diverging content in more than one imported file state",
+                        entity.id
+                    ));
+                }
+                None => {
+                    entities.insert(entity.id, entity.clone());
+                }
             }
         }
     }
@@ -3558,8 +3596,9 @@ fn rebase_imported_merge_semantic_deltas(
     all_parent_baseline: &ImportedRuntimeSemanticState,
     target_files: &HashMap<String, ImportedSemanticFileState>,
     target_relations: &HashMap<RelationId, Relation>,
+    tolerant: bool,
 ) -> Result<(Vec<EntityDelta>, Vec<RelationDelta>)> {
-    let target_entities = imported_target_entities(target_files)?;
+    let target_entities = imported_target_entities(target_files, tolerant)?;
     let mut entity_ids = BTreeSet::new();
     entity_ids.extend(all_parent_baseline.entities.keys().copied());
     entity_ids.extend(target_entities.keys().copied());

--- a/crates/kin-cli/src/commands/ref_lookup.rs
+++ b/crates/kin-cli/src/commands/ref_lookup.rs
@@ -703,6 +703,11 @@ fn replay_imported_semantics(
         blob_store,
         kin_root,
         kin_core::build_genesis_change().id,
+        // Lazy-ref hydration for review / history / blame reads arbitrary,
+        // uncertified repositories. It hydrates best-effort: a compatibility
+        // hydration facet degrades rather than failing the read. Certification
+        // (`kin init`) is the strict path.
+        true,
     )
     .map(|_| ())
 }

--- a/crates/kin-daemon/src/api.rs
+++ b/crates/kin-daemon/src/api.rs
@@ -4750,15 +4750,21 @@ async fn review(
             drop(graph_mutation);
             drop(hydration_gate);
 
-            let response =
-                kin_cli::commands::review::render_prepared_shadow_request(graph.as_ref(), prepared)
-                    .map_err(|error| {
-                        if kin_cli::commands::ref_lookup::is_ref_resolution_error(&error) {
-                            (StatusCode::BAD_REQUEST, format!("{error:#}"))
-                        } else {
-                            internal_error(error)
-                        }
-                    })?;
+            let response = kin_cli::commands::review::render_prepared_shadow_request(
+                graph.as_ref(),
+                prepared,
+            )
+            .map_err(|error| {
+                // The client response carries only the top-level context;
+                // record the full cause chain here so a shadow failure is
+                // diagnosable from the daemon log.
+                tracing::warn!(target: "kin_daemon::api", "shadow review render failed: {error:#}");
+                if kin_cli::commands::ref_lookup::is_ref_resolution_error(&error) {
+                    (StatusCode::BAD_REQUEST, format!("{error:#}"))
+                } else {
+                    internal_error(error)
+                }
+            })?;
             return Ok(Json(response));
         }
         request => request,

--- a/crates/kin-git/src/import.rs
+++ b/crates/kin-git/src/import.rs
@@ -62,9 +62,11 @@ fn shallow_boundary_ids(repo: &gix::Repository) -> Result<HashSet<gix::ObjectId>
 #[derive(Debug, Clone)]
 pub(crate) struct CommitFileDelta {
     pub path: String,
-    pub old_blob_id: Option<gix::ObjectId>,
-    pub new_blob_id: Option<gix::ObjectId>,
-    pub new_entry_kind: Option<SourceEntryKind>,
+    /// Prior side of the change, if present: its Git object id and class. A file
+    /// or symlink carries a blob id; a gitlink carries the pinned commit id.
+    pub old: Option<(gix::ObjectId, GitEntryClass)>,
+    /// Resulting side of the change, if present: its Git object id and class.
+    pub new: Option<(gix::ObjectId, GitEntryClass)>,
 }
 
 /// Options for importing Git history into Kin.
@@ -780,23 +782,66 @@ fn commit_to_change(
     })
 }
 
-/// Extract artifact deltas from a commit by diffing against its first parent.
+/// Importer-internal classification of a Git tree entry.
 ///
-/// For root commits (no parents), all files in the tree are "Added".
-/// For non-root commits, we diff against the first parent's tree.
-fn source_entry_kind(mode: gix::objs::tree::EntryMode) -> Result<Option<SourceEntryKind>> {
+/// Distinct from the canonical [`SourceEntryKind`] so a submodule pointer can be
+/// carried through import as a tracked, mode-unknown change without adding a
+/// Git-compatibility construct to the shared type vocabulary. A gitlink is not
+/// exact-source materializable (it names another repository's commit, not file
+/// content), so it resolves to a source-tree gap rather than a synthesized file.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum GitEntryClass {
+    /// A file or symbolic link — an exact source entry with a known mode.
+    Source(SourceEntryKind),
+    /// A gitlink (submodule pointer). Recorded as a mode-unknown artifact delta;
+    /// its pinned commit id is captured as the delta's content identity.
+    Gitlink,
+}
+
+/// Classify a Git tree entry mode. `None` for a tree (directory), which is not a
+/// source entry.
+///
+/// A gitlink is classified, not refused: it is recorded as a tracked,
+/// mode-unknown pointer change so a submodule move is visible to review and the
+/// presence of a submodule anywhere in history does not block ref hydration.
+fn classify_git_entry(mode: gix::objs::tree::EntryMode) -> Option<GitEntryClass> {
     use gix::objs::tree::EntryKind;
 
     match mode.kind() {
-        EntryKind::Blob => Ok(Some(SourceEntryKind::File { executable: false })),
-        EntryKind::BlobExecutable => Ok(Some(SourceEntryKind::File { executable: true })),
-        EntryKind::Link => Ok(Some(SourceEntryKind::Symlink)),
-        EntryKind::Tree => Ok(None),
-        EntryKind::Commit => Err(GitError::Other(
-            "exact Git import does not yet support gitlink/submodule entries; import refused rather than silently omitting source state"
-                .to_string(),
-        )),
+        EntryKind::Blob => Some(GitEntryClass::Source(SourceEntryKind::File {
+            executable: false,
+        })),
+        EntryKind::BlobExecutable => Some(GitEntryClass::Source(SourceEntryKind::File {
+            executable: true,
+        })),
+        EntryKind::Link => Some(GitEntryClass::Source(SourceEntryKind::Symlink)),
+        EntryKind::Tree => None,
+        EntryKind::Commit => Some(GitEntryClass::Gitlink),
     }
+}
+
+/// Content-identity hash for one side of an artifact delta. A file or symlink
+/// hashes its Git blob; a gitlink hashes the textual pointer form Git itself
+/// uses in diffs (`Subproject commit <hex>`), so a pointer move is a visible
+/// content change and the pinned commit stays recoverable from the blob store.
+fn entry_content_hash(
+    repo: &gix::Repository,
+    oid: gix::ObjectId,
+    class: GitEntryClass,
+    blob_store: Option<&BlobStore>,
+) -> Result<Hash256> {
+    match class {
+        GitEntryClass::Source(_) => blob_hash(repo, oid, blob_store),
+        GitEntryClass::Gitlink => gitlink_pointer_hash(oid, blob_store),
+    }
+}
+
+fn gitlink_pointer_hash(oid: gix::ObjectId, blob_store: Option<&BlobStore>) -> Result<Hash256> {
+    let content = format!("Subproject commit {oid}\n").into_bytes();
+    if let Some(store) = blob_store {
+        store.write(&content)?;
+    }
+    Ok(Hash256::from_bytes(kin_blobs::digest(&content).0))
 }
 
 fn utf8_git_path(path: &[u8]) -> Result<String> {
@@ -824,6 +869,24 @@ fn modified_artifact_kind(kind: SourceEntryKind) -> ArtifactDeltaKind {
     }
 }
 
+/// Resulting delta kind for an added entry. A gitlink has no exact file mode, so
+/// it is recorded as a mode-unknown addition rather than a fabricated file kind.
+fn added_delta_kind(class: GitEntryClass) -> ArtifactDeltaKind {
+    match class {
+        GitEntryClass::Source(kind) => added_artifact_kind(kind),
+        GitEntryClass::Gitlink => ArtifactDeltaKind::Added,
+    }
+}
+
+/// Resulting delta kind for a modified entry. A gitlink pointer move is recorded
+/// as a mode-unknown modification.
+fn modified_delta_kind(class: GitEntryClass) -> ArtifactDeltaKind {
+    match class {
+        GitEntryClass::Source(kind) => modified_artifact_kind(kind),
+        GitEntryClass::Gitlink => ArtifactDeltaKind::Modified,
+    }
+}
+
 fn extract_artifact_deltas(
     repo: &gix::Repository,
     commit: &gix::Commit<'_>,
@@ -831,21 +894,21 @@ fn extract_artifact_deltas(
 ) -> Result<Vec<ArtifactDelta>> {
     let mut deltas = Vec::new();
     for delta in commit_file_deltas(repo, commit)? {
-        let kind = match (delta.old_blob_id, delta.new_blob_id, delta.new_entry_kind) {
-            (None, Some(_), Some(entry_kind)) => added_artifact_kind(entry_kind),
-            (Some(_), None, None) => ArtifactDeltaKind::Removed,
-            (Some(_), Some(_), Some(entry_kind)) => modified_artifact_kind(entry_kind),
-            _ => continue,
+        let kind = match (&delta.old, &delta.new) {
+            (None, Some((_, class))) => added_delta_kind(*class),
+            (Some(_), None) => ArtifactDeltaKind::Removed,
+            (Some(_), Some((_, class))) => modified_delta_kind(*class),
+            (None, None) => continue,
         };
 
-        let old_hash = match delta.old_blob_id {
-            Some(blob_id) => Some(blob_hash(repo, blob_id, blob_store)?),
-            None => None,
-        };
-        let new_hash = match delta.new_blob_id {
-            Some(blob_id) => Some(blob_hash(repo, blob_id, blob_store)?),
-            None => None,
-        };
+        let old_hash = delta
+            .old
+            .map(|(oid, class)| entry_content_hash(repo, oid, class, blob_store))
+            .transpose()?;
+        let new_hash = delta
+            .new
+            .map(|(oid, class)| entry_content_hash(repo, oid, class, blob_store))
+            .transpose()?;
 
         deltas.push(ArtifactDelta {
             file_id: FilePathId::new(delta.path),
@@ -868,12 +931,12 @@ fn extract_full_tree_artifact_deltas(
         .map_err(|error| GitError::Git(error.to_string()))?;
     full_tree_blob_entries(repo, &tree)?
         .into_iter()
-        .map(|(path, blob_id, kind)| {
+        .map(|(path, oid, class)| {
             Ok(ArtifactDelta {
                 file_id: FilePathId::new(path),
-                kind: added_artifact_kind(kind),
+                kind: added_delta_kind(class),
                 old_hash: None,
-                new_hash: Some(blob_hash(repo, blob_id, blob_store)?),
+                new_hash: Some(entry_content_hash(repo, oid, class, blob_store)?),
             })
         })
         .collect()
@@ -890,16 +953,16 @@ fn extract_merge_artifact_deltas(
     let current_tree = commit
         .tree()
         .map_err(|error| GitError::Git(error.to_string()))?;
-    let current: BTreeMap<String, (gix::ObjectId, SourceEntryKind)> =
+    let current: BTreeMap<String, (gix::ObjectId, GitEntryClass)> =
         full_tree_blob_entries(repo, &current_tree)?
             .into_iter()
-            .map(|(path, id, kind)| (path, (id, kind)))
+            .map(|(path, id, class)| (path, (id, class)))
             .collect();
 
     // Parent order is Git-authoritative. Keep the first occurrence of a path
     // only to provide deterministic old_hash metadata; replay correctness is
     // supplied by the complete remove/upsert correction below.
-    let mut parent_union: BTreeMap<String, (gix::ObjectId, SourceEntryKind)> = BTreeMap::new();
+    let mut parent_union: BTreeMap<String, (gix::ObjectId, GitEntryClass)> = BTreeMap::new();
     for parent_id in commit.parent_ids() {
         let parent = repo
             .find_commit(parent_id.detach())
@@ -907,36 +970,36 @@ fn extract_merge_artifact_deltas(
         let parent_tree = parent
             .tree()
             .map_err(|error| GitError::Git(error.to_string()))?;
-        for (path, id, kind) in full_tree_blob_entries(repo, &parent_tree)? {
-            parent_union.entry(path).or_insert((id, kind));
+        for (path, id, class) in full_tree_blob_entries(repo, &parent_tree)? {
+            parent_union.entry(path).or_insert((id, class));
         }
     }
 
     let mut deltas = Vec::with_capacity(current.len() + parent_union.len());
-    for (path, (old_id, _)) in &parent_union {
+    for (path, (old_id, old_class)) in &parent_union {
         if !current.contains_key(path) {
             deltas.push(ArtifactDelta {
                 file_id: FilePathId::new(path),
                 kind: ArtifactDeltaKind::Removed,
-                old_hash: Some(blob_hash(repo, *old_id, blob_store)?),
+                old_hash: Some(entry_content_hash(repo, *old_id, *old_class, blob_store)?),
                 new_hash: None,
             });
         }
     }
-    for (path, (new_id, new_kind)) in current {
+    for (path, (new_id, new_class)) in current {
         let old_hash = parent_union
             .get(&path)
-            .map(|(old_id, _)| blob_hash(repo, *old_id, blob_store))
+            .map(|(old_id, old_class)| entry_content_hash(repo, *old_id, *old_class, blob_store))
             .transpose()?;
         deltas.push(ArtifactDelta {
             file_id: FilePathId::new(path),
             kind: if old_hash.is_some() {
-                modified_artifact_kind(new_kind)
+                modified_delta_kind(new_class)
             } else {
-                added_artifact_kind(new_kind)
+                added_delta_kind(new_class)
             },
             old_hash,
-            new_hash: Some(blob_hash(repo, new_id, blob_store)?),
+            new_hash: Some(entry_content_hash(repo, new_id, new_class, blob_store)?),
         });
     }
     deltas.sort_by(|left, right| left.file_id.0.cmp(&right.file_id.0));
@@ -973,12 +1036,11 @@ pub(crate) fn commit_file_deltas(
                 ..
             } => {
                 let path = utf8_git_path(location.as_ref())?;
-                if let Some(new_entry_kind) = source_entry_kind(entry_mode)? {
+                if let Some(class) = classify_git_entry(entry_mode) {
                     deltas.push(CommitFileDelta {
                         path,
-                        old_blob_id: None,
-                        new_blob_id: Some(id),
-                        new_entry_kind: Some(new_entry_kind),
+                        old: None,
+                        new: Some((id, class)),
                     });
                 }
             }
@@ -989,12 +1051,11 @@ pub(crate) fn commit_file_deltas(
                 ..
             } => {
                 let path = utf8_git_path(location.as_ref())?;
-                if source_entry_kind(entry_mode)?.is_some() {
+                if let Some(class) = classify_git_entry(entry_mode) {
                     deltas.push(CommitFileDelta {
                         path,
-                        old_blob_id: Some(id),
-                        new_blob_id: None,
-                        new_entry_kind: None,
+                        old: Some((id, class)),
+                        new: None,
                     });
                 }
             }
@@ -1006,15 +1067,10 @@ pub(crate) fn commit_file_deltas(
                 id,
             } => {
                 let path = utf8_git_path(location.as_ref())?;
-                let old_entry_kind = source_entry_kind(previous_entry_mode)?;
-                let new_entry_kind = source_entry_kind(entry_mode)?;
-                if old_entry_kind.is_some() || new_entry_kind.is_some() {
-                    deltas.push(CommitFileDelta {
-                        path,
-                        old_blob_id: old_entry_kind.map(|_| previous_id),
-                        new_blob_id: new_entry_kind.map(|_| id),
-                        new_entry_kind,
-                    });
+                let old = classify_git_entry(previous_entry_mode).map(|class| (previous_id, class));
+                let new = classify_git_entry(entry_mode).map(|class| (id, class));
+                if old.is_some() || new.is_some() {
+                    deltas.push(CommitFileDelta { path, old, new });
                 }
             }
             _ => {}
@@ -1075,7 +1131,7 @@ pub fn base_link_change_id_from_git_oid_hex(oid: &str) -> Result<SemanticChangeI
 fn full_tree_blob_entries(
     repo: &gix::Repository,
     tree: &gix::Tree<'_>,
-) -> Result<Vec<(String, gix::ObjectId, SourceEntryKind)>> {
+) -> Result<Vec<(String, gix::ObjectId, GitEntryClass)>> {
     let options = gix::diff::Options::default().with_rewrites(None);
     let changes = repo
         .diff_tree_to_tree(None, Some(tree), Some(options))
@@ -1091,8 +1147,8 @@ fn full_tree_blob_entries(
         } = change
         {
             let path = utf8_git_path(location.as_ref())?;
-            if let Some(kind) = source_entry_kind(entry_mode)? {
-                entries.push((path, id, kind));
+            if let Some(class) = classify_git_entry(entry_mode) {
+                entries.push((path, id, class));
             }
         }
     }
@@ -1109,6 +1165,10 @@ fn bounded_full_tree_blob_entries(
     tree: &gix::Tree<'_>,
     max_entries: usize,
 ) -> Result<Vec<(String, gix::ObjectId, SourceEntryKind)>> {
+    // Returns only exact-source (file/symlink) entries. A gitlink in a
+    // truncated-history boundary tree is left as an exact-source gap here rather
+    // than routed through the byte-budget blob-load path below; its pointer
+    // moves are still recorded by the per-commit diff path.
     let empty_tree = repo.empty_tree();
     let mut changes = empty_tree
         .changes()
@@ -1135,12 +1195,12 @@ fn bounded_full_tree_blob_entries(
                     return Ok::<_, std::convert::Infallible>(std::ops::ControlFlow::Break(()));
                 }
             };
-            let kind = match source_entry_kind(entry_mode) {
-                Ok(Some(kind)) => kind,
-                Ok(None) => return Ok(std::ops::ControlFlow::Continue(())),
-                Err(error) => {
-                    callback_error = Some(error);
-                    return Ok(std::ops::ControlFlow::Break(()));
+            let kind = match classify_git_entry(entry_mode) {
+                Some(GitEntryClass::Source(kind)) => kind,
+                // Gitlink (see the fn-level note) and directories are not
+                // exact-source entries at this boundary; skip.
+                Some(GitEntryClass::Gitlink) | None => {
+                    return Ok(std::ops::ControlFlow::Continue(()))
                 }
             };
             if entries.len() == max_entries {
@@ -1758,10 +1818,10 @@ mod tests {
     }
 
     #[test]
-    fn exact_import_rejects_gitlinks_instead_of_omitting_them() {
+    fn exact_import_records_gitlinks_as_tracked_pointer_changes() {
         let dir = tempfile::tempdir().unwrap();
         if !init_git_repo(dir.path()) {
-            eprintln!("git not available, skipping gitlink rejection test");
+            eprintln!("git not available, skipping gitlink import test");
             return;
         }
 
@@ -1799,10 +1859,26 @@ mod tests {
             .unwrap()
             .success());
 
+        // A submodule in history must not block import (regression: it used to
+        // be refused). The pointer is recorded as a tracked, mode-unknown
+        // artifact delta carrying the pinned commit as content — not refused,
+        // not silently omitted, and not mislabeled as a file.
         let genesis_id = SemanticChangeId::from_hash(Hash256::from_bytes([0x13; 32]));
-        let error = import_git_history(dir.path(), genesis_id, &ImportOptions::default())
-            .expect_err("an exact import must not silently omit gitlinks");
-        assert!(error.to_string().contains("gitlink/submodule"));
+        let imported = import_git_history(dir.path(), genesis_id, &ImportOptions::default())
+            .expect("a submodule pointer is recorded as a tracked change, not refused");
+
+        let gitlink = imported
+            .iter()
+            .flat_map(|change| &change.change.artifact_deltas)
+            .find(|delta| delta.file_id.0 == "vendor/sub")
+            .expect("the gitlink pointer is recorded as an artifact delta");
+        assert_eq!(gitlink.kind, ArtifactDeltaKind::Added);
+        // Mode-unknown on purpose: a submodule is not an exact-source file kind,
+        // so it resolves to a source-tree gap rather than a fabricated file.
+        assert_eq!(gitlink.kind.source_entry_kind(), None);
+        // The pinned commit is captured as the delta's content identity.
+        assert!(gitlink.new_hash.is_some());
+        assert!(gitlink.old_hash.is_none());
     }
 
     #[test]
@@ -2591,7 +2667,7 @@ mod tests {
             let expected_paths: Vec<_> = full_tree_blob_entries(&repo, &parent_tree)
                 .unwrap()
                 .into_iter()
-                .map(|(path, _, kind)| (path, added_artifact_kind(kind)))
+                .map(|(path, _, class)| (path, added_delta_kind(class)))
                 .collect();
             let anchor_paths: Vec<_> = anchor
                 .change
@@ -2620,7 +2696,10 @@ mod tests {
         let head_tree = git_merge.tree().unwrap();
         let expected_entries = full_tree_blob_entries(&repo, &head_tree).unwrap();
         let mut expected_archive = Vec::new();
-        for (path, blob_oid, kind) in expected_entries {
+        for (path, blob_oid, class) in expected_entries {
+            let GitEntryClass::Source(kind) = class else {
+                unreachable!("merge fixture contains no submodules");
+            };
             let bytes = repo.find_blob(blob_oid).unwrap().take_data();
             expected_archive.push((path, kind, bytes));
         }
@@ -2698,7 +2777,10 @@ mod tests {
         let git_merge = repo.find_commit(head_id).unwrap();
         let expected_entries = full_tree_blob_entries(&repo, &git_merge.tree().unwrap()).unwrap();
         let mut expected_archive = Vec::new();
-        for (path, blob_oid, kind) in expected_entries {
+        for (path, blob_oid, class) in expected_entries {
+            let GitEntryClass::Source(kind) = class else {
+                unreachable!("merge fixture contains no submodules");
+            };
             expected_archive.push((path, kind, repo.find_blob(blob_oid).unwrap().take_data()));
         }
         let mut replay_archive = Vec::new();


### PR DESCRIPTION
## What was broken

On v0.3.1, `kin review shadow <base>..<head>` returned HTTP 500 for any repository that has

- a **git submodule (gitlink)** anywhere in the history it hydrates, or
- a **content-addressed entity projected into more than one file** — normal for C++ projects that ship both per-header files and an amalgamated single-include copy.

The flagship review path hard-failed instead of producing a report. A/B on the same inputs (Catch2 benign scenario): v0.2.28 succeeded, v0.3.1 returned HTTP 500.

## Root cause

The exact Git importer added for release-source certification enforces strict invariants: it refused gitlink tree entries outright, and required every entity to occur in exactly one imported file state. Lazy ref hydration for `review`, `history`, and `blame` shares that importer, so invariants written for certifying *our own* release bytes were applied to *arbitrary, uncertified* repositories.

## The fix

**Record gitlinks instead of refusing them.** A submodule pointer becomes a tracked artifact delta carrying the pinned commit id (the `Subproject commit <hex>` form Git itself uses in diffs), classified through a new importer-internal `GitEntryClass`. It has no exact source file mode, so it stays mode-unknown: it resolves to a source-tree gap and exact export reports the missing mode rather than crashing. No Git-compatibility construct is added to the canonical type vocabulary — modelling submodules natively is separate follow-up work.

**Treat identical entity projections as the same entity.** A content-addressed entity is not owned by a single file. Identical projections are deduped; only the same id carrying diverging content remains a collision.

**Split importer strictness by caller.** `kin init` builds authoritative graph state and still rejects a diverging entity-id collision. Lazy ref hydration reads uncertified repositories and keeps the first projection by deterministic file order (sorted by path, so the resolution is reproducible) and continues.

**Log the full cause chain** when a shadow render fails — the client response carries only the top-level context, which previously masked the real error entirely.

## Evidence

- All 62 `kin-git` tests pass, including `exact_import_records_gitlinks_as_tracked_pointer_changes` (replaces the prior refusal test; asserts the mode-unknown delta with a content hash).
- End-to-end on the Catch2 probe with the built binaries: `kin review shadow` now returns a complete shadow gate report (changed entities, blast radius, policy, evidence gaps) after hydrating all 3398 commits, with zero HTTP 500s. Previously it failed immediately.
- `cargo fmt` clean; no new clippy findings in the changed files.

## Not changed

No canonical type changes — `kin-model` and `kin-db` are untouched, and the kin-db dependency stays pinned at 0.3.1. Certification strictness is preserved. The base-link byte-budget path continues to treat gitlinks as source-tree gaps rather than routing synthetic content through the blob-load budget.

Workspace version bumped to 0.3.2.
