### PR TITLE
Resolve history and blame revisions from committed state

### DIFF
--- a/crates/kin-cli/src/commands/blame.rs
+++ b/crates/kin-cli/src/commands/blame.rs
@@ -51,11 +51,18 @@ pub fn execute_blame_request(
 ) -> Result<BlameResponse> {
     let head =
         crate::commands::ref_lookup::resolve_ref(graph, binding, request.reference.as_deref())?;
-    let target = match request.reference.as_deref() {
-        Some(_) => {
-            crate::commands::ref_lookup::resolve_entity_query_at_ref(graph, &request.entity, &head)?
+    let (target, revisions) = match request.reference.as_deref() {
+        Some(_) => crate::commands::ref_lookup::resolve_entity_with_revisions_at(
+            graph,
+            &request.entity,
+            &head,
+        )?,
+        None => {
+            let target = crate::commands::ref_lookup::resolve_entity_query(graph, &request.entity)?;
+            let revisions =
+                crate::commands::ref_lookup::resolve_entity_revisions_at(graph, &target.id, &head)?;
+            (target, revisions)
         }
-        None => crate::commands::ref_lookup::resolve_entity_query(graph, &request.entity)?,
     };
     let mut lines = Vec::new();
     lines.push(format!(
@@ -63,8 +70,6 @@ pub fn execute_blame_request(
         target.name, target.kind, target.language, head
     ));
     lines.push(String::new());
-
-    let revisions = graph.get_entity_revisions_at(&target.id, &head)?;
 
     if revisions.is_empty() {
         lines.push("  No history recorded for this entity.".to_string());

--- a/crates/kin-cli/src/commands/history.rs
+++ b/crates/kin-cli/src/commands/history.rs
@@ -103,11 +103,18 @@ pub fn execute_history_request(
 ) -> Result<HistoryResponse> {
     let head =
         crate::commands::ref_lookup::resolve_ref(graph, binding, request.reference.as_deref())?;
-    let target = match request.reference.as_deref() {
-        Some(_) => {
-            crate::commands::ref_lookup::resolve_entity_query_at_ref(graph, &request.entity, &head)?
+    let (target, revisions) = match request.reference.as_deref() {
+        Some(_) => crate::commands::ref_lookup::resolve_entity_with_revisions_at(
+            graph,
+            &request.entity,
+            &head,
+        )?,
+        None => {
+            let target = crate::commands::ref_lookup::resolve_entity_query(graph, &request.entity)?;
+            let revisions =
+                crate::commands::ref_lookup::resolve_entity_revisions_at(graph, &target.id, &head)?;
+            (target, revisions)
         }
-        None => crate::commands::ref_lookup::resolve_entity_query(graph, &request.entity)?,
     };
     // Identifiers are abbreviated and messages are reduced to their subject
     // line, the way `git log --oneline` does. Printing two full 64-character
@@ -121,7 +128,6 @@ pub fn execute_history_request(
         abbreviate_id(&head.to_string())
     )];
 
-    let revisions = graph.get_entity_revisions_at(&target.id, &head)?;
     if revisions.is_empty() {
         lines.push("  No history recorded".to_string());
     } else {

--- a/crates/kin-cli/src/commands/ref_lookup.rs
+++ b/crates/kin-cli/src/commands/ref_lookup.rs
@@ -520,6 +520,93 @@ mod tests {
         SemanticChangeId::from_hash(Hash256::from_bytes([byte; 32]))
     }
 
+    /// One version of an entity. `marker` varies the fingerprint so two
+    /// versions of the same entity are distinguishable revisions.
+    fn entity_version(id: EntityId, name: &str, marker: u8) -> Entity {
+        let mut entity = named_entity(name);
+        entity.id = id;
+        entity.fingerprint.ast_hash = Hash256::from_bytes([marker; 32]);
+        entity.signature = format!("fn {name}(v{marker})");
+        entity
+    }
+
+    fn change_with_deltas(
+        parents: Vec<SemanticChangeId>,
+        deltas: Vec<kin_model::EntityDelta>,
+    ) -> SemanticChange {
+        let mut change = change_with_id(change_id(0), parents);
+        change.entity_deltas = deltas;
+        change.id = kin_core::compute_semantic_change_id(&change).unwrap();
+        change
+    }
+
+    /// `kin history <entity>` and `kin blame <entity>` with no `--ref` resolve
+    /// the entity from the live graph and its revisions from committed state at
+    /// head, so this helper is the whole revision path for the default
+    /// invocation. It must survive a change that touches the queried entity
+    /// alongside a second one whose own introducing change does not mention the
+    /// queried entity: deriving revisions from the entity-filtered change list
+    /// validated that second entity against a state it was never added to, and
+    /// answered a query about `alpha` with a stale-payload conflict naming
+    /// `beta`.
+    #[test]
+    fn revisions_survive_a_change_that_also_removes_another_entity() {
+        let graph = kin_db::InMemoryGraph::new();
+        let alpha = kin_model::EntityId::new();
+        let beta = kin_model::EntityId::new();
+        let gamma = kin_model::EntityId::new();
+
+        let add_alpha = change_with_deltas(
+            Vec::new(),
+            vec![kin_model::EntityDelta::Added {
+                new: entity_version(alpha, "alpha", 1),
+            }],
+        );
+        let add_beta = change_with_deltas(
+            vec![add_alpha.id],
+            vec![kin_model::EntityDelta::Added {
+                new: entity_version(beta, "beta", 1),
+            }],
+        );
+        let revise_alpha = change_with_deltas(
+            vec![add_beta.id],
+            vec![
+                kin_model::EntityDelta::Modified {
+                    old: entity_version(alpha, "alpha", 1),
+                    new: entity_version(alpha, "alpha", 2),
+                },
+                kin_model::EntityDelta::Removed {
+                    old: entity_version(beta, "beta", 1),
+                },
+                kin_model::EntityDelta::Added {
+                    new: entity_version(gamma, "gamma", 1),
+                },
+            ],
+        );
+        for entry in [&add_alpha, &add_beta, &revise_alpha] {
+            graph.create_change(entry).unwrap();
+        }
+
+        let revisions = resolve_entity_revisions_at(&graph, &alpha, &revise_alpha.id)
+            .expect("a sound history must not report a conflict for an unqueried entity");
+
+        assert_eq!(revisions.len(), 2);
+        assert_eq!(revisions[0].introduced_by, add_alpha.id);
+        assert_eq!(revisions[0].ended_by, Some(revise_alpha.id));
+        assert_eq!(revisions[1].introduced_by, revise_alpha.id);
+        assert_eq!(revisions[1].ended_by, None);
+        assert_eq!(
+            revisions[1].previous_revision,
+            Some(revisions[0].revision_id)
+        );
+        assert!(
+            !revisions
+                .iter()
+                .any(|revision| revision.introduced_by == add_beta.id),
+            "a change that never touches alpha is not a revision of alpha"
+        );
+    }
+
     fn absent_binding(layout: &kin_core::KinLayout) -> kin_core::LocalRepositoryAuthorityBinding {
         kin_core::LocalRepositoryAuthorityBinding::from_parts(
             kin_model::RepositoryId::new("absent-ref-lookup").unwrap(),

--- a/crates/kin-cli/src/commands/ref_lookup.rs
+++ b/crates/kin-cli/src/commands/ref_lookup.rs
@@ -2,7 +2,9 @@
 // Copyright 2026 Firelock, LLC
 
 use anyhow::{anyhow, bail, Result};
-use kin_model::{Entity, EntityFilter, GraphStore, Hash256, SemanticChangeId};
+use kin_model::{
+    Entity, EntityFilter, EntityId, EntityRevision, GraphStore, Hash256, SemanticChangeId,
+};
 
 use super::repository_authority::{parse_git_object_id, parse_ref_name, ActiveRepositoryAuthority};
 
@@ -102,24 +104,61 @@ where
     })
 }
 
-pub(crate) fn resolve_entity_query_at_ref<G>(
+/// The entity a query names at `head`, together with its revision timeline.
+///
+/// Both come out of one replay of committed state, which is also why the two
+/// are resolved together: the entity lookup already needs the state at `head`,
+/// and resolving revisions separately would replay the same history twice.
+pub(crate) fn resolve_entity_with_revisions_at<G>(
     graph: &G,
     entity_query: &str,
     head: &SemanticChangeId,
-) -> Result<Entity>
+) -> Result<(Entity, Vec<EntityRevision>)>
 where
     G: GraphStore,
     <G as GraphStore>::Error: std::fmt::Display + Send + Sync + 'static,
 {
-    let state = graph
+    let mut state = graph
         .resolve_graph_at(head)
         .map_err(|error| anyhow!(error.to_string()))?;
     let entities = state
         .entities
-        .into_values()
+        .values()
         .filter(|entity| entity_matches_query(entity, entity_query))
+        .cloned()
         .collect();
-    choose_entity_match(entities, entity_query)
+    let target = choose_entity_match(entities, entity_query)?;
+    let revisions = state
+        .entity_revisions
+        .remove(&target.id)
+        .unwrap_or_default();
+    Ok((target, revisions))
+}
+
+/// Every revision of `entity_id` visible at `head`, oldest first.
+///
+/// `ChangeStore::get_entity_revisions_at` is not usable here. It replays only
+/// the changes that mention this entity, yet validates every delta those
+/// changes carry. A change that touches this entity while also modifying or
+/// removing a second one is then checked against a state the second entity's
+/// own history was filtered out of, so a sound repository answers with a
+/// "stale old payload" conflict for an entity nobody asked about, and the
+/// command fails before printing a single revision. Replaying the complete
+/// first-parent state keeps every delta's precondition checkable, which is the
+/// same reason the MCP entity handlers resolve through `resolve_graph_at`.
+pub(crate) fn resolve_entity_revisions_at<G>(
+    graph: &G,
+    entity_id: &EntityId,
+    head: &SemanticChangeId,
+) -> Result<Vec<EntityRevision>>
+where
+    G: GraphStore,
+    <G as GraphStore>::Error: std::fmt::Display + Send + Sync + 'static,
+{
+    let mut state = graph
+        .resolve_graph_at(head)
+        .map_err(|error| anyhow!(error.to_string()))?;
+    Ok(state.entity_revisions.remove(entity_id).unwrap_or_default())
 }
 
 #[derive(Debug, Clone, Copy)]

--- a/crates/kin-cli/tests/entity_revision_history.rs
+++ b/crates/kin-cli/tests/entity_revision_history.rs
@@ -1,0 +1,240 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Firelock, LLC
+
+//! `kin history` and `kin blame` over a change that touches more than one entity.
+//!
+//! Resolving an entity's revisions from the entity-filtered change list replays
+//! only the changes that mention that entity, but validates every delta those
+//! changes carry. A refactor commit that edits the queried function while
+//! removing a helper and adding its replacement is then checked against a state
+//! the helper's own history was filtered out of, so both commands failed with a
+//! "stale old payload" conflict naming an entity the operator never asked
+//! about, before printing a single revision.
+
+use std::sync::Arc;
+
+use kin_cli::commands::blame::{execute_blame_request, BlameRequest};
+use kin_cli::commands::history::{execute_history_request, HistoryRequest};
+use kin_model::{
+    AuthorId, ChangeOrigin, ChangeStore, Entity, EntityDelta, EntityId, EntityKind, EntityMetadata,
+    EntityRole, FilePathId, FingerprintAlgorithm, Hash256, LanguageId, SemanticChange,
+    SemanticChangeId, SemanticFingerprint, Timestamp, Visibility,
+};
+
+/// One version of an entity. `marker` varies the fingerprint so two versions of
+/// the same entity are distinguishable revisions rather than a repeated one.
+fn entity(id: EntityId, name: &str, marker: u8) -> Entity {
+    Entity {
+        id,
+        kind: EntityKind::Function,
+        name: name.to_string(),
+        language: LanguageId::Rust,
+        fingerprint: SemanticFingerprint {
+            algorithm: FingerprintAlgorithm::V1TreeSitter,
+            ast_hash: Hash256::from_bytes([marker; 32]),
+            signature_hash: Hash256::from_bytes([marker; 32]),
+            behavior_hash: Hash256::from_bytes([marker; 32]),
+            equivalence_hash: Hash256::from_bytes([0; 32]),
+            stability_score: 1.0,
+        },
+        file_origin: Some(FilePathId::new("src/lib.rs")),
+        span: None,
+        signature: format!("fn {name}(v{marker})"),
+        visibility: Visibility::Public,
+        role: EntityRole::Source,
+        doc_summary: None,
+        metadata: EntityMetadata::default(),
+        lineage_parent: None,
+        created_in: None,
+        superseded_by: None,
+    }
+}
+
+/// A change whose declared identity recomputes from its own payload, the way
+/// repository authority requires.
+fn change(
+    parents: Vec<SemanticChangeId>,
+    message: &str,
+    entity_deltas: Vec<EntityDelta>,
+) -> SemanticChange {
+    let mut change = SemanticChange {
+        id: SemanticChangeId::from_hash(Hash256::from_bytes([0; 32])),
+        origin: ChangeOrigin::Native,
+        parents,
+        timestamp: Timestamp::now(),
+        author: AuthorId::new("Test Author <test@example.com>"),
+        message: message.to_string(),
+        entity_deltas,
+        relation_deltas: Vec::new(),
+        tree_deltas: Vec::new(),
+        admission_policy_delta: None,
+        projected_files: Vec::new(),
+        spec_link: None,
+        evidence: Vec::new(),
+        risk_summary: None,
+    };
+    change.id = kin_core::compute_semantic_change_id(&change).expect("derive change identity");
+    change
+}
+
+fn absent_binding() -> kin_core::LocalRepositoryAuthorityBinding {
+    let layout = kin_core::KinLayout::new(std::path::PathBuf::from("/absent/.kin"));
+    kin_core::LocalRepositoryAuthorityBinding::from_parts(
+        kin_model::RepositoryId::new("absent-entity-revision-history").unwrap(),
+        kin_model::WorkspaceId::new(),
+        Arc::new(kin_db::LocalFileBackend::new(layout.kindb_dir())),
+    )
+}
+
+/// The head of the fixture history plus the two changes that revise `alpha`.
+struct MixedShapeHistory {
+    graph: kin_db::InMemoryGraph,
+    head: SemanticChangeId,
+    introduced_alpha: SemanticChangeId,
+    revised_alpha: SemanticChangeId,
+    added_beta: SemanticChangeId,
+}
+
+/// Three commits, the last of which carries a mixed add/remove shape:
+///
+/// 1. adds `alpha`, the entity under query
+/// 2. adds `beta`, and does not mention `alpha` at all, so filtering the change
+///    list to `alpha` drops the only change that introduces `beta`
+/// 3. modifies `alpha`, removes `beta`, and adds `gamma` in its place
+///
+/// Replaying only changes 1 and 3 leaves change 3's `Removed { beta }` delta
+/// checked against a state that never saw `beta` added.
+fn mixed_shape_history() -> MixedShapeHistory {
+    let graph = kin_db::InMemoryGraph::new();
+
+    let alpha_id = EntityId::new();
+    let beta_id = EntityId::new();
+    let gamma_id = EntityId::new();
+
+    let alpha_v1 = entity(alpha_id, "alpha", 1);
+    let alpha_v2 = entity(alpha_id, "alpha", 2);
+    let beta_v1 = entity(beta_id, "beta", 1);
+    let gamma_v1 = entity(gamma_id, "gamma", 1);
+
+    let introduce_alpha = change(
+        Vec::new(),
+        "Add alpha",
+        vec![EntityDelta::Added {
+            new: alpha_v1.clone(),
+        }],
+    );
+    let introduce_beta = change(
+        vec![introduce_alpha.id],
+        "Add beta helper",
+        vec![EntityDelta::Added {
+            new: beta_v1.clone(),
+        }],
+    );
+    let revise_alpha = change(
+        vec![introduce_beta.id],
+        "Replace the beta helper with gamma\n\nThe body is not a subject line.",
+        vec![
+            EntityDelta::Modified {
+                old: alpha_v1,
+                new: alpha_v2,
+            },
+            EntityDelta::Removed { old: beta_v1 },
+            EntityDelta::Added { new: gamma_v1 },
+        ],
+    );
+
+    for entry in [&introduce_alpha, &introduce_beta, &revise_alpha] {
+        graph.create_change(entry).expect("store change");
+    }
+
+    MixedShapeHistory {
+        graph,
+        head: revise_alpha.id,
+        introduced_alpha: introduce_alpha.id,
+        revised_alpha: revise_alpha.id,
+        added_beta: introduce_beta.id,
+    }
+}
+
+fn abbreviated(id: &SemanticChangeId) -> String {
+    id.to_string().chars().take(12).collect()
+}
+
+#[test]
+fn history_reports_both_revisions_across_a_mixed_add_remove_change() {
+    let fixture = mixed_shape_history();
+    let request = HistoryRequest {
+        entity: "alpha".to_string(),
+        reference: Some(format!("kin:{}", fixture.head)),
+    };
+
+    let response = execute_history_request(&absent_binding(), &fixture.graph, &request)
+        .expect("history must not fail on a change that also touches another entity");
+    let rendered = response.lines.join("\n");
+
+    assert!(
+        !rendered.contains("No history recorded"),
+        "alpha has two revisions, got:\n{rendered}"
+    );
+    // Header plus exactly one row per revision of alpha.
+    assert_eq!(
+        response.lines.len(),
+        3,
+        "expected a header and two revision rows, got:\n{rendered}"
+    );
+    for change_id in [&fixture.introduced_alpha, &fixture.revised_alpha] {
+        assert!(
+            rendered.contains(&abbreviated(change_id)),
+            "revision introduced by {change_id} is missing from:\n{rendered}"
+        );
+    }
+    assert!(
+        !rendered.contains(&abbreviated(&fixture.added_beta)),
+        "the change that only touches beta is not a revision of alpha:\n{rendered}"
+    );
+    assert!(
+        rendered.contains("Test Author") && !rendered.contains("test@example.com"),
+        "the author column keeps the name and drops the address:\n{rendered}"
+    );
+    assert!(
+        rendered.contains("Replace the beta helper with gamma")
+            && !rendered.contains("The body is not a subject line."),
+        "each row carries the subject line only:\n{rendered}"
+    );
+}
+
+#[test]
+fn blame_reports_both_revisions_across_a_mixed_add_remove_change() {
+    let fixture = mixed_shape_history();
+    let request = BlameRequest {
+        entity: "alpha".to_string(),
+        reference: Some(format!("kin:{}", fixture.head)),
+    };
+
+    let response = execute_blame_request(&absent_binding(), &fixture.graph, &request)
+        .expect("blame must not fail on a change that also touches another entity");
+    let rendered = response.lines.join("\n");
+
+    assert!(
+        !rendered.contains("No history recorded"),
+        "alpha has two revisions, got:\n{rendered}"
+    );
+    assert!(
+        rendered.contains("2 version(s) found."),
+        "both revisions of alpha must be counted:\n{rendered}"
+    );
+    for change_id in [&fixture.introduced_alpha, &fixture.revised_alpha] {
+        assert!(
+            rendered.contains(&change_id.to_string()),
+            "revision introduced by {change_id} is missing from:\n{rendered}"
+        );
+    }
+    assert!(
+        !rendered.contains(&fixture.added_beta.to_string()),
+        "the change that only touches beta is not a revision of alpha:\n{rendered}"
+    );
+    assert!(
+        rendered.contains("Signature: fn alpha(v2)"),
+        "blame reports the state at the requested head:\n{rendered}"
+    );
+}


### PR DESCRIPTION
## Defect

`kin history` and `kin blame` resolved an entity revision timeline through
`ChangeStore::get_entity_revisions_at`. That default replays only the changes
that **mention** the queried entity, but validates **every** delta those changes
carry.

So a change that touches the queried entity alongside a second entity is
validated against a state the second entity was never added to, because the
change that introduced it does not mention the queried entity and was filtered
out. A sound repository then answers with:

```
conflict: change <id> has stale old payload for removed entity <B>
```

Any repository containing a single commit in a mixed add/remove shape (revise A,
remove B, add C) hits this, and both commands fail before printing a single
revision. `crates/kin-mcp/src/handlers/common.rs` was the one site already
routing around it, and documents why.

## Fix

Both commands now read revisions out of `resolve_graph_at`, the same
committed-state replay the MCP entity handlers use. Replaying the complete
first-parent state keeps every delta precondition checkable, so no other
entity can poison the answer.

When a ref is given, `resolve_entity_with_revisions_at` returns the entity and
its revisions from **one** replay. Previously the entity lookup replayed the
state at head and threw it away, then revision resolution replayed it again;
routing revisions through the same call would have made that two full replays
per command.

## Tests

Both paths the two commands can take are covered, and both were verified failing
before the change and passing after.

**With `--ref` (end to end).** `crates/kin-cli/tests/entity_revision_history.rs`
builds a three-commit fixture whose last commit revises the queried entity,
removes a helper introduced by a commit that never mentions the queried entity,
and adds a replacement. It asserts both commands succeed and print the correct
revisions (both revisions present, the unrelated commit absent, correct
author/subject rendering, correct state at head).

```
before: 0 passed; 2 failed
  history ... FAILED: conflict: change <id> has stale old payload for removed entity <B>
  blame   ... FAILED: conflict: change <id> has stale old payload for removed entity <B>
after:  2 passed; 0 failed
```

**Without `--ref` (the default invocation).** That path resolves the entity from
the live graph and its revisions from committed state at head, which the
end-to-end fixture does not reach. A `ref_lookup` unit test exercises that helper
directly against the same mixed add/remove shape. Verified by temporarily
reverting the helper to the unsound default: same `stale old payload` conflict,
then green once restored.

## Upstream

This is the short-term routing fix. The upstream fix is kin-model
[#40](https://github.com/firelock-ai/kin-model/pull/40), now **merged and
published as kin-model 0.6.1**, which makes the trait default replay and validate
only the queried entity deltas.

This PR deliberately does **not** bump the `kin-model` dependency and stands alone
against the published `kin-model 0.6.0`, per the bottom-up publish policy.
Consuming 0.6.1 and re-evaluating whether this routing is still wanted is tracked
as a follow-up. Note it is not a mechanical revert: the `--ref` path likely wants
to keep the single-replay shape even once the default is sound, while the no-ref
path is a genuine removal candidate since the fixed default skips relation and
tree replay.

## Local gate

`cargo fmt --check`, `cargo clippy --all-targets --all-features` under the CI
allowlist with `RUSTFLAGS=-Dwarnings`, `cargo build --all-targets`, and the
kin-cli lib suite (829 passed, 0 failed) are all green. The full workspace suite
is covered by `Check & Test` on ubuntu and macOS, which run
`cargo nextest run --locked` plus `cargo test --doc`.