### PR TITLE
Report admission progress by default for init and clone

### DIFF
--- a/crates/kin-cli/src/main.rs
+++ b/crates/kin-cli/src/main.rs
@@ -1966,7 +1966,7 @@ fn main() -> Result<()> {
             .init();
     } else {
         tracing_subscriber::registry()
-            .with(default_env_filter(false))
+            .with(default_env_filter(false, &command_name))
             .with(tracing_subscriber::fmt::layer().with_writer(std::io::stderr))
             .init();
     }
@@ -3114,20 +3114,133 @@ fn env_flag(name: &str) -> bool {
         .unwrap_or(false)
 }
 
-fn default_env_filter(profile_enabled: bool) -> EnvFilter {
+/// Commands that run one long uninterruptible phase over a whole repository.
+///
+/// For everything else the default stays `warn`, because a short command that
+/// prints its own result has nothing to report in between. These two can spend
+/// hours inside a single call, and at that length no output at all is
+/// indistinguishable from a wedged process: a full-history admission was once
+/// killed after 11h43m of silence that turned out to be ordinary progress.
+const PROGRESS_REPORTING_COMMANDS: [&str; 2] = ["init", "clone"];
+
+/// Progress-bearing targets raised to `info` for [`PROGRESS_REPORTING_COMMANDS`].
+///
+/// Deliberately target-scoped rather than crate-wide. `kin_core=info` would also
+/// surface every unrelated event those crates emit, which is how a default
+/// filter becomes noise nobody reads. Add a target here only when it reports
+/// admission or validation progress.
+///
+/// The two `kin_core` modules hold three event callsites between them, none in a
+/// loop, so they contribute at most three lines to an admission. The KinDB
+/// target reports periodic replay progress and is throttled at its source; it
+/// stays inert until this workspace depends on a KinDB that emits it, because a
+/// directive naming an absent target simply never matches.
+const ADMISSION_PROGRESS_TARGETS: [&str; 3] = [
+    "kin_core::init",
+    "kin_core::git_init",
+    "kin_db::storage::history_replay",
+];
+
+fn default_env_filter(profile_enabled: bool, command: &str) -> EnvFilter {
     if std::env::var_os("RUST_LOG").is_some() {
-        EnvFilter::from_default_env()
-    } else if profile_enabled {
-        EnvFilter::new("info")
-    } else {
-        EnvFilter::new("warn")
+        return EnvFilter::from_default_env();
     }
+    EnvFilter::new(default_filter_directives(profile_enabled, command))
+}
+
+/// The directive string [`default_env_filter`] would install, absent `RUST_LOG`.
+///
+/// Split out so the choice is testable without mutating process environment,
+/// which no test can do without racing every other test in the binary.
+fn default_filter_directives(profile_enabled: bool, command: &str) -> String {
+    if profile_enabled {
+        return "info".to_string();
+    }
+    if !PROGRESS_REPORTING_COMMANDS.contains(&command) {
+        return "warn".to_string();
+    }
+    let mut directives = String::from("warn");
+    for target in ADMISSION_PROGRESS_TARGETS {
+        directives.push(',');
+        directives.push_str(target);
+        directives.push_str("=info");
+    }
+    directives
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
     use clap::CommandFactory;
+
+    /// A long admission must report progress without `RUST_LOG` being set.
+    #[test]
+    fn progress_reporting_commands_raise_admission_targets_to_info() {
+        for command in PROGRESS_REPORTING_COMMANDS {
+            let directives = default_filter_directives(false, command);
+            assert!(
+                directives.starts_with("warn"),
+                "{command} must keep warn as its floor: {directives}"
+            );
+            for target in ADMISSION_PROGRESS_TARGETS {
+                assert!(
+                    directives.contains(&format!("{target}=info")),
+                    "{command} must report {target} progress: {directives}"
+                );
+            }
+        }
+    }
+
+    /// Ordinary commands print their own result, so raising them would only add
+    /// noise to every invocation.
+    #[test]
+    fn ordinary_commands_keep_the_quiet_default() {
+        for command in ["locate", "commit", "status", "log", "help"] {
+            assert!(
+                !PROGRESS_REPORTING_COMMANDS.contains(&command),
+                "{command} is not a long single-phase command"
+            );
+            assert_eq!(
+                default_filter_directives(false, command),
+                "warn",
+                "{command} must stay quiet by default"
+            );
+        }
+    }
+
+    #[test]
+    fn profiling_still_raises_everything_to_info() {
+        for command in ["init", "locate"] {
+            assert_eq!(default_filter_directives(true, command), "info");
+        }
+    }
+
+    /// A malformed directive is silently dropped by `EnvFilter`, which would
+    /// disable progress reporting while every other test still passed. Parse the
+    /// exact string the binary installs and require each target to survive.
+    #[test]
+    fn every_default_directive_parses_and_is_retained() {
+        for (profile, command) in [
+            (false, "init"),
+            (false, "clone"),
+            (false, "locate"),
+            (true, "init"),
+        ] {
+            let directives = default_filter_directives(profile, command);
+            let filter = tracing_subscriber::filter::EnvFilter::builder()
+                .parse(&directives)
+                .unwrap_or_else(|error| {
+                    panic!("default directives {directives:?} must parse: {error}")
+                });
+            let rendered = filter.to_string();
+            for directive in directives.split(',') {
+                assert!(
+                    rendered.contains(directive),
+                    "directive {directive:?} was dropped from {rendered:?}"
+                );
+            }
+        }
+    }
 
     fn on_cli_test_stack(test: impl FnOnce() + Send + 'static) {
         std::thread::Builder::new()

--- a/crates/kin-cli/src/main.rs
+++ b/crates/kin-cli/src/main.rs
@@ -1966,7 +1966,7 @@ fn main() -> Result<()> {
             .init();
     } else {
         tracing_subscriber::registry()
-            .with(default_env_filter(false, &command_name))
+            .with(default_env_filter(&command_name))
             .with(tracing_subscriber::fmt::layer().with_writer(std::io::stderr))
             .init();
     }
@@ -3123,39 +3123,53 @@ fn env_flag(name: &str) -> bool {
 /// killed after 11h43m of silence that turned out to be ordinary progress.
 const PROGRESS_REPORTING_COMMANDS: [&str; 2] = ["init", "clone"];
 
-/// Progress-bearing targets raised to `info` for [`PROGRESS_REPORTING_COMMANDS`].
+/// Admission targets raised to `info` for [`PROGRESS_REPORTING_COMMANDS`].
 ///
 /// Deliberately target-scoped rather than crate-wide. `kin_core=info` would also
 /// surface every unrelated event those crates emit, which is how a default
-/// filter becomes noise nobody reads. Add a target here only when it reports
-/// admission or validation progress.
+/// filter becomes noise nobody reads.
 ///
-/// The two `kin_core` modules hold three event callsites between them, none in a
-/// loop, so they contribute at most three lines to an admission. The KinDB
-/// target reports periodic replay progress and is throttled at its source; it
-/// stays inert until this workspace depends on a KinDB that emits it, because a
-/// directive naming an absent target simply never matches.
+/// What each target actually delivers today, because the difference matters to
+/// anyone watching a long run:
+///
+/// - `kin_core::init` and `kin_core::git_init` carry three callsites between
+///   them, and all three are **terminal**: two report a completed admission and
+///   one reports recovered stale initialization stages. They add at most three
+///   lines, and none of them appears mid-flight. They are enabled so the
+///   admission surfaces its own outcome and so no further `kin-cli` change is
+///   needed later.
+/// - `kin_db::storage::history_replay` is the only periodic emitter, throttled
+///   at its source. It does not exist in the KinDB this workspace currently
+///   pins, and a directive naming an absent target simply never matches, so it
+///   is pre-wired and inert.
+///
+/// So a long admission does **not** report mid-flight progress at this version.
+/// It begins to the moment this workspace consumes a KinDB shipping
+/// `storage::history_replay`, with no change here. Anyone diagnosing an
+/// apparently stalled `kin init` before then should not read silence as
+/// evidence that the instrumentation ran.
 const ADMISSION_PROGRESS_TARGETS: [&str; 3] = [
     "kin_core::init",
     "kin_core::git_init",
     "kin_db::storage::history_replay",
 ];
 
-fn default_env_filter(profile_enabled: bool, command: &str) -> EnvFilter {
+fn default_env_filter(command: &str) -> EnvFilter {
     if std::env::var_os("RUST_LOG").is_some() {
         return EnvFilter::from_default_env();
     }
-    EnvFilter::new(default_filter_directives(profile_enabled, command))
+    EnvFilter::new(default_filter_directives(command))
 }
 
 /// The directive string [`default_env_filter`] would install, absent `RUST_LOG`.
 ///
 /// Split out so the choice is testable without mutating process environment,
 /// which no test can do without racing every other test in the binary.
-fn default_filter_directives(profile_enabled: bool, command: &str) -> String {
-    if profile_enabled {
-        return "info".to_string();
-    }
+///
+/// Profiling is deliberately absent here. That path installs its own subscriber
+/// with no `EnvFilter` at all, so it never reaches this function; carrying a
+/// `profile_enabled` branch would only invite a test that proves a dead arm.
+fn default_filter_directives(command: &str) -> String {
     if !PROGRESS_REPORTING_COMMANDS.contains(&command) {
         return "warn".to_string();
     }
@@ -3173,11 +3187,12 @@ mod tests {
     use super::*;
     use clap::CommandFactory;
 
-    /// A long admission must report progress without `RUST_LOG` being set.
+    /// The admission commands must carry every configured target without
+    /// `RUST_LOG` being set.
     #[test]
     fn progress_reporting_commands_raise_admission_targets_to_info() {
         for command in PROGRESS_REPORTING_COMMANDS {
-            let directives = default_filter_directives(false, command);
+            let directives = default_filter_directives(command);
             assert!(
                 directives.starts_with("warn"),
                 "{command} must keep warn as its floor: {directives}"
@@ -3221,17 +3236,10 @@ mod tests {
                 "{command} is not a long single-phase command"
             );
             assert_eq!(
-                default_filter_directives(false, command),
+                default_filter_directives(command),
                 "warn",
                 "{command} must stay quiet by default"
             );
-        }
-    }
-
-    #[test]
-    fn profiling_still_raises_everything_to_info() {
-        for command in ["init", "locate"] {
-            assert_eq!(default_filter_directives(true, command), "info");
         }
     }
 
@@ -3240,13 +3248,8 @@ mod tests {
     /// exact string the binary installs and require each target to survive.
     #[test]
     fn every_default_directive_parses_and_is_retained() {
-        for (profile, command) in [
-            (false, "init"),
-            (false, "clone"),
-            (false, "locate"),
-            (true, "init"),
-        ] {
-            let directives = default_filter_directives(profile, command);
+        for command in ["init", "clone", "locate", "help"] {
+            let directives = default_filter_directives(command);
             let filter = tracing_subscriber::filter::EnvFilter::builder()
                 .parse(&directives)
                 .unwrap_or_else(|error| {

--- a/crates/kin-cli/src/main.rs
+++ b/crates/kin-cli/src/main.rs
@@ -3191,6 +3191,26 @@ mod tests {
         }
     }
 
+    /// The filter is keyed on the clap subcommand name, so a renamed command
+    /// would silently stop reporting progress with every other test still green.
+    /// This CLI does rename subcommands, so pin the names against clap itself.
+    #[test]
+    fn progress_reporting_commands_are_real_subcommands() {
+        on_cli_test_stack(|| {
+            let command = Cli::command();
+            let known: Vec<String> = command
+                .get_subcommands()
+                .map(|sub| sub.get_name().to_string())
+                .collect();
+            for expected in PROGRESS_REPORTING_COMMANDS {
+                assert!(
+                    known.iter().any(|name| name == expected),
+                    "{expected:?} is not a kin subcommand; known: {known:?}"
+                );
+            }
+        });
+    }
+
     /// Ordinary commands print their own result, so raising them would only add
     /// noise to every invocation.
     #[test]


### PR DESCRIPTION
## Summary

`kin-cli` installed `EnvFilter::new("warn")` as the default for every command, so nothing emitted at `info` reached the user unless they happened to set `RUST_LOG`. That discards admission output wholesale, including the periodic replay progress KinDB is gaining.

- make `default_env_filter` command-aware, and split the directive choice into a pure `default_filter_directives` function
- raise only admission targets, and only for `init` and `clone`
- leave every other command on the quiet default, since a short command prints its own result and has nothing to report in between

`RUST_LOG` still wins outright. Profiling is unaffected because that path installs its own subscriber with no `EnvFilter` and never reaches this function.

## What this delivers, and what it does not yet

Being precise about this, because the failure mode it guards against is someone reading silence as a wedged process:

- The two `kin_core` targets carry three callsites between them, and all three are **terminal**: two report a completed admission (`init.rs:426`, `git_init.rs:315`) and one reports recovered stale initialization stages (`init.rs:2088`). They add at most three lines, and **none of them fires mid-flight**.
- `kin_db::storage::history_replay` is the only periodic emitter. It does not exist in the KinDB this workspace pins, and a directive naming an absent target never matches, so it is **pre-wired and inert**.

**So a long admission does not report mid-flight progress at this version.** It begins to the moment this workspace consumes a KinDB shipping `storage::history_replay`, with no further change here. Until then, silence during a long `kin init` is not evidence that instrumentation ran. The doc comment on `ADMISSION_PROGRESS_TARGETS` says the same thing at the code.

What the change buys now is that the admission surfaces its own outcome, and that the wiring is in place so the periodic emitter needs no second kin-cli change to become visible.

## Why this shape

A crate-wide `kin_core=info,kin_db=info` was rejected: it surfaces every unrelated event those crates emit, and grows silently as either crate adds logging. A dedicated progress target that emitters opt into is the better long-term shape, but it needs edits in the emitting crates rather than here, so it is left as a follow-up.

## Verification

Four tests in the existing `kin-cli` test module, two of which exist because this feature can fail silently:

- `progress_reporting_commands_are_real_subcommands` pins each configured name against clap's own command tree. The filter is keyed on the subcommand name, so a rename would stop reporting with every other test green, and this CLI does rename subcommands (`#[command(name = "locate-debug")]`).
- `every_default_directive_parses_and_is_retained` parses the exact string the binary installs and requires every directive to survive, because `EnvFilter` drops a malformed directive silently. It asserts on the parsed filter's rendering, not on the input.
- `progress_reporting_commands_raise_admission_targets_to_info` and `ordinary_commands_keep_the_quiet_default` cover the two live branches.

Known limits, recorded rather than hidden. No test can verify that a target string names a module that exists; `kin_core::innit=info` parses, survives, and matches nothing. That is unverifiable from `kin-cli`, which cannot introspect another crate's module paths, and it is the strongest argument for the dedicated-target follow-up. The three current targets were verified by reading the emitting files. Nothing asserts that `main()` passes the real command name either; guarding that needs a subprocess stderr assertion, which is heavier than the risk warrants.

`RUST_LOG` precedence is covered by construction rather than by a test, deliberately: asserting it requires mutating process environment, which races every other test in the binary.

MCP stdio hygiene is sound on two independent grounds: the single `fmt::layer()` in the binary writes to stderr (`main.rs:1970`), and the MCP stdio server is `Command::Mcp`, which is not in the raised set and keeps `warn` unchanged. `kin init --json` also stays pure JSON on stdout, since every added line goes to stderr.

Gates, re-run after the final edit:

- `cargo fmt --check`: clean
- `cargo clippy --all-targets --all-features` with the ci.yml allowlist under `RUSTFLAGS=-D warnings`: clean
- `cargo build --all-targets`: ok
- `cargo test --workspace`: 40 test binaries ok, 0 failures

## Scope

One file, `crates/kin-cli/src/main.rs`. No MCP handler, daemon lifecycle, or CI file touched.

Progresses FIR-1694 (ticket stays open per its acceptance-boundary comment: mid-flight progress requires the kin-db storage::history_replay consumption)