### PR TITLE
Fix the cargo-fuzz build and scope the per-PR fuzz job to compiling

### DIFF
--- a/.github/workflows/fuzz.yml
+++ b/.github/workflows/fuzz.yml
@@ -10,13 +10,24 @@
 # The invariant under test is that the parser is total on arbitrary input -- it
 # returns a value or a handled error and never panics, crashes, or hits UB.
 #
-# Triggers:
-#   - pull_request touching the parser crate or the harness: a short smoke per
-#     target keeps regressions out of `main` without slowing every PR.
-#   - schedule (weekly): a longer bounded campaign for drift detection.
-#   - workflow_dispatch: on-demand runs.
+# Triggers, and what each one is for:
+#   - pull_request: BUILD ONLY, no campaign. The fuzz package is a detached
+#     workspace, so nothing in the ordinary `cargo build --workspace` / clippy
+#     gate ever compiles these targets; this is the only pre-merge check that
+#     they still match the surface they exercise. Compiling is cheap and
+#     deterministic, whereas a timed campaign on a PR spends minutes to sample a
+#     little entropy and can fail for reasons the PR did not cause.
+#   - schedule (weekly) and workflow_dispatch: build plus a bounded campaign,
+#     which is where actually looking for crashes belongs.
 #
-# Every run has a hard `-max_total_time` wall-clock cap plus a per-input
+# The pull_request paths deliberately include the dependency-pin surface and not
+# just the harness. The build last broke because a kin-model major bump in the
+# root manifest desynchronized the versions this package resolved -- a change
+# touching neither `crates/kin-parser/**` nor `fuzz/**`, so no PR run fired and
+# the breakage sat until the following weekly run. Watching the pins that the
+# harness compiles against is what puts that class of drift in front of a PR.
+#
+# Every campaign has a hard `-max_total_time` wall-clock cap plus a per-input
 # `-timeout`, so neither a single pathological input nor the campaign as a whole
 # can hang the runner.
 
@@ -29,6 +40,10 @@ on:
       - "crates/kin-parser/**"
       - "fuzz/**"
       - ".github/workflows/fuzz.yml"
+      # Root manifest carries the kin-model / tree-sitter pins kin-parser
+      # inherits; .cargo/config.toml carries the registry they resolve through.
+      - "Cargo.toml"
+      - ".cargo/config.toml"
   schedule:
     # Mondays 06:00 UTC.
     - cron: "0 6 * * 1"
@@ -54,18 +69,25 @@ jobs:
     steps:
       - uses: actions/checkout@v7
 
-      # kin-model resolves from the Kin sparse registry ([registries.kin]). The
-      # fuzz crate is detached from the kin workspace, but Cargo still discovers
-      # the tracked .cargo/config.toml by walking up from fuzz/, so the registry
-      # is configured exactly as for a normal kin build.
+      # kin-parser's transitive kin-model resolves from the Kin sparse registry
+      # ([registries.kin]). The fuzz crate is detached from the kin workspace,
+      # but Cargo still discovers the tracked .cargo/config.toml by walking up
+      # from fuzz/, so the registry is configured exactly as for a normal kin
+      # build.
       - name: Verify kin cargo registry config
         run: |
           test -f .cargo/config.toml
           grep -q '^\[registries\.kin\]' .cargo/config.toml
 
-      # cargo-fuzz requires nightly (libFuzzer + -Zsanitizer).
+      # cargo-fuzz requires nightly (libFuzzer + -Zsanitizer), so this job cannot
+      # use the repo's pinned stable from rust-toolchain.toml. Pin a dated
+      # nightly for the same reason that file pins stable: an unpinned @nightly
+      # lets a green build turn red with no change to this repository, and the
+      # failure then has to be told apart from a real one. Bump DELIBERATELY.
       - name: Install nightly toolchain
-        uses: dtolnay/rust-toolchain@nightly
+        uses: dtolnay/rust-toolchain@master
+        with:
+          toolchain: nightly-2026-06-17
 
       - name: Cache cargo registry and fuzz build
         uses: actions/cache@v6
@@ -74,29 +96,40 @@ jobs:
             ~/.cargo/registry
             ~/.cargo/git
             fuzz/target
-          key: ${{ runner.os }}-parser-fuzz-${{ hashFiles('fuzz/Cargo.toml', 'crates/kin-parser/**') }}
+          # Keyed on the toolchain pin as well as the sources, so bumping the
+          # nightly cannot restore objects built by the previous one. The root
+          # manifest is in the hash because it carries the dependency pins
+          # kin-parser inherits.
+          key: ${{ runner.os }}-parser-fuzz-nightly-2026-06-17-${{ hashFiles('fuzz/Cargo.toml', 'Cargo.toml', 'crates/kin-parser/**') }}
           restore-keys: |
-            ${{ runner.os }}-parser-fuzz-
+            ${{ runner.os }}-parser-fuzz-nightly-2026-06-17-
 
+      # Version-pinned alongside the toolchain: an unpinned cargo-fuzz is the
+      # same reproducibility hole as an unpinned toolchain. `--locked` pins its
+      # own dependency versions too. Deliberately still `cargo install` rather
+      # than taiki-e/install-action, which does not carry cargo-fuzz and would
+      # quietly fall back to cargo-binstall.
       - name: Install cargo-fuzz
-        run: cargo install cargo-fuzz --locked
+        run: cargo install cargo-fuzz --version 0.13.1 --locked
 
       - name: Build fuzz target
-        run: cargo +nightly fuzz build ${{ matrix.target }}
+        run: cargo +nightly-2026-06-17 fuzz build ${{ matrix.target }}
 
-      # Bounded campaign: 300s/target on the weekly schedule, 60s on PRs/dispatch.
+      # Bounded campaign: 300s/target on the weekly schedule, 60s on dispatch.
+      # Skipped on pull_request, where the build step above is the whole gate.
       # `-timeout` caps any single input; `-rss_limit_mb` guards against a runaway
       # allocation aborting the runner. EVENT_NAME / TARGET are mapped through env
       # (not interpolated into the shell) per GitHub Actions injection-hardening
       # guidance.
       - name: Run bounded fuzz campaign
+        if: github.event_name != 'pull_request'
         env:
           EVENT_NAME: ${{ github.event_name }}
           TARGET: ${{ matrix.target }}
         run: |
           DURATION=60
           if [ "$EVENT_NAME" = "schedule" ]; then DURATION=300; fi
-          cargo +nightly fuzz run "$TARGET" -- \
+          cargo +nightly-2026-06-17 fuzz run "$TARGET" -- \
             -max_total_time="$DURATION" -timeout=25 -rss_limit_mb=2048
 
       - name: Upload crash artifacts on failure

--- a/crates/kin-parser/src/lib.rs
+++ b/crates/kin-parser/src/lib.rs
@@ -38,6 +38,14 @@ pub mod languages;
 pub mod shallow;
 pub mod todos;
 
+/// Re-exported because this crate's public signatures name it: `LanguageAdapter::extract`
+/// and [`parse_shallow_file`] both take a `&FilePathId`. Without the re-export a caller
+/// must declare its own `kin-model` dependency purely to spell the argument type, and any
+/// version skew between that dependency and the one this crate resolves produces two
+/// distinct `FilePathId` types and a mismatched-types error at the call site. Reaching the
+/// type through `kin_parser` makes that skew unrepresentable.
+pub use kin_model::FilePathId;
+
 pub use adapter::{EditHint, LanguageAdapter};
 pub use error::{ParseError, Result};
 pub use extract::{

--- a/fuzz/Cargo.toml
+++ b/fuzz/Cargo.toml
@@ -13,9 +13,17 @@
 # the parent kin workspace and is built only by the Fuzz CI workflow, never by
 # the standard `cargo build --workspace` / clippy gate. kin-parser is pulled in
 # by path; its `workspace = true` dependency inheritance still resolves from the
-# kin workspace root, so kin-model resolves from the Kin registry exactly as in a
-# normal kin build (Cargo discovers the tracked .cargo/config.toml by walking up
-# from this directory).
+# kin workspace root, so its transitive kin-model comes from the Kin registry at
+# whatever version that root pins (Cargo discovers the tracked .cargo/config.toml
+# by walking up from this directory).
+#
+# Deliberately no direct kin-model dependency. Being a detached workspace, this
+# manifest cannot inherit the root's pin via `workspace = true`, so a version
+# written here is a second, independently-drifting pin: once the root moved to a
+# semver-incompatible kin-model, both versions compiled and the shared
+# `FilePathId` became two distinct types. The targets reach that type through
+# `kin_parser`'s re-export instead, leaving kin-parser as the single edge into
+# the kin dependency graph and the duplicate unrepresentable.
 
 [package]
 name = "kin-parser-fuzz"
@@ -30,7 +38,6 @@ cargo-fuzz = true
 [dependencies]
 libfuzzer-sys = "0.4"
 kin-parser = { path = "../crates/kin-parser" }
-kin-model = { version = "0.2.1", registry = "kin" }
 
 [workspace]
 

--- a/fuzz/fuzz_targets/parse_adapter.rs
+++ b/fuzz/fuzz_targets/parse_adapter.rs
@@ -14,8 +14,7 @@
 
 #![no_main]
 
-use kin_model::FilePathId;
-use kin_parser::AdapterRegistry;
+use kin_parser::{AdapterRegistry, FilePathId};
 use libfuzzer_sys::fuzz_target;
 
 fuzz_target!(|data: &[u8]| {

--- a/fuzz/fuzz_targets/parse_shallow.rs
+++ b/fuzz/fuzz_targets/parse_shallow.rs
@@ -14,8 +14,7 @@
 
 #![no_main]
 
-use kin_model::FilePathId;
-use kin_parser::parse_shallow_file;
+use kin_parser::{parse_shallow_file, FilePathId};
 use libfuzzer_sys::fuzz_target;
 
 // Language hints accepted by `get_shallow_grammar`.

--- a/scripts/test-release-workflow-authority.py
+++ b/scripts/test-release-workflow-authority.py
@@ -3546,14 +3546,24 @@ def main() -> None:
 
     field_compensation = dict(workflow_sources)
     field_compensation[ci_path] = unbound_ci
-    fuzz_key = (
-        "          key: ${{ runner.os }}-parser-fuzz-"
-        "${{ hashFiles('fuzz/Cargo.toml', 'crates/kin-parser/**') }}\n"
-    )
-    if field_compensation[fuzz_path].count(fuzz_key) != 1:
+    # Matched by prefix, not by the whole line. What this falsification needs is
+    # an active field on an unrelated cache step; which inputs the fuzz key
+    # happens to hash, and whether it carries a toolchain pin, is incidental to
+    # that and changes whenever the fuzz job is retuned. Pinning the exact text
+    # here would fail the release-authority suite for an unrelated edit. The
+    # `key:` prefix still distinguishes it from the `restore-keys:` entries,
+    # which are indented further and carry no field name.
+    fuzz_key_prefix = "          key: ${{ runner.os }}-parser-fuzz-"
+    fuzz_key_matches = [
+        line
+        for line in field_compensation[fuzz_path].splitlines(keepends=True)
+        if line.startswith(fuzz_key_prefix)
+    ]
+    if len(fuzz_key_matches) != 1:
         raise AssertionError(
             "cache falsification could not identify the unrelated fuzz cache step"
         )
+    fuzz_key = fuzz_key_matches[0]
     field_compensation[fuzz_path] = field_compensation[fuzz_path].replace(
         fuzz_key,
         fuzz_key + f"          {MAIN_ONLY_CACHE_SAVE}\n",


### PR DESCRIPTION
Both cargo-fuzz targets have failed at the **Build fuzz target** step since 2026-07-27 (first red: main run 30255923093; last green 2026-07-20). This restores them and settles whether the job belongs on the PR path.

## Root cause

**Duplicate, semver-incompatible `kin-model` in the fuzz package's dependency graph.** Not toolchain drift, and not the repository-v6 cutover.

`fuzz/Cargo.toml` declares its own empty `[workspace]`, so it is detached from the kin workspace and **cannot** inherit the root's pins via `workspace = true`. It therefore carried an independent pin, `kin-model = { version = "0.2.1", registry = "kin" }`. `kin-parser` comes in by path, and *its* `kin-model = { workspace = true }` resolves from the kin workspace root. Once the root pin crossed a major boundary, Cargo compiled **both** versions and the shared `FilePathId` became two distinct types:

```
error[E0308]: mismatched types
   --> fuzz_targets/parse_adapter.rs:30:50
 30 |             let _ = adapter.extract(&tree, data, &file_id);
    |                             -------              ^^^^^^^^ expected `kin_model::ids::FilePathId`, found `FilePathId`
note: there are multiple different versions of crate `kin_model` in the dependency graph
    --> .../kin-model-0.4.0/src/ids.rs:142:1     <- this is the expected type
    ::: .../kin-model-0.2.6/src/ids.rs:142:1     <- this is the found type
```

`git log -L` on the root manifest's `kin-model` line puts the transition inside the green→red window:

| commit | date | change |
|---|---|---|
| `4bff31aa` "Harden exact source release authority for Kin 0.3.0 (#399)" | **2026-07-22** | `0.2.5` → `=0.4.0` ← **the break** |
| `ec008ff5` / `59af20f6` / `2bbb55f1` / `f3220615` | since | `=0.4.0` → `=0.5.0` → `=0.6.0` → `=0.6.1` → `=0.6.4` |

Before `4bff31aa` the root sat on `0.2.5`, semver-compatible with the fuzz pin, so Cargo unified them. `fuzz/Cargo.toml` had not been touched since it was introduced in #99, so its pin never followed.

Ruled out, with evidence:
- **Unpinned nightly** — `E0308` on duplicate crate versions is toolchain-independent, and it reproduces on a pinned `nightly-2026-06-17`. (The workflow *was* on unpinned `@nightly`; hardened below, but that was not the cause.)
- **repository-v6 / PR 447** — no API was removed. `FilePathId` still exists at the same path with an identical definition in both versions; the two types differ only because they come from two crate *instances*.
- **Dependabot** — no dependabot change touches that pin; the table above accounts for every movement of the line.

## Fix

Re-synchronizing the pin would have gone red again on the next bump — the root moved **five times in seven days**. So the dependency is removed instead of realigned:

- `fuzz/Cargo.toml` drops its direct `kin-model` dependency, leaving `kin-parser` as the package's single edge into the kin dependency graph. The duplicate becomes unrepresentable rather than merely re-aligned.
- `kin-parser` re-exports `FilePathId`. This is additive and arguably owed: kin-parser's public signatures (`LanguageAdapter::extract`, `parse_shallow_file`) already *name* the type, so until now every consumer had to declare its own `kin-model` dependency purely to spell an argument type — and any skew reproduced exactly this bug.

Coverage is unchanged: both harnesses still drive the real surfaces (`AdapterRegistry` parse+extract across every built-in grammar; `parse_shallow_file` across all six shallow hints). Nothing was stubbed, retargeted, or dropped.

```
$ cargo tree --manifest-path fuzz/Cargo.toml -i kin-model
kin-model v0.6.4 (registry `kin`)
└── kin-parser v0.3.6 (crates/kin-parser)
    └── kin-parser-fuzz v0.0.0 (fuzz)
```

Separately, the toolchain is pinned: `@nightly` → `nightly-2026-06-17`, cargo-fuzz pinned to `0.13.1`, and the build cache keyed on the pin. Every other workflow already pins (`@1.96.0` in ci.yml ×4, release.yml, sast.yml, daemon-smoke.yml); fuzz was the lone outlier, against the doctrine stated in `rust-toolchain.toml` ("Bump DELIBERATELY … never by @stable drift").

## Policy

**Fuzz stays per-PR as a compile-only gate; the timed campaign moves to schedule + dispatch.**

Findings behind that choice:

- **The fuzz contexts are not required.** Ruleset "Require status checks on main" requires exactly `Check & Test (ubuntu-latest)`, `Check & Test (macos-latest)`, `DCO Sign-off`, `cargo-deny`, `gitleaks (full history)`, and `Windows installer + vector-free release build`. Fuzz never blocked a merge.
- **Correction to the premise that every PR carried two red checks.** The workflow is paths-filtered, so only PRs touching `crates/kin-parser/**`, `fuzz/**`, or the workflow ran it — PR 491 has both red checks; PRs 493 and 494 have none. The blast radius was parser-touching PRs.
- **The decisive point:** the breaking commit touched the **root `Cargo.toml`** — neither the parser crate nor the harness — so **no PR run fired at all**, and the break sat latent from Jul-22 until the Monday scheduled run. The paths filter was too narrow to see the class of drift that actually broke it.

So this PR:

- makes `pull_request` **build only** — the fuzz package is a detached workspace that `cargo build --workspace` and clippy never compile, so this build is the *only* pre-merge check that the harness still matches the surface it exercises. It is cheap and deterministic, whereas a timed campaign on a PR spends minutes to sample little entropy and can fail for reasons the PR did not cause;
- **broadens** the PR paths to `Cargo.toml` and `.cargo/config.toml`, the dependency-pin surface — precisely what would have caught this at PR time;
- keeps the campaign on the weekly schedule (300 s) and manual dispatch (60 s), where hunting crashes belongs.

Option (b) — moving it wholly to scheduled — was rejected: it deletes the only pre-merge coverage of a drift class that just escaped every other gate for five days. The check was ignorable because it was *broken*, not because compile-checking the harness is low value.

I also do **not** recommend adding these to the required set: a required context on a paths-filtered workflow never reports on non-matching PRs, leaving them blocked in perpetual "pending". That would need an always-running skip-shim, which is not worth it for a compile check that is now green and fast.

## Verification

Both targets, clean `fuzz/target`, pinned toolchain, the exact CI command:

```
$ cargo +nightly-2026-06-17 fuzz build parse_adapter
    Finished `release` profile [optimized + debuginfo] target(s) in 47.00s
$ cargo +nightly-2026-06-17 fuzz build parse_shallow
    Finished `release` profile [optimized + debuginfo] target(s) in 0.79s
```

Harnesses genuinely run, not merely compile:

```
parse_adapter: #27033 DONE cov: 1730 ft: 4658 corp: 485/3188b  — 27,033 runs / 16s, no crash
parse_shallow: #37274 DONE cov: 326  ft: 1468 corp: 231/3624b  — 37,274 runs / 16s, no crash
```

Full local gate, all after the final edit: `cargo fmt -- --check`, clippy `--all-targets --all-features` with the ci.yml allowlist under `RUSTFLAGS=-D warnings`, `cargo build --all-targets`, `cargo test --doc`, and `cargo nextest run --workspace --no-fail-fast` → **4031 passed, 0 failed**.

Closes FIR-1670

## Follow-on: release-authority fixture

Pinning the toolchain into the fuzz cache key tripped `scripts/test-release-workflow-authority.py`, which located the fuzz cache step by matching its `key:` line in full:

```
AssertionError: cache falsification could not identify the unrelated fuzz cache step
```

That falsification only needs the step to have *an* active field — which inputs the key hashes, and whether it carries a toolchain pin, is incidental and changes whenever the fuzz job is retuned. It now matches on the `key:` prefix (still requiring exactly one hit), which stays distinct from the further-indented `restore-keys:` entries and keeps the falsification equally strong, while no longer failing for edits it does not govern. Without this it would also have broken on every future nightly bump.

Whole CI step verified locally: `test-release-workflow-authority.py`, `test_install_optional_vfs.py`, `test_installer_parity.py`, `test-npm-automatic-release.py`, `test-verify-npm-release.py`, and the three `node --test` suites (13 pass / 0 fail).
