### PR TITLE
Restore the pinned latest-release badge in the README hero row

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,11 +10,9 @@
 
 <p><em>Exact context, not more.</em></p>
 
-<p>
-<a href="LICENSE"><img src="https://img.shields.io/badge/license-Apache--2.0-blue.svg" alt="License: Apache-2.0"></a>
-<a href="https://github.com/firelock-ai/kin/releases/latest"><img src="https://img.shields.io/github/v/release/firelock-ai/kin?color=6E56CF&label=release" alt="Latest release"></a>
-<a href="https://kinlab.ai"><img src="https://img.shields.io/badge/hosted-kinlab.ai-111111.svg" alt="Hosted at kinlab.ai"></a>
-</p>
+[![License: Apache-2.0](https://img.shields.io/badge/license-Apache--2.0-blue.svg)](LICENSE)
+[![Latest release](https://img.shields.io/badge/release-latest-6E56CF.svg)](https://github.com/firelock-ai/kin/releases/latest)
+[![Hosted at kinlab.ai](https://img.shields.io/badge/hosted-kinlab.ai-111111.svg)](https://kinlab.ai)
 
 </div>
 


### PR DESCRIPTION
The npm launcher tests job runs `scripts/test-release-workflow-authority.py`, which pins two README release-badge rules: the literal markdown badge `[![Latest release](https://img.shields.io/badge/release-latest-6E56CF.svg)]` pointing at `/releases/latest` must be present, and `img.shields.io/github/v/release` must be absent because it follows the newest GitHub tag rather than the promoted release.

The hero badge row replaced that markdown badge with an HTML anchor carrying the dynamic GitHub badge, which violates both rules at once. Docs-scoped CI skips the npm launcher tests job, so the change landed untested and every code-scoped pull request has been failing on it since.

This restores the pinned markdown badge alongside the hero. The three badges are markdown again inside the same centered hero div, so the lockup, headings, tagline, and single centered badge row render exactly as before. Verified against the GitHub markdown API in file-render mode: the badges emit as one paragraph with no line breaks, inside the centered div.

The reconcile decision, whether the policy needle should accept an HTML badge form or whether the badge placement should be redesigned, is left to the README owner and is being ticketed rather than settled here. No workflow or policy script was touched.

Local verification mirrors the npm launcher tests job exactly:
- `npm test` + `npm run lint` for `./packages/kin` (33 tests) and `./packages/kin-mcp` (13 tests), all pass
- `test-release-workflow-authority.py`, `test_install_optional_vfs.py`, `test_installer_parity.py`, `test-npm-automatic-release.py`, `test-verify-npm-release.py`, all pass
- `node --test` over the three script test files (13 tests), plus every `node --check` and `bash -n` in the job