### PR TITLE
Surface the response body when a gated checkout fails

### DIFF
--- a/crates/kin-daemon/src/api.rs
+++ b/crates/kin-daemon/src/api.rs
@@ -15976,8 +15976,24 @@ mod tests {
         );
 
         drop(guard);
-        assert_eq!(first.await.unwrap().status(), StatusCode::OK);
-        assert_eq!(second.await.unwrap().status(), StatusCode::OK);
+        // On failure, surface the error body: this test flaked once on CI with a
+        // bare 500 and the discarded body was the only thing that could have
+        // named the cause. 300 solo repetitions under load pass, so whatever
+        // fails here is cross-test interference the next occurrence must
+        // identify itself.
+        for (label, handle) in [("first", &mut first), ("second", &mut second)] {
+            let response = handle.await.unwrap();
+            let status = response.status();
+            if status != StatusCode::OK {
+                let body = axum::body::to_bytes(response.into_body(), 65536)
+                    .await
+                    .unwrap();
+                panic!(
+                    "{label} checkout returned {status} after the gate released: {}",
+                    String::from_utf8_lossy(&body)
+                );
+            }
+        }
         assert_eq!(
             std::fs::read(state.layout.working_dir().join("src/shared.rs")).unwrap(),
             b"main checkout bytes\n",


### PR DESCRIPTION
The macOS flake, diagnosed as far as the evidence allows — **left open for your review per the mandate**.

**What the failure actually was:** not gate timing. `first.await` returned a bare **500** *after* the gate released (api.rs:15980) — the serialization semantics held; `execute_checkout_request` itself failed. The assert threw away the response body, which was the only thing that could have named the cause.

**Repro effort:** 300 solo repetitions under 6-way CPU load, then 25 full-suite runs (450 tests each, the exact parallel shape CI ran) — **11,250+ executions, zero failures** on the same Apple-silicon/macOS family as the runner. Fixture audit: per-test UUID tempdirs, OnceLock-stable registry override, no env reads on the checkout path. Whatever fails is CI-runner-specific or rarer still.

**The fix:** stop destroying the evidence. A non-OK status now panics with the status **and the full response body**, so the next occurrence self-diagnoses instead of costing another blind debug cycle. Test semantics otherwise unchanged; passes locally (`1 passed`).

If you'd rather also quarantine it (`#[ignore]` + a tracking issue) until the body-bearing failure lands, say so — I'd argue against, since it just proved 449 siblings plus itself clean 25 times in a row.