### PR TITLE
Move the Windows release leg off the pull-request path and scope CI caches to trusted refs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -108,12 +108,14 @@ jobs:
           targets: x86_64-pc-windows-msvc
 
       # Restore on every event, save only from main. A cache entry written from
-      # a pull request ref is readable by that one pull request and nothing
-      # else, so saving from pull requests bought no warm start while consuming
-      # the shared repository cache budget and evicting main's entry, which is
-      # why no reusable cargo cache existed on refs/heads/main at all. Saving
-      # only from main keeps one warm entry per job that every pull request
-      # restores, and leaves fork pull requests with no path to write one.
+      # a pull request ref is readable by later runs on that SAME ref and by
+      # nothing else, so the old configuration warmed pushes 2..N of one pull
+      # request while spending the shared repository cache budget and evicting
+      # main's entry, which is why no reusable cargo cache existed on
+      # refs/heads/main at all. Saving only from main trades that intra-branch
+      # warm start for one entry every pull request restores from push 1.
+      # The tradeoff is real and measured: see the trusted-ref note in
+      # scripts/test-release-workflow-authority.py.
       - name: Cache cargo registry and build
         uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -325,14 +325,14 @@ jobs:
     outputs:
       docs_only: ${{ steps.classify.outputs.docs_only }}
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           fetch-depth: 0
       - name: Classify changed paths
         id: classify
         # This step gates release-critical jobs. Override workflow defaults and
         # shell startup injection rather than inheriting mutable semantics.
-        shell: /usr/bin/bash --noprofile --norc -e -u -o pipefail {0}
+        shell: /usr/bin/bash --noprofile --norc -p -e -u -o pipefail {0}
         env:
           BASH_ENV: ""
           EVENT_NAME: ${{ github.event_name }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -107,18 +107,17 @@ jobs:
         with:
           targets: x86_64-pc-windows-msvc
 
+      # Restore on every event, save only from main. A cache entry written from
+      # a pull request ref is readable by that one pull request and nothing
+      # else, so saving from pull requests bought no warm start while consuming
+      # the shared repository cache budget and evicting main's entry, which is
+      # why no reusable cargo cache existed on refs/heads/main at all. Saving
+      # only from main keeps one warm entry per job that every pull request
+      # restores, and leaves fork pull requests with no path to write one.
       - name: Cache cargo registry and build
-        uses: actions/cache@v6
+        uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
         with:
-          path: |
-            ~/.cargo/registry
-            ~/.cargo/git
-            target
-          # A key distinct from the installer job: this builds the debug profile,
-          # and one shared key would have the two jobs overwrite each other.
-          key: windows-authority-cargo-${{ hashFiles('Cargo.lock') }}
-          restore-keys: |
-            windows-authority-cargo-
+          save-if: ${{ github.ref == 'refs/heads/main' }}
 
       - name: Compile and run native Windows authority tests
         shell: bash
@@ -146,7 +145,19 @@ jobs:
   windows-installer:
     name: Windows installer + vector-free release build
     needs: changes
-    if: ${{ !cancelled() && needs.changes.outputs.docs_only != 'true' }}
+    # Deliberately off the pull-request path. This leg cold-builds the whole
+    # dependency graph in the release profile for x86_64-pc-windows-msvc and
+    # measured 20 to 25 minutes per round, longer than any other job, so it set
+    # the floor for every land-and-iterate cycle. It now runs on each push to
+    # main, which is exactly the commit release proof reads: release-tag.yml
+    # names this check in REQUIRED_CHECKS and refuses to mint a tag unless it is
+    # present and green on the release sha. On a pull request the job reports
+    # skipped, which satisfies the required context the same way the
+    # documentation-only path already relies on.
+    if: >-
+      ${{ !cancelled()
+      && github.event_name != 'pull_request'
+      && needs.changes.outputs.docs_only != 'true' }}
     runs-on: windows-latest
     timeout-minutes: 60
     steps:
@@ -398,16 +409,13 @@ jobs:
           grep -q '^\[registries\.kin\]' .cargo/config.toml
           if grep -q '^\[patch\.kin\]' .cargo/config.toml; then echo "::error::[patch.kin] git pins must be removed — kin-* resolve from the Kin registry"; exit 1; fi
 
+      # Same trusted-ref scoping as the Windows authority job: restore always,
+      # save only from main. This is the pull-request critical path, so a warm
+      # dependency graph here is what a round actually costs.
       - name: Cache cargo registry and build
-        uses: actions/cache@v6
+        uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
         with:
-          path: |
-            ~/.cargo/registry
-            ~/.cargo/git
-            target
-          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
-          restore-keys: |
-            ${{ runner.os }}-cargo-
+          save-if: ${{ github.ref == 'refs/heads/main' }}
 
       - name: Check formatting
         run: cargo fmt -- --check

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -330,11 +330,17 @@ jobs:
           fetch-depth: 0
       - name: Classify changed paths
         id: classify
-        # This step gates release-critical jobs. Override workflow defaults and
-        # shell startup injection rather than inheriting mutable semantics.
+        # This step gates release-critical jobs. Pin its process startup and run
+        # Git with an empty environment rather than inheriting mutable authority.
         shell: /usr/bin/bash --noprofile --norc -p -e -u -o pipefail {0}
         env:
+          PATH: /usr/bin:/bin
           BASH_ENV: ""
+          ENV: ""
+          LD_AUDIT: ""
+          LD_LIBRARY_PATH: /dev/null
+          LD_PRELOAD: ""
+          WORKSPACE: ${{ github.workspace }}
           EVENT_NAME: ${{ github.event_name }}
           BASE_SHA: ${{ github.event.pull_request.base.sha }}
           HEAD_SHA: ${{ github.event.pull_request.head.sha }}
@@ -342,7 +348,43 @@ jobs:
           set -euo pipefail
           docs_only=false
           if [ "$EVENT_NAME" = "pull_request" ]; then
-            changed="$(git diff --name-only "$BASE_SHA...$HEAD_SHA")"
+            # env -i drops inherited GIT_DIR/GIT_WORK_TREE/GIT_INDEX_FILE,
+            # GIT_CONFIG_*, object/replace, executable, and diff authority.
+            changed="$(
+              /usr/bin/env -i \
+                HOME=/dev/null \
+                PATH=/usr/bin:/bin \
+                LC_ALL=C \
+                GIT_CONFIG_NOSYSTEM=1 \
+                GIT_CONFIG_SYSTEM=/dev/null \
+                GIT_CONFIG_GLOBAL=/dev/null \
+                GIT_CONFIG_COUNT=0 \
+                GIT_ATTR_NOSYSTEM=1 \
+                GIT_PAGER=cat \
+                GIT_TERMINAL_PROMPT=0 \
+                /usr/bin/git \
+                  --no-pager \
+                  --no-replace-objects \
+                  --no-lazy-fetch \
+                  --no-optional-locks \
+                  --literal-pathspecs \
+                  --git-dir="$WORKSPACE/.git" \
+                  --work-tree="$WORKSPACE" \
+                  -c core.attributesFile=/dev/null \
+                  -c core.fsmonitor=false \
+                  -c diff.external= \
+                  -c diff.renames=false \
+                  -c diff.ignoreSubmodules=none \
+                  diff \
+                  --no-ext-diff \
+                  --no-textconv \
+                  --no-renames \
+                  --ignore-submodules=none \
+                  --submodule=short \
+                  --name-only \
+                  "$BASE_SHA...$HEAD_SHA" \
+                  --
+            )"
             if [ -n "$changed" ]; then
               docs_only=true
               while IFS= read -r path; do

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -330,7 +330,11 @@ jobs:
           fetch-depth: 0
       - name: Classify changed paths
         id: classify
+        # This step gates release-critical jobs. Override workflow defaults and
+        # shell startup injection rather than inheriting mutable semantics.
+        shell: /usr/bin/bash --noprofile --norc -e -u -o pipefail {0}
         env:
+          BASH_ENV: ""
           EVENT_NAME: ${{ github.event_name }}
           BASE_SHA: ${{ github.event.pull_request.base.sha }}
           HEAD_SHA: ${{ github.event.pull_request.head.sha }}

--- a/.github/workflows/daemon-smoke.yml
+++ b/.github/workflows/daemon-smoke.yml
@@ -48,8 +48,8 @@ jobs:
       # Registry only, matching what this job used to cache: the smoke asserts on
       # freshly built binaries, so no target directory is carried across runs.
       # Restore on every event, save only from main, for the same reason as the
-      # CI jobs: an entry written from a pull request ref is readable by that one
-      # pull request, so saving from pull requests warmed nothing and spent the
+      # CI jobs: an entry written from a pull request ref is readable only by
+      # later runs on that same ref, so it warmed one branch while spending the
       # shared repository cache budget that main's reusable entry needs.
       - name: Cache cargo registry
         uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1

--- a/.github/workflows/daemon-smoke.yml
+++ b/.github/workflows/daemon-smoke.yml
@@ -45,16 +45,17 @@ jobs:
           grep -q '^\[registries\.kin\]' .cargo/config.toml
           if grep -q '^\[patch\.kin\]' .cargo/config.toml; then echo "::error::[patch.kin] git pins must be removed — kin-* resolve from the Kin registry"; exit 1; fi
 
+      # Registry only, matching what this job used to cache: the smoke asserts on
+      # freshly built binaries, so no target directory is carried across runs.
+      # Restore on every event, save only from main, for the same reason as the
+      # CI jobs: an entry written from a pull request ref is readable by that one
+      # pull request, so saving from pull requests warmed nothing and spent the
+      # shared repository cache budget that main's reusable entry needs.
       - name: Cache cargo registry
-        uses: actions/cache@v6
+        uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
         with:
-          path: |
-            ~/.cargo/registry
-            ~/.cargo/git
-          key: ${{ runner.os }}-cargo-smoke-${{ hashFiles('**/Cargo.lock') }}
-          restore-keys: |
-            ${{ runner.os }}-cargo-smoke-
-            ${{ runner.os }}-cargo-
+          cache-targets: "false"
+          save-if: ${{ github.ref == 'refs/heads/main' }}
 
       # Cargo.lock and .cargo/config.toml together pin kin-* deps to public
       # source until every crate is registry-published.

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -50,8 +50,10 @@ jobs:
           cache-from: type=gha
           # Export layers only from main. A pull request's Actions cache scope
           # is private to that pull request, so exporting mode=max from every
-          # round wrote layers nothing else could read while spending the shared
-          # repository cache budget. Pull requests still import main's layers.
+          # round wrote layers only that same branch could reread, while
+          # spending the shared repository cache budget. Pull requests still
+          # import main's layers, and skipping the export also removes the
+          # mode=max upload from every pull-request round.
           cache-to: ${{ github.ref == 'refs/heads/main' && 'type=gha,mode=max' || '' }}
 
       - name: Verify container build provenance

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -48,7 +48,11 @@ jobs:
             KIN_BUILD_DIRTY=false
             KIN_BUILD_BRANCH=${{ github.ref_name }}
           cache-from: type=gha
-          cache-to: type=gha,mode=max
+          # Export layers only from main. A pull request's Actions cache scope
+          # is private to that pull request, so exporting mode=max from every
+          # round wrote layers nothing else could read while spending the shared
+          # repository cache budget. Pull requests still import main's layers.
+          cache-to: ${{ github.ref == 'refs/heads/main' && 'type=gha,mode=max' || '' }}
 
       - name: Verify container build provenance
         env:

--- a/.github/workflows/release-tag.yml
+++ b/.github/workflows/release-tag.yml
@@ -30,10 +30,12 @@ on:
 
 # The App installation token carries the only write capability (creating the
 # tag ref). The workflow's own GITHUB_TOKEN stays read-only: contents:read for
-# checkout and ref reads, checks:read to inspect the commit's check-runs.
+# checkout and ref reads, checks:read for check-runs, and actions:read to bind
+# each required check suite to its exact workflow path, event, and head SHA.
 permissions:
   contents: read
   checks: read
+  actions: read
 
 # Never run two tag mints at once, and never cancel one mid-flight.
 concurrency:
@@ -153,6 +155,7 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
           REPO: ${{ github.repository }}
+          CURRENT_RUN_ID: ${{ github.run_id }}
           REQUIRED_CHECKS: |
             Check & Test (ubuntu-latest)
             Check & Test (macos-latest)
@@ -162,63 +165,269 @@ jobs:
             Windows installer + vector-free release build
         run: |
           set -euo pipefail
-          gh api "repos/$REPO/commits/$SHA/check-runs?per_page=100" --paginate \
-            -q '.check_runs[] | {name: .name, status: .status, conclusion: .conclusion, id: .id}' \
+          # `filter=all` is deliberate: a rerun or second workflow that claims
+          # one required name is ambiguous authority, not evidence to collapse
+          # by recency. Release from a fresh main commit with one producer.
+          gh api "repos/$REPO/commits/$SHA/check-runs?per_page=100&filter=all" --paginate \
+            -q '.check_runs[] | {
+              name: .name,
+              status: .status,
+              conclusion: .conclusion,
+              id: .id,
+              app_slug: .app.slug,
+              check_suite_id: .check_suite.id,
+              head_sha: .head_sha
+            }' \
             > check_runs.ndjson || { echo "::error::failed to fetch check-runs for $SHA"; exit 1; }
+          gh api "repos/$REPO/actions/runs?head_sha=$SHA&per_page=100" --paginate \
+            -q '.workflow_runs[] | {
+              id: .id,
+              workflow_id: .workflow_id,
+              path: .path,
+              event: .event,
+              head_sha: .head_sha,
+              status: .status,
+              conclusion: .conclusion,
+              check_suite_id: .check_suite_id
+            }' \
+            > workflow_runs.ndjson || { echo "::error::failed to fetch workflow runs for $SHA"; exit 1; }
+          gh api "repos/$REPO/actions/runs/$CURRENT_RUN_ID" \
+            -q '{
+              id: .id,
+              workflow_id: .workflow_id,
+              path: .path,
+              event: .event,
+              head_sha: .head_sha,
+              status: .status,
+              conclusion: .conclusion,
+              check_suite_id: .check_suite_id
+            }' \
+            > current_run.json || { echo "::error::failed to fetch current release-tag run"; exit 1; }
           python3 - <<'PY'
           import json, os, sys
 
-          runs = {}
-          with open("check_runs.ndjson") as handle:
-              for line in handle:
-                  line = line.strip()
-                  if not line:
-                      continue
-                  run = json.loads(line)
-                  name = run["name"]
-                  # Keep only the latest attempt per check name (highest id).
-                  if name not in runs or run["id"] > runs[name]["id"]:
-                      runs[name] = run
+          def read_ndjson(path):
+              records = []
+              with open(path) as handle:
+                  for line in handle:
+                      line = line.strip()
+                      if line:
+                          records.append(json.loads(line))
+              return records
 
-          required = [c.strip() for c in os.environ["REQUIRED_CHECKS"].splitlines() if c.strip()]
+          check_runs = read_ndjson("check_runs.ndjson")
+          workflow_runs = read_ndjson("workflow_runs.ndjson")
+          with open("current_run.json") as handle:
+              current_run = json.load(handle)
+
+          runs_by_name = {}
+          for run in check_runs:
+              runs_by_name.setdefault(run["name"], []).append(run)
+
+          workflows_by_suite = {}
+          for run in workflow_runs:
+              workflows_by_suite.setdefault(run["check_suite_id"], []).append(run)
+
+          required = [
+              check.strip()
+              for check in os.environ["REQUIRED_CHECKS"].splitlines()
+              if check.strip()
+          ]
+          expected_provenance = {
+              "Check & Test (ubuntu-latest)": (
+                  245803170,
+                  ".github/workflows/ci.yml",
+                  "push",
+              ),
+              "Check & Test (macos-latest)": (
+                  245803170,
+                  ".github/workflows/ci.yml",
+                  "push",
+              ),
+              # Uppercase `Sign-off` is the skipped-on-push CI job. The
+              # pull_request_target DCO workflow emits lowercase `sign-off`
+              # and is deliberately not release evidence.
+              "DCO Sign-off": (245803170, ".github/workflows/ci.yml", "push"),
+              "cargo-deny": (251549972, ".github/workflows/sast.yml", "push"),
+              "gitleaks (full history)": (
+                  293452372,
+                  ".github/workflows/secret-scan.yml",
+                  "push",
+              ),
+              "Windows installer + vector-free release build": (
+                  245803170,
+                  ".github/workflows/ci.yml",
+                  "push",
+              ),
+          }
+          expected_sha = os.environ["SHA"]
+          current_run_id = int(os.environ["CURRENT_RUN_ID"])
           skippable_required = {"DCO Sign-off"}
           non_failing_optional = {"success", "skipped", "neutral"}
           errors = []
 
-          if not runs:
+          if required != list(expected_provenance):
+              errors.append("required check order does not match its provenance contract")
+          if not check_runs:
               errors.append("no check-runs found on sha")
 
+          current_suite_id = current_run.get("check_suite_id")
+          current_identity = (
+              current_run.get("id"),
+              current_run.get("workflow_id"),
+              current_run.get("path"),
+              current_run.get("event"),
+              current_run.get("head_sha"),
+          )
+          expected_current_identity = (
+              current_run_id,
+              318521292,
+              ".github/workflows/release-tag.yml",
+              "workflow_dispatch",
+              expected_sha,
+          )
+          if current_identity != expected_current_identity:
+              errors.append(
+                  "current release-tag workflow provenance mismatch: "
+                  f"expected={expected_current_identity} actual={current_identity}"
+              )
+          release_tag_suite_ids = set()
+          if not isinstance(current_suite_id, int):
+              errors.append("current release-tag workflow has no check suite id")
+          else:
+              release_tag_suite_ids.add(current_suite_id)
+          expected_release_tag_run = (
+              318521292,
+              ".github/workflows/release-tag.yml",
+              "workflow_dispatch",
+              expected_sha,
+          )
+          for workflow in workflow_runs:
+              identity = (
+                  workflow.get("workflow_id"),
+                  workflow.get("path"),
+                  workflow.get("event"),
+                  workflow.get("head_sha"),
+              )
+              if identity == expected_release_tag_run:
+                  suite_id = workflow.get("check_suite_id")
+                  if isinstance(suite_id, int):
+                      release_tag_suite_ids.add(suite_id)
+                  else:
+                      errors.append(
+                          "release-tag workflow run has no check suite id: "
+                          f"{workflow.get('id')}"
+                      )
+
           for name in required:
-              run = runs.get(name)
+              matching_runs = runs_by_name.get(name, [])
+              if not matching_runs:
+                  errors.append(f"missing required check: {name}")
+                  continue
+              if len(matching_runs) != 1:
+                  errors.append(
+                      f"ambiguous required check: {name} "
+                      f"({len(matching_runs)} check-runs)"
+                  )
+                  continue
+
+              run = matching_runs[0]
               allowed_conclusions = (
                   {"success", "skipped"}
                   if name in skippable_required
                   else {"success"}
               )
-              if run is None:
-                  errors.append(f"missing required check: {name}")
-              elif run["status"] != "completed":
-                  errors.append(f"required check not completed: {name} (status={run['status']})")
+              if run["status"] != "completed":
+                  errors.append(
+                      f"required check not completed: {name} "
+                      f"(status={run['status']})"
+                  )
               elif run["conclusion"] not in allowed_conclusions:
-                  errors.append(f"required check not green: {name} (conclusion={run['conclusion']})")
+                  errors.append(
+                      f"required check not green: {name} "
+                      f"(conclusion={run['conclusion']})"
+                  )
+              if run.get("app_slug") != "github-actions":
+                  errors.append(
+                      f"required check has wrong app authority: {name} "
+                      f"(app={run.get('app_slug')})"
+                  )
+              if run.get("head_sha") != expected_sha:
+                  errors.append(
+                      f"required check has wrong head sha: {name} "
+                      f"(head={run.get('head_sha')})"
+                  )
 
-          for name, run in runs.items():
-              # Self-exclude this workflow's own job ("Mint release tag") — a gate must not read its own refusals as evidence.
-              if name == "Mint release tag":
+              suite_id = run.get("check_suite_id")
+              matching_workflows = workflows_by_suite.get(suite_id, [])
+              if len(matching_workflows) != 1:
+                  errors.append(
+                      f"required check has ambiguous workflow provenance: {name} "
+                      f"(suite={suite_id}, workflow-runs={len(matching_workflows)})"
+                  )
+                  continue
+              workflow = matching_workflows[0]
+              expected_workflow_id, expected_path, expected_event = (
+                  expected_provenance[name]
+              )
+              actual_identity = (
+                  workflow.get("workflow_id"),
+                  workflow.get("path"),
+                  workflow.get("event"),
+                  workflow.get("head_sha"),
+              )
+              expected_identity = (
+                  expected_workflow_id,
+                  expected_path,
+                  expected_event,
+                  expected_sha,
+              )
+              if actual_identity != expected_identity:
+                  errors.append(
+                      f"required check workflow provenance mismatch: {name} "
+                      f"expected={expected_identity} actual={actual_identity}"
+                  )
+              if (
+                  workflow.get("status") != "completed"
+                  or workflow.get("conclusion") != "success"
+              ):
+                  errors.append(
+                      f"required check workflow not green: {name} "
+                      f"(status={workflow.get('status')}, "
+                      f"conclusion={workflow.get('conclusion')})"
+                  )
+
+          for run in check_runs:
+              name = run["name"]
+              # Exclude only this exact workflow identity's tag-mint attempts,
+              # including a prior refusal on the same SHA. A same-name check
+              # from another workflow remains visible and must be green.
+              if (
+                  name == "Mint release tag"
+                  and run.get("check_suite_id") in release_tag_suite_ids
+              ):
                   continue
               if run["status"] != "completed":
-                  errors.append(f"check still in progress: {name} (status={run['status']})")
+                  errors.append(
+                      f"check still in progress: {name} (status={run['status']})"
+                  )
               elif run["conclusion"] not in non_failing_optional:
-                  errors.append(f"check not green: {name} (conclusion={run['conclusion']})")
+                  errors.append(
+                      f"check not green: {name} "
+                      f"(conclusion={run['conclusion']})"
+                  )
 
           if errors:
               print("::error::refusing — check verification failed:")
-              for err in errors:
-                  print(f"  - {err}")
+              for error in errors:
+                  print(f"  - {error}")
               sys.exit(1)
 
-          print(f"verified {len(required)} required checks green; "
-                f"{len(runs)} total checks, none failing or in progress")
+          print(
+              f"verified {len(required)} uniquely named required checks with "
+              f"workflow provenance; {len(check_runs)} total checks, none "
+              "failing or in progress"
+          )
           PY
 
       - name: Verify tag does not already exist

--- a/.github/workflows/release-tag.yml
+++ b/.github/workflows/release-tag.yml
@@ -143,8 +143,9 @@ jobs:
       - name: Verify required checks are green
         # Fail closed on the commit's check-runs. REQUIRED_CHECKS is the
         # presence-required release-critical set — a sha missing any of these is
-        # refused even if nothing failed. Each must be present and green
-        # (skipped/neutral allowed — DCO is skipped on a merged HEAD). Separately,
+        # refused even if nothing failed. Every required check must conclude
+        # success except DCO, which is allowed to report skipped because that
+        # pull-request-only job is inapplicable on a merged main HEAD. Separately,
         # no check anywhere may be failing or still in progress; the second loop
         # owns that present-check strictness, so this list need not mirror every
         # CI context. It is the main branch-protection required contexts plus the
@@ -180,7 +181,8 @@ jobs:
                       runs[name] = run
 
           required = [c.strip() for c in os.environ["REQUIRED_CHECKS"].splitlines() if c.strip()]
-          acceptable = {"success", "skipped", "neutral"}
+          skippable_required = {"DCO Sign-off"}
+          non_failing_optional = {"success", "skipped", "neutral"}
           errors = []
 
           if not runs:
@@ -188,11 +190,16 @@ jobs:
 
           for name in required:
               run = runs.get(name)
+              allowed_conclusions = (
+                  {"success", "skipped"}
+                  if name in skippable_required
+                  else {"success"}
+              )
               if run is None:
                   errors.append(f"missing required check: {name}")
               elif run["status"] != "completed":
                   errors.append(f"required check not completed: {name} (status={run['status']})")
-              elif run["conclusion"] not in acceptable:
+              elif run["conclusion"] not in allowed_conclusions:
                   errors.append(f"required check not green: {name} (conclusion={run['conclusion']})")
 
           for name, run in runs.items():
@@ -201,7 +208,7 @@ jobs:
                   continue
               if run["status"] != "completed":
                   errors.append(f"check still in progress: {name} (status={run['status']})")
-              elif run["conclusion"] not in acceptable:
+              elif run["conclusion"] not in non_failing_optional:
                   errors.append(f"check not green: {name} (conclusion={run['conclusion']})")
 
           if errors:

--- a/crates/kin-cli/src/commands/graph.rs
+++ b/crates/kin-cli/src/commands/graph.rs
@@ -1463,12 +1463,19 @@ mod tests {
     fn graph_source_fixture(source: Option<&[u8]>) -> GraphSourceFixture {
         let temp = tempfile::tempdir().unwrap();
         let repo = temp.path().join("repo");
+        let git_global_config = temp.path().join("git-global-config");
+        fs::write(&git_global_config, b"").unwrap();
         fs::create_dir(&repo).unwrap();
         let git = |args: &[&str]| {
             let output = Command::new("git")
+                // This fixture consumes the committed repository immediately.
+                // Prevent user-level maintenance settings from detaching work
+                // that can leave transient pack locks after `git commit` exits.
+                .args(["-c", "maintenance.auto=false", "-c", "gc.auto=0"])
                 .args(args)
                 .current_dir(&repo)
                 .env("GIT_CONFIG_NOSYSTEM", "1")
+                .env("GIT_CONFIG_GLOBAL", &git_global_config)
                 .output()
                 .unwrap();
             assert!(

--- a/scripts/test-release-workflow-authority.py
+++ b/scripts/test-release-workflow-authority.py
@@ -31,7 +31,152 @@ INSTALL_PS1 = ROOT / "scripts" / "install.ps1"
 HEALTH = ROOT / "crates" / "kin-cli" / "src" / "commands" / "health.rs"
 RUST_CACHE_ACTION = "Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4"
 MAIN_ONLY_CACHE_SAVE = "save-if: ${{ github.ref == 'refs/heads/main' }}"
+MAIN_ONLY_CACHE_SAVE_VALUE = "${{ github.ref == 'refs/heads/main' }}"
 RUST_CACHE_REFERENCE = re.compile(r"Swatinem/rust-cache@", re.IGNORECASE)
+CANONICAL_STEP_FIELDS = frozenset(
+    {
+        "continue-on-error",
+        "env",
+        "id",
+        "if",
+        "name",
+        "run",
+        "shell",
+        "timeout-minutes",
+        "uses",
+        "with",
+        "working-directory",
+    }
+)
+CACHE_AUTHORITY_ADVERSARIAL_WORKFLOWS = (
+    (
+        "escaped action key and value",
+        "canonical unquoted `key:` syntax",
+        r"""
+name: Escaped action
+on: push
+permissions:
+  contents: read
+jobs:
+  adversarial:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Hidden moving cache action
+        "u\u0073es": "Swatinem/rust-ca\u0063he@v2"
+        with:
+          save-if: ${{ true }}
+""",
+    ),
+    (
+        "aliased action value",
+        "direct action scalar",
+        r"""
+name: Aliased action
+on: push
+permissions:
+  contents: read
+env:
+  HIDDEN_CACHE: &hidden_cache "Swatinem/rust-ca\u0063he@v2"
+jobs:
+  adversarial:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Hidden alias cache action
+        uses: *hidden_cache
+        with:
+          save-if: ${{ true }}
+""",
+    ),
+    (
+        "multiline escaped action value",
+        "direct action scalar",
+        r"""
+name: Multiline escaped action
+on: push
+permissions:
+  contents: read
+jobs:
+  adversarial:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Hidden multiline cache action
+        uses: "Swatinem/rust-ca\
+          che@v2"
+        with:
+          save-if: ${{ true }}
+""",
+    ),
+    (
+        "flow-mapping action step",
+        "canonical block mapping",
+        r"""
+name: Flow action
+on: push
+permissions:
+  contents: read
+jobs:
+  adversarial:
+    runs-on: ubuntu-latest
+    steps:
+      - {name: Hidden flow cache action, "u\u0073es": "Swatinem/rust-ca\u0063he@v2", with: {save-if: "${{ true }}"}}
+""",
+    ),
+    (
+        "escaped save-if key",
+        "canonical unquoted `key:` syntax",
+        r"""
+name: Escaped cache policy
+on: push
+permissions:
+  contents: read
+jobs:
+  adversarial:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Hidden cache save policy
+        uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4
+        with:
+          "save\u002dif": ${{ true }}
+""",
+    ),
+    (
+        "aliased save-if value",
+        "must be the exact main-only scalar",
+        r"""
+name: Aliased cache policy
+on: push
+permissions:
+  contents: read
+env:
+  HIDDEN_SAVE: &hidden_save "${{ true }}"
+jobs:
+  adversarial:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Hidden aliased save policy
+        uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4
+        with:
+          save-if: *hidden_save
+""",
+    ),
+    (
+        "flow-mapping with policy",
+        "with field must be a canonical block mapping",
+        r"""
+name: Flow cache policy
+on: push
+permissions:
+  contents: read
+jobs:
+  adversarial:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Hidden flow save policy
+        uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4
+        with: {save-if: "${{ true }}"}
+""",
+    ),
+)
 REQUIRED_RELEASE_CHECKS = (
     "Check & Test (ubuntu-latest)",
     "Check & Test (macos-latest)",
@@ -827,145 +972,295 @@ def create_docs_only_git_fixture(directory: Path) -> tuple[Path, str, str]:
     return repository, base_sha, head_sha
 
 
-def yaml_uses_scalar(line: str) -> str | None:
-    """Read the simple scalar forms accepted for a workflow step's `uses` key."""
+def workflow_structural_lines(content: str) -> list[tuple[int, int, str]]:
+    """Return active YAML lines while excluding literal and folded bodies."""
 
-    if not line.strip() or line.lstrip().startswith("#"):
-        return None
-    match = re.match(
-        r"""^\s*(?:-\s*)?uses:\s*(?:"([^"\r\n]+)"|'([^'\r\n]+)'|([^#\s]+))"""
-        r"""\s*(?:#.*)?$""",
-        line,
+    structural: list[tuple[int, int, str]] = []
+    block_scalar_indent: int | None = None
+    block_scalar = re.compile(
+        r"^(?:-\s+)?[A-Za-z0-9_-]+:\s*[|>]"
+        r"(?:[+-]?[1-9]?|[1-9][+-]?)?\s*(?:#.*)?$"
+    )
+    for line_number, line in enumerate(content.splitlines(), start=1):
+        if block_scalar_indent is not None:
+            if not line.strip():
+                continue
+            indent = len(line) - len(line.lstrip())
+            if indent > block_scalar_indent:
+                continue
+            block_scalar_indent = None
+
+        if not line.strip() or line.lstrip().startswith("#"):
+            continue
+        indentation = line[: len(line) - len(line.lstrip())]
+        if "\t" in indentation:
+            raise AssertionError(
+                f"workflow YAML indentation must use spaces: line {line_number}"
+            )
+        stripped = line.lstrip()
+        indent = len(indentation)
+        structural.append((line_number, indent, stripped))
+        if block_scalar.fullmatch(stripped):
+            block_scalar_indent = indent
+    return structural
+
+
+def canonical_step_field(
+    workflow: Path,
+    line_number: int,
+    source: str,
+) -> tuple[str, str]:
+    """Parse one canonical block-style workflow-step field."""
+
+    match = re.fullmatch(
+        r"(?P<key>[A-Za-z][A-Za-z0-9-]*):(?P<value>.*)",
+        source,
     )
     if match is None:
-        if re.match(r"^\s*(?:-\s*)?uses:\s*", line):
-            raise AssertionError(
-                "workflow uses scalar must be a single plain or quoted value"
-            )
-        return None
-    double_quoted, single_quoted, plain = match.groups()
-    if double_quoted is not None:
-        if "\\" in double_quoted:
-            raise AssertionError(
-                "workflow uses scalar must not contain YAML escape sequences"
-            )
-        return double_quoted
-    if single_quoted is not None:
-        return single_quoted
-    assert plain is not None
-    return plain
+        raise AssertionError(
+            f"{workflow.name}:{line_number} workflow step fields must use "
+            "canonical unquoted `key:` syntax in a canonical block mapping"
+        )
+    key = match.group("key")
+    if key not in CANONICAL_STEP_FIELDS:
+        raise AssertionError(
+            f"{workflow.name}:{line_number} workflow step field is not in the "
+            f"canonical Actions grammar: {key}"
+        )
+    return key, match.group("value").strip()
 
 
-def rust_cache_step_bounds(lines: list[str], uses_line: int) -> tuple[int, int]:
-    uses = lines[uses_line]
-    inline = re.match(r"^(\s*)-\s+uses:\s*", uses)
-    if inline:
-        step_start = uses_line
-        step_indent = len(inline.group(1))
-    else:
-        uses_indent = len(uses) - len(uses.lstrip())
-        step_indent = uses_indent - 2
-        step_start = -1
-        for index in range(uses_line - 1, -1, -1):
-            line = lines[index]
-            stripped = line.lstrip()
-            if not stripped or stripped.startswith("#"):
-                continue
-            indent = len(line) - len(stripped)
-            if indent < step_indent:
-                break
-            if indent == step_indent and re.match(r"-\s+", stripped):
-                step_start = index
-                break
-        if step_start < 0:
-            raise AssertionError(
-                "rust-cache use is not nested in a structurally identifiable step"
-            )
+def canonical_workflow_steps(
+    workflow: Path,
+    content: str,
+) -> list[
+    tuple[
+        dict[str, tuple[int, int, str]],
+        list[tuple[int, int, str]],
+    ]
+]:
+    """Inventory steps under a fail-closed, actionlint-compatible block grammar."""
 
-    step_end = len(lines)
-    for index in range(step_start + 1, len(lines)):
-        line = lines[index]
-        stripped = line.lstrip()
-        if not stripped or stripped.startswith("#"):
+    structural = workflow_structural_lines(content)
+    steps: list[
+        tuple[
+            dict[str, tuple[int, int, str]],
+            list[tuple[int, int, str]],
+        ]
+    ] = []
+
+    for steps_index, (steps_line, steps_indent, stripped) in enumerate(structural):
+        steps_match = re.fullmatch(r"steps:(?P<value>.*)", stripped)
+        if steps_match is None:
             continue
-        indent = len(line) - len(stripped)
-        if indent < step_indent or (
-            indent == step_indent and re.match(r"-\s+", stripped)
-        ):
-            step_end = index
+        steps_value = steps_match.group("value").strip()
+        if steps_value and not steps_value.startswith("#"):
+            raise AssertionError(
+                f"{workflow.name}:{steps_line} workflow steps must use a "
+                "canonical block sequence"
+            )
+        end = len(structural)
+        for index in range(steps_index + 1, len(structural)):
+            if structural[index][1] <= steps_indent:
+                end = index
+                break
+        children = structural[steps_index + 1 : end]
+        if not children:
+            raise AssertionError(
+                f"{workflow.name} steps mapping must contain canonical step entries"
+            )
+
+        list_indent = steps_indent + 2
+        field_indent = list_indent + 2
+        fields: dict[str, tuple[int, int, str]] | None = None
+        step_lines: list[tuple[int, int, str]] = []
+
+        def finish_step() -> None:
+            nonlocal fields, step_lines
+            if fields is None:
+                return
+            execution_fields = {"run", "uses"}.intersection(fields)
+            if len(execution_fields) != 1:
+                raise AssertionError(
+                    f"{workflow.name}:{step_lines[0][0]} canonical workflow "
+                    "steps must contain exactly one run or uses field"
+                )
+            steps.append((fields, step_lines))
+            fields = None
+            step_lines = []
+
+        for line_number, indent, child in children:
+            if indent == list_indent:
+                finish_step()
+                if not child.startswith("- "):
+                    raise AssertionError(
+                        f"{workflow.name}:{line_number} workflow steps must use "
+                        "a canonical block mapping for every sequence item"
+                    )
+                fields = {}
+                step_lines = [(line_number, indent, child)]
+                key, value = canonical_step_field(
+                    workflow,
+                    line_number,
+                    child[2:],
+                )
+                fields[key] = (line_number, field_indent, value)
+                continue
+
+            if fields is None:
+                raise AssertionError(
+                    f"{workflow.name}:{line_number} workflow step entries must "
+                    "start at canonical two-space child indentation"
+                )
+            step_lines.append((line_number, indent, child))
+            if indent == field_indent:
+                key, value = canonical_step_field(workflow, line_number, child)
+                if key in fields:
+                    raise AssertionError(
+                        f"{workflow.name}:{line_number} workflow step contains "
+                        f"a duplicate {key} field"
+                    )
+                fields[key] = (line_number, field_indent, value)
+            elif indent < field_indent:
+                raise AssertionError(
+                    f"{workflow.name}:{line_number} workflow step fields must "
+                    "use canonical two-space child indentation"
+                )
+        finish_step()
+    return steps
+
+
+def yaml_uses_scalar(workflow: Path, line_number: int, value: str) -> str:
+    """Decode the direct scalar forms permitted for every action reference."""
+
+    double_quoted = re.fullmatch(r'"([^"\r\n]*)"\s*(?:#.*)?', value)
+    if double_quoted is not None:
+        action = double_quoted.group(1)
+        if "\\" in action:
+            raise AssertionError(
+                f"{workflow.name}:{line_number} workflow uses scalar must not "
+                "contain YAML escape sequences"
+            )
+        return action
+
+    single_quoted = re.fullmatch(r"'([^'\r\n]*)'\s*(?:#.*)?", value)
+    if single_quoted is not None:
+        return single_quoted.group(1)
+
+    plain = re.fullmatch(r"""([^#\s'"\\]+)\s*(?:#.*)?""", value)
+    if plain is None or plain.group(1).startswith(("*", "&", "!", "{", "[", "|", ">")):
+        raise AssertionError(
+            f"{workflow.name}:{line_number} workflow uses must be one direct "
+            "action scalar without aliases, anchors, tags, or flow values"
+        )
+    return plain.group(1)
+
+
+def canonical_job_action_uses(workflow: Path, content: str) -> list[str]:
+    """Inventory reusable-workflow references alongside action-step references."""
+
+    actions: list[str] = []
+    for block in workflow_job_blocks(content).values():
+        for key, value in job_top_level_mapping_fields(block):
+            if key == "uses":
+                actions.append(yaml_uses_scalar(workflow, 0, value))
+    return actions
+
+
+def canonical_child_mapping(
+    workflow: Path,
+    step_lines: list[tuple[int, int, str]],
+    parent_line: int,
+    parent_indent: int,
+) -> dict[str, tuple[int, str]]:
+    """Parse a step field's canonical two-space-indented child mapping."""
+
+    fields: dict[str, tuple[int, str]] = {}
+    expected_indent = parent_indent + 2
+    for line_number, indent, source in step_lines:
+        if line_number <= parent_line:
+            continue
+        if indent <= parent_indent:
             break
-    return step_start, step_end
+        if indent != expected_indent:
+            raise AssertionError(
+                f"{workflow.name}:{line_number} workflow with inputs must use "
+                "canonical two-space child indentation"
+            )
+        match = re.fullmatch(
+            r"(?P<key>[A-Za-z][A-Za-z0-9_-]*):(?P<value>.*)",
+            source,
+        )
+        if match is None:
+            raise AssertionError(
+                f"{workflow.name}:{line_number} workflow with inputs must use "
+                "canonical unquoted `key:` syntax"
+            )
+        key = match.group("key")
+        if key in fields:
+            raise AssertionError(
+                f"{workflow.name}:{line_number} workflow with mapping contains "
+                f"a duplicate {key} input"
+            )
+        fields[key] = (line_number, match.group("value").strip())
+    return fields
 
 
 def assert_rust_cache_steps(workflows: dict[Path, str]) -> None:
     rust_cache_uses = 0
     for workflow, content in sorted(workflows.items()):
-        textual_occurrences = len(RUST_CACHE_REFERENCE.findall(content))
-        accounted_occurrences = 0
-        lines = content.splitlines()
-        for uses_line, line in enumerate(lines):
-            action = yaml_uses_scalar(line)
-            if action is None or RUST_CACHE_REFERENCE.search(action) is None:
+        for fields, step_lines in canonical_workflow_steps(workflow, content):
+            uses_field = fields.get("uses")
+            if uses_field is None:
                 continue
-            accounted_occurrences += 1
+            uses_line, _, uses_value = uses_field
+            action = yaml_uses_scalar(workflow, uses_line, uses_value)
+            if RUST_CACHE_REFERENCE.search(action) is None:
+                continue
             rust_cache_uses += 1
             if action != RUST_CACHE_ACTION:
                 raise AssertionError(
                     f"{workflow.name} uses rust-cache at an unpinned ref"
                 )
 
-            step_start, step_end = rust_cache_step_bounds(lines, uses_line)
-            step = lines[step_start:step_end]
-            with_lines = []
-            save_lines = []
-            for relative_index, step_line in enumerate(step):
-                active = step_line.lstrip()
-                if not active or active.startswith("#"):
-                    continue
-                with_match = re.match(r"^(\s*)with:\s*(?:#.*)?$", step_line)
-                if with_match:
-                    with_lines.append((relative_index, len(with_match.group(1))))
-                save_match = re.match(
-                    r"^(\s*)save-if:\s*(.*?)\s*$",
-                    step_line,
-                )
-                if save_match:
-                    value = save_match.group(2).split(" #", 1)[0].rstrip()
-                    save_lines.append((relative_index, len(save_match.group(1)), value))
-
-            if len(with_lines) != 1 or len(save_lines) != 1:
+            with_field = fields.get("with")
+            if with_field is None:
                 raise AssertionError(
-                    f"{workflow.name} rust-cache step must contain exactly one "
+                    f"{workflow.name} rust-cache step must contain one canonical "
                     "with mapping and one main-only save-if"
                 )
-            with_line, with_indent = with_lines[0]
-            save_line, save_indent, save_value = save_lines[0]
-            with_end = len(step)
-            for relative_index in range(with_line + 1, len(step)):
-                candidate = step[relative_index]
-                active = candidate.lstrip()
-                if not active or active.startswith("#"):
-                    continue
-                indent = len(candidate) - len(active)
-                if indent <= with_indent:
-                    with_end = relative_index
-                    break
-            if (
-                save_line <= with_line
-                or save_line >= with_end
-                or save_indent != with_indent + 2
-                or f"save-if: {save_value}" != MAIN_ONLY_CACHE_SAVE
-            ):
+            with_line, with_indent, with_value = with_field
+            if with_value and not with_value.startswith("#"):
                 raise AssertionError(
-                    f"{workflow.name} rust-cache save-if is not structurally "
-                    "bound to its with mapping or is not main-only"
+                    f"{workflow.name} rust-cache with field must be a canonical "
+                    "block mapping"
+                )
+            inputs = canonical_child_mapping(
+                workflow,
+                step_lines,
+                with_line,
+                with_indent,
+            )
+            save = inputs.get("save-if")
+            if save is None:
+                raise AssertionError(
+                    f"{workflow.name} rust-cache step must contain one canonical "
+                    "with mapping and one main-only save-if"
+                )
+            _, save_value = save
+            save_value = save_value.split(" #", 1)[0].rstrip()
+            if save_value != MAIN_ONLY_CACHE_SAVE_VALUE:
+                raise AssertionError(
+                    f"{workflow.name} rust-cache save-if must be the exact "
+                    "main-only scalar"
                 )
 
-        if textual_occurrences != accounted_occurrences:
-            raise AssertionError(
-                f"{workflow.name} contains a rust-cache textual occurrence that "
-                "is not an accounted uses scalar"
-            )
+        for action in canonical_job_action_uses(workflow, content):
+            if RUST_CACHE_REFERENCE.search(action) is not None:
+                raise AssertionError(
+                    f"{workflow.name} rust-cache use must be a canonical "
+                    "workflow action step, not a reusable-workflow job"
+                )
 
     if rust_cache_uses == 0:
         raise AssertionError("no pinned rust-cache steps found")
@@ -2867,7 +3162,7 @@ def main() -> None:
     )
     expect_assertion(
         "rust-cache save-if moved from with to an env field in the same step",
-        "not structurally bound to its with mapping",
+        "one canonical with mapping and one main-only save-if",
         lambda: assert_rust_cache_steps(same_step_field),
     )
 
@@ -2936,15 +3231,27 @@ jobs:
             lambda escaped_use=escaped_use: assert_rust_cache_steps(escaped_use),
         )
 
-    unaccounted_text = dict(workflow_sources)
-    unaccounted_text[ci_path] += (
-        f"\nenv:\n  UNACCOUNTED_CACHE_ACTION: {RUST_CACHE_ACTION}\n"
+    for index, (label, expected_error, fixture) in enumerate(
+        CACHE_AUTHORITY_ADVERSARIAL_WORKFLOWS,
+        start=1,
+    ):
+        adversarial = dict(workflow_sources)
+        adversarial[WORKFLOWS / f"cache-authority-adversarial-{index}.yml"] = (
+            textwrap.dedent(fixture).lstrip()
+        )
+        expect_assertion(
+            label,
+            expected_error,
+            lambda adversarial=adversarial: assert_rust_cache_steps(adversarial),
+        )
+
+    non_action_text = dict(workflow_sources)
+    non_action_text[ci_path] = non_action_text[ci_path].replace(
+        "jobs:\n",
+        f"env:\n  UNACCOUNTED_CACHE_ACTION: {RUST_CACHE_ACTION}\n\njobs:\n",
+        1,
     )
-    expect_assertion(
-        "rust-cache text outside an accounted uses scalar",
-        "not an accounted uses scalar",
-        lambda: assert_rust_cache_steps(unaccounted_text),
-    )
+    assert_rust_cache_steps(non_action_text)
 
     for obsolete in (
         ROOT / "scripts" / "promote-npm-release.sh",

--- a/scripts/test-release-workflow-authority.py
+++ b/scripts/test-release-workflow-authority.py
@@ -185,12 +185,66 @@ REQUIRED_RELEASE_CHECKS = (
     "gitleaks (full history)",
     "Windows installer + vector-free release build",
 )
+DOCS_ONLY_WORKFLOW_HEADER = textwrap.dedent(
+    """\
+    name: CI
+    on:
+      push:
+        branches: [main]
+      pull_request:
+        branches: [main]
+      repository_dispatch:
+        types: [dependency-updated]
+    permissions:
+      contents: read
+    concurrency:
+      group: ${{ github.workflow }}-${{ github.ref }}
+      cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
+    env:
+      CARGO_TERM_COLOR: always
+      RUSTFLAGS: "-D warnings"
+    """
+).rstrip()
 DOCS_ONLY_CLASSIFIER_SHELL = textwrap.dedent(
     """\
     set -euo pipefail
     docs_only=false
     if [ "$EVENT_NAME" = "pull_request" ]; then
-      changed="$(git diff --name-only "$BASE_SHA...$HEAD_SHA")"
+      changed="$(
+        /usr/bin/env -i \\
+          HOME=/dev/null \\
+          PATH=/usr/bin:/bin \\
+          LC_ALL=C \\
+          GIT_CONFIG_NOSYSTEM=1 \\
+          GIT_CONFIG_SYSTEM=/dev/null \\
+          GIT_CONFIG_GLOBAL=/dev/null \\
+          GIT_CONFIG_COUNT=0 \\
+          GIT_ATTR_NOSYSTEM=1 \\
+          GIT_PAGER=cat \\
+          GIT_TERMINAL_PROMPT=0 \\
+          /usr/bin/git \\
+            --no-pager \\
+            --no-replace-objects \\
+            --no-lazy-fetch \\
+            --no-optional-locks \\
+            --literal-pathspecs \\
+            --git-dir="$WORKSPACE/.git" \\
+            --work-tree="$WORKSPACE" \\
+            -c core.attributesFile=/dev/null \\
+            -c core.fsmonitor=false \\
+            -c diff.external= \\
+            -c diff.renames=false \\
+            -c diff.ignoreSubmodules=none \\
+            diff \\
+            --no-ext-diff \\
+            --no-textconv \\
+            --no-renames \\
+            --ignore-submodules=none \\
+            --submodule=short \\
+            --name-only \\
+            "$BASE_SHA...$HEAD_SHA" \\
+            --
+      )"
       if [ -n "$changed" ]; then
         docs_only=true
         while IFS= read -r path; do
@@ -222,7 +276,13 @@ DOCS_ONLY_CLASSIFIER_JOB = textwrap.dedent(
           id: classify
           shell: /usr/bin/bash --noprofile --norc -p -e -u -o pipefail {0}
           env:
+            PATH: /usr/bin:/bin
             BASH_ENV: ""
+            ENV: ""
+            LD_AUDIT: ""
+            LD_LIBRARY_PATH: /dev/null
+            LD_PRELOAD: ""
+            WORKSPACE: ${{ github.workspace }}
             EVENT_NAME: ${{ github.event_name }}
             BASE_SHA: ${{ github.event.pull_request.base.sha }}
             HEAD_SHA: ${{ github.event.pull_request.head.sha }}
@@ -230,7 +290,41 @@ DOCS_ONLY_CLASSIFIER_JOB = textwrap.dedent(
             set -euo pipefail
             docs_only=false
             if [ "$EVENT_NAME" = "pull_request" ]; then
-              changed="$(git diff --name-only "$BASE_SHA...$HEAD_SHA")"
+              changed="$(
+                /usr/bin/env -i \\
+                  HOME=/dev/null \\
+                  PATH=/usr/bin:/bin \\
+                  LC_ALL=C \\
+                  GIT_CONFIG_NOSYSTEM=1 \\
+                  GIT_CONFIG_SYSTEM=/dev/null \\
+                  GIT_CONFIG_GLOBAL=/dev/null \\
+                  GIT_CONFIG_COUNT=0 \\
+                  GIT_ATTR_NOSYSTEM=1 \\
+                  GIT_PAGER=cat \\
+                  GIT_TERMINAL_PROMPT=0 \\
+                  /usr/bin/git \\
+                    --no-pager \\
+                    --no-replace-objects \\
+                    --no-lazy-fetch \\
+                    --no-optional-locks \\
+                    --literal-pathspecs \\
+                    --git-dir="$WORKSPACE/.git" \\
+                    --work-tree="$WORKSPACE" \\
+                    -c core.attributesFile=/dev/null \\
+                    -c core.fsmonitor=false \\
+                    -c diff.external= \\
+                    -c diff.renames=false \\
+                    -c diff.ignoreSubmodules=none \\
+                    diff \\
+                    --no-ext-diff \\
+                    --no-textconv \\
+                    --no-renames \\
+                    --ignore-submodules=none \\
+                    --submodule=short \\
+                    --name-only \\
+                    "$BASE_SHA...$HEAD_SHA" \\
+                    --
+              )"
               if [ -n "$changed" ]; then
                 docs_only=true
                 while IFS= read -r path; do
@@ -534,9 +628,28 @@ def classifier_active_job_source(classifier: str) -> str:
     return "\n".join(active_lines)
 
 
-def assert_docs_only_classifier_guard(classifier: str) -> None:
-    """Require the exact reviewed job and shell, with comments as the only slack."""
+def workflow_active_header_source(workflow: str) -> str:
+    """Return the active workflow-level contract above the jobs mapping."""
 
+    marker = "\njobs:\n"
+    if workflow.count(marker) != 1:
+        raise AssertionError(
+            "docs_only authority requires exactly one canonical jobs mapping"
+        )
+    return classifier_active_job_source(workflow.split(marker, 1)[0])
+
+
+def assert_docs_only_classifier_guard(workflow: str) -> None:
+    """Require the exact workflow header, classifier job, and classifier shell."""
+
+    if workflow_active_header_source(workflow) != DOCS_ONLY_WORKFLOW_HEADER:
+        raise AssertionError(
+            "diff classifier workflow header must exactly match the closed-form "
+            "process environment authority contract"
+        )
+    classifier = workflow_job_blocks(workflow).get("changes")
+    if classifier is None:
+        raise AssertionError("diff classifier workflow must contain the changes job")
     job_source = classifier_active_job_source(classifier)
     if job_source != DOCS_ONLY_CLASSIFIER_JOB:
         raise AssertionError(
@@ -792,6 +905,7 @@ def execute_docs_only_classifier(
                 "EVENT_NAME": "push",
                 "BASE_SHA": "unused-on-push",
                 "HEAD_SHA": "unused-on-push",
+                "WORKSPACE": str(cwd),
                 "GITHUB_OUTPUT": str(output),
             }
         )
@@ -835,7 +949,7 @@ def execute_docs_only_classifier(
 
 def assert_classifier_bypass_rejected(
     label: str,
-    classifier: str,
+    workflow: str,
     *,
     execute: bool = True,
 ) -> None:
@@ -843,12 +957,13 @@ def assert_classifier_bypass_rejected(
 
     expect_assertion(
         label,
-        "exactly match the closed-form docs_only authority contract",
-        lambda: assert_docs_only_classifier_guard(classifier),
+        "closed-form",
+        lambda: assert_docs_only_classifier_guard(workflow),
     )
     if not execute:
         return
 
+    classifier = workflow_job_blocks(workflow)["changes"]
     result, outputs = execute_docs_only_classifier(classifier)
     assert_classifier_execution_won(label, result, outputs)
 
@@ -894,6 +1009,33 @@ def assert_classifier_execution_failed_closed(
         raise AssertionError(f"classifier did not fail closed: {label}: {outputs}")
 
 
+def assert_classifier_execution_code_bearing(
+    label: str,
+    result: subprocess.CompletedProcess[str],
+    outputs: list[str],
+    *,
+    changed_paths: tuple[str, ...],
+) -> None:
+    """Prove the real classifier rejects and reports a code-bearing diff."""
+
+    if result.returncode != 0:
+        raise AssertionError(
+            f"classifier code-bearing proof did not execute: {label}: "
+            f"{result.stdout}{result.stderr}"
+        )
+    if outputs != ["docs_only=false"]:
+        raise AssertionError(
+            f"classifier admitted a code-bearing diff: {label}: {outputs}"
+        )
+    reported = set(result.stdout.splitlines())
+    missing = [path for path in changed_paths if path not in reported]
+    if missing:
+        raise AssertionError(
+            f"classifier omitted code-bearing paths: {label}: {missing}: "
+            f"{result.stdout}"
+        )
+
+
 def bash_supports_nameref() -> bool:
     """Return whether the local bash can execute the hosted nameref bypass."""
 
@@ -914,46 +1056,69 @@ def bash_supports_nameref() -> bool:
     return probe.returncode == 0
 
 
+def git_fixture_environment(directory: Path) -> dict[str, str]:
+    """Return a process and Git-authority-clean fixture environment."""
+
+    environment = {
+        key: value
+        for key, value in os.environ.items()
+        if not key.startswith("GIT_")
+        and key not in {"LD_AUDIT", "LD_LIBRARY_PATH", "LD_PRELOAD"}
+    }
+    global_config = directory / "git-global-config"
+    global_config.write_text("", encoding="utf-8")
+    environment.update(
+        {
+            "PATH": "/usr/bin:/bin",
+            "GIT_CONFIG_NOSYSTEM": "1",
+            "GIT_CONFIG_SYSTEM": "/dev/null",
+            "GIT_CONFIG_GLOBAL": str(global_config),
+            "GIT_CONFIG_COUNT": "0",
+            "GIT_ATTR_NOSYSTEM": "1",
+        }
+    )
+    return environment
+
+
+def run_fixture_git(
+    repository: Path,
+    environment: dict[str, str],
+    *args: str,
+) -> str:
+    """Run the reviewed hosted-runner Git path for a hermetic fixture."""
+
+    result = subprocess.run(
+        [
+            "/usr/bin/git",
+            "-c",
+            "maintenance.auto=false",
+            "-c",
+            "gc.auto=0",
+            *args,
+        ],
+        cwd=repository,
+        env=environment,
+        capture_output=True,
+        text=True,
+        timeout=10,
+        check=False,
+    )
+    if result.returncode != 0:
+        raise AssertionError(
+            f"classifier Git fixture failed: git {args}: {result.stdout}{result.stderr}"
+        )
+    return result.stdout.strip()
+
+
 def create_docs_only_git_fixture(directory: Path) -> tuple[Path, str, str]:
     """Create a hermetic two-commit repository with one docs-only change."""
 
     repository = directory / "repository"
     repository.mkdir()
-    global_config = directory / "git-global-config"
-    global_config.write_text("", encoding="utf-8")
-    environment = {
-        key: value for key, value in os.environ.items() if not key.startswith("GIT_")
-    }
-    environment.update(
-        {
-            "GIT_CONFIG_NOSYSTEM": "1",
-            "GIT_CONFIG_GLOBAL": str(global_config),
-        }
-    )
+    environment = git_fixture_environment(directory)
 
     def git(*args: str) -> str:
-        result = subprocess.run(
-            [
-                "git",
-                "-c",
-                "maintenance.auto=false",
-                "-c",
-                "gc.auto=0",
-                *args,
-            ],
-            cwd=repository,
-            env=environment,
-            capture_output=True,
-            text=True,
-            timeout=10,
-            check=False,
-        )
-        if result.returncode != 0:
-            raise AssertionError(
-                f"docs-only Git fixture failed: git {args}: "
-                f"{result.stdout}{result.stderr}"
-            )
-        return result.stdout.strip()
+        return run_fixture_git(repository, environment, *args)
 
     git("init", "--initial-branch=main")
     git("config", "user.email", "kin@example.invalid")
@@ -970,6 +1135,119 @@ def create_docs_only_git_fixture(directory: Path) -> tuple[Path, str, str]:
     git("commit", "-m", "docs only")
     head_sha = git("rev-parse", "HEAD")
     return repository, base_sha, head_sha
+
+
+def create_classifier_authority_attack_fixture(
+    directory: Path,
+    base_workflow: str,
+    hostile_workflow: str,
+) -> tuple[Path, str, str, dict[str, str], tuple[Path, ...]]:
+    """Create a code diff plus executable, Git-env, and replace-object attacks."""
+
+    repository = directory / "authority-repository"
+    repository.mkdir()
+    environment = git_fixture_environment(directory)
+
+    def git(*args: str) -> str:
+        return run_fixture_git(repository, environment, *args)
+
+    git("init", "--initial-branch=main")
+    git("config", "user.email", "kin@example.invalid")
+    git("config", "user.name", "Kin")
+    (repository / "README.md").write_text("base\n", encoding="utf-8")
+    source = repository / "src"
+    source.mkdir()
+    (source / "lib.rs").write_text("pub fn authority() -> bool { true }\n")
+    workflows = repository / ".github" / "workflows"
+    workflows.mkdir(parents=True)
+    (workflows / "ci.yml").write_text(base_workflow, encoding="utf-8")
+    git("add", "--all")
+    git("commit", "-m", "seed")
+    base_sha = git("rev-parse", "HEAD")
+
+    docs = repository / "docs"
+    docs.mkdir()
+    (docs / "release-bot.md").write_text("docs-only\n", encoding="utf-8")
+    git("add", "--all")
+    git("commit", "-m", "docs only")
+    docs_sha = git("rev-parse", "HEAD")
+
+    (source / "lib.rs").write_text("pub fn authority() -> bool { false }\n")
+    (workflows / "ci.yml").write_text(hostile_workflow, encoding="utf-8")
+    (repository / ".gitattributes").write_text(
+        "src/lib.rs diff=hostile\n",
+        encoding="utf-8",
+    )
+    attack = repository / "attack"
+    attack.mkdir()
+    path_git = attack / "git"
+    path_git.write_text(
+        "#!/bin/sh\nprintf '%s\\n' docs/decoy.md\n",
+        encoding="utf-8",
+    )
+    path_git.chmod(0o755)
+    external_marker = directory / "external-diff-ran"
+    external_diff = attack / "external-diff"
+    external_diff.write_text(
+        f"#!/bin/sh\n: > {external_marker!s}\nexit 0\n",
+        encoding="utf-8",
+    )
+    external_diff.chmod(0o755)
+    textconv_marker = directory / "textconv-ran"
+    textconv = attack / "textconv"
+    textconv.write_text(
+        f"#!/bin/sh\n: > {textconv_marker!s}\nprintf decoy\n",
+        encoding="utf-8",
+    )
+    textconv.chmod(0o755)
+    hostile_config = attack / "gitconfig"
+    hostile_config.write_text(
+        "[diff]\n"
+        f"\texternal = {external_diff!s}\n"
+        "\trenames = true\n"
+        '[diff "hostile"]\n'
+        f"\ttextconv = {textconv!s}\n",
+        encoding="utf-8",
+    )
+    git("add", "--all")
+    git("commit", "-m", "code and workflow attack")
+    head_sha = git("rev-parse", "HEAD")
+    git("replace", head_sha, docs_sha)
+
+    hostile_environment = {
+        "PATH": f"{attack!s}:/usr/local/bin:/usr/bin:/bin",
+        "HOME": str(attack),
+        "XDG_CONFIG_HOME": str(attack),
+        "LD_LIBRARY_PATH": str(attack),
+        "GIT_DIR": str(attack / "decoy.git"),
+        "GIT_WORK_TREE": str(attack),
+        "GIT_INDEX_FILE": str(attack / "index"),
+        "GIT_COMMON_DIR": str(attack / "common"),
+        "GIT_OBJECT_DIRECTORY": str(attack / "objects"),
+        "GIT_ALTERNATE_OBJECT_DIRECTORIES": str(attack / "alternate-objects"),
+        "GIT_EXEC_PATH": str(attack),
+        "GIT_CONFIG": str(hostile_config),
+        "GIT_CONFIG_NOSYSTEM": "0",
+        "GIT_CONFIG_SYSTEM": str(hostile_config),
+        "GIT_CONFIG_GLOBAL": str(hostile_config),
+        "GIT_CONFIG_COUNT": "2",
+        "GIT_CONFIG_KEY_0": "diff.external",
+        "GIT_CONFIG_VALUE_0": str(external_diff),
+        "GIT_CONFIG_KEY_1": "diff.hostile.textconv",
+        "GIT_CONFIG_VALUE_1": str(textconv),
+        "GIT_CONFIG_PARAMETERS": "'diff.renames'='true'",
+        "GIT_ATTR_NOSYSTEM": "0",
+        "GIT_EXTERNAL_DIFF": str(external_diff),
+        "GIT_DIFF_OPTS": "--unified=0",
+        "GIT_REPLACE_REF_BASE": "refs/replace",
+    }
+    return (
+        repository,
+        base_sha,
+        head_sha,
+        hostile_environment,
+        (external_marker, textconv_marker),
+    )
 
 
 def workflow_structural_lines(content: str) -> list[tuple[int, int, str]]:
@@ -2353,7 +2631,7 @@ def main() -> None:
     classifier_start = ci_workflow.index("  changes:")
     classifier_end = ci_workflow.index("\n  check-docs-only:", classifier_start)
     classifier = ci_workflow[classifier_start:classifier_end]
-    assert_docs_only_classifier_guard(classifier)
+    assert_docs_only_classifier_guard(ci_workflow)
     assert_check_consumer_authority(ci_workflow)
     consumer_blocks = workflow_job_blocks(ci_workflow)
     docs_only_check = consumer_blocks["check-docs-only"]
@@ -2521,14 +2799,136 @@ def main() -> None:
                 f"diff classifier falsification could not identify {label}"
             )
         mutant = classifier.replace(old, new, 1)
+        mutant_workflow = ci_workflow.replace(classifier, mutant, 1)
         expect_assertion(
             label,
             "exactly match the closed-form docs_only authority contract",
-            lambda mutant=mutant: assert_docs_only_classifier_guard(mutant),
+            lambda mutant_workflow=mutant_workflow: assert_docs_only_classifier_guard(
+                mutant_workflow
+            ),
         )
 
+    workflow_environment_needle = '  RUSTFLAGS: "-D warnings"'
+    if ci_workflow.count(workflow_environment_needle) != 1:
+        raise AssertionError(
+            "diff classifier falsification could not identify workflow environment"
+        )
+    workflow_environment_attacks = (
+        (
+            "workflow PATH resolves Git from a checked-out executable",
+            "  PATH: ${{ github.workspace }}/attack:/usr/local/bin:/usr/bin:/bin",
+        ),
+        (
+            "workflow Git repository and index authority redirected",
+            "  GIT_DIR: ${{ github.workspace }}/attack/decoy.git\n"
+            "  GIT_WORK_TREE: ${{ github.workspace }}/attack\n"
+            "  GIT_INDEX_FILE: ${{ github.workspace }}/attack/index",
+        ),
+        (
+            "workflow Git configuration and external diff authority injected",
+            '  GIT_CONFIG_NOSYSTEM: "0"\n'
+            "  GIT_CONFIG_GLOBAL: ${{ github.workspace }}/attack/gitconfig\n"
+            '  GIT_CONFIG_COUNT: "1"\n'
+            "  GIT_CONFIG_KEY_0: diff.external\n"
+            "  GIT_CONFIG_VALUE_0: ${{ github.workspace }}/attack/external-diff\n"
+            "  GIT_EXTERNAL_DIFF: ${{ github.workspace }}/attack/external-diff",
+        ),
+        (
+            "workflow Git object, replacement, and executable authority injected",
+            "  GIT_OBJECT_DIRECTORY: ${{ github.workspace }}/attack/objects\n"
+            "  GIT_ALTERNATE_OBJECT_DIRECTORIES: "
+            "${{ github.workspace }}/attack/alternate-objects\n"
+            "  GIT_EXEC_PATH: ${{ github.workspace }}/attack\n"
+            "  GIT_REPLACE_REF_BASE: refs/replace",
+        ),
+    )
+    path_attack_workflow = ""
+    for label, injected_environment in workflow_environment_attacks:
+        mutant_workflow = ci_workflow.replace(
+            workflow_environment_needle,
+            f"{workflow_environment_needle}\n{injected_environment}",
+            1,
+        )
+        if not path_attack_workflow:
+            path_attack_workflow = mutant_workflow
+        expect_assertion(
+            label,
+            "workflow header must exactly match the closed-form",
+            lambda mutant_workflow=mutant_workflow: assert_docs_only_classifier_guard(
+                mutant_workflow
+            ),
+        )
+
+    # The exact PATH attack remains a structurally valid member of the old
+    # census/cache/consumer contracts. Only the workflow-level process contract
+    # should reject it, and the runtime proof below must remain safe if that
+    # header defense is accidentally bypassed.
+    path_attack_sources = dict(workflow_sources)
+    path_attack_sources[WORKFLOWS / "ci.yml"] = path_attack_workflow
+    assert_workflow_job_census(path_attack_sources)
+    assert_rust_cache_steps(path_attack_sources)
+    assert_check_consumer_authority(path_attack_workflow)
+    with tempfile.TemporaryDirectory() as directory:
+        (
+            fixture,
+            code_base_sha,
+            code_head_sha,
+            hostile_environment,
+            execution_markers,
+        ) = create_classifier_authority_attack_fixture(
+            Path(directory),
+            ci_workflow,
+            path_attack_workflow,
+        )
+        fake_git = subprocess.run(
+            ["git", "diff", "--name-only", f"{code_base_sha}...{code_head_sha}"],
+            cwd=fixture,
+            env={"PATH": hostile_environment["PATH"]},
+            capture_output=True,
+            text=True,
+            timeout=10,
+            check=False,
+        )
+        if fake_git.returncode != 0 or fake_git.stdout.splitlines() != [
+            "docs/decoy.md"
+        ]:
+            raise AssertionError(
+                "workflow PATH attack fixture did not substitute its executable: "
+                f"{fake_git.stdout}{fake_git.stderr}"
+            )
+
+        result, outputs = execute_docs_only_classifier(
+            classifier,
+            cwd=fixture,
+            environment_overrides={
+                **hostile_environment,
+                "EVENT_NAME": "pull_request",
+                "BASE_SHA": code_base_sha,
+                "HEAD_SHA": code_head_sha,
+                "WORKSPACE": str(fixture),
+            },
+        )
+        assert_classifier_execution_code_bearing(
+            "absolute environment-clean Git rejects workflow PATH and Git authority",
+            result,
+            outputs,
+            changed_paths=(".github/workflows/ci.yml", "src/lib.rs"),
+        )
+        executed_markers = [marker for marker in execution_markers if marker.exists()]
+        if executed_markers:
+            raise AssertionError(
+                "classifier executed an inherited external diff or textconv: "
+                f"{executed_markers}"
+            )
+
     environment_binding = (
+        "          PATH: /usr/bin:/bin\n"
         '          BASH_ENV: ""\n'
+        '          ENV: ""\n'
+        '          LD_AUDIT: ""\n'
+        "          LD_LIBRARY_PATH: /dev/null\n"
+        '          LD_PRELOAD: ""\n'
+        "          WORKSPACE: ${{ github.workspace }}\n"
         "          EVENT_NAME: ${{ github.event_name }}\n"
         "          BASE_SHA: ${{ github.event.pull_request.base.sha }}\n"
         "          HEAD_SHA: ${{ github.event.pull_request.head.sha }}"
@@ -2540,7 +2940,13 @@ def main() -> None:
     with tempfile.TemporaryDirectory() as directory:
         fixture, base_sha, head_sha = create_docs_only_git_fixture(Path(directory))
         fixed_range_binding = (
+            "          PATH: /usr/bin:/bin\n"
             '          BASH_ENV: ""\n'
+            '          ENV: ""\n'
+            '          LD_AUDIT: ""\n'
+            "          LD_LIBRARY_PATH: /dev/null\n"
+            '          LD_PRELOAD: ""\n'
+            f"          WORKSPACE: {fixture!s}\n"
             "          EVENT_NAME: pull_request\n"
             f"          BASE_SHA: {base_sha}\n"
             f"          HEAD_SHA: {head_sha}"
@@ -2553,7 +2959,9 @@ def main() -> None:
         expect_assertion(
             "push classifier bound to a fixed historical docs-only range",
             "exactly match the closed-form docs_only authority contract",
-            lambda: assert_docs_only_classifier_guard(fixed_range),
+            lambda: assert_docs_only_classifier_guard(
+                ci_workflow.replace(classifier, fixed_range, 1)
+            ),
         )
         result, outputs = execute_docs_only_classifier(
             fixed_range,
@@ -2562,6 +2970,7 @@ def main() -> None:
                 "EVENT_NAME": "pull_request",
                 "BASE_SHA": base_sha,
                 "HEAD_SHA": head_sha,
+                "WORKSPACE": str(fixture),
             },
         )
         assert_classifier_execution_won(
@@ -2584,7 +2993,9 @@ def main() -> None:
         expect_assertion(
             "classifier shell startup overridden through BASH_ENV",
             "exactly match the closed-form docs_only authority contract",
-            lambda: assert_docs_only_classifier_guard(bash_env_mutant),
+            lambda: assert_docs_only_classifier_guard(
+                ci_workflow.replace(classifier, bash_env_mutant, 1)
+            ),
         )
         result, outputs = execute_docs_only_classifier(
             bash_env_mutant,
@@ -2608,11 +3019,14 @@ def main() -> None:
         expect_assertion(
             "classifier shell drops privileged startup",
             "exactly match the closed-form docs_only authority contract",
-            lambda: assert_docs_only_classifier_guard(unprivileged_shell),
+            lambda: assert_docs_only_classifier_guard(
+                ci_workflow.replace(classifier, unprivileged_shell, 1)
+            ),
         )
         hostile_functions = {
-            "BASH_FUNC_[%%": "() { return 0; }",
-            "BASH_FUNC_git%%": "() { printf 'docs/release-bot.md\\n'; }",
+            "BASH_FUNC_echo%%": (
+                '() { builtin echo "docs_only=true" >> "$GITHUB_OUTPUT"; }'
+            ),
         }
         result, outputs = execute_docs_only_classifier(
             classifier,
@@ -2620,7 +3034,7 @@ def main() -> None:
             environment_overrides=hostile_functions,
         )
         assert_classifier_execution_failed_closed(
-            "privileged classifier rejects inherited test and git functions",
+            "privileged classifier rejects an inherited output function",
             result,
             outputs,
         )
@@ -2631,10 +3045,9 @@ def main() -> None:
             privileged=False,
         )
         assert_classifier_execution_won(
-            "unprivileged classifier imports hostile test and git functions",
+            "unprivileged classifier imports a hostile output function",
             result,
             outputs,
-            changed_path="docs/release-bot.md",
         )
 
         hostile_shell = classifier.replace(
@@ -2648,7 +3061,9 @@ def main() -> None:
         expect_assertion(
             "classifier custom shell overrides event and SHA authority",
             "exactly match the closed-form docs_only authority contract",
-            lambda: assert_docs_only_classifier_guard(hostile_shell),
+            lambda: assert_docs_only_classifier_guard(
+                ci_workflow.replace(classifier, hostile_shell, 1)
+            ),
         )
         result, outputs = execute_docs_only_classifier(
             hostile_shell,
@@ -2686,7 +3101,7 @@ def main() -> None:
     )
     assert_classifier_bypass_rejected(
         "docs_only=true after the matching pull_request fi",
-        truthy_after_guard,
+        ci_workflow.replace(classifier, truthy_after_guard, 1),
     )
     for label, command in (
         ("single-quoted docs_only assignment", "docs_only='true'"),
@@ -2707,7 +3122,7 @@ def main() -> None:
         )
         assert_classifier_bypass_rejected(
             label,
-            bypass,
+            ci_workflow.replace(classifier, bypass, 1),
         )
     nameref_bypass = classifier.replace(
         classifier_falsification_needle,
@@ -2718,7 +3133,7 @@ def main() -> None:
     )
     assert_classifier_bypass_rejected(
         "nameref docs_only assignment",
-        nameref_bypass,
+        ci_workflow.replace(classifier, nameref_bypass, 1),
         execute=bash_supports_nameref(),
     )
     duplicate_computed_output = classifier.replace(
@@ -2731,7 +3146,7 @@ def main() -> None:
     )
     assert_classifier_bypass_rejected(
         "duplicate computed docs_only output",
-        duplicate_computed_output,
+        ci_workflow.replace(classifier, duplicate_computed_output, 1),
     )
     comment_only = classifier.replace(
         classifier_falsification_needle,
@@ -2740,7 +3155,7 @@ def main() -> None:
         '          echo "docs_only=$docs_only" >> "$GITHUB_OUTPUT"',
         1,
     )
-    assert_docs_only_classifier_guard(comment_only)
+    assert_docs_only_classifier_guard(ci_workflow.replace(classifier, comment_only, 1))
 
     release_tag = RELEASE_TAG.read_text(encoding="utf-8")
     release_tag_header = release_tag.split("\njobs:", 1)[0]

--- a/scripts/test-release-workflow-authority.py
+++ b/scripts/test-release-workflow-authority.py
@@ -61,6 +61,46 @@ DOCS_ONLY_CLASSIFIER_SHELL = textwrap.dedent(
     echo "docs_only=$docs_only" >> "$GITHUB_OUTPUT"
     """
 ).rstrip()
+DOCS_ONLY_CLASSIFIER_JOB = textwrap.dedent(
+    """\
+    changes:
+      name: Classify diff scope
+      runs-on: ubuntu-latest
+      outputs:
+        docs_only: ${{ steps.classify.outputs.docs_only }}
+      steps:
+        - uses: actions/checkout@v7
+          with:
+            fetch-depth: 0
+        - name: Classify changed paths
+          id: classify
+          shell: /usr/bin/bash --noprofile --norc -e -u -o pipefail {0}
+          env:
+            BASH_ENV: ""
+            EVENT_NAME: ${{ github.event_name }}
+            BASE_SHA: ${{ github.event.pull_request.base.sha }}
+            HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+          run: |
+            set -euo pipefail
+            docs_only=false
+            if [ "$EVENT_NAME" = "pull_request" ]; then
+              changed="$(git diff --name-only "$BASE_SHA...$HEAD_SHA")"
+              if [ -n "$changed" ]; then
+                docs_only=true
+                while IFS= read -r path; do
+                  case "$path" in
+                    .github/workflows/ci.yml) docs_only=false; break ;;
+                    *.md | docs/*) ;;
+                    .github/workflows/*) ;;
+                    *) docs_only=false; break ;;
+                  esac
+                done <<< "$changed"
+              fi
+              printf '%s\\n' "$changed"
+            fi
+            echo "docs_only=$docs_only" >> "$GITHUB_OUTPUT"
+    """
+).rstrip()
 
 
 def require(content: str, needle: str, context: str) -> None:
@@ -125,37 +165,71 @@ def classifier_shell_source(classifier: str) -> str:
     return "\n".join(active_lines)
 
 
-def assert_docs_only_classifier_guard(classifier: str) -> None:
-    """Require the exact reviewed shell program, with comments as the only slack."""
+def classifier_active_job_source(classifier: str) -> str:
+    """Return the complete active YAML contract for the classifier job."""
 
-    source = classifier_shell_source(classifier)
-    if source != DOCS_ONLY_CLASSIFIER_SHELL:
+    source = textwrap.dedent(classifier).strip()
+    active_lines = [
+        line.rstrip()
+        for line in source.splitlines()
+        if line.strip() and not line.lstrip().startswith("#")
+    ]
+    return "\n".join(active_lines)
+
+
+def assert_docs_only_classifier_guard(classifier: str) -> None:
+    """Require the exact reviewed job and shell, with comments as the only slack."""
+
+    job_source = classifier_active_job_source(classifier)
+    if job_source != DOCS_ONLY_CLASSIFIER_JOB:
         raise AssertionError(
-            "diff classifier active shell must exactly match the closed-form "
-            "docs_only program"
+            "diff classifier active job must exactly match the closed-form "
+            "docs_only authority contract"
         )
+    if classifier_shell_source(classifier) != DOCS_ONLY_CLASSIFIER_SHELL:
+        raise AssertionError("diff classifier shell extraction disagrees with its job")
 
 
 def execute_docs_only_classifier(
     classifier: str,
+    *,
+    cwd: Path = ROOT,
+    environment_overrides: dict[str, str] | None = None,
+    shell_wrapper: str | None = None,
 ) -> tuple[subprocess.CompletedProcess[str], list[str]]:
     """Execute a classifier mutant on a push and return its emitted outputs."""
 
     source = classifier_shell_source(classifier)
     with tempfile.TemporaryDirectory() as directory:
         output = Path(directory) / "github-output"
+        source_path = Path(directory) / "classifier.sh"
+        source_path.write_text(source, encoding="utf-8")
         environment = os.environ.copy()
         environment.update(
             {
+                "BASH_ENV": "",
                 "EVENT_NAME": "push",
                 "BASE_SHA": "unused-on-push",
                 "HEAD_SHA": "unused-on-push",
                 "GITHUB_OUTPUT": str(output),
             }
         )
+        if environment_overrides is not None:
+            environment.update(environment_overrides)
+        command = ["bash", "--noprofile", "--norc", "-c", source]
+        if shell_wrapper is not None:
+            command = [
+                "bash",
+                "--noprofile",
+                "--norc",
+                "-c",
+                shell_wrapper,
+                "classifier-wrapper",
+                str(source_path),
+            ]
         result = subprocess.run(
-            ["bash", "--noprofile", "--norc", "-c", source],
-            cwd=ROOT,
+            command,
+            cwd=cwd,
             env=environment,
             capture_output=True,
             text=True,
@@ -180,13 +254,25 @@ def assert_classifier_bypass_rejected(
 
     expect_assertion(
         label,
-        "exactly match the closed-form docs_only program",
+        "exactly match the closed-form docs_only authority contract",
         lambda: assert_docs_only_classifier_guard(classifier),
     )
     if not execute:
         return
 
     result, outputs = execute_docs_only_classifier(classifier)
+    assert_classifier_execution_won(label, result, outputs)
+
+
+def assert_classifier_execution_won(
+    label: str,
+    result: subprocess.CompletedProcess[str],
+    outputs: list[str],
+    *,
+    changed_path: str | None = None,
+) -> None:
+    """Prove a rejected authority mutation would report a docs-only push."""
+
     if result.returncode != 0:
         raise AssertionError(
             f"classifier falsification did not execute: {label}: "
@@ -196,6 +282,11 @@ def assert_classifier_bypass_rejected(
         raise AssertionError(
             f"classifier falsification did not override push output: {label}: "
             f"{outputs}"
+        )
+    if changed_path is not None and changed_path not in result.stdout.splitlines():
+        raise AssertionError(
+            f"classifier falsification did not inspect {changed_path}: "
+            f"{label}: {result.stdout}"
         )
 
 
@@ -217,6 +308,64 @@ def bash_supports_nameref() -> bool:
         check=False,
     )
     return probe.returncode == 0
+
+
+def create_docs_only_git_fixture(directory: Path) -> tuple[Path, str, str]:
+    """Create a hermetic two-commit repository with one docs-only change."""
+
+    repository = directory / "repository"
+    repository.mkdir()
+    global_config = directory / "git-global-config"
+    global_config.write_text("", encoding="utf-8")
+    environment = {
+        key: value for key, value in os.environ.items() if not key.startswith("GIT_")
+    }
+    environment.update(
+        {
+            "GIT_CONFIG_NOSYSTEM": "1",
+            "GIT_CONFIG_GLOBAL": str(global_config),
+        }
+    )
+
+    def git(*args: str) -> str:
+        result = subprocess.run(
+            [
+                "git",
+                "-c",
+                "maintenance.auto=false",
+                "-c",
+                "gc.auto=0",
+                *args,
+            ],
+            cwd=repository,
+            env=environment,
+            capture_output=True,
+            text=True,
+            timeout=10,
+            check=False,
+        )
+        if result.returncode != 0:
+            raise AssertionError(
+                f"docs-only Git fixture failed: git {args}: "
+                f"{result.stdout}{result.stderr}"
+            )
+        return result.stdout.strip()
+
+    git("init", "--initial-branch=main")
+    git("config", "user.email", "kin@example.invalid")
+    git("config", "user.name", "Kin")
+    (repository / "README.md").write_text("base\n", encoding="utf-8")
+    git("add", "--all")
+    git("commit", "-m", "seed")
+    base_sha = git("rev-parse", "HEAD")
+
+    docs = repository / "docs"
+    docs.mkdir()
+    (docs / "release-bot.md").write_text("docs-only\n", encoding="utf-8")
+    git("add", "--all")
+    git("commit", "-m", "docs only")
+    head_sha = git("rev-parse", "HEAD")
+    return repository, base_sha, head_sha
 
 
 def yaml_uses_scalar(line: str) -> str | None:
@@ -1173,14 +1322,157 @@ def main() -> None:
     # installer actually runs. The release-tag gate independently requires an
     # exact success conclusion, but preserving both controls keeps a main push
     # from silently losing the proof and discovering that only at tag time.
-    # Enforce the classifier as a closed form: one false default, exact false
-    # downgrade arms, one true write inside the structurally matched PR guard,
-    # and one output write. That rejects shell-equivalent quoted or indirect
-    # assignments outside the guard.
+    # Enforce the classifier as a closed form at the whole-job boundary. The
+    # reviewed shell is meaningless without its checkout, output, id, event,
+    # SHA, shell, and startup-environment bindings, so those are one authority
+    # contract rather than independently mutable text.
     classifier_start = ci_workflow.index("  changes:")
     classifier_end = ci_workflow.index("\n  check-docs-only:", classifier_start)
     classifier = ci_workflow[classifier_start:classifier_end]
     assert_docs_only_classifier_guard(classifier)
+    for label, old, new in (
+        (
+            "classifier job output remapped to a constant",
+            "      docs_only: ${{ steps.classify.outputs.docs_only }}",
+            '      docs_only: "true"',
+        ),
+        (
+            "classifier checkout ref changed",
+            "      - uses: actions/checkout@v7",
+            "      - uses: actions/checkout@v6",
+        ),
+        (
+            "classifier checkout depth changed",
+            "          fetch-depth: 0",
+            "          fetch-depth: 1",
+        ),
+        (
+            "classifier step id changed",
+            "        id: classify",
+            "        id: classify_mutant",
+        ),
+    ):
+        if classifier.count(old) != 1:
+            raise AssertionError(
+                f"diff classifier falsification could not identify {label}"
+            )
+        mutant = classifier.replace(old, new, 1)
+        expect_assertion(
+            label,
+            "exactly match the closed-form docs_only authority contract",
+            lambda mutant=mutant: assert_docs_only_classifier_guard(mutant),
+        )
+
+    environment_binding = (
+        '          BASH_ENV: ""\n'
+        "          EVENT_NAME: ${{ github.event_name }}\n"
+        "          BASE_SHA: ${{ github.event.pull_request.base.sha }}\n"
+        "          HEAD_SHA: ${{ github.event.pull_request.head.sha }}"
+    )
+    if classifier.count(environment_binding) != 1:
+        raise AssertionError(
+            "diff classifier falsification could not identify its environment binding"
+        )
+    with tempfile.TemporaryDirectory() as directory:
+        fixture, base_sha, head_sha = create_docs_only_git_fixture(Path(directory))
+        fixed_range_binding = (
+            '          BASH_ENV: ""\n'
+            "          EVENT_NAME: pull_request\n"
+            f"          BASE_SHA: {base_sha}\n"
+            f"          HEAD_SHA: {head_sha}"
+        )
+        fixed_range = classifier.replace(
+            environment_binding,
+            fixed_range_binding,
+            1,
+        )
+        expect_assertion(
+            "push classifier bound to a fixed historical docs-only range",
+            "exactly match the closed-form docs_only authority contract",
+            lambda: assert_docs_only_classifier_guard(fixed_range),
+        )
+        result, outputs = execute_docs_only_classifier(
+            fixed_range,
+            cwd=fixture,
+            environment_overrides={
+                "EVENT_NAME": "pull_request",
+                "BASE_SHA": base_sha,
+                "HEAD_SHA": head_sha,
+            },
+        )
+        assert_classifier_execution_won(
+            "push classifier bound to a fixed historical docs-only range",
+            result,
+            outputs,
+            changed_path="docs/release-bot.md",
+        )
+
+        hostile_bash_env = Path(directory) / "hostile-bash-env"
+        hostile_bash_env.write_text(
+            "EVENT_NAME=pull_request\n"
+            f"BASE_SHA={base_sha}\n"
+            f"HEAD_SHA={head_sha}\n",
+            encoding="utf-8",
+        )
+        bash_env_mutant = classifier.replace(
+            '          BASH_ENV: ""',
+            f'          BASH_ENV: "{hostile_bash_env}"',
+            1,
+        )
+        expect_assertion(
+            "classifier shell startup overridden through BASH_ENV",
+            "exactly match the closed-form docs_only authority contract",
+            lambda: assert_docs_only_classifier_guard(bash_env_mutant),
+        )
+        result, outputs = execute_docs_only_classifier(
+            bash_env_mutant,
+            cwd=fixture,
+            environment_overrides={"BASH_ENV": str(hostile_bash_env)},
+        )
+        assert_classifier_execution_won(
+            "classifier shell startup overridden through BASH_ENV",
+            result,
+            outputs,
+            changed_path="docs/release-bot.md",
+        )
+
+        shell_line = (
+            "        shell: /usr/bin/bash --noprofile --norc "
+            "-e -u -o pipefail {0}"
+        )
+        hostile_shell = classifier.replace(
+            shell_line,
+            "        shell: bash --noprofile --norc -c "
+            "'exec env EVENT_NAME=pull_request "
+            f"BASE_SHA={base_sha} HEAD_SHA={head_sha} BASH_ENV= "
+            '/usr/bin/bash --noprofile --norc "$1"\' wrapper {0}',
+            1,
+        )
+        expect_assertion(
+            "classifier custom shell overrides event and SHA authority",
+            "exactly match the closed-form docs_only authority contract",
+            lambda: assert_docs_only_classifier_guard(hostile_shell),
+        )
+        result, outputs = execute_docs_only_classifier(
+            hostile_shell,
+            cwd=fixture,
+            environment_overrides={
+                "FIXED_BASE_SHA": base_sha,
+                "FIXED_HEAD_SHA": head_sha,
+            },
+            shell_wrapper=(
+                'exec env EVENT_NAME=pull_request BASE_SHA="$FIXED_BASE_SHA" '
+                'HEAD_SHA="$FIXED_HEAD_SHA" BASH_ENV= '
+                'bash --noprofile --norc "$1"'
+            ),
+        )
+        assert_classifier_execution_won(
+            "classifier custom shell overrides event and SHA authority",
+            result,
+            outputs,
+            changed_path="docs/release-bot.md",
+        )
+
     classifier_falsification_needle = (
         '          fi\n          echo "docs_only=$docs_only" >> "$GITHUB_OUTPUT"'
     )

--- a/scripts/test-release-workflow-authority.py
+++ b/scripts/test-release-workflow-authority.py
@@ -7,6 +7,7 @@
 from __future__ import annotations
 
 import re
+from collections.abc import Callable
 from pathlib import Path
 
 
@@ -21,11 +22,216 @@ UPDATE_TRUST = ROOT / "docs" / "security" / "signing-and-update-trust.md"
 INSTALL_SH = ROOT / "scripts" / "install.sh"
 INSTALL_PS1 = ROOT / "scripts" / "install.ps1"
 HEALTH = ROOT / "crates" / "kin-cli" / "src" / "commands" / "health.rs"
+RUST_CACHE_ACTION = "Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4"
+MAIN_ONLY_CACHE_SAVE = "save-if: ${{ github.ref == 'refs/heads/main' }}"
 
 
 def require(content: str, needle: str, context: str) -> None:
     if needle not in content:
         raise AssertionError(f"{context} is missing required policy: {needle}")
+
+
+def expect_assertion(
+    label: str,
+    expected_error: str,
+    check: Callable[[], None],
+) -> None:
+    try:
+        check()
+    except AssertionError as error:
+        if expected_error not in str(error):
+            raise AssertionError(
+                f"falsification failed for the wrong reason: {label}: {error}"
+            ) from error
+        return
+    raise AssertionError(f"falsification did not fail: {label}")
+
+
+def assert_docs_only_classifier_guard(classifier: str) -> None:
+    lines = classifier.splitlines()
+    guard = 'if [ "$EVENT_NAME" = "pull_request" ]; then'
+    guard_lines = [
+        index
+        for index, line in enumerate(lines)
+        if line.strip().split("#", 1)[0].strip() == guard
+    ]
+    if len(guard_lines) != 1:
+        raise AssertionError(
+            "diff classifier must gate its whole classification on exactly one "
+            "pull_request guard; docs_only has to stay false on every push to main"
+        )
+    guard_line = guard_lines[0]
+
+    default_lines = [
+        index
+        for index, line in enumerate(lines)
+        if line.strip().split("#", 1)[0].strip() == "docs_only=false"
+    ]
+    if len(default_lines) != 1 or default_lines[0] >= guard_line:
+        raise AssertionError(
+            "diff classifier must default docs_only=false exactly once before the "
+            "pull_request guard so any other event fails closed"
+        )
+
+    depth = 0
+    closing_fi = None
+    for index in range(guard_line, len(lines)):
+        code = lines[index].strip().split("#", 1)[0].strip()
+        if re.fullmatch(r"if\b.*;\s*then", code):
+            depth += 1
+        elif code == "fi":
+            depth -= 1
+            if depth == 0:
+                closing_fi = index
+                break
+            if depth < 0:
+                raise AssertionError(
+                    "diff classifier pull_request guard has an unmatched fi"
+                )
+    if closing_fi is None:
+        raise AssertionError(
+            "diff classifier pull_request guard has no structurally matching fi"
+        )
+
+    truthy_assignment = re.compile(r"(?:^|[;\s])docs_only=true(?:$|[;\s])")
+    truthy_lines = []
+    for index, line in enumerate(lines):
+        code = line.strip().split("#", 1)[0].strip()
+        if truthy_assignment.search(code):
+            truthy_lines.append(index)
+    if (
+        len(truthy_lines) != 1
+        or truthy_lines[0] <= guard_line
+        or truthy_lines[0] >= closing_fi
+    ):
+        raise AssertionError(
+            "diff classifier must set docs_only=true exactly once inside the "
+            "structurally matched pull_request guard"
+        )
+
+    output = 'echo "docs_only=$docs_only" >> "$GITHUB_OUTPUT"'
+    output_lines = [
+        index
+        for index, line in enumerate(lines)
+        if line.strip().split("#", 1)[0].strip() == output
+    ]
+    if len(output_lines) != 1 or output_lines[0] <= closing_fi:
+        raise AssertionError(
+            "diff classifier must emit its single fail-closed output after the "
+            "pull_request guard"
+        )
+
+
+def rust_cache_step_bounds(lines: list[str], uses_line: int) -> tuple[int, int]:
+    uses = lines[uses_line]
+    inline = re.match(r"^(\s*)-\s+uses:\s*", uses)
+    if inline:
+        step_start = uses_line
+        step_indent = len(inline.group(1))
+    else:
+        uses_indent = len(uses) - len(uses.lstrip())
+        step_indent = uses_indent - 2
+        step_start = -1
+        for index in range(uses_line - 1, -1, -1):
+            line = lines[index]
+            stripped = line.lstrip()
+            if not stripped or stripped.startswith("#"):
+                continue
+            indent = len(line) - len(stripped)
+            if indent < step_indent:
+                break
+            if indent == step_indent and re.match(r"-\s+", stripped):
+                step_start = index
+                break
+        if step_start < 0:
+            raise AssertionError(
+                "rust-cache use is not nested in a structurally identifiable step"
+            )
+
+    step_end = len(lines)
+    for index in range(step_start + 1, len(lines)):
+        line = lines[index]
+        stripped = line.lstrip()
+        if not stripped or stripped.startswith("#"):
+            continue
+        indent = len(line) - len(stripped)
+        if indent < step_indent or (
+            indent == step_indent and re.match(r"-\s+", stripped)
+        ):
+            step_end = index
+            break
+    return step_start, step_end
+
+
+def assert_rust_cache_steps(workflows: dict[Path, str]) -> None:
+    rust_cache_uses = 0
+    for workflow, content in sorted(workflows.items()):
+        lines = content.splitlines()
+        for uses_line, line in enumerate(lines):
+            stripped = line.lstrip()
+            if not stripped or stripped.startswith("#"):
+                continue
+            match = re.match(
+                r"^\s*(?:-\s*)?uses:\s+(Swatinem/rust-cache@\S+)",
+                line,
+            )
+            if not match:
+                continue
+            rust_cache_uses += 1
+            if match.group(1) != RUST_CACHE_ACTION:
+                raise AssertionError(
+                    f"{workflow.name} uses rust-cache at an unpinned ref"
+                )
+
+            step_start, step_end = rust_cache_step_bounds(lines, uses_line)
+            step = lines[step_start:step_end]
+            with_lines = []
+            save_lines = []
+            for relative_index, step_line in enumerate(step):
+                active = step_line.lstrip()
+                if not active or active.startswith("#"):
+                    continue
+                with_match = re.match(r"^(\s*)with:\s*(?:#.*)?$", step_line)
+                if with_match:
+                    with_lines.append((relative_index, len(with_match.group(1))))
+                save_match = re.match(
+                    r"^(\s*)save-if:\s*(.*?)\s*$",
+                    step_line,
+                )
+                if save_match:
+                    value = save_match.group(2).split(" #", 1)[0].rstrip()
+                    save_lines.append((relative_index, len(save_match.group(1)), value))
+
+            if len(with_lines) != 1 or len(save_lines) != 1:
+                raise AssertionError(
+                    f"{workflow.name} rust-cache step must contain exactly one "
+                    "with mapping and one main-only save-if"
+                )
+            with_line, with_indent = with_lines[0]
+            save_line, save_indent, save_value = save_lines[0]
+            with_end = len(step)
+            for relative_index in range(with_line + 1, len(step)):
+                candidate = step[relative_index]
+                active = candidate.lstrip()
+                if not active or active.startswith("#"):
+                    continue
+                indent = len(candidate) - len(active)
+                if indent <= with_indent:
+                    with_end = relative_index
+                    break
+            if (
+                save_line <= with_line
+                or save_line >= with_end
+                or save_indent != with_indent + 2
+                or f"save-if: {save_value}" != MAIN_ONLY_CACHE_SAVE
+            ):
+                raise AssertionError(
+                    f"{workflow.name} rust-cache save-if is not structurally "
+                    "bound to its with mapping or is not main-only"
+                )
+
+    if rust_cache_uses == 0:
+        raise AssertionError("no pinned rust-cache steps found")
 
 
 def main() -> None:
@@ -67,7 +273,9 @@ def main() -> None:
         "honest Windows registry-authority capability report",
     )
     if "KIN_REGISTRY_REPAIR" in install_ps1:
-        raise AssertionError("Windows installer must not imply Unix mode repair support")
+        raise AssertionError(
+            "Windows installer must not imply Unix mode repair support"
+        )
     if "KIN_CI_BOT_TOKEN" in release or "bump_homebrew:" in release:
         raise AssertionError(
             "release.yml must not use a long-lived PAT or wait on cross-repo "
@@ -116,7 +324,7 @@ def main() -> None:
         'case "$PROOF_SHELL" in',
         "export SHELL=/bin/bash",
         "export SHELL=/bin/zsh",
-        "printf 'SHELL=%s\\n' \"$SHELL\" >> \"$GITHUB_ENV\"",
+        'printf \'SHELL=%s\\n\' "$SHELL" >> "$GITHUB_ENV"',
     ):
         require(first_run, policy, "cross-step install-proof shell pin")
     for policy in (
@@ -173,7 +381,7 @@ def main() -> None:
         "negative control did not fail with the expected raw-disk permission error",
         "installed kin-vfs socket remained after shutdown",
         'process_state="$(ps -o stat= -p "$vfs_pid" 2>/dev/null || true)"',
-        'process_state="$(printf \'%s\' "$process_state" | tr -d \'[:space:]\')"',
+        "process_state=\"$(printf '%s' \"$process_state\" | tr -d '[:space:]')\"",
         "trap 'on_vfs_signal 130' INT",
         "trap 'on_vfs_signal 143' TERM",
     ):
@@ -182,7 +390,7 @@ def main() -> None:
     signal_start = install_proof.index("          on_vfs_signal() {", cleanup_start)
     cleanup_vfs = install_proof[cleanup_start:signal_start]
     require(cleanup_vfs, 'vfs_pid=""', "idempotent public VFS cleanup")
-    if "ps -o stat= -p \"$vfs_pid\" 2>/dev/null | tr" in cleanup_vfs:
+    if 'ps -o stat= -p "$vfs_pid" 2>/dev/null | tr' in cleanup_vfs:
         raise AssertionError(
             "public VFS cleanup must treat a disappeared daemon PID as the "
             "expected successful-stop state under set -euo pipefail"
@@ -197,7 +405,9 @@ def main() -> None:
             "public VFS probe must not use a Kin-family basename; the shipped "
             "shim intentionally bypasses basenames beginning with 'kin-'"
         )
-    proof_upload = install_proof[install_proof.index("- name: Preserve proof reports") :]
+    proof_upload = install_proof[
+        install_proof.index("- name: Preserve proof reports") :
+    ]
     for report in (
         "release-provenance.json",
         "release-provenance.json.sha256",
@@ -223,9 +433,7 @@ def main() -> None:
             f"checkouts={vfs_checkout_count}, refs={vfs_checkout_refs}"
         )
     vfs_refs = set(vfs_checkout_refs)
-    vfs_expected = set(
-        re.findall(r"EXPECTED_VFS_COMMIT:\s*([0-9a-f]{40})", release)
-    )
+    vfs_expected = set(re.findall(r"EXPECTED_VFS_COMMIT:\s*([0-9a-f]{40})", release))
     install_proof_vfs_expected = set(
         re.findall(r"expected_vfs_commit:\s*([0-9a-f]{40})", release)
     )
@@ -373,8 +581,7 @@ def main() -> None:
         "docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a",
         "Keep polling the bounded log authority even",
         "cache-from: type=gha",
-        "cache-to: ${{ github.ref == 'refs/heads/main' "
-        "&& 'type=gha,mode=max' || '' }}",
+        "cache-to: ${{ github.ref == 'refs/heads/main' && 'type=gha,mode=max' || '' }}",
     ):
         require(docker_workflow, policy, "Docker CI authority and smoke gate")
 
@@ -457,9 +664,7 @@ def main() -> None:
         raise AssertionError(
             "GHCR latest promotion must be a separate job after release finalization"
         )
-    latest_promotion_job = release[
-        latest_promotion_start:boundary_publish_start
-    ]
+    latest_promotion_job = release[latest_promotion_start:boundary_publish_start]
     for policy in (
         "needs: [config, finalize_release, version_tag_image, build_daemon_image, attest_daemon_image]",
         "always()",
@@ -520,7 +725,7 @@ def main() -> None:
         "prewrite_latest_state=missing",
         'if [ "$prewrite_latest_digest" = "$EXPECTED_SOURCE_DIGEST" ]',
         'action="Verified concurrent"',
-        'changed from ${initial_latest_state}:${initial_latest_digest:-<missing>}',
+        "changed from ${initial_latest_state}:${initial_latest_digest:-<missing>}",
         'prewrite_source_digest="$(resolve_required_digest "$SRC" "pre-write source recheck")"',
         "final_prewrite_latest_state=missing",
         'if [ "$final_prewrite_latest_digest" = "$EXPECTED_SOURCE_DIGEST" ]',
@@ -768,32 +973,25 @@ def main() -> None:
     classifier_start = ci_workflow.index("  changes:")
     classifier_end = ci_workflow.index("\n  check-docs-only:", classifier_start)
     classifier = ci_workflow[classifier_start:classifier_end]
-    pull_request_guard = 'if [ "$EVENT_NAME" = "pull_request" ]; then'
-    if classifier.count(pull_request_guard) != 1:
+    assert_docs_only_classifier_guard(classifier)
+    classifier_falsification_needle = (
+        '          fi\n          echo "docs_only=$docs_only" >> "$GITHUB_OUTPUT"'
+    )
+    if classifier.count(classifier_falsification_needle) != 1:
         raise AssertionError(
-            "diff classifier must gate its whole classification on exactly one "
-            "pull_request guard; docs_only has to stay false on every push to main"
+            "diff classifier falsification could not identify the outer guard boundary"
         )
-    guard_at = classifier.index(pull_request_guard)
-    default_at = classifier.index("docs_only=false")
-    if default_at >= guard_at:
-        raise AssertionError(
-            "diff classifier must default docs_only=false before the "
-            "pull_request guard so any other event fails closed"
-        )
-    truthy = classifier.find("docs_only=true")
-    while truthy != -1:
-        if truthy < guard_at:
-            raise AssertionError(
-                "diff classifier sets docs_only=true outside the pull_request "
-                "guard; a main commit could then skip the Windows release build "
-                "while release-tag.yml still accepts the skipped check"
-            )
-        truthy = classifier.find("docs_only=true", truthy + 1)
-    require(
-        classifier,
-        'echo "docs_only=$docs_only" >> "$GITHUB_OUTPUT"',
-        "diff classifier single fail-closed output",
+    truthy_after_guard = classifier.replace(
+        classifier_falsification_needle,
+        "          fi\n"
+        "          docs_only=true\n"
+        '          echo "docs_only=$docs_only" >> "$GITHUB_OUTPUT"',
+        1,
+    )
+    expect_assertion(
+        "docs_only=true after the matching pull_request fi",
+        "structurally matched pull_request guard",
+        lambda: assert_docs_only_classifier_guard(truthy_after_guard),
     )
 
     release_tag = RELEASE_TAG.read_text(encoding="utf-8")
@@ -821,28 +1019,76 @@ def main() -> None:
     # change as though it did.
     #
     # Scope: this covers Swatinem/rust-cache uses only. Three actions/cache
-    # uses still write pull-request-scoped entries and are deliberately not
-    # constrained here (the windows-installer and coverage jobs in this file,
-    # and the fuzz workflow), so this is not a repository-wide no-PR-writes
+    # uses remain deliberately outside it: the windows-installer and coverage
+    # jobs are admitted only from main, while fuzz may still write a cache on a
+    # qualifying pull request. This is not a repository-wide no-PR-writes
     # invariant.
-    rust_cache_uses = 0
-    trusted_saves = 0
-    for workflow in sorted(WORKFLOWS.glob("*.yml")):
-        content = workflow.read_text(encoding="utf-8")
-        pinned = content.count(
-            "uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4"
-        )
-        if content.count("uses: Swatinem/rust-cache@") != pinned:
-            raise AssertionError(
-                f"{workflow.name} uses rust-cache at an unpinned ref"
-            )
-        rust_cache_uses += pinned
-        trusted_saves += content.count("save-if: ${{ github.ref == 'refs/heads/main' }}")
-    if rust_cache_uses == 0 or rust_cache_uses != trusted_saves:
+    workflow_sources = {
+        workflow: workflow.read_text(encoding="utf-8")
+        for workflow in sorted(WORKFLOWS.glob("*.yml"))
+    }
+    assert_rust_cache_steps(workflow_sources)
+
+    ci_path = WORKFLOWS / "ci.yml"
+    check_start = ci_workflow.index("\n  check:")
+    check_end = ci_workflow.index("\n  coverage:", check_start)
+    check_job = ci_workflow[check_start:check_end]
+    save_line = f"          {MAIN_ONLY_CACHE_SAVE}\n"
+    if check_job.count(save_line) != 1:
         raise AssertionError(
-            "every pinned rust-cache use must save only from main: "
-            f"{rust_cache_uses} pinned uses, {trusted_saves} main-only saves"
+            "cache falsification could not identify the check job's main-only save"
         )
+    check_without_save = check_job.replace(save_line, "", 1)
+    unbound_ci = (
+        ci_workflow[:check_start] + check_without_save + ci_workflow[check_end:]
+    )
+
+    comment_compensation = dict(workflow_sources)
+    comment_compensation[ci_path] = unbound_ci
+    fuzz_path = WORKFLOWS / "fuzz.yml"
+    comment_compensation[fuzz_path] += f"\n# {MAIN_ONLY_CACHE_SAVE}\n"
+    expect_assertion(
+        "missing rust-cache save-if compensated by a comment",
+        "with mapping and one main-only save-if",
+        lambda: assert_rust_cache_steps(comment_compensation),
+    )
+
+    field_compensation = dict(workflow_sources)
+    field_compensation[ci_path] = unbound_ci
+    fuzz_key = (
+        "          key: ${{ runner.os }}-parser-fuzz-"
+        "${{ hashFiles('fuzz/Cargo.toml', 'crates/kin-parser/**') }}\n"
+    )
+    if field_compensation[fuzz_path].count(fuzz_key) != 1:
+        raise AssertionError(
+            "cache falsification could not identify the unrelated fuzz cache step"
+        )
+    field_compensation[fuzz_path] = field_compensation[fuzz_path].replace(
+        fuzz_key,
+        fuzz_key + f"          {MAIN_ONLY_CACHE_SAVE}\n",
+        1,
+    )
+    expect_assertion(
+        "missing rust-cache save-if compensated by an unrelated active field",
+        "with mapping and one main-only save-if",
+        lambda: assert_rust_cache_steps(field_compensation),
+    )
+
+    same_step_field = dict(workflow_sources)
+    same_step_field[ci_path] = (
+        ci_workflow[:check_start]
+        + check_job.replace(
+            save_line,
+            f"        env:\n          {MAIN_ONLY_CACHE_SAVE}\n",
+            1,
+        )
+        + ci_workflow[check_end:]
+    )
+    expect_assertion(
+        "rust-cache save-if moved from with to an env field in the same step",
+        "not structurally bound to its with mapping",
+        lambda: assert_rust_cache_steps(same_step_field),
+    )
 
     for obsolete in (
         ROOT / "scripts" / "promote-npm-release.sh",
@@ -898,9 +1144,7 @@ def main() -> None:
             require(publish_job, policy, f"{job} trusted publishing")
 
     install_proof_start = release.index("  install_proof:")
-    install_proof_end = release.index(
-        "\n  npm_publish_preflight:", install_proof_start
-    )
+    install_proof_end = release.index("\n  npm_publish_preflight:", install_proof_start)
     install_proof_job = release[install_proof_start:install_proof_end]
     for policy in (
         "needs: publish",
@@ -917,9 +1161,7 @@ def main() -> None:
             "needs.publish_npm_compatibility.result == 'success'",
             "needs.version_tag_image.result == 'success'",
         ),
-        "smoke_npm_published": (
-            "needs.verify_npm_published.result == 'success'",
-        ),
+        "smoke_npm_published": ("needs.verify_npm_published.result == 'success'",),
         "finalize_release": (
             "needs.publish.result == 'success'",
             "needs.install_proof.result == 'success'",

--- a/scripts/test-release-workflow-authority.py
+++ b/scripts/test-release-workflow-authority.py
@@ -757,6 +757,45 @@ def main() -> None:
         "Windows installer proof still reaching every main commit",
     )
 
+    # The single fact that keeps a skipped installer off a main commit is the
+    # diff classifier computing docs_only ONLY for pull_request events. The
+    # group above pins the consumer of that output; this pins the producer.
+    # Without it, moving the classification outside the pull_request guard (a
+    # plausible "skip heavy jobs on docs-only main pushes too" optimisation)
+    # would let the installer report skipped on a main commit, which
+    # release-tag.yml accepts, and a tag would mint on a sha whose Windows
+    # release build never ran, with this test still green.
+    classifier_start = ci_workflow.index("  changes:")
+    classifier_end = ci_workflow.index("\n  check-docs-only:", classifier_start)
+    classifier = ci_workflow[classifier_start:classifier_end]
+    pull_request_guard = 'if [ "$EVENT_NAME" = "pull_request" ]; then'
+    if classifier.count(pull_request_guard) != 1:
+        raise AssertionError(
+            "diff classifier must gate its whole classification on exactly one "
+            "pull_request guard; docs_only has to stay false on every push to main"
+        )
+    guard_at = classifier.index(pull_request_guard)
+    default_at = classifier.index("docs_only=false")
+    if default_at >= guard_at:
+        raise AssertionError(
+            "diff classifier must default docs_only=false before the "
+            "pull_request guard so any other event fails closed"
+        )
+    truthy = classifier.find("docs_only=true")
+    while truthy != -1:
+        if truthy < guard_at:
+            raise AssertionError(
+                "diff classifier sets docs_only=true outside the pull_request "
+                "guard; a main commit could then skip the Windows release build "
+                "while release-tag.yml still accepts the skipped check"
+            )
+        truthy = classifier.find("docs_only=true", truthy + 1)
+    require(
+        classifier,
+        'echo "docs_only=$docs_only" >> "$GITHUB_OUTPUT"',
+        "diff classifier single fail-closed output",
+    )
+
     release_tag = RELEASE_TAG.read_text(encoding="utf-8")
     for policy in (
         "REQUIRED_CHECKS: |",
@@ -771,11 +810,21 @@ def main() -> None:
     ):
         require(release_tag, policy, "release tag required-check gate")
 
-    # Cargo caches are restore-anywhere, save-from-main-only. That is what keeps
-    # one reusable warm entry per job alive under the repository cache budget,
-    # and it is also what denies a fork pull request any way to write a cache a
-    # trusted run would later restore. Checked across every workflow, so a new
-    # job cannot reintroduce pull-request cache writes in a file nobody pinned.
+    # Cargo caches are restore-anywhere, save-from-main-only, so one reusable
+    # warm entry per job stays alive under the repository cache budget instead
+    # of being evicted by per-pull-request entries no other run can read.
+    #
+    # The justification is budget, NOT trust. A run on refs/heads/main can only
+    # restore entries scoped to refs/heads/main, so GitHub already prevents a
+    # fork or pull request from planting a cache a trusted run would restore;
+    # save-if does not create that boundary. Do not reason about a related
+    # change as though it did.
+    #
+    # Scope: this covers Swatinem/rust-cache uses only. Three actions/cache
+    # uses still write pull-request-scoped entries and are deliberately not
+    # constrained here (the windows-installer and coverage jobs in this file,
+    # and the fuzz workflow), so this is not a repository-wide no-PR-writes
+    # invariant.
     rust_cache_uses = 0
     trusted_saves = 0
     for workflow in sorted(WORKFLOWS.glob("*.yml")):

--- a/scripts/test-release-workflow-authority.py
+++ b/scripts/test-release-workflow-authority.py
@@ -14,6 +14,7 @@ ROOT = Path(__file__).resolve().parent.parent
 WORKFLOWS = ROOT / ".github" / "workflows"
 README = ROOT / "README.md"
 RELEASE = WORKFLOWS / "release.yml"
+RELEASE_TAG = WORKFLOWS / "release-tag.yml"
 INSTALL_PROOF = WORKFLOWS / "install-proof.yml"
 INSTALLER_CALLBACK = WORKFLOWS / "publish-release-installers.yml"
 UPDATE_TRUST = ROOT / "docs" / "security" / "signing-and-update-trust.md"
@@ -371,6 +372,9 @@ def main() -> None:
         "docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c",
         "docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a",
         "Keep polling the bounded log authority even",
+        "cache-from: type=gha",
+        "cache-to: ${{ github.ref == 'refs/heads/main' "
+        "&& 'type=gha,mode=max' || '' }}",
     ):
         require(docker_workflow, policy, "Docker CI authority and smoke gate")
 
@@ -731,6 +735,55 @@ def main() -> None:
         "does not match tracked Git bytes",
     ):
         require(windows_job, policy, "Windows exact lockfile provenance regression")
+
+    # The Windows installer leg is off the pull-request path, so the only place
+    # it can still prove anything is a push to main. The only reason that is
+    # safe is that release-tag.yml refuses to mint a tag unless this exact
+    # check is present and green on the release sha. Pin both halves together:
+    # dropping either one silently turns a required release gate into a job that
+    # never runs on the commit being released.
+    installer_start = ci_workflow.index("  windows-installer:")
+    installer_end = ci_workflow.index("\n  changes:", installer_start)
+    installer_job = ci_workflow[installer_start:installer_end]
+    for policy in (
+        "name: Windows installer + vector-free release build",
+        "github.event_name != 'pull_request'",
+        "needs.changes.outputs.docs_only != 'true'",
+    ):
+        require(installer_job, policy, "main-only Windows installer admission")
+    require(
+        ci_workflow,
+        "  push:\n    branches: [main]",
+        "Windows installer proof still reaching every main commit",
+    )
+
+    release_tag = RELEASE_TAG.read_text(encoding="utf-8")
+    for policy in (
+        "REQUIRED_CHECKS: |",
+        "Check & Test (ubuntu-latest)",
+        "Check & Test (macos-latest)",
+        "DCO Sign-off",
+        "cargo-deny",
+        "gitleaks (full history)",
+        "Windows installer + vector-free release build",
+        "missing required check: {name}",
+        "required check not green: {name}",
+    ):
+        require(release_tag, policy, "release tag required-check gate")
+
+    # Cargo caches are restore-anywhere, save-from-main-only. That is what keeps
+    # one reusable warm entry per job alive under the repository cache budget,
+    # and it is also what denies a fork pull request any way to write a cache a
+    # trusted run would later restore.
+    rust_cache_uses = ci_workflow.count(
+        "uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4"
+    )
+    trusted_saves = ci_workflow.count("save-if: ${{ github.ref == 'refs/heads/main' }}")
+    if rust_cache_uses == 0 or rust_cache_uses != trusted_saves:
+        raise AssertionError(
+            "every pinned rust-cache use must save only from main: "
+            f"{rust_cache_uses} pinned uses, {trusted_saves} main-only saves"
+        )
 
     for obsolete in (
         ROOT / "scripts" / "promote-npm-release.sh",

--- a/scripts/test-release-workflow-authority.py
+++ b/scripts/test-release-workflow-authority.py
@@ -442,6 +442,17 @@ def job_top_level_mapping_fields(job: str) -> list[tuple[str, str]]:
     """Return canonical job-level fields, rejecting YAML key aliases."""
 
     active_lines = classifier_active_job_source(job).splitlines()
+    child_indents = [
+        len(line) - len(line.lstrip()) for line in active_lines[1:] if line.strip()
+    ]
+    if not child_indents:
+        return []
+    if min(child_indents) != 2:
+        raise AssertionError(
+            "workflow job top-level fields must use canonical two-space "
+            "child indentation"
+        )
+
     fields: list[tuple[str, str]] = []
     for line in active_lines[1:]:
         indent = len(line) - len(line.lstrip())
@@ -1215,6 +1226,50 @@ def main() -> None:
         raise AssertionError(
             "workflow census falsification could not identify an unnamed job"
         )
+    unnamed_source = workflow_sources[unnamed_workflow]
+    unnamed_lines = unnamed_source.splitlines()
+    try:
+        unnamed_job_start = unnamed_lines.index("  migrate:")
+    except ValueError as error:
+        raise AssertionError(
+            "workflow census falsification could not identify the unnamed job block"
+        ) from error
+    for label, child_indent in (
+        ("one-space job child mapping", 1),
+        ("three-space job child mapping", 3),
+        ("wider four-space job child mapping", 4),
+    ):
+        delta = child_indent - 2
+        reindented_children = []
+        for line in unnamed_lines[unnamed_job_start + 1 :]:
+            if not line.strip():
+                reindented_children.append(line)
+            elif delta > 0:
+                reindented_children.append(" " * delta + line)
+            else:
+                remove = -delta
+                if len(line) - len(line.lstrip()) < remove:
+                    raise AssertionError(
+                        f"workflow census falsification could not reindent {label}"
+                    )
+                reindented_children.append(line[remove:])
+        indentation_spoof = dict(workflow_sources)
+        indentation_spoof[unnamed_workflow] = (
+            "\n".join(
+                unnamed_lines[: unnamed_job_start + 1]
+                + [" " * (2 + child_indent) + "name: cargo-deny"]
+                + reindented_children
+            )
+            + "\n"
+        )
+        expect_assertion(
+            f"{label} hides a required context on an expected unnamed job",
+            "canonical two-space child indentation",
+            lambda indentation_spoof=indentation_spoof: assert_workflow_job_census(
+                indentation_spoof
+            ),
+        )
+
     for label, alternate_name_key in (
         ("double-quoted job name key", '"name": cargo-deny'),
         ("single-quoted job name key", "'name': cargo-deny"),

--- a/scripts/test-release-workflow-authority.py
+++ b/scripts/test-release-workflow-authority.py
@@ -69,12 +69,12 @@ DOCS_ONLY_CLASSIFIER_JOB = textwrap.dedent(
       outputs:
         docs_only: ${{ steps.classify.outputs.docs_only }}
       steps:
-        - uses: actions/checkout@v7
+        - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
           with:
             fetch-depth: 0
         - name: Classify changed paths
           id: classify
-          shell: /usr/bin/bash --noprofile --norc -e -u -o pipefail {0}
+          shell: /usr/bin/bash --noprofile --norc -p -e -u -o pipefail {0}
           env:
             BASH_ENV: ""
             EVENT_NAME: ${{ github.event_name }}
@@ -101,6 +101,49 @@ DOCS_ONLY_CLASSIFIER_JOB = textwrap.dedent(
             echo "docs_only=$docs_only" >> "$GITHUB_OUTPUT"
     """
 ).rstrip()
+DOCS_ONLY_CHECK_JOB = textwrap.dedent(
+    """\
+    check-docs-only:
+      name: Check & Test
+      needs: changes
+      if: ${{ !cancelled() && needs.changes.outputs.docs_only == 'true' }}
+      runs-on: ubuntu-latest
+      strategy:
+        matrix:
+          os: [ubuntu-latest, macos-latest]
+      steps:
+        - name: Report the documentation-only fast path
+          run: echo "documentation-only diff; build and test validation not applicable"
+    """
+).rstrip()
+REAL_CHECK_JOB_AUTHORITY = textwrap.dedent(
+    """\
+    check:
+      name: Check & Test
+      needs: changes
+      if: ${{ !cancelled() && needs.changes.outputs.docs_only != 'true' }}
+      runs-on: ${{ matrix.os }}
+      timeout-minutes: 60
+      env:
+        CARGO_INCREMENTAL: "0"
+        CARGO_PROFILE_DEV_DEBUG: "0"
+        CARGO_PROFILE_TEST_DEBUG: "0"
+      strategy:
+        matrix:
+          os: [ubuntu-latest, macos-latest]
+      steps:
+    """
+).rstrip()
+CI_JOB_DISPLAY_NAMES = {
+    "dco": "DCO Sign-off",
+    "npm-launchers": "npm launcher tests",
+    "windows-authority-tests": "Windows authority tests",
+    "windows-installer": "Windows installer + vector-free release build",
+    "changes": "Classify diff scope",
+    "check-docs-only": "Check & Test",
+    "check": "Check & Test",
+    "coverage": "Code Coverage",
+}
 
 
 def require(content: str, needle: str, context: str) -> None:
@@ -190,11 +233,93 @@ def assert_docs_only_classifier_guard(classifier: str) -> None:
         raise AssertionError("diff classifier shell extraction disagrees with its job")
 
 
+def workflow_job_blocks(workflow: str) -> dict[str, str]:
+    """Return every job block from a workflow, preserving declaration order."""
+
+    marker = "jobs:\n"
+    if workflow.count(marker) != 1:
+        raise AssertionError("workflow must contain exactly one jobs mapping")
+    jobs = workflow.split(marker, 1)[1]
+    matches = list(
+        re.finditer(r"^  (?P<job>[A-Za-z0-9_-]+):[ \t]*$", jobs, re.MULTILINE)
+    )
+    blocks: dict[str, str] = {}
+    for index, match in enumerate(matches):
+        job = match.group("job")
+        if job in blocks:
+            raise AssertionError(f"workflow declares duplicate job id: {job}")
+        end = matches[index + 1].start() if index + 1 < len(matches) else len(jobs)
+        blocks[job] = jobs[match.start():end].rstrip()
+    return blocks
+
+
+def job_display_name(job: str) -> str:
+    """Return the exact one-line display name for a job block."""
+
+    active_lines = classifier_active_job_source(job).splitlines()
+    names = [
+        line.removeprefix("  name:").strip()
+        for line in active_lines[1:]
+        if line.startswith("  name:")
+    ]
+    if len(names) != 1:
+        raise AssertionError("every CI job must carry exactly one one-line display name")
+    return names[0]
+
+
+def real_check_job_authority_source(job: str) -> str:
+    """Return the real check job's admission fields and top-level controls."""
+
+    active_lines = classifier_active_job_source(job).splitlines()
+    try:
+        steps = active_lines.index("  steps:")
+    except ValueError as error:
+        raise AssertionError("real Check & Test job is missing its steps mapping") from error
+    authority = active_lines[: steps + 1]
+    authority.extend(
+        line
+        for line in active_lines[steps + 1 :]
+        if len(line) - len(line.lstrip()) == 2
+    )
+    return "\n".join(authority)
+
+
+def assert_check_consumer_authority(workflow: str) -> None:
+    """Pin both jobs that can emit the release-required Check & Test contexts."""
+
+    blocks = workflow_job_blocks(workflow)
+    actual_names = {job: job_display_name(block) for job, block in blocks.items()}
+    if actual_names != CI_JOB_DISPLAY_NAMES:
+        raise AssertionError(
+            "Check & Test consumer authority requires the exact reviewed CI job "
+            "identity and display-name map"
+        )
+
+    docs_only = blocks.get("check-docs-only")
+    real = blocks.get("check")
+    if (
+        docs_only is None
+        or classifier_active_job_source(docs_only) != DOCS_ONLY_CHECK_JOB
+    ):
+        raise AssertionError(
+            "Check & Test consumer authority requires the exact inert docs-only job"
+        )
+    if (
+        real is None
+        or real_check_job_authority_source(real) != REAL_CHECK_JOB_AUTHORITY
+    ):
+        raise AssertionError(
+            "Check & Test consumer authority requires the exact real check admission "
+            "and matrix contract"
+        )
+
+
 def execute_docs_only_classifier(
     classifier: str,
     *,
     cwd: Path = ROOT,
     environment_overrides: dict[str, str] | None = None,
+    privileged: bool = True,
     shell_wrapper: str | None = None,
 ) -> tuple[subprocess.CompletedProcess[str], list[str]]:
     """Execute a classifier mutant on a push and return its emitted outputs."""
@@ -216,7 +341,17 @@ def execute_docs_only_classifier(
         )
         if environment_overrides is not None:
             environment.update(environment_overrides)
-        command = ["bash", "--noprofile", "--norc", "-c", source]
+        command = [
+            "bash",
+            "--noprofile",
+            "--norc",
+            *(["-p"] if privileged else []),
+            "-e",
+            "-u",
+            "-o",
+            "pipefail",
+            str(source_path),
+        ]
         if shell_wrapper is not None:
             command = [
                 "bash",
@@ -287,6 +422,24 @@ def assert_classifier_execution_won(
         raise AssertionError(
             f"classifier falsification did not inspect {changed_path}: "
             f"{label}: {result.stdout}"
+        )
+
+
+def assert_classifier_execution_failed_closed(
+    label: str,
+    result: subprocess.CompletedProcess[str],
+    outputs: list[str],
+) -> None:
+    """Prove hostile inherited shell state leaves a push classified as code."""
+
+    if result.returncode != 0:
+        raise AssertionError(
+            f"classifier fail-closed proof did not execute: {label}: "
+            f"{result.stdout}{result.stderr}"
+        )
+    if outputs != ["docs_only=false"]:
+        raise AssertionError(
+            f"classifier did not fail closed: {label}: {outputs}"
         )
 
 
@@ -1330,6 +1483,147 @@ def main() -> None:
     classifier_end = ci_workflow.index("\n  check-docs-only:", classifier_start)
     classifier = ci_workflow[classifier_start:classifier_end]
     assert_docs_only_classifier_guard(classifier)
+    assert_check_consumer_authority(ci_workflow)
+    consumer_blocks = workflow_job_blocks(ci_workflow)
+    docs_only_check = consumer_blocks["check-docs-only"]
+    real_check = consumer_blocks["check"]
+
+    docs_only_condition = (
+        "    if: ${{ !cancelled() && "
+        "needs.changes.outputs.docs_only == 'true' }}"
+    )
+    real_check_condition = (
+        "    if: ${{ !cancelled() && "
+        "needs.changes.outputs.docs_only != 'true' }}"
+    )
+    swapped_docs_only_check = docs_only_check.replace(
+        docs_only_condition,
+        real_check_condition,
+        1,
+    )
+    swapped_real_check = real_check.replace(
+        real_check_condition,
+        docs_only_condition,
+        1,
+    )
+    swapped_consumers = ci_workflow.replace(
+        docs_only_check,
+        swapped_docs_only_check,
+        1,
+    ).replace(
+        real_check,
+        swapped_real_check,
+        1,
+    )
+    expect_assertion(
+        "stub and real Check & Test conditions swapped",
+        "Check & Test consumer authority",
+        lambda: assert_check_consumer_authority(swapped_consumers),
+    )
+
+    for label, old, new in (
+        (
+            "docs-only Check & Test job identity changed",
+            "  check-docs-only:",
+            "  check-context-spoof:",
+        ),
+        (
+            "docs-only Check & Test display name changed",
+            "    name: Check & Test",
+            "    name: Documentation shortcut",
+        ),
+        (
+            "docs-only Check & Test dependency changed",
+            "    needs: changes",
+            "    needs: dco",
+        ),
+        (
+            "docs-only Check & Test runner changed",
+            "    runs-on: ubuntu-latest",
+            "    runs-on: ${{ matrix.os }}",
+        ),
+        (
+            "docs-only Check & Test matrix changed",
+            "        os: [ubuntu-latest, macos-latest]",
+            "        os: [ubuntu-latest]",
+        ),
+        (
+            "docs-only Check & Test inert step changed",
+            '      run: echo "documentation-only diff; '
+            'build and test validation not applicable"',
+            '      run: echo "unreviewed shortcut"',
+        ),
+    ):
+        if docs_only_check.count(old) != 1:
+            raise AssertionError(
+                f"Check & Test consumer falsification could not identify {label}"
+            )
+        mutant_job = docs_only_check.replace(old, new, 1)
+        mutant_workflow = ci_workflow.replace(docs_only_check, mutant_job, 1)
+        expect_assertion(
+            label,
+            "Check & Test consumer authority",
+            lambda mutant_workflow=mutant_workflow: (
+                assert_check_consumer_authority(mutant_workflow)
+            ),
+        )
+
+    for label, old, new in (
+        (
+            "real Check & Test display name changed",
+            "    name: Check & Test",
+            "    name: Check & Test trusted",
+        ),
+        (
+            "real Check & Test dependency changed",
+            "    needs: changes",
+            "    needs: dco",
+        ),
+        (
+            "real Check & Test runner detached from its matrix",
+            "    runs-on: ${{ matrix.os }}",
+            "    runs-on: ubuntu-latest",
+        ),
+        (
+            "real Check & Test matrix changed",
+            "        os: [ubuntu-latest, macos-latest]",
+            "        os: [ubuntu-latest]",
+        ),
+    ):
+        if real_check.count(old) != 1:
+            raise AssertionError(
+                f"Check & Test consumer falsification could not identify {label}"
+            )
+        mutant_job = real_check.replace(old, new, 1)
+        mutant_workflow = ci_workflow.replace(real_check, mutant_job, 1)
+        expect_assertion(
+            label,
+            "Check & Test consumer authority",
+            lambda mutant_workflow=mutant_workflow: (
+                assert_check_consumer_authority(mutant_workflow)
+            ),
+        )
+
+    coverage_job = consumer_blocks["coverage"]
+    if coverage_job.count("    name: Code Coverage") != 1:
+        raise AssertionError(
+            "Check & Test consumer falsification could not identify coverage name"
+        )
+    duplicate_context = ci_workflow.replace(
+        coverage_job,
+        coverage_job.replace(
+            "    name: Code Coverage",
+            "    name: Check & Test",
+            1,
+        ),
+        1,
+    )
+    expect_assertion(
+        "unrelated job spoofs the Check & Test display context",
+        "Check & Test consumer authority",
+        lambda: assert_check_consumer_authority(duplicate_context),
+    )
+
     for label, old, new in (
         (
             "classifier job output remapped to a constant",
@@ -1337,9 +1631,10 @@ def main() -> None:
             '      docs_only: "true"',
         ),
         (
-            "classifier checkout ref changed",
+            "classifier checkout pin changed to a moving ref",
+            "      - uses: actions/checkout@"
+            "3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1",
             "      - uses: actions/checkout@v7",
-            "      - uses: actions/checkout@v6",
         ),
         (
             "classifier checkout depth changed",
@@ -1429,17 +1724,54 @@ def main() -> None:
             cwd=fixture,
             environment_overrides={"BASH_ENV": str(hostile_bash_env)},
         )
+        assert_classifier_execution_failed_closed(
+            "privileged classifier shell ignores BASH_ENV startup injection",
+            result,
+            outputs,
+        )
+
+        shell_line = (
+            "        shell: /usr/bin/bash --noprofile --norc "
+            "-p -e -u -o pipefail {0}"
+        )
+        unprivileged_shell = classifier.replace(
+            shell_line,
+            "        shell: /usr/bin/bash --noprofile --norc "
+            "-e -u -o pipefail {0}",
+            1,
+        )
+        expect_assertion(
+            "classifier shell drops privileged startup",
+            "exactly match the closed-form docs_only authority contract",
+            lambda: assert_docs_only_classifier_guard(unprivileged_shell),
+        )
+        hostile_functions = {
+            "BASH_FUNC_[%%": "() { return 0; }",
+            "BASH_FUNC_git%%": "() { printf 'docs/release-bot.md\\n'; }",
+        }
+        result, outputs = execute_docs_only_classifier(
+            classifier,
+            cwd=fixture,
+            environment_overrides=hostile_functions,
+        )
+        assert_classifier_execution_failed_closed(
+            "privileged classifier rejects inherited test and git functions",
+            result,
+            outputs,
+        )
+        result, outputs = execute_docs_only_classifier(
+            unprivileged_shell,
+            cwd=fixture,
+            environment_overrides=hostile_functions,
+            privileged=False,
+        )
         assert_classifier_execution_won(
-            "classifier shell startup overridden through BASH_ENV",
+            "unprivileged classifier imports hostile test and git functions",
             result,
             outputs,
             changed_path="docs/release-bot.md",
         )
 
-        shell_line = (
-            "        shell: /usr/bin/bash --noprofile --norc "
-            "-e -u -o pipefail {0}"
-        )
         hostile_shell = classifier.replace(
             shell_line,
             "        shell: bash --noprofile --norc -c "

--- a/scripts/test-release-workflow-authority.py
+++ b/scripts/test-release-workflow-authority.py
@@ -774,11 +774,21 @@ def main() -> None:
     # Cargo caches are restore-anywhere, save-from-main-only. That is what keeps
     # one reusable warm entry per job alive under the repository cache budget,
     # and it is also what denies a fork pull request any way to write a cache a
-    # trusted run would later restore.
-    rust_cache_uses = ci_workflow.count(
-        "uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4"
-    )
-    trusted_saves = ci_workflow.count("save-if: ${{ github.ref == 'refs/heads/main' }}")
+    # trusted run would later restore. Checked across every workflow, so a new
+    # job cannot reintroduce pull-request cache writes in a file nobody pinned.
+    rust_cache_uses = 0
+    trusted_saves = 0
+    for workflow in sorted(WORKFLOWS.glob("*.yml")):
+        content = workflow.read_text(encoding="utf-8")
+        pinned = content.count(
+            "uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4"
+        )
+        if content.count("uses: Swatinem/rust-cache@") != pinned:
+            raise AssertionError(
+                f"{workflow.name} uses rust-cache at an unpinned ref"
+            )
+        rust_cache_uses += pinned
+        trusted_saves += content.count("save-if: ${{ github.ref == 'refs/heads/main' }}")
     if rust_cache_uses == 0 or rust_cache_uses != trusted_saves:
         raise AssertionError(
             "every pinned rust-cache use must save only from main: "

--- a/scripts/test-release-workflow-authority.py
+++ b/scripts/test-release-workflow-authority.py
@@ -6,6 +6,7 @@
 
 from __future__ import annotations
 
+import hashlib
 import json
 import os
 import re
@@ -144,6 +145,174 @@ CI_JOB_DISPLAY_NAMES = {
     "check": "Check & Test",
     "coverage": "Code Coverage",
 }
+EXPECTED_WORKFLOW_JOB_DISPLAY_NAMES: dict[str, dict[str, str | None]] = {
+    ".github/workflows/approve-to-merge.yml": {
+        "gate": None,
+    },
+    ".github/workflows/ci.yml": CI_JOB_DISPLAY_NAMES,
+    ".github/workflows/daemon-smoke.yml": {
+        "daemon-smoke": "Linux Daemon Smoke + MCP Headless",
+    },
+    ".github/workflows/dco.yml": {
+        # This pull_request_target check is deliberately distinct from the
+        # release-required CI job. GitHub check names are case-sensitive:
+        # lowercase "sign-off" is extra PR evidence, never release evidence.
+        "dco": "DCO sign-off",
+    },
+    ".github/workflows/docker.yml": {
+        "build-image": "Docker Image Build (no push)",
+    },
+    ".github/workflows/fuzz.yml": {
+        "fuzz": "cargo-fuzz (${{ matrix.target }})",
+    },
+    ".github/workflows/install-proof.yml": {
+        "install-proof": "${{ matrix.os }}",
+    },
+    ".github/workflows/link-check.yml": {
+        "link-check": "Check public documentation links",
+    },
+    ".github/workflows/notify-approver.yml": {
+        "notify": None,
+    },
+    ".github/workflows/publish-release-installers.yml": {
+        "dispatch": None,
+    },
+    ".github/workflows/registry-index-migrate.yml": {
+        "migrate": None,
+    },
+    ".github/workflows/release-tag.yml": {
+        "mint-release-tag": "Mint release tag",
+    },
+    ".github/workflows/release.yml": {
+        "config": "Resolve release config",
+        "build_daemon_image": "Build immutable daemon image",
+        "attest_daemon_image": "Attest immutable daemon image",
+        "build": "Build (${{ matrix.artifact }})",
+        "notarize_linux": "Notarize macOS binaries (Linux / rcodesign)",
+        "publish": "Publish Release",
+        "install_proof": "Public Install Proof",
+        "npm_publish_preflight": "Preflight Both npm Packages",
+        "publish_npm_compatibility": (
+            "Publish npm Compatibility Wrapper (@kinlab/kin-mcp)"
+        ),
+        "publish_npm_canonical": "Publish npm Canonical Package (@kinlab/kin)",
+        "verify_npm_published": (
+            "Verify Published npm Provenance (${{ matrix.package }})"
+        ),
+        "smoke_npm_published": (
+            "Anonymous Published npm Smoke (${{ matrix.package }})"
+        ),
+        "finalize_release": "Promote Proven Release",
+        "promote_ghcr_latest": "Promote stable ghcr latest",
+        "publish_boundary_contracts": "Post-release boundary contracts publish",
+        "version_tag_image": "Version-tag ghcr image",
+    },
+    ".github/workflows/sast.yml": {
+        "changes": "Classify diff scope",
+        "cargo-deny": "cargo-deny",
+    },
+    ".github/workflows/secret-scan.yml": {
+        "gitleaks": "gitleaks (full history)",
+    },
+}
+EXPECTED_DYNAMIC_JOB_CONTEXT_SHA256 = {
+    (
+        ".github/workflows/fuzz.yml",
+        "fuzz",
+    ): "aa645addde738ea8f1fac9c70071ac0f603fd0030602f15d013535abf9a32443",
+    (
+        ".github/workflows/install-proof.yml",
+        "install-proof",
+    ): "c5cd6bbfa99f45c84084d22aafe5e0bb038c2ee006404a58d72e19a0db69b46e",
+    (
+        ".github/workflows/release.yml",
+        "build",
+    ): "4708a5968103aa4c624423fd5a67c5c183969919773e52c9cc204b2c9983c90b",
+    (
+        ".github/workflows/release.yml",
+        "verify_npm_published",
+    ): "be398c786bc9f4a31e8a4196076f707a93b33b70c0ec9b4a0ea5e87f3e84c314",
+    (
+        ".github/workflows/release.yml",
+        "smoke_npm_published",
+    ): "495829aee07c97dfd59924fcac7ff3ddb57be574ffd0bf741adc93a37425b492",
+}
+REQUIRED_CHECK_JOB_PRODUCERS = {
+    "Check & Test": {
+        (".github/workflows/ci.yml", "check-docs-only"),
+        (".github/workflows/ci.yml", "check"),
+    },
+    "DCO Sign-off": {
+        (".github/workflows/ci.yml", "dco"),
+    },
+    "cargo-deny": {
+        (".github/workflows/sast.yml", "cargo-deny"),
+    },
+    "gitleaks (full history)": {
+        (".github/workflows/secret-scan.yml", "gitleaks"),
+    },
+    "Windows installer + vector-free release build": {
+        (".github/workflows/ci.yml", "windows-installer"),
+    },
+}
+# Durable workflow IDs are GitHub's repository-scoped identity, while `path`
+# makes that identity reviewable in source. These values are also exercised
+# against the current REST response shape by the positive fixture below.
+REQUIRED_RELEASE_CHECK_PROVENANCE = {
+    "Check & Test (ubuntu-latest)": (
+        245_803_170,
+        ".github/workflows/ci.yml",
+        "push",
+    ),
+    "Check & Test (macos-latest)": (
+        245_803_170,
+        ".github/workflows/ci.yml",
+        "push",
+    ),
+    "DCO Sign-off": (245_803_170, ".github/workflows/ci.yml", "push"),
+    "cargo-deny": (251_549_972, ".github/workflows/sast.yml", "push"),
+    "gitleaks (full history)": (
+        293_452_372,
+        ".github/workflows/secret-scan.yml",
+        "push",
+    ),
+    "Windows installer + vector-free release build": (
+        245_803_170,
+        ".github/workflows/ci.yml",
+        "push",
+    ),
+}
+RELEASE_TAG_WORKFLOW_ID = 318_521_292
+RELEASE_GATE_FIXTURE_SHA = "1" * 40
+RELEASE_GATE_CURRENT_RUN_ID = 9000
+EXTERNAL_REQUIRED_CONTEXT_SPOOF = textwrap.dedent(
+    """\
+    name: Required Context Spoof
+
+    on:
+      push:
+        branches: [main]
+
+    permissions:
+      contents: read
+
+    jobs:
+      delay:
+        name: Delay context creation
+        runs-on: ubuntu-latest
+        steps:
+          - run: sleep 1
+      spoof:
+        name: Check & Test
+        needs: delay
+        runs-on: ubuntu-latest
+        strategy:
+          matrix:
+            os: [ubuntu-latest, macos-latest]
+        steps:
+          - run: echo success
+    """
+)
 
 
 def require(content: str, needle: str, context: str) -> None:
@@ -240,21 +409,37 @@ def workflow_job_blocks(workflow: str) -> dict[str, str]:
     if workflow.count(marker) != 1:
         raise AssertionError("workflow must contain exactly one jobs mapping")
     jobs = workflow.split(marker, 1)[1]
+    top_level_job_lines = [
+        line
+        for line in jobs.splitlines()
+        if line.startswith("  ")
+        and not line.startswith(("   ", "\t"))
+        and line.strip()
+        and not line.lstrip().startswith("#")
+    ]
+    for line in top_level_job_lines:
+        if re.fullmatch(r"  [A-Za-z0-9_-]+:[ \t]*", line) is None:
+            raise AssertionError(
+                "workflow job ids must use one canonical unquoted scalar line: "
+                f"{line.strip()}"
+            )
     matches = list(
         re.finditer(r"^  (?P<job>[A-Za-z0-9_-]+):[ \t]*$", jobs, re.MULTILINE)
     )
+    if len(matches) != len(top_level_job_lines):
+        raise AssertionError("workflow job census did not account for every job key")
     blocks: dict[str, str] = {}
     for index, match in enumerate(matches):
         job = match.group("job")
         if job in blocks:
             raise AssertionError(f"workflow declares duplicate job id: {job}")
         end = matches[index + 1].start() if index + 1 < len(matches) else len(jobs)
-        blocks[job] = jobs[match.start():end].rstrip()
+        blocks[job] = jobs[match.start() : end].rstrip()
     return blocks
 
 
-def job_display_name(job: str) -> str:
-    """Return the exact one-line display name for a job block."""
+def optional_job_display_name(job: str) -> str | None:
+    """Return a job's exact top-level display name, if it declares one."""
 
     active_lines = classifier_active_job_source(job).splitlines()
     names = [
@@ -262,9 +447,97 @@ def job_display_name(job: str) -> str:
         for line in active_lines[1:]
         if line.startswith("  name:")
     ]
-    if len(names) != 1:
-        raise AssertionError("every CI job must carry exactly one one-line display name")
-    return names[0]
+    if len(names) > 1:
+        raise AssertionError(
+            "workflow jobs may carry at most one one-line display name"
+        )
+    return names[0] if names else None
+
+
+def job_display_name(job: str) -> str:
+    """Return the required exact one-line display name for a CI job block."""
+
+    name = optional_job_display_name(job)
+    if name is None:
+        raise AssertionError(
+            "every CI job must carry exactly one one-line display name"
+        )
+    return name
+
+
+def dynamic_job_context_source(job: str) -> str:
+    """Return the name-bearing matrix contract for a dynamic job display name."""
+
+    active_lines = classifier_active_job_source(job).splitlines()
+    try:
+        strategy_start = active_lines.index("  strategy:")
+    except ValueError as error:
+        raise AssertionError(
+            "a matrix-derived workflow job name requires an explicit strategy"
+        ) from error
+    strategy_end = len(active_lines)
+    for index in range(strategy_start + 1, len(active_lines)):
+        line = active_lines[index]
+        if len(line) - len(line.lstrip()) <= 2:
+            strategy_end = index
+            break
+    return "\n".join(active_lines[strategy_start:strategy_end])
+
+
+def assert_workflow_job_census(workflows: dict[Path, str]) -> None:
+    """Pin every workflow job so no second required-context producer can appear."""
+
+    actual: dict[str, dict[str, str | None]] = {}
+    dynamic_contexts: dict[tuple[str, str], str] = {}
+    for workflow, content in sorted(workflows.items()):
+        path = workflow.relative_to(ROOT).as_posix()
+        actual[path] = {}
+        for job_id, block in workflow_job_blocks(content).items():
+            display_name = optional_job_display_name(block)
+            actual[path][job_id] = display_name
+            if display_name is None or "${{" not in display_name:
+                continue
+            if "${{ matrix." not in display_name:
+                raise AssertionError(
+                    "dynamic workflow job display names must derive only from "
+                    f"their reviewed matrix contract: {path}:{job_id}"
+                )
+            authority = (
+                f"{display_name}\n{dynamic_job_context_source(block)}"
+            ).encode()
+            dynamic_contexts[(path, job_id)] = hashlib.sha256(authority).hexdigest()
+
+    if actual != EXPECTED_WORKFLOW_JOB_DISPLAY_NAMES:
+        raise AssertionError(
+            "workflow-wide required-check producer census requires the exact "
+            "reviewed workflow paths, job ids, and display names"
+        )
+    if dynamic_contexts != EXPECTED_DYNAMIC_JOB_CONTEXT_SHA256:
+        raise AssertionError(
+            "workflow-wide required-check producer census requires the exact "
+            "reviewed matrix expansions for dynamic job display names"
+        )
+
+    actual_producers = {name: set() for name in REQUIRED_CHECK_JOB_PRODUCERS}
+    reserved_expanded_names = set(REQUIRED_RELEASE_CHECKS) - set(
+        REQUIRED_CHECK_JOB_PRODUCERS
+    )
+    for path, jobs in actual.items():
+        for job_id, display_name in jobs.items():
+            if display_name in actual_producers:
+                actual_producers[display_name].add((path, job_id))
+            if display_name in reserved_expanded_names:
+                raise AssertionError(
+                    "workflow job directly claims a release-required expanded "
+                    f"context outside its reviewed producer: {path}:{job_id}: "
+                    f"{display_name}"
+                )
+
+    if actual_producers != REQUIRED_CHECK_JOB_PRODUCERS:
+        raise AssertionError(
+            "workflow-wide release-required check producers do not match the "
+            "reviewed workflow/job authority map"
+        )
 
 
 def real_check_job_authority_source(job: str) -> str:
@@ -274,7 +547,9 @@ def real_check_job_authority_source(job: str) -> str:
     try:
         steps = active_lines.index("  steps:")
     except ValueError as error:
-        raise AssertionError("real Check & Test job is missing its steps mapping") from error
+        raise AssertionError(
+            "real Check & Test job is missing its steps mapping"
+        ) from error
     authority = active_lines[: steps + 1]
     authority.extend(
         line
@@ -372,9 +647,7 @@ def execute_docs_only_classifier(
             check=False,
         )
         outputs = (
-            output.read_text(encoding="utf-8").splitlines()
-            if output.exists()
-            else []
+            output.read_text(encoding="utf-8").splitlines() if output.exists() else []
         )
     return result, outputs
 
@@ -415,8 +688,7 @@ def assert_classifier_execution_won(
         )
     if not outputs or outputs[-1] != "docs_only=true":
         raise AssertionError(
-            f"classifier falsification did not override push output: {label}: "
-            f"{outputs}"
+            f"classifier falsification did not override push output: {label}: {outputs}"
         )
     if changed_path is not None and changed_path not in result.stdout.splitlines():
         raise AssertionError(
@@ -438,9 +710,7 @@ def assert_classifier_execution_failed_closed(
             f"{result.stdout}{result.stderr}"
         )
     if outputs != ["docs_only=false"]:
-        raise AssertionError(
-            f"classifier did not fail closed: {label}: {outputs}"
-        )
+        raise AssertionError(f"classifier did not fail closed: {label}: {outputs}")
 
 
 def bash_supports_nameref() -> bool:
@@ -452,8 +722,8 @@ def bash_supports_nameref() -> bool:
             "--noprofile",
             "--norc",
             "-c",
-            "target=original; original=false; declare -n ref=\"$target\"; "
-            "ref=true; [ \"$original\" = true ]",
+            'target=original; original=false; declare -n ref="$target"; '
+            'ref=true; [ "$original" = true ]',
         ],
         capture_output=True,
         text=True,
@@ -680,34 +950,150 @@ def release_check_gate_source(release_tag: str) -> str:
 def execute_release_check_gate(
     source: str,
     conclusions: dict[str, str],
-) -> subprocess.CompletedProcess[str]:
-    """Execute the workflow's real admission code against synthetic check runs."""
-
-    runs = [
-        {
-            "name": name,
-            "status": "completed",
-            "conclusion": conclusions.get(name, "success"),
-            "id": index,
-        }
-        for index, name in enumerate(REQUIRED_RELEASE_CHECKS, start=1)
+    *,
+    mutate_fixture: Callable[
+        [
+            list[dict[str, object]],
+            list[dict[str, object]],
+            dict[str, object],
+        ],
+        None,
     ]
+    | None = None,
+) -> subprocess.CompletedProcess[str]:
+    """Execute the real gate against a current-API-shaped provenance fixture."""
+
+    workflow_specs = {
+        ".github/workflows/ci.yml": {
+            "id": 1001,
+            "workflow_id": 245_803_170,
+            "path": ".github/workflows/ci.yml",
+            "event": "push",
+            "head_sha": RELEASE_GATE_FIXTURE_SHA,
+            "status": "completed",
+            "conclusion": "success",
+            "check_suite_id": 101,
+        },
+        ".github/workflows/sast.yml": {
+            "id": 1002,
+            "workflow_id": 251_549_972,
+            "path": ".github/workflows/sast.yml",
+            "event": "push",
+            "head_sha": RELEASE_GATE_FIXTURE_SHA,
+            "status": "completed",
+            "conclusion": "success",
+            "check_suite_id": 102,
+        },
+        ".github/workflows/secret-scan.yml": {
+            "id": 1003,
+            "workflow_id": 293_452_372,
+            "path": ".github/workflows/secret-scan.yml",
+            "event": "push",
+            "head_sha": RELEASE_GATE_FIXTURE_SHA,
+            "status": "completed",
+            "conclusion": "success",
+            "check_suite_id": 103,
+        },
+    }
+    workflow_runs = list(workflow_specs.values())
+    current_run: dict[str, object] = {
+        "id": RELEASE_GATE_CURRENT_RUN_ID,
+        "workflow_id": RELEASE_TAG_WORKFLOW_ID,
+        "path": ".github/workflows/release-tag.yml",
+        "event": "workflow_dispatch",
+        "head_sha": RELEASE_GATE_FIXTURE_SHA,
+        "status": "in_progress",
+        "conclusion": None,
+        "check_suite_id": 104,
+    }
+    workflow_runs.append(current_run.copy())
+    check_runs = []
+    for index, name in enumerate(REQUIRED_RELEASE_CHECKS, start=1):
+        _, workflow_path, _ = REQUIRED_RELEASE_CHECK_PROVENANCE[name]
+        check_runs.append(
+            {
+                "name": name,
+                "status": "completed",
+                "conclusion": conclusions.get(name, "success"),
+                "id": index,
+                "app_slug": "github-actions",
+                "check_suite_id": workflow_specs[workflow_path]["check_suite_id"],
+                "head_sha": RELEASE_GATE_FIXTURE_SHA,
+            }
+        )
+    check_runs.append(
+        {
+            "name": "Mint release tag",
+            "status": "in_progress",
+            "conclusion": None,
+            "id": len(check_runs) + 1,
+            "app_slug": "github-actions",
+            "check_suite_id": current_run["check_suite_id"],
+            "head_sha": RELEASE_GATE_FIXTURE_SHA,
+        }
+    )
+    if mutate_fixture is not None:
+        mutate_fixture(check_runs, workflow_runs, current_run)
+
     with tempfile.TemporaryDirectory() as directory:
-        evidence = Path(directory) / "check_runs.ndjson"
-        evidence.write_text(
-            "".join(f"{json.dumps(run)}\n" for run in runs),
+        fixture = Path(directory)
+        (fixture / "check_runs.ndjson").write_text(
+            "".join(f"{json.dumps(run)}\n" for run in check_runs),
+            encoding="utf-8",
+        )
+        (fixture / "workflow_runs.ndjson").write_text(
+            "".join(f"{json.dumps(run)}\n" for run in workflow_runs),
+            encoding="utf-8",
+        )
+        (fixture / "current_run.json").write_text(
+            json.dumps(current_run),
             encoding="utf-8",
         )
         environment = os.environ.copy()
-        environment["REQUIRED_CHECKS"] = "\n".join(REQUIRED_RELEASE_CHECKS)
+        environment.update(
+            {
+                "CURRENT_RUN_ID": str(RELEASE_GATE_CURRENT_RUN_ID),
+                "REQUIRED_CHECKS": "\n".join(REQUIRED_RELEASE_CHECKS),
+                "SHA": RELEASE_GATE_FIXTURE_SHA,
+            }
+        )
         return subprocess.run(
             [sys.executable, "-c", source],
-            cwd=directory,
+            cwd=fixture,
             env=environment,
             capture_output=True,
             text=True,
             timeout=10,
             check=False,
+        )
+
+
+def assert_release_gate_fixture_rejected(
+    source: str,
+    label: str,
+    expected_error: str,
+    mutate_fixture: Callable[
+        [
+            list[dict[str, object]],
+            list[dict[str, object]],
+            dict[str, object],
+        ],
+        None,
+    ],
+) -> None:
+    """Require a provenance/collision fixture to fail for the expected reason."""
+
+    result = execute_release_check_gate(
+        source,
+        {},
+        mutate_fixture=mutate_fixture,
+    )
+    output = result.stdout + result.stderr
+    if result.returncode == 0:
+        raise AssertionError(f"release gate falsification was admitted: {label}")
+    if expected_error not in output:
+        raise AssertionError(
+            f"release gate falsification failed for the wrong reason: {label}: {output}"
         )
 
 
@@ -766,6 +1152,80 @@ def main() -> None:
     install_ps1 = INSTALL_PS1.read_text(encoding="utf-8")
     health = HEALTH.read_text(encoding="utf-8")
     docker_workflow = (WORKFLOWS / "docker.yml").read_text(encoding="utf-8")
+    workflow_sources = {
+        workflow: workflow.read_text(encoding="utf-8") for workflow in workflow_paths()
+    }
+    assert_workflow_job_census(workflow_sources)
+
+    external_context_spoof = dict(workflow_sources)
+    external_context_spoof[WORKFLOWS / "required-context-spoof.yaml"] = (
+        EXTERNAL_REQUIRED_CONTEXT_SPOOF
+    )
+    expect_assertion(
+        "external workflow emits the release-required Check & Test matrix contexts",
+        "workflow-wide required-check producer census",
+        lambda: assert_workflow_job_census(external_context_spoof),
+    )
+
+    quoted_job_spoof = dict(workflow_sources)
+    quoted_job_spoof[WORKFLOWS / "ci.yml"] = quoted_job_spoof[
+        WORKFLOWS / "ci.yml"
+    ].replace(
+        "jobs:\n",
+        'jobs:\n  "context-spoof":\n'
+        "    name: Check & Test\n"
+        "    runs-on: ubuntu-latest\n"
+        "    steps:\n"
+        "      - run: echo success\n",
+        1,
+    )
+    expect_assertion(
+        "quoted job id hides a required-context producer before the first job",
+        "canonical unquoted scalar",
+        lambda: assert_workflow_job_census(quoted_job_spoof),
+    )
+
+    auxiliary_dco = WORKFLOWS / "dco.yml"
+    promoted_dco = dict(workflow_sources)
+    if promoted_dco[auxiliary_dco].count("    name: DCO sign-off") != 1:
+        raise AssertionError(
+            "workflow census falsification could not identify auxiliary DCO name"
+        )
+    promoted_dco[auxiliary_dco] = promoted_dco[auxiliary_dco].replace(
+        "    name: DCO sign-off",
+        "    name: DCO Sign-off",
+        1,
+    )
+    expect_assertion(
+        "auxiliary DCO workflow claims the release-required DCO context",
+        "workflow-wide required-check producer census",
+        lambda: assert_workflow_job_census(promoted_dco),
+    )
+
+    install_proof_workflow = WORKFLOWS / "install-proof.yml"
+    dynamic_context_spoof = dict(workflow_sources)
+    if (
+        dynamic_context_spoof[install_proof_workflow].count(
+            "          - os: ubuntu-latest"
+        )
+        != 1
+    ):
+        raise AssertionError(
+            "workflow census falsification could not identify install-proof matrix"
+        )
+    dynamic_context_spoof[install_proof_workflow] = dynamic_context_spoof[
+        install_proof_workflow
+    ].replace(
+        "          - os: ubuntu-latest",
+        "          - os: Check & Test (ubuntu-latest)",
+        1,
+    )
+    expect_assertion(
+        "dynamic matrix-only job resolves to a release-required context",
+        "exact reviewed matrix expansions",
+        lambda: assert_workflow_job_census(dynamic_context_spoof),
+    )
+
     require(
         install_sh,
         '"$EXTRACT_DIR/kin" registry authority --initialize',
@@ -1489,12 +1949,10 @@ def main() -> None:
     real_check = consumer_blocks["check"]
 
     docs_only_condition = (
-        "    if: ${{ !cancelled() && "
-        "needs.changes.outputs.docs_only == 'true' }}"
+        "    if: ${{ !cancelled() && needs.changes.outputs.docs_only == 'true' }}"
     )
     real_check_condition = (
-        "    if: ${{ !cancelled() && "
-        "needs.changes.outputs.docs_only != 'true' }}"
+        "    if: ${{ !cancelled() && needs.changes.outputs.docs_only != 'true' }}"
     )
     swapped_docs_only_check = docs_only_check.replace(
         docs_only_condition,
@@ -1563,8 +2021,8 @@ def main() -> None:
         expect_assertion(
             label,
             "Check & Test consumer authority",
-            lambda mutant_workflow=mutant_workflow: (
-                assert_check_consumer_authority(mutant_workflow)
+            lambda mutant_workflow=mutant_workflow: assert_check_consumer_authority(
+                mutant_workflow
             ),
         )
 
@@ -1599,8 +2057,8 @@ def main() -> None:
         expect_assertion(
             label,
             "Check & Test consumer authority",
-            lambda mutant_workflow=mutant_workflow: (
-                assert_check_consumer_authority(mutant_workflow)
+            lambda mutant_workflow=mutant_workflow: assert_check_consumer_authority(
+                mutant_workflow
             ),
         )
 
@@ -1704,9 +2162,7 @@ def main() -> None:
 
         hostile_bash_env = Path(directory) / "hostile-bash-env"
         hostile_bash_env.write_text(
-            "EVENT_NAME=pull_request\n"
-            f"BASE_SHA={base_sha}\n"
-            f"HEAD_SHA={head_sha}\n",
+            f"EVENT_NAME=pull_request\nBASE_SHA={base_sha}\nHEAD_SHA={head_sha}\n",
             encoding="utf-8",
         )
         bash_env_mutant = classifier.replace(
@@ -1731,13 +2187,11 @@ def main() -> None:
         )
 
         shell_line = (
-            "        shell: /usr/bin/bash --noprofile --norc "
-            "-p -e -u -o pipefail {0}"
+            "        shell: /usr/bin/bash --noprofile --norc -p -e -u -o pipefail {0}"
         )
         unprivileged_shell = classifier.replace(
             shell_line,
-            "        shell: /usr/bin/bash --noprofile --norc "
-            "-e -u -o pipefail {0}",
+            "        shell: /usr/bin/bash --noprofile --norc -e -u -o pipefail {0}",
             1,
         )
         expect_assertion(
@@ -1861,7 +2315,7 @@ def main() -> None:
         "          fi\n"
         '          echo "docs_only=$docs_only" >> "$GITHUB_OUTPUT"\n'
         "          name=docs_$(printf only); "
-        "printf '%s=true\\n' \"$name\" >> \"$GITHUB_OUTPUT\"",
+        'printf \'%s=true\\n\' "$name" >> "$GITHUB_OUTPUT"',
         1,
     )
     assert_classifier_bypass_rejected(
@@ -1878,6 +2332,22 @@ def main() -> None:
     assert_docs_only_classifier_guard(comment_only)
 
     release_tag = RELEASE_TAG.read_text(encoding="utf-8")
+    release_tag_header = release_tag.split("\njobs:", 1)[0]
+    require(
+        release_tag_header,
+        "permissions:\n  contents: read\n  checks: read\n  actions: read",
+        "release-tag read-only check and workflow provenance access",
+    )
+    for forbidden_permission in (
+        "contents: write",
+        "checks: write",
+        "actions: write",
+    ):
+        if forbidden_permission in release_tag_header:
+            raise AssertionError(
+                "release-tag workflow token must remain read-only: "
+                f"{forbidden_permission}"
+            )
     for policy in (
         "REQUIRED_CHECKS: |",
         "Check & Test (ubuntu-latest)",
@@ -1888,6 +2358,16 @@ def main() -> None:
         "Windows installer + vector-free release build",
         "missing required check: {name}",
         "required check not green: {name}",
+        "ambiguous required check: {name}",
+        "required check workflow provenance mismatch: {name}",
+        "actions: read",
+        "filter=all",
+        "app_slug: .app.slug",
+        "check_suite_id: .check_suite.id",
+        "workflow_id: .workflow_id",
+        "head_sha: .head_sha",
+        "workflow_runs.ndjson",
+        "current_run.json",
     ):
         require(release_tag, policy, "release tag required-check gate")
     for policy in (
@@ -1900,6 +2380,12 @@ def main() -> None:
         require(release_tag, policy, "per-check release conclusion policy")
 
     release_gate = release_check_gate_source(release_tag)
+    positive_fixture = execute_release_check_gate(release_gate, {})
+    if positive_fixture.returncode != 0:
+        raise AssertionError(
+            "current release check provenance fixture was rejected: "
+            f"{positive_fixture.stdout}{positive_fixture.stderr}"
+        )
     for accepted_conclusion in ("success", "skipped"):
         assert_release_check_accepted(
             release_gate,
@@ -1921,6 +2407,266 @@ def main() -> None:
         "neutral",
     )
 
+    def required_check_fixture(
+        check_runs: list[dict[str, object]],
+        name: str,
+    ) -> dict[str, object]:
+        matches = [run for run in check_runs if run["name"] == name]
+        if len(matches) != 1:
+            raise AssertionError(
+                f"release gate fixture requires one {name} check, got {len(matches)}"
+            )
+        return matches[0]
+
+    def workflow_fixture(
+        workflow_runs: list[dict[str, object]],
+        suite_id: object,
+    ) -> dict[str, object]:
+        matches = [run for run in workflow_runs if run["check_suite_id"] == suite_id]
+        if len(matches) != 1:
+            raise AssertionError(
+                "release gate fixture requires one workflow for suite "
+                f"{suite_id}, got {len(matches)}"
+            )
+        return matches[0]
+
+    def add_prior_release_tag_refusal(
+        check_runs: list[dict[str, object]],
+        workflow_runs: list[dict[str, object]],
+        _current_run: dict[str, object],
+    ) -> None:
+        workflow_runs.append(
+            {
+                "id": 8_000,
+                "workflow_id": RELEASE_TAG_WORKFLOW_ID,
+                "path": ".github/workflows/release-tag.yml",
+                "event": "workflow_dispatch",
+                "head_sha": RELEASE_GATE_FIXTURE_SHA,
+                "status": "completed",
+                "conclusion": "failure",
+                "check_suite_id": 105,
+            }
+        )
+        check_runs.append(
+            {
+                "name": "Mint release tag",
+                "status": "completed",
+                "conclusion": "failure",
+                "id": 8_001,
+                "app_slug": "github-actions",
+                "check_suite_id": 105,
+                "head_sha": RELEASE_GATE_FIXTURE_SHA,
+            }
+        )
+
+    retry_fixture = execute_release_check_gate(
+        release_gate,
+        {},
+        mutate_fixture=add_prior_release_tag_refusal,
+    )
+    if retry_fixture.returncode != 0:
+        raise AssertionError(
+            "prior refusal from the exact release-tag workflow blocked a retry: "
+            f"{retry_fixture.stdout}{retry_fixture.stderr}"
+        )
+
+    def add_external_mint_failure(
+        check_runs: list[dict[str, object]],
+        workflow_runs: list[dict[str, object]],
+        _current_run: dict[str, object],
+    ) -> None:
+        workflow_runs.append(
+            {
+                "id": 8_100,
+                "workflow_id": 999,
+                "path": ".github/workflows/mint-name-spoof.yml",
+                "event": "push",
+                "head_sha": RELEASE_GATE_FIXTURE_SHA,
+                "status": "completed",
+                "conclusion": "failure",
+                "check_suite_id": 106,
+            }
+        )
+        check_runs.append(
+            {
+                "name": "Mint release tag",
+                "status": "completed",
+                "conclusion": "failure",
+                "id": 8_101,
+                "app_slug": "github-actions",
+                "check_suite_id": 106,
+                "head_sha": RELEASE_GATE_FIXTURE_SHA,
+            }
+        )
+
+    assert_release_gate_fixture_rejected(
+        release_gate,
+        "same-name tag check from another workflow is not self-excluded",
+        "check not green: Mint release tag (conclusion=failure)",
+        add_external_mint_failure,
+    )
+
+    def add_higher_id_success_collision(
+        check_runs: list[dict[str, object]],
+        workflow_runs: list[dict[str, object]],
+        _current_run: dict[str, object],
+    ) -> None:
+        real = required_check_fixture(
+            check_runs,
+            "Check & Test (ubuntu-latest)",
+        )
+        real["conclusion"] = "failure"
+        spoof = real.copy()
+        spoof.update(
+            {
+                "id": 10_000,
+                "conclusion": "success",
+                "check_suite_id": 999,
+            }
+        )
+        check_runs.append(spoof)
+        workflow_runs.append(
+            {
+                "id": 9_999,
+                "workflow_id": 999,
+                "path": ".github/workflows/required-context-spoof.yaml",
+                "event": "push",
+                "head_sha": RELEASE_GATE_FIXTURE_SHA,
+                "status": "completed",
+                "conclusion": "success",
+                "check_suite_id": 999,
+            }
+        )
+
+    assert_release_gate_fixture_rejected(
+        release_gate,
+        "higher-ID same-name success masks a failed required producer",
+        "ambiguous required check: Check & Test (ubuntu-latest) (2 check-runs)",
+        add_higher_id_success_collision,
+    )
+
+    def add_duplicate_success(
+        check_runs: list[dict[str, object]],
+        _workflow_runs: list[dict[str, object]],
+        _current_run: dict[str, object],
+    ) -> None:
+        duplicate = required_check_fixture(check_runs, "cargo-deny").copy()
+        duplicate["id"] = 10_001
+        check_runs.append(duplicate)
+
+    assert_release_gate_fixture_rejected(
+        release_gate,
+        "two successful check-runs claim one required context",
+        "ambiguous required check: cargo-deny (2 check-runs)",
+        add_duplicate_success,
+    )
+
+    def change_required_workflow_path(
+        check_runs: list[dict[str, object]],
+        workflow_runs: list[dict[str, object]],
+        _current_run: dict[str, object],
+    ) -> None:
+        check = required_check_fixture(check_runs, "cargo-deny")
+        workflow = workflow_fixture(workflow_runs, check["check_suite_id"])
+        workflow["path"] = ".github/workflows/required-context-spoof.yaml"
+
+    assert_release_gate_fixture_rejected(
+        release_gate,
+        "required check comes from the wrong workflow path",
+        "required check workflow provenance mismatch: cargo-deny",
+        change_required_workflow_path,
+    )
+
+    def change_required_workflow_id(
+        check_runs: list[dict[str, object]],
+        workflow_runs: list[dict[str, object]],
+        _current_run: dict[str, object],
+    ) -> None:
+        check = required_check_fixture(check_runs, "cargo-deny")
+        workflow = workflow_fixture(workflow_runs, check["check_suite_id"])
+        workflow["workflow_id"] = 999
+
+    assert_release_gate_fixture_rejected(
+        release_gate,
+        "required check comes from the wrong workflow identity",
+        "required check workflow provenance mismatch: cargo-deny",
+        change_required_workflow_id,
+    )
+
+    def change_required_workflow_event(
+        check_runs: list[dict[str, object]],
+        workflow_runs: list[dict[str, object]],
+        _current_run: dict[str, object],
+    ) -> None:
+        check = required_check_fixture(
+            check_runs,
+            "gitleaks (full history)",
+        )
+        workflow = workflow_fixture(workflow_runs, check["check_suite_id"])
+        workflow["event"] = "workflow_run"
+
+    assert_release_gate_fixture_rejected(
+        release_gate,
+        "required check comes from the wrong workflow event",
+        "required check workflow provenance mismatch: gitleaks (full history)",
+        change_required_workflow_event,
+    )
+
+    def change_required_check_head(
+        check_runs: list[dict[str, object]],
+        _workflow_runs: list[dict[str, object]],
+        _current_run: dict[str, object],
+    ) -> None:
+        check = required_check_fixture(
+            check_runs,
+            "Windows installer + vector-free release build",
+        )
+        check["head_sha"] = "2" * 40
+
+    assert_release_gate_fixture_rejected(
+        release_gate,
+        "required check is attached to the wrong head sha",
+        (
+            "required check has wrong head sha: "
+            "Windows installer + vector-free release build"
+        ),
+        change_required_check_head,
+    )
+
+    def change_required_workflow_head(
+        check_runs: list[dict[str, object]],
+        workflow_runs: list[dict[str, object]],
+        _current_run: dict[str, object],
+    ) -> None:
+        check = required_check_fixture(
+            check_runs,
+            "Check & Test (macos-latest)",
+        )
+        workflow = workflow_fixture(workflow_runs, check["check_suite_id"])
+        workflow["head_sha"] = "3" * 40
+
+    assert_release_gate_fixture_rejected(
+        release_gate,
+        "required workflow run is attached to the wrong head sha",
+        "required check workflow provenance mismatch: Check & Test (macos-latest)",
+        change_required_workflow_head,
+    )
+
+    def change_required_check_app(
+        check_runs: list[dict[str, object]],
+        _workflow_runs: list[dict[str, object]],
+        _current_run: dict[str, object],
+    ) -> None:
+        check = required_check_fixture(check_runs, "DCO Sign-off")
+        check["app_slug"] = "unreviewed-checks-app"
+
+    assert_release_gate_fixture_rejected(
+        release_gate,
+        "required check comes from a different checks app",
+        "required check has wrong app authority: DCO Sign-off",
+        change_required_check_app,
+    )
+
     # Cargo caches are restore-anywhere, save-from-main-only, so one reusable
     # warm entry per job stays alive under the repository cache budget instead
     # of being evicted by per-pull-request entries no other run can read.
@@ -1936,9 +2682,6 @@ def main() -> None:
     # jobs are admitted only from main, while fuzz may still write a cache on a
     # qualifying pull request. This is not a repository-wide no-PR-writes
     # invariant.
-    workflow_sources = {
-        workflow: workflow.read_text(encoding="utf-8") for workflow in workflow_paths()
-    }
     assert_rust_cache_steps(workflow_sources)
 
     with tempfile.TemporaryDirectory() as directory:

--- a/scripts/test-release-workflow-authority.py
+++ b/scripts/test-release-workflow-authority.py
@@ -39,7 +39,28 @@ REQUIRED_RELEASE_CHECKS = (
     "gitleaks (full history)",
     "Windows installer + vector-free release build",
 )
-WINDOWS_INSTALLER_CHECK = "Windows installer + vector-free release build"
+DOCS_ONLY_CLASSIFIER_SHELL = textwrap.dedent(
+    """\
+    set -euo pipefail
+    docs_only=false
+    if [ "$EVENT_NAME" = "pull_request" ]; then
+      changed="$(git diff --name-only "$BASE_SHA...$HEAD_SHA")"
+      if [ -n "$changed" ]; then
+        docs_only=true
+        while IFS= read -r path; do
+          case "$path" in
+            .github/workflows/ci.yml) docs_only=false; break ;;
+            *.md | docs/*) ;;
+            .github/workflows/*) ;;
+            *) docs_only=false; break ;;
+          esac
+        done <<< "$changed"
+      fi
+      printf '%s\\n' "$changed"
+    fi
+    echo "docs_only=$docs_only" >> "$GITHUB_OUTPUT"
+    """
+).rstrip()
 
 
 def require(content: str, needle: str, context: str) -> None:
@@ -73,13 +94,9 @@ def workflow_paths(directory: Path = WORKFLOWS) -> list[Path]:
     )
 
 
-def active_shell_code(line: str) -> str:
-    """Return active shell code for the classifier's deliberately closed form."""
+def classifier_shell_source(classifier: str) -> str:
+    """Extract the classifier's complete active shell block."""
 
-    return line.strip().split("#", 1)[0].strip()
-
-
-def assert_docs_only_classifier_guard(classifier: str) -> None:
     lines = classifier.splitlines()
     run_lines = [index for index, line in enumerate(lines) if line.strip() == "run: |"]
     if len(run_lines) != 1:
@@ -88,102 +105,118 @@ def assert_docs_only_classifier_guard(classifier: str) -> None:
         )
     run_line = run_lines[0]
     run_indent = len(lines[run_line]) - len(lines[run_line].lstrip())
-    shell_lines: list[int] = []
+    shell_lines: list[str] = []
     for index in range(run_line + 1, len(lines)):
         line = lines[index]
         if not line.strip():
+            shell_lines.append(line)
             continue
         indent = len(line) - len(line.lstrip())
         if indent <= run_indent:
             break
-        shell_lines.append(index)
+        shell_lines.append(line)
 
-    guard = 'if [ "$EVENT_NAME" = "pull_request" ]; then'
-    guard_lines = [
-        index for index in shell_lines if active_shell_code(lines[index]) == guard
+    source = textwrap.dedent("\n".join(shell_lines)).strip()
+    active_lines = [
+        line.rstrip()
+        for line in source.splitlines()
+        if line.strip() and not line.lstrip().startswith("#")
     ]
-    if len(guard_lines) != 1:
-        raise AssertionError(
-            "diff classifier must gate its whole classification on exactly one "
-            "pull_request guard; docs_only has to stay false on every push to main"
-        )
-    guard_line = guard_lines[0]
+    return "\n".join(active_lines)
 
-    default_lines = [
-        index
-        for index in shell_lines
-        if active_shell_code(lines[index]) == "docs_only=false"
-    ]
-    if len(default_lines) != 1 or default_lines[0] >= guard_line:
+
+def assert_docs_only_classifier_guard(classifier: str) -> None:
+    """Require the exact reviewed shell program, with comments as the only slack."""
+
+    source = classifier_shell_source(classifier)
+    if source != DOCS_ONLY_CLASSIFIER_SHELL:
         raise AssertionError(
-            "diff classifier must default docs_only=false exactly once before the "
-            "pull_request guard so any other event fails closed"
+            "diff classifier active shell must exactly match the closed-form "
+            "docs_only program"
         )
 
-    depth = 0
-    closing_fi = None
-    for index in (candidate for candidate in shell_lines if candidate >= guard_line):
-        code = active_shell_code(lines[index])
-        if re.fullmatch(r"if\b.*;\s*then", code):
-            depth += 1
-        elif code == "fi":
-            depth -= 1
-            if depth == 0:
-                closing_fi = index
-                break
-            if depth < 0:
-                raise AssertionError(
-                    "diff classifier pull_request guard has an unmatched fi"
-                )
-    if closing_fi is None:
+
+def execute_docs_only_classifier(
+    classifier: str,
+) -> tuple[subprocess.CompletedProcess[str], list[str]]:
+    """Execute a classifier mutant on a push and return its emitted outputs."""
+
+    source = classifier_shell_source(classifier)
+    with tempfile.TemporaryDirectory() as directory:
+        output = Path(directory) / "github-output"
+        environment = os.environ.copy()
+        environment.update(
+            {
+                "EVENT_NAME": "push",
+                "BASE_SHA": "unused-on-push",
+                "HEAD_SHA": "unused-on-push",
+                "GITHUB_OUTPUT": str(output),
+            }
+        )
+        result = subprocess.run(
+            ["bash", "--noprofile", "--norc", "-c", source],
+            cwd=ROOT,
+            env=environment,
+            capture_output=True,
+            text=True,
+            timeout=10,
+            check=False,
+        )
+        outputs = (
+            output.read_text(encoding="utf-8").splitlines()
+            if output.exists()
+            else []
+        )
+    return result, outputs
+
+
+def assert_classifier_bypass_rejected(
+    label: str,
+    classifier: str,
+    *,
+    execute: bool = True,
+) -> None:
+    """Prove a shell-equivalent bypass is rejected and would otherwise win."""
+
+    expect_assertion(
+        label,
+        "exactly match the closed-form docs_only program",
+        lambda: assert_docs_only_classifier_guard(classifier),
+    )
+    if not execute:
+        return
+
+    result, outputs = execute_docs_only_classifier(classifier)
+    if result.returncode != 0:
         raise AssertionError(
-            "diff classifier pull_request guard has no structurally matching fi"
+            f"classifier falsification did not execute: {label}: "
+            f"{result.stdout}{result.stderr}"
+        )
+    if not outputs or outputs[-1] != "docs_only=true":
+        raise AssertionError(
+            f"classifier falsification did not override push output: {label}: "
+            f"{outputs}"
         )
 
-    output = 'echo "docs_only=$docs_only" >> "$GITHUB_OUTPUT"'
-    allowed_references = {
-        "docs_only=false",
-        "docs_only=true",
-        ".github/workflows/ci.yml) docs_only=false; break ;;",
-        "*) docs_only=false; break ;;",
-        output,
-    }
-    unauthorized_references = [
-        (index, active_shell_code(lines[index]))
-        for index in shell_lines
-        if re.search(r"\bdocs_only\b", active_shell_code(lines[index]))
-        and active_shell_code(lines[index]) not in allowed_references
-    ]
-    if unauthorized_references:
-        line_number, code = unauthorized_references[0]
-        raise AssertionError(
-            "diff classifier violates the closed-form docs_only policy at "
-            f"shell line {line_number + 1}: {code}"
-        )
 
-    truthy_lines = [
-        index
-        for index in shell_lines
-        if active_shell_code(lines[index]) == "docs_only=true"
-    ]
-    if (
-        len(truthy_lines) != 1
-        or truthy_lines[0] <= guard_line
-        or truthy_lines[0] >= closing_fi
-    ):
-        raise AssertionError(
-            "diff classifier must set docs_only=true exactly once inside the "
-            "structurally matched pull_request guard"
-        )
+def bash_supports_nameref() -> bool:
+    """Return whether the local bash can execute the hosted nameref bypass."""
 
-    output_lines = [
-        index for index in shell_lines if active_shell_code(lines[index]) == output
-    ]
-    if len(output_lines) != 1 or output_lines[0] <= closing_fi:
-        raise AssertionError(
-            "diff classifier must emit its single fail-closed output after the "
-            "pull_request guard"
-        )
+    probe = subprocess.run(
+        [
+            "bash",
+            "--noprofile",
+            "--norc",
+            "-c",
+            "target=original; original=false; declare -n ref=\"$target\"; "
+            "ref=true; [ \"$original\" = true ]",
+        ],
+        capture_output=True,
+        text=True,
+        timeout=10,
+        check=False,
+    )
+    return probe.returncode == 0
 
 
 def yaml_uses_scalar(line: str) -> str | None:
@@ -197,8 +230,22 @@ def yaml_uses_scalar(line: str) -> str | None:
         line,
     )
     if match is None:
+        if re.match(r"^\s*(?:-\s*)?uses:\s*", line):
+            raise AssertionError(
+                "workflow uses scalar must be a single plain or quoted value"
+            )
         return None
-    return next(value for value in match.groups() if value is not None)
+    double_quoted, single_quoted, plain = match.groups()
+    if double_quoted is not None:
+        if "\\" in double_quoted:
+            raise AssertionError(
+                "workflow uses scalar must not contain YAML escape sequences"
+            )
+        return double_quoted
+    if single_quoted is not None:
+        return single_quoted
+    assert plain is not None
+    return plain
 
 
 def rust_cache_step_bounds(lines: list[str], uses_line: int) -> tuple[int, int]:
@@ -378,6 +425,19 @@ def assert_release_check_rejected(
         raise AssertionError(
             "release check falsification failed without the expected refusal: "
             f"{check_name}={conclusion}: {output}"
+        )
+
+
+def assert_release_check_accepted(
+    source: str,
+    check_name: str,
+    conclusion: str,
+) -> None:
+    result = execute_release_check_gate(source, {check_name: conclusion})
+    if result.returncode != 0:
+        raise AssertionError(
+            "release check falsification rejected an allowed conclusion: "
+            f"{check_name}={conclusion}: {result.stdout}{result.stderr}"
         )
 
 
@@ -1135,27 +1195,55 @@ def main() -> None:
         '          echo "docs_only=$docs_only" >> "$GITHUB_OUTPUT"',
         1,
     )
-    expect_assertion(
+    assert_classifier_bypass_rejected(
         "docs_only=true after the matching pull_request fi",
-        "structurally matched pull_request guard",
-        lambda: assert_docs_only_classifier_guard(truthy_after_guard),
+        truthy_after_guard,
     )
-    for label, assignment in (
+    for label, command in (
         ("single-quoted docs_only assignment", "docs_only='true'"),
         ("double-quoted docs_only assignment", 'docs_only="true"'),
         ("indirect printf docs_only assignment", "printf -v docs_only true"),
+        (
+            "computed-name docs_only assignment",
+            'name=docs_$(printf only); printf -v "$name" true',
+        ),
+        ("eval-computed docs_only assignment", "eval 'docs_'only=true"),
+        ("quoted-hash docs_only assignment", "printf '#'; docs_only=true"),
     ):
         bypass = classifier.replace(
             classifier_falsification_needle,
-            f"          fi\n          {assignment}\n"
+            f"          fi\n          {command}\n"
             '          echo "docs_only=$docs_only" >> "$GITHUB_OUTPUT"',
             1,
         )
-        expect_assertion(
+        assert_classifier_bypass_rejected(
             label,
-            "closed-form docs_only policy",
-            lambda bypass=bypass: assert_docs_only_classifier_guard(bypass),
+            bypass,
         )
+    nameref_bypass = classifier.replace(
+        classifier_falsification_needle,
+        "          fi\n"
+        '          name=docs_only; declare -n ref="$name"; ref=true\n'
+        '          echo "docs_only=$docs_only" >> "$GITHUB_OUTPUT"',
+        1,
+    )
+    assert_classifier_bypass_rejected(
+        "nameref docs_only assignment",
+        nameref_bypass,
+        execute=bash_supports_nameref(),
+    )
+    duplicate_computed_output = classifier.replace(
+        classifier_falsification_needle,
+        "          fi\n"
+        '          echo "docs_only=$docs_only" >> "$GITHUB_OUTPUT"\n'
+        "          name=docs_$(printf only); "
+        "printf '%s=true\\n' \"$name\" >> \"$GITHUB_OUTPUT\"",
+        1,
+    )
+    assert_classifier_bypass_rejected(
+        "duplicate computed docs_only output",
+        duplicate_computed_output,
+    )
     comment_only = classifier.replace(
         classifier_falsification_needle,
         "          fi\n"
@@ -1188,21 +1276,21 @@ def main() -> None:
         require(release_tag, policy, "per-check release conclusion policy")
 
     release_gate = release_check_gate_source(release_tag)
-    dco_skipped = execute_release_check_gate(
-        release_gate,
-        {"DCO Sign-off": "skipped"},
-    )
-    if dco_skipped.returncode != 0:
-        raise AssertionError(
-            "release gate rejected the explicitly justified DCO skip: "
-            f"{dco_skipped.stdout}{dco_skipped.stderr}"
-        )
-    for rejected_conclusion in ("skipped", "neutral"):
-        assert_release_check_rejected(
+    for accepted_conclusion in ("success", "skipped"):
+        assert_release_check_accepted(
             release_gate,
-            WINDOWS_INSTALLER_CHECK,
-            rejected_conclusion,
+            "DCO Sign-off",
+            accepted_conclusion,
         )
+    for check_name in REQUIRED_RELEASE_CHECKS:
+        if check_name == "DCO Sign-off":
+            continue
+        for rejected_conclusion in ("skipped", "neutral"):
+            assert_release_check_rejected(
+                release_gate,
+                check_name,
+                rejected_conclusion,
+            )
     assert_release_check_rejected(
         release_gate,
         "DCO Sign-off",
@@ -1313,6 +1401,14 @@ def main() -> None:
     )
     assert_rust_cache_steps(quoted_pinned)
 
+    single_quoted_pinned = dict(workflow_sources)
+    single_quoted_pinned[ci_path] = single_quoted_pinned[ci_path].replace(
+        pinned_use,
+        f"uses: '{RUST_CACHE_ACTION}'",
+        1,
+    )
+    assert_rust_cache_steps(single_quoted_pinned)
+
     quoted_unpinned = dict(workflow_sources)
     quoted_unpinned[ci_path] = quoted_unpinned[ci_path].replace(
         pinned_use,
@@ -1339,6 +1435,23 @@ jobs:
         "uses rust-cache at an unpinned ref",
         lambda: assert_rust_cache_steps(yaml_unpinned),
     )
+
+    for label, escaped_action in (
+        ("hex-escaped rust-cache separator", r"Swatinem/rust-cache\x40v2"),
+        ("unicode-escaped rust-cache separator", r"Swatinem/rust-cache\u0040v2"),
+        ("unicode-escaped rust-cache repository", r"Swatinem/rust-ca\u0063he@v2"),
+    ):
+        escaped_use = dict(workflow_sources)
+        escaped_use[ci_path] = escaped_use[ci_path].replace(
+            pinned_use,
+            f'uses: "{escaped_action}"',
+            1,
+        )
+        expect_assertion(
+            label,
+            "must not contain YAML escape sequences",
+            lambda escaped_use=escaped_use: assert_rust_cache_steps(escaped_use),
+        )
 
     unaccounted_text = dict(workflow_sources)
     unaccounted_text[ci_path] += (

--- a/scripts/test-release-workflow-authority.py
+++ b/scripts/test-release-workflow-authority.py
@@ -6,7 +6,13 @@
 
 from __future__ import annotations
 
+import json
+import os
 import re
+import subprocess
+import sys
+import tempfile
+import textwrap
 from collections.abc import Callable
 from pathlib import Path
 
@@ -24,6 +30,16 @@ INSTALL_PS1 = ROOT / "scripts" / "install.ps1"
 HEALTH = ROOT / "crates" / "kin-cli" / "src" / "commands" / "health.rs"
 RUST_CACHE_ACTION = "Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4"
 MAIN_ONLY_CACHE_SAVE = "save-if: ${{ github.ref == 'refs/heads/main' }}"
+RUST_CACHE_REFERENCE = re.compile(r"Swatinem/rust-cache@", re.IGNORECASE)
+REQUIRED_RELEASE_CHECKS = (
+    "Check & Test (ubuntu-latest)",
+    "Check & Test (macos-latest)",
+    "DCO Sign-off",
+    "cargo-deny",
+    "gitleaks (full history)",
+    "Windows installer + vector-free release build",
+)
+WINDOWS_INSTALLER_CHECK = "Windows installer + vector-free release build"
 
 
 def require(content: str, needle: str, context: str) -> None:
@@ -47,13 +63,44 @@ def expect_assertion(
     raise AssertionError(f"falsification did not fail: {label}")
 
 
+def workflow_paths(directory: Path = WORKFLOWS) -> list[Path]:
+    """Return every workflow filename GitHub Actions recognizes."""
+
+    return sorted(
+        path
+        for path in directory.iterdir()
+        if path.is_file() and path.suffix in {".yml", ".yaml"}
+    )
+
+
+def active_shell_code(line: str) -> str:
+    """Return active shell code for the classifier's deliberately closed form."""
+
+    return line.strip().split("#", 1)[0].strip()
+
+
 def assert_docs_only_classifier_guard(classifier: str) -> None:
     lines = classifier.splitlines()
+    run_lines = [index for index, line in enumerate(lines) if line.strip() == "run: |"]
+    if len(run_lines) != 1:
+        raise AssertionError(
+            "diff classifier must contain exactly one closed-form shell run block"
+        )
+    run_line = run_lines[0]
+    run_indent = len(lines[run_line]) - len(lines[run_line].lstrip())
+    shell_lines: list[int] = []
+    for index in range(run_line + 1, len(lines)):
+        line = lines[index]
+        if not line.strip():
+            continue
+        indent = len(line) - len(line.lstrip())
+        if indent <= run_indent:
+            break
+        shell_lines.append(index)
+
     guard = 'if [ "$EVENT_NAME" = "pull_request" ]; then'
     guard_lines = [
-        index
-        for index, line in enumerate(lines)
-        if line.strip().split("#", 1)[0].strip() == guard
+        index for index in shell_lines if active_shell_code(lines[index]) == guard
     ]
     if len(guard_lines) != 1:
         raise AssertionError(
@@ -64,8 +111,8 @@ def assert_docs_only_classifier_guard(classifier: str) -> None:
 
     default_lines = [
         index
-        for index, line in enumerate(lines)
-        if line.strip().split("#", 1)[0].strip() == "docs_only=false"
+        for index in shell_lines
+        if active_shell_code(lines[index]) == "docs_only=false"
     ]
     if len(default_lines) != 1 or default_lines[0] >= guard_line:
         raise AssertionError(
@@ -75,8 +122,8 @@ def assert_docs_only_classifier_guard(classifier: str) -> None:
 
     depth = 0
     closing_fi = None
-    for index in range(guard_line, len(lines)):
-        code = lines[index].strip().split("#", 1)[0].strip()
+    for index in (candidate for candidate in shell_lines if candidate >= guard_line):
+        code = active_shell_code(lines[index])
         if re.fullmatch(r"if\b.*;\s*then", code):
             depth += 1
         elif code == "fi":
@@ -93,12 +140,32 @@ def assert_docs_only_classifier_guard(classifier: str) -> None:
             "diff classifier pull_request guard has no structurally matching fi"
         )
 
-    truthy_assignment = re.compile(r"(?:^|[;\s])docs_only=true(?:$|[;\s])")
-    truthy_lines = []
-    for index, line in enumerate(lines):
-        code = line.strip().split("#", 1)[0].strip()
-        if truthy_assignment.search(code):
-            truthy_lines.append(index)
+    output = 'echo "docs_only=$docs_only" >> "$GITHUB_OUTPUT"'
+    allowed_references = {
+        "docs_only=false",
+        "docs_only=true",
+        ".github/workflows/ci.yml) docs_only=false; break ;;",
+        "*) docs_only=false; break ;;",
+        output,
+    }
+    unauthorized_references = [
+        (index, active_shell_code(lines[index]))
+        for index in shell_lines
+        if re.search(r"\bdocs_only\b", active_shell_code(lines[index]))
+        and active_shell_code(lines[index]) not in allowed_references
+    ]
+    if unauthorized_references:
+        line_number, code = unauthorized_references[0]
+        raise AssertionError(
+            "diff classifier violates the closed-form docs_only policy at "
+            f"shell line {line_number + 1}: {code}"
+        )
+
+    truthy_lines = [
+        index
+        for index in shell_lines
+        if active_shell_code(lines[index]) == "docs_only=true"
+    ]
     if (
         len(truthy_lines) != 1
         or truthy_lines[0] <= guard_line
@@ -109,17 +176,29 @@ def assert_docs_only_classifier_guard(classifier: str) -> None:
             "structurally matched pull_request guard"
         )
 
-    output = 'echo "docs_only=$docs_only" >> "$GITHUB_OUTPUT"'
     output_lines = [
-        index
-        for index, line in enumerate(lines)
-        if line.strip().split("#", 1)[0].strip() == output
+        index for index in shell_lines if active_shell_code(lines[index]) == output
     ]
     if len(output_lines) != 1 or output_lines[0] <= closing_fi:
         raise AssertionError(
             "diff classifier must emit its single fail-closed output after the "
             "pull_request guard"
         )
+
+
+def yaml_uses_scalar(line: str) -> str | None:
+    """Read the simple scalar forms accepted for a workflow step's `uses` key."""
+
+    if not line.strip() or line.lstrip().startswith("#"):
+        return None
+    match = re.match(
+        r"""^\s*(?:-\s*)?uses:\s*(?:"([^"\r\n]+)"|'([^'\r\n]+)'|([^#\s]+))"""
+        r"""\s*(?:#.*)?$""",
+        line,
+    )
+    if match is None:
+        return None
+    return next(value for value in match.groups() if value is not None)
 
 
 def rust_cache_step_bounds(lines: list[str], uses_line: int) -> tuple[int, int]:
@@ -166,19 +245,16 @@ def rust_cache_step_bounds(lines: list[str], uses_line: int) -> tuple[int, int]:
 def assert_rust_cache_steps(workflows: dict[Path, str]) -> None:
     rust_cache_uses = 0
     for workflow, content in sorted(workflows.items()):
+        textual_occurrences = len(RUST_CACHE_REFERENCE.findall(content))
+        accounted_occurrences = 0
         lines = content.splitlines()
         for uses_line, line in enumerate(lines):
-            stripped = line.lstrip()
-            if not stripped or stripped.startswith("#"):
+            action = yaml_uses_scalar(line)
+            if action is None or RUST_CACHE_REFERENCE.search(action) is None:
                 continue
-            match = re.match(
-                r"^\s*(?:-\s*)?uses:\s+(Swatinem/rust-cache@\S+)",
-                line,
-            )
-            if not match:
-                continue
+            accounted_occurrences += 1
             rust_cache_uses += 1
-            if match.group(1) != RUST_CACHE_ACTION:
+            if action != RUST_CACHE_ACTION:
                 raise AssertionError(
                     f"{workflow.name} uses rust-cache at an unpinned ref"
                 )
@@ -230,8 +306,79 @@ def assert_rust_cache_steps(workflows: dict[Path, str]) -> None:
                     "bound to its with mapping or is not main-only"
                 )
 
+        if textual_occurrences != accounted_occurrences:
+            raise AssertionError(
+                f"{workflow.name} contains a rust-cache textual occurrence that "
+                "is not an accounted uses scalar"
+            )
+
     if rust_cache_uses == 0:
         raise AssertionError("no pinned rust-cache steps found")
+
+
+def release_check_gate_source(release_tag: str) -> str:
+    """Extract the exact Python gate executed by the release-tag workflow."""
+
+    step_start = release_tag.index("      - name: Verify required checks are green")
+    step_end = release_tag.index("\n      - name:", step_start + 1)
+    step = release_tag[step_start:step_end]
+    marker = "          python3 - <<'PY'\n"
+    source_start = step.index(marker) + len(marker)
+    source_end = step.index("\n          PY", source_start)
+    return textwrap.dedent(step[source_start:source_end])
+
+
+def execute_release_check_gate(
+    source: str,
+    conclusions: dict[str, str],
+) -> subprocess.CompletedProcess[str]:
+    """Execute the workflow's real admission code against synthetic check runs."""
+
+    runs = [
+        {
+            "name": name,
+            "status": "completed",
+            "conclusion": conclusions.get(name, "success"),
+            "id": index,
+        }
+        for index, name in enumerate(REQUIRED_RELEASE_CHECKS, start=1)
+    ]
+    with tempfile.TemporaryDirectory() as directory:
+        evidence = Path(directory) / "check_runs.ndjson"
+        evidence.write_text(
+            "".join(f"{json.dumps(run)}\n" for run in runs),
+            encoding="utf-8",
+        )
+        environment = os.environ.copy()
+        environment["REQUIRED_CHECKS"] = "\n".join(REQUIRED_RELEASE_CHECKS)
+        return subprocess.run(
+            [sys.executable, "-c", source],
+            cwd=directory,
+            env=environment,
+            capture_output=True,
+            text=True,
+            timeout=10,
+            check=False,
+        )
+
+
+def assert_release_check_rejected(
+    source: str,
+    check_name: str,
+    conclusion: str,
+) -> None:
+    result = execute_release_check_gate(source, {check_name: conclusion})
+    output = result.stdout + result.stderr
+    expected = f"required check not green: {check_name} (conclusion={conclusion})"
+    if result.returncode == 0:
+        raise AssertionError(
+            f"release check falsification admitted {check_name}={conclusion}"
+        )
+    if expected not in output:
+        raise AssertionError(
+            "release check falsification failed without the expected refusal: "
+            f"{check_name}={conclusion}: {output}"
+        )
 
 
 def main() -> None:
@@ -962,14 +1109,14 @@ def main() -> None:
         "Windows installer proof still reaching every main commit",
     )
 
-    # The single fact that keeps a skipped installer off a main commit is the
-    # diff classifier computing docs_only ONLY for pull_request events. The
-    # group above pins the consumer of that output; this pins the producer.
-    # Without it, moving the classification outside the pull_request guard (a
-    # plausible "skip heavy jobs on docs-only main pushes too" optimisation)
-    # would let the installer report skipped on a main commit, which
-    # release-tag.yml accepts, and a tag would mint on a sha whose Windows
-    # release build never ran, with this test still green.
+    # Main's classifier must keep reporting false so the release-critical
+    # installer actually runs. The release-tag gate independently requires an
+    # exact success conclusion, but preserving both controls keeps a main push
+    # from silently losing the proof and discovering that only at tag time.
+    # Enforce the classifier as a closed form: one false default, exact false
+    # downgrade arms, one true write inside the structurally matched PR guard,
+    # and one output write. That rejects shell-equivalent quoted or indirect
+    # assignments outside the guard.
     classifier_start = ci_workflow.index("  changes:")
     classifier_end = ci_workflow.index("\n  check-docs-only:", classifier_start)
     classifier = ci_workflow[classifier_start:classifier_end]
@@ -993,6 +1140,30 @@ def main() -> None:
         "structurally matched pull_request guard",
         lambda: assert_docs_only_classifier_guard(truthy_after_guard),
     )
+    for label, assignment in (
+        ("single-quoted docs_only assignment", "docs_only='true'"),
+        ("double-quoted docs_only assignment", 'docs_only="true"'),
+        ("indirect printf docs_only assignment", "printf -v docs_only true"),
+    ):
+        bypass = classifier.replace(
+            classifier_falsification_needle,
+            f"          fi\n          {assignment}\n"
+            '          echo "docs_only=$docs_only" >> "$GITHUB_OUTPUT"',
+            1,
+        )
+        expect_assertion(
+            label,
+            "closed-form docs_only policy",
+            lambda bypass=bypass: assert_docs_only_classifier_guard(bypass),
+        )
+    comment_only = classifier.replace(
+        classifier_falsification_needle,
+        "          fi\n"
+        "          # docs_only='true' is intentionally ignored in comments\n"
+        '          echo "docs_only=$docs_only" >> "$GITHUB_OUTPUT"',
+        1,
+    )
+    assert_docs_only_classifier_guard(comment_only)
 
     release_tag = RELEASE_TAG.read_text(encoding="utf-8")
     for policy in (
@@ -1007,6 +1178,36 @@ def main() -> None:
         "required check not green: {name}",
     ):
         require(release_tag, policy, "release tag required-check gate")
+    for policy in (
+        'skippable_required = {"DCO Sign-off"}',
+        'non_failing_optional = {"success", "skipped", "neutral"}',
+        "if name in skippable_required",
+        'else {"success"}',
+        'run["conclusion"] not in allowed_conclusions',
+    ):
+        require(release_tag, policy, "per-check release conclusion policy")
+
+    release_gate = release_check_gate_source(release_tag)
+    dco_skipped = execute_release_check_gate(
+        release_gate,
+        {"DCO Sign-off": "skipped"},
+    )
+    if dco_skipped.returncode != 0:
+        raise AssertionError(
+            "release gate rejected the explicitly justified DCO skip: "
+            f"{dco_skipped.stdout}{dco_skipped.stderr}"
+        )
+    for rejected_conclusion in ("skipped", "neutral"):
+        assert_release_check_rejected(
+            release_gate,
+            WINDOWS_INSTALLER_CHECK,
+            rejected_conclusion,
+        )
+    assert_release_check_rejected(
+        release_gate,
+        "DCO Sign-off",
+        "neutral",
+    )
 
     # Cargo caches are restore-anywhere, save-from-main-only, so one reusable
     # warm entry per job stays alive under the repository cache budget instead
@@ -1024,10 +1225,19 @@ def main() -> None:
     # qualifying pull request. This is not a repository-wide no-PR-writes
     # invariant.
     workflow_sources = {
-        workflow: workflow.read_text(encoding="utf-8")
-        for workflow in sorted(WORKFLOWS.glob("*.yml"))
+        workflow: workflow.read_text(encoding="utf-8") for workflow in workflow_paths()
     }
     assert_rust_cache_steps(workflow_sources)
+
+    with tempfile.TemporaryDirectory() as directory:
+        fixture_directory = Path(directory)
+        for name in ("recognized.yml", "recognized.yaml", "ignored.txt"):
+            (fixture_directory / name).write_text("fixture\n", encoding="utf-8")
+        enumerated = [path.name for path in workflow_paths(fixture_directory)]
+        if enumerated != ["recognized.yaml", "recognized.yml"]:
+            raise AssertionError(
+                "workflow enumeration must include both .yml and .yaml files"
+            )
 
     ci_path = WORKFLOWS / "ci.yml"
     check_start = ci_workflow.index("\n  check:")
@@ -1088,6 +1298,56 @@ def main() -> None:
         "rust-cache save-if moved from with to an env field in the same step",
         "not structurally bound to its with mapping",
         lambda: assert_rust_cache_steps(same_step_field),
+    )
+
+    pinned_use = f"uses: {RUST_CACHE_ACTION}"
+    if workflow_sources[ci_path].count(pinned_use) < 1:
+        raise AssertionError(
+            "cache falsification could not identify a pinned rust-cache use"
+        )
+    quoted_pinned = dict(workflow_sources)
+    quoted_pinned[ci_path] = quoted_pinned[ci_path].replace(
+        pinned_use,
+        f'uses: "{RUST_CACHE_ACTION}"',
+        1,
+    )
+    assert_rust_cache_steps(quoted_pinned)
+
+    quoted_unpinned = dict(workflow_sources)
+    quoted_unpinned[ci_path] = quoted_unpinned[ci_path].replace(
+        pinned_use,
+        'uses: "Swatinem/rust-cache@v2"',
+        1,
+    )
+    expect_assertion(
+        "quoted rust-cache use at a moving ref",
+        "uses rust-cache at an unpinned ref",
+        lambda: assert_rust_cache_steps(quoted_unpinned),
+    )
+
+    yaml_unpinned = dict(workflow_sources)
+    yaml_unpinned[WORKFLOWS / "adversarial-cache.yaml"] = f"""\
+jobs:
+  adversarial:
+    steps:
+      - uses: "Swatinem/rust-cache@v2"
+        with:
+          {MAIN_ONLY_CACHE_SAVE}
+"""
+    expect_assertion(
+        ".yaml workflow containing a moving rust-cache ref",
+        "uses rust-cache at an unpinned ref",
+        lambda: assert_rust_cache_steps(yaml_unpinned),
+    )
+
+    unaccounted_text = dict(workflow_sources)
+    unaccounted_text[ci_path] += (
+        f"\nenv:\n  UNACCOUNTED_CACHE_ACTION: {RUST_CACHE_ACTION}\n"
+    )
+    expect_assertion(
+        "rust-cache text outside an accounted uses scalar",
+        "not an accounted uses scalar",
+        lambda: assert_rust_cache_steps(unaccounted_text),
     )
 
     for obsolete in (
@@ -1310,7 +1570,7 @@ def main() -> None:
             "release.yml has moving third-party action refs: " + ", ".join(unpinned)
         )
 
-    for workflow in sorted(WORKFLOWS.glob("*.yml")):
+    for workflow in workflow_paths():
         content = workflow.read_text(encoding="utf-8")
         header = content.split("\njobs:", maxsplit=1)[0]
         if re.search(r"(?m)^permissions:\s*$", header) is None:

--- a/scripts/test-release-workflow-authority.py
+++ b/scripts/test-release-workflow-authority.py
@@ -438,18 +438,43 @@ def workflow_job_blocks(workflow: str) -> dict[str, str]:
     return blocks
 
 
+def job_top_level_mapping_fields(job: str) -> list[tuple[str, str]]:
+    """Return canonical job-level fields, rejecting YAML key aliases."""
+
+    active_lines = classifier_active_job_source(job).splitlines()
+    fields: list[tuple[str, str]] = []
+    for line in active_lines[1:]:
+        indent = len(line) - len(line.lstrip())
+        if indent != 2:
+            continue
+        match = re.fullmatch(
+            r"  (?P<key>[A-Za-z0-9_-]+):(?:[ \t]*(?P<value>.*))?",
+            line,
+        )
+        if match is None:
+            raise AssertionError(
+                "workflow job top-level keys must use canonical unquoted "
+                f"`key:` syntax: {line.strip()}"
+            )
+        fields.append((match.group("key"), match.group("value") or ""))
+    return fields
+
+
 def optional_job_display_name(job: str) -> str | None:
     """Return a job's exact top-level display name, if it declares one."""
 
-    active_lines = classifier_active_job_source(job).splitlines()
     names = [
-        line.removeprefix("  name:").strip()
-        for line in active_lines[1:]
-        if line.startswith("  name:")
+        value.strip()
+        for key, value in job_top_level_mapping_fields(job)
+        if key == "name"
     ]
     if len(names) > 1:
         raise AssertionError(
             "workflow jobs may carry at most one one-line display name"
+        )
+    if names and (not names[0] or names[0] in {"|", "|-", ">", ">-"}):
+        raise AssertionError(
+            "workflow job display names must be non-empty one-line scalars"
         )
     return names[0] if names else None
 
@@ -1184,6 +1209,42 @@ def main() -> None:
         "canonical unquoted scalar",
         lambda: assert_workflow_job_census(quoted_job_spoof),
     )
+
+    unnamed_workflow = WORKFLOWS / "registry-index-migrate.yml"
+    if unnamed_workflow not in workflow_sources:
+        raise AssertionError(
+            "workflow census falsification could not identify an unnamed job"
+        )
+    for label, alternate_name_key in (
+        ("double-quoted job name key", '"name": cargo-deny'),
+        ("single-quoted job name key", "'name': cargo-deny"),
+        ("job name key with whitespace before the colon", "name : cargo-deny"),
+        ("tagged job name key", "!!str name: cargo-deny"),
+    ):
+        alternate_name_spoof = dict(workflow_sources)
+        alternate_name_spoof[unnamed_workflow] = textwrap.dedent(
+            f"""\
+            name: Registry Index Migrate
+            on:
+              push:
+                branches: [main]
+            permissions:
+              contents: read
+            jobs:
+              migrate:
+                {alternate_name_key}
+                runs-on: ubuntu-latest
+                steps:
+                  - run: echo success
+            """
+        )
+        expect_assertion(
+            f"{label} emits a required context from an expected unnamed job",
+            "canonical unquoted `key:` syntax",
+            lambda alternate_name_spoof=alternate_name_spoof: (
+                assert_workflow_job_census(alternate_name_spoof)
+            ),
+        )
 
     auxiliary_dco = WORKFLOWS / "dco.yml"
     promoted_dco = dict(workflow_sources)


### PR DESCRIPTION
## What

Two changes, both aimed at the wall clock a pull-request round costs the whole fleet.

**1. The Windows installer leg leaves the pull-request path.** `Windows installer + vector-free release build` cold-compiles the entire dependency graph in the release profile for `x86_64-pc-windows-msvc`. Measured at 20.5 and 24.6 min on runs 30390278470 and 30390270908, longer than any other job, so it set the floor for every land-and-iterate cycle. It now runs on push to main and on the `dependency-updated` dispatch, and reports skipped on a pull request.

This job already ran on every push to main before this PR, so main-push wall clock is unchanged. The entire saving is on the pull-request path.

Release gating is pinned in two places. `release-tag.yml` names this exact check in `REQUIRED_CHECKS` and refuses to mint a tag unless it is present and green on the release sha. The load-bearing fact underneath that is the `changes` classifier computing `docs_only` only inside the structurally matched `pull_request` shell guard, so `docs_only` is false on main and the installer cannot skip there. The authority test now finds the matching `fi`, requires the only truthy assignment inside it, and self-falsifies by placing a second truthy assignment after it.

**2. Cargo and Docker caches restore anywhere, save only from main.** Measured on 2026-07-28 the repository held 12.1 GB across 10 entries, eight of them 1.2 to 1.9 GB pull-request entries, and not one cargo cache on `refs/heads/main`.

A cache entry written from `refs/pull/N/merge` is readable by later runs on that same ref, so the old configuration did warm pushes 2..N of a single pull request. It also spent the shared repository cache budget on entries no other branch could read, evicting the main entry every pull request can restore from its first push. This is a tradeoff: give up the intra-branch warm start in exchange for a shared one. Because strict required-status-check policy forces a re-push before merge, the intra-branch restore was load-bearing at land time, which is the leading explanation for the `Check & Test` regression below.

`Check & Test` (both platforms), `Windows authority tests`, and `Linux Daemon Smoke` use `Swatinem/rust-cache` pinned by commit SHA with `save-if: ${{ github.ref == 'refs/heads/main' }}`. The smoke job keeps registry-only scope via `cache-targets: false`. `Docker Image Build (no push)` keeps `cache-from` everywhere and exports `cache-to` only from main.

The justification for save scoping is budget, not a new trust boundary. GitHub already prevents a pull-request merge-ref cache from being restored by main or a sibling pull request. The structural authority check now binds exactly one main-only `save-if` to the `with:` mapping of every live rust-cache step; comments, unrelated fields, and an `env.save-if` in the same action step cannot compensate for a missing input.

## Scope boundary

This is not a repository-wide “no PR cache writes” invariant.

- All `Swatinem/rust-cache` uses are covered structurally.
- Docker buildx import/export is covered.
- Three `actions/cache` uses remain outside that invariant. Windows installer and coverage are main-only by job admission. `fuzz.yml` can still write a cargo/fuzz cache on a qualifying parser pull request.

FIR-1644 therefore stays open through the post-merge evidence below and until its broader acceptance wording is reconciled with the deliberately retained fuzz cache.

## Files

- `.github/workflows/ci.yml`: installer admission and cargo cache steps
- `.github/workflows/docker.yml`: conditional `cache-to`
- `.github/workflows/daemon-smoke.yml`: main-only rust-cache save and no stale restore fallback
- `scripts/test-release-workflow-authority.py`: release/check linkage plus structural shell/YAML authority and self-falsification

## Authority test

The existing 15-probe sandbox matrix still covers installer admission, release-tag required-check presence, action pinning, Docker export, main trigger presence, daemon cache scope, and the original classifier mutations.

Four additional counterexamples now execute in memory on every authority-test run and must fail for the intended reason:

| counterexample | caught |
| --- | --- |
| `docs_only=true` inserted after the pull-request guard's matching `fi` | yes |
| missing rust-cache `save-if` compensated by a YAML comment | yes |
| missing rust-cache `save-if` compensated by an unrelated active field | yes |
| rust-cache `save-if` moved from `with:` to `env:` in the same step | yes |

`actionlint` is clean on every workflow touched by this PR. Whole-tree `actionlint` still reports the pre-existing `SC2034` warning in `registry-index-migrate.yml`; that file's blob is identical at this PR's base and head and is outside this focused repair.

## Measured PR path

Before: runs 30390278470 / 30390270908 (cold). Docker from #467. After: runs 30393521508 / 30393521700 / 30393521545, also cold because no main-side entry exists until this merges.

| job | before | after | delta |
| --- | --- | --- | --- |
| Windows installer + vector-free release build | 20.5 / 24.6 min | **skipped, 0 min** | off the PR path |
| Check & Test (macos-latest) | 16.0 / 16.2 min | 18.6 min | **+2.5 min** |
| Check & Test (ubuntu-latest) | 13.5 / 13.0 min | 14.8 min | **+1.6 min** |
| Windows authority tests | 13.5 / 14.4 min | 11.2 min | -2.7 min |
| Docker Image Build (no push) | 14.1 min | 9.7 min | -4.4 min |
| Linux Daemon Smoke | 3.0 min | 2.5 min | -0.5 min |

**Critical path: about 20.5 to 24.6 min before, 18.6 min after.**

The Windows and Docker cold-run gains are consistent with removing cache export work billed inside job wall clock. `Check & Test` regressed on both platforms. That regression is real, n=1 per arm, and not explained away here.

## Post-merge obligation — FIR-1644 remains open

Once main has run and written entries:

1. Inspect `gh cache list` first. The repository's configured eviction limit is live-verified at 10 GB, but usage can temporarily exceed it before LRU eviction. A main push creates four runtime rust-cache entries (two `check` matrix arms, Windows authority, and daemon registry-only) plus Docker blobs and the existing main-only caches, so main-entry stability must be observed rather than assumed.
2. Confirm main-scope entries exist and qualifying pull requests restore them.
3. Take the median warm `Check & Test (macos-latest)` across five qualifying same-arm pull-request runs, excluding `dependabot/*` because they change `Cargo.lock`.
4. Roll back the `check` job's rust-cache step if that median is `>= 16.0 min`, the best old-configuration duration.

Rollback is narrow: delete only the rust-cache step from the `check` job and leave the other jobs alone. The authority test enumerates actual rust-cache steps rather than enforcing a hardcoded count, so the remaining steps still have to bind their own main-only save policy.

## Merge order with #477

Land #480 before #477. The two heads are each mergeable against current main but not mutually compatible without a rebase. After #480 lands, #477 must preserve the structural helpers, resolve the shared `RELEASE_TAG` constant once, update the required-check error needle to its renamed `missing required GitHub Actions check` text, and rerun the full authority gate. The detailed bidirectional collision proof remains in the PR discussion.

## Exact-head verification

At `1702be7ab5be27d1ca73db7064d17eeab988d78b` after a signed merge of main `40a39029e683e5fbc86e81aee16af3210dacfe58` (PR #479):

- embedded classifier/cache falsifications: green
- external rerun of the same adversarial mutations: rejected for the intended structural errors
- `python3 scripts/test-release-workflow-authority.py`: green
- relevant-workflow `actionlint`: green
- `ruff check` and `ruff format --check`: green
- Python compile: green
- both npm launcher test/lint suites: 46 tests green
- install/VFS/parity/npm release-policy script suite: green
- `git diff --check`: green
- net diff against current main remains exactly the four intended CI/authority files

## Not claimed

This PR's own timings do not demonstrate a warm-cache win. FIR-1573's acceptance is a Windows job p50 under 10 minutes on a warm cache; this relocates that job rather than meeting the duration target, so FIR-1573 also stays open.

Refs FIR-1644