### PR TITLE
Report MCP graph status from the fields the daemon emits and traverse neighborhoods in both directions

### DIFF
--- a/crates/kin-mcp/src/daemon_delegate.rs
+++ b/crates/kin-mcp/src/daemon_delegate.rs
@@ -1023,11 +1023,12 @@ pub async fn forward_tool_call(
                 .map(text_result_from_value)
                 .transpose()
         }
-        // Coverage exposure: surface embedding-index coverage to MCP agents.
-        // The generic graph tool dispatcher only knows entity_count; the
-        // daemon's status command computes embedding coverage from the live
-        // graph (`graph.embedding_status()`), so forward there and project the
-        // fields MCP agents need. Self-contained — no daemon-api coordination.
+        // Coverage exposure: surface graph and embedding-index coverage to MCP
+        // agents. The generic graph tool dispatcher only knows entity_count.
+        // The two counts live on two different daemon surfaces: enrichment
+        // counts on the status command's authority lease, embedding coverage on
+        // the resources command's live `graph.embedding_status()`. Forward to
+        // both and project the fields MCP agents need.
         "kin_graph_status" => forward_graph_status(arguments).await,
         // Stage-time validation in product mode: reject intrinsically-malformed
         // staged operations locally before the daemon round-trip, so the agent
@@ -1061,54 +1062,215 @@ fn validate_stage_arguments(arguments: &HashMap<String, serde_json::Value>) -> R
     crate::session::validate_staged_operations(&operations)
 }
 
-/// Forward `kin_graph_status` to the daemon's status command and project the
-/// graph/embedding coverage fields agents care about.
+/// Forward `kin_graph_status` to the daemon surfaces that actually carry the
+/// counts and project them.
 ///
-/// In product mode coverage is otherwise CLI-only (`kin status`); this gives
-/// MCP agents the same embedding-index visibility without leaving graph-owned
-/// truth — the daemon computes the counts from its live graph.
+/// Two round-trips because the two halves of the answer have two owners:
+/// `/commands/status` renders the repository-v6 authority lease (enrichment
+/// counts), and `/commands/resources` attaches the daemon's live
+/// `graph.embedding_status()` (embedding coverage). Status carries no embedding
+/// field at all, so a single call cannot answer both halves.
+///
+/// The embedding half degrades rather than failing the whole call: an agent
+/// reaching for a readiness check still gets the graph counts when the resource
+/// surface is unavailable, and gets an explicit unavailable marker instead of a
+/// fabricated zero.
 async fn forward_graph_status(
     arguments: &HashMap<String, serde_json::Value>,
 ) -> Result<Option<ToolCallResult>, String> {
     let Some(base) = daemon_base_url() else {
         return Ok(None);
     };
-    let value = daemon_json_request("graph status", &base, |client, base| {
+    let status = daemon_json_request("graph status", &base, |client, base| {
         let request = client
             .post(format!("{base}/commands/status"))
             .json(&serde_json::json!({ "json": false }));
         with_session_header(with_auth(request), arguments)
     })
     .await?;
-    text_result_from_value(project_graph_status(&value)?).map(Some)
+    let resources =
+        daemon_json_request("graph status embedding coverage", &base, |client, base| {
+            let request = client
+                .post(format!("{base}/commands/resources"))
+                .json(&serde_json::json!({ "json": false }));
+            with_session_header(with_auth(request), arguments)
+        })
+        .await;
+    text_result_from_value(project_graph_status(&status, resources.as_ref())?).map(Some)
 }
 
-/// Project the daemon's status response into the coverage fields MCP agents
-/// need.
+/// Read a `u64` at `object[key]`, naming the miss instead of defaulting.
 ///
-/// Rejects an empty body loudly. The shared request helper reads one as `Null`
-/// so the mutations that answer `204 No Content` work, but every count here
-/// falls back to 0, so letting `Null` through would render a missing answer as
-/// a real reading of an empty graph. A status surface that reports zeros it did
-/// not measure is worse than one that fails.
-fn project_graph_status(value: &serde_json::Value) -> Result<serde_json::Value, String> {
-    if value.is_null() {
+/// Every count in this projection is load-bearing: a default would render an
+/// unread field as a measurement. `path` names the full location so a drifted
+/// producer is diagnosable from the error alone.
+fn required_u64(object: &serde_json::Value, key: &str, path: &str) -> Result<u64, String> {
+    object
+        .get(key)
+        .ok_or_else(|| format!("daemon graph status response carries no `{path}`"))?
+        .as_u64()
+        .ok_or_else(|| format!("daemon graph status field `{path}` is not a number"))
+}
+
+/// Project the daemon's status and resources responses into the coverage fields
+/// MCP agents need.
+///
+/// Every field is read from the exact path its producer writes and every miss
+/// is an error. The previous projection read `summary.entities` and
+/// `summary.embeddings_*`, keys no daemon surface has ever emitted, and floored
+/// each miss to 0 — so the tool reported a fully enriched repository as an empty
+/// graph while stamping the answer with daemon authority. A status surface that
+/// reports zeros it did not measure is worse than one that fails, which is why
+/// an absent key now fails loud and cannot be mistaken for a real reading.
+///
+/// `status` is `kin_cli::commands::status::CommandStatusResponse` and
+/// `resources` is `kin_cli::commands::resources::CommandResourcesResponse`.
+/// kin-mcp cannot depend on kin-cli to name those types directly (kin-cli
+/// depends on this crate), so the strictness above is what holds the two shapes
+/// together: drift surfaces as a named error on the next call rather than as a
+/// silent zero.
+fn project_graph_status(
+    status: &serde_json::Value,
+    resources: Result<&serde_json::Value, &String>,
+) -> Result<serde_json::Value, String> {
+    if status.is_null() {
         return Err(
             "daemon graph status returned an empty body; refusing to report zero counts as \
              graph truth"
                 .to_string(),
         );
     }
-    let summary = value.get("summary").unwrap_or(value);
-    let field_u64 = |key: &str| summary.get(key).and_then(serde_json::Value::as_u64);
-    Ok(serde_json::json!({
-        "entity_count": field_u64("entities").unwrap_or(0),
-        "embeddings_indexed": field_u64("embeddings_indexed").unwrap_or(0),
-        "embeddings_total": field_u64("embeddings_total").unwrap_or(0),
-        "embeddings_pending": field_u64("embeddings_pending").unwrap_or(0),
+    let report = status
+        .get("report")
+        .ok_or_else(|| "daemon graph status response carries no `report`".to_string())?;
+    let enrichment = report.get("semantic_enrichment").ok_or_else(|| {
+        "daemon graph status response carries no `report.semantic_enrichment`".to_string()
+    })?;
+
+    let entity_count = required_u64(
+        enrichment,
+        "entity_count",
+        "report.semantic_enrichment.entity_count",
+    )?;
+    let relation_count = required_u64(
+        enrichment,
+        "relation_count",
+        "report.semantic_enrichment.relation_count",
+    )?;
+    let semantic_change_count = required_u64(
+        enrichment,
+        "semantic_change_count",
+        "report.semantic_enrichment.semantic_change_count",
+    )?;
+    let presence = enrichment
+        .get("presence")
+        .and_then(serde_json::Value::as_str)
+        .ok_or_else(|| {
+            "daemon graph status response carries no `report.semantic_enrichment.presence`"
+                .to_string()
+        })?;
+    // Repository-v6 has no completion attestation yet: counts are exact and
+    // completeness is deliberately not inferred from them. Carrying the flag
+    // keeps an agent from reading a populated graph as a complete one.
+    let completion_attested = enrichment
+        .get("completion_attested")
+        .and_then(serde_json::Value::as_bool)
+        .ok_or_else(|| {
+            "daemon graph status response carries no \
+             `report.semantic_enrichment.completion_attested`"
+                .to_string()
+        })?;
+
+    let mut projected = serde_json::json!({
+        "entity_count": entity_count,
+        "relation_count": relation_count,
+        "semantic_change_count": semantic_change_count,
+        "enrichment_presence": presence,
+        "completion_attested": completion_attested,
         "authority": "repo-daemon",
-        "note": "Embedding coverage is computed from the daemon-owned live graph."
-    }))
+        "note": "Enrichment counts come from the daemon-owned repository-v6 authority lease; \
+                 embedding coverage from the daemon's live graph. Counts are exact; \
+                 enrichment completeness is not attested.",
+    });
+
+    // Embedding coverage is a separate measurement on a separate surface. When
+    // it cannot be read, the numeric fields are omitted entirely rather than
+    // zeroed: an absent field makes an agent look, where a 0 reads as a real
+    // count of an unembedded graph.
+    let embedding = match resources {
+        Ok(resources) => project_embedding_coverage(resources),
+        Err(error) => Err(error.clone()),
+    };
+    let object = projected
+        .as_object_mut()
+        .expect("projected status is a JSON object");
+    match embedding {
+        Ok(coverage) => {
+            object.insert("embeddings_available".into(), serde_json::json!(true));
+            for (key, value) in coverage {
+                object.insert(key, value);
+            }
+        }
+        Err(reason) => {
+            object.insert("embeddings_available".into(), serde_json::json!(false));
+            object.insert(
+                "embeddings_unavailable_reason".into(),
+                serde_json::json!(reason),
+            );
+        }
+    }
+    Ok(projected)
+}
+
+/// Project the embedding half from `/commands/resources`.
+///
+/// `embeddings_total` is read, never derived: `InMemoryGraph::embedding_status`
+/// computes `pending = queue_len.max(total - indexed)`, so total is not indexed
+/// plus pending and reconstructing it would invent a number.
+fn project_embedding_coverage(
+    resources: &serde_json::Value,
+) -> Result<serde_json::Map<String, serde_json::Value>, String> {
+    if resources.is_null() {
+        return Err("daemon resources returned an empty body".to_string());
+    }
+    let runtime = resources
+        .get("embed_runtime")
+        .ok_or_else(|| "daemon resources response carries no `embed_runtime`".to_string())?;
+    let indexed = required_u64(
+        runtime,
+        "embeddings_indexed",
+        "embed_runtime.embeddings_indexed",
+    )?;
+    let pending = required_u64(
+        runtime,
+        "embeddings_pending",
+        "embed_runtime.embeddings_pending",
+    )?;
+    let total = required_u64(
+        runtime,
+        "embeddings_total",
+        "embed_runtime.embeddings_total",
+    )?;
+    let mut coverage = serde_json::Map::new();
+    coverage.insert("embeddings_indexed".into(), serde_json::json!(indexed));
+    coverage.insert("embeddings_pending".into(), serde_json::json!(pending));
+    coverage.insert("embeddings_total".into(), serde_json::json!(total));
+    // Embed-degraded state decides whether a pending count is still draining or
+    // is stuck forever; a readiness check that omits it can wait on a worker
+    // that already died.
+    if let Some(failed) = runtime
+        .get("embed_worker_failed")
+        .and_then(serde_json::Value::as_bool)
+    {
+        coverage.insert("embed_worker_failed".into(), serde_json::json!(failed));
+    }
+    if let Some(busy) = runtime
+        .get("embedding_work_busy")
+        .and_then(serde_json::Value::as_bool)
+    {
+        coverage.insert("embedding_work_busy".into(), serde_json::json!(busy));
+    }
+    Ok(coverage)
 }
 
 pub fn daemon_unavailable_tool_result(name: &str) -> ToolCallResult {
@@ -1533,29 +1695,177 @@ mod tests {
         handle.abort();
     }
 
+    /// A `POST /commands/status` body as the daemon really renders it:
+    /// `kin_cli::commands::status::CommandStatusResponse`, whose fields are
+    /// `report`, `build`, `text` and `json`, with the enrichment counts nested
+    /// under `report.semantic_enrichment`. Non-zero throughout so a projection
+    /// that silently defaults cannot pass.
+    fn daemon_status_body() -> serde_json::Value {
+        serde_json::json!({
+            "report": {
+                "schema": "kin.status.v1",
+                "authority": "repository-v6",
+                "repo_root": "/tmp/repo",
+                "repository": {
+                    "repository_id": "01930000-0000-7000-8000-000000000001",
+                    "generation": 4,
+                    "roots": { "generation": 4 },
+                    "ref_count": 2,
+                    "source_cas_verified": true
+                },
+                "workspace": {
+                    "workspace_id": "01930000-0000-7000-8000-000000000002",
+                    "generation": 4,
+                    "head": { "symbolic": { "target": "main" } },
+                    "tree_hash": "00",
+                    "dirty": false,
+                    "artifact_count": 11
+                },
+                "semantic_enrichment": {
+                    "presence": "present",
+                    "entity_count": 42,
+                    "relation_count": 17,
+                    "semantic_change_count": 3,
+                    "completion_attested": false
+                }
+            },
+            "build": null,
+            "text": "Kin repository-v6 status\n",
+            "json": null
+        })
+    }
+
+    /// A `POST /commands/resources` body as the daemon really renders it:
+    /// `kin_cli::commands::resources::CommandResourcesResponse`, with live
+    /// embedding state under `embed_runtime`.
+    fn daemon_resources_body() -> serde_json::Value {
+        serde_json::json!({
+            "plan": { "schema_version": "kin.resource_plan.v1" },
+            "embed_runtime": {
+                "embed_worker_failed": false,
+                "embedding_work_busy": true,
+                "embeddings_indexed": 7,
+                "embeddings_pending": 3,
+                "embeddings_total": 10,
+                "hybrid_metrics": {},
+                "metal_profile": null
+            },
+            "actual": {},
+            "text": "",
+            "json": null
+        })
+    }
+
     /// The empty-body allowance exists for the 204 mutations. It must not reach
-    /// the status projection, where every count defaults to 0 and an absent
-    /// answer would render as a genuine reading of an empty graph.
+    /// the status projection, where an absent answer would render as a genuine
+    /// reading of an empty graph.
     #[test]
     fn graph_status_refuses_to_report_an_empty_body_as_zero_counts() {
-        let err = project_graph_status(&serde_json::Value::Null)
+        let resources = daemon_resources_body();
+        let err = project_graph_status(&serde_json::Value::Null, Ok(&resources))
             .expect_err("an empty status body must fail loudly");
         assert!(err.contains("empty body"), "{err}");
         assert!(err.contains("refusing"), "{err}");
     }
 
+    /// The wiring test: every count is projected from the shape the daemon
+    /// really produces, and every one of them is non-zero, so a projection that
+    /// missed its key and floored to 0 fails here instead of shipping.
     #[test]
-    fn graph_status_projects_summary_counts() {
-        let value = serde_json::json!({
+    fn graph_status_projects_the_real_daemon_bodies() {
+        let status = daemon_status_body();
+        let resources = daemon_resources_body();
+        let projected =
+            project_graph_status(&status, Ok(&resources)).expect("a real body must project");
+        assert_eq!(projected["entity_count"], 42);
+        assert_eq!(projected["relation_count"], 17);
+        assert_eq!(projected["semantic_change_count"], 3);
+        assert_eq!(projected["enrichment_presence"], "present");
+        assert_eq!(projected["completion_attested"], false);
+        assert_eq!(projected["embeddings_available"], true);
+        assert_eq!(projected["embeddings_indexed"], 7);
+        assert_eq!(projected["embeddings_pending"], 3);
+        assert_eq!(projected["embeddings_total"], 10);
+        assert_eq!(projected["embed_worker_failed"], false);
+        assert_eq!(projected["embedding_work_busy"], true);
+        assert_eq!(projected["authority"], "repo-daemon");
+    }
+
+    /// The regression this projection exists to prevent: the shape the old
+    /// projector was written against is not a shape any daemon surface emits,
+    /// and feeding it must now fail loudly rather than answer four zeros
+    /// stamped with daemon authority.
+    #[test]
+    fn graph_status_rejects_the_shape_the_old_projector_assumed() {
+        let legacy = serde_json::json!({
             "summary": { "entities": 42, "embeddings_indexed": 7, "embeddings_total": 10 }
         });
-        let projected = project_graph_status(&value).expect("a real body must project");
+        let resources = daemon_resources_body();
+        let err = project_graph_status(&legacy, Ok(&resources))
+            .expect_err("the invented `summary` shape must not project");
+        assert!(err.contains("`report`"), "{err}");
+    }
+
+    /// Key drift inside an otherwise well-formed body names the exact path that
+    /// went missing, so the next producer change is diagnosable from the tool
+    /// output alone.
+    #[test]
+    fn graph_status_names_the_field_that_drifted() {
+        let mut status = daemon_status_body();
+        status["report"]["semantic_enrichment"]
+            .as_object_mut()
+            .unwrap()
+            .remove("entity_count");
+        let resources = daemon_resources_body();
+        let err = project_graph_status(&status, Ok(&resources))
+            .expect_err("a missing count must fail loudly");
+        assert!(
+            err.contains("report.semantic_enrichment.entity_count"),
+            "{err}"
+        );
+    }
+
+    /// The embedding half is a separate measurement on a separate surface. When
+    /// it is unavailable the graph counts still answer, and the numeric fields
+    /// are absent rather than zero — an agent must not read "not measured" as
+    /// "measured zero".
+    #[test]
+    fn graph_status_marks_embedding_coverage_unavailable_without_faking_zeros() {
+        let status = daemon_status_body();
+        let error = "daemon resources failed: HTTP 503".to_string();
+        let projected =
+            project_graph_status(&status, Err(&error)).expect("graph counts must still answer");
         assert_eq!(projected["entity_count"], 42);
-        assert_eq!(projected["embeddings_indexed"], 7);
-        assert_eq!(projected["embeddings_total"], 10);
-        // Absent within a present body is still 0: that is a real reading.
-        assert_eq!(projected["embeddings_pending"], 0);
-        assert_eq!(projected["authority"], "repo-daemon");
+        assert_eq!(projected["embeddings_available"], false);
+        assert!(projected["embeddings_unavailable_reason"]
+            .as_str()
+            .expect("a reason must be carried")
+            .contains("503"));
+        assert!(
+            projected.get("embeddings_indexed").is_none(),
+            "an unmeasured count must be absent, not zero: {projected}"
+        );
+        assert!(
+            projected.get("embeddings_total").is_none(),
+            "an unmeasured count must be absent, not zero: {projected}"
+        );
+    }
+
+    /// A resources body whose embedding block drifted degrades the embedding
+    /// half only; it must not fabricate coverage or take down the graph counts.
+    #[test]
+    fn graph_status_degrades_when_the_embedding_block_drifts() {
+        let status = daemon_status_body();
+        let resources = serde_json::json!({ "plan": {}, "text": "", "json": null });
+        let projected =
+            project_graph_status(&status, Ok(&resources)).expect("graph counts must still answer");
+        assert_eq!(projected["entity_count"], 42);
+        assert_eq!(projected["embeddings_available"], false);
+        assert!(projected["embeddings_unavailable_reason"]
+            .as_str()
+            .expect("a reason must be carried")
+            .contains("embed_runtime"));
+        assert!(projected.get("embeddings_indexed").is_none());
     }
 
     /// An HTTP error from a live daemon must classify as `DaemonError`, never

--- a/crates/kin-mcp/src/handlers/entities.rs
+++ b/crates/kin-mcp/src/handlers/entities.rs
@@ -2345,84 +2345,186 @@ Get the dependency neighborhood of an entity — both what it depends on and wha
 on it — as a compact graph. Starting from an entity ID, Kin traverses the semantic \
 relations (calls, imports, implements, …) out to the depth you specify and returns the \
 reachable entities as lightweight summaries (id, name, kind, file, signature) plus the \
-edges connecting them, along with total counts and a truncation flag. Reach for it when \
-you want the structural shape around a symbol — its blast radius and its supports — \
-rather than full source bodies: impact-scoping a change, understanding coupling, or \
-mapping how a module hangs together. It returns summaries rather than code precisely so \
-the neighborhood stays within token budgets even at depth; when you then want to read a \
+edges connecting them, along with total counts and a truncation flag. Traversal follows \
+edges in both directions by default: direction='out' walks only what the focal depends \
+on, 'in' walks only what depends on the focal (its dependents — this is the blast-radius \
+direction), and 'both' merges them. Every returned edge carries the direction it was \
+traversed in, so dependencies and dependents are never conflated. Reach for it when you \
+want the structural shape around a symbol — its blast radius and its supports — rather \
+than full source bodies: impact-scoping a change, understanding coupling, or mapping how \
+a module hangs together. It returns summaries rather than code precisely so the \
+neighborhood stays within token budgets even at depth; when you then want to read a \
 specific neighbor's implementation, follow up with get_entity_source, and when you want \
 a directional ordered chain with bodies inlined, use trace_data_flow. \
 When no neighbors come back, the additive `negative` object's `safe_to_conclude_absent` \
 flag says whether \"isolated, no dependencies\" is authoritative or merely \"not indexed yet\".";
 
+/// Traverse the neighborhood around a focal entity in the requested direction.
+///
+/// Walks the relation table with [`GraphStore::get_all_relations_for_entity`],
+/// which returns an entity's outgoing *and* incoming edges from two separate
+/// adjacency indexes at the same cost. This deliberately does not use
+/// `get_dependency_neighborhood`: that traversal is fed only the outgoing index,
+/// so it returns what the focal depends on and never what depends on it. This
+/// tool has always described itself as answering both, which meant an agent
+/// asking for blast radius was handed the focal's dependencies and told they
+/// were its dependents — the one error a caller cannot detect from the output.
+/// Direction is now traversed as described and tagged per edge.
 pub fn handle_graph_neighborhood<G: GraphStore>(
     args: &HashMap<String, serde_json::Value>,
     store: &G,
 ) -> Result<ToolCallResult> {
+    // Bidirectional traversal widens the frontier: a hot callee's incoming edge
+    // set is unbounded in a way its outgoing set is not, so the walk is capped
+    // and reports the cap through `truncated` rather than returning a partial
+    // neighborhood that looks complete.
+    const MAX_VISITED_ENTITIES: usize = 2_000;
+
     let id_str = get_string_param(args, "entity_id")?;
     let entity_id = parse_entity_id(&id_str)?;
     let depth = get_optional_u64(args, "depth", 2) as u32;
     let limit = get_optional_u64(args, "limit", 30) as usize;
+    let direction = match get_optional_string_param(args, "direction") {
+        Some(value) => match value.trim().to_lowercase().as_str() {
+            "out" | "outgoing" | "dependencies" | "depends_on" | "calls" => "out",
+            "in" | "incoming" | "dependents" | "callers" | "impact" => "in",
+            "both" | "all" | "" => "both",
+            other => {
+                return Err(McpError::InvalidParams(format!(
+                    "invalid direction '{other}': expected out, in, or both"
+                )));
+            }
+        },
+        None => "both",
+    };
+    let want_outgoing = matches!(direction, "out" | "both");
+    let want_incoming = matches!(direction, "in" | "both");
 
-    let neighborhood = store
-        .get_dependency_neighborhood(&entity_id, depth)
-        .map_err(McpError::graph)?;
+    let mut visited: std::collections::HashSet<kin_model::ids::EntityId> =
+        std::collections::HashSet::new();
+    let mut entities: Vec<serde_json::Value> = Vec::new();
+    let mut relations: Vec<serde_json::Value> = Vec::new();
+    let mut seen_relations: std::collections::HashSet<kin_model::ids::RelationId> =
+        std::collections::HashSet::new();
+    let mut truncated = false;
 
-    let total_entities = neighborhood.entities.len();
-    let total_relations = neighborhood.relations.len();
+    // The focal itself is part of its own neighborhood, matching what the
+    // previous traversal returned so counts stay comparable across the change.
+    if let Some(focal) = store.get_entity(&entity_id).map_err(McpError::graph)? {
+        visited.insert(entity_id);
+        entities.push(compact_entity_summary(&focal));
+    }
+
+    let mut frontier: Vec<(kin_model::ids::EntityId, u32)> = vec![(entity_id, 0)];
+    while !frontier.is_empty() && !truncated {
+        let mut next_frontier: Vec<(kin_model::ids::EntityId, u32)> = Vec::new();
+        for (current, current_depth) in frontier.drain(..) {
+            if current_depth >= depth {
+                continue;
+            }
+            let edges = store
+                .get_all_relations_for_entity(&current)
+                .map_err(McpError::graph)?;
+            for rel in &edges {
+                let src_entity = rel.src.as_entity();
+                let dst_entity = rel.dst.as_entity();
+                // Classify by which endpoint is the node being expanded, so the
+                // tag names the direction actually traversed rather than a
+                // direction assumed from the focal.
+                let (neighbor, edge_direction) = if want_outgoing
+                    && src_entity == Some(current)
+                    && dst_entity.is_some_and(|id| id != current)
+                {
+                    (dst_entity.unwrap(), "outgoing")
+                } else if want_incoming
+                    && dst_entity == Some(current)
+                    && src_entity.is_some_and(|id| id != current)
+                {
+                    (src_entity.unwrap(), "incoming")
+                } else {
+                    continue;
+                };
+
+                // An edge is reachable from both endpoints; emit it once.
+                if seen_relations.insert(rel.id) {
+                    relations.push(serde_json::json!({
+                        "src": rel.src,
+                        "dst": rel.dst,
+                        "kind": format!("{:?}", rel.kind),
+                        "direction": edge_direction,
+                        "from": current.to_string(),
+                    }));
+                }
+
+                if !visited.insert(neighbor) {
+                    continue;
+                }
+                if visited.len() > MAX_VISITED_ENTITIES {
+                    truncated = true;
+                    break;
+                }
+                if let Some(entity) = store.get_entity(&neighbor).map_err(McpError::graph)? {
+                    entities.push(compact_entity_summary(&entity));
+                }
+                next_frontier.push((neighbor, current_depth + 1));
+            }
+            if truncated {
+                break;
+            }
+        }
+        frontier = next_frontier;
+    }
+
+    let total_entities = entities.len();
+    let total_relations = relations.len();
 
     // Return compact entity summaries (name, kind, file, id) instead of full
     // entity objects to keep response sizes bounded.
-    let compact_entities: Vec<_> = neighborhood
-        .entities
-        .values()
-        .take(limit)
-        .map(|e| {
-            serde_json::json!({
-                "id": e.id,
-                "name": e.name,
-                "kind": format!("{:?}", e.kind),
-                "file_path": e.file_origin.as_ref().map(|p| p.to_string()),
-                "signature": e.signature,
-            })
-        })
-        .collect();
-
+    entities.truncate(limit);
     // Cap relations to match the entity limit to avoid unbounded output.
-    let compact_relations: Vec<_> = neighborhood
-        .relations
-        .iter()
-        .take(limit * 3)
-        .map(|r| {
-            serde_json::json!({
-                "src": r.src,
-                "dst": r.dst,
-                "kind": format!("{:?}", r.kind),
-            })
-        })
-        .collect();
+    relations.truncate(limit * 3);
 
     let result = serde_json::json!({
+        "focal_id": entity_id.to_string(),
+        "direction": direction,
+        "depth": depth,
         "entity_count": total_entities,
         "relation_count": total_relations,
-        "truncated": total_entities > limit,
-        "entities": compact_entities,
-        "relations": compact_relations,
+        "truncated": truncated || total_entities > limit,
+        "entities": entities,
+        "relations": relations,
     });
 
     let json = serde_json::to_string_pretty(&result).map_err(McpError::Json)?;
     Ok(ToolCallResult::text(json))
 }
 
+/// The lightweight per-entity row the neighborhood returns in place of a full
+/// entity object, so a deep walk stays within an agent's token budget.
+fn compact_entity_summary(entity: &kin_model::Entity) -> serde_json::Value {
+    serde_json::json!({
+        "id": entity.id,
+        "name": entity.name,
+        "kind": format!("{:?}", entity.kind),
+        "file_path": entity.file_origin.as_ref().map(|p| p.to_string()),
+        "signature": entity.signature,
+    })
+}
+
 pub const GRAPH_STATUS_DESC: &str = "\
-Report the status of the semantic graph that MCP is serving from — the live entity \
-count, embedding-index coverage (embeddings_indexed / embeddings_total / \
-embeddings_pending), and the authority backing it. In product mode this is answered by \
-the repo daemon, so it reflects the daemon-owned, live graph state rather than a stale \
-MCP-local snapshot. Reach for it as a quick health/readiness check: confirm the graph \
-is populated, check how much of it has embeddings indexed (so you know whether \
-semantic_locate / vector retrieval will be complete or still warming up), and verify \
-you're talking to graph-owned truth before relying on the other tools.";
+Report the status of the semantic graph that MCP is serving from — the live entity, \
+relation and semantic-change counts, embedding-index coverage (embeddings_indexed / \
+embeddings_total / embeddings_pending), and the authority backing it. In product mode \
+this is answered by the repo daemon, so it reflects the daemon-owned, live graph state \
+rather than a stale MCP-local snapshot. Reach for it as a quick health/readiness check: \
+confirm the graph is populated, check how much of it has embeddings indexed (so you know \
+whether semantic_locate / vector retrieval will be complete or still warming up), and \
+verify you're talking to graph-owned truth before relying on the other tools. \
+Counts are exact but enrichment completeness is not attested (completion_attested), so a \
+populated graph is not by itself a complete one. Embedding coverage is measured on a \
+separate daemon surface: when it cannot be read, embeddings_available is false and the \
+numeric embedding fields are absent rather than zero — absent means not measured, never \
+measured-as-empty.";
 
 /// Report the health of the graph visible to this dispatcher.
 ///
@@ -2439,6 +2541,12 @@ pub fn handle_graph_status<G: GraphStore>(
     let result = serde_json::json!({
         "entity_count": entity_count,
         "authority": "repo-daemon",
+        // Embedding coverage is computed by the daemon from its live graph and
+        // is not reachable from a bare `GraphStore`. Marked unavailable rather
+        // than omitted silently, so this path cannot be read as a measurement
+        // of an unembedded graph.
+        "embeddings_available": false,
+        "embeddings_unavailable_reason": "in-process dispatch has no daemon embedding surface",
         "note": "Product MCP calls are served by the repo daemon. Offline in-process dispatch is test-only."
     });
 
@@ -3348,5 +3456,244 @@ mod tests {
         args.insert("granularity".to_string(), serde_json::json!("module"));
         let err = handle_semantic_locate(&args, &store).unwrap_err();
         assert!(matches!(err, McpError::InvalidParams(_)));
+    }
+
+    /// `caller -> focal -> callee`: the focal has exactly one dependent and one
+    /// dependency, on opposite sides of the relation table.
+    fn neighborhood_fixture() -> (InMemoryGraph, EntityId, EntityId, EntityId) {
+        let store = InMemoryGraph::new();
+        let caller = make_entity("caller", "src/caller.rs");
+        let focal = make_entity("focal", "src/focal.rs");
+        let callee = make_entity("callee", "src/callee.rs");
+        let (caller_id, focal_id, callee_id) = (caller.id, focal.id, callee.id);
+        store.upsert_entity(&caller).unwrap();
+        store.upsert_entity(&focal).unwrap();
+        store.upsert_entity(&callee).unwrap();
+        store
+            .upsert_relation(&make_relation(caller_id, focal_id, RelationKind::Calls))
+            .unwrap();
+        store
+            .upsert_relation(&make_relation(focal_id, callee_id, RelationKind::Calls))
+            .unwrap();
+        (store, caller_id, focal_id, callee_id)
+    }
+
+    fn neighborhood_names(response: &serde_json::Value) -> Vec<String> {
+        let mut names: Vec<String> = response["entities"]
+            .as_array()
+            .expect("entities must be an array")
+            .iter()
+            .map(|e| {
+                e["name"]
+                    .as_str()
+                    .expect("name must be a string")
+                    .to_string()
+            })
+            .collect();
+        names.sort();
+        names
+    }
+
+    fn neighborhood_response_in(
+        store: &InMemoryGraph,
+        focal: EntityId,
+        direction: Option<&str>,
+    ) -> serde_json::Value {
+        let mut args = HashMap::new();
+        args.insert(
+            "entity_id".to_string(),
+            serde_json::json!(focal.to_string()),
+        );
+        if let Some(direction) = direction {
+            args.insert("direction".to_string(), serde_json::json!(direction));
+        }
+        parsed_response(&handle_graph_neighborhood(&args, store).unwrap())
+    }
+
+    /// The FIR-1595 regression. The tool has always described itself as
+    /// returning "both what it depends on and what depends on it", but traversed
+    /// the outgoing index alone, so `caller` — the only entity whose behavior a
+    /// change to `focal` can break — was never in the answer. An agent asking
+    /// this tool for blast radius got the focal's dependencies instead, with
+    /// nothing in the output to reveal the substitution.
+    #[test]
+    fn graph_neighborhood_returns_dependents_not_only_dependencies() {
+        let (store, _, focal_id, _) = neighborhood_fixture();
+        let response = neighborhood_response_in(&store, focal_id, None);
+        assert_eq!(response["direction"], "both");
+        assert_eq!(
+            neighborhood_names(&response),
+            vec!["callee", "caller", "focal"],
+            "the default neighborhood must carry the dependent as well as the dependency"
+        );
+        assert_eq!(response["entity_count"], 3);
+        assert_eq!(response["relation_count"], 2);
+        assert_eq!(response["truncated"], false);
+    }
+
+    /// Direction is not just a filter on a merged walk: asking for dependents
+    /// alone must return the dependent alone.
+    #[test]
+    fn graph_neighborhood_direction_in_returns_only_dependents() {
+        let (store, caller_id, focal_id, _) = neighborhood_fixture();
+        let response = neighborhood_response_in(&store, focal_id, Some("in"));
+        assert_eq!(response["direction"], "in");
+        assert_eq!(neighborhood_names(&response), vec!["caller", "focal"]);
+        let edges = response["relations"].as_array().unwrap();
+        assert_eq!(edges.len(), 1);
+        assert_eq!(edges[0]["direction"], "incoming");
+        assert_eq!(edges[0]["src"]["Entity"], serde_json::json!(caller_id));
+        assert_eq!(edges[0]["dst"]["Entity"], serde_json::json!(focal_id));
+    }
+
+    /// The previous behavior stays reachable by name, so a caller that really
+    /// wants dependencies can ask for them and know that is what it got.
+    #[test]
+    fn graph_neighborhood_direction_out_returns_only_dependencies() {
+        let (store, _, focal_id, callee_id) = neighborhood_fixture();
+        let response = neighborhood_response_in(&store, focal_id, Some("out"));
+        assert_eq!(response["direction"], "out");
+        assert_eq!(neighborhood_names(&response), vec!["callee", "focal"]);
+        let edges = response["relations"].as_array().unwrap();
+        assert_eq!(edges.len(), 1);
+        assert_eq!(edges[0]["direction"], "outgoing");
+        assert_eq!(edges[0]["dst"]["Entity"], serde_json::json!(callee_id));
+    }
+
+    /// Direction aliases exist because agents phrase this as "callers" or
+    /// "dependents" far more often than as "in".
+    #[test]
+    fn graph_neighborhood_accepts_direction_aliases() {
+        let (store, _, focal_id, _) = neighborhood_fixture();
+        for alias in ["in", "incoming", "dependents", "callers", "impact"] {
+            let response = neighborhood_response_in(&store, focal_id, Some(alias));
+            assert_eq!(response["direction"], "in", "alias {alias} must map to in");
+        }
+        for alias in ["out", "outgoing", "dependencies", "depends_on", "calls"] {
+            let response = neighborhood_response_in(&store, focal_id, Some(alias));
+            assert_eq!(
+                response["direction"], "out",
+                "alias {alias} must map to out"
+            );
+        }
+    }
+
+    #[test]
+    fn graph_neighborhood_rejects_an_unknown_direction() {
+        let (store, _, focal_id, _) = neighborhood_fixture();
+        let mut args = HashMap::new();
+        args.insert(
+            "entity_id".to_string(),
+            serde_json::json!(focal_id.to_string()),
+        );
+        args.insert("direction".to_string(), serde_json::json!("sideways"));
+        let err = handle_graph_neighborhood(&args, &store).unwrap_err();
+        assert!(matches!(err, McpError::InvalidParams(_)), "{err:?}");
+    }
+
+    /// Depth must walk dependents transitively, not just one hop back: the
+    /// grandparent of a focal is inside its blast radius at depth 2.
+    #[test]
+    fn graph_neighborhood_walks_dependents_transitively() {
+        let (store, caller_id, focal_id, _) = neighborhood_fixture();
+        let grandparent = make_entity("grandparent", "src/grandparent.rs");
+        let grandparent_id = grandparent.id;
+        store.upsert_entity(&grandparent).unwrap();
+        store
+            .upsert_relation(&make_relation(
+                grandparent_id,
+                caller_id,
+                RelationKind::Calls,
+            ))
+            .unwrap();
+
+        let mut args = HashMap::new();
+        args.insert(
+            "entity_id".to_string(),
+            serde_json::json!(focal_id.to_string()),
+        );
+        args.insert("direction".to_string(), serde_json::json!("in"));
+        args.insert("depth".to_string(), serde_json::json!(2));
+        let response = parsed_response(&handle_graph_neighborhood(&args, &store).unwrap());
+        assert_eq!(
+            neighborhood_names(&response),
+            vec!["caller", "focal", "grandparent"]
+        );
+    }
+
+    /// An edge reachable from both of its endpoints is still one edge. Walking
+    /// both directions must not double-count the relation table.
+    #[test]
+    fn graph_neighborhood_emits_each_edge_once() {
+        let (store, _, focal_id, callee_id) = neighborhood_fixture();
+        // focal -> callee and callee -> focal: a cycle whose single pair of
+        // edges is reachable from either side in `both` mode.
+        store
+            .upsert_relation(&make_relation(callee_id, focal_id, RelationKind::Calls))
+            .unwrap();
+        let response = neighborhood_response_in(&store, focal_id, Some("both"));
+        let edges = response["relations"].as_array().unwrap();
+        let mut ids: Vec<String> = edges
+            .iter()
+            .map(|e| format!("{}->{}", e["src"], e["dst"]))
+            .collect();
+        ids.sort();
+        let unique: std::collections::HashSet<&String> = ids.iter().collect();
+        assert_eq!(
+            unique.len(),
+            ids.len(),
+            "each relation must appear once: {ids:?}"
+        );
+    }
+
+    /// A focal with no edges at all still reports itself, and reports honestly
+    /// that nothing else is there.
+    #[test]
+    fn graph_neighborhood_on_an_isolated_entity_reports_only_the_focal() {
+        let store = InMemoryGraph::new();
+        let lonely = make_entity("lonely", "src/lonely.rs");
+        let lonely_id = lonely.id;
+        store.upsert_entity(&lonely).unwrap();
+        let response = neighborhood_response_in(&store, lonely_id, None);
+        assert_eq!(neighborhood_names(&response), vec!["lonely"]);
+        assert_eq!(response["relation_count"], 0);
+        assert_eq!(response["truncated"], false);
+    }
+
+    /// The declared tool schema must offer the parameter the handler honors,
+    /// and the description must claim the direction the traversal delivers.
+    #[test]
+    fn graph_neighborhood_schema_and_description_match_the_behavior() {
+        let tools = crate::tools::tool_definitions();
+        let tool = tools
+            .tools
+            .iter()
+            .find(|t| t.name == "graph_neighborhood")
+            .expect("graph_neighborhood must be registered");
+        assert!(
+            tool.input_schema["properties"]["direction"].is_object(),
+            "the direction parameter must be declared: {}",
+            tool.input_schema
+        );
+        assert!(
+            tool.description.contains("both directions"),
+            "the description must state that traversal is bidirectional"
+        );
+    }
+
+    /// Nothing in this crate may quietly go back to the outgoing-only
+    /// traversal: `get_dependency_neighborhood` is fed only the outgoing index
+    /// in kin-db, which is what made this tool answer dependencies when it was
+    /// asked for dependents.
+    #[test]
+    fn graph_neighborhood_does_not_use_the_outgoing_only_traversal() {
+        // Split so this guard's own source line is not a match for itself.
+        let needle = concat!(".get_dependency_", "neighborhood(");
+        let source = include_str!("entities.rs");
+        let call_site = source.lines().find(|line| line.contains(needle));
+        assert!(
+            call_site.is_none(),
+            "outgoing-only neighborhood traversal reintroduced: {call_site:?}"
+        );
     }
 }

--- a/crates/kin-mcp/src/tools.rs
+++ b/crates/kin-mcp/src/tools.rs
@@ -457,7 +457,8 @@ pub fn tool_definitions() -> ToolsListResult {
                     "properties": {
                         "entity_id": { "type": "string", "description": "Entity UUID" },
                         "depth": { "type": "integer", "description": "Traversal depth", "default": 2 },
-                        "limit": { "type": "integer", "description": "Max entities to return (default 30)", "default": 30 }
+                        "limit": { "type": "integer", "description": "Max entities to return (default 30)", "default": 30 },
+                        "direction": { "type": "string", "description": "Direction of traversal: 'out' walks what the focal depends on, 'in' walks what depends on the focal (dependents / blast radius), 'both' merges. Default 'both'.", "default": "both" }
                     },
                     "required": ["entity_id"]
                 }),

--- a/docs/mcp-tools.md
+++ b/docs/mcp-tools.md
@@ -50,7 +50,7 @@ can run `kin mcp start` with the same `agent-default` profile), see
 - **`get_entity_source` / `get_entity_body`**: Retrieve the implementation source of an entity, served from the graph.
 - **`get_context_pack`**: Package a target entity alongside its caller/import neighborhood into a single prompt-friendly bundle.
 - **`explore_codebase`**: Get a one-shot map of the codebase via a selectable strategy (e.g. `overview`: entity counts by kind and language, plus the top public declarations).
-- **`graph_neighborhood`**: Return the dependency neighborhood of an entity — what it depends on and what depends on it — traversed to a given depth.
+- **`graph_neighborhood`**: Return the dependency neighborhood of an entity — what it depends on and what depends on it — traversed to a given depth. `direction` selects which side to walk: `out` for dependencies, `in` for dependents (blast radius), `both` (default) for the merged neighborhood; every returned edge is tagged with the direction it was traversed in.
 
 ---
 


### PR DESCRIPTION
Two agent-facing MCP surfaces answered confidently with something other than what they measured. Both now match their descriptions, and both fail loud rather than fabricating a number.

## kin_graph_status always answered zero

`project_graph_status` read `summary.entities` and `summary.embeddings_*`. `POST /commands/status` returns `kin_cli::commands::status::CommandStatusResponse`, whose fields are `report`, `build`, `text` and `json`. There is no `summary` key, no `entities` key, and no embedding key anywhere in it, so `summary` fell back to the whole body, all four lookups missed, and all four fell through to `unwrap_or(0)`. Every repository reported `entity_count: 0` and zero embedding coverage, including fully enriched and fully embedded ones, stamped `"authority": "repo-daemon"` with a note claiming the counts came from the daemon-owned live graph.

- Enrichment counts now read from `report.semantic_enrichment` (`entity_count`, `relation_count`, `semantic_change_count`, `presence`, `completion_attested`).
- Embedding coverage now reads from `POST /commands/resources` (`embed_runtime.embeddings_indexed/pending/total`), which is where the daemon attaches live `graph.embedding_status()`. Status carries no embedding field at all, so one call cannot answer both halves. `embeddings_total` is read, never derived, because `pending = queue_len.max(total - indexed)` means total is not indexed plus pending.
- Every field is required. A missing key returns an error naming its exact path instead of defaulting, so producer drift is diagnosable from the tool output.
- The embedding half degrades instead of failing the whole readiness check. When it cannot be read, `embeddings_available` is false, a reason is carried, and the numeric fields are **absent rather than zero**, so absence cannot be misread as a measurement of an unembedded graph.

The old test fed the projector a hand-written `{"summary": {...}}`, a shape no daemon surface produces, so it proved the projector and not the wiring and stayed green while the tool answered zero. Tests now build the bodies the daemon really returns, with every count non-zero so a projection that missed its key and floored to 0 fails instead of shipping. There is also an explicit regression test that the old invented shape is now rejected.

kin-mcp cannot depend on kin-cli to name those response types directly (kin-cli depends on kin-mcp, verified in its `Cargo.toml`), so strictness is what holds the two shapes together.

## graph_neighborhood traversed one direction while describing two

The tool described itself as returning "both what it depends on and what depends on it" but called `get_dependency_neighborhood`, which kin-db feeds only the outgoing adjacency index. An agent asking this tool for blast radius received the focal's dependencies presented as its dependents, with nothing in the output to reveal the substitution.

This is fixed as genuine bidirectional traversal rather than a description walkback. `GraphStore::get_all_relations_for_entity` already returns an entity's outgoing **and** incoming edges from two separate adjacency indexes at the same cost, and `trace_data_flow` in this crate already walks it bidirectionally. The neighborhood now does the same:

- Walks both directions by default and tags every returned edge with the direction it was actually traversed in, plus the node it was expanded from, so dependencies and dependents are never conflated.
- Adds a `direction` parameter (`out` / `in` / `both`, default `both`) with the aliases agents actually use (`dependents`, `callers`, `impact`, `dependencies`, …). The previous outgoing-only behavior stays reachable by name as `out`.
- Deduplicates edges reachable from both endpoints, and caps the walk, because a hot callee's incoming edge set is unbounded in a way its outgoing set is not. The cap reports through `truncated` rather than returning a partial neighborhood that looks complete.
- A guard test fails if `get_dependency_neighborhood` is ever reintroduced in this crate.

The tool schema, `GRAPH_NEIGHBORHOOD_DESC`, and `docs/mcp-tools.md` all now state the behavior that ships. A test asserts the declared schema offers the parameter the handler honors and that the description claims the direction the traversal delivers.

## Verification

- `cargo test -p kin-mcp` — 264 passed, 0 failed.
- `cargo fmt --all -- --check` — clean.
- `cargo clippy -p kin-mcp --all-targets --all-features` under `RUSTFLAGS=-Dwarnings` with the ci.yml allowlist — clean.
- `cargo check -p kin-daemon --all-targets` — clean (the daemon routes `/mcp/tools/call` into `kin_mcp::handlers::handle_tool_call`, so the neighborhood fix reaches real agents through the product path).

No capability fixtures were touched. No other crate references either surface: `kin_graph_status` appears outside kin-mcp only in one daemon session-lease test that asserts `StatusCode::OK`, and `graph_neighborhood` only as a name in a kin-core doc table.

Closes FIR-1658

Part of FIR-1595. The direction defect that ticket leads with is fixed here and behavior now matches the description. It is not closed because it bundles a second, unrelated finding: Kin's user-facing line numbers are 0-indexed where every editor, grep, and GitHub is 1-indexed, a systematic -1 across impact/find_references that needs a presentation-layer decision across many tools. Closing the ticket on this PR would drop that.

FIR-1659 was in this lane's brief and is not here. It is not a kin-mcp defect. The surface is `kin graph validate` in `crates/kin-cli/src/commands/graph.rs`, and the fix is premised on the counted-note form that PR #483 introduces, which is still open and rewrites those same kin-cli files. Doing it here would have crossed a lane boundary into an open PR's diff.