### PR TITLE
Make the checkpoint crash simulation die without a crash report

### DIFF
--- a/crates/kin-cli/src/commands/init.rs
+++ b/crates/kin-cli/src/commands/init.rs
@@ -9021,9 +9021,12 @@ func prCheckout(cmd *cobra.Command, args []string) error {
             checkpoint_worker_command(&root, &dir.path().join("crash-blobs"), "crash-orphan")
                 .output()
                 .unwrap();
-        assert!(
-            !crashed.status.success(),
-            "crash worker unexpectedly published a complete checkpoint"
+        assert_eq!(
+            crashed.status.code(),
+            Some(history_checkpoint::CRASH_SIMULATION_EXIT_CODE),
+            "crash worker did not die at the armed crash boundary\nstdout:\n{}\nstderr:\n{}",
+            String::from_utf8_lossy(&crashed.stdout),
+            String::from_utf8_lossy(&crashed.stderr)
         );
 
         let orphan_objects: Vec<_> = recursive_checkpoint_files(&root)

--- a/crates/kin-cli/src/commands/init/history_checkpoint.rs
+++ b/crates/kin-cli/src/commands/init/history_checkpoint.rs
@@ -218,6 +218,12 @@ impl HydrationCheckpointConfig {
     }
 }
 
+/// Exit code for the injected mid-checkpoint process death. Distinct from a
+/// worker panic (libtest exits 101) so the parent can assert the process died
+/// at the armed boundary and not for an incidental reason.
+#[cfg(test)]
+pub(super) const CRASH_SIMULATION_EXIT_CODE: i32 = 86;
+
 fn checkpoint_build_policy(
     embedded_sha: &str,
     embedded_dirty: bool,
@@ -1872,9 +1878,13 @@ impl HydrationCheckpointSession {
         // Test-only process-crash injection after all immutable objects are
         // durably installed but before the reachability manifest exists.
         // Recovery must happen in the next process's prepare maintenance.
+        // Dies by exit rather than abort: both stop here without running
+        // destructors or writing the manifest, but SIGABRT additionally puts
+        // every suite run through the host's crash-report and binary
+        // assessment tooling.
         #[cfg(test)]
         if self.config.crash_after_objects_before_manifest {
-            std::process::abort();
+            std::process::exit(CRASH_SIMULATION_EXIT_CODE);
         }
 
         let manifest = ManifestPayloadV2 {


### PR DESCRIPTION
## What

The mid-checkpoint crash injection in `HydrationCheckpointSession::persist_boundary` now dies with `std::process::exit(CRASH_SIMULATION_EXIT_CODE)` instead of `std::process::abort()`, and the parent test asserts the exact exit code instead of any non-success status.

## Why

Both mechanisms stop the process at the armed boundary without running destructors or writing the manifest, so the recovery contract under test is unchanged: immutable objects remain durably installed, the manifest never appears, and the next process's prepare maintenance must recover. The difference is delivery. SIGABRT routes every suite run through the host's crash-report and binary-assessment tooling; a plain exit does not.

The assertion change strengthens the test: a worker that dies from an incidental panic exits 101 and previously satisfied the non-success check, while now only death at the armed crash point passes.

## Testing

- `installed_objects_without_manifest_are_recovered_after_real_process_crash` exercises the changed path end to end and runs in CI's Check \& Test legs on this PR.