### PR TITLE
Separate an absent repository from a storage fault, and refuse a self-contradicting daemon identity at startup

### DIFF
--- a/crates/kin-daemon/src/api.rs
+++ b/crates/kin-daemon/src/api.rs
@@ -6719,6 +6719,14 @@ async fn mcp_tools_call(
 /// identity compare answers "is this the advertised repository" while the
 /// question is "is this one we serve". Those diverge for every sibling a hosted
 /// daemon carries, and a load error holds no evidence either way.
+///
+/// A served repository splits once more, and this half the load itself decides:
+/// a backend that answers completely and holds nothing under the id is a
+/// missing repository (404), while a backend that fails to answer is a fault
+/// (500). The loader types that difference as
+/// [`DaemonError::RepoAbsentFromStorage`] so it survives the trip here. Reading
+/// it back out of a flattened storage error's wording would be the same
+/// infer-from-the-failure mistake the served key space exists to avoid.
 async fn repo_scoped_graph(
     state: &DaemonState,
     repo_id: &str,
@@ -6733,7 +6741,19 @@ async fn repo_scoped_graph(
             ),
         ));
     }
-    state.get_repo_graph(repo_id).await.map_err(internal_error)
+    match state.get_repo_graph(repo_id).await {
+        Ok(graph) => Ok(graph),
+        Err(crate::error::DaemonError::RepoAbsentFromStorage(absent)) => Err((
+            StatusCode::NOT_FOUND,
+            format!(
+                "this daemon serves repository {} and is configured for {absent}, \
+                 but storage holds no graph for {absent}; \
+                 GET /repos lists the repositories storage actually holds",
+                state.cached_repo_id
+            ),
+        )),
+        Err(error) => Err(internal_error(error)),
+    }
 }
 
 async fn repository_authority_snapshot(
@@ -14083,7 +14103,22 @@ mod tests {
     /// expired credentials, a snapshot authority that disagrees with the
     /// acknowledged head, or a corrupt delta chain. All of them arrive as an
     /// `Err` out of the recovery read, which is the single path
-    /// `load_recovered_snapshot` takes.
+    /// `load_recovered_snapshot` takes, so fault injection is scoped to exactly
+    /// the three reads that path makes.
+    ///
+    /// Every other trait method forwards to the inner backend, including the
+    /// ones whose trait defaults would answer instead of delegating. That is
+    /// not tidiness: `supports_incremental_deltas` defaults to `false` and the
+    /// whole source-blob family defaults to "not supported by this backend",
+    /// so a partially-forwarding fixture silently downgrades the very
+    /// capabilities a hosted backend has. A test reusing it would then be
+    /// measuring the fixture's degraded shape and reporting it as hosted
+    /// behavior.
+    ///
+    /// The single method deliberately left on its trait default is
+    /// `compact_deltas`, which `LocalFileBackend` also leaves defaulted. That
+    /// default composes through this type's own reads, so compaction stays
+    /// fault-aware instead of routing around the switch.
     struct RepoFaultBackend {
         inner: kin_db::LocalFileBackend,
         faulting: FaultSwitch,
@@ -14130,6 +14165,10 @@ mod tests {
     const BACKEND_FAULT_TEXT: &str = "object store unreachable";
 
     impl kin_db::StorageBackend for RepoFaultBackend {
+        fn supports_incremental_deltas(&self) -> bool {
+            self.inner.supports_incremental_deltas()
+        }
+
         fn load_recovery_state(
             &self,
             repo_id: &str,
@@ -14161,6 +14200,52 @@ mod tests {
             }
         }
 
+        fn save_source_blob(
+            &self,
+            repo_id: &str,
+            digest: [u8; 32],
+            data: &[u8],
+        ) -> std::result::Result<(), kin_db::KinDbError> {
+            self.inner.save_source_blob(repo_id, digest, data)
+        }
+
+        fn load_source_blob(
+            &self,
+            repo_id: &str,
+            digest: [u8; 32],
+        ) -> std::result::Result<Option<Vec<u8>>, kin_db::KinDbError> {
+            self.inner.load_source_blob(repo_id, digest)
+        }
+
+        fn load_source_blob_bounded(
+            &self,
+            repo_id: &str,
+            digest: [u8; 32],
+            max_bytes: u64,
+        ) -> std::result::Result<Option<Vec<u8>>, kin_db::KinDbError> {
+            self.inner
+                .load_source_blob_bounded(repo_id, digest, max_bytes)
+        }
+
+        fn with_verified_source_blob_batch(
+            &self,
+            repo_id: &str,
+            operation: &mut dyn FnMut(
+                &dyn kin_db::VerifiedSourceBlobBatch,
+            ) -> std::result::Result<(), kin_db::KinDbError>,
+        ) -> std::result::Result<(), kin_db::KinDbError> {
+            self.inner
+                .with_verified_source_blob_batch(repo_id, operation)
+        }
+
+        fn source_blob_len(
+            &self,
+            repo_id: &str,
+            digest: [u8; 32],
+        ) -> std::result::Result<Option<u64>, kin_db::KinDbError> {
+            self.inner.source_blob_len(repo_id, digest)
+        }
+
         fn save_snapshot(
             &self,
             repo_id: &str,
@@ -14168,6 +14253,42 @@ mod tests {
             expected_gen: kin_db::Generation,
         ) -> std::result::Result<kin_db::Generation, kin_db::KinDbError> {
             self.inner.save_snapshot(repo_id, data, expected_gen)
+        }
+
+        fn save_snapshot_classified(
+            &self,
+            repo_id: &str,
+            data: &[u8],
+            expected_cursor: kin_db::SnapshotCursor,
+        ) -> kin_db::SnapshotSaveOutcome {
+            self.inner
+                .save_snapshot_classified(repo_id, data, expected_cursor)
+        }
+
+        fn save_snapshot_validated(
+            &self,
+            repo_id: &str,
+            data: &[u8],
+            expected: kin_db::SnapshotCursor,
+            history_validator_version: Option<u32>,
+        ) -> kin_db::SnapshotSaveOutcome {
+            self.inner
+                .save_snapshot_validated(repo_id, data, expected, history_validator_version)
+        }
+
+        fn record_history_validation(
+            &self,
+            repo_id: &str,
+            generation: kin_db::Generation,
+            snapshot_sha256: &str,
+            validator_version: u32,
+        ) -> std::result::Result<bool, kin_db::KinDbError> {
+            self.inner.record_history_validation(
+                repo_id,
+                generation,
+                snapshot_sha256,
+                validator_version,
+            )
         }
 
         fn save_delta(
@@ -14221,6 +14342,107 @@ mod tests {
         }
     }
 
+    /// The shipped hosted shape: one advertised repo, several allowlisted
+    /// siblings, none of them pre-warmed into the repo graph map, over a
+    /// backend that can be made to fault per repository.
+    fn hosted_state_with_allowlist(
+        label: &str,
+        advertised: &str,
+        siblings: &[&str],
+    ) -> (Arc<DaemonState>, FaultSwitch) {
+        let dir = std::env::temp_dir().join(format!("kin-daemon-{label}-{}", Uuid::new_v4()));
+        let kin_dir = dir.join(".kin");
+        std::fs::create_dir_all(kin_dir.join("objects")).unwrap();
+        std::fs::create_dir_all(kin_dir.join("working")).unwrap();
+        let layout = kin_core::KinLayout::new(kin_dir);
+        kin_core::manifest::KinManifest::new()
+            .save(&layout.manifest_path())
+            .unwrap();
+        let backend_dir = dir.join("backend");
+        std::fs::create_dir_all(&backend_dir).unwrap();
+
+        let (backend, faults) = RepoFaultBackend::new(&backend_dir);
+        let allowed: std::collections::HashSet<String> = std::iter::once(advertised)
+            .chain(siblings.iter().copied())
+            .map(ToOwned::to_owned)
+            .collect();
+        let state = Arc::new(
+            DaemonState::open_with_backend(layout, Box::new(backend), advertised, Some(allowed))
+                .unwrap(),
+        );
+        (state, faults)
+    }
+
+    /// The fault fixture must be indistinguishable from the backend it wraps
+    /// except when a fault is armed. A trait default answering in place of a
+    /// forward is not a smaller lie than a wrong value: it reports "this
+    /// backend cannot do that" about a backend that can, so a test reusing the
+    /// fixture measures a degraded shape and reports it as hosted behavior.
+    #[test]
+    fn the_fault_fixture_forwards_the_capabilities_of_the_backend_it_wraps() {
+        use kin_db::StorageBackend;
+
+        let dir =
+            std::env::temp_dir().join(format!("kin-daemon-fault-fidelity-{}", Uuid::new_v4()));
+        std::fs::create_dir_all(&dir).unwrap();
+        let real = kin_db::LocalFileBackend::new(&dir);
+        let (fixture, _faults) = RepoFaultBackend::new(&dir);
+
+        assert!(
+            real.supports_incremental_deltas(),
+            "the wrapped backend is expected to have a delta write path"
+        );
+        assert_eq!(
+            fixture.supports_incremental_deltas(),
+            real.supports_incremental_deltas(),
+            "a fixture that under-reports delta support sends writes down the wrong path"
+        );
+
+        let repo_id = "fidelity-repo";
+        let body: &[u8] = b"fn main() {}";
+        let digest: [u8; 32] = Sha256::digest(body).into();
+        fixture
+            .save_source_blob(repo_id, digest, body)
+            .expect("the fixture must forward immutable source-blob writes");
+        assert_eq!(
+            real.load_source_blob(repo_id, digest).unwrap().as_deref(),
+            Some(body),
+            "the forwarded write must land in the wrapped backend"
+        );
+        assert_eq!(
+            fixture
+                .load_source_blob(repo_id, digest)
+                .unwrap()
+                .as_deref(),
+            Some(body)
+        );
+        assert_eq!(
+            fixture
+                .load_source_blob_bounded(repo_id, digest, kin_db::MAX_SOURCE_BLOB_BYTES)
+                .unwrap()
+                .as_deref(),
+            Some(body)
+        );
+        assert_eq!(
+            fixture.source_blob_len(repo_id, digest).unwrap(),
+            Some(body.len() as u64)
+        );
+
+        let mut batched: Option<Vec<u8>> = None;
+        fixture
+            .with_verified_source_blob_batch(repo_id, &mut |batch| {
+                batched = batch
+                    .load_verified(kin_db::SourceBlobValidationRequest {
+                        digest,
+                        max_bytes: kin_db::MAX_SOURCE_BLOB_BYTES,
+                    })?
+                    .map(|verified| verified.into_bytes());
+                Ok(())
+            })
+            .expect("the fixture must forward verified batch reads");
+        assert_eq!(batched.as_deref(), Some(body));
+    }
+
     /// A hosted daemon serves every allowlisted repository, not only the one it
     /// advertises. So a backend fault on an allowlisted sibling is a fault, and
     /// answering 404 there would report a GCS outage or a corrupt delta chain as
@@ -14233,30 +14455,9 @@ mod tests {
     /// than inferred from the failure afterwards.
     #[tokio::test]
     async fn a_backend_fault_on_a_served_sibling_stays_a_fault_rather_than_a_404() {
-        let dir = std::env::temp_dir().join(format!("kin-daemon-repo-fault-{}", Uuid::new_v4()));
-        let kin_dir = dir.join(".kin");
-        std::fs::create_dir_all(kin_dir.join("objects")).unwrap();
-        std::fs::create_dir_all(kin_dir.join("working")).unwrap();
-        let layout = kin_core::KinLayout::new(kin_dir);
-        kin_core::manifest::KinManifest::new()
-            .save(&layout.manifest_path())
-            .unwrap();
-        let backend_dir = dir.join("backend");
-        std::fs::create_dir_all(&backend_dir).unwrap();
-
-        // The shipped hosted shape: one advertised repo, several allowlisted
-        // siblings, none of them pre-warmed into the repo graph map.
         let advertised = "primary-repo";
         let sibling = "sibling-repo";
-        let (backend, faults) = RepoFaultBackend::new(&backend_dir);
-        let allowed: std::collections::HashSet<String> =
-            [advertised.to_string(), sibling.to_string()]
-                .into_iter()
-                .collect();
-        let state = Arc::new(
-            DaemonState::open_with_backend(layout, Box::new(backend), advertised, Some(allowed))
-                .unwrap(),
-        );
+        let (state, faults) = hosted_state_with_allowlist("repo-fault", advertised, &[sibling]);
         assert_eq!(
             advertised_repo_id(Arc::clone(&state)).await,
             advertised,
@@ -14305,6 +14506,80 @@ mod tests {
         assert!(
             message.contains(advertised) && message.contains(unserved),
             "the refusal must name both the served and requested ids: {message}"
+        );
+    }
+
+    /// An allowlisted repository with nothing stored under it is a repository
+    /// that is not there, not a daemon that is broken. The backend read
+    /// succeeded and reported neither snapshot authority nor deltas, which is a
+    /// complete answer. Reporting it as a fault told every client, retry loop,
+    /// and 5xx alert that this daemon had failed, when no amount of retrying
+    /// makes an absent repository appear.
+    ///
+    /// It is equally not an identity mismatch: the id IS in this daemon's
+    /// served key space, so the refusal must not claim otherwise.
+    #[tokio::test]
+    async fn an_allowlisted_repo_absent_from_storage_is_missing_rather_than_a_fault() {
+        let advertised = "primary-repo";
+        let absent = "never-stored-repo";
+        let (state, faults) = hosted_state_with_allowlist("repo-absent", advertised, &[absent]);
+        assert_eq!(
+            advertised_repo_id(Arc::clone(&state)).await,
+            advertised,
+            "the fixture must advertise the primary id"
+        );
+        assert!(
+            state.serves_repo_id(absent),
+            "the allowlist is the served key space, so the absent id is served"
+        );
+
+        for path in [
+            format!("/repos/{absent}/health"),
+            format!("/repos/{absent}/entities"),
+            format!("/repos/{absent}/provenance/verify"),
+        ] {
+            let (status, body) = repo_route(Arc::clone(&state), &path).await;
+            let message = String::from_utf8_lossy(&body);
+            assert_eq!(
+                status,
+                StatusCode::NOT_FOUND,
+                "a served repository absent from storage must be missing at {path}: {message}"
+            );
+            assert!(
+                message.contains(advertised) && message.contains(absent),
+                "the refusal must name both the served and requested ids: {message}"
+            );
+            assert!(
+                !message.contains("does not serve"),
+                "an allowlisted repository must not be reported as unserved: {message}"
+            );
+        }
+
+        // The advertised repository still answers on the same daemon, so the
+        // 404s above are about that repository rather than a daemon-wide state.
+        let (status, body) =
+            repo_route(Arc::clone(&state), &format!("/repos/{advertised}/entities")).await;
+        assert_eq!(
+            status,
+            StatusCode::OK,
+            "the advertised repo must stay routable: {}",
+            String::from_utf8_lossy(&body)
+        );
+
+        // Absence is decided by what the load reported, not by the id: the very
+        // same id over a backend that cannot answer is still a fault.
+        faults.start_faulting(absent);
+        let (status, body) =
+            repo_route(Arc::clone(&state), &format!("/repos/{absent}/entities")).await;
+        let message = String::from_utf8_lossy(&body);
+        assert_eq!(
+            status,
+            StatusCode::INTERNAL_SERVER_ERROR,
+            "a backend that cannot answer is still a fault: {message}"
+        );
+        assert!(
+            message.contains(BACKEND_FAULT_TEXT),
+            "the fault must carry the backend error rather than discard it: {message}"
         );
     }
 

--- a/crates/kin-daemon/src/bin/kin-daemon.rs
+++ b/crates/kin-daemon/src/bin/kin-daemon.rs
@@ -1,7 +1,6 @@
 // SPDX-License-Identifier: Apache-2.0
 // Copyright 2026 Firelock, LLC
 
-#[cfg(feature = "gcs")]
 use std::collections::HashSet;
 
 #[global_allocator]
@@ -151,16 +150,64 @@ fn parse_args() -> Result<Args, String> {
     })
 }
 
+/// The `allowed_repo_ids` key space a storage mode hands `DaemonState`, refusing
+/// any configuration whose key space excludes the repository being served.
+///
+/// The daemon takes its identity from two independent sources: the served
+/// repo id (`--repo-id`, `KIN_REPO_ID`, or the manifest) and, in GCS mode, the
+/// allowlist (`KIN_REPO_IDS`). Nothing reconciled them, and
+/// `DaemonState::serves_repo_id` answers from the allowlist alone whenever one
+/// is configured. An allowlist that omits the served id therefore produced a
+/// daemon that advertised that id on `GET /health` and refused it on every
+/// `/repos/{repo_id}` route: a live process whose two identity surfaces
+/// contradict each other, with no request able to tell which one is right.
+///
+/// There is no reading of that configuration under which the daemon can serve
+/// correctly, so it refuses to start rather than admitting the served id behind
+/// the operator's back. Silently widening the allowlist would serve a
+/// repository the operator explicitly did not list, which is the opposite
+/// failure and a worse one in a hosted multi-tenant pod.
+fn served_repo_key_space(
+    storage: &StorageMode,
+    repo_id: &str,
+) -> std::result::Result<Option<HashSet<String>>, String> {
+    let configured: Option<HashSet<String>> = match storage {
+        // Local mode has no allowlist source: the served key space is the
+        // repository authority the daemon opened, so the advertised id is
+        // routable by construction.
+        StorageMode::Local => None,
+        #[cfg(feature = "gcs")]
+        StorageMode::Gcs => parse_allowed_repo_ids(),
+    };
+    match configured {
+        Some(allowed) if !allowed.contains(repo_id) => {
+            let mut listed: Vec<&str> = allowed.iter().map(String::as_str).collect();
+            listed.sort_unstable();
+            Err(format!(
+                "KIN_REPO_IDS does not list the repository this daemon serves. \
+                 Serving repo_id {repo_id}; KIN_REPO_IDS allows [{}]. \
+                 This daemon would advertise {repo_id} on GET /health and then refuse \
+                 it on every /repos/{repo_id} route. Add {repo_id} to KIN_REPO_IDS, or \
+                 unset KIN_REPO_IDS to serve every repository the backend holds.",
+                listed.join(", ")
+            ))
+        }
+        admitted => Ok(admitted),
+    }
+}
+
 fn create_state(
     layout: KinLayout,
     storage: &StorageMode,
     repo_id: &str,
+    #[cfg_attr(not(feature = "gcs"), allow(unused_variables))] allowed_repo_ids: Option<
+        HashSet<String>,
+    >,
 ) -> std::result::Result<DaemonState, Box<dyn std::error::Error>> {
     match storage {
         StorageMode::Local => Ok(DaemonState::open_with_repo_id(layout, Some(repo_id))?),
         #[cfg(feature = "gcs")]
         StorageMode::Gcs => {
-            let allowed_repo_ids = parse_allowed_repo_ids();
             let bucket = env::var("KIN_GCS_BUCKET")
                 .map_err(|_| "KIN_GCS_BUCKET env var required for --storage gcs")?;
             let prefix = env::var("KIN_GCS_PREFIX").unwrap_or_default();
@@ -444,9 +491,24 @@ async fn async_main() -> i32 {
         }
     };
 
+    // Reconcile the served identity with the configured key space before taking
+    // the repository singleton lock. A daemon that cannot serve the id it will
+    // advertise has nothing to contend for, and refusing here keeps the operator
+    // message about the misconfiguration itself rather than wrapping it in a
+    // failure to open state.
+    // Exit 2, the same code `enforce_startup_env` uses: this is one more
+    // correctness-relevant KIN_* value refusing to boot, not a runtime failure.
+    let allowed_repo_ids = match served_repo_key_space(&args.storage, &repo_id) {
+        Ok(allowed_repo_ids) => allowed_repo_ids,
+        Err(error) => {
+            eprintln!("kin-daemon: {error}");
+            return 2;
+        }
+    };
+
     let kin_root = layout.root().to_path_buf();
     let (state, authority) = match acquire_before_state(&kin_root, acquire_daemon_authority, || {
-        create_state(layout, &args.storage, &repo_id)
+        create_state(layout, &args.storage, &repo_id, allowed_repo_ids)
     }) {
         Ok(opened) => opened,
         Err(error) => {
@@ -536,6 +598,121 @@ mod tests {
             "state construction must not run before singleton authority is acquired"
         );
         drop(first);
+    }
+
+    /// Every storage mode the daemon can boot in, so the routability assertion
+    /// below cannot silently stop covering a mode that is added later. The
+    /// `match` in `served_repo_key_space` is what forces a new variant to be
+    /// handled; this list is what forces it to be exercised.
+    fn every_storage_mode() -> Vec<StorageMode> {
+        #[allow(unused_mut)]
+        let mut modes = vec![StorageMode::Local];
+        #[cfg(feature = "gcs")]
+        modes.push(StorageMode::Gcs);
+        modes
+    }
+
+    fn with_repo_ids<T>(value: Option<&str>, body: impl FnOnce() -> T) -> T {
+        match value {
+            Some(value) => env::set_var("KIN_REPO_IDS", value),
+            None => env::remove_var("KIN_REPO_IDS"),
+        }
+        let outcome = body();
+        env::remove_var("KIN_REPO_IDS");
+        outcome
+    }
+
+    /// The identity a daemon advertises must be one it will route, in every
+    /// storage mode and under every allowlist that mode can be handed, not only
+    /// the default configuration that has nothing to disagree with.
+    ///
+    /// `DaemonState::serves_repo_id` answers from `allowed_repo_ids` alone
+    /// whenever a key space is configured, so this is the exact predicate every
+    /// `/repos/{repo_id}` route resolves against. Startup therefore has two
+    /// admissible outcomes and no third: it either yields a key space that
+    /// admits the advertised id, or it refuses to boot. A daemon that runs
+    /// while contradicting its own `/health` is the state this forbids.
+    #[test]
+    #[serial_test::serial]
+    fn every_storage_mode_admits_the_repo_id_it_advertises_or_refuses_to_boot() {
+        let repo_id = "advertised-repo";
+        for storage in every_storage_mode() {
+            for allowlist in [
+                None,
+                Some(repo_id),
+                Some("advertised-repo,sibling-repo"),
+                Some("other-repo,third-repo"),
+            ] {
+                let outcome = with_repo_ids(allowlist, || served_repo_key_space(&storage, repo_id));
+                let Ok(key_space) = outcome else {
+                    continue;
+                };
+                assert!(
+                    key_space
+                        .as_ref()
+                        .is_none_or(|allowed| allowed.contains(repo_id)),
+                    "{storage:?} booted with a key space that refuses the id it advertises \
+                     (KIN_REPO_IDS={allowlist:?}): {key_space:?}"
+                );
+            }
+        }
+    }
+
+    /// The misconfiguration itself: an allowlist that omits the served id. It
+    /// must refuse to boot, and the refusal must name both values so the
+    /// operator can see which one to change.
+    #[cfg(feature = "gcs")]
+    #[test]
+    #[serial_test::serial]
+    fn a_gcs_allowlist_excluding_the_served_repo_refuses_startup() {
+        let refusal = with_repo_ids(Some("other-repo, third-repo"), || {
+            served_repo_key_space(&StorageMode::Gcs, "advertised-repo")
+                .expect_err("an allowlist without the served id must refuse startup")
+        });
+
+        assert!(
+            refusal.contains("advertised-repo"),
+            "the refusal must name the served repo id: {refusal}"
+        );
+        assert!(
+            refusal.contains("other-repo") && refusal.contains("third-repo"),
+            "the refusal must name the configured allowlist: {refusal}"
+        );
+        assert!(
+            refusal.contains("KIN_REPO_IDS"),
+            "the refusal must name the setting to change: {refusal}"
+        );
+    }
+
+    /// A consistent allowlist is still honored in full: admission reconciles the
+    /// served id with the key space, it does not discard the operator's list or
+    /// widen it to every repository in the bucket.
+    #[cfg(feature = "gcs")]
+    #[test]
+    #[serial_test::serial]
+    fn a_gcs_allowlist_containing_the_served_repo_is_admitted_unchanged() {
+        let admitted = with_repo_ids(Some("advertised-repo,sibling-repo"), || {
+            served_repo_key_space(&StorageMode::Gcs, "advertised-repo")
+                .expect("an allowlist naming the served id must be admitted")
+        })
+        .expect("a configured allowlist must survive admission");
+
+        assert!(admitted.contains("advertised-repo"));
+        assert!(admitted.contains("sibling-repo"));
+        assert_eq!(admitted.len(), 2, "admission must not widen the key space");
+    }
+
+    /// No allowlist means no key-space constraint, which is how a single-repo
+    /// hosted pod runs. Admission must not invent one.
+    #[cfg(feature = "gcs")]
+    #[test]
+    #[serial_test::serial]
+    fn gcs_without_an_allowlist_keeps_an_unconstrained_key_space() {
+        let admitted = with_repo_ids(None, || {
+            served_repo_key_space(&StorageMode::Gcs, "advertised-repo")
+                .expect("an unset allowlist must be admitted")
+        });
+        assert!(admitted.is_none(), "got {admitted:?}");
     }
 
     impl Write for SharedBuf {

--- a/crates/kin-daemon/src/error.rs
+++ b/crates/kin-daemon/src/error.rs
@@ -27,6 +27,23 @@ pub enum DaemonError {
     #[error("Not initialized: no .kin/ directory found")]
     NotInitialized,
 
+    /// The storage backend answered completely and holds no such repository.
+    ///
+    /// Absence is a trustworthy answer, not a failure to answer: the backend
+    /// was reachable, its authority read succeeded, and it reported nothing
+    /// stored under this id. Every other storage arm is the opposite, whether
+    /// an unreachable object store, expired credentials, or a corrupt delta
+    /// chain, and callers must be able to route the two differently: a
+    /// repository that is not there versus a daemon that cannot answer.
+    ///
+    /// This is typed rather than flattened into
+    /// [`Graph`](Self::Graph)`(StorageError(..))` because recovering the
+    /// distinction afterwards would mean matching on message text, and a
+    /// classification inferred from a failure string is exactly what stops
+    /// holding the first time the wording moves.
+    #[error("repository '{0}' has no graph in storage")]
+    RepoAbsentFromStorage(String),
+
     #[error("{0}")]
     IncompatibleRepo(String),
 

--- a/crates/kin-daemon/src/state.rs
+++ b/crates/kin-daemon/src/state.rs
@@ -2927,6 +2927,13 @@ impl DaemonState {
 
     /// Load a repo's graph from the storage backend (synchronous).
     /// Used internally for pre-loading and by `get_repo_graph`.
+    ///
+    /// The absent case is typed as
+    /// [`DaemonError::RepoAbsentFromStorage`] rather than folded into the
+    /// fault arms. `load_recovered_snapshot` returns `Ok(None)` only when the
+    /// backend read succeeded and found neither snapshot authority nor
+    /// deltas, so absence here is a complete answer and callers may route it
+    /// as a missing repository instead of a broken daemon.
     fn load_repo_graph(&self, repo_id: &str) -> Result<Arc<kin_db::InMemoryGraph>> {
         let Some(backend) = &self.storage_backend else {
             return Err(DaemonError::Graph(kin_db::KinDbError::StorageError(
@@ -2953,9 +2960,7 @@ impl DaemonState {
                 );
                 Ok(graph)
             }
-            None => Err(DaemonError::Graph(kin_db::KinDbError::StorageError(
-                format!("repo '{}' not found in storage", repo_id),
-            ))),
+            None => Err(DaemonError::RepoAbsentFromStorage(repo_id.to_string())),
         }
     }
 


### PR DESCRIPTION
Two daemon identity surfaces could each answer something the other contradicted, and both are fixed here by making the contradiction impossible to represent rather than by teaching a caller to guess.

The first is the repo-scoped read path. `load_repo_graph` already knew the difference between a backend that answered completely and holds no such repository and a backend that failed to answer at all, then threw that knowledge away by flattening both into `DaemonError::Graph(StorageError(String))`. `repo_scoped_graph` could only have recovered it by matching on the message text, which is the same infer-from-the-failure mistake that was removed from this exact resolver once before. The absent case is now typed as `DaemonError::RepoAbsentFromStorage` and the resolver answers 404 for it, naming both the served and the requested id, while every genuine fault still answers 500 carrying its underlying error. The 404 wording is deliberately not the unserved-id wording, because an allowlisted repository that storage happens not to hold is served, and saying otherwise would be false.

The second is startup. In GCS mode the daemon took its identity from two independent sources, the served repo id and the `KIN_REPO_IDS` allowlist, and nothing reconciled them. `DaemonState::serves_repo_id` answers from the allowlist alone whenever one is configured, so an allowlist that omitted the served id produced a live daemon advertising an id on `GET /health` that it refused on every `/repos/{repo_id}` route. That configuration has no reading under which the daemon can serve correctly, so it now refuses to boot, naming both values and both remedies, before the repository singleton lock is taken. Silently widening the allowlist instead would serve a repository the operator explicitly did not list, which is the worse failure in a hosted pod.

The `RepoFaultBackend` test fixture is hardened alongside. It forwarded 11 of the 21 `StorageBackend` methods while the local backend it wraps implements 20, so nine were answering from trait defaults that report no incremental-delta support and no source-blob storage at all. A test reusing the fixture would have measured that degraded shape and reported it as hosted behavior. All nine now forward, with `compact_deltas` left on the same trait default `LocalFileBackend` uses so compaction still composes through the fault switch rather than around it.

Both fixes are falsified: reverting the 404 mapping puts the new absent-repository test back on the old 500, and reverting the startup admission fails both the refusal test and the every-storage-mode routability test.

One coverage gap is worth naming rather than leaving to be discovered. `--all-features` clippy compiles the `gcs` code on every PR, but neither `cargo build --all-targets` nor `cargo nextest run` enables the feature, so the three gcs-only startup tests here are type-checked by CI and never executed by it. The fourth, which asserts every storage mode either admits the id it advertises or refuses to boot, is feature-independent and does run. All of them were run locally under `--features gcs`. Wiring a gcs test step into CI touches the workflow file and is left for a follow-up.

Closes FIR-1697
Closes FIR-1688
