### PR TITLE
Gate the automatic locate fan-out on score composition, not ratio alone

### DIFF
--- a/crates/kin-cli/src/commands/locate.rs
+++ b/crates/kin-cli/src/commands/locate.rs
@@ -77,6 +77,22 @@ pub struct LocateResult {
     /// Empty for a single-query locate, so single-query output is byte-identical.
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub queries: Vec<String>,
+    /// How the ranked `files` scores were composed: direct entity-resolve
+    /// ordering keeps (normalized, boosted) raw match scores, while every
+    /// other track RRF-composes rank reciprocals. Top1/top2 separation is a
+    /// sound confidence signal only for RRF-composed rankings, so the
+    /// automatic fan-out gate always fuses direct-ordered primaries. Runtime
+    /// only; never serialized.
+    #[serde(skip)]
+    pub score_composition: Option<ScoreComposition>,
+}
+
+/// Score-composition regime of a locate ranking (see
+/// [`LocateResult::score_composition`]).
+#[derive(Clone, Copy, Debug, PartialEq)]
+pub enum ScoreComposition {
+    DirectEntityOrdered,
+    RrfComposed,
 }
 
 /// One retrieval capability that did not fully run for a query, with the
@@ -2074,6 +2090,7 @@ pub fn run_with_graph_capture_with_priority_files_and_vector_source(
     // floors/adaptive_cap) below runs unchanged. When unset, the original
     // track-regime path fusion runs verbatim — see the flip-plan in
     // crates/kin-cli/docs/locate-entity-fusion-flip-plan.md for scope and A/B.
+    let mut direct_entity_ordered = false;
     let mut fused = if locate_env_bool("KIN_LOCATE_ENTITY_FUSION", quality.entity_fusion_default())
     {
         entity_granular_fused_files(
@@ -2143,6 +2160,7 @@ pub fn run_with_graph_capture_with_priority_files_and_vector_source(
                     // Rich entity results — trust entity_resolve ordering directly.
                     // Normalize scores to a bounded range and supplement with other
                     // signals for files entity_resolve didn't find.
+                    direct_entity_ordered = true;
                     let resolve_list = &ranked_lists[7];
                     let mut result: Vec<(String, f32)> = Vec::new();
                     let resolve_set: HashSet<String> =
@@ -3506,6 +3524,11 @@ pub fn run_with_graph_capture_with_priority_files_and_vector_source(
         explain,
     )
     .with_semantic_coverage(semantic_coverage);
+    result.score_composition = Some(if direct_entity_ordered {
+        ScoreComposition::DirectEntityOrdered
+    } else {
+        ScoreComposition::RrfComposed
+    });
     // No-silent-degradation contract: every capability that could not fully
     // run for this query rides on the result AND hits the daemon log at WARN.
     for degradation in &degradations {
@@ -7079,6 +7102,20 @@ pub fn auto_fanout_should_fuse(separation: Option<f32>) -> bool {
         Some(s) => s < ratio,
         None => true,
     }
+}
+
+/// Fan-out decision for the automatic sharp variant given the primary
+/// result. Direct-entity-ordered rankings always fuse: their top1/top2
+/// separation measures lexical concentration on the dominant name match,
+/// not answer confidence, so a wrong-file concentration reads as confident
+/// (raw resolve scale ~100 boosted, vs RRF's ~1.0). RRF-composed rankings
+/// keep the separation gate. Unknown composition (the budget-exhausted
+/// fallback path) also falls back to the separation gate.
+pub fn auto_fanout_should_fuse_for(result: &LocateResult) -> bool {
+    if result.score_composition == Some(ScoreComposition::DirectEntityOrdered) {
+        return true;
+    }
+    auto_fanout_should_fuse(locate_confidence_separation(result))
 }
 
 fn preserved_query_identifiers(text: &str) -> Vec<String> {
@@ -15364,6 +15401,7 @@ pub fn fuse_locate_results(
         semantic_coverage: primary.semantic_coverage,
         degradations,
         queries: variants,
+        score_composition: None,
     }
 }
 
@@ -19846,6 +19884,35 @@ mod tests {
         assert!(
             auto_fanout_should_fuse(weak),
             "weak separation must fuse: {weak:?}"
+        );
+    }
+
+    #[test]
+    fn fanout_gate_always_fuses_direct_entity_ordered_rankings() {
+        let entry = |path: &str, score: f32| -> LocateFileEntry {
+            serde_json::from_value(serde_json::json!({ "path": path, "score": score }))
+                .expect("minimal file entry deserializes")
+        };
+        let mut result = LocateResult::default();
+        result.files = vec![entry("a.go", 190.0), entry("b.go", 25.8)];
+        assert!(
+            !auto_fanout_should_fuse(locate_confidence_separation(&result)),
+            "the ratio alone reads this ranking as confident"
+        );
+        result.score_composition = Some(ScoreComposition::DirectEntityOrdered);
+        assert!(
+            auto_fanout_should_fuse_for(&result),
+            "direct-ordered rankings must fuse regardless of separation"
+        );
+        result.score_composition = Some(ScoreComposition::RrfComposed);
+        assert!(
+            !auto_fanout_should_fuse_for(&result),
+            "RRF-composed rankings keep the separation gate"
+        );
+        result.score_composition = None;
+        assert!(
+            !auto_fanout_should_fuse_for(&result),
+            "unknown composition falls back to the separation gate"
         );
     }
 

--- a/crates/kin-daemon/src/api.rs
+++ b/crates/kin-daemon/src/api.rs
@@ -4287,6 +4287,7 @@ async fn locate(
                 &head,
                 reference,
                 &variants,
+                auto_fanout,
                 req.explain,
                 req.max_files,
                 req.max_files_explicit,
@@ -4525,14 +4526,14 @@ async fn run_multiquery_fused_locate(
             )
             .await?,
         );
-        // The automatic sharp variant fuses only when the primary is unsure:
-        // a confidently separated single-query ranking returns untouched and
-        // the second retrieval never runs. Caller-supplied variants keep
+        // The automatic sharp variant fuses only when the primary is unsure.
+        // Direct-entity-ordered rankings always fuse (their top1/top2 gap
+        // measures lexical concentration, not confidence); RRF-composed
+        // rankings skip fusion when confidently separated, and the second
+        // retrieval never runs on a skip. Caller-supplied variants keep
         // unconditional fusion semantics.
         if index == 0 && auto_fanout {
-            let separation =
-                kin_cli::commands::locate::locate_confidence_separation(&per_variant[0]);
-            if !kin_cli::commands::locate::auto_fanout_should_fuse(separation) {
+            if !kin_cli::commands::locate::auto_fanout_should_fuse_for(&per_variant[0]) {
                 return Ok(per_variant.pop().expect("primary result present"));
             }
         }
@@ -4554,13 +4555,14 @@ fn run_multiquery_locate_at_ref(
     head: &kin_model::SemanticChangeId,
     reference: &str,
     variants: &[String],
+    auto_fanout: bool,
     explain: bool,
     max_files: usize,
     max_files_explicit: bool,
     snippet_opts: kin_cli::commands::locate::SnippetOptions,
 ) -> Result<kin_cli::commands::locate::LocateResult, String> {
     let mut per_variant = Vec::with_capacity(variants.len());
-    for variant in variants {
+    for (index, variant) in variants.iter().enumerate() {
         per_variant.push(
             kin_cli::commands::locate::run_with_graph_capture_at_ref(
                 &state.layout,
@@ -4576,6 +4578,15 @@ fn run_multiquery_locate_at_ref(
             )
             .map_err(|error| error.to_string())?,
         );
+        // Same confidence gate as the daemon-state path: the automatic sharp
+        // variant only fuses an unsure primary; caller-supplied variants keep
+        // unconditional fusion semantics.
+        if index == 0
+            && auto_fanout
+            && !kin_cli::commands::locate::auto_fanout_should_fuse_for(&per_variant[0])
+        {
+            return Ok(per_variant.pop().expect("primary result present"));
+        }
     }
     Ok(kin_cli::commands::locate::fuse_locate_results(
         variants.to_vec(),


### PR DESCRIPTION
## Problem

The confidence gate shipped with the automatic identifier fan-out reads top1/top2 score separation, and its one documented miss was a ranking that is confidently *wrong*: a dominant name match concentrated on a wrong file at separation 7.36 skipped fusion, while a genuinely confident ranking sat at 1.60. No ratio threshold orders those two correctly, because the two numbers come from different scoring regimes.

## Mechanism

Locate's fusion has two score-composition regimes. The EntityDominant rich-results branch trusts entity-resolve ordering directly: scores are raw resolve-scale (normalized to ~100, then post-fusion boosts push them higher), so top1/top2 separation there measures lexical concentration on the dominant name match, not answer confidence. Every other track RRF-composes rank reciprocals (scores ~0.1-1.0), where separation is a real cross-signal consensus measure. The ratio was sound on one regime and spurious on the other.

## Change

- `LocateResult` records its `score_composition` (`DirectEntityOrdered` vs `RrfComposed`), set at the fusion branch that produced the ranking. Runtime-only field, `#[serde(skip)]`: no wire or output change anywhere.
- The automatic sharp-variant gate (`auto_fanout_should_fuse_for`) always fuses direct-entity-ordered primaries and keeps the separation gate (`KIN_LOCATE_AUTO_FANOUT_CONFIDENCE_RATIO`, default 1.5) for RRF-composed rankings. Unknown composition (the budget-exhausted fallback path) also falls back to the separation gate.
- The at-ref multi-query path gains the same gate instead of fusing the automatic variant unconditionally.
- No new environment variables; caller-supplied variants keep unconditional fusion semantics.

## Measurement

Same deterministic paired harness as the parent change (8-task diagnostic cohort, 47 gold files, one graph per task, compat-v0, cold caches, daemon path; n=1 per arm, dev binaries, not a benchmark claim). Baseline arms reproduced byte-identically across runs, so the new field does not perturb the single-query path.

| arm | gold in top-10 (/47) | tasks with a top-10 gold |
|---|---|---|
| pre-fix (broken term gate) | 13 | 5/8 |
| healed gate only | 11 | 5/8 |
| healed + unconditional fan-out | 12 | 6/8 |
| healed + ratio-only gate (parent change) | 12 | 6/8 |
| healed + composition-aware gate (this PR) | 13 | 7/8 |

Movements versus gate-only under the shipped form:

- cli/cli (direct-ordered, the previously documented miss): now fuses; `config_file.go` 20 -> 9, recovering the task from hitless.
- serverless/serverless (RRF, separation 1.60): fusion skipped; `monitorStack.js` stays at rank 1.
- sveltejs/svelte (direct-ordered): recovery kept; `Stylesheet.ts` unranked -> 3.
- clap-rs/clap (RRF, separation 1.30): fuses as before; `styled_str.rs` 11 -> 3, `04_new_help.rs` 5 -> 14, count unchanged.
- langchain-ai/langchain (direct-ordered): fuses; `agent.py` 12 -> 9, `schema.py` 9 -> 4, `output_parser.py` 4 -> 2, `prompt.py` 3 -> 11; count unchanged at 4.
- future-architect/vuls (direct-ordered): fuses; top-3 shuffle only (`debian.go` 2 -> 3, `packages.go` 3 -> 2), count unchanged.

## Tests

- `fanout_gate_always_fuses_direct_entity_ordered_rankings`: a 190/25.8 ranking must fuse when direct-ordered, must not when RRF-composed, and unknown composition falls back to the separation gate.
- Existing separation-gate and sharp-variant tests unchanged and green.
- Suites: kin-daemon lib 452/452; kin-cli lib 1140 pass with only the pre-existing host-state failures (setup/update MCP-config tests), fail-identical on a clean tree, tracked separately. fmt clean.
