### PR TITLE
Hold the automatic fan-out's fused declaration to the primary budget

### DIFF
--- a/crates/kin-cli/src/commands/locate.rs
+++ b/crates/kin-cli/src/commands/locate.rs
@@ -15405,6 +15405,18 @@ pub fn fuse_locate_results(
     }
 }
 
+/// Bound a fused locate declaration to the primary variant's budget: the
+/// automatic sharp variant may reorder and substitute files within the
+/// declaration the single query earned, but must not widen it (fusion width
+/// is what turns recall gains into precision losses on list-scored
+/// surfaces). Entities and attribution are untouched; only the declared
+/// file list truncates. No-op when the fused list already fits.
+pub fn bound_fused_declaration_to_primary(result: &mut LocateResult, primary_declared: usize) {
+    if result.files.len() > primary_declared {
+        result.files.truncate(primary_declared);
+    }
+}
+
 fn build_result(
     results: &[(String, f32)],
     all_hits: &[HashMap<String, Vec<FileHit>>],
@@ -15854,6 +15866,37 @@ mod tests {
         assert_eq!(e2.matched_queries, vec!["identifier query".to_string()]);
         let e3 = fused.entities.iter().find(|e| e.entity_id == "e3").unwrap();
         assert_eq!(e3.matched_queries, vec!["behavior query".to_string()]);
+    }
+
+    #[test]
+    fn bound_fused_declaration_keeps_primary_budget_and_order() {
+        let entry = |path: &str, score: f32| -> LocateFileEntry {
+            serde_json::from_value(serde_json::json!({ "path": path, "score": score }))
+                .expect("minimal file entry deserializes")
+        };
+        let mut v0 = LocateResult::default();
+        v0.files = vec![entry("a.go", 3.0), entry("b.go", 2.0), entry("c.go", 1.0)];
+        let mut v1 = LocateResult::default();
+        v1.files = vec![entry("c.go", 9.0), entry("d.go", 8.0), entry("e.go", 7.0)];
+        let variants = vec!["broad".to_string(), "sharp".to_string()];
+        let mut fused = fuse_locate_results(variants, vec![v0, v1], 60.0);
+        assert_eq!(fused.files.len(), 5, "union widens before the bound");
+        assert_eq!(
+            fused.files[0].path, "c.go",
+            "corroborated file fuses to the top"
+        );
+        bound_fused_declaration_to_primary(&mut fused, 3);
+        assert_eq!(
+            fused.files.len(),
+            3,
+            "auto fusion must not widen the declaration"
+        );
+        assert_eq!(
+            fused.files[0].path, "c.go",
+            "bounded list keeps the fused order"
+        );
+        bound_fused_declaration_to_primary(&mut fused, 10);
+        assert_eq!(fused.files.len(), 3, "larger budget is a no-op");
     }
 
     #[test]

--- a/crates/kin-daemon/src/api.rs
+++ b/crates/kin-daemon/src/api.rs
@@ -4562,11 +4562,22 @@ async fn run_multiquery_fused_locate(
             }
         }
     }
-    Ok(kin_cli::commands::locate::fuse_locate_results(
+    let primary_declared = per_variant
+        .first()
+        .map(|result| result.files.len())
+        .unwrap_or(0);
+    let mut fused = kin_cli::commands::locate::fuse_locate_results(
         variants.to_vec(),
         per_variant,
         kin_cli::commands::locate::locate_rrf_k(),
-    ))
+    );
+    // The automatic sharp variant reorders within the declaration budget the
+    // primary earned; it must not widen it. Caller-supplied fusion keeps its
+    // union width.
+    if auto_fanout {
+        kin_cli::commands::locate::bound_fused_declaration_to_primary(&mut fused, primary_declared);
+    }
+    Ok(fused)
 }
 
 /// Fan out a multi-query locate at an explicit ref: retrieve each variant against
@@ -4612,11 +4623,22 @@ fn run_multiquery_locate_at_ref(
             return Ok(per_variant.pop().expect("primary result present"));
         }
     }
-    Ok(kin_cli::commands::locate::fuse_locate_results(
+    let primary_declared = per_variant
+        .first()
+        .map(|result| result.files.len())
+        .unwrap_or(0);
+    let mut fused = kin_cli::commands::locate::fuse_locate_results(
         variants.to_vec(),
         per_variant,
         kin_cli::commands::locate::locate_rrf_k(),
-    ))
+    );
+    // The automatic sharp variant reorders within the declaration budget the
+    // primary earned; it must not widen it. Caller-supplied fusion keeps its
+    // union width.
+    if auto_fanout {
+        kin_cli::commands::locate::bound_fused_declaration_to_primary(&mut fused, primary_declared);
+    }
+    Ok(fused)
 }
 
 /// Insert a full locate ranking into the paging cache, evicting the oldest entry


### PR DESCRIPTION
## Problem

The automatic sharp-variant fan-out unions two adaptive-capped declared lists, so fusion widened the declaration itself: on the 26-task Go diagnostic suite the mean declared list grew from 9.8 to 14.4 files. The union finds more gold (22 to 28 in-list, recall 0.3635 to 0.4449, two previously hitless tasks recovered) but the width converts that into a list-precision loss (F1 0.1378 to 0.1274) on list-scored surfaces, even though the fused ranking is precision-dense (24 of its 28 golds sit in the top 10).

## Change

The fused declaration now stays inside the budget the primary query earned: `bound_fused_declaration_to_primary` truncates the fused file list to the primary variant's declared length on the automatic fan-out path (both daemon-state and at-ref multi-query paths). The automatic variant reorders and substitutes files within that width but cannot widen it; the confidence gate still skips the second retrieval entirely on a confidently separated RRF primary. Caller-supplied multi-query fusion keeps its union width unchanged. Entities and per-hit attribution are untouched. No new environment variables.

## Measurement

Same deterministic harness family as the two parent changes (sha-pinned clean binaries, one graph per task, compat-v0, cold caches, daemon path; n=1 per arm, not a benchmark claim).

26-task Go suite, list-scored:

| arm | P | R | F1 | hit-tasks | declared mean |
|---|---|---|---|---|---|
| pre-lever base | 0.0901 | 0.3635 | 0.1378 | 17/26 | 9.8 |
| fan-out unbounded (current main) | 0.0796 | 0.4449 | 0.1274 | 19/26 | 14.4 |
| fan-out bounded (this PR) | 0.0978 | 0.3968 | 0.1467 | 18/26 | 9.8 |
| lexical baseline (reference) | 0.1000 | 0.4821 | 0.1563 | 21/26 | n/a |

Paired per-task F1: 10 wins / 3 losses / 13 ties versus unbounded fusion; 4 wins / 2 losses / 20 ties versus the pre-lever base. The bound holds the declared budget exactly (9.8 mean, matching the pre-lever sizing) while keeping most of the union's recall gain (+0.033 vs base) and one of the two task recoveries; the other recovery's gold sits past its task's primary budget and drops, the accepted cost of the bound.

This lands the best kin arm yet measured on the honest graph but remains below the lexical reference (0.1467 vs 0.1563). Truncation analysis of the fused rankings shows the remaining distance lives in cutoff sizing tighter than the earned budget (top-6 truncation of the same outputs scores 0.1781, top-8 scores 0.1680, both in-sample); that is declaration-cutoff sizing on the shared cap logic, a separate lever with a wider blast radius, deliberately not bundled here.

8-task mixed-language control (rank-scored, explicit `--max-files 50`): gold-in-top-10 unchanged at 13/47 and every prior protection holds; the only deltas are four deep-tail golds (former ranks 22-43) now past their primary budgets, invisible to the top-10 metric.

## Tests

- `bound_fused_declaration_keeps_primary_budget_and_order`: the union widens to 5 before the bound, truncates to the primary's 3 with fused order preserved (corroborated file stays on top), and a larger budget is a no-op.
- Existing fusion, gate, and sharp-variant tests unchanged and green.
- Suites: kin-daemon lib 452/452; kin-cli lib 1142 pass with only the four pre-existing host-state failures (setup/update MCP-config tests, fail-identical on a clean tree, tracked separately). fmt clean.
