### PR TITLE
Prove and enforce sealed all-content observation at exact Git admission

### DIFF
--- a/crates/kin-core/src/git_init.rs
+++ b/crates/kin-core/src/git_init.rs
@@ -41,7 +41,10 @@ use crate::init::{
 use crate::layout::KinLayout;
 use crate::manifest::KinManifest;
 
-#[cfg(test)]
+// Gated on unix as well as test because exact Git admission is unix-only, so
+// the tests that drive this injection are too. Leaving it on every test build
+// would make it dead code on Windows, which CI rejects under `-D warnings`.
+#[cfg(all(unix, test))]
 std::thread_local! {
     static WITHHELD_STAGED_BODY: std::cell::Cell<Option<Hash256>> =
         const { std::cell::Cell::new(None) };
@@ -49,22 +52,22 @@ std::thread_local! {
 
 /// Drop one captured body on its way into the staged repository, so a test can
 /// prove admission refuses a graph that cannot answer for its own content.
-#[cfg(test)]
+#[cfg(all(unix, test))]
 fn withhold_staged_body(digest: Hash256) {
     WITHHELD_STAGED_BODY.set(Some(digest));
 }
 
-#[cfg(test)]
+#[cfg(all(unix, test))]
 fn clear_withheld_staged_body() {
     WITHHELD_STAGED_BODY.set(None);
 }
 
-#[cfg(test)]
+#[cfg(all(unix, test))]
 fn staged_body_is_withheld(digest: Hash256) -> bool {
     WITHHELD_STAGED_BODY.with(|withheld| withheld.get() == Some(digest))
 }
 
-#[cfg(not(test))]
+#[cfg(not(all(unix, test)))]
 const fn staged_body_is_withheld(_digest: Hash256) -> bool {
     false
 }

--- a/crates/kin-core/src/git_init.rs
+++ b/crates/kin-core/src/git_init.rs
@@ -9,12 +9,15 @@
 //! the staged `.kin` repository is atomically published.
 
 use std::path::Path;
+use std::sync::Arc;
 
 use kin_blobs::BlobStore;
+use kin_db::{LocalFileBackend, RepositoryAuthorityManager};
 use kin_git::{
     admit_semantic_git_import, build_git_external_authority, capture_lossless_git_repository,
     plan_semantic_git_import, preflight_git_migration, preflight_git_migration_after_publication,
-    GitLocalIgnoreSourceKind, GitMigrationPreflightProof, LosslessGitRepository,
+    seal_all_content_observation, AdmittedContentClosure, GitLocalIgnoreSourceKind,
+    GitMigrationPreflightProof, LosslessGitRepository, SealedContentObservation,
 };
 use kin_model::{
     compute_resolved_tree_hash, AdmissionCase, AuthorId, ChangeStore,
@@ -31,8 +34,40 @@ use crate::config::{
     KinConfig,
 };
 use crate::error::{KinError, Result};
-use crate::init::{prepare_repository_layout_at, publish_repository_layout_linearized, InitResult};
+use crate::init::{
+    prepare_repository_layout_at, publish_repository_layout_linearized, GraphOwnedContent,
+    InitResult,
+};
+use crate::layout::KinLayout;
 use crate::manifest::KinManifest;
+
+#[cfg(test)]
+std::thread_local! {
+    static WITHHELD_STAGED_BODY: std::cell::Cell<Option<Hash256>> =
+        const { std::cell::Cell::new(None) };
+}
+
+/// Drop one captured body on its way into the staged repository, so a test can
+/// prove admission refuses a graph that cannot answer for its own content.
+#[cfg(test)]
+fn withhold_staged_body(digest: Hash256) {
+    WITHHELD_STAGED_BODY.set(Some(digest));
+}
+
+#[cfg(test)]
+fn clear_withheld_staged_body() {
+    WITHHELD_STAGED_BODY.set(None);
+}
+
+#[cfg(test)]
+fn staged_body_is_withheld(digest: Hash256) -> bool {
+    WITHHELD_STAGED_BODY.with(|withheld| withheld.get() == Some(digest))
+}
+
+#[cfg(not(test))]
+const fn staged_body_is_withheld(_digest: Hash256) -> bool {
+    false
+}
 
 /// Admit one clean materialized Git worktree as a complete Kin repository.
 ///
@@ -93,6 +128,8 @@ fn init_from_git_with_hooks(
     let mut prepared =
         prepare_repository_layout_at(&staging_dir, &final_kin_dir, config, manifest)?;
     copy_captured_authority(&prepared, &snapshot, &capture_store, &source_proof)?;
+    let sealed_observation = seal_all_content_observation(&admitted, &prepared)
+        .map_err(|error| git_boundary_error("seal all-content observation", error))?;
 
     let workspace_seed = admitted.workspace_seed.clone();
     let workspace_policy = admitted.workspace_policy().clone();
@@ -147,6 +184,19 @@ fn init_from_git_with_hooks(
                     .to_string(),
             ));
         }
+        // Re-seal the published repository, deriving the closure from the exact
+        // import plan rather than its admitted form. Requiring both derivations
+        // to fingerprint identically proves publication preserved graph-owned
+        // content and that the two closures agree, instead of assuming it.
+        let published_observation =
+            seal_published_content_observation(published.path(), &semantic_plan)?;
+        if published_observation.fingerprint != sealed_observation.fingerprint {
+            return Err(KinError::Other(
+                "sealed all-content observation changed across repository publication; published \
+                 authority is not safe to use without recovery"
+                    .to_string(),
+            ));
+        }
         Ok(())
     })?;
     // Exact Git refs intentionally retain external-object targets, so the
@@ -161,9 +211,35 @@ fn init_from_git_with_hooks(
         repository = %result.repository_id,
         workspace = %result.workspace_id,
         generation = result.authority.receipt.generation,
+        observed_trees = sealed_observation.observed_trees,
+        observed_entries = sealed_observation.observed_entries,
+        sealed_bodies = sealed_observation.coverage.sealed_bodies,
+        sealed_body_bytes = sealed_observation.coverage.sealed_body_bytes,
+        opaque_bodies = sealed_observation.coverage.opaque_bodies,
+        declared_exclusions = sealed_observation.exclusions.len(),
+        seal = %sealed_observation.fingerprint,
         "admitted exact Git repository as graph-owned Kin authority"
     );
     Ok(result)
+}
+
+/// Re-derive the sealed all-content observation against a published repository.
+///
+/// Reads only graph-owned content through the published repository's own
+/// authority, so a repository that seals here answers for its admitted content
+/// without consulting the working tree or the source object store.
+fn seal_published_content_observation(
+    published_kin_dir: &Path,
+    closure: &impl AdmittedContentClosure,
+) -> Result<SealedContentObservation> {
+    let layout = KinLayout::new(published_kin_dir.to_path_buf());
+    let authority = RepositoryAuthorityManager::open(
+        closure.closure_repository_id().clone(),
+        Arc::new(LocalFileBackend::new(layout.kindb_dir())),
+    )
+    .map_err(|error| KinError::Graph(error.to_string()))?;
+    seal_all_content_observation(closure, &GraphOwnedContent::new(&authority))
+        .map_err(|error| git_boundary_error("seal published all-content observation", error))
 }
 
 fn verify_material_workspace_seed(
@@ -345,6 +421,9 @@ fn copy_captured_authority(
                 error,
             )
         })?;
+        if staged_body_is_withheld(record.body_hash) {
+            continue;
+        }
         prepared.save_source_blob(record.body_hash, &body)?;
     }
     for input in &proof.ignored_local.inputs {
@@ -1122,6 +1201,131 @@ mod tests {
             .tree
             .artifact_at_path(&RepoPath::from_utf8("containers/Dockerfile").unwrap())
             .is_some());
+    }
+
+    /// A source repository carrying an opaque binary, an executable bit, a
+    /// symlink, an empty file, and two revisions of a source file, so the
+    /// admitted closure spans more content than the workspace head alone.
+    #[cfg(unix)]
+    fn initialize_all_shapes_source(source: &Path) {
+        use std::os::unix::fs::{symlink, PermissionsExt};
+
+        initialize_git(source);
+        std::fs::create_dir_all(source.join("src")).unwrap();
+        std::fs::write(source.join("src/lib.rs"), b"pub fn answer() -> u8 { 42 }\n").unwrap();
+        std::fs::write(source.join("payload.bin"), [0_u8, 255, 17, 0, 128, 42]).unwrap();
+        std::fs::write(source.join("empty.txt"), b"").unwrap();
+        let executable = source.join("tool");
+        std::fs::write(&executable, b"#!/bin/sh\nexit 0\n").unwrap();
+        let mut permissions = std::fs::metadata(&executable).unwrap().permissions();
+        permissions.set_mode(0o755);
+        std::fs::set_permissions(&executable, permissions).unwrap();
+        symlink("src/lib.rs", source.join("source-link")).unwrap();
+        git(source, ["add", "--all"]);
+        git(source, ["commit", "-m", "exact tree with every shape"]);
+
+        // A second revision so a body that no longer appears at the workspace
+        // head still belongs to the admitted closure.
+        std::fs::write(source.join("src/lib.rs"), b"pub fn answer() -> u8 { 43 }\n").unwrap();
+        git(source, ["add", "--all"]);
+        git(source, ["commit", "-m", "second revision"]);
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn admitted_repository_owns_every_historical_body_without_the_source_git_repository() {
+        use std::sync::Arc;
+
+        use kin_db::{LocalFileBackend, RepositoryAuthorityManager};
+        use kin_model::TreeEntry;
+
+        let root = tempfile::tempdir().unwrap();
+        let source = root.path().join("source");
+        std::fs::create_dir(&source).unwrap();
+        initialize_all_shapes_source(&source);
+
+        let result = init_from_git(&source).unwrap();
+
+        // Remove the Git object store the content came from. Anything the
+        // repository can still answer is genuinely graph-owned.
+        std::fs::remove_dir_all(source.join(".git")).unwrap();
+
+        let backend = Arc::new(LocalFileBackend::new(result.layout.kindb_dir()));
+        let authority =
+            RepositoryAuthorityManager::open(result.repository_id.clone(), backend).unwrap();
+        let lease = authority.read_authority();
+        let metadata = lease.metadata();
+        assert_eq!(metadata.aliases.len(), 2);
+
+        let workspace = &metadata.workspaces[0];
+        let mut proven = 0_usize;
+        for artifact in workspace.tree.artifacts() {
+            let Some(identity) = artifact.entry.blob_identity() else {
+                continue;
+            };
+            let body = authority
+                .load_source_blob(identity)
+                .unwrap()
+                .unwrap_or_else(|| {
+                    panic!(
+                        "admitted repository cannot answer for {}",
+                        String::from_utf8_lossy(artifact.path.as_bytes())
+                    )
+                });
+            assert_eq!(kin_blobs::digest(&body), identity);
+            proven += 1;
+        }
+        // Five content-bearing paths: the source file, the opaque binary, the
+        // empty file, the executable, and the symlink target.
+        assert_eq!(proven, 5);
+
+        // The superseded first revision is still owned, so history reads never
+        // need the source Git repository either.
+        let superseded = lease
+            .metadata()
+            .aliases
+            .iter()
+            .map(|alias| alias.change_id)
+            .collect::<Vec<_>>();
+        assert_eq!(superseded.len(), 2);
+        assert!(matches!(
+            workspace
+                .tree
+                .artifact_at_path(&kin_model::RepoPath::from_utf8("source-link").unwrap())
+                .unwrap()
+                .entry,
+            TreeEntry::Symlink { .. }
+        ));
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn admission_fails_closed_when_a_body_never_reaches_graph_storage() {
+        let root = tempfile::tempdir().unwrap();
+        let source = root.path().join("source");
+        std::fs::create_dir(&source).unwrap();
+        initialize_all_shapes_source(&source);
+
+        // A Git blob's CAS identity is the digest of its raw body, which for a
+        // regular file is the file's exact bytes.
+        let opaque = kin_blobs::digest(&std::fs::read(source.join("payload.bin")).unwrap());
+
+        withhold_staged_body(opaque);
+        let error = init_from_git(&source).unwrap_err();
+        clear_withheld_staged_body();
+
+        let message = error.to_string();
+        assert!(
+            message.contains("seal all-content observation"),
+            "admission must fail on the seal, got: {message}"
+        );
+        assert!(
+            message.contains("payload.bin"),
+            "the failure must name the unsealed path, got: {message}"
+        );
+        // Fail closed means nothing was published.
+        assert!(!source.join(".kin").exists());
+        assert_no_staging_directories(root.path());
     }
 
     fn initialize_git(source: &Path) {

--- a/crates/kin-core/src/git_init.rs
+++ b/crates/kin-core/src/git_init.rs
@@ -48,6 +48,7 @@ use crate::manifest::KinManifest;
 std::thread_local! {
     static WITHHELD_STAGED_BODY: std::cell::Cell<Option<Hash256>> =
         const { std::cell::Cell::new(None) };
+    static DIVERGED_PUBLISHED_CLOSURE: std::cell::Cell<bool> = const { std::cell::Cell::new(false) };
 }
 
 /// Drop one captured body on its way into the staged repository, so a test can
@@ -72,11 +73,105 @@ const fn staged_body_is_withheld(_digest: Hash256) -> bool {
     false
 }
 
+/// Derive the published observation from a deliberately diverged closure, so a
+/// test can prove the cross-check refuses a divergence rather than assuming it.
+#[cfg(all(unix, test))]
+fn diverge_published_closure(diverged: bool) {
+    DIVERGED_PUBLISHED_CLOSURE.set(diverged);
+}
+
+#[cfg(all(unix, test))]
+fn published_closure_is_diverged() -> bool {
+    DIVERGED_PUBLISHED_CLOSURE.get()
+}
+
+/// A closure whose last admitted tree carries the bodies of two plain files
+/// exchanged.
+///
+/// Every shape count, distinct body, and byte total is unchanged by the
+/// exchange, so this is exactly the divergence a fingerprint over counts alone
+/// cannot see and a fingerprint bound to observed content must reject.
+#[cfg(all(unix, test))]
+struct DivergedClosure {
+    repository_id: RepositoryId,
+    trees: Vec<kin_model::ResolvedTree>,
+}
+
+#[cfg(all(unix, test))]
+impl DivergedClosure {
+    fn from_closure(closure: &impl AdmittedContentClosure) -> Self {
+        use kin_model::{ResolvedTree, TreeEntry};
+
+        let mut trees = closure
+            .admitted_trees()
+            .into_iter()
+            .cloned()
+            .collect::<Vec<_>>();
+        let head = trees
+            .last_mut()
+            .expect("an admitted closure observes a tree");
+        let plain_files = head
+            .artifacts_by_path()
+            .filter(|artifact| {
+                matches!(
+                    artifact.entry,
+                    TreeEntry::Blob {
+                        executable: false,
+                        ..
+                    }
+                )
+            })
+            .map(|artifact| (artifact.path.clone(), artifact.entry))
+            .take(2)
+            .collect::<Vec<_>>();
+        let [(left_path, left_entry), (right_path, right_entry)] = plain_files.as_slice() else {
+            panic!("the admitted head tree carries two plain files to exchange");
+        };
+        assert_ne!(
+            left_entry, right_entry,
+            "exchanging equal entries is not a divergence"
+        );
+        let exchanged = head
+            .clone()
+            .into_artifacts()
+            .map(|mut artifact| {
+                if artifact.path == *left_path {
+                    artifact.entry = *right_entry;
+                } else if artifact.path == *right_path {
+                    artifact.entry = *left_entry;
+                }
+                artifact
+            })
+            .collect::<Vec<_>>();
+        *head = ResolvedTree::from_artifacts(exchanged)
+            .expect("exchanging two entries preserves tree validity");
+        Self {
+            repository_id: closure.closure_repository_id().clone(),
+            trees,
+        }
+    }
+}
+
+#[cfg(all(unix, test))]
+impl AdmittedContentClosure for DivergedClosure {
+    fn closure_repository_id(&self) -> &RepositoryId {
+        &self.repository_id
+    }
+
+    fn admitted_trees(&self) -> Vec<&kin_model::ResolvedTree> {
+        self.trees.iter().collect()
+    }
+}
+
 /// Admit one clean materialized Git worktree as a complete Kin repository.
 ///
-/// The source Git repository is never mutated. Publication is all-or-nothing:
-/// source drift, unsupported compatibility state, an existing destination, or
-/// any graph/CAS validation error leaves `.kin` absent.
+/// The source Git repository is never mutated. Every refusal before the
+/// publication rename leaves `.kin` absent: source drift, unsupported
+/// compatibility state, an existing destination, a graph or CAS validation
+/// error, or an admitted closure the staged graph cannot answer for. Divergence
+/// found after the rename cannot unpublish, so it fails loud as
+/// [`KinError::RepositoryPublishedButUncertain`] with the published repository
+/// left in place for recovery.
 pub fn init_from_git(working_dir: &Path) -> Result<InitResult> {
     init_from_git_with_hook(working_dir, || {})
 }
@@ -191,6 +286,14 @@ fn init_from_git_with_hooks(
         // import plan rather than its admitted form. Requiring both derivations
         // to fingerprint identically proves publication preserved graph-owned
         // content and that the two closures agree, instead of assuming it.
+        //
+        // This observation is after the linearization point, so it detects
+        // divergence rather than preventing publication: a refusal here leaves
+        // the published `.kin` on disk and reports
+        // `RepositoryPublishedButUncertain`, exactly like the post-publication
+        // source proof above. The staged observation before publication is what
+        // keeps a repository that cannot answer for its content from being
+        // published at all. Neither site degrades into a filesystem read.
         let published_observation =
             seal_published_content_observation(published.path(), &semantic_plan)?;
         if published_observation.fingerprint != sealed_observation.fingerprint {
@@ -241,7 +344,14 @@ fn seal_published_content_observation(
         Arc::new(LocalFileBackend::new(layout.kindb_dir())),
     )
     .map_err(|error| KinError::Graph(error.to_string()))?;
-    seal_all_content_observation(closure, &GraphOwnedContent::new(&authority))
+    let content = GraphOwnedContent::new(&authority);
+    #[cfg(all(unix, test))]
+    if published_closure_is_diverged() {
+        let diverged = DivergedClosure::from_closure(closure);
+        return seal_all_content_observation(&diverged, &content)
+            .map_err(|error| git_boundary_error("seal published all-content observation", error));
+    }
+    seal_all_content_observation(closure, &content)
         .map_err(|error| git_boundary_error("seal published all-content observation", error))
 }
 
@@ -1283,7 +1393,22 @@ mod tests {
         assert_eq!(proven, 5);
 
         // The superseded first revision is still owned, so history reads never
-        // need the source Git repository either.
+        // need the source Git repository either. Its body appears at no path in
+        // the head tree, so only the admitted closure can account for it.
+        let superseded_body = kin_blobs::digest(b"pub fn answer() -> u8 { 42 }\n");
+        assert!(
+            workspace
+                .tree
+                .artifacts()
+                .all(|artifact| artifact.entry.blob_identity() != Some(superseded_body)),
+            "the superseded body must not be reachable from the head tree"
+        );
+        let body = authority
+            .load_source_blob(superseded_body)
+            .unwrap()
+            .expect("admitted repository cannot answer for the superseded revision");
+        assert_eq!(kin_blobs::digest(&body), superseded_body);
+
         let superseded = lease
             .metadata()
             .aliases
@@ -1329,6 +1454,117 @@ mod tests {
         // Fail closed means nothing was published.
         assert!(!source.join(".kin").exists());
         assert_no_staging_directories(root.path());
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn a_body_lost_across_publication_is_refused_before_the_published_seal_reads_it() {
+        let root = tempfile::tempdir().unwrap();
+        let source = root.path().join("source");
+        std::fs::create_dir(&source).unwrap();
+        initialize_all_shapes_source(&source);
+
+        // Remove one body from the published store between the two
+        // observations, which the staged observation already proved present.
+        let opaque = kin_blobs::digest(&std::fs::read(source.join("payload.bin")).unwrap());
+        let published_kin_dir = source.join(".kin");
+        let error = init_from_git_with_hooks(
+            &source,
+            || {},
+            move || remove_published_body(&published_kin_dir, opaque),
+        )
+        .unwrap_err();
+
+        // A physically defective published body never reaches the published
+        // seal: opening the published repository's authority loads and
+        // re-digests every body the admitted trees reference, so it refuses
+        // first. That is the layering this pins, and it is why the published
+        // seal's own detection power is closure divergence rather than store
+        // corruption. Do not rewrite this to expect the seal; a store defect
+        // cannot get past graph-authority verification to reach it.
+        let message = error.to_string();
+        assert!(
+            message.contains("is absent from immutable source CAS"),
+            "graph authority must refuse the absent body, got: {message}"
+        );
+        assert!(
+            message.contains(&opaque.to_string()),
+            "the refusal must name the lost body, got: {message}"
+        );
+        // The rename already happened, so the contract here is uncertain rather
+        // than absent: the operator is told to recover, not to reinitialize.
+        assert!(matches!(
+            error,
+            KinError::RepositoryPublishedButUncertain { .. }
+        ));
+        assert!(source.join(".kin").is_dir());
+        assert_no_staging_directories(root.path());
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn published_closure_divergence_fails_loud_as_published_but_uncertain() {
+        let root = tempfile::tempdir().unwrap();
+        let source = root.path().join("source");
+        std::fs::create_dir(&source).unwrap();
+        initialize_all_shapes_source(&source);
+
+        // The published derivation observes two plain files with their bodies
+        // exchanged. Both bodies are present and byte-exact, so the seal itself
+        // succeeds and only the cross-check against the staged observation can
+        // refuse. Counts and byte totals are identical, so the fingerprint has
+        // to bind content for this to be detectable at all.
+        diverge_published_closure(true);
+        let error = init_from_git(&source).unwrap_err();
+        diverge_published_closure(false);
+
+        let message = error.to_string();
+        assert!(
+            message
+                .contains("sealed all-content observation changed across repository publication"),
+            "the cross-check must name the divergence, got: {message}"
+        );
+        assert!(matches!(
+            error,
+            KinError::RepositoryPublishedButUncertain { .. }
+        ));
+        assert!(source.join(".kin").is_dir());
+        assert_no_staging_directories(root.path());
+    }
+
+    /// Delete one graph-owned body from a published repository.
+    ///
+    /// The body is located by the content identity the store names its file
+    /// after, rather than by a hardcoded store layout, so the injection keeps
+    /// working if the directory shape changes and fails loudly if the naming
+    /// convention does.
+    #[cfg(unix)]
+    fn remove_published_body(published_kin_dir: &Path, identity: Hash256) {
+        let name = identity
+            .as_bytes()
+            .iter()
+            .map(|byte| format!("{byte:02x}"))
+            .collect::<String>();
+        assert!(
+            remove_first_named_file(published_kin_dir, &name),
+            "published repository stores no body named {name}"
+        );
+    }
+
+    #[cfg(unix)]
+    fn remove_first_named_file(directory: &Path, name: &str) -> bool {
+        for entry in std::fs::read_dir(directory).unwrap() {
+            let entry = entry.unwrap();
+            if entry.file_type().unwrap().is_dir() {
+                if remove_first_named_file(&entry.path(), name) {
+                    return true;
+                }
+            } else if entry.file_name() == std::ffi::OsStr::new(name) {
+                std::fs::remove_file(entry.path()).unwrap();
+                return true;
+            }
+        }
+        false
     }
 
     fn initialize_git(source: &Path) {

--- a/crates/kin-core/src/init.rs
+++ b/crates/kin-core/src/init.rs
@@ -9,6 +9,7 @@ use std::sync::Arc;
 
 use fs2::FileExt as _;
 use kin_db::{LocalFileBackend, RepositoryAuthorityManager, StorageBackend};
+use kin_git::SealedContentSource;
 use kin_model::{
     compute_resolved_tree_hash, AdmissionCase, AdmissionPolicyDelta, AuthorId,
     DefaultRefExpectation, DefaultRefMutation, EffectiveAdmissionPolicyStamp, ExternalObjectId,
@@ -220,6 +221,17 @@ impl PreparedRepositoryInit {
             .map_err(graph_error)
     }
 
+    /// Read immutable source bytes back out of the unpublished staging store.
+    ///
+    /// This is the read side of [`Self::save_source_blob`], and it exists so
+    /// admission can prove the staged repository owns every body its admitted
+    /// trees reference before that repository is published.
+    pub fn load_source_blob(&self, digest: Hash256) -> Result<Option<Vec<u8>>> {
+        self.authority()?
+            .load_source_blob(digest)
+            .map_err(graph_error)
+    }
+
     /// Commit exactly one complete generation-zero to generation-one
     /// repository transition.
     ///
@@ -283,6 +295,37 @@ impl PreparedRepositoryInit {
         self.authority.as_ref().ok_or_else(|| {
             KinError::Other("staged repository authority is no longer open".to_string())
         })
+    }
+}
+
+/// Graph-owned repository content, exposed to sealed observation.
+///
+/// The wrapper deliberately narrows a full authority manager down to the single
+/// capability an observation needs: resolve a content identity to the bytes the
+/// repository already owns. An observation therefore cannot reach the working
+/// tree, the ambient object store, or any other authority surface.
+pub struct GraphOwnedContent<'a>(&'a RepositoryAuthorityManager<LocalFileBackend>);
+
+impl<'a> GraphOwnedContent<'a> {
+    pub const fn new(authority: &'a RepositoryAuthorityManager<LocalFileBackend>) -> Self {
+        Self(authority)
+    }
+}
+
+impl SealedContentSource for GraphOwnedContent<'_> {
+    fn load_sealed_content(&self, digest: Hash256) -> std::result::Result<Vec<u8>, String> {
+        match self.0.load_source_blob(digest) {
+            Ok(Some(body)) => Ok(body),
+            Ok(None) => Err("the repository owns no body for this content identity".to_string()),
+            Err(error) => Err(error.to_string()),
+        }
+    }
+}
+
+impl SealedContentSource for PreparedRepositoryInit {
+    fn load_sealed_content(&self, digest: Hash256) -> std::result::Result<Vec<u8>, String> {
+        let authority = self.authority().map_err(|error| error.to_string())?;
+        GraphOwnedContent::new(authority).load_sealed_content(digest)
     }
 }
 

--- a/crates/kin-core/src/init.rs
+++ b/crates/kin-core/src/init.rs
@@ -324,8 +324,13 @@ impl SealedContentSource for GraphOwnedContent<'_> {
 
 impl SealedContentSource for PreparedRepositoryInit {
     fn load_sealed_content(&self, digest: Hash256) -> std::result::Result<Vec<u8>, String> {
-        let authority = self.authority().map_err(|error| error.to_string())?;
-        GraphOwnedContent::new(authority).load_sealed_content(digest)
+        match self.load_source_blob(digest) {
+            Ok(Some(body)) => Ok(body),
+            Ok(None) => {
+                Err("the staged repository owns no body for this content identity".to_string())
+            }
+            Err(error) => Err(error.to_string()),
+        }
     }
 }
 

--- a/crates/kin-git/src/error.rs
+++ b/crates/kin-git/src/error.rs
@@ -64,8 +64,9 @@ pub struct UnsealedContentGap {
 
 /// Render a gap report so the failure names the paths an operator must fix.
 ///
-/// The count is always exact; when the sample is narrower than the count, the
-/// message says so rather than reading as if every gap were listed.
+/// The count and the sample both count distinct unsealed bodies, so the exact
+/// count is reported, a truncated sample says so, and a sample that lists every
+/// gap it found never reads as truncated.
 fn describe_unsealed_gaps(total_gaps: usize, reported: &[UnsealedContentGap]) -> String {
     let mut described = reported
         .iter()
@@ -144,12 +145,15 @@ pub enum GitError {
     },
 
     #[error(
-        "sealed all-content observation failed: {total_gaps} admitted entr(ies) have no byte-exact graph-owned body, so this repository cannot answer for its own content without reading the filesystem: {}",
+        "sealed all-content observation failed: {total_gaps} admitted bod(ies) are not byte-exact in graph-owned storage, so this repository cannot answer for its own content without reading the filesystem: {}",
         describe_unsealed_gaps(*total_gaps, reported)
     )]
     UnsealedContent {
+        /// Distinct unsealed bodies, counted once each however many admitted
+        /// entries reference them.
         total_gaps: usize,
-        /// A bounded sample of the gaps. `total_gaps` is always the exact count.
+        /// A bounded sample of the gaps, one entry per distinct unsealed body.
+        /// `total_gaps` is always the exact count.
         reported: Vec<UnsealedContentGap>,
     },
 

--- a/crates/kin-git/src/error.rs
+++ b/crates/kin-git/src/error.rs
@@ -62,6 +62,32 @@ pub struct UnsealedContentGap {
     pub detail: String,
 }
 
+/// Render a gap report so the failure names the paths an operator must fix.
+///
+/// The count is always exact; when the sample is narrower than the count, the
+/// message says so rather than reading as if every gap were listed.
+fn describe_unsealed_gaps(total_gaps: usize, reported: &[UnsealedContentGap]) -> String {
+    let mut described = reported
+        .iter()
+        .map(|gap| {
+            format!(
+                "{} (expects {}: {})",
+                String::from_utf8_lossy(&gap.path),
+                gap.expected,
+                gap.detail
+            )
+        })
+        .collect::<Vec<_>>()
+        .join("; ");
+    if total_gaps > reported.len() {
+        described.push_str(&format!(
+            "; and {} further gap(s) not listed",
+            total_gaps - reported.len()
+        ));
+    }
+    described
+}
+
 /// Errors from the kin-git adapter.
 #[derive(Debug, Error)]
 pub enum GitError {
@@ -118,7 +144,8 @@ pub enum GitError {
     },
 
     #[error(
-        "sealed all-content observation failed: {total_gaps} admitted entr(ies) have no byte-exact graph-owned body, so this repository cannot answer for its own content without reading the filesystem"
+        "sealed all-content observation failed: {total_gaps} admitted entr(ies) have no byte-exact graph-owned body, so this repository cannot answer for its own content without reading the filesystem: {}",
+        describe_unsealed_gaps(*total_gaps, reported)
     )]
     UnsealedContent {
         total_gaps: usize,

--- a/crates/kin-git/src/error.rs
+++ b/crates/kin-git/src/error.rs
@@ -48,6 +48,20 @@ pub struct GitCheckoutFilterFact {
     pub required_present: bool,
 }
 
+/// One admitted entry whose content the graph cannot answer for.
+///
+/// Paths and identities are carried as plain bytes and text so a gap report
+/// survives into an error without depending on repository model types.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct UnsealedContentGap {
+    pub path: Vec<u8>,
+    /// Content identity the admitted tree requires.
+    pub expected: String,
+    /// Why the body could not be sealed: absent, unreadable, or not matching
+    /// the identity the tree recorded.
+    pub detail: String,
+}
+
 /// Errors from the kin-git adapter.
 #[derive(Debug, Error)]
 pub enum GitError {
@@ -101,6 +115,15 @@ pub enum GitError {
         filter_count: usize,
         hooks: Vec<LocalGitHookFact>,
         filters: Vec<GitCheckoutFilterFact>,
+    },
+
+    #[error(
+        "sealed all-content observation failed: {total_gaps} admitted entr(ies) have no byte-exact graph-owned body, so this repository cannot answer for its own content without reading the filesystem"
+    )]
+    UnsealedContent {
+        total_gaps: usize,
+        /// A bounded sample of the gaps. `total_gaps` is always the exact count.
+        reported: Vec<UnsealedContentGap>,
     },
 
     #[error("Git object format {0} is not supported for exact rehydration")]

--- a/crates/kin-git/src/lib.rs
+++ b/crates/kin-git/src/lib.rs
@@ -18,13 +18,14 @@ pub mod error;
 pub mod lossless;
 pub mod preflight;
 pub mod repository_export;
+pub mod sealed_observation;
 pub mod semantic_import;
 
 pub use admission_history::{admit_semantic_git_import, AdmittedSemanticGitImportPlan};
 pub use authority::build_git_external_authority;
 pub use error::{
     GitCheckoutFilterFact, GitError, LocalGitHookFact, LocalGitHookKind, RegisteredGitWorktreeFact,
-    RegisteredGitWorktreeKind, Result,
+    RegisteredGitWorktreeKind, Result, UnsealedContentGap,
 };
 pub use lossless::{
     capture_lossless_git_repository, rehydrate_lossless_git_repository,
@@ -41,5 +42,9 @@ pub use preflight::{
 pub use repository_export::{
     export_repository_to_git, verify_repository_git_export, RepositoryGitCommitBinding,
     RepositoryGitExportPlan, RepositoryGitExportProof, RepositoryGitExportResult,
+};
+pub use sealed_observation::{
+    seal_all_content_observation, AdmittedContentClosure, ContentExclusionReason,
+    DeclaredContentExclusion, SealedContentCoverage, SealedContentObservation, SealedContentSource,
 };
 pub use semantic_import::{plan_semantic_git_import, GitWorkspaceSeed, SemanticGitImportPlan};

--- a/crates/kin-git/src/sealed_observation.rs
+++ b/crates/kin-git/src/sealed_observation.rs
@@ -197,12 +197,12 @@ pub fn seal_all_content_observation(
                 }
                 TreeEntry::Gitlink { target } => {
                     coverage.gitlink_entries += 1;
-                    exclusions
-                        .entry((path.clone(), target))
-                        .or_insert_with(|| DeclaredContentExclusion {
+                    exclusions.entry((path.clone(), target)).or_insert_with(|| {
+                        DeclaredContentExclusion {
                             path: path.clone(),
                             reason: ContentExclusionReason::ForeignGitlinkTarget { target },
-                        });
+                        }
+                    });
                     continue;
                 }
             };
@@ -446,7 +446,12 @@ mod tests {
         plan.workspace_seed
             .base_tree
             .artifact_at_path(&path)
-            .unwrap_or_else(|| panic!("fixture is missing {}", String::from_utf8_lossy(path.as_bytes())))
+            .unwrap_or_else(|| {
+                panic!(
+                    "fixture is missing {}",
+                    String::from_utf8_lossy(path.as_bytes())
+                )
+            })
             .entry
             .blob_identity()
             .expect("fixture entry carries content")
@@ -456,8 +461,7 @@ mod tests {
     #[test]
     fn seals_every_content_shape_and_declares_only_foreign_gitlinks() {
         let fixture = ExactFixture::all_shapes();
-        let observation =
-            seal_all_content_observation(&fixture.plan, &fixture.blob_store).unwrap();
+        let observation = seal_all_content_observation(&fixture.plan, &fixture.blob_store).unwrap();
 
         // Two commits plus the workspace seed tree, each carrying the same
         // seven paths: four plain files, one executable, one symlink, one
@@ -501,13 +505,10 @@ mod tests {
     #[test]
     fn admitted_and_unadmitted_closures_seal_to_the_same_fingerprint() {
         let fixture = ExactFixture::all_shapes();
-        let admitted =
-            admit_semantic_git_import(&fixture.plan, &fixture.blob_store).unwrap();
+        let admitted = admit_semantic_git_import(&fixture.plan, &fixture.blob_store).unwrap();
 
-        let from_plan =
-            seal_all_content_observation(&fixture.plan, &fixture.blob_store).unwrap();
-        let from_admitted =
-            seal_all_content_observation(&admitted, &fixture.blob_store).unwrap();
+        let from_plan = seal_all_content_observation(&fixture.plan, &fixture.blob_store).unwrap();
+        let from_admitted = seal_all_content_observation(&admitted, &fixture.blob_store).unwrap();
         assert_eq!(from_admitted, from_plan);
     }
 

--- a/crates/kin-git/src/sealed_observation.rs
+++ b/crates/kin-git/src/sealed_observation.rs
@@ -1,0 +1,647 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Firelock, LLC
+
+//! Sealed all-content observation over an admitted repository closure.
+//!
+//! Exact Git admission proves that the reachable object closure is captured
+//! atomically. That is a statement about Git objects, not about the repository
+//! content those objects resolve to. Nothing in the object walk asserts that
+//! the trees Kin actually answers from are content-complete in graph-owned
+//! storage; that has held only because the tree decoder and the authority copy
+//! happen to agree on the same body identity.
+//!
+//! This boundary makes the guarantee explicit. It walks every admitted tree,
+//! classifies every entry by its exact shape, and proves that every
+//! content-bearing entry resolves to a byte-exact body the graph already owns.
+//!
+//! Content is read only through the supplied graph-owned source; the
+//! filesystem is never consulted. A repository that seals here can answer for
+//! its admitted content without a raw file read. Shapes whose content is
+//! genuinely foreign are declared as explicit exclusions rather than skipped,
+//! and any entry that cannot be sealed fails admission with an enumerated gap
+//! report instead of degrading into a filesystem fallback.
+
+use std::collections::{BTreeMap, BTreeSet};
+
+use kin_blobs::{digest, BlobStore};
+use kin_model::{GitObjectId, Hash256, RepoPath, RepositoryId, ResolvedTree, TreeEntry};
+
+use crate::admission_history::AdmittedSemanticGitImportPlan;
+use crate::error::{GitError, Result, UnsealedContentGap};
+use crate::semantic_import::SemanticGitImportPlan;
+
+/// Upper bound on gaps carried in a failure. The reported total is always
+/// exact; only the per-entry detail list is bounded, so a repository with a
+/// systematically empty store produces a readable error rather than one entry
+/// per artifact in its entire history.
+const MAX_REPORTED_GAPS: usize = 32;
+
+/// Graph-owned content the observation is permitted to read.
+///
+/// The observation deliberately cannot reach the filesystem. Implementations
+/// expose exactly one capability: resolve a content identity to bytes the
+/// repository already owns.
+pub trait SealedContentSource {
+    /// Load one body by its content identity.
+    ///
+    /// `Err` denotes an absent or unreadable body. The caller turns that into a
+    /// reported gap rather than an immediate abort, so a single seal reports
+    /// every gap it found instead of only the first.
+    fn load_sealed_content(&self, digest: Hash256) -> std::result::Result<Vec<u8>, String>;
+}
+
+impl SealedContentSource for BlobStore {
+    fn load_sealed_content(&self, digest: Hash256) -> std::result::Result<Vec<u8>, String> {
+        self.read(&digest).map_err(|error| error.to_string())
+    }
+}
+
+/// An admitted closure whose content can be sealed.
+///
+/// Implemented by both the exact import plan and its admitted form so the same
+/// observation can be derived independently from either and the two results
+/// compared, rather than assuming the two agree.
+pub trait AdmittedContentClosure {
+    fn closure_repository_id(&self) -> &RepositoryId;
+    /// Every admitted tree, in a deterministic order: one per imported commit,
+    /// then the workspace seed tree.
+    fn admitted_trees(&self) -> Vec<&ResolvedTree>;
+}
+
+impl AdmittedContentClosure for SemanticGitImportPlan {
+    fn closure_repository_id(&self) -> &RepositoryId {
+        &self.repository_id
+    }
+
+    fn admitted_trees(&self) -> Vec<&ResolvedTree> {
+        self.commit_trees
+            .values()
+            .chain(std::iter::once(&self.workspace_seed.base_tree))
+            .collect()
+    }
+}
+
+impl AdmittedContentClosure for AdmittedSemanticGitImportPlan {
+    fn closure_repository_id(&self) -> &RepositoryId {
+        &self.repository_id
+    }
+
+    fn admitted_trees(&self) -> Vec<&ResolvedTree> {
+        self.commit_trees
+            .values()
+            .chain(std::iter::once(&self.workspace_seed.base_tree))
+            .collect()
+    }
+}
+
+/// Coverage of one sealed all-content observation.
+///
+/// Entry counters are per tree occurrence, so a path present at every commit is
+/// counted at every commit. Body counters are over distinct content identities,
+/// because sealing proves a body once no matter how many trees reference it.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub struct SealedContentCoverage {
+    pub regular_file_entries: usize,
+    pub executable_file_entries: usize,
+    pub symlink_entries: usize,
+    pub gitlink_entries: usize,
+    /// Distinct content identities proven present and byte-exact in the graph.
+    pub sealed_bodies: usize,
+    pub sealed_body_bytes: u64,
+    /// Distinct sealed bodies with no content. An empty file is exactly
+    /// versioned like any other; it is counted so an all-empty seal cannot be
+    /// mistaken for a complete one.
+    pub empty_bodies: usize,
+    /// Distinct sealed bodies that are not valid UTF-8. No semantic entity
+    /// enrichment is expected of them and none is fabricated; they stay exactly
+    /// versioned by content, path, and mode.
+    pub opaque_bodies: usize,
+    /// Distinct observed paths this host cannot name as UTF-8. They remain
+    /// graph-owned and byte-exact regardless of host representability.
+    pub non_utf8_paths: usize,
+}
+
+/// Content the observation intentionally does not own, declared rather than
+/// silently skipped.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct DeclaredContentExclusion {
+    pub path: RepoPath,
+    pub reason: ContentExclusionReason,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum ContentExclusionReason {
+    /// A submodule pointer. The commit it names belongs to a different
+    /// repository, so this repository seals the pointer exactly and owns no
+    /// body for it. No entity is fabricated for the absent content.
+    ForeignGitlinkTarget { target: GitObjectId },
+}
+
+/// Proof that every content-bearing entry of an admitted closure resolves to a
+/// byte-exact body the graph owns.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct SealedContentObservation {
+    pub repository_id: RepositoryId,
+    /// Admitted trees observed: one per imported commit, plus the workspace
+    /// seed tree.
+    pub observed_trees: usize,
+    pub observed_entries: usize,
+    pub coverage: SealedContentCoverage,
+    pub exclusions: Vec<DeclaredContentExclusion>,
+    pub fingerprint: Hash256,
+}
+
+/// Prove sealed all-content observation over an admitted closure.
+///
+/// Every entry of every admitted tree is classified and, when it carries
+/// content, proven present and byte-exact in `content`. Bodies are verified
+/// against their recorded identity here rather than trusting the source to have
+/// verified them, so the proof stands on its own.
+///
+/// Fails closed with every gap it found. A partial observation is never
+/// returned, and no gap is ever repaired from the filesystem.
+pub fn seal_all_content_observation(
+    closure: &impl AdmittedContentClosure,
+    content: &impl SealedContentSource,
+) -> Result<SealedContentObservation> {
+    let mut coverage = SealedContentCoverage::default();
+    let mut observed_entries = 0usize;
+    let mut observed_trees = 0usize;
+    let mut sealed = BTreeSet::<Hash256>::new();
+    let mut failed = BTreeSet::<Hash256>::new();
+    let mut total_gaps = 0usize;
+    let mut reported_gaps = Vec::<UnsealedContentGap>::new();
+    let mut exclusions = BTreeMap::<(RepoPath, GitObjectId), DeclaredContentExclusion>::new();
+    let mut non_utf8_paths = BTreeSet::<RepoPath>::new();
+
+    for tree in closure.admitted_trees() {
+        observed_trees += 1;
+        for artifact in tree.artifacts_by_path() {
+            observed_entries += 1;
+            let path = &artifact.path;
+            if path.as_utf8().is_none() {
+                non_utf8_paths.insert(path.clone());
+            }
+            let identity = match artifact.entry {
+                TreeEntry::Blob { hash, executable } => {
+                    if executable {
+                        coverage.executable_file_entries += 1;
+                    } else {
+                        coverage.regular_file_entries += 1;
+                    }
+                    hash
+                }
+                TreeEntry::Symlink { target_blob } => {
+                    coverage.symlink_entries += 1;
+                    target_blob
+                }
+                TreeEntry::Gitlink { target } => {
+                    coverage.gitlink_entries += 1;
+                    exclusions
+                        .entry((path.clone(), target))
+                        .or_insert_with(|| DeclaredContentExclusion {
+                            path: path.clone(),
+                            reason: ContentExclusionReason::ForeignGitlinkTarget { target },
+                        });
+                    continue;
+                }
+            };
+            if sealed.contains(&identity) {
+                continue;
+            }
+            if failed.contains(&identity) {
+                total_gaps += 1;
+                continue;
+            }
+            match seal_body(content, identity) {
+                Ok(body) => {
+                    sealed.insert(identity);
+                    coverage.sealed_bodies += 1;
+                    coverage.sealed_body_bytes += body.len() as u64;
+                    if body.is_empty() {
+                        coverage.empty_bodies += 1;
+                    }
+                    if std::str::from_utf8(&body).is_err() {
+                        coverage.opaque_bodies += 1;
+                    }
+                }
+                Err(detail) => {
+                    failed.insert(identity);
+                    total_gaps += 1;
+                    if reported_gaps.len() < MAX_REPORTED_GAPS {
+                        reported_gaps.push(UnsealedContentGap {
+                            path: path.as_bytes().to_vec(),
+                            expected: identity.to_string(),
+                            detail,
+                        });
+                    }
+                }
+            }
+        }
+    }
+
+    if total_gaps > 0 {
+        return Err(GitError::UnsealedContent {
+            total_gaps,
+            reported: reported_gaps,
+        });
+    }
+
+    coverage.non_utf8_paths = non_utf8_paths.len();
+    let exclusions = exclusions.into_values().collect::<Vec<_>>();
+    let repository_id = closure.closure_repository_id().clone();
+    let fingerprint = fingerprint_observation(
+        &repository_id,
+        observed_trees,
+        observed_entries,
+        &coverage,
+        &exclusions,
+    );
+    Ok(SealedContentObservation {
+        repository_id,
+        observed_trees,
+        observed_entries,
+        coverage,
+        exclusions,
+        fingerprint,
+    })
+}
+
+/// Read one body and prove it matches the identity the tree recorded.
+fn seal_body(
+    content: &impl SealedContentSource,
+    identity: Hash256,
+) -> std::result::Result<Vec<u8>, String> {
+    let body = content.load_sealed_content(identity)?;
+    let observed = digest(&body);
+    if observed != identity {
+        return Err(format!(
+            "graph-owned body hashes to {observed}, but the admitted tree requires {identity}"
+        ));
+    }
+    Ok(body)
+}
+
+fn fingerprint_observation(
+    repository_id: &RepositoryId,
+    observed_trees: usize,
+    observed_entries: usize,
+    coverage: &SealedContentCoverage,
+    exclusions: &[DeclaredContentExclusion],
+) -> Hash256 {
+    let mut buffer = Vec::new();
+    buffer.extend_from_slice(b"kin.git.sealed-content-observation.v1\0");
+    append_bytes(&mut buffer, repository_id.as_str().as_bytes());
+    for count in [
+        observed_trees,
+        observed_entries,
+        coverage.regular_file_entries,
+        coverage.executable_file_entries,
+        coverage.symlink_entries,
+        coverage.gitlink_entries,
+        coverage.sealed_bodies,
+        coverage.empty_bodies,
+        coverage.opaque_bodies,
+        coverage.non_utf8_paths,
+    ] {
+        buffer.extend_from_slice(&(count as u64).to_le_bytes());
+    }
+    buffer.extend_from_slice(&coverage.sealed_body_bytes.to_le_bytes());
+    buffer.extend_from_slice(&(exclusions.len() as u64).to_le_bytes());
+    for exclusion in exclusions {
+        append_bytes(&mut buffer, exclusion.path.as_bytes());
+        match &exclusion.reason {
+            ContentExclusionReason::ForeignGitlinkTarget { target } => {
+                buffer.push(1);
+                append_bytes(&mut buffer, target.to_string().as_bytes());
+            }
+        }
+    }
+    digest(&buffer)
+}
+
+fn append_bytes(buffer: &mut Vec<u8>, bytes: &[u8]) {
+    buffer.extend_from_slice(&(bytes.len() as u64).to_le_bytes());
+    buffer.extend_from_slice(bytes);
+}
+
+#[cfg(test)]
+mod tests {
+    use std::fs;
+    use std::path::Path;
+    use std::process::Command;
+
+    use pretty_assertions::assert_eq;
+    use tempfile::{tempdir, TempDir};
+
+    use super::*;
+    use crate::admission_history::admit_semantic_git_import;
+    use crate::lossless::capture_lossless_git_repository;
+    use crate::semantic_import::plan_semantic_git_import;
+
+    /// A content source backed by a real store with selected bodies withheld,
+    /// so the fail-closed path is exercised against the production seal rather
+    /// than a hand-rolled stub.
+    struct WithholdingSource<'a> {
+        inner: &'a BlobStore,
+        withheld: Vec<Hash256>,
+        corrupted: Vec<Hash256>,
+    }
+
+    impl SealedContentSource for WithholdingSource<'_> {
+        fn load_sealed_content(&self, digest: Hash256) -> std::result::Result<Vec<u8>, String> {
+            if self.withheld.contains(&digest) {
+                return Err("blob not found".to_string());
+            }
+            if self.corrupted.contains(&digest) {
+                return Ok(b"content that is not what the tree recorded".to_vec());
+            }
+            self.inner.load_sealed_content(digest)
+        }
+    }
+
+    #[cfg(unix)]
+    struct ExactFixture {
+        _root: TempDir,
+        blob_store: BlobStore,
+        plan: SemanticGitImportPlan,
+        binary_body: Hash256,
+        symlink_body: Hash256,
+        executable_body: Hash256,
+        empty_body: Hash256,
+    }
+
+    #[cfg(unix)]
+    impl ExactFixture {
+        /// A repository carrying every shape the seal must cover: text, an
+        /// opaque binary, an empty file, an executable bit, a symlink, a
+        /// gitlink, and a path this host cannot name as UTF-8.
+        fn all_shapes() -> Self {
+            use std::os::unix::fs::{symlink, PermissionsExt};
+
+            let root = tempdir().unwrap();
+            let repo = root.path().join("source");
+            fs::create_dir(&repo).unwrap();
+            git_ok(&repo, ["init", "--initial-branch=main"]);
+            configure_git(&repo);
+
+            write(&repo, "src/lib.rs", b"pub fn value() -> u8 { 7 }\n");
+            write(&repo, "assets/raw.bin", &[0, 255, 1, 128, b'\n', 0, 42]);
+            write(&repo, "empty.txt", b"");
+            write(&repo, "scripts/tool.sh", b"#!/bin/sh\nprintf 'kin\\n'\n");
+            let executable = repo.join("scripts/tool.sh");
+            let mut permissions = fs::metadata(&executable).unwrap().permissions();
+            permissions.set_mode(0o755);
+            fs::set_permissions(&executable, permissions).unwrap();
+            symlink("src/lib.rs", repo.join("source-link")).unwrap();
+            git_ok(&repo, ["add", "--all"]);
+
+            let non_utf8 = git_stdin_text(&repo, ["hash-object", "-w", "--stdin"], &[0xde, 0xad]);
+            let mut index_entry = format!("100644 {non_utf8}\t").into_bytes();
+            index_entry.extend_from_slice(b"odd-\xff.bin\0");
+            git_stdin_ok(&repo, ["update-index", "-z", "--index-info"], &index_entry);
+            git_ok(
+                &repo,
+                [
+                    "update-index",
+                    "--add",
+                    "--cacheinfo",
+                    "160000,4242424242424242424242424242424242424242,vendor/sub",
+                ],
+            );
+            git_ok(&repo, ["commit", "-m", "exact tree with every shape"]);
+
+            write(&repo, "src/lib.rs", b"pub fn value() -> u8 { 8 }\n");
+            git_ok(&repo, ["add", "src/lib.rs"]);
+            git_ok(&repo, ["commit", "-m", "second revision"]);
+
+            let blob_store = BlobStore::new(root.path().join("cas")).unwrap();
+            let snapshot = capture_lossless_git_repository(
+                &repo,
+                RepositoryId::new("sealed-observation").unwrap(),
+                &blob_store,
+            )
+            .unwrap();
+            let plan = plan_semantic_git_import(&snapshot, &blob_store).unwrap();
+
+            let binary_body = body_at(&plan, b"assets/raw.bin");
+            let symlink_body = body_at(&plan, b"source-link");
+            let executable_body = body_at(&plan, b"scripts/tool.sh");
+            let empty_body = body_at(&plan, b"empty.txt");
+            Self {
+                _root: root,
+                blob_store,
+                plan,
+                binary_body,
+                symlink_body,
+                executable_body,
+                empty_body,
+            }
+        }
+    }
+
+    #[cfg(unix)]
+    fn body_at(plan: &SemanticGitImportPlan, path: &[u8]) -> Hash256 {
+        let path = RepoPath::from_bytes(path.to_vec()).unwrap();
+        plan.workspace_seed
+            .base_tree
+            .artifact_at_path(&path)
+            .unwrap_or_else(|| panic!("fixture is missing {}", String::from_utf8_lossy(path.as_bytes())))
+            .entry
+            .blob_identity()
+            .expect("fixture entry carries content")
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn seals_every_content_shape_and_declares_only_foreign_gitlinks() {
+        let fixture = ExactFixture::all_shapes();
+        let observation =
+            seal_all_content_observation(&fixture.plan, &fixture.blob_store).unwrap();
+
+        // Two commits plus the workspace seed tree.
+        assert_eq!(observation.observed_trees, 3);
+        assert!(observation.coverage.executable_file_entries > 0);
+        assert!(observation.coverage.symlink_entries > 0);
+        assert!(observation.coverage.gitlink_entries > 0);
+        assert_eq!(observation.coverage.non_utf8_paths, 1);
+
+        // The opaque binary, the symlink target, the executable body, and the
+        // empty file are all proven present and byte-exact.
+        assert!(observation.coverage.opaque_bodies >= 1);
+        assert_eq!(observation.coverage.empty_bodies, 1);
+        for body in [
+            fixture.binary_body,
+            fixture.symlink_body,
+            fixture.executable_body,
+            fixture.empty_body,
+        ] {
+            fixture.blob_store.read(&body).unwrap();
+        }
+
+        // The only declared exclusion is the foreign submodule pointer, and no
+        // entity is invented for it.
+        assert_eq!(observation.exclusions.len(), 1);
+        let exclusion = &observation.exclusions[0];
+        assert_eq!(exclusion.path.as_bytes(), b"vendor/sub");
+        assert!(matches!(
+            exclusion.reason,
+            ContentExclusionReason::ForeignGitlinkTarget { .. }
+        ));
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn admitted_and_unadmitted_closures_seal_to_the_same_fingerprint() {
+        let fixture = ExactFixture::all_shapes();
+        let admitted =
+            admit_semantic_git_import(&fixture.plan, &fixture.blob_store).unwrap();
+
+        let from_plan =
+            seal_all_content_observation(&fixture.plan, &fixture.blob_store).unwrap();
+        let from_admitted =
+            seal_all_content_observation(&admitted, &fixture.blob_store).unwrap();
+        assert_eq!(from_admitted, from_plan);
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn fails_closed_when_an_opaque_body_is_absent_from_graph_storage() {
+        let fixture = ExactFixture::all_shapes();
+        let source = WithholdingSource {
+            inner: &fixture.blob_store,
+            withheld: vec![fixture.binary_body],
+            corrupted: Vec::new(),
+        };
+
+        let error = seal_all_content_observation(&fixture.plan, &source).unwrap_err();
+        let GitError::UnsealedContent {
+            total_gaps,
+            reported,
+        } = error
+        else {
+            panic!("absent content must fail as an unsealed-content gap, got {error:?}");
+        };
+        assert!(total_gaps >= 1);
+        let gap = reported
+            .iter()
+            .find(|gap| gap.path == b"assets/raw.bin")
+            .expect("the withheld binary is reported by path");
+        assert_eq!(gap.expected, fixture.binary_body.to_string());
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn fails_closed_when_a_symlink_target_body_does_not_match_its_identity() {
+        let fixture = ExactFixture::all_shapes();
+        let source = WithholdingSource {
+            inner: &fixture.blob_store,
+            withheld: Vec::new(),
+            corrupted: vec![fixture.symlink_body],
+        };
+
+        let error = seal_all_content_observation(&fixture.plan, &source).unwrap_err();
+        let GitError::UnsealedContent { reported, .. } = error else {
+            panic!("a body/identity mismatch must fail closed, got {error:?}");
+        };
+        let gap = reported
+            .iter()
+            .find(|gap| gap.path == b"source-link")
+            .expect("the corrupted symlink target is reported by path");
+        assert!(
+            gap.detail.contains("hashes to"),
+            "the gap names the mismatch: {}",
+            gap.detail
+        );
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn seal_is_deterministic_and_binds_the_observed_counts() {
+        let fixture = ExactFixture::all_shapes();
+        let first = seal_all_content_observation(&fixture.plan, &fixture.blob_store).unwrap();
+        let second = seal_all_content_observation(&fixture.plan, &fixture.blob_store).unwrap();
+        assert_eq!(second.fingerprint, first.fingerprint);
+
+        let mut drifted = first.clone();
+        drifted.coverage.symlink_entries += 1;
+        let refingerprinted = fingerprint_observation(
+            &drifted.repository_id,
+            drifted.observed_trees,
+            drifted.observed_entries,
+            &drifted.coverage,
+            &drifted.exclusions,
+        );
+        assert_ne!(refingerprinted, first.fingerprint);
+    }
+
+    fn write(repo: &Path, relative: &str, body: &[u8]) {
+        let path = repo.join(relative);
+        if let Some(parent) = path.parent() {
+            fs::create_dir_all(parent).unwrap();
+        }
+        fs::write(path, body).unwrap();
+    }
+
+    fn configure_git(repo: &Path) {
+        git_ok(repo, ["config", "user.name", "Kin Test"]);
+        git_ok(repo, ["config", "user.email", "test@kin.invalid"]);
+        git_ok(repo, ["config", "commit.gpgsign", "false"]);
+    }
+
+    fn git_ok<const N: usize>(repo: &Path, args: [&str; N]) {
+        let output = git(repo, args, None);
+        assert!(
+            output.status.success(),
+            "git {args:?} failed: {}",
+            String::from_utf8_lossy(&output.stderr)
+        );
+    }
+
+    fn git_stdin_ok<const N: usize>(repo: &Path, args: [&str; N], stdin: &[u8]) {
+        let output = git(repo, args, Some(stdin));
+        assert!(
+            output.status.success(),
+            "git {args:?} failed: {}",
+            String::from_utf8_lossy(&output.stderr)
+        );
+    }
+
+    fn git_stdin_text<const N: usize>(repo: &Path, args: [&str; N], stdin: &[u8]) -> String {
+        let output = git(repo, args, Some(stdin));
+        assert!(
+            output.status.success(),
+            "git {args:?} failed: {}",
+            String::from_utf8_lossy(&output.stderr)
+        );
+        String::from_utf8(output.stdout).unwrap().trim().to_string()
+    }
+
+    fn git<const N: usize>(
+        repo: &Path,
+        args: [&str; N],
+        stdin: Option<&[u8]>,
+    ) -> std::process::Output {
+        use std::io::Write as _;
+        use std::process::Stdio;
+
+        let mut command = Command::new("git");
+        command
+            .current_dir(repo)
+            .args(args)
+            .env("GIT_CONFIG_GLOBAL", "/dev/null")
+            .env("GIT_CONFIG_SYSTEM", "/dev/null")
+            .stdin(if stdin.is_some() {
+                Stdio::piped()
+            } else {
+                Stdio::null()
+            })
+            .stdout(Stdio::piped())
+            .stderr(Stdio::piped());
+        let mut child = command.spawn().unwrap();
+        if let Some(stdin) = stdin {
+            child.stdin.take().unwrap().write_all(stdin).unwrap();
+        }
+        child.wait_with_output().unwrap()
+    }
+}

--- a/crates/kin-git/src/sealed_observation.rs
+++ b/crates/kin-git/src/sealed_observation.rs
@@ -325,7 +325,11 @@ fn append_bytes(buffer: &mut Vec<u8>, bytes: &[u8]) {
     buffer.extend_from_slice(bytes);
 }
 
-#[cfg(test)]
+// Every case here builds a real Git repository carrying symlinks, executable
+// bits, and non-UTF-8 paths, which is unix-only. Gating the module rather than
+// each item keeps its helpers from becoming dead code on Windows, which CI
+// rejects under `-D warnings`.
+#[cfg(all(test, unix))]
 mod tests {
     use std::fs;
     use std::path::Path;

--- a/crates/kin-git/src/sealed_observation.rs
+++ b/crates/kin-git/src/sealed_observation.rs
@@ -459,16 +459,23 @@ mod tests {
         let observation =
             seal_all_content_observation(&fixture.plan, &fixture.blob_store).unwrap();
 
-        // Two commits plus the workspace seed tree.
+        // Two commits plus the workspace seed tree, each carrying the same
+        // seven paths: four plain files, one executable, one symlink, one
+        // gitlink.
         assert_eq!(observation.observed_trees, 3);
-        assert!(observation.coverage.executable_file_entries > 0);
-        assert!(observation.coverage.symlink_entries > 0);
-        assert!(observation.coverage.gitlink_entries > 0);
+        assert_eq!(observation.observed_entries, 21);
+        assert_eq!(observation.coverage.regular_file_entries, 12);
+        assert_eq!(observation.coverage.executable_file_entries, 3);
+        assert_eq!(observation.coverage.symlink_entries, 3);
+        assert_eq!(observation.coverage.gitlink_entries, 3);
         assert_eq!(observation.coverage.non_utf8_paths, 1);
 
-        // The opaque binary, the symlink target, the executable body, and the
-        // empty file are all proven present and byte-exact.
-        assert!(observation.coverage.opaque_bodies >= 1);
+        // Seven distinct bodies: two revisions of the source file, the opaque
+        // binary, the empty file, the executable, the symlink target, and the
+        // body behind the non-UTF-8 path. All are sealed, none is skipped.
+        assert_eq!(observation.coverage.sealed_bodies, 7);
+        assert_eq!(observation.coverage.sealed_body_bytes, 98);
+        assert_eq!(observation.coverage.opaque_bodies, 1);
         assert_eq!(observation.coverage.empty_bodies, 1);
         for body in [
             fixture.binary_body,

--- a/crates/kin-git/src/sealed_observation.rs
+++ b/crates/kin-git/src/sealed_observation.rs
@@ -23,18 +23,29 @@
 
 use std::collections::{BTreeMap, BTreeSet};
 
-use kin_blobs::{digest, BlobStore};
+use kin_blobs::digest;
+#[cfg(test)]
+use kin_blobs::BlobStore;
 use kin_model::{GitObjectId, Hash256, RepoPath, RepositoryId, ResolvedTree, TreeEntry};
 
 use crate::admission_history::AdmittedSemanticGitImportPlan;
 use crate::error::{GitError, Result, UnsealedContentGap};
 use crate::semantic_import::SemanticGitImportPlan;
 
-/// Upper bound on gaps carried in a failure. The reported total is always
-/// exact; only the per-entry detail list is bounded, so a repository with a
-/// systematically empty store produces a readable error rather than one entry
-/// per artifact in its entire history.
+/// Upper bound on gaps carried in a failure. A gap is one distinct unsealed
+/// body, counted once no matter how many admitted entries reference it, so the
+/// reported total and the detail list count the same thing. Only the detail
+/// list is bounded, so a repository with a systematically empty store produces
+/// a readable error rather than one entry per artifact in its entire history.
 const MAX_REPORTED_GAPS: usize = 32;
+
+/// Shape tags bound into the per-tree content digest. An entry's shape is part
+/// of what the repository owns, so a body that moves between a regular file, an
+/// executable, and a symlink is a different observation even at the same path.
+const SHAPE_REGULAR_FILE: u8 = 1;
+const SHAPE_EXECUTABLE_FILE: u8 = 2;
+const SHAPE_SYMLINK: u8 = 3;
+const SHAPE_FOREIGN_GITLINK: u8 = 4;
 
 /// Graph-owned content the observation is permitted to read.
 ///
@@ -50,6 +61,11 @@ pub trait SealedContentSource {
     fn load_sealed_content(&self, digest: Hash256) -> std::result::Result<Vec<u8>, String>;
 }
 
+// Sealing against a bare content store proves byte-exactness but says nothing
+// about graph ownership, so this impl exists only for fixtures that need a real
+// store behind the observation. Product paths must seal against repository
+// authority; gating the impl keeps the weaker source from compiling into one.
+#[cfg(test)]
 impl SealedContentSource for BlobStore {
     fn load_sealed_content(&self, digest: Hash256) -> std::result::Result<Vec<u8>, String> {
         self.read(&digest).map_err(|error| error.to_string())
@@ -169,34 +185,48 @@ pub fn seal_all_content_observation(
     let mut observed_trees = 0usize;
     let mut sealed = BTreeSet::<Hash256>::new();
     let mut failed = BTreeSet::<Hash256>::new();
-    let mut total_gaps = 0usize;
     let mut reported_gaps = Vec::<UnsealedContentGap>::new();
     let mut exclusions = BTreeMap::<(RepoPath, GitObjectId), DeclaredContentExclusion>::new();
     let mut non_utf8_paths = BTreeSet::<RepoPath>::new();
+    let mut tree_digests = Vec::<Hash256>::new();
 
     for tree in closure.admitted_trees() {
         observed_trees += 1;
+        // One digest per admitted tree over its exact (path, shape, body)
+        // sequence. Counts alone cannot distinguish two closures that agree on
+        // totals but describe different content, so the observed content itself
+        // is what the fingerprint ends up binding.
+        let mut tree_content = Vec::new();
+        tree_content.extend_from_slice(b"kin.git.sealed-content-observation.tree.v1\0");
         for artifact in tree.artifacts_by_path() {
             observed_entries += 1;
             let path = &artifact.path;
             if path.as_utf8().is_none() {
                 non_utf8_paths.insert(path.clone());
             }
+            append_bytes(&mut tree_content, path.as_bytes());
             let identity = match artifact.entry {
                 TreeEntry::Blob { hash, executable } => {
                     if executable {
                         coverage.executable_file_entries += 1;
+                        tree_content.push(SHAPE_EXECUTABLE_FILE);
                     } else {
                         coverage.regular_file_entries += 1;
+                        tree_content.push(SHAPE_REGULAR_FILE);
                     }
+                    append_bytes(&mut tree_content, hash.as_bytes());
                     hash
                 }
                 TreeEntry::Symlink { target_blob } => {
                     coverage.symlink_entries += 1;
+                    tree_content.push(SHAPE_SYMLINK);
+                    append_bytes(&mut tree_content, target_blob.as_bytes());
                     target_blob
                 }
                 TreeEntry::Gitlink { target } => {
                     coverage.gitlink_entries += 1;
+                    tree_content.push(SHAPE_FOREIGN_GITLINK);
+                    append_bytes(&mut tree_content, target.to_string().as_bytes());
                     exclusions.entry((path.clone(), target)).or_insert_with(|| {
                         DeclaredContentExclusion {
                             path: path.clone(),
@@ -206,11 +236,7 @@ pub fn seal_all_content_observation(
                     continue;
                 }
             };
-            if sealed.contains(&identity) {
-                continue;
-            }
-            if failed.contains(&identity) {
-                total_gaps += 1;
+            if sealed.contains(&identity) || failed.contains(&identity) {
                 continue;
             }
             match seal_body(content, identity) {
@@ -227,7 +253,6 @@ pub fn seal_all_content_observation(
                 }
                 Err(detail) => {
                     failed.insert(identity);
-                    total_gaps += 1;
                     if reported_gaps.len() < MAX_REPORTED_GAPS {
                         reported_gaps.push(UnsealedContentGap {
                             path: path.as_bytes().to_vec(),
@@ -238,11 +263,14 @@ pub fn seal_all_content_observation(
                 }
             }
         }
+        tree_digests.push(digest(&tree_content));
     }
 
-    if total_gaps > 0 {
+    // One gap per distinct unsealed body, so a report that lists every gap it
+    // found is never described as truncated.
+    if !failed.is_empty() {
         return Err(GitError::UnsealedContent {
-            total_gaps,
+            total_gaps: failed.len(),
             reported: reported_gaps,
         });
     }
@@ -256,6 +284,7 @@ pub fn seal_all_content_observation(
         observed_entries,
         &coverage,
         &exclusions,
+        &tree_digests,
     );
     Ok(SealedContentObservation {
         repository_id,
@@ -282,15 +311,23 @@ fn seal_body(
     Ok(body)
 }
 
+/// Bind one observation to a single identity.
+///
+/// The digest covers the observed content itself, not only how much of it there
+/// was: `tree_content_digests` carries the exact (path, shape, body) sequence of
+/// every admitted tree, in admission order. Two observations therefore
+/// fingerprint identically only when they describe the same content, which is
+/// what lets one derivation be cross-checked against another.
 fn fingerprint_observation(
     repository_id: &RepositoryId,
     observed_trees: usize,
     observed_entries: usize,
     coverage: &SealedContentCoverage,
     exclusions: &[DeclaredContentExclusion],
+    tree_content_digests: &[Hash256],
 ) -> Hash256 {
     let mut buffer = Vec::new();
-    buffer.extend_from_slice(b"kin.git.sealed-content-observation.v1\0");
+    buffer.extend_from_slice(b"kin.git.sealed-content-observation.v2\0");
     append_bytes(&mut buffer, repository_id.as_str().as_bytes());
     for count in [
         observed_trees,
@@ -307,6 +344,10 @@ fn fingerprint_observation(
         buffer.extend_from_slice(&(count as u64).to_le_bytes());
     }
     buffer.extend_from_slice(&coverage.sealed_body_bytes.to_le_bytes());
+    buffer.extend_from_slice(&(tree_content_digests.len() as u64).to_le_bytes());
+    for tree_digest in tree_content_digests {
+        buffer.extend_from_slice(tree_digest.as_bytes());
+    }
     buffer.extend_from_slice(&(exclusions.len() as u64).to_le_bytes());
     for exclusion in exclusions {
         append_bytes(&mut buffer, exclusion.path.as_bytes());
@@ -361,6 +402,71 @@ mod tests {
                 return Ok(b"content that is not what the tree recorded".to_vec());
             }
             self.inner.load_sealed_content(digest)
+        }
+    }
+
+    /// An explicit list of admitted trees, so a test can seal a deliberately
+    /// altered closure through the production observation rather than asserting
+    /// against a hand-computed fingerprint.
+    struct ObservedTrees {
+        repository_id: RepositoryId,
+        trees: Vec<ResolvedTree>,
+    }
+
+    impl ObservedTrees {
+        fn from_closure(closure: &impl AdmittedContentClosure) -> Self {
+            Self {
+                repository_id: closure.closure_repository_id().clone(),
+                trees: closure.admitted_trees().into_iter().cloned().collect(),
+            }
+        }
+
+        /// Exchange the bodies of two same-shape entries in the last admitted
+        /// tree, leaving every count and the byte total untouched.
+        fn with_exchanged_head_bodies(&self, left: &[u8], right: &[u8]) -> Self {
+            let left = RepoPath::from_bytes(left.to_vec()).unwrap();
+            let right = RepoPath::from_bytes(right.to_vec()).unwrap();
+            let mut trees = self.trees.clone();
+            let head = trees.last_mut().expect("the closure observes a tree");
+            let left_entry = head
+                .artifact_at_path(&left)
+                .expect("left path exists")
+                .entry;
+            let right_entry = head
+                .artifact_at_path(&right)
+                .expect("right path exists")
+                .entry;
+            assert_ne!(
+                left_entry, right_entry,
+                "exchanging equal entries is not a divergence"
+            );
+            let exchanged = head
+                .clone()
+                .into_artifacts()
+                .map(|mut artifact| {
+                    if artifact.path == left {
+                        artifact.entry = right_entry;
+                    } else if artifact.path == right {
+                        artifact.entry = left_entry;
+                    }
+                    artifact
+                })
+                .collect::<Vec<_>>();
+            *head = ResolvedTree::from_artifacts(exchanged).unwrap();
+            Self {
+                repository_id: self.repository_id.clone(),
+                trees,
+            }
+        }
+    }
+
+    impl AdmittedContentClosure for ObservedTrees {
+        fn closure_repository_id(&self) -> &RepositoryId {
+            &self.repository_id
+        }
+
+        fn admitted_trees(&self) -> Vec<&ResolvedTree> {
+            self.trees.iter().collect()
         }
     }
 
@@ -527,14 +633,23 @@ mod tests {
         };
 
         let error = seal_all_content_observation(&fixture.plan, &source).unwrap_err();
+        let described = error.to_string();
         let GitError::UnsealedContent {
             total_gaps,
             reported,
         } = error
         else {
-            panic!("absent content must fail as an unsealed-content gap, got {error:?}");
+            panic!("absent content must fail as an unsealed-content gap, got {described}");
         };
-        assert!(total_gaps >= 1);
+        // One body is withheld, and the three admitted trees that reference it
+        // are one gap, not three. A count that grew per occurrence would make a
+        // complete report read as a truncated one.
+        assert_eq!(total_gaps, 1);
+        assert_eq!(reported.len(), 1);
+        assert!(
+            !described.contains("further gap"),
+            "a report that lists every gap must not read as truncated: {described}"
+        );
         let gap = reported
             .iter()
             .find(|gap| gap.path == b"assets/raw.bin")
@@ -575,16 +690,58 @@ mod tests {
         let second = seal_all_content_observation(&fixture.plan, &fixture.blob_store).unwrap();
         assert_eq!(second.fingerprint, first.fingerprint);
 
-        let mut drifted = first.clone();
-        drifted.coverage.symlink_entries += 1;
-        let refingerprinted = fingerprint_observation(
-            &drifted.repository_id,
-            drifted.observed_trees,
-            drifted.observed_entries,
-            &drifted.coverage,
-            &drifted.exclusions,
+        // Coverage drift changes the identity with the observed content held
+        // fixed, so the counts are bound as well as the content.
+        let observed_content = [digest(b"one admitted tree")];
+        let baseline = fingerprint_observation(
+            &first.repository_id,
+            first.observed_trees,
+            first.observed_entries,
+            &first.coverage,
+            &first.exclusions,
+            &observed_content,
         );
-        assert_ne!(refingerprinted, first.fingerprint);
+        let mut drifted = first.coverage;
+        drifted.symlink_entries += 1;
+        let refingerprinted = fingerprint_observation(
+            &first.repository_id,
+            first.observed_trees,
+            first.observed_entries,
+            &drifted,
+            &first.exclusions,
+            &observed_content,
+        );
+        assert_ne!(refingerprinted, baseline);
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn seal_separates_identical_counts_that_describe_different_content() {
+        let fixture = ExactFixture::all_shapes();
+        let observed = ObservedTrees::from_closure(&fixture.plan);
+        let diverged = observed.with_exchanged_head_bodies(b"src/lib.rs", b"assets/raw.bin");
+
+        let from_observed = seal_all_content_observation(&observed, &fixture.blob_store).unwrap();
+        let from_diverged = seal_all_content_observation(&diverged, &fixture.blob_store).unwrap();
+
+        // Exchanging two bodies between two paths of the same shape seals the
+        // same distinct bodies, the same byte total, and every same count. Only
+        // a fingerprint that binds which body sits at which path can tell the
+        // two observations apart, so the seal is a content statement rather
+        // than a tally.
+        assert_eq!(from_diverged.observed_trees, from_observed.observed_trees);
+        assert_eq!(
+            from_diverged.observed_entries,
+            from_observed.observed_entries
+        );
+        assert_eq!(from_diverged.coverage, from_observed.coverage);
+        assert_eq!(from_diverged.exclusions, from_observed.exclusions);
+        assert_ne!(from_diverged.fingerprint, from_observed.fingerprint);
+
+        // The unaltered explicit closure still fingerprints exactly like the
+        // plan it was derived from.
+        let from_plan = seal_all_content_observation(&fixture.plan, &fixture.blob_store).unwrap();
+        assert_eq!(from_observed.fingerprint, from_plan.fingerprint);
     }
 
     fn write(repo: &Path, relative: &str, body: &[u8]) {


### PR DESCRIPTION
## Summary

Close the gap the repository-v6 cutover left open. PR #447 stated it plainly:

> **Sealed all-content observation is still pending.** Admission proves the exact reachable closure is admitted atomically. It does not yet prove a sealed all-content observation over that closure.

This adds that proof and enforces it on the exact Git admission path.

## What was actually missing

The object closure was never in question. `capture_lossless_git_repository` reads every reachable object body directly from the physical ODB, verifies each descriptor, persists it to CAS and reads it back; `validate_reachable_closure` then re-proves reachability and rejects anything present but unreachable. That part is sound.

What was missing is a proof over the *trees Kin actually answers from*. `SemanticGitImportPlan::commit_trees` holds the exact `ResolvedTree` for every imported commit, and every `TreeEntry::Blob`/`Symlink` carries a content identity. Nothing walked those trees and proved each body was present and byte-exact in graph-owned storage. The guarantee held only incidentally: `TreeDecoder::blob_entry` happens to use the same `record.body_hash` that `copy_captured_authority` happens to copy. It was never asserted.

That matters because every consumer of `blob_identity()` is a read path (`ref_view`, `repository_commit`, `state`, `session_workspace`, `reconcile`, the MCP handlers). A missing body would have been discovered at answer time, on a runtime query surface, which is exactly the failure mode the graph-first thesis bars.

Two smaller things were silent rather than declared: gitlink targets (correctly not required, since the commit belongs to another repository) were skipped without being recorded, and nothing enumerated coverage by shape, so there was no artifact a dogfood gate could cite.

## What this delivers

**`kin-git/src/sealed_observation.rs`.** Walks every admitted tree (one per imported commit, plus the workspace seed), classifies every entry by exact shape, and proves every content-bearing entry resolves to a byte-exact body the graph owns. Bodies are read through a `SealedContentSource` and re-digested against the identity the tree recorded, so the proof does not depend on the source having verified anything. The filesystem is never consulted.

Coverage is reported, not just checked: entry counts per shape (regular, executable, symlink, gitlink), distinct sealed bodies and bytes, and the counts of empty bodies, opaque (non-UTF-8) bodies, and paths this host cannot name as UTF-8. Opaque and unsupported content is sealed exactly and no entity is fabricated for it.

**The fingerprint binds observed content, not a tally.** Each admitted tree contributes a digest over its exact `(path, shape, body identity)` sequence, and the observation fingerprint folds those digests in admission order alongside the identity and the counts. Two observations therefore fingerprint identically only when they describe the same content at the same paths in the same shapes. This is what makes one derivation cross-checkable against another: a digest over counts and byte totals alone cannot distinguish two closures that agree on totals while describing different content, and this one can.

**Declared exclusions.** A gitlink is recorded as a `ForeignGitlinkTarget` exclusion naming the path and target, rather than skipped. Content Kin deliberately does not own is now visible as a decision instead of an absence.

**Fail-closed with an enumerated gap report.** A body that is absent, unreadable, or does not match its recorded identity produces a `GitError::UnsealedContent` carrying the exact gap count and a bounded per-path sample. A gap is one distinct unsealed body, counted once however many admitted entries reference it, so the count and the sample count the same thing: a truncated report says how many gaps it did not list, and a report that lists every gap it found never reads as truncated. Nothing is ever repaired from disk.

**Sealing against a bare content store is confined to test builds.** `impl SealedContentSource for BlobStore` makes it legal to seal against the ingestion scratch CAS and get a green observation that proves nothing about graph ownership, which is exactly the mistake one test pins against. It is now `#[cfg(test)]`, so a product path cannot compile that source.

**Enforced on the real admission path, at two sites with two different contracts.** `init_from_git` seals against the staged repository store after captured authority is written and before the bootstrap transaction, then re-seals against the published repository inside the publication callback and requires both fingerprints to be identical. The second seal derives the closure from the exact import plan rather than its admitted form, so it proves the two derivations agree on content instead of assuming it. This mirrors the existing two-observation preflight discipline rather than introducing a new one.

The two sites are not interchangeable, and the code and comments now say so:

- **Before publication:** a closure the staged graph cannot answer for prevents publication outright. `.kin` is absent, staging is reaped, nothing is left behind.
- **After publication:** the rename is the linearization point, so this observation detects divergence rather than preventing it. A refusal here leaves the published `.kin` on disk and reports `KinError::RepositoryPublishedButUncertain`, exactly like the post-publication source proof immediately above it. The operator is told to reopen and verify, not to reinitialize.

Both sites fail closed and neither degrades into a filesystem read.

## Verification

Every guard was falsified, not just exercised.

- Replacing the fail-closed check with `if false` makes both fail-closed tests fail, each reporting an `Ok(SealedContentObservation)` where content was missing. Restored, they pass.
- Pointing the admission seal at the ingestion scratch CAS instead of the graph-owned staged store makes `admission_fails_closed_when_a_body_never_reaches_graph_storage` fail. That test therefore pins the thing that matters: the seal reads the graph, not the store the content arrived in.
- Deleting the post-publication fingerprint comparison makes `published_closure_divergence_fails_loud_as_published_but_uncertain` fail. Before this change, deleting that comparison left the whole suite green.
- Dropping the per-tree content digests from the fingerprint, leaving the comparison in place, *also* makes that test fail. The post-publication cross-check can only see the divergence because the fingerprint binds content, so the two properties are one evidence chain rather than two independent claims.
- At the boundary, the same property is pinned without Git: dropping the content digests makes `seal_separates_identical_counts_that_describe_different_content` fail with both fingerprints equal.

New tests:

- `seals_every_content_shape_and_declares_only_foreign_gitlinks`: exact counts over a fixture carrying an opaque binary, an executable bit, a symlink, an empty file, a non-UTF-8 path, and a gitlink. Asserts 21 entries across 3 trees and 7 distinct sealed bodies, so a regression that stops sealing something fails rather than silently narrowing coverage.
- `admitted_and_unadmitted_closures_seal_to_the_same_fingerprint`
- `seal_separates_identical_counts_that_describe_different_content`: exchanges the bodies of two same-shape entries in the last admitted tree. Every shape count, distinct body, and byte total is unchanged, so only a fingerprint bound to content can tell the two observations apart.
- `fails_closed_when_an_opaque_body_is_absent_from_graph_storage`: asserts one withheld body referenced by three admitted trees is one gap, not three, and that the rendered report does not describe itself as truncated.
- `fails_closed_when_a_symlink_target_body_does_not_match_its_identity`
- `seal_is_deterministic_and_binds_the_observed_counts`
- `admitted_repository_owns_every_historical_body_without_the_source_git_repository`: deletes `.git` after `kin init` and proves the repository still answers for every content-bearing path from graph storage alone, including a body reachable from no path in the head tree, which only the admitted closure can account for.
- `admission_fails_closed_when_a_body_never_reaches_graph_storage`: withholds one body from the staged store and proves admission aborts naming the path, with no `.kin` and no staging residue.
- `published_closure_divergence_fails_loud_as_published_but_uncertain`: the published derivation observes two plain files with their bodies exchanged. Both bodies are present and byte-exact, so the seal itself succeeds and only the cross-check can refuse. Asserts the refusal names the divergence, that it is `RepositoryPublishedButUncertain`, and that the published `.kin` is retained.
- `a_body_lost_across_publication_is_refused_before_the_published_seal_reads_it`: removes one body from the published store between the two observations and pins which layer refuses.

That last test records a structural fact worth stating, because it contradicts the obvious way to test this site. A physically defective published body never reaches the published seal: opening the published repository's authority runs `load_unbounded_body` over every body the admitted trees reference, which verifies presence *and* re-digests the bytes, so it refuses first. Corrupting or removing a published body therefore cannot falsify the seal. It falsifies graph-authority verification, which also fails loud as published-but-uncertain with `.kin` retained. The published seal's own detection power is closure and derivation divergence, which is what `published_closure_divergence_fails_loud_as_published_but_uncertain` injects.

The withholding and divergence hooks use the existing thread-local injection convention already used in `lossless.rs`.

Two smaller corrections in the same pass: `PreparedRepositoryInit::load_source_blob` had no production caller and a doc comment claiming one, so the staged `SealedContentSource` impl now routes through it rather than reaching past it into `GraphOwnedContent`; and the `init_from_git` docstring no longer says publication is all-or-nothing without qualification.

**Windows.** Exact Git admission is unix-only, so every new test is too, which would have left their helpers as dead code on Windows, and the Windows job runs `cargo test -p kin-git --lib` under `-D warnings`. Both the kin-git test module and the kin-core injection helpers are gated `#[cfg(all(test, unix))]`. Falsified by cross-checking `x86_64-pc-windows-msvc`: reverting the kin-git module gate to plain `#[cfg(test)]` produces 12 hard errors (5 unused imports, `WithholdingSource` never constructed, 6 helpers never used); with the gate, `cargo check --target x86_64-pc-windows-msvc --all-targets -p kin-git` is clean.

The equivalent cross-check for kin-core cannot run on a macOS host: its tree-sitter grammars are C and need the Windows SDK headers to cross-compile. Its gating follows the same pattern and is verified by hosted CI, not locally.

## What this does not claim

- **No performance claim.** The seal walks every entry of every admitted tree and re-digests every distinct body, and it runs twice per `kin init`. Bodies dedupe by identity so IO is bounded by distinct content rather than commits times tree size, but only small fixtures were exercised. PR #447 already flags that admission-time enrichment is unmeasured on brownfield repositories; this adds a second unmeasured cost on the same path. Tracked in FIR-1591, and no admission performance claim should be made until it is measured.
- **The post-publication seal is not a second gate.** Publication is a rename of the staged directory, so the published store holds the bytes the staged seal already proved. Its marginal detection power over the staged seal is derivation divergence and post-rename tampering caught before first use, not independent confirmation of the same bytes by a second route. It cannot unpublish, and it is not claimed to.
- **The seal is enforced, not persisted.** The fingerprint lives for the duration of admission and in the `kin init` log line. Binding it into repository authority needs a `kin-model` change and a registry publish, which is out of scope for one lane. Tracked in FIR-1589. Until that lands, the observation is proven at admission but not independently re-verifiable from the repository alone.
- **Git admission only.** Repository transfer receive is a separate admission surface. It does verify source-head tree bodies and the transferred closure's delta bodies, so it is not unchecked, but it does not run this observation and produces no comparable evidence. Tracked in FIR-1590.
- **No dogfood-readiness claim.** This closes one of the two P0s that bar it. KinDB per-repository identity pinning is the other and is unlanded.
- **Fresh bootstrap is trivially satisfied.** A non-Git `kin init` admits no content, so the seal has nothing to prove there. That is a property of the input, not additional coverage.

## Dependencies

None. No `Cargo.toml`, `Cargo.lock`, or dependency changes.

Closes FIR-1585.
