### PR TITLE
Guard hydration replay semantics with digest pins and report incomplete revert-history ancestry

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -349,6 +349,27 @@ jobs:
 
           echo "Zero File-Search guards are falsifiable: every probe was caught."
 
+      # Deep history is a PROJECTION re-authored at ingest, not a stored fact:
+      # a merge change's entity/relation deltas are discarded and recomputed by
+      # the replay algorithm. Editing that algorithm changes what Kin reports
+      # about the past, and HYDRATION_SEMANTICS_VERSION is the declared dial for
+      # it — but nothing coupled the two, so the dial sat unchanged across the
+      # releases that rewrote replay. This pins the replay surface by digest, so
+      # an edit cannot ship without an explicit, reviewed manifest update.
+      - name: Check Hydration Replay Semantics
+        run: python3 scripts/verify-hydration-semantics.py
+
+      - name: Falsify Hydration Replay Semantics guard
+        run: |
+          set -euo pipefail
+          poisoned="$(mktemp -d)"
+          trap 'rm -rf "$poisoned"' EXIT
+          cp -a crates scripts "$poisoned/"
+          # The REAL guard and manifest run against the poisoned copy: the
+          # manifest is policy, so letting the copy supply it would falsify
+          # nothing.
+          python3 scripts/falsify-hydration-semantics.py "$poisoned"
+
       # TEMPORARY debt allow-list — burn down per crates/kin-cli/docs/kin-cli-clippy-triage.md
       # + release-ops task; no additions without lead sign-off.
       # Enumerated from `cargo clippy --all-targets --all-features` on main against

--- a/crates/kin-cli/src/commands/init/history_checkpoint.rs
+++ b/crates/kin-cli/src/commands/init/history_checkpoint.rs
@@ -31,6 +31,24 @@ const PARSER_FRONTIER_SCHEMA: &str = "kin.history-hydration.parser-frontier.v3";
 const LINKER_FRONTIER_SCHEMA: &str = "kin.history-hydration.linker-frontier.v3";
 const FORMAT_VERSION: u32 = 3;
 /// Bump for a replay semantic change even when the artifact shapes are stable.
+///
+/// Scope, precisely: this participates in [`CheckpointVersionKeyV2`] and so
+/// gates reuse of the hydration checkpoint store under
+/// `.kin/checkpoints/history-hydration/` — nothing else. It is NOT recorded in
+/// the graph, so it cannot describe which replay algorithm authored the changes
+/// already persisted there, and it cannot invalidate them.
+///
+/// It is also, on its own, inert: the same key carries `clean_git_sha`, and
+/// checkpoints are refused outright for a dirty or unknown build, so any source
+/// edit already produces a different key. Bumping this constant therefore
+/// invalidates nothing that the build SHA has not invalidated already, and a
+/// bump must not be mistaken for having addressed a replay-semantics change to
+/// existing repositories.
+///
+/// The mechanical coupling to the replay surface lives in
+/// `scripts/verify-hydration-semantics.py`, which pins those functions by
+/// digest and fails CI when one is edited without an explicit manifest update.
+/// Keep `scripts/hydration-semantics-manifest.json` in step with this value.
 const HYDRATION_SEMANTICS_VERSION: u32 = 3;
 const DEFAULT_INTERVAL: usize = 2_000;
 const DEFAULT_MANIFESTS_PER_HISTORY: usize = 6;

--- a/crates/kin-review/src/revert_history.rs
+++ b/crates/kin-review/src/revert_history.rs
@@ -31,8 +31,10 @@
 //! temporal evidence is still reported but stays informational: the benign-60
 //! sweep showed that deleting a recent addition is common cleanup unless an
 //! independent review signal also says the change is risky. When the base has
-//! less history than the window can meaningfully scan, the channel reports an
-//! honest evidence gap instead of silently passing.
+//! less history than the window can meaningfully scan, or when the graph cannot
+//! resolve an ancestry reference the DAG declares, the channel reports an
+//! honest evidence gap instead of silently passing: a window built from an
+//! incomplete DAG must never be presented as a complete one.
 //!
 //! Matching is computed at review time exclusively from the base's ancestry
 //! window — the graph may hold changes outside the reviewed lineage (other
@@ -69,16 +71,51 @@ struct WindowRemoval {
     distance: usize,
 }
 
-/// Revert-history findings plus an optional honesty gap for the scanned base.
+/// Revert-history findings plus the honesty gaps for the scanned base.
 pub(crate) fn collect_revert_history_findings<G: GraphStore>(
     store: &G,
     resolved_base: &SemanticChangeId,
     range_changes: &[SemanticChange],
-) -> Result<(Vec<InlineComment>, Option<ShadowEvidenceGap>), ReviewError> {
+) -> Result<(Vec<InlineComment>, Vec<ShadowEvidenceGap>), ReviewError> {
     let window = walk_base_window(store, resolved_base)?;
 
-    let gap = if window.changes_scanned < REVERT_HISTORY_MIN_DEPTH {
-        Some(ShadowEvidenceGap {
+    let mut gaps = Vec::new();
+
+    // An ancestry reference the graph cannot resolve truncates the walk twice
+    // over: the unresolved change contributes no deltas, and its own parents
+    // are never enqueued, so an arbitrarily large subtree of the base's causal
+    // past is absent from the window. Scanning fewer changes than the DAG
+    // declares makes the channel's silence unfalsifiable — indistinguishable
+    // from "no revert evidence exists" — so the deficit is reported rather than
+    // absorbed. This is a graph gap, not a shallow history: the count below can
+    // clear REVERT_HISTORY_MIN_DEPTH while the window is still incomplete.
+    if !window.unresolved_ancestry.is_empty() {
+        let (first_id, first_distance) = window.unresolved_ancestry[0];
+        let where_phrase = if first_distance == 0 {
+            "the resolved base itself".to_string()
+        } else {
+            format!("{} change(s) before the base", first_distance)
+        };
+        gaps.push(ShadowEvidenceGap {
+            kind: "revert_history_incomplete_ancestry".to_string(),
+            subject: "blast_radius.revert_history".to_string(),
+            detail: format!(
+                "{} ancestry reference(s) of the base do not resolve to a change in the \
+                 graph (first: {} at {}); the walk terminated at each, so their deltas \
+                 and their own ancestry are absent from the {} change(s) actually \
+                 scanned. Revert/reintroduction evidence was assessed against an \
+                 INCOMPLETE ancestry DAG, and the absence of a finding is NOT proof \
+                 that no revert exists",
+                window.unresolved_ancestry.len(),
+                first_id,
+                where_phrase,
+                window.changes_scanned
+            ),
+        });
+    }
+
+    if window.changes_scanned < REVERT_HISTORY_MIN_DEPTH {
+        gaps.push(ShadowEvidenceGap {
             kind: "revert_history_shallow".to_string(),
             subject: "blast_radius.revert_history".to_string(),
             detail: format!(
@@ -87,10 +124,8 @@ pub(crate) fn collect_revert_history_findings<G: GraphStore>(
                  of this verdict",
                 window.changes_scanned, REVERT_HISTORY_WINDOW
             ),
-        })
-    } else {
-        None
-    };
+        });
+    }
 
     // Head-side deltas for the reviewed range, deduplicated and order-stable.
     let mut head_added: BTreeMap<(String, String), Entity> = BTreeMap::new();
@@ -286,7 +321,7 @@ pub(crate) fn collect_revert_history_findings<G: GraphStore>(
         }
     }
 
-    Ok((findings, gap))
+    Ok((findings, gaps))
 }
 
 /// Everything the channel learned from scanning the base's ancestry window.
@@ -294,6 +329,11 @@ pub(crate) fn collect_revert_history_findings<G: GraphStore>(
 /// causal past may influence a finding.
 struct BaseWindow {
     changes_scanned: usize,
+    /// Ancestry references the graph could not resolve, in the walk's
+    /// deterministic discovery order, each with the distance it was reached at.
+    /// Non-empty means the window is a strict subset of the declared ancestry
+    /// and the channel's silence cannot be trusted.
+    unresolved_ancestry: Vec<(SemanticChangeId, usize)>,
     removals: Vec<WindowRemoval>,
     /// Entity ids ADDED inside the window, with their distance from the base.
     added_ids: HashMap<EntityId, usize>,
@@ -320,6 +360,7 @@ fn walk_base_window<G: GraphStore>(
         HashMap::new();
     let mut values: HashMap<EntityId, Entity> = HashMap::new();
     let mut visited: HashSet<SemanticChangeId> = HashSet::new();
+    let mut unresolved_ancestry: Vec<(SemanticChangeId, usize)> = Vec::new();
     let mut queue: VecDeque<(SemanticChangeId, usize)> = VecDeque::new();
 
     // The base change itself is scanned at distance 0: its deltas are part of
@@ -335,7 +376,13 @@ fn walk_base_window<G: GraphStore>(
         if !visited.insert(id) {
             continue;
         }
+        // A declared ancestor the graph cannot produce is a graph gap, not an
+        // end of history: its deltas and its own ancestry silently leave the
+        // window. Record it so the caller can report the deficit; continuing
+        // the walk still surfaces whatever evidence the reachable ancestry
+        // does hold, which is strictly more useful than abandoning the scan.
         let Some(change) = store.get_change(&id).map_err(ReviewError::graph)? else {
+            unresolved_ancestry.push((id, distance));
             continue;
         };
         scanned += 1;
@@ -368,6 +415,7 @@ fn walk_base_window<G: GraphStore>(
 
     Ok(BaseWindow {
         changes_scanned: scanned,
+        unresolved_ancestry,
         removals,
         added_ids,
         prior_bodies,

--- a/crates/kin-review/src/shadow.rs
+++ b/crates/kin-review/src/shadow.rs
@@ -236,6 +236,7 @@ pub struct ShadowEvidenceGap {
     /// | "actor_attribution_unavailable" | "impact_signal_absent"
     /// | "deep_history_impact_ceiling" | "cross_repo_not_evaluated"
     /// | "ref_state_unavailable" | "base_not_on_head_ancestry"
+    /// | "revert_history_shallow" | "revert_history_incomplete_ancestry"
     pub kind: String,
     pub subject: String,
     pub detail: String,
@@ -567,19 +568,18 @@ fn assemble_report_with_changes<G: GraphStore>(
     // Toolchain-surface findings feed the gate as ordinary warning findings via
     // the inline-comment channel, never through the evidence-gap demotion path.
     review.inline_comments.extend(toolchain_findings);
-    // Revert-history findings use the same inline-comment channel, with an
-    // honest gap when the base has too little history to scan. Strong matches
-    // may gate as warnings; weak temporal hints stay informational. Evidence is
-    // available at review time only: the window looks strictly BEFORE the base.
-    let (revert_findings, revert_gap) = crate::revert_history::collect_revert_history_findings(
+    // Revert-history findings use the same inline-comment channel, with honest
+    // gaps when the base has too little history to scan or when the graph could
+    // not resolve part of the ancestry the DAG declares. Strong matches may gate
+    // as warnings; weak temporal hints stay informational. Evidence is available
+    // at review time only: the window looks strictly BEFORE the base.
+    let (revert_findings, revert_gaps) = crate::revert_history::collect_revert_history_findings(
         store,
         &request.resolved_base,
         changes,
     )?;
     review.inline_comments.extend(revert_findings);
-    if let Some(gap) = revert_gap {
-        evidence_gaps.push(gap);
-    }
+    evidence_gaps.extend(revert_gaps);
     let policy = derive_policy(&review, &evidence_gaps, &changed_entities);
     let repair_context = collect_repair_context(&policy.findings, &review);
     let audit = collect_audit_evidence(store, request, &review, changes.len())?;
@@ -4293,6 +4293,62 @@ mod tests {
             prev = Some(change_id(i));
         }
         prev.expect("chain is non-empty")
+    }
+
+    // An ancestry reference the graph cannot produce costs the window twice:
+    // the unresolved change's deltas never land, and its own ancestry is never
+    // enqueued. A clean scan of whatever remains reachable is therefore not
+    // evidence that no revert exists, so the channel must report the deficit
+    // rather than absorb it and certify silence.
+    #[test]
+    fn revert_history_unresolvable_ancestry_reports_incomplete_gap() {
+        let graph = InMemoryGraph::new();
+        let reachable_tail = padded_history_graph(&graph, vec![], vec![], 30);
+        let dangling = change_id(199);
+        let base_id = change_id(150);
+        let base = change_with_deltas(
+            base_id,
+            vec![reachable_tail, dangling],
+            vec![],
+            vec![],
+            vec![],
+        );
+        graph.create_change(&base).unwrap();
+
+        let (_, gaps) =
+            crate::revert_history::collect_revert_history_findings(&graph, &base_id, &[]).unwrap();
+
+        let gap = gaps
+            .iter()
+            .find(|g| g.kind == "revert_history_incomplete_ancestry")
+            .expect("an unresolvable ancestry reference must be reported as an evidence gap");
+        assert!(
+            gap.detail.contains(&dangling.to_string()),
+            "the gap must name the unresolved change, got: {}",
+            gap.detail
+        );
+        assert!(
+            !gaps.iter().any(|g| g.kind == "revert_history_shallow"),
+            "ample reachable depth must not also report the shallow gap: the two \
+             deficits are independent"
+        );
+    }
+
+    // Negative control for the guard above: a fully resolvable ancestry must
+    // stay silent, or the gap becomes noise on every healthy review.
+    #[test]
+    fn revert_history_complete_ancestry_reports_no_gap() {
+        let graph = InMemoryGraph::new();
+        let base_id = padded_history_graph(&graph, vec![], vec![], 30);
+
+        let (_, gaps) =
+            crate::revert_history::collect_revert_history_findings(&graph, &base_id, &[]).unwrap();
+
+        assert!(
+            gaps.is_empty(),
+            "a complete 30-change ancestry must report no revert-history gap, got: {:?}",
+            gaps.iter().map(|g| g.kind.as_str()).collect::<Vec<_>>()
+        );
     }
 
     #[test]

--- a/scripts/falsify-hydration-semantics.py
+++ b/scripts/falsify-hydration-semantics.py
@@ -1,0 +1,142 @@
+#!/usr/bin/env python3
+"""Falsify the hydration replay-semantics guard.
+
+A guard that has never been shown to fail proves nothing. This plants a probe
+in every guarded function in a throwaway copy of the tree, one at a time, and
+asserts the real guard catches each one and names it. It also drives the two
+non-digest failure modes: the dial drifting away from the manifest, and a
+guarded function disappearing from under the pin.
+
+The guard under test is always the REAL scripts/verify-hydration-semantics.py
+with the REAL manifest — only the tree is poisoned. The manifest is policy, so
+letting the poisoned copy supply it would falsify nothing.
+
+Usage: falsify-hydration-semantics.py <poisoned_repo_root>
+"""
+import importlib.util
+import os
+import re
+import subprocess
+import sys
+
+SCRIPT_DIR = os.path.dirname(os.path.abspath(__file__))
+GUARD = os.path.join(SCRIPT_DIR, "verify-hydration-semantics.py")
+MANIFEST = os.path.join(SCRIPT_DIR, "hydration-semantics-manifest.json")
+
+spec = importlib.util.spec_from_file_location("hydration_guard", GUARD)
+guard = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(guard)
+
+
+def run_guard(root):
+    proc = subprocess.run(
+        [sys.executable, GUARD, root], capture_output=True, text=True
+    )
+    return proc.returncode, proc.stdout + proc.stderr
+
+
+def expect_failure(label, root, must_name):
+    code, out = run_guard(root)
+    if code == 0:
+        print(f"::error::falsification failed — {label} did not fail the guard")
+        print(out)
+        sys.exit(1)
+    if must_name not in out:
+        print(
+            f"::error::falsification failed — {label} failed but never named '{must_name}'"
+        )
+        print(out)
+        sys.exit(1)
+    print(f"  ok: {label}")
+
+
+def read(path):
+    with open(path, "r", encoding="utf-8") as f:
+        return f.read()
+
+
+def write(path, text):
+    with open(path, "w", encoding="utf-8") as f:
+        f.write(text)
+
+
+def main():
+    if len(sys.argv) < 2:
+        print("::error::usage: falsify-hydration-semantics.py <poisoned_repo_root>")
+        return 1
+    root = os.path.abspath(sys.argv[1])
+
+    import json
+
+    with open(MANIFEST, "r", encoding="utf-8") as f:
+        manifest = json.load(f)
+    entries = manifest["guarded"]
+
+    code, out = run_guard(root)
+    if code != 0:
+        print("::error::falsification cannot start — the guard already fails on the clean copy")
+        print(out)
+        return 1
+    print(f"clean copy passes; planting {len(entries) + 2} probes")
+
+    # 1. A probe in every guarded function, one at a time.
+    for entry in entries:
+        path = os.path.join(root, entry["file"])
+        original = read(path)
+        text, found = guard.extract_function(original, entry["function"])
+        if text is None:
+            print(
+                f"::error::falsification setup failed — cannot extract "
+                f"`{entry['function']}` (matches: {found})"
+            )
+            return 1
+        brace = text.index("{")
+        poisoned_fn = text[: brace + 1] + "\n    let _falsification_probe = 1;" + text[brace + 1 :]
+        write(path, original.replace(text, poisoned_fn, 1))
+        expect_failure(
+            f"probe in `{entry['function']}`", root, entry["function"]
+        )
+        write(path, original)
+
+    # 2. The dial moving without the manifest following it.
+    version_path = os.path.join(root, guard.VERSION_FILE)
+    original = read(version_path)
+    bumped = re.sub(
+        rf"(const\s+{guard.VERSION_CONST}\s*:\s*u32\s*=\s*)(\d+)",
+        lambda m: m.group(1) + str(int(m.group(2)) + 1),
+        original,
+        count=1,
+    )
+    if bumped == original:
+        print(f"::error::falsification setup failed — could not bump {guard.VERSION_CONST}")
+        return 1
+    write(version_path, bumped)
+    expect_failure("dial bumped without the manifest", root, guard.VERSION_CONST)
+    write(version_path, original)
+
+    # 3. A guarded function vanishing from under its pin.
+    entry = entries[0]
+    path = os.path.join(root, entry["file"])
+    original = read(path)
+    text, _ = guard.extract_function(original, entry["function"])
+    renamed = text.replace(
+        f"fn {entry['function']}", f"fn {entry['function']}_relocated", 1
+    )
+    write(path, original.replace(text, renamed, 1))
+    expect_failure(
+        f"`{entry['function']}` renamed out from under the pin", root, entry["function"]
+    )
+    write(path, original)
+
+    code, out = run_guard(root)
+    if code != 0:
+        print("::error::falsification left the copy dirty — the guard no longer passes")
+        print(out)
+        return 1
+
+    print("Hydration replay-semantics guard is falsifiable: every probe was caught.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/hydration-semantics-manifest.json
+++ b/scripts/hydration-semantics-manifest.json
@@ -1,0 +1,41 @@
+{
+  "comment": "Replay-semantics surface pinned by scripts/verify-hydration-semantics.py. These functions re-author the entity/relation deltas persisted for multi-parent (merge) changes during history hydration, so editing one changes what Kin reports about the past on already-ingested repositories. A digest mismatch is not a failure to fix by regenerating: decide first whether replay semantics changed, and if so bump HYDRATION_SEMANTICS_VERSION and hydration_semantics_version together.",
+  "hydration_semantics_version": 3,
+  "guarded": [
+    {
+      "file": "crates/kin-cli/src/commands/init.rs",
+      "function": "replay_imported_secondary_parents",
+      "digest": "sha256:a35363a3609e9f63c7a1289f8d437ccb662152caa1a80f1e905926a2938e7866",
+      "reason": "Walks each secondary parent's unique ancestry to build the all-parent runtime baseline a merge is rebased onto. Its DFS order and visited-marking rule decide which changes contribute, and so decide the merge's persisted deltas.",
+      "owner": "kin-cli"
+    },
+    {
+      "file": "crates/kin-cli/src/commands/init.rs",
+      "function": "rebase_imported_merge_semantic_deltas",
+      "digest": "sha256:09ea99ef84c3bd580773e4ece8f819ddb71b963fdc33c7b46d21eadd1852a601",
+      "reason": "Diffs the all-parent baseline against the merge target and REPLACES the merge change's entity_deltas and relation_deltas outright. This function is the direct author of every merge change's persisted payload.",
+      "owner": "kin-cli"
+    },
+    {
+      "file": "crates/kin-cli/src/commands/init.rs",
+      "function": "apply_imported_change_to_runtime_state",
+      "digest": "sha256:a2789e4d2aa3de44f5dcd1ffeaf05cb77f16df4154969cf7cbb53ac087c21f0f",
+      "reason": "The live entity/relation fold the baseline replay is built from, kept field-for-field aligned with kin-model's authoritative replay_graph_state. A divergence here silently shifts the baseline every merge is diffed against.",
+      "owner": "kin-cli"
+    },
+    {
+      "file": "crates/kin-cli/src/commands/init.rs",
+      "function": "imported_entities_exactly_equivalent",
+      "digest": "sha256:6b6a9824a6c69f477da250e81a88c9380002398f336e04bb94d5d86b3dce2977",
+      "reason": "Decides whether a baseline entity and its target counterpart are the same, and therefore whether the merge emits a Modified delta or nothing at all.",
+      "owner": "kin-cli"
+    },
+    {
+      "file": "crates/kin-cli/src/commands/init.rs",
+      "function": "imported_relations_exactly_equivalent",
+      "digest": "sha256:cfad3ea32fd6f44d7a57badb4470c8dad5adb444a4f179cf7ef6b706dd28433f",
+      "reason": "The relation-side equivalence predicate: decides whether a relation is rewritten as a Removed+Added pair in the merge's persisted deltas.",
+      "owner": "kin-cli"
+    }
+  ]
+}

--- a/scripts/verify-hydration-semantics.py
+++ b/scripts/verify-hydration-semantics.py
@@ -1,0 +1,375 @@
+#!/usr/bin/env python3
+"""Hydration replay-semantics guard.
+
+Kin's deep history is not a stored fact. It is a projection re-authored at
+ingest by the hydration replay algorithm, so the bytes persisted for a change
+are a function of the code in this guard's manifest. A merge change's
+`entity_deltas`/`relation_deltas` are discarded and recomputed from the
+all-parent runtime baseline, which means an edit to any of those functions
+silently changes what Kin reports about the past.
+
+`HYDRATION_SEMANTICS_VERSION` is the declared dial for that class of change,
+but nothing mechanically couples the two: the constant sat at 3 across the
+releases that shipped the replay rewrite, and the hydration checkpoint was
+invalidated only incidentally by an unrelated parser-version bump.
+
+This guard supplies the missing coupling. It digests each guarded function's
+source and compares it against the digest recorded in the manifest. Any edit
+fails CI until a human updates the manifest entry, and updating that entry puts
+the recorded `hydration_semantics_version` in front of them. The guard also
+asserts the manifest's recorded version still equals the live constant, so the
+two cannot drift apart unnoticed.
+
+A digest is deliberately NOT a "bump the version on every edit" rule. Most
+edits to these functions (a rename, a perf refactor) do not change replay
+semantics, and forcing a bump on each one trains the reflex this guard exists
+to prevent. What it forces is an explicit, reviewed decision.
+
+Usage: verify-hydration-semantics.py [repo_root]
+
+The optional repo_root selects the tree to scan (default: the repo containing
+this script). The manifest always travels with the script — it is the policy,
+not a property of the tree under test — which lets CI point the guard at a
+deliberately poisoned copy and assert that it fails.
+"""
+import hashlib
+import json
+import os
+import re
+import sys
+
+SCRIPT_DIR = os.path.dirname(os.path.abspath(__file__))
+KIN_ROOT = os.path.abspath(sys.argv[1]) if len(sys.argv) > 1 else os.path.dirname(SCRIPT_DIR)
+MANIFEST_PATH = os.path.join(SCRIPT_DIR, "hydration-semantics-manifest.json")
+
+# Every entry names an accountable owner and says why the function is part of
+# the replay-semantics surface, so the guarded set cannot grow or shrink
+# without a stated reason.
+REQUIRED_FIELDS = ("file", "function", "digest", "reason", "owner")
+
+# The file and constant that declare the dial this manifest is pinned to.
+VERSION_FILE = "crates/kin-cli/src/commands/init/history_checkpoint.rs"
+VERSION_CONST = "HYDRATION_SEMANTICS_VERSION"
+
+# Applied with `.match(code, line_start)`, which anchors at the offset; a
+# leading `^` would only ever match at position zero without re.MULTILINE.
+FN_START = re.compile(
+    r"(?:pub(?:\([^)]*\))?\s+)?(?:const\s+)?(?:async\s+)?(?:unsafe\s+)?"
+    r"(?:extern\s+\"[^\"]*\"\s+)?fn\s+(?P<name>[A-Za-z_][A-Za-z0-9_]*)\b"
+)
+
+# Matched with an explicit `pos` rather than against a slice: these run at every
+# character of a multi-hundred-KB file, and slicing would copy the whole
+# remainder each time, making the scan quadratic.
+RAW_STRING_START = re.compile(r'(?:b)?r(#*)"')
+CHAR_LITERAL = re.compile(r"'(?:\\.|[^\\'])'")
+
+
+def fail(message):
+    print(f"::error::{message}")
+
+
+def strip_to_code(text):
+    """Blank out comments and literal contents, preserving length and newlines.
+
+    Brace matching must not be fooled by a `{` inside a string or a comment.
+    Returning a same-length buffer lets the caller index straight back into the
+    original source, so the digest is taken over the real bytes rather than
+    this stripped view.
+    """
+    out = list(text)
+    i = 0
+    n = len(text)
+    while i < n:
+        c = text[i]
+        nxt = text[i + 1] if i + 1 < n else ""
+
+        # Line comment.
+        if c == "/" and nxt == "/":
+            while i < n and text[i] != "\n":
+                out[i] = " "
+                i += 1
+            continue
+
+        # Block comment (Rust nests them).
+        if c == "/" and nxt == "*":
+            depth = 0
+            while i < n:
+                if text[i] == "/" and i + 1 < n and text[i + 1] == "*":
+                    depth += 1
+                    out[i] = out[i + 1] = " "
+                    i += 2
+                    continue
+                if text[i] == "*" and i + 1 < n and text[i + 1] == "/":
+                    depth -= 1
+                    out[i] = out[i + 1] = " "
+                    i += 2
+                    if depth == 0:
+                        break
+                    continue
+                if text[i] != "\n":
+                    out[i] = " "
+                i += 1
+            continue
+
+        # Raw string: r"..." / r#"..."# / br#"..."#
+        m = RAW_STRING_START.match(text, i)
+        if m and (i == 0 or not (text[i - 1].isalnum() or text[i - 1] == "_")):
+            hashes = m.group(1)
+            terminator = '"' + hashes
+            start = m.end()
+            end = text.find(terminator, start)
+            end = n if end == -1 else end + len(terminator)
+            for j in range(i, end):
+                if text[j] != "\n":
+                    out[j] = " "
+            i = end
+            continue
+
+        # Normal string.
+        if c == '"':
+            out[i] = " "
+            i += 1
+            while i < n:
+                if text[i] == "\\":
+                    if text[i] != "\n":
+                        out[i] = " "
+                    if i + 1 < n and text[i + 1] != "\n":
+                        out[i + 1] = " "
+                    i += 2
+                    continue
+                if text[i] == '"':
+                    out[i] = " "
+                    i += 1
+                    break
+                if text[i] != "\n":
+                    out[i] = " "
+                i += 1
+            continue
+
+        # Char literal, but not a lifetime (`'a`) — only a real `'x'`/`'\n'`.
+        if c == "'":
+            m = CHAR_LITERAL.match(text, i)
+            if m:
+                for j in range(i, m.end()):
+                    out[j] = " "
+                i = m.end()
+                continue
+
+        i += 1
+    return "".join(out)
+
+
+# Several guarded functions share one (large) file; strip it once per tree.
+_STRIP_CACHE = {}
+
+
+def _stripped(source):
+    key = hashlib.sha256(source.encode("utf-8")).hexdigest()
+    if key not in _STRIP_CACHE:
+        _STRIP_CACHE[key] = strip_to_code(source)
+    return _STRIP_CACHE[key]
+
+
+def extract_function(source, name):
+    """Return the exact source text of top-level `fn name`, or None.
+
+    Anchored at column zero: these are all free functions in the guarded
+    modules, and refusing to match an indented definition keeps the guard from
+    silently latching onto a same-named helper nested in a test module.
+    """
+    code = _stripped(source)
+    matches = []
+    for line_match in re.finditer(r"^.*$", code, re.MULTILINE):
+        line_start = line_match.start()
+        m = FN_START.match(code, line_start)
+        if m and m.group("name") == name:
+            matches.append(line_start)
+
+    if len(matches) != 1:
+        return None, len(matches)
+
+    start = matches[0]
+    brace = code.find("{", start)
+    if brace == -1:
+        return None, 1
+
+    depth = 0
+    for i in range(brace, len(code)):
+        if code[i] == "{":
+            depth += 1
+        elif code[i] == "}":
+            depth -= 1
+            if depth == 0:
+                return source[start : i + 1], 1
+    return None, 1
+
+
+def digest_of(text):
+    """SHA-256 over the function source, normalized for line endings and
+    trailing whitespace only. Everything else — every token, every brace — is
+    load-bearing, because it is what re-authors history."""
+    lines = [line.rstrip() for line in text.replace("\r\n", "\n").split("\n")]
+    normalized = "\n".join(lines).strip() + "\n"
+    return "sha256:" + hashlib.sha256(normalized.encode("utf-8")).hexdigest()
+
+
+def load_manifest():
+    try:
+        with open(MANIFEST_PATH, "r", encoding="utf-8") as f:
+            return json.load(f)
+    except Exception as e:
+        fail(f"cannot load hydration semantics manifest {MANIFEST_PATH}: {e}")
+        sys.exit(1)
+
+
+def live_version(errors):
+    path = os.path.join(KIN_ROOT, VERSION_FILE)
+    try:
+        with open(path, "r", encoding="utf-8") as f:
+            source = f.read()
+    except Exception as e:
+        errors.append(f"cannot read {VERSION_FILE}: {e}")
+        return None
+    m = re.search(
+        rf"^\s*(?:pub(?:\([^)]*\))?\s+)?const\s+{VERSION_CONST}\s*:\s*u32\s*=\s*(\d+)\s*;",
+        source,
+        re.MULTILINE,
+    )
+    if not m:
+        errors.append(
+            f"{VERSION_FILE} no longer declares `const {VERSION_CONST}: u32`; "
+            "this guard pins the manifest to that constant and cannot verify it"
+        )
+        return None
+    return int(m.group(1))
+
+
+def main():
+    manifest = load_manifest()
+    entries = manifest.get("guarded", [])
+    errors = []
+
+    if not entries:
+        fail("hydration semantics manifest lists no guarded functions")
+        return 1
+
+    recorded_version = manifest.get("hydration_semantics_version")
+    actual_version = live_version(errors)
+    if recorded_version is None:
+        errors.append("manifest is missing `hydration_semantics_version`")
+    elif actual_version is not None and recorded_version != actual_version:
+        errors.append(
+            f"{VERSION_CONST} is {actual_version} but the manifest records "
+            f"{recorded_version}. The dial and the pinned replay surface must move "
+            "together: update `hydration_semantics_version` in "
+            "scripts/hydration-semantics-manifest.json"
+        )
+
+    sources = {}
+    for index, entry in enumerate(entries):
+        missing = [f for f in REQUIRED_FIELDS if not entry.get(f)]
+        if missing:
+            errors.append(f"guarded[{index}] is missing required field(s): {', '.join(missing)}")
+            continue
+
+        rel_path = entry["file"]
+        name = entry["function"]
+        abs_path = os.path.join(KIN_ROOT, rel_path)
+
+        if rel_path not in sources:
+            try:
+                with open(abs_path, "r", encoding="utf-8") as f:
+                    sources[rel_path] = f.read()
+            except Exception as e:
+                errors.append(f"cannot read {rel_path} (guarding `{name}`): {e}")
+                sources[rel_path] = None
+        source = sources[rel_path]
+        if source is None:
+            continue
+
+        text, found = extract_function(source, name)
+        if text is None:
+            if found == 0:
+                errors.append(
+                    f"`{name}` no longer exists as a top-level fn in {rel_path}. If the "
+                    "replay surface moved or was renamed, update "
+                    "scripts/hydration-semantics-manifest.json to point at its new home"
+                )
+            elif found > 1:
+                errors.append(
+                    f"`{name}` matches {found} top-level definitions in {rel_path}; "
+                    "the guard cannot tell which one authors history"
+                )
+            else:
+                errors.append(f"cannot delimit the body of `{name}` in {rel_path}")
+            continue
+
+        actual = digest_of(text)
+        if actual != entry["digest"]:
+            errors.append(
+                f"`{name}` in {rel_path} changed.\n"
+                f"    recorded: {entry['digest']}\n"
+                f"    actual:   {actual}\n"
+                "    This function re-authors persisted history. Decide whether the change "
+                "alters replay semantics for ALREADY-INGESTED repositories:\n"
+                f"      - if it does, bump {VERSION_CONST} in {VERSION_FILE} and set the "
+                "manifest's `hydration_semantics_version` to match;\n"
+                "      - either way, record the new digest in "
+                "scripts/hydration-semantics-manifest.json.\n"
+                "    Regenerate digests with: "
+                "python3 scripts/verify-hydration-semantics.py --write"
+            )
+
+    if errors:
+        print(f"Hydration replay-semantics guard FAILED ({len(errors)} problem(s)):\n")
+        for e in errors:
+            fail(e)
+        return 1
+
+    print(
+        f"Hydration replay-semantics guard passed: {len(entries)} guarded function(s) "
+        f"match the manifest at {VERSION_CONST}={recorded_version}."
+    )
+    return 0
+
+
+def write_digests():
+    """Rewrite the manifest's digests and version from the current tree.
+
+    Deliberately a separate, explicit invocation: it exists so updating a
+    pinned digest is a decision the author records, never something the guard
+    does for them on the way past.
+    """
+    manifest = load_manifest()
+    errors = []
+    version = live_version(errors)
+    if errors:
+        for e in errors:
+            fail(e)
+        return 1
+    manifest["hydration_semantics_version"] = version
+
+    for entry in manifest.get("guarded", []):
+        path = os.path.join(KIN_ROOT, entry["file"])
+        with open(path, "r", encoding="utf-8") as f:
+            source = f.read()
+        text, found = extract_function(source, entry["function"])
+        if text is None:
+            fail(f"cannot extract `{entry['function']}` from {entry['file']} (matches: {found})")
+            return 1
+        entry["digest"] = digest_of(text)
+
+    with open(MANIFEST_PATH, "w", encoding="utf-8") as f:
+        json.dump(manifest, f, indent=2)
+        f.write("\n")
+    print(f"Rewrote {MANIFEST_PATH} at {VERSION_CONST}={version}.")
+    return 0
+
+
+if __name__ == "__main__":
+    if "--write" in sys.argv:
+        sys.argv = [a for a in sys.argv if a != "--write"]
+        KIN_ROOT = os.path.abspath(sys.argv[1]) if len(sys.argv) > 1 else os.path.dirname(SCRIPT_DIR)
+        sys.exit(write_digests())
+    sys.exit(main())


### PR DESCRIPTION
Two guards against silent history re-authoring, one CI-side and one runtime-side.

1. CI digest pin on the hydration replay surface. scripts/hydration-semantics-manifest.json pins the five replay functions by content digest; scripts/verify-hydration-semantics.py fails CI when any pinned function changes without a matching HYDRATION_SEMANTICS_VERSION bump, and scripts/falsify-hydration-semantics.py proves the guard actually fires by mutating each pinned region and asserting the verifier rejects it. A replay-semantics change can no longer ship while the hydration checkpoint key stays put. The key previously held only because unrelated fields happened to move in the same release.

2. Revert-history ancestry gap reporting. The base-window walk previously skipped missing ancestor changes silently, so a window that lost most of its changes to missing nodes reported no gap and certified silence it did not earn. The walk now records a revert_history_incomplete_ancestry evidence gap when an ancestor cannot be loaded, and the shadow report carries it, so the channel's honesty mechanism covers its own failure mode.