### PR TITLE
Keep Kin MCP auto-init off protocol stdout

### DIFF
--- a/packages/kin-mcp/src/index.js
+++ b/packages/kin-mcp/src/index.js
@@ -195,7 +195,16 @@ export async function runKinMcp(argv = [], options = {}) {
       return 2;
     }
     stderr.write('No .kin/ found; KIN_MCP_AUTO_INIT=1, running kin init...\n');
-    const initCode = await spawnKin(binaryPath, ['init', '.'], { ...spawnOptions, cwd });
+    const initCode = await spawnKin(
+      binaryPath,
+      ['init', '.'],
+      {
+        ...spawnOptions,
+        cwd,
+        stdio: ['ignore', 'pipe', 'pipe']
+      },
+      { forwardOutputTo: stderr }
+    );
     if (initCode !== 0) {
       stderr.write('kin init failed. Cannot start MCP server.\n');
       return initCode;
@@ -474,7 +483,7 @@ async function isRunnable(filePath, platform) {
   }
 }
 
-function spawnKin(binaryPath, args, options) {
+function spawnKin(binaryPath, args, options, { forwardOutputTo } = {}) {
   const env = options.env || process.env;
 
   return new Promise((resolve, reject) => {
@@ -483,6 +492,11 @@ function spawnKin(binaryPath, args, options) {
       env,
       stdio: options.stdio || 'inherit'
     });
+
+    if (forwardOutputTo) {
+      forwardStream(child.stdout, forwardOutputTo);
+      forwardStream(child.stderr, forwardOutputTo);
+    }
 
     const handlers = new Map();
     for (const signal of ['SIGINT', 'SIGTERM', 'SIGHUP']) {
@@ -514,5 +528,19 @@ function spawnKin(binaryPath, args, options) {
       }
       resolve(code ?? 1);
     });
+  });
+}
+
+function forwardStream(source, destination) {
+  if (!source) {
+    return;
+  }
+
+  source.on('data', chunk => {
+    const ready = destination.write(chunk);
+    if (ready === false && typeof destination.once === 'function') {
+      source.pause();
+      destination.once('drain', () => source.resume());
+    }
   });
 }

--- a/packages/kin-mcp/test/index.test.js
+++ b/packages/kin-mcp/test/index.test.js
@@ -6,6 +6,7 @@ import http from 'node:http';
 import os from 'node:os';
 import path from 'node:path';
 import test from 'node:test';
+import { fileURLToPath } from 'node:url';
 
 import {
   childEnv,
@@ -514,6 +515,59 @@ test('runKinMcp auto-inits when explicitly allowed', async () => {
     assert.ok(initPos >= 0, 'expected kin init . call');
     assert.ok(mcpPos >= 0, 'expected kin mcp start call');
     assert.ok(initPos < mcpPos, 'init should run before mcp start');
+  } finally {
+    await fs.rm(tmpDir, { recursive: true, force: true });
+  }
+});
+
+test('auto-init keeps MCP stdout protocol-only from process start', async () => {
+  const tmpDir = await fs.mkdtemp(
+    path.join(os.tmpdir(), 'kin-mcp-autoinit-protocol-')
+  );
+  const binaryPath = path.join(tmpDir, 'kin');
+  const protocolPayload = JSON.stringify({
+    jsonrpc: '2.0',
+    id: 1,
+    result: { protocolVersion: '2024-11-05' }
+  });
+  const protocolFrame =
+    `Content-Length: ${Buffer.byteLength(protocolPayload)}\r\n\r\n${protocolPayload}`;
+  await fs.writeFile(
+    binaryPath,
+    [
+      '#!/bin/sh',
+      'if [ "$1" = "init" ]; then',
+      "  printf '%s\\n' 'init stdout must leave the protocol channel'",
+      "  printf '%s\\n' 'init stderr remains diagnostic' >&2",
+      `  mkdir -p "${tmpDir}/.kin"`,
+      '  exit 0',
+      'fi',
+      `printf '%s' '${protocolFrame}'`,
+      ''
+    ].join('\n'),
+    { mode: 0o755 }
+  );
+
+  try {
+    const result = cp.spawnSync(
+      process.execPath,
+      [fileURLToPath(new URL('../bin/kin-mcp.js', import.meta.url))],
+      {
+        cwd: tmpDir,
+        encoding: 'utf8',
+        env: {
+          ...process.env,
+          KIN_MCP_KIN_BINARY: binaryPath,
+          KIN_MCP_AUTO_INIT: '1'
+        }
+      }
+    );
+
+    assert.equal(result.status, 0, result.stderr);
+    assert.equal(result.stdout, protocolFrame);
+    assert.doesNotMatch(result.stdout, /init stdout/);
+    assert.match(result.stderr, /init stdout must leave the protocol channel/);
+    assert.match(result.stderr, /init stderr remains diagnostic/);
   } finally {
     await fs.rm(tmpDir, { recursive: true, force: true });
   }


### PR DESCRIPTION
## What changed

- detach `kin init .` from MCP stdin when `KIN_MCP_AUTO_INIT=1`
- pipe and drain init stdout/stderr onto the wrapper's diagnostic stderr channel
- preserve the existing `kin mcp start` stdio contract unchanged
- add a real subprocess regression that emits human init stdout before a framed MCP response and proves wrapper stdout is protocol-only from byte zero

## Why

The auto-init child previously inherited the wrapper's stdio. Human-readable `kin init` output could precede JSON-RPC on stdout, and the child could consume an early MCP request from stdin. That makes first-run auto-init unsafe for real MCP clients even though initialization itself succeeds.

This keeps the real initialization path; it does not add demo state or bypass repository/graph authority.

## Exact-head verification

- base `bee8507f96c9306a5fdcf0144c7322dad9d0edd3`
- head `b63b9d5ece49e84a5480bce70bac946806e6df48`
- tree `8efa375d823a07365b5debf36ab21d6566b555e8`
- package tests: 18 passed, 0 failed
- package lint: passed
- independent exact-head review: GO, 0 P0 / 0 P1 / 0 P2 / 0 P3
- `git diff --check` and `git show --check`: passed

Released-package and real-client first-run acceptance remain separate gates.

Closes FIR-1700