### PR TITLE
Let documentation-only diffs satisfy the heavy required checks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -145,6 +145,8 @@ jobs:
 
   windows-installer:
     name: Windows installer + vector-free release build
+    needs: changes
+    if: ${{ !cancelled() && needs.changes.outputs.docs_only != 'true' }}
     runs-on: windows-latest
     timeout-minutes: 60
     steps:
@@ -291,8 +293,50 @@ jobs:
           test -s .kin/kindb/head-generation
           test -s .kin/kindb/graph.kidx
 
+  # Classify the PR diff so documentation-only and workflow-only changes can
+  # satisfy the heavy required checks without a toolchain or registry
+  # dependency. Fail closed: any classifier failure or non-pull_request event
+  # reports docs_only=false and every gated job runs. ci.yml itself never
+  # qualifies for its own fast path.
+  changes:
+    name: Classify diff scope
+    runs-on: ubuntu-latest
+    outputs:
+      docs_only: ${{ steps.classify.outputs.docs_only }}
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          fetch-depth: 0
+      - name: Classify changed paths
+        id: classify
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+        run: |
+          set -euo pipefail
+          docs_only=false
+          if [ "$EVENT_NAME" = "pull_request" ]; then
+            changed="$(git diff --name-only "$BASE_SHA...$HEAD_SHA")"
+            if [ -n "$changed" ]; then
+              docs_only=true
+              while IFS= read -r path; do
+                case "$path" in
+                  .github/workflows/ci.yml) docs_only=false; break ;;
+                  *.md | docs/*) ;;
+                  .github/workflows/*) ;;
+                  *) docs_only=false; break ;;
+                esac
+              done <<< "$changed"
+            fi
+            printf '%s\n' "$changed"
+          fi
+          echo "docs_only=$docs_only" >> "$GITHUB_OUTPUT"
+
   check:
     name: Check & Test
+    needs: changes
+    if: ${{ !cancelled() && needs.changes.outputs.docs_only != 'true' }}
     runs-on: ${{ matrix.os }}
     timeout-minutes: 60
     # The all-features clippy/build/test sequence can otherwise retain more

--- a/.github/workflows/sast.yml
+++ b/.github/workflows/sast.yml
@@ -17,8 +17,49 @@ concurrency:
   cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
 
 jobs:
+  # Mirror of ci.yml's diff classifier: cargo-deny resolves the full
+  # dependency graph, which documentation-only and workflow-only changes
+  # cannot alter. Fail closed: any classifier failure or non-pull_request
+  # event reports docs_only=false and the gated job runs.
+  changes:
+    name: Classify diff scope
+    runs-on: ubuntu-latest
+    outputs:
+      docs_only: ${{ steps.classify.outputs.docs_only }}
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          fetch-depth: 0
+      - name: Classify changed paths
+        id: classify
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+        run: |
+          set -euo pipefail
+          docs_only=false
+          if [ "$EVENT_NAME" = "pull_request" ]; then
+            changed="$(git diff --name-only "$BASE_SHA...$HEAD_SHA")"
+            if [ -n "$changed" ]; then
+              docs_only=true
+              while IFS= read -r path; do
+                case "$path" in
+                  .github/workflows/ci.yml) docs_only=false; break ;;
+                  *.md | docs/*) ;;
+                  .github/workflows/*) ;;
+                  *) docs_only=false; break ;;
+                esac
+              done <<< "$changed"
+            fi
+            printf '%s\n' "$changed"
+          fi
+          echo "docs_only=$docs_only" >> "$GITHUB_OUTPUT"
+
   cargo-deny:
     name: cargo-deny
+    needs: changes
+    if: ${{ !cancelled() && needs.changes.outputs.docs_only != 'true' }}
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v7


### PR DESCRIPTION
## What

A `Classify diff scope` job in ci.yml and sast.yml reports `docs_only` when a pull request touches only markdown, `docs/`, and workflow files other than ci.yml. The three heavy required jobs (Check \& Test on both platforms, Windows installer + vector-free release build, cargo-deny) skip on that verdict; a job-level skip reports a skipped conclusion, which satisfies branch protection.

## Why

Those jobs all resolve the dependency graph, so during the registry outage a workflow-plus-docs PR (the outage's own fix, kin#429) could not go green and had to be merged through a documented branch-protection lift. With this classifier the same PR would have merged on green with no override, and routine docs changes stop paying for toolchain runs.

## Fail-closed properties

- Push and repository_dispatch events always classify as code.
- A classifier failure leaves `docs_only` unset and the gates use `!cancelled() && docs_only != 'true'`, so every heavy job runs.
- Any edit to ci.yml itself is classified as code (this PR runs full CI for that reason).
- gitleaks, DCO, npm launcher tests, and Windows authority tests are untouched and always run.

## Testing

- Workflow YAML parses; the embedded classifier passes `bash -n`; `scripts/test-release-workflow-authority.py` passes.
- Full CI runs on this PR (ci.yml edit). After merge I will falsify the fast path with a throwaway docs-only PR and confirm the skipped checks satisfy protection before relying on it.