### PR TITLE
Cancel superseded Docker and daemon-smoke runs

### DIFF
--- a/.github/workflows/daemon-smoke.yml
+++ b/.github/workflows/daemon-smoke.yml
@@ -9,6 +9,10 @@ on:
   pull_request:
     branches: [main]
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
+
 permissions:
   contents: read
 

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -9,6 +9,10 @@ on:
   pull_request:
     branches: [main]
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
+
 permissions:
   contents: read
 


### PR DESCRIPTION
`docker.yml` (13 min/run) and `daemon-smoke.yml` (3 min/run) run on every PR push with **no concurrency group** — rapid iteration stacks builds for commits that are already obsolete. `ci.yml`, SAST, and secret-scan already declare one.

Adopts the identical expression `ci.yml` uses: superseded PR runs cancel, main runs never cancel. No behavior change for any run that matters.