### PR TITLE
Make the MCP write path tell the truth about what it committed and who committed it

### DIFF
--- a/crates/kin-daemon/src/mcp_commit.rs
+++ b/crates/kin-daemon/src/mcp_commit.rs
@@ -797,16 +797,17 @@ fn plan_exact_transaction(
                 // body.
                 //
                 // Scoped to `doc_summary` and deliberately not extended to the
-                // whole `metadata` bag. That bag holds keys the daemon's own
-                // workers maintain, `embedding_body_preview` from the embed
-                // pipeline and `blob_hash` from indexing, and they move
-                // asynchronously with respect to any caller. An agent that
-                // reads an entity, thinks, and then commits can therefore hold
-                // a metadata bag that authority has since moved on from, and
-                // comparing the bag would refuse it for a difference it neither
-                // caused nor can control. `doc_summary` is a single named field
-                // whose value a caller either changed on purpose or did not, so
-                // a difference there is real evidence of intent.
+                // whole `metadata` bag. That bag carries values derived from the
+                // entity's own source: `kin-parser` writes
+                // `embedding_body_preview` out of the source bytes at extraction
+                // time, so any commit that changes a body necessarily changes it
+                // too. An agent that reads an entity once and then makes two
+                // edits therefore holds, on the second, a bag that its own first
+                // commit already moved authority past, and comparing the bag
+                // would refuse it for a difference it caused by succeeding.
+                // `doc_summary` is a single named field whose value a caller
+                // either changed on purpose or did not, so a difference there is
+                // real evidence of intent.
                 if payload_entity.doc_summary != existing.doc_summary {
                     return Err(format!(
                         "staged doc summary for entity {} differs from repository authority; \

--- a/crates/kin-daemon/src/mcp_commit.rs
+++ b/crates/kin-daemon/src/mcp_commit.rs
@@ -441,17 +441,21 @@ fn mcp_actor_id(session_id: &str) -> ActorId {
     ActorId::from_hash(Hash256::from_bytes(hasher.finalize().into()))
 }
 
-/// A stable audit-event identity for one entity within one committed change.
+/// A stable audit-event identity for one scope within one committed change.
 ///
 /// Derived so a commit that is resumed after a crash re-derives the identifiers
 /// it already wrote instead of appending a second attribution record for a
-/// single write.
-fn mcp_audit_event_id(change: &SemanticChangeId, entity: &EntityId) -> AuditEventId {
+/// single write. `None` names the change itself, which is what a commit that
+/// touched no entity is attributed to.
+fn mcp_audit_event_id(change: &SemanticChangeId, entity: Option<&EntityId>) -> AuditEventId {
     let mut hasher = Sha256::new();
     hasher.update(b"kin-mcp-commit-audit-v1\0");
     hasher.update(change.to_string().as_bytes());
     hasher.update([0]);
-    hasher.update(entity.to_string().as_bytes());
+    match entity {
+        Some(entity) => hasher.update(entity.to_string().as_bytes()),
+        None => hasher.update(b"change"),
+    }
     AuditEventId::from_hash(Hash256::from_bytes(hasher.finalize().into()))
 }
 
@@ -465,8 +469,11 @@ fn mcp_audit_event_id(change: &SemanticChangeId, entity: &EntityId) -> AuditEven
 /// does not reach either, because both read the audit trail.
 ///
 /// One event per changed entity, because that is the scope the review layer
-/// matches on. Called only after the repository receipt exists, so nothing is
-/// attributed to a commit that did not land.
+/// matches on, and one event scoped to the change itself when a transaction
+/// changed no entity at all: a relation-only commit is still an agent write,
+/// and leaving it out of the audit trail is the same silence this closes.
+/// Called only after the repository receipt exists, so nothing is attributed to
+/// a commit that did not land.
 fn record_commit_provenance(
     graph: &kin_db::InMemoryGraph,
     actor: &CommitActor,
@@ -495,9 +502,22 @@ fn record_commit_provenance(
         .collect::<Vec<_>>();
     entities.sort_unstable();
     entities.dedup();
-    if entities.is_empty() {
-        return Ok(());
-    }
+    let scopes = if entities.is_empty() {
+        vec![(
+            mcp_audit_event_id(&committed.change.id, None),
+            WorkScope::Change(committed.change.id),
+        )]
+    } else {
+        entities
+            .into_iter()
+            .map(|entity| {
+                (
+                    mcp_audit_event_id(&committed.change.id, Some(&entity)),
+                    WorkScope::Entity(entity),
+                )
+            })
+            .collect()
+    };
 
     let already_recorded = graph
         .query_audit_events(Some(&actor.actor.actor_id), DEDUP_WINDOW)
@@ -517,8 +537,7 @@ fn record_commit_provenance(
     })
     .to_string();
 
-    for entity in entities {
-        let event_id = mcp_audit_event_id(&committed.change.id, &entity);
+    for (event_id, scope) in scopes {
         if already_recorded.contains(&event_id) {
             continue;
         }
@@ -527,11 +546,11 @@ fn record_commit_provenance(
                 event_id,
                 actor_id: actor.actor.actor_id,
                 action: "kin_transaction_commit".to_string(),
-                target_scope: Some(WorkScope::Entity(entity)),
+                target_scope: Some(scope.clone()),
                 timestamp: committed.change.timestamp.clone(),
                 details: Some(details.clone()),
             })
-            .map_err(|error| format!("record commit attribution for entity {entity}: {error}"))?;
+            .map_err(|error| format!("record commit attribution for {scope}: {error}"))?;
     }
     Ok(())
 }
@@ -2234,6 +2253,81 @@ mod tests {
                 .len(),
             1,
             "one write is one attribution record, however many attempts it took"
+        );
+    }
+
+    /// A commit that changed no entity is still an agent write.
+    ///
+    /// Attribution keyed only to changed entities would leave a relation-only
+    /// transaction out of the audit trail entirely, which is the same silence
+    /// this whole surface exists to end. It is attributed to the change itself.
+    #[test]
+    fn a_relation_only_commit_is_attributed_to_the_change_it_published() {
+        let (_dir, state) = test_state();
+        let (caller, _) = install_exact_source(
+            &state,
+            "src/caller.rs",
+            b"pub fn caller() -> u8 { 1 }\n",
+            "caller",
+        );
+        let (callee, _) = install_exact_source(
+            &state,
+            "src/callee.rs",
+            b"pub fn callee() -> u8 { 2 }\n",
+            "callee",
+        );
+        let sessions = kin_mcp::SessionRegistry::new();
+        let session = start_agent_session(&sessions, "gemini-cli", "relation-writer");
+        let session_id = session.session_id.to_string();
+        let transaction = sessions
+            .begin_transaction(&session_id, "relations")
+            .unwrap();
+        sessions
+            .stage_transaction(
+                &transaction.transaction_id,
+                vec![kin_mcp::McpMutationOperation {
+                    verb: "create".to_string(),
+                    target: String::new(),
+                    payload: Some(kin_mcp::McpMutationPayload::Relation {
+                        from: caller.id,
+                        to: callee.id,
+                        kind: kin_model::relation::RelationKind::Calls,
+                    }),
+                    body: None,
+                    description: "link the call".to_string(),
+                }],
+            )
+            .unwrap();
+
+        let result = commit_exact_transaction(
+            &state,
+            &sessions,
+            &HashMap::from([(
+                "transaction_id".to_string(),
+                serde_json::json!(transaction.transaction_id),
+            )]),
+            None,
+        );
+        assert_ne!(
+            result.is_error,
+            Some(true),
+            "relation-only commit failed: {}",
+            result_text(&result)
+        );
+
+        let events = state
+            .graph
+            .query_audit_events(Some(&mcp_actor_id(&session_id)), 16)
+            .unwrap();
+        assert_eq!(
+            events.len(),
+            1,
+            "a relation-only commit must still leave an attribution record"
+        );
+        assert!(
+            matches!(events[0].target_scope, Some(WorkScope::Change(_))),
+            "with no entity to scope to, the change itself is the scope: {:?}",
+            events[0].target_scope
         );
     }
 

--- a/crates/kin-daemon/src/mcp_commit.rs
+++ b/crates/kin-daemon/src/mcp_commit.rs
@@ -73,17 +73,37 @@ fn commit_exact_transaction_inner(
         .ok_or_else(|| "missing required parameter: transaction_id".to_string())?
         .to_string();
 
-    if let Some(inline) = arguments.get("operations") {
-        let operations = kin_mcp::session::parse_staged_operations(inline)?;
-        kin_mcp::session::validate_staged_operations(&operations)?;
-        sessions
-            .stage_transaction(&transaction_id, operations)
-            .map_err(|error| format!("cannot stage inline transaction operations: {error}"))?;
-    }
-
     let mut transaction = sessions
         .get_transaction(&transaction_id)
         .ok_or_else(|| format!("Transaction not found: {transaction_id}"))?;
+
+    // Operations handed to the commit call itself stage and publish in one
+    // step. Once the transaction is fenced they are read as a restatement of
+    // what is already fenced instead: `kin_transaction_commit` documents
+    // re-entry as an idempotent resume, and staging onto a fenced transaction
+    // would fail on the state check and strand a caller whose only published
+    // recovery is to re-send the identical call.
+    if let Some(inline) = arguments.get("operations") {
+        let operations = kin_mcp::session::parse_staged_operations(inline)?;
+        kin_mcp::session::validate_staged_operations(&operations)?;
+        if matches!(transaction.state.as_str(), "committing" | "committed") {
+            if !kin_mcp::session::staged_operations_match(
+                &transaction.staged_operations,
+                &operations,
+            ) {
+                return Err(format!(
+                    "Cannot commit transaction {transaction_id}: the inline operations differ from \
+                     the operations already fenced for publication, and a fenced payload cannot be \
+                     edited. Re-send the fenced operations to resume it, or begin a new transaction \
+                     with kin_transaction_begin for a different change."
+                ));
+            }
+        } else {
+            transaction = sessions
+                .stage_transaction(&transaction_id, operations)
+                .map_err(|error| format!("cannot stage inline transaction operations: {error}"))?;
+        }
+    }
     if !matches!(
         transaction.state.as_str(),
         "active" | "validated" | "committing" | "committed"
@@ -1431,6 +1451,320 @@ mod tests {
         assert_ne!(
             reparsed.fingerprint, entity.fingerprint,
             "semantic fingerprint must come from reparsing the exact new bytes"
+        );
+    }
+
+    /// Operations handed to the commit call itself must land exactly like
+    /// staged ones.
+    ///
+    /// The tool advertises the inline array as the single-call convenience
+    /// form, so a caller that uses it is entitled to the same durability as
+    /// stage-then-commit. The failure this closes reported `status: committed`
+    /// with `ops_applied: 1` while `modified_files` stayed empty and the body
+    /// never reached the file: a success response for a change that never
+    /// happened, which is the one outcome an agent cannot detect or recover
+    /// from. Read-back is byte-exact against the working file, the repository
+    /// CAS blob, and the reparsed entity.
+    #[test]
+    fn inline_operations_commit_persists_the_body_byte_exact() {
+        let (_dir, state) = test_state();
+        let (entity, _) = install_exact_source(
+            &state,
+            "src/lib.rs",
+            b"pub fn value() -> u8 { 1 }\n",
+            "value",
+        );
+        let sessions = test_sessions();
+        let transaction = sessions
+            .begin_transaction(TEST_SESSION, "file:src/lib.rs")
+            .unwrap();
+
+        // The exact shape reported as lost: an entity payload plus a body,
+        // passed on the commit call with no prior kin_transaction_stage.
+        let arguments = HashMap::from([
+            (
+                "transaction_id".to_string(),
+                serde_json::json!(transaction.transaction_id),
+            ),
+            (
+                "operations".to_string(),
+                serde_json::json!([{
+                    "verb": "update",
+                    "target": entity.id.to_string(),
+                    "payload": {"Entity": entity},
+                    "body": "pub fn value() -> u8 { 2 }",
+                    "description": "inline entity body update",
+                }]),
+            ),
+        ]);
+        let result = commit_exact_transaction(&state, &sessions, &arguments, None);
+        assert_ne!(
+            result.is_error,
+            Some(true),
+            "inline operations commit failed: {}",
+            result_text(&result)
+        );
+
+        let response: serde_json::Value = serde_json::from_str(result_text(&result)).unwrap();
+        assert_eq!(response["status"], "committed");
+        assert_eq!(response["ops_applied"], 1);
+        assert_eq!(
+            response["modified_files"],
+            serde_json::json!(["src/lib.rs"]),
+            "a committed inline body must name the file it changed: {}",
+            result_text(&result)
+        );
+
+        let expected = b"pub fn value() -> u8 { 2 }\n";
+        assert_eq!(
+            std::fs::read(state.layout.working_dir().join("src/lib.rs")).unwrap(),
+            expected,
+            "inline body must reach the working file byte-exact"
+        );
+        let after = load_native_commit_base(&state.layout).unwrap();
+        let artifact = after
+            .tree
+            .artifact_at_path(&RepoPath::from_utf8("src/lib.rs").unwrap())
+            .unwrap();
+        assert_eq!(
+            load_native_source_blob(&state.layout, artifact.entry.blob_identity().unwrap())
+                .unwrap(),
+            expected,
+            "inline body must reach repository CAS byte-exact"
+        );
+        let reparsed = after.graph.get_entity(&entity.id).unwrap().unwrap();
+        assert_ne!(
+            reparsed.fingerprint, entity.fingerprint,
+            "inline body must be reparsed into graph truth"
+        );
+    }
+
+    /// The payload-less inline form has to persist too.
+    #[test]
+    fn inline_payload_less_operations_commit_persists_the_body_byte_exact() {
+        let (_dir, state) = test_state();
+        let (entity, _) = install_exact_source(
+            &state,
+            "src/lib.rs",
+            b"pub fn value() -> u8 { 1 }\n",
+            "value",
+        );
+        let sessions = test_sessions();
+        let transaction = sessions
+            .begin_transaction(TEST_SESSION, "file:src/lib.rs")
+            .unwrap();
+
+        let arguments = HashMap::from([
+            (
+                "transaction_id".to_string(),
+                serde_json::json!(transaction.transaction_id),
+            ),
+            (
+                "operations".to_string(),
+                serde_json::json!([{
+                    "verb": "update",
+                    "target": "value",
+                    "body": "pub fn value() -> u8 { 3 }",
+                    "description": "inline payload-less body update",
+                }]),
+            ),
+        ]);
+        let result = commit_exact_transaction(&state, &sessions, &arguments, None);
+        assert_ne!(
+            result.is_error,
+            Some(true),
+            "inline payload-less commit failed: {}",
+            result_text(&result)
+        );
+
+        let expected = b"pub fn value() -> u8 { 3 }\n";
+        assert_eq!(
+            std::fs::read(state.layout.working_dir().join("src/lib.rs")).unwrap(),
+            expected
+        );
+        let after = load_native_commit_base(&state.layout).unwrap();
+        let reparsed = after.graph.get_entity(&entity.id).unwrap().unwrap();
+        assert_ne!(reparsed.fingerprint, entity.fingerprint);
+    }
+
+    /// An `operations` element carrying a key Kin does not model is refused
+    /// before anything commits.
+    ///
+    /// A caller improvising the shape reaches for `content`, `source`, or
+    /// `new_body` before it reaches for `body`. Serde ignores keys it does not
+    /// know, so the misspelled body vanished and the operation was planned as
+    /// if no body had been sent at all. Naming the unknown key is the whole
+    /// difference between a caller fixing one word and a caller concluding
+    /// that inline commits do not work.
+    #[test]
+    fn inline_operations_with_an_unmodelled_key_are_refused() {
+        let (_dir, state) = test_state();
+        let (entity, _) = install_exact_source(
+            &state,
+            "src/lib.rs",
+            b"pub fn value() -> u8 { 1 }\n",
+            "value",
+        );
+        let before = load_native_commit_base(&state.layout).unwrap();
+        let sessions = test_sessions();
+        let transaction = sessions
+            .begin_transaction(TEST_SESSION, "file:src/lib.rs")
+            .unwrap();
+
+        let arguments = HashMap::from([
+            (
+                "transaction_id".to_string(),
+                serde_json::json!(transaction.transaction_id),
+            ),
+            (
+                "operations".to_string(),
+                serde_json::json!([{
+                    "verb": "update",
+                    "target": entity.id.to_string(),
+                    "content": "pub fn value() -> u8 { 2 }",
+                    "description": "misspelled body key",
+                }]),
+            ),
+        ]);
+        let result = commit_exact_transaction(&state, &sessions, &arguments, None);
+        assert_eq!(result.is_error, Some(true));
+        assert!(
+            result_text(&result).contains("content"),
+            "the refusal must name the unknown key: {}",
+            result_text(&result)
+        );
+
+        let after = load_native_commit_base(&state.layout).unwrap();
+        assert_eq!(after.roots.generation, before.roots.generation);
+        assert_eq!(
+            std::fs::read(state.layout.working_dir().join("src/lib.rs")).unwrap(),
+            b"pub fn value() -> u8 { 1 }\n"
+        );
+    }
+
+    /// Re-sending an inline commit after its fence is a resume, not a restage.
+    ///
+    /// `kin_transaction_commit` documents itself as idempotent on re-entry: the
+    /// fenced payload resumes and the call reports whether it landed. Inline
+    /// callers were excluded from that contract, because the resume tried to
+    /// stage the same array onto a transaction no longer in `active` and died
+    /// on the staging error instead of resolving the commit. The identical
+    /// array now resumes; a different one is refused rather than appended to a
+    /// payload already fenced under a different digest.
+    #[test]
+    fn re_sent_inline_operations_resume_a_fenced_commit() {
+        let (_dir, state) = test_state();
+        let (entity, _) = install_exact_source(
+            &state,
+            "src/lib.rs",
+            b"pub fn value() -> u8 { 1 }\n",
+            "value",
+        );
+        let sessions = test_sessions();
+        let transaction = sessions
+            .begin_transaction(TEST_SESSION, "file:src/lib.rs")
+            .unwrap();
+        let operations = serde_json::json!([{
+            "verb": "update",
+            "target": entity.id.to_string(),
+            "body": "pub fn value() -> u8 { 2 }",
+            "description": "inline body update",
+        }]);
+        let arguments = HashMap::from([
+            (
+                "transaction_id".to_string(),
+                serde_json::json!(transaction.transaction_id),
+            ),
+            ("operations".to_string(), operations.clone()),
+        ]);
+
+        // Fail after the repository receipt exists, so the transaction is left
+        // fenced exactly as a crashed publication would leave it.
+        state
+            .mcp_fail_after_authority_once
+            .store(true, Ordering::SeqCst);
+        let crashed = commit_exact_transaction(&state, &sessions, &arguments, None);
+        assert_eq!(crashed.is_error, Some(true));
+        assert_eq!(
+            sessions
+                .get_transaction(&transaction.transaction_id)
+                .unwrap()
+                .state,
+            "committing"
+        );
+
+        let resumed = commit_exact_transaction(&state, &sessions, &arguments, None);
+        assert_ne!(
+            resumed.is_error,
+            Some(true),
+            "re-sending the same inline array must resume the fenced commit: {}",
+            result_text(&resumed)
+        );
+        assert_eq!(
+            std::fs::read(state.layout.working_dir().join("src/lib.rs")).unwrap(),
+            b"pub fn value() -> u8 { 2 }\n"
+        );
+    }
+
+    /// A fenced transaction must not absorb a different inline payload.
+    #[test]
+    fn divergent_inline_operations_cannot_edit_a_fenced_commit() {
+        let (_dir, state) = test_state();
+        let (entity, _) = install_exact_source(
+            &state,
+            "src/lib.rs",
+            b"pub fn value() -> u8 { 1 }\n",
+            "value",
+        );
+        let sessions = test_sessions();
+        let transaction = sessions
+            .begin_transaction(TEST_SESSION, "file:src/lib.rs")
+            .unwrap();
+        let arguments = |body: &str| {
+            HashMap::from([
+                (
+                    "transaction_id".to_string(),
+                    serde_json::json!(transaction.transaction_id),
+                ),
+                (
+                    "operations".to_string(),
+                    serde_json::json!([{
+                        "verb": "update",
+                        "target": entity.id.to_string(),
+                        "body": body,
+                        "description": "inline body update",
+                    }]),
+                ),
+            ])
+        };
+
+        state
+            .mcp_fail_after_authority_once
+            .store(true, Ordering::SeqCst);
+        let crashed = commit_exact_transaction(
+            &state,
+            &sessions,
+            &arguments("pub fn value() -> u8 { 2 }"),
+            None,
+        );
+        assert_eq!(crashed.is_error, Some(true));
+
+        let diverged = commit_exact_transaction(
+            &state,
+            &sessions,
+            &arguments("pub fn value() -> u8 { 9 }"),
+            None,
+        );
+        assert_eq!(diverged.is_error, Some(true));
+        assert!(
+            result_text(&diverged).contains("differ from the operations already fenced"),
+            "a divergent resume must say so: {}",
+            result_text(&diverged)
+        );
+        assert_eq!(
+            std::fs::read(state.layout.working_dir().join("src/lib.rs")).unwrap(),
+            b"pub fn value() -> u8 { 2 }\n",
+            "the fenced body, not the divergent one, is what authority holds"
         );
     }
 

--- a/crates/kin-daemon/src/mcp_commit.rs
+++ b/crates/kin-daemon/src/mcp_commit.rs
@@ -2331,6 +2331,84 @@ mod tests {
         );
     }
 
+    fn entity_span_by_name(state: &Arc<DaemonState>, name: &str) -> kin_model::SourceSpan {
+        state
+            .graph
+            .query_entities(&EntityFilter {
+                name_pattern: Some(name.to_string()),
+                ..EntityFilter::default()
+            })
+            .unwrap()
+            .into_iter()
+            .find(|entity| entity.name == name)
+            .unwrap_or_else(|| panic!("graph must contain {name}"))
+            .span
+            .unwrap_or_else(|| panic!("{name} must carry a source span"))
+    }
+
+    /// A commit moves the positions of entities it did not edit.
+    ///
+    /// An edit that makes one entity taller pushes everything below it down. If
+    /// the graph keeps the pre-commit position for those neighbours, then a
+    /// graph-native read after a graph-native write hands back line anchors that
+    /// no longer describe the file, and an agent deriving anything from them
+    /// derives it wrong. Positions have to move with the bytes or not be served
+    /// at all.
+    ///
+    /// Asserted against the file rather than against a constant, and accepting
+    /// either line-numbering base, so this measures freshness only. Which base
+    /// `start_line` counts from is a separate question about the read boundary
+    /// and is not what this test pins.
+    #[test]
+    fn a_commit_repositions_the_entities_it_pushed_down() {
+        let (_dir, state) = test_state();
+        let (first, _) = install_exact_source(
+            &state,
+            "src/lib.rs",
+            b"pub fn first() -> u8 { 1 }\n\npub fn second() -> u8 { 2 }\n",
+            "first",
+        );
+        let before = entity_span_by_name(&state, "second");
+
+        // Two lines taller than what it replaces.
+        let sessions = test_sessions();
+        let (_tx, arguments) =
+            stage_entity_edit(&sessions, &first, "pub fn first() -> u8 {\n    1\n}");
+        let result = commit_exact_transaction(&state, &sessions, &arguments, None);
+        assert_ne!(
+            result.is_error,
+            Some(true),
+            "commit failed: {}",
+            result_text(&result)
+        );
+
+        let after = entity_span_by_name(&state, "second");
+        assert_eq!(
+            after.start_line - before.start_line,
+            2,
+            "an untouched neighbour must move by exactly the lines inserted above it"
+        );
+
+        let file = std::fs::read_to_string(state.layout.working_dir().join("src/lib.rs")).unwrap();
+        let lines = file.lines().collect::<Vec<_>>();
+        let named = |index: u32| {
+            usize::try_from(index)
+                .ok()
+                .and_then(|index| lines.get(index))
+                .is_some_and(|line| line.contains("fn second"))
+        };
+        assert!(
+            named(after.start_line) || named(after.start_line.saturating_sub(1)),
+            "start_line {} does not land on 'fn second' under either base:\n{file}",
+            after.start_line
+        );
+        assert!(
+            file[after.start_byte..].starts_with("pub fn second"),
+            "start_byte {} must index the post-commit bytes of the entity it names",
+            after.start_byte
+        );
+    }
+
     /// A session with no registration still commits under an identity.
     #[test]
     fn a_session_without_an_agent_registration_still_names_an_author() {

--- a/crates/kin-daemon/src/mcp_commit.rs
+++ b/crates/kin-daemon/src/mcp_commit.rs
@@ -2098,8 +2098,7 @@ mod tests {
             state.graph.as_ref(),
         )
         .unwrap();
-        let provenance: serde_json::Value =
-            serde_json::from_str(result_text(&provenance)).unwrap();
+        let provenance: serde_json::Value = serde_json::from_str(result_text(&provenance)).unwrap();
         assert!(
             provenance["change_count"].as_u64().unwrap() >= 1,
             "provenance must count the MCP change: {provenance}"
@@ -2150,8 +2149,7 @@ mod tests {
         let session_id = session.session_id.to_string();
 
         for body in ["pub fn value() -> u8 { 2 }", "pub fn value() -> u8 { 3 }"] {
-            let result =
-                commit_one_entity_edit(&state, &sessions, &session_id, &entity, body);
+            let result = commit_one_entity_edit(&state, &sessions, &session_id, &entity, body);
             assert_ne!(
                 result.is_error,
                 Some(true),

--- a/crates/kin-daemon/src/mcp_commit.rs
+++ b/crates/kin-daemon/src/mcp_commit.rs
@@ -97,8 +97,11 @@ fn commit_exact_transaction_inner(
                 return Err(format!(
                     "Cannot commit transaction {transaction_id}: the inline operations differ from \
                      the operations already fenced for publication, and a fenced payload cannot be \
-                     edited. Re-send the fenced operations to resume it, or begin a new transaction \
-                     with kin_transaction_begin for a different change."
+                     edited. Re-send this commit with no `operations` array at all to resume the \
+                     fenced payload as it stands, which is the exit that always works and the one \
+                     to use when the fenced set includes operations staged separately. Re-sending \
+                     the exact fenced operations also resumes it. Begin a new transaction with \
+                     kin_transaction_begin only for a genuinely different change."
                 ));
             }
         } else {
@@ -405,6 +408,9 @@ fn resolve_commit_actor(sessions: &kin_mcp::SessionRegistry, session_id: &str) -
 /// `kin history` reads everything before the first `<` as the author's name and
 /// prints one row per revision, so an angle bracket or a newline arriving from a
 /// client-supplied session name would truncate or break the row it appears in.
+/// `/` goes too, because it is the separator the vendor and client names are
+/// joined with: a vendor of `a/b` with client `c` would otherwise render
+/// identically to a vendor of `a` with client `b/c`.
 fn provenance_label(raw: &str) -> String {
     /// Long enough for a real vendor and session name, short enough that a
     /// pathological one cannot dominate a change record.
@@ -413,7 +419,7 @@ fn provenance_label(raw: &str) -> String {
     let collapsed = raw
         .chars()
         .map(|character| {
-            if character.is_control() || matches!(character, '<' | '>') {
+            if character.is_control() || matches!(character, '<' | '>' | '/') {
                 ' '
             } else {
                 character
@@ -481,10 +487,18 @@ fn record_commit_provenance(
     committed: &NativeCommitResult,
 ) -> Result<(), String> {
     /// How far back a resume looks for the attribution it may already have
-    /// written. MCP commits are serialized behind the coordination gate, so a
-    /// resume sits within a handful of events of the attempt it is resuming;
-    /// the window is wide enough to absorb an interleaved restart and bounded
-    /// so the scan does not grow with the audit log.
+    /// written.
+    ///
+    /// Queried without an actor filter deliberately. The store applies its
+    /// limit with `take`, after any filter, so a filtered query short-circuits
+    /// only once it has found that many matching events; a session with fewer
+    /// commits than the limit never reaches it and the traversal runs the whole
+    /// log. Unfiltered, the limit bounds the traversal itself, which is the
+    /// property this needs. The derived event ids do the matching.
+    ///
+    /// MCP commits are serialized behind the coordination gate, so a resume
+    /// sits within a handful of events of the attempt it is resuming, and the
+    /// window is wide enough to absorb an interleaved restart.
     const DEDUP_WINDOW: usize = 1024;
 
     graph
@@ -520,7 +534,7 @@ fn record_commit_provenance(
     };
 
     let already_recorded = graph
-        .query_audit_events(Some(&actor.actor.actor_id), DEDUP_WINDOW)
+        .query_audit_events(None, DEDUP_WINDOW)
         .map_err(|error| format!("read existing commit attribution: {error}"))?
         .into_iter()
         .map(|event| event.event_id)
@@ -745,6 +759,29 @@ fn plan_exact_transaction(
                 {
                     return Err(format!(
                         "staged source span for entity {} does not match repository authority",
+                        existing.id
+                    ));
+                }
+                // The commit publishes whatever reparsing the new bytes derives,
+                // so a payload field the caller edited by hand cannot survive.
+                // Refusing an edited one is the same rule already applied to
+                // name, kind, origin, and span, extended to the two fields an
+                // agent would plausibly try to change on their own: keeping
+                // them would report a metadata edit as committed while
+                // publishing only the body.
+                if payload_entity.doc_summary != existing.doc_summary {
+                    return Err(format!(
+                        "staged doc summary for entity {} differs from repository authority; \
+                         entity metadata is derived from the committed source, so send it \
+                         unchanged and put the new documentation in `body`",
+                        existing.id
+                    ));
+                }
+                if payload_entity.metadata != existing.metadata {
+                    return Err(format!(
+                        "staged metadata for entity {} differs from repository authority; \
+                         entity metadata is derived from the committed source and cannot be \
+                         set directly, so send it unchanged",
                         existing.id
                     ));
                 }
@@ -2079,12 +2116,17 @@ mod tests {
             },
         )
         .unwrap();
+        // `kin history` gives the author column 20 characters and ellipsizes
+        // past that, so "claude-code/one-change-demo" (27) renders cut. Asserted
+        // in its rendered form rather than on a prefix, so the truncation is a
+        // stated property of this surface instead of an accident the assertion
+        // happens to survive.
         assert!(
             history
                 .lines
                 .iter()
-                .any(|line| line.contains("claude-code/one-c")),
-            "history must name the committing agent: {:#?}",
+                .any(|line| line.contains("claude-code/one-cha\u{2026}")),
+            "history must name the committing agent, truncated to its column: {:#?}",
             history.lines
         );
 
@@ -2150,6 +2192,203 @@ mod tests {
                 .len(),
             1,
             "the audit trail must be queryable by the agent that wrote it"
+        );
+    }
+
+    /// Asking who touched one entity must not answer with another entity's writer.
+    ///
+    /// Every field of the provenance response is keyed to the entity asked
+    /// about, so an audit list filled from the repository's most recent activity
+    /// reads as that entity's history. Before anything wrote audit events the
+    /// list was always empty and the omission was invisible; once commits record
+    /// attribution it becomes a confident wrong answer. Two entities, two
+    /// sessions, and the later commit is the unrelated one, so an unfiltered
+    /// list would put the wrong agent at the top.
+    #[test]
+    fn provenance_answers_for_the_entity_asked_about_not_the_latest_commit() {
+        let (_dir, state) = test_state();
+        let (subject, _) = install_exact_source(
+            &state,
+            "src/subject.rs",
+            b"pub fn subject() -> u8 { 1 }\n",
+            "subject",
+        );
+        let (unrelated, _) = install_exact_source(
+            &state,
+            "src/unrelated.rs",
+            b"pub fn unrelated() -> u8 { 1 }\n",
+            "unrelated",
+        );
+        let sessions = kin_mcp::SessionRegistry::new();
+
+        let author = start_agent_session(&sessions, "claude-code", "feature-work");
+        let result = commit_one_entity_edit(
+            &state,
+            &sessions,
+            &author.session_id.to_string(),
+            &subject,
+            "pub fn subject() -> u8 { 2 }",
+        );
+        assert_ne!(
+            result.is_error,
+            Some(true),
+            "subject commit failed: {}",
+            result_text(&result)
+        );
+
+        // A different session commits something else, afterwards, so it owns
+        // the most recent audit rows.
+        let other = start_agent_session(&sessions, "codex", "cleanup");
+        let result = commit_one_entity_edit(
+            &state,
+            &sessions,
+            &other.session_id.to_string(),
+            &unrelated,
+            "pub fn unrelated() -> u8 { 2 }",
+        );
+        assert_ne!(
+            result.is_error,
+            Some(true),
+            "unrelated commit failed: {}",
+            result_text(&result)
+        );
+
+        let provenance = kin_mcp::handlers::provenance::handle_provenance_query(
+            &HashMap::from([(
+                "entity_id".to_string(),
+                serde_json::json!(subject.id.to_string()),
+            )]),
+            state.graph.as_ref(),
+        )
+        .unwrap();
+        let provenance: serde_json::Value = serde_json::from_str(result_text(&provenance)).unwrap();
+        let events = provenance["recent_audit_events"].as_array().unwrap();
+        assert_eq!(
+            events.len(),
+            1,
+            "only the subject's own write belongs in its provenance: {provenance}"
+        );
+        assert_eq!(
+            events[0]["target_scope"]["Entity"],
+            serde_json::json!(subject.id.to_string()),
+            "the surviving event must name the entity that was asked about"
+        );
+        let details: serde_json::Value =
+            serde_json::from_str(events[0]["details"].as_str().unwrap()).unwrap();
+        assert_eq!(
+            details["actor"], "claude-code/feature-work",
+            "the answer must be the agent that wrote this entity, not the last agent to write anything"
+        );
+
+        // And the same query for the other entity answers with the other agent,
+        // so the filter narrows rather than simply returning the first event.
+        let other_provenance = kin_mcp::handlers::provenance::handle_provenance_query(
+            &HashMap::from([(
+                "entity_id".to_string(),
+                serde_json::json!(unrelated.id.to_string()),
+            )]),
+            state.graph.as_ref(),
+        )
+        .unwrap();
+        let other_provenance: serde_json::Value =
+            serde_json::from_str(result_text(&other_provenance)).unwrap();
+        let other_events = other_provenance["recent_audit_events"].as_array().unwrap();
+        assert_eq!(other_events.len(), 1);
+        let other_details: serde_json::Value =
+            serde_json::from_str(other_events[0]["details"].as_str().unwrap()).unwrap();
+        assert_eq!(other_details["actor"], "codex/cleanup");
+    }
+
+    /// A payload field the commit cannot honor is refused, not dropped.
+    ///
+    /// The commit publishes what reparsing the new bytes derives, so a
+    /// doc summary the caller edited by hand never lands. Committing the body
+    /// and discarding that edit reports `ops_applied: 1` for an operation only
+    /// half of which happened, which is the same defect this PR closes on the
+    /// other path, in the other half of the operation.
+    #[test]
+    fn an_edited_payload_field_the_commit_cannot_honor_is_refused() {
+        let (_dir, state) = test_state();
+        let (entity, _) = install_exact_source(
+            &state,
+            "src/lib.rs",
+            b"pub fn value() -> u8 { 1 }\n",
+            "value",
+        );
+        let before = load_native_commit_base(&state.layout).unwrap();
+        let sessions = test_sessions();
+        let transaction = sessions
+            .begin_transaction(TEST_SESSION, "file:src/lib.rs")
+            .unwrap();
+
+        let mut edited = entity.clone();
+        edited.doc_summary = Some("returns the configured value".to_string());
+        let arguments = HashMap::from([
+            (
+                "transaction_id".to_string(),
+                serde_json::json!(transaction.transaction_id),
+            ),
+            (
+                "operations".to_string(),
+                serde_json::json!([{
+                    "verb": "update",
+                    "target": entity.id.to_string(),
+                    "payload": {"Entity": edited},
+                    "body": "pub fn value() -> u8 { 2 }",
+                    "description": "body edit plus a hand-edited doc summary",
+                }]),
+            ),
+        ]);
+        let result = commit_exact_transaction(&state, &sessions, &arguments, None);
+        assert_eq!(
+            result.is_error,
+            Some(true),
+            "a metadata edit that cannot land must be refused: {}",
+            result_text(&result)
+        );
+        assert!(
+            result_text(&result).contains("doc summary"),
+            "the refusal must name the field it could not honor: {}",
+            result_text(&result)
+        );
+
+        let after = load_native_commit_base(&state.layout).unwrap();
+        assert_eq!(
+            after.roots.generation, before.roots.generation,
+            "the body must not land on its own while the metadata half is refused"
+        );
+        assert_eq!(
+            std::fs::read(state.layout.working_dir().join("src/lib.rs")).unwrap(),
+            b"pub fn value() -> u8 { 1 }\n"
+        );
+    }
+
+    /// An unchanged payload beside a body still commits.
+    ///
+    /// The refusal above is scoped to a field the caller edited. Echoing back
+    /// the entity exactly as it was read is the documented shape and must keep
+    /// working.
+    #[test]
+    fn an_unedited_payload_beside_a_body_still_commits() {
+        let (_dir, state) = test_state();
+        let (entity, _) = install_exact_source(
+            &state,
+            "src/lib.rs",
+            b"pub fn value() -> u8 { 1 }\n",
+            "value",
+        );
+        let sessions = test_sessions();
+        let (_tx, arguments) = stage_entity_edit(&sessions, &entity, "pub fn value() -> u8 { 2 }");
+        let result = commit_exact_transaction(&state, &sessions, &arguments, None);
+        assert_ne!(
+            result.is_error,
+            Some(true),
+            "an unedited payload must still commit: {}",
+            result_text(&result)
+        );
+        assert_eq!(
+            std::fs::read(state.layout.working_dir().join("src/lib.rs")).unwrap(),
+            b"pub fn value() -> u8 { 2 }\n"
         );
     }
 

--- a/crates/kin-daemon/src/mcp_commit.rs
+++ b/crates/kin-daemon/src/mcp_commit.rs
@@ -15,10 +15,13 @@ use std::path::PathBuf;
 use std::sync::atomic::Ordering;
 use std::sync::Arc;
 
+use kin_model::graph::ProvenanceStore;
+use kin_model::provenance::{Actor, ActorId, ActorKind, AuditEvent, AuditEventId};
+use kin_model::work::WorkScope;
 use kin_model::{
-    Entity, EntityDelta, EntityStore, FileLayout, FilePathId, GraphNodeId, Hash256, LocatedEntry,
-    OperationId, Relation, RelationDelta, RelationOrigin, RepoPath, SourceRegion, TransactionDelta,
-    TreeDelta, TreeEntry,
+    Entity, EntityDelta, EntityId, EntityStore, FileLayout, FilePathId, GraphNodeId, Hash256,
+    LocatedEntry, OperationId, Relation, RelationDelta, RelationOrigin, RepoPath, SemanticChangeId,
+    SourceRegion, TransactionDelta, TreeDelta, TreeEntry,
 };
 use sha2::{Digest, Sha256};
 
@@ -142,6 +145,10 @@ fn commit_exact_transaction_inner(
     let operation_id = OperationId::from_uuid(operation_uuid);
     let payload_hash = transaction_payload_hash(&transaction)?;
     let authority_context = authority_context(state)?;
+    // Resolved once, from the live registry, and used for both the change
+    // author and the durable attribution record. Resolving it twice could
+    // straddle the session ending and attribute one commit two ways.
+    let actor = resolve_commit_actor(sessions, &transaction.session_id);
 
     // A non-terminal committing marker means authority may already have moved.
     // Recover by the caller-stable operation ID before attempting any new plan.
@@ -158,6 +165,7 @@ fn commit_exact_transaction_inner(
                 state,
                 sessions,
                 transaction,
+                &actor,
                 recovered,
                 Vec::new(),
                 coordination,
@@ -187,6 +195,7 @@ fn commit_exact_transaction_inner(
         state,
         &authority_context,
         &transaction,
+        &actor,
         operation_id,
         &base,
     ) {
@@ -261,6 +270,7 @@ fn commit_exact_transaction_inner(
         state,
         sessions,
         transaction,
+        &actor,
         committed,
         plan.layouts,
         coordination,
@@ -345,6 +355,185 @@ fn describe_cleared_operation(operation: &kin_mcp::McpMutationOperation) -> Stri
         ("", _) => format!("{verb} (unnamed target)"),
         (target, _) => format!("{verb} {target}"),
     }
+}
+
+/// Who a committed MCP transaction is attributed to.
+///
+/// The actor is the agent session that opened the transaction. A raw session id
+/// identifies nobody once that session ends, and the session registry is
+/// in-memory, so the vendor and client name the session registered with are
+/// copied into the commit author and into a durable actor record at commit
+/// time. The session id stays inside the author so a live coordination lookup
+/// remains possible while the session is running, and so the two records can be
+/// tied together afterwards.
+struct CommitActor {
+    author: kin_model::AuthorId,
+    actor: Actor,
+    session_id: String,
+}
+
+fn resolve_commit_actor(sessions: &kin_mcp::SessionRegistry, session_id: &str) -> CommitActor {
+    let agent = uuid::Uuid::parse_str(session_id)
+        .ok()
+        .map(kin_model::SessionId)
+        .and_then(|id| sessions.get_agent_session(&id));
+    let display_name = match agent {
+        Some(agent) => format!(
+            "{}/{}",
+            provenance_label(&agent.vendor),
+            provenance_label(&agent.client_name)
+        ),
+        // A session registered through the legacy compatibility surface, or one
+        // that has already ended, has no vendor to name. The id it committed
+        // under is still an identity, and is better than an empty author.
+        None => provenance_label(session_id),
+    };
+    CommitActor {
+        author: kin_model::AuthorId::new(format!("{display_name} <mcp-agent:{session_id}>")),
+        actor: Actor {
+            actor_id: mcp_actor_id(session_id),
+            kind: ActorKind::Assistant,
+            display_name,
+            external_refs: Vec::new(),
+        },
+        session_id: session_id.to_string(),
+    }
+}
+
+/// One field of a provenance display name, made safe to render.
+///
+/// `kin history` reads everything before the first `<` as the author's name and
+/// prints one row per revision, so an angle bracket or a newline arriving from a
+/// client-supplied session name would truncate or break the row it appears in.
+fn provenance_label(raw: &str) -> String {
+    /// Long enough for a real vendor and session name, short enough that a
+    /// pathological one cannot dominate a change record.
+    const MAX_LABEL: usize = 64;
+
+    let collapsed = raw
+        .chars()
+        .map(|character| {
+            if character.is_control() || matches!(character, '<' | '>') {
+                ' '
+            } else {
+                character
+            }
+        })
+        .collect::<String>()
+        .split_whitespace()
+        .collect::<Vec<_>>()
+        .join(" ");
+    if collapsed.is_empty() {
+        return "unknown".to_string();
+    }
+    collapsed.chars().take(MAX_LABEL).collect()
+}
+
+/// A stable actor identity for one MCP session.
+///
+/// Derived rather than random so every commit a session makes resolves to the
+/// same actor, which is what lets `query_audit_events` filter by actor and what
+/// keeps a session's writes from reading as a crowd of one-commit strangers.
+fn mcp_actor_id(session_id: &str) -> ActorId {
+    let mut hasher = Sha256::new();
+    hasher.update(b"kin-mcp-session-actor-v1\0");
+    hasher.update(session_id.as_bytes());
+    ActorId::from_hash(Hash256::from_bytes(hasher.finalize().into()))
+}
+
+/// A stable audit-event identity for one entity within one committed change.
+///
+/// Derived so a commit that is resumed after a crash re-derives the identifiers
+/// it already wrote instead of appending a second attribution record for a
+/// single write.
+fn mcp_audit_event_id(change: &SemanticChangeId, entity: &EntityId) -> AuditEventId {
+    let mut hasher = Sha256::new();
+    hasher.update(b"kin-mcp-commit-audit-v1\0");
+    hasher.update(change.to_string().as_bytes());
+    hasher.update([0]);
+    hasher.update(entity.to_string().as_bytes());
+    AuditEventId::from_hash(Hash256::from_bytes(hasher.finalize().into()))
+}
+
+/// Record who committed, and what they touched, into the provenance surfaces.
+///
+/// Without this an MCP write is anonymous to every read surface that answers
+/// "who changed this": `kin_provenance_query` returns no audit context, and
+/// `kin-review`'s impact analysis, which resolves attribution and its
+/// unreviewed-agent-change signal entirely from audit events and the actor they
+/// name, treats an agent's commit as if nobody made it. The change author alone
+/// does not reach either, because both read the audit trail.
+///
+/// One event per changed entity, because that is the scope the review layer
+/// matches on. Called only after the repository receipt exists, so nothing is
+/// attributed to a commit that did not land.
+fn record_commit_provenance(
+    graph: &kin_db::InMemoryGraph,
+    actor: &CommitActor,
+    transaction: &kin_mcp::McpTransaction,
+    committed: &NativeCommitResult,
+) -> Result<(), String> {
+    /// How far back a resume looks for the attribution it may already have
+    /// written. MCP commits are serialized behind the coordination gate, so a
+    /// resume sits within a handful of events of the attempt it is resuming;
+    /// the window is wide enough to absorb an interleaved restart and bounded
+    /// so the scan does not grow with the audit log.
+    const DEDUP_WINDOW: usize = 1024;
+
+    graph
+        .create_actor(&actor.actor)
+        .map_err(|error| format!("record committing agent actor: {error}"))?;
+
+    let mut entities = committed
+        .change
+        .entity_deltas
+        .iter()
+        .map(|delta| match delta {
+            EntityDelta::Added { new } | EntityDelta::Modified { new, .. } => new.id,
+            EntityDelta::Removed { old } => old.id,
+        })
+        .collect::<Vec<_>>();
+    entities.sort_unstable();
+    entities.dedup();
+    if entities.is_empty() {
+        return Ok(());
+    }
+
+    let already_recorded = graph
+        .query_audit_events(Some(&actor.actor.actor_id), DEDUP_WINDOW)
+        .map_err(|error| format!("read existing commit attribution: {error}"))?
+        .into_iter()
+        .map(|event| event.event_id)
+        .collect::<HashSet<_>>();
+
+    let details = serde_json::json!({
+        "schema": "kin.mcp.commit_audit.v1",
+        "transaction_id": transaction.transaction_id,
+        "session_id": actor.session_id,
+        "actor": actor.actor.display_name,
+        "change_id": committed.change.id.to_string(),
+        "repository_generation": committed.receipt.generation,
+        "repository_operation_id": committed.receipt.operation_id.to_string(),
+    })
+    .to_string();
+
+    for entity in entities {
+        let event_id = mcp_audit_event_id(&committed.change.id, &entity);
+        if already_recorded.contains(&event_id) {
+            continue;
+        }
+        graph
+            .record_audit_event(&AuditEvent {
+                event_id,
+                actor_id: actor.actor.actor_id,
+                action: "kin_transaction_commit".to_string(),
+                target_scope: Some(WorkScope::Entity(entity)),
+                timestamp: committed.change.timestamp.clone(),
+                details: Some(details.clone()),
+            })
+            .map_err(|error| format!("record commit attribution for entity {entity}: {error}"))?;
+    }
+    Ok(())
 }
 
 fn transaction_payload_hash(transaction: &kin_mcp::McpTransaction) -> Result<String, String> {
@@ -438,6 +627,7 @@ fn plan_exact_transaction(
     state: &DaemonState,
     authority_context: &LocalRepositoryAuthorityContext,
     transaction: &kin_mcp::McpTransaction,
+    actor: &CommitActor,
     operation_id: OperationId,
     base: &NativeCommitBase,
 ) -> Result<ExactMcpPlan, String> {
@@ -697,7 +887,7 @@ fn plan_exact_transaction(
         authority_context,
         operation_id,
         kin_model::Timestamp::now(),
-        kin_model::AuthorId::new(format!("mcp:{}", transaction.session_id)),
+        actor.author.clone(),
         message,
         base,
     )
@@ -882,6 +1072,7 @@ fn finalize_committed_transaction(
     state: &Arc<DaemonState>,
     sessions: &kin_mcp::SessionRegistry,
     transaction: kin_mcp::McpTransaction,
+    actor: &CommitActor,
     committed: NativeCommitResult,
     planned_layouts: Vec<FileLayout>,
     coordination: Option<&kin_mcp::CoordinationWritePreflight>,
@@ -913,6 +1104,7 @@ fn finalize_committed_transaction(
             transaction.transaction_id
         ));
     }
+    record_commit_provenance(state.graph.as_ref(), actor, &transaction, &committed)?;
 
     let observed_generation = state.snapshot_generation.load(Ordering::SeqCst);
     if observed_generation < committed.receipt.generation {
@@ -1765,6 +1957,325 @@ mod tests {
             std::fs::read(state.layout.working_dir().join("src/lib.rs")).unwrap(),
             b"pub fn value() -> u8 { 2 }\n",
             "the fenced body, not the divergent one, is what authority holds"
+        );
+    }
+
+    /// A live agent session, the way `kin_session_start` registers one.
+    fn start_agent_session(
+        sessions: &kin_mcp::SessionRegistry,
+        vendor: &str,
+        client_name: &str,
+    ) -> kin_model::session::AgentSession {
+        sessions.start_agent_session(
+            vendor,
+            client_name,
+            kin_model::session::SessionTransport::Mcp,
+            None,
+            PathBuf::from("/tmp"),
+            kin_model::session::SessionCapabilities {
+                can_write: true,
+                can_commit: true,
+                ..kin_model::session::SessionCapabilities::default()
+            },
+        )
+    }
+
+    fn commit_one_entity_edit(
+        state: &Arc<DaemonState>,
+        sessions: &kin_mcp::SessionRegistry,
+        session_id: &str,
+        entity: &Entity,
+        body: &str,
+    ) -> kin_mcp::ToolCallResult {
+        let transaction = sessions
+            .begin_transaction(session_id, "file:src/lib.rs")
+            .unwrap();
+        sessions
+            .stage_transaction(
+                &transaction.transaction_id,
+                vec![kin_mcp::McpMutationOperation {
+                    verb: "update".to_string(),
+                    target: entity.id.to_string(),
+                    payload: None,
+                    body: Some(body.to_string()),
+                    description: "attributed body update".to_string(),
+                }],
+            )
+            .unwrap();
+        commit_exact_transaction(
+            state,
+            sessions,
+            &HashMap::from([(
+                "transaction_id".to_string(),
+                serde_json::json!(transaction.transaction_id),
+            )]),
+            None,
+        )
+    }
+
+    /// An agent's commit has to be attributable afterwards, by name.
+    ///
+    /// The pitch is that the graph knows who changed what, and an MCP write
+    /// used to leave nothing any read surface could answer that with: the audit
+    /// trail was empty, no actor existed, and the only identity anywhere was a
+    /// session id that lived in the live response and nowhere else. Sealing the
+    /// change later with `kin commit` then attributed the operator who ran the
+    /// CLI, not the agent that wrote the code. This asserts every surface an
+    /// operator would actually reach for.
+    #[test]
+    fn a_committed_transaction_is_attributable_to_the_agent_that_made_it() {
+        let (_dir, state) = test_state();
+        let (entity, _) = install_exact_source(
+            &state,
+            "src/lib.rs",
+            b"pub fn value() -> u8 { 1 }\n",
+            "value",
+        );
+        let sessions = kin_mcp::SessionRegistry::new();
+        let session = start_agent_session(&sessions, "claude-code", "one-change-demo");
+        let session_id = session.session_id.to_string();
+
+        let result = commit_one_entity_edit(
+            &state,
+            &sessions,
+            &session_id,
+            &entity,
+            "pub fn value() -> u8 { 2 }",
+        );
+        assert_ne!(
+            result.is_error,
+            Some(true),
+            "attributed commit failed: {}",
+            result_text(&result)
+        );
+
+        // kin history: the agent's name, not an opaque id and not the operator.
+        let binding = state.local_repository_authority_binding().unwrap();
+        let history = kin_cli::commands::history::execute_history_request(
+            &binding,
+            state.graph.as_ref(),
+            &kin_cli::commands::history::HistoryRequest {
+                entity: "value".to_string(),
+                reference: None,
+            },
+        )
+        .unwrap();
+        assert!(
+            history
+                .lines
+                .iter()
+                .any(|line| line.contains("claude-code/one-c")),
+            "history must name the committing agent: {:#?}",
+            history.lines
+        );
+
+        // kin blame: the full author, so the session id is recoverable from a
+        // read surface after the session itself is gone.
+        let blame = kin_cli::commands::blame::execute_blame_request(
+            &binding,
+            state.graph.as_ref(),
+            &kin_cli::commands::blame::BlameRequest {
+                entity: "value".to_string(),
+                reference: None,
+            },
+        )
+        .unwrap();
+        assert!(
+            blame
+                .lines
+                .iter()
+                .any(|line| line.contains(&format!("mcp-agent:{session_id}"))),
+            "blame must carry the committing session id: {:#?}",
+            blame.lines
+        );
+
+        // kin_provenance_query: change count, latest change, and audit context.
+        let provenance = kin_mcp::handlers::provenance::handle_provenance_query(
+            &HashMap::from([(
+                "entity_id".to_string(),
+                serde_json::json!(entity.id.to_string()),
+            )]),
+            state.graph.as_ref(),
+        )
+        .unwrap();
+        let provenance: serde_json::Value =
+            serde_json::from_str(result_text(&provenance)).unwrap();
+        assert!(
+            provenance["change_count"].as_u64().unwrap() >= 1,
+            "provenance must count the MCP change: {provenance}"
+        );
+        assert!(!provenance["latest_change"].is_null());
+        let events = provenance["recent_audit_events"].as_array().unwrap();
+        assert_eq!(
+            events.len(),
+            1,
+            "one commit of one entity is one attribution record: {provenance}"
+        );
+        assert_eq!(events[0]["action"], "kin_transaction_commit");
+        let details: serde_json::Value =
+            serde_json::from_str(events[0]["details"].as_str().unwrap()).unwrap();
+        assert_eq!(details["session_id"], session_id);
+        assert_eq!(details["actor"], "claude-code/one-change-demo");
+
+        // The actor the audit event names resolves, and resolves as an agent:
+        // this is what kin-review's impact analysis reads to decide an agent
+        // change went in unreviewed.
+        let actor_id = mcp_actor_id(&session_id);
+        let actor = state.graph.get_actor(&actor_id).unwrap().unwrap();
+        assert_eq!(actor.kind, ActorKind::Assistant);
+        assert_eq!(actor.display_name, "claude-code/one-change-demo");
+        assert_eq!(
+            state
+                .graph
+                .query_audit_events(Some(&actor_id), 16)
+                .unwrap()
+                .len(),
+            1,
+            "the audit trail must be queryable by the agent that wrote it"
+        );
+    }
+
+    /// Two commits by one session are two records by one actor.
+    #[test]
+    fn one_agent_session_keeps_one_actor_identity_across_commits() {
+        let (_dir, state) = test_state();
+        let (entity, _) = install_exact_source(
+            &state,
+            "src/lib.rs",
+            b"pub fn value() -> u8 { 1 }\n",
+            "value",
+        );
+        let sessions = kin_mcp::SessionRegistry::new();
+        let session = start_agent_session(&sessions, "codex", "repeat-writer");
+        let session_id = session.session_id.to_string();
+
+        for body in ["pub fn value() -> u8 { 2 }", "pub fn value() -> u8 { 3 }"] {
+            let result =
+                commit_one_entity_edit(&state, &sessions, &session_id, &entity, body);
+            assert_ne!(
+                result.is_error,
+                Some(true),
+                "commit failed: {}",
+                result_text(&result)
+            );
+        }
+
+        let actor_id = mcp_actor_id(&session_id);
+        assert_eq!(
+            state.graph.list_actors().unwrap().len(),
+            1,
+            "a session is one actor, not one per commit"
+        );
+        assert_eq!(
+            state
+                .graph
+                .query_audit_events(Some(&actor_id), 16)
+                .unwrap()
+                .len(),
+            2,
+            "each commit contributes its own attribution record"
+        );
+    }
+
+    /// A resumed commit must not double-count itself in the audit trail.
+    ///
+    /// Attribution is written after the repository receipt exists, and the
+    /// receipt path is re-entered on resume. A second record for one write
+    /// would read as an agent that committed twice.
+    #[test]
+    fn a_resumed_commit_records_its_attribution_once() {
+        let (_dir, state) = test_state();
+        let (entity, _) = install_exact_source(
+            &state,
+            "src/lib.rs",
+            b"pub fn value() -> u8 { 1 }\n",
+            "value",
+        );
+        let sessions = kin_mcp::SessionRegistry::new();
+        let session = start_agent_session(&sessions, "claude-code", "resumed-writer");
+        let session_id = session.session_id.to_string();
+        let transaction = sessions
+            .begin_transaction(&session_id, "file:src/lib.rs")
+            .unwrap();
+        sessions
+            .stage_transaction(
+                &transaction.transaction_id,
+                vec![kin_mcp::McpMutationOperation {
+                    verb: "update".to_string(),
+                    target: entity.id.to_string(),
+                    payload: None,
+                    body: Some("pub fn value() -> u8 { 2 }".to_string()),
+                    description: "attributed body update".to_string(),
+                }],
+            )
+            .unwrap();
+        let arguments = HashMap::from([(
+            "transaction_id".to_string(),
+            serde_json::json!(transaction.transaction_id),
+        )]);
+
+        state
+            .mcp_fail_after_authority_once
+            .store(true, Ordering::SeqCst);
+        let crashed = commit_exact_transaction(&state, &sessions, &arguments, None);
+        assert_eq!(crashed.is_error, Some(true));
+
+        let resumed = commit_exact_transaction(&state, &sessions, &arguments, None);
+        assert_ne!(
+            resumed.is_error,
+            Some(true),
+            "resume failed: {}",
+            result_text(&resumed)
+        );
+
+        assert_eq!(
+            state
+                .graph
+                .query_audit_events(Some(&mcp_actor_id(&session_id)), 16)
+                .unwrap()
+                .len(),
+            1,
+            "one write is one attribution record, however many attempts it took"
+        );
+    }
+
+    /// A session with no registration still commits under an identity.
+    #[test]
+    fn a_session_without_an_agent_registration_still_names_an_author() {
+        let (_dir, state) = test_state();
+        let (entity, _) = install_exact_source(
+            &state,
+            "src/lib.rs",
+            b"pub fn value() -> u8 { 1 }\n",
+            "value",
+        );
+        let sessions = test_sessions();
+        let (_tx, arguments) = stage_entity_edit(&sessions, &entity, "pub fn value() -> u8 { 2 }");
+        let result = commit_exact_transaction(&state, &sessions, &arguments, None);
+        assert_ne!(result.is_error, Some(true), "{}", result_text(&result));
+
+        let binding = state.local_repository_authority_binding().unwrap();
+        let history = kin_cli::commands::history::execute_history_request(
+            &binding,
+            state.graph.as_ref(),
+            &kin_cli::commands::history::HistoryRequest {
+                entity: "value".to_string(),
+                reference: None,
+            },
+        )
+        .unwrap();
+        assert!(
+            history.lines.iter().any(|line| line.contains(TEST_SESSION)),
+            "an unregistered session still commits under the id it used: {:#?}",
+            history.lines
+        );
+        assert_eq!(
+            state
+                .graph
+                .query_audit_events(Some(&mcp_actor_id(TEST_SESSION)), 16)
+                .unwrap()
+                .len(),
+            1
         );
     }
 

--- a/crates/kin-daemon/src/mcp_commit.rs
+++ b/crates/kin-daemon/src/mcp_commit.rs
@@ -514,9 +514,36 @@ fn record_commit_provenance(
             EntityDelta::Removed { old } => old.id,
         })
         .collect::<Vec<_>>();
+    // A relation-only commit changed no entity, so it has no entity delta to
+    // scope to, but it is still an agent write against the entities the relation
+    // joins. Scoping it to the change alone made it unfindable: every reader
+    // that answers "who touched this entity" selects changes by scanning entity
+    // deltas, which a relation-only change has none of, so the commit was
+    // recorded and invisible. Its endpoints are the entities an operator would
+    // ask about, so they are what it is attributed to.
+    if entities.is_empty() {
+        entities.extend(
+            committed
+                .change
+                .relation_deltas
+                .iter()
+                .flat_map(|delta| match delta {
+                    RelationDelta::Added { new } | RelationDelta::Modified { new, .. } => {
+                        [new.src, new.dst]
+                    }
+                    RelationDelta::Removed { old } => [old.src, old.dst],
+                })
+                .filter_map(|endpoint| match endpoint {
+                    GraphNodeId::Entity(id) => Some(id),
+                    _ => None,
+                }),
+        );
+    }
     entities.sort_unstable();
     entities.dedup();
     let scopes = if entities.is_empty() {
+        // Nothing entity-shaped to name, so the change itself carries the
+        // attribution rather than the write going unrecorded.
         vec![(
             mcp_audit_event_id(&committed.change.id, None),
             WorkScope::Change(committed.change.id),
@@ -763,25 +790,28 @@ fn plan_exact_transaction(
                     ));
                 }
                 // The commit publishes whatever reparsing the new bytes derives,
-                // so a payload field the caller edited by hand cannot survive.
+                // so a doc summary the caller edited by hand cannot survive.
                 // Refusing an edited one is the same rule already applied to
-                // name, kind, origin, and span, extended to the two fields an
-                // agent would plausibly try to change on their own: keeping
-                // them would report a metadata edit as committed while
-                // publishing only the body.
+                // name, kind, origin, and span: keeping it would report a
+                // documentation edit as committed while publishing only the
+                // body.
+                //
+                // Scoped to `doc_summary` and deliberately not extended to the
+                // whole `metadata` bag. That bag holds keys the daemon's own
+                // workers maintain, `embedding_body_preview` from the embed
+                // pipeline and `blob_hash` from indexing, and they move
+                // asynchronously with respect to any caller. An agent that
+                // reads an entity, thinks, and then commits can therefore hold
+                // a metadata bag that authority has since moved on from, and
+                // comparing the bag would refuse it for a difference it neither
+                // caused nor can control. `doc_summary` is a single named field
+                // whose value a caller either changed on purpose or did not, so
+                // a difference there is real evidence of intent.
                 if payload_entity.doc_summary != existing.doc_summary {
                     return Err(format!(
                         "staged doc summary for entity {} differs from repository authority; \
-                         entity metadata is derived from the committed source, so send it \
+                         entity documentation is derived from the committed source, so send it \
                          unchanged and put the new documentation in `body`",
-                        existing.id
-                    ));
-                }
-                if payload_entity.metadata != existing.metadata {
-                    return Err(format!(
-                        "staged metadata for entity {} differs from repository authority; \
-                         entity metadata is derived from the committed source and cannot be \
-                         set directly, so send it unchanged",
                         existing.id
                     ));
                 }
@@ -2363,6 +2393,95 @@ mod tests {
         );
     }
 
+    /// The payload an agent actually builds is what `get_entity` handed it,
+    /// decoded from the wire, and it has to commit.
+    ///
+    /// This is the shape the product uses: call `get_entity`, take the returned
+    /// object whole, add a `body`, commit. It is not the same as echoing the
+    /// in-memory struct, because `entity_response_json` injects ten
+    /// response-only keys at top level (read_path, start_line, end_line,
+    /// source_excerpt, source_change_id, artifact_id, artifact_path,
+    /// artifact_entry, stale, source) and `Entity` does not deny unknown
+    /// fields.
+    ///
+    /// What this pins is that the round trip is faithful: those keys are
+    /// discarded on the way back in and land nowhere, so an echoed payload
+    /// equals what authority holds. That is worth a test because it is not
+    /// obvious. `EntityMetadata` is `#[serde(flatten)] extra: HashMap`, so it
+    /// absorbs unknown keys found inside the `metadata` object; `Entity.metadata`
+    /// is a plain named field, so top-level decorations never reach it. Flip
+    /// either of those and every field-by-field check the commit planner makes
+    /// against authority starts refusing a caller that did nothing but echo.
+    #[test]
+    fn a_payload_decoded_from_a_real_get_entity_response_still_commits() {
+        let (_dir, state) = test_state();
+        let (entity, _) = install_exact_source(
+            &state,
+            "src/lib.rs",
+            b"pub fn value() -> u8 { 1 }\n",
+            "value",
+        );
+
+        // The exact bytes `get_entity` returns, then straight back in as the
+        // payload, which is the round trip nothing else in the workspace walks.
+        let binding = state.local_repository_authority_binding().unwrap();
+        let response = kin_mcp::handlers::common::entity_response_json(
+            state.graph.as_ref(),
+            &entity,
+            Some(&binding),
+        )
+        .expect("the read surface must render the entity");
+        for injected in ["read_path", "start_line", "source_excerpt", "stale"] {
+            assert!(
+                response.get(injected).is_some(),
+                "fixture must exercise a response carrying the injected key {injected}: {response}"
+            );
+        }
+        let echoed: Entity = serde_json::from_value(response)
+            .expect("a get_entity response must decode back into an Entity");
+        assert_eq!(
+            echoed.metadata, entity.metadata,
+            "response-only keys must be discarded on decode, not folded into metadata"
+        );
+        assert_eq!(
+            echoed.doc_summary, entity.doc_summary,
+            "an echoed payload must carry the doc summary authority holds"
+        );
+
+        let sessions = test_sessions();
+        let transaction = sessions
+            .begin_transaction(TEST_SESSION, "file:src/lib.rs")
+            .unwrap();
+        let arguments = HashMap::from([
+            (
+                "transaction_id".to_string(),
+                serde_json::json!(transaction.transaction_id),
+            ),
+            (
+                "operations".to_string(),
+                serde_json::json!([{
+                    "verb": "update",
+                    "target": entity.id.to_string(),
+                    "payload": {"Entity": echoed},
+                    "body": "pub fn value() -> u8 { 2 }",
+                    "description": "echo the read response back as the payload",
+                }]),
+            ),
+        ]);
+        let result = commit_exact_transaction(&state, &sessions, &arguments, None);
+        assert_ne!(
+            result.is_error,
+            Some(true),
+            "a payload echoed from a real get_entity response must commit: {}",
+            result_text(&result)
+        );
+        assert_eq!(
+            std::fs::read(state.layout.working_dir().join("src/lib.rs")).unwrap(),
+            b"pub fn value() -> u8 { 2 }\n",
+            "the body must land for the payload shape the product actually builds"
+        );
+    }
+
     /// An unchanged payload beside a body still commits.
     ///
     /// The refusal above is scoped to a field the caller edited. Echoing back
@@ -2495,13 +2614,19 @@ mod tests {
         );
     }
 
-    /// A commit that changed no entity is still an agent write.
+    /// A relation-only commit must be answerable through the surface an
+    /// operator actually asks.
     ///
     /// Attribution keyed only to changed entities would leave a relation-only
-    /// transaction out of the audit trail entirely, which is the same silence
-    /// this whole surface exists to end. It is attributed to the change itself.
+    /// transaction out of the audit trail entirely. Scoping it to the change
+    /// instead was no better in practice: every reader that answers "who touched
+    /// this entity" selects changes by scanning entity deltas, and a
+    /// relation-only change has none, so the record existed and no query could
+    /// reach it. Asserted through `kin_provenance_query` rather than through
+    /// `query_audit_events`, because querying the store directly is exactly what
+    /// hid the gap.
     #[test]
-    fn a_relation_only_commit_is_attributed_to_the_change_it_published() {
+    fn a_relation_only_commit_is_attributed_to_the_entities_it_joined() {
         let (_dir, state) = test_state();
         let (caller, _) = install_exact_source(
             &state,
@@ -2560,14 +2685,45 @@ mod tests {
             .unwrap();
         assert_eq!(
             events.len(),
-            1,
-            "a relation-only commit must still leave an attribution record"
+            2,
+            "a relation-only commit is attributed to both endpoints it joined"
         );
-        assert!(
-            matches!(events[0].target_scope, Some(WorkScope::Change(_))),
-            "with no entity to scope to, the change itself is the scope: {:?}",
-            events[0].target_scope
-        );
+        let mut scoped = events
+            .iter()
+            .filter_map(|event| match event.target_scope {
+                Some(WorkScope::Entity(id)) => Some(id),
+                _ => None,
+            })
+            .collect::<Vec<_>>();
+        scoped.sort_unstable();
+        let mut expected = vec![caller.id, callee.id];
+        expected.sort_unstable();
+        assert_eq!(scoped, expected, "both endpoints must be named");
+
+        // The surface that matters: asking about either endpoint returns the
+        // agent that created the relation.
+        for endpoint in [&caller, &callee] {
+            let provenance = kin_mcp::handlers::provenance::handle_provenance_query(
+                &HashMap::from([(
+                    "entity_id".to_string(),
+                    serde_json::json!(endpoint.id.to_string()),
+                )]),
+                state.graph.as_ref(),
+            )
+            .unwrap();
+            let provenance: serde_json::Value =
+                serde_json::from_str(result_text(&provenance)).unwrap();
+            let events = provenance["recent_audit_events"].as_array().unwrap();
+            assert_eq!(
+                events.len(),
+                1,
+                "provenance for {} must reach the relation write: {provenance}",
+                endpoint.name
+            );
+            let details: serde_json::Value =
+                serde_json::from_str(events[0]["details"].as_str().unwrap()).unwrap();
+            assert_eq!(details["actor"], "gemini-cli/relation-writer");
+        }
     }
 
     fn entity_span_by_name(state: &Arc<DaemonState>, name: &str) -> kin_model::SourceSpan {

--- a/crates/kin-mcp/src/handlers/mod.rs
+++ b/crates/kin-mcp/src/handlers/mod.rs
@@ -3477,6 +3477,73 @@ mod tests {
         }
     }
 
+    /// The widened refusal must be unreachable on the product surface.
+    ///
+    /// Refusing a body is only safe because `kin mcp start` pins
+    /// `DaemonRequired`, and in that mode every arm of the delegate match
+    /// returns before the in-process path is reached: a live daemon takes the
+    /// commit, and an unreachable one gets `daemon_required_unavailable`. That
+    /// invariant is the entire safety argument, and it currently holds only
+    /// because `uses_daemon()` and `requires_daemon()` happen to return the same
+    /// thing. They are separate methods, and the delegate match already carries
+    /// the fall-through arm that a third mode would activate; the first mode
+    /// that preferred a daemon but tolerated its absence would route product
+    /// writes into a path that refuses every body-carrying operation.
+    ///
+    /// Pinned here so that change fails a test instead of failing a user.
+    #[tokio::test]
+    async fn daemon_required_mode_never_reaches_the_in_process_refusal() {
+        use crate::session::{McpMutationOperation, McpMutationPayload};
+
+        let store = InMemoryGraph::default();
+        let entity = placement_free_entity("value");
+        store.upsert_entity(&entity).unwrap();
+
+        let sessions = SessionRegistry::new();
+        sessions.set_coordination_mode(crate::session::CoordinationEnforcementMode::Warn);
+        // Staged under OfflineFallback so the transaction exists locally; the
+        // commit below is the call under test.
+        let tx_id = begin_offline_transaction(&sessions, "daemon-required-refusal").await;
+        sessions
+            .stage_transaction(
+                &tx_id,
+                vec![McpMutationOperation {
+                    verb: "update".into(),
+                    target: entity.id.to_string(),
+                    payload: None::<McpMutationPayload>,
+                    body: Some("pub fn value() -> u8 { 2 }".into()),
+                    description: "body update".into(),
+                }],
+            )
+            .unwrap();
+
+        let mut commit_args = HashMap::new();
+        commit_args.insert("transaction_id".into(), serde_json::json!(tx_id));
+        let commit_res = sessions::handle_transaction_commit(
+            &commit_args,
+            &store,
+            &sessions,
+            SessionAuthorityMode::DaemonRequired,
+        )
+        .await
+        .unwrap();
+
+        let text = tool_result_text(&commit_res);
+        assert!(
+            !text.contains("source_body_requires_daemon_commit"),
+            "the in-process refusal must be unreachable under DaemonRequired, got: {text}"
+        );
+        assert!(
+            text.contains("daemon"),
+            "an unreachable daemon must say so rather than refuse the operation: {text}"
+        );
+        assert_eq!(
+            sessions.get_transaction(&tx_id).unwrap().state,
+            "active",
+            "delegation must not terminalize the transaction"
+        );
+    }
+
     #[tokio::test]
     async fn handle_transaction_stage_rejects_malformed_op_at_stage_time() {
         // D.7 Track A: a payload-less operation must fail loud at stage time —

--- a/crates/kin-mcp/src/handlers/mod.rs
+++ b/crates/kin-mcp/src/handlers/mod.rs
@@ -3426,7 +3426,7 @@ mod tests {
                 target: entity.id.to_string(),
                 payload: shape
                     .with_payload
-                    .then(|| McpMutationPayload::Entity(updated)),
+                    .then_some(McpMutationPayload::Entity(updated)),
                 body: shape.body.map(str::to_string),
                 description: shape.label.into(),
             };

--- a/crates/kin-mcp/src/handlers/mod.rs
+++ b/crates/kin-mcp/src/handlers/mod.rs
@@ -3158,6 +3158,222 @@ mod tests {
         );
     }
 
+    /// An entity payload sent alongside a source body must not commit the
+    /// payload and drop the body.
+    ///
+    /// This is the shape that reported `status: committed, ops_applied: 1,
+    /// empty: false` while the file it named never changed. The payload part
+    /// applies cleanly, so nothing in the response looks wrong, and the source
+    /// the agent actually wrote is gone with no signal that it was. A partial
+    /// commit reported as a whole one is undetectable to the caller, which is
+    /// why the whole operation is refused instead.
+    #[tokio::test]
+    async fn offline_commit_refuses_an_entity_payload_carrying_a_source_body() {
+        use crate::session::{McpMutationOperation, McpMutationPayload};
+
+        let store = InMemoryGraph::default();
+        let entity = placement_free_entity("value");
+        store.upsert_entity(&entity).unwrap();
+        let before = serde_json::to_value(&entity).unwrap();
+
+        let sessions = SessionRegistry::new();
+        sessions.set_coordination_mode(crate::session::CoordinationEnforcementMode::Warn);
+        let session_authority = SessionAuthorityMode::OfflineFallback;
+        let tx_id = begin_offline_transaction(&sessions, "offline-payload-plus-body").await;
+
+        let mut updated = entity.clone();
+        updated.doc_summary = Some("returns the configured value".into());
+        let op = McpMutationOperation {
+            verb: "update".into(),
+            target: entity.id.to_string(),
+            payload: Some(McpMutationPayload::Entity(updated)),
+            body: Some("pub fn value() -> u8 { 2 }".into()),
+            description: "entity payload plus source body".into(),
+        };
+        let mut stage_args = HashMap::new();
+        stage_args.insert("transaction_id".into(), serde_json::json!(tx_id));
+        stage_args.insert("operations".into(), serde_json::json!(vec![op]));
+        let stage_res =
+            sessions::handle_transaction_stage(&stage_args, &sessions, session_authority)
+                .await
+                .unwrap();
+        assert_ne!(
+            stage_res.is_error,
+            Some(true),
+            "staging must keep accepting the daemon-committable shape: {}",
+            tool_result_text(&stage_res)
+        );
+
+        let mut commit_args = HashMap::new();
+        commit_args.insert("transaction_id".into(), serde_json::json!(tx_id));
+        let commit_res =
+            sessions::handle_transaction_commit(&commit_args, &store, &sessions, session_authority)
+                .await
+                .unwrap();
+
+        assert_eq!(
+            commit_res.is_error,
+            Some(true),
+            "a commit that cannot honor the body must refuse, not report success"
+        );
+        let commit_text = tool_result_text(&commit_res);
+        assert!(
+            commit_text.contains("require the daemon commit path"),
+            "message must name the daemon requirement, got: {commit_text}"
+        );
+        assert!(
+            commit_text.contains("source_body_requires_daemon_commit"),
+            "refusal must carry its machine-readable code, got: {commit_text}"
+        );
+
+        assert_eq!(sessions.get_transaction(&tx_id).unwrap().state, "active");
+        let after = serde_json::to_value(store.get_entity(&entity.id).unwrap().unwrap()).unwrap();
+        assert_eq!(
+            before, after,
+            "no part of a body-carrying operation may reach graph truth on this path"
+        );
+    }
+
+    /// The refusal follows the operations, not the way they were delivered.
+    ///
+    /// The inline array is advertised as the single-call convenience form, so
+    /// it is the form an agent reaches for first. It must reach the same
+    /// verdict as stage-then-commit rather than becoming the one route that
+    /// reports success for a dropped body.
+    #[tokio::test]
+    async fn offline_commit_refuses_inline_operations_carrying_a_source_body() {
+        use crate::session::{McpMutationOperation, McpMutationPayload};
+
+        let store = InMemoryGraph::default();
+        let entity = placement_free_entity("value");
+        store.upsert_entity(&entity).unwrap();
+        let before = serde_json::to_value(&entity).unwrap();
+
+        let sessions = SessionRegistry::new();
+        sessions.set_coordination_mode(crate::session::CoordinationEnforcementMode::Warn);
+        let session_authority = SessionAuthorityMode::OfflineFallback;
+        let tx_id = begin_offline_transaction(&sessions, "offline-inline-body").await;
+
+        let mut updated = entity.clone();
+        updated.doc_summary = Some("returns the configured value".into());
+        let op = McpMutationOperation {
+            verb: "update".into(),
+            target: entity.id.to_string(),
+            payload: Some(McpMutationPayload::Entity(updated)),
+            body: Some("pub fn value() -> u8 { 2 }".into()),
+            description: "inline entity payload plus source body".into(),
+        };
+        let mut commit_args = HashMap::new();
+        commit_args.insert("transaction_id".into(), serde_json::json!(tx_id));
+        commit_args.insert("operations".into(), serde_json::json!(vec![op]));
+        let commit_res =
+            sessions::handle_transaction_commit(&commit_args, &store, &sessions, session_authority)
+                .await
+                .unwrap();
+
+        assert_eq!(commit_res.is_error, Some(true));
+        let commit_text = tool_result_text(&commit_res);
+        assert!(
+            commit_text.contains("source_body_requires_daemon_commit"),
+            "inline delivery must reach the same typed refusal, got: {commit_text}"
+        );
+        let after = serde_json::to_value(store.get_entity(&entity.id).unwrap().unwrap()).unwrap();
+        assert_eq!(before, after);
+    }
+
+    /// A refusal is parseable, not just readable.
+    ///
+    /// An agent that has to regex prose to decide whether to retry, restage, or
+    /// escalate will get it wrong. The refusal carries a stable schema, code,
+    /// and operation list so the decision is a field lookup.
+    #[tokio::test]
+    async fn commit_refusal_is_machine_readable() {
+        use crate::session::{CommitRefusal, McpMutationOperation, McpMutationPayload};
+
+        let store = InMemoryGraph::default();
+        let entity = placement_free_entity("value");
+        store.upsert_entity(&entity).unwrap();
+
+        let sessions = SessionRegistry::new();
+        sessions.set_coordination_mode(crate::session::CoordinationEnforcementMode::Warn);
+        let session_authority = SessionAuthorityMode::OfflineFallback;
+        let tx_id = begin_offline_transaction(&sessions, "offline-typed-refusal").await;
+
+        let op = McpMutationOperation {
+            verb: "update".into(),
+            target: "value".into(),
+            payload: None::<McpMutationPayload>,
+            body: Some("pub fn value() -> u8 { 2 }".into()),
+            description: "payload-less body update".into(),
+        };
+        let mut commit_args = HashMap::new();
+        commit_args.insert("transaction_id".into(), serde_json::json!(tx_id));
+        commit_args.insert("operations".into(), serde_json::json!(vec![op]));
+        let commit_res =
+            sessions::handle_transaction_commit(&commit_args, &store, &sessions, session_authority)
+                .await
+                .unwrap();
+
+        assert_eq!(commit_res.is_error, Some(true));
+        let commit_text = tool_result_text(&commit_res);
+        let evidence = commit_text
+            .lines()
+            .next_back()
+            .expect("refusal renders its evidence on the last line");
+        let refusal: CommitRefusal =
+            serde_json::from_str(evidence).expect("refusal evidence must parse");
+        assert_eq!(refusal.schema, CommitRefusal::SCHEMA);
+        assert_eq!(
+            refusal.code,
+            crate::session::CommitRefusalCode::SourceBodyRequiresDaemonCommit
+        );
+        assert_eq!(refusal.transaction_id, tx_id);
+        assert!(!refusal.applied, "a refusal never applied anything");
+        assert_eq!(refusal.transaction_state, "active");
+        assert_eq!(refusal.operations.len(), 1);
+    }
+
+    /// A field Kin does not model is named, not dropped.
+    ///
+    /// Serde ignores unknown keys, so an operation calling its source text
+    /// `content` decoded to `body: None` and committed nothing while looking
+    /// entirely well-formed. One misspelled word is the whole difference
+    /// between a caller fixing it and a caller concluding inline commits are
+    /// broken.
+    #[tokio::test]
+    async fn inline_operations_with_an_unmodelled_field_are_refused() {
+        let store = InMemoryGraph::default();
+        let entity = placement_free_entity("value");
+        store.upsert_entity(&entity).unwrap();
+
+        let sessions = SessionRegistry::new();
+        sessions.set_coordination_mode(crate::session::CoordinationEnforcementMode::Warn);
+        let session_authority = SessionAuthorityMode::OfflineFallback;
+        let tx_id = begin_offline_transaction(&sessions, "offline-unknown-field").await;
+
+        let mut commit_args = HashMap::new();
+        commit_args.insert("transaction_id".into(), serde_json::json!(tx_id));
+        commit_args.insert(
+            "operations".into(),
+            serde_json::json!([{
+                "verb": "update",
+                "target": entity.id.to_string(),
+                "content": "pub fn value() -> u8 { 2 }",
+                "description": "misspelled body key",
+            }]),
+        );
+        let err =
+            sessions::handle_transaction_commit(&commit_args, &store, &sessions, session_authority)
+                .await
+                .expect_err("an unknown operation field must be refused");
+        assert!(matches!(err, McpError::InvalidParams(_)));
+        assert!(
+            err.to_string().contains("'content'"),
+            "the refusal must name the unknown field, got: {err}"
+        );
+        assert_eq!(sessions.get_transaction(&tx_id).unwrap().state, "active");
+    }
+
     #[tokio::test]
     async fn handle_transaction_stage_rejects_malformed_op_at_stage_time() {
         // D.7 Track A: a payload-less operation must fail loud at stage time —

--- a/crates/kin-mcp/src/handlers/mod.rs
+++ b/crates/kin-mcp/src/handlers/mod.rs
@@ -3374,6 +3374,109 @@ mod tests {
         assert_eq!(sessions.get_transaction(&tx_id).unwrap().state, "active");
     }
 
+    /// Across every operation shape, a commit either persists the content it
+    /// was handed or refuses; it never reports success having dropped it.
+    ///
+    /// This is the invariant, stated once over the whole shape matrix rather
+    /// than one shape at a time. On this path, which has no projection, the
+    /// dividing line is simply whether the operation carries source text: if it
+    /// does, the commit refuses, and if it does not, the commit applies
+    /// everything the operation carried. Nothing lands in between.
+    #[tokio::test]
+    async fn no_commit_shape_reports_success_while_dropping_content() {
+        use crate::session::{McpMutationOperation, McpMutationPayload};
+
+        struct Shape {
+            label: &'static str,
+            body: Option<&'static str>,
+            with_payload: bool,
+        }
+        let shapes = [
+            Shape {
+                label: "payload-less source edit",
+                body: Some("pub fn value() -> u8 { 2 }"),
+                with_payload: false,
+            },
+            Shape {
+                label: "entity payload plus source edit",
+                body: Some("pub fn value() -> u8 { 2 }"),
+                with_payload: true,
+            },
+            Shape {
+                label: "entity payload alone",
+                body: None,
+                with_payload: true,
+            },
+        ];
+
+        for shape in shapes {
+            let store = InMemoryGraph::default();
+            let entity = placement_free_entity("value");
+            store.upsert_entity(&entity).unwrap();
+
+            let sessions = SessionRegistry::new();
+            sessions.set_coordination_mode(crate::session::CoordinationEnforcementMode::Warn);
+            let session_authority = SessionAuthorityMode::OfflineFallback;
+            let tx_id = begin_offline_transaction(&sessions, "offline-shape-matrix").await;
+
+            let mut updated = entity.clone();
+            updated.doc_summary = Some("returns the configured value".into());
+            let op = McpMutationOperation {
+                verb: "update".into(),
+                target: entity.id.to_string(),
+                payload: shape
+                    .with_payload
+                    .then(|| McpMutationPayload::Entity(updated)),
+                body: shape.body.map(str::to_string),
+                description: shape.label.into(),
+            };
+            let mut commit_args = HashMap::new();
+            commit_args.insert("transaction_id".into(), serde_json::json!(tx_id));
+            commit_args.insert("operations".into(), serde_json::json!(vec![op]));
+            let commit_res = sessions::handle_transaction_commit(
+                &commit_args,
+                &store,
+                &sessions,
+                session_authority,
+            )
+            .await
+            .unwrap();
+
+            let text = tool_result_text(&commit_res);
+            let applied = store
+                .get_entity(&entity.id)
+                .unwrap()
+                .unwrap()
+                .doc_summary
+                .is_some();
+            if shape.body.is_some() {
+                assert_eq!(
+                    commit_res.is_error,
+                    Some(true),
+                    "{}: a body this path cannot write must refuse: {text}",
+                    shape.label
+                );
+                assert!(
+                    !applied,
+                    "{}: a refusal must apply no part of the operation",
+                    shape.label
+                );
+            } else {
+                assert_ne!(
+                    commit_res.is_error,
+                    Some(true),
+                    "{}: a body-free operation must still commit: {text}",
+                    shape.label
+                );
+                assert!(
+                    applied,
+                    "{}: a reported commit must have applied its payload",
+                    shape.label
+                );
+            }
+        }
+    }
+
     #[tokio::test]
     async fn handle_transaction_stage_rejects_malformed_op_at_stage_time() {
         // D.7 Track A: a payload-less operation must fail loud at stage time —

--- a/crates/kin-mcp/src/handlers/provenance.rs
+++ b/crates/kin-mcp/src/handlers/provenance.rs
@@ -2,21 +2,37 @@
 // Copyright 2026 Firelock, LLC
 
 use std::collections::HashMap;
+use std::collections::HashSet;
 
 use kin_model::graph::GraphStore;
+use kin_model::work::WorkScope;
 
 use crate::error::{McpError, Result};
 use crate::types::ToolCallResult;
 
 use super::common::*;
 
+/// How many recent audit events to consider before narrowing them to the
+/// queried entity.
+///
+/// The store filters by actor, never by scope, so the scope narrowing has to
+/// happen here over a window of recent events. Wide enough that an entity's own
+/// recent activity is not pushed out by unrelated commits, bounded so the answer
+/// does not grow with the repository's whole audit history.
+const AUDIT_SCAN: usize = 512;
+
+/// How many of the queried entity's own events to return.
+const AUDIT_RETURNED: usize = 20;
+
 pub const PROVENANCE_QUERY_DESC: &str = "\
 Answer who-and-whether-approved for an entity: it returns the entity's change count, \
-its latest change, any approvals recorded on that change, and recent audit events. \
-Reach for it to establish accountability and trust before relying on a piece of code — \
-\"who last touched this, and has it been signed off?\" — or when assembling an audit \
-trail. It builds on entity_history (the raw change list) by adding approval status and \
-audit context in one call.";
+its latest change, any approvals recorded on that change, and recent audit events \
+recorded against that entity. Reach for it to establish accountability and trust before \
+relying on a piece of code, to answer \"who last touched this, and has it been signed \
+off?\", or when assembling an audit trail. It builds on entity_history (the raw change \
+list) by adding approval status and audit context in one call. Every field is scoped to \
+the entity you asked about; an empty recent_audit_events means no recorded write named \
+this entity, not that the repository has been quiet.";
 
 pub fn handle_provenance_query<G: GraphStore>(
     args: &HashMap<String, serde_json::Value>,
@@ -38,10 +54,31 @@ pub fn handle_provenance_query<G: GraphStore>(
         approvals_json = serde_json::json!(approvals);
     }
 
-    // Get recent audit events (not actor-filtered, just recent)
+    // Audit events for THIS entity, not the repository's most recent activity.
+    //
+    // The store has no scope filter, so an unnarrowed query returns whatever
+    // happened last anywhere. Returning that under an `entity_id` key answers
+    // "who touched this entity" with a different entity's commit, by a different
+    // agent, and nothing in the response says otherwise. The events carry the
+    // scope needed to narrow them, so narrow them here.
+    //
+    // A commit that changed no entity is scoped to its change instead, so those
+    // are kept when the change is one of this entity's own.
+    let entity_changes = history
+        .iter()
+        .map(|change| change.id)
+        .collect::<HashSet<_>>();
     let events = store
-        .query_audit_events(None, 20)
-        .map_err(McpError::graph)?;
+        .query_audit_events(None, AUDIT_SCAN)
+        .map_err(McpError::graph)?
+        .into_iter()
+        .filter(|event| match &event.target_scope {
+            Some(WorkScope::Entity(id)) => *id == entity_id,
+            Some(WorkScope::Change(id)) => entity_changes.contains(id),
+            _ => false,
+        })
+        .take(AUDIT_RETURNED)
+        .collect::<Vec<_>>();
 
     let result = serde_json::json!({
         "entity_id": id_str,

--- a/crates/kin-mcp/src/handlers/provenance.rs
+++ b/crates/kin-mcp/src/handlers/provenance.rs
@@ -15,10 +15,16 @@ use super::common::*;
 /// How many recent audit events to consider before narrowing them to the
 /// queried entity.
 ///
-/// The store filters by actor, never by scope, so the scope narrowing has to
-/// happen here over a window of recent events. Wide enough that an entity's own
-/// recent activity is not pushed out by unrelated commits, bounded so the answer
-/// does not grow with the repository's whole audit history.
+/// The store filters by actor, never by scope, so narrowing by scope has to
+/// happen here, which means taking a window of recent events first and filtering
+/// second. The consequence is stated in the tool description rather than hidden:
+/// an entity whose last write is older than this many events returns an empty
+/// list even though it was written. Filtering before limiting would need a
+/// scope-aware query in the store, which is kin-db's surface, not this one.
+///
+/// Bounded so one entity's answer does not grow with the repository's whole
+/// audit history, and wide enough that an entity's own recent activity survives
+/// a busy period from other lanes.
 const AUDIT_SCAN: usize = 512;
 
 /// How many of the queried entity's own events to return.
@@ -31,8 +37,13 @@ recorded against that entity. Reach for it to establish accountability and trust
 relying on a piece of code, to answer \"who last touched this, and has it been signed \
 off?\", or when assembling an audit trail. It builds on entity_history (the raw change \
 list) by adding approval status and audit context in one call. Every field is scoped to \
-the entity you asked about; an empty recent_audit_events means no recorded write named \
-this entity, not that the repository has been quiet.";
+the entity you asked about: recent_audit_events never carries another entity's writes. It \
+is drawn from the repository's recent audit activity and then narrowed, so it is the \
+entity's own recent writes rather than its complete write history, and an entity whose \
+last write is older than the scan window comes back with an empty list. Treat a populated \
+list as authoritative about who wrote this entity, and an empty one as no recent record \
+rather than as proof nothing ever wrote it; change_count and latest_change are the \
+complete-history fields.";
 
 pub fn handle_provenance_query<G: GraphStore>(
     args: &HashMap<String, serde_json::Value>,

--- a/crates/kin-mcp/src/handlers/sessions.rs
+++ b/crates/kin-mcp/src/handlers/sessions.rs
@@ -833,13 +833,18 @@ fn transaction_touched_scopes<G: GraphStore>(
 /// Indexed reasons for every staged operation the in-process commit path must
 /// refuse even though staging and the daemon planner accept it.
 ///
-/// Today that is exactly the payload-less source update (verb update/modify
-/// with a `target` and a `body`). Turning that shape into a real change means
-/// planning the exact span edit and projecting the new source into the working
-/// file, and both live in the daemon (`kin-daemon`'s `plan_exact_transaction`).
-/// The in-process path has no projection, so committing it here can only
-/// produce a same-entity no-op delta while reporting success, discarding the
-/// agent's body. Refuse instead.
+/// That is every operation carrying new source text, whether or not it also
+/// carries an entity payload. Turning a body into a real change means planning
+/// the exact span edit and projecting the new source into the working file, and
+/// both live in the daemon (`kin-daemon`'s `plan_exact_transaction`). The
+/// in-process path has no projection, so it can only apply whatever else the
+/// operation carries and drop the body.
+///
+/// The payload-ful case is the one that bit hardest, because it does not look
+/// like a no-op from the outside: the entity payload commits, the response says
+/// `ops_applied: 1` and `empty: false`, and the source the agent actually sent
+/// is gone. A partial success reported as a success is worse than a refusal,
+/// because the caller has no way to detect it and no reason to retry.
 ///
 /// Deliberately private and applied only after the daemon-delegate early
 /// return in [`handle_transaction_commit`]: the daemon commits through
@@ -850,15 +855,21 @@ fn offline_only_uncommittable_operations(operations: &[McpMutationOperation]) ->
     operations
         .iter()
         .enumerate()
-        .filter(|(_, op)| crate::session::is_target_body_update(op))
+        .filter(|(_, op)| crate::session::carries_source_body(op))
         .map(|(idx, op)| {
+            let shape = if op.payload.is_some() {
+                "an entity payload plus a source body"
+            } else {
+                "a payload-less source update (target plus body)"
+            };
+            let target = op.target.trim();
+            let target = if target.is_empty() { "(unnamed)" } else { target };
             format!(
-                "operation #{idx} ('{}'): a payload-less source update (target '{}' plus body) \
-                 requires the daemon commit path, which plans the exact span edit and projects \
-                 the new source into the working file; the in-process commit path has no \
-                 projection and would report success while discarding the body",
+                "operation #{idx} ('{}'): {shape} for target '{target}' requires the daemon \
+                 commit path, which plans the exact span edit and projects the new source into \
+                 the working file; the in-process commit path has no projection and would report \
+                 success while discarding the body",
                 op.verb,
-                op.target.trim()
             )
         })
         .collect()
@@ -873,13 +884,14 @@ pub async fn handle_transaction_commit<G: GraphStore>(
     let transaction_id = get_string_param(args, "transaction_id")?;
 
     // If operations are provided, validate and stage them in one shot
-    // to bypass state-loss across HTTP calls.
+    // to bypass state-loss across HTTP calls. Decoded through the same parser
+    // the stage tool uses, so an inline caller gets the identical contract: a
+    // field Kin does not model is named rather than dropped, and a shape the
+    // commit path cannot honor is refused here instead of at commit.
     let mut inline_ops = None;
     if let Some(ops_val) = args.get("operations") {
-        let parsed: Vec<crate::session::McpMutationOperation> =
-            serde_json::from_value(ops_val.clone()).map_err(|e| {
-                crate::error::McpError::InvalidParams(format!("invalid operations array: {e}"))
-            })?;
+        let parsed = crate::session::parse_staged_operations(ops_val)
+            .map_err(crate::error::McpError::InvalidParams)?;
         crate::session::validate_staged_operations(&parsed)
             .map_err(crate::error::McpError::InvalidParams)?;
         inline_ops = Some(parsed);
@@ -931,30 +943,31 @@ pub async fn handle_transaction_commit<G: GraphStore>(
     // is applied and the transaction stays active so the agent can fix it.
     let uncommittable = crate::session::uncommittable_operations(&tx.staged_operations);
     if !uncommittable.is_empty() {
-        return Ok(ToolCallResult::error(format!(
-            "Cannot commit transaction {}: {} staged operation(s) are not committable and would \
-             be silently dropped:\n  - {}\nFix or remove them and retry; the transaction is left \
-             active.",
-            transaction_id,
-            uncommittable.len(),
-            uncommittable.join("\n  - ")
-        )));
+        return Ok(ToolCallResult::error(
+            crate::session::CommitRefusal::new(
+                crate::session::CommitRefusalCode::NotCommittable,
+                &transaction_id,
+                uncommittable,
+            )
+            .render(),
+        ));
     }
 
     // Everything from here down is the in-process path: the daemon returned
     // above. Refuse the operation shapes only the daemon can honor rather than
-    // applying a delta that reports success and changes nothing. Rejected
-    // atomically and before any graph apply, so the transaction stays active.
+    // applying a delta that reports success while dropping the source the
+    // caller sent. Rejected atomically and before any graph apply, so the
+    // transaction stays active.
     let daemon_only = offline_only_uncommittable_operations(&tx.staged_operations);
     if !daemon_only.is_empty() {
-        return Ok(ToolCallResult::error(format!(
-            "Cannot commit transaction {}: {} staged operation(s) require the daemon commit \
-             path:\n  - {}\nCommit through a running Kin daemon, or restage the change as an \
-             entity payload. The transaction is left active.",
-            transaction_id,
-            daemon_only.len(),
-            daemon_only.join("\n  - ")
-        )));
+        return Ok(ToolCallResult::error(
+            crate::session::CommitRefusal::new(
+                crate::session::CommitRefusalCode::SourceBodyRequiresDaemonCommit,
+                &transaction_id,
+                daemon_only,
+            )
+            .render(),
+        ));
     }
 
     // Load-bearing ordering: run coordination enforcement against the fully

--- a/crates/kin-mcp/src/handlers/sessions.rs
+++ b/crates/kin-mcp/src/handlers/sessions.rs
@@ -766,7 +766,15 @@ delta. A commit refused before anything is published leaves the transaction usab
 operations are cleared and named in the refusal, so re-stage corrected ones on the SAME \
 transaction and commit again; kin_transaction_abort is the clean exit if you would rather \
 abandon it. An optional operations array may stage and commit in one call and uses the same \
-payload-less source-edit or structured payload operation shapes as kin_transaction_stage.";
+payload-less source-edit or structured payload operation shapes as kin_transaction_stage; it \
+commits with identical durability, so a success naming modified_files means the body reached the \
+file, and re-sending the same array after an interrupted commit resumes it rather than staging it \
+twice. New source text is carried ONLY by `body`: an operation naming it anything else is refused \
+with the unknown field named, never accepted with the source dropped. A refusal ends with a \
+one-line JSON object carrying schema, code, and the operations it names, so you can branch on the \
+code instead of reading the sentence. On success the change is attributed to the calling session: \
+its vendor and client name become the change author and a queryable audit record, so \
+kin_provenance_query, kin history, and kin blame all name the agent that wrote it.";
 
 fn push_scope_once(scopes: &mut Vec<kin_model::IntentScope>, scope: kin_model::IntentScope) {
     if !scopes.contains(&scope) {
@@ -863,7 +871,11 @@ fn offline_only_uncommittable_operations(operations: &[McpMutationOperation]) ->
                 "a payload-less source update (target plus body)"
             };
             let target = op.target.trim();
-            let target = if target.is_empty() { "(unnamed)" } else { target };
+            let target = if target.is_empty() {
+                "(unnamed)"
+            } else {
+                target
+            };
             format!(
                 "operation #{idx} ('{}'): {shape} for target '{target}' requires the daemon \
                  commit path, which plans the exact span edit and projects the new source into \

--- a/crates/kin-mcp/src/lib.rs
+++ b/crates/kin-mcp/src/lib.rs
@@ -23,9 +23,9 @@ pub use server::{
     McpServerConfig, RepoBinder, SessionAuthorityMode,
 };
 pub use session::{
-    AssistantSession, CoordinationEnforcementMode, CoordinationSurfaceCoverage,
-    CoordinationWritePreflight, IntentRegistrationAttempt, McpMutationOperation,
-    McpMutationPayload, McpTransaction, SessionRegistry,
+    AssistantSession, CommitRefusal, CommitRefusalCode, CoordinationEnforcementMode,
+    CoordinationSurfaceCoverage, CoordinationWritePreflight, IntentRegistrationAttempt,
+    McpMutationOperation, McpMutationPayload, McpTransaction, SessionRegistry,
 };
 pub use tools::{
     agent_default_tool_names, benchmark_tool_names, context_bench_tool_names, tool_definitions,

--- a/crates/kin-mcp/src/session.rs
+++ b/crates/kin-mcp/src/session.rs
@@ -2151,6 +2151,89 @@ mod tests {
     }
 
     #[test]
+    fn parse_staged_operations_names_a_field_it_does_not_model() {
+        // The whole point: a misspelled `body` used to decode to no body at
+        // all, so the operation staged clean and committed nothing.
+        let error = parse_staged_operations(&serde_json::json!([{
+            "verb": "update",
+            "target": "value",
+            "content": "pub fn value() -> u8 { 2 }",
+            "description": "misspelled body key",
+        }]))
+        .expect_err("an unknown field must be refused, not dropped");
+        assert!(error.contains("'content'"), "got: {error}");
+        assert!(error.contains("body"), "the fix must be named: {error}");
+    }
+
+    #[test]
+    fn parse_staged_operations_rejects_a_non_object_element() {
+        let error = parse_staged_operations(&serde_json::json!(["update value"]))
+            .expect_err("a string element is not an operation");
+        assert!(error.contains("element #0"), "got: {error}");
+    }
+
+    #[test]
+    fn staged_operations_match_distinguishes_a_resume_from_an_edit() {
+        let staged = vec![op(
+            "update",
+            Some(McpMutationPayload::Entity(entity_named("foo"))),
+        )];
+        assert!(staged_operations_match(&staged, &staged.clone()));
+
+        let mut edited = staged.clone();
+        edited[0].body = Some("pub fn foo() {}".to_string());
+        assert!(
+            !staged_operations_match(&staged, &edited),
+            "a changed body is a different payload, not a resume"
+        );
+        assert!(!staged_operations_match(&staged, &[]));
+    }
+
+    #[test]
+    fn commit_refusal_renders_prose_and_machine_readable_evidence() {
+        let refusal = CommitRefusal::new(
+            CommitRefusalCode::SourceBodyRequiresDaemonCommit,
+            "tx-1",
+            vec!["operation #0 ('update'): needs projection".to_string()],
+        );
+        let rendered = refusal.render();
+        assert!(rendered.contains("tx-1"));
+        assert!(rendered.contains("needs projection"));
+
+        let evidence: CommitRefusal =
+            serde_json::from_str(rendered.lines().next_back().unwrap()).unwrap();
+        assert_eq!(evidence.schema, CommitRefusal::SCHEMA);
+        assert_eq!(
+            evidence.code,
+            CommitRefusalCode::SourceBodyRequiresDaemonCommit
+        );
+        assert!(!evidence.applied);
+        assert_eq!(evidence.operations.len(), 1);
+    }
+
+    #[test]
+    fn carries_source_body_covers_every_shape_whose_substance_is_the_body() {
+        let mut payload_less = op("update", None);
+        payload_less.body = Some("pub fn value() {}".to_string());
+        assert!(carries_source_body(&payload_less));
+
+        let mut with_payload = op(
+            "update",
+            Some(McpMutationPayload::Entity(entity_named("value"))),
+        );
+        with_payload.body = Some("pub fn value() {}".to_string());
+        assert!(
+            carries_source_body(&with_payload),
+            "an entity payload does not make the body optional"
+        );
+
+        let mut blank = with_payload.clone();
+        blank.body = Some("   \n".to_string());
+        assert!(!carries_source_body(&blank), "whitespace is not source");
+        assert!(!carries_source_body(&op("update", None)));
+    }
+
+    #[test]
     fn validate_staged_operations_accepts_well_formed_and_empty() {
         assert!(validate_staged_operations(&[]).is_ok());
         let ops = vec![op(

--- a/crates/kin-mcp/src/session.rs
+++ b/crates/kin-mcp/src/session.rs
@@ -83,7 +83,9 @@ pub fn is_target_body_update(op: &McpMutationOperation) -> bool {
 /// the daemon can honor without a payload, while this names every shape whose
 /// substance is the body, including an entity payload sent alongside one.
 pub fn carries_source_body(op: &McpMutationOperation) -> bool {
-    op.body.as_deref().is_some_and(|body| !body.trim().is_empty())
+    op.body
+        .as_deref()
+        .is_some_and(|body| !body.trim().is_empty())
 }
 
 /// Why a commit was refused before anything was applied, in a form a caller can
@@ -492,7 +494,10 @@ pub fn parse_staged_operations(
 /// Used to tell a resume of a fenced commit apart from an attempt to change
 /// what that commit publishes. Compared through their serialized form because
 /// an operation carries payload types that model no equality of their own.
-pub fn staged_operations_match(left: &[McpMutationOperation], right: &[McpMutationOperation]) -> bool {
+pub fn staged_operations_match(
+    left: &[McpMutationOperation],
+    right: &[McpMutationOperation],
+) -> bool {
     match (serde_json::to_value(left), serde_json::to_value(right)) {
         (Ok(left), Ok(right)) => left == right,
         // A set that cannot be serialized cannot be proven identical, and a

--- a/crates/kin-mcp/src/session.rs
+++ b/crates/kin-mcp/src/session.rs
@@ -70,6 +70,109 @@ pub fn is_target_body_update(op: &McpMutationOperation) -> bool {
             .is_some_and(|body| !body.trim().is_empty())
 }
 
+/// An operation that carries new source text for a file.
+///
+/// Source text can only become truth by being spliced into exact repository
+/// bytes and projected into the working file, which lives in the daemon commit
+/// path. Any other path must refuse an operation shaped like this rather than
+/// commit whatever else the operation carries, because a commit that keeps the
+/// metadata and drops the source reports an agent's edit as durable while the
+/// file it named is unchanged.
+///
+/// Deliberately wider than [`is_target_body_update`]: that names the one shape
+/// the daemon can honor without a payload, while this names every shape whose
+/// substance is the body, including an entity payload sent alongside one.
+pub fn carries_source_body(op: &McpMutationOperation) -> bool {
+    op.body.as_deref().is_some_and(|body| !body.trim().is_empty())
+}
+
+/// Why a commit was refused before anything was applied, in a form a caller can
+/// branch on without reading prose.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum CommitRefusalCode {
+    /// The operations cannot be turned into a committed delta on any path.
+    NotCommittable,
+    /// The operations carry new source text and this path has no projection to
+    /// write it with. The daemon commit path honors the identical operations.
+    SourceBodyRequiresDaemonCommit,
+}
+
+impl CommitRefusalCode {
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::NotCommittable => "not_committable",
+            Self::SourceBodyRequiresDaemonCommit => "source_body_requires_daemon_commit",
+        }
+    }
+
+    fn remedy(self) -> &'static str {
+        match self {
+            Self::NotCommittable => {
+                "Fix or remove the named operations and commit again; the transaction is left \
+                 active and nothing was applied."
+            }
+            Self::SourceBodyRequiresDaemonCommit => {
+                "These operations require the daemon commit path, which splices the body into \
+                 exact repository bytes and projects the result into the working file. Commit \
+                 through a running Kin daemon; the transaction is left active and nothing was \
+                 applied."
+            }
+        }
+    }
+}
+
+/// One refusal, naming its code, the operations that caused it, and the state
+/// the transaction is left in.
+///
+/// Rendered as a sentence followed by the same refusal as JSON: an agent reads
+/// the code and the operation list, a human reads the sentence, and neither has
+/// to reconstruct the other from the other's format.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct CommitRefusal {
+    pub schema: String,
+    pub code: CommitRefusalCode,
+    pub transaction_id: String,
+    pub transaction_state: String,
+    pub applied: bool,
+    pub operations: Vec<String>,
+    pub remedy: String,
+}
+
+impl CommitRefusal {
+    pub const SCHEMA: &'static str = "kin.mcp.commit_refusal.v1";
+
+    pub fn new(code: CommitRefusalCode, transaction_id: &str, operations: Vec<String>) -> Self {
+        Self {
+            schema: Self::SCHEMA.to_string(),
+            code,
+            transaction_id: transaction_id.to_string(),
+            transaction_state: "active".to_string(),
+            applied: false,
+            operations,
+            remedy: code.remedy().to_string(),
+        }
+    }
+
+    pub fn render(&self) -> String {
+        let listed = self
+            .operations
+            .iter()
+            .map(|reason| format!("  - {reason}"))
+            .collect::<Vec<_>>()
+            .join("\n");
+        let evidence = serde_json::to_string(self)
+            .unwrap_or_else(|error| format!("{{\"serialize_error\":\"{error}\"}}"));
+        format!(
+            "Cannot commit transaction {}: {} staged operation(s) were refused ({}):\n{listed}\n{}\n{evidence}",
+            self.transaction_id,
+            self.operations.len(),
+            self.code.as_str(),
+            self.remedy,
+        )
+    }
+}
+
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct McpTransaction {
     pub transaction_id: String,
@@ -327,6 +430,14 @@ pub const ACCEPTED_OPERATION_SHAPES: &str = "each element of `operations` is one
      \"description\": \"<why>\"}\n\
      Prefer the first shape: it needs only a target and the new source text";
 
+/// Every field an operation is allowed to carry.
+///
+/// Serde drops keys it does not model, so an operation naming its source text
+/// anything other than `body` decodes cleanly with `body: None` and is planned
+/// as if no source had been sent. Checking the key set first is what turns that
+/// into a refusal the caller can act on.
+const OPERATION_FIELDS: [&str; 5] = ["verb", "target", "payload", "body", "description"];
+
 /// Decode an `operations` argument into staged operations.
 ///
 /// A raw serde failure here names an internal field of whichever payload
@@ -334,17 +445,60 @@ pub const ACCEPTED_OPERATION_SHAPES: &str = "each element of `operations` is one
 /// improvising the shape nothing it can act on. Every decode failure is
 /// rewritten to name the accepted shapes, so a caller that guessed wrong learns
 /// the contract from the refusal instead of looping on retries.
+///
+/// Unknown keys are refused rather than ignored. A caller writing the shape by
+/// hand reaches for `content`, `source`, or `new_body` before it reaches for
+/// `body`, and silently discarding that key is indistinguishable from a commit
+/// that dropped the change: the operation stages, commits, and reports success
+/// having carried no source at all.
 pub fn parse_staged_operations(
     operations: &serde_json::Value,
 ) -> std::result::Result<Vec<McpMutationOperation>, String> {
-    if !operations.is_array() {
+    let serde_json::Value::Array(elements) = operations else {
         return Err(format!(
             "invalid operations: expected a JSON array, got {}; {ACCEPTED_OPERATION_SHAPES}",
             json_type_name(operations)
         ));
+    };
+    for (idx, element) in elements.iter().enumerate() {
+        let Some(fields) = element.as_object() else {
+            return Err(format!(
+                "invalid operations: element #{idx} is {}, expected an object; \
+                 {ACCEPTED_OPERATION_SHAPES}",
+                json_type_name(element)
+            ));
+        };
+        let unknown = fields
+            .keys()
+            .filter(|key| !OPERATION_FIELDS.contains(&key.as_str()))
+            .map(|key| format!("'{key}'"))
+            .collect::<Vec<_>>();
+        if !unknown.is_empty() {
+            return Err(format!(
+                "invalid operations: element #{idx} carries unknown field(s) {}; an operation is \
+                 described only by {}. New source text goes in `body`, and nowhere else, or it is \
+                 not committed; {ACCEPTED_OPERATION_SHAPES}",
+                unknown.join(", "),
+                OPERATION_FIELDS.join(", ")
+            ));
+        }
     }
     serde_json::from_value(operations.clone())
         .map_err(|error| format!("invalid operations array: {error}; {ACCEPTED_OPERATION_SHAPES}"))
+}
+
+/// Whether two staged operation sets describe exactly the same work.
+///
+/// Used to tell a resume of a fenced commit apart from an attempt to change
+/// what that commit publishes. Compared through their serialized form because
+/// an operation carries payload types that model no equality of their own.
+pub fn staged_operations_match(left: &[McpMutationOperation], right: &[McpMutationOperation]) -> bool {
+    match (serde_json::to_value(left), serde_json::to_value(right)) {
+        (Ok(left), Ok(right)) => left == right,
+        // A set that cannot be serialized cannot be proven identical, and a
+        // resume that guesses wrong would append to a fenced payload.
+        _ => false,
+    }
 }
 
 fn json_type_name(value: &serde_json::Value) -> &'static str {


### PR DESCRIPTION
Two write-path truth defects found dogfooding an MCP-driven edit end to end.

Closes FIR-1678
Closes FIR-1679

## What actually reproduced on main

Both were filed against released 0.3.6, so the first step was reproducing against main rather than trusting the ticket text. The results split the work.

**Commit truth.** The daemon commit path already staged an inline `operations` array and published it through repository authority, but nothing tested that, so the guarantee was unheld. The projection-less in-process path still reproduced the reported failure exactly: an operation carrying an entity payload alongside a `body` committed the payload and dropped the body, returning `status: committed, ops_applied: 1, empty: false`. Its refusal covered only the payload-less body shape.

**Provenance.** The "No history recorded" symptom does not reproduce on main; a probe shows history, blame, head, and `change_count` all working. What was still broken sits underneath: `record_audit_event` had zero callers anywhere in the workspace, so `kin_provenance_query` could only ever return an empty audit context, and `kin-review`'s impact analysis, which resolves actor attribution and its unreviewed-agent-change signal entirely from audit events and the actor they name, treated an agent's commit as authorless. The change author was a bare `mcp:<session-uuid>`, which identifies nobody once the in-memory session registry drops it.

## Changes

Commit truth:

- The in-process refusal widens from the payload-less shape to every body-carrying shape. A path with no projection can only drop a body, so it refuses instead of committing the rest and reporting success.
- Refusals carry a typed envelope (`kin.mcp.commit_refusal.v1`) with a machine-readable code, the transaction id, the state it is left in, `applied: false`, and the indexed operation reasons. Rendered as prose followed by one line of JSON, so an agent branches on the code and a human reads the sentence.
- `parse_staged_operations` refuses unknown keys and names them. Serde drops keys it does not model, so an operation calling its source `content` or `new_body` decoded to `body: None` and was planned as an empty change. The tool schema already declared `additionalProperties: false`; nothing enforced it.
- Inline operations on the commit call decode through the same parser the stage tool uses, so inline and staged delivery share one contract.
- Inline operations re-sent against a fenced transaction resume it instead of dying on the staging state check. The tool documents re-entry as an idempotent resume, and inline callers were excluded from exactly the recovery their only published option relies on. A divergent array is refused rather than appended to a fenced payload.

Provenance:

- A commit resolves the agent session behind the transaction and carries its vendor and client name into the change author beside the session id: `claude-code/one-change-demo <mcp-agent:<uuid>>`. `kin history` renders the name, `kin blame` renders the whole string, so the session id stays recoverable from a read surface after the session ends. Client-supplied names are stripped of the characters those renderers parse on.
- A stable actor is derived from the session id and registered as `ActorKind::Assistant`, so a session is one actor across its commits rather than a crowd of one-commit strangers.
- One audit event per changed entity, scoped `WorkScope::Entity`, which is the scope the review layer matches on, with details naming the transaction, session, actor, change id, repository generation, and operation id. Recorded only after the repository receipt exists.
- Event ids derive from the change and entity, so a fenced commit resumed after a crash re-derives what it already wrote rather than recording a second write.

The commit tool description now states the inline durability guarantee, the `body`-only rule, the typed-refusal line, and the attribution behavior, because that description is what an agent reads.

## Tests

Daemon commit path: inline commit persists the body byte-exact in the working file, repository CAS, and the reparsed entity, with `modified_files` naming the file; the payload-less inline form does the same; an unknown key is refused with authority and file bytes unchanged; a re-sent inline array resumes a fenced commit and a divergent one is refused; a committed transaction is attributable through `kin history`, `kin blame`, `kin_provenance_query`, `get_actor`, and an actor-filtered audit query; one session keeps one actor across commits; a resumed commit records its attribution once; an unregistered session still names an author.

In-process path: the reproduced payload-plus-body defect refuses and applies nothing; inline delivery reaches the same refusal; the refusal round-trips through its own schema; an unmodelled field is refused; and a shape-matrix test states the invariant once, that an operation carrying source text is refused and applies nothing while one without it commits and applies everything.

## Compatibility note

Two changes convert a previously-successful call into an error, both on the product daemon path.

`kin_transaction_stage` now returns `InvalidParams` for an operation carrying a field Kin does not model, where it previously succeeded with that field silently dropped. It is contract-legal, because the tool schema already declared `additionalProperties: false` on both operation shapes, and it is the product-path half of the misspelled-body defect: an operation naming its source `content` instead of `body` used to stage clean and commit nothing. No existing test or fixture sends extra operation fields.

`kin_transaction_commit` now refuses an entity payload whose `doc_summary` differs from repository authority, where it previously committed the body and discarded the edit while reporting `ops_applied: 1`. Entity documentation is derived from committed source, so the edit could never have landed; the caller is told to send `doc_summary` unchanged and put the new documentation in `body`. Scoped to that one named field deliberately: the wider `metadata` bag holds keys the daemon's own embed and indexing workers maintain asynchronously, so comparing it would refuse a caller for a difference it neither caused nor can control.

## Review

Adversarially reviewed at `6257da9c`: GO conditional on one P1, with five P2s and a P3. Both reproduction claims were independently verified, and the reviewer's own primary hypothesis, that the widened refusal would block the product write recipe, was refuted by tracing five hops from `kin mcp start` through to the daemon dispatch.

Everything the review raised is either fixed here or filed:

- **P1-1 (fixed).** `handle_provenance_query` filled `recent_audit_events` from an unscoped `query_audit_events(None, 20)`. That field was always empty while nothing wrote audit events; this PR is the first writer, which turned a harmless omission into a confident wrong answer, returning the repository's 20 most recent events under a response keyed to one entity. Now narrowed to the queried entity's own events. The previous test could not have caught it, asserting `events.len() == 1` in a fixture with one commit in its whole history; the new test uses two entities and two sessions with the unrelated commit last.
- **P2-1 (fixed, beyond what was asked).** The review's minimum was a test stating that the daemon path discards hand-edited payload metadata. For a PR about not reporting success for work that did not happen, stating it was not enough: the planner now refuses an edited `doc_summary` or `metadata`, the same rule it already applies to name, kind, origin, and span. Compared against authority, so echoing back the entity you read still commits.
- **P2-2 (half fixed, half filed as FIR-1698).** The dedup comment claimed a bound it did not have: the store applies its limit with `take` after the actor filter, so a session with fewer commits than the limit traversed the entire log every commit. Dropping the actor filter makes the limit bound the traversal. The forced full O(graph) snapshot on every provenance write is kin-db's, and is filed with the delta-format evidence showing the incremental path already exists.
- **P2-3 (fixed).** Added a test pinning that `DaemonRequired` mode never reaches the in-process refusal, which is the invariant the whole safety argument rests on.
- **P2-4 (fixed in test, filed as FIR-1699).** The attribution assertion used a prefix that survived `kin history`'s 20-column truncation by accident; it now asserts the rendered form. The truncation itself is a `kin-cli` rendering question.
- **P2-5 (fixed).** The divergence refusal now names the exit that always works for a caller that mixed staged and inline operations: re-send the commit with no `operations` array.
- **P3-1 (fixed).** `provenance_label` now strips `/`, the separator it is joined with.

Re-reviewed again at `117ad2af`, which was NO-GO on the `metadata` half of the P2-1 refusal. That arm is dropped and the `doc_summary` arm kept, as adjudicated. One correction to the record: the reviewer's stated mechanism, that a wire echo folds ten response-only keys into `metadata` because `EntityMetadata` is flattened, does not hold. The flatten is inside the `metadata` object, while `Entity.metadata` is a plain named field, so top-level decorations are discarded on decode. The wire-echo test added this round proves it: after a real `entity_response_json` round trip, `metadata` is byte-identical to the original. The arm is still dropped, for a different and real reason: `metadata` carries `embedding_body_preview` and `blob_hash`, which the embed and indexing workers move asynchronously, so an agent that reads then commits can be refused for a difference it never made.

Also in this round: relation-only commits are now attributed to the entities the relation joins rather than to the change alone, which no reader could reach (change selection for an entity scans entity deltas, and a relation-only change has none), with the assertion moved onto `kin_provenance_query`; and the provenance description no longer claims an empty audit list proves nothing wrote the entity, since narrowing happens after a bounded recent-events window.

Scope disclosure beyond the two `Closes` lines: this PR also adds one passing test, `a_commit_repositions_the_entities_it_pushed_down`, asserting a commit updates the spans of entities it pushed down. That is FIR-1625 territory and the PR does not close it; the test passing is itself evidence the freshness half of that ticket already holds on main.

## Not in scope

The FIR-1679 follow-up notes two entity-count defects in `kin log` output after an operator runs `kin commit`. Those are in the CLI commit and log counting path, not the MCP write path, and need their own ticket.
