### PR TITLE
Notify the approver when a bump PR is labeled

### DIFF
--- a/.github/workflows/notify-approver.yml
+++ b/.github/workflows/notify-approver.yml
@@ -1,0 +1,15 @@
+name: Notify Approver
+
+on:
+  pull_request:
+    types: [opened, labeled]
+
+permissions:
+  contents: read
+
+jobs:
+  notify:
+    uses: firelock-ai/kin-actions/.github/workflows/notify-approver.yml@v0.1.19
+    permissions:
+      contents: read
+      pull-requests: write


### PR DESCRIPTION
Completes the thumbs-up loop: a `release:consumer-bump`-labeled PR now **notifies you** — a native review request when someone else authored it, or a bot comment @-mentioning you when you're the author (every automation PR today, since the wave/sync PATs are your own account — GitHub rejects author-as-reviewer and doesn't notify authors of their own PRs). Marker-guarded, so relabeling never spams. Authority script passes locally.