### PR TITLE
Carry repository-v6 transfers past one envelope and name a stale derived view

### DIFF
--- a/crates/kin-cli/src/commands/transfer.rs
+++ b/crates/kin-cli/src/commands/transfer.rs
@@ -40,9 +40,41 @@ pub struct CommandTransferRequest {
     pub destination_ref: Option<RefName>,
 }
 
+/// What happened to the views a daemon derives from repository authority once
+/// a transfer's authority had already moved.
+///
+/// Repository authority is the truth, and it is durable before anything
+/// derived from it is touched. A refresh that fails after that point has not
+/// failed the transfer and must not be reported as one, but it does leave
+/// retrieval answering from state that is behind the admitted head. This is
+/// how that partial success is named instead of being flattened into either a
+/// clean success or a server error.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(tag = "state", rename_all = "snake_case")]
+pub enum DerivedViewRefresh {
+    /// Everything derived from authority matches the admitted head.
+    Current,
+    /// Authority moved and is durable; these views did not follow it.
+    Stale { detail: String },
+}
+
+impl DerivedViewRefresh {
+    pub fn is_stale(&self) -> bool {
+        matches!(self, Self::Stale { .. })
+    }
+}
+
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct CommandTransferResponse {
     pub outcome: RepositoryTransferOutcome,
+    /// Defaulted so a response from a daemon that predates this field reads as
+    /// the state it in fact reported: a refresh it never surfaced.
+    #[serde(default = "derived_views_current")]
+    pub derived_views: DerivedViewRefresh,
+}
+
+fn derived_views_current() -> DerivedViewRefresh {
+    DerivedViewRefresh::Current
 }
 
 /// A negotiated plan that moved nothing.
@@ -186,7 +218,7 @@ pub async fn push(
     let peer = resolve_peer(&layout, remote.as_deref(), url.as_deref())?;
     let request = build_request(peer, reference.as_deref(), None)?;
     let response = daemon().await?.command_push(&request).await?;
-    render_outcome(&response.outcome, json)
+    render_outcome(&response, json)
 }
 
 pub async fn pull(
@@ -199,7 +231,7 @@ pub async fn pull(
     let peer = resolve_peer(&layout, remote.as_deref(), url.as_deref())?;
     let request = build_request(peer, reference.as_deref(), None)?;
     let response = daemon().await?.command_pull(&request).await?;
-    render_outcome(&response.outcome, json)
+    render_outcome(&response, json)
 }
 
 pub async fn plan_push(
@@ -222,11 +254,12 @@ pub async fn plan_push(
     println!("Source ref:  {}", plan.source_ref);
     println!("Destination: {}", plan.destination_ref);
     println!("{}", render_plan(&plan.plan.plan));
-    if !plan.plan.fits_one_envelope {
-        println!(
-            "This gap does not fit one transfer envelope (limit {} changes). Transfer v1 has no continuation packs, so a push would be refused at pack build.",
+    match plan.plan.pack_count {
+        Some(0) | Some(1) | None => {}
+        Some(packs) => println!(
+            "This gap needs {packs} transfer packs at the negotiated bound of {} changes each. Each pack is published on its own, so an interruption leaves the remote on the last one that landed and a re-run resumes from there.",
             plan.plan.max_changes_per_envelope
-        );
+        ),
     }
     println!(
         "Nothing was published. This plan describes the two leases as they were read, not a reservation of them."
@@ -256,23 +289,30 @@ fn render_plan(plan: &RepositoryTransferPlan) -> String {
     }
 }
 
-fn render_outcome(outcome: &RepositoryTransferOutcome, json: bool) -> Result<()> {
+fn render_outcome(response: &CommandTransferResponse, json: bool) -> Result<()> {
     if json {
-        println!("{}", serde_json::to_string_pretty(outcome)?);
+        println!("{}", serde_json::to_string_pretty(response)?);
         return Ok(());
     }
+    let outcome = &response.outcome;
     let verb = match outcome.direction {
         RepositoryTransferDirection::Push => "Pushed",
         RepositoryTransferDirection::Pull => "Pulled",
     };
     println!("{}", render_plan(&outcome.plan));
-    match &outcome.receipt {
+    match outcome.final_receipt() {
         None => println!("{verb} nothing: no repository transaction was published."),
         Some(receipt) => {
             println!(
                 "{verb} {} onto {} at {}.",
                 outcome.repository_id, outcome.destination_ref, receipt.destination_head
             );
+            if outcome.receipts.len() > 1 {
+                println!(
+                    "Packs:     {} continuation packs, each published on its own",
+                    outcome.receipts.len()
+                );
+            }
             println!("Transfer:  {}", receipt.transfer_id);
             println!("Outcome:   {:?}", receipt.outcome);
             println!(
@@ -280,6 +320,14 @@ fn render_outcome(outcome: &RepositoryTransferOutcome, json: bool) -> Result<()>
                 receipt.authority_receipt.generation
             );
         }
+    }
+    if let DerivedViewRefresh::Stale { detail } = &response.derived_views {
+        println!(
+            "Repository authority moved and is durable, but the views derived from it did not follow: {detail}"
+        );
+        println!(
+            "Search and retrieval answer from behind the admitted head until those views are rebuilt. Restart the daemon to rebuild them."
+        );
     }
     Ok(())
 }

--- a/crates/kin-cli/tests/command_capabilities.rs
+++ b/crates/kin-cli/tests/command_capabilities.rs
@@ -121,6 +121,55 @@ fn remaining_open_gate_commands_fail_before_repository_discovery() {
     assert!(stderr.contains("not a Kin repository"), "{stderr}");
 }
 
+/// Push is wired to the transfer surface, not to the gate.
+///
+/// The flip that exposed it is a fixture edit, so nothing in the fixture can
+/// prove the dispatch arm reaches anything. Driving the real binary is what
+/// proves it: the gate message must be absent and the transfer surface's own
+/// discovery failure must be present. Pull is still gated and is asserted in
+/// the same pass, so a gate that stopped refusing anything at all cannot pass
+/// this as a connected command.
+#[test]
+fn push_reaches_the_transfer_surface_instead_of_the_capability_gate() {
+    let root = tempdir().expect("temp root");
+    let home = root.path().join("home");
+    std::fs::create_dir_all(&home).expect("create home");
+
+    let output = kin_command(&home)
+        .args(["push"])
+        .current_dir(root.path())
+        .output()
+        .expect("run exposed push outside a repository");
+    assert!(
+        !output.status.success(),
+        "push must fail outside a repository"
+    );
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        !stderr.contains("is fail-closed on repository-v6"),
+        "push must no longer answer from the capability gate: {stderr}"
+    );
+    assert!(
+        stderr.contains("not a Kin repository"),
+        "push must reach the transfer surface and fail on discovery: {stderr}"
+    );
+
+    let output = kin_command(&home)
+        .args(["pull"])
+        .current_dir(root.path())
+        .output()
+        .expect("run gated pull outside a repository");
+    assert!(
+        !output.status.success(),
+        "pull must fail outside a repository"
+    );
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains("is fail-closed on repository-v6"),
+        "pull is still gated and must answer from the capability gate: {stderr}"
+    );
+}
+
 /// The session cluster is wired to the session surface, not to the gate.
 ///
 /// Each command is driven through the real binary and must fail on repository

--- a/crates/kin-cli/tests/command_capabilities.rs
+++ b/crates/kin-cli/tests/command_capabilities.rs
@@ -40,7 +40,7 @@ fn capability_json_keeps_the_bounded_dogfood_bar_explicit() {
     assert_eq!(report["bounded_dogfood_required_ready"], 12);
     assert_eq!(report["bounded_dogfood_required_total"], 12);
     assert_eq!(report["full_git_replacement_ready"], false);
-    assert_eq!(report["ready_commands"], 26);
+    assert_eq!(report["ready_commands"], 27);
     assert_eq!(report["command_total"], 33);
 
     let commands = report["commands"]

--- a/crates/kin-cli/tests/fixtures/git-replacement-capabilities-v1.json
+++ b/crates/kin-cli/tests/fixtures/git-replacement-capabilities-v1.json
@@ -254,7 +254,7 @@
         "refuse a non-fast-forward gap with both heads named and no force path",
         "carry a closure larger than one negotiated envelope as an ordered sequence of packs, each published in its own repository transaction and proven by its own receipt",
         "leave an interrupted multi-pack publication on the last head that was receipted, which is an exact ancestor of the target, and resume from there on a re-run",
-        "refuse a step that cannot be split, naming the negotiated byte bound the single change exceeds"
+        "refuse a step that cannot be split, naming the negotiated bound it exceeds, whether that step is one change or the smallest one a merge leaves reachable"
       ],
       "evidence_tests": [
         "kin_remote::repository_transfer_negotiation::tests::a_push_past_the_negotiated_envelope_lands_the_whole_gap_across_continuation_packs",
@@ -263,9 +263,12 @@
         "kin_remote::repository_transfer_negotiation::tests::push_refuses_a_remote_head_this_replica_has_not_admitted",
         "kin_daemon::api::tests::a_push_past_the_negotiated_envelope_crosses_real_http_as_continuation_packs",
         "kin_daemon::api::tests::native_push_and_pull_move_exact_history_between_two_daemons_over_http",
-        "kin_daemon::api::tests::a_divergent_remote_refuses_the_push_over_http_and_moves_nothing"
+        "kin_daemon::api::tests::a_divergent_remote_refuses_the_push_over_http_and_moves_nothing",
+        "kin_remote::repository_transfer_negotiation::tests::a_step_that_cannot_be_split_is_refused_by_name_rather_than_replanned",
+        "kin_remote::repository_transfer_negotiation::tests::a_peer_whose_envelope_cannot_carry_the_smallest_step_is_refused_rather_than_looped_on",
+        "crates/kin-cli/tests/command_capabilities.rs::push_reaches_the_transfer_surface_instead_of_the_capability_gate"
       ],
-      "note": "Runs end to end between two Kin daemons over HTTP, including a gap larger than one negotiated envelope, which is published as an ordered sequence of packs rather than refused. Nothing spans those packs and this protocol does not claim it does: each is atomic on its own, and an interruption leaves the remote on the last receipted head. The remaining bound is one indivisible change whose new bodies exceed the negotiated byte limit, which is refused by name rather than split. The peer is a Kin daemon transfer seam; the KinLab control-plane wrapper and its protection rules are not driven by this command."
+      "note": "Runs end to end between two Kin daemons over HTTP, including a gap larger than one negotiated envelope, which is published as an ordered sequence of packs rather than refused. Nothing spans those packs and this protocol does not claim it does: each is atomic on its own, and an interruption leaves the remote on the last receipted head. The remaining bound is a step that cannot be split, either one change whose new bodies exceed the negotiated byte limit or the smallest step a merge leaves reachable when that step exceeds a negotiated bound, which is refused by name rather than replanned. The peer is a Kin daemon transfer seam; the KinLab control-plane wrapper and its protection rules are not driven by this command."
     },
     {
       "command": "pull",

--- a/crates/kin-cli/tests/fixtures/git-replacement-capabilities-v1.json
+++ b/crates/kin-cli/tests/fixtures/git-replacement-capabilities-v1.json
@@ -245,22 +245,27 @@
     },
     {
       "command": "push",
-      "status": "open_gate",
-      "exposure": "fail_closed",
+      "status": "ready",
+      "exposure": "enabled",
       "authority": "repository-v6 remote capability and exact transport",
       "required_for_bounded_dogfood": false,
       "acceptance_spec": [
-        "DONE: negotiate the remote destination lease, build the exact closure, publish it, and verify the returned receipt binds the pack that was sent",
-        "DONE: refuse a non-fast-forward gap with both heads named and no force path",
-        "OPEN: carry a closure larger than one negotiated envelope (512 changes, 4096 bodies, 16 MiB decoded); transfer v1 has no continuation packs, so a repository past that bound is refused at pack build",
-        "OPEN: drive the KinLab control-plane transfer envelope route, including its protection rules and durable receipts, rather than a peer daemon transfer seam directly"
+        "negotiate the remote destination lease, build the exact closure, publish it, and verify the returned receipt binds the pack that was sent",
+        "refuse a non-fast-forward gap with both heads named and no force path",
+        "carry a closure larger than one negotiated envelope as an ordered sequence of packs, each published in its own repository transaction and proven by its own receipt",
+        "leave an interrupted multi-pack publication on the last head that was receipted, which is an exact ancestor of the target, and resume from there on a re-run",
+        "refuse a step that cannot be split, naming the negotiated byte bound the single change exceeds"
       ],
       "evidence_tests": [
-        "crates/kin-remote/src/repository_transfer_negotiation.rs",
-        "crates/kin-remote/src/repository_transfer_http.rs",
-        "crates/kin-daemon/src/api.rs"
+        "kin_remote::repository_transfer_negotiation::tests::a_push_past_the_negotiated_envelope_lands_the_whole_gap_across_continuation_packs",
+        "kin_remote::repository_transfer_negotiation::tests::an_interrupted_multi_pack_push_resumes_from_the_pack_that_landed",
+        "kin_remote::repository_transfer_negotiation::tests::a_continuation_segment_publishes_a_head_the_destination_ref_can_reach",
+        "kin_remote::repository_transfer_negotiation::tests::push_refuses_a_remote_head_this_replica_has_not_admitted",
+        "kin_daemon::api::tests::a_push_past_the_negotiated_envelope_crosses_real_http_as_continuation_packs",
+        "kin_daemon::api::tests::native_push_and_pull_move_exact_history_between_two_daemons_over_http",
+        "kin_daemon::api::tests::a_divergent_remote_refuses_the_push_over_http_and_moves_nothing"
       ],
-      "note": "The full path runs end to end between two Kin daemons over HTTP with receipts verified, but only within one bounded transfer envelope, and the transfer status this protocol publishes still reports push_apply_ready=false. Exposing it as general `kin push` would promise a capability that a repository past the envelope bound does not have."
+      "note": "Runs end to end between two Kin daemons over HTTP, including a gap larger than one negotiated envelope, which is published as an ordered sequence of packs rather than refused. Nothing spans those packs and this protocol does not claim it does: each is atomic on its own, and an interruption leaves the remote on the last receipted head. The remaining bound is one indivisible change whose new bodies exceed the negotiated byte limit, which is refused by name rather than split. The peer is a Kin daemon transfer seam; the KinLab control-plane wrapper and its protection rules are not driven by this command."
     },
     {
       "command": "pull",
@@ -270,18 +275,20 @@
       "required_for_bounded_dogfood": false,
       "acceptance_spec": [
         "DONE: read the remote ref advertisement, adopt its default ref when this replica has none, and fetch the exact exported closure",
-        "DONE: admit the pack in one local authority transaction and refuse a receipt that does not bind it",
+        "DONE: admit each pack in one local authority transaction and refuse a receipt that does not bind it",
         "DONE: refuse a remote this replica already contains, naming the remote head",
-        "OPEN: carry a closure larger than one negotiated envelope; transfer v1 has no continuation packs",
-        "OPEN: carry an exported pack past the 24 MiB transfer body bound; the daemon route and the client read declare the same limit, and a pack past it is refused as an oversized envelope rather than split",
+        "DONE: carry a closure larger than one negotiated envelope as an ordered sequence of packs, resuming from the last one admitted",
+        "DONE: report a derived-view refresh that fails after authority is durable as a typed partial success rather than a server error",
         "OPEN: graph-derived workspace transition after admission, so a working tree follows the new head"
       ],
       "evidence_tests": [
-        "crates/kin-remote/src/repository_transfer_negotiation.rs",
-        "crates/kin-remote/src/repository_transfer_http.rs",
-        "crates/kin-daemon/src/api.rs"
+        "kin_remote::repository_transfer_negotiation::tests::a_pull_past_the_negotiated_envelope_admits_the_whole_gap_across_continuation_packs",
+        "kin_remote::repository_transfer_negotiation::tests::pull_admits_the_same_gap_from_the_other_side",
+        "kin_remote::repository_transfer_negotiation::tests::pull_refuses_a_remote_this_replica_already_contains",
+        "kin_daemon::api::tests::a_pull_whose_derived_refresh_fails_reports_partial_success_not_a_server_error",
+        "kin_daemon::api::tests::native_push_and_pull_move_exact_history_between_two_daemons_over_http"
       ],
-      "note": "Negotiation, export, and admission run end to end between two Kin daemons over HTTP with receipts verified. It stays closed because the envelope is bounded and because admission does not yet move the workspace to the admitted head. The envelope is bounded twice: by the negotiated change count, and by the 24 MiB one-body transfer bound. A pack carries base64 CAS bodies for the whole source tree, so on a real repository the byte bound binds first."
+      "note": "Negotiation, export, and admission run end to end between two Kin daemons over HTTP with receipts verified, including a gap past one envelope. It stays closed for one reason only: admitting history does not move the workspace to the admitted head, so a working tree after `kin pull` still shows the old one. That is what a caller expects this command to do, and until it does, exposing it would promise a transition that does not happen."
     },
     {
       "command": "merge",
@@ -388,13 +395,16 @@
         "derive the local publication head from one repository authority generation",
         "read the remote destination lease over the repository-v6 transfer seam and classify the gap without moving history",
         "refuse a remote head this replica has not admitted, naming both heads, with no force path",
-        "report the negotiated envelope bound so an oversized gap is predictable before a push runs"
+        "refuse the imported-Git baseline and the missing or mismatched source bodies a push would refuse, before anything is published",
+        "report how many packs the publication will take at the negotiated envelope"
       ],
       "evidence_tests": [
-        "crates/kin-remote/src/repository_transfer_negotiation.rs",
-        "crates/kin-daemon/src/api.rs"
+        "kin_remote::repository_transfer_negotiation::tests::a_plan_counts_the_packs_a_push_will_take",
+        "kin_remote::repository_transfer_negotiation::tests::a_plan_refuses_a_divergent_imported_git_baseline_the_way_a_push_would",
+        "kin_remote::repository_transfer_negotiation::tests::the_planned_distance_is_exactly_what_the_pack_carries",
+        "kin_daemon::api::tests::native_push_and_pull_move_exact_history_between_two_daemons_over_http"
       ],
-      "note": "Negotiates against a live peer transfer seam and publishes nothing. Reports whether the gap fits one transfer envelope, because transfer v1 has no continuation packs."
+      "note": "Negotiates against a live peer transfer seam and publishes nothing. Everything a push decides before it ships bytes is decided here too: the lease, the fast-forward classification, the imported-Git baseline, and the presence and identity of every immutable body the publication head's tree depends on. The per-pack byte arithmetic is only knowable once packs are assembled, so the plan reports the pack count and the negotiated bound rather than predicting that refusal."
     },
     {
       "command": "exec",

--- a/crates/kin-daemon/src/api.rs
+++ b/crates/kin-daemon/src/api.rs
@@ -6758,10 +6758,9 @@ fn refresh_local_derived_views(
         .record_repository_authority_commit(receipt.authority_receipt.generation)
         .map_err(|error| format!("record repository authority generation: {error}"))?;
     for change in changes {
-        state
-            .graph
-            .create_change(change)
-            .map_err(|error| format!("admit change {} into the daemon graph: {error}", change.id))?;
+        state.graph.create_change(change).map_err(|error| {
+            format!("admit change {} into the daemon graph: {error}", change.id)
+        })?;
     }
     state.bump_version();
     state.emit_event(DaemonEvent::GraphRootChanged {

--- a/crates/kin-daemon/src/api.rs
+++ b/crates/kin-daemon/src/api.rs
@@ -10422,7 +10422,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn repository_transfer_status_preserves_non_utf8_ref_bytes_and_gates_push() {
+    async fn repository_transfer_status_preserves_non_utf8_ref_bytes_and_advertises_apply() {
         let state = test_state();
         let repository_id = state.cached_repo_id.clone();
         let destination_ref =
@@ -10447,9 +10447,9 @@ mod tests {
         let status: kin_remote::repository_transfer::RepositoryTransferStatus =
             serde_json::from_slice(&body).unwrap();
         assert_eq!(status.destination_ref, destination_ref);
-        assert!(!status.push_apply_ready);
+        assert!(status.push_apply_ready);
         assert!(status.bounded_envelope_export_ready);
-        assert!(!status.pull_apply_ready);
+        assert!(status.pull_apply_ready);
     }
 
     #[test]

--- a/crates/kin-daemon/src/api.rs
+++ b/crates/kin-daemon/src/api.rs
@@ -28,6 +28,7 @@ use kin_model::{
 };
 // One declared bound governs both directions: what these routes accept is what
 // the transfer client reads.
+use kin_cli::commands::transfer::DerivedViewRefresh;
 use kin_remote::repository_transfer_http::REPOSITORY_TRANSFER_HTTP_BODY_LIMIT;
 use serde::{Deserialize, Serialize};
 use serde_json::json;
@@ -445,6 +446,11 @@ pub struct RepoHealthResponse {
     pub embed_persistence_unavailable: bool,
     #[serde(default)]
     pub filesystem_reconcile_disabled: bool,
+    /// Why views derived from repository authority are behind it, when they
+    /// are. Set by a transfer whose authority became durable and whose derived
+    /// refresh then failed; absent means they match.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub derived_views_stale: Option<String>,
 }
 
 /// Repo entities search response.
@@ -6715,13 +6721,67 @@ async fn repo_transfer_export(
             ),
         ));
     }
-    let pack = kin_remote::repository_transfer::build_repository_transfer_pack(
+    // Export the largest pack that fits the caller's negotiated envelope rather
+    // than the whole closure. A gap past the envelope is carried by a sequence
+    // of these, each of which the caller admits and receipts on its own.
+    let segment = kin_remote::repository_transfer::build_repository_transfer_segment(
         &authority,
         &request.source_ref,
         &request.expectation,
     )
     .map_err(repository_transfer_error)?;
-    Ok(Json(pack))
+    Ok(Json(segment.pack))
+}
+
+/// Refresh the local views this daemon derives from repository authority, once
+/// an admitted transfer is already durable.
+///
+/// Returns the failure rather than raising it. Authority moved and the receipt
+/// proving it exists; a caller told this failed would believe a transfer that
+/// really happened did not, and would retry against a head that has already
+/// advanced. What is actually true is narrower and is what the caller gets
+/// back: retrieval is serving state that is behind the admitted head.
+fn refresh_local_derived_views(
+    state: &DaemonState,
+    receipt: &kin_remote::repository_transfer::RepositoryTransferReceipt,
+    changes: &[kin_model::SemanticChange],
+    head: kin_model::SemanticChangeId,
+) -> std::result::Result<(), String> {
+    // An idempotent replay already updated these derived local views on the
+    // original request. Reapplying them would make the receipt path spuriously
+    // fail after authority had correctly returned its replay.
+    if receipt.outcome != kin_remote::repository_transfer::RepositoryTransferApplyOutcome::Committed
+    {
+        return Ok(());
+    }
+    state
+        .record_repository_authority_commit(receipt.authority_receipt.generation)
+        .map_err(|error| format!("record repository authority generation: {error}"))?;
+    for change in changes {
+        state
+            .graph
+            .create_change(change)
+            .map_err(|error| format!("admit change {} into the daemon graph: {error}", change.id))?;
+    }
+    state.bump_version();
+    state.emit_event(DaemonEvent::GraphRootChanged {
+        old_root_hash: None,
+        new_root_hash: head.to_string(),
+    });
+    Ok(())
+}
+
+/// Record that derived views are behind authority, so the gap is a daemon
+/// health signal rather than something an operator has to infer from answers
+/// that quietly went stale.
+async fn record_derived_view_staleness(state: &DaemonState, refresh: &DerivedViewRefresh) {
+    if let DerivedViewRefresh::Stale { detail } = refresh {
+        tracing::error!(
+            detail = %detail,
+            "repository authority moved but daemon-derived views did not follow; retrieval is behind the admitted head"
+        );
+        *state.derived_views_stale.write().await = Some(detail.clone());
+    }
 }
 
 /// POST /repos/{repo_id}/transfer/receive — validate and publish one exact
@@ -6745,27 +6805,23 @@ async fn repo_transfer_receive(
 
     // Repository authority is already durable. Refresh only derived daemon
     // views after that receipt exists; a failure here cannot revoke or fake
-    // the committed transfer.
-    if state.storage_backend.is_some() {
+    // the committed transfer, and must not be answered to the sending peer as
+    // a failed publication.
+    let refresh = if state.storage_backend.is_some() {
         state.repo_graphs.write().await.remove(&repo_id);
-    } else if receipt.outcome
-        == kin_remote::repository_transfer::RepositoryTransferApplyOutcome::Committed
-    {
-        // An idempotent replay already updated these derived local views on
-        // the original request. Reapplying them would make the receipt path
-        // spuriously fail after authority had correctly returned its replay.
-        state
-            .record_repository_authority_commit(receipt.authority_receipt.generation)
-            .map_err(repository_commit_error)?;
-        for change in &request.pack.changes {
-            state.graph.create_change(change).map_err(internal_error)?;
+        DerivedViewRefresh::Current
+    } else {
+        match refresh_local_derived_views(
+            &state,
+            &receipt,
+            &request.pack.changes,
+            request.pack.source_head,
+        ) {
+            Ok(()) => DerivedViewRefresh::Current,
+            Err(detail) => DerivedViewRefresh::Stale { detail },
         }
-        state.bump_version();
-        state.emit_event(DaemonEvent::GraphRootChanged {
-            old_root_hash: None,
-            new_root_hash: request.pack.source_head.to_string(),
-        });
-    }
+    };
+    record_derived_view_staleness(&state, &refresh).await;
     Ok(Json(receipt))
 }
 
@@ -6891,6 +6947,9 @@ async fn command_push(
     .map_err(repository_transfer_error)?;
     Ok(Json(kin_cli::commands::transfer::CommandTransferResponse {
         outcome,
+        // A push moves the remote's authority, not this replica's, so nothing
+        // derived from local authority is behind after it.
+        derived_views: DerivedViewRefresh::Current,
     }))
 }
 
@@ -6904,11 +6963,6 @@ async fn command_pull(
     State(state): State<Arc<DaemonState>>,
     Json(request): Json<kin_cli::commands::transfer::CommandTransferRequest>,
 ) -> Result<impl IntoResponse, (StatusCode, String)> {
-    use kin_remote::repository_transfer_negotiation::{
-        verify_receipt_binds_pack, PullNegotiation, RepositoryTransferDirection,
-        RepositoryTransferOutcome, RepositoryTransferPlan,
-    };
-
     let context = transfer_command_context(&state, &request)?;
     let repo_id = context.repo_id.clone();
     let repository_id = context.repository_id.clone();
@@ -6920,99 +6974,73 @@ async fn command_pull(
         transport,
         ..
     } = context;
-    let (authority, resolved) = {
+    let local_derived_views = state.storage_backend.is_none();
+    let blocking_state = Arc::clone(&state);
+    let outcome = {
         let repository_id = repository_id.clone();
         tokio::task::spawn_blocking(move || {
             // A replica that has admitted nothing cannot name a ref from its own
             // state. The advertisement is what an unborn replica adopts, so
             // resolving it here is the same step a clone takes.
-            let resolved = (|| {
-                let source_ref = match requested_source_ref {
-                    Some(name) => name,
-                    None => kin_remote::repository_transfer_negotiation::remote_default_ref(
-                        &transport,
-                        &repository_id,
-                    )?,
-                };
-                let destination_ref =
-                    requested_destination_ref.unwrap_or_else(|| source_ref.clone());
-                let negotiation = kin_remote::repository_transfer_negotiation::fetch_pull_pack(
-                    &authority,
+            let source_ref = match requested_source_ref {
+                Some(name) => name,
+                None => kin_remote::repository_transfer_negotiation::remote_default_ref(
                     &transport,
                     &repository_id,
-                    &source_ref,
-                    &destination_ref,
-                )?;
-                Ok((source_ref, destination_ref, negotiation))
-            })();
-            (authority, resolved)
+                )?,
+            };
+            let destination_ref = requested_destination_ref.unwrap_or_else(|| source_ref.clone());
+            // Admission runs here rather than inside the negotiation helper so
+            // that publication and the refresh of every daemon-derived view stay
+            // on the same path the inbound receive route already uses. A gap
+            // past one envelope arrives as several packs, and each takes that
+            // path in turn.
+            let mut refresh = DerivedViewRefresh::Current;
+            let outcome = kin_remote::repository_transfer_negotiation::pull_from_remote_with(
+                &authority,
+                &transport,
+                &repository_id,
+                &source_ref,
+                &destination_ref,
+                |pack| {
+                    let receipt = kin_remote::repository_transfer::apply_repository_transfer_pack(
+                        &authority,
+                        &repository_id,
+                        &destination_ref,
+                        kin_model::AuthorId::new("kin-daemon:repository-transfer-puller"),
+                        pack,
+                    )?;
+                    if local_derived_views && !refresh.is_stale() {
+                        if let Err(detail) = refresh_local_derived_views(
+                            &blocking_state,
+                            &receipt,
+                            &pack.changes,
+                            pack.source_head,
+                        ) {
+                            refresh = DerivedViewRefresh::Stale { detail };
+                        }
+                    }
+                    Ok(receipt)
+                },
+            )?;
+            Ok::<_, kin_remote::repository_transfer::RepositoryTransferError>((outcome, refresh))
         })
         .await
         .map_err(internal_error)?
     };
-    let (source_ref, destination_ref, negotiation) = resolved.map_err(repository_transfer_error)?;
+    let (outcome, mut derived_views) = outcome.map_err(repository_transfer_error)?;
 
-    let pack = match negotiation {
-        PullNegotiation::UpToDate { head } => {
-            return Ok(Json(kin_cli::commands::transfer::CommandTransferResponse {
-                outcome: RepositoryTransferOutcome {
-                    direction: RepositoryTransferDirection::Pull,
-                    repository_id,
-                    source_ref,
-                    destination_ref,
-                    plan: RepositoryTransferPlan::UpToDate { head },
-                    receipt: None,
-                },
-            }));
-        }
-        PullNegotiation::Pack(pack) => *pack,
-    };
-
-    let plan = RepositoryTransferPlan::FastForward {
-        source_head: pack.source_head,
-        destination_head: pack.expected_destination_head,
-        change_count: Some(pack.changes.len()),
-    };
-    let receipt = kin_remote::repository_transfer::apply_repository_transfer_pack(
-        &authority,
-        &repository_id,
-        &destination_ref,
-        kin_model::AuthorId::new("kin-daemon:repository-transfer-puller"),
-        &pack,
-    )
-    .map_err(repository_transfer_error)?;
-    verify_receipt_binds_pack(&pack, &receipt).map_err(repository_transfer_error)?;
-
-    // Repository authority is already durable. Refresh only derived daemon
-    // views after that receipt exists; a failure here cannot revoke or fake
-    // the committed transfer.
-    if state.storage_backend.is_some() {
+    if !local_derived_views && outcome.moved_history() {
         state.repo_graphs.write().await.remove(&repo_id);
-    } else if receipt.outcome
-        == kin_remote::repository_transfer::RepositoryTransferApplyOutcome::Committed
-    {
-        state
-            .record_repository_authority_commit(receipt.authority_receipt.generation)
-            .map_err(repository_commit_error)?;
-        for change in &pack.changes {
-            state.graph.create_change(change).map_err(internal_error)?;
-        }
-        state.bump_version();
-        state.emit_event(DaemonEvent::GraphRootChanged {
-            old_root_hash: None,
-            new_root_hash: pack.source_head.to_string(),
-        });
     }
+    if !outcome.moved_history() {
+        derived_views = DerivedViewRefresh::Current;
+    }
+    record_derived_view_staleness(&state, &derived_views).await;
 
     Ok(Json(kin_cli::commands::transfer::CommandTransferResponse {
-        outcome: RepositoryTransferOutcome {
-            direction: RepositoryTransferDirection::Pull,
-            repository_id,
-            source_ref,
-            destination_ref,
-            plan,
-            receipt: Some(receipt),
-        },
+        outcome,
+        derived_views,
     }))
 }
 
@@ -7095,6 +7123,7 @@ async fn repo_health(
             .load(std::sync::atomic::Ordering::Relaxed),
         embed_persistence_unavailable: !state.can_persist_embed_progress_locally(),
         filesystem_reconcile_disabled: state.filesystem_reconcile_disabled(),
+        derived_views_stale: state.derived_views_stale.read().await.clone(),
     }))
 }
 
@@ -10608,9 +10637,10 @@ mod tests {
             }
         );
         assert_eq!(planned.plan.max_changes_per_envelope, 512);
-        assert!(
-            !planned.plan.fits_one_envelope,
-            "an unborn destination has no counted closure, so the plan must not assert it fits"
+        assert_eq!(
+            planned.plan.pack_count,
+            Some(1),
+            "this closure fits one envelope, so it is one pack"
         );
 
         // The push crosses a real socket and returns a receipt bound to it.
@@ -10629,9 +10659,14 @@ mod tests {
         );
         let receipt = pushed
             .outcome
-            .receipt
+            .final_receipt()
             .expect("a moved head returns a receipt");
         assert_eq!(receipt.destination_head, source_head);
+        assert_eq!(pushed.outcome.receipts.len(), 1);
+        assert_eq!(
+            pushed.derived_views,
+            kin_cli::commands::transfer::DerivedViewRefresh::Current
+        );
         assert_eq!(
             receipt.outcome,
             kin_remote::repository_transfer::RepositoryTransferApplyOutcome::Committed
@@ -10648,7 +10683,7 @@ mod tests {
                 head: Some(source_head),
             }
         );
-        assert!(repeated.outcome.receipt.is_none());
+        assert!(repeated.outcome.receipts.is_empty());
 
         // A third replica pulls the same history back out of the one that was
         // just published to, so the export seam is exercised on real bytes that
@@ -10669,10 +10704,295 @@ mod tests {
         assert_eq!(
             pulled
                 .outcome
-                .receipt
+                .final_receipt()
                 .expect("a moved head returns a receipt")
                 .destination_head,
             source_head
+        );
+        assert_eq!(
+            pulled.derived_views,
+            kin_cli::commands::transfer::DerivedViewRefresh::Current
+        );
+    }
+
+    /// The real HTTP transport, standing in for a peer that accepts a smaller
+    /// envelope than the protocol maximum.
+    ///
+    /// The envelope is negotiated, not fixed: a destination publishes what it
+    /// will take in one pack and a sender honours it. Nothing here fakes the
+    /// wire, the routes, or the packs. Clamping the advertised bound is what
+    /// makes continuation reachable on a history a test can seed, because
+    /// seeding past the 512-change default costs minutes of exact repository
+    /// transactions.
+    struct NarrowEnvelopePeer {
+        inner: kin_remote::repository_transfer_http::HttpRepositoryTransferTransport,
+        max_changes: u32,
+    }
+
+    impl kin_remote::repository_transfer_negotiation::RepositoryTransferTransport
+        for NarrowEnvelopePeer
+    {
+        fn advertise_refs(
+            &self,
+            repository_id: &RepositoryId,
+        ) -> kin_remote::repository_transfer::Result<
+            kin_remote::repository_transfer::RepositoryRefAdvertisement,
+        > {
+            self.inner.advertise_refs(repository_id)
+        }
+
+        fn transfer_status(
+            &self,
+            repository_id: &RepositoryId,
+            destination_ref: &kin_model::RefName,
+        ) -> kin_remote::repository_transfer::Result<
+            kin_remote::repository_transfer::RepositoryTransferStatus,
+        > {
+            let mut status = self.inner.transfer_status(repository_id, destination_ref)?;
+            status.limits.max_changes = self.max_changes;
+            Ok(status)
+        }
+
+        fn export_pack(
+            &self,
+            repository_id: &RepositoryId,
+            source_ref: &kin_model::RefName,
+            expectation: &kin_remote::repository_transfer::RepositoryTransferExpectation,
+        ) -> kin_remote::repository_transfer::Result<
+            kin_remote::repository_transfer::RepositoryTransferPack,
+        > {
+            self.inner
+                .export_pack(repository_id, source_ref, expectation)
+        }
+
+        fn receive_pack(
+            &self,
+            repository_id: &RepositoryId,
+            destination_ref: &kin_model::RefName,
+            pack: &kin_remote::repository_transfer::RepositoryTransferPack,
+        ) -> kin_remote::repository_transfer::Result<
+            kin_remote::repository_transfer::RepositoryTransferReceipt,
+        > {
+            self.inner
+                .receive_pack(repository_id, destination_ref, pack)
+        }
+    }
+
+    #[tokio::test]
+    async fn a_push_past_the_negotiated_envelope_crosses_real_http_as_continuation_packs() {
+        use kin_remote::repository_transfer_negotiation::RepositoryTransferPlan;
+
+        let repo_id = format!("transfer-e2e-continuation-{}", Uuid::new_v4());
+        let repository_id = RepositoryId::new(repo_id.clone()).unwrap();
+        let main = kin_model::RefName::branch(b"main").unwrap();
+
+        let (_source_state, _source_working, source_storage) = replica_state(&repo_id);
+        let (destination_state, _destination_working, _destination_storage) =
+            replica_state(&repo_id);
+
+        let mut heads = Vec::new();
+        let mut previous = None;
+        for step in 0..5u128 {
+            previous = Some(seed_replica_change(
+                &source_storage,
+                &repository_id,
+                previous,
+                step + 1,
+                "extend the exact line",
+            ));
+            heads.push(previous.unwrap());
+        }
+        let source_head = previous.unwrap();
+
+        let destination_url = serve_replica(Arc::clone(&destination_state)).await;
+        let peer = NarrowEnvelopePeer {
+            inner: kin_remote::repository_transfer_http::HttpRepositoryTransferTransport::new(
+                kin_remote::repository_transfer_http::RepositoryTransferEndpoint::new(
+                    destination_url.clone(),
+                ),
+            ),
+            max_changes: 2,
+        };
+        let source_authority = RepositoryAuthorityManager::open(
+            repository_id.clone(),
+            Arc::new(kin_db::LocalFileBackend::new(
+                source_storage.path().to_path_buf(),
+            )) as Arc<dyn StorageBackend>,
+        )
+        .unwrap();
+
+        let pushed_repository_id = repository_id.clone();
+        let outcome = tokio::task::spawn_blocking(move || {
+            kin_remote::repository_transfer_negotiation::push_to_remote(
+                &source_authority,
+                &peer,
+                &pushed_repository_id,
+                &main,
+                &main,
+            )
+        })
+        .await
+        .unwrap()
+        .expect("a gap past the negotiated envelope publishes as continuation packs");
+
+        assert_eq!(
+            outcome.plan,
+            RepositoryTransferPlan::FastForward {
+                source_head,
+                destination_head: None,
+                change_count: Some(5),
+            },
+            "the reported move is the whole publication, not its last pack"
+        );
+        assert_eq!(
+            outcome.receipts.len(),
+            3,
+            "five changes across a two-change envelope cross the wire as three packs"
+        );
+        // Every pack was published on its own, and each landed an exact change
+        // of the line rather than some synthesized intermediate state.
+        for receipt in &outcome.receipts {
+            assert_eq!(
+                receipt.outcome,
+                kin_remote::repository_transfer::RepositoryTransferApplyOutcome::Committed
+            );
+            assert!(
+                heads.contains(&receipt.destination_head),
+                "every receipted head is an exact change on the source line"
+            );
+        }
+        assert_eq!(
+            outcome.final_receipt().unwrap().destination_head,
+            source_head
+        );
+
+        // The remote resolves the ref to the head the transfer was moving
+        // toward, read back through its own advertisement route.
+        let advertised = router(Arc::clone(&destination_state))
+            .oneshot(
+                Request::get(format!("/repos/{repo_id}/transfer/advertise"))
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(advertised.status(), StatusCode::OK);
+        let body = axum::body::to_bytes(advertised.into_body(), 1024 * 1024)
+            .await
+            .unwrap();
+        let advertised: kin_remote::repository_transfer::RepositoryRefAdvertisement =
+            serde_json::from_slice(&body).unwrap();
+        assert_eq!(
+            advertised.refs.first().map(|entry| entry.head),
+            Some(source_head)
+        );
+    }
+
+    #[tokio::test]
+    async fn a_pull_whose_derived_refresh_fails_reports_partial_success_not_a_server_error() {
+        // Repository authority moves first and is durable before anything
+        // derived from it is touched. A refresh that fails after that point
+        // used to surface as HTTP 500, which tells the caller a transfer that
+        // really happened did not. What is true is narrower and typed: the
+        // history is admitted, and retrieval is behind it.
+        let destination_state = test_state();
+        let repo_id = destination_state.cached_repo_id.clone();
+        let repository_id = RepositoryId::new(repo_id.clone()).unwrap();
+
+        let (source_state, _source_working, source_storage) = replica_state(&repo_id);
+        let root = seed_replica_change(&source_storage, &repository_id, None, 1, "root the line");
+        let source_head = seed_replica_change(
+            &source_storage,
+            &repository_id,
+            Some(root),
+            2,
+            "advance the line",
+        );
+        let source_url = serve_replica(Arc::clone(&source_state)).await;
+
+        // Put the daemon's derived generation cursor ahead of anything the
+        // transfer can produce, so installing the admitted generation is
+        // refused after authority has already committed.
+        destination_state
+            .snapshot_generation
+            .store(u64::MAX, std::sync::atomic::Ordering::SeqCst);
+
+        let request = kin_cli::commands::transfer::CommandTransferRequest {
+            remote_base_url: source_url,
+            remote_token: None,
+            repository_id: Some(repo_id.clone()),
+            source_ref: None,
+            destination_ref: None,
+        };
+        let (status, body) =
+            transfer_command(Arc::clone(&destination_state), "pull", &request).await;
+        assert_eq!(
+            status,
+            StatusCode::OK,
+            "a durable admission with a stale derived view is not a server error: {}",
+            String::from_utf8_lossy(&body)
+        );
+        let pulled: kin_cli::commands::transfer::CommandTransferResponse =
+            serde_json::from_slice(&body).unwrap();
+        assert_eq!(
+            pulled
+                .outcome
+                .final_receipt()
+                .expect("authority moved, so a receipt exists")
+                .destination_head,
+            source_head
+        );
+        let kin_cli::commands::transfer::DerivedViewRefresh::Stale { detail } =
+            &pulled.derived_views
+        else {
+            panic!(
+                "a failed derived refresh must be named, not flattened into success: {:?}",
+                pulled.derived_views
+            );
+        };
+        assert!(
+            detail.contains("generation"),
+            "the partial success must say what did not follow: {detail}"
+        );
+
+        // Authority really moved: the destination advertises the admitted head.
+        let advertised = router(Arc::clone(&destination_state))
+            .oneshot(
+                Request::get(format!("/repos/{repo_id}/transfer/advertise"))
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(advertised.status(), StatusCode::OK);
+        let advertised_body = axum::body::to_bytes(advertised.into_body(), 1024 * 1024)
+            .await
+            .unwrap();
+        let advertised: kin_remote::repository_transfer::RepositoryRefAdvertisement =
+            serde_json::from_slice(&advertised_body).unwrap();
+        assert_eq!(
+            advertised.refs.first().map(|entry| entry.head),
+            Some(source_head),
+            "the admitted head is durable regardless of what the derived refresh did"
+        );
+
+        // And the gap is a health signal rather than something an operator has
+        // to infer from answers that quietly went stale.
+        let health = router(Arc::clone(&destination_state))
+            .oneshot(
+                Request::get(format!("/repos/{repo_id}/health"))
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        let health_body = axum::body::to_bytes(health.into_body(), 1024 * 1024)
+            .await
+            .unwrap();
+        let health: RepoHealthResponse = serde_json::from_slice(&health_body).unwrap();
+        assert!(
+            health.derived_views_stale.is_some(),
+            "a daemon serving behind authority must say so on its health surface"
         );
     }
 

--- a/crates/kin-daemon/src/state.rs
+++ b/crates/kin-daemon/src/state.rs
@@ -1019,6 +1019,16 @@ pub struct DaemonState {
     /// daemon-health signal so this degraded state is LOUD, never silent (the
     /// worker dying must NOT take the whole daemon down).
     pub embed_worker_failed: AtomicBool,
+    /// Why the views this daemon derives from repository authority stopped
+    /// matching it, or `None` when they match.
+    ///
+    /// Set when an admitted repository transfer became durable and the refresh
+    /// of everything derived from it then failed. Authority is the truth and it
+    /// moved, so that is not a failed transfer and must not be reported as one.
+    /// It is also not nothing: retrieval served from these views is behind
+    /// authority until they are rebuilt. Surfaced as a daemon-health signal so
+    /// the gap is loud rather than inferred from stale answers.
+    pub derived_views_stale: RwLock<Option<String>>,
     /// Durable store for in-flight MCP transactions, keyed by transaction id.
     ///
     /// Each `/mcp/tools/call` rebuilds a fresh `SessionRegistry` for the request,
@@ -1649,6 +1659,7 @@ impl DaemonState {
             persisted_entity_count: AtomicU64::new(loaded_entity_count as u64),
             mass_deletion_blocked: AtomicBool::new(false),
             embed_worker_failed: AtomicBool::new(false),
+            derived_views_stale: RwLock::new(None),
             mcp_transactions: Mutex::new(HashMap::new()),
             locate_rankings: Mutex::new(HashMap::new()),
             semantic_locate_pages: Mutex::new(HashMap::new()),
@@ -1810,6 +1821,7 @@ impl DaemonState {
             persisted_entity_count: AtomicU64::new(loaded_entity_count as u64),
             mass_deletion_blocked: AtomicBool::new(false),
             embed_worker_failed: AtomicBool::new(false),
+            derived_views_stale: RwLock::new(None),
             mcp_transactions: Mutex::new(HashMap::new()),
             locate_rankings: Mutex::new(HashMap::new()),
             semantic_locate_pages: Mutex::new(HashMap::new()),

--- a/crates/kin-remote/src/repository_transfer.rs
+++ b/crates/kin-remote/src/repository_transfer.rs
@@ -52,7 +52,11 @@ impl RepositoryAuthorityMetadata for RepositoryAuthorityState {
 }
 
 pub const REPOSITORY_TRANSFER_PROTOCOL: &str = "kin-repository-v6-fast-forward";
-pub const REPOSITORY_TRANSFER_SCHEMA_VERSION: u32 = 1;
+/// Version 2 adds `transfer_target_head`, which is what lets a receiver tell a
+/// deliberate continuation segment apart from a peer whose authority moved
+/// under the negotiation. A version 1 peer is refused by name rather than
+/// through a field-shape parse error.
+pub const REPOSITORY_TRANSFER_SCHEMA_VERSION: u32 = 2;
 pub const FEATURE_EXACT_TREES: &str = "exact-trees-v1";
 pub const FEATURE_IMMUTABLE_SOURCE_CAS: &str = "immutable-source-cas-v1";
 pub const FEATURE_REF_CAS: &str = "ref-cas-v1";
@@ -238,7 +242,21 @@ pub struct RepositoryTransferPack {
     pub repository_id: RepositoryId,
     pub source_ref: RefName,
     pub destination_ref: RefName,
+    /// The exact head this one pack publishes.
+    ///
+    /// For a transfer that fits a single envelope this is the source ref head.
+    /// For a continuation segment it is an intermediate checkpoint: an exact
+    /// ancestor of [`Self::transfer_target_head`] that the destination ref can
+    /// fast-forward to on its own.
     pub source_head: SemanticChangeId,
+    /// The head the whole transfer is moving toward.
+    ///
+    /// A receiver needs this to tell two very different things apart. A pack
+    /// whose `source_head` is not the head the peer advertised is either one
+    /// segment of a deliberate continuation, or a peer whose authority moved
+    /// mid-negotiation. Without a declared target those are indistinguishable,
+    /// and the safe reading of the second one is to refuse.
+    pub transfer_target_head: SemanticChangeId,
     pub source_tree_hash: Hash256,
     pub expected_destination_target: Option<RefTarget>,
     pub expected_destination_head: Option<SemanticChangeId>,
@@ -417,57 +435,323 @@ pub fn repository_ref_advertisement<B: StorageBackend + ?Sized + 'static>(
     })
 }
 
+/// One pack of a transfer that may need more than one, and what is left after
+/// it is published.
+///
+/// A segment is a complete, self-validating transfer in its own right: it
+/// carries a parent-closed change closure, publishes one exact head, and comes
+/// back with one receipt. What makes it a segment rather than the whole
+/// transfer is only that [`Self::remaining_changes`] is not zero.
+#[derive(Debug, Clone)]
+pub struct RepositoryTransferSegment {
+    pub pack: RepositoryTransferPack,
+    /// Exact changes still to move after this pack is published.
+    pub remaining_changes: usize,
+}
+
+impl RepositoryTransferSegment {
+    /// True when this pack lands the transfer target head, so nothing follows.
+    pub fn is_final(&self) -> bool {
+        self.remaining_changes == 0
+    }
+}
+
+/// The changes one pack carries, and how many are left behind it.
+struct SegmentPlan {
+    ordered: Vec<SemanticChangeId>,
+    remaining: usize,
+}
+
+/// A pack that could not be assembled inside the negotiated bounds.
+///
+/// This is separated from a genuine error because it is the one refusal a
+/// segmented transfer can answer by trying a smaller step. Every other failure
+/// means the history or the lease is wrong, and retrying would only repeat it.
+enum Assembled {
+    Pack(Box<RepositoryTransferPack>),
+    OverNegotiatedBound(String),
+}
+
 pub fn build_repository_transfer_pack<B: StorageBackend + ?Sized + 'static>(
     authority: &RepositoryAuthorityManager<B>,
     source_ref: &RefName,
     expectation: &RepositoryTransferExpectation,
 ) -> Result<RepositoryTransferPack> {
-    validate_expectation(expectation)?;
-    let lease = authority.read_authority();
-    if lease.authority_metadata().repository_id != expectation.repository_id {
+    let context = TransferSourceContext::read(authority, source_ref, expectation)?;
+    let ordered = collect_fast_forward_closure(
+        &context.all_changes,
+        context.source_head,
+        expectation.destination_head,
+    )?;
+    enforce_count("changes", ordered.len(), expectation.limits.max_changes)?;
+    let plan = SegmentPlan {
+        ordered,
+        remaining: 0,
+    };
+    match assemble_segment_pack(authority, &context, expectation, source_ref, &plan)? {
+        Assembled::Pack(pack) => Ok(*pack),
+        Assembled::OverNegotiatedBound(reason) => Err(invalid(reason)),
+    }
+}
+
+/// Build the largest pack that fits the negotiated bounds and still publishes a
+/// head the destination ref can fast-forward to.
+///
+/// The bound this works around is the negotiated envelope, not the history. A
+/// closure past the envelope is split into a sequence of packs, each of which
+/// is published atomically on its own. What it cannot split is one change: a
+/// single change whose new bodies exceed the negotiated byte bound is refused
+/// by name, because there is no smaller step that still lands a valid head.
+pub fn build_repository_transfer_segment<B: StorageBackend + ?Sized + 'static>(
+    authority: &RepositoryAuthorityManager<B>,
+    source_ref: &RefName,
+    expectation: &RepositoryTransferExpectation,
+) -> Result<RepositoryTransferSegment> {
+    let context = TransferSourceContext::read(authority, source_ref, expectation)?;
+    let closure = collect_fast_forward_closure(
+        &context.all_changes,
+        context.source_head,
+        expectation.destination_head,
+    )?;
+    if closure.is_empty() {
         return Err(invalid(format!(
-            "source repository {} does not match destination repository {}",
-            lease.authority_metadata().repository_id,
-            expectation.repository_id
+            "source head {} is already the destination head; there is no segment to build",
+            context.source_head
         )));
     }
-    require_negotiated_features(&expectation.supported_features)?;
 
-    let source_target = lease
-        .resolve_ref_target(source_ref)
-        .map_err(storage)?
-        .ok_or_else(|| invalid(format!("source ref {source_ref} is absent")))?;
-    let source_head = lease
-        .resolve_target_change_id(&source_target)
-        .map_err(storage)?;
-    let source_git_authority_hash =
-        hash_git_authority(lease.authority_metadata().git_external_authority.as_ref())?;
-    if source_git_authority_hash != expectation.git_authority_hash {
-        return Err(RepositoryTransferError::Conflict(
-            "repository-v6 transfer v1 requires identical imported-Git authority on both replicas; Git-authority bootstrap/divergence is not adapted"
-                .to_string(),
-        ));
-    }
-
-    let all_changes = lease.snapshot().changes.clone();
-    let ordered_ids =
-        collect_fast_forward_closure(&all_changes, source_head, expectation.destination_head)?;
-    enforce_count("changes", ordered_ids.len(), expectation.limits.max_changes)?;
-    let store = TransferChangeStore::new(all_changes.values().cloned());
-    let source_tree = store.resolve_tree_at(&source_head).map_err(model)?;
-    let source_tree_hash = compute_resolved_tree_hash(&source_tree).map_err(model)?;
-    let mut source_tree_bodies = BTreeSet::new();
-    for artifact in source_tree.artifacts() {
-        if let Some(hash) = artifact.entry.blob_identity() {
-            source_tree_bodies.insert(hash);
-        } else if !matches!(artifact.entry, TreeEntry::Gitlink { .. }) {
-            return Err(invalid(format!(
-                "source tree entry at {} has neither CAS body nor Gitlink identity",
-                artifact.path
-            )));
+    let mut budget = expectation.limits.max_changes;
+    loop {
+        let plan = plan_transfer_segment(
+            &context.all_changes,
+            &closure,
+            expectation.destination_head,
+            &expectation.limits,
+            budget,
+        )?;
+        let planned = plan.ordered.len();
+        match assemble_segment_pack(authority, &context, expectation, source_ref, &plan)? {
+            Assembled::Pack(pack) => {
+                return Ok(RepositoryTransferSegment {
+                    pack: *pack,
+                    remaining_changes: plan.remaining,
+                })
+            }
+            Assembled::OverNegotiatedBound(reason) => {
+                if planned <= 1 {
+                    return Err(invalid(format!(
+                        "the next publishable step of this transfer is one exact change and it {reason}; \
+                         a single change cannot be split across continuation packs"
+                    )));
+                }
+                // Halve rather than step down one change at a time: the bound
+                // that was hit is a byte or object total, so the useful search
+                // is over magnitudes, and this converges in log steps instead
+                // of rebuilding the pack once per change.
+                budget = u32::try_from(planned / 2).unwrap_or(1).max(1);
+            }
         }
     }
-    for hash in source_tree_bodies {
+}
+
+/// Check everything a publication decides before it assembles a pack.
+///
+/// This exists so a plan can refuse what a push refuses without publishing
+/// anything: the repository identity, the negotiated features, the source ref,
+/// the imported-Git authority baseline, and the presence and identity of every
+/// immutable body the publication head's tree depends on. It deliberately does
+/// not build packs, so it says nothing about per-pack byte totals.
+pub fn verify_transfer_source_readiness<B: StorageBackend + ?Sized + 'static>(
+    authority: &RepositoryAuthorityManager<B>,
+    source_ref: &RefName,
+    expectation: &RepositoryTransferExpectation,
+) -> Result<()> {
+    let context = TransferSourceContext::read(authority, source_ref, expectation)?;
+    let store = TransferChangeStore::new(context.all_changes.values().cloned());
+    let tree = store.resolve_tree_at(&context.source_head).map_err(model)?;
+    for hash in resolved_tree_body_identities(&tree)? {
+        let bytes = authority
+            .load_source_blob(hash)
+            .map_err(storage)?
+            .ok_or_else(|| invalid(format!("source tree CAS body {hash} is absent")))?;
+        verify_body(hash, &bytes)?;
+    }
+    Ok(())
+}
+
+/// How many packs the gap in `expectation` takes, counting nothing that needs
+/// bytes to be read.
+///
+/// This is a floor, not a promise. Segmentation also splits on the negotiated
+/// byte bounds, and those are only known once bodies are loaded, so a
+/// publication can take more packs than this and never fewer.
+pub fn count_repository_transfer_packs<B: StorageBackend + ?Sized + 'static>(
+    authority: &RepositoryAuthorityManager<B>,
+    source_ref: &RefName,
+    expectation: &RepositoryTransferExpectation,
+) -> Result<usize> {
+    let context = TransferSourceContext::read(authority, source_ref, expectation)?;
+    let mut boundary = expectation.destination_head;
+    let mut packs = 0usize;
+    loop {
+        let closure =
+            collect_fast_forward_closure(&context.all_changes, context.source_head, boundary)?;
+        if closure.is_empty() {
+            return Ok(packs);
+        }
+        let plan = plan_transfer_segment(
+            &context.all_changes,
+            &closure,
+            boundary,
+            &expectation.limits,
+            expectation.limits.max_changes,
+        )?;
+        packs += 1;
+        if plan.remaining == 0 {
+            return Ok(packs);
+        }
+        boundary = plan.ordered.last().copied();
+    }
+}
+
+/// Everything one coherent authority lease contributes to a pack.
+struct TransferSourceContext {
+    all_changes: std::collections::HashMap<SemanticChangeId, SemanticChange>,
+    source_head: SemanticChangeId,
+    source_git_authority_hash: Option<Hash256>,
+    aliases: Vec<ExternalChangeAlias>,
+    external_objects: Vec<ExternalObjectRecord>,
+}
+
+impl TransferSourceContext {
+    fn read<B: StorageBackend + ?Sized + 'static>(
+        authority: &RepositoryAuthorityManager<B>,
+        source_ref: &RefName,
+        expectation: &RepositoryTransferExpectation,
+    ) -> Result<Self> {
+        validate_expectation(expectation)?;
+        let lease = authority.read_authority();
+        if lease.authority_metadata().repository_id != expectation.repository_id {
+            return Err(invalid(format!(
+                "source repository {} does not match destination repository {}",
+                lease.authority_metadata().repository_id,
+                expectation.repository_id
+            )));
+        }
+        require_negotiated_features(&expectation.supported_features)?;
+
+        let source_target = lease
+            .resolve_ref_target(source_ref)
+            .map_err(storage)?
+            .ok_or_else(|| invalid(format!("source ref {source_ref} is absent")))?;
+        let source_head = lease
+            .resolve_target_change_id(&source_target)
+            .map_err(storage)?;
+        let source_git_authority_hash =
+            hash_git_authority(lease.authority_metadata().git_external_authority.as_ref())?;
+        if source_git_authority_hash != expectation.git_authority_hash {
+            return Err(RepositoryTransferError::Conflict(
+                "repository-v6 transfer v1 requires identical imported-Git authority on both replicas; Git-authority bootstrap/divergence is not adapted"
+                    .to_string(),
+            ));
+        }
+
+        Ok(Self {
+            all_changes: lease.snapshot().changes.clone(),
+            source_head,
+            source_git_authority_hash,
+            aliases: lease.authority_metadata().aliases.clone(),
+            external_objects: lease.authority_metadata().external_objects.clone(),
+        })
+    }
+}
+
+/// Choose the longest parent-closed prefix of `closure` that stays inside the
+/// negotiated bounds and ends on a change the destination ref can fast-forward
+/// to.
+///
+/// Both conditions matter and only one of them is obvious. The prefix is
+/// parent-closed because the closure is ordered parent-before-child. The
+/// endpoint has to be a descendant of the destination head as well, which a
+/// prefix does not give for free: merging a side line puts that line's changes
+/// in the closure ahead of the merge, and none of them descend from the
+/// destination head. Ending a segment there would ask the destination ref to
+/// move sideways onto an unrelated change.
+fn plan_transfer_segment(
+    changes: &std::collections::HashMap<SemanticChangeId, SemanticChange>,
+    closure: &[SemanticChangeId],
+    destination_head: Option<SemanticChangeId>,
+    limits: &RepositoryTransferLimits,
+    change_budget: u32,
+) -> Result<SegmentPlan> {
+    let mut descends = BTreeMap::new();
+    let mut bodies = BTreeSet::new();
+    let mut last_publishable: Option<usize> = None;
+
+    for (index, id) in closure.iter().enumerate() {
+        let change = changes
+            .get(id)
+            .ok_or_else(|| invalid(format!("source closure is missing change {id}")))?;
+        descends.insert(
+            *id,
+            destination_head.is_none()
+                || change.parents.iter().any(|parent| {
+                    Some(*parent) == destination_head || descends.get(parent) == Some(&true)
+                }),
+        );
+        for delta in &change.tree_deltas {
+            if let Some(new) = delta.new_state() {
+                if let Some(hash) = new.entry.blob_identity() {
+                    bodies.insert(hash);
+                }
+            }
+        }
+        let count = u32::try_from(index + 1).unwrap_or(u32::MAX);
+        if count > change_budget
+            || u32::try_from(bodies.len()).unwrap_or(u32::MAX) > limits.max_bodies
+        {
+            break;
+        }
+        if descends.get(id) == Some(&true) {
+            last_publishable = Some(index);
+        }
+    }
+
+    let end = last_publishable.ok_or_else(|| {
+        invalid(format!(
+            "no change in this closure both fits the negotiated envelope ({change_budget} changes, \
+             {} bodies) and descends from destination head {}; the transfer cannot be split here",
+            limits.max_bodies,
+            destination_head
+                .map(|head| head.to_string())
+                .unwrap_or_else(|| "an unborn ref".to_string()),
+        ))
+    })?;
+    // Carry exactly the endpoint's own ancestry rather than the whole scanned
+    // prefix. A topological prefix can hold a change that is not an ancestor
+    // of the change it ends on: order a merge's two lines the other way and
+    // the far line lands ahead of the near one. Sending it in this segment
+    // would leave the next segment's closure carrying it a second time.
+    let ordered = collect_fast_forward_closure(changes, closure[end], destination_head)?;
+    let remaining = closure.len().saturating_sub(ordered.len());
+    Ok(SegmentPlan { ordered, remaining })
+}
+
+fn assemble_segment_pack<B: StorageBackend + ?Sized + 'static>(
+    authority: &RepositoryAuthorityManager<B>,
+    context: &TransferSourceContext,
+    expectation: &RepositoryTransferExpectation,
+    source_ref: &RefName,
+    plan: &SegmentPlan,
+) -> Result<Assembled> {
+    // An empty closure means the two replicas already resolve the ref to the
+    // same change. The pack then publishes that head and carries nothing,
+    // which is what a caller that asked for a pack anyway should get back.
+    let segment_head = plan.ordered.last().copied().unwrap_or(context.source_head);
+    let store = TransferChangeStore::new(context.all_changes.values().cloned());
+    let segment_tree = store.resolve_tree_at(&segment_head).map_err(model)?;
+    let segment_tree_hash = compute_resolved_tree_hash(&segment_tree).map_err(model)?;
+    for hash in resolved_tree_body_identities(&segment_tree)? {
         let bytes = authority
             .load_source_blob(hash)
             .map_err(storage)?
@@ -475,14 +759,15 @@ pub fn build_repository_transfer_pack<B: StorageBackend + ?Sized + 'static>(
         verify_body(hash, &bytes)?;
     }
 
-    let mut changes = Vec::with_capacity(ordered_ids.len());
-    let mut trees = Vec::with_capacity(ordered_ids.len());
+    let mut changes = Vec::with_capacity(plan.ordered.len());
+    let mut trees = Vec::with_capacity(plan.ordered.len());
     let mut required_body_hashes = BTreeSet::new();
-    let included = ordered_ids.iter().copied().collect::<BTreeSet<_>>();
+    let included = plan.ordered.iter().copied().collect::<BTreeSet<_>>();
     let mut required_git_oids = BTreeSet::new();
-    for change_id in ordered_ids {
-        let change = all_changes
-            .get(&change_id)
+    for change_id in &plan.ordered {
+        let change = context
+            .all_changes
+            .get(change_id)
             .cloned()
             .ok_or_else(|| invalid(format!("source closure is missing change {change_id}")))?;
         validate_semantic_change_id(&change).map_err(model)?;
@@ -504,8 +789,7 @@ pub fn build_repository_transfer_pack<B: StorageBackend + ?Sized + 'static>(
         changes.push(change);
     }
 
-    let aliases = lease
-        .authority_metadata()
+    let aliases = context
         .aliases
         .iter()
         .filter(|alias| {
@@ -513,8 +797,7 @@ pub fn build_repository_transfer_pack<B: StorageBackend + ?Sized + 'static>(
         })
         .cloned()
         .collect::<Vec<_>>();
-    let external_objects = lease
-        .authority_metadata()
+    let external_objects = context
         .external_objects
         .iter()
         .filter(|record| required_git_oids.contains(&record.object.oid))
@@ -524,18 +807,24 @@ pub fn build_repository_transfer_pack<B: StorageBackend + ?Sized + 'static>(
         required_body_hashes.insert(record.body_hash);
     }
 
-    enforce_count("trees", trees.len(), expectation.limits.max_trees)?;
-    enforce_count(
-        "external objects",
-        external_objects.len(),
-        expectation.limits.max_external_objects,
-    )?;
-    enforce_count("aliases", aliases.len(), expectation.limits.max_aliases)?;
-    enforce_count(
-        "source bodies",
-        required_body_hashes.len(),
-        expectation.limits.max_bodies,
-    )?;
+    for (label, actual, limit) in [
+        ("trees", trees.len(), expectation.limits.max_trees),
+        (
+            "external objects",
+            external_objects.len(),
+            expectation.limits.max_external_objects,
+        ),
+        ("aliases", aliases.len(), expectation.limits.max_aliases),
+        (
+            "source bodies",
+            required_body_hashes.len(),
+            expectation.limits.max_bodies,
+        ),
+    ] {
+        if let Some(reason) = over_count(label, actual, limit) {
+            return Ok(Assembled::OverNegotiatedBound(reason));
+        }
+    }
 
     let mut total_bytes = 0_u64;
     let mut bodies = Vec::with_capacity(required_body_hashes.len());
@@ -547,8 +836,8 @@ pub fn build_repository_transfer_pack<B: StorageBackend + ?Sized + 'static>(
         let byte_len = u64::try_from(bytes.len())
             .map_err(|_| invalid("source body length does not fit u64"))?;
         if byte_len > expectation.limits.max_single_body_bytes {
-            return Err(invalid(format!(
-                "source body {hash} is {byte_len} bytes, over negotiated limit {}",
+            return Ok(Assembled::OverNegotiatedBound(format!(
+                "carries source body {hash} at {byte_len} bytes, over negotiated limit {}",
                 expectation.limits.max_single_body_bytes
             )));
         }
@@ -556,8 +845,8 @@ pub fn build_repository_transfer_pack<B: StorageBackend + ?Sized + 'static>(
             .checked_add(byte_len)
             .ok_or_else(|| invalid("source body byte total overflow"))?;
         if total_bytes > expectation.limits.max_decoded_body_bytes {
-            return Err(invalid(format!(
-                "source body closure is {total_bytes} bytes, over negotiated limit {}",
+            return Ok(Assembled::OverNegotiatedBound(format!(
+                "carries a {total_bytes} byte source body closure, over negotiated limit {}",
                 expectation.limits.max_decoded_body_bytes
             )));
         }
@@ -572,13 +861,14 @@ pub fn build_repository_transfer_pack<B: StorageBackend + ?Sized + 'static>(
         repository_id: expectation.repository_id.clone(),
         source_ref: source_ref.clone(),
         destination_ref: expectation.destination_ref.clone(),
-        source_head,
-        source_tree_hash,
+        source_head: segment_head,
+        transfer_target_head: context.source_head,
+        source_tree_hash: segment_tree_hash,
         expected_destination_target: expectation.destination_target.clone(),
         expected_destination_head: expectation.destination_head,
         expected_destination_roots: expectation.roots.clone(),
         expected_destination_default_ref: expectation.default_ref.clone(),
-        source_git_authority_hash,
+        source_git_authority_hash: context.source_git_authority_hash,
         expected_destination_git_authority_hash: expectation.git_authority_hash,
         required_features: required_features(),
         changes,
@@ -589,7 +879,25 @@ pub fn build_repository_transfer_pack<B: StorageBackend + ?Sized + 'static>(
     };
     pack.transfer_id = compute_transfer_id(&pack)?;
     validate_pack(&pack)?;
-    Ok(pack)
+    Ok(Assembled::Pack(Box::new(pack)))
+}
+
+/// Every immutable CAS body one resolved tree depends on.
+fn resolved_tree_body_identities(
+    tree: &kin_model::ResolvedTree,
+) -> Result<BTreeSet<Hash256>> {
+    let mut identities = BTreeSet::new();
+    for artifact in tree.artifacts() {
+        if let Some(hash) = artifact.entry.blob_identity() {
+            identities.insert(hash);
+        } else if !matches!(artifact.entry, TreeEntry::Gitlink { .. }) {
+            return Err(invalid(format!(
+                "source tree entry at {} has neither CAS body nor Gitlink identity",
+                artifact.path
+            )));
+        }
+    }
+    Ok(identities)
 }
 
 pub fn apply_repository_transfer_pack<B: StorageBackend + ?Sized + 'static>(
@@ -762,6 +1070,31 @@ pub fn validate_pack(pack: &RepositoryTransferPack) -> Result<()> {
             pack.source_head
         )));
     }
+    // The head a pack publishes is the last change it carries. A pack that
+    // carried changes past its own publish head would be describing a segment
+    // boundary that its ref mutation does not match, which is exactly the
+    // ambiguity continuation packs exist to remove.
+    if let Some(last) = pack.changes.last() {
+        if last.id != pack.source_head {
+            return Err(invalid(format!(
+                "pack publishes {} but its closure ends at {}",
+                pack.source_head, last.id
+            )));
+        }
+    }
+    // A pack that already carries the transfer target has nothing left to
+    // continue toward, so it must be publishing it.
+    if pack.transfer_target_head != pack.source_head
+        && pack
+            .changes
+            .iter()
+            .any(|change| change.id == pack.transfer_target_head)
+    {
+        return Err(invalid(format!(
+            "pack carries transfer target {} but publishes {} instead",
+            pack.transfer_target_head, pack.source_head
+        )));
+    }
 
     if pack.trees.len() != pack.changes.len() {
         return Err(invalid(
@@ -868,7 +1201,31 @@ fn validate_status(status: &RepositoryTransferStatus) -> Result<()> {
         return Err(invalid("unsupported repository transfer status protocol"));
     }
     status.roots.validate().map_err(model)?;
+    validate_limits(&status.limits)?;
     require_negotiated_features(&status.supported_features)
+}
+
+/// Refuse a peer whose advertised envelope cannot carry anything.
+///
+/// A continuation loop asks the peer how much it accepts and then sends that
+/// much until the gap closes. A peer advertising a zero-sized envelope would
+/// make every segment empty, so the loop has to refuse it here rather than
+/// discover it as a lack of progress after the first round trip.
+fn validate_limits(limits: &RepositoryTransferLimits) -> Result<()> {
+    for (label, value) in [
+        ("max_changes", u64::from(limits.max_changes)),
+        ("max_trees", u64::from(limits.max_trees)),
+        ("max_bodies", u64::from(limits.max_bodies)),
+        ("max_single_body_bytes", limits.max_single_body_bytes),
+        ("max_decoded_body_bytes", limits.max_decoded_body_bytes),
+    ] {
+        if value == 0 {
+            return Err(invalid(format!(
+                "destination advertises {label} of zero, which can never carry a transfer"
+            )));
+        }
+    }
+    Ok(())
 }
 
 fn validate_expectation(expectation: &RepositoryTransferExpectation) -> Result<()> {
@@ -1188,6 +1545,15 @@ fn verify_body(expected: Hash256, bytes: &[u8]) -> Result<()> {
         )));
     }
     Ok(())
+}
+
+/// Describe a count past its negotiated limit, or `None` when it fits.
+///
+/// Separate from [`enforce_count`] because a segmented transfer answers this
+/// by building a smaller pack rather than by failing.
+fn over_count(label: &str, actual: usize, limit: u32) -> Option<String> {
+    let fits = u32::try_from(actual).is_ok_and(|actual| actual <= limit);
+    (!fits).then(|| format!("carries {actual} {label}, over negotiated limit {limit}"))
 }
 
 fn enforce_count(label: &str, actual: usize, limit: u32) -> Result<()> {

--- a/crates/kin-remote/src/repository_transfer.rs
+++ b/crates/kin-remote/src/repository_transfer.rs
@@ -673,6 +673,16 @@ impl TransferSourceContext {
     }
 }
 
+/// The earliest change in `closure` the destination ref can fast-forward to.
+fn smallest_publishable_step(
+    closure: &[SemanticChangeId],
+    descends: &BTreeMap<SemanticChangeId, bool>,
+) -> Option<usize> {
+    closure
+        .iter()
+        .position(|id| descends.get(id) == Some(&true))
+}
+
 /// Choose the longest parent-closed prefix of `closure` that stays inside the
 /// negotiated bounds and ends on a change the destination ref can fast-forward
 /// to.
@@ -714,26 +724,32 @@ fn plan_transfer_segment(
             }
         }
         let count = u32::try_from(index + 1).unwrap_or(u32::MAX);
-        if count > change_budget
-            || u32::try_from(bodies.len()).unwrap_or(u32::MAX) > limits.max_bodies
-        {
-            break;
-        }
-        if descends.get(id) == Some(&true) {
+        let within_budget = count <= change_budget
+            && u32::try_from(bodies.len()).unwrap_or(u32::MAX) <= limits.max_bodies;
+        if within_budget && descends.get(id) == Some(&true) {
             last_publishable = Some(index);
         }
     }
 
-    let end = last_publishable.ok_or_else(|| {
-        invalid(format!(
-            "no change in this closure both fits the negotiated envelope ({change_budget} changes, \
-             {} bodies) and descends from destination head {}; the transfer cannot be split here",
-            limits.max_bodies,
-            destination_head
-                .map(|head| head.to_string())
-                .unwrap_or_else(|| "an unborn ref".to_string()),
-        ))
-    })?;
+    // No boundary fits the budget. That does not mean the transfer is stuck:
+    // it means the smallest step that lands a head this ref can reach is
+    // bigger than the envelope asked for. Merging a side line does this, and
+    // it does it partway through a publication that has already moved history,
+    // so refusing here would strand a transfer rather than bound it. Take the
+    // smallest publishable step there is and let the pack limits refuse it if
+    // it genuinely cannot be built.
+    let end = match last_publishable {
+        Some(end) => end,
+        None => smallest_publishable_step(closure, &descends).ok_or_else(|| {
+            invalid(format!(
+                "no change in this closure descends from destination head {}, so no pack can \
+                 publish a head this ref reaches",
+                destination_head
+                    .map(|head| head.to_string())
+                    .unwrap_or_else(|| "an unborn ref".to_string()),
+            ))
+        })?,
+    };
     // Carry exactly the endpoint's own ancestry rather than the whole scanned
     // prefix. A topological prefix can hold a change that is not an ancestor
     // of the change it ends on: order a merge's two lines the other way and
@@ -890,9 +906,7 @@ fn assemble_segment_pack<B: StorageBackend + ?Sized + 'static>(
 }
 
 /// Every immutable CAS body one resolved tree depends on.
-fn resolved_tree_body_identities(
-    tree: &kin_model::ResolvedTree,
-) -> Result<BTreeSet<Hash256>> {
+fn resolved_tree_body_identities(tree: &kin_model::ResolvedTree) -> Result<BTreeSet<Hash256>> {
     let mut identities = BTreeSet::new();
     for artifact in tree.artifacts() {
         if let Some(hash) = artifact.entry.blob_identity() {

--- a/crates/kin-remote/src/repository_transfer.rs
+++ b/crates/kin-remote/src/repository_transfer.rs
@@ -115,6 +115,31 @@ impl Default for RepositoryTransferLimits {
     }
 }
 
+impl RepositoryTransferLimits {
+    /// Bound peer- or request-supplied ceilings by what this implementation can
+    /// construct and validate locally.
+    ///
+    /// Transfer limits are ceilings rather than quotas, so choosing the
+    /// smaller local value remains compatible with a peer that can accept a
+    /// larger envelope. It also keeps an untrusted advertisement or export
+    /// request from making this process assemble a pack its own receiver would
+    /// reject, or from turning one bounded transfer step into unbounded work.
+    fn bounded_by_local(self) -> Self {
+        let local = Self::default();
+        Self {
+            max_changes: self.max_changes.min(local.max_changes),
+            max_trees: self.max_trees.min(local.max_trees),
+            max_bodies: self.max_bodies.min(local.max_bodies),
+            max_external_objects: self.max_external_objects.min(local.max_external_objects),
+            max_aliases: self.max_aliases.min(local.max_aliases),
+            max_decoded_body_bytes: self
+                .max_decoded_body_bytes
+                .min(local.max_decoded_body_bytes),
+            max_single_body_bytes: self.max_single_body_bytes.min(local.max_single_body_bytes),
+        }
+    }
+}
+
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 #[serde(deny_unknown_fields)]
 pub struct RepositoryTransferStatus {
@@ -166,6 +191,7 @@ impl TryFrom<RepositoryTransferStatus> for RepositoryTransferExpectation {
 
     fn try_from(status: RepositoryTransferStatus) -> Result<Self> {
         validate_status(&status)?;
+        let limits = status.limits.bounded_by_local();
         Ok(Self {
             repository_id: status.repository_id,
             destination_ref: status.destination_ref,
@@ -175,7 +201,7 @@ impl TryFrom<RepositoryTransferStatus> for RepositoryTransferExpectation {
             default_ref: status.default_ref,
             git_authority_hash: status.git_authority_hash,
             supported_features: status.supported_features,
-            limits: status.limits,
+            limits,
         })
     }
 }
@@ -491,7 +517,8 @@ pub fn build_repository_transfer_pack<B: StorageBackend + ?Sized + 'static>(
     source_ref: &RefName,
     expectation: &RepositoryTransferExpectation,
 ) -> Result<RepositoryTransferPack> {
-    let context = TransferSourceContext::read(authority, source_ref, expectation)?;
+    let expectation = locally_bounded_expectation(expectation)?;
+    let context = TransferSourceContext::read(authority, source_ref, &expectation)?;
     let ordered = collect_fast_forward_closure(
         &context.all_changes,
         context.source_head,
@@ -503,7 +530,7 @@ pub fn build_repository_transfer_pack<B: StorageBackend + ?Sized + 'static>(
         remaining: 0,
         is_smallest_publishable_step: false,
     };
-    match assemble_segment_pack(authority, &context, expectation, source_ref, &plan)? {
+    match assemble_segment_pack(authority, &context, &expectation, source_ref, &plan)? {
         Assembled::Pack(pack) => Ok(*pack),
         Assembled::OverNegotiatedBound(reason) => Err(invalid(reason)),
     }
@@ -522,7 +549,8 @@ pub fn build_repository_transfer_segment<B: StorageBackend + ?Sized + 'static>(
     source_ref: &RefName,
     expectation: &RepositoryTransferExpectation,
 ) -> Result<RepositoryTransferSegment> {
-    let context = TransferSourceContext::read(authority, source_ref, expectation)?;
+    let expectation = locally_bounded_expectation(expectation)?;
+    let context = TransferSourceContext::read(authority, source_ref, &expectation)?;
     let closure = collect_fast_forward_closure(
         &context.all_changes,
         context.source_head,
@@ -545,7 +573,7 @@ pub fn build_repository_transfer_segment<B: StorageBackend + ?Sized + 'static>(
             budget,
         )?;
         let planned = plan.ordered.len();
-        match assemble_segment_pack(authority, &context, expectation, source_ref, &plan)? {
+        match assemble_segment_pack(authority, &context, &expectation, source_ref, &plan)? {
             Assembled::Pack(pack) => {
                 return Ok(RepositoryTransferSegment {
                     pack: *pack,
@@ -599,7 +627,8 @@ pub fn verify_transfer_source_readiness<B: StorageBackend + ?Sized + 'static>(
     source_ref: &RefName,
     expectation: &RepositoryTransferExpectation,
 ) -> Result<()> {
-    let context = TransferSourceContext::read(authority, source_ref, expectation)?;
+    let expectation = locally_bounded_expectation(expectation)?;
+    let context = TransferSourceContext::read(authority, source_ref, &expectation)?;
     let store = TransferChangeStore::new(context.all_changes.values().cloned());
     let tree = store.resolve_tree_at(&context.source_head).map_err(model)?;
     for hash in resolved_tree_body_identities(&tree)? {
@@ -623,7 +652,8 @@ pub fn count_repository_transfer_packs<B: StorageBackend + ?Sized + 'static>(
     source_ref: &RefName,
     expectation: &RepositoryTransferExpectation,
 ) -> Result<usize> {
-    let context = TransferSourceContext::read(authority, source_ref, expectation)?;
+    let expectation = locally_bounded_expectation(expectation)?;
+    let context = TransferSourceContext::read(authority, source_ref, &expectation)?;
     let mut boundary = expectation.destination_head;
     let mut packs = 0usize;
     loop {
@@ -1298,6 +1328,15 @@ fn validate_expectation(expectation: &RepositoryTransferExpectation) -> Result<(
     require_negotiated_features(&expectation.supported_features)
 }
 
+fn locally_bounded_expectation(
+    expectation: &RepositoryTransferExpectation,
+) -> Result<RepositoryTransferExpectation> {
+    validate_expectation(expectation)?;
+    let mut bounded = expectation.clone();
+    bounded.limits = bounded.limits.bounded_by_local();
+    Ok(bounded)
+}
+
 fn required_features() -> Vec<String> {
     REQUIRED_FEATURES
         .iter()
@@ -1753,6 +1792,19 @@ mod tests {
             Arc::new(LocalFileBackend::new(storage_root)),
         )
         .unwrap()
+    }
+
+    fn limits_above_every_local_ceiling() -> RepositoryTransferLimits {
+        let local = RepositoryTransferLimits::default();
+        RepositoryTransferLimits {
+            max_changes: local.max_changes.checked_add(1).unwrap(),
+            max_trees: local.max_trees.checked_add(1).unwrap(),
+            max_bodies: local.max_bodies.checked_add(1).unwrap(),
+            max_external_objects: local.max_external_objects.checked_add(1).unwrap(),
+            max_aliases: local.max_aliases.checked_add(1).unwrap(),
+            max_decoded_body_bytes: local.max_decoded_body_bytes.checked_add(1).unwrap(),
+            max_single_body_bytes: local.max_single_body_bytes.checked_add(1).unwrap(),
+        }
     }
 
     fn native_change(
@@ -2263,6 +2315,45 @@ mod tests {
         )
         .unwrap_err();
         assert!(error.to_string().contains("different exact transaction"));
+    }
+
+    #[test]
+    fn status_advertisement_above_local_caps_is_bounded_before_negotiation() {
+        let fixture = fixture();
+        let mut advertised =
+            repository_transfer_status(&fixture.destination, &fixture.repository_id, &fixture.main)
+                .unwrap();
+        advertised.limits = limits_above_every_local_ceiling();
+
+        let expectation = RepositoryTransferExpectation::try_from(advertised).unwrap();
+
+        assert_eq!(
+            expectation.limits,
+            RepositoryTransferLimits::default(),
+            "a peer's larger ceilings must not enlarge this process's bounded envelope"
+        );
+    }
+
+    #[test]
+    fn export_expectation_above_local_caps_is_bounded_before_assembly() {
+        let fixture = fixture();
+        let status =
+            repository_transfer_status(&fixture.destination, &fixture.repository_id, &fixture.main)
+                .unwrap();
+        let mut expectation = RepositoryTransferExpectation::try_from(status).unwrap();
+        expectation.limits = limits_above_every_local_ceiling();
+
+        let bounded = locally_bounded_expectation(&expectation).unwrap();
+        assert_eq!(
+            bounded.limits,
+            RepositoryTransferLimits::default(),
+            "request-body ceilings must be bounded before an export is planned"
+        );
+
+        let segment =
+            build_repository_transfer_segment(&fixture.source, &fixture.main, &expectation)
+                .unwrap();
+        validate_pack(&segment.pack).expect("the locally bounded exporter must build a valid pack");
     }
 
     #[test]

--- a/crates/kin-remote/src/repository_transfer.rs
+++ b/crates/kin-remote/src/repository_transfer.rs
@@ -130,13 +130,20 @@ pub struct RepositoryTransferStatus {
     pub git_authority_hash: Option<Hash256>,
     pub supported_features: Vec<String>,
     pub limits: RepositoryTransferLimits,
-    /// False until deterministic continuation packs make per-envelope limits
-    /// independent of repository history/blob size. Do not expose this
-    /// bounded primitive as general `kin push`.
+    /// This peer applies a publication whose closure is larger than one
+    /// envelope, by receiving the continuation packs it is split into.
+    ///
+    /// What this does not claim is freedom from every bound. A single change
+    /// whose new bodies exceed the negotiated byte limit is indivisible and is
+    /// refused by name, because there is no smaller step that still lands a
+    /// valid head. The bound that continuation packs removed is the one that
+    /// scaled with history length.
     pub push_apply_ready: bool,
     /// The server can export this bounded exact seam. The name deliberately
     /// avoids advertising a general pull capability.
     pub bounded_envelope_export_ready: bool,
+    /// This peer admits an exported closure larger than one envelope, pack by
+    /// pack, under the same bound as [`Self::push_apply_ready`].
     pub pull_apply_ready: bool,
 }
 
@@ -348,9 +355,9 @@ pub fn repository_transfer_status<B: StorageBackend + ?Sized + 'static>(
         git_authority_hash,
         supported_features: required_features(),
         limits: RepositoryTransferLimits::default(),
-        push_apply_ready: false,
+        push_apply_ready: true,
         bounded_envelope_export_ready: true,
-        pull_apply_ready: false,
+        pull_apply_ready: true,
     })
 }
 
@@ -2125,9 +2132,9 @@ mod tests {
         let advertised =
             repository_transfer_status(&fixture.destination, &fixture.repository_id, &fixture.main)
                 .unwrap();
-        assert!(!advertised.push_apply_ready);
+        assert!(advertised.push_apply_ready);
         assert!(advertised.bounded_envelope_export_ready);
-        assert!(!advertised.pull_apply_ready);
+        assert!(advertised.pull_apply_ready);
         assert_eq!(fixture.pack.changes.len(), 1);
         assert_eq!(fixture.pack.trees.len(), 1);
         assert_eq!(

--- a/crates/kin-remote/src/repository_transfer.rs
+++ b/crates/kin-remote/src/repository_transfer.rs
@@ -467,6 +467,13 @@ impl RepositoryTransferSegment {
 struct SegmentPlan {
     ordered: Vec<SemanticChangeId>,
     remaining: usize,
+    /// The plan had to reach past the change budget to end on a change the
+    /// destination ref can fast-forward to.
+    ///
+    /// This is what tells a caller whether a refusal can be answered by trying
+    /// a smaller step. Nothing inside this segment can end one, so replanning
+    /// under any smaller budget rebuilds exactly this segment.
+    is_smallest_publishable_step: bool,
 }
 
 /// A pack that could not be assembled inside the negotiated bounds.
@@ -494,6 +501,7 @@ pub fn build_repository_transfer_pack<B: StorageBackend + ?Sized + 'static>(
     let plan = SegmentPlan {
         ordered,
         remaining: 0,
+        is_smallest_publishable_step: false,
     };
     match assemble_segment_pack(authority, &context, expectation, source_ref, &plan)? {
         Assembled::Pack(pack) => Ok(*pack),
@@ -549,6 +557,24 @@ pub fn build_repository_transfer_segment<B: StorageBackend + ?Sized + 'static>(
                     return Err(invalid(format!(
                         "the next publishable step of this transfer is one exact change and it {reason}; \
                          a single change cannot be split across continuation packs"
+                    )));
+                }
+                // A smaller budget is only worth trying when it can produce a
+                // smaller segment, and here it cannot: the planner already had
+                // to reach past the budget to end on a change this ref can
+                // fast-forward to, so every replan rebuilds this same segment.
+                // Refusing by name is the answer the caller needs; shrinking
+                // the budget again would be a hang standing in for a refusal.
+                //
+                // This is also what bounds the loop. A plan that stayed inside
+                // its budget is never longer than it, so the next budget is
+                // strictly smaller than the segment just refused, and a plan
+                // that reached past its budget stops here.
+                if plan.is_smallest_publishable_step {
+                    return Err(invalid(format!(
+                        "the next publishable step of this transfer is {planned} changes and it \
+                         {reason}; no smaller part of it ends on a change this destination ref can \
+                         fast-forward to, so it cannot be split across continuation packs"
                     )));
                 }
                 // Halve rather than step down one change at a time: the bound
@@ -738,17 +764,20 @@ fn plan_transfer_segment(
     // so refusing here would strand a transfer rather than bound it. Take the
     // smallest publishable step there is and let the pack limits refuse it if
     // it genuinely cannot be built.
-    let end = match last_publishable {
-        Some(end) => end,
-        None => smallest_publishable_step(closure, &descends).ok_or_else(|| {
-            invalid(format!(
-                "no change in this closure descends from destination head {}, so no pack can \
-                 publish a head this ref reaches",
-                destination_head
-                    .map(|head| head.to_string())
-                    .unwrap_or_else(|| "an unborn ref".to_string()),
-            ))
-        })?,
+    let (end, is_smallest_publishable_step) = match last_publishable {
+        Some(end) => (end, false),
+        None => (
+            smallest_publishable_step(closure, &descends).ok_or_else(|| {
+                invalid(format!(
+                    "no change in this closure descends from destination head {}, so no pack can \
+                     publish a head this ref reaches",
+                    destination_head
+                        .map(|head| head.to_string())
+                        .unwrap_or_else(|| "an unborn ref".to_string()),
+                ))
+            })?,
+            true,
+        ),
     };
     // Carry exactly the endpoint's own ancestry rather than the whole scanned
     // prefix. A topological prefix can hold a change that is not an ancestor
@@ -757,7 +786,11 @@ fn plan_transfer_segment(
     // would leave the next segment's closure carrying it a second time.
     let ordered = collect_fast_forward_closure(changes, closure[end], destination_head)?;
     let remaining = closure.len().saturating_sub(ordered.len());
-    Ok(SegmentPlan { ordered, remaining })
+    Ok(SegmentPlan {
+        ordered,
+        remaining,
+        is_smallest_publishable_step,
+    })
 }
 
 fn assemble_segment_pack<B: StorageBackend + ?Sized + 'static>(
@@ -1226,12 +1259,17 @@ fn validate_status(status: &RepositoryTransferStatus) -> Result<()> {
     require_negotiated_features(&status.supported_features)
 }
 
-/// Refuse a peer whose advertised envelope cannot carry anything.
+/// Refuse an envelope that cannot carry anything.
 ///
 /// A continuation loop asks the peer how much it accepts and then sends that
 /// much until the gap closes. A peer advertising a zero-sized envelope would
 /// make every segment empty, so the loop has to refuse it here rather than
 /// discover it as a lack of progress after the first round trip.
+///
+/// The same numbers come back the other way on the export route, where they
+/// arrive in a request body rather than from a status this process built, so
+/// an exporter checks them too rather than trusting the sender to have asked
+/// for something it can answer.
 fn validate_limits(limits: &RepositoryTransferLimits) -> Result<()> {
     for (label, value) in [
         ("max_changes", u64::from(limits.max_changes)),
@@ -1242,7 +1280,7 @@ fn validate_limits(limits: &RepositoryTransferLimits) -> Result<()> {
     ] {
         if value == 0 {
             return Err(invalid(format!(
-                "destination advertises {label} of zero, which can never carry a transfer"
+                "the negotiated {label} is zero, which can never carry a transfer"
             )));
         }
     }
@@ -1251,6 +1289,7 @@ fn validate_limits(limits: &RepositoryTransferLimits) -> Result<()> {
 
 fn validate_expectation(expectation: &RepositoryTransferExpectation) -> Result<()> {
     expectation.roots.validate().map_err(model)?;
+    validate_limits(&expectation.limits)?;
     if expectation.destination_head.is_some() != expectation.destination_target.is_some() {
         return Err(invalid(
             "destination target and resolved head must both be present or absent",

--- a/crates/kin-remote/src/repository_transfer_http.rs
+++ b/crates/kin-remote/src/repository_transfer_http.rs
@@ -344,6 +344,29 @@ mod tests {
     }
 
     #[test]
+    fn a_body_of_exactly_the_declared_bound_is_read_and_one_byte_more_is_refused() {
+        // Both replicas declare the same number, so the boundary itself has to
+        // land on the same side of the refusal on both. A client that stopped
+        // one byte early would refuse envelopes the daemon route accepts, and
+        // would blame the peer for a bound this side chose.
+        let filler = REPOSITORY_TRANSFER_HTTP_BODY_LIMIT - r#"{"value":""}"#.len();
+        let payload = format!(r#"{{"value":"{}"}}"#, "a".repeat(filler));
+        assert_eq!(payload.len(), REPOSITORY_TRANSFER_HTTP_BODY_LIMIT);
+        let value: serde_json::Value =
+            read_json(json_response(payload), "transfer export").expect("a body at the bound");
+        assert_eq!(value["value"].as_str().unwrap().len(), filler);
+
+        let payload = format!(r#"{{"value":"{}"}}"#, "a".repeat(filler + 1));
+        assert_eq!(payload.len(), REPOSITORY_TRANSFER_HTTP_BODY_LIMIT + 1);
+        let error = read_json::<serde_json::Value>(json_response(payload), "transfer export")
+            .expect_err("a body one byte past the bound is refused");
+        let RepositoryTransferError::Invalid(message) = error else {
+            panic!("a local read bound is not a remote storage failure");
+        };
+        assert!(message.contains("transfer body limit"));
+    }
+
+    #[test]
     fn a_body_past_the_declared_bound_is_an_oversized_envelope_not_a_remote_failure() {
         // The peer sent this body correctly; the local client refused to read
         // it. Calling that Storage would tell an operator the remote broke.

--- a/crates/kin-remote/src/repository_transfer_negotiation.rs
+++ b/crates/kin-remote/src/repository_transfer_negotiation.rs
@@ -478,13 +478,29 @@ where
     let mut receipts = Vec::new();
     let mut originally_at = None;
     let mut published_changes = 0usize;
-    let mut previous_remaining: Option<usize> = None;
+    let mut previous_head: Option<Option<SemanticChangeId>> = None;
 
     let (source_head, plan) = loop {
         let expectation = negotiated_destination_lease(transport, repository_id, destination_ref)?;
         if receipts.is_empty() {
             originally_at = expectation.destination_head;
         }
+        // Every round must find the remote further along than the last one
+        // left it. Without this a peer that receipts a pack and then keeps
+        // reporting its old head would have this loop republish the same
+        // segment forever, which is a hang standing in for a refusal.
+        if let Some(previous) = previous_head {
+            if expectation.destination_head == previous {
+                return Err(conflict(format!(
+                    "remote reported the same head on {destination_ref} after publishing a \
+                     continuation pack, so the transfer toward {} made no progress",
+                    previous
+                        .map(|head| head.to_string())
+                        .unwrap_or_else(|| "an unborn ref".to_string())
+                )));
+            }
+        }
+        previous_head = Some(expectation.destination_head);
         let (source_head, plan) = classify_push(
             local,
             source_ref,
@@ -502,20 +518,6 @@ where
                 segment.pack.transfer_target_head
             )));
         }
-        // Every round must leave strictly less to move. Without this a peer
-        // that accepts a pack and then keeps reporting its old head would keep
-        // this loop republishing the same segment forever, which is a hang
-        // rather than the refusal it actually is.
-        if let Some(previous) = previous_remaining {
-            if segment.remaining_changes >= previous {
-                return Err(conflict(format!(
-                    "remote made no progress across continuation packs: {} exact changes remained \
-                     before this pack and {} remain after it",
-                    previous, segment.remaining_changes
-                )));
-            }
-        }
-        previous_remaining = Some(segment.remaining_changes);
         published_changes += segment.pack.changes.len();
 
         let receipt = transport.receive_pack(repository_id, destination_ref, &segment.pack)?;
@@ -1429,10 +1431,12 @@ mod tests {
         let peer = LocalPeer::advertising_max_changes(&fixture.destination, 2);
 
         // Publish the first pack alone, exactly as the loop would.
-        let expectation = negotiated_destination_lease(&peer, &fixture.repository_id, &fixture.main)
-            .expect("the remote lease is readable");
+        let expectation =
+            negotiated_destination_lease(&peer, &fixture.repository_id, &fixture.main)
+                .expect("the remote lease is readable");
         let segment =
-            build_repository_transfer_segment(&fixture.source, &fixture.main, &expectation).unwrap();
+            build_repository_transfer_segment(&fixture.source, &fixture.main, &expectation)
+                .unwrap();
         assert!(!segment.is_final());
         let receipt = peer
             .receive_pack(&fixture.repository_id, &fixture.main, &segment.pack)
@@ -1506,10 +1510,14 @@ mod tests {
 
     #[test]
     fn a_continuation_segment_publishes_a_head_the_destination_ref_can_reach() {
-        // A topological prefix is not enough on its own. Merging a side line
-        // puts that line ahead of the merge in the closure, and ending a
-        // segment there would move the destination ref sideways onto a change
-        // that is not descended from the head it holds.
+        // A topological prefix is not a valid segment boundary on its own.
+        // Merging a side line puts that line's changes ahead of the merge in
+        // the closure, and neither of them descends from the head the
+        // destination holds. Ending a segment there would ask the destination
+        // ref to move sideways onto an unrelated change, so the smallest step
+        // that lands a reachable head is the merge itself even though it is
+        // bigger than the envelope asked for. Refusing instead would strand a
+        // publication partway through.
         let repository_id = RepositoryId::new(format!("segment-merge-{}", Uuid::new_v4())).unwrap();
         let source_dir = TempDir::new().unwrap();
         let destination_dir = TempDir::new().unwrap();
@@ -1532,6 +1540,8 @@ mod tests {
 
         let peer = LocalPeer::new(&destination);
         push_to_remote(&source, &peer, &repository_id, &main, &main).unwrap();
+        assert_eq!(head_of(&destination, &main), Some(published));
+
         let merged = publish_with_parents(
             &source,
             &repository_id,
@@ -1541,31 +1551,123 @@ mod tests {
             4,
             "merge the side line",
         );
+        let after_merge = publish(
+            &source,
+            &repository_id,
+            &main,
+            Some(merged),
+            5,
+            "advance past the merge",
+        );
 
-        // One change per envelope. The side change and the root are both in
-        // the closure and neither can end a segment, so the only publishable
-        // step is the merge itself, and it does not fit. The refusal has to
-        // say so rather than publish a sideways head.
+        // One change per envelope. Nothing before the merge can end a segment,
+        // so the first pack is the merge closure and the second is the single
+        // change after it.
         let narrow = LocalPeer::advertising_max_changes(&destination, 1);
-        let error = push_to_remote(&source, &narrow, &repository_id, &main, &main)
-            .expect_err("no single-change segment can end on a reachable head here");
-        let RepositoryTransferError::Invalid(message) = error else {
-            panic!("an unsplittable closure is an invalid transfer, not a conflict: {error:?}");
-        };
-        assert!(
-            message.contains("descends from destination head"),
-            "the refusal must say why no segment boundary exists: {message}"
+        let outcome = push_to_remote(&source, &narrow, &repository_id, &main, &main)
+            .expect("an unsplittable step is taken whole, not refused");
+
+        assert_eq!(
+            outcome.receipts.len(),
+            2,
+            "the merge closure is one step and the change after it is another"
         );
         assert_eq!(
-            head_of(&destination, &main),
-            Some(published),
-            "a refused segmentation must move nothing"
+            outcome.receipts[0].destination_head, merged,
+            "the first pack lands the merge, the earliest head this ref can reach"
         );
+        assert_eq!(outcome.receipts[1].destination_head, after_merge);
+        assert_eq!(head_of(&destination, &main), Some(after_merge));
+        assert_eq!(
+            outcome.plan,
+            RepositoryTransferPlan::FastForward {
+                source_head: after_merge,
+                destination_head: Some(published),
+                // The merge closure carries the root a second time: it reaches
+                // the merge by a path that never passes through the head the
+                // destination held, so the fast-forward closure collects it.
+                // The receiver accepts a change it already has when the bytes
+                // are identical, which is why this is redundancy rather than a
+                // conflict.
+                change_count: Some(4),
+            }
+        );
+    }
 
-        // With room for the whole closure the same push lands normally.
-        let outcome = push_to_remote(&source, &peer, &repository_id, &main, &main).unwrap();
-        assert_eq!(outcome.receipts.len(), 1);
-        assert_eq!(head_of(&destination, &main), Some(merged));
+    #[test]
+    fn a_peer_that_never_advances_is_refused_rather_than_looped_on() {
+        // The continuation loop asks the remote where it is, publishes the next
+        // step, and asks again. A peer that receipts a pack and then reports the
+        // same head has not moved, and there is no number of retries that fixes
+        // it. Reporting that as a refusal is the difference between an error and
+        // a hang.
+        let (fixture, _) = line_of(4);
+        let peer = FrozenPeer {
+            inner: LocalPeer::advertising_max_changes(&fixture.destination, 2),
+        };
+
+        let error = push_to_remote(
+            &fixture.source,
+            &peer,
+            &fixture.repository_id,
+            &fixture.main,
+            &fixture.main,
+        )
+        .expect_err("a remote that never advances is refused");
+
+        let RepositoryTransferError::Conflict(message) = error else {
+            panic!("a peer that will not advance is a conflict: {error:?}");
+        };
+        assert!(
+            message.contains("made no progress"),
+            "the refusal must say the remote did not move: {message}"
+        );
+    }
+
+    /// A peer whose transfer status keeps reporting the head it had before any
+    /// pack was published.
+    struct FrozenPeer<'a> {
+        inner: LocalPeer<'a>,
+    }
+
+    impl RepositoryTransferTransport for FrozenPeer<'_> {
+        fn advertise_refs(
+            &self,
+            repository_id: &RepositoryId,
+        ) -> Result<RepositoryRefAdvertisement> {
+            self.inner.advertise_refs(repository_id)
+        }
+
+        fn transfer_status(
+            &self,
+            repository_id: &RepositoryId,
+            destination_ref: &RefName,
+        ) -> Result<RepositoryTransferStatus> {
+            let mut status = self.inner.transfer_status(repository_id, destination_ref)?;
+            status.destination_target = None;
+            status.destination_head = None;
+            Ok(status)
+        }
+
+        fn export_pack(
+            &self,
+            repository_id: &RepositoryId,
+            source_ref: &RefName,
+            expectation: &RepositoryTransferExpectation,
+        ) -> Result<RepositoryTransferPack> {
+            self.inner
+                .export_pack(repository_id, source_ref, expectation)
+        }
+
+        fn receive_pack(
+            &self,
+            repository_id: &RepositoryId,
+            destination_ref: &RefName,
+            pack: &RepositoryTransferPack,
+        ) -> Result<RepositoryTransferReceipt> {
+            self.inner
+                .receive_pack(repository_id, destination_ref, pack)
+        }
     }
 
     #[test]
@@ -1612,12 +1714,8 @@ mod tests {
         // work when it cannot.
         let fixture = fixture();
         let peer = LocalPeer::new(&fixture.destination);
-        let mut expectation = negotiated_destination_lease(
-            &peer,
-            &fixture.repository_id,
-            &fixture.main,
-        )
-        .unwrap();
+        let mut expectation =
+            negotiated_destination_lease(&peer, &fixture.repository_id, &fixture.main).unwrap();
         expectation.git_authority_hash = Some(Hash256::from_bytes([0x71; 32]));
 
         let error = verify_transfer_source_readiness(&fixture.source, &fixture.main, &expectation)

--- a/crates/kin-remote/src/repository_transfer_negotiation.rs
+++ b/crates/kin-remote/src/repository_transfer_negotiation.rs
@@ -936,6 +936,10 @@ mod tests {
         /// The bound a peer publishes is negotiated, not fixed, so a small one
         /// is a legal peer rather than a test-only shortcut.
         advertised_max_changes: Option<u32>,
+        /// Advertise a small bound the sender's change budget cannot reach, so
+        /// a step that is unsplittable on a non-change bound is exercised on a
+        /// history a test can build.
+        advertised_max_trees: Option<u32>,
         exported: RefCell<usize>,
         received: RefCell<usize>,
     }
@@ -949,6 +953,7 @@ mod tests {
                 claimed_repository: None,
                 claimed_destination_ref: None,
                 advertised_max_changes: None,
+                advertised_max_trees: None,
                 exported: RefCell::new(0),
                 received: RefCell::new(0),
             }
@@ -957,6 +962,13 @@ mod tests {
         fn advertising_max_changes(authority: &'a TestManager, max_changes: u32) -> Self {
             Self {
                 advertised_max_changes: Some(max_changes),
+                ..Self::new(authority)
+            }
+        }
+
+        fn advertising_max_trees(authority: &'a TestManager, max_trees: u32) -> Self {
+            Self {
+                advertised_max_trees: Some(max_trees),
                 ..Self::new(authority)
             }
         }
@@ -1011,6 +1023,9 @@ mod tests {
             if let Some(max_changes) = self.advertised_max_changes {
                 status.limits.max_changes = max_changes;
             }
+            if let Some(max_trees) = self.advertised_max_trees {
+                status.limits.max_trees = max_trees;
+            }
             Ok(status)
         }
 
@@ -1026,6 +1041,9 @@ mod tests {
             let mut expectation = expectation.clone();
             if let Some(max_changes) = self.advertised_max_changes {
                 expectation.limits.max_changes = expectation.limits.max_changes.min(max_changes);
+            }
+            if let Some(max_trees) = self.advertised_max_trees {
+                expectation.limits.max_trees = expectation.limits.max_trees.min(max_trees);
             }
             build_repository_transfer_segment(self.authority, source_ref, &expectation)
                 .map(|segment| segment.pack)
@@ -1591,6 +1609,168 @@ mod tests {
                 // conflict.
                 change_count: Some(4),
             }
+        );
+    }
+
+    /// Run `work` on its own thread and fail the test if it does not finish.
+    ///
+    /// What these tests assert is termination, and a test that simply called
+    /// the segment builder would hang the suite instead of failing it. The
+    /// deadline is a liveness bound rather than a performance one: the
+    /// fixtures below finish in milliseconds, so it is set far above any
+    /// plausible slow machine.
+    fn within_deadline<T: Send + 'static>(
+        what: &str,
+        work: impl FnOnce() -> T + Send + 'static,
+    ) -> T {
+        let (sender, receiver) = std::sync::mpsc::channel();
+        std::thread::spawn(move || {
+            let _ = sender.send(work());
+        });
+        receiver
+            .recv_timeout(std::time::Duration::from_secs(60))
+            .unwrap_or_else(|_| panic!("{what} did not terminate"))
+    }
+
+    /// Publish a merge whose smallest publishable step is two changes.
+    ///
+    /// The destination is left holding the mainline change before the merge,
+    /// so the closure is the side line followed by the merge and only the
+    /// merge descends from the head the destination holds.
+    fn merge_past_a_published_head(
+        source: &TestManager,
+        destination: &TestManager,
+        repository_id: &RepositoryId,
+        main: &RefName,
+    ) {
+        let side = RefName::branch(b"side").unwrap();
+        let root = publish(source, repository_id, main, None, 1, "root");
+        let published = publish(source, repository_id, main, Some(root), 2, "mainline");
+        let sibling = publish_with_parents(
+            source,
+            repository_id,
+            &side,
+            vec![root],
+            None,
+            3,
+            "side line",
+        );
+
+        let peer = LocalPeer::new(destination);
+        push_to_remote(source, &peer, repository_id, main, main).unwrap();
+
+        publish_with_parents(
+            source,
+            repository_id,
+            main,
+            vec![published, sibling],
+            Some(published),
+            4,
+            "merge the side line",
+        );
+    }
+
+    #[test]
+    fn a_step_that_cannot_be_split_is_refused_by_name_rather_than_replanned() {
+        // The smallest step that lands a head this ref can reach is bigger
+        // than the envelope on every bound, not only on the change count. The
+        // planner reaches past the change budget to take that step, so a
+        // smaller budget cannot produce a smaller segment: replanning returns
+        // the same one. Refusing and naming the bound is the answer; halving
+        // the budget again is a hang standing in for a refusal.
+        let outcome = within_deadline("a segment over a non-change bound", || {
+            let repository_id =
+                RepositoryId::new(format!("unsplittable-{}", Uuid::new_v4())).unwrap();
+            let source_dir = TempDir::new().unwrap();
+            let destination_dir = TempDir::new().unwrap();
+            let source = manager(&source_dir, &repository_id);
+            let destination = manager(&destination_dir, &repository_id);
+            let main = RefName::branch(b"main").unwrap();
+            merge_past_a_published_head(&source, &destination, &repository_id, &main);
+
+            let status = repository_transfer_status(&destination, &repository_id, &main).unwrap();
+            let mut expectation = RepositoryTransferExpectation::try_from(status).unwrap();
+            // Leave the change bound at the protocol default and clamp only a
+            // bound the change budget cannot reach. This is the shape a merge
+            // step of more than MAX_TRANSFER_CHANGES changes has under
+            // entirely default limits, where max_trees equals max_changes.
+            expectation.limits.max_trees = 1;
+
+            build_repository_transfer_segment(&source, &main, &expectation)
+                .map(|segment| segment.pack.changes.len())
+        });
+
+        let error = outcome.expect_err("a step that cannot be split is refused, not replanned");
+        let RepositoryTransferError::Invalid(message) = error else {
+            panic!("an envelope too small for the smallest step is a refusal: {error:?}");
+        };
+        // Three, not two: the merge reaches its side line by a path that never
+        // passes through the head the destination holds, so the fast-forward
+        // closure collects the root a second time.
+        assert!(
+            message.contains("carries 3 trees, over negotiated limit 1"),
+            "the refusal must name the negotiated bound the step exceeds: {message}"
+        );
+        assert!(
+            message.contains("cannot be split"),
+            "the refusal must say why no smaller step is available: {message}"
+        );
+    }
+
+    #[test]
+    fn a_peer_whose_envelope_cannot_carry_the_smallest_step_is_refused_rather_than_looped_on() {
+        // The same refusal over the negotiation loop a push actually drives.
+        // The bound arrives from the peer's own advertisement, which is where
+        // it comes from on the export route, so this is the shape a remote can
+        // put a sender in rather than one only a direct caller can build.
+        let outcome = within_deadline("a push into an envelope below the smallest step", || {
+            let repository_id =
+                RepositoryId::new(format!("narrow-peer-{}", Uuid::new_v4())).unwrap();
+            let source_dir = TempDir::new().unwrap();
+            let destination_dir = TempDir::new().unwrap();
+            let source = manager(&source_dir, &repository_id);
+            let destination = manager(&destination_dir, &repository_id);
+            let main = RefName::branch(b"main").unwrap();
+            merge_past_a_published_head(&source, &destination, &repository_id, &main);
+
+            let narrow = LocalPeer::advertising_max_trees(&destination, 1);
+            push_to_remote(&source, &narrow, &repository_id, &main, &main)
+                .map(|outcome| outcome.receipts.len())
+        });
+
+        let error = outcome.expect_err("a peer that cannot carry the smallest step is refused");
+        let RepositoryTransferError::Invalid(message) = error else {
+            panic!("an envelope too small for the smallest step is a refusal: {error:?}");
+        };
+        assert!(
+            message.contains("over negotiated limit 1"),
+            "the refusal must name the negotiated bound the step exceeds: {message}"
+        );
+    }
+
+    #[test]
+    fn an_envelope_that_can_carry_nothing_is_refused_before_a_pack_is_built() {
+        // An exporter takes its limits from the request it was handed, not
+        // from a status it built, so the numbers are the caller's word. A
+        // bound of zero is already refused when a peer advertises one; it is
+        // refused on the way in for the same reason, rather than becoming
+        // work that can only end in a refusal.
+        let (fixture, _) = line_of(2);
+        let status =
+            repository_transfer_status(&fixture.destination, &fixture.repository_id, &fixture.main)
+                .unwrap();
+        let mut expectation = RepositoryTransferExpectation::try_from(status).unwrap();
+        expectation.limits.max_trees = 0;
+
+        let error = build_repository_transfer_segment(&fixture.source, &fixture.main, &expectation)
+            .expect_err("an envelope that can carry nothing is refused");
+
+        let RepositoryTransferError::Invalid(message) = error else {
+            panic!("a bound that can carry nothing is a refusal: {error:?}");
+        };
+        assert!(
+            message.contains("the negotiated max_trees is zero"),
+            "the refusal must name the bound that can carry nothing: {message}"
         );
     }
 

--- a/crates/kin-remote/src/repository_transfer_negotiation.rs
+++ b/crates/kin-remote/src/repository_transfer_negotiation.rs
@@ -28,7 +28,8 @@ use kin_model::{AuthorId, RefName, RepositoryId, SemanticChange, SemanticChangeI
 use serde::{Deserialize, Serialize};
 
 use crate::repository_transfer::{
-    apply_repository_transfer_pack, build_repository_transfer_pack, repository_transfer_status,
+    apply_repository_transfer_pack, build_repository_transfer_segment,
+    count_repository_transfer_packs, repository_transfer_status, verify_transfer_source_readiness,
     RepositoryRefAdvertisement, RepositoryTransferError, RepositoryTransferExpectation,
     RepositoryTransferPack, RepositoryTransferReceipt, RepositoryTransferStatus, Result,
     REPOSITORY_TRANSFER_PROTOCOL, REPOSITORY_TRANSFER_SCHEMA_VERSION,
@@ -90,7 +91,16 @@ pub enum RepositoryTransferPlan {
     },
 }
 
-/// One completed negotiation, including the receipt when history moved.
+/// One completed negotiation, including a receipt per published pack.
+///
+/// Atomicity contract for a transfer that needed more than one pack: each pack
+/// is published in one repository transaction and proven by its own receipt,
+/// and the packs are ordered. There is no transaction spanning them, and this
+/// protocol does not claim one. A transfer interrupted between packs leaves
+/// the destination ref on the last head that was receipted, which is always an
+/// exact ancestor of the head the transfer was moving toward, so re-running it
+/// resumes from there rather than restarting or rewinding. `receipts` is the
+/// complete evidence of what actually moved.
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct RepositoryTransferOutcome {
     pub direction: RepositoryTransferDirection,
@@ -98,14 +108,21 @@ pub struct RepositoryTransferOutcome {
     pub source_ref: RefName,
     pub destination_ref: RefName,
     pub plan: RepositoryTransferPlan,
-    /// Absent exactly when the plan was [`RepositoryTransferPlan::UpToDate`].
-    pub receipt: Option<RepositoryTransferReceipt>,
+    /// One receipt per published pack, in publication order. Empty exactly
+    /// when the plan was [`RepositoryTransferPlan::UpToDate`].
+    pub receipts: Vec<RepositoryTransferReceipt>,
 }
 
 impl RepositoryTransferOutcome {
-    /// True when this negotiation published a repository transaction.
+    /// True when this negotiation published at least one repository
+    /// transaction.
     pub fn moved_history(&self) -> bool {
-        self.receipt.is_some()
+        !self.receipts.is_empty()
+    }
+
+    /// The receipt for the pack that landed the transfer's final head.
+    pub fn final_receipt(&self) -> Option<&RepositoryTransferReceipt> {
+        self.receipts.last()
     }
 }
 
@@ -365,28 +382,35 @@ where
     Ok((source_head, plan))
 }
 
-/// A negotiated publication plan, and whether this protocol version can carry
-/// it in one envelope.
+/// A negotiated publication plan, and how many packs carrying it will take.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct RepositoryPushPlan {
     pub plan: RepositoryTransferPlan,
     /// The most changes one negotiated envelope carries.
     pub max_changes_per_envelope: u32,
-    /// False when the gap needs more changes than one envelope holds.
+    /// How many packs this publication needs, each published atomically.
     ///
-    /// Transfer v1 has no continuation packs, so a gap this large is refused at
-    /// pack-build time rather than split. Reporting it from the plan is what
-    /// makes that refusal predictable instead of a surprise mid-publication.
-    pub fits_one_envelope: bool,
+    /// `None` when the count is not knowable from the local lease alone, which
+    /// is the case for an unborn destination: counting its closure means
+    /// walking the whole line.
+    pub pack_count: Option<usize>,
 }
 
 /// Negotiate a publication without moving any history.
 ///
 /// This is the read-only half of [`push_to_remote`]: it reads the remote lease
-/// and classifies the gap, and refuses exactly what a push would refuse, but it
-/// never builds a pack or contacts the receive seam. A plan that reports a
-/// fast-forward is a statement about the two leases it just read, not a promise
-/// that they will still hold when a push runs.
+/// and classifies the gap, and refuses what a push would refuse, but it never
+/// publishes anything and never contacts the receive seam. A plan that reports
+/// a fast-forward is a statement about the two leases it just read, not a
+/// promise that they will still hold when a push runs.
+///
+/// Parity with a push is checked, not assumed. Everything a push decides
+/// before it ships bytes is decided here too: the destination lease, the
+/// fast-forward classification, the imported-Git authority baseline, and the
+/// presence and identity of every immutable source body the publication head's
+/// tree depends on. What is left to the push itself is the per-pack byte
+/// arithmetic, which is only knowable once the packs are assembled; the plan
+/// reports the pack count and the negotiated bound instead of predicting it.
 pub fn plan_push_to_remote<B, T>(
     local: &RepositoryAuthorityManager<B>,
     transport: &T,
@@ -400,25 +424,30 @@ where
 {
     let expectation = negotiated_destination_lease(transport, repository_id, destination_ref)?;
     let max_changes_per_envelope = expectation.limits.max_changes;
-    let (_, plan) = classify_push(
+    let (source_head, plan) = classify_push(
         local,
         source_ref,
         destination_ref,
         expectation.destination_head,
     )?;
-    // An unborn destination has no counted closure yet, because counting it
-    // means walking the whole line. Treat unknown as "not yet known to fit"
-    // rather than asserting it fits.
-    let fits_one_envelope = match &plan {
-        RepositoryTransferPlan::UpToDate { .. } => true,
-        RepositoryTransferPlan::FastForward { change_count, .. } => change_count
-            .map(|count| u32::try_from(count).is_ok_and(|count| count <= max_changes_per_envelope))
-            .unwrap_or(false),
+    let _ = source_head;
+    verify_transfer_source_readiness(local, source_ref, &expectation)?;
+    // Counted even when the destination is unborn and `change_count` is not.
+    // Walking the whole line is what the push is about to do anyway, and an
+    // operator deciding whether to start it needs the number most in exactly
+    // that case.
+    let pack_count = match &plan {
+        RepositoryTransferPlan::UpToDate { .. } => Some(0),
+        RepositoryTransferPlan::FastForward { .. } => Some(count_repository_transfer_packs(
+            local,
+            source_ref,
+            &expectation,
+        )?),
     };
     Ok(RepositoryPushPlan {
         plan,
         max_changes_per_envelope,
-        fits_one_envelope,
+        pack_count,
     })
 }
 
@@ -428,6 +457,13 @@ where
 /// refuses a non-fast-forward before building anything. There is no force
 /// path: a remote head this replica has not admitted is reported with both
 /// heads named so the operator integrates instead of overwriting.
+///
+/// A gap larger than one negotiated envelope is published as an ordered
+/// sequence of packs rather than refused. Each round re-reads the remote lease,
+/// so every pack is built against the head the remote actually holds at that
+/// moment, and each is published in its own repository transaction with its own
+/// receipt. See [`RepositoryTransferOutcome`] for what that does and does not
+/// promise across packs.
 pub fn push_to_remote<B, T>(
     local: &RepositoryAuthorityManager<B>,
     transport: &T,
@@ -439,48 +475,82 @@ where
     B: StorageBackend + ?Sized + 'static,
     T: RepositoryTransferTransport + ?Sized,
 {
-    let expectation = negotiated_destination_lease(transport, repository_id, destination_ref)?;
-    let destination_head = expectation.destination_head;
-    let (source_head, plan) = classify_push(
-        local,
-        source_ref,
-        destination_ref,
-        expectation.destination_head,
-    )?;
+    let mut receipts = Vec::new();
+    let mut originally_at = None;
+    let mut published_changes = 0usize;
+    let mut previous_remaining: Option<usize> = None;
 
-    if matches!(plan, RepositoryTransferPlan::UpToDate { .. }) {
-        return Ok(RepositoryTransferOutcome {
-            direction: RepositoryTransferDirection::Push,
-            repository_id: repository_id.clone(),
-            source_ref: source_ref.clone(),
-            destination_ref: destination_ref.clone(),
-            plan,
-            receipt: None,
-        });
-    }
+    let (source_head, plan) = loop {
+        let expectation = negotiated_destination_lease(transport, repository_id, destination_ref)?;
+        if receipts.is_empty() {
+            originally_at = expectation.destination_head;
+        }
+        let (source_head, plan) = classify_push(
+            local,
+            source_ref,
+            destination_ref,
+            expectation.destination_head,
+        )?;
+        if matches!(plan, RepositoryTransferPlan::UpToDate { .. }) {
+            break (source_head, plan);
+        }
 
-    let pack = build_repository_transfer_pack(local, source_ref, &expectation)?;
-    if pack.source_head != source_head {
-        return Err(conflict(format!(
-            "local authority moved during negotiation: planned head {source_head}, packed head {}",
-            pack.source_head
-        )));
-    }
-    let plan = RepositoryTransferPlan::FastForward {
-        source_head,
-        destination_head,
-        change_count: Some(pack.changes.len()),
+        let segment = build_repository_transfer_segment(local, source_ref, &expectation)?;
+        if segment.pack.transfer_target_head != source_head {
+            return Err(conflict(format!(
+                "local authority moved during negotiation: planned head {source_head}, packed transfer toward {}",
+                segment.pack.transfer_target_head
+            )));
+        }
+        // Every round must leave strictly less to move. Without this a peer
+        // that accepts a pack and then keeps reporting its old head would keep
+        // this loop republishing the same segment forever, which is a hang
+        // rather than the refusal it actually is.
+        if let Some(previous) = previous_remaining {
+            if segment.remaining_changes >= previous {
+                return Err(conflict(format!(
+                    "remote made no progress across continuation packs: {} exact changes remained \
+                     before this pack and {} remain after it",
+                    previous, segment.remaining_changes
+                )));
+            }
+        }
+        previous_remaining = Some(segment.remaining_changes);
+        published_changes += segment.pack.changes.len();
+
+        let receipt = transport.receive_pack(repository_id, destination_ref, &segment.pack)?;
+        verify_receipt_binds_pack(&segment.pack, &receipt)?;
+        receipts.push(receipt);
+
+        if segment.is_final() {
+            break (
+                source_head,
+                RepositoryTransferPlan::FastForward {
+                    source_head,
+                    destination_head: originally_at,
+                    change_count: Some(published_changes),
+                },
+            );
+        }
     };
-    let receipt = transport.receive_pack(repository_id, destination_ref, &pack)?;
-    verify_receipt_binds_pack(&pack, &receipt)?;
 
+    let plan = match (receipts.is_empty(), plan) {
+        // A publication that took several packs reports the whole move, not
+        // the last one: the operator asked to publish a head, not a segment.
+        (false, RepositoryTransferPlan::UpToDate { .. }) => RepositoryTransferPlan::FastForward {
+            source_head,
+            destination_head: originally_at,
+            change_count: Some(published_changes),
+        },
+        (_, plan) => plan,
+    };
     Ok(RepositoryTransferOutcome {
         direction: RepositoryTransferDirection::Push,
         repository_id: repository_id.clone(),
         source_ref: source_ref.clone(),
         destination_ref: destination_ref.clone(),
         plan,
-        receipt: Some(receipt),
+        receipts,
     })
 }
 
@@ -552,16 +622,30 @@ where
     }
 
     let pack = transport.export_pack(repository_id, source_ref, &expectation)?;
-    if pack.source_head != source_head {
+    // A pack that publishes something other than the advertised head is either
+    // one segment of a continuation toward it, or a remote whose authority
+    // moved under the negotiation. The declared target is what separates them,
+    // and it has to be the head this replica negotiated for.
+    if pack.transfer_target_head != source_head {
         return Err(conflict(format!(
-            "remote authority moved during negotiation: advertised head {source_head}, exported head {}",
-            pack.source_head
+            "remote authority moved during negotiation: advertised head {source_head}, exported transfer toward {}",
+            pack.transfer_target_head
         )));
     }
     if &pack.destination_ref != destination_ref {
         return Err(invalid(format!(
             "remote exported a pack for destination ref {} but this replica asked for {destination_ref}",
             pack.destination_ref
+        )));
+    }
+    // A segment that publishes the head this replica already holds moves
+    // nothing, so admitting it would let a remote keep a continuation loop
+    // running without ever closing the gap.
+    if Some(pack.source_head) == destination_head {
+        return Err(conflict(format!(
+            "remote exported a pack publishing {}, which this replica already holds; \
+             the transfer toward {source_head} made no progress",
+            pack.source_head
         )));
     }
     Ok(PullNegotiation::Pack(Box::new(pack)))
@@ -585,29 +669,93 @@ where
     B: StorageBackend + ?Sized + 'static,
     T: RepositoryTransferTransport + ?Sized,
 {
-    let negotiation =
-        fetch_pull_pack(local, transport, repository_id, source_ref, destination_ref)?;
-    let pack = match negotiation {
-        PullNegotiation::UpToDate { head } => {
-            return Ok(RepositoryTransferOutcome {
-                direction: RepositoryTransferDirection::Pull,
-                repository_id: repository_id.clone(),
-                source_ref: source_ref.clone(),
-                destination_ref: destination_ref.clone(),
-                plan: RepositoryTransferPlan::UpToDate { head },
-                receipt: None,
-            });
+    pull_from_remote_with(
+        local,
+        transport,
+        repository_id,
+        source_ref,
+        destination_ref,
+        |pack| {
+            apply_repository_transfer_pack(
+                local,
+                repository_id,
+                destination_ref,
+                actor.clone(),
+                pack,
+            )
+        },
+    )
+}
+
+/// Run a pull, admitting each pack through a caller-supplied publication step.
+///
+/// A receiver that owns derived state beyond repository authority has to admit
+/// packs itself, so that publication and the refresh of everything derived from
+/// it stay on one path. `admit` is that step. It is called once per pack, in
+/// order, and this function verifies each returned receipt binds the pack it
+/// was given before asking for the next one.
+///
+/// A remote gap larger than one negotiated envelope arrives as several packs.
+/// Each is admitted and receipted on its own; see [`RepositoryTransferOutcome`]
+/// for the contract that spans them.
+pub fn pull_from_remote_with<B, T, A>(
+    local: &RepositoryAuthorityManager<B>,
+    transport: &T,
+    repository_id: &RepositoryId,
+    source_ref: &RefName,
+    destination_ref: &RefName,
+    mut admit: A,
+) -> Result<RepositoryTransferOutcome>
+where
+    B: StorageBackend + ?Sized + 'static,
+    T: RepositoryTransferTransport + ?Sized,
+    A: FnMut(&RepositoryTransferPack) -> Result<RepositoryTransferReceipt>,
+{
+    let mut receipts = Vec::new();
+    let mut originally_at = None;
+    let mut admitted_changes = 0usize;
+
+    loop {
+        let negotiation =
+            fetch_pull_pack(local, transport, repository_id, source_ref, destination_ref)?;
+        let pack = match negotiation {
+            PullNegotiation::UpToDate { head: current } => {
+                if receipts.is_empty() {
+                    return Ok(RepositoryTransferOutcome {
+                        direction: RepositoryTransferDirection::Pull,
+                        repository_id: repository_id.clone(),
+                        source_ref: source_ref.clone(),
+                        destination_ref: destination_ref.clone(),
+                        plan: RepositoryTransferPlan::UpToDate { head: current },
+                        receipts,
+                    });
+                }
+                break;
+            }
+            PullNegotiation::Pack(pack) => pack,
+        };
+
+        if receipts.is_empty() {
+            originally_at = pack.expected_destination_head;
         }
-        PullNegotiation::Pack(pack) => pack,
-    };
+        let is_final = pack.source_head == pack.transfer_target_head;
+        admitted_changes += pack.changes.len();
 
-    let destination_head = pack.expected_destination_head;
-    let source_head = pack.source_head;
-    let change_count = pack.changes.len();
-    let receipt =
-        apply_repository_transfer_pack(local, repository_id, destination_ref, actor, &pack)?;
-    verify_receipt_binds_pack(&pack, &receipt)?;
+        let receipt = admit(&pack)?;
+        verify_receipt_binds_pack(&pack, &receipt)?;
+        receipts.push(receipt);
 
+        if is_final {
+            break;
+        }
+    }
+
+    // The head this pull admitted is the one the last receipt was verified to
+    // bind, not a head tracked alongside it.
+    let source_head = receipts
+        .last()
+        .map(|receipt| receipt.destination_head)
+        .ok_or_else(|| invalid("a pull that moved history produces at least one receipt"))?;
     Ok(RepositoryTransferOutcome {
         direction: RepositoryTransferDirection::Pull,
         repository_id: repository_id.clone(),
@@ -615,10 +763,10 @@ where
         destination_ref: destination_ref.clone(),
         plan: RepositoryTransferPlan::FastForward {
             source_head,
-            destination_head,
-            change_count: Some(change_count),
+            destination_head: originally_at,
+            change_count: Some(admitted_changes),
         },
-        receipt: Some(receipt),
+        receipts,
     })
 }
 
@@ -781,6 +929,11 @@ mod tests {
         /// Rewrite the ref the transfer status answers about, for the same
         /// reason: a peer that answers a question nobody asked is refused.
         claimed_destination_ref: Option<RefName>,
+        /// Advertise a smaller envelope than the protocol maximum, so
+        /// continuation behaviour is exercised on histories a test can build.
+        /// The bound a peer publishes is negotiated, not fixed, so a small one
+        /// is a legal peer rather than a test-only shortcut.
+        advertised_max_changes: Option<u32>,
         exported: RefCell<usize>,
         received: RefCell<usize>,
     }
@@ -793,8 +946,16 @@ mod tests {
                 forge_receipt: false,
                 claimed_repository: None,
                 claimed_destination_ref: None,
+                advertised_max_changes: None,
                 exported: RefCell::new(0),
                 received: RefCell::new(0),
+            }
+        }
+
+        fn advertising_max_changes(authority: &'a TestManager, max_changes: u32) -> Self {
+            Self {
+                advertised_max_changes: Some(max_changes),
+                ..Self::new(authority)
             }
         }
 
@@ -845,6 +1006,9 @@ mod tests {
             if let Some(claimed) = &self.claimed_destination_ref {
                 status.destination_ref = claimed.clone();
             }
+            if let Some(max_changes) = self.advertised_max_changes {
+                status.limits.max_changes = max_changes;
+            }
             Ok(status)
         }
 
@@ -855,7 +1019,14 @@ mod tests {
             expectation: &RepositoryTransferExpectation,
         ) -> Result<RepositoryTransferPack> {
             *self.exported.borrow_mut() += 1;
-            build_repository_transfer_pack(self.authority, source_ref, expectation)
+            // A sender may segment more finely than the receiver's bound
+            // requires; the receiver's limits are ceilings, not quotas.
+            let mut expectation = expectation.clone();
+            if let Some(max_changes) = self.advertised_max_changes {
+                expectation.limits.max_changes = expectation.limits.max_changes.min(max_changes);
+            }
+            build_repository_transfer_segment(self.authority, source_ref, &expectation)
+                .map(|segment| segment.pack)
         }
 
         fn receive_pack(
@@ -955,9 +1126,16 @@ mod tests {
                 change_count: Some(2),
             }
         );
-        let receipt = outcome.receipt.expect("a moved head produces a receipt");
+        let receipt = outcome
+            .final_receipt()
+            .expect("a moved head produces a receipt");
         assert_eq!(receipt.outcome, RepositoryTransferApplyOutcome::Committed);
         assert_eq!(receipt.destination_head, fixture.source_head);
+        assert_eq!(
+            outcome.receipts.len(),
+            1,
+            "a gap inside one envelope is published as one pack"
+        );
         assert_eq!(
             head_of(&fixture.destination, &fixture.main),
             Some(fixture.source_head),
@@ -1045,7 +1223,7 @@ mod tests {
             }
         );
         assert_eq!(planned.max_changes_per_envelope, 512);
-        assert!(planned.fits_one_envelope);
+        assert_eq!(planned.pack_count, Some(1));
 
         let outcome = push_to_remote(
             &fixture.source,
@@ -1158,8 +1336,297 @@ mod tests {
             head_of(&fixture.destination, &fixture.main),
             Some(fixture.source_head)
         );
-        let receipt = outcome.receipt.expect("a moved head produces a receipt");
+        let receipt = outcome
+            .final_receipt()
+            .expect("a moved head produces a receipt");
         assert_eq!(receipt.outcome, RepositoryTransferApplyOutcome::Committed);
+    }
+
+    /// A line `count` changes longer than the base fixture, and every exact
+    /// head on it in order.
+    fn line_of(count: u128) -> (Fixture, Vec<SemanticChangeId>) {
+        let mut fixture = fixture();
+        let lease = fixture.source.read_authority();
+        let root = lease
+            .snapshot()
+            .changes
+            .values()
+            .find(|change| change.parents.is_empty())
+            .expect("the fixture roots one change")
+            .id;
+        drop(lease);
+        let mut heads = vec![root, fixture.source_head];
+        let mut previous = Some(fixture.source_head);
+        for step in 0..count {
+            let head = publish(
+                &fixture.source,
+                &fixture.repository_id,
+                &fixture.main,
+                previous,
+                100 + step,
+                &format!("extend the exact line {step}"),
+            );
+            heads.push(head);
+            previous = Some(head);
+        }
+        fixture.source_head = previous.expect("the line has a head");
+        (fixture, heads)
+    }
+
+    #[test]
+    fn a_push_past_the_negotiated_envelope_lands_the_whole_gap_across_continuation_packs() {
+        // The bound is the envelope, not the history. Six exact changes across
+        // an envelope that carries two must arrive whole, and the remote must
+        // end on the same head the local replica publishes.
+        let (fixture, _) = line_of(4);
+        let peer = LocalPeer::advertising_max_changes(&fixture.destination, 2);
+
+        let outcome = push_to_remote(
+            &fixture.source,
+            &peer,
+            &fixture.repository_id,
+            &fixture.main,
+            &fixture.main,
+        )
+        .unwrap();
+
+        assert_eq!(
+            outcome.plan,
+            RepositoryTransferPlan::FastForward {
+                source_head: fixture.source_head,
+                destination_head: None,
+                change_count: Some(6),
+            },
+            "the reported move is the whole publication, not its last segment"
+        );
+        assert_eq!(
+            outcome.receipts.len(),
+            3,
+            "six changes across a two-change envelope take three packs"
+        );
+        assert_eq!(*peer.received.borrow(), 3);
+        assert_eq!(
+            head_of(&fixture.destination, &fixture.main),
+            Some(fixture.source_head),
+            "the remote resolves the ref to the exact head the local replica holds"
+        );
+        for receipt in &outcome.receipts {
+            assert_eq!(receipt.outcome, RepositoryTransferApplyOutcome::Committed);
+        }
+        assert_eq!(
+            outcome.final_receipt().unwrap().destination_head,
+            fixture.source_head,
+            "the last receipt binds the head the transfer was moving toward"
+        );
+    }
+
+    #[test]
+    fn an_interrupted_multi_pack_push_resumes_from_the_pack_that_landed() {
+        // This is the whole per-pack contract. Nothing spans the packs, so an
+        // interruption has to leave the remote on a real ancestor of the target
+        // and a re-run has to carry only what is left.
+        let (fixture, heads) = line_of(4);
+        let peer = LocalPeer::advertising_max_changes(&fixture.destination, 2);
+
+        // Publish the first pack alone, exactly as the loop would.
+        let expectation = negotiated_destination_lease(&peer, &fixture.repository_id, &fixture.main)
+            .expect("the remote lease is readable");
+        let segment =
+            build_repository_transfer_segment(&fixture.source, &fixture.main, &expectation).unwrap();
+        assert!(!segment.is_final());
+        let receipt = peer
+            .receive_pack(&fixture.repository_id, &fixture.main, &segment.pack)
+            .unwrap();
+        verify_receipt_binds_pack(&segment.pack, &receipt).unwrap();
+        let landed = head_of(&fixture.destination, &fixture.main).expect("one pack landed");
+        assert_eq!(landed, segment.pack.source_head);
+        assert!(
+            heads.contains(&landed),
+            "an interrupted transfer leaves the remote on an exact change of the line"
+        );
+        assert_ne!(
+            landed, fixture.source_head,
+            "the interruption is before the target head"
+        );
+
+        // A re-run resumes rather than restarting or rewinding.
+        let outcome = push_to_remote(
+            &fixture.source,
+            &peer,
+            &fixture.repository_id,
+            &fixture.main,
+            &fixture.main,
+        )
+        .unwrap();
+        assert_eq!(
+            outcome.plan,
+            RepositoryTransferPlan::FastForward {
+                source_head: fixture.source_head,
+                destination_head: Some(landed),
+                change_count: Some(4),
+            },
+            "the resumed push carries only what the interrupted one did not"
+        );
+        assert_eq!(
+            head_of(&fixture.destination, &fixture.main),
+            Some(fixture.source_head)
+        );
+    }
+
+    #[test]
+    fn a_pull_past_the_negotiated_envelope_admits_the_whole_gap_across_continuation_packs() {
+        let (fixture, _) = line_of(4);
+        let peer = LocalPeer::advertising_max_changes(&fixture.source, 2);
+
+        let outcome = pull_from_remote(
+            &fixture.destination,
+            &peer,
+            &fixture.repository_id,
+            &fixture.main,
+            &fixture.main,
+            AuthorId::new("pulling-replica"),
+        )
+        .unwrap();
+
+        assert_eq!(
+            outcome.plan,
+            RepositoryTransferPlan::FastForward {
+                source_head: fixture.source_head,
+                destination_head: None,
+                change_count: Some(6),
+            }
+        );
+        assert_eq!(outcome.receipts.len(), 3);
+        assert_eq!(*peer.exported.borrow(), 3);
+        assert_eq!(
+            head_of(&fixture.destination, &fixture.main),
+            Some(fixture.source_head)
+        );
+    }
+
+    #[test]
+    fn a_continuation_segment_publishes_a_head_the_destination_ref_can_reach() {
+        // A topological prefix is not enough on its own. Merging a side line
+        // puts that line ahead of the merge in the closure, and ending a
+        // segment there would move the destination ref sideways onto a change
+        // that is not descended from the head it holds.
+        let repository_id = RepositoryId::new(format!("segment-merge-{}", Uuid::new_v4())).unwrap();
+        let source_dir = TempDir::new().unwrap();
+        let destination_dir = TempDir::new().unwrap();
+        let source = manager(&source_dir, &repository_id);
+        let destination = manager(&destination_dir, &repository_id);
+        let main = RefName::branch(b"main").unwrap();
+        let side = RefName::branch(b"side").unwrap();
+
+        let root = publish(&source, &repository_id, &main, None, 1, "root");
+        let published = publish(&source, &repository_id, &main, Some(root), 2, "mainline");
+        let sibling = publish_with_parents(
+            &source,
+            &repository_id,
+            &side,
+            vec![root],
+            None,
+            3,
+            "side line",
+        );
+
+        let peer = LocalPeer::new(&destination);
+        push_to_remote(&source, &peer, &repository_id, &main, &main).unwrap();
+        let merged = publish_with_parents(
+            &source,
+            &repository_id,
+            &main,
+            vec![published, sibling],
+            Some(published),
+            4,
+            "merge the side line",
+        );
+
+        // One change per envelope. The side change and the root are both in
+        // the closure and neither can end a segment, so the only publishable
+        // step is the merge itself, and it does not fit. The refusal has to
+        // say so rather than publish a sideways head.
+        let narrow = LocalPeer::advertising_max_changes(&destination, 1);
+        let error = push_to_remote(&source, &narrow, &repository_id, &main, &main)
+            .expect_err("no single-change segment can end on a reachable head here");
+        let RepositoryTransferError::Invalid(message) = error else {
+            panic!("an unsplittable closure is an invalid transfer, not a conflict: {error:?}");
+        };
+        assert!(
+            message.contains("descends from destination head"),
+            "the refusal must say why no segment boundary exists: {message}"
+        );
+        assert_eq!(
+            head_of(&destination, &main),
+            Some(published),
+            "a refused segmentation must move nothing"
+        );
+
+        // With room for the whole closure the same push lands normally.
+        let outcome = push_to_remote(&source, &peer, &repository_id, &main, &main).unwrap();
+        assert_eq!(outcome.receipts.len(), 1);
+        assert_eq!(head_of(&destination, &main), Some(merged));
+    }
+
+    #[test]
+    fn a_plan_counts_the_packs_a_push_will_take() {
+        let (fixture, _) = line_of(4);
+        let peer = LocalPeer::advertising_max_changes(&fixture.destination, 2);
+
+        let planned = plan_push_to_remote(
+            &fixture.source,
+            &peer,
+            &fixture.repository_id,
+            &fixture.main,
+            &fixture.main,
+        )
+        .unwrap();
+
+        assert_eq!(planned.max_changes_per_envelope, 2);
+        assert_eq!(
+            planned.pack_count,
+            Some(3),
+            "the plan must say how many packs the operator is about to publish"
+        );
+
+        let outcome = push_to_remote(
+            &fixture.source,
+            &peer,
+            &fixture.repository_id,
+            &fixture.main,
+            &fixture.main,
+        )
+        .unwrap();
+        assert_eq!(
+            outcome.receipts.len(),
+            planned.pack_count.unwrap(),
+            "the executed push must take exactly the packs the plan counted"
+        );
+    }
+
+    #[test]
+    fn a_plan_refuses_a_divergent_imported_git_baseline_the_way_a_push_would() {
+        // Parity is the point of the plan. A push refuses a Git-authority
+        // baseline the two replicas do not share, so a plan that reported a
+        // clean fast-forward there would be telling the operator a push will
+        // work when it cannot.
+        let fixture = fixture();
+        let peer = LocalPeer::new(&fixture.destination);
+        let mut expectation = negotiated_destination_lease(
+            &peer,
+            &fixture.repository_id,
+            &fixture.main,
+        )
+        .unwrap();
+        expectation.git_authority_hash = Some(Hash256::from_bytes([0x71; 32]));
+
+        let error = verify_transfer_source_readiness(&fixture.source, &fixture.main, &expectation)
+            .expect_err("a Git-authority baseline mismatch is refused before any pack is built");
+
+        assert!(
+            matches!(error, RepositoryTransferError::Conflict(_)),
+            "a divergent imported-Git baseline is a conflict: {error:?}"
+        );
     }
 
     #[test]

--- a/packages/boundary-contracts/src/index.d.ts
+++ b/packages/boundary-contracts/src/index.d.ts
@@ -499,7 +499,7 @@ export interface RepositoryTransferLimits {
 }
 
 export interface RepositoryTransferStatus {
-  schema_version: 1;
+  schema_version: 2;
   protocol: "kin-repository-v6-fast-forward";
   repository_id: string;
   destination_ref: RepositoryTransferRefName;
@@ -523,14 +523,21 @@ export interface RepositoryTransferBody {
 }
 
 export interface RepositoryTransferPack {
-  schema_version: 1;
+  schema_version: 2;
   protocol: "kin-repository-v6-fast-forward";
   transfer_id: string;
   operation_id: string;
   repository_id: string;
   source_ref: RepositoryTransferRefName;
   destination_ref: RepositoryTransferRefName;
+  /** The exact head this one pack publishes. */
   source_head: string;
+  /**
+   * The head the whole transfer is moving toward. Equal to `source_head` on a
+   * single-pack transfer and on the last pack of a continuation; an earlier
+   * exact ancestor of it on every pack before that.
+   */
+  transfer_target_head: string;
   source_tree_hash: string;
   expected_destination_target: RepositoryTransferRefTarget | null;
   expected_destination_head: string | null;
@@ -547,7 +554,7 @@ export interface RepositoryTransferPack {
 }
 
 export interface RepositoryTransferReceipt {
-  schema_version: 1;
+  schema_version: 2;
   protocol: "kin-repository-v6-fast-forward";
   transfer_id: string;
   repository_id: string;

--- a/packages/boundary-contracts/src/index.d.ts
+++ b/packages/boundary-contracts/src/index.d.ts
@@ -511,9 +511,9 @@ export interface RepositoryTransferStatus {
   git_authority_hash: string | null;
   supported_features: string[];
   limits: RepositoryTransferLimits;
-  push_apply_ready: false;
+  push_apply_ready: boolean;
   bounded_envelope_export_ready: boolean;
-  pull_apply_ready: false;
+  pull_apply_ready: boolean;
 }
 
 export interface RepositoryTransferBody {


### PR DESCRIPTION
Continuation of the native replication work landed in #458, closing the residual findings from its review.

## Pull transport body cap

The client read bound and the daemon route bound are now proven to be the same number at the boundary itself: a body of exactly the declared limit is read, and one byte more is refused as an oversized envelope rather than blamed on the peer. The cap and the misclassification fix landed with #458; this adds the boundary case, which is what a near-miss test cannot cover.

## Continuation packs

A closure larger than one negotiated envelope is now published as an ordered sequence of packs instead of refused at pack build. Both directions run the same loop with the roles swapped.

A pack declares the head the whole transfer is moving toward as well as the head it publishes. Without that, a pack whose head is not the one the peer advertised is ambiguous between a deliberate segment and a peer whose authority moved mid-negotiation, and the safe reading of the second is to refuse. Schema version moves to 2 so a version 1 peer is refused by name instead of through a field-shape parse error.

Segment selection carries the endpoint's own ancestry rather than a topological prefix, and only ends on a change the destination ref can fast-forward to. Both matter: a prefix can hold a change that is not an ancestor of the change it ends on, and merging a side line puts that line ahead of the merge in the closure where nothing descends from the destination head. When no boundary fits the envelope at all, the closure takes the earliest reachable change even though it is larger than asked for, because refusing there would strand a publication that has already moved history.

**Atomicity contract, stated rather than implied.** Each pack is published in one repository transaction and proven by its own receipt. Nothing spans them and this protocol does not claim it does. A transfer interrupted between packs leaves the destination on the last receipted head, which is always an exact ancestor of the target, so a re-run resumes from there rather than restarting or rewinding. The outcome carries one receipt per pack as the complete evidence of what moved.

## A step that cannot be split is refused rather than replanned

Taking the earliest reachable change when no boundary fits left the retry loop with nothing to shrink. The builder answered a refusal from the negotiated bounds by halving the change budget and planning again, which converges only while a smaller budget can produce a smaller segment. Once the planner has reached past the budget to end on a change the destination ref can fast-forward to, every replan rebuilt the same segment and the retry never terminated. A merge whose smallest publishable step exceeds any non-change bound spun instead of refusing, reachable at the default limits where `max_trees` equals `max_changes`, and reachable from a peer because the export route takes those bounds from a request body.

The planner now reports when it had to reach past the budget, which is exactly the condition under which no smaller step exists, and the builder refuses by name instead of halving again. That is the refusal the acceptance line already promised, firing for a step of any size rather than only for a single change. It also bounds the loop, because a plan that stayed inside its budget is never longer than it, so each replan starts from a budget strictly smaller than the segment just refused.

Two tests cover it, both hanging on the previous commit and passing on this one. `a_step_that_cannot_be_split_is_refused_by_name_rather_than_replanned` builds the merge shape with only `max_trees` clamped and the change bound left at the protocol default, and `a_peer_whose_envelope_cannot_carry_the_smallest_step_is_refused_rather_than_looped_on` drives the same refusal through the negotiation loop a push runs. Both assert the message names the negotiated bound, and both run the call under a deadline on their own thread, because a test that simply called the builder would hang the suite instead of failing it.

Not covered by execution: the same shape at entirely default limits needs a merge step of more than 512 changes, and seeding that costs minutes of exact repository transactions. The clamped bound exercises the identical path, since every bound reaches the same refusal.

## Peer-supplied limits are validated and locally bounded on the way in

`validate_limits` refuses an envelope of zero when a peer advertises one in status or supplies one in an export request. Small positive envelopes remain legal because the multi-pack protocol is specifically designed to honor them.

Peer-supplied ceilings cannot enlarge this implementation's work envelope. Status-to-expectation negotiation and every direct export/planning entrypoint now clamp all seven count/byte ceilings to `RepositoryTransferLimits::default()`, which is the same local policy enforced by `validate_pack`. This prevents a malicious or misconfigured peer from making Kin construct an oversized pack that Kin itself would reject, or from amplifying one transfer step beyond local CPU/RAM policy. Above-cap advertisement and direct-export tests cover the two untrusted entry paths; the kin-remote suite passes 72/72, all three focused hang/refusal tests pass, and the real `kin push` dispatch test reaches the transfer surface.

## plan-push parity

The plan now refuses the imported-Git baseline mismatch and the missing or mismatched source bodies a push refuses, and reports how many packs the publication will take. What it still does not predict is the per-pack byte arithmetic, which is only knowable once packs are assembled; it reports the pack count and the negotiated bound instead of guessing that refusal.

## The 500 after a durable move

A pull whose derived-view refresh failed returned HTTP 500 after repository authority had already committed, telling the caller a transfer that really happened did not. Authority is the truth and it moved, so that is now a typed partial success on the response, a daemon health signal on `/repos/{id}/health`, and a line the CLI prints saying retrieval is behind the admitted head.

## Capability flips

`push` moves to ready. `pull` stays open_gate, and its note now gives the single remaining reason: admitting history does not move the workspace to the admitted head. The transfer status advertises push and pull apply readiness, since the bound those flags were waiting on was the one that scaled with history length.

Exposing a command is a fixture edit, so the fixture cannot show that the dispatch arm reaches anything. `push_reaches_the_transfer_surface_instead_of_the_capability_gate` drives the real binary and requires the transfer surface's own discovery failure with the gate's refusal absent, matching what checkout and the session cluster already prove. Still-gated `pull` is asserted in the same pass, so a gate that stopped refusing anything cannot pass as a connected command.

## What this does not claim

No kinlab control-plane endpoint is driven. Every peer under test is a real Kin daemon transfer seam over a real socket, which is the same seam the control plane proxies to, but the control-plane wrapper and its protection rules are untouched and untested here. A live proof was not attempted: the local kinlab checkout is behind the merge that added the transfer-envelope route, and a lane worktree cannot install its dependencies. The transfer schema bump was checked against kinlab's pinned schema constants and does not collide with them, which are the shadow gate report's, not the transfer pack's.

The multi-pack HTTP proof runs against a peer advertising a two-change envelope rather than the 512-change default, because seeding past that default costs minutes of exact repository transactions (200 changes measured at 158s). The envelope is negotiated, so a smaller one is a legal peer; the routes, the wire, and the packs are real.

## Follow-ups left open

Three known gaps in the stale-derived-view reporting are deliberately out of scope here, each erring loud rather than silent:

- `derived_views_stale` is set and never cleared, so a later pull that rebuilds the views leaves the health signal asserting staleness until the daemon restarts. The CLI's remedy text already says to restart, but an operator cannot confirm recovery from the signal itself.
- In `command_pull`, once a refresh goes stale the closure stops attempting refresh for later packs, so only the first pack's failure detail is ever surfaced.
- `repo_transfer_receive` records staleness locally and returns 200, so the sending peer is never told the receiver's derived views went stale.
