### PR TITLE
Name the remedy when a command refuses outside a repository

### DIFF
--- a/crates/kin-cli/src/commands/approvals.rs
+++ b/crates/kin-cli/src/commands/approvals.rs
@@ -21,8 +21,7 @@ pub struct ApprovalsResponse {
 
 /// `kin approvals <change-id>` — Show approvals for a specific change.
 pub async fn show(change_id: String) -> Result<()> {
-    let layout = kin_core::KinLayout::discover(&std::env::current_dir()?)
-        .ok_or_else(|| anyhow::anyhow!("not a Kin repository (no .kin/ found)"))?;
+    let layout = crate::commands::require_repository_layout()?;
     print_approvals_response(
         run_daemon_approvals(&layout, &ApprovalsRequest::Show { change_id }).await?,
     )
@@ -30,8 +29,7 @@ pub async fn show(change_id: String) -> Result<()> {
 
 /// `kin approvals list` — Show all actors and their delegation counts.
 pub async fn list() -> Result<()> {
-    let layout = kin_core::KinLayout::discover(&std::env::current_dir()?)
-        .ok_or_else(|| anyhow::anyhow!("not a Kin repository (no .kin/ found)"))?;
+    let layout = crate::commands::require_repository_layout()?;
     print_approvals_response(run_daemon_approvals(&layout, &ApprovalsRequest::List).await?)
 }
 

--- a/crates/kin-cli/src/commands/assistant.rs
+++ b/crates/kin-cli/src/commands/assistant.rs
@@ -9,8 +9,7 @@ use kin_core::{ManagedDocConfig, RepoSummary, SyncMode};
 
 /// `kin assistant install <assistant>` — Install an assistant adapter.
 pub async fn install(assistant: String) -> Result<()> {
-    let layout = kin_core::KinLayout::discover(&std::env::current_dir()?)
-        .ok_or_else(|| anyhow::anyhow!("not a Kin repository (no .kin/ found)"))?;
+    let layout = crate::commands::require_repository_layout()?;
 
     let kind = AssistantKind::from_str(&assistant).ok_or_else(|| {
         anyhow::anyhow!(
@@ -81,8 +80,7 @@ pub async fn install(assistant: String) -> Result<()> {
 
 /// `kin assistant doctor` — Run connectivity checks for all installed adapters.
 pub async fn run_doctor(assistant: Option<String>) -> Result<()> {
-    let layout = kin_core::KinLayout::discover(&std::env::current_dir()?)
-        .ok_or_else(|| anyhow::anyhow!("not a Kin repository (no .kin/ found)"))?;
+    let layout = crate::commands::require_repository_layout()?;
 
     if let Some(name) = assistant {
         // Doctor a specific assistant.
@@ -116,8 +114,7 @@ pub async fn run_doctor(assistant: Option<String>) -> Result<()> {
 
 /// `kin assistant list` — List installed assistant adapters.
 pub async fn list() -> Result<()> {
-    let layout = kin_core::KinLayout::discover(&std::env::current_dir()?)
-        .ok_or_else(|| anyhow::anyhow!("not a Kin repository (no .kin/ found)"))?;
+    let layout = crate::commands::require_repository_layout()?;
 
     let adapters = list_adapters(&layout)?;
 
@@ -152,8 +149,7 @@ pub async fn list() -> Result<()> {
 
 /// `kin assistant sync` — Regenerate managed blocks in all enabled target files.
 pub async fn sync() -> Result<()> {
-    let layout = kin_core::KinLayout::discover(&std::env::current_dir()?)
-        .ok_or_else(|| anyhow::anyhow!("not a Kin repository (no .kin/ found)"))?;
+    let layout = crate::commands::require_repository_layout()?;
 
     let config = ManagedDocConfig::load(&layout)?;
 
@@ -195,8 +191,7 @@ pub async fn configure(
     enable: Option<String>,
     disable: Option<String>,
 ) -> Result<()> {
-    let layout = kin_core::KinLayout::discover(&std::env::current_dir()?)
-        .ok_or_else(|| anyhow::anyhow!("not a Kin repository (no .kin/ found)"))?;
+    let layout = crate::commands::require_repository_layout()?;
 
     let mut config = ManagedDocConfig::load(&layout)?;
     let mut changed = false;
@@ -306,8 +301,7 @@ pub async fn hooks(assistant: Option<String>) -> Result<()> {
 
 /// `kin assistant snippets [assistant]` — Generate config snippets.
 pub async fn snippets(assistant: Option<String>) -> Result<()> {
-    let layout = kin_core::KinLayout::discover(&std::env::current_dir()?)
-        .ok_or_else(|| anyhow::anyhow!("not a Kin repository (no .kin/ found)"))?;
+    let layout = crate::commands::require_repository_layout()?;
 
     let kinds: Vec<AssistantKind> = if let Some(name) = assistant {
         let kind = AssistantKind::from_str(&name).ok_or_else(|| {
@@ -355,8 +349,7 @@ pub async fn snippets(assistant: Option<String>) -> Result<()> {
 
 /// `kin assistant prompt --assistant <name> [--mode benchmark|normal]`
 pub async fn prompt(assistant: String, mode: String) -> Result<()> {
-    let layout = kin_core::KinLayout::discover(&std::env::current_dir()?)
-        .ok_or_else(|| anyhow::anyhow!("not a Kin repository (no .kin/ found)"))?;
+    let layout = crate::commands::require_repository_layout()?;
 
     let kind = AssistantKind::from_str(&assistant).ok_or_else(|| {
         anyhow::anyhow!(

--- a/crates/kin-cli/src/commands/audit.rs
+++ b/crates/kin-cli/src/commands/audit.rs
@@ -40,8 +40,7 @@ pub async fn run_with_filters(
     limit: usize,
     filters: AuditFilters,
 ) -> Result<()> {
-    let layout = kin_core::KinLayout::discover(&std::env::current_dir()?)
-        .ok_or_else(|| anyhow::anyhow!("not a Kin repository (no .kin/ found)"))?;
+    let layout = crate::commands::require_repository_layout()?;
     let response = run_daemon_audit(
         &layout,
         &AuditRequest {

--- a/crates/kin-cli/src/commands/backup.rs
+++ b/crates/kin-cli/src/commands/backup.rs
@@ -210,8 +210,7 @@ pub async fn delete(name: String) -> Result<()> {
 // -- Helpers --
 
 fn discover_layout() -> Result<kin_core::KinLayout> {
-    kin_core::KinLayout::discover(&std::env::current_dir()?)
-        .ok_or_else(|| anyhow::anyhow!("not a Kin repository (no .kin/ found)"))
+    crate::commands::require_repository_layout()
 }
 
 fn require_explicit_offline_restore(layout: &kin_core::KinLayout) -> Result<()> {

--- a/crates/kin-cli/src/commands/blame.rs
+++ b/crates/kin-cli/src/commands/blame.rs
@@ -19,8 +19,7 @@ pub struct BlameResponse {
 
 /// `kin blame <entity>` — Show who/when each version of an entity was committed.
 pub async fn run(entity: String, reference: Option<String>) -> Result<()> {
-    let layout = kin_core::KinLayout::discover(&std::env::current_dir()?)
-        .ok_or_else(|| anyhow::anyhow!("not a Kin repository (no .kin/ found)"))?;
+    let layout = crate::commands::require_repository_layout()?;
     let response = run_daemon_blame(&layout, &BlameRequest { entity, reference }).await?;
     for line in response.lines {
         println!("{line}");

--- a/crates/kin-cli/src/commands/branch.rs
+++ b/crates/kin-cli/src/commands/branch.rs
@@ -158,11 +158,7 @@ fn mutation_request(name: RefName, mutation: BranchMutation) -> BranchRequest {
 }
 
 async fn execute(request: BranchRequest) -> Result<BranchResponse> {
-    let layout = kin_core::KinLayout::discover(&std::env::current_dir()?).ok_or_else(|| {
-        anyhow::anyhow!(
-            "not a Kin repository (no .kin/ found)\nhint: run `kin init .` to initialize a Kin repository here"
-        )
-    })?;
+    let layout = crate::commands::require_repository_layout()?;
     let daemon_url = crate::daemon_client::resolve_daemon_url(&layout)
         .await?
         .ok_or_else(|| {

--- a/crates/kin-cli/src/commands/checkout.rs
+++ b/crates/kin-cli/src/commands/checkout.rs
@@ -49,11 +49,7 @@ pub async fn run(
     path_hex: Option<String>,
     change_id: Option<String>,
 ) -> Result<()> {
-    let layout = kin_core::KinLayout::discover(&std::env::current_dir()?).ok_or_else(|| {
-        anyhow::anyhow!(
-            "not a Kin repository (no .kin/ found)\nhint: run `kin init .` to initialize a Kin repository here"
-        )
-    })?;
+    let layout = crate::commands::require_repository_layout()?;
     let daemon_url = crate::daemon_client::resolve_daemon_url(&layout)
         .await?
         .ok_or_else(|| {

--- a/crates/kin-cli/src/commands/commit.rs
+++ b/crates/kin-cli/src/commands/commit.rs
@@ -4,11 +4,7 @@
 use anyhow::{Context, Result};
 
 pub async fn run(message: String, quiet: bool) -> Result<()> {
-    let layout = kin_core::KinLayout::discover(&std::env::current_dir()?).ok_or_else(|| {
-        anyhow::anyhow!(
-            "not a Kin repository (no .kin/ found)\nhint: run `kin init .` to initialize a Kin repository here"
-        )
-    })?;
+    let layout = crate::commands::require_repository_layout()?;
 
     let result = run_daemon_commit(&layout, &message).await?;
     if !quiet {

--- a/crates/kin-cli/src/commands/context.rs
+++ b/crates/kin-cli/src/commands/context.rs
@@ -60,8 +60,7 @@ pub struct ContextResponse {
 }
 
 pub async fn run(entity: String, budget: String, assistant: Option<String>) -> Result<()> {
-    let layout = kin_core::KinLayout::discover(&std::env::current_dir()?)
-        .ok_or_else(|| anyhow::anyhow!("not a Kin repository (no .kin/ found)"))?;
+    let layout = crate::commands::require_repository_layout()?;
     let _scope = announce_active_scope(&layout, "context").await?;
     let response = run_daemon_context(
         &layout,

--- a/crates/kin-cli/src/commands/dead_code.rs
+++ b/crates/kin-cli/src/commands/dead_code.rs
@@ -60,8 +60,7 @@ pub struct DeadCodeSeededResponse {
 }
 
 pub async fn run() -> Result<()> {
-    let layout = kin_core::KinLayout::discover(&std::env::current_dir()?)
-        .ok_or_else(|| anyhow::anyhow!("not a Kin repository (no .kin/ found)"))?;
+    let layout = crate::commands::require_repository_layout()?;
     let response = run_daemon_dead_code(&layout).await?;
     for line in response.lines {
         println!("{line}");
@@ -74,8 +73,7 @@ pub async fn run_seeded(
     limit: Option<usize>,
     name_pattern: Option<String>,
 ) -> Result<()> {
-    let layout = kin_core::KinLayout::discover(&std::env::current_dir()?)
-        .ok_or_else(|| anyhow::anyhow!("not a Kin repository (no .kin/ found)"))?;
+    let layout = crate::commands::require_repository_layout()?;
     let response = run_daemon_dead_code_seeded(
         &layout,
         &DeadCodeSeededRequest {

--- a/crates/kin-cli/src/commands/diff.rs
+++ b/crates/kin-cli/src/commands/diff.rs
@@ -615,8 +615,7 @@ fn summarize(
 }
 
 pub fn run(base: Option<String>, head: Option<String>, json: bool) -> Result<()> {
-    let layout = kin_core::KinLayout::discover(&std::env::current_dir()?)
-        .ok_or_else(|| anyhow!("not a Kin repository (no .kin/ found)"))?;
+    let layout = crate::commands::require_repository_layout()?;
     let binding = kin_core::LocalRepositoryAuthorityBinding::from_layout(&layout)?;
     let report = inspect(&binding, base.as_deref(), head.as_deref())?;
     if json {

--- a/crates/kin-cli/src/commands/drift.rs
+++ b/crates/kin-cli/src/commands/drift.rs
@@ -54,11 +54,7 @@ pub struct DriftResponse {
 }
 
 pub async fn run(json: bool) -> Result<()> {
-    let layout = kin_core::KinLayout::discover(&std::env::current_dir()?).ok_or_else(|| {
-        anyhow::anyhow!(
-            "not a Kin repository (no .kin/ found)\nhint: run `kin init .` to initialize a Kin repository here"
-        )
-    })?;
+    let layout = crate::commands::require_repository_layout()?;
     let daemon_url = crate::daemon_client::resolve_daemon_url(&layout)
         .await?
         .ok_or_else(|| {

--- a/crates/kin-cli/src/commands/eject.rs
+++ b/crates/kin-cli/src/commands/eject.rs
@@ -34,8 +34,7 @@ const EJECT_GIT_CAPTURE_LIMIT: u64 = 8 * 1024 * 1024;
 pub async fn run(yes: bool) -> Result<()> {
     ensure_eject_platform()?;
     let cwd = std::env::current_dir()?;
-    let layout = kin_core::KinLayout::discover(&cwd)
-        .ok_or_else(|| anyhow::anyhow!("not a Kin repository"))?;
+    let layout = crate::commands::require_repository_layout_at(&cwd)?;
     ensure_real_directory(layout.root(), "Kin metadata")?;
     let binding = kin_core::LocalRepositoryAuthorityBinding::from_layout(&layout)?;
     refuse_live_vfs(&layout)?;

--- a/crates/kin-cli/src/commands/embed.rs
+++ b/crates/kin-cli/src/commands/embed.rs
@@ -213,8 +213,7 @@ pub async fn run(
         rebuild = rebuild
     )
     .entered();
-    let layout = kin_core::KinLayout::discover(&std::env::current_dir()?)
-        .ok_or_else(|| anyhow::anyhow!("not a Kin repository (no .kin/ found)"))?;
+    let layout = crate::commands::require_repository_layout()?;
 
     if let Some(seconds) = max_seconds {
         let response = run_daemon_embed(

--- a/crates/kin-cli/src/commands/git.rs
+++ b/crates/kin-cli/src/commands/git.rs
@@ -102,8 +102,7 @@ pub(crate) fn capture_export_snapshot_from_state(
 /// Project repository-v6 authority into a new bare Git repository.
 pub fn export(output: PathBuf) -> Result<()> {
     let cwd = std::env::current_dir()?;
-    let layout = kin_core::KinLayout::discover(&cwd)
-        .ok_or_else(|| anyhow::anyhow!("not a Kin repository (no .kin/ found)"))?;
+    let layout = crate::commands::require_repository_layout_at(&cwd)?;
     let binding = kin_core::LocalRepositoryAuthorityBinding::from_layout(&layout)?;
     let output = validate_export_destination(&layout, &cwd, &output)?;
     let authority = ActiveRepositoryAuthority::open(&binding)?;

--- a/crates/kin-cli/src/commands/graph.rs
+++ b/crates/kin-cli/src/commands/graph.rs
@@ -81,15 +81,13 @@ pub enum EntitySourceOutcome {
 
 /// `kin graph status` — quick health check of the semantic graph.
 pub async fn status() -> Result<()> {
-    let layout = kin_core::KinLayout::discover(&std::env::current_dir()?)
-        .ok_or_else(|| anyhow::anyhow!("not a Kin repository (no .kin/ found)"))?;
+    let layout = crate::commands::require_repository_layout()?;
     print_graph_response(run_daemon_graph(&layout, &GraphCommandRequest::Status).await?)
 }
 
 /// `kin graph validate` — structural integrity checks.
 pub async fn validate() -> Result<()> {
-    let layout = kin_core::KinLayout::discover(&std::env::current_dir()?)
-        .ok_or_else(|| anyhow::anyhow!("not a Kin repository (no .kin/ found)"))?;
+    let layout = crate::commands::require_repository_layout()?;
     print_graph_response(run_daemon_graph(&layout, &GraphCommandRequest::Validate).await?)
 }
 
@@ -101,8 +99,7 @@ pub async fn validate() -> Result<()> {
 /// This lets an LLM agent recover from a hallucinated UUID instead of treating
 /// the tool call as a hard CLI failure.
 pub async fn inspect(name: String, json: bool) -> Result<()> {
-    let layout = kin_core::KinLayout::discover(&std::env::current_dir()?)
-        .ok_or_else(|| anyhow::anyhow!("not a Kin repository (no .kin/ found)"))?;
+    let layout = crate::commands::require_repository_layout()?;
     let response = run_daemon_graph(&layout, &GraphCommandRequest::Inspect { name }).await?;
     if json {
         // SP-23 graceful-error: emit the full response (lines + error) as JSON
@@ -128,8 +125,7 @@ pub async fn inspect(name: String, json: bool) -> Result<()> {
 /// response rather than a hard CLI failure. Non-JSON mode keeps the existing
 /// exit-1-on-error behavior for shell-script compatibility.
 pub async fn source(entity: String, json: bool) -> Result<()> {
-    let layout = kin_core::KinLayout::discover(&std::env::current_dir()?)
-        .ok_or_else(|| anyhow::anyhow!("not a Kin repository (no .kin/ found)"))?;
+    let layout = crate::commands::require_repository_layout()?;
     let response = run_daemon_graph(&layout, &GraphCommandRequest::Source { entity }).await?;
     if json {
         if let Some(error) = response.error {

--- a/crates/kin-cli/src/commands/graph_viz.rs
+++ b/crates/kin-cli/src/commands/graph_viz.rs
@@ -136,8 +136,7 @@ async fn serve_graph_json(State(json): State<Arc<String>>) -> Response {
 
 /// `kin graph viz` — serve an interactive force-directed graph over HTTP.
 pub async fn run(port: u16, open_browser: bool) -> Result<()> {
-    let layout = kin_core::KinLayout::discover(&std::env::current_dir()?)
-        .ok_or_else(|| anyhow::anyhow!("not a Kin repository (no .kin/ found)"))?;
+    let layout = crate::commands::require_repository_layout()?;
     let snap =
         crate::backend::open_snapshot_explicit_admin_read_only(&layout, "kin graph viz").await?;
     let payload = build_payload_from_snapshot(&snap)?;

--- a/crates/kin-cli/src/commands/history.rs
+++ b/crates/kin-cli/src/commands/history.rs
@@ -68,8 +68,7 @@ fn truncate(value: &str, width: usize) -> String {
 }
 
 pub async fn run(entity: String, reference: Option<String>) -> Result<()> {
-    let layout = kin_core::KinLayout::discover(&std::env::current_dir()?)
-        .ok_or_else(|| anyhow::anyhow!("not a Kin repository (no .kin/ found)"))?;
+    let layout = crate::commands::require_repository_layout()?;
     let response = run_daemon_history(&layout, &HistoryRequest { entity, reference }).await?;
     for line in response.lines {
         println!("{}", crate::output_style::paint_history_line(&line));

--- a/crates/kin-cli/src/commands/impact.rs
+++ b/crates/kin-cli/src/commands/impact.rs
@@ -59,8 +59,7 @@ pub async fn run(
     signature: Option<String>,
     json: bool,
 ) -> Result<()> {
-    let layout = kin_core::KinLayout::discover(&std::env::current_dir()?)
-        .ok_or_else(|| anyhow::anyhow!("not a Kin repository (no .kin/ found)"))?;
+    let layout = crate::commands::require_repository_layout()?;
     let response = run_daemon_impact(
         &layout,
         &ImpactRequest {

--- a/crates/kin-cli/src/commands/intent.rs
+++ b/crates/kin-cli/src/commands/intent.rs
@@ -4,8 +4,7 @@
 use anyhow::{Context, Result};
 
 async fn daemon_base_url() -> Result<String> {
-    let layout = kin_core::KinLayout::discover(&std::env::current_dir()?)
-        .ok_or_else(|| anyhow::anyhow!("not a Kin repository (no .kin/ found)"))?;
+    let layout = crate::commands::require_repository_layout()?;
     crate::daemon_client::resolve_daemon_url(&layout)
         .await?
         .ok_or_else(|| {

--- a/crates/kin-cli/src/commands/locate.rs
+++ b/crates/kin-cli/src/commands/locate.rs
@@ -1350,8 +1350,7 @@ pub async fn capture(
     entity_surface: bool,
     paging: LocatePaging,
 ) -> Result<LocateResult> {
-    let layout = kin_core::KinLayout::discover(&std::env::current_dir()?)
-        .ok_or_else(|| anyhow::anyhow!("not a Kin repository (no .kin/ found)"))?;
+    let layout = crate::commands::require_repository_layout()?;
     if locate_env_bool("KIN_LOCATE_FORCE_LOCAL", false) {
         anyhow::bail!(
             "KIN_LOCATE_FORCE_LOCAL is no longer supported; locate requires the Kin daemon"

--- a/crates/kin-cli/src/commands/locate_cursor.rs
+++ b/crates/kin-cli/src/commands/locate_cursor.rs
@@ -42,8 +42,7 @@ pub fn persist_locate_cursor(next_cursor: Option<&str>) {
 /// absent: a `--next` with no prior page is a user error, not a silent empty.
 pub fn read_persisted_locate_cursor() -> Result<String> {
     let cwd = std::env::current_dir()?;
-    let layout = kin_core::KinLayout::discover(&cwd)
-        .ok_or_else(|| anyhow::anyhow!("not a Kin repository (no .kin/ found)"))?;
+    let layout = crate::commands::require_repository_layout_at(&cwd)?;
     let path = locate_cursor_path(&layout);
     let cursor = std::fs::read_to_string(&path).map_err(|_| {
         anyhow::anyhow!(

--- a/crates/kin-cli/src/commands/log.rs
+++ b/crates/kin-cli/src/commands/log.rs
@@ -168,8 +168,7 @@ pub fn inspect(
 }
 
 pub fn run(count: usize, json: bool) -> Result<()> {
-    let layout = kin_core::KinLayout::discover(&std::env::current_dir()?)
-        .ok_or_else(|| anyhow::anyhow!("not a Kin repository (no .kin/ found)"))?;
+    let layout = crate::commands::require_repository_layout()?;
     let binding = kin_core::LocalRepositoryAuthorityBinding::from_layout(&layout)?;
     let report = inspect(&binding, count)?;
     if json {

--- a/crates/kin-cli/src/commands/mcp.rs
+++ b/crates/kin-cli/src/commands/mcp.rs
@@ -285,9 +285,8 @@ async fn bind_daemon_for_repo_dir(dir: &Path) -> std::result::Result<String, Str
             return Ok(url);
         }
     }
-    let layout = kin_core::KinLayout::discover(dir).ok_or_else(|| {
-        "not inside a kin repository (no .kin/ found); run `kin init .` first".to_string()
-    })?;
+    let layout = crate::commands::require_repository_layout_at(dir)
+        .map_err(|refusal| format!("{refusal:#}"))?;
     let url = crate::daemon_client::resolve_daemon_url_for_mcp(&layout)
         .await
         .map_err(|e| format!("{e:#}"))?
@@ -405,8 +404,12 @@ mod tests {
             .await
             .expect_err("a directory with no .kin/ must not resolve a daemon");
         assert!(
-            reason.contains("not inside a kin repository"),
+            reason.contains("not a Kin repository"),
             "unexpected reason: {reason}"
+        );
+        assert!(
+            reason.contains("kin init"),
+            "the reason must name the remedy: {reason}"
         );
     }
 

--- a/crates/kin-cli/src/commands/merge.rs
+++ b/crates/kin-cli/src/commands/merge.rs
@@ -142,11 +142,7 @@ pub async fn run(source: String, json: bool) -> Result<()> {
 
 /// Discover the repository every merge-transaction command is bound to.
 pub(crate) fn require_repository_layout() -> Result<kin_core::KinLayout> {
-    kin_core::KinLayout::discover(&std::env::current_dir()?).ok_or_else(|| {
-        anyhow::anyhow!(
-            "not a Kin repository (no .kin/ found)\nhint: run `kin init .` to initialize a Kin repository here"
-        )
-    })
+    crate::commands::require_repository_layout()
 }
 
 async fn execute(request: MergeRequest) -> Result<MergeResponse> {

--- a/crates/kin-cli/src/commands/mod.rs
+++ b/crates/kin-cli/src/commands/mod.rs
@@ -131,4 +131,76 @@ mod repository_refusal_tests {
             "refusal must name the remedy: {message}"
         );
     }
+
+    /// Byte offset just past the parenthesis closing the one at `open`.
+    fn end_of_call(source: &str, open: usize) -> Option<usize> {
+        let mut depth = 0usize;
+        for (offset, character) in source[open..].char_indices() {
+            match character {
+                '(' => depth += 1,
+                ')' => {
+                    depth -= 1;
+                    if depth == 0 {
+                        return Some(open + offset + 1);
+                    }
+                }
+                _ => {}
+            }
+        }
+        None
+    }
+
+    #[test]
+    fn no_command_hand_rolls_the_repository_refusal() {
+        // One home for the wording only holds while it stays the only home.
+        // The shape that produced 81 copies is a discovery immediately
+        // refused in place, so this crate's sources carry it in exactly one
+        // file: the one declaring the canonical refusal. A command reverting
+        // to a local refusal reads as an ordinary two-line diff and would
+        // otherwise pass every gate while dropping the remedy the caller
+        // needs. Deliberate exceptions refuse on their own condition rather
+        // than on discovery, so they are outside this shape by construction.
+        const DISCOVERY: &str = "KinLayout::discover(";
+        const REFUSAL: &str = ".ok_or_else(";
+
+        let sources = std::path::Path::new(env!("CARGO_MANIFEST_DIR")).join("src");
+        let canonical = sources.join("commands").join("mod.rs");
+        assert!(canonical.is_file(), "canonical refusal file must exist");
+
+        let mut hand_rolled = Vec::new();
+        let mut pending = vec![sources];
+        while let Some(directory) = pending.pop() {
+            let entries = std::fs::read_dir(&directory).expect("read crate sources");
+            for entry in entries.flatten() {
+                let path = entry.path();
+                if path.is_dir() {
+                    pending.push(path);
+                    continue;
+                }
+                if path.extension().and_then(|ext| ext.to_str()) != Some("rs") || path == canonical
+                {
+                    continue;
+                }
+                let source = std::fs::read_to_string(&path).expect("read a crate source");
+                let mut cursor = 0;
+                while let Some(hit) = source[cursor..].find(DISCOVERY) {
+                    let open = cursor + hit + DISCOVERY.len() - 1;
+                    let closed = end_of_call(&source, open).unwrap_or(source.len());
+                    if source[closed..].trim_start().starts_with(REFUSAL) {
+                        let line = source[..open].lines().count();
+                        hand_rolled.push(format!("{}:{line}", path.display()));
+                    }
+                    cursor = open + 1;
+                }
+            }
+        }
+        hand_rolled.sort();
+
+        assert!(
+            hand_rolled.is_empty(),
+            "a command refusing outside a repository must refuse through \
+             require_repository_layout or require_repository_layout_at, so the condition and \
+             the remedy cannot drift apart again; hand-rolled at {hand_rolled:?}"
+        );
+    }
 }

--- a/crates/kin-cli/src/commands/mod.rs
+++ b/crates/kin-cli/src/commands/mod.rs
@@ -89,3 +89,46 @@ pub mod update;
 pub mod verify;
 pub mod work;
 pub mod xref;
+
+/// Discover the Kin repository a command is bound to, or refuse by naming the
+/// command that creates one.
+///
+/// Every command that needs a repository refuses through here so the refusal
+/// cannot drift per command. Running a repository command from the wrong
+/// directory is an ordinary first mistake, and a refusal that only states the
+/// absence leaves the caller to guess the remedy.
+pub(crate) fn require_repository_layout() -> anyhow::Result<kin_core::KinLayout> {
+    require_repository_layout_at(&std::env::current_dir()?)
+}
+
+/// Discover the Kin repository containing `start`, refusing the same way.
+pub(crate) fn require_repository_layout_at(
+    start: &std::path::Path,
+) -> anyhow::Result<kin_core::KinLayout> {
+    kin_core::KinLayout::discover(start).ok_or_else(|| {
+        anyhow::anyhow!(
+            "not a Kin repository (no .kin/ found)\nhint: run `kin init .` to initialize a Kin repository here"
+        )
+    })
+}
+
+#[cfg(test)]
+mod repository_refusal_tests {
+    use super::require_repository_layout_at;
+
+    #[test]
+    fn refusing_outside_a_repository_names_the_command_that_creates_one() {
+        let empty = tempfile::tempdir().expect("temp dir");
+        let err = require_repository_layout_at(empty.path())
+            .expect_err("a directory with no .kin/ is not a repository");
+        let message = err.to_string();
+        assert!(
+            message.contains("not a Kin repository"),
+            "refusal must state the condition: {message}"
+        );
+        assert!(
+            message.contains("kin init"),
+            "refusal must name the remedy: {message}"
+        );
+    }
+}

--- a/crates/kin-cli/src/commands/note.rs
+++ b/crates/kin-cli/src/commands/note.rs
@@ -38,8 +38,7 @@ pub struct NoteExecution {
 }
 
 async fn run_daemon_note(request: &NoteRequest) -> Result<NoteResponse> {
-    let layout = kin_core::KinLayout::discover(&std::env::current_dir()?)
-        .ok_or_else(|| anyhow::anyhow!("not a Kin repository (no .kin/ found)"))?;
+    let layout = crate::commands::require_repository_layout()?;
     let daemon_url = std::env::var("KIN_DAEMON_URL")
         .ok()
         .filter(|value| !value.trim().is_empty())
@@ -78,8 +77,7 @@ pub async fn stale() -> Result<()> {
 
 /// `kin todo import` — Import inline TODOs from source files.
 pub async fn todo_import(path: Option<String>) -> Result<()> {
-    let layout = kin_core::KinLayout::discover(&std::env::current_dir()?)
-        .ok_or_else(|| anyhow::anyhow!("not a Kin repository (no .kin/ found)"))?;
+    let layout = crate::commands::require_repository_layout()?;
     let scan_root = path
         .clone()
         .map(std::path::PathBuf::from)

--- a/crates/kin-cli/src/commands/overview.rs
+++ b/crates/kin-cli/src/commands/overview.rs
@@ -21,8 +21,7 @@ pub struct OverviewResponse {
 }
 
 pub async fn run_json() -> Result<()> {
-    let layout = kin_core::KinLayout::discover(&std::env::current_dir()?)
-        .ok_or_else(|| anyhow::anyhow!("not a Kin repository (no .kin/ found)"))?;
+    let layout = crate::commands::require_repository_layout()?;
     print_overview_response(
         run_daemon_overview(
             &layout,
@@ -36,8 +35,7 @@ pub async fn run_json() -> Result<()> {
 }
 
 pub async fn run(compact: bool) -> Result<()> {
-    let layout = kin_core::KinLayout::discover(&std::env::current_dir()?)
-        .ok_or_else(|| anyhow::anyhow!("not a Kin repository (no .kin/ found)"))?;
+    let layout = crate::commands::require_repository_layout()?;
     print_overview_response(
         run_daemon_overview(
             &layout,

--- a/crates/kin-cli/src/commands/pipeline.rs
+++ b/crates/kin-cli/src/commands/pipeline.rs
@@ -22,8 +22,7 @@ fn resolve_org_id() -> Result<String> {
 }
 
 fn resolve_repo_id() -> Result<String> {
-    let layout = kin_core::KinLayout::discover(&std::env::current_dir()?)
-        .ok_or_else(|| anyhow::anyhow!("not a Kin repository (no .kin/ found)"))?;
+    let layout = crate::commands::require_repository_layout()?;
     remote::resolve_repo_id(&layout)
 }
 

--- a/crates/kin-cli/src/commands/prepared_state.rs
+++ b/crates/kin-cli/src/commands/prepared_state.rs
@@ -68,7 +68,9 @@ pub async fn publish(target: PathBuf, json: bool) -> Result<()> {
     let repo_path = std::env::current_dir()?;
     let kin_dir = repo_path.join(".kin");
     if !kin_dir.exists() {
-        bail!("not a Kin repository (no .kin/ found)");
+        bail!(
+            "not a Kin repository (no .kin/ found)\nhint: run `kin init .` to initialize a Kin repository here"
+        );
     }
 
     let mut manifest = expected_manifest(&repo_path)?;

--- a/crates/kin-cli/src/commands/reconcile.rs
+++ b/crates/kin-cli/src/commands/reconcile.rs
@@ -204,8 +204,7 @@ impl SessionReconcileObservation {
 
 pub async fn run(session_id: Option<String>, confirm_mass_deletion: bool) -> Result<()> {
     let cwd = std::env::current_dir().context("resolve current directory")?;
-    let layout = kin_core::KinLayout::discover(&cwd)
-        .ok_or_else(|| anyhow!("not inside a Kin repository"))?;
+    let layout = crate::commands::require_repository_layout_at(&cwd)?;
     run_for_layout(&layout, session_id.as_deref(), confirm_mass_deletion).await
 }
 

--- a/crates/kin-cli/src/commands/refs.rs
+++ b/crates/kin-cli/src/commands/refs.rs
@@ -89,8 +89,7 @@ pub struct BulkRefsResponse {
 }
 
 pub async fn run(entity: String, kind: String) -> Result<()> {
-    let layout = kin_core::KinLayout::discover(&std::env::current_dir()?)
-        .ok_or_else(|| anyhow::anyhow!("not a Kin repository (no .kin/ found)"))?;
+    let layout = crate::commands::require_repository_layout()?;
     let _scope = announce_active_scope(&layout, "refs").await?;
     let response = run_daemon_refs(&layout, &RefsRequest { entity, kind }).await?;
     for line in response.lines {
@@ -100,8 +99,7 @@ pub async fn run(entity: String, kind: String) -> Result<()> {
 }
 
 pub async fn run_bulk(entities: String, kind: String, compact: bool) -> Result<()> {
-    let layout = kin_core::KinLayout::discover(&std::env::current_dir()?)
-        .ok_or_else(|| anyhow::anyhow!("not a Kin repository (no .kin/ found)"))?;
+    let layout = crate::commands::require_repository_layout()?;
     let _scope = announce_active_scope(&layout, "refs:bulk").await?;
     let entity_ids: Vec<String> = entities
         .split(',')

--- a/crates/kin-cli/src/commands/release_cmd.rs
+++ b/crates/kin-cli/src/commands/release_cmd.rs
@@ -22,8 +22,7 @@ fn resolve_org_id() -> Result<String> {
 }
 
 fn resolve_repo_id() -> Result<String> {
-    let layout = kin_core::KinLayout::discover(&std::env::current_dir()?)
-        .ok_or_else(|| anyhow::anyhow!("not a Kin repository (no .kin/ found)"))?;
+    let layout = crate::commands::require_repository_layout()?;
     remote::resolve_repo_id(&layout)
 }
 

--- a/crates/kin-cli/src/commands/remote.rs
+++ b/crates/kin-cli/src/commands/remote.rs
@@ -369,8 +369,7 @@ pub(crate) fn ensure_git_remote(working_dir: &Path, name: &str, url: Option<&str
 }
 
 pub async fn list() -> Result<()> {
-    let layout = kin_core::KinLayout::discover(&std::env::current_dir()?)
-        .ok_or_else(|| anyhow::anyhow!("not a Kin repository (no .kin/ found)"))?;
+    let layout = crate::commands::require_repository_layout()?;
     let config = KinConfig::load_or_default(&layout.config_path())?;
 
     if config.remote.refs.is_empty() {
@@ -420,8 +419,7 @@ pub async fn add(
     publish_proofs: bool,
     default: bool,
 ) -> Result<()> {
-    let layout = kin_core::KinLayout::discover(&std::env::current_dir()?)
-        .ok_or_else(|| anyhow::anyhow!("not a Kin repository (no .kin/ found)"))?;
+    let layout = crate::commands::require_repository_layout()?;
     let host = RemoteHostKind::from_str(&host).ok_or_else(|| {
         anyhow::anyhow!(
             "unknown remote host '{}'; expected github, gitlab, bitbucket, or kinlab",
@@ -526,8 +524,7 @@ pub async fn lease(
 }
 
 pub(crate) async fn load_push_plan(requested_remote: Option<&str>) -> Result<PushPlanContext> {
-    let layout = kin_core::KinLayout::discover(&std::env::current_dir()?)
-        .ok_or_else(|| anyhow::anyhow!("not a Kin repository (no .kin/ found)"))?;
+    let layout = crate::commands::require_repository_layout()?;
     let binding = kin_core::LocalRepositoryAuthorityBinding::from_layout(&layout)?;
     let config = KinConfig::load_or_default(&layout.config_path())?;
 

--- a/crates/kin-cli/src/commands/resources.rs
+++ b/crates/kin-cli/src/commands/resources.rs
@@ -304,11 +304,7 @@ pub async fn run(json: bool, profile: Option<String>) -> Result<()> {
 async fn run_daemon_resources(
     request: &CommandResourcesRequest,
 ) -> Result<CommandResourcesResponse> {
-    let layout = kin_core::KinLayout::discover(&std::env::current_dir()?).ok_or_else(|| {
-        anyhow::anyhow!(
-            "not a Kin repository (no .kin/ found)\nhint: run `kin init .` to initialize a Kin repository here"
-        )
-    })?;
+    let layout = crate::commands::require_repository_layout()?;
     let daemon_url = std::env::var("KIN_DAEMON_URL")
         .ok()
         .filter(|value| !value.trim().is_empty())

--- a/crates/kin-cli/src/commands/review.rs
+++ b/crates/kin-cli/src/commands/review.rs
@@ -102,8 +102,7 @@ struct ReviewResultJson {
 }
 
 async fn run_daemon_review(request: &ReviewRequest) -> Result<ReviewResponse> {
-    let layout = kin_core::KinLayout::discover(&std::env::current_dir()?)
-        .ok_or_else(|| anyhow::anyhow!("not a Kin repository (no .kin/ found)"))?;
+    let layout = crate::commands::require_repository_layout()?;
     let daemon_url = std::env::var("KIN_DAEMON_URL")
         .ok()
         .filter(|value| !value.trim().is_empty())

--- a/crates/kin-cli/src/commands/rollback.rs
+++ b/crates/kin-cli/src/commands/rollback.rs
@@ -63,11 +63,7 @@ pub async fn run(change_id: String, feature: Option<String>) -> Result<()> {
              explicit change instead"
         );
     }
-    let layout = kin_core::KinLayout::discover(&std::env::current_dir()?).ok_or_else(|| {
-        anyhow::anyhow!(
-            "not a Kin repository (no .kin/ found)\nhint: run `kin init .` to initialize a Kin repository here"
-        )
-    })?;
+    let layout = crate::commands::require_repository_layout()?;
     let daemon_url = crate::daemon_client::resolve_daemon_url(&layout)
         .await?
         .ok_or_else(|| {

--- a/crates/kin-cli/src/commands/scope.rs
+++ b/crates/kin-cli/src/commands/scope.rs
@@ -25,8 +25,7 @@ pub async fn run(
     session: Option<&str>,
 ) -> Result<()> {
     let session_id = resolve_session_id(session)?;
-    let layout = kin_core::KinLayout::discover(&std::env::current_dir()?)
-        .ok_or_else(|| anyhow::anyhow!("not a Kin repository (no .kin/ found)"))?;
+    let layout = crate::commands::require_repository_layout()?;
     let daemon_url = crate::daemon_client::resolve_daemon_url(&layout)
         .await?
         .ok_or_else(|| anyhow::anyhow!("daemon not available"))?;

--- a/crates/kin-cli/src/commands/search.rs
+++ b/crates/kin-cli/src/commands/search.rs
@@ -263,8 +263,7 @@ pub async fn run(
     show_body: bool,
     body_limit: Option<usize>,
 ) -> Result<()> {
-    let layout = kin_core::KinLayout::discover(&std::env::current_dir()?)
-        .ok_or_else(|| anyhow::anyhow!("not a Kin repository (no .kin/ found)"))?;
+    let layout = crate::commands::require_repository_layout()?;
 
     let _scope = announce_active_scope(&layout, "search").await?;
 
@@ -299,8 +298,7 @@ pub async fn run_json(
     _show_body: bool,
     _body_limit: Option<usize>,
 ) -> Result<()> {
-    let layout = kin_core::KinLayout::discover(&std::env::current_dir()?)
-        .ok_or_else(|| anyhow::anyhow!("not a Kin repository (no .kin/ found)"))?;
+    let layout = crate::commands::require_repository_layout()?;
 
     let _scope = announce_active_scope(&layout, "search").await?;
 
@@ -372,8 +370,7 @@ async fn run_semantic_daemon(
     language: Option<String>,
     limit: usize,
 ) -> Result<()> {
-    let layout = kin_core::KinLayout::discover(&std::env::current_dir()?)
-        .ok_or_else(|| anyhow::anyhow!("not a Kin repository (no .kin/ found)"))?;
+    let layout = crate::commands::require_repository_layout()?;
     let _scope = announce_active_scope(&layout, "search --semantic").await?;
     let response = run_daemon_search(
         &layout,
@@ -397,8 +394,7 @@ async fn run_semantic_daemon_json(
     language: Option<String>,
     limit: usize,
 ) -> Result<()> {
-    let layout = kin_core::KinLayout::discover(&std::env::current_dir()?)
-        .ok_or_else(|| anyhow::anyhow!("not a Kin repository (no .kin/ found)"))?;
+    let layout = crate::commands::require_repository_layout()?;
     let _scope = announce_active_scope(&layout, "search --semantic --json").await?;
     let response = run_daemon_search(
         &layout,

--- a/crates/kin-cli/src/commands/secret.rs
+++ b/crates/kin-cli/src/commands/secret.rs
@@ -23,8 +23,7 @@ fn resolve_org_id() -> Result<String> {
 }
 
 fn resolve_repo_id() -> Result<String> {
-    let layout = kin_core::KinLayout::discover(&std::env::current_dir()?)
-        .ok_or_else(|| anyhow::anyhow!("not a Kin repository (no .kin/ found)"))?;
+    let layout = crate::commands::require_repository_layout()?;
     remote::resolve_repo_id(&layout)
 }
 

--- a/crates/kin-cli/src/commands/security.rs
+++ b/crates/kin-cli/src/commands/security.rs
@@ -29,8 +29,7 @@ pub struct SecurityResponse {
 /// When `--propagate` is set, additionally traces transitive dependency
 /// chains for each finding to surface downstream vulnerability propagation.
 pub async fn run_with_options(propagate: bool) -> Result<()> {
-    let layout = kin_core::KinLayout::discover(&std::env::current_dir()?)
-        .ok_or_else(|| anyhow::anyhow!("not a Kin repository (no .kin/ found)"))?;
+    let layout = crate::commands::require_repository_layout()?;
     let response = run_daemon_security(&layout, &SecurityRequest { propagate }).await?;
     for line in response.lines {
         println!("{line}");

--- a/crates/kin-cli/src/commands/semver.rs
+++ b/crates/kin-cli/src/commands/semver.rs
@@ -243,8 +243,7 @@ pub fn inspect(
 }
 
 pub fn run(base: String, head: String, json: bool) -> Result<()> {
-    let layout = kin_core::KinLayout::discover(&std::env::current_dir()?)
-        .ok_or_else(|| anyhow!("not a Kin repository (no .kin/ found)"))?;
+    let layout = crate::commands::require_repository_layout()?;
     let binding = kin_core::LocalRepositoryAuthorityBinding::from_layout(&layout)?;
     let report = inspect(&binding, &base, &head)?;
     if json {

--- a/crates/kin-cli/src/commands/session_run.rs
+++ b/crates/kin-cli/src/commands/session_run.rs
@@ -285,7 +285,7 @@ pub(crate) fn discard(session_dir: &Path) -> Result<()> {
 /// Discover the repository layout for a session surface.
 pub fn discover_layout() -> Result<kin_core::KinLayout> {
     let cwd = std::env::current_dir().context("resolve current directory")?;
-    kin_core::KinLayout::discover(&cwd).ok_or_else(|| anyhow!("not inside a Kin repository"))
+    crate::commands::require_repository_layout_at(&cwd)
 }
 
 /// How `kin exec` interprets its trailing arguments.

--- a/crates/kin-cli/src/commands/spec.rs
+++ b/crates/kin-cli/src/commands/spec.rs
@@ -6,8 +6,7 @@ use std::fs;
 use anyhow::Result;
 
 pub async fn create(intent: String) -> Result<()> {
-    let layout = kin_core::KinLayout::discover(&std::env::current_dir()?)
-        .ok_or_else(|| anyhow::anyhow!("not a Kin repository (no .kin/ found)"))?;
+    let layout = crate::commands::require_repository_layout()?;
 
     let spec = kin_model::Spec {
         id: kin_model::SpecId::new(),
@@ -35,8 +34,7 @@ pub async fn create(intent: String) -> Result<()> {
 }
 
 pub async fn list() -> Result<()> {
-    let layout = kin_core::KinLayout::discover(&std::env::current_dir()?)
-        .ok_or_else(|| anyhow::anyhow!("not a Kin repository (no .kin/ found)"))?;
+    let layout = crate::commands::require_repository_layout()?;
 
     let specs_dir = layout.root().join("specs");
     if !specs_dir.exists() {
@@ -66,8 +64,7 @@ pub async fn list() -> Result<()> {
 }
 
 pub async fn show(id: String) -> Result<()> {
-    let layout = kin_core::KinLayout::discover(&std::env::current_dir()?)
-        .ok_or_else(|| anyhow::anyhow!("not a Kin repository (no .kin/ found)"))?;
+    let layout = crate::commands::require_repository_layout()?;
 
     let specs_dir = layout.root().join("specs");
     let spec_file = specs_dir.join(format!("{}.json", id));

--- a/crates/kin-cli/src/commands/stash.rs
+++ b/crates/kin-cli/src/commands/stash.rs
@@ -183,11 +183,7 @@ fn confirm_workspace_reset() -> Result<()> {
 }
 
 async fn execute(request: StashRequest) -> Result<StashResponse> {
-    let layout = kin_core::KinLayout::discover(&std::env::current_dir()?).ok_or_else(|| {
-        anyhow::anyhow!(
-            "not a Kin repository (no .kin/ found)\nhint: run `kin init .` to initialize a Kin repository here"
-        )
-    })?;
+    let layout = crate::commands::require_repository_layout()?;
     let daemon_url = crate::daemon_client::resolve_daemon_url(&layout)
         .await?
         .ok_or_else(|| {

--- a/crates/kin-cli/src/commands/status.rs
+++ b/crates/kin-cli/src/commands/status.rs
@@ -398,11 +398,7 @@ pub fn inspect(
 }
 
 pub fn run(json: bool) -> Result<()> {
-    let layout = kin_core::KinLayout::discover(&std::env::current_dir()?).ok_or_else(|| {
-        anyhow::anyhow!(
-            "not a Kin repository (no .kin/ found)\nhint: run `kin init .` to initialize one"
-        )
-    })?;
+    let layout = crate::commands::require_repository_layout()?;
     let binding = kin_core::LocalRepositoryAuthorityBinding::from_layout(&layout)?;
     let report = inspect(&layout, &binding)?;
     if json {

--- a/crates/kin-cli/src/commands/support.rs
+++ b/crates/kin-cli/src/commands/support.rs
@@ -87,8 +87,7 @@ pub fn inspect_support_graph(
 }
 
 pub async fn run(json: bool) -> Result<()> {
-    let layout = kin_core::KinLayout::discover(&std::env::current_dir()?)
-        .ok_or_else(|| anyhow::anyhow!("not a Kin repository (no .kin/ found)"))?;
+    let layout = crate::commands::require_repository_layout()?;
 
     let report = run_daemon_support(&layout).await?;
 

--- a/crates/kin-cli/src/commands/tag.rs
+++ b/crates/kin-cli/src/commands/tag.rs
@@ -193,11 +193,7 @@ async fn publish(
     snapshot: bool,
 ) -> Result<()> {
     let name = parse_tag_ref(&tag)?;
-    let layout = kin_core::KinLayout::discover(&std::env::current_dir()?).ok_or_else(|| {
-        anyhow::anyhow!(
-            "not a Kin repository (no .kin/ found)\nhint: run `kin init .` to initialize a Kin repository here"
-        )
-    })?;
+    let layout = crate::commands::require_repository_layout()?;
     let daemon_url = crate::daemon_client::resolve_daemon_url(&layout)
         .await?
         .ok_or_else(|| {

--- a/crates/kin-cli/src/commands/telemetry.rs
+++ b/crates/kin-cli/src/commands/telemetry.rs
@@ -6,8 +6,7 @@ use anyhow::{Context, Result};
 use super::locate_telemetry::{consent_marker_path, telemetry_dir};
 
 pub async fn run_status() -> Result<()> {
-    let layout = kin_core::KinLayout::discover(&std::env::current_dir()?)
-        .ok_or_else(|| anyhow::anyhow!("not a Kin repository (no .kin/ found)"))?;
+    let layout = crate::commands::require_repository_layout()?;
 
     let kin_root = layout.root();
     let consent_path = consent_marker_path(kin_root);
@@ -56,8 +55,7 @@ pub async fn run_status() -> Result<()> {
 }
 
 pub async fn run_consent() -> Result<()> {
-    let layout = kin_core::KinLayout::discover(&std::env::current_dir()?)
-        .ok_or_else(|| anyhow::anyhow!("not a Kin repository (no .kin/ found)"))?;
+    let layout = crate::commands::require_repository_layout()?;
 
     let kin_root = layout.root();
     let consent_path = consent_marker_path(kin_root);
@@ -80,8 +78,7 @@ pub async fn run_consent() -> Result<()> {
 }
 
 pub async fn run_revoke() -> Result<()> {
-    let layout = kin_core::KinLayout::discover(&std::env::current_dir()?)
-        .ok_or_else(|| anyhow::anyhow!("not a Kin repository (no .kin/ found)"))?;
+    let layout = crate::commands::require_repository_layout()?;
 
     let kin_root = layout.root();
     let consent_path = consent_marker_path(kin_root);
@@ -104,8 +101,7 @@ pub async fn run_revoke() -> Result<()> {
 }
 
 pub async fn run_purge() -> Result<()> {
-    let layout = kin_core::KinLayout::discover(&std::env::current_dir()?)
-        .ok_or_else(|| anyhow::anyhow!("not a Kin repository (no .kin/ found)"))?;
+    let layout = crate::commands::require_repository_layout()?;
 
     let kin_root = layout.root();
     let spool_dir = telemetry_dir(kin_root);

--- a/crates/kin-cli/src/commands/trace.rs
+++ b/crates/kin-cli/src/commands/trace.rs
@@ -86,8 +86,7 @@ pub async fn run(
     nearby_limit: usize,
     transitive_limit: usize,
 ) -> Result<()> {
-    let layout = kin_core::KinLayout::discover(&std::env::current_dir()?)
-        .ok_or_else(|| anyhow::anyhow!("not a Kin repository (no .kin/ found)"))?;
+    let layout = crate::commands::require_repository_layout()?;
     let _scope = announce_active_scope(&layout, "trace").await?;
     let response = run_daemon_trace(
         &layout,
@@ -239,8 +238,7 @@ pub async fn run_json(
     _nearby_limit: usize,
     _transitive_limit: usize,
 ) -> Result<()> {
-    let layout = kin_core::KinLayout::discover(&std::env::current_dir()?)
-        .ok_or_else(|| anyhow::anyhow!("not a Kin repository (no .kin/ found)"))?;
+    let layout = crate::commands::require_repository_layout()?;
     let _scope = announce_active_scope(&layout, "trace --json").await?;
     let response = run_daemon_trace(
         &layout,

--- a/crates/kin-cli/src/commands/trace_data_flow.rs
+++ b/crates/kin-cli/src/commands/trace_data_flow.rs
@@ -155,8 +155,7 @@ pub async fn run_seeded(
         direction,
         limit_per_step,
     };
-    let layout = kin_core::KinLayout::discover(&std::env::current_dir()?)
-        .ok_or_else(|| anyhow::anyhow!("not a Kin repository (no .kin/ found)"))?;
+    let layout = crate::commands::require_repository_layout()?;
     let response = run_daemon_trace_data_flow(&layout, &request).await?;
     println!("{}", serde_json::to_string_pretty(&response)?);
     Ok(())

--- a/crates/kin-cli/src/commands/traffic.rs
+++ b/crates/kin-cli/src/commands/traffic.rs
@@ -4,8 +4,7 @@
 use anyhow::{Context, Result};
 
 async fn daemon_base_url() -> Result<String> {
-    let layout = kin_core::KinLayout::discover(&std::env::current_dir()?)
-        .ok_or_else(|| anyhow::anyhow!("not a Kin repository (no .kin/ found)"))?;
+    let layout = crate::commands::require_repository_layout()?;
     crate::daemon_client::resolve_daemon_url(&layout)
         .await?
         .ok_or_else(|| {

--- a/crates/kin-cli/src/commands/transfer.rs
+++ b/crates/kin-cli/src/commands/transfer.rs
@@ -177,11 +177,7 @@ fn parse_ref(value: Option<&str>) -> Result<Option<RefName>> {
 }
 
 fn layout() -> Result<KinLayout> {
-    KinLayout::discover(&std::env::current_dir()?).ok_or_else(|| {
-        anyhow::anyhow!(
-            "not a Kin repository (no .kin/ found)\nhint: run `kin init .` to initialize one"
-        )
-    })
+    crate::commands::require_repository_layout()
 }
 
 async fn daemon() -> Result<crate::daemon_client::DaemonClient> {

--- a/crates/kin-cli/src/commands/verify.rs
+++ b/crates/kin-cli/src/commands/verify.rs
@@ -52,8 +52,7 @@ pub struct VerifyCommandResponse {
 ///
 /// Shows per-entity test linkage and overall coverage summary.
 pub async fn run(entity: String) -> Result<()> {
-    let layout = kin_core::KinLayout::discover(&std::env::current_dir()?)
-        .ok_or_else(|| anyhow!("not a Kin repository (no .kin/ found)"))?;
+    let layout = crate::commands::require_repository_layout()?;
     print_verify_response(
         run_daemon_verify_command(&layout, &VerifyCommandRequest::Entity { entity }).await?,
     )
@@ -61,23 +60,20 @@ pub async fn run(entity: String) -> Result<()> {
 
 /// `kin verify --summary` — Show repository-wide coverage summary only.
 pub async fn summary() -> Result<()> {
-    let layout = kin_core::KinLayout::discover(&std::env::current_dir()?)
-        .ok_or_else(|| anyhow!("not a Kin repository (no .kin/ found)"))?;
+    let layout = crate::commands::require_repository_layout()?;
     print_verify_response(run_daemon_verify_command(&layout, &VerifyCommandRequest::Summary).await?)
 }
 
 /// `kin verify --missing` — Show only entities without any linked test.
 pub async fn missing() -> Result<()> {
-    let layout = kin_core::KinLayout::discover(&std::env::current_dir()?)
-        .ok_or_else(|| anyhow!("not a Kin repository (no .kin/ found)"))?;
+    let layout = crate::commands::require_repository_layout()?;
     print_verify_response(run_daemon_verify_command(&layout, &VerifyCommandRequest::Missing).await?)
 }
 
 /// `kin verify plan <entity> --depth 2` — Show the targeted proof set Kin would
 /// use for verification, widened by downstream semantic impact.
 pub async fn plan(entity: String, depth: u32) -> Result<()> {
-    let layout = kin_core::KinLayout::discover(&std::env::current_dir()?)
-        .ok_or_else(|| anyhow!("not a Kin repository (no .kin/ found)"))?;
+    let layout = crate::commands::require_repository_layout()?;
     print_verify_response(
         run_daemon_verify_command(&layout, &VerifyCommandRequest::Plan { entity, depth }).await?,
     )
@@ -86,8 +82,7 @@ pub async fn plan(entity: String, depth: u32) -> Result<()> {
 /// `kin verify change [<change-id>] --depth 2` — Show the targeted proof set
 /// Kin would use for a semantic change, defaulting to the current HEAD.
 pub async fn plan_change(change_id: Option<String>, depth: u32) -> Result<()> {
-    let layout = kin_core::KinLayout::discover(&std::env::current_dir()?)
-        .ok_or_else(|| anyhow!("not a Kin repository (no .kin/ found)"))?;
+    let layout = crate::commands::require_repository_layout()?;
     print_verify_response(
         run_daemon_verify_command(
             &layout,
@@ -104,8 +99,7 @@ pub async fn plan_change(change_id: Option<String>, depth: u32) -> Result<()> {
 /// set. Otherwise it falls back to an entity-name filter and still records a
 /// proof run for the entity.
 pub async fn run_verification(entity: String, runner: String, depth: u32) -> Result<()> {
-    let layout = kin_core::KinLayout::discover(&std::env::current_dir()?)
-        .ok_or_else(|| anyhow!("not a Kin repository (no .kin/ found)"))?;
+    let layout = crate::commands::require_repository_layout()?;
     let response = run_daemon_verify_run(
         &layout,
         &VerifyRunRequest {

--- a/crates/kin-cli/src/commands/work.rs
+++ b/crates/kin-cli/src/commands/work.rs
@@ -69,8 +69,7 @@ pub struct WorkExecution {
 }
 
 async fn run_daemon_work(request: &WorkRequest) -> Result<WorkResponse> {
-    let layout = kin_core::KinLayout::discover(&std::env::current_dir()?)
-        .ok_or_else(|| anyhow::anyhow!("not a Kin repository (no .kin/ found)"))?;
+    let layout = crate::commands::require_repository_layout()?;
     let daemon_url = std::env::var("KIN_DAEMON_URL")
         .ok()
         .filter(|value| !value.trim().is_empty())

--- a/crates/kin-cli/src/commands/xref.rs
+++ b/crates/kin-cli/src/commands/xref.rs
@@ -23,8 +23,7 @@ pub struct XrefResponse {
 }
 
 pub async fn run(entity: String) -> Result<()> {
-    let layout = kin_core::KinLayout::discover(&std::env::current_dir()?)
-        .ok_or_else(|| anyhow::anyhow!("not a Kin repository (no .kin/ found)"))?;
+    let layout = crate::commands::require_repository_layout()?;
     let response = run_daemon_xref(&layout, &XrefRequest { entity }).await?;
     for line in response.lines {
         println!("{line}");

--- a/crates/kin-cli/tests/command_capabilities.rs
+++ b/crates/kin-cli/tests/command_capabilities.rs
@@ -203,7 +203,7 @@ fn session_commands_reach_the_session_surface_instead_of_the_capability_gate() {
             "kin {args:?} must no longer answer from the capability gate: {stderr}"
         );
         assert!(
-            stderr.contains("not inside a Kin repository"),
+            stderr.contains("not a Kin repository"),
             "kin {args:?} must reach the session surface and fail on discovery: {stderr}"
         );
     }


### PR DESCRIPTION
Running a repository command from the wrong directory is an ordinary first mistake, and the refusal for it had drifted across the command surface.

Measured on `72d2c315`, of the 85 sites in `crates/kin-cli/src` that refuse when no `.kin/` is found:

- **73** stated only the condition, leaving the caller to guess the remedy
- **9** carried the hint naming `kin init`
- **3** carried a differently worded hint

The cause is structural, not careless: each site was an independent copy of the same discovery expression, so there was never one place the wording lived.

## Approach

One canonical helper in `commands/mod.rs`: `require_repository_layout()` discovers from the current directory, `require_repository_layout_at(&Path)` from a caller-supplied root, and both refuse by naming the command that creates a repository. All 84 discovery sites route through it. `merge.rs`'s local `require_repository_layout()` is subsumed.

The change removes more lines than it adds and leaves a single place where the wording can change.

**One site deliberately keeps its own shape.** Prepared-state publish tests for `.kin` directly in the current directory rather than discovering upward through ancestors, and it uses the resulting `repo_path` / `kin_dir` afterwards. Adopting the helper there would silently widen it to an ancestor walk, so it gains the hint only.

## Enforcement

One home for the wording only holds while it stays the only home, and a call site reverting to a local refusal reads as an ordinary two-line diff. Two tests hold the invariant:

- a directory with no `.kin/` refuses with both the condition and the remedy
- a source scan over this crate fails when a discovery is refused in place anywhere but the canonical helper, which is the shape that produced the drift

The second test was falsified rather than assumed. Reverting `status.rs` to a local `KinLayout::discover(...).ok_or_else(...)` fails it naming `crates/kin-cli/src/commands/status.rs:401`, and restoring the call site turns it green again.

The MCP daemon binding gained a test assertion that its refusal names the remedy, since that refusal is a reason string a caller logs rather than a propagated error.

## Verification

- `cargo fmt --all -- --check` clean
- `cargo clippy -p kin-cli --all-targets --all-features` with the ci.yml 45-lint allowlist under `RUSTFLAGS=-D warnings`: exit 0
- `cargo build -p kin-cli --all-targets` clean
- `cargo test -p kin-cli --lib`: 996 passed, 0 failed
- `scripts/zero_file_search_guard.sh`: PASSED

Against the first commit: `cargo test --workspace` 4561 passed, 0 failed across 101 suites, and `scripts/verify-zero-file-search.py` PASSED over 144 source files. The full workspace suite runs in CI on the final head.

Closes FIR-1738
Part-of FIR-1737
