### PR TITLE
Keep exact Git admission output replayable

### DIFF
--- a/crates/kin-core/env_var_allowlist.txt
+++ b/crates/kin-core/env_var_allowlist.txt
@@ -12,6 +12,7 @@
 # conscious decision to keep a name out of the registry, not a place to silence a
 # real gap.
 #
+KIN_REAL_REPOSITORY
 KIN_UPDATE_TEMP_CLEANUP_CRASH_PARENT
 KIN_UPDATE_TEMP_LEASE_CRASH_MARKER
 KIN_UPDATE_TEMP_LEASE_CRASH_PARENT

--- a/crates/kin-index/src/history.rs
+++ b/crates/kin-index/src/history.rs
@@ -21,7 +21,8 @@ use sha2::{Digest, Sha256};
 use crate::classifier::{FileClassification, FileClassifier};
 use crate::error::{IndexError, Result};
 use crate::linker::{
-    link_cross_file_with_completeness, ArtifactIdentityMap, FileParseCompletenessMap, FileParseData,
+    is_external_import_placeholder, link_cross_file_with_completeness, ArtifactIdentityMap,
+    FileParseCompletenessMap, FileParseData,
 };
 use crate::pipeline::IndexPipeline;
 
@@ -35,7 +36,7 @@ use crate::pipeline::IndexPipeline;
 /// establish whether replay semantics actually changed, and if they did, bump
 /// this constant and the manifest's recorded version together. Never
 /// regenerate a digest silently.
-pub const HYDRATION_SEMANTICS_VERSION: u32 = 4;
+pub const HYDRATION_SEMANTICS_VERSION: u32 = 5;
 
 /// Semantic graph delta derived for one pre-enrichment change identity.
 ///
@@ -284,10 +285,16 @@ fn semantic_state_for_tree(
         }
         completeness.insert(file.path.clone(), file.completeness.clone());
         for entity in &file.entities {
-            if entities.insert(entity.id, entity.clone()).is_some() {
+            if let Some(previous) = entities.insert(entity.id, entity.clone()) {
                 return Err(invalid(format!(
-                    "semantic entity identity {:?} is duplicated in one tree",
-                    entity.id
+                    "semantic entity identity {} is duplicated in one tree: {} {:?} from {:?} and {} {:?} from {}",
+                    entity.id,
+                    previous.name,
+                    previous.kind,
+                    previous.file_origin,
+                    entity.name,
+                    entity.kind,
+                    file.path
                 )));
             }
         }
@@ -303,6 +310,27 @@ fn semantic_state_for_tree(
     let linked = link_cross_file_with_completeness(&parse_data, &artifact_ids, &completeness)?;
     let mut relations = BTreeMap::new();
     for relation in linked {
+        if let Some(absent) = absent_local_endpoint(&relation, &entities) {
+            // A change carries the entity set of its own tree, so replaying it
+            // can only bind an edge whose endpoints that tree defines. The
+            // linker's cross-repo placeholder destination is absent by
+            // contract and stays a view-time inference rather than change-owned
+            // history; every other absent endpoint is inconsistent state and
+            // fails closed here instead of being admitted.
+            if absent.is_destination && is_external_import_placeholder(&relation) {
+                continue;
+            }
+            return Err(invalid(format!(
+                "linked relation {} names {} entity {} that the tree does not define",
+                relation.id,
+                if absent.is_destination {
+                    "destination"
+                } else {
+                    "source"
+                },
+                absent.entity_id
+            )));
+        }
         if relations.insert(relation.id, relation).is_some() {
             return Err(invalid(
                 "cross-file linker returned a duplicate relation identity",
@@ -315,6 +343,31 @@ fn semantic_state_for_tree(
         entities,
         relations,
     })
+}
+
+/// An entity endpoint of a linked relation that the tree does not define.
+struct AbsentEndpoint {
+    entity_id: EntityId,
+    is_destination: bool,
+}
+
+/// Report the first entity endpoint of `relation` that `entities` does not
+/// define, source before destination. Non-entity endpoints are not part of the
+/// entity state a change replays, so they are never reported.
+fn absent_local_endpoint(
+    relation: &Relation,
+    entities: &BTreeMap<EntityId, Entity>,
+) -> Option<AbsentEndpoint> {
+    [(relation.src, false), (relation.dst, true)]
+        .into_iter()
+        .find_map(|(node, is_destination)| {
+            node.as_entity()
+                .filter(|entity_id| !entities.contains_key(entity_id))
+                .map(|entity_id| AbsentEndpoint {
+                    entity_id,
+                    is_destination,
+                })
+        })
 }
 
 fn stabilize_historical_entities(
@@ -438,7 +491,7 @@ mod tests {
     use kin_git::{
         admit_semantic_git_import, capture_lossless_git_repository, plan_semantic_git_import,
     };
-    use kin_model::{EntityKind, RepositoryId};
+    use kin_model::{ChangeStore, EntityKind, RepositoryId};
     use tempfile::tempdir;
 
     use super::*;
@@ -658,6 +711,117 @@ mod tests {
             .unwrap()
             .validate(&blob_store)
             .unwrap();
+    }
+
+    /// The shape that blocked every real repository: a commit that starts
+    /// calling a symbol imported from another crate. The linker answers with a
+    /// cross-repo placeholder destination that is absent from this repository's
+    /// entity set by contract, so a change carrying that edge cannot be
+    /// replayed. Admission must still bind the commit and the local call graph
+    /// around it.
+    #[test]
+    fn calling_an_imported_external_symbol_stays_replayable() {
+        let root = tempdir().unwrap();
+        let repository = root.path().join("source");
+        fs::create_dir(&repository).unwrap();
+        git(&repository, &["init", "--initial-branch=main"]);
+        git(
+            &repository,
+            &["config", "user.email", "kin@example.invalid"],
+        );
+        git(&repository, &["config", "user.name", "Kin Test"]);
+        write(
+            &repository,
+            "src/main.rs",
+            b"fn colored() -> bool {\n    true\n}\n\nfn main() {\n    let _ = colored();\n}\n",
+        );
+        git(&repository, &["add", "--all"]);
+        git(&repository, &["commit", "-m", "local call graph only"]);
+
+        write(
+            &repository,
+            "src/main.rs",
+            b"extern crate isatty;\n\nuse isatty::stdout_isatty;\n\nfn colored() -> bool {\n    true\n}\n\nfn main() {\n    let _ = colored() && stdout_isatty();\n}\n",
+        );
+        git(&repository, &["add", "--all"]);
+        git(&repository, &["commit", "-m", "detect interactive terminal"]);
+
+        let blob_store = BlobStore::new(root.path().join("cas")).unwrap();
+        let snapshot = capture_lossless_git_repository(
+            &repository,
+            RepositoryId::new("history-external-import").unwrap(),
+            &blob_store,
+        )
+        .unwrap();
+        let plan = plan_semantic_git_import(&snapshot, &blob_store).unwrap();
+        let trees = trees_by_change(&plan);
+        let deltas = derive_historical_semantic_deltas(&plan.changes, &trees, &blob_store).unwrap();
+
+        let bindings = deltas
+            .iter()
+            .map(|delta| {
+                (
+                    delta.change_id,
+                    delta.entity_deltas.clone(),
+                    delta.relation_deltas.clone(),
+                )
+            })
+            .collect::<Vec<_>>();
+        let enriched = plan
+            .with_historical_semantics(&blob_store, &bindings)
+            .unwrap();
+        enriched.validate(&blob_store).unwrap();
+        let admitted = admit_semantic_git_import(&enriched, &blob_store).unwrap();
+
+        let entity_ids = admitted
+            .changes
+            .iter()
+            .flat_map(|change| &change.entity_deltas)
+            .filter_map(EntityDelta::new_state)
+            .map(|entity| entity.id)
+            .collect::<HashSet<_>>();
+        let bound_relations = admitted
+            .changes
+            .iter()
+            .flat_map(|change| &change.relation_deltas)
+            .filter_map(RelationDelta::new_state)
+            .collect::<Vec<_>>();
+        assert!(
+            bound_relations
+                .iter()
+                .any(|relation| relation.kind == kin_model::RelationKind::Calls),
+            "the local call graph must survive"
+        );
+        for relation in &bound_relations {
+            for node in [relation.src, relation.dst] {
+                if let kin_model::GraphNodeId::Entity(entity_id) = node {
+                    assert!(
+                        entity_ids.contains(&entity_id),
+                        "relation {} names entity {entity_id}, which history never defines",
+                        relation.id
+                    );
+                }
+            }
+        }
+
+        let graph = kin_db::InMemoryGraph::new();
+        for change in &admitted.changes {
+            graph.create_change(change).unwrap();
+        }
+        let head = admitted
+            .changes
+            .iter()
+            .map(|change| change.id)
+            .find(|candidate| {
+                !admitted
+                    .changes
+                    .iter()
+                    .any(|change| change.parents.contains(candidate))
+            })
+            .unwrap();
+        graph
+            .resolve_graph_at(&head)
+            .expect("admitted history must replay without a dangling relation");
     }
 
     #[test]

--- a/crates/kin-index/src/history.rs
+++ b/crates/kin-index/src/history.rs
@@ -376,6 +376,8 @@ fn stabilize_historical_entities(
     parsed_entities: &[Entity],
 ) -> Vec<Entity> {
     let mut matched = HashSet::<EntityId>::new();
+    let mut in_use = HashSet::<EntityId>::new();
+    let mut unmatched = Vec::new();
     let mut current = Vec::with_capacity(parsed_entities.len());
 
     for parsed in parsed_entities {
@@ -400,11 +402,31 @@ fn stabilize_historical_entities(
             stabilized.created_in = old.created_in;
             stabilized.superseded_by = old.superseded_by;
             matched.insert(old.id);
+            in_use.insert(old.id);
         } else {
-            stabilized.id = historical_entity_id(artifact_id, parsed.id);
+            unmatched.push(current.len());
         }
         current.push(stabilized);
     }
+
+    // Deriving an identity from the parser identity alone can land on one this
+    // same file already carries. Inheritance deliberately detaches an entity
+    // from the position it was first parsed at, so a later definition that
+    // takes over that position derives exactly the identity the moved entity
+    // still holds: two conditionally compiled definitions of one name are
+    // enough. Mint against the identities already in use so distinct
+    // definitions can never collapse into one entity.
+    for index in unmatched {
+        let parser_id = parsed_entities[index].id;
+        let mut identity = historical_entity_id(artifact_id, parser_id);
+        let mut displacement = 0_u32;
+        while !in_use.insert(identity) {
+            displacement += 1;
+            identity = displaced_historical_entity_id(artifact_id, parser_id, displacement);
+        }
+        current[index].id = identity;
+    }
+
     current.sort_by_key(|entity| entity.id);
     current
 }
@@ -414,6 +436,30 @@ fn historical_entity_id(artifact_id: ArtifactId, parser_id: EntityId) -> EntityI
     hasher.update(b"kin.historical-entity.v1\0");
     hasher.update(artifact_id.0.as_bytes());
     hasher.update(parser_id.0.as_bytes());
+    let digest = hasher.finalize();
+    let mut bytes = [0_u8; 16];
+    bytes.copy_from_slice(&digest[..16]);
+    bytes[6] = (bytes[6] & 0x0f) | 0x40;
+    bytes[8] = (bytes[8] & 0x3f) | 0x80;
+    EntityId(uuid::Uuid::from_bytes(bytes))
+}
+
+/// Derive the identity of a parsed entity whose primary derived identity is
+/// already carried by another entity in the same file.
+///
+/// Kept separate from [`historical_entity_id`] so an identity only ever moves
+/// when a collision actually forces it: every entity that can keep its primary
+/// derivation keeps exactly the identity it had.
+fn displaced_historical_entity_id(
+    artifact_id: ArtifactId,
+    parser_id: EntityId,
+    displacement: u32,
+) -> EntityId {
+    let mut hasher = Sha256::new();
+    hasher.update(b"kin.historical-entity.displaced.v1\0");
+    hasher.update(artifact_id.0.as_bytes());
+    hasher.update(parser_id.0.as_bytes());
+    hasher.update(displacement.to_be_bytes());
     let digest = hasher.finalize();
     let mut bytes = [0_u8; 16];
     bytes.copy_from_slice(&digest[..16]);
@@ -744,7 +790,10 @@ mod tests {
             b"extern crate isatty;\n\nuse isatty::stdout_isatty;\n\nfn colored() -> bool {\n    true\n}\n\nfn main() {\n    let _ = colored() && stdout_isatty();\n}\n",
         );
         git(&repository, &["add", "--all"]);
-        git(&repository, &["commit", "-m", "detect interactive terminal"]);
+        git(
+            &repository,
+            &["commit", "-m", "detect interactive terminal"],
+        );
 
         let blob_store = BlobStore::new(root.path().join("cas")).unwrap();
         let snapshot = capture_lossless_git_repository(
@@ -822,6 +871,109 @@ mod tests {
         graph
             .resolve_graph_at(&head)
             .expect("admitted history must replay without a dangling relation");
+    }
+
+    /// Identity derivation is positional, inheritance is not. A definition that
+    /// takes over the position an inherited entity was first parsed at derives
+    /// that entity's identity, and two definitions of one name in one file must
+    /// never collapse into a single entity because of it.
+    #[test]
+    fn a_definition_taking_an_inherited_position_keeps_its_own_identity() {
+        let artifact_id = ArtifactId::new();
+        let path = "src/output.rs";
+        let moved = parsed_function(path, "print_entry_uncolorized", 2);
+        let arrived = parsed_function(path, "print_entry_uncolorized", 6);
+        let inherited = Entity {
+            id: historical_entity_id(artifact_id, arrived.id),
+            ..parsed_function(path, "print_entry_uncolorized", 6)
+        };
+
+        let stabilized =
+            stabilize_historical_entities(artifact_id, vec![&inherited], &[moved, arrived]);
+
+        assert_eq!(stabilized.len(), 2);
+        assert_ne!(
+            stabilized[0].id, stabilized[1].id,
+            "two definitions must not share one identity"
+        );
+        assert!(
+            stabilized.iter().any(|entity| entity.id == inherited.id),
+            "the entity that matched must keep the identity it carried"
+        );
+    }
+
+    /// The whole-history form of the same defect: one conditionally compiled
+    /// pair is enough to make a tree claim one entity twice.
+    #[test]
+    fn conditionally_compiled_duplicates_of_one_name_enrich() {
+        let root = tempdir().unwrap();
+        let repository = root.path().join("source");
+        fs::create_dir(&repository).unwrap();
+        git(&repository, &["init", "--initial-branch=main"]);
+        git(
+            &repository,
+            &["config", "user.email", "kin@example.invalid"],
+        );
+        git(&repository, &["config", "user.name", "Kin Test"]);
+        write(
+            &repository,
+            "src/output.rs",
+            b"fn head() {}\n\nfn tail() {}\n\nfn print_entry_uncolorized() {}\n",
+        );
+        git(&repository, &["add", "--all"]);
+        git(&repository, &["commit", "-m", "one definition"]);
+
+        write(
+            &repository,
+            "src/output.rs",
+            b"fn print_entry_uncolorized_base() {}\n#[cfg(not(unix))]\nfn print_entry_uncolorized() {}\n#[cfg(unix)]\nfn print_entry_uncolorized() {}\n",
+        );
+        git(&repository, &["add", "--all"]);
+        git(&repository, &["commit", "-m", "split by target"]);
+
+        let blob_store = BlobStore::new(root.path().join("cas")).unwrap();
+        let snapshot = capture_lossless_git_repository(
+            &repository,
+            RepositoryId::new("history-conditional-duplicates").unwrap(),
+            &blob_store,
+        )
+        .unwrap();
+        let plan = plan_semantic_git_import(&snapshot, &blob_store).unwrap();
+        let trees = trees_by_change(&plan);
+        let deltas = derive_historical_semantic_deltas(&plan.changes, &trees, &blob_store).unwrap();
+
+        let tip = deltas
+            .last()
+            .unwrap()
+            .entity_deltas
+            .iter()
+            .filter_map(EntityDelta::new_state)
+            .filter(|entity| entity.name == "print_entry_uncolorized")
+            .map(|entity| entity.id)
+            .collect::<HashSet<_>>();
+        assert_eq!(
+            tip.len(),
+            2,
+            "both definitions must reach history as distinct entities"
+        );
+    }
+
+    fn parsed_function(path: &str, name: &str, start_line: u32) -> Entity {
+        let pipeline = IndexPipeline::new();
+        let body = format!("{}fn {name}() {{}}\n", "\n".repeat(start_line as usize - 1));
+        let indexed = pipeline
+            .index_file_content_with_tests(
+                &FilePathId::new(path),
+                body.as_bytes(),
+                kin_blobs::Hash256::from_bytes(kin_blobs::digest_bytes(body.as_bytes())),
+            )
+            .unwrap()
+            .indexed_file;
+        indexed
+            .entities
+            .into_iter()
+            .find(|entity| entity.name == name)
+            .unwrap()
     }
 
     #[test]

--- a/crates/kin-index/tests/real_repository_enrichment.rs
+++ b/crates/kin-index/tests/real_repository_enrichment.rs
@@ -1,0 +1,106 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Firelock, LLC
+
+//! Whole-history enrichment proof against a real Git repository.
+//!
+//! Ignored by default. It needs a repository this tree cannot vendor, and cost
+//! grows with history length times tree size, so it is minutes of work on a
+//! repository of any real size. Point `KIN_REAL_REPOSITORY` at a non-shallow
+//! clone and run it explicitly:
+//!
+//! ```sh
+//! git clone https://github.com/sharkdp/fd /tmp/fd
+//! KIN_REAL_REPOSITORY=/tmp/fd cargo test --release -p kin-index \
+//!     --test real_repository_enrichment -- --ignored --nocapture
+//! ```
+//!
+//! Shallow clones are rejected at capture, so history length cannot be varied
+//! with `--depth`; truncate a full clone instead.
+
+use std::collections::BTreeMap;
+use std::path::Path;
+
+use kin_blobs::BlobStore;
+use kin_git::{
+    admit_semantic_git_import, capture_lossless_git_repository, plan_semantic_git_import,
+};
+use kin_index::derive_historical_semantic_deltas;
+use kin_model::{ChangeStore, RepositoryId};
+
+#[test]
+#[ignore]
+fn a_real_repository_enriches_into_replayable_history() {
+    let repository = std::env::var("KIN_REAL_REPOSITORY")
+        .expect("set KIN_REAL_REPOSITORY to a non-shallow Git clone");
+    let root = tempfile::tempdir().unwrap();
+    let blob_store = BlobStore::new(root.path().join("cas")).unwrap();
+
+    let snapshot = capture_lossless_git_repository(
+        Path::new(&repository),
+        RepositoryId::new("real-repository-enrichment").unwrap(),
+        &blob_store,
+    )
+    .unwrap();
+    let plan = plan_semantic_git_import(&snapshot, &blob_store).unwrap();
+    let trees = plan
+        .aliases
+        .iter()
+        .map(|alias| {
+            (
+                alias.change_id,
+                plan.commit_trees
+                    .get(&alias.oid)
+                    .expect("every imported commit has an exact resolved tree")
+                    .clone(),
+            )
+        })
+        .collect::<BTreeMap<_, _>>();
+
+    let deltas = derive_historical_semantic_deltas(&plan.changes, &trees, &blob_store).unwrap();
+    let bindings = deltas
+        .into_iter()
+        .map(|delta| (delta.change_id, delta.entity_deltas, delta.relation_deltas))
+        .collect::<Vec<_>>();
+    let admitted = admit_semantic_git_import(
+        &plan
+            .with_historical_semantics(&blob_store, &bindings)
+            .unwrap(),
+        &blob_store,
+    )
+    .unwrap();
+    admitted.validate(&blob_store).unwrap();
+
+    // The graph must never publish a change its own replay rejects, so every
+    // head is resolved rather than only the tip of the default branch.
+    let graph = kin_db::InMemoryGraph::new();
+    for change in &admitted.changes {
+        graph.create_change(change).unwrap();
+    }
+    let heads = admitted
+        .changes
+        .iter()
+        .map(|change| change.id)
+        .filter(|candidate| {
+            !admitted
+                .changes
+                .iter()
+                .any(|change| change.parents.contains(candidate))
+        })
+        .collect::<Vec<_>>();
+    assert!(!heads.is_empty(), "history must have at least one head");
+    for head in &heads {
+        let resolved = graph.resolve_graph_at(head).unwrap_or_else(|error| {
+            panic!("admitted history must replay at {head}: {error}");
+        });
+        println!(
+            "head {head}: {} entities, {} relations",
+            resolved.entities.len(),
+            resolved.relations.len()
+        );
+    }
+    println!(
+        "{} changes, {} heads enriched from {repository}",
+        admitted.changes.len(),
+        heads.len()
+    );
+}

--- a/scripts/hydration-semantics-manifest.json
+++ b/scripts/hydration-semantics-manifest.json
@@ -19,7 +19,7 @@
     {
       "file": "crates/kin-index/src/history.rs",
       "function": "stabilize_historical_entities",
-      "digest": "sha256:257511e43f2742ae16e93bc62f4aa760211c98c8359e566200820c568035fd9a",
+      "digest": "sha256:ee7c9abc6215b230dc26f31f98f961e1d89f88e0bdb10e0004990d239d4375ff",
       "reason": "Carries entity identity across changes. Whether an entity is recognized as the same one decides whether history records a modification or an unrelated add and remove pair.",
       "owner": "kin-index"
     },

--- a/scripts/hydration-semantics-manifest.json
+++ b/scripts/hydration-semantics-manifest.json
@@ -1,6 +1,6 @@
 {
   "comment": "Replay-semantics surface pinned by scripts/verify-hydration-semantics.py. These functions re-author the entity/relation deltas persisted for historical changes during Git admission, so editing one changes what Kin reports about the past on already-ingested repositories. A digest mismatch is not a failure to fix by regenerating: decide first whether replay semantics changed, and if so bump HYDRATION_SEMANTICS_VERSION and hydration_semantics_version together.",
-  "hydration_semantics_version": 4,
+  "hydration_semantics_version": 5,
   "guarded": [
     {
       "file": "crates/kin-index/src/history.rs",
@@ -12,7 +12,7 @@
     {
       "file": "crates/kin-index/src/history.rs",
       "function": "semantic_state_for_tree",
-      "digest": "sha256:f91a92ef3090a8c8622badfb59bd59f4032729c5caf35e331f7014c72dc06e80",
+      "digest": "sha256:883a0ba2ac406e67a7efb59d59cae37c0d33aa6829938d20f986d19833d75cab",
       "reason": "Turns one exact resolved tree plus CAS bodies into the entity/relation state a change is diffed from and to. Its classification, parse, and cross-file linking order decide what the past is said to contain.",
       "owner": "kin-index"
     },


### PR DESCRIPTION
Exact Git admission fails on every real repository. On `1644f73d` a pristine `sharkdp/fd` clone is refused from its 26th commit onward and `BurntSushi/ripgrep` from its 25th, which blocks all brownfield admission. This fixes the two enrichment defects behind that and leaves a third, downstream of this repo, precisely located and reproducible.

## Defect A: history carried an edge its own replay cannot bind

The cross-file linker deliberately emits a cross-repo placeholder edge for a call to a symbol imported from another crate: `make_external_reference_relation` derives a destination entity id from the import source and symbol, and that entity is absent from the local entity set by contract (`is_external_import_placeholder` names the contract, and `kin graph validate` exempts exactly that shape).

Historical enrichment bound every linked relation into a change's relation deltas, placeholders included. Replaying such a change cannot bind an edge to an entity the tree never defines, so admission rejected its own output. That is not an exotic shape: fd reaches it at commit 26 (`use isatty::stdout_isatty` plus a call to it), ripgrep at 25.

`semantic_state_for_tree` now emits only relations whose endpoints the tree defines. The placeholder stays a view-time inference, which is where it is already produced and consumed: `build_graph_at_ref` relinks at read time and the daemon's spine registers cross-repo edges from the live workspace graph, so nothing that consumes those edges loses them. Any other absent endpoint fails closed naming the relation and the entity, rather than being admitted and refused later.

## Defect B: two definitions of one name collapsed into one entity

Historical identity is derived from the parser identity, which is positional: `(path, name, kind, start_line)`. Inheritance deliberately detaches an entity from the position it was first parsed at, so it survives moving. The two rules combine badly: a later definition that takes over the original position derives the identity the moved entity still holds, the tree then claims one entity twice, and enrichment aborts.

fd hits this exactly. `print_entry_uncolorized` first appears at line 104, moves to line 76 while keeping its identity, and then a commit splits it into a `#[cfg(not(unix))]` / `#[cfg(unix)]` pair whose second definition lands on line 104 again.

`stabilize_historical_entities` now mints against the identities already in use in the file and displaces deterministically when one is taken. Identities that do not collide keep exactly the derivation they had; the tree-level duplicate check stays, so a duplicate is still refused rather than masked, and it now reports both entities and the file.

## Replay semantics version

Both fixes change what enrichment persists for already-ingested repositories, so `HYDRATION_SEMANTICS_VERSION` and the manifest's recorded version move from 4 to 5 together.

## Evidence

Tests, each verified to fail before its fix and pass after:

- `calling_an_imported_external_symbol_stays_replayable` builds fd's commit-26 shape, then binds, admits, and resolves the admitted history through `resolve_graph_at`. Before the fix it fails on the same placeholder entity id the real fd clone fails on, since that id is derived from `("isatty", "stdout_isatty")`.
- `a_definition_taking_an_inherited_position_keeps_its_own_identity` pins the identity contract directly.
- `conditionally_compiled_duplicates_of_one_name_enrich` reproduces the whole-history form and fails before the fix with the same duplicate-identity error the full fd clone raises.
- `real_repository_enrichment` is ignored by default and takes a real clone through capture, plan, derive, bind, admit, and replay at every head. It is the whole-repository proof, kept out of the default suite because it needs a clone this tree cannot vendor and costs history length times tree size.

Run in-lane against a full `sharkdp/fd` clone (1988 commits, 1999 changes, 8 heads), release build:

- enrichment completes and every head replays: 484 entities and 907 relations at the tip, 245s
- every one of the 1999 changes replays its own first-parent chain with no dangling relation and no stale payload

Local gate: fmt, hydration guard, clippy on the CI allowlist, `build --all-targets`, runtime-boundary and private-coupling checks, and `cargo test --workspace`.

## What is still broken

`kin init` on fd still fails, now past both defects above, inside repository persistence:

```
graph error: conflict: change <id> has stale old payload for entity <id>
```

This is not the enrichment output. Immediately before `commit_repository_bootstrap`, every change in the transaction resolves cleanly through `resolve_graph_at` (verified with temporary instrumentation, 0 of 95 failing); the same changes fail once kin-db validates them during the commit. It needs merges to appear: fd truncated to 95 commits reproduces it in seconds, fd truncated to 26 does not.

That defect lives downstream of this repo and is tracked separately. This PR is the enrichment half, and it is what makes the failure visible at all.

## Correction from independent review (pre-merge)

The original claim that view-time relinking preserves cross-repo placeholder edges is overstated. Read paths regenerate external reference edges only where files are re-parsed (persisted entities empty or sparse); densely-admitted files enter the link universe with empty relations and imports, and the daemon spine consumes replayed relations only. Consequence: a repository imported clean from Git has empty cross-repo external references until a file is edited and re-indexed. This is a gap opened into newly reachable state, not a regression (repositories carrying these edges could not be admitted at all before this change). Follow-up tracked in Linear; the durable resolution may be the external-reference node design decision rather than read-time regeneration. The hydration semantics 4 to 5 bump is a review dial and does not itself implement re-ingest migration.
