### PR TITLE
Consume kin-db 0.6.7 reopen proof

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3237,9 +3237,9 @@ dependencies = [
 
 [[package]]
 name = "kin-db"
-version = "0.6.5"
+version = "0.6.7"
 source = "sparse+https://kinlab.ai/registry/cargo/"
-checksum = "a5434248b321add448ef991990763793f55b9bf63ee4350bea52b369cd7618c8"
+checksum = "fab279dfb7cfc1c37fedaed1be22409f58ddb7cc31715694252c17e0b47f115d"
 dependencies = [
  "bincode",
  "bstr",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -150,7 +150,7 @@ kin-lsp = { version = "0.6.0", registry = "kin" }
 # backend on every target (incl. Linux, where it cannot compile). Metal is re-enabled
 # additively on macOS via a `[target.'cfg(target_os = "macos")'.dependencies]` block in the
 # binary/runtime crates (kin-cli, kin-daemon). Feature unification makes that additive.
-kin-db = { version = "0.6.5", registry = "kin", default-features = false }
+kin-db = { version = "=0.6.7", registry = "kin", default-features = false }
 kin-vfs-core = { version = "0.1.5", registry = "kin" }
 
 [profile.release]

--- a/crates/kin-core/src/git_init.rs
+++ b/crates/kin-core/src/git_init.rs
@@ -1467,6 +1467,16 @@ mod tests {
         // Remove one body from the published store between the two
         // observations, which the staged observation already proved present.
         let opaque = kin_blobs::digest(&std::fs::read(source.join("payload.bin")).unwrap());
+        let external_oid = gix::hash::ObjectId::from_hex(
+            git_stdout(&source, ["hash-object", "payload.bin"])
+                .trim()
+                .as_bytes(),
+        )
+        .unwrap();
+        let external_object = ExternalObjectId::new(
+            ExternalObjectKind::Blob,
+            kin_model::GitObjectId::sha1(external_oid.as_bytes().try_into().unwrap()),
+        );
         let published_kin_dir = source.join(".kin");
         let error = init_from_git_with_hooks(
             &source,
@@ -1483,13 +1493,14 @@ mod tests {
         // corruption. Do not rewrite this to expect the seal; a store defect
         // cannot get past graph-authority verification to reach it.
         let message = error.to_string();
+        let missing_body = format!("body for {external_object:?} is absent");
         assert!(
-            message.contains("is absent from immutable source CAS"),
+            message.contains("Git external authority body validation failed"),
             "graph authority must refuse the absent body, got: {message}"
         );
         assert!(
-            message.contains(&opaque.to_string()),
-            "the refusal must name the lost body, got: {message}"
+            message.contains(&missing_body),
+            "the refusal must name the exact lost external object, got: {message}"
         );
         // The rename already happened, so the contract here is uncertain rather
         // than absent: the operator is told to recover, not to reinitialize.

--- a/crates/kin-core/src/git_init.rs
+++ b/crates/kin-core/src/git_init.rs
@@ -1467,16 +1467,18 @@ mod tests {
         // Remove one body from the published store between the two
         // observations, which the staged observation already proved present.
         let opaque = kin_blobs::digest(&std::fs::read(source.join("payload.bin")).unwrap());
-        let external_oid = gix::hash::ObjectId::from_hex(
+        let external_oid = match gix::hash::ObjectId::from_hex(
             git_stdout(&source, ["hash-object", "payload.bin"])
                 .trim()
                 .as_bytes(),
         )
-        .unwrap();
-        let external_object = ExternalObjectId::new(
-            ExternalObjectKind::Blob,
-            kin_model::GitObjectId::sha1(external_oid.as_bytes().try_into().unwrap()),
-        );
+        .unwrap()
+        {
+            gix::hash::ObjectId::Sha1(bytes) => kin_model::GitObjectId::sha1(bytes),
+            gix::hash::ObjectId::Sha256(bytes) => kin_model::GitObjectId::sha256(bytes),
+            _ => panic!("fixture Git returned an unsupported object ID algorithm"),
+        };
+        let external_object = ExternalObjectId::new(ExternalObjectKind::Blob, external_oid);
         let published_kin_dir = source.join(".kin");
         let error = init_from_git_with_hooks(
             &source,

--- a/crates/kin-daemon/src/state.rs
+++ b/crates/kin-daemon/src/state.rs
@@ -1550,6 +1550,15 @@ impl DaemonState {
             Arc::clone(&local_repository_backend),
         )
         .map_err(DaemonError::Graph)?;
+        // Startup latency on a large repository is dominated by whether this
+        // open replayed the whole history or trusted a durable validation of
+        // the exact bytes it loaded. Record which path ran so an operator can
+        // diagnose a slow reopen from persisted logs.
+        info!(
+            repository = %repository_id,
+            by_history_validation = authority.opened_by_history_validation(),
+            "opened repository authority"
+        );
         // Opening authority above is what retains the per-repository storage
         // capability on this backend. Prove the pin took before serving any
         // request from it: a daemon that cannot revalidate its own namespace


### PR DESCRIPTION
## Summary

- pin Kin exactly to released `kin-db =0.6.7`
- preserve the published sparse-registry checksum in `Cargo.lock`
- log whether repository authority opened through durable history validation
- update the publication-loss test to assert the exact missing Git external object for both SHA-1 and SHA-256 repositories

This is the focused downstream consumer for reopen performance. The rejected loading/readiness experiment is intentionally not included.

## Verification

Current exact head `90b328fa8f556771430a5d5af415d3705652d54c`:

- independent fresh-eyes review: GO; no P0-P2 findings
- `cargo fmt --all -- --check`
- `git diff --check`
- focused publication-loss test: PASS with `GIT_DEFAULT_HASH` unset
- focused publication-loss test: PASS with `GIT_DEFAULT_HASH=sha256`
- hosted full matrix: running

Registry-clean product-change head `8192f338da3b27f4825d7b20a3181a3213f6103e`:

- detached `/tmp` registry-only `cargo check --locked`
- detached `/tmp` registry-only release build of `kin` and `kin-daemon`
- real-store run `release-clean-8192f338-20260728-1358`: PASS
  - warm reopen 1: 7.368s, `by_history_validation=true`, structural 0ms, replay 0ms
  - warm reopen 2: 8.012s, `by_history_validation=true`, structural 0ms, replay 0ms
  - stable 3,803 entities / 13,022 relations
  - unchanged snapshot SHA-256 and authority generation
  - last-byte snapshot tamper refused with authoritative digest mismatch

The two later commits change only the test assertion required to consume kin-db 0.6.7's richer external-authority error contract; they do not add runtime behavior.

Released dependency identity:

- `kin-db 0.6.7`: `fab279dfb7cfc1c37fedaed1be22409f58ddb7cc31715694252c17e0b47f115d`

## Evidence boundary

This remains branch-level registry-clean acceptance. It is not merged-main, released-Kin, production, public-installer, cross-OS, or real-client acceptance evidence.