### PR TITLE
Probe the documentation-only required-check fast path

### DIFF
--- a/crates/kin-registry/PUBLISHING.md
+++ b/crates/kin-registry/PUBLISHING.md
@@ -156,3 +156,5 @@ dispatch. It dry-runs by default and mutates only when dispatched with
 each unserveable record otherwise. Deployment promotions should gate on it
 immediately after deploy so a data precondition the serving code enforces
 can never sit undetected in front of clients.
+
+<!-- fast-path falsification probe -->


### PR DESCRIPTION
Throwaway falsification probe for the kin#433 diff classifier: a markdown-only diff should classify docs_only, skip the three heavy required checks as skipped-conclusion runs, and reach a mergeable state. Will be closed unmerged once the verdict is recorded.