### PR TITLE
Bump version to 0.3.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,38 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.3.5] - 2026-07-26
+
+### Fixed
+
+- Locate's term-support gate no longer rejects bare method identifiers:
+  qualified names (`Type.method`) match through suffix passes, source support
+  is judged by the entity's own role rather than a directory-name allowlist,
+  and root-level `vendor/` trees are excluded like interior ones. Queries that
+  previously collapsed to generic prose terms keep their identifiers.
+- Opening a projection waits out a live exact-source projection holder under a
+  bounded deadline instead of failing on contention, and names the holder on
+  timeout.
+- Unserveable legacy registry index records are repaired at daemon startup, and
+  host assessment load is surfaced.
+
+### Added
+
+- Single locate queries carrying identifier-shaped tokens fan out automatically
+  into the broad and identifier-distilled variants, fused only when the primary
+  ranking is unsure: direct entity-ordered rankings always fuse, RRF-composed
+  rankings gate on top1/top2 separation
+  (`KIN_LOCATE_AUTO_FANOUT_CONFIDENCE_RATIO`, default 1.5).
+  `KIN_LOCATE_AUTO_QUERY_FANOUT=0` disables the automatic variant.
+- Explain output records per-identifier `query_identifier_gate` verdicts.
+
+### Changed
+
+- Automatically fused declarations stay within the primary query's declared
+  budget and, for adaptively sized declarations, within the confident prefix
+  (`KIN_LOCATE_FUSED_DECLARATION_CAP`, default 8). Explicit `--max-files`
+  widths are honored as-is.
+
 ## [0.3.4] - 2026-07-24
 
 ### Fixed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3044,14 +3044,14 @@ dependencies = [
 
 [[package]]
 name = "kin-buildinfo"
-version = "0.3.4"
+version = "0.3.5"
 dependencies = [
  "sha2 0.11.0",
 ]
 
 [[package]]
 name = "kin-cli"
-version = "0.3.4"
+version = "0.3.5"
 dependencies = [
  "age",
  "anyhow",
@@ -3125,7 +3125,7 @@ dependencies = [
 
 [[package]]
 name = "kin-context"
-version = "0.3.4"
+version = "0.3.5"
 dependencies = [
  "kin-blobs",
  "kin-db",
@@ -3141,7 +3141,7 @@ dependencies = [
 
 [[package]]
 name = "kin-core"
-version = "0.3.4"
+version = "0.3.5"
 dependencies = [
  "cap-fs-ext",
  "cap-std",
@@ -3171,7 +3171,7 @@ dependencies = [
 
 [[package]]
 name = "kin-daemon"
-version = "0.3.4"
+version = "0.3.5"
 dependencies = [
  "async-stream",
  "axum",
@@ -3264,7 +3264,7 @@ dependencies = [
 
 [[package]]
 name = "kin-git"
-version = "0.3.4"
+version = "0.3.5"
 dependencies = [
  "chrono",
  "gix",
@@ -3282,7 +3282,7 @@ dependencies = [
 
 [[package]]
 name = "kin-index"
-version = "0.3.4"
+version = "0.3.5"
 dependencies = [
  "hex",
  "kin-blobs",
@@ -3330,7 +3330,7 @@ dependencies = [
 
 [[package]]
 name = "kin-integration-tests"
-version = "0.3.4"
+version = "0.3.5"
 dependencies = [
  "kin-blobs",
  "kin-cli",
@@ -3372,7 +3372,7 @@ dependencies = [
 
 [[package]]
 name = "kin-mcp"
-version = "0.3.4"
+version = "0.3.5"
 dependencies = [
  "kin-blobs",
  "kin-context",
@@ -3399,7 +3399,7 @@ dependencies = [
 
 [[package]]
 name = "kin-migrate"
-version = "0.3.4"
+version = "0.3.5"
 dependencies = [
  "chrono",
  "kin-blobs",
@@ -3441,7 +3441,7 @@ dependencies = [
 
 [[package]]
 name = "kin-parser"
-version = "0.3.4"
+version = "0.3.5"
 dependencies = [
  "kin-model",
  "pretty_assertions",
@@ -3471,7 +3471,7 @@ dependencies = [
 
 [[package]]
 name = "kin-projection"
-version = "0.3.4"
+version = "0.3.5"
 dependencies = [
  "kin-blobs",
  "kin-db",
@@ -3486,7 +3486,7 @@ dependencies = [
 
 [[package]]
 name = "kin-ranking"
-version = "0.3.4"
+version = "0.3.5"
 dependencies = [
  "kin-model",
  "serde",
@@ -3495,7 +3495,7 @@ dependencies = [
 
 [[package]]
 name = "kin-reconcile"
-version = "0.3.4"
+version = "0.3.5"
 dependencies = [
  "kin-blobs",
  "kin-db",
@@ -3515,7 +3515,7 @@ dependencies = [
 
 [[package]]
 name = "kin-registry"
-version = "0.3.4"
+version = "0.3.5"
 dependencies = [
  "async-stream",
  "axum",
@@ -3548,7 +3548,7 @@ dependencies = [
 
 [[package]]
 name = "kin-remote"
-version = "0.3.4"
+version = "0.3.5"
 dependencies = [
  "chrono",
  "kin-model",
@@ -3564,7 +3564,7 @@ dependencies = [
 
 [[package]]
 name = "kin-review"
-version = "0.3.4"
+version = "0.3.5"
 dependencies = [
  "kin-blobs",
  "kin-db",
@@ -3580,7 +3580,7 @@ dependencies = [
 
 [[package]]
 name = "kin-runtime"
-version = "0.3.4"
+version = "0.3.5"
 dependencies = [
  "chrono",
  "hex",
@@ -3612,7 +3612,7 @@ dependencies = [
 
 [[package]]
 name = "kin-semantic-contracts"
-version = "0.3.4"
+version = "0.3.5"
 dependencies = [
  "kin-db",
  "kin-model",
@@ -3627,7 +3627,7 @@ dependencies = [
 
 [[package]]
 name = "kin-spine"
-version = "0.3.4"
+version = "0.3.5"
 dependencies = [
  "chrono",
  "hashbrown 0.15.5",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,7 +27,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.3.4"
+version = "0.3.5"
 edition = "2021"
 license = "Apache-2.0"
 authors = ["Troy Fortin <troy@firelock.ai>"]

--- a/crates/kin-cli/Cargo.toml
+++ b/crates/kin-cli/Cargo.toml
@@ -86,7 +86,7 @@ toml = { workspace = true }
 toml_edit = "0.25"
 tempfile = { workspace = true }
 unicode-normalization = "0.1"
-kin-spine = { version = "0.3.4", path = "../kin-spine" }
+kin-spine = { version = "0.3.5", path = "../kin-spine" }
 
 [dev-dependencies]
 pretty_assertions = { workspace = true }

--- a/packages/boundary-contracts/package.json
+++ b/packages/boundary-contracts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kin/boundary-contracts",
-  "version": "0.3.4",
+  "version": "0.3.5",
   "private": false,
   "description": "Shared contracts for Kin ecosystem boundaries.",
   "type": "module",

--- a/packages/kin-mcp/package.json
+++ b/packages/kin-mcp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kinlab/kin-mcp",
-  "version": "0.3.4",
+  "version": "0.3.5",
   "description": "Start Kin's MCP server, the system of record for AI-written software, through an npm-friendly wrapper.",
   "type": "module",
   "bin": {

--- a/packages/kin/package.json
+++ b/packages/kin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kinlab/kin",
-  "version": "0.3.4",
+  "version": "0.3.5",
   "description": "Canonical installer and launcher for Kin, the system of record for AI-written software. Provisions and runs the managed kin + kin-daemon release. MCP is one included mode (kin mcp start).",
   "license": "Apache-2.0",
   "type": "module",


### PR DESCRIPTION
Release bump covering the locate retrieval stack landed since v0.3.4 (#431, #436, #438, #439), the bounded projection-lock wait (#423), and the registry record repair at daemon startup (#437). Changelog entry included; all five version-lockstep files bumped together (workspace Cargo.toml, kin-cli's kin-spine pin, packages/kin, packages/kin-mcp, packages/boundary-contracts) and the lock refreshed patch-off (member version lines only, sources and checksums untouched).