### PR TITLE
Adopt the kin-model merge-transaction schema

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3237,9 +3237,9 @@ dependencies = [
 
 [[package]]
 name = "kin-db"
-version = "0.6.4"
+version = "0.6.5"
 source = "sparse+https://kinlab.ai/registry/cargo/"
-checksum = "8a95c58aa62dd26c6c4b81c5f47f37c86261011595c49c8d764c3cfc2a5c33c9"
+checksum = "a5434248b321add448ef991990763793f55b9bf63ee4350bea52b369cd7618c8"
 dependencies = [
  "bincode",
  "bstr",
@@ -3442,9 +3442,9 @@ dependencies = [
 
 [[package]]
 name = "kin-model"
-version = "0.6.1"
+version = "0.6.4"
 source = "sparse+https://kinlab.ai/registry/cargo/"
-checksum = "a6cf7f074145c0582e6a05f995c33ff714969e9bcb4ed54af1365816ed8e86dd"
+checksum = "a6be89147ec09ed24c2d1c493b3e9dcc886b140f71b3b4c1960e879e112be81d"
 dependencies = [
  "chrono",
  "gix-hash",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -122,7 +122,7 @@ pretty_assertions = "1"
 serial_test = "3"
 
 # Internal crates
-kin-model = { version = "=0.6.1", registry = "kin" }
+kin-model = { version = "=0.6.4", registry = "kin" }
 kin-blobs = { version = "0.1.1", registry = "kin" }
 kin-core = { path = "crates/kin-core" }
 kin-parser = { path = "crates/kin-parser" }
@@ -150,7 +150,7 @@ kin-lsp = { version = "0.6.0", registry = "kin" }
 # backend on every target (incl. Linux, where it cannot compile). Metal is re-enabled
 # additively on macOS via a `[target.'cfg(target_os = "macos")'.dependencies]` block in the
 # binary/runtime crates (kin-cli, kin-daemon). Feature unification makes that additive.
-kin-db = { version = "0.6.4", registry = "kin", default-features = false }
+kin-db = { version = "0.6.5", registry = "kin", default-features = false }
 kin-vfs-core = { version = "0.1.5", registry = "kin" }
 
 [profile.release]

--- a/crates/kin-cli/src/commands/locate.rs
+++ b/crates/kin-cli/src/commands/locate.rs
@@ -15969,6 +15969,7 @@ mod tests {
                 }),
                 local_overlay_delta: (index == 0)
                     .then(|| FrozenLocalOverlayDelta::initialize(overlay.clone())),
+                merge_transaction_delta: None,
             };
             drop(lease);
             manager.commit_repository_transaction(transaction).unwrap();

--- a/crates/kin-cli/tests/repository_branches.rs
+++ b/crates/kin-cli/tests/repository_branches.rs
@@ -276,6 +276,7 @@ fn add_exact_refs(layout: &kin_core::KinLayout) {
         default_ref_mutation: None,
         workspace_mutation: None,
         local_overlay_delta: None,
+        merge_transaction_delta: None,
     };
     let receipt = manager
         .commit_repository_transaction(transaction)
@@ -311,6 +312,7 @@ fn exact_ref_create_transaction(
         default_ref_mutation: None,
         workspace_mutation: None,
         local_overlay_delta: None,
+        merge_transaction_delta: None,
     }
 }
 
@@ -920,6 +922,7 @@ fn admit_uncommitted_workspace_edit(
                 new_admission_policy: workspace.admission_policy,
             }),
             local_overlay_delta: None,
+            merge_transaction_delta: None,
         })
         .expect("commit admitted workspace edit");
 }

--- a/crates/kin-core/src/init.rs
+++ b/crates/kin-core/src/init.rs
@@ -1215,6 +1215,7 @@ fn build_repository_bootstrap_transaction(
         }),
         workspace_mutation: Some(workspace_mutation),
         local_overlay_delta: Some(FrozenLocalOverlayDelta::initialize(local_overlay)),
+        merge_transaction_delta: None,
     };
 
     if let Some(change_id) = initial_change_id {

--- a/crates/kin-core/src/tree.rs
+++ b/crates/kin-core/src/tree.rs
@@ -12329,6 +12329,7 @@ mod tests {
                 new_admission_policy: workspace.admission_policy,
             }),
             local_overlay_delta: None,
+            merge_transaction_delta: None,
         };
 
         let error = validate_repository_projection_transaction(
@@ -13402,6 +13403,7 @@ mod tests {
             }),
             workspace_mutation: None,
             local_overlay_delta: None,
+            merge_transaction_delta: None,
         };
         let marker = ReconciliationAuthorityCommit {
             repository_id: transaction.repository_id.clone(),
@@ -13536,6 +13538,7 @@ mod tests {
             }),
             workspace_mutation: None,
             local_overlay_delta: None,
+            merge_transaction_delta: None,
         };
         let marker = ReconciliationAuthorityCommit {
             repository_id: transaction.repository_id.clone(),
@@ -13676,6 +13679,7 @@ mod tests {
                 new_admission_policy: workspace.admission_policy,
             }),
             local_overlay_delta: None,
+            merge_transaction_delta: None,
         };
         let competing_transaction = RepositoryTransaction {
             operation_id: OperationId::new(),

--- a/crates/kin-daemon/src/api.rs
+++ b/crates/kin-daemon/src/api.rs
@@ -10534,6 +10534,7 @@ mod tests {
             }),
             workspace_mutation: None,
             local_overlay_delta: None,
+            merge_transaction_delta: None,
         };
         drop(lease);
         manager.commit_repository_transaction(transaction).unwrap();
@@ -10985,6 +10986,7 @@ mod tests {
             default_ref_mutation: None,
             workspace_mutation: None,
             local_overlay_delta: None,
+            merge_transaction_delta: None,
         };
         drop(lease);
         authority
@@ -11410,6 +11412,7 @@ mod tests {
             default_ref_mutation: None,
             workspace_mutation: None,
             local_overlay_delta: None,
+            merge_transaction_delta: None,
         };
         drop(lease);
         external

--- a/crates/kin-daemon/src/repository_branch.rs
+++ b/crates/kin-daemon/src/repository_branch.rs
@@ -686,6 +686,7 @@ fn switch(
             },
         }),
         local_overlay_delta: None,
+        merge_transaction_delta: None,
     };
     // Validate the derived view before materializing anything over it. This
     // reads the working copy only at paths the workspace tree already tracks
@@ -796,6 +797,7 @@ fn replay_switch(
         default_ref_mutation: None,
         workspace_mutation: Some(mutation.clone()),
         local_overlay_delta: None,
+        merge_transaction_delta: None,
     };
     if transaction.transaction_hash()? != receipt.transaction_hash {
         return Err(branch_conflict(format!(
@@ -913,6 +915,7 @@ fn ref_transaction(
         default_ref_mutation: None,
         workspace_mutation: None,
         local_overlay_delta: None,
+        merge_transaction_delta: None,
     }
 }
 

--- a/crates/kin-daemon/src/repository_checkout.rs
+++ b/crates/kin-daemon/src/repository_checkout.rs
@@ -309,6 +309,7 @@ fn plan_and_commit(
             default_ref_mutation: None,
             workspace_mutation: receipt.operation.workspace_mutation.clone(),
             local_overlay_delta: None,
+            merge_transaction_delta: None,
         };
         let replay_hash = replay_transaction
             .transaction_hash()
@@ -643,6 +644,7 @@ fn plan_and_commit(
             new_admission_policy: workspace.admission_policy,
         }),
         local_overlay_delta: None,
+        merge_transaction_delta: None,
     };
     let (projected_entries, receipt, authority_freeze) =
         kin_core::tree::checkout_repository_workspace_subtree_and_commit_repository_transaction(

--- a/crates/kin-daemon/src/repository_commit.rs
+++ b/crates/kin-daemon/src/repository_commit.rs
@@ -287,6 +287,7 @@ pub(crate) fn plan_session_workspace_admission(
             },
         }),
         local_overlay_delta: None,
+        merge_transaction_delta: None,
     };
     transaction.validate()?;
     let transaction_hash = transaction.transaction_hash()?;
@@ -553,6 +554,7 @@ pub(crate) fn publish_workspace_tree(
             },
         }),
         local_overlay_delta: None,
+        merge_transaction_delta: None,
     };
     transaction.validate()?;
 
@@ -815,6 +817,7 @@ fn plan_native_commit_inner(
         default_ref_mutation: None,
         workspace_mutation: Some(workspace_mutation),
         local_overlay_delta: None,
+        merge_transaction_delta: None,
     };
     transaction.validate()?;
 

--- a/crates/kin-daemon/src/repository_merge.rs
+++ b/crates/kin-daemon/src/repository_merge.rs
@@ -420,6 +420,7 @@ fn fast_forward(
             theirs_policy,
         )?),
         local_overlay_delta: None,
+        merge_transaction_delta: None,
     };
     publish(
         state,
@@ -633,6 +634,7 @@ fn three_way(
             shared_policy,
         )?),
         local_overlay_delta: None,
+        merge_transaction_delta: None,
     };
     let mut execution = publish(
         state,

--- a/crates/kin-daemon/src/repository_rollback.rs
+++ b/crates/kin-daemon/src/repository_rollback.rs
@@ -390,6 +390,7 @@ fn plan_and_commit(
             },
         }),
         local_overlay_delta: None,
+        merge_transaction_delta: None,
     };
     transaction
         .validate()

--- a/crates/kin-daemon/src/repository_stash.rs
+++ b/crates/kin-daemon/src/repository_stash.rs
@@ -452,6 +452,7 @@ fn push(
             },
         }),
         local_overlay_delta: None,
+        merge_transaction_delta: None,
     };
     seal.validate()
         .context("validate the exact stash seal transaction")?;
@@ -611,6 +612,7 @@ fn return_to_base(
             },
         }),
         local_overlay_delta: None,
+        merge_transaction_delta: None,
     };
     transaction
         .validate()
@@ -820,6 +822,7 @@ fn pop(
             },
         }),
         local_overlay_delta: None,
+        merge_transaction_delta: None,
     };
     transaction
         .validate()

--- a/crates/kin-daemon/src/repository_tag.rs
+++ b/crates/kin-daemon/src/repository_tag.rs
@@ -200,6 +200,7 @@ fn publish(
         default_ref_mutation: None,
         workspace_mutation: None,
         local_overlay_delta: None,
+        merge_transaction_delta: None,
     };
     let (receipt, authority_freeze) = commit_and_freeze_exact(&authority.manager, transaction)
         .with_context(|| format!("publish repository-v6 tag {}", request.name))?;
@@ -427,6 +428,7 @@ fn replay(
         default_ref_mutation: None,
         workspace_mutation: None,
         local_overlay_delta: None,
+        merge_transaction_delta: None,
     };
     if transaction.transaction_hash()? != receipt.transaction_hash {
         return Err(tag_conflict(format!(

--- a/crates/kin-git/src/admission_history.rs
+++ b/crates/kin-git/src/admission_history.rs
@@ -156,6 +156,7 @@ impl AdmittedSemanticGitImportPlan {
             default_ref_mutation: self.default_ref_mutation,
             workspace_mutation: None,
             local_overlay_delta: None,
+            merge_transaction_delta: None,
         };
         transaction.validate()?;
         Ok(transaction)

--- a/crates/kin-mcp/src/handlers/mod.rs
+++ b/crates/kin-mcp/src/handlers/mod.rs
@@ -451,6 +451,7 @@ mod tests {
                 new_admission_policy: admission_policy,
             }),
             local_overlay_delta: None,
+            merge_transaction_delta: None,
         };
         authority
             .commit_repository_transaction(transaction)
@@ -552,6 +553,7 @@ mod tests {
             default_ref_mutation: None,
             workspace_mutation: None,
             local_overlay_delta: None,
+            merge_transaction_delta: None,
         };
         authority
             .commit_repository_transaction(transaction)

--- a/crates/kin-remote/src/repository_transfer.rs
+++ b/crates/kin-remote/src/repository_transfer.rs
@@ -1132,6 +1132,7 @@ fn transfer_transaction(
         default_ref_mutation,
         workspace_mutation: None,
         local_overlay_delta: None,
+        merge_transaction_delta: None,
     };
     transaction.validate().map_err(model)?;
     Ok(transaction)
@@ -1463,6 +1464,7 @@ mod tests {
             }),
             workspace_mutation: None,
             local_overlay_delta: None,
+            merge_transaction_delta: None,
         };
         drop(lease);
         manager.commit_repository_transaction(transaction).unwrap();
@@ -1725,6 +1727,7 @@ mod tests {
             default_ref_mutation: None,
             workspace_mutation: None,
             local_overlay_delta: None,
+            merge_transaction_delta: None,
         };
         drop(source_lease);
         source
@@ -1935,6 +1938,7 @@ mod tests {
             default_ref_mutation: None,
             workspace_mutation: None,
             local_overlay_delta: None,
+            merge_transaction_delta: None,
         };
         drop(lease);
         fixture
@@ -1994,6 +1998,7 @@ mod tests {
             }),
             workspace_mutation: None,
             local_overlay_delta: None,
+            merge_transaction_delta: None,
         };
         drop(lease);
         authority
@@ -2205,6 +2210,7 @@ mod tests {
             default_ref_mutation: None,
             workspace_mutation: None,
             local_overlay_delta: None,
+            merge_transaction_delta: None,
         };
         drop(lease);
         fixture

--- a/crates/kin-remote/src/repository_transfer_negotiation.rs
+++ b/crates/kin-remote/src/repository_transfer_negotiation.rs
@@ -757,6 +757,7 @@ mod tests {
             }),
             workspace_mutation: None,
             local_overlay_delta: None,
+            merge_transaction_delta: None,
         };
         drop(lease);
         manager.commit_repository_transaction(transaction).unwrap();


### PR DESCRIPTION
Unblocks every kin-db consumer in kin. Picked this up because it is the hard blocker under #471 and no other PR was doing it; flagged the intent on #471 and FIR-1611 first.

## Why this is forced

kin-model 0.6.2 added a required `merge_transaction_delta` to `RepositoryTransaction`, and kin-db #137 changed kin-db's dependency from caret `kin-model = "0.6.1"` to exact `= "0.6.4"`. That exact pin propagates, so kin pinned at `=0.6.1` and any kin-db release built on 0.6.4 cannot co-resolve at all:

```
error: failed to select a version for `kin-model`.
    ... required by package `kin-db v0.6.5`
versions that meet the requirements `=0.6.4` are: 0.6.4
  previously selected package `kin-model v0.6.1 (registry `kin`)`
```

The exact pin is sound on its own terms, since kin-db's `Cargo.lock` is gitignored and a caret requirement is exactly what let a fresh CI resolve pick up 0.6.2 and break kin-db main. The cost is that kin-model moves are now lockstep, and kin has to adopt each schema change before taking any kin-db release built on it.

`kin-model` goes to `=0.6.4`, `kin-db` to `0.6.5`. `Cargo.lock` is re-locked patch-off: both entries keep a `sparse+` source and a checksum, and no kin crate resolves to a path.

## What the field is set to, and why None is not a shortcut

There are 39 real `RepositoryTransaction` constructions: 38 explicit full literals across 16 Rust files set `merge_transaction_delta: None`, and one struct-update inherits `None` from its covered base transaction. That is not a placeholder; it is what each site already means:

- `kin-git/src/admission_history.rs` — generation-zero Git bootstrap
- `kin-core/src/init.rs` — repository initialization
- `kin-remote/src/repository_transfer.rs:1111` — fast-forward transfer receive
- `kin-daemon/src/repository_merge.rs` `fast_forward` and `three_way` — **these commit exactly the state they commit today.** Durable merge state is the capability that does not exist yet (FIR-1621), not one this change removes.
- the rest are test fixtures around those paths

kin-db's `apply_merge_transaction` early-returns on an absent delta, so persistence treats `None` as a no-op and behavior is unchanged everywhere.

**This is not the FIR-1621 kin-side consumption.** That work wires `kin conflicts` and `kin resolve` through the sealed transaction path and replaces the two `repository_merge.rs` `None`s with real deltas. This PR only makes kin compile and resolve against the schema.

## Gate

All 14 applicable exact-head hosted checks pass. macOS nextest passed 3,848/3,848 and Linux passed 3,837/3,837, with 9 skipped on each platform. All three `chaos_recovery` tests pass on both. The selected Windows authority suites pass 152 tests. Formatting, clippy, build, doc tests, daemon smoke, Docker no-push, cargo-deny, gitleaks, and DCO are green; only coverage and the mutually exclusive docs-only stub are skipped.

The kin-model 0.6.4 package also carries the first-parent revision correction from its 0.6.3 line; this PR is schema adoption at the Kin call sites, not a claim that the package bump is globally schema-only. No direct production Kin caller of the changed default revision methods was found in the source audit.