### PR TITLE
Bump every release version surface to 0.3.3 in lockstep

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3044,14 +3044,14 @@ dependencies = [
 
 [[package]]
 name = "kin-buildinfo"
-version = "0.3.2"
+version = "0.3.3"
 dependencies = [
  "sha2 0.11.0",
 ]
 
 [[package]]
 name = "kin-cli"
-version = "0.3.2"
+version = "0.3.3"
 dependencies = [
  "age",
  "anyhow",
@@ -3125,7 +3125,7 @@ dependencies = [
 
 [[package]]
 name = "kin-context"
-version = "0.3.2"
+version = "0.3.3"
 dependencies = [
  "kin-blobs",
  "kin-db",
@@ -3141,7 +3141,7 @@ dependencies = [
 
 [[package]]
 name = "kin-core"
-version = "0.3.2"
+version = "0.3.3"
 dependencies = [
  "cap-fs-ext",
  "cap-std",
@@ -3171,7 +3171,7 @@ dependencies = [
 
 [[package]]
 name = "kin-daemon"
-version = "0.3.2"
+version = "0.3.3"
 dependencies = [
  "async-stream",
  "axum",
@@ -3264,7 +3264,7 @@ dependencies = [
 
 [[package]]
 name = "kin-git"
-version = "0.3.2"
+version = "0.3.3"
 dependencies = [
  "chrono",
  "gix",
@@ -3282,7 +3282,7 @@ dependencies = [
 
 [[package]]
 name = "kin-index"
-version = "0.3.2"
+version = "0.3.3"
 dependencies = [
  "hex",
  "kin-blobs",
@@ -3330,7 +3330,7 @@ dependencies = [
 
 [[package]]
 name = "kin-integration-tests"
-version = "0.3.2"
+version = "0.3.3"
 dependencies = [
  "kin-blobs",
  "kin-cli",
@@ -3372,7 +3372,7 @@ dependencies = [
 
 [[package]]
 name = "kin-mcp"
-version = "0.3.2"
+version = "0.3.3"
 dependencies = [
  "kin-blobs",
  "kin-context",
@@ -3399,7 +3399,7 @@ dependencies = [
 
 [[package]]
 name = "kin-migrate"
-version = "0.3.2"
+version = "0.3.3"
 dependencies = [
  "chrono",
  "kin-blobs",
@@ -3441,7 +3441,7 @@ dependencies = [
 
 [[package]]
 name = "kin-parser"
-version = "0.3.2"
+version = "0.3.3"
 dependencies = [
  "kin-model",
  "pretty_assertions",
@@ -3471,7 +3471,7 @@ dependencies = [
 
 [[package]]
 name = "kin-projection"
-version = "0.3.2"
+version = "0.3.3"
 dependencies = [
  "kin-blobs",
  "kin-db",
@@ -3486,7 +3486,7 @@ dependencies = [
 
 [[package]]
 name = "kin-ranking"
-version = "0.3.2"
+version = "0.3.3"
 dependencies = [
  "kin-model",
  "serde",
@@ -3495,7 +3495,7 @@ dependencies = [
 
 [[package]]
 name = "kin-reconcile"
-version = "0.3.2"
+version = "0.3.3"
 dependencies = [
  "kin-blobs",
  "kin-db",
@@ -3515,7 +3515,7 @@ dependencies = [
 
 [[package]]
 name = "kin-registry"
-version = "0.3.2"
+version = "0.3.3"
 dependencies = [
  "async-stream",
  "axum",
@@ -3548,7 +3548,7 @@ dependencies = [
 
 [[package]]
 name = "kin-remote"
-version = "0.3.2"
+version = "0.3.3"
 dependencies = [
  "chrono",
  "kin-model",
@@ -3564,7 +3564,7 @@ dependencies = [
 
 [[package]]
 name = "kin-review"
-version = "0.3.2"
+version = "0.3.3"
 dependencies = [
  "kin-blobs",
  "kin-db",
@@ -3580,7 +3580,7 @@ dependencies = [
 
 [[package]]
 name = "kin-runtime"
-version = "0.3.2"
+version = "0.3.3"
 dependencies = [
  "chrono",
  "hex",
@@ -3612,7 +3612,7 @@ dependencies = [
 
 [[package]]
 name = "kin-semantic-contracts"
-version = "0.3.2"
+version = "0.3.3"
 dependencies = [
  "kin-db",
  "kin-model",
@@ -3627,7 +3627,7 @@ dependencies = [
 
 [[package]]
 name = "kin-spine"
-version = "0.3.2"
+version = "0.3.3"
 dependencies = [
  "chrono",
  "hashbrown 0.15.5",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,7 +27,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.3.2"
+version = "0.3.3"
 edition = "2021"
 license = "Apache-2.0"
 authors = ["Troy Fortin <troy@firelock.ai>"]

--- a/crates/kin-cli/Cargo.toml
+++ b/crates/kin-cli/Cargo.toml
@@ -86,7 +86,7 @@ toml = { workspace = true }
 toml_edit = "0.25"
 tempfile = { workspace = true }
 unicode-normalization = "0.1"
-kin-spine = { version = "0.3.1", path = "../kin-spine" }
+kin-spine = { version = "0.3.3", path = "../kin-spine" }
 
 [dev-dependencies]
 pretty_assertions = { workspace = true }

--- a/packages/boundary-contracts/package.json
+++ b/packages/boundary-contracts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kin/boundary-contracts",
-  "version": "0.3.1",
+  "version": "0.3.3",
   "private": false,
   "description": "Shared contracts for Kin ecosystem boundaries.",
   "type": "module",

--- a/packages/kin-mcp/package.json
+++ b/packages/kin-mcp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kinlab/kin-mcp",
-  "version": "0.3.1",
+  "version": "0.3.3",
   "description": "Start Kin's MCP server, the system of record for AI-written software, through an npm-friendly wrapper.",
   "type": "module",
   "bin": {

--- a/packages/kin/package.json
+++ b/packages/kin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kinlab/kin",
-  "version": "0.3.1",
+  "version": "0.3.3",
   "description": "Canonical installer and launcher for Kin, the system of record for AI-written software. Provisions and runs the managed kin + kin-daemon release. MCP is one included mode (kin mcp start).",
   "license": "Apache-2.0",
   "type": "module",


### PR DESCRIPTION
The published npm packages carry their own versions, and the release publish step refuses a package whose version does not match the release tag. Moving only the Cargo workspace version leaves those manifests behind, so the publish halts at the npm preflight and the release is never promoted — which is what happened on v0.3.2.

Moves together:
- `Cargo.toml` workspace version
- `crates/kin-cli/Cargo.toml` kin-spine path-dependency pin
- `packages/kin/package.json` (@kinlab/kin)
- `packages/kin-mcp/package.json` (@kinlab/kin-mcp)
- `packages/boundary-contracts/package.json` (@kin/boundary-contracts)

The `kin-db` registry dependency tracks an external crate rather than this workspace's release version and stays pinned at 0.3.1.

Lock re-generated registry-clean: no path-patched sources, kin-db source and checksum preserved.

The v0.3.2 tag keeps its published prerelease and assets (all five install-proof legs passed on those bytes); it is superseded rather than moved.