### PR TITLE
Order context-pack candidates by a total order before budget admission

### DIFF
--- a/crates/kin-context/src/builder.rs
+++ b/crates/kin-context/src/builder.rs
@@ -445,7 +445,11 @@ where
                         )
                 })
                 .collect::<Vec<_>>();
-            entities.sort_by_key(|entity| same_file_neighbor_rank(&focal, entity));
+            // Same total-order requirement as the weight sort below: the rank is
+            // three coarse buckets, so neighbours tie routinely, and only the
+            // first six survive. Ranking on entity id last keeps the survivors
+            // from depending on the order `query_entities` happened to return.
+            entities.sort_by_key(|entity| (same_file_neighbor_rank(&focal, entity), entity.id));
             entities
         } else {
             Vec::new()
@@ -465,6 +469,16 @@ where
     // Sort subgraph entities by descending relation weight so that when the
     // token budget is tight, high-signal entities (Calls, DependsOn) are
     // included before low-signal ones (References, Contains).
+    //
+    // Entity id breaks weight ties into a total order. `subgraph.entities` is a
+    // hash map, so the collected order varies between invocations; relation
+    // weight comes from a small set of per-kind constants, so equal weights are
+    // the common case rather than an edge case. Ordering on weight alone would
+    // leave tied candidates in hash order, and the budget fold below admits
+    // greedily in this order, so the surviving set would differ run to run for
+    // an unchanged graph. `total_cmp` keeps the comparator total even if a
+    // weight is ever NaN, which would otherwise collapse to `Equal` and
+    // reintroduce the same nondeterminism through a broken ordering.
     let mut sorted_entities: Vec<(&EntityId, &Entity)> = subgraph
         .entities
         .iter()
@@ -473,7 +487,7 @@ where
     sorted_entities.sort_by(|(a_id, _), (b_id, _)| {
         let wa = weight_map.get(a_id).copied().unwrap_or(0.0);
         let wb = weight_map.get(b_id).copied().unwrap_or(0.0);
-        wb.partial_cmp(&wa).unwrap_or(std::cmp::Ordering::Equal)
+        wb.total_cmp(&wa).then_with(|| a_id.cmp(b_id))
     });
 
     let mut dep_entries = Vec::new();
@@ -680,12 +694,17 @@ where
     }
 
     append_supporting_artifacts(graph, &mut pack, &supporting_files, budget_max)?;
+    // Dedup in encounter order rather than through a set. `supporting_artifacts`
+    // is already ordered by file path, and `append_artifact_scoped_metadata`
+    // admits the work items and annotations it finds under the same token
+    // budget, so draining a hash set here would let arbitrary iteration order
+    // decide which metadata survives a tight budget.
+    let mut seen_supporting_files = std::collections::HashSet::new();
     let supporting_files: Vec<FilePathId> = pack
         .supporting_artifacts
         .iter()
         .map(|entry| entry.file_path.clone())
-        .collect::<std::collections::HashSet<_>>()
-        .into_iter()
+        .filter(|path| seen_supporting_files.insert(path.clone()))
         .collect();
     if !supporting_files.is_empty() {
         append_artifact_scoped_metadata(graph, &mut pack, &supporting_files, budget_max)?;
@@ -1257,6 +1276,106 @@ mod tests {
             admitted(&b),
             "parallel context-pack assembly must admit a stable set"
         );
+    }
+
+    #[test]
+    fn tight_budget_truncation_is_deterministic_across_invocations() {
+        use kin_model::relation::{Relation, RelationKind, RelationOrigin};
+
+        // Equal-weight (all `Calls`) candidates with fixed-width names, so every
+        // projection costs the same tokens and relation weight alone cannot order
+        // them. Which candidates survive a tight budget is then decided purely by
+        // the tie-break, which is exactly what must not vary between runs.
+        let n = PARALLEL_ASSEMBLY_MIN_ENTITIES + 24;
+        let focal = make_entity("focal", EntityKind::Function);
+        let deps: Vec<Entity> = (0..n)
+            .map(|i| make_entity(&format!("dep_{i:04}"), EntityKind::Function))
+            .collect();
+
+        // Two stores holding the same entity ids, populated in opposite orders.
+        // A correct builder owes both the same answer; an order-sensitive one
+        // does not. Insertion order also perturbs the graph's own hash layout.
+        let store_of = |reverse: bool| {
+            let store = kin_db::InMemoryGraph::new();
+            store.upsert_entity(&focal).unwrap();
+            let ordered: Vec<&Entity> = if reverse {
+                deps.iter().rev().collect()
+            } else {
+                deps.iter().collect()
+            };
+            for dep in ordered {
+                store.upsert_entity(dep).unwrap();
+                store
+                    .upsert_relation(&Relation {
+                        id: kin_model::ids::RelationId::new(),
+                        kind: RelationKind::Calls,
+                        src: GraphNodeId::Entity(focal.id),
+                        dst: GraphNodeId::Entity(dep.id),
+                        confidence: 1.0,
+                        origin: RelationOrigin::Parsed,
+                        created_in: None,
+                        import_source: None,
+                        evidence: Vec::new(),
+                    })
+                    .unwrap();
+            }
+            store
+        };
+
+        let forward = store_of(false);
+        let reverse = store_of(true);
+
+        let admitted = |p: &ContextPack| {
+            let mut ids: Vec<_> = p
+                .dependency_signatures
+                .iter()
+                .map(|e| e.entity_id)
+                .collect();
+            ids.sort();
+            ids
+        };
+
+        // Size the budget off an unconstrained pack so the cut lands mid-list
+        // regardless of how projection costs change later.
+        let full = build_context_pack(
+            &forward,
+            &focal.id,
+            &ContextOptions {
+                budget: TokenBudget::Large32k,
+                ..ContextOptions::default()
+            },
+        )
+        .unwrap();
+        let opts = ContextOptions {
+            budget: TokenBudget::Custom(full.actual_tokens / 2),
+            ..ContextOptions::default()
+        };
+
+        let baseline = build_context_pack(&forward, &focal.id, &opts).unwrap();
+        let kept = baseline.dependency_signatures.len();
+        assert!(
+            kept > 0 && kept < full.dependency_signatures.len(),
+            "budget must actually truncate for this test to mean anything: kept {kept} of {}",
+            full.dependency_signatures.len()
+        );
+
+        // Repeated invocations rebuild the neighborhood subgraph, and each rebuild
+        // gets a freshly seeded hash map, so an order-sensitive selection diverges
+        // here without needing separate processes.
+        for run in 1..16 {
+            let again = build_context_pack(&forward, &focal.id, &opts).unwrap();
+            assert_eq!(
+                admitted(&again),
+                admitted(&baseline),
+                "invocation {run} admitted a different set under the same budget"
+            );
+            let mirrored = build_context_pack(&reverse, &focal.id, &opts).unwrap();
+            assert_eq!(
+                admitted(&mirrored),
+                admitted(&baseline),
+                "invocation {run} admitted a different set when the graph was populated in reverse"
+            );
+        }
     }
 
     fn make_artifact_work_item(title: &str, file_path: &FilePathId) -> WorkItem {


### PR DESCRIPTION
Context-pack entity selection was nondeterministic under a tight token budget: the same repository state could yield a different surviving set on every invocation.

## Root cause

`build_context_pack` collected subgraph entities out of `SubGraph.entities`, a `HashMap`, and ordered them by relation weight alone. Relation weight comes from a small set of per-kind constants, so equal weights are the common case rather than an edge case, and tied candidates kept whatever order the hash map produced. The greedy budget fold then admitted candidates in that order, so which entities survived truncation varied run to run.

## Changes

All three sites are in `crates/kin-context/src/builder.rs`.

- The weight sort now compares `wb.total_cmp(&wa).then_with(|| a_id.cmp(b_id))`. Entity id makes the comparator a total order over distinct candidates, and `total_cmp` replaces `partial_cmp().unwrap_or(Equal)` so a NaN weight cannot collapse the comparison into a non-total ordering and reintroduce the same defect.
- The same-file neighbor fallback sorts on `(same_file_neighbor_rank(...), entity.id)`. The rank is three coarse buckets and only the first six neighbors are admitted, so ties were routine, and the surviving set depended on the order `query_entities` happened to return.
- The supporting-file list is deduped in encounter order over the already-path-sorted `supporting_artifacts` rather than by draining a `HashSet`. `append_artifact_scoped_metadata` admits work items and annotations under the same token budget through `push_work_item` and `push_annotation`, both of which drop entries once the budget is exhausted, so set iteration order was deciding which metadata survived.

The pre-sort iteration source is deliberately left as-is. `sort_by` is stable and the comparator is now a total order over distinct entity ids, so the resulting permutation is unique regardless of collect order; an additional id sort would be dead work in the context-pack path. The new test guards the invariant instead.

`query_entities` needed no change at intake. kin-db 0.6.4, the version this workspace resolves, already sorts results with an `a.id.cmp(&b.id)` total tie-break, and `InMemoryGraph` is that same implementation. The entity-id term added to the same-file sort also removes this crate's implicit dependence on that upstream guarantee.

## Test

`tight_budget_truncation_is_deterministic_across_invocations` builds the same pack repeatedly under a budget sized off an unconstrained pack so the cut lands mid-list, using equal-weight candidates with fixed-width names so projection cost cannot break the tie. It asserts truncation actually occurred, then asserts the admitted set is identical across repeated invocations and against a second graph populated in reverse insertion order.

The test was written before the fix and fails against the unfixed builder: two consecutive invocations in one process admitted different sets of 43 entities out of 88.

## Verification

`cargo fmt --all -- --check`, `cargo clippy --all-targets --all-features` under the ci.yml allowlist, `cargo build --all-targets`, and `cargo test --workspace` all pass. 3969 tests passed with zero failures.

Closes FIR-1518
Closes FIR-1546