### PR TITLE
Produce the per-platform required contexts on the docs-only fast path

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -333,6 +333,23 @@ jobs:
           fi
           echo "docs_only=$docs_only" >> "$GITHUB_OUTPUT"
 
+  # A skipped matrix job never expands, so the required per-platform contexts
+  # would go missing instead of reporting skipped. This stub carries the same
+  # display name and matrix as the real job and succeeds instantly on
+  # documentation-only diffs, producing the exact required context names. The
+  # two jobs' conditions are mutually exclusive.
+  check-docs-only:
+    name: Check & Test
+    needs: changes
+    if: ${{ !cancelled() && needs.changes.outputs.docs_only == 'true' }}
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        os: [ubuntu-latest, macos-latest]
+    steps:
+      - name: Report the documentation-only fast path
+        run: echo "documentation-only diff; build and test validation not applicable"
+
   check:
     name: Check & Test
     needs: changes


### PR DESCRIPTION
## What

Adds a `check-docs-only` stub job sharing the `Check & Test` display name and os matrix, running only when the diff classifier reports `docs_only`. It succeeds instantly on cheap runners, emitting real SUCCESS runs named exactly `Check & Test (ubuntu-latest)` and `Check & Test (macos-latest)`.

## Why

The kin#434 falsification probe showed the classifier and the non-matrix skips work (cargo-deny and the Windows installer report skipped under their exact required names and satisfy protection), but a skipped matrix job never expands, so the two per-platform required contexts went missing entirely and the probe stayed BLOCKED.

## Testing

- Workflow YAML parses; the authority test passes.
- Full CI runs on this PR (ci.yml edit is always classified as code).
- After merge, the open probe kin#434 gets rebased to re-run the fast path end to end; expected verdict is CLEAN with both stub contexts SUCCESS, then the probe closes unmerged.