### PR TITLE
Close replication preconditions on v6: replica init, pack identity, init determinism

### DIFF
--- a/crates/kin-core/src/init.rs
+++ b/crates/kin-core/src/init.rs
@@ -2065,6 +2065,59 @@ mod tests {
     }
 
     #[test]
+    fn independent_initializations_hold_an_equal_change_set() {
+        let first_directory = tempfile::tempdir().unwrap();
+        let second_directory = tempfile::tempdir().unwrap();
+        let first = init(first_directory.path()).unwrap();
+        let second = init(second_directory.path()).unwrap();
+
+        // Replication between two repositories that were initialized separately
+        // compares the changes each side holds. Initialization admits no
+        // history, so neither side carries a synthesized root whose payload
+        // could differ. A synthetic root stamped at initialization time would
+        // make these sets unequal and first contact unreconcilable.
+        let first_changes = held_change_ids(&first);
+        let second_changes = held_change_ids(&second);
+        assert!(first_changes.is_empty());
+        assert_eq!(first_changes, second_changes);
+
+        assert_eq!(first.authority.initial_change_id, None);
+        assert_eq!(second.authority.initial_change_id, None);
+        assert_eq!(first.head, second.head);
+        assert_eq!(
+            first.authority.workspace.base_target,
+            second.authority.workspace.base_target
+        );
+        assert_eq!(
+            first.authority.workspace.base_tree_hash,
+            second.authority.workspace.base_tree_hash
+        );
+        assert_eq!(
+            first.authority.workspace.workspace_tree_hash,
+            second.authority.workspace.workspace_tree_hash
+        );
+        assert_eq!(
+            first.authority.workspace.workspace_semantic_overlay_hash,
+            second.authority.workspace.workspace_semantic_overlay_hash
+        );
+
+        // Repository and workspace identity stay per-repository. Only history
+        // is shared across a replication boundary.
+        assert_ne!(first.repository_id, second.repository_id);
+        assert_ne!(first.workspace_id, second.workspace_id);
+    }
+
+    fn held_change_ids(result: &InitResult) -> std::collections::BTreeSet<SemanticChangeId> {
+        let authority = RepositoryAuthorityManager::open(
+            result.repository_id.clone(),
+            Arc::new(LocalFileBackend::new(result.layout.kindb_dir())),
+        )
+        .unwrap();
+        let lease = authority.read_authority();
+        lease.snapshot().changes.keys().copied().collect()
+    }
+
+    #[test]
     fn init_writes_valid_config() {
         let directory = tempfile::tempdir().unwrap();
         let result = init(directory.path()).unwrap();

--- a/crates/kin-core/src/init.rs
+++ b/crates/kin-core/src/init.rs
@@ -307,6 +307,34 @@ impl Drop for PreparedRepositoryInit {
 ///
 /// Returns `KinError::AlreadyInitialized` if `.kin/` already exists.
 pub fn init(working_dir: &Path) -> Result<InitResult> {
+    init_with_config(working_dir, KinConfig::default())
+}
+
+/// Initialize a repository that will adopt a remote's history over a native
+/// clone.
+///
+/// A clone learns the remote's default ref from the ref advertisement before
+/// any history arrives, so the replica is created against that ref rather than
+/// the local configuration default. Synthesizing `main` for a remote that does
+/// not publish it would leave a ghost ref no import can ever reconcile.
+///
+/// Like [`init`], this admits no history. The replica holds no changes until
+/// the caller imports them, so it stays byte-comparable with the remote at
+/// first contact.
+///
+/// # Errors
+///
+/// Returns `KinError::AlreadyInitialized` if `.kin/` already exists, and fails
+/// loud if `default_branch` is not a valid ref name.
+pub fn init_replica(working_dir: &Path, default_branch: &str) -> Result<InitResult> {
+    let config = KinConfig {
+        default_branch: default_branch.to_string(),
+        ..KinConfig::default()
+    };
+    init_with_config(working_dir, config)
+}
+
+fn init_with_config(working_dir: &Path, config: KinConfig) -> Result<InitResult> {
     let canonical_working_dir = working_dir
         .canonicalize()
         .map_err(|error| KinError::io(working_dir, error))?;
@@ -321,7 +349,6 @@ pub fn init(working_dir: &Path) -> Result<InitResult> {
         Err(error) => return Err(KinError::io(&kin_dir, error)),
     }
 
-    let config = KinConfig::default();
     let manifest = KinManifest::new();
     let staging_parent = canonical_working_dir.parent().ok_or_else(|| {
         KinError::Other(format!(
@@ -2105,6 +2132,68 @@ mod tests {
         // is shared across a replication boundary.
         assert_ne!(first.repository_id, second.repository_id);
         assert_ne!(first.workspace_id, second.workspace_id);
+    }
+
+    #[test]
+    fn replica_adopts_the_remote_default_ref_without_inventing_main() {
+        let directory = tempfile::tempdir().unwrap();
+        let result = init_replica(directory.path(), "trunk").unwrap();
+
+        assert_eq!(
+            result.head,
+            WorkspaceHead::Symbolic {
+                target: RefName::branch(b"trunk").unwrap()
+            }
+        );
+        assert_ne!(
+            result.head,
+            WorkspaceHead::Symbolic {
+                target: RefName::branch(b"main").unwrap()
+            }
+        );
+        let loaded = KinConfig::load(&result.layout.config_path()).unwrap();
+        assert_eq!(loaded.default_branch, "trunk");
+
+        // A replica carries no history of its own. Import supplies it, so the
+        // replica is comparable with the remote at first contact.
+        assert_eq!(result.authority.initial_change_id, None);
+        assert!(held_change_ids(&result).is_empty());
+        assert_eq!(result.authority.workspace.base_target, None);
+    }
+
+    #[test]
+    fn replica_and_plain_init_differ_only_in_the_adopted_ref() {
+        let replica_directory = tempfile::tempdir().unwrap();
+        let init_directory = tempfile::tempdir().unwrap();
+        let replica = init_replica(replica_directory.path(), "main").unwrap();
+        let plain = init(init_directory.path()).unwrap();
+
+        assert_eq!(replica.head, plain.head);
+        assert_eq!(held_change_ids(&replica), held_change_ids(&plain));
+        assert_eq!(
+            replica.authority.workspace.workspace_tree_hash,
+            plain.authority.workspace.workspace_tree_hash
+        );
+        assert_eq!(
+            replica.authority.workspace.workspace_semantic_overlay_hash,
+            plain.authority.workspace.workspace_semantic_overlay_hash
+        );
+    }
+
+    #[test]
+    fn replica_rejects_an_invalid_remote_default_ref() {
+        let parent = tempfile::tempdir().unwrap();
+        let repository = parent.path().join("replica");
+        std::fs::create_dir(&repository).unwrap();
+
+        assert!(init_replica(&repository, "").is_err());
+        assert!(!repository.join(".kin").exists());
+        let leftovers = std::fs::read_dir(parent.path())
+            .unwrap()
+            .map(|entry| entry.unwrap().file_name())
+            .filter(|name| name.to_string_lossy().starts_with(".kin.init-"))
+            .collect::<Vec<_>>();
+        assert!(leftovers.is_empty(), "staging leftovers: {leftovers:?}");
     }
 
     fn held_change_ids(result: &InitResult) -> std::collections::BTreeSet<SemanticChangeId> {

--- a/crates/kin-core/src/lib.rs
+++ b/crates/kin-core/src/lib.rs
@@ -51,9 +51,9 @@ pub use hooks::{
     generate_claude_hooks, render_hooks_instructions, render_hooks_json, HookTemplate,
 };
 pub use init::{
-    init, initialize_repository_authority, prepare_repository_layout_at, publish_repository_layout,
-    publish_repository_layout_linearized, InitResult, PreparedRepositoryInit, PublishedRepository,
-    RepositoryBootstrap, RepositoryPublication,
+    init, init_replica, initialize_repository_authority, prepare_repository_layout_at,
+    publish_repository_layout, publish_repository_layout_linearized, InitResult,
+    PreparedRepositoryInit, PublishedRepository, RepositoryBootstrap, RepositoryPublication,
 };
 pub use layout::KinLayout;
 pub use manifest::KinManifest;

--- a/crates/kin-remote/src/repository_transfer.rs
+++ b/crates/kin-remote/src/repository_transfer.rs
@@ -336,6 +336,87 @@ pub fn repository_transfer_status<B: StorageBackend + ?Sized + 'static>(
     })
 }
 
+/// One advertised ref and the change it resolves to.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct RepositoryRefAdvertisementEntry {
+    pub name: RefName,
+    pub target: RefTarget,
+    pub head: SemanticChangeId,
+}
+
+/// What a repository publishes before any history moves.
+///
+/// A clone starts here: it has no ref of its own to ask about yet, so it
+/// cannot use the per-ref transfer status, and it needs the default ref
+/// before it can initialize a replica that adopts the remote layout.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct RepositoryRefAdvertisement {
+    pub schema_version: u32,
+    pub protocol: String,
+    pub repository_id: RepositoryId,
+    /// Published refs ordered by name, so the advertisement is one spelling
+    /// per repository state rather than a function of storage order.
+    pub refs: Vec<RepositoryRefAdvertisementEntry>,
+    /// The ref a fresh clone adopts.
+    ///
+    /// An unborn repository publishes a default ref that is absent from
+    /// `refs`: it has declared where history will land without having any.
+    /// A clone must reproduce that state rather than treat it as an error.
+    pub default_ref: Option<RefName>,
+    pub roots: RootBundle,
+    pub supported_features: Vec<String>,
+    pub limits: RepositoryTransferLimits,
+}
+
+/// Advertise every published ref for `repository_id`.
+pub fn repository_ref_advertisement<B: StorageBackend + ?Sized + 'static>(
+    authority: &RepositoryAuthorityManager<B>,
+    repository_id: &RepositoryId,
+) -> Result<RepositoryRefAdvertisement> {
+    let lease = authority.read_authority();
+    if &lease.authority_metadata().repository_id != repository_id {
+        return Err(invalid(format!(
+            "authority belongs to {}, not requested repository {}",
+            lease.authority_metadata().repository_id,
+            repository_id
+        )));
+    }
+
+    let mut refs = Vec::with_capacity(lease.authority_metadata().ref_state.refs.len());
+    for entry in &lease.authority_metadata().ref_state.refs {
+        refs.push(RepositoryRefAdvertisementEntry {
+            name: entry.name.clone(),
+            target: entry.target.clone(),
+            head: lease
+                .resolve_target_change_id(&entry.target)
+                .map_err(storage)?,
+        });
+    }
+    refs.sort_by(|left, right| left.name.cmp(&right.name));
+    if let Some(duplicate) = refs
+        .windows(2)
+        .find(|pair| pair[0].name == pair[1].name)
+        .map(|pair| pair[0].name.clone())
+    {
+        return Err(invalid(format!(
+            "repository publishes ref {duplicate} more than once"
+        )));
+    }
+
+    Ok(RepositoryRefAdvertisement {
+        schema_version: REPOSITORY_TRANSFER_SCHEMA_VERSION,
+        protocol: REPOSITORY_TRANSFER_PROTOCOL.to_string(),
+        repository_id: repository_id.clone(),
+        refs,
+        default_ref: lease.authority_metadata().ref_state.default_ref.clone(),
+        roots: lease.roots().clone(),
+        supported_features: required_features(),
+        limits: RepositoryTransferLimits::default(),
+    })
+}
+
 pub fn build_repository_transfer_pack<B: StorageBackend + ?Sized + 'static>(
     authority: &RepositoryAuthorityManager<B>,
     source_ref: &RefName,
@@ -1792,6 +1873,141 @@ mod tests {
             error.to_string().contains("required immutable source body"),
             "{error}"
         );
+    }
+
+    #[test]
+    fn advertisement_publishes_ordered_refs_with_resolved_heads() {
+        let fixture = fixture();
+        let advertised =
+            repository_ref_advertisement(&fixture.source, &fixture.repository_id).unwrap();
+
+        assert_eq!(advertised.protocol, REPOSITORY_TRANSFER_PROTOCOL);
+        assert_eq!(
+            advertised.schema_version,
+            REPOSITORY_TRANSFER_SCHEMA_VERSION
+        );
+        assert_eq!(advertised.repository_id, fixture.repository_id);
+
+        let main = advertised
+            .refs
+            .iter()
+            .find(|entry| entry.name == fixture.main)
+            .expect("source publishes the transferred ref");
+        let status =
+            repository_transfer_status(&fixture.source, &fixture.repository_id, &fixture.main)
+                .unwrap();
+        assert_eq!(Some(main.head), status.destination_head);
+        assert_eq!(Some(main.target.clone()), status.destination_target);
+        assert_eq!(advertised.default_ref, status.default_ref);
+
+        // Publish two more refs in an order the advertisement must not keep,
+        // so the ordering assertion below has something to sort.
+        let head = status.destination_head.unwrap();
+        let zulu = RefName::branch(b"zulu").unwrap();
+        let alpha = RefName::branch(b"alpha").unwrap();
+        let lease = fixture.source.read_authority();
+        let transaction = RepositoryTransaction {
+            schema_version: REPOSITORY_TRANSACTION_SCHEMA_VERSION,
+            operation_id: OperationId::new(),
+            repository_id: fixture.repository_id.clone(),
+            expected_generation: lease.roots().generation,
+            expected_roots: lease.roots().clone(),
+            actor: AuthorId::new("transfer-fixture"),
+            reason: "publish additional refs out of advertised order".to_string(),
+            external_objects: Vec::new(),
+            git_authority_delta: None,
+            changes: Vec::new(),
+            aliases: Vec::new(),
+            ref_mutations: vec![
+                RefMutation {
+                    name: zulu.clone(),
+                    expected: RefExpectation::MustNotExist,
+                    new_target: Some(RefTarget::change(head)),
+                    policy: RefUpdatePolicy::FastForwardOnly,
+                },
+                RefMutation {
+                    name: alpha.clone(),
+                    expected: RefExpectation::MustNotExist,
+                    new_target: Some(RefTarget::change(head)),
+                    policy: RefUpdatePolicy::FastForwardOnly,
+                },
+            ],
+            default_ref_mutation: None,
+            workspace_mutation: None,
+            local_overlay_delta: None,
+        };
+        drop(lease);
+        fixture
+            .source
+            .commit_repository_transaction(transaction)
+            .unwrap();
+
+        let advertised =
+            repository_ref_advertisement(&fixture.source, &fixture.repository_id).unwrap();
+        assert_eq!(advertised.refs.len(), 3);
+        assert!(advertised
+            .refs
+            .windows(2)
+            .all(|pair| pair[0].name < pair[1].name));
+        assert_eq!(advertised.refs.first().unwrap().name, alpha);
+        assert_eq!(advertised.refs.last().unwrap().name, zulu);
+        assert!(advertised
+            .refs
+            .iter()
+            .all(|entry| entry.head == head || entry.name == fixture.main));
+    }
+
+    #[test]
+    fn advertisement_rejects_a_repository_it_was_not_asked_for() {
+        let fixture = fixture();
+        let other = RepositoryId::new(uuid::Uuid::new_v4().to_string()).unwrap();
+        let error = repository_ref_advertisement(&fixture.source, &other).unwrap_err();
+        assert!(error.to_string().contains("not requested repository"));
+    }
+
+    #[test]
+    fn unborn_repository_advertises_a_default_ref_it_has_no_history_for() {
+        let directory = TempDir::new().unwrap();
+        let repository_id = RepositoryId::new(uuid::Uuid::new_v4().to_string()).unwrap();
+        let authority = manager(&directory, &repository_id);
+        let trunk = RefName::branch(b"trunk").unwrap();
+
+        // Declare where history will land without landing any, which is the
+        // state an empty repository is published in.
+        let lease = authority.read_authority();
+        let transaction = RepositoryTransaction {
+            schema_version: REPOSITORY_TRANSACTION_SCHEMA_VERSION,
+            operation_id: OperationId::new(),
+            repository_id: repository_id.clone(),
+            expected_generation: lease.roots().generation,
+            expected_roots: lease.roots().clone(),
+            actor: AuthorId::new("transfer-fixture"),
+            reason: "declare an unborn default ref".to_string(),
+            external_objects: Vec::new(),
+            git_authority_delta: None,
+            changes: Vec::new(),
+            aliases: Vec::new(),
+            ref_mutations: Vec::new(),
+            default_ref_mutation: Some(DefaultRefMutation {
+                expected: DefaultRefExpectation::MustBeUnset,
+                new_default: Some(trunk.clone()),
+            }),
+            workspace_mutation: None,
+            local_overlay_delta: None,
+        };
+        drop(lease);
+        authority
+            .commit_repository_transaction(transaction)
+            .unwrap();
+
+        let advertised = repository_ref_advertisement(&authority, &repository_id).unwrap();
+
+        // A clone of an empty repository has to reproduce exactly this: a
+        // declared landing place with nothing in it. Treating the advertised
+        // default as a ref that must resolve would make empty repositories
+        // uncloneable.
+        assert!(advertised.refs.is_empty());
+        assert_eq!(advertised.default_ref, Some(trunk));
     }
 
     #[test]

--- a/crates/kin-remote/src/repository_transfer.rs
+++ b/crates/kin-remote/src/repository_transfer.rs
@@ -696,12 +696,27 @@ pub fn validate_pack(pack: &RepositoryTransferPack) -> Result<()> {
         }
     }
 
+    // Bodies are a deduplicated set, and the sender emits them ordered by
+    // identity. Pack identity is computed over the serialized pack, so a
+    // permuted body array describes the same transfer under a different
+    // transfer id. Pinning the order here keeps that identity a function of
+    // content alone.
     let mut body_hashes = BTreeSet::new();
+    let mut previous_body: Option<Hash256> = None;
     let mut total = 0_u64;
     for body in &pack.bodies {
         if !body_hashes.insert(body.hash) {
             return Err(invalid(format!("duplicate source body {}", body.hash)));
         }
+        if let Some(previous) = previous_body {
+            if body.hash < previous {
+                return Err(invalid(format!(
+                    "source body {} breaks ascending pack order after {}",
+                    body.hash, previous
+                )));
+            }
+        }
+        previous_body = Some(body.hash);
         let bytes = body.decode()?;
         total = total
             .checked_add(body.byte_len)
@@ -1777,6 +1792,47 @@ mod tests {
             error.to_string().contains("required immutable source body"),
             "{error}"
         );
+    }
+
+    #[test]
+    fn pack_identity_is_a_function_of_body_content_not_body_order() {
+        let fixture = fixture();
+        let status =
+            repository_transfer_status(&fixture.destination, &fixture.repository_id, &fixture.main)
+                .unwrap();
+        let mut full = RepositoryTransferExpectation::try_from(status).unwrap();
+        full.destination_target = None;
+        full.destination_head = None;
+        let pack = build_repository_transfer_pack(&fixture.source, &fixture.main, &full).unwrap();
+        assert!(pack.bodies.len() >= 2);
+
+        // The sender deduplicates bodies through an ordered set, so a pack it
+        // builds is always ascending by body identity.
+        assert!(pack
+            .bodies
+            .windows(2)
+            .all(|pair| pair[0].hash < pair[1].hash));
+        validate_pack(&pack).unwrap();
+
+        // Reordering bodies preserves every byte of transferred content but
+        // changes the serialized pack, and with it the recomputed transfer
+        // identity. Accepting both spellings would let one transfer carry two
+        // identities, so the receiver pins the canonical order instead.
+        let mut permuted = pack.clone();
+        permuted.bodies.reverse();
+        permuted.transfer_id = compute_transfer_id(&permuted).unwrap();
+        assert_ne!(permuted.transfer_id, pack.transfer_id);
+        let error = validate_pack(&permuted).unwrap_err();
+        assert!(
+            error.to_string().contains("ascending"),
+            "unexpected error: {error}"
+        );
+
+        let mut duplicate = pack.clone();
+        duplicate.bodies.push(pack.bodies[0].clone());
+        duplicate.transfer_id = compute_transfer_id(&duplicate).unwrap();
+        let error = validate_pack(&duplicate).unwrap_err();
+        assert!(error.to_string().contains("duplicate source body"));
     }
 
     #[test]


### PR DESCRIPTION
Four independently reviewable commits closing preconditions for native replication on v6. Rebased onto current `main`.

## 1. Pin equal held-change sets across independent initializations

The recorded blocker said initialization synthesized a genesis change with a fixed id but a wall-clock payload, so two separately initialized repositories could never agree on their root.

That is no longer how initialization works. The v6 cutover made `init` produce an unborn repository: it deliberately does not invent a synthetic commit, `build_genesis_change` no longer exists, and `initial_change_id` is `None`. The blocker is closed by the current design, not by a new fix. What was missing is anything pinning the property, so this adds it: two independent inits must hold equal change sets and agree on head, base target, base tree hash, workspace tree hash, and semantic overlay hash, while repository and workspace identity stay distinct.

## 2. Adopt the remote default ref when initializing a replica

A native clone learns the remote default ref from the ref advertisement before any history arrives. Initialization had no way to use it, because the only entry point pinned the default ref to the locally configured branch. Cloning a remote whose default is not `main` would leave behind a `main` the remote never published and no import could reconcile.

`init_replica` initializes against a caller-supplied default ref and otherwise matches `init` exactly, admitting no history. An invalid ref name fails before anything is published and leaves no staging directory behind.

## 3. Pin transfer pack identity to body content rather than body order

`validate_pack` rejected duplicate bodies but accepted any body order, while `transfer_id` is computed over the serialized pack. A reordered pack carrying byte-identical content therefore validated under a second, different transfer identity, so one transfer could be receipted twice under two identities.

This was confirmed before being fixed: a 9-body pack with `bodies` reversed and `transfer_id` recomputed returned `Ok(())` from `validate_pack`. The receiver now rejects a body array that is not ascending by identity, with the duplicate check kept ahead of it so an exact repeat still reports as a duplicate. The sender already emitted ascending order, so this rejects only packs no honest builder produces.

## 4. Advertise the repository ref set before any history moves

A clone has no ref of its own yet, so it cannot use the per-ref transfer status to discover what a remote publishes: that call takes the very ref the clone is trying to find. `repository_ref_advertisement` publishes the ref set directly, ordered by name so one repository state has one advertised spelling, and refuses a name published twice.

An unborn repository advertises a default ref absent from its ref set, having declared where history will land without having any. That is a state a clone must reproduce rather than reject, so it is carried through as is.

Together with commit 2 this closes the discovery half of clone: advertisement supplies the default ref, `init_replica` adopts it, and the existing transfer pack applies history onto it.

## Verification

- `cargo test -p kin-core --lib`: 435 passed, 0 failed
- `cargo test -p kin-remote --lib`: 44 passed, 0 failed
- `cargo build --all-targets` (workspace): exit 0
- `cargo fmt --all -- --check`: clean
- `cargo clippy --all-targets -- -D warnings` on `kin-core` and `kin-remote`: clean

Every new guard was falsified before being trusted, and three of them failed that check on the first attempt:

- The change-set read path was shown to be non-vacuous by temporarily asserting it is non-empty inside the existing git-init admission test.
- The body-order guard was shown to close a hole that was demonstrably open, but the first version asserted ordering over a fixture holding a single body, where `windows(2).all(...)` is trivially true. It now builds a 9-body pack.
- The ref-ordering guard had the same defect against a single-ref fixture. It now publishes two extra refs, created `zulu` before `alpha`, and asserts the advertisement returns `alpha` first.
- The unborn-advertisement test originally ran against a fresh authority that had no default ref at all, so it asserted nothing. It now commits a transaction that declares a default ref with no ref mutations, which is the real unborn state.

## Unrelated pre-existing failure

`cargo test --workspace` has one failure on this machine, `prepared_state_publish_and_materialize_preserve_indexed_state`, asserting `indexed_embedding_count > 0`. It reproduces identically on pristine `origin/main` with these commits absent, `main` CI is green (ci.yml runs the whole workspace under nextest), and this branch touches only three files in `kin-core` and `kin-remote`. It is not caused by this PR and is reported separately.

## Not claimed

No native clone, push, pull, or fetch runs end to end. Transport and CLI wiring remain unbuilt on v6. This closes preconditions and the discovery surface only.