### PR TITLE
Decide test exclusion from cfg predicates and narrow the spawn crate to pins

### DIFF
--- a/crates/kin-cli/src/commands/setup.rs
+++ b/crates/kin-cli/src/commands/setup.rs
@@ -14043,6 +14043,7 @@ expect_workspace "$TEST_ALIASED_SESSION_START" "$TEST_ALIASED_SESSION_PHYSICAL" 
     }
 
     #[test]
+    #[serial]
     fn codex_relative_repo_binding_uses_entry_cwd_not_process_cwd() {
         let dir = tempfile::tempdir().unwrap();
         let repo_a = dir.path().join("repo-a");
@@ -14836,6 +14837,7 @@ expect_workspace "$TEST_ALIASED_SESSION_START" "$TEST_ALIASED_SESSION_PHYSICAL" 
     }
 
     #[test]
+    #[serial]
     fn config_transaction_test_authority_normalizes_relative_nonexistent_paths() {
         let current = env::current_dir().unwrap();
         let fixture = tempfile::Builder::new()

--- a/scripts/falsify-zero-file-search.py
+++ b/scripts/falsify-zero-file-search.py
@@ -22,6 +22,21 @@ lexical awareness reads as an unclosed body before excusing the rest of the
 file. The other pays for a real filesystem probe with a rename in test code the
 guard never reads, which is what a pin counted over the raw file will accept.
 
+The widest exemption of all is a whole file, and it has no falsification history
+by construction: nothing is scanned there, so no probe can fail. A module
+narrowed out of that state is probed across its production region here, and a
+body exemption reground onto a pin is probed inside the body it used to excuse.
+
+Which lines count as production is itself a policy decision, and the tracker
+that made it keyed on the literal string `mod tests`. The cfg probes exercise
+each spelling separately, including the ones that mention `test` and still
+compile in production, and each carries a control the scan must always report so
+a silent guard cannot pass for a correctly excluded item.
+
+Every probe asks whether the SCAN reported the file, not whether the tool exited
+nonzero. An allowlist error also exits nonzero and also prints the path it
+complains about, and that failure mode is exactly the one that masks the scan.
+
 The enforced-module list is read from the guard itself rather than restated
 here. A module added to the guard's coverage is falsified automatically, and
 this harness cannot quietly fall behind what the guard claims to cover.
@@ -146,6 +161,134 @@ SLACK_PROBE = (
 # A rename inside a test module: routine, invisible to the guard, and the offset
 # that used to pay for the probe above.
 SLACK_TEST_REPLACEMENT = ".authority_metadata()"
+
+# Modules that were exempt as whole files and are now scanned around pinned
+# expressions. A whole-file exemption is the widest gap the policy can have and
+# the quietest: the guard's summary line and exit status are identical whether
+# the file is a boundary end to end or has grown a raw source read since anyone
+# looked. Narrowing one is only worth as much as the proof that the file is
+# actually scanned now, so each is probed across its production region.
+NARROWED_MODULES = ["crates/kin-daemon-spawn/src/lib.rs"]
+
+# (module, function, pinned expression) for bodies that were exempt by name and
+# are now covered by a pin on the primitive instead. The pin masks two `.exists()`
+# calls; the twenty-four lines around them must be scanned again, which is the
+# whole difference between the two grains. Poison goes just inside the body, on a
+# line that is not the pinned one.
+REGROUND_PINS = [
+    ("crates/kin-daemon/src/daemon.rs", "repository_root_missing", ".exists()"),
+    ("crates/kin-daemon/src/daemon.rs", "classify_control_plane", ".exists()"),
+]
+
+# The cfg tracker decides which items are production code, and it decided it by
+# naming convention: the attribute line armed and disarmed in the same iteration,
+# so only a following literal `mod tests` kept the exclusion alive. Every entry
+# here is a spelling that decision got wrong or could get wrong, and the marker
+# is placed in the violating line's own text so the guard's report distinguishes
+# them. `expect` is the set of markers the scan must report; every probe also
+# carries a control the scan must always report, so "the guard stayed silent
+# because it is broken" cannot pass as "the item was correctly excluded".
+TRACKER_CONTROL = "__tracker_control_path"
+
+
+def tracker_read(marker):
+    return f"    let _ = std::fs::read_to_string({marker}).unwrap();"
+
+
+TRACKER_PROBES = [
+    (
+        "cfg(test) fn",
+        "#[cfg(test)]\nfn __tracker_gated_fn() {\n"
+        + tracker_read("__tracker_cfg_test_fn")
+        + "\n}",
+        [("__tracker_cfg_test_fn", False)],
+    ),
+    (
+        "cfg(test) mod, unconventional name",
+        "#[cfg(test)]\nmod __tracker_ingest_cas_tests {\n    fn probe() {\n"
+        + tracker_read("__tracker_cfg_test_mod")
+        + "\n    }\n}",
+        [("__tracker_cfg_test_mod", False)],
+    ),
+    (
+        "cfg(all(test, unix))",
+        "#[cfg(all(test, unix))]\nfn __tracker_all_gated() {\n"
+        + tracker_read("__tracker_cfg_all_test")
+        + "\n}",
+        [("__tracker_cfg_all_test", False)],
+    ),
+    (
+        "cfg(any(unix, test)) stays scanned",
+        "#[cfg(any(unix, test))]\nfn __tracker_any_gated() {\n"
+        + tracker_read("__tracker_cfg_any_test")
+        + "\n}",
+        [("__tracker_cfg_any_test", True)],
+    ),
+    (
+        "cfg(not(test)) stays scanned",
+        "#[cfg(not(test))]\nfn __tracker_not_gated() {\n"
+        + tracker_read("__tracker_cfg_not_test")
+        + "\n}",
+        [("__tracker_cfg_not_test", True)],
+    ),
+    (
+        "cfg_attr(not(test), ..) gates nothing",
+        "#[cfg_attr(not(test), allow(dead_code))]\nfn __tracker_cfg_attr() {\n"
+        + tracker_read("__tracker_cfg_attr_test")
+        + "\n}",
+        [("__tracker_cfg_attr_test", True)],
+    ),
+    (
+        "#[test] fn",
+        "#[test]\nfn __tracker_test_attr() {\n"
+        + tracker_read("__tracker_test_attribute")
+        + "\n}",
+        [("__tracker_test_attribute", False)],
+    ),
+    (
+        "#[tokio::test] fn",
+        '#[tokio::test(flavor = "multi_thread")]\nasync fn __tracker_tokio_test() {\n'
+        + tracker_read("__tracker_tokio_attribute")
+        + "\n}",
+        [("__tracker_tokio_attribute", False)],
+    ),
+    (
+        "exclusion ends at the gated item",
+        "#[cfg(test)]\nmod __tracker_bounded {\n    fn probe() {\n"
+        + tracker_read("__tracker_inside_bound")
+        + "\n    }\n}\nfn __tracker_next_item() {\n"
+        + tracker_read("__tracker_after_bound")
+        + "\n}",
+        [("__tracker_inside_bound", False), ("__tracker_after_bound", True)],
+    ),
+    (
+        "a literal brace cannot widen the exclusion",
+        "#[cfg(test)]\nfn __tracker_brace_gated() {\n"
+        + '    let _template = "{";\n'
+        + tracker_read("__tracker_inside_brace")
+        + "\n}\nfn __tracker_after_brace() {\n"
+        + tracker_read("__tracker_after_brace_probe")
+        + "\n}",
+        [("__tracker_inside_brace", False), ("__tracker_after_brace_probe", True)],
+    ),
+    (
+        "a gated struct field excludes nothing",
+        "struct __TrackerFields {\n    #[cfg(test)]\n    probe: bool,\n}\n"
+        + "fn __tracker_after_field() {\n"
+        + tracker_read("__tracker_after_field_probe")
+        + "\n}",
+        [("__tracker_after_field_probe", True)],
+    ),
+    (
+        "cfg(test) macro_rules",
+        "#[cfg(test)]\nmacro_rules! __tracker_gated_macro {\n    () => {\n"
+        + tracker_read("__tracker_inside_macro")
+        + "\n    };\n}\nfn __tracker_after_macro() {\n"
+        + tracker_read("__tracker_after_macro_probe")
+        + "\n}",
+        [("__tracker_inside_macro", False), ("__tracker_after_macro_probe", True)],
+    ),
+]
 
 
 def load_guard(root):
@@ -344,6 +487,21 @@ def run(cmd):
     return result.returncode, result.stdout + result.stderr
 
 
+def scan_reported(out, rel):
+    """Whether the Python guard's SCAN reported this file.
+
+    A nonzero exit is not evidence the scan ran, and neither is the file's name
+    appearing in the output: an allowlist error also exits nonzero and also
+    prints the path it is complaining about. Only the scan prints the
+    `[VIOLATION] <path>` header, so that is what a probe has to look for. This
+    matters because the two failure modes read identically from outside and one
+    of them masks the other: a stale pin once reported itself while ten real
+    violations in a newly covered crate went unmentioned, and a probe satisfied
+    by "exit code was 1 and the basename appeared" would have called that a pass.
+    """
+    return f"[VIOLATION] {rel}" in out
+
+
 def main():
     if len(sys.argv) != 2:
         print(__doc__)
@@ -403,11 +561,19 @@ def main():
                         cell.append("-")
                         continue
                     code, out = run(cmd)
+                    named = (
+                        scan_reported(out, rel)
+                        if tag == "py"
+                        else os.path.basename(rel) in out
+                    )
                     if code == 0:
                         failures.append(f"{rel} @ {label}: {tag} guard PASSED on a poisoned tree")
                         cell.append("BLIND")
-                    elif os.path.basename(rel) not in out:
-                        failures.append(f"{rel} @ {label}: {tag} guard failed but never named the file")
+                    elif not named:
+                        failures.append(
+                            f"{rel} @ {label}: {tag} guard failed but its scan never "
+                            "reported the file"
+                        )
                         cell.append("UNNAMED")
                     else:
                         cell.append("ok")
@@ -416,6 +582,143 @@ def main():
             with open(path, "w", encoding="utf-8") as f:
                 f.write(original)
         print(f"  {os.path.basename(rel):24} {'  '.join(marks)}")
+
+    # A module that was whole-file exempt has no falsification history at all:
+    # nothing was ever scanned there, so no probe could fail. Prove the narrowed
+    # policy across the production region, at the same four sites the answer
+    # modules get, and require the SCAN to report it rather than settling for a
+    # nonzero exit.
+    for rel in NARROWED_MODULES:
+        path = os.path.join(root, rel)
+        if not os.path.isfile(path):
+            failures.append(f"{rel}: narrowed-module falsification target is missing")
+            continue
+        with open(path, "r", encoding="utf-8") as f:
+            original = f.read()
+        lines = original.split("\n")
+        marks = []
+        try:
+            for label, idx in probe_sites(lines):
+                poisoned = lines[:idx] + [POISON] + lines[idx:]
+                with open(path, "w", encoding="utf-8") as f:
+                    f.write("\n".join(poisoned))
+                code, out = run([sys.executable, py_guard, root])
+                if code == 0:
+                    failures.append(
+                        f"{rel} @ {label}: guard PASSED on a poisoned tree that was "
+                        "whole-file exempt before this policy was narrowed"
+                    )
+                    marks.append(f"{label}=BLIND")
+                elif not scan_reported(out, rel):
+                    failures.append(
+                        f"{rel} @ {label}: guard failed but the scan never reported "
+                        "the file"
+                    )
+                    marks.append(f"{label}=UNNAMED")
+                else:
+                    marks.append(f"{label}=ok")
+        finally:
+            with open(path, "w", encoding="utf-8") as f:
+                f.write(original)
+        print(f"  narrowed {os.path.basename(rel):15} {'  '.join(marks)}")
+
+    # A pin on a primitive replaced two function-body exemptions. The bodies are
+    # scanned again, which is the only reason the trade is worth making, so
+    # poison each one on a line that is not the pinned one and require the report.
+    # An exemption that had regressed to whole-body would swallow this silently.
+    for rel, fn_name, pin in REGROUND_PINS:
+        path = os.path.join(root, rel)
+        with open(path, "r", encoding="utf-8") as f:
+            original = f.read()
+        lines = original.split("\n")
+        span = fn_body_span(lines, fn_name)
+        if span is None:
+            failures.append(f"{rel}: could not locate {fn_name} to falsify")
+            continue
+        if pin not in "\n".join(lines[span[0] : span[1] + 1]):
+            failures.append(
+                f"{rel}: {fn_name} no longer contains the pinned {pin!r}, so the "
+                "reground pin no longer covers it"
+            )
+            continue
+        try:
+            poisoned = lines[: span[0] + 1] + [POISON] + lines[span[0] + 1 :]
+            with open(path, "w", encoding="utf-8") as f:
+                f.write("\n".join(poisoned))
+            code, out = run([sys.executable, py_guard, root])
+            mark = "ok"
+            if code == 0 or not scan_reported(out, rel):
+                failures.append(
+                    f"{rel}: poison inside {fn_name} was not reported, so that body "
+                    "is still exempt in whole rather than covered by a pin"
+                )
+                mark = "BLIND"
+            print(f"  reground pin {fn_name:26} {mark}")
+        finally:
+            with open(path, "w", encoding="utf-8") as f:
+                f.write(original)
+
+    # Which items are production code is a policy decision, and the tracker used
+    # to make it by naming convention. Each probe below is one cfg spelling, with
+    # a control the scan must always report so silence cannot pass for exclusion.
+    #
+    # Every probe's markers are unique, so the whole table is planted in one run
+    # and each expectation read out of the same output. That is one guard run
+    # instead of eleven, which matters because the guard walks every crate and
+    # this harness already runs it well over a hundred times. The cost of batching
+    # is attribution: an over-wide exclusion in one snippet would surface as a
+    # missing marker in a later one. So a batch that fails is replayed one probe
+    # at a time, which localises it exactly, and only a failing run pays for that.
+    tracker_rel = f"{CMD_DIR}/search.rs"
+    tracker_path = os.path.join(root, tracker_rel)
+    with open(tracker_path, "r", encoding="utf-8") as f:
+        tracker_original = f.read()
+    control = (
+        "fn __tracker_control() {\n"
+        f"    let _ = std::fs::read_to_string({TRACKER_CONTROL}).unwrap();\n"
+        "}"
+    )
+
+    def tracker_verdicts(probes):
+        """Plant `probes` together and return {label: mark} for the one run."""
+        body = "".join(f"\n{snippet}\n" for _, snippet, _ in probes)
+        with open(tracker_path, "w", encoding="utf-8") as handle:
+            handle.write(tracker_original + body + "\n" + control + "\n")
+        code, out = run([sys.executable, py_guard, root])
+        if code == 0 or TRACKER_CONTROL not in out:
+            return {label: "NOCONTROL" for label, _, _ in probes}
+        verdicts = {}
+        for label, _, expectations in probes:
+            mark = "ok"
+            for marker, want_reported in expectations:
+                if want_reported and marker not in out:
+                    mark = "MISSED"
+                elif not want_reported and marker in out:
+                    mark = "SPURIOUS"
+            verdicts[label] = mark
+        return verdicts
+
+    EXPLAIN = {
+        "NOCONTROL": "the control probe was not reported, so the run proves "
+        "nothing about the gated items",
+        "MISSED": "an item that is production code was not reported",
+        "SPURIOUS": "an item that exists only in a test build was reported as "
+        "production",
+    }
+    try:
+        verdicts = tracker_verdicts(TRACKER_PROBES)
+        if any(mark != "ok" for mark in verdicts.values()):
+            verdicts = {}
+            for probe in TRACKER_PROBES:
+                verdicts.update(tracker_verdicts([probe]))
+        for label, _, _ in TRACKER_PROBES:
+            mark = verdicts[label]
+            if mark != "ok":
+                failures.append(f"tracker probe {label!r}: {EXPLAIN[mark]}")
+            print(f"  cfg tracker {label:38} {mark}")
+    finally:
+        with open(tracker_path, "w", encoding="utf-8") as f:
+            f.write(tracker_original)
 
     # An expression pin must exempt only its own bytes, not the entire source
     # line. Poison every pinned line while retaining the allowed expression on
@@ -465,10 +768,10 @@ def main():
                 )
             else:
                 for rel in pinned:
-                    if os.path.basename(rel) not in out:
+                    if not scan_reported(out, rel):
                         failures.append(
                             f"{rel}: Python same-line falsification failed but "
-                            "the guard never named the file"
+                            "the scan never reported the file"
                         )
             print(
                 "  pinned same-line poison   "
@@ -559,7 +862,7 @@ def main():
                 with open(path, "w", encoding="utf-8") as f:
                     f.write("\n".join(poisoned))
                 code, out = run([sys.executable, py_guard, root])
-                named = base in out
+                named = scan_reported(out, rel)
                 if want_named and not named:
                     failures.append(
                         f"{rel} @ {label}: guard did not name the file on a "
@@ -746,10 +1049,14 @@ def main():
                             "on bare Path::metadata"
                         )
                         cell.append("BLIND")
-                    elif os.path.basename(metadata_rel) not in out:
+                    elif not (
+                        scan_reported(out, metadata_rel)
+                        if tag == "py"
+                        else os.path.basename(metadata_rel) in out
+                    ):
                         failures.append(
                             f"{metadata_rel} @ {label}: {tag} guard failed but "
-                            "never named the file"
+                            "never reported the file"
                         )
                         cell.append("UNNAMED")
                     else:
@@ -799,10 +1106,14 @@ def main():
                                 f"{deny_rel} @ {label}: {tag} guard PASSED on {probe_name}"
                             )
                             cell.append("BLIND")
-                        elif os.path.basename(deny_rel) not in out:
+                        elif not (
+                            scan_reported(out, deny_rel)
+                            if tag == "py"
+                            else os.path.basename(deny_rel) in out
+                        ):
                             failures.append(
                                 f"{deny_rel} @ {label}: {tag} guard failed on "
-                                f"{probe_name} but never named the file"
+                                f"{probe_name} but never reported the file"
                             )
                             cell.append("UNNAMED")
                         else:

--- a/scripts/verify-zero-file-search.py
+++ b/scripts/verify-zero-file-search.py
@@ -183,18 +183,40 @@ def load_allowlist():
             else:
                 lexed = lex_lines(lines)
 
+        if policy.whole_file and not scan_reaches(item["file"]):
+            errors.append(
+                f"  entry {item['file']} exempts the whole file, but the scan "
+                f"never reaches that path (owner: {item['owner']}), so the "
+                "exemption grants nothing and only records a claim nothing "
+                "enforces. Remove it, or pin the boundary, which forces the "
+                "file to be scanned around the pins"
+            )
+
         # `allow_fn` is validated first because the bodies it excuses decide
         # which lines the scan reads, and those lines are what `allow_match`
         # counts have to be measured against.
         if raw_fns is not None and lexed is not None:
             try:
                 bodies = find_fn_body_ranges(lines, None, lexed)
+                scanned = {index for index, _ in scannable_lines(lexed)}
                 for name, want in parse_pin_list(raw_fns, "fn").items():
                     found = len(bodies.get(name, ()))
                     if found != want:
                         errors.append(
                             f"  entry {item['file']} allow_fn {name!r} resolves to "
                             f"{found} function bodies (want {want})"
+                        )
+                        continue
+                    if not any(
+                        index in scanned
+                        for lo, hi in bodies[name]
+                        for index in range(lo, hi + 1)
+                    ):
+                        errors.append(
+                            f"  entry {item['file']} allow_fn {name!r} names a body "
+                            "the scan never reads, so the exemption excuses "
+                            "nothing. A test-gated or otherwise unscanned "
+                            "function needs no entry. Remove it"
                         )
                         continue
                     policy.fns.add(name)
@@ -382,6 +404,22 @@ def is_test_file(rel_path):
             return True
 
     return False
+
+
+def scan_reaches(rel_path):
+    """Whether the walk would scan this path absent any allowlist policy.
+
+    A pinned entry answers yes by construction: naming spans in a file forces it
+    to be scanned even inside a boundary directory. A whole-file entry for a path
+    the walk skips anyway answers no, and such an entry is inert. Eight of them
+    had accumulated on command modules outside the query set and on a file
+    already enumerated as a boundary, each reading like an enforced boundary
+    declaration while granting exactly nothing. Deciding this from the same walk
+    predicate the scan uses is what keeps the two from drifting: add a module to
+    QUERY_COMMANDS and its dormant whole-file exemption would begin to matter,
+    which is when it has to be re-justified rather than silently inherited.
+    """
+    return rel_path.startswith("crates/") and not is_test_file(rel_path)
 
 
 # Patterns to scan.
@@ -668,42 +706,254 @@ def find_fn_body_ranges(lines, fn_names=None, lexed=None):
     return found
 
 
+# The leading path of an attribute, with the whitespace Rust permits around the
+# `::` separators. `#[test]`, `#[tokio::test]` and `#[cfg(...)]` are all read
+# from this one shape.
+ATTR_PATH = re.compile(r"^#\s*\[\s*([A-Za-z0-9_]+(?:\s*::\s*[A-Za-z0-9_]+)*)")
+
+# An item head an attribute can gate, whose extent the tracker can bound by
+# brace matching or a terminating `;`. Modifiers may repeat and appear in any
+# order, so they are matched as a run rather than as a fixed sequence.
+# Deliberately a closed set: a construct this does not recognise -- a gated
+# struct field, enum variant, match arm, or statement -- has no bound this
+# tracker can trust, and the safe answer there is to keep scanning.
+#
+# `macro_rules!` sits outside the word-boundary group on purpose. A trailing
+# `\b` asserts a word character follows, and `!` is not one, so listing it
+# among the keywords produced an alternative that could never match while
+# reading as though it did. The failure was the safe direction, and no
+# cfg-gated macro exists in the tree today, but a closed set that silently
+# omits one of its own members is the same defect this tracker was rewritten
+# to remove: a policy decision made by an accident of spelling.
+ITEM_HEAD = re.compile(
+    r"^(?:(?:pub(?:\s*\([^)]*\))?|default|unsafe|async|const|extern(?:\s+\"[^\"]*\")?)\s+)*"
+    r"(?:(?:mod|fn|impl|struct|enum|union|trait|type|use|const|static)\b"
+    r"|macro_rules\s*!)"
+)
+
+
+def split_predicates(inner):
+    """Split a cfg predicate list on its top-level commas."""
+    parts, depth, current = [], 0, []
+    for ch in inner:
+        if ch == "(":
+            depth += 1
+        elif ch == ")":
+            depth -= 1
+        if ch == "," and depth == 0:
+            parts.append("".join(current))
+            current = []
+            continue
+        current.append(ch)
+    if "".join(current).strip():
+        parts.append("".join(current))
+    return [p.strip() for p in parts if p.strip()]
+
+
+CFG_CALL = re.compile(r"^([A-Za-z0-9_]+)\s*\((.*)\)$", re.S)
+
+
+def predicate_is_test_only(predicate):
+    """Whether a cfg predicate can only hold in a test build.
+
+    Evaluated rather than pattern-matched, because the tree carries predicates
+    that mention `test` and still compile in production. `all(...)` is test-only
+    when any member is, since every member must hold. `any(...)` only when every
+    member is, since one suffices: `cfg(any(unix, test))` is live on unix in a
+    release build, and excluding it would stop scanning production code. `not(..)`
+    is never treated as test-only, and neither is any other predicate, so an
+    unrecognised spelling keeps its item scanned.
+    """
+    predicate = predicate.strip()
+    call = CFG_CALL.match(predicate)
+    if call:
+        operator, inner = call.group(1).strip(), call.group(2)
+        members = split_predicates(inner)
+        if operator == "all":
+            return any(predicate_is_test_only(m) for m in members)
+        if operator == "any":
+            return bool(members) and all(predicate_is_test_only(m) for m in members)
+        return False
+    return predicate == "test"
+
+
+def attribute_extent(lexed, start):
+    """(last_line, text, trailing) for the attribute opening on line `start`.
+
+    Bracket-matched over the lexically stripped text, so an attribute spanning
+    lines is read whole and a `]` inside a string literal cannot close it early.
+    `trailing` is whatever follows the closing bracket on its line, which is how
+    a one-line `#[cfg(test)] use std::fs;` is recognised.
+    """
+    depth = 0
+    parts = []
+    for j in range(start, len(lexed)):
+        structure = lexed[j][0]
+        begin = structure.index("#") if j == start else 0
+        for k in range(begin, len(structure)):
+            ch = structure[k]
+            if ch == "[":
+                depth += 1
+            elif ch == "]":
+                depth -= 1
+                if depth == 0:
+                    parts.append(structure[begin : k + 1])
+                    return j, "".join(parts), structure[k + 1 :]
+        parts.append(structure[begin:])
+    return None, "".join(parts), ""
+
+
+def is_test_gate(text):
+    """Whether an attribute removes its item from every non-test build.
+
+    Two shapes qualify. A `test` attribute path -- `#[test]`, `#[tokio::test]`
+    -- marks an item rustc only emits under `--test`. A `cfg` whose predicate is
+    test-only gates the item's existence outright. `cfg_attr` never qualifies: it
+    applies an attribute conditionally and leaves the item itself compiled.
+    """
+    m = ATTR_PATH.match(text)
+    if not m:
+        return False
+    path = re.sub(r"\s+", "", m.group(1))
+    if path == "test" or path.endswith("::test"):
+        return True
+    if path != "cfg":
+        return False
+    open_paren = text.find("(", m.end())
+    if open_paren < 0:
+        return False
+    depth = 0
+    for k in range(open_paren, len(text)):
+        if text[k] == "(":
+            depth += 1
+        elif text[k] == ")":
+            depth -= 1
+            if depth == 0:
+                return predicate_is_test_only(text[open_paren + 1 : k])
+    return False
+
+
+def item_span(lexed, start):
+    """(start, last_line) for the item beginning on line `start`, or None.
+
+    Bounded the same way a function body is: brace depth from the item's opening
+    brace to its matching close, or a terminating `;` outside parentheses and
+    brackets for a declaration that has no block. Counted on the lexically
+    stripped text so a brace inside a literal or a comment cannot move the bound.
+    An item whose close is never found returns None, which drops the exclusion
+    and keeps the lines scanned rather than excusing everything below it.
+    """
+    depth = 0
+    started = False
+    nesting = 0
+    for j in range(start, len(lexed)):
+        structure = lexed[j][0]
+        if not started:
+            for ch in structure:
+                if ch in "([":
+                    nesting += 1
+                elif ch in ")]":
+                    nesting -= 1
+                elif ch == "{" and nesting <= 0:
+                    break
+                elif ch == ";" and nesting <= 0:
+                    return start, j
+        opens = structure.count("{")
+        closes = structure.count("}")
+        if opens:
+            started = True
+        if started:
+            depth += opens - closes
+            if depth <= 0:
+                return start, j
+    return None
+
+
+def test_gated_ranges(lexed):
+    """Inclusive line ranges holding items that exist only in a test build.
+
+    The tracker this replaces armed on the attribute line and disarmed on the
+    same iteration, because an attribute carries no brace and the guard's
+    disarm condition is `brace_depth <= armed_depth`. What kept it working at
+    all was the literal string `mod tests` on the following line re-arming it,
+    so exclusion was decided by a naming convention: `#[cfg(test)] mod
+    ingest_cas_tests` and every `#[cfg(test)] fn` were scanned as production.
+    The failure direction was safe, but over-reporting manufactures allowlist
+    entries, and an exemption that exists to silence a false positive is
+    indistinguishable later from one that licenses real boundary IO.
+
+    Attribute runs are read whole and the item they gate is bounded explicitly,
+    so exclusion follows from the cfg predicate rather than from a name. A gated
+    construct whose extent cannot be bounded, and an attribute run that gates
+    nothing recognisable, both stay scanned.
+    """
+    ranges = []
+    n = len(lexed)
+    i = 0
+    while i < n:
+        if not lexed[i][0].strip().startswith("#["):
+            i += 1
+            continue
+
+        block_start = i
+        gated = False
+        item_start = None
+        j = i
+        while j < n:
+            structure = lexed[j][0]
+            stripped = structure.strip()
+            if not stripped:
+                j += 1
+                continue
+            if not stripped.startswith("#["):
+                item_start = j
+                break
+            last_line, text, trailing = attribute_extent(lexed, j)
+            if last_line is None:
+                break
+            if is_test_gate(text):
+                gated = True
+            if trailing.strip():
+                item_start = last_line
+                break
+            j = last_line + 1
+
+        span = None
+        if gated and item_start is not None:
+            head = lexed[item_start][0].strip()
+            if item_start != block_start:
+                candidate = head
+            else:
+                # The item shares the attribute's line, so only what follows the
+                # closing bracket is the item.
+                candidate = attribute_extent(lexed, item_start)[2].strip()
+            if ITEM_HEAD.match(candidate):
+                span = item_span(lexed, item_start)
+
+        if span is None:
+            i = block_start + 1
+            continue
+        ranges.append((block_start, span[1]))
+        i = span[1] + 1
+    return ranges
+
+
 def scannable_lines(lexed):
     """Yield (index, code) for every line the scan reads, index 0-based.
 
-    Test modules and `#[test]` attributes are skipped here rather than in the
-    caller so that allowlist pin counts and the scan itself are measured over
-    exactly the same text. A count taken over the raw file measured a superset:
-    test-module and commented-out occurrences counted toward a pin's budget
-    without ever being sites the pin could license, and removing one from a test
-    then silently released budget for a real filesystem probe in a scanned path.
+    Test-only items are skipped here rather than in the caller so that allowlist
+    pin counts and the scan itself are measured over exactly the same text. A
+    count taken over the raw file measured a superset: test and commented-out
+    occurrences counted toward a pin's budget without ever being sites the pin
+    could license, and removing one from a test then silently released budget for
+    a real filesystem probe in a scanned path.
     """
-    in_test_module = False
-    brace_depth = 0
-    test_module_brace_depth = -1
-
-    for idx, (structure, code) in enumerate(lexed):
-        stripped = structure.strip()
-
-        # Track test module to ignore test code inside source files
-        if "mod tests" in stripped or "#[cfg(test)]" in stripped:
-            in_test_module = True
-            test_module_brace_depth = brace_depth
-
-        # Track brace depth
-        brace_depth += stripped.count("{") - stripped.count("}")
-
-        if in_test_module and brace_depth <= test_module_brace_depth:
-            in_test_module = False
-            test_module_brace_depth = -1
-
-        if in_test_module:
+    excluded = set()
+    for lo, hi in test_gated_ranges(lexed):
+        excluded.update(range(lo, hi + 1))
+    for idx, (_structure, code) in enumerate(lexed):
+        if idx in excluded:
             continue
-
-        # Skip attributes like #[test]
-        if stripped.startswith("#[test]"):
-            continue
-
         yield idx, code
 
 

--- a/scripts/zero-file-search-allowlist.json
+++ b/scripts/zero-file-search-allowlist.json
@@ -1,54 +1,6 @@
 {
   "allowlist": [
     {
-      "file": "crates/kin-cli/src/commands/checkout.rs",
-      "reason": "IO Boundary: materializes file state during checkout and reads files for status/reconcile bounds",
-      "owner": "kin-cli",
-      "expiration": "2026-12-31"
-    },
-    {
-      "file": "crates/kin-cli/src/commands/commit.rs",
-      "reason": "IO Boundary: reads local workspace files to build gitignore, hashes, and commit metadata",
-      "owner": "kin-cli",
-      "expiration": "2026-12-31"
-    },
-    {
-      "file": "crates/kin-cli/src/commands/init.rs",
-      "reason": "IO Ingestion: imports files from disk to build the initial semantic graph",
-      "owner": "kin-cli",
-      "expiration": "2026-12-31"
-    },
-    {
-      "file": "crates/kin-cli/src/commands/reconcile.rs",
-      "reason": "IO Boundary: writes/projects graph modifications back to filesystem",
-      "owner": "kin-cli",
-      "expiration": "2026-12-31"
-    },
-    {
-      "file": "crates/kin-cli/src/commands/session_workspace.rs",
-      "reason": "IO Boundary: syncs workspace by reading and writing files",
-      "owner": "kin-cli",
-      "expiration": "2026-12-31"
-    },
-    {
-      "file": "crates/kin-cli/src/commands/secret.rs",
-      "reason": "IO Boundary: reads authentication/tokens from stdin or config file",
-      "owner": "kin-cli",
-      "expiration": "2026-12-31"
-    },
-    {
-      "file": "crates/kin-cli/src/commands/locate_debug.rs",
-      "reason": "Debug Command: reads benchmark/test inputs from disk",
-      "owner": "kin-cli",
-      "expiration": "2026-12-31"
-    },
-    {
-      "file": "crates/kin-cli/src/backend.rs",
-      "reason": "Direct Snapshot direct-reads (offline bootstrap fallback)",
-      "owner": "kin-cli",
-      "expiration": "2026-12-31"
-    },
-    {
       "file": "crates/kin-cli/src/capability.rs",
       "reason": "Hardware check: reads /proc/meminfo for system stats",
       "owner": "kin-cli",
@@ -174,9 +126,43 @@
     },
     {
       "file": "crates/kin-daemon-spawn/src/lib.rs",
-      "reason": "Daemon process lifecycle IO boundary end to end (spawn plan, port record, disposition, registrar); zero answer-authority surface. Every filesystem and subprocess primitive here reaches or supervises the daemon that holds graph authority, never answers in its place, and no query result derives from any of them. Exempt whole-file rather than pinned because the process handle signatures repeat, which an exactly-once allow_match cannot express. lib.rs is the crate's only module, so a later-added module is scanned by default: re-review this exemption when a second .rs file joins the crate",
+      "reason": "Daemon process lifecycle boundary (spawn plan, process-group guardian, readiness handshake, port record, disposition, registrar) with zero answer-authority surface. Every primitive here reaches or supervises the daemon that holds graph authority, never answers in its place, and no query result derives from any of them. This was a whole-file exemption, which left 4041 lines unscanned and let any newly added filesystem read ride in unexamined; the crate's single module made that the entire crate. It is now pinned by primitive, so every line is scanned and only these expressions are masked. Four classes. (1) Type paths: the first three pins are the std, tokio, and unix-extension `process::` module paths, which appear in struct fields, parameter and return types, and imports. A type path is not execution, and pinning the path rather than the surrounding bodies is what keeps execution visible: masking `std::process::` leaves `Command::new(` intact, so every construction site still has to be pinned on its own and a new one fails the guard. (2) Process construction: the two `Command::new` pins are the guardian sentinel and watcher spawns and the daemon command builder, which are the whole point of a spawn boundary. (3) The readiness handshake: the guardian publishes its process group through a temp-and-rename file the parent reads once and removes on every exit path, which is why the remove pin carries seven occurrences. (4) The port record: reading the port the daemon reported, recognizing an orphaned record from a port file without its pid file, and clearing that record. Counts are exact over scanned code, so an added occurrence of any pin drops the pin and reports every line it claimed",
       "owner": "kin-daemon-spawn",
-      "expiration": "2026-12-31"
+      "expiration": "2026-12-31",
+      "allow_match": [
+        {
+          "expr": "std::process::",
+          "count": 53
+        },
+        {
+          "expr": "tokio::process::",
+          "count": 2
+        },
+        {
+          "expr": "std::os::unix::process::",
+          "count": 4
+        },
+        {
+          "expr": "Command::new(&self.executable)",
+          "count": 2
+        },
+        "Command::new(&self.daemon_bin)",
+        {
+          "expr": "std::fs::remove_file(readiness_path)",
+          "count": 7
+        },
+        "std::fs::read_to_string(readiness_path)",
+        "std::fs::write(&temporary_path, readiness)",
+        "std::fs::rename(&temporary_path, readiness_path)",
+        "std::fs::remove_file(&temporary_path)",
+        "std::fs::remove_file(kin_root.join(OWNER_FILE_NAME))",
+        "std::fs::remove_file(kin_root.join(PORT_FILE_NAME))",
+        "std::fs::read_to_string(kin_root.join(PORT_FILE_NAME))",
+        {
+          "expr": ".exists()",
+          "count": 2
+        }
+      ]
     },
     {
       "file": "crates/kin-daemon/src/api.rs",
@@ -273,7 +259,6 @@
         "read_endpoint_owner_record",
         "endpoint_ownership_with_probe",
         "proven_live_other_endpoint_owner_with_probe",
-        "publish_foreign_endpoint_for_test",
         "remove_endpoint_components",
         "publish_daemon_endpoint_under_authority_with_probe"
       ],
@@ -334,7 +319,7 @@
     },
     {
       "file": "crates/kin-daemon/src/daemon.rs",
-      "reason": "Daemon run loop boundary. Two pins are the liveness checks that ask whether this daemon's own endpoint records and control plane are still present, which is a question about the process rather than about the repository. The rest are the run loop reporting its process id, exiting, and canonicalizing the bound repository root twice while wiring authority into the server. No repository content is read and no query answer derives from any of it. Pinned by expression rather than by function, because the run loop is half this module and exempting its body would leave more unscanned than the primitives justify. Those two liveness pins named expressions that no longer exist: endpoint_files_missing and control_plane_missing were replaced by a classifier that verifies who owns an endpoint before treating its absence as an eviction notice. The successors are exempted per function rather than by snippet, because a pinned expression is exactly what went stale here.",
+      "reason": "Daemon run loop boundary. Two pins are the liveness checks that ask whether this daemon's own repository root and control plane are still present, which is a question about the process rather than about the repository. The rest are the run loop reporting its process id, exiting, and canonicalizing the bound repository root twice while wiring authority into the server. No repository content is read and no query answer derives from any of it. Pinned by expression rather than by function, because the run loop is half this module and exempting its body would leave more unscanned than the primitives justify. The liveness pins first named endpoint_files_missing and control_plane_missing, expressions that stopped existing when a classifier replaced them to verify who owns an endpoint before treating its absence as an eviction notice. Their successors, repository_root_missing and classify_control_plane, were then exempted per function, which excused twenty-four lines to license two expressions. They are pinned again, but on the primitive rather than on a snippet: the two `.exists()` calls are the only filesystem primitive in either body, and a count on the primitive survives the rewording that made the first pins stale while still failing the guard the moment a third appears.",
       "owner": "kin-daemon",
       "expiration": "2026-12-31",
       "allow_match": [
@@ -342,12 +327,12 @@
           "expr": ".canonicalize()",
           "count": 2
         },
+        {
+          "expr": ".exists()",
+          "count": 2
+        },
         "std::process::id(),",
         "std::process::exit(0);"
-      ],
-      "allow_fn": [
-        "repository_root_missing",
-        "classify_control_plane"
       ]
     },
     {


### PR DESCRIPTION
The zero-file-search tracker decided which lines are production code by a naming
convention. In `scannable_lines` the attribute line armed test exclusion and the same
iteration disarmed it, because an attribute carries no brace and the disarm condition
compares brace depth against the armed depth. What kept the arm alive was the literal
string `mod tests` on the following line. So a `#[cfg(test)]` module named anything else
was scanned as production, and so was every `#[cfg(test)]` function. The direction was
safe, but over-reporting manufactures exemptions, and an entry that exists to silence a
false positive is indistinguishable a year later from one that licenses real boundary IO.

Attribute runs are now read whole and the item they gate is bounded explicitly, by brace
matching from the opening brace or by a semicolon outside parentheses and brackets, both
counted on lexically stripped text. The cfg predicate is evaluated rather than matched,
which the tree requires: `all(..)` is test-only when any member is, `any(..)` only when
every member is, and `not(..)` never, so the twenty uses of `cfg(any(unix, test))` and ten
of `cfg(not(test))` keep their items scanned while the forty-three of
`cfg(all(test, unix))` do not. `cfg_attr` never gates existence. A construct the tracker
cannot bound, a gated struct field for instance, stays scanned. Across the whole tree this
excludes 18551 lines of test-only code and newly scans zero lines, so dropping the name
convention costs no coverage.

The kin-daemon-spawn crate was exempt as a whole file. Its single module is 4041 lines, so
the exemption covered the crate, and any filesystem read added there would have ridden in
unexamined. Scanning it reports 76 expressions across 32 functions. Exempting those bodies
would have excused roughly a thousand lines to license 76 expressions, so the file is
pinned by primitive instead and every other byte is scanned. The grain holds because
masking is byte-exact: masking a `std::process::` type path leaves `Command::new(`
matchable, so each of the three construction sites is pinned on its own and a new one
fails the guard. Counts are exact over scanned code, so an added occurrence drops the pin
and the scan then reports every line that pin had claimed.

Two daemon run loop bodies exempted by name are reground onto the primitive they were
excusing. `repository_root_missing` and `classify_control_plane` contain exactly two
`.exists()` calls and no other filesystem primitive, so one counted pin covers the same
two expressions and returns twenty-four lines to the scan. A pinned snippet is what went
stale there once already, when `endpoint_files_missing` and `control_plane_missing` were
renamed; a pin on the primitive survives that rewording and still fails on a third call.

Two validation rules make a dead exemption loud instead of dormant, which is the
discipline `allow_match` already had. A whole-file entry naming a path the walk never
reaches grants nothing, and eight had accumulated on command modules outside the query set
and on a file already enumerated as a boundary directory. A function exemption whose body
the scan never reads excuses nothing, which is what a `#[cfg(test)]` helper in
`lifecycle.rs` became the moment the tracker recognised it. Both rules report after the
scan, so neither can mask it.

The allowlist drops from 37 entries to 29 and from thirteen whole-file exemptions to four,
and the lines the allowlist removes from the scan drop from 9358 to 5275. Pins rise from
142 to 154, which is the honest cost of turning one 4041-line exemption into byte-exact
expressions.

The falsifier now asks whether the scan reported a file rather than whether the tool
exited nonzero. That distinction is the point: an allowlist error also exits nonzero and
also prints the path it complains about, so the old check could have been satisfied by the
exact masking failure the harness exists to catch. New probes cover the narrowed module
across its production region, the reground bodies from inside, and eleven cfg spellings
each with a control the scan must always report, planted in one run and replayed
individually only when the batch fails.

Separately, two `setup.rs` tests read the process working directory while two serialized
tests in the same binary mutate it. Serialization orders only the tests that carry the
attribute, so a reader without it runs concurrently with a mutation; the relative-path test
builds paths against the directory it read and asserts on their canonical form, which only
holds if the directory has not moved underneath it. Both readers now carry the attribute.
Note that this race cannot appear under nextest, which runs each test in its own process;
it is `cargo test` that shares one.

Closes FIR-1704
Closes FIR-1702