### PR TITLE
Make the daemon's advertised repo identity routable and restore graph validate notes

### DIFF
--- a/crates/kin-cli/src/commands/graph.rs
+++ b/crates/kin-cli/src/commands/graph.rs
@@ -363,11 +363,7 @@ fn build_graph_status_response(
             lines.push(format!("⚠ {}", w));
         }
     }
-    // Notes describe expected absences, so they follow the verdict rather than
-    // suppressing it.
-    for note in &health.notes {
-        lines.push(format!("ℹ {}", note));
-    }
+    append_health_notes(&mut lines, &health.notes);
 
     Ok(GraphCommandResponse {
         lines,
@@ -375,6 +371,20 @@ fn build_graph_status_response(
             .then(|| format!("{} critical graph health issue(s) found", criticals.len())),
         source: None,
     })
+}
+
+/// Render a health report's notes in the single form every graph reporting
+/// surface uses.
+///
+/// Notes describe expected absences rather than defects, so they follow the
+/// verdict instead of suppressing it. `status` and `validate` render them from
+/// here so the two cannot drift: a surface that carries the verdict but drops
+/// the notes reports a repository whose enrichment is still pending as
+/// indistinguishable from a fully enriched one.
+fn append_health_notes(lines: &mut Vec<String>, notes: &[String]) {
+    for note in notes {
+        lines.push(format!("ℹ {}", note));
+    }
 }
 
 fn build_graph_validate_response(
@@ -502,6 +512,7 @@ fn build_graph_validate_response(
             lines.push(format!("✗ {}", issue));
         }
     }
+    append_health_notes(&mut lines, &health.notes);
 
     Ok(GraphCommandResponse {
         lines,
@@ -1776,6 +1787,48 @@ mod tests {
 
         let line = orphan_line(&response).expect("graph tree lacks the file, so it is orphaned");
         assert!(line.contains('1'), "{line}");
+    }
+
+    fn note_lines(response: &GraphCommandResponse) -> Vec<&String> {
+        response
+            .lines
+            .iter()
+            .filter(|line| line.starts_with('ℹ'))
+            .collect()
+    }
+
+    /// Notes describe a healthy graph rather than a defect, so a surface that
+    /// keeps the verdict but drops them under-reports the repository's real
+    /// state. Both graph surfaces read one health report, so both must render
+    /// the same notes for the same state, and a reported issue must not
+    /// suppress them.
+    #[test]
+    fn graph_validate_and_status_report_the_same_health_notes() {
+        let (_temp, _layout, binding, graph) = orphan_fixture(&["src/tracked.rs"]);
+        let mut entity = test_entity("covered");
+        entity.role = EntityRole::Test;
+        entity.file_origin = Some(FilePathId::new("src/tracked.rs"));
+        graph.upsert_entity(&entity).unwrap();
+
+        let validate = build_graph_validate_response(&binding, &graph).unwrap();
+        let status = build_graph_status_response(&binding, &graph).unwrap();
+
+        let validate_notes = note_lines(&validate);
+        assert!(
+            !validate_notes.is_empty(),
+            "validate must carry the health notes: {:?}",
+            validate.lines
+        );
+        assert_eq!(
+            validate_notes,
+            note_lines(&status),
+            "the two surfaces must not drift on note reporting"
+        );
+        assert!(
+            validate.lines.iter().any(|line| line.starts_with('✗')),
+            "this fixture also diverges, so notes are proven to survive a verdict: {:?}",
+            validate.lines
+        );
     }
 
     /// The converse: a file the graph's exact tree carries is not an orphan

--- a/crates/kin-cli/src/commands/graph_health.rs
+++ b/crates/kin-cli/src/commands/graph_health.rs
@@ -55,6 +55,13 @@ pub struct GraphHealthReport {
     pub repository_artifact_coverage: RepositoryArtifactCoverage,
     pub supported_entity_source_file_count: usize,
     pub supported_shallow_source_file_count: usize,
+    /// Whether supported sources were admitted while the graph derived neither
+    /// an entity layer nor a single facet.
+    ///
+    /// Informational and JSON-only by design: it moves no verdict, no note, and
+    /// no exit code. Every coverage level is a reachable healthy state under
+    /// the current substrate, so keying a verdict on this would fail closed on
+    /// repositories that are merely early. Consumers read it from the report.
     pub graph_empty_for_supported_inputs: bool,
     pub contaminated_entity_count: usize,
     pub contaminated_non_entity_count: usize,

--- a/crates/kin-cli/src/daemon_client.rs
+++ b/crates/kin-cli/src/daemon_client.rs
@@ -461,7 +461,10 @@ impl DaemonClient {
     /// Search entities via the multi-repo API.
     ///
     /// Uses `GET /repos/{repo_id}/entities?query=<pattern>`.
-    /// The `repo_id` is derived from the `.kin/` directory name.
+    /// The `repo_id` is the identity the daemon advertises on `GET /health`,
+    /// which is the only key space the repo-scoped routes resolve. Deriving it
+    /// from a directory name instead addresses a repository the daemon does
+    /// not serve.
     pub async fn search_entities(
         &self,
         repo_id: &str,

--- a/crates/kin-cli/tests/graph_status_after_admission.rs
+++ b/crates/kin-cli/tests/graph_status_after_admission.rs
@@ -231,6 +231,60 @@ fn graph_status_passes_on_a_healthy_freshly_admitted_repository() {
     );
 }
 
+fn graph_validate(
+    binding: &kin_core::LocalRepositoryAuthorityBinding,
+    graph: &kin_db::InMemoryGraph,
+) -> kin_cli::commands::graph::GraphCommandResponse {
+    execute_graph_command(binding, graph, &GraphCommandRequest::Validate)
+        .expect("run graph validate")
+}
+
+fn note_lines(response: &kin_cli::commands::graph::GraphCommandResponse) -> Vec<&String> {
+    response
+        .lines
+        .iter()
+        .filter(|line| line.starts_with('ℹ'))
+        .collect()
+}
+
+/// Exact admission binds the entity layer and no facet layer, so a freshly
+/// admitted repository is healthy with its enrichment still pending. Validate
+/// must say so: passing silently makes a pending repository indistinguishable
+/// from a fully enriched one, which is the same reporting loss on the validate
+/// surface that the status surface was fixed for.
+#[test]
+fn graph_validate_reports_pending_enrichment_and_agrees_with_status() {
+    let root = tempdir().expect("temp root");
+    let repo = root.path().join("repo");
+    fs::create_dir_all(&repo).expect("create repo");
+    let admitted = admit(&repo);
+    let graph = workspace_query_graph(&admitted.binding);
+
+    let validate = graph_validate(&admitted.binding, &graph);
+
+    assert!(
+        validate.error.is_none(),
+        "pending enrichment is healthy, so validate must not fail: {:?}\n{}",
+        validate.error,
+        validate.lines.join("\n")
+    );
+    assert!(
+        validate
+            .lines
+            .iter()
+            .any(|line| line.contains("no query-facing enrichment facet")),
+        "validate must surface the pending-enrichment note: {}",
+        validate.lines.join("\n")
+    );
+
+    let status = graph_status(&admitted.binding, &graph);
+    assert_eq!(
+        note_lines(&validate),
+        note_lines(&status),
+        "validate and status must agree on note presence for one repo state"
+    );
+}
+
 #[test]
 fn graph_status_fails_on_a_facet_that_disagrees_with_exact_tree_truth() {
     let root = tempdir().expect("temp root");

--- a/crates/kin-daemon/src/api.rs
+++ b/crates/kin-daemon/src/api.rs
@@ -6698,6 +6698,38 @@ async fn mcp_tools_call(
 // Multi-repo endpoints — list and query lazily-loaded repo graphs
 // ---------------------------------------------------------------------------
 
+/// Resolve one repo-scoped route's `{repo_id}` to its graph.
+///
+/// Every `/repos/{repo_id}/…` route goes through here so the identity a daemon
+/// advertises on `/health` is the identity those routes accept: `/health`
+/// reports [`primary_repo_id`], which is the repository authority id the
+/// daemon opened, and that id is always resident in the repo graph map.
+///
+/// An id this daemon does not serve is an identity mismatch, so it answers 404
+/// naming the id that is served. Only a failure to load the advertised repo is
+/// an internal fault. Reporting a mismatch as a multi-repo storage 500 told
+/// clients the daemon was broken when the request was simply addressed to the
+/// wrong repository.
+async fn repo_scoped_graph(
+    state: &DaemonState,
+    repo_id: &str,
+) -> Result<Arc<kin_db::InMemoryGraph>, (StatusCode, String)> {
+    state.get_repo_graph(repo_id).await.map_err(|error| {
+        if repo_id == state.cached_repo_id {
+            internal_error(error)
+        } else {
+            (
+                StatusCode::NOT_FOUND,
+                format!(
+                    "this daemon serves repository {} and does not serve {repo_id}; \
+                     GET /health advertises the repo_id every /repos/{{repo_id}} route accepts",
+                    state.cached_repo_id
+                ),
+            )
+        }
+    })
+}
+
 async fn repository_authority_snapshot(
     state: &DaemonState,
     repo_id: &str,
@@ -6707,10 +6739,7 @@ async fn repository_authority_snapshot(
         return Ok(authority.manager.read_authority().snapshot().clone());
     }
 
-    let graph = state
-        .get_repo_graph(repo_id)
-        .await
-        .map_err(internal_error)?;
+    let graph = repo_scoped_graph(state, repo_id).await?;
     let snapshot = graph.to_snapshot();
     let metadata = snapshot.repository_authority.as_ref().ok_or_else(|| {
         (
@@ -7354,10 +7383,7 @@ async fn repo_health(
     Path(repo_id): Path<String>,
     State(state): State<Arc<DaemonState>>,
 ) -> std::result::Result<impl IntoResponse, (StatusCode, String)> {
-    let graph = state
-        .get_repo_graph(&repo_id)
-        .await
-        .map_err(internal_error)?;
+    let graph = repo_scoped_graph(&state, &repo_id).await?;
     let entity_count = graph.entity_count();
     Ok(Json(RepoHealthResponse {
         repo_id,
@@ -7384,10 +7410,7 @@ async fn repo_entities(
     Query(params): Query<RepoEntitiesQuery>,
     State(state): State<Arc<DaemonState>>,
 ) -> std::result::Result<impl IntoResponse, (StatusCode, String)> {
-    let graph = state
-        .get_repo_graph(&repo_id)
-        .await
-        .map_err(internal_error)?;
+    let graph = repo_scoped_graph(&state, &repo_id).await?;
 
     let filter = kin_model::EntityFilter {
         name_pattern: params.query.clone(),
@@ -7574,10 +7597,7 @@ async fn repo_provenance_entity(
     Path((repo_id, entity_id_str)): Path<(String, String)>,
     State(state): State<Arc<DaemonState>>,
 ) -> std::result::Result<impl IntoResponse, (StatusCode, String)> {
-    let graph = state
-        .get_repo_graph(&repo_id)
-        .await
-        .map_err(internal_error)?;
+    let graph = repo_scoped_graph(&state, &repo_id).await?;
     let entity_id = parse_entity_id_hex(&entity_id_str)?;
 
     let snapshot = graph.to_snapshot();
@@ -7681,10 +7701,7 @@ async fn repo_provenance_verify(
     Path(repo_id): Path<String>,
     State(state): State<Arc<DaemonState>>,
 ) -> std::result::Result<impl IntoResponse, (StatusCode, String)> {
-    let graph = state
-        .get_repo_graph(&repo_id)
-        .await
-        .map_err(internal_error)?;
+    let graph = repo_scoped_graph(&state, &repo_id).await?;
     let snapshot = graph.to_snapshot();
 
     // Build a stored hash map from the current snapshot (this represents the
@@ -8708,6 +8725,13 @@ fn persist_coordination_reservation(
     persist_coordination_event(state, draft)
 }
 
+/// The repository identity `/health` advertises.
+///
+/// This is the repository authority id the daemon opened, which is also the
+/// key every `/repos/{repo_id}/…` route resolves through
+/// ([`repo_scoped_graph`], [`repository_authority_snapshot`],
+/// [`repository_transfer_authority`]). One key space, so a client may take
+/// `/health.repo_id` and address any repo-scoped route with it.
 fn primary_repo_id(state: &DaemonState) -> String {
     state.cached_repo_id.clone()
 }
@@ -13937,6 +13961,111 @@ mod tests {
         let legacy: HealthResponse = serde_json::from_value(legacy).unwrap();
         assert!(legacy.coordination.is_none());
         assert!(legacy.coordination_event_persist_failures.is_none());
+    }
+
+    async fn advertised_repo_id(state: Arc<DaemonState>) -> String {
+        let response = router(state)
+            .oneshot(Request::get("/health").body(Body::empty()).unwrap())
+            .await
+            .unwrap();
+        assert_eq!(response.status(), StatusCode::OK);
+        let body = axum::body::to_bytes(response.into_body(), 64 * 1024)
+            .await
+            .unwrap();
+        serde_json::from_slice::<HealthResponse>(&body)
+            .unwrap()
+            .repo_id
+    }
+
+    async fn repo_route(state: Arc<DaemonState>, path: &str) -> (StatusCode, Vec<u8>) {
+        let response = router(state)
+            .oneshot(Request::get(path).body(Body::empty()).unwrap())
+            .await
+            .unwrap();
+        let status = response.status();
+        let body = axum::body::to_bytes(response.into_body(), 1024 * 1024)
+            .await
+            .unwrap();
+        (status, body.to_vec())
+    }
+
+    /// The identity contract a client depends on: read `repo_id` off `/health`
+    /// and every `/repos/{repo_id}/…` route resolves it. Two key spaces here
+    /// meant a caller that trusted the advertised id got a storage-mode 500 on
+    /// every repo-scoped call against a perfectly healthy daemon.
+    #[tokio::test]
+    async fn health_repo_id_addresses_every_repo_scoped_route() {
+        let state = test_state();
+        let repo_id = advertised_repo_id(Arc::clone(&state)).await;
+        assert!(!repo_id.trim().is_empty(), "/health must advertise an id");
+
+        let (status, body) =
+            repo_route(Arc::clone(&state), &format!("/repos/{repo_id}/health")).await;
+        assert_eq!(
+            status,
+            StatusCode::OK,
+            "advertised repo id must route: {}",
+            String::from_utf8_lossy(&body)
+        );
+        let health: RepoHealthResponse = serde_json::from_slice(&body).unwrap();
+        assert_eq!(
+            health.repo_id, repo_id,
+            "the repo route must echo the advertised identity back"
+        );
+
+        for path in [
+            format!("/repos/{repo_id}/entities"),
+            format!("/repos/{repo_id}/refs"),
+            format!("/repos/{repo_id}/files"),
+            format!("/repos/{repo_id}/history"),
+            format!("/repos/{repo_id}/provenance/verify"),
+        ] {
+            let (status, body) = repo_route(Arc::clone(&state), &path).await;
+            assert_eq!(
+                status,
+                StatusCode::OK,
+                "{path} must accept the advertised repo id: {}",
+                String::from_utf8_lossy(&body)
+            );
+        }
+
+        // /repos lists the same key space the advertised id belongs to.
+        let (status, body) = repo_route(Arc::clone(&state), "/repos").await;
+        assert_eq!(status, StatusCode::OK);
+        let listed: ReposResponse = serde_json::from_slice(&body).unwrap();
+        assert!(
+            listed.repos.contains(&repo_id),
+            "the advertised id must appear in the repo listing: {:?}",
+            listed.repos
+        );
+    }
+
+    /// An id this daemon does not serve is an identity mismatch, not a broken
+    /// daemon: 404 naming the id that is served, rather than the lazy
+    /// multi-repo loader's "no storage backend configured" 500.
+    #[tokio::test]
+    async fn an_unserved_repo_id_is_an_identity_mismatch_rather_than_a_storage_failure() {
+        let state = test_state();
+        let served = advertised_repo_id(Arc::clone(&state)).await;
+        let unserved = format!("not-{served}");
+
+        for path in [
+            format!("/repos/{unserved}/health"),
+            format!("/repos/{unserved}/entities"),
+            format!("/repos/{unserved}/provenance/verify"),
+        ] {
+            let (status, body) = repo_route(Arc::clone(&state), &path).await;
+            assert_eq!(status, StatusCode::NOT_FOUND, "{path}");
+            let message = String::from_utf8_lossy(&body);
+            assert!(
+                message.contains(&served) && message.contains(&unserved),
+                "the refusal must name both the served and requested ids: {message}"
+            );
+            assert!(
+                !message.contains("no storage backend configured"),
+                "an identity mismatch must not read as a storage-mode failure: {message}"
+            );
+        }
     }
 
     #[tokio::test]

--- a/crates/kin-daemon/src/api.rs
+++ b/crates/kin-daemon/src/api.rs
@@ -6705,29 +6705,35 @@ async fn mcp_tools_call(
 /// reports [`primary_repo_id`], which is the repository authority id the
 /// daemon opened, and that id is always resident in the repo graph map.
 ///
-/// An id this daemon does not serve is an identity mismatch, so it answers 404
-/// naming the id that is served. Only a failure to load the advertised repo is
-/// an internal fault. Reporting a mismatch as a multi-repo storage 500 told
-/// clients the daemon was broken when the request was simply addressed to the
-/// wrong repository.
+/// Addressing is decided from the served key space
+/// ([`DaemonState::serves_repo_id`]) *before* any load is attempted, so the two
+/// failure categories stay distinct. An id outside that key space is an
+/// identity mismatch and answers 404 naming the id that is served. Every
+/// failure of a repository this daemon does serve is a fault and keeps its
+/// underlying error, whether or not that repository is the advertised one: a
+/// hosted daemon serves each allowlisted sibling, so an unreachable backend or
+/// a corrupt delta chain must not be relabelled as a repository this daemon
+/// does not have.
+///
+/// Deciding the category from the failure afterwards cannot work, because an
+/// identity compare answers "is this the advertised repository" while the
+/// question is "is this one we serve". Those diverge for every sibling a hosted
+/// daemon carries, and a load error holds no evidence either way.
 async fn repo_scoped_graph(
     state: &DaemonState,
     repo_id: &str,
 ) -> Result<Arc<kin_db::InMemoryGraph>, (StatusCode, String)> {
-    state.get_repo_graph(repo_id).await.map_err(|error| {
-        if repo_id == state.cached_repo_id {
-            internal_error(error)
-        } else {
-            (
-                StatusCode::NOT_FOUND,
-                format!(
-                    "this daemon serves repository {} and does not serve {repo_id}; \
-                     GET /health advertises the repo_id every /repos/{{repo_id}} route accepts",
-                    state.cached_repo_id
-                ),
-            )
-        }
-    })
+    if !state.serves_repo_id(repo_id) {
+        return Err((
+            StatusCode::NOT_FOUND,
+            format!(
+                "this daemon serves repository {} and does not serve {repo_id}; \
+                 GET /health advertises the repo_id every /repos/{{repo_id}} route accepts",
+                state.cached_repo_id
+            ),
+        ));
+    }
+    state.get_repo_graph(repo_id).await.map_err(internal_error)
 }
 
 async fn repository_authority_snapshot(
@@ -7369,7 +7375,7 @@ async fn command_transfer_plan(
 async fn list_repos(
     State(state): State<Arc<DaemonState>>,
 ) -> Result<impl IntoResponse, (StatusCode, String)> {
-    let repos = state.list_available_repos().map_err(|e| {
+    let repos = state.list_available_repos().await.map_err(|e| {
         (
             StatusCode::INTERNAL_SERVER_ERROR,
             format!("failed to list repos: {e}"),
@@ -8730,8 +8736,16 @@ fn persist_coordination_reservation(
 /// This is the repository authority id the daemon opened, which is also the
 /// key every `/repos/{repo_id}/…` route resolves through
 /// ([`repo_scoped_graph`], [`repository_authority_snapshot`],
-/// [`repository_transfer_authority`]). One key space, so a client may take
-/// `/health.repo_id` and address any repo-scoped route with it.
+/// [`repository_transfer_authority`]). One key space *for the daemon API*, so a
+/// client may take `/health.repo_id` and address any repo-scoped route on this
+/// daemon with it. A hosted daemon additionally serves the allowlisted siblings
+/// `GET /repos` lists.
+///
+/// The supervisor is a different service on its own port and its
+/// `/repos/{repo_id}/route` endpoint is a distinct, path-derived key space
+/// (`local-<sha16>` of the working directory, see
+/// `kin_cli::daemon_client::supervisor_repo_id_for_working_dir`). Those ids are
+/// not interchangeable with this one in either direction.
 fn primary_repo_id(state: &DaemonState) -> String {
     state.cached_repo_id.clone()
 }
@@ -14043,16 +14057,29 @@ mod tests {
     /// An id this daemon does not serve is an identity mismatch, not a broken
     /// daemon: 404 naming the id that is served, rather than the lazy
     /// multi-repo loader's "no storage backend configured" 500.
+    ///
+    /// The route list covers every surface the identity resolution reaches,
+    /// including the four that resolve through `repository_authority_snapshot`.
+    /// Those short-circuit on the advertised id, so driving them with an id the
+    /// daemon serves exercises none of this: only an unserved id reaches
+    /// `repo_scoped_graph` through them.
     #[tokio::test]
     async fn an_unserved_repo_id_is_an_identity_mismatch_rather_than_a_storage_failure() {
         let state = test_state();
         let served = advertised_repo_id(Arc::clone(&state)).await;
         let unserved = format!("not-{served}");
+        // Parses as a canonical semantic change id, so the archive route
+        // reaches identity resolution instead of refusing on the id shape.
+        let well_formed_change = "a".repeat(64);
 
         for path in [
             format!("/repos/{unserved}/health"),
             format!("/repos/{unserved}/entities"),
             format!("/repos/{unserved}/provenance/verify"),
+            format!("/repos/{unserved}/files"),
+            format!("/repos/{unserved}/refs"),
+            format!("/repos/{unserved}/history"),
+            format!("/repos/{unserved}/archive/tar/{well_formed_change}"),
         ] {
             let (status, body) = repo_route(Arc::clone(&state), &path).await;
             assert_eq!(status, StatusCode::NOT_FOUND, "{path}");
@@ -14066,6 +14093,239 @@ mod tests {
                 "an identity mismatch must not read as a storage-mode failure: {message}"
             );
         }
+    }
+
+    /// A `StorageBackend` that faults on demand for named repositories,
+    /// delegating everything else to a real local backend.
+    ///
+    /// The faults it raises are the ones a hosted backend actually raises for a
+    /// repository it is configured to serve: an unreachable object store,
+    /// expired credentials, a snapshot authority that disagrees with the
+    /// acknowledged head, or a corrupt delta chain. All of them arrive as an
+    /// `Err` out of the recovery read, which is the single path
+    /// `load_recovered_snapshot` takes.
+    struct RepoFaultBackend {
+        inner: kin_db::LocalFileBackend,
+        faulting: FaultSwitch,
+    }
+
+    /// Handle the test keeps after the backend is moved into the daemon, so a
+    /// fault can be armed once the daemon has already opened healthy.
+    #[derive(Clone)]
+    struct FaultSwitch(Arc<std::sync::Mutex<std::collections::HashSet<String>>>);
+
+    impl FaultSwitch {
+        fn start_faulting(&self, repo_id: &str) {
+            self.0.lock().unwrap().insert(repo_id.to_string());
+        }
+
+        fn fault_for(&self, repo_id: &str) -> Option<kin_db::KinDbError> {
+            self.0.lock().unwrap().contains(repo_id).then(|| {
+                kin_db::KinDbError::StorageError(format!(
+                    "{BACKEND_FAULT_TEXT} while reading {repo_id}"
+                ))
+            })
+        }
+    }
+
+    impl RepoFaultBackend {
+        fn new(path: &std::path::Path) -> (Self, FaultSwitch) {
+            let faulting = FaultSwitch(Arc::new(std::sync::Mutex::new(
+                std::collections::HashSet::new(),
+            )));
+            (
+                Self {
+                    inner: kin_db::LocalFileBackend::new(path),
+                    faulting: faulting.clone(),
+                },
+                faulting,
+            )
+        }
+
+        fn fault_for(&self, repo_id: &str) -> Option<kin_db::KinDbError> {
+            self.faulting.fault_for(repo_id)
+        }
+    }
+
+    const BACKEND_FAULT_TEXT: &str = "object store unreachable";
+
+    impl kin_db::StorageBackend for RepoFaultBackend {
+        fn load_recovery_state(
+            &self,
+            repo_id: &str,
+        ) -> std::result::Result<kin_db::SnapshotRecoveryState, kin_db::KinDbError> {
+            match self.fault_for(repo_id) {
+                Some(error) => Err(error),
+                None => self.inner.load_recovery_state(repo_id),
+            }
+        }
+
+        fn load_snapshot_authority(
+            &self,
+            repo_id: &str,
+        ) -> std::result::Result<Option<kin_db::SnapshotAuthority>, kin_db::KinDbError> {
+            match self.fault_for(repo_id) {
+                Some(error) => Err(error),
+                None => self.inner.load_snapshot_authority(repo_id),
+            }
+        }
+
+        fn load_snapshot(
+            &self,
+            repo_id: &str,
+        ) -> std::result::Result<Option<(Vec<u8>, kin_db::Generation)>, kin_db::KinDbError>
+        {
+            match self.fault_for(repo_id) {
+                Some(error) => Err(error),
+                None => self.inner.load_snapshot(repo_id),
+            }
+        }
+
+        fn save_snapshot(
+            &self,
+            repo_id: &str,
+            data: &[u8],
+            expected_gen: kin_db::Generation,
+        ) -> std::result::Result<kin_db::Generation, kin_db::KinDbError> {
+            self.inner.save_snapshot(repo_id, data, expected_gen)
+        }
+
+        fn save_delta(
+            &self,
+            repo_id: &str,
+            delta_data: &[u8],
+            base_gen: kin_db::Generation,
+        ) -> std::result::Result<kin_db::Generation, kin_db::KinDbError> {
+            self.inner.save_delta(repo_id, delta_data, base_gen)
+        }
+
+        fn load_deltas_since(
+            &self,
+            repo_id: &str,
+            since_gen: kin_db::Generation,
+        ) -> std::result::Result<Vec<(Vec<u8>, kin_db::Generation)>, kin_db::KinDbError> {
+            self.inner.load_deltas_since(repo_id, since_gen)
+        }
+
+        fn clear_deltas(&self, repo_id: &str) -> std::result::Result<(), kin_db::KinDbError> {
+            self.inner.clear_deltas(repo_id)
+        }
+
+        fn save_overlay(
+            &self,
+            repo_id: &str,
+            session_id: &str,
+            data: &[u8],
+        ) -> std::result::Result<(), kin_db::KinDbError> {
+            self.inner.save_overlay(repo_id, session_id, data)
+        }
+
+        fn load_overlay(
+            &self,
+            repo_id: &str,
+            session_id: &str,
+        ) -> std::result::Result<Option<Vec<u8>>, kin_db::KinDbError> {
+            self.inner.load_overlay(repo_id, session_id)
+        }
+
+        fn delete_overlay(
+            &self,
+            repo_id: &str,
+            session_id: &str,
+        ) -> std::result::Result<(), kin_db::KinDbError> {
+            self.inner.delete_overlay(repo_id, session_id)
+        }
+
+        fn list_repos(&self) -> std::result::Result<Vec<String>, kin_db::KinDbError> {
+            self.inner.list_repos()
+        }
+    }
+
+    /// A hosted daemon serves every allowlisted repository, not only the one it
+    /// advertises. So a backend fault on an allowlisted sibling is a fault, and
+    /// answering 404 there would report a GCS outage or a corrupt delta chain as
+    /// a repository this daemon does not have: false on its face, contradicted
+    /// by `GET /repos` on the same daemon, and invisible to every retry loop and
+    /// 5xx alert that exists to catch exactly that.
+    ///
+    /// This is the case an identity compare cannot decide, and the reason
+    /// addressing is resolved from the served key space before the load rather
+    /// than inferred from the failure afterwards.
+    #[tokio::test]
+    async fn a_backend_fault_on_a_served_sibling_stays_a_fault_rather_than_a_404() {
+        let dir = std::env::temp_dir().join(format!("kin-daemon-repo-fault-{}", Uuid::new_v4()));
+        let kin_dir = dir.join(".kin");
+        std::fs::create_dir_all(kin_dir.join("objects")).unwrap();
+        std::fs::create_dir_all(kin_dir.join("working")).unwrap();
+        let layout = kin_core::KinLayout::new(kin_dir);
+        kin_core::manifest::KinManifest::new()
+            .save(&layout.manifest_path())
+            .unwrap();
+        let backend_dir = dir.join("backend");
+        std::fs::create_dir_all(&backend_dir).unwrap();
+
+        // The shipped hosted shape: one advertised repo, several allowlisted
+        // siblings, none of them pre-warmed into the repo graph map.
+        let advertised = "primary-repo";
+        let sibling = "sibling-repo";
+        let (backend, faults) = RepoFaultBackend::new(&backend_dir);
+        let allowed: std::collections::HashSet<String> =
+            [advertised.to_string(), sibling.to_string()]
+                .into_iter()
+                .collect();
+        let state = Arc::new(
+            DaemonState::open_with_backend(layout, Box::new(backend), advertised, Some(allowed))
+                .unwrap(),
+        );
+        assert_eq!(
+            advertised_repo_id(Arc::clone(&state)).await,
+            advertised,
+            "the fixture must advertise the primary id"
+        );
+        assert!(
+            state.serves_repo_id(sibling),
+            "the allowlist is the served key space, so the sibling is served"
+        );
+
+        faults.start_faulting(sibling);
+
+        for path in [
+            format!("/repos/{sibling}/health"),
+            format!("/repos/{sibling}/entities"),
+            format!("/repos/{sibling}/provenance/verify"),
+        ] {
+            let (status, body) = repo_route(Arc::clone(&state), &path).await;
+            let message = String::from_utf8_lossy(&body);
+            assert_eq!(
+                status,
+                StatusCode::INTERNAL_SERVER_ERROR,
+                "a backend fault on a served repository must stay a fault at {path}: {message}"
+            );
+            assert!(
+                message.contains(BACKEND_FAULT_TEXT),
+                "the fault must carry the backend error rather than discard it: {message}"
+            );
+            assert!(
+                !message.contains("does not serve"),
+                "a served repository must never be reported as unserved: {message}"
+            );
+        }
+
+        // The same daemon still refuses an id outside the served key space, and
+        // still refuses it as an identity mismatch.
+        let unserved = "absent-repo";
+        let (status, body) =
+            repo_route(Arc::clone(&state), &format!("/repos/{unserved}/entities")).await;
+        let message = String::from_utf8_lossy(&body);
+        assert_eq!(
+            status,
+            StatusCode::NOT_FOUND,
+            "an id outside the allowlist is an identity mismatch: {message}"
+        );
+        assert!(
+            message.contains(advertised) && message.contains(unserved),
+            "the refusal must name both the served and requested ids: {message}"
+        );
     }
 
     #[tokio::test]

--- a/crates/kin-daemon/src/state.rs
+++ b/crates/kin-daemon/src/state.rs
@@ -2860,6 +2860,25 @@ impl DaemonState {
         Arc::clone(graphs.entry(repo_id.to_string()).or_insert(loaded))
     }
 
+    /// Whether `repo_id` belongs to the key space this daemon serves.
+    ///
+    /// Addressability is a separate question from whether a load succeeds, and
+    /// only this one can be answered without touching storage. When an
+    /// allowlist is configured it *is* the served key space, which is why
+    /// [`Self::list_available_repos`] filters by the same set. Without one, a
+    /// storage backend serves every repository it can load, and a local daemon
+    /// serves exactly the repository authority it opened.
+    ///
+    /// Callers decide addressability with this before attempting a load so a
+    /// backend fault on a served repository is never reported as a request
+    /// addressed to the wrong repository.
+    pub fn serves_repo_id(&self, repo_id: &str) -> bool {
+        match &self.allowed_repo_ids {
+            Some(allowed_repo_ids) => allowed_repo_ids.contains(repo_id),
+            None => self.storage_backend.is_some() || repo_id == self.cached_repo_id,
+        }
+    }
+
     /// Get or lazy-load a repo's graph from the storage backend.
     ///
     /// Returns the cached graph if already loaded, otherwise loads from
@@ -2899,17 +2918,15 @@ impl DaemonState {
     /// When a storage backend is configured, discovers repos directly from
     /// storage — no env vars needed. Falls back to loaded repo keys in
     /// local mode.
-    pub fn list_available_repos(&self) -> Result<Vec<String>> {
+    pub async fn list_available_repos(&self) -> Result<Vec<String>> {
         let mut repos = if let Some(backend) = &self.storage_backend {
             backend.list_repos().map_err(DaemonError::from)?
         } else {
-            // Local mode: return the loaded repo_graphs keys.
-            let graphs = self
-                .repo_graphs
-                .try_read()
-                .map(|g| g.keys().cloned().collect())
-                .unwrap_or_default();
-            graphs
+            // Local mode: return the loaded repo_graphs keys. This awaits the
+            // read rather than falling back to an empty listing on a contended
+            // lock, which reported "this daemon serves no repositories" for
+            // what was only a concurrent writer.
+            self.repo_graphs.read().await.keys().cloned().collect()
         };
         if let Some(allowed_repo_ids) = &self.allowed_repo_ids {
             repos.retain(|repo_id| allowed_repo_ids.contains(repo_id));


### PR DESCRIPTION
Two small truth fixes on the daemon and CLI reporting surfaces.

## Repo-scoped daemon routes resolve the identity /health advertises

`GET /health` reports the repository authority id the daemon opened. Every
`/repos/{repo_id}/…` route now resolves through one helper, so a client can take
`/health.repo_id` and address any repo-scoped route with it. The routes covered
are health, entities, files, refs, history, both provenance endpoints, and the
exact-source archive; `/transfer/*` already resolved this way.

That helper decides addressing from the key space the daemon actually serves,
`DaemonState::serves_repo_id`, *before* attempting any load. An id outside that
key space answers 404 naming the id that is served, instead of falling through
to the lazy multi-repo loader's `no storage backend configured for multi-repo
mode` 500, which reported an addressing mistake as a broken daemon. Every
failure of a repository the daemon does serve stays a fault carrying its
underlying error.

Deciding addressing before the load is what keeps those two categories apart. A
hosted daemon serves each allowlisted sibling, not only the id it advertises, so
an identity compare against the advertised id answers a different question than
the one being asked: it would report an unreachable object store or a corrupt
delta chain on a served sibling as a repository the daemon does not have, which
`GET /repos` on that same daemon contradicts, and which no 5xx alert or retry
loop would ever see. A load error carries no evidence of which category it
belongs to, so the decision cannot be deferred until after it.

The predicate lives on `DaemonState`, beside the allowlist it consults, because
`list_available_repos` filters by that same set. `GET /repos` and
`/repos/{repo_id}/…` now decide membership from one definition rather than two
that can drift.

`/spine/repos/{repo_id}/ingest` is deliberately unchanged and still reports load
failures as 500. A 404 there is a capability signal to its callers, not an
error.

Tests read `repo_id` off `/health` and drive every repo-scoped route with it,
assert the repo route echoes the same id back and that the id appears in
`GET /repos`, and pin the 404 identity-mismatch shape across every route the
helper reaches. A hosted fixture opens a daemon over a `StorageBackend` with an
allowlisted sibling and no pre-warming, arms a backend fault on that sibling
after the daemon has opened healthy, and asserts the sibling answers 500 carrying
the backend error while an id outside the allowlist still answers 404 naming both
ids.

`GET /repos` in local mode fell back to an empty listing when the read lock was
contended, reporting "this daemon serves no repositories" for what was only a
concurrent writer. It now awaits the read.

`DaemonClient::search_entities` documented its `repo_id` as derived from the
`.kin/` directory name, which is the stale key space that produced this bug. Its
doc now names `/health.repo_id` as the authoritative identity. The daemon's key
space is documented as the daemon API's own: the supervisor is a separate service
whose `/repos/{repo_id}/route` endpoint keys on a path-derived `local-<sha16>`,
and the two are not interchangeable.

## kin graph validate reports its health notes

Validate carried the verdict but dropped every note, so a repository whose
enrichment is still pending read as indistinguishable from a fully enriched one.
Both graph surfaces now render notes through one helper, after the verdict and
without suppressing it. A note still sets no error and moves no exit code.

The integration test admits a real Git repository through the exact admission
boundary and asserts validate does not fail, surfaces the pending-enrichment
note, and produces the same note set as status for that one repo state. A unit
test additionally proves a reported issue does not suppress the notes.

`graph_empty_for_supported_inputs` is documented as informational and JSON-only:
it has no consumer outside test fixtures, and keying a verdict on it would fail
closed on repositories that are merely early, since every coverage level is a
reachable healthy state under the current substrate.

Closes FIR-1490
Closes FIR-1659
