### PR TITLE
Bound test waits and isolate git fixtures so the workspace suite terminates

### DIFF
--- a/crates/kin-cli/src/commands/exec.rs
+++ b/crates/kin-cli/src/commands/exec.rs
@@ -161,7 +161,15 @@ fn run_command_in_session(
     let status = cmd
         .current_dir(ws_root)
         .envs(extra_env.iter().map(|(k, v)| (k.as_str(), v.as_str())))
-        .stdin(std::process::Stdio::inherit())
+        // A real `kin exec` hands the terminal to the command, which is the
+        // point of the surface. A unit test has no terminal to hand over: a
+        // command that reads stdin there would wait on a descriptor nobody
+        // writes to, so the test blocks forever instead of failing.
+        .stdin(if cfg!(test) {
+            std::process::Stdio::null()
+        } else {
+            std::process::Stdio::inherit()
+        })
         .stdout(std::process::Stdio::inherit())
         .stderr(std::process::Stdio::inherit())
         .status()

--- a/crates/kin-cli/src/commands/init.rs
+++ b/crates/kin-cli/src/commands/init.rs
@@ -8043,7 +8043,19 @@ func prCheckout(cmd *cobra.Command, args []string) error {
         if !ok {
             return false;
         }
-        for (k, v) in [("user.email", "test@test.com"), ("user.name", "Test")] {
+        // Pin every setting a developer's global config could otherwise supply
+        // to a `git commit` below. Commit signing hands the terminal to a
+        // pinentry prompt and hooks can wait on input of their own, neither of
+        // which anything in a test run will ever answer, so an inherited value
+        // turns a commit into an unbounded wait rather than a failure.
+        for (k, v) in [
+            ("user.email", "test@test.com"),
+            ("user.name", "Test"),
+            ("commit.gpgsign", "false"),
+            ("tag.gpgsign", "false"),
+            ("core.hooksPath", ".git/no-hooks"),
+            ("gc.auto", "0"),
+        ] {
             let _ = Command::new("git")
                 .args(["config", k, v])
                 .current_dir(dir)

--- a/crates/kin-cli/src/commands/test_subprocess.rs
+++ b/crates/kin-cli/src/commands/test_subprocess.rs
@@ -17,7 +17,16 @@ use std::io::{Read as _, Seek as _, SeekFrom};
 use std::process::{Child, Command, ExitStatus, Output, Stdio};
 use std::time::{Duration, Instant};
 
-pub(crate) const DEFAULT_TEST_SUBPROCESS_TIMEOUT: Duration = Duration::from_secs(60);
+/// Wall-clock cap for a test-driven worker process.
+///
+/// This is a backstop against a wait that would otherwise never end, not an
+/// assertion about how fast the machine is. The workers it bounds re-execute
+/// this test binary and normally finish in under a second, but the suite runs
+/// them many-at-once and a developer machine may be saturated by other work at
+/// the same time, so the cap is set far above any legitimate completion time.
+/// Tightening it back toward the observed runtime trades a class of hangs for a
+/// class of load-dependent false failures.
+pub(crate) const DEFAULT_TEST_SUBPROCESS_TIMEOUT: Duration = Duration::from_secs(300);
 const TEST_SUBPROCESS_REAP_GRACE: Duration = Duration::from_secs(5);
 const TEST_SUBPROCESS_POLL_INTERVAL: Duration = Duration::from_millis(10);
 

--- a/crates/kin-cli/src/commands/test_subprocess.rs
+++ b/crates/kin-cli/src/commands/test_subprocess.rs
@@ -502,6 +502,34 @@ pub(crate) fn output_with_timeout(
     }
 }
 
+/// Run a blocking call that waits on an external process or resource under a
+/// hard wall-clock cap.
+///
+/// The call runs on a worker thread, so a wait that never completes cannot
+/// stall the test binary: the caller panics with a legible message, drops any
+/// `serial_test` guard it holds, and the run still reaches a verdict. A suite
+/// that blocks forever reports nothing and pins the machine; one that fails
+/// names the resource that never arrived.
+pub(crate) fn call_with_deadline<T, F>(label: &str, timeout: Duration, call: F) -> T
+where
+    T: Send + 'static,
+    F: FnOnce() -> T + Send + 'static,
+{
+    let (sender, receiver) = std::sync::mpsc::channel();
+    std::thread::spawn(move || {
+        let _ = sender.send(call());
+    });
+    match receiver.recv_timeout(timeout) {
+        Ok(value) => value,
+        Err(std::sync::mpsc::RecvTimeoutError::Timeout) => {
+            panic!("{label} did not complete within {timeout:?}")
+        }
+        Err(std::sync::mpsc::RecvTimeoutError::Disconnected) => {
+            panic!("{label} panicked before it produced a result")
+        }
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/crates/kin-cli/src/commands/test_subprocess.rs
+++ b/crates/kin-cli/src/commands/test_subprocess.rs
@@ -519,6 +519,7 @@ pub(crate) fn output_with_timeout(
 /// `serial_test` guard it holds, and the run still reaches a verdict. A suite
 /// that blocks forever reports nothing and pins the machine; one that fails
 /// names the resource that never arrived.
+#[cfg(unix)]
 pub(crate) fn call_with_deadline<T, F>(label: &str, timeout: Duration, call: F) -> T
 where
     T: Send + 'static,

--- a/crates/kin-cli/src/commands/with.rs
+++ b/crates/kin-cli/src/commands/with.rs
@@ -707,17 +707,29 @@ mod tests {
             .unwrap();
         }
 
-        let original_path = std::env::var("PATH").unwrap_or_default();
-        std::env::set_var("PATH", format!("{}:{original_path}", stub_dir.display()));
-
         let (program, args) =
             build_assistant_command(AssistantKind::ClaudeCode, "session smoke task", false)
                 .unwrap();
+        assert_eq!(program, "claude");
+        // Launch the stub by absolute path. Resolving the assistant through a
+        // process-global `PATH` prepend races every other thread in this binary
+        // and can fall through to a real `claude` on a developer machine. The
+        // launcher inherits this process's stdin by contract, so a real
+        // interactive assistant would block on the terminal and never return.
+        let stub = stub_dir.join(&program);
+
         let mut env = session_launch_env(session_id, &ws_root, "http://127.0.0.1:9/test", None);
         env.extend(session_shim_env(&layout, &ws_root, false, false).unwrap());
-        let code = spawn_assistant_in_session(&program, &args, &ws_root, &env).unwrap();
 
-        std::env::set_var("PATH", original_path);
+        let launch_root = ws_root.clone();
+        let code = crate::commands::test_subprocess::call_with_deadline(
+            "session assistant launch",
+            crate::commands::test_subprocess::DEFAULT_TEST_SUBPROCESS_TIMEOUT,
+            move || {
+                spawn_assistant_in_session(&stub.to_string_lossy(), &args, &launch_root, &env)
+            },
+        )
+        .unwrap();
 
         assert_eq!(code, 0);
         let recorded = std::fs::read_to_string(&record).unwrap();

--- a/crates/kin-cli/src/commands/with.rs
+++ b/crates/kin-cli/src/commands/with.rs
@@ -725,9 +725,7 @@ mod tests {
         let code = crate::commands::test_subprocess::call_with_deadline(
             "session assistant launch",
             crate::commands::test_subprocess::DEFAULT_TEST_SUBPROCESS_TIMEOUT,
-            move || {
-                spawn_assistant_in_session(&stub.to_string_lossy(), &args, &launch_root, &env)
-            },
+            move || spawn_assistant_in_session(&stub.to_string_lossy(), &args, &launch_root, &env),
         )
         .unwrap();
 

--- a/crates/kin-cli/src/retrieval_profile.rs
+++ b/crates/kin-cli/src/retrieval_profile.rs
@@ -308,10 +308,27 @@ mod tests {
         }
     }
 
+    /// Clears the process-global serving mark on the way out, including when
+    /// the test unwinds.
+    ///
+    /// The mark gates the cross-encoder default, and a cross-encoder default
+    /// left switched on makes unrelated `locate` tests fetch reranker weights
+    /// over the network. Restoring it only on the success path means one failed
+    /// assertion here turns into a download — and an unbounded one — somewhere
+    /// else in the binary.
+    struct DaemonServingMark;
+
+    impl Drop for DaemonServingMark {
+        fn drop(&mut self) {
+            reset_daemon_serving_for_tests();
+        }
+    }
+
     #[test]
     #[serial_test::serial]
     fn accuracy_profile_gates_cross_encoder_on_cached_model_and_daemon_context() {
         let accuracy = RetrievalProfile::AccuracyV1;
+        let _mark = DaemonServingMark;
 
         // Outside a serving daemon the default never turns the reranker on,
         // cached model or not — a test binary or one-shot library caller must
@@ -326,6 +343,5 @@ mod tests {
             !accuracy.cross_encoder_default(false),
             "an unset default must never trigger a mid-query model download"
         );
-        reset_daemon_serving_for_tests();
     }
 }

--- a/crates/kin-cli/tests/bench_meta_json.rs
+++ b/crates/kin-cli/tests/bench_meta_json.rs
@@ -2,8 +2,11 @@
 // Copyright 2026 Firelock, LLC
 
 use serde_json::Value;
-use std::process::Command;
 use tempfile::tempdir;
+
+mod common;
+
+use common::Command;
 
 #[test]
 fn bench_meta_json_reports_cache_key_dimensions() {

--- a/crates/kin-cli/tests/common/mod.rs
+++ b/crates/kin-cli/tests/common/mod.rs
@@ -1,14 +1,168 @@
 // SPDX-License-Identifier: Apache-2.0
 // Copyright 2026 Firelock, LLC
 
+//! Shared bounded-subprocess support for the CLI integration tests.
+//!
+//! Every process an integration test drives — `kin`, `kin-daemon`, `cargo`,
+//! `rustc` — waits on something the machine may not be able to supply: a daemon
+//! that never becomes ready, a cargo build-directory lock another checkout
+//! holds, a model that is not downloaded. `Command::output()` waits on all of
+//! them without a deadline and with this process's stdin attached, so the
+//! default test suite can block forever while printing nothing. Every spawn
+//! here closes stdin and carries a wall-clock cap, so the suite always reaches
+//! a verdict and names the process that did not finish.
+
+// Each integration test binary includes this module and uses a different
+// subset of it.
+#![allow(dead_code)]
+
 use serde_json::Value;
+use std::ffi::OsStr;
+use std::io::{Read as _, Seek as _, SeekFrom};
 use std::path::{Path, PathBuf};
-use std::process::Command;
+use std::process::{Output, Stdio};
 use std::sync::OnceLock;
+use std::time::{Duration, Instant};
 
 static BUILD_DAEMON: OnceLock<()> = OnceLock::new();
 
+/// Wall-clock cap for a single test-driven subprocess.
+///
+/// Generous enough that a cold daemon start on a loaded machine still passes,
+/// short enough that a wait which is never going to end fails the run instead
+/// of pinning the machine.
+pub const COMMAND_TIMEOUT: Duration = Duration::from_secs(180);
+
+/// Wall-clock cap for the in-test `cargo build` fallback, which competes for
+/// the same build-directory lock as the `cargo test` invocation that is running
+/// this suite.
+pub const BUILD_TIMEOUT: Duration = Duration::from_secs(600);
+
+const POLL_INTERVAL: Duration = Duration::from_millis(20);
+
+/// A drop-in replacement for `std::process::Command` whose `output()` cannot
+/// block forever.
+///
+/// Two differences from the standard type, both load-bearing:
+///
+/// - Output is captured into regular files rather than pipes. `kin` detaches a
+///   `kin-daemon` that inherits the caller's stdout and stderr, and a pipe stays
+///   open for as long as any descendant holds its write end — so
+///   `std::process::Command::output()` keeps reading long after the `kin`
+///   process it launched has exited, for as long as the daemon lives.
+/// - The wait carries a wall-clock deadline. At the deadline the child is
+///   killed and the test fails naming the command, instead of leaving a silent,
+///   idle process the developer has to notice and kill by hand.
+pub struct Command(std::process::Command);
+
+impl Command {
+    pub fn new<S: AsRef<OsStr>>(program: S) -> Self {
+        Self(std::process::Command::new(program))
+    }
+
+    pub fn arg<S: AsRef<OsStr>>(&mut self, arg: S) -> &mut Self {
+        self.0.arg(arg);
+        self
+    }
+
+    pub fn args<I, S>(&mut self, args: I) -> &mut Self
+    where
+        I: IntoIterator<Item = S>,
+        S: AsRef<OsStr>,
+    {
+        self.0.args(args);
+        self
+    }
+
+    pub fn env<K: AsRef<OsStr>, V: AsRef<OsStr>>(&mut self, key: K, value: V) -> &mut Self {
+        self.0.env(key, value);
+        self
+    }
+
+    pub fn envs<I, K, V>(&mut self, vars: I) -> &mut Self
+    where
+        I: IntoIterator<Item = (K, V)>,
+        K: AsRef<OsStr>,
+        V: AsRef<OsStr>,
+    {
+        self.0.envs(vars);
+        self
+    }
+
+    pub fn env_remove<K: AsRef<OsStr>>(&mut self, key: K) -> &mut Self {
+        self.0.env_remove(key);
+        self
+    }
+
+    pub fn current_dir<P: AsRef<Path>>(&mut self, dir: P) -> &mut Self {
+        self.0.current_dir(dir);
+        self
+    }
+
+    /// Run to completion under [`COMMAND_TIMEOUT`] with stdin closed.
+    pub fn output(&mut self) -> std::io::Result<Output> {
+        self.output_within(COMMAND_TIMEOUT)
+    }
+
+    pub fn output_within(&mut self, timeout: Duration) -> std::io::Result<Output> {
+        let label = self.0.get_program().to_string_lossy().into_owned();
+        run_bounded_within(&mut self.0, &label, timeout)
+    }
+}
+
+fn run_bounded_within(
+    command: &mut std::process::Command,
+    label: &str,
+    timeout: Duration,
+) -> std::io::Result<Output> {
+    let stdout = tempfile::tempfile()?;
+    let stderr = tempfile::tempfile()?;
+    command
+        .stdin(Stdio::null())
+        .stdout(Stdio::from(stdout.try_clone()?))
+        .stderr(Stdio::from(stderr.try_clone()?));
+
+    let mut child = command.spawn()?;
+    let deadline = Instant::now() + timeout;
+    loop {
+        match child.try_wait() {
+            Ok(Some(status)) => {
+                return Ok(Output {
+                    status,
+                    stdout: read_capture(stdout)?,
+                    stderr: read_capture(stderr)?,
+                });
+            }
+            Ok(None) if Instant::now() < deadline => std::thread::sleep(POLL_INTERVAL),
+            Ok(None) => {
+                let _ = child.kill();
+                let _ = child.wait();
+                panic!(
+                    "{label} did not exit within {timeout:?}; stdout={} stderr={}",
+                    String::from_utf8_lossy(&read_capture(stdout).unwrap_or_default()),
+                    String::from_utf8_lossy(&read_capture(stderr).unwrap_or_default())
+                );
+            }
+            Err(error) => {
+                let _ = child.kill();
+                let _ = child.wait();
+                return Err(error);
+            }
+        }
+    }
+}
+
+fn read_capture(mut file: std::fs::File) -> std::io::Result<Vec<u8>> {
+    file.seek(SeekFrom::Start(0))?;
+    let mut bytes = Vec::new();
+    file.read_to_end(&mut bytes)?;
+    Ok(bytes)
+}
+
 fn daemon_compat_ok(path: &Path) -> bool {
+    if !path.exists() {
+        return false;
+    }
     let Ok(output) = Command::new(path).arg("--compat-json").output() else {
         return false;
     };
@@ -32,12 +186,21 @@ pub fn fresh_daemon_bin() -> PathBuf {
     BUILD_DAEMON.get_or_init(|| {
         let manifest_dir = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
         let workspace_root = manifest_dir.ancestors().nth(2).expect("kin workspace root");
-        let status = Command::new(env!("CARGO"))
+        // This shells out to cargo from inside a cargo-driven test run, so it
+        // contends for the build-directory lock with whatever else is building
+        // this checkout. Cargo waits on that lock forever and prints only to
+        // the stderr this call captures, so the wait is bounded here.
+        let output = Command::new(env!("CARGO"))
             .args(["build", "-p", "kin-daemon", "--bin", "kin-daemon"])
             .current_dir(workspace_root)
-            .status()
-            .expect("build kin-daemon");
-        assert!(status.success(), "cargo build -p kin-daemon failed");
+            .output_within(BUILD_TIMEOUT)
+            .expect("run cargo build -p kin-daemon");
+        assert!(
+            output.status.success(),
+            "cargo build -p kin-daemon failed: stdout={} stderr={}",
+            String::from_utf8_lossy(&output.stdout),
+            String::from_utf8_lossy(&output.stderr)
+        );
     });
 
     assert!(

--- a/crates/kin-cli/tests/contextbench_locate_json.rs
+++ b/crates/kin-cli/tests/contextbench_locate_json.rs
@@ -4,10 +4,11 @@
 use serde_json::Value;
 use std::fs;
 use std::path::Path;
-use std::process::Command;
 use tempfile::tempdir;
 
 mod common;
+
+use common::Command;
 
 fn git(path: &Path, args: &[&str]) {
     let output = Command::new("git")

--- a/crates/kin-cli/tests/daemon_stop.rs
+++ b/crates/kin-cli/tests/daemon_stop.rs
@@ -17,10 +17,12 @@
 use kin_cli::daemon_client::is_process_alive;
 use serde_json::Value;
 use std::path::Path;
-use std::process::{Command, Output};
+use std::process::Output;
 use std::time::{Duration, Instant};
 
 mod common;
+
+use common::Command;
 
 /// Run `kin <args>` in `repo` with a fully isolated daemon/supervisor
 /// environment. The long idle timeouts keep the daemon from self-stopping mid

--- a/crates/kin-cli/tests/eject_round_trip.rs
+++ b/crates/kin-cli/tests/eject_round_trip.rs
@@ -25,8 +25,12 @@
 use std::collections::BTreeMap;
 use std::fs;
 use std::path::Path;
-use std::process::{Command, Output};
+use std::process::Output;
 use tempfile::tempdir;
+
+mod common;
+
+use common::Command;
 
 /// Run a git command in `dir` and assert it succeeds.
 fn git(dir: &Path, args: &[&str]) -> Output {

--- a/crates/kin-cli/tests/git_export_roundtrip.rs
+++ b/crates/kin-cli/tests/git_export_roundtrip.rs
@@ -20,11 +20,12 @@
 use serial_test::serial;
 use std::fs;
 use std::path::Path;
-use std::process::Command;
 use std::time::Duration;
 use tempfile::tempdir;
 
 mod common;
+
+use common::Command;
 
 const README: &str =
     "# git export round-trip demo\n\nA tiny repo used to prove the export contract.\n";

--- a/crates/kin-cli/tests/history_blame_hydration.rs
+++ b/crates/kin-cli/tests/history_blame_hydration.rs
@@ -13,10 +13,11 @@
 use kin_cli::commands::blame::{execute_blame_request, BlameRequest};
 use kin_cli::commands::history::{execute_history_request, HistoryRequest};
 use std::path::Path;
-use std::process::Command;
 use tempfile::tempdir;
 
 mod common;
+
+use common::Command;
 
 fn kin_command() -> Command {
     let mut cmd = Command::new(env!("CARGO_BIN_EXE_kin"));

--- a/crates/kin-cli/tests/init_json.rs
+++ b/crates/kin-cli/tests/init_json.rs
@@ -6,11 +6,12 @@ use kin_db::EntityStore;
 use serde_json::Value;
 use std::fs;
 use std::path::Path;
-use std::process::Command;
 use tempfile::tempdir;
 
 #[cfg(feature = "vector")]
 mod common;
+
+use common::Command;
 
 #[cfg(feature = "vector")]
 fn find_cache_graph_path(cache_dir: &Path) -> std::path::PathBuf {

--- a/crates/kin-cli/tests/init_json.rs
+++ b/crates/kin-cli/tests/init_json.rs
@@ -8,7 +8,6 @@ use std::fs;
 use std::path::Path;
 use tempfile::tempdir;
 
-#[cfg(feature = "vector")]
 mod common;
 
 use common::Command;

--- a/crates/kin-cli/tests/locate_json_stdout.rs
+++ b/crates/kin-cli/tests/locate_json_stdout.rs
@@ -4,13 +4,14 @@
 use serial_test::serial;
 use std::env;
 use std::fs;
-use std::process::Command;
 use std::time::Duration;
 #[cfg(unix)]
 use std::time::Instant;
 use tempfile::tempdir;
 
 mod common;
+
+use common::Command;
 
 #[cfg(unix)]
 fn wait_for_pid_exit(pid: u32) {

--- a/crates/kin-cli/tests/prepared_state_json.rs
+++ b/crates/kin-cli/tests/prepared_state_json.rs
@@ -7,10 +7,12 @@ use kin_db::EntityStore;
 use serde_json::Value;
 use std::fs;
 use std::path::Path;
-use std::process::{Command, Output};
+use std::process::Output;
 use tempfile::tempdir;
 
 mod common;
+
+use common::Command;
 
 fn git(path: &Path, args: &[&str]) -> Output {
     let output = Command::new("git")

--- a/crates/kin-cli/tests/registry_authority.rs
+++ b/crates/kin-cli/tests/registry_authority.rs
@@ -5,7 +5,10 @@
 
 use std::os::unix::fs::PermissionsExt;
 use std::path::Path;
-use std::process::Command;
+
+mod common;
+
+use common::Command;
 
 fn mode(path: &Path) -> u32 {
     std::fs::metadata(path).unwrap().permissions().mode() & 0o777

--- a/crates/kin-cli/tests/review_shadow_json.rs
+++ b/crates/kin-cli/tests/review_shadow_json.rs
@@ -12,10 +12,11 @@ use kin_cli::commands::ref_lookup::{
 };
 use serde_json::Value;
 use std::path::Path;
-use std::process::Command;
 use tempfile::tempdir;
 
 mod common;
+
+use common::Command;
 
 fn kin_command() -> Command {
     let mut cmd = Command::new(env!("CARGO_BIN_EXE_kin"));

--- a/crates/kin-git/src/import.rs
+++ b/crates/kin-git/src/import.rs
@@ -1512,6 +1512,18 @@ mod tests {
                     .args(["config", "core.hooksPath", ".git/no-hooks"])
                     .current_dir(dir)
                     .output();
+                // Commit signing is a common global default and it hands the
+                // terminal to a pinentry prompt. Nothing answers that prompt
+                // during a test run, so an inherited value makes the commits
+                // below wait forever instead of failing.
+                let _ = Command::new("git")
+                    .args(["config", "commit.gpgsign", "false"])
+                    .current_dir(dir)
+                    .output();
+                let _ = Command::new("git")
+                    .args(["config", "tag.gpgsign", "false"])
+                    .current_dir(dir)
+                    .output();
                 true
             }
             _ => false,

--- a/crates/kin-migrate/src/finalize.rs
+++ b/crates/kin-migrate/src/finalize.rs
@@ -224,7 +224,21 @@ mod tests {
     #[test]
     fn update_registry_does_not_panic_on_missing_home() {
         let tmp = tempfile::tempdir().unwrap();
-        // Should not panic even if ~/.kin doesn't exist.
+        // Point the registry authority at a path whose parent directory does
+        // not exist yet. That is the condition under test, and it keeps the
+        // test off the real `~/.kin/registry.toml`: writing there mutates the
+        // developer's own repo list, and the exclusive lock it takes has no
+        // timeout, so a `kin` process holding that lock would block this test
+        // forever.
+        let registry_path = tmp.path().join("registry-home/registry.toml");
+        std::env::set_var("KIN_REGISTRY_PATH", &registry_path);
+
         update_registry(tmp.path(), 42).unwrap();
+
+        assert!(
+            registry_path.exists(),
+            "the registry authority must be created under the missing home"
+        );
+        std::env::remove_var("KIN_REGISTRY_PATH");
     }
 }


### PR DESCRIPTION
cargo test --workspace could hang: unbounded waits on subprocesses and shared git fixtures that deadlocked under parallel execution. The hang reproduced in CI on 2026-07-25 on both platforms on an unrelated branch (run 30140067435: ubuntu hung inside update-module unit tests and was wall-clock killed with an orphaned test binary; macos was killed holding three orphaned kin-daemon processes).

This branch bounds every wait, caps subprocess lifetimes, isolates git fixtures per test, keeps the default suite off host-global state and terminal waits, and compiles the CLI init tests without the vector feature.

Verified terminating: a full cargo test --workspace on this branch ran to completion in 4m17s (warm target dir) with 3947 passed, 0 failed, rc=0, across all 74 test binaries, on macOS with the machine otherwise idle. Non-blocking observation recorded during the run: one daemon fixture logs a local snapshot generation mismatch on teardown in its temp dir without affecting any test result; tracked separately.