### PR TITLE
Make every MCP daemon forward survive repo-daemon idle shutdown

### DIFF
--- a/crates/kin-mcp/src/daemon_delegate.rs
+++ b/crates/kin-mcp/src/daemon_delegate.rs
@@ -1024,17 +1024,35 @@ async fn forward_graph_status(
         with_session_header(with_auth(request), arguments)
     })
     .await?;
-    let summary = value.get("summary").unwrap_or(&value);
+    text_result_from_value(project_graph_status(&value)?).map(Some)
+}
+
+/// Project the daemon's status response into the coverage fields MCP agents
+/// need.
+///
+/// Rejects an empty body loudly. The shared request helper reads one as `Null`
+/// so the mutations that answer `204 No Content` work, but every count here
+/// falls back to 0, so letting `Null` through would render a missing answer as
+/// a real reading of an empty graph. A status surface that reports zeros it did
+/// not measure is worse than one that fails.
+fn project_graph_status(value: &serde_json::Value) -> Result<serde_json::Value, String> {
+    if value.is_null() {
+        return Err(
+            "daemon graph status returned an empty body; refusing to report zero counts as \
+             graph truth"
+                .to_string(),
+        );
+    }
+    let summary = value.get("summary").unwrap_or(value);
     let field_u64 = |key: &str| summary.get(key).and_then(serde_json::Value::as_u64);
-    let result = serde_json::json!({
+    Ok(serde_json::json!({
         "entity_count": field_u64("entities").unwrap_or(0),
         "embeddings_indexed": field_u64("embeddings_indexed").unwrap_or(0),
         "embeddings_total": field_u64("embeddings_total").unwrap_or(0),
         "embeddings_pending": field_u64("embeddings_pending").unwrap_or(0),
         "authority": "repo-daemon",
         "note": "Embedding coverage is computed from the daemon-owned live graph."
-    });
-    text_result_from_value(result).map(Some)
+    }))
 }
 
 pub fn daemon_unavailable_tool_result(name: &str) -> ToolCallResult {
@@ -1450,6 +1468,31 @@ mod tests {
             "expected a parse failure, got: {err:?}"
         );
         handle.abort();
+    }
+
+    /// The empty-body allowance exists for the 204 mutations. It must not reach
+    /// the status projection, where every count defaults to 0 and an absent
+    /// answer would render as a genuine reading of an empty graph.
+    #[test]
+    fn graph_status_refuses_to_report_an_empty_body_as_zero_counts() {
+        let err = project_graph_status(&serde_json::Value::Null)
+            .expect_err("an empty status body must fail loudly");
+        assert!(err.contains("empty body"), "{err}");
+        assert!(err.contains("refusing"), "{err}");
+    }
+
+    #[test]
+    fn graph_status_projects_summary_counts() {
+        let value = serde_json::json!({
+            "summary": { "entities": 42, "embeddings_indexed": 7, "embeddings_total": 10 }
+        });
+        let projected = project_graph_status(&value).expect("a real body must project");
+        assert_eq!(projected["entity_count"], 42);
+        assert_eq!(projected["embeddings_indexed"], 7);
+        assert_eq!(projected["embeddings_total"], 10);
+        // Absent within a present body is still 0: that is a real reading.
+        assert_eq!(projected["embeddings_pending"], 0);
+        assert_eq!(projected["authority"], "repo-daemon");
     }
 
     /// An HTTP error from a live daemon must classify as `DaemonError`, never

--- a/crates/kin-mcp/src/daemon_delegate.rs
+++ b/crates/kin-mcp/src/daemon_delegate.rs
@@ -798,9 +798,12 @@ async fn forward_mcp_with_seam(
     seam: &impl DaemonCallSeam,
     daemon_url: &str,
 ) -> Result<Option<ToolCallResult>, String> {
-    attempt_with_revival(&format!("tool {name}"), daemon_url, seam, |base| async move {
-        seam.call_tool(&base, name, args).await
-    })
+    attempt_with_revival(
+        &format!("tool {name}"),
+        daemon_url,
+        seam,
+        |base| async move { seam.call_tool(&base, name, args).await },
+    )
     .await
 }
 
@@ -852,7 +855,9 @@ where
                 )));
             }
             let body = resp.text().await.map_err(|e| {
-                DaemonCallError::DaemonError(format!("daemon {operation} response read failed: {e}"))
+                DaemonCallError::DaemonError(format!(
+                    "daemon {operation} response read failed: {e}"
+                ))
             })?;
             if body.trim().is_empty() {
                 return Ok(serde_json::Value::Null);
@@ -1496,7 +1501,10 @@ mod tests {
     /// misread the failure.
     #[tokio::test]
     async fn live_daemon_errors_are_not_the_daemon_exited_class() {
-        let seam = FakeSeam::new(vec![Err(daemon_err())], Ok("http://127.0.0.1:9".to_string()));
+        let seam = FakeSeam::new(
+            vec![Err(daemon_err())],
+            Ok("http://127.0.0.1:9".to_string()),
+        );
         let err = forward_mcp_with_seam("tool", &HashMap::new(), &seam, "http://127.0.0.1:4219")
             .await
             .unwrap_err();
@@ -1553,7 +1561,9 @@ mod tests {
 
         // No .kin discovery, no binary lookup, no spawn: the healthy override
         // short-circuits before any of that.
-        let revived = revive_mcp_daemon().await.expect("must reuse the live daemon");
+        let revived = revive_mcp_daemon()
+            .await
+            .expect("must reuse the live daemon");
         assert_eq!(revived, already_revived);
 
         clear_daemon_url_override();

--- a/crates/kin-mcp/src/daemon_delegate.rs
+++ b/crates/kin-mcp/src/daemon_delegate.rs
@@ -1234,11 +1234,17 @@ pub async fn forward_release_intent(
 pub async fn forward_check_traffic(
     scope_strings: &[String],
 ) -> Result<Option<serde_json::Value>, String> {
-    let Some(base) = daemon_base_url() else {
+    if daemon_base_url().is_none() {
         return Ok(None);
-    };
+    }
     let mut reports = Vec::new();
     for scope in scope_strings {
+        // Re-resolve per scope: if an earlier scope revived the daemon, the
+        // remaining ones must address the new URL directly instead of each
+        // rediscovering the dead one through the whole retry-then-revive path.
+        let Some(base) = daemon_base_url() else {
+            return Ok(None);
+        };
         let encoded = scope.replace(':', "%3A");
         let value = daemon_json_request("check traffic", &base, |client, base| {
             with_auth(client.get(format!("{base}/traffic/{encoded}")))

--- a/crates/kin-mcp/src/daemon_delegate.rs
+++ b/crates/kin-mcp/src/daemon_delegate.rs
@@ -44,6 +44,32 @@ pub(crate) fn clear_daemon_url_override() {
     }
 }
 
+/// Serializes daemon revival so concurrent failing calls start one daemon, not
+/// one each. See [`revive_mcp_daemon`].
+static REVIVAL_LOCK: tokio::sync::Mutex<()> = tokio::sync::Mutex::const_new(());
+
+/// The revival-path daemon URL currently installed, if any.
+fn current_daemon_url_override() -> Option<String> {
+    DAEMON_URL_OVERRIDE.lock().ok()?.clone()
+}
+
+/// Does a daemon answer `/health` at `base` right now?
+///
+/// Deliberately does not use the cached delegate client: this runs on the
+/// revival path to decide whether a daemon another caller just started is
+/// usable, so it wants a short, self-contained probe rather than the delegate's
+/// 60 s request budget.
+async fn daemon_is_healthy(base: &str) -> bool {
+    let Ok(probe) = reqwest::Client::builder()
+        .connect_timeout(Duration::from_millis(300))
+        .timeout(Duration::from_secs(3))
+        .build()
+    else {
+        return false;
+    };
+    matches!(probe.get(format!("{base}/health")).send().await, Ok(resp) if resp.status().is_success())
+}
+
 /// Base URL for the daemon HTTP API.
 ///
 /// Checks the revival-path override first; falls back to the `KIN_DAEMON_URL`
@@ -69,6 +95,42 @@ fn daemon_base_url() -> Option<String> {
 /// an agent session is truly abandoned.  An explicit
 /// `KIN_DAEMON_IDLE_TIMEOUT_SECS` env var always overrides this at runtime.
 const MCP_IDLE_TIMEOUT_SECS: &str = "1800";
+
+/// Idle timeout to inject into a revival-spawned daemon, or `None` to inject
+/// nothing.
+///
+/// Mirrors `kin_cli::daemon_client::resolve_idle_timeout_env` and
+/// `kin_daemon::lifecycle::resolve_idle_timeout_env`: a user-set
+/// `KIN_DAEMON_IDLE_TIMEOUT_SECS` propagates to the child on its own and must
+/// never be overwritten, so this returns `None` in that case. Factored out of
+/// the spawn path so the precedence is unit-testable without spawning a
+/// process.
+fn mcp_spawn_idle_timeout(user_env_is_set: bool) -> Option<&'static str> {
+    (!user_env_is_set).then_some(MCP_IDLE_TIMEOUT_SECS)
+}
+
+// ── Unrecoverable-daemon error class ────────────────────────────────────
+
+/// Prefix marking the "the repo daemon is gone and could not be brought back"
+/// error class.
+///
+/// Every delegate failure that leaves the session unable to reach a daemon is
+/// tagged with this, so an agent (or a wrapping client) can tell an
+/// unrecoverable lifecycle failure apart from an ordinary tool error such as a
+/// bad argument or an HTTP 4xx from a live daemon. The two are handled
+/// completely differently: the first needs an operator restart, the second
+/// needs a corrected call.
+pub const DAEMON_EXITED_RESTART_REQUIRED: &str = "repo daemon exited; restart required";
+
+/// Does this delegate error mean the repo daemon is gone rather than that the
+/// call itself was rejected?
+///
+/// Callers that retry, degrade, or prompt for an operator restart need the two
+/// apart: only this class is fixed by restarting a daemon, and restarting one
+/// over an ordinary tool error is wasted work.
+pub fn is_daemon_exited_error(message: &str) -> bool {
+    message.starts_with(DAEMON_EXITED_RESTART_REQUIRED)
+}
 
 /// Bearer token the daemon expects on non-public routes.
 ///
@@ -418,6 +480,30 @@ pub(crate) enum DaemonCallError {
     DaemonError(String),
 }
 
+/// Classify a `reqwest` send failure.
+///
+/// Connect/timeout failures mean the request never reached a live daemon and
+/// warrant the retry-then-revive path; everything else is a protocol-level
+/// failure from a daemon that did respond.
+fn classify_send_error(operation: &str, error: reqwest::Error) -> DaemonCallError {
+    if error.is_connect() || error.is_timeout() {
+        DaemonCallError::ConnectionLost(error.to_string())
+    } else {
+        DaemonCallError::DaemonError(format!("daemon {operation} failed: {error}"))
+    }
+}
+
+/// Ability to restart a dead repo daemon and report its new base URL.
+///
+/// Split from [`DaemonCallSeam`] so every forwarded request — session, intent,
+/// traffic, status, and MCP tool calls alike — shares one revival policy
+/// through [`attempt_with_revival`], rather than revival being a property of
+/// the tool-call path only.
+pub(crate) trait DaemonReviver: Sync {
+    /// Attempt to revive a dead daemon and return its new base URL.
+    async fn revive(&self) -> Result<String, String>;
+}
+
 /// Abstraction over daemon communication and revival used by
 /// [`forward_mcp_with_seam`].
 ///
@@ -425,12 +511,12 @@ pub(crate) enum DaemonCallError {
 /// and can spawn a new daemon process via `std::process::Command`.  Tests
 /// inject a controlled stub to exercise the revival state machine without
 /// touching the network or spawning any processes.
-pub(crate) trait DaemonCallSeam: Sync {
+pub(crate) trait DaemonCallSeam: DaemonReviver {
     /// Attempt a single MCP tool call against the daemon at `base`.
     ///
     /// Returns:
     /// - `Ok(Some(result))` on success.
-    /// - `Ok(None)` when the daemon URL is not configured (graceful no-op).
+    /// - `Ok(None)` when no HTTP client can be built at all (graceful no-op).
     /// - `Err(ConnectionLost(_))` for transport failures — warrants revival.
     /// - `Err(DaemonError(_))` for HTTP/protocol failures — no revival.
     async fn call_tool(
@@ -439,13 +525,16 @@ pub(crate) trait DaemonCallSeam: Sync {
         name: &str,
         args: &HashMap<String, serde_json::Value>,
     ) -> Result<Option<ToolCallResult>, DaemonCallError>;
-
-    /// Attempt to revive a dead daemon and return its new base URL.
-    async fn revive(&self) -> Result<String, String>;
 }
 
 /// Production implementation of [`DaemonCallSeam`].
 pub(crate) struct RealDaemonSeam;
+
+impl DaemonReviver for RealDaemonSeam {
+    async fn revive(&self) -> Result<String, String> {
+        revive_mcp_daemon().await
+    }
+}
 
 impl DaemonCallSeam for RealDaemonSeam {
     async fn call_tool(
@@ -461,13 +550,10 @@ impl DaemonCallSeam for RealDaemonSeam {
             .post(format!("{}/mcp/tools/call", base))
             .json(&serde_json::json!({ "name": name, "arguments": args }));
         let request = with_session_header(with_auth(request), args);
-        let resp = request.send().await.map_err(|e| {
-            if e.is_connect() || e.is_timeout() {
-                DaemonCallError::ConnectionLost(e.to_string())
-            } else {
-                DaemonCallError::DaemonError(format!("daemon MCP tool call failed: {e}"))
-            }
-        })?;
+        let resp = request
+            .send()
+            .await
+            .map_err(|e| classify_send_error("MCP tool call", e))?;
         if !resp.status().is_success() {
             return Err(DaemonCallError::DaemonError(format!(
                 "daemon MCP tool call failed: HTTP {}",
@@ -478,10 +564,6 @@ impl DaemonCallSeam for RealDaemonSeam {
             DaemonCallError::DaemonError(format!("daemon MCP tool call response parse failed: {e}"))
         })?;
         Ok(Some(result))
-    }
-
-    async fn revive(&self) -> Result<String, String> {
-        revive_mcp_daemon().await
     }
 }
 
@@ -543,6 +625,21 @@ fn find_mcp_free_port() -> Option<u16> {
 /// base URL into [`DAEMON_URL_OVERRIDE`] so all subsequent delegate calls
 /// are routed to the revived daemon automatically.
 async fn revive_mcp_daemon() -> Result<String, String> {
+    // Serialize revival across concurrent tool calls. Every forwarded request
+    // now reaches this path, so a dead daemon can be observed by several calls
+    // at once; without this each would spawn its own daemon and all but one
+    // would lose the race for the repo lock and exit, turning one recoverable
+    // outage into a burst of doomed processes.
+    let _revival_guard = REVIVAL_LOCK.lock().await;
+    // A concurrent caller may have already revived the daemon while we waited
+    // for the guard. Reuse a healthy one rather than starting a second.
+    if let Some(existing) = current_daemon_url_override() {
+        if daemon_is_healthy(&existing).await {
+            tracing::debug!(url = %existing, "MCP revival: reusing daemon revived concurrently");
+            return Ok(existing);
+        }
+    }
+
     let kin_dir =
         discover_kin_dir().ok_or_else(|| "MCP revival: cannot find .kin directory".to_string())?;
     let working_dir = kin_dir
@@ -572,8 +669,10 @@ async fn revive_mcp_daemon() -> Result<String, String> {
     cmd.stderr(std::process::Stdio::null());
     // Inject the MCP-path idle timeout unless the user has an explicit
     // override in the environment — user's value always wins.
-    if std::env::var_os("KIN_DAEMON_IDLE_TIMEOUT_SECS").is_none() {
-        cmd.env("KIN_DAEMON_IDLE_TIMEOUT_SECS", MCP_IDLE_TIMEOUT_SECS);
+    if let Some(timeout) =
+        mcp_spawn_idle_timeout(std::env::var_os("KIN_DAEMON_IDLE_TIMEOUT_SECS").is_some())
+    {
+        cmd.env("KIN_DAEMON_IDLE_TIMEOUT_SECS", timeout);
     }
     #[cfg(unix)]
     unsafe {
@@ -617,36 +716,46 @@ async fn revive_mcp_daemon() -> Result<String, String> {
 
 // ── Seam-based MCP tool dispatch ────────────────────────────────────────
 
-/// Core MCP-tool-call dispatch with one-shot daemon revival.
+/// Run one daemon request with one-shot revival, shared by every forwarded
+/// call.
 ///
 /// On a connection-class failure ([`DaemonCallError::ConnectionLost`]) the
-/// call is retried once against the **same** URL before revival is considered:
-/// a transport error is just as often a stale kept-alive socket or a request
-/// landing inside the daemon's post-boot stall as it is a dead daemon, and
-/// revival against a live daemon cannot succeed (the repo lock is held), so
-/// misclassifying costs the whole call. Only when the same-URL retry also
-/// fails is the seam's `revive` method called **exactly once**. If revival
-/// succeeds the original request is retried against the new URL.
-/// Non-connection failures bypass retry and revival entirely.
+/// request is retried once against the **same** URL before revival is
+/// considered: a transport error is just as often a stale kept-alive socket or
+/// a request landing inside the daemon's post-boot stall as it is a dead
+/// daemon, and revival against a live daemon cannot succeed (the repo lock is
+/// held), so misclassifying costs the whole call. Only when the same-URL retry
+/// also fails is `revive` called **exactly once**. If revival succeeds the
+/// request is retried against the new URL.  Non-connection failures bypass
+/// retry and revival entirely.
+///
+/// `attempt` receives the base URL to use, so the post-revival retry addresses
+/// the new daemon rather than the dead one.
 ///
 /// Invariants:
 /// - `revive` is called at most once per invocation.
-/// - `call_tool` is called at most three times (attempt, same-URL retry,
+/// - `attempt` is called at most three times (attempt, same-URL retry,
 ///   post-revival retry).
 /// - Non-connection errors are never silently discarded.
-async fn forward_mcp_with_seam(
-    name: &str,
-    args: &HashMap<String, serde_json::Value>,
-    seam: &impl DaemonCallSeam,
+/// - Every failure that ends with no reachable daemon is tagged
+///   [`DAEMON_EXITED_RESTART_REQUIRED`].
+async fn attempt_with_revival<T, A, Fut>(
+    operation: &str,
     daemon_url: &str,
-) -> Result<Option<ToolCallResult>, String> {
-    let first_err = match seam.call_tool(daemon_url, name, args).await {
+    reviver: &impl DaemonReviver,
+    attempt: A,
+) -> Result<T, String>
+where
+    A: Fn(String) -> Fut,
+    Fut: std::future::Future<Output = Result<T, DaemonCallError>>,
+{
+    let first_err = match attempt(daemon_url.to_string()).await {
         Ok(result) => return Ok(result),
         Err(DaemonCallError::DaemonError(e)) => return Err(e),
         Err(DaemonCallError::ConnectionLost(e)) => e,
     };
     tokio::time::sleep(Duration::from_millis(250)).await;
-    match seam.call_tool(daemon_url, name, args).await {
+    match attempt(daemon_url.to_string()).await {
         Ok(result) => Ok(result),
         Err(DaemonCallError::DaemonError(e)) => Err(e),
         Err(DaemonCallError::ConnectionLost(retry_err)) => {
@@ -654,15 +763,15 @@ async fn forward_mcp_with_seam(
             // dead-daemon read is earned. Single revival attempt before
             // giving up.
             let first_err = format!("{first_err}; retry: {retry_err}");
-            match seam.revive().await {
+            match reviver.revive().await {
                 Err(revive_err) => Err(format!(
-                    "tool {name}: daemon at {daemon_url} is not responding \
-                     ({first_err}); revival failed: {revive_err}. \
+                    "{DAEMON_EXITED_RESTART_REQUIRED}: {operation}: daemon at {daemon_url} \
+                     is not responding ({first_err}); revival failed: {revive_err}. \
                      Restart `kin mcp start` to recover."
                 )),
                 Ok(new_url) => {
                     // Retry exactly once on the post-revival URL.
-                    match seam.call_tool(&new_url, name, args).await {
+                    match attempt(new_url.clone()).await {
                         Ok(result) => Ok(result),
                         Err(e) => {
                             let detail = match e {
@@ -670,8 +779,8 @@ async fn forward_mcp_with_seam(
                                 | DaemonCallError::DaemonError(s) => s,
                             };
                             Err(format!(
-                                "tool {name}: daemon was revived at {new_url} but \
-                                 the retry still failed: {detail}. \
+                                "{DAEMON_EXITED_RESTART_REQUIRED}: {operation}: daemon was \
+                                 revived at {new_url} but the retry still failed: {detail}. \
                                  Check `kin daemon status`."
                             ))
                         }
@@ -682,6 +791,19 @@ async fn forward_mcp_with_seam(
     }
 }
 
+/// Core MCP-tool-call dispatch, layered on [`attempt_with_revival`].
+async fn forward_mcp_with_seam(
+    name: &str,
+    args: &HashMap<String, serde_json::Value>,
+    seam: &impl DaemonCallSeam,
+    daemon_url: &str,
+) -> Result<Option<ToolCallResult>, String> {
+    attempt_with_revival(&format!("tool {name}"), daemon_url, seam, |base| async move {
+        seam.call_tool(&base, name, args).await
+    })
+    .await
+}
+
 async fn forward_mcp_tool_call(
     name: &str,
     arguments: &HashMap<String, serde_json::Value>,
@@ -690,6 +812,59 @@ async fn forward_mcp_tool_call(
         return Ok(None);
     };
     forward_mcp_with_seam(name, arguments, &RealDaemonSeam, &base).await
+}
+
+/// Issue a JSON daemon request under the shared retry/revive policy.
+///
+/// `build` is invoked once per attempt with the base URL for **that** attempt,
+/// so the post-revival retry addresses the revived daemon rather than the dead
+/// one. This is the single entry point for the session, intent, traffic, and
+/// status forwards: before it existed each of them issued a bare one-shot
+/// request, so an idle-shutdown between two tool calls took every one of them
+/// down permanently while `/mcp/tools/call` recovered.
+///
+/// An empty response body (the daemon answers some mutations with `204 No
+/// Content`) parses as `Value::Null` rather than failing.
+async fn daemon_json_request<B>(
+    operation: &str,
+    base: &str,
+    build: B,
+) -> Result<serde_json::Value, String>
+where
+    B: Fn(&reqwest::Client, &str) -> reqwest::RequestBuilder,
+{
+    attempt_with_revival(operation, base, &RealDaemonSeam, |url| {
+        let build = &build;
+        async move {
+            let Some(client) = daemon_client().await else {
+                return Err(DaemonCallError::DaemonError(format!(
+                    "daemon {operation} failed: could not build an HTTP client"
+                )));
+            };
+            let resp = build(&client, &url)
+                .send()
+                .await
+                .map_err(|e| classify_send_error(operation, e))?;
+            if !resp.status().is_success() {
+                return Err(DaemonCallError::DaemonError(format!(
+                    "daemon {operation} failed: HTTP {}",
+                    resp.status()
+                )));
+            }
+            let body = resp.text().await.map_err(|e| {
+                DaemonCallError::DaemonError(format!("daemon {operation} response read failed: {e}"))
+            })?;
+            if body.trim().is_empty() {
+                return Ok(serde_json::Value::Null);
+            }
+            serde_json::from_str(&body).map_err(|e| {
+                DaemonCallError::DaemonError(format!(
+                    "daemon {operation} response parse failed: {e}"
+                ))
+            })
+        }
+    })
+    .await
 }
 
 /// Forward any product-mode MCP tool call to the daemon-owned implementation.
@@ -821,30 +996,16 @@ fn validate_stage_arguments(arguments: &HashMap<String, serde_json::Value>) -> R
 async fn forward_graph_status(
     arguments: &HashMap<String, serde_json::Value>,
 ) -> Result<Option<ToolCallResult>, String> {
-    let Some(client) = daemon_client().await else {
-        return Ok(None);
-    };
     let Some(base) = daemon_base_url() else {
         return Ok(None);
     };
-    let request = client
-        .post(format!("{}/commands/status", base))
-        .json(&serde_json::json!({ "json": false }));
-    let request = with_session_header(with_auth(request), arguments);
-    let resp = request
-        .send()
-        .await
-        .map_err(|e| format!("daemon graph status failed: {e}"))?;
-    if !resp.status().is_success() {
-        return Err(format!(
-            "daemon graph status failed: HTTP {}",
-            resp.status()
-        ));
-    }
-    let value: serde_json::Value = resp
-        .json()
-        .await
-        .map_err(|e| format!("daemon graph status response parse failed: {e}"))?;
+    let value = daemon_json_request("graph status", &base, |client, base| {
+        let request = client
+            .post(format!("{base}/commands/status"))
+            .json(&serde_json::json!({ "json": false }));
+        with_session_header(with_auth(request), arguments)
+    })
+    .await?;
     let summary = value.get("summary").unwrap_or(&value);
     let field_u64 = |key: &str| summary.get(key).and_then(serde_json::Value::as_u64);
     let result = serde_json::json!({
@@ -903,8 +1064,18 @@ pub async fn fetch_health_snapshot() -> Option<serde_json::Value> {
     resp.json::<serde_json::Value>().await.ok()
 }
 
-/// Get or initialize the daemon client. Returns `None` if the daemon is not
-/// reachable right now; daemon-required callers turn that into a hard error.
+/// Get or initialize the daemon HTTP client. Returns `None` only when a client
+/// cannot be constructed at all.
+///
+/// This deliberately does **not** probe the daemon for liveness. It used to:
+/// a `/health` probe gated every call and a failed probe returned `None`, which
+/// callers read as "no daemon configured" and turned into a graceful no-op.
+/// That silently swallowed the exact signal the revival path exists to act on,
+/// so a daemon that idled out was never restarted and the whole MCP session
+/// stayed dead. Liveness now belongs to the request itself: a transport failure
+/// classifies as [`DaemonCallError::ConnectionLost`] and drives retry and
+/// revival, while "no daemon configured" is a `None` from [`daemon_base_url`]
+/// alone. The probe was also a wasted round-trip in front of every call.
 pub async fn daemon_client() -> Option<reqwest::Client> {
     if let Some(client) = DAEMON_CLIENT.get() {
         return Some(client.clone());
@@ -935,28 +1106,8 @@ pub async fn daemon_client() -> Option<reqwest::Client> {
         .build()
         .ok()?;
 
-    let Some(base) = daemon_base_url() else {
-        debug!("daemon delegate: KIN_DAEMON_URL is not set");
-        return None;
-    };
-    let probe_url = format!("{}/health", base);
-    let ok = client
-        .get(&probe_url)
-        .send()
-        .await
-        .ok()?
-        .status()
-        .is_success();
-
-    if ok {
-        debug!("daemon delegate: connected to {}", base);
-        let cached = client.clone();
-        let _ = DAEMON_CLIENT.set(cached.clone());
-        Some(cached)
-    } else {
-        debug!("daemon delegate: daemon not reachable");
-        None
-    }
+    let _ = DAEMON_CLIENT.set(client.clone());
+    Some(client)
 }
 
 /// Forward a session start to the daemon.
@@ -970,9 +1121,6 @@ pub async fn forward_session_start(
     cwd: &str,
     capabilities: &SessionCapabilities,
 ) -> Result<Option<serde_json::Value>, String> {
-    let Some(client) = daemon_client().await else {
-        return Ok(None);
-    };
     let Some(base) = daemon_base_url() else {
         return Ok(None);
     };
@@ -986,20 +1134,10 @@ pub async fn forward_session_start(
     if let Some(p) = pid {
         body["pid"] = serde_json::json!(p);
     }
-    let resp = with_auth(client.post(format!("{}/session", base)).json(&body))
-        .send()
-        .await
-        .map_err(|e| format!("daemon session start failed: {e}"))?;
-    if !resp.status().is_success() {
-        return Err(format!(
-            "daemon session start failed: HTTP {}",
-            resp.status()
-        ));
-    }
-    let value = resp
-        .json()
-        .await
-        .map_err(|e| format!("daemon session start response parse failed: {e}"))?;
+    let value = daemon_json_request("session start", &base, |client, base| {
+        with_auth(client.post(format!("{base}/session")).json(&body))
+    })
+    .await?;
     Ok(Some(value))
 }
 
@@ -1007,45 +1145,25 @@ pub async fn forward_session_start(
 pub async fn forward_session_heartbeat(
     session_id: &str,
 ) -> Result<Option<serde_json::Value>, String> {
-    let Some(client) = daemon_client().await else {
-        return Ok(None);
-    };
     let Some(base) = daemon_base_url() else {
         return Ok(None);
     };
-    let resp = with_auth(client.post(format!("{}/session/{}/heartbeat", base, session_id)))
-        .send()
-        .await
-        .map_err(|e| format!("daemon heartbeat failed: {e}"))?;
-    if !resp.status().is_success() {
-        return Err(format!("daemon heartbeat failed: HTTP {}", resp.status()));
-    }
-    let value = resp
-        .json()
-        .await
-        .map_err(|e| format!("daemon heartbeat response parse failed: {e}"))?;
+    let value = daemon_json_request("heartbeat", &base, |client, base| {
+        with_auth(client.post(format!("{base}/session/{session_id}/heartbeat")))
+    })
+    .await?;
     Ok(Some(value))
 }
 
 /// Forward a session end to the daemon.
 pub async fn forward_session_end(session_id: &str) -> Result<Option<serde_json::Value>, String> {
-    let Some(client) = daemon_client().await else {
-        return Ok(None);
-    };
     let Some(base) = daemon_base_url() else {
         return Ok(None);
     };
-    let resp = with_auth(client.delete(format!("{}/session/{}", base, session_id)))
-        .send()
-        .await
-        .map_err(|e| format!("daemon session end failed: {e}"))?;
-    if !resp.status().is_success() {
-        return Err(format!("daemon session end failed: HTTP {}", resp.status()));
-    }
-    let value = resp
-        .json()
-        .await
-        .map_err(|e| format!("daemon session end response parse failed: {e}"))?;
+    let value = daemon_json_request("session end", &base, |client, base| {
+        with_auth(client.delete(format!("{base}/session/{session_id}")))
+    })
+    .await?;
     Ok(Some(value))
 }
 
@@ -1057,9 +1175,6 @@ pub async fn forward_register_intent(
     task_description: &str,
     expires_at: Option<&str>,
 ) -> Result<Option<serde_json::Value>, String> {
-    let Some(client) = daemon_client().await else {
-        return Ok(None);
-    };
     let Some(base) = daemon_base_url() else {
         return Ok(None);
     };
@@ -1076,20 +1191,10 @@ pub async fn forward_register_intent(
     } else {
         body
     };
-    let resp = with_auth(client.post(format!("{}/intent/register", base)).json(&body))
-        .send()
-        .await
-        .map_err(|e| format!("daemon intent register failed: {e}"))?;
-    if !resp.status().is_success() {
-        return Err(format!(
-            "daemon intent register failed: HTTP {}",
-            resp.status()
-        ));
-    }
-    let value = resp
-        .json()
-        .await
-        .map_err(|e| format!("daemon intent register response parse failed: {e}"))?;
+    let value = daemon_json_request("intent register", &base, |client, base| {
+        with_auth(client.post(format!("{base}/intent/register")).json(&body))
+    })
+    .await?;
     Ok(Some(value))
 }
 
@@ -1101,22 +1206,14 @@ pub async fn forward_release_intent(
     session_id: &str,
     intent_id: &str,
 ) -> Result<Option<serde_json::Value>, String> {
-    let Some(client) = daemon_client().await else {
-        return Ok(None);
-    };
     let Some(base) = daemon_base_url() else {
         return Ok(None);
     };
-    let resp = with_auth(client.delete(format!("{}/intent/{}", base, intent_id)))
-        .send()
-        .await
-        .map_err(|e| format!("daemon release intent failed: {e}"))?;
-    if !resp.status().is_success() {
-        return Err(format!(
-            "daemon release intent failed: HTTP {}",
-            resp.status()
-        ));
-    }
+    // The 204 body is empty, so the shared request helper yields `Null` here.
+    daemon_json_request("release intent", &base, |client, base| {
+        with_auth(client.delete(format!("{base}/intent/{intent_id}")))
+    })
+    .await?;
     // Daemon returns 204 No Content; synthesize a result for the MCP handler.
     Ok(Some(serde_json::json!({
         "intent_id": intent_id,
@@ -1132,29 +1229,16 @@ pub async fn forward_release_intent(
 pub async fn forward_check_traffic(
     scope_strings: &[String],
 ) -> Result<Option<serde_json::Value>, String> {
-    let Some(client) = daemon_client().await else {
-        return Ok(None);
-    };
     let Some(base) = daemon_base_url() else {
         return Ok(None);
     };
     let mut reports = Vec::new();
     for scope in scope_strings {
         let encoded = scope.replace(':', "%3A");
-        let resp = with_auth(client.get(format!("{}/traffic/{}", base, encoded)))
-            .send()
-            .await
-            .map_err(|e| format!("daemon check traffic failed: {e}"))?;
-        if !resp.status().is_success() {
-            return Err(format!(
-                "daemon check traffic failed: HTTP {}",
-                resp.status()
-            ));
-        }
-        let value: serde_json::Value = resp
-            .json()
-            .await
-            .map_err(|e| format!("daemon check traffic response parse failed: {e}"))?;
+        let value = daemon_json_request("check traffic", &base, |client, base| {
+            with_auth(client.get(format!("{base}/traffic/{encoded}")))
+        })
+        .await?;
         reports.push(value);
     }
     Ok(Some(serde_json::json!({
@@ -1222,12 +1306,269 @@ mod tests {
                 .pop_front()
                 .expect("FakeSeam: unexpected extra call_tool invocation")
         }
+    }
 
+    impl DaemonReviver for FakeSeam {
         async fn revive(&self) -> Result<String, String> {
             self.revive_count
                 .fetch_add(1, std::sync::atomic::Ordering::SeqCst);
             self.revive_result.clone()
         }
+    }
+
+    /// Reviver-only stub for the non-tool-call forwards, which drive
+    /// [`attempt_with_revival`] directly.
+    struct FakeReviver {
+        result: Result<String, String>,
+        count: std::sync::atomic::AtomicUsize,
+    }
+
+    impl FakeReviver {
+        fn new(result: Result<String, String>) -> Self {
+            Self {
+                result,
+                count: std::sync::atomic::AtomicUsize::new(0),
+            }
+        }
+
+        fn revives(&self) -> usize {
+            self.count.load(std::sync::atomic::Ordering::SeqCst)
+        }
+    }
+
+    impl DaemonReviver for FakeReviver {
+        async fn revive(&self) -> Result<String, String> {
+            self.count.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+            self.result.clone()
+        }
+    }
+
+    // ── Session-path revival over real sockets ─────────────────────────────
+    //
+    // The regression FIR-1575 reports: only `/mcp/tools/call` had a revival
+    // path, so a repo daemon that idled out between two tool calls left every
+    // session/intent/traffic/status forward failing forever. These drive the
+    // shared state machine those forwards now use, against real loopback
+    // sockets, so reqwest's own error classification is exercised rather than
+    // assumed. No daemon process is ever spawned.
+
+    /// A loopback URL whose port is closed: what an exited daemon leaves behind.
+    async fn exited_daemon_url() -> String {
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let port = listener.local_addr().unwrap().port();
+        drop(listener);
+        format!("http://127.0.0.1:{port}")
+    }
+
+    /// Minimal HTTP responder answering every request with `200 OK` and `body`.
+    /// Abort the returned handle to take it down.
+    async fn stub_daemon(body: &'static str) -> (String, tokio::task::JoinHandle<()>) {
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let port = listener.local_addr().unwrap().port();
+        let handle = tokio::spawn(async move {
+            while let Ok((mut socket, _)) = listener.accept().await {
+                tokio::spawn(async move {
+                    use tokio::io::{AsyncReadExt, AsyncWriteExt};
+                    let mut buf = [0u8; 8192];
+                    let _ = socket.read(&mut buf).await;
+                    let response = format!(
+                        "HTTP/1.1 200 OK\r\ncontent-type: application/json\r\n\
+                         content-length: {}\r\nconnection: close\r\n\r\n{body}",
+                        body.len()
+                    );
+                    let _ = socket.write_all(response.as_bytes()).await;
+                    let _ = socket.shutdown().await;
+                });
+            }
+        });
+        (format!("http://127.0.0.1:{port}"), handle)
+    }
+
+    fn probe_client() -> reqwest::Client {
+        reqwest::Client::builder()
+            .connect_timeout(Duration::from_millis(300))
+            .timeout(Duration::from_secs(3))
+            .pool_max_idle_per_host(0)
+            .build()
+            .unwrap()
+    }
+
+    /// One `POST {base}/session` attempt, classified the way the real session
+    /// forward classifies it.
+    async fn post_session(
+        client: &reqwest::Client,
+        base: &str,
+    ) -> Result<serde_json::Value, DaemonCallError> {
+        let resp = client
+            .post(format!("{base}/session"))
+            .json(&serde_json::json!({ "vendor": "test" }))
+            .send()
+            .await
+            .map_err(|e| classify_send_error("session start", e))?;
+        if !resp.status().is_success() {
+            return Err(DaemonCallError::DaemonError(format!(
+                "daemon session start failed: HTTP {}",
+                resp.status()
+            )));
+        }
+        resp.json().await.map_err(|e| {
+            DaemonCallError::DaemonError(format!("daemon session start response parse failed: {e}"))
+        })
+    }
+
+    /// (a) The daemon exits between calls; the next session forward transparently
+    /// respawns and succeeds. Before this change the same call returned a hard
+    /// error and every later one did too, for the life of the agent process.
+    #[tokio::test]
+    async fn session_forward_survives_daemon_exit_by_reviving() {
+        let dead = exited_daemon_url().await;
+        let (revived, revived_handle) = stub_daemon(r#"{"session_id":"s-1"}"#).await;
+        let reviver = FakeReviver::new(Ok(revived.clone()));
+        let client = probe_client();
+
+        let value: serde_json::Value =
+            attempt_with_revival("session start", &dead, &reviver, |base| {
+                let client = client.clone();
+                async move { post_session(&client, &base).await }
+            })
+            .await
+            .expect("session start must recover through revival");
+
+        assert_eq!(
+            value["session_id"], "s-1",
+            "the response must come from the revived daemon"
+        );
+        assert_eq!(reviver.revives(), 1, "revive runs exactly once");
+        revived_handle.abort();
+    }
+
+    /// A live daemon is never disturbed: no retry, no revival, one request.
+    #[tokio::test]
+    async fn healthy_daemon_never_triggers_revival() {
+        let (live, live_handle) = stub_daemon(r#"{"session_id":"s-live"}"#).await;
+        let reviver = FakeReviver::new(Err("revival must not run".to_string()));
+        let client = probe_client();
+
+        let value: serde_json::Value =
+            attempt_with_revival("session start", &live, &reviver, |base| {
+                let client = client.clone();
+                async move { post_session(&client, &base).await }
+            })
+            .await
+            .expect("healthy daemon must answer directly");
+
+        assert_eq!(value["session_id"], "s-live");
+        assert_eq!(reviver.revives(), 0);
+        live_handle.abort();
+    }
+
+    /// (b) When respawn cannot succeed, the caller gets the distinguishable
+    /// "daemon exited" class rather than a generic delegate failure.
+    #[tokio::test]
+    async fn unrecoverable_respawn_surfaces_the_daemon_exited_class() {
+        let dead = exited_daemon_url().await;
+        let reviver = FakeReviver::new(Err("kin-daemon binary not found".to_string()));
+        let client = probe_client();
+
+        let err = attempt_with_revival("session start", &dead, &reviver, |base| {
+            let client = client.clone();
+            async move { post_session(&client, &base).await }
+        })
+        .await
+        .expect_err("a dead daemon that cannot be revived must fail");
+
+        assert!(
+            is_daemon_exited_error(&err),
+            "must carry the unrecoverable-daemon class: {err}"
+        );
+        assert!(
+            err.contains("kin-daemon binary not found"),
+            "must preserve why revival failed: {err}"
+        );
+        assert!(
+            err.contains("kin mcp start"),
+            "must state the recovery action: {err}"
+        );
+    }
+
+    /// An error from a *live* daemon must not be mistaken for the daemon being
+    /// gone: an agent that restarts its MCP server over a bad argument has
+    /// misread the failure.
+    #[tokio::test]
+    async fn live_daemon_errors_are_not_the_daemon_exited_class() {
+        let seam = FakeSeam::new(vec![Err(daemon_err())], Ok("http://127.0.0.1:9".to_string()));
+        let err = forward_mcp_with_seam("tool", &HashMap::new(), &seam, "http://127.0.0.1:4219")
+            .await
+            .unwrap_err();
+        assert!(
+            !is_daemon_exited_error(&err),
+            "an HTTP 500 from a live daemon is not a lifecycle failure: {err}"
+        );
+    }
+
+    /// A revived daemon that still fails is equally unrecoverable, and says so
+    /// in the same class.
+    #[tokio::test]
+    async fn failure_after_revival_is_also_the_daemon_exited_class() {
+        let seam = FakeSeam::new(
+            vec![Err(conn_lost()), Err(conn_lost()), Err(conn_lost())],
+            Ok("http://127.0.0.1:9999".to_string()),
+        );
+        let err = forward_mcp_with_seam("tool", &HashMap::new(), &seam, "http://127.0.0.1:4219")
+            .await
+            .unwrap_err();
+        assert!(is_daemon_exited_error(&err), "{err}");
+    }
+
+    // ── Idle-timeout injection ─────────────────────────────────────────────
+
+    /// (c) `KIN_DAEMON_IDLE_TIMEOUT_SECS` override behaviour: a user value
+    /// propagates to the child on its own and must never be overwritten;
+    /// otherwise the revival path injects the 30-minute MCP window.
+    #[test]
+    fn revival_spawn_injects_mcp_idle_timeout_unless_user_set_one() {
+        assert_eq!(
+            mcp_spawn_idle_timeout(false),
+            Some(MCP_IDLE_TIMEOUT_SECS),
+            "with no user override the revived daemon gets the MCP window"
+        );
+        assert_eq!(
+            mcp_spawn_idle_timeout(true),
+            None,
+            "a user-set KIN_DAEMON_IDLE_TIMEOUT_SECS must never be overwritten"
+        );
+    }
+
+    // ── Revival single-flight ──────────────────────────────────────────────
+
+    /// Every forward now reaches revival, so a dead daemon can be observed by
+    /// several calls at once. The first caller's daemon must be reused rather
+    /// than each caller starting its own and losing the repo-lock race.
+    #[tokio::test]
+    async fn revival_reuses_a_daemon_another_caller_already_started() {
+        let (already_revived, handle) = stub_daemon(r#"{"status":"ok"}"#).await;
+        if let Ok(mut guard) = DAEMON_URL_OVERRIDE.lock() {
+            *guard = Some(already_revived.clone());
+        }
+
+        // No .kin discovery, no binary lookup, no spawn: the healthy override
+        // short-circuits before any of that.
+        let revived = revive_mcp_daemon().await.expect("must reuse the live daemon");
+        assert_eq!(revived, already_revived);
+
+        clear_daemon_url_override();
+        handle.abort();
+    }
+
+    /// The delegate client must not gate calls on a liveness probe. Returning
+    /// `None` for an unreachable daemon is what made the delegate swallow the
+    /// signal revival exists to act on.
+    #[tokio::test]
+    async fn daemon_client_is_available_without_a_reachable_daemon() {
+        assert!(
+            daemon_client().await.is_some(),
+            "client construction must not depend on a live daemon"
+        );
     }
 
     fn conn_lost() -> DaemonCallError {

--- a/crates/kin-mcp/src/daemon_delegate.rs
+++ b/crates/kin-mcp/src/daemon_delegate.rs
@@ -844,32 +844,45 @@ where
                     "daemon {operation} failed: could not build an HTTP client"
                 )));
             };
-            let resp = build(&client, &url)
-                .send()
-                .await
-                .map_err(|e| classify_send_error(operation, e))?;
-            if !resp.status().is_success() {
-                return Err(DaemonCallError::DaemonError(format!(
-                    "daemon {operation} failed: HTTP {}",
-                    resp.status()
-                )));
-            }
-            let body = resp.text().await.map_err(|e| {
-                DaemonCallError::DaemonError(format!(
-                    "daemon {operation} response read failed: {e}"
-                ))
-            })?;
-            if body.trim().is_empty() {
-                return Ok(serde_json::Value::Null);
-            }
-            serde_json::from_str(&body).map_err(|e| {
-                DaemonCallError::DaemonError(format!(
-                    "daemon {operation} response parse failed: {e}"
-                ))
-            })
+            send_daemon_json(operation, build(&client, &url)).await
         }
     })
     .await
+}
+
+/// Send one already-built daemon request and read its JSON body.
+///
+/// Split out of [`daemon_json_request`] so the response handling is testable
+/// without the revival wrapper: a test that drove the wrapper would, on any
+/// hiccup against its stub, reach the real revival path and spawn an actual
+/// `kin-daemon` against whatever repository the test process is sitting in.
+///
+/// An empty body is `Value::Null`, not an error. Some daemon mutations answer
+/// `204 No Content`, and the callers that expect it (intent release) synthesize
+/// their own result.
+async fn send_daemon_json(
+    operation: &str,
+    request: reqwest::RequestBuilder,
+) -> Result<serde_json::Value, DaemonCallError> {
+    let resp = request
+        .send()
+        .await
+        .map_err(|e| classify_send_error(operation, e))?;
+    if !resp.status().is_success() {
+        return Err(DaemonCallError::DaemonError(format!(
+            "daemon {operation} failed: HTTP {}",
+            resp.status()
+        )));
+    }
+    let body = resp.text().await.map_err(|e| {
+        DaemonCallError::DaemonError(format!("daemon {operation} response read failed: {e}"))
+    })?;
+    if body.trim().is_empty() {
+        return Ok(serde_json::Value::Null);
+    }
+    serde_json::from_str(&body).map_err(|e| {
+        DaemonCallError::DaemonError(format!("daemon {operation} response parse failed: {e}"))
+    })
 }
 
 /// Forward any product-mode MCP tool call to the daemon-owned implementation.
@@ -1374,6 +1387,16 @@ mod tests {
     /// Minimal HTTP responder answering every request with `200 OK` and `body`.
     /// Abort the returned handle to take it down.
     async fn stub_daemon(body: &'static str) -> (String, tokio::task::JoinHandle<()>) {
+        stub_daemon_raw(200, "OK", body).await
+    }
+
+    /// As [`stub_daemon`], with an explicit status line. `content-length` always
+    /// matches `body`, so a `204` carries a genuinely empty body.
+    async fn stub_daemon_raw(
+        status: u16,
+        reason: &'static str,
+        body: &'static str,
+    ) -> (String, tokio::task::JoinHandle<()>) {
         let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
         let port = listener.local_addr().unwrap().port();
         let handle = tokio::spawn(async move {
@@ -1383,7 +1406,7 @@ mod tests {
                     let mut buf = [0u8; 8192];
                     let _ = socket.read(&mut buf).await;
                     let response = format!(
-                        "HTTP/1.1 200 OK\r\ncontent-type: application/json\r\n\
+                        "HTTP/1.1 {status} {reason}\r\ncontent-type: application/json\r\n\
                          content-length: {}\r\nconnection: close\r\n\r\n{body}",
                         body.len()
                     );
@@ -1393,6 +1416,57 @@ mod tests {
             }
         });
         (format!("http://127.0.0.1:{port}"), handle)
+    }
+
+    /// The intent-release forward reads its response through the shared JSON
+    /// helper, but the daemon answers `DELETE /intent/{id}` with `204 No
+    /// Content`. An empty body must read as `Null`, not as a parse failure that
+    /// would report a successful release as an error.
+    #[tokio::test]
+    async fn empty_204_body_reads_as_null_rather_than_a_parse_failure() {
+        let (base, handle) = stub_daemon_raw(204, "No Content", "").await;
+        let client = probe_client();
+        let value = send_daemon_json(
+            "release intent",
+            client.delete(format!("{base}/intent/intent-1")),
+        )
+        .await
+        .expect("204 No Content must not be an error");
+        assert!(value.is_null(), "empty body must read as Null: {value:?}");
+        handle.abort();
+    }
+
+    /// A non-empty body that is not JSON is still a loud failure: the empty-body
+    /// allowance must not become a general "ignore the body" path.
+    #[tokio::test]
+    async fn non_json_body_is_still_an_error() {
+        let (base, handle) = stub_daemon_raw(200, "OK", "not json at all").await;
+        let client = probe_client();
+        let err = send_daemon_json("session start", client.get(format!("{base}/session")))
+            .await
+            .expect_err("a non-JSON body must fail");
+        assert!(
+            matches!(err, DaemonCallError::DaemonError(ref m) if m.contains("parse failed")),
+            "expected a parse failure, got: {err:?}"
+        );
+        handle.abort();
+    }
+
+    /// An HTTP error from a live daemon must classify as `DaemonError`, never
+    /// `ConnectionLost`: only the latter triggers revival, and restarting a
+    /// daemon that just answered is wasted work.
+    #[tokio::test]
+    async fn http_error_from_a_live_daemon_is_not_a_connection_loss() {
+        let (base, handle) = stub_daemon_raw(500, "Internal Server Error", "{}").await;
+        let client = probe_client();
+        let err = send_daemon_json("session start", client.get(format!("{base}/session")))
+            .await
+            .expect_err("HTTP 500 must fail");
+        assert!(
+            matches!(err, DaemonCallError::DaemonError(ref m) if m.contains("HTTP 500")),
+            "expected a DaemonError naming the status, got: {err:?}"
+        );
+        handle.abort();
     }
 
     fn probe_client() -> reqwest::Client {


### PR DESCRIPTION
## Problem

An agent session whose MCP shim was talking to a CLI-spawned repo daemon lost every kin tool permanently the moment that daemon idled out. A daemon autostarted by `kin clone` (or any kin CLI command) gets a 60 s idle window; any agent that thinks for longer than that between tool calls reproduces it.

A revival path already existed for `/mcp/tools/call`, but it never fired. Two independent gaps kept it from working:

**1. Only the tool-call path had revival at all.** `forward_session_start`, `forward_session_heartbeat`, `forward_session_end`, `forward_register_intent`, `forward_release_intent`, `forward_check_traffic` and `forward_graph_status` each issued a bare one-shot HTTP request and mapped any failure straight to `Err`. So `kin_session_start` against a dead daemon was a hard, permanent error while `/mcp/tools/call` was, in principle, recoverable.

**2. The delegate's own liveness probe swallowed the revival trigger.** `daemon_client()` probed `/health` before handing back a client and returned `None` when the probe failed. Callers read `None` as "no daemon is configured" and turned it into a graceful `Ok(None)` no-op, which the dispatch layer treats as success-with-no-result. A dead daemon therefore never produced the `ConnectionLost` classification that revival keys on, so revival could not run even on the path that had it. This is why the reported repro shows both `kin_session_start` and `kin_transaction_*` failing.

## Change

- One retry-then-revive state machine, `attempt_with_revival`, now backs **every** forwarded daemon request. `DaemonReviver` is split out of `DaemonCallSeam` so the non-tool-call forwards share the policy without pretending to be tool calls. `daemon_json_request` is the single entry point for the session/intent/traffic/status forwards, and it hands each attempt the base URL for *that* attempt, so the post-revival retry addresses the revived daemon rather than the dead one.
- `daemon_client()` no longer probes. Liveness is the request's own transport result: a connect/timeout failure classifies as `ConnectionLost` and drives retry then revival, while "no daemon configured" is now a `None` from `daemon_base_url()` alone. This also removes a wasted round-trip in front of every call.
- Revival is serialized behind a single-flight lock. Now that every forward can reach revival, a dead daemon can be observed by several in-flight calls at once; without this each would spawn its own daemon and all but one would lose the race for the repo lock and exit. A caller that finds a healthy daemon already installed reuses it instead of spawning.
- Failures that end with no reachable daemon carry a distinguishable class, `DAEMON_EXITED_RESTART_REQUIRED` ("repo daemon exited; restart required"), with `is_daemon_exited_error()` to test for it. An HTTP error from a live daemon is deliberately *not* in this class: restarting an MCP server over a bad argument is wasted work.
- The traffic forward re-resolves the daemon URL per scope, so a revival triggered by one scope does not leave the rest rediscovering the dead daemon through the full failure path.

Behaviour preserved: the same-URL retry before revival stays (a lone transport error is as often a stale socket or a post-boot stall as a dead daemon, and revival against a live daemon cannot succeed while it holds the repo lock); revival still runs at most once per call; non-connection errors still bypass retry and revival entirely.

## Tests

`crates/kin-mcp/src/daemon_delegate.rs`, 41 tests in the module, all green.

- `session_forward_survives_daemon_exit_by_reviving` — the daemon exits between calls (a real loopback port closed under the client), the next session forward transparently revives and returns the new daemon's response. Real sockets, so reqwest's own error classification is exercised rather than assumed. No daemon process is spawned.
- `unrecoverable_respawn_surfaces_the_daemon_exited_class` — respawn fails, the error carries the distinguishable class, preserves why revival failed, and names the recovery action.
- `live_daemon_errors_are_not_the_daemon_exited_class` / `failure_after_revival_is_also_the_daemon_exited_class` — the class boundary in both directions.
- `revival_spawn_injects_mcp_idle_timeout_unless_user_set_one` — `KIN_DAEMON_IDLE_TIMEOUT_SECS` override behaviour is intact: a user-set value propagates to the child on its own and is never overwritten; otherwise the 30-minute MCP window is injected.
- `healthy_daemon_never_triggers_revival`, `revival_reuses_a_daemon_another_caller_already_started`, `daemon_client_is_available_without_a_reachable_daemon`.

Local gate: `cargo fmt --check`, clippy per the ci.yml allowlist, the zero-file-search and hydration guards, `cargo build --all-targets --locked`, `cargo nextest run --locked`, `cargo test --doc --locked`.

## Deliberately not done

Re-arming an **existing** daemon's idle timeout from MCP startup (option 2 in the ticket) is not included. The daemon has no control surface for it: the idle timeout is read from the environment once at process start and moved into `run_idle_monitor` by value, so this would need a new mutable field on `DaemonState`, a per-iteration re-read in the idle monitor, and a new authenticated route, all inside the shutdown machinery.

It also buys little now. `ready_for_idle_shutdown` already returns false while `has_external_sessions()` holds, so a shim that has called `kin_session_start` blocks idle shutdown for the life of that session. The exposed window is the pre-session one, which revival now covers, and a revived daemon is spawned with the 1800 s window, so the steady state after a single transparent respawn is already the MCP timeout.
