### PR TITLE
Plan daemon workspace transitions from the live graph

### DIFF
--- a/crates/kin-cli/src/main.rs
+++ b/crates/kin-cli/src/main.rs
@@ -483,7 +483,7 @@ enum Command {
         #[arg(long)]
         abort: bool,
     },
-    /// [OPEN GATE] Seal and restore exact graph-owned workspace state
+    /// Seal and restore exact graph-owned workspace state
     Stash {
         #[command(subcommand)]
         action: StashAction,
@@ -1482,7 +1482,7 @@ enum AssistantAction {
 
 #[derive(Subcommand)]
 enum StashAction {
-    /// [OPEN GATE] Seal exact graph-owned workspace state and return the workspace to its base.
+    /// Seal exact graph-owned workspace state and return the workspace to its base.
     Push {
         /// Label the sealed state. Defaults to the workspace head it was sealed on.
         #[arg(long, short = 'm')]
@@ -1492,9 +1492,9 @@ enum StashAction {
         #[arg(long)]
         yes: bool,
     },
-    /// [OPEN GATE] Restore the most recently sealed workspace state and drop its stash
+    /// Restore the most recently sealed workspace state and drop its stash
     Pop,
-    /// [OPEN GATE] List sealed workspace states
+    /// List sealed workspace states
     List {
         /// Output the machine-readable stash report
         #[arg(long)]

--- a/crates/kin-cli/tests/command_capabilities.rs
+++ b/crates/kin-cli/tests/command_capabilities.rs
@@ -40,7 +40,7 @@ fn capability_json_keeps_the_bounded_dogfood_bar_explicit() {
     assert_eq!(report["bounded_dogfood_required_ready"], 12);
     assert_eq!(report["bounded_dogfood_required_total"], 12);
     assert_eq!(report["full_git_replacement_ready"], false);
-    assert_eq!(report["ready_commands"], 27);
+    assert_eq!(report["ready_commands"], 28);
     assert_eq!(report["command_total"], 33);
 
     let commands = report["commands"]

--- a/crates/kin-cli/tests/command_capabilities.rs
+++ b/crates/kin-cli/tests/command_capabilities.rs
@@ -40,7 +40,7 @@ fn capability_json_keeps_the_bounded_dogfood_bar_explicit() {
     assert_eq!(report["bounded_dogfood_required_ready"], 12);
     assert_eq!(report["bounded_dogfood_required_total"], 12);
     assert_eq!(report["full_git_replacement_ready"], false);
-    assert_eq!(report["ready_commands"], 26);
+    assert_eq!(report["ready_commands"], 27);
     assert_eq!(report["command_total"], 33);
 
     let commands = report["commands"]

--- a/crates/kin-cli/tests/fixtures/git-replacement-capabilities-v1.json
+++ b/crates/kin-cli/tests/fixtures/git-replacement-capabilities-v1.json
@@ -303,8 +303,8 @@
     },
     {
       "command": "stash",
-      "status": "open_gate",
-      "exposure": "fail_closed",
+      "status": "ready",
+      "exposure": "enabled",
       "authority": "repository-v6 workspace transaction",
       "required_for_bounded_dogfood": false,
       "acceptance_spec": [

--- a/crates/kin-cli/tests/fixtures/git-replacement-capabilities-v1.json
+++ b/crates/kin-cli/tests/fixtures/git-replacement-capabilities-v1.json
@@ -321,12 +321,14 @@
         "persist and restore exact graph-owned workspace state without branch sidecars or raw-file inference"
       ],
       "evidence_tests": [
+        "crates/kin-cli/tests/repository_stash.rs",
         "kin_cli::commands::stash::tests::stash_ref_names_round_trip_only_through_canonical_ordinals",
         "kin_daemon::api::tests::command_stash_leaves_ready_commands_working_on_the_returned_workspace",
         "kin_daemon::api::tests::command_stash_refuses_restore_onto_moved_authority",
         "kin_daemon::api::tests::command_stash_refuses_sealing_a_clean_workspace_and_restoring_over_a_dirty_one",
         "kin_daemon::api::tests::command_stash_seals_restores_and_round_trips_exact_workspace_state",
         "kin_daemon::api::tests::switch_refuses_a_daemon_that_lost_authority_owned_semantics",
+        "kin_daemon::api::tests::switch_survives_enrichment_that_lands_after_the_authority_commit",
         "kin_daemon::api::tests::switch_tolerates_derived_semantics_the_workspace_has_not_published",
         "kin_daemon::commit_deltas::tests::commit_publishes_an_entity_whose_provenance_moved_without_its_fingerprint"
       ],

--- a/crates/kin-cli/tests/fixtures/git-replacement-capabilities-v1.json
+++ b/crates/kin-cli/tests/fixtures/git-replacement-capabilities-v1.json
@@ -311,13 +311,16 @@
         "persist and restore exact graph-owned workspace state without branch sidecars or raw-file inference"
       ],
       "evidence_tests": [
-        "kin_daemon::api::tests::command_stash_seals_restores_and_round_trips_exact_workspace_state",
+        "kin_cli::commands::stash::tests::stash_ref_names_round_trip_only_through_canonical_ordinals",
+        "kin_daemon::api::tests::command_stash_leaves_ready_commands_working_on_the_returned_workspace",
         "kin_daemon::api::tests::command_stash_refuses_restore_onto_moved_authority",
         "kin_daemon::api::tests::command_stash_refuses_sealing_a_clean_workspace_and_restoring_over_a_dirty_one",
-        "kin_daemon::api::tests::command_stash_leaves_ready_commands_working_on_the_returned_workspace",
-        "kin_cli::commands::stash::tests::stash_ref_names_round_trip_only_through_canonical_ordinals"
+        "kin_daemon::api::tests::command_stash_seals_restores_and_round_trips_exact_workspace_state",
+        "kin_daemon::api::tests::switch_refuses_a_daemon_that_lost_authority_owned_semantics",
+        "kin_daemon::api::tests::switch_tolerates_derived_semantics_the_workspace_has_not_published",
+        "kin_daemon::commit_deltas::tests::commit_publishes_an_entity_whose_provenance_moved_without_its_fingerprint"
       ],
-      "note": "The graph-owned path exists and is covered: sealing writes the exact workspace tree and base-relative semantics as one immutable change under refs/kin/stash/, and restore refuses a moved authority base rather than rebasing onto it. It stays fail-closed because against a live daemon a seal can leave the daemon query graph disagreeing with workspace authority, so the next ready command refuses until the daemon reopens. In-process route coverage does not reproduce it; the background daemon loop is the missing variable."
+      "note": "Sealing writes the exact workspace tree and base-relative semantics as one immutable change under refs/kin/stash/, and restore refuses a moved authority base rather than rebasing onto it. The live-daemon wedge that held this gate closed is fixed: the daemon query graph is a derived view that runs ahead of workspace authority because reconciliation and asynchronous LSP enrichment publish into it continuously, so commands now plan their daemon-side transition from the live graph, and a commit publishes an entity whose provenance moved even when its fingerprint did not. Against a live daemon a seal now returns a clean workspace, restore succeeds, and the freshness-gated commands that follow either half of the cycle succeed rather than refusing until the daemon reopens."
     },
     {
       "command": "reconcile",

--- a/crates/kin-cli/tests/repository_stash.rs
+++ b/crates/kin-cli/tests/repository_stash.rs
@@ -1,0 +1,249 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Firelock, LLC
+
+//! `kin stash` seals and restores exact graph-owned workspace state through the
+//! real `kin` and `kin-daemon` binaries.
+//!
+//! The in-process route tests cover the seal and restore transactions. What
+//! only a real binary can cover is the surface a user reaches: that `kin stash`
+//! is past its capability gate, that a seal is driven by the workspace the
+//! background daemon actually admitted rather than by a hand-installed graph,
+//! and that the sealed bytes come back. LSP enrichment is deliberately left
+//! enabled, because the wedge that held this gate closed was an enrichment
+//! write racing a repository command.
+
+use serde_json::Value;
+use std::fs;
+use std::path::Path;
+use std::time::{Duration, Instant};
+use tempfile::tempdir;
+
+mod common;
+
+use common::Command;
+
+/// How long to wait for the daemon watcher to admit a host edit into workspace
+/// authority. Sealing is defined over graph-owned changes, so the workspace has
+/// to be dirty in authority before a seal has anything to do.
+const ADMISSION_TIMEOUT: Duration = Duration::from_secs(120);
+
+fn require_git(path: &Path, args: &[&str]) {
+    let output = Command::new("git")
+        .args(args)
+        .env("GIT_CONFIG_NOSYSTEM", "1")
+        .env("GIT_CONFIG_GLOBAL", "/dev/null")
+        .current_dir(path)
+        .output()
+        .expect("run git");
+    assert!(
+        output.status.success(),
+        "git {args:?} failed: stdout={} stderr={}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+}
+
+fn run_kin(repo: &Path, home: &Path, args: &[&str]) -> std::process::Output {
+    Command::new(env!("CARGO_BIN_EXE_kin"))
+        .args(args)
+        .env("HOME", home)
+        .env("GIT_CONFIG_NOSYSTEM", "1")
+        .env("GIT_CONFIG_GLOBAL", "/dev/null")
+        .env("KIN_DAEMON_BIN", common::fresh_daemon_bin())
+        .env_remove("KIN_DAEMON_URL")
+        .env_remove("KIN_VFS_WORKSPACE")
+        .current_dir(repo)
+        .output()
+        .expect("run kin")
+}
+
+fn require_kin(repo: &Path, home: &Path, args: &[&str]) -> String {
+    let output = run_kin(repo, home, args);
+    assert!(
+        output.status.success(),
+        "kin {args:?} failed: stdout={} stderr={}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+    String::from_utf8_lossy(&output.stdout).into_owned()
+}
+
+fn require_kin_json(repo: &Path, home: &Path, args: &[&str]) -> Value {
+    let stdout = require_kin(repo, home, args);
+    serde_json::from_str(&stdout).expect("kin should emit JSON")
+}
+
+const BASE_SOURCE: &[u8] = b"pub fn shipped() -> u8 { 1 }\n";
+const SEALED_SOURCE: &[u8] = b"pub fn shipped() -> u8 { 2 }\npub fn added() -> u8 { 3 }\n";
+const SEALED_OPAQUE: &[u8] = &[0x00, 0xfe, 0x7f, 0x41];
+
+/// A single-commit Git history admitted into Kin.
+fn initialize(repo: &Path, home: &Path) {
+    fs::create_dir_all(repo).expect("create repo");
+    require_git(repo, &["init", "--initial-branch=main"]);
+    require_git(repo, &["config", "user.email", "kin@example.invalid"]);
+    require_git(repo, &["config", "user.name", "Kin"]);
+    require_git(repo, &["config", "commit.gpgsign", "false"]);
+    fs::create_dir_all(repo.join("src")).expect("create source directory");
+    fs::write(repo.join("src/lib.rs"), BASE_SOURCE).expect("write source");
+    fs::write(repo.join("compose.yaml"), b"services: {}\n")
+        .expect("write unsupported-language file");
+    require_git(repo, &["add", "--all"]);
+    require_git(repo, &["commit", "-m", "base"]);
+
+    let init = run_kin(repo, home, &["init", ".", "--json"]);
+    assert!(
+        init.status.success(),
+        "stdout={} stderr={}",
+        String::from_utf8_lossy(&init.stdout),
+        String::from_utf8_lossy(&init.stderr)
+    );
+}
+
+fn workspace_dirty(repo: &Path, home: &Path) -> bool {
+    require_kin_json(repo, home, &["status", "--json"])["workspace"]["dirty"]
+        .as_bool()
+        .expect("status reports workspace dirtiness")
+}
+
+/// Block until the daemon has admitted the working-copy edits into workspace
+/// authority, or fail naming the wait rather than sealing an empty workspace.
+fn await_admitted_workspace_changes(repo: &Path, home: &Path) {
+    let deadline = Instant::now() + ADMISSION_TIMEOUT;
+    while Instant::now() < deadline {
+        if workspace_dirty(repo, home) {
+            return;
+        }
+        std::thread::sleep(Duration::from_millis(500));
+    }
+    panic!(
+        "the daemon did not admit the working-copy edits into workspace authority within {:?}",
+        ADMISSION_TIMEOUT
+    );
+}
+
+fn stash_entries(repo: &Path, home: &Path) -> Vec<Value> {
+    let report = require_kin_json(repo, home, &["stash", "list", "--json"]);
+    assert_eq!(report["schema"], "kin.stash-list.v1");
+    assert_eq!(report["authority"], "repository-v6");
+    report["entries"]
+        .as_array()
+        .expect("stash list reports its entries")
+        .clone()
+}
+
+#[test]
+fn stash_seals_graph_owned_workspace_state_and_pop_restores_it() {
+    let root = tempdir().expect("temp root");
+    let home = root.path().join("home");
+    let repo = root.path().join("repo");
+    fs::create_dir_all(&home).expect("create home");
+    initialize(&repo, &home);
+
+    assert!(
+        stash_entries(&repo, &home).is_empty(),
+        "a fresh repository holds no sealed state"
+    );
+
+    fs::write(repo.join("src/lib.rs"), SEALED_SOURCE).expect("edit tracked source");
+    fs::write(repo.join("scratch.mystery"), SEALED_OPAQUE).expect("add opaque artifact");
+    await_admitted_workspace_changes(&repo, &home);
+
+    let sealed = require_kin(
+        &repo,
+        &home,
+        &["stash", "push", "--yes", "-m", "sealed under test"],
+    );
+    assert!(
+        sealed.contains("refs/kin/stash/0"),
+        "the seal did not name the exact ref it wrote: {sealed}"
+    );
+
+    // The workspace is back at its authority base: tracked bytes restored, and
+    // an artifact the base tree never held removed rather than left behind.
+    assert_eq!(
+        fs::read(repo.join("src/lib.rs")).expect("read source after seal"),
+        BASE_SOURCE,
+        "sealing did not return tracked bytes to the authority base"
+    );
+    assert!(
+        !repo.join("scratch.mystery").exists(),
+        "sealing left an artifact the authority base does not hold"
+    );
+    assert!(
+        !workspace_dirty(&repo, &home),
+        "the workspace still reports graph-owned changes after a seal"
+    );
+
+    let entries = stash_entries(&repo, &home);
+    assert_eq!(entries.len(), 1, "the seal is not listed: {entries:?}");
+    assert_eq!(entries[0]["ordinal"], 0);
+    assert_eq!(entries[0]["message"], "sealed under test");
+
+    let restored = require_kin(&repo, &home, &["stash", "pop"]);
+    assert!(
+        restored.contains("refs/kin/stash/0"),
+        "the restore did not name the stash it consumed: {restored}"
+    );
+    assert_eq!(
+        fs::read(repo.join("src/lib.rs")).expect("read source after restore"),
+        SEALED_SOURCE,
+        "restoring did not bring the sealed bytes back"
+    );
+    assert_eq!(
+        fs::read(repo.join("scratch.mystery")).expect("read opaque artifact after restore"),
+        SEALED_OPAQUE,
+        "restoring dropped an opaque artifact the seal held"
+    );
+    assert!(
+        stash_entries(&repo, &home).is_empty(),
+        "a restored stash must be dropped, not left for a second restore"
+    );
+
+    // The transition left the projection agreeing with graph truth, so the
+    // commands gated on a fresh workspace still work against what it returned.
+    let drift = require_kin_json(&repo, &home, &["doctor", "--drift", "--json"]);
+    assert_eq!(
+        drift["clean"], true,
+        "the stash cycle left the projection diverged from graph truth: {drift}"
+    );
+}
+
+#[test]
+fn stash_answers_from_the_stash_surface_rather_than_the_capability_gate() {
+    let root = tempdir().expect("temp root");
+    let home = root.path().join("home");
+    let repo = root.path().join("repo");
+    fs::create_dir_all(&home).expect("create home");
+    initialize(&repo, &home);
+
+    // A clean workspace has nothing to seal. The refusal must come from the
+    // stash transaction, not from the capability gate that used to answer
+    // before the command was ever reached.
+    let refused = run_kin(&repo, &home, &["stash", "push", "--yes"]);
+    assert!(
+        !refused.status.success(),
+        "sealing a clean workspace published an empty stash"
+    );
+    let stderr = String::from_utf8_lossy(&refused.stderr);
+    assert!(
+        stderr.contains("holds no graph-owned changes to seal"),
+        "the refusal must come from the stash surface: {stderr}"
+    );
+    assert!(
+        !stderr.contains("fail-closed on repository-v6"),
+        "`kin stash` is still answering from the capability gate: {stderr}"
+    );
+
+    // Restoring with nothing sealed is likewise a stash refusal.
+    let popped = run_kin(&repo, &home, &["stash", "pop"]);
+    assert!(
+        !popped.status.success(),
+        "restoring without a sealed stash reported success"
+    );
+    let stderr = String::from_utf8_lossy(&popped.stderr);
+    assert!(
+        stderr.contains("holds no sealed stash to restore"),
+        "the refusal must come from the stash surface: {stderr}"
+    );
+}

--- a/crates/kin-daemon/src/api.rs
+++ b/crates/kin-daemon/src/api.rs
@@ -13023,6 +13023,61 @@ mod tests {
         );
     }
 
+    /// The daemon-side transition is planned before the authority transaction
+    /// commits, and the enrichment worker writes into the live graph without
+    /// taking the coordination gate or the persistence lock. An enrichment tick
+    /// that lands in that window must not leave authority at the new generation
+    /// with the daemon cursor still on the old one, which is the same wedge one
+    /// step later: finalization therefore plans against the graph it is
+    /// installing into rather than against the plan-time snapshot.
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn switch_survives_enrichment_that_lands_after_the_authority_commit() {
+        let (state, _layout, _repository, _main, _feature) =
+            universal_branch_test_state("switch-enrichment-window");
+        let generation_before = state
+            .snapshot_generation
+            .load(std::sync::atomic::Ordering::SeqCst);
+        state
+            .repository_command_enrich_after_authority_once
+            .store(true, std::sync::atomic::Ordering::SeqCst);
+
+        let switch = kin_cli::commands::branch::BranchRequest::Switch {
+            name: kin_model::RefName::branch(b"feature").unwrap(),
+            operation_id: kin_model::OperationId::new(),
+            actor: AuthorId::new("enrichment-window-test"),
+        };
+        let (status, body) = post_branch_request(Arc::clone(&state), &switch, None).await;
+        assert_eq!(
+            status,
+            StatusCode::OK,
+            "enrichment landing after the authority commit must not fail the switch: {}",
+            String::from_utf8_lossy(&body)
+        );
+        assert_eq!(
+            state
+                .snapshot_generation
+                .load(std::sync::atomic::Ordering::SeqCst),
+            generation_before + 1,
+            "the daemon cursor must follow the authority commit the switch just made"
+        );
+
+        // The wedge is the next command, not this one: a daemon cursor left
+        // behind authority refuses every freshness-gated command after it.
+        let back = kin_cli::commands::branch::BranchRequest::Switch {
+            name: kin_model::RefName::branch(b"main").unwrap(),
+            operation_id: kin_model::OperationId::new(),
+            actor: AuthorId::new("enrichment-window-test"),
+        };
+        let (status, body) = post_branch_request(Arc::clone(&state), &back, None).await;
+        assert_eq!(
+            status,
+            StatusCode::OK,
+            "the command after the enrichment window must not be wedged: {}",
+            String::from_utf8_lossy(&body)
+        );
+    }
+
     /// A seal must leave the daemon and repository authority agreeing, so the
     /// ready commands still work against the workspace it returned.
     #[cfg(unix)]

--- a/crates/kin-daemon/src/api.rs
+++ b/crates/kin-daemon/src/api.rs
@@ -12576,6 +12576,134 @@ mod tests {
         assert_eq!(workspace.tree_hash, entry.tree_hash);
     }
 
+    /// Install one entity into the daemon query graph alone, the way the
+    /// asynchronous LSP enrichment worker and parser reconciliation both do:
+    /// derived semantics that have not crossed the repository compare-and-swap.
+    fn install_unpublished_derived_entity(state: &DaemonState, name: &str) -> kin_model::EntityId {
+        let entity = kin_model::Entity {
+            id: kin_model::EntityId::new(),
+            kind: kin_model::EntityKind::Function,
+            name: name.to_string(),
+            language: kin_model::LanguageId::Rust,
+            fingerprint: kin_model::SemanticFingerprint {
+                algorithm: kin_model::FingerprintAlgorithm::V1TreeSitter,
+                ast_hash: kin_model::Hash256::from_bytes([7; 32]),
+                signature_hash: kin_model::Hash256::from_bytes([8; 32]),
+                behavior_hash: kin_model::Hash256::from_bytes([9; 32]),
+                equivalence_hash: kin_model::Hash256::from_bytes([0; 32]),
+                stability_score: 1.0,
+            },
+            file_origin: Some(kin_model::FilePathId::new("selected/compose.yaml")),
+            span: None,
+            signature: format!("fn {name}()"),
+            visibility: kin_model::Visibility::Public,
+            role: kin_model::EntityRole::Source,
+            doc_summary: None,
+            metadata: kin_model::EntityMetadata::default(),
+            lineage_parent: None,
+            created_in: None,
+            superseded_by: None,
+        };
+        let id = entity.id;
+        state
+            .graph
+            .apply_transaction_delta(&kin_model::TransactionDelta {
+                entity_deltas: vec![kin_model::EntityDelta::Added { new: entity }],
+                ..kin_model::TransactionDelta::default()
+            })
+            .unwrap();
+        id
+    }
+
+    /// The daemon query graph legitimately runs ahead of workspace authority:
+    /// enrichment is published into it continuously and reaches authority only
+    /// at commit. A switch must plan around that lead rather than refuse it.
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn switch_tolerates_derived_semantics_the_workspace_has_not_published() {
+        let (state, _layout, _repository, _main, _feature) =
+            universal_branch_test_state("switch-derived-lead");
+        install_unpublished_derived_entity(&state, "enriched_ahead_of_authority");
+
+        let switch = kin_cli::commands::branch::BranchRequest::Switch {
+            name: kin_model::RefName::branch(b"feature").unwrap(),
+            operation_id: kin_model::OperationId::new(),
+            actor: AuthorId::new("derived-lead-test"),
+        };
+        let (status, body) = post_branch_request(Arc::clone(&state), &switch, None).await;
+        assert_eq!(
+            status,
+            StatusCode::OK,
+            "unpublished derived enrichment must not wedge a switch: {}",
+            String::from_utf8_lossy(&body)
+        );
+    }
+
+    /// The lead that is tolerated above is strictly additive. A daemon that
+    /// dropped semantics authority owns is answering from something other than
+    /// graph truth, and must still refuse.
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn switch_refuses_a_daemon_that_lost_authority_owned_semantics() {
+        let (state, _layout, _repository, _main, _feature) =
+            universal_branch_test_state("switch-lost-authority");
+        install_unpublished_derived_entity(&state, "published_then_lost");
+        // Commit so the entity is authority-owned rather than merely derived.
+        let committed = router(Arc::clone(&state))
+            .oneshot(
+                Request::post("/commands/commit")
+                    .header("content-type", "application/json")
+                    .body(Body::from(
+                        json!({
+                            "operation_id": kin_model::OperationId::new(),
+                            "timestamp": kin_model::Timestamp::now(),
+                            "message": "publish the derived entity into authority"
+                        })
+                        .to_string(),
+                    ))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(committed.status(), StatusCode::OK);
+
+        let authority_owned = state
+            .graph
+            .to_snapshot()
+            .entities
+            .values()
+            .find(|entity| entity.name == "published_then_lost")
+            .cloned()
+            .expect("the commit publishes the entity into workspace authority");
+        state
+            .graph
+            .apply_transaction_delta(&kin_model::TransactionDelta {
+                entity_deltas: vec![kin_model::EntityDelta::Removed {
+                    old: authority_owned,
+                }],
+                ..kin_model::TransactionDelta::default()
+            })
+            .unwrap();
+
+        let switch = kin_cli::commands::branch::BranchRequest::Switch {
+            name: kin_model::RefName::branch(b"feature").unwrap(),
+            operation_id: kin_model::OperationId::new(),
+            actor: AuthorId::new("lost-authority-test"),
+        };
+        let (status, body) = post_branch_request(Arc::clone(&state), &switch, None).await;
+        assert_eq!(
+            status,
+            StatusCode::CONFLICT,
+            "a daemon missing authority-owned semantics must refuse: {}",
+            String::from_utf8_lossy(&body)
+        );
+        let message = String::from_utf8_lossy(&body);
+        assert!(
+            message.contains("no longer holds the repository workspace authority"),
+            "{message}"
+        );
+    }
+
     /// A seal must leave the daemon and repository authority agreeing, so the
     /// ready commands still work against the workspace it returned.
     #[cfg(unix)]

--- a/crates/kin-daemon/src/commit_deltas.rs
+++ b/crates/kin-daemon/src/commit_deltas.rs
@@ -1840,4 +1840,73 @@ mod tests {
             deltas.relation_deltas.len()
         );
     }
+
+    /// An entity whose body did not change but whose source provenance moved
+    /// must still be published.
+    ///
+    /// The workspace semantic overlay is derived by whole-value difference
+    /// against the change a commit publishes. Recording only fingerprint
+    /// changes leaves the published base holding a superseded payload, so the
+    /// difference is stranded in the overlay: the workspace reports dirty
+    /// permanently, the next switch or merge refuses it, and a further commit
+    /// publishes an empty change because the fingerprint still has not moved.
+    #[test]
+    fn commit_publishes_an_entity_whose_provenance_moved_without_its_fingerprint() {
+        let tmp = tempfile::tempdir().unwrap();
+        let init = kin_core::init(tmp.path()).unwrap();
+        let layout = init.layout;
+        let graph = Arc::new(kin_db::InMemoryGraph::new());
+        let blobs = BlobStore::new(layout.ingest_cas_dir()).unwrap();
+
+        let genesis = genesis_change();
+        graph.create_change(&genesis).unwrap();
+
+        let src_dir = layout.working_dir();
+        std::fs::create_dir_all(src_dir.join("src")).unwrap();
+        let content = b"pub fn stable() {}\n";
+        std::fs::write(src_dir.join("src/lib.rs"), content).unwrap();
+        let digest = blobs.write(content).unwrap();
+        let hash = Hash256::from_bytes(digest.0);
+        let path = RepoPath::from_utf8("src/lib.rs").unwrap();
+
+        let entity = make_entity("stable", "src/lib.rs", [99; 32]);
+        graph.upsert_entity(&entity).unwrap();
+        let head = record_commit(
+            &graph,
+            vec![EntityDelta::Added {
+                new: entity.clone(),
+            }],
+            vec![],
+            vec![TreeDelta::Added {
+                artifact_id: ArtifactId::new(),
+                new: LocatedEntry::new(path, TreeEntry::blob(hash, false)),
+            }],
+            &genesis.id,
+            "main",
+        );
+
+        // Same identity, same body, same fingerprint. Only the blob provenance
+        // the reconciler stamps has advanced, exactly as it does when an edit
+        // elsewhere in the file rewrites the artifact this entity came from.
+        let mut reprovenanced = entity.clone();
+        reprovenanced
+            .metadata
+            .extra
+            .insert("blob_hash".into(), "advanced-source-blob".into());
+        graph.upsert_entity(&reprovenanced).unwrap();
+        assert!(
+            !kin_index::entity_semantics_changed(&entity, &reprovenanced),
+            "the fixture must move provenance without moving meaning"
+        );
+
+        let deltas = compute_deltas_vs_last_commit(&graph, &head).unwrap();
+        assert_eq!(
+            deltas.entity_deltas,
+            vec![EntityDelta::Modified {
+                old: entity,
+                new: reprovenanced,
+            }],
+            "a moved payload must reach the published change, not the workspace overlay"
+        );
+    }
 }

--- a/crates/kin-daemon/src/commit_deltas.rs
+++ b/crates/kin-daemon/src/commit_deltas.rs
@@ -439,7 +439,19 @@ fn compute_deltas_from_resolved_state(
                     new: entity.clone(),
                 });
             }
-            Some(committed) if kin_index::entity_semantics_changed(committed, entity) => {
+            // Compare the complete payload, not only the AST/signature/behavior
+            // fingerprint. An entity whose body is unchanged but whose span or
+            // blob provenance advanced is still a different value, and the
+            // workspace semantic overlay is derived by whole-value difference
+            // against the change this delta publishes. Recording only
+            // fingerprint changes therefore leaves the published base holding a
+            // superseded payload, which strands that difference in the overlay:
+            // the workspace reports dirty forever, the next switch or merge
+            // refuses it, and a further commit publishes an empty change
+            // because the fingerprint still has not moved. Publishing the exact
+            // payload is also what keeps history able to reproduce the spans
+            // and source provenance the entity actually had at that change.
+            Some(committed) if committed != entity => {
                 entity_deltas.push(EntityDelta::Modified {
                     old: committed.clone(),
                     new: entity.clone(),

--- a/crates/kin-daemon/src/commit_deltas.rs
+++ b/crates/kin-daemon/src/commit_deltas.rs
@@ -1894,9 +1894,13 @@ mod tests {
             .extra
             .insert("blob_hash".into(), "advanced-source-blob".into());
         graph.upsert_entity(&reprovenanced).unwrap();
-        assert!(
-            !kin_index::entity_semantics_changed(&entity, &reprovenanced),
-            "the fixture must move provenance without moving meaning"
+        assert_eq!(
+            entity.fingerprint, reprovenanced.fingerprint,
+            "the fixture must move provenance without moving the semantic fingerprint"
+        );
+        assert_ne!(
+            entity, reprovenanced,
+            "the fixture must still be a different entity payload"
         );
 
         let deltas = compute_deltas_vs_last_commit(&graph, &head).unwrap();

--- a/crates/kin-daemon/src/local_repository_authority.rs
+++ b/crates/kin-daemon/src/local_repository_authority.rs
@@ -138,8 +138,23 @@ impl ActiveLocalRepositoryAuthority {
     }
 }
 
-/// Refuse a fresh repository mutation unless the daemon's complete derived
-/// workspace still names the exact authority lease used to plan it.
+/// Refuse a fresh repository mutation unless the daemon's derived workspace is
+/// still a faithful view of the exact authority lease used to plan it.
+///
+/// The daemon query graph is a derived view that legitimately runs ahead of
+/// workspace authority. Parser reconciliation and the asynchronous LSP
+/// enrichment worker publish semantic facets into it continuously, and those
+/// facets cross the repository-v6 compare-and-swap only when a change is
+/// committed. Demanding exact equality here therefore refuses every authority
+/// command that follows any enrichment tick, which wedges routine sessions
+/// rather than protecting them.
+///
+/// What must still hold is narrower and is enforced below: the daemon is at the
+/// same authority generation, it holds no exact tree state authority has not
+/// admitted, and it has neither dropped nor rewritten any entity or relation
+/// that authority owns. Because a derived lead is permitted, every caller must
+/// plan its daemon-side transition from the live graph via
+/// [`plan_daemon_semantic_delta`] rather than reusing the authority-side delta.
 pub(crate) fn require_fresh_daemon_workspace(
     state: &DaemonState,
     roots: &RootBundle,
@@ -155,14 +170,68 @@ pub(crate) fn require_fresh_daemon_workspace(
         );
     }
     let live = state.graph.to_snapshot();
-    if live.resolved_tree != workspace_graph.resolved_tree
-        || live.entities != workspace_graph.entities
-        || live.relations != workspace_graph.relations
-    {
+    if live.resolved_tree != workspace_graph.resolved_tree {
         bail!(
-            "daemon graph does not match the exact repository workspace authority; reopen before \
+            "daemon exact tree does not match the repository workspace authority; reopen before \
              {operation}"
         );
     }
+    if let Some(divergence) = authority_semantics_divergence(&live, workspace_graph) {
+        bail!(
+            "daemon graph no longer holds the repository workspace authority it was planned \
+             against ({divergence}); reopen before {operation}"
+        );
+    }
     Ok(())
+}
+
+/// Describe the first authority-owned entity or relation the daemon graph has
+/// dropped or rewritten, or `None` when authority is still fully retained.
+///
+/// A derived view may hold more than authority owns. It may never hold less,
+/// and it may never hold a different value under an identity authority already
+/// published: either would mean the daemon is answering from something other
+/// than graph truth.
+fn authority_semantics_divergence(
+    live: &kin_db::GraphSnapshot,
+    authority: &kin_db::GraphSnapshot,
+) -> Option<String> {
+    for (entity_id, entity) in &authority.entities {
+        match live.entities.get(entity_id) {
+            Some(live_entity) if live_entity == entity => {}
+            Some(_) => return Some(format!("entity {entity_id} was rewritten")),
+            None => return Some(format!("entity {entity_id} is missing")),
+        }
+    }
+    for (relation_id, relation) in &authority.relations {
+        match live.relations.get(relation_id) {
+            Some(live_relation) if live_relation == relation => {}
+            Some(_) => return Some(format!("relation {relation_id} was rewritten")),
+            None => return Some(format!("relation {relation_id} is missing")),
+        }
+    }
+    None
+}
+
+/// Plan the daemon-side semantic transition of one repository command from the
+/// live query graph.
+///
+/// The authority-side delta of the same command is planned from the workspace
+/// lease. These are deliberately two different deltas over the same transition:
+/// the live graph carries derived enrichment that has not crossed the
+/// compare-and-swap, so reusing the authority delta would leave that enrichment
+/// installed and land the daemon on a graph that is not the exact target.
+pub(crate) fn plan_daemon_semantic_delta(
+    state: &DaemonState,
+    target_entities: &std::collections::HashMap<kin_model::EntityId, kin_model::Entity>,
+    target_relations: &std::collections::HashMap<kin_model::RelationId, kin_model::Relation>,
+) -> Result<kin_model::WorkspaceSemanticDelta> {
+    let live = state.graph.to_snapshot();
+    kin_core::diff_workspace_semantics(
+        &live.entities,
+        &live.relations,
+        target_entities,
+        target_relations,
+    )
+    .map_err(Into::into)
 }

--- a/crates/kin-daemon/src/repository_branch.rs
+++ b/crates/kin-daemon/src/repository_branch.rs
@@ -604,9 +604,15 @@ fn switch(
         &target_state.relations,
     )
     .context("plan exact branch semantic transition")?;
+    let daemon_semantic_delta = crate::local_repository_authority::plan_daemon_semantic_delta(
+        state,
+        &target_state.entities,
+        &target_state.relations,
+    )
+    .context("plan the branch semantic transition for the daemon view")?;
     let daemon_delta = TransactionDelta {
-        entity_deltas: semantic_delta.entity_deltas().to_vec(),
-        relation_deltas: semantic_delta.relation_deltas().to_vec(),
+        entity_deltas: daemon_semantic_delta.entity_deltas().to_vec(),
+        relation_deltas: daemon_semantic_delta.relation_deltas().to_vec(),
         tree_deltas: tree_deltas.clone(),
         admission_policy_delta: None,
     };
@@ -823,9 +829,29 @@ fn replay_switch(
     let previous_tree = desired_tree
         .apply(&inverse)
         .context("reconstruct pre-switch workspace tree from persisted receipt")?;
+    // A replay recovers the daemon after authority already moved, so the
+    // workspace graph the lease holds now is the switch target. Planning the
+    // daemon side from the live graph to that target keeps the recovery honest
+    // when derived enrichment landed before the crash.
+    let target_graph = lease
+        .workspace_graph_snapshot(&workspace.workspace_id)
+        .context("materialize the replayed branch-switch workspace authority")?
+        .ok_or_else(|| {
+            anyhow::anyhow!(
+                "repository {} has no graph snapshot for workspace {}",
+                authority.repository_id,
+                workspace.workspace_id
+            )
+        })?;
+    let daemon_semantic_delta = crate::local_repository_authority::plan_daemon_semantic_delta(
+        state,
+        &target_graph.entities,
+        &target_graph.relations,
+    )
+    .context("plan the replayed branch semantic transition for the daemon view")?;
     let daemon_delta = TransactionDelta {
-        entity_deltas: mutation.semantic_delta.entity_deltas().to_vec(),
-        relation_deltas: mutation.semantic_delta.relation_deltas().to_vec(),
+        entity_deltas: daemon_semantic_delta.entity_deltas().to_vec(),
+        relation_deltas: daemon_semantic_delta.relation_deltas().to_vec(),
         tree_deltas: mutation.tree_deltas.clone(),
         admission_policy_delta: None,
     };

--- a/crates/kin-daemon/src/repository_branch.rs
+++ b/crates/kin-daemon/src/repository_branch.rs
@@ -145,6 +145,14 @@ pub(crate) fn execute(
         ));
     }
 
+    #[cfg(test)]
+    if state
+        .repository_command_enrich_after_authority_once
+        .swap(false, std::sync::atomic::Ordering::SeqCst)
+    {
+        state.install_derived_enrichment();
+    }
+
     let finalization = state
         .finalize_local_repository_commit(
             &execution.receipt,

--- a/crates/kin-daemon/src/repository_checkout.rs
+++ b/crates/kin-daemon/src/repository_checkout.rs
@@ -259,19 +259,19 @@ fn plan_and_commit(
         .iter()
         .find(|receipt| receipt.operation_id == request.operation_id)
         .cloned();
+    let workspace_graph = lease
+        .workspace_graph_snapshot(&workspace.workspace_id)
+        .map_err(|error| {
+            classify_graph_checkout_error(error, "materialize checkout workspace authority")
+        })?
+        .ok_or_else(|| {
+            CheckoutCommandError::internal(anyhow::anyhow!(
+                "repository {} has no graph snapshot for workspace {}",
+                authority.repository_id,
+                workspace.workspace_id
+            ))
+        })?;
     if existing_receipt.is_none() {
-        let workspace_graph = lease
-            .workspace_graph_snapshot(&workspace.workspace_id)
-            .map_err(|error| {
-                classify_graph_checkout_error(error, "materialize checkout workspace authority")
-            })?
-            .ok_or_else(|| {
-                CheckoutCommandError::internal(anyhow::anyhow!(
-                    "repository {} has no graph snapshot for workspace {}",
-                    authority.repository_id,
-                    workspace.workspace_id
-                ))
-            })?;
         require_fresh_daemon_workspace(state, &roots, &workspace_graph, "checking out a path")
             .map_err(CheckoutCommandError::conflict)?;
     }
@@ -502,9 +502,30 @@ fn plan_and_commit(
             "checkout graph preflight was not bound to the exact repository tree transition"
         )));
     }
+    // The authority-side transition is planned from the workspace lease, not
+    // from the daemon delta above. The daemon graph carries derived enrichment
+    // that has not crossed the compare-and-swap, so reusing its delta here
+    // would ask authority to publish or retract semantics it never owned.
+    let authority_graph = kin_db::InMemoryGraph::from_snapshot(workspace_graph)
+        .context("prepare exact checkout workspace authority graph")?;
+    let authority_delta = crate::commit_deltas::compute_selected_checkout_delta(
+        &authority_graph,
+        &graph_plan.selected,
+        &graph_plan.target_state,
+        &graph_plan.previous_tree,
+        &graph_plan.desired_tree,
+    )
+    .map_err(|error| {
+        classify_daemon_checkout_error(error, "plan exact checkout authority graph transition")
+    })?;
+    if authority_delta.tree_deltas != tree_deltas {
+        return Err(CheckoutCommandError::internal(anyhow::anyhow!(
+            "checkout authority plan was not bound to the exact repository tree transition"
+        )));
+    }
     let semantic_delta = WorkspaceSemanticDelta::new(
-        daemon_delta.entity_deltas.clone(),
-        daemon_delta.relation_deltas.clone(),
+        authority_delta.entity_deltas.clone(),
+        authority_delta.relation_deltas.clone(),
     )
     .context("canonicalize exact checkout semantic transition")?;
     let repository_changed = !tree_deltas.is_empty() || !semantic_delta.is_empty();

--- a/crates/kin-daemon/src/repository_checkout.rs
+++ b/crates/kin-daemon/src/repository_checkout.rs
@@ -259,22 +259,28 @@ fn plan_and_commit(
         .iter()
         .find(|receipt| receipt.operation_id == request.operation_id)
         .cloned();
-    let workspace_graph = lease
-        .workspace_graph_snapshot(&workspace.workspace_id)
-        .map_err(|error| {
-            classify_graph_checkout_error(error, "materialize checkout workspace authority")
-        })?
-        .ok_or_else(|| {
-            CheckoutCommandError::internal(anyhow::anyhow!(
-                "repository {} has no graph snapshot for workspace {}",
-                authority.repository_id,
-                workspace.workspace_id
-            ))
-        })?;
-    if existing_receipt.is_none() {
+    // Materialized only on the planning path. A replay returns before the
+    // authority transition is planned, so demanding a workspace authority
+    // graph there would fail a recovery that can otherwise complete.
+    let workspace_graph = if existing_receipt.is_none() {
+        let workspace_graph = lease
+            .workspace_graph_snapshot(&workspace.workspace_id)
+            .map_err(|error| {
+                classify_graph_checkout_error(error, "materialize checkout workspace authority")
+            })?
+            .ok_or_else(|| {
+                CheckoutCommandError::internal(anyhow::anyhow!(
+                    "repository {} has no graph snapshot for workspace {}",
+                    authority.repository_id,
+                    workspace.workspace_id
+                ))
+            })?;
         require_fresh_daemon_workspace(state, &roots, &workspace_graph, "checking out a path")
             .map_err(CheckoutCommandError::conflict)?;
-    }
+        Some(workspace_graph)
+    } else {
+        None
+    };
     let mut snapshot = lease.snapshot().clone();
     snapshot.repository_authority = None;
     drop(lease);
@@ -506,6 +512,11 @@ fn plan_and_commit(
     // from the daemon delta above. The daemon graph carries derived enrichment
     // that has not crossed the compare-and-swap, so reusing its delta here
     // would ask authority to publish or retract semantics it never owned.
+    let workspace_graph = workspace_graph.ok_or_else(|| {
+        CheckoutCommandError::internal(anyhow::anyhow!(
+            "checkout planning reached the authority transition without a workspace authority graph"
+        ))
+    })?;
     let authority_graph = kin_db::InMemoryGraph::from_snapshot(workspace_graph)
         .context("prepare exact checkout workspace authority graph")?;
     let authority_delta = crate::commit_deltas::compute_selected_checkout_delta(

--- a/crates/kin-daemon/src/repository_merge.rs
+++ b/crates/kin-daemon/src/repository_merge.rs
@@ -376,9 +376,15 @@ fn fast_forward(
         drop(lease);
         policy
     };
+    let daemon_semantic_delta = crate::local_repository_authority::plan_daemon_semantic_delta(
+        state,
+        &theirs_state.entities,
+        &theirs_state.relations,
+    )
+    .context("plan the exact fast-forward semantic transition for the daemon view")?;
     let daemon_delta = TransactionDelta {
-        entity_deltas: semantic_delta.entity_deltas().to_vec(),
-        relation_deltas: semantic_delta.relation_deltas().to_vec(),
+        entity_deltas: daemon_semantic_delta.entity_deltas().to_vec(),
+        relation_deltas: daemon_semantic_delta.relation_deltas().to_vec(),
         tree_deltas: tree_deltas.clone(),
         admission_policy_delta: None,
     };
@@ -585,9 +591,15 @@ fn three_way(
         &authoritative.relations,
     )
     .context("plan exact merged workspace semantics")?;
+    let daemon_semantic_delta = crate::local_repository_authority::plan_daemon_semantic_delta(
+        state,
+        &authoritative.entities,
+        &authoritative.relations,
+    )
+    .context("plan the exact merged workspace semantics for the daemon view")?;
     let daemon_delta = TransactionDelta {
-        entity_deltas: workspace_semantic_delta.entity_deltas().to_vec(),
-        relation_deltas: workspace_semantic_delta.relation_deltas().to_vec(),
+        entity_deltas: daemon_semantic_delta.entity_deltas().to_vec(),
+        relation_deltas: daemon_semantic_delta.relation_deltas().to_vec(),
         tree_deltas: workspace_tree_deltas.clone(),
         admission_policy_delta: None,
     };

--- a/crates/kin-daemon/src/repository_rollback.rs
+++ b/crates/kin-daemon/src/repository_rollback.rs
@@ -332,9 +332,15 @@ fn plan_and_commit(
         &target_state.relations,
     )
     .context("plan the exact workspace semantic restoration")?;
+    let daemon_semantic_delta = crate::local_repository_authority::plan_daemon_semantic_delta(
+        state,
+        &target_state.entities,
+        &target_state.relations,
+    )
+    .context("plan the exact workspace semantic restoration for the daemon view")?;
     let daemon_delta = TransactionDelta {
-        entity_deltas: workspace_semantic_delta.entity_deltas().to_vec(),
-        relation_deltas: workspace_semantic_delta.relation_deltas().to_vec(),
+        entity_deltas: daemon_semantic_delta.entity_deltas().to_vec(),
+        relation_deltas: daemon_semantic_delta.relation_deltas().to_vec(),
         tree_deltas: workspace_tree_deltas.clone(),
         admission_policy_delta: None,
     };

--- a/crates/kin-daemon/src/state.rs
+++ b/crates/kin-daemon/src/state.rs
@@ -916,6 +916,12 @@ pub struct DaemonState {
     /// daemon installs its derived graph/generation cursor.
     #[cfg(test)]
     pub(crate) repository_command_fail_after_authority_once: AtomicBool,
+    /// Deterministic enrichment seam in the same window: the asynchronous LSP
+    /// worker writes derived relations into the live graph without taking the
+    /// coordination gate or the persistence lock, so it can land between a
+    /// command's plan and its finalization.
+    #[cfg(test)]
+    pub(crate) repository_command_enrich_after_authority_once: AtomicBool,
     /// Monotonically increasing version counter for VFS cache invalidation.
     /// Incremented on every graph mutation (reconcile, commit, overlay update).
     /// Unlike entity_count, this never decreases on deletions.
@@ -1702,6 +1708,8 @@ impl DaemonState {
             mcp_fail_after_authority_once: AtomicBool::new(false),
             #[cfg(test)]
             repository_command_fail_after_authority_once: AtomicBool::new(false),
+            #[cfg(test)]
+            repository_command_enrich_after_authority_once: AtomicBool::new(false),
             vfs_version: AtomicU64::new(persisted_vfs_version),
             event_tx: tokio::sync::broadcast::channel(256).0,
             session_scopes: RwLock::new(HashMap::new()),
@@ -1864,6 +1872,8 @@ impl DaemonState {
             mcp_fail_after_authority_once: AtomicBool::new(false),
             #[cfg(test)]
             repository_command_fail_after_authority_once: AtomicBool::new(false),
+            #[cfg(test)]
+            repository_command_enrich_after_authority_once: AtomicBool::new(false),
             vfs_version: AtomicU64::new(persisted_vfs_version),
             event_tx: tokio::sync::broadcast::channel(256).0,
             session_scopes: RwLock::new(HashMap::new()),
@@ -3318,20 +3328,93 @@ impl DaemonState {
         Ok(())
     }
 
+    /// Write derived semantics into the live query graph the way the LSP
+    /// enrichment worker does: additive upserts under nothing but the graph
+    /// authority epoch, holding neither the coordination gate nor the
+    /// persistence lock. Used to place an enrichment tick at an exact point
+    /// inside a repository command rather than waiting for a real worker to
+    /// race one in.
+    #[cfg(test)]
+    pub(crate) fn install_derived_enrichment(&self) {
+        use kin_model::EntityStore;
+        let anchor = kin_model::Entity {
+            id: kin_model::EntityId::new(),
+            kind: kin_model::EntityKind::Function,
+            name: "enriched_inside_the_command_window".to_string(),
+            language: kin_model::LanguageId::Rust,
+            fingerprint: kin_model::SemanticFingerprint {
+                algorithm: kin_model::FingerprintAlgorithm::V1TreeSitter,
+                ast_hash: kin_model::Hash256::from_bytes([11; 32]),
+                signature_hash: kin_model::Hash256::from_bytes([12; 32]),
+                behavior_hash: kin_model::Hash256::from_bytes([13; 32]),
+                equivalence_hash: kin_model::Hash256::from_bytes([0; 32]),
+                stability_score: 1.0,
+            },
+            file_origin: None,
+            span: None,
+            signature: "fn enriched_inside_the_command_window()".to_string(),
+            visibility: kin_model::Visibility::Public,
+            role: kin_model::EntityRole::Source,
+            doc_summary: None,
+            metadata: kin_model::EntityMetadata::default(),
+            lineage_parent: None,
+            created_in: None,
+            superseded_by: None,
+        };
+        let relation = kin_model::Relation {
+            id: kin_model::RelationId::new(),
+            kind: kin_model::RelationKind::Calls,
+            src: kin_model::GraphNodeId::Entity(anchor.id),
+            dst: kin_model::GraphNodeId::Entity(anchor.id),
+            confidence: 0.95,
+            origin: kin_model::RelationOrigin::Lsp,
+            created_in: None,
+            import_source: None,
+            evidence: Vec::new(),
+        };
+        let _guard = self.begin_graph_authority_mutation();
+        self.graph
+            .apply_transaction_delta(&TransactionDelta {
+                entity_deltas: vec![kin_model::EntityDelta::Added { new: anchor }],
+                ..TransactionDelta::default()
+            })
+            .expect("derived enrichment entity must reach the live graph");
+        self.graph
+            .upsert_relation(&relation)
+            .expect("derived enrichment relation must reach the live graph");
+        self.bump_version();
+    }
+
     /// Install one already-durable local repository receipt into the daemon's
     /// derived graph and generation cursor.
     ///
     /// Callers must hold `coordination_gate`, `persist_lock`, and one
     /// `GraphAuthorityMutationGuard` across both the repository CAS and this
     /// method. The complete delta must have been constructed and preflighted
-    /// before that irreversible CAS. This method revalidates it against the
-    /// still-live graph so a replay heals the authority/daemon crash gap without
-    /// absorbing an unrelated later generation.
+    /// before that irreversible CAS. This method revalidates the transition
+    /// against the still-live graph so a replay heals the authority/daemon crash
+    /// gap without absorbing an unrelated later generation.
+    ///
+    /// The daemon-side semantic and tree transition is planned here rather than
+    /// taken from `planned_delta`. Between planning and this call the authority
+    /// transaction committed and the projection was materialized, and the
+    /// asynchronous LSP enrichment worker writes into the live graph without
+    /// taking either the coordination gate or the persistence lock. A plan-time
+    /// delta can therefore no longer describe the transition the live graph
+    /// needs, and applying it would leave the daemon short of the exact
+    /// authority graph after authority had already advanced. Only the admission
+    /// policy transition, which no derived writer produces, is carried over from
+    /// the plan.
+    ///
+    /// One consequence is worth naming: because the target is the exact
+    /// authority graph, every finalization discards whatever derived enrichment
+    /// the live graph is holding beyond authority. That lead is derived, and the
+    /// enrichment worker recomputes it.
     pub(crate) fn finalize_local_repository_commit(
         &self,
         receipt: &RepositoryCommitReceipt,
         authority_freeze: &LocalRepositoryAuthorityFreeze,
-        delta: &TransactionDelta,
+        planned_delta: &TransactionDelta,
         expected_previous_tree: &ResolvedTree,
         desired_tree: &ResolvedTree,
     ) -> Result<LocalRepositoryFinalization> {
@@ -3402,15 +3485,26 @@ impl DaemonState {
 
         let authority_snapshot = authority_graph.to_snapshot();
         let live_snapshot = self.graph.to_snapshot();
-        let already_installed = live_snapshot.resolved_tree == *desired_tree
-            && live_snapshot.entities == authority_snapshot.entities
-            && live_snapshot.relations == authority_snapshot.relations;
-        let graph_changed = !already_installed && delta != &TransactionDelta::default();
+        let semantics = kin_core::diff_workspace_semantics(
+            &live_snapshot.entities,
+            &live_snapshot.relations,
+            &authority_snapshot.entities,
+            &authority_snapshot.relations,
+        )?;
+        let tree_deltas =
+            kin_core::exact_tree_correction(&live_snapshot.resolved_tree, desired_tree)?;
+        let finalization_delta = TransactionDelta {
+            entity_deltas: semantics.entity_deltas().to_vec(),
+            relation_deltas: semantics.relation_deltas().to_vec(),
+            tree_deltas,
+            admission_policy_delta: planned_delta.admission_policy_delta.clone(),
+        };
+        let graph_changed = finalization_delta != TransactionDelta::default();
         if graph_changed {
             let preflight =
                 kin_db::InMemoryGraph::from_snapshot(live_snapshot).map_err(DaemonError::from)?;
             preflight
-                .apply_transaction_delta(delta)
+                .apply_transaction_delta(&finalization_delta)
                 .map_err(DaemonError::from)?;
             let preflight_snapshot = preflight.to_snapshot();
             if preflight_snapshot.resolved_tree != *desired_tree
@@ -3423,7 +3517,7 @@ impl DaemonState {
                 )));
             }
             self.graph
-                .apply_transaction_delta(delta)
+                .apply_transaction_delta(&finalization_delta)
                 .map_err(DaemonError::from)?;
         }
         let live_snapshot = self.graph.to_snapshot();

--- a/crates/kin-index/src/lib.rs
+++ b/crates/kin-index/src/lib.rs
@@ -51,8 +51,8 @@ pub use linker::{
 pub use linker::{is_external_import_placeholder, EXTERNAL_IMPORT_REFERENCE_RULE};
 pub use overlay::{apply_file_removal, apply_to_graph, ApplyResult};
 pub use pipeline::{
-    classify_file_role, entity_semantics_changed, normalize_file_path_id, IndexPipeline,
-    IndexedAny, IndexedFile, COMMAND_EFFECT_CONTRACT_KEY,
+    classify_file_role, normalize_file_path_id, IndexPipeline, IndexedAny, IndexedFile,
+    COMMAND_EFFECT_CONTRACT_KEY,
 };
 pub use repository::{
     host_path_from_repo_path, is_repository_control_path, read_verified_scanned_entry,

--- a/crates/kin-index/src/pipeline.rs
+++ b/crates/kin-index/src/pipeline.rs
@@ -630,6 +630,14 @@ pub const COMMAND_EFFECT_CONTRACT_KEY: &str = "command_effect_contract";
 /// sides carry one (key-absent vs key-present is persist-path coverage skew,
 /// never evidence of change). Every entity-delta producer must use this one
 /// definition so graph truth does not depend on which write path recorded it.
+/// Report whether two revisions of one entity differ in meaning rather than in
+/// payload.
+///
+/// This is a reporting predicate for surfaces that describe intent, such as
+/// review and impact. It must not gate a repository authority delta: a change
+/// that omits an entity because only its span or blob provenance advanced
+/// publishes a base that no longer equals the workspace graph, and the
+/// difference is then stranded in the workspace semantic overlay.
 pub fn entity_semantics_changed(old: &Entity, new: &Entity) -> bool {
     let contract_changed = match (
         old.metadata.extra.get(COMMAND_EFFECT_CONTRACT_KEY),

--- a/crates/kin-index/src/pipeline.rs
+++ b/crates/kin-index/src/pipeline.rs
@@ -625,33 +625,6 @@ fn attach_equivalence_class(
 /// entity metadata.
 pub const COMMAND_EFFECT_CONTRACT_KEY: &str = "command_effect_contract";
 
-/// Whether two versions of the same entity differ semantically: any of the
-/// three fingerprint hashes, or an attached command-effect contract when BOTH
-/// sides carry one (key-absent vs key-present is persist-path coverage skew,
-/// never evidence of change). Every entity-delta producer must use this one
-/// definition so graph truth does not depend on which write path recorded it.
-/// Report whether two revisions of one entity differ in meaning rather than in
-/// payload.
-///
-/// This is a reporting predicate for surfaces that describe intent, such as
-/// review and impact. It must not gate a repository authority delta: a change
-/// that omits an entity because only its span or blob provenance advanced
-/// publishes a base that no longer equals the workspace graph, and the
-/// difference is then stranded in the workspace semantic overlay.
-pub fn entity_semantics_changed(old: &Entity, new: &Entity) -> bool {
-    let contract_changed = match (
-        old.metadata.extra.get(COMMAND_EFFECT_CONTRACT_KEY),
-        new.metadata.extra.get(COMMAND_EFFECT_CONTRACT_KEY),
-    ) {
-        (Some(a), Some(b)) => a != b,
-        _ => false,
-    };
-    old.fingerprint.ast_hash != new.fingerprint.ast_hash
-        || old.fingerprint.signature_hash != new.fingerprint.signature_hash
-        || old.fingerprint.behavior_hash != new.fingerprint.behavior_hash
-        || contract_changed
-}
-
 /// Whether a single path component names a test directory: one of its
 /// `[_-.]`-delimited words is an exact test keyword. Word-level matching (never a
 /// raw substring) keeps a testing tool's shipped product package — `_pytest`,


### PR DESCRIPTION
Fixes the wedge behind FIR-1622 and the dirty overlay behind FIR-1619. They share a root cause, but not the one either ticket proposed. Diagnosed with a live-daemon reproducer before choosing a design; the ticket's suspected cause (no watcher self-write suppression) was falsified.

## What actually breaks

**The suspected cause was wrong.** There is indeed no watcher self-write suppression, but the file watcher is not the writer that wedges anything. Two independent defects are:

**1. The freshness check forbids a lead that the design requires.** `require_fresh_daemon_workspace` demanded `live.entities == authority.entities && live.relations == authority.relations`. That equality is unachievable: the reconcile loop publishes only the *tree* through the compare-and-swap and leaves parser semantics in the live graph, and the asynchronous LSP enrichment worker writes relations into the live graph outside the coordination gate. Both reach authority only when a change is committed. So the check passes for a moment after each commit and then fails permanently at the next enrichment tick, refusing every switch, merge, rollback, and checkout with `daemon graph does not match the exact repository workspace authority`.

Falsified both ways on a live daemon: with `KIN_DAEMON_DISABLE_LSP=1` the same switch succeeds; with LSP on it refuses, and the daemon log shows `LSP enrichment added relations` landing between the commit and the refusal.

**2. History and the workspace overlay disagreed on what "changed" means.** The published change recorded an entity as `Modified` only when `entity_semantics_changed` (AST / signature / behavior fingerprint) was true, but kin-db derives the workspace semantic overlay by *whole-value* difference against that change. An entity whose body is unchanged and whose blob provenance advanced (the reconciler stamps `blob_hash` on every reconciled entity) was therefore omitted from history, so the new base held a superseded payload and the difference was stranded in the overlay. `WorkspaceState::is_dirty()` is true whenever the overlay is non-empty, so the workspace reported dirty permanently, the next switch refused it, and a further commit published an **empty** change because the fingerprint still had not moved. That is FIR-1619 verbatim.

## The fix

- Narrow the freshness contract to what authority actually guarantees: same generation, no exact tree state authority has not admitted, and no entity or relation authority owns that the daemon dropped or rewrote. An additive derived lead is permitted; loss or rewrite still refuses.
- Because a lead is now permitted, each command plans its two deltas separately instead of reusing one. Branch switch, merge (fast-forward and composed), rollback, and switch replay plan the **daemon** side from the live graph; checkout plans the **authority** side from the workspace lease. Stash already did this and is the model.
- Publish entity modifications by whole payload rather than by fingerprint, so the base a commit installs equals the workspace graph and nothing is stranded in the overlay.

## Post-review hardening

- Finalization now recomputes the exact live-to-authority semantic and tree correction after the durable repository CAS, instead of applying a plan-time delta to a graph that enrichment may have advanced. Admission-policy changes remain the only plan-time component carried through.
- Checkout replay materializes the exact selected authority tree before finalization, keeping projection, workspace authority, and the daemon cursor coherent across the crash-gap replay path.
- A real-binary `kin stash push` / `pop` integration test leaves LSP enrichment enabled, proves opaque non-code bytes round-trip, and requires the freshness-gated drift check to pass after the cycle.

## Evidence

All live-daemon runs used a scratch daemon under the lane's own directory, with the real watcher and LSP enrichment enabled.

| target | before (origin/main `1d016b02`) | after |
| --- | --- | --- |
| FIR-1619 switch, commit, switch again | switch refuses `has graph-owned changes`; workspace dirty; further commit publishes 0/0/0; second switch refuses | both switches succeed, workspace clean after commit, no empty change |
| FIR-1622 stash seal/restore then a freshness-gated command | `stash pop` refuses 409; the following `branch switch` refuses 409 | seal, `branch create`, pop, `branch create`, commit, switch all succeed |
| anti-suppression: foreign edit written immediately after a switch returns | n/a | admitted as an edit; `foreign_marker` reaches the graph; commit is non-empty |

The anti-suppression result is guaranteed by construction, not by tuning: no suppression mechanism was added, so no observation is ever dropped. The wedge is removed by making the freshness contract honest about what authority owns, not by hiding events from the watcher.

Regression tests include `switch_tolerates_derived_semantics_the_workspace_has_not_published`, `switch_refuses_a_daemon_that_lost_authority_owned_semantics`, `switch_survives_enrichment_that_lands_after_the_authority_commit`, `commit_publishes_an_entity_whose_provenance_moved_without_its_fingerprint`, the four daemon stash route tests, and `crates/kin-cli/tests/repository_stash.rs` against the real binaries.

## Stash flip

Flipped to `ready` / `enabled` on its own merits: the live-daemon cycle that held the gate closed now passes, including the freshness-gated commands after both halves. Ready count recounted by execution from the merged fixture: **28 of 33**. Bounded dogfood unchanged at 12/12.

Note that the pre-fix control run needed the gate flipped in a detached origin/main worktree to exercise the same daemon path, since the CLI otherwise refuses at the capability gate.


## Integrated verification

Exact pushed head: `8fcf9352e13ed1ebe20932fa14e738ea21869819`, after merging Kin main at `92c449653f02212685e32349c0dce1dd91cadcd4` without force-pushing.

- `cargo fmt --all -- --check`
- the exact CI clippy allowlist under `RUSTFLAGS=-Dwarnings`
- runtime-boundary and private-repo-coupling guards
- `cargo build --all-targets --locked` under `RUSTFLAGS=-Dwarnings`
- focused matrices: capability 5/5, real-binary stash 2/2, daemon stash 4/4, switch/freshness 4/4, provenance regression 1/1
- full `cargo test --workspace --locked` with ambient VFS authority and user Git hooks removed: zero failures, including doc tests

An initial local full-suite attempt inherited `KIN_VFS_WORKSPACE` / `KIN_VFS_SOCK` and the user's global DCO hook. It failed 14 unrelated temp-repository tests because their Git fixture commits were intercepted. The trusted rerun explicitly removed those ambient authorities and passed; no product code was changed on the contaminated evidence.
