### PR TITLE
Pin the fuzz nightly action to the revision that accepts a toolchain input

### DIFF
--- a/.github/workflows/fuzz.yml
+++ b/.github/workflows/fuzz.yml
@@ -99,14 +99,19 @@ jobs:
       # nightly for the same reason that file pins stable: an unpinned @nightly
       # lets a green build turn red with no change to this repository, and the
       # failure then has to be told apart from a real one. Bump DELIBERATELY.
-      # The action itself is sha-pinned, same commit the release workflow pins.
-      # Its ref used to be @master, which is a branch: the action could change
-      # under a job whose whole purpose is a fixed toolchain. The trailing
-      # comment names the action tag that sha carries, matching release.yml; the
-      # Rust version this job installs comes from the explicit input below, so
-      # the ref never had to spell it.
+      # The action is sha-pinned rather than referenced by a branch, because a
+      # branch could change under a job whose whole purpose is a fixed toolchain.
+      # The sha has to come from the default branch, which is the only revision
+      # declaring a `toolchain` input. This action also publishes a branch per
+      # toolchain (`1.96.0`, `stable`, and so on) whose action hardcodes that
+      # version and accepts only `targets`, `target`, and `components`. Pinning
+      # one of those shas here made `toolchain` an unexpected input, so the step
+      # installed 1.96.0, and the nightly named below arrived only when rustup
+      # resolved it on the first `cargo +nightly-2026-06-17` call. release.yml
+      # pins a per-toolchain sha deliberately: it wants stable and passes only
+      # `targets`.
       - name: Install nightly toolchain
-        uses: dtolnay/rust-toolchain@c0e9df88980754dd93e5833b8dcb1b304c1fe173 # action tag 1.96.0
+        uses: dtolnay/rust-toolchain@2c7215f132e9ebf062739d9130488b56d53c060c # default branch
         with:
           toolchain: nightly-2026-06-17
 


### PR DESCRIPTION
`.github/workflows/fuzz.yml` pinned `dtolnay/rust-toolchain` at a sha from the action's per-toolchain `1.96.0` branch. That revision hardcodes 1.96.0 and declares only `targets`, `target`, and `components`, so the `toolchain: nightly-2026-06-17` input this job passes was rejected as unexpected.

Every pull_request fuzz run under this pin carried the annotation (fuzz.yml has no push trigger, and the last on-main cron run predates the regression)

```
Unexpected input(s) 'toolchain', valid inputs are ['targets', 'target', 'components']
```

and the step named "Install nightly toolchain" installed 1.96.0. The dated nightly still arrived, but only because rustup resolved it implicitly on the first `cargo +nightly-2026-06-17` invocation, which is the opposite of what a job pinning its toolchain deliberately is trying to guarantee.

This pins the default-branch revision `2c7215f132e9ebf062739d9130488b56d53c060c`, which declares a `toolchain` input, so the step installs the toolchain it names. The pin stays a sha, so it is no less reproducible than before.

`release.yml` pins the same per-toolchain sha and is deliberately left alone: it wants stable 1.96.0 and passes only `targets`, which that revision accepts.

Verification:

- `action.yml` at the new sha declares a `toolchain` input; at the old sha it does not.
- `2c7215f132e9ebf062739d9130488b56d53c060c` is the head of `master`, the action's default branch.
- The fuzz workflow's `pull_request` paths include `.github/workflows/fuzz.yml`, so this PR runs both fuzz targets and the annotation should be absent.

This is a workflow-only change repairing an annotation present on every branch, so it lands on `main` rather than on any one feature branch.
