### PR TITLE
Execute the gcs feature test suite in the CI check job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -827,6 +827,18 @@ jobs:
         # nextest does not run doctests; keep them covered explicitly.
         run: cargo test --doc --locked
 
+      # `gcs` is a non-default feature, so the passes above never execute the
+      # hosted-storage code it gates, and Clippy's `--all-features` pass only
+      # type-checks it. Without this step a behavioral regression in the
+      # GCS-mode startup admission path compiles clean and reaches main with a
+      # green required context. The whole package runs rather than just the
+      # binary target: the feature gates only `bin/kin-daemon.rs` today, and
+      # scoping to that target would silently stop covering a gate added to the
+      # library later. No companion doctest pass belongs here because
+      # kin-daemon declares `doctest = false`.
+      - name: Test gcs feature
+        run: cargo nextest run -p kin-daemon --features gcs --locked
+
   # Security audit moved to sast.yml (cargo-deny: advisories + licenses + bans + sources)
 
   coverage:


### PR DESCRIPTION
## What changed

The `check` job in `ci.yml` gains one step that runs
`cargo nextest run -p kin-daemon --features gcs --locked`, placed after the existing
default-feature test and doctest passes.

`gcs` is a non-default feature, so until now CI compiled the hosted-storage code it gates but
never executed it. The Clippy step runs `--all-features` and so type-checks every
`#[cfg(feature = "gcs")]` item, which means a compile break there does fail CI. The build, test,
and doctest steps all resolve default features only, so a behavioral regression in the GCS-mode
paths could reach main with a green required context.

## Why a step rather than a new job

`Check & Test` is already a release-required context, and the `check` job that produces it
already runs on `pull_request` and on `merge_group`. A step inherits both triggers with no new
required-context plumbing and no ruleset change. A separate job would have been a new context
that could report skipped on `merge_group` and silently satisfy itself, which is the false
assurance the merge-queue work exists to prevent.

The step runs the whole package rather than only the `kin-daemon` binary target. The feature
gates only `bin/kin-daemon.rs` today, and scoping the command to that target would silently stop
covering a gate added to the library later.

No companion doctest pass belongs here because `kin-daemon` declares `doctest = false`. That was
verified rather than assumed, since `cargo test --doc -p kin-daemon --features gcs --locked`
reports zero doctests.

## Verification

The workflow header is byte-pinned by `scripts/test-release-workflow-authority.py`, and the
`check` job's admission fields and matrix are pinned alongside it. Both pinned regions exclude
the `steps:` sequence contents, so no pin needed updating and none was changed. The script passes
on this head. The header pin was then falsified rather than trusted, by adding a
`workflow_dispatch` trigger and confirming the run fails with "diff classifier workflow header
must exactly match the closed-form process environment authority contract".

The diff classifier was executed, not read, to confirm the step actually runs where it must. With
`EVENT_NAME=merge_group` it emits `docs_only=false`, so the real `check` job is admitted on queue
groups instead of taking the documentation-only fast path. A pull request touching
`.github/workflows/ci.yml` likewise emits `docs_only=false`, so this pull request exercises its
own new step.

The suite passes locally on this head, with 620 tests run and 620 passed under the `gcs` feature.

The new command was falsified from both sides. A deliberately failing `#[cfg(feature = "gcs")]`
test was added to `bin/kin-daemon.rs`, and the default workspace selection
`cargo nextest list --locked` could not see it at all, while the new command failed on it with
exit 100. A control run proved the empty result was genuine absence rather than a bad filter,
since the same filter syntax against the same binary does list a test that exists under default
features. The probe was removed and the tree confirmed clean.

`actionlint` passes on `ci.yml`.

One scope note so the step is not read as more than it is today. At this base the `kin-daemon`
package exposes the same 620 tests under default features and under `gcs`, so no test is gcs-only
yet. The immediate effect of the step is to execute the package's suite compiled with the feature
enabled, which links and exercises the gated code. It begins protecting gcs-only tests the moment
any land, and the startup-admission tests in #513 are the first of those and are still in the
queue. The two changes are order independent.

## Cost

The `gcs` feature pulls `object_store` and the reqwest stack into the graph, so the step rebuilds
`kin-db` and `kin-daemon` under a feature combination the other steps do not produce. Locally the
added step costs roughly four minutes wall clock, of which the test run itself is 85 seconds and
the rest is compilation. Pull requests restore the cache saved from main, so the first runs after
this lands pay the full cost and later ones do not. The job's existing 60 minute timeout is
unchanged.

Closes FIR-1723
