### PR TITLE
Adopt the kin-model 0.7 external-reference and sealed-observation contracts

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3254,9 +3254,9 @@ dependencies = [
 
 [[package]]
 name = "kin-db"
-version = "0.6.7"
+version = "0.7.6"
 source = "sparse+https://kinlab.ai/registry/cargo/"
-checksum = "fab279dfb7cfc1c37fedaed1be22409f58ddb7cc31715694252c17e0b47f115d"
+checksum = "1c6429d44f30f92d3c9582befe066966cd06293be011ac8c9cf3c45dfa255c8b"
 dependencies = [
  "bincode",
  "bstr",
@@ -3353,9 +3353,9 @@ dependencies = [
 
 [[package]]
 name = "kin-infer"
-version = "0.2.41"
+version = "0.2.42"
 source = "sparse+https://kinlab.ai/registry/cargo/"
-checksum = "073c47139ed0850d8f3ae2d1f11c63ffc10f3bc24e6a09c9e2d77a134ab416b1"
+checksum = "4da5929f5c6055a21828a807507e7d7dc8db1425d67df25e2474603f05c54bc3"
 dependencies = [
  "block",
  "half",
@@ -3397,9 +3397,9 @@ dependencies = [
 
 [[package]]
 name = "kin-lsp"
-version = "0.6.0"
+version = "0.6.5"
 source = "sparse+https://kinlab.ai/registry/cargo/"
-checksum = "5b754e534fd4aa0f82b7e4af738d27e55967ccd4dfeaf9956c0321b4425a058e"
+checksum = "bebfcef0d2cef12fe515c4969b3250510fc00bb990f602810292c00c2e329d00"
 dependencies = [
  "kin-model",
  "serde",
@@ -3471,9 +3471,9 @@ dependencies = [
 
 [[package]]
 name = "kin-model"
-version = "0.6.4"
+version = "0.7.1"
 source = "sparse+https://kinlab.ai/registry/cargo/"
-checksum = "a6be89147ec09ed24c2d1c493b3e9dcc886b140f71b3b4c1960e879e112be81d"
+checksum = "4c3a35cfb62580592442c3413ae74a3382b81b24eff209e719a8d68502a8f212"
 dependencies = [
  "chrono",
  "gix-hash",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -124,7 +124,7 @@ pretty_assertions = "1"
 serial_test = "3"
 
 # Internal crates
-kin-model = { version = "=0.6.4", registry = "kin" }
+kin-model = { version = "=0.7.1", registry = "kin" }
 kin-blobs = { version = "0.1.3", registry = "kin" }
 kin-core = { path = "crates/kin-core" }
 kin-parser = { path = "crates/kin-parser" }
@@ -147,13 +147,13 @@ kin-daemon-spawn = { path = "crates/kin-daemon-spawn" }
 kin-mcp = { path = "crates/kin-mcp" }
 kin-spine = { path = "crates/kin-spine" }
 kin-registry = { path = "crates/kin-registry" }
-kin-lsp = { version = "0.6.0", registry = "kin" }
+kin-lsp = { version = "0.6.5", registry = "kin" }
 # Cross-platform base: NO "metal" here. `[workspace.dependencies]` entries cannot be
 # `[target.'cfg(...)']`-gated, so listing "metal" here forces the macOS-only kin-infer/metal
 # backend on every target (incl. Linux, where it cannot compile). Metal is re-enabled
 # additively on macOS via a `[target.'cfg(target_os = "macos")'.dependencies]` block in the
 # binary/runtime crates (kin-cli, kin-daemon). Feature unification makes that additive.
-kin-db = { version = "=0.6.7", registry = "kin", default-features = false }
+kin-db = { version = "=0.7.6", registry = "kin", default-features = false }
 kin-vfs-core = { version = "0.1.5", registry = "kin" }
 
 [profile.release]

--- a/crates/kin-cli/src/commands/graph_health.rs
+++ b/crates/kin-cli/src/commands/graph_health.rs
@@ -879,6 +879,7 @@ mod tests {
                     },
                 ],
                 admission_policy_delta: None,
+                external_reference_deltas: Vec::new(),
             })
             .unwrap();
         graph
@@ -944,6 +945,7 @@ mod tests {
                     },
                 ],
                 admission_policy_delta: None,
+                external_reference_deltas: Vec::new(),
             })
             .unwrap();
         graph

--- a/crates/kin-cli/src/commands/locate.rs
+++ b/crates/kin-cli/src/commands/locate.rs
@@ -16006,6 +16006,7 @@ mod tests {
             spec_link: None,
             evidence: Vec::new(),
             risk_summary: None,
+            external_reference_deltas: Vec::new(),
         };
         change.id = kin_core::compute_semantic_change_id(&change).unwrap();
         change
@@ -16111,6 +16112,7 @@ mod tests {
                 local_overlay_delta: (index == 0)
                     .then(|| FrozenLocalOverlayDelta::initialize(overlay.clone())),
                 merge_transaction_delta: None,
+                sealed_observation: None,
             };
             drop(lease);
             manager.commit_repository_transaction(transaction).unwrap();
@@ -16150,6 +16152,7 @@ mod tests {
                     relation_deltas: Vec::new(),
                     tree_deltas: vec![tree_delta],
                     admission_policy_delta: None,
+                    external_reference_deltas: Vec::new(),
                 })?;
             }
             EntityStore::upsert_opaque_artifact(self, artifact)

--- a/crates/kin-cli/src/commands/ref_lookup.rs
+++ b/crates/kin-cli/src/commands/ref_lookup.rs
@@ -513,6 +513,7 @@ mod tests {
             spec_link: None,
             evidence: Vec::new(),
             risk_summary: None,
+            external_reference_deltas: Vec::new(),
         }
     }
 

--- a/crates/kin-cli/src/commands/review.rs
+++ b/crates/kin-cli/src/commands/review.rs
@@ -1313,6 +1313,7 @@ mod tests {
             evidence: vec![],
             risk_summary: None,
             admission_policy_delta: None,
+            external_reference_deltas: Vec::new(),
         };
         base.id = kin_model::compute_semantic_change_id(&base).unwrap();
         let base_id = base.id;
@@ -1333,6 +1334,7 @@ mod tests {
             evidence: vec![],
             risk_summary: None,
             admission_policy_delta: None,
+            external_reference_deltas: Vec::new(),
         };
         head.id = kin_model::compute_semantic_change_id(&head).unwrap();
         let head_id = head.id;

--- a/crates/kin-cli/src/commands/verify.rs
+++ b/crates/kin-cli/src/commands/verify.rs
@@ -1190,6 +1190,7 @@ mod tests {
             evidence: vec![],
             risk_summary: None,
             admission_policy_delta: None,
+            external_reference_deltas: Vec::new(),
         };
 
         let plan = build_change_verification_plan(graph.as_ref(), &change, 1).unwrap();

--- a/crates/kin-cli/tests/entity_revision_history.rs
+++ b/crates/kin-cli/tests/entity_revision_history.rs
@@ -72,6 +72,7 @@ fn change(
         spec_link: None,
         evidence: Vec::new(),
         risk_summary: None,
+        external_reference_deltas: Vec::new(),
     };
     change.id = kin_core::compute_semantic_change_id(&change).expect("derive change identity");
     change

--- a/crates/kin-cli/tests/repository_branches.rs
+++ b/crates/kin-cli/tests/repository_branches.rs
@@ -284,6 +284,7 @@ fn add_exact_refs(layout: &kin_core::KinLayout) {
         workspace_mutation: None,
         local_overlay_delta: None,
         merge_transaction_delta: None,
+        sealed_observation: None,
     };
     let receipt = manager
         .commit_repository_transaction(transaction)
@@ -320,6 +321,7 @@ fn exact_ref_create_transaction(
         workspace_mutation: None,
         local_overlay_delta: None,
         merge_transaction_delta: None,
+        sealed_observation: None,
     }
 }
 
@@ -996,6 +998,7 @@ fn admit_uncommitted_workspace_edit(
             }),
             local_overlay_delta: None,
             merge_transaction_delta: None,
+            sealed_observation: None,
         })
         .expect("commit admitted workspace edit");
 }

--- a/crates/kin-context/src/builder.rs
+++ b/crates/kin-context/src/builder.rs
@@ -1152,6 +1152,7 @@ mod tests {
                     new: LocatedEntry::new(path, TreeEntry::blob(hash, false)),
                 }],
                 admission_policy_delta: None,
+                external_reference_deltas: Vec::new(),
             })
             .expect("test fixture admission must use the repository tree transaction");
         artifact_id
@@ -1873,6 +1874,7 @@ mod tests {
                     ),
                 }],
                 admission_policy_delta: None,
+                external_reference_deltas: Vec::new(),
             })
             .unwrap();
 

--- a/crates/kin-core/src/diff.rs
+++ b/crates/kin-core/src/diff.rs
@@ -101,6 +101,7 @@ mod tests {
             spec_link: None,
             evidence: Vec::new(),
             risk_summary: None,
+            external_reference_deltas: Vec::new(),
         }
     }
 

--- a/crates/kin-core/src/init.rs
+++ b/crates/kin-core/src/init.rs
@@ -1220,6 +1220,7 @@ fn build_repository_bootstrap_transaction(
         workspace_mutation: Some(workspace_mutation),
         local_overlay_delta: Some(FrozenLocalOverlayDelta::initialize(local_overlay)),
         merge_transaction_delta: None,
+        sealed_observation: None,
     };
 
     if let Some(change_id) = initial_change_id {
@@ -2900,6 +2901,7 @@ mod tests {
             risk_summary: None,
             origin: ChangeOrigin::Native,
             admission_policy_delta: Some(AdmissionPolicyDelta::initialize(shared_policy.clone())),
+            external_reference_deltas: Vec::new(),
         };
         initial_change.id = compute_semantic_change_id(&initial_change).unwrap();
 

--- a/crates/kin-core/src/ref_view.rs
+++ b/crates/kin-core/src/ref_view.rs
@@ -1109,6 +1109,7 @@ mod tests {
             risk_summary: None,
             origin: kin_model::ChangeOrigin::Native,
             admission_policy_delta: None,
+            external_reference_deltas: Vec::new(),
         };
         change.id = crate::compute_semantic_change_id(&change).unwrap();
         let id = change.id;
@@ -1742,6 +1743,7 @@ def uri_encoder(value):\n    return value.replace(' ', '%20')\n",
             risk_summary: None,
             origin: kin_model::ChangeOrigin::Native,
             admission_policy_delta: None,
+            external_reference_deltas: Vec::new(),
         };
         let remove_change = SemanticChange {
             id: remove_id,
@@ -1760,6 +1762,7 @@ def uri_encoder(value):\n    return value.replace(' ', '%20')\n",
             risk_summary: None,
             origin: kin_model::ChangeOrigin::Native,
             admission_policy_delta: None,
+            external_reference_deltas: Vec::new(),
         };
 
         let lifecycle = RefLifecycle::from_changes(&[create_change, remove_change]);

--- a/crates/kin-core/src/tree.rs
+++ b/crates/kin-core/src/tree.rs
@@ -12330,6 +12330,7 @@ mod tests {
             }),
             local_overlay_delta: None,
             merge_transaction_delta: None,
+            sealed_observation: None,
         };
 
         let error = validate_repository_projection_transaction(
@@ -13404,6 +13405,7 @@ mod tests {
             workspace_mutation: None,
             local_overlay_delta: None,
             merge_transaction_delta: None,
+            sealed_observation: None,
         };
         let marker = ReconciliationAuthorityCommit {
             repository_id: transaction.repository_id.clone(),
@@ -13539,6 +13541,7 @@ mod tests {
             workspace_mutation: None,
             local_overlay_delta: None,
             merge_transaction_delta: None,
+            sealed_observation: None,
         };
         let marker = ReconciliationAuthorityCommit {
             repository_id: transaction.repository_id.clone(),
@@ -13680,6 +13683,7 @@ mod tests {
             }),
             local_overlay_delta: None,
             merge_transaction_delta: None,
+            sealed_observation: None,
         };
         let competing_transaction = RepositoryTransaction {
             operation_id: OperationId::new(),

--- a/crates/kin-daemon/src/api.rs
+++ b/crates/kin-daemon/src/api.rs
@@ -11256,6 +11256,7 @@ mod tests {
             spec_link: None,
             evidence: Vec::new(),
             risk_summary: None,
+            external_reference_deltas: Vec::new(),
         };
         change.id = compute_semantic_change_id(&change).unwrap();
 
@@ -11290,6 +11291,7 @@ mod tests {
             workspace_mutation: None,
             local_overlay_delta: None,
             merge_transaction_delta: None,
+            sealed_observation: None,
         };
         drop(lease);
         manager.commit_repository_transaction(transaction).unwrap();
@@ -11919,6 +11921,7 @@ mod tests {
                     new: kin_model::LocatedEntry::new(path, entry),
                 }],
                 admission_policy_delta: None,
+                external_reference_deltas: Vec::new(),
             })
             .unwrap();
         let plan = crate::repository_commit::plan_native_commit(
@@ -12008,6 +12011,7 @@ mod tests {
             spec_link: None,
             evidence: Vec::new(),
             risk_summary: None,
+            external_reference_deltas: Vec::new(),
         };
         change.id = kin_core::compute_semantic_change_id(&change).unwrap();
         let target_ref = kin_model::RefName::branch(b"semantic-target").unwrap();
@@ -12033,6 +12037,7 @@ mod tests {
             workspace_mutation: None,
             local_overlay_delta: None,
             merge_transaction_delta: None,
+            sealed_observation: None,
         };
         drop(lease);
         authority
@@ -12459,6 +12464,7 @@ mod tests {
             workspace_mutation: None,
             local_overlay_delta: None,
             merge_transaction_delta: None,
+            sealed_observation: None,
         };
         drop(lease);
         external
@@ -18261,6 +18267,7 @@ mod tests {
             spec_link: None,
             evidence: vec![],
             risk_summary: None,
+            external_reference_deltas: Vec::new(),
         };
         change.id = kin_core::compute_semantic_change_id(&change).unwrap();
         state.graph.create_change(&change).unwrap();
@@ -18351,6 +18358,7 @@ mod tests {
             spec_link: None,
             evidence: vec![],
             risk_summary: None,
+            external_reference_deltas: Vec::new(),
         };
         change.id = kin_core::compute_semantic_change_id(&change).unwrap();
         state.graph.create_change(&change).unwrap();

--- a/crates/kin-daemon/src/commit_deltas.rs
+++ b/crates/kin-daemon/src/commit_deltas.rs
@@ -84,6 +84,7 @@ pub fn compute_deltas_vs_repository_authority(
             tree: ResolvedTree::default(),
             entity_tombstones: Default::default(),
             relation_tombstones: Default::default(),
+            external_references: HashMap::new(),
         },
     };
     compute_deltas_from_resolved_state(graph, committed)
@@ -232,6 +233,7 @@ pub fn compute_selected_checkout_delta(
         relation_deltas: semantic_delta.relation_deltas().to_vec(),
         tree_deltas: kin_core::exact_tree_correction(&current.resolved_tree, desired_tree)?,
         admission_policy_delta: None,
+        external_reference_deltas: Vec::new(),
     };
 
     let preflight = InMemoryGraph::from_snapshot(current).map_err(DaemonError::Graph)?;
@@ -412,6 +414,13 @@ fn checkout_node_exists(
         GraphNodeId::Contract(contract_id) => current.contracts.contains_key(&contract_id),
         GraphNodeId::Work(work_id) => current.work_items.contains_key(&work_id),
         GraphNodeId::VerificationRun(run_id) => current.verification_runs.contains_key(&run_id),
+        // External references are not scoped by a path selection, and this
+        // delta adds none, so the desired set equals the current one. An edge
+        // to a reference the graph does not hold is dropped exactly like any
+        // other absent endpoint rather than inventing the reference.
+        GraphNodeId::ExternalReference(reference_id) => {
+            current.external_references.contains_key(&reference_id)
+        }
     }
 }
 
@@ -886,6 +895,7 @@ mod tests {
                 )
                 .unwrap(),
                 admission_policy_delta: None,
+                external_reference_deltas: Vec::new(),
             })
             .unwrap();
         let target = ResolvedGraphState {
@@ -898,6 +908,7 @@ mod tests {
             tree: target_tree,
             entity_tombstones: Default::default(),
             relation_tombstones: Default::default(),
+            external_references: HashMap::new(),
         };
 
         let delta = compute_selected_checkout_delta(
@@ -978,6 +989,7 @@ mod tests {
             tree: tree.clone(),
             entity_tombstones: Default::default(),
             relation_tombstones: Default::default(),
+            external_references: HashMap::new(),
         };
 
         let delta =
@@ -988,6 +1000,88 @@ mod tests {
         graph.apply_transaction_delta(&delta).unwrap();
         assert_eq!(graph.get_entity(&selected_id).unwrap(), Some(target_entity));
         assert!(graph.to_snapshot().relations.is_empty());
+    }
+
+    /// A path selection does not scope the external-reference domain, so a
+    /// spliced edge to an external endpoint survives exactly when the graph
+    /// already holds that reference. The absent case must drop the edge rather
+    /// than fabricate the endpoint, because the resulting delta is applied
+    /// against a graph that rejects a relation to a reference it does not hold.
+    #[test]
+    fn selected_checkout_keeps_external_reference_edges_only_when_the_reference_exists() {
+        fn checkout_delta_for_external_edge(
+            reference: &kin_model::ExternalReference,
+            present_in_graph: bool,
+        ) -> TransactionDelta {
+            let selected = RepoPath::from_utf8("src").unwrap();
+            let selected_id = EntityId::new();
+            let artifact_id = ArtifactId::new();
+            let entry = TreeEntry::blob(Hash256::from_bytes([0x41; 32]), false);
+            let tree = resolved_tree(vec![(
+                artifact_id,
+                RepoPath::from_utf8("src/lib.rs").unwrap(),
+                entry,
+            )]);
+            let target_entity = make_entity_with_id(
+                selected_id,
+                "selected",
+                "src/lib.rs",
+                LanguageId::Rust,
+                [0x42; 32],
+            );
+            let edge = relation(
+                RelationId::new(),
+                GraphNodeId::Entity(selected_id),
+                GraphNodeId::ExternalReference(reference.id),
+                RelationKind::Calls,
+            );
+            let graph = InMemoryGraph::new();
+            graph
+                .apply_transaction_delta(&TransactionDelta {
+                    tree_deltas: kin_core::exact_tree_correction(&ResolvedTree::default(), &tree)
+                        .unwrap(),
+                    external_reference_deltas: if present_in_graph {
+                        vec![kin_model::ExternalReferenceDelta::Added {
+                            new: reference.clone(),
+                        }]
+                    } else {
+                        Vec::new()
+                    },
+                    ..TransactionDelta::default()
+                })
+                .unwrap();
+            let target = ResolvedGraphState {
+                entities: HashMap::from([(selected_id, target_entity)]),
+                relations: HashMap::from([(edge.id, edge)]),
+                entity_revisions: Default::default(),
+                tree: tree.clone(),
+                entity_tombstones: Default::default(),
+                relation_tombstones: Default::default(),
+                external_references: HashMap::from([(reference.id, reference.clone())]),
+            };
+
+            let delta =
+                compute_selected_checkout_delta(&graph, &selected, &target, &tree, &tree).unwrap();
+            graph
+                .apply_transaction_delta(&delta)
+                .expect("a checkout delta must apply to the graph it was computed against");
+            delta
+        }
+
+        let reference = kin_model::ExternalReference::new_resolved(
+            "kin.checkout-fixture-v1",
+            "fixture-source",
+            "fixture::symbol",
+        )
+        .unwrap();
+
+        let absent = checkout_delta_for_external_edge(&reference, false);
+        assert!(absent.relation_deltas.is_empty());
+        assert!(absent.external_reference_deltas.is_empty());
+
+        let present = checkout_delta_for_external_edge(&reference, true);
+        assert_eq!(present.relation_deltas.len(), 1);
+        assert!(present.external_reference_deltas.is_empty());
     }
 
     fn genesis_change() -> kin_model::SemanticChange {
@@ -1006,6 +1100,7 @@ mod tests {
             spec_link: None,
             evidence: vec![],
             risk_summary: None,
+            external_reference_deltas: Vec::new(),
         };
         change.id = kin_core::compute_semantic_change_id(&change).unwrap();
         change
@@ -1035,6 +1130,7 @@ mod tests {
             spec_link: None,
             evidence: vec![],
             risk_summary: None,
+            external_reference_deltas: Vec::new(),
         };
         change.id = kin_core::compute_semantic_change_id(&change).unwrap();
         let change_id = change.id;
@@ -1050,6 +1146,7 @@ mod tests {
                 relation_deltas: Vec::new(),
                 tree_deltas: correction,
                 admission_policy_delta: None,
+                external_reference_deltas: Vec::new(),
             })
             .expect("publish committed tree as live test authority");
         change_id
@@ -1093,6 +1190,7 @@ mod tests {
             relation_deltas: Vec::new(),
             tree_deltas,
             admission_policy_delta: None,
+            external_reference_deltas: Vec::new(),
         })?;
         Ok(())
     }

--- a/crates/kin-daemon/src/mcp_commit.rs
+++ b/crates/kin-daemon/src/mcp_commit.rs
@@ -1310,6 +1310,7 @@ fn transaction_delta_between(
         relation_deltas,
         tree_deltas,
         admission_policy_delta: None,
+        external_reference_deltas: Vec::new(),
     })
 }
 

--- a/crates/kin-daemon/src/repository_branch.rs
+++ b/crates/kin-daemon/src/repository_branch.rs
@@ -623,6 +623,7 @@ fn switch(
         relation_deltas: daemon_semantic_delta.relation_deltas().to_vec(),
         tree_deltas: tree_deltas.clone(),
         admission_policy_delta: None,
+        external_reference_deltas: Vec::new(),
     };
     preflight_switch_delta(state, &workspace.tree, &target_state, &daemon_delta)?;
     let already_active = matches!(
@@ -701,6 +702,7 @@ fn switch(
         }),
         local_overlay_delta: None,
         merge_transaction_delta: None,
+        sealed_observation: None,
     };
     // Validate the derived view before materializing anything over it. This
     // reads the working copy only at paths the workspace tree already tracks
@@ -812,6 +814,7 @@ fn replay_switch(
         workspace_mutation: Some(mutation.clone()),
         local_overlay_delta: None,
         merge_transaction_delta: None,
+        sealed_observation: None,
     };
     if transaction.transaction_hash()? != receipt.transaction_hash {
         return Err(branch_conflict(format!(
@@ -864,6 +867,7 @@ fn replay_switch(
         relation_deltas: daemon_semantic_delta.relation_deltas().to_vec(),
         tree_deltas: mutation.tree_deltas.clone(),
         admission_policy_delta: None,
+        external_reference_deltas: Vec::new(),
     };
     drop(lease);
     let (replayed, authority_freeze) =
@@ -950,6 +954,7 @@ fn ref_transaction(
         workspace_mutation: None,
         local_overlay_delta: None,
         merge_transaction_delta: None,
+        sealed_observation: None,
     }
 }
 

--- a/crates/kin-daemon/src/repository_checkout.rs
+++ b/crates/kin-daemon/src/repository_checkout.rs
@@ -316,6 +316,7 @@ fn plan_and_commit(
             workspace_mutation: receipt.operation.workspace_mutation.clone(),
             local_overlay_delta: None,
             merge_transaction_delta: None,
+            sealed_observation: None,
         };
         let replay_hash = replay_transaction
             .transaction_hash()
@@ -677,6 +678,7 @@ fn plan_and_commit(
         }),
         local_overlay_delta: None,
         merge_transaction_delta: None,
+        sealed_observation: None,
     };
     let (projected_entries, receipt, authority_freeze) =
         kin_core::tree::checkout_repository_workspace_subtree_and_commit_repository_transaction(

--- a/crates/kin-daemon/src/repository_commit.rs
+++ b/crates/kin-daemon/src/repository_commit.rs
@@ -288,6 +288,7 @@ pub(crate) fn plan_session_workspace_admission(
         }),
         local_overlay_delta: None,
         merge_transaction_delta: None,
+        sealed_observation: None,
     };
     transaction.validate()?;
     let transaction_hash = transaction.transaction_hash()?;
@@ -555,6 +556,7 @@ pub(crate) fn publish_workspace_tree(
         }),
         local_overlay_delta: None,
         merge_transaction_delta: None,
+        sealed_observation: None,
     };
     transaction.validate()?;
 
@@ -756,6 +758,7 @@ fn plan_native_commit_inner(
         spec_link: None,
         evidence: Vec::new(),
         risk_summary: None,
+        external_reference_deltas: Vec::new(),
     };
     change.id = compute_semantic_change_id(&change)?;
 
@@ -818,6 +821,7 @@ fn plan_native_commit_inner(
         workspace_mutation: Some(workspace_mutation),
         local_overlay_delta: None,
         merge_transaction_delta: None,
+        sealed_observation: None,
     };
     transaction.validate()?;
 
@@ -1196,6 +1200,7 @@ mod tests {
                     new: LocatedEntry::new(artifact.path.clone(), artifact.entry),
                 }],
                 admission_policy_delta: None,
+                external_reference_deltas: Vec::new(),
             })
             .unwrap();
         artifact
@@ -1874,6 +1879,7 @@ mod tests {
                     new: LocatedEntry::new(artifact.path, artifact.entry),
                 }],
                 admission_policy_delta: None,
+                external_reference_deltas: Vec::new(),
             })
             .unwrap();
         let plan = plan_native_commit(

--- a/crates/kin-daemon/src/repository_merge.rs
+++ b/crates/kin-daemon/src/repository_merge.rs
@@ -415,6 +415,7 @@ fn fast_forward(
         relation_deltas: daemon_semantic_delta.relation_deltas().to_vec(),
         tree_deltas: tree_deltas.clone(),
         admission_policy_delta: None,
+        external_reference_deltas: Vec::new(),
     };
     preflight_merge_delta(
         state,
@@ -455,6 +456,7 @@ fn fast_forward(
         )?),
         local_overlay_delta: None,
         merge_transaction_delta: None,
+        sealed_observation: None,
     };
     publish(
         state,
@@ -601,6 +603,7 @@ fn three_way(
         spec_link: None,
         evidence: Vec::new(),
         risk_summary: None,
+        external_reference_deltas: Vec::new(),
     };
     change.id = compute_semantic_change_id(&change).context("hash exact merge change")?;
     let merge_target = RefTarget::change(change.id);
@@ -644,6 +647,7 @@ fn three_way(
         relation_deltas: daemon_semantic_delta.relation_deltas().to_vec(),
         tree_deltas: workspace_tree_deltas.clone(),
         admission_policy_delta: None,
+        external_reference_deltas: Vec::new(),
     };
     preflight_merge_delta(
         state,
@@ -688,6 +692,7 @@ fn three_way(
         )?),
         local_overlay_delta: None,
         merge_transaction_delta: None,
+        sealed_observation: None,
     };
     let mut execution = publish(
         state,
@@ -945,6 +950,7 @@ pub(crate) fn publish_resolved_merge(
         spec_link: None,
         evidence: Vec::new(),
         risk_summary: None,
+        external_reference_deltas: Vec::new(),
     };
     change.id = compute_semantic_change_id(&change).context("hash exact merge change")?;
     let merge_target = RefTarget::change(change.id);
@@ -982,6 +988,7 @@ pub(crate) fn publish_resolved_merge(
         relation_deltas: daemon_semantic_delta.relation_deltas().to_vec(),
         tree_deltas: workspace_tree_deltas.clone(),
         admission_policy_delta: None,
+        external_reference_deltas: Vec::new(),
     };
     preflight_merge_delta(
         state,
@@ -1033,6 +1040,7 @@ pub(crate) fn publish_resolved_merge(
             record.clone(),
             terminated.clone(),
         )),
+        sealed_observation: None,
     };
     transaction
         .validate()
@@ -1704,6 +1712,7 @@ fn open_conflicted_merge(
         workspace_mutation: None,
         local_overlay_delta: None,
         merge_transaction_delta: Some(delta),
+        sealed_observation: None,
     };
     transaction
         .validate()

--- a/crates/kin-daemon/src/repository_merge_state.rs
+++ b/crates/kin-daemon/src/repository_merge_state.rs
@@ -441,6 +441,7 @@ fn record_transaction(
         workspace_mutation: None,
         local_overlay_delta: None,
         merge_transaction_delta: Some(delta),
+        sealed_observation: None,
     }
 }
 

--- a/crates/kin-daemon/src/repository_rollback.rs
+++ b/crates/kin-daemon/src/repository_rollback.rs
@@ -316,6 +316,7 @@ fn plan_and_commit(
         spec_link: None,
         evidence: Vec::new(),
         risk_summary: None,
+        external_reference_deltas: Vec::new(),
     };
     change.id =
         compute_semantic_change_id(&change).context("compute the rollback change identity")?;
@@ -343,6 +344,7 @@ fn plan_and_commit(
         relation_deltas: daemon_semantic_delta.relation_deltas().to_vec(),
         tree_deltas: workspace_tree_deltas.clone(),
         admission_policy_delta: None,
+        external_reference_deltas: Vec::new(),
     };
     preflight_rollback_delta(state, &workspace.tree, &target_state, &daemon_delta)?;
 
@@ -397,6 +399,7 @@ fn plan_and_commit(
         }),
         local_overlay_delta: None,
         merge_transaction_delta: None,
+        sealed_observation: None,
     };
     transaction
         .validate()

--- a/crates/kin-daemon/src/repository_stash.rs
+++ b/crates/kin-daemon/src/repository_stash.rs
@@ -383,6 +383,7 @@ fn push(
         spec_link: None,
         evidence: Vec::new(),
         risk_summary: None,
+        external_reference_deltas: Vec::new(),
     };
     change.id = compute_semantic_change_id(&change).context("identify the exact sealed change")?;
     let sealed_change_id = change.id;
@@ -453,6 +454,7 @@ fn push(
         }),
         local_overlay_delta: None,
         merge_transaction_delta: None,
+        sealed_observation: None,
     };
     seal.validate()
         .context("validate the exact stash seal transaction")?;
@@ -576,6 +578,7 @@ fn return_to_base(
         )
         .context("plan the exact workspace return tree transition for the daemon view")?,
         admission_policy_delta: None,
+        external_reference_deltas: Vec::new(),
     };
     let transaction = RepositoryTransaction {
         schema_version: REPOSITORY_TRANSACTION_SCHEMA_VERSION,
@@ -613,6 +616,7 @@ fn return_to_base(
         }),
         local_overlay_delta: None,
         merge_transaction_delta: None,
+        sealed_observation: None,
     };
     transaction
         .validate()
@@ -780,6 +784,7 @@ fn pop(
         tree_deltas: kin_core::exact_tree_correction(&daemon_snapshot.resolved_tree, &sealed_tree)
             .context("plan the exact stash restore tree transition for the daemon view")?,
         admission_policy_delta: None,
+        external_reference_deltas: Vec::new(),
     };
     let transaction = RepositoryTransaction {
         schema_version: REPOSITORY_TRANSACTION_SCHEMA_VERSION,
@@ -823,6 +828,7 @@ fn pop(
         }),
         local_overlay_delta: None,
         merge_transaction_delta: None,
+        sealed_observation: None,
     };
     transaction
         .validate()

--- a/crates/kin-daemon/src/repository_tag.rs
+++ b/crates/kin-daemon/src/repository_tag.rs
@@ -201,6 +201,7 @@ fn publish(
         workspace_mutation: None,
         local_overlay_delta: None,
         merge_transaction_delta: None,
+        sealed_observation: None,
     };
     let (receipt, authority_freeze) = commit_and_freeze_exact(&authority.manager, transaction)
         .with_context(|| format!("publish repository-v6 tag {}", request.name))?;
@@ -429,6 +430,7 @@ fn replay(
         workspace_mutation: None,
         local_overlay_delta: None,
         merge_transaction_delta: None,
+        sealed_observation: None,
     };
     if transaction.transaction_hash()? != receipt.transaction_hash {
         return Err(tag_conflict(format!(

--- a/crates/kin-daemon/src/state.rs
+++ b/crates/kin-daemon/src/state.rs
@@ -3760,6 +3760,7 @@ impl DaemonState {
             relation_deltas: semantics.relation_deltas().to_vec(),
             tree_deltas,
             admission_policy_delta: planned_delta.admission_policy_delta.clone(),
+            external_reference_deltas: Vec::new(),
         };
         let graph_changed = finalization_delta != TransactionDelta::default();
         if graph_changed {
@@ -4832,6 +4833,7 @@ mod tests {
             spec_link: None,
             evidence: vec![],
             risk_summary: None,
+            external_reference_deltas: Vec::new(),
         };
         change.id = kin_core::compute_semantic_change_id(&change).unwrap();
         change
@@ -5596,6 +5598,7 @@ mod tests {
                     ),
                 }],
                 admission_policy_delta: None,
+                external_reference_deltas: Vec::new(),
             })
             .unwrap();
         sibling_graph

--- a/crates/kin-git/src/admission_history.rs
+++ b/crates/kin-git/src/admission_history.rs
@@ -157,6 +157,7 @@ impl AdmittedSemanticGitImportPlan {
             workspace_mutation: None,
             local_overlay_delta: None,
             merge_transaction_delta: None,
+            sealed_observation: None,
         };
         transaction.validate()?;
         Ok(transaction)

--- a/crates/kin-git/src/repository_export.rs
+++ b/crates/kin-git/src/repository_export.rs
@@ -1255,6 +1255,7 @@ mod tests {
             spec_link: None,
             evidence: Vec::new(),
             risk_summary: None,
+            external_reference_deltas: Vec::new(),
         };
         native.id = compute_semantic_change_id(&native).unwrap();
         let expected_tree = base_tree.apply(&native.tree_deltas).unwrap();
@@ -1609,6 +1610,7 @@ mod tests {
             spec_link: None,
             evidence: Vec::new(),
             risk_summary: None,
+            external_reference_deltas: Vec::new(),
         };
         change.id = compute_semantic_change_id(&change).unwrap();
         change

--- a/crates/kin-git/src/semantic_import.rs
+++ b/crates/kin-git/src/semantic_import.rs
@@ -340,6 +340,7 @@ fn build_semantic_git_import_plan(
             spec_link: None,
             evidence: Vec::new(),
             risk_summary: None,
+            external_reference_deltas: Vec::new(),
         };
         change.id = compute_semantic_change_id(&change)?;
         validate_semantic_change_id(&change)?;

--- a/crates/kin-mcp/src/handlers/mod.rs
+++ b/crates/kin-mcp/src/handlers/mod.rs
@@ -329,6 +329,7 @@ mod tests {
             risk_summary: None,
             origin: kin_model::ChangeOrigin::Native,
             admission_policy_delta,
+            external_reference_deltas: Vec::new(),
         };
         change.id = kin_model::compute_semantic_change_id(&change).unwrap();
         change
@@ -527,6 +528,7 @@ mod tests {
             }),
             local_overlay_delta: None,
             merge_transaction_delta: None,
+            sealed_observation: None,
         };
         authority
             .commit_repository_transaction(transaction)
@@ -628,6 +630,7 @@ mod tests {
             }),
             local_overlay_delta: None,
             merge_transaction_delta: None,
+            sealed_observation: None,
         };
         authority
             .commit_repository_transaction(transaction)
@@ -776,6 +779,7 @@ mod tests {
             workspace_mutation: None,
             local_overlay_delta: None,
             merge_transaction_delta: None,
+            sealed_observation: None,
         };
         authority
             .commit_repository_transaction(transaction)
@@ -2075,6 +2079,7 @@ mod tests {
                     relation_deltas: vec![],
                     tree_deltas: change.tree_deltas.clone(),
                     admission_policy_delta: None,
+                    external_reference_deltas: Vec::new(),
                 })
                 .unwrap();
             store.create_change(&change).unwrap();
@@ -5547,6 +5552,7 @@ mod tests {
                     kin_model::SharedAdmissionPolicy::empty(0),
                 )
             }),
+            external_reference_deltas: Vec::new(),
         };
         change.id = kin_model::compute_semantic_change_id(&change).unwrap();
         change

--- a/crates/kin-mcp/src/handlers/sessions.rs
+++ b/crates/kin-mcp/src/handlers/sessions.rs
@@ -1128,6 +1128,7 @@ pub async fn handle_transaction_commit<G: GraphStore>(
         relation_deltas,
         tree_deltas: Vec::new(),
         admission_policy_delta: None,
+        external_reference_deltas: Vec::new(),
     };
 
     if let Err(err) = store.apply_transaction_delta(&delta) {

--- a/crates/kin-projection/src/engine.rs
+++ b/crates/kin-projection/src/engine.rs
@@ -658,6 +658,7 @@ mod tests {
                     ),
                 }],
                 admission_policy_delta: None,
+                external_reference_deltas: Vec::new(),
             })
             .unwrap();
         graph
@@ -703,6 +704,7 @@ mod tests {
                     ),
                 }],
                 admission_policy_delta: None,
+                external_reference_deltas: Vec::new(),
             })
             .unwrap();
         graph

--- a/crates/kin-remote/src/delta_bridge.rs
+++ b/crates/kin-remote/src/delta_bridge.rs
@@ -190,6 +190,7 @@ mod tests {
             spec_link: None,
             evidence: vec![],
             risk_summary: None,
+            external_reference_deltas: Vec::new(),
         };
         change.id =
             compute_semantic_change_id(&change).expect("test change must be identity-exact");

--- a/crates/kin-remote/src/repository_transfer.rs
+++ b/crates/kin-remote/src/repository_transfer.rs
@@ -1589,6 +1589,7 @@ fn transfer_transaction(
         workspace_mutation: None,
         local_overlay_delta: None,
         merge_transaction_delta: None,
+        sealed_observation: None,
     };
     transaction.validate().map_err(model)?;
     Ok(transaction)
@@ -1828,6 +1829,7 @@ mod tests {
             spec_link: None,
             evidence: Vec::new(),
             risk_summary: None,
+            external_reference_deltas: Vec::new(),
         };
         change.id = compute_semantic_change_id(&change).unwrap();
         change
@@ -1943,6 +1945,7 @@ mod tests {
             workspace_mutation: None,
             local_overlay_delta: None,
             merge_transaction_delta: None,
+            sealed_observation: None,
         };
         drop(lease);
         manager.commit_repository_transaction(transaction).unwrap();
@@ -2121,6 +2124,7 @@ mod tests {
             spec_link: None,
             evidence: Vec::new(),
             risk_summary: None,
+            external_reference_deltas: Vec::new(),
         };
         parent.id = compute_semantic_change_id(&parent).unwrap();
         let mut imported_head = SemanticChange {
@@ -2140,6 +2144,7 @@ mod tests {
             spec_link: None,
             evidence: Vec::new(),
             risk_summary: None,
+            external_reference_deltas: Vec::new(),
         };
         imported_head.id = compute_semantic_change_id(&imported_head).unwrap();
         let aliases = vec![
@@ -2206,6 +2211,7 @@ mod tests {
             workspace_mutation: None,
             local_overlay_delta: None,
             merge_transaction_delta: None,
+            sealed_observation: None,
         };
         drop(source_lease);
         source
@@ -2456,6 +2462,7 @@ mod tests {
             workspace_mutation: None,
             local_overlay_delta: None,
             merge_transaction_delta: None,
+            sealed_observation: None,
         };
         drop(lease);
         fixture
@@ -2516,6 +2523,7 @@ mod tests {
             workspace_mutation: None,
             local_overlay_delta: None,
             merge_transaction_delta: None,
+            sealed_observation: None,
         };
         drop(lease);
         authority
@@ -2728,6 +2736,7 @@ mod tests {
             workspace_mutation: None,
             local_overlay_delta: None,
             merge_transaction_delta: None,
+            sealed_observation: None,
         };
         drop(lease);
         fixture

--- a/crates/kin-remote/src/repository_transfer_negotiation.rs
+++ b/crates/kin-remote/src/repository_transfer_negotiation.rs
@@ -824,6 +824,7 @@ mod tests {
             spec_link: None,
             evidence: Vec::new(),
             risk_summary: None,
+            external_reference_deltas: Vec::new(),
         };
         change.id = compute_semantic_change_id(&change).unwrap();
         change
@@ -908,6 +909,7 @@ mod tests {
             workspace_mutation: None,
             local_overlay_delta: None,
             merge_transaction_delta: None,
+            sealed_observation: None,
         };
         drop(lease);
         manager.commit_repository_transaction(transaction).unwrap();

--- a/crates/kin-review/src/diff.rs
+++ b/crates/kin-review/src/diff.rs
@@ -600,6 +600,7 @@ mod tests {
             risk_summary: None,
             origin: kin_model::ChangeOrigin::Native,
             admission_policy_delta: None,
+            external_reference_deltas: Vec::new(),
         };
 
         let diff = diff_from_change(&change);
@@ -634,6 +635,7 @@ mod tests {
             risk_summary: None,
             origin: kin_model::ChangeOrigin::Native,
             admission_policy_delta: None,
+            external_reference_deltas: Vec::new(),
         };
 
         let diff = diff_from_change(&change);
@@ -670,6 +672,7 @@ mod tests {
             risk_summary: None,
             origin: kin_model::ChangeOrigin::Native,
             admission_policy_delta: None,
+            external_reference_deltas: Vec::new(),
         };
 
         let diff = diff_from_change(&change);
@@ -694,6 +697,7 @@ mod tests {
             risk_summary: None,
             origin: kin_model::ChangeOrigin::Native,
             admission_policy_delta: None,
+            external_reference_deltas: Vec::new(),
         };
 
         let diff = diff_from_change(&change);
@@ -719,6 +723,7 @@ mod tests {
             risk_summary: None,
             origin: kin_model::ChangeOrigin::Native,
             admission_policy_delta: None,
+            external_reference_deltas: Vec::new(),
         };
 
         let diff = diff_from_change(&change);
@@ -757,6 +762,7 @@ mod tests {
             risk_summary: None,
             origin: kin_model::ChangeOrigin::Native,
             admission_policy_delta: None,
+            external_reference_deltas: Vec::new(),
         };
 
         let diff = diff_from_change(&change);
@@ -785,6 +791,7 @@ mod tests {
             risk_summary: None,
             origin: kin_model::ChangeOrigin::Native,
             admission_policy_delta: None,
+            external_reference_deltas: Vec::new(),
         };
 
         let diff = diff_from_change(&change);
@@ -814,6 +821,7 @@ mod tests {
             risk_summary: None,
             origin: kin_model::ChangeOrigin::Native,
             admission_policy_delta: None,
+            external_reference_deltas: Vec::new(),
         };
 
         let diff = diff_from_change(&change);
@@ -844,6 +852,7 @@ mod tests {
             risk_summary: None,
             origin: kin_model::ChangeOrigin::Native,
             admission_policy_delta: None,
+            external_reference_deltas: Vec::new(),
         };
 
         let diff = diff_from_change(&change);
@@ -888,6 +897,7 @@ mod tests {
             risk_summary: None,
             origin: kin_model::ChangeOrigin::Native,
             admission_policy_delta: None,
+            external_reference_deltas: Vec::new(),
         };
 
         let emitted: Vec<EntityId> = diff_from_changes(&[change])
@@ -944,6 +954,7 @@ mod tests {
             risk_summary: None,
             origin: kin_model::ChangeOrigin::Native,
             admission_policy_delta: None,
+            external_reference_deltas: Vec::new(),
         };
 
         let diff = diff_from_changes(&[change]);
@@ -973,6 +984,7 @@ mod tests {
             risk_summary: None,
             origin: kin_model::ChangeOrigin::Native,
             admission_policy_delta: None,
+            external_reference_deltas: Vec::new(),
         };
 
         let c2 = SemanticChange {
@@ -990,6 +1002,7 @@ mod tests {
             risk_summary: None,
             origin: kin_model::ChangeOrigin::Native,
             admission_policy_delta: None,
+            external_reference_deltas: Vec::new(),
         };
 
         let diff = diff_from_changes(&[c1, c2]);
@@ -1019,6 +1032,7 @@ mod tests {
             risk_summary: None,
             origin: kin_model::ChangeOrigin::Native,
             admission_policy_delta: None,
+            external_reference_deltas: Vec::new(),
         };
 
         let c2 = SemanticChange {
@@ -1036,6 +1050,7 @@ mod tests {
             risk_summary: None,
             origin: kin_model::ChangeOrigin::Native,
             admission_policy_delta: None,
+            external_reference_deltas: Vec::new(),
         };
 
         let diff = diff_from_changes(&[c1, c2]);

--- a/crates/kin-review/src/impact.rs
+++ b/crates/kin-review/src/impact.rs
@@ -742,6 +742,7 @@ mod tests {
                     ),
                 }],
                 admission_policy_delta: None,
+                external_reference_deltas: Vec::new(),
             })
             .expect("test artifact admission");
         artifact_id

--- a/crates/kin-review/src/ref_graph.rs
+++ b/crates/kin-review/src/ref_graph.rs
@@ -440,6 +440,7 @@ mod tests {
                     ),
                 }],
                 admission_policy_delta: None,
+                external_reference_deltas: Vec::new(),
             })
             .expect("test artifact admission");
         artifact_id
@@ -709,6 +710,7 @@ mod tests {
             risk_summary: None,
             origin: kin_model::ChangeOrigin::Native,
             admission_policy_delta: None,
+            external_reference_deltas: Vec::new(),
         };
         change.id = kin_model::compute_semantic_change_id(&change).unwrap();
         change

--- a/crates/kin-review/src/release_gate.rs
+++ b/crates/kin-review/src/release_gate.rs
@@ -470,6 +470,7 @@ mod tests {
             risk_summary: None,
             origin: kin_model::ChangeOrigin::Native,
             admission_policy_delta: None,
+            external_reference_deltas: Vec::new(),
         };
         change.id = kin_model::compute_semantic_change_id(&change).unwrap();
         change

--- a/crates/kin-review/src/review.rs
+++ b/crates/kin-review/src/review.rs
@@ -211,6 +211,7 @@ mod tests {
             risk_summary: None,
             origin: kin_model::ChangeOrigin::Native,
             admission_policy_delta: None,
+            external_reference_deltas: Vec::new(),
         };
 
         let diff = diff_from_change(&change);

--- a/crates/kin-review/src/shadow.rs
+++ b/crates/kin-review/src/shadow.rs
@@ -2335,6 +2335,7 @@ mod tests {
             risk_summary: None,
             origin: kin_model::ChangeOrigin::Native,
             admission_policy_delta: None,
+            external_reference_deltas: Vec::new(),
         };
         change.id = kin_model::compute_semantic_change_id(&change).unwrap();
         change

--- a/fuzz/Cargo.lock
+++ b/fuzz/Cargo.lock
@@ -644,9 +644,9 @@ dependencies = [
 
 [[package]]
 name = "kin-model"
-version = "0.6.4"
+version = "0.7.1"
 source = "sparse+https://kinlab.ai/registry/cargo/"
-checksum = "a6be89147ec09ed24c2d1c493b3e9dcc886b140f71b3b4c1960e879e112be81d"
+checksum = "4c3a35cfb62580592442c3413ae74a3382b81b24eff209e719a8d68502a8f212"
 dependencies = [
  "chrono",
  "gix-hash",

--- a/scripts/hydration-semantics-manifest.json
+++ b/scripts/hydration-semantics-manifest.json
@@ -82,7 +82,7 @@
     {
       "file": "crates/kin-git/src/semantic_import.rs",
       "function": "build_semantic_git_import_plan",
-      "digest": "sha256:7a40b21ecef701fbbaaad7639ef2bcb070bca479d06bc440cf86b392eb78ae1e",
+      "digest": "sha256:ed32076e2e329bb714b10d8de562d262ee5a29a794a4b0d203a6268bbb863bb8",
       "reason": "Builds the parent-first change sequence and tree map replay consumes. Its ordering and tree selection decide the baseline every historical delta is computed against.",
       "owner": "kin-git"
     },


### PR DESCRIPTION
Part-of FIR-1610.

Pins kin-model to `=0.7.1`, kin-db to `=0.7.6`, kin-lsp to `0.6.5`, and carries the appended external-reference and sealed-observation contract fields through every kin construction path. This is the compatibility half of the adoption. It does not produce a single external reference, and it persists no selector.

## Why kin-lsp had to move

kin-lsp `0.6.0` requires `kin-model ^0.6`. Pinning the model to `=0.7.1` while leaving the language server alone resolves **two kin-model generations into one lock**: 0.6.4 retained for kin-lsp, 0.7.1 for everything else. That was the actual first resolution result here, and it is a hard stop condition in the FIR-1610 adoption audit. After the lsp bump the lock resolves exactly one `kin-model 0.7.1`, one `kin-db 0.7.6`, one `kin-lsp 0.6.5`, each `sparse+` sourced with a checksum and no path patch.

kin-db 0.7.6 rather than 0.7.5: both carry exact `kin-model =0.7.1`, and 0.7.6 only advances `kin-infer 0.2.41 -> 0.2.42`, which keeps kin aligned with the dependency wave landing across the other repos.

## The migration itself

126 construction sites, enumerated by rustc E0063 across four compile rounds rather than by grep, so the inventory is the compiler's. 31 are production paths and 95 are test fixtures. Every site names the field explicitly. For `sealed_observation` and `SemanticChange`, which derive no `Default`, no site was converted to `..Default::default()`, so a future non-empty default cannot reach a compatibility path without a compiler error at that exact site. The reference-carrying types (`TransactionDelta`, `SubGraph`, `ResolvedGraphState`) do derive `Default`, so struct-update sites absorb appended fields silently; empty is the semantically correct value for them today, and this change itself introduces one such site, so that guarantee is narrower for those types and rests on the empty-is-correct invariant rather than the compiler.

One semantic decision: the exhaustive `GraphNodeId::ExternalReference` arm in `checkout_node_exists`. A path selection does not scope the external-reference domain and a checkout delta introduces no reference, so the desired set equals the current one and the arm reads `current.external_references`, matching how `Test`, `Contract`, `Work`, and `VerificationRun` are already answered. An edge to a reference the graph does not hold is dropped exactly as any other absent endpoint is, because inventing the endpoint produces a delta the graph then refuses to apply.

The new test covers both directions. Absent reference drops the edge; present reference keeps it; both cases apply the resulting delta back to the graph it was computed against. A constant-`false` arm fails the present case and a constant-`true` arm fails the absent case.

## Reviewer note 1: no constructor-count pin test, on purpose

The adoption audit asked for a test pinning the count of `RepositoryTransaction` constructors. That was considered and rejected. `sealed_observation` has no literal-level default, so rustc already refuses any constructor that omits it, and E0063 is complete by construction. A hand-maintained count constant is the same brittle shape as the capability pin that went silently wrong when two lanes bumped it to the same value, and as the kin-db coverage revision that fired on the wrong event.

The single struct-update site the audit flagged, `competing_transaction` in `kin-core/src/tree.rs`, is a workspace-transition-freeze test fixture rather than a production path, and its base sets `sealed_observation: None` explicitly.

## Reviewer note 2: the audit's legacy positional MessagePack fixtures have no surface here

Verified in kin-db source at both tags: `v0.6.7` has `CURRENT_VERSION = 12` with `MIN_SUPPORTED_VERSION = CURRENT_VERSION`, and 0.7.x has `CURRENT_VERSION = 13` with the same equality. Each pre-release kin-db accepts exactly one on-disk snapshot version, so a v12 snapshot is rejected at the frame header before any positional struct decode runs. Kin never sees legacy positional bytes and cannot regress on them; that hazard lives entirely inside one format version, which is kin-db's and kin-model's gate.

The kin-side obligation is the opposite assertion, and it already holds without a code change: kin-db raises `IncompatibleSnapshotVersion` carrying the remediation "reinitialize this pre-release repository with the current Kin", and `repository_commit_error_is_definitely_prepublication` in kin-core already classifies that variant as determinate.

## Release-note consequence

**No pre-existing Kin repository opens under v0.4.0; re-initialization is required.** This is kin-db's standing pre-release posture and was already true before this change: main's kin-db `=0.6.7` accepts only snapshot v12, and measured on-disk stores (v6/v8) are already outside that window today. Stores written by current binaries (v12) stop opening when this v13 line lands. Not a regression introduced by this adoption; it belongs in the v0.4.0 notes with that attribution.

## Deliberately not in this change

1. **The authority-payload receipt.** kin-db exposes `open_with_payload_stats`, whose receipt is only coherent when it comes from the same open that built the manager. It has to be carried beside the manager in `ActiveRepositoryAuthority` and mapped into status under that same lease, and the status field needs `#[serde(default, skip_serializing_if = "Option::is_none")]` so an old `kin.status.v1` payload decodes as `None`.
2. **Resolver-namespace governance and first-class reference production.** Every state-diffing planner here (rollback, merge, stash, checkout) leaves the reference vector empty because there is no reference diff to compute: the follow-up owes a reference diff beside the existing entity and relation diffs, plus inverse handling. Until a resolver issues canonical coordinates, nothing is persisted. Kin's current spine matching trims, lowercases, folds underscore to hyphen, and reduces an import source to a root token; persisting those values would freeze language aliases and case folding into permanent graph identity.

## Gates

`cargo check --workspace --all-targets` clean. `cargo fmt --all` clean. `cargo clippy --all-targets --all-features` clean under the exact ci.yml allowlist with `RUSTFLAGS=-D warnings`. `cargo build --all-targets --locked` clean. `verify-zero-file-search.py` passed with 144 source files actually scanned, `zero_file_search_guard.sh`, `check_runtime_boundaries.sh`, and `check_private_repo_coupling.sh` all passed.


