### PR TITLE
Cache only the registry for coverage

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -501,13 +501,17 @@ jobs:
           grep -q '^\[registries\.kin\]' .cargo/config.toml
           if grep -q '^\[patch\.kin\]' .cargo/config.toml; then echo "::error::[patch.kin] git pins must be removed — kin-* resolve from the Kin registry"; exit 1; fi
 
-      - name: Cache cargo registry and build
+      - name: Cache cargo registry
+        # Registry only, deliberately: tarpaulin's instrumented builds use their
+        # own flags, so a cached target never fingerprint-matches. Measured on
+        # main: a 4.62 GB target cache HIT left coverage at 24.2 min vs 23.5
+        # cold — zero benefit, while its size (47% of the repo's 10 GB budget)
+        # evicted the Windows release-build cache that does pay for itself.
         uses: actions/cache@v6
         with:
           path: |
             ~/.cargo/registry
             ~/.cargo/git
-            target
           key: ${{ runner.os }}-cargo-tarpaulin-${{ hashFiles('**/Cargo.lock') }}
           restore-keys: |
             ${{ runner.os }}-cargo-tarpaulin-


### PR DESCRIPTION
Measured on main after the caching change: Coverage ran **24.2 min with a 4.62 GB cache HIT** vs 23.5 min cold. Tarpaulin instruments builds with its own flags, so the cached `target` never fingerprint-matches — the cache buys zero minutes.

Meanwhile that 4.62 GB is **47% of the repo's 10 GB cache budget** (currently at 9.88 GB), and the eviction pressure it creates is why this same run shows the Windows release-build cache MISSING — the one cache that demonstrably pays (installer 26.2 → 18.3 min warm-split; authority tests 13.6 → 5.0 with a hit).

Registry stays cached (crate downloads are real time); the dead target tree goes.