### PR TITLE
Seal exact workspace and session observation through publication

### DIFF
--- a/crates/kin-cli/src/commands/reconcile.rs
+++ b/crates/kin-cli/src/commands/reconcile.rs
@@ -23,7 +23,7 @@ use serde::{Deserialize, Serialize};
 
 #[cfg(unix)]
 use super::repository_authority::ActiveRepositoryAuthority;
-use super::session_workspace::SessionWorkspaceBase;
+use crate::commands::session_workspace::SessionWorkspaceBase;
 
 pub const RECONCILE_SUMMARY_SCHEMA: &str = "kin.session-reconcile.v1";
 
@@ -1044,6 +1044,53 @@ mod tests {
         assert_eq!(
             ReconcilePath::from(&raw),
             ReconcilePath::Hex("6173736574732f706f6c6963792dff".to_string())
+        );
+    }
+
+    /// The scanner returns, and the observation still holds the no-follow
+    /// directory capability the walk was taken through. Swapping the session
+    /// out from under a completed observation is therefore still detected at
+    /// the moment publication asks, not only while the scanner was running.
+    #[cfg(unix)]
+    #[test]
+    fn observation_retains_its_session_capability_after_the_scanner_returns() {
+        let repo = tempfile::tempdir().unwrap();
+        std::fs::write(repo.path().join("member.txt"), b"admitted\n").unwrap();
+        let init = kin_core::init(repo.path()).unwrap();
+        let layout = init.layout;
+        let binding = kin_core::LocalRepositoryAuthorityBinding::from_layout(&layout).unwrap();
+        let blobs = kin_blobs::BlobStore::new(layout.ingest_cas_dir()).unwrap();
+
+        let session_dir = layout.runs_dir().join("session-capability-probe");
+        let request = crate::commands::session_workspace::SessionWorkspaceRequest {
+            session_dir: session_dir.display().to_string(),
+            strategy: None,
+            scope: None,
+        };
+        crate::commands::session_workspace::materialize_session_workspace(
+            &layout, &binding, &request,
+        )
+        .unwrap();
+
+        let observation =
+            observe_session_workspace(&layout, &binding, &session_dir, &blobs, false).unwrap();
+        observation
+            .revalidate_retained_capability(&layout)
+            .expect("an untouched session must still satisfy its retained capability");
+
+        // Swap the observed session directory for a different directory of the
+        // same name, exactly as a racing writer or a symlink swap would.
+        let displaced = layout.runs_dir().join("session-capability-probe-displaced");
+        std::fs::rename(&session_dir, &displaced).unwrap();
+        std::fs::create_dir(&session_dir).unwrap();
+        std::fs::create_dir(session_dir.join(".kin-session")).unwrap();
+
+        let error = observation
+            .revalidate_retained_capability(&layout)
+            .unwrap_err();
+        assert!(
+            error.to_string().contains("retained session capability"),
+            "{error:#}"
         );
     }
 

--- a/crates/kin-cli/src/commands/reconcile.rs
+++ b/crates/kin-cli/src/commands/reconcile.rs
@@ -115,18 +115,90 @@ pub struct ReconcileSummary {
 /// Source bodies have already been written and read back from the daemon's
 /// non-authoritative ingestion CAS, then released from request memory.
 /// Repository publication reloads them from CAS by identity.
+///
+/// The observation owns the retained no-follow directory capability it was
+/// taken through, so the capability outlives planning and reaches publication
+/// rather than being released when the scanner returns. Every field is
+/// private and every constructor path runs the scanner, so no caller outside
+/// this module can fabricate an observation or hand publication a desired tree
+/// that no retained walk produced.
+///
+/// The seal is a type-level one. Removing the capability, or building this
+/// value by hand, does not compile:
+///
+/// ```compile_fail
+/// # use kin_cli::commands::reconcile::SessionReconcileObservation;
+/// # fn fabricate(base: kin_cli::commands::session_workspace::SessionWorkspaceBase,
+/// #              tree: kin_model::ResolvedTree) -> SessionReconcileObservation {
+/// SessionReconcileObservation {
+///     base,
+///     desired_tree: tree,
+///     deltas: Vec::new(),
+///     observed_materialized_artifacts: 0,
+///     observed_body_bytes: 0,
+///     preserved_graph_only_artifacts: 0,
+/// }
+/// # }
+/// ```
 pub struct SessionReconcileObservation {
-    pub base: SessionWorkspaceBase,
-    pub desired_tree: ResolvedTree,
-    pub deltas: Vec<TreeDelta>,
-    pub observed_materialized_artifacts: usize,
-    pub observed_body_bytes: u64,
-    pub preserved_graph_only_artifacts: usize,
+    #[cfg(unix)]
+    retained: RetainedSession,
+    #[cfg(unix)]
+    base_bytes: Vec<u8>,
+    base: SessionWorkspaceBase,
+    desired_tree: ResolvedTree,
+    deltas: Vec<TreeDelta>,
+    observed_materialized_artifacts: usize,
+    observed_body_bytes: u64,
+    preserved_graph_only_artifacts: usize,
 }
 
 impl SessionReconcileObservation {
+    pub fn base(&self) -> &SessionWorkspaceBase {
+        &self.base
+    }
+
+    pub fn desired_tree(&self) -> &ResolvedTree {
+        &self.desired_tree
+    }
+
+    pub fn deltas(&self) -> &[TreeDelta] {
+        &self.deltas
+    }
+
+    pub const fn observed_materialized_artifacts(&self) -> usize {
+        self.observed_materialized_artifacts
+    }
+
+    pub const fn observed_body_bytes(&self) -> u64 {
+        self.observed_body_bytes
+    }
+
+    pub const fn preserved_graph_only_artifacts(&self) -> usize {
+        self.preserved_graph_only_artifacts
+    }
+
     pub fn changes(&self) -> Vec<ReconcileChange> {
         self.deltas.iter().map(reconcile_change).collect()
+    }
+
+    /// Re-prove the retained capability still names the observed session.
+    ///
+    /// Publication calls this after planning, so the window between the last
+    /// scan and the authority transaction is covered by the same directory
+    /// identities and the same base bytes the plan was derived from.
+    pub fn revalidate_retained_capability(&self, layout: &kin_core::KinLayout) -> Result<()> {
+        #[cfg(unix)]
+        {
+            self.retained
+                .revalidate_visible(layout, &self.base_bytes)
+                .context("revalidate retained session capability before publication")
+        }
+        #[cfg(not(unix))]
+        {
+            let _ = layout;
+            bail!("retained session capability is unavailable on this platform")
+        }
     }
 }
 
@@ -203,6 +275,8 @@ pub fn observe_session_workspace(
         let observed_materialized_artifacts = first.entries.len();
 
         Ok(SessionReconcileObservation {
+            retained,
+            base_bytes,
             base,
             desired_tree,
             deltas,

--- a/crates/kin-cli/src/main.rs
+++ b/crates/kin-cli/src/main.rs
@@ -56,7 +56,7 @@ enum Command {
         #[arg(long, default_value_t = false)]
         json: bool,
     },
-    /// [OPEN GATE] Create an exact semantic and artifact commit
+    /// Create an exact semantic and artifact commit
     Commit {
         /// Commit message
         #[arg(short, long)]
@@ -774,7 +774,7 @@ enum Command {
         #[arg(last = true)]
         task: Vec<String>,
     },
-    /// [OPEN GATE] Admit one exact disposable-session observation into repository-v6 authority
+    /// Admit one exact disposable-session observation into repository-v6 authority
     Reconcile {
         /// Session ID (defaults to most recent session)
         session: Option<String>,

--- a/crates/kin-cli/tests/command_capabilities.rs
+++ b/crates/kin-cli/tests/command_capabilities.rs
@@ -36,11 +36,11 @@ fn capability_json_keeps_the_bounded_dogfood_bar_explicit() {
         serde_json::from_slice(&output.stdout).expect("capability stdout should be JSON");
     assert_eq!(report["schema"], "kin.git-replacement-capabilities.v1");
     assert_eq!(report["substrate"], "repository-v6");
-    assert_eq!(report["bounded_dogfood_ready"], false);
-    assert_eq!(report["bounded_dogfood_required_ready"], 11);
+    assert_eq!(report["bounded_dogfood_ready"], true);
+    assert_eq!(report["bounded_dogfood_required_ready"], 12);
     assert_eq!(report["bounded_dogfood_required_total"], 12);
     assert_eq!(report["full_git_replacement_ready"], false);
-    assert_eq!(report["ready_commands"], 13);
+    assert_eq!(report["ready_commands"], 15);
     assert_eq!(report["command_total"], 32);
 
     let commands = report["commands"]
@@ -105,29 +105,9 @@ fn remaining_open_gate_commands_fail_before_repository_discovery() {
     std::fs::create_dir_all(&home).expect("create home");
 
     let output = kin_command(&home)
-        .args(["commit", "--message", "must remain sealed"])
-        .current_dir(root.path())
-        .output()
-        .expect("run gated commit");
-    assert!(!output.status.success());
-    let stderr = String::from_utf8_lossy(&output.stderr);
-    assert!(stderr.contains("`kin commit` is fail-closed on repository-v6"));
-    assert!(stderr.contains("kin capabilities --json"));
-
-    let output = kin_command(&home)
-        .arg("reconcile")
-        .current_dir(root.path())
-        .output()
-        .expect("run gated reconcile");
-    assert!(!output.status.success());
-    let stderr = String::from_utf8_lossy(&output.stderr);
-    assert!(stderr.contains("`kin reconcile` is fail-closed on repository-v6"));
-    assert!(stderr.contains("kin capabilities --json"));
-
-    // Checkout is exposed now, so it must fail on repository discovery rather
-    // than on the capability gate. Asserting the gate message is absent keeps a
-    // silent re-seal from passing as a discovery failure.
-    let output = kin_command(&home)
+        // Checkout is exposed now, so it must fail on repository discovery rather
+        // than on the capability gate. Asserting the gate message is absent keeps a
+        // silent re-seal from passing as a discovery failure.
         .args(["checkout", "src/lib.rs"])
         .current_dir(root.path())
         .output()

--- a/crates/kin-cli/tests/fixtures/git-replacement-capabilities-v1.json
+++ b/crates/kin-cli/tests/fixtures/git-replacement-capabilities-v1.json
@@ -36,8 +36,8 @@
     },
     {
       "command": "commit",
-      "status": "open_gate",
-      "exposure": "fail_closed",
+      "status": "ready",
+      "exposure": "enabled",
       "authority": "sealed exact-workspace observation consumed by repository-v6 transaction and compare-and-swap ref publication",
       "required_for_bounded_dogfood": true,
       "acceptance_spec": [
@@ -53,9 +53,13 @@
         "kin_daemon::repository_commit::tests::native_commit_preserves_host_unrepresentable_byte_exact_path",
         "kin_daemon::api::tests::command_commit_preserves_complete_arbitrary_repository_tree",
         "kin_core::tree::tests::repository_projection_covers_materializable_entries_and_preserves_gitlinks",
-        "kin_core::tree::tests::repository_projection_rejects_gitlink_transition_before_namespace_mutation"
+        "kin_core::tree::tests::repository_projection_rejects_gitlink_transition_before_namespace_mutation",
+        "kin_daemon::loop_runner::tests::incomplete_host_walk_publishes_no_workspace_authority",
+        "kin_daemon::loop_runner::tests::unconfirmed_mass_deletion_publishes_no_part_of_the_observation",
+        "kin_daemon::repository_commit::tests::stale_desired_tree_is_refused_against_newer_authority",
+        "kin_daemon::repository_commit::tests::desired_tree_planned_against_a_foreign_prior_tree_is_refused"
       ],
-      "note": "Exact artifact representation and repository transaction publication are implemented, but the ambient scanner currently drops its completion proof before publication, can replan a stale desired tree against newer authority, and can partially publish around the mass-deletion guard."
+      "note": "Commit consumes one complete host observation that carries the scanner's completion proof into publication, binds the observed manifest to the authority roots and prior workspace tree it was planned against, and refuses rather than replans when authority moved. An unconfirmed mass deletion refuses the whole observation, so no addition, modification, or derived admission-policy state published beside it."
     },
     {
       "command": "log",
@@ -289,8 +293,8 @@
     },
     {
       "command": "reconcile",
-      "status": "open_gate",
-      "exposure": "fail_closed",
+      "status": "ready",
+      "exposure": "enabled",
       "authority": "sealed exact-session observation consumed by repository-v6 explicit ingestion boundary",
       "required_for_bounded_dogfood": false,
       "acceptance_spec": [
@@ -302,9 +306,10 @@
       ],
       "evidence_tests": [
         "api::tests::reconcile_endpoint_admits_complete_exact_session_tree_and_replays",
-        "api::tests::reconcile_rejects_control_aliases_special_members_and_stale_bases"
+        "api::tests::reconcile_rejects_control_aliases_special_members_and_stale_bases",
+        "kin_cli::commands::reconcile::tests::observation_retains_its_session_capability_after_the_scanner_returns"
       ],
-      "note": "The session scanner already performs retained-root double observation and authority-root CAS, but its public observation DTO drops the retained capability before planning and remains fabricable outside the scanner."
+      "note": "The session scanner performs retained-root double observation and authority-root CAS, and its observation now owns the retained no-follow directory capability it was taken through. Every field is private, so the observation cannot be built outside the scanner, and planning re-proves the retained capability before anything is planned against it."
     },
     {
       "command": "conflicts",

--- a/crates/kin-daemon/src/api.rs
+++ b/crates/kin-daemon/src/api.rs
@@ -10690,10 +10690,16 @@ mod tests {
         let authority_context =
             crate::local_repository_authority::LocalRepositoryAuthorityContext::from_state(&state)
                 .unwrap();
+        let admitted = crate::repository_commit::admitted_workspace_tree_for_test(
+            state.layout.working_dir(),
+            roots_before.clone(),
+            state.graph.resolved_tree(),
+            desired.clone(),
+        );
         let publication_error = crate::repository_commit::publish_workspace_tree(
             state.blobs.as_ref(),
             &authority_context,
-            &desired,
+            &admitted,
             kin_model::OperationId::new(),
             AuthorId::new("kindb-root-swap-background-test"),
         )

--- a/crates/kin-daemon/src/api.rs
+++ b/crates/kin-daemon/src/api.rs
@@ -2691,8 +2691,8 @@ async fn reconcile_session_workspace(
     )
     .map_err(session_reconcile_error)?;
 
-    let previous_tree_hash = observation.base.source_workspace.tree_hash;
-    let desired_tree_hash = kin_model::compute_resolved_tree_hash(&observation.desired_tree)
+    let previous_tree_hash = observation.base().source_workspace.tree_hash;
+    let desired_tree_hash = kin_model::compute_resolved_tree_hash(observation.desired_tree())
         .map_err(repository_authority_error)?;
     let changes = observation.changes();
     let added = changes
@@ -2708,8 +2708,8 @@ async fn reconcile_session_workspace(
         .filter(|change| change.kind == kin_cli::commands::reconcile::ReconcileChangeKind::Removed)
         .count();
 
-    if state.graph.resolved_tree() != observation.base.source_workspace.tree
-        && state.graph.resolved_tree() != observation.desired_tree
+    if state.graph.resolved_tree() != observation.base().source_workspace.tree
+        && state.graph.resolved_tree() != *observation.desired_tree()
     {
         return Err((
             StatusCode::CONFLICT,
@@ -2720,12 +2720,12 @@ async fn reconcile_session_workspace(
     }
 
     let (authority_generation, workspace_generation, idempotent_replay) = if observation
-        .deltas
+        .deltas()
         .is_empty()
     {
         (
-            observation.base.authority_roots.generation,
-            observation.base.source_workspace.generation,
+            observation.base().authority_roots.generation,
+            observation.base().source_workspace.generation,
             false,
         )
     } else {
@@ -2733,10 +2733,10 @@ async fn reconcile_session_workspace(
             crate::local_repository_authority::LocalRepositoryAuthorityContext::from_state(&state)
                 .map_err(repository_commit_error)?;
         let plan = crate::repository_commit::plan_session_workspace_admission(
+            &state.layout,
             state.blobs.as_ref(),
             &authority_context,
-            &observation.base,
-            &observation.desired_tree,
+            &observation,
         )
         .map_err(repository_commit_error)?;
         let committed = crate::repository_commit::commit_session_workspace_admission(
@@ -2766,15 +2766,15 @@ async fn reconcile_session_workspace(
         }
 
         let graph_tree = state.graph.resolved_tree();
-        if graph_tree == observation.base.source_workspace.tree {
+        if graph_tree == observation.base().source_workspace.tree {
             state
                 .graph
                 .apply_transaction_delta(&TransactionDelta {
-                    tree_deltas: observation.deltas.clone(),
+                    tree_deltas: observation.deltas().to_vec(),
                     ..TransactionDelta::default()
                 })
                 .map_err(internal_error)?;
-        } else if graph_tree != observation.desired_tree {
+        } else if graph_tree != *observation.desired_tree() {
             return Err((
                 StatusCode::CONFLICT,
                 "repository receipt is durable but the daemon query tree cannot be advanced \
@@ -2792,7 +2792,7 @@ async fn reconcile_session_workspace(
         (
             committed.receipt.generation,
             observation
-                .base
+                .base()
                 .source_workspace
                 .generation
                 .saturating_add(1),
@@ -2803,20 +2803,20 @@ async fn reconcile_session_workspace(
     drop(graph_mutation);
     Ok(Json(kin_cli::commands::reconcile::ReconcileSummary {
         schema: kin_cli::commands::reconcile::RECONCILE_SUMMARY_SCHEMA.to_string(),
-        operation_id: observation.base.reconcile_operation_id,
-        repository_id: observation.base.repository_id,
+        operation_id: observation.base().reconcile_operation_id,
+        repository_id: observation.base().repository_id.clone(),
         authority_generation,
         workspace_generation,
         previous_tree_hash,
         desired_tree_hash,
         idempotent_replay,
-        changed: !observation.deltas.is_empty(),
+        changed: !observation.deltas().is_empty(),
         added,
         modified,
         removed,
-        observed_materialized_artifacts: observation.observed_materialized_artifacts,
-        preserved_graph_only_artifacts: observation.preserved_graph_only_artifacts,
-        observed_body_bytes: observation.observed_body_bytes,
+        observed_materialized_artifacts: observation.observed_materialized_artifacts(),
+        preserved_graph_only_artifacts: observation.preserved_graph_only_artifacts(),
+        observed_body_bytes: observation.observed_body_bytes(),
         semantic_files_enriched: 0,
         semantic_enrichment_failures: 0,
         changes,

--- a/crates/kin-daemon/src/commit_deltas.rs
+++ b/crates/kin-daemon/src/commit_deltas.rs
@@ -492,6 +492,40 @@ fn compute_deltas_from_resolved_state(
     })
 }
 
+/// One host observation carried together with the scanner's completion proof.
+///
+/// [`kin_index::CompleteScanToken`] can only be minted by a repository walk in
+/// which every directory read, metadata lookup, file read, and symbolic-link
+/// read succeeded. Carrying it in the observation keeps the proof attached
+/// through planning and into publication, so a partial walk or a fabricated
+/// path map cannot reach repository authority.
+///
+/// The observed entry set stays mutable because the daemon narrows it to the
+/// paths one ambient notification batch actually named. Narrowing what may
+/// move never weakens the proof that the walk itself was complete.
+pub(crate) struct CompleteWorkspaceObservation {
+    entries: BTreeMap<RepoPath, TreeEntry>,
+    completion: kin_index::CompleteScanToken,
+}
+
+impl CompleteWorkspaceObservation {
+    pub(crate) fn insert(&mut self, path: RepoPath, entry: TreeEntry) {
+        self.entries.insert(path, entry);
+    }
+
+    pub(crate) fn retain(&mut self, keep: impl FnMut(&RepoPath, &mut TreeEntry) -> bool) {
+        self.entries.retain(keep);
+    }
+
+    pub(crate) fn entries(&self) -> &BTreeMap<RepoPath, TreeEntry> {
+        &self.entries
+    }
+
+    pub(crate) const fn completion(&self) -> kin_index::CompleteScanToken {
+        self.completion
+    }
+}
+
 /// Turn one complete host scan into exact graph entries.
 ///
 /// Graph-only entries (currently Gitlinks) are copied from the parent tree:
@@ -500,7 +534,7 @@ pub(crate) fn observed_tree_from_complete_scan(
     blobs: &kin_blobs::BlobStore,
     scan: &kin_index::CompleteRepositoryScan,
     previous: &ResolvedTree,
-) -> Result<BTreeMap<RepoPath, TreeEntry>> {
+) -> Result<CompleteWorkspaceObservation> {
     let mut observed = previous
         .artifacts_by_path()
         .filter(|artifact| matches!(artifact.entry, TreeEntry::Gitlink { .. }))
@@ -527,7 +561,10 @@ pub(crate) fn observed_tree_from_complete_scan(
         observed.insert(scanned.repo_path.clone(), entry);
     }
 
-    Ok(observed)
+    Ok(CompleteWorkspaceObservation {
+        entries: observed,
+        completion: scan.completion(),
+    })
 }
 
 fn read_scanned_entry(scanned: &kin_index::ScannedRepositoryEntry) -> Result<Vec<u8>> {

--- a/crates/kin-daemon/src/commit_deltas.rs
+++ b/crates/kin-daemon/src/commit_deltas.rs
@@ -1074,7 +1074,8 @@ mod tests {
         )
         .map_err(kin_index::IndexError::from)?;
         let observed = observed_tree_from_complete_scan(blobs, &scan, &previous)?;
-        let tree_deltas = kin_core::plan_observed_tree_deltas(&previous, observed)?;
+        let tree_deltas =
+            kin_core::plan_observed_tree_deltas(&previous, observed.entries().clone())?;
         graph.apply_transaction_delta(&kin_model::TransactionDelta {
             entity_deltas: Vec::new(),
             relation_deltas: Vec::new(),

--- a/crates/kin-daemon/src/loop_runner.rs
+++ b/crates/kin-daemon/src/loop_runner.rs
@@ -1835,11 +1835,17 @@ mod tests {
         std::fs::remove_file(&tracked).unwrap();
         let _tracked_listener = UnixListener::bind(&tracked).unwrap();
 
+        // The walk itself refuses: a tracked path Kin cannot represent makes
+        // the scan incomplete, so there is no completion proof to publish with
+        // and graph truth is retained.
         let error = admit_file_event(&state, &FileEvent::Changed(tracked))
             .expect_err("tracked special type must fail instead of erasing graph truth");
-        assert!(error
-            .to_string()
-            .contains("tracked repository path changed"));
+        assert!(
+            error
+                .to_string()
+                .contains("tracked path changed to an unsupported special filesystem entry"),
+            "{error}"
+        );
         assert_eq!(tree_entry(&state, "tracked.sock"), Some(old_entry));
     }
 

--- a/crates/kin-daemon/src/loop_runner.rs
+++ b/crates/kin-daemon/src/loop_runner.rs
@@ -11,7 +11,7 @@ use kin_index::{
     FileClassification, FileClassifier, FileEvent, FileWatcher, IndexPipeline, IndexedAny,
 };
 use kin_model::{
-    ArtifactId, EntityFilter, EntityId, EntityStore, FilePathId, Hash256, LocatedEntry, RepoPath,
+    EntityFilter, EntityId, EntityStore, FilePathId, Hash256, RepoPath,
     ShallowTrackedFile, TransactionDelta, TreeDelta, TreeEntry,
 };
 use tracing::{debug, error, info, warn};
@@ -110,7 +110,6 @@ enum AdmittedFileEvent {
     Removed {
         repo_path: RepoPath,
         file_id: Option<FilePathId>,
-        tree_delta: Option<TreeDelta>,
         tree_changed: bool,
     },
     Ignored,
@@ -348,14 +347,14 @@ fn is_within_graph_only_member(state: &DaemonState, path: &RepoPath) -> Result<b
 
 fn publish_exact_workspace_tree(
     state: &DaemonState,
-    desired_tree: &kin_model::ResolvedTree,
+    admitted: &crate::repository_commit::AdmittedWorkspaceTree,
 ) -> Result<()> {
     let authority_context =
         crate::local_repository_authority::LocalRepositoryAuthorityContext::from_state(state)?;
     let Some(admission) = crate::repository_commit::publish_workspace_tree(
         state.blobs.as_ref(),
         &authority_context,
-        desired_tree,
+        admitted,
         kin_model::OperationId::new(),
         kin_model::AuthorId::new(kin_core::whoami()),
     )?
@@ -379,6 +378,29 @@ fn invalid_tree_transition(error: impl std::fmt::Display) -> DaemonError {
             "invalid admitted exact-tree transition: {error}"
         )),
     ))
+}
+
+/// Refuse one whole observation whose removals were never confirmed.
+///
+/// This is a refusal of the observation, not of its removal subset: no tree,
+/// policy, or graph state derived from it may be published.
+fn mass_deletion_refused(removed: u64, total_graph_files: u64) -> DaemonError {
+    DaemonError::Graph(kin_db::KinDbError::Model(
+        kin_model::ModelError::InvalidOperation(format!(
+            "refusing one complete host observation: it removes {removed} of {total_graph_files} \
+             graph-known artifacts. No part of an unconfirmed mass deletion is published. Set \
+             KIN_ALLOW_MASS_DELETION=1 to confirm an intentional mass deletion"
+        )),
+    ))
+}
+
+/// Read the repository roots the next observation will be planned against.
+fn current_authority_roots(state: &DaemonState) -> Result<kin_model::RootBundle> {
+    let authority_context =
+        crate::local_repository_authority::LocalRepositoryAuthorityContext::from_state(state)?;
+    let authority = authority_context.open().map_err(DaemonError::Graph)?;
+    let roots = authority.read_authority().roots().clone();
+    Ok(roots)
 }
 
 /// Report whether one repository path was named by an observation, either
@@ -416,6 +438,11 @@ fn exact_tree_admission(
     observation: Option<&BTreeSet<RepoPath>>,
 ) -> Result<ExactTreeAdmission> {
     let working_dir = state.layout.working_dir();
+    // Read the authority roots the observation is about to be planned against.
+    // Publication compare-and-swaps on this bundle, so a repository that moves
+    // while the host walk is running fails the whole admission instead of
+    // having its desired tree replanned onto the newer authority.
+    let expected_roots = current_authority_roots(state)?;
     let previous = state.graph.resolved_tree();
     let tracked_paths = previous
         .artifacts_by_path()
@@ -449,7 +476,7 @@ fn exact_tree_admission(
         }
         observed.retain(|path, _| previous.artifact_id_at_path(path).is_some());
     }
-    let mut deltas = kin_core::plan_observed_tree_deltas(&previous, observed.clone())?;
+    let deltas = kin_core::plan_observed_tree_deltas(&previous, observed.entries().clone())?;
 
     let removed_count = deltas
         .iter()
@@ -461,20 +488,15 @@ fn exact_tree_admission(
         .unwrap_or(false);
     if should_block_mass_deletion(removed_count, previous.len() as u64, allow_mass_deletion) {
         state.mass_deletion_blocked.store(true, Ordering::Relaxed);
-        warn!(
-            total_graph_files = previous.len(),
-            removed_count,
-            "refusing filesystem-sync removals: they would wipe >75% of graph-known artifacts. Set KIN_ALLOW_MASS_DELETION=1 to confirm an intentional mass deletion"
-        );
-        for delta in &deltas {
-            if let TreeDelta::Removed { old, .. } = delta {
-                observed.insert(old.path.clone(), old.entry);
-            }
-        }
-        deltas = kin_core::plan_observed_tree_deltas(&previous, observed)?;
-    } else {
-        state.mass_deletion_blocked.store(false, Ordering::Relaxed);
+        // One host walk is one observation. Suppressing only its removals and
+        // replanning would publish the additions, modifications, and derived
+        // admission-policy state that the same unconfirmed observation carried,
+        // which is a partial publication of a transition the operator refused.
+        // The whole observation is dropped instead; nothing crosses authority
+        // and graph truth is retained until the deletion is confirmed.
+        return Err(mass_deletion_refused(removed_count, previous.len() as u64));
     }
+    state.mass_deletion_blocked.store(false, Ordering::Relaxed);
 
     let mut changed_paths = BTreeSet::new();
     let mut semantic_events = Vec::new();
@@ -499,8 +521,16 @@ fn exact_tree_admission(
         let desired_tree = previous.apply(&deltas).map_err(invalid_tree_transition)?;
         // Repository authority moves first. The in-memory graph is a derived
         // staging/query view and must never acknowledge dirty file truth that
-        // has not crossed the repository-v6 compare-and-swap.
-        publish_exact_workspace_tree(state, &desired_tree)?;
+        // has not crossed the repository-v6 compare-and-swap. The scanner's
+        // completion proof and the planning base travel with the tree so
+        // publication can verify both rather than trust the caller.
+        let admitted = crate::repository_commit::AdmittedWorkspaceTree::from_complete_observation(
+            observed.completion(),
+            expected_roots,
+            previous.clone(),
+            desired_tree,
+        );
+        publish_exact_workspace_tree(state, &admitted)?;
         state.graph.apply_transaction_delta(&TransactionDelta {
             entity_deltas: Vec::new(),
             relation_deltas: Vec::new(),
@@ -516,54 +546,15 @@ fn exact_tree_admission(
     })
 }
 
-fn planned_tree_delta(
-    state: &DaemonState,
-    path: RepoPath,
-    new_entry: Option<TreeEntry>,
-) -> Option<TreeDelta> {
-    let existing = state
-        .graph
-        .artifact_id_at_path(&path)
-        .and_then(|artifact_id| state.graph.resolved_artifact(&artifact_id));
-    match (existing, new_entry) {
-        (Some(existing), Some(entry)) if existing.entry == entry => None,
-        (Some(existing), Some(entry)) => Some(TreeDelta::Updated {
-            artifact_id: existing.artifact_id,
-            old: existing.located_entry(),
-            new: LocatedEntry::new(path, entry),
-        }),
-        (None, Some(entry)) => Some(TreeDelta::Added {
-            artifact_id: ArtifactId::new(),
-            new: LocatedEntry::new(path, entry),
-        }),
-        (Some(existing), None) => Some(TreeDelta::Removed {
-            artifact_id: existing.artifact_id,
-            old: existing.located_entry(),
-        }),
-        (None, None) => None,
-    }
-}
 
-fn apply_tree_delta(state: &DaemonState, delta: Option<TreeDelta>) -> Result<bool> {
-    let Some(delta) = delta else {
-        return Ok(false);
-    };
-    let desired_tree = state
-        .graph
-        .resolved_tree()
-        .apply(std::slice::from_ref(&delta))
-        .map_err(invalid_tree_transition)?;
-    publish_exact_workspace_tree(state, &desired_tree)?;
-    state.graph.apply_transaction_delta(&TransactionDelta {
-        entity_deltas: Vec::new(),
-        relation_deltas: Vec::new(),
-        tree_deltas: vec![delta],
-        ..TransactionDelta::default()
-    })?;
-    Ok(true)
-}
-
-/// Admit exact repository-tree truth before attempting any enrichment.
+/// Classify one host event against exact repository-tree truth that has
+/// already been admitted, before attempting any enrichment.
+///
+/// `admitted_paths` are the paths the preceding complete-scan transaction moved.
+/// This function never publishes: exact tree truth reaches repository authority
+/// only through [`exact_tree_admission`], which carries the scanner's completion
+/// proof. A per-event publication seam here would be a raw-filesystem rebuild of
+/// authority with no proof that the walk behind it ever completed.
 ///
 /// A removal notification is reclassified as a change when the directory
 /// entry exists again (including a dangling symlink); a change notification is
@@ -571,7 +562,7 @@ fn apply_tree_delta(state: &DaemonState, delta: Option<TreeDelta>) -> Result<boo
 fn admit_file_event_with_exact_tree(
     state: &DaemonState,
     event: &FileEvent,
-    admitted_paths: Option<&BTreeSet<RepoPath>>,
+    admitted_paths: &BTreeSet<RepoPath>,
 ) -> Result<AdmittedFileEvent> {
     let path = match event {
         FileEvent::Changed(path) | FileEvent::Removed(path) => path,
@@ -589,7 +580,7 @@ fn admit_file_event_with_exact_tree(
     }
     let file_id = semantic_file_id(&repo_path);
     let tracked = state.graph.artifact_id_at_path(&repo_path).is_some()
-        || admitted_paths.is_some_and(|paths| paths.contains(&repo_path));
+        || admitted_paths.contains(&repo_path);
     let ignore =
         kin_index::RepositoryIgnore::load(working_dir).map_err(kin_index::IndexError::from)?;
     if !tracked && ignore.matches(&repo_path) {
@@ -599,17 +590,10 @@ fn admit_file_event_with_exact_tree(
     let metadata = match std::fs::symlink_metadata(path) {
         Ok(metadata) => metadata,
         Err(error) if error.kind() == std::io::ErrorKind::NotFound => {
-            let tree_delta = admitted_paths
-                .is_none()
-                .then(|| planned_tree_delta(state, repo_path.clone(), None))
-                .flatten();
-            let tree_changed = admitted_paths
-                .map(|paths| paths.contains(&repo_path))
-                .unwrap_or_else(|| tree_delta.is_some());
+            let tree_changed = admitted_paths.contains(&repo_path);
             return Ok(AdmittedFileEvent::Removed {
                 repo_path,
                 file_id,
-                tree_delta,
                 tree_changed,
             });
         }
@@ -658,13 +642,7 @@ fn admit_file_event_with_exact_tree(
         )));
     };
 
-    let tree_changed = match admitted_paths {
-        Some(paths) => paths.contains(&repo_path),
-        None => apply_tree_delta(
-            state,
-            planned_tree_delta(state, repo_path.clone(), Some(entry)),
-        )?,
-    };
+    let tree_changed = admitted_paths.contains(&repo_path);
 
     if is_symlink {
         Ok(AdmittedFileEvent::Symlink {
@@ -687,7 +665,10 @@ fn admit_file_event_with_exact_tree(
 
 #[cfg(test)]
 fn admit_file_event(state: &DaemonState, event: &FileEvent) -> Result<AdmittedFileEvent> {
-    admit_file_event_with_exact_tree(state, event, None)
+    // Mirror production ordering: one complete-scan transaction crosses
+    // authority first, then host events are classified against what it moved.
+    let admission = exact_tree_admission(state, None)?;
+    admit_file_event_with_exact_tree(state, event, &admission.changed_paths)
 }
 
 fn clear_incompatible_facets(
@@ -733,26 +714,21 @@ fn clear_incompatible_facets(
     Ok(cleanup)
 }
 
-/// Clear UTF-8-only enrichment while the artifact is still admitted, then
-/// remove exact tree identity. Non-UTF-8 artifacts have no `FilePathId`
-/// enrichment surface and proceed directly to the tree transaction.
+/// Clear UTF-8-only enrichment for an artifact the exact-tree transaction has
+/// already removed. Non-UTF-8 artifacts have no `FilePathId` enrichment
+/// surface and need no cleanup.
 fn finalize_tree_removal(
     state: &DaemonState,
     file_id: Option<&FilePathId>,
-    tree_delta: Option<TreeDelta>,
     tree_changed: bool,
 ) -> Result<FacetCleanup> {
     if !tree_changed {
         return Ok(FacetCleanup::default());
     }
-    let cleanup = match file_id {
-        Some(file_id) => clear_incompatible_facets(state, file_id, EnrichmentFacet::None)?,
-        None => FacetCleanup::default(),
-    };
-    if tree_delta.is_some() {
-        apply_tree_delta(state, tree_delta)?;
+    match file_id {
+        Some(file_id) => clear_incompatible_facets(state, file_id, EnrichmentFacet::None),
+        None => Ok(FacetCleanup::default()),
     }
-    Ok(cleanup)
 }
 
 fn shallow_tracked_file(shallow: kin_parser::ShallowFile) -> ShallowTrackedFile {
@@ -1079,7 +1055,7 @@ pub async fn run_loop(
             let admitted = match admit_file_event_with_exact_tree(
                 &state,
                 event,
-                Some(&exact_admission.changed_paths),
+                &exact_admission.changed_paths,
             ) {
                 Ok(admitted) => admitted,
                 Err(error) => {
@@ -1264,14 +1240,12 @@ pub async fn run_loop(
                 AdmittedFileEvent::Removed {
                     repo_path,
                     file_id,
-                    tree_delta,
                     ..
                 } => {
                     if !tree_changed {
                         continue;
                     }
-                    match finalize_tree_removal(&state, file_id.as_ref(), tree_delta, tree_changed)
-                    {
+                    match finalize_tree_removal(&state, file_id.as_ref(), tree_changed) {
                         Ok(cleanup) => {
                             if let Some(file_id) = &file_id {
                                 projection_changed.remove(file_id.clone());
@@ -1883,8 +1857,8 @@ mod tests {
                 entity_deltas: vec![],
                 relation_deltas: vec![],
                 tree_deltas: vec![TreeDelta::Added {
-                    artifact_id: ArtifactId::new(),
-                    new: LocatedEntry::new(test_repo_path("submodule"), gitlink),
+                    artifact_id: kin_model::ArtifactId::new(),
+                    new: kin_model::LocatedEntry::new(test_repo_path("submodule"), gitlink),
                 }],
                 ..TransactionDelta::default()
             })
@@ -2337,7 +2311,7 @@ pub(crate) async fn sync_filesystem_with_graph_under_coordination(
         let admitted = match admit_file_event_with_exact_tree(
             state,
             &event,
-            Some(&exact_admission.changed_paths),
+            &exact_admission.changed_paths,
         ) {
             Ok(admitted) => admitted,
             Err(error) => {
@@ -2469,13 +2443,12 @@ pub(crate) async fn sync_filesystem_with_graph_under_coordination(
             AdmittedFileEvent::Removed {
                 repo_path,
                 file_id,
-                tree_delta,
                 tree_changed,
             } => {
                 if !tree_changed {
                     continue;
                 }
-                match finalize_tree_removal(state, file_id.as_ref(), tree_delta, tree_changed) {
+                match finalize_tree_removal(state, file_id.as_ref(), tree_changed) {
                     Ok(cleanup) => {
                         if let Some(file_id) = &file_id {
                             projection_changed.remove(file_id.clone());

--- a/crates/kin-daemon/src/loop_runner.rs
+++ b/crates/kin-daemon/src/loop_runner.rs
@@ -11,8 +11,8 @@ use kin_index::{
     FileClassification, FileClassifier, FileEvent, FileWatcher, IndexPipeline, IndexedAny,
 };
 use kin_model::{
-    EntityFilter, EntityId, EntityStore, FilePathId, Hash256, RepoPath,
-    ShallowTrackedFile, TransactionDelta, TreeDelta, TreeEntry,
+    EntityFilter, EntityId, EntityStore, FilePathId, Hash256, RepoPath, ShallowTrackedFile,
+    TransactionDelta, TreeDelta, TreeEntry,
 };
 use tracing::{debug, error, info, warn};
 
@@ -545,7 +545,6 @@ fn exact_tree_admission(
         semantic_events: dedup_file_events(semantic_events),
     })
 }
-
 
 /// Classify one host event against exact repository-tree truth that has
 /// already been admitted, before attempting any enrichment.
@@ -1238,9 +1237,7 @@ pub async fn run_loop(
                     continue;
                 }
                 AdmittedFileEvent::Removed {
-                    repo_path,
-                    file_id,
-                    ..
+                    repo_path, file_id, ..
                 } => {
                     if !tree_changed {
                         continue;
@@ -2227,6 +2224,107 @@ mod tests {
         let batch = take_file_event_batch(&mut pending, 1);
         assert!(matches!(&batch[0], FileEvent::Removed(actual) if actual == &path));
         assert!(pending.is_empty());
+    }
+
+    /// A walk that cannot complete has no completion proof, so it has nothing
+    /// to publish with. Authority must be untouched rather than advanced from
+    /// whatever the partial walk happened to read.
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn incomplete_host_walk_publishes_no_workspace_authority() {
+        use std::os::unix::net::UnixListener;
+
+        let repo = tempfile::tempdir().unwrap();
+        let tracked = repo.path().join("service.txt");
+        std::fs::write(&tracked, b"regular while it is admitted\n").unwrap();
+        let init = kin_core::init(repo.path()).unwrap();
+        let state = Arc::new(DaemonState::open(init.layout).unwrap());
+        sync_filesystem_with_graph(&state).await.unwrap();
+
+        let tree_before = authority_tree(&state);
+        assert!(tree_before
+            .artifact_at_path(&test_repo_path("service.txt"))
+            .is_some());
+
+        std::fs::remove_file(&tracked).unwrap();
+        let _listener = UnixListener::bind(&tracked).unwrap();
+
+        let error = sync_filesystem_with_graph(&state).await.unwrap_err();
+        assert!(
+            error.to_string().contains("repository scan incomplete"),
+            "{error}"
+        );
+        assert_eq!(
+            authority_tree(&state),
+            tree_before,
+            "a walk that never completed must not move workspace authority"
+        );
+    }
+
+    /// The mass-deletion guard refuses an observation, not a delta subset.
+    /// Anything else the same unconfirmed walk saw must stay unpublished too.
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn unconfirmed_mass_deletion_publishes_no_part_of_the_observation() {
+        let repo = tempfile::tempdir().unwrap();
+        for index in 0..20 {
+            std::fs::write(
+                repo.path().join(format!("member{index}.txt")),
+                format!("admitted {index}\n"),
+            )
+            .unwrap();
+        }
+        let init = kin_core::init(repo.path()).unwrap();
+        let state = Arc::new(DaemonState::open(init.layout).unwrap());
+        sync_filesystem_with_graph(&state).await.unwrap();
+
+        let tree_before = authority_tree(&state);
+        assert_eq!(tree_before.len(), 20);
+
+        let survivor_entry_before = tree_before
+            .artifact_at_path(&test_repo_path("member19.txt"))
+            .unwrap()
+            .entry;
+
+        for index in 0..18 {
+            std::fs::remove_file(repo.path().join(format!("member{index}.txt"))).unwrap();
+        }
+        // The same walk also carries an ordinary modification. It is a delta
+        // the operator never refused, which is exactly why the old behavior
+        // published it while suppressing the removals beside it.
+        std::fs::write(
+            repo.path().join("member19.txt"),
+            b"edited in the same observation as the deletion\n",
+        )
+        .unwrap();
+
+        let error = sync_filesystem_with_graph(&state).await.unwrap_err();
+        assert!(
+            error
+                .to_string()
+                .contains("No part of an unconfirmed mass deletion is published"),
+            "{error}"
+        );
+        assert!(state.is_mass_deletion_blocked());
+
+        let tree_after = authority_tree(&state);
+        assert_eq!(
+            tree_after, tree_before,
+            "no part of a refused observation may cross authority"
+        );
+        assert_eq!(
+            tree_after
+                .artifact_at_path(&test_repo_path("member19.txt"))
+                .unwrap()
+                .entry,
+            survivor_entry_before,
+            "the modification carried by a refused observation must not publish"
+        );
+        assert_eq!(
+            tree_entry(&state, "member19.txt"),
+            Some(survivor_entry_before),
+            "graph state derived from a refused observation must not publish either"
+        );
     }
 
     #[test]

--- a/crates/kin-daemon/src/repository_commit.rs
+++ b/crates/kin-daemon/src/repository_commit.rs
@@ -91,6 +91,9 @@ pub(crate) struct AdmittedWorkspaceTree {
     previous_tree: kin_model::ResolvedTree,
     desired_tree: kin_model::ResolvedTree,
     expected_roots: RootBundle,
+    /// Held, not read: the proof does its work by being impossible to supply
+    /// without a completed walk, and by staying attached to the tree it
+    /// proved.
     #[allow(dead_code)]
     completion: kin_index::CompleteScanToken,
 }
@@ -109,6 +112,35 @@ impl AdmittedWorkspaceTree {
             completion,
         }
     }
+}
+
+/// Admit `desired_tree` for a test by taking a real host walk first.
+///
+/// `CompleteScanToken` cannot be minted outside `kin-index`, so a test cannot
+/// fabricate an admission any more than production can. It has to walk the
+/// working directory and carry back the proof that the walk finished.
+#[cfg(test)]
+pub(crate) fn admitted_workspace_tree_for_test(
+    working_dir: &std::path::Path,
+    expected_roots: RootBundle,
+    previous_tree: kin_model::ResolvedTree,
+    desired_tree: kin_model::ResolvedTree,
+) -> AdmittedWorkspaceTree {
+    let ignore = kin_index::RepositoryIgnore::load(working_dir).expect("load repository ignore");
+    let scan = kin_index::scan_repository(
+        working_dir,
+        &ignore,
+        previous_tree
+            .artifacts_by_path()
+            .map(|artifact| &artifact.path),
+    )
+    .expect("complete host walk");
+    AdmittedWorkspaceTree::from_complete_observation(
+        scan.completion(),
+        expected_roots,
+        previous_tree,
+        desired_tree,
+    )
 }
 
 /// Immutable session-reconcile plan bound to the authority lease captured when
@@ -1193,13 +1225,25 @@ mod tests {
         operation_id: OperationId,
         actor: AuthorId,
     ) -> Result<Option<WorkspaceAdmissionResult>> {
-        super::publish_workspace_tree(
-            blobs,
-            &test_authority_context(layout),
-            desired_tree,
-            operation_id,
-            actor,
-        )
+        let context = test_authority_context(layout);
+        let authority = context.open()?;
+        let lease = authority.read_authority();
+        let expected_roots = lease.roots().clone();
+        let previous_tree = lease
+            .metadata()
+            .workspaces
+            .iter()
+            .find(|workspace| workspace.workspace_id == context.workspace_id())
+            .map(|workspace| workspace.tree.clone())
+            .unwrap_or_default();
+        drop(lease);
+        let admitted = super::admitted_workspace_tree_for_test(
+            layout.working_dir(),
+            expected_roots,
+            previous_tree,
+            desired_tree.clone(),
+        );
+        super::publish_workspace_tree(blobs, &context, &admitted, operation_id, actor)
     }
 
     #[allow(clippy::too_many_arguments)]
@@ -1242,6 +1286,134 @@ mod tests {
             &test_authority_context(layout),
             plan,
         )
+    }
+
+    /// A desired tree describes one transition out of one observed prior tree.
+    /// Once authority has moved past that prior tree, re-deriving the same
+    /// desired tree against the newer workspace would publish a transition
+    /// nobody observed and silently revert whatever moved authority. The stale
+    /// admission must be refused instead.
+    #[test]
+    fn stale_desired_tree_is_refused_against_newer_authority() {
+        let root = tempfile::tempdir().unwrap();
+        let init = kin_core::init(root.path()).unwrap();
+        let blobs = kin_blobs::BlobStore::new(init.layout.ingest_cas_dir()).unwrap();
+        let graph = kin_db::InMemoryGraph::new();
+
+        let observed = add_artifact(&graph, &blobs, b"observed.txt", b"observed\n", |hash| {
+            TreeEntry::blob(hash, false)
+        });
+        let concurrent = add_artifact(
+            &graph,
+            &blobs,
+            b"concurrent.txt",
+            b"published by someone else\n",
+            |hash| TreeEntry::blob(hash, false),
+        );
+
+        let context = test_authority_context(&init.layout);
+        let roots_at_observation = context.open().unwrap().read_authority().roots().clone();
+        let previous_tree = ResolvedTree::default();
+
+        // The observation is planned against the empty workspace tree.
+        let stale = super::admitted_workspace_tree_for_test(
+            init.layout.working_dir(),
+            roots_at_observation.clone(),
+            previous_tree.clone(),
+            ResolvedTree::from_artifacts([observed]).unwrap(),
+        );
+
+        // Authority moves before the stale admission reaches publication.
+        publish_workspace_tree(
+            &init.layout,
+            &blobs,
+            &ResolvedTree::from_artifacts([concurrent.clone()]).unwrap(),
+            OperationId::new(),
+            AuthorId::new("concurrent-writer"),
+        )
+        .unwrap()
+        .expect("the concurrent transition must advance authority");
+
+        let roots_after_concurrent = context.open().unwrap().read_authority().roots().clone();
+        assert_ne!(roots_at_observation, roots_after_concurrent);
+
+        let error = super::publish_workspace_tree(
+            &blobs,
+            &context,
+            &stale,
+            OperationId::new(),
+            AuthorId::new("stale-observer"),
+        )
+        .unwrap_err();
+        assert!(
+            error
+                .to_string()
+                .contains("does not replan a stale desired tree against newer authority"),
+            "{error}"
+        );
+
+        let lease = context.open().unwrap().read_authority();
+        let workspace = lease
+            .metadata()
+            .workspaces
+            .iter()
+            .find(|workspace| workspace.workspace_id == init.workspace_id)
+            .unwrap()
+            .clone();
+        drop(lease);
+        assert_eq!(
+            workspace.tree,
+            ResolvedTree::from_artifacts([concurrent]).unwrap(),
+            "the refused stale admission must not revert the concurrent transition"
+        );
+        assert!(workspace
+            .tree
+            .artifact_at_path(&kin_model::RepoPath::from_utf8("observed.txt").unwrap())
+            .is_none());
+    }
+
+    /// The same refusal applies when authority did not move but the plan was
+    /// taken against a tree that was never this workspace's authority tree.
+    #[test]
+    fn desired_tree_planned_against_a_foreign_prior_tree_is_refused() {
+        let root = tempfile::tempdir().unwrap();
+        let init = kin_core::init(root.path()).unwrap();
+        let blobs = kin_blobs::BlobStore::new(init.layout.ingest_cas_dir()).unwrap();
+        let graph = kin_db::InMemoryGraph::new();
+        let invented = add_artifact(
+            &graph,
+            &blobs,
+            b"invented.txt",
+            b"never admitted\n",
+            |hash| TreeEntry::blob(hash, false),
+        );
+        let desired = add_artifact(&graph, &blobs, b"desired.txt", b"desired\n", |hash| {
+            TreeEntry::blob(hash, false)
+        });
+
+        let context = test_authority_context(&init.layout);
+        let roots = context.open().unwrap().read_authority().roots().clone();
+        let admitted = super::admitted_workspace_tree_for_test(
+            init.layout.working_dir(),
+            roots,
+            ResolvedTree::from_artifacts([invented]).unwrap(),
+            ResolvedTree::from_artifacts([desired]).unwrap(),
+        );
+
+        let error = super::publish_workspace_tree(
+            &blobs,
+            &context,
+            &admitted,
+            OperationId::new(),
+            AuthorId::new("foreign-base-observer"),
+        )
+        .unwrap_err();
+        assert!(
+            error
+                .to_string()
+                .contains("does not replan a stale desired tree against newer authority"),
+            "{error}"
+        );
     }
 
     #[test]

--- a/crates/kin-daemon/src/repository_commit.rs
+++ b/crates/kin-daemon/src/repository_commit.rs
@@ -79,6 +79,38 @@ pub struct WorkspaceAdmissionResult {
     pub file_count: usize,
 }
 
+/// One exact workspace transition that a complete host scan actually proved.
+///
+/// The constructor requires [`kin_index::CompleteScanToken`], which only a
+/// fully successful repository walk mints, so publication cannot be handed a
+/// tree assembled from a partial walk or from nothing at all. It also binds the
+/// authority roots and the workspace tree the transition was planned against,
+/// which is what lets publication refuse a stale desired tree instead of
+/// silently replanning it against newer authority.
+pub(crate) struct AdmittedWorkspaceTree {
+    previous_tree: kin_model::ResolvedTree,
+    desired_tree: kin_model::ResolvedTree,
+    expected_roots: RootBundle,
+    #[allow(dead_code)]
+    completion: kin_index::CompleteScanToken,
+}
+
+impl AdmittedWorkspaceTree {
+    pub(crate) fn from_complete_observation(
+        completion: kin_index::CompleteScanToken,
+        expected_roots: RootBundle,
+        previous_tree: kin_model::ResolvedTree,
+        desired_tree: kin_model::ResolvedTree,
+    ) -> Self {
+        Self {
+            previous_tree,
+            desired_tree,
+            expected_roots,
+            completion,
+        }
+    }
+}
+
 /// Immutable session-reconcile plan bound to the authority lease captured when
 /// the disposable session was materialized.
 pub struct SessionWorkspaceAdmissionPlan {
@@ -103,16 +135,26 @@ pub struct SessionWorkspaceAdmissionResult {
 /// Build one exact session admission against the session's retained roots and
 /// complete source workspace.
 ///
+/// Planning takes the sealed observation rather than a loose base and tree, so
+/// the retained no-follow directory capability is still held here and can be
+/// re-proved before anything is planned against it. A caller cannot reach this
+/// boundary with a desired tree that no retained walk produced.
+///
 /// Unlike the ambient filesystem synchronizer, this never silently rebases
 /// onto a newer workspace. The only accepted moved-authority state is the
 /// exact durable receipt for this session's caller-stable operation and
 /// transaction hash.
 pub(crate) fn plan_session_workspace_admission(
+    layout: &kin_core::KinLayout,
     blobs: &kin_blobs::BlobStore,
     authority_context: &LocalRepositoryAuthorityContext,
-    base: &kin_cli::commands::session_workspace::SessionWorkspaceBase,
-    desired_tree: &kin_model::ResolvedTree,
+    observation: &kin_cli::commands::reconcile::SessionReconcileObservation,
 ) -> Result<SessionWorkspaceAdmissionPlan> {
+    observation
+        .revalidate_retained_capability(layout)
+        .map_err(|error| invalid(error.to_string()))?;
+    let base = observation.base();
+    let desired_tree = observation.desired_tree();
     let repository_id = authority_context.repository_id().clone();
     let workspace_id = authority_context.workspace_id();
     if base.repository_id != repository_id
@@ -351,22 +393,35 @@ pub(crate) fn commit_session_workspace_admission(
 
 /// Atomically publish one exact graph-owned workspace tree.
 ///
-/// The caller has already performed the explicit filesystem-ingestion scan.
-/// This boundary consumes only its admitted exact tree plus bodies in the
-/// non-authoritative ingestion CAS, copies newly referenced bodies into
-/// repository CAS, and compare-and-swaps the workspace. It never creates a
-/// history node or advances a ref.
+/// The caller has already performed the explicit filesystem-ingestion scan and
+/// carries its completion proof in `admitted`. This boundary consumes only that
+/// admitted exact tree plus bodies in the non-authoritative ingestion CAS,
+/// copies newly referenced bodies into repository CAS, and compare-and-swaps
+/// the workspace. It never creates a history node or advances a ref.
+///
+/// Authority that moved after the observation was planned fails the whole
+/// publication. The desired tree describes one transition out of one observed
+/// prior tree; re-deriving it against a newer workspace would publish a
+/// transition nobody observed, and would silently revert whatever moved
+/// authority in the meantime.
 pub(crate) fn publish_workspace_tree(
     blobs: &kin_blobs::BlobStore,
     authority_context: &LocalRepositoryAuthorityContext,
-    desired_tree: &kin_model::ResolvedTree,
+    admitted: &AdmittedWorkspaceTree,
     operation_id: OperationId,
     actor: AuthorId,
 ) -> Result<Option<WorkspaceAdmissionResult>> {
+    let desired_tree = &admitted.desired_tree;
     let repository_id = authority_context.repository_id().clone();
     let workspace_id = authority_context.workspace_id();
     let authority = authority_context.open().map_err(DaemonError::Graph)?;
     let lease = authority.read_authority();
+    if lease.roots() != &admitted.expected_roots {
+        return Err(invalid(
+            "repository authority moved after the complete workspace observation was planned; \
+             exact admission does not replan a stale desired tree against newer authority",
+        ));
+    }
     let workspace = lease
         .metadata()
         .workspaces
@@ -383,6 +438,13 @@ pub(crate) fn publish_workspace_tree(
             "workspace {} belongs to {}, not {}",
             workspace.workspace_id, workspace.repository_id, repository_id
         )));
+    }
+    if workspace.tree != admitted.previous_tree {
+        return Err(invalid(
+            "the complete workspace observation was planned against a tree that is not this \
+             workspace's authority tree; exact admission does not replan a stale desired tree \
+             against newer authority",
+        ));
     }
     if workspace.tree == *desired_tree {
         return Ok(None);

--- a/crates/kin-daemon/src/state.rs
+++ b/crates/kin-daemon/src/state.rs
@@ -5486,13 +5486,21 @@ mod tests {
             TreeEntry::blob(hash, false),
         )])
         .unwrap();
-        crate::repository_commit::publish_workspace_tree(
-            &blobs,
-            &crate::local_repository_authority::LocalRepositoryAuthorityContext::from_layout_for_test(
+        let context =
+            crate::local_repository_authority::LocalRepositoryAuthorityContext::from_layout_for_test(
                 &init.layout,
             )
-            .unwrap(),
-            &desired,
+            .unwrap();
+        let admitted = crate::repository_commit::admitted_workspace_tree_for_test(
+            init.layout.working_dir(),
+            context.open().unwrap().read_authority().roots().clone(),
+            ResolvedTree::default(),
+            desired.clone(),
+        );
+        crate::repository_commit::publish_workspace_tree(
+            &blobs,
+            &context,
+            &admitted,
             kin_model::OperationId::new(),
             kin_model::AuthorId::new("lsp-authority-test"),
         )

--- a/crates/kin-daemon/src/state.rs
+++ b/crates/kin-daemon/src/state.rs
@@ -5404,13 +5404,21 @@ mod tests {
         #[cfg(not(unix))]
         let artifacts = blob_artifacts;
         let desired = ResolvedTree::from_artifacts(artifacts).unwrap();
-        crate::repository_commit::publish_workspace_tree(
-            &blobs,
-            &crate::local_repository_authority::LocalRepositoryAuthorityContext::from_layout_for_test(
+        let context =
+            crate::local_repository_authority::LocalRepositoryAuthorityContext::from_layout_for_test(
                 &init.layout,
             )
-            .unwrap(),
-            &desired,
+            .unwrap();
+        let admitted = crate::repository_commit::admitted_workspace_tree_for_test(
+            init.layout.working_dir(),
+            context.open().unwrap().read_authority().roots().clone(),
+            ResolvedTree::default(),
+            desired.clone(),
+        );
+        crate::repository_commit::publish_workspace_tree(
+            &blobs,
+            &context,
+            &admitted,
             kin_model::OperationId::new(),
             kin_model::AuthorId::new("authority-open-test"),
         )
@@ -6007,11 +6015,19 @@ mod tests {
             TreeEntry::blob(body_hash, false),
         );
         let desired = ResolvedTree::from_artifacts([artifact.clone()]).unwrap();
+        let context =
+            crate::local_repository_authority::LocalRepositoryAuthorityContext::from_state(&state)
+                .unwrap();
+        let admitted = crate::repository_commit::admitted_workspace_tree_for_test(
+            layout.working_dir(),
+            context.open().unwrap().read_authority().roots().clone(),
+            state.graph.resolved_tree(),
+            desired.clone(),
+        );
         let admission = crate::repository_commit::publish_workspace_tree(
             state.blobs.as_ref(),
-            &crate::local_repository_authority::LocalRepositoryAuthorityContext::from_state(&state)
-                .unwrap(),
-            &desired,
+            &context,
+            &admitted,
             kin_model::OperationId::new(),
             kin_model::AuthorId::new("dogfood"),
         )


### PR DESCRIPTION
Closes the four scanner defects that gated `commit` and `reconcile`, and flips both to `ready` in the capability inventory.

## The four defects

**1. The ambient scanner dropped its completion proof before publication.**
`kin_index::CompleteScanToken` existed but died at the `observed_tree_from_complete_scan` boundary; publication accepted a bare `ResolvedTree`. The token now travels inside `CompleteWorkspaceObservation` and then `AdmittedWorkspaceTree`, whose constructor requires it. Since the token's field is private to `kin-index`, no crate can mint one, so publication is unreachable without a walk that finished. The per-event publication seam (`apply_tree_delta` / `planned_tree_delta`, reachable when `admitted_paths` was `None`) is removed outright: `admitted_paths` is non-optional and exact tree truth crosses authority only through the complete-scan admission.

**2. A stale desired tree could be replanned against newer authority.**
`publish_workspace_tree` re-derived `exact_tree_correction(&workspace.tree, desired_tree)` against whatever authority held at publication time. If authority moved after the walk, that published a transition nobody observed and silently reverted the concurrent writer. The admission now binds the authority roots and the prior workspace tree it was planned against, and publication refuses on either mismatch.

**3. Partial publication around the mass-deletion guard.**
The guard suppressed removals and replanned, so additions, modifications, and derived admission-policy state from the same unconfirmed observation still published. It now refuses the whole observation: nothing crosses authority and graph truth is retained until the deletion is confirmed.

**4. The session observation DTO dropped the retained capability and was fabricable.**
`SessionReconcileObservation` had all-public fields and released the `RetainedSession` directory capability when the scanner returned. It now owns that capability, keeps every field private (so it cannot be built outside the scanner), and `plan_session_workspace_admission` takes the observation itself and re-proves the capability before planning against it.

## Evidence

Local gate on `429541cd` + this branch: `cargo fmt --check`, `cargo clippy --all-targets --all-features` under the ci.yml allowlist with `RUSTFLAGS=-D warnings`, `cargo build --all-targets`, `cargo test --workspace` — **3746 passed, 0 failed, 9 ignored**.

New tests:
- `loop_runner::tests::incomplete_host_walk_publishes_no_workspace_authority`
- `loop_runner::tests::unconfirmed_mass_deletion_publishes_no_part_of_the_observation`
- `repository_commit::tests::stale_desired_tree_is_refused_against_newer_authority`
- `repository_commit::tests::desired_tree_planned_against_a_foreign_prior_tree_is_refused`
- `kin_cli::commands::reconcile::tests::observation_retains_its_session_capability_after_the_scanner_returns`

End-to-end on a scratch repo with the branch binaries (`kin 0.3.6`, release build):
- `kin init` (empty, native unborn) then `kin commit` admitted 5 artifacts including a symlink and a binary; second commit linked the DAG parent correctly.
- One observation carrying 32 removals of 40 plus a modification was refused whole. Tree stayed at 40 artifacts, hash unchanged, and the modification did not publish. `KIN_ALLOW_MASS_DELETION=1` then crossed the whole transition at once.
- Session materialized via `/commands/session-workspace`, edited inside the session, `kin reconcile` admitted `+1 ~0` with artifact identity preserved on the modification, then `kin commit` closed the cycle.

`kin capabilities` now reports bounded-dogfood-required 11 of 12, with `checkout` the only one still open (FIR-1586's lane).

## Notes for review

- Test publication paths obtain a real completion proof by walking the working directory, since the token cannot be minted outside the scanner. There is deliberately no test-only back door.
- `admission_skips_untracked_special_but_rejects_tracked_type_loss` still fails closed; its assertion moved to the scanner's wording because the refusal now happens at the walk rather than at per-event admission.
- The mass-deletion guard is per-observation. A running watcher that drains removals across several sub-threshold batches will still admit them incrementally; that predates this change and is not addressed here.