### PR TITLE
Judge daemon endpoint liveness by incarnation and leave one start contract

### DIFF
--- a/crates/kin-cli/src/daemon_client.rs
+++ b/crates/kin-cli/src/daemon_client.rs
@@ -2239,6 +2239,181 @@ pub fn repo_daemon_owner_path(kin_root: &Path) -> PathBuf {
     kin_root.join("daemon.owner")
 }
 
+/// Schema tag carried by the endpoint owner sidecar.
+pub const ENDPOINT_OWNER_SCHEMA: &str = "kin.daemon.endpoint-owner.v1";
+
+/// Who published the endpoint currently on disk.
+///
+/// `daemon.pid` holds a bare PID because every version of every Kin surface
+/// reads it that way, and a PID alone cannot survive reuse: after the recorded
+/// daemon exits, that number starts naming whatever the kernel handed it to
+/// next, and a reader comparing PIDs either preserves a dead endpoint forever
+/// or deletes a live one. This sidecar records the same process incarnation the
+/// singleton lock stamps, so ownership can be *proved* rather than inferred
+/// from a number.
+///
+/// The record carries identity and nothing else. A port field was tempting and
+/// is deliberately absent: `daemon.port` is the port, nothing would read a
+/// second copy, and two records of the same fact can only ever disagree.
+///
+/// The definition lives here rather than beside the daemon that writes it for
+/// the same reason. The daemon publishes the record and the CLI start path
+/// reads it to decide whether an endpoint may be replaced; a second declaration
+/// of one schema is a second thing to keep in step, and the schema tag exists
+/// precisely so a reader can refuse a record it does not understand.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct EndpointOwnerRecord {
+    schema: String,
+    identity: ProcessIdentity,
+}
+
+impl EndpointOwnerRecord {
+    /// A record attributing an endpoint to this process incarnation, or `None`
+    /// on a target that cannot describe one.
+    pub fn current() -> Option<Self> {
+        Some(Self {
+            schema: ENDPOINT_OWNER_SCHEMA.to_string(),
+            identity: current_process_identity().ok()?,
+        })
+    }
+
+    /// The incarnation this record names.
+    pub fn identity(&self) -> &ProcessIdentity {
+        &self.identity
+    }
+
+    /// Attribute an endpoint to an incarnation other than this process, so a
+    /// test can build the state a predecessor or a successor would leave behind
+    /// without running a second daemon.
+    ///
+    /// Hidden rather than `#[cfg(test)]`: the daemon crate's tests need it too,
+    /// and a `cfg(test)` item is invisible across a crate boundary.
+    #[doc(hidden)]
+    pub fn for_identity(identity: ProcessIdentity) -> Self {
+        Self {
+            schema: ENDPOINT_OWNER_SCHEMA.to_string(),
+            identity,
+        }
+    }
+}
+
+/// Read the endpoint owner sidecar, if one exists and this build understands it.
+pub fn read_endpoint_owner_record(kin_root: &Path) -> Option<EndpointOwnerRecord> {
+    let raw = std::fs::read_to_string(repo_daemon_owner_path(kin_root)).ok()?;
+    let record: EndpointOwnerRecord = serde_json::from_str(&raw).ok()?;
+    (record.schema == ENDPOINT_OWNER_SCHEMA).then_some(record)
+}
+
+/// What could be established about the owner of a published endpoint, and
+/// whether the answer came from a verified incarnation or only from a PID.
+///
+/// The two travel together because the honest diagnostic differs: a bare PID
+/// that stopped responding says only that a number is gone, while a verified
+/// identity mismatch says the daemon that published this endpoint is gone and
+/// its PID now names something else.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct EndpointOwnerLiveness {
+    liveness: ProcessLiveness,
+    identity_verified: bool,
+}
+
+impl EndpointOwnerLiveness {
+    /// Whether the endpoint may be retired: only affirmative death qualifies.
+    pub fn authorizes_cleanup(self) -> bool {
+        self.liveness.authorizes_cleanup()
+    }
+
+    /// Whether the verdict was decided against a recorded incarnation rather
+    /// than a bare PID.
+    pub fn identity_verified(self) -> bool {
+        self.identity_verified
+    }
+
+    fn from_identity(liveness: ProcessLiveness) -> Self {
+        Self {
+            liveness,
+            identity_verified: true,
+        }
+    }
+
+    fn from_pid(liveness: ProcessLiveness) -> Self {
+        Self {
+            liveness,
+            identity_verified: false,
+        }
+    }
+}
+
+/// Judge the owner of this repo's published endpoint, preferring the recorded
+/// incarnation over the bare PID.
+///
+/// This is the client-side twin of `kin_daemon::lifecycle::endpoint_ownership`
+/// and answers the same question in the same direction: it governs whether an
+/// endpoint may be *deleted*, so an indeterminate probe is ownership-preserving.
+/// Refusing to retire what cannot be inspected costs a stale file; retiring a
+/// live daemon's endpoint strands the repo.
+///
+/// Deciding from the bare PID is what wedged autostart. A SIGKILLed daemon
+/// leaves its endpoint behind, the kernel hands that PID to an unrelated
+/// process, `kill(pid, 0)` reports it alive, and the start path concludes
+/// forever that a live daemon it cannot reach owns the repo: never `Invalid`,
+/// never retired, never respawned.
+pub fn endpoint_owner_liveness(kin_root: &Path, recorded_pid: u32) -> EndpointOwnerLiveness {
+    endpoint_owner_liveness_with_probes(
+        kin_root,
+        recorded_pid,
+        process_identity_is_current,
+        process_liveness,
+    )
+}
+
+/// Both probes are injectable for the same reason the daemon's are: the
+/// indeterminate arm and the legacy arm are decisions, and a decision that
+/// cannot be exercised in a test is one a later change can silently invert.
+fn endpoint_owner_liveness_with_probes(
+    kin_root: &Path,
+    recorded_pid: u32,
+    identity_probe: impl FnOnce(&ProcessIdentity) -> std::io::Result<bool>,
+    pid_probe: impl FnOnce(u32) -> ProcessLiveness,
+) -> EndpointOwnerLiveness {
+    let Some(record) = read_endpoint_owner_record(kin_root) else {
+        // A legacy endpoint published before attribution existed, or by a
+        // compatible older daemon. A bare PID is all there is to go on.
+        return EndpointOwnerLiveness::from_pid(pid_probe(recorded_pid));
+    };
+    if record.identity.pid != recorded_pid {
+        // Attribution and endpoint disagree, so the record does not describe
+        // the endpoint being judged. Publication installs the record before the
+        // PID file it attributes, so this is a torn write or a mixed-version
+        // writer rather than a generation this reader can reason about. Judge
+        // the PID the endpoint actually names, which can only ever be more
+        // conservative than acting on a statement about a different process.
+        return EndpointOwnerLiveness::from_pid(pid_probe(recorded_pid));
+    }
+    if record.identity.pid == std::process::id() {
+        // Answer the "is it mine" case from this process's own identity rather
+        // than from a probe of its PID: routing the self case through a
+        // fallible probe would let a transient error report this process as
+        // gone.
+        return EndpointOwnerLiveness::from_identity(match current_process_identity() {
+            Ok(current) if current == record.identity => ProcessLiveness::Alive,
+            // Our PID, a different incarnation: the publisher exited and the
+            // kernel handed us its number.
+            Ok(_) => ProcessLiveness::Dead,
+            Err(_) => ProcessLiveness::Unknown,
+        });
+    }
+    EndpointOwnerLiveness::from_identity(match identity_probe(&record.identity) {
+        Ok(true) => ProcessLiveness::Alive,
+        // The PID resolves to a different incarnation than the one that
+        // published this endpoint, so the publisher is gone.
+        Ok(false) => ProcessLiveness::Dead,
+        // An identity that cannot be read at all (another user's process) is
+        // indeterminate, and an uninspectable owner is not a dead one.
+        Err(_) => ProcessLiveness::Unknown,
+    })
+}
+
 /// Remove a repo worker daemon's pid/port endpoint files. The daemon deletes
 /// these itself on graceful shutdown; `kin daemon stop` also calls this after a
 /// confirmed stop so a later `status` never reports the dead endpoint as stale.
@@ -2881,6 +3056,10 @@ fn live_daemon_endpoint(kin_root: &Path) -> Option<LiveDaemonEndpoint> {
     live_daemon_endpoint_with_probe(kin_root, process_liveness)
 }
 
+/// `probe` is the *legacy* arm: it decides only for an endpoint published with
+/// no owner record beside it. An attributed endpoint is judged against the
+/// recorded incarnation, because that is the only reading that survives PID
+/// reuse.
 fn live_daemon_endpoint_with_probe(
     kin_root: &Path,
     probe: impl FnOnce(u32) -> ProcessLiveness,
@@ -2892,7 +3071,16 @@ fn live_daemon_endpoint_with_probe(
     // to a same-PID successor's newly published port, making the final
     // compare-and-retire accept the wrong endpoint generation.
     let port = recorded.port;
-    if probe(pid).authorizes_cleanup() {
+    // Read attribution *after* the endpoint it attributes, which is the order
+    // that can only ever make this more conservative. Publication installs the
+    // owner record before the PID file, so a snapshot showing a successor's
+    // endpoint is always accompanied by a readable successor record; reading
+    // the record first would instead pair a predecessor's dead identity with a
+    // successor's live endpoint, and the compare-and-retire below would then
+    // find the successor's files unchanged and delete them.
+    if endpoint_owner_liveness_with_probes(kin_root, pid, process_identity_is_current, probe)
+        .authorizes_cleanup()
+    {
         // Compare-and-delete even here, where the window is only as wide as this
         // function: a successor that republished between the read and the
         // liveness check would otherwise lose its endpoint to a true statement
@@ -4274,11 +4462,22 @@ async fn probe_daemon_endpoint_with_warming_signal(
     let mut warming = false;
 
     loop {
-        if !is_process_alive(endpoint.pid) {
-            return EndpointVerdict::Invalid(format!(
-                "recorded daemon process {} is not alive",
-                endpoint.pid
-            ));
+        // Judged against the recorded incarnation, not the bare PID. `Invalid`
+        // authorizes the caller to clear this endpoint and respawn, so it needs
+        // positive evidence of death; a recycled PID that merely *exists* is
+        // not a live daemon, and treating it as one is what left autostart
+        // reporting LiveNotReady forever with nothing able to clear the record.
+        let owner = endpoint_owner_liveness(kin_root, endpoint.pid);
+        if owner.authorizes_cleanup() {
+            return EndpointVerdict::Invalid(if owner.identity_verified() {
+                format!(
+                    "the daemon that published this endpoint is gone; pid {} now names \
+                     a different process",
+                    endpoint.pid
+                )
+            } else {
+                format!("recorded daemon process {} is not alive", endpoint.pid)
+            });
         }
 
         let probe_error = match client.get(format!("{base_url}/readiness")).send().await {

--- a/crates/kin-cli/src/daemon_client.rs
+++ b/crates/kin-cli/src/daemon_client.rs
@@ -8084,7 +8084,8 @@ mod tests {
     fn a_recycled_pid_does_not_keep_a_dead_daemons_endpoint_alive() {
         let dir = tempfile::tempdir().unwrap();
         let root = dir.path();
-        let pid = write_attributed_endpoint_files(root, recycled_identity_for_this_process(), 51000);
+        let pid =
+            write_attributed_endpoint_files(root, recycled_identity_for_this_process(), 51000);
 
         // The bare-PID probe every earlier version used: this PID is running,
         // so the endpoint looked live and wedged autostart permanently.
@@ -8100,7 +8101,8 @@ mod tests {
             "the daemon that published this endpoint is gone, so it must be retirable"
         );
         assert_eq!(
-            live_daemon_endpoint(root), None,
+            live_daemon_endpoint(root),
+            None,
             "a recycled PID is not the daemon that published the endpoint"
         );
         assert!(
@@ -8123,7 +8125,8 @@ mod tests {
         let listener = std::net::TcpListener::bind("127.0.0.1:0").unwrap();
         let port = listener.local_addr().unwrap().port();
         drop(listener);
-        let pid = write_attributed_endpoint_files(&root, recycled_identity_for_this_process(), port);
+        let pid =
+            write_attributed_endpoint_files(&root, recycled_identity_for_this_process(), port);
 
         let verdict = probe_daemon_endpoint(
             &root,
@@ -8220,9 +8223,12 @@ mod tests {
         .unwrap();
         write_endpoint_files(root, 4242, 51000);
 
-        let owner = endpoint_owner_liveness_with_probes(root, 4242, |_| Ok(false), |_| {
-            ProcessLiveness::Unknown
-        });
+        let owner = endpoint_owner_liveness_with_probes(
+            root,
+            4242,
+            |_| Ok(false),
+            |_| ProcessLiveness::Unknown,
+        );
         assert!(
             !owner.identity_verified(),
             "a record for a different PID does not attribute this endpoint"

--- a/crates/kin-cli/src/daemon_client.rs
+++ b/crates/kin-cli/src/daemon_client.rs
@@ -8038,6 +8038,219 @@ mod tests {
         }
     }
 
+    // ── Endpoint owner liveness ───────────────────────────────────────────
+    //
+    // The failure these close: the start path decided from `daemon.pid` alone.
+    // A SIGKILLed daemon leaves its endpoint behind, the kernel hands that PID
+    // to an unrelated process, `kill(pid, 0)` reports it alive, and autostart
+    // concluded forever that a live daemon it could not reach owned the repo.
+    // The endpoint was never proven invalid, so nothing retired it and nothing
+    // respawned.
+
+    /// Publish an endpoint attributed to a given incarnation, the way the daemon
+    /// does: the owner record first, then the endpoint it attributes.
+    fn write_attributed_endpoint_files(
+        kin_root: &Path,
+        identity: ProcessIdentity,
+        port: u16,
+    ) -> u32 {
+        let pid = identity.pid();
+        std::fs::write(
+            repo_daemon_owner_path(kin_root),
+            serde_json::to_string(&EndpointOwnerRecord::for_identity(identity)).unwrap(),
+        )
+        .unwrap();
+        write_endpoint_files(kin_root, pid, port);
+        pid
+    }
+
+    /// The same live PID, a different incarnation of it: exactly the shape PID
+    /// reuse produces once the daemon that published the endpoint is gone.
+    fn recycled_identity_for_this_process() -> ProcessIdentity {
+        let current = current_process_identity().expect("read this process's identity");
+        let forged = ProcessIdentity {
+            pid: current.pid,
+            boot_id: current.boot_id.clone(),
+            birth_token: format!("{}9", current.birth_token),
+        };
+        assert_ne!(
+            forged, current,
+            "the forged identity must name a different incarnation"
+        );
+        forged
+    }
+
+    #[test]
+    fn a_recycled_pid_does_not_keep_a_dead_daemons_endpoint_alive() {
+        let dir = tempfile::tempdir().unwrap();
+        let root = dir.path();
+        let pid = write_attributed_endpoint_files(root, recycled_identity_for_this_process(), 51000);
+
+        // The bare-PID probe every earlier version used: this PID is running,
+        // so the endpoint looked live and wedged autostart permanently.
+        assert_eq!(process_liveness(pid), ProcessLiveness::Alive);
+
+        let owner = endpoint_owner_liveness(root, pid);
+        assert!(
+            owner.identity_verified(),
+            "an attributed endpoint must be judged against its recorded incarnation"
+        );
+        assert!(
+            owner.authorizes_cleanup(),
+            "the daemon that published this endpoint is gone, so it must be retirable"
+        );
+        assert_eq!(
+            live_daemon_endpoint(root), None,
+            "a recycled PID is not the daemon that published the endpoint"
+        );
+        assert!(
+            !root.join("daemon.pid").exists()
+                && !root.join("daemon.port").exists()
+                && !repo_daemon_owner_path(root).exists(),
+            "the proven-stale endpoint must be retired so a replacement can start"
+        );
+    }
+
+    #[tokio::test]
+    async fn probing_a_recycled_pid_endpoint_proves_it_invalid() {
+        // The other half: `probe_daemon_endpoint` re-checked liveness from the
+        // bare PID, so a recycled PID returned LiveNotReady until the deadline
+        // on every attempt, forever, and the caller is forbidden from clearing
+        // an endpoint that was never proven wrong.
+        let dir = tempfile::tempdir().unwrap();
+        let root = dir.path().join(".kin");
+        std::fs::create_dir_all(&root).unwrap();
+        let listener = std::net::TcpListener::bind("127.0.0.1:0").unwrap();
+        let port = listener.local_addr().unwrap().port();
+        drop(listener);
+        let pid = write_attributed_endpoint_files(&root, recycled_identity_for_this_process(), port);
+
+        let verdict = probe_daemon_endpoint(
+            &root,
+            LiveDaemonEndpoint { pid, port },
+            Duration::from_millis(50),
+        )
+        .await;
+
+        match verdict {
+            EndpointVerdict::Invalid(detail) => assert!(
+                detail.contains("different process"),
+                "the diagnostic must say the publisher is gone, not that a number is: {detail}"
+            ),
+            other => panic!("a recycled PID must prove the record wrong, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn an_endpoint_owned_by_a_live_incarnation_survives() {
+        // The inverse, so the fix cannot be "always delete": this process really
+        // did publish this endpoint, and it must keep it.
+        let dir = tempfile::tempdir().unwrap();
+        let root = dir.path();
+        let identity = current_process_identity().expect("read this process's identity");
+        let pid = write_attributed_endpoint_files(root, identity, 51000);
+
+        let owner = endpoint_owner_liveness(root, pid);
+        assert!(owner.identity_verified());
+        assert!(
+            !owner.authorizes_cleanup(),
+            "a verified live owner's endpoint must never be retirable"
+        );
+        assert_eq!(
+            live_daemon_endpoint(root),
+            Some(LiveDaemonEndpoint { pid, port: 51000 })
+        );
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn an_uninspectable_owner_is_preserved_rather_than_retired() {
+        // The indeterminate arm, driven through a real foreign process so the
+        // record names an incarnation that really exists. An owner this process
+        // cannot inspect is not a dead one, and the removal decision fails
+        // closed.
+        let dir = tempfile::tempdir().unwrap();
+        let root = dir.path();
+        let mut foreign = std::process::Command::new("sleep")
+            .arg("30")
+            .spawn()
+            .expect("spawn a stand-in foreign owner");
+        let identity = process_identity(foreign.id())
+            .expect("read the foreign owner's identity")
+            .expect("the foreign owner is running");
+        let pid = write_attributed_endpoint_files(root, identity, 51000);
+
+        let unreadable = |_: &ProcessIdentity| {
+            Err(std::io::Error::new(
+                std::io::ErrorKind::PermissionDenied,
+                "cannot read birth identity for a foreign process",
+            ))
+        };
+        assert!(
+            !endpoint_owner_liveness_with_probes(root, pid, unreadable, process_liveness)
+                .authorizes_cleanup(),
+            "an owner that cannot be inspected must not authorize retirement"
+        );
+        assert_eq!(
+            live_daemon_endpoint(root),
+            Some(LiveDaemonEndpoint { pid, port: 51000 }),
+            "a foreign live owner keeps its endpoint"
+        );
+        assert!(root.join("daemon.pid").exists() && root.join("daemon.port").exists());
+
+        let _ = foreign.kill();
+        let _ = foreign.wait();
+    }
+
+    #[test]
+    fn attribution_that_names_another_pid_falls_back_to_the_endpoint_it_describes() {
+        // A torn or mixed-version write: the record and the PID file disagree,
+        // so the record describes a different process than the endpoint being
+        // judged. Judging the PID the endpoint actually names is the only
+        // reading that cannot act on a statement about somebody else.
+        let dir = tempfile::tempdir().unwrap();
+        let root = dir.path();
+        std::fs::write(
+            repo_daemon_owner_path(root),
+            serde_json::to_string(&EndpointOwnerRecord::for_identity(
+                recycled_identity_for_this_process(),
+            ))
+            .unwrap(),
+        )
+        .unwrap();
+        write_endpoint_files(root, 4242, 51000);
+
+        let owner = endpoint_owner_liveness_with_probes(root, 4242, |_| Ok(false), |_| {
+            ProcessLiveness::Unknown
+        });
+        assert!(
+            !owner.identity_verified(),
+            "a record for a different PID does not attribute this endpoint"
+        );
+        assert!(!owner.authorizes_cleanup());
+    }
+
+    #[test]
+    fn a_legacy_endpoint_is_still_judged_by_its_pid() {
+        // No owner record, so a bare PID is all there is. The legacy arm must
+        // keep working: an endpoint published by a compatible older daemon is
+        // retired when its PID is provably gone.
+        let dir = tempfile::tempdir().unwrap();
+        let root = dir.path();
+        write_endpoint_files(root, 4242, 51000);
+
+        let owner = endpoint_owner_liveness(root, 4242);
+        assert!(
+            !owner.identity_verified(),
+            "an unattributed endpoint cannot be identity verified"
+        );
+        assert_eq!(
+            live_daemon_endpoint_with_probe(root, |_| ProcessLiveness::Dead),
+            None
+        );
+        assert!(!root.join("daemon.pid").exists() && !root.join("daemon.port").exists());
+    }
+
     #[test]
     fn live_daemon_endpoint_returns_alive_pid_even_before_port_binds() {
         let dir = tempfile::tempdir().unwrap();

--- a/crates/kin-daemon-spawn/src/lib.rs
+++ b/crates/kin-daemon-spawn/src/lib.rs
@@ -4,14 +4,22 @@
 //! The one definition of how a repo daemon is started and how its port is
 //! learned.
 //!
-//! Two callers start daemons: the CLI autostart path and the MCP revival path.
-//! They cannot share code through either of their own crates — `kin-cli`
-//! depends on `kin-mcp`, and `kin-mcp` cannot depend on `kin-daemon` because
-//! `kin-daemon` already depends on `kin-mcp`. So each grew its own copy of the
-//! contract, and the MCP copy has now twice regressed to a weaker version of a
+//! Two callers start a daemon and wait for it: the CLI autostart path and the
+//! MCP revival path. They cannot share code through either of their own crates
+//! — `kin-cli` depends on `kin-mcp`, and `kin-mcp` cannot depend on `kin-daemon`
+//! because `kin-daemon` already depends on `kin-mcp`. So each grew its own copy
+//! of the contract, and the MCP copy twice regressed to a weaker version of a
 //! rule the CLI copy already enforced.
 //!
-//! This crate is the shared floor beneath both. It deliberately holds the
+//! A third surface starts a daemon without waiting for it: the macOS LaunchAgent
+//! plist, which hands its argument vector to launchd rather than to a child this
+//! process supervises. It is not a caller of the startup helpers here, but it
+//! does have to agree about port selection, so it passes
+//! [`DAEMON_PORT_ARGUMENT`] like everything else. `kin-daemon` also once
+//! re-exported a fourth entry point of its own; it is gone, so counting the
+//! spawn contracts in the tree now yields the one below.
+//!
+//! This crate is the shared floor beneath them. It deliberately holds the
 //! decisions that diverged rather than everything a spawn touches:
 //!
 //! - the daemon owns port selection ([`DAEMON_PORT_ARGUMENT`]), and the port is

--- a/crates/kin-daemon-spawn/src/lib.rs
+++ b/crates/kin-daemon-spawn/src/lib.rs
@@ -5,9 +5,9 @@
 //! learned.
 //!
 //! Two callers start a daemon and wait for it: the CLI autostart path and the
-//! MCP revival path. They cannot share code through either of their own crates
-//! — `kin-cli` depends on `kin-mcp`, and `kin-mcp` cannot depend on `kin-daemon`
-//! because `kin-daemon` already depends on `kin-mcp`. So each grew its own copy
+//! MCP revival path. They cannot share code through either of their own crates,
+//! because `kin-cli` depends on `kin-mcp` and `kin-mcp` cannot depend on
+//! `kin-daemon`, which already depends on `kin-mcp`. So each grew its own copy
 //! of the contract, and the MCP copy twice regressed to a weaker version of a
 //! rule the CLI copy already enforced.
 //!

--- a/crates/kin-daemon/src/lib.rs
+++ b/crates/kin-daemon/src/lib.rs
@@ -142,10 +142,7 @@ pub use daemon::{
     DaemonConfig,
 };
 pub use error::{DaemonError, Result};
-pub use lifecycle::{
-    daemon_is_up, ensure_daemon_running, ensure_daemon_running_with_idle_timeout, AutoStartError,
-    MCP_IDLE_TIMEOUT_SECS,
-};
+pub use lifecycle::{daemon_is_up, AutoStartError, MCP_IDLE_TIMEOUT_SECS};
 pub use loop_runner::LoopConfig;
 pub use session_registry::SessionCoordinator;
 pub use state::{ChangeType, DaemonEvent, DaemonState, LspEnrichmentMessage, LspEnrichmentRequest};

--- a/crates/kin-daemon/src/lifecycle.rs
+++ b/crates/kin-daemon/src/lifecycle.rs
@@ -642,35 +642,13 @@ where
 /// incarnation.
 const ENDPOINT_OWNER_FILE: &str = "daemon.owner";
 
-/// Schema tag carried by [`ENDPOINT_OWNER_FILE`].
-const ENDPOINT_OWNER_SCHEMA: &str = "kin.daemon.endpoint-owner.v1";
-
-/// Who published the endpoint currently on disk.
+/// The record written into [`ENDPOINT_OWNER_FILE`].
 ///
-/// `daemon.pid` holds a bare PID because every version of every Kin surface
-/// reads it that way, and a PID alone cannot survive reuse: after the recorded
-/// daemon exits, that number starts naming whatever the kernel handed it to
-/// next, and a reader comparing PIDs either preserves a dead endpoint forever
-/// or deletes a live one. This sidecar records the same process incarnation the
-/// singleton lock stamps, so ownership can be *proved* rather than inferred
-/// from a number.
-/// The record carries identity and nothing else. A port field was tempting and
-/// is deliberately absent: `daemon.port` is the port, nothing would read a
-/// second copy, and two records of the same fact can only ever disagree.
-#[derive(Debug, Clone, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
-struct EndpointOwnerRecord {
-    schema: String,
-    identity: kin_cli::daemon_client::ProcessIdentity,
-}
-
-impl EndpointOwnerRecord {
-    fn current() -> Option<Self> {
-        Some(Self {
-            schema: ENDPOINT_OWNER_SCHEMA.to_string(),
-            identity: kin_cli::daemon_client::current_process_identity().ok()?,
-        })
-    }
-}
+/// Declared once, beside the process identity it carries, and shared with the
+/// CLI start path that reads it: the daemon publishes attribution and the CLI
+/// decides from it whether an endpoint may be replaced, and two declarations of
+/// one schema are two things to keep in step.
+use kin_cli::daemon_client::EndpointOwnerRecord;
 
 /// What the on-disk endpoint says about its owner.
 ///
@@ -701,11 +679,7 @@ impl EndpointOwnership {
     }
 }
 
-fn read_endpoint_owner_record(kin_root: &Path) -> Option<EndpointOwnerRecord> {
-    let raw = std::fs::read_to_string(kin_root.join(ENDPOINT_OWNER_FILE)).ok()?;
-    let record: EndpointOwnerRecord = serde_json::from_str(&raw).ok()?;
-    (record.schema == ENDPOINT_OWNER_SCHEMA).then_some(record)
-}
+use kin_cli::daemon_client::read_endpoint_owner_record;
 
 /// Classify the published endpoint's owner.
 ///
@@ -735,24 +709,24 @@ fn endpoint_ownership_with_probe(
         // `read(daemon.pid) == process::id()`, which cannot fail; routing the
         // self case through a fallible probe would let a transient error
         // refuse a daemon permission to retire its own endpoint and strand it.
-        if record.identity.pid() == std::process::id() {
+        if record.identity().pid() == std::process::id() {
             return match kin_cli::daemon_client::current_process_identity() {
-                Ok(current) if current == record.identity => EndpointOwnership::CurrentProcess,
+                Ok(current) if current == *record.identity() => EndpointOwnership::CurrentProcess,
                 // Our PID, a different incarnation: the publisher is gone and
                 // the kernel handed us its number.
                 Ok(_) => EndpointOwnership::OtherProcess {
-                    pid: record.identity.pid(),
+                    pid: record.identity().pid(),
                     live: false,
                 },
                 Err(_) => EndpointOwnership::OtherProcess {
-                    pid: record.identity.pid(),
+                    pid: record.identity().pid(),
                     live: true,
                 },
             };
         }
-        return match probe(&record.identity) {
+        return match probe(record.identity()) {
             Ok(is_current) => EndpointOwnership::OtherProcess {
-                pid: record.identity.pid(),
+                pid: record.identity().pid(),
                 live: is_current,
             },
             // An identity that cannot be read at all (another user's process)
@@ -761,7 +735,7 @@ fn endpoint_ownership_with_probe(
             // live here. Publication asks a different question and must not
             // reuse this answer: see [`proven_live_other_endpoint_owner`].
             Err(_) => EndpointOwnership::OtherProcess {
-                pid: record.identity.pid(),
+                pid: record.identity().pid(),
                 live: true,
             },
         };
@@ -810,12 +784,12 @@ fn proven_live_other_endpoint_owner_with_probe(
         return None;
     }
     let record = read_endpoint_owner_record(kin_root)?;
-    if record.identity.pid() == std::process::id() {
+    if record.identity().pid() == std::process::id() {
         return None;
     }
-    probe(&record.identity)
+    probe(record.identity())
         .unwrap_or(false)
-        .then(|| record.identity.pid())
+        .then(|| record.identity().pid())
 }
 
 /// Publish an endpoint attributed to a process other than this one, so tests
@@ -828,10 +802,7 @@ pub(crate) fn publish_foreign_endpoint_for_test(
     port: u16,
 ) {
     let pid = identity.pid();
-    let record = EndpointOwnerRecord {
-        schema: ENDPOINT_OWNER_SCHEMA.to_string(),
-        identity,
-    };
+    let record = EndpointOwnerRecord::for_identity(identity);
     std::fs::write(kin_root.join("daemon.pid"), pid.to_string()).unwrap();
     std::fs::write(kin_root.join("daemon.port"), port.to_string()).unwrap();
     std::fs::write(
@@ -4388,7 +4359,7 @@ mod tests {
             "publication must record who published"
         );
         let record = read_endpoint_owner_record(root).expect("owner record parses");
-        assert_eq!(record.identity.pid(), std::process::id());
+        assert_eq!(record.identity().pid(), std::process::id());
     }
 
     #[test]
@@ -4516,11 +4487,7 @@ mod tests {
         std::fs::write(root.join("daemon.port"), "51234").unwrap();
         std::fs::write(
             root.join(ENDPOINT_OWNER_FILE),
-            serde_json::to_string(&EndpointOwnerRecord {
-                schema: ENDPOINT_OWNER_SCHEMA.to_string(),
-                identity,
-            })
-            .unwrap(),
+            serde_json::to_string(&EndpointOwnerRecord::for_identity(identity)).unwrap(),
         )
         .unwrap();
 

--- a/crates/kin-daemon/src/lifecycle.rs
+++ b/crates/kin-daemon/src/lifecycle.rs
@@ -1075,14 +1075,6 @@ fn is_port_open(port: u16) -> bool {
     std::net::TcpStream::connect_timeout(&addr, Duration::from_millis(200)).is_ok()
 }
 
-#[cfg(target_os = "macos")]
-fn find_free_port() -> Option<u16> {
-    std::net::TcpListener::bind("127.0.0.1:0")
-        .ok()
-        .and_then(|l| l.local_addr().ok())
-        .map(|a| a.port())
-}
-
 // ── Daemon Binary Discovery ─────────────────────────────────────────────
 
 #[cfg(target_os = "macos")]
@@ -1186,36 +1178,12 @@ fn validate_launch_agent_daemon_binary(path: &Path) -> Result<(), String> {
 /// their command through, rather than repeated per crate.
 pub const MCP_IDLE_TIMEOUT_SECS: &str = kin_daemon_spawn::MCP_IDLE_TIMEOUT_SECS;
 
-// ── The One Function ────────────────────────────────────────────────────
-
-/// Ensure the daemon is running for this repo. Returns its base URL.
-///
-/// 1. If a compatible repo daemon is already ready, return its URL.
-/// 2. Otherwise use the shared supervisor/startup contract and wait for
-///    repository-identity-checked readiness.
-/// 3. If start fails → return Err.
-///
-/// This compatibility entry point delegates to the CLI-owned lifecycle
-/// implementation so there is only one startup, readiness, supervisor, and
-/// failure-cleanup contract.
-pub async fn ensure_daemon_running(kin_root: &Path) -> Result<String, AutoStartError> {
-    ensure_daemon_running_with_idle_timeout(kin_root, None).await
-}
-
-/// Like [`ensure_daemon_running`] but lets the caller inject a specific idle
-/// timeout into the spawned daemon process.
-///
-/// Pass `Some(MCP_IDLE_TIMEOUT_SECS)` on the MCP-initiated path (30 min) so
-/// interactive agent sessions don't expire the daemon mid-session.  Pass
-/// `None` to use the compiled default (60 s).  An explicit
-/// `KIN_DAEMON_IDLE_TIMEOUT_SECS` env var always takes precedence over both.
-pub async fn ensure_daemon_running_with_idle_timeout(
-    kin_root: &Path,
-    idle_timeout_override: Option<&'static str>,
-) -> Result<String, AutoStartError> {
-    kin_cli::daemon_client::ensure_daemon_running_with_idle_timeout(kin_root, idle_timeout_override)
-        .await
-}
+// Starting a repo daemon is not this crate's surface. `kin-cli` owns the one
+// startup, readiness, supervisor, and failure-cleanup contract, and
+// `kin-daemon-spawn` owns the decisions both start paths share. This module
+// used to re-export a third entry point on top of them, which for a published
+// crate is an invitation to start a daemon through a path nothing in tree
+// exercises. Call `kin_cli::daemon_client::ensure_daemon_running` instead.
 
 // ── macOS Launch Agent (start on boot) ───────────────────────────────────
 
@@ -2429,45 +2397,23 @@ fn install_replacement_after_legacy_preflight<Replacement>(
     }
 }
 
-/// Internal implementation for a future Kin-owned launchd opt-in surface.
+/// Render the LaunchAgent plist for one repository.
 ///
-/// This stays crate-private because its containment re-executes the current
-/// Kin product binary, which must dispatch the private guardian mode before
-/// argument parsing. Exposing it to arbitrary downstream executables would
-/// create an invalid implicit host contract. The current CLI does not call it
-/// during `kin init`.
-///
-/// Each repo gets its own agent with a canonical-root digest label:
-///   ai.firelock.kin-daemon.<digest>.<readable-suffix>
+/// Pure in its inputs so the argument vector launchd will run is assertable
+/// without installing anything, which is the only way the port rule above stays
+/// pinned: it is a property of the plist, not of a code path a test can reach.
 #[cfg(target_os = "macos")]
-#[allow(dead_code)]
-pub(crate) fn register_launch_agent(kin_root: &Path) -> Result<(), String> {
-    let working_dir = kin_root.parent().ok_or("no parent")?;
-    let canonical_working_dir = working_dir.canonicalize().map_err(|error| {
-        format!(
-            "canonicalize repository root {} for LaunchAgent registration: {error}",
-            working_dir.display()
-        )
-    })?;
-    let repo_path = launch_agent_path_text(&canonical_working_dir, "repository root")?;
-
-    let binary_resolution_cwd = std::env::current_dir()
-        .map_err(|error| format!("resolve current directory for kin-daemon selection: {error}"))?;
-    let selected_daemon =
-        find_daemon_binary().ok_or_else(|| "kin-daemon binary not found".to_string())?;
-    let daemon_bin = resolve_launch_agent_daemon_binary(&selected_daemon, &binary_resolution_cwd)?;
-    validate_launch_agent_daemon_binary(&daemon_bin)?;
-    let daemon_path = launch_agent_path_text(&daemon_bin, "kin-daemon path")?;
-
-    let port = read_port_file(kin_root).unwrap_or_else(|| find_free_port().unwrap_or(4219));
-
-    let label = launch_agent_label(&canonical_working_dir)?;
-    let escaped_label = plist_xml_text(&label)?;
+fn render_launch_agent_plist(
+    label: &str,
+    daemon_path: &str,
+    repo_path: &str,
+) -> Result<String, String> {
+    let escaped_label = plist_xml_text(label)?;
     let escaped_bin = plist_xml_text(daemon_path)?;
     let escaped_repo = plist_xml_text(repo_path)?;
     let escaped_stdout = plist_xml_text(&format!("/tmp/{label}.stdout.log"))?;
     let escaped_stderr = plist_xml_text(&format!("/tmp/{label}.stderr.log"))?;
-    let plist = format!(
+    Ok(format!(
         r#"<?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN"
   "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
@@ -2498,10 +2444,52 @@ pub(crate) fn register_launch_agent(kin_root: &Path) -> Result<(), String> {
         label = escaped_label,
         bin = escaped_bin,
         repo = escaped_repo,
-        port = port,
+        port = kin_daemon_spawn::DAEMON_PORT_ARGUMENT,
         stdout = escaped_stdout,
         stderr = escaped_stderr,
-    );
+    ))
+}
+
+/// Internal implementation for a future Kin-owned launchd opt-in surface.
+///
+/// This stays crate-private because its containment re-executes the current
+/// Kin product binary, which must dispatch the private guardian mode before
+/// argument parsing. Exposing it to arbitrary downstream executables would
+/// create an invalid implicit host contract. The current CLI does not call it
+/// during `kin init`.
+///
+/// Each repo gets its own agent with a canonical-root digest label:
+///   ai.firelock.kin-daemon.<digest>.<readable-suffix>
+#[cfg(target_os = "macos")]
+#[allow(dead_code)]
+pub(crate) fn register_launch_agent(kin_root: &Path) -> Result<(), String> {
+    let working_dir = kin_root.parent().ok_or("no parent")?;
+    let canonical_working_dir = working_dir.canonicalize().map_err(|error| {
+        format!(
+            "canonicalize repository root {} for LaunchAgent registration: {error}",
+            working_dir.display()
+        )
+    })?;
+    let repo_path = launch_agent_path_text(&canonical_working_dir, "repository root")?;
+
+    let binary_resolution_cwd = std::env::current_dir()
+        .map_err(|error| format!("resolve current directory for kin-daemon selection: {error}"))?;
+    let selected_daemon =
+        find_daemon_binary().ok_or_else(|| "kin-daemon binary not found".to_string())?;
+    let daemon_bin = resolve_launch_agent_daemon_binary(&selected_daemon, &binary_resolution_cwd)?;
+    validate_launch_agent_daemon_binary(&daemon_bin)?;
+    let daemon_path = launch_agent_path_text(&daemon_bin, "kin-daemon path")?;
+
+    // The daemon owns port selection, here as on every other start path. This
+    // used to bake a number into the plist: the port a daemon happened to be
+    // serving, or one probed with a listener and released, or 4219 when neither
+    // was available. Every one of those is a port some other process may hold
+    // by the time launchd runs the agent, and `KeepAlive` then restarts a
+    // daemon that keeps dying on the same bind conflict. Passing zero makes the
+    // daemon bind an ephemeral port and publish it, which is what the port file
+    // exists for and what every reader already consults.
+    let label = launch_agent_label(&canonical_working_dir)?;
+    let plist = render_launch_agent_plist(&label, daemon_path, repo_path)?;
 
     let home = std::env::var("HOME").map_err(|_| "HOME not set")?;
     let launch_agents = PathBuf::from(&home).join("Library/LaunchAgents");
@@ -3631,6 +3619,44 @@ mod tests {
         assert!(
             legacy_plist.exists(),
             "unverifiable relative legacy plist must remain"
+        );
+    }
+
+    #[cfg(target_os = "macos")]
+    #[test]
+    fn a_launch_agent_lets_the_daemon_choose_its_own_port() {
+        // The plist used to carry a number: the port a daemon happened to be
+        // serving, one probed with a listener and immediately released, or 4219.
+        // launchd runs this argument vector at boot, long after any of those
+        // facts was true, and `KeepAlive` turns a bind conflict into a restart
+        // loop. Zero is the same request every other start path makes.
+        let plist = render_launch_agent_plist(
+            "ai.firelock.kin-daemon.digest.repo",
+            "/usr/local/bin/kin-daemon",
+            "/repos/app",
+        )
+        .expect("render the launch agent plist");
+
+        let dir = tempfile::tempdir().expect("tempdir");
+        let plist_path = dir.path().join("agent.plist");
+        std::fs::write(&plist_path, &plist).expect("write plist");
+        let arguments =
+            read_plist_program_arguments(&plist_path).expect("extract ProgramArguments");
+
+        assert_eq!(
+            arguments,
+            vec![
+                "/usr/local/bin/kin-daemon",
+                "--repo",
+                "/repos/app",
+                "--port",
+                kin_daemon_spawn::DAEMON_PORT_ARGUMENT,
+            ],
+            "launchd must ask the daemon to bind and report a port, not name one"
+        );
+        assert!(
+            !plist.contains("4219"),
+            "no hardcoded fallback port may survive in the plist: {plist}"
         );
     }
 

--- a/scripts/zero-file-search-allowlist.json
+++ b/scripts/zero-file-search-allowlist.json
@@ -261,7 +261,6 @@
         "rollback_with_actions",
         "read_bounded_launch_agent_plist",
         "write_launch_agent_stage",
-        "ensure_daemon_running_with_idle_timeout",
         {
           "fn": "register_launch_agent",
           "count": 2
@@ -270,7 +269,6 @@
           "fn": "unregister_launch_agent",
           "count": 2
         },
-        "read_endpoint_owner_record",
         "endpoint_ownership_with_probe",
         "proven_live_other_endpoint_owner_with_probe",
         "publish_foreign_endpoint_for_test",


### PR DESCRIPTION
The daemon publishes a sidecar naming the process incarnation that owns a repo endpoint, and every destructive decision on the daemon side is already made against that record. The CLI start path had not moved: it still decided from the bare PID in `daemon.pid`. That is a decision a PID cannot support. A SIGKILLed daemon leaves its endpoint behind, the kernel later hands that number to an unrelated process, `kill(pid, 0)` reports it alive, and the start path concludes forever that a live daemon it cannot reach owns the repo. The endpoint is never proven invalid, so nothing retires it and nothing respawns, and autostart wedges permanently on a repo whose daemon is long dead.

Both CLI call sites now judge the recorded incarnation and fall back to the bare PID only for a legacy endpoint published without attribution, which is what `kin_daemon::lifecycle::endpoint_ownership` already does. The asymmetry that split is built on is preserved. These two sites govern whether an endpoint may be deleted, so only affirmative death authorizes retirement and an indeterminate probe stays ownership preserving; refusing to retire what cannot be inspected costs a stale file, while retiring a live daemon's endpoint strands the repo. The stricter "provably a different live incarnation" question governs publication, and that one is untouched on the daemon side.

Attribution is read after the endpoint it attributes, which is load bearing rather than incidental. Publication installs the owner record before the PID file, so a snapshot showing a successor's endpoint always has a readable successor record beside it. Reading the record first would instead pair a predecessor's dead identity with a successor's live endpoint, and the compare and retire would then find the successor's files unchanged and delete them. The chosen order can only ever make the verdict more conservative.

The record schema now has one definition, in `kin-cli` beside the process identity it carries, rather than one in the writer and another in the reader. Two declarations of one schema are two things to keep in step, which is the same argument the record's own documentation already makes about refusing to store a second copy of the port.

Separately, `kin-daemon` published a third pair of start entry points on top of the two the shared spawn contract exists to reconcile. They had become thin delegations to the CLI implementation, so nothing in tree reached them, but a published crate exporting another way to start a daemon is an invitation to use a path no test covers. They are removed, along with the free port probe that became unreferenced with them.

The macOS LaunchAgent kept its own port policy: the port a daemon happened to be serving, or one probed with a listener and released before launchd could ever use it, or 4219 when neither was available. launchd runs that argument vector at boot, long after any of those facts was true, and `KeepAlive` turns the resulting bind conflict into a restart loop. It now passes the same zero every other start path passes, so the daemon binds an ephemeral port and publishes it to the port file every reader already consults. Rendering the plist became a pure function so the argument vector launchd will actually run is assertable without installing anything.

Tests cover the recycled PID case on both call sites, built by altering a real identity's birth token so the PID is genuinely running and only the incarnation differs, which is the shape PID reuse produces and the one a bare PID probe cannot see. The inverse cases are covered too, so the fix cannot degenerate into always retiring: a verified live owner keeps its endpoint, an owner that cannot be inspected keeps it, attribution naming a different PID falls back to the endpoint it describes, and an unattributed endpoint is still judged by its PID. Reverting the identity wiring fails exactly the two recycled PID tests and leaves the other four green, with the probe returning `LiveNotReady` rather than `Invalid`, which is the reported wedge reproduced as a test.

Closes FIR-1690
Closes FIR-1691
