### PR TITLE
Read entity body indentation absolutely and surface session expiry

### DIFF
--- a/crates/kin-daemon/src/api.rs
+++ b/crates/kin-daemon/src/api.rs
@@ -326,6 +326,14 @@ struct SessionStartResponse {
     started_at: kin_model::timestamp::Timestamp,
     capabilities: SessionCapabilities,
     status: String,
+    /// How long the session may go idle before the sweeper may reap it.
+    idle_timeout_secs: u64,
+    /// When that window closes if nothing refreshes it. Every session-bound
+    /// daemon call refreshes the heartbeat, so this only arrives on a genuinely
+    /// silent agent — but an agent that cannot see the deadline cannot decide to
+    /// send `kin_session_heartbeat` before it, which is how a long read phase
+    /// silently stranded a transaction.
+    expires_at: kin_model::timestamp::Timestamp,
 }
 
 #[derive(Debug, Serialize, Deserialize)]
@@ -333,6 +341,10 @@ struct SessionHeartbeatResponse {
     session_id: String,
     status: String,
     heartbeat_at: kin_model::timestamp::Timestamp,
+    /// Same contract as on [`SessionStartResponse`]: the refreshed window, and
+    /// the deadline it now runs to.
+    idle_timeout_secs: u64,
+    expires_at: kin_model::timestamp::Timestamp,
 }
 
 #[derive(Debug, Serialize, Deserialize)]
@@ -1823,6 +1835,8 @@ async fn start_session(
             )
         })?;
 
+    let idle_ttl = state.coordinator.session_idle_ttl();
+    let expires_at = session_expiry(&session.last_heartbeat, idle_ttl);
     Ok(Json(SessionStartResponse {
         session_id: session.session_id.to_string(),
         vendor: session.vendor,
@@ -1831,7 +1845,46 @@ async fn start_session(
         started_at: session.started_at,
         capabilities: session.capabilities,
         status: "active".to_string(),
+        idle_timeout_secs: idle_ttl.as_secs(),
+        expires_at,
     }))
+}
+
+/// What to tell a caller whose session id no longer names a live session.
+///
+/// The id is well-formed, so this is an ended or idle-reaped session rather
+/// than a typo, and the only move is a fresh `kin_session_start`. Saying so is
+/// the difference between an agent restarting in one call and an agent
+/// retrying the same dead id until it times out.
+fn expired_session_message(session_id: &SessionId) -> String {
+    format!(
+        "session not found: {session_id}. It was ended or expired after its idle timeout \
+         (KIN_SESSION_IDLE_TTL_SECS). Call kin_session_start for a new session id, then \
+         re-open any transaction on it; every session-bound call refreshes the idle window, \
+         and kin_session_heartbeat refreshes it during a long read phase."
+    )
+}
+
+/// The instant an idle session stops being refreshable, from the heartbeat it
+/// last recorded.
+///
+/// Saturates rather than wrapping: a TTL large enough to overflow the calendar
+/// means "not reachable from here", and reporting the heartbeat itself as the
+/// deadline would tell an agent its live session had already expired.
+fn session_expiry(
+    last_heartbeat: &kin_model::timestamp::Timestamp,
+    idle_ttl: Duration,
+) -> kin_model::timestamp::Timestamp {
+    let window = i64::try_from(idle_ttl.as_secs())
+        .ok()
+        .and_then(chrono::TimeDelta::try_seconds)
+        .unwrap_or(chrono::TimeDelta::MAX);
+    kin_model::timestamp::Timestamp(
+        last_heartbeat
+            .0
+            .checked_add_signed(window)
+            .unwrap_or(chrono::DateTime::<chrono::Utc>::MAX_UTC),
+    )
 }
 
 /// GET /session/{session_id} — fetch a single active session.
@@ -1859,6 +1912,18 @@ async fn session_heartbeat(
     State(state): State<Arc<DaemonState>>,
 ) -> Result<impl IntoResponse, (StatusCode, String)> {
     let session_id = parse_session_id(&session_id)?;
+    // A heartbeat against a session the sweeper already reaped is the one call
+    // guaranteed to be in flight when a long-lived agent loses its session. It
+    // must come back as an actionable 404 naming the restart, not as a 500 that
+    // reads like a daemon fault.
+    if state
+        .coordinator
+        .get_session(&session_id)
+        .map_err(internal_error)?
+        .is_none()
+    {
+        return Err((StatusCode::NOT_FOUND, expired_session_message(&session_id)));
+    }
     state
         .coordinator
         .heartbeat(&session_id)
@@ -1868,12 +1933,16 @@ async fn session_heartbeat(
         .coordinator
         .get_session(&session_id)
         .map_err(internal_error)?
-        .ok_or_else(|| (StatusCode::NOT_FOUND, "session not found".to_string()))?;
+        .ok_or_else(|| (StatusCode::NOT_FOUND, expired_session_message(&session_id)))?;
 
+    let idle_ttl = state.coordinator.session_idle_ttl();
+    let expires_at = session_expiry(&session.last_heartbeat, idle_ttl);
     Ok(Json(SessionHeartbeatResponse {
         session_id: session.session_id.to_string(),
         status: "active".to_string(),
         heartbeat_at: session.last_heartbeat,
+        idle_timeout_secs: idle_ttl.as_secs(),
+        expires_at,
     }))
 }
 
@@ -17337,6 +17406,103 @@ mod tests {
             .unwrap();
         let end_json: SessionEndResponse = serde_json::from_slice(&end_body).unwrap();
         assert_eq!(end_json.status, "ended");
+    }
+
+    /// Session start and heartbeat must both say how long the session is good
+    /// for, and a call on a dead session must say it expired and name the
+    /// restart.
+    ///
+    /// An agent cannot decide to heartbeat before a deadline it cannot see, and
+    /// a bare "not found" reads like a bad argument rather than an expiry, so a
+    /// thinking pause silently stranded the whole session.
+    #[tokio::test]
+    async fn session_responses_carry_their_expiry_and_a_dead_session_says_so() {
+        let state = test_state();
+        let idle_ttl = state.coordinator.session_idle_ttl();
+        let app = router(state);
+
+        let start_response = app
+            .clone()
+            .oneshot(
+                Request::post("/session")
+                    .header("content-type", "application/json")
+                    .body(Body::from(
+                        serde_json::json!({
+                            "vendor": "claude-code",
+                            "client_name": "expiry-test",
+                            "transport": "mcp",
+                            "cwd": "/project"
+                        })
+                        .to_string(),
+                    ))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(start_response.status(), StatusCode::OK);
+        let start_body = axum::body::to_bytes(start_response.into_body(), 4096)
+            .await
+            .unwrap();
+        let start_json: SessionStartResponse = serde_json::from_slice(&start_body).unwrap();
+        assert_eq!(start_json.idle_timeout_secs, idle_ttl.as_secs());
+        assert!(
+            start_json.expires_at.0 > start_json.started_at.0,
+            "the expiry must be ahead of the session it belongs to: {:?} vs {:?}",
+            start_json.expires_at,
+            start_json.started_at
+        );
+
+        let heartbeat_response = app
+            .clone()
+            .oneshot(
+                Request::post(format!("/session/{}/heartbeat", start_json.session_id))
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(heartbeat_response.status(), StatusCode::OK);
+        let heartbeat_body = axum::body::to_bytes(heartbeat_response.into_body(), 4096)
+            .await
+            .unwrap();
+        let heartbeat_json: SessionHeartbeatResponse =
+            serde_json::from_slice(&heartbeat_body).unwrap();
+        assert_eq!(heartbeat_json.idle_timeout_secs, idle_ttl.as_secs());
+        assert!(
+            heartbeat_json.expires_at.0 >= start_json.expires_at.0,
+            "a heartbeat must not move the deadline backwards"
+        );
+
+        // End the session, then heartbeat it: the shape an agent hits after the
+        // sweeper reaps an idle session.
+        let end_response = app
+            .clone()
+            .oneshot(
+                Request::delete(format!("/session/{}", start_json.session_id))
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(end_response.status(), StatusCode::OK);
+
+        let dead_response = app
+            .oneshot(
+                Request::post(format!("/session/{}/heartbeat", start_json.session_id))
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(dead_response.status(), StatusCode::NOT_FOUND);
+        let dead_body = axum::body::to_bytes(dead_response.into_body(), 4096)
+            .await
+            .unwrap();
+        let message = String::from_utf8(dead_body.to_vec()).unwrap();
+        assert!(
+            message.contains("expired") && message.contains("kin_session_start"),
+            "an expired session must be named as expired and name its recovery: {message}"
+        );
     }
 
     // -----------------------------------------------------------------------

--- a/crates/kin-daemon/src/api.rs
+++ b/crates/kin-daemon/src/api.rs
@@ -342,12 +342,11 @@ struct SessionStartResponse {
     status: String,
     /// How long the session may go idle before the sweeper may reap it.
     idle_timeout_secs: u64,
-    /// When that window closes if nothing refreshes it. Every session-bound
-    /// daemon call refreshes the heartbeat, so this only arrives on a genuinely
-    /// silent agent — but an agent that cannot see the deadline cannot decide to
-    /// send `kin_session_heartbeat` before it, which is how a long read phase
-    /// silently stranded a transaction.
-    expires_at: kin_model::timestamp::Timestamp,
+    /// When the current idle window becomes eligible for reaping if no call
+    /// refreshes it. A live registered PID is stronger liveness evidence and
+    /// can keep the session past this boundary, so this is deliberately not
+    /// named `expires_at`.
+    idle_reap_eligible_at: kin_model::timestamp::Timestamp,
 }
 
 #[derive(Debug, Serialize, Deserialize)]
@@ -355,10 +354,10 @@ struct SessionHeartbeatResponse {
     session_id: String,
     status: String,
     heartbeat_at: kin_model::timestamp::Timestamp,
-    /// Same contract as on [`SessionStartResponse`]: the refreshed window, and
-    /// the deadline it now runs to.
+    /// Same contract as on [`SessionStartResponse`]: the refreshed idle window
+    /// and its next reaping-eligibility boundary.
     idle_timeout_secs: u64,
-    expires_at: kin_model::timestamp::Timestamp,
+    idle_reap_eligible_at: kin_model::timestamp::Timestamp,
 }
 
 #[derive(Debug, Serialize, Deserialize)]
@@ -1869,7 +1868,7 @@ async fn start_session(
         })?;
 
     let idle_ttl = state.coordinator.session_idle_ttl();
-    let expires_at = session_expiry(&session.last_heartbeat, idle_ttl);
+    let idle_reap_eligible_at = session_idle_reap_eligibility(&session.last_heartbeat, idle_ttl);
     Ok(Json(SessionStartResponse {
         session_id: session.session_id.to_string(),
         vendor: session.vendor,
@@ -1879,7 +1878,7 @@ async fn start_session(
         capabilities: session.capabilities,
         status: "active".to_string(),
         idle_timeout_secs: idle_ttl.as_secs(),
-        expires_at,
+        idle_reap_eligible_at,
     }))
 }
 
@@ -1898,13 +1897,16 @@ fn expired_session_message(session_id: &SessionId) -> String {
     )
 }
 
-/// The instant an idle session stops being refreshable, from the heartbeat it
-/// last recorded.
+/// The instant the current idle window becomes eligible for reaping, measured
+/// from the last recorded heartbeat.
+///
+/// A registered PID that is still alive is stronger liveness evidence and can
+/// keep the session active beyond this boundary.
 ///
 /// Saturates rather than wrapping: a TTL large enough to overflow the calendar
 /// means "not reachable from here", and reporting the heartbeat itself as the
 /// deadline would tell an agent its live session had already expired.
-fn session_expiry(
+fn session_idle_reap_eligibility(
     last_heartbeat: &kin_model::timestamp::Timestamp,
     idle_ttl: Duration,
 ) -> kin_model::timestamp::Timestamp {
@@ -1945,37 +1947,25 @@ async fn session_heartbeat(
     State(state): State<Arc<DaemonState>>,
 ) -> Result<impl IntoResponse, (StatusCode, String)> {
     let session_id = parse_session_id(&session_id)?;
-    // A heartbeat against a session the sweeper already reaped is the one call
-    // guaranteed to be in flight when a long-lived agent loses its session. It
-    // must come back as an actionable 404 naming the restart, not as a 500 that
-    // reads like a daemon fault.
-    if state
-        .coordinator
-        .get_session(&session_id)
-        .map_err(internal_error)?
-        .is_none()
-    {
-        return Err((StatusCode::NOT_FOUND, expired_session_message(&session_id)));
-    }
-    state
-        .coordinator
-        .heartbeat(&session_id)
-        .map_err(internal_error)?;
-
+    // Existence and refresh are one coordinator operation under the same
+    // arbitration guard as stale-session sweeping. A heartbeat against a
+    // session the sweeper already reaped is the one call guaranteed to be in
+    // flight when a long-lived agent loses its session; it must come back as an
+    // actionable 404, never a precheck/update race reported as HTTP 500.
     let session = state
         .coordinator
-        .get_session(&session_id)
+        .heartbeat_session(&session_id)
         .map_err(internal_error)?
         .ok_or_else(|| (StatusCode::NOT_FOUND, expired_session_message(&session_id)))?;
 
     let idle_ttl = state.coordinator.session_idle_ttl();
-    let expires_at = session_expiry(&session.last_heartbeat, idle_ttl);
+    let idle_reap_eligible_at = session_idle_reap_eligibility(&session.last_heartbeat, idle_ttl);
     Ok(Json(SessionHeartbeatResponse {
         session_id: session.session_id.to_string(),
         status: "active".to_string(),
         heartbeat_at: session.last_heartbeat,
         idle_timeout_secs: idle_ttl.as_secs(),
-        expires_at,
+        idle_reap_eligible_at,
     }))
 }
 
@@ -17562,9 +17552,9 @@ mod tests {
         assert_eq!(end_json.status, "ended");
     }
 
-    /// Session start and heartbeat must both say how long the session is good
-    /// for, and a call on a dead session must say it expired and name the
-    /// restart.
+    /// Session start and heartbeat must both expose the next idle-reaping
+    /// eligibility boundary, and a call on a dead session must say it expired
+    /// and name the restart.
     ///
     /// An agent cannot decide to heartbeat before a deadline it cannot see, and
     /// a bare "not found" reads like a bad argument rather than an expiry, so a
@@ -17600,9 +17590,9 @@ mod tests {
         let start_json: SessionStartResponse = serde_json::from_slice(&start_body).unwrap();
         assert_eq!(start_json.idle_timeout_secs, idle_ttl.as_secs());
         assert!(
-            start_json.expires_at.0 > start_json.started_at.0,
-            "the expiry must be ahead of the session it belongs to: {:?} vs {:?}",
-            start_json.expires_at,
+            start_json.idle_reap_eligible_at.0 > start_json.started_at.0,
+            "the idle-reaping boundary must be ahead of the session it belongs to: {:?} vs {:?}",
+            start_json.idle_reap_eligible_at,
             start_json.started_at
         );
 
@@ -17623,8 +17613,8 @@ mod tests {
             serde_json::from_slice(&heartbeat_body).unwrap();
         assert_eq!(heartbeat_json.idle_timeout_secs, idle_ttl.as_secs());
         assert!(
-            heartbeat_json.expires_at.0 >= start_json.expires_at.0,
-            "a heartbeat must not move the deadline backwards"
+            heartbeat_json.idle_reap_eligible_at.0 >= start_json.idle_reap_eligible_at.0,
+            "a heartbeat must not move the idle-reaping boundary backwards"
         );
 
         // End the session, then heartbeat it: the shape an agent hits after the

--- a/crates/kin-daemon/src/mcp_commit.rs
+++ b/crates/kin-daemon/src/mcp_commit.rs
@@ -2034,6 +2034,149 @@ mod tests {
         }
     }
 
+    /// Abandoning a transaction must leave the repository exactly as if it had
+    /// never been begun.
+    ///
+    /// `kin_transaction_abort` sits in the default agent write profile and its
+    /// description promises to discard the staged mutations, so what has to be
+    /// asserted is not the state label but that repository authority and the
+    /// working tree are untouched and the staged set is gone.
+    #[test]
+    fn aborting_a_staged_transaction_moves_neither_authority_nor_the_working_tree() {
+        let (_dir, state) = test_state();
+        let (value, _) = install_exact_source(
+            &state,
+            "src/lib.rs",
+            b"pub fn value() -> u8 { 1 }\n",
+            "value",
+        );
+        let before = load_native_commit_base(&state.layout).unwrap();
+        let before_file = std::fs::read(state.layout.working_dir().join("src/lib.rs")).unwrap();
+
+        let sessions = test_sessions();
+        let (transaction_id, _arguments) =
+            stage_entity_edit(&sessions, &value, "pub fn value() -> u8 { 2 }");
+        assert_eq!(
+            sessions
+                .get_transaction(&transaction_id)
+                .unwrap()
+                .staged_operations
+                .len(),
+            1
+        );
+
+        let aborted = sessions.abort_transaction(&transaction_id).unwrap();
+        assert_eq!(aborted.state, "aborted");
+        assert!(
+            aborted.staged_operations.is_empty(),
+            "abort must discard the staged mutations it says it discards"
+        );
+        assert_eq!(
+            load_native_commit_base(&state.layout)
+                .unwrap()
+                .roots
+                .generation,
+            before.roots.generation,
+            "an aborted transaction must not move repository authority"
+        );
+        assert_eq!(
+            std::fs::read(state.layout.working_dir().join("src/lib.rs")).unwrap(),
+            before_file,
+            "an aborted transaction must not touch the working tree"
+        );
+        assert!(
+            sessions
+                .begin_transaction(TEST_SESSION, "file:src/lib.rs")
+                .is_ok(),
+            "the session must outlive the transaction it abandoned"
+        );
+    }
+
+    /// The recovery an agent actually reaches for: a transaction whose commit
+    /// was refused must still be abandonable.
+    ///
+    /// A refused pre-publication commit returns the transaction to `active`
+    /// with its operations cleared. An agent that decides against the work
+    /// rather than correcting it calls abort, so abort has to accept the state
+    /// the failure path leaves behind and not only a pristine one.
+    #[test]
+    fn a_transaction_whose_commit_was_refused_can_still_be_aborted() {
+        let (_dir, state) = test_state();
+        let (value, _) = install_exact_source(
+            &state,
+            "src/lib.rs",
+            b"pub fn value() -> u8 { 1 }\n",
+            "value",
+        );
+        let before = load_native_commit_base(&state.layout).unwrap();
+        let sessions = test_sessions();
+        let transaction = sessions
+            .begin_transaction(TEST_SESSION, "file:src/lib.rs")
+            .unwrap();
+        let arguments = HashMap::from([(
+            "transaction_id".to_string(),
+            serde_json::json!(transaction.transaction_id),
+        )]);
+
+        sessions
+            .stage_transaction(
+                &transaction.transaction_id,
+                vec![
+                    kin_mcp::McpMutationOperation {
+                        verb: "update".to_string(),
+                        target: value.id.to_string(),
+                        payload: None,
+                        body: Some("pub fn value() -> u8 { 2 }".to_string()),
+                        description: "correct work staged alongside the failure".to_string(),
+                    },
+                    kin_mcp::McpMutationOperation {
+                        verb: "update".to_string(),
+                        target: "no_such_entity".to_string(),
+                        payload: None,
+                        body: Some("pub fn no_such_entity() {}".to_string()),
+                        description: String::new(),
+                    },
+                ],
+            )
+            .unwrap();
+
+        let refused = commit_exact_transaction(&state, &sessions, &arguments, None);
+        assert_eq!(refused.is_error, Some(true));
+        let poisoned = sessions
+            .get_transaction(&transaction.transaction_id)
+            .unwrap();
+        assert_eq!(poisoned.state, "active");
+        assert!(poisoned.staged_operations.is_empty());
+
+        let aborted = sessions
+            .abort_transaction(&transaction.transaction_id)
+            .expect("a transaction a refused commit returned to active must be abortable");
+        assert_eq!(aborted.state, "aborted");
+        assert_eq!(
+            load_native_commit_base(&state.layout)
+                .unwrap()
+                .roots
+                .generation,
+            before.roots.generation,
+            "neither the refused commit nor the abort may move repository authority"
+        );
+        assert!(
+            sessions
+                .stage_transaction(
+                    &transaction.transaction_id,
+                    vec![kin_mcp::McpMutationOperation {
+                        verb: "update".to_string(),
+                        target: value.id.to_string(),
+                        payload: None,
+                        body: Some("pub fn value() -> u8 { 3 }".to_string()),
+                        description: "after the abort".to_string(),
+                    }],
+                )
+                .is_err(),
+            "an abandoned transaction must not accept new work"
+        );
+    }
+
     /// A caller that guesses the operations shape gets the accepted shapes
     /// back, not a serde field name from inside a payload variant.
     #[test]

--- a/crates/kin-daemon/src/mcp_commit.rs
+++ b/crates/kin-daemon/src/mcp_commit.rs
@@ -572,6 +572,11 @@ fn plan_exact_transaction(
                 error.valid_up_to()
             )
         })?;
+        // `entity_body_splice`, not a raw span splice: an entity span opens at
+        // the entity's first token, so a nested entity's indentation sits in the
+        // file ahead of the span while the rest of its body carries indentation
+        // inside it. A caller that submits the entity as the file renders it
+        // would otherwise have line 1 indented twice.
         let splices = file_edits
             .iter()
             .map(|(entity, body)| {
@@ -579,10 +584,7 @@ fn plan_exact_transaction(
                     .span
                     .as_ref()
                     .expect("validated source edit always has a span");
-                kin_projection::Splice {
-                    byte_range: span.start_byte..span.end_byte,
-                    new_content: body.clone(),
-                }
+                kin_projection::entity_body_splice(&original, span.start_byte..span.end_byte, body)
             })
             .collect();
         let projected = kin_projection::apply_splices(&original, splices)
@@ -1595,6 +1597,441 @@ mod tests {
                 .unwrap(),
             b"pub fn value() -> u8 { 2 }\n"
         );
+    }
+
+    /// An ambiguous bare name must hand back the candidates it could not choose
+    /// between, and the corrected id must commit on the transaction the caller
+    /// already holds.
+    ///
+    /// Without the candidate list the advice ("use the entity id") names an id
+    /// the caller has no way to learn, and without the clear the corrected retry
+    /// re-plans the same ambiguity forever. Both halves are needed for an
+    /// unscripted agent to recover in-session.
+    #[test]
+    fn ambiguous_name_target_lists_candidates_and_the_id_retry_commits() {
+        let (_dir, state) = test_state();
+        let (left, _) = install_exact_source(
+            &state,
+            "src/left.rs",
+            b"pub fn shared() -> u8 { 1 }\n",
+            "shared",
+        );
+        let (right, _) = install_exact_source(
+            &state,
+            "src/right.rs",
+            b"pub fn shared() -> u8 { 10 }\n",
+            "shared",
+        );
+        let sessions = test_sessions();
+        let transaction = sessions
+            .begin_transaction(TEST_SESSION, "entity:shared")
+            .unwrap();
+        let arguments = HashMap::from([(
+            "transaction_id".to_string(),
+            serde_json::json!(transaction.transaction_id),
+        )]);
+        sessions
+            .stage_transaction(
+                &transaction.transaction_id,
+                vec![kin_mcp::McpMutationOperation {
+                    verb: "update".to_string(),
+                    target: "shared".to_string(),
+                    payload: None,
+                    body: Some("pub fn shared() -> u8 { 2 }".to_string()),
+                    description: "bare name an agent would reach for first".to_string(),
+                }],
+            )
+            .unwrap();
+
+        let ambiguous = commit_exact_transaction(&state, &sessions, &arguments, None);
+        assert_eq!(ambiguous.is_error, Some(true));
+        let message = result_text(&ambiguous);
+        assert!(
+            message.contains("is ambiguous (2 exact-name matches)"),
+            "the refusal must say what was ambiguous: {message}"
+        );
+        for candidate in [&left, &right] {
+            assert!(
+                message.contains(&candidate.id.to_string()),
+                "candidate id {} must be listed: {message}",
+                candidate.id
+            );
+        }
+        for path in ["src/left.rs", "src/right.rs"] {
+            assert!(
+                message.contains(path),
+                "candidate file path {path} must be listed: {message}"
+            );
+        }
+        assert!(
+            message.contains("pub fn shared() -> u8"),
+            "each candidate must carry its declaration so the caller can tell them apart: {message}"
+        );
+
+        // The id the refusal named, staged on the SAME transaction, commits.
+        sessions
+            .stage_transaction(
+                &transaction.transaction_id,
+                vec![kin_mcp::McpMutationOperation {
+                    verb: "update".to_string(),
+                    target: left.id.to_string(),
+                    payload: None,
+                    body: Some("pub fn shared() -> u8 { 2 }".to_string()),
+                    description: "corrected id retry".to_string(),
+                }],
+            )
+            .unwrap();
+        let committed = commit_exact_transaction(&state, &sessions, &arguments, None);
+        assert_ne!(
+            committed.is_error,
+            Some(true),
+            "the id retry must commit on the same transaction: {}",
+            result_text(&committed)
+        );
+        assert_eq!(
+            std::fs::read(state.layout.working_dir().join("src/left.rs")).unwrap(),
+            b"pub fn shared() -> u8 { 2 }\n"
+        );
+        assert_eq!(
+            std::fs::read(state.layout.working_dir().join("src/right.rs")).unwrap(),
+            b"pub fn shared() -> u8 { 10 }\n"
+        );
+    }
+
+    /// A nested entity submitted exactly as the file renders it lands at its own
+    /// indentation, not at twice it.
+    ///
+    /// An entity span opens at the entity's first token, so an impl method's
+    /// four spaces sit in the file ahead of the span while the rest of its body
+    /// carries indentation inside it. Splicing the caller's body verbatim put
+    /// its copy of line 1's indentation after the file's: the method compiled at
+    /// eight spaces and failed `cargo fmt`. Byte-exactness is the promise, so
+    /// this asserts the whole file byte-for-byte, for an impl method and a
+    /// module-nested function committed together, against a top-level function
+    /// that has no indentation to double.
+    #[test]
+    fn nested_entity_bodies_commit_at_their_own_indentation() {
+        let (_dir, state) = test_state();
+        let impl_source =
+            b"pub struct Builder;\n\nimpl Builder {\n    pub fn set(&mut self) -> u8 {\n        1\n    }\n}\n";
+        let (method, _) =
+            install_exact_source(&state, "src/builder.rs", impl_source, "Builder::set");
+        let module_source = b"pub mod inner {\n    pub fn nested() -> u8 {\n        1\n    }\n}\n";
+        let (nested, _) = install_exact_source(&state, "src/nested.rs", module_source, "nested");
+        let (top_level, _) = install_exact_source(
+            &state,
+            "src/plain.rs",
+            b"pub fn plain() -> u8 {\n    1\n}\n",
+            "plain",
+        );
+
+        let sessions = test_sessions();
+        let transaction = sessions
+            .begin_transaction(TEST_SESSION, "entity:set")
+            .unwrap();
+        sessions
+            .stage_transaction(
+                &transaction.transaction_id,
+                vec![
+                    // Each body is the entity exactly as the file renders it,
+                    // leading indentation included: what an agent writes back
+                    // after reading the source.
+                    kin_mcp::McpMutationOperation {
+                        verb: "update".to_string(),
+                        target: method.id.to_string(),
+                        payload: None,
+                        body: Some(
+                            "    pub fn set(&mut self) -> u8 {\n        2\n    }".to_string(),
+                        ),
+                        description: "impl-nested method".to_string(),
+                    },
+                    kin_mcp::McpMutationOperation {
+                        verb: "update".to_string(),
+                        target: nested.id.to_string(),
+                        payload: None,
+                        body: Some("    pub fn nested() -> u8 {\n        2\n    }".to_string()),
+                        description: "module-nested function".to_string(),
+                    },
+                    kin_mcp::McpMutationOperation {
+                        verb: "update".to_string(),
+                        target: top_level.id.to_string(),
+                        payload: None,
+                        body: Some("pub fn plain() -> u8 {\n    2\n}".to_string()),
+                        description: "top-level function".to_string(),
+                    },
+                ],
+            )
+            .unwrap();
+
+        let result = commit_exact_transaction(
+            &state,
+            &sessions,
+            &HashMap::from([(
+                "transaction_id".to_string(),
+                serde_json::json!(transaction.transaction_id),
+            )]),
+            None,
+        );
+        assert_ne!(
+            result.is_error,
+            Some(true),
+            "nested body commit failed: {}",
+            result_text(&result)
+        );
+
+        for (file, expected) in [
+            (
+                "src/builder.rs",
+                b"pub struct Builder;\n\nimpl Builder {\n    pub fn set(&mut self) -> u8 {\n        2\n    }\n}\n".to_vec(),
+            ),
+            (
+                "src/nested.rs",
+                b"pub mod inner {\n    pub fn nested() -> u8 {\n        2\n    }\n}\n".to_vec(),
+            ),
+            ("src/plain.rs", b"pub fn plain() -> u8 {\n    2\n}\n".to_vec()),
+        ] {
+            assert_eq!(
+                std::fs::read(state.layout.working_dir().join(file)).unwrap(),
+                expected,
+                "{file} is not byte-identical to the intended source"
+            );
+            let after = load_native_commit_base(&state.layout).unwrap();
+            let artifact = after
+                .tree
+                .artifact_at_path(&RepoPath::from_utf8(file).unwrap())
+                .unwrap();
+            assert_eq!(
+                load_native_source_blob(&state.layout, artifact.entry.blob_identity().unwrap())
+                    .unwrap(),
+                expected,
+                "{file} repository authority is not byte-identical either"
+            );
+        }
+    }
+
+    /// The exact bytes the read surface serves are the span slice, with no
+    /// leading indentation on line 1. Submitting those back unchanged has to
+    /// keep committing, or the indentation fix traded one break for another.
+    #[test]
+    fn span_slice_body_for_a_nested_entity_still_commits_exactly() {
+        let (_dir, state) = test_state();
+        let source =
+            b"pub struct Builder;\n\nimpl Builder {\n    pub fn set(&mut self) -> u8 {\n        1\n    }\n}\n";
+        let (method, _) = install_exact_source(&state, "src/builder.rs", source, "Builder::set");
+        let sessions = test_sessions();
+        let transaction = sessions
+            .begin_transaction(TEST_SESSION, "entity:set")
+            .unwrap();
+        sessions
+            .stage_transaction(
+                &transaction.transaction_id,
+                vec![kin_mcp::McpMutationOperation {
+                    verb: "update".to_string(),
+                    target: method.id.to_string(),
+                    payload: None,
+                    // No leading indentation: the span slice, verbatim.
+                    body: Some("pub fn set(&mut self) -> u8 {\n        2\n    }".to_string()),
+                    description: "span-slice body".to_string(),
+                }],
+            )
+            .unwrap();
+
+        let result = commit_exact_transaction(
+            &state,
+            &sessions,
+            &HashMap::from([(
+                "transaction_id".to_string(),
+                serde_json::json!(transaction.transaction_id),
+            )]),
+            None,
+        );
+        assert_ne!(
+            result.is_error,
+            Some(true),
+            "span-slice body commit failed: {}",
+            result_text(&result)
+        );
+        assert_eq!(
+            std::fs::read(state.layout.working_dir().join("src/builder.rs")).unwrap(),
+            b"pub struct Builder;\n\nimpl Builder {\n    pub fn set(&mut self) -> u8 {\n        2\n    }\n}\n"
+        );
+    }
+
+    /// The whole rehearsal, end to end: a three-file signature change staged on
+    /// one transaction, surviving a deliberate mid-flight staging error, landing
+    /// byte-identical.
+    ///
+    /// This is the shape an unscripted agent could not survive. It reaches for a
+    /// bare name, the name is ambiguous, and before the fixes the refusal named
+    /// an id it could not see while the failed operation stayed staged, so every
+    /// later commit on that transaction re-failed identically. Then the bodies it
+    /// wrote back carried the indentation the file showed it, and the nested ones
+    /// landed at twice it.
+    ///
+    /// The assertion is the whole file, byte for byte, for all three files, plus
+    /// `ops_applied` and the modified-file set from the commit receipt.
+    #[test]
+    fn three_file_signature_change_survives_a_mid_flight_staging_error() {
+        let (_dir, state) = test_state();
+
+        // The entity whose signature changes, plus a same-named `commands` that
+        // makes the bare name ambiguous the way `hostname` was in the rehearsal.
+        let cli_source = b"pub fn resolve_binary(prog: &str) -> String {\n    prog.to_string()\n}\n\npub mod compat {\n    pub fn commands() -> String {\n        String::new()\n    }\n}\n";
+        let (resolve_binary, _) =
+            install_exact_source(&state, "src/cli.rs", cli_source, "resolve_binary");
+        // Caller one: an impl-nested method.
+        let worker_source = b"pub struct Worker;\n\nimpl Worker {\n    pub fn preprocessor(&mut self) -> String {\n        crate::cli::resolve_binary(\"pre\")\n    }\n}\n";
+        let (preprocessor, _) = install_exact_source(
+            &state,
+            "src/worker.rs",
+            worker_source,
+            "Worker::preprocessor",
+        );
+        // Caller two: a module-nested function.
+        let defaults_source = b"pub mod defaults {\n    pub fn commands() -> String {\n        crate::cli::resolve_binary(\"cmd\")\n    }\n}\n";
+        let (commands, _) =
+            install_exact_source(&state, "src/defaults.rs", defaults_source, "commands");
+        let before = load_native_commit_base(&state.layout).unwrap();
+
+        const NEW_RESOLVE_BINARY: &str = "pub fn resolve_binary(prog: &str, search_dirs: Option<&[String]>) -> String {\n    let _ = search_dirs;\n    prog.to_string()\n}";
+        // Both caller bodies carry the indentation their files render, because
+        // that is what a caller reading the source writes back.
+        const NEW_PREPROCESSOR: &str = "    pub fn preprocessor(&mut self) -> String {\n        crate::cli::resolve_binary(\"pre\", None)\n    }";
+        const NEW_COMMANDS: &str = "    pub fn commands() -> String {\n        crate::cli::resolve_binary(\"cmd\", None)\n    }";
+
+        let sessions = test_sessions();
+        let transaction = sessions
+            .begin_transaction(TEST_SESSION, "entity:resolve_binary")
+            .unwrap();
+        let arguments = HashMap::from([(
+            "transaction_id".to_string(),
+            serde_json::json!(transaction.transaction_id),
+        )]);
+
+        // Attempt one: correct work alongside one bare name that cannot resolve.
+        sessions
+            .stage_transaction(
+                &transaction.transaction_id,
+                vec![
+                    kin_mcp::McpMutationOperation {
+                        verb: "update".to_string(),
+                        target: resolve_binary.id.to_string(),
+                        payload: None,
+                        body: Some(NEW_RESOLVE_BINARY.to_string()),
+                        description: "add the search_dirs parameter".to_string(),
+                    },
+                    kin_mcp::McpMutationOperation {
+                        verb: "update".to_string(),
+                        target: preprocessor.id.to_string(),
+                        payload: None,
+                        body: Some(NEW_PREPROCESSOR.to_string()),
+                        description: "pass None".to_string(),
+                    },
+                    kin_mcp::McpMutationOperation {
+                        verb: "update".to_string(),
+                        target: "commands".to_string(),
+                        payload: None,
+                        body: Some(NEW_COMMANDS.to_string()),
+                        description: "pass None, targeted by bare name".to_string(),
+                    },
+                ],
+            )
+            .unwrap();
+
+        let refused = commit_exact_transaction(&state, &sessions, &arguments, None);
+        assert_eq!(refused.is_error, Some(true));
+        let message = result_text(&refused);
+        assert!(
+            message.contains(&commands.id.to_string()),
+            "the refusal must name the id that resolves the ambiguity: {message}"
+        );
+        assert!(
+            message.contains("src/defaults.rs") && message.contains("src/cli.rs"),
+            "the refusal must locate every candidate: {message}"
+        );
+        assert!(
+            sessions
+                .get_transaction(&transaction.transaction_id)
+                .unwrap()
+                .staged_operations
+                .is_empty(),
+            "a refused attempt must leave the transaction editable"
+        );
+        assert_eq!(
+            load_native_commit_base(&state.layout)
+                .unwrap()
+                .roots
+                .generation,
+            before.roots.generation,
+            "a refused attempt must not move repository authority"
+        );
+
+        // Attempt two: the same transaction, every target an id.
+        sessions
+            .stage_transaction(
+                &transaction.transaction_id,
+                vec![
+                    kin_mcp::McpMutationOperation {
+                        verb: "update".to_string(),
+                        target: resolve_binary.id.to_string(),
+                        payload: None,
+                        body: Some(NEW_RESOLVE_BINARY.to_string()),
+                        description: "add the search_dirs parameter".to_string(),
+                    },
+                    kin_mcp::McpMutationOperation {
+                        verb: "update".to_string(),
+                        target: preprocessor.id.to_string(),
+                        payload: None,
+                        body: Some(NEW_PREPROCESSOR.to_string()),
+                        description: "pass None".to_string(),
+                    },
+                    kin_mcp::McpMutationOperation {
+                        verb: "update".to_string(),
+                        target: commands.id.to_string(),
+                        payload: None,
+                        body: Some(NEW_COMMANDS.to_string()),
+                        description: "pass None".to_string(),
+                    },
+                ],
+            )
+            .unwrap();
+        let committed = commit_exact_transaction(&state, &sessions, &arguments, None);
+        assert_ne!(
+            committed.is_error,
+            Some(true),
+            "the corrected three-file change must commit on the same transaction: {}",
+            result_text(&committed)
+        );
+        let receipt: serde_json::Value = serde_json::from_str(result_text(&committed)).unwrap();
+        assert_eq!(receipt["ops_applied"], 3);
+        assert_eq!(
+            receipt["modified_files"],
+            serde_json::json!(["src/cli.rs", "src/defaults.rs", "src/worker.rs"])
+        );
+
+        for (file, expected) in [
+            (
+                "src/cli.rs",
+                "pub fn resolve_binary(prog: &str, search_dirs: Option<&[String]>) -> String {\n    let _ = search_dirs;\n    prog.to_string()\n}\n\npub mod compat {\n    pub fn commands() -> String {\n        String::new()\n    }\n}\n",
+            ),
+            (
+                "src/worker.rs",
+                "pub struct Worker;\n\nimpl Worker {\n    pub fn preprocessor(&mut self) -> String {\n        crate::cli::resolve_binary(\"pre\", None)\n    }\n}\n",
+            ),
+            (
+                "src/defaults.rs",
+                "pub mod defaults {\n    pub fn commands() -> String {\n        crate::cli::resolve_binary(\"cmd\", None)\n    }\n}\n",
+            ),
+        ] {
+            assert_eq!(
+                String::from_utf8(
+                    std::fs::read(state.layout.working_dir().join(file)).unwrap()
+                )
+                .unwrap(),
+                expected,
+                "{file} is not byte-identical to the intended source"
+            );
+        }
     }
 
     /// A caller that guesses the operations shape gets the accepted shapes

--- a/crates/kin-daemon/src/session_registry.rs
+++ b/crates/kin-daemon/src/session_registry.rs
@@ -212,27 +212,61 @@ impl SessionCoordinator {
         Ok(session_id)
     }
 
-    /// Record a heartbeat for a session. Returns an error if the session
-    /// doesn't exist.
-    pub fn heartbeat(&self, session_id: &SessionId) -> Result<()> {
-        // Verify the session exists.
-        let session = self
+    /// Refresh a session heartbeat and return the refreshed record.
+    ///
+    /// The existence check and update share the same arbitration guard as the
+    /// stale-session sweeper. Without that linearization point, the sweeper can
+    /// delete a session after a caller observes it but before the heartbeat
+    /// update lands, turning an ordinary expired-session response into an
+    /// internal error.
+    pub fn heartbeat_session(&self, session_id: &SessionId) -> Result<Option<AgentSession>> {
+        self.heartbeat_session_with(session_id, || {})
+    }
+
+    fn heartbeat_session_with<F>(
+        &self,
+        session_id: &SessionId,
+        before_update: F,
+    ) -> Result<Option<AgentSession>>
+    where
+        F: FnOnce(),
+    {
+        let _arbitration = self
+            .arbitration
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
+        let Some(mut session) = self
             .graph
             .get_session(session_id)
-            .map_err(DaemonError::from)?;
-        if session.is_none() {
-            return Err(DaemonError::Graph(kin_db::KinDbError::NotFound(format!(
-                "session not found: {}",
-                session_id
-            ))));
-        }
+            .map_err(DaemonError::from)?
+        else {
+            return Ok(None);
+        };
+
+        // Test seams can pause at the old precheck/update race boundary while
+        // the production path pays only an inlined no-op closure.
+        before_update();
 
         let now = Timestamp::now();
         self.graph
             .update_heartbeat(session_id, &now)
             .map_err(DaemonError::from)?;
+        session.last_heartbeat = now;
         debug!(session_id = %session_id, "heartbeat recorded");
-        Ok(())
+        Ok(Some(session))
+    }
+
+    /// Record a heartbeat for a session. Returns an error if the session
+    /// doesn't exist.
+    pub fn heartbeat(&self, session_id: &SessionId) -> Result<()> {
+        self.heartbeat_session(session_id)?
+            .map(drop)
+            .ok_or_else(|| {
+                DaemonError::Graph(kin_db::KinDbError::NotFound(format!(
+                    "session not found: {}",
+                    session_id
+                )))
+            })
     }
 
     /// Deregister a session and clean up all its intents.
@@ -1083,6 +1117,101 @@ mod tests {
         // Heartbeat on nonexistent session should fail.
         let fake = SessionId::new();
         assert!(coord.heartbeat(&fake).is_err());
+    }
+
+    /// The stale-session sweeper must not be able to delete a session between
+    /// the heartbeat existence read and its update.
+    ///
+    /// The hook pauses the heartbeat at that historical race boundary while
+    /// the sweeper attempts to enter its own arbitration section. The sweeper
+    /// must remain blocked until the heartbeat publishes its fresh timestamp;
+    /// after that it must observe the refreshed session and reap nothing.
+    #[test]
+    fn heartbeat_refresh_is_atomic_with_stale_session_sweeping() {
+        let coord = Arc::new(SessionCoordinator::with_session_idle_ttl(
+            Arc::new(kin_db::InMemoryGraph::new()),
+            Duration::from_secs(1),
+        ));
+        let sid = coord
+            .register_session(
+                "codex",
+                "atomic-heartbeat",
+                SessionTransport::Mcp,
+                None,
+                PathBuf::from("/project"),
+                SessionCapabilities::default(),
+            )
+            .unwrap();
+        let stale_heartbeat =
+            Timestamp(chrono::Utc::now() - chrono::TimeDelta::try_seconds(5).unwrap());
+        coord
+            .graph
+            .update_heartbeat(&sid, &stale_heartbeat)
+            .unwrap();
+
+        let at_update_boundary = Arc::new(std::sync::Barrier::new(2));
+        let release_update = Arc::new(std::sync::Barrier::new(2));
+        let heartbeat_coord = Arc::clone(&coord);
+        let heartbeat_boundary = Arc::clone(&at_update_boundary);
+        let heartbeat_release = Arc::clone(&release_update);
+        let heartbeat = std::thread::spawn(move || {
+            heartbeat_coord.heartbeat_session_with(&sid, || {
+                heartbeat_boundary.wait();
+                heartbeat_release.wait();
+            })
+        });
+
+        at_update_boundary.wait();
+        let (sweep_started_tx, sweep_started_rx) = std::sync::mpsc::channel();
+        let (sweep_tx, sweep_rx) = std::sync::mpsc::channel();
+        let sweep_coord = Arc::clone(&coord);
+        let sweep = std::thread::spawn(move || {
+            sweep_started_tx.send(()).unwrap();
+            let outcome = sweep_coord.sweep_stale_sessions();
+            sweep_tx.send(outcome).unwrap();
+        });
+        sweep_started_rx
+            .recv_timeout(Duration::from_secs(2))
+            .expect("sweeper thread must reach the arbitration attempt");
+
+        // A missing heartbeat arbitration guard would let the sweeper delete
+        // the stale record immediately while the hook is paused.
+        let premature = sweep_rx.recv_timeout(Duration::from_millis(200));
+        release_update.wait();
+
+        let refreshed = heartbeat
+            .join()
+            .expect("heartbeat thread must not panic")
+            .expect("heartbeat refresh must not fail")
+            .expect("the registered session must still exist");
+        let sweeper_was_blocked =
+            matches!(&premature, Err(std::sync::mpsc::RecvTimeoutError::Timeout));
+        let sweep_outcome = match premature {
+            Ok(outcome) => outcome,
+            Err(std::sync::mpsc::RecvTimeoutError::Timeout) => sweep_rx
+                .recv_timeout(Duration::from_secs(2))
+                .expect("sweeper must finish after heartbeat releases the guard"),
+            Err(error) => panic!("sweeper result channel failed: {error}"),
+        };
+        sweep.join().expect("sweeper thread must not panic");
+
+        assert!(
+            sweeper_was_blocked,
+            "the sweeper crossed the heartbeat precheck/update boundary"
+        );
+        assert_eq!(
+            sweep_outcome.expect("sweeper must succeed"),
+            0,
+            "the sweeper must observe the refreshed heartbeat"
+        );
+        assert_eq!(
+            coord
+                .get_session(&sid)
+                .unwrap()
+                .expect("session must remain active")
+                .last_heartbeat,
+            refreshed.last_heartbeat
+        );
     }
 
     #[test]

--- a/crates/kin-mcp/src/daemon_delegate.rs
+++ b/crates/kin-mcp/src/daemon_delegate.rs
@@ -555,10 +555,7 @@ impl DaemonCallSeam for RealDaemonSeam {
             .await
             .map_err(|e| classify_send_error("MCP tool call", e))?;
         if !resp.status().is_success() {
-            return Err(DaemonCallError::DaemonError(format!(
-                "daemon MCP tool call failed: HTTP {}",
-                resp.status()
-            )));
+            return Err(daemon_http_error("MCP tool call", resp).await);
         }
         let result = resp.json::<ToolCallResult>().await.map_err(|e| {
             DaemonCallError::DaemonError(format!("daemon MCP tool call response parse failed: {e}"))
@@ -850,6 +847,68 @@ where
     .await
 }
 
+/// Maximum daemon error-body bytes preserved in an MCP-facing error.
+///
+/// The daemon is a loopback peer, but an accidental HTML/proxy response or a
+/// pathological route body must not turn one rejected tool call into an
+/// unbounded MCP response.
+const MAX_DAEMON_ERROR_BODY_BYTES: usize = 8 * 1024;
+
+/// Preserve an actionable, bounded response body from a daemon HTTP error.
+///
+/// Reading by chunks enforces the bound while the response is in flight rather
+/// than collecting an arbitrarily large body and truncating only afterward.
+async fn daemon_http_error(operation: &str, mut response: reqwest::Response) -> DaemonCallError {
+    let status = response.status();
+    let mut body = Vec::with_capacity(MAX_DAEMON_ERROR_BODY_BYTES);
+    let mut truncated = false;
+
+    loop {
+        match response.chunk().await {
+            Ok(Some(chunk)) => {
+                let remaining = MAX_DAEMON_ERROR_BODY_BYTES.saturating_sub(body.len());
+                if chunk.len() > remaining {
+                    body.extend_from_slice(&chunk[..remaining]);
+                    truncated = true;
+                    break;
+                }
+                body.extend_from_slice(&chunk);
+                if body.len() == MAX_DAEMON_ERROR_BODY_BYTES {
+                    match response.chunk().await {
+                        Ok(Some(_)) => truncated = true,
+                        Ok(None) => {}
+                        Err(error) => {
+                            return DaemonCallError::DaemonError(format!(
+                                "daemon {operation} failed: HTTP {status}; error response read \
+                                 failed after {} bytes: {error}",
+                                body.len()
+                            ));
+                        }
+                    }
+                    break;
+                }
+            }
+            Ok(None) => break,
+            Err(error) => {
+                return DaemonCallError::DaemonError(format!(
+                    "daemon {operation} failed: HTTP {status}; error response read failed: {error}"
+                ));
+            }
+        }
+    }
+
+    let detail = String::from_utf8_lossy(&body);
+    let detail = detail.trim();
+    let truncation = if truncated { " … [truncated]" } else { "" };
+    if detail.is_empty() {
+        DaemonCallError::DaemonError(format!("daemon {operation} failed: HTTP {status}"))
+    } else {
+        DaemonCallError::DaemonError(format!(
+            "daemon {operation} failed: HTTP {status}: {detail}{truncation}"
+        ))
+    }
+}
+
 /// Send one already-built daemon request and read its JSON body.
 ///
 /// Split out of [`daemon_json_request`] so the response handling is testable
@@ -869,10 +928,7 @@ async fn send_daemon_json(
         .await
         .map_err(|e| classify_send_error(operation, e))?;
     if !resp.status().is_success() {
-        return Err(DaemonCallError::DaemonError(format!(
-            "daemon {operation} failed: HTTP {}",
-            resp.status()
-        )));
+        return Err(daemon_http_error(operation, resp).await);
     }
     let body = resp.text().await.map_err(|e| {
         DaemonCallError::DaemonError(format!("daemon {operation} response read failed: {e}"))
@@ -1184,11 +1240,18 @@ pub async fn forward_session_heartbeat(
     let Some(base) = daemon_base_url() else {
         return Ok(None);
     };
-    let value = daemon_json_request("heartbeat", &base, |client, base| {
+    session_heartbeat_request(&base, session_id).await.map(Some)
+}
+
+async fn session_heartbeat_request(
+    base: &str,
+    session_id: &str,
+) -> Result<serde_json::Value, String> {
+    let value = daemon_json_request("heartbeat", base, |client, base| {
         with_auth(client.post(format!("{base}/session/{session_id}/heartbeat")))
     })
     .await?;
-    Ok(Some(value))
+    Ok(value)
 }
 
 /// Forward a session end to the daemon.
@@ -1508,6 +1571,69 @@ mod tests {
         assert!(
             matches!(err, DaemonCallError::DaemonError(ref m) if m.contains("HTTP 500")),
             "expected a DaemonError naming the status, got: {err:?}"
+        );
+        handle.abort();
+    }
+
+    #[tokio::test]
+    async fn daemon_error_body_is_preserved_but_bounded() {
+        let oversized: &'static str = Box::leak(
+            "actionable "
+                .repeat(MAX_DAEMON_ERROR_BODY_BYTES)
+                .into_boxed_str(),
+        );
+        let (base, handle) = stub_daemon_raw(400, "Bad Request", oversized).await;
+        let client = probe_client();
+        let error = send_daemon_json("transaction", client.post(format!("{base}/transaction")))
+            .await
+            .expect_err("HTTP 400 must fail");
+        let DaemonCallError::DaemonError(message) = error else {
+            panic!("an HTTP response must not be classified as a connection loss");
+        };
+
+        assert!(
+            message.contains("actionable"),
+            "the daemon's diagnostic body must survive: {message}"
+        );
+        assert!(
+            message.contains("[truncated]"),
+            "an oversized diagnostic must say it was truncated: {message}"
+        );
+        assert!(
+            message.len() <= MAX_DAEMON_ERROR_BODY_BYTES + 128,
+            "bounded error body grew to {} bytes",
+            message.len()
+        );
+        handle.abort();
+    }
+
+    /// Drive the real heartbeat delegate response reader and the same final
+    /// ToolCallResult adapter used by the product handler. This is the boundary
+    /// the direct Axum route test cannot cover.
+    #[tokio::test]
+    async fn expired_session_404_reaches_the_final_mcp_tool_result() {
+        let body = "session not found: dead-session. It expired after its idle timeout. \
+                    Call kin_session_start for a new session id.";
+        let (base, handle) = stub_daemon_raw(404, "Not Found", body).await;
+
+        let forwarded = session_heartbeat_request(&base, "dead-session")
+            .await
+            .map(Some);
+        let result = crate::handlers::sessions::delegated_session_heartbeat_result(
+            forwarded,
+            crate::server::SessionAuthorityMode::DaemonRequired,
+        )
+        .expect("delegate adaptation must succeed")
+        .expect("daemon-required mode must produce a result");
+
+        assert_eq!(result.is_error, Some(true));
+        let ContentBlock::Text { text } = result
+            .content
+            .first()
+            .expect("error ToolCallResult must carry text");
+        assert!(
+            text.contains("expired") && text.contains("kin_session_start"),
+            "final MCP error lost the daemon recovery diagnosis: {text}"
         );
         handle.abort();
     }

--- a/crates/kin-mcp/src/handlers/sessions.rs
+++ b/crates/kin-mcp/src/handlers/sessions.rs
@@ -627,8 +627,13 @@ pub async fn handle_transaction_begin(
 pub const TRANSACTION_STAGE_DESC: &str = "\
 Stage one or more mutation operations onto an active transaction. The simplest write is \
 a payload-less entity source edit: {verb: \"update\", target: \"<entity name or id>\", \
-body: \"<the entity's full new source text>\", description: \"...\"}. The entity is \
-resolved fail-closed server-side (exact name or id; ambiguity is an error) and on \
+body: \"<the entity's full new source text>\", description: \"...\"}. Prefer the entity \
+id that semantic_locate, find_references, or get_context_pack already handed you: a bare \
+name resolves only when it is unique, and an ambiguous one is refused (with the candidate \
+ids, so the retry is mechanical). The body is the entity exactly as its file renders it; \
+its first line's indentation is read as the entity's own line indentation, not as extra \
+indentation on top of it, so a nested method or function goes back unchanged. The entity is \
+resolved fail-closed server-side and on \
 commit the graph-to-file projection writes the body into the entity's working-directory \
 file. Structured payloads (full entity, relation add/remove) are also accepted. Each \
 operation is validated at stage time: anything the commit path would silently drop (a \
@@ -732,7 +737,10 @@ collision_warnings, and conflicts (entities skipped due to a concurrent file edi
 non-empty set is surfaced as an error instead). Before graph application, exact entity/artifact \
 intent conflicts and session write/commit capabilities are attested; enforce mode rejects \
 before graph truth changes. Contract-scope coverage remains explicitly false until touched \
-contracts can be derived from the semantic delta.";
+contracts can be derived from the semantic delta. A commit that is refused before anything \
+is published leaves the transaction usable: its staged operations are cleared and named in \
+the refusal, so you re-stage corrected ones on the SAME transaction and commit again, and \
+kin_transaction_abort is the clean exit if you would rather abandon it.";
 
 fn push_scope_once(scopes: &mut Vec<kin_model::IntentScope>, scope: kin_model::IntentScope) {
     if !scopes.contains(&scope) {
@@ -1092,7 +1100,11 @@ pub async fn handle_transaction_commit<G: GraphStore>(
 }
 
 pub const TRANSACTION_ABORT_DESC: &str = "\
-Abort the transaction and discard all staged mutations.";
+Abort the transaction and discard all staged mutations. Reach for it when you decide \
+against work you already staged, so the transaction ends instead of sitting open holding \
+operations you no longer intend. You do not need it to recover from a refused commit: a \
+commit refused before publication already clears its staged operations and names them, so \
+you can re-stage corrected ones on the same transaction.";
 
 pub async fn handle_transaction_abort(
     args: &HashMap<String, serde_json::Value>,

--- a/crates/kin-mcp/src/handlers/sessions.rs
+++ b/crates/kin-mcp/src/handlers/sessions.rs
@@ -62,12 +62,13 @@ the session lifecycle uses — keep it alive with kin_session_heartbeat, declare
 you'll touch via kin_register_intent (enabling collision detection against other \
 agents), and close out with kin_session_end. Prefer this over the legacy \
 register_session, which captures none of this context. When the session is daemon-backed \
-the response also carries idle_timeout_secs and expires_at: the session is reaped if it \
-goes that long with no call, so if your next step is a read phase that could outlast \
-expires_at, send kin_session_heartbeat (any session-bound call also refreshes the \
-window), and a call on an expired session fails saying so and names kin_session_start as \
-the recovery. An in-process session returns neither field; heartbeat it on the same \
-cadence rather than reading a deadline off the response.";
+the response also carries idle_timeout_secs and idle_reap_eligible_at: the latter is the \
+next boundary at which an idle PID-less session may be reaped, not an unconditional \
+expiry (a live registered PID is stronger liveness evidence). If your next step is a read \
+phase that could outlast that boundary, send kin_session_heartbeat; any session-bound call \
+also refreshes the window. A call on an already-reaped session fails saying so and names \
+kin_session_start as the recovery. An in-process session returns neither field; heartbeat \
+it on the same cadence rather than reading a boundary off the response.";
 
 pub async fn handle_session_start(
     args: &HashMap<String, serde_json::Value>,
@@ -137,10 +138,29 @@ during a long-running session so Kin doesn't treat it as stale and so the agent'
 presence (and any held intents) stays visible to other agents. Pair it with \
 kin_session_start (which issues the session ID) and kin_session_end (which closes the \
 session and releases its intents). A daemon-backed response carries the refreshed \
-idle_timeout_secs and expires_at, so you know how long the session is good for, and \
-heartbeating an already-expired session fails saying so and names kin_session_start as \
-the recovery. An in-process response carries neither field and reports only that the \
-session is alive.";
+idle_timeout_secs and idle_reap_eligible_at, the next boundary at which an idle PID-less \
+session may be reaped; a live registered PID can keep it active beyond that boundary. \
+Heartbeating an already-reaped session fails saying so and names kin_session_start as the \
+recovery. An in-process response carries neither field and reports only that the session \
+is alive.";
+
+pub(crate) fn delegated_session_heartbeat_result(
+    daemon_result: std::result::Result<Option<serde_json::Value>, String>,
+    session_authority_mode: SessionAuthorityMode,
+) -> Result<Option<ToolCallResult>> {
+    match daemon_result {
+        Ok(Some(value)) => {
+            let json =
+                serde_json::to_string_pretty(&value).map_err(crate::error::McpError::Json)?;
+            Ok(Some(ToolCallResult::text(json)))
+        }
+        Ok(None) if session_authority_mode.requires_daemon() => {
+            Ok(Some(daemon_required_unavailable("session heartbeat")))
+        }
+        Ok(None) => Ok(None),
+        Err(error) => Ok(Some(ToolCallResult::error(error))),
+    }
+}
 
 pub async fn handle_session_heartbeat(
     args: &HashMap<String, serde_json::Value>,
@@ -151,19 +171,11 @@ pub async fn handle_session_heartbeat(
     let session_id = parse_session_id(&id_str)?;
 
     if session_authority_mode.uses_daemon() {
-        match crate::daemon_delegate::forward_session_heartbeat(&id_str).await {
-            Ok(Some(value)) => {
-                let json =
-                    serde_json::to_string_pretty(&value).map_err(crate::error::McpError::Json)?;
-                return Ok(ToolCallResult::text(json));
-            }
-            Ok(None) if session_authority_mode.requires_daemon() => {
-                return Ok(daemon_required_unavailable("session heartbeat"));
-            }
-            Ok(None) => {}
-            Err(err) => {
-                return Ok(ToolCallResult::error(err));
-            }
+        if let Some(result) = delegated_session_heartbeat_result(
+            crate::daemon_delegate::forward_session_heartbeat(&id_str).await,
+            session_authority_mode,
+        )? {
+            return Ok(result);
         }
     }
 
@@ -648,8 +660,8 @@ resolved fail-closed server-side and on \
 commit the graph-to-file projection writes the body into the entity's working-directory \
 file. Structured payloads (full entity, relation add/remove) are also accepted. Each \
 operation is validated at stage time: anything the commit path would silently drop (a \
-missing or unknown verb, a missing payload, a nameless entity, a relation \
-update/modify, or a blob payload) is rejected immediately with an actionable error \
+missing or unknown verb, a missing payload outside the target/body source-edit form, a \
+nameless entity, a relation update/modify, or a blob payload) is rejected immediately with an actionable error \
 instead of vanishing at commit. This rejection is identical in daemon and in-process \
 modes. Accepted operations are queued and can be validated or committed together.";
 
@@ -740,18 +752,21 @@ pub async fn handle_transaction_validate(
 }
 
 pub const TRANSACTION_COMMIT_DESC: &str = "\
-Commit all staged mutations in the transaction atomically to the graph. On success \
-returns status, ops_applied (entity+relation deltas applied), empty (true for a \
-no-op commit), new_root_hash (graph Merkle root after the commit), modified_files \
-(working-directory files the projection wrote — entity-body edits reach disk here), \
-collision_warnings, and conflicts (entities skipped due to a concurrent file edit; a \
-non-empty set is surfaced as an error instead). Before graph application, exact entity/artifact \
-intent conflicts and session write/commit capabilities are attested; enforce mode rejects \
-before graph truth changes. Contract-scope coverage remains explicitly false until touched \
-contracts can be derived from the semantic delta. A commit that is refused before anything \
-is published leaves the transaction usable: its staged operations are cleared and named in \
-the refusal, so you re-stage corrected ones on the SAME transaction and commit again, and \
-kin_transaction_abort is the clean exit if you would rather abandon it.";
+Publish all staged mutations atomically through exact repository authority. The daemon \
+requires a clean exact workspace, loads source from repository CAS, splices existing entity \
+body edits in memory, reparses the final bytes, and journals semantic change, exact workspace \
+tree, and ref publication together. Relation-only transactions are supported. New or deleted \
+source entities, metadata-only source edits, ambiguous or overlapping spans, non-UTF-8 source, \
+gitlinks, and dirty or mismatched authority fail before mutation. On success the result names \
+status, ops_applied, empty, change_id, repository_generation, new_root_hash, and modified_files. \
+Before graph application, exact entity/artifact intent conflicts and session write/commit \
+capabilities are attested; enforce mode rejects before graph truth changes. Contract-scope \
+coverage remains explicitly false until touched contracts can be derived from the semantic \
+delta. A commit refused before anything is published leaves the transaction usable: its staged \
+operations are cleared and named in the refusal, so re-stage corrected ones on the SAME \
+transaction and commit again; kin_transaction_abort is the clean exit if you would rather \
+abandon it. An optional operations array may stage and commit in one call and uses the same \
+payload-less source-edit or structured payload operation shapes as kin_transaction_stage.";
 
 fn push_scope_once(scopes: &mut Vec<kin_model::IntentScope>, scope: kin_model::IntentScope) {
     if !scopes.contains(&scope) {

--- a/crates/kin-mcp/src/handlers/sessions.rs
+++ b/crates/kin-mcp/src/handlers/sessions.rs
@@ -61,7 +61,11 @@ other agents, and gate collaboration features. It returns a session ID that the 
 the session lifecycle uses — keep it alive with kin_session_heartbeat, declare what \
 you'll touch via kin_register_intent (enabling collision detection against other \
 agents), and close out with kin_session_end. Prefer this over the legacy \
-register_session, which captures none of this context.";
+register_session, which captures none of this context. The response carries \
+idle_timeout_secs and expires_at: the session is reaped if it goes that long with no \
+call, so if your next step is a read phase that could outlast expires_at, send \
+kin_session_heartbeat (any session-bound call also refreshes the window). A call on an \
+expired session fails saying so and names kin_session_start as the recovery.";
 
 pub async fn handle_session_start(
     args: &HashMap<String, serde_json::Value>,
@@ -130,7 +134,9 @@ Send a heartbeat to keep an agent session marked alive. Reach for it periodicall
 during a long-running session so Kin doesn't treat it as stale and so the agent's \
 presence (and any held intents) stays visible to other agents. Pair it with \
 kin_session_start (which issues the session ID) and kin_session_end (which closes the \
-session and releases its intents).";
+session and releases its intents). Its response carries the refreshed idle_timeout_secs \
+and expires_at, so you always know how long the session is good for; heartbeating an \
+already-expired session fails saying so and names kin_session_start as the recovery.";
 
 pub async fn handle_session_heartbeat(
     args: &HashMap<String, serde_json::Value>,
@@ -523,10 +529,11 @@ pub fn resolve_target_entity<G: GraphStore>(
                 .iter()
                 .map(|entity| {
                     format!(
-                        "{} ({:?} at {})",
+                        "{} ({:?} at {}): {}",
                         entity.id,
                         entity.kind,
-                        candidate_location(entity)
+                        candidate_location(entity),
+                        candidate_declaration(entity)
                     )
                 })
                 .collect::<Vec<_>>()
@@ -547,6 +554,33 @@ fn candidate_location(entity: &kin_model::Entity) -> String {
         (Some(file), None) => file.0.clone(),
         (None, _) => "<no source origin>".to_string(),
     }
+}
+
+/// The one-line declaration that tells two same-named candidates apart.
+///
+/// A location says where a candidate lives; the declaration says what it is,
+/// which is what the caller is actually choosing between when the same name
+/// appears as several overloads or trait implementations. Bounded so one
+/// ambiguity refusal cannot carry an unbounded signature dump.
+fn candidate_declaration(entity: &kin_model::Entity) -> String {
+    /// Long enough for a real signature, short enough that a dozen candidates
+    /// stay readable.
+    const MAX_DECLARATION: usize = 160;
+
+    let declaration = entity
+        .signature
+        .lines()
+        .map(str::trim)
+        .find(|line| !line.is_empty())
+        .unwrap_or(entity.name.as_str());
+    if declaration.chars().count() <= MAX_DECLARATION {
+        return declaration.to_string();
+    }
+    let truncated = declaration
+        .chars()
+        .take(MAX_DECLARATION)
+        .collect::<String>();
+    format!("{truncated}...")
 }
 
 pub const TRANSACTION_BEGIN_DESC: &str = "\

--- a/crates/kin-mcp/src/handlers/sessions.rs
+++ b/crates/kin-mcp/src/handlers/sessions.rs
@@ -61,11 +61,13 @@ other agents, and gate collaboration features. It returns a session ID that the 
 the session lifecycle uses — keep it alive with kin_session_heartbeat, declare what \
 you'll touch via kin_register_intent (enabling collision detection against other \
 agents), and close out with kin_session_end. Prefer this over the legacy \
-register_session, which captures none of this context. The response carries \
-idle_timeout_secs and expires_at: the session is reaped if it goes that long with no \
-call, so if your next step is a read phase that could outlast expires_at, send \
-kin_session_heartbeat (any session-bound call also refreshes the window). A call on an \
-expired session fails saying so and names kin_session_start as the recovery.";
+register_session, which captures none of this context. When the session is daemon-backed \
+the response also carries idle_timeout_secs and expires_at: the session is reaped if it \
+goes that long with no call, so if your next step is a read phase that could outlast \
+expires_at, send kin_session_heartbeat (any session-bound call also refreshes the \
+window), and a call on an expired session fails saying so and names kin_session_start as \
+the recovery. An in-process session returns neither field; heartbeat it on the same \
+cadence rather than reading a deadline off the response.";
 
 pub async fn handle_session_start(
     args: &HashMap<String, serde_json::Value>,
@@ -134,9 +136,11 @@ Send a heartbeat to keep an agent session marked alive. Reach for it periodicall
 during a long-running session so Kin doesn't treat it as stale and so the agent's \
 presence (and any held intents) stays visible to other agents. Pair it with \
 kin_session_start (which issues the session ID) and kin_session_end (which closes the \
-session and releases its intents). Its response carries the refreshed idle_timeout_secs \
-and expires_at, so you always know how long the session is good for; heartbeating an \
-already-expired session fails saying so and names kin_session_start as the recovery.";
+session and releases its intents). A daemon-backed response carries the refreshed \
+idle_timeout_secs and expires_at, so you know how long the session is good for, and \
+heartbeating an already-expired session fails saying so and names kin_session_start as \
+the recovery. An in-process response carries neither field and reports only that the \
+session is alive.";
 
 pub async fn handle_session_heartbeat(
     args: &HashMap<String, serde_json::Value>,
@@ -632,7 +636,14 @@ id that semantic_locate, find_references, or get_context_pack already handed you
 name resolves only when it is unique, and an ambiguous one is refused (with the candidate \
 ids, so the retry is mechanical). The body is the entity exactly as its file renders it; \
 its first line's indentation is read as the entity's own line indentation, not as extra \
-indentation on top of it, so a nested method or function goes back unchanged. The entity is \
+indentation on top of it, so a nested method or function goes back unchanged. That read \
+is a byte-exact prefix match against the file's own indentation run, so copy the file's \
+whitespace rather than re-indenting; a body opening with spaces where the file uses tabs \
+(or with a different width) is spliced verbatim and lands on top of the file's \
+indentation. Note also that source rendered by get_entity_source and \
+get_context_pack.focal_entity.body is capped at 40 lines or 2400 characters and marks \
+the cut with \"... [truncated]\": a body that came back truncated is not the entity's \
+full source and must not be staged as-is. The entity is \
 resolved fail-closed server-side and on \
 commit the graph-to-file projection writes the body into the entity's working-directory \
 file. Structured payloads (full entity, relation add/remove) are also accepted. Each \
@@ -1100,11 +1111,14 @@ pub async fn handle_transaction_commit<G: GraphStore>(
 }
 
 pub const TRANSACTION_ABORT_DESC: &str = "\
-Abort the transaction and discard all staged mutations. Reach for it when you decide \
-against work you already staged, so the transaction ends instead of sitting open holding \
-operations you no longer intend. You do not need it to recover from a refused commit: a \
-commit refused before publication already clears its staged operations and names them, so \
-you can re-stage corrected ones on the same transaction.";
+Abort an active or validated transaction and discard all staged mutations. Reach for it \
+when you decide against work you already staged, so the transaction ends instead of \
+sitting open holding operations you no longer intend. Once kin_transaction_commit has \
+fenced the transaction for publication this is refused, because repository authority may \
+already have moved; re-send the commit instead, which resumes the fenced payload \
+idempotently and reports whether it landed. You do not need abort to recover from a \
+refused commit either: a commit refused before publication already clears its staged \
+operations and names them, so you can re-stage corrected ones on the same transaction.";
 
 pub async fn handle_transaction_abort(
     args: &HashMap<String, serde_json::Value>,

--- a/crates/kin-mcp/src/session.rs
+++ b/crates/kin-mcp/src/session.rs
@@ -985,8 +985,15 @@ impl SessionRegistry {
         scope: &str,
     ) -> std::result::Result<McpTransaction, String> {
         if !self.has_session(session_id) {
+            // A well-formed id that names nothing is an ended or idle-reaped
+            // session, not a typo. Saying only "not found" sends an agent
+            // hunting for a bad argument; naming expiry sends it to the one
+            // call that recovers.
             return Err(format!(
-                "Session not found: {session_id}. Start a session with kin_session_start first."
+                "Session not found: {session_id}. It was ended or expired after its idle \
+                 timeout. Call kin_session_start for a new session id and begin the \
+                 transaction on that one; kin_session_heartbeat keeps a session alive \
+                 through a long read phase."
             ));
         }
         let transaction_id = EntityId::new().to_string();

--- a/crates/kin-mcp/src/session.rs
+++ b/crates/kin-mcp/src/session.rs
@@ -1119,6 +1119,21 @@ impl SessionRegistry {
         Ok(cleared)
     }
 
+    /// End an editable transaction and discard everything it staged.
+    ///
+    /// Only `active` and `validated` transactions may abort, because those are
+    /// the states in which nothing has been fenced and the staged set is the
+    /// only thing to undo.
+    ///
+    /// A `committing` transaction is owned by the commit path instead:
+    /// `prepare_transaction_commit` has persisted its payload digest and
+    /// repository authority may already have moved, so the way out is to
+    /// re-enter the commit with the same staged operations, which resumes
+    /// idempotently and resolves whether the commit landed. Relabelling that
+    /// state `aborted` would make the resume unreachable and strand the
+    /// transaction in exactly the case the fence exists to survive. A
+    /// `committed` transaction refuses for a different reason: overwriting a
+    /// real receipt with `aborted` records provenance that never happened.
     pub fn abort_transaction(
         &self,
         transaction_id: &str,
@@ -1127,12 +1142,26 @@ impl SessionRegistry {
             .transactions
             .lock()
             .expect("transactions lock poisoned");
-        if let Some(tx) = map.get_mut(transaction_id) {
-            tx.state = "aborted".to_string();
-            Ok(tx.clone())
-        } else {
-            Err(format!("Transaction not found: {}", transaction_id))
+        let tx = map
+            .get_mut(transaction_id)
+            .ok_or_else(|| format!("Transaction not found: {transaction_id}"))?;
+        if !matches!(tx.state.as_str(), "active" | "validated") {
+            let recovery = if tx.state == "committing" {
+                "its commit is already fenced, so repository authority may have moved: \
+                 re-send kin_transaction_commit with the same transaction id, which \
+                 resumes the fenced payload idempotently and reports whether it landed"
+            } else {
+                "the transaction already reached a terminal state and holds nothing to \
+                 discard: begin a new one with kin_transaction_begin"
+            };
+            return Err(format!(
+                "Cannot abort transaction {} in state: {}. {recovery}.",
+                transaction_id, tx.state
+            ));
         }
+        tx.staged_operations.clear();
+        tx.state = "aborted".to_string();
+        Ok(tx.clone())
     }
 
     pub fn get_transaction(&self, transaction_id: &str) -> Option<McpTransaction> {
@@ -1783,6 +1812,139 @@ mod tests {
         assert!(registry
             .stage_transaction(&tx.transaction_id, vec![])
             .is_err());
+    }
+
+    fn staged_edit(registry: &SessionRegistry, session: &str) -> McpTransaction {
+        let tx = registry.begin_transaction(session, "src/lib.rs").unwrap();
+        registry
+            .stage_transaction(
+                &tx.transaction_id,
+                vec![McpMutationOperation {
+                    verb: "update".to_string(),
+                    target: "value".to_string(),
+                    payload: None,
+                    body: Some("pub fn value() -> u8 { 2 }".to_string()),
+                    description: "replace the body".to_string(),
+                }],
+            )
+            .unwrap()
+    }
+
+    #[test]
+    fn abort_discards_the_staged_mutations_it_says_it_discards() {
+        let registry = SessionRegistry::new();
+        registry.register("sess-1", "test");
+        let staged = staged_edit(&registry, "sess-1");
+        assert_eq!(staged.staged_operations.len(), 1);
+
+        let aborted = registry.abort_transaction(&staged.transaction_id).unwrap();
+        assert_eq!(aborted.state, "aborted");
+        assert!(
+            aborted.staged_operations.is_empty(),
+            "abort promises to discard the staged mutations, so the returned \
+             transaction must not still carry them"
+        );
+        let stored = registry.get_transaction(&staged.transaction_id).unwrap();
+        assert!(
+            stored.staged_operations.is_empty(),
+            "the registry's own copy must be discarded too, not just the clone \
+             handed back to the caller"
+        );
+        assert!(
+            registry
+                .stage_transaction(&staged.transaction_id, vec![])
+                .is_err(),
+            "an aborted transaction must not accept further operations"
+        );
+    }
+
+    #[test]
+    fn abort_is_refused_once_a_commit_is_fenced_and_the_commit_stays_resumable() {
+        let registry = SessionRegistry::new();
+        registry.register("sess-1", "test");
+        let staged = staged_edit(&registry, "sess-1");
+
+        let fenced = registry
+            .prepare_transaction_commit(&staged.transaction_id, "payload-digest")
+            .unwrap();
+        assert_eq!(fenced.state, "committing");
+
+        let refused = registry
+            .abort_transaction(&staged.transaction_id)
+            .expect_err("a fenced transaction must not be abortable");
+        assert!(
+            refused.contains("committing"),
+            "the refusal must name the state that blocks it: {refused}"
+        );
+        assert!(
+            refused.contains("kin_transaction_commit"),
+            "the refusal must name the call that owns a fenced transaction: {refused}"
+        );
+
+        // Refusing is only worth anything if it keeps the documented recovery
+        // reachable: re-entering the fence with the same digest still resumes,
+        // and the payload it resumes is the one that was fenced.
+        let resumed = registry
+            .prepare_transaction_commit(&staged.transaction_id, "payload-digest")
+            .expect("the fenced commit must remain resumable after a refused abort");
+        assert_eq!(resumed.state, "committing");
+        assert_eq!(
+            resumed.staged_operations.len(),
+            1,
+            "a refused abort must not touch the fenced payload"
+        );
+        assert_eq!(
+            registry
+                .commit_transaction(&staged.transaction_id)
+                .unwrap()
+                .state,
+            "committed"
+        );
+    }
+
+    #[test]
+    fn abort_is_refused_on_a_terminal_transaction() {
+        let registry = SessionRegistry::new();
+        registry.register("sess-1", "test");
+
+        let committed = staged_edit(&registry, "sess-1");
+        registry
+            .commit_transaction(&committed.transaction_id)
+            .unwrap();
+        let refused = registry
+            .abort_transaction(&committed.transaction_id)
+            .expect_err(
+                "aborting a committed transaction would record a receipt that never happened",
+            );
+        assert!(refused.contains("committed"), "{refused}");
+        assert_eq!(
+            registry
+                .get_transaction(&committed.transaction_id)
+                .unwrap()
+                .state,
+            "committed",
+            "a refused abort must not relabel the transaction"
+        );
+
+        let aborted = staged_edit(&registry, "sess-1");
+        registry.abort_transaction(&aborted.transaction_id).unwrap();
+        assert!(
+            registry.abort_transaction(&aborted.transaction_id).is_err(),
+            "a second abort must be refused rather than silently succeeding"
+        );
+    }
+
+    #[test]
+    fn abort_of_an_unknown_transaction_names_the_id() {
+        let registry = SessionRegistry::new();
+        let err = registry
+            .abort_transaction("no-such-transaction")
+            .expect_err("aborting an id that names nothing must fail");
+        assert!(
+            err.contains("no-such-transaction"),
+            "the failure must name the id the caller passed: {err}"
+        );
+        assert!(err.contains("not found"), "{err}");
     }
 
     // ── Stage-time validation (D.7 Track A) ──────────────────────────────────

--- a/crates/kin-mcp/src/tools.rs
+++ b/crates/kin-mcp/src/tools.rs
@@ -600,7 +600,7 @@ pub fn tool_definitions() -> ToolsListResult {
             },
             ToolDefinition {
                 name: "kin_transaction_abort".into(),
-                description: "Abort the transaction and discard all staged mutations.".into(),
+                description: "Abort an active or validated transaction and discard all staged mutations. Once kin_transaction_commit has fenced the transaction for publication this is refused, because repository authority may already have moved; re-send the commit instead, which resumes the fenced payload idempotently and reports whether it landed. You do not need abort to recover from a refused commit: a commit refused before publication already clears its staged operations and names them, so corrected ones go on the same transaction.".into(),
                 input_schema: serde_json::json!({
                     "type": "object",
                     "properties": {

--- a/crates/kin-mcp/src/tools.rs
+++ b/crates/kin-mcp/src/tools.rs
@@ -1043,6 +1043,11 @@ pub fn agent_default_tool_names() -> &'static [&'static str] {
         "kin_transaction_begin",
         "kin_transaction_stage",
         "kin_transaction_commit",
+        // Without abort, an agent that decides against a transaction, or that
+        // wants to start clean after a refusal, has no way out of the one it
+        // holds: begin/stage/commit can only push work forward. A write profile
+        // that cannot abandon a transaction cannot honor "nothing half-applies".
+        "kin_transaction_abort",
         "kin_provenance_query",
     ]
 }
@@ -1156,6 +1161,8 @@ mod tests {
             // this tool. A profile that carries the advice without the tool
             // strands any agent whose read phase outlasts the idle TTL.
             "kin_session_heartbeat",
+            // The only clean exit from a transaction the agent decided against.
+            "kin_transaction_abort",
         ] {
             assert!(
                 profile.contains(&required),

--- a/crates/kin-mcp/src/tools.rs
+++ b/crates/kin-mcp/src/tools.rs
@@ -3,6 +3,78 @@
 
 use crate::types::{ToolDefinition, ToolsListResult};
 
+/// Honest JSON Schema for one transaction operation.
+///
+/// The product daemon accepts two materially different shapes. A source-body
+/// edit is intentionally payload-less; structured entity/relation mutations
+/// require `payload`. Keeping these as disjoint `oneOf` branches prevents MCP
+/// clients from being told that the preferred source-edit form is invalid.
+fn transaction_operation_schema() -> serde_json::Value {
+    serde_json::json!({
+        "oneOf": [
+            {
+                "title": "Entity source body edit",
+                "type": "object",
+                "properties": {
+                    "verb": {
+                        "type": "string",
+                        "enum": ["update", "modify"],
+                        "description": "Update an existing source entity."
+                    },
+                    "target": {
+                        "type": "string",
+                        "minLength": 1,
+                        "description": "Exact repository entity UUID or unambiguous exact entity name."
+                    },
+                    "body": {
+                        "type": "string",
+                        "minLength": 1,
+                        "description": "The entity's complete new UTF-8 source text, including its own leading indentation. Do not submit a truncated retrieval body."
+                    },
+                    "description": {
+                        "type": "string",
+                        "description": "Human-readable explanation of this change."
+                    }
+                },
+                "required": ["verb", "target", "body", "description"],
+                "additionalProperties": false
+            },
+            {
+                "title": "Structured entity or relation mutation",
+                "type": "object",
+                "properties": {
+                    "verb": {
+                        "type": "string",
+                        "enum": [
+                            "create", "add", "upsert", "insert",
+                            "update", "modify", "delete", "remove"
+                        ],
+                        "description": "Entity or relation mutation verb."
+                    },
+                    "target": {
+                        "type": "string",
+                        "description": "Exact repository entity UUID for an Entity payload; empty string for a Relation payload."
+                    },
+                    "payload": {
+                        "type": "object",
+                        "description": "Exact mutation payload: {\"Entity\": { ...existing entity identity... }} or {\"Relation\": {\"from\": \"...\", \"to\": \"...\", \"kind\": \"...\"}}."
+                    },
+                    "body": {
+                        "type": "string",
+                        "description": "Full new UTF-8 source text for a source-bound Entity update. Omit for Relation operations."
+                    },
+                    "description": {
+                        "type": "string",
+                        "description": "Human-readable explanation of this change."
+                    }
+                },
+                "required": ["verb", "target", "payload", "description"],
+                "additionalProperties": false
+            }
+        ]
+    })
+}
+
 /// Build the list of all MCP tools that Kin exposes.
 pub fn tool_definitions() -> ToolsListResult {
     ToolsListResult {
@@ -522,7 +594,7 @@ pub fn tool_definitions() -> ToolsListResult {
             },
             ToolDefinition {
                 name: "kin_transaction_stage".into(),
-                description: "Stage one or more exact repository mutation operations onto an active transaction. Existing source entity edits require the exact entity ID as target plus a full UTF-8 replacement body. Relation operations use an empty target and omit body.".into(),
+                description: crate::handlers::sessions::TRANSACTION_STAGE_DESC.into(),
                 input_schema: serde_json::json!({
                     "type": "object",
                     "properties": {
@@ -531,23 +603,7 @@ pub fn tool_definitions() -> ToolsListResult {
                         "operations": {
                             "type": "array",
                             "description": "Array of mutation operations to stage",
-                            "items": {
-                                "type": "object",
-                                "properties": {
-                                    "verb": { "type": "string", "description": "Entity: update or modify. Relation: create/add/upsert/insert or delete/remove." },
-                                    "target": { "type": "string", "description": "Exact repository entity UUID for an Entity payload; empty string for a Relation payload." },
-                                    "payload": {
-                                        "type": "object",
-                                        "description": "Exact mutation payload: {\"Entity\": { ...existing entity identity... }} or {\"Relation\": {\"from\": \"...\", \"to\": \"...\", \"kind\": \"...\"}}"
-                                    },
-                                    "body": {
-                                        "type": "string",
-                                        "description": "Required full UTF-8 replacement source text for an existing Entity body. Omit only for Relation operations; metadata-only source edits are rejected."
-                                    },
-                                    "description": { "type": "string", "description": "Human-readable explanation of this change" }
-                                },
-                                "required": ["verb", "target", "payload", "description"]
-                            }
+                            "items": transaction_operation_schema()
                         }
                     },
                     "required": ["transaction_id", "operations"]
@@ -567,7 +623,7 @@ pub fn tool_definitions() -> ToolsListResult {
             },
             ToolDefinition {
                 name: "kin_transaction_commit".into(),
-                description: "Publish staged mutations through exact repository authority. The daemon requires a clean exact workspace, loads source from repository CAS, splices existing entity body edits in memory, reparses final bytes, and journals exact working-tree projection with semantic change + workspace + ref publication. Relation-only transactions are supported. New/source-deleted entities, metadata-only source edits, ambiguous or overlapping spans, non-UTF-8 source, gitlinks, and dirty/mismatched authority fail before mutation. On success returns `status`, `ops_applied`, `change_id`, `repository_generation`, `new_root_hash`, and `modified_files`. An optional `operations` array may be staged and committed in one call.".into(),
+                description: crate::handlers::sessions::TRANSACTION_COMMIT_DESC.into(),
                 input_schema: serde_json::json!({
                     "type": "object",
                     "properties": {
@@ -576,23 +632,7 @@ pub fn tool_definitions() -> ToolsListResult {
                         "operations": {
                             "type": "array",
                             "description": "Optional exact mutation operations to stage atomically in this commit request",
-                            "items": {
-                                "type": "object",
-                                "properties": {
-                                    "verb": { "type": "string", "description": "Entity: update or modify. Relation: create/add/upsert/insert or delete/remove." },
-                                    "target": { "type": "string", "description": "Exact repository entity UUID for an Entity payload; empty string for a Relation payload." },
-                                    "payload": {
-                                        "type": "object",
-                                        "description": "Exact mutation payload: {\"Entity\": { ...existing entity identity... }} or {\"Relation\": {\"from\": \"...\", \"to\": \"...\", \"kind\": \"...\"}}"
-                                    },
-                                    "body": {
-                                        "type": "string",
-                                        "description": "Required full UTF-8 replacement source text for an existing Entity body; omit for Relation operations."
-                                    },
-                                    "description": { "type": "string", "description": "Human-readable explanation of this change" }
-                                },
-                                "required": ["verb", "target", "payload", "description"]
-                            }
+                            "items": transaction_operation_schema()
                         }
                     },
                     "required": ["transaction_id"]
@@ -1118,6 +1158,99 @@ mod tests {
         assert!(json.contains("kin_transaction_validate"));
         assert!(json.contains("kin_transaction_commit"));
         assert!(json.contains("kin_transaction_abort"));
+    }
+
+    #[test]
+    fn serialized_tools_list_exposes_the_real_transaction_operation_contract() {
+        fn required_set(schema: &serde_json::Value) -> std::collections::BTreeSet<String> {
+            schema["required"]
+                .as_array()
+                .expect("schema branch must declare required fields")
+                .iter()
+                .map(|field| {
+                    field
+                        .as_str()
+                        .expect("required field must be a string")
+                        .to_string()
+                })
+                .collect()
+        }
+
+        let serialized =
+            serde_json::to_value(tool_definitions()).expect("tools/list must serialize");
+        let tools = serialized["tools"]
+            .as_array()
+            .expect("serialized tools/list must contain a tools array");
+
+        for (tool_name, expected_description, expected_top_required) in [
+            (
+                "kin_transaction_stage",
+                crate::handlers::sessions::TRANSACTION_STAGE_DESC,
+                ["operations", "transaction_id"].as_slice(),
+            ),
+            (
+                "kin_transaction_commit",
+                crate::handlers::sessions::TRANSACTION_COMMIT_DESC,
+                ["transaction_id"].as_slice(),
+            ),
+        ] {
+            let tool = tools
+                .iter()
+                .find(|tool| tool["name"] == tool_name)
+                .unwrap_or_else(|| panic!("{tool_name} must be exposed by tools/list"));
+            assert_eq!(tool["description"], expected_description);
+            assert!(
+                tool["description"]
+                    .as_str()
+                    .is_some_and(|description| description.contains("payload-less")),
+                "{tool_name} must advertise the preferred payload-less source-edit form"
+            );
+            if tool_name == "kin_transaction_stage" {
+                let description = tool["description"].as_str().unwrap();
+                assert!(description.contains("indentation"), "{description}");
+                assert!(description.contains("[truncated]"), "{description}");
+            }
+
+            let top_required = required_set(&tool["inputSchema"]);
+            let expected_top_required: std::collections::BTreeSet<String> = expected_top_required
+                .iter()
+                .map(|field| (*field).into())
+                .collect();
+            assert_eq!(top_required, expected_top_required, "{tool_name}");
+
+            let variants = tool["inputSchema"]["properties"]["operations"]["items"]["oneOf"]
+                .as_array()
+                .expect("transaction operations must be disjoint oneOf variants");
+            assert_eq!(variants.len(), 2, "{tool_name}");
+
+            let body_edit = variants
+                .iter()
+                .find(|variant| variant["title"] == "Entity source body edit")
+                .expect("payload-less body-edit branch");
+            assert_eq!(
+                required_set(body_edit),
+                ["body", "description", "target", "verb"]
+                    .into_iter()
+                    .map(String::from)
+                    .collect()
+            );
+            assert!(
+                body_edit["properties"].get("payload").is_none(),
+                "payload-less body-edit branch must reject payload"
+            );
+
+            let structured = variants
+                .iter()
+                .find(|variant| variant["title"] == "Structured entity or relation mutation")
+                .expect("structured payload branch");
+            assert_eq!(
+                required_set(structured),
+                ["description", "payload", "target", "verb"]
+                    .into_iter()
+                    .map(String::from)
+                    .collect()
+            );
+        }
     }
 
     #[test]

--- a/crates/kin-projection/src/engine.rs
+++ b/crates/kin-projection/src/engine.rs
@@ -406,10 +406,14 @@ pub fn project_to_bytes(
         } = region
         {
             if let Some(new_body) = mutations.get(entity_id) {
-                splices.push(Splice {
-                    byte_range: byte_range.clone(),
-                    new_content: new_body.clone(),
-                });
+                // Caller-authored bodies, so the same first-line indentation
+                // reading `splice_entity` uses. A body that is the region's own
+                // bytes is unaffected.
+                splices.push(crate::splice::entity_body_splice(
+                    base_content,
+                    byte_range.clone(),
+                    new_body,
+                ));
             }
         }
     }

--- a/crates/kin-projection/src/engine.rs
+++ b/crates/kin-projection/src/engine.rs
@@ -179,7 +179,11 @@ pub fn project_entity_mutations_with_policy(
                 } = region
                 {
                     if eid == entity_id {
-                        let splice = splice_entity(layout, entity_id, new_body)?;
+                        let original = state
+                            .file_contents
+                            .get(file_id)
+                            .ok_or_else(|| ProjectionError::LayoutNotFound(file_id.to_string()))?;
+                        let splice = splice_entity(original, layout, entity_id, new_body)?;
                         file_mutations
                             .entry(file_id.clone())
                             .or_default()

--- a/crates/kin-projection/src/lib.rs
+++ b/crates/kin-projection/src/lib.rs
@@ -28,7 +28,7 @@ pub use imports::{add_import, remove_import, update_import_symbols};
 pub use layout_tracker::{build_layout, entity_at_offset, entity_byte_range, update_layout};
 pub use living_docs::generate_living_docs;
 pub use placement::{decide_placement, generate_file_template, PlacementDecision};
-pub use splice::{apply_splices, reconstruct_file, splice_entity, Splice};
+pub use splice::{apply_splices, entity_body_splice, reconstruct_file, splice_entity, Splice};
 pub use tree::{
     materialize_resolved_tree, transition_resolved_tree, verify_resolved_tree_materialization,
     TreeProjectionReport,

--- a/crates/kin-projection/src/splice.rs
+++ b/crates/kin-projection/src/splice.rs
@@ -66,11 +66,71 @@ pub fn apply_splices(original: &[u8], mut splices: Vec<Splice>) -> Result<Vec<u8
     Ok(result)
 }
 
+/// The whitespace run between the start of `start`'s line and `start` itself,
+/// or empty when `start` is at a line start or anything non-whitespace precedes
+/// it on the line.
+///
+/// This is the entity's own indentation: an entity span begins at the entity's
+/// first token, so for anything nested the file carries the indentation ahead of
+/// the span rather than inside it.
+fn line_indent_before(original: &[u8], start: usize) -> &[u8] {
+    let start = start.min(original.len());
+    let line_start = original[..start]
+        .iter()
+        .rposition(|byte| *byte == b'\n')
+        .map_or(0, |newline| newline + 1);
+    let indent = &original[line_start..start];
+    if !indent.is_empty() && indent.iter().all(|byte| matches!(byte, b' ' | b'\t')) {
+        indent
+    } else {
+        &[]
+    }
+}
+
+/// Build the splice that replaces an entity's source region with a new body,
+/// reading the body's first-line indentation the same way as every other line.
+///
+/// An entity span starts at the entity's first token, so a nested entity (an
+/// impl method, a function inside a module block) has its indentation sitting in
+/// the file *before* the span, while every line of its body after the first
+/// carries indentation *inside* it. A verbatim splice therefore reads line 1 as
+/// relative to the entity's column and lines 2..n as absolute, and a caller that
+/// submits the entity exactly as the file shows it gets line 1 indented twice:
+/// the caller's copy lands after the file's. It compiles and it is wrong, which
+/// is worse than a refusal.
+///
+/// The fix is to read line 1 absolutely too. When the span is preceded on its
+/// line by nothing but whitespace and the new body opens with exactly that
+/// whitespace, the splice extends back over the file's copy so the body's own
+/// indentation lands at column 0 of the entity's line. A body that does not open
+/// with the entity's indentation (an exact span slice, or a deliberate
+/// re-indentation) is spliced verbatim, so re-submitting what the read surface
+/// returned stays byte-identical.
+pub fn entity_body_splice(original: &[u8], byte_range: Range<usize>, new_body: &[u8]) -> Splice {
+    let indent = line_indent_before(original, byte_range.start);
+    let start = if !indent.is_empty() && new_body.starts_with(indent) {
+        byte_range.start - indent.len()
+    } else {
+        byte_range.start
+    };
+    Splice {
+        byte_range: start..byte_range.end,
+        new_content: new_body.to_vec(),
+    }
+}
+
 /// Build a splice for a specific entity within a FileLayout.
 ///
-/// Finds the entity's byte range in the layout and creates a splice
-/// that replaces it with `new_body`.
-pub fn splice_entity(layout: &FileLayout, entity_id: &EntityId, new_body: &[u8]) -> Result<Splice> {
+/// Finds the entity's byte range in the layout and creates a splice that
+/// replaces it with `new_body`, normalizing the body's first-line indentation
+/// through [`entity_body_splice`]. `original` is the file the layout describes;
+/// the replaced region cannot be decided without it.
+pub fn splice_entity(
+    original: &[u8],
+    layout: &FileLayout,
+    entity_id: &EntityId,
+    new_body: &[u8],
+) -> Result<Splice> {
     for region in &layout.regions {
         if let SourceRegion::EntityRef {
             entity_id: ref eid,
@@ -78,10 +138,7 @@ pub fn splice_entity(layout: &FileLayout, entity_id: &EntityId, new_body: &[u8])
         } = region
         {
             if eid == entity_id {
-                return Ok(Splice {
-                    byte_range: byte_range.clone(),
-                    new_content: new_body.to_vec(),
-                });
+                return Ok(entity_body_splice(original, byte_range.clone(), new_body));
             }
         }
     }
@@ -97,6 +154,12 @@ pub fn splice_entity(layout: &FileLayout, entity_id: &EntityId, new_body: &[u8])
 /// The `get_entity_body` closure is called for each EntityRef region to
 /// retrieve the entity's current source text. Trivia regions are copied
 /// from the original file content.
+///
+/// Bodies are spliced verbatim over their regions. This runs the graph-to-file
+/// direction, where a body is the exact bytes of its own region and the
+/// indentation ahead of it is trivia the layout already accounts for; the
+/// first-line normalization in [`entity_body_splice`] belongs to the opposite
+/// direction, where a caller authors a body against the file it can see.
 pub fn reconstruct_file<F>(
     original: &[u8],
     layout: &FileLayout,
@@ -202,7 +265,7 @@ mod tests {
             ],
         };
 
-        let splice = splice_entity(&layout, &entity_id, b"fn bar() {}").unwrap();
+        let splice = splice_entity(original, &layout, &entity_id, b"fn bar() {}").unwrap();
         let result = apply_splices(original, vec![splice]).unwrap();
         assert_eq!(result, b"// header\nfn bar() {}\n// end");
     }
@@ -211,8 +274,120 @@ mod tests {
     fn splice_entity_not_found() {
         let layout = make_layout();
         let missing_id = EntityId::new();
-        let err = splice_entity(&layout, &missing_id, b"new body").unwrap_err();
+        let err = splice_entity(
+            b"0123456789abcdefghijklmno",
+            &layout,
+            &missing_id,
+            b"new body",
+        )
+        .unwrap_err();
         assert!(matches!(err, ProjectionError::EntityNotInLayout { .. }));
+    }
+
+    /// An impl-nested method whose new body carries the indentation the file
+    /// shows must land at that indentation, not at twice it.
+    ///
+    /// This is the shape an agent produces: it reads the method as the file
+    /// renders it and writes it back the same way. A verbatim splice put the
+    /// body's four spaces after the file's four and produced an eight-space
+    /// method that compiles and fails `cargo fmt`.
+    #[test]
+    fn impl_method_body_carrying_its_indentation_is_not_double_indented() {
+        let original = b"impl Builder {\n    fn set(&mut self) {\n        self.a = 1;\n    }\n}\n";
+        let span = 19..64; // "fn set(&mut self) {\n        self.a = 1;\n    }"
+        assert_eq!(
+            &original[span.clone()],
+            b"fn set(&mut self) {\n        self.a = 1;\n    }"
+        );
+
+        let new_body = b"    fn set(&mut self) {\n        self.a = 2;\n    }";
+        let splice = entity_body_splice(original, span, new_body);
+        let result = apply_splices(original, vec![splice]).unwrap();
+        assert_eq!(
+            result,
+            b"impl Builder {\n    fn set(&mut self) {\n        self.a = 2;\n    }\n}\n"
+        );
+    }
+
+    /// The exact bytes the read surface serves are the span slice, with no
+    /// leading indentation on line 1. Submitting them back unchanged has to stay
+    /// byte-identical, or the normalization traded one indent bug for another.
+    #[test]
+    fn span_slice_body_round_trips_byte_identically() {
+        let original = b"impl Builder {\n    fn set(&mut self) {\n        self.a = 1;\n    }\n}\n";
+        let span = 19..64;
+        let splice = entity_body_splice(original, span.clone(), &original[span]);
+        let result = apply_splices(original, vec![splice]).unwrap();
+        assert_eq!(result, original);
+    }
+
+    /// Nested modules indent the same way impls do, at whatever depth.
+    #[test]
+    fn nested_module_function_body_carrying_its_indentation_is_not_double_indented() {
+        let original = b"mod outer {\n    mod inner {\n        fn f() -> u8 { 1 }\n    }\n}\n";
+        let span = 36..54; // "fn f() -> u8 { 1 }"
+        assert_eq!(&original[span.clone()], b"fn f() -> u8 { 1 }");
+
+        let new_body = b"        fn f() -> u8 { 2 }";
+        let splice = entity_body_splice(original, span, new_body);
+        let result = apply_splices(original, vec![splice]).unwrap();
+        assert_eq!(
+            result,
+            b"mod outer {\n    mod inner {\n        fn f() -> u8 { 2 }\n    }\n}\n"
+        );
+    }
+
+    /// A top-level function has no indentation to double, so the normalization
+    /// must leave it exactly alone.
+    #[test]
+    fn top_level_function_body_is_spliced_verbatim() {
+        let original = b"fn f() -> u8 { 1 }\n";
+        let splice = entity_body_splice(original, 0..18, b"fn f() -> u8 { 2 }");
+        let result = apply_splices(original, vec![splice]).unwrap();
+        assert_eq!(result, b"fn f() -> u8 { 2 }\n");
+    }
+
+    /// A caller that genuinely wants a deeper indentation still gets it: the
+    /// body's own first-line whitespace is what lands, whatever it is.
+    #[test]
+    fn deliberate_reindentation_is_preserved() {
+        let original = b"impl Builder {\n    fn set(&mut self) {}\n}\n";
+        let span = 19..39;
+        assert_eq!(&original[span.clone()], b"fn set(&mut self) {}");
+
+        // Eight spaces where the file has four: the caller re-indents, and the
+        // result is eight, not twelve.
+        let splice = entity_body_splice(original, span, b"        fn set(&mut self) {}");
+        let result = apply_splices(original, vec![splice]).unwrap();
+        assert_eq!(result, b"impl Builder {\n        fn set(&mut self) {}\n}\n");
+    }
+
+    /// Only whitespace running to the start of the line counts as the entity's
+    /// indentation. A second entity later on the same line has code before it,
+    /// so nothing is consumed.
+    #[test]
+    fn indentation_is_only_consumed_when_the_span_opens_its_line() {
+        let original = b"fn a() {} fn b() {}\n";
+        // "fn b() {}" starts at 10, preceded on its line by "fn a() {} ".
+        let splice = entity_body_splice(original, 10..19, b" fn b() {}");
+        assert_eq!(splice.byte_range, 10..19);
+        let result = apply_splices(original, vec![splice]).unwrap();
+        assert_eq!(result, b"fn a() {}  fn b() {}\n");
+    }
+
+    /// Tabs indent too, and a tab prefix must not be matched against a space
+    /// prefix.
+    #[test]
+    fn tab_indentation_is_matched_exactly() {
+        let original = b"impl B {\n\tfn f() {}\n}\n";
+        let span = 10..19;
+        assert_eq!(&original[span.clone()], b"fn f() {}");
+
+        let consumed = entity_body_splice(original, span.clone(), b"\tfn f() {2}");
+        assert_eq!(consumed.byte_range, 9..19);
+
+        let untouched = entity_body_splice(original, span, b"    fn f() {2}");
+        assert_eq!(untouched.byte_range, 10..19);
     }
 
     #[test]

--- a/crates/kin-projection/tests/round_trip.rs
+++ b/crates/kin-projection/tests/round_trip.rs
@@ -54,7 +54,7 @@ fn rust_fn_round_trip() {
 
     // Modify the entity
     let new_body = b"fn add(a: i32, b: i32) -> i32 {\n    a.wrapping_add(b)\n}\n";
-    let splice = splice_entity(&layout, &entity_id, new_body).unwrap();
+    let splice = splice_entity(source, &layout, &entity_id, new_body).unwrap();
     let result = apply_splices(source, vec![splice]).unwrap();
 
     // Verify trivia is preserved
@@ -120,7 +120,7 @@ fn python_def_round_trip() {
     );
 
     let new_body = b"def greet(name):\n    return f\"Hi, {name}!\"\n";
-    let splice = splice_entity(&layout, &entity_id, new_body).unwrap();
+    let splice = splice_entity(source, &layout, &entity_id, new_body).unwrap();
     let result = apply_splices(source, vec![splice]).unwrap();
 
     assert!(result.starts_with(b"# utils\n"));
@@ -178,7 +178,7 @@ fn typescript_function_round_trip() {
     );
 
     let new_body = b"export function parse(input: string): number {\n  return Number(input);\n}\n";
-    let splice = splice_entity(&layout, &entity_id, new_body).unwrap();
+    let splice = splice_entity(source, &layout, &entity_id, new_body).unwrap();
     let result = apply_splices(source, vec![splice]).unwrap();
 
     assert!(result.starts_with(b"// module\n"));
@@ -225,7 +225,7 @@ fn go_func_round_trip() {
     );
 
     let new_body = b"func Add(a, b int) int {\n\tresult := a + b\n\treturn result\n}\n";
-    let splice = splice_entity(&layout, &entity_id, new_body).unwrap();
+    let splice = splice_entity(source, &layout, &entity_id, new_body).unwrap();
     let result = apply_splices(source, vec![splice]).unwrap();
 
     assert!(result.starts_with(b"package main\n\n"));
@@ -283,7 +283,7 @@ fn java_method_round_trip() {
     );
 
     let new_body = b"public int add(int a, int b) {\n    return Math.addExact(a, b);\n}\n";
-    let splice = splice_entity(&layout, &entity_id, new_body).unwrap();
+    let splice = splice_entity(source, &layout, &entity_id, new_body).unwrap();
     let result = apply_splices(source, vec![splice]).unwrap();
 
     assert!(result.starts_with(b"// Main.java\n"));


### PR DESCRIPTION
FIR-1598 measured an unscripted agent losing 2/2 to a grep agent at 3.4x the cost, and root-caused it to four defects on the transaction surface. Four of the six items on the ticket already had landed fixes on `main`; this verifies each of those in the source and locks it behind a FIR-1598-shaped test, and fixes the two that were still open.

## Per defect: mechanism and evidence

**1. Transaction poisoning. Already fixed on `main`; regression-locked here.**
`unstage_failed_attempt` clears the whole staged set on any commit failure landing before the publication fence, names every operation it dropped, and says corrected operations can be staged on the same transaction. Every pre-fence failure path routes through it. Added `three_file_signature_change_survives_a_mid_flight_staging_error` and `ambiguous_name_target_lists_candidates_and_the_id_retry_commits`, which assert the FIR-1598 shape (ambiguous bare name mid-flight, corrected id retry on the same transaction) rather than the unresolvable-name shape the existing test covers.

**2. Session TTL. Half fixed on `main`; the other half fixed here.**
Already landed: the idle TTL is 1800s (it was two 30-second heartbeat intervals, which is the measured ~150s), and `kin_session_heartbeat` is in `agent_default_tool_names`. Still open: nothing surfaced the deadline, so an agent could not decide to heartbeat before a read phase outlasted it, and a reaped session answered with a bare not-found at HTTP 500. Session start and heartbeat now report `idle_timeout_secs` and `expires_at` computed from the session's own `last_heartbeat` plus the coordinator's live TTL; a call on an ended or idle-reaped session answers 404 with a message naming the expiry, the env var that sets the window, and `kin_session_start` as the recovery. `SessionRegistry::begin_transaction` says the same. Both tool descriptions now point at the fields.

**3. Ambiguous name targets. Mostly fixed on `main`; sharpened here.**
The candidate list already carried entity ids and `file:line`. Each candidate now also carries its one-line declaration, bounded at 160 chars: a location says where a candidate lives, a declaration says what it is, and that is what the caller is choosing between. The acceptance half with no test, that an unambiguous id retry works on the transaction the caller already holds, is now covered.

**4. impl-method indent. The real remaining defect, fixed here.**
An entity span is the tree-sitter node range, so it opens at the entity's first token. A nested entity therefore carries its indentation in the file *ahead* of the span while every line of its body after the first carries indentation *inside* it. Splicing a caller-authored body verbatim read line 1 as relative to the entity's column and lines 2..n as absolute, so a body written back as the file renders it landed at twice the indentation: it compiled and failed `cargo fmt`, which is worse than a refusal.

`kin_projection::entity_body_splice` reads line 1 absolutely too. When the span is preceded on its line by nothing but whitespace and the body opens with exactly that whitespace, the splice extends back over the file's copy so the body's own indentation lands at column 0 of the entity's line. A body that does not open with the entity's indentation is spliced verbatim, which covers both the exact span slice the read surface serves and a deliberate re-indentation. The exact MCP commit planner and `splice_entity` both route through it; `reconstruct_file` deliberately does not, because it runs the graph-to-file direction where a body is the exact bytes of its own region.

**5 and 6. Already fixed on `main`, verified in source.** `get_context_pack`'s description names `focal_entity.body` (with a test pinning the string), and `ACCEPTED_OPERATION_SHAPES` replaces the raw serde field error on both the non-array and the deserialization refusal.

## Falsification

The indent fix was falsified, not just tested. With `entity_body_splice` reverted to a verbatim splice and nothing else changed:

- `kin-projection --lib`: 4 failures — `impl_method_body_carrying_its_indentation_is_not_double_indented`, `nested_module_function_body_carrying_its_indentation_is_not_double_indented`, `deliberate_reindentation_is_preserved`, `tab_indentation_is_matched_exactly`.
- `kin-daemon --lib mcp_commit`: `nested_entity_bodies_commit_at_their_own_indentation` fails, producing `impl Builder {\n        pub fn set(...)` where the intended source is `impl Builder {\n    pub fn set(...)`. That is byte-for-byte the reported symptom, an impl method re-indented from 4 spaces to 8.
- `span_slice_body_for_a_nested_entity_still_commits_exactly` passes with and without the fix, which is the evidence the normalization did not trade one indent bug for another.

All pass with the fix restored.

## Acceptance rehearsal

`three_file_signature_change_survives_a_mid_flight_staging_error` runs the measured shape through the real repository-authority commit path: session, transaction begin, a three-file signature change with an impl-nested caller and a module-nested caller, one deliberate ambiguous bare-name operation mid-flight, a refusal carrying the candidate ids and saying the operations were cleared, repository authority unmoved, then the corrected id retry on the SAME transaction committing with `ops_applied: 3` and all three files asserted byte-for-byte against the intended source.

## Not claimed

- The agent-arm comparison has **not** been rerun. Nothing here claims the 2/2 loss or the 3.4x cost has flipped.
- The rehearsal drives `commit_exact_transaction`, the same entry point MCP `kin_transaction_commit` reaches after `mcp_session_registry_snapshot`, but it does not exercise the `kin mcp start` stdio JSON-RPC transport or `semantic_locate`. The session-expiry test drives the axum router directly rather than a spawned daemon.

## API change for review

`kin_projection::splice_entity` gained a leading `original: &[u8]` parameter — the replaced region cannot be decided without the file bytes, so the signature now forces callers to supply them. `entity_body_splice` is newly exported.

---

## Follow-up commit: a way out of a transaction

`agent_default_tool_names` carried `kin_transaction_begin`, `_stage`, and `_commit` but not `kin_transaction_abort`, so an agent on that profile could only push a transaction forward and had no clean exit from one it had decided against. That is the other half of "nothing half-applies". Added, with the profile test asserting it stays.

The write-path tool descriptions now carry the contract the surface actually enforces, because those descriptions are what an unscripted agent reads:

- `kin_transaction_stage` steers to the entity id the read tools already returned, says a bare name resolves only when unique and that an ambiguous one comes back with the candidate ids, and states the body contract: the entity exactly as its file renders it, first-line indentation read as the entity's own line indentation rather than as indentation on top of it.
- `kin_transaction_commit` says a refusal before publication leaves the transaction usable with its operations cleared and named, so corrected operations go on the SAME transaction.
- `kin_transaction_abort` says when to reach for it and that recovering from a refused commit is not one of those times.
- `kin_session_start` and `kin_session_heartbeat` point at `idle_timeout_secs` / `expires_at` and at the expiry recovery.

`project_to_bytes` splices caller-authored bodies, so it now reads first-line indentation the same way the rest of the projection surface does.

Closes FIR-1598
