### PR TITLE
Keep a busy daemon distinguishable from a dead one

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3076,6 +3076,7 @@ dependencies = [
  "dialoguer",
  "directories 5.0.1",
  "ed25519-dalek",
+ "filetime",
  "flate2",
  "fs2",
  "hex",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -60,6 +60,7 @@ uuid = { version = "1", features = ["v4", "serde"] }
 
 # Time
 chrono = { version = "0.4", features = ["serde"] }
+filetime = "0.2"
 
 # Logging
 tracing = "0.1"

--- a/crates/kin-cli/Cargo.toml
+++ b/crates/kin-cli/Cargo.toml
@@ -103,6 +103,7 @@ rustix = { workspace = true }
 
 [target.'cfg(windows)'.dependencies]
 windows-sys = { version = "0.61", features = [
+    "Wdk_System_SystemInformation",
     "Win32_Foundation",
     "Win32_Security",
     "Win32_Security_Authorization",

--- a/crates/kin-cli/Cargo.toml
+++ b/crates/kin-cli/Cargo.toml
@@ -67,6 +67,7 @@ uuid = { workspace = true }
 serde_json = { workspace = true }
 semver = { workspace = true }
 chrono = { workspace = true }
+filetime = { workspace = true }
 reqwest = { workspace = true, features = ["blocking", "json"] }
 hex = { workspace = true }
 sha2.workspace = true

--- a/crates/kin-cli/src/commands/bench_meta.rs
+++ b/crates/kin-cli/src/commands/bench_meta.rs
@@ -583,13 +583,19 @@ mod tests {
             .current_dir(repo.path())
             .output()
             .unwrap();
-        Command::new("git")
-            .args(["commit", "-m", "init"])
+        let commit = Command::new("git")
+            .args(["commit", "--signoff", "-m", "init"])
             .env("GIT_AUTHOR_DATE", "1000000000 +0000")
             .env("GIT_COMMITTER_DATE", "1000000000 +0000")
             .current_dir(repo.path())
             .output()
             .unwrap();
+        assert!(
+            commit.status.success(),
+            "git commit failed: stdout={} stderr={}",
+            String::from_utf8_lossy(&commit.stdout),
+            String::from_utf8_lossy(&commit.stderr)
+        );
 
         let meta = build_meta().unwrap();
         let (prepared, repo_base) = build_prepared_manifests(&meta, repo.path()).unwrap();
@@ -632,13 +638,19 @@ mod tests {
             .current_dir(repo.path())
             .output()
             .unwrap();
-        Command::new("git")
-            .args(["commit", "-m", "init"])
+        let commit = Command::new("git")
+            .args(["commit", "--signoff", "-m", "init"])
             .env("GIT_AUTHOR_DATE", "1000000100 +0000")
             .env("GIT_COMMITTER_DATE", "1000000100 +0000")
             .current_dir(repo.path())
             .output()
             .unwrap();
+        assert!(
+            commit.status.success(),
+            "git commit failed: stdout={} stderr={}",
+            String::from_utf8_lossy(&commit.stdout),
+            String::from_utf8_lossy(&commit.stderr)
+        );
 
         let meta = build_meta().unwrap();
         let (prepared_a, repo_base_a) = build_prepared_manifests(&meta, repo.path()).unwrap();

--- a/crates/kin-cli/src/commands/graph.rs
+++ b/crates/kin-cli/src/commands/graph.rs
@@ -1496,7 +1496,7 @@ mod tests {
             fs::write(repo.join("README.md"), b"authority without source\n").unwrap();
         }
         git(&["add", "--all"]);
-        git(&["commit", "-m", "seed exact source authority"]);
+        git(&["commit", "--signoff", "-m", "seed exact source authority"]);
         let init = kin_core::init_from_git(&repo).unwrap();
         let layout = init.layout;
         let binding = kin_core::LocalRepositoryAuthorityBinding::from_layout(&layout).unwrap();

--- a/crates/kin-cli/src/commands/setup.rs
+++ b/crates/kin-cli/src/commands/setup.rs
@@ -11803,8 +11803,9 @@ fn cleanup_stale_daemons() -> Result<usize> {
         let has_port = kin_root.join("daemon.port").exists();
         let has_pid = kin_root.join("daemon.pid").exists();
         if has_port && !has_pid {
-            let _ = std::fs::remove_file(kin_root.join("daemon.port"));
-            cleaned += 1;
+            if crate::daemon_client::remove_orphaned_daemon_port(&kin_root) {
+                cleaned += 1;
+            }
         }
     }
     Ok(cleaned)

--- a/crates/kin-cli/src/daemon_client.rs
+++ b/crates/kin-cli/src/daemon_client.rs
@@ -2100,6 +2100,7 @@ const SUPERVISOR_PID_FILE: &str = "supervisor.pid";
 const SUPERVISOR_PORT_FILE: &str = "supervisor.port";
 const SUPERVISOR_LIFECYCLE_FILE: &str = "supervisor.lifecycle";
 const SUPERVISOR_SINGLETON_FILE: &str = "supervisor.lock";
+const SUPERVISOR_STARTUP_FILE: &str = "supervisor.start.lock";
 
 /// Path to the per-user supervisor pid file (under the Kin registry directory).
 pub fn supervisor_pid_path() -> PathBuf {
@@ -2115,10 +2116,28 @@ pub fn supervisor_port_path() -> PathBuf {
 /// supervisor stop so a later `status` never reports the dead endpoint as stale.
 pub fn remove_stale_supervisor_files() {
     let dir = supervisor_dir();
+    let startup_authority = match try_acquire_supervisor_startup_lock_in_dir(&dir) {
+        Ok(authority) => authority,
+        Err(error) if error.kind() == std::io::ErrorKind::AlreadyExists => {
+            warn!(
+                dir = %dir.display(),
+                "preserving supervisor endpoint because legacy startup authority is held"
+            );
+            return;
+        }
+        Err(error) => {
+            warn!(
+                dir = %dir.display(),
+                %error,
+                "preserving supervisor endpoint because legacy startup authority is unavailable"
+            );
+            return;
+        }
+    };
     let recorded = supervisor_endpoint_snapshot(&dir);
     match recorded.pid {
         Some(pid) if process_liveness(pid).authorizes_cleanup() => {
-            let _ = retire_supervisor_endpoint_if_unchanged(&dir, recorded);
+            let _ = retire_supervisor_endpoint_if_unchanged(&dir, recorded, &startup_authority);
         }
         Some(_) => {
             warn!(
@@ -2133,7 +2152,7 @@ pub fn remove_stale_supervisor_files() {
             );
         }
         None => {
-            let _ = retire_supervisor_endpoint_if_unchanged(&dir, recorded);
+            let _ = retire_supervisor_endpoint_if_unchanged(&dir, recorded, &startup_authority);
         }
     }
 }
@@ -2194,10 +2213,12 @@ impl SupervisorEndpointRetirement {
 fn retire_supervisor_endpoint_if_unchanged(
     dir: &Path,
     judged: SupervisorEndpointSnapshot,
+    startup_authority: &SupervisorStartupLock,
 ) -> SupervisorEndpointRetirement {
     retire_supervisor_endpoint_if_unchanged_with_hooks(
         dir,
         judged,
+        startup_authority,
         || {},
         |path| std::fs::remove_file(path),
     )
@@ -2206,13 +2227,21 @@ fn retire_supervisor_endpoint_if_unchanged(
 fn retire_supervisor_endpoint_if_unchanged_with_hooks<F, G>(
     dir: &Path,
     judged: SupervisorEndpointSnapshot,
-    after_comparison: F,
+    startup_authority: &SupervisorStartupLock,
+    after_final_snapshot: F,
     remove_file: G,
 ) -> SupervisorEndpointRetirement
 where
     F: FnOnce(),
     G: FnMut(&Path) -> std::io::Result<()>,
 {
+    if !startup_authority.authorizes(dir) {
+        return SupervisorEndpointRetirement::CoordinationUnavailable(format!(
+            "legacy startup authority at {} does not authorize {}",
+            startup_authority.path().display(),
+            dir.display()
+        ));
+    }
     if let Err(error) = std::fs::create_dir_all(dir) {
         return SupervisorEndpointRetirement::CoordinationUnavailable(error.to_string());
     }
@@ -2238,9 +2267,10 @@ where
         }
     }
 
-    // The lifetime inode is opened before the comparison for the same reason as
-    // daemon.lock: current publishers hold it continuously, while a
-    // non-participating legacy endpoint is still protected by its live PID.
+    // Current publishers continuously hold the lifetime inode. Compatible
+    // older publishers do not know this lock, so callers must also hold the
+    // legacy supervisor.start.lock from before this comparison through the
+    // final retire-or-spawn decision.
     let singleton = match OpenOptions::new()
         .create(true)
         .read(true)
@@ -2257,7 +2287,6 @@ where
     if current != judged {
         return SupervisorEndpointRetirement::Changed { current };
     }
-    after_comparison();
     match singleton.try_lock_exclusive() {
         Ok(()) => {}
         Err(error) if error.kind() == fs2::lock_contended_error().kind() => {
@@ -2271,6 +2300,7 @@ where
     if current != judged {
         return SupervisorEndpointRetirement::Changed { current };
     }
+    after_final_snapshot();
     let pid_path = dir.join(SUPERVISOR_PID_FILE);
     let port_path = dir.join(SUPERVISOR_PORT_FILE);
     match remove_endpoint_files_with(&pid_path, &port_path, remove_file) {
@@ -2357,7 +2387,9 @@ fn live_supervisor_endpoint() -> Option<LiveDaemonEndpoint> {
     let recorded = supervisor_endpoint_snapshot(&dir);
     let pid = recorded.pid?;
     if process_liveness(pid).authorizes_cleanup() {
-        let _ = retire_supervisor_endpoint_if_unchanged(&dir, recorded);
+        // Route lookups are observers, not startup authorities. Leave stale
+        // endpoint cleanup to the path holding supervisor.start.lock so a
+        // compatible older launcher cannot publish through an unlink window.
         return None;
     }
     let port = recorded.port?;
@@ -2827,6 +2859,29 @@ impl Drop for StartupLock {
     }
 }
 
+/// Proof that this process owns the cross-version supervisor startup
+/// authority for one state directory.
+///
+/// Compatible pre-singleton CLIs use the same create-new lock path and keep it
+/// until their child publishes and passes health. Requiring this token for
+/// endpoint retirement therefore excludes both current publishers (through
+/// lifecycle/singleton locks) and supported legacy publishers (through this
+/// startup lock).
+struct SupervisorStartupLock {
+    dir: PathBuf,
+    lock: StartupLock,
+}
+
+impl SupervisorStartupLock {
+    fn path(&self) -> &Path {
+        &self.lock.path
+    }
+
+    fn authorizes(&self, dir: &Path) -> bool {
+        self.dir == dir && self.lock.path == dir.join(SUPERVISOR_STARTUP_FILE)
+    }
+}
+
 fn startup_lock_is_stale(path: &Path, stale_after: Duration) -> bool {
     std::fs::metadata(path)
         .and_then(|metadata| metadata.modified())
@@ -2875,26 +2930,43 @@ async fn acquire_startup_lock(kin_root: &Path) -> Result<StartupLock> {
     }
 }
 
-async fn acquire_supervisor_startup_lock() -> Result<StartupLock> {
+fn try_acquire_supervisor_startup_lock_in_dir(
+    dir: &Path,
+) -> std::io::Result<SupervisorStartupLock> {
+    std::fs::create_dir_all(dir)?;
+    let path = dir.join(SUPERVISOR_STARTUP_FILE);
+    let mut file = OpenOptions::new()
+        .write(true)
+        .create_new(true)
+        .open(&path)?;
+    let _ = writeln!(
+        file,
+        "pid={} acquired_at={:?}",
+        std::process::id(),
+        std::time::SystemTime::now()
+    );
+    Ok(SupervisorStartupLock {
+        dir: dir.to_path_buf(),
+        lock: StartupLock { path, _file: file },
+    })
+}
+
+async fn acquire_supervisor_startup_lock() -> Result<SupervisorStartupLock> {
     let dir = supervisor_dir();
-    std::fs::create_dir_all(&dir)
+    acquire_supervisor_startup_lock_in_dir(&dir).await
+}
+
+async fn acquire_supervisor_startup_lock_in_dir(dir: &Path) -> Result<SupervisorStartupLock> {
+    std::fs::create_dir_all(dir)
         .with_context(|| format!("create supervisor state directory {}", dir.display()))?;
-    let path = dir.join("supervisor.start.lock");
+    let path = dir.join(SUPERVISOR_STARTUP_FILE);
     let timeout = Duration::from_secs(startup_lock_timeout_secs());
     let stale_after = timeout.saturating_mul(2).max(Duration::from_secs(10));
     let deadline = Instant::now() + timeout;
 
     loop {
-        match OpenOptions::new().write(true).create_new(true).open(&path) {
-            Ok(mut file) => {
-                let _ = writeln!(
-                    file,
-                    "pid={} acquired_at={:?}",
-                    std::process::id(),
-                    std::time::SystemTime::now()
-                );
-                return Ok(StartupLock { path, _file: file });
-            }
+        match try_acquire_supervisor_startup_lock_in_dir(dir) {
+            Ok(authority) => return Ok(authority),
             Err(err) if err.kind() == std::io::ErrorKind::AlreadyExists => {
                 if startup_lock_is_stale(&path, stale_after) {
                     warn!(path = %path.display(), "removing stale supervisor startup lock");
@@ -3428,16 +3500,33 @@ async fn validate_supervisor_endpoint(endpoint: LiveDaemonEndpoint) -> Result<St
 #[derive(Debug)]
 enum ExistingSupervisor {
     Connected(String),
-    None,
+    NeedsStartupAuthority,
+    SpawnAuthorized,
     LiveNotReady(String),
 }
 
-async fn wait_for_existing_supervisor() -> ExistingSupervisor {
-    wait_for_existing_supervisor_in_dir(&supervisor_dir()).await
+async fn probe_existing_supervisor() -> ExistingSupervisor {
+    let dir = supervisor_dir();
+    wait_for_existing_supervisor_in_dir(&dir, None).await
 }
 
-async fn wait_for_existing_supervisor_in_dir(dir: &Path) -> ExistingSupervisor {
+async fn wait_for_existing_supervisor_in_dir(
+    dir: &Path,
+    startup_authority: Option<&SupervisorStartupLock>,
+) -> ExistingSupervisor {
+    wait_for_existing_supervisor_in_dir_with_hook(dir, startup_authority, || {}).await
+}
+
+async fn wait_for_existing_supervisor_in_dir_with_hook<F>(
+    dir: &Path,
+    startup_authority: Option<&SupervisorStartupLock>,
+    after_snapshot: F,
+) -> ExistingSupervisor
+where
+    F: FnOnce(),
+{
     let recorded = supervisor_endpoint_snapshot(dir);
+    after_snapshot();
     let Some(pid) = recorded.pid else {
         if recorded.pid_exists {
             return ExistingSupervisor::LiveNotReady(
@@ -3446,9 +3535,12 @@ async fn wait_for_existing_supervisor_in_dir(dir: &Path) -> ExistingSupervisor {
                     .to_string(),
             );
         }
+        let Some(startup_authority) = startup_authority else {
+            return ExistingSupervisor::NeedsStartupAuthority;
+        };
         if !recorded.port_exists {
-            return match retire_supervisor_endpoint_if_unchanged(dir, recorded) {
-                SupervisorEndpointRetirement::Retired => ExistingSupervisor::None,
+            return match retire_supervisor_endpoint_if_unchanged(dir, recorded, startup_authority) {
+                SupervisorEndpointRetirement::Retired => ExistingSupervisor::SpawnAuthorized,
                 preserved => ExistingSupervisor::LiveNotReady(format!(
                     "supervisor startup authority is unavailable because {}; kin will not start \
                      a replacement",
@@ -3456,8 +3548,8 @@ async fn wait_for_existing_supervisor_in_dir(dir: &Path) -> ExistingSupervisor {
                 )),
             };
         }
-        return match retire_supervisor_endpoint_if_unchanged(dir, recorded) {
-            SupervisorEndpointRetirement::Retired => ExistingSupervisor::None,
+        return match retire_supervisor_endpoint_if_unchanged(dir, recorded, startup_authority) {
+            SupervisorEndpointRetirement::Retired => ExistingSupervisor::SpawnAuthorized,
             preserved => ExistingSupervisor::LiveNotReady(format!(
                 "supervisor endpoint retirement was refused because {}; kin will not start a \
                  replacement",
@@ -3467,8 +3559,11 @@ async fn wait_for_existing_supervisor_in_dir(dir: &Path) -> ExistingSupervisor {
     };
 
     if process_liveness(pid).authorizes_cleanup() {
-        return match retire_supervisor_endpoint_if_unchanged(dir, recorded) {
-            SupervisorEndpointRetirement::Retired => ExistingSupervisor::None,
+        let Some(startup_authority) = startup_authority else {
+            return ExistingSupervisor::NeedsStartupAuthority;
+        };
+        return match retire_supervisor_endpoint_if_unchanged(dir, recorded, startup_authority) {
+            SupervisorEndpointRetirement::Retired => ExistingSupervisor::SpawnAuthorized,
             preserved => ExistingSupervisor::LiveNotReady(format!(
                 "supervisor endpoint retirement was refused because {}; kin will not start a \
                  replacement",
@@ -3571,26 +3666,38 @@ pub async fn ensure_supervisor_running() -> Result<String> {
         .map(|_| url);
     }
 
-    match wait_for_existing_supervisor().await {
+    // The fast path is deliberately read-only. A compatible older CLI holds
+    // supervisor.start.lock until its older supervisor has published and
+    // passed health, so no endpoint may be retired before we acquire that
+    // cross-version authority.
+    match probe_existing_supervisor().await {
         ExistingSupervisor::Connected(base_url) => return Ok(base_url),
         ExistingSupervisor::LiveNotReady(message) => bail!(message),
-        ExistingSupervisor::None => {}
+        ExistingSupervisor::NeedsStartupAuthority => {}
+        ExistingSupervisor::SpawnAuthorized => {
+            bail!("supervisor probe authorized a spawn without legacy startup authority")
+        }
     }
 
-    let _startup_lock = acquire_supervisor_startup_lock().await?;
-    match wait_for_existing_supervisor().await {
+    let startup_authority = acquire_supervisor_startup_lock().await?;
+    let dir = supervisor_dir();
+    match wait_for_existing_supervisor_in_dir(&dir, Some(&startup_authority)).await {
         ExistingSupervisor::Connected(base_url) => return Ok(base_url),
         ExistingSupervisor::LiveNotReady(message) => bail!(message),
-        ExistingSupervisor::None => {}
+        ExistingSupervisor::SpawnAuthorized => {}
+        ExistingSupervisor::NeedsStartupAuthority => {
+            bail!("supervisor startup authority was lost before the spawn decision")
+        }
     }
 
     let daemon_bin = find_daemon_binary()?;
     // The supervisor binds :0 and reports its real bound port via its endpoint
     // files; passing 0 (rather than a reserved port) removes the same
     // reserve-release-rebind race the repo-daemon path had. The prior
-    // ExistingSupervisor::None decision is the only spawn authorization; stale
-    // endpoint retirement has already completed under lifecycle + singleton
-    // authority, so this path never performs an unconditional unlink.
+    // ExistingSupervisor::SpawnAuthorized is the only spawn authorization.
+    // Stale endpoint retirement completed while holding the legacy startup
+    // authority plus current lifecycle/singleton authority, and that startup
+    // authority remains held until this child has published and passed health.
     info!(binary = %daemon_bin.display(), "starting supervisor (OS-assigned port)");
 
     let mut cmd = std::process::Command::new(&daemon_bin);
@@ -4260,6 +4367,19 @@ mod tests {
         std::fs::write(kin_root.join("daemon.port"), port.to_string()).unwrap();
     }
 
+    /// Model the merge-base supervisor publisher exactly: atomically replace
+    /// each endpoint component without taking supervisor.lifecycle or
+    /// supervisor.lock. Its parent CLI owns supervisor.start.lock.
+    fn write_legacy_supervisor_endpoint_files(dir: &Path, pid: u32, port: u16) {
+        let pid_tmp = dir.join(format!("{SUPERVISOR_PID_FILE}.tmp"));
+        std::fs::write(&pid_tmp, pid.to_string()).unwrap();
+        std::fs::rename(pid_tmp, dir.join(SUPERVISOR_PID_FILE)).unwrap();
+
+        let port_tmp = dir.join(format!("{SUPERVISOR_PORT_FILE}.tmp"));
+        std::fs::write(&port_tmp, port.to_string()).unwrap();
+        std::fs::rename(port_tmp, dir.join(SUPERVISOR_PORT_FILE)).unwrap();
+    }
+
     #[tokio::test]
     async fn unready_endpoint_with_a_live_owner_is_preserved_not_clobbered() {
         let dir = tempfile::tempdir().unwrap();
@@ -4568,9 +4688,95 @@ mod tests {
     }
 
     #[test]
+    fn legacy_supervisor_publisher_is_excluded_after_final_retirement_snapshot() {
+        let dir = tempfile::tempdir().unwrap();
+        let startup_authority = try_acquire_supervisor_startup_lock_in_dir(dir.path()).unwrap();
+        write_legacy_supervisor_endpoint_files(dir.path(), 999_999_999, 51000);
+        let judged = supervisor_endpoint_snapshot(dir.path());
+        let mut legacy_publication_was_excluded = false;
+
+        let decision = retire_supervisor_endpoint_if_unchanged_with_hooks(
+            dir.path(),
+            judged,
+            &startup_authority,
+            || match try_acquire_supervisor_startup_lock_in_dir(dir.path()) {
+                Err(error) if error.kind() == std::io::ErrorKind::AlreadyExists => {
+                    legacy_publication_was_excluded = true;
+                }
+                Err(error) => panic!("legacy startup authority probe failed: {error}"),
+                Ok(_legacy_authority) => {
+                    write_legacy_supervisor_endpoint_files(dir.path(), std::process::id(), 51001);
+                    panic!("a legacy launcher acquired startup authority during retirement");
+                }
+            },
+            |path| std::fs::remove_file(path),
+        );
+
+        assert!(legacy_publication_was_excluded);
+        assert_eq!(decision, SupervisorEndpointRetirement::Retired);
+        assert!(!dir.path().join(SUPERVISOR_PID_FILE).exists());
+        assert!(!dir.path().join(SUPERVISOR_PORT_FILE).exists());
+        assert!(
+            dir.path().join(SUPERVISOR_STARTUP_FILE).exists(),
+            "startup authority must remain held after retirement for the caller's spawn decision"
+        );
+    }
+
+    #[tokio::test]
+    async fn legacy_supervisor_publication_during_probe_is_followed_and_forbids_spawn() {
+        let dir = tempfile::tempdir().unwrap();
+        let legacy_startup_authority =
+            try_acquire_supervisor_startup_lock_in_dir(dir.path()).unwrap();
+        let legacy_port = closed_loopback_port();
+
+        let initial = wait_for_existing_supervisor_in_dir_with_hook(dir.path(), None, || {
+            // The merge-base supervisor itself writes without either new lock.
+            // Its merge-base parent CLI still owns supervisor.start.lock.
+            write_legacy_supervisor_endpoint_files(dir.path(), std::process::id(), legacy_port);
+        })
+        .await;
+
+        assert!(
+            matches!(initial, ExistingSupervisor::NeedsStartupAuthority),
+            "a read-only pre-lock probe must defer stale retirement: {initial:?}"
+        );
+        assert_eq!(
+            supervisor_endpoint_snapshot(dir.path()),
+            SupervisorEndpointSnapshot {
+                pid: Some(std::process::id()),
+                port: Some(legacy_port),
+                pid_exists: true,
+                port_exists: true,
+            },
+            "the post-snapshot legacy publication must survive the read-only probe"
+        );
+
+        drop(legacy_startup_authority);
+        let current_startup_authority =
+            try_acquire_supervisor_startup_lock_in_dir(dir.path()).unwrap();
+        let final_decision =
+            wait_for_existing_supervisor_in_dir(dir.path(), Some(&current_startup_authority)).await;
+
+        assert!(
+            matches!(final_decision, ExistingSupervisor::LiveNotReady(_)),
+            "the final serialized check must follow/preserve the live legacy owner and forbid a \
+             second spawn: {final_decision:?}"
+        );
+        assert_eq!(
+            supervisor_endpoint_snapshot(dir.path()).pid,
+            Some(std::process::id())
+        );
+        assert_eq!(
+            supervisor_endpoint_snapshot(dir.path()).port,
+            Some(legacy_port)
+        );
+    }
+
+    #[test]
     fn supervisor_retirement_permission_denial_never_authorizes_replacement() {
         for denied_name in [SUPERVISOR_PID_FILE, SUPERVISOR_PORT_FILE] {
             let dir = tempfile::tempdir().unwrap();
+            let startup_authority = try_acquire_supervisor_startup_lock_in_dir(dir.path()).unwrap();
             std::fs::write(dir.path().join(SUPERVISOR_PID_FILE), "999999999").unwrap();
             std::fs::write(dir.path().join(SUPERVISOR_PORT_FILE), "51000").unwrap();
             let judged = supervisor_endpoint_snapshot(dir.path());
@@ -4578,6 +4784,7 @@ mod tests {
             let decision = retire_supervisor_endpoint_if_unchanged_with_hooks(
                 dir.path(),
                 judged,
+                &startup_authority,
                 || {},
                 |path| {
                     if path.file_name().and_then(|name| name.to_str()) == Some(denied_name) {
@@ -4631,11 +4838,14 @@ mod tests {
         );
 
         let supervisor_dir = tempfile::tempdir().unwrap();
+        let supervisor_startup_authority =
+            try_acquire_supervisor_startup_lock_in_dir(supervisor_dir.path()).unwrap();
         let supervisor_judged = supervisor_endpoint_snapshot(supervisor_dir.path());
         assert_eq!(
             retire_supervisor_endpoint_if_unchanged_with_hooks(
                 supervisor_dir.path(),
                 supervisor_judged,
+                &supervisor_startup_authority,
                 || {},
                 |_| Err(std::io::Error::from(std::io::ErrorKind::NotFound)),
             ),
@@ -4846,6 +5056,7 @@ mod tests {
     #[tokio::test]
     async fn live_supervisor_health_failure_preserves_lifetime_owner_and_forbids_spawn() {
         let dir = tempfile::tempdir().unwrap();
+        let startup_authority = try_acquire_supervisor_startup_lock_in_dir(dir.path()).unwrap();
         let singleton = OpenOptions::new()
             .create(true)
             .read(true)
@@ -4862,7 +5073,7 @@ mod tests {
         .unwrap();
         std::fs::write(dir.path().join(SUPERVISOR_PORT_FILE), port.to_string()).unwrap();
 
-        let verdict = wait_for_existing_supervisor_in_dir(dir.path()).await;
+        let verdict = wait_for_existing_supervisor_in_dir(dir.path(), None).await;
         assert!(
             matches!(verdict, ExistingSupervisor::LiveNotReady(_)),
             "a health hiccup from a live owner must forbid spawning: {verdict:?}"
@@ -4872,7 +5083,8 @@ mod tests {
         assert_eq!(
             retire_supervisor_endpoint_if_unchanged(
                 dir.path(),
-                supervisor_endpoint_snapshot(dir.path())
+                supervisor_endpoint_snapshot(dir.path()),
+                &startup_authority,
             ),
             SupervisorEndpointRetirement::SingletonHeld,
             "the process-lifetime singleton must independently prevent retirement"
@@ -4884,7 +5096,8 @@ mod tests {
 
         std::fs::remove_file(dir.path().join(SUPERVISOR_PID_FILE)).unwrap();
         std::fs::remove_file(dir.path().join(SUPERVISOR_PORT_FILE)).unwrap();
-        let unpublished_owner = wait_for_existing_supervisor_in_dir(dir.path()).await;
+        let unpublished_owner =
+            wait_for_existing_supervisor_in_dir(dir.path(), Some(&startup_authority)).await;
         assert!(
             matches!(unpublished_owner, ExistingSupervisor::LiveNotReady(_)),
             "a supervisor holding its lifetime singleton before publication must still forbid a \

--- a/crates/kin-cli/src/daemon_client.rs
+++ b/crates/kin-cli/src/daemon_client.rs
@@ -14,7 +14,7 @@ use serde::Deserialize;
 use serde::Serialize;
 use sha2::{Digest, Sha256};
 use std::fs::{File, OpenOptions};
-use std::io::{Read, Seek, SeekFrom, Write};
+use std::io::Write;
 use std::path::{Path, PathBuf};
 use std::process::{Child, Command, Stdio};
 use std::sync::atomic::{AtomicBool, Ordering};
@@ -131,7 +131,13 @@ struct SupervisorRouteResponse {
 
 #[derive(Debug, Deserialize)]
 struct DaemonCompatResponse {
+    #[serde(default)]
+    schema: String,
     graph_snapshot_version: u32,
+    #[serde(default)]
+    supervisor_startup_protocol: Option<u32>,
+    #[serde(default)]
+    supervisor_startup_capabilities: Vec<String>,
 }
 
 #[derive(Debug, Serialize)]
@@ -1627,6 +1633,19 @@ pub enum ProcessLiveness {
     Unknown,
 }
 
+/// Stable identity of one operating-system process incarnation.
+///
+/// A numeric PID is only a lookup key: after exit it can name an unrelated
+/// process. Startup capabilities therefore bind both the current boot and the
+/// process creation instant. On supported targets, failure to obtain either
+/// component is an indeterminate owner and must fail closed.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ProcessIdentity {
+    pid: u32,
+    boot_id: String,
+    birth_token: String,
+}
+
 impl ProcessLiveness {
     /// Compatibility view for callers that only need a conservative boolean.
     ///
@@ -1681,6 +1700,247 @@ pub fn process_liveness(pid: u32) -> ProcessLiveness {
         // ownership rather than guessing "dead" and deleting live authority.
         ProcessLiveness::Unknown
     }
+}
+
+fn stable_boot_identity() -> std::io::Result<String> {
+    #[cfg(target_os = "linux")]
+    {
+        let boot_id = std::fs::read_to_string("/proc/sys/kernel/random/boot_id")?;
+        let boot_id = boot_id.trim();
+        if boot_id.is_empty() {
+            return Err(std::io::Error::new(
+                std::io::ErrorKind::InvalidData,
+                "Linux boot_id is empty",
+            ));
+        }
+        return Ok(format!("linux-boot-id:{boot_id}"));
+    }
+
+    #[cfg(target_os = "macos")]
+    {
+        let mut boot_time = libc::timeval {
+            tv_sec: 0,
+            tv_usec: 0,
+        };
+        let mut len = std::mem::size_of::<libc::timeval>();
+        let mut mib = [libc::CTL_KERN, libc::KERN_BOOTTIME];
+        let status = unsafe {
+            libc::sysctl(
+                mib.as_mut_ptr(),
+                mib.len() as _,
+                &mut boot_time as *mut libc::timeval as *mut _,
+                &mut len,
+                std::ptr::null_mut(),
+                0,
+            )
+        };
+        if status != 0 || len != std::mem::size_of::<libc::timeval>() {
+            return Err(std::io::Error::last_os_error());
+        }
+        return Ok(format!(
+            "macos-kern-boottime:{}:{:06}",
+            boot_time.tv_sec, boot_time.tv_usec
+        ));
+    }
+
+    #[cfg(windows)]
+    {
+        use windows_sys::core::GUID;
+        use windows_sys::Wdk::System::SystemInformation::NtQuerySystemInformation;
+
+        #[repr(C)]
+        struct SystemBootEnvironmentInformation {
+            boot_identifier: GUID,
+            firmware_type: u32,
+            boot_flags: u64,
+        }
+
+        let mut info = SystemBootEnvironmentInformation {
+            boot_identifier: GUID::default(),
+            firmware_type: 0,
+            boot_flags: 0,
+        };
+        let mut returned = 0_u32;
+        // SYSTEM_INFORMATION_CLASS 90 is
+        // SystemBootEnvironmentInformation. Its BootIdentifier is generated
+        // once by the kernel for this boot and does not derive from wall time.
+        let status = unsafe {
+            NtQuerySystemInformation(
+                90,
+                &mut info as *mut _ as *mut _,
+                std::mem::size_of::<SystemBootEnvironmentInformation>() as u32,
+                &mut returned,
+            )
+        };
+        if status < 0 {
+            return Err(std::io::Error::other(format!(
+                "NtQuerySystemInformation(SystemBootEnvironmentInformation) failed with NTSTATUS \
+                 0x{:08x}",
+                status as u32
+            )));
+        }
+        let guid = info.boot_identifier;
+        return Ok(format!(
+            "windows-boot-guid:{:08x}-{:04x}-{:04x}-{}",
+            guid.data1,
+            guid.data2,
+            guid.data3,
+            hex::encode(guid.data4)
+        ));
+    }
+
+    #[cfg(not(any(target_os = "linux", target_os = "macos", windows)))]
+    {
+        Err(std::io::Error::new(
+            std::io::ErrorKind::Unsupported,
+            "stable boot identity is unsupported on this platform",
+        ))
+    }
+}
+
+fn process_identity(pid: u32) -> std::io::Result<Option<ProcessIdentity>> {
+    let liveness = process_liveness(pid);
+    if liveness == ProcessLiveness::Dead {
+        return Ok(None);
+    }
+
+    let boot_id = stable_boot_identity()?;
+
+    #[cfg(target_os = "linux")]
+    {
+        let stat = match std::fs::read_to_string(format!("/proc/{pid}/stat")) {
+            Ok(stat) => stat,
+            Err(error)
+                if error.kind() == std::io::ErrorKind::NotFound
+                    && process_liveness(pid) == ProcessLiveness::Dead =>
+            {
+                return Ok(None);
+            }
+            Err(error) => return Err(error),
+        };
+        // `comm` is parenthesized and may contain spaces or `)`, so split only
+        // after its final closing delimiter. The 20th field in the remaining
+        // sequence is field 22 (`starttime`, in boot-relative clock ticks).
+        let after_comm = stat.rsplit_once(')').map(|(_, rest)| rest).ok_or_else(|| {
+            std::io::Error::new(
+                std::io::ErrorKind::InvalidData,
+                format!("process {pid} stat has no command delimiter"),
+            )
+        })?;
+        let start_ticks = after_comm
+            .split_whitespace()
+            .nth(19)
+            .ok_or_else(|| {
+                std::io::Error::new(
+                    std::io::ErrorKind::InvalidData,
+                    format!("process {pid} stat has no start-time field"),
+                )
+            })?
+            .parse::<u64>()
+            .map_err(|error| {
+                std::io::Error::new(
+                    std::io::ErrorKind::InvalidData,
+                    format!("process {pid} start-time field is invalid: {error}"),
+                )
+            })?;
+        return Ok(Some(ProcessIdentity {
+            pid,
+            boot_id,
+            birth_token: format!("linux-start-ticks:{start_ticks}"),
+        }));
+    }
+
+    #[cfg(target_os = "macos")]
+    {
+        let Ok(raw_pid) = libc::pid_t::try_from(pid) else {
+            return Ok(None);
+        };
+        let mut info = unsafe { std::mem::zeroed::<libc::proc_bsdinfo>() };
+        let expected = std::mem::size_of::<libc::proc_bsdinfo>();
+        let written = unsafe {
+            libc::proc_pidinfo(
+                raw_pid,
+                libc::PROC_PIDTBSDINFO,
+                0,
+                &mut info as *mut _ as *mut _,
+                expected as i32,
+            )
+        };
+        if written != expected as i32 {
+            if process_liveness(pid) == ProcessLiveness::Dead {
+                return Ok(None);
+            }
+            return Err(std::io::Error::new(
+                std::io::ErrorKind::PermissionDenied,
+                format!("cannot read birth identity for process {pid}"),
+            ));
+        }
+        return Ok(Some(ProcessIdentity {
+            pid,
+            boot_id,
+            birth_token: format!(
+                "macos-start-time:{}:{:06}",
+                info.pbi_start_tvsec, info.pbi_start_tvusec
+            ),
+        }));
+    }
+
+    #[cfg(windows)]
+    {
+        use windows_sys::Win32::Foundation::{CloseHandle, FILETIME};
+        use windows_sys::Win32::System::Threading::{
+            GetProcessTimes, OpenProcess, PROCESS_QUERY_LIMITED_INFORMATION,
+        };
+
+        let process = unsafe { OpenProcess(PROCESS_QUERY_LIMITED_INFORMATION, 0, pid) };
+        if process.is_null() {
+            if process_liveness(pid) == ProcessLiveness::Dead {
+                return Ok(None);
+            }
+            return Err(std::io::Error::last_os_error());
+        }
+        let mut created = FILETIME::default();
+        let mut exited = FILETIME::default();
+        let mut kernel = FILETIME::default();
+        let mut user = FILETIME::default();
+        let queried =
+            unsafe { GetProcessTimes(process, &mut created, &mut exited, &mut kernel, &mut user) };
+        let _ = unsafe { CloseHandle(process) };
+        if queried == 0 {
+            if process_liveness(pid) == ProcessLiveness::Dead {
+                return Ok(None);
+            }
+            return Err(std::io::Error::last_os_error());
+        }
+        let created_100ns = ((created.dwHighDateTime as u64) << 32) | created.dwLowDateTime as u64;
+        return Ok(Some(ProcessIdentity {
+            pid,
+            boot_id,
+            birth_token: format!("windows-created-100ns:{created_100ns}"),
+        }));
+    }
+
+    #[cfg(not(any(target_os = "linux", target_os = "macos", windows)))]
+    {
+        let _ = boot_id;
+        Err(std::io::Error::new(
+            std::io::ErrorKind::Unsupported,
+            "process birth identity is unsupported on this platform",
+        ))
+    }
+}
+
+fn current_process_identity() -> std::io::Result<ProcessIdentity> {
+    process_identity(std::process::id())?.ok_or_else(|| {
+        std::io::Error::new(
+            std::io::ErrorKind::NotFound,
+            "the current process disappeared while reading its birth identity",
+        )
+    })
+}
+
+fn process_identity_is_current(identity: &ProcessIdentity) -> std::io::Result<bool> {
+    Ok(process_identity(identity.pid)?.as_ref() == Some(identity))
 }
 
 #[cfg(windows)]
@@ -2103,6 +2363,10 @@ const SUPERVISOR_PORT_FILE: &str = "supervisor.port";
 const SUPERVISOR_LIFECYCLE_FILE: &str = "supervisor.lifecycle";
 const SUPERVISOR_SINGLETON_FILE: &str = "supervisor.lock";
 const SUPERVISOR_STARTUP_FILE: &str = "supervisor.start.lock";
+const SUPERVISOR_STARTUP_AUTHORITY_FILE: &str = "authority.lock";
+const SUPERVISOR_STARTUP_PROTOCOL: u32 = 2;
+const SUPERVISOR_STARTUP_CAPABILITY: &str = "generation-adoption-ack-v2";
+const SUPERVISOR_LEGACY_SENTINEL_CAPABILITY: &str = "legacy-directory-sentinel-v1";
 /// Internal handoff from the current CLI launcher to the supervisor child.
 ///
 /// This is scrubbed from every daemon command and set only on a supervisor
@@ -2167,27 +2431,7 @@ pub fn remove_stale_supervisor_files() {
 fn try_acquire_supervisor_startup_lock_for_cleanup(
     dir: &Path,
 ) -> std::io::Result<SupervisorStartupLock> {
-    match try_acquire_supervisor_startup_lock_in_dir(dir) {
-        Ok(authority) => Ok(authority),
-        Err(error) if error.kind() == std::io::ErrorKind::AlreadyExists => {
-            let path = dir.join(SUPERVISOR_STARTUP_FILE);
-            let (snapshot, record) = supervisor_startup_record_at(&path)?;
-            let Some(record) = record else {
-                return Err(error);
-            };
-            if !process_liveness(record.pid).authorizes_cleanup() {
-                return Err(error);
-            }
-            if !remove_supervisor_startup_lock_if_unchanged(&path, &snapshot)? {
-                return Err(std::io::Error::new(
-                    std::io::ErrorKind::AlreadyExists,
-                    "supervisor startup authority changed during dead-owner cleanup",
-                ));
-            }
-            try_acquire_supervisor_startup_lock_in_dir(dir)
-        }
-        Err(error) => Err(error),
-    }
+    try_acquire_supervisor_startup_lock_in_dir(dir)
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -2270,7 +2514,7 @@ where
 {
     if !startup_authority.authorizes(dir) {
         return SupervisorEndpointRetirement::CoordinationUnavailable(format!(
-            "legacy startup authority at {} does not authorize {}",
+            "startup protocol authority at {} does not authorize {}",
             startup_authority.path().display(),
             dir.display()
         ));
@@ -2300,10 +2544,9 @@ where
         }
     }
 
-    // Current publishers continuously hold the lifetime inode. Compatible
-    // older publishers do not know this lock, so callers must also hold the
-    // legacy supervisor.start.lock from before this comparison through the
-    // final retire-or-spawn decision.
+    // Current publishers continuously hold the lifetime inode. The permanent
+    // startup directory excludes immutable create-new launchers, while this
+    // caller's v2 authority lock serializes the final retire-or-spawn decision.
     let singleton = match OpenOptions::new()
         .create(true)
         .read(true)
@@ -2500,11 +2743,33 @@ fn daemon_binary_matches_cli_graph(path: &Path) -> Result<(), String> {
     }
     let compat: DaemonCompatResponse = serde_json::from_slice(&output.stdout)
         .map_err(|error| format!("compat probe returned invalid JSON: {error}"))?;
+    validate_daemon_compat_response(&compat)
+}
+
+fn validate_daemon_compat_response(compat: &DaemonCompatResponse) -> Result<(), String> {
     let expected = kin_db::GraphSnapshot::CURRENT_VERSION;
     if compat.graph_snapshot_version != expected {
         return Err(format!(
             "graph snapshot version {} does not match CLI expected version {expected}",
             compat.graph_snapshot_version
+        ));
+    }
+    if compat.schema != "kin.daemon.compat.v2"
+        || compat.supervisor_startup_protocol != Some(SUPERVISOR_STARTUP_PROTOCOL)
+        || !compat
+            .supervisor_startup_capabilities
+            .iter()
+            .any(|capability| capability == SUPERVISOR_STARTUP_CAPABILITY)
+        || !compat
+            .supervisor_startup_capabilities
+            .iter()
+            .any(|capability| capability == SUPERVISOR_LEGACY_SENTINEL_CAPABILITY)
+    {
+        return Err(format!(
+            "daemon does not acknowledge supervisor startup protocol v{} ({}, {})",
+            SUPERVISOR_STARTUP_PROTOCOL,
+            SUPERVISOR_STARTUP_CAPABILITY,
+            SUPERVISOR_LEGACY_SENTINEL_CAPABILITY
         ));
     }
     Ok(())
@@ -2518,6 +2783,20 @@ fn validate_daemon_binary(path: &Path) -> Result<(), String> {
 }
 
 fn find_daemon_binary() -> Result<PathBuf> {
+    if let Ok(explicit) = std::env::var("KIN_DAEMON_BIN") {
+        let path = PathBuf::from(explicit);
+        if !path.exists() {
+            bail!("explicit KIN_DAEMON_BIN does not exist: {}", path.display());
+        }
+        return match validate_daemon_binary(&path) {
+            Ok(()) => Ok(path),
+            Err(reason) => bail!(
+                "explicit KIN_DAEMON_BIN {} is incompatible with this kin CLI: {reason}",
+                path.display()
+            ),
+        };
+    }
+
     let mut rejected = Vec::new();
     let mut consider = |path: PathBuf| -> Option<PathBuf> {
         if !path.exists() {
@@ -2532,12 +2811,6 @@ fn find_daemon_binary() -> Result<PathBuf> {
         }
     };
 
-    if let Ok(explicit) = std::env::var("KIN_DAEMON_BIN") {
-        let path = PathBuf::from(explicit);
-        if let Some(path) = consider(path) {
-            return Ok(path);
-        }
-    }
     if let Ok(exe) = std::env::current_exe() {
         let sibling = exe.with_file_name("kin-daemon");
         if let Some(path) = consider(sibling) {
@@ -2892,113 +3165,214 @@ impl Drop for StartupLock {
     }
 }
 
-#[derive(Debug, Clone, PartialEq, Eq)]
-struct SupervisorStartupRecord {
-    pid: u32,
-    generation: Option<String>,
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+struct StartupFileIdentity {
+    volume: u64,
+    file: u64,
 }
 
-fn parse_supervisor_startup_record(content: &str) -> Option<SupervisorStartupRecord> {
-    let mut pid = None;
-    let mut generation = None;
-    for field in content.split_whitespace() {
-        if let Some(value) = field.strip_prefix("pid=") {
-            pid = value.parse::<u32>().ok();
-        } else if let Some(value) = field.strip_prefix("generation=") {
-            generation = (!value.is_empty()).then(|| value.to_string());
+fn startup_file_identity(metadata: &std::fs::Metadata) -> std::io::Result<StartupFileIdentity> {
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::MetadataExt;
+        return Ok(StartupFileIdentity {
+            volume: metadata.dev(),
+            file: metadata.ino(),
+        });
+    }
+    #[cfg(windows)]
+    {
+        use std::os::windows::fs::MetadataExt;
+        return Ok(StartupFileIdentity {
+            volume: metadata.volume_serial_number().ok_or_else(|| {
+                std::io::Error::new(
+                    std::io::ErrorKind::Unsupported,
+                    "startup authority volume identity is unavailable",
+                )
+            })? as u64,
+            file: metadata.file_index().ok_or_else(|| {
+                std::io::Error::new(
+                    std::io::ErrorKind::Unsupported,
+                    "startup authority file identity is unavailable",
+                )
+            })?,
+        });
+    }
+    #[cfg(not(any(unix, windows)))]
+    {
+        let _ = metadata;
+        Err(std::io::Error::new(
+            std::io::ErrorKind::Unsupported,
+            "startup authority file identity is unsupported on this platform",
+        ))
+    }
+}
+
+fn startup_metadata_is_reparse_point(metadata: &std::fs::Metadata) -> bool {
+    #[cfg(windows)]
+    {
+        use std::os::windows::fs::MetadataExt;
+        metadata.file_attributes()
+            & windows_sys::Win32::Storage::FileSystem::FILE_ATTRIBUTE_REPARSE_POINT
+            != 0
+    }
+    #[cfg(not(windows))]
+    {
+        let _ = metadata;
+        false
+    }
+}
+
+fn open_startup_regular_file(
+    path: &Path,
+    create: bool,
+    create_new: bool,
+    write: bool,
+) -> std::io::Result<File> {
+    let mut options = OpenOptions::new();
+    options
+        .read(true)
+        .write(write)
+        .create(create)
+        .create_new(create_new)
+        .truncate(false);
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::OpenOptionsExt;
+        options.custom_flags(libc::O_NOFOLLOW | libc::O_CLOEXEC);
+    }
+    #[cfg(windows)]
+    {
+        use std::os::windows::fs::OpenOptionsExt;
+        options.custom_flags(windows_sys::Win32::Storage::FileSystem::FILE_FLAG_OPEN_REPARSE_POINT);
+    }
+    let file = options.open(path)?;
+    let metadata = file.metadata()?;
+    if metadata.file_type().is_symlink()
+        || startup_metadata_is_reparse_point(&metadata)
+        || !metadata.is_file()
+    {
+        return Err(std::io::Error::new(
+            std::io::ErrorKind::InvalidData,
+            format!(
+                "supervisor startup protocol refuses non-regular file {}",
+                path.display()
+            ),
+        ));
+    }
+    Ok(file)
+}
+
+fn ensure_supervisor_startup_namespace(dir: &Path) -> std::io::Result<PathBuf> {
+    std::fs::create_dir_all(dir)?;
+    let path = dir.join(SUPERVISOR_STARTUP_FILE);
+    loop {
+        match std::fs::symlink_metadata(&path) {
+            Ok(metadata)
+                if metadata.file_type().is_symlink()
+                    || startup_metadata_is_reparse_point(&metadata) =>
+            {
+                return Err(std::io::Error::new(
+                    std::io::ErrorKind::PermissionDenied,
+                    format!(
+                        "supervisor startup protocol refuses symlink {}",
+                        path.display()
+                    ),
+                ));
+            }
+            Ok(metadata) if metadata.is_dir() => return Ok(path),
+            Ok(_) => {
+                return Err(std::io::Error::new(
+                    std::io::ErrorKind::Unsupported,
+                    format!(
+                        "legacy supervisor launcher marker at {} is incompatible with startup \
+                         protocol v{SUPERVISOR_STARTUP_PROTOCOL}; refusing before supervisor boot",
+                        path.display()
+                    ),
+                ));
+            }
+            Err(error) if error.kind() == std::io::ErrorKind::NotFound => {
+                match std::fs::create_dir(&path) {
+                    Ok(()) => return Ok(path),
+                    Err(error) if error.kind() == std::io::ErrorKind::AlreadyExists => continue,
+                    Err(error) => return Err(error),
+                }
+            }
+            Err(error) => return Err(error),
         }
     }
-    pid.map(|pid| SupervisorStartupRecord { pid, generation })
 }
 
-fn write_supervisor_startup_record(
-    file: &mut File,
-    pid: u32,
-    generation: &str,
-) -> std::io::Result<()> {
-    FileExt::lock_exclusive(file)?;
-    let result = (|| {
-        file.set_len(0)?;
-        file.seek(SeekFrom::Start(0))?;
-        writeln!(
-            file,
-            "pid={pid} generation={generation} heartbeat_at={:?}",
-            std::time::SystemTime::now()
-        )?;
-        file.flush()
-    })();
-    let unlock = FileExt::unlock(file);
-    result.and(unlock)
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+struct SupervisorLaunchRecord {
+    schema: String,
+    protocol: u32,
+    generation: String,
+    launcher: ProcessIdentity,
+    authority: StartupFileIdentity,
 }
 
-fn supervisor_startup_record_at(
-    path: &Path,
-) -> std::io::Result<(String, Option<SupervisorStartupRecord>)> {
-    let mut file = OpenOptions::new().read(true).write(true).open(path)?;
-    FileExt::lock_shared(&file)?;
-    let mut content = String::new();
-    let result = file.read_to_string(&mut content);
-    let unlock = FileExt::unlock(&file);
-    result.and(unlock)?;
-    let record = parse_supervisor_startup_record(&content);
-    Ok((content, record))
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+struct SupervisorAdoptionRecord {
+    schema: String,
+    protocol: u32,
+    generation: String,
+    supervisor: ProcessIdentity,
+    authority: StartupFileIdentity,
 }
 
-fn remove_supervisor_startup_lock_if_unchanged(
-    path: &Path,
-    expected: &str,
-) -> std::io::Result<bool> {
-    let current = match supervisor_startup_record_at(path) {
-        Ok((current, _)) => current,
-        Err(error) if error.kind() == std::io::ErrorKind::NotFound => return Ok(false),
-        Err(error) => return Err(error),
-    };
-    if current != expected {
-        return Ok(false);
+fn supervisor_launch_record_path(namespace: &Path, generation: &str) -> PathBuf {
+    namespace.join(format!("launch-{generation}.json"))
+}
+
+fn supervisor_adoption_record_path(namespace: &Path, generation: &str) -> PathBuf {
+    namespace.join(format!("adopt-{generation}.json"))
+}
+
+fn write_immutable_startup_record<T: Serialize>(path: &Path, record: &T) -> std::io::Result<()> {
+    let mut file = open_startup_regular_file(path, false, true, true)?;
+    serde_json::to_writer(&mut file, record).map_err(std::io::Error::other)?;
+    file.write_all(b"\n")?;
+    file.flush()?;
+    file.sync_all()
+}
+
+fn read_startup_record<T: serde::de::DeserializeOwned>(path: &Path) -> std::io::Result<T> {
+    let mut file = open_startup_regular_file(path, false, false, false)?;
+    if file.metadata()?.len() > 64 * 1024 {
+        return Err(std::io::Error::new(
+            std::io::ErrorKind::InvalidData,
+            format!("startup record is unexpectedly large: {}", path.display()),
+        ));
     }
-    match std::fs::remove_file(path) {
-        Ok(()) => Ok(true),
-        Err(error) if error.kind() == std::io::ErrorKind::NotFound => Ok(false),
-        Err(error) => Err(error),
-    }
+    serde_json::from_reader(&mut file).map_err(|error| {
+        std::io::Error::new(
+            std::io::ErrorKind::InvalidData,
+            format!("invalid startup record {}: {error}", path.display()),
+        )
+    })
 }
 
-fn remove_supervisor_startup_lock_generation(
-    path: &Path,
-    generation: &str,
-) -> std::io::Result<bool> {
-    let (content, record) = match supervisor_startup_record_at(path) {
-        Ok(record) => record,
-        Err(error) if error.kind() == std::io::ErrorKind::NotFound => return Ok(false),
-        Err(error) => return Err(error),
-    };
-    if record.and_then(|record| record.generation).as_deref() != Some(generation) {
-        return Ok(false);
-    }
-    remove_supervisor_startup_lock_if_unchanged(path, &content)
-}
-
-/// Generation-bound proof that one startup participant owns the cross-version
-/// supervisor launch authority for one state directory.
+/// Process-bound startup serialization for protocol-v2 launchers.
 ///
-/// Compatible pre-singleton CLIs use the same create-new pathname. Current
-/// launchers add a generation and transfer that exact generation to the
-/// supervisor child, which keeps the marker present for its entire lifetime.
-/// Every destructive use re-reads the pathname, so an unlinked/replaced token
-/// immediately stops authorizing work and its eventual `Drop` cannot remove a
-/// successor generation.
+/// `supervisor.start.lock` is now a permanent directory. Immutable old clients
+/// use `remove_file`, which cannot delete it even after sleep or scheduler
+/// starvation; current clients serialize on the never-unlinked
+/// `authority.lock` inode inside it. Drop only releases the kernel lock, so it
+/// has no pathname transition that could remove or overwrite a successor.
 #[derive(Debug)]
 pub struct SupervisorStartupLock {
     dir: PathBuf,
-    path: PathBuf,
+    namespace: PathBuf,
     file: File,
+    file_identity: StartupFileIdentity,
     generation: String,
-    remove_on_drop: bool,
+    launch: SupervisorLaunchRecord,
 }
 
 impl SupervisorStartupLock {
     fn path(&self) -> &Path {
-        &self.path
+        &self.namespace
     }
 
     /// Exact generation handed from a launcher to its supervisor child.
@@ -3006,85 +3380,101 @@ impl SupervisorStartupLock {
         &self.generation
     }
 
+    fn current_authority_identity(&self) -> std::io::Result<StartupFileIdentity> {
+        let path = self.namespace.join(SUPERVISOR_STARTUP_AUTHORITY_FILE);
+        let file = open_startup_regular_file(&path, false, false, false)?;
+        startup_file_identity(&file.metadata()?)
+    }
+
     fn authorizes(&self, dir: &Path) -> bool {
-        if self.dir != dir || self.path != dir.join(SUPERVISOR_STARTUP_FILE) {
+        if self.dir != dir || self.namespace != dir.join(SUPERVISOR_STARTUP_FILE) {
             return false;
         }
-        supervisor_startup_record_at(&self.path)
-            .ok()
-            .and_then(|(_, record)| record)
-            .and_then(|record| record.generation)
-            .as_deref()
-            == Some(self.generation.as_str())
+        let own_identity = self
+            .file
+            .metadata()
+            .and_then(|metadata| startup_file_identity(&metadata));
+        if own_identity.ok().as_ref() != Some(&self.file_identity) {
+            return false;
+        }
+        if self.current_authority_identity().ok().as_ref() != Some(&self.file_identity) {
+            return false;
+        }
+        if process_identity_is_current(&self.launch.launcher).ok() != Some(true) {
+            return false;
+        }
+        read_startup_record::<SupervisorLaunchRecord>(&supervisor_launch_record_path(
+            &self.namespace,
+            &self.generation,
+        ))
+        .ok()
+        .as_ref()
+            == Some(&self.launch)
     }
 
-    /// Refresh the old-client-visible marker without changing its current
-    /// owner. Returns false if the pathname no longer names this generation.
+    /// Validate authority without refreshing wall-clock metadata.
     pub fn heartbeat(&mut self) -> std::io::Result<bool> {
-        let Some(record) = supervisor_startup_record_at(&self.path)?.1 else {
-            return Ok(false);
-        };
-        if record.generation.as_deref() != Some(self.generation.as_str()) {
-            return Ok(false);
-        }
-        write_supervisor_startup_record(&mut self.file, record.pid, &self.generation)?;
         Ok(self.authorizes(&self.dir))
     }
 
-    /// Refresh this generation while assigning its liveness record to `pid`.
-    /// The launcher uses the spawned child's PID at final handoff; the child
-    /// then keeps stamping its own PID for its process lifetime.
-    pub fn heartbeat_for_pid(&mut self, pid: u32) -> std::io::Result<bool> {
+    fn verify_adoption(&self, child_pid: u32) -> std::io::Result<()> {
         if !self.authorizes(&self.dir) {
-            return Ok(false);
-        }
-        write_supervisor_startup_record(&mut self.file, pid, &self.generation)?;
-        Ok(self.authorizes(&self.dir))
-    }
-
-    /// Leave pathname cleanup to the supervisor child that adopted this same
-    /// generation. Used only after that child has answered health.
-    fn handoff_cleanup_to_supervisor(&mut self) {
-        self.remove_on_drop = false;
-    }
-
-    fn adopt_in_dir(dir: &Path, generation: &str) -> std::io::Result<Self> {
-        let path = dir.join(SUPERVISOR_STARTUP_FILE);
-        let record = supervisor_startup_record_at(&path)?.1.ok_or_else(|| {
-            std::io::Error::new(
-                std::io::ErrorKind::InvalidData,
-                "supervisor startup marker has no parseable owner",
-            )
-        })?;
-        if record.generation.as_deref() != Some(generation) {
             return Err(std::io::Error::new(
                 std::io::ErrorKind::PermissionDenied,
-                "supervisor startup generation does not match the launcher handoff",
+                "supervisor startup authority changed before adoption acknowledgement",
             ));
         }
-        let mut file = OpenOptions::new().read(true).write(true).open(&path)?;
-        write_supervisor_startup_record(&mut file, std::process::id(), generation)?;
-        let authority = Self {
-            dir: dir.to_path_buf(),
-            path,
-            file,
-            generation: generation.to_string(),
-            remove_on_drop: true,
-        };
-        if !authority.authorizes(dir) {
+        let adoption: SupervisorAdoptionRecord = read_startup_record(
+            &supervisor_adoption_record_path(&self.namespace, &self.generation),
+        )?;
+        if adoption.schema != "kin.supervisor.adoption.v2"
+            || adoption.protocol != SUPERVISOR_STARTUP_PROTOCOL
+            || adoption.generation != self.generation
+            || adoption.authority != self.file_identity
+            || adoption.supervisor.pid != child_pid
+            || !process_identity_is_current(&adoption.supervisor)?
+        {
             return Err(std::io::Error::new(
                 std::io::ErrorKind::PermissionDenied,
-                "supervisor startup generation changed during child handoff",
+                "supervisor adoption acknowledgement is not bound to the launched child",
             ));
         }
-        Ok(authority)
+        Ok(())
     }
 }
 
-impl Drop for SupervisorStartupLock {
-    fn drop(&mut self) {
-        if self.remove_on_drop {
-            let _ = remove_supervisor_startup_lock_generation(&self.path, &self.generation);
+#[derive(Debug)]
+pub struct SupervisorRuntimeStartup {
+    namespace: PathBuf,
+    generation: String,
+    authority: StartupFileIdentity,
+    supervisor: ProcessIdentity,
+}
+
+impl SupervisorRuntimeStartup {
+    pub fn acknowledge(&self) -> std::io::Result<()> {
+        let record = SupervisorAdoptionRecord {
+            schema: "kin.supervisor.adoption.v2".to_string(),
+            protocol: SUPERVISOR_STARTUP_PROTOCOL,
+            generation: self.generation.clone(),
+            supervisor: self.supervisor.clone(),
+            authority: self.authority.clone(),
+        };
+        let path = supervisor_adoption_record_path(&self.namespace, &self.generation);
+        match write_immutable_startup_record(&path, &record) {
+            Ok(()) => Ok(()),
+            Err(error) if error.kind() == std::io::ErrorKind::AlreadyExists => {
+                let existing: SupervisorAdoptionRecord = read_startup_record(&path)?;
+                if existing == record {
+                    Ok(())
+                } else {
+                    Err(std::io::Error::new(
+                        std::io::ErrorKind::PermissionDenied,
+                        "supervisor adoption record belongs to a different process incarnation",
+                    ))
+                }
+            }
+            Err(error) => Err(error),
         }
     }
 }
@@ -3137,37 +3527,55 @@ async fn acquire_startup_lock(kin_root: &Path) -> Result<StartupLock> {
     }
 }
 
-/// Create a fresh generation only when the shared startup pathname is absent.
-///
-/// Exposed for the supervisor runtime and cross-version executable tests; normal
-/// callers should use the bounded acquisition path.
+/// Acquire the current protocol's persistent startup authority without waiting.
 #[doc(hidden)]
 pub fn try_acquire_supervisor_startup_lock_in_dir(
     dir: &Path,
 ) -> std::io::Result<SupervisorStartupLock> {
-    std::fs::create_dir_all(dir)?;
-    let path = dir.join(SUPERVISOR_STARTUP_FILE);
-    let generation = Uuid::new_v4().to_string();
-    let mut file = OpenOptions::new()
-        .read(true)
-        .write(true)
-        .create_new(true)
-        .open(&path)?;
-    if let Err(error) = write_supervisor_startup_record(&mut file, std::process::id(), &generation)
-    {
-        let _ = std::fs::remove_file(&path);
-        return Err(error);
+    let namespace = ensure_supervisor_startup_namespace(dir)?;
+    let authority_path = namespace.join(SUPERVISOR_STARTUP_AUTHORITY_FILE);
+    let file = open_startup_regular_file(&authority_path, true, false, true)?;
+    let file_identity = startup_file_identity(&file.metadata()?)?;
+    match file.try_lock_exclusive() {
+        Ok(()) => {}
+        Err(error) if error.kind() == fs2::lock_contended_error().kind() => {
+            return Err(std::io::Error::new(
+                std::io::ErrorKind::AlreadyExists,
+                "another current launcher holds supervisor startup authority",
+            ));
+        }
+        Err(error) => return Err(error),
     }
+
+    let generation = Uuid::new_v4().to_string();
+    let launch = SupervisorLaunchRecord {
+        schema: "kin.supervisor.launch.v2".to_string(),
+        protocol: SUPERVISOR_STARTUP_PROTOCOL,
+        generation: generation.clone(),
+        launcher: current_process_identity()?,
+        authority: file_identity.clone(),
+    };
+    write_immutable_startup_record(
+        &supervisor_launch_record_path(&namespace, &generation),
+        &launch,
+    )?;
     Ok(SupervisorStartupLock {
         dir: dir.to_path_buf(),
-        path,
+        namespace,
         file,
+        file_identity,
         generation,
-        remove_on_drop: true,
+        launch,
     })
 }
 
-async fn acquire_supervisor_startup_lock() -> Result<SupervisorStartupLock> {
+#[derive(Debug)]
+enum SupervisorStartupAcquisition {
+    Authority(SupervisorStartupLock),
+    Connected(String),
+}
+
+async fn acquire_supervisor_startup_lock() -> Result<SupervisorStartupAcquisition> {
     let dir = supervisor_dir();
     acquire_supervisor_startup_lock_in_dir_with_timeout(
         &dir,
@@ -3179,56 +3587,28 @@ async fn acquire_supervisor_startup_lock() -> Result<SupervisorStartupLock> {
 async fn acquire_supervisor_startup_lock_in_dir_with_timeout(
     dir: &Path,
     timeout: Duration,
-) -> Result<SupervisorStartupLock> {
+) -> Result<SupervisorStartupAcquisition> {
     std::fs::create_dir_all(dir)
         .with_context(|| format!("create supervisor state directory {}", dir.display()))?;
     let path = dir.join(SUPERVISOR_STARTUP_FILE);
     let deadline = Instant::now() + timeout;
-    let mut reported_unparseable_owner = false;
 
     loop {
         match try_acquire_supervisor_startup_lock_in_dir(dir) {
-            Ok(authority) => return Ok(authority),
+            Ok(authority) => return Ok(SupervisorStartupAcquisition::Authority(authority)),
             Err(err) if err.kind() == std::io::ErrorKind::AlreadyExists => {
-                match supervisor_startup_record_at(&path) {
-                    Ok((snapshot, Some(record)))
-                        if process_liveness(record.pid).authorizes_cleanup() =>
-                    {
-                        match remove_supervisor_startup_lock_if_unchanged(&path, &snapshot) {
-                            Ok(true) => {
-                                warn!(
-                                    path = %path.display(),
-                                    pid = record.pid,
-                                    "reclaimed supervisor startup lock from a dead owner"
-                                );
-                                continue;
-                            }
-                            Ok(false) => continue,
-                            Err(error) => {
-                                return Err(error).with_context(|| {
-                                    format!(
-                                        "reclaim dead supervisor startup lock at {}",
-                                        path.display()
-                                    )
-                                });
-                            }
+                // A caller waiting behind a live launch must follow discovery
+                // while it waits. Returning the repaired endpoint promptly is
+                // the normal outcome; waiting for the launcher's lock to drop
+                // would strand this command behind a healthy supervisor.
+                let recorded = supervisor_endpoint_snapshot(dir);
+                if let (Some(pid), Some(port)) = (recorded.pid, recorded.port) {
+                    if process_liveness(pid).may_be_alive() {
+                        if let Ok(base_url) =
+                            validate_supervisor_endpoint(LiveDaemonEndpoint { pid, port }).await
+                        {
+                            return Ok(SupervisorStartupAcquisition::Connected(base_url));
                         }
-                    }
-                    Ok((_snapshot, Some(_record))) => {}
-                    Ok((_snapshot, None)) => {
-                        if !reported_unparseable_owner {
-                            warn!(
-                                path = %path.display(),
-                                "preserving supervisor startup lock with an unparseable owner"
-                            );
-                            reported_unparseable_owner = true;
-                        }
-                    }
-                    Err(error) if error.kind() == std::io::ErrorKind::NotFound => continue,
-                    Err(error) => {
-                        return Err(error).with_context(|| {
-                            format!("read supervisor startup lock at {}", path.display())
-                        });
                     }
                 }
                 if Instant::now() >= deadline {
@@ -3248,22 +3628,120 @@ async fn acquire_supervisor_startup_lock_in_dir_with_timeout(
     }
 }
 
-/// Adopt the launcher's exact startup generation inside the supervisor child.
-///
-/// A direct/manual supervisor launch may create a fresh generation only when
-/// no launcher owns the path. If a legacy launcher holds the marker but did not
-/// pass a generation, the current child fails closed instead of running without
-/// cross-version lifetime protection.
-#[doc(hidden)]
-pub fn acquire_supervisor_runtime_startup_lock(
-    dir: &Path,
-) -> std::io::Result<SupervisorStartupLock> {
-    match std::env::var(SUPERVISOR_STARTUP_GENERATION_ENV) {
-        Ok(generation) if !generation.trim().is_empty() => {
-            SupervisorStartupLock::adopt_in_dir(dir, generation.trim())
+fn supervisor_startup_authority_is_held(namespace: &Path) -> std::io::Result<bool> {
+    let file = open_startup_regular_file(
+        &namespace.join(SUPERVISOR_STARTUP_AUTHORITY_FILE),
+        false,
+        false,
+        true,
+    )?;
+    match file.try_lock_exclusive() {
+        Ok(()) => {
+            FileExt::unlock(&file)?;
+            Ok(false)
         }
-        _ => try_acquire_supervisor_startup_lock_in_dir(dir),
+        Err(error) if error.kind() == fs2::lock_contended_error().kind() => Ok(true),
+        Err(error) => Err(error),
     }
+}
+
+/// Validate a versioned launch capability inside the supervisor child.
+///
+/// The immutable PR-base launcher supplies no generation. It is rejected
+/// before singleton acquisition or endpoint publication, so its unconditional
+/// Drop cleanup cannot inherit a current daemon lifetime. A current launcher is
+/// accepted only while its exact authority inode is locked and its
+/// boot/birth-bound identity is still current. A same-process supervisor
+/// re-exec may reuse an existing adoption record because `exec` preserves both
+/// PID and process birth identity.
+#[doc(hidden)]
+pub fn validate_supervisor_runtime_startup(
+    dir: &Path,
+) -> std::io::Result<SupervisorRuntimeStartup> {
+    let generation = std::env::var(SUPERVISOR_STARTUP_GENERATION_ENV)
+        .ok()
+        .filter(|value| !value.trim().is_empty())
+        .ok_or_else(|| {
+            let marker = dir.join(SUPERVISOR_STARTUP_FILE);
+            let detail = match std::fs::symlink_metadata(&marker) {
+                Ok(metadata) if !metadata.is_dir() => {
+                    "legacy launcher marker detected; this daemon requires startup protocol v2"
+                }
+                Ok(_) => "startup protocol v2 launch capability is missing",
+                Err(_) => "startup protocol v2 launch capability is missing",
+            };
+            std::io::Error::new(
+                std::io::ErrorKind::Unsupported,
+                format!("{detail}; refusing before supervisor boot"),
+            )
+        })?;
+    let generation = generation.trim();
+    Uuid::parse_str(generation).map_err(|_| {
+        std::io::Error::new(
+            std::io::ErrorKind::InvalidInput,
+            "supervisor startup generation is not a UUID",
+        )
+    })?;
+
+    let namespace = dir.join(SUPERVISOR_STARTUP_FILE);
+    let namespace_metadata = std::fs::symlink_metadata(&namespace)?;
+    if namespace_metadata.file_type().is_symlink()
+        || startup_metadata_is_reparse_point(&namespace_metadata)
+        || !namespace_metadata.is_dir()
+    {
+        return Err(std::io::Error::new(
+            std::io::ErrorKind::PermissionDenied,
+            "supervisor startup namespace is not a real directory",
+        ));
+    }
+    let authority_file = open_startup_regular_file(
+        &namespace.join(SUPERVISOR_STARTUP_AUTHORITY_FILE),
+        false,
+        false,
+        false,
+    )?;
+    let authority = startup_file_identity(&authority_file.metadata()?)?;
+    let launch: SupervisorLaunchRecord =
+        read_startup_record(&supervisor_launch_record_path(&namespace, generation))?;
+    if launch.schema != "kin.supervisor.launch.v2"
+        || launch.protocol != SUPERVISOR_STARTUP_PROTOCOL
+        || launch.generation != generation
+        || launch.authority != authority
+    {
+        return Err(std::io::Error::new(
+            std::io::ErrorKind::PermissionDenied,
+            "supervisor launch capability does not match the current startup authority",
+        ));
+    }
+
+    let supervisor = current_process_identity()?;
+    let adoption_path = supervisor_adoption_record_path(&namespace, generation);
+    let accepted_reexec = match read_startup_record::<SupervisorAdoptionRecord>(&adoption_path) {
+        Ok(existing) => {
+            existing.schema == "kin.supervisor.adoption.v2"
+                && existing.protocol == SUPERVISOR_STARTUP_PROTOCOL
+                && existing.generation == generation
+                && existing.authority == authority
+                && existing.supervisor == supervisor
+        }
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => false,
+        Err(error) => return Err(error),
+    };
+    if !accepted_reexec
+        && (!process_identity_is_current(&launch.launcher)?
+            || !supervisor_startup_authority_is_held(&namespace)?)
+    {
+        return Err(std::io::Error::new(
+            std::io::ErrorKind::PermissionDenied,
+            "supervisor launcher is not the live owner of the launch capability",
+        ));
+    }
+    Ok(SupervisorRuntimeStartup {
+        namespace,
+        generation: generation.to_string(),
+        authority,
+        supervisor,
+    })
 }
 
 /// What probing a recorded daemon endpoint established.
@@ -3958,20 +4436,26 @@ pub async fn ensure_supervisor_running() -> Result<String> {
         .map(|_| url);
     }
 
-    // The fast path is deliberately read-only. A compatible older CLI holds
-    // supervisor.start.lock until its older supervisor has published and
-    // passed health, so no endpoint may be retired before we acquire that
-    // cross-version authority.
+    // The fast path is deliberately read-only. No endpoint may be retired
+    // before the current CLI holds the v2 startup authority; immutable clients
+    // are excluded by the permanent directory sentinel.
     match probe_existing_supervisor().await {
         ExistingSupervisor::Connected(base_url) => return Ok(base_url),
         ExistingSupervisor::LiveNotReady(message) => bail!(message),
         ExistingSupervisor::NeedsStartupAuthority => {}
         ExistingSupervisor::SpawnAuthorized => {
-            bail!("supervisor probe authorized a spawn without legacy startup authority")
+            bail!("supervisor probe authorized a spawn without startup protocol authority")
         }
     }
 
-    let mut startup_authority = acquire_supervisor_startup_lock().await?;
+    // Validate the binary's explicit protocol acknowledgement before taking
+    // cleanup or spawn authority. In particular, an immutable base daemon is
+    // rejected here and is never started under a marker it cannot adopt.
+    let daemon_bin = find_daemon_binary()?;
+    let mut startup_authority = match acquire_supervisor_startup_lock().await? {
+        SupervisorStartupAcquisition::Connected(base_url) => return Ok(base_url),
+        SupervisorStartupAcquisition::Authority(authority) => authority,
+    };
     let dir = supervisor_dir();
     match wait_for_existing_supervisor_in_dir(&dir, Some(&startup_authority)).await {
         ExistingSupervisor::Connected(base_url) => return Ok(base_url),
@@ -3982,14 +4466,14 @@ pub async fn ensure_supervisor_running() -> Result<String> {
         }
     }
 
-    let daemon_bin = find_daemon_binary()?;
     // The supervisor binds :0 and reports its real bound port via its endpoint
     // files; passing 0 (rather than a reserved port) removes the same
     // reserve-release-rebind race the repo-daemon path had. The prior
     // ExistingSupervisor::SpawnAuthorized is the only spawn authorization.
-    // Stale endpoint retirement completed while holding the legacy startup
-    // authority plus current lifecycle/singleton authority, and that startup
-    // authority remains held until this child has published and passed health.
+    // Stale endpoint retirement completed while holding the v2 kernel-locked
+    // startup authority plus lifecycle/singleton authority, and that startup
+    // authority remains held until this child has published, acknowledged the
+    // exact generation, and passed health.
     info!(binary = %daemon_bin.display(), "starting supervisor (OS-assigned port)");
 
     let mut cmd = std::process::Command::new(&daemon_bin);
@@ -4026,15 +4510,13 @@ pub async fn ensure_supervisor_running() -> Result<String> {
     let mut child = cmd.spawn().context("spawn kin supervisor")?;
     let deadline = Instant::now() + Duration::from_secs(daemon_ready_timeout_secs());
     let base_url = wait_for_supervisor_ready(&mut child, deadline, &mut startup_authority).await?;
-    if !startup_authority
-        .heartbeat_for_pid(child.id())
-        .context("transfer supervisor startup authority to the ready child")?
-    {
+    if let Err(error) = startup_authority.verify_adoption(child.id()) {
         let _ = child.kill();
         let _ = child.wait();
-        bail!("supervisor startup authority changed before lifetime handoff");
+        return Err(error).context(
+            "supervisor became healthy without acknowledging the exact startup generation",
+        );
     }
-    startup_authority.handoff_cleanup_to_supervisor();
     info!(supervisor = %base_url, "supervisor is up and ready");
     Ok(base_url)
 }
@@ -4993,123 +5475,334 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn supervisor_startup_authority_is_live_owner_and_generation_bound() {
+    async fn supervisor_startup_authority_serializes_a_b_c_and_drop_never_unlinks() {
         let dir = tempfile::tempdir().unwrap();
         let mut launcher_a = try_acquire_supervisor_startup_lock_in_dir(dir.path()).unwrap();
         assert!(
             startup_lock_is_stale(launcher_a.path(), Duration::ZERO),
-            "the marker must be old enough for the former time-only predicate"
+            "the test must make the former wall-clock lease look expired"
         );
 
-        let shortened_wait =
+        let b_while_a =
             acquire_supervisor_startup_lock_in_dir_with_timeout(dir.path(), Duration::ZERO)
                 .await
                 .unwrap_err();
         assert!(
-            shortened_wait
+            b_while_a
                 .to_string()
                 .contains("timed out waiting for supervisor startup lock"),
-            "launcher B must not time-steal launcher A while A's PID is live: {shortened_wait:#}"
+            "B must not time-steal A even when the directory mtime looks expired: {b_while_a:#}"
         );
         assert!(launcher_a.authorizes(dir.path()));
         assert!(launcher_a.heartbeat().unwrap());
-
-        // Model an external/legacy pathname replacement while A still has its
-        // original open file. A must immediately lose authority, and its later
-        // Drop must compare-preserve B's generation.
-        std::fs::remove_file(launcher_a.path()).unwrap();
-        let launcher_b = try_acquire_supervisor_startup_lock_in_dir(dir.path()).unwrap();
-        assert_ne!(launcher_a.generation(), launcher_b.generation());
-        assert!(!launcher_a.authorizes(dir.path()));
+        let namespace = launcher_a.path().to_path_buf();
+        let generation_a = launcher_a.generation().to_string();
         drop(launcher_a);
+
+        let launcher_b = try_acquire_supervisor_startup_lock_in_dir(dir.path()).unwrap();
+        assert_ne!(generation_a, launcher_b.generation());
         assert!(
             launcher_b.authorizes(dir.path()),
-            "launcher A's Drop must not unlink launcher B's generation"
+            "A's Drop only releases its kernel lock and cannot unlink B"
         );
+        assert!(namespace.is_dir());
 
-        let launcher_c_error =
+        let c_while_b =
             acquire_supervisor_startup_lock_in_dir_with_timeout(dir.path(), Duration::ZERO)
                 .await
                 .unwrap_err();
         assert!(
-            launcher_c_error
+            c_while_b
                 .to_string()
                 .contains("timed out waiting for supervisor startup lock"),
-            "launcher C must not enter while launcher B is live: {launcher_c_error:#}"
+            "C must not enter while B owns the authority: {c_while_b:#}"
         );
         assert!(launcher_b.authorizes(dir.path()));
 
         drop(launcher_b);
         let launcher_c = try_acquire_supervisor_startup_lock_in_dir(dir.path()).unwrap();
         assert!(launcher_c.authorizes(dir.path()));
+        drop(launcher_c);
+        assert!(
+            namespace.is_dir(),
+            "no Drop edge removes the old-client-blocking directory sentinel"
+        );
     }
 
     #[test]
-    fn supervisor_startup_generation_transfers_without_a_cleanup_gap() {
+    fn supervisor_adoption_ack_is_generation_process_and_inode_bound() {
         let dir = tempfile::tempdir().unwrap();
-        let mut launcher = try_acquire_supervisor_startup_lock_in_dir(dir.path()).unwrap();
+        let launcher = try_acquire_supervisor_startup_lock_in_dir(dir.path()).unwrap();
         let generation = launcher.generation().to_string();
-        let child = SupervisorStartupLock::adopt_in_dir(dir.path(), &generation).unwrap();
+        let runtime = SupervisorRuntimeStartup {
+            namespace: launcher.path().to_path_buf(),
+            generation: generation.clone(),
+            authority: launcher.file_identity.clone(),
+            supervisor: current_process_identity().unwrap(),
+        };
+        runtime.acknowledge().unwrap();
+        launcher.verify_adoption(std::process::id()).unwrap();
 
-        launcher.handoff_cleanup_to_supervisor();
-        drop(launcher);
+        let adoption_path = supervisor_adoption_record_path(launcher.path(), &generation);
+        let replacement = SupervisorAdoptionRecord {
+            schema: "kin.supervisor.adoption.v2".to_string(),
+            protocol: SUPERVISOR_STARTUP_PROTOCOL,
+            generation,
+            supervisor: ProcessIdentity {
+                birth_token: "reused-pid".to_string(),
+                ..current_process_identity().unwrap()
+            },
+            authority: launcher.file_identity.clone(),
+        };
+        std::fs::remove_file(&adoption_path).unwrap();
+        write_immutable_startup_record(&adoption_path, &replacement).unwrap();
         assert!(
-            child.authorizes(dir.path()),
-            "the launcher must leave the adopted generation present"
-        );
-
-        drop(child);
-        assert!(
-            !dir.path().join(SUPERVISOR_STARTUP_FILE).exists(),
-            "the adopted child owns compare-removal at process exit"
+            launcher.verify_adoption(std::process::id()).is_err(),
+            "a replacement acknowledgement cannot inherit an earlier validation"
         );
     }
 
-    #[tokio::test]
-    async fn live_legacy_startup_owner_is_not_reclaimed_by_elapsed_time() {
-        let dir = tempfile::tempdir().unwrap();
-        let path = dir.path().join(SUPERVISOR_STARTUP_FILE);
-        let legacy_record = format!(
-            "pid={} acquired_at={:?}\n",
-            std::process::id(),
-            std::time::SystemTime::now()
-        );
-        std::fs::write(&path, &legacy_record).unwrap();
-        assert!(startup_lock_is_stale(&path, Duration::ZERO));
+    #[test]
+    #[serial_test::serial]
+    fn runtime_reexec_requires_prior_adoption_and_survives_launcher_drop() {
+        let prior = std::env::var_os(SUPERVISOR_STARTUP_GENERATION_ENV);
 
-        let error = acquire_supervisor_startup_lock_in_dir_with_timeout(dir.path(), Duration::ZERO)
-            .await
-            .unwrap_err();
-        assert!(error
-            .to_string()
-            .contains("timed out waiting for supervisor startup lock"));
+        let adopted_dir = tempfile::tempdir().unwrap();
+        let adopted_launcher =
+            try_acquire_supervisor_startup_lock_in_dir(adopted_dir.path()).unwrap();
+        let adopted_generation = adopted_launcher.generation().to_string();
+        std::env::set_var(SUPERVISOR_STARTUP_GENERATION_ENV, &adopted_generation);
+        let first_runtime = validate_supervisor_runtime_startup(adopted_dir.path()).unwrap();
+        first_runtime.acknowledge().unwrap();
+        drop(adopted_launcher);
+
+        let reexec_runtime = validate_supervisor_runtime_startup(adopted_dir.path()).unwrap();
+        assert_eq!(reexec_runtime.generation, adopted_generation);
         assert_eq!(
-            std::fs::read_to_string(&path).unwrap(),
-            legacy_record,
-            "a parseable live legacy owner is liveness authority, not an mtime lease"
+            reexec_runtime.supervisor,
+            current_process_identity().unwrap(),
+            "an exec-preserved process incarnation may adopt its immutable acknowledgement"
+        );
+
+        let crashed_dir = tempfile::tempdir().unwrap();
+        let crashed_launcher =
+            try_acquire_supervisor_startup_lock_in_dir(crashed_dir.path()).unwrap();
+        std::env::set_var(
+            SUPERVISOR_STARTUP_GENERATION_ENV,
+            crashed_launcher.generation(),
+        );
+        drop(crashed_launcher);
+        let error = validate_supervisor_runtime_startup(crashed_dir.path()).unwrap_err();
+
+        match prior {
+            Some(value) => std::env::set_var(SUPERVISOR_STARTUP_GENERATION_ENV, value),
+            None => std::env::remove_var(SUPERVISOR_STARTUP_GENERATION_ENV),
+        }
+
+        assert_eq!(error.kind(), std::io::ErrorKind::PermissionDenied);
+        assert!(
+            error.to_string().contains("launcher is not the live owner"),
+            "a launcher crash before adoption must fail closed: {error}"
         );
     }
 
     #[tokio::test]
-    async fn dead_legacy_startup_owner_is_reclaimed_without_time_authority() {
+    async fn legacy_file_marker_is_rejected_and_never_reclaimed_by_pid_or_time() {
+        for record in [
+            format!("pid={} acquired_at=old\n", std::process::id()),
+            "pid=999999999 acquired_at=old\n".to_string(),
+        ] {
+            let dir = tempfile::tempdir().unwrap();
+            let path = dir.path().join(SUPERVISOR_STARTUP_FILE);
+            std::fs::write(&path, &record).unwrap();
+            assert!(startup_lock_is_stale(&path, Duration::ZERO));
+
+            let error =
+                acquire_supervisor_startup_lock_in_dir_with_timeout(dir.path(), Duration::ZERO)
+                    .await
+                    .unwrap_err();
+            assert!(
+                format!("{error:#}").contains("legacy supervisor launcher marker"),
+                "unsupported legacy pairing must reject explicitly: {error:#}"
+            );
+            assert_eq!(
+                std::fs::read_to_string(&path).unwrap(),
+                record,
+                "neither a dead-looking PID nor elapsed wall time authorizes unlink"
+            );
+        }
+    }
+
+    #[test]
+    #[serial_test::serial]
+    fn runtime_rejects_immutable_legacy_launcher_before_singleton_or_endpoint_publish() {
         let dir = tempfile::tempdir().unwrap();
-        let path = dir.path().join(SUPERVISOR_STARTUP_FILE);
+        let marker = dir.path().join(SUPERVISOR_STARTUP_FILE);
         std::fs::write(
-            &path,
-            "pid=999999999 acquired_at=SystemTime { tv_sec: 0, tv_nsec: 0 }\n",
+            &marker,
+            format!("pid={} acquired_at=legacy\n", std::process::id()),
         )
         .unwrap();
+        let prior = std::env::var_os(SUPERVISOR_STARTUP_GENERATION_ENV);
+        std::env::remove_var(SUPERVISOR_STARTUP_GENERATION_ENV);
+        let error = validate_supervisor_runtime_startup(dir.path()).unwrap_err();
+        match prior {
+            Some(value) => std::env::set_var(SUPERVISOR_STARTUP_GENERATION_ENV, value),
+            None => std::env::remove_var(SUPERVISOR_STARTUP_GENERATION_ENV),
+        }
 
-        let authority =
-            acquire_supervisor_startup_lock_in_dir_with_timeout(dir.path(), Duration::ZERO)
-                .await
-                .unwrap();
-        assert!(authority.authorizes(dir.path()));
+        assert_eq!(error.kind(), std::io::ErrorKind::Unsupported);
         assert!(
-            std::fs::read_to_string(path)
-                .unwrap()
-                .contains(authority.generation()),
-            "dead legacy recovery must mint a fresh generation"
+            error.to_string().contains("legacy launcher marker"),
+            "rejection must diagnose the immutable launcher pairing: {error}"
+        );
+        assert!(!dir.path().join(SUPERVISOR_SINGLETON_FILE).exists());
+        assert!(!dir.path().join(SUPERVISOR_PID_FILE).exists());
+        assert!(!dir.path().join(SUPERVISOR_PORT_FILE).exists());
+        assert!(
+            marker.is_file(),
+            "the daemon must leave cleanup to the immutable launcher's own Drop"
+        );
+    }
+
+    #[test]
+    fn compat_handshake_rejects_base_daemon_without_adoption_ack() {
+        let base: DaemonCompatResponse = serde_json::from_value(serde_json::json!({
+            "schema": "kin.daemon.compat.v1",
+            "graph_snapshot_version": kin_db::GraphSnapshot::CURRENT_VERSION,
+        }))
+        .unwrap();
+        let error = validate_daemon_compat_response(&base).unwrap_err();
+        assert!(
+            error.contains("does not acknowledge supervisor startup protocol"),
+            "old daemons must be rejected explicitly before spawn: {error}"
+        );
+
+        let current: DaemonCompatResponse = serde_json::from_value(serde_json::json!({
+            "schema": "kin.daemon.compat.v2",
+            "graph_snapshot_version": kin_db::GraphSnapshot::CURRENT_VERSION,
+            "supervisor_startup_protocol": SUPERVISOR_STARTUP_PROTOCOL,
+            "supervisor_startup_capabilities": [
+                SUPERVISOR_STARTUP_CAPABILITY,
+                SUPERVISOR_LEGACY_SENTINEL_CAPABILITY,
+            ],
+        }))
+        .unwrap();
+        validate_daemon_compat_response(&current).unwrap();
+    }
+
+    #[test]
+    fn process_identity_rejects_pid_reuse_and_reboot_boundaries() {
+        let first_boot = stable_boot_identity().unwrap();
+        std::thread::sleep(Duration::from_millis(10));
+        assert_eq!(
+            stable_boot_identity().unwrap(),
+            first_boot,
+            "boot identity must be a kernel boot token, not wall-clock-minus-uptime"
+        );
+
+        let current = current_process_identity().unwrap();
+        assert!(process_identity_is_current(&current).unwrap());
+
+        let reused = ProcessIdentity {
+            birth_token: format!("{}-reused", current.birth_token),
+            ..current.clone()
+        };
+        assert!(!process_identity_is_current(&reused).unwrap());
+
+        let rebooted = ProcessIdentity {
+            boot_id: format!("{}-next-boot", current.boot_id),
+            ..current
+        };
+        assert!(!process_identity_is_current(&rebooted).unwrap());
+    }
+
+    async fn supervisor_health_server() -> (u16, tokio::task::JoinHandle<()>) {
+        use tokio::io::{AsyncReadExt, AsyncWriteExt};
+
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let port = listener.local_addr().unwrap().port();
+        let server = tokio::spawn(async move {
+            loop {
+                let Ok((mut socket, _)) = listener.accept().await else {
+                    return;
+                };
+                let mut buffer = [0_u8; 2048];
+                let Ok(read) = socket.read(&mut buffer).await else {
+                    continue;
+                };
+                if !String::from_utf8_lossy(&buffer[..read]).contains("/health") {
+                    continue;
+                }
+                let body = r#"{"status":"ok"}"#;
+                let response = format!(
+                    "HTTP/1.1 200 OK\r\ncontent-type: application/json\r\n\
+                     connection: close\r\ncontent-length: {}\r\n\r\n{body}",
+                    body.len()
+                );
+                let _ = socket.write_all(response.as_bytes()).await;
+                let _ = socket.flush().await;
+            }
+        });
+        (port, server)
+    }
+
+    #[tokio::test]
+    async fn waiter_behind_live_startup_authority_follows_republished_discovery_promptly() {
+        let dir = tempfile::tempdir().unwrap();
+        let launcher = try_acquire_supervisor_startup_lock_in_dir(dir.path()).unwrap();
+        let waiter_dir = dir.path().to_path_buf();
+        let waiter = tokio::spawn(async move {
+            acquire_supervisor_startup_lock_in_dir_with_timeout(&waiter_dir, Duration::from_secs(5))
+                .await
+        });
+        tokio::time::sleep(Duration::from_millis(150)).await;
+
+        let (port, server) = supervisor_health_server().await;
+        write_legacy_supervisor_endpoint_files(dir.path(), std::process::id(), port);
+        let outcome = tokio::time::timeout(Duration::from_secs(1), waiter)
+            .await
+            .expect("waiter must follow repaired discovery promptly")
+            .expect("waiter task")
+            .expect("waiter result");
+        assert!(
+            matches!(
+                outcome,
+                SupervisorStartupAcquisition::Connected(ref url)
+                    if url == &format!("http://127.0.0.1:{port}")
+            ),
+            "the waiter must connect instead of waiting for the launch lock: {outcome:?}"
+        );
+        assert!(
+            launcher.authorizes(dir.path()),
+            "following discovery must not steal startup authority"
+        );
+        server.abort();
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn startup_namespace_and_authority_symlinks_fail_closed() {
+        let state = tempfile::tempdir().unwrap();
+        let target = tempfile::tempdir().unwrap();
+        std::os::unix::fs::symlink(target.path(), state.path().join(SUPERVISOR_STARTUP_FILE))
+            .unwrap();
+        let namespace_error = try_acquire_supervisor_startup_lock_in_dir(state.path()).unwrap_err();
+        assert_eq!(namespace_error.kind(), std::io::ErrorKind::PermissionDenied);
+
+        let state = tempfile::tempdir().unwrap();
+        let namespace = state.path().join(SUPERVISOR_STARTUP_FILE);
+        std::fs::create_dir(&namespace).unwrap();
+        let target_file = state.path().join("target.lock");
+        std::fs::write(&target_file, "").unwrap();
+        std::os::unix::fs::symlink(
+            &target_file,
+            namespace.join(SUPERVISOR_STARTUP_AUTHORITY_FILE),
+        )
+        .unwrap();
+        assert!(
+            try_acquire_supervisor_startup_lock_in_dir(state.path()).is_err(),
+            "authority symlinks must never become lock authority"
         );
     }
 

--- a/crates/kin-cli/src/daemon_client.rs
+++ b/crates/kin-cli/src/daemon_client.rs
@@ -2201,11 +2201,14 @@ async fn probe_daemon_endpoint(
         let probe_error = match client.get(format!("{base_url}/readiness")).send().await {
             Ok(resp) if resp.status().is_success() => {
                 match probe_health_for_repo(&client, &base_url, working_dir).await {
-                    // The daemon answered and identified itself: whatever it
-                    // said is real evidence, so a mismatch is a genuinely stale
-                    // record rather than a slow start.
-                    Ok(()) => return EndpointVerdict::Serving(base_url),
-                    Err(err) => return EndpointVerdict::Invalid(err.to_string()),
+                    HealthProbe::Matches => return EndpointVerdict::Serving(base_url),
+                    // The daemon answered and identified itself as something
+                    // else. That is real evidence the record is stale, not a
+                    // slow start.
+                    HealthProbe::Rejected(reason) => return EndpointVerdict::Invalid(reason),
+                    // No usable answer says nothing about whether the daemon is
+                    // alive, so it must not be treated as evidence against it.
+                    HealthProbe::Unanswered(detail) => detail,
                 }
             }
             Ok(resp) => {
@@ -2239,22 +2242,50 @@ async fn probe_daemon_endpoint(
     }
 }
 
+/// What a `/health` probe established about the daemon behind an endpoint.
+///
+/// The split that matters is answered vs unanswered. Only an answer identifies
+/// the daemon, and only an identification can prove an endpoint record wrong.
+/// A dropped connection or an unparseable body proves nothing, and collapsing
+/// it into "invalid" would put the endpoint-clobbering bug straight back.
+enum HealthProbe {
+    /// The daemon answered and serves this repo.
+    Matches,
+    /// The daemon answered and is serving a different repo, or reported a
+    /// status that is not serving at all.
+    Rejected(String),
+    /// No usable answer: transport error, HTTP error status, or a body that
+    /// would not parse.
+    Unanswered(String),
+}
+
 async fn probe_health_for_repo(
     client: &reqwest::Client,
     base_url: &str,
     working_dir: &Path,
-) -> Result<()> {
-    let health: HealthResponse = client
-        .get(format!("{base_url}/health"))
-        .send()
-        .await
-        .context("probe daemon health")?
-        .error_for_status()
-        .context("daemon health returned an error")?
-        .json()
-        .await
-        .context("parse daemon health response")?;
-    validate_health_repo(&health, working_dir)
+) -> HealthProbe {
+    let answered = async {
+        let health: HealthResponse = client
+            .get(format!("{base_url}/health"))
+            .send()
+            .await
+            .context("probe daemon health")?
+            .error_for_status()
+            .context("daemon health returned an error")?
+            .json()
+            .await
+            .context("parse daemon health response")?;
+        Ok::<HealthResponse, anyhow::Error>(health)
+    }
+    .await;
+
+    match answered {
+        Ok(health) => match validate_health_repo(&health, working_dir) {
+            Ok(()) => HealthProbe::Matches,
+            Err(reason) => HealthProbe::Rejected(reason.to_string()),
+        },
+        Err(error) => HealthProbe::Unanswered(error.to_string()),
+    }
 }
 
 async fn wait_for_daemon_ready(
@@ -2385,8 +2416,7 @@ async fn wait_for_existing_daemon_within(
             "daemon for this repo is alive but not ready yet; waiting rather than \
              replacing a running daemon"
         );
-        verdict =
-            probe_daemon_endpoint(kin_root, existing, patience.saturating_sub(short)).await;
+        verdict = probe_daemon_endpoint(kin_root, existing, patience.saturating_sub(short)).await;
     }
 
     match verdict {
@@ -3296,6 +3326,73 @@ mod tests {
             message.contains("kin daemon stop"),
             "the refusal must tell the operator how to act: {message}"
         );
+    }
+
+    /// A daemon that answers `/readiness` but drops every `/health` connection.
+    ///
+    /// Stands in for a live daemon too busy to complete a second request.
+    /// Returns its port and the task serving it.
+    async fn daemon_answering_readiness_but_not_health() -> (u16, tokio::task::JoinHandle<()>) {
+        use tokio::io::{AsyncReadExt, AsyncWriteExt};
+
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let port = listener.local_addr().unwrap().port();
+        let server = tokio::spawn(async move {
+            loop {
+                let Ok((mut socket, _)) = listener.accept().await else {
+                    return;
+                };
+                let mut buf = vec![0u8; 2048];
+                let Ok(read) = socket.read(&mut buf).await else {
+                    continue;
+                };
+                let request = String::from_utf8_lossy(&buf[..read]).to_string();
+                if request.contains("/readiness") {
+                    let body = r#"{"ready":true,"warming":false}"#;
+                    let _ = socket
+                        .write_all(
+                            format!(
+                                "HTTP/1.1 200 OK\r\ncontent-type: application/json\r\n\
+                                 connection: close\r\ncontent-length: {}\r\n\r\n{body}",
+                                body.len()
+                            )
+                            .as_bytes(),
+                        )
+                        .await;
+                    let _ = socket.flush().await;
+                }
+                // Anything else (i.e. /health) gets no answer at all.
+            }
+        });
+        (port, server)
+    }
+
+    #[tokio::test]
+    async fn a_health_probe_that_never_answers_is_not_evidence_against_the_daemon() {
+        // Only an answer can identify a daemon, so only an answer can prove an
+        // endpoint record wrong. A dropped health connection says nothing, and
+        // treating it as proof would clobber the live daemon all over again.
+        let dir = tempfile::tempdir().unwrap();
+        let root = dir.path();
+        let (port, server) = daemon_answering_readiness_but_not_health().await;
+        write_endpoint_files(root, std::process::id(), port);
+
+        let verdict = wait_for_existing_daemon_within(
+            root,
+            Duration::from_millis(50),
+            Duration::from_millis(400),
+        )
+        .await;
+
+        assert!(
+            matches!(verdict, ExistingDaemon::LiveNotReady(_)),
+            "an unanswered health probe must not condemn a live daemon: {verdict:?}"
+        );
+        assert!(
+            root.join("daemon.pid").exists() && root.join("daemon.port").exists(),
+            "endpoint files must survive an unanswered health probe"
+        );
+        server.abort();
     }
 
     #[tokio::test]

--- a/crates/kin-cli/src/daemon_client.rs
+++ b/crates/kin-cli/src/daemon_client.rs
@@ -2178,6 +2178,13 @@ impl DaemonEndpointRetirement {
             }
         }
     }
+
+    fn may_reflect_publication(&self) -> bool {
+        matches!(
+            self,
+            Self::Changed { .. } | Self::LifecycleContended | Self::SingletonHeld
+        )
+    }
 }
 
 /// Remove endpoint files only while they still name the exact endpoint a verdict
@@ -2364,9 +2371,11 @@ const SUPERVISOR_LIFECYCLE_FILE: &str = "supervisor.lifecycle";
 const SUPERVISOR_SINGLETON_FILE: &str = "supervisor.lock";
 const SUPERVISOR_STARTUP_FILE: &str = "supervisor.start.lock";
 const SUPERVISOR_STARTUP_AUTHORITY_FILE: &str = "authority.lock";
+const SUPERVISOR_STARTUP_RECORDS_DIR: &str = "records-v2";
 const SUPERVISOR_STARTUP_PROTOCOL: u32 = 2;
 const SUPERVISOR_STARTUP_CAPABILITY: &str = "generation-adoption-ack-v2";
 const SUPERVISOR_LEGACY_SENTINEL_CAPABILITY: &str = "legacy-directory-sentinel-v1";
+const SUPERVISOR_BOUNDED_ROLLBACK_CAPABILITY: &str = "bounded-legacy-rollback-v1";
 /// Internal handoff from the current CLI launcher to the supervisor child.
 ///
 /// This is scrubbed from every daemon command and set only on a supervisor
@@ -2484,6 +2493,13 @@ impl SupervisorEndpointRetirement {
                 format!("supervisor retirement coordination is unavailable: {detail}")
             }
         }
+    }
+
+    fn may_reflect_publication(&self) -> bool {
+        matches!(
+            self,
+            Self::Changed { .. } | Self::LifecycleContended | Self::SingletonHeld
+        )
     }
 }
 
@@ -2764,12 +2780,17 @@ fn validate_daemon_compat_response(compat: &DaemonCompatResponse) -> Result<(), 
             .supervisor_startup_capabilities
             .iter()
             .any(|capability| capability == SUPERVISOR_LEGACY_SENTINEL_CAPABILITY)
+        || !compat
+            .supervisor_startup_capabilities
+            .iter()
+            .any(|capability| capability == SUPERVISOR_BOUNDED_ROLLBACK_CAPABILITY)
     {
         return Err(format!(
-            "daemon does not acknowledge supervisor startup protocol v{} ({}, {})",
+            "daemon does not acknowledge supervisor startup protocol v{} ({}, {}, {})",
             SUPERVISOR_STARTUP_PROTOCOL,
             SUPERVISOR_STARTUP_CAPABILITY,
-            SUPERVISOR_LEGACY_SENTINEL_CAPABILITY
+            SUPERVISOR_LEGACY_SENTINEL_CAPABILITY,
+            SUPERVISOR_BOUNDED_ROLLBACK_CAPABILITY
         ));
     }
     Ok(())
@@ -3171,10 +3192,11 @@ struct StartupFileIdentity {
     file: u64,
 }
 
-fn startup_file_identity(metadata: &std::fs::Metadata) -> std::io::Result<StartupFileIdentity> {
+fn startup_file_identity(file: &File) -> std::io::Result<StartupFileIdentity> {
     #[cfg(unix)]
     {
         use std::os::unix::fs::MetadataExt;
+        let metadata = file.metadata()?;
         return Ok(StartupFileIdentity {
             volume: metadata.dev(),
             file: metadata.ino(),
@@ -3182,25 +3204,30 @@ fn startup_file_identity(metadata: &std::fs::Metadata) -> std::io::Result<Startu
     }
     #[cfg(windows)]
     {
-        use std::os::windows::fs::MetadataExt;
+        use std::mem::zeroed;
+        use std::os::windows::io::AsRawHandle as _;
+        use windows_sys::Win32::Storage::FileSystem::{
+            GetFileInformationByHandle, BY_HANDLE_FILE_INFORMATION,
+        };
+
+        // The std MetadataExt accessors for these fields are still unstable.
+        // Query the exact open handle instead, so identity cannot drift through
+        // a pathname reopen between validation and use.
+        // SAFETY: zero is a valid initializer for this output structure and
+        // `file` owns a live handle for the duration of the call.
+        let mut information: BY_HANDLE_FILE_INFORMATION = unsafe { zeroed() };
+        if unsafe { GetFileInformationByHandle(file.as_raw_handle().cast(), &mut information) } == 0
+        {
+            return Err(std::io::Error::last_os_error());
+        }
         return Ok(StartupFileIdentity {
-            volume: metadata.volume_serial_number().ok_or_else(|| {
-                std::io::Error::new(
-                    std::io::ErrorKind::Unsupported,
-                    "startup authority volume identity is unavailable",
-                )
-            })? as u64,
-            file: metadata.file_index().ok_or_else(|| {
-                std::io::Error::new(
-                    std::io::ErrorKind::Unsupported,
-                    "startup authority file identity is unavailable",
-                )
-            })?,
+            volume: information.dwVolumeSerialNumber as u64,
+            file: ((information.nFileIndexHigh as u64) << 32) | information.nFileIndexLow as u64,
         });
     }
     #[cfg(not(any(unix, windows)))]
     {
-        let _ = metadata;
+        let _ = file;
         Err(std::io::Error::new(
             std::io::ErrorKind::Unsupported,
             "startup authority file identity is unsupported on this platform",
@@ -3263,11 +3290,114 @@ fn open_startup_regular_file(
     Ok(file)
 }
 
-fn ensure_supervisor_startup_namespace(dir: &Path) -> std::io::Result<PathBuf> {
+fn open_startup_directory(path: &Path) -> std::io::Result<File> {
+    let mut options = OpenOptions::new();
+    #[cfg(not(windows))]
+    options.read(true);
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::OpenOptionsExt;
+        options.custom_flags(libc::O_NOFOLLOW | libc::O_CLOEXEC | libc::O_DIRECTORY);
+    }
+    #[cfg(windows)]
+    {
+        use std::os::windows::fs::OpenOptionsExt;
+        use windows_sys::Win32::Storage::FileSystem::{
+            FILE_FLAG_BACKUP_SEMANTICS, FILE_FLAG_OPEN_REPARSE_POINT, FILE_READ_ATTRIBUTES,
+            FILE_WRITE_ATTRIBUTES,
+        };
+        options
+            .access_mode(FILE_READ_ATTRIBUTES | FILE_WRITE_ATTRIBUTES)
+            .custom_flags(FILE_FLAG_BACKUP_SEMANTICS | FILE_FLAG_OPEN_REPARSE_POINT);
+    }
+    let file = options.open(path)?;
+    let metadata = file.metadata()?;
+    if metadata.file_type().is_symlink()
+        || startup_metadata_is_reparse_point(&metadata)
+        || !metadata.is_dir()
+    {
+        return Err(std::io::Error::new(
+            std::io::ErrorKind::PermissionDenied,
+            format!(
+                "supervisor startup protocol refuses non-directory handle {}",
+                path.display()
+            ),
+        ));
+    }
+    Ok(file)
+}
+
+#[derive(Debug)]
+struct SupervisorStartupNamespace {
+    sentinel: PathBuf,
+    records: PathBuf,
+    sentinel_file: File,
+    sentinel_identity: StartupFileIdentity,
+}
+
+/// Keep immutable protocol-v1 launchers on their bounded deadline path.
+///
+/// Those launchers treat an old `supervisor.start.lock` mtime as permission to
+/// call `remove_file` and immediately retry. The permanent v2 directory cannot
+/// be removed that way, so an aged ordinary mtime would turn the retry into an
+/// unbounded busy loop after a binary rollback. Current launchers instead stamp
+/// the outer, never-mutated sentinel far into the future. The legacy
+/// `modified().elapsed()` check then returns `Err` and reaches its configured
+/// deadline, while the directory continues to exclude legacy `create_new`
+/// launchers structurally.
+///
+/// All mutable v2 records live one level below the sentinel so creating a
+/// generation cannot refresh or age this compatibility stamp. Failure to set
+/// and read back a future timestamp fails current startup closed.
+fn preserve_bounded_legacy_rollback(
+    sentinel: &Path,
+    sentinel_file: &File,
+) -> std::io::Result<StartupFileIdentity> {
+    // One hundred leap years is inside the supported timestamp range of the
+    // filesystems Kin supports and is refreshed by every current launcher.
+    const FUTURE_SECS: u64 = 100 * 366 * 24 * 60 * 60;
+    let future = std::time::SystemTime::now()
+        .checked_add(Duration::from_secs(FUTURE_SECS))
+        .ok_or_else(|| {
+            std::io::Error::new(
+                std::io::ErrorKind::InvalidData,
+                "cannot represent the supervisor rollback sentinel timestamp",
+            )
+        })?;
+    let identity = startup_file_identity(sentinel_file)?;
+    filetime::set_file_handle_times(
+        sentinel_file,
+        None,
+        Some(filetime::FileTime::from_system_time(future)),
+    )?;
+    let readback_identity = startup_file_identity(sentinel_file)?;
+    if readback_identity != identity {
+        return Err(std::io::Error::new(
+            std::io::ErrorKind::PermissionDenied,
+            format!(
+                "supervisor rollback sentinel handle identity changed at {}",
+                sentinel.display()
+            ),
+        ));
+    }
+    let modified = sentinel_file.metadata()?.modified()?;
+    if modified.elapsed().is_ok() {
+        return Err(std::io::Error::new(
+            std::io::ErrorKind::InvalidData,
+            format!(
+                "filesystem did not preserve a future supervisor rollback sentinel timestamp at {}",
+                sentinel.display()
+            ),
+        ));
+    }
+    Ok(identity)
+}
+
+fn ensure_supervisor_startup_namespace(dir: &Path) -> std::io::Result<SupervisorStartupNamespace> {
     std::fs::create_dir_all(dir)?;
-    let path = dir.join(SUPERVISOR_STARTUP_FILE);
+    let sentinel = dir.join(SUPERVISOR_STARTUP_FILE);
     loop {
-        match std::fs::symlink_metadata(&path) {
+        match std::fs::symlink_metadata(&sentinel) {
             Ok(metadata)
                 if metadata.file_type().is_symlink()
                     || startup_metadata_is_reparse_point(&metadata) =>
@@ -3276,24 +3406,24 @@ fn ensure_supervisor_startup_namespace(dir: &Path) -> std::io::Result<PathBuf> {
                     std::io::ErrorKind::PermissionDenied,
                     format!(
                         "supervisor startup protocol refuses symlink {}",
-                        path.display()
+                        sentinel.display()
                     ),
                 ));
             }
-            Ok(metadata) if metadata.is_dir() => return Ok(path),
+            Ok(metadata) if metadata.is_dir() => break,
             Ok(_) => {
                 return Err(std::io::Error::new(
                     std::io::ErrorKind::Unsupported,
                     format!(
                         "legacy supervisor launcher marker at {} is incompatible with startup \
                          protocol v{SUPERVISOR_STARTUP_PROTOCOL}; refusing before supervisor boot",
-                        path.display()
+                        sentinel.display()
                     ),
                 ));
             }
             Err(error) if error.kind() == std::io::ErrorKind::NotFound => {
-                match std::fs::create_dir(&path) {
-                    Ok(()) => return Ok(path),
+                match std::fs::create_dir(&sentinel) {
+                    Ok(()) => break,
                     Err(error) if error.kind() == std::io::ErrorKind::AlreadyExists => continue,
                     Err(error) => return Err(error),
                 }
@@ -3301,6 +3431,51 @@ fn ensure_supervisor_startup_namespace(dir: &Path) -> std::io::Result<PathBuf> {
             Err(error) => return Err(error),
         }
     }
+
+    // Create every fixed entry before stamping the outer sentinel. Per-launch
+    // records are written only beneath `records`, so the outer directory mtime
+    // remains a stable compatibility signal after this point.
+    drop(open_startup_regular_file(
+        &sentinel.join(SUPERVISOR_STARTUP_AUTHORITY_FILE),
+        true,
+        false,
+        true,
+    )?);
+    let records = sentinel.join(SUPERVISOR_STARTUP_RECORDS_DIR);
+    loop {
+        match std::fs::symlink_metadata(&records) {
+            Ok(metadata)
+                if metadata.file_type().is_symlink()
+                    || startup_metadata_is_reparse_point(&metadata)
+                    || !metadata.is_dir() =>
+            {
+                return Err(std::io::Error::new(
+                    std::io::ErrorKind::PermissionDenied,
+                    format!(
+                        "supervisor startup protocol refuses non-directory records namespace {}",
+                        records.display()
+                    ),
+                ));
+            }
+            Ok(_) => break,
+            Err(error) if error.kind() == std::io::ErrorKind::NotFound => {
+                match std::fs::create_dir(&records) {
+                    Ok(()) => break,
+                    Err(error) if error.kind() == std::io::ErrorKind::AlreadyExists => continue,
+                    Err(error) => return Err(error),
+                }
+            }
+            Err(error) => return Err(error),
+        }
+    }
+    let sentinel_file = open_startup_directory(&sentinel)?;
+    let sentinel_identity = preserve_bounded_legacy_rollback(&sentinel, &sentinel_file)?;
+    Ok(SupervisorStartupNamespace {
+        sentinel,
+        records,
+        sentinel_file,
+        sentinel_identity,
+    })
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
@@ -3363,7 +3538,10 @@ fn read_startup_record<T: serde::de::DeserializeOwned>(path: &Path) -> std::io::
 #[derive(Debug)]
 pub struct SupervisorStartupLock {
     dir: PathBuf,
-    namespace: PathBuf,
+    sentinel: PathBuf,
+    records: PathBuf,
+    sentinel_file: File,
+    sentinel_identity: StartupFileIdentity,
     file: File,
     file_identity: StartupFileIdentity,
     generation: String,
@@ -3372,7 +3550,7 @@ pub struct SupervisorStartupLock {
 
 impl SupervisorStartupLock {
     fn path(&self) -> &Path {
-        &self.namespace
+        &self.sentinel
     }
 
     /// Exact generation handed from a launcher to its supervisor child.
@@ -3381,19 +3559,29 @@ impl SupervisorStartupLock {
     }
 
     fn current_authority_identity(&self) -> std::io::Result<StartupFileIdentity> {
-        let path = self.namespace.join(SUPERVISOR_STARTUP_AUTHORITY_FILE);
+        let path = self.sentinel.join(SUPERVISOR_STARTUP_AUTHORITY_FILE);
         let file = open_startup_regular_file(&path, false, false, false)?;
-        startup_file_identity(&file.metadata()?)
+        startup_file_identity(&file)
+    }
+
+    fn current_sentinel_identity(&self) -> std::io::Result<StartupFileIdentity> {
+        let file = open_startup_directory(&self.sentinel)?;
+        startup_file_identity(&file)
     }
 
     fn authorizes(&self, dir: &Path) -> bool {
-        if self.dir != dir || self.namespace != dir.join(SUPERVISOR_STARTUP_FILE) {
+        if self.dir != dir
+            || self.sentinel != dir.join(SUPERVISOR_STARTUP_FILE)
+            || self.records != self.sentinel.join(SUPERVISOR_STARTUP_RECORDS_DIR)
+        {
             return false;
         }
-        let own_identity = self
-            .file
-            .metadata()
-            .and_then(|metadata| startup_file_identity(&metadata));
+        if startup_file_identity(&self.sentinel_file).ok().as_ref() != Some(&self.sentinel_identity)
+            || self.current_sentinel_identity().ok().as_ref() != Some(&self.sentinel_identity)
+        {
+            return false;
+        }
+        let own_identity = startup_file_identity(&self.file);
         if own_identity.ok().as_ref() != Some(&self.file_identity) {
             return false;
         }
@@ -3404,7 +3592,7 @@ impl SupervisorStartupLock {
             return false;
         }
         read_startup_record::<SupervisorLaunchRecord>(&supervisor_launch_record_path(
-            &self.namespace,
+            &self.records,
             &self.generation,
         ))
         .ok()
@@ -3425,7 +3613,7 @@ impl SupervisorStartupLock {
             ));
         }
         let adoption: SupervisorAdoptionRecord = read_startup_record(
-            &supervisor_adoption_record_path(&self.namespace, &self.generation),
+            &supervisor_adoption_record_path(&self.records, &self.generation),
         )?;
         if adoption.schema != "kin.supervisor.adoption.v2"
             || adoption.protocol != SUPERVISOR_STARTUP_PROTOCOL
@@ -3445,7 +3633,7 @@ impl SupervisorStartupLock {
 
 #[derive(Debug)]
 pub struct SupervisorRuntimeStartup {
-    namespace: PathBuf,
+    records: PathBuf,
     generation: String,
     authority: StartupFileIdentity,
     supervisor: ProcessIdentity,
@@ -3460,7 +3648,7 @@ impl SupervisorRuntimeStartup {
             supervisor: self.supervisor.clone(),
             authority: self.authority.clone(),
         };
-        let path = supervisor_adoption_record_path(&self.namespace, &self.generation);
+        let path = supervisor_adoption_record_path(&self.records, &self.generation);
         match write_immutable_startup_record(&path, &record) {
             Ok(()) => Ok(()),
             Err(error) if error.kind() == std::io::ErrorKind::AlreadyExists => {
@@ -3533,9 +3721,9 @@ pub fn try_acquire_supervisor_startup_lock_in_dir(
     dir: &Path,
 ) -> std::io::Result<SupervisorStartupLock> {
     let namespace = ensure_supervisor_startup_namespace(dir)?;
-    let authority_path = namespace.join(SUPERVISOR_STARTUP_AUTHORITY_FILE);
-    let file = open_startup_regular_file(&authority_path, true, false, true)?;
-    let file_identity = startup_file_identity(&file.metadata()?)?;
+    let authority_path = namespace.sentinel.join(SUPERVISOR_STARTUP_AUTHORITY_FILE);
+    let file = open_startup_regular_file(&authority_path, false, false, true)?;
+    let file_identity = startup_file_identity(&file)?;
     match file.try_lock_exclusive() {
         Ok(()) => {}
         Err(error) if error.kind() == fs2::lock_contended_error().kind() => {
@@ -3545,6 +3733,21 @@ pub fn try_acquire_supervisor_startup_lock_in_dir(
             ));
         }
         Err(error) => return Err(error),
+    }
+    let current_sentinel = open_startup_directory(&namespace.sentinel)?;
+    if startup_file_identity(&current_sentinel)? != namespace.sentinel_identity {
+        return Err(std::io::Error::new(
+            std::io::ErrorKind::PermissionDenied,
+            "supervisor startup sentinel changed before authority acquisition",
+        ));
+    }
+    if preserve_bounded_legacy_rollback(&namespace.sentinel, &namespace.sentinel_file)?
+        != namespace.sentinel_identity
+    {
+        return Err(std::io::Error::new(
+            std::io::ErrorKind::PermissionDenied,
+            "supervisor startup sentinel changed while preserving rollback compatibility",
+        ));
     }
 
     let generation = Uuid::new_v4().to_string();
@@ -3556,12 +3759,15 @@ pub fn try_acquire_supervisor_startup_lock_in_dir(
         authority: file_identity.clone(),
     };
     write_immutable_startup_record(
-        &supervisor_launch_record_path(&namespace, &generation),
+        &supervisor_launch_record_path(&namespace.records, &generation),
         &launch,
     )?;
     Ok(SupervisorStartupLock {
         dir: dir.to_path_buf(),
-        namespace,
+        sentinel: namespace.sentinel,
+        records: namespace.records,
+        sentinel_file: namespace.sentinel_file,
+        sentinel_identity: namespace.sentinel_identity,
         file,
         file_identity,
         generation,
@@ -3683,26 +3889,25 @@ pub fn validate_supervisor_runtime_startup(
         )
     })?;
 
-    let namespace = dir.join(SUPERVISOR_STARTUP_FILE);
-    let namespace_metadata = std::fs::symlink_metadata(&namespace)?;
-    if namespace_metadata.file_type().is_symlink()
-        || startup_metadata_is_reparse_point(&namespace_metadata)
-        || !namespace_metadata.is_dir()
-    {
+    let sentinel = dir.join(SUPERVISOR_STARTUP_FILE);
+    let sentinel_file = open_startup_directory(&sentinel)?;
+    if sentinel_file.metadata()?.modified()?.elapsed().is_ok() {
         return Err(std::io::Error::new(
             std::io::ErrorKind::PermissionDenied,
-            "supervisor startup namespace is not a real directory",
+            "supervisor startup sentinel does not preserve bounded legacy rollback",
         ));
     }
+    let records = sentinel.join(SUPERVISOR_STARTUP_RECORDS_DIR);
+    let _records_file = open_startup_directory(&records)?;
     let authority_file = open_startup_regular_file(
-        &namespace.join(SUPERVISOR_STARTUP_AUTHORITY_FILE),
+        &sentinel.join(SUPERVISOR_STARTUP_AUTHORITY_FILE),
         false,
         false,
         false,
     )?;
-    let authority = startup_file_identity(&authority_file.metadata()?)?;
+    let authority = startup_file_identity(&authority_file)?;
     let launch: SupervisorLaunchRecord =
-        read_startup_record(&supervisor_launch_record_path(&namespace, generation))?;
+        read_startup_record(&supervisor_launch_record_path(&records, generation))?;
     if launch.schema != "kin.supervisor.launch.v2"
         || launch.protocol != SUPERVISOR_STARTUP_PROTOCOL
         || launch.generation != generation
@@ -3715,7 +3920,7 @@ pub fn validate_supervisor_runtime_startup(
     }
 
     let supervisor = current_process_identity()?;
-    let adoption_path = supervisor_adoption_record_path(&namespace, generation);
+    let adoption_path = supervisor_adoption_record_path(&records, generation);
     let accepted_reexec = match read_startup_record::<SupervisorAdoptionRecord>(&adoption_path) {
         Ok(existing) => {
             existing.schema == "kin.supervisor.adoption.v2"
@@ -3729,7 +3934,7 @@ pub fn validate_supervisor_runtime_startup(
     };
     if !accepted_reexec
         && (!process_identity_is_current(&launch.launcher)?
-            || !supervisor_startup_authority_is_held(&namespace)?)
+            || !supervisor_startup_authority_is_held(&sentinel)?)
     {
         return Err(std::io::Error::new(
             std::io::ErrorKind::PermissionDenied,
@@ -3737,7 +3942,7 @@ pub fn validate_supervisor_runtime_startup(
         ));
     }
     Ok(SupervisorRuntimeStartup {
-        namespace,
+        records,
         generation: generation.to_string(),
         authority,
         supervisor,
@@ -3994,6 +4199,10 @@ enum ExistingDaemon {
     Connected(String),
     /// No usable record (absent, or proven wrong and now cleared). Start one.
     None,
+    /// A serialized owner exists, but its endpoint publication is not complete
+    /// yet. Re-snapshot until the shared startup deadline instead of treating a
+    /// legitimate no-endpoint or PID-only state as terminal.
+    Starting(String),
     /// A live daemon owns this repo but is not serving yet. Starting a second
     /// one would lose the singleton flock, so the caller must report this
     /// instead.
@@ -4023,6 +4232,29 @@ async fn wait_for_existing_daemon_within(
     patience: Duration,
 ) -> ExistingDaemon {
     let deadline = Instant::now() + patience;
+    loop {
+        match inspect_existing_daemon_once(kin_root, short, deadline, patience).await {
+            ExistingDaemon::Starting(_detail) if Instant::now() < deadline => {
+                tokio::time::sleep(Duration::from_millis(50)).await;
+            }
+            ExistingDaemon::Starting(detail) => {
+                return ExistingDaemon::LiveNotReady(format!(
+                    "kin daemon startup is serialized but endpoint publication did not complete \
+                     within {}s: {detail}. Kin will not start a second daemon",
+                    patience.as_secs()
+                ));
+            }
+            resolved => return resolved,
+        }
+    }
+}
+
+async fn inspect_existing_daemon_once(
+    kin_root: &Path,
+    short: Duration,
+    deadline: Instant,
+    patience: Duration,
+) -> ExistingDaemon {
     let recorded = daemon_endpoint_snapshot(kin_root);
     let Some(pid) = recorded.pid else {
         if recorded.pid_exists {
@@ -4036,6 +4268,12 @@ async fn wait_for_existing_daemon_within(
             let retirement = retire_daemon_endpoint_if_unchanged(kin_root, recorded);
             return match retirement {
                 DaemonEndpointRetirement::Retired => ExistingDaemon::None,
+                preserved if preserved.may_reflect_publication() => {
+                    ExistingDaemon::Starting(format!(
+                        "the endpoint is not published yet and {}",
+                        preserved.preserved_reason()
+                    ))
+                }
                 preserved => {
                     follow_preserved_daemon_endpoint(kin_root, deadline, patience, preserved).await
                 }
@@ -4044,6 +4282,10 @@ async fn wait_for_existing_daemon_within(
         let retirement = retire_daemon_endpoint_if_unchanged(kin_root, recorded);
         return match retirement {
             DaemonEndpointRetirement::Retired => ExistingDaemon::None,
+            preserved if preserved.may_reflect_publication() => ExistingDaemon::Starting(format!(
+                "the endpoint PID is not published yet and {}",
+                preserved.preserved_reason()
+            )),
             preserved => {
                 follow_preserved_daemon_endpoint(kin_root, deadline, patience, preserved).await
             }
@@ -4054,6 +4296,10 @@ async fn wait_for_existing_daemon_within(
         let retirement = retire_daemon_endpoint_if_unchanged(kin_root, recorded);
         return match retirement {
             DaemonEndpointRetirement::Retired => ExistingDaemon::None,
+            preserved if preserved.may_reflect_publication() => ExistingDaemon::Starting(format!(
+                "the recorded owner changed during startup and {}",
+                preserved.preserved_reason()
+            )),
             preserved => {
                 follow_preserved_daemon_endpoint(kin_root, deadline, patience, preserved).await
             }
@@ -4061,9 +4307,8 @@ async fn wait_for_existing_daemon_within(
     }
 
     let Some(port) = recorded.port else {
-        return ExistingDaemon::LiveNotReady(format!(
-            "kin daemon pid {pid} may still own this repo, but its port record is absent or \
-             unparseable; refusing to start a second daemon"
+        return ExistingDaemon::Starting(format!(
+            "kin daemon pid {pid} may still own this repo and has not published a usable port yet"
         ));
     };
     let existing = LiveDaemonEndpoint { pid, port };
@@ -4110,6 +4355,12 @@ async fn wait_for_existing_daemon_within(
                 remove_daemon_files_if_unchanged(kin_root, existing.pid, Some(existing.port));
             match retirement {
                 DaemonEndpointRetirement::Retired => ExistingDaemon::None,
+                preserved if preserved.may_reflect_publication() => {
+                    ExistingDaemon::Starting(format!(
+                        "the endpoint changed while its predecessor was retired and {}",
+                        preserved.preserved_reason()
+                    ))
+                }
                 preserved => {
                     follow_preserved_daemon_endpoint(kin_root, deadline, patience, preserved).await
                 }
@@ -4256,6 +4507,7 @@ enum ExistingSupervisor {
     Connected(String),
     NeedsStartupAuthority,
     SpawnAuthorized,
+    Starting(String),
     LiveNotReady(String),
 }
 
@@ -4295,6 +4547,12 @@ where
         if !recorded.port_exists {
             return match retire_supervisor_endpoint_if_unchanged(dir, recorded, startup_authority) {
                 SupervisorEndpointRetirement::Retired => ExistingSupervisor::SpawnAuthorized,
+                preserved if preserved.may_reflect_publication() => {
+                    ExistingSupervisor::Starting(format!(
+                        "the supervisor endpoint is not published yet and {}",
+                        preserved.preserved_reason()
+                    ))
+                }
                 preserved => ExistingSupervisor::LiveNotReady(format!(
                     "supervisor startup authority is unavailable because {}; kin will not start \
                      a replacement",
@@ -4304,6 +4562,12 @@ where
         }
         return match retire_supervisor_endpoint_if_unchanged(dir, recorded, startup_authority) {
             SupervisorEndpointRetirement::Retired => ExistingSupervisor::SpawnAuthorized,
+            preserved if preserved.may_reflect_publication() => {
+                ExistingSupervisor::Starting(format!(
+                    "the supervisor PID is not published yet and {}",
+                    preserved.preserved_reason()
+                ))
+            }
             preserved => ExistingSupervisor::LiveNotReady(format!(
                 "supervisor endpoint retirement was refused because {}; kin will not start a \
                  replacement",
@@ -4318,6 +4582,12 @@ where
         };
         return match retire_supervisor_endpoint_if_unchanged(dir, recorded, startup_authority) {
             SupervisorEndpointRetirement::Retired => ExistingSupervisor::SpawnAuthorized,
+            preserved if preserved.may_reflect_publication() => {
+                ExistingSupervisor::Starting(format!(
+                    "the supervisor endpoint changed during startup and {}",
+                    preserved.preserved_reason()
+                ))
+            }
             preserved => ExistingSupervisor::LiveNotReady(format!(
                 "supervisor endpoint retirement was refused because {}; kin will not start a \
                  replacement",
@@ -4327,9 +4597,9 @@ where
     }
 
     let Some(port) = recorded.port else {
-        return ExistingSupervisor::LiveNotReady(format!(
-            "kin supervisor pid {pid} may still own the per-user control plane, but its port \
-             record is absent or unparseable; refusing to start a second supervisor"
+        return ExistingSupervisor::Starting(format!(
+            "kin supervisor pid {pid} may still own the per-user control plane and has not \
+             published a usable port yet"
         ));
     };
     let existing = LiveDaemonEndpoint { pid, port };
@@ -4343,11 +4613,34 @@ where
                 "supervisor owner is live or indeterminate but health is unavailable; \
                  preserving endpoint and refusing replacement"
             );
-            ExistingSupervisor::LiveNotReady(format!(
+            ExistingSupervisor::Starting(format!(
                 "kin supervisor (pid {}, port {}) may still own the per-user control plane but \
-                 did not pass health: {err}. Kin will not replace a live or indeterminate owner",
+                 has not passed health yet: {err}",
                 existing.pid, existing.port
             ))
+        }
+    }
+}
+
+async fn follow_existing_supervisor_publication(
+    dir: &Path,
+    startup_authority: &SupervisorStartupLock,
+    timeout: Duration,
+) -> ExistingSupervisor {
+    let deadline = Instant::now() + timeout;
+    loop {
+        match wait_for_existing_supervisor_in_dir(dir, Some(startup_authority)).await {
+            ExistingSupervisor::Starting(_detail) if Instant::now() < deadline => {
+                tokio::time::sleep(Duration::from_millis(50)).await;
+            }
+            ExistingSupervisor::Starting(detail) => {
+                return ExistingSupervisor::LiveNotReady(format!(
+                    "kin supervisor startup is serialized but endpoint publication did not \
+                     complete within {}s: {detail}. Kin will not start a second supervisor",
+                    timeout.as_secs()
+                ));
+            }
+            resolved => return resolved,
         }
     }
 }
@@ -4442,7 +4735,7 @@ pub async fn ensure_supervisor_running() -> Result<String> {
     match probe_existing_supervisor().await {
         ExistingSupervisor::Connected(base_url) => return Ok(base_url),
         ExistingSupervisor::LiveNotReady(message) => bail!(message),
-        ExistingSupervisor::NeedsStartupAuthority => {}
+        ExistingSupervisor::NeedsStartupAuthority | ExistingSupervisor::Starting(_) => {}
         ExistingSupervisor::SpawnAuthorized => {
             bail!("supervisor probe authorized a spawn without startup protocol authority")
         }
@@ -4457,9 +4750,17 @@ pub async fn ensure_supervisor_running() -> Result<String> {
         SupervisorStartupAcquisition::Authority(authority) => authority,
     };
     let dir = supervisor_dir();
-    match wait_for_existing_supervisor_in_dir(&dir, Some(&startup_authority)).await {
+    match follow_existing_supervisor_publication(
+        &dir,
+        &startup_authority,
+        Duration::from_secs(daemon_ready_timeout_secs()),
+    )
+    .await
+    {
         ExistingSupervisor::Connected(base_url) => return Ok(base_url),
-        ExistingSupervisor::LiveNotReady(message) => bail!(message),
+        ExistingSupervisor::Starting(message) | ExistingSupervisor::LiveNotReady(message) => {
+            bail!(message)
+        }
         ExistingSupervisor::SpawnAuthorized => {}
         ExistingSupervisor::NeedsStartupAuthority => {
             bail!("supervisor startup authority was lost before the spawn decision")
@@ -4775,7 +5076,9 @@ pub async fn ensure_daemon_running_with_idle_timeout(
             register_repo_daemon_with_supervisor(kin_root, &base_url, &supervisor_url).await?;
             return Ok(base_url);
         }
-        ExistingDaemon::LiveNotReady(message) => bail!(message),
+        ExistingDaemon::Starting(message) | ExistingDaemon::LiveNotReady(message) => {
+            bail!(message)
+        }
         ExistingDaemon::None => {}
     }
 
@@ -4788,7 +5091,9 @@ pub async fn ensure_daemon_running_with_idle_timeout(
             register_repo_daemon_with_supervisor(kin_root, &base_url, &supervisor_url).await?;
             return Ok(base_url);
         }
-        ExistingDaemon::LiveNotReady(message) => bail!(message),
+        ExistingDaemon::Starting(message) | ExistingDaemon::LiveNotReady(message) => {
+            bail!(message)
+        }
         ExistingDaemon::None => {}
     }
 
@@ -5264,6 +5569,51 @@ mod tests {
         (port, server)
     }
 
+    fn serve_repo_daemon_health(
+        listener: tokio::net::TcpListener,
+        repo_root: &Path,
+    ) -> tokio::task::JoinHandle<()> {
+        use tokio::io::{AsyncReadExt, AsyncWriteExt};
+
+        let repo_root = strict_canonical_path(repo_root).unwrap();
+        tokio::spawn(async move {
+            loop {
+                let Ok((mut socket, _)) = listener.accept().await else {
+                    return;
+                };
+                let mut buffer = [0_u8; 2048];
+                let Ok(read) = socket.read(&mut buffer).await else {
+                    continue;
+                };
+                let request = String::from_utf8_lossy(&buffer[..read]);
+                let body = if request.contains("/readiness") {
+                    r#"{"ready":true,"warming":false}"#.to_string()
+                } else if request.contains("/health") {
+                    serde_json::json!({
+                        "status": "ok",
+                        "version": "test",
+                        "uptime_seconds": 0,
+                        "graph_entity_count": 0,
+                        "graph_loaded": true,
+                        "reconciliation_status": "idle",
+                        "repo_root": repo_root,
+                        "pid": std::process::id(),
+                    })
+                    .to_string()
+                } else {
+                    continue;
+                };
+                let response = format!(
+                    "HTTP/1.1 200 OK\r\ncontent-type: application/json\r\n\
+                     connection: close\r\ncontent-length: {}\r\n\r\n{body}",
+                    body.len()
+                );
+                let _ = socket.write_all(response.as_bytes()).await;
+                let _ = socket.flush().await;
+            }
+        })
+    }
+
     #[tokio::test]
     async fn a_health_probe_that_never_answers_is_not_evidence_against_the_daemon() {
         // Only an answer can identify a daemon, so only an answer can prove an
@@ -5479,8 +5829,8 @@ mod tests {
         let dir = tempfile::tempdir().unwrap();
         let mut launcher_a = try_acquire_supervisor_startup_lock_in_dir(dir.path()).unwrap();
         assert!(
-            startup_lock_is_stale(launcher_a.path(), Duration::ZERO),
-            "the test must make the former wall-clock lease look expired"
+            !startup_lock_is_stale(launcher_a.path(), Duration::ZERO),
+            "the permanent sentinel must keep immutable clients on their bounded deadline path"
         );
 
         let b_while_a =
@@ -5491,7 +5841,7 @@ mod tests {
             b_while_a
                 .to_string()
                 .contains("timed out waiting for supervisor startup lock"),
-            "B must not time-steal A even when the directory mtime looks expired: {b_while_a:#}"
+            "B must not time-steal A while its exact kernel authority is held: {b_while_a:#}"
         );
         assert!(launcher_a.authorizes(dir.path()));
         assert!(launcher_a.heartbeat().unwrap());
@@ -5535,7 +5885,7 @@ mod tests {
         let launcher = try_acquire_supervisor_startup_lock_in_dir(dir.path()).unwrap();
         let generation = launcher.generation().to_string();
         let runtime = SupervisorRuntimeStartup {
-            namespace: launcher.path().to_path_buf(),
+            records: launcher.records.clone(),
             generation: generation.clone(),
             authority: launcher.file_identity.clone(),
             supervisor: current_process_identity().unwrap(),
@@ -5543,7 +5893,7 @@ mod tests {
         runtime.acknowledge().unwrap();
         launcher.verify_adoption(std::process::id()).unwrap();
 
-        let adoption_path = supervisor_adoption_record_path(launcher.path(), &generation);
+        let adoption_path = supervisor_adoption_record_path(&launcher.records, &generation);
         let replacement = SupervisorAdoptionRecord {
             schema: "kin.supervisor.adoption.v2".to_string(),
             protocol: SUPERVISOR_STARTUP_PROTOCOL,
@@ -5685,6 +6035,7 @@ mod tests {
             "supervisor_startup_capabilities": [
                 SUPERVISOR_STARTUP_CAPABILITY,
                 SUPERVISOR_LEGACY_SENTINEL_CAPABILITY,
+                SUPERVISOR_BOUNDED_ROLLBACK_CAPABILITY,
             ],
         }))
         .unwrap();
@@ -5717,12 +6068,10 @@ mod tests {
         assert!(!process_identity_is_current(&rebooted).unwrap());
     }
 
-    async fn supervisor_health_server() -> (u16, tokio::task::JoinHandle<()>) {
+    fn serve_supervisor_health(listener: tokio::net::TcpListener) -> tokio::task::JoinHandle<()> {
         use tokio::io::{AsyncReadExt, AsyncWriteExt};
 
-        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
-        let port = listener.local_addr().unwrap().port();
-        let server = tokio::spawn(async move {
+        tokio::spawn(async move {
             loop {
                 let Ok((mut socket, _)) = listener.accept().await else {
                     return;
@@ -5743,24 +6092,75 @@ mod tests {
                 let _ = socket.write_all(response.as_bytes()).await;
                 let _ = socket.flush().await;
             }
-        });
-        (port, server)
+        })
     }
 
     #[tokio::test]
-    async fn waiter_behind_live_startup_authority_follows_republished_discovery_promptly() {
+    async fn supervisor_waiter_follows_staged_publication_without_stealing_authority() {
         let dir = tempfile::tempdir().unwrap();
         let launcher = try_acquire_supervisor_startup_lock_in_dir(dir.path()).unwrap();
+        let singleton = OpenOptions::new()
+            .create(true)
+            .read(true)
+            .write(true)
+            .truncate(false)
+            .open(dir.path().join(SUPERVISOR_SINGLETON_FILE))
+            .unwrap();
+        singleton.lock_exclusive().unwrap();
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let port = listener.local_addr().unwrap().port();
+
+        let no_endpoint_fast_path = wait_for_existing_supervisor_in_dir(dir.path(), None).await;
+        assert!(
+            matches!(
+                no_endpoint_fast_path,
+                ExistingSupervisor::NeedsStartupAuthority
+            ),
+            "the public fast path must join startup authority before endpoint publication: \
+             {no_endpoint_fast_path:?}"
+        );
         let waiter_dir = dir.path().to_path_buf();
         let waiter = tokio::spawn(async move {
             acquire_supervisor_startup_lock_in_dir_with_timeout(&waiter_dir, Duration::from_secs(5))
                 .await
         });
         tokio::time::sleep(Duration::from_millis(150)).await;
+        assert!(
+            !waiter.is_finished(),
+            "a waiter with no endpoint must remain behind the original startup generation"
+        );
 
-        let (port, server) = supervisor_health_server().await;
-        write_legacy_supervisor_endpoint_files(dir.path(), std::process::id(), port);
-        let outcome = tokio::time::timeout(Duration::from_secs(1), waiter)
+        std::fs::write(
+            dir.path().join(SUPERVISOR_PID_FILE),
+            std::process::id().to_string(),
+        )
+        .unwrap();
+        let fast_path = wait_for_existing_supervisor_in_dir(dir.path(), None).await;
+        assert!(
+            matches!(fast_path, ExistingSupervisor::Starting(_)),
+            "the public fast path must join PID-only publication: {fast_path:?}"
+        );
+        tokio::time::sleep(Duration::from_millis(150)).await;
+        assert!(
+            !waiter.is_finished(),
+            "PID-only publication must remain behind the original startup generation"
+        );
+        let port_tmp = dir.path().join(format!("{SUPERVISOR_PORT_FILE}.tmp"));
+        std::fs::write(&port_tmp, port.to_string()).unwrap();
+        std::fs::rename(port_tmp, dir.path().join(SUPERVISOR_PORT_FILE)).unwrap();
+        let unready_fast_path = wait_for_existing_supervisor_in_dir(dir.path(), None).await;
+        assert!(
+            matches!(unready_fast_path, ExistingSupervisor::Starting(_)),
+            "the public fast path must follow a complete endpoint until health is served: \
+             {unready_fast_path:?}"
+        );
+        tokio::time::sleep(Duration::from_millis(150)).await;
+        assert!(
+            !waiter.is_finished(),
+            "a complete endpoint that has not served health must remain with its original owner"
+        );
+        let server = serve_supervisor_health(listener);
+        let outcome = tokio::time::timeout(Duration::from_secs(3), waiter)
             .await
             .expect("waiter must follow repaired discovery promptly")
             .expect("waiter task")
@@ -5777,6 +6177,11 @@ mod tests {
             launcher.authorizes(dir.path()),
             "following discovery must not steal startup authority"
         );
+        assert!(
+            dir.path().join(SUPERVISOR_SINGLETON_FILE).exists(),
+            "following publication must not unlink lifetime authority"
+        );
+        drop(singleton);
         server.abort();
     }
 
@@ -5877,7 +6282,7 @@ mod tests {
             wait_for_existing_supervisor_in_dir(dir.path(), Some(&current_startup_authority)).await;
 
         assert!(
-            matches!(final_decision, ExistingSupervisor::LiveNotReady(_)),
+            matches!(final_decision, ExistingSupervisor::Starting(_)),
             "the final serialized check must follow/preserve the live legacy owner and forbid a \
              second spawn: {final_decision:?}"
         );
@@ -6173,6 +6578,76 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn daemon_waiter_follows_no_endpoint_pid_only_and_unready_publication() {
+        let repo = tempfile::tempdir().unwrap();
+        let root = repo.path().join(".kin");
+        std::fs::create_dir(&root).unwrap();
+        let singleton = OpenOptions::new()
+            .create(true)
+            .read(true)
+            .write(true)
+            .truncate(false)
+            .open(root.join("daemon.lock"))
+            .unwrap();
+        singleton.lock_exclusive().unwrap();
+
+        // Bind the final port without serving it yet. This gives the waiter a
+        // deterministic complete-but-not-yet-serving publication slice after
+        // the preceding no-endpoint and PID-only slices.
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let port = listener.local_addr().unwrap().port();
+        let waiter_root = root.clone();
+        let waiter = tokio::spawn(async move {
+            wait_for_existing_daemon_within(
+                &waiter_root,
+                Duration::from_millis(20),
+                Duration::from_secs(3),
+            )
+            .await
+        });
+
+        tokio::time::sleep(Duration::from_millis(100)).await;
+        assert!(
+            !waiter.is_finished(),
+            "a held singleton with no endpoint must be followed, not rejected"
+        );
+        std::fs::write(root.join("daemon.pid"), std::process::id().to_string()).unwrap();
+        tokio::time::sleep(Duration::from_millis(100)).await;
+        assert!(
+            !waiter.is_finished(),
+            "PID-only publication must be followed, not rejected"
+        );
+        std::fs::write(root.join("daemon.port"), port.to_string()).unwrap();
+        tokio::time::sleep(Duration::from_millis(100)).await;
+        assert!(
+            !waiter.is_finished(),
+            "a complete endpoint that has not served yet must remain owned"
+        );
+
+        let server = serve_repo_daemon_health(listener, repo.path());
+        let outcome = tokio::time::timeout(Duration::from_secs(2), waiter)
+            .await
+            .expect("waiter must follow endpoint publication")
+            .expect("waiter task");
+        assert!(
+            matches!(
+                outcome,
+                ExistingDaemon::Connected(ref url)
+                    if url == &format!("http://127.0.0.1:{port}")
+            ),
+            "the waiter must connect to the original serialized owner: {outcome:?}"
+        );
+        assert_eq!(read_pid_file(&root), Some(std::process::id()));
+        assert_eq!(read_port_file(&root), Some(port));
+        assert!(
+            root.join("daemon.lock").exists(),
+            "following publication must not unlink lifetime authority"
+        );
+        drop(singleton);
+        server.abort();
+    }
+
+    #[tokio::test]
     async fn live_supervisor_health_failure_preserves_lifetime_owner_and_forbids_spawn() {
         let dir = tempfile::tempdir().unwrap();
         let startup_authority = try_acquire_supervisor_startup_lock_in_dir(dir.path()).unwrap();
@@ -6194,7 +6669,7 @@ mod tests {
 
         let verdict = wait_for_existing_supervisor_in_dir(dir.path(), None).await;
         assert!(
-            matches!(verdict, ExistingSupervisor::LiveNotReady(_)),
+            matches!(verdict, ExistingSupervisor::Starting(_)),
             "a health hiccup from a live owner must forbid spawning: {verdict:?}"
         );
         assert!(dir.path().join(SUPERVISOR_PID_FILE).exists());
@@ -6218,7 +6693,7 @@ mod tests {
         let unpublished_owner =
             wait_for_existing_supervisor_in_dir(dir.path(), Some(&startup_authority)).await;
         assert!(
-            matches!(unpublished_owner, ExistingSupervisor::LiveNotReady(_)),
+            matches!(unpublished_owner, ExistingSupervisor::Starting(_)),
             "a supervisor holding its lifetime singleton before publication must still forbid a \
              second spawn: {unpublished_owner:?}"
         );
@@ -6517,6 +6992,52 @@ mod tests {
         );
         assert_eq!(read_pid_file(root), Some(4242));
         assert_eq!(read_port_file(root), Some(51001));
+    }
+
+    #[cfg(windows)]
+    #[test]
+    fn windows_startup_file_identity_uses_the_exact_open_handle() {
+        let dir = tempfile::tempdir().unwrap();
+        let first_path = dir.path().join("first.lock");
+        let second_path = dir.path().join("second.lock");
+        std::fs::write(&first_path, "").unwrap();
+        std::fs::write(&second_path, "").unwrap();
+        let first = open_startup_regular_file(&first_path, false, false, false).unwrap();
+        let first_reopened = open_startup_regular_file(&first_path, false, false, false).unwrap();
+        let second = open_startup_regular_file(&second_path, false, false, false).unwrap();
+
+        assert_eq!(
+            startup_file_identity(&first).unwrap(),
+            startup_file_identity(&first_reopened).unwrap(),
+            "two handles to the same startup authority must report one identity"
+        );
+        assert_ne!(
+            startup_file_identity(&first).unwrap(),
+            startup_file_identity(&second).unwrap(),
+            "distinct startup authority files must not alias"
+        );
+    }
+
+    #[cfg(windows)]
+    #[test]
+    fn windows_directory_handle_can_preserve_bounded_rollback_timestamp() {
+        let dir = tempfile::tempdir().unwrap();
+        let namespace = ensure_supervisor_startup_namespace(dir.path()).unwrap();
+        assert_eq!(
+            startup_file_identity(&namespace.sentinel_file).unwrap(),
+            namespace.sentinel_identity
+        );
+        assert!(
+            namespace
+                .sentinel_file
+                .metadata()
+                .unwrap()
+                .modified()
+                .unwrap()
+                .elapsed()
+                .is_err(),
+            "the exact Windows directory handle must retain a future mtime"
+        );
     }
 
     #[cfg(windows)]

--- a/crates/kin-cli/src/daemon_client.rs
+++ b/crates/kin-cli/src/daemon_client.rs
@@ -14,12 +14,13 @@ use serde::Deserialize;
 use serde::Serialize;
 use sha2::{Digest, Sha256};
 use std::fs::{File, OpenOptions};
-use std::io::Write;
+use std::io::{Read, Seek, SeekFrom, Write};
 use std::path::{Path, PathBuf};
 use std::process::{Child, Command, Stdio};
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::time::{Duration, Instant};
 use tracing::{info, warn};
+use uuid::Uuid;
 
 static BUILD_MISMATCH_REPORTED: AtomicBool = AtomicBool::new(false);
 
@@ -45,6 +46,7 @@ const DAEMON_AMBIENT_AUTHORITY_ENV: &[&str] = &[
     "KIN_SESSION_DIR",
     "KIN_DAEMON_URL",
     "KIN_DAEMON_WATCH_PID",
+    SUPERVISOR_STARTUP_GENERATION_ENV,
     "KIN_REPO_ID",
     "KIN_REPO_IDS",
     "KIN_PRIMARY_REPO_ID",
@@ -2101,6 +2103,11 @@ const SUPERVISOR_PORT_FILE: &str = "supervisor.port";
 const SUPERVISOR_LIFECYCLE_FILE: &str = "supervisor.lifecycle";
 const SUPERVISOR_SINGLETON_FILE: &str = "supervisor.lock";
 const SUPERVISOR_STARTUP_FILE: &str = "supervisor.start.lock";
+/// Internal handoff from the current CLI launcher to the supervisor child.
+///
+/// This is scrubbed from every daemon command and set only on a supervisor
+/// spawn. It names the exact startup-lock generation the child must adopt.
+pub const SUPERVISOR_STARTUP_GENERATION_ENV: &str = "KIN_SUPERVISOR_STARTUP_GENERATION";
 
 /// Path to the per-user supervisor pid file (under the Kin registry directory).
 pub fn supervisor_pid_path() -> PathBuf {
@@ -2116,12 +2123,12 @@ pub fn supervisor_port_path() -> PathBuf {
 /// supervisor stop so a later `status` never reports the dead endpoint as stale.
 pub fn remove_stale_supervisor_files() {
     let dir = supervisor_dir();
-    let startup_authority = match try_acquire_supervisor_startup_lock_in_dir(&dir) {
+    let startup_authority = match try_acquire_supervisor_startup_lock_for_cleanup(&dir) {
         Ok(authority) => authority,
         Err(error) if error.kind() == std::io::ErrorKind::AlreadyExists => {
             warn!(
                 dir = %dir.display(),
-                "preserving supervisor endpoint because legacy startup authority is held"
+                "preserving supervisor endpoint because cross-version startup authority is held"
             );
             return;
         }
@@ -2129,7 +2136,7 @@ pub fn remove_stale_supervisor_files() {
             warn!(
                 dir = %dir.display(),
                 %error,
-                "preserving supervisor endpoint because legacy startup authority is unavailable"
+                "preserving supervisor endpoint because cross-version startup authority is unavailable"
             );
             return;
         }
@@ -2154,6 +2161,32 @@ pub fn remove_stale_supervisor_files() {
         None => {
             let _ = retire_supervisor_endpoint_if_unchanged(&dir, recorded, &startup_authority);
         }
+    }
+}
+
+fn try_acquire_supervisor_startup_lock_for_cleanup(
+    dir: &Path,
+) -> std::io::Result<SupervisorStartupLock> {
+    match try_acquire_supervisor_startup_lock_in_dir(dir) {
+        Ok(authority) => Ok(authority),
+        Err(error) if error.kind() == std::io::ErrorKind::AlreadyExists => {
+            let path = dir.join(SUPERVISOR_STARTUP_FILE);
+            let (snapshot, record) = supervisor_startup_record_at(&path)?;
+            let Some(record) = record else {
+                return Err(error);
+            };
+            if !process_liveness(record.pid).authorizes_cleanup() {
+                return Err(error);
+            }
+            if !remove_supervisor_startup_lock_if_unchanged(&path, &snapshot)? {
+                return Err(std::io::Error::new(
+                    std::io::ErrorKind::AlreadyExists,
+                    "supervisor startup authority changed during dead-owner cleanup",
+                ));
+            }
+            try_acquire_supervisor_startup_lock_in_dir(dir)
+        }
+        Err(error) => Err(error),
     }
 }
 
@@ -2859,26 +2892,200 @@ impl Drop for StartupLock {
     }
 }
 
-/// Proof that this process owns the cross-version supervisor startup
-/// authority for one state directory.
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct SupervisorStartupRecord {
+    pid: u32,
+    generation: Option<String>,
+}
+
+fn parse_supervisor_startup_record(content: &str) -> Option<SupervisorStartupRecord> {
+    let mut pid = None;
+    let mut generation = None;
+    for field in content.split_whitespace() {
+        if let Some(value) = field.strip_prefix("pid=") {
+            pid = value.parse::<u32>().ok();
+        } else if let Some(value) = field.strip_prefix("generation=") {
+            generation = (!value.is_empty()).then(|| value.to_string());
+        }
+    }
+    pid.map(|pid| SupervisorStartupRecord { pid, generation })
+}
+
+fn write_supervisor_startup_record(
+    file: &mut File,
+    pid: u32,
+    generation: &str,
+) -> std::io::Result<()> {
+    FileExt::lock_exclusive(file)?;
+    let result = (|| {
+        file.set_len(0)?;
+        file.seek(SeekFrom::Start(0))?;
+        writeln!(
+            file,
+            "pid={pid} generation={generation} heartbeat_at={:?}",
+            std::time::SystemTime::now()
+        )?;
+        file.flush()
+    })();
+    let unlock = FileExt::unlock(file);
+    result.and(unlock)
+}
+
+fn supervisor_startup_record_at(
+    path: &Path,
+) -> std::io::Result<(String, Option<SupervisorStartupRecord>)> {
+    let mut file = OpenOptions::new().read(true).write(true).open(path)?;
+    FileExt::lock_shared(&file)?;
+    let mut content = String::new();
+    let result = file.read_to_string(&mut content);
+    let unlock = FileExt::unlock(&file);
+    result.and(unlock)?;
+    let record = parse_supervisor_startup_record(&content);
+    Ok((content, record))
+}
+
+fn remove_supervisor_startup_lock_if_unchanged(
+    path: &Path,
+    expected: &str,
+) -> std::io::Result<bool> {
+    let current = match supervisor_startup_record_at(path) {
+        Ok((current, _)) => current,
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => return Ok(false),
+        Err(error) => return Err(error),
+    };
+    if current != expected {
+        return Ok(false);
+    }
+    match std::fs::remove_file(path) {
+        Ok(()) => Ok(true),
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => Ok(false),
+        Err(error) => Err(error),
+    }
+}
+
+fn remove_supervisor_startup_lock_generation(
+    path: &Path,
+    generation: &str,
+) -> std::io::Result<bool> {
+    let (content, record) = match supervisor_startup_record_at(path) {
+        Ok(record) => record,
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => return Ok(false),
+        Err(error) => return Err(error),
+    };
+    if record.and_then(|record| record.generation).as_deref() != Some(generation) {
+        return Ok(false);
+    }
+    remove_supervisor_startup_lock_if_unchanged(path, &content)
+}
+
+/// Generation-bound proof that one startup participant owns the cross-version
+/// supervisor launch authority for one state directory.
 ///
-/// Compatible pre-singleton CLIs use the same create-new lock path and keep it
-/// until their child publishes and passes health. Requiring this token for
-/// endpoint retirement therefore excludes both current publishers (through
-/// lifecycle/singleton locks) and supported legacy publishers (through this
-/// startup lock).
-struct SupervisorStartupLock {
+/// Compatible pre-singleton CLIs use the same create-new pathname. Current
+/// launchers add a generation and transfer that exact generation to the
+/// supervisor child, which keeps the marker present for its entire lifetime.
+/// Every destructive use re-reads the pathname, so an unlinked/replaced token
+/// immediately stops authorizing work and its eventual `Drop` cannot remove a
+/// successor generation.
+#[derive(Debug)]
+pub struct SupervisorStartupLock {
     dir: PathBuf,
-    lock: StartupLock,
+    path: PathBuf,
+    file: File,
+    generation: String,
+    remove_on_drop: bool,
 }
 
 impl SupervisorStartupLock {
     fn path(&self) -> &Path {
-        &self.lock.path
+        &self.path
+    }
+
+    /// Exact generation handed from a launcher to its supervisor child.
+    pub fn generation(&self) -> &str {
+        &self.generation
     }
 
     fn authorizes(&self, dir: &Path) -> bool {
-        self.dir == dir && self.lock.path == dir.join(SUPERVISOR_STARTUP_FILE)
+        if self.dir != dir || self.path != dir.join(SUPERVISOR_STARTUP_FILE) {
+            return false;
+        }
+        supervisor_startup_record_at(&self.path)
+            .ok()
+            .and_then(|(_, record)| record)
+            .and_then(|record| record.generation)
+            .as_deref()
+            == Some(self.generation.as_str())
+    }
+
+    /// Refresh the old-client-visible marker without changing its current
+    /// owner. Returns false if the pathname no longer names this generation.
+    pub fn heartbeat(&mut self) -> std::io::Result<bool> {
+        let Some(record) = supervisor_startup_record_at(&self.path)?.1 else {
+            return Ok(false);
+        };
+        if record.generation.as_deref() != Some(self.generation.as_str()) {
+            return Ok(false);
+        }
+        write_supervisor_startup_record(&mut self.file, record.pid, &self.generation)?;
+        Ok(self.authorizes(&self.dir))
+    }
+
+    /// Refresh this generation while assigning its liveness record to `pid`.
+    /// The launcher uses the spawned child's PID at final handoff; the child
+    /// then keeps stamping its own PID for its process lifetime.
+    pub fn heartbeat_for_pid(&mut self, pid: u32) -> std::io::Result<bool> {
+        if !self.authorizes(&self.dir) {
+            return Ok(false);
+        }
+        write_supervisor_startup_record(&mut self.file, pid, &self.generation)?;
+        Ok(self.authorizes(&self.dir))
+    }
+
+    /// Leave pathname cleanup to the supervisor child that adopted this same
+    /// generation. Used only after that child has answered health.
+    fn handoff_cleanup_to_supervisor(&mut self) {
+        self.remove_on_drop = false;
+    }
+
+    fn adopt_in_dir(dir: &Path, generation: &str) -> std::io::Result<Self> {
+        let path = dir.join(SUPERVISOR_STARTUP_FILE);
+        let record = supervisor_startup_record_at(&path)?.1.ok_or_else(|| {
+            std::io::Error::new(
+                std::io::ErrorKind::InvalidData,
+                "supervisor startup marker has no parseable owner",
+            )
+        })?;
+        if record.generation.as_deref() != Some(generation) {
+            return Err(std::io::Error::new(
+                std::io::ErrorKind::PermissionDenied,
+                "supervisor startup generation does not match the launcher handoff",
+            ));
+        }
+        let mut file = OpenOptions::new().read(true).write(true).open(&path)?;
+        write_supervisor_startup_record(&mut file, std::process::id(), generation)?;
+        let authority = Self {
+            dir: dir.to_path_buf(),
+            path,
+            file,
+            generation: generation.to_string(),
+            remove_on_drop: true,
+        };
+        if !authority.authorizes(dir) {
+            return Err(std::io::Error::new(
+                std::io::ErrorKind::PermissionDenied,
+                "supervisor startup generation changed during child handoff",
+            ));
+        }
+        Ok(authority)
+    }
+}
+
+impl Drop for SupervisorStartupLock {
+    fn drop(&mut self) {
+        if self.remove_on_drop {
+            let _ = remove_supervisor_startup_lock_generation(&self.path, &self.generation);
+        }
     }
 }
 
@@ -2930,48 +3137,99 @@ async fn acquire_startup_lock(kin_root: &Path) -> Result<StartupLock> {
     }
 }
 
-fn try_acquire_supervisor_startup_lock_in_dir(
+/// Create a fresh generation only when the shared startup pathname is absent.
+///
+/// Exposed for the supervisor runtime and cross-version executable tests; normal
+/// callers should use the bounded acquisition path.
+#[doc(hidden)]
+pub fn try_acquire_supervisor_startup_lock_in_dir(
     dir: &Path,
 ) -> std::io::Result<SupervisorStartupLock> {
     std::fs::create_dir_all(dir)?;
     let path = dir.join(SUPERVISOR_STARTUP_FILE);
+    let generation = Uuid::new_v4().to_string();
     let mut file = OpenOptions::new()
+        .read(true)
         .write(true)
         .create_new(true)
         .open(&path)?;
-    let _ = writeln!(
-        file,
-        "pid={} acquired_at={:?}",
-        std::process::id(),
-        std::time::SystemTime::now()
-    );
+    if let Err(error) = write_supervisor_startup_record(&mut file, std::process::id(), &generation)
+    {
+        let _ = std::fs::remove_file(&path);
+        return Err(error);
+    }
     Ok(SupervisorStartupLock {
         dir: dir.to_path_buf(),
-        lock: StartupLock { path, _file: file },
+        path,
+        file,
+        generation,
+        remove_on_drop: true,
     })
 }
 
 async fn acquire_supervisor_startup_lock() -> Result<SupervisorStartupLock> {
     let dir = supervisor_dir();
-    acquire_supervisor_startup_lock_in_dir(&dir).await
+    acquire_supervisor_startup_lock_in_dir_with_timeout(
+        &dir,
+        Duration::from_secs(startup_lock_timeout_secs()),
+    )
+    .await
 }
 
-async fn acquire_supervisor_startup_lock_in_dir(dir: &Path) -> Result<SupervisorStartupLock> {
+async fn acquire_supervisor_startup_lock_in_dir_with_timeout(
+    dir: &Path,
+    timeout: Duration,
+) -> Result<SupervisorStartupLock> {
     std::fs::create_dir_all(dir)
         .with_context(|| format!("create supervisor state directory {}", dir.display()))?;
     let path = dir.join(SUPERVISOR_STARTUP_FILE);
-    let timeout = Duration::from_secs(startup_lock_timeout_secs());
-    let stale_after = timeout.saturating_mul(2).max(Duration::from_secs(10));
     let deadline = Instant::now() + timeout;
+    let mut reported_unparseable_owner = false;
 
     loop {
         match try_acquire_supervisor_startup_lock_in_dir(dir) {
             Ok(authority) => return Ok(authority),
             Err(err) if err.kind() == std::io::ErrorKind::AlreadyExists => {
-                if startup_lock_is_stale(&path, stale_after) {
-                    warn!(path = %path.display(), "removing stale supervisor startup lock");
-                    let _ = std::fs::remove_file(&path);
-                    continue;
+                match supervisor_startup_record_at(&path) {
+                    Ok((snapshot, Some(record)))
+                        if process_liveness(record.pid).authorizes_cleanup() =>
+                    {
+                        match remove_supervisor_startup_lock_if_unchanged(&path, &snapshot) {
+                            Ok(true) => {
+                                warn!(
+                                    path = %path.display(),
+                                    pid = record.pid,
+                                    "reclaimed supervisor startup lock from a dead owner"
+                                );
+                                continue;
+                            }
+                            Ok(false) => continue,
+                            Err(error) => {
+                                return Err(error).with_context(|| {
+                                    format!(
+                                        "reclaim dead supervisor startup lock at {}",
+                                        path.display()
+                                    )
+                                });
+                            }
+                        }
+                    }
+                    Ok((_snapshot, Some(_record))) => {}
+                    Ok((_snapshot, None)) => {
+                        if !reported_unparseable_owner {
+                            warn!(
+                                path = %path.display(),
+                                "preserving supervisor startup lock with an unparseable owner"
+                            );
+                            reported_unparseable_owner = true;
+                        }
+                    }
+                    Err(error) if error.kind() == std::io::ErrorKind::NotFound => continue,
+                    Err(error) => {
+                        return Err(error).with_context(|| {
+                            format!("read supervisor startup lock at {}", path.display())
+                        });
+                    }
                 }
                 if Instant::now() >= deadline {
                     bail!(
@@ -2987,6 +3245,24 @@ async fn acquire_supervisor_startup_lock_in_dir(dir: &Path) -> Result<Supervisor
                 });
             }
         }
+    }
+}
+
+/// Adopt the launcher's exact startup generation inside the supervisor child.
+///
+/// A direct/manual supervisor launch may create a fresh generation only when
+/// no launcher owns the path. If a legacy launcher holds the marker but did not
+/// pass a generation, the current child fails closed instead of running without
+/// cross-version lifetime protection.
+#[doc(hidden)]
+pub fn acquire_supervisor_runtime_startup_lock(
+    dir: &Path,
+) -> std::io::Result<SupervisorStartupLock> {
+    match std::env::var(SUPERVISOR_STARTUP_GENERATION_ENV) {
+        Ok(generation) if !generation.trim().is_empty() => {
+            SupervisorStartupLock::adopt_in_dir(dir, generation.trim())
+        }
+        _ => try_acquire_supervisor_startup_lock_in_dir(dir),
     }
 }
 
@@ -3610,14 +3886,30 @@ fn open_supervisor_log() -> Result<File> {
         .with_context(|| format!("open supervisor log at {}", log_path.display()))
 }
 
-async fn wait_for_supervisor_ready(child: &mut Child, deadline: Instant) -> Result<String> {
+async fn wait_for_supervisor_ready(
+    child: &mut Child,
+    deadline: Instant,
+    startup_authority: &mut SupervisorStartupLock,
+) -> Result<String> {
     let timeout = deadline.saturating_duration_since(Instant::now());
     let client = daemon_health_client();
     let mut last_error = String::from("supervisor did not report its port");
+    let mut next_startup_heartbeat = Instant::now();
 
     while Instant::now() < deadline {
         if let Some(status) = child.try_wait().context("check supervisor child status")? {
             bail!("supervisor exited during startup with status {status}");
+        }
+        if Instant::now() >= next_startup_heartbeat {
+            if !startup_authority
+                .heartbeat()
+                .context("refresh supervisor startup authority during readiness")?
+            {
+                let _ = child.kill();
+                let _ = child.wait();
+                bail!("supervisor startup authority changed during readiness");
+            }
+            next_startup_heartbeat = Instant::now() + Duration::from_secs(1);
         }
 
         // The supervisor binds :0 and writes its real bound port to its port
@@ -3679,7 +3971,7 @@ pub async fn ensure_supervisor_running() -> Result<String> {
         }
     }
 
-    let startup_authority = acquire_supervisor_startup_lock().await?;
+    let mut startup_authority = acquire_supervisor_startup_lock().await?;
     let dir = supervisor_dir();
     match wait_for_existing_supervisor_in_dir(&dir, Some(&startup_authority)).await {
         ExistingSupervisor::Connected(base_url) => return Ok(base_url),
@@ -3703,6 +3995,10 @@ pub async fn ensure_supervisor_running() -> Result<String> {
     let mut cmd = std::process::Command::new(&daemon_bin);
     scrub_daemon_process_authority(&mut cmd);
     cmd.args(["--supervisor", "--port", "0"]);
+    cmd.env(
+        SUPERVISOR_STARTUP_GENERATION_ENV,
+        startup_authority.generation(),
+    );
     let log = open_supervisor_log()?;
     let stderr = log
         .try_clone()
@@ -3729,7 +4025,16 @@ pub async fn ensure_supervisor_running() -> Result<String> {
 
     let mut child = cmd.spawn().context("spawn kin supervisor")?;
     let deadline = Instant::now() + Duration::from_secs(daemon_ready_timeout_secs());
-    let base_url = wait_for_supervisor_ready(&mut child, deadline).await?;
+    let base_url = wait_for_supervisor_ready(&mut child, deadline, &mut startup_authority).await?;
+    if !startup_authority
+        .heartbeat_for_pid(child.id())
+        .context("transfer supervisor startup authority to the ready child")?
+    {
+        let _ = child.kill();
+        let _ = child.wait();
+        bail!("supervisor startup authority changed before lifetime handoff");
+    }
+    startup_authority.handoff_cleanup_to_supervisor();
     info!(supervisor = %base_url, "supervisor is up and ready");
     Ok(base_url)
 }
@@ -4685,6 +4990,127 @@ mod tests {
                  replacement: {verdict:?}"
             );
         }
+    }
+
+    #[tokio::test]
+    async fn supervisor_startup_authority_is_live_owner_and_generation_bound() {
+        let dir = tempfile::tempdir().unwrap();
+        let mut launcher_a = try_acquire_supervisor_startup_lock_in_dir(dir.path()).unwrap();
+        assert!(
+            startup_lock_is_stale(launcher_a.path(), Duration::ZERO),
+            "the marker must be old enough for the former time-only predicate"
+        );
+
+        let shortened_wait =
+            acquire_supervisor_startup_lock_in_dir_with_timeout(dir.path(), Duration::ZERO)
+                .await
+                .unwrap_err();
+        assert!(
+            shortened_wait
+                .to_string()
+                .contains("timed out waiting for supervisor startup lock"),
+            "launcher B must not time-steal launcher A while A's PID is live: {shortened_wait:#}"
+        );
+        assert!(launcher_a.authorizes(dir.path()));
+        assert!(launcher_a.heartbeat().unwrap());
+
+        // Model an external/legacy pathname replacement while A still has its
+        // original open file. A must immediately lose authority, and its later
+        // Drop must compare-preserve B's generation.
+        std::fs::remove_file(launcher_a.path()).unwrap();
+        let launcher_b = try_acquire_supervisor_startup_lock_in_dir(dir.path()).unwrap();
+        assert_ne!(launcher_a.generation(), launcher_b.generation());
+        assert!(!launcher_a.authorizes(dir.path()));
+        drop(launcher_a);
+        assert!(
+            launcher_b.authorizes(dir.path()),
+            "launcher A's Drop must not unlink launcher B's generation"
+        );
+
+        let launcher_c_error =
+            acquire_supervisor_startup_lock_in_dir_with_timeout(dir.path(), Duration::ZERO)
+                .await
+                .unwrap_err();
+        assert!(
+            launcher_c_error
+                .to_string()
+                .contains("timed out waiting for supervisor startup lock"),
+            "launcher C must not enter while launcher B is live: {launcher_c_error:#}"
+        );
+        assert!(launcher_b.authorizes(dir.path()));
+
+        drop(launcher_b);
+        let launcher_c = try_acquire_supervisor_startup_lock_in_dir(dir.path()).unwrap();
+        assert!(launcher_c.authorizes(dir.path()));
+    }
+
+    #[test]
+    fn supervisor_startup_generation_transfers_without_a_cleanup_gap() {
+        let dir = tempfile::tempdir().unwrap();
+        let mut launcher = try_acquire_supervisor_startup_lock_in_dir(dir.path()).unwrap();
+        let generation = launcher.generation().to_string();
+        let child = SupervisorStartupLock::adopt_in_dir(dir.path(), &generation).unwrap();
+
+        launcher.handoff_cleanup_to_supervisor();
+        drop(launcher);
+        assert!(
+            child.authorizes(dir.path()),
+            "the launcher must leave the adopted generation present"
+        );
+
+        drop(child);
+        assert!(
+            !dir.path().join(SUPERVISOR_STARTUP_FILE).exists(),
+            "the adopted child owns compare-removal at process exit"
+        );
+    }
+
+    #[tokio::test]
+    async fn live_legacy_startup_owner_is_not_reclaimed_by_elapsed_time() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join(SUPERVISOR_STARTUP_FILE);
+        let legacy_record = format!(
+            "pid={} acquired_at={:?}\n",
+            std::process::id(),
+            std::time::SystemTime::now()
+        );
+        std::fs::write(&path, &legacy_record).unwrap();
+        assert!(startup_lock_is_stale(&path, Duration::ZERO));
+
+        let error = acquire_supervisor_startup_lock_in_dir_with_timeout(dir.path(), Duration::ZERO)
+            .await
+            .unwrap_err();
+        assert!(error
+            .to_string()
+            .contains("timed out waiting for supervisor startup lock"));
+        assert_eq!(
+            std::fs::read_to_string(&path).unwrap(),
+            legacy_record,
+            "a parseable live legacy owner is liveness authority, not an mtime lease"
+        );
+    }
+
+    #[tokio::test]
+    async fn dead_legacy_startup_owner_is_reclaimed_without_time_authority() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join(SUPERVISOR_STARTUP_FILE);
+        std::fs::write(
+            &path,
+            "pid=999999999 acquired_at=SystemTime { tv_sec: 0, tv_nsec: 0 }\n",
+        )
+        .unwrap();
+
+        let authority =
+            acquire_supervisor_startup_lock_in_dir_with_timeout(dir.path(), Duration::ZERO)
+                .await
+                .unwrap();
+        assert!(authority.authorizes(dir.path()));
+        assert!(
+            std::fs::read_to_string(path)
+                .unwrap()
+                .contains(authority.generation()),
+            "dead legacy recovery must mint a fresh generation"
+        );
     }
 
     #[test]

--- a/crates/kin-cli/src/daemon_client.rs
+++ b/crates/kin-cli/src/daemon_client.rs
@@ -74,6 +74,11 @@ pub struct HealthResponse {
     pub reconciliation_status: String,
     #[serde(default)]
     pub repo_id: Option<String>,
+    /// Exact local workspace authority served by the daemon. Two clones share
+    /// `repo_id`, so repository identity alone can never authorize routing a
+    /// local command to an endpoint.
+    #[serde(default)]
+    pub workspace_id: Option<String>,
     #[serde(default)]
     pub repo_root: Option<String>,
     #[serde(default)]
@@ -1613,11 +1618,35 @@ pub fn daemon_required() -> bool {
 pub fn is_process_alive(pid: u32) -> bool {
     #[cfg(unix)]
     {
-        unsafe { libc::kill(pid as libc::pid_t, 0) == 0 }
+        let Ok(pid) = libc::pid_t::try_from(pid) else {
+            return false;
+        };
+        if unsafe { libc::kill(pid, 0) } == 0 {
+            return true;
+        }
+        std::io::Error::last_os_error().raw_os_error() == Some(libc::EPERM)
     }
-    #[cfg(not(unix))]
+    #[cfg(windows)]
+    {
+        use windows_sys::Win32::Foundation::{CloseHandle, STILL_ACTIVE};
+        use windows_sys::Win32::System::Threading::{
+            GetExitCodeProcess, OpenProcess, PROCESS_QUERY_LIMITED_INFORMATION,
+        };
+
+        let process = unsafe { OpenProcess(PROCESS_QUERY_LIMITED_INFORMATION, 0, pid) };
+        if process.is_null() {
+            return false;
+        }
+        let mut code = 0;
+        let queried = unsafe { GetExitCodeProcess(process, &mut code) } != 0;
+        let _ = unsafe { CloseHandle(process) };
+        queried && code == STILL_ACTIVE as u32
+    }
+    #[cfg(not(any(unix, windows)))]
     {
         let _ = pid;
+        // Unknown targets have no reliable process primitive here. Preserve
+        // ownership rather than guessing "dead" and deleting live authority.
         true
     }
 }
@@ -2068,17 +2097,34 @@ fn strict_canonical_path(path: &Path) -> Option<String> {
     path.canonicalize().ok().map(|p| p.display().to_string())
 }
 
-/// The repository identity recorded in this repo's own manifest.
+/// Repository and workspace identity recorded in this repo's own manifest.
 ///
 /// Startup configuration IO at an explicit boundary, not a semantic answer path:
-/// it reads the local manifest to learn which repository the caller is standing
-/// in, so a daemon's self-reported identity can be compared against something
-/// stronger than a rendered path.
-fn local_repo_identity(kin_root: &Path) -> Option<String> {
+/// it reads the local manifest to learn which exact workspace the caller is
+/// standing in, so a daemon's self-reported identity can be compared against
+/// something stronger than a rendered path.
+struct LocalWorkspaceIdentity {
+    repo_id: String,
+    workspace_id: Option<String>,
+}
+
+fn local_workspace_identity(kin_root: &Path) -> Option<LocalWorkspaceIdentity> {
     kin_core::manifest::KinManifest::load(&kin_root.join("manifest.json"))
         .ok()
-        .map(|manifest| manifest.repo_id)
-        .filter(|repo_id| !repo_id.trim().is_empty())
+        .and_then(|manifest| {
+            let repo_id = manifest.repo_id.trim();
+            if repo_id.is_empty() {
+                return None;
+            }
+            let workspace_id = match manifest.workspace_id.trim() {
+                "" => None,
+                workspace_id => Some(workspace_id.to_string()),
+            };
+            Some(LocalWorkspaceIdentity {
+                repo_id: repo_id.to_string(),
+                workspace_id,
+            })
+        })
 }
 
 /// What a `/health` body establishes about whether this daemon serves this repo.
@@ -2095,13 +2141,14 @@ enum RepoIdentity {
 
 /// Decide whether a health body identifies this repo, with no silent fallback.
 ///
-/// Identity is compared strongest-first. The manifest repository id is exact
-/// (the daemon asserts its own `repo_id` equals its manifest's at open time), so
-/// when both sides carry one the comparison is conclusive in either direction.
-/// Only when an id is unavailable does this fall back to paths, and then both
-/// sides must resolve before a difference counts as evidence — `/tmp` against
+/// Identity is compared strongest-first. A repository id establishes shared
+/// repository truth, but not local authority: two clones deliberately share
+/// `repo_id` and carry distinct `workspace_id` values. When both sides carry
+/// workspace identity, that exact pair is conclusive. Older daemons that do not
+/// report a workspace id fall back to canonical paths, and both sides must
+/// resolve before a difference counts as evidence — `/tmp` against
 /// `/private/tmp` on macOS, or a symlinked worktree, is an aliasing artifact and
-/// not a different repository.
+/// not a different workspace.
 fn classify_health_repo(
     health: &HealthResponse,
     kin_root: &Path,
@@ -2111,17 +2158,49 @@ fn classify_health_repo(
         return RepoIdentity::Rejected(format!("daemon health status is {}", health.status));
     }
 
-    let reported_id = health
+    let reported_repo_id = health
         .repo_id
         .as_deref()
         .map(str::trim)
         .filter(|id| !id.is_empty());
-    if let (Some(reported), Some(expected)) = (reported_id, local_repo_identity(kin_root)) {
-        return if reported == expected {
+    let reported_workspace_id = health
+        .workspace_id
+        .as_deref()
+        .map(str::trim)
+        .filter(|id| !id.is_empty());
+    let local_identity = local_workspace_identity(kin_root);
+
+    if let (Some(reported_repo), Some(expected)) = (reported_repo_id, local_identity.as_ref()) {
+        if reported_repo != expected.repo_id {
+            return RepoIdentity::Rejected(format!(
+                "daemon repo mismatch: endpoint serves repository {reported_repo}, expected {}",
+                expected.repo_id
+            ));
+        }
+        if let (Some(reported_workspace), Some(expected_workspace)) =
+            (reported_workspace_id, expected.workspace_id.as_deref())
+        {
+            return if reported_workspace == expected_workspace {
+                RepoIdentity::Matches
+            } else {
+                RepoIdentity::Rejected(format!(
+                    "daemon workspace mismatch: endpoint serves workspace {reported_workspace}, \
+                     expected {expected_workspace}"
+                ))
+            };
+        }
+    } else if let (Some(reported_workspace), Some(expected_workspace)) = (
+        reported_workspace_id,
+        local_identity
+            .as_ref()
+            .and_then(|identity| identity.workspace_id.as_deref()),
+    ) {
+        return if reported_workspace == expected_workspace {
             RepoIdentity::Matches
         } else {
             RepoIdentity::Rejected(format!(
-                "daemon repo mismatch: endpoint serves repository {reported}, expected {expected}"
+                "daemon workspace mismatch: endpoint serves workspace {reported_workspace}, \
+                 expected {expected_workspace}"
             ))
         };
     }
@@ -2349,6 +2428,13 @@ async fn probe_daemon_endpoint(
 
         let probe_error = match client.get(format!("{base_url}/readiness")).send().await {
             Ok(resp) if resp.status().is_success() => {
+                // Successful readiness carries the warming signal too. Parse it
+                // before the health probe: a daemon can answer readiness and
+                // then be too busy to complete the second request, and that is
+                // exactly when retaining "warming" makes the diagnostic honest.
+                if let Ok(readiness) = resp.json::<ReadinessResponse>().await {
+                    warming = readiness.warming;
+                }
                 match probe_health_for_repo(&client, &base_url, kin_root, working_dir).await {
                     HealthProbe::Matches => return EndpointVerdict::Serving(base_url),
                     // The daemon answered and identified itself as something
@@ -3489,7 +3575,9 @@ mod tests {
     ///
     /// Stands in for a live daemon too busy to complete a second request.
     /// Returns its port and the task serving it.
-    async fn daemon_answering_readiness_but_not_health() -> (u16, tokio::task::JoinHandle<()>) {
+    async fn daemon_answering_readiness_but_not_health(
+        warming: bool,
+    ) -> (u16, tokio::task::JoinHandle<()>) {
         use tokio::io::{AsyncReadExt, AsyncWriteExt};
 
         let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
@@ -3505,7 +3593,7 @@ mod tests {
                 };
                 let request = String::from_utf8_lossy(&buf[..read]).to_string();
                 if request.contains("/readiness") {
-                    let body = r#"{"ready":true,"warming":false}"#;
+                    let body = format!(r#"{{"ready":true,"warming":{warming}}}"#);
                     let _ = socket
                         .write_all(
                             format!(
@@ -3531,7 +3619,7 @@ mod tests {
         // treating it as proof would clobber the live daemon all over again.
         let dir = tempfile::tempdir().unwrap();
         let root = dir.path();
-        let (port, server) = daemon_answering_readiness_but_not_health().await;
+        let (port, server) = daemon_answering_readiness_but_not_health(false).await;
         write_endpoint_files(root, std::process::id(), port);
 
         let verdict = wait_for_existing_daemon_within(
@@ -3548,6 +3636,35 @@ mod tests {
         assert!(
             root.join("daemon.pid").exists() && root.join("daemon.port").exists(),
             "endpoint files must survive an unanswered health probe"
+        );
+        server.abort();
+    }
+
+    #[tokio::test]
+    async fn a_successful_readiness_body_retains_warming_when_health_drops() {
+        let dir = tempfile::tempdir().unwrap();
+        let root = dir.path();
+        let (port, server) = daemon_answering_readiness_but_not_health(true).await;
+        write_endpoint_files(root, std::process::id(), port);
+
+        let ExistingDaemon::LiveNotReady(message) = wait_for_existing_daemon_within(
+            root,
+            Duration::from_millis(50),
+            Duration::from_millis(400),
+        )
+        .await
+        else {
+            panic!("a live warming daemon must remain LiveNotReady when health drops");
+        };
+
+        assert!(
+            message.contains("warming"),
+            "the successful readiness body's warming signal must survive a failed health probe: \
+             {message}"
+        );
+        assert!(
+            root.join("daemon.pid").exists() && root.join("daemon.port").exists(),
+            "a warming daemon's endpoint files must be preserved"
         );
         server.abort();
     }
@@ -3656,7 +3773,11 @@ mod tests {
     // comparison is not that: two spellings of one directory are an aliasing
     // artifact, and a path that will not resolve is no information at all.
 
-    fn health_naming(repo_id: Option<&str>, repo_root: Option<String>) -> HealthResponse {
+    fn health_naming(
+        repo_id: Option<&str>,
+        workspace_id: Option<&str>,
+        repo_root: Option<String>,
+    ) -> HealthResponse {
         HealthResponse {
             status: "ok".to_string(),
             version: "test".to_string(),
@@ -3665,6 +3786,7 @@ mod tests {
             graph_loaded: false,
             reconciliation_status: "idle".to_string(),
             repo_id: repo_id.map(str::to_string),
+            workspace_id: workspace_id.map(str::to_string),
             repo_root,
             pid: Some(std::process::id()),
             behavior_env: Default::default(),
@@ -3687,7 +3809,7 @@ mod tests {
         std::os::unix::fs::symlink(&real, &alias).unwrap();
 
         // The daemon reports the resolved path; the client holds the alias.
-        let health = health_naming(None, Some(strict_canonical_path(&real).unwrap()));
+        let health = health_naming(None, None, Some(strict_canonical_path(&real).unwrap()));
         assert_eq!(
             classify_health_repo(&health, &alias.join(".kin"), &alias),
             RepoIdentity::Matches,
@@ -3700,7 +3822,7 @@ mod tests {
         // Fail-open was the old behavior: an absent repo_root skipped the check
         // entirely and any daemon passed identity validation.
         let dir = tempfile::tempdir().unwrap();
-        let health = health_naming(None, None);
+        let health = health_naming(None, None, None);
         assert!(
             matches!(
                 classify_health_repo(&health, &dir.path().join(".kin"), dir.path()),
@@ -3713,7 +3835,7 @@ mod tests {
     #[test]
     fn an_unresolvable_repo_root_is_indeterminate_not_a_mismatch() {
         let dir = tempfile::tempdir().unwrap();
-        let health = health_naming(None, Some("/nonexistent/kin/repo/path".to_string()));
+        let health = health_naming(None, None, Some("/nonexistent/kin/repo/path".to_string()));
         assert!(
             matches!(
                 classify_health_repo(&health, &dir.path().join(".kin"), dir.path()),
@@ -3729,7 +3851,11 @@ mod tests {
         // genuinely name different directories.
         let mine = tempfile::tempdir().unwrap();
         let theirs = tempfile::tempdir().unwrap();
-        let health = health_naming(None, Some(strict_canonical_path(theirs.path()).unwrap()));
+        let health = health_naming(
+            None,
+            None,
+            Some(strict_canonical_path(theirs.path()).unwrap()),
+        );
         assert!(
             matches!(
                 classify_health_repo(&health, &mine.path().join(".kin"), mine.path()),
@@ -3740,9 +3866,10 @@ mod tests {
     }
 
     #[test]
-    fn a_manifest_repository_id_decides_before_any_path_does() {
-        // The exact identity both sides already carry. When it is available it
-        // is conclusive in both directions and no path spelling is consulted.
+    fn workspace_identity_decides_local_authority_within_a_repository() {
+        // Repository identity proves shared history, not local endpoint
+        // authority. Two clones carry the same repo id and different workspace
+        // ids, so only the pair can decide before paths.
         let dir = tempfile::tempdir().unwrap();
         let kin_root = dir.path().join(".kin");
         std::fs::create_dir_all(&kin_root).unwrap();
@@ -3758,9 +3885,11 @@ mod tests {
         )
         .unwrap();
 
-        // Same id, and a repo_root that would have failed a path comparison.
+        // Same repo and workspace, even though repo_root would fail a path
+        // comparison.
         let same = health_naming(
             Some("11111111-1111-4111-8111-111111111111"),
+            Some("22222222-2222-4222-8222-222222222222"),
             Some("/some/other/spelling".to_string()),
         );
         assert_eq!(
@@ -3768,21 +3897,49 @@ mod tests {
             RepoIdentity::Matches
         );
 
-        // Different id, and a repo_root that would have passed one.
-        let other = health_naming(
+        // Same repository but a different workspace must be rejected even
+        // when the path would otherwise pass.
+        let other_workspace = health_naming(
+            Some("11111111-1111-4111-8111-111111111111"),
             Some("33333333-3333-4333-8333-333333333333"),
             Some(strict_canonical_path(dir.path()).unwrap()),
         );
         assert!(matches!(
-            classify_health_repo(&other, &kin_root, dir.path()),
-            RepoIdentity::Rejected(_)
+            classify_health_repo(&other_workspace, &kin_root, dir.path()),
+            RepoIdentity::Rejected(ref reason) if reason.contains("workspace mismatch")
+        ));
+
+        // Different repository remains conclusive even if workspace and path
+        // are made to look local.
+        let other_repo = health_naming(
+            Some("33333333-3333-4333-8333-333333333333"),
+            Some("22222222-2222-4222-8222-222222222222"),
+            Some(strict_canonical_path(dir.path()).unwrap()),
+        );
+        assert!(matches!(
+            classify_health_repo(&other_repo, &kin_root, dir.path()),
+            RepoIdentity::Rejected(ref reason) if reason.contains("repo mismatch")
+        ));
+
+        // An old daemon with no workspace id gets only the legacy path
+        // fallback. Matching repo ids do not bypass a proven path mismatch.
+        let other_dir = tempfile::tempdir().unwrap();
+        let old_daemon = health_naming(
+            Some("11111111-1111-4111-8111-111111111111"),
+            None,
+            Some(strict_canonical_path(other_dir.path()).unwrap()),
+        );
+        assert!(matches!(
+            classify_health_repo(&old_daemon, &kin_root, dir.path()),
+            RepoIdentity::Rejected(ref reason) if reason.contains("repo mismatch")
         ));
     }
 
     #[test]
     fn a_non_serving_status_is_still_a_real_answer() {
         let dir = tempfile::tempdir().unwrap();
-        let mut health = health_naming(None, Some(strict_canonical_path(dir.path()).unwrap()));
+        let mut health =
+            health_naming(None, None, Some(strict_canonical_path(dir.path()).unwrap()));
         health.status = "starting".to_string();
         assert!(matches!(
             classify_health_repo(&health, &dir.path().join(".kin"), dir.path()),
@@ -3832,6 +3989,23 @@ mod tests {
     }
 
     #[test]
+    fn process_liveness_recognizes_the_current_process() {
+        assert!(
+            is_process_alive(std::process::id()),
+            "the current process must be observable as alive"
+        );
+    }
+
+    #[cfg(windows)]
+    #[test]
+    fn windows_process_liveness_rejects_a_missing_process() {
+        assert!(
+            !is_process_alive(u32::MAX),
+            "an unopenable Windows process id must not wedge daemon ownership forever"
+        );
+    }
+
+    #[test]
     fn daemon_is_up_returns_listening_port() {
         let dir = tempfile::tempdir().unwrap();
         let listener = std::net::TcpListener::bind("127.0.0.1:0").unwrap();
@@ -3869,6 +4043,7 @@ mod tests {
             graph_loaded: false,
             reconciliation_status: "idle".to_string(),
             repo_id: Some("wrong".to_string()),
+            workspace_id: None,
             repo_root: Some(canonical_path_string(other.path())),
             pid: Some(std::process::id()),
             behavior_env: Default::default(),
@@ -3888,6 +4063,7 @@ mod tests {
             graph_loaded: false,
             reconciliation_status: "idle".to_string(),
             repo_id: Some("repo".to_string()),
+            workspace_id: None,
             repo_root: Some(canonical_path_string(repo_root)),
             pid: Some(std::process::id()),
             behavior_env: Default::default(),

--- a/crates/kin-cli/src/daemon_client.rs
+++ b/crates/kin-cli/src/daemon_client.rs
@@ -1654,6 +1654,52 @@ pub fn remove_stale_daemon_files(kin_root: &Path) {
     let _ = std::fs::remove_file(repo_daemon_port_path(kin_root));
 }
 
+/// Remove endpoint files only while they still name the exact endpoint a verdict
+/// was formed about.
+///
+/// Every judgement about a daemon is made from a `(pid, port)` read at some
+/// earlier instant, and the daemon that owns this repo can change between that
+/// read and the delete: the recorded owner exits, a successor takes the flock
+/// and republishes its own pid and port. Deleting unconditionally then acts on a
+/// true statement about the old process by destroying the new one's files —
+/// re-entering the exact failure this path exists to prevent, through the
+/// evidence door rather than the timeout door. The wider the probe window, the
+/// likelier that is, and waiting out a warm-up makes the window long by design.
+///
+/// This is the client-side twin of
+/// `kin_daemon::lifecycle::remove_daemon_files_if_current_process`, which solves
+/// the same race from the daemon's side.
+///
+/// `judged_port` is `None` when the verdict was reached before a port was ever
+/// published, which is the one case where the port file is legitimately absent.
+///
+/// Returns whether the files were removed.
+fn remove_daemon_files_if_unchanged(
+    kin_root: &Path,
+    judged_pid: u32,
+    judged_port: Option<u16>,
+) -> bool {
+    let current_pid = read_pid_file(kin_root);
+    let current_port = read_port_file(kin_root);
+    let same_owner = current_pid == Some(judged_pid);
+    // An unchanged pid that republished its port is still a live daemon whose
+    // endpoint must survive, so a known port has to match too.
+    let same_endpoint = judged_port.is_none_or(|port| current_port == Some(port));
+    if !(same_owner && same_endpoint) {
+        warn!(
+            judged_pid,
+            ?judged_port,
+            ?current_pid,
+            ?current_port,
+            "endpoint files changed while this daemon was being judged; \
+             leaving the successor's endpoint intact"
+        );
+        return false;
+    }
+    remove_stale_daemon_files(kin_root);
+    true
+}
+
 fn supervisor_dir() -> PathBuf {
     kin_core::registry::registry_path()
         .parent()
@@ -1714,7 +1760,11 @@ pub fn supervisor_recorded_endpoint() -> (Option<u32>, Option<u16>) {
 fn live_daemon_endpoint(kin_root: &Path) -> Option<LiveDaemonEndpoint> {
     let pid = read_pid_file(kin_root)?;
     if !is_process_alive(pid) {
-        remove_stale_daemon_files(kin_root);
+        // Compare-and-delete even here, where the window is only as wide as this
+        // function: a successor that republished between the read and the
+        // liveness check would otherwise lose its endpoint to a true statement
+        // about its predecessor.
+        remove_daemon_files_if_unchanged(kin_root, pid, read_port_file(kin_root));
         return None;
     }
     let port = read_port_file(kin_root)?;
@@ -2006,6 +2056,105 @@ fn canonical_path_string(path: &Path) -> String {
         .to_string()
 }
 
+/// Canonical form of a path, or `None` when it cannot be resolved.
+///
+/// Deliberately not [`canonical_path_string`], which falls back to the
+/// unresolved path. That fallback is fine for a log line and wrong for a
+/// comparison: an unresolved path compared against a correctly-resolved peer
+/// differs for a reason that has nothing to do with which repo either side is
+/// serving. Where the answer drives a destructive action, a failure to resolve
+/// must read as "no evidence", never as "different".
+fn strict_canonical_path(path: &Path) -> Option<String> {
+    path.canonicalize().ok().map(|p| p.display().to_string())
+}
+
+/// The repository identity recorded in this repo's own manifest.
+///
+/// Startup configuration IO at an explicit boundary, not a semantic answer path:
+/// it reads the local manifest to learn which repository the caller is standing
+/// in, so a daemon's self-reported identity can be compared against something
+/// stronger than a rendered path.
+fn local_repo_identity(kin_root: &Path) -> Option<String> {
+    kin_core::manifest::KinManifest::load(&kin_root.join("manifest.json"))
+        .ok()
+        .map(|manifest| manifest.repo_id)
+        .filter(|repo_id| !repo_id.trim().is_empty())
+}
+
+/// What a `/health` body establishes about whether this daemon serves this repo.
+#[derive(Debug, PartialEq, Eq)]
+enum RepoIdentity {
+    /// Proven the same repository.
+    Matches,
+    /// Proven a different repository, or a status that is not serving at all.
+    Rejected(String),
+    /// Nothing conclusive: the daemon named no identity this client can compare,
+    /// or a path would not resolve on one side.
+    Indeterminate(String),
+}
+
+/// Decide whether a health body identifies this repo, with no silent fallback.
+///
+/// Identity is compared strongest-first. The manifest repository id is exact
+/// (the daemon asserts its own `repo_id` equals its manifest's at open time), so
+/// when both sides carry one the comparison is conclusive in either direction.
+/// Only when an id is unavailable does this fall back to paths, and then both
+/// sides must resolve before a difference counts as evidence — `/tmp` against
+/// `/private/tmp` on macOS, or a symlinked worktree, is an aliasing artifact and
+/// not a different repository.
+fn classify_health_repo(
+    health: &HealthResponse,
+    kin_root: &Path,
+    working_dir: &Path,
+) -> RepoIdentity {
+    if !health_status_is_serving(&health.status) {
+        return RepoIdentity::Rejected(format!("daemon health status is {}", health.status));
+    }
+
+    let reported_id = health
+        .repo_id
+        .as_deref()
+        .map(str::trim)
+        .filter(|id| !id.is_empty());
+    if let (Some(reported), Some(expected)) = (reported_id, local_repo_identity(kin_root)) {
+        return if reported == expected {
+            RepoIdentity::Matches
+        } else {
+            RepoIdentity::Rejected(format!(
+                "daemon repo mismatch: endpoint serves repository {reported}, expected {expected}"
+            ))
+        };
+    }
+
+    let Some(reported_root) = health.repo_root.as_deref() else {
+        // A daemon that names neither an id nor a root has told us nothing. It
+        // is not proof of a match, which would let an unrelated daemon pass, and
+        // not proof of a mismatch, which would destroy a live endpoint.
+        return RepoIdentity::Indeterminate(
+            "daemon reported neither a repository id nor a repo root".to_string(),
+        );
+    };
+    let Some(expected_root) = strict_canonical_path(working_dir) else {
+        return RepoIdentity::Indeterminate(format!(
+            "cannot resolve {} to compare against the daemon's repo root",
+            working_dir.display()
+        ));
+    };
+    if reported_root == expected_root {
+        return RepoIdentity::Matches;
+    }
+    match strict_canonical_path(Path::new(reported_root)) {
+        Some(resolved) if resolved == expected_root => RepoIdentity::Matches,
+        Some(resolved) => RepoIdentity::Rejected(format!(
+            "daemon repo mismatch: endpoint is for {resolved}, expected {expected_root}"
+        )),
+        None => RepoIdentity::Indeterminate(format!(
+            "daemon reported repo root {reported_root}, which does not resolve; \
+             cannot establish whether it is this repository"
+        )),
+    }
+}
+
 /// Whether a daemon `/health` status string means the daemon is alive and
 /// serving the graph. The daemon reports `"attention"` (not `"ok"`) when it is
 /// up and serving but degraded — a withheld mass-deletion wipe or a permanently
@@ -2018,19 +2167,19 @@ fn health_status_is_serving(status: &str) -> bool {
     matches!(status, "ok" | "attention")
 }
 
+/// Whether this daemon may be used for this repo, for callers that only need a
+/// yes/no and treat every no the same way.
+///
+/// Used by the fresh-spawn path, where an inconclusive identity is still a
+/// reason to keep waiting on a daemon we started ourselves and expect to
+/// identify itself. Callers whose "no" branch destroys state must use
+/// [`classify_health_repo`] instead and distinguish proven-different from
+/// nothing-established.
 pub(crate) fn validate_health_repo(health: &HealthResponse, working_dir: &Path) -> Result<()> {
-    if !health_status_is_serving(&health.status) {
-        bail!("daemon health status is {}", health.status);
-    }
-    if let Some(repo_root) = health.repo_root.as_deref() {
-        let expected = canonical_path_string(working_dir);
-        if repo_root != expected {
-            bail!(
-                "daemon repo mismatch: endpoint is for {}, expected {}",
-                repo_root,
-                expected
-            );
-        }
+    let kin_root = working_dir.join(".kin");
+    match classify_health_repo(health, &kin_root, working_dir) {
+        RepoIdentity::Matches => {}
+        RepoIdentity::Rejected(reason) | RepoIdentity::Indeterminate(reason) => bail!(reason),
     }
     if health.status == "attention" {
         warn!(
@@ -2200,7 +2349,7 @@ async fn probe_daemon_endpoint(
 
         let probe_error = match client.get(format!("{base_url}/readiness")).send().await {
             Ok(resp) if resp.status().is_success() => {
-                match probe_health_for_repo(&client, &base_url, working_dir).await {
+                match probe_health_for_repo(&client, &base_url, kin_root, working_dir).await {
                     HealthProbe::Matches => return EndpointVerdict::Serving(base_url),
                     // The daemon answered and identified itself as something
                     // else. That is real evidence the record is stale, not a
@@ -2262,6 +2411,7 @@ enum HealthProbe {
 async fn probe_health_for_repo(
     client: &reqwest::Client,
     base_url: &str,
+    kin_root: &Path,
     working_dir: &Path,
 ) -> HealthProbe {
     let answered = async {
@@ -2280,9 +2430,13 @@ async fn probe_health_for_repo(
     .await;
 
     match answered {
-        Ok(health) => match validate_health_repo(&health, working_dir) {
-            Ok(()) => HealthProbe::Matches,
-            Err(reason) => HealthProbe::Rejected(reason.to_string()),
+        Ok(health) => match classify_health_repo(&health, kin_root, working_dir) {
+            RepoIdentity::Matches => HealthProbe::Matches,
+            RepoIdentity::Rejected(reason) => HealthProbe::Rejected(reason),
+            // The daemon answered but did not identify itself in terms this
+            // client can compare. That is silence about identity, and silence
+            // must not authorize deleting its endpoint.
+            RepoIdentity::Indeterminate(detail) => HealthProbe::Unanswered(detail),
         },
         Err(error) => HealthProbe::Unanswered(error.to_string()),
     }
@@ -2435,7 +2589,10 @@ async fn wait_for_existing_daemon_within(
                 error = %reason,
                 "daemon endpoint proved invalid; clearing stale endpoint files"
             );
-            remove_stale_daemon_files(kin_root);
+            // The verdict is true about the endpoint that was probed, which may
+            // no longer be the endpoint on disk — the probe deliberately runs
+            // long enough for a successor to take over.
+            remove_daemon_files_if_unchanged(kin_root, existing.pid, Some(existing.port));
             ExistingDaemon::None
         }
         EndpointVerdict::LiveNotReady {
@@ -3247,7 +3404,7 @@ mod tests {
         );
     }
 
-    // ── FIR-1583: a busy daemon must never be treated as a dead one ───────
+    // ── A busy daemon must never be treated as a dead one ─────────────────
     //
     // The deadlock chain started here. A daemon that did not answer readiness
     // inside a short fixed budget had its `daemon.pid` and `daemon.port`
@@ -3395,6 +3552,80 @@ mod tests {
         server.abort();
     }
 
+    // ── A verdict is about an endpoint, not about a path ──────────────────
+    //
+    // Every judgement is formed from a (pid, port) read at some earlier instant,
+    // and the owner of the repo can change in between: the recorded daemon
+    // exits, a successor takes the flock and republishes. Acting on the old
+    // verdict then destroys the new daemon's files — the same failure, entered
+    // through the evidence door instead of the timeout door. Waiting out a
+    // warm-up makes that window long on purpose, so the delete has to re-check.
+
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn a_successor_endpoint_survives_a_verdict_about_its_predecessor() {
+        let dir = tempfile::tempdir().unwrap();
+        let root = dir.path().to_path_buf();
+
+        // A real process, so "the recorded owner is gone" is established the way
+        // production establishes it rather than mocked into place.
+        let mut predecessor = Command::new("sleep")
+            .arg("30")
+            .spawn()
+            .expect("spawn predecessor process");
+        write_endpoint_files(&root, predecessor.id(), closed_loopback_port());
+
+        let successor_port = closed_loopback_port();
+        let successor_root = root.clone();
+        let handover = tokio::spawn(async move {
+            tokio::time::sleep(Duration::from_millis(300)).await;
+            // The successor publishes its endpoint first...
+            write_endpoint_files(&successor_root, std::process::id(), successor_port);
+            // ...and only then does the predecessor actually go away. Reap it:
+            // a zombie still answers kill(pid, 0) and would read as alive.
+            let _ = predecessor.kill();
+            let _ = predecessor.wait();
+        });
+
+        let verdict =
+            wait_for_existing_daemon_within(&root, Duration::from_secs(2), Duration::from_secs(3))
+                .await;
+        handover.await.expect("handover task");
+
+        assert_eq!(
+            read_pid_file(&root),
+            Some(std::process::id()),
+            "the successor's pid file must survive a verdict about its predecessor: {verdict:?}"
+        );
+        assert_eq!(
+            read_port_file(&root),
+            Some(successor_port),
+            "the successor's port file must survive a verdict about its predecessor"
+        );
+    }
+
+    #[test]
+    fn compare_and_delete_refuses_once_the_recorded_endpoint_moved() {
+        let dir = tempfile::tempdir().unwrap();
+        let root = dir.path();
+
+        // Same owner, same port: the judgement still describes what is on disk.
+        write_endpoint_files(root, 4242, 51000);
+        assert!(remove_daemon_files_if_unchanged(root, 4242, Some(51000)));
+        assert!(!root.join("daemon.pid").exists());
+
+        // A different owner republished.
+        write_endpoint_files(root, 4243, 51000);
+        assert!(!remove_daemon_files_if_unchanged(root, 4242, Some(51000)));
+        assert!(root.join("daemon.pid").exists());
+
+        // Same owner, but it rebound to a different port, so the endpoint the
+        // verdict describes no longer exists either.
+        write_endpoint_files(root, 4242, 51001);
+        assert!(!remove_daemon_files_if_unchanged(root, 4242, Some(51000)));
+        assert!(root.join("daemon.port").exists());
+    }
+
     #[tokio::test]
     async fn dead_owner_endpoint_is_cleared_so_a_replacement_can_start() {
         // The other side of the rule: a recorded owner that is provably gone is
@@ -3416,6 +3647,147 @@ mod tests {
         );
         assert!(!root.join("daemon.pid").exists());
         assert!(!root.join("daemon.port").exists());
+    }
+
+    // ── Only a proven different repo is grounds for destruction ───────────
+    //
+    // "The daemon answered and named a different repo" is one of exactly two
+    // affirmative grounds for deleting a live daemon's endpoint. A rendered-path
+    // comparison is not that: two spellings of one directory are an aliasing
+    // artifact, and a path that will not resolve is no information at all.
+
+    fn health_naming(repo_id: Option<&str>, repo_root: Option<String>) -> HealthResponse {
+        HealthResponse {
+            status: "ok".to_string(),
+            version: "test".to_string(),
+            uptime_seconds: 0,
+            graph_entity_count: Some(0),
+            graph_loaded: false,
+            reconciliation_status: "idle".to_string(),
+            repo_id: repo_id.map(str::to_string),
+            repo_root,
+            pid: Some(std::process::id()),
+            behavior_env: Default::default(),
+            build: None,
+        }
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn an_aliased_path_to_the_same_directory_is_not_a_different_repo() {
+        // macOS reports /tmp as /private/tmp and this fleet runs lane worktrees
+        // behind symlinks, so the daemon's resolved root and the client's
+        // unresolved one routinely disagree as strings while naming one
+        // directory. Reading that as a different repository deletes the live
+        // daemon serving it.
+        let dir = tempfile::tempdir().unwrap();
+        let real = dir.path().join("repo");
+        std::fs::create_dir_all(&real).unwrap();
+        let alias = dir.path().join("alias");
+        std::os::unix::fs::symlink(&real, &alias).unwrap();
+
+        // The daemon reports the resolved path; the client holds the alias.
+        let health = health_naming(None, Some(strict_canonical_path(&real).unwrap()));
+        assert_eq!(
+            classify_health_repo(&health, &alias.join(".kin"), &alias),
+            RepoIdentity::Matches,
+            "two spellings of one directory must not read as two repositories"
+        );
+    }
+
+    #[test]
+    fn a_daemon_that_names_no_identity_is_indeterminate_not_a_match() {
+        // Fail-open was the old behavior: an absent repo_root skipped the check
+        // entirely and any daemon passed identity validation.
+        let dir = tempfile::tempdir().unwrap();
+        let health = health_naming(None, None);
+        assert!(
+            matches!(
+                classify_health_repo(&health, &dir.path().join(".kin"), dir.path()),
+                RepoIdentity::Indeterminate(_)
+            ),
+            "silence about identity is not proof of identity"
+        );
+    }
+
+    #[test]
+    fn an_unresolvable_repo_root_is_indeterminate_not_a_mismatch() {
+        let dir = tempfile::tempdir().unwrap();
+        let health = health_naming(None, Some("/nonexistent/kin/repo/path".to_string()));
+        assert!(
+            matches!(
+                classify_health_repo(&health, &dir.path().join(".kin"), dir.path()),
+                RepoIdentity::Indeterminate(_)
+            ),
+            "a path that will not resolve proves nothing about which repo is served"
+        );
+    }
+
+    #[test]
+    fn a_resolvable_different_directory_is_a_real_mismatch() {
+        // The rule must still fire where it should: both sides resolve, and they
+        // genuinely name different directories.
+        let mine = tempfile::tempdir().unwrap();
+        let theirs = tempfile::tempdir().unwrap();
+        let health = health_naming(None, Some(strict_canonical_path(theirs.path()).unwrap()));
+        assert!(
+            matches!(
+                classify_health_repo(&health, &mine.path().join(".kin"), mine.path()),
+                RepoIdentity::Rejected(_)
+            ),
+            "a daemon serving a different directory is real evidence"
+        );
+    }
+
+    #[test]
+    fn a_manifest_repository_id_decides_before_any_path_does() {
+        // The exact identity both sides already carry. When it is available it
+        // is conclusive in both directions and no path spelling is consulted.
+        let dir = tempfile::tempdir().unwrap();
+        let kin_root = dir.path().join(".kin");
+        std::fs::create_dir_all(&kin_root).unwrap();
+        std::fs::write(
+            kin_root.join("manifest.json"),
+            serde_json::json!({
+                "kin_version": "test",
+                "repo_id": "11111111-1111-4111-8111-111111111111",
+                "workspace_id": "22222222-2222-4222-8222-222222222222",
+                "created_at": "2026-01-01T00:00:00Z",
+            })
+            .to_string(),
+        )
+        .unwrap();
+
+        // Same id, and a repo_root that would have failed a path comparison.
+        let same = health_naming(
+            Some("11111111-1111-4111-8111-111111111111"),
+            Some("/some/other/spelling".to_string()),
+        );
+        assert_eq!(
+            classify_health_repo(&same, &kin_root, dir.path()),
+            RepoIdentity::Matches
+        );
+
+        // Different id, and a repo_root that would have passed one.
+        let other = health_naming(
+            Some("33333333-3333-4333-8333-333333333333"),
+            Some(strict_canonical_path(dir.path()).unwrap()),
+        );
+        assert!(matches!(
+            classify_health_repo(&other, &kin_root, dir.path()),
+            RepoIdentity::Rejected(_)
+        ));
+    }
+
+    #[test]
+    fn a_non_serving_status_is_still_a_real_answer() {
+        let dir = tempfile::tempdir().unwrap();
+        let mut health = health_naming(None, Some(strict_canonical_path(dir.path()).unwrap()));
+        health.status = "starting".to_string();
+        assert!(matches!(
+            classify_health_repo(&health, &dir.path().join(".kin"), dir.path()),
+            RepoIdentity::Rejected(_)
+        ));
     }
 
     #[test]

--- a/crates/kin-cli/src/daemon_client.rs
+++ b/crates/kin-cli/src/daemon_client.rs
@@ -1785,9 +1785,71 @@ pub fn remove_orphaned_daemon_port(kin_root: &Path) -> bool {
     )
 }
 
-fn remove_stale_daemon_files_uncoordinated(kin_root: &Path) {
-    let _ = std::fs::remove_file(repo_daemon_pid_path(kin_root));
-    let _ = std::fs::remove_file(repo_daemon_port_path(kin_root));
+fn remove_endpoint_files_with<F>(
+    pid_path: &Path,
+    port_path: &Path,
+    mut remove_file: F,
+) -> std::io::Result<()>
+where
+    F: FnMut(&Path) -> std::io::Result<()>,
+{
+    let paths = [pid_path, port_path];
+    let mut failure_kind = None;
+    let mut failures = Vec::new();
+
+    // Attempt both removals even when the first fails. A partial retirement must
+    // still fail closed, but clearing the other stale component leaves the next
+    // operator attempt with less ambiguous evidence.
+    for &path in &paths {
+        if let Err(error) = remove_file(path) {
+            if error.kind() != std::io::ErrorKind::NotFound {
+                failure_kind.get_or_insert(error.kind());
+                failures.push(format!("remove {}: {error}", path.display()));
+            }
+        }
+    }
+
+    // `NotFound` is a successful removal result only when the path is actually
+    // absent. Re-check both components while the caller still holds lifecycle
+    // and singleton authority so `Retired` can remain a trustworthy capability
+    // to start a replacement.
+    for &path in &paths {
+        match std::fs::symlink_metadata(path) {
+            Ok(_) => {
+                failure_kind.get_or_insert(std::io::ErrorKind::Other);
+                failures.push(format!(
+                    "endpoint component {} still exists after retirement",
+                    path.display()
+                ));
+            }
+            Err(error) if error.kind() == std::io::ErrorKind::NotFound => {}
+            Err(error) => {
+                failure_kind.get_or_insert(error.kind());
+                failures.push(format!("verify retirement of {}: {error}", path.display()));
+            }
+        }
+    }
+
+    if failures.is_empty() {
+        Ok(())
+    } else {
+        Err(std::io::Error::new(
+            failure_kind.unwrap_or(std::io::ErrorKind::Other),
+            failures.join("; "),
+        ))
+    }
+}
+
+fn remove_stale_daemon_files_uncoordinated_with<F>(
+    kin_root: &Path,
+    remove_file: F,
+) -> std::io::Result<()>
+where
+    F: FnMut(&Path) -> std::io::Result<()>,
+{
+    let pid_path = repo_daemon_pid_path(kin_root);
+    let port_path = repo_daemon_port_path(kin_root);
+    remove_endpoint_files_with(&pid_path, &port_path, remove_file)
 }
 
 fn try_acquire_daemon_endpoint_authority(kin_root: &Path) -> std::io::Result<File> {
@@ -1907,23 +1969,32 @@ where
         pid_exists: true,
         port_exists: judged_port.is_some(),
     };
-    retire_daemon_endpoint_if_unchanged_with_hook(kin_root, judged, after_comparison)
+    retire_daemon_endpoint_if_unchanged_with_hooks(kin_root, judged, after_comparison, |path| {
+        std::fs::remove_file(path)
+    })
 }
 
 fn retire_daemon_endpoint_if_unchanged(
     kin_root: &Path,
     judged: DaemonEndpointSnapshot,
 ) -> DaemonEndpointRetirement {
-    retire_daemon_endpoint_if_unchanged_with_hook(kin_root, judged, || {})
+    retire_daemon_endpoint_if_unchanged_with_hooks(
+        kin_root,
+        judged,
+        || {},
+        |path| std::fs::remove_file(path),
+    )
 }
 
-fn retire_daemon_endpoint_if_unchanged_with_hook<F>(
+fn retire_daemon_endpoint_if_unchanged_with_hooks<F, G>(
     kin_root: &Path,
     judged: DaemonEndpointSnapshot,
     after_comparison: F,
+    remove_file: G,
 ) -> DaemonEndpointRetirement
 where
     F: FnOnce(),
+    G: FnMut(&Path) -> std::io::Result<()>,
 {
     // Current daemon publication and every current retirement path take this
     // same never-unlinked authority. Holding it across the final comparison
@@ -2004,8 +2075,18 @@ where
         return DaemonEndpointRetirement::Changed { current };
     }
 
-    remove_stale_daemon_files_uncoordinated(kin_root);
-    DaemonEndpointRetirement::Retired
+    match remove_stale_daemon_files_uncoordinated_with(kin_root, remove_file) {
+        Ok(()) => DaemonEndpointRetirement::Retired,
+        Err(error) => {
+            warn!(
+                ?judged,
+                repo = %kin_root.display(),
+                %error,
+                "preserving daemon startup authority because endpoint retirement failed"
+            );
+            DaemonEndpointRetirement::CoordinationUnavailable(error.to_string())
+        }
+    }
 }
 
 fn supervisor_dir() -> PathBuf {
@@ -2114,16 +2195,23 @@ fn retire_supervisor_endpoint_if_unchanged(
     dir: &Path,
     judged: SupervisorEndpointSnapshot,
 ) -> SupervisorEndpointRetirement {
-    retire_supervisor_endpoint_if_unchanged_with_hook(dir, judged, || {})
+    retire_supervisor_endpoint_if_unchanged_with_hooks(
+        dir,
+        judged,
+        || {},
+        |path| std::fs::remove_file(path),
+    )
 }
 
-fn retire_supervisor_endpoint_if_unchanged_with_hook<F>(
+fn retire_supervisor_endpoint_if_unchanged_with_hooks<F, G>(
     dir: &Path,
     judged: SupervisorEndpointSnapshot,
     after_comparison: F,
+    remove_file: G,
 ) -> SupervisorEndpointRetirement
 where
     F: FnOnce(),
+    G: FnMut(&Path) -> std::io::Result<()>,
 {
     if let Err(error) = std::fs::create_dir_all(dir) {
         return SupervisorEndpointRetirement::CoordinationUnavailable(error.to_string());
@@ -2183,9 +2271,20 @@ where
     if current != judged {
         return SupervisorEndpointRetirement::Changed { current };
     }
-    let _ = std::fs::remove_file(dir.join(SUPERVISOR_PID_FILE));
-    let _ = std::fs::remove_file(dir.join(SUPERVISOR_PORT_FILE));
-    SupervisorEndpointRetirement::Retired
+    let pid_path = dir.join(SUPERVISOR_PID_FILE);
+    let port_path = dir.join(SUPERVISOR_PORT_FILE);
+    match remove_endpoint_files_with(&pid_path, &port_path, remove_file) {
+        Ok(()) => SupervisorEndpointRetirement::Retired,
+        Err(error) => {
+            warn!(
+                ?judged,
+                dir = %dir.display(),
+                %error,
+                "preserving supervisor startup authority because endpoint retirement failed"
+            );
+            SupervisorEndpointRetirement::CoordinationUnavailable(error.to_string())
+        }
+    }
 }
 
 fn read_pid_file(kin_root: &Path) -> Option<u32> {
@@ -4409,6 +4508,159 @@ mod tests {
             DaemonEndpointRetirement::Changed { .. }
         ));
         assert!(root.join("daemon.port").exists());
+    }
+
+    #[tokio::test]
+    async fn daemon_retirement_permission_denial_never_authorizes_replacement() {
+        for denied_name in ["daemon.pid", "daemon.port"] {
+            let dir = tempfile::tempdir().unwrap();
+            let root = dir.path();
+            write_endpoint_files(root, 999_999_999, 51000);
+            let judged = daemon_endpoint_snapshot(root);
+
+            let decision = retire_daemon_endpoint_if_unchanged_with_hooks(
+                root,
+                judged,
+                || {},
+                |path| {
+                    if path.file_name().and_then(|name| name.to_str()) == Some(denied_name) {
+                        Err(std::io::Error::new(
+                            std::io::ErrorKind::PermissionDenied,
+                            format!("injected denial for {denied_name}"),
+                        ))
+                    } else {
+                        std::fs::remove_file(path)
+                    }
+                },
+            );
+
+            assert!(
+                matches!(
+                    &decision,
+                    DaemonEndpointRetirement::CoordinationUnavailable(detail)
+                        if detail.contains(denied_name)
+                ),
+                "a {denied_name} deletion error must fail closed: {decision:?}"
+            );
+            assert!(
+                root.join(denied_name).exists(),
+                "the injected failure must leave {denied_name} in place"
+            );
+            let removed_name = if denied_name == "daemon.pid" {
+                "daemon.port"
+            } else {
+                "daemon.pid"
+            };
+            assert!(
+                !root.join(removed_name).exists(),
+                "retirement must attempt the second component even after a first-component error"
+            );
+
+            let verdict =
+                follow_preserved_daemon_endpoint(root, Instant::now(), Duration::ZERO, decision)
+                    .await;
+            assert!(
+                matches!(verdict, ExistingDaemon::LiveNotReady(_)),
+                "a partial retirement must preserve startup authority, never authorize a \
+                 replacement: {verdict:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn supervisor_retirement_permission_denial_never_authorizes_replacement() {
+        for denied_name in [SUPERVISOR_PID_FILE, SUPERVISOR_PORT_FILE] {
+            let dir = tempfile::tempdir().unwrap();
+            std::fs::write(dir.path().join(SUPERVISOR_PID_FILE), "999999999").unwrap();
+            std::fs::write(dir.path().join(SUPERVISOR_PORT_FILE), "51000").unwrap();
+            let judged = supervisor_endpoint_snapshot(dir.path());
+
+            let decision = retire_supervisor_endpoint_if_unchanged_with_hooks(
+                dir.path(),
+                judged,
+                || {},
+                |path| {
+                    if path.file_name().and_then(|name| name.to_str()) == Some(denied_name) {
+                        Err(std::io::Error::new(
+                            std::io::ErrorKind::PermissionDenied,
+                            format!("injected denial for {denied_name}"),
+                        ))
+                    } else {
+                        std::fs::remove_file(path)
+                    }
+                },
+            );
+
+            assert!(
+                matches!(
+                    &decision,
+                    SupervisorEndpointRetirement::CoordinationUnavailable(detail)
+                        if detail.contains(denied_name)
+                ),
+                "a {denied_name} deletion error must fail closed, not authorize a supervisor \
+                 replacement: {decision:?}"
+            );
+            assert!(
+                dir.path().join(denied_name).exists(),
+                "the injected failure must leave {denied_name} in place"
+            );
+            let removed_name = if denied_name == SUPERVISOR_PID_FILE {
+                SUPERVISOR_PORT_FILE
+            } else {
+                SUPERVISOR_PID_FILE
+            };
+            assert!(
+                !dir.path().join(removed_name).exists(),
+                "retirement must attempt the second component even after a first-component error"
+            );
+        }
+    }
+
+    #[test]
+    fn retirement_treats_not_found_as_success_only_when_components_are_absent() {
+        let daemon_dir = tempfile::tempdir().unwrap();
+        let daemon_judged = daemon_endpoint_snapshot(daemon_dir.path());
+        assert_eq!(
+            retire_daemon_endpoint_if_unchanged_with_hooks(
+                daemon_dir.path(),
+                daemon_judged,
+                || {},
+                |_| Err(std::io::Error::from(std::io::ErrorKind::NotFound)),
+            ),
+            DaemonEndpointRetirement::Retired
+        );
+
+        let supervisor_dir = tempfile::tempdir().unwrap();
+        let supervisor_judged = supervisor_endpoint_snapshot(supervisor_dir.path());
+        assert_eq!(
+            retire_supervisor_endpoint_if_unchanged_with_hooks(
+                supervisor_dir.path(),
+                supervisor_judged,
+                || {},
+                |_| Err(std::io::Error::from(std::io::ErrorKind::NotFound)),
+            ),
+            SupervisorEndpointRetirement::Retired
+        );
+
+        let remaining_dir = tempfile::tempdir().unwrap();
+        write_endpoint_files(remaining_dir.path(), 999_999_999, 51000);
+        let remaining_judged = daemon_endpoint_snapshot(remaining_dir.path());
+        let decision = retire_daemon_endpoint_if_unchanged_with_hooks(
+            remaining_dir.path(),
+            remaining_judged,
+            || {},
+            |_| Err(std::io::Error::from(std::io::ErrorKind::NotFound)),
+        );
+        assert!(
+            matches!(
+                decision,
+                DaemonEndpointRetirement::CoordinationUnavailable(_)
+            ),
+            "`NotFound` cannot authorize replacement when post-removal verification still sees \
+             endpoint components"
+        );
+        assert!(remaining_dir.path().join("daemon.pid").exists());
+        assert!(remaining_dir.path().join("daemon.port").exists());
     }
 
     #[test]

--- a/crates/kin-cli/src/daemon_client.rs
+++ b/crates/kin-cli/src/daemon_client.rs
@@ -1747,17 +1747,10 @@ pub fn repo_daemon_port_path(kin_root: &Path) -> PathBuf {
 /// these itself on graceful shutdown; `kin daemon stop` also calls this after a
 /// confirmed stop so a later `status` never reports the dead endpoint as stale.
 pub fn remove_stale_daemon_files(kin_root: &Path) {
-    let Ok(_authority) = try_acquire_daemon_endpoint_authority(kin_root) else {
-        warn!(
-            repo = %kin_root.display(),
-            "preserving daemon endpoint because lifecycle authority is contended"
-        );
-        return;
-    };
-    let pid_path = repo_daemon_pid_path(kin_root);
-    match read_pid_file(kin_root) {
+    let recorded = daemon_endpoint_snapshot(kin_root);
+    match recorded.pid {
         Some(pid) if process_liveness(pid).authorizes_cleanup() => {
-            remove_stale_daemon_files_uncoordinated(kin_root);
+            let _ = retire_daemon_endpoint_if_unchanged(kin_root, recorded);
         }
         Some(pid) => {
             warn!(
@@ -1766,8 +1759,8 @@ pub fn remove_stale_daemon_files(kin_root: &Path) {
                 "preserving daemon endpoint because its recorded owner may still be alive"
             );
         }
-        None if !pid_path.exists() => {
-            let _ = std::fs::remove_file(repo_daemon_port_path(kin_root));
+        None if !recorded.pid_exists => {
+            let _ = retire_daemon_endpoint_if_unchanged(kin_root, recorded);
         }
         None => {
             warn!(
@@ -1782,13 +1775,14 @@ pub fn remove_stale_daemon_files(kin_root: &Path) {
 /// PID owner. Used before startup and by setup hygiene; a successor publishing
 /// its complete endpoint takes the same authority and therefore survives.
 pub fn remove_orphaned_daemon_port(kin_root: &Path) -> bool {
-    let Ok(_authority) = try_acquire_daemon_endpoint_authority(kin_root) else {
-        return false;
-    };
-    if repo_daemon_pid_path(kin_root).exists() {
+    let recorded = daemon_endpoint_snapshot(kin_root);
+    if recorded.pid_exists || !recorded.port_exists {
         return false;
     }
-    std::fs::remove_file(repo_daemon_port_path(kin_root)).is_ok()
+    matches!(
+        retire_daemon_endpoint_if_unchanged(kin_root, recorded),
+        DaemonEndpointRetirement::Retired
+    )
 }
 
 fn remove_stale_daemon_files_uncoordinated(kin_root: &Path) {
@@ -1805,6 +1799,61 @@ fn try_acquire_daemon_endpoint_authority(kin_root: &Path) -> std::io::Result<Fil
         .open(kin_root.join("daemon.lifecycle"))?;
     authority.try_lock_exclusive()?;
     Ok(authority)
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+struct DaemonEndpointSnapshot {
+    pid: Option<u32>,
+    port: Option<u16>,
+    pid_exists: bool,
+    port_exists: bool,
+}
+
+fn daemon_endpoint_snapshot(kin_root: &Path) -> DaemonEndpointSnapshot {
+    let pid_path = repo_daemon_pid_path(kin_root);
+    let port_path = repo_daemon_port_path(kin_root);
+    DaemonEndpointSnapshot {
+        pid: read_pid_file(kin_root),
+        port: read_port_file(kin_root),
+        pid_exists: pid_path.exists(),
+        port_exists: port_path.exists(),
+    }
+}
+
+/// Linearized outcome of a destructive endpoint-retirement attempt.
+///
+/// Only `Retired` authorizes a caller to start a replacement. Every other
+/// variant means the record was preserved and startup must follow the current
+/// generation or fail closed.
+#[derive(Debug, Clone, PartialEq, Eq)]
+enum DaemonEndpointRetirement {
+    Retired,
+    Changed { current: DaemonEndpointSnapshot },
+    LifecycleContended,
+    SingletonHeld,
+    CoordinationUnavailable(String),
+}
+
+impl DaemonEndpointRetirement {
+    fn preserved_reason(&self) -> String {
+        match self {
+            Self::Retired => "endpoint was retired".to_string(),
+            Self::Changed { current } => format!(
+                "endpoint changed during retirement (pid={:?}, port={:?})",
+                current.pid, current.port
+            ),
+            Self::LifecycleContended => {
+                "daemon lifecycle coordination is held by another participant".to_string()
+            }
+            Self::SingletonHeld => {
+                "the repository daemon singleton is still held by a current or legacy owner"
+                    .to_string()
+            }
+            Self::CoordinationUnavailable(detail) => {
+                format!("daemon retirement coordination is unavailable: {detail}")
+            }
+        }
+    }
 }
 
 /// Remove endpoint files only while they still name the exact endpoint a verdict
@@ -1826,21 +1875,53 @@ fn try_acquire_daemon_endpoint_authority(kin_root: &Path) -> std::io::Result<Fil
 /// `judged_port` is `None` when the verdict was reached before a port was ever
 /// published, which is the one case where the port file is legitimately absent.
 ///
-/// Returns whether the files were removed.
+/// Returns a typed decision. Only [`DaemonEndpointRetirement::Retired`] permits
+/// a caller to start a replacement.
 fn remove_daemon_files_if_unchanged(
     kin_root: &Path,
     judged_pid: u32,
     judged_port: Option<u16>,
-) -> bool {
-    remove_daemon_files_if_unchanged_with_hook(kin_root, judged_pid, judged_port, || {})
+) -> DaemonEndpointRetirement {
+    let judged = DaemonEndpointSnapshot {
+        pid: Some(judged_pid),
+        port: judged_port,
+        pid_exists: true,
+        port_exists: judged_port.is_some(),
+    };
+    retire_daemon_endpoint_if_unchanged(kin_root, judged)
 }
 
+#[cfg(test)]
 fn remove_daemon_files_if_unchanged_with_hook<F>(
     kin_root: &Path,
     judged_pid: u32,
     judged_port: Option<u16>,
     after_comparison: F,
-) -> bool
+) -> DaemonEndpointRetirement
+where
+    F: FnOnce(),
+{
+    let judged = DaemonEndpointSnapshot {
+        pid: Some(judged_pid),
+        port: judged_port,
+        pid_exists: true,
+        port_exists: judged_port.is_some(),
+    };
+    retire_daemon_endpoint_if_unchanged_with_hook(kin_root, judged, after_comparison)
+}
+
+fn retire_daemon_endpoint_if_unchanged(
+    kin_root: &Path,
+    judged: DaemonEndpointSnapshot,
+) -> DaemonEndpointRetirement {
+    retire_daemon_endpoint_if_unchanged_with_hook(kin_root, judged, || {})
+}
+
+fn retire_daemon_endpoint_if_unchanged_with_hook<F>(
+    kin_root: &Path,
+    judged: DaemonEndpointSnapshot,
+    after_comparison: F,
+) -> DaemonEndpointRetirement
 where
     F: FnOnce(),
 {
@@ -1848,36 +1929,83 @@ where
     // same never-unlinked authority. Holding it across the final comparison
     // and both unlinks makes the judgement linearizable: a successor either
     // publishes before the comparison (and is preserved) or after retirement.
-    let Ok(_authority) = try_acquire_daemon_endpoint_authority(kin_root) else {
-        warn!(
-            judged_pid,
-            ?judged_port,
-            repo = %kin_root.display(),
-            "preserving daemon endpoint because lifecycle authority is contended"
-        );
-        return false;
+    let _authority = match try_acquire_daemon_endpoint_authority(kin_root) {
+        Ok(authority) => authority,
+        Err(error) if error.kind() == fs2::lock_contended_error().kind() => {
+            warn!(
+                ?judged,
+                repo = %kin_root.display(),
+                "preserving daemon endpoint because lifecycle authority is contended"
+            );
+            return DaemonEndpointRetirement::LifecycleContended;
+        }
+        Err(error) => {
+            warn!(
+                ?judged,
+                repo = %kin_root.display(),
+                %error,
+                "preserving daemon endpoint because lifecycle authority is unavailable"
+            );
+            return DaemonEndpointRetirement::CoordinationUnavailable(error.to_string());
+        }
     };
-    let current_pid = read_pid_file(kin_root);
-    let current_port = read_port_file(kin_root);
-    let same_owner = current_pid == Some(judged_pid);
-    // An unchanged PID that gained or changed a port is a different endpoint
-    // generation (including PID reuse) and must survive. `None` means the
-    // judged endpoint had no port, not "ignore whichever port exists now."
-    let same_endpoint = current_port == judged_port;
-    if !(same_owner && same_endpoint) {
+
+    // Open the never-unlinked singleton pathname before the comparison. A
+    // compatible legacy publisher does not take daemon.lifecycle, but it does
+    // lock this inode for its process lifetime. Trying the already-opened inode
+    // after the comparison therefore closes the mixed-version
+    // compare-then-unlink window without ever replacing daemon.lock.
+    let singleton = match OpenOptions::new()
+        .create(true)
+        .read(true)
+        .write(true)
+        .truncate(false)
+        .open(kin_root.join("daemon.lock"))
+    {
+        Ok(singleton) => singleton,
+        Err(error) => {
+            return DaemonEndpointRetirement::CoordinationUnavailable(error.to_string());
+        }
+    };
+
+    let current = daemon_endpoint_snapshot(kin_root);
+    if current != judged {
         warn!(
-            judged_pid,
-            ?judged_port,
-            ?current_pid,
-            ?current_port,
+            ?judged,
+            ?current,
             "endpoint files changed while this daemon was being judged; \
              leaving the successor's endpoint intact"
         );
-        return false;
+        return DaemonEndpointRetirement::Changed { current };
     }
+
     after_comparison();
+
+    match singleton.try_lock_exclusive() {
+        Ok(()) => {}
+        Err(error) if error.kind() == fs2::lock_contended_error().kind() => {
+            warn!(
+                ?judged,
+                repo = %kin_root.display(),
+                "preserving daemon endpoint because the daemon singleton is held"
+            );
+            return DaemonEndpointRetirement::SingletonHeld;
+        }
+        Err(error) => {
+            return DaemonEndpointRetirement::CoordinationUnavailable(error.to_string());
+        }
+    }
+
+    // A legacy publisher may have completed and released its singleton between
+    // the first comparison and our nonblocking lock. Revalidate under both
+    // authorities so even that short-lived generation is preserved.
+    let current = daemon_endpoint_snapshot(kin_root);
+    if current != judged {
+        return DaemonEndpointRetirement::Changed { current };
+    }
+
     remove_stale_daemon_files_uncoordinated(kin_root);
-    true
+    DaemonEndpointRetirement::Retired
 }
 
 fn supervisor_dir() -> PathBuf {
@@ -1887,21 +2015,177 @@ fn supervisor_dir() -> PathBuf {
         .unwrap_or_else(|| PathBuf::from(".kin"))
 }
 
+const SUPERVISOR_PID_FILE: &str = "supervisor.pid";
+const SUPERVISOR_PORT_FILE: &str = "supervisor.port";
+const SUPERVISOR_LIFECYCLE_FILE: &str = "supervisor.lifecycle";
+const SUPERVISOR_SINGLETON_FILE: &str = "supervisor.lock";
+
 /// Path to the per-user supervisor pid file (under the Kin registry directory).
 pub fn supervisor_pid_path() -> PathBuf {
-    supervisor_dir().join("supervisor.pid")
+    supervisor_dir().join(SUPERVISOR_PID_FILE)
 }
 
 /// Path to the per-user supervisor port file (under the Kin registry directory).
 pub fn supervisor_port_path() -> PathBuf {
-    supervisor_dir().join("supervisor.port")
+    supervisor_dir().join(SUPERVISOR_PORT_FILE)
 }
 
 /// Remove the supervisor's pid/port endpoint files. Called after a confirmed
 /// supervisor stop so a later `status` never reports the dead endpoint as stale.
 pub fn remove_stale_supervisor_files() {
-    let _ = std::fs::remove_file(supervisor_pid_path());
-    let _ = std::fs::remove_file(supervisor_port_path());
+    let dir = supervisor_dir();
+    let recorded = supervisor_endpoint_snapshot(&dir);
+    match recorded.pid {
+        Some(pid) if process_liveness(pid).authorizes_cleanup() => {
+            let _ = retire_supervisor_endpoint_if_unchanged(&dir, recorded);
+        }
+        Some(_) => {
+            warn!(
+                ?recorded,
+                "preserving supervisor endpoint because its owner is live or indeterminate"
+            );
+        }
+        None if recorded.pid_exists => {
+            warn!(
+                ?recorded,
+                "preserving supervisor endpoint because its owner is live or indeterminate"
+            );
+        }
+        None => {
+            let _ = retire_supervisor_endpoint_if_unchanged(&dir, recorded);
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+struct SupervisorEndpointSnapshot {
+    pid: Option<u32>,
+    port: Option<u16>,
+    pid_exists: bool,
+    port_exists: bool,
+}
+
+fn supervisor_endpoint_snapshot(dir: &Path) -> SupervisorEndpointSnapshot {
+    let pid_path = dir.join(SUPERVISOR_PID_FILE);
+    let port_path = dir.join(SUPERVISOR_PORT_FILE);
+    SupervisorEndpointSnapshot {
+        pid: std::fs::read_to_string(&pid_path)
+            .ok()
+            .and_then(|value| value.trim().parse().ok()),
+        port: std::fs::read_to_string(&port_path)
+            .ok()
+            .and_then(|value| value.trim().parse().ok()),
+        pid_exists: pid_path.exists(),
+        port_exists: port_path.exists(),
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+enum SupervisorEndpointRetirement {
+    Retired,
+    Changed { current: SupervisorEndpointSnapshot },
+    LifecycleContended,
+    SingletonHeld,
+    CoordinationUnavailable(String),
+}
+
+impl SupervisorEndpointRetirement {
+    fn preserved_reason(&self) -> String {
+        match self {
+            Self::Retired => "endpoint was retired".to_string(),
+            Self::Changed { current } => format!(
+                "endpoint changed during retirement (pid={:?}, port={:?})",
+                current.pid, current.port
+            ),
+            Self::LifecycleContended => {
+                "supervisor lifecycle coordination is held by another participant".to_string()
+            }
+            Self::SingletonHeld => {
+                "the supervisor process-lifetime singleton is still held".to_string()
+            }
+            Self::CoordinationUnavailable(detail) => {
+                format!("supervisor retirement coordination is unavailable: {detail}")
+            }
+        }
+    }
+}
+
+fn retire_supervisor_endpoint_if_unchanged(
+    dir: &Path,
+    judged: SupervisorEndpointSnapshot,
+) -> SupervisorEndpointRetirement {
+    retire_supervisor_endpoint_if_unchanged_with_hook(dir, judged, || {})
+}
+
+fn retire_supervisor_endpoint_if_unchanged_with_hook<F>(
+    dir: &Path,
+    judged: SupervisorEndpointSnapshot,
+    after_comparison: F,
+) -> SupervisorEndpointRetirement
+where
+    F: FnOnce(),
+{
+    if let Err(error) = std::fs::create_dir_all(dir) {
+        return SupervisorEndpointRetirement::CoordinationUnavailable(error.to_string());
+    }
+    let lifecycle = match OpenOptions::new()
+        .create(true)
+        .read(true)
+        .write(true)
+        .truncate(false)
+        .open(dir.join(SUPERVISOR_LIFECYCLE_FILE))
+    {
+        Ok(lifecycle) => lifecycle,
+        Err(error) => {
+            return SupervisorEndpointRetirement::CoordinationUnavailable(error.to_string());
+        }
+    };
+    match lifecycle.try_lock_exclusive() {
+        Ok(()) => {}
+        Err(error) if error.kind() == fs2::lock_contended_error().kind() => {
+            return SupervisorEndpointRetirement::LifecycleContended;
+        }
+        Err(error) => {
+            return SupervisorEndpointRetirement::CoordinationUnavailable(error.to_string());
+        }
+    }
+
+    // The lifetime inode is opened before the comparison for the same reason as
+    // daemon.lock: current publishers hold it continuously, while a
+    // non-participating legacy endpoint is still protected by its live PID.
+    let singleton = match OpenOptions::new()
+        .create(true)
+        .read(true)
+        .write(true)
+        .truncate(false)
+        .open(dir.join(SUPERVISOR_SINGLETON_FILE))
+    {
+        Ok(singleton) => singleton,
+        Err(error) => {
+            return SupervisorEndpointRetirement::CoordinationUnavailable(error.to_string());
+        }
+    };
+    let current = supervisor_endpoint_snapshot(dir);
+    if current != judged {
+        return SupervisorEndpointRetirement::Changed { current };
+    }
+    after_comparison();
+    match singleton.try_lock_exclusive() {
+        Ok(()) => {}
+        Err(error) if error.kind() == fs2::lock_contended_error().kind() => {
+            return SupervisorEndpointRetirement::SingletonHeld;
+        }
+        Err(error) => {
+            return SupervisorEndpointRetirement::CoordinationUnavailable(error.to_string());
+        }
+    }
+    let current = supervisor_endpoint_snapshot(dir);
+    if current != judged {
+        return SupervisorEndpointRetirement::Changed { current };
+    }
+    let _ = std::fs::remove_file(dir.join(SUPERVISOR_PID_FILE));
+    let _ = std::fs::remove_file(dir.join(SUPERVISOR_PORT_FILE));
+    SupervisorEndpointRetirement::Retired
 }
 
 fn read_pid_file(kin_root: &Path) -> Option<u32> {
@@ -1928,13 +2212,8 @@ pub fn repo_daemon_recorded_endpoint(kin_root: &Path) -> (Option<u32>, Option<u1
 /// `supervisor.{pid,port}` files with no liveness probe. Either component is
 /// `None` when its file is absent or unparseable.
 pub fn supervisor_recorded_endpoint() -> (Option<u32>, Option<u16>) {
-    let pid = std::fs::read_to_string(supervisor_pid_path())
-        .ok()
-        .and_then(|s| s.trim().parse().ok());
-    let port = std::fs::read_to_string(supervisor_port_path())
-        .ok()
-        .and_then(|s| s.trim().parse().ok());
-    (pid, port)
+    let recorded = supervisor_endpoint_snapshot(&supervisor_dir());
+    (recorded.pid, recorded.port)
 }
 
 fn live_daemon_endpoint(kin_root: &Path) -> Option<LiveDaemonEndpoint> {
@@ -1945,39 +2224,44 @@ fn live_daemon_endpoint_with_probe(
     kin_root: &Path,
     probe: impl FnOnce(u32) -> ProcessLiveness,
 ) -> Option<LiveDaemonEndpoint> {
-    let pid = read_pid_file(kin_root)?;
+    let recorded = daemon_endpoint_snapshot(kin_root);
+    let pid = recorded.pid?;
     // Capture both components before forming the liveness verdict. Reading the
     // port afterward could bind a true "dead" result about the predecessor PID
     // to a same-PID successor's newly published port, making the final
     // compare-and-retire accept the wrong endpoint generation.
-    let port = read_port_file(kin_root);
+    let port = recorded.port;
     if probe(pid).authorizes_cleanup() {
         // Compare-and-delete even here, where the window is only as wide as this
         // function: a successor that republished between the read and the
         // liveness check would otherwise lose its endpoint to a true statement
         // about its predecessor.
-        remove_daemon_files_if_unchanged(kin_root, pid, port);
-        return None;
+        match retire_daemon_endpoint_if_unchanged(kin_root, recorded) {
+            DaemonEndpointRetirement::Retired => return None,
+            DaemonEndpointRetirement::Changed { current } => {
+                return Some(LiveDaemonEndpoint {
+                    pid: current.pid?,
+                    port: current.port?,
+                });
+            }
+            DaemonEndpointRetirement::LifecycleContended
+            | DaemonEndpointRetirement::SingletonHeld
+            | DaemonEndpointRetirement::CoordinationUnavailable(_) => {}
+        }
     }
     let port = port?;
     Some(LiveDaemonEndpoint { pid, port })
 }
 
 fn live_supervisor_endpoint() -> Option<LiveDaemonEndpoint> {
-    let pid = std::fs::read_to_string(supervisor_pid_path())
-        .ok()?
-        .trim()
-        .parse()
-        .ok()?;
-    if !is_process_alive(pid) {
-        remove_stale_supervisor_files();
+    let dir = supervisor_dir();
+    let recorded = supervisor_endpoint_snapshot(&dir);
+    let pid = recorded.pid?;
+    if process_liveness(pid).authorizes_cleanup() {
+        let _ = retire_supervisor_endpoint_if_unchanged(&dir, recorded);
         return None;
     }
-    let port = std::fs::read_to_string(supervisor_port_path())
-        .ok()?
-        .trim()
-        .parse()
-        .ok()?;
+    let port = recorded.port?;
     Some(LiveDaemonEndpoint { pid, port })
 }
 
@@ -2573,6 +2857,16 @@ async fn probe_daemon_endpoint(
     endpoint: LiveDaemonEndpoint,
     timeout: Duration,
 ) -> EndpointVerdict {
+    let warming = std::sync::Arc::new(AtomicBool::new(false));
+    probe_daemon_endpoint_with_warming_signal(kin_root, endpoint, timeout, warming).await
+}
+
+async fn probe_daemon_endpoint_with_warming_signal(
+    kin_root: &Path,
+    endpoint: LiveDaemonEndpoint,
+    timeout: Duration,
+    warming_signal: std::sync::Arc<AtomicBool>,
+) -> EndpointVerdict {
     let Some(working_dir) = kin_root.parent() else {
         return EndpointVerdict::Invalid("invalid .kin layout: no parent".to_string());
     };
@@ -2597,6 +2891,7 @@ async fn probe_daemon_endpoint(
                 // exactly when retaining "warming" makes the diagnostic honest.
                 if let Ok(readiness) = resp.json::<ReadinessResponse>().await {
                     warming = readiness.warming;
+                    warming_signal.store(warming, Ordering::Relaxed);
                 }
                 match probe_health_for_repo(&client, &base_url, kin_root, working_dir).await {
                     HealthProbe::Matches => return EndpointVerdict::Serving(base_url),
@@ -2617,6 +2912,7 @@ async fn probe_daemon_endpoint(
                 match resp.json::<ReadinessResponse>().await {
                     Ok(readiness) => {
                         warming = readiness.warming;
+                        warming_signal.store(warming, Ordering::Relaxed);
                         format!(
                             "readiness returned HTTP {status} (ready={}, warming={})",
                             readiness.ready, readiness.warming
@@ -2801,16 +3097,60 @@ async fn wait_for_existing_daemon_within(
     short: Duration,
     patience: Duration,
 ) -> ExistingDaemon {
-    let Some(existing) = live_daemon_endpoint(kin_root) else {
-        return ExistingDaemon::None;
+    let deadline = Instant::now() + patience;
+    let recorded = daemon_endpoint_snapshot(kin_root);
+    let Some(pid) = recorded.pid else {
+        if recorded.pid_exists {
+            return ExistingDaemon::LiveNotReady(
+                "the recorded daemon PID is unparseable; refusing to replace an owner whose \
+                 liveness cannot be established"
+                    .to_string(),
+            );
+        }
+        if !recorded.port_exists {
+            let retirement = retire_daemon_endpoint_if_unchanged(kin_root, recorded);
+            return match retirement {
+                DaemonEndpointRetirement::Retired => ExistingDaemon::None,
+                preserved => {
+                    follow_preserved_daemon_endpoint(kin_root, deadline, patience, preserved).await
+                }
+            };
+        }
+        let retirement = retire_daemon_endpoint_if_unchanged(kin_root, recorded);
+        return match retirement {
+            DaemonEndpointRetirement::Retired => ExistingDaemon::None,
+            preserved => {
+                follow_preserved_daemon_endpoint(kin_root, deadline, patience, preserved).await
+            }
+        };
     };
 
-    let mut verdict = probe_daemon_endpoint(kin_root, existing, short).await;
+    if process_liveness(pid).authorizes_cleanup() {
+        let retirement = retire_daemon_endpoint_if_unchanged(kin_root, recorded);
+        return match retirement {
+            DaemonEndpointRetirement::Retired => ExistingDaemon::None,
+            preserved => {
+                follow_preserved_daemon_endpoint(kin_root, deadline, patience, preserved).await
+            }
+        };
+    }
+
+    let Some(port) = recorded.port else {
+        return ExistingDaemon::LiveNotReady(format!(
+            "kin daemon pid {pid} may still own this repo, but its port record is absent or \
+             unparseable; refusing to start a second daemon"
+        ));
+    };
+    let existing = LiveDaemonEndpoint { pid, port };
+
+    let short_deadline = (Instant::now() + short).min(deadline);
+    let mut verdict = probe_daemon_endpoint_until(kin_root, existing, short_deadline, false).await;
 
     if let EndpointVerdict::LiveNotReady {
         pid, port, warming, ..
     } = &verdict
     {
+        let last_warming = *warming;
         warn!(
             pid = *pid,
             port = *port,
@@ -2819,7 +3159,7 @@ async fn wait_for_existing_daemon_within(
             "daemon for this repo is alive but not ready yet; waiting rather than \
              replacing a running daemon"
         );
-        verdict = probe_daemon_endpoint(kin_root, existing, patience.saturating_sub(short)).await;
+        verdict = probe_daemon_endpoint_until(kin_root, existing, deadline, last_warming).await;
     }
 
     match verdict {
@@ -2841,8 +3181,14 @@ async fn wait_for_existing_daemon_within(
             // The verdict is true about the endpoint that was probed, which may
             // no longer be the endpoint on disk — the probe deliberately runs
             // long enough for a successor to take over.
-            remove_daemon_files_if_unchanged(kin_root, existing.pid, Some(existing.port));
-            ExistingDaemon::None
+            let retirement =
+                remove_daemon_files_if_unchanged(kin_root, existing.pid, Some(existing.port));
+            match retirement {
+                DaemonEndpointRetirement::Retired => ExistingDaemon::None,
+                preserved => {
+                    follow_preserved_daemon_endpoint(kin_root, deadline, patience, preserved).await
+                }
+            }
         }
         EndpointVerdict::LiveNotReady {
             pid,
@@ -2855,6 +3201,77 @@ async fn wait_for_existing_daemon_within(
             &detail,
             warming,
             patience.as_secs(),
+        )),
+    }
+}
+
+async fn probe_daemon_endpoint_until(
+    kin_root: &Path,
+    endpoint: LiveDaemonEndpoint,
+    deadline: Instant,
+    last_warming: bool,
+) -> EndpointVerdict {
+    let remaining = deadline.saturating_duration_since(Instant::now());
+    if remaining.is_zero() {
+        return EndpointVerdict::LiveNotReady {
+            pid: endpoint.pid,
+            port: endpoint.port,
+            detail: "the caller's daemon readiness deadline elapsed".to_string(),
+            warming: last_warming,
+        };
+    }
+    let warming_signal = std::sync::Arc::new(AtomicBool::new(last_warming));
+    match tokio::time::timeout(
+        remaining,
+        probe_daemon_endpoint_with_warming_signal(
+            kin_root,
+            endpoint,
+            remaining,
+            std::sync::Arc::clone(&warming_signal),
+        ),
+    )
+    .await
+    {
+        Ok(verdict) => verdict,
+        Err(_) => EndpointVerdict::LiveNotReady {
+            pid: endpoint.pid,
+            port: endpoint.port,
+            detail: "the caller's daemon readiness deadline elapsed".to_string(),
+            warming: warming_signal.load(Ordering::Relaxed),
+        },
+    }
+}
+
+async fn follow_preserved_daemon_endpoint(
+    kin_root: &Path,
+    deadline: Instant,
+    patience: Duration,
+    retirement: DaemonEndpointRetirement,
+) -> ExistingDaemon {
+    debug_assert!(!matches!(retirement, DaemonEndpointRetirement::Retired));
+    let reason = retirement.preserved_reason();
+    let current = daemon_endpoint_snapshot(kin_root);
+    let (Some(pid), Some(port)) = (current.pid, current.port) else {
+        return ExistingDaemon::LiveNotReady(format!(
+            "daemon endpoint retirement was refused because {reason}; the current endpoint is \
+             incomplete or indeterminate, so kin will not start a replacement"
+        ));
+    };
+    let endpoint = LiveDaemonEndpoint { pid, port };
+    match probe_daemon_endpoint_until(kin_root, endpoint, deadline, false).await {
+        EndpointVerdict::Serving(base_url) => ExistingDaemon::Connected(base_url),
+        EndpointVerdict::LiveNotReady {
+            pid,
+            port,
+            detail,
+            warming,
+        } => ExistingDaemon::LiveNotReady(format!(
+            "{} Retirement was refused because {reason}.",
+            live_daemon_not_ready_message(pid, port, &detail, warming, patience.as_secs(),)
+        )),
+        EndpointVerdict::Invalid(detail) => ExistingDaemon::LiveNotReady(format!(
+            "daemon endpoint retirement was refused because {reason}; the preserved endpoint \
+             (pid {pid}, port {port}) is not usable: {detail}. Kin will not start a second daemon"
         )),
     }
 }
@@ -2909,19 +3326,80 @@ async fn validate_supervisor_endpoint(endpoint: LiveDaemonEndpoint) -> Result<St
     Ok(base_url)
 }
 
-async fn wait_for_existing_supervisor() -> Option<String> {
-    let existing = live_supervisor_endpoint()?;
+#[derive(Debug)]
+enum ExistingSupervisor {
+    Connected(String),
+    None,
+    LiveNotReady(String),
+}
+
+async fn wait_for_existing_supervisor() -> ExistingSupervisor {
+    wait_for_existing_supervisor_in_dir(&supervisor_dir()).await
+}
+
+async fn wait_for_existing_supervisor_in_dir(dir: &Path) -> ExistingSupervisor {
+    let recorded = supervisor_endpoint_snapshot(dir);
+    let Some(pid) = recorded.pid else {
+        if recorded.pid_exists {
+            return ExistingSupervisor::LiveNotReady(
+                "the supervisor PID record is unparseable; refusing to replace an owner whose \
+                 liveness cannot be established"
+                    .to_string(),
+            );
+        }
+        if !recorded.port_exists {
+            return match retire_supervisor_endpoint_if_unchanged(dir, recorded) {
+                SupervisorEndpointRetirement::Retired => ExistingSupervisor::None,
+                preserved => ExistingSupervisor::LiveNotReady(format!(
+                    "supervisor startup authority is unavailable because {}; kin will not start \
+                     a replacement",
+                    preserved.preserved_reason()
+                )),
+            };
+        }
+        return match retire_supervisor_endpoint_if_unchanged(dir, recorded) {
+            SupervisorEndpointRetirement::Retired => ExistingSupervisor::None,
+            preserved => ExistingSupervisor::LiveNotReady(format!(
+                "supervisor endpoint retirement was refused because {}; kin will not start a \
+                 replacement",
+                preserved.preserved_reason()
+            )),
+        };
+    };
+
+    if process_liveness(pid).authorizes_cleanup() {
+        return match retire_supervisor_endpoint_if_unchanged(dir, recorded) {
+            SupervisorEndpointRetirement::Retired => ExistingSupervisor::None,
+            preserved => ExistingSupervisor::LiveNotReady(format!(
+                "supervisor endpoint retirement was refused because {}; kin will not start a \
+                 replacement",
+                preserved.preserved_reason()
+            )),
+        };
+    }
+
+    let Some(port) = recorded.port else {
+        return ExistingSupervisor::LiveNotReady(format!(
+            "kin supervisor pid {pid} may still own the per-user control plane, but its port \
+             record is absent or unparseable; refusing to start a second supervisor"
+        ));
+    };
+    let existing = LiveDaemonEndpoint { pid, port };
     match validate_supervisor_endpoint(existing).await {
-        Ok(base_url) => Some(base_url),
+        Ok(base_url) => ExistingSupervisor::Connected(base_url),
         Err(err) => {
             warn!(
                 pid = existing.pid,
                 port = existing.port,
                 error = %err,
-                "invalid supervisor endpoint; clearing stale endpoint files"
+                "supervisor owner is live or indeterminate but health is unavailable; \
+                 preserving endpoint and refusing replacement"
             );
-            remove_stale_supervisor_files();
-            None
+            ExistingSupervisor::LiveNotReady(format!(
+                "kin supervisor (pid {}, port {}) may still own the per-user control plane but \
+                 did not pass health: {err}. Kin will not replace a live or indeterminate owner",
+                existing.pid, existing.port
+            ))
         }
     }
 }
@@ -2994,21 +3472,26 @@ pub async fn ensure_supervisor_running() -> Result<String> {
         .map(|_| url);
     }
 
-    if let Some(base_url) = wait_for_existing_supervisor().await {
-        return Ok(base_url);
+    match wait_for_existing_supervisor().await {
+        ExistingSupervisor::Connected(base_url) => return Ok(base_url),
+        ExistingSupervisor::LiveNotReady(message) => bail!(message),
+        ExistingSupervisor::None => {}
     }
 
     let _startup_lock = acquire_supervisor_startup_lock().await?;
-    if let Some(base_url) = wait_for_existing_supervisor().await {
-        return Ok(base_url);
+    match wait_for_existing_supervisor().await {
+        ExistingSupervisor::Connected(base_url) => return Ok(base_url),
+        ExistingSupervisor::LiveNotReady(message) => bail!(message),
+        ExistingSupervisor::None => {}
     }
 
     let daemon_bin = find_daemon_binary()?;
     // The supervisor binds :0 and reports its real bound port via its endpoint
     // files; passing 0 (rather than a reserved port) removes the same
-    // reserve-release-rebind race the repo-daemon path had. Clear stale endpoint
-    // files so wait_for_supervisor_ready reads only this spawn's port.
-    remove_stale_supervisor_files();
+    // reserve-release-rebind race the repo-daemon path had. The prior
+    // ExistingSupervisor::None decision is the only spawn authorization; stale
+    // endpoint retirement has already completed under lifecycle + singleton
+    // authority, so this path never performs an unconditional unlink.
     info!(binary = %daemon_bin.display(), "starting supervisor (OS-assigned port)");
 
     let mut cmd = std::process::Command::new(&daemon_bin);
@@ -3872,6 +4355,11 @@ mod tests {
                 .await;
         handover.await.expect("handover task");
 
+        assert!(
+            matches!(verdict, ExistingDaemon::LiveNotReady(_)),
+            "a changed successor must forbid replacement even when it has not served yet: \
+             {verdict:?}"
+        );
         assert_eq!(
             read_pid_file(&root),
             Some(std::process::id()),
@@ -3891,23 +4379,35 @@ mod tests {
 
         // Same owner, same port: the judgement still describes what is on disk.
         write_endpoint_files(root, 4242, 51000);
-        assert!(remove_daemon_files_if_unchanged(root, 4242, Some(51000)));
+        assert_eq!(
+            remove_daemon_files_if_unchanged(root, 4242, Some(51000)),
+            DaemonEndpointRetirement::Retired
+        );
         assert!(!root.join("daemon.pid").exists());
 
         // A different owner republished.
         write_endpoint_files(root, 4243, 51000);
-        assert!(!remove_daemon_files_if_unchanged(root, 4242, Some(51000)));
+        assert!(matches!(
+            remove_daemon_files_if_unchanged(root, 4242, Some(51000)),
+            DaemonEndpointRetirement::Changed { .. }
+        ));
         assert!(root.join("daemon.pid").exists());
 
         // Same owner, but it rebound to a different port, so the endpoint the
         // verdict describes no longer exists either.
         write_endpoint_files(root, 4242, 51001);
-        assert!(!remove_daemon_files_if_unchanged(root, 4242, Some(51000)));
+        assert!(matches!(
+            remove_daemon_files_if_unchanged(root, 4242, Some(51000)),
+            DaemonEndpointRetirement::Changed { .. }
+        ));
         assert!(root.join("daemon.port").exists());
 
         // A judgement formed before any port existed must not match a
         // same-PID endpoint that has since published one.
-        assert!(!remove_daemon_files_if_unchanged(root, 4242, None));
+        assert!(matches!(
+            remove_daemon_files_if_unchanged(root, 4242, None),
+            DaemonEndpointRetirement::Changed { .. }
+        ));
         assert!(root.join("daemon.port").exists());
     }
 
@@ -3968,21 +4468,176 @@ mod tests {
             drop(authority);
         });
 
-        assert!(remove_daemon_files_if_unchanged_with_hook(
-            &root,
-            4242,
-            Some(51000),
-            || {
+        assert_eq!(
+            remove_daemon_files_if_unchanged_with_hook(&root, 4242, Some(51000), || {
                 comparison_tx.send(()).unwrap();
                 publication_started_rx
                     .recv_timeout(Duration::from_secs(5))
                     .expect("successor must attempt publication after comparison");
-            }
-        ));
+            }),
+            DaemonEndpointRetirement::Retired
+        );
         successor.join().expect("successor publisher");
 
         assert_eq!(read_pid_file(&root), Some(4243));
         assert_eq!(read_port_file(&root), Some(51001));
+    }
+
+    #[test]
+    fn legacy_singleton_publisher_after_comparison_is_preserved() {
+        use std::sync::mpsc;
+
+        let dir = tempfile::tempdir().unwrap();
+        let root = dir.path().to_path_buf();
+        write_endpoint_files(&root, 4242, 51000);
+
+        let (comparison_tx, comparison_rx) = mpsc::channel();
+        let (published_tx, published_rx) = mpsc::channel();
+        let (release_tx, release_rx) = mpsc::channel();
+        let legacy_root = root.clone();
+        let legacy = std::thread::spawn(move || {
+            comparison_rx
+                .recv_timeout(Duration::from_secs(5))
+                .expect("retirement must reach its endpoint comparison");
+            let singleton = OpenOptions::new()
+                .create(true)
+                .read(true)
+                .write(true)
+                .truncate(false)
+                .open(legacy_root.join("daemon.lock"))
+                .unwrap();
+            singleton.lock_exclusive().unwrap();
+            // Model a compatible old publisher: it owns daemon.lock and writes
+            // endpoint files without participating in daemon.lifecycle.
+            write_endpoint_files(&legacy_root, 4243, 51001);
+            published_tx.send(()).unwrap();
+            release_rx
+                .recv_timeout(Duration::from_secs(5))
+                .expect("test must retain the legacy lifetime lock");
+        });
+
+        let decision = remove_daemon_files_if_unchanged_with_hook(&root, 4242, Some(51000), || {
+            comparison_tx.send(()).unwrap();
+            published_rx
+                .recv_timeout(Duration::from_secs(5))
+                .expect("legacy publisher must acquire and publish");
+        });
+
+        assert_eq!(decision, DaemonEndpointRetirement::SingletonHeld);
+        assert_eq!(read_pid_file(&root), Some(4243));
+        assert_eq!(read_port_file(&root), Some(51001));
+        assert!(
+            root.join("daemon.lock").exists(),
+            "endpoint retirement must never unlink the singleton pathname"
+        );
+
+        release_tx.send(()).unwrap();
+        legacy.join().expect("legacy publisher");
+    }
+
+    #[tokio::test]
+    async fn contended_retirement_never_becomes_start_authorization() {
+        let dir = tempfile::tempdir().unwrap();
+        let root = dir.path();
+        write_endpoint_files(root, 999_999_999, closed_loopback_port());
+        let lifecycle = OpenOptions::new()
+            .create(true)
+            .read(true)
+            .write(true)
+            .truncate(false)
+            .open(root.join("daemon.lifecycle"))
+            .unwrap();
+        lifecycle.lock_exclusive().unwrap();
+
+        let verdict = wait_for_existing_daemon_within(
+            root,
+            Duration::from_millis(20),
+            Duration::from_millis(50),
+        )
+        .await;
+
+        assert!(
+            matches!(verdict, ExistingDaemon::LiveNotReady(_)),
+            "coordination contention must fail closed rather than authorize a spawn: {verdict:?}"
+        );
+        assert!(root.join("daemon.pid").exists());
+        assert!(root.join("daemon.port").exists());
+    }
+
+    #[tokio::test]
+    async fn unpublished_daemon_singleton_owner_forbids_spawn() {
+        let dir = tempfile::tempdir().unwrap();
+        let singleton = OpenOptions::new()
+            .create(true)
+            .read(true)
+            .write(true)
+            .truncate(false)
+            .open(dir.path().join("daemon.lock"))
+            .unwrap();
+        singleton.lock_exclusive().unwrap();
+
+        let verdict = wait_for_existing_daemon_within(
+            dir.path(),
+            Duration::from_millis(20),
+            Duration::from_millis(50),
+        )
+        .await;
+
+        assert!(
+            matches!(verdict, ExistingDaemon::LiveNotReady(_)),
+            "a process-lifetime singleton owner must forbid a loser spawn even before endpoint \
+             publication: {verdict:?}"
+        );
+        assert!(dir.path().join("daemon.lock").exists());
+    }
+
+    #[tokio::test]
+    async fn live_supervisor_health_failure_preserves_lifetime_owner_and_forbids_spawn() {
+        let dir = tempfile::tempdir().unwrap();
+        let singleton = OpenOptions::new()
+            .create(true)
+            .read(true)
+            .write(true)
+            .truncate(false)
+            .open(dir.path().join(SUPERVISOR_SINGLETON_FILE))
+            .unwrap();
+        singleton.lock_exclusive().unwrap();
+        let port = closed_loopback_port();
+        std::fs::write(
+            dir.path().join(SUPERVISOR_PID_FILE),
+            std::process::id().to_string(),
+        )
+        .unwrap();
+        std::fs::write(dir.path().join(SUPERVISOR_PORT_FILE), port.to_string()).unwrap();
+
+        let verdict = wait_for_existing_supervisor_in_dir(dir.path()).await;
+        assert!(
+            matches!(verdict, ExistingSupervisor::LiveNotReady(_)),
+            "a health hiccup from a live owner must forbid spawning: {verdict:?}"
+        );
+        assert!(dir.path().join(SUPERVISOR_PID_FILE).exists());
+        assert!(dir.path().join(SUPERVISOR_PORT_FILE).exists());
+        assert_eq!(
+            retire_supervisor_endpoint_if_unchanged(
+                dir.path(),
+                supervisor_endpoint_snapshot(dir.path())
+            ),
+            SupervisorEndpointRetirement::SingletonHeld,
+            "the process-lifetime singleton must independently prevent retirement"
+        );
+        assert!(
+            dir.path().join(SUPERVISOR_SINGLETON_FILE).exists(),
+            "the supervisor singleton pathname is never unlinked"
+        );
+
+        std::fs::remove_file(dir.path().join(SUPERVISOR_PID_FILE)).unwrap();
+        std::fs::remove_file(dir.path().join(SUPERVISOR_PORT_FILE)).unwrap();
+        let unpublished_owner = wait_for_existing_supervisor_in_dir(dir.path()).await;
+        assert!(
+            matches!(unpublished_owner, ExistingSupervisor::LiveNotReady(_)),
+            "a supervisor holding its lifetime singleton before publication must still forbid a \
+             second spawn: {unpublished_owner:?}"
+        );
     }
 
     #[tokio::test]
@@ -4268,7 +4923,14 @@ mod tests {
             ProcessLiveness::Dead
         });
 
-        assert_eq!(endpoint, None);
+        assert_eq!(
+            endpoint,
+            Some(LiveDaemonEndpoint {
+                pid: 4242,
+                port: 51001,
+            }),
+            "a changed generation must be returned for follow-up, never collapsed into absence"
+        );
         assert_eq!(read_pid_file(root), Some(4242));
         assert_eq!(read_port_file(root), Some(51001));
     }

--- a/crates/kin-cli/src/daemon_client.rs
+++ b/crates/kin-cli/src/daemon_client.rs
@@ -8,6 +8,7 @@
 //! auto-start logic so the CLI does not need to depend on `kin-daemon`.
 
 use anyhow::{anyhow, bail, Context, Result};
+use fs2::FileExt;
 use kin_core::KinLayout;
 use serde::Deserialize;
 use serde::Serialize;
@@ -1612,43 +1613,110 @@ pub fn daemon_required() -> bool {
     true
 }
 
-/// Whether a process with the given pid currently exists (signal 0 probe on
-/// unix). Used by the daemon lifecycle and by `kin daemon status`/`stop` to
-/// classify a recorded pid as live or stale.
-pub fn is_process_alive(pid: u32) -> bool {
+/// What the operating system can prove about a process identifier.
+///
+/// `Unknown` is deliberately ownership-preserving. Permission failures and
+/// other indeterminate probes are not evidence that a live owner disappeared,
+/// so callers may retire process-owned state only for [`ProcessLiveness::Dead`].
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ProcessLiveness {
+    Alive,
+    Dead,
+    Unknown,
+}
+
+impl ProcessLiveness {
+    /// Compatibility view for callers that only need a conservative boolean.
+    ///
+    /// Unknown owners are treated as possibly alive so existing status,
+    /// supervisor, session, and stop paths fail closed instead of pruning or
+    /// replacing authority they could not inspect.
+    pub fn may_be_alive(self) -> bool {
+        !matches!(self, Self::Dead)
+    }
+
+    fn authorizes_cleanup(self) -> bool {
+        matches!(self, Self::Dead)
+    }
+}
+
+/// Classify whether a process with the given PID exists.
+pub fn process_liveness(pid: u32) -> ProcessLiveness {
     #[cfg(unix)]
     {
         let Ok(pid) = libc::pid_t::try_from(pid) else {
-            return false;
+            return ProcessLiveness::Dead;
         };
         if unsafe { libc::kill(pid, 0) } == 0 {
-            return true;
+            return ProcessLiveness::Alive;
         }
-        std::io::Error::last_os_error().raw_os_error() == Some(libc::EPERM)
+        return match std::io::Error::last_os_error().raw_os_error() {
+            Some(libc::ESRCH) => ProcessLiveness::Dead,
+            Some(libc::EPERM) => ProcessLiveness::Unknown,
+            _ => ProcessLiveness::Unknown,
+        };
     }
     #[cfg(windows)]
     {
-        use windows_sys::Win32::Foundation::{CloseHandle, STILL_ACTIVE};
+        use windows_sys::Win32::Foundation::{CloseHandle, GetLastError};
         use windows_sys::Win32::System::Threading::{
             GetExitCodeProcess, OpenProcess, PROCESS_QUERY_LIMITED_INFORMATION,
         };
 
         let process = unsafe { OpenProcess(PROCESS_QUERY_LIMITED_INFORMATION, 0, pid) };
         if process.is_null() {
-            return false;
+            return classify_windows_process_probe(false, unsafe { GetLastError() }, false, 0);
         }
         let mut code = 0;
         let queried = unsafe { GetExitCodeProcess(process, &mut code) } != 0;
         let _ = unsafe { CloseHandle(process) };
-        queried && code == STILL_ACTIVE as u32
+        return classify_windows_process_probe(true, 0, queried, code);
     }
     #[cfg(not(any(unix, windows)))]
     {
         let _ = pid;
         // Unknown targets have no reliable process primitive here. Preserve
         // ownership rather than guessing "dead" and deleting live authority.
-        true
+        ProcessLiveness::Unknown
     }
+}
+
+#[cfg(windows)]
+fn classify_windows_process_probe(
+    opened: bool,
+    open_error: u32,
+    queried: bool,
+    exit_code: u32,
+) -> ProcessLiveness {
+    use windows_sys::Win32::Foundation::{ERROR_INVALID_PARAMETER, STILL_ACTIVE};
+
+    if !opened {
+        // OpenProcess documents ERROR_INVALID_PARAMETER for a PID that cannot
+        // identify a process. Access denied and every other failure are
+        // indeterminate: the process may be live but inaccessible.
+        return if open_error == ERROR_INVALID_PARAMETER {
+            ProcessLiveness::Dead
+        } else {
+            ProcessLiveness::Unknown
+        };
+    }
+    if !queried {
+        return ProcessLiveness::Unknown;
+    }
+    if exit_code == STILL_ACTIVE as u32 {
+        ProcessLiveness::Alive
+    } else {
+        ProcessLiveness::Dead
+    }
+}
+
+/// Whether a process may still be alive.
+///
+/// Retained as the conservative compatibility surface. Call
+/// [`process_liveness`] when a destructive decision needs to distinguish
+/// affirmative death from an indeterminate probe.
+pub fn is_process_alive(pid: u32) -> bool {
+    process_liveness(pid).may_be_alive()
 }
 
 /// Whether a TCP port on localhost is accepting connections. Distinguishes a
@@ -1679,8 +1747,64 @@ pub fn repo_daemon_port_path(kin_root: &Path) -> PathBuf {
 /// these itself on graceful shutdown; `kin daemon stop` also calls this after a
 /// confirmed stop so a later `status` never reports the dead endpoint as stale.
 pub fn remove_stale_daemon_files(kin_root: &Path) {
+    let Ok(_authority) = try_acquire_daemon_endpoint_authority(kin_root) else {
+        warn!(
+            repo = %kin_root.display(),
+            "preserving daemon endpoint because lifecycle authority is contended"
+        );
+        return;
+    };
+    let pid_path = repo_daemon_pid_path(kin_root);
+    match read_pid_file(kin_root) {
+        Some(pid) if process_liveness(pid).authorizes_cleanup() => {
+            remove_stale_daemon_files_uncoordinated(kin_root);
+        }
+        Some(pid) => {
+            warn!(
+                pid,
+                repo = %kin_root.display(),
+                "preserving daemon endpoint because its recorded owner may still be alive"
+            );
+        }
+        None if !pid_path.exists() => {
+            let _ = std::fs::remove_file(repo_daemon_port_path(kin_root));
+        }
+        None => {
+            warn!(
+                repo = %kin_root.display(),
+                "preserving daemon endpoint because its PID record is unparseable"
+            );
+        }
+    }
+}
+
+/// Remove a port record only when lifecycle authority proves there is still no
+/// PID owner. Used before startup and by setup hygiene; a successor publishing
+/// its complete endpoint takes the same authority and therefore survives.
+pub fn remove_orphaned_daemon_port(kin_root: &Path) -> bool {
+    let Ok(_authority) = try_acquire_daemon_endpoint_authority(kin_root) else {
+        return false;
+    };
+    if repo_daemon_pid_path(kin_root).exists() {
+        return false;
+    }
+    std::fs::remove_file(repo_daemon_port_path(kin_root)).is_ok()
+}
+
+fn remove_stale_daemon_files_uncoordinated(kin_root: &Path) {
     let _ = std::fs::remove_file(repo_daemon_pid_path(kin_root));
     let _ = std::fs::remove_file(repo_daemon_port_path(kin_root));
+}
+
+fn try_acquire_daemon_endpoint_authority(kin_root: &Path) -> std::io::Result<File> {
+    let authority = OpenOptions::new()
+        .create(true)
+        .read(true)
+        .write(true)
+        .truncate(false)
+        .open(kin_root.join("daemon.lifecycle"))?;
+    authority.try_lock_exclusive()?;
+    Ok(authority)
 }
 
 /// Remove endpoint files only while they still name the exact endpoint a verdict
@@ -1708,12 +1832,38 @@ fn remove_daemon_files_if_unchanged(
     judged_pid: u32,
     judged_port: Option<u16>,
 ) -> bool {
+    remove_daemon_files_if_unchanged_with_hook(kin_root, judged_pid, judged_port, || {})
+}
+
+fn remove_daemon_files_if_unchanged_with_hook<F>(
+    kin_root: &Path,
+    judged_pid: u32,
+    judged_port: Option<u16>,
+    after_comparison: F,
+) -> bool
+where
+    F: FnOnce(),
+{
+    // Current daemon publication and every current retirement path take this
+    // same never-unlinked authority. Holding it across the final comparison
+    // and both unlinks makes the judgement linearizable: a successor either
+    // publishes before the comparison (and is preserved) or after retirement.
+    let Ok(_authority) = try_acquire_daemon_endpoint_authority(kin_root) else {
+        warn!(
+            judged_pid,
+            ?judged_port,
+            repo = %kin_root.display(),
+            "preserving daemon endpoint because lifecycle authority is contended"
+        );
+        return false;
+    };
     let current_pid = read_pid_file(kin_root);
     let current_port = read_port_file(kin_root);
     let same_owner = current_pid == Some(judged_pid);
-    // An unchanged pid that republished its port is still a live daemon whose
-    // endpoint must survive, so a known port has to match too.
-    let same_endpoint = judged_port.is_none_or(|port| current_port == Some(port));
+    // An unchanged PID that gained or changed a port is a different endpoint
+    // generation (including PID reuse) and must survive. `None` means the
+    // judged endpoint had no port, not "ignore whichever port exists now."
+    let same_endpoint = current_port == judged_port;
     if !(same_owner && same_endpoint) {
         warn!(
             judged_pid,
@@ -1725,7 +1875,8 @@ fn remove_daemon_files_if_unchanged(
         );
         return false;
     }
-    remove_stale_daemon_files(kin_root);
+    after_comparison();
+    remove_stale_daemon_files_uncoordinated(kin_root);
     true
 }
 
@@ -1787,16 +1938,28 @@ pub fn supervisor_recorded_endpoint() -> (Option<u32>, Option<u16>) {
 }
 
 fn live_daemon_endpoint(kin_root: &Path) -> Option<LiveDaemonEndpoint> {
+    live_daemon_endpoint_with_probe(kin_root, process_liveness)
+}
+
+fn live_daemon_endpoint_with_probe(
+    kin_root: &Path,
+    probe: impl FnOnce(u32) -> ProcessLiveness,
+) -> Option<LiveDaemonEndpoint> {
     let pid = read_pid_file(kin_root)?;
-    if !is_process_alive(pid) {
+    // Capture both components before forming the liveness verdict. Reading the
+    // port afterward could bind a true "dead" result about the predecessor PID
+    // to a same-PID successor's newly published port, making the final
+    // compare-and-retire accept the wrong endpoint generation.
+    let port = read_port_file(kin_root);
+    if probe(pid).authorizes_cleanup() {
         // Compare-and-delete even here, where the window is only as wide as this
         // function: a successor that republished between the read and the
         // liveness check would otherwise lose its endpoint to a true statement
         // about its predecessor.
-        remove_daemon_files_if_unchanged(kin_root, pid, read_port_file(kin_root));
+        remove_daemon_files_if_unchanged(kin_root, pid, port);
         return None;
     }
-    let port = read_port_file(kin_root)?;
+    let port = port?;
     Some(LiveDaemonEndpoint { pid, port })
 }
 
@@ -3161,9 +3324,9 @@ pub async fn ensure_daemon_running_with_idle_timeout(
     // The daemon owns port selection: it binds :0 and reports the real bound
     // port via the port file. Passing 0 (rather than a port we reserve here)
     // eliminates the reserve-release-rebind race where a sibling process steals
-    // the port between our probe and the daemon's bind. Clear any stale port
-    // file first so wait_for_daemon_ready only reads the port this spawn writes.
-    let _ = std::fs::remove_file(kin_root.join("daemon.port"));
+    // the port between our probe and the daemon's bind. Clear an orphaned port
+    // only while lifecycle authority proves no successor PID was published.
+    remove_orphaned_daemon_port(kin_root);
 
     info!(binary = %daemon_bin.display(), repo = %working_dir.display(), "starting daemon (OS-assigned port)");
 
@@ -3741,6 +3904,85 @@ mod tests {
         write_endpoint_files(root, 4242, 51001);
         assert!(!remove_daemon_files_if_unchanged(root, 4242, Some(51000)));
         assert!(root.join("daemon.port").exists());
+
+        // A judgement formed before any port existed must not match a
+        // same-PID endpoint that has since published one.
+        assert!(!remove_daemon_files_if_unchanged(root, 4242, None));
+        assert!(root.join("daemon.port").exists());
+    }
+
+    #[test]
+    fn generic_stale_cleanup_preserves_a_live_successor() {
+        let dir = tempfile::tempdir().unwrap();
+        let root = dir.path();
+        write_endpoint_files(root, std::process::id(), 51000);
+
+        remove_stale_daemon_files(root);
+
+        assert_eq!(read_pid_file(root), Some(std::process::id()));
+        assert_eq!(read_port_file(root), Some(51000));
+    }
+
+    #[test]
+    fn orphan_port_cleanup_requires_an_absent_pid_record() {
+        let dir = tempfile::tempdir().unwrap();
+        let root = dir.path();
+        std::fs::write(root.join("daemon.pid"), "indeterminate").unwrap();
+        std::fs::write(root.join("daemon.port"), "51000").unwrap();
+
+        assert!(!remove_orphaned_daemon_port(root));
+        assert!(root.join("daemon.pid").exists());
+        assert!(root.join("daemon.port").exists());
+
+        std::fs::remove_file(root.join("daemon.pid")).unwrap();
+        assert!(remove_orphaned_daemon_port(root));
+        assert!(!root.join("daemon.port").exists());
+    }
+
+    #[test]
+    fn successor_publication_after_final_comparison_is_serialized() {
+        use std::sync::mpsc;
+
+        let dir = tempfile::tempdir().unwrap();
+        let root = dir.path().to_path_buf();
+        write_endpoint_files(&root, 4242, 51000);
+
+        let (comparison_tx, comparison_rx) = mpsc::channel();
+        let (publication_started_tx, publication_started_rx) = mpsc::channel();
+        let successor_root = root.clone();
+        let successor = std::thread::spawn(move || {
+            comparison_rx
+                .recv_timeout(Duration::from_secs(5))
+                .expect("retirement must reach the final comparison");
+            publication_started_tx.send(()).unwrap();
+            let authority = loop {
+                match try_acquire_daemon_endpoint_authority(&successor_root) {
+                    Ok(authority) => break authority,
+                    Err(error) if error.kind() == fs2::lock_contended_error().kind() => {
+                        std::thread::sleep(Duration::from_millis(5));
+                    }
+                    Err(error) => panic!("successor publication authority: {error}"),
+                }
+            };
+            write_endpoint_files(&successor_root, 4243, 51001);
+            drop(authority);
+        });
+
+        assert!(remove_daemon_files_if_unchanged_with_hook(
+            &root,
+            4242,
+            Some(51000),
+            || {
+                comparison_tx.send(()).unwrap();
+                publication_started_rx
+                    .recv_timeout(Duration::from_secs(5))
+                    .expect("successor must attempt publication after comparison");
+            }
+        ));
+        successor.join().expect("successor publisher");
+
+        assert_eq!(read_pid_file(&root), Some(4243));
+        assert_eq!(read_port_file(&root), Some(51001));
     }
 
     #[tokio::test]
@@ -3994,6 +4236,41 @@ mod tests {
             is_process_alive(std::process::id()),
             "the current process must be observable as alive"
         );
+        assert_eq!(process_liveness(std::process::id()), ProcessLiveness::Alive);
+    }
+
+    #[test]
+    fn indeterminate_liveness_never_retires_an_endpoint() {
+        let dir = tempfile::tempdir().unwrap();
+        let root = dir.path();
+        write_endpoint_files(root, 4242, 51000);
+
+        let endpoint = live_daemon_endpoint_with_probe(root, |_| ProcessLiveness::Unknown)
+            .expect("unknown liveness must preserve possible ownership");
+
+        assert_eq!(endpoint.pid, 4242);
+        assert_eq!(endpoint.port, 51000);
+        assert!(root.join("daemon.pid").exists());
+        assert!(root.join("daemon.port").exists());
+    }
+
+    #[test]
+    fn dead_verdict_cannot_bind_to_a_same_pid_successor_port() {
+        let dir = tempfile::tempdir().unwrap();
+        let root = dir.path();
+        write_endpoint_files(root, 4242, 51000);
+
+        let endpoint = live_daemon_endpoint_with_probe(root, |_| {
+            // Model PID reuse: the predecessor was judged by its original
+            // (pid, port), then a successor with the same numeric PID published
+            // a new endpoint generation before conditional retirement.
+            write_endpoint_files(root, 4242, 51001);
+            ProcessLiveness::Dead
+        });
+
+        assert_eq!(endpoint, None);
+        assert_eq!(read_pid_file(root), Some(4242));
+        assert_eq!(read_port_file(root), Some(51001));
     }
 
     #[cfg(windows)]
@@ -4002,6 +4279,35 @@ mod tests {
         assert!(
             !is_process_alive(u32::MAX),
             "an unopenable Windows process id must not wedge daemon ownership forever"
+        );
+    }
+
+    #[cfg(windows)]
+    #[test]
+    fn windows_access_denied_and_query_failure_are_indeterminate() {
+        use windows_sys::Win32::Foundation::{
+            ERROR_ACCESS_DENIED, ERROR_INVALID_PARAMETER, STILL_ACTIVE,
+        };
+
+        assert_eq!(
+            classify_windows_process_probe(false, ERROR_INVALID_PARAMETER, false, 0),
+            ProcessLiveness::Dead
+        );
+        assert_eq!(
+            classify_windows_process_probe(false, ERROR_ACCESS_DENIED, false, 0),
+            ProcessLiveness::Unknown
+        );
+        assert_eq!(
+            classify_windows_process_probe(true, 0, false, 0),
+            ProcessLiveness::Unknown
+        );
+        assert_eq!(
+            classify_windows_process_probe(true, 0, true, STILL_ACTIVE as u32),
+            ProcessLiveness::Alive
+        );
+        assert_eq!(
+            classify_windows_process_probe(true, 0, true, 0),
+            ProcessLiveness::Dead
         );
     }
 

--- a/crates/kin-cli/src/daemon_client.rs
+++ b/crates/kin-cli/src/daemon_client.rs
@@ -98,6 +98,19 @@ pub struct BuildResponse {
     pub built_at: String,
 }
 
+/// Response from `GET /readiness`.
+///
+/// `warming` is the daemon's explicit "alive but still materializing a
+/// cross-repo warm-up" signal. A client must never read a slow readiness as
+/// evidence that the daemon is dead.
+#[derive(Debug, Default, Deserialize)]
+struct ReadinessResponse {
+    #[serde(default)]
+    ready: bool,
+    #[serde(default)]
+    warming: bool,
+}
+
 #[derive(Debug, Deserialize)]
 struct SupervisorHealthResponse {
     status: String,
@@ -2131,54 +2144,117 @@ async fn acquire_supervisor_startup_lock() -> Result<StartupLock> {
     }
 }
 
-async fn validate_daemon_endpoint(
+/// What probing a recorded daemon endpoint established.
+///
+/// The distinction that matters is *why* an endpoint is unusable. A daemon that
+/// simply has not answered yet is alive; a daemon whose recorded process is gone,
+/// or that answered and proved the record wrong, is not. Only the latter may
+/// have its endpoint files cleared: deleting a live daemon's `daemon.pid` and
+/// `daemon.port` strands the repo, because the next start loses the singleton
+/// flock to the daemon still holding it and the lock reclaim has lost the pid it
+/// needed as evidence.
+#[derive(Debug)]
+enum EndpointVerdict {
+    /// The daemon answered readiness and health for this repo.
+    Serving(String),
+    /// Positive evidence the record is wrong: the recorded process is gone, or
+    /// the endpoint answered and named a different repo or a non-serving status.
+    /// Safe to clear and respawn.
+    Invalid(String),
+    /// The recorded owner process is alive but has not reported readiness.
+    /// Never clear: a busy daemon is not a dead one.
+    LiveNotReady {
+        pid: u32,
+        port: u16,
+        detail: String,
+        warming: bool,
+    },
+}
+
+/// Poll a recorded endpoint until it serves, proves itself invalid, or the
+/// budget runs out.
+///
+/// Reaching the deadline is not evidence of anything except that the daemon is
+/// slow, so it yields `LiveNotReady` rather than a verdict the caller could act
+/// on destructively.
+async fn probe_daemon_endpoint(
     kin_root: &Path,
     endpoint: LiveDaemonEndpoint,
     timeout: Duration,
-) -> Result<String> {
-    let working_dir = kin_root
-        .parent()
-        .ok_or_else(|| anyhow!("invalid .kin layout: no parent"))?;
+) -> EndpointVerdict {
+    let Some(working_dir) = kin_root.parent() else {
+        return EndpointVerdict::Invalid("invalid .kin layout: no parent".to_string());
+    };
     let base_url = format!("http://127.0.0.1:{}", endpoint.port);
     let client = daemon_health_client();
     let deadline = Instant::now() + timeout;
+    let mut warming = false;
 
     loop {
         if !is_process_alive(endpoint.pid) {
-            remove_stale_daemon_files(kin_root);
-            bail!("recorded daemon process {} is not alive", endpoint.pid);
+            return EndpointVerdict::Invalid(format!(
+                "recorded daemon process {} is not alive",
+                endpoint.pid
+            ));
         }
 
         let probe_error = match client.get(format!("{base_url}/readiness")).send().await {
             Ok(resp) if resp.status().is_success() => {
-                let health: HealthResponse = client
-                    .get(format!("{base_url}/health"))
-                    .send()
-                    .await
-                    .context("probe daemon health")?
-                    .error_for_status()
-                    .context("daemon health returned an error")?
-                    .json()
-                    .await
-                    .context("parse daemon health response")?;
-                validate_health_repo(&health, working_dir)?;
-                return Ok(base_url);
+                match probe_health_for_repo(&client, &base_url, working_dir).await {
+                    // The daemon answered and identified itself: whatever it
+                    // said is real evidence, so a mismatch is a genuinely stale
+                    // record rather than a slow start.
+                    Ok(()) => return EndpointVerdict::Serving(base_url),
+                    Err(err) => return EndpointVerdict::Invalid(err.to_string()),
+                }
             }
-            Ok(resp) => format!("readiness returned HTTP {}", resp.status()),
+            Ok(resp) => {
+                let status = resp.status();
+                // A 503 body carries the daemon's own readiness detail. It
+                // answered, so it is unambiguously alive; keep the last known
+                // warming signal if this particular body fails to parse.
+                match resp.json::<ReadinessResponse>().await {
+                    Ok(readiness) => {
+                        warming = readiness.warming;
+                        format!(
+                            "readiness returned HTTP {status} (ready={}, warming={})",
+                            readiness.ready, readiness.warming
+                        )
+                    }
+                    Err(_) => format!("readiness returned HTTP {status}"),
+                }
+            }
             Err(err) => err.to_string(),
         };
 
         if Instant::now() >= deadline {
-            bail!(
-                "daemon pid {} on {} failed readiness within {:.1}s: {}",
-                endpoint.pid,
-                base_url,
-                timeout.as_secs_f64(),
-                probe_error
-            );
+            return EndpointVerdict::LiveNotReady {
+                pid: endpoint.pid,
+                port: endpoint.port,
+                detail: probe_error,
+                warming,
+            };
         }
         tokio::time::sleep(Duration::from_millis(200)).await;
     }
+}
+
+async fn probe_health_for_repo(
+    client: &reqwest::Client,
+    base_url: &str,
+    working_dir: &Path,
+) -> Result<()> {
+    let health: HealthResponse = client
+        .get(format!("{base_url}/health"))
+        .send()
+        .await
+        .context("probe daemon health")?
+        .error_for_status()
+        .context("daemon health returned an error")?
+        .json()
+        .await
+        .context("parse daemon health response")?;
+    validate_health_repo(&health, working_dir)
 }
 
 async fn wait_for_daemon_ready(
@@ -2256,34 +2332,121 @@ async fn wait_for_daemon_ready(
     )
 }
 
-async fn wait_for_existing_daemon(kin_root: &Path) -> Option<String> {
-    let existing = live_daemon_endpoint(kin_root)?;
-    match validate_daemon_endpoint(
+/// What the caller should do about the endpoint currently recorded for a repo.
+#[derive(Debug)]
+enum ExistingDaemon {
+    /// Use this daemon.
+    Connected(String),
+    /// No usable record (absent, or proven wrong and now cleared). Start one.
+    None,
+    /// A live daemon owns this repo but is not serving yet. Starting a second
+    /// one would lose the singleton flock, so the caller must report this
+    /// instead.
+    LiveNotReady(String),
+}
+
+/// Resolve the endpoint recorded for this repo, escalating patience — never
+/// destruction — when the recorded owner is alive.
+///
+/// The short budget is the fast path for a healthy daemon. Exhausting it while
+/// the recorded process is still alive says only that the daemon is busy (a
+/// large graph load, a cross-repo warm-up), so this escalates to the same long
+/// budget a freshly spawned daemon gets rather than declaring it dead. Endpoint
+/// files are cleared only against positive evidence.
+async fn wait_for_existing_daemon(kin_root: &Path) -> ExistingDaemon {
+    wait_for_existing_daemon_within(
         kin_root,
-        existing,
         Duration::from_secs(existing_daemon_ready_timeout_secs()),
+        Duration::from_secs(daemon_ready_timeout_secs()),
     )
     .await
+}
+
+async fn wait_for_existing_daemon_within(
+    kin_root: &Path,
+    short: Duration,
+    patience: Duration,
+) -> ExistingDaemon {
+    let Some(existing) = live_daemon_endpoint(kin_root) else {
+        return ExistingDaemon::None;
+    };
+
+    let mut verdict = probe_daemon_endpoint(kin_root, existing, short).await;
+
+    if let EndpointVerdict::LiveNotReady {
+        pid, port, warming, ..
+    } = &verdict
     {
-        Ok(base_url) => {
+        warn!(
+            pid = *pid,
+            port = *port,
+            warming = *warming,
+            patience_secs = patience.as_secs(),
+            "daemon for this repo is alive but not ready yet; waiting rather than \
+             replacing a running daemon"
+        );
+        verdict =
+            probe_daemon_endpoint(kin_root, existing, patience.saturating_sub(short)).await;
+    }
+
+    match verdict {
+        EndpointVerdict::Serving(base_url) => {
             info!(
                 pid = existing.pid,
                 port = existing.port,
                 "connected to existing daemon"
             );
-            Some(base_url)
+            ExistingDaemon::Connected(base_url)
         }
-        Err(err) => {
+        EndpointVerdict::Invalid(reason) => {
             warn!(
                 pid = existing.pid,
                 port = existing.port,
-                error = %err,
-                "invalid daemon endpoint; clearing stale endpoint files"
+                error = %reason,
+                "daemon endpoint proved invalid; clearing stale endpoint files"
             );
             remove_stale_daemon_files(kin_root);
-            None
+            ExistingDaemon::None
         }
+        EndpointVerdict::LiveNotReady {
+            pid,
+            port,
+            detail,
+            warming,
+        } => ExistingDaemon::LiveNotReady(live_daemon_not_ready_message(
+            pid,
+            port,
+            &detail,
+            warming,
+            patience.as_secs(),
+        )),
     }
+}
+
+/// Message for a daemon that owns this repo, is alive, and never reported
+/// readiness inside the full budget.
+///
+/// It names the process so an operator can act on it. The old path silently
+/// deleted this daemon's endpoint files and spawned a replacement, which lost
+/// the singleton flock and left the repo unusable until the first daemon
+/// exited — with nothing in the output pointing at the daemon still running.
+fn live_daemon_not_ready_message(
+    pid: u32,
+    port: u16,
+    detail: &str,
+    warming: bool,
+    waited_secs: u64,
+) -> String {
+    let state = if warming {
+        "is still warming its cross-repo index"
+    } else {
+        "has not reported readiness"
+    };
+    format!(
+        "kin daemon (pid {pid}, port {port}) owns this repo and {state} after {waited_secs}s: \
+         {detail}. It is running, so kin will not replace it. Wait for it to finish, or stop it \
+         with `kin daemon stop`; raise KIN_DAEMON_READY_TIMEOUT_SECS if this repo needs longer."
+    )
 }
 
 async fn validate_supervisor_endpoint(endpoint: LiveDaemonEndpoint) -> Result<String> {
@@ -2499,13 +2662,19 @@ async fn supervisor_route_for_repo(kin_root: &Path, supervisor_url: &str) -> Opt
         pid: read_pid_file(kin_root).unwrap_or(std::process::id()),
         port,
     };
-    validate_daemon_endpoint(
+    // A supervisor route that does not check out just means this path cannot
+    // answer; the repo-local endpoint path decides what is stale. Nothing is
+    // cleared from here.
+    match probe_daemon_endpoint(
         kin_root,
         endpoint,
         Duration::from_secs(existing_daemon_ready_timeout_secs()),
     )
     .await
-    .ok()
+    {
+        EndpointVerdict::Serving(base_url) => Some(base_url),
+        EndpointVerdict::Invalid(_) | EndpointVerdict::LiveNotReady { .. } => None,
+    }
 }
 
 fn supervisor_route_for_repo_if_running(kin_root: &Path) -> Option<String> {
@@ -2689,18 +2858,26 @@ pub async fn ensure_daemon_running_with_idle_timeout(
         return Ok(base_url);
     }
 
-    if let Some(base_url) = wait_for_existing_daemon(kin_root).await {
-        register_repo_daemon_with_supervisor(kin_root, &base_url, &supervisor_url).await?;
-        return Ok(base_url);
+    match wait_for_existing_daemon(kin_root).await {
+        ExistingDaemon::Connected(base_url) => {
+            register_repo_daemon_with_supervisor(kin_root, &base_url, &supervisor_url).await?;
+            return Ok(base_url);
+        }
+        ExistingDaemon::LiveNotReady(message) => bail!(message),
+        ExistingDaemon::None => {}
     }
 
     let _startup_lock = acquire_startup_lock(kin_root).await?;
     if let Some(base_url) = supervisor_route_for_repo(kin_root, &supervisor_url).await {
         return Ok(base_url);
     }
-    if let Some(base_url) = wait_for_existing_daemon(kin_root).await {
-        register_repo_daemon_with_supervisor(kin_root, &base_url, &supervisor_url).await?;
-        return Ok(base_url);
+    match wait_for_existing_daemon(kin_root).await {
+        ExistingDaemon::Connected(base_url) => {
+            register_repo_daemon_with_supervisor(kin_root, &base_url, &supervisor_url).await?;
+            return Ok(base_url);
+        }
+        ExistingDaemon::LiveNotReady(message) => bail!(message),
+        ExistingDaemon::None => {}
     }
 
     let daemon_bin = find_daemon_binary()?;
@@ -3038,6 +3215,132 @@ mod tests {
             !tail.contains("384, got 768"),
             "stale prior-run line must not be surfaced even when fresh output exists: {tail}"
         );
+    }
+
+    // ── FIR-1583: a busy daemon must never be treated as a dead one ───────
+    //
+    // The deadlock chain started here. A daemon that did not answer readiness
+    // inside a short fixed budget had its `daemon.pid` and `daemon.port`
+    // deleted while it was still running and still holding the per-repo
+    // singleton flock. The replacement daemon then lost that flock, and with
+    // `daemon.pid` gone the lock reclaim had no owner evidence left, so every
+    // later command repeated the same failure until the first daemon exited.
+    // A timeout is evidence that a daemon is slow, never that it is dead.
+
+    /// A loopback port with nothing listening: connections are refused
+    /// immediately, so the probe exercises the unreachable-endpoint path
+    /// without waiting on a real timeout.
+    fn closed_loopback_port() -> u16 {
+        let listener = std::net::TcpListener::bind("127.0.0.1:0").unwrap();
+        let port = listener.local_addr().unwrap().port();
+        drop(listener);
+        port
+    }
+
+    fn write_endpoint_files(kin_root: &Path, pid: u32, port: u16) {
+        std::fs::write(kin_root.join("daemon.pid"), pid.to_string()).unwrap();
+        std::fs::write(kin_root.join("daemon.port"), port.to_string()).unwrap();
+    }
+
+    #[tokio::test]
+    async fn unready_endpoint_with_a_live_owner_is_preserved_not_clobbered() {
+        let dir = tempfile::tempdir().unwrap();
+        let root = dir.path();
+        // The recorded owner is this test process, so it is provably alive —
+        // exactly the daemon-still-loading shape.
+        write_endpoint_files(root, std::process::id(), closed_loopback_port());
+
+        let verdict = wait_for_existing_daemon_within(
+            root,
+            Duration::from_millis(50),
+            Duration::from_millis(150),
+        )
+        .await;
+
+        assert!(
+            matches!(verdict, ExistingDaemon::LiveNotReady(_)),
+            "a live owner that has not answered must be reported, not replaced: {verdict:?}"
+        );
+        assert!(
+            root.join("daemon.pid").exists(),
+            "a live daemon's pid file must survive a readiness timeout"
+        );
+        assert!(
+            root.join("daemon.port").exists(),
+            "a live daemon's port file must survive a readiness timeout"
+        );
+    }
+
+    #[tokio::test]
+    async fn unready_endpoint_names_the_holder_and_refuses_to_replace_it() {
+        let dir = tempfile::tempdir().unwrap();
+        let root = dir.path();
+        let pid = std::process::id();
+        write_endpoint_files(root, pid, closed_loopback_port());
+
+        let ExistingDaemon::LiveNotReady(message) = wait_for_existing_daemon_within(
+            root,
+            Duration::from_millis(50),
+            Duration::from_millis(150),
+        )
+        .await
+        else {
+            panic!("a live-but-unready owner must produce a LiveNotReady verdict");
+        };
+
+        assert!(
+            message.contains(&pid.to_string()),
+            "the refusal must name the process that owns the repo: {message}"
+        );
+        assert!(
+            message.contains("kin daemon stop"),
+            "the refusal must tell the operator how to act: {message}"
+        );
+    }
+
+    #[tokio::test]
+    async fn dead_owner_endpoint_is_cleared_so_a_replacement_can_start() {
+        // The other side of the rule: a recorded owner that is provably gone is
+        // positive evidence, so the record is cleared and a start proceeds.
+        let dir = tempfile::tempdir().unwrap();
+        let root = dir.path();
+        write_endpoint_files(root, 999_999_999, closed_loopback_port());
+
+        let verdict = wait_for_existing_daemon_within(
+            root,
+            Duration::from_millis(50),
+            Duration::from_millis(150),
+        )
+        .await;
+
+        assert!(
+            matches!(verdict, ExistingDaemon::None),
+            "a dead owner must not block a fresh start: {verdict:?}"
+        );
+        assert!(!root.join("daemon.pid").exists());
+        assert!(!root.join("daemon.port").exists());
+    }
+
+    #[test]
+    fn not_ready_message_distinguishes_warming_from_silent() {
+        let warming = live_daemon_not_ready_message(4242, 51000, "HTTP 503", true, 300);
+        assert!(
+            warming.contains("warming"),
+            "a daemon that reported warming must be described as warming: {warming}"
+        );
+        let silent = live_daemon_not_ready_message(4242, 51000, "connection refused", false, 300);
+        assert!(
+            silent.contains("has not reported readiness"),
+            "a silent daemon must not be described as warming: {silent}"
+        );
+        for message in [&warming, &silent] {
+            assert!(message.contains("4242"), "must name the pid: {message}");
+            assert!(message.contains("51000"), "must name the port: {message}");
+            assert!(
+                message.contains("will not replace it"),
+                "must state that kin refuses to replace a running daemon: {message}"
+            );
+        }
     }
 
     #[test]

--- a/crates/kin-core/src/env_registry.rs
+++ b/crates/kin-core/src/env_registry.rs
@@ -217,6 +217,7 @@ pub const OPERATIONAL: &[EnvVarSpec] = &[
     EnvVarSpec { name: "KIN_SUPERVISOR_BIND_HOST", kind: Kind::Str, default: "", sensitivity: Sensitivity::Operational, summary: "host/interface the supervisor binds to" },
     EnvVarSpec { name: "KIN_SUPERVISOR_REQUIRE_TOKEN", kind: Kind::Bool, default: "false", sensitivity: Sensitivity::Operational, summary: "require a bearer token for supervisor requests" },
     EnvVarSpec { name: "KIN_SUPERVISOR_IDLE_TIMEOUT_SECS", kind: Kind::Secs, default: "3600", sensitivity: Sensitivity::Operational, summary: "supervisor auto-shutdown idle period; 0 disables idle shutdown" },
+    EnvVarSpec { name: "KIN_SUPERVISOR_STARTUP_GENERATION", kind: Kind::Str, default: "", sensitivity: Sensitivity::Operational, summary: "internal versioned supervisor launch capability generation" },
     EnvVarSpec { name: "KIN_SUPERVISOR_REAP_CPU", kind: Kind::Bool, default: "true", sensitivity: Sensitivity::Operational, summary: "enable the CPU-heuristic zombie reaper; set falsey to disable" },
     EnvVarSpec { name: "KIN_SUPERVISOR_REAP_CPU_PERCENT", kind: Kind::NonNegF32, default: "", sensitivity: Sensitivity::Operational, summary: "CPU percent threshold for the reaper heuristic" },
     EnvVarSpec { name: "KIN_SUPERVISOR_REAP_CPU_SWEEPS", kind: Kind::Usize, default: "", sensitivity: Sensitivity::Operational, summary: "consecutive sweeps over threshold before reaping" },

--- a/crates/kin-daemon/src/api.rs
+++ b/crates/kin-daemon/src/api.rs
@@ -17229,12 +17229,13 @@ mod tests {
             crate::lifecycle::without_blocking_runtime_worker(move || {
                 let _ = warm_started_tx.send(());
                 // Bounded so a failing assertion below still lets the runtime
-                // shut down instead of wedging the test binary.
-                let _ = release_rx.recv_timeout(Duration::from_secs(30));
+                // shut down instead of wedging the test binary. Longer than the
+                // assertion cap so the release below is the normal exit.
+                let _ = release_rx.recv_timeout(Duration::from_secs(120));
             });
         });
         warm_started_rx
-            .recv_timeout(Duration::from_secs(10))
+            .recv_timeout(Duration::from_secs(30))
             .expect("the warm-up must start");
 
         let (answered_tx, answered_rx) = mpsc::channel::<StatusCode>();
@@ -17247,7 +17248,10 @@ mod tests {
             let _ = answered_tx.send(response.status());
         });
 
-        let status = answered_rx.recv_timeout(Duration::from_secs(10)).expect(
+        // Generous enough that whole-workspace CPU contention cannot trip it,
+        // while still bounded: a warm-up that parks the worker never answers at
+        // any cap, so this fails rather than hangs.
+        let status = answered_rx.recv_timeout(Duration::from_secs(60)).expect(
             "readiness must be answered while a sibling warm-up blocks; a warm-up that \
              holds the runtime worker makes a live daemon indistinguishable from a dead one",
         );

--- a/crates/kin-daemon/src/api.rs
+++ b/crates/kin-daemon/src/api.rs
@@ -190,6 +190,10 @@ pub struct HealthResponse {
     pub graph_loaded: bool,
     pub reconciliation_status: String,
     pub repo_id: String,
+    /// Exact local workspace authority. Hosted snapshot daemons do not carry a
+    /// local workspace and report `null`.
+    #[serde(default)]
+    pub workspace_id: Option<String>,
     pub repo_root: String,
     pub pid: u32,
     #[serde(default)]
@@ -1731,6 +1735,9 @@ async fn health(
         graph_loaded,
         reconciliation_status: state.reconciliation_status_str().to_string(),
         repo_id: primary_repo_id(&state),
+        workspace_id: state
+            .local_repository_workspace_id()
+            .map(|workspace_id| workspace_id.to_string()),
         repo_root: state
             .layout
             .working_dir()
@@ -17164,6 +17171,9 @@ mod tests {
     #[tokio::test]
     async fn health_includes_version_string() {
         let state = test_state();
+        let expected_workspace_id = state
+            .local_repository_workspace_id()
+            .map(|workspace_id| workspace_id.to_string());
         let app = router(state);
         let response = app
             .oneshot(Request::get("/health").body(Body::empty()).unwrap())
@@ -17180,6 +17190,10 @@ mod tests {
         let json: HealthResponse = serde_json::from_slice(&body).unwrap();
         assert!(!json.version.is_empty());
         assert_eq!(json.reconciliation_status, "idle");
+        assert_eq!(
+            json.workspace_id, expected_workspace_id,
+            "health must name the exact local workspace authority"
+        );
     }
 
     #[tokio::test]
@@ -17225,39 +17239,62 @@ mod tests {
 
         let (warm_started_tx, warm_started_rx) = mpsc::channel::<()>();
         let (release_tx, release_rx) = mpsc::channel::<()>();
+        let release_rx = Arc::new(std::sync::Mutex::new(release_rx));
+        let hook_release_rx = Arc::clone(&release_rx);
+        state.set_spine_initialization_test_hook(Some(Arc::new(move || {
+            let _ = warm_started_tx.send(());
+            // Bounded so a failing assertion still lets the runtime shut down.
+            let _ = hook_release_rx
+                .lock()
+                .unwrap_or_else(std::sync::PoisonError::into_inner)
+                .recv_timeout(Duration::from_secs(120));
+        })));
+
+        let (warm_finished_tx, warm_finished_rx) = mpsc::channel::<bool>();
+        let warm_state = Arc::clone(&state);
         runtime.spawn(async move {
-            crate::lifecycle::without_blocking_runtime_worker(move || {
-                let _ = warm_started_tx.send(());
-                // Bounded so a failing assertion below still lets the runtime
-                // shut down instead of wedging the test binary. Longer than the
-                // assertion cap so the release below is the normal exit.
-                let _ = release_rx.recv_timeout(Duration::from_secs(120));
-            });
+            let _ = warm_finished_tx.send(warm_state.ensure_spine().is_some());
         });
         warm_started_rx
             .recv_timeout(Duration::from_secs(30))
-            .expect("the warm-up must start");
+            .expect("the real ensure_spine warm-up must start");
 
-        let (answered_tx, answered_rx) = mpsc::channel::<StatusCode>();
+        let (answered_tx, answered_rx) = mpsc::channel::<(StatusCode, bool)>();
         let probe_state = Arc::clone(&state);
         runtime.spawn(async move {
             let response = router(probe_state)
                 .oneshot(Request::get("/readiness").body(Body::empty()).unwrap())
                 .await
                 .expect("readiness request");
-            let _ = answered_tx.send(response.status());
+            let status = response.status();
+            let body = axum::body::to_bytes(response.into_body(), 64 * 1024)
+                .await
+                .expect("readiness body");
+            let readiness: ReadinessResponse =
+                serde_json::from_slice(&body).expect("readiness JSON");
+            let _ = answered_tx.send((status, readiness.warming));
         });
 
         // Generous enough that whole-workspace CPU contention cannot trip it,
         // while still bounded: a warm-up that parks the worker never answers at
         // any cap, so this fails rather than hangs.
-        let status = answered_rx.recv_timeout(Duration::from_secs(60)).expect(
+        let answer = answered_rx.recv_timeout(Duration::from_secs(60));
+        let _ = release_tx.send(());
+        let warmed = warm_finished_rx.recv_timeout(Duration::from_secs(60));
+
+        let (status, warming) = answer.expect(
             "readiness must be answered while a sibling warm-up blocks; a warm-up that \
              holds the runtime worker makes a live daemon indistinguishable from a dead one",
         );
         assert_eq!(status, StatusCode::OK);
-
-        let _ = release_tx.send(());
+        assert!(
+            warming,
+            "readiness must identify the actual ensure_spine pass as warming"
+        );
+        assert!(
+            warmed.expect("spine initialization must finish after release"),
+            "spine initialization must publish after release"
+        );
     }
 
     #[tokio::test]

--- a/crates/kin-daemon/src/api.rs
+++ b/crates/kin-daemon/src/api.rs
@@ -249,6 +249,11 @@ pub struct HealthResponse {
     /// complete citable measurement source during this daemon lifetime.
     #[serde(default)]
     pub coordination_event_persist_failures: Option<u64>,
+    /// A cross-repo spine warm-up is loading sibling repository graphs right
+    /// now. The daemon is alive and serving its own repo throughout; this is
+    /// the signal that distinguishes "busy" from "dead".
+    #[serde(default)]
+    pub spine_warming: bool,
     pub build: BuildResponse,
 }
 
@@ -264,9 +269,14 @@ pub struct BuildResponse {
 }
 
 /// Readiness response.
-#[derive(Debug, Serialize)]
+#[derive(Debug, Serialize, serde::Deserialize)]
 pub struct ReadinessResponse {
     pub ready: bool,
+    /// The daemon is alive and its own repo is served, but a cross-repo spine
+    /// warm-up is still materializing sibling graphs. Clients must read this as
+    /// alive-and-waiting; it is never evidence that the daemon is dead.
+    #[serde(default)]
+    pub warming: bool,
 }
 
 /// JSON-friendly intent payload for CLI and adapter consumers.
@@ -1746,6 +1756,7 @@ async fn health(
             ),
         ),
         coordination_event_persist_failures: Some(coordination_event_persist_failures),
+        spine_warming: state.spine_warming(),
         build: current_build_response(),
     }))
 }
@@ -1753,17 +1764,32 @@ async fn health(
 /// GET /readiness — returns 200 when initialized, 503 otherwise.
 /// An initialized daemon has either loaded a snapshot or completed at least
 /// one reconciliation cycle. An empty but initialized workspace is ready.
+///
+/// Readiness is deliberately independent of cross-repo spine warm-up: this
+/// daemon's own repo is what a client connecting to it needs served, and a
+/// sibling warm-up that gated readiness would report a busy daemon as a dead
+/// one. A warm-up in progress is reported through `warming` instead.
 async fn readiness(State(state): State<Arc<DaemonState>>) -> impl IntoResponse {
     let initialized = state
         .is_initialized
         .load(std::sync::atomic::Ordering::Relaxed);
+    let warming = state.spine_warming();
 
     if initialized {
-        (StatusCode::OK, Json(ReadinessResponse { ready: true }))
+        (
+            StatusCode::OK,
+            Json(ReadinessResponse {
+                ready: true,
+                warming,
+            }),
+        )
     } else {
         (
             StatusCode::SERVICE_UNAVAILABLE,
-            Json(ReadinessResponse { ready: false }),
+            Json(ReadinessResponse {
+                ready: false,
+                warming,
+            }),
         )
     }
 }
@@ -17168,6 +17194,93 @@ mod tests {
             .await
             .unwrap();
         assert_eq!(response.status(), StatusCode::OK);
+    }
+
+    // ── FIR-1583: readiness must survive a blocking warm-up ───────────────
+    //
+    // Sibling spine warm-up is a synchronous join that can run for minutes, and
+    // it is reached from async request handlers. Run inline it parks a runtime
+    // worker, and a daemon whose workers are all parked answers nothing — which
+    // is how a live, warming daemon came to look dead to a client and had its
+    // endpoint files clobbered.
+    //
+    // The runtime here has exactly one worker, so a warm-up that fails to release
+    // it starves everything. The assertion is made from the test thread (which is
+    // NOT on that runtime) with a hard wall-clock cap, so the old behavior fails
+    // this test in bounded time instead of hanging.
+    #[test]
+    fn readiness_is_answered_while_a_blocking_warm_up_holds_the_runtime() {
+        use std::sync::mpsc;
+
+        let runtime = tokio::runtime::Builder::new_multi_thread()
+            .worker_threads(1)
+            .enable_all()
+            .build()
+            .expect("build single-worker runtime");
+
+        let state = runtime.block_on(async { test_state() });
+        state
+            .is_initialized
+            .store(true, std::sync::atomic::Ordering::Relaxed);
+
+        let (warm_started_tx, warm_started_rx) = mpsc::channel::<()>();
+        let (release_tx, release_rx) = mpsc::channel::<()>();
+        runtime.spawn(async move {
+            crate::lifecycle::without_blocking_runtime_worker(move || {
+                let _ = warm_started_tx.send(());
+                // Bounded so a failing assertion below still lets the runtime
+                // shut down instead of wedging the test binary.
+                let _ = release_rx.recv_timeout(Duration::from_secs(30));
+            });
+        });
+        warm_started_rx
+            .recv_timeout(Duration::from_secs(10))
+            .expect("the warm-up must start");
+
+        let (answered_tx, answered_rx) = mpsc::channel::<StatusCode>();
+        let probe_state = Arc::clone(&state);
+        runtime.spawn(async move {
+            let response = router(probe_state)
+                .oneshot(Request::get("/readiness").body(Body::empty()).unwrap())
+                .await
+                .expect("readiness request");
+            let _ = answered_tx.send(response.status());
+        });
+
+        let status = answered_rx.recv_timeout(Duration::from_secs(10)).expect(
+            "readiness must be answered while a sibling warm-up blocks; a warm-up that \
+             holds the runtime worker makes a live daemon indistinguishable from a dead one",
+        );
+        assert_eq!(status, StatusCode::OK);
+
+        let _ = release_tx.send(());
+    }
+
+    #[tokio::test]
+    async fn readiness_reports_the_warming_state_it_is_in() {
+        // Readiness is about this daemon's own repo, so it stays 200 during a
+        // cross-repo warm-up. `warming` is how a client learns the daemon is
+        // busy rather than idle — the signal that makes waiting the correct
+        // response instead of respawning.
+        let state = test_state();
+        state
+            .is_initialized
+            .store(true, std::sync::atomic::Ordering::Relaxed);
+
+        let response = router(Arc::clone(&state))
+            .oneshot(Request::get("/readiness").body(Body::empty()).unwrap())
+            .await
+            .unwrap();
+        assert_eq!(response.status(), StatusCode::OK);
+        let body = axum::body::to_bytes(response.into_body(), 64 * 1024)
+            .await
+            .unwrap();
+        let readiness: ReadinessResponse = serde_json::from_slice(&body).unwrap();
+        assert!(readiness.ready);
+        assert!(
+            !readiness.warming,
+            "an idle daemon must not claim to be warming"
+        );
     }
 
     // -----------------------------------------------------------------------

--- a/crates/kin-daemon/src/api.rs
+++ b/crates/kin-daemon/src/api.rs
@@ -17196,7 +17196,7 @@ mod tests {
         assert_eq!(response.status(), StatusCode::OK);
     }
 
-    // ── FIR-1583: readiness must survive a blocking warm-up ───────────────
+    // ── Readiness must survive a blocking warm-up ─────────────────────────
     //
     // Sibling spine warm-up is a synchronous join that can run for minutes, and
     // it is reached from async request handlers. Run inline it parks a runtime

--- a/crates/kin-daemon/src/bin/kin-daemon.rs
+++ b/crates/kin-daemon/src/bin/kin-daemon.rs
@@ -354,9 +354,14 @@ async fn async_main() -> i32 {
         println!(
             "{}",
             serde_json::json!({
-                "schema": "kin.daemon.compat.v1",
+                "schema": "kin.daemon.compat.v2",
                 "version": env!("CARGO_PKG_VERSION"),
                 "graph_snapshot_version": kin_db::GraphSnapshot::CURRENT_VERSION,
+                "supervisor_startup_protocol": 2,
+                "supervisor_startup_capabilities": [
+                    "generation-adoption-ack-v2",
+                    "legacy-directory-sentinel-v1",
+                ],
                 "build": {
                     "sha": build.sha,
                     "dirty": build.dirty,

--- a/crates/kin-daemon/src/bin/kin-daemon.rs
+++ b/crates/kin-daemon/src/bin/kin-daemon.rs
@@ -12,7 +12,7 @@ use std::process;
 use std::time::Duration;
 
 use kin_core::KinLayout;
-use kin_daemon::{run, DaemonConfig, DaemonState};
+use kin_daemon::{acquire_daemon_authority, run_with_authority, DaemonConfig, DaemonState};
 use tracing_subscriber::EnvFilter;
 
 kin_buildinfo::embed_update_build_identity!(
@@ -173,6 +173,17 @@ fn create_state(
             )?)
         }
     }
+}
+
+fn acquire_before_state<T>(
+    kin_root: &Path,
+    acquire: impl FnOnce(&Path) -> kin_daemon::Result<kin_daemon::lifecycle::DaemonLock>,
+    create: impl FnOnce() -> std::result::Result<T, Box<dyn std::error::Error>>,
+) -> std::result::Result<(T, kin_daemon::lifecycle::DaemonLock), Box<dyn std::error::Error>> {
+    let authority =
+        acquire(kin_root).map_err(|error| Box::new(error) as Box<dyn std::error::Error>)?;
+    let state = create()?;
+    Ok((state, authority))
 }
 
 #[cfg(feature = "gcs")]
@@ -408,10 +419,13 @@ async fn async_main() -> i32 {
         }
     };
 
-    let state = match create_state(layout, &args.storage, &repo_id) {
-        Ok(state) => state,
+    let kin_root = layout.root().to_path_buf();
+    let (state, authority) = match acquire_before_state(&kin_root, acquire_daemon_authority, || {
+        create_state(layout, &args.storage, &repo_id)
+    }) {
+        Ok(opened) => opened,
         Err(error) => {
-            eprintln!("kin-daemon: failed to open daemon state: {error}");
+            eprintln!("kin-daemon: failed to acquire daemon authority or open state: {error}");
             process::exit(1);
         }
     };
@@ -451,7 +465,7 @@ async fn async_main() -> i32 {
         ..DaemonConfig::default()
     };
 
-    if let Err(error) = run(state, config).await {
+    if let Err(error) = run_with_authority(state, config, authority).await {
         eprintln!("kin-daemon: {error}");
         return 1;
     }
@@ -462,6 +476,7 @@ async fn async_main() -> i32 {
 mod tests {
     use super::*;
     use std::io::Write;
+    use std::sync::atomic::{AtomicBool, Ordering};
     use std::sync::{Arc, Mutex};
     use tracing::level_filters::LevelFilter;
     use tracing_subscriber::fmt::MakeWriter;
@@ -471,6 +486,32 @@ mod tests {
     /// the process's stdout/stderr to.
     #[derive(Clone)]
     struct SharedBuf(Arc<Mutex<Vec<u8>>>);
+
+    #[test]
+    fn singleton_authority_is_acquired_before_state_construction() {
+        let dir = tempfile::tempdir().unwrap();
+        let root = dir.path();
+        let first = kin_daemon::lifecycle::acquire_singleton_lock(root)
+            .expect("first lock IO")
+            .expect("first starter must own the repo");
+        let state_constructor_called = AtomicBool::new(false);
+
+        let opened = acquire_before_state(
+            root,
+            |root| kin_daemon::daemon::acquire_daemon_authority_within(root, Duration::ZERO),
+            || {
+                state_constructor_called.store(true, Ordering::SeqCst);
+                Ok::<_, Box<dyn std::error::Error>>(())
+            },
+        );
+
+        assert!(opened.is_err(), "the contending starter must be refused");
+        assert!(
+            !state_constructor_called.load(Ordering::SeqCst),
+            "state construction must not run before singleton authority is acquired"
+        );
+        drop(first);
+    }
 
     impl Write for SharedBuf {
         fn write(&mut self, buf: &[u8]) -> std::io::Result<usize> {

--- a/crates/kin-daemon/src/bin/kin-daemon.rs
+++ b/crates/kin-daemon/src/bin/kin-daemon.rs
@@ -361,6 +361,7 @@ async fn async_main() -> i32 {
                 "supervisor_startup_capabilities": [
                     "generation-adoption-ack-v2",
                     "legacy-directory-sentinel-v1",
+                    "bounded-legacy-rollback-v1",
                 ],
                 "build": {
                     "sha": build.sha,

--- a/crates/kin-daemon/src/daemon.rs
+++ b/crates/kin-daemon/src/daemon.rs
@@ -2,7 +2,7 @@
 // Copyright 2026 Firelock, LLC
 
 use std::sync::Arc;
-use std::time::Duration;
+use std::time::{Duration, Instant};
 
 use tracing::{debug, error, info, warn};
 
@@ -56,6 +56,50 @@ fn should_enable_lsp_enrichment(config_enabled: bool, filesystem_reconcile_disab
     config_enabled && !filesystem_reconcile_disabled
 }
 
+/// Acquire the process-lifetime repository authority before daemon state opens.
+pub fn acquire_daemon_authority(
+    kin_root: &std::path::Path,
+) -> Result<crate::lifecycle::DaemonLock> {
+    acquire_daemon_authority_within(kin_root, crate::lifecycle::SINGLETON_LOCK_RETRY_BUDGET)
+}
+
+/// Acquire process-lifetime repository authority with one caller-owned budget.
+///
+/// Exposed so the process entrypoint can acquire before constructing
+/// [`DaemonState`], and so deterministic tests can use a short deadline without
+/// changing the production retry contract.
+pub fn acquire_daemon_authority_within(
+    kin_root: &std::path::Path,
+    budget: Duration,
+) -> Result<crate::lifecycle::DaemonLock> {
+    let deadline = Instant::now() + budget;
+    let reclaim = match crate::lifecycle::acquire_singleton_lock_within(kin_root, Duration::ZERO) {
+        Ok(Some(lock)) => return Ok(lock),
+        Ok(None) => {
+            // Current automatic recovery deliberately refuses pathname
+            // replacement at the mixed-version boundary. It still resolves
+            // and reports owner evidence before the bounded retry. Both that
+            // resolution and retry share this caller's one deadline.
+            crate::lifecycle::reclaim_stale_locks_within(
+                kin_root,
+                deadline.saturating_duration_since(Instant::now()),
+            )
+        }
+        Err(error) => return Err(DaemonError::Io(error)),
+    };
+
+    match crate::lifecycle::acquire_singleton_lock_within(
+        kin_root,
+        deadline.saturating_duration_since(Instant::now()),
+    ) {
+        Ok(Some(lock)) => Ok(lock),
+        Ok(None) => Err(DaemonError::RepoOwnedByAnotherDaemon(
+            singleton_contention_message(kin_root, reclaim),
+        )),
+        Err(error) => Err(DaemonError::Io(error)),
+    }
+}
+
 /// Actionable refusal text for a daemon that lost the per-repo singleton lock.
 ///
 /// Reads the holder from disk evidence and renders it. Kept split from
@@ -105,13 +149,26 @@ fn format_singleton_contention(
         ),
         _ => "stop any remaining kin-daemon process for this repo, then retry".to_string(),
     };
+    let compatibility_boundary = match reclaim {
+        crate::lifecycle::StaleLockReclaim::CoordinationUnavailable(reason) => {
+            format!(
+                " Automatic lock-file retirement was refused because safe coordination is \
+                 unavailable: {reason}. Replacing the inode cannot be proven safe."
+            )
+        }
+        _ => String::new(),
+    };
     if reclaimed > 0 {
         format!(
             "refusing to start a second daemon: {context} (reclaimed {reclaimed} stale lock \
-             file(s) first, and the lock is still contended). To proceed, {remedy}."
+             file(s) first, and the lock is still contended).{compatibility_boundary} To proceed, \
+             {remedy}."
         )
     } else {
-        format!("refusing to start a second daemon: {context}. To proceed, {remedy}.")
+        format!(
+            "refusing to start a second daemon: {context}.{compatibility_boundary} To proceed, \
+             {remedy}."
+        )
     }
 }
 
@@ -569,66 +626,21 @@ async fn enrich_single_entity(
 /// 3. The orphan session sweeper (Phase 7)
 ///
 /// All run concurrently. Any shutting down causes the others to stop.
-pub async fn run(mut state: DaemonState, config: DaemonConfig) -> Result<()> {
-    // Singleton guard: at most one daemon per repo. Acquire an exclusive OS
-    // lock on `.kin/daemon.lock` before any side effects (no LSP discovery, no
-    // pid/port files, no bound port). If another live daemon already owns this
-    // repo, refuse to start a second process that would fight over the same
-    // graph/kindb state — exit cleanly so the caller treats it as a no-op. The
-    // kernel releases the lock on process death (including SIGKILL), so it can
-    // never go stale.
-    //
-    // Held in `_daemon_lock` for the whole body of `run()`; it is dropped only
-    // after the final endpoint-file cleanup below, releasing the lock last.
-    let _daemon_lock = match crate::lifecycle::acquire_singleton_lock(state.layout.root()) {
-        Ok(Some(lock)) => lock,
-        Ok(None) => {
-            // Contended. Either a live daemon already owns this repo, or a
-            // forked child leaked the flock fd past its dead parent (os error 35
-            // with no live owner). Reclaim clears only the latter — it acts only
-            // on a recorded owner that is present and dead — so a genuine second
-            // daemon still refuses to start.
-            let reclaim = crate::lifecycle::reclaim_stale_locks(state.layout.root());
-            let cleared = reclaim.cleared().len();
-            if cleared > 0 {
-                warn!(
-                    repo = %state.layout.root().display(),
-                    cleared,
-                    "reclaimed stale repo locks left by a dead daemon; retrying singleton acquire"
-                );
-            }
-            // Retry for a bounded window either way: an exiting daemon releases
-            // the flock as its process dies, and refusing on the first
-            // EWOULDBLOCK turns that handoff into a user-visible failure.
-            match crate::lifecycle::acquire_singleton_lock_within(
-                state.layout.root(),
-                crate::lifecycle::SINGLETON_LOCK_RETRY_BUDGET,
-            ) {
-                Ok(Some(lock)) => lock,
-                Ok(None) => {
-                    // Still held. Name the holder from real process evidence so
-                    // the operator knows exactly which process to wait for or
-                    // stop, and fail loudly instead of exiting 0 — a silent
-                    // clean exit reaches the CLI only as "daemon exited during
-                    // startup", which describes nothing.
-                    return Err(DaemonError::RepoOwnedByAnotherDaemon(
-                        singleton_contention_message(state.layout.root(), reclaim),
-                    ));
-                }
-                Err(error) => return Err(DaemonError::Io(error)),
-            }
-        }
-        Err(error) => return Err(DaemonError::Io(error)),
-    };
+pub async fn run(state: DaemonState, config: DaemonConfig) -> Result<()> {
+    let authority = acquire_daemon_authority(state.layout.root())?;
+    run_with_authority(state, config, authority).await
+}
 
-    // Stamp ownership immediately, before the slower migrate / LSP-discovery
-    // steps below. A contending starter consults `daemon.pid` to decide whether
-    // a contended lock is a live owner (refuse) or a dead-owner stale lock
-    // (reclaim); recording our live PID now closes the window where a lingering
-    // dead-owner PID could be mistaken for reclaimable while we already hold the
-    // lock. The port file is still written later, once the port is bound.
-    crate::lifecycle::write_pid_file(state.layout.root());
-
+/// Run with repository singleton authority already acquired.
+///
+/// The production process entrypoint uses this form so the lifetime guard is
+/// held before `DaemonState::open*` can recover or publish persisted state.
+/// [`run`] remains as the source-compatible wrapper for library callers.
+pub async fn run_with_authority(
+    mut state: DaemonState,
+    config: DaemonConfig,
+    _daemon_lock: crate::lifecycle::DaemonLock,
+) -> Result<()> {
     // Refuse to serve an incompatible `.kin/` layout. We now hold the singleton
     // lock (sole writer for this repo) but have not bound a port, written
     // endpoint files, or touched graph/kindb state — the safe point to validate
@@ -682,19 +694,14 @@ pub async fn run(mut state: DaemonState, config: DaemonConfig) -> Result<()> {
     // a port, dropped it, and a sibling process stole it before the daemon bound.
     let (api_listener, bound_port) = match api::bind_api_listener(&state, config.api_port) {
         Ok(bound) => bound,
-        Err(error) => {
-            // We hold the singleton lock and already wrote daemon.pid; drop the
-            // pid file so a failed bind never strands a stale endpoint record.
-            crate::lifecycle::remove_pid_file(state.layout.root());
-            return Err(DaemonError::Io(error));
-        }
+        Err(error) => return Err(DaemonError::Io(error)),
     };
 
-    // Publish the actual bound port so CLI processes can discover and auto-connect.
-    // Each repo gets its own daemon on its own port — the port file enables
-    // per-repo isolation (critical for benchmark worktrees). The PID file was
-    // written earlier, immediately after acquiring the singleton lock.
-    crate::lifecycle::write_port_file(state.layout.root(), bound_port);
+    // Publish PID and the actual bound port as one lifecycle-authorized
+    // operation. Endpoint retirement takes the same authority, so no client can
+    // delete a successor publication using a verdict about its predecessor.
+    crate::lifecycle::publish_daemon_endpoint(state.layout.root(), bound_port)
+        .map_err(DaemonError::Io)?;
 
     // Shutdown signal: when set to true, all loops exit.
     let (cancel_tx, cancel_rx) = tokio::sync::watch::channel(false);
@@ -2501,6 +2508,27 @@ mod tests {
         assert!(
             unknown.contains("names no owner"),
             "an unidentifiable holder must be described as such, not guessed at: {unknown}"
+        );
+
+        let compatibility_boundary = format_singleton_contention(
+            "/repo/.kin",
+            Some(crate::lifecycle::SingletonLockHolder {
+                pid: 4242,
+                alive: false,
+            }),
+            &crate::lifecycle::StaleLockReclaim::CoordinationUnavailable(
+                "recorded owner pid 4242 is dead, but compatible older daemons do not participate"
+                    .to_string(),
+            ),
+        );
+        assert!(
+            compatibility_boundary.contains("Automatic lock-file retirement was refused"),
+            "the refusal must disclose the unsupported mixed-version boundary: \
+             {compatibility_boundary}"
+        );
+        assert!(
+            compatibility_boundary.contains("cannot be proven safe"),
+            "the message must not claim exclusion it cannot enforce: {compatibility_boundary}"
         );
     }
 

--- a/crates/kin-daemon/src/daemon.rs
+++ b/crates/kin-daemon/src/daemon.rs
@@ -639,8 +639,24 @@ pub async fn run(state: DaemonState, config: DaemonConfig) -> Result<()> {
 pub async fn run_with_authority(
     mut state: DaemonState,
     config: DaemonConfig,
-    _daemon_lock: crate::lifecycle::DaemonLock,
+    daemon_lock: crate::lifecycle::DaemonLock,
 ) -> Result<()> {
+    // A singleton file handle is authority for one canonical repository, not a
+    // process-global permission to run any DaemonState. Validate the binding
+    // before migration, listener binding, or endpoint publication so a safe
+    // public API caller cannot replay repo A's capability against repo B.
+    let state_root = state
+        .layout
+        .root()
+        .canonicalize()
+        .map_err(DaemonError::Io)?;
+    if daemon_lock.canonical_kin_root() != state_root {
+        return Err(DaemonError::AuthorityMismatch {
+            authority_root: daemon_lock.canonical_kin_root().to_path_buf(),
+            state_root,
+        });
+    }
+
     // Refuse to serve an incompatible `.kin/` layout. We now hold the singleton
     // lock (sole writer for this repo) but have not bound a port, written
     // endpoint files, or touched graph/kindb state — the safe point to validate
@@ -2180,8 +2196,8 @@ mod tests {
     use super::{
         drain_pending_flush, format_singleton_contention, next_embed_error_backoff,
         parse_duration_secs, parse_owner_watch_pid, should_enable_lsp_enrichment, should_flush_now,
-        shutdown_signalled, watched_process_is_alive, DaemonConfig, DEFAULT_RUNTIME_SHUTDOWN_GRACE,
-        DEFAULT_SHUTDOWN_ESCALATION_GRACE,
+        shutdown_signalled, watched_process_is_alive, DaemonConfig, DaemonState,
+        DEFAULT_RUNTIME_SHUTDOWN_GRACE, DEFAULT_SHUTDOWN_ESCALATION_GRACE,
     };
     use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
     use std::sync::Arc;
@@ -2198,6 +2214,40 @@ mod tests {
         assert!(!should_enable_lsp_enrichment(true, true));
         assert!(!should_enable_lsp_enrichment(false, false));
         assert!(!should_enable_lsp_enrichment(false, true));
+    }
+
+    #[tokio::test]
+    async fn preacquired_authority_cannot_be_replayed_against_another_repo() {
+        let repo_a = tempfile::tempdir().unwrap();
+        let repo_b = tempfile::tempdir().unwrap();
+        let initialized_a = kin_core::init(repo_a.path()).unwrap();
+        let initialized_b = kin_core::init(repo_b.path()).unwrap();
+        let repo_b_kin_root = initialized_b.layout.root().to_path_buf();
+
+        let authority = super::acquire_daemon_authority(initialized_a.layout.root()).unwrap();
+        let state = DaemonState::open(initialized_b.layout).unwrap();
+        let result = super::run_with_authority(
+            state,
+            DaemonConfig {
+                api_port: 0,
+                ..DaemonConfig::default()
+            },
+            authority,
+        )
+        .await;
+
+        assert!(
+            matches!(
+                result,
+                Err(crate::error::DaemonError::AuthorityMismatch { .. })
+            ),
+            "repo A authority must not authorize repo B state: {result:?}"
+        );
+        assert!(
+            !repo_b_kin_root.join("daemon.pid").exists()
+                && !repo_b_kin_root.join("daemon.port").exists(),
+            "authority mismatch must fail before endpoint publication"
+        );
     }
 
     #[test]

--- a/crates/kin-daemon/src/daemon.rs
+++ b/crates/kin-daemon/src/daemon.rs
@@ -2164,8 +2164,8 @@ mod tests {
     use super::{
         drain_pending_flush, format_singleton_contention, next_embed_error_backoff,
         parse_duration_secs, parse_owner_watch_pid, should_enable_lsp_enrichment, should_flush_now,
-        shutdown_signalled, watched_process_is_alive, DaemonConfig,
-        DEFAULT_RUNTIME_SHUTDOWN_GRACE, DEFAULT_SHUTDOWN_ESCALATION_GRACE,
+        shutdown_signalled, watched_process_is_alive, DaemonConfig, DEFAULT_RUNTIME_SHUTDOWN_GRACE,
+        DEFAULT_SHUTDOWN_ESCALATION_GRACE,
     };
     use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
     use std::sync::Arc;

--- a/crates/kin-daemon/src/daemon.rs
+++ b/crates/kin-daemon/src/daemon.rs
@@ -2436,7 +2436,7 @@ mod tests {
         assert!(!DaemonConfig::default().embed_pipeline_overlap);
     }
 
-    // ── FIR-1583: a contended start must name what it lost to ─────────────
+    // ── A contended start must name what it lost to ───────────────────────
     //
     // The old refusal said "another kin daemon already owns this repo" and
     // exited 0, so the CLI reported only "daemon exited during startup" and the

--- a/crates/kin-daemon/src/daemon.rs
+++ b/crates/kin-daemon/src/daemon.rs
@@ -394,8 +394,17 @@ fn watched_process_is_alive(pid: i32) -> bool {
     )
 }
 
-#[cfg(not(unix))]
+#[cfg(windows)]
+fn watched_process_is_alive(pid: i32) -> bool {
+    u32::try_from(pid)
+        .ok()
+        .is_some_and(kin_cli::daemon_client::is_process_alive)
+}
+
+#[cfg(not(any(unix, windows)))]
 fn watched_process_is_alive(_pid: i32) -> bool {
+    // Fail closed on unsupported targets rather than treating an uncheckable
+    // owner as dead.
     true
 }
 

--- a/crates/kin-daemon/src/daemon.rs
+++ b/crates/kin-daemon/src/daemon.rs
@@ -56,6 +56,65 @@ fn should_enable_lsp_enrichment(config_enabled: bool, filesystem_reconcile_disab
     config_enabled && !filesystem_reconcile_disabled
 }
 
+/// Actionable refusal text for a daemon that lost the per-repo singleton lock.
+///
+/// Reads the holder from disk evidence and renders it. Kept split from
+/// [`format_singleton_contention`] so the wording is testable without a repo.
+fn singleton_contention_message(
+    kin_root: &std::path::Path,
+    reclaim: crate::lifecycle::StaleLockReclaim,
+) -> String {
+    format_singleton_contention(
+        &kin_root.display().to_string(),
+        crate::lifecycle::singleton_lock_holder(kin_root),
+        &reclaim,
+    )
+}
+
+/// Render the refusal a contended starter reports.
+///
+/// The old text ("another kin daemon already owns this repo") named nothing an
+/// operator could act on, and the process exited 0 so the message never even
+/// reached the caller as a failure. Every branch here names the evidence that
+/// produced it and what to do next.
+fn format_singleton_contention(
+    repo: &str,
+    holder: Option<crate::lifecycle::SingletonLockHolder>,
+    reclaim: &crate::lifecycle::StaleLockReclaim,
+) -> String {
+    let reclaimed = reclaim.cleared().len();
+    let context = match holder {
+        Some(holder) if holder.alive => format!(
+            "another kin daemon (pid {}) already owns {repo} and is still running",
+            holder.pid
+        ),
+        Some(holder) => format!(
+            "the daemon lock for {repo} is still held after its recorded owner (pid {}) exited, \
+             so a leaked lock fd is keeping it alive",
+            holder.pid
+        ),
+        None => format!(
+            "the daemon lock for {repo} is held but names no owner, so the holding process \
+             cannot be identified from disk"
+        ),
+    };
+    let remedy = match holder {
+        Some(holder) if holder.alive => format!(
+            "wait for pid {} to finish starting, or stop it with `kin daemon stop`",
+            holder.pid
+        ),
+        _ => "stop any remaining kin-daemon process for this repo, then retry".to_string(),
+    };
+    if reclaimed > 0 {
+        format!(
+            "refusing to start a second daemon: {context} (reclaimed {reclaimed} stale lock \
+             file(s) first, and the lock is still contended). To proceed, {remedy}."
+        )
+    } else {
+        format!("refusing to start a second daemon: {context}. To proceed, {remedy}.")
+    }
+}
+
 fn idle_check_interval(idle_timeout: Duration) -> Duration {
     let millis = (idle_timeout.as_millis() / 4).clamp(100, 5_000) as u64;
     Duration::from_millis(millis)
@@ -517,30 +576,35 @@ pub async fn run(mut state: DaemonState, config: DaemonConfig) -> Result<()> {
         Ok(None) => {
             // Contended. Either a live daemon already owns this repo, or a
             // forked child leaked the flock fd past its dead parent (os error 35
-            // with no live owner). Reclaim clears only the latter — it is a
-            // no-op unless the recorded owner PID is present and dead — so a
-            // genuine second daemon still refuses to start.
-            let cleared = crate::lifecycle::reclaim_stale_locks(state.layout.root());
-            if cleared.is_empty() {
+            // with no live owner). Reclaim clears only the latter — it acts only
+            // on a recorded owner that is present and dead — so a genuine second
+            // daemon still refuses to start.
+            let reclaim = crate::lifecycle::reclaim_stale_locks(state.layout.root());
+            let cleared = reclaim.cleared().len();
+            if cleared > 0 {
                 warn!(
                     repo = %state.layout.root().display(),
-                    "another kin daemon already owns this repo — refusing to start a second daemon"
+                    cleared,
+                    "reclaimed stale repo locks left by a dead daemon; retrying singleton acquire"
                 );
-                return Ok(());
             }
-            warn!(
-                repo = %state.layout.root().display(),
-                cleared = cleared.len(),
-                "reclaimed stale repo locks left by a dead daemon; retrying singleton acquire"
-            );
-            match crate::lifecycle::acquire_singleton_lock(state.layout.root()) {
+            // Retry for a bounded window either way: an exiting daemon releases
+            // the flock as its process dies, and refusing on the first
+            // EWOULDBLOCK turns that handoff into a user-visible failure.
+            match crate::lifecycle::acquire_singleton_lock_within(
+                state.layout.root(),
+                crate::lifecycle::SINGLETON_LOCK_RETRY_BUDGET,
+            ) {
                 Ok(Some(lock)) => lock,
                 Ok(None) => {
-                    warn!(
-                        repo = %state.layout.root().display(),
-                        "singleton lock still contended after stale-lock reclaim — refusing to start"
-                    );
-                    return Ok(());
+                    // Still held. Name the holder from real process evidence so
+                    // the operator knows exactly which process to wait for or
+                    // stop, and fail loudly instead of exiting 0 — a silent
+                    // clean exit reaches the CLI only as "daemon exited during
+                    // startup", which describes nothing.
+                    return Err(DaemonError::RepoOwnedByAnotherDaemon(
+                        singleton_contention_message(state.layout.root(), reclaim),
+                    ));
                 }
                 Err(error) => return Err(DaemonError::Io(error)),
             }
@@ -2098,10 +2162,10 @@ async fn select_with_signals(
 #[cfg(all(test, unix))]
 mod tests {
     use super::{
-        drain_pending_flush, next_embed_error_backoff, parse_duration_secs, parse_owner_watch_pid,
-        should_enable_lsp_enrichment, should_flush_now, shutdown_signalled,
-        watched_process_is_alive, DaemonConfig, DEFAULT_RUNTIME_SHUTDOWN_GRACE,
-        DEFAULT_SHUTDOWN_ESCALATION_GRACE,
+        drain_pending_flush, format_singleton_contention, next_embed_error_backoff,
+        parse_duration_secs, parse_owner_watch_pid, should_enable_lsp_enrichment, should_flush_now,
+        shutdown_signalled, watched_process_is_alive, DaemonConfig,
+        DEFAULT_RUNTIME_SHUTDOWN_GRACE, DEFAULT_SHUTDOWN_ESCALATION_GRACE,
     };
     use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
     use std::sync::Arc;
@@ -2370,6 +2434,65 @@ mod tests {
         // The deterministic serial persist path is the default; only the
         // throughput profile opts into overlap (wired in the daemon binary).
         assert!(!DaemonConfig::default().embed_pipeline_overlap);
+    }
+
+    // ── FIR-1583: a contended start must name what it lost to ─────────────
+    //
+    // The old refusal said "another kin daemon already owns this repo" and
+    // exited 0, so the CLI reported only "daemon exited during startup" and the
+    // operator had no way to tell a live holder from a leaked lock fd.
+
+    #[test]
+    fn contention_message_names_a_live_holder_and_how_to_clear_it() {
+        let message = format_singleton_contention(
+            "/repo/.kin",
+            Some(crate::lifecycle::SingletonLockHolder {
+                pid: 4242,
+                alive: true,
+            }),
+            &crate::lifecycle::StaleLockReclaim::OwnerAlive(4242),
+        );
+        assert!(message.contains("4242"), "must name the holder: {message}");
+        assert!(
+            message.contains("/repo/.kin"),
+            "must name the repo: {message}"
+        );
+        assert!(
+            message.contains("kin daemon stop"),
+            "must give the operator an action: {message}"
+        );
+    }
+
+    #[test]
+    fn contention_message_distinguishes_a_dead_owner_from_an_unidentified_one() {
+        let leaked = format_singleton_contention(
+            "/repo/.kin",
+            Some(crate::lifecycle::SingletonLockHolder {
+                pid: 4242,
+                alive: false,
+            }),
+            &crate::lifecycle::StaleLockReclaim::Cleared(vec![std::path::PathBuf::from(
+                "/repo/.kin/daemon.lock",
+            )]),
+        );
+        assert!(
+            leaked.contains("leaked lock fd"),
+            "a dead recorded owner is a leaked fd, not a running daemon: {leaked}"
+        );
+        assert!(
+            leaked.contains("reclaimed 1 stale lock"),
+            "the reclaim that already ran must be reported: {leaked}"
+        );
+
+        let unknown = format_singleton_contention(
+            "/repo/.kin",
+            None,
+            &crate::lifecycle::StaleLockReclaim::OwnerUnknown,
+        );
+        assert!(
+            unknown.contains("names no owner"),
+            "an unidentifiable holder must be described as such, not guessed at: {unknown}"
+        );
     }
 
     // The embed worker keeps at most one flush in flight and always awaits it

--- a/crates/kin-daemon/src/error.rs
+++ b/crates/kin-daemon/src/error.rs
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 // Copyright 2026 Firelock, LLC
 
+use std::path::PathBuf;
 use thiserror::Error;
 
 #[derive(Error, Debug)]
@@ -31,6 +32,14 @@ pub enum DaemonError {
 
     #[error("Already running")]
     AlreadyRunning,
+
+    #[error(
+        "daemon authority protects {authority_root}, but daemon state belongs to {state_root}"
+    )]
+    AuthorityMismatch {
+        authority_root: PathBuf,
+        state_root: PathBuf,
+    },
 
     /// A second daemon lost the per-repo singleton lock. Carries the actionable
     /// text naming the holder; a bare "already running" told the operator

--- a/crates/kin-daemon/src/error.rs
+++ b/crates/kin-daemon/src/error.rs
@@ -32,6 +32,12 @@ pub enum DaemonError {
     #[error("Already running")]
     AlreadyRunning,
 
+    /// A second daemon lost the per-repo singleton lock. Carries the actionable
+    /// text naming the holder; a bare "already running" told the operator
+    /// nothing about which process to wait for or stop.
+    #[error("{0}")]
+    RepoOwnedByAnotherDaemon(String),
+
     #[error("IO error: {0}")]
     Io(#[from] std::io::Error),
 }

--- a/crates/kin-daemon/src/lib.rs
+++ b/crates/kin-daemon/src/lib.rs
@@ -136,7 +136,10 @@ pub mod supervisor;
 pub mod traffic_adapter;
 pub mod write_veto;
 
-pub use daemon::{run, DaemonConfig};
+pub use daemon::{
+    acquire_daemon_authority, acquire_daemon_authority_within, run, run_with_authority,
+    DaemonConfig,
+};
 pub use error::{DaemonError, Result};
 pub use lifecycle::{
     daemon_is_up, ensure_daemon_running, ensure_daemon_running_with_idle_timeout, AutoStartError,

--- a/crates/kin-daemon/src/lifecycle.rs
+++ b/crates/kin-daemon/src/lifecycle.rs
@@ -7,6 +7,7 @@
 //! The CLI reads those files to connect. If the daemon isn't running, the
 //! CLI spawns it and waits for the port to open.
 
+use std::io::{Seek, SeekFrom, Write};
 use std::path::{Path, PathBuf};
 use std::process::Stdio;
 use std::time::Duration;
@@ -30,7 +31,76 @@ use tracing::info;
 /// while the first still believes it holds the lock.
 #[derive(Debug)]
 pub struct DaemonLock {
-    _file: std::fs::File,
+    file: std::fs::File,
+}
+
+impl Drop for DaemonLock {
+    /// Clear the owner stamp before releasing the lock.
+    ///
+    /// This is what makes the stamp mean something precise: a non-empty
+    /// `daemon.lock` body says a process took the lock and did *not* release it
+    /// cleanly. A clean exit runs this drop; a `SIGKILL` cannot, which is
+    /// exactly the case reclaim needs to identify. Without the clear, every
+    /// ordinary shutdown would leave a dead-owner record and the next startup
+    /// would "reclaim" locks that were never stale.
+    fn drop(&mut self) {
+        let _ = self.file.set_len(0);
+        let _ = self.file.flush();
+    }
+}
+
+/// Stamp the acquiring process's PID into the lock file body.
+///
+/// The flock lives on the open file description, so the file's *contents* are
+/// free real estate. Recording the owner there gives every other process a
+/// piece of evidence about who holds the repo that does not depend on
+/// `daemon.pid` surviving: `daemon.pid` is written by the daemon and can be
+/// removed by any other participant, while this stamp is written under the
+/// lock by the only process that could have taken it.
+fn stamp_lock_owner(file: &mut std::fs::File) {
+    let pid = std::process::id();
+    if file.set_len(0).is_err() {
+        return;
+    }
+    if file.seek(SeekFrom::Start(0)).is_err() {
+        return;
+    }
+    if write!(file, "{pid}").is_err() {
+        return;
+    }
+    let _ = file.flush();
+}
+
+/// Owner PID recorded inside `.kin/daemon.lock` by whichever process last
+/// acquired the lock, if present and parseable.
+///
+/// Unlike [`recorded_daemon_pid`], this record cannot be erased by a client
+/// clearing endpoint files, so it stays available exactly when `daemon.pid` is
+/// missing.
+pub fn lock_owner_pid(kin_root: &Path) -> Option<u32> {
+    std::fs::read_to_string(kin_root.join("daemon.lock"))
+        .ok()
+        .and_then(|content| content.trim().parse::<u32>().ok())
+}
+
+/// Who currently owns this repo's daemon lock, as far as on-disk evidence can
+/// say, and whether that process is still alive.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct SingletonLockHolder {
+    pub pid: u32,
+    pub alive: bool,
+}
+
+/// Resolve the recorded owner of the repo daemon lock from real process
+/// evidence: the lock file's own owner stamp first (it survives endpoint-file
+/// deletion), then `daemon.pid`. Returns `None` only when neither record
+/// exists.
+pub fn singleton_lock_holder(kin_root: &Path) -> Option<SingletonLockHolder> {
+    let pid = lock_owner_pid(kin_root).or_else(|| recorded_daemon_pid(kin_root))?;
+    Some(SingletonLockHolder {
+        pid,
+        alive: is_process_alive(pid),
+    })
 }
 
 /// Try to acquire the exclusive daemon lock for a repo.
@@ -46,14 +116,19 @@ pub struct DaemonLock {
 /// - `Err(_)` — an unexpected IO error opening the lock file.
 pub fn acquire_singleton_lock(kin_root: &Path) -> std::io::Result<Option<DaemonLock>> {
     let path = kin_root.join("daemon.lock");
-    let file = std::fs::OpenOptions::new()
+    let mut file = std::fs::OpenOptions::new()
         .create(true)
         .read(true)
         .write(true)
         .truncate(false)
         .open(&path)?;
     match file.try_lock_exclusive() {
-        Ok(()) => Ok(Some(DaemonLock { _file: file })),
+        Ok(()) => {
+            // Record ownership while holding the lock, so a contender that
+            // fails to acquire can always name the process it lost to.
+            stamp_lock_owner(&mut file);
+            Ok(Some(DaemonLock { file }))
+        }
         // fs2 reports contention with the platform's "would block" error
         // (EWOULDBLOCK on Unix). Treat that — and only that — as "already
         // held"; surface every other IO error to the caller.
@@ -61,6 +136,65 @@ pub fn acquire_singleton_lock(kin_root: &Path) -> std::io::Result<Option<DaemonL
         Err(err) => Err(err),
     }
 }
+
+/// Acquire the singleton lock, retrying for a bounded window while the lock is
+/// contended.
+///
+/// The handoff window between an exiting daemon and its successor is real but
+/// short: the kernel releases the flock as the old process dies, and a starter
+/// that gives up on the first `EWOULDBLOCK` turns that microsecond race into a
+/// user-visible refusal. Retry briefly, then stop — an unbounded retry would
+/// turn a genuine second daemon into a spinner instead of a loud error.
+///
+/// Returns `Ok(None)` when the lock is still held at the end of the window; the
+/// caller must then report the holder rather than start a second daemon.
+pub fn acquire_singleton_lock_within(
+    kin_root: &Path,
+    budget: Duration,
+) -> std::io::Result<Option<DaemonLock>> {
+    without_blocking_runtime_worker(|| {
+        let deadline = std::time::Instant::now() + budget;
+        loop {
+            if let Some(lock) = acquire_singleton_lock(kin_root)? {
+                return Ok(Some(lock));
+            }
+            if std::time::Instant::now() >= deadline {
+                return Ok(None);
+            }
+            std::thread::sleep(SINGLETON_LOCK_RETRY_INTERVAL);
+        }
+    })
+}
+
+/// Run a blocking step without holding a tokio worker thread hostage.
+///
+/// Daemon lifecycle has two of these: waiting out a contended singleton lock,
+/// and warming sibling repository graphs for the spine. Both are synchronous
+/// and both are reached from async contexts, and blocking the worker inline is
+/// what let a warm-up starve the daemon's own liveness routes — a client
+/// polling `/readiness` saw nothing, concluded the daemon was dead, and
+/// clobbered a live daemon's endpoint files. `block_in_place` hands this
+/// worker's remaining tasks to another thread first, so `/health` and
+/// `/readiness` keep being served throughout.
+///
+/// Outside a multi-thread runtime (a `current_thread` runtime, or no runtime at
+/// all, as in unit tests) there is no worker to hand off and `block_in_place`
+/// would panic, so the work runs directly.
+pub(crate) fn without_blocking_runtime_worker<T>(work: impl FnOnce() -> T) -> T {
+    match tokio::runtime::Handle::try_current() {
+        Ok(handle) if handle.runtime_flavor() == tokio::runtime::RuntimeFlavor::MultiThread => {
+            tokio::task::block_in_place(work)
+        }
+        _ => work(),
+    }
+}
+
+/// How long a contended starter keeps retrying the singleton lock before it
+/// reports the holder. Long enough to cover an exiting daemon's teardown,
+/// short enough that a genuine second daemon fails fast and loudly.
+pub const SINGLETON_LOCK_RETRY_BUDGET: Duration = Duration::from_secs(5);
+
+const SINGLETON_LOCK_RETRY_INTERVAL: Duration = Duration::from_millis(100);
 
 // ── Stale-Lock Reclaim ────────────────────────────────────────────────────
 
@@ -90,6 +224,32 @@ fn lock_files(kin_root: &Path) -> Vec<PathBuf> {
     locks
 }
 
+/// What a reclaim attempt concluded, and why.
+///
+/// Every variant is reported: a reclaim that declines must say which evidence
+/// made it decline, because the alternative — returning an empty list — reads
+/// to the caller exactly like "nothing was wrong here".
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum StaleLockReclaim {
+    /// The recorded owner is dead; these lock files were removed.
+    Cleared(Vec<PathBuf>),
+    /// A recorded owner is alive, so the locks are deliberately preserved.
+    OwnerAlive(u32),
+    /// Neither the lock file's owner stamp nor `daemon.pid` names an owner, so
+    /// liveness cannot be established and reclaiming would be a guess.
+    OwnerUnknown,
+}
+
+impl StaleLockReclaim {
+    /// Lock files actually removed; empty for every non-clearing outcome.
+    pub fn cleared(&self) -> &[PathBuf] {
+        match self {
+            Self::Cleared(paths) => paths,
+            _ => &[],
+        }
+    }
+}
+
 /// Reclaim stale lock files left behind when a daemon died while a forked child
 /// still held an inherited `flock(2)` fd.
 ///
@@ -100,28 +260,39 @@ fn lock_files(kin_root: &Path) -> Vec<PathBuf> {
 /// closes, so a fresh acquire then spuriously fails with `EWOULDBLOCK`
 /// (os error 35) even though no live daemon owns the repo.
 ///
-/// SAFETY: reclaim ONLY when the recorded owner PID is present **and dead**.
+/// SAFETY: reclaim ONLY when a recorded owner PID is present **and dead**.
 ///
 /// - A *live* owner means a real daemon holds the lock; unlinking would let a
 ///   second daemon lock a fresh inode and run concurrently — the very
 ///   singleton-multiplicity hazard `daemon.lock` exists to prevent.
-/// - An *absent* PID is ambiguous (a daemon mid-startup may hold the flock
-///   before stamping its PID), so it is treated conservatively as "do not
-///   reclaim" — refusing to start is always safe; reclaiming a live lock is not.
+/// - No recorded owner at all means liveness is unknowable from disk, so the
+///   locks stay and the gap is reported instead of silently swallowed.
+///
+/// Ownership is read from two independent records: the owner stamp written into
+/// `daemon.lock` under the lock itself, and `daemon.pid`. The stamp is what
+/// keeps this path working when `daemon.pid` is absent — a client that cleared
+/// endpoint files used to erase the only evidence, turning reclaim into a
+/// permanent no-op while the repo stayed wedged. If either record names a live
+/// process, nothing is touched.
 ///
 /// Unlinking a genuinely leaked-fd lock is safe: the next acquire creates a new
 /// inode, while the zombie child's flock stays on the now-orphaned old one.
-///
-/// Returns the lock files actually cleared (each logged loudly); empty when no
-/// reclaim was warranted.
-pub fn reclaim_stale_locks(kin_root: &Path) -> Vec<PathBuf> {
-    match recorded_daemon_pid(kin_root) {
-        // Present and dead → the unambiguous stale-owner record a SIGKILLed
-        // daemon leaves behind. Safe to reclaim.
-        Some(pid) if !is_process_alive(pid) => {}
-        // Present and alive, or absent → do not touch the locks.
-        _ => return Vec::new(),
+pub fn reclaim_stale_locks(kin_root: &Path) -> StaleLockReclaim {
+    let recorded: Vec<u32> = [lock_owner_pid(kin_root), recorded_daemon_pid(kin_root)]
+        .into_iter()
+        .flatten()
+        .collect();
+    if let Some(alive) = recorded.iter().copied().find(|pid| is_process_alive(*pid)) {
+        return StaleLockReclaim::OwnerAlive(alive);
     }
+    let Some(&dead_owner) = recorded.first() else {
+        tracing::warn!(
+            repo = %kin_root.display(),
+            "repo lock is contended but no owner is recorded in daemon.lock or daemon.pid; \
+             refusing to reclaim a lock whose holder cannot be identified"
+        );
+        return StaleLockReclaim::OwnerUnknown;
+    };
 
     let mut cleared = Vec::new();
     for lock in lock_files(kin_root) {
@@ -132,6 +303,7 @@ pub fn reclaim_stale_locks(kin_root: &Path) -> Vec<PathBuf> {
             Ok(()) => {
                 tracing::warn!(
                     lock = %lock.display(),
+                    owner_pid = dead_owner,
                     "reclaimed stale repo lock left by a dead daemon owner"
                 );
                 cleared.push(lock);
@@ -145,7 +317,7 @@ pub fn reclaim_stale_locks(kin_root: &Path) -> Vec<PathBuf> {
             }
         }
     }
-    cleared
+    StaleLockReclaim::Cleared(cleared)
 }
 
 // ── Daemon State Files ──────────────────────────────────────────────────
@@ -710,8 +882,12 @@ mod tests {
         std::fs::write(root.join("daemon.lock"), b"").unwrap();
         std::fs::write(root.join("kindb").join("graph.lock"), b"").unwrap();
 
-        let cleared = reclaim_stale_locks(root);
-        assert_eq!(cleared.len(), 2, "both stale locks should be reclaimed");
+        let reclaim = reclaim_stale_locks(root);
+        assert_eq!(
+            reclaim.cleared().len(),
+            2,
+            "both stale locks should be reclaimed"
+        );
         assert!(!root.join("daemon.lock").exists());
         assert!(!root.join("kindb").join("graph.lock").exists());
 
@@ -736,8 +912,9 @@ mod tests {
         std::fs::write(root.join("daemon.lock"), b"").unwrap();
         std::fs::write(root.join("kindb").join("graph.lock"), b"").unwrap();
 
-        assert!(
-            reclaim_stale_locks(root).is_empty(),
+        assert_eq!(
+            reclaim_stale_locks(root),
+            StaleLockReclaim::OwnerAlive(std::process::id()),
             "live-owner locks must be preserved"
         );
         assert!(root.join("daemon.lock").exists());
@@ -745,19 +922,197 @@ mod tests {
     }
 
     #[test]
-    fn reclaim_is_noop_without_recorded_owner() {
-        // No daemon.pid is ambiguous (a daemon may hold the flock before
-        // stamping its PID), so the conservative choice is to NOT reclaim:
-        // refusing to start is always safe; reclaiming a live lock is not.
+    fn reclaim_is_noop_without_any_recorded_owner() {
+        // Neither record names an owner, so liveness cannot be established and
+        // reclaiming would be a guess. Refusing to start is always safe;
+        // reclaiming a live lock is not. The outcome is reported as
+        // OwnerUnknown rather than an empty list, so the caller can say why.
         let dir = tempfile::tempdir().unwrap();
         let root = dir.path();
         std::fs::create_dir_all(root.join("kindb")).unwrap();
         std::fs::write(root.join("daemon.lock"), b"").unwrap();
         std::fs::write(root.join("kindb").join("graph.lock"), b"").unwrap();
 
-        assert!(reclaim_stale_locks(root).is_empty());
+        assert_eq!(reclaim_stale_locks(root), StaleLockReclaim::OwnerUnknown);
         assert!(root.join("daemon.lock").exists());
         assert!(root.join("kindb").join("graph.lock").exists());
+    }
+
+    // ── FIR-1583: reclaim must work without daemon.pid ────────────────────
+    //
+    // The deadlock chain ended here: a client cleared a live daemon's endpoint
+    // files, so when that daemon later died by SIGKILL there was no daemon.pid
+    // left, reclaim had no owner to evaluate, and every subsequent start lost
+    // the leaked flock forever. The lock file's own owner stamp is the evidence
+    // that survives, because only the process holding the lock can write it.
+
+    #[test]
+    fn singleton_lock_stamps_its_owner_pid() {
+        let dir = tempfile::tempdir().unwrap();
+        let root = dir.path();
+
+        let lock = acquire_singleton_lock(root)
+            .expect("lock IO should succeed")
+            .expect("first acquire should win");
+        assert_eq!(
+            lock_owner_pid(root),
+            Some(std::process::id()),
+            "the acquiring process must record itself in the lock file"
+        );
+        drop(lock);
+    }
+
+    #[test]
+    fn releasing_the_lock_clears_the_owner_stamp() {
+        // A clean release must leave no dead-owner record: otherwise every
+        // ordinary restart would look like a crashed predecessor and "reclaim"
+        // locks that were never stale.
+        let dir = tempfile::tempdir().unwrap();
+        let root = dir.path();
+
+        let lock = acquire_singleton_lock(root)
+            .expect("lock IO should succeed")
+            .expect("first acquire should win");
+        drop(lock);
+
+        assert_eq!(
+            lock_owner_pid(root),
+            None,
+            "a cleanly released lock must not name an owner"
+        );
+        assert_eq!(reclaim_stale_locks(root), StaleLockReclaim::OwnerUnknown);
+        assert!(
+            root.join("daemon.lock").exists(),
+            "a clean release must not make the next startup reclaim anything"
+        );
+    }
+
+    #[test]
+    fn reclaim_uses_the_lock_owner_stamp_when_daemon_pid_is_missing() {
+        // The exact deadlock state: a dead owner recorded only in the lock
+        // file, because daemon.pid was removed by someone else. Before the
+        // stamp existed this returned "nothing to do" and the repo stayed
+        // wedged until the leaked fd closed.
+        let dir = tempfile::tempdir().unwrap();
+        let root = dir.path();
+        std::fs::create_dir_all(root.join("kindb")).unwrap();
+        std::fs::write(root.join("daemon.lock"), "999999999").unwrap();
+        std::fs::write(root.join("kindb").join("graph.lock"), b"").unwrap();
+        assert!(
+            !root.join("daemon.pid").exists(),
+            "this is the missing-pid case"
+        );
+
+        let reclaim = reclaim_stale_locks(root);
+        assert_eq!(
+            reclaim.cleared().len(),
+            2,
+            "a dead owner named only by the lock stamp must still be reclaimable"
+        );
+        assert!(!root.join("daemon.lock").exists());
+        assert!(!root.join("kindb").join("graph.lock").exists());
+    }
+
+    #[test]
+    fn reclaim_refuses_when_the_lock_stamp_names_a_live_owner() {
+        // Same missing-pid shape, live owner. Reclaiming here would let a
+        // second daemon lock a fresh inode and run concurrently.
+        let dir = tempfile::tempdir().unwrap();
+        let root = dir.path();
+        std::fs::create_dir_all(root.join("kindb")).unwrap();
+        std::fs::write(root.join("daemon.lock"), std::process::id().to_string()).unwrap();
+        std::fs::write(root.join("kindb").join("graph.lock"), b"").unwrap();
+
+        assert_eq!(
+            reclaim_stale_locks(root),
+            StaleLockReclaim::OwnerAlive(std::process::id())
+        );
+        assert!(root.join("daemon.lock").exists());
+        assert!(root.join("kindb").join("graph.lock").exists());
+    }
+
+    #[test]
+    fn reclaim_refuses_when_only_the_pid_file_names_a_live_owner() {
+        // Evidence is a union, not a preference: a live owner in either record
+        // must veto the reclaim.
+        let dir = tempfile::tempdir().unwrap();
+        let root = dir.path();
+        std::fs::create_dir_all(root.join("kindb")).unwrap();
+        std::fs::write(root.join("daemon.lock"), "999999999").unwrap();
+        std::fs::write(root.join("daemon.pid"), std::process::id().to_string()).unwrap();
+
+        assert_eq!(
+            reclaim_stale_locks(root),
+            StaleLockReclaim::OwnerAlive(std::process::id())
+        );
+        assert!(root.join("daemon.lock").exists());
+    }
+
+    #[test]
+    fn lock_holder_is_named_from_the_stamp_without_a_pid_file() {
+        // What the contention error needs: identify the holder so the refusal
+        // can name a process instead of saying "another daemon owns this repo".
+        let dir = tempfile::tempdir().unwrap();
+        let root = dir.path();
+        std::fs::write(root.join("daemon.lock"), std::process::id().to_string()).unwrap();
+
+        let holder = singleton_lock_holder(root).expect("stamp identifies the holder");
+        assert_eq!(holder.pid, std::process::id());
+        assert!(holder.alive);
+
+        std::fs::write(root.join("daemon.lock"), "999999999").unwrap();
+        let dead = singleton_lock_holder(root).expect("stamp identifies the holder");
+        assert_eq!(dead.pid, 999999999);
+        assert!(!dead.alive);
+    }
+
+    #[test]
+    fn bounded_retry_gives_up_instead_of_spinning_forever() {
+        // The loser retries to cover an exiting daemon's teardown, then stops.
+        // An unbounded retry would replace a loud error with a hang.
+        let dir = tempfile::tempdir().unwrap();
+        let root = dir.path();
+        let held = acquire_singleton_lock(root)
+            .expect("lock IO should succeed")
+            .expect("first acquire should win");
+
+        let started = std::time::Instant::now();
+        let budget = Duration::from_millis(300);
+        let contended = acquire_singleton_lock_within(root, budget).expect("lock IO should succeed");
+
+        assert!(contended.is_none(), "a held lock must not be handed out");
+        assert!(
+            started.elapsed() >= budget,
+            "the retry must actually cover its budget"
+        );
+        assert!(
+            started.elapsed() < budget * 20,
+            "the retry must be bounded, not a spin"
+        );
+        drop(held);
+    }
+
+    #[test]
+    fn bounded_retry_wins_once_the_holder_releases() {
+        // The handoff case the retry exists for.
+        let dir = tempfile::tempdir().unwrap();
+        let root = dir.path().to_path_buf();
+        let held = acquire_singleton_lock(&root)
+            .expect("lock IO should succeed")
+            .expect("first acquire should win");
+
+        let releaser = std::thread::spawn(move || {
+            std::thread::sleep(Duration::from_millis(150));
+            drop(held);
+        });
+
+        let acquired = acquire_singleton_lock_within(&root, Duration::from_secs(10))
+            .expect("lock IO should succeed");
+        assert!(
+            acquired.is_some(),
+            "the successor must take the lock once the holder releases"
+        );
+        releaser.join().expect("releaser thread");
     }
 
     #[test]

--- a/crates/kin-daemon/src/lifecycle.rs
+++ b/crates/kin-daemon/src/lifecycle.rs
@@ -1078,7 +1078,8 @@ mod tests {
 
         let started = std::time::Instant::now();
         let budget = Duration::from_millis(300);
-        let contended = acquire_singleton_lock_within(root, budget).expect("lock IO should succeed");
+        let contended =
+            acquire_singleton_lock_within(root, budget).expect("lock IO should succeed");
 
         assert!(contended.is_none(), "a held lock must not be handed out");
         assert!(

--- a/crates/kin-daemon/src/lifecycle.rs
+++ b/crates/kin-daemon/src/lifecycle.rs
@@ -10,7 +10,7 @@
 use std::io::{Seek, SeekFrom, Write};
 use std::path::{Path, PathBuf};
 use std::process::Stdio;
-use std::time::Duration;
+use std::time::{Duration, Instant};
 
 use fs2::FileExt;
 use tracing::info;
@@ -23,13 +23,15 @@ use tracing::info;
 /// process per repo. The lock is an OS-level advisory `flock(2)` on
 /// `.kin/daemon.lock`. Because the kernel ties the lock to the open file
 /// description, it is released automatically when this handle is dropped *or*
-/// when the process dies — including a hard `SIGKILL` — so it can never go
-/// stale and strand the repo.
+/// when the last process holding that description exits. A forked child can
+/// inherit the description and keep it locked after the stamped daemon dies;
+/// that case is detected and reported, but not automatically unlinked.
 ///
-/// The on-disk lock file is unlinked only by dead-owner recovery while holding
-/// the separate lifecycle coordination lock. Acquisition takes that same
-/// coordination lock before opening this inode, so no successor can lock and
-/// stamp the old inode between the reclaimer's owner check and unlink.
+/// Current builds never unlink this pathname automatically. The separate
+/// lifecycle coordination lock serializes all current acquisition and endpoint
+/// publication paths, but it cannot exclude a compatible older writer that
+/// does not participate. Recovery therefore fails closed rather than replacing
+/// an inode that a legacy process could have acquired after a userspace check.
 #[derive(Debug)]
 pub struct DaemonLock {
     file: std::fs::File,
@@ -120,18 +122,29 @@ pub fn acquire_singleton_lock(kin_root: &Path) -> std::io::Result<Option<DaemonL
 }
 
 fn acquire_singleton_lock_inner(kin_root: &Path) -> std::io::Result<Option<DaemonLock>> {
-    acquire_singleton_lock_inner_with_coordination_hook(kin_root, || {})
+    acquire_singleton_lock_inner_until(kin_root, Instant::now() + SINGLETON_LOCK_RETRY_BUDGET)
 }
 
-fn acquire_singleton_lock_inner_with_coordination_hook<F>(
+fn acquire_singleton_lock_inner_until(
     kin_root: &Path,
+    deadline: Instant,
+) -> std::io::Result<Option<DaemonLock>> {
+    acquire_singleton_lock_inner_until_with_coordination_hook(kin_root, deadline, || {})
+}
+
+fn acquire_singleton_lock_inner_until_with_coordination_hook<F>(
+    kin_root: &Path,
+    deadline: Instant,
     on_coordination_contention: F,
 ) -> std::io::Result<Option<DaemonLock>>
 where
     F: FnMut(),
 {
-    let _coordination =
-        acquire_singleton_coordination_guard_with_hook(kin_root, on_coordination_contention)?;
+    let _coordination = acquire_singleton_coordination_guard_until_with_hook(
+        kin_root,
+        deadline,
+        on_coordination_contention,
+    )?;
     let path = kin_root.join("daemon.lock");
     let mut file = std::fs::OpenOptions::new()
         .create(true)
@@ -154,19 +167,29 @@ where
     }
 }
 
-/// Serialize daemon-lock inode replacement against acquisition.
+/// Serialize current daemon acquisition, evidence reads, and endpoint changes.
 ///
-/// `daemon.lock` itself cannot provide this serialization: dead-owner recovery
-/// exists specifically because a leaked child fd can keep that inode locked
-/// after its daemon owner dies. This second, never-unlinked inode is held only
-/// for the short owner-check/open/stamp critical section. A bounded acquire
-/// fails closed if an inherited coordination fd ever does leak.
+/// `daemon.lock` itself cannot provide this coordination while a leaked child
+/// fd keeps that inode locked after its stamped owner dies. This second,
+/// never-unlinked inode is held only for short authority sections. A bounded
+/// acquire fails closed if an inherited coordination fd ever leaks.
 fn acquire_singleton_coordination_guard(kin_root: &Path) -> std::io::Result<std::fs::File> {
-    acquire_singleton_coordination_guard_with_hook(kin_root, || {})
+    acquire_singleton_coordination_guard_until(
+        kin_root,
+        Instant::now() + SINGLETON_LOCK_RETRY_BUDGET,
+    )
 }
 
-fn acquire_singleton_coordination_guard_with_hook<F>(
+fn acquire_singleton_coordination_guard_until(
     kin_root: &Path,
+    deadline: Instant,
+) -> std::io::Result<std::fs::File> {
+    acquire_singleton_coordination_guard_until_with_hook(kin_root, deadline, || {})
+}
+
+fn acquire_singleton_coordination_guard_until_with_hook<F>(
+    kin_root: &Path,
+    deadline: Instant,
     mut on_contention: F,
 ) -> std::io::Result<std::fs::File>
 where
@@ -179,19 +202,21 @@ where
         .write(true)
         .truncate(false)
         .open(path)?;
-    let deadline = std::time::Instant::now() + SINGLETON_LOCK_RETRY_BUDGET;
     loop {
         match file.try_lock_exclusive() {
             Ok(()) => return Ok(file),
             Err(err) if err.kind() == fs2::lock_contended_error().kind() => {
                 on_contention();
-                if std::time::Instant::now() >= deadline {
+                let now = Instant::now();
+                if now >= deadline {
                     return Err(std::io::Error::new(
                         std::io::ErrorKind::WouldBlock,
                         "timed out waiting for daemon lifecycle coordination lock",
                     ));
                 }
-                std::thread::sleep(SINGLETON_LOCK_RETRY_INTERVAL);
+                std::thread::sleep(
+                    SINGLETON_LOCK_RETRY_INTERVAL.min(deadline.saturating_duration_since(now)),
+                );
             }
             Err(err) => return Err(err),
         }
@@ -214,15 +239,26 @@ pub fn acquire_singleton_lock_within(
     budget: Duration,
 ) -> std::io::Result<Option<DaemonLock>> {
     without_blocking_runtime_worker(|| {
-        let deadline = std::time::Instant::now() + budget;
+        let deadline = Instant::now() + budget;
         loop {
-            if let Some(lock) = acquire_singleton_lock_inner(kin_root)? {
-                return Ok(Some(lock));
+            match acquire_singleton_lock_inner_until(kin_root, deadline) {
+                Ok(Some(lock)) => return Ok(Some(lock)),
+                Ok(None) => {}
+                Err(error)
+                    if error.kind() == std::io::ErrorKind::WouldBlock
+                        && Instant::now() >= deadline =>
+                {
+                    return Ok(None);
+                }
+                Err(error) => return Err(error),
             }
-            if std::time::Instant::now() >= deadline {
+            let now = Instant::now();
+            if now >= deadline {
                 return Ok(None);
             }
-            std::thread::sleep(SINGLETON_LOCK_RETRY_INTERVAL);
+            std::thread::sleep(
+                SINGLETON_LOCK_RETRY_INTERVAL.min(deadline.saturating_duration_since(now)),
+            );
         }
     })
 }
@@ -294,24 +330,6 @@ impl LockOwnerEvidence {
     }
 }
 
-/// All on-disk lock files for a repo: the daemon singleton lock under the `.kin`
-/// root, plus every `*.lock` under `.kin/kindb/` (kin-db's snapshot `graph.lock`
-/// and any future sibling such as a kvec write lock). Enumerated by extension so
-/// the set tracks kin-db across versions without hard-coding paths that may not
-/// exist in every build.
-fn lock_files(kin_root: &Path) -> Vec<PathBuf> {
-    let mut locks = vec![kin_root.join("daemon.lock")];
-    if let Ok(entries) = std::fs::read_dir(kin_root.join("kindb")) {
-        for entry in entries.flatten() {
-            let path = entry.path();
-            if path.extension().is_some_and(|ext| ext == "lock") {
-                locks.push(path);
-            }
-        }
-    }
-    locks
-}
-
 /// What a reclaim attempt concluded, and why.
 ///
 /// Every variant is reported: a reclaim that declines must say which evidence
@@ -319,7 +337,8 @@ fn lock_files(kin_root: &Path) -> Vec<PathBuf> {
 /// to the caller exactly like "nothing was wrong here".
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum StaleLockReclaim {
-    /// The recorded owner is dead; these lock files were removed.
+    /// Legacy/historical outcome retained for source compatibility. Current
+    /// mixed-version-safe recovery does not produce it automatically.
     Cleared(Vec<PathBuf>),
     /// A recorded owner is alive, so the locks are deliberately preserved.
     OwnerAlive(u32),
@@ -335,8 +354,9 @@ pub enum StaleLockReclaim {
         current_lock_owner: Option<u32>,
         current_endpoint_owner: Option<u32>,
     },
-    /// The separate acquisition/reclaim coordination inode could not be
-    /// acquired. Recovery fails closed instead of unlinking without exclusion.
+    /// Safe acquisition/retirement coordination is unavailable. This includes
+    /// both a contended lifecycle inode and the mixed-version boundary where
+    /// compatible older writers do not participate in that protocol.
     CoordinationUnavailable(String),
 }
 
@@ -375,17 +395,65 @@ impl StaleLockReclaim {
 /// permanent no-op while the repo stayed wedged. If either record names a live
 /// process, nothing is touched.
 ///
-/// Unlinking a genuinely leaked-fd lock is safe: the next acquire creates a new
-/// inode, while the zombie child's flock stays on the now-orphaned old one.
+/// Automatic unlink is intentionally unsupported while non-participating older
+/// writers remain compatible. A dead owner is reported precisely, but every
+/// lock is preserved; the operator can stop the leaked holder or allow it to
+/// exit, after which the ordinary bounded acquire succeeds on the same inode.
 pub fn reclaim_stale_locks(kin_root: &Path) -> StaleLockReclaim {
-    without_blocking_runtime_worker(|| reclaim_stale_locks_with_hook(kin_root, || {}))
+    reclaim_stale_locks_within(kin_root, SINGLETON_LOCK_RETRY_BUDGET)
 }
 
+/// Resolve stale-lock evidence within the caller's remaining acquisition
+/// budget. Coordination timeout is reported fail-closed.
+pub fn reclaim_stale_locks_within(kin_root: &Path, budget: Duration) -> StaleLockReclaim {
+    let deadline = Instant::now() + budget;
+    without_blocking_runtime_worker(|| {
+        reclaim_stale_locks_with_hooks_until(kin_root, deadline, || {}, || {})
+    })
+}
+
+#[cfg(test)]
 fn reclaim_stale_locks_with_hook<F>(kin_root: &Path, before_revalidation: F) -> StaleLockReclaim
 where
     F: FnOnce(),
 {
-    let _coordination = match acquire_singleton_coordination_guard(kin_root) {
+    reclaim_stale_locks_with_hooks_until(
+        kin_root,
+        Instant::now() + SINGLETON_LOCK_RETRY_BUDGET,
+        before_revalidation,
+        || {},
+    )
+}
+
+#[cfg(test)]
+fn reclaim_stale_locks_with_hooks<F, G>(
+    kin_root: &Path,
+    before_revalidation: F,
+    after_revalidation: G,
+) -> StaleLockReclaim
+where
+    F: FnOnce(),
+    G: FnOnce(),
+{
+    reclaim_stale_locks_with_hooks_until(
+        kin_root,
+        Instant::now() + SINGLETON_LOCK_RETRY_BUDGET,
+        before_revalidation,
+        after_revalidation,
+    )
+}
+
+fn reclaim_stale_locks_with_hooks_until<F, G>(
+    kin_root: &Path,
+    deadline: Instant,
+    before_revalidation: F,
+    after_revalidation: G,
+) -> StaleLockReclaim
+where
+    F: FnOnce(),
+    G: FnOnce(),
+{
+    let _coordination = match acquire_singleton_coordination_guard_until(kin_root, deadline) {
         Ok(coordination) => coordination,
         Err(error) => {
             tracing::warn!(
@@ -413,9 +481,9 @@ where
     before_revalidation();
 
     // The coordination inode excludes every current acquisition path. Re-read
-    // anyway immediately before unlink so an older/non-participating writer,
-    // PID reuse, or an endpoint publisher cannot turn dead-owner evidence into
-    // authority over a successor.
+    // anyway so PID reuse or a current endpoint publisher is reported
+    // accurately. It cannot exclude an older/non-participating writer, which
+    // is why the verified dead-owner case below still refuses automatic unlink.
     let current = LockOwnerEvidence::read(kin_root);
     if let Some(alive) = current.live_owner() {
         return StaleLockReclaim::OwnerAlive(alive);
@@ -437,41 +505,71 @@ where
         };
     }
 
-    let mut cleared = Vec::new();
-    for lock in lock_files(kin_root) {
-        if !lock.exists() {
-            continue;
-        }
-        match std::fs::remove_file(&lock) {
-            Ok(()) => {
-                tracing::warn!(
-                    lock = %lock.display(),
-                    owner_pid = dead_owner,
-                    "reclaimed stale repo lock left by a dead daemon owner"
-                );
-                cleared.push(lock);
-            }
-            Err(err) => {
-                tracing::warn!(
-                    lock = %lock.display(),
-                    error = %err,
-                    "failed to reclaim stale repo lock"
-                );
-            }
-        }
-    }
-    StaleLockReclaim::Cleared(cleared)
+    after_revalidation();
+
+    tracing::warn!(
+        repo = %kin_root.display(),
+        owner_pid = dead_owner,
+        "recorded daemon owner is dead, but automatic singleton retirement is disabled at the \
+         mixed-version compatibility boundary; preserving every lock"
+    );
+    StaleLockReclaim::CoordinationUnavailable(format!(
+        "recorded owner pid {dead_owner} is dead, but automatic singleton retirement is \
+         unsupported while compatible older daemons may acquire without daemon.lifecycle"
+    ))
 }
 
 // ── Daemon State Files ──────────────────────────────────────────────────
 
+fn write_atomic_endpoint_component(
+    kin_root: &Path,
+    name: &str,
+    value: impl AsRef<[u8]>,
+) -> std::io::Result<()> {
+    let tmp = kin_root.join(format!("{name}.tmp"));
+    let dst = kin_root.join(name);
+    std::fs::write(&tmp, value)?;
+    std::fs::rename(tmp, dst)
+}
+
+/// Publish the daemon's complete endpoint while holding lifecycle authority.
+///
+/// Current endpoint retirement takes the same never-unlinked lock, so a
+/// successor publication cannot land between a predecessor comparison and
+/// deletion. Both temporary files are prepared before either visible component
+/// changes; on any publication failure the incomplete endpoint is removed
+/// before authority is released.
+pub fn publish_daemon_endpoint(kin_root: &Path, port: u16) -> std::io::Result<()> {
+    let _authority = acquire_singleton_coordination_guard(kin_root)?;
+    let pid = std::process::id().to_string();
+    let port = port.to_string();
+    let result: std::io::Result<()> = (|| {
+        std::fs::write(kin_root.join("daemon.pid.tmp"), pid.as_bytes())?;
+        std::fs::write(kin_root.join("daemon.port.tmp"), port.as_bytes())?;
+        std::fs::rename(kin_root.join("daemon.pid.tmp"), kin_root.join("daemon.pid"))?;
+        std::fs::rename(
+            kin_root.join("daemon.port.tmp"),
+            kin_root.join("daemon.port"),
+        )?;
+        Ok(())
+    })();
+    if result.is_err() {
+        let _ = std::fs::remove_file(kin_root.join("daemon.pid.tmp"));
+        let _ = std::fs::remove_file(kin_root.join("daemon.port.tmp"));
+        let _ = std::fs::remove_file(kin_root.join("daemon.pid"));
+        let _ = std::fs::remove_file(kin_root.join("daemon.port"));
+    }
+    result
+}
+
 /// Write PID file atomically (write tmp + rename).
+///
+/// Retained for API compatibility and tests. Production startup publishes the
+/// PID and bound port together with [`publish_daemon_endpoint`].
 pub fn write_pid_file(kin_root: &Path) {
-    let pid = std::process::id();
-    let tmp = kin_root.join("daemon.pid.tmp");
-    let dst = kin_root.join("daemon.pid");
-    if std::fs::write(&tmp, pid.to_string()).is_ok() {
-        let _ = std::fs::rename(&tmp, &dst);
+    if let Ok(_authority) = acquire_singleton_coordination_guard(kin_root) {
+        let _ =
+            write_atomic_endpoint_component(kin_root, "daemon.pid", std::process::id().to_string());
     }
 }
 
@@ -480,10 +578,8 @@ pub fn write_pid_file(kin_root: &Path) {
 /// Written atomically (temp + rename) so a CLI polling the port file during the
 /// daemon→CLI port handshake never parses a torn or partial value.
 pub fn write_port_file(kin_root: &Path, port: u16) {
-    let tmp = kin_root.join("daemon.port.tmp");
-    let dst = kin_root.join("daemon.port");
-    if std::fs::write(&tmp, port.to_string()).is_ok() {
-        let _ = std::fs::rename(&tmp, &dst);
+    if let Ok(_authority) = acquire_singleton_coordination_guard(kin_root) {
+        let _ = write_atomic_endpoint_component(kin_root, "daemon.port", port.to_string());
     }
 }
 
@@ -496,6 +592,9 @@ pub fn read_port_file(kin_root: &Path) -> Option<u16> {
 
 /// Remove PID file, but only if it's ours (prevents removing a successor's).
 pub fn remove_pid_file(kin_root: &Path) {
+    let Ok(_authority) = acquire_singleton_coordination_guard(kin_root) else {
+        return;
+    };
     let path = kin_root.join("daemon.pid");
     if let Ok(content) = std::fs::read_to_string(&path) {
         if content.trim().parse::<u32>().ok() == Some(std::process::id()) {
@@ -509,6 +608,13 @@ pub fn remove_pid_file(kin_root: &Path) {
 /// This avoids a shutdown race where an older daemon removes the port file for
 /// a newer successor that already replaced `daemon.pid`.
 pub fn remove_daemon_files_if_current_process(kin_root: &Path) {
+    let Ok(_authority) = acquire_singleton_coordination_guard(kin_root) else {
+        tracing::warn!(
+            repo = %kin_root.display(),
+            "preserving daemon endpoint because lifecycle authority is unavailable"
+        );
+        return;
+    };
     let pid_path = kin_root.join("daemon.pid");
     let belongs_to_current = std::fs::read_to_string(&pid_path)
         .ok()
@@ -535,9 +641,13 @@ pub fn daemon_is_up(kin_root: &Path) -> Option<u16> {
         .parse()
         .ok()?;
     if !is_process_alive(pid) {
-        // Stale — clean up.
-        let _ = std::fs::remove_file(kin_root.join("daemon.pid"));
-        let _ = std::fs::remove_file(kin_root.join("daemon.port"));
+        // Stale — clean up only while publication is excluded and this PID is
+        // still the endpoint owner.
+        let _authority = acquire_singleton_coordination_guard(kin_root).ok()?;
+        if recorded_daemon_pid(kin_root) == Some(pid) && !is_process_alive(pid) {
+            let _ = std::fs::remove_file(kin_root.join("daemon.pid"));
+            let _ = std::fs::remove_file(kin_root.join("daemon.port"));
+        }
         return None;
     }
     let port = read_port_file(kin_root)?;
@@ -895,6 +1005,19 @@ mod tests {
         );
     }
 
+    #[test]
+    fn complete_endpoint_publication_writes_pid_and_bound_port_together() {
+        let dir = tempfile::tempdir().unwrap();
+        let root = dir.path();
+
+        publish_daemon_endpoint(root, 51234).expect("publish endpoint");
+
+        assert_eq!(recorded_daemon_pid(root), Some(std::process::id()));
+        assert_eq!(read_port_file(root), Some(51234));
+        assert!(!root.join("daemon.pid.tmp").exists());
+        assert!(!root.join("daemon.port.tmp").exists());
+    }
+
     // ── Idle-timeout env resolution ────────────────────────────────────────
     //
     // These lock the scoped-timeout contract: user env wins over everything,
@@ -1006,10 +1129,11 @@ mod tests {
     }
 
     #[test]
-    fn reclaim_clears_locks_when_owner_pid_is_dead() {
-        // A SIGKILLed daemon whose forked child leaked the flock fd
-        // leaves a dead-owner PID and lingering lock files. The reclaim path
-        // clears them so startup proceeds instead of failing with os error 35.
+    fn reclaim_fails_closed_when_owner_pid_is_dead() {
+        // A SIGKILLed daemon whose forked child leaked the flock fd leaves a
+        // dead-owner PID and lingering lock files. Because compatible legacy
+        // starters do not take daemon.lifecycle, automatic pathname
+        // replacement cannot prove exclusion and must preserve every lock.
         let dir = tempfile::tempdir().unwrap();
         let root = dir.path();
         std::fs::create_dir_all(root.join("kindb")).unwrap();
@@ -1018,21 +1142,18 @@ mod tests {
         std::fs::write(root.join("kindb").join("graph.lock"), b"").unwrap();
 
         let reclaim = reclaim_stale_locks(root);
-        assert_eq!(
-            reclaim.cleared().len(),
-            2,
-            "both stale locks should be reclaimed"
-        );
-        assert!(!root.join("daemon.lock").exists());
-        assert!(!root.join("kindb").join("graph.lock").exists());
-
-        // Startup proceeds: the singleton lock acquires cleanly afterward.
         assert!(
-            acquire_singleton_lock(root)
-                .expect("lock IO should succeed")
-                .is_some(),
-            "singleton lock should acquire after stale-lock reclaim"
+            matches!(
+                &reclaim,
+                StaleLockReclaim::CoordinationUnavailable(reason)
+                    if reason.contains("compatible older daemons")
+                        && reason.contains("999999999")
+            ),
+            "dead-owner retirement must disclose the mixed-version boundary: {reclaim:?}"
         );
+        assert!(reclaim.cleared().is_empty());
+        assert!(root.join("daemon.lock").exists());
+        assert!(root.join("kindb").join("graph.lock").exists());
     }
 
     #[test]
@@ -1057,74 +1178,63 @@ mod tests {
     }
 
     #[test]
-    fn reclaim_serializes_a_successor_acquire_before_unlink() {
-        use std::sync::mpsc;
+    fn legacy_acquirer_after_final_read_cannot_be_unlinked() {
+        use std::cell::RefCell;
 
         let dir = tempfile::tempdir().unwrap();
-        let root = dir.path().to_path_buf();
+        let root = dir.path();
         std::fs::write(root.join("daemon.lock"), "999999999").unwrap();
+        let legacy_lock = RefCell::new(None);
 
-        let (reclaim_checked_tx, reclaim_checked_rx) = mpsc::channel();
-        let (release_reclaim_tx, release_reclaim_rx) = mpsc::channel();
-        let reclaim_root = root.clone();
-        let reclaimer = std::thread::spawn(move || {
-            reclaim_stale_locks_with_hook(&reclaim_root, || {
-                reclaim_checked_tx.send(()).unwrap();
-                release_reclaim_rx
-                    .recv_timeout(Duration::from_secs(5))
-                    .expect("test must release the reclaimer");
-            })
-        });
-        reclaim_checked_rx
-            .recv_timeout(Duration::from_secs(5))
-            .expect("reclaimer must reach its final owner check");
+        let reclaim = reclaim_stale_locks_with_hooks(
+            root,
+            || {},
+            || {
+                // This hook is after the final owner read. It models an older
+                // daemon that does not take daemon.lifecycle: acquire and stamp
+                // the existing singleton inode at the exact former unlink
+                // window.
+                let mut file = std::fs::OpenOptions::new()
+                    .read(true)
+                    .write(true)
+                    .open(root.join("daemon.lock"))
+                    .unwrap();
+                file.try_lock_exclusive()
+                    .expect("legacy successor acquires the old inode");
+                file.set_len(0).unwrap();
+                file.seek(SeekFrom::Start(0)).unwrap();
+                write!(file, "{}", std::process::id()).unwrap();
+                file.flush().unwrap();
+                legacy_lock.replace(Some(file));
+            },
+        );
 
-        let (acquire_blocked_tx, acquire_blocked_rx) = mpsc::channel();
-        let (acquired_tx, acquired_rx) = mpsc::channel();
-        let acquire_root = root.clone();
-        let successor = std::thread::spawn(move || {
-            let mut blocked_signal = Some(acquire_blocked_tx);
-            let acquired =
-                acquire_singleton_lock_inner_with_coordination_hook(&acquire_root, || {
-                    if let Some(signal) = blocked_signal.take() {
-                        signal.send(()).unwrap();
-                    }
-                });
-            acquired_tx.send(acquired).unwrap();
-        });
-        acquire_blocked_rx
-            .recv_timeout(Duration::from_secs(5))
-            .expect("successor must observe lifecycle-lock contention");
         assert!(
-            matches!(acquired_rx.try_recv(), Err(mpsc::TryRecvError::Empty)),
-            "a successor must not acquire and stamp daemon.lock while a reclaimer can still \
-             unlink that inode"
+            matches!(
+                &reclaim,
+                StaleLockReclaim::CoordinationUnavailable(reason)
+                    if reason.contains("compatible older daemons")
+                        && reason.contains("999999999")
+            ),
+            "the legacy-acquirer seam must fail closed: {reclaim:?}"
         );
-
-        release_reclaim_tx.send(()).unwrap();
-        let reclaim = reclaimer.join().expect("reclaimer must not panic");
+        assert!(root.join("daemon.lock").exists());
         assert_eq!(
-            reclaim.cleared(),
-            &[root.join("daemon.lock")],
-            "the dead predecessor inode should be cleared before the successor opens one"
-        );
-
-        let lock = acquired_rx
-            .recv_timeout(Duration::from_secs(5))
-            .expect("successor must finish after reclaim releases coordination")
-            .expect("successor acquisition IO")
-            .expect("successor must acquire the replacement inode");
-        successor.join().expect("successor must not panic");
-        assert_eq!(
-            lock_owner_pid(&root),
+            lock_owner_pid(root),
             Some(std::process::id()),
-            "the replacement inode must retain the successor's live owner stamp"
+            "the legacy successor's stamp must survive the former unlink window"
         );
-        drop(lock);
+        assert!(
+            acquire_singleton_lock_within(root, Duration::ZERO)
+                .expect("current acquire IO")
+                .is_none(),
+            "current acquisition must observe the legacy holder on the preserved inode"
+        );
+        drop(legacy_lock.into_inner());
     }
 
     #[test]
-    fn reclaim_revalidates_owner_evidence_immediately_before_unlink() {
+    fn reclaim_revalidates_owner_evidence_before_reporting_retirement_boundary() {
         let dir = tempfile::tempdir().unwrap();
         let root = dir.path();
         std::fs::write(root.join("daemon.lock"), "999999999").unwrap();
@@ -1230,13 +1340,17 @@ mod tests {
         );
 
         let reclaim = reclaim_stale_locks(root);
-        assert_eq!(
-            reclaim.cleared().len(),
-            2,
-            "a dead owner named only by the lock stamp must still be reclaimable"
+        assert!(
+            matches!(
+                &reclaim,
+                StaleLockReclaim::CoordinationUnavailable(reason)
+                    if reason.contains("compatible older daemons")
+                        && reason.contains("999999999")
+            ),
+            "dead stamp-only ownership must fail closed: {reclaim:?}"
         );
-        assert!(!root.join("daemon.lock").exists());
-        assert!(!root.join("kindb").join("graph.lock").exists());
+        assert!(root.join("daemon.lock").exists());
+        assert!(root.join("kindb").join("graph.lock").exists());
     }
 
     #[test]
@@ -1317,6 +1431,30 @@ mod tests {
             "the retry must be bounded, not a spin"
         );
         drop(held);
+    }
+
+    #[test]
+    fn bounded_retry_deadline_includes_lifecycle_coordination() {
+        let dir = tempfile::tempdir().unwrap();
+        let root = dir.path();
+        let lifecycle = acquire_singleton_coordination_guard(root)
+            .expect("test must hold lifecycle coordination");
+
+        let started = Instant::now();
+        let budget = Duration::from_millis(150);
+        let contended =
+            acquire_singleton_lock_within(root, budget).expect("bounded acquire result");
+
+        assert!(contended.is_none());
+        assert!(
+            started.elapsed() >= budget,
+            "the caller budget must be honored rather than skipped"
+        );
+        assert!(
+            started.elapsed() < Duration::from_secs(1),
+            "the inner lifecycle wait must not substitute its five-second budget"
+        );
+        drop(lifecycle);
     }
 
     #[test]

--- a/crates/kin-daemon/src/lifecycle.rs
+++ b/crates/kin-daemon/src/lifecycle.rs
@@ -35,6 +35,18 @@ use tracing::info;
 #[derive(Debug)]
 pub struct DaemonLock {
     file: std::fs::File,
+    canonical_kin_root: PathBuf,
+}
+
+impl DaemonLock {
+    /// Canonical `.kin` root whose singleton this capability protects.
+    ///
+    /// Carrying the repository identity with the file handle prevents a caller
+    /// from replaying authority acquired for repo A while starting state opened
+    /// from repo B.
+    pub fn canonical_kin_root(&self) -> &Path {
+        &self.canonical_kin_root
+    }
 }
 
 impl Drop for DaemonLock {
@@ -140,12 +152,13 @@ fn acquire_singleton_lock_inner_until_with_coordination_hook<F>(
 where
     F: FnMut(),
 {
+    let canonical_kin_root = kin_root.canonicalize()?;
     let _coordination = acquire_singleton_coordination_guard_until_with_hook(
-        kin_root,
+        &canonical_kin_root,
         deadline,
         on_coordination_contention,
     )?;
-    let path = kin_root.join("daemon.lock");
+    let path = canonical_kin_root.join("daemon.lock");
     let mut file = std::fs::OpenOptions::new()
         .create(true)
         .read(true)
@@ -157,7 +170,10 @@ where
             // Record ownership while holding the lock, so a contender that
             // fails to acquire can always name the process it lost to.
             stamp_lock_owner(&mut file);
-            Ok(Some(DaemonLock { file }))
+            Ok(Some(DaemonLock {
+                file,
+                canonical_kin_root,
+            }))
         }
         // fs2 reports contention with the platform's "would block" error
         // (EWOULDBLOCK on Unix). Treat that — and only that — as "already

--- a/crates/kin-daemon/src/lifecycle.rs
+++ b/crates/kin-daemon/src/lifecycle.rs
@@ -26,9 +26,10 @@ use tracing::info;
 /// when the process dies — including a hard `SIGKILL` — so it can never go
 /// stale and strand the repo.
 ///
-/// The on-disk lock file is intentionally never unlinked: removing it would
-/// open a TOCTOU window where a second daemon creates and locks a fresh file
-/// while the first still believes it holds the lock.
+/// The on-disk lock file is unlinked only by dead-owner recovery while holding
+/// the separate lifecycle coordination lock. Acquisition takes that same
+/// coordination lock before opening this inode, so no successor can lock and
+/// stamp the old inode between the reclaimer's owner check and unlink.
 #[derive(Debug)]
 pub struct DaemonLock {
     file: std::fs::File,
@@ -115,6 +116,22 @@ pub fn singleton_lock_holder(kin_root: &Path) -> Option<SingletonLockHolder> {
 ///   not start a second daemon and should exit cleanly.
 /// - `Err(_)` — an unexpected IO error opening the lock file.
 pub fn acquire_singleton_lock(kin_root: &Path) -> std::io::Result<Option<DaemonLock>> {
+    without_blocking_runtime_worker(|| acquire_singleton_lock_inner(kin_root))
+}
+
+fn acquire_singleton_lock_inner(kin_root: &Path) -> std::io::Result<Option<DaemonLock>> {
+    acquire_singleton_lock_inner_with_coordination_hook(kin_root, || {})
+}
+
+fn acquire_singleton_lock_inner_with_coordination_hook<F>(
+    kin_root: &Path,
+    on_coordination_contention: F,
+) -> std::io::Result<Option<DaemonLock>>
+where
+    F: FnMut(),
+{
+    let _coordination =
+        acquire_singleton_coordination_guard_with_hook(kin_root, on_coordination_contention)?;
     let path = kin_root.join("daemon.lock");
     let mut file = std::fs::OpenOptions::new()
         .create(true)
@@ -137,6 +154,50 @@ pub fn acquire_singleton_lock(kin_root: &Path) -> std::io::Result<Option<DaemonL
     }
 }
 
+/// Serialize daemon-lock inode replacement against acquisition.
+///
+/// `daemon.lock` itself cannot provide this serialization: dead-owner recovery
+/// exists specifically because a leaked child fd can keep that inode locked
+/// after its daemon owner dies. This second, never-unlinked inode is held only
+/// for the short owner-check/open/stamp critical section. A bounded acquire
+/// fails closed if an inherited coordination fd ever does leak.
+fn acquire_singleton_coordination_guard(kin_root: &Path) -> std::io::Result<std::fs::File> {
+    acquire_singleton_coordination_guard_with_hook(kin_root, || {})
+}
+
+fn acquire_singleton_coordination_guard_with_hook<F>(
+    kin_root: &Path,
+    mut on_contention: F,
+) -> std::io::Result<std::fs::File>
+where
+    F: FnMut(),
+{
+    let path = kin_root.join("daemon.lifecycle");
+    let file = std::fs::OpenOptions::new()
+        .create(true)
+        .read(true)
+        .write(true)
+        .truncate(false)
+        .open(path)?;
+    let deadline = std::time::Instant::now() + SINGLETON_LOCK_RETRY_BUDGET;
+    loop {
+        match file.try_lock_exclusive() {
+            Ok(()) => return Ok(file),
+            Err(err) if err.kind() == fs2::lock_contended_error().kind() => {
+                on_contention();
+                if std::time::Instant::now() >= deadline {
+                    return Err(std::io::Error::new(
+                        std::io::ErrorKind::WouldBlock,
+                        "timed out waiting for daemon lifecycle coordination lock",
+                    ));
+                }
+                std::thread::sleep(SINGLETON_LOCK_RETRY_INTERVAL);
+            }
+            Err(err) => return Err(err),
+        }
+    }
+}
+
 /// Acquire the singleton lock, retrying for a bounded window while the lock is
 /// contended.
 ///
@@ -155,7 +216,7 @@ pub fn acquire_singleton_lock_within(
     without_blocking_runtime_worker(|| {
         let deadline = std::time::Instant::now() + budget;
         loop {
-            if let Some(lock) = acquire_singleton_lock(kin_root)? {
+            if let Some(lock) = acquire_singleton_lock_inner(kin_root)? {
                 return Ok(Some(lock));
             }
             if std::time::Instant::now() >= deadline {
@@ -206,6 +267,33 @@ fn recorded_daemon_pid(kin_root: &Path) -> Option<u32> {
         .and_then(|content| content.trim().parse::<u32>().ok())
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+struct LockOwnerEvidence {
+    lock_owner: Option<u32>,
+    endpoint_owner: Option<u32>,
+}
+
+impl LockOwnerEvidence {
+    fn read(kin_root: &Path) -> Self {
+        Self {
+            lock_owner: lock_owner_pid(kin_root),
+            endpoint_owner: recorded_daemon_pid(kin_root),
+        }
+    }
+
+    fn owners(self) -> impl Iterator<Item = u32> {
+        [self.lock_owner, self.endpoint_owner].into_iter().flatten()
+    }
+
+    fn live_owner(self) -> Option<u32> {
+        self.owners().find(|pid| is_process_alive(*pid))
+    }
+
+    fn first_owner(self) -> Option<u32> {
+        self.owners().next()
+    }
+}
+
 /// All on-disk lock files for a repo: the daemon singleton lock under the `.kin`
 /// root, plus every `*.lock` under `.kin/kindb/` (kin-db's snapshot `graph.lock`
 /// and any future sibling such as a kvec write lock). Enumerated by extension so
@@ -238,6 +326,18 @@ pub enum StaleLockReclaim {
     /// Neither the lock file's owner stamp nor `daemon.pid` names an owner, so
     /// liveness cannot be established and reclaiming would be a guess.
     OwnerUnknown,
+    /// Ownership evidence changed after the dead-owner check. The new state is
+    /// preserved rather than unlinking an inode whose authority is no longer
+    /// the one that was evaluated.
+    OwnerChanged {
+        previous_lock_owner: Option<u32>,
+        previous_endpoint_owner: Option<u32>,
+        current_lock_owner: Option<u32>,
+        current_endpoint_owner: Option<u32>,
+    },
+    /// The separate acquisition/reclaim coordination inode could not be
+    /// acquired. Recovery fails closed instead of unlinking without exclusion.
+    CoordinationUnavailable(String),
 }
 
 impl StaleLockReclaim {
@@ -278,14 +378,30 @@ impl StaleLockReclaim {
 /// Unlinking a genuinely leaked-fd lock is safe: the next acquire creates a new
 /// inode, while the zombie child's flock stays on the now-orphaned old one.
 pub fn reclaim_stale_locks(kin_root: &Path) -> StaleLockReclaim {
-    let recorded: Vec<u32> = [lock_owner_pid(kin_root), recorded_daemon_pid(kin_root)]
-        .into_iter()
-        .flatten()
-        .collect();
-    if let Some(alive) = recorded.iter().copied().find(|pid| is_process_alive(*pid)) {
+    without_blocking_runtime_worker(|| reclaim_stale_locks_with_hook(kin_root, || {}))
+}
+
+fn reclaim_stale_locks_with_hook<F>(kin_root: &Path, before_revalidation: F) -> StaleLockReclaim
+where
+    F: FnOnce(),
+{
+    let _coordination = match acquire_singleton_coordination_guard(kin_root) {
+        Ok(coordination) => coordination,
+        Err(error) => {
+            tracing::warn!(
+                repo = %kin_root.display(),
+                error = %error,
+                "refusing stale-lock reclaim without lifecycle coordination"
+            );
+            return StaleLockReclaim::CoordinationUnavailable(error.to_string());
+        }
+    };
+
+    let previous = LockOwnerEvidence::read(kin_root);
+    if let Some(alive) = previous.live_owner() {
         return StaleLockReclaim::OwnerAlive(alive);
     }
-    let Some(&dead_owner) = recorded.first() else {
+    let Some(dead_owner) = previous.first_owner() else {
         tracing::warn!(
             repo = %kin_root.display(),
             "repo lock is contended but no owner is recorded in daemon.lock or daemon.pid; \
@@ -293,6 +409,33 @@ pub fn reclaim_stale_locks(kin_root: &Path) -> StaleLockReclaim {
         );
         return StaleLockReclaim::OwnerUnknown;
     };
+
+    before_revalidation();
+
+    // The coordination inode excludes every current acquisition path. Re-read
+    // anyway immediately before unlink so an older/non-participating writer,
+    // PID reuse, or an endpoint publisher cannot turn dead-owner evidence into
+    // authority over a successor.
+    let current = LockOwnerEvidence::read(kin_root);
+    if let Some(alive) = current.live_owner() {
+        return StaleLockReclaim::OwnerAlive(alive);
+    }
+    if current != previous {
+        tracing::warn!(
+            repo = %kin_root.display(),
+            previous_lock_owner = ?previous.lock_owner,
+            previous_endpoint_owner = ?previous.endpoint_owner,
+            current_lock_owner = ?current.lock_owner,
+            current_endpoint_owner = ?current.endpoint_owner,
+            "daemon lock ownership changed during stale-lock reclaim; preserving all locks"
+        );
+        return StaleLockReclaim::OwnerChanged {
+            previous_lock_owner: previous.lock_owner,
+            previous_endpoint_owner: previous.endpoint_owner,
+            current_lock_owner: current.lock_owner,
+            current_endpoint_owner: current.endpoint_owner,
+        };
+    }
 
     let mut cleared = Vec::new();
     for lock in lock_files(kin_root) {
@@ -381,15 +524,7 @@ pub fn remove_daemon_files_if_current_process(kin_root: &Path) {
 
 /// Is the process with this PID alive?
 fn is_process_alive(pid: u32) -> bool {
-    #[cfg(unix)]
-    {
-        unsafe { libc::kill(pid as libc::pid_t, 0) == 0 }
-    }
-    #[cfg(not(unix))]
-    {
-        let _ = pid;
-        true
-    }
+    kin_cli::daemon_client::is_process_alive(pid)
 }
 
 /// Is the daemon running for this repo? Checks PID file + port reachable.
@@ -919,6 +1054,97 @@ mod tests {
         );
         assert!(root.join("daemon.lock").exists());
         assert!(root.join("kindb").join("graph.lock").exists());
+    }
+
+    #[test]
+    fn reclaim_serializes_a_successor_acquire_before_unlink() {
+        use std::sync::mpsc;
+
+        let dir = tempfile::tempdir().unwrap();
+        let root = dir.path().to_path_buf();
+        std::fs::write(root.join("daemon.lock"), "999999999").unwrap();
+
+        let (reclaim_checked_tx, reclaim_checked_rx) = mpsc::channel();
+        let (release_reclaim_tx, release_reclaim_rx) = mpsc::channel();
+        let reclaim_root = root.clone();
+        let reclaimer = std::thread::spawn(move || {
+            reclaim_stale_locks_with_hook(&reclaim_root, || {
+                reclaim_checked_tx.send(()).unwrap();
+                release_reclaim_rx
+                    .recv_timeout(Duration::from_secs(5))
+                    .expect("test must release the reclaimer");
+            })
+        });
+        reclaim_checked_rx
+            .recv_timeout(Duration::from_secs(5))
+            .expect("reclaimer must reach its final owner check");
+
+        let (acquire_blocked_tx, acquire_blocked_rx) = mpsc::channel();
+        let (acquired_tx, acquired_rx) = mpsc::channel();
+        let acquire_root = root.clone();
+        let successor = std::thread::spawn(move || {
+            let mut blocked_signal = Some(acquire_blocked_tx);
+            let acquired =
+                acquire_singleton_lock_inner_with_coordination_hook(&acquire_root, || {
+                    if let Some(signal) = blocked_signal.take() {
+                        signal.send(()).unwrap();
+                    }
+                });
+            acquired_tx.send(acquired).unwrap();
+        });
+        acquire_blocked_rx
+            .recv_timeout(Duration::from_secs(5))
+            .expect("successor must observe lifecycle-lock contention");
+        assert!(
+            matches!(acquired_rx.try_recv(), Err(mpsc::TryRecvError::Empty)),
+            "a successor must not acquire and stamp daemon.lock while a reclaimer can still \
+             unlink that inode"
+        );
+
+        release_reclaim_tx.send(()).unwrap();
+        let reclaim = reclaimer.join().expect("reclaimer must not panic");
+        assert_eq!(
+            reclaim.cleared(),
+            &[root.join("daemon.lock")],
+            "the dead predecessor inode should be cleared before the successor opens one"
+        );
+
+        let lock = acquired_rx
+            .recv_timeout(Duration::from_secs(5))
+            .expect("successor must finish after reclaim releases coordination")
+            .expect("successor acquisition IO")
+            .expect("successor must acquire the replacement inode");
+        successor.join().expect("successor must not panic");
+        assert_eq!(
+            lock_owner_pid(&root),
+            Some(std::process::id()),
+            "the replacement inode must retain the successor's live owner stamp"
+        );
+        drop(lock);
+    }
+
+    #[test]
+    fn reclaim_revalidates_owner_evidence_immediately_before_unlink() {
+        let dir = tempfile::tempdir().unwrap();
+        let root = dir.path();
+        std::fs::write(root.join("daemon.lock"), "999999999").unwrap();
+
+        let reclaim = reclaim_stale_locks_with_hook(root, || {
+            // Simulate an older/non-participating successor that does not take
+            // daemon.lifecycle. The final evidence read must still catch it.
+            std::fs::write(root.join("daemon.lock"), std::process::id().to_string()).unwrap();
+        });
+
+        assert_eq!(
+            reclaim,
+            StaleLockReclaim::OwnerAlive(std::process::id()),
+            "a newly live owner must cancel stale-owner recovery"
+        );
+        assert!(
+            root.join("daemon.lock").exists(),
+            "revalidation must preserve the successor's inode"
+        );
+        assert_eq!(lock_owner_pid(root), Some(std::process::id()));
     }
 
     #[test]

--- a/crates/kin-daemon/src/lifecycle.rs
+++ b/crates/kin-daemon/src/lifecycle.rs
@@ -938,7 +938,7 @@ mod tests {
         assert!(root.join("kindb").join("graph.lock").exists());
     }
 
-    // ── FIR-1583: reclaim must work without daemon.pid ────────────────────
+    // ── Reclaim must work without daemon.pid ──────────────────────────────
     //
     // The deadlock chain ended here: a client cleared a live daemon's endpoint
     // files, so when that daemon later died by SIGKILL there was no daemon.pid

--- a/crates/kin-daemon/src/session_registry.rs
+++ b/crates/kin-daemon/src/session_registry.rs
@@ -1015,30 +1015,8 @@ fn timestamp_age(ts: &Timestamp, now: &Timestamp) -> Option<Duration> {
     }
 }
 
-/// Check if a process is alive by checking /proc or using kill -0.
 fn is_process_alive(pid: u32) -> bool {
-    // Use std::fs to check /proc on Linux, or signal 0 via Command on macOS/Unix.
-    #[cfg(target_os = "linux")]
-    {
-        std::path::Path::new(&format!("/proc/{}", pid)).exists()
-    }
-    #[cfg(target_os = "macos")]
-    {
-        // On macOS, use `kill -0 <pid>` via Command to avoid libc dependency.
-        std::process::Command::new("kill")
-            .args(["-0", &pid.to_string()])
-            .stdout(std::process::Stdio::null())
-            .stderr(std::process::Stdio::null())
-            .status()
-            .map(|s| s.success())
-            .unwrap_or(true) // If we can't check, assume alive (conservative).
-    }
-    #[cfg(not(any(target_os = "linux", target_os = "macos")))]
-    {
-        // On unsupported platforms, assume alive (conservative).
-        let _ = pid;
-        true
-    }
+    kin_cli::daemon_client::is_process_alive(pid)
 }
 
 #[cfg(test)]

--- a/crates/kin-daemon/src/state.rs
+++ b/crates/kin-daemon/src/state.rs
@@ -4602,7 +4602,7 @@ mod tests {
             .expect("daemon test fixtures must open through repository-v6 workspace authority")
     }
 
-    // ── FIR-1583: the warming signal must be exact ────────────────────────
+    // ── The warming signal must be exact ──────────────────────────────────
     //
     // "Busy warming" is what lets a client tell a live daemon from a dead one.
     // A signal that leaks true after a warm-up ends would make every later

--- a/crates/kin-daemon/src/state.rs
+++ b/crates/kin-daemon/src/state.rs
@@ -961,12 +961,21 @@ pub struct DaemonState {
     /// - `InMemorySpineBackend`: local dev / single daemon (default)
     /// - `FirestoreSpineBackend`: cloud / stateless daemon pool (when GOOGLE_CLOUD_PROJECT is set)
     pub spine: std::sync::OnceLock<Arc<dyn kin_spine::SpineBackend>>,
-    /// True while lazy spine initialization is loading sibling repository
-    /// graphs. This is the daemon's honest "busy warming" signal: the process
-    /// is alive and its own repo is served, but a cross-repo surface is still
-    /// materializing. Clients must treat it as alive-and-waiting, never as a
-    /// dead endpoint.
+    /// Serializes the complete lazy initialization pass. `OnceLock` serializes
+    /// publication only; without this gate, multiple callers can concurrently
+    /// perform the full O(graph) capture/load/build pass and one warm guard can
+    /// clear the shared signal while another initializer is still running.
+    spine_initialization: Mutex<()>,
+    /// True throughout the complete lazy spine initialization pass, including
+    /// primary capture, sibling loading, edge construction, and publication.
+    /// This is the daemon's honest "busy warming" signal: the process is alive
+    /// and its own repo is served, but a cross-repo surface is materializing.
+    /// Clients must treat it as alive-and-waiting, never as a dead endpoint.
     spine_warming: AtomicBool,
+    /// Deterministic blocking seam for concurrency and runtime-starvation
+    /// regression tests. Production initialization has no injected hook.
+    #[cfg(test)]
+    spine_initialization_test_hook: Mutex<Option<Arc<dyn Fn() + Send + Sync>>>,
     /// Serializes hosted repo registration and all-repo edge refresh passes.
     /// The backend independently keeps a pass-wide incomplete lease; this gate
     /// prevents daemon request paths from racing that lease with a new ingest.
@@ -1751,7 +1760,10 @@ impl DaemonState {
             event_tx: tokio::sync::broadcast::channel(256).0,
             session_scopes: RwLock::new(HashMap::new()),
             spine: std::sync::OnceLock::new(),
+            spine_initialization: Mutex::new(()),
             spine_warming: AtomicBool::new(false),
+            #[cfg(test)]
+            spine_initialization_test_hook: Mutex::new(None),
             spine_refresh_gate: tokio::sync::Mutex::new(()),
             repo_graphs: RwLock::new(HashMap::new()),
             allowed_repo_ids: None,
@@ -1916,7 +1928,10 @@ impl DaemonState {
             event_tx: tokio::sync::broadcast::channel(256).0,
             session_scopes: RwLock::new(HashMap::new()),
             spine: std::sync::OnceLock::new(),
+            spine_initialization: Mutex::new(()),
             spine_warming: AtomicBool::new(false),
+            #[cfg(test)]
+            spine_initialization_test_hook: Mutex::new(None),
             spine_refresh_gate: tokio::sync::Mutex::new(()),
             repo_graphs: RwLock::new(HashMap::new()), // populated below
             allowed_repo_ids,
@@ -2001,7 +2016,19 @@ impl DaemonState {
             return None;
         }
         if self.spine.get().is_none() {
-            self.initialize_spine_lazy();
+            // The entire synchronous O(graph) pass belongs inside the Tokio
+            // blocking handoff, not only the sibling thread join buried within
+            // it. The mutex is acquired there too so a contending initializer
+            // cannot park another async worker.
+            without_blocking_runtime_worker(|| {
+                let _initialization = self
+                    .spine_initialization
+                    .lock()
+                    .unwrap_or_else(std::sync::PoisonError::into_inner);
+                if self.spine.get().is_none() {
+                    self.initialize_spine_lazy();
+                }
+            });
         }
         self.spine.get().map(|s| s.as_ref())
     }
@@ -2099,7 +2126,8 @@ impl DaemonState {
 
     /// Lazily initialize the spine from the loaded graph and startup-pinned
     /// sibling authority capabilities.
-    /// Called by `ensure_spine()` on first access. Thread-safe via `OnceLock`.
+    /// Called by `ensure_spine()` on first access while holding
+    /// `spine_initialization`; `OnceLock` remains the publication edge.
     ///
     /// Backend selection:
     /// - If `GOOGLE_CLOUD_PROJECT` is set AND the `firestore` feature is enabled
@@ -2110,10 +2138,20 @@ impl DaemonState {
         self.initialize_spine_lazy_with_publication_hook(|| {});
     }
 
-    /// Whether lazy spine initialization is currently loading sibling
-    /// repository graphs.
+    /// Whether a complete lazy spine initialization pass is in progress.
     pub fn spine_warming(&self) -> bool {
         self.spine_warming.load(Ordering::Relaxed)
+    }
+
+    #[cfg(test)]
+    pub(crate) fn set_spine_initialization_test_hook(
+        &self,
+        hook: Option<Arc<dyn Fn() + Send + Sync>>,
+    ) {
+        *self
+            .spine_initialization_test_hook
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner) = hook;
     }
 
     fn load_registered_workspace_graph(
@@ -2149,6 +2187,21 @@ impl DaemonState {
             return;
         }
 
+        // Announce the warm-up before any O(graph) capture or construction so
+        // liveness surfaces remain honest for the complete blocking pass. The
+        // serialization gate around this method guarantees only one guard can
+        // exist, and Drop clears it on every exit path including a panic.
+        let _warming = SpineWarmGuard::arm(&self.spine_warming);
+        #[cfg(test)]
+        if let Some(hook) = self
+            .spine_initialization_test_hook
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner)
+            .clone()
+        {
+            hook();
+        }
+
         // Capture the mutable primary before constructing or publishing the
         // OnceLock value. A busy writer therefore leaves the spine uninitialized
         // and the next request retries instead of permanently caching an empty
@@ -2168,11 +2221,6 @@ impl DaemonState {
         let mut captures = vec![primary];
         let mut authority_incomplete = self.registered_local_repository_authority_incomplete;
 
-        // Announce the warm-up before the first sibling load so liveness
-        // surfaces can report "alive and warming" for its whole duration. The
-        // guard clears the flag on every exit path, including a panic.
-        let _warming = SpineWarmGuard::arm(&self.spine_warming);
-
         // Capture only sibling capabilities frozen during startup. Lazy
         // initialization may load graph bytes, but cannot rediscover registry
         // paths, manifests, or storage roots from a request.
@@ -2184,15 +2232,12 @@ impl DaemonState {
                 .spawn(move || Self::load_registered_workspace_graph(&binding))
                 .map_err(|error| format!("spawn sibling authority load: {error}"))
                 .and_then(|handle| {
-                    // Wait for the sibling load without holding a runtime
-                    // worker: this join can run for minutes on a large
-                    // registered repo, and readiness must stay answerable
-                    // throughout.
-                    without_blocking_runtime_worker(|| {
-                        handle
-                            .join()
-                            .map_err(|_| "sibling authority loader panicked".to_string())
-                    })
+                    // `ensure_spine` handed off the complete initialization pass
+                    // before reaching this join, so no nested runtime blocking
+                    // handoff is needed here.
+                    handle
+                        .join()
+                        .map_err(|_| "sibling authority loader panicked".to_string())
                 })
                 .and_then(|result| result);
 
@@ -5101,6 +5146,87 @@ mod tests {
         assert!(retried, "the next request must retry initialization");
         assert_eq!(registered_root.as_deref(), Some(expected_root.as_str()));
         assert!(registered_entity);
+    }
+
+    #[test]
+    #[serial_test::serial]
+    fn concurrent_spine_callers_share_one_truthful_initialization() {
+        use std::sync::{mpsc, Condvar};
+
+        let registry_dir = tempfile::tempdir().unwrap();
+        let registry_path = registry_dir.path().join("registry.toml");
+        kin_core::registry::KinRegistry { repos: Vec::new() }
+            .save_to(&registry_path)
+            .unwrap();
+        let prev_registry = std::env::var_os("KIN_REGISTRY_PATH");
+        let prev_disable = std::env::var_os("KIN_DISABLE_SPINE");
+        std::env::set_var("KIN_REGISTRY_PATH", &registry_path);
+        std::env::remove_var("KIN_DISABLE_SPINE");
+
+        let repo_dir = tempfile::tempdir().unwrap();
+        let init = kin_core::init(repo_dir.path()).unwrap();
+        let state = Arc::new(test_state(init.layout, repo_dir.path()));
+        let hook_calls = Arc::new(AtomicUsize::new(0));
+        let release = Arc::new((Mutex::new(false), Condvar::new()));
+        let (entered_tx, entered_rx) = mpsc::channel();
+        let hook_calls_for_hook = Arc::clone(&hook_calls);
+        let release_for_hook = Arc::clone(&release);
+        state.set_spine_initialization_test_hook(Some(Arc::new(move || {
+            hook_calls_for_hook.fetch_add(1, Ordering::SeqCst);
+            let _ = entered_tx.send(());
+            let (released, wake) = &*release_for_hook;
+            let released = released
+                .lock()
+                .unwrap_or_else(std::sync::PoisonError::into_inner);
+            let _ = wake
+                .wait_timeout_while(released, Duration::from_secs(120), |released| !*released)
+                .unwrap_or_else(std::sync::PoisonError::into_inner);
+        })));
+
+        let first_state = Arc::clone(&state);
+        let first = std::thread::spawn(move || first_state.ensure_spine().is_some());
+        entered_rx
+            .recv_timeout(Duration::from_secs(30))
+            .expect("first initializer must enter the blocking seam");
+        assert!(
+            state.spine_warming(),
+            "the daemon must report warming for the blocked initialization"
+        );
+
+        let second_state = Arc::clone(&state);
+        let second = std::thread::spawn(move || second_state.ensure_spine().is_some());
+        std::thread::sleep(Duration::from_millis(250));
+        let calls_while_blocked = hook_calls.load(Ordering::SeqCst);
+
+        let (released, wake) = &*release;
+        *released
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner) = true;
+        wake.notify_all();
+        assert!(first.join().unwrap(), "first caller must publish the spine");
+        assert!(
+            second.join().unwrap(),
+            "second caller must reuse the published spine"
+        );
+
+        match prev_registry {
+            Some(value) => std::env::set_var("KIN_REGISTRY_PATH", value),
+            None => std::env::remove_var("KIN_REGISTRY_PATH"),
+        }
+        match prev_disable {
+            Some(value) => std::env::set_var("KIN_DISABLE_SPINE", value),
+            None => std::env::remove_var("KIN_DISABLE_SPINE"),
+        }
+
+        assert_eq!(
+            calls_while_blocked, 1,
+            "OnceLock publication alone must not allow duplicate O(graph) initializers"
+        );
+        assert_eq!(hook_calls.load(Ordering::SeqCst), 1);
+        assert!(
+            !state.spine_warming(),
+            "warming must clear only after the sole initializer exits"
+        );
     }
 
     #[test]

--- a/crates/kin-daemon/src/state.rs
+++ b/crates/kin-daemon/src/state.rs
@@ -4640,14 +4640,6 @@ mod tests {
         );
     }
 
-    #[test]
-    fn a_daemon_with_no_warm_up_in_flight_does_not_claim_to_be_warming() {
-        let fixture = tempfile::tempdir().expect("tempdir");
-        let initialized = kin_core::init(fixture.path()).expect("init fixture repository");
-        let state = test_state(initialized.layout, fixture.path());
-        assert!(!state.spine_warming());
-    }
-
     fn test_entity(name: &str, file_path: &str) -> Entity {
         Entity {
             id: kin_model::EntityId::new(),

--- a/crates/kin-daemon/src/state.rs
+++ b/crates/kin-daemon/src/state.rs
@@ -671,6 +671,27 @@ struct SpineGraphCapture {
     relations: Vec<kin_model::Relation>,
 }
 
+use crate::lifecycle::without_blocking_runtime_worker;
+
+/// Holds the "spine is warming" signal up for exactly as long as sibling loads
+/// are in flight, clearing it on every exit path including an unwind.
+struct SpineWarmGuard<'a> {
+    flag: &'a AtomicBool,
+}
+
+impl<'a> SpineWarmGuard<'a> {
+    fn arm(flag: &'a AtomicBool) -> Self {
+        flag.store(true, Ordering::Relaxed);
+        Self { flag }
+    }
+}
+
+impl Drop for SpineWarmGuard<'_> {
+    fn drop(&mut self) {
+        self.flag.store(false, Ordering::Relaxed);
+    }
+}
+
 /// One local sibling repository capability frozen while the daemon starts.
 ///
 /// Lazy spine initialization may load graph bytes later, but it must never
@@ -940,6 +961,12 @@ pub struct DaemonState {
     /// - `InMemorySpineBackend`: local dev / single daemon (default)
     /// - `FirestoreSpineBackend`: cloud / stateless daemon pool (when GOOGLE_CLOUD_PROJECT is set)
     pub spine: std::sync::OnceLock<Arc<dyn kin_spine::SpineBackend>>,
+    /// True while lazy spine initialization is loading sibling repository
+    /// graphs. This is the daemon's honest "busy warming" signal: the process
+    /// is alive and its own repo is served, but a cross-repo surface is still
+    /// materializing. Clients must treat it as alive-and-waiting, never as a
+    /// dead endpoint.
+    spine_warming: AtomicBool,
     /// Serializes hosted repo registration and all-repo edge refresh passes.
     /// The backend independently keeps a pass-wide incomplete lease; this gate
     /// prevents daemon request paths from racing that lease with a new ingest.
@@ -1500,9 +1527,10 @@ impl DaemonState {
             }
         }
 
-        // Reclaim stale daemon/runtime locks left by a dead process. A no-op
-        // unless the recorded owner PID is present and dead, so a live
-        // daemon's locks are never touched.
+        // Reclaim stale daemon/runtime locks left by a dead process. Acts only
+        // on a recorded owner that is present and dead, so a live daemon's
+        // locks are never touched; every declining outcome is logged by the
+        // reclaim itself rather than silently swallowed here.
         let _ = crate::lifecycle::reclaim_stale_locks(layout.root());
 
         // Resolve repository identity before opening any graph state. The
@@ -1723,6 +1751,7 @@ impl DaemonState {
             event_tx: tokio::sync::broadcast::channel(256).0,
             session_scopes: RwLock::new(HashMap::new()),
             spine: std::sync::OnceLock::new(),
+            spine_warming: AtomicBool::new(false),
             spine_refresh_gate: tokio::sync::Mutex::new(()),
             repo_graphs: RwLock::new(HashMap::new()),
             allowed_repo_ids: None,
@@ -1887,6 +1916,7 @@ impl DaemonState {
             event_tx: tokio::sync::broadcast::channel(256).0,
             session_scopes: RwLock::new(HashMap::new()),
             spine: std::sync::OnceLock::new(),
+            spine_warming: AtomicBool::new(false),
             spine_refresh_gate: tokio::sync::Mutex::new(()),
             repo_graphs: RwLock::new(HashMap::new()), // populated below
             allowed_repo_ids,
@@ -2080,6 +2110,12 @@ impl DaemonState {
         self.initialize_spine_lazy_with_publication_hook(|| {});
     }
 
+    /// Whether lazy spine initialization is currently loading sibling
+    /// repository graphs.
+    pub fn spine_warming(&self) -> bool {
+        self.spine_warming.load(Ordering::Relaxed)
+    }
+
     fn load_registered_workspace_graph(
         binding: &kin_core::LocalRepositoryAuthorityBinding,
     ) -> std::result::Result<Arc<kin_db::InMemoryGraph>, String> {
@@ -2132,6 +2168,11 @@ impl DaemonState {
         let mut captures = vec![primary];
         let mut authority_incomplete = self.registered_local_repository_authority_incomplete;
 
+        // Announce the warm-up before the first sibling load so liveness
+        // surfaces can report "alive and warming" for its whole duration. The
+        // guard clears the flag on every exit path, including a panic.
+        let _warming = SpineWarmGuard::arm(&self.spine_warming);
+
         // Capture only sibling capabilities frozen during startup. Lazy
         // initialization may load graph bytes, but cannot rediscover registry
         // paths, manifests, or storage roots from a request.
@@ -2143,9 +2184,15 @@ impl DaemonState {
                 .spawn(move || Self::load_registered_workspace_graph(&binding))
                 .map_err(|error| format!("spawn sibling authority load: {error}"))
                 .and_then(|handle| {
-                    handle
-                        .join()
-                        .map_err(|_| "sibling authority loader panicked".to_string())
+                    // Wait for the sibling load without holding a runtime
+                    // worker: this join can run for minutes on a large
+                    // registered repo, and readiness must stay answerable
+                    // throughout.
+                    without_blocking_runtime_worker(|| {
+                        handle
+                            .join()
+                            .map_err(|_| "sibling authority loader panicked".to_string())
+                    })
                 })
                 .and_then(|result| result);
 
@@ -4553,6 +4600,52 @@ mod tests {
         assert_eq!(layout.working_dir(), canonical_working_dir.as_path());
         DaemonState::open(layout)
             .expect("daemon test fixtures must open through repository-v6 workspace authority")
+    }
+
+    // ── FIR-1583: the warming signal must be exact ────────────────────────
+    //
+    // "Busy warming" is what lets a client tell a live daemon from a dead one.
+    // A signal that leaks true after a warm-up ends would make every later
+    // command think the daemon is still busy; one that fails to rise makes a
+    // warming daemon indistinguishable from an idle one.
+
+    #[test]
+    fn warm_guard_raises_the_signal_and_clears_it_on_drop() {
+        let flag = AtomicBool::new(false);
+        assert!(!flag.load(Ordering::Relaxed));
+        {
+            let _guard = SpineWarmGuard::arm(&flag);
+            assert!(flag.load(Ordering::Relaxed), "the warm-up must be visible");
+        }
+        assert!(
+            !flag.load(Ordering::Relaxed),
+            "the signal must not outlive the warm-up"
+        );
+    }
+
+    #[test]
+    fn warm_guard_clears_the_signal_on_unwind() {
+        // A sibling load that panics must not leave the daemon permanently
+        // claiming to be warming.
+        let flag = std::sync::Arc::new(AtomicBool::new(false));
+        let panicking = std::sync::Arc::clone(&flag);
+        let outcome = std::panic::catch_unwind(std::panic::AssertUnwindSafe(move || {
+            let _guard = SpineWarmGuard::arm(&panicking);
+            panic!("sibling authority loader panicked");
+        }));
+        assert!(outcome.is_err(), "the fixture must actually panic");
+        assert!(
+            !flag.load(Ordering::Relaxed),
+            "an unwinding warm-up must still clear its signal"
+        );
+    }
+
+    #[test]
+    fn a_daemon_with_no_warm_up_in_flight_does_not_claim_to_be_warming() {
+        let fixture = tempfile::tempdir().expect("tempdir");
+        let initialized = kin_core::init(fixture.path()).expect("init fixture repository");
+        let state = test_state(initialized.layout, fixture.path());
+        assert!(!state.spine_warming());
     }
 
     fn test_entity(name: &str, file_path: &str) -> Entity {

--- a/crates/kin-daemon/src/supervisor.rs
+++ b/crates/kin-daemon/src/supervisor.rs
@@ -10,6 +10,7 @@
 use std::collections::BTreeMap;
 #[cfg(unix)]
 use std::collections::{HashMap, HashSet};
+use std::io::{Seek, SeekFrom, Write};
 use std::net::SocketAddr;
 use std::path::{Path, PathBuf};
 use std::sync::atomic::{AtomicU64, Ordering};
@@ -22,6 +23,7 @@ use axum::middleware::{self, Next};
 use axum::response::{IntoResponse, Response};
 use axum::routing::{delete, get, post};
 use axum::{Json, Router};
+use fs2::FileExt;
 use serde::{Deserialize, Serialize};
 use serde_json::json;
 use sha2::{Digest, Sha256};
@@ -34,6 +36,10 @@ use crate::state::DaemonState;
 const SUPERVISOR_PID_FILE: &str = "supervisor.pid";
 const SUPERVISOR_PORT_FILE: &str = "supervisor.port";
 const SUPERVISOR_TOKEN_FILE: &str = "supervisor.token";
+const SUPERVISOR_LIFECYCLE_FILE: &str = "supervisor.lifecycle";
+const SUPERVISOR_SINGLETON_FILE: &str = "supervisor.lock";
+const SUPERVISOR_LIFECYCLE_BUDGET: Duration = Duration::from_secs(5);
+const SUPERVISOR_LIFECYCLE_RETRY_INTERVAL: Duration = Duration::from_millis(50);
 const DEFAULT_HEARTBEAT_INTERVAL: Duration = Duration::from_secs(5);
 const HEARTBEAT_TTL: Duration = Duration::from_secs(20);
 /// Ceiling for the retry backoff a repo daemon applies while it cannot reach a
@@ -169,48 +175,157 @@ fn supervisor_dir() -> PathBuf {
         .unwrap_or_else(|| PathBuf::from(".kin"))
 }
 
-fn supervisor_pid_path() -> PathBuf {
-    supervisor_dir().join(SUPERVISOR_PID_FILE)
+#[derive(Debug)]
+struct SupervisorLock {
+    file: std::fs::File,
 }
 
-fn supervisor_port_path() -> PathBuf {
-    supervisor_dir().join(SUPERVISOR_PORT_FILE)
+impl Drop for SupervisorLock {
+    fn drop(&mut self) {
+        let _ = self.file.set_len(0);
+        let _ = self.file.flush();
+    }
 }
 
-fn write_supervisor_endpoint_files(port: u16) {
-    let dir = supervisor_dir();
-    let _ = std::fs::create_dir_all(&dir);
+fn acquire_supervisor_lifecycle_guard(dir: &Path) -> std::io::Result<std::fs::File> {
+    std::fs::create_dir_all(dir)?;
+    let deadline = Instant::now() + SUPERVISOR_LIFECYCLE_BUDGET;
+    let file = std::fs::OpenOptions::new()
+        .create(true)
+        .read(true)
+        .write(true)
+        .truncate(false)
+        .open(dir.join(SUPERVISOR_LIFECYCLE_FILE))?;
+    loop {
+        match file.try_lock_exclusive() {
+            Ok(()) => return Ok(file),
+            Err(error) if error.kind() == fs2::lock_contended_error().kind() => {
+                let now = Instant::now();
+                if now >= deadline {
+                    return Err(std::io::Error::new(
+                        std::io::ErrorKind::WouldBlock,
+                        "timed out waiting for supervisor lifecycle authority",
+                    ));
+                }
+                std::thread::sleep(
+                    SUPERVISOR_LIFECYCLE_RETRY_INTERVAL
+                        .min(deadline.saturating_duration_since(now)),
+                );
+            }
+            Err(error) => return Err(error),
+        }
+    }
+}
+
+fn stamp_supervisor_lock_owner(file: &mut std::fs::File) {
+    if file.set_len(0).is_err() || file.seek(SeekFrom::Start(0)).is_err() {
+        return;
+    }
+    if write!(file, "{}", std::process::id()).is_ok() {
+        let _ = file.flush();
+    }
+}
+
+fn recorded_supervisor_pid(dir: &Path) -> Option<u32> {
+    std::fs::read_to_string(dir.join(SUPERVISOR_PID_FILE))
+        .ok()
+        .and_then(|value| value.trim().parse().ok())
+}
+
+fn acquire_supervisor_lock(dir: &Path) -> std::io::Result<SupervisorLock> {
+    let _lifecycle = acquire_supervisor_lifecycle_guard(dir)?;
+
+    // A compatible older supervisor does not know supervisor.lock, so its live
+    // PID record remains an independent mixed-version exclusion signal.
+    if let Some(pid) = recorded_supervisor_pid(dir) {
+        if pid != std::process::id() && kin_cli::daemon_client::process_liveness(pid).may_be_alive()
+        {
+            return Err(std::io::Error::new(
+                std::io::ErrorKind::AddrInUse,
+                format!("kin supervisor pid {pid} may still be running"),
+            ));
+        }
+    }
+
+    let mut file = std::fs::OpenOptions::new()
+        .create(true)
+        .read(true)
+        .write(true)
+        .truncate(false)
+        .open(dir.join(SUPERVISOR_SINGLETON_FILE))?;
+    match file.try_lock_exclusive() {
+        Ok(()) => {
+            stamp_supervisor_lock_owner(&mut file);
+            Ok(SupervisorLock { file })
+        }
+        Err(error) if error.kind() == fs2::lock_contended_error().kind() => {
+            Err(std::io::Error::new(
+                std::io::ErrorKind::AddrInUse,
+                "another kin supervisor holds the per-user singleton",
+            ))
+        }
+        Err(error) => Err(error),
+    }
+}
+
+fn write_supervisor_endpoint_files(
+    dir: &Path,
+    _supervisor_lock: &SupervisorLock,
+    port: u16,
+) -> std::io::Result<()> {
+    let _lifecycle = acquire_supervisor_lifecycle_guard(dir)?;
     let pid_tmp = dir.join(format!("{SUPERVISOR_PID_FILE}.tmp"));
-    if std::fs::write(&pid_tmp, std::process::id().to_string()).is_ok() {
-        let _ = std::fs::rename(pid_tmp, supervisor_pid_path());
-    }
-    // Written atomically (temp + rename) so a CLI polling the port file during
-    // the supervisor→CLI port handshake never parses a torn or partial value.
     let port_tmp = dir.join(format!("{SUPERVISOR_PORT_FILE}.tmp"));
-    if std::fs::write(&port_tmp, port.to_string()).is_ok() {
-        let _ = std::fs::rename(port_tmp, supervisor_port_path());
+    let pid_path = dir.join(SUPERVISOR_PID_FILE);
+    let port_path = dir.join(SUPERVISOR_PORT_FILE);
+    let result = (|| {
+        std::fs::write(&pid_tmp, std::process::id().to_string())?;
+        std::fs::write(&port_tmp, port.to_string())?;
+        std::fs::rename(&pid_tmp, &pid_path)?;
+        std::fs::rename(&port_tmp, &port_path)?;
+        Ok(())
+    })();
+    if result.is_err() {
+        let _ = std::fs::remove_file(pid_tmp);
+        let _ = std::fs::remove_file(port_tmp);
+        if recorded_supervisor_pid(dir) == Some(std::process::id()) {
+            let _ = std::fs::remove_file(pid_path);
+            let _ = std::fs::remove_file(port_path);
+        }
     }
+    result
 }
 
-fn remove_supervisor_endpoint_files_if_current_process() {
-    let pid_path = supervisor_pid_path();
+fn remove_supervisor_endpoint_files_if_current_process(dir: &Path, port: u16) {
+    let Ok(_lifecycle) = acquire_supervisor_lifecycle_guard(dir) else {
+        warn!("preserving supervisor endpoint because lifecycle authority is unavailable");
+        return;
+    };
+    let pid_path = dir.join(SUPERVISOR_PID_FILE);
+    let port_path = dir.join(SUPERVISOR_PORT_FILE);
     let belongs_to_current = std::fs::read_to_string(&pid_path)
         .ok()
         .and_then(|content| content.trim().parse::<u32>().ok())
         == Some(std::process::id());
-    if !belongs_to_current {
+    let same_port = std::fs::read_to_string(&port_path)
+        .ok()
+        .and_then(|content| content.trim().parse::<u16>().ok())
+        == Some(port);
+    if !(belongs_to_current && same_port) {
         return;
     }
     let _ = std::fs::remove_file(pid_path);
-    let _ = std::fs::remove_file(supervisor_port_path());
+    let _ = std::fs::remove_file(port_path);
 }
 
 pub fn supervisor_url_from_files() -> Option<String> {
     supervisor_url_from_dir(&supervisor_dir())
 }
 
-/// Endpoint recorded by a live supervisor under `dir`. Returns `None` — and
-/// clears the stale files — when the recorded process is gone.
+/// Endpoint recorded by a live supervisor under `dir`.
+///
+/// This read-only discovery path never retires endpoint files. The CLI owns
+/// conditional retirement under supervisor.lifecycle plus supervisor.lock.
 fn supervisor_url_from_dir(dir: &Path) -> Option<String> {
     let pid_path = dir.join(SUPERVISOR_PID_FILE);
     let port_path = dir.join(SUPERVISOR_PORT_FILE);
@@ -220,8 +335,6 @@ fn supervisor_url_from_dir(dir: &Path) -> Option<String> {
         .parse::<u32>()
         .ok()?;
     if !is_process_alive(pid) {
-        let _ = std::fs::remove_file(&pid_path);
-        let _ = std::fs::remove_file(&port_path);
         return None;
     }
     let port = std::fs::read_to_string(&port_path)
@@ -1093,6 +1206,8 @@ async fn deregister_daemon(
 }
 
 pub async fn run_supervisor(port: u16, idle_timeout: Option<Duration>) -> std::io::Result<()> {
+    let state_dir = supervisor_dir();
+    let supervisor_lock = acquire_supervisor_lock(&state_dir)?;
     let state = Arc::new(SupervisorState::new());
 
     let bind_host = std::env::var("KIN_SUPERVISOR_BIND_HOST")
@@ -1120,7 +1235,7 @@ pub async fn run_supervisor(port: u16, idle_timeout: Option<Duration>) -> std::i
 
     let listener = tokio::net::TcpListener::bind(addr).await?;
     let bound_port = listener.local_addr()?.port();
-    write_supervisor_endpoint_files(bound_port);
+    write_supervisor_endpoint_files(&state_dir, &supervisor_lock, bound_port)?;
     let (shutdown_tx, mut shutdown_rx) = tokio::sync::watch::channel(false);
 
     if let Some(idle_timeout) = idle_timeout {
@@ -1181,7 +1296,7 @@ pub async fn run_supervisor(port: u16, idle_timeout: Option<Duration>) -> std::i
             }
         })
         .await;
-    remove_supervisor_endpoint_files_if_current_process();
+    remove_supervisor_endpoint_files_if_current_process(&state_dir, bound_port);
     result
 }
 
@@ -2097,6 +2212,54 @@ fn reexec_self(self_exe_mtime: u64) -> std::io::Error {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn supervisor_singleton_is_process_lifetime_and_never_unlinked() {
+        let dir = tempfile::tempdir().unwrap();
+        let first = acquire_supervisor_lock(dir.path()).unwrap();
+
+        let error = acquire_supervisor_lock(dir.path()).unwrap_err();
+        assert_eq!(error.kind(), std::io::ErrorKind::AddrInUse);
+        assert!(
+            dir.path().join(SUPERVISOR_SINGLETON_FILE).exists(),
+            "a contended acquire must preserve the singleton pathname"
+        );
+        assert!(
+            dir.path().join(SUPERVISOR_LIFECYCLE_FILE).exists(),
+            "the lifecycle authority is never unlinked"
+        );
+
+        drop(first);
+        let reacquired = acquire_supervisor_lock(dir.path()).unwrap();
+        drop(reacquired);
+        assert!(
+            dir.path().join(SUPERVISOR_SINGLETON_FILE).exists(),
+            "clean release drops the flock but never replaces its inode"
+        );
+    }
+
+    #[test]
+    fn supervisor_publication_and_cleanup_are_generation_conditional() {
+        let dir = tempfile::tempdir().unwrap();
+        let authority = acquire_supervisor_lock(dir.path()).unwrap();
+        write_supervisor_endpoint_files(dir.path(), &authority, 50595).unwrap();
+
+        // A same-process successor generation must survive cleanup formed
+        // against the prior port.
+        write_supervisor_endpoint_files(dir.path(), &authority, 50596).unwrap();
+        remove_supervisor_endpoint_files_if_current_process(dir.path(), 50595);
+        assert_eq!(
+            std::fs::read_to_string(dir.path().join(SUPERVISOR_PORT_FILE))
+                .unwrap()
+                .trim(),
+            "50596"
+        );
+
+        remove_supervisor_endpoint_files_if_current_process(dir.path(), 50596);
+        assert!(!dir.path().join(SUPERVISOR_PID_FILE).exists());
+        assert!(!dir.path().join(SUPERVISOR_PORT_FILE).exists());
+        assert!(dir.path().join(SUPERVISOR_SINGLETON_FILE).exists());
+    }
 
     fn repo_payload(instance_id: &str, port: u16) -> RepoDaemonRegistration {
         RepoDaemonRegistration {
@@ -3369,8 +3532,9 @@ mod tests {
             Some("http://127.0.0.1:50596")
         );
 
-        // A recorded supervisor that is no longer alive is not adopted, and its
-        // stale endpoint files are cleared.
+        // A recorded supervisor that is no longer alive is not adopted. This
+        // read-only discovery path preserves its files; conditional retirement
+        // belongs to the CLI's lifecycle + singleton authority.
         #[cfg(unix)]
         {
             std::fs::write(dir.join(SUPERVISOR_PID_FILE), "999999999").unwrap();
@@ -3380,8 +3544,8 @@ mod tests {
                     .as_deref(),
                 Some(inherited.as_str())
             );
-            assert!(!dir.join(SUPERVISOR_PID_FILE).exists());
-            assert!(!dir.join(SUPERVISOR_PORT_FILE).exists());
+            assert!(dir.join(SUPERVISOR_PID_FILE).exists());
+            assert!(dir.join(SUPERVISOR_PORT_FILE).exists());
         }
 
         let _ = std::fs::remove_dir_all(&dir);

--- a/crates/kin-daemon/src/supervisor.rs
+++ b/crates/kin-daemon/src/supervisor.rs
@@ -14,7 +14,7 @@ use std::io::{Seek, SeekFrom, Write};
 use std::net::SocketAddr;
 use std::path::{Path, PathBuf};
 use std::sync::atomic::{AtomicU64, Ordering};
-use std::sync::Arc;
+use std::sync::{Arc, Mutex};
 use std::time::{Duration, Instant};
 
 use axum::extract::{Path as AxumPath, Query, State};
@@ -38,8 +38,13 @@ const SUPERVISOR_PORT_FILE: &str = "supervisor.port";
 const SUPERVISOR_TOKEN_FILE: &str = "supervisor.token";
 const SUPERVISOR_LIFECYCLE_FILE: &str = "supervisor.lifecycle";
 const SUPERVISOR_SINGLETON_FILE: &str = "supervisor.lock";
+#[cfg(test)]
+const SUPERVISOR_STARTUP_FILE: &str = "supervisor.start.lock";
 const SUPERVISOR_LIFECYCLE_BUDGET: Duration = Duration::from_secs(5);
 const SUPERVISOR_LIFECYCLE_RETRY_INTERVAL: Duration = Duration::from_millis(50);
+/// Keep the legacy create-new marker younger than the immutable old client's
+/// minimum ten-second stale threshold.
+const SUPERVISOR_STARTUP_HEARTBEAT_INTERVAL: Duration = Duration::from_secs(2);
 const DEFAULT_HEARTBEAT_INTERVAL: Duration = Duration::from_secs(5);
 const HEARTBEAT_TTL: Duration = Duration::from_secs(20);
 /// Ceiling for the retry backoff a repo daemon applies while it cannot reach a
@@ -294,6 +299,75 @@ fn write_supervisor_endpoint_files(
         }
     }
     result
+}
+
+fn maintain_legacy_supervisor_exclusion(
+    dir: &Path,
+    startup_lock: &Mutex<kin_cli::daemon_client::SupervisorStartupLock>,
+    supervisor_lock: &SupervisorLock,
+    port: u16,
+) -> std::io::Result<()> {
+    let mut startup_lock = startup_lock
+        .lock()
+        .map_err(|_| std::io::Error::other("supervisor startup lock mutex was poisoned"))?;
+    if !startup_lock.heartbeat_for_pid(std::process::id())? {
+        return Err(std::io::Error::new(
+            std::io::ErrorKind::PermissionDenied,
+            "supervisor startup-lock generation was replaced",
+        ));
+    }
+    drop(startup_lock);
+
+    let current_pid = recorded_supervisor_pid(dir);
+    let current_port = std::fs::read_to_string(dir.join(SUPERVISOR_PORT_FILE))
+        .ok()
+        .and_then(|value| value.trim().parse::<u16>().ok());
+    if current_pid != Some(std::process::id()) || current_port != Some(port) {
+        // The immutable PR-base client deletes these files on any health
+        // failure before it tries the shared startup marker. Re-publish while
+        // our current process-lifetime singleton is still held. The marker
+        // prevents that old client from reaching its spawn after deletion.
+        write_supervisor_endpoint_files(dir, supervisor_lock, port)?;
+    }
+    Ok(())
+}
+
+fn spawn_legacy_supervisor_exclusion_maintenance(
+    dir: PathBuf,
+    startup_lock: Arc<Mutex<kin_cli::daemon_client::SupervisorStartupLock>>,
+    supervisor_lock: Arc<SupervisorLock>,
+    port: u16,
+    failure_shutdown: tokio::sync::watch::Sender<bool>,
+    mut stop_rx: tokio::sync::watch::Receiver<bool>,
+) -> tokio::task::JoinHandle<()> {
+    tokio::spawn(async move {
+        let mut interval = tokio::time::interval(SUPERVISOR_STARTUP_HEARTBEAT_INTERVAL);
+        interval.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Delay);
+        loop {
+            tokio::select! {
+                changed = stop_rx.changed() => {
+                    if changed.is_err() || *stop_rx.borrow() {
+                        break;
+                    }
+                }
+                _ = interval.tick() => {
+                    if let Err(error) = maintain_legacy_supervisor_exclusion(
+                        &dir,
+                        &startup_lock,
+                        &supervisor_lock,
+                        port,
+                    ) {
+                        warn!(
+                            %error,
+                            "lost cross-version supervisor exclusion; shutting down fail-closed"
+                        );
+                        let _ = failure_shutdown.send(true);
+                        break;
+                    }
+                }
+            }
+        }
+    })
 }
 
 fn remove_supervisor_endpoint_files_if_current_process(dir: &Path, port: u16) {
@@ -1207,7 +1281,10 @@ async fn deregister_daemon(
 
 pub async fn run_supervisor(port: u16, idle_timeout: Option<Duration>) -> std::io::Result<()> {
     let state_dir = supervisor_dir();
-    let supervisor_lock = acquire_supervisor_lock(&state_dir)?;
+    let startup_lock = Arc::new(Mutex::new(
+        kin_cli::daemon_client::acquire_supervisor_runtime_startup_lock(&state_dir)?,
+    ));
+    let supervisor_lock = Arc::new(acquire_supervisor_lock(&state_dir)?);
     let state = Arc::new(SupervisorState::new());
 
     let bind_host = std::env::var("KIN_SUPERVISOR_BIND_HOST")
@@ -1237,6 +1314,17 @@ pub async fn run_supervisor(port: u16, idle_timeout: Option<Duration>) -> std::i
     let bound_port = listener.local_addr()?.port();
     write_supervisor_endpoint_files(&state_dir, &supervisor_lock, bound_port)?;
     let (shutdown_tx, mut shutdown_rx) = tokio::sync::watch::channel(false);
+    let (startup_maintenance_stop, startup_maintenance_stop_rx) =
+        tokio::sync::watch::channel(false);
+    maintain_legacy_supervisor_exclusion(&state_dir, &startup_lock, &supervisor_lock, bound_port)?;
+    let startup_maintenance = spawn_legacy_supervisor_exclusion_maintenance(
+        state_dir.clone(),
+        Arc::clone(&startup_lock),
+        Arc::clone(&supervisor_lock),
+        bound_port,
+        shutdown_tx.clone(),
+        startup_maintenance_stop_rx,
+    );
 
     if let Some(idle_timeout) = idle_timeout {
         let idle_state = Arc::clone(&state);
@@ -1296,6 +1384,10 @@ pub async fn run_supervisor(port: u16, idle_timeout: Option<Duration>) -> std::i
             }
         })
         .await;
+    let _ = startup_maintenance_stop.send(true);
+    if let Err(error) = startup_maintenance.await {
+        warn!(%error, "supervisor startup-lock maintenance task failed");
+    }
     remove_supervisor_endpoint_files_if_current_process(&state_dir, bound_port);
     result
 }
@@ -2259,6 +2351,60 @@ mod tests {
         assert!(!dir.path().join(SUPERVISOR_PID_FILE).exists());
         assert!(!dir.path().join(SUPERVISOR_PORT_FILE).exists());
         assert!(dir.path().join(SUPERVISOR_SINGLETON_FILE).exists());
+    }
+
+    #[test]
+    fn current_supervisor_blocks_legacy_prelock_respawn_and_repairs_discovery() {
+        let dir = tempfile::tempdir().unwrap();
+        let startup_lock = Arc::new(Mutex::new(
+            kin_cli::daemon_client::try_acquire_supervisor_startup_lock_in_dir(dir.path()).unwrap(),
+        ));
+        let supervisor_lock = Arc::new(acquire_supervisor_lock(dir.path()).unwrap());
+        let port = 50597;
+        write_supervisor_endpoint_files(dir.path(), &supervisor_lock, port).unwrap();
+
+        let deleted = Arc::new(std::sync::Barrier::new(2));
+        let legacy_dir = dir.path().to_path_buf();
+        let legacy_deleted = Arc::clone(&deleted);
+        let legacy = std::thread::spawn(move || {
+            // Exact destructive ordering in the immutable PR-base CLI:
+            // health fails, both discovery files are deleted, and only then
+            // does it attempt create-new startup authority.
+            let _ = std::fs::remove_file(legacy_dir.join(SUPERVISOR_PID_FILE));
+            let _ = std::fs::remove_file(legacy_dir.join(SUPERVISOR_PORT_FILE));
+            legacy_deleted.wait();
+            std::fs::OpenOptions::new()
+                .write(true)
+                .create_new(true)
+                .open(legacy_dir.join(SUPERVISOR_STARTUP_FILE))
+                .is_ok()
+        });
+
+        deleted.wait();
+        maintain_legacy_supervisor_exclusion(dir.path(), &startup_lock, &supervisor_lock, port)
+            .unwrap();
+        assert!(
+            !legacy.join().unwrap(),
+            "the old client must not obtain spawn authority after deleting discovery"
+        );
+        assert_eq!(
+            recorded_supervisor_pid(dir.path()),
+            Some(std::process::id())
+        );
+        assert_eq!(
+            std::fs::read_to_string(dir.path().join(SUPERVISOR_PORT_FILE))
+                .unwrap()
+                .trim(),
+            port.to_string()
+        );
+        assert!(
+            startup_lock
+                .lock()
+                .unwrap()
+                .heartbeat_for_pid(std::process::id())
+                .unwrap(),
+            "the current supervisor must retain its exact startup generation"
+        );
     }
 
     fn repo_payload(instance_id: &str, port: u16) -> RepoDaemonRegistration {

--- a/crates/kin-daemon/src/supervisor.rs
+++ b/crates/kin-daemon/src/supervisor.rs
@@ -14,7 +14,7 @@ use std::io::{Seek, SeekFrom, Write};
 use std::net::SocketAddr;
 use std::path::{Path, PathBuf};
 use std::sync::atomic::{AtomicU64, Ordering};
-use std::sync::{Arc, Mutex};
+use std::sync::Arc;
 use std::time::{Duration, Instant};
 
 use axum::extract::{Path as AxumPath, Query, State};
@@ -38,13 +38,8 @@ const SUPERVISOR_PORT_FILE: &str = "supervisor.port";
 const SUPERVISOR_TOKEN_FILE: &str = "supervisor.token";
 const SUPERVISOR_LIFECYCLE_FILE: &str = "supervisor.lifecycle";
 const SUPERVISOR_SINGLETON_FILE: &str = "supervisor.lock";
-#[cfg(test)]
-const SUPERVISOR_STARTUP_FILE: &str = "supervisor.start.lock";
 const SUPERVISOR_LIFECYCLE_BUDGET: Duration = Duration::from_secs(5);
 const SUPERVISOR_LIFECYCLE_RETRY_INTERVAL: Duration = Duration::from_millis(50);
-/// Keep the legacy create-new marker younger than the immutable old client's
-/// minimum ten-second stale threshold.
-const SUPERVISOR_STARTUP_HEARTBEAT_INTERVAL: Duration = Duration::from_secs(2);
 const DEFAULT_HEARTBEAT_INTERVAL: Duration = Duration::from_secs(5);
 const HEARTBEAT_TTL: Duration = Duration::from_secs(20);
 /// Ceiling for the retry backoff a repo daemon applies while it cannot reach a
@@ -299,75 +294,6 @@ fn write_supervisor_endpoint_files(
         }
     }
     result
-}
-
-fn maintain_legacy_supervisor_exclusion(
-    dir: &Path,
-    startup_lock: &Mutex<kin_cli::daemon_client::SupervisorStartupLock>,
-    supervisor_lock: &SupervisorLock,
-    port: u16,
-) -> std::io::Result<()> {
-    let mut startup_lock = startup_lock
-        .lock()
-        .map_err(|_| std::io::Error::other("supervisor startup lock mutex was poisoned"))?;
-    if !startup_lock.heartbeat_for_pid(std::process::id())? {
-        return Err(std::io::Error::new(
-            std::io::ErrorKind::PermissionDenied,
-            "supervisor startup-lock generation was replaced",
-        ));
-    }
-    drop(startup_lock);
-
-    let current_pid = recorded_supervisor_pid(dir);
-    let current_port = std::fs::read_to_string(dir.join(SUPERVISOR_PORT_FILE))
-        .ok()
-        .and_then(|value| value.trim().parse::<u16>().ok());
-    if current_pid != Some(std::process::id()) || current_port != Some(port) {
-        // The immutable PR-base client deletes these files on any health
-        // failure before it tries the shared startup marker. Re-publish while
-        // our current process-lifetime singleton is still held. The marker
-        // prevents that old client from reaching its spawn after deletion.
-        write_supervisor_endpoint_files(dir, supervisor_lock, port)?;
-    }
-    Ok(())
-}
-
-fn spawn_legacy_supervisor_exclusion_maintenance(
-    dir: PathBuf,
-    startup_lock: Arc<Mutex<kin_cli::daemon_client::SupervisorStartupLock>>,
-    supervisor_lock: Arc<SupervisorLock>,
-    port: u16,
-    failure_shutdown: tokio::sync::watch::Sender<bool>,
-    mut stop_rx: tokio::sync::watch::Receiver<bool>,
-) -> tokio::task::JoinHandle<()> {
-    tokio::spawn(async move {
-        let mut interval = tokio::time::interval(SUPERVISOR_STARTUP_HEARTBEAT_INTERVAL);
-        interval.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Delay);
-        loop {
-            tokio::select! {
-                changed = stop_rx.changed() => {
-                    if changed.is_err() || *stop_rx.borrow() {
-                        break;
-                    }
-                }
-                _ = interval.tick() => {
-                    if let Err(error) = maintain_legacy_supervisor_exclusion(
-                        &dir,
-                        &startup_lock,
-                        &supervisor_lock,
-                        port,
-                    ) {
-                        warn!(
-                            %error,
-                            "lost cross-version supervisor exclusion; shutting down fail-closed"
-                        );
-                        let _ = failure_shutdown.send(true);
-                        break;
-                    }
-                }
-            }
-        }
-    })
 }
 
 fn remove_supervisor_endpoint_files_if_current_process(dir: &Path, port: u16) {
@@ -1281,9 +1207,7 @@ async fn deregister_daemon(
 
 pub async fn run_supervisor(port: u16, idle_timeout: Option<Duration>) -> std::io::Result<()> {
     let state_dir = supervisor_dir();
-    let startup_lock = Arc::new(Mutex::new(
-        kin_cli::daemon_client::acquire_supervisor_runtime_startup_lock(&state_dir)?,
-    ));
+    let startup = kin_cli::daemon_client::validate_supervisor_runtime_startup(&state_dir)?;
     let supervisor_lock = Arc::new(acquire_supervisor_lock(&state_dir)?);
     let state = Arc::new(SupervisorState::new());
 
@@ -1313,18 +1237,11 @@ pub async fn run_supervisor(port: u16, idle_timeout: Option<Duration>) -> std::i
     let listener = tokio::net::TcpListener::bind(addr).await?;
     let bound_port = listener.local_addr()?.port();
     write_supervisor_endpoint_files(&state_dir, &supervisor_lock, bound_port)?;
+    if let Err(error) = startup.acknowledge() {
+        remove_supervisor_endpoint_files_if_current_process(&state_dir, bound_port);
+        return Err(error);
+    }
     let (shutdown_tx, mut shutdown_rx) = tokio::sync::watch::channel(false);
-    let (startup_maintenance_stop, startup_maintenance_stop_rx) =
-        tokio::sync::watch::channel(false);
-    maintain_legacy_supervisor_exclusion(&state_dir, &startup_lock, &supervisor_lock, bound_port)?;
-    let startup_maintenance = spawn_legacy_supervisor_exclusion_maintenance(
-        state_dir.clone(),
-        Arc::clone(&startup_lock),
-        Arc::clone(&supervisor_lock),
-        bound_port,
-        shutdown_tx.clone(),
-        startup_maintenance_stop_rx,
-    );
 
     if let Some(idle_timeout) = idle_timeout {
         let idle_state = Arc::clone(&state);
@@ -1384,10 +1301,6 @@ pub async fn run_supervisor(port: u16, idle_timeout: Option<Duration>) -> std::i
             }
         })
         .await;
-    let _ = startup_maintenance_stop.send(true);
-    if let Err(error) = startup_maintenance.await {
-        warn!(%error, "supervisor startup-lock maintenance task failed");
-    }
     remove_supervisor_endpoint_files_if_current_process(&state_dir, bound_port);
     result
 }
@@ -2354,56 +2267,33 @@ mod tests {
     }
 
     #[test]
-    fn current_supervisor_blocks_legacy_prelock_respawn_and_repairs_discovery() {
+    fn current_protocol_directory_sentinel_blocks_legacy_respawn_without_heartbeat() {
         let dir = tempfile::tempdir().unwrap();
-        let startup_lock = Arc::new(Mutex::new(
-            kin_cli::daemon_client::try_acquire_supervisor_startup_lock_in_dir(dir.path()).unwrap(),
-        ));
+        let _startup_lock =
+            kin_cli::daemon_client::try_acquire_supervisor_startup_lock_in_dir(dir.path()).unwrap();
         let supervisor_lock = Arc::new(acquire_supervisor_lock(dir.path()).unwrap());
         let port = 50597;
         write_supervisor_endpoint_files(dir.path(), &supervisor_lock, port).unwrap();
 
-        let deleted = Arc::new(std::sync::Barrier::new(2));
-        let legacy_dir = dir.path().to_path_buf();
-        let legacy_deleted = Arc::clone(&deleted);
-        let legacy = std::thread::spawn(move || {
-            // Exact destructive ordering in the immutable PR-base CLI:
-            // health fails, both discovery files are deleted, and only then
-            // does it attempt create-new startup authority.
-            let _ = std::fs::remove_file(legacy_dir.join(SUPERVISOR_PID_FILE));
-            let _ = std::fs::remove_file(legacy_dir.join(SUPERVISOR_PORT_FILE));
-            legacy_deleted.wait();
-            std::fs::OpenOptions::new()
-                .write(true)
-                .create_new(true)
-                .open(legacy_dir.join(SUPERVISOR_STARTUP_FILE))
-                .is_ok()
-        });
-
-        deleted.wait();
-        maintain_legacy_supervisor_exclusion(dir.path(), &startup_lock, &supervisor_lock, port)
-            .unwrap();
+        // Exact destructive ordering in the immutable PR-base CLI: health
+        // fails, both discovery files are deleted, and only then does it try
+        // create-new on supervisor.start.lock. The current protocol keeps that
+        // pathname as a non-empty directory, which remove_file cannot delete
+        // and create_new cannot replace. No timer or runtime task participates.
+        let _ = std::fs::remove_file(dir.path().join(SUPERVISOR_PID_FILE));
+        let _ = std::fs::remove_file(dir.path().join(SUPERVISOR_PORT_FILE));
+        let legacy_acquired = std::fs::OpenOptions::new()
+            .write(true)
+            .create_new(true)
+            .open(dir.path().join("supervisor.start.lock"))
+            .is_ok();
         assert!(
-            !legacy.join().unwrap(),
+            !legacy_acquired,
             "the old client must not obtain spawn authority after deleting discovery"
         );
-        assert_eq!(
-            recorded_supervisor_pid(dir.path()),
-            Some(std::process::id())
-        );
-        assert_eq!(
-            std::fs::read_to_string(dir.path().join(SUPERVISOR_PORT_FILE))
-                .unwrap()
-                .trim(),
-            port.to_string()
-        );
         assert!(
-            startup_lock
-                .lock()
-                .unwrap()
-                .heartbeat_for_pid(std::process::id())
-                .unwrap(),
-            "the current supervisor must retain its exact startup generation"
+            dir.path().join("supervisor.start.lock").is_dir(),
+            "the compatibility sentinel must remain a directory for the supervisor lifetime"
         );
     }
 

--- a/crates/kin-daemon/src/supervisor.rs
+++ b/crates/kin-daemon/src/supervisor.rs
@@ -269,15 +269,7 @@ fn discover_supervisor_url(failing: Option<&str>) -> Option<String> {
 }
 
 fn is_process_alive(pid: u32) -> bool {
-    #[cfg(unix)]
-    {
-        unsafe { libc::kill(pid as libc::pid_t, 0) == 0 }
-    }
-    #[cfg(not(unix))]
-    {
-        let _ = pid;
-        true
-    }
+    kin_cli::daemon_client::is_process_alive(pid)
 }
 
 fn canonical_path_string(path: impl Into<PathBuf>) -> String {

--- a/crates/kin-daemon/tests/compat_json_stdout.rs
+++ b/crates/kin-daemon/tests/compat_json_stdout.rs
@@ -38,11 +38,25 @@ fn compat_json_stdout_is_pure_json_under_env_overrides() {
             )
         });
 
-    assert_eq!(parsed["schema"], "kin.daemon.compat.v1");
+    assert_eq!(parsed["schema"], "kin.daemon.compat.v2");
     assert!(
         parsed["graph_snapshot_version"].is_number(),
         "compat payload must carry a numeric graph_snapshot_version"
     );
+    assert_eq!(parsed["supervisor_startup_protocol"], 2);
+    let capabilities = parsed["supervisor_startup_capabilities"]
+        .as_array()
+        .expect("compat payload must carry startup capabilities");
+    for required in [
+        "generation-adoption-ack-v2",
+        "legacy-directory-sentinel-v1",
+        "bounded-legacy-rollback-v1",
+    ] {
+        assert!(
+            capabilities.iter().any(|capability| capability == required),
+            "compat payload must advertise {required}: {parsed}"
+        );
+    }
     assert!(parsed["build"]["sha"].is_string());
     assert!(parsed["build"]["dirty"].is_boolean());
     assert!(parsed["build"]["source_known"].is_boolean());

--- a/docs/env-vars.md
+++ b/docs/env-vars.md
@@ -3,7 +3,7 @@
 
 # Kin environment variables
 
-This is the authoritative list of supported `KIN_*` environment variables (410 total, 310 correctness-relevant), generated from the central registry in `kin-core`.
+This is the authoritative list of supported `KIN_*` environment variables (411 total, 310 correctness-relevant), generated from the central registry in `kin-core`.
 
 At CLI and daemon startup Kin validates this surface (`KIN_ENV_VALIDATION`, default `warn`):
 
@@ -115,6 +115,7 @@ Sensitivity legend: **correctness** (affects retrieval/ranking/output or data sa
 | `KIN_SUPERVISOR_REDEPLOY_GRACE` | seconds>=0 | *(unset)* | operational | grace period before a supervisor redeploy |
 | `KIN_SUPERVISOR_REEXEC_DISABLE` | bool | false | operational | disable supervisor self-reexec on binary mtime change |
 | `KIN_SUPERVISOR_REQUIRE_TOKEN` | bool | false | operational | require a bearer token for supervisor requests |
+| `KIN_SUPERVISOR_STARTUP_GENERATION` | string | *(unset)* | operational | internal versioned supervisor launch capability generation |
 | `KIN_SUPERVISOR_URL` | url | *(unset)* | operational | explicit supervisor endpoint URL |
 
 ## Registry

--- a/scripts/test-supervisor-startup-compat-matrix.sh
+++ b/scripts/test-supervisor-startup-compat-matrix.sh
@@ -61,6 +61,7 @@ run_registry_probe() {
   local daemon_bin=$2
   local state=$3
   local idle_timeout=${4:-1}
+  local startup_timeout=${5:-5}
   mkdir -p "$state"
   (
     cd "$state"
@@ -74,17 +75,38 @@ run_registry_probe() {
       KIN_REGISTRY_PATH="$state/registry.toml" \
       KIN_DAEMON_BIN="$daemon_bin" \
       KIN_DAEMON_READY_TIMEOUT_SECS=5 \
-      KIN_DAEMON_STARTUP_LOCK_TIMEOUT_SECS=5 \
+      KIN_DAEMON_STARTUP_LOCK_TIMEOUT_SECS="$startup_timeout" \
       KIN_SUPERVISOR_IDLE_TIMEOUT_SECS="$idle_timeout" \
       "$kin_bin" registry daemons --json
   )
+}
+
+run_registry_probe_bounded() {
+  local wall_timeout=$1
+  shift
+  run_registry_probe "$@" &
+  local probe_pid=$!
+  local deadline=$((SECONDS + wall_timeout))
+  while kill -0 "$probe_pid" 2>/dev/null; do
+    if ((SECONDS >= deadline)); then
+      kill -TERM "$probe_pid" 2>/dev/null || true
+      sleep 0.2
+      kill -KILL "$probe_pid" 2>/dev/null || true
+      wait "$probe_pid" 2>/dev/null || true
+      return 124
+    fi
+    sleep 0.1
+  done
+  local probe_status=0
+  wait "$probe_pid" || probe_status=$?
+  return "$probe_status"
 }
 
 current_current="$MATRIX_ROOT/current-cli-current-daemon"
 run_registry_probe "$CURRENT_KIN" "$CURRENT_DAEMON" "$current_current" 10 \
   >"$current_current.stdout" 2>"$current_current.stderr"
 [[ -d "$current_current/supervisor.start.lock" ]]
-compgen -G "$current_current/supervisor.start.lock/adopt-*.json" >/dev/null
+compgen -G "$current_current/supervisor.start.lock/records-v2/adopt-*.json" >/dev/null
 
 run_registry_probe "$BASE_KIN" "$CURRENT_DAEMON" "$current_current" 10 \
   >"$current_current.base-live.stdout" 2>"$current_current.base-live.stderr"
@@ -93,6 +115,38 @@ grep -F '"supervisor_url"' "$current_current.base-live.stdout" >/dev/null
 [[ -f "$current_current/supervisor.port" ]]
 [[ -d "$current_current/supervisor.start.lock" ]]
 stop_recorded_supervisor "$current_current"
+
+# The immutable base stale threshold has a hard 10-second floor. Let the
+# current-state residue age past that floor before invoking exact-base
+# CLI+daemon. The outer sentinel's verified future mtime must keep the old
+# client's failed remove_file(directory) branch unreachable, so its own
+# configured one-second startup deadline rejects boundedly. The independent
+# watchdog turns the historical busy loop into a deterministic matrix failure.
+sleep 11
+rollback_started=$SECONDS
+if run_registry_probe_bounded 5 \
+  "$BASE_KIN" "$BASE_DAEMON" "$current_current" 1 1 \
+  >"$current_current.base-rollback.stdout" \
+  2>"$current_current.base-rollback.stderr"; then
+  echo "immutable base CLI unexpectedly crossed the permanent current authority" >&2
+  exit 1
+else
+  rollback_status=$?
+fi
+if [[ "$rollback_status" -eq 124 ]]; then
+  echo "immutable base CLI exceeded the rollback wall-clock bound" >&2
+  exit 1
+fi
+rollback_elapsed=$((SECONDS - rollback_started))
+if ((rollback_elapsed > 4)); then
+  echo "immutable base CLI rejected too slowly after current-state residue" >&2
+  exit 1
+fi
+grep -F "timed out waiting for supervisor startup lock" \
+  "$current_current.base-rollback.stderr" >/dev/null
+[[ -d "$current_current/supervisor.start.lock" ]]
+[[ -f "$current_current/supervisor.start.lock/authority.lock" ]]
+[[ -d "$current_current/supervisor.start.lock/records-v2" ]]
 
 base_current="$MATRIX_ROOT/base-cli-current-daemon"
 if run_registry_probe "$BASE_KIN" "$CURRENT_DAEMON" "$base_current" \
@@ -121,5 +175,6 @@ grep -F "does not acknowledge supervisor startup protocol" \
 echo "supervisor startup compatibility matrix: PASS"
 echo "  current CLI -> current daemon: adopted generation and served"
 echo "  immutable base CLI -> live current daemon: connected through published endpoint"
+echo "  immutable base CLI + daemon after aged current residue: rejected in ${rollback_elapsed}s"
 echo "  immutable base CLI -> current daemon: rejected before singleton/publication"
 echo "  current CLI -> immutable base daemon: rejected by compat handshake before startup"

--- a/scripts/test-supervisor-startup-compat-matrix.sh
+++ b/scripts/test-supervisor-startup-compat-matrix.sh
@@ -1,0 +1,125 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2026 Firelock, LLC
+set -euo pipefail
+
+if [[ $# -ne 4 ]]; then
+  echo "usage: $0 <current-kin> <current-daemon> <base-kin> <base-daemon>" >&2
+  exit 64
+fi
+
+absolute_executable() {
+  local candidate=$1
+  if [[ ! -x "$candidate" ]]; then
+    echo "not executable: $candidate" >&2
+    exit 66
+  fi
+  local directory
+  directory=$(cd "$(dirname "$candidate")" && pwd -P)
+  printf '%s/%s\n' "$directory" "$(basename "$candidate")"
+}
+
+CURRENT_KIN=$(absolute_executable "$1")
+CURRENT_DAEMON=$(absolute_executable "$2")
+BASE_KIN=$(absolute_executable "$3")
+BASE_DAEMON=$(absolute_executable "$4")
+MATRIX_ROOT=$(mktemp -d "${TMPDIR:-/tmp}/kin-supervisor-compat.XXXXXX")
+
+stop_recorded_supervisor() {
+  local state=$1
+  local pid_file="$state/supervisor.pid"
+  if [[ -f "$pid_file" ]]; then
+    local pid
+    pid=$(tr -dc '0-9' <"$pid_file")
+    if [[ -n "$pid" ]] && kill -0 "$pid" 2>/dev/null; then
+      kill -TERM "$pid" 2>/dev/null || true
+      for _ in $(seq 1 50); do
+        kill -0 "$pid" 2>/dev/null || return 0
+        sleep 0.1
+      done
+      echo "supervisor $pid did not terminate" >&2
+      return 1
+    fi
+  fi
+}
+
+cleanup() {
+  local state
+  for state in "$MATRIX_ROOT"/*; do
+    [[ -d "$state" ]] && stop_recorded_supervisor "$state" || true
+  done
+  if [[ "${KIN_KEEP_COMPAT_MATRIX:-0}" == "1" ]]; then
+    echo "matrix artifacts retained at $MATRIX_ROOT" >&2
+  else
+    rm -rf -- "$MATRIX_ROOT"
+  fi
+}
+trap cleanup EXIT
+
+run_registry_probe() {
+  local kin_bin=$1
+  local daemon_bin=$2
+  local state=$3
+  local idle_timeout=${4:-1}
+  mkdir -p "$state"
+  (
+    cd "$state"
+    env \
+      -u KIN_SUPERVISOR_URL \
+      -u KIN_SUPERVISOR_STARTUP_GENERATION \
+      -u KIN_KEEP_COMPAT_MATRIX \
+      -u KIN_VFS_WORKSPACE \
+      -u DYLD_INSERT_LIBRARIES \
+      -u LD_PRELOAD \
+      KIN_REGISTRY_PATH="$state/registry.toml" \
+      KIN_DAEMON_BIN="$daemon_bin" \
+      KIN_DAEMON_READY_TIMEOUT_SECS=5 \
+      KIN_DAEMON_STARTUP_LOCK_TIMEOUT_SECS=5 \
+      KIN_SUPERVISOR_IDLE_TIMEOUT_SECS="$idle_timeout" \
+      "$kin_bin" registry daemons --json
+  )
+}
+
+current_current="$MATRIX_ROOT/current-cli-current-daemon"
+run_registry_probe "$CURRENT_KIN" "$CURRENT_DAEMON" "$current_current" 10 \
+  >"$current_current.stdout" 2>"$current_current.stderr"
+[[ -d "$current_current/supervisor.start.lock" ]]
+compgen -G "$current_current/supervisor.start.lock/adopt-*.json" >/dev/null
+
+run_registry_probe "$BASE_KIN" "$CURRENT_DAEMON" "$current_current" 10 \
+  >"$current_current.base-live.stdout" 2>"$current_current.base-live.stderr"
+grep -F '"supervisor_url"' "$current_current.base-live.stdout" >/dev/null
+[[ -f "$current_current/supervisor.pid" ]]
+[[ -f "$current_current/supervisor.port" ]]
+[[ -d "$current_current/supervisor.start.lock" ]]
+stop_recorded_supervisor "$current_current"
+
+base_current="$MATRIX_ROOT/base-cli-current-daemon"
+if run_registry_probe "$BASE_KIN" "$CURRENT_DAEMON" "$base_current" \
+  >"$base_current.stdout" 2>"$base_current.stderr"; then
+  echo "immutable base CLI unexpectedly launched the current daemon" >&2
+  exit 1
+fi
+grep -F "legacy launcher marker detected" "$base_current/supervisor.log" >/dev/null
+[[ ! -e "$base_current/supervisor.pid" ]]
+[[ ! -e "$base_current/supervisor.port" ]]
+[[ ! -e "$base_current/supervisor.lock" ]]
+[[ ! -e "$base_current/supervisor.start.lock" ]]
+
+current_base="$MATRIX_ROOT/current-cli-base-daemon"
+if run_registry_probe "$CURRENT_KIN" "$BASE_DAEMON" "$current_base" \
+  >"$current_base.stdout" 2>"$current_base.stderr"; then
+  echo "current CLI unexpectedly launched a daemon without adoption acknowledgement" >&2
+  exit 1
+fi
+grep -F "does not acknowledge supervisor startup protocol" \
+  "$current_base.stderr" >/dev/null
+[[ ! -e "$current_base/supervisor.pid" ]]
+[[ ! -e "$current_base/supervisor.port" ]]
+[[ ! -e "$current_base/supervisor.start.lock" ]]
+
+echo "supervisor startup compatibility matrix: PASS"
+echo "  current CLI -> current daemon: adopted generation and served"
+echo "  immutable base CLI -> live current daemon: connected through published endpoint"
+echo "  immutable base CLI -> current daemon: rejected before singleton/publication"
+echo "  current CLI -> immutable base daemon: rejected by compat handshake before startup"


### PR DESCRIPTION
Daemon boot could wedge a repo for minutes at a time. A synchronous O(graph)
spine warm-up could occupy a Tokio worker, the CLI could read that silence as
death and remove a live daemon's endpoint files, and a replacement could then
lose the per-repo singleton lock without enough owner evidence to recover.

This change keeps a busy daemon distinguishable from a dead or unrelated one,
and makes every destructive recovery decision depend on current, serialized
evidence.

## Readiness stays observable throughout initialization

The complete lazy spine initialization pass now runs through the blocking
runtime handoff: mutex contention, primary capture, sibling loads, backend
construction, and publication all stay off the Tokio worker. A dedicated
initialization mutex permits only one initializer, while `OnceLock` remains the
publication edge.

The warming guard covers that entire pass and can no longer be cleared by an
overlapping caller. `/readiness` reports `warming`, `/health` reports
`spine_warming`, and the CLI retains a successful readiness response's warming
signal even if the following health probe drops.

Readiness remains HTTP 200 while warming. The daemon can already serve its own
repository; cross-repository materialization is not allowed to make liveness
look like death.

## Endpoint files are cleared only against exact local authority

Within `probe_daemon_endpoint`, only positive evidence authorizes clearing a
repo's endpoint record: a recorded owner that is provably gone, or a responding
daemon that proves it serves another local authority. A timeout is evidence of
slowness, not death, and an unanswered health probe establishes no identity.

Identity is repository plus workspace. Two clones intentionally share
`repo_id`, so matching repository identity cannot override a differing
`workspace_id`. Older daemons that do not report workspace identity fall back
to canonical paths, and a path difference is conclusive only when both sides
resolve.

Successful readiness bodies are parsed even on HTTP 200 so `warming=true`
survives a subsequent health failure. Process liveness now has an explicit
Windows implementation using the process API; unsupported targets preserve
authority rather than guessing that an owner is dead.

Every endpoint deletion re-reads the `(pid, port)` immediately before acting
and refuses if the owner changed.

Scope note: this governs endpoint records for a daemon this process did not
start. `wait_for_daemon_ready` can still kill a child it spawned itself after a
pure deadline, and daemon identity is still a bare PID. Those separate
boundaries remain tracked in FIR-1653.

## Lock reclaim and acquisition share one lifecycle critical section

Acquisition and stale reclaim now serialize through
`.kin/daemon.lifecycle`, a persistent coordination inode that is never
unlinked. `daemon.lock` cannot safely provide this exclusion because recovery
exists specifically for a leaked child descriptor that keeps the old inode
locked after the daemon owner dies.

The acquiring process stamps `daemon.lock` while holding both the coordination
lock and the singleton lock. Reclaim reads the lock stamp and `daemon.pid`,
refuses if either owner is live, then re-reads both immediately before unlink.
An owner change or unavailable coordination lock fails closed. A successor
therefore cannot acquire and stamp a new lock between stale-owner validation
and unlink.

Bounded retry still covers a legitimate teardown handoff. A genuinely
contended start then fails loudly with the recorded holder instead of exiting
successfully with an unactionable warning.

## Verification

Adversarial regression coverage includes:

- the same repository opened as two distinct workspaces;
- canonical-path fallback for older health payloads;
- a successful `warming=true` readiness response followed by a failed health
  probe;
- an actual single-worker readiness request during spine initialization;
- concurrent spine callers proving one initializer and an exact warming flag;
- acquisition blocked behind stale reclaim until unlink is complete; and
- a legacy/non-participating owner change cancelling reclaim.

Local CI-equivalent gates at head `1e9c1209`:

- exact `ci.yml` clippy allowlist with `-D warnings`, all targets, and all
  features;
- `cargo fmt -- --check`;
- zero-file-search, hydration-semantics, runtime-boundary, and private-coupling
  guards;
- `cargo build --all-targets --locked`;
- `cargo nextest run --locked --no-fail-fast`: 3902 passed, 9 intentionally
  skipped; and
- `cargo test --doc --locked`: 1 passed, 2 ignored.

The full test pass used `GIT_CONFIG_GLOBAL=/dev/null` and
`GIT_CONFIG_NOSYSTEM=1`. Without that isolation, the user's global DCO hook
rejects fixture commits before the affected tests run; the shared test-harness
Git/environment isolation is tracked in FIR-1652.

The Windows process-API branch was type-checked directly against
`windows-sys`; a full local MSVC cross-build was unavailable because this macOS
host lacks the MSVC C headers. Hosted Windows CI remains the cross-platform
gate.

Closes FIR-1583
