### PR TITLE
Revalidate the pinned repository namespace on every authority bind and expose checkout

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3237,9 +3237,9 @@ dependencies = [
 
 [[package]]
 name = "kin-db"
-version = "0.6.1"
+version = "0.6.3"
 source = "sparse+https://kinlab.ai/registry/cargo/"
-checksum = "aebd1093ec20ec38a52fc39c074240ad96af63aa9a574e2173014e9bdb590bd8"
+checksum = "8f2e86b147b1aabc744d46bf2af7ddc0ff1da7d5d518d08c5f48a35c5268f44d"
 dependencies = [
  "bincode",
  "bstr",
@@ -3278,7 +3278,6 @@ dependencies = [
  "tokio",
  "tracing",
  "uuid",
- "winapi-util",
  "windows-sys 0.61.2",
 ]
 
@@ -3443,9 +3442,9 @@ dependencies = [
 
 [[package]]
 name = "kin-model"
-version = "0.6.0"
+version = "0.6.1"
 source = "sparse+https://kinlab.ai/registry/cargo/"
-checksum = "41dd393ac2ce6fb40d662fcc0d816db8d0b536c8856c2c62bbb705e3ccbbca59"
+checksum = "a6cf7f074145c0582e6a05f995c33ff714969e9bcb4ed54af1365816ed8e86dd"
 dependencies = [
  "chrono",
  "gix-hash",
@@ -6584,7 +6583,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.48.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -122,7 +122,7 @@ pretty_assertions = "1"
 serial_test = "3"
 
 # Internal crates
-kin-model = { version = "=0.6.0", registry = "kin" }
+kin-model = { version = "=0.6.1", registry = "kin" }
 kin-blobs = { version = "0.1.1", registry = "kin" }
 kin-core = { path = "crates/kin-core" }
 kin-parser = { path = "crates/kin-parser" }
@@ -150,7 +150,7 @@ kin-lsp = { version = "0.6.0", registry = "kin" }
 # backend on every target (incl. Linux, where it cannot compile). Metal is re-enabled
 # additively on macOS via a `[target.'cfg(target_os = "macos")'.dependencies]` block in the
 # binary/runtime crates (kin-cli, kin-daemon). Feature unification makes that additive.
-kin-db = { version = "0.6.1", registry = "kin", default-features = false }
+kin-db = { version = "0.6.3", registry = "kin", default-features = false }
 kin-vfs-core = { version = "0.1.5", registry = "kin" }
 
 [profile.release]

--- a/crates/kin-cli/tests/command_capabilities.rs
+++ b/crates/kin-cli/tests/command_capabilities.rs
@@ -37,10 +37,10 @@ fn capability_json_keeps_the_bounded_dogfood_bar_explicit() {
     assert_eq!(report["schema"], "kin.git-replacement-capabilities.v1");
     assert_eq!(report["substrate"], "repository-v6");
     assert_eq!(report["bounded_dogfood_ready"], false);
-    assert_eq!(report["bounded_dogfood_required_ready"], 10);
+    assert_eq!(report["bounded_dogfood_required_ready"], 11);
     assert_eq!(report["bounded_dogfood_required_total"], 12);
     assert_eq!(report["full_git_replacement_ready"], false);
-    assert_eq!(report["ready_commands"], 12);
+    assert_eq!(report["ready_commands"], 13);
     assert_eq!(report["command_total"], 32);
 
     let commands = report["commands"]
@@ -124,15 +124,21 @@ fn remaining_open_gate_commands_fail_before_repository_discovery() {
     assert!(stderr.contains("`kin reconcile` is fail-closed on repository-v6"));
     assert!(stderr.contains("kin capabilities --json"));
 
+    // Checkout is exposed now, so it must fail on repository discovery rather
+    // than on the capability gate. Asserting the gate message is absent keeps a
+    // silent re-seal from passing as a discovery failure.
     let output = kin_command(&home)
         .args(["checkout", "src/lib.rs"])
         .current_dir(root.path())
         .output()
-        .expect("run gated checkout");
+        .expect("run exposed checkout outside a repository");
     assert!(!output.status.success());
     let stderr = String::from_utf8_lossy(&output.stderr);
-    assert!(stderr.contains("`kin checkout` is fail-closed on repository-v6"));
-    assert!(stderr.contains("kin capabilities --json"));
+    assert!(
+        !stderr.contains("is fail-closed on repository-v6"),
+        "checkout must no longer answer from the capability gate: {stderr}"
+    );
+    assert!(stderr.contains("not a Kin repository"), "{stderr}");
 }
 
 #[test]

--- a/crates/kin-cli/tests/fixtures/git-replacement-capabilities-v1.json
+++ b/crates/kin-cli/tests/fixtures/git-replacement-capabilities-v1.json
@@ -214,12 +214,13 @@
     },
     {
       "command": "checkout",
-      "status": "open_gate",
-      "exposure": "fail_closed",
+      "status": "ready",
+      "exposure": "enabled",
       "authority": "daemon-private repository-v6 exact tree, semantic graph, source CAS, and crash-recoverable projection transaction",
       "required_for_bounded_dogfood": true,
       "acceptance_spec": [
         "resolve a selected immutable change through startup-pinned repository and workspace identity without Git or legacy object fallback",
+        "refuse a repository storage namespace replaced at the same ambient path, detached, or absent from the pinned store instead of answering from replacement authority",
         "verify complete selected tree, semantic graph, and source CAS closure before one projection and authority transaction",
         "preserve every unsupported-language and non-code artifact, executable bit, symlink, gitlink, opaque binary, and host-unrepresentable byte path in graph authority while materializing only host-representable entries",
         "reject every session-scoped request before mutation and preserve independently dirty unselected paths",
@@ -230,9 +231,13 @@
         "kin_daemon::api::tests::command_checkout_persists_same_tree_semantics_and_replays_after_restart",
         "kin_daemon::api::tests::command_checkout_rejects_unknown_unscoped_and_expired_sessions_without_mutation",
         "kin_daemon::api::tests::command_checkout_returns_typed_bad_request_and_conflict_statuses",
-        "kin_daemon::api::tests::command_checkout_projection_only_repairs_universal_bytes_and_replays_after_restart"
+        "kin_daemon::api::tests::command_checkout_projection_only_repairs_universal_bytes_and_replays_after_restart",
+        "kin_daemon::api::tests::command_checkout_refuses_replaced_repository_namespace_without_mutation",
+        "kin_daemon::api::tests::command_checkout_refuses_detached_repository_namespace_without_mutation",
+        "kin_core::repository_authority::tests::retained_binding_rejects_identical_repository_namespace_replacement",
+        "kin_core::repository_authority::tests::retained_binding_rejects_detached_repository_namespace"
       ],
-      "note": "The daemon-private checkout boundary and its exact replay tests are complete, but exposure remains fail-closed until kin-db retains and revalidates the selected repository authority subtree—not only the top-level storage root—across the daemon process lifetime."
+      "note": "Checkout binds only the repository and workspace identity this daemon pinned at startup, revalidates the retained per-repository storage namespace before planning, and answers a namespace replaced at the same ambient path, detached, or absent from the pinned store with a typed conflict instead of mismatched truth. Exact projection, universal artifact preservation, and caller-stable replay are proven across same-daemon and restart gaps. The retained-identity refusals are proven on Unix; the Windows file-identity path is implemented but not covered by CI."
     },
     {
       "command": "push",

--- a/crates/kin-core/src/lib.rs
+++ b/crates/kin-core/src/lib.rs
@@ -78,4 +78,6 @@ pub use ranking::{
     normalize_symbol_hint, normalize_trace_name, qualifier_hint_from_query, select_best_match,
 };
 pub use ref_view::{build_graph_at_ref, collect_changes_at_ref, filter_vector_results_to_scope};
-pub use repository_authority::LocalRepositoryAuthorityBinding;
+pub use repository_authority::{
+    revalidate_pinned_local_namespace, LocalRepositoryAuthorityBinding,
+};

--- a/crates/kin-core/src/repository_authority.rs
+++ b/crates/kin-core/src/repository_authority.rs
@@ -72,7 +72,7 @@ impl LocalRepositoryAuthorityBinding {
             WorkspaceId::from_uuid(workspace_uuid),
             Arc::new(LocalFileBackend::new(layout.kindb_dir())),
         );
-        binding.pin_local_namespace().map_err(|error| {
+        binding.revalidate_pinned_namespace().map_err(|error| {
             KinError::Other(format!(
                 "cannot pin repository authority namespace at startup: {error}"
             ))
@@ -88,33 +88,57 @@ impl LocalRepositoryAuthorityBinding {
         self.workspace_id
     }
 
-    /// Pin and validate the exact local storage root and repository namespace
-    /// without decoding the full graph snapshot.
+    /// Revalidate the retained storage root and per-repository authority
+    /// namespace without decoding the full graph snapshot.
     ///
-    /// KinDB's capability-backed repository listing retains both identities;
-    /// later `open_manager` calls therefore reject a root or per-repository
-    /// directory that was swapped after process startup.
-    pub fn pin_local_namespace(&self) -> std::result::Result<(), kin_db::KinDbError> {
-        let repositories = self.backend.list_repos()?;
-        if repositories
-            .iter()
-            .any(|repository| repository == self.repository_id.as_str())
-        {
-            Ok(())
-        } else {
-            Err(kin_db::KinDbError::StorageError(format!(
-                "local storage authority has no repository namespace {}",
-                self.repository_id
-            )))
-        }
+    /// See [`revalidate_pinned_local_namespace`] for the exact property this
+    /// refuses on.
+    pub fn revalidate_pinned_namespace(&self) -> std::result::Result<(), kin_db::KinDbError> {
+        revalidate_pinned_local_namespace(&self.backend, &self.repository_id)
     }
 
     /// Open a coherent authority manager through the retained storage
-    /// capability. KinDB revalidates the pinned storage-root identity here.
+    /// capability.
+    ///
+    /// KinDB revalidates both the pinned storage-root identity and the
+    /// retained per-repository namespace identity here, and retains the
+    /// per-repository capability on the first successful call.
     pub fn open_manager(
         &self,
     ) -> std::result::Result<RepositoryAuthorityManager<LocalFileBackend>, kin_db::KinDbError> {
         RepositoryAuthorityManager::open(self.repository_id.clone(), Arc::clone(&self.backend))
+    }
+}
+
+/// Refuse `repository_id` unless `backend` still reaches the exact storage root
+/// and per-repository authority namespace it has already pinned.
+///
+/// KinDB retains a per-repository storage capability the first time repository
+/// authority is read through a backend, keyed on the namespace directory's
+/// filesystem identity, and revalidates that identity on every later access.
+/// Reading authority identity through the same retained backend therefore
+/// refuses a repository directory replaced at the same ambient path, a detached
+/// namespace, and a store that does not hold this repository at all.
+///
+/// This deliberately addresses the one repository by name rather than
+/// enumerating the storage root. `.kin/kindb/` also holds snapshot, vector,
+/// index, and generation files beside the repository namespaces, so a listing
+/// pass answers for entries that carry no authority and are not this caller's
+/// concern.
+///
+/// Ordering is load-bearing. The first read on a fresh backend is what takes
+/// the pin, so a long-lived process must take it once at startup and revalidate
+/// on every later authority bind; a swap that lands before the first read
+/// becomes the baseline rather than a refusal.
+pub fn revalidate_pinned_local_namespace(
+    backend: &LocalFileBackend,
+    repository_id: &RepositoryId,
+) -> std::result::Result<(), kin_db::KinDbError> {
+    match backend.load_snapshot_authority(repository_id.as_str())? {
+        Some(_) => Ok(()),
+        None => Err(kin_db::KinDbError::StorageError(format!(
+            "local storage authority does not hold repository namespace {repository_id}"
+        ))),
     }
 }
 
@@ -161,6 +185,106 @@ mod tests {
                 .to_string()
                 .contains("changed since this backend opened"),
             "unexpected root-replacement error: {error}"
+        );
+    }
+
+    #[test]
+    fn retained_binding_rejects_identical_repository_namespace_replacement() {
+        let directory = tempfile::tempdir().unwrap();
+        let initialized = crate::init(directory.path()).unwrap();
+        let binding = LocalRepositoryAuthorityBinding::from_layout(&initialized.layout).unwrap();
+        // The pin is taken before the swap, which is what makes the replacement
+        // detectable at all rather than becoming the new baseline.
+        binding.open_manager().unwrap();
+
+        let namespace = initialized
+            .layout
+            .kindb_dir()
+            .join(binding.repository_id().as_str());
+        let replacement = initialized.layout.root().join("namespace-replacement");
+        let original = initialized.layout.root().join("namespace-original");
+        copy_directory(&namespace, &replacement);
+        std::fs::rename(&namespace, &original).unwrap();
+        std::fs::rename(&replacement, &namespace).unwrap();
+
+        let error = binding
+            .revalidate_pinned_namespace()
+            .expect_err("retained binding must refuse a replaced repository namespace");
+        assert!(
+            error.to_string().contains("refusing replacement authority"),
+            "unexpected namespace-replacement revalidation error: {error}"
+        );
+
+        let error = match binding.open_manager() {
+            Ok(_) => panic!("retained binding must refuse authority from a replaced namespace"),
+            Err(error) => error,
+        };
+        assert!(
+            error.to_string().contains("refusing replacement authority"),
+            "unexpected namespace-replacement authority error: {error}"
+        );
+    }
+
+    #[test]
+    fn retained_binding_rejects_detached_repository_namespace() {
+        let directory = tempfile::tempdir().unwrap();
+        let initialized = crate::init(directory.path()).unwrap();
+        let binding = LocalRepositoryAuthorityBinding::from_layout(&initialized.layout).unwrap();
+        binding.open_manager().unwrap();
+
+        let namespace = initialized
+            .layout
+            .kindb_dir()
+            .join(binding.repository_id().as_str());
+        std::fs::rename(
+            &namespace,
+            initialized.layout.root().join("namespace-detached"),
+        )
+        .unwrap();
+
+        let error = binding
+            .revalidate_pinned_namespace()
+            .expect_err("retained binding must refuse a detached repository namespace");
+        assert!(
+            error.to_string().contains("detached after this backend"),
+            "unexpected detached-namespace revalidation error: {error}"
+        );
+
+        let error = match binding.open_manager() {
+            Ok(_) => panic!("retained binding must refuse authority from a detached namespace"),
+            Err(error) => error,
+        };
+        assert!(
+            error.to_string().contains("detached after this backend"),
+            "unexpected detached-namespace authority error: {error}"
+        );
+    }
+
+    #[test]
+    fn binding_refuses_a_store_that_does_not_hold_its_repository() {
+        let directory = tempfile::tempdir().unwrap();
+        let mine_root = directory.path().join("mine");
+        let other_root = directory.path().join("other");
+        std::fs::create_dir_all(&mine_root).unwrap();
+        std::fs::create_dir_all(&other_root).unwrap();
+        let mine = crate::init(&mine_root).unwrap();
+        let other = crate::init(&other_root).unwrap();
+        let mine_binding = LocalRepositoryAuthorityBinding::from_layout(&mine.layout).unwrap();
+
+        let wrong_store = LocalRepositoryAuthorityBinding::from_parts(
+            mine_binding.repository_id().clone(),
+            mine_binding.workspace_id(),
+            Arc::new(LocalFileBackend::new(other.layout.kindb_dir())),
+        );
+
+        let error = wrong_store
+            .revalidate_pinned_namespace()
+            .expect_err("a binding must refuse a store that does not hold its repository");
+        assert!(
+            error
+                .to_string()
+                .contains("does not hold repository namespace"),
+            "unexpected wrong-store error: {error}"
         );
     }
 }

--- a/crates/kin-daemon/src/api.rs
+++ b/crates/kin-daemon/src/api.rs
@@ -10724,9 +10724,18 @@ mod tests {
             .iter()
             .all(|repository_ref| repository_ref.name != branch);
 
+        // A replaced storage root is the same refusal as a replaced repository
+        // namespace under it: the pinned authority is no longer at that path.
+        // Both answer with a conflict rather than an internal fault.
         assert_eq!(
             branch_status,
-            StatusCode::INTERNAL_SERVER_ERROR,
+            StatusCode::CONFLICT,
+            "{}",
+            String::from_utf8_lossy(&branch_body)
+        );
+        assert!(
+            String::from_utf8_lossy(&branch_body)
+                .contains("pinned at startup is no longer the one at that path"),
             "{}",
             String::from_utf8_lossy(&branch_body)
         );

--- a/crates/kin-daemon/src/api.rs
+++ b/crates/kin-daemon/src/api.rs
@@ -11638,6 +11638,155 @@ mod tests {
         assert_eq!(authority.manager.read_authority().roots(), &roots_before);
     }
 
+    #[cfg(unix)]
+    fn copy_directory_tree(source: &FsPath, target: &FsPath) {
+        std::fs::create_dir(target).unwrap();
+        for entry in std::fs::read_dir(source).unwrap() {
+            let entry = entry.unwrap();
+            let source_path = entry.path();
+            let target_path = target.join(entry.file_name());
+            if entry.file_type().unwrap().is_dir() {
+                copy_directory_tree(&source_path, &target_path);
+            } else {
+                std::fs::copy(source_path, target_path).unwrap();
+            }
+        }
+    }
+
+    #[cfg(unix)]
+    fn pinned_repository_namespace(state: &DaemonState) -> PathBuf {
+        let manifest =
+            kin_core::manifest::KinManifest::load(&state.layout.manifest_path()).unwrap();
+        state.layout.kindb_dir().join(manifest.repo_id)
+    }
+
+    /// Prove the retained per-repository capability, not only the storage root,
+    /// is what checkout answers from: a byte-identical repository namespace
+    /// copied over the same ambient path mid-daemon-lifetime is refused.
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn command_checkout_refuses_replaced_repository_namespace_without_mutation() {
+        let state = committed_test_state();
+        let checkout = |operation_id| kin_cli::commands::checkout::CheckoutRequest {
+            path: Some("README.md".to_string()),
+            path_hex: None,
+            change_id: None,
+            operation_id,
+            actor: AuthorId::new("checkout-namespace-replacement-test"),
+        };
+
+        // Establish the baseline: the same request succeeds while the pinned
+        // namespace is intact, so the later refusal cannot be blamed on an
+        // unrelated defect in the request itself.
+        let accepted = router(Arc::clone(&state))
+            .oneshot(
+                Request::post("/commands/checkout")
+                    .header("content-type", "application/json")
+                    .body(Body::from(
+                        serde_json::to_vec(&checkout(kin_model::OperationId::new())).unwrap(),
+                    ))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(accepted.status(), StatusCode::OK);
+        let generation_before = state
+            .snapshot_generation
+            .load(std::sync::atomic::Ordering::SeqCst);
+        let roots_before = state.graph.compute_root_hash();
+
+        // Stage both halves of the swap outside the storage root: a spare
+        // namespace directory inside it would be listed as a second repository
+        // resolving onto the retained identity, which is a different refusal.
+        let namespace = pinned_repository_namespace(&state);
+        let replacement = state.layout.root().join("namespace-replacement");
+        let displaced = state.layout.root().join("namespace-displaced");
+        copy_directory_tree(&namespace, &replacement);
+        std::fs::rename(&namespace, &displaced).unwrap();
+        std::fs::rename(&replacement, &namespace).unwrap();
+
+        let refused = router(Arc::clone(&state))
+            .oneshot(
+                Request::post("/commands/checkout")
+                    .header("content-type", "application/json")
+                    .body(Body::from(
+                        serde_json::to_vec(&checkout(kin_model::OperationId::new())).unwrap(),
+                    ))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        let status = refused.status();
+        let body = axum::body::to_bytes(refused.into_body(), 64 * 1024)
+            .await
+            .unwrap();
+        let body = String::from_utf8_lossy(&body);
+        assert_eq!(status, StatusCode::CONFLICT, "{body}");
+        assert!(
+            body.contains("pinned at startup is no longer the one at that path"),
+            "refusal must name the pinned-namespace mismatch: {body}"
+        );
+        assert_eq!(
+            state
+                .snapshot_generation
+                .load(std::sync::atomic::Ordering::SeqCst),
+            generation_before,
+            "a refused checkout must not advance repository authority"
+        );
+        assert_eq!(state.graph.compute_root_hash(), roots_before);
+    }
+
+    /// A repository namespace detached from under a live daemon must fail
+    /// closed rather than fall back to the storage root or a fresh namespace.
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn command_checkout_refuses_detached_repository_namespace_without_mutation() {
+        let state = committed_test_state();
+        let generation_before = state
+            .snapshot_generation
+            .load(std::sync::atomic::Ordering::SeqCst);
+
+        let namespace = pinned_repository_namespace(&state);
+        std::fs::rename(&namespace, state.layout.root().join("namespace-detached")).unwrap();
+
+        let request = kin_cli::commands::checkout::CheckoutRequest {
+            path: Some("README.md".to_string()),
+            path_hex: None,
+            change_id: None,
+            operation_id: kin_model::OperationId::new(),
+            actor: AuthorId::new("checkout-namespace-detach-test"),
+        };
+        let refused = router(Arc::clone(&state))
+            .oneshot(
+                Request::post("/commands/checkout")
+                    .header("content-type", "application/json")
+                    .body(Body::from(serde_json::to_vec(&request).unwrap()))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        let status = refused.status();
+        let body = axum::body::to_bytes(refused.into_body(), 64 * 1024)
+            .await
+            .unwrap();
+        let body = String::from_utf8_lossy(&body);
+        assert_eq!(status, StatusCode::CONFLICT, "{body}");
+        assert!(
+            body.contains("pinned at startup is no longer the one at that path"),
+            "refusal must name the pinned-namespace mismatch: {body}"
+        );
+        assert!(
+            body.contains("detached after this backend"),
+            "refusal must name the detachment rather than a generic miss: {body}"
+        );
+        assert_eq!(
+            state
+                .snapshot_generation
+                .load(std::sync::atomic::Ordering::SeqCst),
+            generation_before
+        );
+    }
+
     #[tokio::test]
     async fn exact_source_route_reads_repository_cas_and_ignores_checkout_bytes() {
         let state = test_state();

--- a/crates/kin-daemon/src/local_repository_authority.rs
+++ b/crates/kin-daemon/src/local_repository_authority.rs
@@ -130,6 +130,9 @@ impl ActiveLocalRepositoryAuthority {
         })
     }
 
+    /// Bind for assertions that only need the refusal text. Command paths must
+    /// use [`Self::open_bound`] so they can answer with a typed status.
+    #[cfg(test)]
     pub(crate) fn open(state: &DaemonState) -> Result<Self> {
         Self::open_bound(state).map_err(RepositoryAuthorityBindRefusal::into_error)
     }

--- a/crates/kin-daemon/src/local_repository_authority.rs
+++ b/crates/kin-daemon/src/local_repository_authority.rs
@@ -50,6 +50,48 @@ impl LocalRepositoryAuthorityContext {
     ) -> std::result::Result<RepositoryAuthorityManager<LocalFileBackend>, kin_db::KinDbError> {
         self.binding.open_manager()
     }
+
+    pub(crate) fn revalidate_pinned_namespace(
+        &self,
+    ) -> std::result::Result<(), kin_db::KinDbError> {
+        self.binding.revalidate_pinned_namespace()
+    }
+}
+
+/// Why a command refused to bind this daemon's local repository authority.
+///
+/// Command boundaries answer an identity refusal with a typed conflict rather
+/// than a generic internal error: the request is coherent, but the storage
+/// namespace this daemon pinned is no longer the one on disk, so there is no
+/// authority left to answer from.
+pub(crate) enum RepositoryAuthorityBindRefusal {
+    /// This daemon never completed a startup repository binding.
+    Unbound(DaemonError),
+    /// The retained capability no longer reaches the exact per-repository
+    /// namespace this daemon pinned: replaced at the same ambient path,
+    /// detached, or a store that does not hold this repository.
+    Identity(kin_db::KinDbError),
+    /// The pinned namespace is intact but its authority could not be opened.
+    Unavailable(kin_db::KinDbError),
+}
+
+impl RepositoryAuthorityBindRefusal {
+    pub(crate) fn is_identity_refusal(&self) -> bool {
+        matches!(self, Self::Identity(_))
+    }
+
+    pub(crate) fn into_error(self) -> anyhow::Error {
+        match self {
+            Self::Unbound(error) => anyhow::Error::new(error),
+            Self::Identity(error) => anyhow::anyhow!(
+                "refusing repository-v6 authority: the storage namespace this daemon pinned at \
+                 startup is no longer the one at that path: {error}"
+            ),
+            Self::Unavailable(error) => anyhow::anyhow!(
+                "open repository-v6 authority through startup-pinned storage capability: {error}"
+            ),
+        }
+    }
 }
 
 /// Local repository authority bound to the identities the daemon validated at
@@ -64,18 +106,32 @@ pub(crate) struct ActiveLocalRepositoryAuthority {
 }
 
 impl ActiveLocalRepositoryAuthority {
-    pub(crate) fn open(state: &DaemonState) -> Result<Self> {
-        let context = LocalRepositoryAuthorityContext::from_state(state)?;
-        let manager = context.open().map_err(|error| {
-            anyhow::anyhow!(
-                "open repository-v6 authority through startup-pinned storage capability: {error}"
-            )
-        })?;
+    /// Bind the startup-pinned authority, revalidating the retained
+    /// per-repository namespace identity before any planning reads it.
+    ///
+    /// The revalidation is deliberately ahead of the authority open so a
+    /// replaced or detached namespace is named as such, instead of surfacing as
+    /// whatever the authority decode happens to fail on.
+    pub(crate) fn open_bound(
+        state: &DaemonState,
+    ) -> std::result::Result<Self, RepositoryAuthorityBindRefusal> {
+        let context = LocalRepositoryAuthorityContext::from_state(state)
+            .map_err(RepositoryAuthorityBindRefusal::Unbound)?;
+        context
+            .revalidate_pinned_namespace()
+            .map_err(RepositoryAuthorityBindRefusal::Identity)?;
+        let manager = context
+            .open()
+            .map_err(RepositoryAuthorityBindRefusal::Unavailable)?;
         Ok(Self {
             manager,
             repository_id: context.repository_id().clone(),
             workspace_id: context.workspace_id(),
         })
+    }
+
+    pub(crate) fn open(state: &DaemonState) -> Result<Self> {
+        Self::open_bound(state).map_err(RepositoryAuthorityBindRefusal::into_error)
     }
 }
 

--- a/crates/kin-daemon/src/repository_branch.rs
+++ b/crates/kin-daemon/src/repository_branch.rs
@@ -18,7 +18,7 @@ use kin_model::{
 };
 
 use crate::local_repository_authority::{
-    require_fresh_daemon_workspace, ActiveLocalRepositoryAuthority,
+    require_fresh_daemon_workspace, ActiveLocalRepositoryAuthority, RepositoryAuthorityBindRefusal,
 };
 use crate::state::{DaemonEvent, DaemonState};
 
@@ -89,7 +89,7 @@ pub(crate) fn execute(
 ) -> std::result::Result<BranchResponse, (StatusCode, String)> {
     if matches!(request, BranchRequest::List) {
         let authority =
-            ActiveLocalRepositoryAuthority::open(state).map_err(internal_branch_error)?;
+            ActiveLocalRepositoryAuthority::open_bound(state).map_err(branch_bind_refusal)?;
         return list(&authority).map_err(internal_branch_error);
     }
 
@@ -101,7 +101,8 @@ pub(crate) fn execute(
         )
     })?;
     let previous_graph_root = hex::encode(state.graph.compute_root_hash());
-    let authority = ActiveLocalRepositoryAuthority::open(state).map_err(internal_branch_error)?;
+    let authority =
+        ActiveLocalRepositoryAuthority::open_bound(state).map_err(branch_bind_refusal)?;
     let outcome =
         match request {
             BranchRequest::List => unreachable!("list returned before mutation gates"),
@@ -1093,4 +1094,17 @@ fn repository_finalization_error(error: crate::error::DaemonError) -> (StatusCod
 
 fn internal_branch_error(error: impl std::fmt::Display) -> (StatusCode, String) {
     (StatusCode::INTERNAL_SERVER_ERROR, error.to_string())
+}
+
+/// Answer a pinned-namespace refusal as a conflict for the same reason checkout
+/// does: the branch request is well formed, but the repository authority this
+/// daemon pinned is no longer the one at that path.
+fn branch_bind_refusal(refusal: RepositoryAuthorityBindRefusal) -> (StatusCode, String) {
+    let identity = refusal.is_identity_refusal();
+    let error = refusal.into_error();
+    if identity {
+        (StatusCode::CONFLICT, format!("{error:#}"))
+    } else {
+        internal_branch_error(format!("{error:#}"))
+    }
 }

--- a/crates/kin-daemon/src/repository_checkout.rs
+++ b/crates/kin-daemon/src/repository_checkout.rs
@@ -23,7 +23,7 @@ use sha2::{Digest, Sha256};
 
 use crate::error::DaemonError;
 use crate::local_repository_authority::{
-    require_fresh_daemon_workspace, ActiveLocalRepositoryAuthority,
+    require_fresh_daemon_workspace, ActiveLocalRepositoryAuthority, RepositoryAuthorityBindRefusal,
 };
 use crate::state::{DaemonEvent, DaemonState};
 
@@ -205,7 +205,8 @@ fn plan_and_commit(
     let layout = &state.layout;
     let selected = parse_checkout_path(request.path.as_deref(), request.path_hex.as_deref())
         .map_err(CheckoutCommandError::bad_request)?;
-    let authority = ActiveLocalRepositoryAuthority::open(state)?;
+    let authority = ActiveLocalRepositoryAuthority::open_bound(state)
+        .map_err(classify_authority_bind_refusal)?;
     let lease = authority.manager.read_authority();
     let roots = lease.roots().clone();
     let workspace = lease
@@ -680,6 +681,22 @@ fn plan_and_commit(
         daemon_delta,
         authority_freeze,
     ))
+}
+
+/// A pinned-namespace refusal is a conflict, not an internal fault: the request
+/// is well formed and the daemon is healthy, but the repository authority it
+/// pinned is no longer the one at that path, so there is no coherent truth left
+/// to check out from.
+fn classify_authority_bind_refusal(
+    refusal: RepositoryAuthorityBindRefusal,
+) -> CheckoutCommandError {
+    let identity = refusal.is_identity_refusal();
+    let error = refusal.into_error();
+    if identity {
+        CheckoutCommandError::Conflict(error)
+    } else {
+        CheckoutCommandError::Internal(error)
+    }
 }
 
 fn classify_model_checkout_error(

--- a/crates/kin-daemon/src/state.rs
+++ b/crates/kin-daemon/src/state.rs
@@ -1509,6 +1509,13 @@ impl DaemonState {
             Arc::clone(&local_repository_backend),
         )
         .map_err(DaemonError::Graph)?;
+        // Opening authority above is what retains the per-repository storage
+        // capability on this backend. Prove the pin took before serving any
+        // request from it: a daemon that cannot revalidate its own namespace
+        // must refuse to start rather than run unpinned, because every later
+        // authority bind treats whatever is retained as the baseline.
+        kin_core::revalidate_pinned_local_namespace(&local_repository_backend, &repository_id)
+            .map_err(DaemonError::Graph)?;
         let lease = authority.read_authority();
         let workspace_snapshot = lease
             .workspace_graph_snapshot(&workspace_id)


### PR DESCRIPTION
Repository authority identity was pinned only at the storage root. The per-repository namespace under it was revalidated whenever kin-db happened to be asked for a capability, so the checkout boundary could answer from whatever namespace occupied the ambient path, and a refusal surfaced as an internal fault rather than a conflict.

## What changed

- **Consume kin-db 0.6.3.** kin-db 0.6.3 declares `kin-model = "0.6.1"`, which the workspace exact pin `=0.6.0` cannot unify, so kin-model moves to `=0.6.1` with it. Registry-only re-lock; both keep `sparse+` sources and checksums. No source change was needed for kin-model 0.6.1.
- **Revalidate the pinned namespace by name.** `kin_core::revalidate_pinned_local_namespace` reads authority identity for the one named repository. That routes through the same kin-db `repository_capability` that retains the per-repository capability on first use and revalidates its filesystem identity on every later access, so a namespace replaced at the same ambient path, detached, or absent from the pinned store is refused.
- **Prove the pin took at startup.** `DaemonState::open` asserts it immediately after the authority open that takes the pin. A daemon that cannot revalidate its own namespace refuses to start rather than run unpinned, because every later bind treats whatever is retained as the baseline.
- **Type the refusal.** `ActiveLocalRepositoryAuthority::open_bound` revalidates before any planning read and returns `RepositoryAuthorityBindRefusal`. Checkout and branch answer an identity refusal with `409 Conflict`: the request is well formed and the daemon is healthy, but the pinned authority is no longer the one on disk. Classification is structural, on which call failed, not on error text.
- **Expose `checkout`.** Status moves to ready with a new acceptance-spec item naming the refusal, four added evidence tests, and a note stating the now-true contract. Bounded-dogfood required goes to 11 of 12. `commit` stays gated.

## Why not enumerate the storage root

The previous implementation called `list_repos`. That is the wrong primitive for revalidating one repository, and on kin-db 0.6.3 it is also broken for this use: 0.6.1 skipped non-directory entries, while 0.6.3 propagates an error for any entry that parses as a repository id but is not a directory. `.kin/kindb/` legitimately holds `graph.kndb`, `graph.kvec`, `graph.kidx`, `head-generation`, and `generation` beside the namespaces, so listing hard-fails on a real local storage root once those files exist. That affected every `LocalRepositoryAuthorityBinding::from_layout` caller on the bump, independent of this change. The remaining two `list_repos` callers in kin are unaffected: init lists a fresh empty staging root, and the other is hosted-GCS only. kin-db still carries the latent trap for future callers.

## Tests

New, all failing before the wiring and passing after:

- `kin_daemon::api::tests::command_checkout_refuses_replaced_repository_namespace_without_mutation` and `..._refuses_detached_repository_namespace_without_mutation` drive the real daemon router. Each first proves the identical request succeeds while the pin is intact, then swaps or detaches the namespace mid-process-lifetime and asserts `409` plus an unchanged `snapshot_generation` and graph root hash. These assert the capability plumbing, not kin-db: any layer constructing a fresh path-based backend instead of cloning the pinned `Arc` would return `200` here.
- `kin_core::repository_authority::tests` covers per-repository replacement, detachment, and a store that does not hold the repository.

`command_branch_and_workspace_publication_reject_replaced_kindb_root` moves from `500` to `409`. A replaced storage root is the same refusal class as a replaced namespace under it, and it now also asserts the refusal names the pinned mismatch.

## Scope

The retained-identity refusals are proven on Unix. The Windows file-identity path in kin-db is implemented and has no CI coverage at all right now; the capability note says so rather than implying parity.
