### PR TITLE
Hold adaptively sized fused declarations to the confident prefix

### DIFF
--- a/crates/kin-cli/src/commands/locate.rs
+++ b/crates/kin-cli/src/commands/locate.rs
@@ -15409,11 +15409,24 @@ pub fn fuse_locate_results(
 /// automatic sharp variant may reorder and substitute files within the
 /// declaration the single query earned, but must not widen it (fusion width
 /// is what turns recall gains into precision losses on list-scored
-/// surfaces). Entities and attribution are untouched; only the declared
-/// file list truncates. No-op when the fused list already fits.
-pub fn bound_fused_declaration_to_primary(result: &mut LocateResult, primary_declared: usize) {
-    if result.files.len() > primary_declared {
-        result.files.truncate(primary_declared);
+/// surfaces). When the declaration was adaptively sized (no explicit
+/// max-files from the caller), the fused list additionally holds to the
+/// confident prefix, KIN_LOCATE_FUSED_DECLARATION_CAP entries (default 8):
+/// fused rankings concentrate their precision in the leading entries, and
+/// width past that prefix converts recall into list-precision loss. An
+/// explicit caller width is honored as-is. Entities and attribution are
+/// untouched; only the declared file list truncates.
+pub fn bound_fused_declaration_to_primary(
+    result: &mut LocateResult,
+    primary_declared: usize,
+    adaptive_declaration: bool,
+) {
+    let mut budget = primary_declared;
+    if adaptive_declaration {
+        budget = budget.min(locate_env_usize("KIN_LOCATE_FUSED_DECLARATION_CAP", 8));
+    }
+    if result.files.len() > budget {
+        result.files.truncate(budget);
     }
 }
 
@@ -15885,7 +15898,7 @@ mod tests {
             fused.files[0].path, "c.go",
             "corroborated file fuses to the top"
         );
-        bound_fused_declaration_to_primary(&mut fused, 3);
+        bound_fused_declaration_to_primary(&mut fused, 3, false);
         assert_eq!(
             fused.files.len(),
             3,
@@ -15895,8 +15908,44 @@ mod tests {
             fused.files[0].path, "c.go",
             "bounded list keeps the fused order"
         );
-        bound_fused_declaration_to_primary(&mut fused, 10);
+        bound_fused_declaration_to_primary(&mut fused, 10, false);
         assert_eq!(fused.files.len(), 3, "larger budget is a no-op");
+    }
+
+    #[test]
+    fn fused_declaration_confident_prefix_caps_adaptive_widths_only() {
+        let entry = |path: &str, score: f32| -> LocateFileEntry {
+            serde_json::from_value(serde_json::json!({ "path": path, "score": score }))
+                .expect("minimal file entry deserializes")
+        };
+        let wide = |n: usize| -> LocateResult {
+            let mut result = LocateResult::default();
+            result.files = (0..n)
+                .map(|i| entry(&format!("f{i}.go"), (n - i) as f32))
+                .collect();
+            result
+        };
+        let mut adaptive = wide(12);
+        bound_fused_declaration_to_primary(&mut adaptive, 12, true);
+        assert_eq!(
+            adaptive.files.len(),
+            8,
+            "adaptive declarations hold to the confident prefix"
+        );
+        let mut explicit = wide(12);
+        bound_fused_declaration_to_primary(&mut explicit, 12, false);
+        assert_eq!(
+            explicit.files.len(),
+            12,
+            "explicit caller widths are honored as-is"
+        );
+        let mut narrow = wide(4);
+        bound_fused_declaration_to_primary(&mut narrow, 4, true);
+        assert_eq!(
+            narrow.files.len(),
+            4,
+            "the prefix cap never widens a narrow budget"
+        );
     }
 
     #[test]

--- a/crates/kin-core/src/env_registry_generated.rs
+++ b/crates/kin-core/src/env_registry_generated.rs
@@ -99,6 +99,7 @@ pub const GENERATED_KNOBS: &[EnvVarSpec] = &[
     EnvVarSpec { name: "KIN_LOCATE_FLOOR_PRECOMP", kind: Kind::Bool, default: "true", sensitivity: Sensitivity::Correctness, summary: "locate tuning knob: floor precomp" },
     EnvVarSpec { name: "KIN_LOCATE_FORCE_LOCAL", kind: Kind::Bool, default: "false", sensitivity: Sensitivity::Correctness, summary: "locate tuning knob: force local" },
     EnvVarSpec { name: "KIN_LOCATE_FRAMEWORK_NOISE_PENALTY", kind: Kind::NonNegF32, default: "0.03", sensitivity: Sensitivity::Correctness, summary: "locate tuning knob: framework noise penalty" },
+    EnvVarSpec { name: "KIN_LOCATE_FUSED_DECLARATION_CAP", kind: Kind::Usize, default: "8", sensitivity: Sensitivity::Correctness, summary: "locate tuning knob: fused declaration cap" },
     EnvVarSpec { name: "KIN_LOCATE_GRAPH_BLEND", kind: Kind::NonNegF32, default: "0.10", sensitivity: Sensitivity::Correctness, summary: "locate tuning knob: graph blend" },
     EnvVarSpec { name: "KIN_LOCATE_GRAPH_NAME_MATCH_LIMIT", kind: Kind::Usize, default: "16", sensitivity: Sensitivity::Correctness, summary: "locate tuning knob: graph name match limit" },
     EnvVarSpec { name: "KIN_LOCATE_GRAPH_ONLY_PROJECTION_FLOOR", kind: Kind::NonNegF32, default: "0.25", sensitivity: Sensitivity::Correctness, summary: "locate tuning knob: graph only projection floor" },

--- a/crates/kin-daemon/src/api.rs
+++ b/crates/kin-daemon/src/api.rs
@@ -4575,7 +4575,11 @@ async fn run_multiquery_fused_locate(
     // primary earned; it must not widen it. Caller-supplied fusion keeps its
     // union width.
     if auto_fanout {
-        kin_cli::commands::locate::bound_fused_declaration_to_primary(&mut fused, primary_declared);
+        kin_cli::commands::locate::bound_fused_declaration_to_primary(
+            &mut fused,
+            primary_declared,
+            !max_files_explicit,
+        );
     }
     Ok(fused)
 }
@@ -4636,7 +4640,11 @@ fn run_multiquery_locate_at_ref(
     // primary earned; it must not widen it. Caller-supplied fusion keeps its
     // union width.
     if auto_fanout {
-        kin_cli::commands::locate::bound_fused_declaration_to_primary(&mut fused, primary_declared);
+        kin_cli::commands::locate::bound_fused_declaration_to_primary(
+            &mut fused,
+            primary_declared,
+            !max_files_explicit,
+        );
     }
     Ok(fused)
 }

--- a/docs/env-vars.md
+++ b/docs/env-vars.md
@@ -3,7 +3,7 @@
 
 # Kin environment variables
 
-This is the authoritative list of supported `KIN_*` environment variables (408 total, 304 correctness-relevant), generated from the central registry in `kin-core`.
+This is the authoritative list of supported `KIN_*` environment variables (409 total, 305 correctness-relevant), generated from the central registry in `kin-core`.
 
 At CLI and daemon startup Kin validates this surface (`KIN_ENV_VALIDATION`, default `warn`):
 
@@ -302,6 +302,7 @@ Sensitivity legend: **correctness** (affects retrieval/ranking/output or data sa
 | `KIN_LOCATE_FLOOR_PRECOMP` | bool | true | correctness | locate tuning knob: floor precomp |
 | `KIN_LOCATE_FORCE_LOCAL` | bool | false | correctness | locate tuning knob: force local |
 | `KIN_LOCATE_FRAMEWORK_NOISE_PENALTY` | float>=0 | 0.03 | correctness | locate tuning knob: framework noise penalty |
+| `KIN_LOCATE_FUSED_DECLARATION_CAP` | usize | 8 | correctness | locate tuning knob: fused declaration cap |
 | `KIN_LOCATE_GRAPH_BLEND` | float>=0 | 0.10 | correctness | locate tuning knob: graph blend |
 | `KIN_LOCATE_GRAPH_NAME_MATCH_LIMIT` | usize | 16 | correctness | locate tuning knob: graph name match limit |
 | `KIN_LOCATE_GRAPH_ONLY_PROJECTION_FLOOR` | float>=0 | 0.25 | correctness | locate tuning knob: graph only projection floor |


### PR DESCRIPTION
## Problem

Holding the auto-fused declaration to the primary's earned budget (parent change) repaired the width regression but left list precision short: fused rankings concentrate their precision in the leading entries, and the earned budget (mean 9.8 files) still spends its tail slots on singletons that dilute precision without adding hit-tasks. Truncation analysis of the parent arm's own outputs showed a stable plateau: cutting fused declarations at 5-8 entries clears the lexical reference, with the cliff at 9, and 7-8 keep every hit-task.

## Change

Adaptively sized declarations (no explicit max-files from the caller) now hold the fused list to the confident prefix: `KIN_LOCATE_FUSED_DECLARATION_CAP` entries (default 8, the conservative edge of the measured plateau) inside the primary budget. Explicit caller widths are honored as-is, so agent-requested limits and harnesses that ask for wide lists are untouched. Applies to the automatic fan-out path only; caller-supplied multi-query fusion keeps its union width. The knob is registry-extracted with the standard doc regeneration.

Corroboration-only and score-knee cutoff rules were evaluated first and rejected by the same offline analysis: both destroy hit-tasks whose only gold is a singleton (14-16 hit-tasks vs 18).

## Measurement

Same deterministic harness family (sha-pinned clean binary, one graph per task, compat-v0, cold caches, daemon path; n=1 per arm, not a benchmark claim). The offline truncation model predicted this arm at F1 0.1636 with 18 hit-tasks; the live rung measured exactly that.

26-task Go suite, list-scored:

| arm | P | R | F1 | hit-tasks | declared mean |
|---|---|---|---|---|---|
| pre-lever base | 0.0901 | 0.3635 | 0.1378 | 17/26 | 9.8 |
| budget-hold (parent, current main) | 0.0978 | 0.3968 | 0.1467 | 18/26 | 9.8 |
| confident-prefix (this PR) | 0.1116 | 0.3968 | 0.1636 | 18/26 | 8.5 |
| lexical baseline (reference) | 0.1000 | 0.4821 | 0.1563 | 21/26 | n/a |

Paired per-task F1: 11 wins / 0 losses / 15 ties versus the parent arm (recall untouched, precision only); 12 wins / 2 losses / 12 ties versus the pre-lever base. First arm above the lexical reference on the honest graph, on both F1 and precision.

8-task mixed-language control (rank-scored, explicit `--max-files 50`): zero gold-rank deltas versus the parent arm, as required, since the cap never applies to explicit widths.

## Tests

- `fused_declaration_confident_prefix_caps_adaptive_widths_only`: a 12-wide adaptive fused declaration holds to 8, the same list under an explicit width stays 12, and a narrow budget is never widened.
- `bound_fused_declaration_keeps_primary_budget_and_order` updated for the explicit/adaptive distinction; fusion, gate, and sharp-variant tests unchanged and green.
- Suites: kin-daemon lib 452/452; kin-core env-registry 25/25 (knob extracted, docs regenerated); kin-cli lib 1141 pass with only pre-existing host-state failures (setup/update/with MCP-config family, fail-identical on a clean tree, tracked separately). fmt clean.
