### PR TITLE
Bind external targets for cross-repo references at admission

### DIFF
--- a/crates/kin-cli/src/commands/graph.rs
+++ b/crates/kin-cli/src/commands/graph.rs
@@ -4,7 +4,9 @@
 use std::collections::{HashMap, HashSet};
 
 use anyhow::{Context, Result};
-use kin_model::{Entity, EntityId, EntityKind, EntityRole, EntityStore, GraphStore, RelationKind};
+use kin_model::{
+    Entity, EntityId, EntityKind, EntityRole, EntityStore, GraphStore, Hash256, RelationKind,
+};
 use serde::{Deserialize, Serialize};
 
 use super::graph_health::inspect_graph;
@@ -194,17 +196,32 @@ fn build_graph_status_response(
     let health = inspect_graph(binding, graph)?;
 
     let entities = graph.list_all_entities()?;
-    let entity_count = entities.len();
 
-    // Role counts
+    // An external reference target is a node this repository references without
+    // owning: no file, no span, no signature, and a uniform kind. Counting it
+    // among the entities this repository holds would report documentation
+    // coverage falling with no change to documentation, put a fabricated bucket
+    // in the kind histogram, and make the entity and file totals stop
+    // corresponding. It is counted on its own line instead, so it is disclosed
+    // rather than either hidden or folded into a claim about this repository's
+    // own code.
+    let (defined, external_targets): (Vec<&Entity>, Vec<&Entity>) = entities
+        .iter()
+        .partition(|e| !kin_index::is_external_reference_target(e));
+    let entity_count = defined.len();
+
+    // Role counts, over the entities this repository defines. Role
+    // classification is a statement about a repository's own files, and the
+    // warning below reads these counts to decide whether the classifier ran at
+    // all.
     let mut role_counts: HashMap<EntityRole, usize> = HashMap::new();
-    for e in &entities {
+    for e in &defined {
         *role_counts.entry(e.role).or_insert(0) += 1;
     }
 
     // Kind counts
     let mut kind_counts: HashMap<EntityKind, usize> = HashMap::new();
-    for e in &entities {
+    for e in &defined {
         *kind_counts.entry(e.kind).or_insert(0) += 1;
     }
 
@@ -235,7 +252,7 @@ fn build_graph_status_response(
     let embed_status = graph.embedding_status();
 
     // Doc summary coverage
-    let with_docs = entities.iter().filter(|e| e.doc_summary.is_some()).count();
+    let with_docs = defined.iter().filter(|e| e.doc_summary.is_some()).count();
 
     let mut lines = Vec::new();
     lines.push("=== Graph Health ===".to_string());
@@ -253,6 +270,10 @@ fn build_graph_status_response(
         } else {
             total_relations as f64 / entity_count as f64
         }
+    ));
+    lines.push(format!(
+        "External reference targets: {}",
+        external_targets.len()
     ));
     lines.push(String::new());
 
@@ -405,24 +426,42 @@ fn build_graph_validate_response(
 
     // Check for duplicate entities (same name + file + kind + byte position).
     // Using byte position distinguishes legitimate overloads (Python @overload,
-    // Rust impl From<X>, C++ template specializations) from true duplicates.
-    // Two entities at different positions in the same file are never duplicates.
-    let mut seen: HashMap<(String, Option<String>, EntityKind, usize), Vec<kin_model::EntityId>> =
-        HashMap::new();
+    // Rust impl From<X>, C++ template specializations) from true duplicates: two
+    // entities declared at different positions in one file are never duplicates.
+    //
+    // An entity with no span has no position to be distinguished by, and
+    // collapsing that to byte zero makes the position discriminate nothing. An
+    // external reference target is exactly that shape: it stands for a symbol
+    // another repository owns, so it carries no file and no span, and its kind
+    // is uniform. Name alone would then report two legitimately distinct
+    // targets as one duplicated entity, which is what `use log::info` beside
+    // `use tracing::info` produces on an ordinary repository. Its fingerprint
+    // is derived from the facts that do identify it, the import source and the
+    // symbol, so it stands in for the absent position and keeps the check
+    // meaningful: two targets naming different import sources stay distinct,
+    // while two entities claiming the same import source and symbol are still
+    // reported. Entities that do carry a span keep the position key exactly as
+    // before, so nothing this check used to catch stops being caught.
+    let mut seen: HashMap<
+        (String, Option<String>, EntityKind, usize, Option<Hash256>),
+        Vec<kin_model::EntityId>,
+    > = HashMap::new();
     for e in &entities {
         let start_byte = e.span.as_ref().map(|s| s.start_byte).unwrap_or(0);
+        let placeless_identity = e.span.is_none().then_some(e.fingerprint.ast_hash);
         let key = (
             e.name.clone(),
             e.file_origin.as_ref().map(|f| f.0.clone()),
             e.kind,
             start_byte,
+            placeless_identity,
         );
         seen.entry(key).or_default().push(e.id);
     }
     let duplicates: Vec<_> = seen.iter().filter(|(_, ids)| ids.len() > 1).collect();
     if !duplicates.is_empty() {
         issues.push(format!(
-            "{} true duplicate entities (same name+file+kind+position)",
+            "{} true duplicate entities (same name+file+kind, same position or same identity)",
             duplicates.len()
         ));
     }
@@ -1795,6 +1834,61 @@ mod tests {
             .iter()
             .filter(|line| line.starts_with('ℹ'))
             .collect()
+    }
+
+    /// The shape admission binds for a symbol another repository owns. Two of
+    /// them differ only in the fingerprint derived from their import source and
+    /// symbol, which is what makes that fingerprint the identity the duplicate
+    /// check has to read.
+    fn external_target_entity(name: &str, import_identity: u8) -> Entity {
+        let mut entity = test_entity(name);
+        entity.kind = EntityKind::Module;
+        entity.role = EntityRole::External;
+        entity.signature = String::new();
+        entity.fingerprint.ast_hash = Hash256::from_bytes([import_identity; 32]);
+        entity
+    }
+
+    fn duplicate_line(response: &GraphCommandResponse) -> Option<&String> {
+        response
+            .lines
+            .iter()
+            .find(|line| line.contains("duplicate"))
+    }
+
+    /// Two external targets naming one symbol through different import sources
+    /// are two entities, and reporting them as one duplicated entity makes
+    /// validate assert corruption against a graph Kin wrote correctly. The
+    /// converse still has to hold: two entities that make the same claim about
+    /// one external target are a real duplicate, and the check that stops
+    /// false-positiving must not stop detecting.
+    #[test]
+    fn graph_validate_separates_distinct_external_targets_from_duplicated_ones() {
+        let (_temp, _layout, binding, graph) = orphan_fixture(&["src/tracked.rs"]);
+        graph
+            .upsert_entity(&external_target_entity("info", 0x11))
+            .unwrap();
+        graph
+            .upsert_entity(&external_target_entity("info", 0x22))
+            .unwrap();
+
+        let distinct = build_graph_validate_response(&binding, &graph).unwrap();
+        assert!(
+            duplicate_line(&distinct).is_none(),
+            "distinct import sources are distinct entities: {}",
+            distinct.lines.join("\n")
+        );
+
+        // A third entity repeating the second one's claim: same name, same
+        // import identity, its own entity id.
+        graph
+            .upsert_entity(&external_target_entity("info", 0x22))
+            .unwrap();
+
+        let duplicated = build_graph_validate_response(&binding, &graph).unwrap();
+        let line = duplicate_line(&duplicated)
+            .expect("two entities claiming one external target is a duplicate");
+        assert!(line.contains('1'), "{line}");
     }
 
     /// Notes describe a healthy graph rather than a defect, so a surface that

--- a/crates/kin-cli/src/commands/impact.rs
+++ b/crates/kin-cli/src/commands/impact.rs
@@ -296,6 +296,15 @@ fn resolve_entities(
             ..Default::default()
         };
         let mut matches = graph.query_entities(&filter)?;
+        // An external reference target carries the imported symbol's name, so a
+        // name query returns it beside the local declaration that shares that
+        // name. It is never a subject of impact analysis: this repository holds
+        // no definition, no file, and no relations out of it, so nothing can be
+        // said about what changing it would reach. Leaving it in the match set
+        // inflates the count, and under a structured caller's fail-closed
+        // resolution it turns a repository's own `Error` or `Result` into an
+        // ambiguous query answered with no analysis at all.
+        matches.retain(|entity| !kin_index::is_external_reference_target(entity));
         // The human surface preserves Kin's broad name matching. Structured
         // callers explicitly opt into exact, fail-closed identity resolution.
         if request.require_unique {

--- a/crates/kin-cli/tests/graph_status_after_admission.rs
+++ b/crates/kin-cli/tests/graph_status_after_admission.rs
@@ -8,6 +8,7 @@
 //! views: they agree immediately after admission, while daemon routing tests
 //! separately pin that later live-only enrichment does not rewrite authority.
 
+use std::collections::BTreeSet;
 use std::fs;
 use std::net::{SocketAddr, TcpStream};
 use std::path::Path;
@@ -146,6 +147,34 @@ fn seed_repository(repo: &Path) {
     run_git(repo, &["commit", "-m", "advance semantic identities"]);
 }
 
+/// A repository whose cross-file facts are two imports of one symbol name from
+/// two different external modules. This is what an ordinary repository looks
+/// like part way through a migration, `use log::info` in one file beside
+/// `use tracing::info` in another, and the same shape arises from
+/// `anyhow::Result` beside `std::io::Result`, or `useState` imported from both
+/// `react` and `preact/hooks`.
+fn seed_repository_with_same_named_external_imports(repo: &Path) {
+    fs::create_dir_all(repo.join("src")).expect("create source directory");
+    run_git(repo, &["init", "--initial-branch=main"]);
+    run_git(repo, &["config", "user.email", "kin@example.invalid"]);
+    run_git(repo, &["config", "user.name", "Kin"]);
+    fs::write(
+        repo.join("src/legacy.rs"),
+        b"extern crate log;\n\nuse log::info;\n\npub fn legacy() {\n    info();\n}\n",
+    )
+    .expect("write the importer on the old logger");
+    fs::write(
+        repo.join("src/current.rs"),
+        b"extern crate tracing;\n\nuse tracing::info;\n\npub fn current() {\n    info();\n}\n",
+    )
+    .expect("write the importer on the new logger");
+    run_git(repo, &["add", "--all"]);
+    run_git(
+        repo,
+        &["commit", "-m", "two external modules, one symbol name"],
+    );
+}
+
 struct AdmittedRepository {
     layout: kin_core::KinLayout,
     binding: kin_core::LocalRepositoryAuthorityBinding,
@@ -282,6 +311,61 @@ fn graph_validate_reports_pending_enrichment_and_agrees_with_status() {
         note_lines(&validate),
         note_lines(&status),
         "validate and status must agree on note presence for one repo state"
+    );
+}
+
+/// Admission binds one external reference target per unresolved import source,
+/// and two imports of one symbol name produce two of them. Both carry that
+/// symbol as their name, no file, no span, and the same uniform kind, so a
+/// duplicate check that keys on name and declaration position alone sees one
+/// entity recorded twice. Validate would then print a corruption report and exit
+/// non-zero on a graph Kin had just written correctly, on any repository that
+/// imports a common name such as `Error`, `Result`, or `info` from two modules.
+#[test]
+fn graph_validate_accepts_same_named_external_targets_from_different_modules() {
+    let root = tempdir().expect("temp root");
+    let repo = root.path().join("repo");
+    fs::create_dir_all(&repo).expect("create repo");
+    seed_repository_with_same_named_external_imports(&repo);
+    let result = kin_core::init_from_git(&repo).expect("admit exact Git repository authority");
+    let binding = kin_core::LocalRepositoryAuthorityBinding::from_layout(&result.layout)
+        .expect("bind published repository authority");
+    let graph = workspace_query_graph(&binding);
+
+    // The shape under test has to be present, or passing proves nothing.
+    let targets: Vec<_> = graph
+        .list_all_entities()
+        .expect("list entities")
+        .into_iter()
+        .filter(|entity| entity.name == "info" && entity.file_origin.is_none())
+        .collect();
+    assert_eq!(
+        targets.len(),
+        2,
+        "admission binds one external target per import source: {targets:?}"
+    );
+    assert_eq!(
+        targets
+            .iter()
+            .map(|entity| entity.id)
+            .collect::<BTreeSet<_>>()
+            .len(),
+        2,
+        "the two targets are distinct entities, not one recorded twice"
+    );
+
+    let validate = graph_validate(&binding, &graph);
+
+    assert!(
+        !validate.lines.iter().any(|line| line.contains("duplicate")),
+        "two distinct external targets are not a duplicated entity: {}",
+        validate.lines.join("\n")
+    );
+    assert!(
+        validate.error.is_none(),
+        "a healthy graph must not fail validate: {:?}\n{}",
+        validate.error,
+        validate.lines.join("\n")
     );
 }
 

--- a/crates/kin-index/src/history.rs
+++ b/crates/kin-index/src/history.rs
@@ -32,12 +32,21 @@ use crate::pipeline::IndexPipeline;
 ///
 /// Kin's deep history is not a stored fact. It is re-authored here from
 /// graph-owned trees and CAS bodies, so editing any of the replay functions
-/// pinned by `scripts/hydration-semantics-manifest.json` changes what Kin
-/// reports about the past on repositories that were already ingested. A digest
-/// mismatch in that guard is a decision to make, not a file to regenerate:
-/// establish whether replay semantics actually changed, and if they did, bump
-/// this constant and the manifest's recorded version together. Never
-/// regenerate a digest silently.
+/// pinned by `scripts/hydration-semantics-manifest.json` changes what a
+/// repository's past is said to contain the next time that repository is
+/// admitted. A digest mismatch in that guard is a decision to make, not a file
+/// to regenerate: establish whether replay semantics actually changed, and if
+/// they did, bump this constant and the manifest's recorded version together.
+/// Never regenerate a digest silently.
+///
+/// This constant is a declaration, not an enforcement point. Nothing persists
+/// it beside a graph and nothing compares it when one is opened, and no path
+/// re-derives historical deltas for a repository that was already admitted, so
+/// bumping it does not invalidate, migrate, or re-enrich an existing graph. A
+/// repository admitted under an earlier version keeps whatever its past was
+/// authored to contain until it is admitted again, and reports nothing about
+/// which version authored it. Coupling the dial to graph authority so a
+/// version gap can be detected and refused is open follow-up work.
 pub const HYDRATION_SEMANTICS_VERSION: u32 = 7;
 
 /// Semantic graph delta derived for one pre-enrichment change identity.
@@ -87,6 +96,12 @@ pub fn derive_historical_semantic_deltas(
     blob_store: &BlobStore,
 ) -> Result<Vec<HistoricalSemanticDelta>> {
     let pipeline = IndexPipeline::new();
+    // An external target's fingerprint is a pure function of the import source
+    // and symbol its identity is derived from, so it is the same value in every
+    // tree that observes the import. The fold relinks the whole tree per change,
+    // which would otherwise recompute those digests once per commit for a value
+    // that cannot change.
+    let mut external_fingerprints = BTreeMap::<EntityId, SemanticFingerprint>::new();
     let mut states = BTreeMap::<SemanticChangeId, SemanticTreeState>::new();
     let mut known_changes = HashSet::with_capacity(changes.len());
     let mut remaining_child_uses = BTreeMap::<SemanticChangeId, usize>::new();
@@ -144,7 +159,13 @@ pub fn derive_historical_semantic_deltas(
                 change.id
             ))
         })?;
-        let current = semantic_state_for_tree(tree, &parent_states, blob_store, &pipeline)?;
+        let current = semantic_state_for_tree(
+            tree,
+            &parent_states,
+            blob_store,
+            &pipeline,
+            &mut external_fingerprints,
+        )?;
         let entity_deltas = diff_entities(&first_parent.entities, &current.entities);
         let relation_deltas = diff_relations(&first_parent.relations, &current.relations);
 
@@ -190,6 +211,7 @@ fn semantic_state_for_tree(
     parents: &[&SemanticTreeState],
     blob_store: &BlobStore,
     pipeline: &IndexPipeline,
+    external_fingerprints: &mut BTreeMap<EntityId, SemanticFingerprint>,
 ) -> Result<SemanticTreeState> {
     let mut files = BTreeMap::new();
 
@@ -310,7 +332,11 @@ fn semantic_state_for_tree(
     parse_data.sort_by(|left, right| left.file_path.cmp(&right.file_path));
 
     let linked = link_cross_file_with_completeness(&parse_data, &artifact_ids, &completeness)?;
-    entities.extend(external_reference_targets(&linked, &entities));
+    entities.extend(external_reference_targets(
+        &linked,
+        &entities,
+        external_fingerprints,
+    ));
     let mut relations = BTreeMap::new();
     for relation in linked {
         if let Some(absent) = absent_local_endpoint(&relation, &entities) {
@@ -362,17 +388,28 @@ struct AbsentEndpoint {
 /// Binding an external target instead makes the reference complete,
 /// change-owned truth at the admission boundary. The target keeps the linker's
 /// deterministic identity, so every commit that observes the same import binds
-/// the same node and the fold emits no churn. It carries no file origin,
-/// because this tree does not contain the definition, and no signature,
-/// because none was observed. Its uniform [`EntityKind::Module`] says only what
-/// this repository can prove, that the symbol is reached through a module it
-/// does not own, and keeps external targets from ever matching a local
-/// definition by kind.
+/// the same node. It carries no file origin, because this tree does not contain
+/// the definition, and no signature, because none was observed. Its uniform
+/// [`EntityKind::Module`] says only what this repository can prove, that the
+/// symbol is reached through a module it does not own, and keeps external
+/// targets from ever matching a local definition by kind.
+///
+/// Every field is derived from the target itself rather than from whichever
+/// importer happened to be walked first, so a commit that only reorders or
+/// renames unrelated files cannot restate the target and make history record a
+/// modification to a node it never touched.
 fn external_reference_targets(
     linked: &[Relation],
     entities: &BTreeMap<EntityId, Entity>,
+    fingerprints: &mut BTreeMap<EntityId, SemanticFingerprint>,
 ) -> BTreeMap<EntityId, Entity> {
-    let mut targets = BTreeMap::new();
+    // One target can be imported by several files, and in a polyglot tree those
+    // importers do not share a language. The importers are collected first so
+    // the language is chosen from all of them by a total order, because the id
+    // the linker derives excludes language: picking the first importer in walk
+    // order would let an unrelated added or renamed file change which language a
+    // target claims.
+    let mut importers: BTreeMap<EntityId, (&str, &str, Vec<LanguageId>)> = BTreeMap::new();
     for relation in linked {
         if !is_external_import_placeholder(relation) {
             continue;
@@ -380,7 +417,7 @@ fn external_reference_targets(
         let Some(destination) = relation.dst.as_entity() else {
             continue;
         };
-        if entities.contains_key(&destination) || targets.contains_key(&destination) {
+        if entities.contains_key(&destination) {
             continue;
         }
         // The placeholder contract guarantees a local source, a non-empty
@@ -395,27 +432,73 @@ fn external_reference_targets(
         ) else {
             continue;
         };
+        importers
+            .entry(destination)
+            .or_insert((import_source, symbol, Vec::new()))
+            .2
+            .push(source.language);
+    }
+
+    let mut targets = BTreeMap::new();
+    for (destination, (import_source, symbol, languages)) in importers {
+        let fingerprint = fingerprints
+            .entry(destination)
+            .or_insert_with(|| external_reference_fingerprint(import_source, symbol))
+            .clone();
+        let Some(language) = lowest_language(&languages) else {
+            continue;
+        };
         targets.insert(
             destination,
-            external_reference_entity(destination, import_source, symbol, source.language),
+            external_reference_entity(destination, symbol, language, fingerprint),
         );
     }
     targets
 }
 
+/// Choose one language from every language that reached an external target.
+///
+/// [`LanguageId`] carries no total order of its own, so the languages are
+/// ordered by their canonical names. Any total order would do; what matters is
+/// that the choice depends on the set of importing languages and on nothing
+/// else, so it holds still while that set does.
+fn lowest_language(languages: &[LanguageId]) -> Option<LanguageId> {
+    languages
+        .iter()
+        .min_by_key(|language| language.to_string())
+        .copied()
+}
+
+/// Report whether `entity` is an external reference target rather than
+/// something this repository defines.
+///
+/// Consumers of graph truth need this because such a target answers a different
+/// question than every other entity: it names a symbol reached through a module
+/// this repository does not own, so it has no file, no span, and no signature to
+/// report, and it is never the definition of anything found here.
+///
+/// The test is deliberately the conjunction of the role and the absent file
+/// origin rather than the role alone. [`EntityRole::External`] is also assigned
+/// by path classification to real, locally defined entities under `third_party/`
+/// and its siblings, and those own their source; only a target with no file
+/// origin at all stands for a definition that lives elsewhere.
+pub fn is_external_reference_target(entity: &Entity) -> bool {
+    entity.role == EntityRole::External && entity.file_origin.is_none()
+}
+
 /// Build the external target a cross-repo reference resolves against.
 fn external_reference_entity(
     id: EntityId,
-    import_source: &str,
     symbol: &str,
     language: LanguageId,
+    fingerprint: SemanticFingerprint,
 ) -> Entity {
     Entity {
         id,
         kind: EntityKind::Module,
         name: symbol.to_string(),
         language,
-        fingerprint: external_reference_fingerprint(import_source, symbol),
+        fingerprint,
         file_origin: None,
         span: None,
         signature: String::new(),

--- a/crates/kin-index/src/history.rs
+++ b/crates/kin-index/src/history.rs
@@ -13,8 +13,10 @@ use std::path::Path;
 
 use kin_blobs::BlobStore;
 use kin_model::{
-    ArtifactId, ChangeOrigin, Entity, EntityDelta, EntityId, FilePathId, ParseCompleteness,
-    Relation, RelationDelta, RelationId, ResolvedTree, SemanticChange, SemanticChangeId, TreeEntry,
+    ArtifactId, ChangeOrigin, Entity, EntityDelta, EntityId, EntityKind, EntityMetadata,
+    EntityRole, FilePathId, FingerprintAlgorithm, Hash256, LanguageId, ParseCompleteness, Relation,
+    RelationDelta, RelationId, ResolvedTree, SemanticChange, SemanticChangeId, SemanticFingerprint,
+    TreeEntry, Visibility,
 };
 use sha2::{Digest, Sha256};
 
@@ -36,7 +38,7 @@ use crate::pipeline::IndexPipeline;
 /// establish whether replay semantics actually changed, and if they did, bump
 /// this constant and the manifest's recorded version together. Never
 /// regenerate a digest silently.
-pub const HYDRATION_SEMANTICS_VERSION: u32 = 6;
+pub const HYDRATION_SEMANTICS_VERSION: u32 = 7;
 
 /// Semantic graph delta derived for one pre-enrichment change identity.
 ///
@@ -308,18 +310,14 @@ fn semantic_state_for_tree(
     parse_data.sort_by(|left, right| left.file_path.cmp(&right.file_path));
 
     let linked = link_cross_file_with_completeness(&parse_data, &artifact_ids, &completeness)?;
+    entities.extend(external_reference_targets(&linked, &entities));
     let mut relations = BTreeMap::new();
     for relation in linked {
         if let Some(absent) = absent_local_endpoint(&relation, &entities) {
             // A change carries the entity set of its own tree, so replaying it
-            // can only bind an edge whose endpoints that tree defines. The
-            // linker's cross-repo placeholder destination is absent by
-            // contract and stays a view-time inference rather than change-owned
-            // history; every other absent endpoint is inconsistent state and
-            // fails closed here instead of being admitted.
-            if absent.is_destination && is_external_import_placeholder(&relation) {
-                continue;
-            }
+            // can only bind an edge whose endpoints that tree defines. Every
+            // cross-repo destination now has one, so an absent endpoint here is
+            // inconsistent state and fails closed instead of being admitted.
             return Err(invalid(format!(
                 "linked relation {} names {} entity {} that the tree does not define",
                 relation.id,
@@ -349,6 +347,115 @@ fn semantic_state_for_tree(
 struct AbsentEndpoint {
     entity_id: EntityId,
     is_destination: bool,
+}
+
+/// Bind a graph-owned destination for every cross-repo reference the linker
+/// produced against `entities`.
+///
+/// The linker answers an import it cannot resolve locally with a deterministic
+/// placeholder destination naming the symbol another repository owns. That is
+/// the one endpoint this tree cannot supply from its own files, and a change
+/// whose relation names an entity nothing defines does not replay, so the
+/// reference used to be discarded: a freshly imported repository held no
+/// cross-repo references at all and answered every cross-repo query empty.
+///
+/// Binding an external target instead makes the reference complete,
+/// change-owned truth at the admission boundary. The target keeps the linker's
+/// deterministic identity, so every commit that observes the same import binds
+/// the same node and the fold emits no churn. It carries no file origin,
+/// because this tree does not contain the definition, and no signature,
+/// because none was observed. Its uniform [`EntityKind::Module`] says only what
+/// this repository can prove, that the symbol is reached through a module it
+/// does not own, and keeps external targets from ever matching a local
+/// definition by kind.
+fn external_reference_targets(
+    linked: &[Relation],
+    entities: &BTreeMap<EntityId, Entity>,
+) -> BTreeMap<EntityId, Entity> {
+    let mut targets = BTreeMap::new();
+    for relation in linked {
+        if !is_external_import_placeholder(relation) {
+            continue;
+        }
+        let Some(destination) = relation.dst.as_entity() else {
+            continue;
+        };
+        if entities.contains_key(&destination) || targets.contains_key(&destination) {
+            continue;
+        }
+        // The placeholder contract guarantees a local source, a non-empty
+        // import source, and exactly one evidence entry carrying the symbol.
+        let (Some(source), Some(import_source), Some(symbol)) = (
+            relation.src.as_entity().and_then(|id| entities.get(&id)),
+            relation.import_source.as_deref(),
+            relation
+                .evidence
+                .first()
+                .and_then(|evidence| evidence.token.as_deref()),
+        ) else {
+            continue;
+        };
+        targets.insert(
+            destination,
+            external_reference_entity(destination, import_source, symbol, source.language),
+        );
+    }
+    targets
+}
+
+/// Build the external target a cross-repo reference resolves against.
+fn external_reference_entity(
+    id: EntityId,
+    import_source: &str,
+    symbol: &str,
+    language: LanguageId,
+) -> Entity {
+    Entity {
+        id,
+        kind: EntityKind::Module,
+        name: symbol.to_string(),
+        language,
+        fingerprint: external_reference_fingerprint(import_source, symbol),
+        file_origin: None,
+        span: None,
+        signature: String::new(),
+        visibility: Visibility::Public,
+        role: EntityRole::External,
+        doc_summary: None,
+        metadata: EntityMetadata::default(),
+        lineage_parent: None,
+        created_in: None,
+        superseded_by: None,
+    }
+}
+
+/// Derive the fingerprint of an external target from the only two facts this
+/// repository observed about it.
+///
+/// The bodies that would produce a real fingerprint live in another repository,
+/// so every hash is domain-separated over the import source and symbol instead.
+/// That keeps one external target's identity stable across commits while
+/// keeping two different targets distinct, and it never coincides with a
+/// fingerprint computed over actual source. The stability score is zero because
+/// nothing here was measured.
+fn external_reference_fingerprint(import_source: &str, symbol: &str) -> SemanticFingerprint {
+    let digest = |domain: &str| {
+        let mut hasher = Sha256::new();
+        hasher.update(domain.as_bytes());
+        hasher.update((import_source.len() as u64).to_le_bytes());
+        hasher.update(import_source.as_bytes());
+        hasher.update((symbol.len() as u64).to_le_bytes());
+        hasher.update(symbol.as_bytes());
+        Hash256::from_bytes(hasher.finalize().into())
+    };
+    SemanticFingerprint {
+        algorithm: FingerprintAlgorithm::V1TreeSitter,
+        ast_hash: digest("kin.external-reference.ast.v1"),
+        signature_hash: digest("kin.external-reference.signature.v1"),
+        behavior_hash: digest("kin.external-reference.behavior.v1"),
+        equivalence_hash: digest("kin.external-reference.equivalence.v1"),
+        stability_score: 0.0,
+    }
 }
 
 /// Report the first entity endpoint of `relation` that `entities` does not
@@ -761,10 +868,10 @@ mod tests {
 
     /// The shape that blocked every real repository: a commit that starts
     /// calling a symbol imported from another crate. The linker answers with a
-    /// cross-repo placeholder destination that is absent from this repository's
-    /// entity set by contract, so a change carrying that edge cannot be
-    /// replayed. Admission must still bind the commit and the local call graph
-    /// around it.
+    /// cross-repo placeholder destination no local file defines, so enrichment
+    /// must bind an external target for it before the change can replay. The
+    /// commit, the local call graph around it, and the cross-repo reference
+    /// itself must all survive admission.
     ///
     /// Upstream trigger: fd b4a252a3916ab342b289331fbf49aa2db73df579, its 26th
     /// commit, which adds `extern crate isatty` and calls `stdout_isatty` from
@@ -848,6 +955,25 @@ mod tests {
                 .iter()
                 .any(|relation| relation.kind == kin_model::RelationKind::Calls),
             "the local call graph must survive"
+        );
+        let external = bound_relations
+            .iter()
+            .find(|relation| is_external_import_placeholder(relation))
+            .expect("the cross-repo reference must survive admission as change-owned truth");
+        let target = external.dst.as_entity().and_then(|id| {
+            admitted
+                .changes
+                .iter()
+                .flat_map(|change| &change.entity_deltas)
+                .filter_map(EntityDelta::new_state)
+                .find(|entity| entity.id == id)
+        });
+        let target = target.expect("the external reference must bind a destination entity");
+        assert_eq!(target.role, EntityRole::External);
+        assert_eq!(target.name, "stdout_isatty");
+        assert!(
+            target.file_origin.is_none(),
+            "an external target has no file in this repository"
         );
         for relation in &bound_relations {
             for node in [relation.src, relation.dst] {

--- a/crates/kin-index/src/lib.rs
+++ b/crates/kin-index/src/lib.rs
@@ -35,7 +35,9 @@ pub use error::{IndexError, Result};
 pub use fingerprint::{
     behavior_equivalence_hash, compute_entity_fingerprint, language_supports_equivalence,
 };
-pub use history::{derive_historical_semantic_deltas, HistoricalSemanticDelta};
+pub use history::{
+    derive_historical_semantic_deltas, is_external_reference_target, HistoricalSemanticDelta,
+};
 pub use linker::{
     build_projection_derived_relations_for_file, build_projection_derived_relations_from_markers,
     extract_projection_source_markers, link_cross_file, link_cross_file_against_entities,

--- a/crates/kin-index/tests/cross_repo_xref_admission.rs
+++ b/crates/kin-index/tests/cross_repo_xref_admission.rs
@@ -1,0 +1,290 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Firelock, LLC
+
+//! Cross-repo external references must exist in graph-owned truth the moment a
+//! brownfield repository is admitted, with no edit and no filesystem rescan in
+//! between.
+//!
+//! Two repositories are built as ordinary Git checkouts, admitted through the
+//! real capture/plan/enrich/admit pipeline, and then handed to the spine
+//! resolver exactly as the daemon hands it a captured graph. The provider side
+//! supplies the entity the consumer's unresolved import names; the consumer
+//! side must carry that import as a change-owned external-reference relation.
+
+use std::collections::BTreeMap;
+use std::ffi::OsStr;
+use std::path::Path;
+use std::process::{Command, Output};
+
+use kin_blobs::BlobStore;
+use kin_git::{
+    admit_semantic_git_import, capture_lossless_git_repository, plan_semantic_git_import,
+};
+use kin_index::{derive_historical_semantic_deltas, is_external_import_placeholder};
+use kin_model::{
+    ChangeStore, Entity, EntityDelta, Relation, RelationDelta, RepositoryId, SemanticChange,
+};
+use kin_spine::{
+    collect_unresolved_imports, materialize_edges, resolve_imports, EntityEntry, SpineIndex,
+};
+
+/// One admitted repository, reduced to the entity and relation state its
+/// first-parent history replays to.
+struct AdmittedRepository {
+    entities: Vec<Entity>,
+    relations: Vec<Relation>,
+}
+
+#[test]
+fn clean_brownfield_admission_binds_cross_repo_external_references() {
+    let root = tempfile::tempdir().unwrap();
+
+    let provider = admit_repository(
+        &root.path().join("provider"),
+        "provider",
+        &[("src/lib.rs", "pub fn do_work() -> u32 {\n    7\n}\n")],
+    );
+    let consumer = admit_repository(
+        &root.path().join("consumer"),
+        "consumer",
+        &[(
+            "src/app.rs",
+            "use provider::do_work;\n\npub fn run_task() -> u32 {\n    do_work()\n}\n",
+        )],
+    );
+
+    // The consumer's admitted history owns the external reference. Nothing has
+    // edited the checkout, and no query has re-derived it from the filesystem.
+    let external = consumer
+        .relations
+        .iter()
+        .filter(|relation| is_external_import_placeholder(relation))
+        .collect::<Vec<_>>();
+    assert!(
+        !external.is_empty(),
+        "clean admission must bind the consumer's unresolved import as an \
+         external-reference relation; admitted relations: {:?}",
+        consumer
+            .relations
+            .iter()
+            .map(|relation| (relation.kind, relation.import_source.clone()))
+            .collect::<Vec<_>>()
+    );
+    assert!(
+        external.iter().any(|relation| {
+            relation.import_source.as_deref() == Some("provider")
+                && relation
+                    .evidence
+                    .first()
+                    .and_then(|evidence| evidence.token.as_deref())
+                    == Some("do_work")
+        }),
+        "the external reference must name the import module and the real symbol"
+    );
+
+    // The spine resolver sees exactly what a daemon capture would hand it.
+    let unresolved = collect_unresolved_imports(
+        &consumer.entities,
+        &consumer.relations,
+        "consumer",
+        &["provider".to_string()],
+    );
+    assert!(
+        !unresolved.is_empty(),
+        "the admitted external reference must reach the spine as an unresolved import"
+    );
+
+    let index = SpineIndex::new();
+    index.register_repo(
+        "provider",
+        spine_entries("provider", &provider.entities),
+        "",
+    );
+    index.register_repo(
+        "consumer",
+        spine_entries("consumer", &consumer.entities),
+        "",
+    );
+
+    let resolutions = resolve_imports(&index, &unresolved);
+    assert!(
+        materialize_edges(&index, &unresolved, &resolutions) >= 1,
+        "the provider repository must resolve the consumer's admitted external reference"
+    );
+
+    let edges = index.cross_repo_edges_from("consumer");
+    let target = provider
+        .entities
+        .iter()
+        .find(|entity| entity.name == "do_work")
+        .expect("the provider repository defines do_work");
+    assert!(
+        edges
+            .iter()
+            .any(|edge| edge.dst_repo == "provider" && edge.dst_entity == target.id),
+        "a cross-repo edge must bind the consumer call to the provider definition; edges: {edges:?}"
+    );
+}
+
+/// Project admitted entities the way the daemon projects a captured graph into
+/// the spine, so the fixture exercises the production entry shape.
+fn spine_entries(repo_id: &str, entities: &[Entity]) -> Vec<EntityEntry> {
+    entities
+        .iter()
+        .map(|entity| EntityEntry {
+            repo_id: repo_id.to_string(),
+            entity_id: entity.id,
+            name: entity.name.clone(),
+            kind: entity.kind,
+            signature: entity.signature.clone(),
+            fingerprint: entity.fingerprint.clone(),
+            file_path: entity.file_origin.as_ref().map(|origin| origin.0.clone()),
+            role: Some(entity.role),
+        })
+        .collect()
+}
+
+/// Build a Git repository from `files`, admit it exactly as `kin init` does,
+/// and replay its first-parent history into entity and relation state.
+fn admit_repository(dir: &Path, repository_id: &str, files: &[(&str, &str)]) -> AdmittedRepository {
+    std::fs::create_dir_all(dir).unwrap();
+    git_ok(dir, ["init", "--quiet", "--initial-branch", "main"]);
+    git_ok(dir, ["config", "user.name", "Fixture"]);
+    git_ok(dir, ["config", "user.email", "fixture@example.invalid"]);
+    for (path, body) in files {
+        let file = dir.join(path);
+        std::fs::create_dir_all(file.parent().unwrap()).unwrap();
+        std::fs::write(&file, body).unwrap();
+    }
+    git_ok(dir, ["add", "--all"]);
+    git_ok(dir, ["commit", "--quiet", "--message", "seed"]);
+
+    let blob_store = BlobStore::new(dir.join(".fixture-cas")).unwrap();
+    let snapshot = capture_lossless_git_repository(
+        dir,
+        RepositoryId::new(repository_id).unwrap(),
+        &blob_store,
+    )
+    .unwrap();
+    let plan = plan_semantic_git_import(&snapshot, &blob_store).unwrap();
+    let trees = plan
+        .aliases
+        .iter()
+        .map(|alias| {
+            (
+                alias.change_id,
+                plan.commit_trees
+                    .get(&alias.oid)
+                    .expect("every imported commit has an exact resolved tree")
+                    .clone(),
+            )
+        })
+        .collect::<BTreeMap<_, _>>();
+    let bindings = derive_historical_semantic_deltas(&plan.changes, &trees, &blob_store)
+        .unwrap()
+        .into_iter()
+        .map(|delta| (delta.change_id, delta.entity_deltas, delta.relation_deltas))
+        .collect::<Vec<_>>();
+    let admitted = admit_semantic_git_import(
+        &plan
+            .with_historical_semantics(&blob_store, &bindings)
+            .unwrap(),
+        &blob_store,
+    )
+    .unwrap();
+    admitted.validate(&blob_store).unwrap();
+
+    // Admitted history must still replay. An external reference that made
+    // `resolve_graph_at` fail would trade a cross-repo answer for a broken
+    // history surface.
+    let graph = kin_db::InMemoryGraph::new();
+    for change in &admitted.changes {
+        graph.create_change(change).unwrap();
+    }
+    let head = admitted
+        .changes
+        .iter()
+        .map(|change| change.id)
+        .find(|candidate| {
+            !admitted
+                .changes
+                .iter()
+                .any(|change| change.parents.contains(candidate))
+        })
+        .expect("history must have a head");
+    graph
+        .resolve_graph_at(&head)
+        .expect("admitted history must replay");
+
+    replay_first_parent(&admitted.changes)
+}
+
+/// Apply every change's deltas in parent-first order, the way durable authority
+/// replay derives the state a workspace reports.
+fn replay_first_parent(changes: &[SemanticChange]) -> AdmittedRepository {
+    let mut ordered = changes.to_vec();
+    ordered.sort_by_key(|change| change.parents.len());
+
+    let mut entities = BTreeMap::new();
+    let mut relations = BTreeMap::new();
+    for change in &ordered {
+        for delta in &change.entity_deltas {
+            match delta {
+                EntityDelta::Added { new } | EntityDelta::Modified { new, .. } => {
+                    entities.insert(new.id, new.clone());
+                }
+                EntityDelta::Removed { old } => {
+                    entities.remove(&old.id);
+                }
+            }
+        }
+        for delta in &change.relation_deltas {
+            match delta {
+                RelationDelta::Added { new } | RelationDelta::Modified { new, .. } => {
+                    relations.insert(new.id, new.clone());
+                }
+                RelationDelta::Removed { old } => {
+                    relations.remove(&old.id);
+                }
+            }
+        }
+    }
+
+    AdmittedRepository {
+        entities: entities.into_values().collect(),
+        relations: relations.into_values().collect(),
+    }
+}
+
+fn git_ok<I, S>(repo: &Path, args: I)
+where
+    I: IntoIterator<Item = S>,
+    S: AsRef<OsStr>,
+{
+    let output = git_output(repo, args);
+    assert!(
+        output.status.success(),
+        "git failed ({}):\nstdout: {}\nstderr: {}",
+        output.status,
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+}
+
+fn git_output<I, S>(repo: &Path, args: I) -> Output
+where
+    I: IntoIterator<Item = S>,
+    S: AsRef<OsStr>,
+{
+    Command::new("git")
+        .args(args)
+        .current_dir(repo)
+        .env("GIT_CONFIG_NOSYSTEM", "1")
+        .env(
+            "GIT_CONFIG_GLOBAL",
+            if cfg!(windows) { "NUL" } else { "/dev/null" },
+        )
+        .env("HOME", repo)
+        .output()
+        .unwrap()
+}

--- a/crates/kin-index/tests/cross_repo_xref_admission.rs
+++ b/crates/kin-index/tests/cross_repo_xref_admission.rs
@@ -11,7 +11,7 @@
 //! supplies the entity the consumer's unresolved import names; the consumer
 //! side must carry that import as a change-owned external-reference relation.
 
-use std::collections::BTreeMap;
+use std::collections::{BTreeMap, BTreeSet};
 use std::ffi::OsStr;
 use std::path::Path;
 use std::process::{Command, Output};
@@ -52,6 +52,12 @@ fn clean_brownfield_admission_binds_cross_repo_external_references() {
             "use provider::do_work;\n\npub fn run_task() -> u32 {\n    do_work()\n}\n",
         )],
     );
+
+    // Both checkouts go away here, before a single assertion runs. Everything
+    // below is answered from admitted graph truth alone, so the claim that no
+    // query re-derives a cross-repo reference from the filesystem is what makes
+    // this test pass rather than something it merely fails to exercise.
+    drop(root);
 
     // The consumer's admitted history owns the external reference. Nothing has
     // edited the checkout, and no query has re-derived it from the filesystem.
@@ -221,13 +227,34 @@ fn admit_repository(dir: &Path, repository_id: &str, files: &[(&str, &str)]) -> 
 
 /// Apply every change's deltas in parent-first order, the way durable authority
 /// replay derives the state a workspace reports.
+///
+/// The order is derived rather than approximated by parent count, which is an
+/// all-ties no-op on a linear history and would silently produce wrong state the
+/// first time this is pointed at a repository with more than one commit. A
+/// parent outside this change set is treated as already applied, because a
+/// caller may replay a subset.
 fn replay_first_parent(changes: &[SemanticChange]) -> AdmittedRepository {
-    let mut ordered = changes.to_vec();
-    ordered.sort_by_key(|change| change.parents.len());
+    let known: BTreeSet<_> = changes.iter().map(|change| change.id).collect();
+    let mut applied = BTreeSet::new();
+    let mut ordered = Vec::with_capacity(changes.len());
+    while ordered.len() < changes.len() {
+        let next = changes
+            .iter()
+            .find(|change| {
+                !applied.contains(&change.id)
+                    && change
+                        .parents
+                        .iter()
+                        .all(|parent| !known.contains(parent) || applied.contains(parent))
+            })
+            .expect("the admitted change set must be a DAG rooted in this history");
+        applied.insert(next.id);
+        ordered.push(next);
+    }
 
     let mut entities = BTreeMap::new();
     let mut relations = BTreeMap::new();
-    for change in &ordered {
+    for change in ordered {
         for delta in &change.entity_deltas {
             match delta {
                 EntityDelta::Added { new } | EntityDelta::Modified { new, .. } => {

--- a/crates/kin-ranking/src/entity_ranking.rs
+++ b/crates/kin-ranking/src/entity_ranking.rs
@@ -9,7 +9,7 @@
 
 use std::path::Path;
 
-use kin_model::entity::{Entity, EntityKind, Visibility};
+use kin_model::entity::{Entity, EntityKind, EntityRole, Visibility};
 use kin_model::graph::GraphStore;
 use kin_model::relation::RelationKind;
 
@@ -84,6 +84,14 @@ pub fn entity_ranking_key(
 ///
 /// Queries the store by name pattern, then ranks all matches using
 /// [`entity_ranking_key`] to pick the single best result.
+///
+/// A candidate the repository holds no file for is never selected. Every caller
+/// of this function wants a declaration it can open, and an external reference
+/// target carries the imported symbol's name while standing for a definition
+/// another repository owns, so selecting one turns a clean not-found into a
+/// located answer that has no location. A repository that vendors its own copy
+/// of a dependency keeps its [`EntityRole::External`] entities eligible, because
+/// those carry real files.
 pub fn select_best_entity<G: GraphStore>(
     store: &G,
     query: &str,
@@ -94,6 +102,10 @@ pub fn select_best_entity<G: GraphStore>(
         name_pattern: Some(query.to_string()),
         ..Default::default()
     })?;
+    let matches: Vec<Entity> = matches
+        .into_iter()
+        .filter(|entity| entity.file_origin.is_some() || entity.role != EntityRole::External)
+        .collect();
     if matches.is_empty() {
         return Ok(None);
     }

--- a/crates/kin-reconcile/src/reconciler.rs
+++ b/crates/kin-reconcile/src/reconciler.rs
@@ -1492,11 +1492,19 @@ impl MergePreview {
 /// Validate an entity for semantic correctness.
 ///
 /// Returns `Some(reason)` if the entity is malformed, `None` if valid.
+///
+/// An empty signature is malformed for a declaration this repository parsed, and
+/// correct for an external reference target: that target stands for a symbol
+/// another repository owns, so no signature was ever observed and none can be.
+/// Today only freshly parsed entities reach here, so the distinction is not
+/// exercised, but the rule is stated over graph truth rather than over one
+/// caller. Rejecting an external target would fail reconcile on every repository
+/// with a cross-repo import.
 fn validate_entity(entity: &Entity) -> Option<String> {
     if entity.name.is_empty() {
         return Some("entity name is empty".to_string());
     }
-    if entity.signature.is_empty() {
+    if entity.signature.is_empty() && !kin_index::is_external_reference_target(entity) {
         return Some(format!("entity '{}' has an empty signature", entity.name));
     }
     None
@@ -2850,6 +2858,29 @@ mod tests {
     fn validate_entity_accepts_valid() {
         let entity = make_entity("test", "src/lib.rs");
         assert!(super::validate_entity(&entity).is_none());
+    }
+
+    /// An external reference target has no signature by construction, so the
+    /// empty-signature rule must be stated about declarations this repository
+    /// parsed rather than about every entity. A target still has to satisfy every
+    /// other rule.
+    #[test]
+    fn validate_entity_accepts_an_external_reference_target_without_a_signature() {
+        let mut entity = make_entity("do_work", "src/lib.rs");
+        entity.signature = String::new();
+        entity.file_origin = None;
+        entity.role = kin_model::EntityRole::External;
+        assert!(
+            kin_index::is_external_reference_target(&entity),
+            "the fixture must be the shape admission binds"
+        );
+        assert!(super::validate_entity(&entity).is_none());
+
+        entity.name = String::new();
+        assert!(
+            super::validate_entity(&entity).is_some(),
+            "an external target is not exempt from the other rules"
+        );
     }
 
     // ---------------------------------------------------------------

--- a/crates/kin-spine/src/index.rs
+++ b/crates/kin-spine/src/index.rs
@@ -563,6 +563,11 @@ impl SpineIndex {
 
     /// Resolve an entity by name and kind across all repos.
     /// Returns matches sorted by fingerprint similarity if a reference fingerprint is provided.
+    ///
+    /// Entries a repository holds with [`EntityRole::External`] are never
+    /// returned. Those stand for symbols the repository references but does not
+    /// own, so binding one as a resolution target would answer "where is this
+    /// defined" with another repository's unresolved import.
     pub fn resolve(
         &self,
         name: &str,
@@ -573,17 +578,19 @@ impl SpineIndex {
 
         let mut results = Vec::new();
 
+        let owns_definition =
+            |entry: &&EntityEntry| entry.role != Some(kin_model::EntityRole::External);
         if let Some(kind) = kind {
             let key = (name.to_lowercase(), kind);
             if let Some(entries) = inner.by_name.get(&key) {
-                results.extend(entries.iter().cloned());
+                results.extend(entries.iter().filter(owns_definition).cloned());
             }
         } else {
             // Search across all kinds
             let name_lower = name.to_lowercase();
             for ((n, _), entries) in &inner.by_name {
                 if *n == name_lower {
-                    results.extend(entries.iter().cloned());
+                    results.extend(entries.iter().filter(owns_definition).cloned());
                 }
             }
         }

--- a/crates/kin-spine/src/index.rs
+++ b/crates/kin-spine/src/index.rs
@@ -564,10 +564,17 @@ impl SpineIndex {
     /// Resolve an entity by name and kind across all repos.
     /// Returns matches sorted by fingerprint similarity if a reference fingerprint is provided.
     ///
-    /// Entries a repository holds with [`EntityRole::External`] are never
-    /// returned. Those stand for symbols the repository references but does not
-    /// own, so binding one as a resolution target would answer "where is this
-    /// defined" with another repository's unresolved import.
+    /// External reference targets are never returned. Such an entry stands for a
+    /// symbol its repository references without owning, which is what a graph
+    /// binds for an unresolved import, so returning one would answer "where is
+    /// this defined" with another repository's import and hand back a definition
+    /// site that does not exist.
+    ///
+    /// The test is the conjunction of [`EntityRole::External`] and the absent
+    /// path, because neither half identifies the shape alone. That role is also
+    /// carried by real entities a repository vendors under `third_party/` and its
+    /// siblings, which own their source and are legitimate targets, while an
+    /// absent path on its own only means no path was recorded.
     pub fn resolve(
         &self,
         name: &str,
@@ -578,8 +585,9 @@ impl SpineIndex {
 
         let mut results = Vec::new();
 
-        let owns_definition =
-            |entry: &&EntityEntry| entry.role != Some(kin_model::EntityRole::External);
+        let owns_definition = |entry: &&EntityEntry| {
+            entry.role != Some(EntityRole::External) || entry.file_path.is_some()
+        };
         if let Some(kind) = kind {
             let key = (name.to_lowercase(), kind);
             if let Some(entries) = inner.by_name.get(&key) {
@@ -1089,6 +1097,17 @@ mod tests {
         }
     }
 
+    /// The shape admission binds for a symbol another repository owns: the
+    /// imported name, no file, and the uniform kind that says only that the
+    /// symbol is reached through a module this repository does not own.
+    fn external_target_entry(repo: &str, name: &str) -> EntityEntry {
+        let mut entry = test_entry(repo, name, EntityKind::Module);
+        entry.file_path = None;
+        entry.signature = String::new();
+        entry.role = Some(EntityRole::External);
+        entry
+    }
+
     fn test_entry_with_id(repo: &str, id: EntityId, name: &str) -> EntityEntry {
         let mut entry = test_entry(repo, name, EntityKind::Function);
         entry.entity_id = id;
@@ -1405,6 +1424,54 @@ mod tests {
         let results = index.resolve("parse", Some(EntityKind::Function), None);
         assert_eq!(results.len(), 1);
         assert_eq!(results[0].repo_id, "repo-a");
+    }
+
+    /// An external reference target is registered under the repository that
+    /// imports the symbol, not the one that defines it. Two repositories
+    /// importing the same symbol from the same third party is the ordinary case,
+    /// `useState` from `react` being the obvious one, and neither repository is
+    /// the registry entry the other should resolve against: binding one would
+    /// assert the symbol is defined in a repository that only references it.
+    ///
+    /// Nothing else narrows this. Named-repo resolution never reaches it,
+    /// because the import source is not a registered repository, so resolution
+    /// falls through to name matching across every candidate repo, where the two
+    /// importers see each other.
+    #[test]
+    fn resolve_refuses_entries_that_hold_no_definition() {
+        let index = SpineIndex::new();
+        index.register_repo(
+            "repo-a",
+            vec![external_target_entry("repo-a", "useState")],
+            "hash-a",
+        );
+        index.register_repo(
+            "repo-b",
+            vec![external_target_entry("repo-b", "useState")],
+            "hash-b",
+        );
+
+        assert!(
+            index.resolve("useState", None, None).is_empty(),
+            "a repository that only imports a symbol is not where it is defined"
+        );
+        assert!(
+            index
+                .resolve("useState", Some(EntityKind::Module), None)
+                .is_empty(),
+            "the kind-narrowed path must refuse it too"
+        );
+
+        // The repository that owns the declaration is still resolved, and is the
+        // only result even though two other repositories carry the name.
+        index.register_repo(
+            "repo-c",
+            vec![test_entry("repo-c", "useState", EntityKind::Function)],
+            "hash-c",
+        );
+        let results = index.resolve("useState", None, None);
+        assert_eq!(results.len(), 1, "{results:?}");
+        assert_eq!(results[0].repo_id, "repo-c");
     }
 
     #[test]

--- a/crates/kin-spine/src/xref.rs
+++ b/crates/kin-spine/src/xref.rs
@@ -16,7 +16,9 @@
 use std::collections::HashSet;
 
 use crate::index::{fingerprint_match_score, CrossRepoEdge, EntityEntry, SpineIndex};
-use kin_model::{Entity, EntityId, EntityKind, Relation, RelationKind, SemanticFingerprint};
+use kin_model::{
+    Entity, EntityId, EntityKind, EntityRole, Relation, RelationKind, SemanticFingerprint,
+};
 
 /// A detected cross-repo import that can potentially be resolved.
 #[derive(Debug, Clone)]
@@ -361,9 +363,15 @@ fn symbol_leaf(token: &str) -> Option<String> {
 }
 
 /// Walk a repo's entity relations looking for Calls/References where:
-/// - The dst entity doesn't exist in the local entity set (external reference)
+/// - The dst is an external reference target rather than a local definition
 /// - `import_source` is set on the relation
 /// - The relation carries a real imported-symbol token in its evidence
+///
+/// A destination counts as external when the repo's graph binds it with
+/// [`EntityRole::External`], which is what admission enrichment writes for a
+/// symbol another repository owns, or when the repo's graph does not bind it at
+/// all, which is the shape graphs written before external targets were bound
+/// still carry.
 ///
 /// The imported symbol name is taken from the relation's parser/linker evidence
 /// (the symbol actually called/imported), never from the graph node label. When
@@ -377,7 +385,11 @@ pub fn collect_unresolved_imports(
     repo_id: &str,
     registry_repo_ids: &[String],
 ) -> Vec<UnresolvedImport> {
-    let local_ids: HashSet<EntityId> = entities.iter().map(|e| e.id).collect();
+    let local_ids: HashSet<EntityId> = entities
+        .iter()
+        .filter(|e| e.role != EntityRole::External)
+        .map(|e| e.id)
+        .collect();
     let entity_map: std::collections::HashMap<EntityId, &Entity> =
         entities.iter().map(|e| (e.id, e)).collect();
 

--- a/crates/kin-spine/src/xref.rs
+++ b/crates/kin-spine/src/xref.rs
@@ -367,11 +367,19 @@ fn symbol_leaf(token: &str) -> Option<String> {
 /// - `import_source` is set on the relation
 /// - The relation carries a real imported-symbol token in its evidence
 ///
-/// A destination counts as external when the repo's graph binds it with
-/// [`EntityRole::External`], which is what admission enrichment writes for a
+/// A destination counts as external when the repo's graph binds it as an
+/// external reference target, which is what admission enrichment writes for a
 /// symbol another repository owns, or when the repo's graph does not bind it at
 /// all, which is the shape graphs written before external targets were bound
 /// still carry.
+///
+/// A target is identified by carrying [`kin_model::EntityRole::External`] *and*
+/// no file of its own. Neither half identifies it alone: that role is also
+/// carried by real entities a repository vendors under `third_party/` and its
+/// siblings, which hold their own source and are local definitions for this
+/// purpose, while an absent file on its own only means no path was recorded.
+/// Either half used by itself reports a resolved local call as an unresolved
+/// cross-repo import.
 ///
 /// The imported symbol name is taken from the relation's parser/linker evidence
 /// (the symbol actually called/imported), never from the graph node label. When
@@ -387,7 +395,7 @@ pub fn collect_unresolved_imports(
 ) -> Vec<UnresolvedImport> {
     let local_ids: HashSet<EntityId> = entities
         .iter()
-        .filter(|e| e.role != EntityRole::External)
+        .filter(|e| e.role != EntityRole::External || e.file_origin.is_some())
         .map(|e| e.id)
         .collect();
     let entity_map: std::collections::HashMap<EntityId, &Entity> =

--- a/scripts/hydration-semantics-manifest.json
+++ b/scripts/hydration-semantics-manifest.json
@@ -1,6 +1,6 @@
 {
   "comment": "Replay-semantics surface pinned by scripts/verify-hydration-semantics.py. These functions re-author the entity/relation deltas persisted for historical changes during Git admission, so editing one changes what Kin reports about the past on already-ingested repositories. A digest mismatch is not a failure to fix by regenerating: decide first whether replay semantics changed, and if so bump HYDRATION_SEMANTICS_VERSION and hydration_semantics_version together.",
-  "hydration_semantics_version": 6,
+  "hydration_semantics_version": 7,
   "guarded": [
     {
       "file": "crates/kin-index/src/history.rs",
@@ -12,7 +12,7 @@
     {
       "file": "crates/kin-index/src/history.rs",
       "function": "semantic_state_for_tree",
-      "digest": "sha256:883a0ba2ac406e67a7efb59d59cae37c0d33aa6829938d20f986d19833d75cab",
+      "digest": "sha256:616979f0e3f2c5784c1f227c078d3624be96004e145c4603ec17f05c2a43d521",
       "reason": "Turns one exact resolved tree plus CAS bodies into the entity/relation state a change is diffed from and to. Its classification, parse, and cross-file linking order decide what the past is said to contain.",
       "owner": "kin-index"
     },

--- a/scripts/hydration-semantics-manifest.json
+++ b/scripts/hydration-semantics-manifest.json
@@ -1,19 +1,47 @@
 {
-  "comment": "Replay-semantics surface pinned by scripts/verify-hydration-semantics.py. These functions re-author the entity/relation deltas persisted for historical changes during Git admission, so editing one changes what Kin reports about the past on already-ingested repositories. A digest mismatch is not a failure to fix by regenerating: decide first whether replay semantics changed, and if so bump HYDRATION_SEMANTICS_VERSION and hydration_semantics_version together.",
+  "comment": "Replay-semantics surface pinned by scripts/verify-hydration-semantics.py. These functions re-author the entity/relation deltas persisted for historical changes during Git admission, so editing one changes what a repository's past is said to contain the next time that repository is admitted. A digest mismatch is not a failure to fix by regenerating: decide first whether replay semantics changed, and if so bump HYDRATION_SEMANTICS_VERSION and hydration_semantics_version together. Bumping the version records the decision; it does not migrate, invalidate, or re-enrich a repository that was already admitted, because nothing persists the version beside a graph or compares it when one is opened.",
   "hydration_semantics_version": 7,
   "guarded": [
     {
       "file": "crates/kin-index/src/history.rs",
       "function": "derive_historical_semantic_deltas",
-      "digest": "sha256:defd5579325f7b159b1aff73498622a72156c64579319d31ceec0b35f85fa2cf",
+      "digest": "sha256:8033956783d1bc36651423c022d06db20d6ef61a27ae08b318d79980f32af224",
       "reason": "Drives the whole parent-first replay: it decides the per-change baseline, which trees are enriched, and the exact EntityDelta/RelationDelta payload persisted for every historical change.",
       "owner": "kin-index"
     },
     {
       "file": "crates/kin-index/src/history.rs",
       "function": "semantic_state_for_tree",
-      "digest": "sha256:616979f0e3f2c5784c1f227c078d3624be96004e145c4603ec17f05c2a43d521",
+      "digest": "sha256:0340e3ab07f9168d00307ac4514718a00abc2115a22bb58dd805ccbb7f68e794",
       "reason": "Turns one exact resolved tree plus CAS bodies into the entity/relation state a change is diffed from and to. Its classification, parse, and cross-file linking order decide what the past is said to contain.",
+      "owner": "kin-index"
+    },
+    {
+      "file": "crates/kin-index/src/history.rs",
+      "function": "external_reference_targets",
+      "digest": "sha256:9542f2e28f43ed31d8f66c229992457570c3fc18f07fe2ed5f3d729d8ccf574a",
+      "reason": "Decides which cross-repo destinations a tree binds an external target for, and derives every field of that target from the importers it collects. Its output is persisted entity state, so a change here restates what a repository's past says about the symbols it reaches through another repository.",
+      "owner": "kin-index"
+    },
+    {
+      "file": "crates/kin-index/src/history.rs",
+      "function": "external_reference_entity",
+      "digest": "sha256:fb16c3897cb4cf6da2cfb69f72da3a7e1345112b4f6a8f6375263b09689b02bf",
+      "reason": "Authors the exact persisted shape of an external target: its kind, name, visibility, role, and the absence of a file origin, span, and signature. Every cross-repo reference in replayed history terminates on one of these.",
+      "owner": "kin-index"
+    },
+    {
+      "file": "crates/kin-index/src/history.rs",
+      "function": "external_reference_fingerprint",
+      "digest": "sha256:b30eaffff97ce12767ffce6e1432d820d741a15e4d0d9ec9f93ddbbd6fc39f94",
+      "reason": "Derives the persisted fingerprint of an external target. It is the only field distinguishing two targets that share a symbol name, so consumers read it as their identity and changing it repartitions them.",
+      "owner": "kin-index"
+    },
+    {
+      "file": "crates/kin-index/src/history.rs",
+      "function": "lowest_language",
+      "digest": "sha256:52f2ceb3fb1aa466042d056aaacc0097a76bb227b07b357a53af3d6294a83569",
+      "reason": "Chooses the persisted language of an external target from every importing language. A different choice restates the target, so history would record a modification to a node no commit touched.",
       "owner": "kin-index"
     },
     {


### PR DESCRIPTION
## What was wrong

Cross-repo external references were empty on every clean brownfield import, and the emptiness was
reported as complete authority rather than as a gap.

The cross-file linker already emits an external reference for each import that resolves to no local
file (`linker.rs make_external_reference_relation`), and it already runs at admission through
`bind_historical_semantics` -> `derive_historical_semantic_deltas`. Enrichment then discarded every
one of them, because the linker's destination names a symbol no local file defines and
`absent_local_endpoint` refuses a relation whose endpoint the admitted tree does not define.

That drop was load-bearing, not an oversight. Admitted changes are replayed by
`ChangeStore::resolve_graph_at`, whose kin-model implementation refuses a relation with an unbound
`GraphNodeId::Entity` endpoint, and kin-db resolves every admitted change during repository write
validation. Keeping the reference as it stood makes `kin init` fail on any repository with an
external import. Verified both ways against a fixture.

Downstream, the spine looks for persisted `Calls`/`References` whose destination is not a local
entity, a shape the write path could never produce, so `/spine/xref` returned empty with
`authority_complete: true`.

## What changed

Give the destination a node, so the reference is a complete edge that replays instead of an
incomplete edge that had to be thrown away.

- `kin-index/src/history.rs`: bind an external target for each cross-repo reference. It keeps the
  deterministic identity derived from the import source and symbol, so repeated observations of the
  same import bind the same node, and it carries the `External` role with no file origin and no
  signature because this repository holds no definition for it. Every field is derived from the
  target rather than from whichever importer was walked first, so a commit that only reorders or
  renames unrelated files cannot restate the target. The endpoint audit's exception is removed, so
  it now fails closed on every absent endpoint.
- `kin-spine/src/xref.rs`: cross-repo collection keys on a destination the repository holds no file
  for, and still accepts a missing destination so graphs written earlier resolve unchanged.
- `kin-spine/src/index.rs`: an entry with no file is never returned as a resolution result, so a
  repository that only references a symbol cannot be bound as the one that defines it.
- `HYDRATION_SEMANTICS_VERSION` 6 -> 7, with the four new replay functions added to the pinned
  manifest and its digests regenerated. Replay semantics change for repositories admitted after
  this lands.

## Adjudicating the consumers of graph truth

This introduces a new entity shape into persisted truth, so the readers of that truth are changed
with it rather than left to meet it.

- `kin graph validate` keyed duplicate detection on name, file, kind, and byte position. An
  external target has no file and no span, so all three discriminators collapse and two
  legitimately distinct targets sharing a symbol name read as one entity recorded twice: `use
  log::info` beside `use tracing::info` made validate print a corruption report and exit non-zero
  on a healthy graph. An entity with no span is now keyed on the fingerprint derived from its import
  source and symbol, which is the identity that actually distinguishes it. Entities that carry a
  span keep the position key exactly as before, so nothing the check used to catch stops being
  caught.
- `kin impact` resolved a name against every entity carrying it, so a repository defining `Error`
  beside a `use std::io::Error` had two exact matches. Under a structured caller's fail-closed
  resolution that returned `ambiguous` with no analysis at all. External targets are no longer
  subjects of impact analysis.
- `kin graph status` counted external targets among the entities the repository holds, diluting
  relation density, dropping documentation coverage with no change to documentation, and adding a
  fabricated bucket to the kind histogram. It also silenced the "all entities are Source" warning
  that exists to catch a broken role classifier, on every repository with an unresolved import.
  Those counters now describe the repository's own entities and external targets are reported on
  their own line.
- `kin-ranking`'s `select_best_entity` returned an external target where it previously returned
  nothing, so `kin graph source` answered "entity has no file origin" instead of a clean not-found
  and `kin refs` rendered `@ unknown`. A candidate with no file is no longer selectable.
- Both kin-spine predicates key on the absent file rather than on `EntityRole::External`. That role
  is also carried by real entities a repository vendors under `third_party/` and its siblings, which
  own their source: keying on the role would have stopped a vendored `inflate` from resolving as
  another repository's cross-repo target.

The remaining consumer, `kin locate`, spends seed slots on external targets it discards at the
file-mapping stage, so a query can return fewer files than its limit. Output stays correct and the
role multiplier bounds it; the seeding fix is filed separately.

## What is not claimed

`HYDRATION_SEMANTICS_VERSION` is a declaration, not an enforcement point. Nothing persists it beside
a graph, nothing compares it when one is opened, and no path re-derives historical deltas for a
repository that was already admitted. So this does not reach an existing graph: a repository
`kin init`-ed before this lands keeps zero external-reference relations and still answers
`/spine/xref` empty with `authority_complete: true` until it is admitted again, with no signal that
it needs re-ingestion. The dial's doc comment and the manifest comment now say so. Coupling the dial
to graph authority so a version gap can be detected and refused is filed as follow-up work.

Not proven through a live daemon: the `daemon` lane lock was held for this lane's duration, so
`kin xref` and `/spine/xref` were never exercised as HTTP surfaces. The logic is proven in-process
against the real admission pipeline and the real `SpineIndex`.

`EntityKind::Module` for an external target is a compromise. The target's real kind is unknowable
from this repository and kin-model 0.6.4 has no unknown variant, so a uniform distinctive kind was
chosen to keep external targets from matching local definitions by kind.

## Tests

- New `kin-index/tests/cross_repo_xref_admission.rs`: two real Git repositories, both admitted
  through the real capture/plan/enrich/admit pipeline with no edit in between. Both checkouts are
  dropped before the first assertion, so every claim is answered from admitted graph truth alone.
  Asserts the consumer carries an external reference naming module `provider` and symbol `do_work`,
  that the admitted history still replays through `resolve_graph_at`, and that the spine resolves a
  `CrossRepoEdge` from the consumer to the provider's real entity id.
- `graph_validate_accepts_same_named_external_targets_from_different_modules` admits a repository
  importing `info` from both `log` and `tracing` through the real admission boundary, asserts the
  two distinct targets are actually present, and asserts validate reports no duplicate and does not
  fail. Falsified against the previous key, which reported `1 true duplicate entities`.
- `graph_validate_separates_distinct_external_targets_from_duplicated_ones` pins the converse: two
  entities making the same claim about one external target are still reported.
- `resolve_refuses_entries_that_hold_no_definition` covers the spine resolution guard, which
  previously had no test and could be deleted with every test still passing. Falsified by
  neutralizing the filter.
- `calling_an_imported_external_symbol_stays_replayable` was the one test pinning the old contract.
  It now also asserts the reference survives admission, that its destination is an `External`-role
  entity with no file origin, and its stale comment is corrected.
- The fixture's replay helper derives a real parent-first order instead of sorting by parent count,
  which is an all-ties no-op on a linear history and would have silently produced wrong state the
  first time it was pointed at a multi-commit repository.

## Notes for review

kin-model 0.7.0 already defines `ExternalReference` with `GraphNodeId::ExternalReference` and
change-delta plumbing. That is the node this change approximates with an `External`-role entity
under the pinned kin-model 0.6.4. When kin adopts 0.7.x the follow-up is mechanical and strictly
better: the fabricated kind, language, and fingerprint all disappear, external targets leave the
entity surface entirely, and every consumer adjustment above becomes unnecessary.

`kin-daemon`'s `entities_to_spine_entries` publishes every graph entity into the spine, so external
targets are now registered under their referencing repository. The resolution hole that could open
is already closed inside kin-spine, but the honest projection is a one-line role filter in the
daemon. Left to the daemon lane deliberately.

Closes FIR-1612
