### PR TITLE
Load LSP source from repository authority and normalize admitted event paths

### DIFF
--- a/crates/kin-daemon/src/daemon.rs
+++ b/crates/kin-daemon/src/daemon.rs
@@ -1322,6 +1322,16 @@ pub async fn run(mut state: DaemonState, config: DaemonConfig) -> Result<()> {
             .unwrap_or_else(|_| state.layout.working_dir().to_path_buf());
         let _lsp_handle = tokio::spawn(async move {
             info!("LSP enrichment worker started");
+            let source_view = match lsp_state.graph_owned_source_view() {
+                Ok(view) => view,
+                Err(error) => {
+                    error!(
+                        error = %error,
+                        "LSP enrichment worker cannot open graph-owned source authority"
+                    );
+                    return;
+                }
+            };
 
             // Lazily start LSP servers on first use per language.
             let mut servers: std::collections::HashMap<
@@ -1356,11 +1366,10 @@ pub async fn run(mut state: DaemonState, config: DaemonConfig) -> Result<()> {
 
                 match message {
                     LspEnrichmentMessage::Incremental(request) => {
-                        // Canonicalize to match the rootUri sent to RA.
-                        let path = request
-                            .file_path
-                            .canonicalize()
-                            .unwrap_or_else(|_| request.file_path.clone());
+                        // The URI is a compatibility projection of the
+                        // graph-owned repository path. didOpen content is
+                        // loaded separately from repository authority below.
+                        let path = lsp_root.join(&request.file_id.0);
                         let ext = path.extension().and_then(|e| e.to_str()).unwrap_or("");
                         let language = match ext {
                             "rs" => Some(kin_model::LanguageId::Rust),
@@ -1473,10 +1482,20 @@ pub async fn run(mut state: DaemonState, config: DaemonConfig) -> Result<()> {
                             .collect();
                         let index = kin_lsp::EntityIndex::new(entity_refs);
 
-                        // Open the file in the LSP server so it can be queried.
-                        let file_content = match std::fs::read_to_string(&path) {
-                            Ok(c) => c,
-                            Err(_) => continue,
+                        // Open exact graph/CAS bytes in the LSP server. A
+                        // missing body or authority mismatch fails this
+                        // enrichment request loudly; the working tree is never
+                        // allowed to repair or answer it.
+                        let file_content = match source_view.load_text(&request.file_id) {
+                            Ok(content) => content,
+                            Err(error) => {
+                                warn!(
+                                    file = %request.file_id,
+                                    error = %error,
+                                    "LSP enrichment skipped because graph-owned source could not be loaded"
+                                );
+                                continue;
+                            }
                         };
                         let file_uri = kin_lsp::protocol::path_to_uri(&path);
                         let lang_str = match lang {
@@ -1510,11 +1529,7 @@ pub async fn run(mut state: DaemonState, config: DaemonConfig) -> Result<()> {
                             tokio::time::sleep(std::time::Duration::from_secs(5)).await;
                         }
 
-                        let rel_path = path
-                            .strip_prefix(&lsp_root)
-                            .unwrap_or(&path)
-                            .to_string_lossy()
-                            .to_string();
+                        let rel_path = request.file_id.0.clone();
 
                         // Cap: if too many entities changed, it's a full re-parse — skip
                         // this batch to avoid flooding the LSP server. Incremental changes
@@ -1599,12 +1614,12 @@ pub async fn run(mut state: DaemonState, config: DaemonConfig) -> Result<()> {
 
                         // Group entities by file.
                         let mut by_file: std::collections::HashMap<
-                            String,
+                            kin_model::FilePathId,
                             Vec<&kin_model::Entity>,
                         > = std::collections::HashMap::new();
                         for entity in &entities {
                             if let Some(ref fo) = entity.file_origin {
-                                by_file.entry(fo.0.clone()).or_default().push(entity);
+                                by_file.entry(fo.clone()).or_default().push(entity);
                             }
                         }
 
@@ -1637,11 +1652,8 @@ pub async fn run(mut state: DaemonState, config: DaemonConfig) -> Result<()> {
                             .collect();
                         let index = kin_lsp::EntityIndex::new(entity_refs);
 
-                        for (file_path, file_entities) in &by_file {
-                            let abs_path = lsp_root.join(file_path);
-                            if !abs_path.exists() {
-                                continue;
-                            }
+                        for (file_id, file_entities) in &by_file {
+                            let abs_path = lsp_root.join(&file_id.0);
 
                             // Determine language from file extension.
                             let ext = abs_path.extension().and_then(|e| e.to_str()).unwrap_or("");
@@ -1710,10 +1722,19 @@ pub async fn run(mut state: DaemonState, config: DaemonConfig) -> Result<()> {
                                 continue;
                             };
 
-                            // didOpen the file.
-                            let file_content = match std::fs::read_to_string(&abs_path) {
-                                Ok(c) => c,
-                                Err(_) => continue,
+                            // didOpen exact graph/CAS content. The compatibility
+                            // path may not exist on the host; that must not
+                            // affect graph-owned semantic enrichment.
+                            let file_content = match source_view.load_text(file_id) {
+                                Ok(content) => content,
+                                Err(error) => {
+                                    warn!(
+                                        file = %file_id,
+                                        error = %error,
+                                        "LSP sweep skipped graph source that could not be loaded from authority"
+                                    );
+                                    continue;
+                                }
                             };
                             let uri = kin_lsp::protocol::path_to_uri(&abs_path);
                             let lang_str = match lang {
@@ -1748,7 +1769,7 @@ pub async fn run(mut state: DaemonState, config: DaemonConfig) -> Result<()> {
                                     Some(kin_lsp::EntityRef {
                                         id: e.id,
                                         name: e.name.clone(),
-                                        file_path: file_path.clone(),
+                                        file_path: file_id.0.clone(),
                                         start_line: span.start_line as u32,
                                         start_col: span.start_col as u32,
                                         end_line: span.end_line as u32,
@@ -1798,7 +1819,7 @@ pub async fn run(mut state: DaemonState, config: DaemonConfig) -> Result<()> {
 
                             if file_relations > 0 {
                                 info!(
-                                    file = %file_path,
+                                    file = %file_id,
                                     relations = file_relations,
                                     progress = format!("{}/{}", files_processed, total_files),
                                     "sweep enriched file"

--- a/crates/kin-daemon/src/loop_runner.rs
+++ b/crates/kin-daemon/src/loop_runner.rs
@@ -149,40 +149,82 @@ struct ExactTreeAdmission {
     semantic_events: Vec<FileEvent>,
 }
 
-fn repo_path(path: &Path, working_dir: &Path) -> Result<Option<RepoPath>> {
-    // `KinLayout` holds a canonical repository root, while macOS file events
-    // can retain the `/var` spelling of the same `/private/var` path. Resolve
-    // only the parent directory so a dangling symlink or removed entry keeps
-    // its own identity instead of being dereferenced (or rejected as missing).
-    let comparable_path;
-    let path = if path.strip_prefix(working_dir).is_ok() {
-        path
-    } else {
-        let parent = path.parent().ok_or_else(|| {
-            DaemonError::Io(std::io::Error::new(
-                std::io::ErrorKind::InvalidInput,
-                format!("filesystem event has no parent: {}", path.display()),
-            ))
-        })?;
-        let name = path.file_name().ok_or_else(|| {
-            DaemonError::Io(std::io::Error::new(
-                std::io::ErrorKind::InvalidInput,
-                format!("filesystem event has no entry name: {}", path.display()),
-            ))
-        })?;
-        comparable_path = parent.canonicalize().map_err(DaemonError::Io)?.join(name);
-        comparable_path.as_path()
-    };
-    let relative = path.strip_prefix(working_dir).map_err(|error| {
-        DaemonError::Io(std::io::Error::new(
+fn canonicalize_host_parent_preserving_leaf(path: &Path) -> std::io::Result<PathBuf> {
+    let leaf = path.file_name().ok_or_else(|| {
+        std::io::Error::new(
             std::io::ErrorKind::InvalidInput,
             format!(
-                "filesystem event {} escaped repository root {}: {error}",
-                path.display(),
-                working_dir.display()
+                "filesystem event has no repository entry name: {}",
+                path.display()
             ),
-        ))
+        )
     })?;
+    let mut unresolved = vec![leaf.to_os_string()];
+    let mut ancestor = path.parent().ok_or_else(|| {
+        std::io::Error::new(
+            std::io::ErrorKind::InvalidInput,
+            format!(
+                "filesystem event has no parent directory: {}",
+                path.display()
+            ),
+        )
+    })?;
+
+    loop {
+        match ancestor.canonicalize() {
+            Ok(mut canonical) => {
+                for component in unresolved.iter().rev() {
+                    canonical.push(component);
+                }
+                return Ok(canonical);
+            }
+            Err(error) if error.kind() == std::io::ErrorKind::NotFound => {
+                let component = ancestor.file_name().ok_or_else(|| {
+                    std::io::Error::new(
+                        std::io::ErrorKind::NotFound,
+                        format!(
+                            "filesystem event has no existing ancestor to establish repository containment: {}",
+                            path.display()
+                        ),
+                    )
+                })?;
+                unresolved.push(component.to_os_string());
+                ancestor = ancestor.parent().ok_or_else(|| {
+                    std::io::Error::new(
+                        std::io::ErrorKind::NotFound,
+                        format!(
+                            "filesystem event has no existing ancestor to establish repository containment: {}",
+                            path.display()
+                        ),
+                    )
+                })?;
+            }
+            Err(error) => return Err(error),
+        }
+    }
+}
+
+fn repo_path(path: &Path, working_dir: &Path) -> Result<Option<RepoPath>> {
+    // Normalize the repository root and the event's nearest existing parent.
+    // This treats macOS aliases such as /var and /private/var as the same
+    // directory without dereferencing the final entry (which may itself be a
+    // dangling symlink, or already removed). Resolving the parent also rejects
+    // events that appear lexically beneath the repository but traverse a
+    // directory symlink out of it.
+    let canonical_root = working_dir.canonicalize().map_err(DaemonError::Io)?;
+    let canonical_path = canonicalize_host_parent_preserving_leaf(path).map_err(DaemonError::Io)?;
+    let relative = canonical_path
+        .strip_prefix(&canonical_root)
+        .map_err(|error| {
+            DaemonError::Io(std::io::Error::new(
+                std::io::ErrorKind::InvalidInput,
+                format!(
+                    "filesystem event {} escaped repository root {}: {error}",
+                    path.display(),
+                    working_dir.display()
+                ),
+            ))
+        })?;
     let repo_path = kin_index::repo_path_from_host_relative(relative).map_err(DaemonError::Io)?;
     if kin_index::is_repository_control_path(&repo_path) {
         return Ok(None);
@@ -989,7 +1031,7 @@ pub async fn run_loop(
         let mut graph_changed = false;
         let mut projection_changed = ProjectionChangedSet::default();
 
-        let mut lsp_changed: Vec<(PathBuf, Vec<kin_model::EntityId>)> = Vec::new();
+        let mut lsp_changed: Vec<(kin_model::FilePathId, Vec<kin_model::EntityId>)> = Vec::new();
         let graph_mutation = state.begin_graph_authority_mutation();
 
         // One complete observation produces one exact tree transaction. This
@@ -1315,6 +1357,7 @@ pub async fn run_loop(
                     }
 
                     if let ReconcileOutcome::Updated {
+                        file_id,
                         added,
                         modified,
                         removed,
@@ -1368,7 +1411,7 @@ pub async fn run_loop(
                             "reconcile entity counts for LSP enrichment"
                         );
                         if !changed_ids.is_empty() {
-                            lsp_changed.push((path.clone(), changed_ids));
+                            lsp_changed.push((file_id.clone(), changed_ids));
                         }
                     } else if let ReconcileOutcome::FileRemoved {
                         removed, file_id, ..
@@ -1434,9 +1477,9 @@ pub async fn run_loop(
         drop(coordination);
 
         // Queue only changed entities for LSP enrichment.
-        for (path, entity_ids) in lsp_changed {
+        for (file_id, entity_ids) in lsp_changed {
             state.queue_lsp_enrichment(LspEnrichmentRequest {
-                file_path: path,
+                file_id,
                 changed_entity_ids: entity_ids,
             });
         }
@@ -1537,6 +1580,62 @@ mod tests {
     fn open_test_state(repo: &tempfile::TempDir) -> Arc<DaemonState> {
         let init = kin_core::init(repo.path()).unwrap();
         Arc::new(DaemonState::open(init.layout).unwrap())
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn repo_path_accepts_a_host_alias_without_dereferencing_the_leaf() {
+        use std::os::unix::fs::symlink;
+
+        let repo = tempfile::tempdir().unwrap();
+        let state = open_test_state(&repo);
+        let aliases = tempfile::tempdir().unwrap();
+        let alias = aliases.path().join("repo-alias");
+        symlink(repo.path(), &alias).unwrap();
+        symlink("missing-target", repo.path().join("current")).unwrap();
+
+        assert_eq!(
+            repo_path(&alias.join("current"), state.layout.working_dir()).unwrap(),
+            Some(test_repo_path("current")),
+            "host-root aliases must normalize while a dangling symlink remains the repository entry"
+        );
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn repo_path_rejects_a_directory_symlink_escape() {
+        use std::os::unix::fs::symlink;
+
+        let repo = tempfile::tempdir().unwrap();
+        let state = open_test_state(&repo);
+        let outside = tempfile::tempdir().unwrap();
+        symlink(outside.path(), repo.path().join("escape")).unwrap();
+
+        // Build the event from the canonical root so the path is already a
+        // lexical child of the repository. Containment must then be decided by
+        // resolving the parent, not by the string prefix alone.
+        let root = state.layout.working_dir().to_path_buf();
+        let error = repo_path(&root.join("escape/secret.txt"), &root)
+            .expect_err("a lexical child that resolves outside the repository must be rejected");
+        assert!(error.to_string().contains("escaped repository root"));
+    }
+
+    #[test]
+    fn repo_path_keeps_identity_for_an_entry_whose_parent_is_already_gone() {
+        let repo = tempfile::tempdir().unwrap();
+        let state = open_test_state(&repo);
+        let root = state.layout.working_dir().to_path_buf();
+        std::fs::create_dir_all(root.join("removed")).unwrap();
+        std::fs::write(root.join("removed/module.rs"), b"fn gone() {}\n").unwrap();
+        std::fs::remove_dir_all(root.join("removed")).unwrap();
+
+        // Removal events arrive after the directory is gone. Resolving the
+        // nearest existing ancestor keeps the entry admissible instead of
+        // dropping its removal on a missing-parent error.
+        assert_eq!(
+            repo_path(&root.join("removed/module.rs"), &root).unwrap(),
+            Some(test_repo_path("removed/module.rs"))
+        );
     }
 
     fn test_repo_path(path: &str) -> RepoPath {

--- a/crates/kin-daemon/src/state.rs
+++ b/crates/kin-daemon/src/state.rs
@@ -520,10 +520,62 @@ pub enum ChangeType {
 /// Request sent from the reconcile loop to the LSP enrichment worker.
 #[derive(Debug)]
 pub struct LspEnrichmentRequest {
-    /// Path to the changed file.
-    pub file_path: std::path::PathBuf,
+    /// Graph-owned repository path of the changed file. The LSP worker may
+    /// derive a compatibility URI from this identity, but must load didOpen
+    /// bytes from repository authority rather than the working filesystem.
+    pub file_id: FilePathId,
     /// Entity IDs that were added or modified — only these get queried via LSP.
     pub changed_entity_ids: Vec<kin_model::EntityId>,
+}
+
+/// Reusable graph/CAS source view for daemon-side enrichment.
+///
+/// The authority manager is opened once per worker rather than once per file.
+/// Source bodies are immutable and addressed by the live graph entry hash, so
+/// later workspace admissions remain visible through the same manager without
+/// trusting a stale metadata snapshot.
+pub(crate) struct GraphOwnedSourceView {
+    graph: Arc<kin_db::InMemoryGraph>,
+    authority: RepositoryAuthorityManager<LocalFileBackend>,
+}
+
+impl GraphOwnedSourceView {
+    pub(crate) fn load_text(&self, file_id: &FilePathId) -> Result<String> {
+        let path = RepoPath::from_utf8(file_id.0.clone()).map_err(|error| {
+            exact_source_storage_error(format!(
+                "LSP source path {file_id} is not an exact repository path: {error}"
+            ))
+        })?;
+        let entry = self
+            .graph
+            .get_tree_entry(file_id)
+            .map_err(DaemonError::from)?
+            .ok_or_else(|| {
+                exact_source_storage_error(format!(
+                    "LSP source path {file_id} has no graph-owned tree entry"
+                ))
+            })?;
+        let TreeEntry::Blob { hash, .. } = entry else {
+            return Err(exact_source_storage_error(format!(
+                "LSP source path {file_id} is not a source blob"
+            )));
+        };
+        let data = self
+            .authority
+            .load_source_blob(hash)
+            .map_err(DaemonError::from)?
+            .ok_or_else(|| {
+                exact_source_storage_error(format!(
+                    "graph-owned LSP source {file_id} references body {hash} absent from repository authority"
+                ))
+            })?;
+        validate_exact_source_bytes(&path, entry, hash, &data, "repository")?;
+        String::from_utf8(data).map_err(|error| {
+            exact_source_storage_error(format!(
+                "graph-owned LSP source {file_id} at {hash} is not UTF-8: {error}"
+            ))
+        })
+    }
 }
 
 #[derive(Debug, Default)]
@@ -1064,6 +1116,25 @@ impl DaemonState {
             workspace_id,
             backend,
         ))
+    }
+
+    /// Open a reusable UTF-8 source view for graph-backed LSP enrichment.
+    ///
+    /// The live graph selects the exact tree entry; repository-v6 immutable CAS
+    /// supplies and verifies its bytes. The working filesystem and the derived
+    /// ingestion CAS are never consulted, so a checkout drift or cache loss
+    /// cannot silently become semantic-relation authority. The manager is
+    /// opened through the startup-pinned storage capability, which refuses a
+    /// hosted daemon and preserves KinDB's device/inode root pin.
+    pub(crate) fn graph_owned_source_view(&self) -> Result<GraphOwnedSourceView> {
+        let authority =
+            crate::local_repository_authority::LocalRepositoryAuthorityContext::from_state(self)?
+                .open()
+                .map_err(DaemonError::from)?;
+        Ok(GraphOwnedSourceView {
+            graph: Arc::clone(&self.graph),
+            authority,
+        })
     }
 
     /// Begin one entity/relation authority mutation batch.
@@ -5384,6 +5455,78 @@ mod tests {
                 .to_string()
                 .contains("does not match manifest authority"),
             "unexpected identity mismatch error: {error}"
+        );
+    }
+
+    #[test]
+    fn lsp_source_text_uses_graph_and_repository_cas_not_checkout_or_ingest_cache() {
+        let repo_dir = tempfile::tempdir().unwrap();
+        let init = kin_core::init(repo_dir.path()).unwrap();
+        let blobs = BlobStore::new(init.layout.ingest_cas_dir()).unwrap();
+        let authority_bytes = b"pub fn authority_owned() {}\n";
+        let hash = Hash256::from_bytes(blobs.write(authority_bytes).unwrap().0);
+        let desired = ResolvedTree::from_artifacts([ResolvedArtifact::new(
+            ArtifactId::new(),
+            RepoPath::from_utf8("src/lib.rs").unwrap(),
+            TreeEntry::blob(hash, false),
+        )])
+        .unwrap();
+        crate::repository_commit::publish_workspace_tree(
+            &blobs,
+            &crate::local_repository_authority::LocalRepositoryAuthorityContext::from_layout_for_test(
+                &init.layout,
+            )
+            .unwrap(),
+            &desired,
+            kin_model::OperationId::new(),
+            kin_model::AuthorId::new("lsp-authority-test"),
+        )
+        .unwrap()
+        .expect("exact source admission must advance authority");
+
+        let state = DaemonState::open(init.layout).unwrap();
+        // Drift the checkout and destroy the derived ingestion cache. Neither
+        // may answer, and neither may repair, a graph-owned source read.
+        std::fs::create_dir_all(repo_dir.path().join("src")).unwrap();
+        std::fs::write(
+            repo_dir.path().join("src/lib.rs"),
+            b"pub fn unadmitted_checkout_drift() {}\n",
+        )
+        .unwrap();
+        std::fs::remove_file(local_object_path(&state.layout, hash)).unwrap();
+
+        assert_eq!(
+            state
+                .graph_owned_source_view()
+                .unwrap()
+                .load_text(&FilePathId::new("src/lib.rs"))
+                .unwrap(),
+            std::str::from_utf8(authority_bytes).unwrap()
+        );
+    }
+
+    #[test]
+    fn lsp_source_text_refuses_a_path_absent_from_graph_authority() {
+        let repo_dir = tempfile::tempdir().unwrap();
+        let init = kin_core::init(repo_dir.path()).unwrap();
+        let state = DaemonState::open(init.layout).unwrap();
+        // A file that exists only in the checkout has no graph-owned tree
+        // entry, so enrichment must fail loudly instead of reading it.
+        std::fs::create_dir_all(repo_dir.path().join("src")).unwrap();
+        std::fs::write(
+            repo_dir.path().join("src/lib.rs"),
+            b"pub fn never_admitted() {}\n",
+        )
+        .unwrap();
+
+        let error = state
+            .graph_owned_source_view()
+            .unwrap()
+            .load_text(&FilePathId::new("src/lib.rs"))
+            .expect_err("an unadmitted checkout file must not become LSP source authority");
+        assert!(
+            error.to_string().contains("no graph-owned tree entry"),
+            "unexpected graph-miss error: {error}"
         );
     }
 


### PR DESCRIPTION
Re-authors two pre-v6 hardening changes against the current daemon. Both home files were rewritten by the authority cutover, so this is a re-implementation of the intent, not a cherry-pick. Both were verified as live on `main` before any code was written.

## 1. LSP source text comes from graph plus repository CAS

**The violation, on `main` today.** `crates/kin-daemon/src/daemon.rs` opened `textDocument/didOpen` content with `std::fs::read_to_string` on a host path, in both the incremental path and the sweep path. LSP enrichment writes semantic relations into the graph, so relation authority was being derived from whatever the working checkout happened to hold. Nothing selected the file through the graph, and nothing verified the bytes.

**The change.** `LspEnrichmentRequest` now carries `file_id: FilePathId` instead of a host `PathBuf`, so the request is graph identity from the moment the reconcile loop emits it. A new `GraphOwnedSourceView` resolves each read as: live graph selects the exact `TreeEntry::Blob`, repository-v6 immutable CAS supplies its body, `validate_exact_source_bytes` confirms the bytes are the entry they claim to be and are materializable. The host path survives only as the URI handed to the language server, which is a compatibility projection and never a content source.

A missing body, an authority mismatch, or a path with no tree entry now skips that enrichment request with a warning. Neither the checkout nor the derived ingestion CAS can answer a source read or silently repair one.

**v6-specific detail.** The view opens its authority manager through `LocalRepositoryAuthorityContext::from_state`, the startup-pinned storage capability, rather than constructing a fresh `LocalFileBackend` from the layout. KinDB pins the storage root's device/inode identity on that backend; a new path-based backend would accept an identically copied replacement root. This also makes the view fail closed on a hosted daemon, which has no local repository backend.

The sweep loop additionally dropped its `abs_path.exists()` filter. A graph-owned file whose compatibility projection is absent from the host is still a legitimate enrichment target.

## 2. Admitted filesystem event paths are normalized

**The violation, on `main` today.** `repo_path` in `loop_runner.rs` only resolved the event's parent when the *lexical* `strip_prefix` against the repository root failed. A path that sits lexically under the repository but traverses a directory symlink out of it passed the prefix check and was admitted under an in-repository identity.

**The change.** Admission now canonicalizes both the repository root and the event's nearest existing parent, then decides containment on the resolved paths. The leaf is deliberately left unresolved, so a dangling symlink or an already-removed entry keeps its own identity instead of being dereferenced or rejected as missing. `canonicalize_host_parent_preserving_leaf` walks up to the nearest existing ancestor, which is what makes always-canonicalizing safe for removal events that arrive after their directory is gone.

## Tests, and what each one actually distinguishes

Every guard was falsified by reverting the behavior it claims to protect and confirming the test fails.

| Test | Falsified against | Result |
|---|---|---|
| `lsp_source_text_uses_graph_and_repository_cas_not_checkout_or_ingest_cache` | source view repointed at the derived ingest CAS | FAILS |
| `repo_path_rejects_a_directory_symlink_escape` | previous `repo_path` body | FAILS, admits `escape/secret.txt` |
| `repo_path_keeps_identity_for_an_entry_whose_parent_is_already_gone` | ancestor walk disabled | FAILS with `NotFound` |

The LSP test drifts the checkout *and* deletes the ingest CAS object before reading, so it fails if either surface answers.

Two further notes, stated plainly rather than overclaimed:

- `repo_path_accepts_a_host_alias_without_dereferencing_the_leaf` passes against the old code as well. It is a preserved-behavior regression guard, not proof of new capability. It is worth keeping because always-canonicalizing is exactly the kind of change that breaks alias handling and starts dereferencing dangling leaves.
- `lsp_source_text_refuses_a_path_absent_from_graph_authority` guards against a checkout fallback being reintroduced on the graph-miss path. Its distinguishing power is structural (the `expect_err` cannot pass if any fallback returns content) and was not separately falsified by mutation.

A first attempt at the escape test did not distinguish: on macOS `tempfile::tempdir()` returns a `/var/...` path while `KinLayout` stores the canonical `/private/var/...` root, so the lexical prefix check failed for incidental reasons and dragged the old code onto its safe branch. The test now builds the event path from the canonical root so the fast path genuinely engages.

## Gate

Run in an isolated lane worktree, rebased onto `b769aaa3`.

- `cargo fmt --all -- --check` clean
- `cargo clippy --all-targets --all-features` with the ci.yml allowlist and `RUSTFLAGS=-D warnings` clean
- `scripts/check_runtime_boundaries.sh` passed
- `scripts/check_private_repo_coupling.sh` passed
- `cargo build --all-targets --locked` clean
- `cargo test --workspace --locked` result recorded in the thread below

No existing refusal was weakened. Both changes are strictly fail-closed additions.
