### PR TITLE
Merge labeled bump PRs on founder approval

### DIFF
--- a/.github/workflows/approve-to-merge.yml
+++ b/.github/workflows/approve-to-merge.yml
@@ -1,0 +1,19 @@
+name: Approve To Merge
+
+on:
+  pull_request_review:
+    types: [submitted]
+
+# Read-only by default; the merge capability is granted only to the gate job,
+# which the release-workflow authority test requires: top-level tokens default
+# to contents: read, and write elevation is per-job.
+permissions:
+  contents: read
+
+jobs:
+  gate:
+    if: github.event.review.state == 'approved'
+    permissions:
+      contents: write
+      pull-requests: write
+    uses: firelock-ai/kin-actions/.github/workflows/approve-to-merge.yml@v0.1.17


### PR DESCRIPTION
Reworked after kin's own release-workflow authority test correctly rejected the first version: `kin-dependency-wave.yml` is on the **retired list** ("release.yml owns protected public writes"), a deliberate decision from the release-authority hardening that I am not overriding.

What remains is the thumbs-up flow within that model: **your Approve on a PR labeled `release:consumer-bump` arms auto-merge** — required checks still gate, a red gate leaves it open, reviewer allowlist is exact-match `troyjr4103`. Bump PRs for kin stay human-opened (as the authority model requires); the approval click becomes the only step between a prepared, green PR and merge.