### PR TITLE
Scan the graph command modules for file-search authority

### DIFF
--- a/crates/kin-cli/src/commands/graph.rs
+++ b/crates/kin-cli/src/commands/graph.rs
@@ -1722,4 +1722,84 @@ mod tests {
         let error = response.error.expect("not-found must populate error");
         assert!(error.contains(&invented.to_string()), "{error}");
     }
+
+    /// Build a validate fixture whose graph carries exactly `tree_paths` in its
+    /// resolved tree, independent of what the working directory holds.
+    fn orphan_fixture(
+        tree_paths: &[&str],
+    ) -> (
+        tempfile::TempDir,
+        kin_core::KinLayout,
+        kin_core::LocalRepositoryAuthorityBinding,
+        kin_db::InMemoryGraph,
+    ) {
+        let temp = tempfile::tempdir().unwrap();
+        let layout = kin_core::init(temp.path()).unwrap().layout;
+        let binding = kin_core::LocalRepositoryAuthorityBinding::from_layout(&layout).unwrap();
+        let artifacts: Vec<_> = tree_paths
+            .iter()
+            .map(|path| {
+                ResolvedArtifact::new(
+                    ArtifactId::new(),
+                    RepoPath::from_utf8((*path).to_string()).unwrap(),
+                    TreeEntry::blob(Hash256::from_bytes([0x99; 32]), false),
+                )
+            })
+            .collect();
+        let mut snapshot = kin_db::GraphSnapshot::empty();
+        snapshot.resolved_tree = ResolvedTree::from_artifacts(artifacts).unwrap();
+        let graph = kin_db::InMemoryGraph::from_snapshot(snapshot).unwrap();
+        (temp, layout, binding, graph)
+    }
+
+    fn orphan_line(response: &GraphCommandResponse) -> Option<&String> {
+        response.lines.iter().find(|line| line.contains("orphaned"))
+    }
+
+    /// A file present in the working tree but absent from the graph's exact
+    /// tree is still an orphan. Deciding orphan status by probing the working
+    /// directory reports zero here, which is what this asserts against: the
+    /// projection cannot vouch for an entity the graph does not carry.
+    #[test]
+    fn graph_validate_counts_orphans_absent_from_the_graph_tree_despite_the_file_on_disk() {
+        let (_temp, layout, binding, graph) = orphan_fixture(&[]);
+        let on_disk = layout.working_dir().join("src/present.rs");
+        fs::create_dir_all(on_disk.parent().unwrap()).unwrap();
+        fs::write(&on_disk, b"fn present() {}\n").unwrap();
+        assert!(on_disk.exists(), "fixture must put the file on disk");
+
+        let mut entity = test_entity("present");
+        entity.file_origin = Some(FilePathId::new("src/present.rs"));
+        graph.upsert_entity(&entity).unwrap();
+
+        let response = build_graph_validate_response(&binding, &graph).unwrap();
+
+        let line = orphan_line(&response).expect("graph tree lacks the file, so it is orphaned");
+        assert!(line.contains('1'), "{line}");
+    }
+
+    /// The converse: a file the graph's exact tree carries is not an orphan
+    /// even though nothing was ever written to the working directory. Together
+    /// with the test above this pins the authority — the filesystem is neither
+    /// necessary nor sufficient to decide orphan status.
+    #[test]
+    fn graph_validate_clears_orphans_carried_by_the_graph_tree_with_no_file_on_disk() {
+        let (_temp, layout, binding, graph) = orphan_fixture(&["src/tracked.rs"]);
+        assert!(
+            !layout.working_dir().join("src/tracked.rs").exists(),
+            "fixture must leave the working tree empty"
+        );
+
+        let mut entity = test_entity("tracked");
+        entity.file_origin = Some(FilePathId::new("src/tracked.rs"));
+        graph.upsert_entity(&entity).unwrap();
+
+        let response = build_graph_validate_response(&binding, &graph).unwrap();
+
+        assert!(
+            orphan_line(&response).is_none(),
+            "graph tree carries the file: {:?}",
+            response.lines
+        );
+    }
 }

--- a/scripts/verify-zero-file-search.py
+++ b/scripts/verify-zero-file-search.py
@@ -221,6 +221,21 @@ QUERY_COMMANDS = {
     # health reports on the local install and graph state. Environment probes
     # here are a diagnostic boundary, but repo-content reads would not be.
     "health.rs",
+    # `kin graph validate`/`inspect`/`stats` report on graph integrity itself.
+    # A validation surface that decides its answer from the working tree states
+    # the filesystem's opinion of the graph rather than the graph's own, which
+    # is how the orphan count came to be computed by probing each entity's
+    # file_origin with `.exists()`. Orphan status now resolves against the
+    # graph-owned exact tree, and scanning this module is what keeps it there.
+    "graph.rs",
+    # The same graph data, rendered. A visualization that reads the tree would
+    # draw a picture of the projection while claiming to draw the graph.
+    "graph_viz.rs",
+    # Co-change answers from graph-owned CoChanges relations; the Git-format
+    # boundary that captures them lives in kin-git, not here.
+    "cochange.rs",
+    # History answers from recorded commits, not from re-reading the tree.
+    "history.rs",
     # `kin mcp` is how agents reach Kin. It is a launcher today and carries no
     # filesystem primitive at all, which is exactly why it belongs here: the
     # agent-facing entry point should never become the one answer surface that


### PR DESCRIPTION
The Zero File-Search Authority guard skipped every kin-cli command outside its
query list. `crates/kin-cli/src/commands/graph.rs` sat in that gap, so the
answer source for `kin graph validate` was watched by neither CI guard.

Falsified against pre-fix code rather than asserted. Restoring the orphan check
as it stood when FIR-1524 was filed (`source_root.join(&fo.0).exists()` at
graph.rs:412) next to the pre-fix `deps.rs` manifest scrape:

    before this change   deps.rs 7 violations, graph.rs 0 (never scanned)
    after this change    deps.rs 7 violations, graph.rs 1 at line 412

Both answer sources FIR-1524 names already resolve from graph truth on main.
`kin deps` projects the RepoDependency records the registry writes at ingestion
(f7897bd8). `kin graph validate` resolves orphan status against the graph-owned
exact tree through `graph.resolved_tree()`, and reaches it over the daemon,
failing loud when no daemon is available. Neither needed rerouting. What was
missing was anything stopping a return to the old authority.

Coverage now includes graph.rs, graph_viz.rs, cochange.rs, and history.rs, which
answer from graph truth and carry no filesystem primitive today. The
falsification harness derives its probe set from the same list, so the four
added modules are poisoned at four sites each and proven to fail, including the
last-production-line site that sits past the test module.

Two tests pin the validate authority behaviorally in both directions: a file
present in the working tree but absent from the exact tree is still an orphan,
and a file the exact tree carries is not an orphan with nothing on disk. Both
fail when the membership predicate is inverted, while the four pre-existing
validate tests keep passing, so the new tests discriminate on orphan authority
rather than on validation in general.

FIR-1502's other asks are already satisfied on main and were verified rather
than assumed. CI runs both guards and the falsifier as named steps in the
`check` job with no path filter. `load_allowlist` rejects an entry naming a path
that does not exist. rename and deps were rerouted by #386. kin-mcp handlers are
scanned, confirmed by planting an `.exists()` probe in handlers/entities.rs and
watching the checker flag it.

Note for #483, which reworks `build_graph_validate_response`: graph.rs is now
scanned, so a filesystem primitive added to its production code will fail CI.
The production code is clean today, and the `Command::new("git")` in its test
module is skipped as test code. This PR touches no code that #483 touches; the
two tests are appended at the end of the test module.

Verification: 911 kin-cli lib tests pass, both zero-file-search guards and
check_runtime_boundaries.sh pass, the falsification harness passes across all 24
enforced modules, cargo fmt clean, clippy clean under the ci.yml allowlist.

Closes FIR-1524
Closes FIR-1502