### PR TITLE
Negotiate, transport, and wire native repository-v6 push and pull

### DIFF
--- a/crates/kin-cli/src/commands/mod.rs
+++ b/crates/kin-cli/src/commands/mod.rs
@@ -74,6 +74,7 @@ pub(crate) mod test_subprocess;
 pub mod trace;
 pub mod trace_data_flow;
 pub mod traffic;
+pub mod transfer;
 pub mod update;
 pub mod verify;
 pub mod work;

--- a/crates/kin-cli/src/commands/transfer.rs
+++ b/crates/kin-cli/src/commands/transfer.rs
@@ -1,0 +1,339 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Firelock, LLC
+
+//! `kin push`, `kin pull`, and `kin remote plan-push` over exact
+//! repository-v6 transfer.
+//!
+//! The negotiation itself runs in the daemon, not here. The daemon holds this
+//! replica's repository authority and every view derived from it, so a pull has
+//! to publish and refresh on one path. A CLI that admitted a pack on its own
+//! would leave the daemon serving a graph that no longer matches authority.
+//!
+//! This module resolves what the operator meant (which peer, which ref), hands
+//! that to the daemon, and renders the outcome. It never decides what either
+//! replica holds.
+
+use anyhow::{bail, Context, Result};
+use kin_core::{KinConfig, KinLayout, RemoteTransportKind};
+use kin_model::RefName;
+use kin_remote::repository_transfer_negotiation::{
+    RepositoryPushPlan, RepositoryTransferDirection, RepositoryTransferOutcome,
+    RepositoryTransferPlan,
+};
+use serde::{Deserialize, Serialize};
+
+/// One negotiated transfer, as asked for by the CLI.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct CommandTransferRequest {
+    /// Base URL of the peer's repository-v6 transfer seam.
+    pub remote_base_url: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub remote_token: Option<String>,
+    /// Defaults to the repository this daemon serves.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub repository_id: Option<String>,
+    /// Defaults to the local default ref.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub source_ref: Option<RefName>,
+    /// Defaults to `source_ref`.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub destination_ref: Option<RefName>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct CommandTransferResponse {
+    pub outcome: RepositoryTransferOutcome,
+}
+
+/// A negotiated plan that moved nothing.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct CommandTransferPlanResponse {
+    pub repository_id: String,
+    pub source_ref: RefName,
+    pub destination_ref: RefName,
+    pub remote_base_url: String,
+    pub plan: RepositoryPushPlan,
+}
+
+/// Where the peer's transfer seam lives, and how to authenticate to it.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct TransferPeer {
+    pub(crate) base_url: String,
+    pub(crate) token: Option<String>,
+}
+
+/// Resolve the peer from an explicit URL or a configured native-Kin remote.
+///
+/// This fails closed rather than guessing a host. A transfer publishes exact
+/// repository history; sending it to a default endpoint nobody named is not a
+/// convenience.
+pub(crate) fn resolve_peer(
+    layout: &KinLayout,
+    requested_remote: Option<&str>,
+    explicit_url: Option<&str>,
+) -> Result<TransferPeer> {
+    if let Some(url) = explicit_url.map(str::trim).filter(|url| !url.is_empty()) {
+        return Ok(TransferPeer {
+            base_url: url.trim_end_matches('/').to_string(),
+            token: transfer_bearer_token(),
+        });
+    }
+
+    let config = KinConfig::load_or_default(&layout.config_path())
+        .context("load repository remote configuration")?;
+    let native = config
+        .remote
+        .refs
+        .iter()
+        .filter(|remote| remote.transport == RemoteTransportKind::NativeKin)
+        .collect::<Vec<_>>();
+    let requested_remote = requested_remote.or(config.remote.default.as_deref());
+    let selected = match requested_remote {
+        Some(name) => native
+            .iter()
+            .find(|remote| remote.name == name)
+            .copied()
+            .with_context(|| {
+                format!("no native-kin remote named {name} is configured for this repository")
+            })?,
+        None => match native.as_slice() {
+            [] => bail!(
+                "no native-kin remote is configured. Add one with `kin remote add <name> --transport native-kin --url <base-url>`, or pass `--url`."
+            ),
+            [only] => only,
+            many => bail!(
+                "{} native-kin remotes are configured ({}); name one with `--remote`.",
+                many.len(),
+                many.iter()
+                    .map(|remote| remote.name.as_str())
+                    .collect::<Vec<_>>()
+                    .join(", ")
+            ),
+        },
+    };
+
+    let base_url = selected
+        .url
+        .as_deref()
+        .map(str::trim)
+        .filter(|url| !url.is_empty())
+        .with_context(|| {
+            format!(
+                "native-kin remote {} has no transport URL; re-add it with `--url <base-url>`",
+                selected.name
+            )
+        })?;
+    Ok(TransferPeer {
+        base_url: base_url.trim_end_matches('/').to_string(),
+        token: transfer_bearer_token(),
+    })
+}
+
+fn transfer_bearer_token() -> Option<String> {
+    std::env::var("KIN_REMOTE_TOKEN")
+        .ok()
+        .map(|token| token.trim().to_string())
+        .filter(|token| !token.is_empty())
+}
+
+fn parse_ref(value: Option<&str>) -> Result<Option<RefName>> {
+    let Some(value) = value.map(str::trim).filter(|value| !value.is_empty()) else {
+        return Ok(None);
+    };
+    let full = if value.starts_with("refs/") {
+        value.as_bytes().to_vec()
+    } else {
+        format!("refs/heads/{value}").into_bytes()
+    };
+    RefName::from_bytes(full)
+        .map(Some)
+        .map_err(|error| anyhow::anyhow!("invalid ref {value}: {error}"))
+}
+
+fn layout() -> Result<KinLayout> {
+    KinLayout::discover(&std::env::current_dir()?).ok_or_else(|| {
+        anyhow::anyhow!(
+            "not a Kin repository (no .kin/ found)\nhint: run `kin init .` to initialize one"
+        )
+    })
+}
+
+async fn daemon() -> Result<crate::daemon_client::DaemonClient> {
+    crate::daemon_client::DaemonClient::try_connect()
+        .await
+        .context(
+            "no Kin daemon is reachable. Repository authority and every view derived from it live in the daemon, so a transfer must run there.",
+        )
+}
+
+fn build_request(
+    peer: TransferPeer,
+    reference: Option<&str>,
+    destination: Option<&str>,
+) -> Result<CommandTransferRequest> {
+    let source_ref = parse_ref(reference)?;
+    let destination_ref = parse_ref(destination)?.or_else(|| source_ref.clone());
+    Ok(CommandTransferRequest {
+        remote_base_url: peer.base_url,
+        remote_token: peer.token,
+        repository_id: None,
+        source_ref,
+        destination_ref,
+    })
+}
+
+pub async fn push(
+    remote: Option<String>,
+    url: Option<String>,
+    reference: Option<String>,
+    json: bool,
+) -> Result<()> {
+    let layout = layout()?;
+    let peer = resolve_peer(&layout, remote.as_deref(), url.as_deref())?;
+    let request = build_request(peer, reference.as_deref(), None)?;
+    let response = daemon().await?.command_push(&request).await?;
+    render_outcome(&response.outcome, json)
+}
+
+pub async fn pull(
+    remote: Option<String>,
+    url: Option<String>,
+    reference: Option<String>,
+    json: bool,
+) -> Result<()> {
+    let layout = layout()?;
+    let peer = resolve_peer(&layout, remote.as_deref(), url.as_deref())?;
+    let request = build_request(peer, reference.as_deref(), None)?;
+    let response = daemon().await?.command_pull(&request).await?;
+    render_outcome(&response.outcome, json)
+}
+
+pub async fn plan_push(
+    remote: Option<String>,
+    url: Option<String>,
+    reference: Option<String>,
+    json: bool,
+) -> Result<()> {
+    let layout = layout()?;
+    let peer = resolve_peer(&layout, remote.as_deref(), url.as_deref())?;
+    let request = build_request(peer, reference.as_deref(), None)?;
+    let plan = daemon().await?.command_transfer_plan(&request).await?;
+    if json {
+        println!("{}", serde_json::to_string_pretty(&plan)?);
+        return Ok(());
+    }
+    println!("Exact repository-v6 push plan");
+    println!("Repository:  {}", plan.repository_id);
+    println!("Remote:      {}", plan.remote_base_url);
+    println!("Source ref:  {}", plan.source_ref);
+    println!("Destination: {}", plan.destination_ref);
+    println!("{}", render_plan(&plan.plan.plan));
+    if !plan.plan.fits_one_envelope {
+        println!(
+            "This gap does not fit one transfer envelope (limit {} changes). Transfer v1 has no continuation packs, so a push would be refused at pack build.",
+            plan.plan.max_changes_per_envelope
+        );
+    }
+    println!(
+        "Nothing was published. This plan describes the two leases as they were read, not a reservation of them."
+    );
+    Ok(())
+}
+
+fn render_plan(plan: &RepositoryTransferPlan) -> String {
+    match plan {
+        RepositoryTransferPlan::UpToDate { head } => match head {
+            Some(head) => format!("Up to date at {head}; nothing to transfer."),
+            None => "Up to date: neither replica publishes this ref yet.".to_string(),
+        },
+        RepositoryTransferPlan::FastForward {
+            source_head,
+            destination_head,
+            change_count,
+        } => {
+            let from = destination_head
+                .map(|head| head.to_string())
+                .unwrap_or_else(|| "an unborn ref".to_string());
+            let count = change_count
+                .map(|count| format!("{count} exact change(s)"))
+                .unwrap_or_else(|| "the exact closure".to_string());
+            format!("Fast-forward from {from} to {source_head}, moving {count}.")
+        }
+    }
+}
+
+fn render_outcome(outcome: &RepositoryTransferOutcome, json: bool) -> Result<()> {
+    if json {
+        println!("{}", serde_json::to_string_pretty(outcome)?);
+        return Ok(());
+    }
+    let verb = match outcome.direction {
+        RepositoryTransferDirection::Push => "Pushed",
+        RepositoryTransferDirection::Pull => "Pulled",
+    };
+    println!("{}", render_plan(&outcome.plan));
+    match &outcome.receipt {
+        None => println!("{verb} nothing: no repository transaction was published."),
+        Some(receipt) => {
+            println!(
+                "{verb} {} onto {} at {}.",
+                outcome.repository_id, outcome.destination_ref, receipt.destination_head
+            );
+            println!("Transfer:  {}", receipt.transfer_id);
+            println!("Outcome:   {:?}", receipt.outcome);
+            println!(
+                "Authority: generation {}",
+                receipt.authority_receipt.generation
+            );
+        }
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn a_bare_branch_name_resolves_to_its_full_ref() {
+        assert_eq!(
+            parse_ref(Some("main")).unwrap(),
+            Some(RefName::branch(b"main").unwrap())
+        );
+    }
+
+    #[test]
+    fn an_explicit_ref_path_is_carried_through_unchanged() {
+        assert_eq!(
+            parse_ref(Some("refs/tags/v1")).unwrap(),
+            Some(RefName::from_bytes(b"refs/tags/v1".to_vec()).unwrap())
+        );
+    }
+
+    #[test]
+    fn an_absent_or_blank_ref_stays_absent_so_the_daemon_picks_the_default() {
+        assert_eq!(parse_ref(None).unwrap(), None);
+        assert_eq!(parse_ref(Some("   ")).unwrap(), None);
+    }
+
+    #[test]
+    fn the_destination_ref_defaults_to_the_source_ref() {
+        let peer = TransferPeer {
+            base_url: "http://127.0.0.1:4010".to_string(),
+            token: None,
+        };
+        let request = build_request(peer, Some("main"), None).unwrap();
+        assert_eq!(request.source_ref, request.destination_ref);
+        assert_eq!(request.source_ref, Some(RefName::branch(b"main").unwrap()));
+    }
+
+    #[test]
+    fn an_explicit_url_wins_over_configuration_and_keeps_no_trailing_slash() {
+        // Resolution must not need a repository on disk when the operator named
+        // the peer outright.
+        let temporary = tempfile::TempDir::new().unwrap();
+        let layout = KinLayout::new(temporary.path().to_path_buf());
+        let peer = resolve_peer(&layout, None, Some("http://127.0.0.1:4010/")).unwrap();
+        assert_eq!(peer.base_url, "http://127.0.0.1:4010");
+    }
+}

--- a/crates/kin-cli/src/commands/transfer.rs
+++ b/crates/kin-cli/src/commands/transfer.rs
@@ -75,7 +75,7 @@ pub(crate) fn resolve_peer(
     if let Some(url) = explicit_url.map(str::trim).filter(|url| !url.is_empty()) {
         return Ok(TransferPeer {
             base_url: url.trim_end_matches('/').to_string(),
-            token: transfer_bearer_token(),
+            token: crate::commands::remote::native_remote_bearer_token(url),
         });
     }
 
@@ -123,17 +123,11 @@ pub(crate) fn resolve_peer(
                 selected.name
             )
         })?;
+    let base_url = base_url.trim_end_matches('/').to_string();
     Ok(TransferPeer {
-        base_url: base_url.trim_end_matches('/').to_string(),
-        token: transfer_bearer_token(),
+        token: crate::commands::remote::native_remote_bearer_token(&base_url),
+        base_url,
     })
-}
-
-fn transfer_bearer_token() -> Option<String> {
-    std::env::var("KIN_REMOTE_TOKEN")
-        .ok()
-        .map(|token| token.trim().to_string())
-        .filter(|token| !token.is_empty())
 }
 
 fn parse_ref(value: Option<&str>) -> Result<Option<RefName>> {

--- a/crates/kin-cli/src/daemon_client.rs
+++ b/crates/kin-cli/src/daemon_client.rs
@@ -854,6 +854,55 @@ impl DaemonClient {
             .context("parse daemon command status response")
     }
 
+    pub async fn command_push(
+        &self,
+        request: &crate::commands::transfer::CommandTransferRequest,
+    ) -> Result<crate::commands::transfer::CommandTransferResponse> {
+        self.transfer_command("push", request).await
+    }
+
+    pub async fn command_pull(
+        &self,
+        request: &crate::commands::transfer::CommandTransferRequest,
+    ) -> Result<crate::commands::transfer::CommandTransferResponse> {
+        self.transfer_command("pull", request).await
+    }
+
+    pub async fn command_transfer_plan(
+        &self,
+        request: &crate::commands::transfer::CommandTransferRequest,
+    ) -> Result<crate::commands::transfer::CommandTransferPlanResponse> {
+        self.transfer_command("transfer-plan", request).await
+    }
+
+    /// Drive one repository-v6 transfer command in the daemon.
+    ///
+    /// A refusal body is surfaced verbatim. The daemon has already mapped the
+    /// transfer error class onto a status code, and rewording it here would
+    /// hide which replica refused and why.
+    async fn transfer_command<Resp: serde::de::DeserializeOwned>(
+        &self,
+        leaf: &str,
+        request: &crate::commands::transfer::CommandTransferRequest,
+    ) -> Result<Resp> {
+        let resp = self
+            .send(
+                self.client
+                    .post(format!("{}/commands/{leaf}", self.base_url))
+                    .json(request),
+                "send daemon transfer command",
+            )
+            .await?;
+        if !resp.status().is_success() {
+            let status = resp.status().as_u16();
+            let body = resp.text().await.unwrap_or_default();
+            bail!("kin {leaf} refused (HTTP {status}): {body}");
+        }
+        resp.json()
+            .await
+            .context("parse daemon transfer command response")
+    }
+
     pub async fn command_resources(
         &self,
         request: &crate::commands::resources::CommandResourcesRequest,

--- a/crates/kin-cli/src/main.rs
+++ b/crates/kin-cli/src/main.rs
@@ -526,18 +526,36 @@ enum Command {
         #[arg(long)]
         dry_run: bool,
     },
-    /// [OPEN GATE] Plan or prepare an exact publish to the default remote
+    /// [OPEN GATE] Publish exact repository-v6 history to a native Kin remote
     Push {
-        /// Remote name (defaults to configured default or detected origin)
+        /// Remote name (defaults to the configured default native-kin remote)
         #[arg(long)]
         remote: Option<String>,
+        /// Peer transfer base URL, overriding any configured remote
+        #[arg(long)]
+        url: Option<String>,
+        /// Ref to publish (defaults to the repository default ref)
+        #[arg(long = "ref")]
+        reference: Option<String>,
+        /// Print the negotiated outcome as JSON
+        #[arg(long, default_value_t = false)]
+        json: bool,
     },
-    /// [OPEN GATE] Pull exact changes from a remote
+    /// [OPEN GATE] Admit exact repository-v6 history from a native Kin remote
     #[command(visible_alias = "fetch")]
     Pull {
-        /// Remote name (defaults to configured default)
+        /// Remote name (defaults to the configured default native-kin remote)
         #[arg(long)]
         remote: Option<String>,
+        /// Peer transfer base URL, overriding any configured remote
+        #[arg(long)]
+        url: Option<String>,
+        /// Ref to admit (defaults to the repository default ref)
+        #[arg(long = "ref")]
+        reference: Option<String>,
+        /// Print the negotiated outcome as JSON
+        #[arg(long, default_value_t = false)]
+        json: bool,
     },
     /// Clone a repository
     Clone {
@@ -1211,11 +1229,20 @@ enum RemoteAction {
         #[arg(long, default_value_t = false)]
         default: bool,
     },
-    /// [OPEN GATE] Show an exact closure and lease-protected push plan
+    /// Negotiate an exact closure and lease-protected push plan, moving nothing
     PlanPush {
-        /// Remote name (defaults to configured default or detected origin)
+        /// Remote name (defaults to the configured default native-kin remote)
         #[arg(long)]
         remote: Option<String>,
+        /// Peer transfer base URL, overriding any configured remote
+        #[arg(long)]
+        url: Option<String>,
+        /// Ref to plan for (defaults to the repository default ref)
+        #[arg(long = "ref")]
+        reference: Option<String>,
+        /// Print the negotiated plan as JSON
+        #[arg(long, default_value_t = false)]
+        json: bool,
     },
     /// Acquire a graph-aware session lease for a native Kin remote
     Lease {
@@ -2471,8 +2498,14 @@ fn main() -> Result<()> {
                         )
                         .await
                     }
-                    RemoteAction::PlanPush { .. } => {
-                        commands::capabilities::require_ready("remote plan-push")
+                    RemoteAction::PlanPush {
+                        remote,
+                        url,
+                        reference,
+                        json,
+                    } => {
+                        commands::capabilities::require_ready("remote plan-push")?;
+                        commands::transfer::plan_push(remote, url, reference, json).await
                     }
                     RemoteAction::Lease {
                         remote,
@@ -2492,8 +2525,24 @@ fn main() -> Result<()> {
                     let registry = std::env::var("KIN_REGISTRY_URL").unwrap_or(registry);
                     commands::publish::run(packages, registry, dry_run).await
                 }
-                Command::Push { remote: _ } => commands::capabilities::require_ready("push"),
-                Command::Pull { remote: _ } => commands::capabilities::require_ready("pull"),
+                Command::Push {
+                    remote,
+                    url,
+                    reference,
+                    json,
+                } => {
+                    commands::capabilities::require_ready("push")?;
+                    commands::transfer::push(remote, url, reference, json).await
+                }
+                Command::Pull {
+                    remote,
+                    url,
+                    reference,
+                    json,
+                } => {
+                    commands::capabilities::require_ready("pull")?;
+                    commands::transfer::pull(remote, url, reference, json).await
+                }
                 Command::Clone { url, path } => commands::clone::run(url, path).await,
                 Command::Checkout {
                     path,

--- a/crates/kin-cli/tests/command_capabilities.rs
+++ b/crates/kin-cli/tests/command_capabilities.rs
@@ -40,7 +40,7 @@ fn capability_json_keeps_the_bounded_dogfood_bar_explicit() {
     assert_eq!(report["bounded_dogfood_required_ready"], 12);
     assert_eq!(report["bounded_dogfood_required_total"], 12);
     assert_eq!(report["full_git_replacement_ready"], false);
-    assert_eq!(report["ready_commands"], 15);
+    assert_eq!(report["ready_commands"], 16);
     assert_eq!(report["command_total"], 32);
 
     let commands = report["commands"]

--- a/crates/kin-cli/tests/fixtures/git-replacement-capabilities-v1.json
+++ b/crates/kin-cli/tests/fixtures/git-replacement-capabilities-v1.json
@@ -273,6 +273,7 @@
         "DONE: admit the pack in one local authority transaction and refuse a receipt that does not bind it",
         "DONE: refuse a remote this replica already contains, naming the remote head",
         "OPEN: carry a closure larger than one negotiated envelope; transfer v1 has no continuation packs",
+        "OPEN: carry an exported pack past the 24 MiB transfer body bound; the daemon route and the client read declare the same limit, and a pack past it is refused as an oversized envelope rather than split",
         "OPEN: graph-derived workspace transition after admission, so a working tree follows the new head"
       ],
       "evidence_tests": [
@@ -280,7 +281,7 @@
         "crates/kin-remote/src/repository_transfer_http.rs",
         "crates/kin-daemon/src/api.rs"
       ],
-      "note": "Negotiation, export, and admission run end to end between two Kin daemons over HTTP with receipts verified. It stays closed because the envelope is bounded and because admission does not yet move the workspace to the admitted head."
+      "note": "Negotiation, export, and admission run end to end between two Kin daemons over HTTP with receipts verified. It stays closed because the envelope is bounded and because admission does not yet move the workspace to the admitted head. The envelope is bounded twice: by the negotiated change count, and by the 24 MiB one-body transfer bound. A pack carries base64 CAS bodies for the whole source tree, so on a real repository the byte bound binds first."
     },
     {
       "command": "merge",

--- a/crates/kin-cli/tests/fixtures/git-replacement-capabilities-v1.json
+++ b/crates/kin-cli/tests/fixtures/git-replacement-capabilities-v1.json
@@ -250,10 +250,17 @@
       "authority": "repository-v6 remote capability and exact transport",
       "required_for_bounded_dogfood": false,
       "acceptance_spec": [
-        "negotiate remote capabilities and transfer missing exact object/change/tree/ref closure with lease-protected publication"
+        "DONE: negotiate the remote destination lease, build the exact closure, publish it, and verify the returned receipt binds the pack that was sent",
+        "DONE: refuse a non-fast-forward gap with both heads named and no force path",
+        "OPEN: carry a closure larger than one negotiated envelope (512 changes, 4096 bodies, 16 MiB decoded); transfer v1 has no continuation packs, so a repository past that bound is refused at pack build",
+        "OPEN: drive the KinLab control-plane transfer envelope route, including its protection rules and durable receipts, rather than a peer daemon transfer seam directly"
       ],
-      "evidence_tests": [],
-      "note": "The previous path depended on the removed legacy Git exporter."
+      "evidence_tests": [
+        "crates/kin-remote/src/repository_transfer_negotiation.rs",
+        "crates/kin-remote/src/repository_transfer_http.rs",
+        "crates/kin-daemon/src/api.rs"
+      ],
+      "note": "The full path runs end to end between two Kin daemons over HTTP with receipts verified, but only within one bounded transfer envelope, and the transfer status this protocol publishes still reports push_apply_ready=false. Exposing it as general `kin push` would promise a capability that a repository past the envelope bound does not have."
     },
     {
       "command": "pull",
@@ -262,10 +269,18 @@
       "authority": "repository-v6 remote capability and exact transport",
       "required_for_bounded_dogfood": false,
       "acceptance_spec": [
-        "fetch and validate exact remote closure before one local authority transaction and graph-derived workspace transition"
+        "DONE: read the remote ref advertisement, adopt its default ref when this replica has none, and fetch the exact exported closure",
+        "DONE: admit the pack in one local authority transaction and refuse a receipt that does not bind it",
+        "DONE: refuse a remote this replica already contains, naming the remote head",
+        "OPEN: carry a closure larger than one negotiated envelope; transfer v1 has no continuation packs",
+        "OPEN: graph-derived workspace transition after admission, so a working tree follows the new head"
       ],
-      "evidence_tests": [],
-      "note": "The previous native sync path materialized file snapshots outside repository-v6 authority."
+      "evidence_tests": [
+        "crates/kin-remote/src/repository_transfer_negotiation.rs",
+        "crates/kin-remote/src/repository_transfer_http.rs",
+        "crates/kin-daemon/src/api.rs"
+      ],
+      "note": "Negotiation, export, and admission run end to end between two Kin daemons over HTTP with receipts verified. It stays closed because the envelope is bounded and because admission does not yet move the workspace to the admitted head."
     },
     {
       "command": "merge",
@@ -352,16 +367,21 @@
     },
     {
       "command": "remote plan-push",
-      "status": "open_gate",
-      "exposure": "fail_closed",
+      "status": "ready",
+      "exposure": "enabled",
       "authority": "repository-v6 workspace/ref state and negotiated remote capability",
       "required_for_bounded_dogfood": false,
       "acceptance_spec": [
         "derive the local publication head from one repository authority generation",
-        "plan exact closure transfer and lease-protected ref publication without legacy branch state"
+        "read the remote destination lease over the repository-v6 transfer seam and classify the gap without moving history",
+        "refuse a remote head this replica has not admitted, naming both heads, with no force path",
+        "report the negotiated envelope bound so an oversized gap is predictable before a push runs"
       ],
-      "evidence_tests": [],
-      "note": "The legacy planner is not an executable repository-v6 transfer proof."
+      "evidence_tests": [
+        "crates/kin-remote/src/repository_transfer_negotiation.rs",
+        "crates/kin-daemon/src/api.rs"
+      ],
+      "note": "Negotiates against a live peer transfer seam and publishes nothing. Reports whether the gap fits one transfer envelope, because transfer v1 has no continuation packs."
     },
     {
       "command": "exec",

--- a/crates/kin-daemon/Cargo.toml
+++ b/crates/kin-daemon/Cargo.toml
@@ -41,7 +41,7 @@ kin-cli = { workspace = true }
 kin-buildinfo = { workspace = true }
 kin-mcp = { workspace = true }
 kin-review = { workspace = true }
-kin-remote = { workspace = true }
+kin-remote = { workspace = true, features = ["http"] }
 axum = { workspace = true }
 tokio = { workspace = true }
 tracing = { workspace = true }

--- a/crates/kin-daemon/src/api.rs
+++ b/crates/kin-daemon/src/api.rs
@@ -880,6 +880,10 @@ fn api_routes() -> Router<Arc<DaemonState>> {
         .route("/repos/{repo_id}/refs", get(repo_refs))
         .route("/repos/{repo_id}/history", get(repo_history))
         .route(
+            "/repos/{repo_id}/transfer/advertise",
+            get(repo_transfer_advertise),
+        )
+        .route(
             "/repos/{repo_id}/transfer/status",
             post(repo_transfer_status),
         )
@@ -6423,6 +6427,23 @@ fn repository_transfer_error(
         RepositoryTransferError::Storage(_) => StatusCode::FAILED_DEPENDENCY,
     };
     (status, error.to_string())
+}
+
+/// GET /repos/{repo_id}/transfer/advertise — every published ref and the
+/// default ref a fresh replica adopts.
+///
+/// This is where a negotiation starts. A replica that has no ref of its own yet
+/// cannot ask the per-ref transfer status about anything, so discovery has to
+/// be answerable without naming a ref first.
+async fn repo_transfer_advertise(
+    Path(repo_id): Path<String>,
+    State(state): State<Arc<DaemonState>>,
+) -> Result<impl IntoResponse, (StatusCode, String)> {
+    let (repository_id, authority) = repository_transfer_authority(&state, &repo_id)?;
+    let advertisement =
+        kin_remote::repository_transfer::repository_ref_advertisement(&authority, &repository_id)
+            .map_err(repository_transfer_error)?;
+    Ok(Json(advertisement))
 }
 
 /// POST /repos/{repo_id}/transfer/status — exact destination lease and

--- a/crates/kin-daemon/src/api.rs
+++ b/crates/kin-daemon/src/api.rs
@@ -871,6 +871,9 @@ fn api_routes() -> Router<Arc<DaemonState>> {
         )
         .route("/reconcile", post(reconcile_session_workspace))
         .route("/commands/commit", post(command_commit))
+        .route("/commands/push", post(command_push))
+        .route("/commands/pull", post(command_pull))
+        .route("/commands/transfer-plan", post(command_transfer_plan))
         .route("/mcp/tools/call", post(mcp_tools_call))
         // Multi-repo endpoints — list and query lazily-loaded repo graphs
         .route("/repos", get(list_repos))
@@ -6534,6 +6537,290 @@ async fn repo_transfer_receive(
     Ok(Json(receipt))
 }
 
+/// Everything a negotiation needs, resolved from one authority lease.
+struct TransferCommandContext {
+    repo_id: String,
+    repository_id: RepositoryId,
+    authority: RepositoryAuthorityManager<dyn StorageBackend>,
+    /// Absent when neither the caller nor this replica names a ref, which is
+    /// the normal state of a replica that has admitted nothing yet.
+    source_ref: Option<kin_model::RefName>,
+    destination_ref: Option<kin_model::RefName>,
+    transport: kin_remote::repository_transfer_http::HttpRepositoryTransferTransport,
+}
+
+impl TransferCommandContext {
+    /// The refs a publication uses.
+    ///
+    /// A replica with no ref of its own has nothing to publish, so a push and a
+    /// plan both fail closed here rather than adopting a remote ref and
+    /// publishing an empty line onto it.
+    fn publication_refs(
+        &self,
+    ) -> Result<(kin_model::RefName, kin_model::RefName), (StatusCode, String)> {
+        let source = self.source_ref.clone().ok_or_else(|| {
+            (
+                StatusCode::UNPROCESSABLE_ENTITY,
+                format!(
+                    "repository {} publishes no default ref, so there is nothing to send; name a ref explicitly",
+                    self.repository_id
+                ),
+            )
+        })?;
+        let destination = self
+            .destination_ref
+            .clone()
+            .unwrap_or_else(|| source.clone());
+        Ok((source, destination))
+    }
+}
+
+/// Resolve the repository, refs, and peer for one transfer command.
+///
+/// An absent source ref means the repository's own default ref, which is the
+/// only ref a replica can name without the operator choosing one. An absent
+/// destination ref mirrors the source, because a transfer that silently landed
+/// on a different ref than it read would be indistinguishable from one that
+/// landed where it was asked to.
+fn transfer_command_context(
+    state: &DaemonState,
+    request: &kin_cli::commands::transfer::CommandTransferRequest,
+) -> Result<TransferCommandContext, (StatusCode, String)> {
+    let base_url = request.remote_base_url.trim();
+    if base_url.is_empty() {
+        return Err((
+            StatusCode::UNPROCESSABLE_ENTITY,
+            "transfer requires a remote base URL".to_string(),
+        ));
+    }
+    let repo_id = request
+        .repository_id
+        .clone()
+        .unwrap_or_else(|| state.cached_repo_id.clone());
+    let (repository_id, authority) = repository_transfer_authority(state, &repo_id)?;
+
+    let source_ref = request.source_ref.clone().or_else(|| {
+        authority
+            .read_authority()
+            .snapshot()
+            .repository_authority
+            .as_ref()
+            .and_then(|metadata| metadata.ref_state.default_ref.clone())
+    });
+    let destination_ref = request
+        .destination_ref
+        .clone()
+        .or_else(|| source_ref.clone());
+
+    let mut endpoint =
+        kin_remote::repository_transfer_http::RepositoryTransferEndpoint::new(base_url);
+    if let Some(token) = request
+        .remote_token
+        .as_deref()
+        .map(str::trim)
+        .filter(|token| !token.is_empty())
+    {
+        endpoint = endpoint.with_auth(token);
+    }
+
+    Ok(TransferCommandContext {
+        repo_id,
+        repository_id,
+        authority,
+        source_ref,
+        destination_ref,
+        transport: kin_remote::repository_transfer_http::HttpRepositoryTransferTransport::new(
+            endpoint,
+        ),
+    })
+}
+
+/// POST /commands/push — negotiate and publish this replica's exact history to
+/// a remote replica.
+async fn command_push(
+    State(state): State<Arc<DaemonState>>,
+    Json(request): Json<kin_cli::commands::transfer::CommandTransferRequest>,
+) -> Result<impl IntoResponse, (StatusCode, String)> {
+    let context = transfer_command_context(&state, &request)?;
+    let (source_ref, destination_ref) = context.publication_refs()?;
+    // Negotiation blocks on peer HTTP and on authority reads, so it must not run
+    // on the async executor that also serves this daemon's own transfer seam.
+    let outcome = tokio::task::spawn_blocking(move || {
+        kin_remote::repository_transfer_negotiation::push_to_remote(
+            &context.authority,
+            &context.transport,
+            &context.repository_id,
+            &source_ref,
+            &destination_ref,
+        )
+    })
+    .await
+    .map_err(internal_error)?
+    .map_err(repository_transfer_error)?;
+    Ok(Json(kin_cli::commands::transfer::CommandTransferResponse {
+        outcome,
+    }))
+}
+
+/// POST /commands/pull — negotiate, fetch, and admit a remote replica's exact
+/// history into this one.
+///
+/// The pack is applied here rather than inside the negotiation helper so that
+/// publication and the refresh of every daemon-derived view stay on the same
+/// path the inbound receive route already uses.
+async fn command_pull(
+    State(state): State<Arc<DaemonState>>,
+    Json(request): Json<kin_cli::commands::transfer::CommandTransferRequest>,
+) -> Result<impl IntoResponse, (StatusCode, String)> {
+    use kin_remote::repository_transfer_negotiation::{
+        verify_receipt_binds_pack, PullNegotiation, RepositoryTransferDirection,
+        RepositoryTransferOutcome, RepositoryTransferPlan,
+    };
+
+    let context = transfer_command_context(&state, &request)?;
+    let repo_id = context.repo_id.clone();
+    let repository_id = context.repository_id.clone();
+    let requested_source_ref = context.source_ref.clone();
+    let requested_destination_ref = context.destination_ref.clone();
+
+    let TransferCommandContext {
+        authority,
+        transport,
+        ..
+    } = context;
+    let (authority, resolved) = {
+        let repository_id = repository_id.clone();
+        tokio::task::spawn_blocking(move || {
+            // A replica that has admitted nothing cannot name a ref from its own
+            // state. The advertisement is what an unborn replica adopts, so
+            // resolving it here is the same step a clone takes.
+            let resolved = (|| {
+                let source_ref = match requested_source_ref {
+                    Some(name) => name,
+                    None => kin_remote::repository_transfer_negotiation::remote_default_ref(
+                        &transport,
+                        &repository_id,
+                    )?,
+                };
+                let destination_ref =
+                    requested_destination_ref.unwrap_or_else(|| source_ref.clone());
+                let negotiation = kin_remote::repository_transfer_negotiation::fetch_pull_pack(
+                    &authority,
+                    &transport,
+                    &repository_id,
+                    &source_ref,
+                    &destination_ref,
+                )?;
+                Ok((source_ref, destination_ref, negotiation))
+            })();
+            (authority, resolved)
+        })
+        .await
+        .map_err(internal_error)?
+    };
+    let (source_ref, destination_ref, negotiation) = resolved.map_err(repository_transfer_error)?;
+
+    let pack = match negotiation {
+        PullNegotiation::UpToDate { head } => {
+            return Ok(Json(kin_cli::commands::transfer::CommandTransferResponse {
+                outcome: RepositoryTransferOutcome {
+                    direction: RepositoryTransferDirection::Pull,
+                    repository_id,
+                    source_ref,
+                    destination_ref,
+                    plan: RepositoryTransferPlan::UpToDate { head },
+                    receipt: None,
+                },
+            }));
+        }
+        PullNegotiation::Pack(pack) => *pack,
+    };
+
+    let plan = RepositoryTransferPlan::FastForward {
+        source_head: pack.source_head,
+        destination_head: pack.expected_destination_head,
+        change_count: Some(pack.changes.len()),
+    };
+    let receipt = kin_remote::repository_transfer::apply_repository_transfer_pack(
+        &authority,
+        &repository_id,
+        &destination_ref,
+        kin_model::AuthorId::new("kin-daemon:repository-transfer-puller"),
+        &pack,
+    )
+    .map_err(repository_transfer_error)?;
+    verify_receipt_binds_pack(&pack, &receipt).map_err(repository_transfer_error)?;
+
+    // Repository authority is already durable. Refresh only derived daemon
+    // views after that receipt exists; a failure here cannot revoke or fake
+    // the committed transfer.
+    if state.storage_backend.is_some() {
+        state.repo_graphs.write().await.remove(&repo_id);
+    } else if receipt.outcome
+        == kin_remote::repository_transfer::RepositoryTransferApplyOutcome::Committed
+    {
+        state
+            .record_repository_authority_commit(receipt.authority_receipt.generation)
+            .map_err(repository_commit_error)?;
+        for change in &pack.changes {
+            state.graph.create_change(change).map_err(internal_error)?;
+        }
+        state.bump_version();
+        state.emit_event(DaemonEvent::GraphRootChanged {
+            old_root_hash: None,
+            new_root_hash: pack.source_head.to_string(),
+        });
+    }
+
+    Ok(Json(kin_cli::commands::transfer::CommandTransferResponse {
+        outcome: RepositoryTransferOutcome {
+            direction: RepositoryTransferDirection::Pull,
+            repository_id,
+            source_ref,
+            destination_ref,
+            plan,
+            receipt: Some(receipt),
+        },
+    }))
+}
+
+/// POST /commands/transfer-plan — negotiate a publication without moving any
+/// history on either replica.
+async fn command_transfer_plan(
+    State(state): State<Arc<DaemonState>>,
+    Json(request): Json<kin_cli::commands::transfer::CommandTransferRequest>,
+) -> Result<impl IntoResponse, (StatusCode, String)> {
+    let context = transfer_command_context(&state, &request)?;
+    let (source_ref, destination_ref) = context.publication_refs()?;
+    let repository_id = context.repository_id.clone();
+    let planned_source_ref = source_ref.clone();
+    let planned_destination_ref = destination_ref.clone();
+    let remote_base_url = context.transport.base_url().to_string();
+
+    let plan = tokio::task::spawn_blocking(move || {
+        kin_remote::repository_transfer_negotiation::plan_push_to_remote(
+            &context.authority,
+            &context.transport,
+            &context.repository_id,
+            &source_ref,
+            &destination_ref,
+        )
+    })
+    .await
+    .map_err(internal_error)?
+    .map_err(repository_transfer_error)?;
+
+    Ok(Json(
+        kin_cli::commands::transfer::CommandTransferPlanResponse {
+            repository_id: repository_id.to_string(),
+            source_ref: planned_source_ref,
+            destination_ref: planned_destination_ref,
+            remote_base_url,
+            plan,
+        },
+    ))
+}
+
 /// GET /repos — list all repos available in storage.
 ///
 /// In cloud mode this discovers repos from GCS (bucket listing), so it
@@ -9912,6 +10199,310 @@ mod tests {
             "pack": {},
         });
         assert!(serde_json::from_value::<RepositoryTransferReceiveRequest>(forged).is_err());
+    }
+
+    /// Serve one daemon on a real ephemeral socket and return its base URL.
+    ///
+    /// A transfer is a claim about two replicas agreeing over a wire. An
+    /// in-process router call would prove the negotiation and skip the only
+    /// part that is new here, so the peer in these tests is a real bound
+    /// listener serving the real router.
+    async fn serve_replica(state: Arc<DaemonState>) -> String {
+        let (listener, port) = bind_api_listener(&state, 0).expect("bind an ephemeral peer port");
+        let app = router(state);
+        tokio::spawn(async move {
+            let _ = axum::serve(listener, app).await;
+        });
+        format!("http://127.0.0.1:{port}")
+    }
+
+    /// A daemon backed by its own empty repository-v6 storage under `repo_id`.
+    fn replica_state(repo_id: &str) -> (Arc<DaemonState>, tempfile::TempDir, tempfile::TempDir) {
+        install_test_registry_override();
+        let working = tempfile::tempdir().unwrap();
+        let layout = kin_core::init(working.path()).unwrap().layout;
+        let storage = tempfile::tempdir().unwrap();
+        let state = Arc::new(
+            DaemonState::open_with_backend(
+                layout,
+                Box::new(kin_db::LocalFileBackend::new(storage.path().to_path_buf())),
+                repo_id,
+                None,
+            )
+            .unwrap(),
+        );
+        (state, working, storage)
+    }
+
+    /// Publish one exact native change onto `refs/heads/main` in `storage`.
+    fn seed_replica_change(
+        storage: &tempfile::TempDir,
+        repository_id: &RepositoryId,
+        previous: Option<kin_model::SemanticChangeId>,
+        operation: u128,
+        message: &str,
+    ) -> kin_model::SemanticChangeId {
+        use kin_model::{
+            compute_semantic_change_id, ChangeOrigin, DefaultRefExpectation, DefaultRefMutation,
+            RefExpectation, RefMutation, RefTarget, RefUpdatePolicy, RepositoryTransaction,
+            SemanticChange, REPOSITORY_TRANSACTION_SCHEMA_VERSION,
+        };
+
+        let manager = RepositoryAuthorityManager::open(
+            repository_id.clone(),
+            Arc::new(kin_db::LocalFileBackend::new(storage.path().to_path_buf())),
+        )
+        .unwrap();
+        let main = kin_model::RefName::branch(b"main").unwrap();
+        let mut change = SemanticChange {
+            id: kin_model::SemanticChangeId::from_hash(Hash256::from_bytes([0; 32])),
+            origin: ChangeOrigin::Native,
+            parents: previous.into_iter().collect(),
+            timestamp: kin_model::Timestamp::now(),
+            author: kin_model::AuthorId::new("transfer-e2e"),
+            message: message.to_string(),
+            entity_deltas: Vec::new(),
+            relation_deltas: Vec::new(),
+            tree_deltas: Vec::new(),
+            admission_policy_delta: None,
+            projected_files: Vec::new(),
+            spec_link: None,
+            evidence: Vec::new(),
+            risk_summary: None,
+        };
+        change.id = compute_semantic_change_id(&change).unwrap();
+
+        let lease = manager.read_authority();
+        let transaction = RepositoryTransaction {
+            schema_version: REPOSITORY_TRANSACTION_SCHEMA_VERSION,
+            operation_id: kin_model::OperationId::from_uuid(Uuid::from_u128(operation)),
+            repository_id: repository_id.clone(),
+            expected_generation: lease.roots().generation,
+            expected_roots: lease.roots().clone(),
+            actor: kin_model::AuthorId::new("transfer-e2e"),
+            reason: message.to_string(),
+            external_objects: Vec::new(),
+            git_authority_delta: None,
+            changes: vec![change.clone()],
+            aliases: Vec::new(),
+            ref_mutations: vec![RefMutation {
+                name: main.clone(),
+                expected: match previous {
+                    None => RefExpectation::MustNotExist,
+                    Some(head) => RefExpectation::MustEqual {
+                        target: RefTarget::change(head),
+                    },
+                },
+                new_target: Some(RefTarget::change(change.id)),
+                policy: RefUpdatePolicy::FastForwardOnly,
+            }],
+            default_ref_mutation: previous.is_none().then_some(DefaultRefMutation {
+                expected: DefaultRefExpectation::MustBeUnset,
+                new_default: Some(main),
+            }),
+            workspace_mutation: None,
+            local_overlay_delta: None,
+        };
+        drop(lease);
+        manager.commit_repository_transaction(transaction).unwrap();
+        change.id
+    }
+
+    async fn transfer_command(
+        state: Arc<DaemonState>,
+        leaf: &str,
+        request: &kin_cli::commands::transfer::CommandTransferRequest,
+    ) -> (StatusCode, Vec<u8>) {
+        let response = router(state)
+            .oneshot(
+                Request::post(format!("/commands/{leaf}"))
+                    .header("content-type", "application/json")
+                    .body(Body::from(serde_json::to_vec(request).unwrap()))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        let status = response.status();
+        let body = axum::body::to_bytes(response.into_body(), 32 * 1024 * 1024)
+            .await
+            .unwrap();
+        (status, body.to_vec())
+    }
+
+    #[tokio::test]
+    async fn native_push_and_pull_move_exact_history_between_two_daemons_over_http() {
+        use kin_remote::repository_transfer_negotiation::{
+            RepositoryTransferDirection, RepositoryTransferPlan,
+        };
+
+        let repo_id = format!("transfer-e2e-{}", Uuid::new_v4());
+        let repository_id = RepositoryId::new(repo_id.clone()).unwrap();
+
+        let (source_state, _source_working, source_storage) = replica_state(&repo_id);
+        let (destination_state, _destination_working, _destination_storage) =
+            replica_state(&repo_id);
+        let (third_state, _third_working, _third_storage) = replica_state(&repo_id);
+
+        let root = seed_replica_change(&source_storage, &repository_id, None, 1, "root the line");
+        let source_head = seed_replica_change(
+            &source_storage,
+            &repository_id,
+            Some(root),
+            2,
+            "advance the line",
+        );
+
+        let destination_url = serve_replica(Arc::clone(&destination_state)).await;
+        let request = kin_cli::commands::transfer::CommandTransferRequest {
+            remote_base_url: destination_url.clone(),
+            remote_token: None,
+            repository_id: Some(repo_id.clone()),
+            source_ref: None,
+            destination_ref: None,
+        };
+
+        // A plan reads both leases and moves nothing.
+        let (status, body) =
+            transfer_command(Arc::clone(&source_state), "transfer-plan", &request).await;
+        assert_eq!(status, StatusCode::OK, "{}", String::from_utf8_lossy(&body));
+        let planned: kin_cli::commands::transfer::CommandTransferPlanResponse =
+            serde_json::from_slice(&body).unwrap();
+        assert_eq!(
+            planned.plan.plan,
+            RepositoryTransferPlan::FastForward {
+                source_head,
+                destination_head: None,
+                change_count: None,
+            }
+        );
+        assert_eq!(planned.plan.max_changes_per_envelope, 512);
+        assert!(
+            !planned.plan.fits_one_envelope,
+            "an unborn destination has no counted closure, so the plan must not assert it fits"
+        );
+
+        // The push crosses a real socket and returns a receipt bound to it.
+        let (status, body) = transfer_command(Arc::clone(&source_state), "push", &request).await;
+        assert_eq!(status, StatusCode::OK, "{}", String::from_utf8_lossy(&body));
+        let pushed: kin_cli::commands::transfer::CommandTransferResponse =
+            serde_json::from_slice(&body).unwrap();
+        assert_eq!(pushed.outcome.direction, RepositoryTransferDirection::Push);
+        assert_eq!(
+            pushed.outcome.plan,
+            RepositoryTransferPlan::FastForward {
+                source_head,
+                destination_head: None,
+                change_count: Some(2),
+            }
+        );
+        let receipt = pushed
+            .outcome
+            .receipt
+            .expect("a moved head returns a receipt");
+        assert_eq!(receipt.destination_head, source_head);
+        assert_eq!(
+            receipt.outcome,
+            kin_remote::repository_transfer::RepositoryTransferApplyOutcome::Committed
+        );
+
+        // Re-running the same push finds the remote already there.
+        let (status, body) = transfer_command(Arc::clone(&source_state), "push", &request).await;
+        assert_eq!(status, StatusCode::OK, "{}", String::from_utf8_lossy(&body));
+        let repeated: kin_cli::commands::transfer::CommandTransferResponse =
+            serde_json::from_slice(&body).unwrap();
+        assert_eq!(
+            repeated.outcome.plan,
+            RepositoryTransferPlan::UpToDate {
+                head: Some(source_head),
+            }
+        );
+        assert!(repeated.outcome.receipt.is_none());
+
+        // A third replica pulls the same history back out of the one that was
+        // just published to, so the export seam is exercised on real bytes that
+        // arrived over the wire rather than on locally authored fixtures.
+        let (status, body) = transfer_command(Arc::clone(&third_state), "pull", &request).await;
+        assert_eq!(status, StatusCode::OK, "{}", String::from_utf8_lossy(&body));
+        let pulled: kin_cli::commands::transfer::CommandTransferResponse =
+            serde_json::from_slice(&body).unwrap();
+        assert_eq!(pulled.outcome.direction, RepositoryTransferDirection::Pull);
+        assert_eq!(
+            pulled.outcome.plan,
+            RepositoryTransferPlan::FastForward {
+                source_head,
+                destination_head: None,
+                change_count: Some(2),
+            }
+        );
+        assert_eq!(
+            pulled
+                .outcome
+                .receipt
+                .expect("a moved head returns a receipt")
+                .destination_head,
+            source_head
+        );
+    }
+
+    #[tokio::test]
+    async fn a_divergent_remote_refuses_the_push_over_http_and_moves_nothing() {
+        let repo_id = format!("transfer-e2e-diverged-{}", Uuid::new_v4());
+        let repository_id = RepositoryId::new(repo_id.clone()).unwrap();
+
+        let (source_state, _source_working, source_storage) = replica_state(&repo_id);
+        let (destination_state, _destination_working, destination_storage) =
+            replica_state(&repo_id);
+
+        let source_head =
+            seed_replica_change(&source_storage, &repository_id, None, 1, "the local line");
+        let remote_head = seed_replica_change(
+            &destination_storage,
+            &repository_id,
+            None,
+            9,
+            "an independent remote line",
+        );
+        assert_ne!(source_head, remote_head);
+
+        let destination_url = serve_replica(Arc::clone(&destination_state)).await;
+        let request = kin_cli::commands::transfer::CommandTransferRequest {
+            remote_base_url: destination_url,
+            remote_token: None,
+            repository_id: Some(repo_id.clone()),
+            source_ref: None,
+            destination_ref: None,
+        };
+
+        let (status, body) = transfer_command(Arc::clone(&source_state), "push", &request).await;
+        assert_eq!(
+            status,
+            StatusCode::CONFLICT,
+            "a non-fast-forward publication is a conflict, not a malformed request"
+        );
+        let message = String::from_utf8_lossy(&body);
+        assert!(
+            message.contains(&remote_head.to_string())
+                && message.contains(&source_head.to_string()),
+            "the refusal must name both heads: {message}"
+        );
+
+        // The remote is untouched: its advertisement still resolves to its own head.
+        let advertised = router(Arc::clone(&destination_state))
+            .oneshot(
+                Request::get(format!("/repos/{repo_id}/transfer/advertise"))
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(advertised.status(), StatusCode::OK);
+        let advertised = axum::body::to_bytes(advertised.into_body(), 64 * 1024)
+            .await
+            .unwrap();
+        let advertisement: kin_remote::repository_transfer::RepositoryRefAdvertisement =
+            serde_json::from_slice(&advertised).unwrap();
+        assert_eq!(advertisement.refs.len(), 1);
+        assert_eq!(advertisement.refs[0].head, remote_head);
     }
 
     #[tokio::test]

--- a/crates/kin-daemon/src/api.rs
+++ b/crates/kin-daemon/src/api.rs
@@ -26,6 +26,9 @@ use kin_model::{
     RepositoryId, SessionCapabilities, SessionId, SessionStore, SessionTransport, TransactionDelta,
     TreeEntry, WorkStore, WorkspaceId, WorkspaceTreeSnapshot,
 };
+// One declared bound governs both directions: what these routes accept is what
+// the transfer client reads.
+use kin_remote::repository_transfer_http::REPOSITORY_TRANSFER_HTTP_BODY_LIMIT;
 use serde::{Deserialize, Serialize};
 use serde_json::json;
 use sha2::{Digest, Sha256};
@@ -35,7 +38,6 @@ use uuid::Uuid;
 
 static BOOTSTRAP_EXPORTS: OnceLock<Arc<tokio::sync::Semaphore>> = OnceLock::new();
 static EXACT_SOURCE_ARCHIVE_EXPORTS: OnceLock<Arc<tokio::sync::Semaphore>> = OnceLock::new();
-const REPOSITORY_TRANSFER_HTTP_BODY_LIMIT: usize = 24 * 1024 * 1024;
 
 fn exact_source_archive_exports() -> Arc<tokio::sync::Semaphore> {
     Arc::clone(

--- a/crates/kin-remote/src/http_transport.rs
+++ b/crates/kin-remote/src/http_transport.rs
@@ -243,8 +243,8 @@ impl MutationPusher for HttpMutationPusher {
 // Helpers
 // ---------------------------------------------------------------------------
 
-/// Minimal percent-encoding for URL query parameters.
-fn urlencoded(s: &str) -> String {
+/// Minimal percent-encoding for URL query parameters and path segments.
+pub(crate) fn urlencoded(s: &str) -> String {
     let mut out = String::with_capacity(s.len());
     for b in s.bytes() {
         match b {

--- a/crates/kin-remote/src/lib.rs
+++ b/crates/kin-remote/src/lib.rs
@@ -10,6 +10,9 @@ pub mod http_transport;
 pub mod invalidation;
 pub mod mutation_push;
 pub mod repository_transfer;
+#[cfg(feature = "http")]
+pub mod repository_transfer_http;
+pub mod repository_transfer_negotiation;
 pub mod sync_types;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]

--- a/crates/kin-remote/src/repository_transfer_http.rs
+++ b/crates/kin-remote/src/repository_transfer_http.rs
@@ -27,12 +27,33 @@ use crate::repository_transfer::{
 };
 use crate::repository_transfer_negotiation::RepositoryTransferTransport;
 
+/// The most bytes one transfer body carries, in either direction.
+///
+/// The daemon's transfer routes accept this much, so the client reads this
+/// much. Leaving the read side on the HTTP client's implicit 10 MiB default
+/// would cap a pull well below the packs a peer is willing to export, and
+/// would report a body this replica declined to read as a remote failure.
+pub const REPOSITORY_TRANSFER_HTTP_BODY_LIMIT: usize = 24 * 1024 * 1024;
+
 /// Where a peer replica serves its transfer seam.
-#[derive(Debug, Clone)]
+#[derive(Clone)]
 pub struct RepositoryTransferEndpoint {
     pub base_url: String,
     pub auth_token: Option<String>,
     pub timeout_secs: u64,
+}
+
+/// Written by hand so a bearer token cannot reach a log through any derived
+/// `Debug` on this struct or on one that holds it.
+impl std::fmt::Debug for RepositoryTransferEndpoint {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        formatter
+            .debug_struct("RepositoryTransferEndpoint")
+            .field("base_url", &self.base_url)
+            .field("authenticated", &self.auth_token.is_some())
+            .field("timeout_secs", &self.timeout_secs)
+            .finish()
+    }
 }
 
 impl RepositoryTransferEndpoint {
@@ -122,14 +143,37 @@ fn read_json<R: serde::de::DeserializeOwned>(
     response: ureq::http::Response<ureq::Body>,
     what: &str,
 ) -> Result<R> {
-    let body = response.into_body().read_to_string().map_err(|error| {
-        RepositoryTransferError::Storage(format!("failed to read remote {what} response: {error}"))
-    })?;
+    let body = response
+        .into_body()
+        .into_with_config()
+        // The reader fails at the limit rather than past it, so a body of
+        // exactly the declared bound has to stay readable: the daemon accepts
+        // that body, and both sides must agree on which envelopes are legal.
+        .limit(REPOSITORY_TRANSFER_HTTP_BODY_LIMIT as u64 + 1)
+        .read_to_string()
+        .map_err(|error| body_error(error, what))?;
     serde_json::from_str(&body).map_err(|error| {
         RepositoryTransferError::Invalid(format!(
             "remote {what} response is not a valid repository-v6 envelope: {error}"
         ))
     })
+}
+
+/// Map a body this replica would not read onto the refusal it actually is.
+///
+/// A body past the declared bound is an oversized envelope, not a remote
+/// failure: the peer sent it correctly and the local client declined it.
+/// Reporting `Storage` there would tell an operator the remote broke.
+fn body_error(error: ureq::Error, what: &str) -> RepositoryTransferError {
+    match error {
+        ureq::Error::BodyExceedsLimit(_) => RepositoryTransferError::Invalid(format!(
+            "remote {what} response is larger than the \
+             {REPOSITORY_TRANSFER_HTTP_BODY_LIMIT} byte repository-v6 transfer body limit"
+        )),
+        other => RepositoryTransferError::Storage(format!(
+            "failed to read remote {what} response: {other}"
+        )),
+    }
 }
 
 /// Map a peer failure onto the transfer error it actually represents.
@@ -152,6 +196,13 @@ fn peer_error(error: ureq::Error, what: &str) -> RepositoryTransferError {
             )),
             404 => RepositoryTransferError::Invalid(format!(
                 "remote does not serve {what} for this repository (HTTP 404)"
+            )),
+            // The peer is intact and answered; the envelope is too large for
+            // the bound both sides declare. That is the same refusal the
+            // client raises on an oversized body it reads, not a peer failure.
+            413 => RepositoryTransferError::Invalid(format!(
+                "remote refused {what} as larger than the \
+                 {REPOSITORY_TRANSFER_HTTP_BODY_LIMIT} byte repository-v6 transfer body limit (HTTP 413)"
             )),
             other => {
                 RepositoryTransferError::Storage(format!("remote {what} failed with HTTP {other}"))
@@ -221,6 +272,17 @@ mod tests {
         HttpRepositoryTransferTransport::new(RepositoryTransferEndpoint::new(base_url))
     }
 
+    fn json_response(payload: String) -> ureq::http::Response<ureq::Body> {
+        ureq::http::Response::builder()
+            .status(200)
+            .body(
+                ureq::Body::builder()
+                    .mime_type("application/json")
+                    .data(payload),
+            )
+            .unwrap()
+    }
+
     #[test]
     fn endpoint_urls_percent_encode_the_repository_identity() {
         // A repository id accepts any non-control text, so an id carrying a
@@ -258,9 +320,64 @@ mod tests {
             RepositoryTransferError::Storage(_)
         ));
         assert!(matches!(
+            peer_error(ureq::Error::StatusCode(413), "transfer receive"),
+            RepositoryTransferError::Invalid(_)
+        ));
+        assert!(matches!(
             peer_error(ureq::Error::StatusCode(500), "transfer receive"),
             RepositoryTransferError::Storage(_)
         ));
+    }
+
+    #[test]
+    fn a_pack_larger_than_the_client_default_is_still_read() {
+        // The HTTP client caps a body at 10 MiB unless told otherwise, well
+        // under the bound the daemon's transfer routes accept. A pack carries
+        // base64 CAS bodies for the whole source tree, so any repository past
+        // a toy hits that default long before it hits the change bound.
+        let payload = serde_json::json!({ "value": "a".repeat(11 * 1024 * 1024) }).to_string();
+        assert!(payload.len() > 10 * 1024 * 1024);
+
+        let value: serde_json::Value =
+            read_json(json_response(payload), "transfer export").expect("a body under the bound");
+        assert_eq!(value["value"].as_str().unwrap().len(), 11 * 1024 * 1024);
+    }
+
+    #[test]
+    fn a_body_past_the_declared_bound_is_an_oversized_envelope_not_a_remote_failure() {
+        // The peer sent this body correctly; the local client refused to read
+        // it. Calling that Storage would tell an operator the remote broke.
+        let error = body_error(ureq::Error::BodyExceedsLimit(64), "transfer export");
+        let RepositoryTransferError::Invalid(message) = error else {
+            panic!("a local read bound is not a remote storage failure");
+        };
+        assert!(
+            message.contains("transfer body limit"),
+            "the refusal must name the bound that was exceeded: {message}"
+        );
+        assert!(matches!(
+            body_error(ureq::Error::HostNotFound, "transfer export"),
+            RepositoryTransferError::Storage(_)
+        ));
+    }
+
+    #[test]
+    fn debug_output_never_carries_the_bearer_token() {
+        let endpoint =
+            RepositoryTransferEndpoint::new("http://127.0.0.1:4010").with_auth("test-bearer-token");
+
+        let rendered = format!("{endpoint:?}");
+        assert!(
+            !rendered.contains("test-bearer-token"),
+            "an endpoint must never print its token: {rendered}"
+        );
+        assert!(rendered.contains("authenticated: true"));
+
+        let rendered = format!("{:?}", HttpRepositoryTransferTransport::new(endpoint));
+        assert!(
+            !rendered.contains("test-bearer-token"),
+            "a transport must never print its token: {rendered}"
+        );
     }
 
     #[test]

--- a/crates/kin-remote/src/repository_transfer_http.rs
+++ b/crates/kin-remote/src/repository_transfer_http.rs
@@ -153,9 +153,9 @@ fn peer_error(error: ureq::Error, what: &str) -> RepositoryTransferError {
             404 => RepositoryTransferError::Invalid(format!(
                 "remote does not serve {what} for this repository (HTTP 404)"
             )),
-            other => RepositoryTransferError::Storage(format!(
-                "remote {what} failed with HTTP {other}"
-            )),
+            other => {
+                RepositoryTransferError::Storage(format!("remote {what} failed with HTTP {other}"))
+            }
         },
         other => {
             RepositoryTransferError::Storage(format!("remote {what} transport failed: {other}"))
@@ -165,10 +165,7 @@ fn peer_error(error: ureq::Error, what: &str) -> RepositoryTransferError {
 
 impl RepositoryTransferTransport for HttpRepositoryTransferTransport {
     fn advertise_refs(&self, repository_id: &RepositoryId) -> Result<RepositoryRefAdvertisement> {
-        self.get_json(
-            &self.url(repository_id, "advertise"),
-            "ref advertisement",
-        )
+        self.get_json(&self.url(repository_id, "advertise"), "ref advertisement")
     }
 
     fn transfer_status(

--- a/crates/kin-remote/src/repository_transfer_http.rs
+++ b/crates/kin-remote/src/repository_transfer_http.rs
@@ -1,0 +1,277 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Firelock, LLC
+
+//! HTTP transport for exact repository-v6 transfer between two replicas.
+//!
+//! The peer is any host that serves the daemon's repository-v6 transfer seam:
+//!
+//! - `GET  {base_url}/repos/{repository_id}/transfer/advertise`
+//! - `POST {base_url}/repos/{repository_id}/transfer/status`
+//! - `POST {base_url}/repos/{repository_id}/transfer/export`
+//! - `POST {base_url}/repos/{repository_id}/transfer/receive`
+//!
+//! This layer is transport only. It carries exact envelopes, maps peer refusals
+//! back to the transfer error they were raised as, and decides nothing about
+//! what either replica holds. A peer that returns a body this crate cannot
+//! parse is a protocol failure, never a silently empty result.
+
+use std::time::Duration;
+
+use kin_model::{RefName, RepositoryId};
+use ureq::Agent;
+
+use crate::http_transport::urlencoded;
+use crate::repository_transfer::{
+    RepositoryRefAdvertisement, RepositoryTransferError, RepositoryTransferExpectation,
+    RepositoryTransferPack, RepositoryTransferReceipt, RepositoryTransferStatus, Result,
+};
+use crate::repository_transfer_negotiation::RepositoryTransferTransport;
+
+/// Where a peer replica serves its transfer seam.
+#[derive(Debug, Clone)]
+pub struct RepositoryTransferEndpoint {
+    pub base_url: String,
+    pub auth_token: Option<String>,
+    pub timeout_secs: u64,
+}
+
+impl RepositoryTransferEndpoint {
+    pub fn new(base_url: impl Into<String>) -> Self {
+        Self {
+            base_url: base_url.into().trim_end_matches('/').to_string(),
+            auth_token: None,
+            timeout_secs: 120,
+        }
+    }
+
+    pub fn with_auth(mut self, token: impl Into<String>) -> Self {
+        self.auth_token = Some(token.into());
+        self
+    }
+
+    pub fn with_timeout(mut self, secs: u64) -> Self {
+        self.timeout_secs = secs;
+        self
+    }
+}
+
+/// A transfer peer reached over HTTP.
+pub struct HttpRepositoryTransferTransport {
+    endpoint: RepositoryTransferEndpoint,
+    agent: Agent,
+}
+
+impl std::fmt::Debug for HttpRepositoryTransferTransport {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        formatter
+            .debug_struct("HttpRepositoryTransferTransport")
+            .field("base_url", &self.endpoint.base_url)
+            .field("authenticated", &self.endpoint.auth_token.is_some())
+            .finish()
+    }
+}
+
+impl HttpRepositoryTransferTransport {
+    pub fn new(endpoint: RepositoryTransferEndpoint) -> Self {
+        let agent: Agent = Agent::config_builder()
+            .timeout_global(Some(Duration::from_secs(endpoint.timeout_secs)))
+            .build()
+            .into();
+        Self { endpoint, agent }
+    }
+
+    pub fn base_url(&self) -> &str {
+        &self.endpoint.base_url
+    }
+
+    fn url(&self, repository_id: &RepositoryId, leaf: &str) -> String {
+        format!(
+            "{}/repos/{}/transfer/{leaf}",
+            self.endpoint.base_url,
+            urlencoded(repository_id.as_str())
+        )
+    }
+
+    fn get_json<R: serde::de::DeserializeOwned>(&self, url: &str, what: &str) -> Result<R> {
+        let mut request = self.agent.get(url);
+        if let Some(token) = &self.endpoint.auth_token {
+            request = request.header("Authorization", &format!("Bearer {token}"));
+        }
+        let response = request.call().map_err(|error| peer_error(error, what))?;
+        read_json(response, what)
+    }
+
+    fn post_json<T: serde::Serialize, R: serde::de::DeserializeOwned>(
+        &self,
+        url: &str,
+        body: &T,
+        what: &str,
+    ) -> Result<R> {
+        let mut request = self.agent.post(url);
+        if let Some(token) = &self.endpoint.auth_token {
+            request = request.header("Authorization", &format!("Bearer {token}"));
+        }
+        let response = request
+            .send_json(body)
+            .map_err(|error| peer_error(error, what))?;
+        read_json(response, what)
+    }
+}
+
+fn read_json<R: serde::de::DeserializeOwned>(
+    response: ureq::http::Response<ureq::Body>,
+    what: &str,
+) -> Result<R> {
+    let body = response.into_body().read_to_string().map_err(|error| {
+        RepositoryTransferError::Storage(format!("failed to read remote {what} response: {error}"))
+    })?;
+    serde_json::from_str(&body).map_err(|error| {
+        RepositoryTransferError::Invalid(format!(
+            "remote {what} response is not a valid repository-v6 envelope: {error}"
+        ))
+    })
+}
+
+/// Map a peer failure onto the transfer error it actually represents.
+///
+/// The receiving daemon already encodes its refusal class in the status code:
+/// 422 for an invalid envelope, 409 for a lease or fast-forward conflict, 424
+/// for storage. Preserving that mapping is what lets a caller distinguish "this
+/// pack is malformed" from "the remote moved under us" without parsing prose.
+fn peer_error(error: ureq::Error, what: &str) -> RepositoryTransferError {
+    match error {
+        ureq::Error::StatusCode(code) => match code {
+            409 => RepositoryTransferError::Conflict(format!(
+                "remote refused {what} with a repository-v6 conflict (HTTP 409)"
+            )),
+            422 => RepositoryTransferError::Invalid(format!(
+                "remote rejected {what} as an invalid repository-v6 envelope (HTTP 422)"
+            )),
+            424 => RepositoryTransferError::Storage(format!(
+                "remote {what} failed on storage (HTTP 424)"
+            )),
+            404 => RepositoryTransferError::Invalid(format!(
+                "remote does not serve {what} for this repository (HTTP 404)"
+            )),
+            other => RepositoryTransferError::Storage(format!(
+                "remote {what} failed with HTTP {other}"
+            )),
+        },
+        other => {
+            RepositoryTransferError::Storage(format!("remote {what} transport failed: {other}"))
+        }
+    }
+}
+
+impl RepositoryTransferTransport for HttpRepositoryTransferTransport {
+    fn advertise_refs(&self, repository_id: &RepositoryId) -> Result<RepositoryRefAdvertisement> {
+        self.get_json(
+            &self.url(repository_id, "advertise"),
+            "ref advertisement",
+        )
+    }
+
+    fn transfer_status(
+        &self,
+        repository_id: &RepositoryId,
+        destination_ref: &RefName,
+    ) -> Result<RepositoryTransferStatus> {
+        self.post_json(
+            &self.url(repository_id, "status"),
+            &serde_json::json!({ "destination_ref": destination_ref }),
+            "transfer status",
+        )
+    }
+
+    fn export_pack(
+        &self,
+        repository_id: &RepositoryId,
+        source_ref: &RefName,
+        expectation: &RepositoryTransferExpectation,
+    ) -> Result<RepositoryTransferPack> {
+        self.post_json(
+            &self.url(repository_id, "export"),
+            &serde_json::json!({
+                "source_ref": source_ref,
+                "expectation": expectation,
+            }),
+            "transfer export",
+        )
+    }
+
+    fn receive_pack(
+        &self,
+        repository_id: &RepositoryId,
+        destination_ref: &RefName,
+        pack: &RepositoryTransferPack,
+    ) -> Result<RepositoryTransferReceipt> {
+        self.post_json(
+            &self.url(repository_id, "receive"),
+            &serde_json::json!({
+                "destination_ref": destination_ref,
+                "pack": pack,
+            }),
+            "transfer receive",
+        )
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn transport(base_url: &str) -> HttpRepositoryTransferTransport {
+        HttpRepositoryTransferTransport::new(RepositoryTransferEndpoint::new(base_url))
+    }
+
+    #[test]
+    fn endpoint_urls_percent_encode_the_repository_identity() {
+        // A repository id accepts any non-control text, so an id carrying a
+        // slash must not silently address a different route.
+        let transport = transport("http://127.0.0.1:4010/");
+        let repository_id = RepositoryId::new("org/repo name").unwrap();
+        assert_eq!(
+            transport.url(&repository_id, "receive"),
+            "http://127.0.0.1:4010/repos/org%2Frepo%20name/transfer/receive"
+        );
+    }
+
+    #[test]
+    fn trailing_base_url_slashes_do_not_double_up() {
+        let transport = transport("http://127.0.0.1:4010///");
+        let repository_id = RepositoryId::new("kin").unwrap();
+        assert_eq!(
+            transport.url(&repository_id, "status"),
+            "http://127.0.0.1:4010/repos/kin/transfer/status"
+        );
+    }
+
+    #[test]
+    fn peer_status_codes_keep_their_refusal_class() {
+        assert!(matches!(
+            peer_error(ureq::Error::StatusCode(409), "transfer receive"),
+            RepositoryTransferError::Conflict(_)
+        ));
+        assert!(matches!(
+            peer_error(ureq::Error::StatusCode(422), "transfer receive"),
+            RepositoryTransferError::Invalid(_)
+        ));
+        assert!(matches!(
+            peer_error(ureq::Error::StatusCode(424), "transfer receive"),
+            RepositoryTransferError::Storage(_)
+        ));
+        assert!(matches!(
+            peer_error(ureq::Error::StatusCode(500), "transfer receive"),
+            RepositoryTransferError::Storage(_)
+        ));
+    }
+
+    #[test]
+    fn a_connectivity_failure_is_never_reported_as_a_clean_refusal() {
+        // A peer that cannot be reached has not refused anything. Reporting
+        // this as Invalid or Conflict would let a caller conclude the remote
+        // evaluated the transfer and said no.
+        let error = peer_error(ureq::Error::HostNotFound, "ref advertisement");
+        assert!(matches!(error, RepositoryTransferError::Storage(_)));
+    }
+}

--- a/crates/kin-remote/src/repository_transfer_negotiation.rs
+++ b/crates/kin-remote/src/repository_transfer_negotiation.rs
@@ -168,43 +168,20 @@ pub fn classify_local_ancestry(
         return Ok(LocalAncestry::Same);
     }
 
-    // Count every change reachable from the local head but not from the
-    // advertised head. That count is the exact fast-forward distance, which is
-    // what a caller reports and what the pack will carry.
-    let mut behind = HashSet::new();
-    let mut stack = vec![advertised];
-    let mut advertised_seen = false;
-    while let Some(id) = stack.pop() {
-        if !behind.insert(id) {
-            continue;
-        }
-        let Some(change) = changes.get(&id) else {
-            // The advertised head itself is simply absent from local history.
-            // Any other missing parent is a broken local closure, not a peer
-            // disagreement, and must not be reported as "unreachable".
-            if id == advertised {
-                return Ok(LocalAncestry::Unreachable);
-            }
-            return Err(invalid(format!(
-                "exact local history is missing change {id} while classifying {advertised}"
-            )));
-        };
-        advertised_seen = true;
-        stack.extend(change.parents.iter().copied());
-    }
-    if !advertised_seen {
-        return Ok(LocalAncestry::Unreachable);
-    }
-
+    // Walk back from the local head and stop at the advertised change, which is
+    // exactly how the fast-forward closure is collected when the pack is built.
+    // Counting "reachable from the local head but not from the advertised head"
+    // instead would under-count a merge: a shared ancestor reachable from the
+    // local head by a path that never passes through the advertised change is
+    // carried by the pack, and a plan that omitted it would report a smaller
+    // transfer than the one that actually runs.
     let mut distance = 0usize;
     let mut visited = HashSet::new();
     let mut stack = vec![local_head];
     let mut reached_advertised = false;
     while let Some(id) = stack.pop() {
-        if behind.contains(&id) {
-            if id == advertised {
-                reached_advertised = true;
-            }
+        if id == advertised {
+            reached_advertised = true;
             continue;
         }
         if !visited.insert(id) {
@@ -219,8 +196,10 @@ pub fn classify_local_ancestry(
         stack.extend(change.parents.iter().copied());
     }
     if !reached_advertised {
-        // Local history contains the advertised change but not on any path from
-        // the local head: the two lines share ancestry and then part.
+        // The advertised change is on no path back from the local head, whether
+        // because this replica has never admitted it or because the two lines
+        // share ancestry and then part. Local history cannot tell those apart,
+        // and neither is a fast-forward.
         return Ok(LocalAncestry::Unreachable);
     }
     Ok(LocalAncestry::Ancestor { distance })
@@ -725,8 +704,39 @@ mod tests {
         operation: u128,
         message: &str,
     ) -> SemanticChangeId {
-        let change = native_change(previous.into_iter().collect(), message, Vec::new());
+        publish_with_parents(
+            manager,
+            repository_id,
+            ref_name,
+            previous.into_iter().collect(),
+            previous,
+            operation,
+            message,
+        )
+    }
+
+    /// Publish a change with arbitrary parents onto `ref_name`.
+    ///
+    /// `previous` is the ref's current target, which is what the publication
+    /// expects, and is independent of the change's parents once merges exist.
+    fn publish_with_parents(
+        manager: &TestManager,
+        repository_id: &RepositoryId,
+        ref_name: &RefName,
+        parents: Vec<SemanticChangeId>,
+        previous: Option<SemanticChangeId>,
+        operation: u128,
+        message: &str,
+    ) -> SemanticChangeId {
+        let change = native_change(parents, message, Vec::new());
         let lease = manager.read_authority();
+        // A repository adopts its default ref once. A second ref published
+        // later must not try to claim it again.
+        let adopts_default_ref = lease
+            .snapshot()
+            .repository_authority
+            .as_ref()
+            .is_some_and(|metadata| metadata.ref_state.default_ref.is_none());
         let transaction = RepositoryTransaction {
             schema_version: REPOSITORY_TRANSACTION_SCHEMA_VERSION,
             operation_id: OperationId::from_uuid(Uuid::from_u128(operation)),
@@ -750,7 +760,7 @@ mod tests {
                 new_target: Some(RefTarget::change(change.id)),
                 policy: RefUpdatePolicy::FastForwardOnly,
             }],
-            default_ref_mutation: previous.is_none().then_some(DefaultRefMutation {
+            default_ref_mutation: adopts_default_ref.then_some(DefaultRefMutation {
                 expected: DefaultRefExpectation::MustBeUnset,
                 new_default: Some(ref_name.clone()),
             }),
@@ -961,6 +971,134 @@ mod tests {
             1,
             "an up-to-date negotiation must not build or ship a pack at all"
         );
+    }
+
+    #[test]
+    fn the_planned_distance_is_exactly_what_the_pack_carries() {
+        // The plan counts the gap by walking local history; the pack counts it
+        // by building the fast-forward closure. Those are two separate walks,
+        // and a caller acts on the first while the second is what actually
+        // moves. If they can disagree, every reported change count is a guess.
+        let fixture = fixture();
+        let peer = LocalPeer::new(&fixture.destination);
+        push_to_remote(
+            &fixture.source,
+            &peer,
+            &fixture.repository_id,
+            &fixture.main,
+            &fixture.main,
+        )
+        .unwrap();
+
+        let advanced = publish(
+            &fixture.source,
+            &fixture.repository_id,
+            &fixture.main,
+            Some(fixture.source_head),
+            3,
+            "advance past the published head",
+        );
+
+        let planned = plan_push_to_remote(
+            &fixture.source,
+            &peer,
+            &fixture.repository_id,
+            &fixture.main,
+            &fixture.main,
+        )
+        .unwrap();
+        assert_eq!(
+            planned.plan,
+            RepositoryTransferPlan::FastForward {
+                source_head: advanced,
+                destination_head: Some(fixture.source_head),
+                change_count: Some(1),
+            }
+        );
+        assert_eq!(planned.max_changes_per_envelope, 512);
+        assert!(planned.fits_one_envelope);
+
+        let outcome = push_to_remote(
+            &fixture.source,
+            &peer,
+            &fixture.repository_id,
+            &fixture.main,
+            &fixture.main,
+        )
+        .unwrap();
+        assert_eq!(
+            outcome.plan, planned.plan,
+            "the executed push must move exactly what the plan reported"
+        );
+        assert_eq!(head_of(&fixture.destination, &fixture.main), Some(advanced));
+    }
+
+    #[test]
+    fn a_merge_plan_counts_every_change_the_pack_carries() {
+        // A shared ancestor can be reachable from the source head by a path that
+        // never passes through the destination head. The pack carries it, so a
+        // plan that counted "reachable from the source but not from the
+        // destination" would under-report the transfer. Both walks must agree.
+        let repository_id = RepositoryId::new(format!("merge-{}", Uuid::new_v4())).unwrap();
+        let source_dir = TempDir::new().unwrap();
+        let destination_dir = TempDir::new().unwrap();
+        let source = manager(&source_dir, &repository_id);
+        let destination = manager(&destination_dir, &repository_id);
+        let main = RefName::branch(b"main").unwrap();
+        let side = RefName::branch(b"side").unwrap();
+
+        let root = publish(&source, &repository_id, &main, None, 1, "root");
+        let published = publish(&source, &repository_id, &main, Some(root), 2, "mainline");
+        // The side line forks from the root, so the root is reachable from the
+        // merge without passing through the published mainline head.
+        let sibling = publish_with_parents(
+            &source,
+            &repository_id,
+            &side,
+            vec![root],
+            None,
+            3,
+            "side line",
+        );
+
+        // Bring the destination to the mainline head, then merge the side line.
+        let peer = LocalPeer::new(&destination);
+        push_to_remote(&source, &peer, &repository_id, &main, &main).unwrap();
+        assert_eq!(head_of(&destination, &main), Some(published));
+
+        let merged = publish_with_parents(
+            &source,
+            &repository_id,
+            &main,
+            vec![published, sibling],
+            Some(published),
+            4,
+            "merge the side line",
+        );
+
+        let planned = plan_push_to_remote(&source, &peer, &repository_id, &main, &main).unwrap();
+        let RepositoryTransferPlan::FastForward { change_count, .. } = planned.plan else {
+            panic!("a merge past the published head is a fast-forward");
+        };
+
+        let outcome = push_to_remote(&source, &peer, &repository_id, &main, &main).unwrap();
+        let RepositoryTransferPlan::FastForward {
+            change_count: packed,
+            ..
+        } = outcome.plan
+        else {
+            panic!("the executed push is the same fast-forward");
+        };
+        assert_eq!(
+            change_count, packed,
+            "the planned count must equal what the pack carried"
+        );
+        assert_eq!(
+            packed,
+            Some(3),
+            "the merge, the side change, and the root all reach the destination by this path"
+        );
+        assert_eq!(head_of(&destination, &main), Some(merged));
     }
 
     #[test]

--- a/crates/kin-remote/src/repository_transfer_negotiation.rs
+++ b/crates/kin-remote/src/repository_transfer_negotiation.rs
@@ -88,9 +88,7 @@ pub enum LocalAncestry {
 #[serde(tag = "kind", rename_all = "snake_case")]
 pub enum RepositoryTransferPlan {
     /// Both replicas resolve the ref to the same exact change. Nothing moves.
-    UpToDate {
-        head: Option<SemanticChangeId>,
-    },
+    UpToDate { head: Option<SemanticChangeId> },
     /// The receiving head is an ancestor of the sending head. `change_count` is
     /// the exact number of changes the sender will pack, and is `None` when the
     /// sender is the remote, because only the exporting replica can count them.
@@ -266,7 +264,11 @@ pub fn verify_receipt_binds_pack(
     pack: &RepositoryTransferPack,
     receipt: &RepositoryTransferReceipt,
 ) -> Result<()> {
-    require_protocol(receipt.schema_version, &receipt.protocol, "transfer receipt")?;
+    require_protocol(
+        receipt.schema_version,
+        &receipt.protocol,
+        "transfer receipt",
+    )?;
     if receipt.transfer_id != pack.transfer_id {
         return Err(conflict(format!(
             "receipt binds transfer {} but this replica sent transfer {}",
@@ -294,6 +296,162 @@ pub fn verify_receipt_binds_pack(
     Ok(())
 }
 
+/// The ref a replica with no history of its own should adopt from a peer.
+///
+/// A fresh replica cannot name a ref from its own state, and the per-ref
+/// transfer status cannot be asked about a ref nobody has named yet. The
+/// advertisement is the only surface that answers this, which is why an unborn
+/// repository still publishes a default ref.
+pub fn remote_default_ref<T>(transport: &T, repository_id: &RepositoryId) -> Result<RefName>
+where
+    T: RepositoryTransferTransport + ?Sized,
+{
+    let advertisement = transport.advertise_refs(repository_id)?;
+    require_protocol(
+        advertisement.schema_version,
+        &advertisement.protocol,
+        "ref advertisement",
+    )?;
+    require_same_repository(
+        repository_id,
+        &advertisement.repository_id,
+        "ref advertisement",
+    )?;
+    advertisement.default_ref.ok_or_else(|| {
+        invalid(format!(
+            "remote publishes no default ref for {repository_id}; name one explicitly"
+        ))
+    })
+}
+
+/// Read the remote's exact lease for one destination ref, refusing a peer that
+/// answers for a different repository or a different ref than the one asked
+/// about.
+fn negotiated_destination_lease<T>(
+    transport: &T,
+    repository_id: &RepositoryId,
+    destination_ref: &RefName,
+) -> Result<RepositoryTransferExpectation>
+where
+    T: RepositoryTransferTransport + ?Sized,
+{
+    let status = transport.transfer_status(repository_id, destination_ref)?;
+    require_protocol(status.schema_version, &status.protocol, "transfer status")?;
+    require_same_repository(repository_id, &status.repository_id, "transfer status")?;
+    if &status.destination_ref != destination_ref {
+        return Err(invalid(format!(
+            "remote transfer status answers for ref {} but this replica asked about {}",
+            status.destination_ref, destination_ref
+        )));
+    }
+    RepositoryTransferExpectation::try_from(status)
+}
+
+/// Classify the local publication gap against an already-read remote lease.
+fn classify_push<B>(
+    local: &RepositoryAuthorityManager<B>,
+    source_ref: &RefName,
+    destination_ref: &RefName,
+    destination_head: Option<SemanticChangeId>,
+) -> Result<(SemanticChangeId, RepositoryTransferPlan)>
+where
+    B: StorageBackend + ?Sized + 'static,
+{
+    let lease = local.read_authority();
+    let source_target = lease
+        .resolve_ref_target(source_ref)
+        .map_err(storage)?
+        .ok_or_else(|| invalid(format!("local source ref {source_ref} is absent")))?;
+    let source_head = lease
+        .resolve_target_change_id(&source_target)
+        .map_err(storage)?;
+    let Some(head) = destination_head else {
+        return Ok((
+            source_head,
+            RepositoryTransferPlan::FastForward {
+                source_head,
+                destination_head: None,
+                change_count: None,
+            },
+        ));
+    };
+    let plan = match classify_local_ancestry(&lease.snapshot().changes, Some(source_head), head)? {
+        LocalAncestry::Same => RepositoryTransferPlan::UpToDate {
+            head: Some(source_head),
+        },
+        LocalAncestry::Ancestor { distance } => RepositoryTransferPlan::FastForward {
+            source_head,
+            destination_head: Some(head),
+            change_count: Some(distance),
+        },
+        LocalAncestry::Unreachable => {
+            return Err(conflict(format!(
+                "remote head {head} on {destination_ref} is not an ancestor of local head {source_head}; \
+                 the remote holds exact changes this replica has not admitted. Integrate with a pull first. \
+                 This transport publishes fast-forwards only and has no force path"
+            )));
+        }
+    };
+    Ok((source_head, plan))
+}
+
+/// A negotiated publication plan, and whether this protocol version can carry
+/// it in one envelope.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct RepositoryPushPlan {
+    pub plan: RepositoryTransferPlan,
+    /// The most changes one negotiated envelope carries.
+    pub max_changes_per_envelope: u32,
+    /// False when the gap needs more changes than one envelope holds.
+    ///
+    /// Transfer v1 has no continuation packs, so a gap this large is refused at
+    /// pack-build time rather than split. Reporting it from the plan is what
+    /// makes that refusal predictable instead of a surprise mid-publication.
+    pub fits_one_envelope: bool,
+}
+
+/// Negotiate a publication without moving any history.
+///
+/// This is the read-only half of [`push_to_remote`]: it reads the remote lease
+/// and classifies the gap, and refuses exactly what a push would refuse, but it
+/// never builds a pack or contacts the receive seam. A plan that reports a
+/// fast-forward is a statement about the two leases it just read, not a promise
+/// that they will still hold when a push runs.
+pub fn plan_push_to_remote<B, T>(
+    local: &RepositoryAuthorityManager<B>,
+    transport: &T,
+    repository_id: &RepositoryId,
+    source_ref: &RefName,
+    destination_ref: &RefName,
+) -> Result<RepositoryPushPlan>
+where
+    B: StorageBackend + ?Sized + 'static,
+    T: RepositoryTransferTransport + ?Sized,
+{
+    let expectation = negotiated_destination_lease(transport, repository_id, destination_ref)?;
+    let max_changes_per_envelope = expectation.limits.max_changes;
+    let (_, plan) = classify_push(
+        local,
+        source_ref,
+        destination_ref,
+        expectation.destination_head,
+    )?;
+    // An unborn destination has no counted closure yet, because counting it
+    // means walking the whole line. Treat unknown as "not yet known to fit"
+    // rather than asserting it fits.
+    let fits_one_envelope = match &plan {
+        RepositoryTransferPlan::UpToDate { .. } => true,
+        RepositoryTransferPlan::FastForward { change_count, .. } => change_count
+            .map(|count| u32::try_from(count).is_ok_and(|count| count <= max_changes_per_envelope))
+            .unwrap_or(false),
+    };
+    Ok(RepositoryPushPlan {
+        plan,
+        max_changes_per_envelope,
+        fits_one_envelope,
+    })
+}
+
 /// Negotiate and run one exact publication to a remote replica.
 ///
 /// The local replica holds the history, so it classifies the gap itself and
@@ -311,55 +469,14 @@ where
     B: StorageBackend + ?Sized + 'static,
     T: RepositoryTransferTransport + ?Sized,
 {
-    let status = transport.transfer_status(repository_id, destination_ref)?;
-    require_protocol(status.schema_version, &status.protocol, "transfer status")?;
-    require_same_repository(repository_id, &status.repository_id, "transfer status")?;
-    if &status.destination_ref != destination_ref {
-        return Err(invalid(format!(
-            "remote transfer status answers for ref {} but this replica asked about {}",
-            status.destination_ref, destination_ref
-        )));
-    }
-    let destination_head = status.destination_head;
-    let expectation = RepositoryTransferExpectation::try_from(status)?;
-
-    let (source_head, plan) = {
-        let lease = local.read_authority();
-        let source_target = lease
-            .resolve_ref_target(source_ref)
-            .map_err(storage)?
-            .ok_or_else(|| invalid(format!("local source ref {source_ref} is absent")))?;
-        let source_head = lease
-            .resolve_target_change_id(&source_target)
-            .map_err(storage)?;
-        let plan = match destination_head {
-            None => RepositoryTransferPlan::FastForward {
-                source_head,
-                destination_head: None,
-                change_count: None,
-            },
-            Some(head) => {
-                match classify_local_ancestry(&lease.snapshot().changes, Some(source_head), head)? {
-                    LocalAncestry::Same => RepositoryTransferPlan::UpToDate {
-                        head: Some(source_head),
-                    },
-                    LocalAncestry::Ancestor { distance } => RepositoryTransferPlan::FastForward {
-                        source_head,
-                        destination_head: Some(head),
-                        change_count: Some(distance),
-                    },
-                    LocalAncestry::Unreachable => {
-                        return Err(conflict(format!(
-                            "remote head {head} on {destination_ref} is not an ancestor of local head {source_head}; \
-                             the remote holds exact changes this replica has not admitted. Integrate with a pull first. \
-                             This transport publishes fast-forwards only and has no force path"
-                        )));
-                    }
-                }
-            }
-        };
-        (source_head, plan)
-    };
+    let expectation = negotiated_destination_lease(transport, repository_id, destination_ref)?;
+    let destination_head = expectation.destination_head;
+    let (source_head, plan) = classify_push(
+        local,
+        source_ref,
+        destination_ref,
+        expectation.destination_head,
+    )?;
 
     if matches!(plan, RepositoryTransferPlan::UpToDate { .. }) {
         return Ok(RepositoryTransferOutcome {
@@ -397,20 +514,28 @@ where
     })
 }
 
-/// Negotiate and admit one exact publication from a remote replica.
+/// What a pull negotiation produced, before anything is admitted locally.
+#[derive(Debug, Clone)]
+pub enum PullNegotiation {
+    /// Both replicas resolve the ref to the same exact change.
+    UpToDate { head: Option<SemanticChangeId> },
+    /// The exact pack the remote exported to close the gap.
+    Pack(Box<RepositoryTransferPack>),
+}
+
+/// Negotiate a pull and fetch the pack, without admitting it.
 ///
-/// The remote holds the history here, so its export computes the closure and is
-/// the authority on whether the gap is a fast-forward. The local pre-check only
-/// rules out the two cases local history can settle on its own: an identical
-/// head, and a remote head this replica already contains.
-pub fn pull_from_remote<B, T>(
+/// A receiver that owns derived state beyond repository authority needs to
+/// apply the pack itself, so that publication and the refresh of everything
+/// derived from it stay on one path. This is that seam: everything up to and
+/// including the exported pack, and nothing that moves local history.
+pub fn fetch_pull_pack<B, T>(
     local: &RepositoryAuthorityManager<B>,
     transport: &T,
     repository_id: &RepositoryId,
     source_ref: &RefName,
     destination_ref: &RefName,
-    actor: AuthorId,
-) -> Result<RepositoryTransferOutcome>
+) -> Result<PullNegotiation>
 where
     B: StorageBackend + ?Sized + 'static,
     T: RepositoryTransferTransport + ?Sized,
@@ -441,15 +566,8 @@ where
         let lease = local.read_authority();
         match classify_local_ancestry(&lease.snapshot().changes, destination_head, source_head)? {
             LocalAncestry::Same => {
-                return Ok(RepositoryTransferOutcome {
-                    direction: RepositoryTransferDirection::Pull,
-                    repository_id: repository_id.clone(),
-                    source_ref: source_ref.clone(),
-                    destination_ref: destination_ref.clone(),
-                    plan: RepositoryTransferPlan::UpToDate {
-                        head: destination_head,
-                    },
-                    receipt: None,
+                return Ok(PullNegotiation::UpToDate {
+                    head: destination_head,
                 });
             }
             LocalAncestry::Ancestor { distance } => {
@@ -476,6 +594,45 @@ where
             pack.destination_ref
         )));
     }
+    Ok(PullNegotiation::Pack(Box::new(pack)))
+}
+
+/// Negotiate, fetch, and admit one exact publication from a remote replica.
+///
+/// The remote holds the history here, so its export computes the closure and is
+/// the authority on whether the gap is a fast-forward. The local pre-check only
+/// rules out the two cases local history can settle on its own: an identical
+/// head, and a remote head this replica already contains.
+pub fn pull_from_remote<B, T>(
+    local: &RepositoryAuthorityManager<B>,
+    transport: &T,
+    repository_id: &RepositoryId,
+    source_ref: &RefName,
+    destination_ref: &RefName,
+    actor: AuthorId,
+) -> Result<RepositoryTransferOutcome>
+where
+    B: StorageBackend + ?Sized + 'static,
+    T: RepositoryTransferTransport + ?Sized,
+{
+    let negotiation =
+        fetch_pull_pack(local, transport, repository_id, source_ref, destination_ref)?;
+    let pack = match negotiation {
+        PullNegotiation::UpToDate { head } => {
+            return Ok(RepositoryTransferOutcome {
+                direction: RepositoryTransferDirection::Pull,
+                repository_id: repository_id.clone(),
+                source_ref: source_ref.clone(),
+                destination_ref: destination_ref.clone(),
+                plan: RepositoryTransferPlan::UpToDate { head },
+                receipt: None,
+            });
+        }
+        PullNegotiation::Pack(pack) => pack,
+    };
+
+    let destination_head = pack.expected_destination_head;
+    let source_head = pack.source_head;
     let change_count = pack.changes.len();
     let receipt =
         apply_repository_transfer_pack(local, repository_id, destination_ref, actor, &pack)?;
@@ -702,7 +859,14 @@ mod tests {
         let destination = manager(&destination_dir, &repository_id);
         let main = RefName::branch(b"main").unwrap();
 
-        let first = publish(&source, &repository_id, &main, None, 1, "root the exact line");
+        let first = publish(
+            &source,
+            &repository_id,
+            &main,
+            None,
+            1,
+            "root the exact line",
+        );
         let source_head = publish(
             &source,
             &repository_id,

--- a/crates/kin-remote/src/repository_transfer_negotiation.rs
+++ b/crates/kin-remote/src/repository_transfer_negotiation.rs
@@ -56,15 +56,6 @@ pub enum RepositoryTransferDirection {
     Pull,
 }
 
-impl RepositoryTransferDirection {
-    pub fn as_str(self) -> &'static str {
-        match self {
-            Self::Push => "push",
-            Self::Pull => "pull",
-        }
-    }
-}
-
 /// How an advertised head sits against exact local history.
 ///
 /// This is deliberately the only question local history can answer on its own.

--- a/crates/kin-remote/src/repository_transfer_negotiation.rs
+++ b/crates/kin-remote/src/repository_transfer_negotiation.rs
@@ -774,6 +774,14 @@ mod tests {
         actor: AuthorId,
         /// Corrupt the receipt on the way back, to prove the caller checks it.
         forge_receipt: bool,
+        /// Rewrite the repository this peer's discovery envelopes claim to
+        /// answer for, to prove the caller checks identity itself rather than
+        /// trusting a peer to refuse on its behalf.
+        claimed_repository: Option<RepositoryId>,
+        /// Rewrite the ref the transfer status answers about, for the same
+        /// reason: a peer that answers a question nobody asked is refused.
+        claimed_destination_ref: Option<RefName>,
+        exported: RefCell<usize>,
         received: RefCell<usize>,
     }
 
@@ -783,6 +791,9 @@ mod tests {
                 authority,
                 actor: AuthorId::new("local-peer"),
                 forge_receipt: false,
+                claimed_repository: None,
+                claimed_destination_ref: None,
+                exported: RefCell::new(0),
                 received: RefCell::new(0),
             }
         }
@@ -793,6 +804,20 @@ mod tests {
                 ..Self::new(authority)
             }
         }
+
+        fn claiming_repository(authority: &'a TestManager, claimed: RepositoryId) -> Self {
+            Self {
+                claimed_repository: Some(claimed),
+                ..Self::new(authority)
+            }
+        }
+
+        fn claiming_destination_ref(authority: &'a TestManager, claimed: RefName) -> Self {
+            Self {
+                claimed_destination_ref: Some(claimed),
+                ..Self::new(authority)
+            }
+        }
     }
 
     impl RepositoryTransferTransport for LocalPeer<'_> {
@@ -800,7 +825,11 @@ mod tests {
             &self,
             repository_id: &RepositoryId,
         ) -> Result<RepositoryRefAdvertisement> {
-            repository_ref_advertisement(self.authority, repository_id)
+            let mut advertisement = repository_ref_advertisement(self.authority, repository_id)?;
+            if let Some(claimed) = &self.claimed_repository {
+                advertisement.repository_id = claimed.clone();
+            }
+            Ok(advertisement)
         }
 
         fn transfer_status(
@@ -808,7 +837,15 @@ mod tests {
             repository_id: &RepositoryId,
             destination_ref: &RefName,
         ) -> Result<RepositoryTransferStatus> {
-            repository_transfer_status(self.authority, repository_id, destination_ref)
+            let mut status =
+                repository_transfer_status(self.authority, repository_id, destination_ref)?;
+            if let Some(claimed) = &self.claimed_repository {
+                status.repository_id = claimed.clone();
+            }
+            if let Some(claimed) = &self.claimed_destination_ref {
+                status.destination_ref = claimed.clone();
+            }
+            Ok(status)
         }
 
         fn export_pack(
@@ -817,6 +854,7 @@ mod tests {
             source_ref: &RefName,
             expectation: &RepositoryTransferExpectation,
         ) -> Result<RepositoryTransferPack> {
+            *self.exported.borrow_mut() += 1;
             build_repository_transfer_pack(self.authority, source_ref, expectation)
         }
 
@@ -1249,7 +1287,11 @@ mod tests {
     }
 
     #[test]
-    fn an_advertisement_for_another_repository_is_refused_before_any_export() {
+    fn a_peer_asked_about_a_repository_it_does_not_serve_refuses_the_advertisement() {
+        // This is the peer-side half. The peer refuses because its authority
+        // does not belong to the requested repository, so the caller never
+        // reaches its own identity check. The caller-side guards are proven
+        // separately against a peer that lies instead of refusing.
         let fixture = fixture();
         let peer = LocalPeer::new(&fixture.source);
         let other = RepositoryId::new("some-other-repository").unwrap();
@@ -1265,6 +1307,138 @@ mod tests {
         .expect_err("a peer serving a different repository must be refused");
 
         assert!(matches!(error, RepositoryTransferError::Invalid(_)));
+        assert_eq!(*peer.exported.borrow(), 0);
+    }
+
+    #[test]
+    fn a_default_ref_from_an_advertisement_naming_another_repository_is_refused() {
+        // A fresh replica adopts this ref before it holds anything of its own,
+        // so the advertisement is the only surface that can be checked at all.
+        let fixture = fixture();
+        let other = RepositoryId::new("some-other-repository").unwrap();
+        let peer = LocalPeer::claiming_repository(&fixture.source, other.clone());
+
+        let error = remote_default_ref(&peer, &fixture.repository_id).expect_err(
+            "an advertisement that names another repository answers a different question",
+        );
+
+        let RepositoryTransferError::Invalid(message) = error else {
+            panic!("a peer answering for another repository is an invalid envelope");
+        };
+        assert!(
+            message.contains(other.as_str()) && message.contains(fixture.repository_id.as_str()),
+            "the refusal must name both repositories so the operator can act on it: {message}"
+        );
+    }
+
+    #[test]
+    fn a_pull_refuses_an_advertisement_naming_another_repository_before_any_export() {
+        // The peer here holds this repository and answers correctly about its
+        // refs, but labels the envelope with another repository. Only the
+        // caller can catch that, and it has to catch it at discovery rather
+        // than leaving it to the admission check after a pack is already here.
+        let fixture = fixture();
+        let other = RepositoryId::new("some-other-repository").unwrap();
+        let peer = LocalPeer::claiming_repository(&fixture.source, other.clone());
+
+        let error = pull_from_remote(
+            &fixture.destination,
+            &peer,
+            &fixture.repository_id,
+            &fixture.main,
+            &fixture.main,
+            AuthorId::new("pulling-replica"),
+        )
+        .expect_err("a peer answering for another repository has not answered for this one");
+
+        let RepositoryTransferError::Invalid(message) = error else {
+            panic!("a peer answering for another repository is an invalid envelope");
+        };
+        assert!(
+            message.contains("remote ref advertisement belongs to repository"),
+            "the caller's own check must be what refuses, not the peer's: {message}"
+        );
+        assert_eq!(
+            *peer.exported.borrow(),
+            0,
+            "a refusal must happen before any pack is exported"
+        );
+        assert_eq!(
+            head_of(&fixture.destination, &fixture.main),
+            None,
+            "a refused pull must admit nothing"
+        );
+    }
+
+    #[test]
+    fn a_push_refuses_a_transfer_status_naming_another_repository() {
+        // The pack builder compares the two repository ids as well, so the
+        // refusal is asserted on the caller's own message: reaching the pack
+        // builder at all means this replica read a lease it should have
+        // refused, and acted on its head and limits.
+        let fixture = fixture();
+        let other = RepositoryId::new("some-other-repository").unwrap();
+        let peer = LocalPeer::claiming_repository(&fixture.destination, other.clone());
+
+        let error = push_to_remote(
+            &fixture.source,
+            &peer,
+            &fixture.repository_id,
+            &fixture.main,
+            &fixture.main,
+        )
+        .expect_err("a lease labelled for another repository is not this repository's lease");
+
+        let RepositoryTransferError::Invalid(message) = error else {
+            panic!("a peer answering for another repository is an invalid envelope");
+        };
+        assert!(
+            message.contains("remote transfer status belongs to repository")
+                && message.contains(other.as_str()),
+            "the caller's own check must be what refuses, not the pack builder's: {message}"
+        );
+        assert_eq!(*peer.received.borrow(), 0);
+        assert_eq!(
+            head_of(&fixture.destination, &fixture.main),
+            None,
+            "a refused push must move nothing"
+        );
+    }
+
+    #[test]
+    fn a_push_refuses_a_transfer_status_answering_for_another_ref() {
+        // A lease read for one ref says nothing about another. Accepting it
+        // would publish against a head and a policy that were never asked for.
+        let fixture = fixture();
+        let elsewhere = RefName::branch(b"elsewhere").unwrap();
+        let peer = LocalPeer::claiming_destination_ref(&fixture.destination, elsewhere);
+
+        let error = push_to_remote(
+            &fixture.source,
+            &peer,
+            &fixture.repository_id,
+            &fixture.main,
+            &fixture.main,
+        )
+        .expect_err("a status for another ref does not answer the question this replica asked");
+
+        let RepositoryTransferError::Invalid(message) = error else {
+            panic!("a status answering for another ref is an invalid envelope");
+        };
+        assert!(
+            message.contains("remote transfer status answers for ref"),
+            "the refusal must say the peer answered a different question: {message}"
+        );
+        assert_eq!(
+            *peer.received.borrow(),
+            0,
+            "a refusal must happen before any pack reaches the remote"
+        );
+        assert_eq!(
+            head_of(&fixture.destination, &fixture.main),
+            None,
+            "a refused push must move nothing"
+        );
     }
 
     #[test]

--- a/crates/kin-remote/src/repository_transfer_negotiation.rs
+++ b/crates/kin-remote/src/repository_transfer_negotiation.rs
@@ -1,0 +1,1060 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Firelock, LLC
+
+//! Negotiation and orchestration for exact repository-v6 transfer.
+//!
+//! [`crate::repository_transfer`] owns the pack: what it contains, how it is
+//! validated, and how it is published. This module owns the two questions that
+//! sit on either side of it. Before a pack exists: which exact changes are
+//! missing on the receiving replica, and is that gap a fast-forward at all.
+//! After a pack is published: does the returned receipt actually bind the pack
+//! that was sent, or is the caller being told a transfer happened that did not.
+//!
+//! Both directions run the same negotiation with the roles swapped. A push
+//! makes the remote the receiver, so the local replica holds the history and
+//! computes the closure itself. A pull makes the local replica the receiver, so
+//! the remote holds the history and its export computes the closure. Neither
+//! direction has force semantics: a gap that is not a fast-forward is refused
+//! with the two heads named, never rewritten.
+//!
+//! Negotiation reads exact semantic history only. It never consults a checkout,
+//! a Git object directory, or a filesystem heuristic to decide what a replica
+//! holds.
+
+use std::collections::{HashMap, HashSet};
+
+use kin_db::{RepositoryAuthorityManager, StorageBackend};
+use kin_model::{AuthorId, RefName, RepositoryId, SemanticChange, SemanticChangeId};
+use serde::{Deserialize, Serialize};
+
+use crate::repository_transfer::{
+    apply_repository_transfer_pack, build_repository_transfer_pack, repository_transfer_status,
+    RepositoryRefAdvertisement, RepositoryTransferError, RepositoryTransferExpectation,
+    RepositoryTransferPack, RepositoryTransferReceipt, RepositoryTransferStatus, Result,
+    REPOSITORY_TRANSFER_PROTOCOL, REPOSITORY_TRANSFER_SCHEMA_VERSION,
+};
+
+fn invalid(message: impl Into<String>) -> RepositoryTransferError {
+    RepositoryTransferError::Invalid(message.into())
+}
+
+fn conflict(message: impl Into<String>) -> RepositoryTransferError {
+    RepositoryTransferError::Conflict(message.into())
+}
+
+fn storage(error: impl std::fmt::Display) -> RepositoryTransferError {
+    RepositoryTransferError::Storage(error.to_string())
+}
+
+/// Which replica receives the transfer.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum RepositoryTransferDirection {
+    /// The local replica sends; the remote publishes.
+    Push,
+    /// The remote sends; the local replica publishes.
+    Pull,
+}
+
+impl RepositoryTransferDirection {
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::Push => "push",
+            Self::Pull => "pull",
+        }
+    }
+}
+
+/// How an advertised head sits against exact local history.
+///
+/// This is deliberately the only question local history can answer on its own.
+/// A replica knows its own ancestors; it cannot know whether a head it has
+/// never admitted is a descendant of its own or an unrelated line. Callers turn
+/// [`Self::Unreachable`] into a direction-specific refusal rather than guessing.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum LocalAncestry {
+    /// The advertised head is the local head.
+    Same,
+    /// The advertised head is a proper ancestor of the local head, with
+    /// `distance` exact changes between them.
+    Ancestor { distance: usize },
+    /// The local replica has never admitted the advertised head, so the
+    /// advertised head is not an ancestor of the local head.
+    Unreachable,
+}
+
+/// What negotiation decided before any authority moved.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(tag = "kind", rename_all = "snake_case")]
+pub enum RepositoryTransferPlan {
+    /// Both replicas resolve the ref to the same exact change. Nothing moves.
+    UpToDate {
+        head: Option<SemanticChangeId>,
+    },
+    /// The receiving head is an ancestor of the sending head. `change_count` is
+    /// the exact number of changes the sender will pack, and is `None` when the
+    /// sender is the remote, because only the exporting replica can count them.
+    FastForward {
+        source_head: SemanticChangeId,
+        destination_head: Option<SemanticChangeId>,
+        change_count: Option<usize>,
+    },
+}
+
+/// One completed negotiation, including the receipt when history moved.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct RepositoryTransferOutcome {
+    pub direction: RepositoryTransferDirection,
+    pub repository_id: RepositoryId,
+    pub source_ref: RefName,
+    pub destination_ref: RefName,
+    pub plan: RepositoryTransferPlan,
+    /// Absent exactly when the plan was [`RepositoryTransferPlan::UpToDate`].
+    pub receipt: Option<RepositoryTransferReceipt>,
+}
+
+impl RepositoryTransferOutcome {
+    /// True when this negotiation published a repository transaction.
+    pub fn moved_history(&self) -> bool {
+        self.receipt.is_some()
+    }
+}
+
+/// The wire seam a negotiation drives.
+///
+/// The trait exists so negotiation can be proven against a real peer without
+/// being written against one specific host. Implementations are transport only:
+/// they carry exact envelopes and surface peer refusals unchanged. They do not
+/// build packs, relax limits, or decide what a replica holds.
+pub trait RepositoryTransferTransport {
+    /// Every published ref, plus the default ref a fresh replica adopts.
+    fn advertise_refs(&self, repository_id: &RepositoryId) -> Result<RepositoryRefAdvertisement>;
+
+    /// The peer's exact lease for one destination ref.
+    fn transfer_status(
+        &self,
+        repository_id: &RepositoryId,
+        destination_ref: &RefName,
+    ) -> Result<RepositoryTransferStatus>;
+
+    /// Ask the peer to build the pack that closes `expectation`'s gap.
+    fn export_pack(
+        &self,
+        repository_id: &RepositoryId,
+        source_ref: &RefName,
+        expectation: &RepositoryTransferExpectation,
+    ) -> Result<RepositoryTransferPack>;
+
+    /// Ask the peer to validate and publish one exact pack.
+    fn receive_pack(
+        &self,
+        repository_id: &RepositoryId,
+        destination_ref: &RefName,
+        pack: &RepositoryTransferPack,
+    ) -> Result<RepositoryTransferReceipt>;
+}
+
+/// Classify `advertised` against `local_head` using exact local history only.
+///
+/// An absent `local_head` makes any advertised head unreachable: a replica with
+/// no history on the ref has admitted nothing.
+pub fn classify_local_ancestry(
+    changes: &HashMap<SemanticChangeId, SemanticChange>,
+    local_head: Option<SemanticChangeId>,
+    advertised: SemanticChangeId,
+) -> Result<LocalAncestry> {
+    let Some(local_head) = local_head else {
+        return Ok(LocalAncestry::Unreachable);
+    };
+    if local_head == advertised {
+        return Ok(LocalAncestry::Same);
+    }
+
+    // Count every change reachable from the local head but not from the
+    // advertised head. That count is the exact fast-forward distance, which is
+    // what a caller reports and what the pack will carry.
+    let mut behind = HashSet::new();
+    let mut stack = vec![advertised];
+    let mut advertised_seen = false;
+    while let Some(id) = stack.pop() {
+        if !behind.insert(id) {
+            continue;
+        }
+        let Some(change) = changes.get(&id) else {
+            // The advertised head itself is simply absent from local history.
+            // Any other missing parent is a broken local closure, not a peer
+            // disagreement, and must not be reported as "unreachable".
+            if id == advertised {
+                return Ok(LocalAncestry::Unreachable);
+            }
+            return Err(invalid(format!(
+                "exact local history is missing change {id} while classifying {advertised}"
+            )));
+        };
+        advertised_seen = true;
+        stack.extend(change.parents.iter().copied());
+    }
+    if !advertised_seen {
+        return Ok(LocalAncestry::Unreachable);
+    }
+
+    let mut distance = 0usize;
+    let mut visited = HashSet::new();
+    let mut stack = vec![local_head];
+    let mut reached_advertised = false;
+    while let Some(id) = stack.pop() {
+        if behind.contains(&id) {
+            if id == advertised {
+                reached_advertised = true;
+            }
+            continue;
+        }
+        if !visited.insert(id) {
+            continue;
+        }
+        let change = changes.get(&id).ok_or_else(|| {
+            invalid(format!(
+                "exact local history is missing change {id} while classifying {advertised}"
+            ))
+        })?;
+        distance += 1;
+        stack.extend(change.parents.iter().copied());
+    }
+    if !reached_advertised {
+        // Local history contains the advertised change but not on any path from
+        // the local head: the two lines share ancestry and then part.
+        return Ok(LocalAncestry::Unreachable);
+    }
+    Ok(LocalAncestry::Ancestor { distance })
+}
+
+/// Refuse a peer envelope that names a different repository.
+fn require_same_repository(
+    expected: &RepositoryId,
+    advertised: &RepositoryId,
+    what: &str,
+) -> Result<()> {
+    if expected == advertised {
+        return Ok(());
+    }
+    Err(invalid(format!(
+        "remote {what} belongs to repository {advertised}, not requested repository {expected}"
+    )))
+}
+
+fn require_protocol(schema_version: u32, protocol: &str, what: &str) -> Result<()> {
+    if schema_version != REPOSITORY_TRANSFER_SCHEMA_VERSION {
+        return Err(invalid(format!(
+            "remote {what} declares schema version {schema_version}; expected {REPOSITORY_TRANSFER_SCHEMA_VERSION}"
+        )));
+    }
+    if protocol != REPOSITORY_TRANSFER_PROTOCOL {
+        return Err(invalid(format!(
+            "remote {what} declares protocol {protocol:?}; expected {REPOSITORY_TRANSFER_PROTOCOL:?}"
+        )));
+    }
+    Ok(())
+}
+
+/// Refuse a receipt that does not bind the exact pack that was sent.
+///
+/// A receipt is the only evidence a caller has that a transfer was published.
+/// A peer that returns a well-formed receipt for some other transfer, or that
+/// reports a destination head other than the head this pack carried, has not
+/// proven this transfer and must not be reported as success.
+pub fn verify_receipt_binds_pack(
+    pack: &RepositoryTransferPack,
+    receipt: &RepositoryTransferReceipt,
+) -> Result<()> {
+    require_protocol(receipt.schema_version, &receipt.protocol, "transfer receipt")?;
+    if receipt.transfer_id != pack.transfer_id {
+        return Err(conflict(format!(
+            "receipt binds transfer {} but this replica sent transfer {}",
+            receipt.transfer_id, pack.transfer_id
+        )));
+    }
+    if receipt.repository_id != pack.repository_id {
+        return Err(conflict(format!(
+            "receipt binds repository {} but this replica sent repository {}",
+            receipt.repository_id, pack.repository_id
+        )));
+    }
+    if receipt.destination_ref != pack.destination_ref {
+        return Err(conflict(format!(
+            "receipt binds destination ref {} but this replica sent {}",
+            receipt.destination_ref, pack.destination_ref
+        )));
+    }
+    if receipt.destination_head != pack.source_head {
+        return Err(conflict(format!(
+            "receipt reports destination head {} but this pack publishes {}",
+            receipt.destination_head, pack.source_head
+        )));
+    }
+    Ok(())
+}
+
+/// Negotiate and run one exact publication to a remote replica.
+///
+/// The local replica holds the history, so it classifies the gap itself and
+/// refuses a non-fast-forward before building anything. There is no force
+/// path: a remote head this replica has not admitted is reported with both
+/// heads named so the operator integrates instead of overwriting.
+pub fn push_to_remote<B, T>(
+    local: &RepositoryAuthorityManager<B>,
+    transport: &T,
+    repository_id: &RepositoryId,
+    source_ref: &RefName,
+    destination_ref: &RefName,
+) -> Result<RepositoryTransferOutcome>
+where
+    B: StorageBackend + ?Sized + 'static,
+    T: RepositoryTransferTransport + ?Sized,
+{
+    let status = transport.transfer_status(repository_id, destination_ref)?;
+    require_protocol(status.schema_version, &status.protocol, "transfer status")?;
+    require_same_repository(repository_id, &status.repository_id, "transfer status")?;
+    if &status.destination_ref != destination_ref {
+        return Err(invalid(format!(
+            "remote transfer status answers for ref {} but this replica asked about {}",
+            status.destination_ref, destination_ref
+        )));
+    }
+    let destination_head = status.destination_head;
+    let expectation = RepositoryTransferExpectation::try_from(status)?;
+
+    let (source_head, plan) = {
+        let lease = local.read_authority();
+        let source_target = lease
+            .resolve_ref_target(source_ref)
+            .map_err(storage)?
+            .ok_or_else(|| invalid(format!("local source ref {source_ref} is absent")))?;
+        let source_head = lease
+            .resolve_target_change_id(&source_target)
+            .map_err(storage)?;
+        let plan = match destination_head {
+            None => RepositoryTransferPlan::FastForward {
+                source_head,
+                destination_head: None,
+                change_count: None,
+            },
+            Some(head) => {
+                match classify_local_ancestry(&lease.snapshot().changes, Some(source_head), head)? {
+                    LocalAncestry::Same => RepositoryTransferPlan::UpToDate {
+                        head: Some(source_head),
+                    },
+                    LocalAncestry::Ancestor { distance } => RepositoryTransferPlan::FastForward {
+                        source_head,
+                        destination_head: Some(head),
+                        change_count: Some(distance),
+                    },
+                    LocalAncestry::Unreachable => {
+                        return Err(conflict(format!(
+                            "remote head {head} on {destination_ref} is not an ancestor of local head {source_head}; \
+                             the remote holds exact changes this replica has not admitted. Integrate with a pull first. \
+                             This transport publishes fast-forwards only and has no force path"
+                        )));
+                    }
+                }
+            }
+        };
+        (source_head, plan)
+    };
+
+    if matches!(plan, RepositoryTransferPlan::UpToDate { .. }) {
+        return Ok(RepositoryTransferOutcome {
+            direction: RepositoryTransferDirection::Push,
+            repository_id: repository_id.clone(),
+            source_ref: source_ref.clone(),
+            destination_ref: destination_ref.clone(),
+            plan,
+            receipt: None,
+        });
+    }
+
+    let pack = build_repository_transfer_pack(local, source_ref, &expectation)?;
+    if pack.source_head != source_head {
+        return Err(conflict(format!(
+            "local authority moved during negotiation: planned head {source_head}, packed head {}",
+            pack.source_head
+        )));
+    }
+    let plan = RepositoryTransferPlan::FastForward {
+        source_head,
+        destination_head,
+        change_count: Some(pack.changes.len()),
+    };
+    let receipt = transport.receive_pack(repository_id, destination_ref, &pack)?;
+    verify_receipt_binds_pack(&pack, &receipt)?;
+
+    Ok(RepositoryTransferOutcome {
+        direction: RepositoryTransferDirection::Push,
+        repository_id: repository_id.clone(),
+        source_ref: source_ref.clone(),
+        destination_ref: destination_ref.clone(),
+        plan,
+        receipt: Some(receipt),
+    })
+}
+
+/// Negotiate and admit one exact publication from a remote replica.
+///
+/// The remote holds the history here, so its export computes the closure and is
+/// the authority on whether the gap is a fast-forward. The local pre-check only
+/// rules out the two cases local history can settle on its own: an identical
+/// head, and a remote head this replica already contains.
+pub fn pull_from_remote<B, T>(
+    local: &RepositoryAuthorityManager<B>,
+    transport: &T,
+    repository_id: &RepositoryId,
+    source_ref: &RefName,
+    destination_ref: &RefName,
+    actor: AuthorId,
+) -> Result<RepositoryTransferOutcome>
+where
+    B: StorageBackend + ?Sized + 'static,
+    T: RepositoryTransferTransport + ?Sized,
+{
+    let advertisement = transport.advertise_refs(repository_id)?;
+    require_protocol(
+        advertisement.schema_version,
+        &advertisement.protocol,
+        "ref advertisement",
+    )?;
+    require_same_repository(
+        repository_id,
+        &advertisement.repository_id,
+        "ref advertisement",
+    )?;
+    let source_head = advertisement
+        .refs
+        .iter()
+        .find(|entry| &entry.name == source_ref)
+        .map(|entry| entry.head)
+        .ok_or_else(|| invalid(format!("remote does not publish source ref {source_ref}")))?;
+
+    let status = repository_transfer_status(local, repository_id, destination_ref)?;
+    let destination_head = status.destination_head;
+    let expectation = RepositoryTransferExpectation::try_from(status)?;
+
+    {
+        let lease = local.read_authority();
+        match classify_local_ancestry(&lease.snapshot().changes, destination_head, source_head)? {
+            LocalAncestry::Same => {
+                return Ok(RepositoryTransferOutcome {
+                    direction: RepositoryTransferDirection::Pull,
+                    repository_id: repository_id.clone(),
+                    source_ref: source_ref.clone(),
+                    destination_ref: destination_ref.clone(),
+                    plan: RepositoryTransferPlan::UpToDate {
+                        head: destination_head,
+                    },
+                    receipt: None,
+                });
+            }
+            LocalAncestry::Ancestor { distance } => {
+                let local_head = destination_head.expect("an ancestor implies a local head");
+                return Err(conflict(format!(
+                    "remote head {source_head} on {source_ref} is already an exact ancestor of local head \
+                     {local_head}, {distance} changes behind; there is nothing to admit in this direction"
+                )));
+            }
+            LocalAncestry::Unreachable => {}
+        }
+    }
+
+    let pack = transport.export_pack(repository_id, source_ref, &expectation)?;
+    if pack.source_head != source_head {
+        return Err(conflict(format!(
+            "remote authority moved during negotiation: advertised head {source_head}, exported head {}",
+            pack.source_head
+        )));
+    }
+    if &pack.destination_ref != destination_ref {
+        return Err(invalid(format!(
+            "remote exported a pack for destination ref {} but this replica asked for {destination_ref}",
+            pack.destination_ref
+        )));
+    }
+    let change_count = pack.changes.len();
+    let receipt =
+        apply_repository_transfer_pack(local, repository_id, destination_ref, actor, &pack)?;
+    verify_receipt_binds_pack(&pack, &receipt)?;
+
+    Ok(RepositoryTransferOutcome {
+        direction: RepositoryTransferDirection::Pull,
+        repository_id: repository_id.clone(),
+        source_ref: source_ref.clone(),
+        destination_ref: destination_ref.clone(),
+        plan: RepositoryTransferPlan::FastForward {
+            source_head,
+            destination_head,
+            change_count: Some(change_count),
+        },
+        receipt: Some(receipt),
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use std::cell::RefCell;
+    use std::sync::Arc;
+
+    use kin_db::LocalFileBackend;
+    use kin_model::{
+        compute_semantic_change_id, ChangeOrigin, DefaultRefExpectation, DefaultRefMutation,
+        Hash256, OperationId, RefExpectation, RefMutation, RefTarget, RefUpdatePolicy,
+        RepositoryTransaction, Timestamp, TreeDelta, REPOSITORY_TRANSACTION_SCHEMA_VERSION,
+    };
+    use tempfile::TempDir;
+    use uuid::Uuid;
+
+    use crate::repository_transfer::{
+        repository_ref_advertisement, RepositoryTransferApplyOutcome,
+    };
+
+    use super::*;
+
+    type TestManager = RepositoryAuthorityManager<LocalFileBackend>;
+
+    fn manager(directory: &TempDir, repository_id: &RepositoryId) -> TestManager {
+        let storage_root = directory.path().join("kindb");
+        std::fs::create_dir_all(&storage_root).unwrap();
+        RepositoryAuthorityManager::open(
+            repository_id.clone(),
+            Arc::new(LocalFileBackend::new(storage_root)),
+        )
+        .unwrap()
+    }
+
+    fn native_change(
+        parents: Vec<SemanticChangeId>,
+        message: &str,
+        tree_deltas: Vec<TreeDelta>,
+    ) -> SemanticChange {
+        let mut change = SemanticChange {
+            id: SemanticChangeId::from_hash(Hash256::from_bytes([0; 32])),
+            origin: ChangeOrigin::Native,
+            parents,
+            timestamp: Timestamp::now(),
+            author: AuthorId::new("negotiation-fixture"),
+            message: message.to_string(),
+            entity_deltas: Vec::new(),
+            relation_deltas: Vec::new(),
+            tree_deltas,
+            admission_policy_delta: None,
+            projected_files: Vec::new(),
+            spec_link: None,
+            evidence: Vec::new(),
+            risk_summary: None,
+        };
+        change.id = compute_semantic_change_id(&change).unwrap();
+        change
+    }
+
+    /// Publish one native change onto `ref_name`, advancing from `previous`.
+    ///
+    /// The changes carry no tree deltas on purpose. Introducing an artifact
+    /// binds a workspace admission context that has nothing to do with
+    /// negotiation, and pack contents are already proven exactly in
+    /// `repository_transfer`'s own suite. What these fixtures need to be real
+    /// about is history shape: which changes exist, which ref resolves where,
+    /// and what the closure between two heads is.
+    fn publish(
+        manager: &TestManager,
+        repository_id: &RepositoryId,
+        ref_name: &RefName,
+        previous: Option<SemanticChangeId>,
+        operation: u128,
+        message: &str,
+    ) -> SemanticChangeId {
+        let change = native_change(previous.into_iter().collect(), message, Vec::new());
+        let lease = manager.read_authority();
+        let transaction = RepositoryTransaction {
+            schema_version: REPOSITORY_TRANSACTION_SCHEMA_VERSION,
+            operation_id: OperationId::from_uuid(Uuid::from_u128(operation)),
+            repository_id: repository_id.clone(),
+            expected_generation: lease.roots().generation,
+            expected_roots: lease.roots().clone(),
+            actor: AuthorId::new("negotiation-fixture"),
+            reason: format!("publish {message}"),
+            external_objects: Vec::new(),
+            git_authority_delta: None,
+            changes: vec![change.clone()],
+            aliases: Vec::new(),
+            ref_mutations: vec![RefMutation {
+                name: ref_name.clone(),
+                expected: match previous {
+                    None => RefExpectation::MustNotExist,
+                    Some(head) => RefExpectation::MustEqual {
+                        target: RefTarget::change(head),
+                    },
+                },
+                new_target: Some(RefTarget::change(change.id)),
+                policy: RefUpdatePolicy::FastForwardOnly,
+            }],
+            default_ref_mutation: previous.is_none().then_some(DefaultRefMutation {
+                expected: DefaultRefExpectation::MustBeUnset,
+                new_default: Some(ref_name.clone()),
+            }),
+            workspace_mutation: None,
+            local_overlay_delta: None,
+        };
+        drop(lease);
+        manager.commit_repository_transaction(transaction).unwrap();
+        change.id
+    }
+
+    /// A peer reached in-process rather than over HTTP.
+    ///
+    /// Every call runs the same `repository_transfer` entry point the daemon's
+    /// route runs, against a second real authority on real storage. What this
+    /// double leaves unproven is the wire itself, which the daemon suite covers
+    /// separately over a bound socket.
+    struct LocalPeer<'a> {
+        authority: &'a TestManager,
+        actor: AuthorId,
+        /// Corrupt the receipt on the way back, to prove the caller checks it.
+        forge_receipt: bool,
+        received: RefCell<usize>,
+    }
+
+    impl<'a> LocalPeer<'a> {
+        fn new(authority: &'a TestManager) -> Self {
+            Self {
+                authority,
+                actor: AuthorId::new("local-peer"),
+                forge_receipt: false,
+                received: RefCell::new(0),
+            }
+        }
+
+        fn forging_receipts(authority: &'a TestManager) -> Self {
+            Self {
+                forge_receipt: true,
+                ..Self::new(authority)
+            }
+        }
+    }
+
+    impl RepositoryTransferTransport for LocalPeer<'_> {
+        fn advertise_refs(
+            &self,
+            repository_id: &RepositoryId,
+        ) -> Result<RepositoryRefAdvertisement> {
+            repository_ref_advertisement(self.authority, repository_id)
+        }
+
+        fn transfer_status(
+            &self,
+            repository_id: &RepositoryId,
+            destination_ref: &RefName,
+        ) -> Result<RepositoryTransferStatus> {
+            repository_transfer_status(self.authority, repository_id, destination_ref)
+        }
+
+        fn export_pack(
+            &self,
+            _repository_id: &RepositoryId,
+            source_ref: &RefName,
+            expectation: &RepositoryTransferExpectation,
+        ) -> Result<RepositoryTransferPack> {
+            build_repository_transfer_pack(self.authority, source_ref, expectation)
+        }
+
+        fn receive_pack(
+            &self,
+            repository_id: &RepositoryId,
+            destination_ref: &RefName,
+            pack: &RepositoryTransferPack,
+        ) -> Result<RepositoryTransferReceipt> {
+            *self.received.borrow_mut() += 1;
+            let mut receipt = apply_repository_transfer_pack(
+                self.authority,
+                repository_id,
+                destination_ref,
+                self.actor.clone(),
+                pack,
+            )?;
+            if self.forge_receipt {
+                receipt.transfer_id = Hash256::from_bytes([0xab; 32]);
+            }
+            Ok(receipt)
+        }
+    }
+
+    struct Fixture {
+        _source_dir: TempDir,
+        _destination_dir: TempDir,
+        source: TestManager,
+        destination: TestManager,
+        repository_id: RepositoryId,
+        main: RefName,
+        source_head: SemanticChangeId,
+    }
+
+    /// A source holding two exact native changes, and an unborn destination.
+    fn fixture() -> Fixture {
+        let repository_id = RepositoryId::new(format!("negotiation-{}", Uuid::new_v4())).unwrap();
+        let source_dir = TempDir::new().unwrap();
+        let destination_dir = TempDir::new().unwrap();
+        let source = manager(&source_dir, &repository_id);
+        let destination = manager(&destination_dir, &repository_id);
+        let main = RefName::branch(b"main").unwrap();
+
+        let first = publish(&source, &repository_id, &main, None, 1, "root the exact line");
+        let source_head = publish(
+            &source,
+            &repository_id,
+            &main,
+            Some(first),
+            2,
+            "advance the exact line",
+        );
+
+        Fixture {
+            _source_dir: source_dir,
+            _destination_dir: destination_dir,
+            source,
+            destination,
+            repository_id,
+            main,
+            source_head,
+        }
+    }
+
+    fn head_of(manager: &TestManager, ref_name: &RefName) -> Option<SemanticChangeId> {
+        let lease = manager.read_authority();
+        let target = lease.resolve_ref_target(ref_name).unwrap()?;
+        Some(lease.resolve_target_change_id(&target).unwrap())
+    }
+
+    #[test]
+    fn push_publishes_the_whole_gap_and_binds_the_returned_receipt() {
+        let fixture = fixture();
+        let peer = LocalPeer::new(&fixture.destination);
+
+        let outcome = push_to_remote(
+            &fixture.source,
+            &peer,
+            &fixture.repository_id,
+            &fixture.main,
+            &fixture.main,
+        )
+        .unwrap();
+
+        assert_eq!(outcome.direction, RepositoryTransferDirection::Push);
+        assert_eq!(
+            outcome.plan,
+            RepositoryTransferPlan::FastForward {
+                source_head: fixture.source_head,
+                destination_head: None,
+                change_count: Some(2),
+            }
+        );
+        let receipt = outcome.receipt.expect("a moved head produces a receipt");
+        assert_eq!(receipt.outcome, RepositoryTransferApplyOutcome::Committed);
+        assert_eq!(receipt.destination_head, fixture.source_head);
+        assert_eq!(
+            head_of(&fixture.destination, &fixture.main),
+            Some(fixture.source_head),
+            "the remote replica now resolves the ref to the exact source head"
+        );
+    }
+
+    #[test]
+    fn a_second_push_of_the_same_head_moves_nothing_and_sends_no_pack() {
+        let fixture = fixture();
+        let peer = LocalPeer::new(&fixture.destination);
+        push_to_remote(
+            &fixture.source,
+            &peer,
+            &fixture.repository_id,
+            &fixture.main,
+            &fixture.main,
+        )
+        .unwrap();
+        assert_eq!(*peer.received.borrow(), 1);
+
+        let outcome = push_to_remote(
+            &fixture.source,
+            &peer,
+            &fixture.repository_id,
+            &fixture.main,
+            &fixture.main,
+        )
+        .unwrap();
+
+        assert_eq!(
+            outcome.plan,
+            RepositoryTransferPlan::UpToDate {
+                head: Some(fixture.source_head),
+            }
+        );
+        assert!(!outcome.moved_history());
+        assert_eq!(
+            *peer.received.borrow(),
+            1,
+            "an up-to-date negotiation must not build or ship a pack at all"
+        );
+    }
+
+    #[test]
+    fn pull_admits_the_same_gap_from_the_other_side() {
+        let fixture = fixture();
+        let peer = LocalPeer::new(&fixture.source);
+
+        let outcome = pull_from_remote(
+            &fixture.destination,
+            &peer,
+            &fixture.repository_id,
+            &fixture.main,
+            &fixture.main,
+            AuthorId::new("pulling-replica"),
+        )
+        .unwrap();
+
+        assert_eq!(outcome.direction, RepositoryTransferDirection::Pull);
+        assert_eq!(
+            outcome.plan,
+            RepositoryTransferPlan::FastForward {
+                source_head: fixture.source_head,
+                destination_head: None,
+                change_count: Some(2),
+            }
+        );
+        assert_eq!(
+            head_of(&fixture.destination, &fixture.main),
+            Some(fixture.source_head)
+        );
+        let receipt = outcome.receipt.expect("a moved head produces a receipt");
+        assert_eq!(receipt.outcome, RepositoryTransferApplyOutcome::Committed);
+    }
+
+    #[test]
+    fn push_refuses_a_remote_head_this_replica_has_not_admitted() {
+        let fixture = fixture();
+        // The remote admits its own independent line on the same ref.
+        let remote_head = publish(
+            &fixture.destination,
+            &fixture.repository_id,
+            &fixture.main,
+            None,
+            9,
+            "admitted only on the remote replica",
+        );
+        let peer = LocalPeer::new(&fixture.destination);
+
+        let error = push_to_remote(
+            &fixture.source,
+            &peer,
+            &fixture.repository_id,
+            &fixture.main,
+            &fixture.main,
+        )
+        .expect_err("a non-fast-forward publication must be refused");
+
+        let RepositoryTransferError::Conflict(message) = error else {
+            panic!("a divergent remote is a conflict, not an invalid envelope");
+        };
+        assert!(
+            message.contains(&remote_head.to_string())
+                && message.contains(&fixture.source_head.to_string()),
+            "the refusal must name both heads so the operator can act on it: {message}"
+        );
+        assert!(
+            message.contains("no force path"),
+            "the refusal must say force is unavailable rather than imply a retry: {message}"
+        );
+        assert_eq!(
+            head_of(&fixture.destination, &fixture.main),
+            Some(remote_head),
+            "a refused push must leave the remote head exactly where it was"
+        );
+        assert_eq!(
+            *peer.received.borrow(),
+            0,
+            "a refusal must happen before any pack reaches the remote"
+        );
+    }
+
+    #[test]
+    fn pull_refuses_a_remote_this_replica_already_contains() {
+        let fixture = fixture();
+        // Give the destination the full source history, then rewind the peer to
+        // the first change so the remote is strictly behind.
+        let peer = LocalPeer::new(&fixture.source);
+        pull_from_remote(
+            &fixture.destination,
+            &peer,
+            &fixture.repository_id,
+            &fixture.main,
+            &fixture.main,
+            AuthorId::new("pulling-replica"),
+        )
+        .unwrap();
+
+        // A third replica that holds only the first change now advertises it.
+        let behind_dir = TempDir::new().unwrap();
+        let behind = manager(&behind_dir, &fixture.repository_id);
+        let behind_head = publish(
+            &behind,
+            &fixture.repository_id,
+            &fixture.main,
+            None,
+            1,
+            "root the exact line",
+        );
+        let behind_peer = LocalPeer::new(&behind);
+
+        let error = pull_from_remote(
+            &fixture.destination,
+            &behind_peer,
+            &fixture.repository_id,
+            &fixture.main,
+            &fixture.main,
+            AuthorId::new("pulling-replica"),
+        )
+        .expect_err("there is nothing to admit from a replica we already contain");
+
+        let RepositoryTransferError::Conflict(message) = error else {
+            panic!("an already-contained remote is a conflict");
+        };
+        assert!(
+            message.contains(&behind_head.to_string()),
+            "the refusal must name the remote head: {message}"
+        );
+        assert_eq!(
+            head_of(&fixture.destination, &fixture.main),
+            Some(fixture.source_head),
+            "a refused pull must leave the local head exactly where it was"
+        );
+    }
+
+    #[test]
+    fn a_receipt_that_binds_another_transfer_is_refused_even_though_history_moved() {
+        let fixture = fixture();
+        let peer = LocalPeer::forging_receipts(&fixture.destination);
+
+        let error = push_to_remote(
+            &fixture.source,
+            &peer,
+            &fixture.repository_id,
+            &fixture.main,
+            &fixture.main,
+        )
+        .expect_err("a receipt that does not bind the sent pack is not proof of this transfer");
+
+        assert!(matches!(error, RepositoryTransferError::Conflict(_)));
+        // The remote genuinely published; what is refused is the claim that the
+        // returned receipt proves it. Reporting success here would let a peer
+        // acknowledge transfers it never performed.
+        assert_eq!(
+            head_of(&fixture.destination, &fixture.main),
+            Some(fixture.source_head)
+        );
+    }
+
+    #[test]
+    fn an_advertisement_for_another_repository_is_refused_before_any_export() {
+        let fixture = fixture();
+        let peer = LocalPeer::new(&fixture.source);
+        let other = RepositoryId::new("some-other-repository").unwrap();
+
+        let error = pull_from_remote(
+            &fixture.destination,
+            &peer,
+            &other,
+            &fixture.main,
+            &fixture.main,
+            AuthorId::new("pulling-replica"),
+        )
+        .expect_err("a peer serving a different repository must be refused");
+
+        assert!(matches!(error, RepositoryTransferError::Invalid(_)));
+    }
+
+    #[test]
+    fn push_refuses_a_source_ref_this_replica_does_not_publish() {
+        let fixture = fixture();
+        let peer = LocalPeer::new(&fixture.destination);
+        let absent = RefName::branch(b"never-published").unwrap();
+
+        let error = push_to_remote(
+            &fixture.source,
+            &peer,
+            &fixture.repository_id,
+            &absent,
+            &fixture.main,
+        )
+        .expect_err("a source ref that does not exist cannot be published");
+
+        assert!(matches!(error, RepositoryTransferError::Invalid(_)));
+        assert_eq!(*peer.received.borrow(), 0);
+    }
+
+    #[test]
+    fn ancestry_classification_separates_behind_from_unrelated() {
+        let fixture = fixture();
+        let lease = fixture.source.read_authority();
+        let changes = &lease.snapshot().changes;
+        let first = changes
+            .values()
+            .find(|change| change.parents.is_empty())
+            .expect("the fixture roots one change");
+
+        assert_eq!(
+            classify_local_ancestry(changes, Some(fixture.source_head), fixture.source_head)
+                .unwrap(),
+            LocalAncestry::Same
+        );
+        assert_eq!(
+            classify_local_ancestry(changes, Some(fixture.source_head), first.id).unwrap(),
+            LocalAncestry::Ancestor { distance: 1 }
+        );
+        assert_eq!(
+            classify_local_ancestry(
+                changes,
+                Some(fixture.source_head),
+                SemanticChangeId::from_hash(Hash256::from_bytes([0x5c; 32])),
+            )
+            .unwrap(),
+            LocalAncestry::Unreachable,
+            "a head this replica has never admitted is unreachable, not an ancestor"
+        );
+        assert_eq!(
+            classify_local_ancestry(changes, None, fixture.source_head).unwrap(),
+            LocalAncestry::Unreachable,
+            "a replica with no head on the ref has admitted nothing"
+        );
+    }
+
+    #[test]
+    fn a_sibling_line_present_in_local_history_is_not_an_ancestor() {
+        // A change can be known locally and still not be on any path from the
+        // local head. Counting "do I have this id" instead of "is it behind my
+        // head" would call that a fast-forward and silently drop the sibling.
+        let fixture = fixture();
+        let lease = fixture.source.read_authority();
+        let mut changes = lease.snapshot().changes.clone();
+        let root = changes
+            .values()
+            .find(|change| change.parents.is_empty())
+            .expect("the fixture roots one change")
+            .id;
+        drop(lease);
+
+        let sibling = native_change(vec![root], "a second child of the same root", Vec::new());
+        let sibling_id = sibling.id;
+        changes.insert(sibling_id, sibling);
+
+        assert_eq!(
+            classify_local_ancestry(&changes, Some(fixture.source_head), sibling_id).unwrap(),
+            LocalAncestry::Unreachable
+        );
+        assert_eq!(
+            classify_local_ancestry(&changes, Some(sibling_id), fixture.source_head).unwrap(),
+            LocalAncestry::Unreachable
+        );
+    }
+}


### PR DESCRIPTION
Negotiation, transport, and CLI wiring around the repository-v6 transfer pack. The pack format is unchanged: `repository_transfer.rs` already built, validated, and applied `RepositoryTransferPack`. What was missing was everything on either side of it.

## What runs now

Native push and pull run end to end between two Kin daemons over a real socket, with receipts verified and divergence refused. `crates/kin-daemon/src/api.rs` proves this against a bound ephemeral listener serving the real router, not an in-process double:

- `native_push_and_pull_move_exact_history_between_two_daemons_over_http`
- `a_divergent_remote_refuses_the_push_over_http_and_moves_nothing`

## Shape

**Negotiation** (`kin-remote/src/repository_transfer_negotiation.rs`). Both directions run the same negotiation with the roles swapped. A push has the local replica hold the history and compute the closure itself; a pull has the remote export compute it. A gap that is not a fast-forward is refused with both heads named, and there is no force path. Receipts are verified to bind the pack that was sent, so a peer cannot acknowledge a transfer it did not perform.

**Transport** (`kin-remote/src/repository_transfer_http.rs`, feature `http`). Carries exact envelopes to a peer's `/repos/{id}/transfer/*` seam and preserves each refusal class: 409 conflict, 422 invalid, 424 storage. A peer that cannot be reached is never reported as a clean refusal.

**Daemon.** Adds the ref advertisement route (where a replica with no ref of its own starts) plus `push`, `pull`, and `transfer-plan` commands. Negotiation runs in the daemon, not the CLI, because the daemon holds repository authority and every view derived from it: a pull publishes and refreshes those views on the same path the inbound receive route already uses.

**CLI.** `kin push`, `kin pull` (alias `fetch`), and `kin remote plan-push`, each with `--remote`, `--url`, `--ref`, `--json`. Remote resolution fails closed rather than guessing a host.

A pull into a replica that has admitted nothing adopts the remote's advertised default ref, which is what that field exists for.

## Capability flips

`remote plan-push` flips to ready. It negotiates against a live peer, refuses what a push would refuse, and publishes nothing.

`push` and `pull` stay `open_gate` / `fail_closed`, with acceptance specs rewritten to separate what is done from what remains. The reason is not caution: the transfer envelope is bounded at 512 changes, transfer v1 has no continuation packs, and the transfer status this protocol publishes still reports `push_apply_ready=false`. `kin` itself is past 1,800 commits, so a `READY` marking would promise a capability that fails on the flagship repository. `kin remote plan-push` now reports whether a gap fits one envelope, so that refusal is predictable before a push runs instead of a surprise at pack build.

Remaining, recorded in the inventory: continuation packs for oversized closures; the KinLab control-plane transfer-envelope route with its protection rules; a graph-derived workspace transition after admission.

## One defect fixed in review

The first version of the gap classifier counted "reachable from the local head but not from the advertised head". That under-counts a merge: a shared ancestor reachable from the local head by a path that never passes through the advertised change is carried by the pack, so the plan reported a smaller transfer than the one that runs. It now walks back from the local head and stops at the advertised change, exactly how the closure is collected. `a_merge_plan_counts_every_change_the_pack_carries` guards it: restoring the previous walk and running that test fails with `left: Some(2)` against `right: Some(3)`, which is the plan under-reporting the transfer by one change.

## Not claimed

The CLI-to-local-daemon hop is covered by unit tests, not by a live two-daemon binary smoke. Everything from the daemon command inward is exercised over real sockets, but no shipped `kin` binary was driven against a running pair. That smoke needs the daemon lock, which other lanes are actively using tonight, and taking it for this would have blocked them.

Nothing here drives the KinLab control-plane transfer-envelope route. The peer in every test is a real Kin daemon transfer seam, which is the same seam KinLab's gateway proxies to, but the control-plane wrapper and its protection rules are untouched and untested by this change.

## For the merge captain

This bumps the pinned `ready_commands` assertion in `command_capabilities.rs` from 15 to 16, because `remote plan-push` flipped. Any sibling lane flipping a capability tonight touches the same line, so whichever lands second needs a rebase on that one number.

## Gates

All local, on `7655cb29`: `cargo fmt --all --check` clean, `cargo clippy --all-targets --all-features` clean under `-Dwarnings` with the ci.yml allowlist, `cargo build --all-targets` clean, and `cargo test --workspace` green across 82 suites.
