### PR TITLE
Pin governance workflows to kin-actions v0.1.21

### DIFF
--- a/.github/workflows/approve-to-merge.yml
+++ b/.github/workflows/approve-to-merge.yml
@@ -16,4 +16,4 @@ jobs:
     permissions:
       contents: write
       pull-requests: write
-    uses: firelock-ai/kin-actions/.github/workflows/approve-to-merge.yml@v0.1.17
+    uses: firelock-ai/kin-actions/.github/workflows/approve-to-merge.yml@v0.1.21

--- a/.github/workflows/notify-approver.yml
+++ b/.github/workflows/notify-approver.yml
@@ -9,7 +9,7 @@ permissions:
 
 jobs:
   notify:
-    uses: firelock-ai/kin-actions/.github/workflows/notify-approver.yml@v0.1.19
+    uses: firelock-ai/kin-actions/.github/workflows/notify-approver.yml@v0.1.21
     permissions:
       contents: read
       pull-requests: write


### PR DESCRIPTION
## Summary

- pin shared approval and approver-notification workflows to kin-actions v0.1.21
- keep Kin governance automation on the current validated shared workflow bytes

## Verification

- `actionlint` on both changed workflows
- `git diff --check`
- exact two-line workflow-only diff

This changes CI governance wiring only. It does not alter Kin runtime, dependency, release, or proof bytes.