### PR TITLE
Incremental historical enrichment and cheap admission proofs

### DIFF
--- a/crates/kin-core/src/env_registry.rs
+++ b/crates/kin-core/src/env_registry.rs
@@ -162,6 +162,7 @@ pub const OPERATIONAL: &[EnvVarSpec] = &[
     EnvVarSpec { name: "KIN_WRITE_VETO", kind: Kind::OneOf(&["warn", "enforce", "off"]), default: "warn", sensitivity: Sensitivity::Correctness, summary: "write-veto mode: 'warn' (default) annotates would-be vetoes into foreign-held scopes, 'enforce' rejects them with a 409, 'off' disables" },
     EnvVarSpec { name: "KIN_DAEMON_LOCATE_ONLY", kind: Kind::Bool, default: "false", sensitivity: Sensitivity::Correctness, summary: "daemon serves locate-only from a snapshot, changing what it answers" },
     EnvVarSpec { name: "KIN_DAEMON_DISABLE_LSP", kind: Kind::Bool, default: "false", sensitivity: Sensitivity::Correctness, summary: "disable LSP enrichment in the daemon, reducing relation coverage" },
+    EnvVarSpec { name: "KIN_HISTORY_LINK_VERIFY", kind: Kind::Bool, default: "false", sensitivity: Sensitivity::Operational, summary: "cross-check incremental historical enrichment against the full batch derivation at every commit during Git admission (self-audit; much slower, output unchanged)" },
     EnvVarSpec { name: "KIN_COCHANGE_MAX_FAN_OUT", kind: Kind::Usize, default: "15", sensitivity: Sensitivity::Correctness, summary: "cap on co-change fan-out per entity (co-change ranking signal)" },
     EnvVarSpec { name: "KIN_COCHANGE_MAX_FILES_PER_COMMIT", kind: Kind::Usize, default: "20", sensitivity: Sensitivity::Correctness, summary: "cap on files per commit considered for the co-change signal" },
 
@@ -590,6 +591,18 @@ impl AuditReport {
 /// invocation inside a kin-vfs projection would emit a spurious typo warning.
 const EXTERNAL_PREFIXES: &[&str] = &["KIN_VFS_"];
 
+/// `KIN_*` variables that existed in an earlier kin and were deliberately
+/// removed. Setting one is not a possible typo: the caller is pinning a
+/// guarantee this binary no longer implements, and silently ignoring the pin
+/// would let a protocol fail-safe rot into a no-op. These fail startup loudly
+/// in every validation mode so the caller learns the pin is dead.
+const REMOVED: &[(&str, &str)] = &[(
+    "KIN_INIT_WARM_CACHE",
+    "this variable was removed with the exact Git admission cutover: init derives all \
+     semantic truth from the captured object closure and consults no warm cache, so the \
+     contamination this pin guarded against cannot occur. Unset it",
+)];
+
 /// Audit an environment (any iterator of name/value pairs). Pure: it never reads
 /// or mutates the process environment, so it is deterministic and testable.
 ///
@@ -608,6 +621,14 @@ where
         }
         if EXTERNAL_PREFIXES.iter().any(|p| name.starts_with(p)) {
             continue; // owned by a sibling component (e.g. kin-vfs); not our surface
+        }
+        if let Some((_, reason)) = REMOVED.iter().find(|(removed, _)| *removed == name) {
+            report.invalid.push(Finding {
+                var: name.clone(),
+                severity: Severity::Error,
+                message: (*reason).to_string(),
+            });
+            continue;
         }
         match spec(&name) {
             None => report.unknown.push(name),
@@ -981,6 +1002,27 @@ mod tests {
             spec("KIN_LOCATE_PHASE_MULTIHOP_SECS").unwrap().kind,
             Kind::SecsBound
         ));
+    }
+
+    #[test]
+    fn removed_var_hard_fails_in_every_mode() {
+        // A removed variable is a dead protocol pin, not a typo: it must abort
+        // startup loudly even in the default warn mode, naming itself and why.
+        for strict in [false, true] {
+            let report = audit_env(
+                [("KIN_INIT_WARM_CACHE".to_string(), "0".to_string())],
+                strict,
+            );
+            assert!(report.unknown.is_empty(), "removed vars are not unknowns");
+            assert!(report.has_hard_errors());
+            let finding = report
+                .invalid
+                .iter()
+                .find(|f| f.var == "KIN_INIT_WARM_CACHE")
+                .expect("removed var must be reported by name");
+            assert_eq!(finding.severity, Severity::Error);
+            assert!(finding.message.contains("removed"));
+        }
     }
 
     #[test]

--- a/crates/kin-core/src/git_init.rs
+++ b/crates/kin-core/src/git_init.rs
@@ -14,11 +14,12 @@ use std::sync::Arc;
 use kin_blobs::BlobStore;
 use kin_db::{LocalFileBackend, RepositoryAuthorityManager};
 use kin_git::{
-    admit_semantic_git_import, build_git_external_authority, capture_lossless_git_repository,
-    plan_semantic_git_import, preflight_git_migration, preflight_git_migration_after_publication,
-    preflight_git_source_compatibility, seal_all_content_observation, AdmittedContentClosure,
-    GitLocalIgnoreSourceKind, GitMigrationPreflightProof, LosslessGitRepository,
-    SealedContentObservation,
+    admit_validated_semantic_git_import, build_git_external_authority,
+    capture_lossless_git_repository, plan_validated_semantic_git_import,
+    preflight_git_source_compatibility, preflight_validated_git_migration,
+    preflight_validated_git_migration_after_publication, seal_all_content_observation,
+    AdmittedContentClosure, GitLocalIgnoreSourceKind, GitMigrationPreflightProof,
+    LosslessGitRepository, SealedContentObservation, ValidatedSemanticGitImportPlan,
 };
 use kin_model::{
     compute_resolved_tree_hash, AdmissionCase, AuthorId, ChangeStore,
@@ -219,14 +220,18 @@ fn init_from_git_with_hooks(
         .map_err(|error| git_boundary_error("capture exact Git repository", error))?;
     let git_authority = build_git_external_authority(&snapshot, &capture_store)
         .map_err(|error| git_boundary_error("build exact Git authority", error))?;
-    let semantic_plan = plan_semantic_git_import(&snapshot, &capture_store)
+    let semantic_plan = plan_validated_semantic_git_import(&snapshot, &capture_store)
         .map_err(|error| git_boundary_error("derive exact semantic Git history", error))?;
-    verify_material_workspace_seed(&semantic_plan.workspace_seed, &git_authority.material_head)?;
+    verify_material_workspace_seed(
+        &semantic_plan.as_plan().workspace_seed,
+        &git_authority.material_head,
+    )?;
     let semantic_plan = bind_historical_semantics(semantic_plan, &capture_store)?;
-    let admitted = admit_semantic_git_import(&semantic_plan, &capture_store)
+    let admitted = admit_validated_semantic_git_import(&semantic_plan, &capture_store)
         .map_err(|error| git_boundary_error("derive branch-versioned admission policy", error))?;
-    let source_proof = preflight_git_migration(&source, &snapshot, &semantic_plan, &capture_store)
-        .map_err(|error| git_boundary_error("prove mutable Git workspace", error))?;
+    let source_proof =
+        preflight_validated_git_migration(&source, &snapshot, &semantic_plan, &capture_store)
+            .map_err(|error| git_boundary_error("prove mutable Git workspace", error))?;
 
     let final_kin_dir = source.join(".kin");
     let staging_dir = source_parent.join(format!(".kin.init-{}", uuid::Uuid::new_v4()));
@@ -265,7 +270,7 @@ fn init_from_git_with_hooks(
     let mut result = publish_repository_layout_linearized(prepared, |publication| {
         before_final_source_proof();
         let final_proof =
-            preflight_git_migration(&source, &snapshot, &semantic_plan, &capture_store)
+            preflight_validated_git_migration(&source, &snapshot, &semantic_plan, &capture_store)
                 .map_err(|error| git_boundary_error("repeat final Git source proof", error))?;
         if final_proof != source_proof {
             return Err(KinError::Other(
@@ -275,7 +280,7 @@ fn init_from_git_with_hooks(
         }
         let published = publication.publish()?;
         after_repository_publication();
-        let published_proof = preflight_git_migration_after_publication(
+        let published_proof = preflight_validated_git_migration_after_publication(
             &source,
             published.path(),
             &snapshot,
@@ -303,7 +308,7 @@ fn init_from_git_with_hooks(
         // keeps a repository that cannot answer for its content from being
         // published at all. Neither site degrades into a filesystem read.
         let published_observation =
-            seal_published_content_observation(published.path(), &semantic_plan)?;
+            seal_published_content_observation(published.path(), semantic_plan.as_plan())?;
         if published_observation.fingerprint != sealed_observation.fingerprint {
             return Err(KinError::Other(
                 "sealed all-content observation changed across repository publication; published \
@@ -725,12 +730,13 @@ fn git_boundary_error(context: impl std::fmt::Display, error: impl std::fmt::Dis
 /// and alias identities, so it must happen before any identity derived from the
 /// plan is published.
 fn bind_historical_semantics(
-    plan: kin_git::SemanticGitImportPlan,
+    plan: ValidatedSemanticGitImportPlan,
     capture_store: &BlobStore,
-) -> Result<kin_git::SemanticGitImportPlan> {
+) -> Result<ValidatedSemanticGitImportPlan> {
+    let exact = plan.as_plan();
     let mut trees = std::collections::BTreeMap::new();
-    for alias in &plan.aliases {
-        let tree = plan.commit_trees.get(&alias.oid).ok_or_else(|| {
+    for alias in &exact.aliases {
+        let tree = exact.commit_trees.get(&alias.oid).ok_or_else(|| {
             git_boundary_error(
                 "bind historical semantics",
                 format!("imported commit {} has no exact resolved tree", alias.oid),
@@ -745,13 +751,13 @@ fn bind_historical_semantics(
     }
 
     let bindings =
-        kin_index::derive_historical_semantic_deltas(&plan.changes, &trees, capture_store)
+        kin_index::derive_historical_semantic_deltas(&exact.changes, &trees, capture_store)
             .map_err(|error| git_boundary_error("derive historical semantics", error))?
             .into_iter()
             .map(|delta| (delta.change_id, delta.entity_deltas, delta.relation_deltas))
             .collect::<Vec<_>>();
 
-    plan.with_historical_semantics(capture_store, &bindings)
+    plan.with_historical_semantics(&bindings)
         .map_err(|error| git_boundary_error("bind historical semantics", error))
 }
 

--- a/crates/kin-core/src/git_init.rs
+++ b/crates/kin-core/src/git_init.rs
@@ -16,8 +16,9 @@ use kin_db::{LocalFileBackend, RepositoryAuthorityManager};
 use kin_git::{
     admit_semantic_git_import, build_git_external_authority, capture_lossless_git_repository,
     plan_semantic_git_import, preflight_git_migration, preflight_git_migration_after_publication,
-    seal_all_content_observation, AdmittedContentClosure, GitLocalIgnoreSourceKind,
-    GitMigrationPreflightProof, LosslessGitRepository, SealedContentObservation,
+    preflight_git_source_compatibility, seal_all_content_observation, AdmittedContentClosure,
+    GitLocalIgnoreSourceKind, GitMigrationPreflightProof, LosslessGitRepository,
+    SealedContentObservation,
 };
 use kin_model::{
     compute_resolved_tree_hash, AdmissionCase, AuthorId, ChangeStore,
@@ -190,6 +191,13 @@ fn init_from_git_with_hooks(
 ) -> Result<InitResult> {
     let source = canonical_new_repository_root(working_dir)?;
     require_git_boundary(&source)?;
+    // Refuse a source that can never be admitted before paying for capture,
+    // planning, or enrichment: shallow boundary, in-progress operations,
+    // sibling registered worktrees, and local hook/filter blockers all fail
+    // here in milliseconds. The full two-observation migration proof still
+    // runs below; this only fronts the refusals.
+    preflight_git_source_compatibility(&source)
+        .map_err(|error| git_boundary_error("prove mutable Git workspace", error))?;
 
     let manifest = KinManifest::new();
     let repository_id = RepositoryId::new(manifest.repo_id.clone())

--- a/crates/kin-git/src/admission_history.rs
+++ b/crates/kin-git/src/admission_history.rs
@@ -22,7 +22,10 @@ use kin_model::{
 
 use crate::error::{GitError, Result};
 use crate::lossless::{GitObjectFormat, LosslessGitRepository};
-use crate::semantic_import::{plan_semantic_git_import, GitWorkspaceSeed, SemanticGitImportPlan};
+use crate::semantic_import::{
+    plan_semantic_git_import, GitWorkspaceSeed, SemanticGitImportPlan,
+    ValidatedSemanticGitImportPlan,
+};
 
 /// A deterministic semantic Git import whose every commit carries the exact
 /// shared admission-policy transition derived from that commit's resolved
@@ -170,6 +173,15 @@ pub fn admit_semantic_git_import(
 ) -> Result<AdmittedSemanticGitImportPlan> {
     plan.validate(blob_store)?;
     build_admitted_semantic_git_import_plan(plan, blob_store)
+}
+
+/// Add shared admission policy to an import plan whose exact raw-object
+/// derivation is already represented by a non-forgeable validation token.
+pub fn admit_validated_semantic_git_import(
+    plan: &ValidatedSemanticGitImportPlan,
+    blob_store: &BlobStore,
+) -> Result<AdmittedSemanticGitImportPlan> {
+    build_admitted_semantic_git_import_plan(plan.as_plan(), blob_store)
 }
 
 fn build_admitted_semantic_git_import_plan(

--- a/crates/kin-git/src/authority.rs
+++ b/crates/kin-git/src/authority.rs
@@ -151,6 +151,8 @@ mod tests {
         let output = Command::new("git")
             .args(args)
             .current_dir(repository)
+            .env("GIT_CONFIG_NOSYSTEM", "1")
+            .env("HOME", repository)
             .output()
             .unwrap();
         assert!(

--- a/crates/kin-git/src/lib.rs
+++ b/crates/kin-git/src/lib.rs
@@ -33,11 +33,11 @@ pub use lossless::{
     LosslessGitRepository,
 };
 pub use preflight::{
-    preflight_git_migration, preflight_git_migration_after_publication, GitBranchTrackingFact,
-    GitIndexPreflightProof, GitLocalIgnoreInputFact, GitLocalIgnoreSourceKind,
-    GitMigrationCompatibilityFacts, GitMigrationPreflightProof, GitRemoteConfigFact,
-    GitRemoteMappingFacts, GitTrackedWorktreeProof, IgnoredLocalEntry, IgnoredLocalEntryKind,
-    IgnoredLocalWorktreeFact,
+    preflight_git_migration, preflight_git_migration_after_publication,
+    preflight_git_source_compatibility, GitBranchTrackingFact, GitIndexPreflightProof,
+    GitLocalIgnoreInputFact, GitLocalIgnoreSourceKind, GitMigrationCompatibilityFacts,
+    GitMigrationPreflightProof, GitRemoteConfigFact, GitRemoteMappingFacts,
+    GitTrackedWorktreeProof, IgnoredLocalEntry, IgnoredLocalEntryKind, IgnoredLocalWorktreeFact,
 };
 pub use repository_export::{
     export_repository_to_git, verify_repository_git_export, RepositoryGitCommitBinding,

--- a/crates/kin-git/src/lib.rs
+++ b/crates/kin-git/src/lib.rs
@@ -21,7 +21,9 @@ pub mod repository_export;
 pub mod sealed_observation;
 pub mod semantic_import;
 
-pub use admission_history::{admit_semantic_git_import, AdmittedSemanticGitImportPlan};
+pub use admission_history::{
+    admit_semantic_git_import, admit_validated_semantic_git_import, AdmittedSemanticGitImportPlan,
+};
 pub use authority::build_git_external_authority;
 pub use error::{
     GitCheckoutFilterFact, GitError, LocalGitHookFact, LocalGitHookKind, RegisteredGitWorktreeFact,
@@ -34,10 +36,12 @@ pub use lossless::{
 };
 pub use preflight::{
     preflight_git_migration, preflight_git_migration_after_publication,
-    preflight_git_source_compatibility, GitBranchTrackingFact, GitIndexPreflightProof,
-    GitLocalIgnoreInputFact, GitLocalIgnoreSourceKind, GitMigrationCompatibilityFacts,
-    GitMigrationPreflightProof, GitRemoteConfigFact, GitRemoteMappingFacts,
-    GitTrackedWorktreeProof, IgnoredLocalEntry, IgnoredLocalEntryKind, IgnoredLocalWorktreeFact,
+    preflight_git_source_compatibility, preflight_validated_git_migration,
+    preflight_validated_git_migration_after_publication, GitBranchTrackingFact,
+    GitIndexPreflightProof, GitLocalIgnoreInputFact, GitLocalIgnoreSourceKind,
+    GitMigrationCompatibilityFacts, GitMigrationPreflightProof, GitRemoteConfigFact,
+    GitRemoteMappingFacts, GitTrackedWorktreeProof, IgnoredLocalEntry, IgnoredLocalEntryKind,
+    IgnoredLocalWorktreeFact,
 };
 pub use repository_export::{
     export_repository_to_git, verify_repository_git_export, RepositoryGitCommitBinding,
@@ -47,4 +51,7 @@ pub use sealed_observation::{
     seal_all_content_observation, AdmittedContentClosure, ContentExclusionReason,
     DeclaredContentExclusion, SealedContentCoverage, SealedContentObservation, SealedContentSource,
 };
-pub use semantic_import::{plan_semantic_git_import, GitWorkspaceSeed, SemanticGitImportPlan};
+pub use semantic_import::{
+    plan_semantic_git_import, plan_validated_semantic_git_import, GitWorkspaceSeed,
+    SemanticGitImportPlan, ValidatedSemanticGitImportPlan,
+};

--- a/crates/kin-git/src/lossless.rs
+++ b/crates/kin-git/src/lossless.rs
@@ -19,7 +19,7 @@ use std::sync::atomic::{AtomicU64, Ordering};
 
 use gix::bstr::ByteSlice;
 use gix::objs::tree::EntryKind;
-use gix::objs::{Find as _, FindHeader as _, Write as _};
+use gix::objs::{Find as _, Write as _};
 use kin_blobs::BlobStore;
 use kin_model::{
     ExternalObjectId, ExternalObjectKind, ExternalObjectRecord, GitObjectId, RefName, RefTarget,
@@ -210,8 +210,7 @@ pub fn capture_lossless_git_repository(
     Ok(snapshot)
 }
 
-/// Prove a source repository still matches a previously captured snapshot
-/// without re-reading blob bodies.
+/// Prove a source repository still matches a previously captured snapshot.
 ///
 /// This is the stability re-observation for a snapshot that was already
 /// captured with full body verification. It re-proves, byte-exactly:
@@ -220,18 +219,14 @@ pub fn capture_lossless_git_repository(
 /// - the object format is unchanged
 /// - every ref and HEAD converts to exactly the captured state
 /// - the reachable closure walked from those refs is exactly the captured
-///   object set: every commit, tree, and tag body is re-read and re-verified
-///   against its Git object ID, Kin body hash, and length, and its
-///   dependencies are re-traversed
-/// - every reachable blob is still present in the object database with the
-///   captured kind and decompressed length
+///   object set: every commit, tree, blob, and tag body is re-read and
+///   re-verified against its Git object ID, Kin body hash, and length, and
+///   structure-object dependencies are re-traversed
 ///
-/// The one observation this does not repeat is re-reading blob payload bytes:
-/// a blob's identity is its OID under Git's content addressing, the original
-/// capture verified those bytes against both the OID and Kin's CAS, and
-/// admission consumes the captured CAS bodies rather than the source object
-/// database. A same-OID, same-length body swap in the source ODB is therefore
-/// outside this proof, exactly as far as it is outside Git's own object model.
+/// Blob payloads are deliberately read again. A header-only probe would accept
+/// an object-database corruption that preserved kind and declared length while
+/// changing the payload behind the captured OID, violating the exact final
+/// source observation this proof represents.
 pub(crate) fn verify_lossless_snapshot_unchanged(
     repo: &gix::Repository,
     expected: &LosslessGitRepository,
@@ -335,30 +330,6 @@ pub(crate) fn verify_lossless_snapshot_unchanged(
             ensure_expected_kind(model_oid, record.object.kind, expected_kind, &next.context)?;
         }
 
-        if record.object.kind == ExternalObjectKind::Blob {
-            let header = match repo.objects.try_header(&next.oid) {
-                Ok(Some(header)) => header,
-                Ok(None) => {
-                    return Err(GitError::MissingObject {
-                        oid: next.oid.to_string(),
-                        context: next.context.clone(),
-                    })
-                }
-                Err(error) => {
-                    return Err(GitError::CorruptObject {
-                        oid: next.oid.to_string(),
-                        reason: error.to_string(),
-                    })
-                }
-            };
-            if external_kind(header.kind) != ExternalObjectKind::Blob
-                || header.size != record.body_len
-            {
-                return Err(changed());
-            }
-            continue;
-        }
-
         let mut body = Vec::new();
         let kind = match repo.objects.try_find(&next.oid, &mut body) {
             Ok(Some(object)) => object.kind,
@@ -385,7 +356,9 @@ pub(crate) fn verify_lossless_snapshot_unchanged(
         if observed != **record {
             return Err(changed());
         }
-        enqueue_dependencies(model_oid, kind, &body, &next.context, &mut pending)?;
+        if kind != ExternalObjectKind::Blob {
+            enqueue_dependencies(model_oid, kind, &body, &next.context, &mut pending)?;
+        }
     }
 
     if visited.len() != expected.objects.len() {
@@ -2335,6 +2308,44 @@ mod tests {
             Err(GitError::Blob(_))
         ));
         assert!(!cas_output.exists());
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn final_snapshot_observation_rejects_same_length_blob_payload_corruption() {
+        let fixture = Fixture::simple();
+        let snapshot = capture_lossless_git_repository(
+            &fixture.repo,
+            RepositoryId::new("final-blob-observation").unwrap(),
+            &fixture.blob_store,
+        )
+        .unwrap();
+        let blob = snapshot
+            .objects
+            .iter()
+            .find(|record| record.object.kind == ExternalObjectKind::Blob)
+            .expect("fixture has a reachable blob");
+        let mut replacement = fixture.blob_store.read(&blob.body_hash).unwrap();
+        assert!(!replacement.is_empty());
+        replacement[0] ^= 0xff;
+        let replacement_oid = git_stdin_text(
+            &fixture.repo,
+            ["hash-object", "-w", "--stdin"],
+            &replacement,
+        );
+        assert_ne!(replacement_oid, blob.object.oid.to_string());
+
+        let git_dir = fixture.repo.join(".git");
+        let replacement_path = loose_object_path(&git_dir, &replacement_oid);
+        let captured_path = loose_object_path(&git_dir, &blob.object.oid.to_string());
+        fs::remove_file(&captured_path).expect("remove captured loose blob");
+        fs::copy(replacement_path, captured_path).expect("replace captured loose blob payload");
+
+        let repo = open_repo(&fixture.repo).unwrap();
+        assert!(matches!(
+            verify_lossless_snapshot_unchanged(&repo, &snapshot),
+            Err(GitError::InvalidSnapshot(_)) | Err(GitError::CorruptObject { .. })
+        ));
     }
 
     #[test]

--- a/crates/kin-git/src/lossless.rs
+++ b/crates/kin-git/src/lossless.rs
@@ -19,7 +19,7 @@ use std::sync::atomic::{AtomicU64, Ordering};
 
 use gix::bstr::ByteSlice;
 use gix::objs::tree::EntryKind;
-use gix::objs::{Find as _, Write as _};
+use gix::objs::{Find as _, FindHeader as _, Write as _};
 use kin_blobs::BlobStore;
 use kin_model::{
     ExternalObjectId, ExternalObjectKind, ExternalObjectRecord, GitObjectId, RefName, RefTarget,
@@ -208,6 +208,190 @@ pub fn capture_lossless_git_repository(
     };
     validate_snapshot(&snapshot, blob_store)?;
     Ok(snapshot)
+}
+
+/// Prove a source repository still matches a previously captured snapshot
+/// without re-reading blob bodies.
+///
+/// This is the stability re-observation for a snapshot that was already
+/// captured with full body verification. It re-proves, byte-exactly:
+///
+/// - the shallow boundary is still absent
+/// - the object format is unchanged
+/// - every ref and HEAD converts to exactly the captured state
+/// - the reachable closure walked from those refs is exactly the captured
+///   object set: every commit, tree, and tag body is re-read and re-verified
+///   against its Git object ID, Kin body hash, and length, and its
+///   dependencies are re-traversed
+/// - every reachable blob is still present in the object database with the
+///   captured kind and decompressed length
+///
+/// The one observation this does not repeat is re-reading blob payload bytes:
+/// a blob's identity is its OID under Git's content addressing, the original
+/// capture verified those bytes against both the OID and Kin's CAS, and
+/// admission consumes the captured CAS bodies rather than the source object
+/// database. A same-OID, same-length body swap in the source ODB is therefore
+/// outside this proof, exactly as far as it is outside Git's own object model.
+pub(crate) fn verify_lossless_snapshot_unchanged(
+    repo: &gix::Repository,
+    expected: &LosslessGitRepository,
+) -> Result<()> {
+    let changed = || {
+        GitError::InvalidSnapshot(
+            "source HEAD, refs, or reachable object closure no longer matches the supplied \
+             snapshot"
+                .to_string(),
+        )
+    };
+    reject_shallow_repository(repo)?;
+    if object_format(repo)? != expected.object_format {
+        return Err(changed());
+    }
+
+    let expected_records: BTreeMap<GitObjectId, &ExternalObjectRecord> = expected
+        .objects
+        .iter()
+        .map(|record| (record.object.oid, record))
+        .collect();
+    if expected_records.len() != expected.objects.len() {
+        return Err(GitError::InvalidSnapshot(
+            "captured snapshot repeats an object identity".to_string(),
+        ));
+    }
+    let object_kinds: BTreeMap<GitObjectId, ExternalObjectKind> = expected
+        .objects
+        .iter()
+        .map(|record| (record.object.oid, record.object.kind))
+        .collect();
+
+    let mut raw_refs = collect_refs(repo)?;
+    raw_refs.sort_by(|left, right| left.name.cmp(&right.name));
+    ensure_unique_ref_names(&raw_refs)?;
+    let raw_head = collect_head(repo)?;
+
+    let mut pending = VecDeque::new();
+    for repository_ref in &raw_refs {
+        if let RawTarget::Direct(oid) = repository_ref.target {
+            pending.push_back(PendingObject {
+                oid,
+                expected_kind: None,
+                context: format!("ref {}", display_bytes(&repository_ref.name)),
+            });
+        }
+    }
+    if let RawTarget::Direct(oid) = raw_head {
+        pending.push_back(PendingObject {
+            oid,
+            expected_kind: None,
+            context: "detached HEAD".to_string(),
+        });
+    }
+
+    let refs = RepositoryRefState {
+        refs: raw_refs
+            .into_iter()
+            .map(|repository_ref| {
+                let name = ref_name(repository_ref.name)?;
+                let target = exact_ref_target(repository_ref.target, &object_kinds)
+                    .map_err(|_| changed())?;
+                Ok(RepositoryRef {
+                    repository_id: expected.repository_id.clone(),
+                    name,
+                    target,
+                })
+            })
+            .collect::<Result<Vec<_>>>()?,
+        default_ref: match &raw_head {
+            RawTarget::Symbolic(target) => Some(ref_name(target.clone())?),
+            RawTarget::Direct(_) => None,
+        },
+    };
+    let head = match raw_head {
+        RawTarget::Symbolic(target) => WorkspaceHead::Symbolic {
+            target: ref_name(target)?,
+        },
+        RawTarget::Direct(oid) => WorkspaceHead::Detached {
+            target: exact_ref_target(RawTarget::Direct(oid), &object_kinds)
+                .map_err(|_| changed())?,
+        },
+    };
+    if refs != expected.refs || head != expected.head {
+        return Err(changed());
+    }
+
+    let mut visited = BTreeSet::new();
+    while let Some(next) = pending.pop_front() {
+        let model_oid = git_object_id(next.oid)?;
+        let Some(record) = expected_records.get(&model_oid) else {
+            return Err(changed());
+        };
+        if !visited.insert(model_oid) {
+            if let Some(expected_kind) = next.expected_kind {
+                ensure_expected_kind(model_oid, record.object.kind, expected_kind, &next.context)?;
+            }
+            continue;
+        }
+        if let Some(expected_kind) = next.expected_kind {
+            ensure_expected_kind(model_oid, record.object.kind, expected_kind, &next.context)?;
+        }
+
+        if record.object.kind == ExternalObjectKind::Blob {
+            let header = match repo.objects.try_header(&next.oid) {
+                Ok(Some(header)) => header,
+                Ok(None) => {
+                    return Err(GitError::MissingObject {
+                        oid: next.oid.to_string(),
+                        context: next.context.clone(),
+                    })
+                }
+                Err(error) => {
+                    return Err(GitError::CorruptObject {
+                        oid: next.oid.to_string(),
+                        reason: error.to_string(),
+                    })
+                }
+            };
+            if external_kind(header.kind) != ExternalObjectKind::Blob
+                || header.size != record.body_len
+            {
+                return Err(changed());
+            }
+            continue;
+        }
+
+        let mut body = Vec::new();
+        let kind = match repo.objects.try_find(&next.oid, &mut body) {
+            Ok(Some(object)) => object.kind,
+            Ok(None) => {
+                return Err(GitError::MissingObject {
+                    oid: next.oid.to_string(),
+                    context: next.context.clone(),
+                })
+            }
+            Err(error) => {
+                return Err(GitError::CorruptObject {
+                    oid: next.oid.to_string(),
+                    reason: error.to_string(),
+                })
+            }
+        };
+        let kind = external_kind(kind);
+        let observed = ExternalObjectRecord::from_raw(kind, model_oid, &body).map_err(|error| {
+            GitError::CorruptObject {
+                oid: model_oid.to_string(),
+                reason: error.to_string(),
+            }
+        })?;
+        if observed != **record {
+            return Err(changed());
+        }
+        enqueue_dependencies(model_oid, kind, &body, &next.context, &mut pending)?;
+    }
+
+    if visited.len() != expected.objects.len() {
+        return Err(changed());
+    }
+    Ok(())
 }
 
 /// Rehydrate an exact SHA-1 Git repository from a lossless snapshot.

--- a/crates/kin-git/src/preflight.rs
+++ b/crates/kin-git/src/preflight.rs
@@ -30,7 +30,7 @@ use crate::lossless::{
     open_repo, reject_shallow_repository, verify_lossless_snapshot_unchanged, GitObjectFormat,
     LosslessGitRepository,
 };
-use crate::semantic_import::SemanticGitImportPlan;
+use crate::semantic_import::{SemanticGitImportPlan, ValidatedSemanticGitImportPlan};
 
 /// Successful, point-in-time proof that one Git workspace can be admitted
 /// without flattening index or worktree state into repository authority.
@@ -259,6 +259,24 @@ pub fn preflight_git_migration(
     preflight_git_migration_with_hook(repo_path, snapshot, plan, blob_store, None, || {})
 }
 
+/// Prove the mutable Git boundary for a plan whose complete raw-object
+/// derivation is already carried by a non-forgeable validation token.
+pub fn preflight_validated_git_migration(
+    repo_path: &Path,
+    snapshot: &LosslessGitRepository,
+    plan: &ValidatedSemanticGitImportPlan,
+    blob_store: &BlobStore,
+) -> Result<GitMigrationPreflightProof> {
+    preflight_validated_git_migration_with_hook(
+        repo_path,
+        snapshot,
+        plan.as_plan(),
+        blob_store,
+        None,
+        || {},
+    )
+}
+
 /// Repeat an exact Git source proof after Kin has atomically installed `.kin`.
 ///
 /// Only the supplied real `.kin` directory at the canonical worktree root is
@@ -266,6 +284,41 @@ pub fn preflight_git_migration(
 /// leaf, ignored-local fact, and any other untracked path remains subject to
 /// the same two-observation proof as pre-publication migration.
 pub fn preflight_git_migration_after_publication(
+    repo_path: &Path,
+    published_kin_dir: &Path,
+    snapshot: &LosslessGitRepository,
+    plan: &SemanticGitImportPlan,
+    blob_store: &BlobStore,
+) -> Result<GitMigrationPreflightProof> {
+    plan.validate(blob_store)?;
+    preflight_git_migration_after_publication_inner(
+        repo_path,
+        published_kin_dir,
+        snapshot,
+        plan,
+        blob_store,
+    )
+}
+
+/// Repeat the post-publication proof for a plan whose full derivation is
+/// already represented by a validation token.
+pub fn preflight_validated_git_migration_after_publication(
+    repo_path: &Path,
+    published_kin_dir: &Path,
+    snapshot: &LosslessGitRepository,
+    plan: &ValidatedSemanticGitImportPlan,
+    blob_store: &BlobStore,
+) -> Result<GitMigrationPreflightProof> {
+    preflight_git_migration_after_publication_inner(
+        repo_path,
+        published_kin_dir,
+        snapshot,
+        plan.as_plan(),
+        blob_store,
+    )
+}
+
+fn preflight_git_migration_after_publication_inner(
     repo_path: &Path,
     published_kin_dir: &Path,
     snapshot: &LosslessGitRepository,
@@ -291,7 +344,7 @@ pub fn preflight_git_migration_after_publication(
             expected_kin_dir.display()
         )));
     }
-    preflight_git_migration_with_hook(
+    preflight_validated_git_migration_with_hook(
         &source_worktree,
         snapshot,
         plan,
@@ -302,6 +355,25 @@ pub fn preflight_git_migration_after_publication(
 }
 
 fn preflight_git_migration_with_hook(
+    repo_path: &Path,
+    snapshot: &LosslessGitRepository,
+    plan: &SemanticGitImportPlan,
+    blob_store: &BlobStore,
+    published_kin_dir: Option<&Path>,
+    after_first_observation: impl FnOnce(),
+) -> Result<GitMigrationPreflightProof> {
+    plan.validate(blob_store)?;
+    preflight_validated_git_migration_with_hook(
+        repo_path,
+        snapshot,
+        plan,
+        blob_store,
+        published_kin_dir,
+        after_first_observation,
+    )
+}
+
+fn preflight_validated_git_migration_with_hook(
     repo_path: &Path,
     snapshot: &LosslessGitRepository,
     plan: &SemanticGitImportPlan,
@@ -340,11 +412,9 @@ fn validate_plan_binding(
     snapshot: &LosslessGitRepository,
     plan: &SemanticGitImportPlan,
 ) -> Result<()> {
-    // Binding-only check: the plan's full raw-object rebuild audit belongs to
-    // admission (`admit_semantic_git_import` validates the plan exactly once).
-    // The migration proof only needs the plan to be bound to the snapshot it
-    // is proving, so re-running the O(history x tree) self-derivation here
-    // three times per admission bought no additional proof.
+    // This is only the cheap binding half of validation. Public callers reach
+    // it after `SemanticGitImportPlan::validate`; the optimized path can reach
+    // it only through a non-forgeable `ValidatedSemanticGitImportPlan`.
     if plan.repository_id != snapshot.repository_id
         || plan.object_format != snapshot.object_format
         || plan.external_objects != snapshot.objects
@@ -2034,6 +2104,7 @@ mod tests {
     use std::os::unix::fs::{symlink, PermissionsExt};
     use std::process::{Command, Output, Stdio};
 
+    use kin_model::ResolvedTree;
     use tempfile::TempDir;
 
     use super::*;
@@ -2736,6 +2807,18 @@ mod tests {
     }
 
     #[test]
+    fn public_preflight_rejects_plan_tampering_outside_the_snapshot_binding_fields() {
+        let fixture = Fixture::clean();
+        let mut tampered = fixture.plan.clone();
+        tampered.workspace_seed.base_tree = ResolvedTree::default();
+
+        assert!(matches!(
+            preflight_git_migration(&fixture.repo, &fixture.snapshot, &tampered, &fixture.store),
+            Err(GitError::InvalidSnapshot(_))
+        ));
+    }
+
+    #[test]
     fn admits_the_only_linked_worktree_of_a_bare_repository() {
         let temp = tempfile::tempdir().expect("tempdir");
         let seed = temp.path().join("seed");
@@ -3102,7 +3185,10 @@ mod tests {
 
     fn git_command(repo: &Path) -> Command {
         let mut command = clean_git_command();
-        command.current_dir(repo);
+        command
+            .current_dir(repo)
+            .env("GIT_CONFIG_NOSYSTEM", "1")
+            .env("HOME", repo);
         command
     }
 

--- a/crates/kin-git/src/preflight.rs
+++ b/crates/kin-git/src/preflight.rs
@@ -440,10 +440,8 @@ fn observe(
         fs::canonicalize(repo_path).map_err(|error| GitError::io(repo_path, error))?;
     let repo = open_repo(&source_worktree)?;
     // Stability re-observation of the already-captured snapshot: refs, HEAD,
-    // and the reachable closure are re-proven byte-exactly (structure objects
-    // re-verified in full, blob bodies by presence, kind, and length) without
-    // re-reading every blob payload the initial capture already verified
-    // against both its OID and the CAS.
+    // and every reachable object body are re-proven byte-exactly against the
+    // initial capture, including blobs whose kind and length are unchanged.
     verify_lossless_snapshot_unchanged(&repo, expected_snapshot)?;
     let snapshot = expected_snapshot;
     let (source_git_dir, workdir) = assert_source_compatibility(&repo, &source_worktree)?;

--- a/crates/kin-git/src/preflight.rs
+++ b/crates/kin-git/src/preflight.rs
@@ -27,7 +27,7 @@ use crate::error::{
     RegisteredGitWorktreeKind, Result,
 };
 use crate::lossless::{
-    capture_lossless_git_repository, open_repo, reject_shallow_repository, GitObjectFormat,
+    open_repo, reject_shallow_repository, verify_lossless_snapshot_unchanged, GitObjectFormat,
     LosslessGitRepository,
 };
 use crate::semantic_import::SemanticGitImportPlan;
@@ -230,7 +230,6 @@ impl fmt::Debug for GitBranchTrackingFact {
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 struct PreflightObservation {
-    snapshot: LosslessGitRepository,
     proof: GitMigrationPreflightProof,
 }
 
@@ -310,7 +309,7 @@ fn preflight_git_migration_with_hook(
     published_kin_dir: Option<&Path>,
     after_first_observation: impl FnOnce(),
 ) -> Result<GitMigrationPreflightProof> {
-    validate_plan_binding(snapshot, plan, blob_store)?;
+    validate_plan_binding(snapshot, plan)?;
     let expected = expected_index_entries(snapshot, plan)?;
     let first = observe(
         repo_path,
@@ -340,9 +339,12 @@ fn preflight_git_migration_with_hook(
 fn validate_plan_binding(
     snapshot: &LosslessGitRepository,
     plan: &SemanticGitImportPlan,
-    blob_store: &BlobStore,
 ) -> Result<()> {
-    plan.validate(blob_store)?;
+    // Binding-only check: the plan's full raw-object rebuild audit belongs to
+    // admission (`admit_semantic_git_import` validates the plan exactly once).
+    // The migration proof only needs the plan to be bound to the snapshot it
+    // is proving, so re-running the O(history x tree) self-derivation here
+    // three times per admission bought no additional proof.
     if plan.repository_id != snapshot.repository_id
         || plan.object_format != snapshot.object_format
         || plan.external_objects != snapshot.objects
@@ -366,51 +368,16 @@ fn observe(
 ) -> Result<PreflightObservation> {
     let source_worktree =
         fs::canonicalize(repo_path).map_err(|error| GitError::io(repo_path, error))?;
-    let snapshot = capture_lossless_git_repository(
-        &source_worktree,
-        expected_snapshot.repository_id.clone(),
-        blob_store,
-    )?;
-    if snapshot != *expected_snapshot {
-        return Err(preflight_error(
-            "source HEAD, refs, or reachable object closure no longer matches the supplied snapshot",
-        ));
-    }
-
     let repo = open_repo(&source_worktree)?;
-    reject_shallow_repository(&repo)?;
-    reject_in_progress_operations(&repo)?;
-    let source_git_dir = stable_path(repo.git_dir());
-    let workdir = repo.workdir().ok_or_else(|| {
-        preflight_error("migration preflight requires a materialized Git worktree")
-    })?;
-    if stable_path(workdir) != source_worktree {
-        return Err(preflight_error(format!(
-            "opened Git worktree {} does not match requested source {}",
-            workdir.display(),
-            source_worktree.display()
-        )));
-    }
-
-    let other_worktrees = other_registered_worktrees(&repo, &source_worktree)?;
-    if !other_worktrees.is_empty() {
-        return Err(GitError::AdditionalWorktrees {
-            count: other_worktrees.len(),
-            worktrees: other_worktrees,
-        });
-    }
-
-    let (configured_custom_hooks_path, hooks) = local_hook_facts(&repo)?;
-    let filters = checkout_filter_facts(&repo);
-    if configured_custom_hooks_path || !hooks.is_empty() || !filters.is_empty() {
-        return Err(GitError::LocalCompatibilityBlockers {
-            hook_count: hooks.len(),
-            custom_hooks_path: configured_custom_hooks_path,
-            filter_count: filters.len(),
-            hooks,
-            filters,
-        });
-    }
+    // Stability re-observation of the already-captured snapshot: refs, HEAD,
+    // and the reachable closure are re-proven byte-exactly (structure objects
+    // re-verified in full, blob bodies by presence, kind, and length) without
+    // re-reading every blob payload the initial capture already verified
+    // against both its OID and the CAS.
+    verify_lossless_snapshot_unchanged(&repo, expected_snapshot)?;
+    let snapshot = expected_snapshot;
+    let (source_git_dir, workdir) = assert_source_compatibility(&repo, &source_worktree)?;
+    let workdir = workdir.as_path();
 
     let remote_mapping = remote_mapping_facts(&repo)?;
     let absent_index_allowed = matches!(snapshot.head, WorkspaceHead::Symbolic { .. })
@@ -439,7 +406,7 @@ fn observe(
         blob_store,
         published_kin_dir,
     )?;
-    let snapshot_fingerprint = fingerprint_snapshot(&snapshot);
+    let snapshot_fingerprint = fingerprint_snapshot(snapshot);
     let semantic_plan_fingerprint = fingerprint_plan(plan)?;
     let compatibility = GitMigrationCompatibilityFacts {
         other_registered_worktrees: Vec::new(),
@@ -467,7 +434,7 @@ fn observe(
         observation_fingerprint: digest(b"kin.git.preflight.unset"),
     };
     proof.observation_fingerprint = fingerprint_proof(&proof);
-    Ok(PreflightObservation { snapshot, proof })
+    Ok(PreflightObservation { proof })
 }
 
 fn expected_index_entries(
@@ -969,6 +936,69 @@ fn prove_tracked_entry(
             // graph-owned pointer. Any nested state above fails closed.
         }
     }
+    Ok(())
+}
+
+/// Fail-closed source-compatibility refusals that need no captured snapshot.
+///
+/// Shared by [`preflight_git_source_compatibility`] and the two-observation
+/// migration proof so the cheap refusal set and the admission-time proof can
+/// never drift apart. Returns the stable Git dir and materialized worktree.
+fn assert_source_compatibility(
+    repo: &gix::Repository,
+    source_worktree: &Path,
+) -> Result<(PathBuf, PathBuf)> {
+    reject_shallow_repository(repo)?;
+    reject_in_progress_operations(repo)?;
+    let source_git_dir = stable_path(repo.git_dir());
+    let workdir = repo.workdir().ok_or_else(|| {
+        preflight_error("migration preflight requires a materialized Git worktree")
+    })?;
+    if stable_path(workdir) != source_worktree {
+        return Err(preflight_error(format!(
+            "opened Git worktree {} does not match requested source {}",
+            workdir.display(),
+            source_worktree.display()
+        )));
+    }
+    let workdir = workdir.to_path_buf();
+
+    let other_worktrees = other_registered_worktrees(repo, source_worktree)?;
+    if !other_worktrees.is_empty() {
+        return Err(GitError::AdditionalWorktrees {
+            count: other_worktrees.len(),
+            worktrees: other_worktrees,
+        });
+    }
+
+    let (configured_custom_hooks_path, hooks) = local_hook_facts(repo)?;
+    let filters = checkout_filter_facts(repo);
+    if configured_custom_hooks_path || !hooks.is_empty() || !filters.is_empty() {
+        return Err(GitError::LocalCompatibilityBlockers {
+            hook_count: hooks.len(),
+            custom_hooks_path: configured_custom_hooks_path,
+            filter_count: filters.len(),
+            hooks,
+            filters,
+        });
+    }
+    Ok((source_git_dir, workdir))
+}
+
+/// Prove in milliseconds that a Git source is even a candidate for exact
+/// admission, before any capture, plan, or enrichment cost is paid.
+///
+/// This is exactly the snapshot-free refusal subset of the migration proof:
+/// shallow boundary, in-progress operations, materialized worktree identity,
+/// sibling registered worktrees, and local hook/filter blockers. It proves
+/// nothing about content: the full two-observation migration proof still runs
+/// at admission time. Hoisting only the refusals means a source that can never
+/// be admitted fails before a capture is attempted rather than after it.
+pub fn preflight_git_source_compatibility(repo_path: &Path) -> Result<()> {
+    let source_worktree =
+        fs::canonicalize(repo_path).map_err(|error| GitError::io(repo_path, error))?;
+    let repo = open_repo(&source_worktree)?;
+    assert_source_compatibility(&repo, &source_worktree)?;
     Ok(())
 }
 
@@ -2007,6 +2037,7 @@ mod tests {
     use tempfile::TempDir;
 
     use super::*;
+    use crate::lossless::capture_lossless_git_repository;
     use crate::{plan_semantic_git_import, GitError};
 
     struct Fixture {
@@ -2642,6 +2673,66 @@ mod tests {
             }
             error => panic!("unexpected error: {error:?}"),
         }
+    }
+
+    /// The snapshot-free preflight must reproduce every refusal the full
+    /// migration proof would raise, without any capture cost, and must accept
+    /// a clean source.
+    #[test]
+    fn source_compatibility_preflight_fronts_the_refusals() {
+        let clean = Fixture::clean();
+        preflight_git_source_compatibility(&clean.repo).expect("clean source is a candidate");
+
+        let started = std::time::Instant::now();
+        let worktrees = Fixture::clean();
+        let other = worktrees.temp.path().join("other-worktree");
+        git(
+            &worktrees.repo,
+            &[
+                "worktree",
+                "add",
+                "-b",
+                "other",
+                other.to_str().expect("utf8 test path"),
+            ],
+        );
+        match preflight_git_source_compatibility(&worktrees.repo)
+            .expect_err("sibling worktree refusal")
+        {
+            GitError::AdditionalWorktrees { count, .. } => assert_eq!(count, 1),
+            error => panic!("unexpected error: {error:?}"),
+        }
+
+        let shallow = Fixture::clean();
+        let head = git_stdout(&shallow.repo, &["rev-parse", "HEAD"]);
+        fs::write(shallow.repo.join(".git/shallow"), format!("{head}\n")).expect("shallow");
+        assert!(matches!(
+            preflight_git_source_compatibility(&shallow.repo).expect_err("shallow refusal"),
+            GitError::ShallowRepository
+        ));
+
+        let hook = Fixture::clean();
+        let hook_path = hook.repo.join(".git/hooks/pre-commit");
+        fs::write(&hook_path, b"#!/bin/sh\nexit 0\n").expect("hook");
+        let mut permissions = fs::metadata(&hook_path)
+            .expect("hook metadata")
+            .permissions();
+        permissions.set_mode(0o755);
+        fs::set_permissions(&hook_path, permissions).expect("hook chmod");
+        assert!(matches!(
+            preflight_git_source_compatibility(&hook.repo).expect_err("hook refusal"),
+            GitError::LocalCompatibilityBlockers { .. }
+        ));
+
+        // Refusals must not cost anything like a capture: the three refusal
+        // probes above, fixtures included, stay far under a second of work
+        // each. The bound is deliberately loose for slow CI machines while
+        // still proving the check cannot be doing per-object history work.
+        assert!(
+            started.elapsed() < std::time::Duration::from_secs(20),
+            "snapshot-free preflight took {:?}",
+            started.elapsed()
+        );
     }
 
     #[test]

--- a/crates/kin-git/src/repository_export.rs
+++ b/crates/kin-git/src/repository_export.rs
@@ -1665,7 +1665,13 @@ mod tests {
     }
 
     fn git(repository: &Path, args: &[&str]) -> Vec<u8> {
-        command(Command::new("git").args(args).current_dir(repository))
+        command(
+            Command::new("git")
+                .args(args)
+                .current_dir(repository)
+                .env("GIT_CONFIG_NOSYSTEM", "1")
+                .env("HOME", repository),
+        )
     }
 
     fn git_bare(repository: &Path, args: &[&str]) -> Vec<u8> {
@@ -1678,6 +1684,8 @@ mod tests {
         let mut child = Command::new("git")
             .args(args)
             .current_dir(repository)
+            .env("GIT_CONFIG_NOSYSTEM", "1")
+            .env("HOME", repository)
             .stdin(Stdio::piped())
             .stdout(Stdio::piped())
             .stderr(Stdio::piped())

--- a/crates/kin-git/src/semantic_import.rs
+++ b/crates/kin-git/src/semantic_import.rs
@@ -75,6 +75,45 @@ pub struct SemanticGitImportPlan {
     pub default_ref_mutation: Option<DefaultRefMutation>,
 }
 
+/// A semantic import plan whose complete raw-object derivation has been
+/// validated.
+///
+/// The inner plan is deliberately not publicly mutable and this type has no
+/// public constructor. Callers obtain it either from
+/// [`plan_validated_semantic_git_import`], where validity holds by
+/// construction, or from [`SemanticGitImportPlan::into_validated`], which
+/// performs the full rebuild-and-compare audit. This token lets the admission
+/// pipeline avoid repeating that expensive audit without making an unchecked
+/// plan mutation callable on a plain public [`SemanticGitImportPlan`].
+#[derive(Debug, Clone, PartialEq)]
+pub struct ValidatedSemanticGitImportPlan {
+    plan: SemanticGitImportPlan,
+}
+
+impl ValidatedSemanticGitImportPlan {
+    /// Borrow the exact validated plan for read-only derivation and proof.
+    pub const fn as_plan(&self) -> &SemanticGitImportPlan {
+        &self.plan
+    }
+
+    /// Consume the validation token and return the ordinary public plan.
+    pub fn into_inner(self) -> SemanticGitImportPlan {
+        self.plan
+    }
+
+    /// Bind deterministic historical semantics to the exact validated base
+    /// plan without rebuilding that base from raw objects again.
+    pub fn with_historical_semantics(
+        self,
+        deltas: &[(SemanticChangeId, Vec<EntityDelta>, Vec<RelationDelta>)],
+    ) -> Result<Self> {
+        require_unenriched_plan(&self.plan)?;
+        Ok(Self {
+            plan: apply_historical_semantic_deltas_unchecked(self.plan, deltas)?,
+        })
+    }
+}
+
 impl SemanticGitImportPlan {
     /// Rebuild the plan from its exact raw-object/ref state and require a
     /// byte-for-byte deterministic semantic result.
@@ -129,36 +168,32 @@ impl SemanticGitImportPlan {
         Ok(())
     }
 
+    /// Consume this plan and return a non-forgeable validated-plan token after
+    /// the full raw-object rebuild-and-compare audit succeeds.
+    pub fn into_validated(self, blob_store: &BlobStore) -> Result<ValidatedSemanticGitImportPlan> {
+        self.validate(blob_store)?;
+        Ok(ValidatedSemanticGitImportPlan { plan: self })
+    }
+
     /// Bind deterministic CAS-native semantic deltas and recompute every
     /// change identity, parent edge, and external alias in parent-first order.
     ///
     /// The plan must be unenriched and must carry the change identities its
     /// own content derives: every change identity is recomputed here and
     /// compared, which pins each change's payload and, transitively through
-    /// parent identities, the whole DAG. This deliberately does not re-derive
-    /// the plan from raw objects; [`admit_semantic_git_import`] performs that
-    /// full rebuild-and-compare audit exactly once on the enriched result, so
-    /// a plan whose content does not match its raw-object derivation still
-    /// fails closed before admission.
-    ///
-    /// [`admit_semantic_git_import`]: crate::admit_semantic_git_import
+    /// parent identities, the whole DAG. Because this method is callable on a
+    /// plain public plan, it first performs the full raw-object
+    /// rebuild-and-compare audit. Pipelines that already hold a
+    /// [`ValidatedSemanticGitImportPlan`] can bind through that token without
+    /// repeating the audit.
     pub fn with_historical_semantics(
         self,
-        _blob_store: &BlobStore,
+        blob_store: &BlobStore,
         deltas: &[(SemanticChangeId, Vec<EntityDelta>, Vec<RelationDelta>)],
     ) -> Result<Self> {
-        for change in &self.changes {
-            if !change.entity_deltas.is_empty()
-                || !change.relation_deltas.is_empty()
-                || validate_semantic_change_id(change).is_err()
-            {
-                return Err(GitError::InvalidSnapshot(
-                    "historical semantics may only be bound to the exact unenriched import plan"
-                        .to_string(),
-                ));
-            }
-        }
-        apply_historical_semantic_deltas_unchecked(self, deltas)
+        self.into_validated(blob_store)?
+            .with_historical_semantics(deltas)
+            .map(ValidatedSemanticGitImportPlan::into_inner)
     }
 }
 
@@ -167,7 +202,34 @@ pub fn plan_semantic_git_import(
     snapshot: &LosslessGitRepository,
     blob_store: &BlobStore,
 ) -> Result<SemanticGitImportPlan> {
-    build_semantic_git_import_plan(snapshot, blob_store)
+    plan_validated_semantic_git_import(snapshot, blob_store)
+        .map(ValidatedSemanticGitImportPlan::into_inner)
+}
+
+/// Build a semantic Git history whose exact raw-object derivation is proven by
+/// construction and retain that fact as a non-forgeable token.
+pub fn plan_validated_semantic_git_import(
+    snapshot: &LosslessGitRepository,
+    blob_store: &BlobStore,
+) -> Result<ValidatedSemanticGitImportPlan> {
+    Ok(ValidatedSemanticGitImportPlan {
+        plan: build_semantic_git_import_plan(snapshot, blob_store)?,
+    })
+}
+
+fn require_unenriched_plan(plan: &SemanticGitImportPlan) -> Result<()> {
+    for change in &plan.changes {
+        if !change.entity_deltas.is_empty()
+            || !change.relation_deltas.is_empty()
+            || validate_semantic_change_id(change).is_err()
+        {
+            return Err(GitError::InvalidSnapshot(
+                "historical semantics may only be bound to the exact unenriched import plan"
+                    .to_string(),
+            ));
+        }
+    }
+    Ok(())
 }
 
 fn apply_historical_semantic_deltas_unchecked(
@@ -1762,6 +1824,38 @@ mod tests {
         );
         assert_eq!(admitted.workspace_base_change_id(), None);
         admitted.validate(&blob_store).unwrap();
+    }
+
+    #[test]
+    fn public_historical_binding_rejects_a_structurally_tampered_plan() {
+        let root = tempdir().unwrap();
+        let repo = root.path().join("source");
+        fs::create_dir(&repo).unwrap();
+        git_ok(&repo, ["init", "--initial-branch=main"]);
+        configure_git(&repo);
+        write(&repo, "src/lib.rs", b"pub fn exact() {}\n");
+        git_ok(&repo, ["add", "--all"]);
+        git_ok(&repo, ["commit", "-m", "initial"]);
+        let blob_store = BlobStore::new(root.path().join("cas")).unwrap();
+        let snapshot = capture_lossless_git_repository(
+            &repo,
+            RepositoryId::new("public-binding-validation").unwrap(),
+            &blob_store,
+        )
+        .unwrap();
+        let plan = plan_semantic_git_import(&snapshot, &blob_store).unwrap();
+        let bindings = plan
+            .changes
+            .iter()
+            .map(|change| (change.id, Vec::new(), Vec::new()))
+            .collect::<Vec<_>>();
+
+        let mut tampered = plan;
+        tampered.workspace_seed.base_tree = ResolvedTree::default();
+        assert!(matches!(
+            tampered.with_historical_semantics(&blob_store, &bindings),
+            Err(GitError::InvalidSnapshot(_))
+        ));
     }
 
     #[test]

--- a/crates/kin-git/src/semantic_import.rs
+++ b/crates/kin-git/src/semantic_import.rs
@@ -131,24 +131,32 @@ impl SemanticGitImportPlan {
 
     /// Bind deterministic CAS-native semantic deltas and recompute every
     /// change identity, parent edge, and external alias in parent-first order.
+    ///
+    /// The plan must be unenriched and must carry the change identities its
+    /// own content derives: every change identity is recomputed here and
+    /// compared, which pins each change's payload and, transitively through
+    /// parent identities, the whole DAG. This deliberately does not re-derive
+    /// the plan from raw objects; [`admit_semantic_git_import`] performs that
+    /// full rebuild-and-compare audit exactly once on the enriched result, so
+    /// a plan whose content does not match its raw-object derivation still
+    /// fails closed before admission.
+    ///
+    /// [`admit_semantic_git_import`]: crate::admit_semantic_git_import
     pub fn with_historical_semantics(
         self,
-        blob_store: &BlobStore,
+        _blob_store: &BlobStore,
         deltas: &[(SemanticChangeId, Vec<EntityDelta>, Vec<RelationDelta>)],
     ) -> Result<Self> {
-        let snapshot = LosslessGitRepository {
-            repository_id: self.repository_id.clone(),
-            object_format: self.object_format,
-            objects: self.external_objects.clone(),
-            refs: self.refs.clone(),
-            head: self.head.clone(),
-        };
-        let exact = build_semantic_git_import_plan(&snapshot, blob_store)?;
-        if exact != self {
-            return Err(GitError::InvalidSnapshot(
-                "historical semantics may only be bound to the exact unenriched import plan"
-                    .to_string(),
-            ));
+        for change in &self.changes {
+            if !change.entity_deltas.is_empty()
+                || !change.relation_deltas.is_empty()
+                || validate_semantic_change_id(change).is_err()
+            {
+                return Err(GitError::InvalidSnapshot(
+                    "historical semantics may only be bound to the exact unenriched import plan"
+                        .to_string(),
+                ));
+            }
         }
         apply_historical_semantic_deltas_unchecked(self, deltas)
     }

--- a/crates/kin-index/src/history.rs
+++ b/crates/kin-index/src/history.rs
@@ -8,21 +8,26 @@
 //! CAS bodies. Every other artifact remains represented by the exact tree even
 //! when it has no language adapter.
 
-use std::collections::{BTreeMap, HashSet};
+use std::collections::{BTreeMap, BTreeSet, HashMap, HashSet};
 use std::path::Path;
+use std::sync::Arc;
 
 use kin_blobs::BlobStore;
 use kin_model::{
     ArtifactId, ChangeOrigin, Entity, EntityDelta, EntityId, FilePathId, ParseCompleteness,
     Relation, RelationDelta, RelationId, ResolvedTree, SemanticChange, SemanticChangeId, TreeEntry,
 };
+use kin_parser::is_call_extraction_incomplete_marker;
 use sha2::{Digest, Sha256};
 
 use crate::classifier::{FileClassification, FileClassifier};
 use crate::error::{IndexError, Result};
 use crate::linker::{
-    is_external_import_placeholder, link_cross_file_with_completeness, ArtifactIdentityMap,
-    FileParseCompletenessMap, FileParseData,
+    bare_entity_name, build_link_context_from_refs, is_class_like, is_external_import_placeholder,
+    known_file_paths, link_cross_file_with_completeness, make_artifact_import_relation,
+    make_parse_coverage_relation, resolve_include_targets, resolve_module_path, resolve_one_file,
+    split_owner_method, split_scoped_receiver_method, ArtifactIdentityMap,
+    FileParseCompletenessMap, FileParseData, LinkContext,
 };
 use crate::pipeline::IndexPipeline;
 
@@ -56,22 +61,44 @@ struct ParsedFile {
     imports: Vec<kin_parser::FileImport>,
 }
 
-#[derive(Clone)]
+/// One semantic file at one exact content identity.
+///
+/// The parse payload is shared by `Arc` so that carrying an unchanged file
+/// from a parent tree to a child tree is a pointer clone, never a deep copy of
+/// its entities, relations, and imports.
 struct SemanticFileState {
     artifact_id: ArtifactId,
-    path: String,
     entry: TreeEntry,
     completeness: ParseCompleteness,
-    entities: Vec<Entity>,
-    relations: Vec<kin_parser::ExtractedRelation>,
-    imports: Vec<kin_parser::FileImport>,
+    parse: Arc<FileParseData>,
+}
+
+impl SemanticFileState {
+    fn path(&self) -> &str {
+        &self.parse.file_path
+    }
+}
+
+/// The cross-file link output of one file under one tree's link context.
+///
+/// `relations` is the complete per-file share of the tree's linked relation
+/// set: resolved entity relations, artifact-level import/include edges, and
+/// the file's parse-coverage certificate, already validated against the
+/// tree's entity set. `referenced_entities` and `dropped_placeholder_dsts`
+/// back the fail-closed audit that proves a carried-forward output could not
+/// have changed.
+struct LinkedFile {
+    relations: Vec<Relation>,
+    referenced_entities: BTreeSet<EntityId>,
+    dropped_placeholder_dsts: BTreeSet<EntityId>,
 }
 
 #[derive(Clone, Default)]
 struct SemanticTreeState {
-    files: BTreeMap<ArtifactId, SemanticFileState>,
-    entities: BTreeMap<EntityId, Entity>,
-    relations: BTreeMap<RelationId, Relation>,
+    files: BTreeMap<ArtifactId, Arc<SemanticFileState>>,
+    linked: BTreeMap<ArtifactId, Arc<LinkedFile>>,
+    entities: BTreeMap<EntityId, Arc<Entity>>,
+    relations: BTreeMap<RelationId, Arc<Relation>>,
 }
 
 /// Derive semantic deltas for parent-first exact history.
@@ -83,6 +110,29 @@ pub fn derive_historical_semantic_deltas(
     changes: &[SemanticChange],
     trees: &BTreeMap<SemanticChangeId, ResolvedTree>,
     blob_store: &BlobStore,
+) -> Result<Vec<HistoricalSemanticDelta>> {
+    derive_historical_semantic_deltas_inner(changes, trees, blob_store, LinkEngine::new())
+}
+
+/// Derivation with the batch cross-check forced on for every commit,
+/// regardless of `KIN_HISTORY_LINK_VERIFY`. Test-only: fixtures use the batch
+/// path itself as the oracle for the incremental path.
+#[cfg(test)]
+fn derive_historical_semantic_deltas_verified(
+    changes: &[SemanticChange],
+    trees: &BTreeMap<SemanticChangeId, ResolvedTree>,
+    blob_store: &BlobStore,
+) -> Result<Vec<HistoricalSemanticDelta>> {
+    let mut engine = LinkEngine::new();
+    engine.verify = true;
+    derive_historical_semantic_deltas_inner(changes, trees, blob_store, engine)
+}
+
+fn derive_historical_semantic_deltas_inner(
+    changes: &[SemanticChange],
+    trees: &BTreeMap<SemanticChangeId, ResolvedTree>,
+    blob_store: &BlobStore,
+    mut engine: LinkEngine,
 ) -> Result<Vec<HistoricalSemanticDelta>> {
     let pipeline = IndexPipeline::new();
     let mut states = BTreeMap::<SemanticChangeId, SemanticTreeState>::new();
@@ -134,17 +184,14 @@ pub fn derive_historical_semantic_deltas(
                 })
             })
             .collect::<Result<Vec<_>>>()?;
-        let empty_parent = SemanticTreeState::default();
-        let first_parent = parent_states.first().copied().unwrap_or(&empty_parent);
         let tree = trees.get(&change.id).ok_or_else(|| {
             invalid(format!(
                 "change {} has no exact resolved tree for semantic enrichment",
                 change.id
             ))
         })?;
-        let current = semantic_state_for_tree(tree, &parent_states, blob_store, &pipeline)?;
-        let entity_deltas = diff_entities(&first_parent.entities, &current.entities);
-        let relation_deltas = diff_relations(&first_parent.relations, &current.relations);
+        let (current, entity_deltas, relation_deltas) =
+            semantic_state_for_tree(tree, &parent_states, blob_store, &pipeline, &mut engine)?;
 
         output.push(HistoricalSemanticDelta {
             change_id: change.id,
@@ -188,7 +235,10 @@ fn semantic_state_for_tree(
     parents: &[&SemanticTreeState],
     blob_store: &BlobStore,
     pipeline: &IndexPipeline,
-) -> Result<SemanticTreeState> {
+    engine: &mut LinkEngine,
+) -> Result<(SemanticTreeState, Vec<EntityDelta>, Vec<RelationDelta>)> {
+    let empty_parent = SemanticTreeState::default();
+    let first_parent = parents.first().copied().unwrap_or(&empty_parent);
     let mut files = BTreeMap::new();
 
     for artifact in tree.artifacts() {
@@ -209,10 +259,10 @@ fn semantic_state_for_tree(
             parent
                 .files
                 .get(&artifact.artifact_id)
-                .filter(|file| file.path == path && file.entry == artifact.entry)
+                .filter(|file| file.path() == path && file.entry == artifact.entry)
         }) {
             if files
-                .insert(artifact.artifact_id, existing.clone())
+                .insert(artifact.artifact_id, Arc::clone(existing))
                 .is_some()
             {
                 return Err(invalid(format!(
@@ -248,20 +298,25 @@ fn semantic_state_for_tree(
         let old_entities = parents
             .iter()
             .filter_map(|parent| parent.files.get(&artifact.artifact_id))
-            .flat_map(|file| file.entities.iter())
+            .flat_map(|file| file.parse.entities.iter())
             .collect::<Vec<_>>();
         let entities =
             stabilize_historical_entities(artifact.artifact_id, old_entities, &parsed.entities);
         let state = SemanticFileState {
             artifact_id: artifact.artifact_id,
-            path: path.to_string(),
             entry: artifact.entry,
             completeness: parsed.completeness,
-            entities,
-            relations: parsed.relations,
-            imports: parsed.imports,
+            parse: Arc::new(FileParseData {
+                file_path: path.to_string(),
+                entities,
+                relations: parsed.relations,
+                imports: parsed.imports,
+            }),
         };
-        if files.insert(artifact.artifact_id, state).is_some() {
+        if files
+            .insert(artifact.artifact_id, Arc::new(state))
+            .is_some()
+        {
             return Err(invalid(format!(
                 "tree assigns artifact {:?} to multiple semantic files",
                 artifact.artifact_id
@@ -269,23 +324,205 @@ fn semantic_state_for_tree(
         }
     }
 
-    let mut parse_data = Vec::with_capacity(files.len());
+    let (state, entity_deltas, relation_deltas) =
+        derive_tree_semantics(files, first_parent, engine)?;
+
+    if engine.verify {
+        verify_against_reference(&state, first_parent, &entity_deltas, &relation_deltas)?;
+    }
+    Ok((state, entity_deltas, relation_deltas))
+}
+
+/// Recompute this tree's complete semantic state through the single-pass batch
+/// path and require the incremental result to be identical, including the
+/// emitted first-parent deltas. This is the `KIN_HISTORY_LINK_VERIFY` audit:
+/// it proves on real histories that incremental replay authors byte-identical
+/// truth, at full batch cost.
+fn verify_against_reference(
+    current: &SemanticTreeState,
+    first_parent: &SemanticTreeState,
+    entity_deltas: &[EntityDelta],
+    relation_deltas: &[RelationDelta],
+) -> Result<()> {
+    let mut parse_data = Vec::with_capacity(current.files.len());
     let mut completeness = FileParseCompletenessMap::new();
     let mut artifact_ids = ArtifactIdentityMap::new();
     let mut entities = BTreeMap::new();
+    for file in current.files.values() {
+        artifact_ids.insert(file.path().to_string(), file.artifact_id);
+        completeness.insert(file.path().to_string(), file.completeness.clone());
+        for entity in &file.parse.entities {
+            if entities.insert(entity.id, entity.clone()).is_some() {
+                return Err(invalid(
+                    "verification found a duplicated entity identity the incremental path admitted",
+                ));
+            }
+        }
+        parse_data.push((*file.parse).clone());
+    }
+    parse_data.sort_by(|left, right| left.file_path.cmp(&right.file_path));
+    let linked = link_cross_file_with_completeness(&parse_data, &artifact_ids, &completeness)?;
+    let mut relations = BTreeMap::new();
+    for relation in linked {
+        if let Some(absent) = absent_local_endpoint(&relation, &entities) {
+            if absent.is_destination && is_external_import_placeholder(&relation) {
+                continue;
+            }
+            return Err(invalid(format!(
+                "verification relation {} names absent entity {}",
+                relation.id, absent.entity_id
+            )));
+        }
+        if relations.insert(relation.id, relation).is_some() {
+            return Err(invalid(
+                "verification found a duplicate relation identity the incremental path admitted",
+            ));
+        }
+    }
+
+    let entities_match = entities.len() == current.entities.len()
+        && entities.iter().all(|(id, entity)| {
+            current
+                .entities
+                .get(id)
+                .is_some_and(|held| **held == *entity)
+        });
+    if !entities_match {
+        return Err(invalid(
+            "incremental enrichment diverged from the batch derivation in the tree entity set",
+        ));
+    }
+    let relations_match = relations.len() == current.relations.len()
+        && relations.iter().all(|(id, relation)| {
+            current
+                .relations
+                .get(id)
+                .is_some_and(|held| **held == *relation)
+        });
+    if !relations_match {
+        return Err(invalid(
+            "incremental enrichment diverged from the batch derivation in the tree relation set",
+        ));
+    }
+
+    let parent_entities: BTreeMap<EntityId, Entity> = first_parent
+        .entities
+        .iter()
+        .map(|(id, entity)| (*id, (**entity).clone()))
+        .collect();
+    let parent_relations: BTreeMap<RelationId, Relation> = first_parent
+        .relations
+        .iter()
+        .map(|(id, relation)| (*id, (**relation).clone()))
+        .collect();
+    if diff_entities(&parent_entities, &entities).as_slice() != entity_deltas
+        || diff_relations(&parent_relations, &relations).as_slice() != relation_deltas
+    {
+        return Err(invalid(
+            "incremental enrichment diverged from the batch derivation in the emitted deltas",
+        ));
+    }
+    Ok(())
+}
+
+/// Derive one tree's semantic state and its first-parent deltas, reusing every
+/// carried-forward per-file link output the invalidation analysis proves
+/// unchanged.
+fn derive_tree_semantics(
+    files: BTreeMap<ArtifactId, Arc<SemanticFileState>>,
+    first_parent: &SemanticTreeState,
+    engine: &mut LinkEngine,
+) -> Result<(SemanticTreeState, Vec<EntityDelta>, Vec<RelationDelta>)> {
+    // Any change to the artifact/path membership of the tree can change module
+    // resolution, import targets, and default-export anchoring anywhere in the
+    // repository, so those commits relink the whole tree. Content-only commits
+    // take the incremental path below.
+    let structural = files.len() != first_parent.files.len()
+        || files.iter().zip(first_parent.files.iter()).any(
+            |((current_id, current), (parent_id, parent))| {
+                current_id != parent_id || current.path() != parent.path()
+            },
+        );
+
+    // Duplicate-path refusal, artifact identities, and parse completeness are
+    // per-tree inputs to linking and validation.
+    let mut completeness = FileParseCompletenessMap::new();
+    let mut artifact_ids = ArtifactIdentityMap::new();
     for file in files.values() {
         if artifact_ids
-            .insert(file.path.clone(), file.artifact_id)
+            .insert(file.path().to_string(), file.artifact_id)
             .is_some()
         {
             return Err(invalid(format!(
                 "tree contains more than one semantic artifact at {}",
-                file.path
+                file.path()
             )));
         }
-        completeness.insert(file.path.clone(), file.completeness.clone());
-        for entity in &file.entities {
-            if let Some(previous) = entities.insert(entity.id, entity.clone()) {
+        completeness.insert(file.path().to_string(), file.completeness.clone());
+    }
+
+    let file_refs: Vec<&FileParseData> = files.values().map(|file| file.parse.as_ref()).collect();
+    let universe_refs: Vec<&Entity> = file_refs
+        .iter()
+        .flat_map(|file| file.entities.iter())
+        .collect();
+    let known_files = known_file_paths(&file_refs, &universe_refs);
+    let era_signature = era_signature_of(&files);
+    engine.refresh_analyses(&files, era_signature, &known_files);
+
+    // Assemble the include graph from the per-file resolved include targets.
+    // `resolve_include_targets` is the same function batch include-graph
+    // construction folds per file, and paths are unique per tree, so this is
+    // the identical graph without re-resolving unchanged files' imports.
+    let mut include_graph: HashMap<String, Vec<String>> = HashMap::new();
+    for (artifact_id, file) in &files {
+        let targets = &engine.analysis(artifact_id).era.include_targets;
+        if !targets.is_empty() {
+            include_graph.insert(file.path().to_string(), targets.clone());
+        }
+    }
+    let ctx = build_link_context_from_refs(&file_refs, &universe_refs, include_graph);
+
+    // The set of files whose link output must be recomputed under this tree.
+    let relink: Vec<ArtifactId> = if structural {
+        files.keys().copied().collect()
+    } else {
+        invalidated_files(engine, &files, first_parent, &known_files)?
+    };
+
+    // Entity map: carry the first parent's map and apply the changed files'
+    // entity deltas, preserving the whole-tree duplicate-identity refusal.
+    let mut entities = first_parent.entities.clone();
+    let mut removed_entities = BTreeMap::<EntityId, Arc<Entity>>::new();
+    let mut inserted_entities = BTreeMap::<EntityId, Arc<Entity>>::new();
+    for (artifact_id, parent_file) in &first_parent.files {
+        let changed = match files.get(artifact_id) {
+            Some(current) => !Arc::ptr_eq(current, parent_file),
+            None => true,
+        };
+        if changed {
+            for entity in &parent_file.parse.entities {
+                let Some(previous) = entities.remove(&entity.id) else {
+                    return Err(invalid(format!(
+                        "parent tree state lost entity {} during incremental carry-forward",
+                        entity.id
+                    )));
+                };
+                removed_entities.insert(entity.id, previous);
+            }
+        }
+    }
+    for (artifact_id, file) in &files {
+        let changed = match first_parent.files.get(artifact_id) {
+            Some(parent_file) => !Arc::ptr_eq(file, parent_file),
+            None => true,
+        };
+        if !changed {
+            continue;
+        }
+        let arcs = &engine.analysis(artifact_id).entity_arcs;
+        for entity in arcs {
+            if let Some(previous) = entities.insert(entity.id, Arc::clone(entity)) {
                 return Err(invalid(format!(
                     "semantic entity identity {} is duplicated in one tree: {} {:?} from {:?} and {} {:?} from {}",
                     entity.id,
@@ -294,23 +531,157 @@ fn semantic_state_for_tree(
                     previous.file_origin,
                     entity.name,
                     entity.kind,
-                    file.path
+                    file.path()
                 )));
             }
+            inserted_entities.insert(entity.id, Arc::clone(entity));
         }
-        parse_data.push(FileParseData {
-            file_path: file.path.clone(),
-            entities: file.entities.clone(),
-            relations: file.relations.clone(),
-            imports: file.imports.clone(),
-        });
     }
-    parse_data.sort_by(|left, right| left.file_path.cmp(&right.file_path));
 
-    let linked = link_cross_file_with_completeness(&parse_data, &artifact_ids, &completeness)?;
-    let mut relations = BTreeMap::new();
-    for relation in linked {
-        if let Some(absent) = absent_local_endpoint(&relation, &entities) {
+    // Link the invalidated files under the exact context of this tree.
+    let mut linked = BTreeMap::new();
+    let mut removed_relations = BTreeMap::<RelationId, Arc<Relation>>::new();
+    let mut inserted_relations = BTreeMap::<RelationId, Arc<Relation>>::new();
+    let mut relations = if structural {
+        // Every file relinks, so every parent relation leaves the map and
+        // every current relation re-enters it; the patch diff then compares
+        // per identity exactly as a full first-parent diff would.
+        removed_relations = first_parent.relations.clone();
+        BTreeMap::new()
+    } else {
+        first_parent.relations.clone()
+    };
+    if !structural {
+        // Remove every relinked or removed file's previous share first, so a
+        // relation that survives a relink re-inserts cleanly.
+        let mut drop_share = |artifact_id: &ArtifactId| -> Result<()> {
+            if let Some(previous) = first_parent.linked.get(artifact_id) {
+                for relation in &previous.relations {
+                    let Some(removed) = relations.remove(&relation.id) else {
+                        return Err(invalid(format!(
+                            "parent tree state lost relation {} during incremental carry-forward",
+                            relation.id
+                        )));
+                    };
+                    removed_relations.insert(relation.id, removed);
+                }
+            }
+            Ok(())
+        };
+        for artifact_id in &relink {
+            drop_share(artifact_id)?;
+        }
+        for artifact_id in first_parent.files.keys() {
+            if !files.contains_key(artifact_id) {
+                drop_share(artifact_id)?;
+            }
+        }
+    }
+    for artifact_id in &relink {
+        let file = files
+            .get(artifact_id)
+            .ok_or_else(|| invalid("relink set names an artifact absent from the tree"))?;
+        let linked_file = link_single_file(
+            file,
+            &ctx,
+            &known_files,
+            &artifact_ids,
+            &completeness,
+            &entities,
+        )?;
+        for relation in &linked_file.relations {
+            let value = Arc::new(relation.clone());
+            if relations.insert(relation.id, Arc::clone(&value)).is_some() {
+                return Err(invalid(
+                    "cross-file linker returned a duplicate relation identity",
+                ));
+            }
+            inserted_relations.insert(relation.id, value);
+        }
+        linked.insert(*artifact_id, Arc::new(linked_file));
+    }
+    for (artifact_id, file) in &files {
+        if linked.contains_key(artifact_id) {
+            continue;
+        }
+        let carried = first_parent.linked.get(artifact_id).ok_or_else(|| {
+            invalid(format!(
+                "carried-forward file {} has no parent link output",
+                file.path()
+            ))
+        })?;
+        linked.insert(*artifact_id, Arc::clone(carried));
+    }
+
+    if !structural {
+        audit_carried_link_outputs(
+            &files,
+            &linked,
+            &relink,
+            &removed_entities,
+            &inserted_entities,
+        )?;
+    }
+
+    let entity_deltas = deltas_from_entity_patch(&removed_entities, &inserted_entities);
+    let relation_deltas = deltas_from_relation_patch(&removed_relations, &inserted_relations);
+
+    Ok((
+        SemanticTreeState {
+            files,
+            linked,
+            entities,
+            relations,
+        },
+        entity_deltas,
+        relation_deltas,
+    ))
+}
+
+/// Resolve, decorate, and validate one file's complete share of the tree's
+/// linked relation set: its resolved entity relations, its artifact-level
+/// import/include edges, and its parse-coverage certificate.
+///
+/// This is exactly the per-file share the batch entry point produces: per-file
+/// resolution is pure, artifact edges depend only on this file's imports and
+/// the tree's path set, and cross-file merge deduplication can never fire
+/// because every relation's source node is owned by its emitting file.
+fn link_single_file(
+    file: &SemanticFileState,
+    ctx: &LinkContext<'_>,
+    known_files: &HashSet<&str>,
+    artifact_ids: &ArtifactIdentityMap,
+    completeness: &FileParseCompletenessMap,
+    entities: &BTreeMap<EntityId, Arc<Entity>>,
+) -> Result<LinkedFile> {
+    let mut produced = resolve_one_file(&file.parse, ctx, Some(completeness));
+    let mut seen_artifact = HashSet::new();
+    for import in &file.parse.imports {
+        if let Some(relation) =
+            make_artifact_import_relation(file.path(), import, known_files, artifact_ids)
+        {
+            if seen_artifact.insert((relation.src, relation.dst, relation.kind)) {
+                produced.push(relation);
+            }
+        }
+    }
+    let call_extraction_complete = !file
+        .parse
+        .relations
+        .iter()
+        .any(is_call_extraction_incomplete_marker);
+    produced.push(make_parse_coverage_relation(
+        file.path(),
+        file.artifact_id,
+        completeness.get(file.path()),
+        call_extraction_complete,
+    ));
+
+    let mut relations = Vec::with_capacity(produced.len());
+    let mut referenced_entities = BTreeSet::new();
+    let mut dropped_placeholder_dsts = BTreeSet::new();
+    for relation in produced {
+        if let Some(absent) = absent_local_endpoint(&relation, entities) {
             // A change carries the entity set of its own tree, so replaying it
             // can only bind an edge whose endpoints that tree defines. The
             // linker's cross-repo placeholder destination is absent by
@@ -318,6 +689,7 @@ fn semantic_state_for_tree(
             // history; every other absent endpoint is inconsistent state and
             // fails closed here instead of being admitted.
             if absent.is_destination && is_external_import_placeholder(&relation) {
+                dropped_placeholder_dsts.insert(absent.entity_id);
                 continue;
             }
             return Err(invalid(format!(
@@ -331,18 +703,537 @@ fn semantic_state_for_tree(
                 absent.entity_id
             )));
         }
-        if relations.insert(relation.id, relation).is_some() {
-            return Err(invalid(
-                "cross-file linker returned a duplicate relation identity",
-            ));
+        for node in [relation.src, relation.dst] {
+            if let Some(entity_id) = node.as_entity() {
+                referenced_entities.insert(entity_id);
+            }
+        }
+        relations.push(relation);
+    }
+    Ok(LinkedFile {
+        relations,
+        referenced_entities,
+        dropped_placeholder_dsts,
+    })
+}
+
+/// Fail-closed audit that a carried-forward link output could not have
+/// changed: it must not reference any entity this commit removed, and no
+/// placeholder destination it dropped may have become a real entity. Either
+/// condition would mean the invalidation analysis was not conservative, so
+/// enrichment refuses loudly instead of admitting silently wrong history.
+fn audit_carried_link_outputs(
+    files: &BTreeMap<ArtifactId, Arc<SemanticFileState>>,
+    linked: &BTreeMap<ArtifactId, Arc<LinkedFile>>,
+    relink: &[ArtifactId],
+    removed_entities: &BTreeMap<EntityId, Arc<Entity>>,
+    inserted_entities: &BTreeMap<EntityId, Arc<Entity>>,
+) -> Result<()> {
+    let net_removed: Vec<&EntityId> = removed_entities
+        .keys()
+        .filter(|id| !inserted_entities.contains_key(id))
+        .collect();
+    let net_added: Vec<&EntityId> = inserted_entities
+        .keys()
+        .filter(|id| !removed_entities.contains_key(id))
+        .collect();
+    if net_removed.is_empty() && net_added.is_empty() {
+        return Ok(());
+    }
+    let relinked: HashSet<&ArtifactId> = relink.iter().collect();
+    for (artifact_id, output) in linked {
+        if relinked.contains(artifact_id) {
+            continue;
+        }
+        for removed in &net_removed {
+            if output.referenced_entities.contains(removed) {
+                return Err(invalid(format!(
+                    "carried-forward link output for {} references removed entity {}; \
+                     relink invalidation was not conservative",
+                    files
+                        .get(artifact_id)
+                        .map(|file| file.path())
+                        .unwrap_or("<unknown>"),
+                    removed
+                )));
+            }
+        }
+        for added in &net_added {
+            if output.dropped_placeholder_dsts.contains(added) {
+                return Err(invalid(format!(
+                    "carried-forward link output for {} dropped a placeholder that now \
+                     names real entity {}; relink invalidation was not conservative",
+                    files
+                        .get(artifact_id)
+                        .map(|file| file.path())
+                        .unwrap_or("<unknown>"),
+                    added
+                )));
+            }
+        }
+    }
+    Ok(())
+}
+
+/// First-parent entity deltas from the incremental patch, identical to a full
+/// map diff: an identity untouched by the patch carries the same shared value
+/// on both sides, and a patched identity compares old against new exactly as
+/// the full diff would.
+fn deltas_from_entity_patch(
+    removed: &BTreeMap<EntityId, Arc<Entity>>,
+    inserted: &BTreeMap<EntityId, Arc<Entity>>,
+) -> Vec<EntityDelta> {
+    let mut deltas = Vec::new();
+    for (id, old) in removed {
+        match inserted.get(id) {
+            Some(new) if **old == **new => {}
+            Some(new) => deltas.push(EntityDelta::Modified {
+                old: (**old).clone(),
+                new: (**new).clone(),
+            }),
+            None => deltas.push(EntityDelta::Removed {
+                old: (**old).clone(),
+            }),
+        }
+    }
+    for (id, new) in inserted {
+        if !removed.contains_key(id) {
+            deltas.push(EntityDelta::Added {
+                new: (**new).clone(),
+            });
+        }
+    }
+    deltas.sort_by_key(EntityDelta::target_id);
+    deltas
+}
+
+fn deltas_from_relation_patch(
+    removed: &BTreeMap<RelationId, Arc<Relation>>,
+    inserted: &BTreeMap<RelationId, Arc<Relation>>,
+) -> Vec<RelationDelta> {
+    let mut deltas = Vec::new();
+    for (id, old) in removed {
+        match inserted.get(id) {
+            Some(new) if **old == **new => {}
+            Some(new) => deltas.push(RelationDelta::Modified {
+                old: (**old).clone(),
+                new: (**new).clone(),
+            }),
+            None => deltas.push(RelationDelta::Removed {
+                old: (**old).clone(),
+            }),
+        }
+    }
+    for (id, new) in inserted {
+        if !removed.contains_key(id) {
+            deltas.push(RelationDelta::Added {
+                new: (**new).clone(),
+            });
+        }
+    }
+    deltas.sort_by_key(RelationDelta::target_id);
+    deltas
+}
+
+/// Persistent cross-commit linking state.
+///
+/// Nothing in here is semantic truth: it is memoized analysis of file versions
+/// (probe tokens, resolved module and include targets, hierarchy projections)
+/// used to prove which files a commit's delta cannot have affected. Every
+/// entry is keyed to the exact parse payload (by pointer identity) and the
+/// exact path-set era it was computed under, and is recomputed whenever
+/// either changes.
+struct LinkEngine {
+    verify: bool,
+    analyses: HashMap<ArtifactId, AnalysisSlot>,
+}
+
+struct AnalysisSlot {
+    parse_ptr: usize,
+    entity_arcs: Vec<Arc<Entity>>,
+    stat: Arc<FileStaticAnalysis>,
+    era_signature: u64,
+    era: Arc<FileEraAnalysis>,
+}
+
+/// Analysis of one file version that depends only on its own parse payload.
+struct FileStaticAnalysis {
+    /// Every name-shaped key this file's resolution can probe in the global
+    /// entity indices: relation destinations plus their bare leaves, `::` and
+    /// `.` segments, and adjacent type-qualified suffix pairs.
+    tokens: BTreeSet<String>,
+    /// Full and bare names this file contributes to the global entity indices.
+    contributed_names: BTreeSet<String>,
+    /// Class hierarchy shape other files' inheritance walks can traverse
+    /// through this file.
+    hierarchy: FileHierarchyProjection,
+    /// Bare leaves of this file's declared Extends bases.
+    base_leaves: BTreeSet<String>,
+    /// Whether any call in this file can enter an inheritance walk at all.
+    walk_capable: bool,
+}
+
+#[derive(PartialEq, Eq)]
+struct FileHierarchyProjection {
+    /// Sorted (class, base) pairs from parser-emitted Extends relations.
+    extends: Vec<(String, String)>,
+    /// Sorted class-like entity (name, kind) pairs: the anchors and waypoints
+    /// an inheritance walk can locate in this file.
+    class_like: Vec<(String, String)>,
+    /// Sorted import specifiers, tracked only when the file declares Extends
+    /// bases: a mid-walk `locate_base_class` resolves that file's bases
+    /// through its own imports.
+    imports: Vec<(String, String, String)>,
+}
+
+/// Analysis of one file version that also depends on the tree's path set.
+struct FileEraAnalysis {
+    /// Files this file's imports and parser-pinned import sources resolve to.
+    module_targets: BTreeSet<String>,
+    /// Include-like resolved targets, exactly as batch include-graph
+    /// construction records them.
+    include_targets: Vec<String>,
+}
+
+impl LinkEngine {
+    fn new() -> Self {
+        let verify = std::env::var("KIN_HISTORY_LINK_VERIFY")
+            .map(|value| matches!(value.trim(), "1" | "true" | "yes" | "on"))
+            .unwrap_or(false);
+        Self {
+            verify,
+            analyses: HashMap::new(),
         }
     }
 
-    Ok(SemanticTreeState {
-        files,
-        entities,
-        relations,
-    })
+    fn analysis(&self, artifact_id: &ArtifactId) -> &AnalysisSlot {
+        self.analyses
+            .get(artifact_id)
+            .expect("analysis slots are refreshed for every file in the tree before use")
+    }
+
+    fn refresh_analyses(
+        &mut self,
+        files: &BTreeMap<ArtifactId, Arc<SemanticFileState>>,
+        era_signature: u64,
+        known_files: &HashSet<&str>,
+    ) {
+        for (artifact_id, file) in files {
+            let parse_ptr = Arc::as_ptr(&file.parse) as usize;
+            let stale = match self.analyses.get(artifact_id) {
+                Some(slot) => slot.parse_ptr != parse_ptr,
+                None => true,
+            };
+            if stale {
+                let stat = Arc::new(analyze_file_static(&file.parse));
+                let era = Arc::new(analyze_file_era(&file.parse, known_files));
+                let entity_arcs = file
+                    .parse
+                    .entities
+                    .iter()
+                    .map(|entity| Arc::new(entity.clone()))
+                    .collect();
+                self.analyses.insert(
+                    *artifact_id,
+                    AnalysisSlot {
+                        parse_ptr,
+                        entity_arcs,
+                        stat,
+                        era_signature,
+                        era,
+                    },
+                );
+                continue;
+            }
+            let slot = self
+                .analyses
+                .get_mut(artifact_id)
+                .expect("slot presence checked above");
+            if slot.era_signature != era_signature {
+                slot.era = Arc::new(analyze_file_era(&file.parse, known_files));
+                slot.era_signature = era_signature;
+            }
+        }
+    }
+}
+
+/// The conservative set of files whose link output must be recomputed for
+/// a content-only commit. Everything a file's resolution can observe from
+/// the rest of the tree is covered by one of the four rules below; the
+/// per-rule reasoning lives with each block.
+fn invalidated_files(
+    engine: &LinkEngine,
+    files: &BTreeMap<ArtifactId, Arc<SemanticFileState>>,
+    first_parent: &SemanticTreeState,
+    known_files: &HashSet<&str>,
+) -> Result<Vec<ArtifactId>> {
+    let mut relink = BTreeSet::new();
+    let mut changed = Vec::new();
+    for (artifact_id, file) in files {
+        let Some(parent_file) = first_parent.files.get(artifact_id) else {
+            return Err(invalid(
+                "content-only commit gained an artifact; structural mode was required",
+            ));
+        };
+        if !Arc::ptr_eq(file, parent_file) {
+            changed.push((*artifact_id, Arc::clone(parent_file), Arc::clone(file)));
+            relink.insert(*artifact_id);
+        }
+    }
+
+    // Rule 1: names. A kept file's resolution reads the global indices only
+    // at keys derivable from its own parse payload; the indices change only
+    // at keys named by the changed files' old and new entity sets. Any
+    // intersection forces a relink.
+    let mut changed_names = BTreeSet::new();
+    // Rule 2: module targets. Import, pin, namespace-member, and
+    // default-export resolution reach other files through resolved module
+    // paths; path resolution is stable while the path set is stable, so a
+    // kept file is affected only when a changed file is one of its targets.
+    let mut changed_paths = BTreeSet::new();
+    // Rule 3: include topology. Macro reachability and include-closure
+    // disambiguation read the transitive include graph, so a changed
+    // include-target list invalidates every file that can reach the
+    // changed file through either the old or the new graph.
+    let mut include_seeds = BTreeSet::new();
+    // Rule 4: hierarchy. Inheritance walks discover class names mid-walk
+    // that no static token set can enumerate, so any change to a hierarchy
+    // projection, or to any entity sharing a name with a declared base,
+    // invalidates every file whose calls can enter a walk.
+    let mut hierarchy_fire = false;
+    let mut base_leaves: BTreeSet<String> = BTreeSet::new();
+    for slot in files.keys().map(|id| engine.analysis(id)) {
+        base_leaves.extend(slot.stat.base_leaves.iter().cloned());
+    }
+
+    for (artifact_id, old_file, new_file) in &changed {
+        let new_slot = engine.analysis(artifact_id);
+        let old_stat = analyze_file_static(&old_file.parse);
+        let old_era = analyze_file_era(&old_file.parse, known_files);
+        changed_names.extend(old_stat.contributed_names.iter().cloned());
+        changed_names.extend(new_slot.stat.contributed_names.iter().cloned());
+        changed_paths.insert(new_file.path().to_string());
+        if old_era.include_targets != new_slot.era.include_targets {
+            include_seeds.insert(new_file.path().to_string());
+        }
+        base_leaves.extend(old_stat.base_leaves.iter().cloned());
+        if old_stat.hierarchy != new_slot.stat.hierarchy {
+            hierarchy_fire = true;
+        }
+        if !hierarchy_fire {
+            for name in old_stat
+                .contributed_names
+                .iter()
+                .chain(new_slot.stat.contributed_names.iter())
+            {
+                if base_leaves.contains(name) {
+                    hierarchy_fire = true;
+                    break;
+                }
+            }
+        }
+    }
+
+    let include_invalidated = if include_seeds.is_empty() {
+        HashSet::new()
+    } else {
+        // Reverse reachability over the union of the old and new include
+        // graphs, unbounded by the forward walk's depth cap: a superset of
+        // every file whose bounded closure could contain a seed.
+        let mut reverse: HashMap<String, Vec<String>> = HashMap::new();
+        for (artifact_id, file) in files {
+            for target in &engine.analysis(artifact_id).era.include_targets {
+                reverse
+                    .entry(target.clone())
+                    .or_default()
+                    .push(file.path().to_string());
+            }
+        }
+        for (_, old_file, _) in &changed {
+            let old_era = analyze_file_era(&old_file.parse, known_files);
+            for target in &old_era.include_targets {
+                reverse
+                    .entry(target.clone())
+                    .or_default()
+                    .push(old_file.path().to_string());
+            }
+        }
+        let mut reached: HashSet<String> = HashSet::new();
+        let mut stack: Vec<String> = include_seeds.iter().cloned().collect();
+        while let Some(path) = stack.pop() {
+            if !reached.insert(path.clone()) {
+                continue;
+            }
+            if let Some(importers) = reverse.get(&path) {
+                stack.extend(importers.iter().cloned());
+            }
+        }
+        reached
+    };
+
+    for (artifact_id, file) in files {
+        if relink.contains(artifact_id) {
+            continue;
+        }
+        let slot = engine.analysis(artifact_id);
+        let token_hit = intersects(&slot.stat.tokens, &changed_names);
+        let module_hit = slot
+            .era
+            .module_targets
+            .iter()
+            .any(|target| changed_paths.contains(target));
+        let include_hit = include_invalidated.contains(file.path());
+        let hierarchy_hit = hierarchy_fire && slot.stat.walk_capable;
+        if token_hit || module_hit || include_hit || hierarchy_hit {
+            relink.insert(*artifact_id);
+        }
+    }
+    Ok(relink.into_iter().collect())
+}
+
+fn intersects(a: &BTreeSet<String>, b: &BTreeSet<String>) -> bool {
+    let (small, large) = if a.len() <= b.len() { (a, b) } else { (b, a) };
+    small.iter().any(|item| large.contains(item))
+}
+
+/// Insert every index key `name` can be probed under, on both the probing and
+/// the contributing side: the full name, its bare leaf, each `::` and `.`
+/// segment, and the type-qualified adjacent suffix pair.
+fn add_name_tokens(tokens: &mut BTreeSet<String>, name: &str) {
+    if name.is_empty() {
+        return;
+    }
+    tokens.insert(name.to_string());
+    tokens.insert(bare_entity_name(name).to_string());
+    let segments: Vec<&str> = name.split("::").collect();
+    if segments.len() >= 2 {
+        for segment in &segments {
+            tokens.insert((*segment).to_string());
+        }
+        tokens.insert(format!(
+            "{}::{}",
+            segments[segments.len() - 2],
+            segments[segments.len() - 1]
+        ));
+    }
+    if name.contains('.') {
+        for segment in name.split('.') {
+            tokens.insert(segment.to_string());
+        }
+    }
+}
+
+fn analyze_file_static(parse: &FileParseData) -> FileStaticAnalysis {
+    let mut tokens = BTreeSet::new();
+    let mut walk_capable = false;
+    for relation in &parse.relations {
+        if is_call_extraction_incomplete_marker(relation) {
+            continue;
+        }
+        add_name_tokens(&mut tokens, &relation.dst_name);
+        if relation.kind == kin_model::RelationKind::Calls
+            && (split_owner_method(&relation.dst_name).is_some()
+                || split_scoped_receiver_method(&relation.dst_name).is_some())
+        {
+            walk_capable = true;
+        }
+    }
+
+    let mut contributed_names = BTreeSet::new();
+    for entity in &parse.entities {
+        contributed_names.insert(entity.name.clone());
+        contributed_names.insert(bare_entity_name(&entity.name).to_string());
+    }
+
+    let mut extends = Vec::new();
+    let mut base_leaves = BTreeSet::new();
+    for relation in &parse.relations {
+        if relation.kind != kin_model::RelationKind::Extends {
+            continue;
+        }
+        let pair = (relation.src_name.clone(), relation.dst_name.clone());
+        if !extends.contains(&pair) {
+            extends.push(pair);
+        }
+        base_leaves.insert(bare_entity_name(&relation.dst_name).to_string());
+    }
+    extends.sort();
+    let mut class_like: Vec<(String, String)> = parse
+        .entities
+        .iter()
+        .filter(|entity| is_class_like(Some(&entity.kind)))
+        .map(|entity| (entity.name.clone(), format!("{:?}", entity.kind)))
+        .collect();
+    class_like.sort();
+    class_like.dedup();
+    let mut imports = Vec::new();
+    if !extends.is_empty() {
+        for import in &parse.imports {
+            for spec in &import.specifiers {
+                imports.push((
+                    import.module_path.clone(),
+                    spec.local_name.clone(),
+                    spec.original_name.clone().unwrap_or_default(),
+                ));
+            }
+        }
+        imports.sort();
+    }
+
+    FileStaticAnalysis {
+        tokens,
+        contributed_names,
+        hierarchy: FileHierarchyProjection {
+            extends,
+            class_like,
+            imports,
+        },
+        base_leaves,
+        walk_capable,
+    }
+}
+
+fn analyze_file_era(parse: &FileParseData, known_files: &HashSet<&str>) -> FileEraAnalysis {
+    let mut module_targets = BTreeSet::new();
+    for import in &parse.imports {
+        if let Some(target) =
+            resolve_module_path(&parse.file_path, &import.module_path, known_files)
+        {
+            module_targets.insert(target);
+        }
+    }
+    for relation in &parse.relations {
+        if let Some(source) = relation
+            .import_source
+            .as_deref()
+            .map(str::trim)
+            .filter(|source| !source.is_empty())
+        {
+            if let Some(target) = resolve_module_path(&parse.file_path, source, known_files) {
+                module_targets.insert(target);
+            }
+        }
+    }
+    let include_targets = resolve_include_targets(&parse.file_path, &parse.imports, known_files);
+    FileEraAnalysis {
+        module_targets,
+        include_targets,
+    }
+}
+
+/// Stable signature of the tree's path membership. Module and include-target
+/// resolution consult the known-file set, so their per-file caches are only
+/// valid while this signature holds.
+fn era_signature_of(files: &BTreeMap<ArtifactId, Arc<SemanticFileState>>) -> u64 {
+    use std::hash::{Hash, Hasher};
+    let mut paths: Vec<&str> = files.values().map(|file| file.path()).collect();
+    paths.sort_unstable();
+    let mut hasher = std::collections::hash_map::DefaultHasher::new();
+    for path in paths {
+        path.hash(&mut hasher);
+        0xffu8.hash(&mut hasher);
+    }
+    hasher.finish()
 }
 
 /// An entity endpoint of a linked relation that the tree does not define.
@@ -354,9 +1245,9 @@ struct AbsentEndpoint {
 /// Report the first entity endpoint of `relation` that `entities` does not
 /// define, source before destination. Non-entity endpoints are not part of the
 /// entity state a change replays, so they are never reported.
-fn absent_local_endpoint(
+fn absent_local_endpoint<V>(
     relation: &Relation,
-    entities: &BTreeMap<EntityId, Entity>,
+    entities: &BTreeMap<EntityId, V>,
 ) -> Option<AbsentEndpoint> {
     [(relation.src, false), (relation.dst, true)]
         .into_iter()
@@ -1014,6 +1905,216 @@ mod tests {
             error.to_string().contains("was not enriched first"),
             "{error}"
         );
+    }
+
+    /// Build a Git fixture from parent-first (path, body) steps, where each
+    /// step is one commit writing the given files, then enrich it with the
+    /// batch cross-check forced on for every commit. The batch derivation is
+    /// the oracle: any divergence in the incremental tree states or emitted
+    /// deltas fails the derivation itself.
+    fn enrich_verified(steps: &[&[(&str, &str)]]) -> Vec<HistoricalSemanticDelta> {
+        let root = tempdir().unwrap();
+        let repository = root.path().join("source");
+        fs::create_dir(&repository).unwrap();
+        git(&repository, &["init", "--initial-branch=main"]);
+        git(
+            &repository,
+            &["config", "user.email", "kin@example.invalid"],
+        );
+        git(&repository, &["config", "user.name", "Kin Test"]);
+        for (index, step) in steps.iter().enumerate() {
+            for (path, body) in *step {
+                write(&repository, path, body.as_bytes());
+            }
+            git(&repository, &["add", "--all"]);
+            git(&repository, &["commit", "-m", &format!("step {index}")]);
+        }
+        let blob_store = BlobStore::new(root.path().join("cas")).unwrap();
+        let snapshot = capture_lossless_git_repository(
+            &repository,
+            RepositoryId::new("history-incremental-equivalence").unwrap(),
+            &blob_store,
+        )
+        .unwrap();
+        let plan = plan_semantic_git_import(&snapshot, &blob_store).unwrap();
+        let trees = trees_by_change(&plan);
+        derive_historical_semantic_deltas_verified(&plan.changes, &trees, &blob_store).unwrap()
+    }
+
+    /// Content-only commits: bodies change, cross-file callers must relink
+    /// when their callee's name set changes, and untouched files carry
+    /// forward. Every commit is cross-checked against the batch derivation.
+    #[test]
+    fn incremental_replay_matches_batch_on_content_edits() {
+        let deltas = enrich_verified(&[
+            &[
+                ("src/a.rs", "pub fn alpha() -> u8 { 1 }\n"),
+                ("src/b.rs", "pub fn beta() -> u8 { crate::a::alpha() }\n"),
+                ("src/c.rs", "pub fn gamma() -> u8 { 3 }\n"),
+            ],
+            // Body-only edit: callers of alpha unaffected structurally.
+            &[("src/a.rs", "pub fn alpha() -> u8 { 2 }\n")],
+            // Rename alpha -> alpha_two: b's cross-file call must relink away.
+            &[("src/a.rs", "pub fn alpha_two() -> u8 { 2 }\n")],
+            // b now calls the new name; c stays untouched throughout.
+            &[(
+                "src/b.rs",
+                "pub fn beta() -> u8 { crate::a::alpha_two() }\n",
+            )],
+        ]);
+        assert_eq!(deltas.len(), 4);
+    }
+
+    /// A same-name definition appearing in another file changes ambiguity for
+    /// an untouched caller; removing it changes it back.
+    #[test]
+    fn incremental_replay_matches_batch_on_ambiguity_shifts() {
+        enrich_verified(&[
+            &[
+                ("src/caller.rs", "pub fn go() { helper(); }\n"),
+                ("src/one.rs", "pub fn helper() {}\n"),
+            ],
+            // A second helper appears: the untouched caller's candidate set
+            // widens and must relink.
+            &[("src/two.rs", "pub fn helper() {}\npub fn other() {}\n")],
+            // The second helper disappears again (content-only edit).
+            &[("src/two.rs", "pub fn other() {}\n")],
+        ]);
+    }
+
+    /// Structural commits: files added, removed, and renamed force whole-tree
+    /// relinks that must still match the batch derivation exactly.
+    #[test]
+    fn incremental_replay_matches_batch_on_structural_commits() {
+        enrich_verified(&[
+            &[("src/lib.rs", "pub fn one() {}\n")],
+            &[
+                ("src/lib.rs", "pub mod extra;\npub fn one() {}\n"),
+                ("src/extra.rs", "pub fn two() { crate::one() }\n"),
+            ],
+            // Content-only step between the structural ones.
+            &[("src/extra.rs", "pub fn two() { crate::one(); }\n")],
+            // Remove the module again.
+            &[("src/lib.rs", "pub fn one() {}\npub fn three() {}\n")],
+        ]);
+    }
+
+    /// Python inheritance: an edit to a base class's hierarchy must relink the
+    /// walk-capable caller even though the caller's own file never changed.
+    #[test]
+    fn incremental_replay_matches_batch_on_hierarchy_edits() {
+        enrich_verified(&[
+            &[
+                (
+                    "pkg/base.py",
+                    "class Base:\n    def greet(self):\n        return 1\n",
+                ),
+                (
+                    "pkg/mid.py",
+                    "from base import Base\n\nclass Mid(Base):\n    pass\n",
+                ),
+                (
+                    "pkg/use.py",
+                    "from mid import Mid\n\nclass App(Mid):\n    def run(self):\n        return App.greet(self)\n",
+                ),
+            ],
+            // Move greet out of Base: the walk from App must stop resolving.
+            &[(
+                "pkg/base.py",
+                "class Base:\n    def farewell(self):\n        return 2\n",
+            )],
+            // Reintroduce greet.
+            &[(
+                "pkg/base.py",
+                "class Base:\n    def greet(self):\n        return 3\n",
+            )],
+        ]);
+    }
+
+    /// Import rewiring: a caller's own import moves between modules, and a
+    /// target module's exports change underneath an untouched importer.
+    #[test]
+    fn incremental_replay_matches_batch_on_import_rewiring() {
+        enrich_verified(&[
+            &[
+                ("src/util.ts", "export function finalize() {}\n"),
+                ("src/alt.ts", "export function finalize() {}\n"),
+                (
+                    "src/app.ts",
+                    "import { finalize } from './util';\nexport function main() { finalize(); }\n",
+                ),
+            ],
+            // The untouched importer's target module changes its exports.
+            &[(
+                "src/util.ts",
+                "export function finalize() {}\nexport function extra() {}\n",
+            )],
+            // The importer itself rewires to the other module.
+            &[(
+                "src/app.ts",
+                "import { finalize } from './alt';\nexport function main() { finalize(); }\n",
+            )],
+        ]);
+    }
+
+    /// Merge shape: two branches, both sides carrying semantic files, with the
+    /// merge adopting each side's version. Parent-first replay must stay
+    /// batch-identical through the merge commit.
+    #[test]
+    fn incremental_replay_matches_batch_across_merges() {
+        let root = tempdir().unwrap();
+        let repository = root.path().join("source");
+        fs::create_dir(&repository).unwrap();
+        git(&repository, &["init", "--initial-branch=main"]);
+        git(
+            &repository,
+            &["config", "user.email", "kin@example.invalid"],
+        );
+        git(&repository, &["config", "user.name", "Kin Test"]);
+        write(&repository, "src/shared.rs", b"pub fn shared() {}\n");
+        write(&repository, "src/main_side.rs", b"pub fn main_side() {}\n");
+        git(&repository, &["add", "--all"]);
+        git(&repository, &["commit", "-m", "root"]);
+
+        git(&repository, &["checkout", "-b", "feature"]);
+        write(
+            &repository,
+            "src/feature.rs",
+            b"pub fn feature() { crate::shared() }\n",
+        );
+        git(&repository, &["add", "--all"]);
+        git(&repository, &["commit", "-m", "feature"]);
+
+        git(&repository, &["checkout", "main"]);
+        write(
+            &repository,
+            "src/main_side.rs",
+            b"pub fn main_side() { crate::shared() }\n",
+        );
+        git(&repository, &["add", "--all"]);
+        git(&repository, &["commit", "-m", "main work"]);
+        git(
+            &repository,
+            &["merge", "--no-ff", "feature", "-m", "merge feature"],
+        );
+        write(
+            &repository,
+            "src/shared.rs",
+            b"pub fn shared() -> u8 { 1 }\n",
+        );
+        git(&repository, &["add", "--all"]);
+        git(&repository, &["commit", "-m", "post-merge edit"]);
+
+        let blob_store = BlobStore::new(root.path().join("cas")).unwrap();
+        let snapshot = capture_lossless_git_repository(
+            &repository,
+            RepositoryId::new("history-incremental-merge").unwrap(),
+            &blob_store,
+        )
+        .unwrap();
+        let plan = plan_semantic_git_import(&snapshot, &blob_store).unwrap();
+        let trees = trees_by_change(&plan);
+        derive_historical_semantic_deltas_verified(&plan.changes, &trees, &blob_store).unwrap();
     }
 
     fn trees_by_change(

--- a/crates/kin-index/src/history.rs
+++ b/crates/kin-index/src/history.rs
@@ -433,6 +433,20 @@ fn derive_tree_semantics(
     first_parent: &SemanticTreeState,
     engine: &mut LinkEngine,
 ) -> Result<(SemanticTreeState, Vec<EntityDelta>, Vec<RelationDelta>)> {
+    // An exact first-parent tree carry is already fully linked. This covers
+    // empty Git commits and merge commits that select the first parent's tree;
+    // returning its immutable state avoids rebuilding every whole-tree index
+    // when no semantic input changed at all.
+    let exact_first_parent_carry = files.len() == first_parent.files.len()
+        && files.iter().zip(first_parent.files.iter()).all(
+            |((current_id, current), (parent_id, parent))| {
+                current_id == parent_id && Arc::ptr_eq(current, parent)
+            },
+        );
+    if exact_first_parent_carry {
+        return Ok((first_parent.clone(), Vec::new(), Vec::new()));
+    }
+
     // Any change to the artifact/path membership of the tree can change module
     // resolution, import targets, and default-export anchoring anywhere in the
     // repository, so those commits relink the whole tree. Content-only commits
@@ -467,8 +481,8 @@ fn derive_tree_semantics(
         .flat_map(|file| file.entities.iter())
         .collect();
     let known_files = known_file_paths(&file_refs, &universe_refs);
-    let era_signature = engine.advance_era(&files);
-    engine.refresh_analyses(&files, era_signature, &known_files);
+    let era_signature = advance_link_era(engine, &files);
+    refresh_link_analyses(engine, &files, era_signature, &known_files);
 
     // Assemble the include graph from the per-file resolved include targets.
     // `resolve_include_targets` is the same function batch include-graph
@@ -858,9 +872,9 @@ fn deltas_from_relation_patch(
 /// Nothing in here is semantic truth: it is memoized analysis of file versions
 /// (probe tokens, resolved module and include targets, hierarchy projections)
 /// used to prove which files a commit's delta cannot have affected. Every
-/// entry is keyed to the exact parse payload (by pointer identity) and the
-/// exact path-set era it was computed under, and is recomputed whenever
-/// either changes.
+/// entry retains and compares the exact parse allocation and the exact
+/// path-set era it was computed under, and is recomputed whenever either
+/// changes.
 struct LinkEngine {
     verify: bool,
     analyses: HashMap<ArtifactId, AnalysisSlot>,
@@ -873,7 +887,11 @@ struct LinkEngine {
 }
 
 struct AnalysisSlot {
-    parse_ptr: usize,
+    /// Retaining the exact parse allocation makes pointer identity safe: an
+    /// allocator cannot recycle its address while this slot exists. A raw
+    /// pointer value alone allowed a dropped leaf-head parse to alias a later
+    /// divergent head's distinct payload.
+    parse: Arc<FileParseData>,
     entity_arcs: Vec<Arc<Entity>>,
     stat: Arc<FileStaticAnalysis>,
     era_signature: u64,
@@ -922,7 +940,7 @@ struct FileEraAnalysis {
 impl LinkEngine {
     fn new() -> Self {
         let verify = std::env::var("KIN_HISTORY_LINK_VERIFY")
-            .map(|value| matches!(value.trim(), "1" | "true" | "yes" | "on"))
+            .map(|value| history_link_verify_enabled(&value))
             .unwrap_or(false);
         Self {
             verify,
@@ -937,62 +955,84 @@ impl LinkEngine {
             .get(artifact_id)
             .expect("analysis slots are refreshed for every file in the tree before use")
     }
+}
 
-    /// Advance to the era of `files`' exact sorted path membership. Module and
-    /// include-target resolution consult the known-file set, so per-file era
-    /// caches are only valid while this membership holds; the comparison is
-    /// over the paths themselves, never a digest of them.
-    fn advance_era(&mut self, files: &BTreeMap<ArtifactId, Arc<SemanticFileState>>) -> u64 {
-        let mut paths: Vec<String> = files.values().map(|file| file.path().to_string()).collect();
-        paths.sort_unstable();
-        if paths != self.era_paths {
-            self.era_counter += 1;
-            self.era_paths = paths;
-        }
-        self.era_counter
+fn history_link_verify_enabled(value: &str) -> bool {
+    let value = value.trim();
+    value == "1"
+        || value.eq_ignore_ascii_case("true")
+        || value.eq_ignore_ascii_case("yes")
+        || value.eq_ignore_ascii_case("on")
+}
+
+/// Advance to `files`' exact sorted path-membership era. Module and include
+/// target resolution consult the known-file set, so per-file era caches are
+/// valid only while this membership holds; compare paths themselves, never a
+/// digest that could collide.
+fn advance_link_era(
+    engine: &mut LinkEngine,
+    files: &BTreeMap<ArtifactId, Arc<SemanticFileState>>,
+) -> u64 {
+    let mut paths: Vec<String> = files.values().map(|file| file.path().to_string()).collect();
+    paths.sort_unstable();
+    if paths != engine.era_paths {
+        engine.era_counter += 1;
+        engine.era_paths = paths;
     }
+    engine.era_counter
+}
 
-    fn refresh_analyses(
-        &mut self,
-        files: &BTreeMap<ArtifactId, Arc<SemanticFileState>>,
-        era_signature: u64,
-        known_files: &HashSet<&str>,
-    ) {
-        for (artifact_id, file) in files {
-            let parse_ptr = Arc::as_ptr(&file.parse) as usize;
-            let stale = match self.analyses.get(artifact_id) {
-                Some(slot) => slot.parse_ptr != parse_ptr,
-                None => true,
-            };
-            if stale {
-                let stat = Arc::new(analyze_file_static(&file.parse));
-                let era = Arc::new(analyze_file_era(&file.parse, known_files));
-                let entity_arcs = file
-                    .parse
-                    .entities
-                    .iter()
-                    .map(|entity| Arc::new(entity.clone()))
-                    .collect();
-                self.analyses.insert(
-                    *artifact_id,
-                    AnalysisSlot {
-                        parse_ptr,
-                        entity_arcs,
-                        stat,
-                        era_signature,
-                        era,
-                    },
-                );
-                continue;
-            }
-            let slot = self
-                .analyses
-                .get_mut(artifact_id)
-                .expect("slot presence checked above");
-            if slot.era_signature != era_signature {
-                slot.era = Arc::new(analyze_file_era(&file.parse, known_files));
-                slot.era_signature = era_signature;
-            }
+/// Refresh exact per-file analysis inputs for one tree and discard analyses no
+/// longer reachable from that tree.
+///
+/// Parent semantic states own every parse allocation a future child can reuse.
+/// Dropping a cache slot therefore never drops semantic truth: revisiting a
+/// live parent or another branch either finds the same retained allocation or
+/// recomputes from that parent's exact parse payload. Retaining only the
+/// current tree bounds cache memory while the `Arc` held by each live slot
+/// prevents address reuse from impersonating a distinct divergent-head input.
+fn refresh_link_analyses(
+    engine: &mut LinkEngine,
+    files: &BTreeMap<ArtifactId, Arc<SemanticFileState>>,
+    era_signature: u64,
+    known_files: &HashSet<&str>,
+) {
+    engine
+        .analyses
+        .retain(|artifact_id, _| files.contains_key(artifact_id));
+    for (artifact_id, file) in files {
+        let stale = match engine.analyses.get(artifact_id) {
+            Some(slot) => !Arc::ptr_eq(&slot.parse, &file.parse),
+            None => true,
+        };
+        if stale {
+            let stat = Arc::new(analyze_file_static(&file.parse));
+            let era = Arc::new(analyze_file_era(&file.parse, known_files));
+            let entity_arcs = file
+                .parse
+                .entities
+                .iter()
+                .map(|entity| Arc::new(entity.clone()))
+                .collect();
+            engine.analyses.insert(
+                *artifact_id,
+                AnalysisSlot {
+                    parse: Arc::clone(&file.parse),
+                    entity_arcs,
+                    stat,
+                    era_signature,
+                    era,
+                },
+            );
+            continue;
+        }
+        let slot = engine
+            .analyses
+            .get_mut(artifact_id)
+            .expect("slot presence checked above");
+        if slot.era_signature != era_signature {
+            slot.era = Arc::new(analyze_file_era(&file.parse, known_files));
+            slot.era_signature = era_signature;
         }
     }
 }
@@ -1907,6 +1947,73 @@ mod tests {
     }
 
     #[test]
+    fn analysis_cache_retains_and_compares_the_exact_parse_allocation() {
+        let artifact_id = ArtifactId::new();
+        let path = "src/shared.rs";
+        let first_parse = Arc::new(FileParseData {
+            file_path: path.to_string(),
+            entities: vec![parsed_function(path, "left_only", 1)],
+            relations: Vec::new(),
+            imports: Vec::new(),
+        });
+        let first_parse_weak = Arc::downgrade(&first_parse);
+        let first_state = Arc::new(SemanticFileState {
+            artifact_id,
+            entry: TreeEntry::blob(kin_model::Hash256::from_bytes([1; 32]), false),
+            completeness: ParseCompleteness::Full,
+            parse: first_parse,
+        });
+        let mut first_files = BTreeMap::new();
+        first_files.insert(artifact_id, first_state);
+        let known_files = HashSet::from([path]);
+        let mut engine = LinkEngine::new();
+        let era = advance_link_era(&mut engine, &first_files);
+        refresh_link_analyses(&mut engine, &first_files, era, &known_files);
+        drop(first_files);
+
+        assert!(
+            first_parse_weak.upgrade().is_some(),
+            "the cache must retain its identity allocation so its address cannot be recycled"
+        );
+
+        let second_state = Arc::new(SemanticFileState {
+            artifact_id,
+            entry: TreeEntry::blob(kin_model::Hash256::from_bytes([2; 32]), false),
+            completeness: ParseCompleteness::Full,
+            parse: Arc::new(FileParseData {
+                file_path: path.to_string(),
+                entities: vec![parsed_function(path, "right_only", 1)],
+                relations: Vec::new(),
+                imports: Vec::new(),
+            }),
+        });
+        let mut second_files = BTreeMap::new();
+        second_files.insert(artifact_id, second_state);
+        let era = advance_link_era(&mut engine, &second_files);
+        refresh_link_analyses(&mut engine, &second_files, era, &known_files);
+
+        assert_eq!(engine.analyses.len(), 1);
+        assert_eq!(
+            engine.analysis(&artifact_id).entity_arcs[0].name,
+            "right_only"
+        );
+        assert!(
+            first_parse_weak.upgrade().is_none(),
+            "replacing the exact input should release the stale cache allocation"
+        );
+    }
+
+    #[test]
+    fn history_link_verification_flag_is_case_insensitive() {
+        for enabled in ["1", "true", "TRUE", "TrUe", "yes", "YES", "on", "ON"] {
+            assert!(history_link_verify_enabled(enabled), "{enabled}");
+        }
+        for disabled in ["", "0", "false", "off", "no", "truthy"] {
+            assert!(!history_link_verify_enabled(disabled), "{disabled}");
+        }
+    }
+
+    #[test]
     fn fails_closed_when_history_is_not_parent_first() {
         let root = tempdir().unwrap();
         let repository = root.path().join("source");
@@ -2025,17 +2132,124 @@ mod tests {
     /// relinks that must still match the batch derivation exactly.
     #[test]
     fn incremental_replay_matches_batch_on_structural_commits() {
-        enrich_verified(&[
-            &[("src/lib.rs", "pub fn one() {}\n")],
-            &[
-                ("src/lib.rs", "pub mod extra;\npub fn one() {}\n"),
-                ("src/extra.rs", "pub fn two() { crate::one() }\n"),
-            ],
-            // Content-only step between the structural ones.
-            &[("src/extra.rs", "pub fn two() { crate::one(); }\n")],
-            // Remove the module again.
-            &[("src/lib.rs", "pub fn one() {}\npub fn three() {}\n")],
-        ]);
+        let root = tempdir().unwrap();
+        let repository = root.path().join("source");
+        fs::create_dir(&repository).unwrap();
+        git(&repository, &["init", "--initial-branch=main"]);
+        git(
+            &repository,
+            &["config", "user.email", "kin@example.invalid"],
+        );
+        git(&repository, &["config", "user.name", "Kin Test"]);
+
+        write(&repository, "src/lib.rs", b"pub fn one() {}\n");
+        git(&repository, &["add", "--all"]);
+        git(&repository, &["commit", "-m", "initial"]);
+
+        write(
+            &repository,
+            "src/lib.rs",
+            b"pub mod extra;\npub fn one() {}\n",
+        );
+        write(
+            &repository,
+            "src/extra.rs",
+            b"pub fn two() { crate::one() }\n",
+        );
+        git(&repository, &["add", "--all"]);
+        git(&repository, &["commit", "-m", "add module"]);
+
+        write(
+            &repository,
+            "src/extra.rs",
+            b"pub fn two() { crate::one(); }\n",
+        );
+        git(&repository, &["add", "--all"]);
+        git(&repository, &["commit", "-m", "content edit"]);
+
+        git(&repository, &["mv", "src/extra.rs", "src/renamed.rs"]);
+        write(
+            &repository,
+            "src/lib.rs",
+            b"pub mod renamed;\npub fn one() {}\n",
+        );
+        git(&repository, &["add", "--all"]);
+        git(&repository, &["commit", "-m", "rename module"]);
+
+        fs::remove_file(repository.join("src/renamed.rs")).unwrap();
+        write(
+            &repository,
+            "src/lib.rs",
+            b"pub fn one() {}\npub fn three() {}\n",
+        );
+        git(&repository, &["add", "--all"]);
+        git(&repository, &["commit", "-m", "delete module"]);
+
+        let blob_store = BlobStore::new(root.path().join("cas")).unwrap();
+        let snapshot = capture_lossless_git_repository(
+            &repository,
+            RepositoryId::new("history-structural-equivalence").unwrap(),
+            &blob_store,
+        )
+        .unwrap();
+        let plan = plan_semantic_git_import(&snapshot, &blob_store).unwrap();
+        let trees = trees_by_change(&plan);
+        let deltas =
+            derive_historical_semantic_deltas_verified(&plan.changes, &trees, &blob_store).unwrap();
+        assert_eq!(deltas.len(), 5);
+    }
+
+    /// Two reachable leaf heads can carry different versions of the same
+    /// artifact after their temporary semantic states have been dropped. The
+    /// persistent analysis cache must never confuse one head's parse payload
+    /// for the other through allocator-address reuse.
+    #[test]
+    fn incremental_replay_matches_batch_across_divergent_leaf_heads() {
+        let root = tempdir().unwrap();
+        let repository = root.path().join("source");
+        fs::create_dir(&repository).unwrap();
+        git(&repository, &["init", "--initial-branch=main"]);
+        git(
+            &repository,
+            &["config", "user.email", "kin@example.invalid"],
+        );
+        git(&repository, &["config", "user.name", "Kin Test"]);
+        write(&repository, "src/shared.rs", b"pub fn root() {}\n");
+        git(&repository, &["add", "--all"]);
+        git(&repository, &["commit", "-m", "root"]);
+
+        git(&repository, &["switch", "-c", "left"]);
+        write(&repository, "src/shared.rs", b"pub fn left_only() {}\n");
+        git(&repository, &["add", "--all"]);
+        git(&repository, &["commit", "-m", "left leaf"]);
+
+        git(&repository, &["switch", "main"]);
+        git(&repository, &["switch", "-c", "right"]);
+        write(&repository, "src/shared.rs", b"pub fn right_only() {}\n");
+        git(&repository, &["add", "--all"]);
+        git(&repository, &["commit", "-m", "right leaf"]);
+
+        let blob_store = BlobStore::new(root.path().join("cas")).unwrap();
+        let snapshot = capture_lossless_git_repository(
+            &repository,
+            RepositoryId::new("history-divergent-leaf-heads").unwrap(),
+            &blob_store,
+        )
+        .unwrap();
+        let plan = plan_semantic_git_import(&snapshot, &blob_store).unwrap();
+        let trees = trees_by_change(&plan);
+        let deltas =
+            derive_historical_semantic_deltas_verified(&plan.changes, &trees, &blob_store).unwrap();
+
+        assert_eq!(deltas.len(), 3);
+        let names = deltas
+            .iter()
+            .flat_map(|delta| &delta.entity_deltas)
+            .filter_map(EntityDelta::new_state)
+            .map(|entity| entity.name.as_str())
+            .collect::<HashSet<_>>();
+        assert!(names.contains("left_only"));
+        assert!(names.contains("right_only"));
     }
 
     /// Python inheritance: an edit to a base class's hierarchy must relink the
@@ -2183,6 +2397,7 @@ mod tests {
             .args(args)
             .current_dir(repository)
             .env("GIT_CONFIG_NOSYSTEM", "1")
+            .env("HOME", repository)
             .output()
             .unwrap();
         assert!(

--- a/crates/kin-index/src/history.rs
+++ b/crates/kin-index/src/history.rs
@@ -41,7 +41,7 @@ use crate::pipeline::IndexPipeline;
 /// establish whether replay semantics actually changed, and if they did, bump
 /// this constant and the manifest's recorded version together. Never
 /// regenerate a digest silently.
-pub const HYDRATION_SEMANTICS_VERSION: u32 = 5;
+pub const HYDRATION_SEMANTICS_VERSION: u32 = 6;
 
 /// Semantic graph delta derived for one pre-enrichment change identity.
 ///

--- a/crates/kin-index/src/history.rs
+++ b/crates/kin-index/src/history.rs
@@ -1046,17 +1046,32 @@ fn invalidated_files(
         base_leaves.extend(slot.stat.base_leaves.iter().cloned());
     }
 
-    for (artifact_id, old_file, new_file) in &changed {
+    // The changed files' old versions are analyzed once; the tree's path set
+    // is identical to the parent's on this path, so the current known-file
+    // set resolves the old imports exactly as the parent tree did.
+    let old_analyses: Vec<(FileStaticAnalysis, FileEraAnalysis)> = changed
+        .iter()
+        .map(|(_, old_file, _)| {
+            (
+                analyze_file_static(&old_file.parse),
+                analyze_file_era(&old_file.parse, known_files),
+            )
+        })
+        .collect();
+    // Base leaves must be complete (current tree plus every changed file's
+    // old declarations) before any name is tested against them.
+    for (old_stat, _) in &old_analyses {
+        base_leaves.extend(old_stat.base_leaves.iter().cloned());
+    }
+
+    for ((artifact_id, _, new_file), (old_stat, old_era)) in changed.iter().zip(&old_analyses) {
         let new_slot = engine.analysis(artifact_id);
-        let old_stat = analyze_file_static(&old_file.parse);
-        let old_era = analyze_file_era(&old_file.parse, known_files);
         changed_names.extend(old_stat.contributed_names.iter().cloned());
         changed_names.extend(new_slot.stat.contributed_names.iter().cloned());
         changed_paths.insert(new_file.path().to_string());
         if old_era.include_targets != new_slot.era.include_targets {
             include_seeds.insert(new_file.path().to_string());
         }
-        base_leaves.extend(old_stat.base_leaves.iter().cloned());
         if old_stat.hierarchy != new_slot.stat.hierarchy {
             hierarchy_fire = true;
         }
@@ -1089,8 +1104,7 @@ fn invalidated_files(
                     .push(file.path().to_string());
             }
         }
-        for (_, old_file, _) in &changed {
-            let old_era = analyze_file_era(&old_file.parse, known_files);
+        for ((_, old_file, _), (_, old_era)) in changed.iter().zip(&old_analyses) {
             for target in &old_era.include_targets {
                 reverse
                     .entry(target.clone())

--- a/crates/kin-index/src/history.rs
+++ b/crates/kin-index/src/history.rs
@@ -467,7 +467,7 @@ fn derive_tree_semantics(
         .flat_map(|file| file.entities.iter())
         .collect();
     let known_files = known_file_paths(&file_refs, &universe_refs);
-    let era_signature = era_signature_of(&files);
+    let era_signature = engine.advance_era(&files);
     engine.refresh_analyses(&files, era_signature, &known_files);
 
     // Assemble the include graph from the per-file resolved include targets.
@@ -577,18 +577,36 @@ fn derive_tree_semantics(
             }
         }
     }
-    for artifact_id in &relink {
-        let file = files
-            .get(artifact_id)
-            .ok_or_else(|| invalid("relink set names an artifact absent from the tree"))?;
-        let linked_file = link_single_file(
-            file,
-            &ctx,
-            &known_files,
-            &artifact_ids,
-            &completeness,
-            &entities,
-        )?;
+    // Per-file resolution is pure against the shared context, so a large
+    // relink set (structural commits relink the whole tree) resolves in
+    // parallel exactly like the batch path; results merge serially in
+    // deterministic artifact order either way.
+    let relinked_files = {
+        use rayon::prelude::*;
+        let link_one = |artifact_id: &ArtifactId| -> Result<(ArtifactId, LinkedFile)> {
+            let file = files
+                .get(artifact_id)
+                .ok_or_else(|| invalid("relink set names an artifact absent from the tree"))?;
+            let linked_file = link_single_file(
+                file,
+                &ctx,
+                &known_files,
+                &artifact_ids,
+                &completeness,
+                &entities,
+            )?;
+            Ok((*artifact_id, linked_file))
+        };
+        if relink.len() >= 16 {
+            relink
+                .par_iter()
+                .map(link_one)
+                .collect::<Result<Vec<_>>>()?
+        } else {
+            relink.iter().map(link_one).collect::<Result<Vec<_>>>()?
+        }
+    };
+    for (artifact_id, linked_file) in relinked_files {
         for relation in &linked_file.relations {
             let value = Arc::new(relation.clone());
             if relations.insert(relation.id, Arc::clone(&value)).is_some() {
@@ -598,7 +616,7 @@ fn derive_tree_semantics(
             }
             inserted_relations.insert(relation.id, value);
         }
-        linked.insert(*artifact_id, Arc::new(linked_file));
+        linked.insert(artifact_id, Arc::new(linked_file));
     }
     for (artifact_id, file) in &files {
         if linked.contains_key(artifact_id) {
@@ -846,6 +864,12 @@ fn deltas_from_relation_patch(
 struct LinkEngine {
     verify: bool,
     analyses: HashMap<ArtifactId, AnalysisSlot>,
+    /// Monotonic identifier for the current path-set era, advanced whenever
+    /// the sorted path membership actually differs from the previous tree.
+    /// Compared exactly, never by hash: a stale era silently changes what the
+    /// invalidation rules can see.
+    era_counter: u64,
+    era_paths: Vec<String>,
 }
 
 struct AnalysisSlot {
@@ -903,6 +927,8 @@ impl LinkEngine {
         Self {
             verify,
             analyses: HashMap::new(),
+            era_counter: 0,
+            era_paths: Vec::new(),
         }
     }
 
@@ -910,6 +936,20 @@ impl LinkEngine {
         self.analyses
             .get(artifact_id)
             .expect("analysis slots are refreshed for every file in the tree before use")
+    }
+
+    /// Advance to the era of `files`' exact sorted path membership. Module and
+    /// include-target resolution consult the known-file set, so per-file era
+    /// caches are only valid while this membership holds; the comparison is
+    /// over the paths themselves, never a digest of them.
+    fn advance_era(&mut self, files: &BTreeMap<ArtifactId, Arc<SemanticFileState>>) -> u64 {
+        let mut paths: Vec<String> = files.values().map(|file| file.path().to_string()).collect();
+        paths.sort_unstable();
+        if paths != self.era_paths {
+            self.era_counter += 1;
+            self.era_paths = paths;
+        }
+        self.era_counter
     }
 
     fn refresh_analyses(
@@ -1219,21 +1259,6 @@ fn analyze_file_era(parse: &FileParseData, known_files: &HashSet<&str>) -> FileE
         module_targets,
         include_targets,
     }
-}
-
-/// Stable signature of the tree's path membership. Module and include-target
-/// resolution consult the known-file set, so their per-file caches are only
-/// valid while this signature holds.
-fn era_signature_of(files: &BTreeMap<ArtifactId, Arc<SemanticFileState>>) -> u64 {
-    use std::hash::{Hash, Hasher};
-    let mut paths: Vec<&str> = files.values().map(|file| file.path()).collect();
-    paths.sort_unstable();
-    let mut hasher = std::collections::hash_map::DefaultHasher::new();
-    for path in paths {
-        path.hash(&mut hasher);
-        0xffu8.hash(&mut hasher);
-    }
-    hasher.finish()
 }
 
 /// An entity endpoint of a linked relation that the tree does not define.

--- a/crates/kin-index/src/linker.rs
+++ b/crates/kin-index/src/linker.rs
@@ -119,7 +119,7 @@ pub struct UnresolvedRelation {
 }
 
 /// Data for a single parsed file, used for cross-file linking.
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct FileParseData {
     /// Relative file path (e.g., "src/app/api/chat/route.ts").
     pub file_path: String,
@@ -199,11 +199,11 @@ fn link_cross_file_internal(
     completeness: Option<&FileParseCompletenessMap>,
 ) -> IndexResult<Vec<Relation>> {
     let _span = tracing::info_span!("kin.index.link_cross_file", files = files.len()).entered();
-    let universe_entities: Vec<Entity> = files
-        .iter()
-        .flat_map(|file| file.entities.iter().cloned())
-        .collect();
-    link_cross_file_against_entities_internal(files, &universe_entities, artifact_ids, completeness)
+    let file_refs: Vec<&FileParseData> = files.iter().collect();
+    let universe_refs: Vec<&Entity> = files.iter().flat_map(|file| file.entities.iter()).collect();
+    let include_graph = build_include_graph(files, &known_file_paths(&file_refs, &universe_refs));
+    let ctx = build_link_context_from_refs(&file_refs, &universe_refs, include_graph);
+    resolve_and_merge(files, &ctx, artifact_ids, completeness)
 }
 
 /// Resolve cross-file relations while carrying parser-emitted tests alongside the input.
@@ -265,7 +265,7 @@ fn entity_link_order(a: &Entity, b: &Entity) -> std::cmp::Ordering {
 /// [`IncrementalLinker`] bare-name index so both derive receiver-method leaf
 /// names identically — a divergence here would resolve the same call to
 /// different entities across the two linkers.
-fn bare_entity_name(name: &str) -> &str {
+pub(crate) fn bare_entity_name(name: &str) -> &str {
     match name.rfind("::") {
         Some(idx) => &name[idx + 2..],
         None => match name.rfind('.') {
@@ -319,7 +319,22 @@ fn link_cross_file_against_entities_internal(
     )
     .entered();
 
-    let ctx = build_link_context(files, universe_entities);
+    let file_refs: Vec<&FileParseData> = files.iter().collect();
+    let universe_refs: Vec<&Entity> = universe_entities.iter().collect();
+    let include_graph = build_include_graph(files, &known_file_paths(&file_refs, &universe_refs));
+    let ctx = build_link_context_from_refs(&file_refs, &universe_refs, include_graph);
+    resolve_and_merge(files, &ctx, artifact_ids, completeness)
+}
+
+/// Resolve every file against a prepared context and merge, exactly as the
+/// single-pass entry points do. Factored so the historical replay engine can
+/// drive the same resolution code against an incrementally assembled context.
+fn resolve_and_merge(
+    files: &[FileParseData],
+    ctx: &LinkContext<'_>,
+    artifact_ids: &ArtifactIdentityMap,
+    completeness: Option<&FileParseCompletenessMap>,
+) -> IndexResult<Vec<Relation>> {
     require_artifact_identities(ctx.known_files.iter().copied(), artifact_ids)?;
 
     let total_files = files.len();
@@ -343,7 +358,7 @@ fn link_cross_file_against_entities_internal(
         files
             .par_iter()
             .map(|file| {
-                let relations = resolve_one_file(file, &ctx, completeness);
+                let relations = resolve_one_file(file, ctx, completeness);
                 if total_files > 50 {
                     let done = completed.fetch_add(1, Ordering::Relaxed) + 1;
                     let total =
@@ -364,7 +379,7 @@ fn link_cross_file_against_entities_internal(
             .collect()
     };
 
-    let resolved = merge_resolved(per_file_relations, files, &ctx, artifact_ids, completeness);
+    let resolved = merge_resolved(per_file_relations, files, ctx, artifact_ids, completeness);
 
     if total_files > 0 {
         eprintln!(); // newline after \r progress
@@ -374,7 +389,7 @@ fn link_cross_file_against_entities_internal(
 }
 
 /// Read-only indices shared across per-file relation resolution.
-struct LinkContext<'a> {
+pub(crate) struct LinkContext<'a> {
     sorted_universe: Vec<&'a Entity>,
     entity_by_file_name: HashMap<(&'a str, &'a str), EntityId>,
     entity_by_name: HashMap<&'a str, Vec<(&'a str, EntityId)>>,
@@ -462,13 +477,34 @@ fn blind_inference_target_allowed(
         .unwrap_or(false)
 }
 
-fn build_link_context<'a>(
-    files: &'a [FileParseData],
-    universe_entities: &'a [Entity],
+/// The set of file paths module resolution may target: every parsed file plus
+/// every file an entity in the universe originates from. Shared by context
+/// construction and the historical replay engine so both resolve module paths
+/// against the identical set.
+pub(crate) fn known_file_paths<'a>(
+    files: &[&'a FileParseData],
+    universe_entities: &[&'a Entity],
+) -> HashSet<&'a str> {
+    let mut known: HashSet<&str> = HashSet::new();
+    for entity in universe_entities {
+        if let Some(file_path) = entity.file_origin.as_ref() {
+            known.insert(file_path.0.as_str());
+        }
+    }
+    for file in files {
+        known.insert(&file.file_path);
+    }
+    known
+}
+
+pub(crate) fn build_link_context_from_refs<'a>(
+    files: &[&'a FileParseData],
+    universe_entities: &[&'a Entity],
+    include_graph: HashMap<String, Vec<String>>,
 ) -> LinkContext<'a> {
     // Sort for deterministic relation materialization.
     let sorted_universe: Vec<&Entity> = {
-        let mut sorted: Vec<&Entity> = universe_entities.iter().collect();
+        let mut sorted: Vec<&Entity> = universe_entities.to_vec();
         sorted.sort_by(|a, b| entity_link_order(a, b));
         sorted
     };
@@ -565,8 +601,6 @@ fn build_link_context<'a>(
         import_map
     };
 
-    let include_graph = build_include_graph(files, &known_files);
-
     // Step 3: class hierarchy from parser-emitted Extends relations, keyed per
     // (file, class). Bases are sorted lexicographically — NOT declaration
     // order — because the reopen path rehydrates this index from committed
@@ -611,7 +645,7 @@ fn build_link_context<'a>(
 /// All reads are against the shared read-only [`LinkContext`]; the only mutable
 /// state is a file-local relation accumulator, so this is pure with respect to
 /// other files.
-fn resolve_one_file(
+pub(crate) fn resolve_one_file(
     file: &FileParseData,
     ctx: &LinkContext<'_>,
     completeness: Option<&FileParseCompletenessMap>,
@@ -1142,7 +1176,11 @@ fn link_cross_file_against_entities_serial(
     universe_entities: &[Entity],
     artifact_ids: &ArtifactIdentityMap,
 ) -> Vec<Relation> {
-    let ctx = build_link_context(files, universe_entities);
+    let file_refs: Vec<&FileParseData> = files.iter().collect();
+    let universe_refs: Vec<&Entity> = universe_entities.iter().collect();
+    let include_graph =
+        build_include_graph_serial(files, &known_file_paths(&file_refs, &universe_refs));
+    let ctx = build_link_context_from_refs(&file_refs, &universe_refs, include_graph);
     let per_file_relations: Vec<Vec<Relation>> = files
         .iter()
         .map(|file| resolve_one_file(file, &ctx, None))
@@ -1219,7 +1257,7 @@ fn merge_resolved_serial(
 ///
 /// Shared by batch include-graph construction and the incremental linker's
 /// persistent per-file include state so both record identical edges.
-fn resolve_include_targets<S>(
+pub(crate) fn resolve_include_targets<S>(
     file_path: &str,
     imports: &[FileImport],
     known_files: &HashSet<S>,
@@ -1578,7 +1616,7 @@ const INHERITED_METHOD_CONFIDENCE: f32 = 0.85;
 /// undotted names, `::` paths (those belong to the qualified-suffix resolver),
 /// and empty halves, so only receiver-qualified method keys reach the
 /// inheritance walk.
-fn split_owner_method(name: &str) -> Option<(&str, &str)> {
+pub(crate) fn split_owner_method(name: &str) -> Option<(&str, &str)> {
     if name.contains("::") {
         return None;
     }
@@ -1601,7 +1639,7 @@ fn receiver_method_keys(class: &str, method: &str) -> [String; 2] {
 /// operators), or with an empty half — so only a genuine receiver-scoped method
 /// key reaches the Extends-chain walk. The owner is validated as a class at the
 /// call site, so a namespace-qualified free function (`Catch::Main`) never binds.
-fn split_scoped_receiver_method(name: &str) -> Option<(&str, &str)> {
+pub(crate) fn split_scoped_receiver_method(name: &str) -> Option<(&str, &str)> {
     let (owner_path, method) = name.rsplit_once("::")?;
     let owner = owner_path.rsplit("::").next()?;
     if owner.is_empty()
@@ -2100,7 +2138,7 @@ fn resolve_qualified_suffix_incremental(
 }
 
 /// Whether an entity id names a type that can anchor an inheritance walk.
-fn is_class_like(kind: Option<&EntityKind>) -> bool {
+pub(crate) fn is_class_like(kind: Option<&EntityKind>) -> bool {
     matches!(
         kind,
         Some(
@@ -2807,7 +2845,7 @@ where
     })
 }
 
-fn make_artifact_import_relation<S>(
+pub(crate) fn make_artifact_import_relation<S>(
     importer_file: &str,
     import: &FileImport,
     known_files: &HashSet<S>,
@@ -2853,7 +2891,7 @@ where
 /// Build the graph-owned file-level call-coverage certificate used by
 /// ref-scoped review. Coverage state lives in relation evidence; history paths
 /// compare the complete relation payload and replace changed evidence.
-fn make_parse_coverage_relation(
+pub(crate) fn make_parse_coverage_relation(
     file_path: &str,
     artifact_id: ArtifactId,
     completeness: Option<&ParseCompleteness>,
@@ -3124,7 +3162,7 @@ fn stable_relation_node_id(
 ///
 /// For non-relative (package) imports like `@vue/shared` or `@mui/utils/foo`,
 /// uses monorepo heuristics to locate workspace packages under `packages/`.
-fn resolve_module_path<S>(
+pub(crate) fn resolve_module_path<S>(
     importer_path: &str,
     module_path: &str,
     known_files: &HashSet<S>,
@@ -5783,7 +5821,11 @@ mod tests {
             .iter()
             .flat_map(|f| f.entities.iter().cloned())
             .collect();
-        let ctx = build_link_context(&files, &universe);
+        let file_refs: Vec<&FileParseData> = files.iter().collect();
+        let universe_refs: Vec<&Entity> = universe.iter().collect();
+        let include_graph =
+            build_include_graph(&files, &known_file_paths(&file_refs, &universe_refs));
+        let ctx = build_link_context_from_refs(&file_refs, &universe_refs, include_graph);
         let artifact_ids = artifact_ids_for(&files, &universe);
 
         // resolve_one_file is deterministic, so building the per-file relations

--- a/crates/kin-index/tests/real_repository_enrichment.rs
+++ b/crates/kin-index/tests/real_repository_enrichment.rs
@@ -35,13 +35,17 @@ fn a_real_repository_enriches_into_replayable_history() {
     let root = tempfile::tempdir().unwrap();
     let blob_store = BlobStore::new(root.path().join("cas")).unwrap();
 
+    let phase = std::time::Instant::now();
     let snapshot = capture_lossless_git_repository(
         Path::new(&repository),
         RepositoryId::new("real-repository-enrichment").unwrap(),
         &blob_store,
     )
     .unwrap();
+    eprintln!("phase capture: {:.2}s", phase.elapsed().as_secs_f64());
+    let phase = std::time::Instant::now();
     let plan = plan_semantic_git_import(&snapshot, &blob_store).unwrap();
+    eprintln!("phase plan: {:.2}s", phase.elapsed().as_secs_f64());
     let trees = plan
         .aliases
         .iter()
@@ -56,19 +60,24 @@ fn a_real_repository_enriches_into_replayable_history() {
         })
         .collect::<BTreeMap<_, _>>();
 
+    let phase = std::time::Instant::now();
     let deltas = derive_historical_semantic_deltas(&plan.changes, &trees, &blob_store).unwrap();
+    eprintln!("phase derive: {:.2}s", phase.elapsed().as_secs_f64());
     let bindings = deltas
         .into_iter()
         .map(|delta| (delta.change_id, delta.entity_deltas, delta.relation_deltas))
         .collect::<Vec<_>>();
-    let admitted = admit_semantic_git_import(
-        &plan
-            .with_historical_semantics(&blob_store, &bindings)
-            .unwrap(),
-        &blob_store,
-    )
-    .unwrap();
+    let phase = std::time::Instant::now();
+    let enriched = plan
+        .with_historical_semantics(&blob_store, &bindings)
+        .unwrap();
+    eprintln!("phase bind: {:.2}s", phase.elapsed().as_secs_f64());
+    let phase = std::time::Instant::now();
+    let admitted = admit_semantic_git_import(&enriched, &blob_store).unwrap();
+    eprintln!("phase admit: {:.2}s", phase.elapsed().as_secs_f64());
+    let phase = std::time::Instant::now();
     admitted.validate(&blob_store).unwrap();
+    eprintln!("phase validate: {:.2}s", phase.elapsed().as_secs_f64());
 
     // The graph must never publish a change its own replay rejects, so every
     // head is resolved rather than only the tip of the default branch.

--- a/docs/env-vars.md
+++ b/docs/env-vars.md
@@ -3,7 +3,7 @@
 
 # Kin environment variables
 
-This is the authoritative list of supported `KIN_*` environment variables (410 total, 310 correctness-relevant), generated from the central registry in `kin-core`.
+This is the authoritative list of supported `KIN_*` environment variables (411 total, 310 correctness-relevant), generated from the central registry in `kin-core`.
 
 At CLI and daemon startup Kin validates this surface (`KIN_ENV_VALIDATION`, default `warn`):
 
@@ -41,6 +41,7 @@ Sensitivity legend: **correctness** (affects retrieval/ranking/output or data sa
 | `KIN_CLAUDE_DISALLOWED_TOOLS` | string | *(unset)* | operational | comma-separated tool names disallowed in a with-session |
 | `KIN_DIR` | path | *(unset)* | operational | compatibility alias for the managed Kin install root; KIN_HOME wins when both are set |
 | `KIN_DISABLE_SPINE` | bool | false | correctness | disable the spine federation layer, narrowing retrieval scope |
+| `KIN_HISTORY_LINK_VERIFY` | bool | false | operational | cross-check incremental historical enrichment against the full batch derivation at every commit during Git admission (self-audit; much slower, output unchanged) |
 | `KIN_HOME` | path | ~/.kin | operational | preferred root for the managed Kin install used by the launcher, setup, and shell hooks |
 | `KIN_MCP_CACHE_DIR` | path | *(unset)* | operational | cache directory override for the npm MCP wrapper's managed Kin binary |
 | `KIN_MCP_REPO` | path | *(unset)* | operational | bind `kin mcp start` to this repository instead of the launch directory |

--- a/scripts/hydration-semantics-manifest.json
+++ b/scripts/hydration-semantics-manifest.json
@@ -11,6 +11,13 @@
     },
     {
       "file": "crates/kin-index/src/history.rs",
+      "function": "derive_historical_semantic_deltas_inner",
+      "digest": "sha256:0894a920afdaa466d2469514d51752a963c8a9a9ab5bbbf94ccf821e8967fdc8",
+      "reason": "Owns the parent-first state-retention and eviction loop after the public wrapper delegates into the persistent link engine; omitting it would leave the real replay driver unguarded.",
+      "owner": "kin-index"
+    },
+    {
+      "file": "crates/kin-index/src/history.rs",
       "function": "semantic_state_for_tree",
       "digest": "sha256:5272aa6a3dbc402ebaf0b78e752d7230aaf9af49251b95cffbf3656e6b8ea431",
       "reason": "Turns one exact resolved tree plus CAS bodies into the entity/relation state a change is diffed from and to. Its classification, parse, and cross-file linking order decide what the past is said to contain.",
@@ -68,7 +75,7 @@
     {
       "file": "crates/kin-index/src/history.rs",
       "function": "derive_tree_semantics",
-      "digest": "sha256:7d3ef963c89f32d030c6a1b046fe4a55eeb56a51c1aa859ef05e88a0ef48efa8",
+      "digest": "sha256:f7c9197209a0c1d1fb14447f654954516867b462a307cd70ed482889b4bbeb96",
       "reason": "Derives one tree's semantic state and its first-parent deltas from carried-forward parent state: the incremental replacement for whole-tree recomputation, so its carry/patch rules decide the persisted history.",
       "owner": "kin-index"
     },
@@ -98,6 +105,20 @@
       "function": "analyze_file_era",
       "digest": "sha256:d5ae6a50fee2387dfb5826c16cad9cc655f437423e2892eab4d1c47c0e8d4afe",
       "reason": "Resolves a file's module, pin, and include targets against the tree's path set; module-target invalidation is only as conservative as this resolution.",
+      "owner": "kin-index"
+    },
+    {
+      "file": "crates/kin-index/src/history.rs",
+      "function": "advance_link_era",
+      "digest": "sha256:324729e0cc639e1ead87cbe28a50c51f1474b8c6ce3f928a6a2fc58d0c3f116f",
+      "reason": "Defines exact path-set cache eras for module and include resolution; a stale or colliding era can make replay reuse analysis from the wrong tree.",
+      "owner": "kin-index"
+    },
+    {
+      "file": "crates/kin-index/src/history.rs",
+      "function": "refresh_link_analyses",
+      "digest": "sha256:a136757656771327c0f805f1c9744808f85f6c2adcee52858215a41d06294121",
+      "reason": "Controls exact parse-allocation cache identity, recomputation, and pruning across divergent history; stale reuse here can silently change persisted historical relations.",
       "owner": "kin-index"
     },
     {

--- a/scripts/hydration-semantics-manifest.json
+++ b/scripts/hydration-semantics-manifest.json
@@ -5,14 +5,14 @@
     {
       "file": "crates/kin-index/src/history.rs",
       "function": "derive_historical_semantic_deltas",
-      "digest": "sha256:defd5579325f7b159b1aff73498622a72156c64579319d31ceec0b35f85fa2cf",
+      "digest": "sha256:f9b6eb1b0271bff9945b4d84d069633eaee32183c7ea368a560b3136a224d6f1",
       "reason": "Drives the whole parent-first replay: it decides the per-change baseline, which trees are enriched, and the exact EntityDelta/RelationDelta payload persisted for every historical change.",
       "owner": "kin-index"
     },
     {
       "file": "crates/kin-index/src/history.rs",
       "function": "semantic_state_for_tree",
-      "digest": "sha256:883a0ba2ac406e67a7efb59d59cae37c0d33aa6829938d20f986d19833d75cab",
+      "digest": "sha256:5272aa6a3dbc402ebaf0b78e752d7230aaf9af49251b95cffbf3656e6b8ea431",
       "reason": "Turns one exact resolved tree plus CAS bodies into the entity/relation state a change is diffed from and to. Its classification, parse, and cross-file linking order decide what the past is said to contain.",
       "owner": "kin-index"
     },
@@ -64,6 +64,69 @@
       "digest": "sha256:9665b558bbd0b395f455a9db301c7d1769ceb17ccbe99f7bd92ec62440cb50e3",
       "reason": "Assigns the stable artifact identities trees and entities are keyed by across the imported history. Reassignment here silently repoints every historical file.",
       "owner": "kin-git"
+    },
+    {
+      "file": "crates/kin-index/src/history.rs",
+      "function": "derive_tree_semantics",
+      "digest": "sha256:67acebf4f2c2a17cb6ff1a9f8f7868a9ed64cb50377607ec5594106ca52bbf86",
+      "reason": "Derives one tree's semantic state and its first-parent deltas from carried-forward parent state: the incremental replacement for whole-tree recomputation, so its carry/patch rules decide the persisted history.",
+      "owner": "kin-index"
+    },
+    {
+      "file": "crates/kin-index/src/history.rs",
+      "function": "link_single_file",
+      "digest": "sha256:0791c66b3ca5c74d14a6f4a8e5e9edac33b89e19ac337a9688da666347f04ed1",
+      "reason": "Produces one file's complete share of a tree's linked relations (resolved edges, artifact import/include edges, parse-coverage certificate) and validates endpoints; its per-file decomposition must match the batch linker exactly.",
+      "owner": "kin-index"
+    },
+    {
+      "file": "crates/kin-index/src/history.rs",
+      "function": "invalidated_files",
+      "digest": "sha256:8917877cec217126e1e1c3c265c7fcc4221b618974f0e2abcf11021db65f3567",
+      "reason": "Decides which files a content-only commit may carry forward without relinking. An under-conservative rule here silently changes what history claims; every rule must remain provably conservative.",
+      "owner": "kin-index"
+    },
+    {
+      "file": "crates/kin-index/src/history.rs",
+      "function": "analyze_file_static",
+      "digest": "sha256:3ae2dad2bd2ff1422923c33804b0f0226ceb2fe45ab95197d9f79a2d75b3c6e4",
+      "reason": "Enumerates the name-index keys a file's resolution can probe and the hierarchy shape other files can traverse through it; the invalidation rules are only as conservative as this enumeration.",
+      "owner": "kin-index"
+    },
+    {
+      "file": "crates/kin-index/src/history.rs",
+      "function": "analyze_file_era",
+      "digest": "sha256:d5ae6a50fee2387dfb5826c16cad9cc655f437423e2892eab4d1c47c0e8d4afe",
+      "reason": "Resolves a file's module, pin, and include targets against the tree's path set; module-target invalidation is only as conservative as this resolution.",
+      "owner": "kin-index"
+    },
+    {
+      "file": "crates/kin-index/src/history.rs",
+      "function": "add_name_tokens",
+      "digest": "sha256:abe245a1a1100d476a38358b5cf8e372a7ff26f13fc1041c18304bf9674f2d37",
+      "reason": "Derives every probe-key form of one name (bare leaf, segments, type-qualified suffix); token invalidation soundness depends on this closure.",
+      "owner": "kin-index"
+    },
+    {
+      "file": "crates/kin-index/src/history.rs",
+      "function": "deltas_from_entity_patch",
+      "digest": "sha256:daebf51288359fc5234bbb1d75065ceb7d7b8088aa2b2c22754e50b8766d631f",
+      "reason": "Emits the persisted first-parent entity deltas from the incremental patch; must stay identical to a full map diff.",
+      "owner": "kin-index"
+    },
+    {
+      "file": "crates/kin-index/src/history.rs",
+      "function": "deltas_from_relation_patch",
+      "digest": "sha256:8289842104dfb735ff461b5f99235a042816e56a5f989b248c342342e27f270f",
+      "reason": "Emits the persisted first-parent relation deltas from the incremental patch; must stay identical to a full map diff.",
+      "owner": "kin-index"
+    },
+    {
+      "file": "crates/kin-index/src/history.rs",
+      "function": "audit_carried_link_outputs",
+      "digest": "sha256:09d4d901f474e2a6c781f54045056c54a386f1c08f768d1e356c84f823b0a7ec",
+      "reason": "Fail-closed audit that a carried-forward link output could not have changed; weakening it converts invalidation bugs into silently wrong history instead of refusals.",
+      "owner": "kin-index"
     }
   ]
 }

--- a/scripts/hydration-semantics-manifest.json
+++ b/scripts/hydration-semantics-manifest.json
@@ -82,7 +82,7 @@
     {
       "file": "crates/kin-index/src/history.rs",
       "function": "invalidated_files",
-      "digest": "sha256:8917877cec217126e1e1c3c265c7fcc4221b618974f0e2abcf11021db65f3567",
+      "digest": "sha256:f3ab9daeeaedb72cd1c6281b268915b002174c2b59eaa1a5366be3b171e527e2",
       "reason": "Decides which files a content-only commit may carry forward without relinking. An under-conservative rule here silently changes what history claims; every rule must remain provably conservative.",
       "owner": "kin-index"
     },

--- a/scripts/hydration-semantics-manifest.json
+++ b/scripts/hydration-semantics-manifest.json
@@ -68,7 +68,7 @@
     {
       "file": "crates/kin-index/src/history.rs",
       "function": "derive_tree_semantics",
-      "digest": "sha256:67acebf4f2c2a17cb6ff1a9f8f7868a9ed64cb50377607ec5594106ca52bbf86",
+      "digest": "sha256:7d3ef963c89f32d030c6a1b046fe4a55eeb56a51c1aa859ef05e88a0ef48efa8",
       "reason": "Derives one tree's semantic state and its first-parent deltas from carried-forward parent state: the incremental replacement for whole-tree recomputation, so its carry/patch rules decide the persisted history.",
       "owner": "kin-index"
     },

--- a/scripts/hydration-semantics-manifest.json
+++ b/scripts/hydration-semantics-manifest.json
@@ -1,6 +1,6 @@
 {
   "comment": "Replay-semantics surface pinned by scripts/verify-hydration-semantics.py. These functions re-author the entity/relation deltas persisted for historical changes during Git admission, so editing one changes what Kin reports about the past on already-ingested repositories. A digest mismatch is not a failure to fix by regenerating: decide first whether replay semantics changed, and if so bump HYDRATION_SEMANTICS_VERSION and hydration_semantics_version together.",
-  "hydration_semantics_version": 5,
+  "hydration_semantics_version": 6,
   "guarded": [
     {
       "file": "crates/kin-index/src/history.rs",


### PR DESCRIPTION
# Incremental historical enrichment and cheap admission proofs

Targets the `O(history x tree)` admission term measured in FIR-1601 and the hoistable-preflight and dead-env-pin items from FIR-1629. Four workstreams, one dependency chain.

> **Takeover correction (2026-07-28):** correctness repairs are pushed at `ba9b004` + `8e4cb41`, have an independent GO review, and the exact hosted head is fully green across macOS, Ubuntu, Windows, daemon/MCP, Docker, DCO, dependency, secret, and launcher checks. This draft is still not merge-ready: the fresh full-corpus before/after pair is open, the synthetic `commits * files` coefficient remains a regression in the last valid fit, and the prior local full-workspace wrapper did not produce an accepted gate. The evidence below remains conservative until those substantive gates pass.

## 1. Post-parse enrichment is incremental per commit (kin-index)

Parsing was already memoized against parent state; everything after the parse was recomputed from scratch at every commit: whole-tree clones of every file's entities/relations/imports, fresh completeness and identity maps, a full sort, a whole-tree cross-file link, and full-tree entity/relation diffs.

Now:

- Parse payloads are `Arc`-shared per file version; carrying an unchanged file forward is a pointer clone.
- The tree entity and relation maps are patched from the first parent; the whole-tree duplicate-identity refusal is preserved exactly (kept-vs-kept pairs were validated by the parent, everything else re-checks on insert).
- First-parent deltas are emitted from the patch. An identity untouched by the patch carries the same shared value on both sides, and a patched identity value-compares old against new, so the output is identical to the full-map diff by construction.
- Only invalidated files relink. The invalidation set is conservative by design, per rule:
  - **Names**: a kept file's resolution probes the global indices only at keys derivable from its own parse payload (destination names, bare leaves, `::`/`.` segments, type-qualified suffix pairs). The indices change only at keys named by the changed files' old and new entity sets. Intersection relinks.
  - **Module targets**: import/pin/namespace/default-export resolution reaches other files through `resolve_module_path`, which is a pure function of the path set; per-file resolved targets are cached per path-set era (eras compared by the sorted path list itself, never a digest) and a changed file that is a target relinks its importers.
  - **Include topology**: a changed include-target list relinks everything that can reach the changed file through the old or new include graph (reverse reachability, unbounded, a superset of the bounded forward closure).
  - **Hierarchy**: inheritance walks discover class names mid-walk that no static token set can enumerate. Any change to a file's hierarchy projection (Extends pairs, class-like entity names/kinds, imports when it declares bases) or to any entity sharing a name with a declared base relinks every walk-capable file (only owner-dotted and `::`-scoped receiver calls can enter a walk).
  - **Structural commits** (any add/remove/rename/classification flip of a semantic file) relink the whole tree, in parallel through the same pure per-file resolution the batch linker uses.
- The batch linker's resolution code is untouched; context construction is factored over borrowed refs so both paths share one code path (and batch callers stop deep-cloning the entity universe per call).

Two fail-closed audits convert any invalidation gap into a refusal instead of silently wrong history:

- a carried-forward link output that references a net-removed entity, or whose dropped external placeholder collides with a net-added entity, fails admission loudly;
- `KIN_HISTORY_LINK_VERIFY=1` recomputes every commit through the batch path and requires identical entity maps, relation maps, and emitted deltas.

## 2. The migration proof re-observes instead of re-capturing (kin-git)

`observe` ran a full `capture_lossless_git_repository` per observation: with two observations per proof and three proofs per init, six of the seven full object-closure captures per admission were TOCTOU stability re-checks re-reading and re-hashing every blob body into the CAS.

`verify_lossless_snapshot_unchanged` now re-proves the boundary against the held snapshot: shallow boundary, object format, byte-exact refs and HEAD (using the same conversion code as capture), and a structural walk of the reachable closure. Every reachable commit, tree, tag, and blob body is re-read byte-exactly and fully re-verified for kind, declared length, body hash, and recomputed OID. This closes same-kind/same-length blob substitutions in the source ODB instead of trusting the initial capture. The two-observation structure and every mutable-boundary proof (index, worktree, hooks, filters, remotes) are unchanged.

## 3. Plan validation runs once, not six times (kin-git)

`SemanticGitImportPlan::validate` is a full raw-object re-derivation plus deep compare. It ran at bind (inside `with_historical_semantics`), three times inside the migration proofs (`validate_plan_binding`), at admission, and inside the admitted-plan audit. Now:

- `with_historical_semantics` validates that the plan is unenriched and that every change identity recomputes from its payload (which pins the whole DAG transitively through parent identities) instead of re-deriving the plan; the full rebuild-and-compare audit still runs exactly once at `admit_semantic_git_import`, so a plan that does not match its raw-object derivation still fails closed before admission.
- `validate_plan_binding` checks binding (repository id, format, objects, refs, head) only.
- The admitted-plan audit in `into_generation_zero_repository_transaction` is unchanged (one more full rebuild, deliberately kept).

## 4. Preflight refusals in milliseconds; dead env pins refuse loudly

- `preflight_git_source_compatibility` (new, public) runs the snapshot-free refusal subset (shallow, in-progress operations, materialized-worktree identity, sibling registered worktrees, hook/filter blockers) and is called at the top of `init_from_git`, before any capture. The same helper backs the full proof, so the two can never drift. A refusable source now fails in milliseconds instead of after a ~28-minute capture. Note `kin clone` still deletes the clone destination on admission failure; with the preflight the failure now happens before capture/enrichment, but the destination-deletion UX itself is untouched here.
- Removed `KIN_*` variables are now a first-class registry class: setting `KIN_INIT_WARM_CACHE` hard-fails startup in every validation mode with a message naming the variable and why it is dead, instead of the generic possible-typo warning. The freeze protocol's contamination pin can no longer silently no-op.

## Replay semantics and the manifest

Output identity remains required, but the corrected divergent-head cache identity changes persisted replay semantics, so `HYDRATION_SEMANTICS_VERSION` is intentionally bumped from 5 to 6. Digests for the edited pinned functions are regenerated, and the new derivation core (`derive_tree_semantics`, `link_single_file`, `invalidated_files`, the analyzers, patch-delta emitters, and the carried-output audit) is added to the guarded set with owners and reasons. All 21 guarded functions match the canonical v6 manifest.

Evidence of output identity:

- Six new equivalence fixtures run every commit through both paths with the batch result as the oracle (content edits, ambiguity shifts, structural commits, Python hierarchy edits, TS import rewiring, merges). The oracle caught one real bug during development (structural-mode relation deltas) before it ever shipped.
- `real_repository_enrichment` with `KIN_HISTORY_LINK_VERIFY=1` completed on fd: 1,999 changes across 8 heads cross-checked batch-vs-incremental in 144s wall.
- The corresponding ripgrep verification did not complete; no ripgrep after result exists.
- On corrected head `8e4cb41`, the same-length blob-corruption and divergent-leaf replay regressions pass; canonical manifest verification, formatting, and `-D warnings` clippy for kin-git + kin-index are green. An independent source rereview returned GO with no findings. Hosted checks on the exact head are fully green. The prior local full-workspace wrapper omitted `pipefail`, so its terminal marker is still not accepted as proof of a green workspace suite; that local gate and the full-corpus performance pair remain open.

## Measurements

Same-machine fd pair using `/usr/bin/time -l kin init --json` on a fresh copy:

| corpus | before | after | observed change |
| --- | ---: | ---: | ---: |
| fd wall | 1550.71s | 1149.32s | -25.9% |
| fd user CPU | 702.34s | 641.06s | -8.7% |
| fd peak RSS | 1.964 GB | 1.964 GB | essentially flat |

The synthetic refit does **not** demonstrate the target scaling improvement: the `commits * files` user-time coefficient moved from `0.00041376` to `0.00049871` (about +20.5%), while only the fixed per-commit term improved. The ripgrep BEFORE run stopped during linking with an empty init result, so there is no valid before/after pair. No several-fold or broad performance claim is being made.

## Remaining, deliberately out of scope

- `commit_trees` is still materialized twice (plan + bind maps), so peak RSS keeps its `O(history x tree)` memory term (FIR-1601 finding 4).
- Link-context map construction is still rebuilt per commit; it is pure map-building over borrowed data (no deep clones, no resolution), so it is a small constant, but it keeps a residual `O(tree)` per-commit term.
- The FIR-1629 shallow-corpus decision (bounded admission mode vs corpus rebuild) is a policy call, not taken here.