### PR TITLE
Gate test daemon reuse on build identity, not snapshot version alone

### DIFF
--- a/crates/kin-cli/tests/common/mod.rs
+++ b/crates/kin-cli/tests/common/mod.rs
@@ -159,27 +159,109 @@ fn read_capture(mut file: std::fs::File) -> std::io::Result<Vec<u8>> {
     Ok(bytes)
 }
 
-fn daemon_compat_ok(path: &Path) -> bool {
+/// The build identity this test binary carries, in the exact form the daemon
+/// stamps persisted vector sidecars with.
+///
+/// A test that seeds prepared state writes this stamp; the daemon that later
+/// reopens the repository demands its own. The two only agree when both
+/// binaries came out of one build of `kin-buildinfo`.
+pub fn expected_build_stamp() -> String {
+    kin_buildinfo::sha_with_dirty(kin_buildinfo::get())
+}
+
+/// Recompose a `--compat-json` `build.sha` / `build.dirty` pair into the stamp
+/// `kin_buildinfo::sha_with_dirty` would produce for the same build.
+///
+/// The daemon reports the two fields separately, so the harness has to join
+/// them the way the authority does rather than comparing the pair directly:
+/// when the commit is unknown the dirty flag is not part of the identity, and
+/// a raw pair comparison would reject a daemon whose embedder identity
+/// actually matches.
+fn build_stamp(sha: &str, dirty: bool) -> String {
+    if dirty && sha != "unknown" {
+        format!("{sha}-dirty")
+    } else {
+        sha.to_string()
+    }
+}
+
+/// Why a candidate `kin-daemon` may not be reused by this test binary, or
+/// `None` when it may be.
+///
+/// Two independent reasons, and the second is the one that used to be missed.
+/// A daemon whose graph snapshot version differs cannot read the repository at
+/// all. A daemon that is merely built from a *different commit or working
+/// tree* reads it fine, but stamps and demands a different embedder identity —
+/// so a sidecar seeded by this test binary is rejected on load,
+/// `indexed_embedding_count` reads 0, and the suite reports a product defect
+/// that only exists because two binaries in one target directory were built at
+/// different times.
+pub fn daemon_compat_mismatch(
+    payload: &Value,
+    expected_snapshot_version: u64,
+    expected_stamp: &str,
+) -> Option<String> {
+    match payload["graph_snapshot_version"].as_u64() {
+        Some(version) if version == expected_snapshot_version => {}
+        Some(version) => {
+            return Some(format!(
+                "graph snapshot version {version} does not match this test binary's {expected_snapshot_version}"
+            ));
+        }
+        None => return Some("compat payload has no graph_snapshot_version".to_string()),
+    }
+
+    let Some(sha) = payload["build"]["sha"].as_str() else {
+        return Some("compat payload has no build.sha".to_string());
+    };
+    let Some(dirty) = payload["build"]["dirty"].as_bool() else {
+        return Some("compat payload has no build.dirty".to_string());
+    };
+
+    let daemon_stamp = build_stamp(sha, dirty);
+    if daemon_stamp != expected_stamp {
+        return Some(format!(
+            "daemon build identity {daemon_stamp} does not match this test binary's {expected_stamp}"
+        ));
+    }
+    None
+}
+
+fn daemon_compat(path: &Path) -> Result<(), String> {
     if !path.exists() {
-        return false;
+        return Err(format!("{} does not exist", path.display()));
     }
-    let Ok(output) = Command::new(path).arg("--compat-json").output() else {
-        return false;
-    };
+    let output = Command::new(path)
+        .arg("--compat-json")
+        .output()
+        .map_err(|error| format!("could not run {} --compat-json: {error}", path.display()))?;
     if !output.status.success() {
-        return false;
+        return Err(format!(
+            "{} --compat-json exited with {}",
+            path.display(),
+            output.status
+        ));
     }
-    let Ok(payload) = serde_json::from_slice::<Value>(&output.stdout) else {
-        return false;
-    };
-    payload["graph_snapshot_version"].as_u64()
-        == Some(kin_db::GraphSnapshot::CURRENT_VERSION as u64)
+    let payload = serde_json::from_slice::<Value>(&output.stdout).map_err(|error| {
+        format!(
+            "{} --compat-json did not emit JSON: {error}",
+            path.display()
+        )
+    })?;
+    match daemon_compat_mismatch(
+        &payload,
+        kin_db::GraphSnapshot::CURRENT_VERSION as u64,
+        &expected_build_stamp(),
+    ) {
+        Some(reason) => Err(reason),
+        None => Ok(()),
+    }
 }
 
 pub fn fresh_daemon_bin() -> PathBuf {
     let kin_bin = PathBuf::from(env!("CARGO_BIN_EXE_kin"));
     let daemon_bin = kin_bin.with_file_name("kin-daemon");
-    if daemon_compat_ok(&daemon_bin) {
+    if daemon_compat(&daemon_bin).is_ok() {
         return daemon_bin;
     }
 
@@ -203,10 +285,18 @@ pub fn fresh_daemon_bin() -> PathBuf {
         );
     });
 
-    assert!(
-        daemon_compat_ok(&daemon_bin),
-        "kin-daemon at {} is missing or incompatible after rebuild",
-        daemon_bin.display()
-    );
+    if let Err(reason) = daemon_compat(&daemon_bin) {
+        panic!(
+            "kin-daemon at {} is unusable after rebuild: {reason}.\n\
+             This test binary carries build identity {}. A daemon built from a \
+             different commit or working tree stamps persisted vector sidecars \
+             with a different embedder identity, so state this suite seeds is \
+             rejected on reopen and indexed_embedding_count reads 0 — a harness \
+             fault that reads as a product defect. Build both from one tree: \
+             cargo build --all-targets",
+            daemon_bin.display(),
+            expected_build_stamp()
+        );
+    }
     daemon_bin
 }

--- a/crates/kin-cli/tests/daemon_compat_gate.rs
+++ b/crates/kin-cli/tests/daemon_compat_gate.rs
@@ -1,0 +1,108 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Firelock, LLC
+
+//! The reuse decision behind `common::fresh_daemon_bin`.
+//!
+//! A daemon that is version-compatible but built from a different tree is the
+//! failure this gate exists for: it serves the repository correctly and then
+//! rejects every vector sidecar the test binary seeded, because the two stamp
+//! different embedder identities. The suite then reports zero indexed
+//! embeddings as a product defect. These cases pin the comparison so that
+//! skew is caught and named instead.
+
+use serde_json::json;
+
+mod common;
+
+use common::{daemon_compat_mismatch, expected_build_stamp};
+
+const VERSION: u64 = 9;
+const SHA: &str = "1111111111111111111111111111111111111111";
+const OTHER_SHA: &str = "2222222222222222222222222222222222222222";
+
+fn payload(sha: &str, dirty: bool, version: u64) -> serde_json::Value {
+    json!({
+        "schema": "kin.daemon.compat.v1",
+        "graph_snapshot_version": version,
+        "build": { "sha": sha, "dirty": dirty },
+    })
+}
+
+#[test]
+fn matching_version_and_build_identity_is_reusable() {
+    assert_eq!(
+        daemon_compat_mismatch(&payload(SHA, false, VERSION), VERSION, SHA),
+        None
+    );
+}
+
+#[test]
+fn snapshot_version_skew_is_still_caught() {
+    let reason = daemon_compat_mismatch(&payload(SHA, false, VERSION + 1), VERSION, SHA)
+        .expect("a daemon on another snapshot version must not be reused");
+    assert!(
+        reason.contains(&(VERSION + 1).to_string()) && reason.contains(&VERSION.to_string()),
+        "reason must name both versions, got {reason}"
+    );
+}
+
+#[test]
+fn build_identity_skew_names_both_stamps() {
+    let reason = daemon_compat_mismatch(&payload(OTHER_SHA, false, VERSION), VERSION, SHA)
+        .expect("a daemon built from another commit must not be reused");
+    assert!(
+        reason.contains(OTHER_SHA) && reason.contains(SHA),
+        "reason must name the daemon stamp and the test binary stamp, got {reason}"
+    );
+}
+
+#[test]
+fn dirty_flag_skew_is_a_mismatch() {
+    let reason = daemon_compat_mismatch(&payload(SHA, true, VERSION), VERSION, SHA)
+        .expect("a dirty daemon must not be reused by a clean test binary");
+    assert!(
+        reason.contains(&format!("{SHA}-dirty")),
+        "reason must name the dirty stamp, got {reason}"
+    );
+}
+
+/// With no commit id there is no identity to skew, and `sha_with_dirty` drops
+/// the dirty flag. Comparing the raw pair instead of the joined stamp would
+/// reject a daemon whose embedder identity actually matches, and no rebuild
+/// would ever clear it.
+#[test]
+fn unknown_commit_ignores_the_dirty_flag() {
+    assert_eq!(
+        daemon_compat_mismatch(&payload("unknown", true, VERSION), VERSION, "unknown"),
+        None
+    );
+}
+
+#[test]
+fn a_compat_payload_without_build_identity_is_not_reusable() {
+    let payload = json!({ "graph_snapshot_version": VERSION });
+    let reason = daemon_compat_mismatch(&payload, VERSION, SHA)
+        .expect("a daemon that reports no build identity must not be reused");
+    assert!(
+        reason.contains("build.sha"),
+        "reason must name the missing field, got {reason}"
+    );
+}
+
+/// Pins the harness's `build.sha` + `build.dirty` join against
+/// `kin_buildinfo::sha_with_dirty`, which is what the daemon actually stamps
+/// sidecars with. If that rule changes and this join does not, every daemon
+/// would look skewed and no rebuild would clear it.
+#[test]
+fn the_joined_stamp_agrees_with_kin_buildinfo() {
+    let info = kin_buildinfo::get();
+    assert_eq!(
+        daemon_compat_mismatch(
+            &payload(info.sha, info.dirty, VERSION),
+            VERSION,
+            &expected_build_stamp()
+        ),
+        None,
+        "this binary's own build identity must read as reusable"
+    );
+}


### PR DESCRIPTION
## Summary

`crates/kin-cli/tests/common/mod.rs` validated a candidate `kin-daemon` by `graph_snapshot_version` only. A daemon left over from an earlier build passes that check while carrying a different `kin-buildinfo` stamp, and that stamp is the embedder identity the daemon writes into and demands from persisted vector sidecars (`kin-daemon/src/state.rs:1262`). Prepared state a test seeds is then rejected on reopen, `indexed_embedding_count` reads 0, and the suite reports a product defect that exists only because two binaries in one target directory were built at different times.

`--compat-json` already emits `build.sha` and `build.dirty`. This compares them against the test binary's own `kin_buildinfo::sha_with_dirty`, keeping the version check ahead of it. A mismatch stops the reuse so the existing rebuild runs; a mismatch that survives the rebuild fails naming both stamps and the remedy (`cargo build --all-targets`).

The two fields are joined the way `sha_with_dirty` joins them rather than compared as a raw pair. With no commit id the dirty flag is not part of the identity, so a pair comparison would reject a daemon whose embedder identity actually matches and that no rebuild could ever clear.

## Verification

Skew forced with the `KIN_BUILD_*_OVERRIDE` build inputs, daemon stamped `00000000000000000000000000000000deadbeef` against a test binary at `e73ce4b1...-dirty`, both on `graph_snapshot_version` 12.

| case | result |
| --- | --- |
| pre-fix, skewed daemon | **accepted in 0.04s** (the defect) |
| post-fix, matched pair | accepted in 0.04s, no rebuild |
| post-fix, skew a rebuild can heal | rejected, rebuilt (56.7s), daemon returns at the matching stamp |
| post-fix, skew a rebuild cannot heal | fails loud naming both stamps and `cargo build --all-targets` |

Seven unit tests in `tests/daemon_compat_gate.rs` cover the comparison, including a drift pin asserting the harness's join still agrees with `kin_buildinfo::sha_with_dirty`.

`cargo fmt --all --check` clean. `cargo clippy -p kin-cli --all-targets --all-features` clean under `RUSTFLAGS=-D warnings` with the ci.yml allowlist.

The daemon-backed `prepared_state_json` suite was not run: lane `corpus-prep` holds the `daemon` lock (FIR-1560). The gate fires in `fresh_daemon_bin()` before any daemon spawns, so it was verified without that runtime.

Closes FIR-1607