### PR TITLE
Read impact hops from one walk and stop calling harness-run code dead

### DIFF
--- a/crates/kin-cli/src/commands/dead_code.rs
+++ b/crates/kin-cli/src/commands/dead_code.rs
@@ -2,7 +2,9 @@
 // Copyright 2026 Firelock, LLC
 
 use anyhow::{Context, Result};
-use kin_model::{EntityId, EntityStore, GraphNodeId, GraphStore, RelationKind};
+use kin_model::{
+    EntityId, EntityKind, EntityRole, EntityStore, GraphNodeId, GraphStore, RelationKind,
+};
 use serde::{Deserialize, Serialize};
 
 use crate::commands::search::{
@@ -129,26 +131,69 @@ async fn run_daemon_dead_code_seeded(
 pub fn build_dead_code_response(graph: &kin_db::InMemoryGraph) -> Result<DeadCodeResponse> {
     let mut lines = vec!["Scanning for dead code...".to_string()];
 
-    let dead = graph.find_dead_code()?;
-    if dead.is_empty() {
-        lines.push("No dead code found.".to_string());
-    } else {
-        lines.push(format!("Found {} unreferenced entities:", dead.len()));
-        for e in &dead {
-            lines.push(format!(
-                "  {} ({:?}, {}) - {}",
-                e.name,
-                e.kind,
-                e.language,
-                e.file_origin
-                    .as_ref()
-                    .map(|f| f.to_string())
-                    .unwrap_or_else(|| "unknown".to_string())
-            ));
+    // A missing incoming edge is only evidence of deadness for an entity whose
+    // callers would have produced one. A test is invoked by its harness and a
+    // trait method is invoked through the trait, so neither is named by any
+    // edge, and reporting both as unreferenced buries the genuine finds. Both
+    // exclusions are read off graph truth, and the counts stay in the output so
+    // the scan never quietly shrinks its own number.
+    let mut unreferenced = Vec::new();
+    let mut nonproduction = 0usize;
+    let mut trait_satisfying = 0usize;
+    for entity in graph.find_dead_code()? {
+        if entity.role != EntityRole::Source {
+            nonproduction += 1;
+        } else if entity.kind == EntityKind::Method && satisfies_trait_contract(graph, &entity.id)?
+        {
+            trait_satisfying += 1;
+        } else {
+            unreferenced.push(entity);
         }
     }
 
+    if unreferenced.is_empty() {
+        lines.push("No dead code found.".to_string());
+    } else {
+        lines.push(format!(
+            "Found {} unreferenced entities:",
+            unreferenced.len()
+        ));
+    }
+    if nonproduction > 0 || trait_satisfying > 0 {
+        lines.push(format!(
+            "  ({nonproduction} excluded as non-production entities, {trait_satisfying} as trait-implementation methods reached through their trait)"
+        ));
+    }
+    for e in &unreferenced {
+        lines.push(format!(
+            "  {} ({:?}, {}) - {}",
+            e.name,
+            e.kind,
+            e.language,
+            e.file_origin
+                .as_ref()
+                .map(|f| f.to_string())
+                .unwrap_or_else(|| "unknown".to_string())
+        ));
+    }
+
     Ok(DeadCodeResponse { lines })
+}
+
+/// Whether the entity declares that it satisfies a trait contract.
+///
+/// Ingestion records an `Implements` edge from a method declared in a trait
+/// implementation to the trait it satisfies. A call through the trait names the
+/// trait, never the implementation, so this edge is the only thing standing
+/// between a dispatch-reached method and a dead-code report.
+fn satisfies_trait_contract(graph: &impl GraphStore, entity_id: &EntityId) -> Result<bool> {
+    Ok(graph
+        .get_all_relations_for_entity(entity_id)?
+        .into_iter()
+        .any(|relation| {
+            relation.kind == RelationKind::Implements
+                && relation.src == GraphNodeId::Entity(*entity_id)
+        }))
 }
 
 /// Build a seeded dead-code response: semantic_search(query) → top N candidates,
@@ -436,6 +481,64 @@ mod tests {
         let live_row = &response.candidates[live_idx];
         assert_eq!(live_row.reference_count, 1);
         assert!(!live_row.dead);
+    }
+
+    #[test]
+    fn scan_excludes_tests_and_trait_methods_and_says_how_many() {
+        let graph = InMemoryGraph::new();
+
+        let orphan = make_entity("never_called", "src/orphan.rs");
+
+        let mut harness_test = make_entity("checks_never_called", "src/orphan.rs");
+        harness_test.role = EntityRole::Test;
+
+        let mut dispatched = make_entity("Summary::matched", "src/summary.rs");
+        dispatched.kind = EntityKind::Method;
+
+        let mut inherent = make_entity("Summary::helper", "src/summary.rs");
+        inherent.kind = EntityKind::Method;
+
+        let mut sink = make_entity("Sink", "src/sink.rs");
+        sink.kind = EntityKind::TraitDef;
+
+        for entity in [&orphan, &harness_test, &dispatched, &inherent, &sink] {
+            graph.upsert_entity(entity).unwrap();
+        }
+        graph
+            .upsert_relation(&make_relation(
+                dispatched.id,
+                sink.id,
+                RelationKind::Implements,
+            ))
+            .unwrap();
+
+        let lines = build_dead_code_response(&graph).unwrap().lines;
+        let joined = lines.join("\n");
+
+        assert!(
+            joined.contains("Found 2 unreferenced entities:"),
+            "only the orphan and the inherent method are unreferenced: {joined}"
+        );
+        assert!(
+            joined.contains("never_called"),
+            "a function nothing calls is still reported: {joined}"
+        );
+        assert!(
+            joined.contains("Summary::helper"),
+            "an inherent method nothing calls is still reported: {joined}"
+        );
+        assert!(
+            !joined.contains("checks_never_called"),
+            "the harness invokes a test with no edge to record: {joined}"
+        );
+        assert!(
+            !joined.contains("Summary::matched"),
+            "a call through the trait never names the implementation: {joined}"
+        );
+        assert!(
+            joined.contains("1 excluded as non-production entities, 1 as trait-implementation"),
+            "the scan reports what it set aside: {joined}"
+        );
     }
 
     #[test]

--- a/crates/kin-cli/src/commands/dead_code.rs
+++ b/crates/kin-cli/src/commands/dead_code.rs
@@ -151,6 +151,23 @@ pub fn build_dead_code_response(graph: &kin_db::InMemoryGraph) -> Result<DeadCod
         }
     }
 
+    // The scan reads a randomly seeded hash map in parallel, so without an
+    // explicit order the same repository lists its findings differently on every
+    // run and two scans cannot be diffed against each other.
+    unreferenced.sort_by(|left, right| {
+        let file_of = |entity: &kin_model::Entity| {
+            entity
+                .file_origin
+                .as_ref()
+                .map(|file| file.to_string())
+                .unwrap_or_default()
+        };
+        file_of(left)
+            .cmp(&file_of(right))
+            .then_with(|| left.name.cmp(&right.name))
+            .then_with(|| left.id.cmp(&right.id))
+    });
+
     if unreferenced.is_empty() {
         lines.push("No dead code found.".to_string());
     } else {
@@ -538,6 +555,19 @@ mod tests {
         assert!(
             joined.contains("1 excluded as non-production entities, 1 as trait-implementation"),
             "the scan reports what it set aside: {joined}"
+        );
+
+        let orphan_line = lines
+            .iter()
+            .position(|line| line.contains("never_called"))
+            .unwrap();
+        let helper_line = lines
+            .iter()
+            .position(|line| line.contains("Summary::helper"))
+            .unwrap();
+        assert!(
+            orphan_line < helper_line,
+            "findings order by file so two scans of one repo can be diffed: {joined}"
         );
     }
 

--- a/crates/kin-cli/src/commands/impact.rs
+++ b/crates/kin-cli/src/commands/impact.rs
@@ -2,7 +2,7 @@
 // Copyright 2026 Firelock, LLC
 
 use anyhow::{Context, Result};
-use kin_model::{EntityFilter, EntityId, EntityStore};
+use kin_model::{EntityFilter, EntityId, EntityStore, GraphNodeId};
 use serde::{Deserialize, Serialize};
 
 pub const IMPACT_RESPONSE_SCHEMA_VERSION: &str = "kin-impact-response-v1";
@@ -167,12 +167,10 @@ pub async fn build_impact_response(
     }
 
     // 1. Local Impact, grouped by traversal distance so a reader can tell the
-    // direct callers from the transitive ripple. get_downstream_impact(id, d)
-    // is one breadth-first walk capped at d, so the set at hop d minus the set
-    // at hop d-1 is exactly the entities first reached at distance d; reusing
-    // the same traversal per hop keeps the grouped listing consistent with the
-    // flat listing it replaces.
-    let local_impacted = graph.get_downstream_impact(&target.id, request.depth)?;
+    // direct callers from the transitive ripple. The walk below records the hop
+    // at which each entity is first reached, so the count and every group are
+    // read off one traversal of one graph state.
+    let local_impacted = downstream_impact_by_hop(graph, &target.id, request.depth)?;
     if local_impacted.is_empty() {
         lines.push("  No local downstream impact found.".to_string());
     } else {
@@ -182,32 +180,20 @@ pub async fn build_impact_response(
             request.depth,
             if request.depth == 1 { "" } else { "s" }
         ));
-        let mut listed: std::collections::HashSet<EntityId> = std::collections::HashSet::new();
-        for hop in 1..=request.depth {
-            let reached = if hop == request.depth {
-                local_impacted.clone()
-            } else {
-                graph.get_downstream_impact(&target.id, hop)?
-            };
-            let fresh: Vec<&kin_model::Entity> = reached
-                .iter()
-                .filter(|entity| !listed.contains(&entity.id))
-                .collect();
-            if fresh.is_empty() {
-                continue;
+        let mut current_hop = 0;
+        for (hop, entity) in &local_impacted {
+            if *hop != current_hop {
+                current_hop = *hop;
+                lines.push(if *hop == 1 {
+                    "  1 hop (direct callers):".to_string()
+                } else {
+                    format!("  {hop} hops:")
+                });
             }
-            lines.push(if hop == 1 {
-                "  1 hop (direct callers):".to_string()
-            } else {
-                format!("  {hop} hops:")
-            });
-            for entity in fresh {
-                listed.insert(entity.id);
-                let at = entity_location(entity)
-                    .map(|loc| format!(" @ {loc}"))
-                    .unwrap_or_default();
-                lines.push(format!("    - {} ({:?}){}", entity.name, entity.kind, at));
-            }
+            let at = entity_location(entity)
+                .map(|loc| format!(" @ {loc}"))
+                .unwrap_or_default();
+            lines.push(format!("    - {} ({:?}){}", entity.name, entity.kind, at));
         }
     }
 
@@ -223,6 +209,61 @@ pub async fn build_impact_response(
         query,
         ranked,
     })
+}
+
+/// One breadth-first walk over inbound entity edges, pairing every reached
+/// entity with the hop it was first reached at, in discovery order.
+///
+/// Breadth-first order reaches a node by a shortest path, so first-reach hop is
+/// that entity's minimum distance from the target and the caller can group
+/// straight out of this one result. Walking the graph again per hop instead
+/// would cost depth times as much and would read a different graph state each
+/// time, so a concurrent write between two walks could leave the grouped
+/// listing disagreeing with the count printed above it.
+///
+/// The edge set matches `GraphStore::get_downstream_impact`: entity-to-entity
+/// relations pointing at the entity being expanded, with the relation's source
+/// as the dependent. `impact_hop_walk_matches_graph_downstream_impact` pins
+/// that equivalence.
+fn downstream_impact_by_hop(
+    graph: &kin_db::InMemoryGraph,
+    target: &EntityId,
+    depth: u32,
+) -> Result<Vec<(u32, kin_model::Entity)>> {
+    let mut visited: std::collections::HashSet<EntityId> =
+        std::collections::HashSet::from([*target]);
+    let mut reached: Vec<(u32, kin_model::Entity)> = Vec::new();
+    let mut frontier = vec![*target];
+
+    for hop in 1..=depth {
+        let mut next = Vec::new();
+        for current in frontier {
+            for relation in graph.get_all_relations_for_entity(&current)? {
+                if relation.dst != GraphNodeId::Entity(current) {
+                    continue;
+                }
+                let Some(dependent) = relation.src.as_entity() else {
+                    continue;
+                };
+                if !visited.insert(dependent) {
+                    continue;
+                }
+                // An id carried by a relation whose entity record is missing is
+                // still a real step in the walk, so it keeps expanding even
+                // though it cannot be listed.
+                if let Some(entity) = graph.get_entity(&dependent)? {
+                    reached.push((hop, entity));
+                }
+                next.push(dependent);
+            }
+        }
+        if next.is_empty() {
+            break;
+        }
+        frontier = next;
+    }
+
+    Ok(reached)
 }
 
 fn resolve_entities(
@@ -303,7 +344,10 @@ fn impact_not_found_guidance(entity: &str) -> Vec<String> {
 
 #[cfg(test)]
 mod tests {
-    use super::{build_impact_response, impact_not_found_guidance, ImpactRequest, ImpactResponse};
+    use super::{
+        build_impact_response, downstream_impact_by_hop, impact_not_found_guidance, ImpactRequest,
+        ImpactResponse,
+    };
     use kin_model::{
         Entity, EntityId, EntityKind, EntityMetadata, EntityRole, EntityStore, FilePathId,
         FingerprintAlgorithm, GraphNodeId, Hash256, LanguageId, Relation, RelationId, RelationKind,
@@ -655,6 +699,92 @@ mod tests {
         assert!(
             h1 < d && d < h2 && h2 < i,
             "hop groups out of order: {lines:?}"
+        );
+    }
+
+    #[test]
+    fn impact_hop_walk_matches_graph_downstream_impact() {
+        let graph = kin_db::InMemoryGraph::new();
+        let target = entity("changed", "src/lib.rs");
+        let direct = entity("direct_caller", "src/direct.rs");
+        // Reaches the target both directly and through `direct`, so a walk that
+        // recorded last-reach rather than first-reach would file it at 2 hops.
+        let both_ways = entity("shortcut_caller", "src/shortcut.rs");
+        let indirect = entity("indirect_caller", "src/indirect.rs");
+        // Sits one hop past the depth cap and must not appear at all.
+        let beyond = entity("beyond_depth_caller", "src/beyond.rs");
+        // The target's own dependency, reachable only by walking an edge
+        // outward. Nothing the target calls is downstream of it, so a walk that
+        // followed edges in either direction would pick this up and diverge
+        // from the graph's own downstream impact.
+        let callee = entity("upstream_callee", "src/callee.rs");
+        for e in [&target, &direct, &both_ways, &indirect, &beyond, &callee] {
+            graph.upsert_entity(e).unwrap();
+        }
+        for (src, dst) in [
+            (&direct, &target),
+            (&both_ways, &target),
+            (&both_ways, &direct),
+            (&indirect, &direct),
+            (&beyond, &indirect),
+            (&target, &callee),
+        ] {
+            graph
+                .upsert_relation(&Relation {
+                    id: RelationId::from_content(&src.id.to_string(), &dst.id.to_string(), "calls"),
+                    kind: RelationKind::Calls,
+                    src: GraphNodeId::Entity(src.id),
+                    dst: GraphNodeId::Entity(dst.id),
+                    confidence: 1.0,
+                    origin: RelationOrigin::Parsed,
+                    created_in: None,
+                    import_source: None,
+                    evidence: Vec::new(),
+                })
+                .unwrap();
+        }
+
+        let depth = 2;
+        let walked = downstream_impact_by_hop(&graph, &target.id, depth).unwrap();
+        let walked_ids: std::collections::BTreeSet<EntityId> =
+            walked.iter().map(|(_, entity)| entity.id).collect();
+        let authority_ids: std::collections::BTreeSet<EntityId> =
+            graph
+                .get_downstream_impact(&target.id, depth)
+                .unwrap()
+                .into_iter()
+                .map(|entity| entity.id)
+                .collect();
+        assert_eq!(
+            walked_ids, authority_ids,
+            "hop walk must reach exactly what the graph's own downstream impact reaches"
+        );
+        assert!(
+            !walked_ids.contains(&beyond.id),
+            "depth cap must exclude the entity one hop past it"
+        );
+        assert!(
+            !walked_ids.contains(&callee.id),
+            "what the target calls is its dependency, not its downstream impact"
+        );
+
+        let hop_of = |id: EntityId| {
+            walked
+                .iter()
+                .find(|(_, entity)| entity.id == id)
+                .map(|(hop, _)| *hop)
+                .unwrap_or_else(|| panic!("{id} missing from the walk"))
+        };
+        assert_eq!(hop_of(direct.id), 1);
+        assert_eq!(
+            hop_of(both_ways.id),
+            1,
+            "an entity on both a 1-hop and a 2-hop path belongs to the shorter one"
+        );
+        assert_eq!(hop_of(indirect.id), 2);
+        assert!(
+            walked.windows(2).all(|pair| pair[0].0 <= pair[1].0),
+            "hops must come back in nondecreasing order so the listing can group in one pass"
         );
     }
 }

--- a/crates/kin-cli/src/commands/impact.rs
+++ b/crates/kin-cli/src/commands/impact.rs
@@ -225,8 +225,29 @@ pub async fn build_impact_response(
 /// relations pointing at the entity being expanded, with the relation's source
 /// as the dependent. `impact_hop_walk_matches_graph_downstream_impact` pins
 /// that equivalence.
-fn downstream_impact_by_hop(
-    graph: &kin_db::InMemoryGraph,
+/// The two graph reads the hop walk performs, named so a test can count them.
+trait ImpactWalkGraph {
+    /// Entity-to-entity relations that point at `id`.
+    fn inbound_relations(&self, id: &EntityId) -> Result<Vec<kin_model::Relation>>;
+    fn entity(&self, id: &EntityId) -> Result<Option<kin_model::Entity>>;
+}
+
+impl ImpactWalkGraph for kin_db::InMemoryGraph {
+    fn inbound_relations(&self, id: &EntityId) -> Result<Vec<kin_model::Relation>> {
+        Ok(self
+            .get_all_relations_for_entity(id)?
+            .into_iter()
+            .filter(|relation| relation.dst == GraphNodeId::Entity(*id))
+            .collect())
+    }
+
+    fn entity(&self, id: &EntityId) -> Result<Option<kin_model::Entity>> {
+        Ok(self.get_entity(id)?)
+    }
+}
+
+fn downstream_impact_by_hop<G: ImpactWalkGraph>(
+    graph: &G,
     target: &EntityId,
     depth: u32,
 ) -> Result<Vec<(u32, kin_model::Entity)>> {
@@ -238,10 +259,7 @@ fn downstream_impact_by_hop(
     for hop in 1..=depth {
         let mut next = Vec::new();
         for current in frontier {
-            for relation in graph.get_all_relations_for_entity(&current)? {
-                if relation.dst != GraphNodeId::Entity(current) {
-                    continue;
-                }
+            for relation in graph.inbound_relations(&current)? {
                 let Some(dependent) = relation.src.as_entity() else {
                     continue;
                 };
@@ -251,7 +269,7 @@ fn downstream_impact_by_hop(
                 // An id carried by a relation whose entity record is missing is
                 // still a real step in the walk, so it keeps expanding even
                 // though it cannot be listed.
-                if let Some(entity) = graph.get_entity(&dependent)? {
+                if let Some(entity) = graph.entity(&dependent)? {
                     reached.push((hop, entity));
                 }
                 next.push(dependent);
@@ -346,7 +364,7 @@ fn impact_not_found_guidance(entity: &str) -> Vec<String> {
 mod tests {
     use super::{
         build_impact_response, downstream_impact_by_hop, impact_not_found_guidance, ImpactRequest,
-        ImpactResponse,
+        ImpactResponse, ImpactWalkGraph,
     };
     use kin_model::{
         Entity, EntityId, EntityKind, EntityMetadata, EntityRole, EntityStore, FilePathId,
@@ -784,6 +802,158 @@ mod tests {
         assert!(
             walked.windows(2).all(|pair| pair[0].0 <= pair[1].0),
             "hops must come back in nondecreasing order so the listing can group in one pass"
+        );
+    }
+
+    /// Counts each graph read so a test can assert the walk's cost.
+    struct CountingGraph<'a> {
+        inner: &'a kin_db::InMemoryGraph,
+        inbound_reads: std::cell::Cell<usize>,
+    }
+
+    impl ImpactWalkGraph for CountingGraph<'_> {
+        fn inbound_relations(&self, id: &EntityId) -> anyhow::Result<Vec<kin_model::Relation>> {
+            self.inbound_reads.set(self.inbound_reads.get() + 1);
+            self.inner.inbound_relations(id)
+        }
+
+        fn entity(&self, id: &EntityId) -> anyhow::Result<Option<Entity>> {
+            self.inner.entity(id)
+        }
+    }
+
+    fn chain_graph(length: usize) -> (kin_db::InMemoryGraph, Entity) {
+        let graph = kin_db::InMemoryGraph::new();
+        let entities: Vec<Entity> = (0..length)
+            .map(|i| entity(&format!("link_{i}"), &format!("src/link_{i}.rs")))
+            .collect();
+        for e in &entities {
+            graph.upsert_entity(e).unwrap();
+        }
+        // link_1 calls link_0, link_2 calls link_1, and so on, so link_0 has a
+        // chain of dependents exactly `length - 1` hops deep.
+        for pair in entities.windows(2) {
+            graph
+                .upsert_relation(&Relation {
+                    id: RelationId::from_content(
+                        &pair[1].id.to_string(),
+                        &pair[0].id.to_string(),
+                        "calls",
+                    ),
+                    kind: RelationKind::Calls,
+                    src: GraphNodeId::Entity(pair[1].id),
+                    dst: GraphNodeId::Entity(pair[0].id),
+                    confidence: 1.0,
+                    origin: RelationOrigin::Parsed,
+                    created_in: None,
+                    import_source: None,
+                    evidence: Vec::new(),
+                })
+                .unwrap();
+        }
+        let root = entities.into_iter().next().unwrap();
+        (graph, root)
+    }
+
+    #[test]
+    fn impact_walk_reads_each_entity_once_regardless_of_depth() {
+        // A chain of four: the target plus three entities that depend on it in
+        // sequence.
+        let (graph, root) = chain_graph(4);
+        let walk_at = |depth: u32| {
+            let counted = CountingGraph {
+                inner: &graph,
+                inbound_reads: std::cell::Cell::new(0),
+            };
+            let walked = downstream_impact_by_hop(&counted, &root.id, depth).unwrap();
+            let ids: Vec<(u32, EntityId)> =
+                walked.into_iter().map(|(hop, e)| (hop, e.id)).collect();
+            (ids, counted.inbound_reads.get())
+        };
+
+        // Each entity is expanded at most once, and entities found at the depth
+        // cap are never expanded at all. Three reads covers the whole chain. The
+        // shape this replaced ran a complete traversal for each of the three
+        // hops instead.
+        let (reached, reads) = walk_at(3);
+        assert_eq!(reached.len(), 3, "the whole chain is within 3 hops");
+        assert_eq!(
+            reads, 3,
+            "one read per entity expanded, not one traversal per hop"
+        );
+
+        // Past the end of the chain the walk expands the last entity once to
+        // learn nothing depends on it, then stops. That is the ceiling: raising
+        // the cap by an order of magnitude buys no further reads, where the
+        // per-hop shape charged for every hop asked for.
+        let (deep, deep_reads) = walk_at(32);
+        let (deeper, deeper_reads) = walk_at(320);
+        assert_eq!(deep_reads, 4, "one read per entity, and the chain has four");
+        assert_eq!(
+            deep_reads, deeper_reads,
+            "cost stops growing once the graph is exhausted"
+        );
+        assert_eq!(
+            reached, deep,
+            "a larger depth cap must not change what the walk reports"
+        );
+        assert_eq!(deep, deeper);
+    }
+
+    #[tokio::test]
+    async fn impact_listing_lines_are_exact() {
+        // Pins the grouped listing verbatim. The rewrite changed how hops are
+        // computed and must not have changed a single rendered byte.
+        let graph = kin_db::InMemoryGraph::new();
+        let target = entity_at("changed", "src/lib.rs", 10);
+        let direct = entity_at("direct_caller", "src/direct.rs", 20);
+        let indirect = entity_at("indirect_caller", "src/indirect.rs", 30);
+        for e in [&target, &direct, &indirect] {
+            graph.upsert_entity(e).unwrap();
+        }
+        for (src, dst) in [(&direct, &target), (&indirect, &direct)] {
+            graph
+                .upsert_relation(&Relation {
+                    id: RelationId::from_content(&src.id.to_string(), &dst.id.to_string(), "calls"),
+                    kind: RelationKind::Calls,
+                    src: GraphNodeId::Entity(src.id),
+                    dst: GraphNodeId::Entity(dst.id),
+                    confidence: 1.0,
+                    origin: RelationOrigin::Parsed,
+                    created_in: None,
+                    import_source: None,
+                    evidence: Vec::new(),
+                })
+                .unwrap();
+        }
+
+        let dir = tempfile::tempdir().unwrap();
+        let layout = kin_core::KinLayout::new(dir.path().join(".kin"));
+        let response = build_impact_response(
+            &layout,
+            &graph,
+            &ImpactRequest {
+                entity: "changed".to_string(),
+                depth: 3,
+                file: None,
+                kind: None,
+                signature: None,
+                require_unique: false,
+            },
+        )
+        .await
+        .unwrap();
+
+        assert_eq!(
+            response.lines,
+            vec![
+                "Impact analysis for 'changed' (Function) @ src/lib.rs:10:".to_string(),
+                "  2 local entities impacted within 3 hops:".to_string(),
+                "  1 hop (direct callers):".to_string(),
+                "    - direct_caller (Function) @ src/direct.rs:20".to_string(),
+                "  2 hops:".to_string(),
+                "    - indirect_caller (Function) @ src/indirect.rs:30".to_string(),
+            ]
         );
     }
 }

--- a/crates/kin-cli/src/commands/impact.rs
+++ b/crates/kin-cli/src/commands/impact.rs
@@ -748,13 +748,12 @@ mod tests {
         let walked = downstream_impact_by_hop(&graph, &target.id, depth).unwrap();
         let walked_ids: std::collections::BTreeSet<EntityId> =
             walked.iter().map(|(_, entity)| entity.id).collect();
-        let authority_ids: std::collections::BTreeSet<EntityId> =
-            graph
-                .get_downstream_impact(&target.id, depth)
-                .unwrap()
-                .into_iter()
-                .map(|entity| entity.id)
-                .collect();
+        let authority_ids: std::collections::BTreeSet<EntityId> = graph
+            .get_downstream_impact(&target.id, depth)
+            .unwrap()
+            .into_iter()
+            .map(|entity| entity.id)
+            .collect();
         assert_eq!(
             walked_ids, authority_ids,
             "hop walk must reach exactly what the graph's own downstream impact reaches"

--- a/crates/kin-index/src/history.rs
+++ b/crates/kin-index/src/history.rs
@@ -36,7 +36,7 @@ use crate::pipeline::IndexPipeline;
 /// establish whether replay semantics actually changed, and if they did, bump
 /// this constant and the manifest's recorded version together. Never
 /// regenerate a digest silently.
-pub const HYDRATION_SEMANTICS_VERSION: u32 = 5;
+pub const HYDRATION_SEMANTICS_VERSION: u32 = 6;
 
 /// Semantic graph delta derived for one pre-enrichment change identity.
 ///

--- a/crates/kin-index/src/pipeline.rs
+++ b/crates/kin-index/src/pipeline.rs
@@ -145,11 +145,24 @@ impl IndexPipeline {
         } = output;
 
         let role = classify_file_role(&file_id.0);
+        // A test declared inside a production file is invisible to a classifier
+        // that only reads the path, and the harness that runs it leaves no edge
+        // for the graph to record, so it reads as unreferenced to everything
+        // downstream. The parser already recognized these by their attribute or
+        // framework convention, so that finding becomes the entity's role.
+        // Matching is by name within the file: a production declaration sharing
+        // a name with a test in the same file is read as the test.
+        let test_names: std::collections::HashSet<&str> =
+            tests.iter().map(|test| test.name.as_str()).collect();
         let mut entities: Vec<Entity> = extracted_entities
             .into_iter()
             .map(|entity| {
                 let mut ent = entity.into_entity_with_source(language, file_id, Some(source));
-                ent.role = role;
+                ent.role = if role == EntityRole::Source && test_names.contains(ent.name.as_str()) {
+                    EntityRole::Test
+                } else {
+                    role
+                };
                 ent
             })
             .collect();
@@ -1416,6 +1429,61 @@ pub fn add(a: i32, b: i32) -> i32 { a + b }\n";
             artifact.content_hash,
             Hash256::from_bytes(hash.0),
             "structured hash is an enrichment fingerprint, not exact tree identity"
+        );
+    }
+
+    #[test]
+    fn test_functions_in_a_production_file_carry_the_test_role() {
+        let dir = tempfile::tempdir().unwrap();
+        let blob_store = BlobStore::new(dir.path().join("blobs")).unwrap();
+        let pipeline = IndexPipeline::new();
+        let source = br#"
+pub fn shipped() -> u32 { 1 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn shipped_returns_one() {
+        assert_eq!(shipped(), 1);
+    }
+}
+"#;
+        let blob_hash = blob_store.write(source).unwrap();
+        let indexed = pipeline
+            .index_file_content_with_tests(&FilePathId::new("src/shipped.rs"), source, blob_hash)
+            .unwrap();
+
+        let role_of = |name: &str| {
+            indexed
+                .indexed_file
+                .entities
+                .iter()
+                .find(|entity| entity.name == name)
+                .unwrap_or_else(|| {
+                    panic!(
+                        "{name} missing from {:?}",
+                        indexed
+                            .indexed_file
+                            .entities
+                            .iter()
+                            .map(|e| e.name.as_str())
+                            .collect::<Vec<_>>()
+                    )
+                })
+                .role
+        };
+
+        assert_eq!(
+            role_of("shipped_returns_one"),
+            EntityRole::Test,
+            "a test in a production path is still a test"
+        );
+        assert_eq!(
+            role_of("shipped"),
+            EntityRole::Source,
+            "the production function beside it keeps its role"
         );
     }
 }

--- a/crates/kin-parser/src/languages/rust_lang.rs
+++ b/crates/kin-parser/src/languages/rust_lang.rs
@@ -326,6 +326,23 @@ fn extract_rust_node(
                                 span: span_from_node(&member, file_id),
                             });
                             extract_calls_from_context(&member, source, &qualified, relations);
+                            // A method declared in `impl Trait for Type` satisfies
+                            // the trait's contract, so a caller holding the trait
+                            // reaches it without any edge naming the method. Only
+                            // the implementing type carried that fact before, which
+                            // left no way to tell a trait method apart from an
+                            // inherent one that nothing calls.
+                            if let Some(ref trait_n) = trait_name {
+                                if !trait_n.is_empty() {
+                                    relations.push(ExtractedRelation {
+                                        call_shape: None,
+                                        kind: kin_model::RelationKind::Implements,
+                                        src_name: qualified.clone(),
+                                        dst_name: trait_n.clone(),
+                                        import_source: None,
+                                    });
+                                }
+                            }
                             if !type_name.is_empty() {
                                 relations.push(ExtractedRelation {
                                     call_shape: None,
@@ -1505,5 +1522,51 @@ mod handlers {
 
         assert!(entity_names(&out, EntityKind::Module).contains(&"other"));
         assert!(call_edges(&out).contains(&("top", "local")));
+    }
+
+    #[test]
+    fn trait_impl_methods_declare_the_trait_they_satisfy() {
+        let adapter = RustAdapter;
+        let source = br#"
+pub struct Summary;
+
+impl Sink for Summary {
+    fn matched(&mut self) -> bool { true }
+    fn finish(&mut self) {}
+}
+
+impl Summary {
+    fn helper(&self) -> u32 { 1 }
+}
+"#;
+        let tree = adapter.parse(source).unwrap();
+        let out = adapter
+            .extract(&tree, source, &FilePathId::new("src/summary.rs"))
+            .unwrap();
+
+        let implements: Vec<(&str, &str)> = out
+            .relations
+            .iter()
+            .filter(|r| r.kind == kin_model::RelationKind::Implements)
+            .map(|r| (r.src_name.as_str(), r.dst_name.as_str()))
+            .collect();
+
+        assert!(
+            implements.contains(&("Summary::matched", "Sink")),
+            "a trait method must name the trait it satisfies: {implements:?}"
+        );
+        assert!(
+            implements.contains(&("Summary::finish", "Sink")),
+            "every method of the impl block satisfies the trait: {implements:?}"
+        );
+        assert!(
+            implements.contains(&("Summary", "Sink")),
+            "the implementing type keeps its own edge: {implements:?}"
+        );
+        assert!(
+            !implements.iter().any(|(src, _)| *src == "Summary::helper"),
+            "an inherent method satisfies no trait, so nothing shields it from a \
+             dead-code report: {implements:?}"
+        );
     }
 }

--- a/scripts/hydration-semantics-manifest.json
+++ b/scripts/hydration-semantics-manifest.json
@@ -1,6 +1,6 @@
 {
   "comment": "Replay-semantics surface pinned by scripts/verify-hydration-semantics.py. These functions re-author the entity/relation deltas persisted for historical changes during Git admission, so editing one changes what Kin reports about the past on already-ingested repositories. A digest mismatch is not a failure to fix by regenerating: decide first whether replay semantics changed, and if so bump HYDRATION_SEMANTICS_VERSION and hydration_semantics_version together.",
-  "hydration_semantics_version": 5,
+  "hydration_semantics_version": 6,
   "guarded": [
     {
       "file": "crates/kin-index/src/history.rs",


### PR DESCRIPTION
Two precision fixes on the impact and dead-code command paths.

## Impact hop grouping

The hop loop called `get_downstream_impact(target, hop)` once per hop while its comment claimed it reused one traversal. A depth-3 query paid for three traversals, and each group was read from a graph state the count printed above it never observed.

One breadth-first walk now records the hop each entity is first reached at, and both the count and every group come off that single result.

The walk reads the graph through a two-method boundary so its cost is measurable. `impact_walk_reads_each_entity_once_regardless_of_depth` counts the reads and holds them to one per entity expanded, and asserts that raising the depth cap from 32 to 320 past the end of a chain buys no further reads, where the per-hop shape charged for every hop asked for. `impact_listing_lines_are_exact` pins the rendered listing verbatim, since only the computation of hops changed and no output byte should have moved. `impact_hop_walk_matches_graph_downstream_impact` pins the walked entity set equal to the graph's own downstream impact, along with the depth cap and first-reach hop assignment.

The walk lives in the CLI rather than kin-db because `GraphStore::get_downstream_impact` returns entities with no depth attached, and widening that trait is a kin-model and kin-db change behind a registry publish and version ladder. The equivalence test is what keeps the two from drifting.

Closes FIR-1579

## Dead-code over-report

`kin dead-code` reported 2410 unreferenced of 3784 entities on a ripgrep clone. A missing incoming edge is only evidence of deadness for an entity whose callers would have produced one, and two populations produce none: tests, which their harness invokes, and trait-implementation methods, which callers reach through the trait.

Neither fact was in the graph to read, so the fix is at ingestion rather than at the command layer. A method declared in an implementation block now records an `Implements` edge to the trait it satisfies, next to the existing edge from the implementing type. Entity role came only from the file path, which cannot see a test declared inside a production file, so entities the parser already recognized as tests now carry the test role rather than being dropped on the floor. The scan reads both signals and prints what each excluded, so its number stays checkable instead of quietly shrinking.

Findings are also now ordered by file, then name, then id. They were printed in the order a rayon walk over a randomly seeded `hashbrown::HashMap` produced, so one repository listed them differently on every run and two scans could not be diffed.

Per-symbol behavior is unchanged: `build_dead_code_seeded_response` and the `kin refs` bulk path are untouched.

Part of FIR-1582

## Replay semantics: HYDRATION_SEMANTICS_VERSION 5 to 6

This is a deliberate replay-semantics change, declared rather than discovered.

`semantic_state_for_tree`, one of the nine functions pinned by `scripts/hydration-semantics-manifest.json`, re-authors historical deltas through `index_file_content_with_tests`. Recording a test role on entities and an `Implements` edge on trait-implementation methods therefore changes what replay reports about the past on repositories that were already ingested.

The nine guarded function bodies are untouched, so their digests are unchanged and the guard would have stayed green while the output it protects moved. The manifest diff is one line, the recorded version. `HYDRATION_SEMANTICS_VERSION` is the dial that states the change, so it is bumped to 6 and the manifest regenerated with `python3 scripts/verify-hydration-semantics.py --write`.

## Before and after counts: not measured

No new percentage is claimed here, and the 64% figure above is the one from the ticket, not a re-measurement.

Both new signals are written at ingestion, so a corpus ingested before this change carries neither, and the reported rate only moves after a re-index. Producing an honest before and after therefore needs a fresh ripgrep ingest under the daemon lock, which is past this lane's cap. The measurement is a clean follow-up: `find_dead_code` reads only entity kind and file path, so it is invariant to both new signals, which means a single post-change ingest yields both numbers at once, the raw `find_dead_code` count as the before and the filtered count as the after.

Two further scope limits worth knowing at review time. The dispatch fix is Rust-only, so Go, TypeScript, Python and the rest still emit the type-level `Implements` edge alone and still over-report their interface methods. And test-role matching is by name within a file, so a production declaration sharing a name with a test in the same file is read as the test, which biases toward not accusing live code.

## Note on a CI check

`cargo-fuzz (parse_adapter)` and `cargo-fuzz (parse_shallow)` fail at the `Build fuzz target` step. Both already failed the same way on `main` in run 30255923093 on 2026-07-27, before this branch existed, so they are pre-existing and not caused by these changes.
