### PR TITLE
Bound integration daemon lifetime by the runtime teardown proof

### DIFF
--- a/crates/kin-cli/tests/common/mod.rs
+++ b/crates/kin-cli/tests/common/mod.rs
@@ -50,6 +50,21 @@ const COMMAND_DIAGNOSTIC_LIMIT: usize = 4 * 1024;
 const COMMAND_DIAGNOSTIC_MARKER: &str = "\n[bounded capture truncated]";
 const RUNTIME_OWNER_ENV: &str = "KIN_TEST_RUNTIME_OWNER_TOKEN";
 const RUNTIME_CONTAINMENT_GROUP_ENV: &str = "KIN_TEST_RUNTIME_CONTAINMENT_PROCESS_GROUP";
+pub const IDLE_SHUTDOWN_DISABLED_ENV: &str = "KIN_DAEMON_IDLE_TIMEOUT_SECS";
+pub const SUPERVISOR_IDLE_SHUTDOWN_DISABLED_ENV: &str = "KIN_SUPERVISOR_IDLE_TIMEOUT_SECS";
+/// The value both idle-shutdown controls read as "never idle out".
+///
+/// `kin-daemon` treats an empty value or `0` as no idle window at all; every
+/// other value is a number of seconds after which it retires itself.
+pub const IDLE_SHUTDOWN_DISABLED: &str = "0";
+
+/// Whether a configured idle-shutdown value leaves the daemon's idle clock off,
+/// applying the daemon's own parsing rule rather than matching one literal.
+pub fn disables_idle_shutdown(value: Option<&OsStr>) -> bool {
+    value
+        .and_then(OsStr::to_str)
+        .is_some_and(|value| matches!(value.trim(), "" | "0"))
+}
 
 #[cfg(unix)]
 struct RuntimeContainment {
@@ -1023,8 +1038,25 @@ impl IsolatedDaemonRuntime {
             .env("XDG_CONFIG_HOME", self.home_path.join(".config"))
             .env(RUNTIME_OWNER_ENV, &self.owner_token)
             .env("KIN_VFS_DISABLE", "1")
-            .env("KIN_DAEMON_IDLE_TIMEOUT_SECS", "1")
-            .env("KIN_SUPERVISOR_IDLE_TIMEOUT_SECS", "1")
+            // Idle shutdown is disabled because this runtime already bounds
+            // daemon lifetime with evidence rather than a clock. `Drop` stops
+            // every process through the product CLI, terminates the
+            // guardian-owned process group, reaps each direct child, and only
+            // then accepts the final empty-group proof; a killed test binary
+            // reaches the same end through the guardian's own parent-death
+            // watch, and a daemon whose temporary repository disappears exits
+            // on its control-plane check. An idle window adds nothing to that
+            // and races the test holding the daemon: the window is measured
+            // from daemon readiness, so a loaded machine can retire a daemon
+            // between the moment a command proves the endpoint healthy and the
+            // moment it dispatches, and the command then fails against an
+            // endpoint that was live when it was read. Any value short enough
+            // to retire daemons promptly is short enough to lose that race.
+            .env(IDLE_SHUTDOWN_DISABLED_ENV, IDLE_SHUTDOWN_DISABLED)
+            .env(
+                SUPERVISOR_IDLE_SHUTDOWN_DISABLED_ENV,
+                IDLE_SHUTDOWN_DISABLED,
+            )
             // Production deliberately allows ~18s for graceful daemon
             // shutdown and force-exits after ~25s. Integration cleanup has a
             // tighter independent bound, so use the daemon's supported grace
@@ -1196,6 +1228,54 @@ impl IsolatedDaemonRuntime {
                 let _ = std::fs::remove_file(parent.join(name));
             }
         }
+    }
+}
+
+/// What a repository's recorded daemon endpoint can be proven to be.
+///
+/// The published record and the listener it names are separate pieces of state,
+/// so a probe has to separate "no daemon is advertised" from "a daemon is
+/// advertised and does not answer". Only the second breaks a caller: a command
+/// reads the record, proves the endpoint healthy, and dispatches against a
+/// listener that is already gone.
+#[derive(Debug)]
+pub enum RecordedDaemonEndpoint {
+    Unrecorded,
+    Listening { port: u16 },
+    NotListening { port: u16, error: String },
+    Unreadable { detail: String },
+}
+
+const ENDPOINT_PROBE_TIMEOUT: Duration = Duration::from_secs(2);
+
+/// Probe the endpoint `kin_root`'s daemon record names, without spawning one.
+///
+/// `kin_root` is the `.kin/` directory, the same one the daemon publishes into.
+pub fn probe_recorded_daemon_endpoint(kin_root: &Path) -> RecordedDaemonEndpoint {
+    let port_path = kin_root.join(kin_daemon_spawn::PORT_FILE_NAME);
+    let recorded = match std::fs::read_to_string(&port_path) {
+        Ok(recorded) => recorded,
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => {
+            return RecordedDaemonEndpoint::Unrecorded;
+        }
+        Err(error) => {
+            return RecordedDaemonEndpoint::Unreadable {
+                detail: format!("read {}: {error}", port_path.display()),
+            };
+        }
+    };
+    let Ok(port) = recorded.trim().parse::<u16>() else {
+        return RecordedDaemonEndpoint::Unreadable {
+            detail: format!("{} does not name a port: {recorded:?}", port_path.display()),
+        };
+    };
+    let address = std::net::SocketAddr::from(([127, 0, 0, 1], port));
+    match std::net::TcpStream::connect_timeout(&address, ENDPOINT_PROBE_TIMEOUT) {
+        Ok(_) => RecordedDaemonEndpoint::Listening { port },
+        Err(error) => RecordedDaemonEndpoint::NotListening {
+            port,
+            error: error.to_string(),
+        },
     }
 }
 

--- a/crates/kin-cli/tests/contextbench_locate_json.rs
+++ b/crates/kin-cli/tests/contextbench_locate_json.rs
@@ -96,7 +96,6 @@ fn contextbench_locate_keeps_query_selection_and_normalization_inside_kin() {
             ])
             .env("KIN_DAEMON_BIN", &daemon_bin)
             .env("KIN_DAEMON_DISABLE_LSP", "1")
-            .env("KIN_DAEMON_IDLE_TIMEOUT_SECS", "1")
             .env("KIN_DAEMON_READY_TIMEOUT_SECS", "30")
             .env("KIN_BYPASS_EMBEDDING_COVERAGE_CHECK", "1")
             .current_dir(repo.path())

--- a/crates/kin-cli/tests/git_export_roundtrip.rs
+++ b/crates/kin-cli/tests/git_export_roundtrip.rs
@@ -106,7 +106,6 @@ fn kin(runtime: &common::IsolatedDaemonRuntime) -> Command<'_> {
     let mut cmd = runtime.kin_command();
     cmd.env("KIN_DAEMON_DISABLE_LSP", "1")
         .env("KIN_DAEMON_BIN", runtime.daemon_bin())
-        .env("KIN_DAEMON_IDLE_TIMEOUT_SECS", "1")
         .env("KIN_DAEMON_READY_TIMEOUT_SECS", "30")
         .env("KIN_BYPASS_EMBEDDING_COVERAGE_CHECK", "1");
     cmd

--- a/crates/kin-cli/tests/locate_json_stdout.rs
+++ b/crates/kin-cli/tests/locate_json_stdout.rs
@@ -12,17 +12,42 @@ mod common;
 
 use common::Command;
 
+/// Cap on the wait for an idle daemon to finish retiring.
+///
+/// Only a last resort. It bounds a loop that polls the retirement evidence
+/// itself, and it is far enough above the idle window and the shutdown grace
+/// that reaching it means retirement stalled rather than that it was slow.
 #[cfg(unix)]
-fn wait_for_pid_exit(pid: u32) {
-    let deadline = Instant::now() + Duration::from_secs(10);
-    while Instant::now() < deadline {
+const RETIREMENT_OBSERVATION: Duration = Duration::from_secs(30);
+
+/// Wait for an idle daemon to retire: its process gone and the endpoint files
+/// it published removed.
+///
+/// Retirement is several steps. The listener closes, the process exits, and the
+/// published record is removed, and only the last of those is what a later
+/// command would see. Waiting on the process alone proves an early step and
+/// then assumes the rest, which holds only while the remaining steps happen to
+/// fit in the slack left over. So poll the published evidence directly and name
+/// whichever part of it never arrived.
+#[cfg(unix)]
+fn wait_for_retired_daemon(pid: u32, daemon_pid: &std::path::Path, daemon_port: &std::path::Path) {
+    let deadline = Instant::now() + RETIREMENT_OBSERVATION;
+    loop {
         let alive = unsafe { libc::kill(pid as libc::pid_t, 0) == 0 };
-        if !alive {
+        let pid_recorded = daemon_pid.exists();
+        let port_recorded = daemon_port.exists();
+        if !alive && !pid_recorded && !port_recorded {
             return;
+        }
+        if Instant::now() >= deadline {
+            panic!(
+                "idle daemon did not retire within {RETIREMENT_OBSERVATION:?}: process {pid} \
+                 alive={alive}, daemon.pid present={pid_recorded}, daemon.port \
+                 present={port_recorded}"
+            );
         }
         std::thread::sleep(Duration::from_millis(100));
     }
-    panic!("process {pid} did not exit");
 }
 
 /// Commit everything in the worktree so `kin init` sees a clean Git migration
@@ -67,6 +92,39 @@ fn kin_command(runtime: &common::IsolatedDaemonRuntime) -> Command<'_> {
         .env("KIN_DAEMON_BIN", runtime.daemon_bin())
         .env("KIN_DAEMON_READY_TIMEOUT_SECS", "30")
         .env("KIN_BYPASS_EMBEDDING_COVERAGE_CHECK", "1");
+    cmd
+}
+
+/// Idle window for the one test whose subject is a daemon retiring itself.
+///
+/// The shared runtime leaves daemon lifetime to its teardown proof, so a daemon
+/// only retires on its own when the command that spawned it asked for a window.
+///
+/// The value is not free to raise. At one second the daemon exits and removes
+/// the endpoint files it published, which is what this test observes. At five
+/// the process still exits but the files survive past thirty seconds of
+/// polling, so retirement completes in one case and not the other. Until that
+/// difference is understood, this stays at the window the assertion was written
+/// against rather than a longer one that quietly stops proving it.
+const IDLE_SHUTDOWN_UNDER_TEST_SECS: &str = "1";
+
+/// A command that asks the runtime it starts to retire itself when idle.
+///
+/// Both halves carry the window. The worker publishes the endpoint files, and
+/// the supervisor outliving it keeps that endpoint from being retired, so a
+/// test that observes the files disappear needs the whole runtime to wind down
+/// rather than only the worker. A process takes its window from whichever
+/// command spawned it, so every command in such a test has to carry this.
+fn kin_command_awaiting_idle_shutdown(runtime: &common::IsolatedDaemonRuntime) -> Command<'_> {
+    let mut cmd = kin_command(runtime);
+    cmd.env(
+        "KIN_DAEMON_IDLE_TIMEOUT_SECS",
+        IDLE_SHUTDOWN_UNDER_TEST_SECS,
+    )
+    .env(
+        "KIN_SUPERVISOR_IDLE_TIMEOUT_SECS",
+        IDLE_SHUTDOWN_UNDER_TEST_SECS,
+    );
     cmd
 }
 
@@ -175,7 +233,7 @@ fn locate_autostarts_daemon_when_available() {
     );
     commit_worktree(repo.path(), "seed");
 
-    let init = kin_command(&runtime)
+    let init = kin_command_awaiting_idle_shutdown(&runtime)
         .arg("init")
         .arg(".")
         .current_dir(repo.path())
@@ -196,7 +254,7 @@ fn locate_autostarts_daemon_when_available() {
     path_entries.insert(0, daemon_dir.to_path_buf());
     let path = env::join_paths(path_entries).expect("join PATH");
 
-    let locate = kin_command(&runtime)
+    let locate = kin_command_awaiting_idle_shutdown(&runtime)
         .arg("locate")
         .arg("--json")
         .arg("lexer issue")
@@ -223,11 +281,7 @@ fn locate_autostarts_daemon_when_available() {
         .ok()
         .and_then(|raw| raw.trim().parse::<u32>().ok())
     {
-        wait_for_pid_exit(pid);
-        assert!(
-            !daemon_pid.exists() && !daemon_port.exists(),
-            "idle daemon should remove endpoint files"
-        );
+        wait_for_retired_daemon(pid, &daemon_pid, &daemon_port);
     }
 }
 

--- a/crates/kin-cli/tests/locate_json_stdout.rs
+++ b/crates/kin-cli/tests/locate_json_stdout.rs
@@ -65,7 +65,6 @@ fn kin_command(runtime: &common::IsolatedDaemonRuntime) -> Command<'_> {
     let mut cmd = runtime.kin_command();
     cmd.env("KIN_DAEMON_DISABLE_LSP", "1")
         .env("KIN_DAEMON_BIN", runtime.daemon_bin())
-        .env("KIN_DAEMON_IDLE_TIMEOUT_SECS", "1")
         .env("KIN_DAEMON_READY_TIMEOUT_SECS", "30")
         .env("KIN_BYPASS_EMBEDDING_COVERAGE_CHECK", "1");
     cmd
@@ -203,7 +202,6 @@ fn locate_autostarts_daemon_when_available() {
         .arg("lexer issue")
         .env("PATH", path)
         .env("KIN_DAEMON_DISABLE_LSP", "1")
-        .env("KIN_DAEMON_IDLE_TIMEOUT_SECS", "1")
         .env("KIN_DAEMON_READY_TIMEOUT_SECS", "30")
         .current_dir(repo.path())
         .output()

--- a/crates/kin-cli/tests/prepared_state_json.rs
+++ b/crates/kin-cli/tests/prepared_state_json.rs
@@ -269,7 +269,6 @@ fn prepared_state_publish_and_materialize_preserve_indexed_state() {
         .args(["support", "--json"])
         .env("KIN_DAEMON_BIN", runtime.daemon_bin())
         .env("KIN_DAEMON_DISABLE_LSP", "1")
-        .env("KIN_DAEMON_IDLE_TIMEOUT_SECS", "1")
         .env("KIN_DAEMON_READY_TIMEOUT_SECS", "30")
         .output()
         .expect("run kin support --json");

--- a/crates/kin-cli/tests/repository_branches.rs
+++ b/crates/kin-cli/tests/repository_branches.rs
@@ -12,6 +12,7 @@ use std::ffi::OsString;
 use std::fs;
 use std::path::Path;
 use std::sync::Arc;
+use std::time::{Duration, Instant};
 use tempfile::tempdir;
 
 mod common;
@@ -479,6 +480,69 @@ fn branch_create_and_delete_commit_exact_ref_cas() {
     assert_eq!(
         delete_record.ref_mutations[0].new_target, None,
         "delete receipt must retain exact deletion"
+    );
+}
+
+/// How long a served daemon is watched for self-retirement.
+///
+/// Long enough to cover a short idle window plus the daemon's own idle check
+/// interval, so a runtime that reintroduces one is caught rather than merely
+/// made less likely to bite.
+const SERVED_DAEMON_OBSERVATION: Duration = Duration::from_secs(3);
+const SERVED_DAEMON_POLL: Duration = Duration::from_millis(50);
+
+#[test]
+fn a_daemon_that_served_a_branch_command_keeps_answering_its_recorded_endpoint() {
+    let root = tempdir().expect("temp root");
+    let repo = root.path().join("repo");
+    initialize_git_repo(&repo);
+    let runtime = common::IsolatedDaemonRuntime::new(&repo);
+    let layout = initialize_kin_repo(&runtime, &repo);
+
+    let command = runtime.kin_command();
+    for key in [
+        common::IDLE_SHUTDOWN_DISABLED_ENV,
+        common::SUPERVISOR_IDLE_SHUTDOWN_DISABLED_ENV,
+    ] {
+        let configured = command
+            .configured_env_for_test(std::ffi::OsStr::new(key))
+            .unwrap_or_else(|| panic!("{key} is not configured by the isolated runtime"));
+        assert!(
+            common::disables_idle_shutdown(configured.as_deref()),
+            "{key}={configured:?} leaves an idle clock running. Daemon lifetime in this runtime \
+             is bounded by its teardown proof, and an idle window instead retires daemons that a \
+             command has already proven healthy."
+        );
+    }
+    drop(command);
+
+    let create = run_kin(&runtime, &repo, &["branch", "create", "retained"]);
+    assert!(
+        create.status.success(),
+        "stdout={} stderr={}",
+        String::from_utf8_lossy(&create.stdout),
+        String::from_utf8_lossy(&create.stderr)
+    );
+
+    let started = Instant::now();
+    let mut proofs = 0_u32;
+    while started.elapsed() < SERVED_DAEMON_OBSERVATION {
+        match common::probe_recorded_daemon_endpoint(layout.root()) {
+            common::RecordedDaemonEndpoint::Listening { .. } => proofs += 1,
+            observed => panic!(
+                "the daemon that served this repository stopped answering its recorded \
+                 endpoint {:.2}s after a command used it, leaving {observed:?}. A command \
+                 that reads this record, proves the endpoint healthy, and then dispatches \
+                 against it fails with a refused connection, and the test harness bounds \
+                 daemon lifetime by its teardown proof rather than by an idle clock.",
+                started.elapsed().as_secs_f64()
+            ),
+        }
+        std::thread::sleep(SERVED_DAEMON_POLL);
+    }
+    assert!(
+        proofs > 0,
+        "observation window never probed the recorded daemon endpoint"
     );
 }
 


### PR DESCRIPTION
Three `kin-cli::repository_branches` tests failed together on both matrix legs of one CI run while passing on a dependabot run against the same base, with overlapping durations on either side of the split. The failure was not a slow test. Each of the three panicked on the first `kin` command after `kin init`, and the captured stderr names the mechanism exactly:

```
Error: send daemon-owned repository branch request
Caused by:
    0: error sending request for url (http://127.0.0.1:49441/commands/branch)
    1: client error (Connect)
    2: tcp connect error
    3: Connection refused (os error 61)
```

The command read a published daemon endpoint and dispatched against a listener that was already gone.

The shared integration runtime pinned every subprocess it launches to a one second daemon and supervisor idle window. The product default is 3600 seconds, so this is a three-orders-of-magnitude compression applied to every test that uses the harness. The window is measured from daemon readiness rather than from the command that owns the daemon, so on a loaded machine a daemon can retire between the moment a command proves its endpoint healthy and the moment it sends its request. The single retry in the idempotent post path re-dispatches to the same dead URL, so it cannot recover. The value is not a longstanding one: it arrived with the hermetic-subprocess rework, which brought `repository_branches` under a runtime it had never used before, and these tests previously ran with the product default.

Nothing needed the clock. The runtime already bounds daemon lifetime with evidence rather than wall time. `Drop` stops every process through the product CLI, terminates the guardian-owned process group, reaps each direct child, and only then accepts the final empty-group proof, panicking if any step cannot be proven. A test binary that is killed outright reaches the same end through the guardian's own parent-death watch, and a daemon whose temporary repository disappears exits on its control-plane check without any idle window at all. An idle clock adds nothing to those bounds and races the test that is still holding the daemon. Any value short enough to retire daemons promptly is short enough to lose that race, which is why this is a removal rather than a larger number.

So idle shutdown is disabled in the shared runtime, and the four sibling test files that re-pinned the same one second value on individual commands now inherit that single decision instead of carrying their own copy of the defect.

Two guards keep it from coming back, both in the canonical test. The fast one applies the daemon's own parsing rule to the runtime's configured environment, so any re-pinned window fails immediately and names the reason rather than producing a rare connection refused months later. The behavioral one holds a daemon that actually served a branch command and probes the endpoint its record publishes, over an interval longer than the retired window, failing with the elapsed time and the observed endpoint state.

## The one test whose subject is retirement

`locate_autostarts_daemon_when_available` observes a daemon retiring itself, so it is the single place the window has to stay. A daemon takes its window from whichever command spawned it, and the supervisor outliving its worker keeps the endpoint from being retired, so that test now asks for the window explicitly on both halves of the runtime instead of inheriting it from the harness. This is the pre-existing exposure for that one test rather than a new one, and it is stated plainly rather than hidden: a test that watches a daemon retire cannot also be insulated from retirement.

Its wait was also wrong in a way the harness change exposed. It waited on the daemon process exiting and then asserted that the published endpoint files were gone, which proves an early step and assumes the rest. That held only while the remaining steps fit in the leftover slack. Retirement closes the listener, exits the process, and removes the published record, and only the last of those is what a later command would see, so the wait now polls all three and names whichever part of the evidence never arrived.

Assertions were not weakened. Every semantic check in the three original tests is byte-identical, and the diff is confined to `crates/kin-cli/tests/`.

## Falsification

Restoring the one second window to the shared runtime, with everything else unchanged:

- the environment guard fails at once with `KIN_DAEMON_IDLE_TIMEOUT_SECS=Some("1") leaves an idle clock running`
- with that guard bypassed, the behavioral guard fails at **1.06s** after the command that used the daemon, which is the one second window plus the daemon's 250ms idle check interval, reporting the recorded endpoint had stopped answering

Restored to the committed state, both pass.

The reverse direction is also proven. At the previous head, which disabled idle shutdown without giving the autostart test its own window, CI failed deterministically on macOS at `locate_json_stdout.rs` with `process did not exit`: a daemon with no window never retires, so a test that watches for retirement waits forever. That is the failure the second commit closes.

## Gates

On the rebased tree, all under the lane's isolated target directory:

- `cargo fmt -- --check`, clippy under the ci.yml allowlist with `RUSTFLAGS=-D warnings`, and `cargo build --all-targets --locked`: all exit 0
- `verify-zero-file-search.py`, `zero_file_search_guard.sh`: exit 0, 144 files scanned, invariant holds
- every touched test binary looped 10x under a deliberately oversubscribed machine (load average peaking at 34.8 on 18 cores, a sibling lane's full workspace suite running concurrently): **50 runs, 50 pass, 0 fail** across `repository_branches`, `locate_json_stdout`, `contextbench_locate_json`, `prepared_state_json` and `git_export_roundtrip`
- `cargo test --workspace` under the test-box lock

## Measured side effect

Disabling idle shutdown means a test's daemon lives until its runtime is dropped rather than retiring a second after its last request. A census sampled once a second across the loop puts the peak at **17 concurrent daemons** on an 18 core machine, all reaped by the teardown proof. The suite trades a short-lived daemon per command for one daemon per live runtime, which is what makes the endpoint record trustworthy for the command holding it.

## Production gap flagged, not fixed here

`post_idempotent_json` in `crates/kin-cli/src/daemon_client.rs` retries a transport failure against the same `base_url`. When the failure is a dead listener the retry is guaranteed to fail identically, because it neither re-resolves the endpoint nor respawns. The 3600s product default makes this rare in production, so severity is low, but any daemon that exits mid-command produces an unrecoverable command instead of a respawn. That file belongs to the spawn-liveness lane.

Closes FIR-1716
