### PR TITLE
Classify authority bind refusals on namespace identity alone

### DIFF
--- a/crates/kin-cli/src/commands/ref_lookup.rs
+++ b/crates/kin-cli/src/commands/ref_lookup.rs
@@ -647,8 +647,10 @@ mod tests {
     #[test]
     fn full_git_oid_is_not_converted_into_a_synthetic_change_id() {
         let graph = kin_db::InMemoryGraph::new();
-        let layout = kin_core::KinLayout::new(std::path::PathBuf::from("/absent/.kin"));
-        let binding = absent_binding(&layout);
+        let directory = tempfile::tempdir().unwrap();
+        let initialized = kin_core::init(directory.path()).unwrap();
+        let binding = kin_core::LocalRepositoryAuthorityBinding::from_layout(&initialized.layout)
+            .expect("fixture must carry persisted empty repository authority");
         let error = resolve_ref(
             &graph,
             &binding,

--- a/crates/kin-core/src/lib.rs
+++ b/crates/kin-core/src/lib.rs
@@ -96,6 +96,7 @@ pub use ranking::{
 };
 pub use ref_view::{build_graph_at_ref, collect_changes_at_ref, filter_vector_results_to_scope};
 pub use repository_authority::{
-    durable_semantic_enrichment_summary, revalidate_pinned_local_namespace,
-    DurableSemanticEnrichmentSummary, LocalRepositoryAuthorityBinding, PinnedNamespaceRefusal,
+    durable_semantic_enrichment_summary, open_persisted_local_repository_authority,
+    revalidate_pinned_local_namespace, DurableSemanticEnrichmentSummary,
+    LocalRepositoryAuthorityBinding, PinnedNamespaceRefusal,
 };

--- a/crates/kin-core/src/lib.rs
+++ b/crates/kin-core/src/lib.rs
@@ -97,5 +97,5 @@ pub use ranking::{
 pub use ref_view::{build_graph_at_ref, collect_changes_at_ref, filter_vector_results_to_scope};
 pub use repository_authority::{
     durable_semantic_enrichment_summary, revalidate_pinned_local_namespace,
-    DurableSemanticEnrichmentSummary, LocalRepositoryAuthorityBinding,
+    DurableSemanticEnrichmentSummary, LocalRepositoryAuthorityBinding, PinnedNamespaceRefusal,
 };

--- a/crates/kin-core/src/repository_authority.rs
+++ b/crates/kin-core/src/repository_authority.rs
@@ -228,7 +228,9 @@ impl LocalRepositoryAuthorityBinding {
     /// Establish a binding once for a fresh one-shot CLI/offline process.
     ///
     /// Request handlers in a long-lived daemon must receive an existing
-    /// binding instead of calling this constructor.
+    /// binding instead of calling this constructor. This pins namespace
+    /// identity only; the first authority open below also proves that the
+    /// namespace still carries a persisted authority record.
     pub fn from_layout(layout: &KinLayout) -> Result<Self> {
         layout.check_version()?;
         let manifest = KinManifest::load(&layout.manifest_path())?;
@@ -276,16 +278,24 @@ impl LocalRepositoryAuthorityBinding {
     /// Open a coherent authority manager through the retained storage
     /// capability.
     ///
-    /// KinDB revalidates both the pinned storage-root identity and the
-    /// retained per-repository namespace identity here, and retains the
-    /// per-repository capability on the first successful call. This is the one
-    /// authority load and the one exclusive lock a bind pays: the revalidation
-    /// ahead of it reads namespace identity from metadata alone, so naming a
-    /// replaced namespace as such costs no second load.
+    /// KinDB revalidates both the pinned storage-root identity and the retained
+    /// per-repository namespace identity here, and retains the per-repository
+    /// capability on the first successful call. The same recovery must return
+    /// a payload receipt: a bound repository namespace whose authority record
+    /// disappeared is refused rather than reopened as an unpersisted
+    /// generation-zero repository.
+    ///
+    /// This is the one authority load and the one exclusive lock a bind pays:
+    /// the revalidation ahead of it reads namespace identity from metadata
+    /// alone, so naming a replaced namespace as such costs no second load.
     pub fn open_manager(
         &self,
     ) -> std::result::Result<RepositoryAuthorityManager<LocalFileBackend>, kin_db::KinDbError> {
-        RepositoryAuthorityManager::open(self.repository_id.clone(), Arc::clone(&self.backend))
+        open_persisted_local_repository_authority(
+            self.repository_id.clone(),
+            Arc::clone(&self.backend),
+        )
+        .map(|(manager, _payload_stats)| manager)
     }
 
     /// Open a coherent authority manager and keep the payload receipt that the
@@ -296,11 +306,12 @@ impl LocalRepositoryAuthorityBinding {
     /// actually read rather than measuring storage afterwards. It is fixed at
     /// open and does not follow later commits.
     ///
-    /// `None` means recovery found no persisted authority and generation zero
-    /// was constructed only in memory. A reopen of a repository that has
-    /// persisted authority always carries a receipt; treating `None` as an
-    /// ordinary outcome there would report an unmeasured payload as a
-    /// successful read.
+    /// A successful bound-repository open always returns `Some`: recovery that
+    /// finds no persisted authority is refused rather than treating an intact,
+    /// previously initialized namespace as a fresh generation-zero repository.
+    /// The optional shape remains for callers that already expose KinDB's
+    /// payload-receipt type; use KinDB directly when deliberately constructing
+    /// an unpersisted repository before its first commit.
     pub fn open_manager_with_payload_stats(
         &self,
     ) -> std::result::Result<
@@ -310,11 +321,40 @@ impl LocalRepositoryAuthorityBinding {
         ),
         kin_db::KinDbError,
     > {
-        RepositoryAuthorityManager::open_with_payload_stats(
+        open_persisted_local_repository_authority(
             self.repository_id.clone(),
             Arc::clone(&self.backend),
         )
+        .map(|(manager, payload_stats)| (manager, Some(payload_stats)))
     }
+}
+
+/// Open an already initialized local repository through one coherent recovery.
+///
+/// A missing authority record is not a fresh repository when its namespace is
+/// reached through a startup binding. KinDB deliberately permits an absent
+/// record when constructing an unpersisted generation-zero repository, so this
+/// boundary uses the payload receipt from the same recovery to retain the
+/// stricter reopen contract without paying for a second load or lock.
+pub fn open_persisted_local_repository_authority(
+    repository_id: RepositoryId,
+    backend: Arc<LocalFileBackend>,
+) -> std::result::Result<
+    (
+        RepositoryAuthorityManager<LocalFileBackend>,
+        AuthorityPayloadStats,
+    ),
+    kin_db::KinDbError,
+> {
+    let missing_repository_id = repository_id.clone();
+    let (manager, payload_stats) =
+        RepositoryAuthorityManager::open_with_payload_stats(repository_id, backend)?;
+    let payload_stats = payload_stats.ok_or_else(|| {
+        kin_db::KinDbError::StorageError(format!(
+            "local storage authority namespace {missing_repository_id} has no persisted authority record"
+        ))
+    })?;
+    Ok((manager, payload_stats))
 }
 
 /// Why revalidating a startup-pinned repository namespace refused.
@@ -381,7 +421,10 @@ impl std::error::Error for PinnedNamespaceRefusal {}
 /// truncated snapshot, a missing lock file, or a quarantined state on a
 /// namespace this process still reaches was reported as a replaced repository.
 /// A fault that says nothing about identity is [`PinnedNamespaceRefusal::Unavailable`]
-/// here, and the bind stays closed either way.
+/// here, and the bind stays closed either way. An intact namespace whose
+/// persisted authority record is absent passes this identity probe, then is
+/// refused by [`open_persisted_local_repository_authority`] using the receipt
+/// from its single authority recovery.
 ///
 /// Ordering is load-bearing. The first read on a fresh backend is what takes
 /// the pin, so a long-lived process must take it once at startup and revalidate
@@ -391,7 +434,17 @@ pub fn revalidate_pinned_local_namespace(
     backend: &LocalFileBackend,
     repository_id: &RepositoryId,
 ) -> std::result::Result<(), PinnedNamespaceRefusal> {
-    match backend.probe_pinned_repository_namespace(repository_id.as_str()) {
+    classify_pinned_namespace_probe(
+        repository_id,
+        backend.probe_pinned_repository_namespace(repository_id.as_str()),
+    )
+}
+
+fn classify_pinned_namespace_probe(
+    repository_id: &RepositoryId,
+    probe: LocalNamespaceProbe,
+) -> std::result::Result<(), PinnedNamespaceRefusal> {
+    match probe {
         LocalNamespaceProbe::Retained => Ok(()),
         LocalNamespaceProbe::IdentityLost(fault) => {
             Err(PinnedNamespaceRefusal::Identity(fault.into_error()))
@@ -414,13 +467,11 @@ mod payload_receipt_tests {
         let directory = tempfile::tempdir().unwrap();
         let kindb = directory.path().join("kindb");
         std::fs::create_dir_all(&kindb).unwrap();
-        let binding = LocalRepositoryAuthorityBinding::from_parts(
+        let (_manager, receipt) = RepositoryAuthorityManager::open_with_payload_stats(
             RepositoryId::new("payload-receipt-generation-zero").unwrap(),
-            WorkspaceId::from_uuid(uuid::Uuid::from_u128(1)),
             Arc::new(LocalFileBackend::new(&kindb)),
-        );
-
-        let (_manager, receipt) = binding.open_manager_with_payload_stats().unwrap();
+        )
+        .unwrap();
 
         assert!(
             receipt.is_none(),
@@ -458,6 +509,71 @@ mod payload_receipt_tests {
             receipt.total_payload_bytes(),
             receipt.snapshot_bytes() + receipt.acknowledged_delta_bytes(),
             "total payload bytes must be the snapshot plus acknowledged deltas it names"
+        );
+    }
+
+    #[test]
+    fn authority_open_refuses_an_intact_namespace_missing_its_persisted_record() {
+        let directory = tempfile::tempdir().unwrap();
+        let initialized = crate::init(directory.path()).unwrap();
+        let repository_id = RepositoryId::new(
+            KinManifest::load(&initialized.layout.manifest_path())
+                .unwrap()
+                .repo_id,
+        )
+        .unwrap();
+        let namespace = initialized.layout.kindb_dir().join(repository_id.as_str());
+        let snapshots = namespace.join("snapshots");
+        assert!(
+            std::fs::read_dir(&snapshots).unwrap().any(|entry| entry
+                .unwrap()
+                .file_type()
+                .unwrap()
+                .is_file()),
+            "fixture must retain persisted snapshot material"
+        );
+        std::fs::remove_file(namespace.join("authority.json")).unwrap();
+
+        let binding = LocalRepositoryAuthorityBinding::from_layout(&initialized.layout).unwrap();
+        binding
+            .revalidate_pinned_namespace()
+            .expect("the retained namespace identity itself is still intact");
+        let error = match binding.open_manager() {
+            Ok(_) => panic!("a bound namespace missing authority.json must fail closed"),
+            Err(error) => error,
+        };
+
+        assert!(
+            error
+                .to_string()
+                .contains("has no persisted authority record"),
+            "unexpected missing-authority refusal: {error}"
+        );
+    }
+}
+
+#[cfg(test)]
+mod namespace_probe_classification_tests {
+    use super::*;
+
+    #[test]
+    fn unavailable_probe_is_a_non_identity_refusal() {
+        let repository_id = RepositoryId::new("unavailable-probe-classification").unwrap();
+        let refusal = classify_pinned_namespace_probe(
+            &repository_id,
+            LocalNamespaceProbe::Unavailable(kin_db::KinDbError::StorageError(
+                "deterministic probe IO failure".to_string(),
+            )),
+        )
+        .expect_err("an unavailable probe must refuse");
+
+        assert!(
+            matches!(&refusal, PinnedNamespaceRefusal::Unavailable(_)),
+            "unavailable probe must retain the unavailable arm, got {refusal}"
+        );
+        assert!(
+            !refusal.is_identity_refusal(),
+            "an unavailable probe says nothing about namespace identity"
         );
     }
 }

--- a/crates/kin-core/src/repository_authority.rs
+++ b/crates/kin-core/src/repository_authority.rs
@@ -14,7 +14,7 @@ use std::sync::Arc;
 
 use kin_db::{
     AuthorityPayloadStats, LocalFileBackend, LocalNamespaceProbe, RepositoryAuthorityManager,
-    RepositoryAuthorityState,
+    RepositoryAuthorityState, StorageBackend,
 };
 use kin_model::{
     EntityDelta, EntityId, RelationDelta, RelationId, RepositoryId, SemanticChangeId, WorkspaceId,
@@ -285,9 +285,11 @@ impl LocalRepositoryAuthorityBinding {
     /// disappeared is refused rather than reopened as an unpersisted
     /// generation-zero repository.
     ///
-    /// This is the one authority load and the one exclusive lock a bind pays:
-    /// the revalidation ahead of it reads namespace identity from metadata
-    /// alone, so naming a replaced namespace as such costs no second load.
+    /// This is one authority recovery and its one exclusive recovery lock: the
+    /// revalidation ahead of it reads namespace identity from metadata alone,
+    /// so naming a replaced namespace as such costs no second recovery. KinDB
+    /// may separately persist a reusable history-validation proof after a full
+    /// replay; that does not reload authority or decide whether a record exists.
     pub fn open_manager(
         &self,
     ) -> std::result::Result<RepositoryAuthorityManager<LocalFileBackend>, kin_db::KinDbError> {
@@ -336,16 +338,11 @@ impl LocalRepositoryAuthorityBinding {
 /// record when constructing an unpersisted generation-zero repository, so this
 /// boundary uses the payload receipt from the same recovery to retain the
 /// stricter reopen contract without paying for a second load or lock.
-pub fn open_persisted_local_repository_authority(
+pub fn open_persisted_local_repository_authority<B: StorageBackend + ?Sized + 'static>(
     repository_id: RepositoryId,
-    backend: Arc<LocalFileBackend>,
-) -> std::result::Result<
-    (
-        RepositoryAuthorityManager<LocalFileBackend>,
-        AuthorityPayloadStats,
-    ),
-    kin_db::KinDbError,
-> {
+    backend: Arc<B>,
+) -> std::result::Result<(RepositoryAuthorityManager<B>, AuthorityPayloadStats), kin_db::KinDbError>
+{
     let missing_repository_id = repository_id.clone();
     let (manager, payload_stats) =
         RepositoryAuthorityManager::open_with_payload_stats(repository_id, backend)?;

--- a/crates/kin-core/src/repository_authority.rs
+++ b/crates/kin-core/src/repository_authority.rs
@@ -13,8 +13,8 @@ use std::fmt;
 use std::sync::Arc;
 
 use kin_db::{
-    AuthorityPayloadStats, LocalFileBackend, RepositoryAuthorityManager, RepositoryAuthorityState,
-    StorageBackend,
+    AuthorityPayloadStats, LocalFileBackend, LocalNamespaceProbe, RepositoryAuthorityManager,
+    RepositoryAuthorityState,
 };
 use kin_model::{
     EntityDelta, EntityId, RelationDelta, RelationId, RepositoryId, SemanticChangeId, WorkspaceId,
@@ -264,11 +264,12 @@ impl LocalRepositoryAuthorityBinding {
     }
 
     /// Revalidate the retained storage root and per-repository authority
-    /// namespace without decoding the full graph snapshot.
+    /// namespace without acquiring the repository lock or decoding any
+    /// snapshot.
     ///
     /// See [`revalidate_pinned_local_namespace`] for the exact property this
     /// refuses on.
-    pub fn revalidate_pinned_namespace(&self) -> std::result::Result<(), kin_db::KinDbError> {
+    pub fn revalidate_pinned_namespace(&self) -> std::result::Result<(), PinnedNamespaceRefusal> {
         revalidate_pinned_local_namespace(&self.backend, &self.repository_id)
     }
 
@@ -277,7 +278,10 @@ impl LocalRepositoryAuthorityBinding {
     ///
     /// KinDB revalidates both the pinned storage-root identity and the
     /// retained per-repository namespace identity here, and retains the
-    /// per-repository capability on the first successful call.
+    /// per-repository capability on the first successful call. This is the one
+    /// authority load and the one exclusive lock a bind pays: the revalidation
+    /// ahead of it reads namespace identity from metadata alone, so naming a
+    /// replaced namespace as such costs no second load.
     pub fn open_manager(
         &self,
     ) -> std::result::Result<RepositoryAuthorityManager<LocalFileBackend>, kin_db::KinDbError> {
@@ -313,6 +317,49 @@ impl LocalRepositoryAuthorityBinding {
     }
 }
 
+/// Why revalidating a startup-pinned repository namespace refused.
+///
+/// The two arms carry different claims. [`Self::Identity`] says the exact
+/// storage this process bound is gone, which a caller may report as a conflict
+/// naming the repository. [`Self::Unavailable`] says the revalidation reached no
+/// verdict about identity at all, so reporting it as a replaced repository would
+/// be a false diagnosis.
+#[derive(Debug)]
+pub enum PinnedNamespaceRefusal {
+    /// The pinned namespace was replaced or detached, or this storage does not
+    /// hold the repository at all.
+    Identity(kin_db::KinDbError),
+    /// The namespace could not be revalidated for a reason that says nothing
+    /// about identity: IO, permissions, or an entry that could not be read.
+    Unavailable(kin_db::KinDbError),
+}
+
+impl PinnedNamespaceRefusal {
+    pub fn is_identity_refusal(&self) -> bool {
+        matches!(self, Self::Identity(_))
+    }
+
+    pub fn error(&self) -> &kin_db::KinDbError {
+        match self {
+            Self::Identity(error) | Self::Unavailable(error) => error,
+        }
+    }
+
+    pub fn into_error(self) -> kin_db::KinDbError {
+        match self {
+            Self::Identity(error) | Self::Unavailable(error) => error,
+        }
+    }
+}
+
+impl fmt::Display for PinnedNamespaceRefusal {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(formatter, "{}", self.error())
+    }
+}
+
+impl std::error::Error for PinnedNamespaceRefusal {}
+
 /// Refuse `repository_id` unless `backend` still reaches the exact storage root
 /// and per-repository authority namespace it has already pinned.
 ///
@@ -329,6 +376,13 @@ impl LocalRepositoryAuthorityBinding {
 /// pass answers for entries that carry no authority and are not this caller's
 /// concern.
 ///
+/// It answers the identity question only. Reading identity through a full
+/// authority load conflated it with everything a load can fail on, so a
+/// truncated snapshot, a missing lock file, or a quarantined state on a
+/// namespace this process still reaches was reported as a replaced repository.
+/// A fault that says nothing about identity is [`PinnedNamespaceRefusal::Unavailable`]
+/// here, and the bind stays closed either way.
+///
 /// Ordering is load-bearing. The first read on a fresh backend is what takes
 /// the pin, so a long-lived process must take it once at startup and revalidate
 /// on every later authority bind; a swap that lands before the first read
@@ -336,12 +390,18 @@ impl LocalRepositoryAuthorityBinding {
 pub fn revalidate_pinned_local_namespace(
     backend: &LocalFileBackend,
     repository_id: &RepositoryId,
-) -> std::result::Result<(), kin_db::KinDbError> {
-    match backend.load_snapshot_authority(repository_id.as_str())? {
-        Some(_) => Ok(()),
-        None => Err(kin_db::KinDbError::StorageError(format!(
-            "local storage authority does not hold repository namespace {repository_id}"
-        ))),
+) -> std::result::Result<(), PinnedNamespaceRefusal> {
+    match backend.probe_pinned_repository_namespace(repository_id.as_str()) {
+        LocalNamespaceProbe::Retained => Ok(()),
+        LocalNamespaceProbe::IdentityLost(fault) => {
+            Err(PinnedNamespaceRefusal::Identity(fault.into_error()))
+        }
+        LocalNamespaceProbe::Absent => Err(PinnedNamespaceRefusal::Identity(
+            kin_db::KinDbError::StorageError(format!(
+                "local storage authority does not hold repository namespace {repository_id}"
+            )),
+        )),
+        LocalNamespaceProbe::Unavailable(error) => Err(PinnedNamespaceRefusal::Unavailable(error)),
     }
 }
 
@@ -541,10 +601,116 @@ mod tests {
             .revalidate_pinned_namespace()
             .expect_err("a binding must refuse a store that does not hold its repository");
         assert!(
+            error.is_identity_refusal(),
+            "a store that does not hold the repository is a namespace answer, not an IO fault"
+        );
+        assert!(
             error
                 .to_string()
                 .contains("does not hold repository namespace"),
             "unexpected wrong-store error: {error}"
+        );
+    }
+
+    /// Revalidation answers the identity question alone. Riding a full
+    /// authority load conflated it with everything a load can fail on, so a
+    /// corrupt payload on a namespace this process still reaches was reported
+    /// as a replaced repository. The bind still refuses, at the authority open,
+    /// where the fault actually is.
+    #[test]
+    fn revalidation_passes_a_corrupt_payload_on_an_intact_namespace_to_the_authority_open() {
+        let directory = tempfile::tempdir().unwrap();
+        let initialized = crate::init(directory.path()).unwrap();
+        let binding = LocalRepositoryAuthorityBinding::from_layout(&initialized.layout).unwrap();
+        binding.open_manager().unwrap();
+
+        let namespace = initialized
+            .layout
+            .kindb_dir()
+            .join(binding.repository_id().as_str());
+        std::fs::write(namespace.join("authority.json"), b"{ truncated").unwrap();
+        for entry in std::fs::read_dir(namespace.join("snapshots")).unwrap() {
+            let entry = entry.unwrap();
+            if entry.file_type().unwrap().is_file() {
+                std::fs::write(entry.path(), b"not a snapshot").unwrap();
+            }
+        }
+
+        if let Err(refusal) = binding.revalidate_pinned_namespace() {
+            panic!("a corrupt payload on an intact namespace is not a namespace-identity refusal, got {refusal}");
+        }
+        if binding.open_manager().is_ok() {
+            panic!("the authority open must still refuse the corrupt payload");
+        }
+    }
+
+    /// A namespace genuinely replaced under the retained binding is still an
+    /// identity refusal, so narrowing the classification did not soften it.
+    #[test]
+    fn revalidation_classifies_a_replaced_namespace_as_an_identity_refusal() {
+        let directory = tempfile::tempdir().unwrap();
+        let initialized = crate::init(directory.path()).unwrap();
+        let binding = LocalRepositoryAuthorityBinding::from_layout(&initialized.layout).unwrap();
+        binding.open_manager().unwrap();
+
+        let namespace = initialized
+            .layout
+            .kindb_dir()
+            .join(binding.repository_id().as_str());
+        let replacement = initialized.layout.root().join("namespace-replacement");
+        copy_directory(&namespace, &replacement);
+        std::fs::rename(
+            &namespace,
+            initialized.layout.root().join("namespace-original"),
+        )
+        .unwrap();
+        std::fs::rename(&replacement, &namespace).unwrap();
+
+        let refusal = binding
+            .revalidate_pinned_namespace()
+            .expect_err("a replaced namespace must refuse");
+        assert!(
+            refusal.is_identity_refusal(),
+            "a replaced namespace must be classified as identity, got {refusal}"
+        );
+        assert!(
+            refusal
+                .to_string()
+                .contains("refusing replacement authority"),
+            "unexpected replacement refusal: {refusal}"
+        );
+    }
+
+    /// A detached namespace is the other structural identity answer.
+    #[test]
+    fn revalidation_classifies_a_detached_namespace_as_an_identity_refusal() {
+        let directory = tempfile::tempdir().unwrap();
+        let initialized = crate::init(directory.path()).unwrap();
+        let binding = LocalRepositoryAuthorityBinding::from_layout(&initialized.layout).unwrap();
+        binding.open_manager().unwrap();
+
+        let namespace = initialized
+            .layout
+            .kindb_dir()
+            .join(binding.repository_id().as_str());
+        std::fs::rename(
+            &namespace,
+            initialized.layout.root().join("namespace-detached"),
+        )
+        .unwrap();
+
+        let refusal = binding
+            .revalidate_pinned_namespace()
+            .expect_err("a detached namespace must refuse");
+        assert!(
+            refusal.is_identity_refusal(),
+            "a detached namespace must be classified as identity, got {refusal}"
+        );
+        assert!(
+            refusal
+                .to_string()
+                .contains("detached after this backend opened"),
+            "unexpected detachment refusal: {refusal}"
         );
     }
 }

--- a/crates/kin-daemon/src/api.rs
+++ b/crates/kin-daemon/src/api.rs
@@ -7277,23 +7277,26 @@ pub(crate) fn repository_transfer_authority(
             format!("invalid repository identity: {error}"),
         )
     })?;
-    let backend: Arc<dyn StorageBackend> = if let Some(backend) = &state.storage_backend {
-        Arc::clone(backend)
+    let authority = if let Some(backend) = &state.storage_backend {
+        RepositoryAuthorityManager::open(repository_id.clone(), Arc::clone(backend))
+            .map_err(repository_authority_error)?
     } else if repo_id == state.cached_repo_id {
-        state.local_repository_backend().ok_or_else(|| {
-            (
-                StatusCode::INTERNAL_SERVER_ERROR,
-                "local daemon is missing its startup storage capability".to_string(),
-            )
-        })?
+        let backend: Arc<dyn StorageBackend> =
+            state.local_repository_backend().ok_or_else(|| {
+                (
+                    StatusCode::INTERNAL_SERVER_ERROR,
+                    "local daemon is missing its startup storage capability".to_string(),
+                )
+            })?;
+        kin_core::open_persisted_local_repository_authority(repository_id.clone(), backend)
+            .map(|(authority, _payload_stats)| authority)
+            .map_err(repository_authority_error)?
     } else {
         return Err((
             StatusCode::NOT_FOUND,
             format!("repository {repo_id} is unavailable in local daemon mode"),
         ));
     };
-    let authority = RepositoryAuthorityManager::open(repository_id.clone(), backend)
-        .map_err(repository_authority_error)?;
     Ok((repository_id, authority))
 }
 
@@ -11368,6 +11371,19 @@ mod tests {
         Arc::new(DaemonState::open(layout).unwrap())
     }
 
+    fn remove_local_authority_after_startup(state: &DaemonState) -> PathBuf {
+        let namespace = state.layout.kindb_dir().join(&state.cached_repo_id);
+        assert!(
+            std::fs::read_dir(namespace.join("snapshots"))
+                .unwrap()
+                .any(|entry| entry.unwrap().file_type().unwrap().is_file()),
+            "fixture must retain persisted snapshot material"
+        );
+        let authority_path = namespace.join("authority.json");
+        std::fs::remove_file(&authority_path).unwrap();
+        authority_path
+    }
+
     #[tokio::test]
     async fn repository_transfer_status_preserves_non_utf8_ref_bytes_and_advertises_apply() {
         let state = test_state();
@@ -11397,6 +11413,124 @@ mod tests {
         assert!(status.push_apply_ready);
         assert!(status.bounded_envelope_export_ready);
         assert!(status.pull_apply_ready);
+    }
+
+    #[tokio::test]
+    async fn repository_transfer_status_refuses_authority_record_lost_after_startup() {
+        let state = test_state();
+        let repository_id = state.cached_repo_id.clone();
+        let authority_path = remove_local_authority_after_startup(&state);
+        let destination_ref = kin_model::RefName::branch(b"main").unwrap();
+        let response = router(Arc::clone(&state))
+            .oneshot(
+                Request::post(format!("/repos/{repository_id}/transfer/status"))
+                    .header("content-type", "application/json")
+                    .body(Body::from(
+                        serde_json::to_vec(&serde_json::json!({
+                            "destination_ref": destination_ref,
+                        }))
+                        .unwrap(),
+                    ))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(response.status(), StatusCode::FAILED_DEPENDENCY);
+        let body = axum::body::to_bytes(response.into_body(), 64 * 1024)
+            .await
+            .unwrap();
+        assert!(
+            String::from_utf8_lossy(&body).contains("has no persisted authority record"),
+            "unexpected missing-authority status refusal: {}",
+            String::from_utf8_lossy(&body)
+        );
+        assert!(
+            !authority_path.exists(),
+            "a read-only transfer status must not recreate missing authority"
+        );
+    }
+
+    fn transfer_pack_for_unborn_destination(
+        repository_id: &RepositoryId,
+    ) -> kin_remote::repository_transfer::RepositoryTransferPack {
+        let source_storage = tempfile::tempdir().unwrap();
+        let source_head = seed_replica_change(
+            source_storage.path(),
+            repository_id,
+            None,
+            0x471,
+            "root transfer authority bypass regression",
+        );
+        let source = RepositoryAuthorityManager::open(
+            repository_id.clone(),
+            Arc::new(kin_db::LocalFileBackend::new(source_storage.path())),
+        )
+        .unwrap();
+
+        let unborn_storage = tempfile::tempdir().unwrap();
+        let unborn = RepositoryAuthorityManager::open(
+            repository_id.clone(),
+            Arc::new(kin_db::LocalFileBackend::new(unborn_storage.path())),
+        )
+        .unwrap();
+        let destination_ref = kin_model::RefName::branch(b"main").unwrap();
+        let status = kin_remote::repository_transfer::repository_transfer_status(
+            &unborn,
+            repository_id,
+            &destination_ref,
+        )
+        .unwrap();
+        let expectation =
+            kin_remote::repository_transfer::RepositoryTransferExpectation::try_from(status)
+                .unwrap();
+        let segment = kin_remote::repository_transfer::build_repository_transfer_segment(
+            &source,
+            &destination_ref,
+            &expectation,
+        )
+        .unwrap();
+        assert!(segment.is_final());
+        assert_eq!(segment.pack.source_head, source_head);
+        segment.pack
+    }
+
+    #[tokio::test]
+    async fn repository_transfer_receive_cannot_recreate_authority_lost_after_startup() {
+        let state = test_state();
+        let repository_id = RepositoryId::new(state.cached_repo_id.clone()).unwrap();
+        let pack = transfer_pack_for_unborn_destination(&repository_id);
+        let authority_path = remove_local_authority_after_startup(&state);
+        let destination_ref = kin_model::RefName::branch(b"main").unwrap();
+        let response = router(Arc::clone(&state))
+            .oneshot(
+                Request::post(format!("/repos/{repository_id}/transfer/receive"))
+                    .header("content-type", "application/json")
+                    .body(Body::from(
+                        serde_json::to_vec(&serde_json::json!({
+                            "destination_ref": destination_ref,
+                            "pack": pack,
+                        }))
+                        .unwrap(),
+                    ))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(response.status(), StatusCode::FAILED_DEPENDENCY);
+        let body = axum::body::to_bytes(response.into_body(), 64 * 1024)
+            .await
+            .unwrap();
+        assert!(
+            String::from_utf8_lossy(&body).contains("has no persisted authority record"),
+            "unexpected missing-authority receive refusal: {}",
+            String::from_utf8_lossy(&body)
+        );
+        assert!(
+            !authority_path.exists(),
+            "a refused transfer receive must not recreate durable authority"
+        );
     }
 
     #[test]

--- a/crates/kin-daemon/src/local_repository_authority.rs
+++ b/crates/kin-daemon/src/local_repository_authority.rs
@@ -53,7 +53,7 @@ impl LocalRepositoryAuthorityContext {
 
     pub(crate) fn revalidate_pinned_namespace(
         &self,
-    ) -> std::result::Result<(), kin_db::KinDbError> {
+    ) -> std::result::Result<(), kin_core::PinnedNamespaceRefusal> {
         self.binding.revalidate_pinned_namespace()
     }
 }
@@ -71,7 +71,9 @@ pub(crate) enum RepositoryAuthorityBindRefusal {
     /// namespace this daemon pinned: replaced at the same ambient path,
     /// detached, or a store that does not hold this repository.
     Identity(kin_db::KinDbError),
-    /// The pinned namespace is intact but its authority could not be opened.
+    /// The pinned namespace is intact but its authority could not be opened, or
+    /// the revalidation itself reached no verdict about identity. Neither says
+    /// the repository was replaced, so neither answers with a conflict.
     Unavailable(kin_db::KinDbError),
 }
 
@@ -111,7 +113,10 @@ impl ActiveLocalRepositoryAuthority {
     ///
     /// The revalidation is deliberately ahead of the authority open so a
     /// replaced or detached namespace is named as such, instead of surfacing as
-    /// whatever the authority decode happens to fail on.
+    /// whatever the authority decode happens to fail on. It reads namespace
+    /// identity from metadata alone and classifies its own refusal, so a fault
+    /// that says nothing about identity stays internal and the bind still pays
+    /// exactly one authority load and one exclusive lock, in the open below.
     pub(crate) fn open_bound(
         state: &DaemonState,
     ) -> std::result::Result<Self, RepositoryAuthorityBindRefusal> {
@@ -119,7 +124,14 @@ impl ActiveLocalRepositoryAuthority {
             .map_err(RepositoryAuthorityBindRefusal::Unbound)?;
         context
             .revalidate_pinned_namespace()
-            .map_err(RepositoryAuthorityBindRefusal::Identity)?;
+            .map_err(|refusal| match refusal {
+                kin_core::PinnedNamespaceRefusal::Identity(error) => {
+                    RepositoryAuthorityBindRefusal::Identity(error)
+                }
+                kin_core::PinnedNamespaceRefusal::Unavailable(error) => {
+                    RepositoryAuthorityBindRefusal::Unavailable(error)
+                }
+            })?;
         let manager = context
             .open()
             .map_err(RepositoryAuthorityBindRefusal::Unavailable)?;

--- a/crates/kin-daemon/src/local_repository_authority.rs
+++ b/crates/kin-daemon/src/local_repository_authority.rs
@@ -117,6 +117,9 @@ impl ActiveLocalRepositoryAuthority {
     /// identity from metadata alone and classifies its own refusal, so a fault
     /// that says nothing about identity stays internal and the bind still pays
     /// exactly one authority load and one exclusive lock, in the open below.
+    /// That same open also refuses a retained namespace whose persisted
+    /// authority record is absent rather than accepting a fresh generation
+    /// zero in its place.
     pub(crate) fn open_bound(
         state: &DaemonState,
     ) -> std::result::Result<Self, RepositoryAuthorityBindRefusal> {

--- a/crates/kin-daemon/src/state.rs
+++ b/crates/kin-daemon/src/state.rs
@@ -1755,11 +1755,16 @@ impl DaemonState {
             registered_local_repository_authorities,
             registered_local_repository_authority_incomplete,
         ) = Self::pin_registered_local_repository_authorities(&layout);
-        let authority = RepositoryAuthorityManager::open(
-            repository_id.clone(),
-            Arc::clone(&local_repository_backend),
-        )
-        .map_err(DaemonError::Graph)?;
+        // Startup is a reopen of an initialized repository, never construction
+        // of an unpersisted generation-zero authority. Use the receipt from
+        // this same recovery to refuse an intact namespace whose authority
+        // record disappeared without paying for a second load or lock.
+        let (authority, _authority_payload_stats) =
+            kin_core::open_persisted_local_repository_authority(
+                repository_id.clone(),
+                Arc::clone(&local_repository_backend),
+            )
+            .map_err(DaemonError::Graph)?;
         // Startup latency on a large repository is dominated by whether this
         // open replayed the whole history or trusted a durable validation of
         // the exact bytes it loaded. Record which path ran so an operator can
@@ -6215,6 +6220,36 @@ mod tests {
         assert!(
             message.contains(&manifest.repo_id),
             "corruption error must identify the repository namespace: {message}"
+        );
+    }
+
+    #[test]
+    fn open_fails_when_persisted_authority_record_is_missing() {
+        let repo_dir = tempfile::tempdir().unwrap();
+        let init = kin_core::init(repo_dir.path()).unwrap();
+        let layout = init.layout;
+        let manifest = kin_core::manifest::KinManifest::load(&layout.manifest_path()).unwrap();
+        let repository_dir = layout.kindb_dir().join(&manifest.repo_id);
+        assert!(
+            std::fs::read_dir(repository_dir.join("snapshots"))
+                .unwrap()
+                .any(|entry| entry.unwrap().file_type().unwrap().is_file()),
+            "fixture must retain the repository's persisted snapshot material"
+        );
+        std::fs::remove_file(repository_dir.join("authority.json")).unwrap();
+
+        let error = match DaemonState::open(layout) {
+            Ok(_) => panic!("startup must fail closed without persisted authority.json"),
+            Err(error) => error,
+        };
+        let message = error.to_string();
+        assert!(
+            message.contains("has no persisted authority record"),
+            "unexpected missing-authority startup error: {message}"
+        );
+        assert!(
+            message.contains(&manifest.repo_id),
+            "missing-authority error must identify the repository namespace: {message}"
         );
     }
 

--- a/crates/kin-daemon/src/state.rs
+++ b/crates/kin-daemon/src/state.rs
@@ -1775,7 +1775,7 @@ impl DaemonState {
         // must refuse to start rather than run unpinned, because every later
         // authority bind treats whatever is retained as the baseline.
         kin_core::revalidate_pinned_local_namespace(&local_repository_backend, &repository_id)
-            .map_err(DaemonError::Graph)?;
+            .map_err(|refusal| DaemonError::Graph(refusal.into_error()))?;
         let lease = authority.read_authority();
         let workspace_id = match manifest_workspace_id {
             Some(recorded) => recorded,


### PR DESCRIPTION
Revalidating a startup-pinned repository namespace previously rode a full authority load,
and `open_bound` mapped every error that load produced onto one refusal arm. A truncated
snapshot, a missing or non-regular `.lock`, and a quarantined state on a namespace this
process still reached were therefore diagnosed as a replaced namespace and returned as
`409 CONFLICT`.

The narrower identity probe corrected that diagnosis, but two later reviews found reopen
boundaries that also had to remain fail closed. First, an intact pinned namespace with its
persisted `authority.json` removed must not be reopened as a fresh in-memory
generation-zero repository by the startup/payload path. Second, local repository-transfer
status and receive endpoints must use that same persisted-record contract rather than
opening the retained backend directly. The current head handles all three conditions.

## The change

Revalidation now goes through kin-db's typed `probe_pinned_repository_namespace`, which
answers the identity question and only the identity question.
`revalidate_pinned_local_namespace` maps its probe variants onto
`PinnedNamespaceRefusal`:

- `Identity` for a namespace replaced at the same ambient path, detached, occupied by
  something that is not a directory, displaced during creation, a replaced or detached
  storage root, or a store that does not hold the repository at all
- `Unavailable` for faults that say nothing about identity, including IO, permissions, or
  an unreadable entry

`open_bound` maps those two arms onto the two existing
`RepositoryAuthorityBindRefusal` arms, so `409` is reserved for an actual identity loss
and other probe failures remain internal errors. Both matches are total with no catch-all.

The downstream authority open goes through
`open_persisted_local_repository_authority`. It consumes the payload receipt returned by
the same KinDB recovery and refuses when that receipt is absent. That preserves KinDB's
ability to deliberately construct an unpersisted generation-zero repository while making
startup/reopen of an initialized local repository require a persisted authority record.

The helper is now generic over `StorageBackend`, allowing every local repository-transfer
route to use the identical persisted-record boundary through the daemon's retained local
backend capability. This covers transfer status/read operations and the durable
`/transfer/receive` write decision. Hosted daemon storage keeps the raw open because a
genuinely new hosted repository may legally begin at generation zero; only the initialized
local startup binding carries the stricter reopen contract.

## One authority recovery and one recovery lock

The old revalidation called `LocalFileBackend::load_snapshot_authority`, which took the
repository's exclusive recovery lock and decoded authority before answering. An exposed
checkout or branch bind therefore paid once in revalidation and again in `open_manager`.

The identity probe does neither. Its steady-state path revalidates the pinned storage root
and compares the repository directory identity against the pinned one. The subsequent
authority open calls `open_with_payload_stats` exactly once and uses that recovery's
receipt to enforce the persisted-record boundary. There is no second authority recovery
or recovery lock just to distinguish a missing record.

KinDB may separately persist a reusable history-validation proof under its own lock after
a full replay. That does not reload authority or decide whether the persisted authority
record exists. The identity probe also takes brief in-process mutexes over the backend's
pinned-namespace and poisoned-namespace maps; those are not repository recovery locks and
guard no IO.

## Coverage

Core and daemon startup coverage includes:

- `revalidation_passes_a_corrupt_payload_on_an_intact_namespace_to_the_authority_open`
- `revalidation_classifies_a_replaced_namespace_as_an_identity_refusal`
- `revalidation_classifies_a_detached_namespace_as_an_identity_refusal`
- `unavailable_probe_is_a_non_identity_refusal`
- `authority_open_refuses_an_intact_namespace_missing_its_persisted_record`
- `open_fails_when_persisted_authority_record_is_missing`

The transfer repair adds two load-bearing API regressions that start from a valid local
daemon, remove only `authority.json` after startup while retaining snapshot material, and
then exercise the real routes:

- `repository_transfer_status_refuses_authority_record_lost_after_startup` proves the
  read/status path returns `424 FAILED_DEPENDENCY` and does not recreate authority
- `repository_transfer_receive_cannot_recreate_authority_lost_after_startup` builds a
  valid transfer pack for an unborn destination, proves the durable receive path returns
  `424 FAILED_DEPENDENCY`, and proves no authority record is written

Those tests fail against the prior raw-open transfer path: status accepts generation zero,
and receive can durably republish authority.

One CLI unit fixture had modeled an absent authority while testing exact ref-alias behavior.
The stricter reopen contract correctly exposed that stale setup. The fixture now initializes
a real persisted empty authority.

## Why this does not wait on a kin-db release

The probe (`probe_pinned_repository_namespace` and `LocalNamespaceProbe`) is present in
kin-db 0.7.8, which `main` already pins. The repair consumes the payload receipt already
returned by KinDB's published `open_with_payload_stats` API. No kin-db change, dependency
version bump, or publish train is required.

## Scope

FIR-1611 lists three fixes and this carries all three: the typed identity probe with
classification, the single-recovery bind, and the bind documentation checked against the
final shape. The kin-db half of the ticket shipped in 0.7.8. The transfer fix closes the
local API authority bypass discovered while independently reviewing that final shape.

## Local gates

Current head `3c930aad2d71cfa263bc3721cd096633a0bc0770` passed:

- `cargo fmt --all -- --check`
- the exact CI clippy allowlist over all targets and all features with
  `RUSTFLAGS=-D warnings`
- `cargo build --all-targets --locked` with `RUSTFLAGS=-D warnings`
- full `cargo test -p kin-daemon --locked`: 618 library tests plus all daemon binary and
  integration suites passed
- both new regressions exactly and the four-test `repository_transfer` filter
- `cargo test -p kin-core repository_authority --locked`: 12 passed
- `cargo test -p kin-cli --no-default-features --locked`: 1,035 library tests plus all
  binary, integration, and doctest suites passed
- `scripts/verify-zero-file-search.py`
- `scripts/zero_file_search_guard.sh`
- `scripts/check_runtime_boundaries.sh`
- `scripts/check_private_repo_coupling.sh`
- `scripts/test-private-repo-coupling.py`: 4 passed

The immediately preceding head also passed the full workspace nextest/doctest gate (4,693
nextest cases passed, 10 skipped), but that earlier run is not being used as proof of the
new transfer delta.

## Not claiming

- Fresh hosted CI on `3c930aad` is still required, including the Windows authority leg.
  No Windows leg was run locally.
- This is source and local-test evidence, not released-byte, external-client, install, or
  production proof.
- This PR has not been submitted to the merge queue and must receive a fresh independent
  review of the repaired head before admission.

Closes FIR-1611
