### PR TITLE
README: absolute srcset URLs for theme-aware lockup

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,9 @@
 <div align="center">
 
 <a href="https://kinlab.ai"><picture>
-  <source media="(prefers-color-scheme: dark)" srcset="brand/kin-lockup-dark.svg">
-  <source media="(prefers-color-scheme: light)" srcset="brand/kin-lockup-light.svg">
-  <img src="brand/kin-lockup-light.svg" alt="Kin" width="300">
+  <source media="(prefers-color-scheme: dark)" srcset="https://raw.githubusercontent.com/firelock-ai/kin/main/brand/kin-lockup-dark.svg">
+  <source media="(prefers-color-scheme: light)" srcset="https://raw.githubusercontent.com/firelock-ai/kin/main/brand/kin-lockup-light.svg">
+  <img src="https://raw.githubusercontent.com/firelock-ai/kin/main/brand/kin-lockup-light.svg" alt="Kin" width="300">
 </picture></a>
 
 <h3>Software that remembers itself.</h3>


### PR DESCRIPTION
GitHub's markdown sanitizer strips picture sources with relative srcset paths, so only the fallback light lockup rendered on dark theme. Absolute raw URLs are the documented working pattern.