### PR TITLE
Give both daemon spawn paths one contract and stop killing daemons for being slow

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3085,6 +3085,7 @@ dependencies = [
  "kin-buildinfo",
  "kin-context",
  "kin-core",
+ "kin-daemon-spawn",
  "kin-db",
  "kin-git",
  "kin-index",
@@ -3200,6 +3201,7 @@ dependencies = [
  "kin-buildinfo",
  "kin-cli",
  "kin-core",
+ "kin-daemon-spawn",
  "kin-db",
  "kin-git",
  "kin-index",
@@ -3234,6 +3236,17 @@ dependencies = [
  "uuid",
  "which 8.0.4",
  "zip",
+]
+
+[[package]]
+name = "kin-daemon-spawn"
+version = "0.3.6"
+dependencies = [
+ "libc",
+ "pretty_assertions",
+ "tempfile",
+ "tokio",
+ "tracing",
 ]
 
 [[package]]
@@ -3397,6 +3410,7 @@ dependencies = [
  "kin-blobs",
  "kin-context",
  "kin-core",
+ "kin-daemon-spawn",
  "kin-db",
  "kin-git",
  "kin-model",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,6 +21,7 @@ members = [
     "crates/kin-notify",
     "crates/kin-notifier-macos",
     "crates/kin-cli",
+    "crates/kin-daemon-spawn",
     "crates/kin-daemon",
     "crates/kin-mcp",
     "crates/kin-spine",
@@ -142,6 +143,7 @@ kin-buildinfo = { path = "crates/kin-buildinfo" }
 kin-notify = { path = "crates/kin-notify" }
 kin-cli = { path = "crates/kin-cli", default-features = false }
 kin-daemon = { path = "crates/kin-daemon" }
+kin-daemon-spawn = { path = "crates/kin-daemon-spawn" }
 kin-mcp = { path = "crates/kin-mcp" }
 kin-spine = { path = "crates/kin-spine" }
 kin-registry = { path = "crates/kin-registry" }

--- a/crates/kin-cli/Cargo.toml
+++ b/crates/kin-cli/Cargo.toml
@@ -29,6 +29,7 @@ path = "src/main.rs"
 mimalloc = { version = "0.1", default-features = false }
 kin-model = { workspace = true }
 kin-core = { workspace = true }
+kin-daemon-spawn = { workspace = true }
 kin-blobs = { workspace = true }
 kin-parser = { workspace = true }
 kin-index = { workspace = true }

--- a/crates/kin-cli/src/commands/mcp.rs
+++ b/crates/kin-cli/src/commands/mcp.rs
@@ -97,6 +97,11 @@ pub async fn start(global: bool, repo: Option<PathBuf>) -> Result<()> {
         },
     ));
 
+    // The MCP server revives dead repo daemons itself, from a crate that cannot
+    // reach supervisor startup or registration. Publish them before serving so
+    // a revived daemon joins supervisor routing like an autostarted one.
+    crate::daemon_client::install_spawn_registrar();
+
     kin_mcp::run_stdio_daemon(config, repo_binder)
         .await
         .map_err(|e| anyhow::anyhow!("MCP server error: {}", e))?;

--- a/crates/kin-cli/src/daemon_client.rs
+++ b/crates/kin-cli/src/daemon_client.rs
@@ -7367,6 +7367,8 @@ mod tests {
     // graph was killed for being slow, and its replacement started cold and hit
     // the same deadline.
 
+    // Both drive a real child process and need the POSIX stand-in binaries.
+    #[cfg(unix)]
     #[tokio::test]
     async fn a_daemon_still_running_at_the_deadline_is_not_killed() {
         let mut child = std::process::Command::new("sleep")
@@ -7390,6 +7392,7 @@ mod tests {
         let _ = child.wait();
     }
 
+    #[cfg(unix)]
     #[tokio::test]
     async fn a_daemon_that_already_exited_is_reaped() {
         let mut child = std::process::Command::new("true")

--- a/crates/kin-cli/src/daemon_client.rs
+++ b/crates/kin-cli/src/daemon_client.rs
@@ -1646,6 +1646,14 @@ pub struct ProcessIdentity {
     birth_token: String,
 }
 
+impl ProcessIdentity {
+    /// The PID this identity names. Only a lookup key on its own — compare
+    /// whole identities to decide whether it is still the same process.
+    pub fn pid(&self) -> u32 {
+        self.pid
+    }
+}
+
 impl ProcessLiveness {
     /// Compatibility view for callers that only need a conservative boolean.
     ///
@@ -1798,7 +1806,7 @@ fn stable_boot_identity() -> std::io::Result<String> {
     }
 }
 
-fn process_identity(pid: u32) -> std::io::Result<Option<ProcessIdentity>> {
+pub fn process_identity(pid: u32) -> std::io::Result<Option<ProcessIdentity>> {
     let liveness = process_liveness(pid);
     if liveness == ProcessLiveness::Dead {
         return Ok(None);
@@ -1930,7 +1938,7 @@ fn process_identity(pid: u32) -> std::io::Result<Option<ProcessIdentity>> {
     }
 }
 
-fn current_process_identity() -> std::io::Result<ProcessIdentity> {
+pub fn current_process_identity() -> std::io::Result<ProcessIdentity> {
     process_identity(std::process::id())?.ok_or_else(|| {
         std::io::Error::new(
             std::io::ErrorKind::NotFound,
@@ -1939,7 +1947,7 @@ fn current_process_identity() -> std::io::Result<ProcessIdentity> {
     })
 }
 
-fn process_identity_is_current(identity: &ProcessIdentity) -> std::io::Result<bool> {
+pub fn process_identity_is_current(identity: &ProcessIdentity) -> std::io::Result<bool> {
     Ok(process_identity(identity.pid)?.as_ref() == Some(identity))
 }
 
@@ -2615,10 +2623,12 @@ fn read_pid_file(kin_root: &Path) -> Option<u32> {
         .and_then(|s| s.trim().parse().ok())
 }
 
+/// Read the port the daemon published for this repo.
+///
+/// Delegates to the shared spawn contract so the CLI and MCP paths cannot
+/// disagree about what counts as a published port.
 fn read_port_file(kin_root: &Path) -> Option<u16> {
-    std::fs::read_to_string(repo_daemon_port_path(kin_root))
-        .ok()
-        .and_then(|s| s.trim().parse().ok())
+    kin_daemon_spawn::read_reported_port(kin_root)
 }
 
 /// The (pid, port) recorded for the current repo's worker daemon, read from its
@@ -2891,10 +2901,10 @@ fn default_idle_timeout_secs() -> &'static str {
 
 /// Idle timeout (seconds) for MCP-initiated daemon autostarts: 30 minutes.
 ///
-/// Mirrors `kin_daemon::lifecycle::MCP_IDLE_TIMEOUT_SECS`; keep both in sync
-/// at "1800". kin-cli does not take a direct dep on kin-daemon, so the value
-/// is repeated here with an explicit cross-reference as the guard.
-const MCP_IDLE_TIMEOUT_SECS: &str = "1800";
+/// Defined once in the shared spawn contract, which both this path and the MCP
+/// revival path start daemons through. It used to be a literal repeated in each
+/// crate with a comment asking future readers to keep them in sync.
+const MCP_IDLE_TIMEOUT_SECS: &str = kin_daemon_spawn::MCP_IDLE_TIMEOUT_SECS;
 
 /// Pure env-assembly for the daemon's idle timeout, mirroring
 /// `kin_daemon::lifecycle::resolve_idle_timeout_env`.
@@ -4182,12 +4192,27 @@ async fn wait_for_daemon_ready(
         tokio::time::sleep(Duration::from_millis(200)).await;
     }
 
-    let _ = child.kill();
-    let _ = child.wait();
+    // The deadline measures this caller's patience, not the daemon's health.
+    // Killing here used to be unconditional, which meant a daemon still loading
+    // a large graph was destroyed for being slow — and its replacement started
+    // from cold and hit the same deadline. Endpoint probing already settled
+    // this: only positive evidence of death authorizes destruction. A daemon
+    // proven gone is reaped; a live one is left holding its repo, and the next
+    // invocation finds it through the ordinary escalating-patience path.
+    let disposition = kin_daemon_spawn::startup_disposition(child)
+        .unwrap_or(kin_daemon_spawn::StartupDisposition::Indeterminate);
+    let reaped = kin_daemon_spawn::terminate_if_proven_dead(child, &disposition);
+    let fate = if reaped {
+        "it had already exited and was reaped"
+    } else {
+        "it is still running and was left alone rather than killed for being slow; \
+         wait for it, or stop it with `kin daemon stop`"
+    };
     bail!(
-        "daemon failed to become ready within {:.1}s: {}; recent log:\n{}",
+        "daemon failed to become ready within {:.1}s: {}; {}; recent log:\n{}",
         timeout.as_secs_f64(),
         last_error,
+        fate,
         daemon_log_tail_since(kin_root, log_offset)
     )
 }
@@ -5049,6 +5074,46 @@ fn is_connection_error(err: &reqwest::Error) -> bool {
     err.is_connect() || err.is_request() || err.is_timeout()
 }
 
+/// Supervisor access published to whichever crate is starting a daemon.
+///
+/// Supervisor startup and registration live here, and `kin-mcp` cannot call
+/// this crate: `kin-cli` already depends on `kin-mcp`. So the MCP revival path
+/// started daemons the supervisor never learned about, leaving them out of its
+/// routing table and unreachable to every other client. Installing this seam
+/// gives that path the same registration this one performs.
+struct CliSpawnRegistrar;
+
+impl kin_daemon_spawn::DaemonSpawnRegistrar for CliSpawnRegistrar {
+    fn supervisor_url(
+        &self,
+    ) -> std::pin::Pin<Box<dyn std::future::Future<Output = Option<String>> + Send>> {
+        Box::pin(async { ensure_supervisor_running().await.ok() })
+    }
+
+    fn register(
+        &self,
+        kin_root: PathBuf,
+        daemon_url: String,
+    ) -> std::pin::Pin<Box<dyn std::future::Future<Output = Result<(), String>> + Send>> {
+        Box::pin(async move {
+            let supervisor_url = ensure_supervisor_running()
+                .await
+                .map_err(|error| format!("{error:#}"))?;
+            register_repo_daemon_with_supervisor(&kin_root, &daemon_url, &supervisor_url)
+                .await
+                .map_err(|error| format!("{error:#}"))
+        })
+    }
+}
+
+/// Publish this crate's supervisor access to every daemon spawn in this
+/// process, including spawns made from crates that cannot depend on it.
+///
+/// Idempotent: the first installation wins.
+pub fn install_spawn_registrar() {
+    kin_daemon_spawn::install_registrar(std::sync::Arc::new(CliSpawnRegistrar));
+}
+
 pub async fn ensure_daemon_running(kin_root: &Path) -> Result<String> {
     ensure_daemon_running_with_idle_timeout(kin_root, None).await
 }
@@ -5064,6 +5129,7 @@ pub async fn ensure_daemon_running_with_idle_timeout(
     kin_root: &Path,
     idle_timeout_override: Option<&'static str>,
 ) -> Result<String> {
+    install_spawn_registrar();
     let supervisor_url = ensure_supervisor_running()
         .await
         .context("kin supervisor is required")?;
@@ -5111,9 +5177,15 @@ pub async fn ensure_daemon_running_with_idle_timeout(
 
     info!(binary = %daemon_bin.display(), repo = %working_dir.display(), "starting daemon (OS-assigned port)");
 
-    let mut cmd = std::process::Command::new(&daemon_bin);
+    let user_timeout_set = std::env::var_os("KIN_DAEMON_IDLE_TIMEOUT_SECS").is_some();
+    let plan = kin_daemon_spawn::DaemonSpawnPlan {
+        daemon_bin,
+        working_dir: working_dir.to_path_buf(),
+        idle_timeout_secs: resolve_idle_timeout_env(user_timeout_set, idle_timeout_override),
+        supervisor_url: Some(supervisor_url.clone()),
+    };
+    let mut cmd = plan.command();
     scrub_daemon_process_authority(&mut cmd);
-    cmd.args(["--repo", &working_dir.display().to_string(), "--port", "0"]);
     let log_offset = daemon_log_len(kin_root);
     let log = open_daemon_log(kin_root)?;
     let stderr = log
@@ -5121,22 +5193,6 @@ pub async fn ensure_daemon_running_with_idle_timeout(
         .context("clone daemon log handle for stderr")?;
     cmd.stdout(Stdio::from(log));
     cmd.stderr(Stdio::from(stderr));
-    let user_timeout_set = std::env::var_os("KIN_DAEMON_IDLE_TIMEOUT_SECS").is_some();
-    if let Some(timeout) = resolve_idle_timeout_env(user_timeout_set, idle_timeout_override) {
-        cmd.env("KIN_DAEMON_IDLE_TIMEOUT_SECS", timeout);
-    }
-    cmd.env("KIN_SUPERVISOR_URL", &supervisor_url);
-
-    #[cfg(unix)]
-    {
-        use std::os::unix::process::CommandExt;
-        unsafe {
-            cmd.pre_exec(|| {
-                libc::setsid();
-                Ok(())
-            });
-        }
-    }
 
     let mut child = cmd
         .spawn()
@@ -7302,6 +7358,56 @@ mod tests {
 
         assert!(startup_lock_is_stale(&lock, Duration::ZERO));
         assert!(!startup_lock_is_stale(&lock, Duration::from_secs(60)));
+    }
+
+    // ── startup deadline is patience, not a death sentence ─────────────────
+    //
+    // The ready-wait used to SIGKILL its child the moment the deadline passed,
+    // with no check that anything was wrong with it. A daemon loading a large
+    // graph was killed for being slow, and its replacement started cold and hit
+    // the same deadline.
+
+    #[tokio::test]
+    async fn a_daemon_still_running_at_the_deadline_is_not_killed() {
+        let mut child = std::process::Command::new("sleep")
+            .arg("30")
+            .spawn()
+            .expect("spawn a long-lived stand-in for a slow daemon");
+
+        let disposition = kin_daemon_spawn::startup_disposition(&mut child)
+            .expect("a child we spawned is observable");
+        assert_eq!(disposition, kin_daemon_spawn::StartupDisposition::Alive);
+        assert!(
+            !kin_daemon_spawn::terminate_if_proven_dead(&mut child, &disposition),
+            "a live daemon must survive its caller's deadline"
+        );
+        assert!(
+            child.try_wait().expect("still observable").is_none(),
+            "the child must still be running after the deadline elapsed"
+        );
+
+        let _ = child.kill();
+        let _ = child.wait();
+    }
+
+    #[tokio::test]
+    async fn a_daemon_that_already_exited_is_reaped() {
+        let mut child = std::process::Command::new("true")
+            .spawn()
+            .expect("spawn a child that exits immediately");
+        // Let it actually exit before classifying.
+        tokio::time::sleep(Duration::from_millis(100)).await;
+
+        let disposition = kin_daemon_spawn::startup_disposition(&mut child)
+            .expect("a child we spawned is observable");
+        assert!(
+            matches!(disposition, kin_daemon_spawn::StartupDisposition::Exited(_)),
+            "an exited child is positive evidence: {disposition:?}"
+        );
+        assert!(
+            kin_daemon_spawn::terminate_if_proven_dead(&mut child, &disposition),
+            "a dead child is reaped rather than left as a zombie"
+        );
     }
 
     // ── idle-timeout env-assembly ──────────────────────────────────────────

--- a/crates/kin-daemon-spawn/Cargo.toml
+++ b/crates/kin-daemon-spawn/Cargo.toml
@@ -1,0 +1,21 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2026 Firelock, LLC
+
+[package]
+name = "kin-daemon-spawn"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+description = "Shared contract for starting a repo daemon and learning the port it bound"
+repository.workspace = true
+
+[dependencies]
+tokio = { workspace = true }
+tracing = { workspace = true }
+
+[target.'cfg(unix)'.dependencies]
+libc = "0.2"
+
+[dev-dependencies]
+tempfile = { workspace = true }
+pretty_assertions = { workspace = true }

--- a/crates/kin-daemon-spawn/src/lib.rs
+++ b/crates/kin-daemon-spawn/src/lib.rs
@@ -271,6 +271,7 @@ pub fn terminate_if_proven_dead(
 
 /// Coarse process liveness, fail-closed on anything indeterminate.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[cfg_attr(not(unix), allow(dead_code))]
 enum Liveness {
     Alive,
     Dead,

--- a/crates/kin-daemon-spawn/src/lib.rs
+++ b/crates/kin-daemon-spawn/src/lib.rs
@@ -1,0 +1,578 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Firelock, LLC
+
+//! The one definition of how a repo daemon is started and how its port is
+//! learned.
+//!
+//! Two callers start daemons: the CLI autostart path and the MCP revival path.
+//! They cannot share code through either of their own crates — `kin-cli`
+//! depends on `kin-mcp`, and `kin-mcp` cannot depend on `kin-daemon` because
+//! `kin-daemon` already depends on `kin-mcp`. So each grew its own copy of the
+//! contract, and the MCP copy has now twice regressed to a weaker version of a
+//! rule the CLI copy already enforced.
+//!
+//! This crate is the shared floor beneath both. It deliberately holds the
+//! decisions that diverged rather than everything a spawn touches:
+//!
+//! - the daemon owns port selection ([`DAEMON_PORT_ARGUMENT`]), and the port is
+//!   read back from the port file rather than reserved by the parent
+//! - a spawn that never learns a port fails closed; there is no fallback port
+//! - a startup child is killed only against positive evidence that it is dead
+//! - a stale port record is cleared only when no PID owner remains
+//!
+//! HTTP readiness probing stays with the callers: they already own health
+//! response types and repo-identity validation, and keeping `reqwest` out of
+//! here keeps this crate cheap enough that neither caller has a reason to
+//! reimplement it.
+
+use std::path::{Path, PathBuf};
+use std::sync::{Arc, OnceLock};
+use std::time::Duration;
+
+/// The port argument every daemon spawn passes.
+///
+/// Zero means "bind an ephemeral port and report it", which is what makes the
+/// port file the handshake. A parent that instead probes for a free port and
+/// passes that number opens a reserve-release-rebind race: between the probe
+/// closing its listener and the daemon binding, any other process on the
+/// machine can take the port, and the daemon then dies on a bind conflict the
+/// parent will misread as a slow start.
+pub const DAEMON_PORT_ARGUMENT: &str = "0";
+
+/// Idle timeout injected into daemons started to serve an MCP session.
+///
+/// Interactive agent sessions go quiet for long stretches between tool calls,
+/// so the CLI default (60s) expires a daemon mid-session and the MCP shim does
+/// not reconnect. Both spawn paths and the daemon's own default read this.
+pub const MCP_IDLE_TIMEOUT_SECS: &str = "1800";
+
+/// File the daemon writes its bound port into once it is listening.
+pub const PORT_FILE_NAME: &str = "daemon.port";
+
+/// File the daemon writes its PID into as part of endpoint publication.
+pub const PID_FILE_NAME: &str = "daemon.pid";
+
+/// How long to wait between polls of the port file.
+const PORT_POLL_INTERVAL: Duration = Duration::from_millis(200);
+
+// ── Spawn plan ──────────────────────────────────────────────────────────
+
+/// Everything a daemon spawn needs, assembled once so both callers pass the
+/// same argv, environment, and process-group treatment.
+#[derive(Debug, Clone)]
+pub struct DaemonSpawnPlan {
+    /// The `kin-daemon` executable to run.
+    pub daemon_bin: PathBuf,
+    /// The repository working directory (the parent of `.kin`).
+    pub working_dir: PathBuf,
+    /// Idle timeout to inject, or `None` to leave the daemon's default alone.
+    ///
+    /// An explicit `KIN_DAEMON_IDLE_TIMEOUT_SECS` in the caller's environment
+    /// always wins; resolve that before building the plan.
+    pub idle_timeout_secs: Option<&'static str>,
+    /// Supervisor endpoint to hand the daemon, when the caller has one.
+    pub supervisor_url: Option<String>,
+}
+
+impl DaemonSpawnPlan {
+    /// Build the command that starts the daemon.
+    ///
+    /// Callers still choose stdio: the CLI redirects into the daemon log so a
+    /// failed start has a tail to report, while the MCP path has no log handle
+    /// of its own. Everything that governs *which daemon comes up* is decided
+    /// here.
+    pub fn command(&self) -> std::process::Command {
+        let mut cmd = std::process::Command::new(&self.daemon_bin);
+        cmd.args([
+            "--repo",
+            &self.working_dir.display().to_string(),
+            "--port",
+            DAEMON_PORT_ARGUMENT,
+        ]);
+        if let Some(timeout) = self.idle_timeout_secs {
+            cmd.env("KIN_DAEMON_IDLE_TIMEOUT_SECS", timeout);
+        }
+        if let Some(supervisor_url) = &self.supervisor_url {
+            cmd.env("KIN_SUPERVISOR_URL", supervisor_url);
+        }
+        detach_from_caller(&mut cmd);
+        cmd
+    }
+}
+
+/// Put the daemon in its own session so it outlives the process that started
+/// it and never receives the caller's terminal signals.
+fn detach_from_caller(cmd: &mut std::process::Command) {
+    #[cfg(unix)]
+    {
+        use std::os::unix::process::CommandExt;
+        unsafe {
+            cmd.pre_exec(|| {
+                libc::setsid();
+                Ok(())
+            });
+        }
+    }
+    #[cfg(not(unix))]
+    {
+        let _ = cmd;
+    }
+}
+
+/// Resolve the idle timeout to inject, honouring an explicit user setting.
+///
+/// The user's environment always wins: returning `None` leaves whatever they
+/// exported in place rather than overwriting it with a path default.
+pub fn resolve_idle_timeout(
+    user_env_is_set: bool,
+    requested: Option<&'static str>,
+) -> Option<&'static str> {
+    if user_env_is_set {
+        return None;
+    }
+    requested
+}
+
+// ── Port handshake ──────────────────────────────────────────────────────
+
+/// Read the port the daemon reported, if it has published one yet.
+pub fn read_reported_port(kin_root: &Path) -> Option<u16> {
+    std::fs::read_to_string(kin_root.join(PORT_FILE_NAME))
+        .ok()
+        .and_then(|content| content.trim().parse::<u16>().ok())
+        .filter(|port| *port != 0)
+}
+
+/// Why waiting for the daemon's port ended without one.
+///
+/// Every variant is a refusal to guess. There is no variant carrying a fallback
+/// port, because a spawn that cannot learn the real port has nothing to talk
+/// to: binding a default would address whatever else happens to be listening
+/// there, which is worse than failing.
+#[derive(Debug)]
+pub enum PortWaitError {
+    /// The child exited before publishing a port.
+    ChildExited(String),
+    /// The deadline elapsed while the child was still alive. Not evidence of
+    /// anything except slowness, so the child is left running.
+    StillStarting,
+    /// The child could not be inspected at all.
+    Unwatchable(std::io::Error),
+}
+
+impl std::fmt::Display for PortWaitError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::ChildExited(status) => {
+                write!(f, "daemon exited during startup with status {status}")
+            }
+            Self::StillStarting => write!(
+                f,
+                "daemon is still starting and has not reported a port yet; it was left running \
+                 rather than killed. Wait for it, or stop it with `kin daemon stop`"
+            ),
+            Self::Unwatchable(error) => write!(f, "cannot observe the daemon process: {error}"),
+        }
+    }
+}
+
+impl std::error::Error for PortWaitError {}
+
+/// Poll the port file until the daemon publishes its bound port.
+///
+/// Returns the port only when the daemon itself reported one. Reaching the
+/// deadline yields [`PortWaitError::StillStarting`] and leaves the child alive:
+/// see [`StartupDisposition`] for why a deadline is not evidence of death.
+pub async fn await_reported_port(
+    kin_root: &Path,
+    child: &mut std::process::Child,
+    deadline: tokio::time::Instant,
+) -> Result<u16, PortWaitError> {
+    loop {
+        match startup_disposition(child) {
+            Ok(StartupDisposition::Exited(status)) => {
+                return Err(PortWaitError::ChildExited(status))
+            }
+            Ok(_) => {}
+            Err(error) => return Err(PortWaitError::Unwatchable(error)),
+        }
+
+        if let Some(port) = read_reported_port(kin_root) {
+            return Ok(port);
+        }
+
+        if tokio::time::Instant::now() >= deadline {
+            return Err(PortWaitError::StillStarting);
+        }
+        tokio::time::sleep(PORT_POLL_INTERVAL).await;
+    }
+}
+
+// ── Startup child disposition ───────────────────────────────────────────
+
+/// What can be established about a daemon we started but that is not serving
+/// yet.
+///
+/// The distinction is the same one endpoint probing settled on: a daemon that
+/// has not answered yet is alive, and only a daemon proven gone may be treated
+/// as dead. A startup deadline measures the caller's patience, not the child's
+/// health, so it appears in none of these variants.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum StartupDisposition {
+    /// The child is gone and its status is known.
+    Exited(String),
+    /// The child is running and simply has not finished starting.
+    Alive,
+    /// Liveness could not be established. Treated as alive: an unreadable
+    /// process is not a dead one.
+    Indeterminate,
+}
+
+impl StartupDisposition {
+    /// Whether this disposition authorizes terminating the child.
+    ///
+    /// Only a child already gone qualifies, which makes termination a reap
+    /// rather than a kill. This is the whole point: a live-but-slow daemon
+    /// holds the repo singleton and has done real warm-up work, so killing it
+    /// on a timer throws that away and guarantees its replacement starts from
+    /// cold and hits the same deadline.
+    pub fn authorizes_termination(&self) -> bool {
+        matches!(self, Self::Exited(_))
+    }
+}
+
+/// Classify a child we started.
+pub fn startup_disposition(child: &mut std::process::Child) -> std::io::Result<StartupDisposition> {
+    if let Some(status) = child.try_wait()? {
+        return Ok(StartupDisposition::Exited(status.to_string()));
+    }
+    Ok(match process_liveness(child.id()) {
+        Liveness::Dead => StartupDisposition::Exited("unknown (process is gone)".to_string()),
+        Liveness::Alive => StartupDisposition::Alive,
+        Liveness::Unknown => StartupDisposition::Indeterminate,
+    })
+}
+
+/// Terminate a startup child, but only when its disposition proves it is
+/// already gone.
+///
+/// Returns whether anything was terminated, so callers can report honestly.
+pub fn terminate_if_proven_dead(
+    child: &mut std::process::Child,
+    disposition: &StartupDisposition,
+) -> bool {
+    if !disposition.authorizes_termination() {
+        return false;
+    }
+    let _ = child.kill();
+    let _ = child.wait();
+    true
+}
+
+/// Coarse process liveness, fail-closed on anything indeterminate.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum Liveness {
+    Alive,
+    Dead,
+    Unknown,
+}
+
+fn process_liveness(pid: u32) -> Liveness {
+    #[cfg(unix)]
+    {
+        let Ok(pid) = libc::pid_t::try_from(pid) else {
+            return Liveness::Dead;
+        };
+        if unsafe { libc::kill(pid, 0) } == 0 {
+            return Liveness::Alive;
+        }
+        match std::io::Error::last_os_error().raw_os_error() {
+            Some(libc::ESRCH) => Liveness::Dead,
+            _ => Liveness::Unknown,
+        }
+    }
+    #[cfg(not(unix))]
+    {
+        let _ = pid;
+        Liveness::Unknown
+    }
+}
+
+// ── Stale endpoint records ──────────────────────────────────────────────
+
+/// Whether a port record is orphaned: a port with no PID owner beside it.
+///
+/// A port file alone names an endpoint nobody is accountable for. A port file
+/// *with* a PID file may belong to a daemon that is still publishing its
+/// endpoint, and clearing that strands the repo, so both spawn paths clear only
+/// the orphaned shape.
+pub fn port_record_is_orphaned(kin_root: &Path) -> bool {
+    kin_root.join(PORT_FILE_NAME).exists() && !kin_root.join(PID_FILE_NAME).exists()
+}
+
+/// Clear an orphaned port record so a fresh spawn is not read against a dead
+/// predecessor's port. Returns whether anything was removed.
+pub fn clear_orphaned_port_record(kin_root: &Path) -> bool {
+    if !port_record_is_orphaned(kin_root) {
+        return false;
+    }
+    match std::fs::remove_file(kin_root.join(PORT_FILE_NAME)) {
+        Ok(()) => true,
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => false,
+        Err(error) => {
+            tracing::warn!(
+                kin_root = %kin_root.display(),
+                %error,
+                "could not clear an orphaned daemon port record"
+            );
+            false
+        }
+    }
+}
+
+// ── Supervisor registration seam ────────────────────────────────────────
+
+/// Registers a freshly started daemon with the process supervisor.
+///
+/// Supervisor registration lives in `kin-cli`, which `kin-mcp` cannot call.
+/// Rather than let the MCP path go on skipping registration — leaving revived
+/// daemons invisible to the supervisor's routing table — `kin-cli` installs its
+/// implementation here and both spawn paths reach it through this seam.
+pub trait DaemonSpawnRegistrar: Send + Sync {
+    /// The supervisor endpoint a daemon about to be spawned should be told
+    /// about, starting the supervisor if it is not already up.
+    ///
+    /// Spawning without this leaves the daemon unable to reach its supervisor
+    /// even after registration succeeds, so both paths resolve it before
+    /// building their spawn plan.
+    fn supervisor_url(
+        &self,
+    ) -> std::pin::Pin<Box<dyn std::future::Future<Output = Option<String>> + Send>>;
+
+    /// Register `daemon_url` as the daemon serving `kin_root`.
+    fn register(
+        &self,
+        kin_root: PathBuf,
+        daemon_url: String,
+    ) -> std::pin::Pin<Box<dyn std::future::Future<Output = Result<(), String>> + Send>>;
+}
+
+/// Resolve the supervisor endpoint through the installed seam, if there is one.
+pub async fn supervisor_url_for_spawn() -> Option<String> {
+    let registrar = registrar()?;
+    registrar.supervisor_url().await
+}
+
+static REGISTRAR: OnceLock<Arc<dyn DaemonSpawnRegistrar>> = OnceLock::new();
+
+/// Install the process-wide registrar. Returns whether this call installed it;
+/// a second call leaves the first in place.
+pub fn install_registrar(registrar: Arc<dyn DaemonSpawnRegistrar>) -> bool {
+    REGISTRAR.set(registrar).is_ok()
+}
+
+/// The installed registrar, if any.
+pub fn registrar() -> Option<Arc<dyn DaemonSpawnRegistrar>> {
+    REGISTRAR.get().cloned()
+}
+
+/// Register a started daemon with the supervisor through the installed seam.
+///
+/// A missing registrar is reported rather than passed over: it means this
+/// process started a daemon the supervisor will not know about, which is the
+/// exact gap that made revived MCP daemons unroutable.
+pub async fn register_started_daemon(kin_root: &Path, daemon_url: &str) -> Result<(), String> {
+    let Some(registrar) = registrar() else {
+        tracing::warn!(
+            kin_root = %kin_root.display(),
+            daemon_url,
+            "started a daemon with no supervisor registrar installed; it will not appear in \
+             supervisor routing"
+        );
+        return Err("no supervisor registrar is installed in this process".to_string());
+    };
+    registrar
+        .register(kin_root.to_path_buf(), daemon_url.to_string())
+        .await
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn spawn_plan_always_lets_the_daemon_choose_the_port() {
+        let plan = DaemonSpawnPlan {
+            daemon_bin: PathBuf::from("/usr/bin/kin-daemon"),
+            working_dir: PathBuf::from("/repo"),
+            idle_timeout_secs: None,
+            supervisor_url: None,
+        };
+        let cmd = plan.command();
+        let args: Vec<_> = cmd
+            .get_args()
+            .map(|a| a.to_string_lossy().to_string())
+            .collect();
+        assert_eq!(args, vec!["--repo", "/repo", "--port", "0"]);
+    }
+
+    #[test]
+    fn spawn_plan_passes_idle_timeout_and_supervisor_when_present() {
+        let plan = DaemonSpawnPlan {
+            daemon_bin: PathBuf::from("/usr/bin/kin-daemon"),
+            working_dir: PathBuf::from("/repo"),
+            idle_timeout_secs: Some(MCP_IDLE_TIMEOUT_SECS),
+            supervisor_url: Some("http://127.0.0.1:9000".to_string()),
+        };
+        let cmd = plan.command();
+        let envs: Vec<_> = cmd
+            .get_envs()
+            .map(|(k, v)| {
+                (
+                    k.to_string_lossy().to_string(),
+                    v.map(|v| v.to_string_lossy().to_string()),
+                )
+            })
+            .collect();
+        assert!(envs.contains(&(
+            "KIN_DAEMON_IDLE_TIMEOUT_SECS".to_string(),
+            Some("1800".to_string())
+        )));
+        assert!(envs.contains(&(
+            "KIN_SUPERVISOR_URL".to_string(),
+            Some("http://127.0.0.1:9000".to_string())
+        )));
+    }
+
+    #[test]
+    fn an_explicit_user_idle_timeout_is_never_overwritten() {
+        assert_eq!(
+            resolve_idle_timeout(true, Some(MCP_IDLE_TIMEOUT_SECS)),
+            None
+        );
+        assert_eq!(
+            resolve_idle_timeout(false, Some(MCP_IDLE_TIMEOUT_SECS)),
+            Some("1800")
+        );
+        assert_eq!(resolve_idle_timeout(false, None), None);
+    }
+
+    #[test]
+    fn port_is_read_from_the_file_the_daemon_wrote() {
+        let dir = tempfile::tempdir().unwrap();
+        assert_eq!(read_reported_port(dir.path()), None);
+        std::fs::write(dir.path().join(PORT_FILE_NAME), "45123\n").unwrap();
+        assert_eq!(read_reported_port(dir.path()), Some(45123));
+    }
+
+    #[test]
+    fn an_unpublished_or_zero_port_is_not_a_port() {
+        let dir = tempfile::tempdir().unwrap();
+        std::fs::write(dir.path().join(PORT_FILE_NAME), "0").unwrap();
+        assert_eq!(read_reported_port(dir.path()), None);
+        std::fs::write(dir.path().join(PORT_FILE_NAME), "not-a-port").unwrap();
+        assert_eq!(read_reported_port(dir.path()), None);
+    }
+
+    #[test]
+    fn only_a_dead_child_authorizes_termination() {
+        assert!(!StartupDisposition::Alive.authorizes_termination());
+        assert!(!StartupDisposition::Indeterminate.authorizes_termination());
+        assert!(StartupDisposition::Exited("signal: 9".to_string()).authorizes_termination());
+    }
+
+    #[test]
+    fn an_orphaned_port_record_is_one_with_no_pid_owner() {
+        let dir = tempfile::tempdir().unwrap();
+        assert!(!port_record_is_orphaned(dir.path()));
+
+        std::fs::write(dir.path().join(PORT_FILE_NAME), "45123").unwrap();
+        assert!(port_record_is_orphaned(dir.path()));
+
+        std::fs::write(dir.path().join(PID_FILE_NAME), "4242").unwrap();
+        assert!(
+            !port_record_is_orphaned(dir.path()),
+            "a port beside a live PID record may belong to a daemon mid-publication"
+        );
+    }
+
+    #[test]
+    fn clearing_leaves_a_port_that_still_has_a_pid_owner() {
+        let dir = tempfile::tempdir().unwrap();
+        std::fs::write(dir.path().join(PORT_FILE_NAME), "45123").unwrap();
+        std::fs::write(dir.path().join(PID_FILE_NAME), "4242").unwrap();
+        assert!(!clear_orphaned_port_record(dir.path()));
+        assert!(dir.path().join(PORT_FILE_NAME).exists());
+
+        std::fs::remove_file(dir.path().join(PID_FILE_NAME)).unwrap();
+        assert!(clear_orphaned_port_record(dir.path()));
+        assert!(!dir.path().join(PORT_FILE_NAME).exists());
+    }
+
+    #[tokio::test]
+    async fn a_live_child_that_never_reports_a_port_is_left_running() {
+        let dir = tempfile::tempdir().unwrap();
+        let mut child = std::process::Command::new("sleep")
+            .arg("30")
+            .spawn()
+            .expect("spawn a long-lived stand-in child");
+
+        let deadline = tokio::time::Instant::now() + Duration::from_millis(300);
+        let outcome = await_reported_port(dir.path(), &mut child, deadline).await;
+
+        assert!(
+            matches!(outcome, Err(PortWaitError::StillStarting)),
+            "a deadline with a live child must not be reported as death: {outcome:?}"
+        );
+        assert!(
+            matches!(
+                startup_disposition(&mut child),
+                Ok(StartupDisposition::Alive)
+            ),
+            "the child must still be running after the deadline elapsed"
+        );
+
+        let _ = child.kill();
+        let _ = child.wait();
+    }
+
+    #[tokio::test]
+    async fn a_child_that_exits_before_publishing_is_reported_as_exited() {
+        let dir = tempfile::tempdir().unwrap();
+        let mut child = std::process::Command::new("true")
+            .spawn()
+            .expect("spawn a child that exits immediately");
+
+        let deadline = tokio::time::Instant::now() + Duration::from_secs(5);
+        let outcome = await_reported_port(dir.path(), &mut child, deadline).await;
+
+        assert!(
+            matches!(outcome, Err(PortWaitError::ChildExited(_))),
+            "an exited child is positive evidence and must be reported as such: {outcome:?}"
+        );
+    }
+
+    #[tokio::test]
+    async fn a_published_port_is_returned_as_soon_as_it_appears() {
+        let dir = tempfile::tempdir().unwrap();
+        let mut child = std::process::Command::new("sleep")
+            .arg("30")
+            .spawn()
+            .expect("spawn a long-lived stand-in child");
+
+        let port_path = dir.path().join(PORT_FILE_NAME);
+        tokio::spawn(async move {
+            tokio::time::sleep(Duration::from_millis(150)).await;
+            std::fs::write(port_path, "45999").unwrap();
+        });
+
+        let deadline = tokio::time::Instant::now() + Duration::from_secs(5);
+        let port = await_reported_port(dir.path(), &mut child, deadline)
+            .await
+            .expect("the published port is the answer");
+        assert_eq!(port, 45999);
+
+        let _ = child.kill();
+        let _ = child.wait();
+    }
+}

--- a/crates/kin-daemon-spawn/src/lib.rs
+++ b/crates/kin-daemon-spawn/src/lib.rs
@@ -509,6 +509,9 @@ mod tests {
         assert!(!dir.path().join(PORT_FILE_NAME).exists());
     }
 
+    // These three drive a real child process, so they need the POSIX stand-in
+    // binaries. The contract itself is platform-neutral.
+    #[cfg(unix)]
     #[tokio::test]
     async fn a_live_child_that_never_reports_a_port_is_left_running() {
         let dir = tempfile::tempdir().unwrap();
@@ -536,6 +539,7 @@ mod tests {
         let _ = child.wait();
     }
 
+    #[cfg(unix)]
     #[tokio::test]
     async fn a_child_that_exits_before_publishing_is_reported_as_exited() {
         let dir = tempfile::tempdir().unwrap();
@@ -552,6 +556,7 @@ mod tests {
         );
     }
 
+    #[cfg(unix)]
     #[tokio::test]
     async fn a_published_port_is_returned_as_soon_as_it_appears() {
         let dir = tempfile::tempdir().unwrap();

--- a/crates/kin-daemon/Cargo.toml
+++ b/crates/kin-daemon/Cargo.toml
@@ -27,6 +27,7 @@ firestore = ["kin-spine/firestore"]
 mimalloc = { version = "0.1", default-features = false }
 kin-model = { workspace = true }
 kin-core = { workspace = true }
+kin-daemon-spawn = { workspace = true }
 kin-db = { workspace = true }
 kin-infer = { version = ">=0.2.1", registry = "kin", default-features = false }
 kin-blobs = { workspace = true }

--- a/crates/kin-daemon/src/daemon.rs
+++ b/crates/kin-daemon/src/daemon.rs
@@ -132,6 +132,14 @@ fn format_singleton_contention(
             "another kin daemon (pid {}) already owns {repo} and is still running",
             holder.pid
         ),
+        // An identity-verified stamp can say the owning incarnation is gone
+        // without implying anything about whoever holds that PID now.
+        Some(holder) if holder.identity_verified => format!(
+            "the daemon lock for {repo} is still held after the process that took it (pid {}) \
+             exited, so a leaked lock fd is keeping it alive; pid {} no longer identifies that \
+             daemon and may since have been reused",
+            holder.pid, holder.pid
+        ),
         Some(holder) => format!(
             "the daemon lock for {repo} is still held after its recorded owner (pid {}) exited, \
              so a leaked lock fd is keeping it alive",
@@ -2515,6 +2523,7 @@ mod tests {
             Some(crate::lifecycle::SingletonLockHolder {
                 pid: 4242,
                 alive: true,
+                identity_verified: true,
             }),
             &crate::lifecycle::StaleLockReclaim::OwnerAlive(4242),
         );
@@ -2536,6 +2545,7 @@ mod tests {
             Some(crate::lifecycle::SingletonLockHolder {
                 pid: 4242,
                 alive: false,
+                identity_verified: false,
             }),
             &crate::lifecycle::StaleLockReclaim::Cleared(vec![std::path::PathBuf::from(
                 "/repo/.kin/daemon.lock",
@@ -2565,6 +2575,7 @@ mod tests {
             Some(crate::lifecycle::SingletonLockHolder {
                 pid: 4242,
                 alive: false,
+                identity_verified: false,
             }),
             &crate::lifecycle::StaleLockReclaim::CoordinationUnavailable(
                 "recorded owner pid 4242 is dead, but compatible older daemons do not participate"
@@ -2579,6 +2590,24 @@ mod tests {
         assert!(
             compatibility_boundary.contains("cannot be proven safe"),
             "the message must not claim exclusion it cannot enforce: {compatibility_boundary}"
+        );
+    }
+
+    #[test]
+    fn an_identity_verified_dead_owner_does_not_vouch_for_whoever_holds_its_pid_now() {
+        let message = format_singleton_contention(
+            "/repo/.kin",
+            Some(crate::lifecycle::SingletonLockHolder {
+                pid: 4242,
+                alive: false,
+                identity_verified: true,
+            }),
+            &crate::lifecycle::StaleLockReclaim::OwnerUnknown,
+        );
+        assert!(
+            message.contains("may since have been reused"),
+            "a verified-dead owner must not leave the operator believing pid 4242 is still the \
+             daemon: {message}"
         );
     }
 

--- a/crates/kin-daemon/src/lifecycle.rs
+++ b/crates/kin-daemon/src/lifecycle.rs
@@ -73,17 +73,76 @@ impl Drop for DaemonLock {
 /// removed by any other participant, while this stamp is written under the
 /// lock by the only process that could have taken it.
 fn stamp_lock_owner(file: &mut std::fs::File) {
-    let pid = std::process::id();
+    let stamp = current_owner_stamp();
     if file.set_len(0).is_err() {
         return;
     }
     if file.seek(SeekFrom::Start(0)).is_err() {
         return;
     }
-    if write!(file, "{pid}").is_err() {
+    if write!(file, "{stamp}").is_err() {
         return;
     }
     let _ = file.flush();
+}
+
+/// Marker introducing an owner stamp that carries process identity rather than
+/// a bare PID.
+const OWNER_STAMP_V2: &str = "kin-daemon-owner-v2";
+
+/// Render this process's owner stamp.
+///
+/// A PID alone cannot identify a process incarnation: PIDs are reused, so a
+/// stamp naming a dead daemon's PID starts describing whatever unrelated
+/// process the kernel handed that number to next, and every reader then reports
+/// a live daemon owning a repo it has never heard of. Binding the boot and the
+/// process creation instant makes the record false for an impostor.
+///
+/// Falls back to the bare-PID form when identity cannot be read at all, which
+/// is the same evidence the previous format carried and never less.
+fn current_owner_stamp() -> String {
+    match kin_cli::daemon_client::current_process_identity() {
+        Ok(identity) => match serde_json::to_string(&identity) {
+            Ok(encoded) => format!("{OWNER_STAMP_V2} {encoded}"),
+            Err(_) => std::process::id().to_string(),
+        },
+        Err(_) => std::process::id().to_string(),
+    }
+}
+
+/// What a lock file's owner stamp records.
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct LockOwnerStamp {
+    pid: u32,
+    /// Present only for stamps written by a daemon that could read its own
+    /// identity. Absent for the legacy bare-PID form, where a recycled PID
+    /// remains indistinguishable from the original owner.
+    identity: Option<kin_cli::daemon_client::ProcessIdentity>,
+}
+
+/// Parse either stamp form.
+///
+/// The legacy bare-PID form is still accepted: a mixed-version repo can have a
+/// stamp written by an older daemon, and refusing to read it would discard the
+/// only owner evidence that survives endpoint-file deletion.
+fn parse_lock_owner_stamp(body: &str) -> Option<LockOwnerStamp> {
+    let body = body.trim();
+    if let Some(encoded) = body.strip_prefix(OWNER_STAMP_V2) {
+        let identity: kin_cli::daemon_client::ProcessIdentity =
+            serde_json::from_str(encoded.trim()).ok()?;
+        return Some(LockOwnerStamp {
+            pid: identity.pid(),
+            identity: Some(identity),
+        });
+    }
+    Some(LockOwnerStamp {
+        pid: body.parse::<u32>().ok()?,
+        identity: None,
+    })
+}
+
+fn read_lock_owner_stamp(kin_root: &Path) -> Option<LockOwnerStamp> {
+    parse_lock_owner_stamp(&std::fs::read_to_string(kin_root.join("daemon.lock")).ok()?)
 }
 
 /// Owner PID recorded inside `.kin/daemon.lock` by whichever process last
@@ -93,9 +152,7 @@ fn stamp_lock_owner(file: &mut std::fs::File) {
 /// clearing endpoint files, so it stays available exactly when `daemon.pid` is
 /// missing.
 pub fn lock_owner_pid(kin_root: &Path) -> Option<u32> {
-    std::fs::read_to_string(kin_root.join("daemon.lock"))
-        .ok()
-        .and_then(|content| content.trim().parse::<u32>().ok())
+    read_lock_owner_stamp(kin_root).map(|stamp| stamp.pid)
 }
 
 /// Who currently owns this repo's daemon lock, as far as on-disk evidence can
@@ -104,17 +161,48 @@ pub fn lock_owner_pid(kin_root: &Path) -> Option<u32> {
 pub struct SingletonLockHolder {
     pub pid: u32,
     pub alive: bool,
+    /// Whether `alive` was decided against the recorded process incarnation
+    /// rather than the PID alone.
+    ///
+    /// False means the stamp predates identity-bound ownership, so `alive`
+    /// cannot rule out a PID that has been reused since the daemon exited.
+    pub identity_verified: bool,
 }
 
 /// Resolve the recorded owner of the repo daemon lock from real process
 /// evidence: the lock file's own owner stamp first (it survives endpoint-file
 /// deletion), then `daemon.pid`. Returns `None` only when neither record
 /// exists.
+///
+/// When the stamp carries a process identity, liveness means *that* incarnation
+/// is still running. A PID the kernel has since handed to something else reads
+/// as dead, which is the honest answer: the daemon that took the lock is gone,
+/// and reporting the impostor as a running daemon sent operators to stop a
+/// process that had nothing to do with Kin.
 pub fn singleton_lock_holder(kin_root: &Path) -> Option<SingletonLockHolder> {
-    let pid = lock_owner_pid(kin_root).or_else(|| recorded_daemon_pid(kin_root))?;
+    if let Some(stamp) = read_lock_owner_stamp(kin_root) {
+        if let Some(identity) = stamp.identity {
+            return Some(SingletonLockHolder {
+                pid: stamp.pid,
+                // An identity that cannot be read at all (permission denied on
+                // another user's process) is indeterminate, not dead: fail
+                // closed and treat the owner as live.
+                alive: kin_cli::daemon_client::process_identity_is_current(&identity)
+                    .unwrap_or(true),
+                identity_verified: true,
+            });
+        }
+        return Some(SingletonLockHolder {
+            pid: stamp.pid,
+            alive: is_process_alive(stamp.pid),
+            identity_verified: false,
+        });
+    }
+    let pid = recorded_daemon_pid(kin_root)?;
     Some(SingletonLockHolder {
         pid,
         alive: is_process_alive(pid),
+        identity_verified: false,
     })
 }
 
@@ -732,7 +820,10 @@ fn default_idle_timeout_secs() -> &'static str {
 /// Interactive MCP agent loops routinely pause longer than the 60-second CLI
 /// default between tool calls, so MCP-path spawns use this larger window.  An
 /// explicit `KIN_DAEMON_IDLE_TIMEOUT_SECS` env var always overrides both.
-pub const MCP_IDLE_TIMEOUT_SECS: &str = "1800";
+///
+/// Defined once in the shared spawn contract that both daemon-start paths build
+/// their command through, rather than repeated per crate.
+pub const MCP_IDLE_TIMEOUT_SECS: &str = kin_daemon_spawn::MCP_IDLE_TIMEOUT_SECS;
 
 /// Pure resolution of the idle-timeout value to inject into a spawned daemon.
 ///
@@ -1420,6 +1511,67 @@ mod tests {
         let dead = singleton_lock_holder(root).expect("stamp identifies the holder");
         assert_eq!(dead.pid, 999999999);
         assert!(!dead.alive);
+        assert!(
+            !dead.identity_verified,
+            "a bare-PID stamp cannot rule out PID reuse and must not claim it did"
+        );
+    }
+
+    #[test]
+    fn a_recycled_pid_cannot_impersonate_the_daemon_that_took_the_lock() {
+        // The stamp names a process incarnation, and this process is not it.
+        // A bare PID here would report a live daemon owning the repo, because
+        // the PID resolves to something alive: this very test.
+        let dir = tempfile::tempdir().unwrap();
+        let root = dir.path();
+
+        let impostor = current_owner_stamp();
+        assert!(
+            impostor.starts_with(OWNER_STAMP_V2),
+            "this platform must stamp identity, not a bare pid: {impostor}"
+        );
+        // Rewrite the birth token so the record names a different incarnation
+        // of the same live PID — exactly the shape PID reuse produces.
+        let forged = impostor.replace("start-time:", "start-time:9");
+        let forged = forged.replace("start-ticks:", "start-ticks:9");
+        let forged = forged.replace("created-100ns:", "created-100ns:9");
+        assert_ne!(forged, impostor, "the birth token must have been altered");
+        std::fs::write(root.join("daemon.lock"), &forged).unwrap();
+
+        let holder = singleton_lock_holder(root).expect("stamp identifies the holder");
+        assert_eq!(holder.pid, std::process::id());
+        assert!(holder.identity_verified);
+        assert!(
+            !holder.alive,
+            "a live PID whose recorded incarnation is gone is not the daemon that took the lock"
+        );
+    }
+
+    #[test]
+    fn an_identity_stamp_recognizes_its_own_writer() {
+        let dir = tempfile::tempdir().unwrap();
+        let root = dir.path();
+        std::fs::write(root.join("daemon.lock"), current_owner_stamp()).unwrap();
+
+        let holder = singleton_lock_holder(root).expect("stamp identifies the holder");
+        assert_eq!(holder.pid, std::process::id());
+        assert!(holder.alive, "the writing process is still running");
+        assert!(holder.identity_verified);
+    }
+
+    #[test]
+    fn a_legacy_bare_pid_stamp_is_still_read() {
+        // A repo whose lock was stamped by an older daemon must not lose its
+        // only owner evidence to a format it does not recognize.
+        assert_eq!(
+            parse_lock_owner_stamp("4242"),
+            Some(LockOwnerStamp {
+                pid: 4242,
+                identity: None
+            })
+        );
+        assert_eq!(parse_lock_owner_stamp(""), None);
+        assert_eq!(parse_lock_owner_stamp("not-a-pid"), None);
     }
 
     #[test]

--- a/crates/kin-mcp/Cargo.toml
+++ b/crates/kin-mcp/Cargo.toml
@@ -11,6 +11,7 @@ repository.workspace = true
 
 [dependencies]
 kin-core = { workspace = true }
+kin-daemon-spawn = { workspace = true }
 kin-git = { workspace = true }
 kin-model = { workspace = true }
 kin-db = { workspace = true }

--- a/crates/kin-mcp/src/daemon_delegate.rs
+++ b/crates/kin-mcp/src/daemon_delegate.rs
@@ -94,19 +94,36 @@ fn daemon_base_url() -> Option<String> {
 /// 30 minutes gives ample headroom while still ensuring eventual cleanup when
 /// an agent session is truly abandoned.  An explicit
 /// `KIN_DAEMON_IDLE_TIMEOUT_SECS` env var always overrides this at runtime.
-const MCP_IDLE_TIMEOUT_SECS: &str = "1800";
+const MCP_IDLE_TIMEOUT_SECS: &str = kin_daemon_spawn::MCP_IDLE_TIMEOUT_SECS;
 
 /// Idle timeout to inject into a revival-spawned daemon, or `None` to inject
 /// nothing.
 ///
-/// Mirrors `kin_cli::daemon_client::resolve_idle_timeout_env` and
-/// `kin_daemon::lifecycle::resolve_idle_timeout_env`: a user-set
-/// `KIN_DAEMON_IDLE_TIMEOUT_SECS` propagates to the child on its own and must
-/// never be overwritten, so this returns `None` in that case. Factored out of
-/// the spawn path so the precedence is unit-testable without spawning a
-/// process.
+/// A user-set `KIN_DAEMON_IDLE_TIMEOUT_SECS` propagates to the child on its own
+/// and must never be overwritten, so this returns `None` in that case. The
+/// precedence itself lives in `kin_daemon_spawn` so the CLI autostart path and
+/// this one cannot disagree about it.
 fn mcp_spawn_idle_timeout(user_env_is_set: bool) -> Option<&'static str> {
-    (!user_env_is_set).then_some(MCP_IDLE_TIMEOUT_SECS)
+    kin_daemon_spawn::resolve_idle_timeout(user_env_is_set, Some(MCP_IDLE_TIMEOUT_SECS))
+}
+
+/// The spawn plan the revival path starts a daemon from.
+///
+/// Split out so the contract this path once diverged from is assertable without
+/// spawning anything: no port is chosen here, so there is no port to hardcode.
+fn mcp_spawn_plan(
+    daemon_bin: std::path::PathBuf,
+    working_dir: std::path::PathBuf,
+    supervisor_url: Option<String>,
+) -> kin_daemon_spawn::DaemonSpawnPlan {
+    kin_daemon_spawn::DaemonSpawnPlan {
+        daemon_bin,
+        working_dir,
+        idle_timeout_secs: mcp_spawn_idle_timeout(
+            std::env::var_os("KIN_DAEMON_IDLE_TIMEOUT_SECS").is_some(),
+        ),
+        supervisor_url,
+    }
 }
 
 // ── Unrecoverable-daemon error class ────────────────────────────────────
@@ -608,19 +625,20 @@ fn find_mcp_daemon_binary() -> Option<std::path::PathBuf> {
     None
 }
 
-fn find_mcp_free_port() -> Option<u16> {
-    std::net::TcpListener::bind("127.0.0.1:0")
-        .ok()
-        .and_then(|l| l.local_addr().ok())
-        .map(|a| a.port())
-}
-
 /// Spawn a fresh daemon and wait for it to pass `/health`.
 ///
 /// Uses the MCP-path idle timeout (30 min) unless the user has set
 /// `KIN_DAEMON_IDLE_TIMEOUT_SECS` explicitly.  On success, writes the new
 /// base URL into [`DAEMON_URL_OVERRIDE`] so all subsequent delegate calls
 /// are routed to the revived daemon automatically.
+///
+/// Every decision about *how* the daemon is started belongs to
+/// [`kin_daemon_spawn`], which the CLI autostart path uses too. This path once
+/// carried its own copy and drifted from it twice: it reserved a port and
+/// passed the number (reopening the reserve-release-rebind race the port file
+/// exists to close), fell back to a hardcoded port when reservation failed,
+/// never cleared a stale port record, and never registered the daemon it
+/// started with the supervisor.
 async fn revive_mcp_daemon() -> Result<String, String> {
     // Serialize revival across concurrent tool calls. Every forwarded request
     // now reaches this path, so a dead daemon can be observed by several calls
@@ -646,42 +664,36 @@ async fn revive_mcp_daemon() -> Result<String, String> {
     let daemon_bin = find_mcp_daemon_binary().ok_or_else(|| {
         "MCP revival: kin-daemon binary not found (not in PATH or next to kin binary)".to_string()
     })?;
-    let port = find_mcp_free_port().unwrap_or(4219);
+
+    // A port record with no PID owner beside it belongs to a daemon that is
+    // already gone. Left in place, the port we are about to read back would be
+    // its port, not the new daemon's.
+    kin_daemon_spawn::clear_orphaned_port_record(&kin_dir);
+
+    let supervisor_url = kin_daemon_spawn::supervisor_url_for_spawn().await;
+    let plan = mcp_spawn_plan(daemon_bin, working_dir.clone(), supervisor_url);
 
     tracing::info!(
-        binary = %daemon_bin.display(),
+        binary = %plan.daemon_bin.display(),
         repo = %working_dir.display(),
-        port,
-        "MCP revival: starting fresh daemon"
+        "MCP revival: starting fresh daemon (daemon-assigned port)"
     );
 
-    let mut cmd = std::process::Command::new(&daemon_bin);
-    cmd.args([
-        "--repo",
-        &working_dir.display().to_string(),
-        "--port",
-        &port.to_string(),
-    ]);
+    let mut cmd = plan.command();
     cmd.stdout(std::process::Stdio::null());
     cmd.stderr(std::process::Stdio::null());
-    // Inject the MCP-path idle timeout unless the user has an explicit
-    // override in the environment — user's value always wins.
-    if let Some(timeout) =
-        mcp_spawn_idle_timeout(std::env::var_os("KIN_DAEMON_IDLE_TIMEOUT_SECS").is_some())
-    {
-        cmd.env("KIN_DAEMON_IDLE_TIMEOUT_SECS", timeout);
-    }
-    #[cfg(unix)]
-    unsafe {
-        use std::os::unix::process::CommandExt;
-        cmd.pre_exec(|| {
-            libc::setsid();
-            Ok(())
-        });
-    }
-
-    cmd.spawn()
+    let mut child = cmd
+        .spawn()
         .map_err(|e| format!("MCP revival: spawn kin-daemon failed: {e}"))?;
+
+    // The daemon binds :0 and publishes the port it actually got. There is no
+    // fallback: a revival that cannot learn the real port has no daemon to
+    // talk to, and addressing a default port would reach whatever else is
+    // listening there.
+    let port_deadline = tokio::time::Instant::now() + Duration::from_secs(15);
+    let port = kin_daemon_spawn::await_reported_port(&kin_dir, &mut child, port_deadline)
+        .await
+        .map_err(|e| format!("MCP revival: {e}"))?;
 
     // Poll /health until the daemon is ready (bounded at 15 s).
     let new_base = format!("http://127.0.0.1:{port}");
@@ -692,13 +704,19 @@ async fn revive_mcp_daemon() -> Result<String, String> {
         .map_err(|e| format!("MCP revival: build probe client: {e}"))?;
     let deadline = tokio::time::Instant::now() + Duration::from_secs(15);
     loop {
-        if tokio::time::Instant::now() >= deadline {
-            return Err(format!(
-                "MCP revival: daemon did not become healthy within 15s (port {port})"
-            ));
-        }
         if let Ok(resp) = probe.get(format!("{new_base}/health")).send().await {
             if resp.status().is_success() {
+                // A daemon the supervisor does not know about is unroutable to
+                // every other client, so registration is part of starting one.
+                if let Err(error) =
+                    kin_daemon_spawn::register_started_daemon(&kin_dir, &new_base).await
+                {
+                    tracing::warn!(
+                        url = %new_base,
+                        %error,
+                        "MCP revival: daemon is healthy but supervisor registration failed"
+                    );
+                }
                 // Route all subsequent delegate calls at the revived daemon.
                 if let Ok(mut guard) = DAEMON_URL_OVERRIDE.lock() {
                     *guard = Some(new_base.clone());
@@ -706,6 +724,22 @@ async fn revive_mcp_daemon() -> Result<String, String> {
                 tracing::info!(url = %new_base, "MCP revival: daemon is healthy");
                 return Ok(new_base);
             }
+        }
+
+        // The child reporting a port then failing to serve is still a startup
+        // in progress; only its death is evidence against it.
+        if let Ok(disposition) = kin_daemon_spawn::startup_disposition(&mut child) {
+            if let kin_daemon_spawn::StartupDisposition::Exited(status) = disposition {
+                return Err(format!(
+                    "MCP revival: daemon exited during startup with status {status} (port {port})"
+                ));
+            }
+        }
+        if tokio::time::Instant::now() >= deadline {
+            return Err(format!(
+                "MCP revival: daemon did not become healthy within 15s (port {port}); it was left \
+                 running rather than killed"
+            ));
         }
         tokio::time::sleep(Duration::from_millis(100)).await;
     }
@@ -2103,6 +2137,67 @@ mod tests {
             mcp_spawn_idle_timeout(true),
             None,
             "a user-set KIN_DAEMON_IDLE_TIMEOUT_SECS must never be overwritten"
+        );
+    }
+
+    // ── Revival spawn contract ─────────────────────────────────────────────
+    //
+    // This path used to reserve a port itself, pass the number, and fall back
+    // to a hardcoded 4219 when reservation failed. Both are gone: the daemon
+    // binds and reports, and the port comes back off the port file.
+
+    #[test]
+    fn revival_lets_the_daemon_choose_its_port() {
+        let plan = mcp_spawn_plan(
+            std::path::PathBuf::from("/usr/bin/kin-daemon"),
+            std::path::PathBuf::from("/repo"),
+            None,
+        );
+        let cmd = plan.command();
+        let args: Vec<String> = cmd
+            .get_args()
+            .map(|a| a.to_string_lossy().to_string())
+            .collect();
+
+        assert_eq!(
+            args,
+            vec!["--repo", "/repo", "--port", "0"],
+            "revival must pass --port 0, not a port it reserved and released"
+        );
+        assert!(
+            !args.contains(&"4219".to_string()),
+            "no hardcoded fallback port may reach the daemon: {args:?}"
+        );
+    }
+
+    #[test]
+    fn revival_reads_the_port_the_daemon_reported() {
+        let dir = tempfile::tempdir().unwrap();
+        // The port file is the handshake; nothing else names the port.
+        assert_eq!(kin_daemon_spawn::read_reported_port(dir.path()), None);
+        std::fs::write(dir.path().join(kin_daemon_spawn::PORT_FILE_NAME), "51234\n").unwrap();
+        assert_eq!(
+            kin_daemon_spawn::read_reported_port(dir.path()),
+            Some(51234)
+        );
+    }
+
+    #[test]
+    fn revival_passes_a_supervisor_url_through_to_the_daemon() {
+        let plan = mcp_spawn_plan(
+            std::path::PathBuf::from("/usr/bin/kin-daemon"),
+            std::path::PathBuf::from("/repo"),
+            Some("http://127.0.0.1:9100".to_string()),
+        );
+        let cmd = plan.command();
+        let has_supervisor = cmd.get_envs().any(|(k, v)| {
+            k == "KIN_SUPERVISOR_URL"
+                && v.map(|v| v.to_string_lossy().to_string())
+                    == Some("http://127.0.0.1:9100".to_string())
+        });
+        assert!(
+            has_supervisor,
+            "a revived daemon must be told where its supervisor is"
         );
     }
 

--- a/scripts/zero-file-search-allowlist.json
+++ b/scripts/zero-file-search-allowlist.json
@@ -67,10 +67,8 @@
         "if sibling.exists()",
         "if target_sibling.exists()",
         "if candidate.exists()",
-        "std::process::Command::new(&daemon_bin)",
         "cmd.stdout(std::process::Stdio::null());",
-        "cmd.stderr(std::process::Stdio::null());",
-        "use std::os::unix::process::CommandExt;"
+        "cmd.stderr(std::process::Stdio::null());"
       ]
     },
     {
@@ -167,6 +165,12 @@
       "allow_match": [
         "use std::process::ExitCode;"
       ]
+    },
+    {
+      "file": "crates/kin-daemon-spawn/src/lib.rs",
+      "reason": "Daemon process lifecycle IO boundary end to end (spawn plan, port record, disposition, registrar); zero answer-authority surface. Every filesystem and subprocess primitive here reaches or supervises the daemon that holds graph authority, never answers in its place, and no query result derives from any of them. Exempt whole-file rather than pinned because the process handle signatures repeat, which an exactly-once allow_match cannot express. lib.rs is the crate's only module, so a later-added module is scanned by default: re-review this exemption when a second .rs file joins the crate",
+      "owner": "kin-daemon-spawn",
+      "expiration": "2026-12-31"
     }
   ]
 }


### PR DESCRIPTION
Both paths that start a repo daemon now do it through one contract, and a
daemon is no longer killed for being slow.

## FIR-1596: one spawn contract

The MCP revival path and the CLI autostart path each carried their own copy of
how a daemon is started, and the MCP copy had drifted to a weaker version of
rules the CLI copy already enforced:

- it reserved a port with `find_mcp_free_port()` and passed the number, which
  is exactly the reserve-release-rebind race the CLI kills by passing
  `--port 0` and reading the port file
- `unwrap_or(4219)` bound a hardcoded fallback port when reservation failed,
  addressing whatever else was listening there instead of failing
- it never cleared a stale `daemon.port`, so the port read back could be a
  dead predecessor's
- it never registered the daemon with the supervisor, leaving every revived
  daemon out of supervisor routing

kin-cli depends on kin-mcp, and kin-mcp cannot depend on kin-daemon, so
neither crate could host the shared code. New crate `kin-daemon-spawn` sits
beneath both and holds the decisions that diverged: the daemon owns port
selection, the port comes back off the port file, a spawn that never learns a
port fails closed with no fallback, and a stale port record is cleared only
when no PID owner remains. Supervisor startup and registration stay in kin-cli
and reach the MCP path through an installed seam, so a revived daemon joins
supervisor routing like an autostarted one. The idle-timeout constant that was
duplicated across three crates now has one definition.

## FIR-1653: deadline is patience, not a death sentence

`wait_for_daemon_ready` called `child.kill()` whenever its deadline passed,
with no check that anything was wrong with the child. A daemon loading a large
graph was destroyed for being slow, and its replacement started cold into the
same deadline. Endpoint probing settled this in #481: only positive evidence
of death authorizes destruction. A child proven gone is reaped; a live one is
left holding its repo and reported as still starting, with the operator remedy
named.

`SingletonLockHolder` identified its owner by bare PID. PIDs are reused, so a
stamp naming a dead daemon began describing whatever unrelated process the
kernel handed that number to next, and readers reported a live daemon owning a
repo it had never heard of. The lock stamp now carries a process incarnation
(PID plus boot and creation instant, reusing kin-cli's existing
`ProcessIdentity`). Legacy bare-PID stamps are still read and report that
their liveness is not identity verified.

## Verification

Falsification tests, not just happy paths:

- a live-but-slow child is **not** killed at the deadline, and is still
  running afterwards (kin-daemon-spawn and kin-cli)
- an exited child **is** reaped, so the fix does not leak zombies
- the revival plan passes `--port 0` and no argument is ever `4219`
- the port comes from the port file; an absent, zero, or unparseable value is
  not a port
- a forged birth token on this process's own live PID reads as **not alive**,
  which is the recycled-PID case a bare PID cannot detect
- an orphaned port record is cleared, one beside a PID owner is not

Gates: `cargo fmt --all --check` clean, `cargo clippy --all-targets
--all-features` clean under the ci.yml allowlist with `-Dwarnings`,
`cargo build --all-targets --locked` clean, both CI boundary scripts pass.
Suites: kin-daemon-spawn 11/11, kin-mcp 267/267, kin-daemon 504/504, kin-cli
911/911. Three kin-cli tests in `commands/review.rs` and `commands/setup.rs`
fail on this machine only, where a global `core.hooksPath` blocks the fixture
`git commit`; they pass under `GIT_CONFIG_GLOBAL=/dev/null` and are untouched
by this change.

## Zero file-search allowlist

Moving the spawn path into `kin-daemon-spawn` removed two expressions the
allowlist pinned by exact text in `crates/kin-mcp/src/daemon_delegate.rs`:
`std::process::Command::new(&daemon_bin)` and
`use std::os::unix::process::CommandExt;`. Both pins are dropped rather than
relocated. The call site now reads `plan.command()`, which is not a primitive
the scanner flags, and the other nine pins on that entry still hold exactly
once.

`crates/kin-daemon-spawn/src/lib.rs` takes a whole-file entry. Its public
surface is the spawn plan, the port and pid records, startup disposition,
termination of a proven-dead child, and the registrar. It reaches and
supervises the process that holds graph authority and answers no query itself.
It is also not pinnable: `child: &mut std::process::Child,` occurs twice and
`allow_match` requires exactly one occurrence. Scoped to the file rather than
added to `BOUNDARY_DIRS` so a second module added to the crate is scanned by
default and has to justify itself.

Observed checker behavior, recorded here rather than changed: `load_allowlist`
exits before `main` walks `crates/`, so an allowlist error reports only its own
failures and the file scan never runs at all. On this branch that hid ten
violations in the extracted crate behind two pin errors. The gate still fails
closed, so nothing unsafe can merge; the cost is that a red allowlist
understates the work remaining behind it. No fix for that in this PR.

## Rebase-time repair: Windows dead code

The Windows authority build failed under `-D warnings`, before this branch was
rebased and independently of the allowlist work above:

```
error: variants `Alive` and `Dead` are never constructed
   --> crates\kin-daemon-spawn\src\lib.rs:275:5
    = note: `-D dead-code` implied by `-D warnings`
error: could not compile `kin-daemon-spawn` (lib) due to 1 previous error
```

`process_liveness` constructs `Liveness::Alive` and `Liveness::Dead` only
inside its `#[cfg(unix)]` branch; the `#[cfg(not(unix))]` branch returns
`Unknown` and nothing else. The match arms read both variants, but matching
does not count as constructing for the dead-code lint, so off unix they are
genuinely never constructed. The unix builds pass because there they are.

Scoped the allowance to the configuration that cannot construct them, rather
than allowing dead code outright, so enforcement still holds everywhere it can
fire:

```rust
#[cfg_attr(not(unix), allow(dead_code))]
enum Liveness {
```

Cross-checked locally against `x86_64-pc-windows-msvc`, the target CI builds
and the one this repo's pinned Rust 1.96.0 carries:

```
unmodified   error: variants `Alive` and `Dead` are never constructed   exit 101
with fix     Finished                                                   exit 0
host unix    Finished                                                   exit 0
```

Closes FIR-1596
Closes FIR-1653


