### PR TITLE
Answer a mis-addressed spine ingest as an unserved repository rather than a daemon fault

### DIFF
--- a/crates/kin-daemon/src/api.rs
+++ b/crates/kin-daemon/src/api.rs
@@ -14117,6 +14117,29 @@ mod tests {
         (status, body.to_vec())
     }
 
+    /// Drive the real spine ingest route, body and all, exactly as the hosted
+    /// import orchestrator does. Going through `router` rather than calling the
+    /// state method keeps the status code under test the one a client actually
+    /// receives.
+    async fn spine_ingest(state: Arc<DaemonState>, repo_id: &str) -> (StatusCode, Vec<u8>) {
+        let response = router(state)
+            .oneshot(
+                Request::post(format!("/spine/repos/{repo_id}/ingest"))
+                    .header("content-type", "application/json")
+                    .body(Body::from(
+                        serde_json::to_vec(&serde_json::json!({ "repo": repo_id })).unwrap(),
+                    ))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        let status = response.status();
+        let body = axum::body::to_bytes(response.into_body(), 1024 * 1024)
+            .await
+            .unwrap();
+        (status, body.to_vec())
+    }
+
     /// The identity contract a client depends on: read `repo_id` off `/health`
     /// and every `/repos/{repo_id}/…` route resolves it. Two key spaces here
     /// meant a caller that trusted the advertised id got a storage-mode 500 on
@@ -14685,6 +14708,106 @@ mod tests {
         faults.start_faulting(absent);
         let (status, body) =
             repo_route(Arc::clone(&state), &format!("/repos/{absent}/entities")).await;
+        let message = String::from_utf8_lossy(&body);
+        assert_eq!(
+            status,
+            StatusCode::INTERNAL_SERVER_ERROR,
+            "a backend that cannot answer is still a fault: {message}"
+        );
+        assert!(
+            message.contains(BACKEND_FAULT_TEXT),
+            "the fault must carry the backend error rather than discard it: {message}"
+        );
+    }
+
+    /// The spine ingest route resolves a repository by id just as the
+    /// `/repos/{repo_id}` routes do, so it owes a caller the same three
+    /// answers. It gave one: every outcome, a mis-addressed request included,
+    /// arrived as a 500.
+    ///
+    /// This is the shape the control plane actually meets. The import
+    /// orchestrator POSTs one ingest per cataloged repo, so a pod whose
+    /// `KIN_REPO_IDS` omits one of them answered "this daemon failed" to a
+    /// question about which pod owns that repository. The orchestrator then
+    /// retried, and no number of retries moves a repository into a key space
+    /// that excludes it, while the 5xx alerting fired on a daemon that was
+    /// working exactly as configured.
+    #[tokio::test]
+    async fn spine_ingest_refuses_an_unserved_repo_id_rather_than_reporting_a_fault() {
+        let advertised = "primary-repo";
+        let sibling = "sibling-repo";
+        let unserved = "unconfigured-repo";
+        let (state, _faults) =
+            hosted_state_with_allowlist("ingest-unserved", advertised, &[sibling]);
+        assert!(
+            !state.serves_repo_id(unserved),
+            "the fixture must exclude the id under test from the served key space"
+        );
+
+        let (status, body) = spine_ingest(Arc::clone(&state), unserved).await;
+        let message = String::from_utf8_lossy(&body);
+        assert_eq!(
+            status,
+            StatusCode::NOT_FOUND,
+            "an id outside the served key space is a mis-addressed request, \
+             not a daemon that failed: {message}"
+        );
+        assert!(
+            message.contains(advertised) && message.contains(unserved),
+            "the refusal must name the served and the requested id so the caller \
+             can tell a typo from the wrong pod: {message}"
+        );
+
+        // An allowlisted sibling storage has never held is the other 404, and
+        // the two must stay tellable apart in the body. Both are "not here",
+        // but one says this pod does not own the repository and the other says
+        // this pod owns it and has not ingested it, and those route to
+        // different fixes: re-address the request, or run the ingest.
+        assert!(
+            message.contains("does not serve"),
+            "the unserved refusal must say so plainly: {message}"
+        );
+        let (sibling_status, sibling_body) = spine_ingest(Arc::clone(&state), sibling).await;
+        let sibling_message = String::from_utf8_lossy(&sibling_body);
+        assert_eq!(
+            sibling_status,
+            StatusCode::NOT_FOUND,
+            "a served sibling absent from storage is also missing: {sibling_message}"
+        );
+        assert!(
+            !sibling_message.contains("does not serve"),
+            "a served sibling must not inherit the unserved refusal: {sibling_message}"
+        );
+    }
+
+    /// Absence and fault stay distinguishable on the ingest route too. A
+    /// repository the allowlist admits but storage has never held is missing,
+    /// and a backend that cannot answer for that same id is still a fault: the
+    /// answer is decided by what the load reported, never by the id.
+    #[tokio::test]
+    async fn spine_ingest_reports_a_served_repo_absent_from_storage_as_missing() {
+        let advertised = "primary-repo";
+        let absent = "never-stored-repo";
+        let (state, faults) = hosted_state_with_allowlist("ingest-absent", advertised, &[absent]);
+        assert!(
+            state.serves_repo_id(absent),
+            "the allowlist is the served key space, so the absent id is served"
+        );
+
+        let (status, body) = spine_ingest(Arc::clone(&state), absent).await;
+        let message = String::from_utf8_lossy(&body);
+        assert_eq!(
+            status,
+            StatusCode::NOT_FOUND,
+            "a served repository storage does not hold is missing, not a fault: {message}"
+        );
+        assert!(
+            !message.contains("does not serve"),
+            "an allowlisted repository must not be reported as unserved: {message}"
+        );
+
+        faults.start_faulting(absent);
+        let (status, body) = spine_ingest(Arc::clone(&state), absent).await;
         let message = String::from_utf8_lossy(&body);
         assert_eq!(
             status,

--- a/crates/kin-daemon/src/api.rs
+++ b/crates/kin-daemon/src/api.rs
@@ -6825,9 +6825,37 @@ async fn repo_scoped_graph(
             ),
         ));
     }
-    match state.get_repo_graph(repo_id).await {
-        Ok(graph) => Ok(graph),
-        Err(crate::error::DaemonError::RepoAbsentFromStorage(absent)) => Err((
+    state
+        .get_repo_graph(repo_id)
+        .await
+        .map_err(|error| repo_addressed_error(state, error))
+}
+
+/// Classify a repository-addressed [`DaemonError`] into an HTTP answer.
+///
+/// Every route that resolves a repository by id owes the caller the same three
+/// answers, so they are decided once here rather than re-decided per route. An
+/// id outside the served key space and a served id storage holds nothing for
+/// are both "not here" and answer 404 naming the served and the requested
+/// identity; everything else is a daemon that could not answer and keeps its
+/// underlying error behind a 500.
+///
+/// Sharing the classification is what keeps the surfaces consistent with each
+/// other. The spine ingest route used to flatten all three into a single 500,
+/// so a control plane posting to the wrong pod read an addressing refusal as an
+/// outage and retried something no retry could fix, while a `/repos/{repo_id}`
+/// route on that same daemon named the mismatch precisely.
+fn repo_addressed_error(
+    state: &DaemonState,
+    error: crate::error::DaemonError,
+) -> (StatusCode, String) {
+    match error {
+        // The refusal already carries both identities, so it is rendered from
+        // the error rather than rebuilt here: one sentence, one definition.
+        crate::error::DaemonError::RepoNotServed { .. } => {
+            (StatusCode::NOT_FOUND, error.to_string())
+        }
+        crate::error::DaemonError::RepoAbsentFromStorage(ref absent) => (
             StatusCode::NOT_FOUND,
             format!(
                 "this daemon serves repository {} and is configured for {absent}, \
@@ -6835,8 +6863,8 @@ async fn repo_scoped_graph(
                  GET /repos lists the repositories storage actually holds",
                 state.cached_repo_id
             ),
-        )),
-        Err(error) => Err(internal_error(error)),
+        ),
+        _ => internal_error(error),
     }
 }
 
@@ -8624,7 +8652,7 @@ async fn spine_ingest_repo(
     let outcome = state
         .ingest_repo_into_spine(&repo_id, body.refresh_cross_repo_edges)
         .await
-        .map_err(internal_error)?;
+        .map_err(|error| repo_addressed_error(&state, error))?;
 
     Ok(Json(json!({
         "repoId": outcome.repo_id,

--- a/crates/kin-daemon/src/error.rs
+++ b/crates/kin-daemon/src/error.rs
@@ -44,6 +44,27 @@ pub enum DaemonError {
     #[error("repository '{0}' has no graph in storage")]
     RepoAbsentFromStorage(String),
 
+    /// The requested repository lies outside the key space this daemon serves.
+    ///
+    /// This is the third answer alongside a repository that is there and one
+    /// that is absent, and it is the only one decidable without touching
+    /// storage: the configured key space already excludes the id, so no load is
+    /// attempted and no backend state is consulted. Answering it as a storage
+    /// outcome would describe a daemon that failed where nothing was ever
+    /// asked of storage.
+    ///
+    /// Both identities travel with the refusal because either alone is
+    /// unactionable. The requested id alone leaves the caller unable to tell a
+    /// typo from a request sent to the wrong pod, and the served id alone does
+    /// not say which request was refused. Carrying them here rather than
+    /// rebuilding the sentence at each route also keeps every surface phrasing
+    /// the same refusal identically.
+    #[error(
+        "this daemon serves repository {served} and does not serve {requested}; \
+         GET /health advertises the repo_id this daemon accepts"
+    )]
+    RepoNotServed { served: String, requested: String },
+
     #[error("{0}")]
     IncompatibleRepo(String),
 

--- a/crates/kin-daemon/src/state.rs
+++ b/crates/kin-daemon/src/state.rs
@@ -3018,12 +3018,27 @@ impl DaemonState {
     /// Returns the cached graph if already loaded, otherwise loads from
     /// the storage backend and caches it. Only usable when a storage
     /// backend is configured (cloud / multi-repo mode).
+    ///
+    /// Three outcomes leave here and they are all typed, so a caller routes on
+    /// what happened rather than on how it was worded. An id outside the
+    /// configured key space is [`DaemonError::RepoNotServed`], decided before
+    /// any load. A key space that admits the id but a backend holding nothing
+    /// under it is [`DaemonError::RepoAbsentFromStorage`]. Anything else is a
+    /// genuine fault carrying its underlying error.
+    ///
+    /// The refusal used to flatten into
+    /// [`Graph`](DaemonError::Graph)`(StorageError(..))`, which made an
+    /// addressing answer indistinguishable from a storage failure at every
+    /// route that did not pre-empt it with [`Self::serves_repo_id`], and left
+    /// the ingest path reporting a request sent to the wrong pod as a broken
+    /// daemon.
     pub async fn get_repo_graph(&self, repo_id: &str) -> Result<Arc<kin_db::InMemoryGraph>> {
         if let Some(allowed_repo_ids) = &self.allowed_repo_ids {
             if !allowed_repo_ids.contains(repo_id) {
-                return Err(DaemonError::Graph(kin_db::KinDbError::StorageError(
-                    format!("repo '{}' is not configured for this daemon", repo_id),
-                )));
+                return Err(DaemonError::RepoNotServed {
+                    served: self.cached_repo_id.clone(),
+                    requested: repo_id.to_string(),
+                });
             }
         }
         // Fast path: check if already loaded.


### PR DESCRIPTION
A repository id outside the key space a daemon serves is a mis-addressed request, not a daemon that failed, and the spine ingest route was the one surface still answering it as a failure.

`DaemonState::get_repo_graph` refused an id the configured allowlist excludes by returning `DaemonError::Graph(StorageError("repo '{}' is not configured for this daemon"))`. The `/repos/{repo_id}` routes never showed that, because `repo_scoped_graph` pre-empts the refusal with `serves_repo_id` and answers precisely. `POST /spine/repos/{repo_id}/ingest` has no such pre-emption: it calls `ingest_repo_into_spine`, which calls `get_repo_graph` and propagates, and the handler mapped every error through `internal_error`. So a hosted import orchestrator posting one ingest per cataloged repo against a pod whose `KIN_REPO_IDS` omits one of them read "this daemon failed" to a question about which pod owns that repository. It then retried, and no number of retries moves a repository into a key space that excludes it, while 5xx alerting fired on a daemon working exactly as configured.

The refusal is now typed as `DaemonError::RepoNotServed { served, requested }`, decided before any load, carrying both identities because either alone is unactionable: the requested id alone cannot tell a typo from the wrong pod, and the served id alone does not say which request was refused. The sentence lives on the error rather than being rebuilt per route, so every surface phrases the same refusal identically.

Classification is shared rather than re-decided per route. `repo_addressed_error` maps an unserved id and a served id storage holds nothing for to 404, and everything else to 500 with its underlying error intact, and both `repo_scoped_graph` and `spine_ingest_repo` go through it. The two 404s stay tellable apart in the body on purpose: one says this pod does not own the repository and the other says this pod owns it and has not ingested it, and those route to different fixes, re-address the request or run the ingest.

Two route-level tests drive the real router so the status code under test is the one a client receives. The first asserts a non-served id answers 404 naming both the served and the requested identity, and that an allowlisted sibling does not inherit the unserved wording. The second asserts a served repository absent from storage is 404 without that wording, then faults the backend for that same id and asserts it is still a 500 carrying the backend error, so the answer is decided by what the load reported and never by the id.

Falsification: reverting `spine_ingest_repo` to `internal_error` puts both tests back on 500, and reverting the typed variant in `state.rs` collapses the unserved case into the absent wording.

The originating lane report claimed this refusal was unreachable over HTTP. That claim was wrong, and the paragraph is corrected in the coordination report it lives in (`.kin-coord/reports/w2-daemon-truth-20260730.md`, gitignored, so the correction is not in this diff) rather than left to be carried forward as truth.

Closes FIR-1725
