### PR TITLE
Bound managed-config discovery to a declared scan root

### DIFF
--- a/crates/kin-cli/src/commands/health.rs
+++ b/crates/kin-cli/src/commands/health.rs
@@ -792,9 +792,7 @@ pub(crate) fn mcp_client_config_paths() -> Vec<(&'static str, &'static str, Path
 }
 
 fn current_health_repo() -> Option<PathBuf> {
-    let cwd = env::current_dir().ok()?;
-    let layout = kin_core::KinLayout::discover(&cwd)?;
-    Some(layout.working_dir().to_path_buf())
+    crate::commands::managed_config_scope::discover_repo_root()
 }
 
 /// Inspect a single MCP config file for a `kin` server entry carrying the

--- a/crates/kin-cli/src/commands/managed_config_scope.rs
+++ b/crates/kin-cli/src/commands/managed_config_scope.rs
@@ -1,0 +1,138 @@
+//! Scope boundary for managed-config repository discovery and IO.
+//!
+//! Every managed MCP client config except the checkout-local Antigravity
+//! workspace binding is addressed from the home directory, so the home
+//! directory alone bounds where those paths can land. The workspace binding is
+//! instead addressed from a discovered repository root, and repository
+//! discovery walks upward without a ceiling. A caller running below an
+//! unrelated repository therefore binds that repository, reads its
+//! `.agents/mcp_config.json`, and writes back into it.
+//!
+//! This module supplies the ceiling. `KIN_MCP_SCAN_ROOT` pins discovery to one
+//! directory and rejects any repository root found above it, and
+//! `KIN_MCP_FIXTURE_ROOT` turns an escape into an immediate panic instead of a
+//! silent write into the enclosing checkout.
+
+use std::path::{Path, PathBuf};
+
+/// Directory that bounds managed-config repository discovery.
+///
+/// Discovery starts here and never binds a repository above it.
+pub(crate) const SCAN_ROOT_ENV: &str = "KIN_MCP_SCAN_ROOT";
+
+/// Directory that bounds every managed-config path a test may touch.
+///
+/// Set only by tests. A managed path outside it aborts the test at the moment
+/// the path is resolved, rather than after it has written into a real checkout.
+pub(crate) const FIXTURE_ROOT_ENV: &str = "KIN_MCP_FIXTURE_ROOT";
+
+/// Resolve a directory to its canonical form, tolerating a path that does not
+/// exist yet by canonicalizing the nearest existing ancestor and re-appending
+/// the remainder. Containment is compared on canonical paths so a symlinked
+/// temp directory (`/var` to `/private/var` on macOS) still matches.
+fn canonical_dir(path: &Path) -> PathBuf {
+    if let Ok(resolved) = path.canonicalize() {
+        return resolved;
+    }
+    let mut suffix = Vec::new();
+    let mut current = path.to_path_buf();
+    while let Some(parent) = current.parent().map(Path::to_path_buf) {
+        let Some(name) = current.file_name().map(|name| name.to_os_string()) else {
+            break;
+        };
+        suffix.push(name);
+        if let Ok(resolved) = parent.canonicalize() {
+            let mut out = resolved;
+            for part in suffix.iter().rev() {
+                out.push(part);
+            }
+            return out;
+        }
+        current = parent;
+    }
+    path.to_path_buf()
+}
+
+fn env_dir(key: &str) -> Option<PathBuf> {
+    let raw = std::env::var_os(key)?;
+    if raw.is_empty() {
+        return None;
+    }
+    Some(canonical_dir(Path::new(&raw)))
+}
+
+/// True when `path` is `root` or lives beneath it.
+pub(crate) fn is_within(root: &Path, path: &Path) -> bool {
+    canonical_dir(path).starts_with(canonical_dir(root))
+}
+
+/// Directory managed-config repository discovery starts from.
+///
+/// An explicit scan root always wins. Without one, a test build discovers
+/// nothing at all: unit tests that expect a workspace binding declare the
+/// fixture they mean, and the rest can no longer reach whatever repository
+/// happens to enclose the test runner's working directory.
+fn scan_root() -> Option<PathBuf> {
+    if let Some(explicit) = env_dir(SCAN_ROOT_ENV) {
+        return Some(explicit);
+    }
+    if cfg!(test) {
+        return None;
+    }
+    std::env::current_dir().ok()
+}
+
+/// Repository root that owns the checkout-local managed config, bounded by the
+/// scan root so discovery can never bind an enclosing repository.
+pub(crate) fn discover_repo_root() -> Option<PathBuf> {
+    let start = scan_root()?;
+    let layout = kin_core::KinLayout::discover(&start)?;
+    let root = layout.working_dir().to_path_buf();
+    // `KinLayout::discover` walks upward, so a root outside the scan root is a
+    // repository that encloses it rather than the one the caller addressed.
+    if std::env::var_os(SCAN_ROOT_ENV).is_some() && !is_within(&start, &root) {
+        return None;
+    }
+    Some(root)
+}
+
+/// Abort immediately when a managed-config path escapes the declared fixture.
+///
+/// A test that would read or write outside its fixture has already lost its
+/// isolation; failing at path resolution names the offending path while the
+/// stack still shows which flow produced it.
+pub(crate) fn guard_managed_path(path: &Path) {
+    let Some(fixture) = env_dir(FIXTURE_ROOT_ENV) else {
+        return;
+    };
+    assert!(
+        is_within(&fixture, path),
+        "managed config path escaped its fixture: {} is outside {}",
+        canonical_dir(path).display(),
+        fixture.display()
+    );
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn within_matches_self_and_descendants() {
+        let dir = tempfile::tempdir().unwrap();
+        let root = dir.path();
+        assert!(is_within(root, root));
+        assert!(is_within(root, &root.join("a/b/c")));
+        assert!(!is_within(&root.join("a"), root));
+    }
+
+    #[test]
+    fn canonical_dir_resolves_through_missing_leaves() {
+        let dir = tempfile::tempdir().unwrap();
+        let missing = dir.path().join("absent/leaf.json");
+        assert_eq!(
+            canonical_dir(&missing),
+            dir.path().canonicalize().unwrap().join("absent/leaf.json")
+        );
+    }
+}

--- a/crates/kin-cli/src/commands/mod.rs
+++ b/crates/kin-cli/src/commands/mod.rs
@@ -40,6 +40,7 @@ pub mod locate_debug;
 pub mod locate_sizing;
 pub mod locate_telemetry;
 pub mod log;
+pub mod managed_config_scope;
 pub mod mcp;
 pub mod merge;
 pub mod migrate;

--- a/crates/kin-cli/src/commands/setup.rs
+++ b/crates/kin-cli/src/commands/setup.rs
@@ -1598,8 +1598,8 @@ fn configure_codex() -> Result<PathBuf> {
     let home = home_dir()?;
     let target = home.join(".codex").join("config.toml");
     let cwd = env::current_dir().context("could not determine the current directory")?;
-    let repo_root = kin_core::KinLayout::discover(&cwd)
-        .and_then(|layout| layout.working_dir().canonicalize().ok())
+    let repo_root = crate::commands::managed_config_scope::discover_repo_root()
+        .and_then(|root| root.canonicalize().ok())
         .with_context(|| {
             format!(
                 "Codex MCP setup requires an initialized Kin repository; run `kin init` in the target repository and re-run `kin setup` from it (current directory: {})",
@@ -1636,8 +1636,8 @@ fn configure_windsurf() -> Result<PathBuf> {
 
 fn current_initialized_setup_repo(client: &str) -> Result<PathBuf> {
     let cwd = env::current_dir().context("could not determine the current directory")?;
-    kin_core::KinLayout::discover(&cwd)
-        .and_then(|layout| layout.working_dir().canonicalize().ok())
+    crate::commands::managed_config_scope::discover_repo_root()
+        .and_then(|root| root.canonicalize().ok())
         .and_then(|root| canonical_initialized_repo(&root))
         .with_context(|| {
             format!(
@@ -8550,6 +8550,7 @@ impl ConfigLock {
     }
 
     fn plan_with_policy(path: &Path, private: bool) -> Result<ConfigLockPlan> {
+        crate::commands::managed_config_scope::guard_managed_path(path);
         #[cfg(unix)]
         let (path, parent) = Self::normalized_path_with_parent_authority(path)?;
         #[cfg(not(unix))]
@@ -15116,6 +15117,7 @@ expect_workspace "$TEST_ALIASED_SESSION_START" "$TEST_ALIASED_SESSION_PHYSICAL" 
         assert!(git.status.success());
         let _home = EnvGuard::set("HOME", &home);
         let _kin_home = EnvGuard::set("KIN_HOME", &kin_home);
+        let _scan_root = EnvGuard::set(crate::commands::managed_config_scope::SCAN_ROOT_ENV, &repo);
         let previous = env::current_dir().unwrap();
         env::set_current_dir(&repo).unwrap();
         let _cwd = CurrentDirGuard(previous);
@@ -15160,6 +15162,79 @@ expect_workspace "$TEST_ALIASED_SESSION_START" "$TEST_ALIASED_SESSION_PHYSICAL" 
         assert!(repaired.contains(&ConfigLock::normalized_path(&workspace).unwrap()));
         assert!(mcp_repair_targets_ledger_verified(&targets).unwrap());
         assert!(!kin_home.join("update-restart-ack-required.json").exists());
+    }
+
+    /// A repository enclosing the fixture is not the repository under test.
+    /// Discovery walks upward, so without a ceiling a test running below a real
+    /// checkout binds that checkout and captures its workspace MCP config.
+    #[cfg(unix)]
+    #[test]
+    #[serial]
+    fn enclosing_workspace_config_is_never_captured_from_a_scoped_fixture() {
+        struct CurrentDirGuard(PathBuf);
+        impl Drop for CurrentDirGuard {
+            fn drop(&mut self) {
+                let _ = env::set_current_dir(&self.0);
+            }
+        }
+
+        let dir = tempfile::tempdir().unwrap();
+        let outer = dir.path().join("enclosing-checkout");
+        let inner = outer.join("fixture");
+        let home = dir.path().join("home");
+        let kin_home = dir.path().join("kin-home");
+        fs::create_dir_all(outer.join(".kin")).unwrap();
+        fs::create_dir_all(outer.join(".agents")).unwrap();
+        fs::create_dir_all(&inner).unwrap();
+        fs::create_dir_all(&home).unwrap();
+        let decoy = outer.join(".agents").join("mcp_config.json");
+        let decoy_bytes =
+            br#"{"mcpServers":{"kin":{"command":"/enclosing/kin","args":["mcp","start"]}}}"#;
+        fs::write(&decoy, decoy_bytes).unwrap();
+
+        let _home = EnvGuard::set("HOME", &home);
+        let _kin_home = EnvGuard::set("KIN_HOME", &kin_home);
+        let _scan_root =
+            EnvGuard::set(crate::commands::managed_config_scope::SCAN_ROOT_ENV, &inner);
+        let previous = env::current_dir().unwrap();
+        env::set_current_dir(&inner).unwrap();
+        let _cwd = CurrentDirGuard(previous);
+
+        let canonical_decoy = decoy.canonicalize().unwrap();
+        let discovered = crate::commands::health::mcp_client_config_paths();
+        assert!(
+            !discovered.iter().any(|(_, _, path)| path
+                .canonicalize()
+                .is_ok_and(|path| path == canonical_decoy)),
+            "discovery reached the enclosing checkout: {discovered:?}"
+        );
+
+        let targets = current_mcp_repair_targets().unwrap();
+        assert!(
+            !targets.iter().any(|target| target.path == canonical_decoy
+                || target.repo_root.as_deref() == Some(outer.canonicalize().unwrap().as_path())),
+            "repair capture reached the enclosing checkout: {targets:?}"
+        );
+        assert_eq!(fs::read(&decoy).unwrap(), decoy_bytes);
+    }
+
+    /// The fixture guard must fail at the moment an escaping path is resolved,
+    /// so a leak is reported against the flow that produced it.
+    #[cfg(unix)]
+    #[test]
+    #[serial]
+    #[should_panic(expected = "managed config path escaped its fixture")]
+    fn managed_config_outside_the_declared_fixture_aborts_immediately() {
+        let dir = tempfile::tempdir().unwrap();
+        let fixture = dir.path().join("fixture");
+        let outside = dir.path().join("outside");
+        fs::create_dir_all(&fixture).unwrap();
+        fs::create_dir_all(&outside).unwrap();
+        let _fixture_root = EnvGuard::set(
+            crate::commands::managed_config_scope::FIXTURE_ROOT_ENV,
+            &fixture,
+        );
+        let _ = ConfigLock::acquire(&outside.join("mcp.json"));
     }
 
     #[test]


### PR DESCRIPTION
## Summary

`kin-cli` setup/update tests escaped their fixtures. Repository discovery for the checkout-local Antigravity workspace binding walked upward without a ceiling from the process working directory, so tests running below a real checkout bound that checkout, captured its `.agents/mcp_config.json`, and wrote back into it. A second run then met a repair marker whose bytes disagreed with the first.

Every other managed MCP client config is addressed from the home directory, which a fixture already redirects. `antigravity_workspace` was the one path resolved from ambient state instead (`current_health_repo` in `health.rs`, plus `current_initialized_setup_repo` and `configure_codex` in `setup.rs`).

## Changes

- **New `commands/managed_config_scope.rs`** is the single seam for managed-config repository discovery and IO scope. `KIN_MCP_SCAN_ROOT` pins discovery to one directory and rejects any repository root found above it, which is the ceiling the upward walk lacked. Without the variable a test build discovers nothing at all, so a test that means to bind a repository names its fixture instead of inheriting the ambient one.
- **Production resolution is unchanged.** With no scan root declared, discovery still starts at the working directory and applies no containment, so `kin setup` behaves exactly as before.
- **Fixture-escape guard.** `KIN_MCP_FIXTURE_ROOT` makes an escaping managed path panic at `ConfigLock::plan_with_policy`, the single chokepoint every managed config read and write passes through. The failure names the offending path while the stack still shows which flow produced it, rather than surfacing after a write has landed in a real checkout.
- **`antigravity_first_setup_captures_and_repairs_global_and_workspace_bindings`** now declares its fixture as the scan root. It previously relied on ambient discovery finding the enclosing checkout.

## Tests

- `enclosing_workspace_config_is_never_captured_from_a_scoped_fixture` plants a decoy `.agents/mcp_config.json` in a repository *enclosing* the fixture, sets cwd inside the fixture, and asserts the decoy is reached by neither `mcp_client_config_paths` nor `current_mcp_repair_targets`, and that its bytes are unchanged.
- `managed_config_outside_the_declared_fixture_aborts_immediately` proves the guard fires.
- Unit tests for containment and for canonicalizing through paths that do not exist yet.

## Verification

Falsification, on this branch with only `current_health_repo` reverted to ambient discovery:

```
test enclosing_workspace_config_is_never_captured_from_a_scoped_fixture ... FAILED
discovery reached the enclosing checkout: [... ("antigravity_workspace",
  "Google Antigravity workspace", ".../enclosing-checkout/.agents/mcp_config.json")]
```

Green with the fix restored.

Acceptance, run from a checkout with `.kin/` and a populated `.agents/mcp_config.json` planted:

```
pass 1: test result: ok. 913 passed; 0 failed  (160.24s)
pass 2: test result: ok. 913 passed; 0 failed  (127.61s)
```

After both passes the planted config was byte-identical and no lock sidecar had appeared beside it.

`cargo fmt --all --check` clean. `cargo clippy -p kin-cli --all-targets --all-features` clean under the ci.yml allowlist with `RUSTFLAGS=-Dwarnings`.

## Bounded waits, evaluated and not changed

The two 300s waits are one shared constant, `DEFAULT_TEST_SUBPROCESS_TIMEOUT` (`test_subprocess.rs:29`), and it is already the bounded-wait backstop rather than an incurred wait: workers poll at 10ms and normally finish in under a second, with 300s only as the abort ceiling. Its doc comment records that tightening it back toward observed runtime trades a class of hangs for a class of load-dependent false failures. `crash_recovery_worker` returns immediately unless re-executed as a worker. `claude_stub_launch` does not exist in this tree. No follow-up is needed.

Closes FIR-1577
Closes FIR-1562