### PR TITLE
Run required CI contexts on merge queue groups

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,6 +8,7 @@ on:
     branches: [main]
   pull_request:
     branches: [main]
+  merge_group:
   repository_dispatch:
     types: [dependency-updated]
 
@@ -288,6 +289,7 @@ jobs:
     if: >-
       ${{ !cancelled()
       && github.event_name != 'pull_request'
+      && github.event_name != 'merge_group'
       && needs.changes.outputs.docs_only != 'true' }}
     runs-on: windows-latest
     timeout-minutes: 60

--- a/.github/workflows/sast.yml
+++ b/.github/workflows/sast.yml
@@ -8,6 +8,7 @@ on:
     branches: [main]
   pull_request:
     branches: [main]
+  merge_group:
 
 permissions:
   contents: read

--- a/scripts/test-release-workflow-authority.py
+++ b/scripts/test-release-workflow-authority.py
@@ -193,6 +193,7 @@ DOCS_ONLY_WORKFLOW_HEADER = textwrap.dedent(
         branches: [main]
       pull_request:
         branches: [main]
+      merge_group:
       repository_dispatch:
         types: [dependency-updated]
     permissions:


### PR DESCRIPTION
## What changed

- `ci.yml` and `sast.yml` gain the `merge_group:` trigger so every required context (Check & Test ubuntu/macos, DCO Sign-off, cargo-deny) reports on the merge queue's speculative merge commits.
- The Windows installer leg additionally excludes `merge_group`, preserving its deliberate push-to-main-only posture: it reports skipped in the queue exactly as it does on pull requests, and release-tag proof still reads the check from the main sha.
- `secret-scan.yml` needs no change: its `push: branches: ["**"]` already fires on `gh-readonly-queue/**` branches, so the required gitleaks context reports on queue SHAs.
- The `changes` diff classifier already treats any non-pull_request event as full validation, so queue runs never take the docs-only fast path.

Inert until a merge-queue ruleset is enabled on this repo; no behavior changes for pull_request or push runs.

Part of the fleet merge-queue rollout under FIR-1647.