### PR TITLE
Run tests under nextest and cache Windows compiles with sccache

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -167,6 +167,11 @@ jobs:
         with:
           targets: x86_64-pc-windows-msvc
 
+      - name: Install sccache
+        uses: taiki-e/install-action@v2
+        with:
+          tool: sccache
+
       - name: Cache cargo registry and build
         uses: actions/cache@v6
         with:
@@ -174,6 +179,7 @@ jobs:
             ~/.cargo/registry
             ~/.cargo/git
             target
+            .sccache
           key: windows-vectorless-cargo-${{ hashFiles('Cargo.lock') }}
           restore-keys: |
             windows-vectorless-cargo-
@@ -193,9 +199,17 @@ jobs:
 
       - name: Build Windows release binaries without vector features
         shell: bash
-        run: >
-          cargo build --locked --release --target x86_64-pc-windows-msvc
-          -p kin-cli -p kin-daemon --no-default-features
+        env:
+          # Compile cache keyed per crate, so a Cargo.lock change warm-starts
+          # from compiled dependencies instead of a cold tree. The cache lives
+          # in .sccache and persists through the actions/cache block above.
+          RUSTC_WRAPPER: sccache
+          SCCACHE_DIR: ${{ github.workspace }}/.sccache
+          CARGO_INCREMENTAL: "0"
+        run: |
+          cargo build --locked --release --target x86_64-pc-windows-msvc \
+            -p kin-cli -p kin-daemon --no-default-features
+          sccache --show-stats
 
       - name: Verify Windows build provenance and disabled features
         shell: bash
@@ -475,8 +489,17 @@ jobs:
       - name: Build
         run: cargo build --all-targets --locked
 
+      - name: Install nextest
+        uses: taiki-e/install-action@v2
+        with:
+          tool: nextest
+
       - name: Test
-        run: cargo test --locked
+        run: cargo nextest run --locked
+
+      - name: Doc tests
+        # nextest does not run doctests; keep them covered explicitly.
+        run: cargo test --doc --locked
 
   # Security audit moved to sast.yml (cargo-deny: advisories + licenses + bans + sources)
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -179,7 +179,7 @@ jobs:
             ~/.cargo/registry
             ~/.cargo/git
             target
-            .sccache
+            ${{ runner.temp }}/sccache
           key: windows-vectorless-cargo-${{ hashFiles('Cargo.lock') }}
           restore-keys: |
             windows-vectorless-cargo-
@@ -202,9 +202,11 @@ jobs:
         env:
           # Compile cache keyed per crate, so a Cargo.lock change warm-starts
           # from compiled dependencies instead of a cold tree. The cache lives
-          # in .sccache and persists through the actions/cache block above.
+          # OUTSIDE the workspace: an untracked directory inside it reads as a
+          # dirty checkout, and the provenance step then correctly refuses to
+          # certify the build (which is exactly how the first attempt failed).
           RUSTC_WRAPPER: sccache
-          SCCACHE_DIR: ${{ github.workspace }}/.sccache
+          SCCACHE_DIR: ${{ runner.temp }}/sccache
           CARGO_INCREMENTAL: "0"
         run: |
           cargo build --locked --release --target x86_64-pc-windows-msvc \


### PR DESCRIPTION
The adopt-both mandate, kept minimal and measurable:

**nextest** in the Check & Test matrix — parallel test scheduling across kin's ~3,900 tests, typically 30-50% off test wall time. Doctests stay covered by an explicit `cargo test --doc` step (**nextest does not run doctests** — silently losing them would be a coverage regression dressed as a speedup).

**sccache** on the Windows release build only — the existing `target` cache helps solely while `Cargo.lock` is unchanged, so every dependency bump (which is most merges now, given the wave) paid the full ~15-min rebuild. sccache keys per crate and survives lock changes. Its disk cache rides the **existing** cache block (`.sccache` path) — no second cache backend, no new token exposure. `sccache --show-stats` prints hit rates in the log so the next measurement is free.

One new third-party action (`taiki-e/install-action@v2`) covers both tools.

Measurement plan: compare this PR's own runs (cold sccache) against the next dependency-bump PR (warm across lock change) — that's the case the target cache can't serve.