### PR TITLE
Serve repository CAS bodies at the content address the VFS tree advertises

### DIFF
--- a/crates/kin-daemon/src/api.rs
+++ b/crates/kin-daemon/src/api.rs
@@ -956,6 +956,7 @@ fn api_routes() -> Router<Arc<DaemonState>> {
         .route("/vfs/tree", get(vfs_tree))
         .route("/vfs/stat/{*path}", get(vfs_stat))
         .route("/vfs/read/{*path}", get(vfs_read))
+        .route("/vfs/blob/{hash}", get(vfs_blob))
         .route("/vfs/readdir/{*path}", get(vfs_readdir))
         .route("/vfs/subscribe", get(vfs_subscribe))
         // Spine endpoints — cross-repo federation queries
@@ -7873,6 +7874,95 @@ async fn vfs_read(
         );
     }
 
+    Ok(response)
+}
+
+fn vfs_blob_error(
+    status: StatusCode,
+    error: &str,
+    hash: &str,
+    detail: Option<String>,
+) -> (StatusCode, String) {
+    let mut body = json!({
+        "error": error,
+        "hash": hash,
+        "authority": "repository_v6",
+    });
+    if let Some(detail) = detail {
+        body["detail"] = json!(detail);
+    }
+    (status, body.to_string())
+}
+
+/// GET /vfs/blob/{hash} — return exact repository-owned CAS bytes for one
+/// content address.
+///
+/// This is the read half of the `/vfs/tree` contract. The tree mints every
+/// advertised hash from repository-v6 immutable source CAS and reads each
+/// artifact size from that same store, so a served tree already proves each
+/// body is present. This route answers from that one authority: the manager
+/// re-verifies the digest of the bytes it returns, so the response is exactly
+/// the content named by the address.
+///
+/// The whole body is always returned. A client verifies it against the hash
+/// the tree advertised, which a partial response could not satisfy, so `Range`
+/// carries no meaning here and is ignored.
+///
+/// An address the repository authority does not own is reported as a named
+/// graph gap. It is never repaired from the working copy or a Git object
+/// database.
+async fn vfs_blob(
+    Path(hash): Path<String>,
+    State(state): State<Arc<DaemonState>>,
+) -> Result<Response, (StatusCode, String)> {
+    let digest = kin_model::Hash256::from_hex(&hash).map_err(|error| {
+        vfs_blob_error(
+            StatusCode::BAD_REQUEST,
+            "malformed_content_address",
+            &hash,
+            Some(error.to_string()),
+        )
+    })?;
+    let authority = ActiveApiRepositoryAuthority::open(&state)?;
+    let blob_data = authority
+        .manager
+        .load_source_blob(digest)
+        .map_err(|error| {
+            vfs_blob_error(
+                StatusCode::FAILED_DEPENDENCY,
+                "repository_cas_read_failed",
+                &hash,
+                Some(error.to_string()),
+            )
+        })?
+        .ok_or_else(|| {
+            vfs_blob_error(
+                StatusCode::NOT_FOUND,
+                "graph_blob_missing",
+                &hash,
+                Some(format!(
+                    "repository {} owns no immutable source body at this content address",
+                    authority.repository_id
+                )),
+            )
+        })?;
+
+    let mut response = blob_data.into_response();
+    response.headers_mut().insert(
+        header::CONTENT_TYPE,
+        HeaderValue::from_static("application/octet-stream"),
+    );
+    response.headers_mut().insert(
+        HeaderName::from_static("x-kin-blob-hash"),
+        HeaderValue::from_str(&digest.to_string()).map_err(|error| {
+            vfs_blob_error(
+                StatusCode::INTERNAL_SERVER_ERROR,
+                "invalid_content_address_header",
+                &hash,
+                Some(error.to_string()),
+            )
+        })?,
+    );
     Ok(response)
 }
 
@@ -17997,6 +18087,113 @@ mod tests {
             .await
             .unwrap();
         assert_eq!(response.status(), StatusCode::NOT_FOUND);
+    }
+
+    /// Every content address `/vfs/tree` advertises must be readable from the
+    /// same daemon. The tree cannot be built at all unless each body is
+    /// present in repository-owned immutable CAS, so an unreadable advertised
+    /// hash is a broken projection contract, not a missing body.
+    #[tokio::test]
+    async fn vfs_blob_serves_every_content_address_the_tree_advertises() {
+        const BODY: &[u8] = b"content addressed projection body\n";
+        let initial = test_state();
+        let layout = initial.layout.clone();
+        install_repository_file(&initial, "src/probe.rs", BODY);
+        drop(initial);
+        let state = Arc::new(DaemonState::open(layout).unwrap());
+        let app = router(state);
+
+        let response = app
+            .clone()
+            .oneshot(Request::get("/vfs/tree").body(Body::empty()).unwrap())
+            .await
+            .unwrap();
+        assert_eq!(response.status(), StatusCode::OK);
+        let body = axum::body::to_bytes(response.into_body(), 1 << 20)
+            .await
+            .unwrap();
+        let snapshot: WorkspaceTreeSnapshot = serde_json::from_slice(&body).unwrap();
+        let artifact = snapshot
+            .artifacts
+            .iter()
+            .find(|artifact| artifact.path.as_utf8() == Some("src/probe.rs"))
+            .expect("the committed artifact must appear in the workspace tree");
+        let advertised = artifact
+            .entry
+            .blob_identity()
+            .expect("a blob entry carries a content address");
+        assert_eq!(artifact.size, BODY.len() as u64);
+
+        let response = app
+            .oneshot(
+                Request::get(format!("/vfs/blob/{advertised}"))
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(
+            response.status(),
+            StatusCode::OK,
+            "/vfs/tree advertised {advertised} so /vfs/blob must serve it"
+        );
+        assert_eq!(
+            response
+                .headers()
+                .get("x-kin-blob-hash")
+                .and_then(|value| value.to_str().ok()),
+            Some(advertised.to_string().as_str())
+        );
+        let served = axum::body::to_bytes(response.into_body(), 1 << 20)
+            .await
+            .unwrap();
+        assert_eq!(served.as_ref(), BODY);
+    }
+
+    #[tokio::test]
+    async fn vfs_blob_names_the_graph_gap_for_an_unowned_content_address() {
+        let state = test_state();
+        let app = router(state);
+        let unowned = "5a".repeat(32);
+        let response = app
+            .oneshot(
+                Request::get(format!("/vfs/blob/{unowned}"))
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(response.status(), StatusCode::NOT_FOUND);
+        let body = axum::body::to_bytes(response.into_body(), 4096)
+            .await
+            .unwrap();
+        let json: serde_json::Value = serde_json::from_slice(&body)
+            .expect("an absent content address reports a typed graph gap");
+        assert_eq!(json["error"], "graph_blob_missing");
+        assert_eq!(json["hash"], unowned);
+        assert_eq!(json["authority"], "repository_v6");
+    }
+
+    #[tokio::test]
+    async fn vfs_blob_rejects_a_content_address_that_is_not_a_sha256() {
+        let state = test_state();
+        let app = router(state);
+        for malformed in ["not-a-hash", "5a", &"5a".repeat(33)] {
+            let response = app
+                .clone()
+                .oneshot(
+                    Request::get(format!("/vfs/blob/{malformed}"))
+                        .body(Body::empty())
+                        .unwrap(),
+                )
+                .await
+                .unwrap();
+            assert_eq!(
+                response.status(),
+                StatusCode::BAD_REQUEST,
+                "{malformed:?} is not a content address"
+            );
+        }
     }
 
     // -----------------------------------------------------------------------


### PR DESCRIPTION
## Root cause: the route does not exist

The daemon advertises content addresses it has no route to answer.

`api_routes()` served `/vfs/version`, `/vfs/tree`, `/vfs/stat/{*path}`, `/vfs/read/{*path}`, `/vfs/readdir/{*path}`, `/vfs/subscribe` and nothing else. `git log -S"/vfs/blob" --all` over this repo returns nothing: the route was never added and never removed, and there is no fallback or nest that could serve it. So `GET /vfs/blob/<hash>` hit axum's unmatched-route handler and returned **404 with an empty body**.

The consuming shim maps a 404 on that route to `graph blob {hash} missing for {path}` (kin-vfs `kin_provider.rs:264`, whose comment reads "The validated tree references this blob; its absence is a graph gap, never a path-not-found"). A routing 404 and a store miss are the same status code, so the symptom read as a missing blob when the real cause was a missing route.

kin-vfs moved reads from path-addressed `GET /vfs/read/<path>` to content-addressed `GET /vfs/blob/<hash>`. This side never gained the counterpart.

### This is not a hydration gap and not a hash-space mismatch

Both alternatives are ruled out by `RepositoryAuthorityManager::workspace_tree_snapshot` in kin-db. Building the tree reads **every** artifact's size with `backend.source_blob_len(repository_id, digest)` and fails the whole tree with `workspace projection artifact {path} body {digest} is absent from immutable source CAS` when any body is missing.

**A `/vfs/tree` that returns 200 has already proven every hash it advertises has a body in repository-owned immutable source CAS, in the same hash space, under the same repository id.** There is nothing to hydrate and nothing to translate.

### Impact is wider than the report

The linked report says the released pairing is fine and only main-to-main is broken. That is not what the tags show. Released kin `v0.3.6` has no `/vfs/blob` route (no kin release ever has), and released kin-vfs `v0.2.0` already uses `/vfs/blob` exclusively with zero `/vfs/read` references. **Every kin plus kin-vfs pairing from kin-vfs v0.2.0 onward is broken, not only main-to-main.**

## Store map

| Route | Hash source | Body store | Before | After |
|---|---|---|---|---|
| `/vfs/tree` | repository-v6 authority workspace tree | sizes via `backend.source_blob_len` on repository authority CAS | 200 | 200, unchanged |
| `/vfs/read/{*path}` | tree artifact for that path | `authority.manager.load_source_blob(digest)` | 200 | 200, unchanged |
| `/vfs/blob/{hash}` | client-supplied content address | no route | **404, empty body** | `authority.manager.load_source_blob(digest)` |

The new route reads the **same** store as `/vfs/read`, which is the same store the tree's hashes and sizes come from. One authority, one hash space, no second store introduced.

## The fix

`vfs_blob` parses the address with `Hash256::from_hex`, opens the same one-lease `ActiveApiRepositoryAuthority` every other VFS route opens, and reads `manager.load_source_blob(digest)`. That manager call bounds the read and re-verifies the digest of the returned bytes before they leave it, so the response is provably the content named by the address. The response carries `Content-Type: application/octet-stream` and `X-Kin-Blob-Hash`, matching `/vfs/read`.

The whole body is always returned and `Range` is ignored. A client verifies the body against the hash the tree advertised, which a partial response cannot satisfy. Verified against the consumer: kin-vfs `read_range` fetches the whole blob through `fetch_verified_blob`, verifies it, and slices locally. It never sends a `Range` header here.

### Fail-closed and typed

Every failure returns a typed JSON body carrying `error`, `hash`, `authority: "repository_v6"`, and a `detail`, following the existing `filesystem_ingest_disabled_response` pattern in this file. No path reads the working copy or a Git object database.

| Condition | Status | `error` |
|---|---|---|
| address is not a sha256 | 400 | `malformed_content_address`, store never consulted |
| authority unavailable | 424 | existing `repository-v6 authority unavailable` |
| CAS read or digest verification fails | 424 | `repository_cas_read_failed` |
| repository owns no body at that address | 404 | `graph_blob_missing` |

404 is deliberate for the genuine gap. It is the status the shim already reads as a graph gap, so that message becomes accurate rather than a misreading of a routing 404, and the typed body distinguishes the two for any other observer.

## Tests, falsified against base

1. `vfs_blob_serves_every_content_address_the_tree_advertises` commits a file through the real repository authority, `GET /vfs/tree`, deserializes the wire `WorkspaceTreeSnapshot`, takes `entry.blob_identity()`, formats the URL, and `GET /vfs/blob/<hash>`. This is the identical round trip the shim performs. On base it fails: the tree advertises `6dc6785ed72375b18c83ed7354d7a4b62df4ebe75b35bae4dac78cc2e280d471` for `src/probe.rs`, then the blob read returns `left: 404, right: 200`.
2. `vfs_blob_names_the_graph_gap_for_an_unowned_content_address` asserts the typed 404. On base it fails with `EOF while parsing a value, line 1, column 0`, which is positive proof the base 404 body is empty, that is, a routing 404 rather than a handler response.
3. `vfs_blob_rejects_a_content_address_that_is_not_a_sha256` covers a non-hex address, a short one, and a 66-character one. On base all three return 404 instead of 400.

## Coordination with the ingest-CAS work

FIR-1654's hydration fix would neither have masked nor fixed this. That ticket is about `state.blobs`, the daemon's ingest CAS, a derived cache hydrated from authority and consumed by `rebuild_projection` and `refresh_projection`. None of `/vfs/tree`, `/vfs/read`, or the new `/vfs/blob` touches `state.blobs` at all; they go through `ActiveApiRepositoryAuthority::manager`. Hydrating the ingest CAS on the cloud open path changes nothing about whether a route exists. The two land coherently in either order with no shared file region, since FIR-1654's fix is in `state.rs` and the `kin-daemon.rs` shutdown paths.

FIR-1639 is a kin-vfs-side stale-binding defect and is orthogonal, but worth noting for sequencing: this defect blocked the kin-vfs smoke end to end, so FIR-1639 could not be validated against a real daemon until this lands.

Closes FIR-1642
