### PR TITLE
Seal exact workspace state as a graph-owned repository stash

### DIFF
--- a/crates/kin-cli/src/commands/mod.rs
+++ b/crates/kin-cli/src/commands/mod.rs
@@ -67,6 +67,7 @@ pub mod session_workspace;
 pub mod setup;
 pub mod setup_ledger;
 pub mod spec;
+pub mod stash;
 pub mod status;
 pub mod support;
 pub mod telemetry;

--- a/crates/kin-cli/src/commands/stash.rs
+++ b/crates/kin-cli/src/commands/stash.rs
@@ -1,0 +1,234 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Firelock, LLC
+
+//! Wire types and CLI transport for daemon-owned repository-v6 stashes.
+//!
+//! A stash is exact graph-owned workspace state sealed as an immutable change
+//! under `refs/kin/stash/`, bound to the authority target it was taken against.
+//! No branch marker, sidecar file, or working-tree re-read participates.
+//!
+//! The transport stays fail-closed at the capability gate. The daemon-owned
+//! path below it is implemented and covered, but a seal against a live daemon
+//! can still leave the daemon query graph disagreeing with workspace authority,
+//! and no command may ship while it can wedge the next one.
+
+use anyhow::{bail, Result};
+use kin_model::{
+    AuthorId, Hash256, OperationId, RefName, RefTarget, RepositoryId, SemanticChangeId, Timestamp,
+    WorkspaceId,
+};
+use serde::{Deserialize, Serialize};
+
+pub const STASH_LIST_SCHEMA: &str = "kin.stash-list.v1";
+
+/// Repository ref namespace that holds sealed workspace states.
+pub const STASH_REF_PREFIX: &[u8] = b"refs/kin/stash/";
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(tag = "command", rename_all = "snake_case", deny_unknown_fields)]
+pub enum StashRequest {
+    List,
+    Push {
+        message: Option<String>,
+        operation_id: OperationId,
+        timestamp: Timestamp,
+        actor: AuthorId,
+    },
+    Pop {
+        operation_id: OperationId,
+        actor: AuthorId,
+    },
+}
+
+impl StashRequest {
+    pub fn is_mutation(&self) -> bool {
+        !matches!(self, Self::List)
+    }
+}
+
+/// One sealed workspace state.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct StashEntryReport {
+    pub name: RefName,
+    pub ordinal: u64,
+    pub change_id: SemanticChangeId,
+    pub message: String,
+    pub timestamp: Timestamp,
+    /// Authority target the sealed state was taken against, or `None` when it
+    /// was sealed on an unborn workspace.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub base_target: Option<RefTarget>,
+    pub tree_hash: Hash256,
+    pub file_count: usize,
+    pub entity_count: usize,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct StashListReport {
+    pub schema: String,
+    pub authority: String,
+    pub repository_id: RepositoryId,
+    pub authority_generation: u64,
+    pub workspace_id: WorkspaceId,
+    pub workspace_generation: u64,
+    pub workspace_dirty: bool,
+    pub entries: Vec<StashEntryReport>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct StashResponse {
+    #[serde(default)]
+    pub lines: Vec<String>,
+    #[serde(default)]
+    pub mutated: bool,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub report: Option<StashListReport>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub entry: Option<StashEntryReport>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub operation_id: Option<OperationId>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub authority_generation: Option<u64>,
+    #[serde(default)]
+    pub idempotent: bool,
+}
+
+/// Build the exact ref that holds stash `ordinal`.
+pub fn stash_ref_name(ordinal: u64) -> Result<RefName> {
+    let mut bytes = STASH_REF_PREFIX.to_vec();
+    bytes.extend_from_slice(ordinal.to_string().as_bytes());
+    RefName::from_bytes(bytes)
+        .map_err(|error| anyhow::anyhow!("invalid repository stash ref: {error}"))
+}
+
+/// Read the ordinal out of a stash ref, rejecting any non-canonical spelling.
+///
+/// Anything else under the namespace is not a stash this build wrote, and is
+/// never silently reinterpreted as one.
+pub fn stash_ref_ordinal(name: &RefName) -> Option<u64> {
+    let suffix = name.as_bytes().strip_prefix(STASH_REF_PREFIX)?;
+    let text = std::str::from_utf8(suffix).ok()?;
+    let ordinal: u64 = text.parse().ok()?;
+    if ordinal.to_string() != text {
+        return None;
+    }
+    Some(ordinal)
+}
+
+pub async fn list(json: bool) -> Result<()> {
+    super::capabilities::require_ready("stash")?;
+    let response = execute(StashRequest::List).await?;
+    if json {
+        let report = response
+            .report
+            .ok_or_else(|| anyhow::anyhow!("daemon stash list response omitted its report"))?;
+        println!("{}", serde_json::to_string_pretty(&report)?);
+    } else {
+        print_lines(response);
+    }
+    Ok(())
+}
+
+pub async fn push(message: Option<String>, yes: bool) -> Result<()> {
+    super::capabilities::require_ready("stash")?;
+    if !yes {
+        confirm_workspace_reset()?;
+    }
+    let response = execute(StashRequest::Push {
+        message,
+        operation_id: OperationId::new(),
+        timestamp: Timestamp::now(),
+        actor: AuthorId::new(kin_core::whoami()),
+    })
+    .await?;
+    print_lines(response);
+    Ok(())
+}
+
+pub async fn pop() -> Result<()> {
+    super::capabilities::require_ready("stash")?;
+    let response = execute(StashRequest::Pop {
+        operation_id: OperationId::new(),
+        actor: AuthorId::new(kin_core::whoami()),
+    })
+    .await?;
+    print_lines(response);
+    Ok(())
+}
+
+/// Require a typed confirmation before the workspace returns to its base.
+///
+/// Sealing is durable before anything is discarded, so the working files stay
+/// recoverable through `kin stash pop`. The confirmation still exists because
+/// the projected files do disappear, and that must never happen silently from
+/// an unattended stdin that happens to be closed.
+fn confirm_workspace_reset() -> Result<()> {
+    use std::io::{BufRead, IsTerminal, Write};
+
+    let stdin = std::io::stdin();
+    if !stdin.is_terminal() {
+        bail!(
+            "returning the workspace to its base after sealing discards the projected working \
+             files; pass --yes to confirm non-interactively"
+        );
+    }
+    print!("Return the workspace to its base after sealing? Type \"remove\" to confirm: ");
+    std::io::stdout().flush()?;
+    let mut answer = String::new();
+    stdin.lock().read_line(&mut answer)?;
+    if answer.trim() != "remove" {
+        bail!("workspace reset not confirmed; nothing was sealed or changed");
+    }
+    Ok(())
+}
+
+async fn execute(request: StashRequest) -> Result<StashResponse> {
+    let layout = kin_core::KinLayout::discover(&std::env::current_dir()?).ok_or_else(|| {
+        anyhow::anyhow!(
+            "not a Kin repository (no .kin/ found)\nhint: run `kin init .` to initialize a Kin repository here"
+        )
+    })?;
+    let daemon_url = crate::daemon_client::resolve_daemon_url(&layout)
+        .await?
+        .ok_or_else(|| {
+            anyhow::anyhow!(
+                "Kin daemon is required for stash operations but no daemon endpoint is available"
+            )
+        })?;
+    let daemon = crate::daemon_client::DaemonClient::from_base_url_for_layout(daemon_url, &layout)?;
+    daemon.stash(&request).await
+}
+
+fn print_lines(response: StashResponse) {
+    for line in response.lines {
+        println!("{line}");
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn stash_ref_names_round_trip_only_through_canonical_ordinals() {
+        for ordinal in [0_u64, 1, 9, 10, u64::MAX] {
+            let name = stash_ref_name(ordinal).unwrap();
+            assert_eq!(stash_ref_ordinal(&name), Some(ordinal));
+        }
+        assert_eq!(
+            stash_ref_name(3).unwrap().as_bytes(),
+            b"refs/kin/stash/3".as_slice()
+        );
+        for foreign in [
+            "refs/kin/stash/03",
+            "refs/kin/stash/+1",
+            "refs/kin/stash/1/2",
+            "refs/kin/stash/latest",
+            "refs/heads/main",
+            "refs/kin/stashes/1",
+        ] {
+            let name = RefName::from_utf8(foreign).unwrap();
+            assert_eq!(stash_ref_ordinal(&name), None, "{foreign}");
+        }
+    }
+}

--- a/crates/kin-cli/src/daemon_client.rs
+++ b/crates/kin-cli/src/daemon_client.rs
@@ -1215,6 +1215,18 @@ impl DaemonClient {
         .await
     }
 
+    pub async fn stash(
+        &self,
+        request: &crate::commands::stash::StashRequest,
+    ) -> Result<crate::commands::stash::StashResponse> {
+        self.post_idempotent_json(
+            "/commands/stash",
+            request,
+            "send daemon-owned repository stash request",
+        )
+        .await
+    }
+
     pub async fn checkout(
         &self,
         request: &crate::commands::checkout::CheckoutRequest,

--- a/crates/kin-cli/src/main.rs
+++ b/crates/kin-cli/src/main.rs
@@ -483,7 +483,7 @@ enum Command {
         #[arg(long)]
         abort: bool,
     },
-    /// [OPEN GATE] Stash exact repository-v6 workspace state
+    /// [OPEN GATE] Seal and restore exact graph-owned workspace state
     Stash {
         #[command(subcommand)]
         action: StashAction,
@@ -1472,20 +1472,24 @@ enum AssistantAction {
 
 #[derive(Subcommand)]
 enum StashAction {
-    /// [OPEN GATE] Snapshot exact repository-v6 workspace state.
+    /// [OPEN GATE] Seal exact graph-owned workspace state and return the workspace to its base.
     Push {
-        /// DESTRUCTIVE: delete source files from the working tree after
-        /// snapshotting. Requires typing "remove" to confirm (or --yes).
-        #[arg(long)]
-        remove_from_tree: bool,
-        /// Skip typed confirmation for --remove-from-tree (for non-interactive use).
+        /// Label the sealed state. Defaults to the workspace head it was sealed on.
+        #[arg(long, short = 'm')]
+        message: Option<String>,
+        /// Skip the typed confirmation for discarding the projected working
+        /// files (for non-interactive use).
         #[arg(long)]
         yes: bool,
     },
-    /// [OPEN GATE] Restore the most recent exact stash transaction
+    /// [OPEN GATE] Restore the most recently sealed workspace state and drop its stash
     Pop,
-    /// [OPEN GATE] List repository-v6 stash transactions
-    List,
+    /// [OPEN GATE] List sealed workspace states
+    List {
+        /// Output the machine-readable stash report
+        #[arg(long)]
+        json: bool,
+    },
 }
 
 #[derive(Subcommand)]
@@ -2463,7 +2467,11 @@ fn main() -> Result<()> {
                 }
                 Command::Conflicts => commands::capabilities::require_ready("conflicts"),
                 Command::Resolve { .. } => commands::capabilities::require_ready("resolve"),
-                Command::Stash { action: _ } => commands::capabilities::require_ready("stash"),
+                Command::Stash { action } => match action {
+                    StashAction::Push { message, yes } => commands::stash::push(message, yes).await,
+                    StashAction::Pop => commands::stash::pop().await,
+                    StashAction::List { json } => commands::stash::list(json).await,
+                },
                 Command::Blame { entity, reference } => {
                     commands::blame::run(entity, reference).await
                 }

--- a/crates/kin-cli/tests/command_capabilities.rs
+++ b/crates/kin-cli/tests/command_capabilities.rs
@@ -40,7 +40,7 @@ fn capability_json_keeps_the_bounded_dogfood_bar_explicit() {
     assert_eq!(report["bounded_dogfood_required_ready"], 12);
     assert_eq!(report["bounded_dogfood_required_total"], 12);
     assert_eq!(report["full_git_replacement_ready"], false);
-    assert_eq!(report["ready_commands"], 16);
+    assert_eq!(report["ready_commands"], 17);
     assert_eq!(report["command_total"], 32);
 
     let commands = report["commands"]

--- a/crates/kin-cli/tests/fixtures/git-replacement-capabilities-v1.json
+++ b/crates/kin-cli/tests/fixtures/git-replacement-capabilities-v1.json
@@ -310,8 +310,14 @@
       "acceptance_spec": [
         "persist and restore exact graph-owned workspace state without branch sidecars or raw-file inference"
       ],
-      "evidence_tests": [],
-      "note": "The old stash path updates the removed .kin/HEAD branch marker."
+      "evidence_tests": [
+        "kin_daemon::api::tests::command_stash_seals_restores_and_round_trips_exact_workspace_state",
+        "kin_daemon::api::tests::command_stash_refuses_restore_onto_moved_authority",
+        "kin_daemon::api::tests::command_stash_refuses_sealing_a_clean_workspace_and_restoring_over_a_dirty_one",
+        "kin_daemon::api::tests::command_stash_leaves_ready_commands_working_on_the_returned_workspace",
+        "kin_cli::commands::stash::tests::stash_ref_names_round_trip_only_through_canonical_ordinals"
+      ],
+      "note": "The graph-owned path exists and is covered: sealing writes the exact workspace tree and base-relative semantics as one immutable change under refs/kin/stash/, and restore refuses a moved authority base rather than rebasing onto it. It stays fail-closed because against a live daemon a seal can leave the daemon query graph disagreeing with workspace authority, so the next ready command refuses until the daemon reopens. In-process route coverage does not reproduce it; the background daemon loop is the missing variable."
     },
     {
       "command": "reconcile",
@@ -370,7 +376,7 @@
         "apply exact workspace tree and semantic deltas through one repository transaction"
       ],
       "evidence_tests": [],
-      "note": "The old planner read .kin/objects and working-tree files."
+      "note": "kin rename has no planner: the retired one read .kin/objects and working-tree files, and nothing reads bodies from repository-v6 source CAS in its place. There is also no apply path that moves the workspace tree and semantic deltas through one repository transaction."
     },
     {
       "command": "remote plan-push",

--- a/crates/kin-daemon/src/api.rs
+++ b/crates/kin-daemon/src/api.rs
@@ -867,6 +867,7 @@ fn api_routes() -> Router<Arc<DaemonState>> {
         .route("/commands/branch", post(command_branch))
         .route("/commands/merge", post(command_merge))
         .route("/commands/checkout", post(command_checkout))
+        .route("/commands/stash", post(command_stash))
         .route("/commands/rename", post(command_rename))
         .route(
             "/commands/session-workspace",
@@ -2605,6 +2606,60 @@ async fn command_merge(
 
     let _coordination = state.coordination_gate.lock().await;
     let response = crate::repository_merge::execute(&state, &request)?;
+    Ok(Json(response))
+}
+
+/// POST /commands/stash: seal, list, or restore exact workspace state.
+async fn command_stash(
+    headers: axum::http::HeaderMap,
+    State(state): State<Arc<DaemonState>>,
+    Json(request): Json<kin_cli::commands::stash::StashRequest>,
+) -> Result<impl IntoResponse, (StatusCode, String)> {
+    if !state
+        .is_initialized
+        .load(std::sync::atomic::Ordering::Relaxed)
+    {
+        return Err((
+            StatusCode::SERVICE_UNAVAILABLE,
+            "daemon not fully initialized".to_string(),
+        ));
+    }
+    if state.storage_backend.is_some() {
+        return Err((
+            StatusCode::CONFLICT,
+            "local repository stash authority is unavailable for hosted snapshot authority"
+                .to_string(),
+        ));
+    }
+    if extract_session_id_from_headers(&headers)?.is_some() {
+        return Err((
+            StatusCode::CONFLICT,
+            "stash commands do not accept X-Kin-Session because they seal and restore the primary \
+             repository workspace"
+                .to_string(),
+        ));
+    }
+
+    if !request.is_mutation() {
+        return Ok(Json(crate::repository_stash::execute(&state, &request)?));
+    }
+    if state.filesystem_reconcile_disabled() {
+        return Err(filesystem_ingest_disabled_response(
+            "/commands/stash",
+            &state.layout.working_dir().display().to_string(),
+        ));
+    }
+
+    // Seal and restore both decide against the exact workspace the host
+    // actually holds, so the complete-scan admission runs first under the same
+    // uninterrupted coordination gate. Without it a stash would seal whatever
+    // authority happened to hold, and a restore would judge "is this workspace
+    // clean" against a stale answer.
+    let _coordination = state.coordination_gate.lock().await;
+    crate::loop_runner::sync_filesystem_with_graph_under_coordination(&state)
+        .await
+        .map_err(internal_error)?;
+    let response = crate::repository_stash::execute(&state, &request)?;
     Ok(Json(response))
 }
 
@@ -12191,6 +12246,312 @@ mod tests {
                 "{mode}"
             );
         }
+    }
+
+    #[cfg(unix)]
+    async fn post_stash_request(
+        state: Arc<DaemonState>,
+        request: &kin_cli::commands::stash::StashRequest,
+    ) -> (StatusCode, Vec<u8>) {
+        let response = router(state)
+            .oneshot(
+                Request::post("/commands/stash")
+                    .header("content-type", "application/json")
+                    .body(Body::from(serde_json::to_vec(request).unwrap()))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        let status = response.status();
+        let body = axum::body::to_bytes(response.into_body(), 256 * 1024)
+            .await
+            .unwrap();
+        (status, body.to_vec())
+    }
+
+    #[cfg(unix)]
+    fn stash_push() -> kin_cli::commands::stash::StashRequest {
+        kin_cli::commands::stash::StashRequest::Push {
+            message: Some("sealed workspace under test".to_string()),
+            operation_id: kin_model::OperationId::new(),
+            timestamp: kin_model::Timestamp::now(),
+            actor: AuthorId::new("stash-route-test"),
+        }
+    }
+
+    #[cfg(unix)]
+    fn stash_pop() -> kin_cli::commands::stash::StashRequest {
+        kin_cli::commands::stash::StashRequest::Pop {
+            operation_id: kin_model::OperationId::new(),
+            actor: AuthorId::new("stash-route-test"),
+        }
+    }
+
+    #[cfg(unix)]
+    async fn stash_entries(
+        state: Arc<DaemonState>,
+    ) -> Vec<kin_cli::commands::stash::StashEntryReport> {
+        let (status, body) =
+            post_stash_request(state, &kin_cli::commands::stash::StashRequest::List).await;
+        assert_eq!(status, StatusCode::OK, "{}", String::from_utf8_lossy(&body));
+        let response: kin_cli::commands::stash::StashResponse =
+            serde_json::from_slice(&body).unwrap();
+        response
+            .report
+            .expect("stash list carries its report")
+            .entries
+    }
+
+    /// A sealed workspace state must restore byte-exactly onto the base it was
+    /// sealed against, including content no language adapter understands.
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn command_stash_seals_restores_and_round_trips_exact_workspace_state() {
+        let (state, _layout, repository, main_change, _feature) =
+            universal_branch_test_state("stash-round-trip");
+
+        let base_compose = std::fs::read(repository.join("selected/compose.yaml")).unwrap();
+        std::fs::write(
+            repository.join("selected/compose.yaml"),
+            b"services:\n  api:\n    image: dirty\n",
+        )
+        .unwrap();
+        std::fs::write(
+            repository.join("selected/scratch.mystery"),
+            [0x00_u8, 0xfe, 0x7f, 0x41],
+        )
+        .unwrap();
+        let dirty_compose = std::fs::read(repository.join("selected/compose.yaml")).unwrap();
+        let dirty_scratch = std::fs::read(repository.join("selected/scratch.mystery")).unwrap();
+        assert_ne!(dirty_compose, base_compose);
+
+        let (status, body) = post_stash_request(Arc::clone(&state), &stash_push()).await;
+        assert_eq!(status, StatusCode::OK, "{}", String::from_utf8_lossy(&body));
+        let sealed: kin_cli::commands::stash::StashResponse =
+            serde_json::from_slice(&body).unwrap();
+        let entry = sealed.entry.expect("seal reports the sealed stash");
+        assert_eq!(entry.ordinal, 0);
+        assert_eq!(
+            entry.name,
+            kin_model::RefName::from_utf8("refs/kin/stash/0").unwrap()
+        );
+        assert_eq!(
+            entry.base_target,
+            Some(kin_model::RefTarget::change(main_change)),
+            "a sealed state names the exact authority target it was taken against"
+        );
+
+        assert_eq!(
+            std::fs::read(repository.join("selected/compose.yaml")).unwrap(),
+            base_compose,
+            "sealing with a reset returns tracked bytes to their authority base"
+        );
+        assert!(
+            !repository.join("selected/scratch.mystery").exists(),
+            "sealing with a reset removes members the base tree does not hold"
+        );
+        let authority = ActiveApiRepositoryAuthority::open(&state).unwrap();
+        let lease = authority.manager.read_authority();
+        let workspace = lease
+            .metadata()
+            .workspaces
+            .iter()
+            .find(|workspace| workspace.workspace_id == authority.workspace_id)
+            .unwrap()
+            .clone();
+        assert!(
+            !workspace.is_dirty(),
+            "the workspace is clean in graph-owned authority after a reset seal"
+        );
+        assert!(
+            !lease
+                .metadata()
+                .ref_state
+                .refs
+                .iter()
+                .any(|repository_ref| repository_ref.name.is_branch()
+                    && repository_ref.name == entry.name),
+            "a stash is never published as a branch"
+        );
+        drop(lease);
+        drop(authority);
+
+        let listed = stash_entries(Arc::clone(&state)).await;
+        assert_eq!(listed.len(), 1);
+        assert_eq!(listed[0].change_id, entry.change_id);
+
+        let (status, body) = post_stash_request(Arc::clone(&state), &stash_pop()).await;
+        assert_eq!(status, StatusCode::OK, "{}", String::from_utf8_lossy(&body));
+        assert_eq!(
+            std::fs::read(repository.join("selected/compose.yaml")).unwrap(),
+            dirty_compose,
+            "restore reproduces the sealed bytes exactly"
+        );
+        assert_eq!(
+            std::fs::read(repository.join("selected/scratch.mystery")).unwrap(),
+            dirty_scratch,
+            "restore reproduces sealed content no adapter understands"
+        );
+        assert!(
+            stash_entries(Arc::clone(&state)).await.is_empty(),
+            "a restored stash is dropped in the same transaction that restored it"
+        );
+        let authority = ActiveApiRepositoryAuthority::open(&state).unwrap();
+        let lease = authority.manager.read_authority();
+        let workspace = lease
+            .metadata()
+            .workspaces
+            .iter()
+            .find(|workspace| workspace.workspace_id == authority.workspace_id)
+            .unwrap()
+            .clone();
+        assert!(
+            workspace.is_dirty(),
+            "restore returns the workspace to the dirty state that was sealed"
+        );
+        assert_eq!(workspace.tree_hash, entry.tree_hash);
+    }
+
+    /// A seal must leave the daemon and repository authority agreeing, so the
+    /// ready commands still work against the workspace it returned.
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn command_stash_leaves_ready_commands_working_on_the_returned_workspace() {
+        let (state, _layout, repository, _main, _feature) =
+            universal_branch_test_state("stash-then-ready");
+        std::fs::write(
+            repository.join("selected/compose.yaml"),
+            b"services:\n  api:\n    image: dirty\n",
+        )
+        .unwrap();
+        let (status, body) = post_stash_request(Arc::clone(&state), &stash_push()).await;
+        assert_eq!(status, StatusCode::OK, "{}", String::from_utf8_lossy(&body));
+        let (status, body) = post_stash_request(Arc::clone(&state), &stash_pop()).await;
+        assert_eq!(status, StatusCode::OK, "{}", String::from_utf8_lossy(&body));
+        let (status, body) = post_stash_request(Arc::clone(&state), &stash_push()).await;
+        assert_eq!(status, StatusCode::OK, "{}", String::from_utf8_lossy(&body));
+
+        let switch = kin_cli::commands::branch::BranchRequest::Switch {
+            name: kin_model::RefName::branch(b"feature").unwrap(),
+            operation_id: kin_model::OperationId::new(),
+            actor: AuthorId::new("stash-then-ready-test"),
+        };
+        let (status, body) = post_branch_request(Arc::clone(&state), &switch, None).await;
+        assert_eq!(
+            status,
+            StatusCode::OK,
+            "a sealed and returned workspace must still switch branches: {}",
+            String::from_utf8_lossy(&body)
+        );
+    }
+
+    /// Restore must refuse a base that moved after the seal instead of
+    /// replanning the sealed state onto it.
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn command_stash_refuses_restore_onto_moved_authority() {
+        let (state, _layout, repository, _main, _feature) =
+            universal_branch_test_state("stash-moved-authority");
+        std::fs::write(
+            repository.join("selected/compose.yaml"),
+            b"services:\n  api:\n    image: dirty\n",
+        )
+        .unwrap();
+        let (status, body) = post_stash_request(Arc::clone(&state), &stash_push()).await;
+        assert_eq!(status, StatusCode::OK, "{}", String::from_utf8_lossy(&body));
+
+        std::fs::write(
+            repository.join("selected/Independent.md"),
+            b"authority moved after the seal\n",
+        )
+        .unwrap();
+        let committed = router(Arc::clone(&state))
+            .oneshot(
+                Request::post("/commands/commit")
+                    .header("content-type", "application/json")
+                    .body(Body::from(
+                        json!({
+                            "operation_id": kin_model::OperationId::new(),
+                            "timestamp": kin_model::Timestamp::now(),
+                            "message": "move authority past the sealed stash"
+                        })
+                        .to_string(),
+                    ))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(committed.status(), StatusCode::OK);
+
+        let (status, body) = post_stash_request(Arc::clone(&state), &stash_pop()).await;
+        assert_eq!(status, StatusCode::CONFLICT);
+        let message = String::from_utf8_lossy(&body);
+        assert!(
+            message.contains("does not replan a sealed workspace state onto a base it was never"),
+            "{message}"
+        );
+        assert_eq!(
+            stash_entries(Arc::clone(&state)).await.len(),
+            1,
+            "a refused restore leaves the sealed state exactly where it was"
+        );
+        assert_eq!(
+            std::fs::read(repository.join("selected/compose.yaml")).unwrap(),
+            b"services:\n  api:\n    image: main\n",
+            "a refused restore projects nothing"
+        );
+    }
+
+    /// Both directions fail closed: nothing to seal is a refusal, and a
+    /// workspace holding its own graph-owned changes is never overwritten.
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn command_stash_refuses_sealing_a_clean_workspace_and_restoring_over_a_dirty_one() {
+        let (state, _layout, repository, _main, _feature) =
+            universal_branch_test_state("stash-fail-closed");
+
+        let (status, body) = post_stash_request(Arc::clone(&state), &stash_push()).await;
+        assert_eq!(status, StatusCode::CONFLICT);
+        assert!(
+            String::from_utf8_lossy(&body).contains("no graph-owned changes to seal"),
+            "{}",
+            String::from_utf8_lossy(&body)
+        );
+
+        let (status, body) = post_stash_request(Arc::clone(&state), &stash_pop()).await;
+        assert_eq!(status, StatusCode::CONFLICT);
+        assert!(
+            String::from_utf8_lossy(&body).contains("no sealed stash to restore"),
+            "{}",
+            String::from_utf8_lossy(&body)
+        );
+
+        std::fs::write(
+            repository.join("selected/compose.yaml"),
+            b"services:\n  api:\n    image: first\n",
+        )
+        .unwrap();
+        let (status, body) = post_stash_request(Arc::clone(&state), &stash_push()).await;
+        assert_eq!(status, StatusCode::OK, "{}", String::from_utf8_lossy(&body));
+
+        std::fs::write(
+            repository.join("selected/compose.yaml"),
+            b"services:\n  api:\n    image: second\n",
+        )
+        .unwrap();
+
+        let (status, body) = post_stash_request(Arc::clone(&state), &stash_pop()).await;
+        assert_eq!(status, StatusCode::CONFLICT);
+        assert!(
+            String::from_utf8_lossy(&body).contains("holds graph-owned changes of its own"),
+            "{}",
+            String::from_utf8_lossy(&body)
+        );
+        assert_eq!(
+            stash_entries(Arc::clone(&state)).await.len(),
+            1,
+            "the refused restore left the sealed state intact"
+        );
     }
 
     #[cfg(unix)]

--- a/crates/kin-daemon/src/lib.rs
+++ b/crates/kin-daemon/src/lib.rs
@@ -126,6 +126,7 @@ mod repository_branch;
 mod repository_checkout;
 pub mod repository_commit;
 mod repository_merge;
+mod repository_stash;
 pub mod session_registry;
 pub mod state;
 pub mod supervisor;

--- a/crates/kin-daemon/src/repository_stash.rs
+++ b/crates/kin-daemon/src/repository_stash.rs
@@ -1,0 +1,1240 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Firelock, LLC
+
+//! Daemon-owned repository-v6 stashes.
+//!
+//! A stash seals the exact graph-owned workspace state, tree and base-relative
+//! semantics together, as one immutable semantic change reachable only from
+//! `refs/kin/stash/<ordinal>`. Sealing and any workspace reset cross authority
+//! in a single repository transaction, so a stash is never a marker file, a
+//! branch sidecar, or a re-read of the working tree.
+//!
+//! Restore is deliberately not a rebase. A sealed state describes one exact
+//! transition out of the authority target it was taken against; replaying it
+//! onto a target that has since moved would publish a workspace nobody
+//! observed and silently revert whatever moved authority in the meantime.
+
+use anyhow::{bail, Context, Result};
+use axum::http::StatusCode;
+use kin_cli::commands::stash::{
+    stash_ref_name, stash_ref_ordinal, StashEntryReport, StashListReport, StashRequest,
+    StashResponse, STASH_LIST_SCHEMA,
+};
+use kin_model::{
+    compute_resolved_tree_hash, compute_semantic_change_id, AuthorId, ChangeOrigin, ChangeStore,
+    EffectiveAdmissionPolicyStamp, Hash256, OperationId, RefExpectation, RefMutation, RefName,
+    RefTarget, RepositoryCommitOutcome, RepositoryCommitReceipt, RepositoryTransaction,
+    ResolvedTree, SemanticChange, SemanticChangeId, SharedAdmissionPolicy, Timestamp,
+    TransactionDelta, WorkspaceExpectation, WorkspaceMutation, WorkspaceState,
+    REPOSITORY_TRANSACTION_SCHEMA_VERSION,
+};
+
+use crate::local_repository_authority::{
+    ActiveLocalRepositoryAuthority, RepositoryAuthorityBindRefusal,
+};
+use crate::state::{DaemonEvent, DaemonState};
+
+const SEAL_REASON: &str = "seal exact graph-owned workspace state as a repository stash";
+const RESTORE_REASON: &str = "restore exact graph-owned workspace state from a repository stash";
+const RETURN_REASON: &str =
+    "return the exact graph-owned workspace to its authority base after sealing a stash";
+
+enum StashOutcome {
+    Commit(StashExecution, Option<Box<ReturnToBase>>),
+    ReadOnly(StashResponse),
+}
+
+/// Everything the workspace return needs, carried across the seal.
+///
+/// Repository authority hands each commit a freeze that the daemon must
+/// finalize before another transaction can be published, so the two exact
+/// transitions a seal performs cannot both be built up front. The seal returns
+/// this, the command loop finalizes the seal, and only then is the return
+/// planned against the authority the seal actually installed.
+struct ReturnToBase {
+    sealed_workspace: WorkspaceState,
+    base_head: kin_model::WorkspaceHead,
+    base_target: RefTarget,
+    base_tree: ResolvedTree,
+    base_entities: std::collections::HashMap<kin_model::EntityId, kin_model::Entity>,
+    base_relations: std::collections::HashMap<kin_model::RelationId, kin_model::Relation>,
+    sealed_entities: std::collections::HashMap<kin_model::EntityId, kin_model::Entity>,
+    sealed_relations: std::collections::HashMap<kin_model::RelationId, kin_model::Relation>,
+    base_policy: SharedAdmissionPolicy,
+    actor: AuthorId,
+    stash_ref: RefName,
+    entry: StashEntryReport,
+}
+
+struct StashExecution {
+    response: StashResponse,
+    receipt: RepositoryCommitReceipt,
+    authority_freeze: kin_db::LocalRepositoryAuthorityFreeze,
+    daemon_delta: TransactionDelta,
+    previous_tree: ResolvedTree,
+    desired_tree: ResolvedTree,
+    projection_changed: bool,
+}
+
+#[derive(Debug)]
+struct StashConflict(String);
+
+impl std::fmt::Display for StashConflict {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        formatter.write_str(&self.0)
+    }
+}
+
+impl std::error::Error for StashConflict {}
+
+fn stash_conflict(message: impl Into<String>) -> anyhow::Error {
+    anyhow::Error::new(StashConflict(message.into()))
+}
+
+pub(crate) fn execute(
+    state: &DaemonState,
+    request: &StashRequest,
+) -> std::result::Result<StashResponse, (StatusCode, String)> {
+    if matches!(request, StashRequest::List) {
+        let authority =
+            ActiveLocalRepositoryAuthority::open_bound(state).map_err(stash_bind_refusal)?;
+        return list(&authority).map_err(internal_stash_error);
+    }
+
+    let graph_mutation = state.begin_graph_authority_mutation();
+    let persistence = state.persist_lock.lock().map_err(|_| {
+        (
+            StatusCode::INTERNAL_SERVER_ERROR,
+            "daemon persistence lock poisoned".to_string(),
+        )
+    })?;
+    let previous_graph_root = hex::encode(state.graph.compute_root_hash());
+    let authority =
+        ActiveLocalRepositoryAuthority::open_bound(state).map_err(stash_bind_refusal)?;
+    let outcome = match request {
+        StashRequest::List => unreachable!("list returned before the mutation gates"),
+        StashRequest::Push {
+            message,
+            operation_id,
+            timestamp,
+            actor,
+        } => push(
+            state,
+            &authority,
+            message.as_deref(),
+            *operation_id,
+            timestamp.clone(),
+            actor,
+        ),
+        StashRequest::Pop {
+            operation_id,
+            actor,
+        } => pop(state, &authority, *operation_id, actor),
+    }
+    .map_err(classify_stash_error)?;
+    let (execution, follow_up) = match outcome {
+        StashOutcome::Commit(execution, follow_up) => (execution, follow_up),
+        StashOutcome::ReadOnly(response) => {
+            drop(persistence);
+            drop(graph_mutation);
+            return Ok(response);
+        }
+    };
+
+    let mut previous_graph_root = previous_graph_root;
+    let mut response = finalize(state, execution, &mut previous_graph_root)?;
+    if let Some(follow_up) = follow_up {
+        let execution =
+            return_to_base(state, &authority, *follow_up).map_err(classify_stash_error)?;
+        response = finalize(state, execution, &mut previous_graph_root)?;
+    }
+
+    drop(persistence);
+    drop(graph_mutation);
+    Ok(response)
+}
+
+/// Install one committed transition into the daemon and release its freeze.
+fn finalize(
+    state: &DaemonState,
+    execution: StashExecution,
+    previous_graph_root: &mut String,
+) -> std::result::Result<StashResponse, (StatusCode, String)> {
+    let finalization = state
+        .finalize_local_repository_commit(
+            &execution.receipt,
+            &execution.authority_freeze,
+            &execution.daemon_delta,
+            &execution.previous_tree,
+            &execution.desired_tree,
+        )
+        .map_err(repository_finalization_error)?;
+    if finalization.graph_changed {
+        let current_graph_root = hex::encode(state.graph.compute_root_hash());
+        state.bump_version();
+        state.emit_event(DaemonEvent::GraphRootChanged {
+            old_root_hash: Some(previous_graph_root.clone()),
+            new_root_hash: current_graph_root.clone(),
+        });
+        *previous_graph_root = current_graph_root;
+    } else if finalization.generation_advanced {
+        state.mark_dirty();
+    }
+    if finalization.generation_advanced {
+        state.emit_event(DaemonEvent::RepositoryAuthorityChanged {
+            repository_id: execution.receipt.repository_id.to_string(),
+            operation_id: execution.receipt.operation_id,
+            previous_generation: execution.receipt.roots_before.generation,
+            new_generation: execution.receipt.generation,
+        });
+    }
+    if execution.projection_changed && !finalization.graph_changed {
+        state.invalidate_projection();
+    }
+    Ok(execution.response)
+}
+
+fn list(authority: &ActiveLocalRepositoryAuthority) -> Result<StashResponse> {
+    let lease = authority.manager.read_authority();
+    let metadata = lease.metadata();
+    let workspace = local_workspace(authority, metadata)?.clone();
+    let sealed = metadata
+        .ref_state
+        .refs
+        .iter()
+        .filter_map(|repository_ref| {
+            stash_ref_ordinal(&repository_ref.name)
+                .map(|ordinal| (ordinal, repository_ref.name.clone(), &repository_ref.target))
+        })
+        .collect::<Vec<_>>();
+    let mut entries = Vec::with_capacity(sealed.len());
+    if !sealed.is_empty() {
+        let graph = sealed_graph(&lease)?;
+        for (ordinal, name, target) in sealed {
+            let change_id = lease
+                .resolve_target_change_id(target)
+                .with_context(|| format!("resolve exact sealed change for stash {name}"))?;
+            let change = sealed_change(&lease, &name, change_id)?;
+            let sealed_state = graph
+                .resolve_graph_at(&change_id)
+                .with_context(|| format!("resolve exact graph at sealed change {change_id}"))?;
+            entries.push(StashEntryReport {
+                name,
+                ordinal,
+                change_id,
+                message: change.message.clone(),
+                timestamp: change.timestamp,
+                base_target: change
+                    .parents
+                    .first()
+                    .map(|parent| RefTarget::change(*parent)),
+                tree_hash: compute_resolved_tree_hash(&sealed_state.tree)
+                    .context("hash the exact sealed workspace tree")?,
+                file_count: change.tree_deltas.len(),
+                entity_count: change.entity_deltas.len(),
+            });
+        }
+    }
+    entries.sort_by(|left, right| right.ordinal.cmp(&left.ordinal));
+    let report = StashListReport {
+        schema: STASH_LIST_SCHEMA.to_string(),
+        authority: "repository-v6".to_string(),
+        repository_id: authority.repository_id.clone(),
+        authority_generation: lease.roots().generation,
+        workspace_id: workspace.workspace_id,
+        workspace_generation: workspace.generation,
+        workspace_dirty: workspace.is_dirty(),
+        entries,
+    };
+    Ok(StashResponse {
+        lines: render_list(&report),
+        mutated: false,
+        report: Some(report),
+        entry: None,
+        operation_id: None,
+        authority_generation: None,
+        idempotent: false,
+    })
+}
+
+/// Seal the exact graph-owned workspace state as one immutable stash change.
+///
+/// The sealed content is read from persisted workspace authority, never from
+/// the daemon's mutable query overlay and never from a fresh host walk: what a
+/// stash promises to restore is precisely the state that already crossed
+/// admission. The live daemon graph must still agree with that authority, so
+/// unadmitted daemon state is refused rather than silently dropped from the
+/// seal.
+fn push(
+    state: &DaemonState,
+    authority: &ActiveLocalRepositoryAuthority,
+    message: Option<&str>,
+    operation_id: OperationId,
+    timestamp: Timestamp,
+    actor: &AuthorId,
+) -> Result<StashOutcome> {
+    let lease = authority.manager.read_authority();
+    if let Some(receipt) = operation_receipt(lease.metadata().receipts.as_slice(), operation_id) {
+        drop(lease);
+        return recover(authority, receipt);
+    }
+    let roots = lease.roots().clone();
+    let metadata = lease.metadata();
+    let workspace = local_workspace(authority, metadata)?.clone();
+    if !workspace.is_dirty() {
+        return Err(stash_conflict(
+            "workspace holds no graph-owned changes to seal; its exact tree and semantics already \
+             match its authority base",
+        ));
+    }
+    let parent = workspace
+        .base_target
+        .as_ref()
+        .map(|target| lease.resolve_target_change_id(target))
+        .transpose()
+        .context("resolve the exact authority target this workspace is based on")?;
+    let workspace_graph = lease
+        .workspace_graph_snapshot(&workspace.workspace_id)
+        .context("materialize exact graph-owned workspace semantics")?
+        .ok_or_else(|| {
+            anyhow::anyhow!(
+                "repository {} has no graph snapshot for workspace {}",
+                authority.repository_id,
+                workspace.workspace_id
+            )
+        })?;
+    let daemon_snapshot = state.graph.to_snapshot();
+    let daemon_entities = daemon_snapshot.entities;
+    let daemon_relations = daemon_snapshot.relations;
+    let ordinal = next_stash_ordinal(metadata)?;
+    let stash_ref = stash_ref_name(ordinal)?;
+    if lease
+        .resolve_ref_target(&stash_ref)
+        .with_context(|| format!("read repository stash ref {stash_ref}"))?
+        .is_some()
+    {
+        return Err(stash_conflict(format!(
+            "repository stash ref {stash_ref} already exists"
+        )));
+    }
+
+    let parent_policy = match parent {
+        Some(parent) => Some(resolved_admission_policy(metadata, parent)?),
+        None => None,
+    };
+    let (parent_tree, parent_entities, parent_relations) = match parent {
+        Some(parent) => {
+            let mut snapshot = lease.snapshot().clone();
+            snapshot.repository_authority = None;
+            let graph = kin_db::InMemoryGraph::from_snapshot(snapshot)
+                .context("prepare the exact stash parent graph")?;
+            let state = graph
+                .resolve_graph_at(&parent)
+                .with_context(|| format!("resolve exact graph at stash parent {parent}"))?;
+            (state.tree.clone(), state.entities, state.relations)
+        }
+        None => (
+            ResolvedTree::default(),
+            std::collections::HashMap::new(),
+            std::collections::HashMap::new(),
+        ),
+    };
+    // The sealed content is built exactly the way a native commit builds its
+    // own: from the daemon graph the admission just installed, diffed against
+    // the authority target. A stash that sealed only persisted workspace
+    // authority would quietly drop whatever the same admission enriched.
+    let sealed = crate::commit_deltas::compute_deltas_vs_repository_authority(
+        state.graph.as_ref(),
+        lease.snapshot(),
+        parent.as_ref(),
+    )
+    .context("plan the exact sealed change against the authority target")?;
+    let workspace_semantic_delta = kin_core::diff_workspace_semantics(
+        &workspace_graph.entities,
+        &workspace_graph.relations,
+        &daemon_entities,
+        &daemon_relations,
+    )
+    .context("plan the exact sealed workspace semantic transition")?;
+    let (sealed_policy, admission_policy_delta) = SharedAdmissionPolicy::derive_from_tree(
+        parent_policy.as_ref(),
+        &sealed.expected_tree,
+        |hash| repository_source_length(&authority.manager, hash),
+    )
+    .context("derive the exact admission policy for the sealed workspace tree")?;
+    let sealed_tree = sealed.expected_tree;
+    let sealed_tree_hash =
+        compute_resolved_tree_hash(&sealed_tree).context("hash the exact sealed workspace tree")?;
+    let workspace_tree_deltas = kin_core::exact_tree_correction(&workspace.tree, &sealed_tree)
+        .context("plan the exact sealed workspace tree transition")?;
+
+    let mut change = SemanticChange {
+        id: SemanticChangeId::from_hash(Hash256::from_bytes([0; 32])),
+        origin: ChangeOrigin::Native,
+        parents: parent.into_iter().collect(),
+        timestamp: timestamp.clone(),
+        author: actor.clone(),
+        message: seal_message(message, &workspace),
+        entity_deltas: sealed.entity_deltas,
+        relation_deltas: sealed.relation_deltas,
+        tree_deltas: sealed.tree_deltas,
+        admission_policy_delta,
+        projected_files: Vec::new(),
+        spec_link: None,
+        evidence: Vec::new(),
+        risk_summary: None,
+    };
+    change.id = compute_semantic_change_id(&change).context("identify the exact sealed change")?;
+    let sealed_change_id = change.id;
+    let sealed_file_count = change.tree_deltas.len();
+    let sealed_entity_count = change.entity_deltas.len();
+    let sealed_message = change.message.clone();
+    let entry = StashEntryReport {
+        name: stash_ref.clone(),
+        ordinal,
+        change_id: sealed_change_id,
+        message: sealed_message,
+        timestamp,
+        base_target: parent.map(RefTarget::change),
+        tree_hash: sealed_tree_hash,
+        file_count: sealed_file_count,
+        entity_count: sealed_entity_count,
+    };
+
+    // Repository authority binds one native admission to the workspace that
+    // publishes it: a change introducing artifacts must leave its publisher
+    // based on that exact change, so the introduced members have a workspace
+    // whose admission policy validated them. A symbolic head must equal its
+    // ref, so the publishing workspace detaches onto the sealed change without
+    // moving a single projected byte, and a second exact transition returns it
+    // to its branch base. Ordering is the safety property: the state is durable
+    // before anything is discarded, and a failure between the two leaves a
+    // clean workspace detached on the sealed change with every file still on
+    // disk, recoverable with a branch switch or kin stash pop.
+    let seal = RepositoryTransaction {
+        schema_version: REPOSITORY_TRANSACTION_SCHEMA_VERSION,
+        operation_id,
+        repository_id: authority.repository_id.clone(),
+        expected_generation: roots.generation,
+        expected_roots: roots.clone(),
+        actor: actor.clone(),
+        reason: SEAL_REASON.to_string(),
+        external_objects: Vec::new(),
+        git_authority_delta: None,
+        changes: vec![change],
+        aliases: Vec::new(),
+        ref_mutations: vec![RefMutation {
+            name: stash_ref.clone(),
+            expected: RefExpectation::MustNotExist,
+            new_target: Some(RefTarget::change(sealed_change_id)),
+            policy: kin_model::RefUpdatePolicy::FastForwardOnly,
+        }],
+        default_ref_mutation: None,
+        workspace_mutation: Some(WorkspaceMutation {
+            workspace_id: workspace.workspace_id,
+            expected: expect_exact(&workspace),
+            new_generation: workspace
+                .generation
+                .checked_add(1)
+                .ok_or_else(|| anyhow::anyhow!("workspace generation overflow"))?,
+            new_head: kin_model::WorkspaceHead::Detached {
+                target: RefTarget::change(sealed_change_id),
+            },
+            new_base_target: Some(RefTarget::change(sealed_change_id)),
+            new_base_tree_hash: Some(sealed_tree_hash),
+            tree_deltas: workspace_tree_deltas,
+            new_tree_hash: sealed_tree_hash,
+            semantic_delta: workspace_semantic_delta,
+            new_shared_admission_policy: sealed_policy.clone(),
+            new_admission_policy: EffectiveAdmissionPolicyStamp {
+                shared: sealed_policy.stamp(),
+                local: workspace.admission_policy.local,
+            },
+        }),
+        local_overlay_delta: None,
+    };
+    seal.validate()
+        .context("validate the exact stash seal transaction")?;
+    let sealed_workspace = WorkspaceState::new(
+        workspace.repository_id.clone(),
+        workspace.workspace_id,
+        workspace.generation + 1,
+        kin_model::WorkspaceHead::Detached {
+            target: RefTarget::change(sealed_change_id),
+        },
+        Some(RefTarget::change(sealed_change_id)),
+        Some(sealed_tree_hash),
+        sealed_tree.clone(),
+        kin_model::WorkspaceSemanticOverlay::default(),
+        sealed_policy.clone(),
+        EffectiveAdmissionPolicyStamp {
+            shared: sealed_policy.stamp(),
+            local: workspace.admission_policy.local,
+        },
+    )
+    .context("derive the exact workspace state the seal installs")?;
+    drop(lease);
+
+    require_sealed_sources_in_repository_cas(&authority.manager, &sealed_policy, &seal)?;
+    let (sealed_receipt, sealed_freeze) = authority
+        .manager
+        .commit_repository_transaction_and_freeze(seal)
+        .context("seal a repository stash")?;
+    sealed_receipt
+        .validate()
+        .context("validate the sealed stash receipt")?;
+    let seal_execution = StashExecution {
+        response: StashResponse {
+            lines: vec![format!(
+                "Sealed {} at change {} ({} file(s), {} entity delta(s), authority generation {})",
+                stash_ref,
+                sealed_change_id,
+                sealed_file_count,
+                sealed_entity_count,
+                sealed_receipt.generation
+            )],
+            mutated: matches!(sealed_receipt.outcome, RepositoryCommitOutcome::Committed),
+            report: None,
+            entry: Some(entry.clone()),
+            operation_id: Some(sealed_receipt.operation_id),
+            authority_generation: Some(sealed_receipt.generation),
+            idempotent: false,
+        },
+        receipt: sealed_receipt,
+        authority_freeze: sealed_freeze,
+        // The seal publishes the graph the daemon already holds, so it moves
+        // persisted authority without moving the daemon's own view.
+        daemon_delta: TransactionDelta::default(),
+        previous_tree: workspace.tree.clone(),
+        desired_tree: sealed_tree.clone(),
+        projection_changed: false,
+    };
+    let base_target = workspace.base_target.clone().ok_or_else(|| {
+        stash_conflict("an unborn workspace has no authority base to return to after sealing")
+    })?;
+    let base_policy = parent_policy.ok_or_else(|| {
+        stash_conflict("an unborn workspace has no admission policy to return to after sealing")
+    })?;
+    Ok(StashOutcome::Commit(
+        seal_execution,
+        Some(Box::new(ReturnToBase {
+            sealed_workspace,
+            base_head: workspace.head,
+            base_target,
+            base_tree: parent_tree,
+            base_entities: parent_entities,
+            base_relations: parent_relations,
+            sealed_entities: daemon_entities,
+            sealed_relations: daemon_relations,
+            base_policy,
+            actor: actor.clone(),
+            stash_ref,
+            entry,
+        })),
+    ))
+}
+
+/// Return the sealed workspace to the branch base it was taken from.
+///
+/// This runs only after the seal is durable and finalized, so a failure here
+/// discards nothing: the workspace is left clean and detached on the sealed
+/// change with every file still projected, recoverable with a branch switch.
+fn return_to_base(
+    state: &DaemonState,
+    authority: &ActiveLocalRepositoryAuthority,
+    plan: ReturnToBase,
+) -> Result<StashExecution> {
+    let lease = authority.manager.read_authority();
+    let roots = lease.roots().clone();
+    drop(lease);
+    let base_tree_hash = compute_resolved_tree_hash(&plan.base_tree)
+        .context("hash the exact authority base tree")?;
+    let tree_deltas = kin_core::exact_tree_correction(&plan.sealed_workspace.tree, &plan.base_tree)
+        .context("plan the exact workspace return tree transition")?;
+    let semantic_delta = kin_core::diff_workspace_semantics(
+        &plan.sealed_entities,
+        &plan.sealed_relations,
+        &plan.base_entities,
+        &plan.base_relations,
+    )
+    .context("plan the exact workspace return semantic transition")?;
+    let daemon_snapshot = state.graph.to_snapshot();
+    let daemon_semantic_delta = kin_core::diff_workspace_semantics(
+        &daemon_snapshot.entities,
+        &daemon_snapshot.relations,
+        &plan.base_entities,
+        &plan.base_relations,
+    )
+    .context("plan the exact workspace return transition for the daemon view")?;
+    let daemon_delta = TransactionDelta {
+        entity_deltas: daemon_semantic_delta.entity_deltas().to_vec(),
+        relation_deltas: daemon_semantic_delta.relation_deltas().to_vec(),
+        tree_deltas: kin_core::exact_tree_correction(
+            &daemon_snapshot.resolved_tree,
+            &plan.base_tree,
+        )
+        .context("plan the exact workspace return tree transition for the daemon view")?,
+        admission_policy_delta: None,
+    };
+    let transaction = RepositoryTransaction {
+        schema_version: REPOSITORY_TRANSACTION_SCHEMA_VERSION,
+        operation_id: OperationId::new(),
+        repository_id: authority.repository_id.clone(),
+        expected_generation: roots.generation,
+        expected_roots: roots,
+        actor: plan.actor.clone(),
+        reason: RETURN_REASON.to_string(),
+        external_objects: Vec::new(),
+        git_authority_delta: None,
+        changes: Vec::new(),
+        aliases: Vec::new(),
+        ref_mutations: Vec::new(),
+        default_ref_mutation: None,
+        workspace_mutation: Some(WorkspaceMutation {
+            workspace_id: plan.sealed_workspace.workspace_id,
+            expected: expect_exact(&plan.sealed_workspace),
+            new_generation: plan
+                .sealed_workspace
+                .generation
+                .checked_add(1)
+                .ok_or_else(|| anyhow::anyhow!("workspace generation overflow"))?,
+            new_head: plan.base_head,
+            new_base_target: Some(plan.base_target),
+            new_base_tree_hash: Some(base_tree_hash),
+            tree_deltas,
+            new_tree_hash: base_tree_hash,
+            semantic_delta,
+            new_shared_admission_policy: plan.base_policy.clone(),
+            new_admission_policy: EffectiveAdmissionPolicyStamp {
+                shared: plan.base_policy.stamp(),
+                local: plan.sealed_workspace.admission_policy.local,
+            },
+        }),
+        local_overlay_delta: None,
+    };
+    transaction
+        .validate()
+        .context("validate the exact workspace return transaction")?;
+    let drift = kin_core::report_repository_workspace_projection_drift(
+        state.layout.working_dir(),
+        &plan.sealed_workspace.tree,
+        &authority.manager,
+    )
+    .context("validate the exact workspace projection before returning it to its base")?;
+    if let Some(first) = drift.first() {
+        return Err(kin_core::KinError::ProjectionConflict(format!(
+            "{first}; {} tracked path(s) diverge from the graph-owned workspace projection; the \
+             workspace state is already sealed as {}",
+            drift.len(),
+            plan.stash_ref
+        ))
+        .into());
+    }
+    let (materialized, receipt, authority_freeze) =
+        kin_core::tree::transition_repository_workspace_tree_and_commit_repository_transaction(
+            state.layout.working_dir(),
+            &plan.sealed_workspace.tree,
+            &plan.base_tree,
+            &authority.manager,
+            transaction,
+        )
+        .with_context(|| {
+            format!(
+                "return the workspace to its authority base after sealing {}; the state is \
+                 already sealed and can be restored with kin stash pop",
+                plan.stash_ref
+            )
+        })?;
+    receipt
+        .validate()
+        .context("validate the workspace-return receipt")?;
+    Ok(StashExecution {
+        response: StashResponse {
+            lines: vec![
+                format!(
+                    "Sealed {} at change {} ({} file(s), {} entity delta(s))",
+                    plan.stash_ref,
+                    plan.entry.change_id,
+                    plan.entry.file_count,
+                    plan.entry.entity_count
+                ),
+                format!(
+                    "Workspace returned to its authority base ({} projected entries, authority \
+                     generation {})",
+                    materialized, receipt.generation
+                ),
+            ],
+            mutated: matches!(receipt.outcome, RepositoryCommitOutcome::Committed),
+            report: None,
+            entry: Some(plan.entry),
+            operation_id: Some(receipt.operation_id),
+            authority_generation: Some(receipt.generation),
+            idempotent: false,
+        },
+        receipt,
+        authority_freeze,
+        daemon_delta,
+        previous_tree: plan.sealed_workspace.tree,
+        desired_tree: plan.base_tree,
+        projection_changed: true,
+    })
+}
+
+/// Restore the most recently sealed workspace state and drop its stash ref.
+///
+/// The restore refuses unless the workspace is clean and still based on the
+/// exact authority target the stash was sealed against. Both refusals exist for
+/// the same reason: a sealed state is a transition out of one observed base,
+/// and no other base makes its tree or its semantics mean what they meant.
+fn pop(
+    state: &DaemonState,
+    authority: &ActiveLocalRepositoryAuthority,
+    operation_id: OperationId,
+    actor: &AuthorId,
+) -> Result<StashOutcome> {
+    let lease = authority.manager.read_authority();
+    if let Some(receipt) = operation_receipt(lease.metadata().receipts.as_slice(), operation_id) {
+        drop(lease);
+        return recover(authority, receipt);
+    }
+    let roots = lease.roots().clone();
+    let metadata = lease.metadata();
+    let workspace = local_workspace(authority, metadata)?.clone();
+    let (ordinal, stash_ref, stash_target) = latest_stash(metadata)
+        .ok_or_else(|| stash_conflict("repository holds no sealed stash to restore"))?;
+    let sealed_change_id = lease
+        .resolve_target_change_id(&stash_target)
+        .with_context(|| format!("resolve exact sealed change for stash {stash_ref}"))?;
+    let sealed_change = sealed_change(&lease, &stash_ref, sealed_change_id)?;
+
+    if workspace.is_dirty() {
+        return Err(stash_conflict(format!(
+            "workspace {} holds graph-owned changes of its own; restoring {stash_ref} over them \
+             would discard state no stash sealed. Seal or discard the current workspace first",
+            workspace.workspace_id
+        )));
+    }
+    let current_base = workspace
+        .base_target
+        .as_ref()
+        .map(|target| lease.resolve_target_change_id(target))
+        .transpose()
+        .context("resolve the exact authority target this workspace is based on")?;
+    let sealed_base = sealed_change.parents.first().copied();
+    if current_base != sealed_base {
+        return Err(stash_conflict(format!(
+            "{stash_ref} was sealed against {}, but this workspace is now based on {}; exact \
+             restore does not replan a sealed workspace state onto a base it was never observed \
+             against",
+            render_base(sealed_base),
+            render_base(current_base)
+        )));
+    }
+    let workspace_graph = lease
+        .workspace_graph_snapshot(&workspace.workspace_id)
+        .context("materialize exact graph-owned workspace semantics")?
+        .ok_or_else(|| {
+            anyhow::anyhow!(
+                "repository {} has no graph snapshot for workspace {}",
+                authority.repository_id,
+                workspace.workspace_id
+            )
+        })?;
+    let mut snapshot = lease.snapshot().clone();
+    snapshot.repository_authority = None;
+    drop(lease);
+    let graph = kin_db::InMemoryGraph::from_snapshot(snapshot)
+        .context("prepare the exact sealed workspace graph")?;
+    let sealed_state = graph
+        .resolve_graph_at(&sealed_change_id)
+        .with_context(|| format!("resolve exact graph at sealed change {sealed_change_id}"))?;
+    let sealed_tree = sealed_state.tree.clone();
+    let sealed_tree_hash =
+        compute_resolved_tree_hash(&sealed_tree).context("hash the exact sealed workspace tree")?;
+    let sealed_policy = {
+        let lease = authority.manager.read_authority();
+        resolved_admission_policy(lease.metadata(), sealed_change_id)?
+    };
+    let tree_deltas = kin_core::exact_tree_correction(&workspace.tree, &sealed_tree)
+        .context("plan the exact stash restore tree transition")?;
+    let semantic_delta = kin_core::diff_workspace_semantics(
+        &workspace_graph.entities,
+        &workspace_graph.relations,
+        &sealed_state.entities,
+        &sealed_state.relations,
+    )
+    .context("plan the exact stash restore semantic transition")?;
+    let daemon_snapshot = state.graph.to_snapshot();
+    let daemon_semantic_delta = kin_core::diff_workspace_semantics(
+        &daemon_snapshot.entities,
+        &daemon_snapshot.relations,
+        &sealed_state.entities,
+        &sealed_state.relations,
+    )
+    .context("plan the exact stash restore transition for the daemon view")?;
+    let daemon_delta = TransactionDelta {
+        entity_deltas: daemon_semantic_delta.entity_deltas().to_vec(),
+        relation_deltas: daemon_semantic_delta.relation_deltas().to_vec(),
+        tree_deltas: kin_core::exact_tree_correction(&daemon_snapshot.resolved_tree, &sealed_tree)
+            .context("plan the exact stash restore tree transition for the daemon view")?,
+        admission_policy_delta: None,
+    };
+    let transaction = RepositoryTransaction {
+        schema_version: REPOSITORY_TRANSACTION_SCHEMA_VERSION,
+        operation_id,
+        repository_id: authority.repository_id.clone(),
+        expected_generation: roots.generation,
+        expected_roots: roots,
+        actor: actor.clone(),
+        reason: RESTORE_REASON.to_string(),
+        external_objects: Vec::new(),
+        git_authority_delta: None,
+        changes: Vec::new(),
+        aliases: Vec::new(),
+        ref_mutations: vec![RefMutation {
+            name: stash_ref.clone(),
+            expected: RefExpectation::MustEqual {
+                target: stash_target,
+            },
+            new_target: None,
+            policy: kin_model::RefUpdatePolicy::ForceWithLease,
+        }],
+        default_ref_mutation: None,
+        workspace_mutation: Some(WorkspaceMutation {
+            workspace_id: workspace.workspace_id,
+            expected: expect_exact(&workspace),
+            new_generation: workspace
+                .generation
+                .checked_add(1)
+                .ok_or_else(|| anyhow::anyhow!("workspace generation overflow"))?,
+            new_head: workspace.head.clone(),
+            new_base_target: workspace.base_target.clone(),
+            new_base_tree_hash: workspace.base_tree_hash,
+            tree_deltas,
+            new_tree_hash: sealed_tree_hash,
+            semantic_delta,
+            new_shared_admission_policy: sealed_policy.clone(),
+            new_admission_policy: EffectiveAdmissionPolicyStamp {
+                shared: sealed_policy.stamp(),
+                local: workspace.admission_policy.local,
+            },
+        }),
+        local_overlay_delta: None,
+    };
+    transaction
+        .validate()
+        .context("validate the exact stash restore transaction")?;
+
+    let drift = kin_core::report_repository_workspace_projection_drift(
+        state.layout.working_dir(),
+        &workspace.tree,
+        &authority.manager,
+    )
+    .context("validate the exact workspace projection before restoring a stash")?;
+    if let Some(first) = drift.first() {
+        return Err(kin_core::KinError::ProjectionConflict(format!(
+            "{first}; {} tracked path(s) diverge from the graph-owned workspace projection; \
+             reconcile them into graph authority before restoring a stash",
+            drift.len()
+        ))
+        .into());
+    }
+    let previous_tree = workspace.tree.clone();
+    let (materialized, receipt, authority_freeze) =
+        kin_core::tree::transition_repository_workspace_tree_and_commit_repository_transaction(
+            state.layout.working_dir(),
+            &previous_tree,
+            &sealed_tree,
+            &authority.manager,
+            transaction,
+        )
+        .with_context(|| format!("restore repository stash {stash_ref}"))?;
+    receipt
+        .validate()
+        .context("validate the restored stash receipt")?;
+
+    Ok(StashOutcome::Commit(
+        StashExecution {
+            response: StashResponse {
+                lines: vec![format!(
+                    "Restored {} from change {} ({} projected entries, authority generation {})",
+                    stash_ref, sealed_change_id, materialized, receipt.generation
+                )],
+                mutated: matches!(receipt.outcome, RepositoryCommitOutcome::Committed),
+                report: None,
+                entry: Some(StashEntryReport {
+                    name: stash_ref,
+                    ordinal,
+                    change_id: sealed_change_id,
+                    message: sealed_change.message,
+                    timestamp: sealed_change.timestamp,
+                    base_target: sealed_base.map(RefTarget::change),
+                    tree_hash: sealed_tree_hash,
+                    file_count: sealed_change.tree_deltas.len(),
+                    entity_count: sealed_change.entity_deltas.len(),
+                }),
+                operation_id: Some(receipt.operation_id),
+                authority_generation: Some(receipt.generation),
+                idempotent: matches!(receipt.outcome, RepositoryCommitOutcome::IdempotentReplay),
+            },
+            receipt,
+            authority_freeze,
+            daemon_delta,
+            previous_tree,
+            desired_tree: sealed_tree,
+            projection_changed: true,
+        },
+        None,
+    ))
+}
+
+/// Answer a caller-stable operation whose exact effect already crossed
+/// authority.
+///
+/// A sealed stash is carried by an immutable change, and the persisted
+/// operation record deliberately does not retain history payloads, so the
+/// original transaction cannot be rebuilt byte-identically from it. Rather than
+/// approximate one, this reports the durable effect that is already installed.
+/// Nothing is replanned, so a retry can never seal a second stash or restore
+/// onto authority that has since moved.
+fn recover(
+    authority: &ActiveLocalRepositoryAuthority,
+    receipt: RepositoryCommitReceipt,
+) -> Result<StashOutcome> {
+    receipt
+        .validate()
+        .context("validate the persisted stash receipt")?;
+    let lease = authority.manager.read_authority();
+    if lease.roots() != &receipt.roots_after {
+        return Err(stash_conflict(format!(
+            "stash operation {} committed at repository generation {}, but authority is now at \
+             generation {}; reopen against current authority before retrying",
+            receipt.operation_id,
+            receipt.generation,
+            lease.roots().generation
+        )));
+    }
+    let mutation = receipt
+        .operation
+        .ref_mutations
+        .first()
+        .ok_or_else(|| {
+            anyhow::anyhow!(
+                "stash operation {} has no repository ref effect",
+                receipt.operation_id
+            )
+        })?
+        .clone();
+    let ordinal = stash_ref_ordinal(&mutation.name).ok_or_else(|| {
+        anyhow::anyhow!(
+            "operation {} is not a stash operation: it mutated {}",
+            receipt.operation_id,
+            mutation.name
+        )
+    })?;
+    let entry = match mutation.new_target {
+        Some(target) => {
+            let change_id = lease.resolve_target_change_id(&target).with_context(|| {
+                format!("resolve exact sealed change for stash {}", mutation.name)
+            })?;
+            let change = sealed_change(&lease, &mutation.name, change_id)?;
+            let graph = sealed_graph(&lease)?;
+            let sealed_state = graph
+                .resolve_graph_at(&change_id)
+                .with_context(|| format!("resolve exact graph at sealed change {change_id}"))?;
+            Some(StashEntryReport {
+                name: mutation.name.clone(),
+                ordinal,
+                change_id,
+                message: change.message.clone(),
+                timestamp: change.timestamp,
+                base_target: change
+                    .parents
+                    .first()
+                    .map(|parent| RefTarget::change(*parent)),
+                tree_hash: compute_resolved_tree_hash(&sealed_state.tree)
+                    .context("hash the exact sealed workspace tree")?,
+                file_count: change.tree_deltas.len(),
+                entity_count: change.entity_deltas.len(),
+            })
+        }
+        None => None,
+    };
+    Ok(StashOutcome::ReadOnly(StashResponse {
+        lines: vec![format!(
+            "Stash operation {} already crossed authority at generation {} ({})",
+            receipt.operation_id,
+            receipt.generation,
+            if entry.is_some() {
+                format!("sealed {}", mutation.name)
+            } else {
+                format!("restored and dropped {}", mutation.name)
+            }
+        )],
+        mutated: false,
+        report: None,
+        entry,
+        operation_id: Some(receipt.operation_id),
+        authority_generation: Some(receipt.generation),
+        idempotent: true,
+    }))
+}
+
+fn expect_exact(workspace: &WorkspaceState) -> WorkspaceExpectation {
+    WorkspaceExpectation::MustEqual {
+        generation: workspace.generation,
+        head: workspace.head.clone(),
+        base_target: workspace.base_target.clone(),
+        base_tree_hash: workspace.base_tree_hash,
+        tree_hash: workspace.tree_hash,
+        semantic_overlay_hash: workspace.semantic_overlay_hash,
+        admission_policy: workspace.admission_policy,
+    }
+}
+
+/// Copy every body the sealed change names into repository-owned CAS.
+///
+/// Workspace authority already holds these bodies, so this is a repository-CAS
+/// read followed by a repository-CAS write. No ingestion cache and no working
+/// file is consulted: a stash that could only be restored while some
+/// non-authoritative cache survived would not be a durable seal.
+fn require_sealed_sources_in_repository_cas(
+    manager: &kin_db::RepositoryAuthorityManager<kin_db::LocalFileBackend>,
+    shared_policy: &SharedAdmissionPolicy,
+    transaction: &RepositoryTransaction,
+) -> Result<()> {
+    let mut hashes = std::collections::BTreeSet::new();
+    for change in &transaction.changes {
+        for delta in &change.tree_deltas {
+            if let Some(hash) = delta
+                .new_state()
+                .and_then(|located| located.entry.blob_identity())
+            {
+                hashes.insert(hash);
+            }
+        }
+    }
+    hashes.extend(shared_policy.sources.iter().map(|source| source.body_hash));
+    for hash in hashes {
+        if manager
+            .load_source_blob(hash)
+            .with_context(|| format!("read sealed source {hash} from repository CAS"))?
+            .is_none()
+        {
+            bail!(
+                "repository source CAS is missing exact body {hash}; the workspace state cannot \
+                 be sealed as a restorable stash"
+            );
+        }
+    }
+    Ok(())
+}
+
+fn repository_source_length(
+    manager: &kin_db::RepositoryAuthorityManager<kin_db::LocalFileBackend>,
+    hash: Hash256,
+) -> std::result::Result<u64, kin_model::ModelError> {
+    let body = manager
+        .load_source_blob(hash)
+        .map_err(|error| {
+            kin_model::ModelError::InvalidOperation(format!(
+                "read graph-owned admission source {hash}: {error}"
+            ))
+        })?
+        .ok_or_else(|| {
+            kin_model::ModelError::InvalidOperation(format!(
+                "repository source CAS is missing exact admission source {hash}"
+            ))
+        })?;
+    u64::try_from(body.len()).map_err(|_| {
+        kin_model::ModelError::InvalidOperation(format!(
+            "graph-owned admission source {hash} exceeds u64"
+        ))
+    })
+}
+
+/// Materialize the immutable history graph behind one authority lease.
+fn sealed_graph(
+    lease: &kin_db::AuthorityReadLease<kin_db::RepositoryAuthorityState>,
+) -> Result<kin_db::InMemoryGraph> {
+    let mut snapshot = lease.snapshot().clone();
+    snapshot.repository_authority = None;
+    kin_db::InMemoryGraph::from_snapshot(snapshot).context("prepare the exact sealed change graph")
+}
+
+fn sealed_change(
+    lease: &kin_db::AuthorityReadLease<kin_db::RepositoryAuthorityState>,
+    name: &RefName,
+    change_id: SemanticChangeId,
+) -> Result<SemanticChange> {
+    lease
+        .snapshot()
+        .changes
+        .get(&change_id)
+        .cloned()
+        .ok_or_else(|| {
+            anyhow::anyhow!(
+                "stash {name} names change {change_id}, which repository history does not hold"
+            )
+        })
+}
+
+fn next_stash_ordinal(metadata: &kin_db::PersistedRepositoryAuthority) -> Result<u64> {
+    let highest = metadata
+        .ref_state
+        .refs
+        .iter()
+        .filter_map(|repository_ref| stash_ref_ordinal(&repository_ref.name))
+        .max();
+    match highest {
+        Some(highest) => highest
+            .checked_add(1)
+            .ok_or_else(|| anyhow::anyhow!("repository stash ordinals are exhausted")),
+        None => Ok(0),
+    }
+}
+
+fn latest_stash(
+    metadata: &kin_db::PersistedRepositoryAuthority,
+) -> Option<(u64, RefName, RefTarget)> {
+    metadata
+        .ref_state
+        .refs
+        .iter()
+        .filter_map(|repository_ref| {
+            stash_ref_ordinal(&repository_ref.name).map(|ordinal| {
+                (
+                    ordinal,
+                    repository_ref.name.clone(),
+                    repository_ref.target.clone(),
+                )
+            })
+        })
+        .max_by_key(|(ordinal, _, _)| *ordinal)
+}
+
+fn resolved_admission_policy(
+    metadata: &kin_db::PersistedRepositoryAuthority,
+    change_id: SemanticChangeId,
+) -> Result<SharedAdmissionPolicy> {
+    metadata
+        .admission_policies
+        .iter()
+        .find(|resolved| resolved.change_id == change_id)
+        .ok_or_else(|| {
+            anyhow::anyhow!("change {change_id} has no repository-v6 admission-policy record")
+        })?
+        .policy
+        .clone()
+        .ok_or_else(|| {
+            anyhow::anyhow!(
+                "change {change_id} has an unresolved admission policy and cannot bound a \
+                 workspace"
+            )
+        })
+}
+
+fn operation_receipt(
+    receipts: &[RepositoryCommitReceipt],
+    operation_id: OperationId,
+) -> Option<RepositoryCommitReceipt> {
+    receipts
+        .iter()
+        .find(|receipt| receipt.operation_id == operation_id)
+        .cloned()
+}
+
+fn local_workspace<'a>(
+    authority: &ActiveLocalRepositoryAuthority,
+    metadata: &'a kin_db::PersistedRepositoryAuthority,
+) -> Result<&'a WorkspaceState> {
+    metadata
+        .workspaces
+        .iter()
+        .find(|workspace| workspace.workspace_id == authority.workspace_id)
+        .ok_or_else(|| {
+            anyhow::anyhow!(
+                "repository {} has no workspace {} in repository-v6 authority",
+                authority.repository_id,
+                authority.workspace_id
+            )
+        })
+}
+
+fn seal_message(message: Option<&str>, workspace: &WorkspaceState) -> String {
+    match message.map(str::trim).filter(|value| !value.is_empty()) {
+        Some(message) => message.to_string(),
+        None => match &workspace.head {
+            kin_model::WorkspaceHead::Symbolic { target } => {
+                format!("stash on {target}")
+            }
+            kin_model::WorkspaceHead::Detached { .. } => {
+                "stash on a detached workspace".to_string()
+            }
+        },
+    }
+}
+
+fn render_base(change_id: Option<SemanticChangeId>) -> String {
+    change_id.map_or_else(|| "an unborn base".to_string(), |id| id.to_string())
+}
+
+fn render_list(report: &StashListReport) -> Vec<String> {
+    if report.entries.is_empty() {
+        return vec![format!(
+            "(no sealed stashes; workspace {} is {})",
+            report.workspace_id,
+            if report.workspace_dirty {
+                "dirty"
+            } else {
+                "clean"
+            }
+        )];
+    }
+    report
+        .entries
+        .iter()
+        .map(|entry| {
+            format!(
+                "{}  {}  {} file(s)  {}",
+                entry.name, entry.change_id, entry.file_count, entry.message
+            )
+        })
+        .collect()
+}
+
+fn classify_stash_error(error: anyhow::Error) -> (StatusCode, String) {
+    if error.downcast_ref::<StashConflict>().is_some() {
+        return (StatusCode::CONFLICT, format!("{error:#}"));
+    }
+    if let Some(kin_core::KinError::ProjectionConflict(message)) =
+        error.downcast_ref::<kin_core::KinError>()
+    {
+        return (StatusCode::CONFLICT, message.clone());
+    }
+    for cause in error.chain() {
+        if let Some(model) = cause.downcast_ref::<kin_model::ModelError>() {
+            if matches!(model, kin_model::ModelError::Conflict(_)) {
+                return (StatusCode::CONFLICT, format!("{error:#}"));
+            }
+        }
+    }
+    (StatusCode::INTERNAL_SERVER_ERROR, format!("{error:#}"))
+}
+
+fn repository_finalization_error(error: crate::error::DaemonError) -> (StatusCode, String) {
+    (StatusCode::INTERNAL_SERVER_ERROR, format!("{error:#}"))
+}
+
+fn internal_stash_error(error: anyhow::Error) -> (StatusCode, String) {
+    (StatusCode::INTERNAL_SERVER_ERROR, format!("{error:#}"))
+}
+
+fn stash_bind_refusal(refusal: RepositoryAuthorityBindRefusal) -> (StatusCode, String) {
+    let status = if refusal.is_identity_refusal() {
+        StatusCode::CONFLICT
+    } else {
+        StatusCode::INTERNAL_SERVER_ERROR
+    };
+    (status, format!("{:#}", refusal.into_error()))
+}


### PR DESCRIPTION
## What this lands

The repository-v6 `stash` path, built on graph-owned workspace authority. Sealing writes the exact workspace tree and its base-relative semantics as one immutable change under `refs/kin/stash/<ordinal>`, then returns the workspace to the authority target the state was taken against. Restore reproduces the sealed tree byte for byte and drops the stash ref in the same transaction. No branch marker, no sidecar file, no raw-file inference.

## Why sealing is two transactions

Repository authority binds one native admission to the workspace that publishes it: a change introducing artifacts must leave its publisher based on that exact change. A symbolic head must also equal its ref. So the seal detaches onto the sealed change without moving a projected byte, and a second exact transition returns the workspace to its branch base. Each transition finalizes before the next is planned, because a commit freeze blocks the following commit until the daemon installs it.

Ordering carries the safety property: the state is durable before anything is discarded. A failure between the two leaves a clean workspace detached on the sealed change with every file still on disk, recoverable with a branch switch or `kin stash pop`.

## Why the gate stays closed

`stash` stays `open_gate` / `fail_closed`. Against a live daemon the file watcher reconciles the rewritten projection into the daemon query graph before the reconciliation loop admits it. In that window the next authority command refuses on the daemon-freshness check:

```
daemon graph does not match the exact repository workspace authority; reopen before switching branches
```

In-process route coverage does not reproduce it, including the full seal, restore, seal, switch sequence. The background daemon loop is the missing variable. A command that can wedge the next one is not ready, so the capability note now records exactly that instead of the retired `.kin/HEAD` branch marker.

This race is a property of rewriting the projection, not of stash specifically, so `checkout` and `branch switch` are worth checking against it.

## Evidence

Route coverage (`cargo test -p kin-daemon --lib command_stash`, 4 passed):

- `command_stash_seals_restores_and_round_trips_exact_workspace_state` — dirty workspace seals, tracked bytes return to base, the introduced member is gone, the stash is listed and is not a branch, restore round-trips byte-exactly including content no adapter parses, and the stash is dropped by the restore that used it
- `command_stash_refuses_restore_onto_moved_authority` — a commit moves the base, restore refuses and projects nothing, the sealed state stays intact
- `command_stash_refuses_sealing_a_clean_workspace_and_restoring_over_a_dirty_one` — both directions fail closed
- `command_stash_leaves_ready_commands_working_on_the_returned_workspace` — seal, restore, seal, then branch switch

Plus `kin_cli::commands::stash::tests::stash_ref_names_round_trip_only_through_canonical_ordinals`, which rejects every non-canonical spelling under the namespace.

End-to-end on a real scratch repository against a lane-built daemon: seal returns the tree to base, `stash list` reports one sealed state, `branch list` excludes it, and `stash pop` restores all three members byte-exactly. The sequence stops at the second cycle on the daemon-freshness refusal above.

## Also here

The `rename` note is corrected. It previously read as though a planner existed and only its source was wrong. There is no planner: the retired one read `.kin/objects` and working-tree files, nothing reads repository-v6 source CAS in its place, and there is no apply path.

## Local gate

fmt, clippy on the ci.yml allowlist with `-D warnings`, `build --all-targets`, `test --workspace`.