### PR TITLE
Bind daemon endpoint files to their publisher and commit the ingest CAS barrier

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,11 +21,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   publication and read as unpublished, so a daemon started with `--port 0` can
   no longer leave behind an endpoint record nothing can connect to while it goes
   on owning the repository.
-- The derived ingestion CAS is committed on every graceful daemon shutdown
-  instead of relying on its self-drain, and it is hydrated from repository
-  authority on the storage-backend open path as well as the local one, so
-  projection reads on a freshly opened hosted graph find the source bodies they
-  reference.
+- The derived ingestion CAS is committed at the points that need it rather than
+  relying on its self-drain. `kin-blobs` 0.1.3 amortizes the directory barrier
+  that makes a blob's name durable, so a write returning successfully no longer
+  implies the name survives a crash; the barrier is now issued before each graph
+  snapshot records those names, and again on graceful daemon shutdown. A
+  force-escalated shutdown, which exists to end a wedged process, still skips
+  it, and the store re-hydrates on open.
+- The ingestion CAS is hydrated from repository authority on the storage-backend
+  open path as well as the local one, so projection reads on a freshly opened
+  hosted graph find the source bodies they reference. Hydration consults the
+  local cache before fetching, and an instance whose cache already covers the
+  tree does no remote work at all, where every open previously re-fetched every
+  body before checking.
 
 ## [0.3.6] - 2026-07-26
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,26 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- A daemon that refuses to start can no longer take the running daemon's
+  endpoint down with it. `.kin/daemon.pid` and `.kin/daemon.port` are now
+  attributed by a `.kin/daemon.owner` record naming the exact process
+  incarnation that published them, a process may retire only an endpoint it can
+  prove it owns, and a daemon whose endpoint files are removed by something else
+  republishes them and keeps serving rather than shutting down. Retrying a
+  failing MCP call while a daemon was warming used to kill the daemon being
+  waited on.
+- The daemon publishes only a real bound port. Port `0` is refused on
+  publication and read as unpublished, so a daemon started with `--port 0` can
+  no longer leave behind an endpoint record nothing can connect to while it goes
+  on owning the repository.
+- The derived ingestion CAS is committed on every graceful daemon shutdown
+  instead of relying on its self-drain, and it is hydrated from repository
+  authority on the storage-backend open path as well as the local one, so
+  projection reads on a freshly opened hosted graph find the source bodies they
+  reference.
+
 ## [0.3.6] - 2026-07-26
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3040,9 +3040,9 @@ dependencies = [
 
 [[package]]
 name = "kin-blobs"
-version = "0.1.1"
+version = "0.1.3"
 source = "sparse+https://kinlab.ai/registry/cargo/"
-checksum = "8881418b6b53f75f8321ee8b3b200295c254e6807824ddf53997623044c9fc68"
+checksum = "2783752bbe4fec695c3cd6a008d2b379cc32e24450c279773c7e39742c29a1fe"
 dependencies = [
  "hex",
  "schemars",
@@ -6598,7 +6598,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.48.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -125,7 +125,7 @@ serial_test = "3"
 
 # Internal crates
 kin-model = { version = "=0.6.4", registry = "kin" }
-kin-blobs = { version = "0.1.1", registry = "kin" }
+kin-blobs = { version = "0.1.3", registry = "kin" }
 kin-core = { path = "crates/kin-core" }
 kin-parser = { path = "crates/kin-parser" }
 kin-index = { path = "crates/kin-index" }

--- a/crates/kin-cli/src/daemon_client.rs
+++ b/crates/kin-cli/src/daemon_client.rs
@@ -2040,6 +2040,12 @@ pub fn repo_daemon_port_path(kin_root: &Path) -> PathBuf {
     kin_root.join("daemon.port")
 }
 
+/// Path to the sidecar attributing a published endpoint to one process
+/// incarnation. Written by the daemon alongside the endpoint it describes.
+pub fn repo_daemon_owner_path(kin_root: &Path) -> PathBuf {
+    kin_root.join("daemon.owner")
+}
+
 /// Remove a repo worker daemon's pid/port endpoint files. The daemon deletes
 /// these itself on graceful shutdown; `kin daemon stop` also calls this after a
 /// confirmed stop so a later `status` never reports the dead endpoint as stale.
@@ -2139,13 +2145,17 @@ where
 
 fn remove_stale_daemon_files_uncoordinated_with<F>(
     kin_root: &Path,
-    remove_file: F,
+    mut remove_file: F,
 ) -> std::io::Result<()>
 where
     F: FnMut(&Path) -> std::io::Result<()>,
 {
     let pid_path = repo_daemon_pid_path(kin_root);
     let port_path = repo_daemon_port_path(kin_root);
+    // The owner sidecar attributes the endpoint being retired, so it goes with
+    // it. It is not part of the retirement verdict: `daemon.pid` is what makes
+    // an endpoint published, and a leftover attribution names nothing.
+    let _ = remove_file(&repo_daemon_owner_path(kin_root));
     remove_endpoint_files_with(&pid_path, &port_path, remove_file)
 }
 

--- a/crates/kin-daemon-spawn/src/lib.rs
+++ b/crates/kin-daemon-spawn/src/lib.rs
@@ -311,12 +311,23 @@ pub fn port_record_is_orphaned(kin_root: &Path) -> bool {
     kin_root.join(PORT_FILE_NAME).exists() && !kin_root.join(PID_FILE_NAME).exists()
 }
 
+/// File the daemon writes its publishing incarnation into beside the endpoint.
+///
+/// Read by nothing here; named so this repair retires it with the endpoint it
+/// attributes, rather than leaving an attribution behind for a record that no
+/// longer exists.
+pub const OWNER_FILE_NAME: &str = "daemon.owner";
+
 /// Clear an orphaned port record so a fresh spawn is not read against a dead
 /// predecessor's port. Returns whether anything was removed.
 pub fn clear_orphaned_port_record(kin_root: &Path) -> bool {
     if !port_record_is_orphaned(kin_root) {
         return false;
     }
+    // The PID file is already gone, so the sidecar attributes nothing. Retire
+    // it with the port rather than leaving the two repair surfaces disagreeing
+    // about what an endpoint is made of.
+    let _ = std::fs::remove_file(kin_root.join(OWNER_FILE_NAME));
     match std::fs::remove_file(kin_root.join(PORT_FILE_NAME)) {
         Ok(()) => true,
         Err(error) if error.kind() == std::io::ErrorKind::NotFound => false,

--- a/crates/kin-daemon/src/daemon.rs
+++ b/crates/kin-daemon/src/daemon.rs
@@ -347,20 +347,72 @@ pub fn runtime_shutdown_grace() -> Duration {
     )
 }
 
-fn endpoint_files_missing(state: &DaemonState) -> bool {
+/// What the on-disk control plane says about this daemon's right to keep
+/// serving.
+///
+/// Endpoint files disappearing is not, on its own, a reason for a healthy
+/// daemon to die. The two cases that are — the repository was removed, or
+/// another daemon took the repo over — are distinguishable from a third party
+/// deleting `daemon.pid`/`daemon.port` out from under a running incumbent, and
+/// conflating them is how a refused second start killed the daemon it lost to.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum ControlPlane {
+    /// `.kin` is present and the published endpoint names this process.
+    Ours,
+    /// The `.kin` root itself is gone: `kin eject` or doctor removed the repo.
+    RootGone,
+    /// The endpoint names a different daemon that is still running, so this
+    /// process is no longer the one serving the repo.
+    Superseded { pid: u32 },
+    /// `.kin` is present, but this daemon's endpoint is missing, incomplete, or
+    /// attributed to a process that is gone. The daemon still owns the repo
+    /// singleton, so the endpoint is repairable rather than fatal.
+    EndpointLost,
+}
+
+/// How often the control plane is re-examined when no idle timeout paces the
+/// monitor. Cheap: three `exists` checks and, at most, one small read.
+const CONTROL_PLANE_CHECK_INTERVAL: Duration = Duration::from_secs(5);
+
+/// Whether the `.kin` directory this daemon serves has been removed. The only
+/// condition under which a flush must be skipped: there is nowhere to write.
+fn repository_root_missing(state: &DaemonState) -> bool {
+    !state.layout.root().exists()
+}
+
+fn classify_control_plane(state: &DaemonState) -> ControlPlane {
     let root = state.layout.root();
-    !root.join("daemon.pid").exists() || !root.join("daemon.port").exists()
+    if !root.exists() {
+        return ControlPlane::RootGone;
+    }
+    match crate::lifecycle::endpoint_ownership(root) {
+        crate::lifecycle::EndpointOwnership::CurrentProcess => {
+            if crate::lifecycle::read_port_file(root).is_some() {
+                ControlPlane::Ours
+            } else {
+                ControlPlane::EndpointLost
+            }
+        }
+        crate::lifecycle::EndpointOwnership::OtherProcess { pid, live: true } => {
+            ControlPlane::Superseded { pid }
+        }
+        crate::lifecycle::EndpointOwnership::OtherProcess { .. }
+        | crate::lifecycle::EndpointOwnership::Unattributed
+        | crate::lifecycle::EndpointOwnership::Absent => ControlPlane::EndpointLost,
+    }
 }
 
-fn control_plane_missing(state: &DaemonState) -> bool {
-    !state.layout.root().exists() || endpoint_files_missing(state)
-}
-
-fn ready_for_idle_shutdown(state: &DaemonState, idle_timeout: Duration) -> bool {
+fn ready_for_idle_shutdown(
+    state: &DaemonState,
+    idle_timeout: Duration,
+    control_plane: ControlPlane,
+) -> bool {
     if state.active_request_count() > 0 {
         return false;
     }
-    if endpoint_files_missing(state) {
+    if control_plane == ControlPlane::EndpointLost {
+        // Unreachable by new clients until the endpoint is republished, so the
+        // usual initialization and session gates cannot be waiting on anything.
         return state.idle_duration() >= idle_timeout;
     }
     if !state
@@ -473,15 +525,75 @@ fn watched_process_is_alive(_pid: i32) -> bool {
     true
 }
 
+/// Watch the control plane for the two states that end this daemon, repairing
+/// the one that does not.
+///
+/// Returns `true` when the daemon must shut down. A lost endpoint is
+/// republished instead: this process holds the repository singleton, so it is
+/// the only legitimate publisher, and restoring its own record is the exact
+/// truth rather than a guess. Republication also makes the failure
+/// self-healing, because the clients that lost the endpoint find it again on
+/// their next poll.
+fn control_plane_demands_shutdown(state: &DaemonState, bound_port: u16) -> bool {
+    match classify_control_plane(state) {
+        ControlPlane::Ours => false,
+        ControlPlane::RootGone => {
+            warn!(
+                root = %state.layout.root().display(),
+                "Kin control directory disappeared; shutting down daemon"
+            );
+            true
+        }
+        ControlPlane::Superseded { pid } => {
+            warn!(
+                root = %state.layout.root().display(),
+                successor_pid = pid,
+                "another daemon now owns this repository endpoint; shutting down"
+            );
+            true
+        }
+        ControlPlane::EndpointLost => {
+            match crate::lifecycle::publish_daemon_endpoint(state.layout.root(), bound_port) {
+                Ok(()) => info!(
+                    root = %state.layout.root().display(),
+                    port = bound_port,
+                    "daemon endpoint files were removed by another process; republished them"
+                ),
+                Err(error) => warn!(
+                    root = %state.layout.root().display(),
+                    port = bound_port,
+                    %error,
+                    "daemon endpoint files are missing and could not be republished"
+                ),
+            }
+            false
+        }
+    }
+}
+
 async fn run_idle_monitor(
     state: Arc<DaemonState>,
     idle_timeout: Option<Duration>,
+    bound_port: u16,
     cancel_tx: tokio::sync::watch::Sender<bool>,
     mut cancel_rx: tokio::sync::watch::Receiver<bool>,
 ) {
     let Some(idle_timeout) = idle_timeout else {
-        let _ = cancel_rx.changed().await;
-        return;
+        // Endpoint repair is the idle monitor's other job, so it must keep
+        // running even for a daemon that never idles out.
+        loop {
+            tokio::select! {
+                _ = tokio::time::sleep(CONTROL_PLANE_CHECK_INTERVAL) => {}
+                _ = cancel_rx.changed() => return,
+            }
+            if *cancel_rx.borrow() {
+                return;
+            }
+            if control_plane_demands_shutdown(&state, bound_port) {
+                let _ = cancel_tx.send(true);
+                return;
+            }
+        }
     };
     let check_interval = idle_check_interval(idle_timeout);
     // Start the idle window from when monitoring begins, not from process
@@ -504,17 +616,14 @@ async fn run_idle_monitor(
         if *cancel_rx.borrow() {
             return;
         }
-        if control_plane_missing(&state) {
-            warn!(
-                root = %state.layout.root().display(),
-                "Kin control directory disappeared; shutting down daemon"
-            );
+        if control_plane_demands_shutdown(&state, bound_port) {
             let _ = cancel_tx.send(true);
             return;
         }
-        if ready_for_idle_shutdown(&state, idle_timeout) {
+        let control_plane = classify_control_plane(&state);
+        if ready_for_idle_shutdown(&state, idle_timeout, control_plane) {
             if state.is_dirty() {
-                if control_plane_missing(&state) {
+                if repository_root_missing(&state) {
                     warn!(
                         root = %state.layout.root().display(),
                         "skipping dirty graph flush before idle shutdown because Kin control directory is gone"
@@ -522,7 +631,7 @@ async fn run_idle_monitor(
                 } else {
                     info!("flushing dirty graph before idle shutdown");
                     if let Err(error) = save_snapshot_blocking(Arc::clone(&state)).await {
-                        if control_plane_missing(&state) {
+                        if repository_root_missing(&state) {
                             warn!(
                                 error = %error,
                                 root = %state.layout.root().display(),
@@ -737,7 +846,14 @@ pub async fn run_with_authority(
     let idle_cancel_tx = cancel_tx.clone();
     let idle_cancel = cancel_rx.clone();
     let idle_handle = tokio::spawn(async move {
-        run_idle_monitor(idle_state, idle_timeout, idle_cancel_tx, idle_cancel).await
+        run_idle_monitor(
+            idle_state,
+            idle_timeout,
+            bound_port,
+            idle_cancel_tx,
+            idle_cancel,
+        )
+        .await
     });
 
     // Opt-in owner-death watchdog. A harness (e.g. the benchmark driver) sets
@@ -1972,11 +2088,32 @@ pub async fn run_with_authority(
     )
     .await;
 
+    // The derived ingestion CAS defers its directory barriers and commits them
+    // on an explicit sync, on drop, or on a self-drain. This process ends in
+    // `process::exit`, which runs no destructor, so the barrier has to be
+    // issued here or the only one that ever fires is the self-drain.
+    sync_blob_store_blocking(Arc::clone(&state)).await;
+
     // Remove PID and port files after final flush work finishes, so a successor
     // daemon cannot start while this process is still draining persistent state.
     crate::lifecycle::remove_daemon_files_if_current_process(state.layout.root());
 
     result
+}
+
+/// Issue the ingestion CAS barrier off the async workers: it is a run of
+/// `fsync` calls on directories, one per shard touched since the last commit.
+async fn sync_blob_store_blocking(state: Arc<DaemonState>) {
+    let outcome = tokio::task::spawn_blocking(move || state.sync_blob_store()).await;
+    match outcome {
+        Ok(Ok(())) => {}
+        Ok(Err(error)) => {
+            warn!(%error, "ingestion CAS barrier failed on shutdown")
+        }
+        Err(error) => {
+            warn!(%error, "ingestion CAS barrier task failed on shutdown")
+        }
+    }
 }
 
 #[cfg(unix)]

--- a/crates/kin-daemon/src/daemon.rs
+++ b/crates/kin-daemon/src/daemon.rs
@@ -385,20 +385,20 @@ fn classify_control_plane(state: &DaemonState) -> ControlPlane {
     if !root.exists() {
         return ControlPlane::RootGone;
     }
+    // Yielding is gated on proof, not on a PID. This daemon holds the
+    // repository singleton for its whole lifetime, so no legitimate successor
+    // can exist; a foreign endpoint that cannot prove a live owner is debris,
+    // and treating debris as an eviction notice is what killed the incumbent.
+    if let Some(pid) = crate::lifecycle::proven_live_other_endpoint_owner(root) {
+        return ControlPlane::Superseded { pid };
+    }
     match crate::lifecycle::endpoint_ownership(root) {
-        crate::lifecycle::EndpointOwnership::CurrentProcess => {
-            if crate::lifecycle::read_port_file(root).is_some() {
-                ControlPlane::Ours
-            } else {
-                ControlPlane::EndpointLost
-            }
+        crate::lifecycle::EndpointOwnership::CurrentProcess
+            if crate::lifecycle::read_port_file(root).is_some() =>
+        {
+            ControlPlane::Ours
         }
-        crate::lifecycle::EndpointOwnership::OtherProcess { pid, live: true } => {
-            ControlPlane::Superseded { pid }
-        }
-        crate::lifecycle::EndpointOwnership::OtherProcess { .. }
-        | crate::lifecycle::EndpointOwnership::Unattributed
-        | crate::lifecycle::EndpointOwnership::Absent => ControlPlane::EndpointLost,
+        _ => ControlPlane::EndpointLost,
     }
 }
 
@@ -2341,7 +2341,7 @@ mod tests {
     use super::{
         drain_pending_flush, format_singleton_contention, next_embed_error_backoff,
         parse_duration_secs, parse_owner_watch_pid, should_enable_lsp_enrichment, should_flush_now,
-        shutdown_signalled, watched_process_is_alive, DaemonConfig, DaemonState,
+        shutdown_signalled, watched_process_is_alive, ControlPlane, DaemonConfig, DaemonState,
         DEFAULT_RUNTIME_SHUTDOWN_GRACE, DEFAULT_SHUTDOWN_ESCALATION_GRACE,
     };
     use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
@@ -2393,6 +2393,127 @@ mod tests {
                 && !repo_b_kin_root.join("daemon.port").exists(),
             "authority mismatch must fail before endpoint publication"
         );
+    }
+
+    // ── Control-plane classification ──────────────────────────────────────
+    //
+    // A healthy daemon used to read "my endpoint files are gone" as "the
+    // repository is gone" and shut itself down, which is how a refused second
+    // start killed the incumbent it lost to. The two states that genuinely end
+    // a daemon are distinguishable from the one that is repairable.
+
+    #[tokio::test]
+    async fn a_published_endpoint_reads_as_this_daemons_own() {
+        let repo = tempfile::tempdir().unwrap();
+        let initialized = kin_core::init(repo.path()).unwrap();
+        let kin_root = initialized.layout.root().to_path_buf();
+        let state = DaemonState::open(initialized.layout).unwrap();
+        crate::lifecycle::publish_daemon_endpoint(&kin_root, 51234).unwrap();
+
+        assert_eq!(super::classify_control_plane(&state), ControlPlane::Ours);
+    }
+
+    #[tokio::test]
+    async fn a_deleted_endpoint_is_repairable_rather_than_fatal() {
+        let repo = tempfile::tempdir().unwrap();
+        let initialized = kin_core::init(repo.path()).unwrap();
+        let kin_root = initialized.layout.root().to_path_buf();
+        let state = DaemonState::open(initialized.layout).unwrap();
+        crate::lifecycle::publish_daemon_endpoint(&kin_root, 51234).unwrap();
+
+        std::fs::remove_file(kin_root.join("daemon.pid")).unwrap();
+        std::fs::remove_file(kin_root.join("daemon.port")).unwrap();
+
+        assert_eq!(
+            super::classify_control_plane(&state),
+            ControlPlane::EndpointLost
+        );
+        assert!(
+            !super::control_plane_demands_shutdown(&state, 51234),
+            "a daemon that still owns the repo must repair its endpoint, not exit"
+        );
+        assert_eq!(
+            super::classify_control_plane(&state),
+            ControlPlane::Ours,
+            "the repair must republish this daemon's own endpoint"
+        );
+        assert_eq!(
+            crate::lifecycle::read_port_file(&kin_root),
+            Some(51234),
+            "republication must restore the port this daemon actually bound"
+        );
+    }
+
+    #[tokio::test]
+    async fn a_removed_repository_root_ends_the_daemon() {
+        let repo = tempfile::tempdir().unwrap();
+        let initialized = kin_core::init(repo.path()).unwrap();
+        let kin_root = initialized.layout.root().to_path_buf();
+        let state = DaemonState::open(initialized.layout).unwrap();
+        crate::lifecycle::publish_daemon_endpoint(&kin_root, 51234).unwrap();
+
+        std::fs::remove_dir_all(&kin_root).unwrap();
+
+        assert_eq!(
+            super::classify_control_plane(&state),
+            ControlPlane::RootGone
+        );
+        assert!(super::control_plane_demands_shutdown(&state, 51234));
+    }
+
+    #[tokio::test]
+    async fn a_proven_live_successor_endpoint_ends_the_daemon() {
+        let repo = tempfile::tempdir().unwrap();
+        let initialized = kin_core::init(repo.path()).unwrap();
+        let kin_root = initialized.layout.root().to_path_buf();
+        let state = DaemonState::open(initialized.layout).unwrap();
+
+        let mut successor = std::process::Command::new("sleep")
+            .arg("30")
+            .spawn()
+            .expect("spawn a stand-in successor");
+        let identity = kin_cli::daemon_client::process_identity(successor.id())
+            .expect("read the successor's identity")
+            .expect("the successor is running");
+        crate::lifecycle::publish_foreign_endpoint_for_test(&kin_root, identity, 51234);
+
+        assert_eq!(
+            super::classify_control_plane(&state),
+            ControlPlane::Superseded {
+                pid: successor.id()
+            }
+        );
+        assert!(super::control_plane_demands_shutdown(&state, 4219));
+        assert_eq!(
+            std::fs::read_to_string(kin_root.join("daemon.port")).unwrap(),
+            "51234",
+            "yielding to a successor must not disturb the endpoint it published"
+        );
+
+        let _ = successor.kill();
+        let _ = successor.wait();
+    }
+
+    #[tokio::test]
+    async fn a_foreign_endpoint_that_proves_nothing_is_repaired_not_obeyed() {
+        // PID 1 is alive and is not this process, but a bare-PID record cannot
+        // prove that number still names a daemon. This process holds the
+        // repository singleton, so no successor can legitimately exist and the
+        // record is debris — the exact debris a refusing starter used to leave.
+        let repo = tempfile::tempdir().unwrap();
+        let initialized = kin_core::init(repo.path()).unwrap();
+        let kin_root = initialized.layout.root().to_path_buf();
+        let state = DaemonState::open(initialized.layout).unwrap();
+        std::fs::write(kin_root.join("daemon.pid"), "1").unwrap();
+        std::fs::write(kin_root.join("daemon.port"), "51234").unwrap();
+
+        assert_eq!(
+            super::classify_control_plane(&state),
+            ControlPlane::EndpointLost
+        );
+        assert!(!super::control_plane_demands_shutdown(&state, 4219));
+        assert_eq!(super::classify_control_plane(&state), ControlPlane::Ours);
+        assert_eq!(crate::lifecycle::read_port_file(&kin_root), Some(4219));
     }
 
     #[test]

--- a/crates/kin-daemon/src/daemon.rs
+++ b/crates/kin-daemon/src/daemon.rs
@@ -254,15 +254,20 @@ async fn drain_pending_flush(pending: &mut Option<tokio::task::JoinHandle<Result
 //    hydration is a blocking task rather than a drained handle, but the API
 //    server's graceful shutdown waits on in-flight requests, so a hydrating
 //    daemon rides this full 10s;
-// 3. the final storage flush and endpoint-file removal run (fast on the local
-//    backend);
+// 3. the final storage flush, the derived-CAS directory barrier, and
+//    endpoint-file removal run (all fast on the local backend; the barrier is
+//    bounded at one fsync per shard directory touched, so at most 256);
 // 4. `runtime.shutdown_timeout(runtime_shutdown_grace())` waits up to 8s for
 //    the blocking pool, then abandons whatever is still running;
 // 5. the process exits.
 //
 // That normal path is ~18s. Independently, the escalation watchdog force-exits
 // DEFAULT_SHUTDOWN_ESCALATION_GRACE after shutdown is signalled, so the hard
-// bound is ~25s. Owner death costs at most one OWNER_WATCH_CHECK_INTERVAL of
+// bound is ~25s. A force-escalated exit skips step 3 entirely: neither the
+// barrier nor endpoint retirement runs, which is the deliberate trade of a
+// backstop that exists to end a wedged process. Both are recoverable, since
+// the derived CAS re-hydrates on open and a stale endpoint is swept by the
+// next liveness probe. Owner death costs at most one OWNER_WATCH_CHECK_INTERVAL of
 // detection on top of the same bound: ~27s from owner exit to process gone,
 // with no signal ever sent.
 //
@@ -411,8 +416,12 @@ fn ready_for_idle_shutdown(
         return false;
     }
     if control_plane == ControlPlane::EndpointLost {
-        // Unreachable by new clients until the endpoint is republished, so the
-        // usual initialization and session gates cannot be waiting on anything.
+        // Rare by construction: the control-plane check earlier in this same
+        // tick repairs a lost endpoint, so reaching here means republication
+        // itself failed. Kept because that is exactly when it matters: the
+        // daemon is unreachable by new clients, so the usual initialization and
+        // session gates cannot be waiting on anything, and it should be allowed
+        // to idle out rather than linger unreachable.
         return state.idle_duration() >= idle_timeout;
     }
     if !state
@@ -534,7 +543,11 @@ fn watched_process_is_alive(_pid: i32) -> bool {
 /// truth rather than a guess. Republication also makes the failure
 /// self-healing, because the clients that lost the endpoint find it again on
 /// their next poll.
-fn control_plane_demands_shutdown(state: &DaemonState, bound_port: u16) -> bool {
+fn control_plane_demands_shutdown(
+    state: &DaemonState,
+    bound_port: u16,
+    shutting_down: bool,
+) -> bool {
     match classify_control_plane(state) {
         ControlPlane::Ours => false,
         ControlPlane::RootGone => {
@@ -551,6 +564,14 @@ fn control_plane_demands_shutdown(state: &DaemonState, bound_port: u16) -> bool 
                 "another daemon now owns this repository endpoint; shutting down"
             );
             true
+        }
+        ControlPlane::EndpointLost if shutting_down => {
+            // Retirement is already running or about to. Republishing now
+            // would race it and could land after it, leaving an endpoint
+            // advertising a daemon that is about to exit. Task drain is
+            // bounded and does not abort this monitor, and publication can
+            // block on the coordination lock, so the window is real.
+            false
         }
         ControlPlane::EndpointLost => {
             match crate::lifecycle::publish_daemon_endpoint(state.layout.root(), bound_port) {
@@ -589,7 +610,7 @@ async fn run_idle_monitor(
             if *cancel_rx.borrow() {
                 return;
             }
-            if control_plane_demands_shutdown(&state, bound_port) {
+            if control_plane_demands_shutdown(&state, bound_port, *cancel_rx.borrow()) {
                 let _ = cancel_tx.send(true);
                 return;
             }
@@ -616,7 +637,7 @@ async fn run_idle_monitor(
         if *cancel_rx.borrow() {
             return;
         }
-        if control_plane_demands_shutdown(&state, bound_port) {
+        if control_plane_demands_shutdown(&state, bound_port, *cancel_rx.borrow()) {
             let _ = cancel_tx.send(true);
             return;
         }
@@ -2429,7 +2450,7 @@ mod tests {
             ControlPlane::EndpointLost
         );
         assert!(
-            !super::control_plane_demands_shutdown(&state, 51234),
+            !super::control_plane_demands_shutdown(&state, 51234, false),
             "a daemon that still owns the repo must repair its endpoint, not exit"
         );
         assert_eq!(
@@ -2441,6 +2462,31 @@ mod tests {
             crate::lifecycle::read_port_file(&kin_root),
             Some(51234),
             "republication must restore the port this daemon actually bound"
+        );
+    }
+
+    #[tokio::test]
+    async fn a_lost_endpoint_is_not_republished_once_shutdown_is_signalled() {
+        // Task drain is bounded and does not abort this monitor, and
+        // publication can block on the coordination lock, so a repair that
+        // started late could land after retirement and advertise an endpoint
+        // for a process that is exiting.
+        let repo = tempfile::tempdir().unwrap();
+        let initialized = kin_core::init(repo.path()).unwrap();
+        let kin_root = initialized.layout.root().to_path_buf();
+        let state = DaemonState::open(initialized.layout).unwrap();
+        crate::lifecycle::publish_daemon_endpoint(&kin_root, 51234).unwrap();
+        std::fs::remove_file(kin_root.join("daemon.pid")).unwrap();
+        std::fs::remove_file(kin_root.join("daemon.port")).unwrap();
+
+        assert!(
+            !super::control_plane_demands_shutdown(&state, 51234, true),
+            "a lost endpoint is still not a reason to shut down"
+        );
+        assert_eq!(
+            super::classify_control_plane(&state),
+            ControlPlane::EndpointLost,
+            "a shutting-down daemon must not republish an endpoint it is about to retire"
         );
     }
 
@@ -2458,7 +2504,7 @@ mod tests {
             super::classify_control_plane(&state),
             ControlPlane::RootGone
         );
-        assert!(super::control_plane_demands_shutdown(&state, 51234));
+        assert!(super::control_plane_demands_shutdown(&state, 51234, false));
     }
 
     #[tokio::test]
@@ -2483,7 +2529,7 @@ mod tests {
                 pid: successor.id()
             }
         );
-        assert!(super::control_plane_demands_shutdown(&state, 4219));
+        assert!(super::control_plane_demands_shutdown(&state, 4219, false));
         assert_eq!(
             std::fs::read_to_string(kin_root.join("daemon.port")).unwrap(),
             "51234",
@@ -2511,7 +2557,7 @@ mod tests {
             super::classify_control_plane(&state),
             ControlPlane::EndpointLost
         );
-        assert!(!super::control_plane_demands_shutdown(&state, 4219));
+        assert!(!super::control_plane_demands_shutdown(&state, 4219, false));
         assert_eq!(super::classify_control_plane(&state), ControlPlane::Ours);
         assert_eq!(crate::lifecycle::read_port_file(&kin_root), Some(4219));
     }

--- a/crates/kin-daemon/src/lifecycle.rs
+++ b/crates/kin-daemon/src/lifecycle.rs
@@ -729,6 +729,51 @@ pub fn endpoint_ownership(kin_root: &Path) -> EndpointOwnership {
     }
 }
 
+/// The PID of a *different* incarnation that the endpoint record proves is
+/// still running, if there is one.
+///
+/// Only an owner record can prove this. A legacy bare-PID endpoint names a
+/// number that reuse makes ambiguous, and refusing to publish over an
+/// unprovable claim would let a recycled PID keep a repo's rightful owner —
+/// the process actually holding the singleton — from ever advertising itself.
+pub(crate) fn proven_live_other_endpoint_owner(kin_root: &Path) -> Option<u32> {
+    if !kin_root.join("daemon.pid").exists() {
+        return None;
+    }
+    let record = read_endpoint_owner_record(kin_root)?;
+    if record.identity.pid() == std::process::id() {
+        return None;
+    }
+    // An identity that cannot be read at all is indeterminate, not dead.
+    kin_cli::daemon_client::process_identity_is_current(&record.identity)
+        .unwrap_or(true)
+        .then(|| record.identity.pid())
+}
+
+/// Publish an endpoint attributed to a process other than this one, so tests
+/// can build the state a real successor would leave behind without running a
+/// second daemon.
+#[cfg(test)]
+pub(crate) fn publish_foreign_endpoint_for_test(
+    kin_root: &Path,
+    identity: kin_cli::daemon_client::ProcessIdentity,
+    port: u16,
+) {
+    let pid = identity.pid();
+    let record = EndpointOwnerRecord {
+        schema: ENDPOINT_OWNER_SCHEMA.to_string(),
+        identity,
+        port,
+    };
+    std::fs::write(kin_root.join("daemon.pid"), pid.to_string()).unwrap();
+    std::fs::write(kin_root.join("daemon.port"), port.to_string()).unwrap();
+    std::fs::write(
+        kin_root.join(ENDPOINT_OWNER_FILE),
+        serde_json::to_string(&record).unwrap(),
+    )
+    .unwrap();
+}
+
 fn write_atomic_endpoint_component(
     kin_root: &Path,
     name: &str,
@@ -778,15 +823,18 @@ fn publish_daemon_endpoint_under_authority(kin_root: &Path, port: u16) -> std::i
     // A starter that lost the singleton must never reach this, but publication
     // overwrites files by design, so the guarantee is asserted here rather than
     // assumed from the call graph.
-    if let EndpointOwnership::OtherProcess { pid, live: true } = endpoint_ownership(kin_root) {
+    if let Some(pid) = proven_live_other_endpoint_owner(kin_root) {
         return Err(std::io::Error::new(
             std::io::ErrorKind::AlreadyExists,
-            format!("daemon endpoint for {} is owned by live pid {pid}", kin_root.display()),
+            format!(
+                "daemon endpoint for {} is owned by live pid {pid}",
+                kin_root.display()
+            ),
         ));
     }
 
-    let owner = EndpointOwnerRecord::current(port)
-        .and_then(|record| serde_json::to_string(&record).ok());
+    let owner =
+        EndpointOwnerRecord::current(port).and_then(|record| serde_json::to_string(&record).ok());
     let pid = std::process::id().to_string();
     let port = port.to_string();
 
@@ -847,6 +895,12 @@ pub fn write_pid_file(kin_root: &Path) {
 /// Written atomically (temp + rename) so a CLI polling the port file during the
 /// daemon→CLI port handshake never parses a torn or partial value.
 pub fn write_port_file(kin_root: &Path, port: u16) {
+    if port == 0 {
+        // Never a reachable endpoint: it is the bind-time request for an
+        // OS-assigned port, and recording it advertises an address nothing can
+        // dial while the daemon that wrote it keeps owning the repo.
+        return;
+    }
     if let Ok(_authority) = acquire_singleton_coordination_guard(kin_root) {
         let _ = write_atomic_endpoint_component(kin_root, "daemon.port", port.to_string());
     }
@@ -1863,5 +1917,253 @@ mod tests {
         remove_daemon_files_if_current_process(dir.path());
         assert!(dir.path().join("daemon.pid").exists());
         assert!(dir.path().join("daemon.port").exists());
+    }
+
+    // ── Endpoint ownership ────────────────────────────────────────────────
+    //
+    // The failure these close: a daemon that lost the singleton lock deleted
+    // the incumbent's endpoint files on its way out, and the incumbent — which
+    // keyed its own liveness on those files existing — shut itself down. Every
+    // destructive endpoint decision now needs proof of ownership, and the proof
+    // is a process incarnation rather than a reusable PID.
+
+    /// Rewrite a serialized identity's birth token so it names a different
+    /// incarnation of the same live PID: exactly the shape PID reuse produces.
+    fn forge_other_incarnation(encoded: &str) -> String {
+        let forged = encoded
+            .replace("start-time:", "start-time:9")
+            .replace("start-ticks:", "start-ticks:9")
+            .replace("created-100ns:", "created-100ns:9");
+        assert_ne!(forged, encoded, "the birth token must have been altered");
+        forged
+    }
+
+    #[test]
+    fn publication_attributes_the_endpoint_to_its_publisher() {
+        let dir = tempfile::tempdir().unwrap();
+        let root = dir.path();
+
+        publish_daemon_endpoint(root, 51234).expect("publish endpoint");
+
+        assert_eq!(endpoint_ownership(root), EndpointOwnership::CurrentProcess);
+        assert!(
+            root.join(ENDPOINT_OWNER_FILE).exists(),
+            "publication must record who published"
+        );
+        let record = read_endpoint_owner_record(root).expect("owner record parses");
+        assert_eq!(record.identity.pid(), std::process::id());
+        assert_eq!(record.port, 51234);
+    }
+
+    #[test]
+    fn a_recycled_pid_cannot_claim_a_published_endpoint() {
+        // The endpoint names this live PID, but a different incarnation of it.
+        // A bare-PID comparison would authorize this process to delete files it
+        // never published.
+        let dir = tempfile::tempdir().unwrap();
+        let root = dir.path();
+        publish_daemon_endpoint(root, 51234).expect("publish endpoint");
+
+        let record = std::fs::read_to_string(root.join(ENDPOINT_OWNER_FILE)).unwrap();
+        std::fs::write(
+            root.join(ENDPOINT_OWNER_FILE),
+            forge_other_incarnation(&record),
+        )
+        .unwrap();
+
+        assert_eq!(
+            endpoint_ownership(root),
+            EndpointOwnership::OtherProcess {
+                pid: std::process::id(),
+                live: false,
+            },
+            "an incarnation that is gone does not own this endpoint, whatever its PID resolves to"
+        );
+
+        remove_daemon_files_if_current_process(root);
+        assert!(
+            root.join("daemon.pid").exists() && root.join("daemon.port").exists(),
+            "an endpoint this process cannot prove it published must survive"
+        );
+    }
+
+    #[test]
+    fn retirement_clears_the_owner_record_with_the_endpoint() {
+        let dir = tempfile::tempdir().unwrap();
+        let root = dir.path();
+        publish_daemon_endpoint(root, 51234).expect("publish endpoint");
+
+        remove_daemon_files_if_current_process(root);
+
+        assert!(!root.join("daemon.pid").exists());
+        assert!(!root.join("daemon.port").exists());
+        assert!(
+            !root.join(ENDPOINT_OWNER_FILE).exists(),
+            "a retired endpoint must leave no attribution behind for the next reader"
+        );
+        assert_eq!(endpoint_ownership(root), EndpointOwnership::Absent);
+    }
+
+    #[test]
+    fn a_legacy_endpoint_without_an_owner_record_is_still_attributed() {
+        // A repo whose endpoint was published by an older daemon has no
+        // sidecar. Refusing to read the bare PID would make every such endpoint
+        // permanently unremovable, including by the daemon that owns it.
+        let dir = tempfile::tempdir().unwrap();
+        let root = dir.path();
+
+        std::fs::write(root.join("daemon.pid"), std::process::id().to_string()).unwrap();
+        assert_eq!(endpoint_ownership(root), EndpointOwnership::CurrentProcess);
+
+        std::fs::write(root.join("daemon.pid"), "1").unwrap();
+        assert_eq!(
+            endpoint_ownership(root),
+            EndpointOwnership::OtherProcess { pid: 1, live: true }
+        );
+
+        std::fs::write(root.join("daemon.pid"), "not-a-pid").unwrap();
+        assert_eq!(endpoint_ownership(root), EndpointOwnership::Unattributed);
+    }
+
+    #[test]
+    fn a_stray_owner_record_alone_publishes_nothing() {
+        let dir = tempfile::tempdir().unwrap();
+        let root = dir.path();
+        publish_daemon_endpoint(root, 51234).expect("publish endpoint");
+        std::fs::remove_file(root.join("daemon.pid")).unwrap();
+
+        assert_eq!(
+            endpoint_ownership(root),
+            EndpointOwnership::Absent,
+            "daemon.pid is what makes an endpoint published; attribution alone is not one"
+        );
+    }
+
+    #[test]
+    fn publication_refuses_an_unbound_port() {
+        // `--port 0` means "the OS will pick one". Publishing it strands every
+        // reader on an endpoint nothing can dial while the publisher keeps
+        // owning the repo and refusing successors.
+        let dir = tempfile::tempdir().unwrap();
+        let root = dir.path();
+
+        let error = publish_daemon_endpoint(root, 0).expect_err("zero is not an endpoint");
+        assert_eq!(error.kind(), std::io::ErrorKind::InvalidInput);
+        assert_eq!(endpoint_ownership(root), EndpointOwnership::Absent);
+        assert!(!root.join("daemon.port").exists());
+    }
+
+    #[test]
+    fn a_zero_port_record_reads_as_unpublished() {
+        let dir = tempfile::tempdir().unwrap();
+        std::fs::write(dir.path().join("daemon.port"), "0").unwrap();
+        assert_eq!(read_port_file(dir.path()), None);
+        assert!(daemon_is_up(dir.path()).is_none());
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn publication_refuses_to_replace_a_proven_live_owners_endpoint() {
+        // A real other process, so the record names an incarnation that really
+        // is running rather than a PID that might mean anything.
+        let dir = tempfile::tempdir().unwrap();
+        let root = dir.path();
+        let mut incumbent = std::process::Command::new("sleep")
+            .arg("30")
+            .spawn()
+            .expect("spawn a stand-in incumbent");
+        let identity = kin_cli::daemon_client::process_identity(incumbent.id())
+            .expect("read the incumbent's identity")
+            .expect("the incumbent is running");
+
+        std::fs::write(root.join("daemon.pid"), incumbent.id().to_string()).unwrap();
+        std::fs::write(root.join("daemon.port"), "51234").unwrap();
+        std::fs::write(
+            root.join(ENDPOINT_OWNER_FILE),
+            serde_json::to_string(&EndpointOwnerRecord {
+                schema: ENDPOINT_OWNER_SCHEMA.to_string(),
+                identity,
+                port: 51234,
+            })
+            .unwrap(),
+        )
+        .unwrap();
+
+        let error =
+            publish_daemon_endpoint(root, 4219).expect_err("a live owner's endpoint is not ours");
+        assert_eq!(error.kind(), std::io::ErrorKind::AlreadyExists);
+        assert_eq!(
+            std::fs::read_to_string(root.join("daemon.pid")).unwrap(),
+            incumbent.id().to_string()
+        );
+        assert_eq!(
+            std::fs::read_to_string(root.join("daemon.port")).unwrap(),
+            "51234"
+        );
+
+        let _ = incumbent.kill();
+        let _ = incumbent.wait();
+    }
+
+    #[test]
+    fn publication_replaces_a_legacy_endpoint_whose_pid_proves_nothing() {
+        // PID 1 is alive and is not this process, but a bare-PID record cannot
+        // prove that number still names the daemon that wrote it. The publisher
+        // holds the repository singleton, so refusing here would leave the
+        // repo's rightful owner permanently unable to advertise itself.
+        let dir = tempfile::tempdir().unwrap();
+        let root = dir.path();
+        std::fs::write(root.join("daemon.pid"), "1").unwrap();
+        std::fs::write(root.join("daemon.port"), "51234").unwrap();
+
+        publish_daemon_endpoint(root, 4219)
+            .expect("an unprovable claim must not block publication");
+
+        assert_eq!(endpoint_ownership(root), EndpointOwnership::CurrentProcess);
+        assert_eq!(read_port_file(root), Some(4219));
+    }
+
+    #[test]
+    fn a_failed_publication_rolls_back_only_what_it_installed() {
+        // Force the port rename to fail by parking a non-empty directory on the
+        // destination. The rollback must remove the components this call
+        // installed and nothing else.
+        let dir = tempfile::tempdir().unwrap();
+        let root = dir.path();
+        std::fs::create_dir(root.join("daemon.port")).unwrap();
+        std::fs::write(root.join("daemon.port").join("occupant"), b"x").unwrap();
+
+        publish_daemon_endpoint(root, 51234).expect_err("renaming onto a directory must fail");
+
+        assert!(
+            !root.join("daemon.pid").exists(),
+            "the pid this call installed must be rolled back"
+        );
+        assert!(
+            !root.join(ENDPOINT_OWNER_FILE).exists(),
+            "the attribution this call installed must be rolled back"
+        );
+        assert!(
+            root.join("daemon.port").join("occupant").exists(),
+            "a path this call never installed must be left exactly as found"
+        );
+        assert!(!root.join("daemon.pid.tmp").exists());
+        assert!(!root.join("daemon.port.tmp").exists());
+        assert!(!root.join("daemon.owner.tmp").exists());
+    }
+
+    #[test]
+    fn a_live_owners_endpoint_survives_the_liveness_probe() {
+        // The probe answers "is it serving", and the answer for an unreachable
+        // port is no — but that is not a licence to delete a live daemon's
+        // endpoint.
+        let dir = tempfile::tempdir().unwrap();
+        let root = dir.path();
+        std::fs::write(root.join("daemon.pid"), "1").unwrap();
+        std::fs::write(root.join("daemon.port"), "1").unwrap();
+
+        assert!(daemon_is_up(root).is_none());
+        assert!(root.join("daemon.pid").exists());
+        assert!(root.join("daemon.port").exists());
     }
 }

--- a/crates/kin-daemon/src/lifecycle.rs
+++ b/crates/kin-daemon/src/lifecycle.rs
@@ -625,6 +625,110 @@ where
 
 // ── Daemon State Files ──────────────────────────────────────────────────
 
+/// Name of the sidecar that attributes a published endpoint to one process
+/// incarnation.
+const ENDPOINT_OWNER_FILE: &str = "daemon.owner";
+
+/// Schema tag carried by [`ENDPOINT_OWNER_FILE`].
+const ENDPOINT_OWNER_SCHEMA: &str = "kin.daemon.endpoint-owner.v1";
+
+/// Who published the endpoint currently on disk.
+///
+/// `daemon.pid` holds a bare PID because every version of every Kin surface
+/// reads it that way, and a PID alone cannot survive reuse: after the recorded
+/// daemon exits, that number starts naming whatever the kernel handed it to
+/// next, and a reader comparing PIDs either preserves a dead endpoint forever
+/// or deletes a live one. This sidecar records the same process incarnation the
+/// singleton lock stamps, so ownership can be *proved* rather than inferred
+/// from a number.
+#[derive(Debug, Clone, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
+struct EndpointOwnerRecord {
+    schema: String,
+    identity: kin_cli::daemon_client::ProcessIdentity,
+    port: u16,
+}
+
+impl EndpointOwnerRecord {
+    fn current(port: u16) -> Option<Self> {
+        Some(Self {
+            schema: ENDPOINT_OWNER_SCHEMA.to_string(),
+            identity: kin_cli::daemon_client::current_process_identity().ok()?,
+            port,
+        })
+    }
+}
+
+/// What the on-disk endpoint says about its owner.
+///
+/// The distinction that matters is between an endpoint this process may
+/// destroy and one it may not. Only [`EndpointOwnership::CurrentProcess`]
+/// authorizes removal; every other variant means the files belong to somebody
+/// else, or to nobody this build can identify, and must be left alone.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum EndpointOwnership {
+    /// No endpoint is published: `daemon.pid` is absent.
+    Absent,
+    /// The endpoint names this exact process incarnation.
+    CurrentProcess,
+    /// The endpoint names a different owner. `live` is decided against the
+    /// recorded incarnation when an owner record exists, and against the bare
+    /// PID otherwise; an indeterminate probe reads as live, because an
+    /// uninspectable owner is not a dead one.
+    OtherProcess { pid: u32, live: bool },
+    /// An endpoint exists but names nobody: `daemon.pid` is unparseable and
+    /// there is no owner record to fall back on.
+    Unattributed,
+}
+
+impl EndpointOwnership {
+    /// Whether the calling process may delete these endpoint files.
+    pub fn authorizes_removal(self) -> bool {
+        matches!(self, Self::CurrentProcess)
+    }
+}
+
+fn read_endpoint_owner_record(kin_root: &Path) -> Option<EndpointOwnerRecord> {
+    let raw = std::fs::read_to_string(kin_root.join(ENDPOINT_OWNER_FILE)).ok()?;
+    let record: EndpointOwnerRecord = serde_json::from_str(&raw).ok()?;
+    (record.schema == ENDPOINT_OWNER_SCHEMA).then_some(record)
+}
+
+/// Classify the published endpoint's owner.
+///
+/// `daemon.pid` is what makes an endpoint *published*: a stray owner record
+/// with no PID file beside it attributes nothing, and the next publication
+/// overwrites it.
+pub fn endpoint_ownership(kin_root: &Path) -> EndpointOwnership {
+    if !kin_root.join("daemon.pid").exists() {
+        return EndpointOwnership::Absent;
+    }
+    if let Some(record) = read_endpoint_owner_record(kin_root) {
+        return match kin_cli::daemon_client::process_identity_is_current(&record.identity) {
+            Ok(true) if record.identity.pid() == std::process::id() => {
+                EndpointOwnership::CurrentProcess
+            }
+            Ok(is_current) => EndpointOwnership::OtherProcess {
+                pid: record.identity.pid(),
+                live: is_current,
+            },
+            // An identity that cannot be read at all (another user's process)
+            // is indeterminate, not dead.
+            Err(_) => EndpointOwnership::OtherProcess {
+                pid: record.identity.pid(),
+                live: true,
+            },
+        };
+    }
+    match recorded_daemon_pid(kin_root) {
+        Some(pid) if pid == std::process::id() => EndpointOwnership::CurrentProcess,
+        Some(pid) => EndpointOwnership::OtherProcess {
+            pid,
+            live: is_process_alive(pid),
+        },
+        None => EndpointOwnership::Unattributed,
+    }
+}
+
 fn write_atomic_endpoint_component(
     kin_root: &Path,
     name: &str,
@@ -636,32 +740,89 @@ fn write_atomic_endpoint_component(
     std::fs::rename(tmp, dst)
 }
 
+/// Remove every component of an endpoint the caller has already proved it may
+/// destroy — its own, or one whose recorded owner is verifiably gone.
+///
+/// Order matters on a crash: `daemon.pid` goes first because it is what makes
+/// an endpoint published, so an interrupted retirement leaves no record any
+/// reader will act on.
+fn remove_endpoint_components(kin_root: &Path) {
+    let _ = std::fs::remove_file(kin_root.join("daemon.pid"));
+    let _ = std::fs::remove_file(kin_root.join("daemon.port"));
+    let _ = std::fs::remove_file(kin_root.join(ENDPOINT_OWNER_FILE));
+}
+
 /// Publish the daemon's complete endpoint while holding lifecycle authority.
 ///
 /// Current endpoint retirement takes the same never-unlinked lock, so a
 /// successor publication cannot land between a predecessor comparison and
-/// deletion. Both temporary files are prepared before either visible component
-/// changes; on any publication failure the incomplete endpoint is removed
-/// before authority is released.
+/// deletion. Every temporary file is prepared before any visible component
+/// changes, and a failed publication rolls back only the components this call
+/// actually installed — an endpoint belonging to a process that is still
+/// running is never in that set.
 pub fn publish_daemon_endpoint(kin_root: &Path, port: u16) -> std::io::Result<()> {
     let _authority = acquire_singleton_coordination_guard(kin_root)?;
+    publish_daemon_endpoint_under_authority(kin_root, port)
+}
+
+fn publish_daemon_endpoint_under_authority(kin_root: &Path, port: u16) -> std::io::Result<()> {
+    // Port 0 means "the OS will pick one", never "connect here". Publishing it
+    // strands every reader on an endpoint nothing can dial, and the daemon that
+    // published it keeps refusing successors because it still owns the repo.
+    if port == 0 {
+        return Err(std::io::Error::new(
+            std::io::ErrorKind::InvalidInput,
+            "refusing to publish an unbound daemon port",
+        ));
+    }
+    // A starter that lost the singleton must never reach this, but publication
+    // overwrites files by design, so the guarantee is asserted here rather than
+    // assumed from the call graph.
+    if let EndpointOwnership::OtherProcess { pid, live: true } = endpoint_ownership(kin_root) {
+        return Err(std::io::Error::new(
+            std::io::ErrorKind::AlreadyExists,
+            format!("daemon endpoint for {} is owned by live pid {pid}", kin_root.display()),
+        ));
+    }
+
+    let owner = EndpointOwnerRecord::current(port)
+        .and_then(|record| serde_json::to_string(&record).ok());
     let pid = std::process::id().to_string();
     let port = port.to_string();
+
+    let mut installed: Vec<&str> = Vec::new();
     let result: std::io::Result<()> = (|| {
+        if let Some(owner) = &owner {
+            std::fs::write(kin_root.join("daemon.owner.tmp"), owner.as_bytes())?;
+        }
         std::fs::write(kin_root.join("daemon.pid.tmp"), pid.as_bytes())?;
         std::fs::write(kin_root.join("daemon.port.tmp"), port.as_bytes())?;
+        // Attribution lands before the endpoint it attributes, so the instant
+        // `daemon.pid` names this process the proof that it does is already
+        // readable.
+        if owner.is_some() {
+            std::fs::rename(
+                kin_root.join("daemon.owner.tmp"),
+                kin_root.join(ENDPOINT_OWNER_FILE),
+            )?;
+            installed.push(ENDPOINT_OWNER_FILE);
+        }
         std::fs::rename(kin_root.join("daemon.pid.tmp"), kin_root.join("daemon.pid"))?;
+        installed.push("daemon.pid");
         std::fs::rename(
             kin_root.join("daemon.port.tmp"),
             kin_root.join("daemon.port"),
         )?;
+        installed.push("daemon.port");
         Ok(())
     })();
     if result.is_err() {
+        let _ = std::fs::remove_file(kin_root.join("daemon.owner.tmp"));
         let _ = std::fs::remove_file(kin_root.join("daemon.pid.tmp"));
         let _ = std::fs::remove_file(kin_root.join("daemon.port.tmp"));
-        let _ = std::fs::remove_file(kin_root.join("daemon.pid"));
-        let _ = std::fs::remove_file(kin_root.join("daemon.port"));
+        for name in installed {
+            let _ = std::fs::remove_file(kin_root.join(name));
+        }
     }
     result
 }
@@ -672,6 +833,10 @@ pub fn publish_daemon_endpoint(kin_root: &Path, port: u16) -> std::io::Result<()
 /// PID and bound port together with [`publish_daemon_endpoint`].
 pub fn write_pid_file(kin_root: &Path) {
     if let Ok(_authority) = acquire_singleton_coordination_guard(kin_root) {
+        // A partial publication carries no port, so it cannot write an owner
+        // record. Drop any predecessor's record rather than let it attribute
+        // this PID to the wrong incarnation.
+        let _ = std::fs::remove_file(kin_root.join(ENDPOINT_OWNER_FILE));
         let _ =
             write_atomic_endpoint_component(kin_root, "daemon.pid", std::process::id().to_string());
     }
@@ -688,10 +853,15 @@ pub fn write_port_file(kin_root: &Path, port: u16) {
 }
 
 /// Read port from `.kin/daemon.port`.
+///
+/// Zero is not a port anything can connect to: it is the bind-time request for
+/// an OS-assigned port, and a record carrying it names no endpoint. Treated as
+/// unpublished, exactly as the shared spawn contract treats it.
 pub fn read_port_file(kin_root: &Path) -> Option<u16> {
     std::fs::read_to_string(kin_root.join("daemon.port"))
         .ok()
-        .and_then(|s| s.trim().parse().ok())
+        .and_then(|s| s.trim().parse::<u16>().ok())
+        .filter(|port| *port != 0)
 }
 
 /// Remove PID file, but only if it's ours (prevents removing a successor's).
@@ -699,18 +869,19 @@ pub fn remove_pid_file(kin_root: &Path) {
     let Ok(_authority) = acquire_singleton_coordination_guard(kin_root) else {
         return;
     };
-    let path = kin_root.join("daemon.pid");
-    if let Ok(content) = std::fs::read_to_string(&path) {
-        if content.trim().parse::<u32>().ok() == Some(std::process::id()) {
-            let _ = std::fs::remove_file(&path);
-        }
+    if endpoint_ownership(kin_root).authorizes_removal() {
+        let _ = std::fs::remove_file(kin_root.join("daemon.pid"));
+        let _ = std::fs::remove_file(kin_root.join(ENDPOINT_OWNER_FILE));
     }
 }
 
-/// Remove daemon endpoint files, but only if the recorded PID is this process.
+/// Remove daemon endpoint files, but only when this process can prove it
+/// published them.
 ///
-/// This avoids a shutdown race where an older daemon removes the port file for
-/// a newer successor that already replaced `daemon.pid`.
+/// Proof is the recorded process incarnation, not the PID: an endpoint whose
+/// number happens to match a recycled PID belongs to a daemon that already
+/// exited, and one whose number differs may belong to a successor that
+/// republished while this process was draining.
 pub fn remove_daemon_files_if_current_process(kin_root: &Path) {
     let Ok(_authority) = acquire_singleton_coordination_guard(kin_root) else {
         tracing::warn!(
@@ -719,17 +890,18 @@ pub fn remove_daemon_files_if_current_process(kin_root: &Path) {
         );
         return;
     };
-    let pid_path = kin_root.join("daemon.pid");
-    let belongs_to_current = std::fs::read_to_string(&pid_path)
-        .ok()
-        .and_then(|content| content.trim().parse::<u32>().ok())
-        == Some(std::process::id());
-    if !belongs_to_current {
+    let ownership = endpoint_ownership(kin_root);
+    if !ownership.authorizes_removal() {
+        if !matches!(ownership, EndpointOwnership::Absent) {
+            tracing::warn!(
+                repo = %kin_root.display(),
+                ?ownership,
+                "preserving daemon endpoint published by another process"
+            );
+        }
         return;
     }
-
-    let _ = std::fs::remove_file(pid_path);
-    let _ = std::fs::remove_file(kin_root.join("daemon.port"));
+    remove_endpoint_components(kin_root);
 }
 
 /// Is the process with this PID alive?
@@ -738,21 +910,25 @@ fn is_process_alive(pid: u32) -> bool {
 }
 
 /// Is the daemon running for this repo? Checks PID file + port reachable.
+///
+/// A dead owner's endpoint is cleared, but only against proof: the recorded
+/// incarnation is re-read under lifecycle authority and must still be the same
+/// dead owner the first read saw. A live owner — including one this process
+/// cannot inspect — keeps its files.
 pub fn daemon_is_up(kin_root: &Path) -> Option<u16> {
-    let pid: u32 = std::fs::read_to_string(kin_root.join("daemon.pid"))
-        .ok()?
-        .trim()
-        .parse()
-        .ok()?;
-    if !is_process_alive(pid) {
-        // Stale — clean up only while publication is excluded and this PID is
-        // still the endpoint owner.
-        let _authority = acquire_singleton_coordination_guard(kin_root).ok()?;
-        if recorded_daemon_pid(kin_root) == Some(pid) && !is_process_alive(pid) {
-            let _ = std::fs::remove_file(kin_root.join("daemon.pid"));
-            let _ = std::fs::remove_file(kin_root.join("daemon.port"));
+    match endpoint_ownership(kin_root) {
+        EndpointOwnership::Absent | EndpointOwnership::Unattributed => return None,
+        EndpointOwnership::CurrentProcess | EndpointOwnership::OtherProcess { live: true, .. } => {}
+        stale @ EndpointOwnership::OtherProcess { live: false, .. } => {
+            // Stale — clean up only while publication is excluded and the
+            // endpoint still names the same dead owner the verdict was formed
+            // about.
+            let _authority = acquire_singleton_coordination_guard(kin_root).ok()?;
+            if endpoint_ownership(kin_root) == stale {
+                remove_endpoint_components(kin_root);
+            }
+            return None;
         }
-        return None;
     }
     let port = read_port_file(kin_root)?;
     if is_port_open(port) {

--- a/crates/kin-daemon/src/lifecycle.rs
+++ b/crates/kin-daemon/src/lifecycle.rs
@@ -700,6 +700,19 @@ fn read_endpoint_owner_record(kin_root: &Path) -> Option<EndpointOwnerRecord> {
 /// with no PID file beside it attributes nothing, and the next publication
 /// overwrites it.
 pub fn endpoint_ownership(kin_root: &Path) -> EndpointOwnership {
+    endpoint_ownership_with_probe(
+        kin_root,
+        kin_cli::daemon_client::process_identity_is_current,
+    )
+}
+
+/// The probe is injectable for the same reason publication's is: the
+/// indeterminate arm is a decision, not an accident, and a decision that cannot
+/// be exercised in a test is one a later change can silently invert.
+fn endpoint_ownership_with_probe(
+    kin_root: &Path,
+    probe: impl FnOnce(&kin_cli::daemon_client::ProcessIdentity) -> std::io::Result<bool>,
+) -> EndpointOwnership {
     if !kin_root.join("daemon.pid").exists() {
         return EndpointOwnership::Absent;
     }
@@ -724,7 +737,7 @@ pub fn endpoint_ownership(kin_root: &Path) -> EndpointOwnership {
                 },
             };
         }
-        return match kin_cli::daemon_client::process_identity_is_current(&record.identity) {
+        return match probe(&record.identity) {
             Ok(is_current) => EndpointOwnership::OtherProcess {
                 pid: record.identity.pid(),
                 live: is_current,
@@ -2194,23 +2207,78 @@ mod tests {
         assert_eq!(read_port_file(root), Some(4219));
     }
 
+    #[cfg(unix)]
     #[test]
     fn an_unreadable_owner_probe_still_protects_the_endpoint_from_removal() {
         // The other half of the split: failing closed is right for deleting.
         // The same indeterminate probe that must not block publication must
         // still stop this process from retiring an endpoint it cannot prove is
         // dead.
+        //
+        // This drives a real owner record for a real foreign process and
+        // injects the unreadable probe, so the indeterminate arm is actually
+        // executed. An earlier version wrote a bare `daemon.pid` and reached
+        // the legacy branch instead, testing something else entirely under this
+        // name.
+        let dir = tempfile::tempdir().unwrap();
+        let root = dir.path();
+        let mut foreign = std::process::Command::new("sleep")
+            .arg("30")
+            .spawn()
+            .expect("spawn a stand-in foreign owner");
+        let identity = kin_cli::daemon_client::process_identity(foreign.id())
+            .expect("read the foreign owner's identity")
+            .expect("the foreign owner is running");
+        publish_foreign_endpoint_for_test(root, identity, 51234);
+
+        let unreadable = |_: &kin_cli::daemon_client::ProcessIdentity| {
+            Err(std::io::Error::new(
+                std::io::ErrorKind::PermissionDenied,
+                "cannot read birth identity for a foreign process",
+            ))
+        };
+        let ownership = endpoint_ownership_with_probe(root, unreadable);
+
+        assert_eq!(
+            ownership,
+            EndpointOwnership::OtherProcess {
+                pid: foreign.id(),
+                live: true,
+            },
+            "an owner that cannot be inspected must read as live for the removal decision"
+        );
+        assert!(
+            !ownership.authorizes_removal(),
+            "never delete an endpoint whose owner cannot be inspected"
+        );
+
+        // And end to end, through the real probe: the endpoint survives.
+        remove_daemon_files_if_current_process(root);
+        assert!(
+            root.join("daemon.pid").exists() && root.join("daemon.port").exists(),
+            "an endpoint owned by another live process must survive retirement"
+        );
+
+        let _ = foreign.kill();
+        let _ = foreign.wait();
+    }
+
+    #[test]
+    fn a_legacy_endpoint_naming_a_live_pid_is_not_removed() {
+        // The legacy branch the test above used to reach by accident, kept
+        // deliberately and named for what it is: no owner record, a bare PID
+        // that resolves to something alive, so removal is refused.
         let dir = tempfile::tempdir().unwrap();
         let root = dir.path();
         std::fs::write(root.join("daemon.pid"), "1").unwrap();
         std::fs::write(root.join("daemon.port"), "51234").unwrap();
 
-        remove_daemon_files_if_current_process(root);
-
-        assert!(
-            root.join("daemon.pid").exists() && root.join("daemon.port").exists(),
-            "an endpoint owned by a process this one cannot inspect must survive"
+        assert_eq!(
+            endpoint_ownership(root),
+            EndpointOwnership::OtherProcess { pid: 1, live: true }
         );
+        remove_daemon_files_if_current_process(root);
+        assert!(root.join("daemon.pid").exists() && root.join("daemon.port").exists());
     }
 
     #[test]

--- a/crates/kin-daemon/src/lifecycle.rs
+++ b/crates/kin-daemon/src/lifecycle.rs
@@ -870,7 +870,33 @@ pub fn publish_daemon_endpoint(kin_root: &Path, port: u16) -> std::io::Result<()
     })
 }
 
+/// Publish under an injectable ownership probe, so a test can drive the
+/// indeterminate case that the host's own permissions decide otherwise.
+#[cfg(test)]
+fn publish_daemon_endpoint_with_probe(
+    kin_root: &Path,
+    port: u16,
+    probe: impl FnOnce(&kin_cli::daemon_client::ProcessIdentity) -> std::io::Result<bool>,
+) -> std::io::Result<()> {
+    without_blocking_runtime_worker(|| {
+        let _authority = acquire_singleton_coordination_guard(kin_root)?;
+        publish_daemon_endpoint_under_authority_with_probe(kin_root, port, probe)
+    })
+}
+
 fn publish_daemon_endpoint_under_authority(kin_root: &Path, port: u16) -> std::io::Result<()> {
+    publish_daemon_endpoint_under_authority_with_probe(
+        kin_root,
+        port,
+        kin_cli::daemon_client::process_identity_is_current,
+    )
+}
+
+fn publish_daemon_endpoint_under_authority_with_probe(
+    kin_root: &Path,
+    port: u16,
+    probe: impl FnOnce(&kin_cli::daemon_client::ProcessIdentity) -> std::io::Result<bool>,
+) -> std::io::Result<()> {
     // Port 0 means "the OS will pick one", never "connect here". Publishing it
     // strands every reader on an endpoint nothing can dial, and the daemon that
     // published it keeps refusing successors because it still owns the repo.
@@ -883,7 +909,7 @@ fn publish_daemon_endpoint_under_authority(kin_root: &Path, port: u16) -> std::i
     // A starter that lost the singleton must never reach this, but publication
     // overwrites files by design, so the guarantee is asserted here rather than
     // assumed from the call graph.
-    if let Some(pid) = proven_live_other_endpoint_owner(kin_root) {
+    if let Some(pid) = proven_live_other_endpoint_owner_with_probe(kin_root, probe) {
         return Err(std::io::Error::new(
             std::io::ErrorKind::AlreadyExists,
             format!(
@@ -2169,6 +2195,7 @@ mod tests {
         let _ = incumbent.wait();
     }
 
+    #[cfg(unix)]
     #[test]
     fn an_unreadable_owner_probe_is_not_proof_of_a_live_owner() {
         // The wedge this closes. A daemon is SIGKILLed, so its endpoint and
@@ -2179,14 +2206,23 @@ mod tests {
         // startup, so the repo's daemon could never start again: no sweep
         // clears the record either, because they all preserve what they cannot
         // inspect. Only a human deleting the file recovered it.
+        //
+        // Both the record's owner and the probe are supplied by the test. An
+        // earlier version seeded the record from pid 1 and fell back to this
+        // process's own identity when that could not be read, which made the
+        // outcome depend on whether the host lets you inspect pid 1: on macOS
+        // it passed through the owner-is-self shortcut without touching the
+        // indeterminate path at all, and on Linux pid 1 was readable, so
+        // publication saw a genuinely live owner and correctly refused.
         let dir = tempfile::tempdir().unwrap();
         let root = dir.path();
-        let identity = kin_cli::daemon_client::process_identity(1)
-            .ok()
-            .flatten()
-            .unwrap_or_else(|| {
-                kin_cli::daemon_client::current_process_identity().expect("an identity to reshape")
-            });
+        let mut foreign = std::process::Command::new("sleep")
+            .arg("30")
+            .spawn()
+            .expect("spawn a stand-in foreign owner");
+        let identity = kin_cli::daemon_client::process_identity(foreign.id())
+            .expect("read the foreign owner's identity")
+            .expect("the foreign owner is running");
         publish_foreign_endpoint_for_test(root, identity, 51234);
 
         let unreadable = |_: &kin_cli::daemon_client::ProcessIdentity| {
@@ -2201,10 +2237,13 @@ mod tests {
             "an unreadable probe is not proof, so it must not block publication"
         );
 
-        publish_daemon_endpoint(root, 4219)
+        publish_daemon_endpoint_with_probe(root, 4219, unreadable)
             .expect("the rightful owner must still be able to advertise itself");
         assert_eq!(endpoint_ownership(root), EndpointOwnership::CurrentProcess);
         assert_eq!(read_port_file(root), Some(4219));
+
+        let _ = foreign.kill();
+        let _ = foreign.wait();
     }
 
     #[cfg(unix)]

--- a/crates/kin-daemon/src/lifecycle.rs
+++ b/crates/kin-daemon/src/lifecycle.rs
@@ -806,8 +806,14 @@ fn remove_endpoint_components(kin_root: &Path) {
 /// actually installed — an endpoint belonging to a process that is still
 /// running is never in that set.
 pub fn publish_daemon_endpoint(kin_root: &Path, port: u16) -> std::io::Result<()> {
-    let _authority = acquire_singleton_coordination_guard(kin_root)?;
-    publish_daemon_endpoint_under_authority(kin_root, port)
+    // Waiting out the coordination lock is a synchronous sleep reached from
+    // async contexts, and holding a worker hostage here is what once starved
+    // the liveness routes a client was polling before it clobbered the very
+    // endpoint being published.
+    without_blocking_runtime_worker(|| {
+        let _authority = acquire_singleton_coordination_guard(kin_root)?;
+        publish_daemon_endpoint_under_authority(kin_root, port)
+    })
 }
 
 fn publish_daemon_endpoint_under_authority(kin_root: &Path, port: u16) -> std::io::Result<()> {
@@ -937,25 +943,27 @@ pub fn remove_pid_file(kin_root: &Path) {
 /// exited, and one whose number differs may belong to a successor that
 /// republished while this process was draining.
 pub fn remove_daemon_files_if_current_process(kin_root: &Path) {
-    let Ok(_authority) = acquire_singleton_coordination_guard(kin_root) else {
-        tracing::warn!(
-            repo = %kin_root.display(),
-            "preserving daemon endpoint because lifecycle authority is unavailable"
-        );
-        return;
-    };
-    let ownership = endpoint_ownership(kin_root);
-    if !ownership.authorizes_removal() {
-        if !matches!(ownership, EndpointOwnership::Absent) {
+    without_blocking_runtime_worker(|| {
+        let Ok(_authority) = acquire_singleton_coordination_guard(kin_root) else {
             tracing::warn!(
                 repo = %kin_root.display(),
-                ?ownership,
-                "preserving daemon endpoint published by another process"
+                "preserving daemon endpoint because lifecycle authority is unavailable"
             );
+            return;
+        };
+        let ownership = endpoint_ownership(kin_root);
+        if !ownership.authorizes_removal() {
+            if !matches!(ownership, EndpointOwnership::Absent) {
+                tracing::warn!(
+                    repo = %kin_root.display(),
+                    ?ownership,
+                    "preserving daemon endpoint published by another process"
+                );
+            }
+            return;
         }
-        return;
-    }
-    remove_endpoint_components(kin_root);
+        remove_endpoint_components(kin_root);
+    })
 }
 
 /// Is the process with this PID alive?
@@ -977,10 +985,14 @@ pub fn daemon_is_up(kin_root: &Path) -> Option<u16> {
             // Stale — clean up only while publication is excluded and the
             // endpoint still names the same dead owner the verdict was formed
             // about.
-            let _authority = acquire_singleton_coordination_guard(kin_root).ok()?;
-            if endpoint_ownership(kin_root) == stale {
-                remove_endpoint_components(kin_root);
-            }
+            without_blocking_runtime_worker(|| {
+                let Ok(_authority) = acquire_singleton_coordination_guard(kin_root) else {
+                    return;
+                };
+                if endpoint_ownership(kin_root) == stale {
+                    remove_endpoint_components(kin_root);
+                }
+            });
             return None;
         }
     }

--- a/crates/kin-daemon/src/lifecycle.rs
+++ b/crates/kin-daemon/src/lifecycle.rs
@@ -641,19 +641,20 @@ const ENDPOINT_OWNER_SCHEMA: &str = "kin.daemon.endpoint-owner.v1";
 /// or deletes a live one. This sidecar records the same process incarnation the
 /// singleton lock stamps, so ownership can be *proved* rather than inferred
 /// from a number.
+/// The record carries identity and nothing else. A port field was tempting and
+/// is deliberately absent: `daemon.port` is the port, nothing would read a
+/// second copy, and two records of the same fact can only ever disagree.
 #[derive(Debug, Clone, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
 struct EndpointOwnerRecord {
     schema: String,
     identity: kin_cli::daemon_client::ProcessIdentity,
-    port: u16,
 }
 
 impl EndpointOwnerRecord {
-    fn current(port: u16) -> Option<Self> {
+    fn current() -> Option<Self> {
         Some(Self {
             schema: ENDPOINT_OWNER_SCHEMA.to_string(),
             identity: kin_cli::daemon_client::current_process_identity().ok()?,
-            port,
         })
     }
 }
@@ -703,16 +704,36 @@ pub fn endpoint_ownership(kin_root: &Path) -> EndpointOwnership {
         return EndpointOwnership::Absent;
     }
     if let Some(record) = read_endpoint_owner_record(kin_root) {
+        // Answer the "is it mine" case from this process's own identity rather
+        // than from a probe of a foreign PID. Retirement used to be
+        // `read(daemon.pid) == process::id()`, which cannot fail; routing the
+        // self case through a fallible probe would let a transient error
+        // refuse a daemon permission to retire its own endpoint and strand it.
+        if record.identity.pid() == std::process::id() {
+            return match kin_cli::daemon_client::current_process_identity() {
+                Ok(current) if current == record.identity => EndpointOwnership::CurrentProcess,
+                // Our PID, a different incarnation: the publisher is gone and
+                // the kernel handed us its number.
+                Ok(_) => EndpointOwnership::OtherProcess {
+                    pid: record.identity.pid(),
+                    live: false,
+                },
+                Err(_) => EndpointOwnership::OtherProcess {
+                    pid: record.identity.pid(),
+                    live: true,
+                },
+            };
+        }
         return match kin_cli::daemon_client::process_identity_is_current(&record.identity) {
-            Ok(true) if record.identity.pid() == std::process::id() => {
-                EndpointOwnership::CurrentProcess
-            }
             Ok(is_current) => EndpointOwnership::OtherProcess {
                 pid: record.identity.pid(),
                 live: is_current,
             },
             // An identity that cannot be read at all (another user's process)
-            // is indeterminate, not dead.
+            // is indeterminate. `live` governs removal, and refusing to delete
+            // what cannot be inspected is the safe direction, so it reads as
+            // live here. Publication asks a different question and must not
+            // reuse this answer: see [`proven_live_other_endpoint_owner`].
             Err(_) => EndpointOwnership::OtherProcess {
                 pid: record.identity.pid(),
                 live: true,
@@ -729,14 +750,36 @@ pub fn endpoint_ownership(kin_root: &Path) -> EndpointOwnership {
     }
 }
 
-/// The PID of a *different* incarnation that the endpoint record proves is
+/// The PID of a *different* incarnation that the endpoint record **proves** is
 /// still running, if there is one.
 ///
-/// Only an owner record can prove this. A legacy bare-PID endpoint names a
-/// number that reuse makes ambiguous, and refusing to publish over an
-/// unprovable claim would let a recycled PID keep a repo's rightful owner —
-/// the process actually holding the singleton — from ever advertising itself.
+/// This answers the question that governs yielding, not the one that governs
+/// deleting, and the two fail in opposite directions.
+///
+/// Refusing to delete what cannot be inspected is safe: the worst case is a
+/// stale file. Refusing to *publish* over what cannot be inspected is not,
+/// because the caller already holds the repository singleton, so no legitimate
+/// owner can exist and the refusal is fatal at startup. An indeterminate probe
+/// there wedges the repo permanently: a SIGKILLed daemon leaves the record
+/// behind, the kernel later hands its PID to a process owned by another user,
+/// every probe of that PID returns `PermissionDenied` rather than an answer,
+/// and nothing in the system clears the record. The daemon exits 1 forever and
+/// the error names an unrelated process the operator has no reason to touch.
+///
+/// So "not proven" is the answer for an unreadable probe here, which is also
+/// what the name and the legacy-record rule already say: a claim that cannot be
+/// verified must not keep a repo's rightful owner from advertising itself.
 pub(crate) fn proven_live_other_endpoint_owner(kin_root: &Path) -> Option<u32> {
+    proven_live_other_endpoint_owner_with_probe(
+        kin_root,
+        kin_cli::daemon_client::process_identity_is_current,
+    )
+}
+
+fn proven_live_other_endpoint_owner_with_probe(
+    kin_root: &Path,
+    probe: impl FnOnce(&kin_cli::daemon_client::ProcessIdentity) -> std::io::Result<bool>,
+) -> Option<u32> {
     if !kin_root.join("daemon.pid").exists() {
         return None;
     }
@@ -744,9 +787,8 @@ pub(crate) fn proven_live_other_endpoint_owner(kin_root: &Path) -> Option<u32> {
     if record.identity.pid() == std::process::id() {
         return None;
     }
-    // An identity that cannot be read at all is indeterminate, not dead.
-    kin_cli::daemon_client::process_identity_is_current(&record.identity)
-        .unwrap_or(true)
+    probe(&record.identity)
+        .unwrap_or(false)
         .then(|| record.identity.pid())
 }
 
@@ -763,7 +805,6 @@ pub(crate) fn publish_foreign_endpoint_for_test(
     let record = EndpointOwnerRecord {
         schema: ENDPOINT_OWNER_SCHEMA.to_string(),
         identity,
-        port,
     };
     std::fs::write(kin_root.join("daemon.pid"), pid.to_string()).unwrap();
     std::fs::write(kin_root.join("daemon.port"), port.to_string()).unwrap();
@@ -840,7 +881,7 @@ fn publish_daemon_endpoint_under_authority(kin_root: &Path, port: u16) -> std::i
     }
 
     let owner =
-        EndpointOwnerRecord::current(port).and_then(|record| serde_json::to_string(&record).ok());
+        EndpointOwnerRecord::current().and_then(|record| serde_json::to_string(&record).ok());
     let pid = std::process::id().to_string();
     let port = port.to_string();
 
@@ -1964,7 +2005,6 @@ mod tests {
         );
         let record = read_endpoint_owner_record(root).expect("owner record parses");
         assert_eq!(record.identity.pid(), std::process::id());
-        assert_eq!(record.port, 51234);
     }
 
     #[test]
@@ -2095,7 +2135,6 @@ mod tests {
             serde_json::to_string(&EndpointOwnerRecord {
                 schema: ENDPOINT_OWNER_SCHEMA.to_string(),
                 identity,
-                port: 51234,
             })
             .unwrap(),
         )
@@ -2115,6 +2154,79 @@ mod tests {
 
         let _ = incumbent.kill();
         let _ = incumbent.wait();
+    }
+
+    #[test]
+    fn an_unreadable_owner_probe_is_not_proof_of_a_live_owner() {
+        // The wedge this closes. A daemon is SIGKILLed, so its endpoint and
+        // owner record survive. The kernel later hands its PID to a process
+        // owned by another user, where every identity probe returns
+        // PermissionDenied rather than an answer. Treating that as proof of a
+        // live owner refused publication, and publication refusal is fatal at
+        // startup, so the repo's daemon could never start again: no sweep
+        // clears the record either, because they all preserve what they cannot
+        // inspect. Only a human deleting the file recovered it.
+        let dir = tempfile::tempdir().unwrap();
+        let root = dir.path();
+        let identity = kin_cli::daemon_client::process_identity(1)
+            .ok()
+            .flatten()
+            .unwrap_or_else(|| {
+                kin_cli::daemon_client::current_process_identity().expect("an identity to reshape")
+            });
+        publish_foreign_endpoint_for_test(root, identity, 51234);
+
+        let unreadable = |_: &kin_cli::daemon_client::ProcessIdentity| {
+            Err(std::io::Error::new(
+                std::io::ErrorKind::PermissionDenied,
+                "cannot read birth identity for a foreign process",
+            ))
+        };
+        assert_eq!(
+            proven_live_other_endpoint_owner_with_probe(root, unreadable),
+            None,
+            "an unreadable probe is not proof, so it must not block publication"
+        );
+
+        publish_daemon_endpoint(root, 4219)
+            .expect("the rightful owner must still be able to advertise itself");
+        assert_eq!(endpoint_ownership(root), EndpointOwnership::CurrentProcess);
+        assert_eq!(read_port_file(root), Some(4219));
+    }
+
+    #[test]
+    fn an_unreadable_owner_probe_still_protects_the_endpoint_from_removal() {
+        // The other half of the split: failing closed is right for deleting.
+        // The same indeterminate probe that must not block publication must
+        // still stop this process from retiring an endpoint it cannot prove is
+        // dead.
+        let dir = tempfile::tempdir().unwrap();
+        let root = dir.path();
+        std::fs::write(root.join("daemon.pid"), "1").unwrap();
+        std::fs::write(root.join("daemon.port"), "51234").unwrap();
+
+        remove_daemon_files_if_current_process(root);
+
+        assert!(
+            root.join("daemon.pid").exists() && root.join("daemon.port").exists(),
+            "an endpoint owned by a process this one cannot inspect must survive"
+        );
+    }
+
+    #[test]
+    fn a_daemon_can_always_retire_its_own_endpoint() {
+        // Retirement used to be `read(daemon.pid) == process::id()`, which
+        // cannot fail. Identity must not make it fallible: a daemon that
+        // cannot retire its own endpoint leaves a stale one behind, which
+        // other surfaces assert never happens.
+        let dir = tempfile::tempdir().unwrap();
+        let root = dir.path();
+        publish_daemon_endpoint(root, 4219).expect("publish");
+
+        assert_eq!(endpoint_ownership(root), EndpointOwnership::CurrentProcess);
+        remove_daemon_files_if_current_process(root);
+        assert_eq!(endpoint_ownership(root), EndpointOwnership::Absent);
+        assert!(!root.join(ENDPOINT_OWNER_FILE).exists());
     }
 
     #[test]

--- a/crates/kin-daemon/src/state.rs
+++ b/crates/kin-daemon/src/state.rs
@@ -7272,12 +7272,6 @@ mod tests {
         std::fs::write(mcp_transactions_disk_path(&layout), b"{not valid json").unwrap();
         assert!(load_persisted_mcp_transactions(&layout).is_empty());
     }
-}
-
-#[cfg(test)]
-mod ingest_cas_tests {
-    use super::*;
-    use kin_model::{ArtifactId, RepoPath, ResolvedArtifact, ResolvedTree, TreeEntry};
 
     /// Publish one blob as the repository's exact workspace tree and return its
     /// content address. The published body lives in repository authority, which

--- a/crates/kin-daemon/src/state.rs
+++ b/crates/kin-daemon/src/state.rs
@@ -7221,3 +7221,182 @@ mod tests {
         assert!(load_persisted_mcp_transactions(&layout).is_empty());
     }
 }
+
+#[cfg(test)]
+mod ingest_cas_tests {
+    use super::*;
+    use kin_model::{ArtifactId, RepoPath, ResolvedArtifact, ResolvedTree, TreeEntry};
+
+    /// Publish one blob as the repository's exact workspace tree and return its
+    /// content address. The published body lives in repository authority, which
+    /// is the only source an ingest-CAS hydration is allowed to read from.
+    fn publish_single_blob_workspace(layout: &KinLayout, body: &[u8]) -> Hash256 {
+        let blobs = BlobStore::new(layout.ingest_cas_dir()).unwrap();
+        let hash = Hash256::from_bytes(blobs.write(body).unwrap().0);
+        let desired = ResolvedTree::from_artifacts(vec![ResolvedArtifact::new(
+            ArtifactId::new(),
+            RepoPath::from_utf8("service.yaml").unwrap(),
+            TreeEntry::blob(hash, false),
+        )])
+        .unwrap();
+        let context =
+            crate::local_repository_authority::LocalRepositoryAuthorityContext::from_layout_for_test(
+                layout,
+            )
+            .unwrap();
+        let admitted = crate::repository_commit::admitted_workspace_tree_for_test(
+            layout.working_dir(),
+            context.open().unwrap().read_authority().roots().clone(),
+            ResolvedTree::default(),
+            desired,
+        );
+        crate::repository_commit::publish_workspace_tree(
+            &blobs,
+            &context,
+            &admitted,
+            kin_model::OperationId::new(),
+            kin_model::AuthorId::new("ingest-cas-hydration-test"),
+        )
+        .unwrap()
+        .expect("exact workspace admission must advance authority");
+        hash
+    }
+
+    #[test]
+    fn backend_hydration_installs_every_body_the_graph_names() {
+        // "Rehydrated on every daemon open" used to be true of the local path
+        // only. The backend path reads the same derived store through
+        // `rebuild_projection`, keyed on exactly this resolved tree, and used to
+        // open against whatever happened to be on local disk.
+        let repo_dir = tempfile::tempdir().unwrap();
+        let body = b"services:\n  api:\n    image: kin:dev\n";
+        let init = kin_core::init(repo_dir.path()).unwrap();
+        let hash = publish_single_blob_workspace(&init.layout, body);
+
+        let ingest_cas = init.layout.ingest_cas_dir();
+        let kindb_dir = init.layout.kindb_dir();
+        let repo_id = kin_core::manifest::resolve_repo_id(&init.layout, None).unwrap();
+        // Take the graph a hosted snapshot of this repository would carry, then
+        // release every local authority handle before hydrating through the
+        // backend seam.
+        let graph = {
+            let local = DaemonState::open(init.layout).expect("local open");
+            Arc::clone(&local.graph)
+        };
+        assert!(
+            !graph.resolved_tree().is_empty(),
+            "the fixture must carry the tree the projection would read"
+        );
+
+        std::fs::remove_dir_all(&ingest_cas).unwrap();
+        let blobs = BlobStore::new(ingest_cas).unwrap();
+        let backend: Arc<dyn StorageBackend> = Arc::new(LocalFileBackend::new(kindb_dir));
+
+        let hydrated =
+            DaemonState::hydrate_backend_ingest_cas(&repo_id, &backend, graph.as_ref(), &blobs)
+                .expect("repository authority must supply every body the graph names");
+
+        assert_eq!(hydrated, 1);
+        assert_eq!(
+            blobs.read(&hash).unwrap(),
+            body,
+            "hydration must install the exact repository-authority body"
+        );
+    }
+
+    #[test]
+    fn the_local_open_path_hydrates_the_ingest_cas() {
+        let repo_dir = tempfile::tempdir().unwrap();
+        let body = b"local authority body\n";
+        let init = kin_core::init(repo_dir.path()).unwrap();
+        let hash = publish_single_blob_workspace(&init.layout, body);
+        std::fs::remove_dir_all(init.layout.ingest_cas_dir()).unwrap();
+
+        let state = DaemonState::open(init.layout).expect("local open");
+
+        assert_eq!(state.blobs.read(&hash).unwrap(), body);
+        assert!(state.ingest_cas_hydration_gap.is_none());
+    }
+
+    #[test]
+    fn an_empty_hosted_graph_needs_no_repository_authority() {
+        // A graph with no resolved artifacts references no source bodies, so
+        // there is nothing to hydrate and no authority to demand. This is the
+        // ordinary first-boot hosted case and must not be reported as a gap.
+        let repo_dir = tempfile::tempdir().unwrap();
+        let init = kin_core::init(repo_dir.path()).unwrap();
+        let kindb_dir = init.layout.kindb_dir();
+        let repo_id = kin_core::manifest::resolve_repo_id(&init.layout, None).unwrap();
+
+        let state = DaemonState::open_with_backend(
+            init.layout,
+            Box::new(LocalFileBackend::new(kindb_dir)),
+            &repo_id,
+            None,
+        )
+        .expect("backend open");
+
+        assert!(
+            state.ingest_cas_hydration_gap.is_none(),
+            "an empty tree is not an authority gap: {:?}",
+            state.ingest_cas_hydration_gap
+        );
+    }
+
+    #[test]
+    fn a_recorded_hydration_gap_is_named_in_projection_errors() {
+        // A hosted graph whose backend carries no repository authority still
+        // serves every query that needs no source body, so an un-hydratable
+        // store is recorded rather than fatal. The reads that DO need one must
+        // then report the authority gap instead of a bare missing blob, which
+        // reads as graph corruption.
+        let repo_dir = tempfile::tempdir().unwrap();
+        let init = kin_core::init(repo_dir.path()).unwrap();
+        let mut state = DaemonState::open(init.layout).expect("local open");
+        state.ingest_cas_hydration_gap = Some("hosted backend carries no authority".to_string());
+
+        let reported = state
+            .attribute_ingest_cas_gap(exact_source_storage_error("cannot load graph-owned blob"))
+            .to_string();
+        assert!(
+            reported.contains("never hydrated on this open path")
+                && reported.contains("hosted backend carries no authority"),
+            "the error must name the hydration gap: {reported}"
+        );
+    }
+
+    #[test]
+    fn a_hydrated_state_reports_blob_errors_unchanged() {
+        let repo_dir = tempfile::tempdir().unwrap();
+        let init = kin_core::init(repo_dir.path()).unwrap();
+        let state = DaemonState::open(init.layout).expect("local open");
+
+        let reported = state
+            .attribute_ingest_cas_gap(exact_source_storage_error("cannot load graph-owned blob"))
+            .to_string();
+        assert!(
+            !reported.contains("never hydrated"),
+            "a hydrated store must not blame a gap it does not have: {reported}"
+        );
+    }
+
+    #[test]
+    fn syncing_the_blob_store_commits_pending_barriers() {
+        // The store defers each blob's directory barrier and commits it on an
+        // explicit sync, on Drop, or on a self-drain. The daemon exits through
+        // `process::exit`, so this is the only commit point it can actually
+        // reach on a clean shutdown.
+        let repo_dir = tempfile::tempdir().unwrap();
+        let init = kin_core::init(repo_dir.path()).unwrap();
+        let state = DaemonState::open(init.layout).expect("local open");
+
+        let hash = state.blobs.write(b"pending rename\n").unwrap();
+        state
+            .sync_blob_store()
+            .expect("the shutdown commit point must succeed on a healthy store");
+        assert_eq!(state.blobs.read(&hash).unwrap(), b"pending rename\n");
+        state
+            .sync_blob_store()
+            .expect("a second barrier with nothing pending is a no-op, not an error");
+    }
+}

--- a/crates/kin-daemon/src/state.rs
+++ b/crates/kin-daemon/src/state.rs
@@ -874,6 +874,13 @@ pub struct DaemonState {
     pub layout: KinLayout,
     pub graph: Arc<kin_db::InMemoryGraph>,
     pub blobs: Arc<BlobStore>,
+    /// Why the derived ingestion CAS could not be hydrated from graph
+    /// authority when this state was opened, if it could not.
+    ///
+    /// Projection reads name this instead of surfacing a bare missing-blob
+    /// error, so an un-hydrated store is reported as the authority gap it is
+    /// rather than as a mysteriously absent object.
+    ingest_cas_hydration_gap: Option<String>,
     pub reconciler: RwLock<Reconciler>,
     /// Cached FileLayouts for all tracked files.
     /// Populated on init, updated on commits.
@@ -1427,7 +1434,43 @@ impl DaemonState {
                 )));
             }
         }
+        // Hydration is a bulk import: the store defers each blob's directory
+        // barrier and amortizes them across shards, so one commit point here
+        // makes every name it just installed durable for the cost of at most
+        // one barrier per shard touched.
+        blobs.sync().map_err(DaemonError::from)?;
         Ok(hydrated.len())
+    }
+
+    /// Hydrate the derived ingestion CAS for a graph opened through a storage
+    /// backend.
+    ///
+    /// The local path hydrates from repository authority so every blob the
+    /// projection later reads is present before the daemon serves anything.
+    /// The backend path reads the same store through `rebuild_projection` and
+    /// `refresh_projection` but used to open against whatever happened to be
+    /// on local disk, which on a fresh hosted instance is nothing.
+    ///
+    /// Returns the number of source bodies hydrated, or the reason the hosted
+    /// backend could not supply them. A graph with no resolved artifacts needs
+    /// no authority at all, which is the ordinary empty-hosted-graph case.
+    fn hydrate_backend_ingest_cas(
+        repo_id: &str,
+        backend: &Arc<dyn StorageBackend>,
+        graph: &kin_db::InMemoryGraph,
+        blobs: &BlobStore,
+    ) -> std::result::Result<usize, String> {
+        let tree = graph.resolved_tree();
+        if tree.is_empty() {
+            return Ok(0);
+        }
+        let repository_id = RepositoryId::new(repo_id.to_string())
+            .map_err(|error| format!("invalid repository identity {repo_id}: {error}"))?;
+        let authority = RepositoryAuthorityManager::open(repository_id, Arc::clone(backend))
+            .map_err(|error| {
+                format!("hosted backend carries no usable repository authority: {error}")
+            })?;
+        Self::hydrate_ingest_cas(&authority, &tree, blobs).map_err(|error| error.to_string())
     }
 
     /// Freeze local sibling authority capabilities before the daemon becomes
@@ -1724,6 +1767,7 @@ impl DaemonState {
             layout,
             graph,
             blobs: Arc::new(blobs),
+            ingest_cas_hydration_gap: None,
             reconciler: RwLock::new(reconciler),
             projection: RwLock::new(ProjectionState::new()),
             coordinator,
@@ -1867,6 +1911,33 @@ impl DaemonState {
             };
 
         let blobs = BlobStore::new(layout.ingest_cas_dir()).map_err(DaemonError::from)?;
+        let backend: Arc<dyn StorageBackend> = Arc::from(backend);
+        // Rehydrating the derived CAS on every open is what makes it safe to
+        // treat as a cache. That was true of the local path only; a hosted
+        // instance opened against an empty local disk and every projection read
+        // failed on a blob nothing had put there.
+        let ingest_cas_hydration_gap =
+            match Self::hydrate_backend_ingest_cas(repo_id, &backend, graph.as_ref(), &blobs) {
+                Ok(hydrated_source_bodies) => {
+                    info!(
+                        repo_id,
+                        hydrated_source_bodies,
+                        "hydrated derived ingestion CAS from hosted repository authority"
+                    );
+                    None
+                }
+                Err(reason) => {
+                    // Not fatal: a hosted graph whose backend carries no
+                    // repository authority still serves every query that does
+                    // not need source bodies. Recorded so the reads that DO
+                    // need them report this instead of a bare missing blob.
+                    warn!(
+                        repo_id,
+                        reason, "derived ingestion CAS was not hydrated on the backend open path"
+                    );
+                    Some(reason)
+                }
+            };
         // The backend path builds the graph via `from_snapshot_with_text_index`,
         // which does NOT load the vector-index sidecar — do the validated load
         // here (no-ops if no/stale sidecar).
@@ -1892,6 +1963,7 @@ impl DaemonState {
             layout,
             graph: Arc::clone(&graph),
             blobs: Arc::new(blobs),
+            ingest_cas_hydration_gap,
             reconciler: RwLock::new(reconciler),
             projection: RwLock::new(ProjectionState::new()),
             coordinator,
@@ -1907,7 +1979,7 @@ impl DaemonState {
             started_at: Instant::now(),
             is_initialized: AtomicBool::new(loaded_snapshot),
             reconciliation_status: AtomicU8::new(RECON_IDLE),
-            storage_backend: Some(Arc::from(backend)),
+            storage_backend: Some(backend),
             local_repository_backend: None,
             registered_local_repository_authorities: Vec::new(),
             registered_local_repository_authority_incomplete: false,
@@ -4107,6 +4179,35 @@ impl DaemonState {
             .unwrap_or(0)
     }
 
+    /// Name the open-path hydration gap on an error that a hydrated ingestion
+    /// CAS would not have produced.
+    ///
+    /// Without this a hosted daemon reports "cannot load graph-owned blob X",
+    /// which reads as graph corruption. The blob is fine; nothing ever put it
+    /// in this instance's derived store, and that is a different problem with a
+    /// different fix.
+    fn attribute_ingest_cas_gap(&self, error: DaemonError) -> DaemonError {
+        match &self.ingest_cas_hydration_gap {
+            Some(reason) => exact_source_storage_error(format!(
+                "{error}; the derived ingestion CAS was never hydrated on this open path: {reason}"
+            )),
+            None => error,
+        }
+    }
+
+    /// Issue the derived ingestion CAS's deferred directory barriers.
+    ///
+    /// The store defers the barrier that makes a blob's *name* durable and
+    /// amortizes it across shard directories, with three commit points:
+    /// an explicit sync, `Drop`, and a self-drain once enough renames pile up.
+    /// The daemon ends in `process::exit`, which runs no destructor, so without
+    /// an explicit call the only operative barrier is the self-drain — leaving
+    /// up to a full drain threshold of un-barriered renames behind every
+    /// shutdown, including clean ones.
+    pub fn sync_blob_store(&self) -> Result<()> {
+        self.blobs.sync().map_err(DaemonError::from)
+    }
+
     /// Rebuild projection state from the current graph.
     ///
     /// Loads every persisted [`FileLayout`] and its blob-backed base content
@@ -4121,7 +4222,7 @@ impl DaemonState {
         let tree = self.graph.resolved_tree();
         let state =
             ProjectionState::from_resolved_tree(self.graph.as_ref(), self.blobs.as_ref(), &tree)
-                .map_err(DaemonError::from)?;
+                .map_err(|error| self.attribute_ingest_cas_gap(DaemonError::from(error)))?;
         let registered = state.file_ids().len();
         *projection = state;
         info!(
@@ -4181,10 +4282,10 @@ impl DaemonState {
                 .blobs
                 .read(&kin_blobs::Hash256(*hash.as_bytes()))
                 .map_err(|error| {
-                    exact_source_storage_error(format!(
+                    self.attribute_ingest_cas_gap(exact_source_storage_error(format!(
                         "projection refresh for {file_id} cannot load graph-owned blob {}: {error}",
                         hash
-                    ))
+                    )))
                 })?;
             projection.register_file(layout, content);
             loaded += 1;

--- a/crates/kin-daemon/src/state.rs
+++ b/crates/kin-daemon/src/state.rs
@@ -1391,29 +1391,35 @@ impl DaemonState {
             if !hydrated.insert(hash) {
                 continue;
             }
+            // Consult the local cache before reaching for authority. Both sides
+            // verify content addresses -- `BlobStore::read` re-digests what it
+            // read and `load_source_blob` verifies what it fetched -- so a
+            // successful local read already proves the cached bytes are the
+            // authoritative bytes, and comparing them would only be comparing a
+            // value to itself.
+            //
+            // The ordering is not a micro-optimization. On a hosted backend
+            // every `load_source_blob` is a HEAD plus a GET, serialized, and
+            // this runs before the listener binds, so fetching first cost two
+            // round trips per blob on every open even when the cache was
+            // already complete. At ten thousand bodies that is long enough for
+            // a readiness probe to kill a daemon that is working correctly, and
+            // the restart repeats it: a crash loop that never converges.
+            match blobs.read(&hash) {
+                Ok(_) => continue,
+                Err(BlobError::NotFound { .. } | BlobError::HashMismatch { .. }) => {
+                    // HashMismatch quarantines the corrupt derived object, so
+                    // the write below can atomically heal it from authority.
+                }
+                Err(error) => return Err(DaemonError::Blob(error)),
+            }
+
             let authoritative = authority.load_source_blob(hash)?.ok_or_else(|| {
                 DaemonError::Graph(kin_db::KinDbError::StorageError(format!(
                     "workspace artifact {} references source body {} absent from repository authority",
                     artifact.path, hash
                 )))
             })?;
-
-            match blobs.read(&hash) {
-                Ok(cached) if cached == authoritative => continue,
-                Ok(_) => {
-                    return Err(DaemonError::Graph(kin_db::KinDbError::StorageError(
-                        format!(
-                            "derived ingestion CAS body {} differs from repository authority despite matching its content address",
-                            hash
-                        ),
-                    )))
-                }
-                Err(BlobError::NotFound { .. } | BlobError::HashMismatch { .. }) => {
-                    // HashMismatch quarantines the corrupt derived object, so
-                    // this write can atomically heal it from authority.
-                }
-                Err(error) => return Err(DaemonError::Blob(error)),
-            }
 
             let installed_hash = blobs.write(&authoritative)?;
             if installed_hash != hash {
@@ -1454,6 +1460,12 @@ impl DaemonState {
     /// Returns the number of source bodies hydrated, or the reason the hosted
     /// backend could not supply them. A graph with no resolved artifacts needs
     /// no authority at all, which is the ordinary empty-hosted-graph case.
+    ///
+    /// Opening the authority is itself expensive on a hosted backend: it
+    /// re-downloads the repository snapshot that `open_with_backend` has
+    /// already loaded, and kin-db may replay the whole history to validate it.
+    /// So the cheap local question is asked first, and an instance whose
+    /// derived cache already covers the tree never opens authority at all.
     fn hydrate_backend_ingest_cas(
         repo_id: &str,
         backend: &Arc<dyn StorageBackend>,
@@ -1464,6 +1476,9 @@ impl DaemonState {
         if tree.is_empty() {
             return Ok(0);
         }
+        if Self::ingest_cas_covers_tree(&tree, blobs).map_err(|error| error.to_string())? {
+            return Ok(0);
+        }
         let repository_id = RepositoryId::new(repo_id.to_string())
             .map_err(|error| format!("invalid repository identity {repo_id}: {error}"))?;
         let authority = RepositoryAuthorityManager::open(repository_id, Arc::clone(backend))
@@ -1471,6 +1486,26 @@ impl DaemonState {
                 format!("hosted backend carries no usable repository authority: {error}")
             })?;
         Self::hydrate_ingest_cas(&authority, &tree, blobs).map_err(|error| error.to_string())
+    }
+
+    /// Whether every source body the tree names is already readable from the
+    /// derived cache. Purely local: `BlobStore::read` verifies what it read
+    /// against the requested content address, so a clean pass is proof the
+    /// cache holds the authoritative bodies and no authority is needed.
+    fn ingest_cas_covers_tree(tree: &ResolvedTree, blobs: &BlobStore) -> Result<bool> {
+        for artifact in tree.artifacts() {
+            let Some(hash) = artifact.entry.blob_identity() else {
+                continue;
+            };
+            match blobs.read(&hash) {
+                Ok(_) => {}
+                Err(BlobError::NotFound { .. } | BlobError::HashMismatch { .. }) => {
+                    return Ok(false)
+                }
+                Err(error) => return Err(DaemonError::Blob(error)),
+            }
+        }
+        Ok(true)
     }
 
     /// Freeze local sibling authority capabilities before the daemon becomes
@@ -3757,6 +3792,23 @@ impl DaemonState {
             .persist_lock
             .lock()
             .map_err(|_| DaemonError::Io(std::io::Error::other("persist lock poisoned")))?;
+
+        // Make the derived CAS names durable before persisting a graph that
+        // references them.
+        //
+        // kin-blobs defers the directory barrier that makes a blob's *name*
+        // durable and amortizes it across shards, so a write returning Ok does
+        // not yet mean the rename survives a crash. Its contract puts the
+        // obligation on the caller: sync is the commit point for anyone about
+        // to record those names somewhere that outlives a crash. This is that
+        // point. Skipping it would let a snapshot name bodies whose renames are
+        // still only in the page cache.
+        //
+        // Cheap in the steady state: sync returns immediately when nothing is
+        // pending, and otherwise costs one fsync per shard directory touched
+        // since the last barrier, which two-hex sharding caps at 256 no matter
+        // how many blobs were written.
+        self.blobs.sync().map_err(DaemonError::from)?;
 
         let force_full = mode == SnapshotSaveMode::Full;
 
@@ -7301,6 +7353,39 @@ mod ingest_cas_tests {
             blobs.read(&hash).unwrap(),
             body,
             "hydration must install the exact repository-authority body"
+        );
+    }
+
+    #[test]
+    fn a_covered_cache_needs_no_authority_at_all() {
+        // The hosted cost this closes: opening authority re-downloads the
+        // repository snapshot and can replay the whole history, and the old
+        // ordering fetched every body before consulting the cache, so a warm
+        // instance paid the full price on every open. Point the backend at a
+        // directory holding no authority whatsoever: hydration must still
+        // succeed, which is only possible if it never opened one.
+        let repo_dir = tempfile::tempdir().unwrap();
+        let body = b"already cached\n";
+        let init = kin_core::init(repo_dir.path()).unwrap();
+        publish_single_blob_workspace(&init.layout, body);
+
+        let repo_id = kin_core::manifest::resolve_repo_id(&init.layout, None).unwrap();
+        let graph = {
+            let local = DaemonState::open(init.layout).expect("local open");
+            Arc::clone(&local.graph)
+        };
+        let cache_dir = tempfile::tempdir().unwrap();
+        let blobs = BlobStore::new(cache_dir.path().to_path_buf()).unwrap();
+        blobs.write(body).unwrap();
+
+        let empty = tempfile::tempdir().unwrap();
+        let backend: Arc<dyn StorageBackend> =
+            Arc::new(LocalFileBackend::new(empty.path().to_path_buf()));
+
+        assert_eq!(
+            DaemonState::hydrate_backend_ingest_cas(&repo_id, &backend, graph.as_ref(), &blobs),
+            Ok(0),
+            "a cache that already covers the tree must not open repository authority"
         );
     }
 

--- a/crates/kin-daemon/tests/chaos_recovery.rs
+++ b/crates/kin-daemon/tests/chaos_recovery.rs
@@ -38,7 +38,13 @@ fn assert_child_alive(child: &mut Child, port: u16, what: &str) {
 /// so a kill/restart never depends on reusing one port's teardown timing.
 async fn read_published_port(child: &mut Child, repo_root: &Path) -> u16 {
     let port_file = repo_root.join(".kin/daemon.port");
-    let deadline = Instant::now() + Duration::from_secs(30);
+    // Share the readiness budget rather than keeping a tighter one of its own.
+    // Publishing the port is part of the same startup this file already grants
+    // READINESS_TIMEOUT for, and a 30s cap here made a healthy daemon on a
+    // loaded machine indistinguishable from a broken one. A daemon that dies is
+    // still caught eagerly through its child handle, so a generous budget only
+    // ever bounds a slow-but-live startup.
+    let deadline = Instant::now() + READINESS_TIMEOUT;
     let mut backoff = Duration::from_millis(20);
 
     loop {
@@ -54,7 +60,26 @@ async fn read_published_port(child: &mut Child, repo_root: &Path) -> u16 {
             panic!("daemon exited before publishing its port: {status}");
         }
         if Instant::now() >= deadline {
-            panic!("daemon never published its port to {}", port_file.display());
+            // Say which of the two it is. A deadline measures this test's
+            // patience, not the daemon's health, and reporting "never
+            // published" for a process that is still running sends the reader
+            // hunting a startup bug that is not there. This is the same
+            // distinction the production spawn contract draws between
+            // `ChildExited` and `StillStarting`.
+            let fate = match child.try_wait() {
+                Ok(Some(status)) => format!("it exited with {status}"),
+                Ok(None) => {
+                    "it is still running, so this is a slow start rather than a failed one \
+                     (the machine is likely loaded)"
+                        .to_string()
+                }
+                Err(error) => format!("its state could not be read: {error}"),
+            };
+            panic!(
+                "daemon did not publish a port to {} within {:.0}s; {fate}",
+                port_file.display(),
+                READINESS_TIMEOUT.as_secs_f64()
+            );
         }
 
         tokio::time::sleep(backoff).await;

--- a/crates/kin-daemon/tests/chaos_recovery.rs
+++ b/crates/kin-daemon/tests/chaos_recovery.rs
@@ -356,3 +356,133 @@ async fn daemon_exits_after_dirty_repo_control_dir_is_removed() {
         "deleted-control-dir idle shutdown should be graceful: {exit}"
     );
 }
+
+/// Every component of a repo's published endpoint, read as raw bytes.
+///
+/// Compared whole so a test can assert that a file was not merely present
+/// afterwards but untouched: a refusing starter that rewrote the incumbent's
+/// port with its own would leave both paths existing.
+fn endpoint_snapshot(repo_root: &Path) -> Vec<(String, Option<Vec<u8>>)> {
+    ["daemon.pid", "daemon.port", "daemon.owner"]
+        .into_iter()
+        .map(|name| {
+            (
+                name.to_string(),
+                std::fs::read(repo_root.join(".kin").join(name)).ok(),
+            )
+        })
+        .collect()
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn a_refused_second_daemon_leaves_the_incumbent_serving() {
+    // The reported sequence: an MCP retry revived a daemon, the revived daemon
+    // lost the repo singleton and refused, and the incumbent it lost to died
+    // moments later with its endpoint files gone. A refusal must be inert.
+    let repo = tempfile::tempdir().unwrap();
+    init_repo(repo.path());
+
+    let mut incumbent = spawn_daemon_with_env(
+        repo.path(),
+        0,
+        &[
+            ("KIN_DAEMON_DISABLE_LSP", "1"),
+            ("KIN_DAEMON_IDLE_TIMEOUT_SECS", "600"),
+        ],
+    );
+    let port = read_published_port(&mut incumbent, repo.path()).await;
+    assert_eq!(wait_for_health(&mut incumbent, port).await.status, "ok");
+
+    let before = endpoint_snapshot(repo.path());
+    assert!(
+        before.iter().all(|(_, bytes)| bytes.is_some()),
+        "the incumbent must have published an attributed endpoint: {before:?}"
+    );
+
+    let mut refused = spawn_daemon_with_env(repo.path(), 0, &[("KIN_DAEMON_DISABLE_LSP", "1")]);
+    let exit = match tokio::time::timeout(Duration::from_secs(120), refused.wait()).await {
+        Ok(result) => result.expect("second kin-daemon wait failed"),
+        Err(_) => {
+            let _ = refused.start_kill();
+            panic!("the second kin-daemon neither started nor refused");
+        }
+    };
+    assert!(
+        !exit.success(),
+        "losing the repo singleton must be reported as a failure: {exit}"
+    );
+
+    assert_eq!(
+        endpoint_snapshot(repo.path()),
+        before,
+        "a refused start must leave the incumbent's endpoint byte-identical"
+    );
+    assert_child_alive(&mut incumbent, port, "alive after a refused second start");
+    assert_eq!(
+        wait_for_health(&mut incumbent, port).await.status,
+        "ok",
+        "the incumbent must still be serving the repo it owns"
+    );
+
+    incumbent.start_kill().expect("failed to stop kin-daemon");
+    let _ = incumbent.wait().await;
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn a_deleted_endpoint_is_republished_instead_of_ending_the_daemon() {
+    // The other half of the same failure: the incumbent keyed its own liveness
+    // on endpoint files it did not verify it owned. Deleting them must be
+    // repaired by the daemon that still holds the repo, not obeyed.
+    let repo = tempfile::tempdir().unwrap();
+    init_repo(repo.path());
+
+    let mut child = spawn_daemon_with_env(
+        repo.path(),
+        0,
+        &[
+            ("KIN_DAEMON_DISABLE_LSP", "1"),
+            ("KIN_DAEMON_IDLE_TIMEOUT_SECS", "600"),
+        ],
+    );
+    let port = read_published_port(&mut child, repo.path()).await;
+    wait_for_serving(&mut child, port).await;
+
+    let daemon_pid = repo.path().join(".kin/daemon.pid");
+    let daemon_port = repo.path().join(".kin/daemon.port");
+    wait_for_path(
+        &daemon_pid,
+        "daemon did not write pid file",
+        Duration::from_secs(10),
+    )
+    .await;
+    std::fs::remove_file(&daemon_pid).unwrap();
+    std::fs::remove_file(&daemon_port).unwrap();
+
+    wait_for_path(
+        &daemon_pid,
+        "daemon never republished its pid file",
+        Duration::from_secs(60),
+    )
+    .await;
+    wait_for_path(
+        &daemon_port,
+        "daemon never republished its port file",
+        Duration::from_secs(60),
+    )
+    .await;
+
+    assert_child_alive(&mut child, port, "alive after its endpoint was deleted");
+    assert_eq!(
+        std::fs::read_to_string(&daemon_port)
+            .unwrap()
+            .trim()
+            .parse::<u16>()
+            .unwrap(),
+        port,
+        "republication must restore the port the daemon actually bound"
+    );
+    assert_eq!(wait_for_health(&mut child, port).await.status, "ok");
+
+    child.start_kill().expect("failed to stop kin-daemon");
+    let _ = child.wait().await;
+}

--- a/scripts/zero-file-search-allowlist.json
+++ b/scripts/zero-file-search-allowlist.json
@@ -219,7 +219,7 @@
     },
     {
       "file": "crates/kin-daemon/src/lifecycle.rs",
-      "reason": "Daemon lifecycle boundary: starting, finding, and stopping the process that holds graph authority. Four classes, all excused per function. Singleton coordination: the lock file, its owner stamp, and the guards that decide whether this process may become the daemon. Endpoint publication: the pid and port components, each written atomically, read back, and removed only by their owning process. Binary resolution and liveness: locating the kin-daemon executable and probing whether an endpoint is answering before spawning another. Platform registration: the macOS launch agent plist and its non-macOS no-op counterpart, which is why two names carry a count of two. Every path here reaches or supervises the authority and answers no query. The two expression pins are a Stdio import and the struct field holding the lock file handle. Function-scoped so the remainder of the module stays scanned.",
+      "reason": "Daemon lifecycle boundary: starting, finding, and stopping the process that holds graph authority. Four classes, all excused per function. Singleton coordination: the lock file, its owner stamp, and the guards that decide whether this process may become the daemon. Endpoint publication: the pid and port components, each written atomically, read back, and removed only by their owning process. Binary resolution and liveness: locating the kin-daemon executable and probing whether an endpoint is answering before spawning another. Platform registration: the macOS launch agent plist and its non-macOS no-op counterpart, which is why two names carry a count of two. Every path here reaches or supervises the authority and answers no query. The two expression pins are a Stdio import and the struct field holding the lock file handle. Function-scoped so the remainder of the module stays scanned. The publication and ownership paths were split into named helpers so the proof that an endpoint may be removed can be exercised independently of the process that publishes it; those helpers carry the same endpoint control-plane IO the enclosing functions already carried, not new authority.",
       "owner": "kin-daemon",
       "expiration": "2026-12-31",
       "allow_fn": [
@@ -247,7 +247,13 @@
         {
           "fn": "unregister_launch_agent",
           "count": 2
-        }
+        },
+        "read_endpoint_owner_record",
+        "endpoint_ownership_with_probe",
+        "proven_live_other_endpoint_owner_with_probe",
+        "publish_foreign_endpoint_for_test",
+        "remove_endpoint_components",
+        "publish_daemon_endpoint_under_authority_with_probe"
       ],
       "allow_match": [
         "use std::process::Stdio;",
@@ -305,18 +311,20 @@
     },
     {
       "file": "crates/kin-daemon/src/daemon.rs",
-      "reason": "Daemon run loop boundary. Two pins are the liveness checks that ask whether this daemon's own endpoint records and control plane are still present, which is a question about the process rather than about the repository. The rest are the run loop reporting its process id, exiting, and canonicalizing the bound repository root twice while wiring authority into the server. No repository content is read and no query answer derives from any of it. Pinned by expression rather than by function, because the run loop is half this module and exempting its body would leave more unscanned than the primitives justify.",
+      "reason": "Daemon run loop boundary. Two pins are the liveness checks that ask whether this daemon's own endpoint records and control plane are still present, which is a question about the process rather than about the repository. The rest are the run loop reporting its process id, exiting, and canonicalizing the bound repository root twice while wiring authority into the server. No repository content is read and no query answer derives from any of it. Pinned by expression rather than by function, because the run loop is half this module and exempting its body would leave more unscanned than the primitives justify. Those two liveness pins named expressions that no longer exist: endpoint_files_missing and control_plane_missing were replaced by a classifier that verifies who owns an endpoint before treating its absence as an eviction notice. The successors are exempted per function rather than by snippet, because a pinned expression is exactly what went stale here.",
       "owner": "kin-daemon",
       "expiration": "2026-12-31",
       "allow_match": [
-        "!root.join(\"daemon.pid\").exists() || !root.join(\"daemon.port\").exists()",
-        "!state.layout.root().exists() || endpoint_files_missing(state)",
         {
           "expr": ".canonicalize()",
           "count": 2
         },
         "std::process::id(),",
         "std::process::exit(0);"
+      ],
+      "allow_fn": [
+        "repository_root_missing",
+        "classify_control_plane"
       ]
     },
     {


### PR DESCRIPTION
## What

Two daemon lifecycle defects: a refused daemon start could take the running
daemon's endpoint down with it, and the derived ingestion CAS never reached a
durability commit point on shutdown or a hydration on the storage-backend open
path.

## Why

A `kin mcp start` retry against a warming daemon reliably killed the daemon it
was waiting on. The revived daemon lost the repository singleton and refused,
the incumbent's `.kin/daemon.pid` and `.kin/daemon.port` went missing, and the
incumbent, which keyed its own liveness on those files existing, shut itself
down. Separately, `hydrate_ingest_cas` had exactly one call site, so "rehydrated
on every daemon open" was true of the local path only.

Closes FIR-1682
Closes FIR-1654

## How

Endpoint publication writes a `daemon.owner` sidecar carrying the same process
incarnation the singleton lock already stamps. `daemon.pid` keeps its exact
legacy bytes, so existing readers are unaffected and an older daemon's bare-PID
endpoint still resolves through a fallback.

**Removal and publication fail in opposite directions, deliberately.** Refusing
to delete an endpoint whose owner cannot be inspected is safe, because the worst
case is a stale file. Refusing to *publish* over one is not: the publisher
already holds the repository singleton, so no legitimate owner can exist, and
the refusal is fatal at startup. So `live`, which governs removal, treats an
unreadable probe as live, while the publish and supersede decisions require the
owner to be *proven* live and treat an unreadable probe as not proven. A
daemon's own endpoint is resolved from this process's identity rather than a
probe of a foreign PID, so retiring it is as infallible as the bare-PID
comparison it replaced.

A running daemon whose endpoint files are deleted republishes them and keeps
serving; only a removed `.kin` root or a provably live successor ends it.
Republication is skipped once shutdown is signalled, so a late repair cannot
outlive the retirement it races. Port zero is refused on publish and read as
unpublished.

**Durability.** `kin-blobs` moves 0.1.1 to 0.1.3. This is **not** a purely
additive bump, and an earlier revision of this PR wrongly said so: 0.1.1's
`BlobStore::write` ends with `sync_dir(shard_dir);` and 0.1.3 deletes that line,
replacing it with deferred per-shard barriers and a 4096-rename self-drain. The
bump therefore removes an fsync from every write in the workspace and adds an
opt-in commit point, which is a contract change in the opposite direction to how
it was described. Accordingly the barrier is issued where the store's contract
puts the obligation: in `save_snapshot_impl`, before the snapshot records those
blob names, and again on graceful shutdown, since the daemon exits through
`process::exit` and runs no destructor. Cheap in the steady state, because
`sync` returns immediately with nothing pending and otherwise costs one fsync
per shard directory touched, capped at 256 by two-hex sharding. A
force-escalated shutdown still skips it by design; the store re-hydrates on open.

**Hosted open path.** `open_with_backend` now hydrates the ingest CAS from the
resolved tree its projection reads. Hydration consults the local cache before
reaching for authority, and an instance whose cache already covers the tree
opens no repository authority at all. Both sides verify content addresses, so
fetching first was pure cost: two network round trips per blob on a path that
runs before the listener binds, which at scale is long enough for a readiness
probe to kill a daemon that is working correctly. When a hosted backend carries
no usable authority the gap is recorded so the projection reads name it instead
of reporting a bare missing blob.

**Lock churn, disclosed:** besides kin-blobs, the only other hunk moves
`winapi-util 0.1.11` onto `windows-sys 0.61.2`, a version already present in
main's lock. The branch adds zero new packages.

**New steady-state cost, disclosed:** a persistent daemon now wakes every 5s to
check the control plane where it previously parked on a channel. That is what
makes endpoint repair available to persistent daemons and not only to
idle-timeout ones; each tick is a few `exists` calls plus at most two identity
probes.

## Testing

- [x] `cargo test` passes (`cargo test --workspace --locked` plus
      `cargo test --workspace --doc --locked`, `RUSTFLAGS=-D warnings`)
- [x] `cargo clippy` produces no warnings (`--all-targets --all-features` with
      the ci.yml allowlist)
- [x] `cargo fmt` applied

Also run: the zero-file-search guards, the hydration replay-semantics guard, the
runtime-boundary check, and the private-repo-coupling check.

Coverage: two integration tests driving real daemon processes, one asserting a
refused second start leaves the incumbent's endpoint byte-identical and still
answering `/health`, one asserting a deleted endpoint is republished under a
live daemon. Plus unit tests across endpoint ownership (recycled PID cannot
claim an endpoint, an unreadable probe blocks removal but not publication, a
daemon can always retire its own endpoint, legacy attribution still resolves,
rollback touches only what a call installed, port-zero refusal), control-plane
classification including the shutdown-race guard, and ingest-CAS hydration per
open path including the no-authority-needed case.

Unrelated to the diff but fixed here because it is in the same file: the
`chaos_recovery` port wait shared a tighter 30s budget than the readiness path
around it, which made a healthy daemon on a loaded machine report as one that
never started. It now shares `READINESS_TIMEOUT` and its deadline message
distinguishes a child that exited from one that is still running.
