### PR TITLE
Keep modified-content revert reintroductions informational and release 0.3.4

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3044,14 +3044,14 @@ dependencies = [
 
 [[package]]
 name = "kin-buildinfo"
-version = "0.3.3"
+version = "0.3.4"
 dependencies = [
  "sha2 0.11.0",
 ]
 
 [[package]]
 name = "kin-cli"
-version = "0.3.3"
+version = "0.3.4"
 dependencies = [
  "age",
  "anyhow",
@@ -3125,7 +3125,7 @@ dependencies = [
 
 [[package]]
 name = "kin-context"
-version = "0.3.3"
+version = "0.3.4"
 dependencies = [
  "kin-blobs",
  "kin-db",
@@ -3141,7 +3141,7 @@ dependencies = [
 
 [[package]]
 name = "kin-core"
-version = "0.3.3"
+version = "0.3.4"
 dependencies = [
  "cap-fs-ext",
  "cap-std",
@@ -3171,7 +3171,7 @@ dependencies = [
 
 [[package]]
 name = "kin-daemon"
-version = "0.3.3"
+version = "0.3.4"
 dependencies = [
  "async-stream",
  "axum",
@@ -3264,7 +3264,7 @@ dependencies = [
 
 [[package]]
 name = "kin-git"
-version = "0.3.3"
+version = "0.3.4"
 dependencies = [
  "chrono",
  "gix",
@@ -3282,7 +3282,7 @@ dependencies = [
 
 [[package]]
 name = "kin-index"
-version = "0.3.3"
+version = "0.3.4"
 dependencies = [
  "hex",
  "kin-blobs",
@@ -3330,7 +3330,7 @@ dependencies = [
 
 [[package]]
 name = "kin-integration-tests"
-version = "0.3.3"
+version = "0.3.4"
 dependencies = [
  "kin-blobs",
  "kin-cli",
@@ -3372,7 +3372,7 @@ dependencies = [
 
 [[package]]
 name = "kin-mcp"
-version = "0.3.3"
+version = "0.3.4"
 dependencies = [
  "kin-blobs",
  "kin-context",
@@ -3399,7 +3399,7 @@ dependencies = [
 
 [[package]]
 name = "kin-migrate"
-version = "0.3.3"
+version = "0.3.4"
 dependencies = [
  "chrono",
  "kin-blobs",
@@ -3441,7 +3441,7 @@ dependencies = [
 
 [[package]]
 name = "kin-parser"
-version = "0.3.3"
+version = "0.3.4"
 dependencies = [
  "kin-model",
  "pretty_assertions",
@@ -3471,7 +3471,7 @@ dependencies = [
 
 [[package]]
 name = "kin-projection"
-version = "0.3.3"
+version = "0.3.4"
 dependencies = [
  "kin-blobs",
  "kin-db",
@@ -3486,7 +3486,7 @@ dependencies = [
 
 [[package]]
 name = "kin-ranking"
-version = "0.3.3"
+version = "0.3.4"
 dependencies = [
  "kin-model",
  "serde",
@@ -3495,7 +3495,7 @@ dependencies = [
 
 [[package]]
 name = "kin-reconcile"
-version = "0.3.3"
+version = "0.3.4"
 dependencies = [
  "kin-blobs",
  "kin-db",
@@ -3515,7 +3515,7 @@ dependencies = [
 
 [[package]]
 name = "kin-registry"
-version = "0.3.3"
+version = "0.3.4"
 dependencies = [
  "async-stream",
  "axum",
@@ -3548,7 +3548,7 @@ dependencies = [
 
 [[package]]
 name = "kin-remote"
-version = "0.3.3"
+version = "0.3.4"
 dependencies = [
  "chrono",
  "kin-model",
@@ -3564,7 +3564,7 @@ dependencies = [
 
 [[package]]
 name = "kin-review"
-version = "0.3.3"
+version = "0.3.4"
 dependencies = [
  "kin-blobs",
  "kin-db",
@@ -3580,7 +3580,7 @@ dependencies = [
 
 [[package]]
 name = "kin-runtime"
-version = "0.3.3"
+version = "0.3.4"
 dependencies = [
  "chrono",
  "hex",
@@ -3612,7 +3612,7 @@ dependencies = [
 
 [[package]]
 name = "kin-semantic-contracts"
-version = "0.3.3"
+version = "0.3.4"
 dependencies = [
  "kin-db",
  "kin-model",
@@ -3627,7 +3627,7 @@ dependencies = [
 
 [[package]]
 name = "kin-spine"
-version = "0.3.3"
+version = "0.3.4"
 dependencies = [
  "chrono",
  "hashbrown 0.15.5",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,7 +27,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.3.3"
+version = "0.3.4"
 edition = "2021"
 license = "Apache-2.0"
 authors = ["Troy Fortin <troy@firelock.ai>"]

--- a/crates/kin-cli/Cargo.toml
+++ b/crates/kin-cli/Cargo.toml
@@ -86,7 +86,7 @@ toml = { workspace = true }
 toml_edit = "0.25"
 tempfile = { workspace = true }
 unicode-normalization = "0.1"
-kin-spine = { version = "0.3.3", path = "../kin-spine" }
+kin-spine = { version = "0.3.4", path = "../kin-spine" }
 
 [dev-dependencies]
 pretty_assertions = { workspace = true }

--- a/crates/kin-review/src/revert_history.rs
+++ b/crates/kin-review/src/revert_history.rs
@@ -220,33 +220,43 @@ pub(crate) fn collect_revert_history_findings<G: GraphStore>(
                 .or_insert(removal.distance);
         }
 
+        // An exact behavior-fingerprint restore is strong evidence: it gates as
+        // a warning on a public contract, informational otherwise. A bare
+        // name+kind match with modified content is weak temporal evidence — a
+        // same-named surface recurs naturally over a long history, and the
+        // namesake may be an unrelated entity in another file — so it is
+        // reported but never gates, like the other weak revert shapes.
         for ((kind, name), added) in &head_added {
-            let finding = if let Some((removed_name, distance)) =
+            let comment = if let Some((removed_name, distance)) =
                 by_hash.get(&added.fingerprint.behavior_hash)
             {
-                Some(format!(
+                let message = format!(
                     "Added `{}` restores the exact content of `{}`, removed {} — \
                      revert-shaped reintroduction",
                     name,
                     removed_name,
                     distance_phrase(*distance)
-                ))
-            } else {
-                by_name.get(&(kind.clone(), name.clone())).map(|distance| {
-                    format!(
-                        "Added `{}` reintroduces a same-named {} removed {}, with \
-                         modified content — revert-shaped surface",
-                        name,
-                        kind_label(added.kind),
-                        distance_phrase(*distance)
-                    )
-                })
-            };
-            if let Some(message) = finding {
+                );
                 let mut comment = inline_finding(added, message);
                 if !is_public_contract(added) {
                     comment.kind = InlineCommentKind::RevertHistoryIncidental;
                 }
+                Some(comment)
+            } else if let Some(distance) = by_name.get(&(kind.clone(), name.clone())) {
+                let message = format!(
+                    "Added `{}` reintroduces a same-named {} removed {}, with \
+                     modified content — revert-shaped surface",
+                    name,
+                    kind_label(added.kind),
+                    distance_phrase(*distance)
+                );
+                let mut comment = inline_finding(added, message);
+                comment.kind = InlineCommentKind::RevertHistoryIncidental;
+                Some(comment)
+            } else {
+                None
+            };
+            if let Some(comment) = comment {
                 findings.push(comment);
             }
         }

--- a/crates/kin-review/src/shadow.rs
+++ b/crates/kin-review/src/shadow.rs
@@ -4346,6 +4346,51 @@ mod tests {
     }
 
     #[test]
+    fn revert_history_modified_content_reintroduction_is_evidence_only() {
+        // c1 adds `retry_budget`, c2 removes it, padding to depth 30, then the
+        // head re-adds a same-named public function whose body DIFFERS (a new
+        // behavior fingerprint). A name+kind match with modified content is weak
+        // temporal evidence — a same-named surface recurs naturally and the
+        // namesake may live in another file — so it is reported but must not
+        // move the verdict off pass.
+        let graph = InMemoryGraph::new();
+        let mut original = entity_with_span("retry_budget", "src/net.rs", 40, EntityRole::Source);
+        original.fingerprint.behavior_hash = Hash256::from_bytes([7; 32]);
+        let base_id = padded_history_graph(
+            &graph,
+            vec![EntityDelta::Added(original.clone())],
+            vec![EntityDelta::Removed(original.id)],
+            30,
+        );
+        let mut readded = entity_with_span("retry_budget", "src/net.rs", 77, EntityRole::Source);
+        readded.fingerprint.behavior_hash = Hash256::from_bytes([8; 32]);
+        graph.upsert_entity(&readded).unwrap();
+        let head_id = change_id(204);
+        let head = change_with_deltas(
+            head_id,
+            vec![base_id],
+            vec![EntityDelta::Added(readded.clone())],
+            vec![],
+            vec![],
+        );
+        graph.create_change(&head).unwrap();
+
+        let report = build_shadow_report(&graph, &request(base_id, head_id)).unwrap();
+        let finding = report
+            .policy
+            .findings
+            .iter()
+            .find(|f| f.message.contains("with modified content"))
+            .expect("modified-content reintroduction must still be reported");
+        assert_eq!(
+            finding.kind, "revert_history_incidental",
+            "a modified-content match is weak evidence and must not gate"
+        );
+        assert_eq!(finding.severity, "info");
+        assert_eq!(report.policy.verdict, ShadowGateVerdict::Pass);
+    }
+
+    #[test]
     fn revert_history_recent_addition_removal_is_evidence_only() {
         // c2 adds `beta_flag`; the head removes that exact entity id. Deleting
         // something that only just landed is revert-shaped and must be called

--- a/packages/boundary-contracts/package.json
+++ b/packages/boundary-contracts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kin/boundary-contracts",
-  "version": "0.3.3",
+  "version": "0.3.4",
   "private": false,
   "description": "Shared contracts for Kin ecosystem boundaries.",
   "type": "module",

--- a/packages/kin-mcp/package.json
+++ b/packages/kin-mcp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kinlab/kin-mcp",
-  "version": "0.3.3",
+  "version": "0.3.4",
   "description": "Start Kin's MCP server, the system of record for AI-written software, through an npm-friendly wrapper.",
   "type": "module",
   "bin": {

--- a/packages/kin/package.json
+++ b/packages/kin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kinlab/kin",
-  "version": "0.3.3",
+  "version": "0.3.4",
   "description": "Canonical installer and launcher for Kin, the system of record for AI-written software. Provisions and runs the managed kin + kin-daemon release. MCP is one included mode (kin mcp start).",
   "license": "Apache-2.0",
   "type": "module",


### PR DESCRIPTION
## Summary

The revert-history channel gated a same-named entity reintroduction as a warning whenever the added entity was a public contract, even when only the name and kind matched and the body differed. A bare name+kind match is weak temporal evidence: a common surface name recurs across a long history, and the prior removal may be an unrelated namesake in another file.

Only an exact behavior-fingerprint restore now gates. A modified-content match is reported as an incidental informational finding, consistent with the channel's documented treatment of weak temporal evidence and with the other weak revert shapes.

This bundles the 0.3.4 version bump so the release publishes in one cycle.

## Changes

- `crates/kin-review/src/revert_history.rs` — exact `by_hash` restores still gate on a public contract; weak `by_name` modified-content matches always emit `RevertHistoryIncidental`.
- `crates/kin-review/src/shadow.rs` — regression test locking a modified-content reintroduction to an informational finding and a pass verdict.
- Version surfaces moved to 0.3.4 in lockstep: workspace `Cargo.toml`, the `kin-spine` path-dependency pin, and all three published npm manifests, with `Cargo.lock` re-locked patch-off (external `kin-*` entries keep their registry source and checksum).

## Verification

- `cargo fmt --check`, clippy under the CI allowlist with `-D warnings`, and `cargo build --all-targets --locked` all clean.
- `cargo test --locked -p kin-review` — 228 passed, 0 failed, from a clean target.
- End-to-end on a real repository: the previously misgated benign change now resolves to `pass` / `benign-local`, bit-identical across three passes.