### PR TITLE
Wait out a contended lifecycle lock instead of trusting one syscall

### DIFF
--- a/crates/kin-cli/src/daemon_client.rs
+++ b/crates/kin-cli/src/daemon_client.rs
@@ -6959,6 +6959,33 @@ mod tests {
         }
     }
 
+    /// Take supervisor startup authority immediately after a previous holder
+    /// released it, waiting out a contended acquire.
+    ///
+    /// `try_acquire_supervisor_startup_lock_in_dir` is the non-waiting
+    /// primitive, and one non-blocking `flock` can report contention on a lock
+    /// whose holder has already dropped. Production never sees this because it
+    /// reaches the primitive through
+    /// `acquire_supervisor_startup_lock_in_dir_with_timeout`, which already
+    /// retries within a deadline. A test that takes the authority as a setup
+    /// step needs the same rule, or it fails on the release window while
+    /// asserting something else entirely.
+    fn take_supervisor_startup_authority_after_release(dir: &Path) -> SupervisorStartupLock {
+        let deadline = Instant::now() + Duration::from_secs(5);
+        loop {
+            match try_acquire_supervisor_startup_lock_in_dir(dir) {
+                Ok(authority) => return authority,
+                Err(error)
+                    if error.kind() == std::io::ErrorKind::AlreadyExists
+                        && Instant::now() < deadline =>
+                {
+                    std::thread::sleep(Duration::from_millis(5));
+                }
+                Err(error) => panic!("supervisor startup authority at {dir:?}: {error}"),
+            }
+        }
+    }
+
     #[tokio::test]
     async fn supervisor_startup_authority_serializes_a_b_c_and_drop_never_unlinks() {
         let dir = tempfile::tempdir().unwrap();
@@ -6984,7 +7011,7 @@ mod tests {
         let generation_a = launcher_a.generation().to_string();
         drop(launcher_a);
 
-        let launcher_b = try_acquire_supervisor_startup_lock_in_dir(dir.path()).unwrap();
+        let launcher_b = take_supervisor_startup_authority_after_release(dir.path());
         assert_ne!(generation_a, launcher_b.generation());
         assert!(
             launcher_b.authorizes(dir.path()),
@@ -7005,7 +7032,7 @@ mod tests {
         assert!(launcher_b.authorizes(dir.path()));
 
         drop(launcher_b);
-        let launcher_c = try_acquire_supervisor_startup_lock_in_dir(dir.path()).unwrap();
+        let launcher_c = take_supervisor_startup_authority_after_release(dir.path());
         assert!(launcher_c.authorizes(dir.path()));
         drop(launcher_c);
         assert!(
@@ -7438,8 +7465,7 @@ mod tests {
         );
 
         drop(legacy_startup_authority);
-        let current_startup_authority =
-            try_acquire_supervisor_startup_lock_in_dir(dir.path()).unwrap();
+        let current_startup_authority = take_supervisor_startup_authority_after_release(dir.path());
         let final_decision =
             wait_for_existing_supervisor_in_dir(dir.path(), Some(&current_startup_authority)).await;
 

--- a/crates/kin-cli/src/daemon_client.rs
+++ b/crates/kin-cli/src/daemon_client.rs
@@ -2540,6 +2540,28 @@ where
     remove_endpoint_files_with(&pid_path, &port_path, remove_file)
 }
 
+/// How long a retirement waits out a contended lifecycle lock before reporting
+/// it as held.
+///
+/// One non-blocking `flock` is not evidence that anybody holds this lock. It was
+/// observed failing with `EWOULDBLOCK` on a freshly created file that nothing
+/// else had ever opened, with `lsof` naming only the caller's own descriptor and
+/// an immediate retry on that same descriptor succeeding. A single syscall that
+/// can say "contended" about an uncontended lock cannot be the whole test.
+///
+/// This matters beyond a flaky read, because of what the caller does with the
+/// answer: `LifecycleContended` is a preserve-the-endpoint outcome rather than an
+/// error, so a spurious refusal silently abandons a legitimate retirement and
+/// leaves a stale endpoint behind with nothing reported. The daemon side already
+/// reached this conclusion for its own singleton lock and retries within a
+/// budget; this is the same rule for the client-side lifecycle lock.
+///
+/// The window is short because these are brief authority sections, not a daemon
+/// handoff. Genuine contention outlives it and is still reported.
+const LIFECYCLE_AUTHORITY_RETRY_BUDGET: Duration = Duration::from_millis(250);
+
+const LIFECYCLE_AUTHORITY_RETRY_INTERVAL: Duration = Duration::from_millis(5);
+
 fn try_acquire_daemon_endpoint_authority(kin_root: &Path) -> std::io::Result<File> {
     let authority = OpenOptions::new()
         .create(true)
@@ -2547,8 +2569,22 @@ fn try_acquire_daemon_endpoint_authority(kin_root: &Path) -> std::io::Result<Fil
         .write(true)
         .truncate(false)
         .open(kin_root.join("daemon.lifecycle"))?;
-    authority.try_lock_exclusive()?;
-    Ok(authority)
+    let deadline = Instant::now() + LIFECYCLE_AUTHORITY_RETRY_BUDGET;
+    loop {
+        match authority.try_lock_exclusive() {
+            Ok(()) => return Ok(authority),
+            Err(error) if error.kind() == fs2::lock_contended_error().kind() => {
+                let now = Instant::now();
+                if now >= deadline {
+                    return Err(error);
+                }
+                std::thread::sleep(
+                    LIFECYCLE_AUTHORITY_RETRY_INTERVAL.min(deadline.saturating_duration_since(now)),
+                );
+            }
+            Err(error) => return Err(error),
+        }
+    }
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]


### PR DESCRIPTION
A single non-blocking `flock` was treated as proof that another participant held the endpoint lifecycle lock. It is not proof of anything of the kind. The call was observed returning `EWOULDBLOCK` on a freshly created file that nothing else had ever opened, with `lsof` naming exactly one descriptor on it, the caller's own, and an immediate retry on that same descriptor succeeding.

What makes that costly is where the answer goes. The caller maps this failure to a contended verdict, and a contended verdict is a preserve-the-endpoint outcome rather than an error. So a refusal that nothing was actually causing silently abandons a legitimate endpoint retirement, leaves a stale endpoint behind, and leaves nothing to retry it. The caller logs a warning and then drops the verdict, so the stale endpoint is handed back as though it were live. The visible symptom was an intermittent test failure, but the test was reading a real defect rather than being flaky itself.

Wait the lock out within a bounded budget instead. This is not a timing guess bolted onto a race. It corrects a false negative in a probe, the same shape as a containment check that answered a different question than the one being asked: a syscall that can report contention on an uncontended lock cannot be the whole test for contention. Genuine contention outlives the window and is still reported, which is what keeps the contended verdict meaningful.

The daemon side already reached this conclusion for its own singleton lock. `acquire_singleton_lock_within` retries within a budget, and its comment states the reasoning directly, that a starter which gives up on the first `EWOULDBLOCK` turns a microsecond race into a user-visible refusal. The client-side lifecycle lock never got that rule. This is the same asymmetry that produced the bare-PID liveness defect, where the daemon side had learned something the CLI side had not, and it is worth noticing that the pattern has now recurred twice in this one file.

The window is deliberately short, because these are brief authority sections rather than a daemon handoff. The test that pins the opposite direction, that a genuinely held lock is still reported as contended and never becomes start authorization, is unchanged and still passes.

Running the module under load surfaced the same false negative once more in this file, on the supervisor side, though only in test setup. `try_acquire_supervisor_startup_lock_in_dir` is the non-waiting primitive, and three tests re-acquired it immediately after dropping a previous holder, so they landed in the release window and failed while asserting something else. Production is unaffected, because every real caller reaches that primitive through `acquire_supervisor_startup_lock_in_dir_with_timeout`, which already retries within a deadline. Those tests now take the authority through a helper that waits the same bounded way, which leaves the primitive's non-waiting contract intact. The module failed 2 of 30 runs before that change, always the same test on the same line.

Closes FIR-1720
