### PR TITLE
Integrate the test-harness build-identity gate, locate result ordering, and deterministic context-pack truncation

### DIFF
--- a/crates/kin-cli/src/commands/locate.rs
+++ b/crates/kin-cli/src/commands/locate.rs
@@ -1272,7 +1272,7 @@ pub async fn run(
     // Persist the paging cursor so `kin locate --next` can fetch the next page
     // without the caller re-supplying the query. Best-effort; never fatal.
     super::locate_cursor::persist_locate_cursor(result.next_cursor.as_deref());
-    output_result(&result, json);
+    output_result(&result, json, explain);
     Ok(())
 }
 
@@ -1428,7 +1428,7 @@ pub fn run_with_graph(
     max_files_explicit: bool,
 ) -> Result<()> {
     let result = run_with_graph_capture(graph, text, explain, max_files, max_files_explicit)?;
-    output_result(&result, json);
+    output_result(&result, json, explain);
     Ok(())
 }
 
@@ -15756,18 +15756,37 @@ fn coverage_banner(coverage: &SemanticCoverage) -> Option<String> {
     }))
 }
 
-fn output_result(result: &LocateResult, json: bool) {
+fn output_result(result: &LocateResult, json: bool, explain: bool) {
     if json {
         println!(
             "{}",
             serde_json::to_string_pretty(result).unwrap_or_default()
         );
     } else {
-        output_text(result);
+        output_text(result, explain);
     }
 }
 
-fn output_text(result: &LocateResult) {
+/// Render the ranked file list for the human surface.
+///
+/// `result.files` order IS the ranking, and it is the same order the JSON
+/// surface serializes, so the two surfaces agree by construction. That order is
+/// composed, not score-sorted: `adaptive_cap` emits the score-ordered cluster
+/// prefix and then appends re-admission groups (corroborated-past-cap, then
+/// pre-compression readmits ranked by their *uncompressed* evidence), and
+/// `fuse_locate_results` orders by fused RRF score while each row keeps the
+/// composite score of its best-ranked variant. A row's `score` is therefore an
+/// artifact of the stage that admitted it and is not comparable against a row
+/// admitted by a different stage.
+///
+/// Printing that score beside every row implied a sort key the list does not
+/// use, so a higher-scored row appearing below a lower-scored one read as a
+/// sorting bug. Re-sorting by the printed score is not the fix: it would
+/// discard the composed ranking and split the human surface from JSON. Instead
+/// the emitted rank is explicit, and the per-row score is held back for
+/// `--explain`, where it is one diagnostic among the per-signal and per-stage
+/// breakdowns rather than an implied ordering.
+fn output_text(result: &LocateResult, explain: bool) {
     // 0.1-R5: surface degraded semantic coverage on the main path. Written to
     // stderr so the stdout file list stays clean for piping.
     if let Some(banner) = result.semantic_coverage.as_ref().and_then(coverage_banner) {
@@ -15797,19 +15816,44 @@ fn output_text(result: &LocateResult) {
         return;
     }
 
-    for entry in &result.files {
-        println!(
-            "  {:<50} (score: {:.2}, signals: {})",
-            entry.path,
-            entry.score,
-            entry.signals.join(", ")
+    if explain {
+        eprintln!(
+            "ℹ ranked order is authoritative; per-row scores are stage-composed \
+and are not comparable between rows"
         );
-        if !entry.explain.is_empty() {
-            for reason in &entry.explain {
-                println!("    - {}", reason);
-            }
+    }
+
+    for line in locate_text_lines(result, explain) {
+        println!("{}", line);
+    }
+}
+
+/// The stdout lines `output_text` prints for the ranked file list, in order.
+///
+/// Split out from the printing so the emitted order and row shape are directly
+/// testable. Rows keep `result.files` order; see [`output_text`] for why that
+/// order is authoritative and why the per-row score is `--explain` only.
+fn locate_text_lines(result: &LocateResult, explain: bool) -> Vec<String> {
+    let mut lines = Vec::new();
+    for (index, entry) in result.files.iter().enumerate() {
+        let rank = index + 1;
+        let signals = entry.signals.join(", ");
+        if explain {
+            lines.push(format!(
+                "  {:>3}. {:<50} (score: {:.2}, signals: {})",
+                rank, entry.path, entry.score, signals
+            ));
+        } else {
+            lines.push(format!(
+                "  {:>3}. {:<50} (signals: {})",
+                rank, entry.path, signals
+            ));
+        }
+        for reason in &entry.explain {
+            lines.push(format!("    - {}", reason));
         }
     }
+    lines
 }
 
 #[cfg(test)]
@@ -16380,6 +16424,121 @@ mod tests {
         );
         bound_fused_declaration_to_primary(&mut fused, 10, false);
         assert_eq!(fused.files.len(), 3, "larger budget is a no-op");
+    }
+
+    /// A ranking whose emitted order is deliberately not score-descending, the
+    /// shape `adaptive_cap` produces when it appends a pre-compression readmit
+    /// (strong uncompressed evidence, compressed live score) below a
+    /// corroborated row that scored lower.
+    fn non_monotonic_ranking() -> LocateResult {
+        let entry = |path: &str, score: f32| -> LocateFileEntry {
+            serde_json::from_value(serde_json::json!({
+                "path": path,
+                "score": score,
+                "signals": ["lexical", "graph"],
+            }))
+            .expect("minimal file entry deserializes")
+        };
+        let mut result = LocateResult::default();
+        result.files = vec![
+            entry("src/top.rs", 120.00),
+            entry("src/corroborated.rs", 45.79),
+            entry("src/readmitted.rs", 85.10),
+        ];
+        result
+    }
+
+    #[test]
+    fn locate_text_rows_keep_ranked_order_over_printed_score() {
+        let result = non_monotonic_ranking();
+        let lines = locate_text_lines(&result, false);
+        let paths: Vec<&str> = lines
+            .iter()
+            .map(|line| line.split_whitespace().nth(1).unwrap())
+            .collect();
+        assert_eq!(
+            paths,
+            vec!["src/top.rs", "src/corroborated.rs", "src/readmitted.rs"],
+            "rows follow the composed ranking, not the printed score: {lines:?}"
+        );
+        assert!(
+            lines[0].starts_with("    1. "),
+            "rank is explicit and 1-based: {:?}",
+            lines[0]
+        );
+        assert!(
+            lines[2].starts_with("    3. "),
+            "rank keeps counting with the emitted order: {:?}",
+            lines[2]
+        );
+    }
+
+    #[test]
+    fn locate_text_rows_omit_incomparable_score_by_default() {
+        let lines = locate_text_lines(&non_monotonic_ranking(), false);
+        for line in &lines {
+            assert!(
+                !line.contains("score:"),
+                "a cross-row-incomparable score must not imply a sort key: {line:?}"
+            );
+            assert!(
+                line.contains("(signals: lexical, graph)"),
+                "signals still explain why a row was admitted: {line:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn locate_text_rows_carry_score_under_explain() {
+        let lines = locate_text_lines(&non_monotonic_ranking(), true);
+        assert!(
+            lines[1].contains("(score: 45.79, signals: lexical, graph)"),
+            "explain keeps the score as a diagnostic: {:?}",
+            lines[1]
+        );
+        assert!(
+            lines[2].contains("(score: 85.10, signals: lexical, graph)"),
+            "explain keeps the score as a diagnostic: {:?}",
+            lines[2]
+        );
+    }
+
+    #[test]
+    fn locate_text_order_matches_json_order() {
+        let result = non_monotonic_ranking();
+        let json: serde_json::Value =
+            serde_json::to_value(&result).expect("locate result serializes");
+        let json_paths: Vec<String> = json["files"]
+            .as_array()
+            .expect("files array")
+            .iter()
+            .map(|f| f["path"].as_str().expect("path string").to_string())
+            .collect();
+        let text_paths: Vec<String> = locate_text_lines(&result, false)
+            .iter()
+            .map(|line| line.split_whitespace().nth(1).unwrap().to_string())
+            .collect();
+        assert_eq!(
+            text_paths, json_paths,
+            "the human and JSON surfaces must present one ranking"
+        );
+    }
+
+    #[test]
+    fn locate_text_indents_explain_reasons_under_their_row() {
+        let mut result = non_monotonic_ranking();
+        result.files[0].explain = vec!["seeded by entity resolve".to_string()];
+        let lines = locate_text_lines(&result, true);
+        assert!(lines[0].contains("src/top.rs"), "{:?}", lines[0]);
+        assert_eq!(
+            lines[1], "    - seeded by entity resolve",
+            "reasons stay attached to the row above them"
+        );
+        assert!(
+            lines[2].contains("src/corroborated.rs"),
+            "the next ranked row follows its predecessor's reasons: {:?}",
+            lines[2]
+        );
     }
 
     #[test]

--- a/crates/kin-cli/tests/common/mod.rs
+++ b/crates/kin-cli/tests/common/mod.rs
@@ -159,27 +159,109 @@ fn read_capture(mut file: std::fs::File) -> std::io::Result<Vec<u8>> {
     Ok(bytes)
 }
 
-fn daemon_compat_ok(path: &Path) -> bool {
+/// The build identity this test binary carries, in the exact form the daemon
+/// stamps persisted vector sidecars with.
+///
+/// A test that seeds prepared state writes this stamp; the daemon that later
+/// reopens the repository demands its own. The two only agree when both
+/// binaries came out of one build of `kin-buildinfo`.
+pub fn expected_build_stamp() -> String {
+    kin_buildinfo::sha_with_dirty(kin_buildinfo::get())
+}
+
+/// Recompose a `--compat-json` `build.sha` / `build.dirty` pair into the stamp
+/// `kin_buildinfo::sha_with_dirty` would produce for the same build.
+///
+/// The daemon reports the two fields separately, so the harness has to join
+/// them the way the authority does rather than comparing the pair directly:
+/// when the commit is unknown the dirty flag is not part of the identity, and
+/// a raw pair comparison would reject a daemon whose embedder identity
+/// actually matches.
+fn build_stamp(sha: &str, dirty: bool) -> String {
+    if dirty && sha != "unknown" {
+        format!("{sha}-dirty")
+    } else {
+        sha.to_string()
+    }
+}
+
+/// Why a candidate `kin-daemon` may not be reused by this test binary, or
+/// `None` when it may be.
+///
+/// Two independent reasons, and the second is the one that used to be missed.
+/// A daemon whose graph snapshot version differs cannot read the repository at
+/// all. A daemon that is merely built from a *different commit or working
+/// tree* reads it fine, but stamps and demands a different embedder identity —
+/// so a sidecar seeded by this test binary is rejected on load,
+/// `indexed_embedding_count` reads 0, and the suite reports a product defect
+/// that only exists because two binaries in one target directory were built at
+/// different times.
+pub fn daemon_compat_mismatch(
+    payload: &Value,
+    expected_snapshot_version: u64,
+    expected_stamp: &str,
+) -> Option<String> {
+    match payload["graph_snapshot_version"].as_u64() {
+        Some(version) if version == expected_snapshot_version => {}
+        Some(version) => {
+            return Some(format!(
+                "graph snapshot version {version} does not match this test binary's {expected_snapshot_version}"
+            ));
+        }
+        None => return Some("compat payload has no graph_snapshot_version".to_string()),
+    }
+
+    let Some(sha) = payload["build"]["sha"].as_str() else {
+        return Some("compat payload has no build.sha".to_string());
+    };
+    let Some(dirty) = payload["build"]["dirty"].as_bool() else {
+        return Some("compat payload has no build.dirty".to_string());
+    };
+
+    let daemon_stamp = build_stamp(sha, dirty);
+    if daemon_stamp != expected_stamp {
+        return Some(format!(
+            "daemon build identity {daemon_stamp} does not match this test binary's {expected_stamp}"
+        ));
+    }
+    None
+}
+
+fn daemon_compat(path: &Path) -> Result<(), String> {
     if !path.exists() {
-        return false;
+        return Err(format!("{} does not exist", path.display()));
     }
-    let Ok(output) = Command::new(path).arg("--compat-json").output() else {
-        return false;
-    };
+    let output = Command::new(path)
+        .arg("--compat-json")
+        .output()
+        .map_err(|error| format!("could not run {} --compat-json: {error}", path.display()))?;
     if !output.status.success() {
-        return false;
+        return Err(format!(
+            "{} --compat-json exited with {}",
+            path.display(),
+            output.status
+        ));
     }
-    let Ok(payload) = serde_json::from_slice::<Value>(&output.stdout) else {
-        return false;
-    };
-    payload["graph_snapshot_version"].as_u64()
-        == Some(kin_db::GraphSnapshot::CURRENT_VERSION as u64)
+    let payload = serde_json::from_slice::<Value>(&output.stdout).map_err(|error| {
+        format!(
+            "{} --compat-json did not emit JSON: {error}",
+            path.display()
+        )
+    })?;
+    match daemon_compat_mismatch(
+        &payload,
+        kin_db::GraphSnapshot::CURRENT_VERSION as u64,
+        &expected_build_stamp(),
+    ) {
+        Some(reason) => Err(reason),
+        None => Ok(()),
+    }
 }
 
 pub fn fresh_daemon_bin() -> PathBuf {
     let kin_bin = PathBuf::from(env!("CARGO_BIN_EXE_kin"));
     let daemon_bin = kin_bin.with_file_name("kin-daemon");
-    if daemon_compat_ok(&daemon_bin) {
+    if daemon_compat(&daemon_bin).is_ok() {
         return daemon_bin;
     }
 
@@ -203,10 +285,18 @@ pub fn fresh_daemon_bin() -> PathBuf {
         );
     });
 
-    assert!(
-        daemon_compat_ok(&daemon_bin),
-        "kin-daemon at {} is missing or incompatible after rebuild",
-        daemon_bin.display()
-    );
+    if let Err(reason) = daemon_compat(&daemon_bin) {
+        panic!(
+            "kin-daemon at {} is unusable after rebuild: {reason}.\n\
+             This test binary carries build identity {}. A daemon built from a \
+             different commit or working tree stamps persisted vector sidecars \
+             with a different embedder identity, so state this suite seeds is \
+             rejected on reopen and indexed_embedding_count reads 0 — a harness \
+             fault that reads as a product defect. Build both from one tree: \
+             cargo build --all-targets",
+            daemon_bin.display(),
+            expected_build_stamp()
+        );
+    }
     daemon_bin
 }

--- a/crates/kin-cli/tests/daemon_compat_gate.rs
+++ b/crates/kin-cli/tests/daemon_compat_gate.rs
@@ -1,0 +1,108 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Firelock, LLC
+
+//! The reuse decision behind `common::fresh_daemon_bin`.
+//!
+//! A daemon that is version-compatible but built from a different tree is the
+//! failure this gate exists for: it serves the repository correctly and then
+//! rejects every vector sidecar the test binary seeded, because the two stamp
+//! different embedder identities. The suite then reports zero indexed
+//! embeddings as a product defect. These cases pin the comparison so that
+//! skew is caught and named instead.
+
+use serde_json::json;
+
+mod common;
+
+use common::{daemon_compat_mismatch, expected_build_stamp};
+
+const VERSION: u64 = 9;
+const SHA: &str = "1111111111111111111111111111111111111111";
+const OTHER_SHA: &str = "2222222222222222222222222222222222222222";
+
+fn payload(sha: &str, dirty: bool, version: u64) -> serde_json::Value {
+    json!({
+        "schema": "kin.daemon.compat.v1",
+        "graph_snapshot_version": version,
+        "build": { "sha": sha, "dirty": dirty },
+    })
+}
+
+#[test]
+fn matching_version_and_build_identity_is_reusable() {
+    assert_eq!(
+        daemon_compat_mismatch(&payload(SHA, false, VERSION), VERSION, SHA),
+        None
+    );
+}
+
+#[test]
+fn snapshot_version_skew_is_still_caught() {
+    let reason = daemon_compat_mismatch(&payload(SHA, false, VERSION + 1), VERSION, SHA)
+        .expect("a daemon on another snapshot version must not be reused");
+    assert!(
+        reason.contains(&(VERSION + 1).to_string()) && reason.contains(&VERSION.to_string()),
+        "reason must name both versions, got {reason}"
+    );
+}
+
+#[test]
+fn build_identity_skew_names_both_stamps() {
+    let reason = daemon_compat_mismatch(&payload(OTHER_SHA, false, VERSION), VERSION, SHA)
+        .expect("a daemon built from another commit must not be reused");
+    assert!(
+        reason.contains(OTHER_SHA) && reason.contains(SHA),
+        "reason must name the daemon stamp and the test binary stamp, got {reason}"
+    );
+}
+
+#[test]
+fn dirty_flag_skew_is_a_mismatch() {
+    let reason = daemon_compat_mismatch(&payload(SHA, true, VERSION), VERSION, SHA)
+        .expect("a dirty daemon must not be reused by a clean test binary");
+    assert!(
+        reason.contains(&format!("{SHA}-dirty")),
+        "reason must name the dirty stamp, got {reason}"
+    );
+}
+
+/// With no commit id there is no identity to skew, and `sha_with_dirty` drops
+/// the dirty flag. Comparing the raw pair instead of the joined stamp would
+/// reject a daemon whose embedder identity actually matches, and no rebuild
+/// would ever clear it.
+#[test]
+fn unknown_commit_ignores_the_dirty_flag() {
+    assert_eq!(
+        daemon_compat_mismatch(&payload("unknown", true, VERSION), VERSION, "unknown"),
+        None
+    );
+}
+
+#[test]
+fn a_compat_payload_without_build_identity_is_not_reusable() {
+    let payload = json!({ "graph_snapshot_version": VERSION });
+    let reason = daemon_compat_mismatch(&payload, VERSION, SHA)
+        .expect("a daemon that reports no build identity must not be reused");
+    assert!(
+        reason.contains("build.sha"),
+        "reason must name the missing field, got {reason}"
+    );
+}
+
+/// Pins the harness's `build.sha` + `build.dirty` join against
+/// `kin_buildinfo::sha_with_dirty`, which is what the daemon actually stamps
+/// sidecars with. If that rule changes and this join does not, every daemon
+/// would look skewed and no rebuild would clear it.
+#[test]
+fn the_joined_stamp_agrees_with_kin_buildinfo() {
+    let info = kin_buildinfo::get();
+    assert_eq!(
+        daemon_compat_mismatch(
+            &payload(info.sha, info.dirty, VERSION),
+            VERSION,
+            &expected_build_stamp()
+        ),
+        None,
+        "this binary's own build identity must read as reusable"
+    );
+}

--- a/crates/kin-context/src/builder.rs
+++ b/crates/kin-context/src/builder.rs
@@ -445,7 +445,11 @@ where
                         )
                 })
                 .collect::<Vec<_>>();
-            entities.sort_by_key(|entity| same_file_neighbor_rank(&focal, entity));
+            // Same total-order requirement as the weight sort below: the rank is
+            // three coarse buckets, so neighbours tie routinely, and only the
+            // first six survive. Ranking on entity id last keeps the survivors
+            // from depending on the order `query_entities` happened to return.
+            entities.sort_by_key(|entity| (same_file_neighbor_rank(&focal, entity), entity.id));
             entities
         } else {
             Vec::new()
@@ -465,6 +469,16 @@ where
     // Sort subgraph entities by descending relation weight so that when the
     // token budget is tight, high-signal entities (Calls, DependsOn) are
     // included before low-signal ones (References, Contains).
+    //
+    // Entity id breaks weight ties into a total order. `subgraph.entities` is a
+    // hash map, so the collected order varies between invocations; relation
+    // weight comes from a small set of per-kind constants, so equal weights are
+    // the common case rather than an edge case. Ordering on weight alone would
+    // leave tied candidates in hash order, and the budget fold below admits
+    // greedily in this order, so the surviving set would differ run to run for
+    // an unchanged graph. `total_cmp` keeps the comparator total even if a
+    // weight is ever NaN, which would otherwise collapse to `Equal` and
+    // reintroduce the same nondeterminism through a broken ordering.
     let mut sorted_entities: Vec<(&EntityId, &Entity)> = subgraph
         .entities
         .iter()
@@ -473,7 +487,7 @@ where
     sorted_entities.sort_by(|(a_id, _), (b_id, _)| {
         let wa = weight_map.get(a_id).copied().unwrap_or(0.0);
         let wb = weight_map.get(b_id).copied().unwrap_or(0.0);
-        wb.partial_cmp(&wa).unwrap_or(std::cmp::Ordering::Equal)
+        wb.total_cmp(&wa).then_with(|| a_id.cmp(b_id))
     });
 
     let mut dep_entries = Vec::new();
@@ -680,12 +694,17 @@ where
     }
 
     append_supporting_artifacts(graph, &mut pack, &supporting_files, budget_max)?;
+    // Dedup in encounter order rather than through a set. `supporting_artifacts`
+    // is already ordered by file path, and `append_artifact_scoped_metadata`
+    // admits the work items and annotations it finds under the same token
+    // budget, so draining a hash set here would let arbitrary iteration order
+    // decide which metadata survives a tight budget.
+    let mut seen_supporting_files = std::collections::HashSet::new();
     let supporting_files: Vec<FilePathId> = pack
         .supporting_artifacts
         .iter()
         .map(|entry| entry.file_path.clone())
-        .collect::<std::collections::HashSet<_>>()
-        .into_iter()
+        .filter(|path| seen_supporting_files.insert(path.clone()))
         .collect();
     if !supporting_files.is_empty() {
         append_artifact_scoped_metadata(graph, &mut pack, &supporting_files, budget_max)?;
@@ -1257,6 +1276,106 @@ mod tests {
             admitted(&b),
             "parallel context-pack assembly must admit a stable set"
         );
+    }
+
+    #[test]
+    fn tight_budget_truncation_is_deterministic_across_invocations() {
+        use kin_model::relation::{Relation, RelationKind, RelationOrigin};
+
+        // Equal-weight (all `Calls`) candidates with fixed-width names, so every
+        // projection costs the same tokens and relation weight alone cannot order
+        // them. Which candidates survive a tight budget is then decided purely by
+        // the tie-break, which is exactly what must not vary between runs.
+        let n = PARALLEL_ASSEMBLY_MIN_ENTITIES + 24;
+        let focal = make_entity("focal", EntityKind::Function);
+        let deps: Vec<Entity> = (0..n)
+            .map(|i| make_entity(&format!("dep_{i:04}"), EntityKind::Function))
+            .collect();
+
+        // Two stores holding the same entity ids, populated in opposite orders.
+        // A correct builder owes both the same answer; an order-sensitive one
+        // does not. Insertion order also perturbs the graph's own hash layout.
+        let store_of = |reverse: bool| {
+            let store = kin_db::InMemoryGraph::new();
+            store.upsert_entity(&focal).unwrap();
+            let ordered: Vec<&Entity> = if reverse {
+                deps.iter().rev().collect()
+            } else {
+                deps.iter().collect()
+            };
+            for dep in ordered {
+                store.upsert_entity(dep).unwrap();
+                store
+                    .upsert_relation(&Relation {
+                        id: kin_model::ids::RelationId::new(),
+                        kind: RelationKind::Calls,
+                        src: GraphNodeId::Entity(focal.id),
+                        dst: GraphNodeId::Entity(dep.id),
+                        confidence: 1.0,
+                        origin: RelationOrigin::Parsed,
+                        created_in: None,
+                        import_source: None,
+                        evidence: Vec::new(),
+                    })
+                    .unwrap();
+            }
+            store
+        };
+
+        let forward = store_of(false);
+        let reverse = store_of(true);
+
+        let admitted = |p: &ContextPack| {
+            let mut ids: Vec<_> = p
+                .dependency_signatures
+                .iter()
+                .map(|e| e.entity_id)
+                .collect();
+            ids.sort();
+            ids
+        };
+
+        // Size the budget off an unconstrained pack so the cut lands mid-list
+        // regardless of how projection costs change later.
+        let full = build_context_pack(
+            &forward,
+            &focal.id,
+            &ContextOptions {
+                budget: TokenBudget::Large32k,
+                ..ContextOptions::default()
+            },
+        )
+        .unwrap();
+        let opts = ContextOptions {
+            budget: TokenBudget::Custom(full.actual_tokens / 2),
+            ..ContextOptions::default()
+        };
+
+        let baseline = build_context_pack(&forward, &focal.id, &opts).unwrap();
+        let kept = baseline.dependency_signatures.len();
+        assert!(
+            kept > 0 && kept < full.dependency_signatures.len(),
+            "budget must actually truncate for this test to mean anything: kept {kept} of {}",
+            full.dependency_signatures.len()
+        );
+
+        // Repeated invocations rebuild the neighborhood subgraph, and each rebuild
+        // gets a freshly seeded hash map, so an order-sensitive selection diverges
+        // here without needing separate processes.
+        for run in 1..16 {
+            let again = build_context_pack(&forward, &focal.id, &opts).unwrap();
+            assert_eq!(
+                admitted(&again),
+                admitted(&baseline),
+                "invocation {run} admitted a different set under the same budget"
+            );
+            let mirrored = build_context_pack(&reverse, &focal.id, &opts).unwrap();
+            assert_eq!(
+                admitted(&mirrored),
+                admitted(&baseline),
+                "invocation {run} admitted a different set when the graph was populated in reverse"
+            );
+        }
     }
 
     fn make_artifact_work_item(title: &str, file_path: &FilePathId) -> WorkItem {


### PR DESCRIPTION
Integrates three independently reviewed and fully green changes that went behind main under the strict up-to-dateness rule, combined here so one CI cycle lands all three. The CLI integration harness now gates test daemon reuse on build identity rather than on `graph_snapshot_version` alone, comparing the daemon's `build.sha` and `build.dirty` from `--compat-json` against the test binary's own stamp and joining them the way `sha_with_dirty` does, so a leftover daemon from an earlier build no longer passes validation, writes a mismatched embedder identity into persisted vector sidecars, and turns a build skew into a misattributed product defect. `kin locate` stops printing a per-row score that implied a sort key the composed ranking does not use, emitting an explicit rank instead and holding the score back for `--explain`, since a row's score is an artifact of the stage that admitted it and does not compare across stages. Context-pack assembly orders candidates by a total order before budget admission, breaking relation-weight ties on entity id and comparing with `total_cmp` so a NaN weight cannot collapse the comparator to `Equal`, and deduping supporting files in encounter order, so a greedy token budget cutting mid-list yields the same surviving set on every invocation of an unchanged graph. The three touch disjoint areas and cherry-picked without conflict.

Closes FIR-1607
Closes FIR-1518
Closes FIR-1546
Part of FIR-1582
Supersedes #486, #488, #489.
