### PR TITLE
Bind the release tag mint job to the release-tag environment

### DIFF
--- a/.github/workflows/release-tag.yml
+++ b/.github/workflows/release-tag.yml
@@ -47,6 +47,13 @@ jobs:
     name: Mint release tag
     runs-on: ubuntu-latest
     timeout-minutes: 15
+    # The kin-release-bot App credentials are scoped to this environment, which
+    # a job only resolves when it declares the environment. Without the binding
+    # the job silently falls back to repository-scoped copies of the same secret
+    # names, so a key rotation applied to the environment never reaches the mint.
+    # The environment's deployment branch policy admits main only, which matches
+    # the ref guard below.
+    environment: release-tag
     steps:
       - name: Guard — authorized actor and ref
         # Only the release captain or the bot may dispatch, and only against the


### PR DESCRIPTION
The job resolves the kin-release-bot App credentials from whatever scope
GitHub exposes to it, and with no environment declared that is repository
scope. A key rotation applied to the release-tag environment therefore
never reaches the mint, which then fails while requesting an installation
token because the stale repository copy no longer decodes as a JSON web
token.

Declaring the environment makes the environment-scoped credentials
authoritative for this job. The environment's deployment branch policy
admits main only, which matches the ref guard the workflow already
enforces, so the binding adds no new approval or wait state.
