### PR TITLE
Add a dispatchable migration for legacy Cargo index records

### DIFF
--- a/.github/workflows/registry-index-migrate.yml
+++ b/.github/workflows/registry-index-migrate.yml
@@ -1,0 +1,123 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2026 Firelock, LLC
+
+name: Registry Index Migrate
+
+# Repairs Cargo sparse-index version records that predate the
+# cargo_index_format marker and therefore fail index reads with
+# "legacy or incomplete". The repair is an identical-bytes republish
+# through the authenticated publish endpoint: the registry re-derives
+# index metadata from the manifest inside the stored archive and
+# rewrites the record in place. Different bytes are rejected with 409
+# before any mutation, so a failed run cannot corrupt registry state.
+
+on:
+  workflow_dispatch:
+    inputs:
+      packages:
+        description: "Space-separated crate names whose sparse index reports legacy metadata"
+        required: true
+        default: "kin-db kin-model kin-blobs kin-search kin-vector kin-infer kin-lsp kin-vfs-core"
+      base_url:
+        description: "Registry base URL"
+        required: true
+        default: "https://kinlab.ai"
+      execute:
+        description: "true republishes stored bytes to repair records; anything else reports without mutating"
+        required: true
+        default: "false"
+
+permissions:
+  contents: read
+
+concurrency:
+  group: registry-index-migrate
+  cancel-in-progress: false
+
+jobs:
+  migrate:
+    runs-on: ubuntu-latest
+    if: github.ref == 'refs/heads/main'
+    steps:
+      - name: Repair legacy index records
+        env:
+          KINLAB_CARGO_TOKEN: ${{ secrets.KINLAB_CARGO_TOKEN }}
+          BASE_URL: ${{ inputs.base_url }}
+          PACKAGES: ${{ inputs.packages }}
+          EXECUTE: ${{ inputs.execute }}
+        run: |
+          set -euo pipefail
+          if [ "$EXECUTE" = "true" ] && [ -z "$KINLAB_CARGO_TOKEN" ]; then
+            echo "KINLAB_CARGO_TOKEN is required to execute repairs" >&2
+            exit 1
+          fi
+          index_path() {
+            local name="$1"
+            case "${#name}" in
+              1) printf '1/%s' "$name" ;;
+              2) printf '2/%s' "$name" ;;
+              3) printf '3/%s/%s' "${name:0:1}" "$name" ;;
+              *) printf '%s/%s/%s' "${name:0:2}" "${name:2:2}" "$name" ;;
+            esac
+          }
+          overall=0
+          for pkg in $PACKAGES; do
+            path="$(index_path "$pkg")"
+            status=""
+            for attempt in $(seq 1 50); do
+              code=$(curl -sS -m 30 -o idx.body -w '%{http_code}' "$BASE_URL/registry/cargo/$path")
+              if [ "$code" = "200" ]; then
+                status="serving"
+                break
+              fi
+              if [ "$code" != "500" ] || ! grep -q "legacy or incomplete" idx.body; then
+                status="unexpected HTTP $code on index read: $(head -c 200 idx.body)"
+                break
+              fi
+              coord=$(sed -n 's/.*Cargo index metadata for \([^ ]*\) is legacy.*/\1/p' idx.body | head -n 1)
+              name="${coord%@*}"
+              ver="${coord##*@}"
+              if [ "$name" != "$pkg" ] || [ -z "$ver" ]; then
+                status="index error names ${coord:-nothing}, expected package $pkg"
+                break
+              fi
+              dl=$(curl -sS -m 300 -D crate.hdrs -o crate.bin -w '%{http_code}' "$BASE_URL/registry/cargo/dl/$name/$ver")
+              if [ "$dl" != "200" ]; then
+                status="download of $coord failed with HTTP $dl"
+                break
+              fi
+              etag=$(tr -d '\r' < crate.hdrs | awk -F'"' 'tolower($0) ~ /^etag: / { print $2; exit }')
+              sum=$(sha256sum crate.bin | cut -d' ' -f1)
+              if [ "$etag" != "$sum" ]; then
+                status="checksum drift on $coord: record $etag, stored blob $sum"
+                break
+              fi
+              if [ "$EXECUTE" != "true" ]; then
+                status="dry run: would republish $coord ($(wc -c < crate.bin | tr -d ' ') bytes, sha256 $sum)"
+                break
+              fi
+              pub=$(curl -sS -m 300 -o pub.body -w '%{http_code}' -X POST \
+                -H "Authorization: Bearer $KINLAB_CARGO_TOKEN" \
+                -H "Content-Type: application/octet-stream" \
+                --data-binary @crate.bin \
+                "$BASE_URL/registry/cargo/api/v1/crates/publish?name=$name&version=$ver")
+              if [ "$pub" != "200" ]; then
+                status="republish of $coord rejected with HTTP $pub: $(head -c 200 pub.body)"
+                break
+              fi
+              if ! grep -q '"already_published":true' pub.body; then
+                status="republish of $coord did not take the idempotent repair path: $(head -c 200 pub.body)"
+                break
+              fi
+              echo "repaired $coord"
+            done
+            case "$status" in
+              serving) echo "OK   $pkg index serves" ;;
+              "dry run"*) echo "PLAN $pkg $status" ;;
+              *)
+                echo "FAIL $pkg: ${status:-not serving after 50 repair attempts}"
+                overall=1
+                ;;
+            esac
+          done
+          exit "$overall"

--- a/crates/kin-registry/PUBLISHING.md
+++ b/crates/kin-registry/PUBLISHING.md
@@ -110,3 +110,41 @@ the now-fail-closed registry (surfaced as a non-2xx HTTP error).
 | `publish-kinlab-crates.sh` | `KINLAB_CARGO_TOKEN` (or `KINLAB_TOKEN`) | No header; publish rejected by registry |
 
 The sender's token must match the credential for the ecosystem it is mutating.
+
+## Migrating legacy Cargo index metadata
+
+The sparse index serves only version records whose metadata carries
+`cargo_index_format: 1`. Records written before that marker existed make every
+`GET` of the package's index path fail with HTTP 500 and:
+
+```
+Cargo index metadata for <name>@<version> is legacy or incomplete; re-publish or migrate the manifest before serving it
+```
+
+One legacy record fails the whole package file, because a sparse index file is
+one newline-delimited entry per version and has no per-version error channel.
+Resolution of every version of that package fails until the record is repaired.
+
+The supported migration is an identical-bytes republish through the
+authenticated publish endpoint. Re-publishing the exact stored bytes takes the
+idempotent path: the registry re-derives index metadata from the manifest
+inside the archive and rewrites the record in place, preserving `published_at`
+and `published_by`. A republish with different bytes is rejected with `409`
+before touching the blob or the record, so a failed migration attempt changes
+nothing.
+
+Per affected package:
+
+1. `GET <base>/registry/cargo/<prefix>/<name>` and read the failing
+   `<name>@<version>` from the error body. The index reports one legacy record
+   at a time, so the remaining steps repeat until the read returns 200.
+2. `GET <base>/registry/cargo/dl/<name>/<version>` and check that the SHA-256
+   of the body equals the `ETag` value before sending anything.
+3. `POST <base>/registry/cargo/api/v1/crates/publish?name=<name>&version=<version>`
+   with the downloaded bytes and the Cargo bearer token. Expect `200` with
+   `"already_published": true`; a plain publish response means the version did
+   not previously exist and the coordinates should be re-checked.
+
+`.github/workflows/registry-index-migrate.yml` automates this loop as a manual
+dispatch. It dry-runs by default and mutates only when dispatched with
+`execute: true`, using the repository's `KINLAB_CARGO_TOKEN` secret.


### PR DESCRIPTION
## What

Adds `.github/workflows/registry-index-migrate.yml`, a manual-dispatch job that repairs sparse-index version records rejected as `legacy or incomplete`, and documents the procedure in `PUBLISHING.md`.

## Why

Version records that predate the `cargo_index_format` marker fail `CargoIndexEntry::try_from_version`, and one legacy record fails the entire package index file, so every version of that package becomes unresolvable. The registry already ships the repair: an identical-bytes republish takes the idempotent path in `commit_crate`, re-derives index metadata from the manifest inside the stored archive, and rewrites the record in place while preserving `published_at` and `published_by`. Until now nothing wrapped that loop, so the remedy named by the serving error had no runner.

## Safety

- Dry-run by default; mutates only when dispatched with `execute: true`.
- Downloads the stored blob and verifies its SHA-256 against the record checksum before sending anything.
- A republish with different bytes is rejected with 409 before any mutation, so a failed run cannot corrupt registry state.
- Dispatch inputs reach the shell only through `env`, and the job runs only on `refs/heads/main`.
- No third-party actions, no checkout; the job is a single curl loop.

## Testing

- `scripts/test-release-workflow-authority.py` passes with the new workflow present.
- Workflow YAML parses; the embedded script passes `bash -n`.
- Read side falsified against the live registry: all eight currently-rejected records download with body SHA-256 exactly matching the record checksum, so each qualifies for the idempotent repair path.